### PR TITLE
Removes whitelist requirements from Daemon and Enochian

### DIFF
--- a/code/modules/mob/language/station_vr.dm
+++ b/code/modules/mob/language/station_vr.dm
@@ -55,7 +55,6 @@
 	exclaim_verb = "incants"
 	colour = "daemon" //So fancy
 	key = "n"
-	flags = WHITELISTED
 	syllables = list("viepn","e","bag","docu","kar","xlaqf","raa","qwos","nen","ty","von","kytaf","xin","ty","ka","baak","hlafaifpyk","znu","agrith","na'ar","uah","plhu","six","fhler","bjel","scee","lleri",
 	"dttm","aggr","uujl","hjjifr","wwuthaav",)
 
@@ -67,7 +66,6 @@
 	exclaim_verb = "loudly sings"
 	colour = "enochian" //So fancy
 	key = "a"
-	flags = WHITELISTED
 	syllables = list("salve","sum","loqui","operatur","iusta","et","permittit","facere","effercio","pluribus","enim","hoc",
 	"mihi","wan","six","salve","tartu")
 


### PR DESCRIPTION
The whitelist existing currently does nothing more than hinder RP.

- The process of both getting approved for, and then added to the whitelist is tedious, to say the least. Especially for something that is actually rather small.
- So few people are whitelisted for the languages that there is nobody to talk to if you have them.
- As such, few people desire to gain the whitelist.
- Both Table and I believe the whitelist should not exist.