### PR TITLE
Organizes alien whitelist in alphabetical order.

### DIFF
--- a/config/alienwhitelist.txt
+++ b/config/alienwhitelist.txt
@@ -1,10 +1,11 @@
-some~user - Species
+aether_elemental - Daemon
+aruis - Xenochimera
 bothnevarbackwards - Diona
 cameron653 - Xenomorph Hybrid
 hawkerthegreat - Vox
 jemli - Gutter
 natje - Xenochimera
-Rapidvalj - Vox
+rapidvalj - Vox
 rikaru19xjenkins  - Xenomorph Hybrid
 rikaru19xjenkins - Xenochimera
 rixunie - Diona
@@ -14,11 +15,10 @@ sepulchre - Vox
 sepulchre - Xenomorph Hybrid
 silverTalismen - Diona
 silvertalismen - Xenochimera
+singo - Gutter
+some~user - Species
 xioen - Diona
+xioen - Xenochimera
 xioen - Xenomorph Hybrid
 zammyman215 - Vox
 zekesturm - Xenomorph Hybrid
-aether_elemental - Daemon
-Aruis - Xenochimera
-Singo - Gutter
-Xioen - Xenochimera


### PR DESCRIPTION
- Makes alien whitelist alphabetical order.
- Removes capital letters in the ckeys. (This isn't required as the config files say, just looks nicer.)