### PR TITLE
Fix flashlight spam

### DIFF
--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -61,7 +61,8 @@
 					cell.charge -= power_usage
 				else
 					visible_message("<span class='warning'>\The [src] flickers before going dull.</span>")
-					set_light(0)
+					on = !on
+					update_icon()
 
 /obj/item/device/flashlight/update_icon()
 	if(on)
@@ -100,6 +101,9 @@
 /obj/item/device/flashlight/attack_self(mob/user)
 	if(!isturf(user.loc))
 		user << "You cannot turn the light on while in this [user.loc]." //To prevent some lighting anomalities.
+		return 0
+	if(!on && cell.charge < power_usage)
+		user << "The [src] does not have enough charge to turn on."
 		return 0
 	on = !on
 	update_icon()


### PR DESCRIPTION
Flashlights were not properly turning off when they ran out of battery, resulting in a nonstop spam of `The flashlight flickers before going dull.` every single second. Now they properly turn off, and will refuse to turn on without sufficient battery life.