### PR TITLE
Removes a redundant double check from digestion_death and adminlogs digested players

### DIFF
--- a/code/modules/vore/eating/belly_vr.dm
+++ b/code/modules/vore/eating/belly_vr.dm
@@ -267,6 +267,8 @@
 /datum/belly/proc/digestion_death(var/mob/living/M)
 	is_full = 1
 	//M.death(1) // "Stop it he's already dead..." Basically redundant and the reason behind screaming mouse carcasses.
+	if(M.ckey)
+		message_admins("[key_name(owner)] has digested [key_name(M)] in their [name] ([owner ? "<a href='?_src_=holder;adminplayerobservecoodjump=1;X=[owner.x];Y=[owner.y];Z=[owner.z]'>JMP</a>" : "null"])")
 	internal_contents -= M
 
 	// If digested prey is also a pred... anyone inside their bellies gets moved up.

--- a/code/modules/vore/eating/belly_vr.dm
+++ b/code/modules/vore/eating/belly_vr.dm
@@ -266,7 +266,7 @@
 // Indigestable items are removed, and M is deleted.
 /datum/belly/proc/digestion_death(var/mob/living/M)
 	is_full = 1
-	M.death(1)
+	//M.death(1) // "Stop it he's already dead..." Basically redundant and the reason behind screaming mouse carcasses.
 	internal_contents -= M
 
 	// If digested prey is also a pred... anyone inside their bellies gets moved up.


### PR DESCRIPTION
-If we get into this proc the victim is already dead and there's no need for a re-kill.
-Essentially the cause behind mouse carcasses screaming in the gut.
-Thing was calling the death proc for the already dead mob and the death proc is what contains the scream on mice.