### PR TITLE
Allows borgs to use custom stomachs

### DIFF
--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -21,7 +21,7 @@
 		process_killswitch()
 		process_locks()
 		process_queued_alarms()
-	handle_internal_content() //VOREStation Edit
+	handle_internal_contents() //VOREStation Edit
 	update_canmove()
 
 /mob/living/silicon/robot/proc/clamp_values()

--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -21,6 +21,7 @@
 		process_killswitch()
 		process_locks()
 		process_queued_alarms()
+	handle_internal_content() //VOREStation Edit
 	update_canmove()
 
 /mob/living/silicon/robot/proc/clamp_values()

--- a/code/modules/mob/living/silicon/robot/robot_vr.dm
+++ b/code/modules/mob/living/silicon/robot/robot_vr.dm
@@ -1,6 +1,6 @@
-/mob/living/silicon/robot/proc/robot_nom(var/mob/living/T in oview(1))
+/mob/living/silicon/robot/verb/robot_nom(var/mob/living/T in oview(1))
 	set name = "Robot Nom"
-	set category = "pAI Commands"
+	set category = "IC"
 	set desc = "Allows you to eat someone."
 
 	if (stat != CONSCIOUS)

--- a/code/modules/mob/living/silicon/robot/robot_vr.dm
+++ b/code/modules/mob/living/silicon/robot/robot_vr.dm
@@ -1,3 +1,12 @@
+/mob/living/silicon/robot/proc/robot_nom(var/mob/living/T in oview(1))
+	set name = "Robot Nom"
+	set category = "pAI Commands"
+	set desc = "Allows you to eat someone."
+
+	if (stat != CONSCIOUS)
+		return
+	return feed_grabbed_to_self(src,T)
+
 /mob/living/silicon/robot/updateicon()
 	overlays.Cut()
 	if(stat == CONSCIOUS)


### PR DESCRIPTION
Allows borgs to eat people and use custom stomachs, along with fixing how the game handles it when someone ends up in a borg's stomach.

- Makes it so the game properly processes things in a borg's stomach (Previously something could get in via teleportation or whatnot and the game would just hold them there and not actually process them)
- Makes it so borgs have a robot nom verb that allows them to eat people to put them in custom stomachs instead of using the sleeper.