### PR TITLE
Fix Bluespace Harpoon bug, Allow Teleport Jamming

### DIFF
--- a/code/modules/vore/fluffstuff/custom_guns_vr.dm
+++ b/code/modules/vore/fluffstuff/custom_guns_vr.dm
@@ -790,13 +790,18 @@
 
 /obj/item/weapon/bluespace_harpoon/afterattack(atom/A, mob/user as mob)
 	var/current_fire = world.time
-	if(!user || !A || user.machine)
+	if(!user || !A)
 		return
 	if(transforming)
 		to_chat(user,"<span class = 'warning'>You can't fire while \the [src] transforming!</span>")
 		return
 	if(!(current_fire - last_fire >= 20 SECONDS))
 		to_chat(user,"<span class = 'warning'>\The [src] is recharging...</span>")
+		return
+	if(is_jammed(A) || is_jammed(user))
+		to_chat(user,"<span class = 'warning'>\The [src] shot fizzles due to interference!</span>")
+		last_fire = current_fire
+		playsound(user, 'sound/weapons/wave.ogg', 60, 1)
 		return
 
 	last_fire = current_fire

--- a/code/modules/vore/fluffstuff/custom_items_vr.dm
+++ b/code/modules/vore/fluffstuff/custom_items_vr.dm
@@ -1031,6 +1031,11 @@ obj/item/weapon/material/hatchet/tacknife/combatknife/fluff/katarina/handle_shie
 		to_chat(user,"<span class='warning'>\The [src] doesn't have a current valid destination set!</span>")
 		return
 
+	//No, you can't teleport if there's a jammer.
+	if(is_jammed(src) || is_jammed(destination))
+		to_chat(user,"<span class='warning'>\The [src] refuses to teleport you, due to strong interference!</span>")
+		return
+
 	//No, you can't port to or from away missions. Stupidly complicated check.
 	var/turf/uT = get_turf(user)
 	var/turf/dT = get_turf(destination)


### PR DESCRIPTION
The subspace jammers will jam portable teleporters (not the hand tele, for ~reasons~ (mostly to give it one good feature)). This should also fix an annoying bug where the bluespace harpoon fails to work for a long period of time.