### PR TITLE
Redo Vore Panel Interactions

### DIFF
--- a/code/modules/vore/eating/belly_vr.dm
+++ b/code/modules/vore/eating/belly_vr.dm
@@ -21,12 +21,12 @@
 	var/digest_tickrate = 3					// Modulus this of air controller tick number to iterate gurgles on
 	var/immutable = 0						// Prevents this belly from being deleted
 	var/escapable = 0						// Belly can be resisted out of at any time
-	var/escapetime = 600					// Deciseconds, how long to escape this belly
+	var/escapetime = 60 SECONDS				// Deciseconds, how long to escape this belly
 	var/digestchance = 0					// % Chance of stomach beginning to digest if prey struggles
 	var/absorbchance = 0					// % Chance of stomach beginning to absorb if prey struggles
 	var/escapechance = 0 					// % Chance of prey beginning to escape if prey struggles.
 	var/transferchance = 0 					// % Chance of prey being
-	var/transferlocation = null				// Location that the prey is released if they struggle and get dropped off.
+	var/datum/belly/transferlocation = null	// Location that the prey is released if they struggle and get dropped off.
 
 	var/tmp/digest_mode = DM_HOLD				// Whether or not to digest. Default to not digest.
 	var/tmp/list/digest_modes = list(DM_HOLD,DM_DIGEST,DM_HEAL,DM_ABSORB,DM_DRAIN,DM_UNABSORB)	// Possible digest modes
@@ -412,17 +412,12 @@
 				owner << "<span class='notice'>The attempt to escape from your [name] has failed!</span>"
 				return
 
-		else if(prob(transferchance)) //Next, let's have it see if they end up getting into an even bigger mess then when they started.
-			var/datum/belly/T = transferlocation
-			for(var/K in owner.vore_organs)
-				var/datum/belly/B = owner.vore_organs[K]
-				var/datum/belly/TL = B.transferlocation
-				if(TL != null)
-					B.internal_contents -= R
-					T.internal_contents += R
-					R << "<span class='warning'>Your attempt to escape [name] has failed and your struggles only results in you sliding into [owner]'s [transferlocation]</span>"
-					owner << "<span class='warning'>Someone slid into your [transferlocation] due to their struggling inside your [name]!</span>"
-					return
+		else if(prob(transferchance) && transferlocation) //Next, let's have it see if they end up getting into an even bigger mess then when they started.
+			internal_contents -= R
+			transferlocation.internal_contents += R
+			R << "<span class='warning'>Your attempt to escape [name] has failed and your struggles only results in you sliding into [owner]'s [transferlocation]!</span>"
+			owner << "<span class='warning'>Someone slid into your [transferlocation] due to their struggling inside your [name]!</span>"
+			return
 
 		else if(prob(absorbchance)) //After that, let's have it run the absorb chance.
 			R << "<span class='warning'>In response to your struggling, \the [name] begins to get more active...</span>"

--- a/code/modules/vore/eating/vorepanel_vr.dm
+++ b/code/modules/vore/eating/vorepanel_vr.dm
@@ -2,6 +2,11 @@
 // Vore management panel for players
 //
 
+#define BELLIES_MAX 20
+#define BELLIES_NAME_MIN 2
+#define BELLIES_NAME_MAX 12
+#define BELLIES_DESC_MAX 1024
+
 /mob/living/proc/insidePanel()
 	set name = "Vore Panel"
 	set category = "Vore"
@@ -21,6 +26,7 @@
 //
 /datum/vore_look
 	var/datum/belly/selected
+	var/show_interacts = 0
 	var/datum/browser/popup
 	var/loop = null;  // Magic self-reference to stop the handler from being GC'd before user takes action.
 
@@ -114,7 +120,7 @@
 
 		dat += "<span style='[spanstyle]'> ([B.internal_contents.len])</span></a></li>"
 
-	if(user.vore_organs.len < 20)
+	if(user.vore_organs.len < BELLIES_MAX)
 		dat += "<li style='float: left'><a href='?src=\ref[src];newbelly=1'>New+</a></li>"
 	dat += "</ol>"
 	dat += "<HR>"
@@ -172,20 +178,35 @@
 		dat += "<br><a href='?src=\ref[src];b_msgs=\ref[selected]'>Belly Messages</a>"
 
 		//Belly escapability
-		dat += "<br><a href='?src=\ref[src];b_escapable=\ref[selected]'>Set Belly Interactions (below)</a>"
+		dat += "<br><a href='?src=\ref[src];b_escapable=\ref[selected]'>Belly Interactions ([selected.escapable ? "On" : "Off"])</a>"
+		if(selected.escapable)
+			dat += "<a href='?src=\ref[src];show_int=\ref[selected]'>[show_interacts ? "Hide" : "Show"]</a>"
 
-		dat += "<br><a href='?src=\ref[src];b_escapechance=\ref[selected]'>Set Belly Escape Chance</a>"
+		if(show_interacts && selected.escapable)
+			dat += "<HR>"
+			dat += "Interaction Settings <a href='?src=\ref[src];int_help=\ref[selected]'>?</a>"
+			dat += "<br><a href='?src=\ref[src];b_escapechance=\ref[selected]'>Set Belly Escape Chance</a>"
+			dat += " [selected.escapechance]%"
 
-		dat += "<br><a href='?src=\ref[src];b_transferchance=\ref[selected]'>Set Belly Transfer Chance</a>"
+			dat += "<br><a href='?src=\ref[src];b_escapetime=\ref[selected]'>Set Belly Escape Time</a>"
+			dat += " [selected.escapetime/10]s"
 
-		dat += "<br><a href='?src=\ref[src];b_transferlocation=\ref[selected]'>Set Belly Transfer Location</a>"
-		dat += " [selected.transferlocation]"
+			//Special <br> here to add a gap
+			dat += "<br style='line-height:5px;'>"
+			dat += "<br><a href='?src=\ref[src];b_transferchance=\ref[selected]'>Set Belly Transfer Chance</a>"
+			dat += " [selected.transferchance]%"
 
-		dat += "<br><a href='?src=\ref[src];b_absorbchance=\ref[selected]'>Set Belly Absorb Chance</a>"
+			dat += "<br><a href='?src=\ref[src];b_transferlocation=\ref[selected]'>Set Belly Transfer Location</a>"
+			dat += " [selected.transferlocation ? selected.transferlocation : "Disabled"]"
 
-		dat += "<br><a href='?src=\ref[src];b_digestchance=\ref[selected]'>Set Belly Digest Chance</a>"
+			//Special <br> here to add a gap
+			dat += "<br style='line-height:5px;'>"
+			dat += "<br><a href='?src=\ref[src];b_absorbchance=\ref[selected]'>Set Belly Absorb Chance</a>"
+			dat += " [selected.absorbchance]%"
 
-		dat += "<br><a href='?src=\ref[src];b_escapetime=\ref[selected]'>Set Belly Escape Time</a>"
+			dat += "<br><a href='?src=\ref[src];b_digestchance=\ref[selected]'>Set Belly Digest Chance</a>"
+			dat += " [selected.digestchance]%"
+			dat += "<HR>"
 
 		//Delete button
 		dat += "<br><a style='background:#990000;' href='?src=\ref[src];b_del=\ref[selected]'>Delete Belly</a>"
@@ -213,9 +234,23 @@
 		del(src)  // Cleanup
 		return
 
+	if(href_list["show_int"])
+		show_interacts = !show_interacts
+		return 1 //Force update
+
+	if(href_list["int_help"])
+		alert("These control how your belly responds to someone using 'resist' while inside you. The percent chance to trigger each is listed below, \
+				and you can change them to whatever you see fit. Setting them to 0% will disable the possibility of that interaction. \
+				These only function as long as interactions are turned on in general. Keep in mind, the 'belly mode' interactions (digest/absorb) \
+				will affect all prey in that belly, if one resists and triggers digestion/absorption. If multiple trigger at the same time, \
+				only the first in the order of 'Escape > Transfer > Absorb > Digest' will occur.","Interactions Help")
+		return 0 //Force update
+
 	if(href_list["outsidepick"])
-		var/tgt = locate(href_list["outsidepick"])
+		var/atom/movable/tgt = locate(href_list["outsidepick"])
 		var/datum/belly/OB = locate(href_list["outsidebelly"])
+		if(!(tgt in OB.internal_contents)) //Aren't here anymore, need to update menu.
+			return 1
 		var/intent = "Examine"
 
 		if(istype(tgt,/mob/living))
@@ -290,12 +325,12 @@
 			intent = alert("Eject all, Move all?","Query","Eject all","Cancel","Move all")
 			switch(intent)
 				if("Cancel")
-					return 1
+					return 0
 
 				if("Eject all")
 					if(user.stat)
 						user << "<span class='warning'>You can't do that in your state!</span>"
-						return 1
+						return 0
 
 					selected.release_all_contents()
 					playsound(user, 'sound/effects/splat.ogg', 50, 1)
@@ -303,12 +338,12 @@
 				if("Move all")
 					if(user.stat)
 						user << "<span class='warning'>You can't do that in your state!</span>"
-						return 1
+						return 0
 
 					var/choice = input("Move all where?","Select Belly") in user.vore_organs + "Cancel - Don't Move"
 
 					if(choice == "Cancel - Don't Move")
-						return 1
+						return 0
 					else
 						var/datum/belly/B = user.vore_organs[choice]
 						for(var/atom/movable/tgt in selected.internal_contents)
@@ -321,10 +356,10 @@
 
 						for(var/mob/hearer in range(1,user))
 							hearer << sound('sound/vore/squish2.ogg',volume=80)
-			return 1
-
 
 		var/atom/movable/tgt = locate(href_list["insidepick"])
+		if(!(tgt in selected.internal_contents)) //Old menu, needs updating because they aren't really there.
+			return 1 //Forces update
 		intent = "Examine"
 		intent = alert("Examine, Eject, Move? Examine if you want to leave this box.","Query","Examine","Eject","Move")
 		switch(intent)
@@ -334,7 +369,7 @@
 			if("Eject")
 				if(user.stat)
 					user << "<span class='warning'>You can't do that in your state!</span>"
-					return 1
+					return 0
 
 				selected.release_specific_contents(tgt)
 				playsound(user, 'sound/effects/splat.ogg', 50, 1)
@@ -342,12 +377,12 @@
 			if("Move")
 				if(user.stat)
 					user << "<span class='warning'>You can't do that in your state!</span>"
-					return 1
+					return 0
 
 				var/choice = input("Move [tgt] where?","Select Belly") in user.vore_organs + "Cancel - Don't Move"
 
 				if(choice == "Cancel - Don't Move")
-					return 1
+					return 0
 				else
 					var/datum/belly/B = user.vore_organs[choice]
 					if (!(tgt in selected.internal_contents))
@@ -360,16 +395,16 @@
 						hearer << sound('sound/vore/squish2.ogg',volume=80)
 
 	if(href_list["newbelly"])
-		if(user.vore_organs.len >= 20)
-			return 1
+		if(user.vore_organs.len >= BELLIES_MAX)
+			return 0
 
 		var/new_name = html_encode(input(usr,"New belly's name:","New Belly") as text|null)
 
-		if(length(new_name) > 12 || length(new_name) < 2)
-			usr << "<span class='warning'>Entered belly name is too long.</span>"
+		if(length(new_name) > BELLIES_NAME_MAX || length(new_name) < BELLIES_NAME_MIN)
+			alert("Entered belly name length invalid (must be longer than [BELLIES_NAME_MIN], no more than than [BELLIES_NAME_MAX]).","Error")
 			return 0
 		if(new_name in user.vore_organs)
-			usr << "<span class='warning'>No duplicate belly names, please.</span>"
+			alert("No duplicate belly names, please.","Error")
 			return 0
 
 		var/datum/belly/NB = new(user)
@@ -381,14 +416,17 @@
 		selected = locate(href_list["bellypick"])
 		user.vore_selected = selected.name
 
+	////
+	//Please keep these the same order they are on the panel UI for ease of coding
+	////
 	if(href_list["b_name"])
 		var/new_name = html_encode(input(usr,"Belly's new name:","New Name") as text|null)
 
-		if(length(new_name) > 12 || length(new_name) < 2)
-			usr << "<span class='warning'>Entered belly name length invalid (must be longer than 2, shorter than 12).</span>"
+		if(length(new_name) > BELLIES_NAME_MAX || length(new_name) < BELLIES_NAME_MIN)
+			alert("Entered belly name length invalid (must be longer than [BELLIES_NAME_MIN], no more than than [BELLIES_NAME_MAX]).","Error")
 			return 0
 		if(new_name in user.vore_organs)
-			usr << "<span class='warning'>No duplicate belly names, please.</span>"
+			alert("No duplicate belly names, please.","Error")
 			return 0
 
 		user.vore_organs[new_name] = selected
@@ -401,7 +439,7 @@
 			menu_list += selected.transform_modes
 
 		if(selected.digest_modes.len == 1) // Don't do anything
-			return 1
+			return 0
 		if(selected.digest_modes.len == 2) // Just toggle... there's probably a more elegant way to do this...
 			var/index = selected.digest_modes.Find(selected.digest_mode)
 			switch(index)
@@ -417,8 +455,8 @@
 
 		if(new_desc)
 			new_desc = readd_quotes(new_desc)
-			if(length(new_desc) > 1024)
-				usr << "<span class='warning'>Entered belly desc too long. 1024 character limit.</span>"
+			if(length(new_desc) > BELLIES_DESC_MAX)
+				alert("Entered belly desc too long. [BELLIES_DESC_MAX] character limit.","Error")
 				return 0
 			selected.inside_flavor = new_desc
 		else //Returned null
@@ -474,13 +512,13 @@
 					selected.struggle_messages_inside = initial(selected.struggle_messages_inside)
 
 			if("Cancel - No Changes")
-				return 1
+				return 0
 
 	if(href_list["b_verb"])
 		var/new_verb = html_encode(input(usr,"New verb when eating (infinitive tense, e.g. nom or swallow):","New Verb") as text|null)
 
-		if(length(new_verb) > 12 || length(new_verb) < 2)
-			usr << "<span class='warning'>Entered verb length invalid (must be longer than 2, shorter than 12).</span>"
+		if(length(new_verb) > BELLIES_NAME_MAX || length(new_verb) < BELLIES_NAME_MIN)
+			alert("Entered verb length invalid (must be longer than [BELLIES_NAME_MIN], no longer than [BELLIES_NAME_MAX]).","Error")
 			return 0
 
 		selected.vore_verb = new_verb
@@ -489,9 +527,12 @@
 		var/choice = input(user,"Currently set to [selected.vore_sound]","Select Sound") in vore_sounds + "Cancel - No Changes"
 
 		if(choice == "Cancel")
-			return 1
+			return 0
 
 		selected.vore_sound = vore_sounds[choice]
+
+	if(href_list["b_soundtest"])
+		user << selected.vore_sound
 
 	if(href_list["b_escapable"])
 		if(selected.escapable == 0) //Possibly escapable and special interactions.
@@ -500,75 +541,67 @@
 		else if(selected.escapable == 1) //Never escapable.
 			selected.escapable = 0
 			usr << "<span class='warning'>Prey will not be able to have special interactions with your [selected.name].</span>"
+			show_interacts = 0 //Force the hiding of the panel
 		else
-			usr << "<span class='warning'>Something went wrong. Your stomach will now not have special interactions. Press the button enable them again.</span>" //If they somehow have a varable that's not 0 or 1
+			alert("Something went wrong. Your stomach will now not have special interactions. Press the button enable them again and tell a dev.","Error") //If they somehow have a varable that's not 0 or 1
 			selected.escapable = 0
+			show_interacts = 0 //Force the hiding of the panel
 
 	if(href_list["b_escapechance"])
-		var/escape_chance_input = input(user, "Choose the (%) chance that prey that attempt to escape will be able to escape.\
-			Stomach special interactions must be enabled for this to work.\
-			Ranges from -1(disabled) to 100.\n\
-			(-1-100)", "Prey Escape Chance") as num|null
-		if(escape_chance_input)
-			escape_chance_input = round(text2num(escape_chance_input),4)
-			selected.escapechance = sanitize_integer(escape_chance_input, 0, 100, selected.escapechance)
-
-	if(href_list["b_absorbchance"])
-		var/absorb_chance_input = input(user, "Choose the (%) chance that prey that attempt to escape will be absorbed into your [selected.name].\
-			 Stomach special interactions must be enabled for this to work.\
-			 Ranges from -1(disabled) to 100.\n\
-			(-1-100)", "Prey Absorb Chance") as num|null
-		if(absorb_chance_input)
-			absorb_chance_input = round(text2num(absorb_chance_input),4)
-			selected.absorbchance = sanitize_integer(absorb_chance_input, 0, 100, selected.absorbchance)
-
-	if(href_list["b_digestchance"])
-		var/digest_chance_input = input(user, "Choose the (%) chance that prey that attempt to escape will begin to digest inside of your [selected.name].\
-			 Stomach special interactions must be enabled for this to work.\
-			 Ranges from -1(disabled) to 100.\n\
-			(-1-100)", "Prey Digest Chance") as num|null
-		if(digest_chance_input)
-			digest_chance_input = round(text2num(digest_chance_input),4)
-			selected.digestchance = sanitize_integer(digest_chance_input, 0, 100, selected.digestchance)
+		var/escape_chance_input = input(user, "Set prey escape chance on resist (as %)", "Prey Escape Chance") as num|null
+		if(!isnull(escape_chance_input)) //These have to be 'null' because both cancel and 0 are valid, separate options
+			selected.escapechance = sanitize_integer(escape_chance_input, 0, 100, initial(selected.escapechance))
 
 	if(href_list["b_escapetime"])
-		var/escape_time_input = input(user, "Choose the amount of time it will take for prey to be able to escape.\
-			 Stomach special interactions must be enabled for this to effect anything, along with the escape chance\
-			 Ranges from 10 to 600.(10 = 1 second, 600 = 60 seconds)\n\
-			(10-600)", "Prey Escape Time") as num|null
-		if(escape_time_input)
-			escape_time_input = round(text2num(escape_time_input),4)
-			selected.escapetime = sanitize_integer(escape_time_input, 9, 600, selected.escapetime) //Set to 9 to stop rounding problems.
+		var/escape_time_input = input(user, "Set number of seconds for prey to escape on resist (1-60)", "Prey Escape Time") as num|null
+		if(!isnull(escape_time_input))
+			selected.escapetime = sanitize_integer(escape_time_input*10, 10, 600, initial(selected.escapetime))
 
 	if(href_list["b_transferchance"])
-		var/transfer_chance_input = input(user, "Choose the chance that that prey will be dropped off if they attempt to struggle.\
-			 Stomach special interactions must be enabled for this to effect anything, along with a transfer location set\
-			 Ranges from -1(disabled) to 100.\n\
-			(-1-100)", "Prey Escape Time") as num|null
-		if(transfer_chance_input)
-			transfer_chance_input = round(text2num(transfer_chance_input),4)
-			selected.transferchance = sanitize_integer(transfer_chance_input, 9, 600, selected.transferchance) //Set to 9 to stop rounding problems.
+		var/transfer_chance_input = input(user, "Set belly transfer chance on resist (as %). You must also set the location for this to have any effect.", "Prey Escape Time") as num|null
+		if(!isnull(transfer_chance_input))
+			selected.transferchance = sanitize_integer(transfer_chance_input, 0, 100, initial(selected.transferchance))
 
 	if(href_list["b_transferlocation"])
-		var/choice = input("Where do you want your [selected.name] to lead if prey struggles??","Select Belly") in user.vore_organs + "Cancel - None - Remove"
+		var/choice = input("Where do you want your [selected.name] to lead if prey resists?","Select Belly") as null|anything in (user.vore_organs + "None - Remove" - selected.name)
 
-		if(choice == "Cancel - None - Remove")
+		if(!choice) //They cancelled, no changes
+			return 0
+		else if(choice == "None - Remove")
 			selected.transferlocation = null
-			return 1
 		else
 			selected.transferlocation = user.vore_organs[choice]
-			usr << "<span class='warning'>Note: Do not delete your [choice] while this is enabled. This will cause your prey to be unable to escape. If you want to delete your [choice], select Cancel - None - Remove and then delete it.</span>"
 
-	if(href_list["b_soundtest"])
-		user << selected.vore_sound
+	if(href_list["b_absorbchance"])
+		var/absorb_chance_input = input(user, "Set belly absorb mode chance on resist (as %)", "Prey Absorb Chance") as num|null
+		if(!isnull(absorb_chance_input))
+			selected.absorbchance = sanitize_integer(absorb_chance_input, 0, 100, initial(selected.absorbchance))
+
+	if(href_list["b_digestchance"])
+		var/digest_chance_input = input(user, "Set belly digest mode chance on resist (as %)", "Prey Digest Chance") as num|null
+		if(!isnull(digest_chance_input))
+			selected.digestchance = sanitize_integer(digest_chance_input, 0, 100, initial(selected.digestchance))
 
 	if(href_list["b_del"])
-		if(selected.internal_contents.len)
-			usr << "<span class='warning'>Can't delete bellies with contents!</span>"
+		var/dest_for = 0 //Check to see if it's the destination of another vore organ.
+		for(var/I in user.vore_organs)
+			var/datum/belly/B = user.vore_organs[I]
+			if(B.transferlocation == selected)
+				dest_for = B.name
+				break
+
+		if(dest_for)
+			alert("This is the destiantion for at least '[dest_for]' belly transfers. Remove it as the destination from any bellies before deleting it.","Error")
+			return 1
+		else if(selected.internal_contents.len)
+			alert("Can't delete bellies with contents!","Error")
+			return 1
 		else if(selected.immutable)
-			usr << "<span class='warning'>This belly is marked as undeletable.</span>"
+			alert("This belly is marked as undeletable.","Error")
+			return 1
 		else if(user.vore_organs.len == 1)
-			usr << "<span class='warning'>You must have at least one belly.</span>"
+			alert("You must have at least one belly.","Error")
+			return 1
 		else
 			var/alert = alert("Are you sure you want to delete [selected]?","Confirmation","Delete","Cancel")
 			if(alert == "Delete" && !selected.internal_contents.len)
@@ -580,7 +613,7 @@
 
 	if(href_list["saveprefs"])
 		if(!user.save_vore_prefs())
-			user << "<span class='warning'>ERROR: Virgo-specific preferences failed to save!</span>"
+			alert("ERROR: Virgo-specific preferences failed to save!","Error")
 		else
 			user << "<span class='notice'>Virgo-specific preferences saved!</span>"
 
@@ -588,7 +621,7 @@
 		var/choice = alert(user, "This button is for those who don't like being digested. It can make you undigestable. Don't abuse this button by toggling it back and forth to extend a scene or whatever, or you'll make the admins cry. Digesting you is currently: [user.digestable ? "Allowed" : "Prevented"]", "", "Allow Digestion", "Cancel", "Prevent Digestion")
 		switch(choice)
 			if("Cancel")
-				return 1
+				return 0
 			if("Allow Digestion")
 				user.digestable = 1
 			if("Prevent Digestion")

--- a/code/modules/vore/eating/vorepanel_vr.dm
+++ b/code/modules/vore/eating/vorepanel_vr.dm
@@ -304,6 +304,9 @@
 
 		else if(istype(tgt,/obj/item))
 			var/obj/item/T = tgt
+			if(!(tgt in OB.internal_contents))
+				//Doesn't exist anymore, update.
+				return 1
 			intent = alert("What do you want to do to that?","Query","Examine","Use Hand")
 			switch(intent)
 				if("Examine")


### PR DESCRIPTION
- Redid belly interactions into a hide-able section to keep it nice and clean.
- Changed most 'error' messages into modal alert boxes to make it obvious.
- Remade name/desc/bellycount rules into defines at the start of the file.
- Fixed transfer problems as far as I can tell (Fixes #1063 Fixes #763)
- Can't delete transfer location bellies. Notifies you what points at it and tells you to change it first.
- Get rid of the -1% thing. Just set it to 0% if you don't want it to happen.
- Added a little '?' help button for general interaction info.
- Fixed some exploitable behavior (doing things to people who had already left bellies).

https://gyazo.com/b8fb247c0ac101753795a400d61240d0