### PR TITLE
Adds AI Vore Capability

### DIFF
--- a/code/_helpers/icons.dm
+++ b/code/_helpers/icons.dm
@@ -811,8 +811,8 @@ proc // Creates a single icon from a given /atom or /image.  Only the first argu
 
 /proc/getHologramIcon(icon/A, safety=1)//If safety is on, a new icon is not created.
 	var/icon/flat_icon = safety ? A : new(A)//Has to be a new icon to not constantly change the same icon.
-	flat_icon.ColorTone(rgb(125,180,225))//Let's make it bluish.
-	flat_icon.ChangeOpacity(0.5)//Make it half transparent.
+	//flat_icon.ColorTone(rgb(125,180,225))//Let's make it bluish. //VOREStation Removal for AI Vore effects
+	//flat_icon.ChangeOpacity(0.5)//Make it half transparent. //VOREStation Removal for AI Vore effects
 	var/icon/alpha_mask = new('icons/effects/effects.dmi', "scanline")//Scanline effect.
 	flat_icon.AddAlphaMask(alpha_mask)//Finally, let's mix in a distortion effect.
 	return flat_icon

--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -124,9 +124,9 @@ For the other part of the code, check silicon say.dm. Particularly robot talk.*/
 	return
 
 /obj/machinery/hologram/holopad/proc/create_holo(mob/living/silicon/ai/A, turf/T = loc)
-	var/obj/effect/overlay/hologram = new(T)//Spawn a blank effect at the location.
+	var/obj/effect/overlay/aiholo/hologram = new(T)//Spawn a blank effect at the location. //VOREStation Edit to specific type for adding vars
 	hologram.icon = A.holo_icon
-	hologram.mouse_opacity = 0//So you can't click on it.
+	//hologram.mouse_opacity = 0//So you can't click on it. //VOREStation Removal
 	hologram.layer = FLY_LAYER//Above all the other objects/mobs. Or the vast majority of them.
 	hologram.anchored = 1//So space wind cannot drag it.
 	hologram.name = "[A.name] (Hologram)"//If someone decides to right click.
@@ -160,10 +160,22 @@ For the other part of the code, check silicon say.dm. Particularly robot talk.*/
 
 /obj/machinery/hologram/holopad/proc/move_hologram(mob/living/silicon/ai/user)
 	if(masters[user])
+		/*VOREStation Removal, using our own code
 		step_to(masters[user], user.eyeobj) // So it turns.
 		var/obj/effect/overlay/H = masters[user]
 		H.loc = get_turf(user.eyeobj)
 		masters[user] = H
+		*/
+		//VOREStation Add - Solid mass holovore tracking stuff
+		var/obj/effect/overlay/aiholo/H = masters[user]
+		if(H.bellied)
+			walk_to(H, user.eyeobj) //Walk-to respects obstacles
+		else
+			walk_towards(H, user.eyeobj) //Walk-towards does not
+		//Hologram left the screen (got stuck on a wall or something)
+		if(get_dist(H, user.eyeobj) > world.view)
+			clear_holo(user)
+		//VOREStation Add End
 		if((HOLOPAD_MODE == RANGE_BASED && (get_dist(H, src) > holo_range)))
 			clear_holo(user)
 

--- a/code/modules/mob/living/silicon/say.dm
+++ b/code/modules/mob/living/silicon/say.dm
@@ -70,7 +70,7 @@
 
 	var/obj/machinery/hologram/holopad/T = src.holo
 	if(T && T.masters[src])//If there is a hologram and its master is the user.
-
+		var/obj/effect/overlay/aiholo/hologram = T.masters[src] //VOREStation Add for people in the hologram to hear the messages
 		//Human-like, sorta, heard by those who understand humans.
 		var/rendered_a
 		//Speach distorted, heard by those who do not understand AIs.
@@ -85,7 +85,7 @@
 			rendered_a = "<span class='game say'><span class='name'>[name]</span> [verb], <span class='message'>\"[message]\"</span></span>"
 			rendered_b = "<span class='game say'><span class='name'>[voice_name]</span> [verb], <span class='message'>\"[message_stars]\"</span></span>"
 			src << "<i><span class='game say'>Holopad transmitted, <span class='name'>[real_name]</span> [verb], <span class='message'><span class='body'>\"[message]\"</span></span></span></i>"//The AI can "hear" its own message.
-
+		if(hologram.bellied) hologram.bellied.show_message(rendered_a, 2) //VOREStation Add so holobellied people can hear
 		for(var/mob/M in hearers(T.loc))//The location is the object, default distance.
 			if(M.say_understands(src))//If they understand AI speak. Humans and the like will be able to.
 				M.show_message(rendered_a, 2)
@@ -111,7 +111,8 @@
 	if(T && T.masters[src])
 		var/rendered = "<span class='game say'><span class='name'>[name]</span> <span class='message'>[message]</span></span>"
 		src << "<i><span class='game say'>Holopad action relayed, <span class='name'>[real_name]</span> <span class='message'>[message]</span></span></i>"
-
+		var/obj/effect/overlay/aiholo/hologram = T.masters[src] //VOREStation Add for people in the hologram to hear the messages
+		if(hologram.bellied) hologram.bellied.show_message(rendered, 2) //VOREStation Add so holobellied people can hear
 		for(var/mob/M in viewers(T.loc))
 			M.show_message(rendered, 2)
 	else //This shouldn't occur, but better safe then sorry.

--- a/code/modules/vore/eating/silicon_vr.dm
+++ b/code/modules/vore/eating/silicon_vr.dm
@@ -1,0 +1,93 @@
+//Dat AI vore yo
+#define HOLO_ORIGINAL_COLOR null //This seems to work for some reason? And look better?
+#define HOLO_HARDLIGHT_COLOR "#d97de0"
+#define HOLO_ORIGINAL_ALPHA 128
+#define HOLO_HARDLIGHT_ALPHA 210
+
+/obj/effect/overlay/aiholo
+	var/mob/living/bellied //Only belly one person at a time. No huge vore-organs setup for AIs.
+	pass_flags = PASSTABLE | PASSGLASS | PASSGRILLE
+	alpha = HOLO_ORIGINAL_ALPHA //Half alpha here rather than in the icon so we can toggle it easily.
+	color = HOLO_ORIGINAL_COLOR //This is the blue from icons.dm that it was before.
+	desc = "A hologram representing an AI persona."
+
+/obj/effect/overlay/aiholo/proc/get_prey(var/mob/living/prey)
+	if(bellied) return
+	playsound('sound/effects/stealthoff.ogg',50,0)
+	bellied = prey
+	prey.forceMove(src)
+	visible_message("[src] entirely engulfs [prey] in hardlight holograms!")
+	usr << "<span class='notice'>You completely engulf [prey] in hardlight holograms!</span>" //Can't be part of the above, because the above is from the hologram.
+
+	desc = "[initial(desc)] It seems to have hardlight mode enabled and someone inside."
+	pass_flags = 0
+	color = HOLO_HARDLIGHT_COLOR
+	alpha = HOLO_HARDLIGHT_ALPHA
+
+/obj/effect/overlay/aiholo/proc/drop_prey()
+	if(!bellied) return
+	playsound('sound/effects/stealthoff.ogg',50,0)
+	bellied.forceMove(get_turf(src))
+	bellied.Weaken(2)
+	bellied.visible_message("[bellied] flops out of \the [src].","You flop out of \the [src].","You hear a thud.")
+	bellied = null
+
+	desc = "[initial(desc)]"
+	pass_flags = initial(pass_flags)
+	color = initial(color)
+	alpha = initial(alpha)
+
+/obj/effect/overlay/aiholo/Destroy()
+	drop_prey()
+	..()
+
+/mob/living/silicon/ai/verb/holo_nom()
+	set name = "Hardlight Nom"
+	set category = "Vore"
+	set desc = "Wrap up a person in hardlight holograms."
+
+	// Wrong state
+	if (!eyeobj || !holo)
+		usr << "<span class='warning'>You can only use this when holo-projecting!</span>"
+		return
+
+	//Holopads have this 'masters' list where the keys are AI names and the values are the hologram effects
+	var/obj/effect/overlay/aiholo/hologram = holo.masters[src]
+
+	//Something wrong on holopad
+	if(!hologram)
+		return
+
+	//Already full
+	if (hologram.bellied)
+		var/choice = alert("You can only contain one person. [hologram.bellied] is in you.","Already Full","Drop Mob","Cancel")
+		if(choice == "Drop Mob")
+			hologram.drop_prey()
+		return
+
+	var/mob/living/prey = input(src,"Select a mob to eat","Holonoms") as mob in oview(0,eyeobj)|null
+	if(!prey)
+		return //Probably cancelled
+
+	if(!istype(prey))
+		usr << "<span class='warning'>Invalid mob choice!</span>"
+		return
+
+	hologram.visible_message("[hologram] starts engulfing [prey] in hardlight holograms!")
+	src << "<span class='notice'>You begin engulfing [prey] in hardlight holograms.</span>" //Can't be part of the above, because the above is from the hologram.
+	if(do_after(user=eyeobj,delay=50,target=prey,needhand=0) && holo && hologram && !hologram.bellied) //Didn't move and still projecting and effect exists and no other bellied people
+		hologram.get_prey(prey)
+
+/*	Can't, lets them examine things in camera blackout areas
+//I basically have to do this, you know?
+/mob/living/silicon/ai/examinate(atom/A as mob|obj|turf in view(eyeobj))
+	set name = "Examine"
+	set category = "IC"
+
+	A.examine(src)
+*/
+
+/mob/living/AIShiftClick(var/mob/user) //Shift-click as AI overridden on mobs to examine.
+	if(user.client)
+		src.examine(user)
+	return

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -2247,6 +2247,7 @@
 #include "code\modules\vore\eating\belly_vr.dm"
 #include "code\modules\vore\eating\bellymodes_vr.dm"
 #include "code\modules\vore\eating\living_vr.dm"
+#include "code\modules\vore\eating\silicon_vr.dm"
 #include "code\modules\vore\eating\simple_animal_vr.dm"
 #include "code\modules\vore\eating\vore_vr.dm"
 #include "code\modules\vore\eating\vorehooks_vr.dm"


### PR DESCRIPTION
Also just general AI QOL things.

AIs have a "Hardlight Noms" verb in the Vore tab. When their hologram is on top of a person, they can pick this, and will homf them. Takes 5 seconds, neither of you can move or it cancels. Holograms with someone inside become almost opaque and purple. They also have different examine text.

A hologram with someone inside cannot move through glass/tables/etc. Pressing "Hardlight Noms" again will give the option of dumping the prey out. Derezzing the hologram will also do this. Also because the hologram can be 'blocked' by things now when full, moving the hologram off the screen will derez it and dump the prey too.

AIs can examine mobs now to get flavortext and OOC notes. Shift-click only. This is for annoying technical reasons. Sorry to those that like to right-click and click examine.