### PR TITLE
Unwhitelist Gutter?

### DIFF
--- a/code/modules/mob/language/station_vr.dm
+++ b/code/modules/mob/language/station_vr.dm
@@ -60,8 +60,6 @@
 	flags = 0
 /datum/language/seromi
 	flags = 0
-/datum/language/gutter
-	flags = WHITELISTED
 /datum/language/machine
 	flags = NO_STUTTER | WHITELISTED
 


### PR DESCRIPTION
This is a 'proposition' PR.

In my opinion, whitelisting languages just kills them. Sure one person has applied for Gutter, but who the hell are they going to speak to with it? Why would anyone apply unless they're friends with that person? It basically kills the motivation of many to apply, or even use the language.

Instead, if people have taken Gutter and they don't have a criminal background, we should talk to them because they are not respecting the lore. We should probably codify that you're required to respect the lore in the rules more clearly, and that an SCA is required for other things.

If you're in Security and you take Gutter to make it "easier to catch criminals ingame" then you are playing on the wrong server. Sorry. That's just how it is. You should take languages because of story reasons. To make the game more interesting for yourself and everyone around you. Taking a language to "catch the criminals in the video game" means you probably need to be talked to by admins about what the server is about.

I'll conclude with an analogy of whitelisting languages:
You can leave the cookie jar in your child-filled house on the counter, or up out of reach. If you put the cookie jar out of reach rather than teaching them to behave, it just teaches them that you're a 'mean adult' and makes everyone else who has self-control have to reach higher to get the cookies. So it doesn't teach the people who need to be taught anything, and makes people who already know have to jump through hoops.