### PR TITLE
More z-hole backup backup checks for non-turf junk

### DIFF
--- a/code/modules/multiz/movement.dm
+++ b/code/modules/multiz/movement.dm
@@ -193,6 +193,8 @@
 
 // Check if this atom prevents things standing on it from falling. Return TRUE to allow the fall.
 /obj/proc/CanFallThru(atom/movable/mover as mob|obj, turf/target as turf)
+	if(!isturf(mover.loc)) // VORESTATION EDIT. We clearly didn't have enough backup checks.
+		return FALSE //If this ain't working Ima be pissed.
 	return TRUE
 
 // Things that prevent objects standing on them from falling into turf below


### PR DESCRIPTION
To maybe finally make sure only on-turf objects may fall down.
Onsite edit because fuck this. I had it fixed and working before.
NO BAD Z-HOLE. NO EATING SHIT OFF HANDS AND FOLKS YOU BAD. ONLY FLOOR FOOD FOR YOU