### PR TITLE
Design fix

### DIFF
--- a/code/modules/research/designs_vr.dm
+++ b/code/modules/research/designs_vr.dm
@@ -45,7 +45,7 @@
 	build_path = /obj/item/device/sleevemate
 	sort_string = "TAAAD"
 
-/datum/design/item/sleevemate
+/datum/design/item/bodysnatcher
 	name = "Body Snatcher"
 	id = "bodysnatcher"
 	req_tech = list(TECH_MAGNET = 3, TECH_BIO = 3, TECH_ILLEGAL = 2)


### PR DESCRIPTION
Accidentally had the bodysnatcher design listed as /sleevemate from when it was copy and pasted, preventing it from being created. This fixes it

- Allows bodysnatcher to be correctly made by R&D