### PR TITLE
Puts 3x more gas in pressure tanks

### DIFF
--- a/code/ATMOSPHERICS/pipes.dm
+++ b/code/ATMOSPHERICS/pipes.dm
@@ -1060,7 +1060,7 @@
 	desc = "A large vessel containing pressurized gas."
 
 	volume = 10000 //in liters, 1 meters by 1 meters by 2 meters ~tweaked it a little to simulate a pressure tank without needing to recode them yet
-	var/start_pressure = 25*ONE_ATMOSPHERE
+	var/start_pressure = 75*ONE_ATMOSPHERE //Vorestation edit
 
 	level = 1
 	dir = SOUTH


### PR DESCRIPTION
Hullo. Currently the starting amount is very small. You can fill around 422 tiles which sounds like a lot, but it's not. Something like the holodeck is around 120. The engine room is about 250. This does not account for any air pumps, or anything else. Currently many Atmos players have made complaints about the amount of gasses they have, this alleviates that issue.