### PR TITLE
Resleever grower pod processes meat automatically

### DIFF
--- a/code/modules/resleeving/machines.dm
+++ b/code/modules/resleeving/machines.dm
@@ -106,9 +106,13 @@
 
 /obj/machinery/clonepod/transhuman/process()
 
+	var/visible_message = 0
 	for(var/obj/item/weapon/reagent_containers/food/snacks/meat in range(1, src))
 		qdel(meat)
 		biomass += 50
+		visible_message = 1 // Prevent chatspam if multiple meat are near
+
+	if(visible_message)
 		visible_message("[src] sucks in and processes the nearby biomass.")
 
 	if(stat & NOPOWER)

--- a/code/modules/resleeving/machines.dm
+++ b/code/modules/resleeving/machines.dm
@@ -105,6 +105,12 @@
 	return 1
 
 /obj/machinery/clonepod/transhuman/process()
+
+	for(var/obj/item/weapon/reagent_containers/food/snacks/meat in range(1, src))
+		qdel(meat)
+		biomass += 50
+		visible_message("[src] sucks in and processes the nearby biomass.")
+
 	if(stat & NOPOWER)
 		if(occupant)
 			locked = 0


### PR DESCRIPTION
This let resleever's growing pod processes meat automatically next to it for 50 unit of biomass each. Also include meatpie and such because of code weirdness. Shouldn't cause an issue.

(Doesn't change cloning pod as that'll cause issue when synced with upstream)

