### PR TITLE
Adds a new neutral metabolism trait.

### DIFF
--- a/code/datums/supplypacks/security_vr.dm
+++ b/code/datums/supplypacks/security_vr.dm
@@ -1,0 +1,8 @@
+/datum/supply_packs/security/guardbeast
+	name = "V.A.R.M.A.corp autoNOMous security solution"
+	cost = 199
+	containertype = /obj/structure/largecrate/animal/guardbeast
+	containername = "V.A.R.M.A.corp autoNOMous security solution crate"
+	access = list(
+			access_security,
+			access_xenobiology)

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
@@ -3,18 +3,21 @@
 	desc = "You process ingested and injected reagents faster, but get hungry faster."
 	cost = 0
 	var_changes = list("metabolic_rate" = 1.2)
+	excludes = list(/datum/trait/metabolism_down, /datum/trait/metabolism_apex)
 
 /datum/trait/metabolism_down
 	name = "Slow Metabolism"
 	desc = "You process ingested and injected reagents slower, but get hungry slower."
 	cost = 0
 	var_changes = list("metabolic_rate" = 0.8)
+	excludes = list(/datum/trait/metabolism_up, /datum/trait/metabolism_apex)
 
 /datum/trait/metabolism_apex
 	name = "Apex Metabolism"
 	desc = "Finally a proper excuse for your predatory actions. Also makes you process reagents faster but that's totally irrelevant. May cause excessive immersions with large/taur characters. Not recommended for efficient law-abiding workers or eco-aware NIF users."
 	cost = 0
 	var_changes = list("metabolic_rate" = 2)
+	excludes = list(/datum/trait/metabolism_up, /datum/trait/metabolism_down)
 
 /datum/trait/vore_numbing
 	name = "Prey Numbing"

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
@@ -10,6 +10,12 @@
 	cost = 0
 	var_changes = list("metabolic_rate" = 0.8)
 
+/datum/trait/metabolism_predtier
+	name = "Pred-tier Metabolism"
+	desc = "Finally a proper excuse for your predatory actions. Also makes you process reagents faster but that's totally irrelevant. May cause excessive immersions with large/taur characters. Not recommended for efficient law-abiding workers or eco-aware NIF users."
+	cost = 0
+	var_changes = list("metabolic_rate" = 2)
+
 /datum/trait/vore_numbing
 	name = "Prey Numbing"
 	desc = "Adds a 'Digest (Numbing)' belly mode, to douse prey in numbing enzymes during digestion."


### PR DESCRIPTION
After consulting people who the hardly noticeable totally optional high-metabolism trait has made suffer, I've decided to add a new one instead for a noticeable arpee fluff one-uppance!
-It's double powerr!
-Gives pred characters an excuse to do their pred things.
-Aimed majorly for arpees as pred/macro/taur characters.
-Not recommended for efficient law-abiding workers or eco-aware NIF users.
-Saves exercise for Sportaflop!