### PR TITLE
Traits clarity, changes, and additions.

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/negative.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/negative.dm
@@ -42,41 +42,53 @@
 		..(S,H)
 		H.setMaxHealth(S.total_health)
 
+/datum/trait/minor_brute_weak
+	name = "Minor Brute Weakness"
+	desc = "Increases damage from brute damage sources by 15%"
+	cost = -1
+	var_changes = list("brute_mod" = 1.15)
+
 /datum/trait/brute_weak
 	name = "Brute Weakness"
 	desc = "Increases damage from brute damage sources by 25%"
-	cost = -1
+	cost = -2
 	var_changes = list("brute_mod" = 1.25)
 
 /datum/trait/brute_weak_plus
 	name = "Brute Weakness (Plus)"
 	desc = "Increases damage from brute damage sources by 50%"
-	cost = -2
+	cost = -3
 	var_changes = list("brute_mod" = 1.5)
+
+/datum/trait/minor_burn_weak
+	name = "Minor Burn Weakness"
+	desc = "Increases damage from burn damage sources by 15%"
+	cost = -1
+	var_changes = list("burn_mod" = 1.15)
 
 /datum/trait/burn_weak
 	name = "Burn Weakness"
 	desc = "Increases damage from burn damage sources by 25%"
-	cost = -1
+	cost = -2
 	var_changes = list("burn_mod" = 1.25)
 
 /datum/trait/burn_weak_plus
 	name = "Burn Weakness (Plus)"
 	desc = "Increases damage from burn damage sources by 50%"
-	cost = -2
+	cost = -3
 	var_changes = list("burn_mod" = 1.5)
 
 /datum/trait/conductive
 	name = "Conductive"
 	desc = "Increases your susceptibility to electric shocks by 50%"
 	cost = -1
-	var_changes = list("siemens_coefficient" = 1.5)
+	var_changes = list("siemens_coefficient" = 1.5) //This makes you a lot weaker to tasers.
 
 /datum/trait/conductive_plus
 	name = "Conductive (Plus)"
 	desc = "Increases your susceptibility to electric shocks by 100%"
 	cost = -2
-	var_changes = list("siemens_coefficient" = 2.0)
+	var_changes = list("siemens_coefficient" = 2.0) //This makes you extremely weak to tasers.
 
 /datum/trait/photosensitive
 	name = "Photosensitive"

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/negative.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/negative.dm
@@ -24,7 +24,7 @@
 
 /datum/trait/endurance_low
 	name = "Low Endurance"
-	desc = "Reduces your maximum total hitpoints."
+	desc = "Reduces your maximum total hitpoints to 75."
 	cost = -2
 	var_changes = list("total_health" = 75)
 
@@ -32,41 +32,51 @@
 		..(S,H)
 		H.setMaxHealth(S.total_health)
 
+/datum/trait/endurance_very_low
+	name = "Extremely Low Endurance"
+	desc = "Reduces your maximum total hitpoints to 50."
+	cost = -3 //Teshari HP. This makes the person a lot more suseptable to getting stunned, killed, etc. 
+	var_changes = list("total_health" = 50)
+
+	apply(var/datum/species/S,var/mob/living/carbon/human/H)
+		..(S,H)
+		H.setMaxHealth(S.total_health)
+
 /datum/trait/brute_weak
 	name = "Brute Weakness"
-	desc = "Increases damage from brute damage sources."
+	desc = "Increases damage from brute damage sources by 25%"
 	cost = -1
-	var_changes = list("brute_mod" = 1.15)
+	var_changes = list("brute_mod" = 1.25)
 
 /datum/trait/brute_weak_plus
 	name = "Brute Weakness (Plus)"
-	desc = "Increases damage significantly from brute damage sources."
+	desc = "Increases damage from brute damage sources by 50%"
 	cost = -2
-	var_changes = list("brute_mod" = 1.30)
+	var_changes = list("brute_mod" = 1.5)
 
 /datum/trait/burn_weak
 	name = "Burn Weakness"
-	desc = "Increases damage from burn damage sources."
+	desc = "Increases damage from burn damage sources by 25%"
 	cost = -1
-	var_changes = list("burn_mod" = 1.15)
+	var_changes = list("burn_mod" = 1.25)
 
 /datum/trait/burn_weak_plus
 	name = "Burn Weakness (Plus)"
-	desc = "Increases damage significantly from burn damage sources."
+	desc = "Increases damage from burn damage sources by 50%"
 	cost = -2
-	var_changes = list("burn_mod" = 1.30)
+	var_changes = list("burn_mod" = 1.5)
 
 /datum/trait/conductive
 	name = "Conductive"
-	desc = "Increases your susceptibility to electric shocks by a small amount."
+	desc = "Increases your susceptibility to electric shocks by 50%"
 	cost = -1
-	var_changes = list("siemens_coefficient" = 1.15)
+	var_changes = list("siemens_coefficient" = 1.5)
 
 /datum/trait/conductive_plus
 	name = "Conductive (Plus)"
-	desc = "Increases your susceptibility to electric shocks by a moderate amount."
+	desc = "Increases your susceptibility to electric shocks by 100%"
 	cost = -2
-	var_changes = list("siemens_coefficient" = 1.3)
+	var_changes = list("siemens_coefficient" = 2.0)
 
 /datum/trait/photosensitive
 	name = "Photosensitive"

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/negative.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/negative.dm
@@ -1,13 +1,13 @@
 /datum/trait/speed_slow
 	name = "Slowdown"
 	desc = "Allows you to move slower on average than baseline."
-	cost = -1
+	cost = -3
 	var_changes = list("slowdown" = 0.5)
 
 /datum/trait/speed_slow_plus
-	name = "Slowdown (Plus)"
+	name = "Major Slowdown"
 	desc = "Allows you to move MUCH slower on average than baseline."
-	cost = -2
+	cost = -5
 	var_changes = list("slowdown" = 1.0)
 
 /datum/trait/weakling
@@ -17,7 +17,7 @@
 	var_changes = list("item_slowdown_mod" = 1.5)
 
 /datum/trait/weakling_plus
-	name = "Weakling (Plus)"
+	name = "Major Weakling"
 	desc = "Allows you to carry heavy equipment with much more slowdown."
 	cost = -2
 	var_changes = list("item_slowdown_mod" = 2.0)
@@ -55,7 +55,7 @@
 	var_changes = list("brute_mod" = 1.25)
 
 /datum/trait/brute_weak_plus
-	name = "Brute Weakness (Plus)"
+	name = "Major Brute Weakness"
 	desc = "Increases damage from brute damage sources by 50%"
 	cost = -3
 	var_changes = list("brute_mod" = 1.5)
@@ -73,7 +73,7 @@
 	var_changes = list("burn_mod" = 1.25)
 
 /datum/trait/burn_weak_plus
-	name = "Burn Weakness (Plus)"
+	name = "Major Burn Weakness"
 	desc = "Increases damage from burn damage sources by 50%"
 	cost = -3
 	var_changes = list("burn_mod" = 1.5)
@@ -81,13 +81,13 @@
 /datum/trait/conductive
 	name = "Conductive"
 	desc = "Increases your susceptibility to electric shocks by 50%"
-	cost = -1
+	cost = -2
 	var_changes = list("siemens_coefficient" = 1.5) //This makes you a lot weaker to tasers.
 
 /datum/trait/conductive_plus
-	name = "Conductive (Plus)"
+	name = "Major Conductive"
 	desc = "Increases your susceptibility to electric shocks by 100%"
-	cost = -2
+	cost = -3
 	var_changes = list("siemens_coefficient" = 2.0) //This makes you extremely weak to tasers.
 
 /datum/trait/photosensitive

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/positive.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/positive.dm
@@ -5,7 +5,7 @@
 	var_changes = list("slowdown" = -0.5)
 
 /datum/trait/speed_fast_plus
-	name = "Haste (Plus)"
+	name = "Major Haste"
 	desc = "Allows you to move MUCH faster on average than baseline."
 	cost = 5
 	var_changes = list("slowdown" = -1.0)
@@ -17,7 +17,7 @@
 	var_changes = list("item_slowdown_mod" = 0.5)
 
 /datum/trait/hardy_plus
-	name = "Hardy (Plus)"
+	name = "Major Hardy"
 	desc = "Allows you to carry heavy equipment with almost no slowdown."
 	cost = 2
 	var_changes = list("item_slowdown_mod" = 0.1)
@@ -49,7 +49,7 @@
 	var_changes = list("siemens_coefficient" = 0.75)
 
 /datum/trait/nonconductive_plus
-	name = "Non-Conductive (Plus)"
+	name = "Major Non-Conductive"
 	desc = "Decreases your susceptibility to electric shocks by a 50% amount."
 	cost = 3 //Let us not forget this effects tasers!
 	var_changes = list("siemens_coefficient" = 0.5)
@@ -61,7 +61,7 @@
 	var_changes = list("darksight" = 3)
 
 /datum/trait/darksight_plus
-	name = "Darksight (Plus)"
+	name = "Darksight (Major)"
 	desc = "Allows you to see in the dark for the whole screen."
 	cost = 2
 	var_changes = list("darksight" = 7)
@@ -91,7 +91,7 @@
 	var_changes = list("brute_mod" = 0.75)
 
 /datum/trait/brute_resist_plus
-	name = "Brute Resist (Plus)"
+	name = "Major Brute Resist"
 	desc = "Adds 50% resistance to brute damage sources."
 	cost = 3
 	var_changes = list("brute_mod" = 0.5)
@@ -109,7 +109,7 @@
 	var_changes = list("burn_mod" = 0.75)
 
 /datum/trait/burn_resist_plus
-	name = "Burn Resist (Plus)"
+	name = "Major Burn Resist"
 	desc = "Adds 50% resistance to burn damage sources."
 	cost = 3
 	var_changes = list("burn_mod" = 0.5)

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/positive.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/positive.dm
@@ -1,13 +1,13 @@
 /datum/trait/speed_fast
 	name = "Haste"
 	desc = "Allows you to move faster on average than baseline."
-	cost = 2
+	cost = 3
 	var_changes = list("slowdown" = -0.5)
 
 /datum/trait/speed_fast_plus
 	name = "Haste (Plus)"
 	desc = "Allows you to move MUCH faster on average than baseline."
-	cost = 4
+	cost = 5
 	var_changes = list("slowdown" = -1.0)
 
 /datum/trait/hardy
@@ -24,7 +24,7 @@
 
 /datum/trait/endurance_high
 	name = "High Endurance"
-	desc = "Increases your maximum total hitpoints."
+	desc = "Increases your maximum total hitpoints to 125"
 	cost = 2
 	var_changes = list("total_health" = 125)
 
@@ -32,17 +32,27 @@
 		..(S,H)
 		H.setMaxHealth(S.total_health)
 
+/datum/trait/endurance_very_high
+	name = "Very High Endurance"
+	desc = "Increases your maximum total hitpoints to 150"
+	cost = 3
+	var_changes = list("total_health" = 150)
+
+	apply(var/datum/species/S,var/mob/living/carbon/human/H)
+		..(S,H)
+		H.setMaxHealth(S.total_health)
+
 /datum/trait/nonconductive
 	name = "Non-Conductive"
-	desc = "Decreases your susceptibility to electric shocks by a small amount."
-	cost = 1
-	var_changes = list("siemens_coefficient" = 0.85)
+	desc = "Decreases your susceptibility to electric shocks by a 25% amount."
+	cost = 2 //This effects tasers!
+	var_changes = list("siemens_coefficient" = 0.75)
 
 /datum/trait/nonconductive_plus
 	name = "Non-Conductive (Plus)"
-	desc = "Decreases your susceptibility to electric shocks by a moderate amount."
-	cost = 2
-	var_changes = list("siemens_coefficient" = 0.7)
+	desc = "Decreases your susceptibility to electric shocks by a 50% amount."
+	cost = 3 //Let us not forget this effects tasers!
+	var_changes = list("siemens_coefficient" = 0.5)
 
 /datum/trait/darksight
 	name = "Darksight"
@@ -68,32 +78,44 @@
 	cost = 2
 	var_changes = list("unarmed_types" = list(/datum/unarmed_attack/stomp, /datum/unarmed_attack/kick, /datum/unarmed_attack/claws, /datum/unarmed_attack/bite/sharp, /datum/unarmed_attack/bite/sharp/numbing))
 
-/datum/trait/brute_resist
-	name = "Brute Resist"
-	desc = "Adds some resistance to brute damage sources."
+/datum/trait/minor_brute_resist
+	name = "Minor Brute Resist"
+	desc = "Adds 15% resistance to brute damage sources."
 	cost = 1
 	var_changes = list("brute_mod" = 0.85)
 
+/datum/trait/brute_resist
+	name = "Brute Resist"
+	desc = "Adds 25% resistance to brute damage sources."
+	cost = 2
+	var_changes = list("brute_mod" = 0.75)
+
 /datum/trait/brute_resist_plus
 	name = "Brute Resist (Plus)"
-	desc = "Adds some resistance to brute damage sources."
-	cost = 2
-	var_changes = list("brute_mod" = 0.70)
+	desc = "Adds 50% resistance to brute damage sources."
+	cost = 3
+	var_changes = list("brute_mod" = 0.5)
 
-/datum/trait/burn_resist
-	name = "Burn Resist"
-	desc = "Adds some resistance to burn damage sources."
+/datum/trait/minor_burn_resist
+	name = "Minor Brute Resist"
+	desc = "Adds 15% resistance to burn damage sources."
 	cost = 1
 	var_changes = list("burn_mod" = 0.85)
 
+/datum/trait/burn_resist
+	name = "Burn Resist"
+	desc = "Adds 25% resistance to burn damage sources."
+	cost = 2
+	var_changes = list("burn_mod" = 0.75)
+
 /datum/trait/burn_resist_plus
 	name = "Burn Resist (Plus)"
-	desc = "Adds some resistance to burn damage sources."
-	cost = 2
-	var_changes = list("burn_mod" = 0.70)
+	desc = "Adds 50% resistance to burn damage sources."
+	cost = 3
+	var_changes = list("burn_mod" = 0.5)
 
 /datum/trait/photoresistant
 	name = "Photoresistant"
-	desc = "Decreases stun duration from flashes and other light-based stuns."
+	desc = "Decreases stun duration from flashes and other light-based stuns and disabilities by 50%"
 	cost = 1
 	var_changes = list("flash_mod" = 0.5)


### PR DESCRIPTION
- Makes most traits clarify how weaker/stronger you are in terms of percents.
- Adds minor brute weakness & minor burn weakness/resistance. 1 point for 15% weakness.
- Increases brute/burn weakness to 25% for 2 points
- Makes brute/burn weakness/resistance for 50% for 3 points
- Adds "Very Low/High Endurance" which increases/decreases health by 50% for 3 points
- Increases haste+ & slowdown+ to 5 points. Haste/Slowdown to 3 points.
- Makes conductive go from 15% to 50% & 2 points. Conductive+ from 30% to 100% & 3 points
- Non-Conductive gives 25% resistance for 2 points. Non-Conductive plus 50% resistance for 3 points.

Please submit feedback for changes.