### PR TITLE
Revert Awaymission Change

### DIFF
--- a/code/modules/awaymissions/zlevel.dm
+++ b/code/modules/awaymissions/zlevel.dm
@@ -1,5 +1,5 @@
 proc/createRandomZlevel()
-	if(awaydestinations.len || UNIT_TEST)	//crude, but it saves another var! //VOREStation Edit - No loading away missions during Travis testing
+	if(awaydestinations.len)	//crude, but it saves another var!
 		return
 
 	var/list/potentialRandomZlevels = list()


### PR DESCRIPTION
I'm unsure IF this is what broke away missions from loading. They don't seem to load. For all I know the maps could be broken somehow. But I'm leaving this PR here so that if it turns out it's this, it's easy to fix.

This reverts commit ab374a35fcaf10d600567560d5cf9cdb7ef514af.