### PR TITLE
Fire now damages doors.

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -746,6 +746,7 @@ About the new airlock wires panel:
 		return
 
 	src.add_fingerprint(user)
+	if (attempt_vr(src,"attackby_vr",list(C, user))) return
 	if(istype(C, /mob/living))
 		..()
 		return

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -202,6 +202,8 @@
 /obj/machinery/door/attackby(obj/item/I as obj, mob/user as mob)
 	src.add_fingerprint(user)
 
+	if (attempt_vr(src,"attackby_vr",list(I, user))) return
+
 	if(istype(I, /obj/item/stack/material) && I.get_material_name() == src.get_material_name())
 		if(stat & BROKEN)
 			user << "<span class='notice'>It looks like \the [src] is pretty busted. It's going to need more than just patching up now.</span>"

--- a/code/game/machinery/doors/door_vr.dm
+++ b/code/game/machinery/doors/door_vr.dm
@@ -5,9 +5,6 @@
 /obj/machinery/door
 	var/obj/item/stack/material/plasteel/reinforcing //vorestation addition
 
-/obj/machinery/door/blast/regular
-	heat_proof = 1
-
 /obj/machinery/door/firedoor
 	heat_proof = 1
 
@@ -19,13 +16,15 @@
 
 /obj/machinery/door/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
 	var/maxtemperature = 1800 //same as a normal steel wall
+	var/destroytime = 20 //effectively gives an airlock 200HP between breaking and completely disintegrating
 	if(heat_proof)
 		maxtemperature = 6000 //same as a plasteel rwall
+		destroytime = 50 //fireproof airlocks need to take 500 damage after breaking before they're destroyed
 
 	if(exposed_temperature > maxtemperature)
 		var/burndamage = log(RAND_F(0.9, 1.1) * (exposed_temperature - maxtemperature))
-		if (burndamage && health <= 0) //once they break, you've not got long before they're just ash
-			destroy_hits -= (burndamage / 20) //effectively gives an airlock 200HP between breaking and completely disintegrating
+		if (burndamage && health <= 0) //once they break, start taking damage to destroy_hits
+			destroy_hits -= (burndamage / destroytime)
 			if (destroy_hits <= 0)
 				visible_message("<span class='danger'>\The [src.name] disintegrates!</span>")
 				new /obj/effect/decal/cleanable/ash(src.loc) // Turn it to ashes!
@@ -84,3 +83,11 @@
 		reinforcing = null
 		return 1
 	return 0
+
+/obj/machinery/door/blast/regular/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
+	return // blast doors are immune to fire completely.
+
+/obj/machinery/door/blast/regular/
+	heat_proof = 1 //just so repairing them doesn't try to fireproof something that never takes fire damage
+
+

--- a/code/game/machinery/doors/door_vr.dm
+++ b/code/game/machinery/doors/door_vr.dm
@@ -1,0 +1,86 @@
+/turf/simulated/floor/proc/adjacent_fire_act_vr(turf/simulated/floor/adj_turf, datum/gas_mixture/adj_air, adj_temp, adj_volume)
+	for(var/obj/machinery/door/D in src) //makes doors next to fire affected by fire
+		D.fire_act(adj_air, adj_temp, adj_volume)
+
+/obj/machinery/door
+	var/obj/item/stack/material/plasteel/reinforcing //vorestation addition
+
+/obj/machinery/door/blast/regular
+	heat_proof = 1
+
+/obj/machinery/door/firedoor
+	heat_proof = 1
+
+/obj/machinery/door/airlock/vault
+	heat_proof = 1
+
+/obj/machinery/door/airlock/hatch
+	heat_proof = 1
+
+/obj/machinery/door/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
+	var/maxtemperature = 1800 //same as a normal steel wall
+	if(heat_proof)
+		maxtemperature = 6000 //same as a plasteel rwall
+
+	if(exposed_temperature > maxtemperature)
+		var/burndamage = log(RAND_F(0.9, 1.1) * (exposed_temperature - maxtemperature))
+		if (burndamage && health <= 0) //once they break, you've not got long before they're just ash
+			destroy_hits -= (burndamage / 20) //effectively gives an airlock 200HP between breaking and completely disintegrating
+			if (destroy_hits <= 0)
+				visible_message("<span class='danger'>\The [src.name] disintegrates!</span>")
+				new /obj/effect/decal/cleanable/ash(src.loc) // Turn it to ashes!
+				qdel(src)
+		take_damage(burndamage)
+
+	return ..()
+
+/obj/machinery/door/proc/attackby_vr(obj/item/I as obj, mob/user as mob)
+	if(istype(I, /obj/item/stack/material) && I.get_material_name() == "plasteel") // Add heat shielding if it isn't already.
+		if(!heat_proof)
+			var/obj/item/stack/stack = I
+			var/transfer
+			var/amount_needed = 2
+			if (stack.amount >= amount_needed)
+				if(stat & BROKEN)
+					user << "<span class='notice'>It looks like \the [src] is pretty busted. There's not much point reinforcing it.</span>"
+					return 1
+			if (reinforcing)
+				transfer = stack.transfer_to(reinforcing, amount_needed - reinforcing.amount)
+				if (!transfer)
+					user << "<span class='warning'>You must weld or remove \the [reinforcing] from \the [src] before you can add anything else.</span>"
+					return 1
+			else
+				reinforcing = stack.split(amount_needed)
+				if (reinforcing)
+					reinforcing.loc = src
+					transfer = reinforcing.amount
+
+			if (transfer)
+				user << "<span class='notice'>You fit [transfer] [stack.singular_name]\s to \the [src].</span>"
+				return 1
+			return 0
+
+	if(reinforcing && istype(I, /obj/item/weapon/weldingtool))
+		if(!density)
+			user << "<span class='warning'>\The [src] must be closed before you can repair it.</span>"
+			return 1
+
+		var/obj/item/weapon/weldingtool/welder = I
+		if(welder.remove_fuel(0,user))
+			user << "<span class='notice'>You start to weld \the [reinforcing] into place.</span>"
+			playsound(src, 'sound/items/Welder.ogg', 100, 1)
+			if(do_after(user, 5 * reinforcing.amount) && welder && welder.isOn())
+				user << "<span class='notice'>You finish reinforcing \the [src].</span>"
+				heat_proof = 1
+				update_icon()
+				qdel(reinforcing)
+				reinforcing = null
+		return 1
+
+	if(reinforcing && istype(I, /obj/item/weapon/crowbar))
+		user << "<span class='notice'>You remove \the [reinforcing].</span>"
+		playsound(src.loc, 'sound/items/Crowbar.ogg', 100, 1)
+		reinforcing.loc = user.loc
+		reinforcing = null
+		return 1
+	return 0

--- a/code/game/turfs/simulated/floor_acts.dm
+++ b/code/game/turfs/simulated/floor_acts.dm
@@ -43,3 +43,5 @@
 	for(var/obj/structure/window/W in src)
 		if(W.dir == dir_to || W.is_fulltile()) //Same direction or diagonal (full tile)
 			W.fire_act(adj_air, adj_temp, adj_volume)
+
+	attempt_vr(src,"adjacent_fire_act_vr",list(adj_turf,adj_air,adj_temp,adj_volume))

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -672,6 +672,7 @@
 #include "code\game\machinery\doors\brigdoors.dm"
 #include "code\game\machinery\doors\checkForMultipleDoors.dm"
 #include "code\game\machinery\doors\door.dm"
+#include "code\game\machinery\doors\door_vr.dm"
 #include "code\game\machinery\doors\firedoor.dm"
 #include "code\game\machinery\doors\firedoor_assembly.dm"
 #include "code\game\machinery\doors\multi_tile.dm"


### PR DESCRIPTION
Redid PR #955  'cause the last one got borked. Also made it helluva neater thanks to the attempt_vr proc.

Makes airlocks, firelocks and shutters take damage from fire.
The thresholds before they start to take damage have been set the same as their corresponding walls - so normal airlocks will start to take damage at the 1800 degrees (the same as ordinary steel walls) and heat-resistant airlocks, blast doors and firelocks will do so at 6000 (same as a plasteel rwall).
The damage, and threshold before they melt completely after breaking, have been set to put blast doors on a par with reinforced plasteel walls. Ordinary airlocks with the heat_proof property will break slightly beforehand on account of lower HP.

Airlocks that are not heat_proof can now be fireproofed by adding two plasteel sheets and welding them into place, the same procedure as repairing a damaged airlock with steel. The sheets may be retrieved prior to welding by crowbarring them.

All the airlock types in use around the toxins burn chamber and the engine are heat-resistant, so no mapping changes need to be made. If you were running the chamber hot enough to break these doors, you were running it hot enough to melt the walls anyway.

Prevents cheeky fuckers from building impenetrable burn chambers out of airlocks.