### PR TITLE
fixes scree's suit modkit, tweaks suit, adds mech to code

### DIFF
--- a/code/modules/vore/fluffstuff/custom_clothes_vr.dm
+++ b/code/modules/vore/fluffstuff/custom_clothes_vr.dm
@@ -523,7 +523,7 @@
 //End event costumes
 
 //scree:Scree
-/obj/item/clothing/head/helmet/space/void/engineering/fluff/screehelm
+/obj/item/clothing/head/helmet/space/void/engineering/hazmat/fluff/screehelm
 	name = "Modified Tajara Helmet"
 	desc = "A special helmet designed for work in a hazardous, low-pressure environment. Has radiation shielding. This one doesn't look like it was made for humans. Its been modified to include headlights."
 
@@ -546,7 +546,7 @@
 				return 1
 
 //scree:Scree
-/obj/item/clothing/suit/space/void/engineering/fluff/screespess
+/obj/item/clothing/suit/space/void/engineering/hazmat/fluff/screespess
 	name = "Modified Winged Suit"
 	desc = "A special suit that protects against hazardous, low pressure environments. Has radiation shielding. This one doesn't look like it was made for humans. This one was made with a special personal shielding for someone's wings."
 

--- a/code/modules/vore/fluffstuff/custom_items_vr.dm
+++ b/code/modules/vore/fluffstuff/custom_items_vr.dm
@@ -189,10 +189,10 @@ obj/item/weapon/material/hatchet/tacknife/combatknife/fluff/katarina/handle_shie
 	icon = 'icons/vore/custom_items_vr.dmi'
 	icon_state = "modkit"
 
-	from_helmet = /obj/item/clothing/head/helmet/space/void/engineering
-	from_suit = /obj/item/clothing/suit/space/void/engineering
-	to_helmet = /obj/item/clothing/head/helmet/space/void/engineering/fluff/screehelm
-	to_suit = /obj/item/clothing/suit/space/void/engineering/fluff/screespess
+	from_helmet = /obj/item/clothing/head/helmet/space/void
+	from_suit = /obj/item/clothing/suit/space/void
+	to_helmet = /obj/item/clothing/head/helmet/space/void/engineering/hazmat/fluff/screehelm
+	to_suit = /obj/item/clothing/suit/space/void/engineering/hazmat/fluff/screespess
 
 //General Use
 /obj/item/weapon/flag

--- a/code/modules/vore/fluffstuff/custom_mecha_vr.dm
+++ b/code/modules/vore/fluffstuff/custom_mecha_vr.dm
@@ -1,0 +1,12 @@
+/obj/mecha/combat/phazon/scree
+	desc = "A very, very shiny exosuit. This thing has been polished and waxed practically to a mirror finish."
+	name = "Scuttlebug"
+
+/obj/mecha/combat/phazon/scree/New()
+	..()
+	var/obj/item/mecha_parts/mecha_equipment/ME = new /obj/item/mecha_parts/mecha_equipment/weapon/energy/taser
+	ME.attach(src)
+	ME = new /obj/item/mecha_parts/mecha_equipment/tesla_energy_relay
+	ME.attach(src)
+	return
+

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -2186,6 +2186,7 @@
 #include "code\modules\vore\fluffstuff\custom_clothes_vr.dm"
 #include "code\modules\vore\fluffstuff\custom_guns_vr.dm"
 #include "code\modules\vore\fluffstuff\custom_items_vr.dm"
+#include "code\modules\vore\fluffstuff\custom_mecha_vr.dm"
 #include "code\modules\vore\fluffstuff\custom_permits_vr.dm"
 #include "code\modules\vore\resizing\grav_pull_vr.dm"
 #include "code\modules\vore\resizing\holder_micro_vr.dm"


### PR DESCRIPTION
Fixes Scree's modkit 'cause it only worked on engineering suits which made it useless for mining.
Also switched it over to use the engineering hazmat suit as a base (offers complete rad protection and slightly better bomb protection, though less melee protection).

Adds a file for vorestation-specific mecha loadouts and adds Scree's one 'cause I'm sick of rooting in menus and varediting every time I screw around in the thunderdome. Scree still doesn't spawn with the thing 'cause that'd be ridiculous.