### PR TITLE
Makes the metabolism traits affect movement drain and weight gain/loss.

### DIFF
--- a/code/modules/mob/living/carbon/human/life_vr.dm
+++ b/code/modules/mob/living/carbon/human/life_vr.dm
@@ -50,3 +50,24 @@
 
 	//Process regular life stuff
 	nif.life()
+
+//Overriding carbon move proc that forces default hunger factor
+/mob/living/carbon/Move(NewLoc, direct)
+	. = ..()
+	if(.)
+		if(src.nutrition && src.stat != 2)
+			if(ishuman(src))
+				var/mob/living/carbon/human/M = src
+				if(M.stat != 2 && M.nutrition > 0)
+					M.nutrition -= M.species.hunger_factor/10
+					if(M.m_intent == "run")
+						M.nutrition -= M.species.hunger_factor/10
+			else
+				src.nutrition -= DEFAULT_HUNGER_FACTOR/10
+				if(src.m_intent == "run")
+					src.nutrition -= DEFAULT_HUNGER_FACTOR/10
+		if((FAT in src.mutations) && src.m_intent == "run" && src.bodytemperature <= 360)
+			src.bodytemperature += 2
+		// Moving around increases germ_level faster
+		if(germ_level < GERM_LEVEL_MOVE_CAP && prob(8))
+			germ_level++

--- a/code/modules/mob/living/carbon/human/life_vr.dm
+++ b/code/modules/mob/living/carbon/human/life_vr.dm
@@ -1,10 +1,10 @@
 /mob/living/carbon/human/proc/weightgain()
 	if (nutrition > 0 && stat != 2)
 		if (nutrition > MIN_NUTRITION_TO_GAIN && weight < MAX_MOB_WEIGHT && weight_gain)
-			weight += metabolism*(0.01*weight_gain)
+			weight += species.metabolism*(0.01*weight_gain)
 
 		else if (nutrition <= MAX_NUTRITION_TO_LOSE && stat != 2 && weight > MIN_MOB_WEIGHT && weight_loss)
-			weight -= metabolism*(0.01*weight_loss) // starvation weight loss
+			weight -= species.metabolism*(0.01*weight_loss) // starvation weight loss
 
 /mob/living/carbon/human/proc/handle_hud_list_vr()
 

--- a/code/modules/mob/living/carbon/human/species/station/blank_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/blank_vr.dm
@@ -2,6 +2,7 @@
 /datum/species
 	//var/vore_numbing = 0
 	var/gets_food_nutrition = 1 // If this is set to 0, the person can't get nutrrition from food.
+	var/metabolism = 0.0015
 
 /datum/species/custom
 	name = "Custom Species"

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
@@ -2,21 +2,21 @@
 	name = "Fast Metabolism"
 	desc = "You process ingested and injected reagents faster, but get hungry faster."
 	cost = 0
-	var_changes = list("metabolic_rate" = 1.2, "hunger_factor" = 0.2) //Teshari level
+	var_changes = list("metabolic_rate" = 1.2, "hunger_factor" = 0.2, "metabolism" = 0.005) //Teshari level
 	excludes = list(/datum/trait/metabolism_down, /datum/trait/metabolism_apex)
 
 /datum/trait/metabolism_down
 	name = "Slow Metabolism"
 	desc = "You process ingested and injected reagents slower, but get hungry slower."
 	cost = 0
-	var_changes = list("metabolic_rate" = 0.8, "hunger_factor" = 0.04)
+	var_changes = list("metabolic_rate" = 0.8, "hunger_factor" = 0.04, "metabolism" = 0.001)
 	excludes = list(/datum/trait/metabolism_up, /datum/trait/metabolism_apex)
 
 /datum/trait/metabolism_apex
 	name = "Apex Metabolism"
 	desc = "Finally a proper excuse for your predatory actions. Also makes you process reagents faster but that's totally irrelevant. May cause excessive immersions with large/taur characters. Not recommended for efficient law-abiding workers or eco-aware NIF users."
 	cost = 0
-	var_changes = list("metabolic_rate" = 2, "hunger_factor" = 0.5) //Big boy level
+	var_changes = list("metabolic_rate" = 2, "hunger_factor" = 0.5, "metabolism" = 0.010) //Big boy level
 	excludes = list(/datum/trait/metabolism_up, /datum/trait/metabolism_down)
 /*
 /datum/trait/vore_numbing


### PR DESCRIPTION
-Overrides the carbon move proc for humans to use species/traits hunger factor instead of forced global default.
-Bigger hunger factor now burns more flab on running and smaller should burn less.
-Hopefully. Not sure if it actually manages to override the default proc values or just add to them. Anyway we're talking about heckin' miniscule numbers here, the default drain being 0.005 (default / 10) so the difference is next to nonexistent and therefore below the error margins I could detect on test runs hah.
-Yeah the default value means you'd have to run 100 tiles in order to lose 1 point of nutrition. For contrast, the normal nutrition level between hungry and glutted is 250 to 450.
-Moves our weight gain/loss specific metabolism var from mob to species.
-Makes the metabolism traits affect the forementioned var.
-Makes our weight gain/loss mechanics use the forementioned vars instead of one hard set to mob vars.