### PR TITLE
Fixes borgs being unable to push past humans.

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_vr.dm
+++ b/code/modules/mob/living/silicon/robot/robot_vr.dm
@@ -1,3 +1,6 @@
+/mob/living/silicon/robot
+	mob_swap_flags = ~HEAVY
+
 /mob/living/silicon/robot/verb/robot_nom(var/mob/living/T in oview(1))
 	set name = "Robot Nom"
 	set category = "IC"


### PR DESCRIPTION
-Their swap flags had humans (only) excluded for some reason with no explanation given in the blamed commits so dunno what was the original intention there over 2 years ago.

Fixes #2209