### PR TITLE
Prevents accidental stomach flavor text deletion

### DIFF
--- a/code/modules/vore/eating/vorepanel_vr.dm
+++ b/code/modules/vore/eating/vorepanel_vr.dm
@@ -420,6 +420,9 @@
 			usr << "<span class='warning'>Entered belly desc too long. 1024 character limit.</span>"
 			return 0
 
+		if(length(new_desc) < 1) //Prevents current description text from being deleted if they click cancel.
+			return 0
+
 		selected.inside_flavor = new_desc
 
 	if(href_list["b_msgs"])


### PR DESCRIPTION
The "cancel" button when you were changing stomach inside text caused the entire stomach desc text to be deleted. 

This fixes that problem by checking if it's less than 1 (null applies to this) and just not doing anything to the inside text when cancel is clicked