### PR TITLE
Disable gateway until maps can be resized

### DIFF
--- a/maps/RandomZLevels/fileList.txt
+++ b/maps/RandomZLevels/fileList.txt
@@ -7,8 +7,8 @@
 
 #maps/RandomZLevels/labyrinth.dmm #Broken still.
 #maps/RandomZLevels/snowfield.dmm #Broken.
-maps/RandomZLevels/carpfarm.dmm
-maps/RandomZLevels/listeningpost.dmm
-maps/RandomZLevels/blackmarketpackers.dmm
-maps/RandomZLevels/beach.dmm
-maps/RandomZLevels/zoo.dmm
+#maps/RandomZLevels/carpfarm.dmm
+#maps/RandomZLevels/listeningpost.dmm
+#maps/RandomZLevels/blackmarketpackers.dmm
+#maps/RandomZLevels/beach.dmm
+#maps/RandomZLevels/zoo.dmm


### PR DESCRIPTION
They need to be the same size as the rest of the maps, which might mean splitting them into multiz maps or just rearranging.