### PR TITLE
Adds nom-on-bump behaviour

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -92,12 +92,6 @@ default behaviour is:
 				var/turf/oldloc = loc
 				forceMove(tmob.loc)
 
-				// VOREStation Edit - Begin
-				// In case of micros, we don't swap positions; instead occupying the same square!
-				if (handle_micro_bump_helping(tmob)) return
-				// TODO - Check if we need to do something about the slime.UpdateFeed() we are skipping below.
-				// VOREStation Edit - End
-
 				//VOREstation Edit - Begin
 				if (istype(tmob, /mob/living/simple_animal)) //check bumpnom chance, if it's a simplemob that's bumped
 					tmob.Bumped(src)
@@ -107,10 +101,12 @@ default behaviour is:
 					now_pushing = 0
 					return
 
-				//VOREstation Edit - End
+				// In case of micros, we don't swap positions; instead occupying the same square!
+				if (handle_micro_bump_helping(tmob)) return
+				// TODO - Check if we need to do something about the slime.UpdateFeed() we are skipping below.
+				// VOREStation Edit - End
 
 				tmob.forceMove(oldloc)
-
 				now_pushing = 0
 				return
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -98,7 +98,19 @@ default behaviour is:
 				// TODO - Check if we need to do something about the slime.UpdateFeed() we are skipping below.
 				// VOREStation Edit - End
 
+				//VOREstation Edit - Begin
+				if (istype(tmob, /mob/living/simple_animal)) //check bumpnom chance, if it's a simplemob that's bumped
+					tmob.Bumped(src)
+				else if(istype(src, /mob/living/simple_animal)) //otherwise, if it's a simplemob doing the bumping. Simplemob on simplemob doesn't seem to trigger but that's fine.
+					Bumped(tmob)
+				if (tmob.loc == src) //check if they got ate, and if so skip the forcemove
+					now_pushing = 0
+					return
+
+				//VOREstation Edit - End
+
 				tmob.forceMove(oldloc)
+
 				now_pushing = 0
 				return
 

--- a/code/modules/mob/living/simple_animal/simple_animal_vr.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal_vr.dm
@@ -9,6 +9,8 @@
 	var/vore_capacity = 1				// The capacity (in people) this person can hold
 	var/vore_max_size = RESIZE_HUGE		// The max size this mob will consider eating
 	var/vore_min_size = RESIZE_TINY 	// The min size this mob will consider eating
+	var/vore_bump_chance = 0			// Chance of trying to eat anyone that bumps into them, regardless of hostility
+	var/vore_bump_emote	= "grabs hold of"				// Allow messages for bumpnom mobs to have a flavorful bumpnom
 	var/vore_pounce_chance = 5			// Chance of this mob knocking down an opponent
 	var/vore_standing_too = 0			// Can also eat non-stunned mobs
 	var/vore_ignores_undigestable = 1	// Refuse to eat mobs who are undigestable by the prefs toggle.
@@ -171,3 +173,15 @@
 	src.vore_organs[B.name] = B
 	src.vore_selected = B.name
 
+/mob/living/simple_animal/Bumped(var/atom/movable/AM, yes)
+	if(ismob(AM))
+		var/mob/tmob = AM
+		if(will_eat(tmob) && !istype(tmob, type) && prob(vore_bump_chance)) //check if they decide to eat. Includes sanity check to prevent cannibalism.
+			if(tmob.canmove && prob(vore_pounce_chance)) //if they'd pounce for other noms, pounce for these too, otherwise still try and eat them if they hold still
+				tmob.Weaken(5)
+			tmob.visible_message("<span class='danger'>\the [src] [vore_bump_emote] \the [tmob]!</span>!")
+			stop_automated_movement = 1
+			animal_nom(tmob)
+			update_icon()
+			stop_automated_movement = 0
+	..()

--- a/code/modules/mob/living/simple_animal/simple_animal_vr.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal_vr.dm
@@ -176,7 +176,7 @@
 /mob/living/simple_animal/Bumped(var/atom/movable/AM, yes)
 	if(ismob(AM))
 		var/mob/tmob = AM
-		if(will_eat(tmob) && !istype(tmob, type) && prob(vore_bump_chance)) //check if they decide to eat. Includes sanity check to prevent cannibalism.
+		if(will_eat(tmob) && !istype(tmob, type) && prob(vore_bump_chance) && !ckey) //check if they decide to eat. Includes sanity check to prevent cannibalism.
 			if(tmob.canmove && prob(vore_pounce_chance)) //if they'd pounce for other noms, pounce for these too, otherwise still try and eat them if they hold still
 				tmob.Weaken(5)
 			tmob.visible_message("<span class='danger'>\the [src] [vore_bump_emote] \the [tmob]!</span>!")

--- a/code/modules/mob/living/simple_animal/vore/catgirl.dm
+++ b/code/modules/mob/living/simple_animal/vore/catgirl.dm
@@ -48,6 +48,7 @@
 // Activate Noms!
 /mob/living/simple_animal/catgirl
 	vore_active = 1
+	vore_bump_chance = 5
 	vore_pounce_chance = 50
 	vore_standing_too = 1
 	vore_ignores_undigestable = 0 // Catgirls just want to eat yoouuu

--- a/code/modules/mob/living/simple_animal/vore/gaslamp.dm
+++ b/code/modules/mob/living/simple_animal/vore/gaslamp.dm
@@ -53,7 +53,10 @@ TODO: Make them light up and heat the air when exposed to oxygen.
 /mob/living/simple_animal/retaliate/gaslamp
 	vore_active = 1
 	vore_capacity = 2
+	vore_bump_chance = 90 //they're frickin' jellyfish anenome filterfeeders, get tentacled
+	vore_bump_emote = "lazily wraps its tentacles around"
 	vore_standing_too = 1 // Defaults to trying to give you that big tentacle hug.
+	vore_ignores_undigestable = 0 // they absorb rather than digest, you're going in either way
 	vore_default_mode = DM_HOLD
 	vore_digest_chance = 0			// Chance to switch to digest mode if resisted
 	vore_absorb_chance = 20			// BECOME A PART OF ME.

--- a/code/modules/mob/living/simple_animal/vore/wah.dm
+++ b/code/modules/mob/living/simple_animal/vore/wah.dm
@@ -30,7 +30,10 @@
 // Activate Noms!
 /mob/living/simple_animal/wah
 	vore_active = 1
+	vore_bump_chance = 10
+	vore_bump_emote	= "playfully lunges at"
 	vore_pounce_chance = 40
+	vore_default_mode = DM_HOLD // above will only matter if someone toggles it anyway
 	vore_icons = SA_ICON_LIVING
 
 /mob/living/simple_animal/wah/fae
@@ -42,6 +45,10 @@
 	icon_dead = "wah_fae_dead"
 	icon_rest = "wah_fae_rest"
 
+	vore_ignores_undigestable = 0	// wah don't care you're edible or not, you still go in
+	vore_digest_chance = 0			// instead of digesting if you struggle...
+	vore_absorb_chance = 20			// you get to become adorable purple wahpudge.
+	vore_bump_chance = 75
 	maxHealth = 100
 	health = 100
 	melee_damage_lower = 10


### PR DESCRIPTION
Adds a new behaviour to certain simplemobs, giving them a chance of deciding to gobble people up that bump into them regardless of hostility.

This bumpnom behaviour will respect the usual checks like ignoring indigestible people and not eating when full. It _does_ bypass the check for whether it can eat standing people, but assuming it doesn't also pounce you to the floor (with the same chances as it has in combat) you can just move away to avoid it. If you stand still while a wah's casually stuffing you in its mouth you deserve to get ate.

The proc will only trigger in situations where you bump it on non-help intents, or where you would normally swap places. If you decide to go AFK in a room with a catgirl or a gaslamp, buckle in. Likewise, people who are resting or otherwise  have canmove==false won't trigger this, so SSD people _should_ be safe.

Simplemobs don't seem to trigger this against each other (seriously, I filled a room with them bumping into each other all over the place, debug messages everywhere, nothing) so there's no worry about a petting zoo turning into that scene in futurama where they introduce Nibbler. There's an anti-cannibalism check to make sure they won't eat mobs that share a type anyway.

If a mob _does_ try to eat you when you bump it, you'll end up on the same tile rather than swapping. This is because swapping looked really fucky, especially when they pounced and your prone body went sliding across the floor as they moved into your old tile, before getting grabbed back to where you were. (only damper)