### PR TITLE
Fixed damaged and burnt plating icons.

### DIFF
--- a/code/game/turfs/simulated/floor_icon.dm
+++ b/code/game/turfs/simulated/floor_icon.dm
@@ -71,9 +71,9 @@ var/list/flooring_cache = list()
 		icon_state = "dmg[rand(1,4)]"
 	else if(flooring)
 		if(!isnull(broken) && (flooring.flags & TURF_CAN_BREAK))
-			overlays |= get_flooring_overlay("[flooring.icon_base]-broken-[broken]","[flooring.icon_base]_broken[broken]")
+			overlays |= get_flooring_overlay("[flooring.icon_base]-broken-[broken]","broken[broken]") // VOREStation Edit - Eris overlays
 		if(!isnull(burnt) && (flooring.flags & TURF_CAN_BURN))
-			overlays |= get_flooring_overlay("[flooring.icon_base]-burned-[burnt]","[flooring.icon_base]_burned[burnt]")
+			overlays |= get_flooring_overlay("[flooring.icon_base]-burned-[burnt]","burned[burnt]") // VOREStation Edit - Eris overlays
 
 	if(weather_overlay)
 		overlays += weather_overlay


### PR DESCRIPTION
* We are using eris sprites, which have a shared overlay for broken/burnt between all tile types.