### PR TITLE
Persistent size between rounds

### DIFF
--- a/code/modules/client/preference_setup/vore/05_persistence.dm
+++ b/code/modules/client/preference_setup/vore/05_persistence.dm
@@ -2,8 +2,9 @@
 #define PERSIST_WEIGHT		0x02	// Persist mob weight
 #define PERSIST_ORGANS		0x04	// Persist the status (normal/amputated/robotic/etc) and model (for robotic) status of organs
 #define PERSIST_MARKINGS	0x08	// Persist markings
-#define PERSIST_COUNT		4		// Number of valid bits in this bitflag.  Keep this updated!
-#define PERSIST_DEFAULT		PERSIST_SPAWN|PERSIST_ORGANS|PERSIST_MARKINGS // Default setting for new folks
+#define PERSIST_SIZE		0x10	// Persist size
+#define PERSIST_COUNT		5		// Number of valid bits in this bitflag.  Keep this updated!
+#define PERSIST_DEFAULT		PERSIST_SPAWN|PERSIST_ORGANS|PERSIST_MARKINGS|PERSIST_SIZE // Default setting for new folks
 
 // Define a place to save in character setup
 /datum/preferences
@@ -43,6 +44,10 @@
 
 	. += "<tr><td title=\"Update marking preferences (type and color) based on what you have at round end.\">Save Markings: </td>"
 	. += make_yesno(PERSIST_MARKINGS)
+	. += "</tr>"
+
+	. += "<tr><td title=\"Update character scale based on what you were at round end.\">Save Scale: </td>"
+	. += make_yesno(PERSIST_SIZE)
 	. += "</tr>"
 
 	. += "</table>"

--- a/code/modules/vore/persist/persist_vr.dm
+++ b/code/modules/vore/persist/persist_vr.dm
@@ -102,6 +102,8 @@
 		if(prefs.persistence_settings & PERSIST_WEIGHT)
 			resolve_excess_nutrition(H)
 			prefs.weight_vr = H.weight
+		if(prefs.persistence_settings & PERSIST_SIZE)
+			prefs.size_multiplier = H.size_multiplier
 
 	prefs.save_character()
 


### PR DESCRIPTION
Allows your size to save at the end of each round (and when cryo'ing). Get shrank'd or enbiggened? Now you can stay tiny between rounds if you like that consistency.

Don't want that? Just turn it off on the VORE tab. Accidentally left it on, and got saved? Just change your size to what you want in the character setup (and turn off saving it, too).