### PR TITLE
Micro step code changes.

### DIFF
--- a/code/modules/vore/resizing/resize_vr.dm
+++ b/code/modules/vore/resizing/resize_vr.dm
@@ -223,7 +223,7 @@ var/const/RESIZE_A_SMALLTINY = (RESIZE_SMALL + RESIZE_TINY) / 2
 				var/mob/living/carbon/human/H = src
 				if(istype(H) && istype(H.tail_style, /datum/sprite_accessory/tail/taur/naga))
 					src << "Your heavy tail slowly and methodically slides down upon [tmob], crushing against the floor below!"
-					tmob << "[src]'s thick, heavy tail slowly and methodically slides down upon your body, mercilessly crushing you into the floor below.
+					tmob << "[src]'s thick, heavy tail slowly and methodically slides down upon your body, mercilessly crushing you into the floor below."
 					tmob.drip(10)
 				else
 					src << "You methodically place your foot down upon [tmob]'s body, slowly applying pressure, crushing them against the floor below!"

--- a/code/modules/vore/resizing/resize_vr.dm
+++ b/code/modules/vore/resizing/resize_vr.dm
@@ -178,7 +178,7 @@ var/const/RESIZE_A_SMALLTINY = (RESIZE_SMALL + RESIZE_TINY) / 2
 		if((src.get_effective_size() - tmob.get_effective_size()) >= 0.75)
 			now_pushing = 0
 			src.forceMove(tmob.loc)
-			if(src.m_intent == run) //Running down the hallway with disarm intent?
+			if(src.m_intent == "run") //Running down the hallway with disarm intent?
 				tmob.resting = 1 //Force them down to the ground.
 				var/mob/living/carbon/human/H = src
 				if(istype(H) && istype(H.tail_style, /datum/sprite_accessory/tail/taur/naga))
@@ -188,47 +188,61 @@ var/const/RESIZE_A_SMALLTINY = (RESIZE_SMALL + RESIZE_TINY) / 2
 					src << "You quickly push [tmob] to the ground with your foot!"
 					tmob << "[src] pushes you down to the ground with their foot!"
 				return 1
-			if(src.m_intent == walk) //Most likely intentionally stepping on them.
+			if(src.m_intent == "walk") //Most likely intentionally stepping on them.
+				var/size_damage_multiplier = (src.size_multiplier - tmob.size_multiplier)
+				var/damage = (rand(15,30)* size_damage_multiplier) //Since stunned is broken, let's do this. Rand 15-30 multiplied by 1 min or 1.75 max. 15 holo to 52.5 holo, depending on RNG and size differnece.
+				tmob.apply_damage(damage, HALLOSS)
 				tmob.resting = 1
-				tmob.Stun(15)
+				
 				var/mob/living/carbon/human/H = src
 				if(istype(H) && istype(H.tail_style, /datum/sprite_accessory/tail/taur/naga))
-					src << "You  squish [tmob] under your tail, pinning them down!"
-					tmob << "[src] squishes you with their tail, pinning you down!"
+					src << "You push down on [tmob] with your tail, pinning them down under you!"
+					tmob << "[src] pushes down on you with their tail, pinning you down below them!"
 				else
-					src << "You pin [tmob] beneath your foot!"
-					tmob << "[src] pins you beneath their foot!"
+					src << "You firmly push your foot down on [tmob], painfully but harmlessly pinning them to the ground!"
+					tmob << "[src] firmly pushes their foot down on you, quite painfully but harmlessly pinning you do to the ground!"
 
 
 	if(src.a_intent == I_HURT && src.canmove && !src.buckled)
 		if((src.get_effective_size() - tmob.get_effective_size()) >= 0.75)
 			now_pushing = 0
 			src.forceMove(tmob.loc)
-			var/damage = (rand(1,3)*(src.get_effective_size-tmob.get_effective_size)) //Rand 1-3 multiplied by 1 min or 1.75 max. 1 min 5.25 max damage.
+			var/size_damage_multiplier = (src.size_multiplier - tmob.size_multiplier)
+			var/damage = (rand(1,3)* size_damage_multiplier) //Rand 1-3 multiplied by 1 min or 1.75 max. 1 min 5.25 max damage.
 			
-			if(src.m_intent == run)
+			if(src.m_intent == "run")
 				tmob.apply_damage(damage, BRUTE)
 				var/mob/living/carbon/human/H = src
 				if(istype(H) && istype(H.tail_style, /datum/sprite_accessory/tail/taur/naga))
 					src << "Your heavy tail carelessly slides past [tmob],  crushing them!"
 					tmob << "[src] quickly goes over your body, carelessly crushing you with their heavy tail!"
+					if(istype(tmob,/mob/living/carbon/human))
+						var/mob/living/carbon/human/M = tmob
+						M.drip(0.1) 
 				else
 					src << "You carlessly step down onto [tmob], crushing them!!"
 					tmob << "[src] steps carelessly on your body, crushing you!"
+					if(istype(tmob,/mob/living/carbon/human))
+						var/mob/living/carbon/human/M = tmob
+						M.drip(0.1)
 				return 1
 
-			if(src.m_intent == walk) //Oh my.
+			if(src.m_intent == "walk") //Oh my.
 				damage = damage * 5 //Multiplies the above damage by 5. This means a min of 5 damage, or a max of 26.25 damage, depending on size and RNG.
 				tmob.apply_damage(damage, BRUTE)
 				var/mob/living/carbon/human/H = src
 				if(istype(H) && istype(H.tail_style, /datum/sprite_accessory/tail/taur/naga))
 					src << "Your heavy tail slowly and methodically slides down upon [tmob], crushing against the floor below!"
 					tmob << "[src]'s thick, heavy tail slowly and methodically slides down upon your body, mercilessly crushing you into the floor below."
-					tmob.drip(10)
+					if(istype(tmob,/mob/living/carbon/human))
+						var/mob/living/carbon/human/M = tmob
+						M.drip(3) //The least of your problems, honestly.
 				else
 					src << "You methodically place your foot down upon [tmob]'s body, slowly applying pressure, crushing them against the floor below!"
 					tmob << "[src] methodically places their foot upon your body, slowly applying pressure, crushing you against the floor below!"
-					tmob.drip(10)
+					if(istype(tmob,/mob/living/carbon/human))
+						var/mob/living/carbon/human/M = tmob
+						M.drip(3)
 				return 1
 
 			var/mob/living/carbon/human/H = src

--- a/code/modules/vore/resizing/resize_vr.dm
+++ b/code/modules/vore/resizing/resize_vr.dm
@@ -178,22 +178,58 @@ var/const/RESIZE_A_SMALLTINY = (RESIZE_SMALL + RESIZE_TINY) / 2
 		if((src.get_effective_size() - tmob.get_effective_size()) >= 0.75)
 			now_pushing = 0
 			src.forceMove(tmob.loc)
-			tmob.Stun(4)
+			if(src.m_intent == run) //Running down the hallway with disarm intent?
+				tmob.resting = 1 //Force them down to the ground.
+				var/mob/living/carbon/human/H = src
+				if(istype(H) && istype(H.tail_style, /datum/sprite_accessory/tail/taur/naga))
+					src << "Your tail slides over [tmob], pushing them down to the ground!"
+					tmob << "[src]'s tail slides over you, forcing you down to the ground!"
+				else
+					src << "You quickly push [tmob] to the ground with your foot!"
+					tmob << "[src] pushes you down to the ground with their foot!"
+				return 1
+			if(src.m_intent == walk) //Most likely intentionally stepping on them.
+				tmob.resting = 1
+				tmob.Stun(15)
+				var/mob/living/carbon/human/H = src
+				if(istype(H) && istype(H.tail_style, /datum/sprite_accessory/tail/taur/naga))
+					src << "You  squish [tmob] under your tail, pinning them down!"
+					tmob << "[src] squishes you with their tail, pinning you down!"
+				else
+					src << "You pin [tmob] beneath your foot!"
+					tmob << "[src] pins you beneath their foot!"
 
-			var/mob/living/carbon/human/H = src
-			if(istype(H) && istype(H.tail_style, /datum/sprite_accessory/tail/taur/naga))
-				src << "You carefully squish [tmob] under your tail!"
-				tmob << "[src] pins you under their tail!"
-			else
-				src << "You pin [tmob] beneath your foot!"
-				tmob << "[src] pins you beneath their foot!"
-			return 1
 
 	if(src.a_intent == I_HURT && src.canmove && !src.buckled)
 		if((src.get_effective_size() - tmob.get_effective_size()) >= 0.75)
 			now_pushing = 0
 			src.forceMove(tmob.loc)
-			tmob.apply_damage(10, HALLOSS)
+			var/damage = (rand(1,3)*(src.get_effective_size-tmob.get_effective_size)) //Rand 1-3 multiplied by 1 min or 1.75 max. 1 min 5.25 max damage.
+			
+			if(src.m_intent == run)
+				tmob.apply_damage(damage, BRUTE)
+				var/mob/living/carbon/human/H = src
+				if(istype(H) && istype(H.tail_style, /datum/sprite_accessory/tail/taur/naga))
+					src << "Your heavy tail carelessly slides past [tmob],  crushing them!"
+					tmob << "[src] quickly goes over your body, carelessly crushing you with their heavy tail!"
+				else
+					src << "You carlessly step down onto [tmob], crushing them!!"
+					tmob << "[src] steps carelessly on your body, crushing you!"
+				return 1
+
+			if(src.m_intent == walk) //Oh my.
+				damage = damage * 5 //Multiplies the above damage by 5. This means a min of 5 damage, or a max of 26.25 damage, depending on size and RNG.
+				tmob.apply_damage(damage, BRUTE)
+				var/mob/living/carbon/human/H = src
+				if(istype(H) && istype(H.tail_style, /datum/sprite_accessory/tail/taur/naga))
+					src << "Your heavy tail slowly and methodically slides down upon [tmob], crushing against the floor below!"
+					tmob << "[src]'s thick, heavy tail slowly and methodically slides down upon your body, mercilessly crushing you into the floor below.
+					tmob.drip(10)
+				else
+					src << "You methodically place your foot down upon [tmob]'s body, slowly applying pressure, crushing them against the floor below!"
+					tmob << "[src] methodically places their foot upon your body, slowly applying pressure, crushing you against the floor below!"
+					tmob.drip(10)
+				return 1
 
 			var/mob/living/carbon/human/H = src
 			if(istype(H) && istype(H.tail_style, /datum/sprite_accessory/tail/taur/naga))


### PR DESCRIPTION
INFORMATION:
- The bigger the size difference, the more damage.
- Disarm Damage Forumla: (rand(15,30)* size_damage_multiplier)
- Harm Damage Formula: (rand(1,3)* size_damage_multiplier)
- The "stunned" variable that disarm stepping used to use is broken and has been replaced with holodamage.

When someone is stepped on and has a size difference multiplier of >.75, these interactions occur:

- **HELP**: Nothing.

- **Grab**: Picks up the micro as normal. Code untouched.

- **Disarm & Run**: Shoves the person to the ground. They can get back up by simply un-resting.
- **Disarm & Walk**: Shoves the person to the ground and deals heavy holodamage based on some RNG and size. (15-52.5 holodamage, mix and max.)

- **Harm & Run**: Carelessly crush the person below you. Does light damage (1-5.25) depending on RNG and size difference.
- **Harm & Walk**: Purposefully crush the person below you. Does heavy damage (5-26.5) depending on RNG and size difference.


Notes:
This gives macros quite a bit of a mechanical buff to make up for their obscenely large hitbox and makes micros and normal sized people a bit weaker when going against macros during close combat.