### PR TITLE
Makes everyone have numbing gurgles by default.

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/blank_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/blank_vr.dm
@@ -1,6 +1,7 @@
+/*
 /datum/species
 	var/vore_numbing = 0
-
+*/
 /datum/species/custom
 	name = "Custom Species"
 	name_plural = "Custom"

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
@@ -18,13 +18,13 @@
 	cost = 0
 	var_changes = list("metabolic_rate" = 2)
 	excludes = list(/datum/trait/metabolism_up, /datum/trait/metabolism_down)
-
+/*
 /datum/trait/vore_numbing
 	name = "Prey Numbing"
 	desc = "Adds a 'Digest (Numbing)' belly mode, to douse prey in numbing enzymes during digestion."
 	cost = 0
 	var_changes = list("vore_numbing" = TRUE)
-
+*/
 /datum/trait/cold_discomfort
 	name = "Hot-Blooded"
 	desc = "You are too hot at the standard 20C. 18C is more suitable. Rolling down your jumpsuit or being unclothed helps."

--- a/code/modules/vore/eating/belly_vr.dm
+++ b/code/modules/vore/eating/belly_vr.dm
@@ -30,7 +30,7 @@
 	var/datum/belly/transferlocation = null	// Location that the prey is released if they struggle and get dropped off.
 
 	var/tmp/digest_mode = DM_HOLD				// Whether or not to digest. Default to not digest.
-	var/tmp/list/digest_modes = list(DM_HOLD,DM_DIGEST,DM_ITEMWEAK,DM_STRIPDIGEST,DM_HEAL,DM_ABSORB,DM_DRAIN,DM_UNABSORB)	// Possible digest modes
+	var/tmp/list/digest_modes = list(DM_HOLD,DM_DIGEST,DM_ITEMWEAK,DM_STRIPDIGEST,DM_HEAL,DM_ABSORB,DM_DRAIN,DM_UNABSORB,DM_DIGEST_NUMB)	// Possible digest modes
 	var/tmp/list/transform_modes = list(DM_TRANSFORM_MALE,DM_TRANSFORM_FEMALE,DM_TRANSFORM_KEEP_GENDER,DM_TRANSFORM_CHANGE_SPECIES_AND_TAUR,DM_TRANSFORM_CHANGE_SPECIES_AND_TAUR_EGG,DM_TRANSFORM_REPLICA,DM_TRANSFORM_REPLICA_EGG,DM_TRANSFORM_KEEP_GENDER_EGG,DM_TRANSFORM_MALE_EGG,DM_TRANSFORM_FEMALE_EGG, DM_EGG)
 	var/tmp/mob/living/owner					// The mob whose belly this is.
 	var/tmp/list/internal_contents = list()		// People/Things you've eaten into this belly!

--- a/code/modules/vore/eating/vorepanel_vr.dm
+++ b/code/modules/vore/eating/vorepanel_vr.dm
@@ -453,9 +453,9 @@
 	if(href_list["b_mode"])
 		var/list/menu_list = selected.digest_modes
 		if(istype(usr,/mob/living/carbon/human))
-			var/mob/living/carbon/human/H = usr
-			if(H.species.vore_numbing)
-				menu_list += DM_DIGEST_NUMB
+			//var/mob/living/carbon/human/H = usr
+			//if(H.species.vore_numbing)
+				//menu_list += DM_DIGEST_NUMB
 			menu_list += selected.transform_modes
 
 		if(selected.digest_modes.len == 1) // Don't do anything


### PR DESCRIPTION
No idea why this was a trait. Heal bellies are default and they're much more special than numbing digestion.

- Makes numbing digestion able to be selected by everyone.
- Comments out areas where numbing digestion is a trait instead of deleting it, just to keep it as an example of how special stomach modes can be enabled via the trait system.