### PR TITLE
Remove a world.log reference

### DIFF
--- a/code/modules/mob/living/carbon/human/emote_vr.dm
+++ b/code/modules/mob/living/carbon/human/emote_vr.dm
@@ -29,7 +29,6 @@
 				message = "does a flip!"
 				m_type = 1
 
-				world.log << "[src] *flip with danger [danger]%"
 				if(prob(danger))
 					spawn(10) //Stick the landing.
 						var/breaking = pick(involved_parts)


### PR DESCRIPTION
Left this in. Wouldn't have printed to anyone since it's world.log not world, but still shouldn't be there.