### PR TITLE
Soulcatcher chat logging, and subtle logging for free

### DIFF
--- a/code/_helpers/logging_vr.dm
+++ b/code/_helpers/logging_vr.dm
@@ -1,0 +1,11 @@
+/proc/log_nsay(text,inside)
+	if (config.log_say)
+		diary << "\[[time_stamp()]]NSAY (NIF:[inside]): [text][log_end]"
+
+/proc/log_nme(text,inside)
+	if (config.log_emote)
+		diary << "\[[time_stamp()]]NME (NIF:[inside]): [text][log_end]"
+
+/proc/log_subtle(text)
+	if (config.log_emote)
+		diary << "\[[time_stamp()]]SUBTLE: [text][log_end]"

--- a/code/modules/mob/living/carbon/human/emote_vr.dm
+++ b/code/modules/mob/living/carbon/human/emote_vr.dm
@@ -26,7 +26,7 @@
 				return 1
 			var/nifmessage = sanitize(input("Type a message to say.","Speak into NIF") as text|null)
 			if(nifmessage)
-				SC.say_into(nifmessage,src.real_name)
+				SC.say_into(nifmessage,src)
 			return 1
 
 		if ("nme")
@@ -42,7 +42,7 @@
 				return 1
 			var/nifmessage = sanitize(input("Type an action to perform.","Emote into NIF") as text|null)
 			if(nifmessage)
-				SC.emote_into(nifmessage,src.real_name)
+				SC.emote_into(nifmessage,src)
 			return 1
 
 		if ("flip")

--- a/code/modules/mob/say_vr.dm
+++ b/code/modules/mob/say_vr.dm
@@ -41,7 +41,7 @@
 		return
 
 	if (message)
-		log_emote("[name]/[key] : [message]")
+		log_subtle("[name]/[key] : [message]")
 
 		var/list/vis = get_mobs_and_objs_in_view_fast(get_turf(src),1,2) //Turf, Range, and type 2 is emote
 		var/list/vis_mobs = vis["mobs"]

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -65,6 +65,7 @@
 #include "code\_helpers\icons_vr.dm"
 #include "code\_helpers\lists.dm"
 #include "code\_helpers\logging.dm"
+#include "code\_helpers\logging_vr.dm"
 #include "code\_helpers\maths.dm"
 #include "code\_helpers\matrices.dm"
 #include "code\_helpers\mobs.dm"


### PR DESCRIPTION
Logs soulcatcher messages to the chat log so admins can review them, since that's kinda important, and gives subtle it's own logging format so you can tell it's a subtle and not just an emote. Also disables subtles while in the soulcatcher because apparently that was a thing.