### PR TITLE
Hotfix for blank items in bellies

### DIFF
--- a/code/modules/vore/eating/bellymodes_vr.dm
+++ b/code/modules/vore/eating/bellymodes_vr.dm
@@ -12,6 +12,10 @@
 				M << "<span class='notice'>[pick(EL)]</span>"
 			src.emotePend = 0
 
+	for (var/V in internal_contents)
+		if (isnull(V))
+			internal_contents -= V
+
 //////////////////////// Absorbed Handling ////////////////////////
 	for(var/mob/living/M in internal_contents)
 		if(M.absorbed)

--- a/code/modules/vore/eating/vorepanel_vr.dm
+++ b/code/modules/vore/eating/vorepanel_vr.dm
@@ -290,6 +290,8 @@
 					else
 						var/datum/belly/B = user.vore_organs[choice]
 						for(var/atom/movable/tgt in selected.internal_contents)
+							if (!(tgt in selected.internal_contents))
+								continue
 							selected.internal_contents -= tgt
 							B.internal_contents += tgt
 
@@ -326,6 +328,8 @@
 					return 1
 				else
 					var/datum/belly/B = user.vore_organs[choice]
+					if (!(tgt in selected.internal_contents))
+						return 0
 					selected.internal_contents -= tgt
 					B.internal_contents += tgt
 


### PR DESCRIPTION
Fixes #306 (Hotfix)

Until I can find a way to reliable replicate this bug, it is damn near impossible for me to track down. So for now, I'm throwing in a hotfix that will remove any null (blank) items from in bellies every time the belly is processed.

Also throwing in a bugfix for a (sort-of) item duplication bug. Not really duplication, but if you opened the dialog to move an item in a belly and switched selected bellies before hitting 'move', the item would appear twice. Both referenced the same item, so not truly a dupe.