### PR TITLE
Fixes Unathi TF organ rejection

### DIFF
--- a/code/modules/vore/eating/bellymodes_vr.dm
+++ b/code/modules/vore/eating/bellymodes_vr.dm
@@ -336,6 +336,8 @@
 						Z.sync_colour_to_human(P)
 					P << "<span class='notice'>You lose sensation of your body, feeling only the warmth of everything around you... </span>"
 					owner << "<span class='notice'>Your body shifts as you make dramatic changes to your captive's body.</span>"
+					if(P.species == Unathi)
+						P.species.create_organs(P) //This is the only way to make it so Unathi TF doesn't result in people dying from organ rejection.
 					P.fixblood()
 					P.update_body()
 					P.update_tail_showing()
@@ -405,6 +407,8 @@
 						Z.sync_colour_to_human(P)
  					P << "<span class='notice'>You lose sensation of your body, feeling only the warmth of everything around you... </span>"
 					owner << "<span class='notice'>Your body shifts as you make dramatic changes to your captive's body.</span>"
+					if(P.species == Unathi)
+						P.species.create_organs(P)
 					P.fixblood()
 					P.update_hair()
 					P.update_body()
@@ -435,6 +439,8 @@
 				Z.sync_colour_to_human(P)
 			P << "<span class='notice'>You lose sensation of your body, feeling only the warmth around you as are you as you're encased in an egg. </span>"
 			owner << "<span class='notice'>You shift as you make dramatic changes to your captive's body as you encase them in an egg.</span>"
+			if(P.species == Unathi)
+				P.species.create_organs(P)
 			P.fixblood()
 			P.update_hair()
 			P.update_body()
@@ -533,6 +539,8 @@
 				Z.sync_colour_to_human(P)
 			P << "<span class='notice'>You lose sensation of your body, feeling only the warmth around you as are you as you're encased in an egg. </span>"
 			owner << "<span class='notice'>You shift as you make dramatic changes to your captive's body as you encase them in an egg.</span>"
+			if(P.species == Unathi)
+				P.species.create_organs(P)
 			P.fixblood()
 			P.update_hair()
 			P.update_body()

--- a/code/modules/vore/eating/bellymodes_vr.dm
+++ b/code/modules/vore/eating/bellymodes_vr.dm
@@ -336,8 +336,7 @@
 						Z.sync_colour_to_human(P)
 					P << "<span class='notice'>You lose sensation of your body, feeling only the warmth of everything around you... </span>"
 					owner << "<span class='notice'>Your body shifts as you make dramatic changes to your captive's body.</span>"
-					if(P.species == Unathi)
-						P.species.create_organs(P) //This is the only way to make it so Unathi TF doesn't result in people dying from organ rejection.
+					P.species.create_organs(P)//This is the only way to make it so Unathi TF doesn't result in people dying from organ rejection.
 					P.fixblood()
 					P.update_body()
 					P.update_tail_showing()
@@ -407,8 +406,7 @@
 						Z.sync_colour_to_human(P)
  					P << "<span class='notice'>You lose sensation of your body, feeling only the warmth of everything around you... </span>"
 					owner << "<span class='notice'>Your body shifts as you make dramatic changes to your captive's body.</span>"
-					if(P.species == Unathi)
-						P.species.create_organs(P)
+					P.species.create_organs(P)
 					P.fixblood()
 					P.update_hair()
 					P.update_body()
@@ -439,8 +437,7 @@
 				Z.sync_colour_to_human(P)
 			P << "<span class='notice'>You lose sensation of your body, feeling only the warmth around you as are you as you're encased in an egg. </span>"
 			owner << "<span class='notice'>You shift as you make dramatic changes to your captive's body as you encase them in an egg.</span>"
-			if(P.species == Unathi)
-				P.species.create_organs(P)
+			P.species.create_organs(P)
 			P.fixblood()
 			P.update_hair()
 			P.update_body()
@@ -539,8 +536,7 @@
 				Z.sync_colour_to_human(P)
 			P << "<span class='notice'>You lose sensation of your body, feeling only the warmth around you as are you as you're encased in an egg. </span>"
 			owner << "<span class='notice'>You shift as you make dramatic changes to your captive's body as you encase them in an egg.</span>"
-			if(P.species == Unathi)
-				P.species.create_organs(P)
+			P.species.create_organs(P)
 			P.fixblood()
 			P.update_hair()
 			P.update_body()

--- a/code/modules/vore/eating/bellymodes_vr.dm
+++ b/code/modules/vore/eating/bellymodes_vr.dm
@@ -333,6 +333,8 @@
 					P.species.create_organs(P) //This is the only way to make it so Unathi TF doesn't result in people dying from organ rejection.
 					for(var/obj/item/organ/I in P.organs) //This prevents organ rejection
 						I.species = O.species
+					for(var/obj/item/organ/I in P.internal_organs) //This prevents organ rejection
+						I.species = O.species
 					for(var/obj/item/organ/external/Z in P.organs)//Just in case.
 						Z.sync_colour_to_human(P)
 					P << "<span class='notice'>You lose sensation of your body, feeling only the warmth of everything around you... </span>"
@@ -401,7 +403,9 @@
 					P.species = O.species
 					P.custom_species = O.custom_species
 					P.species.create_organs(P)
-					for(var/obj/item/organ/I in P.organs) //This prevents organ rejection
+					for(var/obj/item/organ/I in P.organs)
+						I.species = O.species
+					for(var/obj/item/organ/I in P.internal_organs)
 						I.species = O.species
 					for(var/obj/item/organ/external/Z in P.organs)
 						Z.sync_colour_to_human(P)
@@ -432,7 +436,9 @@
 			P.ear_style = O.ear_style
 			P.species = O.species
 			P.species.create_organs(P)
-			for(var/obj/item/organ/I in P.organs) //This prevents organ rejection
+			for(var/obj/item/organ/I in P.organs)
+				I.species = O.species
+			for(var/obj/item/organ/I in P.internal_organs)
 				I.species = O.species
 			for(var/obj/item/organ/external/Z in P.organs)
 				Z.sync_colour_to_human(P)
@@ -531,7 +537,9 @@
 			P.b_eyes 			= O.b_eyes
 
 			P.species.create_organs(P)
-			for(var/obj/item/organ/I in P.organs) //This prevents organ rejection
+			for(var/obj/item/organ/I in P.organs)
+				I.species = O.species
+			for(var/obj/item/organ/I in P.internal_organs)
 				I.species = O.species
 			for(var/obj/item/organ/external/Z in P.organs)
 				Z.sync_colour_to_human(P)

--- a/code/modules/vore/eating/bellymodes_vr.dm
+++ b/code/modules/vore/eating/bellymodes_vr.dm
@@ -330,13 +330,13 @@
 					P.ear_style = O.ear_style
 					P.species = O.species
 					P.custom_species = O.custom_species
+					P.species.create_organs(P) //This is the only way to make it so Unathi TF doesn't result in people dying from organ rejection.
 					for(var/obj/item/organ/I in P.organs) //This prevents organ rejection
 						I.species = O.species
 					for(var/obj/item/organ/external/Z in P.organs)//Just in case.
 						Z.sync_colour_to_human(P)
 					P << "<span class='notice'>You lose sensation of your body, feeling only the warmth of everything around you... </span>"
 					owner << "<span class='notice'>Your body shifts as you make dramatic changes to your captive's body.</span>"
-					P.species.create_organs(P)//This is the only way to make it so Unathi TF doesn't result in people dying from organ rejection.
 					P.fixblood()
 					P.update_body()
 					P.update_tail_showing()
@@ -400,13 +400,13 @@
 					P.ear_style = O.ear_style
 					P.species = O.species
 					P.custom_species = O.custom_species
+					P.species.create_organs(P)
 					for(var/obj/item/organ/I in P.organs) //This prevents organ rejection
 						I.species = O.species
 					for(var/obj/item/organ/external/Z in P.organs)
 						Z.sync_colour_to_human(P)
  					P << "<span class='notice'>You lose sensation of your body, feeling only the warmth of everything around you... </span>"
 					owner << "<span class='notice'>Your body shifts as you make dramatic changes to your captive's body.</span>"
-					P.species.create_organs(P)
 					P.fixblood()
 					P.update_hair()
 					P.update_body()
@@ -431,13 +431,13 @@
 			P.tail_style = O.tail_style
 			P.ear_style = O.ear_style
 			P.species = O.species
+			P.species.create_organs(P)
 			for(var/obj/item/organ/I in P.organs) //This prevents organ rejection
 				I.species = O.species
 			for(var/obj/item/organ/external/Z in P.organs)
 				Z.sync_colour_to_human(P)
 			P << "<span class='notice'>You lose sensation of your body, feeling only the warmth around you as are you as you're encased in an egg. </span>"
 			owner << "<span class='notice'>You shift as you make dramatic changes to your captive's body as you encase them in an egg.</span>"
-			P.species.create_organs(P)
 			P.fixblood()
 			P.update_hair()
 			P.update_body()
@@ -530,13 +530,13 @@
 			P.g_eyes 			= O.g_eyes
 			P.b_eyes 			= O.b_eyes
 
+			P.species.create_organs(P)
 			for(var/obj/item/organ/I in P.organs) //This prevents organ rejection
 				I.species = O.species
 			for(var/obj/item/organ/external/Z in P.organs)
 				Z.sync_colour_to_human(P)
 			P << "<span class='notice'>You lose sensation of your body, feeling only the warmth around you as are you as you're encased in an egg. </span>"
 			owner << "<span class='notice'>You shift as you make dramatic changes to your captive's body as you encase them in an egg.</span>"
-			P.species.create_organs(P)
 			P.fixblood()
 			P.update_hair()
 			P.update_body()


### PR DESCRIPTION
#1434 
Fixes people from dying from Unathi TF. 
Deletes their old organs and replaces it with the correct organs their species should have. Additionally, this prevents this problem from ever coming up again in case another species is changed like the unathi was.
Fixes organ rejection due to #1393. As it turns out, internal organs aren't listed under organs, but rather internal_organs.
Before/after TF with this code below (Human -> Unathi TF):
https://gyazo.com/b05b8fae807278209b495ba81faab618
https://gyazo.com/2f91bc1ad1a6be660b40fd4ee2c7fd09