### PR TITLE
Fix for several issues (455,443,239)

### DIFF
--- a/code/_helpers/global_lists_vr.dm
+++ b/code/_helpers/global_lists_vr.dm
@@ -23,11 +23,9 @@ var/global/list/important_items = list(
 		/obj/item/device/paicard,
 		/obj/item/weapon/gun,
 		/obj/item/weapon/pinpointer,
-		///obj/item/clothing/suit,
 		/obj/item/clothing/shoes/magboots,
 		/obj/item/blueprints,
 		/obj/item/clothing/head/helmet/space,
-		///obj/item/weapon/storage/internal, //You can't just preserve magical objects like this...
 		/obj/item/weapon/disk/nuclear)
 
 var/global/list/digestion_sounds = list(

--- a/code/_helpers/global_lists_vr.dm
+++ b/code/_helpers/global_lists_vr.dm
@@ -23,16 +23,12 @@ var/global/list/important_items = list(
 		/obj/item/device/paicard,
 		/obj/item/weapon/gun,
 		/obj/item/weapon/pinpointer,
-		/obj/item/clothing/suit,
+		///obj/item/clothing/suit,
 		/obj/item/clothing/shoes/magboots,
 		/obj/item/blueprints,
 		/obj/item/clothing/head/helmet/space,
-		/obj/item/weapon/storage/internal,
+		///obj/item/weapon/storage/internal, //You can't just preserve magical objects like this...
 		/obj/item/weapon/disk/nuclear)
-
-		/* TODOPOLARIS - Depends on porting object
-		///obj/item/weapon/card/id/digested)
-		*/
 
 var/global/list/digestion_sounds = list(
 		'sound/vore/digest1.ogg',

--- a/code/game/objects/items/weapons/storage/internal.dm
+++ b/code/game/objects/items/weapons/storage/internal.dm
@@ -6,7 +6,7 @@
 /obj/item/weapon/storage/internal/New(obj/item/MI)
 	master_item = MI
 	loc = master_item
-	name = master_item.name
+	//name = master_item.name //VOREStation Removal
 	verbs -= /obj/item/verb/verb_pickup	//make sure this is never picked up.
 	..()
 

--- a/code/modules/flufftext/Dreaming.dm
+++ b/code/modules/flufftext/Dreaming.dm
@@ -12,6 +12,10 @@ var/list/dreams = list(
 	"the virologist","the roboticist","the chef","the bartender","the chaplain","the librarian","a mouse","an ert member",
 	"a beach","the holodeck","a smokey room","a voice","the cold","a mouse","an operating table","the bar","the rain","a skrell",
 	"an unathi","a tajaran","the ai core","the mining station","the research station","a beaker of strange liquid",
+	//VOREStation Additions after this
+	"slimey surroundings","a sexy squirrel","licking their lips","a gaping maw","an unlikely predator","sinking inside",
+	"vulpine assets","more dakka","churning guts","pools of fluid","an exceptional grip","mawing in faces","gaping throat",
+	"swallowed whole","a fox","a wolf","a cat","a tiger","a dog","a taur","a xenochimera"
 	)
 
 mob/living/carbon/proc/dream()

--- a/code/modules/vore/eating/bellymodes_vr.dm
+++ b/code/modules/vore/eating/bellymodes_vr.dm
@@ -12,10 +12,6 @@
 				M << "<span class='notice'>[pick(EL)]</span>"
 			src.emotePend = 0
 
-	for (var/V in internal_contents)
-		if (isnull(V))
-			internal_contents -= V
-
 //////////////////////// Absorbed Handling ////////////////////////
 	for(var/mob/living/M in internal_contents)
 		if(M.absorbed)

--- a/code/modules/vore/eating/living_vr.dm
+++ b/code/modules/vore/eating/living_vr.dm
@@ -179,6 +179,7 @@
 	for (var/I in vore_organs)
 		var/datum/belly/B = vore_organs[I]
 		if(B.internal_contents.len)
+			listclearnulls(B.internal_contents)
 			for(var/atom/movable/M in B.internal_contents)
 				if(M.loc != src)
 					B.internal_contents -= M

--- a/code/modules/vore/eating/vorepanel_vr.dm
+++ b/code/modules/vore/eating/vorepanel_vr.dm
@@ -64,7 +64,10 @@
 								continue
 
 					//Anything else
-					dat += "<a href='?src=\ref[src];outsidepick=\ref[O];outsidebelly=\ref[inside_belly]'>[O]</a>"
+					dat += "<a href='?src=\ref[src];outsidepick=\ref[O];outsidebelly=\ref[inside_belly]'>[O]&#8203;</a>"
+
+					//Zero-width space, for wrapping
+					dat += "&#8203;"
 	else
 		dat += "You aren't inside anyone."
 
@@ -135,6 +138,9 @@
 
 				//Anything else
 				dat += "<a href='?src=\ref[src];insidepick=\ref[O]'>[O]</a>"
+
+				//Zero-width space, for wrapping
+				dat += "&#8203;"
 
 			//If there's more than one thing, add an [All] button
 			if(selected.internal_contents.len > 1)

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -576,6 +576,10 @@ macro "hotkeymode"
 		command = ".me"
 		is-disabled = false
 	elem 
+		name = "6"
+		command = "subtle"
+		is-disabled = false
+	elem 
 		name = "A+REP"
 		command = ".west"
 		is-disabled = false
@@ -677,11 +681,11 @@ macro "hotkeymode"
 		is-disabled = false
 	elem 
 		name = "Y"
-		command = "Activate-Held-Object"
+		command = "whisper"
 		is-disabled = false
 	elem 
 		name = "CTRL+Y"
-		command = "Activate-Held-Object"
+		command = "whisper"
 		is-disabled = false
 	elem 
 		name = "Z"


### PR DESCRIPTION
global_lists_vr.dm - Removes generic 'suit' which included basically any outerwear, and the invisible magical storage/internal
storage/internal.dm - Don't name the storage inside suits the same as the suit. It causes weird name-alignment problems where if you delete the suit it might just delete the internal storage, or the other way around.
Dreaming.dm - Added some vorish stuff I made up.
belly_vr.dm - Fixes for digesting items and how that works, and how to prevent them from showing up on the HUD. Also fixes IDs falling onto the floor (among other things).
living_vr.dm - Just in case, adds null-entry cleanup to belly cleanup proc.
bellymodes_vr.dm - Removes previous null-item hotfix.
vorepanel_vr.dm - Adds zero-width space to make items in belly wrap and not look horrible.
skim.dmf - Adds Y hotkey for whisper, and 6 hotkey for subtle.

Closes #455
Closes #443
Closes #239