### PR TITLE
Makes mushroom sprites show up correctly when harvested

### DIFF
--- a/code/modules/hydroponics/seed_datums_vr.dm
+++ b/code/modules/hydroponics/seed_datums_vr.dm
@@ -16,7 +16,7 @@
 	set_trait(TRAIT_PRODUCTION,6)
 	set_trait(TRAIT_YIELD,3)
 	set_trait(TRAIT_POTENCY,15)
-	set_trait(TRAIT_PRODUCT_ICON,"mushroom3-product")
+	set_trait(TRAIT_PRODUCT_ICON,"mushroom3")
 	set_trait(TRAIT_PRODUCT_COLOUR,"#DA00DA")
 	set_trait(TRAIT_PLANT_ICON,"tree")
 
@@ -36,6 +36,6 @@
 	set_trait(TRAIT_PRODUCTION,6)
 	set_trait(TRAIT_YIELD,3)
 	set_trait(TRAIT_POTENCY,15)
-	set_trait(TRAIT_PRODUCT_ICON,"mushroom6-product")
+	set_trait(TRAIT_PRODUCT_ICON,"mushroom6")
 	set_trait(TRAIT_PLANT_ICON,"tree")
 	set_trait(TRAIT_PRODUCT_COLOUR,"#DADA00")


### PR DESCRIPTION
Somehow "-product" got included when I fixed this last time, so this correctly fixes the problem of mushrooms being invisible.