### PR TITLE
Virgo Races Pay Fix

### DIFF
--- a/code/modules/economy/economy_misc.dm
+++ b/code/modules/economy/economy_misc.dm
@@ -53,7 +53,13 @@
 										/datum/species/teshari	= 9, // Skrell sponsored,
 										/datum/species/tajaran	= 7,
 										/datum/species/unathi	= 7,
-										/datum/species/diona 	= 7
+										/datum/species/diona 	= 7,
+										/datum/species/akula	= 9, // Also tied to Skrell lore-wise
+										/datum/species/shapeshifter/promethean 	= 7,
+										/datum/species/sergal 	= 7,
+										/datum/species/nevrean 	= 7,
+										/datum/species/hi_zoxxen 	= 7,
+										/datum/species/fl_zorren 	= 7,
 											)
 
 //---- The following corporations are friendly with NanoTrasen and loosely enable trade and travel:


### PR DESCRIPTION
So, this is something someone pointed out to me over on our work on Eros so I figured I'd check if you guys had the same problem and you did. Races added by VORE should actually get paid for work now! Money, yay
I set all of the economic modifiers for them, except for Akula, to 7, which is Polaris default for Tajara, Unathi, and Diona. Humans default to 10, Skrell to 12, and Teshari to 9. Akula I set to 9, since they have lore ties to the Skrell similar to Teshari.
Modifiers are easy enough to change and add or remove. Cheers! c: