### PR TITLE
More xenochimera tweaks

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -723,6 +723,11 @@
 	return 1
 
 /mob/living/carbon/human/IsAdvancedToolUser(var/silent)
+	// VOREstation start
+	if(feral)
+		src << "<span class='warning'>Your primitive mind can't grasp the concept of that thing.</span>"
+		return 0
+	// VOREstation end
 	if(species.has_fine_manipulation)
 		return 1
 	if(!silent)

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -27,7 +27,7 @@
 
 	//VOREstation start
 	if (feral >= 10) //crazy feral animals give less and less of a shit about pain and hunger as they get crazier
-		tally = max(species.slowdown, tally/(feral/10)) // As feral scales to damage, this amounts to an effective +1 slowdown cap
+		tally = max(species.slowdown, species.slowdown+((tally-species.slowdown)/(feral/10))) // As feral scales to damage, this amounts to an effective +1 slowdown cap
 		if(shock_stage >= 10) tally -= 1.5 //this gets a +3 later, feral critters take reduced penalty
 	//VOREstation end
 

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -25,6 +25,12 @@
 	var/hungry = (500 - nutrition)/5 // So overeat would be 100 and default level would be 80
 	if (hungry >= 70) tally += hungry/50
 
+	//VOREstation start
+	if (feral >= 10) //crazy feral animals give less and less of a shit about pain and hunger as they get crazier
+		tally = max(species.slowdown, tally/(feral/10)) // As feral scales to damage, this amounts to an effective +1 slowdown cap
+		if(shock_stage >= 10) tally -= 1.5 //this gets a +3 later, feral critters take reduced penalty
+	//VOREstation end
+
 	if(istype(buckled, /obj/structure/bed/chair/wheelchair))
 		for(var/organ_name in list(BP_L_HAND, BP_R_HAND, BP_L_ARM, BP_R_ARM))
 			var/obj/item/organ/external/E = get_organ(organ_name)

--- a/code/modules/mob/living/carbon/human/species/station/station_special_abilities_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_special_abilities_vr.dm
@@ -129,27 +129,23 @@
 	fleshcolor = "#14AD8B" //Scree blood.
 	bloodcolor = "#14AD8B"
 
-/mob/living/carbon/human/proc/handle_feral()
-	var/light_amount = 0 //how much light there is in the place
+/mob/living/carbon/human/proc/getlightlevel() //easier than having the same code in like three places
 	if(isturf(src.loc)) //else, there's considered to be no light
 		var/turf/T = src.loc
 		var/atom/movable/lighting_overlay/L = locate(/atom/movable/lighting_overlay) in T
 		if(L)
-			light_amount = 2 * (min(5,L.lum_r + L.lum_g + L.lum_b) - 2.5)
+			return (2 * (min(5,L.lum_r + L.lum_g + L.lum_b) - 2.5))
 		else
-			light_amount =  5
+			return 5
+	else return 0
 
+/mob/living/carbon/human/proc/handle_feral()
 	if(handling_hal) return //avoid conflict with actual hallucinations
 	handling_hal = 1
+	var/light_amount = getlightlevel() //how much light there is in the place
 
-	while(client && feral > 10 && light_amount >= 1.5) // largely a copy of handle_hallucinations() without the fake attackers
-		if(isturf(src.loc)) //update light every time so it breaks out if we go into darkness
-			var/turf/T = src.loc
-			var/atom/movable/lighting_overlay/L = locate(/atom/movable/lighting_overlay) in T
-			if(L)
-				light_amount = 2 * (min(5,L.lum_r + L.lum_g + L.lum_b) - 2.5)
-			else
-				light_amount =  5
+	while(client && feral > 10 && light_amount >= 0.5) // largely a copy of handle_hallucinations() without the fake attackers
+		light_amount = getlightlevel()
 		sleep(rand(200,500)/(feral/10))
 		var/halpick = rand(1,100)
 		switch(halpick)

--- a/code/modules/mob/living/carbon/human/species/station/station_special_abilities_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_special_abilities_vr.dm
@@ -128,3 +128,209 @@
 /obj/effect/gibspawner/human/scree
 	fleshcolor = "#14AD8B" //Scree blood.
 	bloodcolor = "#14AD8B"
+
+/mob/living/carbon/human/proc/handle_feral()
+	var/light_amount = 0 //how much light there is in the place
+	if(isturf(src.loc)) //else, there's considered to be no light
+		var/turf/T = src.loc
+		var/atom/movable/lighting_overlay/L = locate(/atom/movable/lighting_overlay) in T
+		if(L)
+			light_amount = 2 * (min(5,L.lum_r + L.lum_g + L.lum_b) - 2.5)
+		else
+			light_amount =  5
+
+	if(handling_hal) return //avoid conflict with actual hallucinations
+	handling_hal = 1
+
+	while(client && feral > 10 && light_amount >= 1.5) // largely a copy of handle_hallucinations() without the fake attackers
+		if(isturf(src.loc)) //update light every time so it breaks out if we go into darkness
+			var/turf/T = src.loc
+			var/atom/movable/lighting_overlay/L = locate(/atom/movable/lighting_overlay) in T
+			if(L)
+				light_amount = 2 * (min(5,L.lum_r + L.lum_g + L.lum_b) - 2.5)
+			else
+				light_amount =  5
+		sleep(rand(200,500)/(feral/10))
+		var/halpick = rand(1,100)
+		switch(halpick)
+			if(0 to 15) //15% chance
+				//Screwy HUD
+				//src << "Screwy HUD"
+				hal_screwyhud = pick(1,2,3,3,4,4)
+				spawn(rand(100,250))
+					hal_screwyhud = 0
+			if(16 to 25) //10% chance
+				//Strange items
+				//src << "Traitor Items"
+				if(!halitem)
+					halitem = new
+					var/list/slots_free = list(ui_lhand,ui_rhand)
+					if(l_hand) slots_free -= ui_lhand
+					if(r_hand) slots_free -= ui_rhand
+					if(istype(src,/mob/living/carbon/human))
+						var/mob/living/carbon/human/H = src
+						if(!H.belt) slots_free += ui_belt
+						if(!H.l_store) slots_free += ui_storage1
+						if(!H.r_store) slots_free += ui_storage2
+					if(slots_free.len)
+						halitem.screen_loc = pick(slots_free)
+						halitem.layer = 50
+						switch(rand(1,6))
+							if(1) //revolver
+								halitem.icon = 'icons/obj/gun.dmi'
+								halitem.icon_state = "revolver"
+								halitem.name = "Revolver"
+							if(2) //c4
+								halitem.icon = 'icons/obj/assemblies.dmi'
+								halitem.icon_state = "plastic-explosive0"
+								halitem.name = "Mysterious Package"
+								if(prob(25))
+									halitem.icon_state = "c4small_1"
+							if(3) //sword
+								halitem.icon = 'icons/obj/weapons.dmi'
+								halitem.icon_state = "sword1"
+								halitem.name = "Sword"
+							if(4) //stun baton
+								halitem.icon = 'icons/obj/weapons.dmi'
+								halitem.icon_state = "stunbaton"
+								halitem.name = "Stun Baton"
+							if(5) //emag
+								halitem.icon = 'icons/obj/card.dmi'
+								halitem.icon_state = "emag"
+								halitem.name = "Cryptographic Sequencer"
+							if(6) //flashbang
+								halitem.icon = 'icons/obj/grenade.dmi'
+								halitem.icon_state = "flashbang1"
+								halitem.name = "Flashbang"
+						if(client) client.screen += halitem
+						spawn(rand(100,250))
+							if(client)
+								client.screen -= halitem
+							halitem = null
+			if(26 to 35) //10% chance
+				//Flashes of danger
+				//src << "Danger Flash"
+				if(!halimage)
+					var/list/possible_points = list()
+					for(var/turf/simulated/floor/F in view(src,world.view))
+						possible_points += F
+					if(possible_points.len)
+						var/turf/simulated/floor/target = pick(possible_points)
+
+						switch(rand(1,3))
+							if(1)
+								//src << "Space"
+								halimage = image('icons/turf/space.dmi',target,"[rand(1,25)]",TURF_LAYER)
+							if(2)
+								//src << "Fire"
+								halimage = image('icons/effects/fire.dmi',target,"1",TURF_LAYER)
+							if(3)
+								//src << "C4"
+								halimage = image('icons/obj/assemblies.dmi',target,"plastic-explosive2",OBJ_LAYER+0.01)
+
+
+						if(client) client.images += halimage
+						spawn(rand(10,50)) //Only seen for a brief moment.
+							if(client) client.images -= halimage
+							halimage = null
+
+			if(36 to 55) //20% chance
+				//Strange audio
+				//src << "Strange Audio"
+				switch(rand(1,12))
+					if(1) src << 'sound/machines/airlock.ogg'
+					if(2)
+						if(prob(50))src << 'sound/effects/Explosion1.ogg'
+						else src << 'sound/effects/Explosion2.ogg'
+					if(3) src << 'sound/effects/explosionfar.ogg'
+					if(4) src << 'sound/effects/Glassbr1.ogg'
+					if(5) src << 'sound/effects/Glassbr2.ogg'
+					if(6) src << 'sound/effects/Glassbr3.ogg'
+					if(7) src << 'sound/machines/twobeep.ogg'
+					if(8) src << 'sound/machines/windowdoor.ogg'
+					if(9)
+						//To make it more realistic, I added two gunshots (enough to kill)
+						src << 'sound/weapons/Gunshot.ogg'
+						spawn(rand(10,30))
+							src << 'sound/weapons/Gunshot.ogg'
+					if(10) src << 'sound/weapons/smash.ogg'
+					if(11)
+						//Same as above, but with tasers.
+						src << 'sound/weapons/Taser.ogg'
+						spawn(rand(10,30))
+							src << 'sound/weapons/Taser.ogg'
+				//Rare audio
+					if(12)
+//These sounds are (mostly) taken from Hidden: Source
+						var/list/creepyasssounds = list('sound/effects/ghost.ogg', 'sound/effects/ghost2.ogg', 'sound/effects/Heart Beat.ogg', 'sound/effects/screech.ogg',\
+							'sound/hallucinations/behind_you1.ogg', 'sound/hallucinations/behind_you2.ogg', 'sound/hallucinations/far_noise.ogg', 'sound/hallucinations/growl1.ogg', 'sound/hallucinations/growl2.ogg',\
+							'sound/hallucinations/growl3.ogg', 'sound/hallucinations/im_here1.ogg', 'sound/hallucinations/im_here2.ogg', 'sound/hallucinations/i_see_you1.ogg', 'sound/hallucinations/i_see_you2.ogg',\
+							'sound/hallucinations/look_up1.ogg', 'sound/hallucinations/look_up2.ogg', 'sound/hallucinations/over_here1.ogg', 'sound/hallucinations/over_here2.ogg', 'sound/hallucinations/over_here3.ogg',\
+							'sound/hallucinations/turn_around1.ogg', 'sound/hallucinations/turn_around2.ogg', 'sound/hallucinations/veryfar_noise.ogg', 'sound/hallucinations/wail.ogg')
+						src << pick(creepyasssounds)
+			if(56 to 60) //5% chance
+				//Flashes of danger
+				//src << "Danger Flash"
+				if(!halbody)
+					var/list/possible_points = list()
+					for(var/turf/simulated/floor/F in view(src,world.view))
+						possible_points += F
+					if(possible_points.len)
+						var/turf/simulated/floor/target = pick(possible_points)
+						switch(rand(1,4))
+							if(1)
+								halbody = image('icons/mob/human.dmi',target,"husk_l",TURF_LAYER)
+							if(2,3)
+								halbody = image('icons/mob/human.dmi',target,"husk_s",TURF_LAYER)
+							if(4)
+								halbody = image('icons/mob/alien.dmi',target,"alienother",TURF_LAYER)
+	//						if(5)
+	//							halbody = image('xcomalien.dmi',target,"chryssalid",TURF_LAYER)
+
+						if(client) client.images += halbody
+						spawn(rand(50,80)) //Only seen for a brief moment.
+							if(client) client.images -= halbody
+							halbody = null
+			if(61 to 85) //25% chance
+				//food
+				if(!halbody)
+					var/list/possible_points = list()
+					for(var/turf/simulated/floor/F in view(src,world.view))
+						possible_points += F
+					if(possible_points.len)
+						var/turf/simulated/floor/target = pick(possible_points)
+						switch(rand(1,10))
+							if(1)
+								halbody = image('icons/mob/animal.dmi',target,"cow",TURF_LAYER)
+							if(2)
+								halbody = image('icons/mob/animal.dmi',target,"chicken",TURF_LAYER)
+							if(3)
+								halbody = image('icons/obj/food.dmi',target,"bigbiteburger",TURF_LAYER)
+							if(4)
+								halbody = image('icons/obj/food.dmi',target,"meatbreadslice",TURF_LAYER)
+							if(5)
+								halbody = image('icons/obj/food.dmi',target,"sausage",TURF_LAYER)
+							if(6)
+								halbody = image('icons/obj/food.dmi',target,"bearmeat",TURF_LAYER)
+							if(7)
+								halbody = image('icons/obj/food.dmi',target,"fishfillet",TURF_LAYER)
+							if(8)
+								halbody = image('icons/obj/food.dmi',target,"meat",TURF_LAYER)
+							if(9)
+								halbody = image('icons/obj/food.dmi',target,"meatstake",TURF_LAYER)
+							if(10)
+								halbody = image('icons/obj/food.dmi',target,"monkeysdelight",TURF_LAYER)
+
+						if(client) client.images += halbody
+						spawn(rand(50,80)) //Only seen for a brief moment.
+							if(client) client.images -= halbody
+							halbody = null
+			if(86 to 100) //15% chance
+				//disorientation
+				if(client)
+					client.dir = pick(2,4,8)
+					spawn(rand(20,50))
+						client.dir = 1
+
+	handling_hal = 0
+	return

--- a/code/modules/mob/living/carbon/human/species/station/station_special_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_special_vr.dm
@@ -74,7 +74,7 @@
 			if (2.5*H.halloss >= H.traumatic_shock) //If the majority of their shock is due to halloss, greater chance of snapping.
 				if(prob(min(10,(0.2 * H.traumatic_shock))))
 					if(H.feral == 0)
-						H << "<span class='danger'><big>The pain! It stings! Not hurt, but got to get away! Your instincts take over, urging you to flee, to hide, to go to ground, get away from the nasty thing...</big></span>"
+						H << "<span class='danger'><big>The pain! It stings! Got to get away! Your instincts take over, urging you to flee, to hide, to go to ground, get away from the nasty thing...</big></span>"
 					H.feral = max(H.feral, H.halloss) //if already more feral than their halloss justifies, don't increase it.
 					H.emote("twitch")
 			else if(prob(min(10,(0.1 * H.traumatic_shock))))
@@ -83,23 +83,21 @@
 					H << "<span class='danger'><big>Your fight-or-flight response kicks in, your injuries too much to simply ignore - you need to flee, to hide, survive at all costs - or destroy whatever is threatening you.</big></span>"
 					H.feral = 2*H.traumatic_shock //Make 'em snap.
 				else
-					H.feral = min(200, H.feral+(H.traumatic_shock * 0.1)) //If already feral, feralness increases at a slower rate
+					H.feral = max(H.feral, H.traumatic_shock * 2) //keep feralness up to match the current injury state.
 
 	else if (H.jitteriness >= 100) //No stress factors, but there's coffee. Keeps them mildly feral while they're all jittery.
 		if(H.feral == 0)
 			H << "<span class='warning'><big>Suddenly, something flips - everything that moves is... potential prey. A plaything. This is great! Time to hunt!</big></span>"
 			if(H.stat == CONSCIOUS)
 				H.emote("twitch")
-		H.feral = max(H.feral, H.jitteriness-100) //won't make them VERY feral, but they'll be twitchy and pouncy while they're still under the influence, and feralness won't wear off until they're calm..
+		H.feral = max(H.feral, H.jitteriness-100) //won't make them VERY feral, but they'll be twitchy and pouncy while they're still under the influence, and feralness won't wear off until they're calm.
 
 	else
 		if (H.feral > 0) //still feral, but all stress factors are gone. Calm them down.
 			H.feral -= 1
 			if (H.feral <=0) //check if they're unferalled
 				H.feral = 0
-				H << "<span class='primary'>Your thoughts start clearing, your feral urges having passed - for the time being, at least.</span>"
-				H.hallucination = 0 //Remove all their hallucinations.
-
+				H << "<span class='info'>Your thoughts start clearing, your feral urges having passed - for the time being, at least.</span>"
 
 // handle what happens while feral
 
@@ -112,35 +110,46 @@
 				light_amount = 2 * (min(5,L.lum_r + L.lum_g + L.lum_b) - 2.5)
 			else
 				light_amount =  5
-		if(light_amount <= 1.5)
-			H.hallucination = max(0, H.hallucination - 5) //Stop hallucinating if you're in a dark place, all hidden.
-		else
-			for(var/mob/living/M in viewers(H))
-				if(M != H)
-					if(prob(0.5) && (H.nutrition <= 250 || H.jitteriness > 0)) //1 in 200 chance to tell them that person looks like food. This is so irregular so it doesn't pop up 24/7 during ERP. It CAN happen when you're not hungry enough to be feral, especially if coffee is involved.
-						H << "<span class='danger'> Every movement, every flick, every sight and sound has your full attention, your hunting instincts on high alert... In fact, [M] looks extremely appetizing...</span>"
-						if(H.stat == CONSCIOUS)
-							H.emote("twitch")
-					H.hallucination = max(0, H.hallucination - 25) //Stop hallucinating almost immediately once you see someone.
 
-				else if(M == H) //nobody is in view.
-					if(H.nutrition <= 100) //If hungry, nag them to go and find someone or something to eat.
-						if(prob(1))
+		for(var/mob/living/M in viewers(H))
+			if(M != H) // someone in view
+				if(prob(0.5)) // 1 in 200 chance of doing something so as not to interrupt scenes
+					if(light_amount <= 1.5) // in the darkness
+						if(H.nutrition <= 250 || H.jitteriness > 0) //tell them that person looks like food and is good to pounce.
+							H << "<span class='info'> Secure in your hiding place, you still feel the urge to hunt, and [M] looks like an extremely tempting target...</span>"
+					else // in lit area
+						if(H.nutrition <= 250 || H.jitteriness > 0) //tell them that person looks like food. It CAN happen when you're not hungry enough to be feral, especially if coffee is involved.
+							H << "<span class='danger'> Every movement, every flick, every sight and sound has your full attention, your hunting instincts on high alert... In fact, [M] looks extremely appetizing...</span>"
+							if(H.stat == CONSCIOUS)
+								H.emote("twitch")
+							if(!H.handling_hal)
+								spawn H.handle_feral()
+
+			else if(M == H) //nobody is in view.
+				if(light_amount <= 1.5) // in the darkness
+					if(prob(1)) //periodic nagmessages
+						if(H.nutrition <= 100) //If hungry, nag them to go and find someone or something to eat.
+							H << "<span class='info'> Secure in your hiding place, your hunger still gnaws at you. You need to track down some food...</span>"
+						else if(H.jitteriness >= 100)
+							H << "<span class='info'> sneakysneakyyesyesyescleverhidingfindthingsyessssss</span>"
+						else //otherwise, just tell them to hide.
+							H << "<span class='info'> ...safe...</span>"
+				else // in light
+					if(!H.handling_hal)
+						spawn H.handle_feral()
+					if(prob(1)) //periodic nagmessages
+						if(H.nutrition <= 100) //If hungry, nag them to go and find someone or something to eat.
 							H << "<span class='danger'> Confusing sights and sounds and smells surround you - scary and disorienting it may be, but the drive to hunt, to feed, to survive, compels you.</span>"
 							if(H.stat == CONSCIOUS)
 								H.emote("twitch")
-					else if(H.jitteriness >= 100)
-						if(prob(1)) //hypermonster
+						else if(H.jitteriness >= 100)
 							H << "<span class='danger'> yesyesyesyesyesyesgetthethingGETTHETHINGfindfoodsfindpreypounceyesyesyes</span>"
 							if(H.stat == CONSCIOUS)
 								H.emote("twitch")
-					else //otherwise, just tell them to hide.
-						if(prob(1))
+						else //otherwise, just tell them to hide.
 							H << "<span class='danger'> Confusing sights and sounds and smells surround you, this place is wrong, confusing, frightening. You need to hide, go to ground...</span>"
 							if(H.stat == CONSCIOUS)
 								H.emote("twitch")
-
-					H.hallucination = min(200, H.feral*2, H.hallucination +5) //Start hallucinating while alone and feral. 200 hallucination cap. Let's not be too evil.
 
 
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -161,16 +170,18 @@
 		//This is just here to prevent them from getting cold effects
 
 	else if(H.bodytemperature <= 260) //If they're not in stasis and are cold. Don't really have to add in an exception to cryo cells, as the effects aren't anything /too/ horrible.
-		if(H.bodytemperature <= 260 && H.bodytemperature >= 200) //Chilly
-			if(H.halloss < 150) //150 halloss cap. Harsh punishment for staying in space, and it'll take them a while to fully thaw out when they get retrieved.
-				H.halloss = H.halloss + 4 //This will begin to knock them out until they run out of oxygen and suffocate or until someone finds them.
+		var/colddamage = 0
+		if(H.bodytemperature <= 260 && H.bodytemperature >= 200) //Chilly.
+			colddamage = 4 //This will begin to knock them out until they run out of oxygen and suffocate or until someone finds them.
 			H.eye_blurry = 5 //Blurry vision in the cold.
 		if(H.bodytemperature <= 199 && H.bodytemperature >= 100) //Extremely cold. Even in somewhere like the server room it takes a while for bodytemp to drop this low.
-			if(H.halloss < 150)
-				H.halloss = H.halloss + 8
+			colddamage = 8
 			H.eye_blurry = 5
 		if(H.bodytemperature <= 99) //Insanely cold.
-			if(H.halloss < 150)
-				H.halloss = H.halloss + 20
+			colddamage = 20
 			H.eye_blurry = 5
+		if(H.paralysis) //stops weaken spam from being repeatedly taken over max halloss when already KO'd.
+			H.halloss = min(H.halloss+colddamage, H.species.total_health - 1) //if already stunned, only take them up to the point of restunning
+		else
+			H.halloss += colddamage //Harsh punishment for staying in space, and it'll take them a while to fully thaw out when they get retrieved.
 		return


### PR DESCRIPTION
Makes feral creatures not advanced tool users. This primarily affects guns, and is the only thing affected (so far) if you varedit a non-xenochimera creature to be feral.

Injuries no longer increase feral forever, but instead just peg it at an appropriate level for the injury (this should avoid a repeat of 1 broken bone but no other injuries causing feralness to creep up and up and up)

Feralness no longer uses the hallucination var, and has its own proc to handle the results of being cray-cray. Slightly different effects and weighting thereof, is a little more disorienting with the screen-rotations, sees food everywhere. No longer attacked by phantom punpuns.
More importantly, fixes a potential issue where a chimera's hallucinations were stopped near-immediately if someone else is in the same room, regardless of whether the hallucinations were a result of being feral. Now, if they've got an external reason to be tripping balls they'll continue to trip balls regardless of the state of their instincts.

Reordered the feral nagmessages checks so the prob(1) is checked first, _then_ the nutrition/jitteriness, which should hopefully be a tad more efficient.

Had another go at the cold damage thing as I _finally_ found where the "can no longer stand, collapsing!" messages were coming from. Now, it only deals enough halloss to knock you out if you're not _already_ knocked out.