### PR TITLE
Fix micro vore spacing prey

### DIFF
--- a/code/modules/vore/eating/living_vr.dm
+++ b/code/modules/vore/eating/living_vr.dm
@@ -119,7 +119,10 @@
 
 			if (is_vore_predator(src))
 				for (var/mob/living/M in H.contents)
-					attacker.eat_held_mob(attacker, M, src)
+					if (attacker.eat_held_mob(attacker, M, src))
+						H.contents -= M
+						if (H.held_mob == M)
+							H.held_mob = null
 				return 1 //Return 1 to exit upper procs
 			else
 				log_debug("[attacker] attempted to feed [H.contents] to [src] ([src.type]) but it failed.")


### PR DESCRIPTION
Fixes #610 

Alright, finally seem to have tracked this one down. I have no idea *why* this bug has suddenly surfaced, because no code relating to this particular section of the vorecode has changed.

I believe the issue was with the `/obj/item/weapon/holder/micro` object. As it got deleted, it iterated through all of its contents and `held_mob`, moving them to its own location. Since the `holder` was mid-deletion, the `loc` was null. Therefore, poof. `null` loc for the poor prey, even after the vorecode had already set their `loc` to be in the predator.