### PR TITLE
Brutal Predation & minor adjustments.

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1207,7 +1207,9 @@
 		if(species.can_drain_prey == 1)
 			verbs |= /mob/living/carbon/human/proc/succubus_drain //Succubus drain trait.
 			verbs |= /mob/living/carbon/human/proc/succubus_drain_finialize
-			verbs |= /mob/living/carbon/human/proc/succubus_drain_lethal //VOREStation Edit End
+			verbs |= /mob/living/carbon/human/proc/succubus_drain_lethal
+		if(species.hard_vore_enabled == 1) //Hardvore verb.
+			verbs |= /mob/living/carbon/human/proc/shred_limb //VOREStation Edit End
 
 	// Rebuild the HUD. If they aren't logged in then login() should reinstantiate it for them.
 	if(client && client.screen)

--- a/code/modules/mob/living/carbon/human/species/station/blank_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/blank_vr.dm
@@ -3,6 +3,7 @@
 	//var/vore_numbing = 0
 	var/gets_food_nutrition = 1 // If this is set to 0, the person can't get nutrrition from food.
 	var/can_drain_prey = 0 //Determines if the person can use the succubus drain or not.
+	var/hard_vore_enabled = 0 //Determines if the person has the hardvore verb or not.
 	var/metabolism = 0.0015
 
 /datum/species/custom

--- a/code/modules/mob/living/carbon/human/species/station/prometheans_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/prometheans_vr.dm
@@ -18,8 +18,10 @@
 		/mob/living/proc/set_size,
 		/mob/living/carbon/human/proc/succubus_drain,
 		/mob/living/carbon/human/proc/succubus_drain_finialize,
-		/mob/living/carbon/human/proc/succubus_drain_lethal
-		)
+		/mob/living/carbon/human/proc/succubus_drain_lethal,
+		/mob/living/carbon/human/proc/bloodsuck,
+		/mob/living/carbon/human/proc/shred_limb
+		) //Prometheans get all the special verbs since they can't do traits.
 
 
 /datum/species/shapeshifter/promethean/handle_death(var/mob/living/carbon/human/H)

--- a/code/modules/mob/living/carbon/human/species/station/prometheans_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/prometheans_vr.dm
@@ -18,10 +18,8 @@
 		/mob/living/proc/set_size,
 		/mob/living/carbon/human/proc/succubus_drain,
 		/mob/living/carbon/human/proc/succubus_drain_finialize,
-		/mob/living/carbon/human/proc/succubus_drain_lethal,
-		/mob/living/carbon/human/proc/bloodsuck,
-		/mob/living/carbon/human/proc/shred_limb
-		) //Prometheans get all the special verbs since they can't do traits.
+		/mob/living/carbon/human/proc/succubus_drain_lethal
+		)
 
 
 /datum/species/shapeshifter/promethean/handle_death(var/mob/living/carbon/human/H)

--- a/code/modules/mob/living/carbon/human/species/station/station_special_abilities_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_special_abilities_vr.dm
@@ -684,18 +684,18 @@
 			T.apply_damage(15, BRUTE, D) //Damage the external organ they're going through.
 			P.removed()
 			P.forceMove(T.loc) //Move to where prey is.
-			log_and_message_admins("tore out [T]'s [P].", C)
+			log_and_message_admins("tore out [P] of [T].", C)
 			if(eat_limb)
 				var/datum/belly/S = C.vore_organs[eat_limb]
 				P.forceMove(C) //Move to pred's gut
 				S.internal_contents |= P //Add to pred's gut.
-				C.visible_message("<font color='red'><b>[C] severely damages [T]'s [D]!</b></font>")
-				C << "Their [P] moves into your [S]!" //Quietly eat their internal organ!
+				C.visible_message("<font color='red'><b>[C] severely damages [D] of [T]!</b></font>") // Same as below, but (pred) damages the (right hand) of (person)
+				C << "[P] of [T] moves into your [S]!" //Quietly eat their internal organ! Comes out "The (right hand) of (person) moves into your (stomach)
 				playsound(C, S.vore_sound, 70, 1)
-				log_and_message_admins("tore out and ate [T]'s [P] .", C)
+				log_and_message_admins("tore out and ate [P] of [T].", C)
 			else
-				log_and_message_admins("tore out [T]'s [P].", C)
-				C.visible_message("<font color='red'><b>[C] severely damages [T]'s [D], resulting in their [P] falling out!</b></font>")
+				log_and_message_admins("tore out [P] of [T].", C)
+				C.visible_message("<font color='red'><b>[C] severely damages [D] of [T], resulting in their [P] coming out!</b></font>")
 		else if(!P && (D.damage >= 25 || D.brute_dam >= 25)) //Not targeting an internal organ & external organ has been severely damaged already.
 			D.droplimb(1,DROPLIMB_EDGE) //Clean cut so it doesn't kill the prey completely.
 			if(D.cannot_amputate) //Is it groin/chest? You can't remove those.
@@ -707,16 +707,16 @@
 				var/datum/belly/S = C.vore_organs[eat_limb]
 				D.forceMove(C) //Move to pred's gut
 				S.internal_contents |= D //Add to pred's gut.
-				C.visible_message("<span class='warning'>[C] swallows the [D] into their [S]!</span>","You swallow [T]'s [D]!")
+				C.visible_message("<span class='warning'>[C] swallows [D] of [T] into their [S]!</span>","You swallow [D] of [T]!")
 				playsound(C, S.vore_sound, 70, 1)
-				C << "Their [D] moves into your [S]!
-				log_and_message_admins("tore off and ate [T]'s [D].", C)
+				C << "Their [D] moves into your [S]!"
+				log_and_message_admins("tore off and ate [D] of [T].", C)
 			else
-				C.visible_message("<span class='warning'>[C] tears off [T]'s [D]!</span>","You tear out [T]'s [D]!")
+				C.visible_message("<span class='warning'>[C] tears off [D] of [T]!</span>","You tear out [D] of [T]!") //Will come out "You tear out (the right foot) of (person)
 				log_and_message_admins("tore off [T]'s [D].", C)
 		else //Not targeting an internal organ w/ > 25 damage , and the limb doesn't have < 25 damage.
 			if(P)
 				P.damage = 25 //Internal organs can only take damage, not brute damage.
 			T.apply_damage(25, BRUTE, D)
-			C.visible_message("<font color='red'><b>[C] severely damages [T]'s [D]!</b></font>") //Keep it vague. Let the /me's do the talking.
-			log_and_message_admins("shreded [T]'s [D].", C)
+			C.visible_message("<font color='red'><b>[C] severely damages [D] of [T]!</b></font>") //Keep it vague. Let the /me's do the talking.
+			log_and_message_admins("shreded [D] of [T].", C)

--- a/code/modules/mob/living/carbon/human/species/station/station_special_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_special_vr.dm
@@ -23,7 +23,12 @@
 	inherent_verbs = list(
 		/mob/living/carbon/human/proc/begin_reconstitute_form,
 		/mob/living/carbon/human/proc/sonar_ping,
-		/mob/living/carbon/human/proc/purge_impurities)
+		/mob/living/carbon/human/proc/purge_impurities,
+		/mob/living/carbon/human/proc/succubus_drain,
+		/mob/living/carbon/human/proc/succubus_drain_finialize,
+		/mob/living/carbon/human/proc/succubus_drain_lethal,
+		/mob/living/carbon/human/proc/bloodsuck,
+		/mob/living/carbon/human/proc/shred_limb) //Xenochimera get all the special verbs since they can't select traits.
 
 	min_age = 18
 	max_age = 80

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
@@ -76,3 +76,9 @@
 	desc = "Makes you able to gain nutrition from draining prey in your grasp."
 	cost = 0
 	var_changes = list("can_drain_prey" = 1) //The verb is given in human.dm
+
+/datum/trait/hard_vore
+	name = "Brutal Predation"
+	desc = "Allows you to tear off limbs & tear out internal organs."
+	cost = 0 //I would make this cost a point, since it has some in game value, but there are easier, less damaging ways to perform the same functions.
+	var_changes = list("hard_vore_enabled" = 1) //The verb is given in human.dm


### PR DESCRIPTION
- Adds "Brutal Predation" 
- Gives xenochimera & prometheans all the special verbs, since they can't use traits to get them. Allows them to use the verbs as appropriate.

Brutal Predation works as so:
0. Choose the Brutal Predation trait or be a xenochimera/promethean.
1. Get a neckgrab on someone.
2. Click the "Damage/Remove Prey's Organ" (HV) verb.
3. Select the external limb you wish to damage/remove.
4. It will then warn you if it's a vital limb or not. (Head is vital, for example.)
5. Click "yes" and it'll prompt you asking if you wish to damage/tear out an internal organ that's contained within that external organ (Groin contains the kidneys, for example.)
6. Select an internal organ or not.
7. It will then ask you if you wish to swallow the organ into your stomach, and give you a list of all your current organs you could swallow it into.
8. Select a stomach (or not).
9. The action will then start being performed. Takes 10 seconds.

The action itself:
1. If only an external organ was selected, it will damage it for 25 damage, or, if it already has 25 or more damage, it will tear the limb off (Provided it doesn't have the cannot_amputate var. If so, it just does 25 more damage.) and, if a stomach was selected, will eat it. Otherwise, the limbdrops onto the ground.
2. If an internal organ was selected, it will damage it for 25 damage or, if it already has 25 damage, it will tear the limb off and put it in a stomach if selected. Otherwise, the organ falls down onto the same tile the prey is on.