### PR TITLE
AI Upgrades

### DIFF
--- a/code/_helpers/icons.dm
+++ b/code/_helpers/icons.dm
@@ -793,6 +793,26 @@ proc // Creates a single icon from a given /atom or /image.  Only the first argu
 			alpha_mask.Blend(image_overlay,ICON_OR)//OR so they are lumped together in a nice overlay.
 		return alpha_mask//And now return the mask.
 
+//getFlatIcon but generates an icon that can face ALL four directions. The only four.
+/proc/getCompoundIcon(atom/A)
+	var/icon/north = getFlatIcon(A,defdir=NORTH,always_use_defdir=1)
+	var/icon/south = getFlatIcon(A,defdir=SOUTH,always_use_defdir=1)
+	var/icon/east = getFlatIcon(A,defdir=EAST,always_use_defdir=1)
+	var/icon/west = getFlatIcon(A,defdir=WEST,always_use_defdir=1)
+
+	//Starts with a blank icon because of byond bugs.
+	var/icon/full = icon('icons/effects/effects.dmi', "icon_state"="nothing")
+
+	full.Insert(north,dir=NORTH)
+	full.Insert(south,dir=SOUTH)
+	full.Insert(east,dir=EAST)
+	full.Insert(west,dir=WEST)
+	qdel(north)
+	qdel(south)
+	qdel(east)
+	qdel(west)
+	return full
+
 /mob/proc/AddCamoOverlay(atom/A)//A is the atom which we are using as the overlay.
 	var/icon/opacity_icon = new(A.icon, A.icon_state)//Don't really care for overlays/underlays.
 	//Now we need to culculate overlays+underlays and add them together to form an image for a mask.

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -545,82 +545,93 @@ var/list/ai_verbs_hidden = list( // For why this exists, refer to https://xkcd.c
 		return
 
 	var/input
-	if(alert("Would you like to select a hologram based on a crew member or switch to unique avatar?",,"Crew Member","Unique")=="Crew Member")
+	var/choice = alert("Would you like to select a hologram based on a (visible) crew member, switch to unique avatar, or load your character from your character slot?",,"Crew Member","Unique","My Character")
 
-		var/personnel_list[] = list()
+	switch(choice)
+		if("Crew Member")
+			var/list/targets = trackable_mobs()
+			if(targets.len)
+				input = input("Select a crew member:") as null|anything in targets //The definition of "crew member" is a little loose...
+				//This is torture, I know. If someone knows a better way...
+				if(!input) return
+				var/new_holo = getHologramIcon(getCompoundIcon(targets[input]))
+				qdel(holo_icon)
+				holo_icon = new_holo
 
-		for(var/datum/data/record/t in data_core.locked)//Look in data core locked.
-			personnel_list["[t.fields["name"]]: [t.fields["rank"]]"] = t.fields["image"]//Pull names, rank, and image.
+			else
+				alert("No suitable records found. Aborting.")
 
-		if(personnel_list.len)
-			input = input("Select a crew member:") as null|anything in personnel_list
-			var/icon/character_icon = personnel_list[input]
-			if(character_icon)
-				qdel(holo_icon)//Clear old icon so we're not storing it in memory.
-				holo_icon = getHologramIcon(icon(character_icon))
-		else
-			alert("No suitable records found. Aborting.")
+		if("My Character")
+			if(!client || !client.prefs) return
+			var/mob/living/carbon/human/dummy/dummy = new ()
+			//This doesn't include custom_items because that's ... hard.
+			client.prefs.dress_preview_mob(dummy)
+			sleep(1 SECOND) //Strange bug in preview code? Without this, certain things won't show up. Yay race conditions?
+			dummy.regenerate_icons()
 
-	else
-		var/icon_list[] = list(
-		"default",
-		"floating face",
-		"carp",
-		"ian",
-		"runtime",
-		"poly",
-		"pun pun",
-		"male human",
-		"female human",
-		"male unathi",
-		"female unathi",
-		"male tajara",
-		"female tajara",
-		"male tesharii",
-		"female tesharii",
-		"male skrell",
-		"female skrell"
-		)
-		input = input("Please select a hologram:") as null|anything in icon_list
-		if(input)
+			var/new_holo = getHologramIcon(getCompoundIcon(dummy))
 			qdel(holo_icon)
-			switch(input)
-				if("default")
-					holo_icon = getHologramIcon(icon('icons/mob/AI.dmi',"holo1"))
-				if("floating face")
-					holo_icon = getHologramIcon(icon('icons/mob/AI.dmi',"holo2"))
-				if("carp")
-					holo_icon = getHologramIcon(icon('icons/mob/AI.dmi',"holo4"))
-				if("ian")
-					holo_icon = getHologramIcon(icon('icons/mob/animal.dmi',"corgi"))
-				if("runtime")
-					holo_icon = getHologramIcon(icon('icons/mob/animal.dmi',"cat"))
-				if("poly")
-					holo_icon = getHologramIcon(icon('icons/mob/animal.dmi',"parrot_fly"))
-				if("pun pun")
-					holo_icon = getHologramIcon(icon('icons/mob/AI.dmi',"punpun"))
-				if("male human")
-					holo_icon = getHologramIcon(icon('icons/mob/AI.dmi',"holohumm"))
-				if("female human")
-					holo_icon = getHologramIcon(icon('icons/mob/AI.dmi',"holohumf"))
-				if("male unathi")
-					holo_icon = getHologramIcon(icon('icons/mob/AI.dmi',"holounam"))
-				if("female unathi")
-					holo_icon = getHologramIcon(icon('icons/mob/AI.dmi',"holounaf"))
-				if("male tajara")
-					holo_icon = getHologramIcon(icon('icons/mob/AI.dmi',"holotajm"))
-				if("female tajara")
-					holo_icon = getHologramIcon(icon('icons/mob/AI.dmi',"holotajf"))
-				if("male tesharii")
-					holo_icon = getHologramIcon(icon('icons/mob/AI.dmi',"holotesm"))
-				if("female tesharii")
-					holo_icon = getHologramIcon(icon('icons/mob/AI.dmi',"holotesf"))
-				if("male skrell")
-					holo_icon = getHologramIcon(icon('icons/mob/AI.dmi',"holoskrm"))
-				if("female skrell")
-					holo_icon = getHologramIcon(icon('icons/mob/AI.dmi',"holoskrf"))
+			qdel(dummy)
+			holo_icon = new_holo
 
-	return
+		else //One from the dmi.
+			var/icon_list[] = list(
+			"default",
+			"floating face",
+			"carp",
+			"ian",
+			"runtime",
+			"poly",
+			"pun pun",
+			"male human",
+			"female human",
+			"male unathi",
+			"female unathi",
+			"male tajara",
+			"female tajara",
+			"male tesharii",
+			"female tesharii",
+			"male skrell",
+			"female skrell"
+			)
+			input = input("Please select a hologram:") as null|anything in icon_list
+			if(input)
+				qdel(holo_icon)
+				switch(input)
+					if("default")
+						holo_icon = getHologramIcon(icon('icons/mob/AI.dmi',"holo1"))
+					if("floating face")
+						holo_icon = getHologramIcon(icon('icons/mob/AI.dmi',"holo2"))
+					if("carp")
+						holo_icon = getHologramIcon(icon('icons/mob/AI.dmi',"holo4"))
+					if("ian")
+						holo_icon = getHologramIcon(icon('icons/mob/animal.dmi',"corgi"))
+					if("runtime")
+						holo_icon = getHologramIcon(icon('icons/mob/animal.dmi',"cat"))
+					if("poly")
+						holo_icon = getHologramIcon(icon('icons/mob/animal.dmi',"parrot_fly"))
+					if("pun pun")
+						holo_icon = getHologramIcon(icon('icons/mob/AI.dmi',"punpun"))
+					if("male human")
+						holo_icon = getHologramIcon(icon('icons/mob/AI.dmi',"holohumm"))
+					if("female human")
+						holo_icon = getHologramIcon(icon('icons/mob/AI.dmi',"holohumf"))
+					if("male unathi")
+						holo_icon = getHologramIcon(icon('icons/mob/AI.dmi',"holounam"))
+					if("female unathi")
+						holo_icon = getHologramIcon(icon('icons/mob/AI.dmi',"holounaf"))
+					if("male tajara")
+						holo_icon = getHologramIcon(icon('icons/mob/AI.dmi',"holotajm"))
+					if("female tajara")
+						holo_icon = getHologramIcon(icon('icons/mob/AI.dmi',"holotajf"))
+					if("male tesharii")
+						holo_icon = getHologramIcon(icon('icons/mob/AI.dmi',"holotesm"))
+					if("female tesharii")
+						holo_icon = getHologramIcon(icon('icons/mob/AI.dmi',"holotesf"))
+					if("male skrell")
+						holo_icon = getHologramIcon(icon('icons/mob/AI.dmi',"holoskrm"))
+					if("female skrell")
+						holo_icon = getHologramIcon(icon('icons/mob/AI.dmi',"holoskrf"))
 
 //Toggles the luminosity and applies it by re-entereing the camera.
 /mob/living/silicon/ai/proc/toggle_camera_light()

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -727,6 +727,11 @@ var/list/ai_verbs_hidden = list( // For why this exists, refer to https://xkcd.c
 	set desc = "Toggles hologram movement based on moving with your virtual eye."
 
 	hologram_follow = !hologram_follow
+	//VOREStation Add - Required to stop movement because we use walk_to(wards) in hologram.dm
+	if(holo)
+		var/obj/effect/overlay/aiholo/hologram = holo.masters[src]
+		walk(hologram, 0)
+	//VOREStation Add End
 	usr << "Your hologram will [hologram_follow ? "follow" : "no longer follow"] you now."
 
 

--- a/code/modules/vore/eating/silicon_vr.dm
+++ b/code/modules/vore/eating/silicon_vr.dm
@@ -1,8 +1,8 @@
 //Dat AI vore yo
-#define HOLO_ORIGINAL_COLOR null //This seems to work for some reason? And look better?
+#define HOLO_ORIGINAL_COLOR null //Original hologram color: "#7db4e1"
 #define HOLO_HARDLIGHT_COLOR "#d97de0"
-#define HOLO_ORIGINAL_ALPHA 128
-#define HOLO_HARDLIGHT_ALPHA 210
+#define HOLO_ORIGINAL_ALPHA 120
+#define HOLO_HARDLIGHT_ALPHA 200
 
 /obj/effect/overlay/aiholo
 	var/mob/living/bellied //Only belly one person at a time. No huge vore-organs setup for AIs.
@@ -34,8 +34,8 @@
 
 	desc = "[initial(desc)]"
 	pass_flags = initial(pass_flags)
-	color = initial(color)
-	alpha = initial(alpha)
+	color = HOLO_ORIGINAL_COLOR
+	alpha = HOLO_ORIGINAL_ALPHA
 
 /obj/effect/overlay/aiholo/Destroy()
 	drop_prey()


### PR DESCRIPTION
Allows the AI to use their character slot character as their hologram, so you can design a custom hologram for your AI. This hologram will include the loadout gear and job equipment. Basically, it will look exactly like the character preview in character setup (including if you have gear toggled to hidden or not on that page).

Also fixes impersonating crew members to allow you to face all four directions when doing so, and impersonating crew takes current pictures (presumably via cameras) to give a current icon.

Also also the crew/custom holograms are not "blue-ish" for reasons beyond my control with regards to how it interacts with light and dark fur characters and a few other things. The scanlines and transparency make it obvious it's a hologram though (guys we have a holodeck I think we can have color holograms).