### PR TITLE
Removes the snowflake human defined verbs from the majority of the reagent implants

### DIFF
--- a/code/game/objects/items/weapons/implants/implantreagent_vr.dm
+++ b/code/game/objects/items/weapons/implants/implantreagent_vr.dm
@@ -14,6 +14,8 @@
 	var/list/self_emote_descriptor = list("transfer") //In format of You [self_emote_descriptor] some [generated_reagent] into [container]
 	var/list/random_emote = list() //An emote the person with the implant may be forced to perform after a prob check, such as [X] meows.
 	var/assigned_proc = /mob/living/carbon/human/proc/use_reagent_implant
+	var/verb_name = "Transfer From Reagent Implant"
+	var/verb_desc = "Remove reagents from am internal reagent into a container"
 
 /obj/item/weapon/implant/reagent_generator/New()
 	..()
@@ -31,7 +33,7 @@
 /obj/item/weapon/implant/reagent_generator/implanted(mob/living/carbon/source)
 	processing_objects += src
 	to_chat(source, "<span class='notice'>You implant [source] with \the [src].</span>")
-	source.verbs |= assigned_proc
+	assigned_proc = new assigned_proc(source, verb_name, verb_desc)
 	return 1
 
 /obj/item/weapon/implant/reagent_generator/process()

--- a/code/modules/vore/fluffstuff/custom_items_vr.dm
+++ b/code/modules/vore/fluffstuff/custom_items_vr.dm
@@ -649,18 +649,11 @@ obj/item/weapon/material/hatchet/tacknife/combatknife/fluff/katarina/handle_shie
 	emote_descriptor = list("squeezes milk", "tugs on Tempest's breasts, milking them")
 	self_emote_descriptor = list("squeeze")
 	random_emote = list("moos quietly")
-	assigned_proc = /mob/living/carbon/human/proc/use_reagent_implant_tempest
+	verb_name = "Milk"
+	verb_desc = "Grab Tempest's nipples and milk them into a container! May cause blushing and groaning."
 
 /obj/item/weapon/implanter/reagent_generator/tempest
 	implant_type = /obj/item/weapon/implant/reagent_generator/tempest
-
-/mob/living/carbon/human/proc/use_reagent_implant_tempest()
-	set name = "Milk"
-	set desc = "Grab Tempest's nipples and milk them into a container! May cause blushing and groaning."
-	set category = "Object"
-	set src in view(1)
-
-	do_reagent_implant(usr)
 
 
 //Hottokeeki: Belle Day
@@ -673,19 +666,11 @@ obj/item/weapon/material/hatchet/tacknife/combatknife/fluff/katarina/handle_shie
 	emote_descriptor = list("squeezes milk", "tugs on Belle's breasts/udders, milking them", "extracts milk")
 	self_emote_descriptor = list("squeeze", "extract")
 	random_emote = list("moos", "mrours", "groans softly")
-	assigned_proc = /mob/living/carbon/human/proc/use_reagent_implant_belle
+	verb_name = "Milk"
+	verb_desc = "Obtain Belle's milk and put it into a container! May cause blushing and groaning, or arousal."
 
 /obj/item/weapon/implanter/reagent_generator/belle
 	implant_type = /obj/item/weapon/implant/reagent_generator/belle
-
-/mob/living/carbon/human/proc/use_reagent_implant_belle()
-	set name = "Milk"
-	set desc = "Obtain Belle's milk and put it into a container! May cause blushing and groaning, or arousal."
-	set category = "Object"
-	set src in view(1)
-
-	do_reagent_implant(usr)
-
 
 //Vorrarkul: Theodora Lindt
 /obj/item/weapon/implant/reagent_generator/vorrarkul
@@ -697,18 +682,11 @@ obj/item/weapon/material/hatchet/tacknife/combatknife/fluff/katarina/handle_shie
 	emote_descriptor = list("squeezes chocolate milk from Theodora", "tugs on Theodora's nipples, milking them", "kneads Theodora's breasts, milking them")
 	self_emote_descriptor = list("squeeze", "knead")
 	random_emote = list("moans softly", "gives an involuntary squeal")
-	assigned_proc = /mob/living/carbon/human/proc/use_reagent_implant_vorrarkul
+	verb_name = "Milk"
+	verb_desc = "Grab Theodora's breasts and extract delicious chocolate milk from them!"
 
 /obj/item/weapon/implanter/reagent_generator/vorrarkul
 	implant_type = /obj/item/weapon/implant/reagent_generator/vorrarkul
-
-/mob/living/carbon/human/proc/use_reagent_implant_vorrarkul()
-	set name = "Milk"
-	set desc = "Grab Theodora's breasts and extract delicious chocolate milk from them!"
-	set category = "Object"
-	set src in view(1)
-
-	do_reagent_implant(usr)
 
 //SpoopyLizz: Roiz Lizden
 //I made this! Woo!
@@ -730,6 +708,12 @@ obj/item/weapon/material/hatchet/tacknife/combatknife/fluff/katarina/handle_shie
 	self_emote_descriptor = list("lay", "force out", "push out")
 	random_emote = list("hisses softly with a blush on his face", "yelps in embarrassment", "grunts a little")
 	assigned_proc = /mob/living/carbon/human/proc/use_reagent_implant_roiz
+
+/obj/item/weapon/implant/reagent_generator/roiz/implanted(mob/living/carbon/source)
+	processing_objects += src
+	to_chat(source, "<span class='notice'>You implant [source] with \the [src].</span>")
+	source.verbs |= assigned_proc
+	return 1
 
 /obj/item/weapon/implanter/reagent_generator/roiz
 	implant_type = /obj/item/weapon/implant/reagent_generator/roiz


### PR DESCRIPTION
Thanks for @Arokha telling me about a secret DM feature no longer do we need a bunch of coded verbs. We only need one! And types are dynamically created when appropriate using vars on the implant. 

Tempest's, Belle's and Theodora's are converted to use the new system. Roiz's remains the same and gains its own :snowflake: implanted() because it doesn't obey the rules of the rest of it.