### PR TITLE
Fixes simple mobs spamming observers with emotes

### DIFF
--- a/code/modules/mob/emote.dm
+++ b/code/modules/mob/emote.dm
@@ -38,7 +38,14 @@
 			var/mob/M = mob
 			spawn(0) // It's possible that it could be deleted in the meantime, or that it runtimes.
 				if(M)
-					M.show_message(message, m_type)
+					//VOREStation edit
+					if(istype(M, /mob/observer/dead/))
+						var/mob/observer/dead/D = M
+						if((ckey && D.is_preference_enabled(/datum/client_preference/ghost_sight)) || src in view(D))
+							M.show_message(message, m_type)
+					else
+						M.show_message(message, m_type)
+					//End VOREStation edit
 
 		for(var/obj in o_viewers)
 			var/obj/O = obj


### PR DESCRIPTION
Makes emotes viewing function the same as speech. Mobs without clients that aren't on screen won't spam observers. If they have a client and the observer has ghost sight they will see the emote. If the mob has a client and the observer doesn't have ghost sight they won't see the emote. If the mob is onscreen you will always see the emote.

Fixes #1848