### PR TITLE
Fixes missing limbs showing no names and shit on custom species.

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/blank_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/blank_vr.dm
@@ -28,6 +28,20 @@
 
 	var/list/traits = list()
 
+	has_limbs = list(
+		BP_TORSO =  list("path" = /obj/item/organ/external/chest, "descriptor" = "torso"),
+		BP_GROIN =  list("path" = /obj/item/organ/external/groin, "descriptor" = "groin"),
+		BP_HEAD =   list("path" = /obj/item/organ/external/head, "descriptor" = "head"),
+		BP_L_ARM =  list("path" = /obj/item/organ/external/arm, "descriptor" = "left arm"),
+		BP_R_ARM =  list("path" = /obj/item/organ/external/arm/right, "descriptor" = "right arm"),
+		BP_L_LEG =  list("path" = /obj/item/organ/external/leg, "descriptor" = "left leg"),
+		BP_R_LEG =  list("path" = /obj/item/organ/external/leg/right, "descriptor" = "right leg"),
+		BP_L_HAND = list("path" = /obj/item/organ/external/hand, "descriptor" = "left hand"),
+		BP_R_HAND = list("path" = /obj/item/organ/external/hand/right, "descriptor" = "right hand"),
+		BP_L_FOOT = list("path" = /obj/item/organ/external/foot, "descriptor" = "left foot"),
+		BP_R_FOOT = list("path" = /obj/item/organ/external/foot/right, "descriptor" = "right foot")
+		)
+
 /datum/species/custom/get_bodytype()
 	return base_species
 
@@ -61,7 +75,6 @@
 	new_copy.blood_mask = to_copy.blood_mask
 	new_copy.damage_mask = to_copy.damage_mask
 	new_copy.damage_overlays = to_copy.damage_overlays
-
 	new_copy.traits = traits
 
 	//If you had traits, apply them


### PR DESCRIPTION
- Yeah found out the reason, pretty clear by logic after figuring it out, but still somehow functional for normal species apparently(itjustworks.jpg)???
- The stuff was relying on some sort of "descriptor" in the has_limbs list that does not seem to even exist.
- Adding this "descriptor" to custom species limbs list reliably fixed the issue on test runs.
- No fucking clue how the other species somehow manage without that thing however.

![kuva](https://user-images.githubusercontent.com/13697337/31913526-07e25eac-b850-11e7-920a-f2d04cc211eb.png)

Fixes https://github.com/VOREStation/VOREStation/issues/2355