### PR TITLE
Allow MMI/Posi/Digi brains w/o minds to be put in bodies

### DIFF
--- a/code/modules/surgery/robotics.dm
+++ b/code/modules/surgery/robotics.dm
@@ -381,11 +381,11 @@
 
 		if(!istype(M))
 			return 0
-
+		/* VOREStation Edit - Don't worry about it. We can put these in regardless, because resleeving might make it useful after.
 		if(!M.brainmob || !M.brainmob.client || !M.brainmob.ckey || M.brainmob.stat >= DEAD)
 			user << "<span class='danger'>That brain is not usable.</span>"
 			return SURGERY_FAILURE
-
+		*/
 		if(!(affected.robotic >= ORGAN_ROBOT))
 			user << "<span class='danger'>You cannot install a computer brain into a meat skull.</span>"
 			return SURGERY_FAILURE


### PR DESCRIPTION
Right now if you try to put an empty posibrain into a mob it won't let you. But with resleeving, this might be just the step before putting a mind in them, so that's sort of not how it should work. When it was just a ghost-trap object that ghosts could get into, maybe, but it's moved beyond that.