### PR TITLE
Un-scale HUDs for micros and macros.

### DIFF
--- a/code/defines/procs/hud.dm
+++ b/code/defines/procs/hud.dm
@@ -4,6 +4,7 @@ the HUD updates properly! */
 
 // hud overlay image type, used for clearing client.images precisely
 /image/hud_overlay
+	appearance_flags = APPEARANCE_UI // Don't get scaled with macro/micros.  VOREStation edit
 
 //Medical HUD outputs. Called by the Life() proc of the mob using it, usually.
 proc/process_med_hud(var/mob/M, var/local_scanner, var/mob/Alt)

--- a/code/game/dna/dna2_helpers.dm
+++ b/code/game/dna/dna2_helpers.dm
@@ -192,7 +192,7 @@
 		// Playerscale
 		var/size = dna.GetUIValueRange(DNA_UI_PLAYERSCALE, player_sizes_list.len)
 		if((0 < size) && (size <= player_sizes_list.len))
-			H.size_multiplier = player_sizes_list[player_sizes_list[size]]
+			H.resize(player_sizes_list[player_sizes_list[size]], FALSE)
 
 		// Tail/Taur Color
 		H.r_tail   = dna.GetUIValueRange(DNA_UI_TAIL_R,    255)

--- a/code/modules/client/preference_setup/vore/02_size.dm
+++ b/code/modules/client/preference_setup/vore/02_size.dm
@@ -38,7 +38,7 @@
 	pref.weight_loss	= sanitize_integer(pref.weight_loss, WEIGHT_CHANGE_MIN, WEIGHT_CHANGE_MAX, initial(pref.weight_loss))
 
 /datum/category_item/player_setup_item/vore/size/copy_to_mob(var/mob/living/carbon/human/character)
-	character.size_multiplier	= pref.size_multiplier
+	character.resize(pref.size_multiplier, FALSE)
 	character.weight			= pref.weight_vr
 	character.weight_gain		= pref.weight_gain
 	character.weight_loss		= pref.weight_loss

--- a/code/modules/resleeving/designer.dm
+++ b/code/modules/resleeving/designer.dm
@@ -287,7 +287,7 @@
 	H.dna = R.dna.Clone()
 	H.UpdateAppearance() // Update all appearance stuff from the DNA record
 	H.sync_organ_dna() // Do this because sprites depend on DNA-gender of organs (chest etc)
-	H.size_multiplier = active_br.sizemult
+	H.resize(active_br.sizemult, FALSE)
 
 	// And as for clothing...
 	// We don't actually dress them! This is a medical machine, handle the nakedness DOCTOR!

--- a/code/modules/resleeving/machines.dm
+++ b/code/modules/resleeving/machines.dm
@@ -88,7 +88,7 @@
 	//Basically all the VORE stuff
 	H.ooc_notes = current_project.body_oocnotes
 	H.flavor_texts = current_project.mydna.flavor.Copy()
-	H.size_multiplier = current_project.sizemult
+	H.resize(current_project.sizemult, FALSE)
 	H.weight = current_project.weight
 	if(current_project.speciesname)
 		H.custom_species = current_project.speciesname
@@ -301,7 +301,7 @@
 	//Basically all the VORE stuff
 	H.ooc_notes = current_project.body_oocnotes
 	H.flavor_texts = current_project.mydna.flavor.Copy()
-	H.size_multiplier = current_project.sizemult
+	H.resize(current_project.sizemult)
 	H.weight = current_project.weight
 	if(current_project.speciesname)
 		H.custom_species = current_project.speciesname

--- a/code/modules/vore/resizing/resize_vr.dm
+++ b/code/modules/vore/resizing/resize_vr.dm
@@ -57,15 +57,26 @@ var/const/RESIZE_A_SMALLTINY = (RESIZE_SMALL + RESIZE_TINY) / 2
  * Resizes the mob immediately to the desired mod, animating it growing/shrinking.
  * It can be used by anything that calls it.
  */
-/mob/living/proc/resize(var/new_size)
-	var/matrix/resize = matrix() // Defines the matrix to change the player's size
-	resize.Scale(new_size) //Change the size of the matrix
-
-	if(new_size >= RESIZE_NORMAL)
-		resize.Translate(0, -1 * (1 - new_size) * 16) //Move the player up in the tile so their feet align with the bottom
-
-	animate(src, transform = resize, time = 5) //Animate the player resizing
+/mob/living/proc/resize(var/new_size, var/animate = TRUE)
+	if(size_multiplier == new_size)
+		return 1
+	if(animate)
+		var/matrix/resize = matrix() // Defines the matrix to change the player's size
+		resize.Scale(new_size) //Change the size of the matrix
+		resize.Translate(0, 16 * (new_size - 1)) //Move the player up in the tile so their feet align with the bottom
+		animate(src, transform = resize, time = 5) //Animate the player resizing
 	size_multiplier = new_size //Change size_multiplier so that other items can interact with them
+
+/mob/living/carbon/human/resize(var/new_size, var/animate = TRUE)
+	if(..()) return 1
+	var/new_y_offset = 32 * (size_multiplier - 1)
+	for(var/I in hud_list)
+		var/image/hud_overlay/HI = I
+		HI.pixel_y = new_y_offset
+
+// Optimize mannequins - never a point to animating or doing HUDs on these.
+/mob/living/carbon/human/dummy/mannequin/resize(var/new_size)
+	size_multiplier = new_size
 
 /**
  * Verb proc for a command that lets players change their size OOCly.


### PR DESCRIPTION
* Set appearance_flags on HUD images to prevent them from being scaled up/down when the owning mob is macro/micro.
* Optimized the resize() proc and made it adjust the vertical position of the unscaled hud to stay even with the top of the mob's head.
* Also fix the resize proc to be consistent with update_icons().   Now micros wont be in the middle of a turf temporarily after resizing.