### PR TITLE
Removes the minimum limits to gurgle damage and scales the nutrition gain with them.

### DIFF
--- a/code/modules/vore/eating/bellymodes_vr.dm
+++ b/code/modules/vore/eating/bellymodes_vr.dm
@@ -81,9 +81,9 @@
 					s_owner = owner
 					s_owner.cell.charge += 100
 				if(offset) // If any different than default weight, multiply the % of offset.
-					owner.nutrition += offset*(10/difference) // 9.5 nutrition per digestion tick if they're 130 pounds and it's same size. 10.2 per digestion tick if they're 140 and it's same size. Etc etc.
+					owner.nutrition += offset*(2*(digest_brute+digest_burn)/difference) // 9.5 nutrition per digestion tick if they're 130 pounds and it's same size. 10.2 per digestion tick if they're 140 and it's same size. Etc etc.
 				else
-					owner.nutrition += (10/difference)
+					owner.nutrition += (2*(digest_brute+digest_burn)/difference)
 			M.updateVRPanel()
 
 		if(digest_mode == DM_ITEMWEAK)

--- a/code/modules/vore/eating/vorepanel_vr.dm
+++ b/code/modules/vore/eating/vorepanel_vr.dm
@@ -628,10 +628,10 @@
 		selected.digest_burn = new_new_damage
 
 	if(href_list["b_brute_dmg"])
-		var/new_damage = input(user, "Choose the amount of brute damage prey will take per tick. Ranges from 3 to 6", "Set Belly Brute Damage.") as num|null
+		var/new_damage = input(user, "Choose the amount of brute damage prey will take per tick. Ranges from 0 to 6", "Set Belly Brute Damage.") as num|null
 		if(new_damage == null)
 			return
-		var/new_new_damage = Clamp(new_damage, 3, 6)
+		var/new_new_damage = Clamp(new_damage, 0, 6)
 		selected.digest_brute = new_new_damage
 
 	if(href_list["b_escapable"])

--- a/code/modules/vore/eating/vorepanel_vr.dm
+++ b/code/modules/vore/eating/vorepanel_vr.dm
@@ -621,17 +621,17 @@
 			selected.shrink_grow_size = (new_grow/100)
 
 	if(href_list["b_burn_dmg"])
-		var/new_damage = input(user, "Choose the amount of burn damage prey will take per tick. Ranges from 3 to 6.", "Set Belly Burn Damage.") as num|null
+		var/new_damage = input(user, "Choose the amount of burn damage prey will take per tick. Ranges from 1 to 6.", "Set Belly Burn Damage.") as num|null
 		if(new_damage == null)
 			return
-		var/new_new_damage = Clamp(new_damage, 3, 6)
+		var/new_new_damage = Clamp(new_damage, 1, 6)
 		selected.digest_burn = new_new_damage
 
 	if(href_list["b_brute_dmg"])
-		var/new_damage = input(user, "Choose the amount of brute damage prey will take per tick. Ranges from 0 to 6", "Set Belly Brute Damage.") as num|null
+		var/new_damage = input(user, "Choose the amount of brute damage prey will take per tick. Ranges from 1 to 6", "Set Belly Brute Damage.") as num|null
 		if(new_damage == null)
 			return
-		var/new_new_damage = Clamp(new_damage, 0, 6)
+		var/new_new_damage = Clamp(new_damage, 1, 6)
 		selected.digest_brute = new_new_damage
 
 	if(href_list["b_escapable"])

--- a/code/modules/vore/eating/vorepanel_vr.dm
+++ b/code/modules/vore/eating/vorepanel_vr.dm
@@ -621,17 +621,17 @@
 			selected.shrink_grow_size = (new_grow/100)
 
 	if(href_list["b_burn_dmg"])
-		var/new_damage = input(user, "Choose the amount of burn damage prey will take per tick. Ranges from 1 to 6.", "Set Belly Burn Damage.") as num|null
+		var/new_damage = input(user, "Choose the amount of burn damage prey will take per tick. Ranges from 0 to 6.", "Set Belly Burn Damage.") as num|null
 		if(new_damage == null)
 			return
-		var/new_new_damage = Clamp(new_damage, 1, 6)
+		var/new_new_damage = Clamp(new_damage, 0, 6)
 		selected.digest_burn = new_new_damage
 
 	if(href_list["b_brute_dmg"])
-		var/new_damage = input(user, "Choose the amount of brute damage prey will take per tick. Ranges from 1 to 6", "Set Belly Brute Damage.") as num|null
+		var/new_damage = input(user, "Choose the amount of brute damage prey will take per tick. Ranges from 0 to 6", "Set Belly Brute Damage.") as num|null
 		if(new_damage == null)
 			return
-		var/new_new_damage = Clamp(new_damage, 1, 6)
+		var/new_new_damage = Clamp(new_damage, 0, 6)
 		selected.digest_brute = new_new_damage
 
 	if(href_list["b_escapable"])


### PR DESCRIPTION
-Set the minimum gurgle damages to 0, the lower limit obsolete with the nutrition scaling. No damage, no food.
-A tick by tick digestion keeps the delay updated autoheal away just fine.
-Even a 0+1 digestion damage confirmed lethal for every race on a varedited test run so off the loo with the counterarguments.
-Also made the digestion nutrition gain scale with the gurgledamages so that's an even bigger blow against the "meta".
-Formerly 10/sizediff for default damage, now 2*(brute+burn)/sizediff.