### PR TITLE
Cryo consoles require head access

### DIFF
--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -27,6 +27,8 @@
 	var/storage_name = "Cryogenic Oversight Control"
 	var/allow_items = 1
 
+	req_one_access = list(access_heads) //VOREStation Add
+
 /obj/machinery/computer/cryopod/robot
 	name = "robotic storage console"
 	desc = "An interface between crew and the robotic storage systems"


### PR DESCRIPTION
To prevent people from just rummaging around through everyone's stuff and taking it.