### PR TITLE
Boosts air alarm thermostats

### DIFF
--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -39,7 +39,8 @@
 	anchored = 1
 	use_power = 1
 	idle_power_usage = 80
-	active_power_usage = 1000 //For heating/cooling rooms. 1000 joules equates to about 1 degree every 2 seconds for a single tile of air.
+	//active_power_usage = 1000 //For heating/cooling rooms. 1000 joules equates to about 1 degree every 2 seconds for a single tile of air.
+	active_power_usage = 15000 //Vorestation edit
 	power_channel = ENVIRON
 	req_one_access = list(access_atmospherics, access_engine_equip)
 	var/alarm_id = null


### PR DESCRIPTION
So, air alarms are our only thermal control that doesn't rely on replacing air or handheld power cells. Problem is, they suck. Buuuuut apparently this variable actually lets me change that. It can even be overriden by mappers/admins to make specific air alarms *even more effective*. Worth a shot, I think.