### PR TITLE
Trait Tweaks

### DIFF
--- a/code/__defines/misc_vr.dm
+++ b/code/__defines/misc_vr.dm
@@ -18,4 +18,4 @@
 
 //For custom species
 #define STARTING_SPECIES_POINTS 1
-#define MAX_SPECIES_TRAITS 4
+#define MAX_SPECIES_TRAITS 5

--- a/code/game/dna/dna2.dm
+++ b/code/game/dna/dna2.dm
@@ -110,6 +110,7 @@ var/global/list/datum/dna/gene/dna_genes[0]
 	new_dna.body_markings=body_markings.Copy()
 	new_dna.base_species=base_species //VOREStation Edit
 	new_dna.species_traits=species_traits.Copy() //VOREStation Edit
+	new_dna.blood_color=blood_color //VOREStation Edit
 	for(var/b=1;b<=DNA_SE_LENGTH;b++)
 		new_dna.SE[b]=SE[b]
 		if(b<=DNA_UI_LENGTH)

--- a/code/game/dna/dna2.dm
+++ b/code/game/dna/dna2.dm
@@ -92,6 +92,7 @@ var/global/list/datum/dna/gene/dna_genes[0]
 	var/custom_species
 	var/base_species = "Human"
 	var/list/species_traits = list()
+	var/blood_color = "#A10808"
 	// VOREStation
 
 	// New stuff
@@ -171,6 +172,7 @@ var/global/list/datum/dna/gene/dna_genes[0]
 		var/datum/species/custom/CS = character.species
 		src.species_traits = CS.traits.Copy()
 		src.base_species = CS.base_species
+		src.blood_color = CS.blood_color
 
 	// +1 to account for the none-of-the-above possibility
 	SetUIValueRange(DNA_UI_EAR_STYLE,	ear_style + 1,     ear_styles_list.len  + 1,  1)

--- a/code/game/dna/dna2_helpers.dm
+++ b/code/game/dna/dna2_helpers.dm
@@ -203,7 +203,8 @@
 		H.custom_species = dna.custom_species
 		if(istype(H.species,/datum/species/custom))
 			var/datum/species/custom/CS = H.species
-			CS.produceCopy(dna.base_species,dna.species_traits,src)
+			var/datum/species/custom/new_CS = CS.produceCopy(dna.base_species,dna.species_traits,src)
+			new_CS.blood_color = dna.blood_color
 
 		// VOREStation Edit End
 

--- a/code/modules/client/preference_setup/vore/07_traits.dm
+++ b/code/modules/client/preference_setup/vore/07_traits.dm
@@ -95,7 +95,7 @@
 		. += "<b>Icon Base: </b> "
 		. += "<a href='?src=\ref[src];custom_base=1'>[pref.custom_base ? pref.custom_base : "Human"]</a><br>"
 
-		. += "<b>Blood Color: </b> "
+		. += "<b>Blood Color: </b>"
 		. += "<a href='?src=\ref[src];blood_color=1'>Set Color</a>"
 		. += "<a href='?src=\ref[src];blood_reset=1'>R</a><br>"
 

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/negative.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/negative.dm
@@ -2,13 +2,13 @@
 	name = "Slowdown"
 	desc = "Allows you to move slower on average than baseline."
 	cost = -1
-	var_changes = list("slowdown" = 0.3)
+	var_changes = list("slowdown" = 0.5)
 
 /datum/trait/speed_slow_plus
 	name = "Slowdown (Plus)"
 	desc = "Allows you to move MUCH slower on average than baseline."
 	cost = -2
-	var_changes = list("slowdown" = 0.5)
+	var_changes = list("slowdown" = 1.0)
 
 /datum/trait/weakling
 	name = "Weakling"

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/positive.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/positive.dm
@@ -2,13 +2,13 @@
 	name = "Haste"
 	desc = "Allows you to move faster on average than baseline."
 	cost = 2
-	var_changes = list("slowdown" = -0.3)
+	var_changes = list("slowdown" = -0.5)
 
 /datum/trait/speed_fast_plus
 	name = "Haste (Plus)"
 	desc = "Allows you to move MUCH faster on average than baseline."
-	cost = 3
-	var_changes = list("slowdown" = -0.5)
+	cost = 4
+	var_changes = list("slowdown" = -1.0)
 
 /datum/trait/hardy
 	name = "Hardy"
@@ -73,3 +73,9 @@
 	desc = "Adds some resistance to burn damage sources."
 	cost = 2
 	var_changes = list("burn_mod" = 0.70)
+
+/datum/trait/photoresistant
+	name = "Photoresistant"
+	desc = "Decreases stun duration from flashes and other light-based stuns."
+	cost = 1
+	var_changes = list("flash_mod" = 0.5)


### PR DESCRIPTION
`balance intensifies`

Allow 5 traits
Adds blood color as a custom species setting (doesn't apply to synths)
Adds photoresistant trait
Changes haste and slowdown traits to be taj and tesh speeds (higher is now 4 points)