### PR TITLE
Sundry runtimes 2

### DIFF
--- a/code/game/objects/structures/lattice.dm
+++ b/code/game/objects/structures/lattice.dm
@@ -37,7 +37,7 @@
 	if(istype(loc, /turf/simulated/open))
 		var/turf/simulated/open/O = loc
 		spawn(1)
-			if(O) // If we built a new floor with the lattice, the open turf won't exist anymore.
+			if(istype(O)) // If we built a new floor with the lattice, the open turf won't exist anymore.
 				O.update() // This lattice may be supporting things on top of it.  If it's being deleted, they need to fall down.
 	..()
 

--- a/code/modules/vore/eating/living_vr.dm
+++ b/code/modules/vore/eating/living_vr.dm
@@ -184,7 +184,7 @@
 //	Verb for saving vore preferences to save file
 //
 /mob/living/proc/save_vore_prefs()
-	if(!(client || client.prefs_vr))
+	if(!client || !client.prefs_vr)
 		return 0
 	if(!copy_to_prefs_vr())
 		return 0
@@ -194,7 +194,7 @@
 	return 1
 
 /mob/living/proc/apply_vore_prefs()
-	if(!(client || client.prefs_vr))
+	if(!client || !client.prefs_vr)
 		return 0
 	if(!client.prefs_vr.load_vore())
 		return 0


### PR DESCRIPTION
Fixes Runtime in lattice.dm,41: undefined proc or verb /turf/simulated/floor/airless/update().
Fixes Runtime in living_vr.dm,197: Cannot read null.prefs_vr