### PR TITLE
Enables SilencedMP5A5's custom items. Taursuit bugfix.

### DIFF
--- a/code/modules/clothing/spacesuits/void/void_vr.dm
+++ b/code/modules/clothing/spacesuits/void/void_vr.dm
@@ -85,17 +85,17 @@
 			icon_override = 'icons/mob/taursuits_vr.dmi'
 			icon_state = "syndie-horse"
 			pixel_x = -16
-			return 1
+			return ..()
 		else if(istype(H) && istype(H.tail_style, /datum/sprite_accessory/tail/taur/wolf))
 			icon_override = 'icons/mob/taursuits_vr.dmi'
 			icon_state = "syndie-wolf"
 			pixel_x = -16
-			return 1
+			return ..()
 		else if(istype(H) && istype(H.tail_style, /datum/sprite_accessory/tail/taur/naga))
 			icon_override = 'icons/mob/taursuits_vr.dmi'
 			icon_state = "syndie-naga"
 			pixel_x = -16
-			return 1
+			return ..()
 		else
 			H << "<span class='warning'>You need to have a horse, wolf, or naga half to wear this.</span>"
 			return 0
@@ -110,19 +110,19 @@
 			icon_override = 'icons/mob/taursuits_vr.dmi'
 			icon_state = "medical-horse"
 			pixel_x = -16
-			return 1
+			return ..()
 		else if(istype(H) && istype(H.tail_style, /datum/sprite_accessory/tail/taur/wolf))
 			icon = 'icons/mob/taursuits_vr.dmi'
 			icon_override = 'icons/mob/taursuits_vr.dmi'
 			icon_state = "medical-wolf"
 			pixel_x = -16
-			return 1
+			return ..()
 		else if(istype(H) && istype(H.tail_style, /datum/sprite_accessory/tail/taur/naga))
 			icon = 'icons/mob/taursuits_vr.dmi'
 			icon_override = 'icons/mob/taursuits_vr.dmi'
 			icon_state = "medical-naga"
 			pixel_x = -16
-			return 1
+			return ..()
 		else
 			H << "<span class='warning'>You need to have a horse, wolf, or naga half to wear this.</span>"
 			return 0
@@ -138,19 +138,19 @@
 			icon_override = 'icons/mob/taursuits_vr.dmi'
 			icon_state = "engineering-horse"
 			pixel_x = -16
-			return 1
+			return ..()
 		else if(istype(H) && istype(H.tail_style, /datum/sprite_accessory/tail/taur/wolf))
 			icon = 'icons/mob/taursuits_vr.dmi'
 			icon_override = 'icons/mob/taursuits_vr.dmi'
 			icon_state = "engineering-wolf"
 			pixel_x = -16
-			return 1
+			return ..()
 		else if(istype(H) && istype(H.tail_style, /datum/sprite_accessory/tail/taur/naga))
 			icon = 'icons/mob/taursuits_vr.dmi'
 			icon_override = 'icons/mob/taursuits_vr.dmi'
 			icon_state = "engineering-naga"
 			pixel_x = -16
-			return 1
+			return ..()
 		else
 			H << "<span class='warning'>You need to have a horse, wolf, or naga half to wear this.</span>"
 			return 0
@@ -167,21 +167,21 @@
 			icon_state = "security-horse"
 			pixel_x = -16
 			update_icon()
-			return 1
+			return ..()
 		else if(istype(H) && istype(H.tail_style, /datum/sprite_accessory/tail/taur/wolf))
 			icon = 'icons/mob/taursuits_vr.dmi'
 			icon_override = 'icons/mob/taursuits_vr.dmi'
 			icon_state = "security-wolf"
 			pixel_x = -16
 			update_icon()
-			return 1
+			return ..()
 		else if(istype(H) && istype(H.tail_style, /datum/sprite_accessory/tail/taur/naga))
 			icon = 'icons/mob/taursuits_vr.dmi'
 			icon_override = 'icons/mob/taursuits_vr.dmi'
 			icon_state = "security-naga"
 			pixel_x = -16
 			update_icon()
-			return 1
+			return ..()
 		else
 			H << "<span class='warning'>You need to have a horse, wolf, or naga half to wear this.</span>"
 			return 0
@@ -197,21 +197,21 @@
 			icon_state = "atmos-horse"
 			pixel_x = -16
 			update_icon()
-			return 1
+			return ..()
 		else if(istype(H) && istype(H.tail_style, /datum/sprite_accessory/tail/taur/wolf))
 			icon = 'icons/mob/taursuits_vr.dmi'
 			icon_override = 'icons/mob/taursuits_vr.dmi'
 			icon_state = "atmos-wolf"
 			pixel_x = -16
 			update_icon()
-			return 1
+			return ..()
 		else if(istype(H) && istype(H.tail_style, /datum/sprite_accessory/tail/taur/naga))
 			icon = 'icons/mob/taursuits_vr.dmi'
 			icon_override = 'icons/mob/taursuits_vr.dmi'
 			icon_state = "atmos-naga"
 			pixel_x = -16
 			update_icon()
-			return 1
+			return ..()
 		else
 			H << "<span class='warning'>You need to have a horse, wolf, or naga half to wear this.</span>"
 			return 0
@@ -227,21 +227,21 @@
 			icon_state = "mining-horse"
 			pixel_x = -16
 			update_icon()
-			return 1
+			return ..()
 		else if(istype(H) && istype(H.tail_style, /datum/sprite_accessory/tail/taur/wolf))
 			icon = 'icons/mob/taursuits_vr.dmi'
 			icon_override = 'icons/mob/taursuits_vr.dmi'
 			icon_state = "mining-wolf"
 			pixel_x = -16
 			update_icon()
-			return 1
+			return ..()
 		else if(istype(H) && istype(H.tail_style, /datum/sprite_accessory/tail/taur/naga))
 			icon = 'icons/mob/taursuits_vr.dmi'
 			icon_override = 'icons/mob/taursuits_vr.dmi'
 			icon_state = "mining-naga"
 			pixel_x = -16
 			update_icon()
-			return 1
+			return ..()
 		else
 			H << "<span class='warning'>You need to have a horse, wolf, or naga half to wear this.</span>"
 			return 0
@@ -258,21 +258,21 @@
 			icon_state = "syndie-horse"
 			pixel_x = -16
 			update_icon()
-			return 1
+			return ..()
 		else if(istype(H) && istype(H.tail_style, /datum/sprite_accessory/tail/taur/wolf))
 			icon = 'icons/mob/taursuits_vr.dmi'
 			icon_override = 'icons/mob/taursuits_vr.dmi'
 			icon_state = "syndie-wolf"
 			pixel_x = -16
 			update_icon()
-			return 1
+			return ..()
 		else if(istype(H) && istype(H.tail_style, /datum/sprite_accessory/tail/taur/naga))
 			icon = 'icons/mob/taursuits_vr.dmi'
 			icon_override = 'icons/mob/taursuits_vr.dmi'
 			icon_state = "syndie-naga"
 			pixel_x = -16
 			update_icon()
-			return 1
+			return ..()
 		else
 			H << "<span class='warning'>You need to have a horse, wolf, or naga half to wear this.</span>"
 			return 0

--- a/code/modules/clothing/suits/armor_vr.dm
+++ b/code/modules/clothing/suits/armor_vr.dm
@@ -24,7 +24,7 @@
 			icon_override = 'icons/mob/taursuits_vr.dmi' //Just in case
 			icon_state = "heavy_wolf_armor" //Just in case
 			pixel_x = -16
-			return 1
+			return ..()
 		else
 			H << "<span class='warning'>You need to have a wolf-taur half to wear this.</span>"
 			return 0

--- a/code/modules/vore/fluffstuff/custom_items_vr.dm
+++ b/code/modules/vore/fluffstuff/custom_items_vr.dm
@@ -370,6 +370,19 @@ obj/item/weapon/material/hatchet/tacknife/combatknife/fluff/katarina/handle_shie
 	icon_override = 'icons/vore/custom_clothes_vr.dmi'
 	item_state = "serdyhelm_mob"
 
+//SilencedMP5A5:Serdykov Antoz
+/obj/item/device/modkit_conversion/fluff/serdykit
+	name = "Serdykov's hardsuit modification kit"
+	desc = "A kit containing all the needed tools and parts to modify a armor vest and helmet for a specific user. This one looks like it's fitted for a wolf-taur."
+
+	icon = 'icons/vore/custom_items_vr.dmi'
+	icon_state = "modkit"
+
+	from_helmet = /obj/item/clothing/head/helmet
+	from_suit = /obj/item/clothing/suit/armor/vest
+	to_helmet = /obj/item/clothing/head/helmet/serdy
+	to_suit = /obj/item/clothing/suit/armor/vest/wolftaur/serdy
+
 //arokha:Aronai Kadigan, but anyone is welcome to use it.
 /obj/item/clothing/accessory/collar/khcrystal
 	name = "life crystal"

--- a/code/modules/vore/fluffstuff/custom_items_vr.dm
+++ b/code/modules/vore/fluffstuff/custom_items_vr.dm
@@ -345,7 +345,7 @@ obj/item/weapon/material/hatchet/tacknife/combatknife/fluff/katarina/handle_shie
 	desc = "A medal awarded to Lucina Darkarim for excellence in medical service."
 
 //SilencedMP5A5:Serdykov Antoz
-/obj/item/clothing/suit/armor/vest/wolftaur/serdy //SilencedMP5A5's specialty armor suit. Uncomment if/when they make their custom item app and are accepted.
+/obj/item/clothing/suit/armor/vest/wolftaur/serdy //SilencedMP5A5's specialty armor suit.
 	name = "Modified wolf-taur armor vest"
 	desc = "An armored vest that protects against some damage. It appears to be created for a wolf-taur, and seems modified."
 	species_restricted = null //Species restricted since all it cares about is a taur half
@@ -356,7 +356,7 @@ obj/item/weapon/material/hatchet/tacknife/combatknife/fluff/katarina/handle_shie
 			icon_override = 'icons/mob/taursuits_vr.dmi' //Just in case
 			icon_state = "serdy_armor" //Just in case
 			pixel_x = -16
-			return 1
+			..()
 		else
 			H << "<span class='warning'>You need to have a wolf-taur half to wear this.</span>"
 			return 0
@@ -372,14 +372,14 @@ obj/item/weapon/material/hatchet/tacknife/combatknife/fluff/katarina/handle_shie
 
 //SilencedMP5A5:Serdykov Antoz
 /obj/item/device/modkit_conversion/fluff/serdykit
-	name = "Serdykov's hardsuit modification kit"
+	name = "Serdykov's armor modification kit"
 	desc = "A kit containing all the needed tools and parts to modify a armor vest and helmet for a specific user. This one looks like it's fitted for a wolf-taur."
 
 	icon = 'icons/vore/custom_items_vr.dmi'
 	icon_state = "modkit"
 
 	from_helmet = /obj/item/clothing/head/helmet
-	from_suit = /obj/item/clothing/suit/armor/vest
+	from_suit = /obj/item/clothing/suit/armor/vest/wolftaur
 	to_helmet = /obj/item/clothing/head/helmet/serdy
 	to_suit = /obj/item/clothing/suit/armor/vest/wolftaur/serdy
 

--- a/code/modules/vore/fluffstuff/custom_items_vr.dm
+++ b/code/modules/vore/fluffstuff/custom_items_vr.dm
@@ -356,7 +356,7 @@ obj/item/weapon/material/hatchet/tacknife/combatknife/fluff/katarina/handle_shie
 			icon_override = 'icons/mob/taursuits_vr.dmi' //Just in case
 			icon_state = "serdy_armor" //Just in case
 			pixel_x = -16
-			..()
+			return ..()
 		else
 			H << "<span class='warning'>You need to have a wolf-taur half to wear this.</span>"
 			return 0

--- a/code/modules/vore/fluffstuff/custom_items_vr.dm
+++ b/code/modules/vore/fluffstuff/custom_items_vr.dm
@@ -345,7 +345,6 @@ obj/item/weapon/material/hatchet/tacknife/combatknife/fluff/katarina/handle_shie
 	desc = "A medal awarded to Lucina Darkarim for excellence in medical service."
 
 //SilencedMP5A5:Serdykov Antoz
-/*
 /obj/item/clothing/suit/armor/vest/wolftaur/serdy //SilencedMP5A5's specialty armor suit. Uncomment if/when they make their custom item app and are accepted.
 	name = "Modified wolf-taur armor vest"
 	desc = "An armored vest that protects against some damage. It appears to be created for a wolf-taur, and seems modified."
@@ -370,7 +369,6 @@ obj/item/weapon/material/hatchet/tacknife/combatknife/fluff/katarina/handle_shie
 
 	icon_override = 'icons/vore/custom_clothes_vr.dmi'
 	item_state = "serdyhelm_mob"
-*/
 
 //arokha:Aronai Kadigan, but anyone is welcome to use it.
 /obj/item/clothing/accessory/collar/khcrystal


### PR DESCRIPTION
Enables SilencedMP5A5's helmet and taur armor codewise, allowing it to be spawned in/added to the whitlist, as it was approved
here http://forum.vore-station.net/viewtopic.php?f=26&t=805
and herehttp://forum.vore-station.net/viewtopic.php?f=26&t=806
Item paths:
/obj/item/clothing/suit/armor/vest/wolftaur/serdy (This is the armor)
/obj/item/clothing/head/helmet/serdy (This is the helmet)

Additional:
- Fixes taursuits, makes them do return ..()