### PR TITLE
chimera bugfixes and tweaks

### DIFF
--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -186,15 +186,13 @@
 	..()
 
 /mob/living/carbon/human/proc/Stasis(amount)
-	//if((species.flags & NO_SCAN) || isSynthetic()) vorestation removal
-	if(((species.flags & NO_SCAN) && !istype(species, /datum/species/xenochimera)) || isSynthetic()) //vorestation addition
+	if((species.flags & NO_SCAN) || isSynthetic())
 		in_stasis = 0
 	else
 		in_stasis = amount
 
 /mob/living/carbon/human/proc/getStasis()
-	//if((species.flags & NO_SCAN) || isSynthetic()) vorestation removal
-	if(((species.flags & NO_SCAN) && !istype(species, /datum/species/xenochimera)) || isSynthetic()) //vorestation addition
+	if((species.flags & NO_SCAN) || isSynthetic())
 		return 0
 
 	return in_stasis

--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -186,13 +186,15 @@
 	..()
 
 /mob/living/carbon/human/proc/Stasis(amount)
-	if((species.flags & NO_SCAN) || isSynthetic())
+	//if((species.flags & NO_SCAN) || isSynthetic()) vorestation removal
+	if(((species.flags & NO_SCAN) && !istype(species, /datum/species/xenochimera)) || isSynthetic()) //vorestation addition
 		in_stasis = 0
 	else
 		in_stasis = amount
 
 /mob/living/carbon/human/proc/getStasis()
-	if((species.flags & NO_SCAN) || isSynthetic())
+	//if((species.flags & NO_SCAN) || isSynthetic()) vorestation removal
+	if(((species.flags & NO_SCAN) && !istype(species, /datum/species/xenochimera)) || isSynthetic()) //vorestation addition
 		return 0
 
 	return in_stasis

--- a/code/modules/mob/living/carbon/human/species/station/station_special_abilities_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_special_abilities_vr.dm
@@ -23,7 +23,7 @@
 				C.reviving = 1
 				C.canmove = 0 //Make them unable to move. In case they somehow get up before the delay.
 				C << "You begin to reconstruct your form. You will not be able to move during this time. It should take aproximately [round(time)] seconds."
-				C.Stasis(10000) //ensure complete stasis. This will put them to sleep as well.
+				C.does_not_breathe = 1 //effectively makes them spaceworthy while regenning
 
 				spawn(time SECONDS)
 					if(C) //Runtime prevention.
@@ -42,7 +42,7 @@
 			C.reviving = 1
 			C.canmove = 0 //Make them unable to move. In case they somehow get up before the delay.
 			C << "You begin to reconstruct your form. You will not be able to move during this time. It should take aproximately [round(time)] seconds."
-			C.Stasis(10000)
+			C.does_not_breathe = 1 //effectively makes them spaceworthy while regenning
 
 			spawn(time SECONDS)
 				if(C.stat != DEAD) //If they're still alive after regenning.
@@ -94,7 +94,7 @@
 					var/T = get_turf(src)
 					new /obj/effect/gibspawner/human/scree(T)
 					var/braindamage = C.brainloss/2 //If you have 100 brainloss, it gives you 50.
-					C.Stasis(0)
+					C.does_not_breathe = 0 //start breathing again
 					C.revive() // I did have special snowflake code, but this is easier.
 					C.weakened = 2 //Not going to let you get up immediately. 2 ticks before you get up. Overrides the above 10000 weaken.
 					C.nutrition = old_nutrition
@@ -128,7 +128,7 @@
 				C.drop_from_inventory(W)
 			spawn(3600 SECONDS) //1 hour wait until you can revive again.
 				C.reviving = 0
-			C.Stasis(0)
+			C.does_not_breathe = 0 //start breathing again
 			C.verbs -= /mob/living/carbon/human/proc/hatch
 			return
 		else

--- a/code/modules/mob/living/carbon/human/species/station/station_special_abilities_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_special_abilities_vr.dm
@@ -17,13 +17,13 @@
 			return
 
 		if(C.stat == DEAD) //Uh oh, you died!
-			if(C.reagents.has_reagent("nutriment")) //Let's hope you have nutriment in you.... If not
+			if(C.hasnutriment()) //Let's hope you have nutriment in you.... If not
 				var/time = (500+1/((nutrition_used/100+1)/1300))
 				C.weakened = 10000 //Since it takes 1 tick to lose one weaken. Due to prior rounding errors, you'd sometimes unweaken before regenning. This fixes that.
 				C.reviving = 1
 				C.canmove = 0 //Make them unable to move. In case they somehow get up before the delay.
 				C << "You begin to reconstruct your form. You will not be able to move during this time. It should take aproximately [round(time)] seconds."
-				C.in_stasis = 1
+				C.Stasis(10000) //ensure complete stasis. This will put them to sleep as well.
 
 				spawn(time SECONDS)
 					if(C) //Runtime prevention.
@@ -42,7 +42,7 @@
 			C.reviving = 1
 			C.canmove = 0 //Make them unable to move. In case they somehow get up before the delay.
 			C << "You begin to reconstruct your form. You will not be able to move during this time. It should take aproximately [round(time)] seconds."
-			C.in_stasis = 1
+			C.Stasis(10000)
 
 			spawn(time SECONDS)
 				if(C.stat != DEAD) //If they're still alive after regenning.
@@ -50,17 +50,26 @@
 					C.verbs += /mob/living/carbon/human/proc/hatch
 					return
 				else if(C.stat == DEAD)
-					if(C.reagents.has_reagent("nutriment")) //Let's hope you have nutriment in you.... If not
+					if(C.hasnutriment()) //Let's hope you have nutriment in you.... If not
 						C << "<span class='notice'>Consciousness begins to stir as your new body awakens, ready to hatch..</span>"
 						C.verbs += /mob/living/carbon/human/proc/hatch
 					else //Dead until nutrition injected.
 						C << "Your body was unable to regenerate, what few living cells remain require additional nutrients to complete the process."
+						C.reviving = 0 // so they can try again when they're given a kickstart
 						return
 				else
 					return //Something went wrong
 		else
 			return //Something went wrong
 
+
+
+/mob/living/carbon/human/proc/hasnutriment()
+	if (src.bloodstr.has_reagent("nutriment", 30) || src.bloodstr.has_reagent("protein", 15)) //protein needs half as much. For reference, a steak contains 9u protein.
+		return 1
+	else if (src.ingested.has_reagent("nutriment", 60) || src.ingested.has_reagent("protein", 30)) //try forcefeeding them, why not. Less effective.
+		return 1
+	else return 0
 
 
 /mob/living/carbon/human/proc/hatch()
@@ -85,7 +94,7 @@
 					var/T = get_turf(src)
 					new /obj/effect/gibspawner/human/scree(T)
 					var/braindamage = C.brainloss/2 //If you have 100 brainloss, it gives you 50.
-					C.in_stasis = 0
+					C.Stasis(0)
 					C.revive() // I did have special snowflake code, but this is easier.
 					C.weakened = 2 //Not going to let you get up immediately. 2 ticks before you get up. Overrides the above 10000 weaken.
 					C.nutrition = old_nutrition
@@ -119,7 +128,7 @@
 				C.drop_from_inventory(W)
 			spawn(3600 SECONDS) //1 hour wait until you can revive again.
 				C.reviving = 0
-			C.in_stasis = 0
+			C.Stasis(0)
 			C.verbs -= /mob/living/carbon/human/proc/hatch
 			return
 		else

--- a/code/modules/mob/living/carbon/human/species/station/station_special_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_special_vr.dm
@@ -73,7 +73,7 @@
 				H.feral = min(150-H.nutrition, H.feral+1) //Feralness increases while this hungry, capped at 50-150 depending on hunger.
 
 		// If they're hurt, chance of snapping. Not if they're straight-up KO'd though.
-		if (H.stat == CONSCIOUS && H.traumatic_shock >=36 && H.in_stasis == 0) //30 brute/burn, or 18 halloss.
+		if (H.stat == CONSCIOUS && H.traumatic_shock >=36 && !H.inStasisNow()) //30 brute/burn, or 18 halloss.
 			if (2.5*H.halloss >= H.traumatic_shock) //If the majority of their shock is due to halloss, greater chance of snapping.
 				if(prob(min(10,(0.2 * H.traumatic_shock))))
 					if(H.feral == 0)
@@ -110,6 +110,8 @@
 
 	if(H.feral > 0) //do the following if feral, otherwise no effects.
 		var/light_amount = H.getlightlevel() //how much light there is in the place
+
+		H.shock_stage = max(H.shock_stage-(H.feral/20), 0) //if they lose enough health to hit softcrit, handle_shock() will keep resetting this. Otherwise, pissed off critters will lose shock faster than they gain it.
 
 		for(var/mob/living/M in viewers(H))
 			if(M != H) // someone in view
@@ -160,28 +162,25 @@
 	var/pressure2 = environment.return_pressure()
 	var/adjusted_pressure2 = H.calculate_affecting_pressure(pressure2)
 
-	if(adjusted_pressure2 <= 20 && H.in_stasis == 1) //If they're in a enviroment with no pressure and are in stasis (See: regenerating), don't kill them.
+	if(adjusted_pressure2 <= 20 && H.inStasisNow()) //If they're in a enviroment with no pressure and are in stasis (See: regenerating), don't kill them.
 		//This is just to prevent them from taking damage if they're in stasis.
 
 	else if(adjusted_pressure2 <= 20) //If they're in an enviroment with no pressure and are NOT in stasis, damage them.
 		H.take_overall_damage(brute=LOW_PRESSURE_DAMAGE, used_weapon = "Low Pressure")
 
-	if(H.bodytemperature <= 260 && H.in_stasis == 1) //If they're in stasis, don't give them them the negative cold effects
+	if(H.bodytemperature <= 260 && H.inStasisNow()) //If they're in stasis, don't give them them the negative cold effects
 		//This is just here to prevent them from getting cold effects
 
 	else if(H.bodytemperature <= 260) //If they're not in stasis and are cold. Don't really have to add in an exception to cryo cells, as the effects aren't anything /too/ horrible.
-		var/colddamage = 0
+		var/coldshock = 0
 		if(H.bodytemperature <= 260 && H.bodytemperature >= 200) //Chilly.
-			colddamage = 4 //This will begin to knock them out until they run out of oxygen and suffocate or until someone finds them.
+			coldshock = 4 //This will begin to knock them out until they run out of oxygen and suffocate or until someone finds them.
 			H.eye_blurry = 5 //Blurry vision in the cold.
 		if(H.bodytemperature <= 199 && H.bodytemperature >= 100) //Extremely cold. Even in somewhere like the server room it takes a while for bodytemp to drop this low.
-			colddamage = 8
+			coldshock = 8
 			H.eye_blurry = 5
 		if(H.bodytemperature <= 99) //Insanely cold.
-			colddamage = 20
+			coldshock = 16
 			H.eye_blurry = 5
-		if(H.paralysis) //stops weaken spam from being repeatedly taken over max halloss when already KO'd.
-			H.halloss = min(H.halloss+colddamage, H.species.total_health - 1) //if already stunned, only take them up to the point of restunning
-		else
-			H.halloss += colddamage //Harsh punishment for staying in space, and it'll take them a while to fully thaw out when they get retrieved.
+		H.shock_stage = min(H.shock_stage + coldshock, 160) //cold hurts and gives them pain messages, eventually weakening and paralysing, but doesn't damage or trigger feral.
 		return

--- a/code/modules/mob/living/carbon/human/species/station/station_special_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_special_vr.dm
@@ -73,7 +73,7 @@
 				H.feral = min(150-H.nutrition, H.feral+1) //Feralness increases while this hungry, capped at 50-150 depending on hunger.
 
 		// If they're hurt, chance of snapping. Not if they're straight-up KO'd though.
-		if (H.stat == CONSCIOUS && H.traumatic_shock >=36 && !H.inStasisNow()) //30 brute/burn, or 18 halloss.
+		if (H.stat == CONSCIOUS && H.traumatic_shock >=36) //30 brute/burn, or 18 halloss.
 			if (2.5*H.halloss >= H.traumatic_shock) //If the majority of their shock is due to halloss, greater chance of snapping.
 				if(prob(min(10,(0.2 * H.traumatic_shock))))
 					if(H.feral == 0)
@@ -162,13 +162,13 @@
 	var/pressure2 = environment.return_pressure()
 	var/adjusted_pressure2 = H.calculate_affecting_pressure(pressure2)
 
-	if(adjusted_pressure2 <= 20 && H.inStasisNow()) //If they're in a enviroment with no pressure and are in stasis (See: regenerating), don't kill them.
+	if(adjusted_pressure2 <= 20 && H.does_not_breathe) //If they're in a enviroment with no pressure and are not breathing (See: regenerating), don't kill them.
 		//This is just to prevent them from taking damage if they're in stasis.
 
 	else if(adjusted_pressure2 <= 20) //If they're in an enviroment with no pressure and are NOT in stasis, damage them.
 		H.take_overall_damage(brute=LOW_PRESSURE_DAMAGE, used_weapon = "Low Pressure")
 
-	if(H.bodytemperature <= 260 && H.inStasisNow()) //If they're in stasis, don't give them them the negative cold effects
+	if(H.bodytemperature <= 260 && H.does_not_breathe) //If they're regenerating, don't give them them the negative cold effects
 		//This is just here to prevent them from getting cold effects
 
 	else if(H.bodytemperature <= 260) //If they're not in stasis and are cold. Don't really have to add in an exception to cryo cells, as the effects aren't anything /too/ horrible.

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
@@ -34,10 +34,12 @@
 				data -= taste
 
 /datum/reagent/nutriment/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
-	if(!injectable)
+	/* if(!injectable) vorestation removal
 		M.adjustToxLoss(0.1 * removed)
 		return
-	affect_ingest(M, alien, removed)
+	affect_ingest(M, alien, removed) */
+	if(injectable) //vorestation addition/replacement
+		affect_ingest(M, alien, removed)
 
 /datum/reagent/nutriment/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed)
 	switch(alien)
@@ -76,9 +78,6 @@
 /datum/reagent/nutriment/protein/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	if(alien && alien == IS_SKRELL)
 		M.adjustToxLoss(2 * removed)
-		return
-	else if(istype(M.species, /datum/species/xenochimera)) //vorestation addition
-		affect_ingest(M, alien, removed) //like hell are chimera of all things going to be poisoned by injecting them with meat
 		return
 	..()
 

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
@@ -77,6 +77,9 @@
 	if(alien && alien == IS_SKRELL)
 		M.adjustToxLoss(2 * removed)
 		return
+	else if(istype(M.species, /datum/species/xenochimera)) //vorestation addition
+		affect_ingest(M, alien, removed) //like hell are chimera of all things going to be poisoned by injecting them with meat
+		return
 	..()
 
 /datum/reagent/nutriment/protein/egg // Also bad for skrell.


### PR DESCRIPTION
Xenochimera now correctly stop breathing while regenerating.

Fixed a bug where chimera that fail to regenerate due to dying before they're finished would end with their cooldown permanently locked on. Now, they can re-attempt it whenever medical injects them with stuff.

Fixed the nutriment check to look in bloodstream/ingested instead of reagents. Also has a minimum threshold for the amount of stuff you need to give them. Protein is more effective than plain nutriment.
No longer take toxloss from the thing needed to revive them.

Feral critters now tick down their shock stage. Their health is unchanged so they still go into softcrit at 0, fullcrit at -50, and die at -100. Softcrit still has the periodic chance of staggering them and will pin their shockstage at 60 every tick as before if it goes under (with the same chance of weakening)
In practical terms, it's a buff to hauling their mangled carcasses off to safety without passing out on the way, they certainly won't be in a condition to do any fighting. Shock stage also affects gun accuracy, but feral mobs can't use guns anyway.

Cold, conversely, now ticks _up_ their shock stage instead of doing halloss. As a result, cold won't render them feral but will give them a fuckton of pain messages and knock them out. At the coldest level, it only takes 10 ticks for them to reach the cap.