### PR TITLE
Fix lesser predator crate

### DIFF
--- a/code/datums/supplypacks/science_vr.dm
+++ b/code/datums/supplypacks/science_vr.dm
@@ -49,7 +49,7 @@
 	containername = "Dangerous Predator crate"
 	access = access_xenobiology
 
-/datum/supply_packs/sci/pred
+/datum/supply_packs/sci/pred_doom
 	name = "EXTREMELY Dangerous Predator crate"
 	cost = 200
 	containertype = /obj/structure/largecrate/animal/dangerous


### PR DESCRIPTION
Had the same path as the more expensive one, so the firstly defined one would be overridden and not show up.