### PR TITLE
Splits some things into seperate procs

### DIFF
--- a/code/modules/vore/eating/belly_vr.dm
+++ b/code/modules/vore/eating/belly_vr.dm
@@ -418,10 +418,9 @@
 				return
 
 		else if(prob(transferchance) && istype(transferlocation)) //Next, let's have it see if they end up getting into an even bigger mess then when they started.
-			internal_contents -= R
-			transferlocation.internal_contents |= R
 			R << "<span class='warning'>Your attempt to escape [name] has failed and your struggles only results in you sliding into [owner]'s [transferlocation]!</span>"
 			owner << "<span class='warning'>Someone slid into your [transferlocation] due to their struggling inside your [name]!</span>"
+			transfer_contents(R, transferlocation)
 			return
 
 		else if(prob(absorbchance)) //After that, let's have it run the absorb chance.
@@ -439,6 +438,22 @@
 			R << "<span class='warning'>But make no progress in escaping [owner]'s [name].</span>"
 			owner << "<span class='warning'>But appears to be unable to make any progress in escaping your [name].</span>"
 			return
+
+//Transfers contents from one belly to another
+/datum/belly/proc/transfer_contents(var/atom/movable/content, var/datum/belly/target, silent = 0)
+	if(!(content in internal_contents))
+		return
+	internal_contents -= content
+	target.internal_contents |= content
+	if(isliving(content))
+		var/mob/living/M = content
+		if(target.inside_flavor)
+			to_chat(M, "<span class='notice'><B>[target.inside_flavor]</B></span>")
+		if(target.can_taste && M.get_taste_message(0))
+			to_chat(owner, "<span class='notice'>[M] tastes of [M.get_taste_message(0)].</span>")
+	if(!silent)
+		for(var/mob/hearer in range(1,owner))
+			hearer << sound('sound/vore/squish2.ogg',volume=80)
 
 // Belly copies and then returns the copy
 // Needs to be updated for any var changes

--- a/code/modules/vore/eating/living_vr.dm
+++ b/code/modules/vore/eating/living_vr.dm
@@ -256,24 +256,30 @@
 		return
 
 	src.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
+
+	src.visible_message("<span class='warning'>[src] licks [tasted]!</span>","<span class='notice'>You lick [tasted]. They taste rather like [tasted.get_taste_message()].</span>","<b>Slurp!</b>")
+
+
+/mob/living/proc/get_taste_message(allow_generic = 1)
+	if(!vore_taste && !allow_generic)
+		return 0
+
 	var/taste_message = ""
-	if(tasted.vore_taste && (tasted.vore_taste != ""))
-		taste_message += "[tasted.vore_taste]"
+	if(vore_taste && (vore_taste != ""))
+		taste_message += "[vore_taste]"
 	else
-		if(ishuman(tasted))
-			var/mob/living/carbon/human/H = tasted
+		if(ishuman(src))
+			var/mob/living/carbon/human/H = src
 			taste_message += "a normal [H.custom_species ? H.custom_species : H.species.name]"
 		else
-			taste_message += "a plain old normal [tasted]"
+			taste_message += "a plain old normal [src]"
 
-	if(ishuman(tasted))
-		var/mob/living/carbon/human/H = tasted
+	if(ishuman(src))
+		var/mob/living/carbon/human/H = src
 		if(H.touching.reagent_list.len) //Just the first one otherwise I'll go insane.
 			var/datum/reagent/R = H.touching.reagent_list[1]
 			taste_message += " You also get the flavor of [R.taste_description] from something on them"
-
-	src.visible_message("<span class='warning'>[src] licks [tasted]!</span>","<span class='notice'>You lick [tasted]. They taste rather like [taste_message].</span>","<b>Slurp!</b>")
-
+	return taste_message
 //
 // OOC Escape code for pref-breaking or AFK preds
 //
@@ -396,17 +402,8 @@
 	user.update_icons()
 
 	// Flavor handling
-	var/flavor_message = ""
-	if(belly_target.can_taste && prey.vore_taste && (prey.vore_taste != ""))
-		flavor_message += "[prey.vore_taste]."
-	if(ishuman(prey))
-		var/mob/living/carbon/human/H = prey
-		if(H.touching.reagent_list.len) //Just the first one otherwise I'll go insane.
-			var/datum/reagent/R = H.touching.reagent_list[1]
-			flavor_message += " You also get the flavor of [R.taste_description] from something on them"
-
-	if(flavor_message != "")
-		src << "<span class='notice'>[prey] tastes of [flavor_message].</span>"
+	if(prey.get_taste_message(0))
+		to_chat(src, "<span class='notice'>[prey] tastes of [prey.get_taste_message(0)].</span>")
 
 	// Inform Admins
 	if (pred == user)

--- a/code/modules/vore/eating/vorepanel_vr.dm
+++ b/code/modules/vore/eating/vorepanel_vr.dm
@@ -367,12 +367,8 @@
 					else
 						var/datum/belly/B = user.vore_organs[choice]
 						for(var/atom/movable/tgt in selected.internal_contents)
-							if (!(tgt in selected.internal_contents))
-								continue
-							selected.internal_contents -= tgt
-							B.internal_contents += tgt
-
 							tgt << "<span class='warning'>You're squished from [user]'s [selected] to their [B]!</span>"
+							selected.transfer_contents(tgt, B, 1)
 
 						for(var/mob/hearer in range(1,user))
 							hearer << sound('sound/vore/squish2.ogg',volume=80)
@@ -407,12 +403,9 @@
 					var/datum/belly/B = user.vore_organs[choice]
 					if (!(tgt in selected.internal_contents))
 						return 0
-					selected.internal_contents -= tgt
-					B.internal_contents += tgt
-
 					tgt << "<span class='warning'>You're squished from [user]'s [lowertext(selected.name)] to their [lowertext(B.name)]!</span>"
-					for(var/mob/hearer in range(1,user))
-						hearer << sound('sound/vore/squish2.ogg',volume=80)
+					selected.transfer_contents(tgt, B)
+
 
 	if(href_list["newbelly"])
 		if(user.vore_organs.len >= BELLIES_MAX)


### PR DESCRIPTION
Minor copypaste removal, adds a proc for moving objects for one belly to another, and one for getting the taste message of a mob.
The only differences visible in-game are that prey moved into a different belly are shown the belly's flavor text, and if the prey has a set taste and the belly is set to be able to taste, that is shown to the pred. 