### PR TITLE
Fix preference sanitizing and mousedrop runtimes

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -243,6 +243,7 @@ datum/preferences
 		load_preferences()
 		load_character()
 		attempt_vr(client.prefs_vr,"load_vore","") //VOREStation Edit
+		sanitize_preferences()
 	else if(href_list["load"])
 		if(!IsGuestKey(usr.key))
 			open_load_dialog(usr)
@@ -250,6 +251,7 @@ datum/preferences
 	else if(href_list["changeslot"])
 		load_character(text2num(href_list["changeslot"]))
 		attempt_vr(client.prefs_vr,"load_vore","") //VOREStation Edit
+		sanitize_preferences()
 		close_load_dialog(usr)
 	else if(href_list["resetslot"])
 		if("No" == alert("This will reset the current slot. Continue?", "Reset current slot?", "No", "Yes"))

--- a/code/modules/clothing/clothing_accessories.dm
+++ b/code/modules/clothing/clothing_accessories.dm
@@ -40,7 +40,7 @@
 	return ..()
 
 /obj/item/clothing/MouseDrop(var/obj/over_object)
-	if (ishuman(usr) || issmall(usr))
+	if (over_object && (ishuman(usr) || issmall(usr)))
 		//makes sure that the clothing is equipped so that we can't drag it into our hand from miles away.
 		if (!(src.loc == usr))
 			return

--- a/code/modules/detectivework/tools/evidencebag.dm
+++ b/code/modules/detectivework/tools/evidencebag.dm
@@ -12,6 +12,8 @@
 /obj/item/weapon/evidencebag/MouseDrop(var/obj/item/I as obj)
 	if (!ishuman(usr))
 		return
+	if(!istype(I) || I.anchored)
+		return  ..()
 
 	var/mob/living/carbon/human/user = usr
 
@@ -35,9 +37,6 @@
 			user.drop_from_inventory(I)
 		else
 			return
-
-	if(!istype(I) || I.anchored)
-		return
 
 	if(istype(I, /obj/item/weapon/evidencebag))
 		user << "<span class='notice'>You find putting an evidence bag in another evidence bag to be slightly absurd.</span>"

--- a/code/modules/xenoarcheaology/artifacts/replicator.dm
+++ b/code/modules/xenoarcheaology/artifacts/replicator.dm
@@ -63,7 +63,7 @@
 	/obj/item/weapon/wrench,
 	/obj/item/weapon/screwdriver,
 	/obj/item/weapon/grenade/chem_grenade/cleaner,
-	/obj/item/weapon/grenade/chem_grenade/metalfoam) // Vorestation edit for vore mimic.
+	/obj/item/weapon/grenade/chem_grenade/metalfoam)
 
 	var/quantity = rand(5, 15)
 	for(var/i=0, i<quantity, i++)


### PR DESCRIPTION
Fixes un-sanitized preferences runtimes

* Puts back in code that sanitized preferences after loading, it was overwritten in polaris sync commit 3f1e5c80f25af98e27be802cb06a218026a33769
* Also removes a VOREStation Edit comment on lines that were no longer different from Polaris, introduced at the same time.
* Fixes Runtime in 02_language.dm,21: Cannot read null.language

Fix runtimes in MouseDrop when dragging out of the screen

* MouseDrop()'s over_object may be null if dropping over a stat panel or over other empty space. Fix runtimes from assuming it is not null.
* Fixes Runtime in clothing_accessories.dm,54: Cannot read null.name
* Fixes Runtime in evidencebag.dm,21: Cannot read null.loc

