### PR TITLE
Bugfixes and promethean nerf.

### DIFF
--- a/code/game/machinery/suit_storage_unit_vr.dm
+++ b/code/game/machinery/suit_storage_unit_vr.dm
@@ -1,2 +1,2 @@
 /obj/machinery/suit_cycler
-	species = list("Human","Skrell","Unathi","Tajara", "Teshari", "Nevrean", "Akula", "Sergal", "Flatland Zorren", "Highlander Zorren", "Vulpkanin")
+	species = list("Human","Skrell","Unathi","Tajara", "Teshari", "Nevrean", "Akula", "Sergal", "Flatland Zorren", "Highlander Zorren", "Vulpkanin", "Promethean")

--- a/code/modules/clothing/spacesuits/rig/rig_pieces_vr.dm
+++ b/code/modules/clothing/spacesuits/rig/rig_pieces_vr.dm
@@ -8,7 +8,8 @@
 		"Sergal"				= 'icons/mob/species/sergal/helmet_vr.dmi',
 		"Flatland Zorren" 		= 'icons/mob/species/fennec/helmet_vr.dmi',
 		"Highlander Zorren" 	= 'icons/mob/species/fox/helmet_vr.dmi',
-		"Vulpkanin"				= 'icons/mob/species/vulpkanin/helmet.dmi'
+		"Vulpkanin"				= 'icons/mob/species/vulpkanin/helmet.dmi',
+		"Promethean"			= 'icons/mob/species/skrell/helmet.dmi'
 		)
 
 
@@ -23,5 +24,6 @@
 		"Sergal"				= 'icons/mob/species/sergal/suit_vr.dmi',
 		"Flatland Zorren" 		= 'icons/mob/species/fennec/suit_vr.dmi',
 		"Highlander Zorren" 	= 'icons/mob/species/fox/suit_vr.dmi',
-		"Vulpkanin"				= 'icons/mob/species/vulpkanin/suit.dmi'
+		"Vulpkanin"				= 'icons/mob/species/vulpkanin/suit.dmi',
+		"Promethean"			= 'icons/mob/species/skrell/suit.dmi'
 		)

--- a/code/modules/clothing/spacesuits/void/void_vr.dm
+++ b/code/modules/clothing/spacesuits/void/void_vr.dm
@@ -16,7 +16,8 @@
 		"Sergal"				= 'icons/mob/species/sergal/helmet_vr.dmi',
 		"Flatland Zorren" 		= 'icons/mob/species/fennec/helmet_vr.dmi',
 		"Highlander Zorren" 	= 'icons/mob/species/fox/helmet_vr.dmi',
-		"Vulpkanin"				= 'icons/mob/species/vulpkanin/helmet.dmi'
+		"Vulpkanin"				= 'icons/mob/species/vulpkanin/helmet.dmi',
+		"Promethean"			= 'icons/mob/species/skrell/helmet.dmi'
 		)
 
 	sprite_sheets_obj = list(
@@ -29,7 +30,8 @@
 		"Sergal"			= 'icons/obj/clothing/species/sergal/hats.dmi',
 		"Flatland Zorren"	= 'icons/obj/clothing/species/fennec/hats.dmi',
 		"Highlander Zorren"	= 'icons/obj/clothing/species/fox/hats.dmi',
-		"Vulpkanin"				= 'icons/obj/clothing/species/vulpkanin/hats.dmi'
+		"Vulpkanin"			= 'icons/obj/clothing/species/vulpkanin/hats.dmi',
+		"Promethean"		= 'icons/obj/clothing/species/skrell/hats.dmi'
 		)
 
 /obj/item/clothing/suit/space/void
@@ -43,7 +45,8 @@
 		"Sergal"				= 'icons/mob/species/sergal/suit_vr.dmi',
 		"Flatland Zorren" 		= 'icons/mob/species/fennec/suit_vr.dmi',
 		"Highlander Zorren" 	= 'icons/mob/species/fox/suit_vr.dmi',
-		"Vulpkanin"				= 'icons/mob/species/vulpkanin/suit.dmi'
+		"Vulpkanin"				= 'icons/mob/species/vulpkanin/suit.dmi',
+		"Promethean"			= 'icons/mob/species/skrell/suit.dmi'
 		)
 
 
@@ -58,7 +61,8 @@
 		"Sergal"			= 'icons/obj/clothing/species/sergal/suits.dmi',
 		"Flatland Zorren"	= 'icons/obj/clothing/species/fennec/suits.dmi',
 		"Highlander Zorren"	= 'icons/obj/clothing/species/fox/suits.dmi',
-		"Vulpkanin"			= 'icons/obj/clothing/species/vulpkanin/suits.dmi'
+		"Vulpkanin"			= 'icons/obj/clothing/species/vulpkanin/suits.dmi',
+		"Promethean"		= 'icons/obj/clothing/species/skrell/suits.dmi'
 		)
 
 

--- a/code/modules/mob/living/carbon/human/examine_vr.dm
+++ b/code/modules/mob/living/carbon/human/examine_vr.dm
@@ -1,49 +1,106 @@
 /mob/living/carbon/human/proc/examine_weight()
 	var/message = ""
 	var/weight_examine = round(weight)
+	var/t_He 	= "It" //capitalised for use at the start of each line.
+	var/t_he	= "it"
+	var/t_his 	= "its"
+	var/t_His 	= "Its"
+	var/t_is 	= "is"
+	var/t_has 	= "has"
+	var/t_heavy = "heavy"
+	switch(identifying_gender) //Gender is their "real" gender. Identifying_gender is their "chosen" gender.
+		if(MALE)
+			t_He 	= "He"
+			t_he 	= "he"
+			t_His 	= "His"
+			t_his 	= "his"
+			t_heavy = "bulky"
+		if(FEMALE)
+			t_He 	= "She"
+			t_he	= "she"
+			t_His 	= "Her"
+			t_his 	= "her"
+			t_heavy = "curvy"
+		if(PLURAL)
+			t_He	= "They"
+			t_he	= "they"
+			t_His 	= "Their"
+			t_his 	= "their"
+			t_is 	= "are"
+			t_has 	= "have"
+		if(NEUTER)
+			t_He 	= "It"
+			t_he	= "it"
+			t_His 	= "Its"
+			t_his 	= "its"
+
 	switch(weight_examine)
 		if(0 to 74)
-			message = "<span class='warning'>They are terribly lithe and frail!</span>\n"
+			message = "<span class='warning'>[t_He] [t_is] terribly lithe and frail!</span>\n"
 		if(75 to 99)
-			message = "They have a very slender frame.\n"
+			message = "[t_He] [t_has] a very slender frame.\n"
 		if(100 to 124)
-			message = "They have a lightweight, athletic build.\n"
+			message = "[t_He] [t_has] a lightweight, athletic build.\n"
 		if(125 to 174)
-			message = "They have a healthy, average body.\n"
+			message = "[t_He] [t_has] a healthy, average body.\n"
 		if(175 to 224)
-			message = "They have a thick, heavy physique.\n"
+			message = "[t_He] [t_has] a thick, [t_heavy] physique.\n"
 		if(225 to 274)
-			message = "They have a plush, chubby figure.\n"
+			message = "[t_He] [t_has] a plush, chubby figure.\n"
 		if(275 to 325)
-			message = "They have an especially plump body with a round potbelly and large hips.\n"
+			message = "[t_He] [t_has] an especially plump body with a round potbelly and large hips.\n"
 		if(325 to 374)
-			message = "They have a very fat frame with a bulging potbelly, squishy rolls of pudge, very wide hips, and plump set of jiggling thighs.\n"
+			message = "[t_He] [t_has] a very fat frame with a bulging potbelly, squishy rolls of pudge, very wide hips, and plump set of jiggling thighs.\n"
 		if(375 to 474)
-			message = "<span class='warning'>They are incredibly obese. Their massive potbelly sags over their waistline while their fat ass would probably require two chairs to sit down comfortably!</span>\n"
+			message = "<span class='warning'>[t_He] [t_is] incredibly obese. [t_His] massive potbelly sags over [t_his] waistline while [t_his] fat ass would probably require two chairs to sit down comfortably!</span>\n"
 		else
-			message += "<span class='warning'>They are so morbidly obese, you wonder how they can even stand, let alone waddle around the station. They can't get any fatter without being immobilized.</span>\n"
+			message += "<span class='warning'>[t_He] [t_is] so morbidly obese, you wonder how [t_he] can even stand, let alone waddle around the station. [t_He] can't get any fatter without being immobilized.</span>\n"
 	return message //Credit to Aronai for helping me actually get this working!
 
 /mob/living/carbon/human/proc/examine_nutrition()
 	var/message = ""
 	var/nutrition_examine = round(nutrition)
+	var/t_He 	= "It" //capitalised for use at the start of each line.
+	var/t_His 	= "Its"
+	var/t_his 	= "its"
+	var/t_is 	= "is"
+	var/t_has 	= "has"
+	switch(identifying_gender)
+		if(MALE)
+			t_He 	= "He"
+			t_his 	= "his"
+			t_His 	= "His"
+		if(FEMALE)
+			t_He 	= "She"
+			t_his 	= "her"
+			t_His 	= "Her"
+		if(PLURAL)
+			t_He  	= "They"
+			t_his 	= "their"
+			t_His 	= "Their"
+			t_is	= "are"
+			t_has 	= "have"
+		if(NEUTER)
+			t_He 	= "It"
+			t_his 	= "its"
+			t_His	= "Its"
 	switch(nutrition_examine)
 		if(0 to 49)
-			message = "<span class='warning'>They are starving! You can hear their stomach snarling from across the room!</span>\n"
+			message = "<span class='warning'>[t_He] [t_is] starving! You can hear [t_his] stomach snarling from across the room!</span>\n"
 		if(50 to 99)
-			message = "<span class='warning'>They are extremely hungry. A deep growl occasionally rumbles from their empty stomach.</span>\n"
+			message = "<span class='warning'>[t_He] [t_is] extremely hungry. A deep growl occasionally rumbles from [t_his] empty stomach.</span>\n"
 		if(100 to 499)
 			return message //Well that's pretty normal, really.
 		if(500 to 864) // Fat.
-			message = "They have a stuffed belly, bloated fat and round from eating too much.\n"
+			message = "[t_He] [t_has] a stuffed belly, bloated fat and round from eating too much.\n"
 		if(1200 to 1934) // One person fully digested.
-			message = "<span class='warning'>They are sporting a large, round, sagging stomach. It's contains at least their body weight worth of glorping slush.</span>\n"
+			message = "<span class='warning'>[t_He] [t_is] sporting a large, round, sagging stomach. It's contains at least their body weight worth of glorping slush.</span>\n"
 		if(1935 to 3004) // Two people.
-			message = "<span class='warning'>They are engorged with a huge stomach that sags and wobbles as they move. They must have consumed at least twice their body weight. It looks incredibly soft.</span>\n"
+			message = "<span class='warning'>[t_He] [t_is] engorged with a huge stomach that sags and wobbles as they move. [t_He] must have consumed at least twice their body weight. It looks incredibly soft.</span>\n"
 		if(3005 to 4074) // Three people.
-			message = "<span class='warning'>Their stomach is firmly packed with digesting slop. They must have eaten at least a few times worth their body weight! It looks hard for them to stand, and their gut jiggles when they move.</span>\n"
+			message = "<span class='warning'>[t_His] stomach is firmly packed with digesting slop. [t_He] must have eaten at least a few times worth their body weight! It looks hard for them to stand, and [t_his] gut jiggles when they move.</span>\n"
 		if(4075 to 10000) // Four or more people.
-			message = "<span class='warning'>They are so absolutely stuffed that you aren't sure how it's possible to move. They can't seem to swell any bigger. The surface of their belly looks sorely strained!</span>\n"
+			message = "<span class='warning'>[t_He] [t_is] so absolutely stuffed that you aren't sure how it's possible to move. [t_He] can't seem to swell any bigger. The surface of [t_his] belly looks sorely strained!</span>\n"
 	return message
 
 /mob/living/carbon/human/proc/examine_bellies()

--- a/code/modules/mob/living/carbon/human/species/station/prometheans_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/prometheans_vr.dm
@@ -1,4 +1,4 @@
 /datum/species/shapeshifter/promethean
 	max_age = 80
 	valid_transform_species = list("Human", "Unathi", "Tajara", "Skrell", "Diona", "Teshari", "Monkey","Sergal","Akula","Nevrean","Highlander Zorren","Flatland Zorren", "Vulpkanin")
-	heal_rate = 1
+	heal_rate = 0.2 //They heal .2, along with the natural .2 heal per tick when below the  organ natural heal damage threshhold.

--- a/code/modules/mob/living/carbon/human/species/station/prometheans_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/prometheans_vr.dm
@@ -1,4 +1,4 @@
 /datum/species/shapeshifter/promethean
 	max_age = 80
 	valid_transform_species = list("Human", "Unathi", "Tajara", "Skrell", "Diona", "Teshari", "Monkey","Sergal","Akula","Nevrean","Highlander Zorren","Flatland Zorren", "Vulpkanin")
-	heal_rate = .1
+	heal_rate = 1

--- a/code/modules/mob/living/carbon/human/species/station/prometheans_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/prometheans_vr.dm
@@ -1,4 +1,3 @@
 /datum/species/shapeshifter/promethean
-  max_age = 80
-
-	valid_transform_species = list("Human", "Unathi", "Tajara", "Skrell", "Diona", "Teshari", "Monkey","Sergal","Akula","Nevrean","Highlander Zorren","Flatland Zorren")
+	max_age = 80
+	valid_transform_species = list("Human", "Unathi", "Tajara", "Skrell", "Diona", "Teshari", "Monkey","Sergal","Akula","Nevrean","Highlander Zorren","Flatland Zorren", "Vulpkanin")

--- a/code/modules/mob/living/carbon/human/species/station/prometheans_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/prometheans_vr.dm
@@ -1,3 +1,4 @@
 /datum/species/shapeshifter/promethean
 	max_age = 80
 	valid_transform_species = list("Human", "Unathi", "Tajara", "Skrell", "Diona", "Teshari", "Monkey","Sergal","Akula","Nevrean","Highlander Zorren","Flatland Zorren", "Vulpkanin")
+	heal_rate = .1

--- a/code/modules/mob/living/carbon/human/species/station/prometheans_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/prometheans_vr.dm
@@ -1,2 +1,4 @@
 /datum/species/shapeshifter/promethean
   max_age = 80
+
+	valid_transform_species = list("Human", "Unathi", "Tajara", "Skrell", "Diona", "Teshari", "Monkey","Sergal","Akula","Nevrean","Highlander Zorren","Flatland Zorren")

--- a/code/modules/vore/eating/bellymodes_vr.dm
+++ b/code/modules/vore/eating/bellymodes_vr.dm
@@ -134,7 +134,7 @@
 					P.g_eyes = O.g_eyes
 					P.b_eyes = O.b_eyes
 					P << "<span class='notice'>You feel lightheaded and drowsy...</span>"
-					owner << "<span class='notice'>Your belly feels warm as your womb makes subtle changes to your captive's body.</span>"
+					owner << "<span class='notice'>You feel warm as you make subtle changes to your captive's body.</span>"
 					P.update_body()
 
 				if(TFmodify == 2 && P.r_hair != O.r_hair || P.g_hair != O.g_hair || P.b_hair != O.b_hair || P.r_skin != O.r_skin || P.g_skin != O.g_skin || P.b_skin != O.b_skin || P.r_facial != O.r_facial || P.g_facial != O.g_facial || P.b_facial != O.b_facial)
@@ -149,14 +149,14 @@
 					P.b_skin = O.b_skin
 					P.h_style = "Bedhead"
 					P << "<span class='notice'>Your body tingles all over...</span>"
-					owner << "<span class='notice'>Your belly tingles as your womb makes noticeable changes to your captive's body.</span>"
+					owner << "<span class='notice'>You tingle as you make noticeable changes to your captive's body.</span>"
 					P.update_hair()
 					P.update_body()
 
 				if(TFmodify == 3 && P.gender != MALE)
 					P.gender = MALE
 					P << "<span class='notice'>Your body feels very strange...</span>"
-					owner << "<span class='notice'>Your belly feels strange as your womb alters your captive's gender.</span>"
+					owner << "<span class='notice'>You feel strange as you alter your captive's gender.</span>"
 					P.update_body()
 
 			if(O.nutrition > 0)
@@ -182,7 +182,7 @@
 					P.g_eyes = O.g_eyes
 					P.b_eyes = O.b_eyes
 					P << "<span class='notice'>You feel lightheaded and drowsy...</span>"
-					owner << "<span class='notice'>Your belly feels warm as your womb makes subtle changes to your captive's body.</span>"
+					owner << "<span class='notice'>You feel warm as your make subtle changes to your captive's body.</span>"
 					P.update_body()
 
 				if(TFmodify == 2 && P.r_hair != O.r_hair || P.g_hair != O.g_hair || P.b_hair != O.b_hair || P.r_skin != O.r_skin || P.g_skin != O.g_skin || P.b_skin != O.b_skin)
@@ -194,7 +194,7 @@
 					P.b_skin = O.b_skin
 					P.h_style = "Bedhead"
 					P << "<span class='notice'>Your body tingles all over...</span>"
-					owner << "<span class='notice'>Your belly tingles as your womb makes noticeable changes to your captive's body.</span>"
+					owner << "<span class='notice'>You tingle as your make noticeable changes to your captive's body.</span>"
 					P.update_hair()
 					P.update_body()
 
@@ -202,7 +202,7 @@
 					P.f_style = "Shaved"
 					P.gender = FEMALE
 					P << "<span class='notice'>Your body feels very strange...</span>"
-					owner << "<span class='notice'>Your belly feels strange as your womb alters your captive's gender.</span>"
+					owner << "<span class='notice'>You feel strange as you alter your captive's gender.</span>"
 					P.update_body()
 
 			if(O.nutrition > 0)
@@ -228,7 +228,7 @@
 					P.g_eyes = O.g_eyes
 					P.b_eyes = O.b_eyes
 					P << "<span class='notice'>You feel lightheaded and drowsy...</span>"
-					owner << "<span class='notice'>Your belly feels warm as your womb makes subtle changes to your captive's body.</span>"
+					owner << "<span class='notice'>You feel warm as you make subtle changes to your captive's body.</span>"
 					P.update_body()
 
 				if(TFmodify == 2 && P.r_hair != O.r_hair || P.g_hair != O.g_hair || P.b_hair != O.b_hair || P.r_skin != O.r_skin || P.g_skin != O.g_skin || P.b_skin != O.b_skin || P.r_facial != O.r_facial || P.g_facial != O.g_facial || P.b_facial != O.b_facial)
@@ -243,7 +243,7 @@
 					P.b_skin = O.b_skin
 					P.h_style = "Bedhead"
 					P << "<span class='notice'>Your body tingles all over...</span>"
-					owner << "<span class='notice'>Your belly tingles as your womb makes noticeable changes to your captive's body.</span>"
+					owner << "<span class='notice'>You tingle as you make noticeable changes to your captive's body.</span>"
 					P.update_hair()
 					P.update_body()
 
@@ -269,7 +269,7 @@
 					P.g_eyes = O.g_eyes
 					P.b_eyes = O.b_eyes
 					P << "<span class='notice'>You feel lightheaded and drowsy...</span>"
-					owner << "<span class='notice'>Your belly feels warm as your womb makes subtle changes to your captive's body.</span>"
+					owner << "<span class='notice'>You feel warm as you make subtle changes to your captive's body.</span>"
 					P.update_body()
 
 				if(TFmodify == 2 && P.r_hair != O.r_hair || P.g_hair != O.g_hair || P.b_hair != O.b_hair || P.r_skin != O.r_skin || P.g_skin != O.g_skin || P.b_skin != O.b_skin || P.r_facial != O.r_facial || P.g_facial != O.g_facial || P.b_facial != O.b_facial)
@@ -284,7 +284,7 @@
 					P.b_skin = O.b_skin
 					P.h_style = "Bedhead"
 					P << "<span class='notice'>Your body tingles all over...</span>"
-					owner << "<span class='notice'>Your belly tingles as your womb makes noticeable changes to your captive's body.</span>"
+					owner << "<span class='notice'>You tingle as you make noticeable changes to your captive's body.</span>"
 					P.update_hair()
 					P.update_body()
 					//Omitted clause : P.race_icon != O.race_icon
@@ -308,8 +308,8 @@
 					P.ear_style = O.ear_style
 					P.h_style = "Bedhead"
 					P.species = O.species
-					P << "<span class='notice'>You lose sensation of your body, feeling only the warmth of the womb... </span>"
-					owner << "<span class='notice'>Your belly shifts as your womb makes dramatic changes to your captive's body.</span>"
+					P << "<span class='notice'>You lose sensation of your body, feeling only the warmth of everything around you... </span>"
+					owner << "<span class='notice'>Your body shifts as you make dramatic changes to your captive's body.</span>"
 					P.update_hair()
 					P.update_body()
 					P.update_tail_showing()
@@ -348,8 +348,8 @@
 				P.h_style 			= "Bedhead"
 				P.species 			= O.species
 				P.custom_species 	= O.custom_species
-				P << "<span class='notice'>You lose sensation of your body, feeling only the warmth of the womb as you're encased in an egg. </span>"
-				owner << "<span class='notice'>Your belly shifts as your womb makes dramatic changes to your captive's body as you encase them in an egg.</span>"
+				P << "<span class='notice'>You lose sensation of your body, feeling only the warmth around you as you're encased in an egg. </span>"
+				owner << "<span class='notice'>You shift as you make dramatic changes to your captive's body as you encase them in an egg.</span>"
 				P.update_hair()
 				P.update_body()
 				P.update_tail_showing()
@@ -427,8 +427,8 @@
 				P.h_style 			= "Bedhead"
 				P.species 			= O.species
 				P.custom_species 	= O.custom_species
-				P << "<span class='notice'>You lose sensation of your body, feeling only the warmth of the womb as you're encased in an egg. </span>"
-				owner << "<span class='notice'>Your belly shifts as your womb makes dramatic changes to your captive's body as you encase them in an egg.</span>"
+				P << "<span class='notice'>You lose sensation of your body, feeling only the warmth are you as you're encased in an egg. </span>"
+				owner << "<span class='notice'>You shift as you make dramatic changes to your captive's body as you encase them in an egg.</span>"
 				P.update_hair()
 				P.update_body()
 				P.update_tail_showing()
@@ -501,7 +501,7 @@
 				P.b_skin 			= O.b_skin
 				P.h_style 			= "Bedhead"
 				P << "<span class='notice'>Your body tingles all over...</span>"
-				owner << "<span class='notice'>Your belly tingles as your womb makes noticeable changes to your captive's body.</span>"
+				owner << "<span class='notice'>You tingle as you make noticeable changes to your captive's body.</span>"
 				P.update_hair()
 				P.update_body()
 				switch(O.species.egg_type)
@@ -572,7 +572,7 @@
 				P.b_skin 			= O.b_skin
 				P.h_style 			= "Bedhead"
 				P << "<span class='notice'>Your body tingles all over...</span>"
-				owner << "<span class='notice'>Your belly tingles as your womb makes noticeable changes to your captive's body.</span>"
+				owner << "<span class='notice'>You tingle as you make noticeable changes to your captive's body.</span>"
 				P.update_hair()
 				P.update_body()
 				switch(O.species.egg_type)
@@ -645,7 +645,7 @@
 				P.h_style 			= "Bedhead"
 				P.gender 			= MALE
 				P << "<span class='notice'>Your body feels very strange...</span>"
-				owner << "<span class='notice'>Your belly feels strange as your womb alters your captive's gender.</span>"
+				owner << "<span class='notice'>Your body feels strange as you alter your captive's gender.</span>"
 				P.update_hair()
 				P.update_body()
 				switch(O.species.egg_type)
@@ -716,7 +716,7 @@
 				P.h_style			= "Bedhead"
 				P.gender 			= MALE
 				P << "<span class='notice'>Your body feels very strange...</span>"
-				owner << "<span class='notice'>Your belly feels strange as your womb alters your captive's gender.</span>"
+				owner << "<span class='notice'>You feel strange as you alter your captive's gender.</span>"
 				switch(O.species.egg_type)
 					if("Unathi")
 						var/obj/structure/closet/secure_closet/egg/unathi/J = new /obj/structure/closet/secure_closet/egg/unathi(O.loc)
@@ -788,7 +788,7 @@
 				P.h_style 			= "Bedhead"
 				P.gender 			= FEMALE
 				P << "<span class='notice'>Your body feels very strange...</span>"
-				owner << "<span class='notice'>Your belly feels strange as your womb alters your captive's gender.</span>"
+				owner << "<span class='notice'>You feels strange as you alter your captive's gender.</span>"
 				P.update_hair()
 				P.update_body()
 				switch(O.species.egg_type)
@@ -858,7 +858,7 @@
 				P.b_skin 			= O.b_skin
 				P.h_style 			= "Bedhead"
 				P.gender 			= FEMALE
-				owner << "<span class='notice'>Your belly feels strange as your womb alters your captive's gender.</span>"
+				owner << "<span class='notice'>You feel strange as you alter your captive's gender.</span>"
 				P << "<span class='notice'>Your body feels very strange...</span>"
 				P.update_hair()
 				P.update_body()
@@ -921,8 +921,8 @@
 
 			if (O.custom_species)
 				var/defined_species = O.custom_species
-				P << "<span class='notice'>You lose sensation of your body, feeling only the warmth of the womb as you're encased in an egg. </span>"
-				owner << "<span class='notice'>Your belly shifts as your womb encases [P] in an egg.</span>"
+				P << "<span class='notice'>You lose sensation of your body, feeling only the warmth around you as you're encased in an egg. </span>"
+				owner << "<span class='notice'>Your body shifts as you encase [P] in an egg.</span>"
 				switch(O.species.egg_type)
 					if("Unathi")
 						var/obj/structure/closet/secure_closet/egg/unathi/J = new /obj/structure/closet/secure_closet/egg/unathi(O.loc)
@@ -980,8 +980,8 @@
 						J.desc = "This egg has a very unique look to it."
 						internal_contents -= P
 			else
-				P << "<span class='notice'>You lose sensation of your body, feeling only the warmth of the womb as you're encased in an egg. </span>"
-				owner << "<span class='notice'>Your belly shifts as your womb encases [P] in an egg.</span>"
+				P << "<span class='notice'>You lose sensation of your body, feeling only the warmth around you as you're encased in an egg. </span>"
+				owner << "<span class='notice'>Your body shifts as you encase [P] in an egg.</span>"
 				switch(O.species.egg_type)
 					if("Unathi")
 						var/obj/structure/closet/secure_closet/egg/unathi/J = new /obj/structure/closet/secure_closet/egg/unathi(O.loc)

--- a/code/modules/xenobio2/_xeno_setup_vr.dm
+++ b/code/modules/xenobio2/_xeno_setup_vr.dm
@@ -62,3 +62,4 @@
 	xenoChemList += "capsaicin"
 	xenoChemList += "condensedcapsaicin"
 	xenoChemList += "neurotoxin"
+	return 1


### PR DESCRIPTION
This is a bug fix.

Proposed changes in this Pull Request:

- Allows Prometheans to use spacesuits
- Fixes a runtime bug
- Allows Prometheans to shapeshift into all species.
- Clarifies egg transformation better, since you don't have to transform people in a womb anymore.
- Major nerf to Promethean health regen. They now heal .2 per tick instead of the prior 5.)
    Makes fat text use gender specific pronouns.

Notes:
Allows Prometheans to use spacesuits, able to be wearable via the suit cycler. Default to skrell.
From there, they can change body shape and it'll still fit them and change to work for their sprite
(If they're a skrell bodyform then change into a unathi while they have the spacesuit on, their spacesuit sprite will turn into a unathi spacesuit sprite, etc etc.)

Also fixes runtime bug.
Fixes #289
