### PR TITLE
Fix for Issue #1637

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -295,8 +295,8 @@
 		new /obj/item/device/radio/headset/headset_sec(src)
 		new /obj/item/device/radio/headset/headset_sec/alt(src)
 		new /obj/item/clothing/suit/storage/vest/detective(src)
-		new /obj/item/ammo_casing/a44/rubber(src)
-		new /obj/item/ammo_casing/a44/rubber(src)
+		new /obj/item/ammo_magazine/m44sl/rubber
+		new /obj/item/ammo_magazine/m44sl/rubber
 		new /obj/item/taperoll/police(src)
 		new /obj/item/weapon/gun/projectile/revolver/consul(src) //VOREStation Edit
 		new /obj/item/clothing/accessory/holster/armpit(src)


### PR DESCRIPTION
Just a small change to two lines that replaces the single .44 rubber bullets currently spawning in the detective locker with .44 Rubber Speedloaders. 

Fixes #1637