### PR TITLE
Fixes invisible size shrooms

### DIFF
--- a/code/modules/hydroponics/seed_datums_vr.dm
+++ b/code/modules/hydroponics/seed_datums_vr.dm
@@ -16,7 +16,7 @@
 	set_trait(TRAIT_PRODUCTION,6)
 	set_trait(TRAIT_YIELD,3)
 	set_trait(TRAIT_POTENCY,15)
-	set_trait(TRAIT_PRODUCT_ICON,"sizeshroom")
+	set_trait(TRAIT_PRODUCT_ICON,"mushroom3-product")
 	set_trait(TRAIT_PRODUCT_COLOUR,"#DA00DA")
 	set_trait(TRAIT_PLANT_ICON,"tree")
 
@@ -31,4 +31,11 @@
 
 /datum/seed/size/megam/New()
 	..()
+	set_trait(TRAIT_HARVEST_REPEAT,1)
+	set_trait(TRAIT_MATURATION,6)
+	set_trait(TRAIT_PRODUCTION,6)
+	set_trait(TRAIT_YIELD,3)
+	set_trait(TRAIT_POTENCY,15)
+	set_trait(TRAIT_PRODUCT_ICON,"mushroom6-product")
+	set_trait(TRAIT_PLANT_ICON,"tree")
 	set_trait(TRAIT_PRODUCT_COLOUR,"#DADA00")


### PR DESCRIPTION
Exactly what it says on the title.

Since hydroponics has a special way of selecting the icon, this is the simplest fix using the already preexisting mushroom sprites.