### PR TITLE
Allows PAI's to properly eat people [WIP]

### DIFF
--- a/code/modules/mob/living/silicon/pai/life.dm
+++ b/code/modules/mob/living/silicon/pai/life.dm
@@ -24,6 +24,7 @@
 			src << "<font color=green>Communication circuit reinitialized. Speech and messaging functionality restored.</font>"
 
 	handle_statuses()
+	handle_internal_contents() //VOREStation edit
 
 	if(health <= 0)
 		death(null,"gives one shrill beep before falling lifeless.")

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -283,6 +283,7 @@
 
 	var/turf/T = get_turf(src)
 	if(istype(T)) T.visible_message("<b>[src]</b> folds outwards, expanding into a mobile form.")
+	verbs += /mob/living/silicon/pai/proc/pai_nom //VOREStation edit
 
 /mob/living/silicon/pai/verb/fold_up()
 	set category = "pAI Commands"
@@ -372,6 +373,10 @@
 	if(src.loc == card)
 		return
 
+	for(var/I in vore_organs) //VOREStation edit. Release all their stomach contents. Don't want them to be in the PAI when they fold or weird things might happen.
+		var/datum/belly/B = vore_organs[I] //VOREStation edit
+		B.release_all_contents() //VOREStation edit
+
 	var/turf/T = get_turf(src)
 	if(istype(T)) T.visible_message("<b>[src]</b> neatly folds inwards, compacting down to a rectangular card.")
 
@@ -399,6 +404,7 @@
 	canmove = 1
 	resting = 0
 	icon_state = "[chassis]"
+	verbs -= /mob/living/silicon/pai/proc/pai_nom //VOREStation edit. Let's remove their nom verb.
 
 // No binary for pAIs.
 /mob/living/silicon/pai/binarycheck()

--- a/code/modules/mob/living/silicon/pai/pai_vr.dm
+++ b/code/modules/mob/living/silicon/pai/pai_vr.dm
@@ -1,0 +1,8 @@
+/mob/living/silicon/pai/proc/pai_nom(var/mob/living/T in oview(1))
+	set name = "pAI Nom"
+	set category = "pAI Commands"
+	set desc = "Allows you to eat someone while unfolded. Can't be used while in card form."
+    
+	if (stat != CONSCIOUS)
+		return
+	return feed_grabbed_to_self(src,T)

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -1842,6 +1842,7 @@
 #include "code\modules\mob\living\silicon\pai\examine.dm"
 #include "code\modules\mob\living\silicon\pai\life.dm"
 #include "code\modules\mob\living\silicon\pai\pai.dm"
+#include "code\modules\mob\living\silicon\pai\pai_vr.dm"
 #include "code\modules\mob\living\silicon\pai\personality.dm"
 #include "code\modules\mob\living\silicon\pai\recruit.dm"
 #include "code\modules\mob\living\silicon\pai\say.dm"


### PR DESCRIPTION
- Makes pAIs stomach correctly process people in them.
- Gives pAIs a verb that allows them to eat people while in mobile form. While doing testing, it stayed while they were in card form but had no functionality unless they were in mobile form.
- Makes pAIs spit everything out of their stomach if they exit mobile form/die.

Previously, the only way for a pAI to eat someone was with teleportation/translocators. Even then, the stomach didn't properly digest/absorb them. This makes it so they can properly eat people and, that when the people are in them, they can be digested/absorbed/etc like normal.

DNM. Working on this still.