### PR TITLE
Fixes a couple of tail issues

### DIFF
--- a/code/modules/vore/appearance/sprite_accessories_vr.dm
+++ b/code/modules/vore/appearance/sprite_accessories_vr.dm
@@ -307,6 +307,7 @@
 	desc = ""
 	icon_state = "moth"
 	do_colouration = 1
+	color_blend_mode = ICON_MULTIPLY
 
 /datum/sprite_accessory/tail/moth
 	name = "moth wings"
@@ -511,6 +512,7 @@
 	icon_state = "feathered"
 	show_species_tail = 1
 	do_colouration = 1
+	color_blend_mode = ICON_MULTIPLY
 
 /datum/sprite_accessory/tail/redpanda
 	name = "red panda"


### PR DESCRIPTION
The Feathered Wings and Moth Wings have white sprites but were using COLOR_ADD, which just doesn't work. This PR changes them to use COLOR_MULTIPLY which does work.

People who have either of those used with a color set may have to adjust their color, due to color being properly and fully applied now.