### PR TITLE
Allow cyborg combat module in code red

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -246,7 +246,7 @@
 		return
 	var/list/modules = list()
 	modules.Add(robot_module_types)
-	if((crisis && security_level == SEC_LEVEL_RED) || crisis_override) //Leaving this in until it's balanced appropriately.
+	if(crisis || security_level == SEC_LEVEL_RED || crisis_override) // VOREStation Edit
 		src << "\red Crisis mode active. Combat module available."
 		modules+="Combat"
 	modtype = input("Please, select a module!", "Robot module", null, null) as null|anything in modules

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -685,7 +685,7 @@ var/global/list/robot_modules = list(
 
 /obj/item/weapon/robot_module/security/combat/New()
 	src.modules += new /obj/item/device/flash(src)
-	src.modules += new /obj/item/borg/sight/thermal(src)
+	//src.modules += new /obj/item/borg/sight/thermal(src) // VOREStation Edit
 	src.modules += new /obj/item/weapon/gun/energy/laser/mounted(src)
 	src.modules += new /obj/item/weapon/pickaxe/plasmacutter(src)
 	src.modules += new /obj/item/borg/combat/shield(src)

--- a/code/modules/mob/living/silicon/robot/robot_movement.dm
+++ b/code/modules/mob/living/silicon/robot/robot_movement.dm
@@ -18,7 +18,7 @@
 	tally = speed
 
 	if(module_active && istype(module_active,/obj/item/borg/combat/mobility))
-		tally-=3
+		tally-=2 // VOREStation Edit
 
 	return tally+config.robot_delay
 


### PR DESCRIPTION
As mentioned in the Discord chat, small change to automatically allow the Crisis module in code red without admin intervention.