### PR TITLE
Fixes a meteor runtime

### DIFF
--- a/code/modules/events/meteor_strike_vr.dm
+++ b/code/modules/events/meteor_strike_vr.dm
@@ -58,7 +58,7 @@
 			if(!istype(L))
 				continue
 			var/turf/mob_turf = get_turf(L)
-			if(!(mob_turf.z in impacted.expected_z_levels))
+			if(!mob_turf || !(mob_turf.z in impacted.expected_z_levels))
 				continue
 			if(!L.buckled && !issilicon(L))
 				if(!L.Check_Shoegrip())


### PR DESCRIPTION
Fixes a runtime caused by mobs being in nullspace.

On a side note, the meteor really loses something when multi-z explosions are disabled, it can't properly dig out a crater for the meteorite to sit in.