### PR TITLE
Adds a mind backup nifsoft and fixes sleevemate nif and quit issues.

### DIFF
--- a/code/__defines/nifsoft.dm
+++ b/code/__defines/nifsoft.dm
@@ -16,30 +16,31 @@
 #define NIF_UVFILTER			12
 #define NIF_FLASHPROT			13
 //Health-related
-#define NIF_CREWMONITOR			14
-#define NIF_ORGANIC_HEAL		15
-#define NIF_SYNTH_HEAL			16
-#define NIF_AUTOSTASIS			17 //These two are just part of
-#define NIF_MED_ALARM			18 //medichines right now
-#define NIF_TOXHEAL				19 //And this, for organics
-#define NIF_SPAREBREATH			20
+#define NIF_BACKUP				14
+#define NIF_CREWMONITOR			15
+#define NIF_ORGANIC_HEAL		16
+#define NIF_SYNTH_HEAL			17
+#define NIF_AUTOSTASIS			18 //These two are just part of
+#define NIF_MED_ALARM			19 //medichines right now
+#define NIF_TOXHEAL				20 //And this, for organics
+#define NIF_SPAREBREATH			21
 //Combat Related
-#define NIF_BRUTEARMOR			21
-#define NIF_BURNARMOR			22
-#define NIF_PAINKILLERS			23
-#define NIF_HARDCLAWS			24
-#define NIF_HIDDENLASER			25
+#define NIF_BRUTEARMOR			22
+#define NIF_BURNARMOR			23
+#define NIF_PAINKILLERS			24
+#define NIF_HARDCLAWS			25
+#define NIF_HIDDENLASER			26
 //Other
-#define NIF_COMMLINK			26
-#define NIF_APCCHARGE			27
-#define NIF_PRESSURE			28
-#define NIF_HEATSINK			29
-#define NIF_COMPLIANCE			30
-#define NIF_SIZECHANGE			31
-#define NIF_SOULCATCHER			32
+#define NIF_COMMLINK			27
+#define NIF_APCCHARGE			28
+#define NIF_PRESSURE			29
+#define NIF_HEATSINK			30
+#define NIF_COMPLIANCE			31
+#define NIF_SIZECHANGE			32
+#define NIF_SOULCATCHER			33
 
 // Must be equal to the highest number above
-#define TOTAL_NIF_SOFTWARE		32
+#define TOTAL_NIF_SOFTWARE		33
 
 //////////////////////
 // NIF flag list hints

--- a/code/controllers/subsystems/transcore_vr.dm
+++ b/code/controllers/subsystems/transcore_vr.dm
@@ -81,6 +81,21 @@ SUBSYSTEM_DEF(transcore)
 	else
 		MR = new(mind, mind.current, add_to_db = TRUE, one_time = one_time)
 
+		//Pass a 0 to not change NIF status (because the elseif is checking for null)
+		if(nif)
+			MR.nif_path = nif.type
+			MR.nif_durability = nif.durability
+			var/list/nifsofts = list()
+			for(var/N in nif.nifsofts)
+				if(N)
+					var/datum/nifsoft/nifsoft = N
+					nifsofts += nifsoft.type
+			MR.nif_software = nifsofts
+		else if(isnull(nif)) //Didn't pass anything, so no NIF
+			MR.nif_path = null
+			MR.nif_durability = null
+			MR.nif_software = null
+
 	return 1
 
 // Send a past-due notification to the medical radio channel.

--- a/code/game/objects/items/devices/scanners_vr.dm
+++ b/code/game/objects/items/devices/scanners_vr.dm
@@ -125,7 +125,7 @@ var/global/mob/living/carbon/human/dummy/mannequin/sleevemate_mob
 
 	//The actual options
 	if(href_list["mindscan"])
-		if(!target.mind)
+		if(!target.mind || target.mind.name in prevent_respawns)
 			to_chat(usr,"<span class='warning'>Target seems totally braindead.</span>")
 			return
 
@@ -161,7 +161,7 @@ var/global/mob/living/carbon/human/dummy/mannequin/sleevemate_mob
 		return
 
 	if(href_list["mindsteal"])
-		if(!target.mind)
+		if(!target.mind || target.mind.name in prevent_respawns)
 			to_chat(usr,"<span class='warning'>Target seems totally braindead.</span>")
 			return
 

--- a/code/modules/nifsoft/software/05_health.dm
+++ b/code/modules/nifsoft/software/05_health.dm
@@ -210,3 +210,25 @@
 		breath.adjust_gas("oxygen", 300)
 		breath.temperature = T20C
 		return breath
+
+/datum/nifsoft/mindbackup
+	name = "Mind Backup"
+	desc = "Backup your mind on the go. Stores a one-time sync of your current mindstate upon activation"
+	list_pos = NIF_BACKUP
+	cost = 250
+
+	activate()
+		if((. = ..()))
+			var/mob/living/carbon/human/H = nif.human
+			SStranscore.m_backup(H.mind,H.nif,one_time = TRUE)
+			nif.notify("Mind backed up!")
+			nif.use_charge(0.1)
+			deactivate()
+			return TRUE
+
+	deactivate()
+		if((. = ..()))
+			return TRUE
+
+	stat_text()
+		return "Store Backup"


### PR DESCRIPTION
-Adds a nifsoft that can be used for manual mind backups on the go sleevemate style.
-Fixes sleevemate being able to scan people who have quit the round. https://github.com/VOREStation/VOREStation/issues/2336
-Fixes one-time (first time) backups not saving nifs (sleevemate and this thing)
-Apparently the core backup proc only saved nifs on already backed up minds after the second sync.
-The nifsoft's currently priced at 250. Increase/decrease?
-Extremely useful for those skeletal and overly busy shifts where all the implanters stay tauntingly locked away in plain sight.
-Imo it'd actually make more sense for the nif to backup itself than for the implant to copy the nif anyway.
-Adds something actually useful and frequetly installable to wear out people's nifs faster.

To all concerned medical players afraid of losing their jobs because of this, don't worry, I'll be making up for it with some additional workplace hazard updates to give you some actual work to do instead of just being walking implant dispensers :v