### PR TITLE
Replaces live otie grabs with a different feature.

### DIFF
--- a/code/modules/mob/living/simple_animal/vore/otie.dm
+++ b/code/modules/mob/living/simple_animal/vore/otie.dm
@@ -247,7 +247,7 @@
 
 	switch(M.a_intent)
 		if(I_HELP)
-			if (health > 0)
+			if(health > 0)
 				M.visible_message("<span class='notice'>[M] [response_help] \the [src].</span>")
 				LoseTarget()
 				handle_stance(STANCE_IDLE)
@@ -257,6 +257,29 @@
 						tamed = 1
 						faction = M.faction
 				sleep(1 SECOND)
+
+		if(I_GRAB)
+			if(health > 0)
+				audible_emote("growls disapprovingly at [M].")
+				if(friend == M)
+					friend = null
+				return
+			if(M == src)
+				return
+			if(!(status_flags & CANPUSH))
+				return
+
+			var/obj/item/weapon/grab/G = new /obj/item/weapon/grab(M, src)
+
+			M.put_in_active_hand(G)
+
+			G.synch()
+			G.affecting = src
+			LAssailant = M
+
+			M.visible_message("<span class='warning'>[M] has grabbed [src] passively!</span>")
+			M.do_attack_animation(src)
+			ai_log("attack_hand() I was grabbed by: [M]",2)
 
 		else
 			..()

--- a/code/modules/mob/living/simple_animal/vore/otie.dm
+++ b/code/modules/mob/living/simple_animal/vore/otie.dm
@@ -264,22 +264,7 @@
 				if(friend == M)
 					friend = null
 				return
-			if(M == src)
-				return
-			if(!(status_flags & CANPUSH))
-				return
-
-			var/obj/item/weapon/grab/G = new /obj/item/weapon/grab(M, src)
-
-			M.put_in_active_hand(G)
-
-			G.synch()
-			G.affecting = src
-			LAssailant = M
-
-			M.visible_message("<span class='warning'>[M] has grabbed [src] passively!</span>")
-			M.do_attack_animation(src)
-			ai_log("attack_hand() I was grabbed by: [M]",2)
+			..()
 
 		else
 			..()

--- a/code/modules/mob/living/simple_animal/vore/otie.dm
+++ b/code/modules/mob/living/simple_animal/vore/otie.dm
@@ -264,7 +264,8 @@
 				if(friend == M)
 					friend = null
 				return
-			..()
+			else
+				..()
 
 		else
 			..()

--- a/code/modules/mob/living/simple_animal/vore/otie.dm
+++ b/code/modules/mob/living/simple_animal/vore/otie.dm
@@ -261,8 +261,6 @@
 		if(I_GRAB)
 			if(health > 0)
 				audible_emote("growls disapprovingly at [M].")
-				if(friend == M)
-					friend = null
 				return
 			else
 				..()


### PR DESCRIPTION
-Grabbing a live otie no longer does the classic "break sprite offset and piss off the mob" function.
-Instead it now just leads to a disapproving growl and a loss of bonding if the grabber had befriended the thing before.
-Now there is also a way to make them stop following you when you get tired of it.
-Grabbing a dead one does the old stuff tho so ya can still 'dispose' of the bodies or whatever.
-Serious there's always someone who goes grabbing the nonhostile ones fgshjd :v