### PR TITLE
Enhances power monitor computers to use the nano-map to show APC locations.

### DIFF
--- a/code/modules/nano/modules/power_monitor.dm
+++ b/code/modules/nano/modules/power_monitor.dm
@@ -29,6 +29,10 @@
 	ui = nanomanager.try_update_ui(user, src, ui_key, ui, data, force_open)
 	if (!ui)
 		ui = new(user, src, ui_key, "power_monitor.tmpl", "Power Monitoring Console", 800, 500, state = state)
+		// adding a template with the key "mapContent" enables the map ui functionality
+		ui.add_template("mapContent", "power_monitor_map_content.tmpl")
+		// adding a template with the key "mapHeader" replaces the map header content
+		ui.add_template("mapHeader", "power_monitor_map_header.tmpl")
 		ui.set_initial_data(data)
 		ui.open()
 		ui.set_auto_update(1)

--- a/code/modules/power/sensors/powernet_sensor.dm
+++ b/code/modules/power/sensors/powernet_sensor.dm
@@ -163,6 +163,10 @@
 			// Cell Status
 			APC_entry["cell_charge"] = A.cell ? round(A.cell.percent()) : "NO CELL"
 			APC_entry["cell_status"] = A.cell ? chg[A.charging+1] : "N"
+			// Location
+			APC_entry["x"] = A.x
+			APC_entry["y"] = A.y
+			APC_entry["z"] = A.z
 			// Other info
 			APC_entry["total_load"] = reading_to_text(A.lastused_total)
 			// Hopefully removes those goddamn \improper s which are screwing up the UI

--- a/nano/templates/power_monitor.tmpl
+++ b/nano/templates/power_monitor.tmpl
@@ -2,6 +2,7 @@
 	<div class="notice" style="height: 22px">
 		{{:helper.link('Show List', 'cancel', { 'clear' : 1})}}   Sensor selected: {{:data.focus.name}} 
 	</div>
+	{{:helper.link('Show APCs On Map', 'pin-s', {'showMap' : 1})}}
 	{{if data.focus.error}}
 		{{:data.focus.error}}
 	{{else}}

--- a/nano/templates/power_monitor_map_content.tmpl
+++ b/nano/templates/power_monitor_map_content.tmpl
@@ -1,0 +1,33 @@
+<!--
+Title: Power Monitoring Console (Map Content)
+Used In File(s): \code\modules\nano\modules\power_monitor.dm
+ -->
+{{if data.focus}}
+	{{for data.focus.apc_data}}
+		{{if value.z == config.mapZLevel}}
+		    <div class="mapIcon mapIcon16 {{:(value.cell_status == "N" ? 'batt_disc dead' : value.cell_status == "C" ? 'batt_chrg' : 'batt_full')}}" style="left: {{:(value.x + 0.2)}}px; bottom: {{:(value.y - 14.75)}}px;" unselectable="on">
+		        <div class="tooltip hidden">
+		        	<span>{{:value.name}}</span><br>
+		        	<div>
+			        	<span><b>APC Load:</b> {{:value.total_load}}</span>
+			        	{{if value.cell_status == "N"}}
+							{{:helper.link(value.cell_charge + '%', 'batt_disc', null,'disabled', 'width75btn')}}
+						{{else value.cell_status == "C"}}
+							{{:helper.link(value.cell_charge + '%', 'batt_chrg', null,'disabled', 'width75btn')}}
+						{{else}}
+							{{:helper.link(value.cell_charge + '%', 'batt_full', null,'disabled', 'width75btn')}}
+						{{/if}}
+					</div>
+					<table style="clear: both">
+						<tr><th>Equip.</th><th>Lighting</th><th>Env.</th></tr>
+						<tr>
+							<td>{{:value.s_equipment}}</td>
+							<td>{{:value.s_lighting}}</td>
+							<td>{{:value.s_environment}}</td>
+						</tr>
+					</table>
+				</div>
+			</div>
+		{{/if}}
+	{{/for}}
+{{/if}}

--- a/nano/templates/power_monitor_map_header.tmpl
+++ b/nano/templates/power_monitor_map_header.tmpl
@@ -1,0 +1,25 @@
+<!--
+Title: Power Monitoring Console (Map header)
+Used In File(s): \code\modules\nano\modules\power_monitor.dm
+ -->
+{{:helper.link('Show Network Information', 'script', {'showMap' : 0})}}
+{{if data.focus}}<span>Sensor selected: {{:data.focus.name}}</span>{{/if}}
+<div style="float: right; width: 240px;">
+    <span style="float: left;">Zoom Level:&nbsp;</span>
+    <div unselectable="on" class="link zoomLink" data-zoom-level="4">x1.0</div>
+    <div unselectable="on" class="link zoomLink" data-zoom-level="6">x1.5</div>
+    <div unselectable="on" class="link zoomLink" data-zoom-level="8">x2.0</div>
+    <div unselectable="on" class="link zoomLink" data-zoom-level="12">x2.5</div>
+</div>
+<div class='item'>
+	<div class='itemLabel'>Sensors:</div>
+</div>
+{{for data.all_sensors}}
+	{{if value.alarm}}
+		{{:helper.link(value.name, 'alert', { 'setsensor' : value.name})}}
+	{{else}}
+		{{:helper.link(value.name, '' , { 'setsensor' : value.name})}}
+	{{/if}}
+{{empty}}
+	<b>WARN: No Sensors Detected!</b>
+{{/for}}


### PR DESCRIPTION

* In addition to showing APCs on a sensor'd powernet, the same APCs can be shown on the nano-ui map!
* Hover tooltip shows basic information on the APCs.
* Makes it easier to spacially understand where APCs are when you send people out to work on them.