### PR TITLE
Resleeving tweaks, fix compile warning

### DIFF
--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -440,9 +440,13 @@
 			qdel(O)
 
 	//VOREStation Edit - Resleeving.
-	if(to_despawn.mind && (to_despawn.mind.name in transcore.backed_up))
-		var/datum/transhuman/mind_record/MR = transcore.backed_up[to_despawn.mind.name]
-		transcore.stop_backup(MR)
+	if(to_despawn.mind)
+		if(to_despawn.mind.name in transcore.backed_up)
+			var/datum/transhuman/mind_record/MR = transcore.backed_up[to_despawn.mind.name]
+			transcore.stop_backup(MR)
+		if(to_despawn.mind.name in transcore.body_scans) //This uses mind names to avoid people cryo'ing a printed body to delete body scans.
+			var/datum/transhuman/body_record/BR = transcore.body_scans[to_despawn.mind.name]
+			transcore.remove_body(BR)
 	//VOREStation Edit End - Resleeving.
 
 	//Handle job slot/tater cleanup.

--- a/code/modules/integrated_electronics/subtypes/reagents.dm
+++ b/code/modules/integrated_electronics/subtypes/reagents.dm
@@ -73,7 +73,7 @@
 				return
 			var/contained = reagents.get_reagents()
 			var/trans = reagents.trans_to_mob(target, inject_amount(), CHEM_BLOOD)
-			//message_admins("[src] injected \the [AM] with [trans]u of [contained].") //VOREStation Edit - I don't care THAT much.
+			log_debug("[src] injected \the [AM] with [trans]u of [contained].") //VOREStation Edit - I don't care THAT much.
 			to_chat(AM, "<span class='notice'>You feel a tiny prick!</span>")
 			visible_message("<span class='warning'>[src] injects [AM]!</span>")
 		else

--- a/code/modules/resleeving/computers.dm
+++ b/code/modules/resleeving/computers.dm
@@ -165,7 +165,8 @@
 									"gender" = active_br.bodygender, \
 									"synthetic" = active_br.synthetic ? "Yes" : "No", \
 									"locked" = active_br.locked ? "Low" : "High", \
-									"cando" = can_grow_active)
+									"cando" = can_grow_active,
+									"booc" = active_br.body_oocnotes)
 	else
 		data["activeRecord"] = null
 
@@ -175,7 +176,8 @@
 			can_sleeve_current = 0
 		data["activeMindRecord"] = list("charname" = active_mr.mindname, \
 										"obviously_dead" = active_mr.dead_state == MR_DEAD ? "Past-due" : "Current", \
-										"cando" = can_sleeve_current)
+										"cando" = can_sleeve_current,
+										"mooc" = active_mr.mind_oocnotes)
 	else
 		data["activeMindRecord"] = null
 
@@ -214,6 +216,12 @@
 		else
 			active_mr = null
 			temp = "ERROR: Record missing."
+
+	else if (href_list["boocnotes"])
+		menu = 6
+
+	else if (href_list["moocnotes"])
+		menu = 7
 
 	else if (href_list["refresh"])
 		updateUsrDialog()

--- a/code/modules/resleeving/infocore.dm
+++ b/code/modules/resleeving/infocore.dm
@@ -64,6 +64,7 @@ var/datum/transhuman/infocore/transcore = new/datum/transhuman/infocore
 /datum/transhuman/infocore/proc/add_backup(var/datum/transhuman/mind_record/MR)
 	ASSERT(MR)
 	backed_up[MR.mindname] = MR
+	backed_up = sortAssoc(backed_up)
 	log_debug("Added [MR.mindname] to transcore DB.")
 
 /datum/transhuman/infocore/proc/stop_backup(var/datum/transhuman/mind_record/MR)
@@ -76,7 +77,13 @@ var/datum/transhuman/infocore/transcore = new/datum/transhuman/infocore
 /datum/transhuman/infocore/proc/add_body(var/datum/transhuman/body_record/BR)
 	ASSERT(BR)
 	body_scans[BR.mydna.name] = BR
+	body_scans = sortAssoc(body_scans)
 	log_debug("Added [BR.mydna.name] to transcore body DB.")
+
+/datum/transhuman/infocore/proc/remove_body(var/datum/transhuman/body_record/BR)
+	ASSERT(BR)
+	body_scans.Remove("[BR.mydna.name]")
+	log_debug("Removed [BR.mydna.name] from transcore body DB.")
 
 /datum/transhuman/infocore/proc/core_dump(var/obj/item/weapon/disk/transcore/disk)
 	ASSERT(disk)

--- a/nano/templates/sleever.tmpl
+++ b/nano/templates/sleever.tmpl
@@ -108,6 +108,10 @@
 				<div class='itemLabel'>Synthetic:</div>
 				<div class='itemContent'>{{:data.activeBodyRecord.synthetic}}</div>
 			</div>
+			<div class='item'>
+				<div class='itemLabel'>OOC Notes:</div>
+				<div class='itemContent'>{{:helper.link('View', null, {'boocnotes' : data.activeBodyRecord.booc}, data.activeBodyRecord.booc ? null : 'linkOff')}}</div>
+			</div>
 
 			{{:helper.link('Create', 'play', {'create' : data.activeBodyRecord.real_name}, data.activeBodyRecord.cando ? null : 'linkOff')}}
 			
@@ -126,13 +130,40 @@
 				<div class='itemContent'>{{:data.activeMindRecord.charname}}</div>
 			</div>
 			<div class='item'>
-				<div class='itemLabel'>Backup status:</div>
+				<div class='itemLabel'>Backup Status:</div>
 				<div class='itemContent'>{{:data.activeMindRecord.obviously_dead}}</div>
+			</div>
+			<div class='item'>
+				<div class='itemLabel'>OOC Notes:</div>
+				<div class='itemContent'>{{:helper.link('View', null, {'moocnotes' : data.activeMindRecord.mooc}, data.activeMindRecord.mooc ? null : 'linkOff')}}</div>
 			</div>
 			{{:helper.link('Sleeve', 'play', {'sleeve' : data.activeMindRecord.charname}, data.activeMindRecord.cando ? null : 'linkOff')}}
 			
 		{{else}}
 			<div class='item bad'>ERROR: Record not found.</div>
 		{{/if}}
+	
+	<!-- Menu6: Body OOC Notes -->	
+	{{else data.menu == 6}}
+		<h3>Body OOC Notes (This is OOC!)</h3>
+		<div class='item'>{{:helper.link('Back', 'arrowreturn-1-w', {'menu' : 4})}}</div>
+		{{if data.activeBodyRecord}}
+			<div class='itemLabel'>Notes:</div>
+			<div class='itemContent'>{{:data.activeBodyRecord.booc}}</div>
+		{{else}}
+			<div class='item bad'>ERROR: Record not found.</div>
+		{{/if}}
+		
+	<!-- Menu7: Mind OOC Notes -->	
+	{{else data.menu == 7}}
+		<h3>Mind OOC Notes (This is OOC!)</h3>
+		<div class='item'>{{:helper.link('Back', 'arrowreturn-1-w', {'menu' : 5})}}</div>
+		{{if data.activeMindRecord}}
+			<div class='itemLabel'>Notes:</div>
+			<div class='itemContent'>{{:data.activeMindRecord.mooc}}</div>
+		{{else}}
+			<div class='item bad'>ERROR: Record not found.</div>
+		{{/if}}
+
 	{{/if}}
 {{/if}}


### PR DESCRIPTION
Resleeving console now lists people in alphabetical order, and removes bodies when the person cryos (as long as they were really in that body, you can't cryo someone's printed body w/o resleeving and have it remove them)