### PR TITLE
hunger feral tweak and bugfix

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/station_special_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_special_vr.dm
@@ -75,9 +75,11 @@
 				if(H.feral == 0)
 					H << "<span class='danger'><big>Something in your mind flips, your instincts taking over, no longer able to fully comprehend your surroundings as survival becomes your primary concern - you must feed, survive, there is nothing else. Hunt. Eat. Hide. Repeat.</big></span>"
 					log_and_message_admins("has gone feral due to hunger.", H)
+					H.feral += 5 //just put them over the threshold by a decent amount for the first chunk.
 					if(H.stat == CONSCIOUS)
 						H.emote("twitch")
-				H.feral = min(150-H.nutrition, H.feral+1) //Feralness increases while this hungry, capped at 50-150 depending on hunger.
+				if(H.feral + H.nutrition < 150) //Feralness increases while this hungry, capped at 50-150 depending on hunger.
+					H.feral += 1
 
 		// If they're hurt, chance of snapping. Not if they're straight-up KO'd though.
 		if (H.stat == CONSCIOUS && H.traumatic_shock >=min(60, H.nutrition/10)) //at 360 nutrition, this is 30 brute/burn, or 18 halloss. Capped at 50 brute/30 halloss - if they take THAT much, no amount of satiation will help them. Also they're fat.


### PR DESCRIPTION
Last night there was an issue where someone went feral over and over and over and spammed the message log. Thus far I've been unable to replicate it, the only thing that I can think of that might be causing it is if feralness wasn't being incremented somehow, or was being reduced back to 0 for whatever reason without it being part of the normal proc for feralness wearing off.

Changes the hunger feral proc slightly so the moment they go feral, they instantly go up to 5. Considering that this only happens at a nutrition level of 100 or less, and they should be ticking up to 50, this only makes it happen 5 ticks faster so who cares.

Also removes the min() and replaces it with a conditional increment - the old min() proc was applying a ceiling where it shouldn't in cases where feral chimera had eaten, but hadn't eaten enough to get their nutrition over 100. (people with 75 feral were having it reduced to 50 if they brought their nutrition up to 100, instead of it wearing off only after they were over 200 like they should)