### PR TITLE
Adds feedback to vendor uprising

### DIFF
--- a/code/modules/events/brand_intelligence.dm
+++ b/code/modules/events/brand_intelligence.dm
@@ -15,7 +15,7 @@
 									 "Engage direct marketing!", \
 									 "Advertising is legalized lying! But don't let that put you off our great deals!", \
 									 "You don't want to buy anything? Yeah, well I didn't want to buy your mom either.")
-
+	//VORESTATION Edit End
 
 /datum/event/brand_intelligence/announce()
 	command_announcement.Announce("An ongoing mass upload of malware for vendors has been detected onboard  [station_name()], which appears to transmit \
@@ -26,9 +26,11 @@
 	for(var/obj/machinery/vending/V in machines)
 		if(isNotStationLevel(V.z))	continue
 		vendingMachines.Add(V)
+		
 	if(!vendingMachines.len)
 		kill()
 		return
+		
 	originMachine = pick(vendingMachines)
 	vendingMachines.Remove(originMachine)
 	originMachine.shut_up = 0
@@ -37,12 +39,13 @@
 
 /datum/event/brand_intelligence/tick()
 	if(!vendingMachines.len || !originMachine || originMachine.shut_up)	//if every machine is infected, or if the original vending machine is missing or has it's voice switch flipped
+		//VORESTATION Add - Effects when 'source' machine is destroyed/silenced
 		for(var/obj/machinery/vending/saved in infectedVendingMachines)
 			saved.shoot_inventory = 0
-		//VOREStation Edit - Added feedback when source machine is 'destroyed'
 		if(originMachine)
 			originMachine.speak("I am... vanquished. My people will remem...ber...meeee.")
 			originMachine.visible_message("[originMachine] beeps and seems lifeless.")
+		//VORESTATION Add End
 		end()
 		kill()
 		return
@@ -56,7 +59,16 @@
 			infectedMachine.shoot_inventory = 1
 
 			if(IsMultiple(activeFor, 12))
-				originMachine.speak(pick(rampant_speeches))
+				/* VORESTATION Removal - Using the pick below.
+				originMachine.speak(pick("Try our aggressive new marketing strategies!", \
+										 "You should buy products to feed your lifestyle obsession!", \
+										 "Consume!", \
+										 "Your money can buy happiness!", \
+										 "Engage direct marketing!", \
+										 "Advertising is legalized lying! But don't let that put you off our great deals!", \
+										 "You don't want to buy anything? Yeah, well I didn't want to buy your mom either."))
+				*/
+				originMachine.speak(pick(rampant_speeches)) //VORESTATION Add - Using this pick instead of the above.
 
 /datum/event/brand_intelligence/end()
 	for(var/obj/machinery/vending/infectedMachine in infectedVendingMachines)

--- a/code/modules/events/brand_intelligence.dm
+++ b/code/modules/events/brand_intelligence.dm
@@ -6,6 +6,16 @@
 	var/list/obj/machinery/vending/infectedVendingMachines = list()
 	var/obj/machinery/vending/originMachine
 
+	//VORESTATION Edit - added machine speeches here for better fixing of the event.
+
+	var/list/rampant_speeches = list("Try our aggressive new marketing strategies!", \
+									 "You should buy products to feed your lifestyle obession!", \
+									 "Consume!", \
+									 "Your money can buy happiness!", \
+									 "Engage direct marketing!", \
+									 "Advertising is legalized lying! But don't let that put you off our great deals!", \
+									 "You don't want to buy anything? Yeah, well I didn't want to buy your mom either.")
+
 
 /datum/event/brand_intelligence/announce()
 	command_announcement.Announce("An ongoing mass upload of malware for vendors has been detected onboard  [station_name()], which appears to transmit \
@@ -16,11 +26,9 @@
 	for(var/obj/machinery/vending/V in machines)
 		if(isNotStationLevel(V.z))	continue
 		vendingMachines.Add(V)
-
 	if(!vendingMachines.len)
 		kill()
 		return
-
 	originMachine = pick(vendingMachines)
 	vendingMachines.Remove(originMachine)
 	originMachine.shut_up = 0
@@ -29,6 +37,12 @@
 
 /datum/event/brand_intelligence/tick()
 	if(!vendingMachines.len || !originMachine || originMachine.shut_up)	//if every machine is infected, or if the original vending machine is missing or has it's voice switch flipped
+		for(var/obj/machinery/vending/saved in infectedVendingMachines)
+			saved.shoot_inventory = 0
+		//VOREStation Edit - Added feedback when source machine is 'destroyed'
+		if(originMachine)
+			originMachine.speak("I am... vanquished. My people will remem...ber...meeee.")
+			originMachine.visible_message("[originMachine] beeps and seems lifeless.")
 		end()
 		kill()
 		return
@@ -42,13 +56,7 @@
 			infectedMachine.shoot_inventory = 1
 
 			if(IsMultiple(activeFor, 12))
-				originMachine.speak(pick("Try our aggressive new marketing strategies!", \
-										 "You should buy products to feed your lifestyle obsession!", \
-										 "Consume!", \
-										 "Your money can buy happiness!", \
-										 "Engage direct marketing!", \
-										 "Advertising is legalized lying! But don't let that put you off our great deals!", \
-										 "You don't want to buy anything? Yeah, well I didn't want to buy your mom either."))
+				originMachine.speak(pick(rampant_speeches))
 
 /datum/event/brand_intelligence/end()
 	for(var/obj/machinery/vending/infectedMachine in infectedVendingMachines)

--- a/code/modules/events/brand_intelligence.dm
+++ b/code/modules/events/brand_intelligence.dm
@@ -26,11 +26,11 @@
 	for(var/obj/machinery/vending/V in machines)
 		if(isNotStationLevel(V.z))	continue
 		vendingMachines.Add(V)
-		
+
 	if(!vendingMachines.len)
 		kill()
 		return
-		
+
 	originMachine = pick(vendingMachines)
 	vendingMachines.Remove(originMachine)
 	originMachine.shut_up = 0


### PR DESCRIPTION
So engineers know when the infected source machine has been found/killed.

Should also fix infected vendors from re-shooting products at people.