### PR TITLE
Fixes players not being removed from the manifest immediately when cryoing.

### DIFF
--- a/code/_helpers/logging.dm
+++ b/code/_helpers/logging.dm
@@ -180,6 +180,8 @@
 	return "[..()] ([ckey])"
 
 /proc/log_info_line(var/datum/d)
+	if(!d)
+		return "*null*"
 	if(!istype(d))
-		return
+		return json_encode(d)
 	return d.log_info_line()

--- a/code/datums/mixed.dm
+++ b/code/datums/mixed.dm
@@ -23,6 +23,19 @@
 	size = 5.0
 	var/list/fields = list(  )
 
+// Mostly used for data_core records, but unfortuantely used some other places too.  But mostly here, so lets make a good effort.
+// TODO - Some machines/computers might be holding references to us.  Lets look into that, but at least for now lets make sure that the manifest is cleaned up.
+/datum/data/record/Destroy(var/force)
+	if(data_core.locked.Find(src))
+		if(!force)
+			crash_with("Someone tried to qdel a record that was in data_core.locked [log_info_line(src)]")
+			return QDEL_HINT_LETMELIVE
+		data_core.locked -= src
+	data_core.medical -= src
+	data_core.general -= src
+	data_core.security -= src
+	..()
+	return QDEL_HINT_FINDREFERENCE // If we must, we can resort to QDEL_HINT_HARDDEL.  But lets see how this works in practice ~Leshana
 
 /datum/data/text
 	name = "text"


### PR DESCRIPTION
* The cryopod simply qdel's the datacore records. Old garbage.dm hard-del()'d datums, so it was fine.  Now we need to make sure they are actually removed from the data_core.
* Testing shows this fixes #1713 and in most cases the objects also GC cleanly.  However some older computers still retain hard references to data_core entries. But even in the cases where that prevents a clean GC, the player is still removed from the manifest successfully and promptly, so that can wait.