### PR TITLE
Reverts Ace's changes to make parapens functional

### DIFF
--- a/code/modules/paperwork/pen_vr.dm
+++ b/code/modules/paperwork/pen_vr.dm
@@ -1,8 +1,0 @@
-/obj/item/weapon/pen/reagent/paralysis
-	origin_tech = list(TECH_MATERIAL = 2, TECH_ILLEGAL = 5)
-
-/obj/item/weapon/pen/reagent/paralysis/New()
-	..()
-//	reagents.add_reagent("zombiepowder", 10)
-//	reagents.add_reagent("cryptobiolin", 15)
-	reagents.add_reagent("neurotoxin", 30) // A lot less griefy.

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -2165,7 +2165,6 @@
 #include "code\modules\paperwork\paperbin.dm"
 #include "code\modules\paperwork\papershredder.dm"
 #include "code\modules\paperwork\pen.dm"
-#include "code\modules\paperwork\pen_vr.dm"
 #include "code\modules\paperwork\photocopier.dm"
 #include "code\modules\paperwork\photography.dm"
 #include "code\modules\paperwork\silicon_photography.dm"


### PR DESCRIPTION
Neurotoxin is an alcoholic drink that doesn't do as Ace likely expected when injected, because it is what it is. Drink affects like that of Neurotoxin or Beepsky Smash are applied upon ingest. Currently the parapen is non-functional.