### PR TITLE
Fixes birds meowing

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/birds_vr.dm
+++ b/code/modules/mob/living/simple_animal/friendly/birds_vr.dm
@@ -167,7 +167,7 @@
 								   "chirps."))
 	else if (friend.health <= 50)
 		if (prob(10))
-			var/verb = pick("meows", "mews", "mrowls")
+			var/verb = pick("chirps", "caws", "squawks")
 			audible_emote("[verb] anxiously.")
 
 /mob/living/simple_animal/cat/bird/fluff/verb/become_friends_b()


### PR DESCRIPTION
Fixes birds from meowing when their friend is hurt.

Looking back at it, I'm not 100% sure why I have them a subclass of cats. I think I might've done it at the time so they'd have the same flee code as cats and also go after micros/mice the same way as cats.