### PR TITLE
Adds a scannable reagent generator

### DIFF
--- a/code/game/objects/items/weapons/implants/implantreagent_vr.dm
+++ b/code/game/objects/items/weapons/implants/implantreagent_vr.dm
@@ -171,7 +171,7 @@
 			to_chat(user,"<span class='notice'>The container must have one single, pure, liquid reagent inside of it to scan.</span>")
 			return
 		var/datum/reagent/R = container.reagents.get_master_reagent()
-		if(R.reagent_state != 2)
+		if(R.reagent_state != LIQUID)
 			to_chat(user,"<span class='notice'>The reagent inside the beaker must be a liquid.</span>")
 			return
 		var/datum/reagent/R_ID = container.reagents.get_master_reagent_id()

--- a/code/game/objects/items/weapons/implants/implantreagent_vr.dm
+++ b/code/game/objects/items/weapons/implants/implantreagent_vr.dm
@@ -96,3 +96,90 @@
 			if(rimplant.reagents.total_volume == rimplant.reagents.maximum_volume * 0.05)
 				to_chat(src, "<span class='notice'>[pick(rimplant.empty_message)]</span>")
 
+
+
+/obj/item/weapon/implant/reagent_generator/scannable
+	name = "scannable reagent generator implant"
+	desc = "This is an implant that has attached storage and generates a scanned reagent."
+	gen_amount = 0.2 //This is extremely powerful and, as such, has a long time to create reagents
+	gen_cost = 10 //And an extremely high cost to make reagents. 1000 nutrition to go from nothing from full in 100 ticks.
+	transfer_amount = 20
+	usable_volume = 20 //Can't hold much, either.
+	generated_reagent = "water" //Placeholder reagent until the person selects a new reagent.
+	var/assigned_proc2 = /mob/living/carbon/human/proc/scan_reagent_with_implant
+	var/verb_name2 = "Scan reagent with implant"
+	var/verb_desc2 = "Scans a reagent in a container and begins to synthetsise it."
+
+
+/obj/item/weapon/implant/reagent_generator/scannable/implanted(mob/living/carbon/source)
+	processing_objects += src
+	to_chat(source, "<span class='notice'>You implant [source] with \the [src].</span>")
+	assigned_proc = new assigned_proc(source, verb_name, verb_desc)
+	assigned_proc2 = new assigned_proc2(source, verb_name2, verb_desc2)
+	return 1
+
+/obj/item/weapon/implant/reagent_generator/scannable/process()
+	var/before_gen
+	if(imp_in && generated_reagent)
+		before_gen = reagents.total_volume
+		if(reagents.total_volume < reagents.maximum_volume)
+			if(imp_in.nutrition >= gen_cost)
+				do_generation()
+		else
+			return
+	else
+		imp_in.verbs -= assigned_proc
+		imp_in.verbs -= assigned_proc2
+		return
+
+	if(reagents)
+		if(reagents.total_volume == reagents.maximum_volume * 0.05)
+			to_chat(imp_in, "<span class='notice'>[pick(empty_message)]</span>")
+		else if(reagents.total_volume == reagents.maximum_volume && before_gen < reagents.maximum_volume)
+			to_chat(imp_in, "<span class='warning'>[pick(full_message)]</span>")
+
+/mob/living/carbon/human/proc/scan_reagent_with_implant()
+	set name = "Scan reagent and begin synthesis"
+	set desc = "Scan a container and begin internal synthesis of the reagent that is the majority of the container."
+	set category = "Object"
+	set src in view(1)
+
+	do_reagent_scan(usr)
+
+
+
+/mob/living/carbon/human/proc/do_reagent_scan(var/mob/living/carbon/human/user = usr)
+	if(!isliving(user) || !user.canClick())
+		return
+
+	if(user.incapacitated() || user.stat > CONSCIOUS)
+		return
+
+	var/obj/item/weapon/reagent_containers/container = user.get_active_hand()
+	if(!container)
+		to_chat(user,"<span class='notice'>You need an open container in your hand to do this!</span>")
+		return
+
+
+	var/obj/item/weapon/implant/reagent_generator/scannable/rimplant
+	for(var/I in src.contents)
+		if(istype(I, /obj/item/weapon/implant/reagent_generator/scannable))
+			rimplant = I
+			break
+	if(rimplant)
+		if(!container.reagents) //This should only apply to things that can't hold reagents.
+			to_chat(user,"<span class='notice'>The container must have one single, pure, liquid reagent inside of it to scan.</span>")
+			return
+		var/datum/reagent/R = container.reagents.get_master_reagent()
+		if(R.reagent_state != 2)
+			to_chat(user,"<span class='notice'>The reagent inside the beaker must be a liquid.</span>")
+			return
+		var/datum/reagent/R_ID = container.reagents.get_master_reagent_id()
+		var/datum/reagent/R_NAME = container.reagents.get_master_reagent_name()
+		rimplant.reagents.clear_reagents() //Clear out the reagents list, first.
+		rimplant.generated_reagent = R_ID
+		to_chat(user,"<span class='notice'>You scan the reagent inside the container. You will now begin synthesising [R_NAME].</span>")
+		rimplant.reagents.total_volume = 0 //Let's reset the reagents current volume.
+
+/obj/item/weapon/implanter/reagent_generator/scannable
+	implant_type = /obj/item/weapon/implant/reagent_generator/scannable


### PR DESCRIPTION
- Adds in a reagent generator which can scan reagents and produce the scanned reagent over time.

I was recently contacted by ~~A certain fat lizard~~ someone requesting a reagent generator which could scan reagents and then produce them slowly.

Went ahead and whipped this up in ~3 hours, based on the preexisting  reagent generator and using the mech syringe gun as inspiration. 

Notes:
- Generates .2 units per tick.
- Can hold up to 20 units.
- Each tick, 10 nutrition is used to create the .2 units. This means it takes 100 ticks to generate 20 units, resulting in _1000 nutrition required_ for 20 units, making it very costly.
- Can only be used to synthesis reagents that are liquids. This means things like iron, potassium, radium, etc can't be synthesized.

Additionally, I was thinking of putting more safeguards on it (See: Not allowing phoron to be synthesized, as an example.) but decided not to, as someone could play a Vox and generate liquid phoron for some reason.

Currently admin spawn only.
I was personally thinking of having it limited to being a custom item only, or custom item & extremely high R&D level due to simply how powerful it can be if abused.