### PR TITLE
Adds macros to assist with lazily instantiating lists

### DIFF
--- a/code/_macros.dm
+++ b/code/_macros.dm
@@ -51,3 +51,25 @@
 #define to_chat(target, message) target << message
 
 #define CanInteract(user, state) (CanUseTopic(user, state) == STATUS_INTERACTIVE)
+
+// Helper macros to aid in optimizing lazy instantiation of lists.
+// All of these are null-safe, you can use them without knowing if the list var is initialized yet
+
+//Picks from the list, with some safeties, and returns the "default" arg if it fails
+#define DEFAULTPICK(L, default) ((istype(L, /list) && L:len) ? pick(L) : default)
+// Ensures L is initailized after this point
+#define LAZYINITLIST(L) if (!L) L = list()
+// Sets a L back to null iff it is empty
+#define UNSETEMPTY(L) if (L && !L.len) L = null
+// Removes I from list L, and sets I to null if it is now empty
+#define LAZYREMOVE(L, I) if(L) { L -= I; if(!L.len) { L = null; } }
+// Adds I to L, initalizing I if necessary
+#define LAZYADD(L, I) if(!L) { L = list(); } L += I;
+// Reads I from L safely - Works with both associative and traditional lists.
+#define LAZYACCESS(L, I) (L ? (isnum(I) ? (I > 0 && I <= L.len ? L[I] : null) : L[I]) : null)
+// Reads the length of L, returning 0 if null
+#define LAZYLEN(L) length(L)
+// Null-safe L.Cut()
+#define LAZYCLEARLIST(L) if(L) L.Cut()
+// Reads L or an empty list if L is not a list.  Note: Does NOT assign, L may be an expression.
+#define SANITIZE_LIST(L) ( islist(L) ? L : list() )

--- a/code/game/area/Space Station 13 areas.dm
+++ b/code/game/area/Space Station 13 areas.dm
@@ -48,7 +48,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	var/obj/machinery/power/apc/apc = null
 	var/no_air = null
 //	var/list/lights				// list of all lights on this area
-	var/list/all_doors = list()		//Added by Strumpetplaya - Alarm Change - Contains a list of doors adjacent to this area
+	var/list/all_doors = null		//Added by Strumpetplaya - Alarm Change - Contains a list of doors adjacent to this area
 	var/firedoors_closed = 0
 	var/list/ambience = list('sound/ambience/ambigen1.ogg','sound/ambience/ambigen3.ogg','sound/ambience/ambigen4.ogg','sound/ambience/ambigen5.ogg','sound/ambience/ambigen6.ogg','sound/ambience/ambigen7.ogg','sound/ambience/ambigen8.ogg','sound/ambience/ambigen9.ogg','sound/ambience/ambigen10.ogg','sound/ambience/ambigen11.ogg','sound/ambience/ambigen12.ogg','sound/ambience/ambigen14.ogg')
 	var/list/forced_ambience = null

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -87,6 +87,8 @@
 /area/proc/firedoors_close()
 	if(!firedoors_closed)
 		firedoors_closed = TRUE
+		if(!all_doors)
+			return
 		for(var/obj/machinery/door/firedoor/E in all_doors)
 			if(!E.blocked)
 				if(E.operating)
@@ -99,6 +101,8 @@
 /area/proc/firedoors_open()
 	if(firedoors_closed)
 		firedoors_closed = FALSE
+		if(!all_doors)
+			return
 		for(var/obj/machinery/door/firedoor/E in all_doors)
 			if(!E.blocked)
 				if(E.operating)

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -60,18 +60,18 @@
 	var/area/A = get_area(src)
 	ASSERT(istype(A))
 
-	A.all_doors.Add(src)
+	LAZYADD(A.all_doors, src)
 	areas_added = list(A)
 
 	for(var/direction in cardinal)
 		A = get_area(get_step(src,direction))
 		if(istype(A) && !(A in areas_added))
-			A.all_doors.Add(src)
+			LAZYADD(A.all_doors, src)
 			areas_added += A
 
 /obj/machinery/door/firedoor/Destroy()
 	for(var/area/A in areas_added)
-		A.all_doors.Remove(src)
+		LAZYREMOVE(A.all_doors, src)
 	. = ..()
 
 /obj/machinery/door/firedoor/get_material()


### PR DESCRIPTION
* For various reasons its best to not instantiate lists until they are actually going to be used, especially if there is a good chance that a given list variable might *never* be used during the lifetime of an object.
* These macros make it simple and concise to add remove and access entries in lazily created lists.
* Converts area.all_doors list to be lazily instantiated as a simple example of using the lazy list macros.