### PR TITLE
Resolves Issue #20 - Gas Meter Convenience

### DIFF
--- a/code/game/machinery/atmoalter/meter.dm
+++ b/code/game/machinery/atmoalter/meter.dm
@@ -68,7 +68,7 @@
 /obj/machinery/meter/examine(mob/user)
 	var/t = "A gas flow meter. "
 	
-	if(get_dist(user, src) > 3 && !(istype(user, /mob/living/silicon/ai) || istype(user, /mob/observer/dead)))
+	if(get_dist(user, src) > 5 && !(istype(user, /mob/living/silicon/ai) || istype(user, /mob/observer/dead)))
 		t += "<span class='warning'>You are too far away to read it.</span>"
 	
 	else if(stat & (NOPOWER|BROKEN))
@@ -87,7 +87,7 @@
 
 /obj/machinery/meter/Click()
 
-	if(istype(usr, /mob/living/silicon/ai)) // ghosts can call ..() for examine
+	if(istype(usr, /mob/living/carbon/human) || istype(usr, /mob/living/silicon/ai)) // ghosts can call ..() for examine
 		usr.examinate(src)
 		return 1
 	


### PR DESCRIPTION
* Changed gas meters to be readable merely by left-clicking, instead of having to examine.  This behavior was present on oldcode and was nice, so bringing it back.
* Changed readability distance to 5 tiles for the sake of convenience.