### PR TITLE
Reduces effectiveness of tabling as opening combat move.

### DIFF
--- a/code/modules/tables/interactions.dm
+++ b/code/modules/tables/interactions.dm
@@ -106,9 +106,11 @@
 				else
 					user << "<span class='danger'>You need a better grip to do that!</span>"
 					return
-			else
-				G.affecting.loc = src.loc
-				G.affecting.Weaken(5)
+			//VOREStation Edit - Tables dethroned
+			else if(!M.Check_Shoegrip() && do_mob(user, M, 5+(M.getarmor(BP_TORSO,"melee")/4)))
+				M.forceMove(get_turf(src))
+				M.Weaken(round(5-(M.getarmor(null, "melee")/20)))
+			//VOREStation Edit End
 				visible_message("<span class='danger'>[G.assailant] puts [G.affecting] on \the [src].</span>")
 			qdel(W)
 			return


### PR DESCRIPTION
Tabling in its current form is an effectively instant stun with no real counters other then being about four tiles from any tables at all times, which can be extended indefinitely with minimal effort. This degenerates much combat into "Grab, mash z, click table, push to ground, table again occasionally to reapply stun".

Tabling now takes a short time to happen, 1/2 second with some additional time added depending on the melee defence of the victim's chest armor. People wearing active magboots cannot be tabled.
Armor also decreases the length of the stun received.