### PR TITLE
Blurry non-default sprites

### DIFF
--- a/code/modules/vore/eating/living_vr.dm
+++ b/code/modules/vore/eating/living_vr.dm
@@ -25,7 +25,7 @@
 		return 1
 	M.verbs += /mob/living/proc/insidePanel
 
-	M.appearance_flags |= PIXEL_SCALE
+	//M.appearance_flags |= PIXEL_SCALE //This makes sprites not blurry or fuzzy, and makes them sharp. Macros look good with it but can cause issues.
 
 	//Tries to load prefs if a client is present otherwise gives freebie stomach
 	if(!M.vore_organs || !M.vore_organs.len)


### PR DESCRIPTION
Not sure what to call this one.
Disabling this makes sprites appear less sharp and more blurry. Works on smaller sprites but makes Macros look kinda... Off.

Leaving this here for people to discuss and vote.

How it currently is: https://i.imgur.com/vkPrcPM.png?1
How it will look if this is merged: http://i.imgur.com/Q6Be1qE.png
Top part of the above screenshot: 150 160 170 180 190 200