### PR TITLE
Bluespace Jumpsuit and remove arbitrary size changing

### DIFF
--- a/code/modules/clothing/under/miscellaneous_vr.dm
+++ b/code/modules/clothing/under/miscellaneous_vr.dm
@@ -1,3 +1,21 @@
+/obj/item/clothing/var/hides_bulges = FALSE // OwO wats this?
+
+/mob/living/carbon/human/proc/show_pudge()
+	//A uniform could hide it.
+	if(istype(w_uniform,/obj/item/clothing))
+		var/obj/item/clothing/under = w_uniform
+		if(under.hides_bulges)
+			return FALSE
+
+	//We return as soon as we find one, no need for 'else' really.
+	if(istype(wear_suit,/obj/item/clothing))
+		var/obj/item/clothing/suit = wear_suit
+		if(suit.hides_bulges)
+			return FALSE
+
+
+	return TRUE
+
 /obj/item/clothing/under/permit
 	name = "public nudity permit"
 	desc = "This permit entitles the bearer to conduct their duties without a uniform. Normally issued to furred crewmembers or those with nothing to hide."
@@ -9,3 +27,81 @@
 
 	item_state = "golem"  //This is dumb and hacky but was here when I got here.
 	worn_state = "golem"  //It's basically just a coincidentally black iconstate in the file.
+
+/obj/item/clothing/under/bluespace
+	name = "bluespace jumpsuit"
+	icon_state = "lingchameleon"
+	item_icons = list(
+			slot_l_hand_str = 'icons/mob/items/lefthand_uniforms.dmi',
+			slot_r_hand_str = 'icons/mob/items/righthand_uniforms.dmi',
+			)
+	item_state = "lingchameleon"
+	worn_state = "lingchameleon"
+	desc = "Do you feel like warping spacetime today? Because it seems like that's on the agenda, now. \
+			Allows one to resize themselves at will, and conceals their true weight."
+	hides_bulges = TRUE
+	var/original_size
+
+/obj/item/clothing/under/bluespace/verb/resize()
+	set name = "Adjust Size"
+	set category = "Object"
+	set src in usr
+	bluespace_size(usr)
+	..()
+
+/obj/item/clothing/under/bluespace/proc/bluespace_size(mob/usr as mob)
+	if (!ishuman(usr))
+		return
+
+	var/mob/living/carbon/human/H = usr
+
+	if (H.stat || H.restrained())
+		return
+
+	if (src != H.w_uniform)
+		to_chat(H,"<span class='warning'>You must be WEARING the uniform to use it for that...</span>")
+		return
+
+	var/choice = alert(H,"Change which way?","Mass Alteration","Size Up","Cancel","Size Down")
+	if(choice == "Cancel")
+		return FALSE
+
+	if(choice == "Size Up")
+		switch(H.size_multiplier)
+			if(RESIZE_BIG to RESIZE_HUGE)
+				H.resize(RESIZE_HUGE)
+			if(RESIZE_NORMAL to RESIZE_BIG)
+				H.resize(RESIZE_BIG)
+			if(RESIZE_SMALL to RESIZE_NORMAL)
+				H.resize(RESIZE_NORMAL)
+			if((0 - INFINITY) to RESIZE_TINY)
+				H.resize(RESIZE_SMALL)
+
+	else if(choice == "Size Down")
+		switch(H.size_multiplier)
+			if(RESIZE_HUGE to INFINITY)
+				H.resize(RESIZE_BIG)
+			if(RESIZE_BIG to RESIZE_HUGE)
+				H.resize(RESIZE_NORMAL)
+			if(RESIZE_NORMAL to RESIZE_BIG)
+				H.resize(RESIZE_SMALL)
+			if((0 - INFINITY) to RESIZE_NORMAL)
+				H.resize(RESIZE_TINY)
+
+	H.visible_message("<span class='warning'>The space around [H] distorts as they change size!</span>","<span class='notice'>The space around you distorts as you change size!</span>")
+	H.update_icons()
+
+/obj/item/clothing/under/bluespace/mob_can_equip(M as mob, slot, disable_warning = 0)
+	. = ..()
+	if(. && ishuman(M)) //Looks like we're being put on after all.
+		var/mob/living/carbon/human/H = M
+		original_size = H.size_multiplier
+
+/obj/item/clothing/under/bluespace/mob_can_unequip(mob/M, slot, disable_warning = 0)
+	. = ..()
+	if(. && ishuman(M))
+		var/mob/living/carbon/human/H = M
+		H.resize(original_size)
+		H.update_icons()
+		original_size = null
+		H.visible_message("<span class='warning'>The space around [H] distorts as they return to their original size!</span>","<span class='notice'>The space around you distorts as you return to your original size!</span>")

--- a/code/modules/mob/living/carbon/human/examine_vr.dm
+++ b/code/modules/mob/living/carbon/human/examine_vr.dm
@@ -1,4 +1,6 @@
 /mob/living/carbon/human/proc/examine_weight()
+	if(!show_pudge()) //Some clothing or equipment can hide this.
+		return ""
 	var/message = ""
 	var/weight_examine = round(weight)
 	var/t_He 	= "It" //capitalised for use at the start of each line.
@@ -58,6 +60,8 @@
 	return message //Credit to Aronai for helping me actually get this working!
 
 /mob/living/carbon/human/proc/examine_nutrition()
+	if(!show_pudge()) //Some clothing or equipment can hide this.
+		return ""
 	var/message = ""
 	var/nutrition_examine = round(nutrition)
 	var/t_He 	= "It" //capitalised for use at the start of each line.
@@ -104,6 +108,9 @@
 	return message
 
 /mob/living/carbon/human/proc/examine_bellies()
+	if(!show_pudge()) //Some clothing or equipment can hide this.
+		return ""
+
 	var/message = ""
 
 	for (var/I in src.vore_organs)

--- a/code/modules/research/designs_vr.dm
+++ b/code/modules/research/designs_vr.dm
@@ -29,6 +29,14 @@
 	build_path = /obj/item/weapon/gun/energy/sizegun
 	sort_string = "TAAAB"
 
+/datum/design/item/bluespace_jumpsuit
+	name = "Bluespace jumpsuit"
+	id = "bsjumpsuit"
+	req_tech = list(TECH_BLUESPACE = 2, TECH_MATERIAL = 3, TECH_POWER = 2)
+	materials = list(DEFAULT_WALL_MATERIAL = 4000, "glass" = 4000)
+	build_path = /obj/item/clothing/under/bluespace
+	sort_string = "TAAAC"
+
 /datum/design/item/item/pressureinterlock
 	name = "APP pressure interlock"
 	id = "pressureinterlock"

--- a/code/modules/vore/resizing/resize_vr.dm
+++ b/code/modules/vore/resizing/resize_vr.dm
@@ -79,6 +79,8 @@ var/const/RESIZE_A_SMALLTINY = (RESIZE_SMALL + RESIZE_TINY) / 2
 /mob/living/carbon/human/dummy/mannequin/resize(var/new_size)
 	size_multiplier = new_size
 
+/* Removed due to too many 'magic' characters having resizing 100% of the time.
+   Replaced with bluespace jumpsuit, and mass altering NIFSoft.
 /**
  * Verb proc for a command that lets players change their size OOCly.
  * Ace was here! Redid this a little so we'd use math for shrinking characters. This is the old code.
@@ -104,6 +106,8 @@ var/const/RESIZE_A_SMALLTINY = (RESIZE_SMALL + RESIZE_TINY) / 2
 /hook/living_new/proc/resize_setup(mob/living/H)
 	H.verbs += /mob/living/proc/set_size
 	return 1
+*/
+
 
 /**
  * Attempt to scoop up this mob up into H's hands, if the size difference is large enough.


### PR DESCRIPTION
The bluespace jumpsuit is relatively cheap (compared to a shrink ray) and craftable in R&D. When worn, it allows you to resize yourself at will, and when removed you'll snap back to your original size (use a shrinkray or the Mass Altering NIFSoft for permanent changes). The reason it's not permanent is because it's very cheap to make in R&D, really. No mining materials needed, but it only affects you. So you can consider it the 'minor' size change tool. It also hides your bellies and weight/nutrition status for sneakynoms.

This PR also comments out the arbitrary size change verb since we decided to remove it, as it was being used to generally just make 'magic' characters that could resize themselves at will, or use it for mechanical purposes to avoid being shot etc when fighting starts, even though it says specifically not to do these things. If you want such a character that can resize themselves due to their physiology, please apply for an SCA and we can give you a small fluff item or other accomidation to allow such a thing.