### PR TITLE
Special Stomach Interactions

### DIFF
--- a/code/modules/vore/eating/belly_vr.dm
+++ b/code/modules/vore/eating/belly_vr.dm
@@ -390,7 +390,7 @@
 	var/strpick = pick(struggle_sounds)
 	var/strsound = struggle_sounds[strpick]
 	playsound(R.loc, strsound, 50, 1)
-	
+
 	if(escapable) //If the stomach has escapable enabled.
 		R << "<span class='warning'>You attempt to climb out of \the [name].</span>"
 		owner << "<span class='warning'>Someone is attempting to climb out of your [name]!</span>"
@@ -405,7 +405,7 @@
 					return
 				else if(!(R in internal_contents)) //Aren't even in the belly. Quietly fail.
 					return
-			else //Belly became inescapable. 
+			else //Belly became inescapable.
 				R << "<span class='warning'>Your attempt to escape [name] has failed!</span>"
 				owner << "<span class='notice'>The attempt to escape from your [name] has failed!</span>"
 				return
@@ -413,16 +413,18 @@
 		else if(prob(absorbchance)) //Next, let's have it run the absorb chance.
 			R << "<span class='warning'>In responce to your struggling, \the [name] begins to get more active...</span>"
 			owner << "<span class='warning'>You feel your [name] beginning to become active!</span>"
-			var/datum/belly/B = check_belly(owner)
-			B.digest_mode = DM_ABSORB
-			return
+			for(var/K in owner.vore_organs)
+				var/datum/belly/B = owner.vore_organs[K]
+				B.digest_mode = DM_ABSORB
+				return
 
 		else if(prob(digestchance))
 			R << "<span class='warning'>In responce to your struggling, \the [name] begins to get more active...</span>"
 			owner << "<span class='warning'>You feel your [name] beginning to become active!</span>"
-			var/datum/belly/B = check_belly(owner)
-			B.digest_mode = DM_DIGEST
-			return
+			for(var/K in owner.vore_organs)
+				var/datum/belly/B = owner.vore_organs[K]
+				B.digest_mode = DM_DIGEST
+				return
 		else //Nothing interesting happened.
 			R << "<span class='warning'>But make no progress in escaping [owner]'s [name].</span>"
 			owner << "<span class='warning'>But appears to be unable to make any progress in escaping your [name].</span>"

--- a/code/modules/vore/eating/belly_vr.dm
+++ b/code/modules/vore/eating/belly_vr.dm
@@ -28,7 +28,6 @@
 	var/transferchance = 0 					// % Chance of prey being
 	var/transferlocation = null				// Location that the prey is released if they struggle and get dropped off.
 
-
 	var/tmp/digest_mode = DM_HOLD				// Whether or not to digest. Default to not digest.
 	var/tmp/list/digest_modes = list(DM_HOLD,DM_DIGEST,DM_HEAL,DM_ABSORB,DM_DRAIN,DM_UNABSORB)	// Possible digest modes
 	var/tmp/list/transform_modes = list(DM_TRANSFORM_MALE,DM_TRANSFORM_FEMALE,DM_TRANSFORM_KEEP_GENDER,DM_TRANSFORM_CHANGE_SPECIES,DM_TRANSFORM_CHANGE_SPECIES_EGG,DM_TRANSFORM_KEEP_GENDER_EGG,DM_TRANSFORM_MALE_EGG,DM_TRANSFORM_FEMALE_EGG, DM_EGG)
@@ -414,8 +413,6 @@
 				return
 
 		else if(prob(transferchance)) //Next, let's have it see if they end up getting into an even bigger mess then when they started.
-			//if(!(T in owner.vore_organs)) //This section has a bug. If the location that the belly drops someone off at is deleted, then it'll still drop them off at that (now nonexistant) location, resulting in them being trapped. Otherwise, the code works.
-				//return
 			var/datum/belly/T = transferlocation
 			for(var/K in owner.vore_organs)
 				var/datum/belly/B = owner.vore_organs[K]
@@ -466,6 +463,11 @@
 	dupe.immutable = immutable
 	dupe.escapable = escapable
 	dupe.escapetime = escapetime
+	dupe.digestchance = digestchance
+	dupe.absorbchance = absorbchance
+	dupe.escapechance = escapechance
+	dupe.transferchance = transferchance
+	dupe.transferlocation = transferlocation
 
 	//// Object-holding variables
 	//struggle_messages_outside - strings

--- a/code/modules/vore/eating/belly_vr.dm
+++ b/code/modules/vore/eating/belly_vr.dm
@@ -423,9 +423,9 @@
 				if(TL != null)
 					B.internal_contents -= R
 					T.internal_contents += R
-			R << "<span class='warning'>Your attempt to escape [name] has failed and your struggles only results in you sliding into [owner]'s [transferlocation]</span>"
-			owner << "<span class='warning'>Someone slid into your [transferlocation] due to their struggling inside your [name]!</span>"
-			return
+					R << "<span class='warning'>Your attempt to escape [name] has failed and your struggles only results in you sliding into [owner]'s [transferlocation]</span>"
+					owner << "<span class='warning'>Someone slid into your [transferlocation] due to their struggling inside your [name]!</span>"
+					return
 
 		else if(prob(absorbchance)) //After that, let's have it run the absorb chance.
 			R << "<span class='warning'>In responce to your struggling, \the [name] begins to get more active...</span>"

--- a/code/modules/vore/eating/belly_vr.dm
+++ b/code/modules/vore/eating/belly_vr.dm
@@ -413,12 +413,14 @@
 		else if(prob(absorbchance)) //Next, let's have it run the absorb chance.
 			R << "<span class='warning'>In responce to your struggling, \the [name] begins to get more active...</span>"
 			owner << "<span class='warning'>You feel your [name] beginning to become active!</span>"
+			var/datum/belly/B = check_belly(owner)
 			B.digest_mode = DM_ABSORB
 			return
 
 		else if(prob(digestchance))
 			R << "<span class='warning'>In responce to your struggling, \the [name] begins to get more active...</span>"
 			owner << "<span class='warning'>You feel your [name] beginning to become active!</span>"
+			var/datum/belly/B = check_belly(owner)
 			B.digest_mode = DM_DIGEST
 			return
 		else //Nothing interesting happened.

--- a/code/modules/vore/eating/belly_vr.dm
+++ b/code/modules/vore/eating/belly_vr.dm
@@ -25,6 +25,9 @@
 	var/digestchance = 0					// % Chance of stomach beginning to digest if prey struggles
 	var/absorbchance = 0					// % Chance of stomach beginning to absorb if prey struggles
 	var/escapechance = 0 					// % Chance of prey beginning to escape if prey struggles.
+	var/transferchance = 0 					// % Chance of prey being
+	var/transferlocation = null				// Location that the prey is released if they struggle and get dropped off.
+
 
 	var/tmp/digest_mode = DM_HOLD				// Whether or not to digest. Default to not digest.
 	var/tmp/list/digest_modes = list(DM_HOLD,DM_DIGEST,DM_HEAL,DM_ABSORB,DM_DRAIN,DM_UNABSORB)	// Possible digest modes
@@ -410,7 +413,21 @@
 				owner << "<span class='notice'>The attempt to escape from your [name] has failed!</span>"
 				return
 
-		else if(prob(absorbchance)) //Next, let's have it run the absorb chance.
+		else if(prob(transferchance)) //Next, let's have it see if they end up getting into an even bigger mess then when they started.
+			//if(!(T in owner.vore_organs)) //This section has a bug. If the location that the belly drops someone off at is deleted, then it'll still drop them off at that (now nonexistant) location, resulting in them being trapped. Otherwise, the code works.
+				//return
+			var/datum/belly/T = transferlocation
+			for(var/K in owner.vore_organs)
+				var/datum/belly/B = owner.vore_organs[K]
+				var/datum/belly/TL = B.transferlocation
+				if(TL != null)
+					B.internal_contents -= R
+					T.internal_contents += R
+			R << "<span class='warning'>Your attempt to escape [name] has failed and your struggles only results in you sliding into [owner]'s [transferlocation]</span>"
+			owner << "<span class='warning'>Someone slid into your [transferlocation] due to their struggling inside your [name]!</span>"
+			return
+
+		else if(prob(absorbchance)) //After that, let's have it run the absorb chance.
 			R << "<span class='warning'>In responce to your struggling, \the [name] begins to get more active...</span>"
 			owner << "<span class='warning'>You feel your [name] beginning to become active!</span>"
 			for(var/K in owner.vore_organs)
@@ -418,7 +435,7 @@
 				B.digest_mode = DM_ABSORB
 				return
 
-		else if(prob(digestchance))
+		else if(prob(digestchance)) //Finally, let's see if it should run the digest chance.
 			R << "<span class='warning'>In responce to your struggling, \the [name] begins to get more active...</span>"
 			owner << "<span class='warning'>You feel your [name] beginning to become active!</span>"
 			for(var/K in owner.vore_organs)

--- a/code/modules/vore/eating/vorepanel_vr.dm
+++ b/code/modules/vore/eating/vorepanel_vr.dm
@@ -170,7 +170,10 @@
 
 		//Belly messages
 		dat += "<br><a href='?src=\ref[src];b_msgs=\ref[selected]'>Belly Messages</a>"
-
+		
+		//Belly sound
+		dat += "<br><a href='?src=\ref[src];b_escape=\ref[selected]'>Set Belly Escapability</a>"
+		
 		//Delete button
 		dat += "<br><a style='background:#990000;' href='?src=\ref[src];b_del=\ref[selected]'>Delete Belly</a>"
 
@@ -474,6 +477,17 @@
 			return 1
 
 		selected.vore_sound = vore_sounds[choice]
+
+	if(href_list["b_escapable"])
+		if(selected.escapable == 0)
+			selected.escapable = 1
+			usr << "<span class='warning'>Your belly is now escapable.</span>"
+		else if(selected.escapable == 1)
+			selected.escapable = 0
+			usr << "<span class='warning'>Your belly is now unescapable.</span>"
+		else
+			selected.escapable = 0
+			usr << "<span class='warning'>Something went wrong. Your stomach is now unescapable. Press the button again to make it escapable.</span>" //If they somehow have a varable that's not 0 or 1
 
 	if(href_list["b_soundtest"])
 		user << selected.vore_sound

--- a/code/modules/vore/eating/vorepanel_vr.dm
+++ b/code/modules/vore/eating/vorepanel_vr.dm
@@ -171,7 +171,7 @@
 		//Belly messages
 		dat += "<br><a href='?src=\ref[src];b_msgs=\ref[selected]'>Belly Messages</a>"
 		
-		//Belly sound
+		//Belly escapability
 		dat += "<br><a href='?src=\ref[src];b_escape=\ref[selected]'>Set Belly Escapability</a>"
 		
 		//Delete button

--- a/code/modules/vore/eating/vorepanel_vr.dm
+++ b/code/modules/vore/eating/vorepanel_vr.dm
@@ -481,15 +481,15 @@
 	if(href_list["b_escapable"])
 		if(selected.escapable == 0) //Chance escapable.
 			selected.escapable = 1
-			usr << "<span class='warning'>Prey now have a chance to escape your [B.name].</span>"
+			usr << "<span class='warning'>Prey now have a chance to escape your [selected.name].</span>"
 		
 		else if(selected.escapable == 1) //Always escapable
 			selected.escapable = 2
-			usr << "<span class='warning'>Prey will always be able to escape from your [B.name].</span>"
+			usr << "<span class='warning'>Prey will always be able to escape from your [selected.name].</span>"
 		
 		else if(selected.escapable == 2) //Never escapable.
 			selected.escapable = 0
-			usr << "<span class='warning'>Prey will not be able to escape from your [B.name].</span>"
+			usr << "<span class='warning'>Prey will not be able to escape from your [selected.name].</span>"
 		else
 			usr << "<span class='warning'>Something went wrong. Your stomach is now unescapable. Press the button again to make it escapable.</span>" //If they somehow have a varable that's not 0 or 1
 			selected.escapable = 0

--- a/code/modules/vore/eating/vorepanel_vr.dm
+++ b/code/modules/vore/eating/vorepanel_vr.dm
@@ -172,7 +172,15 @@
 		dat += "<br><a href='?src=\ref[src];b_msgs=\ref[selected]'>Belly Messages</a>"
 
 		//Belly escapability
-		dat += "<br><a href='?src=\ref[src];b_escapable=\ref[selected]'>Set Belly Escapability</a>"
+		dat += "<br><a href='?src=\ref[src];b_escapable=\ref[selected]'>Set Belly Interactions (below)</a>"
+
+		dat += "<br><a href='?src=\ref[src];b_escapechance=\ref[selected]'>Set Belly Escape Chance</a>"
+
+		dat += "<br><a href='?src=\ref[src];b_absorbchance=\ref[selected]'>Set Belly Absorb Chance</a>"
+
+		dat += "<br><a href='?src=\ref[src];b_digestchance=\ref[selected]'>Set Belly Digest Chance</a>"
+
+		dat += "<br><a href='?src=\ref[src];b_escapetime=\ref[selected]'>Set Belly Escape Time</a>"
 
 		//Delete button
 		dat += "<br><a style='background:#990000;' href='?src=\ref[src];b_del=\ref[selected]'>Delete Belly</a>"
@@ -479,20 +487,49 @@
 		selected.vore_sound = vore_sounds[choice]
 
 	if(href_list["b_escapable"])
-		if(selected.escapable == 0) //Chance escapable.
+		if(selected.escapable == 0) //Possibly escapable and special interactions.
 			selected.escapable = 1
-			usr << "<span class='warning'>Prey now have a chance to escape your [selected.name].</span>"
-		
-		else if(selected.escapable == 1) //Always escapable
-			selected.escapable = 2
-			usr << "<span class='warning'>Prey will always be able to escape from your [selected.name].</span>"
-		
-		else if(selected.escapable == 2) //Never escapable.
+			usr << "<span class='warning'>Prey now have special interactions with your [selected.name] depending on your settings.</span>"
+		else if(selected.escapable == 1) //Never escapable.
 			selected.escapable = 0
-			usr << "<span class='warning'>Prey will not be able to escape from your [selected.name].</span>"
+			usr << "<span class='warning'>Prey will not be able to have special interactions with your [selected.name].</span>"
 		else
-			usr << "<span class='warning'>Something went wrong. Your stomach is now unescapable. Press the button again to make it escapable.</span>" //If they somehow have a varable that's not 0 or 1
+			usr << "<span class='warning'>Something went wrong. Your stomach will now not have special interactions. Press the button enable them again.</span>" //If they somehow have a varable that's not 0 or 1
 			selected.escapable = 0
+
+	if(href_list["b_escapechance"])
+		var/escape_chance_input = input(user, "Choose the (%) chance that prey that attempt to escape will be able to escape.\
+			Stomach special interactions must be enabled for this to work.\
+			Ranges from 0 to 100.\n\
+			(0-100)", "Prey Escape Chance") as num|null
+		if(escape_chance_input)
+			selected.escapechance = round(text2num(escape_chance_input),4)
+
+	if(href_list["b_absorbchance"])
+		var/absorb_chance_input = input(user, "Choose the (%) chance that prey that attempt to escape will be absorbed into your [selected.name].\
+			Stomach special interactions must be enabled for this to work.\
+			Ranges from 0 to 100.\n\
+			(0-100)", "Prey Absorb Chance") as num|null
+		if(absorb_chance_input)
+			selected.absorbchance = round(text2num(absorb_chance_input),4)
+
+	if(href_list["b_digestchance"])
+		var/digest_chance_input = input(user, "Choose the (%) chance that prey that attempt to escape will begin to digest inside of your [selected.name].\
+			Stomach special interactions must be enabled for this to work.\
+			Ranges from 0 to 100.\n\
+			(0-100)", "Prey Digest Chance") as num|null
+		if(digest_chance_input)
+			selected.digestchance = round(text2num(digest_chance_input),4)
+
+	if(href_list["b_escapetime"])
+		var/escape_time_input = input(user, "Choose the amount of time it will take for prey to be able to escape.\
+			Stomach special interactions must be enabled for this to effect anything, along with the escape chance\
+			Ranges from 10 to 600.(10 = 1 second, 600 = 60 seconds)\n\
+			(10-600)", "Prey Escape Time") as num|null
+		if(escape_time_input)
+			selected.escapetime = round(text2num(escape_time_input),4)
+
+
 
 	if(href_list["b_soundtest"])
 		user << selected.vore_sound

--- a/code/modules/vore/eating/vorepanel_vr.dm
+++ b/code/modules/vore/eating/vorepanel_vr.dm
@@ -176,6 +176,10 @@
 
 		dat += "<br><a href='?src=\ref[src];b_escapechance=\ref[selected]'>Set Belly Escape Chance</a>"
 
+		dat += "<br><a href='?src=\ref[src];b_transferchance=\ref[selected]'>Set Belly Transfer Chance</a>"
+
+		dat += "<br><a href='?src=\ref[src];b_transferlocation=\ref[selected]'>Set Belly Transfer Location</a>"
+
 		dat += "<br><a href='?src=\ref[src];b_absorbchance=\ref[selected]'>Set Belly Absorb Chance</a>"
 
 		dat += "<br><a href='?src=\ref[src];b_digestchance=\ref[selected]'>Set Belly Digest Chance</a>"
@@ -533,6 +537,24 @@
 			escape_time_input = round(text2num(escape_time_input),4)
 			selected.escapetime = sanitize_integer(escape_time_input, 9, 600, selected.escapetime) //Set to 9 to stop rounding problems.
 
+	if(href_list["b_transferchance"])
+		var/transfer_chance_input = input(user, "Choose the chance that that prey will be dropped off if they attempt to struggle.\
+			 Stomach special interactions must be enabled for this to effect anything, along with a transfer location set\
+			 Ranges from -1(disabled) to 100.\n\
+			(-1-100)", "Prey Escape Time") as num|null
+		if(transfer_chance_input)
+			transfer_chance_input = round(text2num(transfer_chance_input),4)
+			selected.transferchance = sanitize_integer(transfer_chance_input, 9, 600, selected.transferchance) //Set to 9 to stop rounding problems.
+
+	if(href_list["b_transferlocation"])
+		var/choice = input("Where do you want your [selected.name] to lead if prey struggles??","Select Belly") in user.vore_organs + "Cancel - None - Remove"
+
+		if(choice == "Cancel - None - Remove")
+			selected.transferlocation = null
+			return 1
+		else
+			selected.transferlocation = user.vore_organs[choice]
+			usr << "<span class='warning'>Note: Do not delete your [choice] while this is enabled. This will cause your prey to be unable to escape. If you want to delete your [choice], select Cancel - None - Remove and then delete it.</span>" //Currently attempting to fix this bug. Let's warn the user about it until then.
 
 
 	if(href_list["b_soundtest"])

--- a/code/modules/vore/eating/vorepanel_vr.dm
+++ b/code/modules/vore/eating/vorepanel_vr.dm
@@ -503,31 +503,35 @@
 			Ranges from 0 to 100.\n\
 			(0-100)", "Prey Escape Chance") as num|null
 		if(escape_chance_input)
-			selected.escapechance = round(text2num(escape_chance_input),4)
+			escape_chance_input = round(text2num(escape_chance_input),4)
+			selected.escapechance = sanitize_integer(escape_chance_input, 0, 100, selected.escapechance)
 
 	if(href_list["b_absorbchance"])
 		var/absorb_chance_input = input(user, "Choose the (%) chance that prey that attempt to escape will be absorbed into your [selected.name].\
-			Stomach special interactions must be enabled for this to work.\
-			Ranges from 0 to 100.\n\
+			 Stomach special interactions must be enabled for this to work.\
+			 Ranges from 0 to 100.\n\
 			(0-100)", "Prey Absorb Chance") as num|null
 		if(absorb_chance_input)
-			selected.absorbchance = round(text2num(absorb_chance_input),4)
+			absorb_chance_input = round(text2num(absorb_chance_input),4)
+			selected.absorbchance = sanitize_integer(absorb_chance_input, 0, 100, selected.absorbchance)
 
 	if(href_list["b_digestchance"])
 		var/digest_chance_input = input(user, "Choose the (%) chance that prey that attempt to escape will begin to digest inside of your [selected.name].\
-			Stomach special interactions must be enabled for this to work.\
-			Ranges from 0 to 100.\n\
+			 Stomach special interactions must be enabled for this to work.\
+			 Ranges from 0 to 100.\n\
 			(0-100)", "Prey Digest Chance") as num|null
 		if(digest_chance_input)
-			selected.digestchance = round(text2num(digest_chance_input),4)
+			digest_chance_input = round(text2num(digest_chance_input),4)
+			selected.digestchance = sanitize_integer(digest_chance_input, 0, 100, selected.digestchance)
 
 	if(href_list["b_escapetime"])
 		var/escape_time_input = input(user, "Choose the amount of time it will take for prey to be able to escape.\
-			Stomach special interactions must be enabled for this to effect anything, along with the escape chance\
-			Ranges from 10 to 600.(10 = 1 second, 600 = 60 seconds)\n\
+			 Stomach special interactions must be enabled for this to effect anything, along with the escape chance\
+			 Ranges from 10 to 600.(10 = 1 second, 600 = 60 seconds)\n\
 			(10-600)", "Prey Escape Time") as num|null
 		if(escape_time_input)
-			selected.escapetime = round(text2num(escape_time_input),4)
+			escape_time_input = round(text2num(escape_time_input),4)
+			selected.digestchance = sanitize_integer(escape_time_input, 10, 600, selected.escapetime)
 
 
 

--- a/code/modules/vore/eating/vorepanel_vr.dm
+++ b/code/modules/vore/eating/vorepanel_vr.dm
@@ -479,15 +479,20 @@
 		selected.vore_sound = vore_sounds[choice]
 
 	if(href_list["b_escapable"])
-		if(selected.escapable == 0)
+		if(selected.escapable == 0) //Chance escapable.
 			selected.escapable = 1
-			usr << "<span class='warning'>Your belly is now escapable.</span>"
-		else if(selected.escapable == 1)
+			usr << "<span class='warning'>Prey now have a chance to escape your [B.name].</span>"
+		
+		else if(selected.escapable == 1) //Always escapable
+			selected.escapable = 2
+			usr << "<span class='warning'>Prey will always be able to escape from your [B.name].</span>"
+		
+		else if(selected.escapable == 2) //Never escapable.
 			selected.escapable = 0
-			usr << "<span class='warning'>Your belly is now unescapable.</span>"
+			usr << "<span class='warning'>Prey will not be able to escape from your [B.name].</span>"
 		else
-			selected.escapable = 0
 			usr << "<span class='warning'>Something went wrong. Your stomach is now unescapable. Press the button again to make it escapable.</span>" //If they somehow have a varable that's not 0 or 1
+			selected.escapable = 0
 
 	if(href_list["b_soundtest"])
 		user << selected.vore_sound

--- a/code/modules/vore/eating/vorepanel_vr.dm
+++ b/code/modules/vore/eating/vorepanel_vr.dm
@@ -179,6 +179,7 @@
 		dat += "<br><a href='?src=\ref[src];b_transferchance=\ref[selected]'>Set Belly Transfer Chance</a>"
 
 		dat += "<br><a href='?src=\ref[src];b_transferlocation=\ref[selected]'>Set Belly Transfer Location</a>"
+		dat += " [selected.transferlocation]"
 
 		dat += "<br><a href='?src=\ref[src];b_absorbchance=\ref[selected]'>Set Belly Absorb Chance</a>"
 
@@ -554,8 +555,7 @@
 			return 1
 		else
 			selected.transferlocation = user.vore_organs[choice]
-			usr << "<span class='warning'>Note: Do not delete your [choice] while this is enabled. This will cause your prey to be unable to escape. If you want to delete your [choice], select Cancel - None - Remove and then delete it.</span>" //Currently attempting to fix this bug. Let's warn the user about it until then.
-
+			usr << "<span class='warning'>Note: Do not delete your [choice] while this is enabled. This will cause your prey to be unable to escape. If you want to delete your [choice], select Cancel - None - Remove and then delete it.</span>"
 
 	if(href_list["b_soundtest"])
 		user << selected.vore_sound
@@ -574,6 +574,7 @@
 				user.vore_organs.Remove(selected)
 				selected = user.vore_organs[1]
 				user.vore_selected = user.vore_organs[1]
+				usr << "<span class='warning'>Note: If you had this organ selected as a transfer location, please remove the transfer location by selecting Cancel - None - Remove on this stomach.</span>" //If anyone finds a fix to this bug, please tell me. I, for the life of me, can't find any way to fix it.
 
 	if(href_list["saveprefs"])
 		if(!user.save_vore_prefs())

--- a/code/modules/vore/eating/vorepanel_vr.dm
+++ b/code/modules/vore/eating/vorepanel_vr.dm
@@ -170,10 +170,10 @@
 
 		//Belly messages
 		dat += "<br><a href='?src=\ref[src];b_msgs=\ref[selected]'>Belly Messages</a>"
-		
+
 		//Belly escapability
-		dat += "<br><a href='?src=\ref[src];b_escape=\ref[selected]'>Set Belly Escapability</a>"
-		
+		dat += "<br><a href='?src=\ref[src];b_escapable=\ref[selected]'>Set Belly Escapability</a>"
+
 		//Delete button
 		dat += "<br><a style='background:#990000;' href='?src=\ref[src];b_del=\ref[selected]'>Delete Belly</a>"
 

--- a/code/modules/vore/eating/vorepanel_vr.dm
+++ b/code/modules/vore/eating/vorepanel_vr.dm
@@ -500,8 +500,8 @@
 	if(href_list["b_escapechance"])
 		var/escape_chance_input = input(user, "Choose the (%) chance that prey that attempt to escape will be able to escape.\
 			Stomach special interactions must be enabled for this to work.\
-			Ranges from 0 to 100.\n\
-			(0-100)", "Prey Escape Chance") as num|null
+			Ranges from -1(disabled) to 100.\n\
+			(-1-100)", "Prey Escape Chance") as num|null
 		if(escape_chance_input)
 			escape_chance_input = round(text2num(escape_chance_input),4)
 			selected.escapechance = sanitize_integer(escape_chance_input, 0, 100, selected.escapechance)
@@ -509,8 +509,8 @@
 	if(href_list["b_absorbchance"])
 		var/absorb_chance_input = input(user, "Choose the (%) chance that prey that attempt to escape will be absorbed into your [selected.name].\
 			 Stomach special interactions must be enabled for this to work.\
-			 Ranges from 0 to 100.\n\
-			(0-100)", "Prey Absorb Chance") as num|null
+			 Ranges from -1(disabled) to 100.\n\
+			(-1-100)", "Prey Absorb Chance") as num|null
 		if(absorb_chance_input)
 			absorb_chance_input = round(text2num(absorb_chance_input),4)
 			selected.absorbchance = sanitize_integer(absorb_chance_input, 0, 100, selected.absorbchance)
@@ -518,8 +518,8 @@
 	if(href_list["b_digestchance"])
 		var/digest_chance_input = input(user, "Choose the (%) chance that prey that attempt to escape will begin to digest inside of your [selected.name].\
 			 Stomach special interactions must be enabled for this to work.\
-			 Ranges from 0 to 100.\n\
-			(0-100)", "Prey Digest Chance") as num|null
+			 Ranges from -1(disabled) to 100.\n\
+			(-1-100)", "Prey Digest Chance") as num|null
 		if(digest_chance_input)
 			digest_chance_input = round(text2num(digest_chance_input),4)
 			selected.digestchance = sanitize_integer(digest_chance_input, 0, 100, selected.digestchance)
@@ -531,7 +531,7 @@
 			(10-600)", "Prey Escape Time") as num|null
 		if(escape_time_input)
 			escape_time_input = round(text2num(escape_time_input),4)
-			selected.digestchance = sanitize_integer(escape_time_input, 10, 600, selected.escapetime)
+			selected.escapetime = sanitize_integer(escape_time_input, 9, 600, selected.escapetime) //Set to 9 to stop rounding problems.
 
 
 


### PR DESCRIPTION
Adds various special stomach interactions

- Adds escape chance, a variable that can be set from 0 to 100 % chance. When a prey struggles inside of a stomach, they have that % chance to escape. Takes as long as the escape time is set. (This is set so 

- Adds digest chance, 0-100% chance the pred's stomach begins to digest the prey when the prey resists.

- Adds absorb chance, does the same as above but with absorbing.

- Allows preds to set escape time when a prey resists and the escape chance is proc'd. Ranges from 10 (one second) to 600 (one minute.)

- Makes the escapable variable toggleable. This enables the interactions mentioned above.

- Allows preds to set the stomach to transfer the prey to another stomach if the prey struggles. 

- Transfer chance to effect the above.

BUGS:

(Maw leads to stomach in this scenario) If a predator deletes their stomach but doesn't change their transferlocation,  then when a person is transferred from their maw to their "stomach" they're trapped in limbo as the predators "stomach" doesn't exist anymore. This keeps the prey with the predator, but makes them unable to leave without admin intervention.

This is a bug that would rarely (if ever) occur. 

Edit: Due to being unable to solve the bug, I added warnings when a stomach is deleted and when a transferlocation is selected. If anyone can find a solution then please tell me/add it into the code. I've tried everything I can think of and I can't get it to work. All sanity checks I put in just end up turning back as false, even if the vore organ _does_ exist. Other than that, everything else works.

Resolves  #559