### PR TITLE
Subspace jammer item

### DIFF
--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -1083,7 +1083,10 @@ var/global/list/obj/item/device/pda/PDAs = list()
 	if (last_text && world.time < last_text + 5)
 		return
 
-	if(!can_use())
+	if (!can_use())
+		return
+
+	if (is_jammed(src))
 		return
 
 	last_text = world.time
@@ -1156,6 +1159,8 @@ var/global/list/obj/item/device/pda/PDAs = list()
 	// Do nothing
 
 /obj/item/device/pda/proc/new_message_from_pda(var/obj/item/device/pda/sending_device, var/message)
+	if (is_jammed(src))
+		return
 	new_message(sending_device, sending_device.owner, sending_device.ownjob, message)
 
 /obj/item/device/pda/proc/new_message(var/sending_unit, var/sender, var/sender_job, var/message, var/reply = 1)

--- a/code/game/objects/items/devices/communicator/communicator.dm
+++ b/code/game/objects/items/devices/communicator/communicator.dm
@@ -169,9 +169,8 @@ var/global/list/obj/item/device/communicator/all_communicators = list()
 // Parameters: None
 // Description: Simple check to see if the exonet node is active.
 /obj/item/device/communicator/proc/get_connection_to_tcomms()
-	if(node)
-		if(node.on && node.allow_external_communicators)
-			return 1
+	if(node && node.on && node.allow_external_communicators && !is_jammed(src))
+		return 1
 	return 0
 
 // Proc: process()
@@ -182,7 +181,7 @@ var/global/list/obj/item/device/communicator/all_communicators = list()
 	if(update_ticks % 5)
 		if(!node)
 			node = get_exonet_node()
-		if(!node || !node.on || !node.allow_external_communicators)
+		if(!get_connection_to_tcomms())
 			close_connection(reason = "Connection timed out")
 
 // Proc: attackby()

--- a/code/game/objects/items/devices/radio/jammer.dm
+++ b/code/game/objects/items/devices/radio/jammer.dm
@@ -1,0 +1,91 @@
+var/global/list/active_radio_jammers = list()
+
+/proc/is_jammed(var/obj/radio)
+	var/turf/Tr = get_turf(radio)
+	if(!Tr) return 0 //Nullspace radios don't get jammed.
+
+	for(var/jammer in active_radio_jammers)
+		var/obj/item/device/radio_jammer/J = jammer
+		var/turf/Tj = get_turf(J)
+
+		if(J.on && Tj.z == Tr.z) //If we're on the same Z, it's worth checking.
+			var/dist = get_dist(Tj,Tr)
+			if(dist <= J.jam_range)
+				return list("jammer" = J, "distance" = dist)
+
+/obj/item/device/radio_jammer
+	name = "subspace jammer"
+	desc = "Primarily for blocking subspace communications, preventing the use of headsets, PDAs, and communicators."
+	icon = 'icons/obj/device_alt.dmi'
+	icon_state = "shield0"
+	var/active_state = "shield1"
+
+	var/on = 0
+	var/jam_range = 7
+	var/obj/item/weapon/cell/device/weapon/power_source
+	var/tick_cost = 80
+
+	origin_tech = list(TECH_ILLEGAL = 7, TECH_BLUESPACE = 5) //Such technology! Subspace jamming!
+
+/obj/item/device/radio_jammer/New()
+	power_source = new(src)
+
+/obj/item/device/radio_jammer/Destroy()
+	if(on)
+		turn_off()
+	if(power_source)
+		qdel(power_source)
+	power_source = null
+	..()
+
+/obj/item/device/radio_jammer/proc/turn_off(mob/user)
+	if(user)
+		to_chat(user,"<span class='warning'>\The [src] deactivates.</span>")
+	processing_objects.Remove(src)
+	active_radio_jammers -= src
+	on = FALSE
+	icon_state = initial(icon_state)
+
+/obj/item/device/radio_jammer/proc/turn_on(mob/user)
+	if(user)
+		to_chat(user,"<span class='notice'>\The [src] is now active.</span>")
+	processing_objects.Add(src)
+	active_radio_jammers += src
+	on = TRUE
+	icon_state = active_state
+
+/obj/item/device/radio_jammer/process()
+	if(!power_source || !power_source.check_charge(tick_cost))
+		var/mob/living/notify
+		if(isliving(loc))
+			notify = loc
+		turn_off(notify)
+	else
+		power_source.use(tick_cost)
+
+
+/obj/item/device/radio_jammer/attack_hand(mob/user)
+	if(user.get_inactive_hand() == src && power_source)
+		to_chat(user,"<span class='notice'>You eject \the [power_source] from \the [src].</span>")
+		user.put_in_hands(power_source)
+		power_source = null
+		turn_off()
+	else
+		return ..()
+
+/obj/item/device/radio_jammer/attack_self(mob/user)
+	if(on)
+		turn_off(user)
+	else
+		if(power_source)
+			turn_on(user)
+		else
+			to_chat(user,"<span class='warning'>\The [src] has no power source!</span>")
+
+/obj/item/device/radio_jammer/attackby(obj/W, mob/user)
+	if(istype(W,/obj/item/weapon/cell/device/weapon) && !power_source)
+		power_source = W
+		power_source.update_icon() //Why doesn't a cell do this already? :|
+		user.unEquip(power_source)
+		power_source.forceMove(src)
+		to_chat(user,"<span class='notice'>You insert \the [power_source] into \the [src].</span>")

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -362,6 +362,12 @@ var/global/list/default_medbay_channels = list(
   /* ###### Radio headsets can only broadcast through subspace ###### */
 
 	if(subspace_transmission)
+		var/list/jamming = is_jammed(src)
+		if(jamming)
+			var/distance = jamming["distance"]
+			to_chat(M,"<span class='danger'>\icon[src] You hear the [distance <= 2 ? "loud hiss" : "soft hiss"] of static.</span>")
+			return 0
+
 		// First, we want to generate a new radio signal
 		var/datum/signal/signal = new
 		signal.transmission_method = 2 // 2 would be a subspace transmission.
@@ -502,6 +508,8 @@ var/global/list/default_medbay_channels = list(
 	if (wires.IsIndexCut(WIRE_RECEIVE))
 		return -1
 	if(!listening)
+		return -1
+	if(is_jammed(src))
 		return -1
 	if(!(0 in level))
 		var/turf/position = get_turf(src)

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -841,6 +841,7 @@
 #include "code\game\objects\items\devices\radio\headset.dm"
 #include "code\game\objects\items\devices\radio\headset_vr.dm"
 #include "code\game\objects\items\devices\radio\intercom.dm"
+#include "code\game\objects\items\devices\radio\jammer.dm"
 #include "code\game\objects\items\devices\radio\radio.dm"
 #include "code\game\objects\items\robot\robot_items.dm"
 #include "code\game\objects\items\robot\robot_parts.dm"


### PR DESCRIPTION
Jams the three devices that I'm aware of that use subspace communications: Headsets, PDAs, and Communicators.

All three will be unable to communicate if in range of a jammer. The default range is 7 turfs, the battery that comes in the jammer is a weapon cell (just to make it a little harder to find replacements) and lasts 60 seconds. The range and power use are variables.

Speaking through a headset will produce 'soft' or 'loud' static depending on how far you are, allowing you to sort of dead-reckon your way to a placed jammer. You can just carry them, otherwise.

I've got no experience with adding tator items so I'll leave that sort of thing up to you guys.