### PR TITLE
Rebalanced the Energy Luger

### DIFF
--- a/code/modules/vore/fluffstuff/custom_guns_vr.dm
+++ b/code/modules/vore/fluffstuff/custom_guns_vr.dm
@@ -419,7 +419,7 @@
 // ------------ Energy Luger ------------
 /obj/item/weapon/gun/energy/gun/eluger
 	name = "energy Luger"
-	desc = "The finest sidearm produced by RauMauser; this pistol can punch a hole through inch thick steel plating. This ain't your great-grand-daddy's Luger! Can switch between stun and kill."
+	desc = "The finest sidearm produced by RauMauser. Although its battery cannot be removed, its ergonomic design makes it easy to shoot, allowing for rapid follow-up shots. It also has the ability to toggle between stun and kill."
 	icon = 'icons/obj/gun_vr.dmi'
 	icon_state = "elugerstun100"
 	item_state = "gun"

--- a/code/modules/vore/fluffstuff/custom_guns_vr.dm
+++ b/code/modules/vore/fluffstuff/custom_guns_vr.dm
@@ -423,13 +423,14 @@
 	icon = 'icons/obj/gun_vr.dmi'
 	icon_state = "elugerstun100"
 	item_state = "gun"
-	charge_cost = 100 //How much energy is needed to fire.
-	projectile_type = /obj/item/projectile/beam/stun
+	fire_delay = null // Lugers are quite comfortable to shoot, thus allowing for more controlled follow-up shots. Rate of fire similar to a laser carbine.
+	battery_lock = 1 // In exchange for balance, you cannot remove the battery. Also there's no sprite for that and I fucking suck at sprites. -Ace
+	origin_tech = list(TECH_COMBAT = 3, TECH_MAGNET = 2, TECH_ILLEGAL = 2) // Illegal tech cuz Space Nazis
 	modifystate = "elugerstun"
 	fire_sound = 'sound/weapons/Taser.ogg'
 	firemodes = list(
-	list(mode_name="stun", charge_cost=100,projectile_type=/obj/item/projectile/beam/stun, modifystate="elugerstun", fire_sound='sound/weapons/Taser.ogg'),
-	list(mode_name="lethal", charge_cost=200,projectile_type=/obj/item/projectile/beam/eluger, modifystate="elugerkill", fire_sound='sound/weapons/eluger.ogg'),
+	list(mode_name="stun", charge_cost=120,projectile_type=/obj/item/projectile/beam/stun, modifystate="elugerstun", fire_sound='sound/weapons/Taser.ogg'),
+	list(mode_name="lethal", charge_cost=240,projectile_type=/obj/item/projectile/beam/eluger, modifystate="elugerkill", fire_sound='sound/weapons/eluger.ogg'),
 	)
 
 //////////////////// Eris Ported Guns ////////////////////


### PR DESCRIPTION
@Yoshax noticed that the Energy Luger can do a retarded amount of damage over its Energy Gun counterpart. The Energy Luger has 140% more shots on all settings than the standard Energy Gun. The Energy Luger has the potential to do 2.4x more damage. This is absurd, and not its intended design. This was an oversight that occured during a recent rework of Polaris energy guns and how batteries work.

I have three possible solutions. This is one of them.

- A) Rebalance it to match the energy gun, including the ability to reload it (requires a new sprite which I do not have).
- B) Lock the battery, making it impossible to reload without a charge station, but allow it to keep twice the capacity. (I'll fix the numbers so it's exactly 2x the Egun capacity, not 2.4x)
- C) Lock the battery, but remove the firing delay. **This is what I did in this PR.**

Discuss the three solutions and decide what is best. Option A is not an option without a sprite, though, so if anyone wants option A, make a sprite.