### PR TITLE
Medical Borgs Assorted Fixes

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -155,7 +155,7 @@ var/global/list/robot_modules = list(
 	src.modules += new /obj/item/device/flash(src)
 	src.modules += new /obj/item/weapon/crowbar/cyborg(src)
 	src.modules += new /obj/item/weapon/extinguisher(src)
-	vr_new() // For modules in robot_modules_vr.dm
+	vr_new() // Vorestation Edit: For modules in robot_modules_vr.dm
 
 /obj/item/weapon/robot_module/robot/standard
 	name = "standard robot module"

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -155,6 +155,7 @@ var/global/list/robot_modules = list(
 	src.modules += new /obj/item/device/flash(src)
 	src.modules += new /obj/item/weapon/crowbar/cyborg(src)
 	src.modules += new /obj/item/weapon/extinguisher(src)
+	vr_new() // For modules in robot_modules_vr.dm
 
 /obj/item/weapon/robot_module/robot/standard
 	name = "standard robot module"

--- a/code/modules/mob/living/silicon/robot/robot_modules_vr.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules_vr.dm
@@ -5,6 +5,17 @@
 	robot_modules["Janihound"] = /obj/item/weapon/robot_module/scrubpup
 	return 1
 
+//Just add a new proc with the robot_module type if you wish to run some other vore code
+/obj/item/weapon/robot_module/proc/vr_new() // Any Global modules, just add them before the return (This will also affect all the borgs in this file)
+	return
+
+/obj/item/weapon/robot_module/robot/medical/surgeon/vr_new() //Surgeon Bot
+	src.modules += new /obj/item/device/sleevemate(src) //Lets them scan people.
+	. = ..() //Any Global vore modules will come from here
+
+/obj/item/weapon/robot_module/robot/medical/crisis/vr_new() //Crisis Bot
+	src.modules += new /obj/item/device/sleevemate(src) //Lets them scan people.
+	. = ..() //Any Global vore modules will come from here
 
 /obj/item/weapon/robot_module/knine
 	name = "k9 robot module"
@@ -82,12 +93,6 @@
 	R.pixel_x 	 = -16
 	R.old_x  	 = -16
 	..()
-
-/obj/item/weapon/robot_module/robot/medical/surgeon/New()
-	src.modules += new /obj/item/device/sleevemate(src) //Lets them scan people.
-
-/obj/item/weapon/robot_module/robot/medical/crisis/New()
-	src.modules += new /obj/item/device/sleevemate(src) //Lets them scan people.
 
 /obj/item/weapon/robot_module/ert
 	name = "Emergency Responce module"

--- a/code/modules/mob/living/silicon/robot/robot_modules_vr.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules_vr.dm
@@ -69,6 +69,7 @@
 	name = "MediHound module"
 	channels = list("Medical" = 1)
 	networks = list(NETWORK_MEDICAL)
+	subsystems = list(/mob/living/silicon/proc/subsystem_crew_monitor)
 	can_be_pushed = 0
 	sprites = list(
 					"Medical Hound" = "medihound",


### PR DESCRIPTION
Fixes #1443 
And also amends the god-awful OVERWRITING that #1994 did.
Gah.

So Crisis Borgs, and Surgeon Borgs, are now selectable again
and Medihounds now have the Crew Monitor like every other medical borg.


If a changelog is needed lemme know.
![image](https://user-images.githubusercontent.com/14105827/29802979-f0134826-8ccc-11e7-9965-855594b33502.png)
