### PR TITLE
Enables %pred and %prey macros in full belly examine text

### DIFF
--- a/code/modules/vore/eating/belly_vr.dm
+++ b/code/modules/vore/eating/belly_vr.dm
@@ -183,6 +183,8 @@
 		var/raw_message = pick(examine_messages)
 
 		formatted_message = replacetext(raw_message,"%belly",lowertext(name))
+		formatted_message = replacetext(formatted_message,"%pred",owner)
+		formatted_message = replacetext(formatted_message,"%prey",english_list(internal_contents))
 
 		return("<span class='warning'>[formatted_message]</span><BR>")
 

--- a/code/modules/vore/eating/vorepanel_vr.dm
+++ b/code/modules/vore/eating/vorepanel_vr.dm
@@ -522,7 +522,7 @@
 					selected.set_messages(new_message,"smi")
 
 			if("Examine Message (when full)")
-				var/new_message = input(user,"These are sent to people who examine you when this belly has contents. Write them in 3rd person ('Their %belly is bulging'). Do not use %pred or %prey in this type."+help,"Examine Message (when full)",selected.get_messages("em")) as message
+				var/new_message = input(user,"These are sent to people who examine you when this belly has contents. Write them in 3rd person ('Their %belly is bulging')."+help,"Examine Message (when full)",selected.get_messages("em")) as message
 				if(new_message)
 					selected.set_messages(new_message,"em")
 


### PR DESCRIPTION
Not really much of a reason for %pred not to work, and %prey could be useful for see-through or external bellies.