### PR TITLE
Removes access restrictions on maintenance airlocks

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -103,7 +103,7 @@
 /obj/machinery/door/airlock/maintenance
 	name = "Maintenance Access"
 	icon = 'icons/obj/doors/Doormaint.dmi'
-	req_one_access = list(access_maint_tunnels)
+	//req_one_access = list(access_maint_tunnels) //VOREStation Edit - Maintenance is open access
 	assembly_type = /obj/structure/door_assembly/door_assembly_mai
 
 /obj/machinery/door/airlock/maintenance/cargo

--- a/code/game/machinery/doors/multi_tile.dm
+++ b/code/game/machinery/doors/multi_tile.dm
@@ -82,4 +82,4 @@
 
 /obj/machinery/door/airlock/multi_tile/metal/mait
 	icon = 'icons/obj/doors/Door2x1_Maint.dmi'
-	req_one_access = list(access_maint_tunnels)
+	//req_one_access = list(access_maint_tunnels) //VOREStaiton Edit - Maintenance is open access


### PR DESCRIPTION
The non-department ones. All the department-specific ones stay locked for obvious reasons. Allows preds to nom more people in private, and exploring the z2 maintenance labyrinth, which, honestly, I'll probably add more to.

Instead of adding access_maint_tunnels to every job (thus making the access almost pointless), we can leave access_maint_tunnels on super deep dark maint areas or something.

Resolves #978 