### PR TITLE
Prevents multiple extend votes.

### DIFF
--- a/code/controllers/autotransfer.dm
+++ b/code/controllers/autotransfer.dm
@@ -3,6 +3,7 @@ var/datum/controller/transfer_controller/transfer_controller
 datum/controller/transfer_controller
 	var/timerbuffer = 0 //buffer for time check
 	var/currenttick = 0
+	var/shift_hard_end = vote_autotransfer_initial + vote_autotransfer_interval //VOREStation Edit
 datum/controller/transfer_controller/New()
 	timerbuffer = config.vote_autotransfer_initial
 	processing_objects += src
@@ -12,6 +13,11 @@ datum/controller/transfer_controller/Destroy()
 
 datum/controller/transfer_controller/proc/process()
 	currenttick = currenttick + 1
-	if (round_duration_in_ticks >= timerbuffer - 1 MINUTE)
+	if (round_duration_in_ticks >= shift_hard_end - 1 MINUTE)//VOREStation Edit START
+		init_shift_change(null, 1)
+		shift_hard_end = timerbuffer + config.vote_autotransfer_interval //If shuttle somehow gets recalled, let's do this.
+		timerbuffer = timerbuffer + config.vote_autotransfer_interval //Just to make sure a vote doesn't occur immediately afterwords.
+	else if (round_duration_in_ticks >= timerbuffer - 1 MINUTE) //VOREStation Edit END
 		vote.autotransfer()
 		timerbuffer = timerbuffer + config.vote_autotransfer_interval
+		

--- a/code/controllers/autotransfer.dm
+++ b/code/controllers/autotransfer.dm
@@ -3,9 +3,10 @@ var/datum/controller/transfer_controller/transfer_controller
 datum/controller/transfer_controller
 	var/timerbuffer = 0 //buffer for time check
 	var/currenttick = 0
-	var/shift_hard_end = vote_autotransfer_initial + vote_autotransfer_interval //VOREStation Edit
+	var/shift_hard_end = 0 //VOREStation Edit
 datum/controller/transfer_controller/New()
 	timerbuffer = config.vote_autotransfer_initial
+	shift_hard_end = config.vote_autotransfer_initial + config.vote_autotransfer_interval //VOREStation Edit
 	processing_objects += src
 
 datum/controller/transfer_controller/Destroy()
@@ -20,4 +21,3 @@ datum/controller/transfer_controller/proc/process()
 	else if (round_duration_in_ticks >= timerbuffer - 1 MINUTE) //VOREStation Edit END
 		vote.autotransfer()
 		timerbuffer = timerbuffer + config.vote_autotransfer_interval
-		

--- a/code/controllers/autotransfer.dm
+++ b/code/controllers/autotransfer.dm
@@ -21,4 +21,4 @@ datum/controller/transfer_controller/proc/process()
 	else if (round_duration_in_ticks >= timerbuffer - 1 MINUTE) //VOREStation Edit END
 		vote.autotransfer()
 		timerbuffer = timerbuffer + config.vote_autotransfer_interval
-		world << "Warning: If the extend vote passes, the round will not be extended again. Wrap up your scenes in the next 60 minutes if the vote succeeds."
+		world << "Warning: If the extend vote passes, the round will not be extended again. Wrap up your scenes in the next 60 minutes if the vote succeeds." //VOREStation Edit

--- a/code/controllers/autotransfer.dm
+++ b/code/controllers/autotransfer.dm
@@ -4,9 +4,11 @@ datum/controller/transfer_controller
 	var/timerbuffer = 0 //buffer for time check
 	var/currenttick = 0
 	var/shift_hard_end = 0 //VOREStation Edit
+	var/shift_last_vote = 0 //VOREStation Edit
 datum/controller/transfer_controller/New()
 	timerbuffer = config.vote_autotransfer_initial
-	shift_hard_end = config.vote_autotransfer_initial + config.vote_autotransfer_interval //VOREStation Edit
+	shift_hard_end = config.vote_autotransfer_initial + (config.vote_autotransfer_interval * 1) //VOREStation Edit //Change this "1" to how many extend votes you want there to be.
+	shift_last_vote = shift_hard_end - config.vote_autotransfer_interval
 	processing_objects += src
 
 datum/controller/transfer_controller/Destroy()
@@ -14,11 +16,13 @@ datum/controller/transfer_controller/Destroy()
 
 datum/controller/transfer_controller/proc/process()
 	currenttick = currenttick + 1
-	if (round_duration_in_ticks >= shift_hard_end - 1 MINUTE)//VOREStation Edit START
+	if (round_duration_in_ticks >= shift_last_vote - 2 MINUTES) //VOREStation Edit START
+		shift_last_vote = 999999999999 //Setting to a stupidly high number since it'll be not used again.
+		world << "Warning: This upcoming extend vote will be your LAST extend vote. Wrap up your scenes in the next 60 minutes if the vote succeeds." //VOREStation Edit
+	if (round_duration_in_ticks >= shift_hard_end - 1 MINUTE)
 		init_shift_change(null, 1)
-		shift_hard_end = timerbuffer + config.vote_autotransfer_interval //If shuttle somehow gets recalled, let's do this.
+		shift_hard_end = timerbuffer + config.vote_autotransfer_interval //If shuttle somehow gets recalled, let's force it to call again next time a vote would occur.
 		timerbuffer = timerbuffer + config.vote_autotransfer_interval //Just to make sure a vote doesn't occur immediately afterwords.
 	else if (round_duration_in_ticks >= timerbuffer - 1 MINUTE) //VOREStation Edit END
 		vote.autotransfer()
 		timerbuffer = timerbuffer + config.vote_autotransfer_interval
-		world << "Warning: If the extend vote passes, the round will not be extended again. Wrap up your scenes in the next 60 minutes if the vote succeeds." //VOREStation Edit

--- a/code/controllers/autotransfer.dm
+++ b/code/controllers/autotransfer.dm
@@ -21,3 +21,4 @@ datum/controller/transfer_controller/proc/process()
 	else if (round_duration_in_ticks >= timerbuffer - 1 MINUTE) //VOREStation Edit END
 		vote.autotransfer()
 		timerbuffer = timerbuffer + config.vote_autotransfer_interval
+		world << "Warning: If the extend vote passes, the round will not be extended again. Wrap up your scenes in the next 60 minutes if the vote succeeds."

--- a/code/controllers/autotransfer.dm
+++ b/code/controllers/autotransfer.dm
@@ -8,7 +8,7 @@ datum/controller/transfer_controller
 datum/controller/transfer_controller/New()
 	timerbuffer = config.vote_autotransfer_initial
 	shift_hard_end = config.vote_autotransfer_initial + (config.vote_autotransfer_interval * 1) //VOREStation Edit //Change this "1" to how many extend votes you want there to be.
-	shift_last_vote = shift_hard_end - config.vote_autotransfer_interval
+	shift_last_vote = shift_hard_end - config.vote_autotransfer_interval //VOREStation Edit
 	processing_objects += src
 
 datum/controller/transfer_controller/Destroy()


### PR DESCRIPTION
Have you ever looked at the manifest, saw "6:26" and thought "Oh! Well, it's been extended once, so I'll wait for next round..." and then coming back a few minutes later and seeing it at "6:40" and knowing that the round was voted to be extended _again_?

It is absolutely awful, and annoying. Shifts shouldn't have the possibility to go on _forever._ 
Having a hard-cap of one extend vote max (Or however many the server sets it to. One in this case.) makes it easier for people to plan when the next round is going to be so they don't constantly go "Alright, I'll join after this round since it has 40 minutes left." Now an extra hour. And another. And so on. 

I tested a simplified version of it (Setting the timer to 10 minutes) on a test server and it autocalled the shuttle when the timer was reached, so I'm confident this will work as planned.