### PR TITLE
Fix runtime errors when uninstalling some nifsofts

### DIFF
--- a/code/modules/nifsoft/software/10_combat.dm
+++ b/code/modules/nifsoft/software/10_combat.dm
@@ -8,14 +8,7 @@
 	wear = 3
 	access = 999 //Prevents anyone from buying it without an emag.
 	activates = FALSE //It's armor.
-
-	install()
-		if((. = ..()))
-			nif.set_flag(NIF_C_BRUTEARMOR,NIF_FLAGS_COMBAT)
-
-	uninstall()
-		. = ..()
-		nif.clear_flag(NIF_C_BRUTEARMOR,NIF_FLAGS_COMBAT)
+	combat_flags = NIF_C_BRUTEARMOR // Default on when installed, clear when uninstalled
 
 /datum/nifsoft/burn_armor
 	name = "Dragon's Skin"
@@ -27,14 +20,7 @@
 	wear = 3
 	access = 999 //Prevents anyone from buying it without an emag.
 	activates = FALSE //It's armor.
-
-	install()
-		if((. = ..()))
-			nif.set_flag(NIF_C_BURNARMOR,NIF_FLAGS_COMBAT)
-
-	uninstall()
-		. = ..()
-		nif.clear_flag(NIF_C_BURNARMOR,NIF_FLAGS_COMBAT)
+	combat_flags = NIF_C_BURNARMOR // Default on when installed, clear when uninstalled
 
 /datum/nifsoft/painkillers
 	name = "Nova Shock"

--- a/code/modules/nifsoft/software/13_soulcatcher.dm
+++ b/code/modules/nifsoft/software/13_soulcatcher.dm
@@ -15,6 +15,7 @@
 	cost = 1265
 	wear = 1
 	p_drain = 0.01
+	other_flags = (NIF_O_SCMYSELF|NIF_O_SCOTHERS) // Default on when installed, clear when uninstalled
 
 	var/setting_flags = (NIF_SC_CATCHING_ME|NIF_SC_CATCHING_OTHERS|NIF_SC_ALLOW_EARS|NIF_SC_ALLOW_EYES|NIF_SC_BACKUPS)
 	var/list/brainmobs = list()
@@ -27,16 +28,6 @@
 	Destroy()
 		qdel_null_list(brainmobs)
 		return ..()
-
-	install()
-		if((. = ..()))
-			nif.set_flag(NIF_O_SCMYSELF,NIF_FLAGS_OTHER)
-			nif.set_flag(NIF_O_SCOTHERS,NIF_FLAGS_OTHER)
-
-	uninstall()
-		if((. = ..()))
-			nif.clear_flag(NIF_O_SCMYSELF,NIF_FLAGS_OTHER)
-			nif.clear_flag(NIF_O_SCOTHERS,NIF_FLAGS_OTHER)
 
 	activate()
 		if((. = ..()))


### PR DESCRIPTION
* /datum/nifsoft/uninstall() sets nif = null, so any overriden uninstall() that calls parent can't access the nif after that.   Luckily the only nifsofts that did this were just clearing flags that they set on install().
* We have an automatic flag set/clearing mechanism using some variables which sets them on install and clears on uninstall, so we switch to that and its all good.