### PR TITLE
Xenochimera tweaks

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/station_special_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_special_vr.dm
@@ -22,7 +22,8 @@
 	icobase_tail = 1
 	inherent_verbs = list(
 		/mob/living/carbon/human/proc/begin_reconstitute_form,
-		/mob/living/carbon/human/proc/sonar_ping)
+		/mob/living/carbon/human/proc/sonar_ping,
+		/mob/living/carbon/human/proc/purge_impurities)
 
 	min_age = 18
 	max_age = 80
@@ -53,7 +54,7 @@
 
 //handle feral triggers
 
-	if(H.nutrition <= 200||H.traumatic_shock > 36) // Stress factors are in play
+	if(H.nutrition <= 200||H.traumatic_shock > min(60, H.nutrition/10)) // Stress factors are in play
 		// If they're hungry, give nag messages.
 		if (!istype(H.loc, /mob)) // if they're in a mob, skip the hunger stuff so it doesn't mess with drain/absorption modes.
 			if(H.nutrition < 200 && H.nutrition > 150)
@@ -73,7 +74,7 @@
 				H.feral = min(150-H.nutrition, H.feral+1) //Feralness increases while this hungry, capped at 50-150 depending on hunger.
 
 		// If they're hurt, chance of snapping. Not if they're straight-up KO'd though.
-		if (H.stat == CONSCIOUS && H.traumatic_shock >=36) //30 brute/burn, or 18 halloss.
+		if (H.stat == CONSCIOUS && H.traumatic_shock >=min(60, H.nutrition/10)) //at 360 nutrition, this is 30 brute/burn, or 18 halloss. Capped at 50 brute/30 halloss - if they take THAT much, no amount of satiation will help them. Also they're fat.
 			if (2.5*H.halloss >= H.traumatic_shock) //If the majority of their shock is due to halloss, greater chance of snapping.
 				if(prob(min(10,(0.2 * H.traumatic_shock))))
 					if(H.feral == 0)


### PR DESCRIPTION
A few tweaks for the bugs.

1. Internal bleeds are sealed at the start of their revive so they won't die while healing the thing they're trying to heal.

2. Adds a "purge impurities" button. The main thing it does is purge the shit out of infections because a being literally made from a colony of flesh-eating microbes shouldn't give a shit about an infected papercut. Takes a little while and has a 5-minute cooldown after use which also locks out their main regen. Depending on how much grossness they're purging, it might make them throw up.

3. Adjusts the threshold for going feral. It now scales with nutrition (capped at 600) so a well-fed monster can take up to 50 brute (up from 36) before the game starts rolling for feralness, while those on the brink of snapping from hunger anyway might flip out at a single punch.