### PR TITLE
Makes rigsuits not get contaminated with plasma.

### DIFF
--- a/code/modules/clothing/spacesuits/rig/rig_pieces_vr.dm
+++ b/code/modules/clothing/spacesuits/rig/rig_pieces_vr.dm
@@ -323,3 +323,13 @@
 				return 1
 		else
 			return 1
+
+//Makes rigsuits phoronproof since they kept getting contaminated and killing people even if they weren't wearing them.
+/obj/item/clothing/head/helmet/space/rig
+	phoronproof = 1
+/obj/item/clothing/gloves/gauntlets/rig
+	phoronproof = 1
+/obj/item/clothing/shoes/magboots/rig
+	phoronproof = 1
+/obj/item/clothing/suit/space/rig
+	phoronproof = 1


### PR DESCRIPTION
This was killing people even if they had it in the AMI/rigsuit and didn't have it equipped, as it was in their contents.

Additionally, rigsuit parts were impossible to clean. 
This makes sure they don't become contaminated with plasma, solving both of those problems