### PR TITLE
Fix 'Spawn Character' DNA

### DIFF
--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -461,14 +461,17 @@ Traitors and the like can also be revived with the previous role mostly intact.
 
 	//Write the appearance and whatnot out to the character
 	picked_client.prefs.copy_to(new_character)
+	if(new_character.dna)
+		new_character.dna.ResetUIFrom(new_character)
+		new_character.sync_organ_dna()
 	if(inhabit)
 		new_character.key = player_key
-
-	//Were they any particular special role? If so, copy.
-	var/datum/antagonist/antag_data = get_antag_data(new_character.mind.special_role)
-	if(antag_data)
-		antag_data.add_antagonist(new_character.mind)
-		antag_data.place_mob(new_character)
+		//Were they any particular special role? If so, copy.
+		if(new_character.mind)
+			var/datum/antagonist/antag_data = get_antag_data(new_character.mind.special_role)
+			if(antag_data)
+				antag_data.add_antagonist(new_character.mind)
+				antag_data.place_mob(new_character)
 
 	//If desired, apply equipment.
 	if(equipment)


### PR DESCRIPTION
Made spawned characters always use male sprites and not have accurate DNA. Also would runtime if you picked the option to not put a mind in, as it assumed there would be one.