### PR TITLE
Hacky fix for HUD problems

### DIFF
--- a/code/controllers/Processes/mob.dm
+++ b/code/controllers/Processes/mob.dm
@@ -12,6 +12,12 @@
 		mob_list = list()
 
 /datum/controller/process/mob/doWork()
+	if(!global_hud || !global_hud.darkMask) // A fix for a problem I can't find yet. ~Aro
+		try
+			global_hud = new()
+			log_debug("Had to recreate global_hud.")
+		catch
+			log_debug("Failed to recreate global_hud.")
 	for(last_object in mob_list)
 		var/mob/M = last_object
 		if(isnull(M.gcDestroyed))


### PR DESCRIPTION
Teshari hud darkness overlay keeps getting deleted globally, and worse it keeps them from spawning after. This is a cheap fix to correct this, but I have no idea what's causing it in the first place.