### PR TITLE
Auto-updates for vore panel and borgo gut UI.

### DIFF
--- a/code/modules/mob/living/silicon/robot/dogborg/dog_sleeper_vr.dm
+++ b/code/modules/mob/living/silicon/robot/dogborg/dog_sleeper_vr.dm
@@ -90,13 +90,10 @@
 /obj/item/device/dogborg/sleeper/attack_self(mob/user)
 	if(..())
 		return
-	if(UI_open == 1) //At least some sort of way to stop the UI needlessly popping up on updates.
-		UI_open = 0
-		return
 	sleeperUI(user)
+	UI_open = 1
 
 /obj/item/device/dogborg/sleeper/proc/sleeperUI(mob/user)
-	UI_open = 1
 	var/dat
 	dat += "<h3>Injector</h3>"
 
@@ -184,6 +181,8 @@
 	//popup.set_title_image(user.browse_rsc_icon(icon, icon_state)) //I have no idea what this is, but it feels irrelevant and causes runtimes idk.
 	popup.set_content(dat)
 	popup.open()
+	onclose(user, "sleeper")
+	UI_open = 0
 	return
 
 /obj/item/device/dogborg/sleeper/Topic(href, href_list)

--- a/code/modules/mob/living/silicon/robot/dogborg/dog_sleeper_vr.dm
+++ b/code/modules/mob/living/silicon/robot/dogborg/dog_sleeper_vr.dm
@@ -15,6 +15,7 @@
 	var/list/injection_chems = list("dexalin", "bicaridine", "kelotane","anti_toxin", "alkysine", "imidazoline", "spaceacillin", "paracetamol") //The borg is able to heal every damage type. As a nerf, they use 750 charge per injection.
 	var/eject_port = "ingestion"
 	var/list/items_preserved = list()
+	var/UI_open = 0
 
 /obj/item/device/dogborg/sleeper/New()
 	..()
@@ -50,6 +51,8 @@
 			user.visible_message("<span class='warning'>[hound.name]'s medical pod lights up as [target.name] slips inside into their [src.name].</span>", "<span class='notice'>Your medical pod lights up as [target] slips into your [src]. Life support functions engaged.</span>")
 			message_admins("[key_name(hound)] has eaten [key_name(patient)] as a dogborg. ([hound ? "<a href='?_src_=holder;adminplayerobservecoodjump=1;X=[hound.x];Y=[hound.y];Z=[hound.z]'>JMP</a>" : "null"])")
 			playsound(hound, 'sound/vore/gulp.ogg', 100, 1) //POLARISTODO
+			if(UI_open == 1)
+				sleeperUI(usr)
 
 /obj/item/device/dogborg/sleeper/proc/go_out(var/target)
 	hound = src.loc
@@ -87,9 +90,13 @@
 /obj/item/device/dogborg/sleeper/attack_self(mob/user)
 	if(..())
 		return
+	if(UI_open == 1) //At least some sort of way to stop the UI needlessly popping up on updates.
+		UI_open = 0
+		return
 	sleeperUI(user)
 
 /obj/item/device/dogborg/sleeper/proc/sleeperUI(mob/user)
+	UI_open = 1
 	var/dat
 	dat += "<h3>Injector</h3>"
 
@@ -174,7 +181,7 @@
 	dat += "</div>"
 
 	var/datum/browser/popup = new(user, "sleeper", "Sleeper Console", 520, 540)	//Set up the popup browser window
-	popup.set_title_image(user.browse_rsc_icon(icon, icon_state))
+	//popup.set_title_image(user.browse_rsc_icon(icon, icon_state)) //I have no idea what this is, but it feels irrelevant and causes runtimes idk.
 	popup.set_content(dat)
 	popup.open()
 	return
@@ -292,6 +299,8 @@
 	patient_laststat = null
 	patient = null
 	hound.updateicon()
+	if(UI_open == 1)
+		sleeperUI(usr)
 	return
 
 //Gurgleborg process
@@ -390,6 +399,8 @@
 						T.drop_from_inventory(I, src)
 				qdel(T)
 				src.update_patient()
+				if(UI_open == 1)
+					sleeperUI(hound)
 
 		//Handle the target being anything but a /mob/living/carbon/human
 		else
@@ -438,6 +449,9 @@
 					contents -= T
 					qdel(T)
 					src.update_patient()
+				if(UI_open == 1)
+					sleeperUI(hound)
+
 		return
 
 /obj/item/device/dogborg/sleeper/process()
@@ -514,6 +528,8 @@
 			if(length(contents) > 11) //grow that tum after a certain junk amount
 				hound.sleeper_r = 1
 				hound.updateicon()
+			if(UI_open == 1)
+				sleeperUI(usr)
 		return
 
 	if(istype(target, /mob/living/simple_animal/mouse)) //Edible mice, dead or alive whatever. Mostly for carcass picking you cruel bastard :v
@@ -527,6 +543,8 @@
 			if(length(contents) > 11) //grow that tum after a certain junk amount
 				hound.sleeper_r = 1
 				hound.updateicon()
+			if(UI_open == 1)
+				sleeperUI(usr)
 		return
 
 	else if(ishuman(target))
@@ -547,6 +565,8 @@
 			playsound(hound, 'sound/vore/gulp.ogg', 80, 1)
 			hound.sleeper_r = 1
 			hound.updateicon()
+			if(UI_open == 1)
+				sleeperUI(usr)
 		return
 	return
 

--- a/code/modules/vore/eating/belly_vr.dm
+++ b/code/modules/vore/eating/belly_vr.dm
@@ -175,6 +175,9 @@
 
 	prey.forceMove(owner)
 	internal_contents |= prey
+	owner.updateVRPanel()
+	for(var/mob/living/M in internal_contents)
+		M.updateVRPanel()
 
 	if(inside_flavor)
 		prey << "<span class='notice'><B>[inside_flavor]</B></span>"
@@ -520,6 +523,9 @@
 	if(!silent)
 		for(var/mob/hearer in range(1,owner))
 			hearer << sound('sound/vore/squish2.ogg',volume=80)
+	owner.updateVRPanel()
+	for(var/mob/living/M in internal_contents)
+		M.updateVRPanel()
 
 // Belly copies and then returns the copy
 // Needs to be updated for any var changes

--- a/code/modules/vore/eating/bellymodes_vr.dm
+++ b/code/modules/vore/eating/bellymodes_vr.dm
@@ -84,6 +84,7 @@
 					owner.nutrition += offset*(10/difference) // 9.5 nutrition per digestion tick if they're 130 pounds and it's same size. 10.2 per digestion tick if they're 140 and it's same size. Etc etc.
 				else
 					owner.nutrition += (10/difference)
+			M.updateVRPanel()
 
 		if(digest_mode == DM_ITEMWEAK)
 			var/obj/item/T = pick(touchable_items)
@@ -189,6 +190,7 @@
 				else
 					return
 
+		owner.updateVRPanel()
 		return
 
 //////////////////////////// DM_STRIPDIGEST ////////////////////////////
@@ -262,6 +264,7 @@
 			//Pref protection!
 			if (!M.digestable || M.absorbed)
 				continue
+			M.updateVRPanel()
 			if(length(slots - checked_slots) < 1)
 				checked_slots.Cut()
 			var/validslot = pick(slots - checked_slots)
@@ -289,7 +292,7 @@
 				for(var/stashslot in stash)
 					var/obj/item/SL = M.get_equipped_item(stashslot)
 					if(SL)
-						SL.forceMove(owner)
+						M.remove_from_mob(SL,owner)
 						internal_contents += SL
 				M.remove_from_mob(I,owner)
 				internal_contents += I
@@ -299,6 +302,7 @@
 					M.remove_from_mob(I,owner)
 					internal_contents += I
 
+		owner.updateVRPanel()
 		return
 
 //////////////////////////// DM_ABSORB ////////////////////////////

--- a/code/modules/vore/eating/bellymodes_vr.dm
+++ b/code/modules/vore/eating/bellymodes_vr.dm
@@ -257,6 +257,8 @@
 						s_owner.cell.charge += (50 * T.w_class)
 					internal_contents -= T
 					qdel(T)
+				for(var/mob/living/carbon/human/M in internal_contents)
+					M.updateVRPanel()
 
 		for(var/mob/living/carbon/human/M in internal_contents)
 			if(!M)
@@ -264,7 +266,6 @@
 			//Pref protection!
 			if (!M.digestable || M.absorbed)
 				continue
-			M.updateVRPanel()
 			if(length(slots - checked_slots) < 1)
 				checked_slots.Cut()
 			var/validslot = pick(slots - checked_slots)
@@ -301,6 +302,7 @@
 				if(!(istype(I,/obj/item/organ) || istype(I,/obj/item/weapon/storage/internal) || istype(I,/obj/screen)))
 					M.remove_from_mob(I,owner)
 					internal_contents += I
+			M.updateVRPanel()
 
 		owner.updateVRPanel()
 		return

--- a/code/modules/vore/eating/living_vr.dm
+++ b/code/modules/vore/eating/living_vr.dm
@@ -13,6 +13,7 @@
 	var/metabolism = 0.0015
 	var/vore_taste = null				// What the character tastes like
 	var/no_vore = 0 					// If the character/mob can vore.
+	var/openpanel = 0					// Is the vore panel open?
 
 //
 // Hook for generic creation of stuff on new creatures

--- a/code/modules/vore/eating/vorepanel_vr.dm
+++ b/code/modules/vore/eating/vorepanel_vr.dm
@@ -21,6 +21,19 @@
 	picker_holder.popup = new(src, "insidePanel","Inside!", 400, 600, picker_holder)
 	picker_holder.popup.set_content(dat)
 	picker_holder.popup.open()
+	src.openpanel = 1
+
+/mob/living/proc/updateVRPanel() //Panel popup update call from belly évents.
+	if(src.openpanel == 1)
+		var/datum/vore_look/picker_holder = new()
+		picker_holder.loop = picker_holder
+		picker_holder.selected = vore_organs[vore_selected]
+
+		var/dat = picker_holder.gen_ui(src)
+
+		picker_holder.popup = new(src, "insidePanel","Inside!", 400, 600, picker_holder)
+		picker_holder.popup.set_content(dat)
+		picker_holder.popup.open()
 
 //
 // Callback Handler for the Inside form
@@ -253,6 +266,7 @@
 
 	if(href_list["close"])
 		qdel(src)  // Cleanup
+		user.openpanel = 0
 		return
 
 	if(href_list["show_int"])


### PR DESCRIPTION
-Vore panel now automatically refreshes when belly contents enter or leave.
-Updates only happen when the panel is open.
-Should also work from the prey's perspective.
-Borgo sleeper UI also does that now.
-Also attempts to fix the strip gurgles dumping uniform pockets on the floor.
-Hacky shit lmao but I need to pass out again like 2 hours ago so goodnight.