### PR TITLE
Prevent resleever attack messages

### DIFF
--- a/code/modules/resleeving/machines.dm
+++ b/code/modules/resleeving/machines.dm
@@ -434,7 +434,9 @@
 		var/mob/M = G.affecting
 		if(put_mob(M))
 			qdel(G)
-	src.updateUsrDialog()
+			src.updateUsrDialog()
+			return //Don't call up else we'll get attack messsages
+
 	return ..()
 
 /obj/machinery/transhuman/resleever/proc/putmind(var/datum/transhuman/mind_record/MR)


### PR DESCRIPTION
Don't call ..() when attacked by grabs.

Fixes #1033 