### PR TITLE
 Added Change CKey Admin Verb

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -40,6 +40,7 @@ var/list/admin_verbs_admin = list(
 	/client/proc/jumptocoord,			//we ghost and jump to a coordinate,
 	/client/proc/Getmob,				//teleports a mob to our location,
 	/client/proc/Getkey,				//teleports a mob with a certain ckey to our location,
+	/client/proc/SetCKey,				//set the ckey of a mob
 //	/client/proc/sendmob,				//sends a mob somewhere, -Removed due to it needing two sorting procs to work, which were executed every time an admin right-clicked. ~Errorage,
 	/client/proc/Jump,
 	/client/proc/jumptokey,				//allows us to jump to the location of a mob with a certain ckey,

--- a/code/modules/admin/ckey_vr.dm
+++ b/code/modules/admin/ckey_vr.dm
@@ -1,0 +1,20 @@
+// Command to set the ckey of a mob without requiring VV permission
+/client/proc/SetCKey(var/mob/M in mob_list)
+	set category = "Admin"
+	set name = "Set CKey"
+	set desc = "Mob to teleport"
+	if(!src.holder)
+		src << "Only administrators may use this command."
+		return
+
+	var/list/keys = list()
+	for(var/mob/playerMob in player_list)
+		keys += playerMob.client
+	var/client/selection = input("Please, select a player!", "Set CKey", null, null) as null|anything in sortKey(keys)
+	if(!selection || !istype(selection))
+		return
+
+	log_admin("[key_name(usr)] set ckey of [key_name(M)] to [selection]")
+	message_admins("[key_name_admin(usr)] set ckey of [key_name_admin(M)] to [selection]", 1)
+	M.ckey = selection.ckey
+	feedback_add_details("admin_verb","SCK") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -901,6 +901,7 @@
 #include "code\modules\admin\admin_secrets.dm"
 #include "code\modules\admin\admin_verbs.dm"
 #include "code\modules\admin\banjob.dm"
+#include "code\modules\admin\ckey_vr.dm"
 #include "code\modules\admin\create_mob.dm"
 #include "code\modules\admin\create_object.dm"
 #include "code\modules\admin\create_turf.dm"


### PR DESCRIPTION
In order to let a broader range of admins set the ckey of mobs without
breaking things, this verb allows setting the ckey of mobs only to
currently-online players.