### PR TITLE
Fixes Sundry Runtimes

### DIFF
--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -211,7 +211,7 @@
 		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 		if (W.force >= src.toughness)
 			user.do_attack_animation(src)
-			visible_message("<span class='warning'><b>[src] has been [pick(W.attack_verb)] with [W] by [user]!</b></span>")
+			visible_message("<span class='warning'><b>[src] has been [W.attack_verb.len? pick(W.attack_verb) : "attacked"] with [W] by [user]!</b></span>")
 			if (istype(W, /obj/item)) //is it even possible to get into attackby() with non-items?
 				var/obj/item/I = W
 				if (I.hitsound)

--- a/code/modules/alarm/atmosphere_alarm.dm
+++ b/code/modules/alarm/atmosphere_alarm.dm
@@ -21,6 +21,6 @@
 //VOREStation Add - Alarm for AR glasses
 /datum/alarm_handler/atmosphere/on_alarm_change(var/datum/alarm/alarm, var/was_raised)
 	..()
-	var/atom/source = alarm.sources_assoc[1]
-	broadcast_engineering_hud_message("Alarm in [alarm.origin]!", source)
+	var/atom/source = length(alarm.sources_assoc) ? alarm.sources_assoc[1] : alarm.alarm_area()
+	broadcast_engineering_hud_message("Alarm in [alarm.origin] [was_raised ? "raised!" : "cleared."]", source)
 //VOREStation Add End

--- a/code/modules/alarm/fire_alarm.dm
+++ b/code/modules/alarm/fire_alarm.dm
@@ -6,11 +6,10 @@
 	if(istype(A))
 		if(was_raised)
 			A.fire_alert()
-
-			//VOREStation Add - Alarm for AR glasses uses
-			var/atom/source = alarm.sources_assoc[1]
-			broadcast_engineering_hud_message("Alarm in [alarm.origin]!", source)
-			//VOREStation Add End
 		else
 			A.fire_reset()
+	//VOREStation Add - Alarm for AR glasses uses
+	var/atom/source = length(alarm.sources_assoc) ? alarm.sources_assoc[1] : alarm.alarm_area()
+	broadcast_engineering_hud_message("Alarm in [alarm.origin] [was_raised ? "raised!" : "cleared."]", source)
+	//VOREStation Add End
 	..()

--- a/code/modules/client/preference_setup/vore/04_resleeving.dm
+++ b/code/modules/client/preference_setup/vore/04_resleeving.dm
@@ -24,6 +24,8 @@
 /datum/category_item/player_setup_item/vore/resleeve/copy_to_mob(var/mob/living/carbon/human/character)
 	if(character && !istype(character,/mob/living/carbon/human/dummy))
 		spawn(50)
+			if(deleted(character) || deleted(pref))
+				return // They might have been deleted during the wait
 			if(pref.resleeve_scan)
 				var/datum/transhuman/body_record/BR = new()  //Clearly related to size.
 				BR.init_from_mob(character, pref.resleeve_scan, pref.resleeve_lock)

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -356,7 +356,7 @@ proc/is_blind(A)
 	broadcast_hud_message(message, broadcast_source, med_hud_users, /obj/item/clothing/glasses/hud/health)
 
 /proc/broadcast_hud_message(var/message, var/broadcast_source, var/list/targets, var/icon)
-	var/turf/sourceturf = get_turf(broadcast_source)
+	var/atom/sourceturf = isarea(broadcast_source) ? broadcast_source : get_turf(broadcast_source) // VOREStation Edit - Allow broadcasts from an area
 	for(var/mob/M in targets)
 		var/turf/targetturf = get_turf(M)
 		if((targetturf.z == sourceturf.z))

--- a/code/modules/mob/new_player/preferences_setup.dm
+++ b/code/modules/mob/new_player/preferences_setup.dm
@@ -225,12 +225,14 @@
 			var/datum/gear/G = gear_datums[thing]
 			if(G)
 				var/permitted = 0
-				if(G.allowed_roles)
+				if(!G.allowed_roles)
+					permitted = 1
+				else if(!previewJob)
+					permitted = 0
+				else
 					for(var/job_name in G.allowed_roles)
 						if(previewJob.title == job_name)
 							permitted = 1
-				else
-					permitted = 1
 
 				if(G.whitelisted && (G.whitelisted != mannequin.species.name))
 					permitted = 0


### PR DESCRIPTION
Fixes Runtime in camera.dm,214: pick() from empty list
Fixes Runtime in preferences_setup.dm,230: Cannot read null.title
Fixes Runtime in atmosphere_alarm.dm,24: list index out of bounds
Fixes Runtime in 04_resleeving.dm,32: Cannot read null.ckey
Fixes Runtime in infocore.dm,175: code/modules/resleeving/infocore.dm:175:Assertion Failed: !deleted(M)