### PR TITLE
Updates Travis to 512.1392

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ language: c
 sudo: false
 
 env:
-  BYOND_MAJOR="511"
-  BYOND_MINOR="1381"
+  BYOND_MAJOR="512"
+  BYOND_MINOR="1392"
   MACRO_COUNT=4
 
 cache:


### PR DESCRIPTION
Updates Travis to 512.1392
Will compile code in 512.1392. Merge this whenever we update to 512.1392. If we update to something like 512.1397 later when it comes, comment here and I'll change it in this PR. 