### PR TITLE
Fixes objects using walk_to() not being able to be garbage collected.

### DIFF
--- a/code/game/gamemodes/events/clang.dm
+++ b/code/game/gamemodes/events/clang.dm
@@ -41,6 +41,10 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 		if(clong && prob(25))
 			src.loc = clong.loc
 
+	Destroy()
+		walk(src, 0) // Because we might have called walk_towards, we must stop the walk loop or BYOND keeps an internal reference to us forever.
+		return ..()
+
 /proc/immovablerod()
 	var/startx = 0
 	var/starty = 0

--- a/code/game/gamemodes/events/dust.dm
+++ b/code/game/gamemodes/events/dust.dm
@@ -90,6 +90,10 @@ The "dust" will damage the hull of the station causin minor hull breaches.
 			walk_towards(src, goal, 1)
 		return
 
+	Destroy()
+		walk(src, 0) // Because we might have called walk_towards, we must stop the walk loop or BYOND keeps an internal reference to us forever.
+		return ..()
+
 	touch_map_edge()
 		qdel(src)
 

--- a/code/game/gamemodes/meteor/meteors.dm
+++ b/code/game/gamemodes/meteor/meteors.dm
@@ -133,7 +133,7 @@
 
 /obj/effect/meteor/Destroy()
 	walk(src,0) //this cancels the walk_towards() proc
-	..()
+	return ..()
 
 /obj/effect/meteor/New()
 	..()

--- a/code/game/objects/effects/chem/chemsmoke.dm
+++ b/code/game/objects/effects/chem/chemsmoke.dm
@@ -12,6 +12,10 @@
 	create_reagents(500)
 	return
 
+/obj/effect/effect/smoke/chem/Destroy()
+	walk(src, 0) // Because we might have called walk_to, we must stop the walk loop or BYOND keeps an internal reference to us forever.
+	return ..()
+
 /datum/effect/effect/system/smoke_spread/chem
 	smoke_type = /obj/effect/effect/smoke/chem
 	var/obj/chemholder
@@ -166,7 +170,7 @@
 	sleep(150+rand(0,20))	// turning it off before it is deleted results in cleaner
 	smoke.set_opacity(0)		// lighting and view range updates
 	fadeOut(smoke)
-	qdel(src)
+	qdel(smoke)
 
 /datum/effect/effect/system/smoke_spread/chem/spores/spawnSmoke(var/turf/T, var/icon/I, var/dist = 1)
 	var/obj/effect/effect/smoke/chem/spores = new /obj/effect/effect/smoke/chem(location)

--- a/code/game/objects/effects/effect_system.dm
+++ b/code/game/objects/effects/effect_system.dm
@@ -179,8 +179,10 @@ steam.start() -- spawns the effect
 
 /obj/effect/effect/smoke/New()
 	..()
-	spawn (time_to_live)
-		qdel(src)
+	if(time_to_live)
+		spawn (time_to_live)
+			if(!QDELETED(src))
+				qdel(src)
 
 /obj/effect/effect/smoke/Crossed(mob/living/carbon/M as mob )
 	..()

--- a/code/game/objects/effects/spiders.dm
+++ b/code/game/objects/effects/spiders.dm
@@ -94,7 +94,7 @@
 		var/obj/item/organ/external/O = loc
 		O.implants -= src
 
-	..()
+	return ..()
 
 /obj/effect/spider/eggcluster/process()
 	amount_grown += rand(0,2)
@@ -138,7 +138,8 @@
 
 /obj/effect/spider/spiderling/Destroy()
 	processing_objects -= src
-	..()
+	walk(src, 0) // Because we might have called walk_to, we must stop the walk loop or BYOND keeps an internal reference to us forever.
+	return ..()
 
 /obj/effect/spider/spiderling/Bump(atom/user)
 	if(istype(user, /obj/structure/table))

--- a/code/game/objects/items/weapons/grenades/flashbang.dm
+++ b/code/game/objects/items/weapons/grenades/flashbang.dm
@@ -91,6 +91,10 @@
 				M << "<span class='danger'>Your ears start to ring!</span>"
 		M.update_icons()
 
+/obj/item/weapon/grenade/flashbang/Destroy()
+	walk(src, 0) // Because we might have called walk_away, we must stop the walk loop or BYOND keeps an internal reference to us forever.
+	return ..()
+
 /obj/item/weapon/grenade/flashbang/clusterbang//Created by Polymorph, fixed by Sieve
 	desc = "Use of this weapon may constiute a war crime in your area, consult your local Colony Director."
 	name = "clusterbang"

--- a/code/modules/vore/eating/silicon_vr.dm
+++ b/code/modules/vore/eating/silicon_vr.dm
@@ -11,6 +11,10 @@
 	color = HOLO_ORIGINAL_COLOR //This is the blue from icons.dm that it was before.
 	desc = "A hologram representing an AI persona."
 
+/obj/effect/overlay/aiholo/Destroy()
+	walk(src, 0) // Because we might have called walk_to, we must stop the walk loop or BYOND keeps an internal reference to us forever.
+	return ..()
+
 /obj/effect/overlay/aiholo/proc/get_prey(var/mob/living/prey)
 	if(bellied) return
 	playsound('sound/effects/stealthoff.ogg',50,0)


### PR DESCRIPTION
* Okay evidently walk_to(A, B) doesn't stop when A reaches B, but keeps running in the background forever until it is manually canceled!  Therefore in order to be garbage collected, we must cancel walking on any object that might have initiated it.
* Fixes this on chemsmoke, spiders, and aiholos.
* Also fixed chemsmoke actually getting qdeled at the right time.