### PR TITLE
Surgery and syringe fixes

### DIFF
--- a/code/modules/mob/living/silicon/robot/analyzer.dm
+++ b/code/modules/mob/living/silicon/robot/analyzer.dm
@@ -16,14 +16,6 @@
 	matter = list(DEFAULT_WALL_MATERIAL = 500, "glass" = 200)
 	var/mode = 1;
 
-
-/obj/item/device/robotanalyzer/do_surgery(mob/living/M, mob/living/user)
-	if(user.a_intent != I_HELP) //in case it is ever used as a surgery tool
-		return ..()
-	do_scan(M, user) //default surgery behaviour is just to scan as usual
-	return 1
-
-
 /obj/item/device/robotanalyzer/attack(mob/living/M as mob, mob/living/user as mob)
 	do_scan(M, user)
 

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -28,12 +28,6 @@
 	update_icon()
 	return
 
-/obj/item/weapon/reagent_containers/hypospray/do_surgery(mob/living/carbon/M, mob/living/user)
-	if(user.a_intent != I_HELP) //in case it is ever used as a surgery tool
-		return ..()
-	attack(M, user)
-	return 1
-
 /obj/item/weapon/reagent_containers/hypospray/attack(mob/living/M as mob, mob/user as mob)
 	if(!reagents.total_volume)
 		user << "<span class='warning'>[src] is empty.</span>"

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -19,13 +19,6 @@
 	if(!icon_state)
 		icon_state = "pill[rand(1, 20)]"
 
-
-/obj/item/weapon/reagent_containers/pill/do_surgery(mob/M, mob/user)
-	if(user.a_intent != I_HELP) //in case it is ever used as a surgery tool
-		return ..()
-	attack(M, user) //default surgery behaviour is just to scan as usual
-	return 1
-
 /obj/item/weapon/reagent_containers/pill/attack(mob/M as mob, mob/user as mob)
 	if(M == user)
 		if(istype(M, /mob/living/carbon/human))

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -53,13 +53,6 @@
 /obj/item/weapon/reagent_containers/syringe/attackby(obj/item/I as obj, mob/user as mob)
 	return
 
-/obj/item/weapon/reagent_containers/syringe/do_surgery(mob/living/carbon/M, mob/living/user)
-	if(user.a_intent == I_HURT)
-		return 0
-	if(user.a_intent != I_HELP) //in case it is ever used as a surgery tool
-		return ..()
-	return 1
-
 /obj/item/weapon/reagent_containers/syringe/afterattack(obj/target, mob/user, proximity)
 	if(!proximity || !target.reagents)
 		return

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -129,7 +129,6 @@
 				if(success)
 					if(!do_mob(user, M, rand(S.min_duration, S.max_duration)))
 						success = FALSE
-					else
 						to_chat(user, "<span class='warning'>You must remain close to your patient to conduct surgery.</span>")
 
 				if(success)


### PR DESCRIPTION
Fixes a line printed about staying close to your patient printed in error, and makes syringes work on laying patients again.

The do_surgery overrides are from a bygone era.

Tested == yes