### PR TITLE
Macro/micro damage scaling

### DIFF
--- a/code/modules/mob/living/damage_procs.dm
+++ b/code/modules/mob/living/damage_procs.dm
@@ -13,7 +13,7 @@
 		world.log << "## DEBUG: apply_damage() was called on [src], with [damage] damage, and an armor value of [blocked]."
 	if(!damage || (blocked >= 100))
 		return 0
-	blocked = (100-blocked)/100
+	blocked = (100-blocked)/100 * 1/size_multiplier // VOREstation Edit - NW was here - scales damage with recipient's scale
 	switch(damagetype)
 		if(BRUTE)
 			adjustBruteLoss(damage * blocked)


### PR DESCRIPTION
One-line fix to allow damage to scale with the recipient's scale. Micros take 4x damage, small takes 2x damage, normal takes 1x damage, big takes 2/3x damage, macro takes 1/2x damage. This can be changed easily.

DO NOT MERGE. UNTESTED CODE. PROOF OF CONCEPT ONLY.