### PR TITLE
Makes Diona a whitelisted race

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/station_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_vr.dm
@@ -300,7 +300,7 @@
 	spawn_flags = SPECIES_CAN_JOIN
 
 /datum/species/diona
-	spawn_flags = SPECIES_CAN_JOIN
+	spawn_flags = SPECIES_CAN_JOIN | SPECIES_IS_WHITELISTED
 
 /datum/species/teshari
 	spawn_flags = SPECIES_CAN_JOIN


### PR DESCRIPTION
In case the poll passes, this PR will whitelist Diona.
Poll in question: http://forum.vore-station.net/viewtopic.php?f=20&t=807&p=5228#p5228

**_However_**, **this will not remove the Diona race from people's savefile if they've already saved a diona character in their character select menus**, as stated by PR #472. 

This means that users that already have Diona in their character saves will most likely need to change their savefile to another species or they'll be able to play it. Whitelisting still works as normal (Put their ckey and species name in the file and they'll be able to play that species) but it's just that preexisting diona players will have access to them until they change their savefile's species. 

The Polaris whitelist system, (to the best of my knowledge,) still isn't 100% working. As in, all races with the exception of humans are whitelisted no matter what without PR #472 if the whitelist is enabled. 

PR #472 did a hacky fix to make it work since a few races needed to be whitlisted ASAP and at the time no other solution other than 1. Having humans the only playable characters and 2. Have xenochimera as a playable character for everyone.

Side note: I still have no bloody idea how to fully fix the whitelist, and the hotfix was the best idea I could come up with at the time. It works, it doesn't change anything that commenting a few areas out, but the problem listed above (Users already having savefiles with a whitelisted race) is the only problem with the hotfix.