### PR TITLE
updates grub-food

### DIFF
--- a/code/modules/reagents/reagent_containers/food/snacks_vr.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks_vr.dm
@@ -208,6 +208,8 @@
 	desc = "A hard chitin, dont chip a tooth!"
 	icon = 'icons/obj/food_vr.dmi'
 	icon_state = "pillbugball"
+	slice_path = /obj/item/weapon/reagent_containers/food/snacks/pillbug
+	slices_num = 1
 	trash = /obj/item/weapon/reagent_containers/food/snacks/pillbug
 	nutriment_amt = 1
 	nutriment_desc = list("crunchy shell bits" = 5)


### PR DESCRIPTION
Makes it so you can slice the bugball food item as intended, so you can decontaminate it before serving.

(previously the bugball had to be decontaminated, bitten open, then decontaminated again to avoid poison)