### PR TITLE
Fixes oxygen tank pressure

### DIFF
--- a/maps/tether/tether-01-surface.dmm
+++ b/maps/tether/tether-01-surface.dmm
@@ -3311,7 +3311,7 @@
 "blI" = (/obj/machinery/atmospherics/pipe/simple/heat_exchanging{dir = 5},/turf/simulated/floor/tiled/steel_dirty/virgo3b,/area/engineering/atmos/intake)
 "blJ" = (/obj/effect/floor_decal/techfloor{dir = 8},/obj/machinery/atmospherics/pipe/cap/visible{tag = "icon-cap (NORTH)"; icon_state = "cap"; dir = 1},/turf/simulated/floor/tiled/techfloor,/area/engineering/atmos)
 "blK" = (/obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction{dir = 8},/turf/simulated/floor/tiled/steel_dirty/virgo3b,/area/engineering/atmos/intake)
-"blL" = (/obj/machinery/atmospherics/pipe/tank/oxygen{dir = 1; start_pressure = 2533.13},/obj/effect/floor_decal/industrial/outline/yellow,/turf/simulated/floor/tiled/steel_dirty,/area/engineering/atmos)
+"blL" = (/obj/machinery/atmospherics/pipe/tank/oxygen{dir = 1},/obj/effect/floor_decal/industrial/outline/yellow,/turf/simulated/floor/tiled/steel_dirty,/area/engineering/atmos)
 "blM" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 10},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 10},/turf/simulated/floor/tiled/techfloor,/area/engineering/atmos)
 "blN" = (/obj/effect/floor_decal/techfloor{dir = 8},/obj/machinery/atmospherics/pipe/manifold4w/visible/black,/obj/machinery/meter,/turf/simulated/floor/tiled/techfloor,/area/engineering/atmos/processing)
 "blO" = (/obj/machinery/atmospherics/pipe/simple/visible/black{dir = 4},/obj/machinery/door/firedoor,/obj/structure/grille,/obj/structure/window/reinforced{dir = 5; icon_state = "fwindow"},/turf/simulated/floor/plating,/area/engineering/atmos/processing)


### PR DESCRIPTION
Early in my atmos revamp, I lowered the pressure in atmos' oxygen reserve to better match the nitrogen stores. And then I made the nitrogen reserve bigger, and the pull got merged before I could reset the oxygen to match it. Oops. This fixes that. I'm done with that map file now, honest.