### PR TITLE
Makes taur suits retain name when put in a cycler

### DIFF
--- a/code/modules/clothing/spacesuits/void/void_vr.dm
+++ b/code/modules/clothing/spacesuits/void/void_vr.dm
@@ -82,22 +82,26 @@
 	species_restricted = null //Species restricted since all it cares about is a taur half
 	mob_can_equip(var/mob/living/carbon/human/H, slot, disable_warning = 0)
 		if(istype(H) && istype(H.tail_style, /datum/sprite_accessory/tail/taur/horse))
+			name = "taur specific blood-red voidsuit"
 			icon_override = 'icons/mob/taursuits_vr.dmi'
 			icon_state = "syndie-horse"
 			pixel_x = -16
 			return 1
 		else if(istype(H) && istype(H.tail_style, /datum/sprite_accessory/tail/taur/wolf))
+			name = "taur specific blood-red voidsuit"
 			icon_override = 'icons/mob/taursuits_vr.dmi'
 			icon_state = "syndie-wolf"
 			pixel_x = -16
 			return 1
 		else if(istype(H) && istype(H.tail_style, /datum/sprite_accessory/tail/taur/naga))
+			name = "taur specific blood-red voidsuit"
 			icon_override = 'icons/mob/taursuits_vr.dmi'
 			icon_state = "syndie-naga"
 			pixel_x = -16
 			return 1
 		else
 			H << "<span class='warning'>You need to have a horse, wolf, or naga half to wear this.</span>"
+			name = "taur specific blood-red voidsuit"
 			return 0
 
 /obj/item/clothing/suit/space/void/medical/taur
@@ -106,18 +110,21 @@
 	species_restricted = null
 	mob_can_equip(var/mob/living/carbon/human/H, slot, disable_warning = 0)
 		if(istype(H) && istype(H.tail_style, /datum/sprite_accessory/tail/taur/horse))
+			name = "taur specific medical voidsuit"
 			icon = 'icons/mob/taursuits_vr.dmi'
 			icon_override = 'icons/mob/taursuits_vr.dmi'
 			icon_state = "medical-horse"
 			pixel_x = -16
 			return 1
 		else if(istype(H) && istype(H.tail_style, /datum/sprite_accessory/tail/taur/wolf))
+			name = "taur specific medical voidsuit"
 			icon = 'icons/mob/taursuits_vr.dmi'
 			icon_override = 'icons/mob/taursuits_vr.dmi'
 			icon_state = "medical-wolf"
 			pixel_x = -16
 			return 1
 		else if(istype(H) && istype(H.tail_style, /datum/sprite_accessory/tail/taur/naga))
+			name = "taur specific medical voidsuit"
 			icon = 'icons/mob/taursuits_vr.dmi'
 			icon_override = 'icons/mob/taursuits_vr.dmi'
 			icon_state = "medical-naga"
@@ -125,6 +132,7 @@
 			return 1
 		else
 			H << "<span class='warning'>You need to have a horse, wolf, or naga half to wear this.</span>"
+			name = "taur specific medical voidsuit"
 			return 0
 
 
@@ -134,18 +142,21 @@
 	species_restricted = null
 	mob_can_equip(var/mob/living/carbon/human/H, slot, disable_warning = 0)
 		if(istype(H) && istype(H.tail_style, /datum/sprite_accessory/tail/taur/horse))
+			name = "taur specific engineering voidsuit"
 			icon = 'icons/mob/taursuits_vr.dmi'
 			icon_override = 'icons/mob/taursuits_vr.dmi'
 			icon_state = "engineering-horse"
 			pixel_x = -16
 			return 1
 		else if(istype(H) && istype(H.tail_style, /datum/sprite_accessory/tail/taur/wolf))
+			name = "taur specific engineering voidsuit"
 			icon = 'icons/mob/taursuits_vr.dmi'
 			icon_override = 'icons/mob/taursuits_vr.dmi'
 			icon_state = "engineering-wolf"
 			pixel_x = -16
 			return 1
 		else if(istype(H) && istype(H.tail_style, /datum/sprite_accessory/tail/taur/naga))
+			name = "taur specific engineering voidsuit"
 			icon = 'icons/mob/taursuits_vr.dmi'
 			icon_override = 'icons/mob/taursuits_vr.dmi'
 			icon_state = "engineering-naga"
@@ -153,6 +164,7 @@
 			return 1
 		else
 			H << "<span class='warning'>You need to have a horse, wolf, or naga half to wear this.</span>"
+			name = "taur specific engineering voidsuit"
 			return 0
 
 
@@ -162,6 +174,7 @@
 	species_restricted = null
 	mob_can_equip(var/mob/living/carbon/human/H, slot, disable_warning = 0)
 		if(istype(H) && istype(H.tail_style, /datum/sprite_accessory/tail/taur/horse))
+			name = "taur specific security voidsuit"
 			icon = 'icons/mob/taursuits_vr.dmi'
 			icon_override = 'icons/mob/taursuits_vr.dmi'
 			icon_state = "security-horse"
@@ -169,6 +182,7 @@
 			update_icon()
 			return 1
 		else if(istype(H) && istype(H.tail_style, /datum/sprite_accessory/tail/taur/wolf))
+			name = "taur specific security voidsuit"
 			icon = 'icons/mob/taursuits_vr.dmi'
 			icon_override = 'icons/mob/taursuits_vr.dmi'
 			icon_state = "security-wolf"
@@ -176,6 +190,7 @@
 			update_icon()
 			return 1
 		else if(istype(H) && istype(H.tail_style, /datum/sprite_accessory/tail/taur/naga))
+			name = "taur specific security voidsuit"
 			icon = 'icons/mob/taursuits_vr.dmi'
 			icon_override = 'icons/mob/taursuits_vr.dmi'
 			icon_state = "security-naga"
@@ -184,6 +199,7 @@
 			return 1
 		else
 			H << "<span class='warning'>You need to have a horse, wolf, or naga half to wear this.</span>"
+			name = "taur specific security voidsuit"
 			return 0
 
 /obj/item/clothing/suit/space/void/atmos/taur
@@ -192,6 +208,7 @@
 	species_restricted = null
 	mob_can_equip(var/mob/living/carbon/human/H, slot, disable_warning = 0)
 		if(istype(H) && istype(H.tail_style, /datum/sprite_accessory/tail/taur/horse))
+			name = "taur specific atmospherics voidsuit"
 			icon = 'icons/mob/taursuits_vr.dmi'
 			icon_override = 'icons/mob/taursuits_vr.dmi'
 			icon_state = "atmos-horse"
@@ -199,6 +216,7 @@
 			update_icon()
 			return 1
 		else if(istype(H) && istype(H.tail_style, /datum/sprite_accessory/tail/taur/wolf))
+			name = "taur specific atmospherics voidsuit"
 			icon = 'icons/mob/taursuits_vr.dmi'
 			icon_override = 'icons/mob/taursuits_vr.dmi'
 			icon_state = "atmos-wolf"
@@ -206,6 +224,7 @@
 			update_icon()
 			return 1
 		else if(istype(H) && istype(H.tail_style, /datum/sprite_accessory/tail/taur/naga))
+			name = "taur specific atmospherics voidsuit"
 			icon = 'icons/mob/taursuits_vr.dmi'
 			icon_override = 'icons/mob/taursuits_vr.dmi'
 			icon_state = "atmos-naga"
@@ -214,6 +233,7 @@
 			return 1
 		else
 			H << "<span class='warning'>You need to have a horse, wolf, or naga half to wear this.</span>"
+			name = "taur specific atmospherics voidsuit"
 			return 0
 
 /obj/item/clothing/suit/space/void/mining/taur
@@ -222,6 +242,7 @@
 	species_restricted = null
 	mob_can_equip(var/mob/living/carbon/human/H, slot, disable_warning = 0)
 		if(istype(H) && istype(H.tail_style, /datum/sprite_accessory/tail/taur/horse))
+			name = "taur specific mining voidsuit"
 			icon = 'icons/mob/taursuits_vr.dmi'
 			icon_override = 'icons/mob/taursuits_vr.dmi'
 			icon_state = "mining-horse"
@@ -229,6 +250,7 @@
 			update_icon()
 			return 1
 		else if(istype(H) && istype(H.tail_style, /datum/sprite_accessory/tail/taur/wolf))
+			name = "taur specific mining voidsuit"
 			icon = 'icons/mob/taursuits_vr.dmi'
 			icon_override = 'icons/mob/taursuits_vr.dmi'
 			icon_state = "mining-wolf"
@@ -236,6 +258,7 @@
 			update_icon()
 			return 1
 		else if(istype(H) && istype(H.tail_style, /datum/sprite_accessory/tail/taur/naga))
+			name = "taur specific mining voidsuit"
 			icon = 'icons/mob/taursuits_vr.dmi'
 			icon_override = 'icons/mob/taursuits_vr.dmi'
 			icon_state = "mining-naga"
@@ -244,6 +267,7 @@
 			return 1
 		else
 			H << "<span class='warning'>You need to have a horse, wolf, or naga half to wear this.</span>"
+			name = "taur specific mining voidsuit"
 			return 0
 
 
@@ -253,6 +277,7 @@
 	species_restricted = null
 	mob_can_equip(var/mob/living/carbon/human/H, slot, disable_warning = 0)
 		if(istype(H) && istype(H.tail_style, /datum/sprite_accessory/tail/taur/horse))
+			name = "taur specific blood-red voidsuit"
 			icon = 'icons/mob/taursuits_vr.dmi'
 			icon_override = 'icons/mob/taursuits_vr.dmi'
 			icon_state = "syndie-horse"
@@ -260,6 +285,7 @@
 			update_icon()
 			return 1
 		else if(istype(H) && istype(H.tail_style, /datum/sprite_accessory/tail/taur/wolf))
+			name = "taur specific blood-red voidsuit"
 			icon = 'icons/mob/taursuits_vr.dmi'
 			icon_override = 'icons/mob/taursuits_vr.dmi'
 			icon_state = "syndie-wolf"
@@ -267,6 +293,7 @@
 			update_icon()
 			return 1
 		else if(istype(H) && istype(H.tail_style, /datum/sprite_accessory/tail/taur/naga))
+			name = "taur specific blood-red voidsuit"
 			icon = 'icons/mob/taursuits_vr.dmi'
 			icon_override = 'icons/mob/taursuits_vr.dmi'
 			icon_state = "syndie-naga"
@@ -275,4 +302,5 @@
 			return 1
 		else
 			H << "<span class='warning'>You need to have a horse, wolf, or naga half to wear this.</span>"
+			name = "taur specific blood-red voidsuit"
 			return 0

--- a/code/modules/clothing/spacesuits/void/void_vr.dm
+++ b/code/modules/clothing/spacesuits/void/void_vr.dm
@@ -78,7 +78,7 @@
 
 /obj/item/clothing/suit/space/void/merc/taur
 	name = "taur specific blood-red voidsuit"
-	desc = "A high-tech space suit. It says has a sticker saying one size fits all taurs on it. Below the sticker, it states that it only fits horses, wolves, and naga taurs."
+	desc = "A high-tech space suit. It says has a sticker saying one size fits all taurs on it. Below the sticker, it states that it only fits horses, wolves, and naga taurs, and that it should not under any circumstance be put in a suit cycler."
 	species_restricted = null //Species restricted since all it cares about is a taur half
 	mob_can_equip(var/mob/living/carbon/human/H, slot, disable_warning = 0)
 		if(istype(H) && istype(H.tail_style, /datum/sprite_accessory/tail/taur/horse))
@@ -102,7 +102,7 @@
 
 /obj/item/clothing/suit/space/void/medical/taur
 	name = "taur specific medical voidsuit"
-	desc = "A high-tech space suit. It says has a sticker saying one size fits all taurs on it. Below the sticker, it states that it only fits horses, wolves, and naga taurs."
+	desc = "A high-tech space suit. It says has a sticker saying one size fits all taurs on it. Below the sticker, it states that it only fits horses, wolves, and naga taurs, and that it should not under any circumstance be put in a suit cycler."
 	species_restricted = null
 	mob_can_equip(var/mob/living/carbon/human/H, slot, disable_warning = 0)
 		if(istype(H) && istype(H.tail_style, /datum/sprite_accessory/tail/taur/horse))
@@ -130,7 +130,7 @@
 
 /obj/item/clothing/suit/space/void/engineering/taur
 	name = "taur specific engineering voidsuit"
-	desc = "A high-tech space suit. It says has a sticker saying one size fits all taurs on it. Below the sticker, it states that it only fits horses, wolves, and naga taurs."
+	desc = "A high-tech space suit. It says has a sticker saying one size fits all taurs on it. Below the sticker, it states that it only fits horses, wolves, and naga taurs, and that it should not under any circumstance be put in a suit cycler."
 	species_restricted = null
 	mob_can_equip(var/mob/living/carbon/human/H, slot, disable_warning = 0)
 		if(istype(H) && istype(H.tail_style, /datum/sprite_accessory/tail/taur/horse))
@@ -158,7 +158,7 @@
 
 /obj/item/clothing/suit/space/void/security/taur
 	name = "taur specific security voidsuit"
-	desc = "A high-tech space suit. It says has a sticker saying one size fits all taurs on it. Below the sticker, it states that it only fits horses, wolves, and naga taurs."
+	desc = "A high-tech space suit. It says has a sticker saying one size fits all taurs on it. Below the sticker, it states that it only fits horses, wolves, and naga taurs, and that it should not under any circumstance be put in a suit cycler."
 	species_restricted = null
 	mob_can_equip(var/mob/living/carbon/human/H, slot, disable_warning = 0)
 		if(istype(H) && istype(H.tail_style, /datum/sprite_accessory/tail/taur/horse))
@@ -188,7 +188,7 @@
 
 /obj/item/clothing/suit/space/void/atmos/taur
 	name = "taur specific atmospherics voidsuit"
-	desc = "A high-tech space suit. It says has a sticker saying one size fits all taurs on it. Below the sticker, it states that it only fits horses, wolves, and naga taurs."
+	desc = "A high-tech space suit. It says has a sticker saying one size fits all taurs on it. Below the sticker, it states that it only fits horses, wolves, and naga taurs, and that it should not under any circumstance be put in a suit cycler."
 	species_restricted = null
 	mob_can_equip(var/mob/living/carbon/human/H, slot, disable_warning = 0)
 		if(istype(H) && istype(H.tail_style, /datum/sprite_accessory/tail/taur/horse))
@@ -218,7 +218,7 @@
 
 /obj/item/clothing/suit/space/void/mining/taur
 	name = "taur specific mining voidsuit"
-	desc = "A high-tech space suit. It says has a sticker saying one size fits all taurs on it. Below the sticker, it states that it only fits horses, wolves, and naga taurs."
+	desc = "A high-tech space suit. It says has a sticker saying one size fits all taurs on it. Below the sticker, it states that it only fits horses, wolves, and naga taurs, and that it should not under any circumstance be put in a suit cycler."
 	species_restricted = null
 	mob_can_equip(var/mob/living/carbon/human/H, slot, disable_warning = 0)
 		if(istype(H) && istype(H.tail_style, /datum/sprite_accessory/tail/taur/horse))
@@ -249,7 +249,7 @@
 
 /obj/item/clothing/suit/space/void/merc/taur
 	name = "taur specific blood-red voidsuit"
-	desc = "A high-tech space suit. It says has a sticker saying one size fits all taurs on it. Below the sticker, it states that it only fits horses, wolves, and naga taurs."
+	desc = "A high-tech space suit. It says has a sticker saying one size fits all taurs on it. Below the sticker, it states that it only fits horses, wolves, and naga taurs, and that it should not under any circumstance be put in a suit cycler."
 	species_restricted = null
 	mob_can_equip(var/mob/living/carbon/human/H, slot, disable_warning = 0)
 		if(istype(H) && istype(H.tail_style, /datum/sprite_accessory/tail/taur/horse))


### PR DESCRIPTION
Adds a warning to taur voidsuits that they shouldn't be put in cyclers

People were putting them in cyclers and wondering why it was still only fitting taurs, so this adds a "Don't stick them in cyclers" warning.

Also makes it so when someone attempts to wear a hardsuit after it's been cycled/puts on on after it's been cycled, it'll go back to it's original name. (Taur specific engineering voidsuit/Taur specific medical voidsuit/etc)
