### PR TITLE
Xenochimera revamp & bugfixes

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/station_special_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_special_vr.dm
@@ -45,9 +45,6 @@
 		return
 	if(H.absorbed == 1) //If they get nomphed and absorbed.
 		return
-	if(H.feral == 1) //Uh oh, they're starving and have gone feral. Prepare for hallucinations!
-		if(H.hallucination < 100 && H.lying = 0) //If they're lying down they won't ramp up any more hallucinations. This is so it won't interrupt scenes.
-			H.hallucination += 5 //Start hallucinating, up to a point.
 
 	if(H.nutrition > 50 && H.feral == 1) //If they went feral then ate something.
 		H.feral = 0
@@ -78,12 +75,16 @@
 				H << "<span class='danger'> You feel a stabbing pain in your gut, causing you to twitch in pain.. It would be extremely wise to find some type of food... In fact, [M] looks extremely appetizing...</span>"
 				if(H.stat == CONSCIOUS)
 					H.emote("twitch")
+			if(H.feral = 1) //This should always be the case under 500 nutrition, but just in case.
+				H.hallucination -= 5 //Start to stop hallucinating once you see someone.
 
 		else if(M == H && H.nutrition <= 50) //Hungry and nobody is in view.
 			if(prob(1)) //Constantly nag them to go and find someone or something to eat.
 				H << "<span class='danger'> You feel a sharp jab in your stomach from hunger, causing you to twitch in pain. You need to find something to eat immediately.</span>"
 				if(H.stat == CONSCIOUS)
 					H.emote("twitch")
+			if(H.feral = 1)
+				H.hallucination += 5 //Start hallucinating while alone and hungry.
 
 //////////////////////////////////////////////////////////////////////////////////////////
 ///////////WIP CODE TO MAKE XENOCHIMERAS NOT DIE IN SPACE WHILE REGENNING BELOW///////////

--- a/code/modules/mob/living/carbon/human/species/station/station_special_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_special_vr.dm
@@ -46,7 +46,7 @@
 	if(H.absorbed == 1) //If they get nomphed and absorbed.
 		return
 	if(H.feral == 1) //Uh oh, they're starving and have gone feral. Prepare for hallucinations!
-		if(H.hallucination < 100)
+		if(H.hallucination < 100 && H.lying = 0) //If they're lying down they won't ramp up any more hallucinations. This is so it won't interrupt scenes.
 			H.hallucination += 5 //Start hallucinating, up to a point.
 
 	if(H.nutrition > 50 && H.feral == 1) //If they went feral then ate something.

--- a/code/modules/mob/living/carbon/human/species/station/station_special_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_special_vr.dm
@@ -76,7 +76,7 @@
 				if(H.stat == CONSCIOUS)
 					H.emote("twitch")
 			if(H.feral = 1) //This should always be the case under 500 nutrition, but just in case.
-				H.hallucination -= 5 //Start to stop hallucinating once you see someone.
+				H.hallucination -= 25 //Start to stop hallucinating once you see someone.
 
 		else if(M == H && H.nutrition <= 50) //Hungry and nobody is in view.
 			if(prob(1)) //Constantly nag them to go and find someone or something to eat.

--- a/code/modules/mob/living/carbon/human/species/station/station_special_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_special_vr.dm
@@ -75,7 +75,7 @@
 				H << "<span class='danger'> You feel a stabbing pain in your gut, causing you to twitch in pain.. It would be extremely wise to find some type of food... In fact, [M] looks extremely appetizing...</span>"
 				if(H.stat == CONSCIOUS)
 					H.emote("twitch")
-			if(H.feral = 1) //This should always be the case under 500 nutrition, but just in case.
+			if(H.feral == 1) //This should always be the case under 500 nutrition, but just in case.
 				H.hallucination -= 25 //Start to stop hallucinating once you see someone.
 
 		else if(M == H && H.nutrition <= 50) //Hungry and nobody is in view.
@@ -83,7 +83,7 @@
 				H << "<span class='danger'> You feel a sharp jab in your stomach from hunger, causing you to twitch in pain. You need to find something to eat immediately.</span>"
 				if(H.stat == CONSCIOUS)
 					H.emote("twitch")
-			if(H.feral = 1)
+			if(H.feral == 1)
 				if(H.hallucination < 200) //200 hallucination cap. Let's not be too evil.
 					H.hallucination += 5 //Start hallucinating while alone and hungry.
 

--- a/code/modules/mob/living/carbon/human/species/station/station_special_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_special_vr.dm
@@ -84,7 +84,8 @@
 				if(H.stat == CONSCIOUS)
 					H.emote("twitch")
 			if(H.feral = 1)
-				H.hallucination += 5 //Start hallucinating while alone and hungry.
+				if(H.hallucination < 200) //200 hallucination cap. Let's not be too evil.
+					H.hallucination += 5 //Start hallucinating while alone and hungry.
 
 //////////////////////////////////////////////////////////////////////////////////////////
 ///////////WIP CODE TO MAKE XENOCHIMERAS NOT DIE IN SPACE WHILE REGENNING BELOW///////////

--- a/code/modules/vore/eating/living_vr.dm
+++ b/code/modules/vore/eating/living_vr.dm
@@ -8,6 +8,7 @@
 	var/weight_gain = 1 				// How fast you gain weight
 	var/weight_loss = 0.5 				// How fast you lose weight
 	var/egg_type = "egg" 					// Default egg type.
+	var/feral = 0 						// If the mob is feral or not. Does nothing for non xenochimera at the moment.
 
 //
 // Hook for generic creation of stuff on new creatures


### PR DESCRIPTION
Revamps xenochimeras.

- Allows more than one xenochimera to be on the station at a time -**Bugfix**
- Xenochimera special effects actually occur now -**Bugfix**
- Xenochimeras wont die due to pressure in space while regenerating. They still die in unpressurized areas when not regenerating, though.
- Xenochimeras slowly gain halloss and obtain blurry vision while in a freezing environment instead of damage. The amount of halloss obtained per tick depends on how cold the environment is. After some time, they will fall over and be out until someone rescues them, completely vulnerable.
- Xenochimeras begin to hallucinate when they go feral and are alone.
- If someone is in sight while feral hallucinations will quickly dissapear to prevent interrupting RP.