### PR TITLE
Renames "second-hand NIF" to "bootleg NIF"

### DIFF
--- a/code/modules/nifsoft/nif.dm
+++ b/code/modules/nifsoft/nif.dm
@@ -556,7 +556,7 @@ You can also set the stat of a NIF to NIF_TEMPFAIL without any issues to disable
 
 // Alternate NIFs
 /obj/item/device/nif/bad
-	name = "second-hand NIF"
+	name = "bootleg NIF"
 	desc = "A copy of a copy of a copy of a copy of... this can't be any good, right? Surely?"
 	durability = 10
 


### PR DESCRIPTION
Second-hand implies it was already used by someone, and from what I can tell NIFs bind permanently to whoever they're put into first. The description also already fits it being some sort of bootleg or shoddy replica.

I don't know who the loreperson for NIFs is, if the original name is better please tell me.