### PR TITLE
Fixes mouse spawners

### DIFF
--- a/code/game/objects/mob_spawner_vr.dm
+++ b/code/game/objects/mob_spawner_vr.dm
@@ -22,7 +22,7 @@
 
 	var/list/spawned_mobs = list()
 
-/obj/structure/mob_spawner/initialize()
+/obj/structure/mob_spawner/New()
 	..()
 	processing_objects.Add(src)
 	last_spawn = world.time + rand(0,spawn_delay)

--- a/code/game/objects/structures/trash_pile.dm
+++ b/code/game/objects/structures/trash_pile.dm
@@ -268,9 +268,11 @@
 	spawn_types = list(/mob/living/simple_animal/mouse)
 	simultaneous_spawns = 1
 	destructible = 1
+	spawn_delay = 1 HOUR
 
-/obj/structure/mob_spawner/mouse_nest/initialize()
+/obj/structure/mob_spawner/mouse_nest/New()
 	..()
+	last_spawn = rand(world.time - spawn_delay, world.time)
 	icon_state = pick(
 		"pile1",
 		"pile2",
@@ -288,3 +290,7 @@
 	. = ..()
 	var/atom/A = get_holder_at_turf_level(src)
 	A.visible_message("[.] crawls out of \the [src].")
+
+/obj/structure/mob_spawner/mouse_nest/get_death_report(var/mob/living/L)
+	..()
+	last_spawn = rand(world.time - spawn_delay, world.time)


### PR DESCRIPTION
For some reason initialize doesn't fire for most of them? New seems to work consistantly though.
Also increases the spawn delay and prevents mice from instantly spawning after being killed.