### PR TITLE
Readds reaction for slime jelly to purple slime

### DIFF
--- a/code/modules/xenobio/items/extracts.dm
+++ b/code/modules/xenobio/items/extracts.dm
@@ -289,7 +289,7 @@
 	name = "purple slime extract"
 	icon_state = "purple slime extract"
 	description_info = "This extract can create a slime steroid agent when injected with phoron, which increases the amount of slime extracts the processor \
-	can extract from a slime specimen."
+	can extract from a slime specimen. The extract can also create a strange, morphic toxic jelly if injected with sugar."
 
 
 /datum/chemical_reaction/slime/purple_steroid
@@ -302,6 +302,16 @@
 /datum/chemical_reaction/slime/purple_steroid/on_reaction(var/datum/reagents/holder)
 	new /obj/item/slimepotion/steroid(get_turf(holder.my_atom))
 	..()
+
+//This is half of what TG gives players, but considering the things our jelly does, this is fair.
+/datum/chemical_reaction/slime/purple_jelly
+	name = "Slime Jam"
+	id = "m_jelly_harvest"
+	result = "slimejelly"
+	required_reagents = list("sugar" = 5)
+	result_amount = 5
+	required = /obj/item/slime_extract/purple
+
 
 
 // *****************


### PR DESCRIPTION
I KNEW something felt like it was missing! 

This readds the ability to get slime jelly from actual slimes, instead of only being able to make it from phoron and craptons of reagents. 

TG's version of the reaction pays out 10 slime jelly, but considering what ours can do, I nerfed it to 5u per extract reaction.

The reason for picking 5u is twofold: Xenobio2 used to give you the same amount per slime core you blended, and making 5u in the lab would require 20u phoron, which is a full sheet's worth. 

Hopefully overall we'll start to see slime jelly and its various reactions start to become viable again, but if this is still too little for things, we may want to increase the payout up to 10, since purples have other, arguably better uses and of course tend to mutate into other colors instead of staying purple, thus making it hard to get a lot of extracts in the first place. 