### PR TITLE
Add additional language whitelists

### DIFF
--- a/code/modules/mob/language/station_vr.dm
+++ b/code/modules/mob/language/station_vr.dm
@@ -52,3 +52,8 @@
 	flags = 0
 /datum/language/seromi
 	flags = 0
+/datum/language/gutter
+	flags = WHITELISTED
+/datum/language/machine
+	flags = NO_STUTTER | WHITELISTED
+


### PR DESCRIPTION
Fixes #539

Gutterband is now whitelisted.
Rootspeak is already species-restricted.
Encoded Audio Language is now whitelisted.