### PR TITLE
Update gaslamps to be more endo-vore forward in their retaliation.

### DIFF
--- a/code/modules/mob/living/simple_animal/vore/gaslamp.dm
+++ b/code/modules/mob/living/simple_animal/vore/gaslamp.dm
@@ -30,8 +30,8 @@ TODO: Make them light up and heat the air when exposed to oxygen.
 
 	melee_damage_lower = 30 // Because fuck anyone who hurts this sweet, innocent creature.
 	melee_damage_upper = 30
-	attacktext = "thrashes"
-	friendly = "caresses"
+	attacktext = "thrashed"
+	friendly = "caressed"
 
 	response_help   = "brushes"	// If clicked on help intent
 	response_disarm = "pushes" // If clicked on disarm intent
@@ -53,6 +53,11 @@ TODO: Make them light up and heat the air when exposed to oxygen.
 /mob/living/simple_animal/retaliate/gaslamp
 	vore_active = 1
 	vore_capacity = 2
-	vore_default_mode = DM_ABSORB
-	vore_pounce_chance = 0 // Beat them into crit before eating.
+	vore_standing_too = 1 // Defaults to trying to give you that big tentacle hug.
+	vore_default_mode = DM_HOLD
+	vore_digest_chance = 0			// Chance to switch to digest mode if resisted
+	vore_absorb_chance = 20			// BECOME A PART OF ME.
+	vore_pounce_chance = 5 // Small chance to punish people who abuse their nomming behaviour to try and kite them forever with repeated melee attacks.
+	vore_stomach_name = "internal chamber"
+	vore_stomach_flavor	= "You are squeezed into the tight embrace of the alien creature's warm and cozy insides."
 	vore_icons = SA_ICON_LIVING


### PR DESCRIPTION
Makes gaslamps more inclined to eats. ALWAYS EATS. These changes are partly in reference to #1857, and I have somewhat err'd on the side of making the mob vore aspect people are wandering outside for way more accessible and may have gone overboard with it on making them more vore focused and less attack-focused since now they only attack you with their melee if you have digestion turned off.

Also changed the attacktext to past tense since that's how it should be [otherwise you get 'has thrashes']. Will PR similar fixes for other mob attacktext separately after this one is merged or closed.