### PR TITLE
Disable all shell() exec prox for extra security.

### DIFF
--- a/code/modules/ext_scripts/irc.dm
+++ b/code/modules/ext_scripts/irc.dm
@@ -1,4 +1,5 @@
 /proc/send2irc(var/channel, var/msg)
+	return  // VOREStation Edit - Can't exploit shell if we never call shell!
 	if (config.use_irc_bot)
 		if (config.use_node_bot)
 			shell("node bridge.js -h \"[config.irc_bot_host]\" -p \"[config.irc_bot_port]\" -c \"[channel]\" -m \"[msg]\"")

--- a/code/modules/ext_scripts/python.dm
+++ b/code/modules/ext_scripts/python.dm
@@ -1,4 +1,5 @@
 /proc/ext_python(var/script, var/args, var/scriptsprefix = 1)
+	return  // VOREStation Edit - Can't exploit shell if we never call shell!
 	if(scriptsprefix) script = "scripts/" + script
 
 	if(world.system_type == MS_WINDOWS)


### PR DESCRIPTION
We do not use python or nodejs scripts. Our discord bot makes HTTP requests.  Therefore we can entirely disable this code.  Even if we ever want to start using these procs for discord integration, we would pipe it through our HTTP discord proxy, not use shell().
With all instances of shell() disabled, we can't be attacked by it.