### PR TITLE
 Makes rigsuits not get contaminated with plasma.

### DIFF
--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -199,7 +199,7 @@
 		if(!piece) continue
 		piece.icon_state = "[initial(icon_state)]"
 		if(airtight)
-			piece.item_flags &= ~(STOPPRESSUREDAMAGE|AIRTIGHT|PHORONGUARD) //VOREStation edit
+			piece.item_flags &= ~(STOPPRESSUREDAMAGE|AIRTIGHT)
 	update_icon(1)
 
 /obj/item/weapon/rig/proc/toggle_seals(var/mob/living/carbon/human/M,var/instant)

--- a/code/modules/clothing/spacesuits/rig/rig_pieces_vr.dm
+++ b/code/modules/clothing/spacesuits/rig/rig_pieces_vr.dm
@@ -323,3 +323,12 @@
 				return 1
 		else
 			return 1
+
+/obj/item/clothing/head/helmet/space/rig
+	phoronproof = 1
+/obj/item/clothing/gloves/gauntlets/rig
+	phoronproof = 1
+/obj/item/clothing/shoes/magboots/rig
+	phoronproof = 1
+/obj/item/clothing/suit/space/rig
+	phoronproof = 1


### PR DESCRIPTION
This was killing people even if they had it in the AMI/rigsuit and didn't have it equipped, as it was in their contents.

Additionally, rigsuit parts were impossible to clean.
This makes sure they don't become contaminated with plasma, solving both of those problems
