### PR TITLE
Update custom_guns_vr.dm to properly reference the .44 lethal speedloader sprite. 

### DIFF
--- a/code/modules/vore/fluffstuff/custom_guns_vr.dm
+++ b/code/modules/vore/fluffstuff/custom_guns_vr.dm
@@ -1051,7 +1051,7 @@
 	name = "speedloader (.44)"
 	desc = "A speedloader for .44 revolvers."
 	icon = 'icons/obj/ammo_vr.dmi'
-	icon_state = "357"
+	icon_state = "s357"
 	caliber = ".44"
 	matter = list(DEFAULT_WALL_MATERIAL = 1260)
 	ammo_type = /obj/item/ammo_casing/a44


### PR DESCRIPTION
A proper fix for the lack of .44 lethal speedloader sprite. 
Blah blah blah. Changed one letter to properly reference the currently titled .44 lethal speedloader sprite. 
It was Icon_state= '357', when it should have been Icon_state= 's357', because that's what the .44 lethal speedloader sprite is called in the .dmi it references. 