### PR TITLE
Makes neutral traits not take trait slots

### DIFF
--- a/code/modules/client/preference_setup/vore/07_traits.dm
+++ b/code/modules/client/preference_setup/vore/07_traits.dm
@@ -97,7 +97,7 @@
 
 		var/points_left = pref.starting_trait_points
 		var/traits_left = pref.max_traits
-		for(var/T in pref.pos_traits + pref.neu_traits + pref.neg_traits)
+		for(var/T in pref.pos_traits + pref.neg_traits)
 			points_left -= traits_costs[T]
 			traits_left--
 
@@ -217,7 +217,7 @@
 		for(var/T in pref.pos_traits + pref.neu_traits + pref.neg_traits)
 			points_left -= traits_costs[T]
 
-		var/traits_left = pref.max_traits - (pref.pos_traits.len + pref.neg_traits.len + pref.neu_traits.len)
+		var/traits_left = pref.max_traits - (pref.pos_traits.len + pref.neg_traits.len)
 
 		var/trait_choice
 		var/done = FALSE


### PR DESCRIPTION
- Makes neutral traits not take up trait slots.

There was virtually 0 reason in game to take something like coldblooded, autohiss, increased metabolism, bloodsucker trait, etc due to its small impact on gameplay when you could take positive+negative traits and actually see a difference.

This change encourages users to actually choose neutral traits, as they're neutral and shouldn't take up slots when they do barely anything to gameplay.