### PR TITLE
add *flip

### DIFF
--- a/code/modules/mob/living/carbon/human/emote_vr.dm
+++ b/code/modules/mob/living/carbon/human/emote_vr.dm
@@ -8,9 +8,15 @@
 			message = "awoos loudly. AwoooOOOOoooo!"
 			m_type = 2
 
+		if ("flip")
+			if(!src.sleeping || !src.resting || !src.buckled || !src.restrained())
+				src.SpinAnimation(7,1)
+			m_type = 1
+
 	if (message)
 		log_emote("[name]/[key] : [message]")
 		custom_emote(m_type,message)
 		return 1
 
 	return 0
+


### PR DESCRIPTION
Adds flipping to emotes. Glory be customs.

 Hold in 'Z', pull the analog stick toward you and press 'A'

It won't ever go out of style.

![knowitallbrotheroot](https://cloud.githubusercontent.com/assets/6293118/23578228/990973d2-0097-11e7-8ce1-4ebf1be2d571.png)
