### PR TITLE
Allow greater customisation of wiki links (Fixes #460)

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -99,6 +99,7 @@ var/list/gamemode_cache = list()
 	var/server
 	var/banappeals
 	var/wikiurl
+	var/wikisearchurl
 	var/forumurl
 	var/githuburl
 	var/rulesurl
@@ -424,6 +425,9 @@ var/list/gamemode_cache = list()
 
 				if ("wikiurl")
 					config.wikiurl = value
+
+				if ("wikisearchurl")
+					config.wikisearchurl = value
 
 				if ("forumurl")
 					config.forumurl = value

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -206,6 +206,11 @@ GUEST_BAN
 ## Wiki address
 # WIKIURL http://example.com
 
+## Wiki search path
+## Set this to whatever path your wiki uses to search for articles
+## Use %s to mark where the search query should be inserted
+# WIKISEARCHURL http://example.com/index.php?title=Special%3ASearch&search=%s
+
 ## GitHub address
 # GITHUBURL https://github.com/example-user/example-repository
 ## Ban appeals URL - usually for a forum or wherever people should go to contact your admins.

--- a/interface/interface.dm
+++ b/interface/interface.dm
@@ -5,8 +5,11 @@
 	set category = "OOC"
 	if(config.wikiurl)
 		if(query)
-			var/output = config.wikiurl + "/doku.php?do=search&id=" + query
-			src << link(output)
+			if(config.wikisearchurl)
+				var/output = replacetext(config.wikisearchurl, "%s", url_encode(query))	
+				src << link(output)
+			else
+				src << "<span class='warning'> The wiki search URL is not set in the server configuration.</span>"
 		else
 			src << link(config.wikiurl)
 	else


### PR DESCRIPTION
Because different servers have different wiki setups, it's just not right to have the search URL hardcoded in. MediaWiki has its own search URL, other wikis have their own. I've added in a new config option to allow server owners to designate the URL to be used for searching.

Bit of a breaking change, since all current servers will need to specify this new config option, but I really don't like how it's hardcoded right now.

Fixes #460.