### PR TITLE
Fire now damages doors.

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -784,7 +784,8 @@ About the new airlock wires panel:
 	else if(istype(C, /obj/item/weapon/pai_cable))	// -- TLE
 		var/obj/item/weapon/pai_cable/cable = C
 		cable.plugin(src, user)
-	else if(!repairing && istype(C, /obj/item/weapon/crowbar))
+	//else if(!repairing && istype(C, /obj/item/weapon/crowbar)) vorestation removal
+	else if(!repairing && !reinforcing && istype(C, /obj/item/weapon/crowbar)) // vorestation replacement
 		if(src.p_open && (operating < 0 || (!operating && welded && !src.arePowerSystemsOn() && density && (!src.locked || (stat & BROKEN)))) )
 			playsound(src.loc, 'sound/items/Crowbar.ogg', 100, 1)
 			user.visible_message("[user] removes the electronics from the airlock assembly.", "You start to remove electronics from the airlock assembly.")

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -112,6 +112,8 @@
 	opacity = 1
 	secured_wires = 1
 	assembly_type = /obj/structure/door_assembly/door_assembly_highsecurity //Until somebody makes better sprites.
+	heat_proof = 1 // vorestation addition
+
 
 /obj/machinery/door/airlock/vault/bolted
 	icon_state = "door_locked"
@@ -129,6 +131,8 @@
 	explosion_resistance = 20
 	opacity = 1
 	assembly_type = /obj/structure/door_assembly/door_assembly_hatch
+	heat_proof = 1 //vorestation addition
+
 
 /obj/machinery/door/airlock/maintenance_hatch
 	name = "Maintenance Hatch"
@@ -749,7 +753,8 @@ About the new airlock wires panel:
 	if(istype(C, /mob/living))
 		..()
 		return
-	if(!repairing && (istype(C, /obj/item/weapon/weldingtool) && !( src.operating > 0 ) && src.density))
+	//if(!repairing && (istype(C, /obj/item/weapon/weldingtool) && !( src.operating > 0 ) && src.density)) vorestation removal
+	if(!repairing && !reinforcing && (istype(C, /obj/item/weapon/weldingtool) && !( src.operating > 0 ) && src.density)) //vorestation replacement
 		var/obj/item/weapon/weldingtool/W = C
 		if(W.remove_fuel(0,user))
 			if(!src.welded)

--- a/code/game/machinery/doors/blast_door.dm
+++ b/code/game/machinery/doors/blast_door.dm
@@ -169,6 +169,7 @@ obj/machinery/door/blast/regular
 	icon_state_closing = "pdoorc1"
 	icon_state = "pdoor1"
 	maxhealth = 600
+	heat_proof = 1 //vorestation addition
 
 obj/machinery/door/blast/regular/open
 	icon_state = "pdoor0"

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -208,7 +208,7 @@
 		if(!heat_proof)
 			var/obj/item/stack/stack = I
 			var/transfer
-			var/amount_needed = 5
+			var/amount_needed = 2
 			if (stack.amount >= amount_needed)
 				if(stat & BROKEN)
 					user << "<span class='notice'>It looks like \the [src] is pretty busted. There's not much point reinforcing it.</span>"

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -23,6 +23,7 @@
 	//These are frequenly used with windows, so make sure zones can pass.
 	//Generally if a firedoor is at a place where there should be a zone boundery then there will be a regular door underneath it.
 	block_air_zones = 0
+	heat_proof = 1 // vorestation addition
 
 	var/blocked = 0
 	var/prying = 0

--- a/code/game/turfs/simulated/floor_acts.dm
+++ b/code/game/turfs/simulated/floor_acts.dm
@@ -43,3 +43,6 @@
 	for(var/obj/structure/window/W in src)
 		if(W.dir == dir_to || W.is_fulltile()) //Same direction or diagonal (full tile)
 			W.fire_act(adj_air, adj_temp, adj_volume)
+
+	for(var/obj/machinery/door/D in src) // Vorestation addition
+		D.fire_act(adj_air, adj_temp, adj_volume)


### PR DESCRIPTION
Makes airlocks, firelocks and shutters take damage from fire.
The thresholds before they start to take damage have been set the same as their corresponding walls - so normal airlocks will start to take damage at the 1800 degrees (the same as ordinary steel walls) and heat-resistant airlocks, blast doors and firelocks will do so at 6000 (same as a plasteel rwall).
The damage, and threshold before they melt completely after breaking, have been set to put blast doors on a par with reinforced plasteel walls. Ordinary airlocks with the heat_proof property will break slightly beforehand on account of lower HP.

Airlocks that are not heat_proof can now be fireproofed by adding two plasteel sheets and welding them into place, the same procedure as repairing a damaged airlock with steel. The sheets may be retrieved prior to welding by crowbarring them.

All the airlock types in use around the toxins burn chamber and the engine are heat-resistant, so no mapping changes need to be made. If you were running the chamber hot enough to break these doors, you were running it hot enough to melt the walls anyway.

Prevents cheeky fuckers from building inpenetrable burn chambers out of airlocks.