### PR TITLE
Fix nested digestion to move mobs/items up a belly when dead

### DIFF
--- a/code/modules/vore/eating/belly_vr.dm
+++ b/code/modules/vore/eating/belly_vr.dm
@@ -247,10 +247,13 @@
 	if (is_vore_predator(M))
 		for (var/bellytype in M.vore_organs)
 			var/datum/belly/belly = M.vore_organs[bellytype]
-			for (var/obj/SubPrey in belly.internal_contents)
-				SubPrey.forceMove(owner)
-				internal_contents += SubPrey
-				SubPrey << "As [M] melts away around you, you find yourself in [owner]'s [name]"
+			for (var/obj/thing in belly.internal_contents)
+				thing.forceMove(owner)
+				internal_contents += thing
+			for (var/mob/subprey in belly.internal_contents)
+				subprey.forceMove(owner)
+				internal_contents += subprey
+				subprey << "As [M] melts away around you, you find yourself in [owner]'s [name]"
 
 	//Drop all items into the belly.
 	if (config.items_survive_digestion)


### PR DESCRIPTION
Current code was only checking for objects when moving nested belly contents up a level. This fixes it so any prey that gets digested will move any of its prey and eaten items up into their predator's belly as intended, instead of getting deleted.