### PR TITLE
Minor changes to transformation & one major fix.

### DIFF
--- a/code/modules/vore/eating/bellymodes_vr.dm
+++ b/code/modules/vore/eating/bellymodes_vr.dm
@@ -318,6 +318,7 @@
 						Z.species = O.species
 					P << "<span class='notice'>You lose sensation of your body, feeling only the warmth of everything around you... </span>"
 					owner << "<span class='notice'>Your body shifts as you make dramatic changes to your captive's body.</span>"
+					P.fixblood()
 					P.update_hair()
 					P.update_body()
 					P.update_tail_showing()
@@ -363,6 +364,7 @@
 					Z.species = O.species
 				P << "<span class='notice'>You lose sensation of your body, feeling only the warmth around you as you're encased in an egg. </span>"
 				owner << "<span class='notice'>You shift as you make dramatic changes to your captive's body as you encase them in an egg.</span>"
+				P.fixblood()
 				P.update_hair()
 				P.update_body()
 				P.update_tail_showing()
@@ -459,6 +461,7 @@
 					Z.species = O.species
 				P << "<span class='notice'>You lose sensation of your body, feeling only the warmth are you as you're encased in an egg. </span>"
 				owner << "<span class='notice'>You shift as you make dramatic changes to your captive's body as you encase them in an egg.</span>"
+				P.fixblood()
 				P.update_hair()
 				P.update_body()
 				P.update_tail_showing()

--- a/code/modules/vore/eating/bellymodes_vr.dm
+++ b/code/modules/vore/eating/bellymodes_vr.dm
@@ -122,7 +122,7 @@
 
 			var/mob/living/carbon/human/O = owner
 
-			var/TFchance = prob(10)
+			var/TFchance = 1
 			if(TFchance == 1)
 
 				var/TFmodify = rand(1,3)
@@ -174,7 +174,7 @@
 
 			var/mob/living/carbon/human/O = owner
 
-			var/TFchance = prob(10)
+			var/TFchance = 1
 			if(TFchance == 1)
 				var/TFmodify = rand(1,3)
 				if(TFmodify == 1 && P.r_eyes != O.r_eyes || P.g_eyes != O.g_eyes || P.b_eyes != O.b_eyes)
@@ -222,7 +222,7 @@
 
 			var/mob/living/carbon/human/O = owner
 
-			var/TFchance = prob(10)
+			var/TFchance = 1
 			if(TFchance == 1)
 
 				var/TFmodify = rand(1,2)
@@ -266,7 +266,7 @@
 
 			var/mob/living/carbon/human/O = owner
 
-			var/TFchance = prob(10)
+			var/TFchance = 1 //This used to be RNG, resulting people waiting ages. This way does it instantly.
 			if(TFchance == 1)
 				var/TFmodify = rand(1,3)
 				if(TFmodify == 1 && P.r_eyes != O.r_eyes || P.g_eyes != O.g_eyes || P.b_eyes != O.b_eyes)
@@ -295,7 +295,7 @@
 					P.update_body()
 					P.updateicon()
 
-				if(TFmodify == 3 && P.r_hair != O.r_hair || P.g_hair != O.g_hair || P.b_hair != O.b_hair || P.r_skin != O.r_skin || P.g_skin != O.g_skin || P.b_skin != O.b_skin || P.tail_style != O.tail_style || P.r_tail != O.r_tail || P.g_tail != O.g_tail || P.b_tail != O.b_tail || P.ear_style != O.ear_style || P.r_facial != O.r_facial || P.g_facial != O.g_facial || P.b_facial != O.b_facial)
+				if(TFmodify == 3 && P.r_hair != O.r_hair || P.g_hair != O.g_hair || P.species != O.species || P.b_hair != O.b_hair || P.r_skin != O.r_skin || P.g_skin != O.g_skin || P.b_skin != O.b_skin || P.tail_style != O.tail_style || P.r_tail != O.r_tail || P.g_tail != O.g_tail || P.b_tail != O.b_tail || P.ear_style != O.ear_style || P.r_facial != O.r_facial || P.g_facial != O.g_facial || P.b_facial != O.b_facial || P.custom_species != O.custom_species)
 					P.r_hair = O.r_hair
 					P.r_facial = O.r_facial
 					P.g_hair = O.g_hair


### PR DESCRIPTION
- Makes TF always proc
- Prevents blood rejection
- Has change species TF check to see if they are the same species as the person.

Minor bugfix to tf along with one major one.

Earlier in a round someone was using TF and one of the messages went off (the first out of 3) but then none others for 5 minutes. 

This was due to them either failing the 10% chance per tick, every tick, or hitting the 10% chance per tick and then hitting 1 instead of 3, resulting in them not having TF work.

This PR makes it so that TF will always proc instead of leaving it up to RNG.

Edit: Found a bug in which the person TF'd would die due to blood rejection. This was fixed by making it so it resets their blood and fixes it when they're TF'd