### PR TITLE
Fixes bellies overwritng each other

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -235,12 +235,14 @@ datum/preferences
 	else if(href_list["reload"])
 		load_preferences()
 		load_character()
+		attempt_vr(client.prefs_vr,"load_vore","") //VOREStation Edit
 	else if(href_list["load"])
 		if(!IsGuestKey(usr.key))
 			open_load_dialog(usr)
 			return 1
 	else if(href_list["changeslot"])
 		load_character(text2num(href_list["changeslot"]))
+		attempt_vr(client.prefs_vr,"load_vore","") //VOREStation Edit
 		close_load_dialog(usr)
 	else
 		return 0

--- a/code/modules/vore/eating/living_vr.dm
+++ b/code/modules/vore/eating/living_vr.dm
@@ -216,7 +216,7 @@
 //
 //	Proc for applying vore preferences, given bellies
 //
-/mob/living/proc/copy_from_prefs_vr(var/list/bellies)
+/mob/living/proc/copy_from_prefs_vr()
 	if(!client || !client.prefs_vr)
 		src << "<span class='warning'>You attempted to apply your vore prefs but somehow you're in this character without a client.prefs_vr variable. Tell a dev.</span>"
 		return 0
@@ -224,14 +224,11 @@
 	var/datum/vore_preferences/P = client.prefs_vr
 
 	src.digestable = P.digestable
-	src.vore_organs = P.belly_prefs
+	src.vore_organs = list()
 
-	if(!src.vore_organs) //Emergency double-backup to stop runtimes from doing .len on this.
-		vore_organs = list()
-
-	for(var/I in vore_organs) //Set the owner at runtime since... yanno.
-		var/datum/belly/B = vore_organs[I]
-		B.owner = src
+	for(var/I in P.belly_prefs)
+		var/datum/belly/Bp = P.belly_prefs[I]
+		src.vore_organs[Bp.name] = Bp.copy()
 
 	return 1
 


### PR DESCRIPTION
[Resolves #277]

Now you can have more than one slot. Fair warning, if you load another character then save bellies, it overwrites those. Like if you do that AFTER spawning. Like you're playing a mob from slot 1, you go into preferences > character set up, load slot 2, then open vore panel and click save, it will overwrite slot 2.

On the one hand, an easy way to copy bellies between characters! On the other, perhaps unexpected.

This prooooooooooobably doesn't delete everyone's bellies? Probably. Maybe you should copy the data folder, just in case. ;o Skip the logs.