### PR TITLE
Size gun fix

### DIFF
--- a/code/modules/research/designs_vr.dm
+++ b/code/modules/research/designs_vr.dm
@@ -22,8 +22,8 @@
 	build_path = /obj/item/weapon/implantcase/backup
 
 /datum/design/item/weapon/sizegun
-	name = "Shrink ray"
-	id = "shrinkray"
+	name = "Size gun"
+	id = "sizegun"
 	req_tech = list(TECH_COMBAT = 3, TECH_MATERIAL = 3, TECH_POWER = 2)
 	materials = list(DEFAULT_WALL_MATERIAL = 3000, "glass" = 2000, "uranium" = 2000)
 	build_path = /obj/item/weapon/gun/energy/sizegun

--- a/code/modules/vore/resizing/sizegun_vr.dm
+++ b/code/modules/vore/resizing/sizegun_vr.dm
@@ -72,5 +72,5 @@
 
 /obj/item/weapon/gun/energy/sizegun/examine(mob/user)
 	..()
-	var/size_examine = size_set_to
+	var/size_examine = (size_set_to*100)
 	user << "<span class='info'>It is currently set at [size_examine]%</span>"


### PR DESCRIPTION
- Fixes size gun description to show the correct %age
- Sets the design name to "Size gun" instead of "Shrink ray"