### PR TITLE
Fixes an issue with suits and sprites

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -51,10 +51,10 @@
 
 		if(H.species)
 			if(exclusive)
-				if(!(H.species.get_bodytype() in species_restricted))
+				if(!(H.species.get_bodytype(H) in species_restricted))	//Vorestation edit
 					wearable = 1
 			else
-				if(H.species.get_bodytype() in species_restricted)
+				if(H.species.get_bodytype(H) in species_restricted)	//Vorestation edit
 					wearable = 1
 
 			if(!wearable && !(slot in list(slot_l_store, slot_r_store, slot_s_store)))

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -786,7 +786,7 @@ var/global/list/damage_icon_parts = list()
 		if(wear_suit.icon_override)
 			t_icon = wear_suit.icon_override
 		else if(wear_suit.sprite_sheets && wear_suit.sprite_sheets[species.get_bodytype(src)])
-			t_icon = wear_suit.sprite_sheets[species.name]
+			t_icon = wear_suit.sprite_sheets[species.get_bodytype(src)] //Vorestation edit
 		else if(wear_suit.item_icons && wear_suit.item_icons[slot_wear_suit_str])
 			t_icon = wear_suit.item_icons[slot_wear_suit_str]
 


### PR DESCRIPTION
First issue was that `get_bodytype()` expected something to be given to it as a parameter to function correctly, and it wasn't recieving such. This worked fine with most things because they just returned a simple string without ever using the thing passed to it. The issue arose with Prometheans and their own `get_bodytype()` which had a null check because it was doing something with it. That's fixed.

Second issue was that the sprite sheet being used for a mob was hardcoded to their species by using the name of the species, this meant that in some circumstances it wouldn't function properly. Prime example was Prometheans. They're meant to be able to morph into a species, and then wear that species things. They couldn't, for two reasons. The first is fixed above, and the second is that no matter what it would use the Promethean spritesheet.

Have not PRed to Polaris because I don't believe it's applicable due to the difference in how the updating of icons is handled.