### PR TITLE
Removed stupid titles from Clown and Mime

### DIFF
--- a/code/game/jobs/job/special.dm
+++ b/code/game/jobs/job/special.dm
@@ -1,5 +1,5 @@
 /datum/job/centcom_officer //For Business
-	title = "Centcom Officer"
+	title = "CentCom Officer"
 	department = "Command"
 	head_position = 1
 	faction = "Station"
@@ -41,7 +41,7 @@
 		return access
 
 /datum/job/centcom_visitor //For Pleasure
-	title = "Centcom Visitor"
+	title = "CentCom Visitor"
 	department = "Civilian"
 	head_position = 1
 	faction = "Station"
@@ -95,7 +95,7 @@
 	economic_modifier = 1
 	access = list()
 	minimal_access = list()
-	alt_titles = list("Fun Mage","Happiness Witch","Joy Summoner","Asshole")
+	alt_titles = list("Comedian","Jester")
 	whitelist_only = 1
 	latejoin_only = 1
 
@@ -133,7 +133,7 @@
 	economic_modifier = 1
 	access = list()
 	minimal_access = list()
-	alt_titles = list("Silent One","The Performer","Kabuki","Asshole")
+	alt_titles = list("Performer","Interpretive Dancer")
 	whitelist_only = 1
 	latejoin_only = 1
 


### PR DESCRIPTION
Clown and Mime are memey enough. We need to keep _some_ semblance of immersion.

Also fixed CentCom capitalization while I was at it.