### PR TITLE
Unwhitelist EAL

### DIFF
--- a/code/modules/mob/language/station_vr.dm
+++ b/code/modules/mob/language/station_vr.dm
@@ -62,6 +62,3 @@
 	flags = 0
 /datum/language/gutter
 	flags = WHITELISTED
-/datum/language/machine
-	flags = NO_STUTTER | WHITELISTED
-


### PR DESCRIPTION
Apparently this was done due to a bug, or prior to something being fixed/added and is not necessary now. Either way, whitelisting languages kills them. Kinda needs SEVERAL PEOPLE to speak the language to even justify it taking up a slot. I used to enjoy speaking in EAL to people, even though they spoke back in GalCom. :/ 

To clarify how EAL works:

**Organics:**
- Can take EAL, and UNDERSTAND EAL when it is spoken to them.
- Cannot speak EAL, unless they have the EAL implant
- Can never use the sound emotes (beep, ping, buzz)

**Synthetics:**
- Can take EAL, and SPEAK and UNDERSTAND EAL
- Can use the sound emotes (beep, ping, buzz)

The sound emotes are not tied to EAL in any way (beep, ping, buzz). They are emotes you can perform if you are synthetic.

The language is supposed to be Star-Warsian kind of droid talk. Like how Luke understood R2D2's beeping but talked back in Galactic Basic because he couldn't speak it. That's the general state of an organic who takes EAL and has no implant.

We MAY make the implant not a loadout item though, and have that by request for organics. Or an R&D thing maybe. This PR does not do that, however.