### PR TITLE
Yes I figured out the shuttle issue.

### DIFF
--- a/code/modules/shuttles/shuttle.dm
+++ b/code/modules/shuttles/shuttle.dm
@@ -83,7 +83,7 @@
 
 		if(process_longjump(departing, destination)) //VOREStation Edit - To hook custom shuttle code in
 			return //VOREStation Edit - It handled it for us (shuttle crash or such)
-		/*
+
 		var/last_progress_sound = 0
 		while (world.time < arrive_time)
 			// Make the shuttle make sounds every four seconds, since the sound file is five seconds.
@@ -91,7 +91,6 @@
 				make_sounds(interim, HYPERSPACE_PROGRESS)
 				last_progress_sound = world.time
 			sleep(5)
-		*/ //VOREStation Edit. Polaris code in this commented out part, but line 84 takes care of it as far as I cna see.
 
 		move(interim, destination, direction)
 		moving_status = SHUTTLE_IDLE


### PR DESCRIPTION
-No, the line 84 did not replace or relate to the timer part you commented out.
-Due to being a less relevant call, the code skipped the line 84 stuff, moving onto the next thing below, slapping the shuttle through instantly because of the timer having been commented out from inbetween.

To clarify, as far as I could figure out, the line 84 exists to handle the custom shuttle crashing event.
The proc stuff of the line pointing towards the shuttle crash event file (code/modules/shuttles/crashes.dm) which had nothing to do with the shuttle timer part.