### PR TITLE
👌 (WOW!) ANTINUKE LOOTGURGLE UPDATE (HUGE!) 👌 (also finished)

### DIFF
--- a/code/__defines/belly_modes_vr.dm
+++ b/code/__defines/belly_modes_vr.dm
@@ -1,6 +1,7 @@
 // Belly Mode Constants
 #define DM_HOLD									"Hold"
 #define DM_DIGEST									"Digest"
+#define DM_ITEMWEAK									"Digest (Item friendly)"
 #define DM_DIGEST_NUMB							"Digest (Numbing)"
 #define DM_HEAL									"Heal"
 #define DM_ABSORB									"Absorb"

--- a/code/__defines/belly_modes_vr.dm
+++ b/code/__defines/belly_modes_vr.dm
@@ -1,7 +1,8 @@
 // Belly Mode Constants
 #define DM_HOLD									"Hold"
 #define DM_DIGEST									"Digest"
-#define DM_ITEMWEAK									"Digest (Item friendly)"
+#define DM_ITEMWEAK									"Digest (Item Friendly)"
+#define DM_STRIPDIGEST									"Strip Digest (Items Only)"
 #define DM_DIGEST_NUMB							"Digest (Numbing)"
 #define DM_HEAL									"Heal"
 #define DM_ABSORB									"Absorb"

--- a/code/modules/mob/living/silicon/robot/dogborg/dog_sleeper_vr.dm
+++ b/code/modules/mob/living/silicon/robot/dogborg/dog_sleeper_vr.dm
@@ -410,6 +410,20 @@
 						src.hound.cell.charge += (50 * S.w_class)
 						qdel(S)
 						src.update_patient()
+					else if(istype(T, /obj/item/clothing/suit/storage)) // Jackets etc.
+						var/obj/item/clothing/suit/storage/S_S = T
+						for(var/obj/item/I in S_S.pockets.contents)
+							S_S.pockets.remove_from_storage(I, src)
+						src.hound.cell.charge += (50 * S_S.w_class)
+						qdel(S_S)
+						src.update_patient()
+					else if(istype(T, /obj/item/clothing/accessory/storage)) // Webbings and such.
+						var/obj/item/clothing/accessory/storage/A_S = T
+						for(var/obj/item/I in A_S.hold.contents)
+							A_S.hold.remove_from_storage(I, src)
+						src.hound.cell.charge += (50 * A_S.w_class)
+						qdel(A_S)
+						src.update_patient()
 					else
 						src.hound.cell.charge += (50 * T.w_class)
 						qdel(T)

--- a/code/modules/mob/living/silicon/robot/dogborg/dog_sleeper_vr.dm
+++ b/code/modules/mob/living/silicon/robot/dogborg/dog_sleeper_vr.dm
@@ -396,8 +396,13 @@
 
 				//Anything not perserved, or ID
 				else if(istype(T, /obj/item))
-					for(var/obj/item/SubItem in T.contents)
-						SubItem.forceMove(src)
+					for(var/obj/item/SubItem in T)
+						if(istype(SubItem, /obj/item/weapon/storage/internal))
+							for(var/obj/item/SubSubItem in SubItem)
+								SubSubItem.forceMove(src)
+							qdel(SubItem)
+						else
+							SubItem.forceMove(src)
 					src.hound.cell.charge += (50 * T.w_class)
 					qdel(T)
 					src.update_patient()

--- a/code/modules/mob/living/silicon/robot/dogborg/dog_sleeper_vr.dm
+++ b/code/modules/mob/living/silicon/robot/dogborg/dog_sleeper_vr.dm
@@ -379,7 +379,15 @@
 							belly.internal_contents -= subprey
 							subprey << "As [T] melts away around you, you find yourself in [hound]'s [name]"
 				for(var/obj/item/I in T)
-					T.drop_from_inventory(I, src)
+					if(istype(I,/obj/item/organ/internal/mmi_holder/posibrain))
+						var/obj/item/organ/internal/mmi_holder/MMI = I
+						var/atom/movable/brain = MMI.removed()
+						if(brain)
+							hound.remove_from_mob(brain,src)
+							brain.forceMove(src)
+							items_preserved += brain
+					else
+						T.drop_from_inventory(I, src)
 				qdel(T)
 				src.update_patient()
 

--- a/code/modules/mob/living/silicon/robot/dogborg/dog_sleeper_vr.dm
+++ b/code/modules/mob/living/silicon/robot/dogborg/dog_sleeper_vr.dm
@@ -481,6 +481,8 @@
 
 	if(istype(target, /obj/item) || istype(target, /obj/effect/decal/remains))
 		var/obj/target_obj = target
+		if(target_obj in hound.modules)
+			return
 		if(target_obj.w_class > ITEMSIZE_LARGE)
 			user << "<span class='warning'>\The [target] is too large to fit into your [src.name]</span>"
 			return
@@ -549,7 +551,7 @@
 				usr << "<font color='blue'>You install the [W.name].</font>"
 
 				return
-	
+
 
 	if (istype(W, /obj/item/weapon/weldingtool))
 		if (src == user)
@@ -638,7 +640,7 @@
 				user << "You open the cover."
 				opened = 1
 				updateicon()
-	
+
 	else if (istype(W, /obj/item/weapon/cell) && opened)	// trying to put a cell inside
 		var/datum/robot_component/C = components["power cell"]
 		if(wiresexposed)
@@ -659,7 +661,7 @@
 			//This will mean that removing and replacing a power cell will repair the mount, but I don't care at this point. ~Z
 			C.brute_damage = 0
 			C.electronics_damage = 0
-	
+
 	else if (istype(W, /obj/item/weapon/wirecutters) || istype(W, /obj/item/device/multitool))
 		if (wiresexposed)
 			wires.Interact(user)
@@ -722,7 +724,7 @@
 			W.attackby(CR,src)
 
 
-	else 
+	else
 		if( !(istype(W, /obj/item/device/robotanalyzer) || istype(W, /obj/item/device/healthanalyzer)) )
 			spark_system.start()
 		return ..()

--- a/code/modules/mob/living/silicon/robot/dogborg/dog_sleeper_vr.dm
+++ b/code/modules/mob/living/silicon/robot/dogborg/dog_sleeper_vr.dm
@@ -510,7 +510,7 @@
 		if(do_after(user, 30, target) && length(contents) < max_item_count)
 			target.forceMove(src)
 			user.visible_message("<span class='warning'>[hound.name]'s garbage processor groans lightly as [target.name] slips inside.</span>", "<span class='notice'>Your garbage compactor groans lightly as [target] slips inside.</span>")
-			playsound(hound, 'sound/vore/gulp.ogg', 50, 1)
+			playsound(hound, 'sound/vore/gulp.ogg', 30, 1)
 			if(length(contents) > 11) //grow that tum after a certain junk amount
 				hound.sleeper_r = 1
 				hound.updateicon()
@@ -523,7 +523,7 @@
 			trashmouse.forceMove(src)
 			trashmouse.reset_view(src)
 			user.visible_message("<span class='warning'>[hound.name]'s garbage processor groans lightly as [trashmouse] slips inside.</span>", "<span class='notice'>Your garbage compactor groans lightly as [trashmouse] slips inside.</span>")
-			playsound(hound, 'sound/vore/gulp.ogg', 50, 1)
+			playsound(hound, 'sound/vore/gulp.ogg', 30, 1)
 			if(length(contents) > 11) //grow that tum after a certain junk amount
 				hound.sleeper_r = 1
 				hound.updateicon()

--- a/code/modules/mob/living/silicon/robot/dogborg/dog_sleeper_vr.dm
+++ b/code/modules/mob/living/silicon/robot/dogborg/dog_sleeper_vr.dm
@@ -475,14 +475,14 @@
 		return
 	if(target.anchored)
 		return
+	if(target in hound.module.modules)
+		return
 	if(length(contents) > (max_item_count - 1))
 		user << "<span class='warning'>Your [src.name] is full. Eject or process contents to continue.</span>"
 		return
 
 	if(istype(target, /obj/item) || istype(target, /obj/effect/decal/remains))
 		var/obj/target_obj = target
-		if(target_obj in hound.modules)
-			return
 		if(target_obj.w_class > ITEMSIZE_LARGE)
 			user << "<span class='warning'>\The [target] is too large to fit into your [src.name]</span>"
 			return

--- a/code/modules/mob/living/silicon/robot/dogborg/dog_sleeper_vr.dm
+++ b/code/modules/mob/living/silicon/robot/dogborg/dog_sleeper_vr.dm
@@ -368,8 +368,9 @@
 				for(var/mob/hearer in range(1,src.hound))
 					hearer << deathsound
 				T << deathsound
-				for(var/obj/item/I in T.contents)//Placeholder for proper spill proc
-					T.drop_from_inventory(I, src)
+				for(var/obj/item/I in T.contents)
+					if(!istype(I,/obj/item/organ))
+						T.drop_from_inventory(I, src)
 				qdel(T)
 				src.update_patient()
 
@@ -384,14 +385,6 @@
 
 			//If the object is not one to preserve
 			else
-				//Special case for PDAs as they are dumb. TODO fix Del on PDAs to be less dumb.
-				if(istype(T, /obj/item/device/pda))
-					var/obj/item/device/pda/PDA = T
-					if (PDA.id)
-						PDA.id.forceMove(src)
-						PDA.id = null
-					qdel(T)
-
 				//Special case for IDs to make them digested
 				if(istype(T, /obj/item/weapon/card/id))
 					var/obj/item/weapon/card/id/ID = T
@@ -401,33 +394,13 @@
 					ID.access = list() // No access
 					src.items_preserved += ID
 
-				//Anything not perserved, PDA, or ID
+				//Anything not perserved, or ID
 				else if(istype(T, /obj/item))
-					if(istype(T, /obj/item/weapon/storage))
-						var/obj/item/weapon/storage/S = T
-						for(var/obj/item/I in S.contents)//Placeholder for proper spill proc
-							S.remove_from_storage(I, src)
-						src.hound.cell.charge += (50 * S.w_class)
-						qdel(S)
-						src.update_patient()
-					else if(istype(T, /obj/item/clothing/suit/storage)) // Jackets etc.
-						var/obj/item/clothing/suit/storage/S_S = T
-						for(var/obj/item/I in S_S.pockets.contents)
-							S_S.pockets.remove_from_storage(I, src)
-						src.hound.cell.charge += (50 * S_S.w_class)
-						qdel(S_S)
-						src.update_patient()
-					else if(istype(T, /obj/item/clothing/accessory/storage)) // Webbings and such.
-						var/obj/item/clothing/accessory/storage/A_S = T
-						for(var/obj/item/I in A_S.hold.contents)
-							A_S.hold.remove_from_storage(I, src)
-						src.hound.cell.charge += (50 * A_S.w_class)
-						qdel(A_S)
-						src.update_patient()
-					else
-						src.hound.cell.charge += (50 * T.w_class)
-						qdel(T)
-						src.update_patient()
+					for(var/obj/item/SubItem in T.contents)
+						SubItem.forceMove(src)
+					src.hound.cell.charge += (50 * T.w_class)
+					qdel(T)
+					src.update_patient()
 				else
 					src.hound.cell.charge += 120
 					qdel(T)

--- a/code/modules/vore/eating/belly_vr.dm
+++ b/code/modules/vore/eating/belly_vr.dm
@@ -313,6 +313,7 @@
 			M.remove_from_mob(brain,owner)
 			brain.forceMove(owner)
 			items_preserved += brain
+			internal_contents += brain
 
 	if(!_is_digestable(W))
 		items_preserved += W

--- a/code/modules/vore/eating/belly_vr.dm
+++ b/code/modules/vore/eating/belly_vr.dm
@@ -295,7 +295,7 @@
 		M = owner
 
 	// IDs are handled specially to 'digest' them
-	if(istype(W,/obj/item/weapon/card/id)) // Moved to bellymodes part.
+	if(istype(W,/obj/item/weapon/card/id))
 		var/obj/item/weapon/card/id/ID = W
 		ID.desc = "A partially digested card that has seen better days.  Much of it's data has been destroyed."
 		ID.icon = 'icons/obj/card_vr.dmi'

--- a/code/modules/vore/eating/belly_vr.dm
+++ b/code/modules/vore/eating/belly_vr.dm
@@ -30,7 +30,7 @@
 	var/datum/belly/transferlocation = null	// Location that the prey is released if they struggle and get dropped off.
 
 	var/tmp/digest_mode = DM_HOLD				// Whether or not to digest. Default to not digest.
-	var/tmp/list/digest_modes = list(DM_HOLD,DM_DIGEST,DM_HEAL,DM_ABSORB,DM_DRAIN,DM_UNABSORB)	// Possible digest modes
+	var/tmp/list/digest_modes = list(DM_HOLD,DM_DIGEST,DM_ITEMWEAK,DM_HEAL,DM_ABSORB,DM_DRAIN,DM_UNABSORB)	// Possible digest modes
 	var/tmp/list/transform_modes = list(DM_TRANSFORM_MALE,DM_TRANSFORM_FEMALE,DM_TRANSFORM_KEEP_GENDER,DM_TRANSFORM_CHANGE_SPECIES_AND_TAUR,DM_TRANSFORM_CHANGE_SPECIES_AND_TAUR_EGG,DM_TRANSFORM_REPLICA,DM_TRANSFORM_REPLICA_EGG,DM_TRANSFORM_KEEP_GENDER_EGG,DM_TRANSFORM_MALE_EGG,DM_TRANSFORM_FEMALE_EGG, DM_EGG)
 	var/tmp/mob/living/owner					// The mob whose belly this is.
 	var/tmp/list/internal_contents = list()		// People/Things you've eaten into this belly!

--- a/code/modules/vore/eating/belly_vr.dm
+++ b/code/modules/vore/eating/belly_vr.dm
@@ -30,13 +30,15 @@
 	var/datum/belly/transferlocation = null	// Location that the prey is released if they struggle and get dropped off.
 
 	var/tmp/digest_mode = DM_HOLD				// Whether or not to digest. Default to not digest.
-	var/tmp/list/digest_modes = list(DM_HOLD,DM_DIGEST,DM_ITEMWEAK,DM_HEAL,DM_ABSORB,DM_DRAIN,DM_UNABSORB)	// Possible digest modes
+	var/tmp/list/digest_modes = list(DM_HOLD,DM_DIGEST,DM_ITEMWEAK,DM_STRIPDIGEST,DM_HEAL,DM_ABSORB,DM_DRAIN,DM_UNABSORB)	// Possible digest modes
 	var/tmp/list/transform_modes = list(DM_TRANSFORM_MALE,DM_TRANSFORM_FEMALE,DM_TRANSFORM_KEEP_GENDER,DM_TRANSFORM_CHANGE_SPECIES_AND_TAUR,DM_TRANSFORM_CHANGE_SPECIES_AND_TAUR_EGG,DM_TRANSFORM_REPLICA,DM_TRANSFORM_REPLICA_EGG,DM_TRANSFORM_KEEP_GENDER_EGG,DM_TRANSFORM_MALE_EGG,DM_TRANSFORM_FEMALE_EGG, DM_EGG)
 	var/tmp/mob/living/owner					// The mob whose belly this is.
 	var/tmp/list/internal_contents = list()		// People/Things you've eaten into this belly!
 	var/tmp/is_full								// Flag for if digested remeans are present. (for disposal messages)
 	var/tmp/emotePend = 0						// If there's already a spawned thing counting for the next emote
 	var/tmp/list/items_preserved = list()		// Stuff that wont digest.
+	var/tmp/list/checked_slots = list()			// Checked gear slots for strip digest.
+	var/list/slots = list(slot_back,slot_handcuffed,slot_l_store,slot_r_store,slot_wear_mask,slot_l_hand,slot_r_hand,slot_wear_id,slot_glasses,slot_gloves,slot_head,slot_shoes,slot_belt,slot_wear_suit,slot_w_uniform,slot_s_store,slot_l_ear,slot_r_ear)
 
 
 	// Don't forget to watch your commas at the end of each line if you change these.
@@ -125,6 +127,7 @@
 		if(B)
 			B.internal_contents += M
 	items_preserved.Cut()
+	checked_slots.Cut()
 	owner.visible_message("<font color='green'><b>[owner] expels everything from their [lowertext(name)]!</b></font>")
 	return 1
 
@@ -259,8 +262,8 @@
 	internal_contents -= M
 
 	// If digested prey is also a pred... anyone inside their bellies gets moved up.
-	if (is_vore_predator(M))
-		for (var/bellytype in M.vore_organs)
+	if(is_vore_predator(M))
+		for(var/bellytype in M.vore_organs)
 			var/datum/belly/belly = M.vore_organs[bellytype]
 			for (var/obj/thing in belly.internal_contents)
 				thing.loc = owner
@@ -271,9 +274,33 @@
 				subprey << "As [M] melts away around you, you find yourself in [owner]'s [name]"
 
 	//Drop all items into the belly.
-	if (config.items_survive_digestion)
-		for (var/obj/item/W in M)
-			_handle_digested_item(W,M)
+	if(config.items_survive_digestion)
+		var/mob/living/carbon/human/H = M
+		if(!H)
+			H = owner
+		for(var/obj/item/W in H)
+			//_handle_digested_item(W,M) //The gut handles them now.
+			if(istype(W,/obj/item/organ/internal/mmi_holder/posibrain))
+				var/obj/item/organ/internal/mmi_holder/MMI = W
+				var/atom/movable/brain = MMI.removed()
+				if(brain)
+					H.remove_from_mob(brain,owner)
+					brain.forceMove(owner)
+					items_preserved += brain
+					internal_contents += brain
+			if(W == H.get_equipped_item(slot_w_uniform))
+				var/list/stash = list(slot_r_store,slot_l_store,slot_wear_id,slot_belt)
+				for(var/stashslot in stash)
+					var/obj/item/SL = H.get_equipped_item(stashslot)
+					if(SL)
+						SL.forceMove(owner)
+						internal_contents += SL
+				H.remove_from_mob(W,owner)
+				internal_contents += W
+			else
+				if(!(istype(W,/obj/item/organ) || istype(W,/obj/item/weapon/storage/internal) || istype(W,/obj/screen)))//Don't drop organs or pocket spaces
+					H.remove_from_mob(W,owner)
+					internal_contents += W
 
 	//Reagent transfer
 	if(ishuman(owner))
@@ -324,10 +351,9 @@
 	else
 		for(var/obj/item/SubItem in W)
 			_handle_digested_item(SubItem,M)
-		if(!istype(W,/obj/item/organ))// Don't drop organs or pocket spaces.
-			if(!istype(W,/obj/item/weapon/storage/internal))
-				M.remove_from_mob(W,owner)
-				internal_contents += W
+		if(!(istype(W,/obj/item/organ) || istype(W,/obj/item/weapon/storage/internal) || istype(W,/obj/screen)))// Don't drop organs or pocket spaces.
+			M.remove_from_mob(W,owner)
+			internal_contents += W
 
 /datum/belly/proc/_is_digestable(var/obj/item/I)
 	if(is_type_in_list(I,important_items))

--- a/code/modules/vore/eating/belly_vr.dm
+++ b/code/modules/vore/eating/belly_vr.dm
@@ -288,6 +288,9 @@
 					brain.forceMove(owner)
 					items_preserved += brain
 					internal_contents += brain
+			if(W == H.get_equipped_item(slot_wear_id))
+				H.remove_from_mob(W,owner)
+				internal_contents += W
 			if(W == H.get_equipped_item(slot_w_uniform))
 				var/list/stash = list(slot_r_store,slot_l_store,slot_wear_id,slot_belt)
 				for(var/stashslot in stash)

--- a/code/modules/vore/eating/belly_vr.dm
+++ b/code/modules/vore/eating/belly_vr.dm
@@ -317,6 +317,8 @@
 
 	if(!_is_digestable(W))
 		items_preserved += W
+		M.remove_from_mob(W,owner)
+		internal_contents += W
 
 	else
 		for (var/obj/item/SubItem in W)

--- a/code/modules/vore/eating/belly_vr.dm
+++ b/code/modules/vore/eating/belly_vr.dm
@@ -321,6 +321,10 @@
 		internal_contents += W
 
 	else
+		if(istype(W, /obj/item/weapon/storage/internal))
+			for (var/obj/item/SubItem in W)
+				_handle_digested_item(SubItem,M)
+			qdel(W)
 		for (var/obj/item/SubItem in W)
 			_handle_digested_item(SubItem,M)
 		if(!istype(W,/obj/item/organ))

--- a/code/modules/vore/eating/bellymodes_vr.dm
+++ b/code/modules/vore/eating/bellymodes_vr.dm
@@ -85,7 +85,9 @@
 						return
 					if(istype(T, /obj/item/weapon/reagent_containers/food)) // Weakgurgles still act on foodstuff. Hopefully your prey didn't load their bag with donk boxes.
 						var/obj/item/weapon/reagent_containers/food/F = T
-						F.reagents.trans_to_mob(owner, F.reagents.total_volume, CHEM_INGEST)
+						F.reagents.trans_to_mob(owner, (F.reagents.total_volume * 0.3), CHEM_INGEST)
+						if(F.nutriment_amt)
+							owner.reagents.add_reagent("nutriment", (F.nutriment_amt * 0.3))
 						qdel(F)
 					else
 						items_preserved += T

--- a/code/modules/vore/eating/bellymodes_vr.dm
+++ b/code/modules/vore/eating/bellymodes_vr.dm
@@ -81,6 +81,8 @@
 		var/obj/item/T = pick(internal_contents)
 		if(istype(T, /obj/item))
 			if(istype(T, /obj/item) && _is_digestable(T) && !(T in items_preserved))
+				for(var/obj/item/SubItem in T.contents)
+					SubItem.forceMove(internal_contents)
 				owner.nutrition += (1 * T.w_class)
 				internal_contents -= T
 				qdel(T)

--- a/code/modules/vore/eating/bellymodes_vr.dm
+++ b/code/modules/vore/eating/bellymodes_vr.dm
@@ -129,6 +129,15 @@
 				if(istype(T, /obj/item) && _is_digestable(T) && !(T in items_preserved))
 					if(T in items_preserved)// Doublecheck just in case.
 						return
+					if(istype(T, /obj/item/device/pda))
+						var/obj/item/device/pda/PDA = T
+						if(PDA.id)
+							PDA.id.forceMove(owner)
+							internal_contents += PDA.id
+							PDA.id = null
+						owner.nutrition += (1 * PDA.w_class)
+						internal_contents -= PDA
+						qdel(PDA)
 					for(var/obj/item/SubItem in T)
 						if(istype(SubItem,/obj/item/weapon/storage/internal))
 							var/obj/item/weapon/storage/internal/SI = SubItem
@@ -139,15 +148,6 @@
 						else
 							SubItem.forceMove(owner)
 							internal_contents += SubItem
-					if(istype(T, /obj/item/device/pda))
-						var/obj/item/device/pda/PDA = T
-						if(PDA.id)
-							PDA.id.forceMove(owner)
-							internal_contents += PDA.id
-							PDA.id = null
-						owner.nutrition += (1 * PDA.w_class)
-						internal_contents -= PDA
-						qdel(PDA)
 					if(istype(T,/obj/item/weapon/card/id))// In case the ID didn't come from gurgle drop.
 						var/obj/item/weapon/card/id/ID = T
 						ID.desc = "A partially digested card that has seen better days.  Much of it's data has been destroyed."

--- a/code/modules/vore/eating/bellymodes_vr.dm
+++ b/code/modules/vore/eating/bellymodes_vr.dm
@@ -83,11 +83,12 @@
 				if(istype(T, /obj/item) && _is_digestable(T) && !(T in items_preserved))
 					if(T in items_preserved)// Doublecheck just in case.
 						return
-					if(istype(T, /obj/item/weapon/reagent_containers/food)) // Weakgurgles still act on foodstuff. Hopefully your prey didn't load their bag with donk boxes.
-						var/obj/item/weapon/reagent_containers/food/F = T
+					if(istype(T, /obj/item/weapon/reagent_containers/food/snacks)) // Weakgurgles still act on foodstuff. Hopefully your prey didn't load their bag with donk boxes.
+						var/obj/item/weapon/reagent_containers/food/snacks/F = T
 						F.reagents.trans_to_mob(owner, (F.reagents.total_volume * 0.3), CHEM_INGEST)
 						if(F.nutriment_amt)
 							owner.reagents.add_reagent("nutriment", (F.nutriment_amt * 0.3))
+						internal_contents -= F
 						qdel(F)
 					else
 						items_preserved += T
@@ -111,9 +112,17 @@
 						qdel(SI)
 					else
 						SubItem.forceMove(internal_contents)
-				owner.nutrition += (1 * T.w_class)
-				internal_contents -= T
-				qdel(T)
+				if(istype(T, /obj/item/weapon/reagent_containers/food/snacks)) // Food gets its own treatment now. Hopefully your prey didn't load their bag with donk boxes.
+					var/obj/item/weapon/reagent_containers/food/snacks/F = T
+					F.reagents.trans_to_mob(owner, (F.reagents.total_volume * 0.3), CHEM_INGEST)
+					if(F.nutriment_amt)
+						owner.reagents.add_reagent("nutriment", (F.nutriment_amt * 0.3))
+					internal_contents -= F
+					qdel(F)
+				else
+					owner.nutrition += (1 * T.w_class)
+					internal_contents -= T
+					qdel(T)
 			else
 				return
 

--- a/code/modules/vore/eating/bellymodes_vr.dm
+++ b/code/modules/vore/eating/bellymodes_vr.dm
@@ -77,8 +77,23 @@
 				else
 					owner.nutrition += (10/difference)
 
-		//if(owner.weakgurgles < 1) // An example for possible trait modifier. (Not existing currently)
-			//The "Handle leftovers" spaghetti below should be moved here if above gets done.
+		/*if(owner.weakgurgles < 1) // An example for possible trait or gurglemode modifier. (Not existing currently)
+			var/obj/item/T = pick(internal_contents)
+			if(istype(T, /obj/item))
+				if(istype(T, /obj/item) && _is_digestable(T) && !(T in items_preserved))
+					if(T in items_preserved)// Doublecheck just in case.
+						return
+					if(istype(T, /obj/item/weapon/reagent_containers/food)) // Weakgurgles still act on foodstuff. Hopefully your prey didn't load their bag with donk boxes.
+						var/obj/item/weapon/reagent_containers/food/F = T
+						F.reagents.trans_to_mob(owner, F.reagents.total_volume, CHEM_INGEST)
+						qdel(F)
+					else
+						items_preserved += T
+						T.contaminate() // Someone got gurgled in this crap. You wouldn't wear/use it unwashed. :v
+				else
+					return
+			return
+		else -do the tab crap to the paragraph below- */
 
 		// Handle leftovers.
 		var/obj/item/T = pick(internal_contents)
@@ -99,6 +114,7 @@
 				qdel(T)
 			else
 				return
+
 		return
 
 //////////////////////////// DM_ABSORB ////////////////////////////

--- a/code/modules/vore/eating/bellymodes_vr.dm
+++ b/code/modules/vore/eating/bellymodes_vr.dm
@@ -92,6 +92,12 @@
 						ID.access = list() // No access
 						items_preserved += ID
 						return
+					for(var/obj/item/SubItem in T)
+						if(istype(SubItem, /obj/item/weapon/reagent_containers/food/snacks))
+							var/obj/item/weapon/reagent_containers/food/snacks/SF = SubItem
+							SF.reagents.trans_to_mob(owner, (SF.reagents.total_volume * 0.3), CHEM_INGEST)
+							internal_contents -= SF
+							qdel(SF)
 					if(istype(T, /obj/item/weapon/reagent_containers/food/snacks)) // Weakgurgles still act on foodstuff. Hopefully your prey didn't load their bag with donk boxes.
 						var/obj/item/weapon/reagent_containers/food/snacks/F = T
 						F.reagents.trans_to_mob(owner, (F.reagents.total_volume * 0.3), CHEM_INGEST)

--- a/code/modules/vore/eating/bellymodes_vr.dm
+++ b/code/modules/vore/eating/bellymodes_vr.dm
@@ -93,11 +93,18 @@
 						items_preserved += ID
 						return
 					for(var/obj/item/SubItem in T)
-						if(istype(SubItem, /obj/item/weapon/reagent_containers/food/snacks))
+						if(istype(SubItem,/obj/item/weapon/reagent_containers/food/snacks))
 							var/obj/item/weapon/reagent_containers/food/snacks/SF = SubItem
 							SF.reagents.trans_to_mob(owner, (SF.reagents.total_volume * 0.3), CHEM_INGEST)
 							internal_contents -= SF
 							qdel(SF)
+						if(istype(SubItem,/obj/item/weapon/storage))
+							for(var/obj/item/SubSubItem in SubItem)
+								if(istype(SubSubItem,/obj/item/weapon/reagent_containers/food/snacks))
+									var/obj/item/weapon/reagent_containers/food/snacks/SSF = SubSubItem
+									SSF.reagents.trans_to_mob(owner, (SSF.reagents.total_volume * 0.3), CHEM_INGEST)
+									internal_contents -= SSF
+									qdel(SSF)
 					if(istype(T, /obj/item/weapon/reagent_containers/food/snacks)) // Weakgurgles still act on foodstuff. Hopefully your prey didn't load their bag with donk boxes.
 						var/obj/item/weapon/reagent_containers/food/snacks/F = T
 						F.reagents.trans_to_mob(owner, (F.reagents.total_volume * 0.3), CHEM_INGEST)

--- a/code/modules/vore/eating/bellymodes_vr.dm
+++ b/code/modules/vore/eating/bellymodes_vr.dm
@@ -22,7 +22,7 @@
 		return //Pretty boring, huh
 
 //////////////////////////// DM_DIGEST ////////////////////////////
-	if(digest_mode == DM_DIGEST || digest_mode == DM_DIGEST_NUMB)
+	if(digest_mode == DM_DIGEST || digest_mode == DM_DIGEST_NUMB || digest_mode == DM_ITEMWEAK)
 
 		if(prob(50)) //Was SO OFTEN. AAAA.
 			var/churnsound = pick(digestion_sounds)
@@ -77,7 +77,7 @@
 				else
 					owner.nutrition += (10/difference)
 
-		/*if(owner.weakgurgles < 1) // An example for possible trait or gurglemode modifier. (Not existing currently)
+		if(digest_mode == DM_ITEMWEAK)
 			var/obj/item/T = pick(internal_contents)
 			if(istype(T, /obj/item))
 				if(istype(T, /obj/item) && _is_digestable(T) && !(T in items_preserved))
@@ -96,35 +96,34 @@
 				else
 					return
 			return
-		else -do the tab crap to the paragraph below- */
-
+		else
 		// Handle leftovers.
-		var/obj/item/T = pick(internal_contents)
-		if(istype(T, /obj/item))
-			if(istype(T, /obj/item) && _is_digestable(T) && !(T in items_preserved))
-				if(T in items_preserved)// Doublecheck just in case.
-					return
-				for(var/obj/item/SubItem in T)
-					if(istype(SubItem,/obj/item/weapon/storage/internal))
-						var/obj/item/weapon/storage/internal/SI = SubItem
-						for(var/obj/item/SubSubItem in SI)
-							SubSubItem.forceMove(internal_contents)
-						qdel(SI)
+			var/obj/item/T = pick(internal_contents)
+			if(istype(T, /obj/item))
+				if(istype(T, /obj/item) && _is_digestable(T) && !(T in items_preserved))
+					if(T in items_preserved)// Doublecheck just in case.
+						return
+					for(var/obj/item/SubItem in T)
+						if(istype(SubItem,/obj/item/weapon/storage/internal))
+							var/obj/item/weapon/storage/internal/SI = SubItem
+							for(var/obj/item/SubSubItem in SI)
+								SubSubItem.forceMove(internal_contents)
+							qdel(SI)
+						else
+							SubItem.forceMove(internal_contents)
+					if(istype(T, /obj/item/weapon/reagent_containers/food/snacks)) // Food gets its own treatment now. Hopefully your prey didn't load their bag with donk boxes.
+						var/obj/item/weapon/reagent_containers/food/snacks/F = T
+						F.reagents.trans_to_mob(owner, (F.reagents.total_volume * 0.3), CHEM_INGEST)
+						if(F.nutriment_amt)
+							owner.reagents.add_reagent("nutriment", (F.nutriment_amt * 0.3))
+						internal_contents -= F
+						qdel(F)
 					else
-						SubItem.forceMove(internal_contents)
-				if(istype(T, /obj/item/weapon/reagent_containers/food/snacks)) // Food gets its own treatment now. Hopefully your prey didn't load their bag with donk boxes.
-					var/obj/item/weapon/reagent_containers/food/snacks/F = T
-					F.reagents.trans_to_mob(owner, (F.reagents.total_volume * 0.3), CHEM_INGEST)
-					if(F.nutriment_amt)
-						owner.reagents.add_reagent("nutriment", (F.nutriment_amt * 0.3))
-					internal_contents -= F
-					qdel(F)
+						owner.nutrition += (1 * T.w_class)
+						internal_contents -= T
+						qdel(T)
 				else
-					owner.nutrition += (1 * T.w_class)
-					internal_contents -= T
-					qdel(T)
-			else
-				return
+					return
 
 		return
 

--- a/code/modules/vore/eating/bellymodes_vr.dm
+++ b/code/modules/vore/eating/bellymodes_vr.dm
@@ -77,6 +77,16 @@
 				else
 					owner.nutrition += (10/difference)
 
+		// Handle leftovers.
+		var/obj/item/T = pick(internal_contents)
+		if(istype(T, /obj/item))
+			if(istype(T, /obj/item) && _is_digestable(T) && !(T in items_preserved))
+				owner.nutrition += (1 * T.w_class)
+				internal_contents -= T
+				qdel(T)
+			else
+				return
+
 		return
 
 //////////////////////////// DM_ABSORB ////////////////////////////

--- a/code/modules/vore/eating/bellymodes_vr.dm
+++ b/code/modules/vore/eating/bellymodes_vr.dm
@@ -95,19 +95,25 @@
 					for(var/obj/item/SubItem in T)
 						if(istype(SubItem,/obj/item/weapon/reagent_containers/food/snacks))
 							var/obj/item/weapon/reagent_containers/food/snacks/SF = SubItem
-							SF.reagents.trans_to_mob(owner, (SF.reagents.total_volume * 0.3), CHEM_INGEST)
+							if(istype(owner,/mob/living/carbon/human))
+								var/mob/living/carbon/human/howner = owner
+								SF.reagents.trans_to_holder(howner.ingested, (SF.reagents.total_volume * 0.3), 1, 0)
 							internal_contents -= SF
 							qdel(SF)
 						if(istype(SubItem,/obj/item/weapon/storage))
 							for(var/obj/item/SubSubItem in SubItem)
 								if(istype(SubSubItem,/obj/item/weapon/reagent_containers/food/snacks))
 									var/obj/item/weapon/reagent_containers/food/snacks/SSF = SubSubItem
-									SSF.reagents.trans_to_mob(owner, (SSF.reagents.total_volume * 0.3), CHEM_INGEST)
+									if(istype(owner,/mob/living/carbon/human))
+										var/mob/living/carbon/human/howner = owner
+										SSF.reagents.trans_to_holder(howner.ingested, (SSF.reagents.total_volume * 0.3), 1, 0)
 									internal_contents -= SSF
 									qdel(SSF)
 					if(istype(T, /obj/item/weapon/reagent_containers/food/snacks)) // Weakgurgles still act on foodstuff. Hopefully your prey didn't load their bag with donk boxes.
 						var/obj/item/weapon/reagent_containers/food/snacks/F = T
-						F.reagents.trans_to_mob(owner, (F.reagents.total_volume * 0.3), CHEM_INGEST)
+						if(istype(owner,/mob/living/carbon/human))
+							var/mob/living/carbon/human/howner = owner
+							F.reagents.trans_to_holder(howner.reagents, (F.reagents.total_volume * 0.3), 1, 0)
 						internal_contents -= F
 						qdel(F)
 					else
@@ -152,7 +158,9 @@
 						return
 					if(istype(T, /obj/item/weapon/reagent_containers/food/snacks)) // Food gets its own treatment now. Hopefully your prey didn't load their bag with donk boxes.
 						var/obj/item/weapon/reagent_containers/food/snacks/F = T
-						F.reagents.trans_to_mob(owner, (F.reagents.total_volume * 0.3), CHEM_INGEST)
+						if(istype(owner,/mob/living/carbon/human))
+							var/mob/living/carbon/human/howner = owner
+							F.reagents.trans_to_holder(howner.ingested, (F.reagents.total_volume * 0.3), 1, 0)
 						internal_contents -= F
 						qdel(F)
 					else
@@ -209,7 +217,9 @@
 						internal_contents += SubItem
 				if(istype(T, /obj/item/weapon/reagent_containers/food/snacks)) // Food gets its own treatment now. Hopefully your prey didn't load their bag with donk boxes.
 					var/obj/item/weapon/reagent_containers/food/snacks/F = T
-					F.reagents.trans_to_mob(owner, (F.reagents.total_volume * 0.3), CHEM_INGEST)
+					if(istype(owner,/mob/living/carbon/human))
+						var/mob/living/carbon/human/howner = owner
+						F.reagents.trans_to_holder(howner.ingested, (F.reagents.total_volume * 0.3), 1, 0)
 					internal_contents -= F
 					qdel(F)
 				else

--- a/code/modules/vore/eating/bellymodes_vr.dm
+++ b/code/modules/vore/eating/bellymodes_vr.dm
@@ -77,18 +77,28 @@
 				else
 					owner.nutrition += (10/difference)
 
+		//if(owner.weakgurgles < 1) // An example for possible trait modifier. (Not existing currently)
+			//The "Handle leftovers" spaghetti below should be moved here if above gets done.
+
 		// Handle leftovers.
 		var/obj/item/T = pick(internal_contents)
 		if(istype(T, /obj/item))
 			if(istype(T, /obj/item) && _is_digestable(T) && !(T in items_preserved))
-				for(var/obj/item/SubItem in T.contents)
-					SubItem.forceMove(internal_contents)
+				if(T in items_preserved)// Doublecheck just in case.
+					return
+				for(var/obj/item/SubItem in T)
+					if(istype(SubItem,/obj/item/weapon/storage/internal))
+						var/obj/item/weapon/storage/internal/SI = SubItem
+						for(var/obj/item/SubSubItem in SI)
+							SubSubItem.forceMove(internal_contents)
+						qdel(SI)
+					else
+						SubItem.forceMove(internal_contents)
 				owner.nutrition += (1 * T.w_class)
 				internal_contents -= T
 				qdel(T)
 			else
 				return
-
 		return
 
 //////////////////////////// DM_ABSORB ////////////////////////////

--- a/code/modules/vore/eating/vorepanel_vr.dm
+++ b/code/modules/vore/eating/vorepanel_vr.dm
@@ -101,6 +101,8 @@
 				spanstyle = "color:red;"
 			if(DM_ITEMWEAK)
 				spanstyle = "color:red;"
+			if(DM_STRIPDIGEST)
+				spanstyle = "color:red;"
 			if(DM_HEAL)
 				spanstyle = "color:green;"
 			if(DM_ABSORB)

--- a/code/modules/vore/eating/vorepanel_vr.dm
+++ b/code/modules/vore/eating/vorepanel_vr.dm
@@ -99,6 +99,8 @@
 				spanstyle = ""
 			if(DM_DIGEST)
 				spanstyle = "color:red;"
+			if(DM_ITEMWEAK)
+				spanstyle = "color:red;"
 			if(DM_HEAL)
 				spanstyle = "color:green;"
 			if(DM_ABSORB)


### PR DESCRIPTION
# **ESSENTIALLY 3 FANCY NEW GURGLEMODES**
**-Normal digestion has been changed into loot drop system, which gradually gurgles the loot after the prey has ascended to pudge.**
**-An item-friendly variant, which only gurgles the prey's snack stashes. It also ruins their unprotected IDs and contaminates their clothing. (At least wash them first you nasties)**
**-A strip digestion mode, which gradually gurgles the gear off your prey, essentially doing what the main gurglemode does without harming the prey.**
**-Also borgo sleeper gurgles now make the prey drop their posibrains and any subprey within their guts if applicable and they can no longer accidentally eat their own equipment modules off the hud.**

**More details tl;dr chronological order changelog below.**


-Managed to build a vore organ equivalent for the inventory gurgle tweaks I made for dogborg guts.
-This means that gurgled prey now drops their loot into the gut.
-After this, the loot in the gut will slowly gurgle away one item at a time, each giving a trace amount of nourishment, multiplied by the item size.
-All the loot will show up in vore panel. However you need to be bashing refresh to see the progress in real time.
-The forbidden/important items list should still work.
-Not so sure about televore beacons tho. Better keep those in with hold mode and pop em out when you go for gurgles just in case :v 
-Also added in a fix for borgs eating their own modules.
<s>-Slight on-site edits to prevent pocket gear from dropping off its invisible pocket storage holders when dumping contents.</s>
-Gurgled items no longer drop their invisible pocket space holder thingies while dumping their contents.
-IDs and probably some other special items shouldn't randomly vanish now.
-Transfering contents from gut to another now also transfers their preserved status and cleans up the list entries from source gut.
-Ejection, single and complete, now properly clears the lists from ejected stuff.
-Borgo-gurgling a pred should now dump their prey into the borgogut.
-Some other cleanups yadda yadda.
<s>-Added a commented example part hinting that the system is pretty much ready for a trait based item-weak gurgle option.</s>
-All should be well now <s>unless you try to gurgle a synth expecting a preserved brain on borgo gut right now. I just remembered I forgot to steal the posibrain yankage bits from the voreorgan code. Oh well it's not like you could've done that with the old code either :v</s> (fixed)
-Normal itemgurglemode now also takes partial nutritional reagent contents from prey's snack stashes.
-Slightly reduced borgo trash nom sound volume.
-Added an item friendly gurglemode, in which:
-Gurgled prey drops all their loot, but the gut will still act on the stuff over time one by one.
-Instead of gurglin the items, it only gurgles foodstuffs. (with just 0.3x nut/reagent gain to avoid unintentional overdosing from the prey's snack stashes)
-However once picked for handling by the gut, the nonfood items get contaminated if applicable. You probably shouldn't wear/use the gear someone just got digested in unwashed :v
-Added a strip digest mode, that only gurgles the prey's gear instead.
-Various fixes and tweaks to earlier commits.
-Item/subitem handling is now the gut's job. Dying to gurgles still makes the prey drop their outer gear.
-in other words the initial gurgle loot drop now only drops the worn gear, leaving the contents for gut subitem stuffs.
-Added another exclusion after noticing tesh abilities hud thingy in the gut :v
-I swear there was something more.