### PR TITLE
Replace 'magic' messages with Facility PA

### DIFF
--- a/code/__defines/misc_vr.dm
+++ b/code/__defines/misc_vr.dm
@@ -13,3 +13,5 @@
 #define VANTAG_VORE    "vantag_vore"
 #define VANTAG_KIDNAP  "vantag_kidnap"
 #define VANTAG_KILL    "vantag_kill"
+
+#define ANNOUNCER_NAME "Facility PA"

--- a/code/defines/procs/announce.dm
+++ b/code/defines/procs/announce.dm
@@ -1,3 +1,5 @@
+//VOREStation Edit - Most of this file has been changed to use the Eris-style PA announcements.
+//You'll need to compare externally, or use your best judgement when merging.
 /var/datum/announcement/priority/priority_announcement = new(do_log = 0)
 /var/datum/announcement/priority/command/command_announcement = new(do_log = 0, do_newscast = 1)
 
@@ -47,38 +49,19 @@
 	Log(message, message_title)
 
 datum/announcement/proc/Message(message as text, message_title as text)
-	for(var/mob/M in player_list)
-		if(!istype(M,/mob/new_player) && !isdeaf(M))
-			M << "<h2 class='alert'>[title]</h2>"
-			M << "<span class='alert'>[message]</span>"
-			if (announcer)
-				M << "<span class='alert'> -[html_encode(announcer)]</span>"
+	global_announcer.autosay("<span class='alert'>[message_title]:</span> [message]", announcer ? announcer : ANNOUNCER_NAME)
 
 datum/announcement/minor/Message(message as text, message_title as text)
-	world << "<b>[message]</b>"
+	global_announcer.autosay(message, announcer ? announcer : ANNOUNCER_NAME)
 
 datum/announcement/priority/Message(message as text, message_title as text)
-	world << "<h1 class='alert'>[message_title]</h1>"
-	world << "<span class='alert'>[message]</span>"
-	if(announcer)
-		world << "<span class='alert'> -[html_encode(announcer)]</span>"
-	world << "<br>"
+	global_announcer.autosay("<span class='alert'>[message_title]:</span> [message]", announcer ? announcer : ANNOUNCER_NAME)
 
 datum/announcement/priority/command/Message(message as text, message_title as text)
-	var/command
-	command += "<h1 class='alert'>[command_name()] Update</h1>"
-	if (message_title)
-		command += "<br><h2 class='alert'>[message_title]</h2>"
-
-	command += "<br><span class='alert'>[message]</span><br>"
-	command += "<br>"
-	for(var/mob/M in player_list)
-		if(!istype(M,/mob/new_player) && !isdeaf(M))
-			M << command
+	global_announcer.autosay("<span class='alert'>[command_name()] - [message_title]:</span> [message]", ANNOUNCER_NAME)
 
 datum/announcement/priority/security/Message(message as text, message_title as text)
-	world << "<font size=4 color='red'>[message_title]</font>"
-	world << "<font color='red'>[message]</font>"
+	global_announcer.autosay("<span class='alert'>[message_title]:</span> [message]", ANNOUNCER_NAME)
 
 datum/announcement/proc/NewsCast(message as text, message_title as text)
 	if(!newscast)
@@ -131,4 +114,4 @@ datum/announcement/proc/Log(message as text, message_title as text)
 		AnnounceArrivalSimple(character.real_name, rank, join_message)
 
 /proc/AnnounceArrivalSimple(var/name, var/rank = "visitor", var/join_message = "has arrived on the station")
-	global_announcer.autosay("[name], [rank], [join_message].", "Arrivals Announcement Computer")
+	global_announcer.autosay("[name], [rank], [join_message].", ANNOUNCER_NAME)

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -664,31 +664,34 @@ proc/admin_notice(var/message, var/rights)
 		log_admin("Announce: [key_name(usr)] : [message]")
 	feedback_add_details("admin_verb","A") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
+//VOREStation Edit to this verb for the purpose of making it compliant with the annunciator system
+var/datum/announcement/priority/admin_pri_announcer = new
+var/datum/announcement/minor/admin_min_announcer = new
 /datum/admins/proc/intercom()
 	set category = "Fun"
 	set name = "Intercom Msg"
 	set desc = "Send an intercom message, like an arrivals announcement."
 	if(!check_rights(0))	return
 
-	//This is basically how death alarms do it
-	var/obj/item/device/radio/headset/a = new /obj/item/device/radio/headset/ert(null)
-	a.icon = 'icons/obj/radio.dmi' //VOREStation Tweak
-	a.icon_state = "intercom" //VOREStation Tweak
+	var/sender = input("Name of sender (max 75):", "Intercom Msg", ANNOUNCER_NAME) as null|text
+	if(sender) //They put a sender
+		sender = sanitize(sender, 75, extra = 0)
+		var/message = input("Message content (max 500):", "Contents", "This is a test of the announcement system.") as null|message
+		if(message) //They put a message
+			message = sanitize(message, 500, extra = 0)
+			var/priority = alert("Priority or Normal?","Intercom Msg","Priority","Cancel","Normal")
+			var/datum/announcement/A
+			switch(priority)
+				if("Priority")
+					A = admin_pri_announcer
+				if("Normal")
+					A = admin_min_announcer
+			if(A)
+				A.announcer = sender
+				A.Announce(message)
+				A.announcer = ""
+				log_admin("Intercom Verb: [key_name(usr)] : [sender]:[message]")
 
-	var/channel = input("Channel for message:","Channel", null) as null|anything in (list("Common") + a.keyslot1.channels + a.keyslot2.channels)
-
-	if(channel) //They picked a channel
-		var/sender = input("Name of sender (max 75):", "Announcement", "Announcement Computer") as null|text
-
-		if(sender) //They put a sender
-			sender = sanitize(sender, 75, extra = 0)
-			var/message = input("Message content (max 500):", "Contents", "This is a test of the announcement system.") as null|message
-
-			if(message) //They put a message
-				message = sanitize(message, 500, extra = 0)
-				a.autosay("[message]", "[sender]", "[channel == "Common" ? null : channel]") //Common is a weird case, as it's not a "channel", it's just talking into a radio without a channel set.
-				log_admin("Intercom: [key_name(usr)] : [sender]:[message]")
-	qdel(a)
 	feedback_add_details("admin_verb","IN") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /datum/admins/proc/toggleooc()


### PR DESCRIPTION
This replaces the mystical messages of things like Command Reports, the 'All hands' message when a CD joins, and head announcements with a PA system that behaves more reasonably than pushing all the messages out of the chat box. Nothing about the systems changed, just the way they show up. They still make the sound, too.

![image](https://cloud.githubusercontent.com/assets/15028025/25402111/c0a0f08a-29c5-11e7-9988-09bc2d6b54ba.png)
