### PR TITLE
Swap 'Give' dialog buttons

### DIFF
--- a/code/modules/mob/living/carbon/give.dm
+++ b/code/modules/mob/living/carbon/give.dm
@@ -15,7 +15,7 @@
 		src << "<span class='warning'>You don't have anything in your hands to give to \the [target].</span>"
 		return
 
-	if(alert(target,"[src] wants to give you \a [I]. Will you accept it?",,"No","Yes") == "No")
+	if(alert(target,"[src] wants to give you \a [I]. Will you accept it?","Item Offer","Yes","No") == "No") //VOREStation Edit - make yes on the left to be consistent with other dialogs
 		target.visible_message("<span class='notice'>\The [src] tried to hand \the [I] to \the [target], \
 		but \the [target] didn't want it.</span>")
 		return


### PR DESCRIPTION
"Yes" on the left to be consistent with other dialogs. The number of times people (myself included) misclick because of this is impressive. Or just accidentally cancel out while typing.
