### PR TITLE
fixes mob_can_equip call in fluff items

### DIFF
--- a/code/modules/vore/fluffstuff/custom_clothes_vr.dm
+++ b/code/modules/vore/fluffstuff/custom_clothes_vr.dm
@@ -436,12 +436,11 @@
 	species_restricted = null
 
 	mob_can_equip(var/mob/living/carbon/human/H, slot, disable_warning = 0)
-		..()
 		if(H.ckey != "scree")
 			H << "<span class='warning'>Your face and whoever is meant for this helmet are too different.</span>"
 			return 0
 		else
-			return 1
+			return ..()
 
 //scree:Scree
 /obj/item/clothing/suit/space/void/engineering/fluff/screespess
@@ -457,12 +456,11 @@
 	species_restricted = null
 
 	mob_can_equip(var/mob/living/carbon/human/H, slot, disable_warning = 0)
-		..()
 		if(H.ckey != "scree")
 			H << "<span class='warning'>The gloves only have three fingers, not to mention the accommodation for extra limbs.</span>"
 			return 0
 		else
-			return 1
+			return ..()
 
 //scree:Scree
 /obj/item/clothing/under/fluff/screesuit
@@ -476,12 +474,11 @@
 	item_state = "screesuit"
 
 	mob_can_equip(var/mob/living/carbon/human/H, slot, disable_warning = 0)
-		..()
 		if(H.ckey != "scree")
 			H << "<span class='warning'>Are you just going to tape them on or what? This isn't gonna work.</span>"
 			return 0
 		else
-			return 1
+			return ..()
 
 //HOS Hardsuit
 /obj/item/clothing/suit/space/void/security/fluff/hos // ToDo: Rig version.
@@ -615,12 +612,11 @@
 	camera_networks = list(NETWORK_MEDICAL)
 
 	mob_can_equip(var/mob/living/carbon/human/H, slot, disable_warning = 0)
-		..()
 		if(H.ckey != "arokha")
 			H << "<span class='warning'>You try to wear the helmet, but it doesn't fit.</span>"
 			return 0
 		else
-			return 1
+			return ..()
 
 /obj/item/clothing/suit/space/void/medical/emt/fluff/aronai
 	name = "KIN-313-SMb medical space helmet"
@@ -638,12 +634,11 @@
 	allowed = list(/obj/item/device/suit_cooling_unit) //Can't fit O2 tanks
 
 	mob_can_equip(var/mob/living/carbon/human/H, slot, disable_warning = 0)
-		..()
 		if(H.ckey != "arokha")
 			H << "<span class='warning'>You try to fit into the suit, to no avail.</span>"
 			return 0
 		else
-			return 1
+			return ..()
 
 //Viveret:Keturah
 /obj/item/clothing/under/dress/maid
@@ -666,12 +661,11 @@
 	light_overlay = "helmet_light"
 
 	mob_can_equip(var/mob/living/carbon/human/H, slot, disable_warning = 0)
-		..()
 		if(H.ckey != "joanrisu")
 			H << "<span class='warning'>You try to fit on the helmet, but it doesn't fit.</span>"
 			return 0
 		else
-			return 1
+			return ..()
 
 
 //JoanRisu:Joan Risu
@@ -695,12 +689,11 @@
 	item_state = "joansuit_mob"
 
 	mob_can_equip(var/mob/living/carbon/human/H, slot, disable_warning = 0)
-		..()
 		if(H.ckey != "joanrisu")
 			H << "<span class='warning'>You try to fit into the suit, to no avail.</span>"
 			return 0
 		else
-			return 1
+			return ..()
 
 
 /obj/item/clothing/under/rank/internalaffairs/fluff/joan


### PR DESCRIPTION
Fixes the callback in the mob_can_equip call in Scree's feathers, and Scree's, Joan's and Aronai's voidsuits.

Have only been able to completely test mine for obvious reasons, but they work as expected.
Assigning Joan and Aro to do their own testing on their own keys and make sure I've not broken their stuff.

Fixes #711.