### PR TITLE
Workaround for custom_item proc

### DIFF
--- a/code/modules/vore/fluffstuff/custom_boxes_vr.dm
+++ b/code/modules/vore/fluffstuff/custom_boxes_vr.dm
@@ -149,6 +149,15 @@
 	can_hold = list(/obj/item/clothing/under/swimsuit/)
 	has_items = list(/obj/item/clothing/under/swimsuit/fluff/penelope)
 
+//Arokha:Aronai Kadigan
+/obj/item/weapon/storage/box/fluff/aronai
+	name = "Aronai's Kit"
+	desc = "A kit containing Aronai's equipment."
+	has_items = list(
+		/obj/item/weapon/storage/backpack/fluff/aronai,
+		/obj/item/weapon/rig/light/hacker/fluff/aronai,
+		/obj/item/clothing/under/rank/khi/fluff/aronai)
+
 /*
 Swimsuits, for general use, to avoid arriving to work with your swimsuit.
 */

--- a/code/modules/vore/fluffstuff/custom_clothes_vr.dm
+++ b/code/modules/vore/fluffstuff/custom_clothes_vr.dm
@@ -853,7 +853,7 @@
 		worn_state = "khi_uniform_sci"
 		armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 5, bio = 0, rad = 5)
 
-	fluff/aro //Aro fluff version
+	fluff/aronai //Aro fluff version
 		name = "KIN meditech suit"
 		desc = "Kitsuhana Industrial Navy uniform. This one has the colors of a resleeving or mnemonics engineer. It has 'Aronai' written inside the top."
 		icon_state = "khi_uniform_aro_i"

--- a/config/custom_items.txt
+++ b/config/custom_items.txt
@@ -57,13 +57,7 @@ item_path: /obj/item/clothing/head/helmet/hos/fluff/lethe
 {
 ckey: arokha
 character_name: Aronai Kadigan
-item_path: /obj/item/weapon/storage/backpack/fluff/aronai
-}
-
-{
-ckey: arokha
-character_name: Aronai Kadigan
-item_path: /obj/item/clothing/under/rank/khi/fluff/aro
+item_path: /obj/item/weapon/storage/box/fluff/aronai
 }
 
 # ######## B CKEYS


### PR DESCRIPTION
It's incapable of spawning this belt, and apparently if I ready up before round start, it will spawn everyone who readies up in space for some reason? Orbis and I tested and aren't suuuper sure why. It's probably the belt though. So, easy solution is a box.