### PR TITLE
Emergency hotfix for alien whitelist

### DIFF
--- a/code/modules/mob/language/station_vr.dm
+++ b/code/modules/mob/language/station_vr.dm
@@ -38,3 +38,17 @@
 	"ist","ein","entch","zwichs","tut","mir","wo","bis","es","vor","nic","gro","lll","enem","zandt","tzch","noch", \
 	"hel","ischt","far","wa","baram","iereng","tech","lach","sam","mak","lich","gen","or","ag","eck","gec","stag","onn", \
 	"bin","ket","jarl","vulf","einech","cresthz","azunein","ghzth")
+
+
+
+
+/datum/language/unathi
+	flags = 0
+/datum/language/tajaran
+	flags = 0
+/datum/language/skrell
+	flags = 0
+/datum/language/human
+	flags = 0
+/datum/language/seromi
+	flags = 0

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -151,13 +151,13 @@
 		if(!ticker || ticker.current_state != GAME_STATE_PLAYING)
 			usr << "\red The round is either not ready, or has already finished..."
 			return
-
-		if(client.prefs.species != "Human" && !check_rights(R_ADMIN, 0))
+/*
+		if(client.prefs.species != "Human" && !check_rights(R_ADMIN, 0)) //VORESTATION EDITS: THE COMMENTED OUT AREAS FROM LINE 154 TO 178
 			if (config.usealienwhitelist)
 				if(!is_alien_whitelisted(src, client.prefs.species))
 					src << alert("You are currently not whitelisted to Play [client.prefs.species].")
 					return 0
-
+*/
 		LateChoices()
 
 	if(href_list["manifest"])
@@ -171,11 +171,11 @@
 		else if(ticker && ticker.mode && ticker.mode.explosion_in_progress)
 			usr << "<span class='danger'>The station is currently exploding. Joining would go poorly.</span>"
 			return
-
+/*
 		if(!is_alien_whitelisted(src, all_species[client.prefs.species]))
 			src << alert("You are currently not whitelisted to play [client.prefs.species].")
 			return 0
-
+*/
 		var/datum/species/S = all_species[client.prefs.species]
 		if(!(S.spawn_flags & SPECIES_CAN_JOIN))
 			src << alert("Your current species, [client.prefs.species], is not available for play on the station.")


### PR DESCRIPTION
- Unwhitelists languages
- Makes non-whitelisted races selectable

What a user will see
Non-whitelisted species: http://puu.sh/qAHq0/ea76a40270.png
Whitelisted species: http://puu.sh/qAHss/0e200688b8.png

This means that a user will be able to select and join as a non-whitelisted species, but not select a whitelisted species.

If they _do_ somehow get their save file changed to a whitelisted species (By admin abuse, or their file previously had the race selected) they'll be able to join in. Not a big problem seeing as admin abuse is the only way it'll occur, and not too many people have selected the races and can simply be told to change it.

Fixes #427