### PR TITLE
reapplies markings after revive for human mobs

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -980,6 +980,14 @@
 						H.brainmob.mind.transfer_to(src)
 						qdel(H)
 
+	// Vorestation Addition - reapply markings/appearance from prefs for player mobs
+	if(client) //just to be sure
+		client.prefs.copy_to(src)
+		if(dna)
+			dna.ResetUIFrom(src)
+			sync_organ_dna()
+	// end vorestation addition
+
 	for (var/ID in virus2)
 		var/datum/disease2/disease/V = virus2[ID]
 		V.cure(src)


### PR DESCRIPTION
Fixes an issue where markings would be deleted by using the rejuvenate/revive verb.

Part of the revive proc involves calling create_organs() on the mob, which deletes all their existing organs, including external ones, and recreates them as appropriate to their species. Notably the mob's DNA still contains all the info related to said markings but I can't figure out how to force the mob's external organs to fetch that information and apply it.

In the meantime, to allow us to use the verb without ruining everything and having to completely respawn their character, any revived human mobs that have a client will now fetch their appearance from the client's prefs, resetting them back to their appearance at spawn.

Fixes #1496 as well.