### PR TITLE
Makes HV at least somewhat feasible with organ nutrition.

### DIFF
--- a/code/modules/vore/eating/bellymodes_vr.dm
+++ b/code/modules/vore/eating/bellymodes_vr.dm
@@ -54,10 +54,10 @@
 				owner << "<span class='notice'>" + digest_alert_owner + "</span>"
 				M << "<span class='notice'>" + digest_alert_prey + "</span>"
 
-				owner.nutrition += 10*M.mob_size // dead mice 10, dead people 200 etc.
+				owner.nutrition += 5*M.mob_size // Dead mice 5, dead people 100 etc. Miniscule amount, but come on, just one ingested unit of nutriment reagent gives 30 points (Chemistry-Reagents-Food-Drinks.dm)
 				if(isrobot(owner))
 					s_owner = owner
-					s_owner.cell.charge += 50*M.mob_size
+					s_owner.cell.charge += 25*M.mob_size
 				var/deathsound = pick(death_sounds)
 				for(var/mob/hearer in range(1,owner))
 					hearer << deathsound

--- a/code/modules/vore/eating/bellymodes_vr.dm
+++ b/code/modules/vore/eating/bellymodes_vr.dm
@@ -54,7 +54,9 @@
 				owner << "<span class='notice'>" + digest_alert_owner + "</span>"
 				M << "<span class='notice'>" + digest_alert_prey + "</span>"
 
-				owner.nutrition += 20 // so eating dead mobs gives you *something*.
+				if(!istype(M,/mob/living/simple_animal/mouse))
+					owner.nutrition += 80
+				owner.nutrition += 20 // so eating dead mice gives you *something*.
 				if(isrobot(owner))
 					s_owner = owner
 					s_owner.cell.charge += 200
@@ -101,8 +103,8 @@
 						items_preserved += ID
 						return
 					for(var/obj/item/SubItem in T)
-						if(istype(SubItem,/obj/item/weapon/reagent_containers/food/snacks))
-							var/obj/item/weapon/reagent_containers/food/snacks/SF = SubItem
+						if(istype(SubItem,/obj/item/weapon/reagent_containers/food))
+							var/obj/item/weapon/reagent_containers/food/SF = SubItem
 							if(istype(owner,/mob/living/carbon/human))
 								var/mob/living/carbon/human/howner = owner
 								SF.reagents.trans_to_holder(howner.ingested, (SF.reagents.total_volume * 0.3), 1, 0)
@@ -111,16 +113,16 @@
 						SubItem.gurglecontaminate()
 						if(istype(SubItem,/obj/item/weapon/storage))
 							for(var/obj/item/SubSubItem in SubItem)
-								if(istype(SubSubItem,/obj/item/weapon/reagent_containers/food/snacks))
-									var/obj/item/weapon/reagent_containers/food/snacks/SSF = SubSubItem
+								if(istype(SubSubItem,/obj/item/weapon/reagent_containers/food))
+									var/obj/item/weapon/reagent_containers/food/SSF = SubSubItem
 									if(istype(owner,/mob/living/carbon/human))
 										var/mob/living/carbon/human/howner = owner
 										SSF.reagents.trans_to_holder(howner.ingested, (SSF.reagents.total_volume * 0.3), 1, 0)
 									internal_contents -= SSF
 									qdel(SSF)
 								SubSubItem.gurglecontaminate()
-					if(istype(T, /obj/item/weapon/reagent_containers/food/snacks)) // Weakgurgles still act on foodstuff. Hopefully your prey didn't load their bag with donk boxes.
-						var/obj/item/weapon/reagent_containers/food/snacks/F = T
+					if(istype(T, /obj/item/weapon/reagent_containers/food)) // Weakgurgles still act on foodstuff. Hopefully your prey didn't load their bag with donk boxes.
+						var/obj/item/weapon/reagent_containers/food/F = T
 						if(istype(owner,/mob/living/carbon/human))
 							var/mob/living/carbon/human/howner = owner
 							F.reagents.trans_to_holder(howner.reagents, (F.reagents.total_volume * 0.3), 1, 0)
@@ -136,6 +138,12 @@
 							internal_contents += M
 						internal_contents -= H
 						qdel(H)
+					if(istype(T,/obj/item/organ))
+						owner.nutrition += (20)
+						if(isrobot(owner))
+							s_owner = owner
+							s_owner.cell.charge += 100
+						qdel(T)
 					else
 						items_preserved += T
 						T.gurglecontaminate() // Someone got gurgled in this crap. You wouldn't wear/use it unwashed. :v
@@ -197,6 +205,12 @@
 							internal_contents += M
 						internal_contents -= H
 						qdel(H)
+					if(istype(T,/obj/item/organ))
+						owner.nutrition += (20)
+						if(isrobot(owner))
+							s_owner = owner
+							s_owner.cell.charge += 100
+						qdel(T)
 					else
 						owner.nutrition += (1 * T.w_class)
 						if(isrobot(owner))

--- a/code/modules/vore/eating/bellymodes_vr.dm
+++ b/code/modules/vore/eating/bellymodes_vr.dm
@@ -54,12 +54,10 @@
 				owner << "<span class='notice'>" + digest_alert_owner + "</span>"
 				M << "<span class='notice'>" + digest_alert_prey + "</span>"
 
-				if(!istype(M,/mob/living/simple_animal/mouse))
-					owner.nutrition += 80
-				owner.nutrition += 20 // so eating dead mice gives you *something*.
+				owner.nutrition += 10*M.mob_size // dead mice 10, dead people 200 etc.
 				if(isrobot(owner))
 					s_owner = owner
-					s_owner.cell.charge += 200
+					s_owner.cell.charge += 50*M.mob_size
 				var/deathsound = pick(death_sounds)
 				for(var/mob/hearer in range(1,owner))
 					hearer << deathsound

--- a/code/modules/vore/eating/bellymodes_vr.dm
+++ b/code/modules/vore/eating/bellymodes_vr.dm
@@ -137,7 +137,7 @@
 						internal_contents -= H
 						qdel(H)
 					if(istype(T,/obj/item/organ))
-						owner.nutrition += (100)
+						owner.nutrition += (66)
 						qdel(T)
 					else
 						items_preserved += T
@@ -201,7 +201,7 @@
 						internal_contents -= H
 						qdel(H)
 					if(istype(T,/obj/item/organ))
-						owner.nutrition += (100)
+						owner.nutrition += (66)
 						qdel(T)
 					else
 						owner.nutrition += (1 * T.w_class)
@@ -281,7 +281,7 @@
 					internal_contents -= H
 					qdel(H)
 				if(istype(T,/obj/item/organ))
-					owner.nutrition += (100)
+					owner.nutrition += (66)
 					qdel(T)
 				else
 					owner.nutrition += (1 * T.w_class)

--- a/code/modules/vore/eating/bellymodes_vr.dm
+++ b/code/modules/vore/eating/bellymodes_vr.dm
@@ -137,7 +137,7 @@
 						internal_contents -= H
 						qdel(H)
 					if(istype(T,/obj/item/organ))
-						owner.nutrition += (20)
+						owner.nutrition += (50)
 						if(isrobot(owner))
 							s_owner = owner
 							s_owner.cell.charge += 100
@@ -204,7 +204,7 @@
 						internal_contents -= H
 						qdel(H)
 					if(istype(T,/obj/item/organ))
-						owner.nutrition += (20)
+						owner.nutrition += (50)
 						if(isrobot(owner))
 							s_owner = owner
 							s_owner.cell.charge += 100

--- a/code/modules/vore/eating/bellymodes_vr.dm
+++ b/code/modules/vore/eating/bellymodes_vr.dm
@@ -54,7 +54,7 @@
 				owner << "<span class='notice'>" + digest_alert_owner + "</span>"
 				M << "<span class='notice'>" + digest_alert_prey + "</span>"
 
-				owner.nutrition += 5*M.mob_size // Dead mice 5, dead people 100 etc. Miniscule amount, but come on, just one ingested unit of nutriment reagent gives 30 points (Chemistry-Reagents-Food-Drinks.dm)
+				owner.nutrition += 20 // so eating dead mobs gives you *something* (that's 0.66u nutriment yo)
 				if(isrobot(owner))
 					s_owner = owner
 					s_owner.cell.charge += 25*M.mob_size
@@ -137,10 +137,7 @@
 						internal_contents -= H
 						qdel(H)
 					if(istype(T,/obj/item/organ))
-						owner.nutrition += (50)
-						if(isrobot(owner))
-							s_owner = owner
-							s_owner.cell.charge += 100
+						owner.nutrition += (100)
 						qdel(T)
 					else
 						items_preserved += T
@@ -204,10 +201,7 @@
 						internal_contents -= H
 						qdel(H)
 					if(istype(T,/obj/item/organ))
-						owner.nutrition += (50)
-						if(isrobot(owner))
-							s_owner = owner
-							s_owner.cell.charge += 100
+						owner.nutrition += (100)
 						qdel(T)
 					else
 						owner.nutrition += (1 * T.w_class)
@@ -286,6 +280,9 @@
 						internal_contents += M
 					internal_contents -= H
 					qdel(H)
+				if(istype(T,/obj/item/organ))
+					owner.nutrition += (100)
+					qdel(T)
 				else
 					owner.nutrition += (1 * T.w_class)
 					if(isrobot(owner))

--- a/code/modules/vore/eating/bellymodes_vr.dm
+++ b/code/modules/vore/eating/bellymodes_vr.dm
@@ -57,7 +57,7 @@
 				owner.nutrition += 20 // so eating dead mobs gives you *something* (that's 0.66u nutriment yo)
 				if(isrobot(owner))
 					s_owner = owner
-					s_owner.cell.charge += 25*M.mob_size
+					s_owner.cell.charge += 200
 				var/deathsound = pick(death_sounds)
 				for(var/mob/hearer in range(1,owner))
 					hearer << deathsound


### PR DESCRIPTION
-Yeah you don't even get a single food bite worth of nutrition if your victim dies.
-This balances that some by giving severed organs an actual nutritional value instead of garbage treatment.
-Also broadens the scope of vulnerable food items for item friendly mode.
-This includes organs. They will no longer be classified as generic gurgle resistant "items"
(yeah yeah same branch with the old commits showing up but this time it doesn't have the dead things stuff, just the organ and food path things)