### PR TITLE
Fixes Otie stuff and adds light replacer for trashdog.

### DIFF
--- a/code/modules/mob/living/silicon/robot/dogborg/dog_modules_vr.dm
+++ b/code/modules/mob/living/silicon/robot/dogborg/dog_modules_vr.dm
@@ -310,3 +310,30 @@
 	hitsound = 'sound/weapons/blade1.ogg'
 	attack_verb = list("slashed", "stabbed", "jabbed", "mauled", "sliced")
 	w_class = ITEMSIZE_NORMAL
+
+/obj/item/device/lightreplacer/dogborg
+	name = "light replacer"
+	desc = "A device to automatically replace lights. This version is capable to produce a few replacements using your internal matter reserves."
+	max_uses = 16
+	var/cooldown = 0
+
+/obj/item/device/lightreplacer/dogborg/attack_self(mob/user)//Boo recharger fill is slow as shit and removes all the extra cyberfat gains you worked so hard for!
+	if(uses >= max_uses)
+		user << "<span class='warning'>[src.name] is full.</span>"
+		return
+	if(uses < max_uses && cooldown == 0)
+		var/mob/living/silicon/robot.R = user
+		if(R.cell.charge <= 800)
+			user << "<span class='warning'>Insufficient power reserves. Please recharge.</span>"
+			return
+		usr << "It has [uses] lights remaining. Attempting to fabricate a replacement. Please stand still."
+		cooldown = 1
+		if(do_after(user, 50))
+			R.cell.charge = R.cell.charge - 400
+			AddUses(1)
+			cooldown = 0
+		else
+			cooldown = 0
+	else
+		usr << "It has [uses] lights remaining."
+		return

--- a/code/modules/mob/living/silicon/robot/dogborg/dog_sleeper_vr.dm
+++ b/code/modules/mob/living/silicon/robot/dogborg/dog_sleeper_vr.dm
@@ -514,11 +514,12 @@
 		return
 	return
 
-/mob/living/silicon/robot/attackby(obj/item/target as obj, mob/user as mob)
+/mob/living/silicon/robot/attackby(obj/item/W as obj, mob/user as mob)
 	if(module_active && istype(module_active,/obj/item/device/dogborg/sleeper/compactor)) //Feeding?
-		if(user.a_intent == I_HELP)
-			var/obj/item/device/dogborg/sleeper/compactor = src.module_active
-			compactor.afterattack(target)
+		if(src == user)
 			return
-		return
-	..()
+		if(user.a_intent == I_HELP)
+			var/obj/item/device/dogborg/sleeper/compactor/CR = module_active
+			user << "You attempt to feed [W] to [src]."
+			W.attackby(CR,src)
+			return ..()

--- a/code/modules/mob/living/silicon/robot/robot_modules_vr.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules_vr.dm
@@ -118,7 +118,7 @@
 	can_be_pushed = 0
 
 /obj/item/weapon/robot_module/scrubpup/New(var/mob/living/silicon/robot/R)
-	src.modules += new /obj/item/device/lightreplacer(src)
+	src.modules += new /obj/item/device/lightreplacer/dogborg(src)
 	src.modules += new /obj/item/weapon/dogborg/jaws/small(src)
 	src.modules += new /obj/item/device/dogborg/boop_module(src)
 	src.modules += new /obj/item/device/dogborg/tongue(src)

--- a/code/modules/mob/living/simple_animal/vore/otie.dm
+++ b/code/modules/mob/living/simple_animal/vore/otie.dm
@@ -8,8 +8,8 @@
 	icon_rest = "otie_rest"
 	faction = "otie"
 	recruitable = 1
-	maxHealth = 100
-	health = 100
+	maxHealth = 150
+	health = 150
 	minbodytemp = 200
 	move_to_delay = 4
 	hostile = 1
@@ -85,8 +85,8 @@
 	icon_dead = "sotie-dead"
 	faction = "neutral"
 	tamed = 1
-	maxHealth = 150 //armored or something
-	health = 150
+	maxHealth = 200 //armored or something
+	health = 200
 	loot_list = list(/obj/item/clothing/glasses/sunglasses/sechud,/obj/item/clothing/suit/armor/vest/alt)
 
 	var/check_records = 1 // If true, arrests people without a record.
@@ -108,6 +108,8 @@
 		var/mob/found_mob = found_atom
 		if(found_mob.faction == faction)
 			return null
+		else
+			return found_atom
 	else if(friend == found_atom)
 		return null
 	else if(tamed == 1 && ishuman(found_atom))
@@ -130,6 +132,8 @@
 		var/mob/found_mob = found_atom
 		if(found_mob.faction == faction)
 			return null
+		else
+			return found_atom
 	else if(friend == found_atom)
 		return null
 	else if(tamed == 1 && ishuman(found_atom))
@@ -224,6 +228,24 @@
 
 /mob/living/simple_animal/otie/attack_hand(mob/living/carbon/human/M as mob)
 	..()
+	if(M.a_intent == I_GRAB)
+		if (M == src)
+			return
+		if (!(status_flags & CANPUSH))
+			return
+		if(!incapacitated(INCAPACITATION_ALL) && (stance != STANCE_IDLE) && prob(grab_resist))
+			M.visible_message("<span class='warning'>[M] tries to grab [src] but fails!</span>")
+			return
+		var/obj/item/weapon/grab/G = new /obj/item/weapon/grab(M, src)
+		M.put_in_active_hand(G)
+		G.synch()
+		G.affecting = src
+		LAssailant = M
+		M.visible_message("<span class='warning'>[M] has grabbed [src] passively!</span>")
+		M.do_attack_animation(src)
+		ai_log("attack_hand() I was grabbed by: [M]",2)
+		pixel_x = -16
+		react_to_attack(M)
 	if(M.a_intent == I_HELP)
 		if (health > 0)
 			LoseTarget()
@@ -242,6 +264,6 @@
 /mob/living/simple_animal/otie
 	vore_active = 1
 	vore_capacity = 1
-	vore_escape_chance = 8
-	vore_pounce_chance = 16
+	vore_escape_chance = 15
+	vore_pounce_chance = 20
 	vore_icons = SA_ICON_LIVING

--- a/code/modules/mob/living/simple_animal/vore/otie.dm
+++ b/code/modules/mob/living/simple_animal/vore/otie.dm
@@ -29,7 +29,7 @@
 	say_got_target = list("Rurrr!", "ROAR!", "MARR!", "RAHH!", "Slurp.. RAH!")
 	say_got_target = list("Rurrr!", "ROAR!", "RERR!", "NOM!", "MINE!", "RAHH!", "RAH!", "WARF!")
 	melee_damage_lower = 5
-	melee_damage_upper = 20
+	melee_damage_upper = 15 //Don't break my bones bro
 	response_help = "pets the"
 	response_disarm = "bops the"
 	response_harm = "hits the"

--- a/code/modules/mob/living/simple_animal/vore/otie.dm
+++ b/code/modules/mob/living/simple_animal/vore/otie.dm
@@ -246,7 +246,7 @@
 		M.visible_message("<span class='warning'>[M] has grabbed [src] passively!</span>")
 		M.do_attack_animation(src)
 		ai_log("attack_hand() I was grabbed by: [M]",2)
-		pixel_x = -16
+		pixel_x = old_x
 		react_to_attack(M)
 	if(M.a_intent == I_HELP)
 		if (health > 0)

--- a/code/modules/mob/living/simple_animal/vore/otie.dm
+++ b/code/modules/mob/living/simple_animal/vore/otie.dm
@@ -108,16 +108,16 @@
 		var/mob/found_mob = found_atom
 		if(found_mob.faction == faction)
 			return null
+		else if(friend == found_atom)
+			return null
+		else if(tamed == 1 && ishuman(found_atom))
+			return null
+		else if(tamed == 1 && isrobot(found_atom))
+			return null
 		else
 			return found_atom
-	else if(friend == found_atom)
-		return null
-	else if(tamed == 1 && ishuman(found_atom))
-		return null
-	else if(tamed == 1 && isrobot(found_atom))
-		return null
 	else
-		return found_atom
+		return null
 
 /mob/living/simple_animal/otie/friendly/security/Found(var/atom/found_atom)
 	if(!SA_attackable(found_atom))
@@ -132,16 +132,16 @@
 		var/mob/found_mob = found_atom
 		if(found_mob.faction == faction)
 			return null
+		else if(friend == found_atom)
+			return null
+		else if(tamed == 1 && ishuman(found_atom))
+			return null
+		else if(tamed == 1 && isrobot(found_atom))
+			return null
 		else
 			return found_atom
-	else if(friend == found_atom)
-		return null
-	else if(tamed == 1 && ishuman(found_atom))
-		return null
-	else if(tamed == 1 && isrobot(found_atom))
-		return null
 	else
-		return found_atom
+		return null
 
 /mob/living/simple_animal/otie/friendly/security/proc/check_threat(var/mob/living/M)
 	if(!M || !ishuman(M) || M.stat == DEAD || src == M)

--- a/code/modules/mob/living/simple_animal/vore/otie.dm
+++ b/code/modules/mob/living/simple_animal/vore/otie.dm
@@ -108,7 +108,7 @@
 		var/mob/found_mob = found_atom
 		if(found_mob.faction == faction)
 			return null
-	else if (friend == found_atom)
+	else if(friend == found_atom)
 		return null
 	else if(tamed == 1 && ishuman(found_atom))
 		return null
@@ -130,7 +130,7 @@
 		var/mob/found_mob = found_atom
 		if(found_mob.faction == faction)
 			return null
-	else if (friend == found_atom)
+	else if(friend == found_atom)
 		return null
 	else if(tamed == 1 && ishuman(found_atom))
 		return null
@@ -205,7 +205,9 @@
 								   "rubs against [friend].",
 								   "noses softly at [friend].",
 								   "slobberlicks [friend].",
-								   "murrs."))
+								   "murrs.",
+								   "leans on [friend].",
+								   "nibbles affectionately on [friend]."))
 	else if (friend.health <= 50)
 		if (prob(10))
 			var/verb = pick("whines", "yelps", "whimpers")

--- a/code/modules/mob/living/simple_animal/vore/otie.dm
+++ b/code/modules/mob/living/simple_animal/vore/otie.dm
@@ -53,6 +53,8 @@
 	icon_dead = "siftusian-dead"
 	icon_rest = "siftusian_rest"
 	tame_chance = 5 // Only a 1 in 20 chance of success. It's feral. What do you expect?
+	melee_damage_lower = 10
+	melee_damage_upper = 25
 	// Lazy way of making sure this otie survives outside.
 	min_oxy = 0.5
 	max_oxy = 0


### PR DESCRIPTION
Got reports of unaggressive ferals.
Checked the code for anything suspicious.
-Also added a couple of the new friendlyactions to the automated mob part.
-Nerfed otie attack damage to reduce the chance of guaranteed one-hit fractures against squishy nerds.
-Buffed otie health a little after seeing how fast a harmbaton took down the armored version yesterday.
-Sightly increased escape chance and pounce chance for oties.
-Figured out a more likely cause for the passive oties. (code had it stop looking after checking target mob's faction.)
-Moved the rest of the meaningful target checks under the ismob check.
-New attempt at trashborgo feeding.(same testing chances as with the previous attempt lmao so no guarantees here either.)
-Added a pixel offset reset to otie grabs.
-Added a new light replacer type for trashborgo.
--Half capacity, able to fabricate replacement bulbs with charge cost.
--Mostly because normal charger refill is slow as shit and removes all the cyberfat gains you worked so hard for!