### PR TITLE
Fixes neutral traits taking up slots on spawn.

### DIFF
--- a/code/modules/mob/new_player/new_player_vr.dm
+++ b/code/modules/mob/new_player/new_player_vr.dm
@@ -29,8 +29,10 @@
 		var/points_left = client.prefs.starting_trait_points
 		var/traits_left = client.prefs.max_traits
 		for(var/T in megalist)
-			traits_left--
 			var/cost = traits_costs[T]
+
+			if(cost)
+				traits_left--
 
 			//A trait was removed from the game
 			if(isnull(cost))


### PR DESCRIPTION
This seems like something that should have been caught in testing.
You _did_ test this, right?

Fixes #2258