### PR TITLE
Makes the metabolism traits actually affect hunger as promised.

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
@@ -2,21 +2,21 @@
 	name = "Fast Metabolism"
 	desc = "You process ingested and injected reagents faster, but get hungry faster."
 	cost = 0
-	var_changes = list("metabolic_rate" = 1.2)
+	var_changes = list("metabolic_rate" = 1.2, "hunger_factor" = 0.2) //Teshari level
 	excludes = list(/datum/trait/metabolism_down, /datum/trait/metabolism_apex)
 
 /datum/trait/metabolism_down
 	name = "Slow Metabolism"
 	desc = "You process ingested and injected reagents slower, but get hungry slower."
 	cost = 0
-	var_changes = list("metabolic_rate" = 0.8)
+	var_changes = list("metabolic_rate" = 0.8, "hunger_factor" = 0.04)
 	excludes = list(/datum/trait/metabolism_up, /datum/trait/metabolism_apex)
 
 /datum/trait/metabolism_apex
 	name = "Apex Metabolism"
 	desc = "Finally a proper excuse for your predatory actions. Also makes you process reagents faster but that's totally irrelevant. May cause excessive immersions with large/taur characters. Not recommended for efficient law-abiding workers or eco-aware NIF users."
 	cost = 0
-	var_changes = list("metabolic_rate" = 2)
+	var_changes = list("metabolic_rate" = 2, "hunger_factor" = 0.5) //Big boy level
 	excludes = list(/datum/trait/metabolism_up, /datum/trait/metabolism_down)
 /*
 /datum/trait/vore_numbing


### PR DESCRIPTION
-Corrected some misinformation after conducting a bunch of var experimenting locally and some ctrl-f research on the code itself. Found out the only connection between metabolic_rate and mob nutrition was the speed ingested reagent nutriment was added from the food bites to the total fullness.
-Yeah they weren't doing jack shit to hunger rates or anything, only reagent processing while the separately handled slop contents stayed slow as ever.
-Slightly slower for slow, Teshari level for high, and something beyond for apex guts aye.