### PR TITLE
Adds 'Subsleeving' into prey

### DIFF
--- a/code/modules/client/preference_setup/vore/04_resleeving.dm
+++ b/code/modules/client/preference_setup/vore/04_resleeving.dm
@@ -29,6 +29,7 @@
 				BR.init_from_mob(character, pref.resleeve_scan, pref.resleeve_lock)
 			if(pref.resleeve_lock)
 				character.resleeve_lock = character.ckey
+			character.original_player = character.ckey
 
 /datum/category_item/player_setup_item/vore/resleeve/content(var/mob/user)
 	. += "<br>"

--- a/code/modules/resleeving/computers.dm
+++ b/code/modules/resleeving/computers.dm
@@ -323,6 +323,7 @@
 				temp = "Error: No sleevers detected."
 			else
 				var/mode = text2num(href_list["sleeve"])
+				var/override
 				var/obj/machinery/transhuman/resleever/sleever = sleevers[1]
 				if (sleevers.len > 1)
 					sleever = input(usr,"Select a resleeving pod to use", "Resleever selection") as anything in sleevers
@@ -336,6 +337,17 @@
 						//OOC body lock thing.
 						if(sleever.occupant.resleeve_lock && active_mr.ckey != sleever.occupant.resleeve_lock)
 							temp = "Error: Mind incompatible with body."
+
+						var/list/subtargets = list()
+						for(var/mob/living/carbon/human/H in sleever.occupant)
+							if(H.resleeve_lock && active_mr.ckey != H.resleeve_lock)
+								continue
+							subtargets += H
+						if(subtargets.len)
+							var/oc_sanity = sleever.occupant
+							override = input(usr,"Multiple bodies detected. Select target for resleeving of [active_mr.mindname] manually. Sleeving of primary body is unsafe with sub-contents, and is not listed.", "Resleeving Target") as null|anything in subtargets
+							if(!override || oc_sanity != sleever.occupant || !(override in sleever.occupant))
+								temp = "Error: Target selection aborted."
 
 					if(2) //Card resleeving
 						if(sleever.sleevecards <= 0)
@@ -352,7 +364,7 @@
 
 				//They were dead, or otherwise available.
 				if(!temp)
-					sleever.putmind(active_mr,mode)
+					sleever.putmind(active_mr,mode,override)
 					temp = "Initiating resleeving..."
 					menu = 1
 

--- a/code/modules/resleeving/infocore.dm
+++ b/code/modules/resleeving/infocore.dm
@@ -154,6 +154,7 @@ var/datum/transhuman/infocore/transcore = new/datum/transhuman/infocore
 	var/list/organ_data = list(O_HEART, O_EYES, O_LUNGS, O_BRAIN)
 	var/toocomplex
 	var/sizemult
+	var/weight
 
 /datum/transhuman/body_record/New(var/copyfrom, var/add_to_db = 0, var/ckeylock = 0)
 	..()
@@ -188,6 +189,7 @@ var/datum/transhuman/infocore/transcore = new/datum/transhuman/infocore
 	bodygender = M.gender
 	body_oocnotes = M.ooc_notes
 	sizemult = M.size_multiplier
+	weight = M.weight
 
 	//Probably should
 	M.dna.check_integrity()

--- a/code/modules/resleeving/machines.dm
+++ b/code/modules/resleeving/machines.dm
@@ -89,6 +89,7 @@
 	H.ooc_notes = current_project.body_oocnotes
 	H.flavor_texts = current_project.mydna.flavor.Copy()
 	H.size_multiplier = current_project.sizemult
+	H.weight = current_project.weight
 	if(current_project.speciesname)
 		H.custom_species = current_project.speciesname
 
@@ -301,6 +302,7 @@
 	H.ooc_notes = current_project.body_oocnotes
 	H.flavor_texts = current_project.mydna.flavor.Copy()
 	H.size_multiplier = current_project.sizemult
+	H.weight = current_project.weight
 	if(current_project.speciesname)
 		H.custom_species = current_project.speciesname
 

--- a/code/modules/resleeving/machines.dm
+++ b/code/modules/resleeving/machines.dm
@@ -471,7 +471,7 @@
 
 	return ..()
 
-/obj/machinery/transhuman/resleever/proc/putmind(var/datum/transhuman/mind_record/MR, mode = 1)
+/obj/machinery/transhuman/resleever/proc/putmind(var/datum/transhuman/mind_record/MR, mode = 1, var/mob/living/carbon/human/override = null)
 	if((!occupant || !istype(occupant) || occupant.stat >= DEAD) && mode == 1)
 		return 0
 
@@ -480,6 +480,12 @@
 		card.sleeveInto(MR)
 		sleevecards--
 		return 1
+
+	//If we're sleeving a subtarget, briefly swap them to not need to duplicate tons of code.
+	var/mob/living/carbon/human/original_occupant
+	if(override)
+		original_occupant = occupant
+		occupant = override
 
 	//In case they already had a mind!
 	if(occupant && occupant.mind)
@@ -524,6 +530,9 @@
 
 	if(occupant.mind && occupant.original_player && ckey(occupant.mind.key) != occupant.original_player)
 		log_and_message_admins("is now a cross-sleeved character. Body originally belonged to [occupant.real_name]. Mind is now [occupant.mind.name].",occupant)
+
+	if(original_occupant)
+		occupant = original_occupant
 
 	return 1
 


### PR DESCRIPTION
Allows the resleever to sleeve minds into people inside the resleeving pod's occupant, aka if you want you can print a new body for the person (or if you're wiping some existing person, take a living person), have someone eat them, then get in resleeving pod and revive them in a gut. That'll keep them from walking around and tripping too much, yuh.

I'm sure there's a million crazy things you could do with this (eat person you want to impersonate, resleeve yourself into them while they're in your guts, then escape your own guts?) so have fun with that.

For technical reasons, for now, you cannot sleeve the PRED if they have prey in them in the resleeving pod. It has to do with wiping out their bellies and forgetting where their prey are. This would happen to prey if the prey has their own prey, as well, but... don't? Also you can always just OOC escape if you get trapped like that.