### PR TITLE
Add vore taste system

### DIFF
--- a/code/modules/vore/eating/belly_vr.dm
+++ b/code/modules/vore/eating/belly_vr.dm
@@ -26,6 +26,7 @@
 	var/absorbchance = 0					// % Chance of stomach beginning to absorb if prey struggles
 	var/escapechance = 0 					// % Chance of prey beginning to escape if prey struggles.
 	var/transferchance = 0 					// % Chance of prey being
+	var/can_taste = 0						// If this belly prints the flavor of prey when it eats someone.
 	var/datum/belly/transferlocation = null	// Location that the prey is released if they struggle and get dropped off.
 
 	var/tmp/digest_mode = DM_HOLD				// Whether or not to digest. Default to not digest.
@@ -452,6 +453,7 @@
 	dupe.digest_burn = digest_burn
 	dupe.digest_tickrate = digest_tickrate
 	dupe.immutable = immutable
+	dupe.can_taste = can_taste
 	dupe.escapable = escapable
 	dupe.escapetime = escapetime
 	dupe.digestchance = digestchance

--- a/code/modules/vore/eating/living_vr.dm
+++ b/code/modules/vore/eating/living_vr.dm
@@ -7,10 +7,11 @@
 	var/weight = 137					// Weight for mobs for weightgain system
 	var/weight_gain = 1 				// How fast you gain weight
 	var/weight_loss = 0.5 				// How fast you lose weight
-	var/egg_type = "egg" 					// Default egg type.
+	var/egg_type = "egg" 				// Default egg type.
 	var/feral = 0 						// How feral the mob is, if at all. Does nothing for non xenochimera at the moment.
 	var/reviving = 0					// Only used for creatures that have the xenochimera regen ability, so far.
 	var/metabolism = 0.0015
+	var/vore_taste = null				// What the character tastes like
 
 //
 // Hook for generic creation of stuff on new creatures
@@ -18,6 +19,7 @@
 /hook/living_new/proc/vore_setup(mob/living/M)
 	M.verbs += /mob/living/proc/insidePanel
 	M.verbs += /mob/living/proc/escapeOOC
+	M.verbs += /mob/living/proc/lick
 
 	//Tries to load prefs if a client is present otherwise gives freebie stomach
 	if(!M.vore_organs || !M.vore_organs.len)
@@ -38,6 +40,7 @@
 				B.immutable = 1
 				B.name = "Stomach"
 				B.inside_flavor = "It appears to be rather warm and wet. Makes sense, considering it's inside \the [M.name]."
+				B.can_taste = 1
 				M.vore_organs[B.name] = B
 				M.vore_selected = B.name
 
@@ -218,6 +221,7 @@
 
 	P.digestable = src.digestable
 	P.belly_prefs = src.vore_organs
+	P.vore_taste = src.vore_taste
 
 	return 1
 
@@ -233,12 +237,45 @@
 
 	src.digestable = P.digestable
 	src.vore_organs = list()
+	src.vore_taste = P.vore_taste
 
 	for(var/I in P.belly_prefs)
 		var/datum/belly/Bp = P.belly_prefs[I]
 		src.vore_organs[Bp.name] = Bp.copy(src)
 
 	return 1
+
+//
+// Clearly super important. Obviously.
+//
+/mob/living/proc/lick(var/mob/living/tasted in oview(1))
+	set name = "Lick Someone"
+	set category = "IC"
+	set desc = "Lick someone nearby!"
+
+	if(!istype(tasted))
+		return
+
+	if(src.sleeping || src.resting || src.weakened || src.stat >= DEAD)
+		return
+
+	var/taste_message = ""
+	if(tasted.vore_taste && (tasted.vore_taste != ""))
+		taste_message += "[tasted.vore_taste]"
+	else
+		if(ishuman(tasted))
+			var/mob/living/carbon/human/H = tasted
+			taste_message += "a normal [H.custom_species ? H.custom_species : H.species.name]"
+		else
+			taste_message += "a plain old normal [tasted]"
+
+	if(ishuman(tasted))
+		var/mob/living/carbon/human/H = tasted
+		if(H.touching.reagent_list.len) //Just the first one otherwise I'll go insane.
+			var/datum/reagent/R = H.touching.reagent_list[1]
+			taste_message += " You also get the flavor of [R.taste_description] from something on them"
+
+	src.visible_message("<span class='warning'>[src] licks [tasted]!</span>","<span class='notice'>You lick [tasted]. They taste rather like [taste_message].</span>","<b>Slurp!</b>")
 
 //
 // OOC Escape code for pref-breaking or AFK preds
@@ -352,6 +389,19 @@
 	// Actually shove prey into the belly.
 	belly_target.nom_mob(prey, user)
 	user.update_icons()
+
+	// Flavor handling
+	var/flavor_message = ""
+	if(belly_target.can_taste && prey.vore_taste && (prey.vore_taste != ""))
+		flavor_message += "[prey.vore_taste]."
+	if(ishuman(prey))
+		var/mob/living/carbon/human/H = prey
+		if(H.touching.reagent_list.len) //Just the first one otherwise I'll go insane.
+			var/datum/reagent/R = H.touching.reagent_list[1]
+			flavor_message += " You also get the flavor of [R.taste_description] from something on them"
+
+	if(flavor_message != "")
+		src << "<span class='notice'>[prey] tastes of [flavor_message].</span>"
 
 	// Inform Admins
 	if (pred == user)

--- a/code/modules/vore/eating/living_vr.dm
+++ b/code/modules/vore/eating/living_vr.dm
@@ -305,11 +305,12 @@
 	//You're in a PC!
 	else if(istype(src.loc,/mob/living))
 		var/mob/living/carbon/pred = src.loc
-		var/confirm = alert(src, "You're in a player-character. This is for escaping from preference-breaking and if your predator disconnects/AFKs. If you are in more than one pred, use this more than once. If your preferences were being broken, please admin-help as well.", "Confirmation", "Okay", "Cancel")
+		var/confirm = alert(src, "You're in a player-character. This is for escaping from preference-breaking and if your predator disconnects/AFKs. If you are in more than one pred. If your preferences were being broken, please admin-help as well.", "Confirmation", "Okay", "Cancel")
 		if(confirm == "Okay")
 			for(var/O in pred.vore_organs)
 				var/datum/belly/CB = pred.vore_organs[O]
-				CB.release_specific_contents(src)
+				CB.internal_contents -= src //Clean them if we can, otherwise it will get GC'd by the vore code later.
+			src.forceMove(get_turf(loc))
 			message_admins("[key_name(src)] used the OOC escape button to get out of [key_name(pred)] (PC) ([pred ? "<a href='?_src_=holder;adminplayerobservecoodjump=1;X=[pred.x];Y=[pred.y];Z=[pred.z]'>JMP</a>" : "null"])")
 
 	//You're in a dogborg!

--- a/code/modules/vore/eating/vore_vr.dm
+++ b/code/modules/vore/eating/vore_vr.dm
@@ -43,6 +43,7 @@ V::::::V           V::::::VO:::::::OOO:::::::ORR:::::R     R:::::REE::::::EEEEEE
 	//Actual preferences
 	var/digestable = 1
 	var/list/belly_prefs = list()
+	var/vore_taste
 
 	//Mechanically required
 	var/path
@@ -101,6 +102,7 @@ V::::::V           V::::::VO:::::::OOO:::::::ORR:::::R     R:::::REE::::::EEEEEE
 
 	S["digestable"] >> digestable
 	S["belly_prefs"] >> belly_prefs
+	S["vore_taste"] >> vore_taste
 
 	if(isnull(digestable))
 		digestable = 1
@@ -118,5 +120,6 @@ V::::::V           V::::::VO:::::::OOO:::::::ORR:::::R     R:::::REE::::::EEEEEE
 
 	S["digestable"] << digestable
 	S["belly_prefs"] << belly_prefs
+	S["vore_taste"] << vore_taste
 
 	return 1

--- a/code/modules/vore/eating/vorepanel_vr.dm
+++ b/code/modules/vore/eating/vorepanel_vr.dm
@@ -6,6 +6,7 @@
 #define BELLIES_NAME_MIN 2
 #define BELLIES_NAME_MAX 12
 #define BELLIES_DESC_MAX 1024
+#define FLAVOR_MAX 40
 
 /mob/living/proc/insidePanel()
 	set name = "Vore Panel"
@@ -177,6 +178,10 @@
 		//Belly messages
 		dat += "<br><a href='?src=\ref[src];b_msgs=\ref[selected]'>Belly Messages</a>"
 
+		//Can belly taste?
+		dat += "<br><a href='?src=\ref[src];b_tastes=\ref[selected]'>Can Taste:</a>"
+		dat += " [selected.can_taste ? "Yes" : "No"]"
+
 		//Belly escapability
 		dat += "<br><a href='?src=\ref[src];b_escapable=\ref[selected]'>Belly Interactions ([selected.escapable ? "On" : "Off"])</a>"
 		if(selected.escapable)
@@ -216,6 +221,7 @@
 	//Under the last HR, save and stuff.
 	dat += "<a href='?src=\ref[src];saveprefs=1'>Save Prefs</a>"
 	dat += "<a href='?src=\ref[src];refresh=1'>Refresh</a>"
+	dat += "<a href='?src=\ref[src];setflavor=1'>Set Flavor</a>"
 
 	switch(user.digestable)
 		if(1)
@@ -537,6 +543,9 @@
 	if(href_list["b_soundtest"])
 		user << selected.vore_sound
 
+	if(href_list["b_tastes"])
+		selected.can_taste = !selected.can_taste
+
 	if(href_list["b_escapable"])
 		if(selected.escapable == 0) //Possibly escapable and special interactions.
 			selected.escapable = 1
@@ -619,6 +628,18 @@
 			alert("ERROR: Virgo-specific preferences failed to save!","Error")
 		else
 			user << "<span class='notice'>Virgo-specific preferences saved!</span>"
+
+	if(href_list["setflavor"])
+		var/new_flavor = html_encode(input(usr,"What your character tastes like (40ch limit). This text will be printed to the pred after 'X tastes of...' so just put something like 'strawberries and cream':","Character Flavor",user.vore_taste) as text|null)
+
+		if(new_flavor)
+			new_flavor = readd_quotes(new_flavor)
+			if(length(new_flavor) > FLAVOR_MAX)
+				alert("Entered flavor/taste text too long. [FLAVOR_MAX] character limit.","Error")
+				return 0
+			user.vore_taste = new_flavor
+		else //Returned null
+			return 0
 
 	if(href_list["toggledg"])
 		var/choice = alert(user, "This button is for those who don't like being digested. It can make you undigestable. Don't abuse this button by toggling it back and forth to extend a scene or whatever, or you'll make the admins cry. Digesting you is currently: [user.digestable ? "Allowed" : "Prevented"]", "", "Allow Digestion", "Cancel", "Prevent Digestion")


### PR DESCRIPTION
There's a setting on bellies (off by default except for the first belly you're ever given which is on by default) as to whether or not they can 'taste' prey. If so, and the prey has set their (literal) flavor text in their vore prefs (button at the bottom) you will be shown their taste when ingested into that belly.

There's also a "Lick Someone" verb in IC that allows you to lick adjacent mobs to see what they taste like.

Both system account for reagents splashed on the mob, so if you want to apply soy sauce to the akula before you eat them, you should be able to taste that as well. Just keep in mind those splashed reagents do dry up eventually, so don't take too long to eat them after that if you actually want to taste it.

Also made OOC escape more robust while I was here (escaping from people should ALWAYS WORK PERIOD, it will just put you on the turf the pred is on).

Resolves #903 
Resolves #1032 