### PR TITLE
More qdel fixes

### DIFF
--- a/code/controllers/Processes/scheduler.dm
+++ b/code/controllers/Processes/scheduler.dm
@@ -46,12 +46,9 @@
 
 /datum/controller/process/scheduler/proc/schedule(var/datum/scheduled_task/st)
 	scheduled_tasks += st
-	destroyed_event.register(st, src, /datum/controller/process/scheduler/proc/unschedule)
 
 /datum/controller/process/scheduler/proc/unschedule(var/datum/scheduled_task/st)
-	if(st in scheduled_tasks)
-		scheduled_tasks -= st
-		destroyed_event.unregister(st, src)
+	scheduled_tasks -= st
 
 /**********
 * Helpers *
@@ -102,6 +99,7 @@
 	task_after_process_args += src
 
 /datum/scheduled_task/Destroy()
+	scheduler.unschedule(src)
 	procedure = null
 	arguments.Cut()
 	task_after_process = null

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -316,7 +316,7 @@
 	if(occupant)
 		occupant.forceMove(loc)
 		occupant.resting = 1
-	..()
+	return ..()
 
 /obj/machinery/cryopod/initialize()
 	..()

--- a/code/game/machinery/doors/multi_tile.dm
+++ b/code/game/machinery/doors/multi_tile.dm
@@ -12,11 +12,9 @@
 		create_fillers()
 
 /obj/machinery/door/airlock/multi_tile/Destroy()
-	if(filler1)
-		qdel(filler1)
-	if(filler2)
-		qdel(filler2)
-	..()
+	qdel_null(filler1)
+	qdel_null(filler2)
+	return ..()
 
 /obj/machinery/door/airlock/multi_tile/Move()
 	. = ..()

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -60,7 +60,7 @@
 /obj/machinery/door/window/Destroy()
 	density = 0
 	update_nearby_tiles()
-	..()
+	return ..()
 
 /obj/machinery/door/window/Bumped(atom/movable/AM as mob|obj)
 	if (!( ismob(AM) ))

--- a/code/game/objects/items/devices/PDA/radio.dm
+++ b/code/game/objects/items/devices/PDA/radio.dm
@@ -103,7 +103,7 @@
 /obj/item/radio/integrated/beepsky/Destroy()
 	if(radio_controller)
 		radio_controller.remove_object(src, control_freq)
-	..()
+	return ..()
 
 /*
  *	Radio Cartridge, essentially a signaler.

--- a/code/game/objects/items/devices/communicator/communicator.dm
+++ b/code/game/objects/items/devices/communicator/communicator.dm
@@ -256,7 +256,7 @@ var/global/list/obj/item/device/communicator/all_communicators = list()
 	if(exonet)
 		exonet.remove_address()
 		exonet = null
-	..()
+	return ..()
 
 // Proc: ui_interact()
 // Parameters: 4 (standard NanoUI arguments)

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -37,7 +37,7 @@
 /obj/item/device/flashlight/Destroy()
 	if(power_use)
 		processing_objects -= src
-	..()
+	return ..()
 
 /obj/item/device/flashlight/verb/toggle()
 	set name = "Toggle Flashlight Brightness"

--- a/code/game/objects/items/devices/paicard.dm
+++ b/code/game/objects/items/devices/paicard.dm
@@ -27,7 +27,8 @@
 	//Will stop people throwing friend pAIs into the singularity so they can respawn
 	if(!isnull(pai))
 		pai.death(0)
-	..()
+	qdel_null(radio)
+	return ..()
 
 /obj/item/device/paicard/attack_self(mob/user)
 	if (!in_range(src, user))

--- a/code/game/objects/items/devices/radio/jammer.dm
+++ b/code/game/objects/items/devices/radio/jammer.dm
@@ -33,10 +33,8 @@ var/global/list/active_radio_jammers = list()
 /obj/item/device/radio_jammer/Destroy()
 	if(on)
 		turn_off()
-	if(power_source)
-		qdel(power_source)
-	power_source = null
-	..()
+	qdel_null(power_source)
+	return ..()
 
 /obj/item/device/radio_jammer/proc/turn_off(mob/user)
 	if(user)

--- a/code/game/objects/structures/inflatable.dm
+++ b/code/game/objects/structures/inflatable.dm
@@ -38,7 +38,7 @@
 
 /obj/structure/inflatable/Destroy()
 	update_nearby_tiles()
-	..()
+	return ..()
 
 /obj/structure/inflatable/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
 	return 0

--- a/code/modules/clothing/suits/storage.dm
+++ b/code/modules/clothing/suits/storage.dm
@@ -8,9 +8,8 @@
 	pockets.max_storage_space = ITEMSIZE_COST_SMALL * 2
 
 /obj/item/clothing/suit/storage/Destroy()
-	qdel(pockets)
-	pockets = null
-	..()
+	qdel_null(pockets)
+	return ..()
 
 /obj/item/clothing/suit/storage/attack_hand(mob/user as mob)
 	if (pockets.handle_attack_hand(user))

--- a/code/modules/hydroponics/spreading/spreading.dm
+++ b/code/modules/hydroponics/spreading/spreading.dm
@@ -77,7 +77,8 @@
 		plant_controller.remove_plant(src)
 	for(var/obj/effect/plant/neighbor in range(1,src))
 		plant_controller.add_plant(neighbor)
-	..()
+	return ..()
+
 /obj/effect/plant/single
 	spread_chance = 0
 

--- a/code/modules/integrated_electronics/subtypes/input_output.dm
+++ b/code/modules/integrated_electronics/subtypes/input_output.dm
@@ -304,7 +304,8 @@
 	if(exonet)
 		exonet.remove_address()
 		qdel(exonet)
-	..()
+		exonet = null
+	return ..()
 
 /obj/item/integrated_circuit/input/EPv2/do_work()
 	var/target_address = get_pin_data(IC_INPUT, 1)
@@ -370,7 +371,7 @@
 
 /obj/item/integrated_circuit/input/microphone/Destroy()
 	listening_objects -= src
-	..()
+	return ..()
 
 /obj/item/integrated_circuit/input/microphone/hear_talk(mob/living/M, msg, var/verb="says", datum/language/speaking=null)
 	var/translated = FALSE
@@ -482,9 +483,6 @@
 	var/light_brightness = 3
 	var/light_rgb = "#FFFFFF"
 	power_draw_idle = 0 // Adjusted based on brightness.
-
-/obj/item/integrated_circuit/output/light/Destroy()
-	..()
 
 /obj/item/integrated_circuit/output/light/do_work()
 	light_toggled = !light_toggled
@@ -644,8 +642,8 @@
 	on_data_written()
 
 /obj/item/integrated_circuit/output/video_camera/Destroy()
-	qdel(camera)
-	..()
+	qdel_null(camera)
+	return ..()
 
 /obj/item/integrated_circuit/output/video_camera/proc/set_camera_status(var/status)
 	if(camera)

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -132,7 +132,7 @@ var/global/list/image/ghost_sightless_images = list() //this is a list of images
 		qdel(ghostimage)
 		ghostimage = null
 		updateallghostimages()
-	..()
+	return ..()
 
 /mob/observer/dead/Topic(href, href_list)
 	if (href_list["track"])

--- a/code/modules/mob/living/carbon/brain/MMI.dm
+++ b/code/modules/mob/living/carbon/brain/MMI.dm
@@ -110,10 +110,8 @@
 	if(isrobot(loc))
 		var/mob/living/silicon/robot/borg = loc
 		borg.mmi = null
-	if(brainmob)
-		qdel(brainmob)
-		brainmob = null
-	..()
+	qdel_null(brainmob)
+	return ..()
 
 /obj/item/device/mmi/radio_enabled
 	name = "radio-enabled man-machine interface"

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -45,7 +45,7 @@
 /obj/item/weapon/gun/energy/Destroy()
 	if(self_recharge)
 		processing_objects.Remove(src)
-	..()
+	return ..()
 
 /obj/item/weapon/gun/energy/process()
 	if(self_recharge) //Every [recharge_time] ticks, recharge a shot for the battery

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -18,11 +18,7 @@
 		unwrap()
 
 	proc/unwrap()
-		if(wrapped) //sometimes items can disappear. For example, bombs. --rastaf0
-			wrapped.loc = (get_turf(src.loc))
-			if(istype(wrapped, /obj/structure/closet))
-				var/obj/structure/closet/O = wrapped
-				O.welded = 0
+		// Destroy will drop our wrapped object on the turf, so let it.
 		qdel(src)
 
 	attackby(obj/item/W as obj, mob/user as mob)
@@ -312,14 +308,15 @@
 
 /obj/structure/bigDelivery/Destroy()
 	if(wrapped) //sometimes items can disappear. For example, bombs. --rastaf0
-		wrapped.loc = (get_turf(loc))
+		wrapped.forceMove(get_turf(src))
 		if(istype(wrapped, /obj/structure/closet))
 			var/obj/structure/closet/O = wrapped
 			O.welded = 0
+		wrapped = null
 	var/turf/T = get_turf(src)
 	for(var/atom/movable/AM in contents)
-		AM.loc = T
-	..()
+		AM.forceMove(T)
+	return ..()
 
 /obj/item/device/destTagger
 	name = "destination tagger"

--- a/code/modules/shieldgen/energy_field.dm
+++ b/code/modules/shieldgen/energy_field.dm
@@ -32,13 +32,12 @@
 	my_gen.field.Remove(src)
 	my_gen = null
 	var/turf/current_loc = get_turf(src)
-	spawn(1) // Updates neightbors after we're gone.
-		for(var/direction in cardinal)
-			var/turf/T = get_step(current_loc, direction)
-			if(T)
-				for(var/obj/effect/energy_field/F in T)
-					F.update_icon()
-	..()
+	. = ..()
+	for(var/direction in cardinal)
+		var/turf/T = get_step(current_loc, direction)
+		if(T)
+			for(var/obj/effect/energy_field/F in T)
+				F.update_icon()
 
 /obj/effect/energy_field/ex_act(var/severity)
 	adjust_strength(-(4 - severity) * 4)

--- a/code/modules/shieldgen/shield_gen.dm
+++ b/code/modules/shieldgen/shield_gen.dm
@@ -38,10 +38,8 @@
 	..()
 
 /obj/machinery/shield_gen/Destroy()
-	for(var/obj/effect/energy_field/D in field)
-		field.Remove(D)
-		D.loc = null
-	..()
+	qdel_null_list(field)
+	return ..()
 
 /obj/machinery/shield_gen/emag_act(var/remaining_charges, var/mob/user)
 	if(prob(75))


### PR DESCRIPTION
* A plethora of Destroy() fixes - return qdel hints and clean stuff up.
*Fix /datum/scheduled_task was unable to be GC'd and was deleted.
  * In addition to fixing the problem, it makes sense.  The observer pattern is overkill for an object type we own; doing it directly in Destroy() is more efficient.