### PR TITLE
Adds admin verbs for debugging process controllers

### DIFF
--- a/code/controllers/verbs.dm
+++ b/code/controllers/verbs.dm
@@ -100,3 +100,26 @@
 			feedback_add_details("admin_verb", "DXenobio")
 	message_admins("Admin [key_name_admin(usr)] is debugging the [controller] controller.")
 	return
+
+/client/proc/debug_process_scheduler()
+	set category = "Debug"
+	set name = "Debug Process Scheduler"
+	set desc = "Debug the process scheduler itself. For vulpine use only."
+
+	if(!check_rights(R_DEBUG)) return
+	if(config.debugparanoid && !check_rights(R_ADMIN)) return
+	debug_variables(processScheduler)
+	feedback_add_details("admin_verb", "DProcSchd")
+	message_admins("Admin [key_name_admin(usr)] is debugging the process scheduler.")
+
+/client/proc/debug_process(controller in processScheduler.nameToProcessMap)
+	set category = "Debug"
+	set name = "Debug Process Controller"
+	set desc = "Debug one of the periodic loop background task controllers for the game (be careful!)"
+
+	if(!check_rights(R_DEBUG)) return
+	if(config.debugparanoid && !check_rights(R_ADMIN)) return
+	var/datum/controller/process/P = processScheduler.nameToProcessMap[controller]
+	debug_variables(P)
+	feedback_add_details("admin_verb", "DProcCtrl")
+	message_admins("Admin [key_name_admin(usr)] is debugging the [controller] controller.")

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -194,6 +194,7 @@ var/list/admin_verbs_debug = list(
 	/client/proc/enable_debug_verbs,
 	/client/proc/callproc,
 	/client/proc/callproc_target,
+	/client/proc/debug_process,
 	/client/proc/SDQL_query,
 	/client/proc/SDQL2_query,
 	/client/proc/Jump,
@@ -212,6 +213,7 @@ var/list/admin_verbs_debug = list(
 var/list/admin_verbs_paranoid_debug = list(
 	/client/proc/callproc,
 	/client/proc/callproc_target,
+	/client/proc/debug_process,
 	/client/proc/debug_controller
 	)
 
@@ -280,6 +282,7 @@ var/list/admin_verbs_hideable = list(
 	/client/proc/cmd_admin_list_open_jobs,
 	/client/proc/callproc,
 	/client/proc/callproc_target,
+	/client/proc/debug_process,
 	/client/proc/Debug2,
 	/client/proc/reload_admins,
 	/client/proc/kill_air,

--- a/code/modules/admin/verbs/mapping.dm
+++ b/code/modules/admin/verbs/mapping.dm
@@ -162,6 +162,7 @@ var/list/debug_verbs = list (
         ,/client/proc/setup_supermatter_engine
 		,/client/proc/atmos_toggle_debug
 		,/client/proc/spawn_tanktransferbomb
+		,/client/proc/debug_process_scheduler
 	)
 
 

--- a/html/changelogs/Leshana-vplk-process-debug-verbs.yml
+++ b/html/changelogs/Leshana-vplk-process-debug-verbs.yml
@@ -1,0 +1,4 @@
+author: Leshana
+delete-after: True
+changes:
+  - rscadd: "Added admin verbs for debugging the scheduled process controllers."


### PR DESCRIPTION
* Adds a verb for debugging any of the running process controllers.  Unlike the old debug controller verb, this one is not hard coded, so any present and future processes will be included.  Requires R_DEBUG (and R_ADMIN if in paranoid mode)
* Adds a verb for debugging the process scheduler itself.  This is hidden by default until debug verbs are shown.   Requires R_DEBUG (and R_ADMIN if in paranoid mode)