### PR TITLE
Couple otie tweaks.

### DIFF
--- a/code/modules/mob/living/simple_animal/vore/otie.dm
+++ b/code/modules/mob/living/simple_animal/vore/otie.dm
@@ -154,7 +154,7 @@
 /mob/living/simple_animal/otie/friendly/security/feed_grabbed_to_self(var/mob/living/user, var/mob/living/prey) // Make the gut start out safe for bellybrigging.
 	var/datum/belly/B = user.vore_selected
 	var/datum/belly/belly_target = user.vore_organs[B]
-	if(ishuman(target))
+	if(ishuman(target_mob))
 		belly_target.digest_mode = DM_HOLD
 	if(istype(prey,/mob/living/simple_animal/mouse))
 		belly_target.digest_mode = DM_DIGEST

--- a/code/modules/mob/living/simple_animal/vore/otie.dm
+++ b/code/modules/mob/living/simple_animal/vore/otie.dm
@@ -154,7 +154,7 @@
 /mob/living/simple_animal/otie/friendly/security/feed_grabbed_to_self(var/mob/living/user, var/mob/living/prey) // Make the gut start out safe for bellybrigging.
 	var/datum/belly/B = user.vore_selected
 	var/datum/belly/belly_target = user.vore_organs[B]
-	if(check_threat(target_mob) >= 4)
+	if(ishuman(target))
 		belly_target.digest_mode = DM_HOLD
 	if(istype(prey,/mob/living/simple_animal/mouse))
 		belly_target.digest_mode = DM_DIGEST
@@ -261,6 +261,8 @@
 		if(I_GRAB)
 			if(health > 0)
 				audible_emote("growls disapprovingly at [M].")
+				if(M == friend)
+					friend = null
 				return
 			else
 				..()


### PR DESCRIPTION
-Makes sec otie start with safe belly upon eating any human, not just crime threat ones. (retaliation against lawful crew members etc.)
-Brings back the grab-unfriend thing. The friend thing literally only tells it who to follow around and currently there is no other "stay" command to get it off your tail without just passing it for someone else's trouble.
-May add more updates here if people can be like atleast somewhat constructive with their criticism.