### PR TITLE
Fixes egg_dm not making vore organ have a color

### DIFF
--- a/code/modules/vore/eating/vorepanel_vr.dm
+++ b/code/modules/vore/eating/vorepanel_vr.dm
@@ -103,6 +103,8 @@
 				spanstyle = "color:purple;"
 			if(DM_TRANSFORM_FEMALE_EGG)
 				spanstyle = "color:purple;"
+			if(DM_EGG)
+				spanstyle = "color:purple;"
 
 		dat += "<span style='[spanstyle]'> ([B.internal_contents.len])</span></a>"
 


### PR DESCRIPTION
Quick and easy bugfix.
I originally forgot to put this in. All it does is make the little counter (0) show up as purple when you turn it to the "encase in egg" or if DM_EGG mode.