### PR TITLE
Loadout edits

### DIFF
--- a/code/modules/client/preference_setup/loadout/loadout_accessories.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_accessories.dm
@@ -29,14 +29,18 @@
 /datum/gear/accessory/wallet
 	display_name = "wallet, orange"
 	path = /obj/item/weapon/storage/wallet/random
+	cost = 1 //VOREStation Edit
 
 /datum/gear/accessory/wallet_poly
 	display_name = "wallet, polychromic"
 	path = /obj/item/weapon/storage/wallet/poly
+	cost = 0 //VOREStation Edit
+	
 
 /datum/gear/accessory/wallet/womens
 	display_name = "wallet, womens"
 	path = /obj/item/weapon/storage/wallet/womens
+	cost = 0 //VOREStation Edit
 
 /datum/gear/accessory/wallet/womens/New()
 	..()

--- a/code/modules/client/preference_setup/loadout/loadout_accessories.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_accessories.dm
@@ -29,7 +29,6 @@
 /datum/gear/accessory/wallet
 	display_name = "wallet, orange"
 	path = /obj/item/weapon/storage/wallet/random
-	cost = 1 //VOREStation Edit
 
 /datum/gear/accessory/wallet_poly
 	display_name = "wallet, polychromic"

--- a/code/modules/client/preference_setup/loadout/loadout_utility.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_utility.dm
@@ -94,7 +94,7 @@
 /datum/gear/utility/implant/tracking
 	display_name = "implant, tracking"
 	path = /obj/item/weapon/implant/tracking/weak
-	cost = 10
+	cost = 0 //VOREStation Edit. Changed cost to 0
 	slot = "implant"
 	exploitable = 1
 


### PR DESCRIPTION
- **Makes tracking implant that spawns in you cost 0.** 
People can teleport to you and get instanommed & it tells security where you are if they look at the monitor. Not really _too_ useful outside of a telenom, and the downside of bigbrother always knowing where you are makes it costing points unreasonable.
- **Makes wallets (excluding orange wallet) free.** 
Wallets are so common that you can easily find them. This saves people a few minutes of searching maint for a wallet so they can have a fancy armband or something. Orange wallet still costs 1, since it  spawns with cash in it. Requested change.