### PR TITLE
Makes nudity permits not cover anything

### DIFF
--- a/code/modules/clothing/under/miscellaneous_vr.dm
+++ b/code/modules/clothing/under/miscellaneous_vr.dm
@@ -3,6 +3,7 @@
 	desc = "This permit entitles the bearer to conduct their duties without a uniform. Normally issued to furred crewmembers or those with nothing to hide."
 	icon = 'icons/obj/card.dmi'
 	icon_state = "guest"
+	body_parts_covered = 0
 
 	sprite_sheets = list()
 


### PR DESCRIPTION
Nudity permits were set up so they counted as covering the body, arms and legs. This makes them not cover anything - flavor text, injuries and prosthetics will all be visible.