### PR TITLE
removes a scree fluff item

### DIFF
--- a/code/modules/vore/fluffstuff/custom_items_vr.dm
+++ b/code/modules/vore/fluffstuff/custom_items_vr.dm
@@ -194,20 +194,6 @@ obj/item/weapon/material/hatchet/tacknife/combatknife/fluff/katarina/handle_shie
 	to_helmet = /obj/item/clothing/head/helmet/space/void/engineering/hazmat/fluff/screehelm
 	to_suit = /obj/item/clothing/suit/space/void/engineering/hazmat/fluff/screespess
 
-/obj/item/clothing/glasses/omnihud/eng/meson/fluff/scree
-	name = "OCR headset"
-	desc = "A meson-scanning headset with retinal projector and ultrasonic earpiece. This one is set up to read text to the wearer."
-	description_info = "The device appears to be configured as an aid to reading, with an OCR system that highlights text for the wearer and \
-	reads it out through the earpiece, while rendering the meson scan data as high-frequency sound. It's like a HUD for bats."
-
-	mob_can_equip(var/mob/living/carbon/human/H, slot, disable_warning = 0)
-		if(..())
-			if(H.ckey != "scree")
-				H << "<span class='warning'>This thing isn't set up for your visual spectrum OR your audio range.</span>"
-				return 0
-			else
-				return 1
-
 //General Use
 /obj/item/weapon/flag
 	name = "Nanotrasen Banner"

--- a/config/custom_items.txt
+++ b/config/custom_items.txt
@@ -603,12 +603,6 @@ item_path: /obj/item/clothing/head/fluff/pompom
 }
 
 {
-ckey: scree
-character_name: Scree
-item_path: /obj/item/clothing/glasses/omnihud/eng/meson/fluff/scree
-}
-
-{
 ckey: seiga
 character_name: Alfonso Oak Telanor
 item_path: /obj/item/clothing/glasses/sunglasses/fluff/alfonso


### PR DESCRIPTION
Removes the meson hudglasses. They never really worked right because the HUD interfered with the meson vision, and honestly Scree can get mesons from loadout if he actually needs them.

The non-ckey restricted item is still there for admins to spawn and I've left the sprite resources in place in case anyone wants to go all Gene Starwind with the retinal projector thing on another item.