### PR TITLE
Vore mobs were supposed to spit you out when they die.

### DIFF
--- a/code/modules/mob/living/simple_animal/simple_animal_vr.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal_vr.dm
@@ -108,7 +108,7 @@
 		set_stance(STANCE_ATTACK)
 	stop_automated_movement = 0
 
-/mob/living/simple_animal/hostile/vore/death()
+/mob/living/simple_animal/death()
 	for(var/I in vore_organs)
 		var/datum/belly/B = vore_organs[I]
 		B.release_all_contents() // When your stomach is empty

--- a/code/modules/mob/living/simple_animal/vore/zz_vore_overrides.dm
+++ b/code/modules/mob/living/simple_animal/vore/zz_vore_overrides.dm
@@ -186,3 +186,14 @@
 /mob/living/simple_animal/hostile/carp/pike
 	vore_active = 1
 	// NO VORE SPRITES
+
+/mob/living/simple_animal/hostile/carp/holodeck
+	vore_icons = 0 // NO VORE SPRITES
+// Override stuff for holodeck carp to make them not digest when set to safe!
+/mob/living/simple_animal/hostile/carp/holodeck/set_safety(var/safe)
+	. = ..()
+	for(var/I in vore_organs)
+		var/datum/belly/B = vore_organs[I]
+		B.digest_mode = safe ? DM_HOLD : vore_default_mode
+		B.digestchance = safe ? 0 : vore_digest_chance
+		B.absorbchance = safe ? 0 : vore_absorb_chance

--- a/code/modules/reagents/Chemistry-Recipes_vr.dm
+++ b/code/modules/reagents/Chemistry-Recipes_vr.dm
@@ -259,7 +259,7 @@
 	required_reagents = list("phoron" = 20, "nutriment" = 20, "sugar" = 20, "mutationtoxin" = 20) //Can't do slime jelly as it'll conflict with another, but mutation toxin will do.
 	result_amount = 1
 	on_reaction(var/datum/reagents/holder)
-		var/mob_path = /mob/living/simple_animal/hostile/vore
+		var/mob_path = /mob/living/simple_animal
 		var/blocked = list(
 			/mob/living/simple_animal/hostile/mimic,
 			/mob/living/simple_animal/hostile/alien/queen

--- a/code/modules/telesci/telesci_computer.dm
+++ b/code/modules/telesci/telesci_computer.dm
@@ -154,8 +154,8 @@
 			sparks()
 			if(telepad)
 				var/L = get_turf(telepad)
-				var/blocked = list(/mob/living/simple_animal/hostile/vore)
-				var/list/hostiles = typesof(/mob/living/simple_animal/hostile/vore) - blocked
+				var/blocked = list(/mob/living/simple_animal/hostile)
+				var/list/hostiles = typesof(/mob/living/simple_animal/hostile) - blocked
 				playsound(L, 'sound/effects/phasein.ogg', 100, 1, extrarange = 3, falloff = 5)
 				for(var/i in 1 to rand(1,4))
 					var/chosen = pick(hostiles)


### PR DESCRIPTION
* A little typo prevented this! Also it had made an illusory path that was referenced two places; fixed that.
* While we're here, also make it so holocarp don't digest when in safe mode. Fixes #1361  And for them to not try to use vore icons that don't exist for them.