### PR TITLE
Tweaks digestion code

### DIFF
--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -1450,8 +1450,10 @@ var/global/list/obj/item/device/pda/PDAs = list()
 
 /obj/item/device/pda/Destroy()
 	PDAs -= src
+	/* VOREStation Removal
 	if (src.id && prob(90)) //IDs are kept in 90% of the cases
 		src.id.loc = get_turf(src.loc)
+	*/
 	..()
 
 /obj/item/device/pda/clown/Crossed(AM as mob|obj) //Clown PDA is slippery.

--- a/code/modules/mob/living/carbon/human/human_organs.dm
+++ b/code/modules/mob/living/carbon/human/human_organs.dm
@@ -85,7 +85,7 @@
 		else if (E.is_malfunctioning())
 			//malfunctioning only happens intermittently so treat it as a missing limb when it procs
 			stance_damage += 2
-			if(prob(10))
+			if(isturf(loc) && prob(10))
 				visible_message("\The [src]'s [E.name] [pick("twitches", "shudders")] and sparks!")
 				var/datum/effect/effect/system/spark_spread/spark_system = new ()
 				spark_system.set_up(5, 0, src)
@@ -110,7 +110,7 @@
 
 	// standing is poor
 	if(stance_damage >= 4 || (stance_damage >= 2 && prob(5)))
-		if(!(lying || resting))
+		if(!(lying || resting) && !isliving(loc))
 			if(limb_pain)
 				emote("scream")
 			custom_emote(1, "collapses!")

--- a/code/modules/organs/subtypes/machine.dm
+++ b/code/modules/organs/subtypes/machine.dm
@@ -71,6 +71,7 @@
 /obj/item/organ/internal/mmi_holder/removed(var/mob/living/user)
 
 	if(stored_mmi)
+		. = stored_mmi //VOREStation Code
 		stored_mmi.loc = get_turf(src)
 		if(owner.mind)
 			owner.mind.transfer_to(stored_mmi.brainmob)


### PR DESCRIPTION
Makes it more synth-friendly, less sparks shooting out of people. More preserving items correctly. Less blank items in people's belly panel.

Lazy-deletes items rather than scouring and deleting one at a time. Just picks out items it likes and puts them into the pred's belly, then deletes the whole mob.