### PR TITLE
Replaces sleeptoxin nurse spider bite.

### DIFF
--- a/code/modules/mob/living/simple_animal/animals/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/animals/giant_spider.dm
@@ -56,7 +56,7 @@
 	melee_damage_lower = 5
 	melee_damage_upper = 10
 	poison_per_bite = 7
-	poison_type = "stoxin"
+	poison_type = "spidertoxin"  // VOREStation edit, original is stoxin. (sleep toxins)
 
 	var/fed = 0
 	var/atom/cocoon_target


### PR DESCRIPTION
With the normal spider toxin. Because right now, every bite causes 7 units pumped into a person. That brings it to 21 units with only three bites, enough to knock down a person for +20 minutes. Which won't fucking do.