### PR TITLE
Increase transfer rate of Xenobio injector

### DIFF
--- a/code/modules/xenobio2/machinery/injector_computer.dm
+++ b/code/modules/xenobio2/machinery/injector_computer.dm
@@ -16,7 +16,7 @@
 	active_power_usage = 500
 	circuit = /obj/item/weapon/circuitboard/xenobio2computer
 	var/obj/machinery/xenobio2/manualinjector/injector
-	var/transfer_amount
+	var/transfer_amount = 5 //VOREStation Edit - This is never set anywhere, and 1 is too slow (1 is the default in the transfer proc).
 	var/active
 
 /obj/machinery/computer/xenobio2/Destroy()


### PR DESCRIPTION
It was not coded correctly. This "transfer_amount" variable is never set anywhere. The "trans_to_mob" reagent transfer function defaults to 1 if you don't give it something, and this proc passes the null transfer_amount to it, which is basically that. So it always transfers 1. 5 is easier to live with.