### PR TITLE
Switch nanomap computers over to using get_sensor_levels()

### DIFF
--- a/code/game/machinery/computer/camera.dm
+++ b/code/game/machinery/computer/camera.dm
@@ -47,7 +47,7 @@
 		data["cameras"] = camera_repository.cameras_in_network(current_network)
 	if(current_camera)
 		switch_to_camera(user, current_camera)
-	data["station_levels"] = using_map.station_levels
+	data["map_levels"] = using_map.get_map_levels(src.z)
 
 	ui = nanomanager.try_update_ui(user, src, ui_key, ui, data, force_open)
 	if (!ui)

--- a/code/modules/nano/modules/atmos_control.dm
+++ b/code/modules/nano/modules/atmos_control.dm
@@ -32,6 +32,7 @@
 /datum/nano_module/atmos_control/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1, var/master_ui = null, var/datum/topic_state/state = default_state)
 	var/data[0]
 	var/alarms[0]
+	var/turf/T = get_turf(nano_host())
 
 	// TODO: Move these to a cache, similar to cameras
 	for(var/obj/machinery/alarm/alarm in (monitored_alarms.len ? monitored_alarms : machines))
@@ -43,7 +44,7 @@
 			"y" = alarm.y,
 			"z" = alarm.z)
 	data["alarms"] = alarms
-	data["station_levels"] = using_map.station_levels
+	data["map_levels"] = using_map.get_map_levels(T.z)
 
 	ui = nanomanager.try_update_ui(user, src, ui_key, ui, data, force_open)
 	if(!ui)

--- a/code/modules/nano/modules/crew_monitor.dm
+++ b/code/modules/nano/modules/crew_monitor.dm
@@ -20,12 +20,10 @@
 	var/turf/T = get_turf(nano_host())
 
 	data["isAI"] = isAI(user)
-
-	data["station_levels"] = get_z_levels(T)
-	var/list/crewmembers = list()
-	for(var/z in data["station_levels"])
-		crewmembers += crew_repository.health_data(z)
-	data["crewmembers"] = crewmembers
+	data["map_levels"] = using_map.get_map_levels(T.z, FALSE)
+	data["crewmembers"] = list()
+	for(var/z in (data["map_levels"] | T.z))  // Always show crew from the current Z even if we can't show a map
+		data["crewmembers"] += crew_repository.health_data(z)
 
 	ui = nanomanager.try_update_ui(user, src, ui_key, ui, data, force_open)
 	if(!ui)
@@ -35,17 +33,12 @@
 		ui.add_template("mapContent", "crew_monitor_map_content.tmpl")
 		// adding a template with the key "mapHeader" replaces the map header content
 		ui.add_template("mapHeader", "crew_monitor_map_header.tmpl")
-		if(!(ui.map_z_level in data["station_levels"]))
-			ui.set_map_z_level(data["station_levels"][1])
 
 		ui.set_initial_data(data)
 		ui.open()
 
 		// should make the UI auto-update; doesn't seem to?
 		ui.set_auto_update(1)
-
-/datum/nano_module/crew_monitor/proc/get_z_levels(var/turf/T)
-	return list(T.z)
 
 /*/datum/nano_module/crew_monitor/proc/scan()
 	for(var/mob/living/carbon/human/H in mob_list)

--- a/code/modules/nano/modules/power_monitor.dm
+++ b/code/modules/nano/modules/power_monitor.dm
@@ -12,6 +12,7 @@
 	var/list/sensors = list()
 	// Focus: If it remains null if no sensor is selected and UI will display sensor list, otherwise it will display sensor reading.
 	var/obj/machinery/power/sensor/focus = null
+	var/turf/T = get_turf(nano_host())
 
 	// Build list of data from sensor readings.
 	for(var/obj/machinery/power/sensor/S in grid_sensors)
@@ -25,7 +26,7 @@
 	data["all_sensors"] = sensors
 	if(focus)
 		data["focus"] = focus.return_reading_data()
-	data["station_levels"] = using_map.station_levels
+	data["map_levels"] = using_map.get_map_levels(T.z)
 
 	ui = nanomanager.try_update_ui(user, src, ui_key, ui, data, force_open)
 	if (!ui)

--- a/maps/tether/tether_defines.dm
+++ b/maps/tether/tether_defines.dm
@@ -174,3 +174,21 @@
 		holomap_legend_x[z] = 220
 		holomap_legend_y[z] = 160
 	holomap_smoosh = list(list(1,2,3,5,6,7))
+
+
+// Short range computers see only the six main levels, others can see the surrounding surface levels.
+/datum/map/tether/get_map_levels(var/srcz, var/long_range = TRUE)
+	if (long_range && (srcz in map_levels))
+		return map_levels
+	else if (srcz == Z_LEVEL_TRANSIT)
+		return list() // Nothing on transit!
+	else if (srcz >= Z_LEVEL_SURFACE_LOW && srcz <= Z_LEVEL_SPACE_HIGH)
+		return list(
+			Z_LEVEL_SURFACE_LOW,
+			Z_LEVEL_SURFACE_MID,
+			Z_LEVEL_SURFACE_HIGH,
+			Z_LEVEL_SPACE_LOW,
+			Z_LEVEL_SPACE_MID,
+			Z_LEVEL_SPACE_HIGH)
+	else
+		return ..()

--- a/maps/tether/tether_things.dm
+++ b/maps/tether/tether_things.dm
@@ -191,16 +191,6 @@ var/global/list/latejoin_tram   = list()
 	..()
 	turfs = latejoin_tram
 
-// Override crew monitors so that ones on the station see the whole station, and ones on surface the whole surface.
-/datum/nano_module/crew_monitor/get_z_levels(var/turf/T)
-	switch(T.z)
-		if(Z_LEVEL_SURFACE_LOW to Z_LEVEL_SURFACE_HIGH)
-			return list(Z_LEVEL_SURFACE_LOW, Z_LEVEL_SURFACE_MID, Z_LEVEL_SURFACE_HIGH)
-		if(Z_LEVEL_SPACE_LOW to Z_LEVEL_SPACE_HIGH)
-			return list(Z_LEVEL_SPACE_LOW, Z_LEVEL_SPACE_MID, Z_LEVEL_SPACE_HIGH)
-		else
-			return ..()
-
 //
 // Holodorms
 //

--- a/maps/~map_system/maps.dm
+++ b/maps/~map_system/maps.dm
@@ -112,3 +112,14 @@ var/list/all_maps = list()
 		world.maxz++
 		empty_levels = list(world.maxz)
 	return pick(empty_levels)
+
+// Get the list of zlevels that a computer on srcz can see maps of (for power/crew monitor, cameras, etc)
+// The long_range parameter expands the coverage.  Default is to return map_levels for long range otherwise just srcz.
+// zLevels outside station_levels will return an empty list.
+/datum/map/proc/get_map_levels(var/srcz, var/long_range = TRUE)
+	if (long_range && (srcz in map_levels))
+		return map_levels
+	else if (srcz in station_levels)
+		return list(srcz)
+	else
+		return list()

--- a/nano/templates/atmos_control.tmpl
+++ b/nano/templates/atmos_control.tmpl
@@ -1,6 +1,8 @@
+{{if data.map_levels.length}}
 <div class="notice" style="height: 22px">
 	{{:helper.link('Show Air Alrms On Map', 'pin-s', {'showMap' : 1})}}
 </div>
+{{/if}}
 <div class='item'>
     {{for data.alarms}}
         {{:helper.link(value.name, null, {'alarm' : value.ref}, null, value.danger == 2 ? 'redButton' : (value.danger == 1 ? 'yellowButton' : null))}}

--- a/nano/templates/atmos_control_map_header.tmpl
+++ b/nano/templates/atmos_control_map_header.tmpl
@@ -3,11 +3,11 @@ Title: Atmos Control Console (Map Header)
 Used In File(s): \code\modules\nano\modules\atmos_control.dm
  -->
 {{:helper.link('Show List', 'script', {'showMap' : 0})}}
-{{if data.station_levels.length > 1}}
+{{if data.map_levels.length > 1}}
 <div style="float: right;">
     <span style="float: left;">Z Level:&nbsp;</span>
-    {{for data.station_levels }}
-        {{:helper.link(value, null, {'mapZLevel' : value}) }}
+    {{for data.map_levels }}
+        {{:helper.link(value, null, {'mapZLevel' : value}, null, config.mapZLevel == value ? 'selected' : null)}}
     {{/for}}
 </div>
 {{/if}}

--- a/nano/templates/crew_monitor.tmpl
+++ b/nano/templates/crew_monitor.tmpl
@@ -16,7 +16,9 @@ Used In File(s): \code\game\machinery\computer\crew.dm
     }
 </style>
 
-{{:helper.link('Show Tracker Map', 'pin-s', {'showMap' : 1})}}
+{{if data.map_levels.length}}
+	{{:helper.link('Show Tracker Map', 'pin-s', {'showMap' : 1})}}
+{{/if}}
 <table class='wideTable'><tbody>
 	{{for data.crewmembers}}
 		{{if value.sensor_type == 1}}

--- a/nano/templates/crew_monitor_map_header.tmpl
+++ b/nano/templates/crew_monitor_map_header.tmpl
@@ -3,11 +3,11 @@ Title: Crew Monitoring Console (Map header)
 Used In File(s): \code\game\machinery\computer\crew.dm
  -->
 {{:helper.link('Show Detail List', 'script', {'showMap' : 0})}}
-{{if data.station_levels.length > 1}}
+{{if data.map_levels.length > 1}}
 <div style="float: right;">
     <span style="float: left;">Z Level:&nbsp;</span>
-    {{for data.station_levels }}
-        {{:helper.link(value, null, {'mapZLevel' : value}) }}
+    {{for data.map_levels }}
+        {{:helper.link(value, null, {'mapZLevel' : value}, null, config.mapZLevel == value ? 'selected' : null)}}
     {{/for}}
 </div>
 {{/if}}

--- a/nano/templates/power_monitor.tmpl
+++ b/nano/templates/power_monitor.tmpl
@@ -2,7 +2,9 @@
 	<div class="notice" style="height: 22px">
 		{{:helper.link('Show List', 'cancel', { 'clear' : 1})}}   Sensor selected: {{:data.focus.name}} 
 	</div>
-	{{:helper.link('Show APCs On Map', 'pin-s', {'showMap' : 1})}}
+	{{if data.map_levels.length}}
+		{{:helper.link('Show APCs On Map', 'pin-s', {'showMap' : 1})}}
+	{{/if}}
 	{{if data.focus.error}}
 		{{:data.focus.error}}
 	{{else}}

--- a/nano/templates/power_monitor_map_header.tmpl
+++ b/nano/templates/power_monitor_map_header.tmpl
@@ -4,11 +4,11 @@ Used In File(s): \code\modules\nano\modules\power_monitor.dm
  -->
 {{:helper.link('Show Network Information', 'script', {'showMap' : 0})}}
 {{if data.focus}}<span>Sensor selected: {{:data.focus.name}}</span>{{/if}}
-{{if data.station_levels.length > 1}}
+{{if data.map_levels.length > 1}}
 <div style="float: right;">
     <span style="float: left;">Z Level:&nbsp;</span>
-    {{for data.station_levels }}
-        {{:helper.link(value, null, {'mapZLevel' : value}) }}
+    {{for data.map_levels }}
+        {{:helper.link(value, null, {'mapZLevel' : value}, null, config.mapZLevel == value ? 'selected' : null)}}
     {{/for}}
 </div>
 {{/if}}

--- a/nano/templates/sec_camera.tmpl
+++ b/nano/templates/sec_camera.tmpl
@@ -2,7 +2,9 @@
 Title: Security Camera Console (Main content)
 Used In File(s): \code\game\machinery\computer\camera.dm
  -->
-{{:helper.link('Show Map', 'pin-s', {'showMap' : 1})}}
+{{if data.map_levels.length}}
+	{{:helper.link('Show Map', 'pin-s', {'showMap' : 1})}}
+{{/if}}
 {{:helper.link('Reset', 'refresh', {'reset' : 1})}}
 <div style="float:left;">
     <div class='item'>

--- a/nano/templates/sec_camera_map_header.tmpl
+++ b/nano/templates/sec_camera_map_header.tmpl
@@ -14,11 +14,11 @@ Used In File(s): \code\game\machinery\computer\camera.dm
         {{/if}}
     </div>
 </div>
-{{if data.station_levels.length > 1}}
+{{if data.map_levels.length > 1}}
 <div style="float: right;">
     <span style="float: left;">Z Level:&nbsp;</span>
-    {{for data.station_levels }}
-        {{:helper.link(value, null, {'mapZLevel' : value}) }}
+    {{for data.map_levels }}
+        {{:helper.link(value, null, {'mapZLevel' : value}, null, config.mapZLevel == value ? 'selected' : null)}}
     {{/for}}
 </div>
 {{/if}}


### PR DESCRIPTION
* Added a proc to the map datum which returns what zlevels a nanomap capable computer should display.
* Updated the atmos control, power monitoring, crew monitoring, and camera consoles to use it.
* Changed templates to not show the map button if no map levels are available.
* Overrode it for tether to let crew monitoring computers monitor the whole station.