### PR TITLE
Make OOC_Notes easily and conveniently viewable when examining players.

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -369,6 +369,11 @@
 
 	if(print_flavor_text()) msg += "[print_flavor_text()]\n"
 
+	// VOREStation Start
+	if(config.allow_Metadata && client)
+		msg += "<span class = 'deptradio'>OOC Notes:</span> <a href='?src=\ref[src];ooc_notes=1'>\[View\]</a>\n"
+	// VOREStation End
+
 	msg += "*---------*</span>"
 	if (pose)
 		if( findtext(pose,".",lentext(pose)) == 0 && findtext(pose,"!",lentext(pose)) == 0 && findtext(pose,"?",lentext(pose)) == 0 )

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -359,6 +359,11 @@
 	if(href_list["item"])
 		handle_strip(href_list["item"],usr)
 
+	// VOREStation Start
+	if(href_list["ooc_notes"])
+		src.Examine_OOC()
+	// VOREStation End
+
 	if (href_list["criminal"])
 		if(hasHUD(usr,"security"))
 


### PR DESCRIPTION
Fixes #183 by making the existing OOC Notes settable in profile setup when examining folks.