### PR TITLE
Crashing Fix Attempt.

### DIFF
--- a/code/controllers/master_controller.dm
+++ b/code/controllers/master_controller.dm
@@ -71,7 +71,7 @@ datum/controller/game_controller/proc/setup_objects()
 		if(T.decals) T.apply_decals()
 		CHECK_SLEEP_MASTER
 	floor_decals_initialized = TRUE
-	sleep(1)
+	sleep(50) //VOREStation Edit. Attempt to prevent server crashing by giving the game more time to apply decals. No idea if this works due to the infrequency of the crashing, but might as well.
 
 	admin_notice("<span class='danger'>Initializing objects</span>", R_DEBUG)
 	for(var/atom/movable/object in world)


### PR DESCRIPTION
Instead of giving the game .1 second to apply decals, let's give it 5 seconds. This should be _more_ than enough time for it to properly apply the decals before the tiles start to get initialized. Or something. I have no idea what the fuck I'm doing, but a small delay doesn't hurt.

Tested and it doesn't break everything: https://i.imgur.com/efn0m4j.png
No guarantee if it actually fixes, but after a bunch of startups and restrarts it seems to not be crashing.

All I had was http://www.byond.com/forum/?post=2245438&page=2 to go off of along with it crashing on initializing tiles, so hopefully this works.