### PR TITLE
Disables electrocute_act on borgs.

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_vr.dm
+++ b/code/modules/mob/living/silicon/robot/robot_vr.dm
@@ -49,3 +49,6 @@
 							cleaned_human << "<span class='warning'>[src] cleans your face!</span>"//Again travis what the fuck? You and your random unrelated bugs.
 		return
 	return
+
+/mob/living/silicon/robot/electrocute_act() // See living_defense.dm line 157, silicon.dm line 84, and ..robot/life.dm line 31
+	return // Something was overlooked preetty badly under the assumption of stun stack capping being obsolete for borgs. Example in practice; shock slime + borg = eternal stunlock.


### PR DESCRIPTION
So, a recent ingame incident had me looking into the code a bit deeper, leading to some overlook discoveries. Definitely a polaris blooper, but I'm not currently in the mood of discussing complicated crap.
Anyway, what I found out, is that the original electrocute_act is supposedly meant for carbon mobs only what comes to code comments and common sense, considering the existence of grounding and the improbability of silicons even receiving raw shocks from anywhere in the first place (apart from shock slimes and other rhetorical raw effect sources). Anyway someone had built silicons a dedicated proc for this, which includes raw stun. Which brings us to the third thing where (likely under the assumption of it being flashing exclusive) someone had commented out stun stack capping from borg life.dm. Combine all this with an unlimited raw effect source (the slime), and you'll get a cake that will instantly and permanently stunlock borgs unconscious until the borg is dead or the slime is removed. Borg stuns are full KO so there's no chance for even stammering for backup there.