### PR TITLE
A miniscule fluff item fix too small to deserve a PR but gets one anyway

### DIFF
--- a/code/modules/vore/fluffstuff/custom_items_vr.dm
+++ b/code/modules/vore/fluffstuff/custom_items_vr.dm
@@ -989,7 +989,7 @@ obj/item/weapon/material/hatchet/tacknife/combatknife/fluff/katarina/handle_shie
 	..()
 
 //verkister: Cameron Eggbert - Science goggles that ACTUALLY do nothing.
-/obj/item/clothing/glasses/science_proper
+/obj/item/clothing/glasses/fluff/science_proper
 	name = "Aesthetic Science Goggles"
 	desc = "The goggles really do nothing this time!"
 	icon_state = "purple"
@@ -997,7 +997,7 @@ obj/item/weapon/material/hatchet/tacknife/combatknife/fluff/katarina/handle_shie
 	item_flags = AIRTIGHT
 
 //verkister: Opie Eggbert - Spiffy fluff goggles
-/obj/item/clothing/glasses/spiffygogs
+/obj/item/clothing/glasses/fluff/spiffygogs
 	name = "Chad Goggles"
 	desc = "You can almost feel the raw power radiating off these strange specs."
 	icon = 'icons/vore/custom_items_vr.dmi'

--- a/code/modules/vore/fluffstuff/custom_items_vr.dm
+++ b/code/modules/vore/fluffstuff/custom_items_vr.dm
@@ -1003,6 +1003,7 @@ obj/item/weapon/material/hatchet/tacknife/combatknife/fluff/katarina/handle_shie
 	icon = 'icons/vore/custom_items_vr.dmi'
 	icon_override = 'icons/vore/custom_clothes_vr.dmi'
 	icon_state = "spiffygogs"
+	slot_flags = SLOT_EYES | SLOT_EARS
 	item_state_slots = list(slot_r_hand_str = "glasses", slot_l_hand_str = "glasses")
 	toggleable = 1
 	off_state = "spiffygogsup"

--- a/config/custom_items.txt
+++ b/config/custom_items.txt
@@ -614,7 +614,7 @@ item_path: /obj/item/clothing/head/fluff/runac
 {
 ckey: verkister
 character_name: Cameron Eggbert
-item_path: /obj/item/clothing/glasses/science_proper
+item_path: /obj/item/clothing/glasses/fluff/science_proper
 }
 {
 ckey: verkister
@@ -624,7 +624,7 @@ item_path: /obj/item/weapon/disk/limb/eggnerdltd
 {
 ckey: verkister
 character_name: Opie Eggbert
-item_path: /obj/item/clothing/glasses/spiffygogs
+item_path: /obj/item/clothing/glasses/fluff/spiffygogs
 }
 {
 ckey: virgo113


### PR DESCRIPTION
-Makes the recent purely cosmetic fluff goggles able to be worn additionally on the extra ear slot and thus not be completely hidden by the character's hairstyle in the "up" state.
-Also fixes my fluff stuffs missing some directory fluff. I ain't fixing this for other people's stuffs this time tho.