### PR TITLE
Reduces log spam from simple_animals

### DIFF
--- a/code/modules/vore/eating/simple_animal_vr.dm
+++ b/code/modules/vore/eating/simple_animal_vr.dm
@@ -43,3 +43,35 @@
 		var/confirm = alert(user, "This mob is currently set to digest all stomach contents. Do you want to disable this?", "Disabling [name]'s Digestion", "Disable", "Cancel")
 		if(confirm == "Disable")
 			B.digest_mode = "Hold"
+
+/mob/living/simple_animal/proc/away_from_players()
+	//Reduces the amount of logging spam by only allowing procs to continue if they have a player nearby to listen.
+	//A return of 0 means that it is not away from players.
+	// This is a stripped down version of the proc get_mobs_and_objs_in_view_fast()
+	var/turf/T = get_turf(src)
+	if(!T) return 1 // If the turf doesn't exist, we don't want the proc running regardless
+
+	// Quickly grabs the mob's hearing range to check from
+	var/list/hear = dview(world.view,T,INVISIBILITY_MAXIMUM)
+	var/list/hearturfs = list()
+	for(var/thing in hear)
+		if(istype(thing,/mob))
+			hearturfs += get_turf(thing)
+
+	//Check each player to see if they're inside said 'hearing range' turfs
+	for(var/mob in player_list)
+		if(!istype(mob, /mob))
+			crash_with("There is a null or non-mob reference inside player_list.")
+			continue
+		if(get_turf(mob) in hearturfs)
+			return 0
+	return 1
+
+
+mob/living/simple_animal/custom_emote()
+	if (away_from_players()) return
+	. = ..()
+
+mob/living/simple_animal/say()
+	if (away_from_players()) return
+	. = ..()


### PR DESCRIPTION
Fixes #1907 

This just adds a small check to see if the animals can actually see any players before emoting.
This way the log spam should not occur anymore. I have tested under 40 minutes of no simple mob spam.
There were no log entries that were EMOTE or SAY between those times. (That weren't my own) First line is Renaults last emote (From setting the speak_chance var to 200)

Best part is, no outside edits, so... go me?

![image](https://user-images.githubusercontent.com/14105827/29905534-640aacc8-8e63-11e7-8f87-77fe948fc974.png)
