### PR TITLE
Fixes ghosts being unable to see any emotes

### DIFF
--- a/code/modules/mob/emote.dm
+++ b/code/modules/mob/emote.dm
@@ -41,7 +41,7 @@
 					//VOREStation edit
 					if(istype(M, /mob/observer/dead/))
 						var/mob/observer/dead/D = M
-						if((ckey && D.is_preference_enabled(/datum/client_preference/ghost_sight)) || src in view(D))
+						if(ckey || (src in view(D)))
 							M.show_message(message, m_type)
 					else
 						M.show_message(message, m_type)


### PR DESCRIPTION
#1850 made observers unable to see emotes, from any range.
This also removes an unnecessary ghost sight preference check, which is already handled by get_mobs_and_objs_in_view_fast.
please test your PRs