### PR TITLE
Minor NIF and Soulcatcher Tweaks

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -125,6 +125,7 @@ var/list/admin_verbs_fun = list(
 	/client/proc/toggle_random_events,
 	/client/proc/editappear,
 	/client/proc/roll_dices,
+	/datum/admins/proc/quick_nif, //VOREStation Add,
 	/datum/admins/proc/call_supply_drop,
 	/datum/admins/proc/call_drop_pod
 	)

--- a/code/modules/admin/verbs/debug_vr.dm
+++ b/code/modules/admin/verbs/debug_vr.dm
@@ -1,0 +1,31 @@
+/datum/admins/proc/quick_nif()
+	set category = "Fun"
+	set name = "Quick NIF"
+	set desc = "Spawns a NIF into someone in quick-implant mode."
+
+	if(!check_rights(R_FUN))
+		return
+
+	var/mob/living/carbon/human/H = input("Pick a humanoid","Quick NIF") as null|anything in human_mob_list
+
+	if(!H)
+		return
+
+	if(!H.get_organ(BP_HEAD))
+		to_chat(usr,"<span class='warning'>Target is unsuitable.</span>")
+		return
+
+	if(H.nif)
+		to_chat(usr,"<span class='warning'>Target already has a NIF.</span>")
+		return
+
+	if(H.species.flags & NO_SCAN)
+		new /obj/item/device/nif/bioadap(H)
+	else
+		new /obj/item/device/nif(H)
+
+	to_chat(usr,"<span class='notice'>Implanted NIF in [H].</span>")
+
+	log_admin("[key_name(src)] Quick NIF'd [H.real_name].")
+	message_admins("[key_name_admin(src)] Quick NIF'd [H.real_name].")
+	feedback_add_details("admin_verb","QNIF") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!

--- a/code/modules/mob/living/carbon/human/emote_vr.dm
+++ b/code/modules/mob/living/carbon/human/emote_vr.dm
@@ -24,7 +24,7 @@
 			if(!SC.brainmob.mind)
 				to_chat(src,"<span class='warning'>You need a loaded mind to use *nme.</span>")
 				return 1
-			var/nifmessage = sanitize(input("Type a message to say.") as text|null)
+			var/nifmessage = sanitize(input("Type a message to say.","Speak into NIF") as text|null)
 			if(nifmessage)
 				nifmessage = "<b>\[\icon[nif.big_icon]NIF\]</b> <b>[src]</b> speaks, \"[nifmessage]\""
 				to_chat(SC.brainmob,nifmessage)
@@ -42,7 +42,7 @@
 			if(!SC.brainmob.mind)
 				to_chat(src,"<span class='warning'>You need a loaded mind to use *nme.</span>")
 				return 1
-			var/nifmessage = sanitize(input("Type an action to perform.") as text|null)
+			var/nifmessage = sanitize(input("Type an action to perform.","Emote into NIF") as text|null)
 			if(nifmessage)
 				nifmessage = "<b>\[\icon[nif.big_icon]NIF\]</b> <b>[src]</b> [nifmessage]"
 				to_chat(SC.brainmob,nifmessage)

--- a/code/modules/nifsoft/nif.dm
+++ b/code/modules/nifsoft/nif.dm
@@ -133,7 +133,8 @@ You can also set the stat of a NIF to NIF_TEMPFAIL without any issues to disable
 		src.forceMove(head)
 		head.implants += src
 		spawn(0) //Let the character finish spawning yo.
-			owner = H.mind.name
+			if(H.mind)
+				owner = H.mind.name
 			implant(H)
 		return TRUE
 

--- a/code/modules/nifsoft/software/13_soulcatcher.dm
+++ b/code/modules/nifsoft/software/13_soulcatcher.dm
@@ -27,6 +27,7 @@
 		brainmob.stat = 0
 		brainmob.silent = FALSE
 		dead_mob_list -= src.brainmob
+		brainmob.add_language(LANGUAGE_GALCOM)
 		load_settings()
 
 	Destroy()

--- a/code/modules/vore/persist/persist_vr.dm
+++ b/code/modules/vore/persist/persist_vr.dm
@@ -39,7 +39,9 @@
  * Prep for save: returns a preferences object if we're ready and allowed to save this mob.
  */
 /proc/prep_for_persist(var/mob/persister)
-	ASSERT(istype(persister))
+	if(!istype(persister))
+		crash_with("prep_for_persist given non-mob [persister]")
+		return
 
 	// Find out of this mob is a proper mob!
 	if (persister.mind && persister.mind.loaded_from_ckey)
@@ -71,7 +73,9 @@
 	return 1
 
 /proc/persist_interround_data(var/mob/occupant, var/datum/spawnpoint/new_spawn_point_type)
-	ASSERT(istype(occupant))
+	if(!istype(occupant))
+		crash_with("persist_interround_data given non-mob [occupant]")
+		return
 
 	var/datum/preferences/prefs = prep_for_persist(occupant)
 	if(!prefs)
@@ -219,7 +223,8 @@
 */
 /proc/persist_nif_data(var/mob/living/carbon/human/H,var/datum/preferences/prefs)
 	if(!istype(H))
-		CRASH("persist_nif_data given a nonhuman: [H]")
+		crash_with("persist_nif_data given a nonhuman: [H]")
+		return
 
 	if(!prefs)
 		prefs = prep_for_persist(H)

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -1191,6 +1191,7 @@
 #include "code\modules\admin\verbs\custom_event.dm"
 #include "code\modules\admin\verbs\deadsay.dm"
 #include "code\modules\admin\verbs\debug.dm"
+#include "code\modules\admin\verbs\debug_vr.dm"
 #include "code\modules\admin\verbs\diagnostics.dm"
 #include "code\modules\admin\verbs\dice.dm"
 #include "code\modules\admin\verbs\getlogs.dm"


### PR DESCRIPTION
- Brainmob can understand galcom so they can understand radio announcements if they're allowed to hear things.
- Adds admin verb in Fun tab for "Quick NIF" to quickly implant someone with a NIF, if for example they lost theirs via bug, or for antags in events.
- Some tweaks in Persist VR to not 'hard crash' just in case runtiming prevents other things.
- Added titles to top of *nsay and *nme boxes so you can remember what you're doing.