### PR TITLE
Disables spider infestations.

### DIFF
--- a/code/modules/events/infestation.dm
+++ b/code/modules/events/infestation.dm
@@ -72,6 +72,7 @@
 			spawn_types = list(/mob/living/simple_animal/lizard)
 			max_number = 6
 			vermstring = "lizards"
+/*
 		if(VERM_SPIDERS)
 			spawn_types = list(/obj/effect/spider/spiderling)
 			max_number = 3
@@ -91,6 +92,7 @@
 				var/spawn_type = pick(spawn_types)
 				new spawn_type(T)
 
+*/
 
 /datum/event/infestation/announce()
 	command_announcement.Announce("Bioscans indicate that [vermstring] have been breeding in [locstring]. Clear them out, before this starts to affect productivity.", "Vermin infestation")


### PR DESCRIPTION
Seeing as these spiderlings, which have S.amount_grown = -1 are still able to grow into mature spiders, whilst their code suggests they would spawn as duds, hence never be able to form into dangerous spiders that attack people on sight. Seems to only be a 50% chance a spiderling grows up, doesn't remove the danger.