### PR TITLE
bugfix in anti-tamper proc & screesuit

### DIFF
--- a/code/game/objects/structures/crates_lockers/crates_vr.dm
+++ b/code/game/objects/structures/crates_lockers/crates_vr.dm
@@ -5,11 +5,7 @@
 	if(!(Proj.damage_type == BRUTE || Proj.damage_type == BURN))
 		return
 
-	health -= Proj.damage
-
-	..()
-
-	if(locked && tamper_proof && health <= 0)
+	if(locked && tamper_proof && health <= Proj.damage)
 		if(tamper_proof == 2) // Mainly used for events to prevent any chance of opening the box improperly.
 			visible_message("<font color='red'><b>The anti-tamper mechanism of [src] triggers an explosion!</b></font>")
 			var/turf/T = get_turf(src.loc)
@@ -33,9 +29,6 @@
 				visible_message("<font color='green'><b>The anti-tamper mechanism of [src] fails!</b></font>")
 		return
 
-	if(health <= 0)
-		for(var/atom/movable/A as mob|obj in src)
-			A.loc = src.loc
-		qdel(src)
+	..()
 
 	return

--- a/code/modules/vore/fluffstuff/custom_clothes_vr.dm
+++ b/code/modules/vore/fluffstuff/custom_clothes_vr.dm
@@ -533,6 +533,8 @@
 	icon_override = 'icons/vore/custom_clothes_vr.dmi'
 	item_state = "scree-helm_mob"
 
+	item_state_slots = list(slot_r_hand_str = "engspace_helmet", slot_l_hand_str = "engspace_helmet")
+
 	light_overlay = "helmet_light_dual"
 
 	species_restricted = null
@@ -555,6 +557,8 @@
 
 	icon_override = 'icons/vore/custom_clothes_vr.dmi'
 	item_state = "scree-spess_mob"
+
+	item_state_slots = list(slot_r_hand_str = "eng_voidsuit", slot_l_hand_str = "eng_voidsuit")
 
 	species_restricted = null
 


### PR DESCRIPTION
Fixes a bug in the vorestation-specific bullet_act() proc that caused crates to take damage twice when shot, as the parent proc also deals damage.

Fixes the inhand sprites on the scree-suit and helmet.