### PR TITLE
Prevent attacking vore mobs from within them

### DIFF
--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -310,6 +310,8 @@
 			M.do_attack_animation(src)
 
 		if(I_HURT)
+			if (M.loc == src)
+				return // VOREStation Edit
 			adjustBruteLoss(harm_intent_damage)
 			M.visible_message("\red [M] [response_harm] \the [src]")
 			M.do_attack_animation(src)


### PR DESCRIPTION
Fixes #541 

As mentioned in the issue, this change only affects `/mob/living/simple_animal` mobs. i.e. Vore mobs, not players.