### PR TITLE
Adds in drain mode, prevents egging while absorbed.

### DIFF
--- a/code/__defines/belly_modes_vr.dm
+++ b/code/__defines/belly_modes_vr.dm
@@ -13,6 +13,7 @@
 #define DM_TRANSFORM_FEMALE_EGG				"Transform (Female) (EGG)"
 #define DM_EGG 								"Encase In Egg"
 #define DM_DRAIN							"Drain"
+#define DM_UNABSORB							"Unabsorb"
 
 
 // Stance for hostile mobs to be in while devouring someone.

--- a/code/__defines/belly_modes_vr.dm
+++ b/code/__defines/belly_modes_vr.dm
@@ -3,15 +3,16 @@
 #define DM_DIGEST							"Digest"
 #define DM_HEAL								"Heal"
 #define DM_ABSORB							"Absorb"
-#define DM_TRANSFORM_MALE                   "Transform (Male)" //I totally don't have a thing for TF. Nope! ~CK
-#define DM_TRANSFORM_FEMALE                 "Transform (Female)"
-#define DM_TRANSFORM_KEEP_GENDER            "Transform (Keep Gender)"
-#define DM_TRANSFORM_CHANGE_SPECIES         "Transform (Change Species)"
-#define DM_TRANSFORM_CHANGE_SPECIES_EGG     "Transform (Change Species) (EGG)"
-#define DM_TRANSFORM_KEEP_GENDER_EGG        "Transform (Keep Gender) (EGG)"
-#define DM_TRANSFORM_MALE_EGG               "Transform (Male) (EGG)"
-#define DM_TRANSFORM_FEMALE_EGG             "Transform (Female) (EGG)"
+#define DM_TRANSFORM_MALE					"Transform (Male)"
+#define DM_TRANSFORM_FEMALE					"Transform (Female)"
+#define DM_TRANSFORM_KEEP_GENDER			"Transform (Keep Gender)"
+#define DM_TRANSFORM_CHANGE_SPECIES			"Transform (Change Species)"
+#define DM_TRANSFORM_CHANGE_SPECIES_EGG		"Transform (Change Species) (EGG)"
+#define DM_TRANSFORM_KEEP_GENDER_EGG		"Transform (Keep Gender) (EGG)"
+#define DM_TRANSFORM_MALE_EGG				"Transform (Male) (EGG)"
+#define DM_TRANSFORM_FEMALE_EGG				"Transform (Female) (EGG)"
 #define DM_EGG 								"Encase In Egg"
+#define DM_DRAIN							"Drain"
 
 
 // Stance for hostile mobs to be in while devouring someone.

--- a/code/modules/vore/eating/belly_vr.dm
+++ b/code/modules/vore/eating/belly_vr.dm
@@ -24,7 +24,7 @@
 	var/escapetime = 600					// Deciseconds, how long to escape this belly
 
 	var/tmp/digest_mode = DM_HOLD				// Whether or not to digest. Default to not digest.
-	var/tmp/list/digest_modes = list(DM_HOLD,DM_DIGEST,DM_HEAL,DM_ABSORB,DM_DRAIN)	// Possible digest modes
+	var/tmp/list/digest_modes = list(DM_HOLD,DM_DIGEST,DM_HEAL,DM_ABSORB,DM_DRAIN,DM_UNABSORB)	// Possible digest modes
 	var/tmp/list/transform_modes = list(DM_TRANSFORM_MALE,DM_TRANSFORM_FEMALE,DM_TRANSFORM_KEEP_GENDER,DM_TRANSFORM_CHANGE_SPECIES,DM_TRANSFORM_CHANGE_SPECIES_EGG,DM_TRANSFORM_KEEP_GENDER_EGG,DM_TRANSFORM_MALE_EGG,DM_TRANSFORM_FEMALE_EGG, DM_EGG)
 	var/tmp/mob/living/owner					// The mob whose belly this is.
 	var/tmp/list/internal_contents = list()		// People/Things you've eaten into this belly!

--- a/code/modules/vore/eating/belly_vr.dm
+++ b/code/modules/vore/eating/belly_vr.dm
@@ -24,7 +24,7 @@
 	var/escapetime = 600					// Deciseconds, how long to escape this belly
 
 	var/tmp/digest_mode = DM_HOLD				// Whether or not to digest. Default to not digest.
-	var/tmp/list/digest_modes = list(DM_HOLD,DM_DIGEST,DM_HEAL,DM_ABSORB)	// Possible digest modes
+	var/tmp/list/digest_modes = list(DM_HOLD,DM_DIGEST,DM_HEAL,DM_ABSORB,DM_DRAIN)	// Possible digest modes
 	var/tmp/list/transform_modes = list(DM_TRANSFORM_MALE,DM_TRANSFORM_FEMALE,DM_TRANSFORM_KEEP_GENDER,DM_TRANSFORM_CHANGE_SPECIES,DM_TRANSFORM_CHANGE_SPECIES_EGG,DM_TRANSFORM_KEEP_GENDER_EGG,DM_TRANSFORM_MALE_EGG,DM_TRANSFORM_FEMALE_EGG, DM_EGG)
 	var/tmp/mob/living/owner					// The mob whose belly this is.
 	var/tmp/list/internal_contents = list()		// People/Things you've eaten into this belly!

--- a/code/modules/vore/eating/bellymodes_vr.dm
+++ b/code/modules/vore/eating/bellymodes_vr.dm
@@ -98,6 +98,19 @@
 		return
 
 
+
+//////////////////////////// DM_UNABSORB ////////////////////////////
+	if(digest_mode == DM_UNABSORB)
+
+		for (var/mob/living/M in internal_contents)
+			if(M.absorbed && owner.nutrition >= 100)
+				M.absorbed = 0
+				M << "<span class='notice'>You suddenly feel solid again </span>"
+				owner << "<span class='notice'>You feel like a part of you is missing.</span>"
+				owner.nutrition -= 100
+		return
+
+
 //////////////////////////// DM_DRAIN ////////////////////////////
 	if(digest_mode == DM_DRAIN)
 

--- a/code/modules/vore/eating/bellymodes_vr.dm
+++ b/code/modules/vore/eating/bellymodes_vr.dm
@@ -97,6 +97,24 @@
 
 		return
 
+
+//////////////////////////// DM_DRAIN ////////////////////////////
+	if(digest_mode == DM_DRAIN)
+
+		for (var/mob/living/M in internal_contents)
+
+			if(prob(10)) //Less often than gurgles. People might leave this on forever.
+				var/drainsound = pick(digestion_sounds)
+				M << sound(drainsound,volume=80)
+				owner << sound(drainsound,volume=80)
+
+			if(M.nutrition >= 100) //Drain them until there's no nutrients left.
+				var/oldnutrition = (M.nutrition * 0.05)
+				M.nutrition = (M.nutrition * 0.95)
+				owner.nutrition += oldnutrition
+				return
+		return
+
 ///////////////////////////// DM_HEAL /////////////////////////////
 	if(digest_mode == DM_HEAL)
 		if(prob(50)) //Wet heals!
@@ -335,13 +353,14 @@
 		for (var/mob/living/carbon/human/P in internal_contents)
 			if(P.stat)
 				continue
-
+			if(P.absorbed) //If they're absorbed, don't egg them
+				return
 			var/mob/living/carbon/human/O = owner
 
 			if (O.custom_species)
 				var/defined_species = O.custom_species
-				P.r_hair 			= O.r_hair //Made all these line up
-				P.r_facial 			= O.r_facial //So you can ea
+				P.r_hair 			= O.r_hair
+				P.r_facial 			= O.r_facial
 				P.g_hair 			= O.g_hair
 				P.g_facial 			= O.g_facial
 				P.b_hair 			= O.b_hair
@@ -360,9 +379,10 @@
 				P.r_eyes 			= O.r_eyes
 				P.g_eyes 			= O.g_eyes
 				P.b_eyes 			= O.b_eyes
+
 				for(var/obj/item/organ/I in P.internal_organs) //This prevents organ rejection
 					I.species = O.species
-					//Z.h_col = //This is required to get their color the same as the preds.
+
 				for(var/obj/item/organ/external/chest/A in O.organs)
 					for(var/obj/item/organ/external/Z in P.organs) //This makes their limb sprites look correct.
 						Z.species = O.species
@@ -541,7 +561,8 @@
 		for (var/mob/living/carbon/human/P in internal_contents)
 			if(P.stat)
 				continue
-
+			if(P.absorbed) //If they're absorbed, don't egg them
+				return
 			var/mob/living/carbon/human/O = owner
 
 			if (O.custom_species)
@@ -716,7 +737,8 @@
 		for (var/mob/living/carbon/human/P in internal_contents)
 			if(P.stat)
 				continue
-
+			if(P.absorbed) //If they're absorbed, don't egg them
+				return
 			var/mob/living/carbon/human/O = owner
 
 			if (O.custom_species)
@@ -890,7 +912,8 @@
 		for (var/mob/living/carbon/human/P in internal_contents)
 			if(P.stat)
 				continue
-
+			if(P.absorbed) //If they're absorbed, don't egg them
+				return
 			var/mob/living/carbon/human/O = owner
 
 
@@ -1064,7 +1087,8 @@
 		for (var/mob/living/carbon/human/P in internal_contents)
 			if(P.stat)
 				continue
-
+			if(P.absorbed) //If they're absorbed, don't egg them
+				return
 			var/mob/living/carbon/human/O = owner
 
 			if (O.custom_species)

--- a/code/modules/vore/eating/vorepanel_vr.dm
+++ b/code/modules/vore/eating/vorepanel_vr.dm
@@ -88,6 +88,8 @@
 				spanstyle = "color:green;"
 			if(DM_ABSORB)
 				spanstyle = "color:purple;"
+			if(DM_DRAIN)
+				spanstyle = "color:purple;"
 			if(DM_TRANSFORM_MALE)
 				spanstyle = "color:purple;"
 			if(DM_TRANSFORM_FEMALE)


### PR DESCRIPTION
- Fixes #469 
- Adds in "drain" mode, which acts like absorb but doesn't absorb them, simply drains them of nutrition.
- Makes it so prey can't be TF'd while absorbed
- Adds in an "unabsorb" mode, which uses up some of the owners nutrition to unabsorb their prey.