### PR TITLE
Adds Rix to Diona Whitelist

### DIFF
--- a/config/alienwhitelist.txt
+++ b/config/alienwhitelist.txt
@@ -13,6 +13,7 @@ natje - Xenochimera
 zalvine - Enochian
 rikaru19xjenkins - Xenochimera
 rikaru19xjenkins  - Xenomorph Hybrid
+rixunie - Diona
 seiga - Vox
 benemuel - Enochian
 benemuel - Daemon


### PR DESCRIPTION
# WHY HASN'T THIS BEEN DONE YET AAAAAAAAH

(also I am posting this from inside a Rix belly send help)

Jokes aside, this does *not* require an application like most whitelists because Rix had Diona from well before the forums even existed. They're grandfathered in.