### PR TITLE
Fix a runtime I missed on Soulcatcher

### DIFF
--- a/code/modules/nifsoft/software/13_soulcatcher.dm
+++ b/code/modules/nifsoft/software/13_soulcatcher.dm
@@ -245,7 +245,7 @@
 
 /mob/living/carbon/brain/caught_soul/Destroy()
 	if(soulcatcher)
-		soulcatcher.emote_into(" - Mind unloaded: [name]","SOULCATCHER")
+		soulcatcher.notify_into("Mind unloaded: [name]")
 		soulcatcher.brainmobs -= src
 		soulcatcher = null
 	if(nif)


### PR DESCRIPTION
Only affects erasing minds, and doens't affect the prey, really. Just means the minds count is wrong and the name sticks around.