### PR TITLE
adds particle guns to science and cargo

### DIFF
--- a/code/datums/supplypacks/misc_vr.dm
+++ b/code/datums/supplypacks/misc_vr.dm
@@ -1,0 +1,14 @@
+
+/datum/supply_packs/misc/beltminer
+	name = "Belt-miner gear crate"
+	contains = list(
+			/obj/item/weapon/gun/energy/particle = 2,
+			/obj/item/weapon/cell/device/weapon = 2,
+			/obj/item/weapon/storage/firstaid/regular = 1,
+			/obj/item/device/gps = 2,
+			/obj/item/weapon/storage/box/traumainjectors = 1
+			)
+	cost = 50
+	containertype = /obj/structure/closet/crate/secure/gear
+	containername = "Belt-miner gear crate"
+	access = access_mining

--- a/code/modules/projectiles/guns/energy/particle.dm
+++ b/code/modules/projectiles/guns/energy/particle.dm
@@ -1,5 +1,5 @@
 /obj/item/weapon/gun/energy/particle //base gun, similar stats to an egun
-	name = "Antiparticle projector pistol"
+	name = "Anti-particle projector pistol"
 	icon = 'icons/obj/gun_vr.dmi'
 	icon_state = "ppistol"
 	item_state = "ppistol_item"
@@ -18,27 +18,28 @@
 	slot_flags = SLOT_BELT
 	w_class = ITEMSIZE_NORMAL
 	projectile_type = /obj/item/projectile/bullet/particle
-	origin_tech = null
+	origin_tech = list(TECH_COMBAT = 3, TECH_MAGNET = 2, TECH_MATERIAL = 2)
 	fire_delay = 10
-	charge_cost = 240	//same cost as lasers
+	charge_cost = 200	//slightly more shots than lasers
 	var/safetycatch = 0 //if 1, won't let you fire in pressurised environment, rather than malfunctioning
 	var/obj/item/pressurelock/attached_safety
 
 
 /obj/item/weapon/gun/energy/particle/advanced //particle equivalent of AEG
-	name = "Advanced antiparticle rifle"
+	name = "Advanced anti-particle rifle"
 	icon_state = "particle"
 	item_state = "particle_item"
 	desc = "An antiparticle projector gun with an enhanced power-generation unit."
 	slot_flags = SLOT_BELT
 	force = 8 //looks heavier than a pistol
 	w_class = ITEMSIZE_LARGE	//bigger than a pistol, too.
+	origin_tech = list(TECH_COMBAT = 4, TECH_MATERIAL = 5, TECH_POWER = 3, TECH_MAGNET = 3)
 	fire_delay = 6	//This one's not a handgun, it should have the same fire delay as everything else
 	self_recharge = 1
 	modifystate = null
 	battery_lock = 1
-	recharge_time = 15 // every 15 ticks, recharge 2 shots. Rather slower than AEG.
-	charge_delay = 20 //Starts recharging faster after firing than an AEG, but much slower recharge rate. Balances out for a full charge.
+	recharge_time = 6 // every 6 ticks, recharge 2 shots. Slightly slower than AEG.
+	charge_delay = 10 //Starts recharging faster after firing than an AEG though.
 
 /obj/item/weapon/gun/energy/particle/cannon //particle version of laser cannon
 	name = "Anti-particle cannon"
@@ -47,17 +48,18 @@
 	item_state = "heavyparticle_item"
 	fire_sound = 'sound/weapons/lasercannonfire.ogg'
 	slot_flags = SLOT_BACK
+	origin_tech = list(TECH_COMBAT = 5, TECH_MATERIAL = 5, TECH_POWER = 4, TECH_MAGNET = 4)
 	projectile_type = /obj/item/projectile/bullet/particle/heavy
 	battery_lock = 1
-	fire_delay = 20
+	fire_delay = 15 // fires faster than a laser cannon. c'mon, it's an awesome-but-impractical endgame gun.
 	w_class = ITEMSIZE_HUGE // So it can't fit in a backpack.
 	force = 10
-	one_handed_penalty = 6 // The thing's heavy and huge.
+	one_handed_penalty = 8 // The thing's heavy and huge.
 	accuracy = 3
-	charge_cost = 480 // 5 shots
+	charge_cost = 400 // 6 shots
 	self_recharge = 1
-	charge_delay = 20 //won't start charging until it's ready to fire again
-	recharge_time = 20 //100 ticks after that to refill the whole thing.
+	charge_delay = 15 //won't start charging until it's ready to fire again
+	recharge_time = 8 //40 ticks after that to refill the whole thing.
 
 //special behaviours for particle guns below
 
@@ -161,7 +163,7 @@
 	icon_state = "pressurelock"
 	desc = "A safety interlock that can be installed in an antiparticle projector. It prevents the weapon from discharging in pressurised environments."
 	w_class = ITEMSIZE_TINY
-
+	origin_tech = list(TECH_COMBAT = 2, TECH_MATERIAL = 2, TECH_ENGINEERING = 2)
 
 // projectiles below
 

--- a/code/modules/reagents/reagent_containers/hypospray_vr.dm
+++ b/code/modules/reagents/reagent_containers/hypospray_vr.dm
@@ -48,3 +48,29 @@
 			user << "<span class='notice'>\The [src] already has a vial.</span>"
 	else
 		..()
+
+/obj/item/weapon/reagent_containers/hypospray/autoinjector/beltminer
+	name = "Emergency trauma injector"
+	desc = "A rapid injector for emergency treatment of injuries. The warning label advises that it is not a substitute for proper medical treatment."
+	icon_state = "autoinjector"
+	item_state = "autoinjector"
+	amount_per_transfer_from_this = 10
+	volume = 10
+
+/obj/item/weapon/reagent_containers/hypospray/autoinjector/beltminer/New()
+	..()
+	reagents.add_reagent("bicaridine", 5)
+	reagents.add_reagent("tricordrazine", 3)
+	reagents.add_reagent("tramadol", 2)
+	update_icon()
+	return
+
+/obj/item/weapon/storage/box/traumainjectors
+	name = "box of emergency trauma injectors"
+	desc = "Contains emergency trauma autoinjectors."
+	icon_state = "syringe"
+
+/obj/item/weapon/storage/box/traumainjectors/New()
+	..()
+	for (var/i = 1 to 7)
+		new /obj/item/weapon/reagent_containers/hypospray/autoinjector/beltminer(src)

--- a/code/modules/research/designs_vr.dm
+++ b/code/modules/research/designs_vr.dm
@@ -29,6 +29,30 @@
 	build_path = /obj/item/weapon/gun/energy/sizegun
 	sort_string = "TAAAB"
 
+/datum/design/item/item/pressureinterlock
+	name = "APP pressure interlock"
+	id = "pressureinterlock"
+	req_tech = list(TECH_COMBAT = 2, TECH_MATERIAL = 2, TECH_ENGINEERING = 2)
+	materials = list(DEFAULT_WALL_MATERIAL = 1000, "glass" = 250)
+	build_path = /obj/item/pressurelock
+	sort_string = "TAADA"
+
+/datum/design/item/weapon/advparticle
+	name = "Advanced anti-particle rifle"
+	id = "advparticle"
+	req_tech = list(TECH_COMBAT = 4, TECH_MATERIAL = 5, TECH_POWER = 3, TECH_MAGNET = 3)
+	materials = list(DEFAULT_WALL_MATERIAL = 5000, "glass" = 1000, "gold" = 1000, "uranium" = 750)
+	build_path = /obj/item/weapon/gun/energy/particle/advanced
+	sort_string = "TAADB"
+
+/datum/design/item/weapon/particlecannon
+	name = "Anti-particle cannon"
+	id = "particlecannon"
+	req_tech = list(TECH_COMBAT = 5, TECH_MATERIAL = 5, TECH_POWER = 4, TECH_MAGNET = 4)
+	materials = list(DEFAULT_WALL_MATERIAL = 10000, "glass" = 1500, "gold" = 2000, "uranium" = 1000, "diamond" = 2000)
+	build_path = /obj/item/weapon/gun/energy/particle/cannon
+	sort_string = "TAADC"
+
 /datum/design/item/hud/omni
 	name = "AR glasses"
 	id = "omnihud"

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -234,6 +234,7 @@
 #include "code\datums\supplypacks\materials.dm"
 #include "code\datums\supplypacks\medical.dm"
 #include "code\datums\supplypacks\misc.dm"
+#include "code\datums\supplypacks\misc_vr.dm"
 #include "code\datums\supplypacks\munitions.dm"
 #include "code\datums\supplypacks\recreation.dm"
 #include "code\datums\supplypacks\robotics.dm"


### PR DESCRIPTION
The advanced anti-particle gun and anti-particle cannon have been given origin techs and added to R&D.
They're both more expensive and require more tech than their AEG/lasercannon counterparts, as per their "cool but impractical" motif.
The safety interlock has also been added to stop them attempting to fire in atmo _if you're a pussy_.

The guns have been given a slight buff in terms of ammo capacity and charge rate to give players a reason to _ever_ take them instead of a laser for fighting mobs in the belt. The cannon is now outright better than the laser version, or it would be if not for the "can't shoot through glass" and "tendency to explode" features, along with being feckin huge.

Basic particle guns have been added to cargo in the "miscellaneous" section as I didn't see anywhere better for a mining gear crate. They come with some extra cells, a couple of GPSs, and a first aid kit with some spare injectors loaded with bicaridine as _most_ of the mobs they'll encounter deal brute.

Most of the numbers here were entirely pulled out of my backside and are subject to change if things are too hard / too easy to produce.

Resolves #967 