### PR TITLE
Makes stasis bags put people to sleep

### DIFF
--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -82,7 +82,8 @@
 		if(!client)
 			species.handle_npc(src)
 
-
+	else //VOREStation Addition - Stasis bags op pls nerf
+		if(in_stasis) Sleeping(5)
 	if(!handle_some_updates())
 		return											//We go ahead and process them 5 times for HUD images and other stuff though.
 


### PR DESCRIPTION
They don't, right now. It's a little weird. People are just magically cured of their pain and can talk normally, forever, as long as they are in a stasis bag. No hunger/drug effects/bleeding/organ damage progression/toxin damage/oxygen damage, etc. AAAnd can talk normally while in "stasis"? Bags op pls nerf.