### PR TITLE
Makes nanopaste useful externally

### DIFF
--- a/code/game/objects/items/stacks/nanopaste.dm
+++ b/code/game/objects/items/stacks/nanopaste.dm
@@ -38,3 +38,7 @@
 					use(1)
 					user.visible_message("<span class='notice'>\The [user] applies some nanite paste on [user != M ? "[M]'s [S.name]" : "[S]"] with [src].</span>",\
 					"<span class='notice'>You apply some nanite paste on [user == M ? "your" : "[M]'s"] [S.name].</span>")
+		//VOREStation Add - External robolimb repair with nanopaste
+		else if(S && (S.robotic >= ORGAN_ROBOT))
+			S.robo_repair(5, "omni", "some damage", src, user)
+		//VOREStation Add End

--- a/code/game/objects/items/stacks/nanopaste.dm
+++ b/code/game/objects/items/stacks/nanopaste.dm
@@ -40,5 +40,6 @@
 					"<span class='notice'>You apply some nanite paste on [user == M ? "your" : "[M]'s"] [S.name].</span>")
 		//VOREStation Add - External robolimb repair with nanopaste
 		else if(S && (S.robotic >= ORGAN_ROBOT))
-			S.robo_repair(5, "omni", "some damage", src, user)
+			if(S.robo_repair(5, "omni", "some damage", src, user))
+				use(1)
 		//VOREStation Add End


### PR DESCRIPTION
Welders and wires repair 15 of brute and burn respectively, this only repairs 5 of both. So you can do it a lot faster with a welder/wires, but you can carry a nanopaste with you to fix that time you hit yourself with a box or something. Quick fieldwork w/o goggles and such.

Fixes #1105