### PR TITLE
Allows acquisition of mutation toxin

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents_vr.dm
+++ b/code/modules/reagents/Chemistry-Reagents_vr.dm
@@ -19,10 +19,10 @@
 			H.verbs +=  /mob/living/proc/set_size
 			H.shapeshifter_set_colour("#05FF9B") //They can still change their color.
 
-/datum/chemical_reaction/slime/sapphire_advmutation
+/datum/chemical_reaction/slime/sapphire_mutation
 	name = "Slime Mutation Toxins"
-	id = "adv_mutation"
-	result = "advmutationtoxin"
+	id = "slime_mutation_tox"
+	result = "mutationtoxin"
 	required_reagents = list("blood" = 5)
 	result_amount = 30
 	required = /obj/item/slime_extract/sapphire


### PR DESCRIPTION
For adv mutation toxin, 
https://github.com/VOREStation/VOREStation/blob/bdf5ce72f87ce89f333278f43f173f923f5cb932/code/modules/reagents/Chemistry-Recipes_vr.dm#L237

This reaction has to occur. This makes it so sapphires let you obtain mutationtoxin, which lets you make:
1. Adv mutation toxin
OR
2. Slime vore reaction