### PR TITLE
Cheap hack fix for get_blahblah_fast breaking due to null in list

### DIFF
--- a/code/_helpers/game.dm
+++ b/code/_helpers/game.dm
@@ -281,6 +281,9 @@
 
 	//A list of every mob with a client
 	for(var/mob in player_list)
+		if(isnull(mob)) //VOREStation Add - Fix for a weird bug with nulls in this list
+			player_list -= mob //VOREStation Add
+			continue //VOREStation Add
 		if(get_turf(mob) in hearturfs)
 			mobs |= mob
 			continue


### PR DESCRIPTION
Just have it clean them on nulls. This check should be fast, the list isn't that long, and it checks other stuff anyway.