### PR TITLE
Adds sound/verb edit for ejection and the framework for different vore audio sets.

### DIFF
--- a/code/_helpers/global_lists_vr.dm
+++ b/code/_helpers/global_lists_vr.dm
@@ -136,6 +136,7 @@ var/global/list/vore_sounds = list(
 		"None" = null)
 
 var/global/list/release_sounds = list(
+		"Splat" = 'sound/effects/splat.ogg',
 		"F cough" = 'sound/effects/mob_effects/f_cougha.ogg',
 		"M cough" = 'sound/effects/mob_effects/m_cougha.ogg',
 		"Synthcough" = 'sound/effects/mob_effects/m_machine_coughc.ogg',

--- a/code/_helpers/global_lists_vr.dm
+++ b/code/_helpers/global_lists_vr.dm
@@ -43,6 +43,13 @@ var/global/list/important_items = list(
 		/obj/item/clothing/suit/storage/hooded/wintercoat/roiz)
 
 var/global/list/digestion_sounds = list(
+		"organic" = digest_organic,
+		"none" = digest_none/*, // NEED NOISES FOR THE REST,
+		"mech" = digest_mech,
+		"goop" = digest_goop,
+		"cyber" = digest_cyber*/)
+
+var/global/list/digest_organic = list(
 		'sound/vore/digest1.ogg',
 		'sound/vore/digest2.ogg',
 		'sound/vore/digest3.ogg',
@@ -56,7 +63,30 @@ var/global/list/digestion_sounds = list(
 		'sound/vore/digest11.ogg',
 		'sound/vore/digest12.ogg')
 
+var/global/list/digest_none = list(null)
+
+var/global/list/digest_mech = list(
+		'sound/items/poster_being_created.ogg',
+		'sound/items/pshred.ogg',
+		'sound/mecha/mechmove04.ogg') // TERRIBLE PRE-SOUND DESIGN PLACEHOLDERS
+
+var/global/list/digest_goop = list(
+		'sound/effects/slime_squish.ogg',
+		'sound/items/drink.ogg',
+		'sound/effects/slosh.ogg') // TERRIBLE PRE-SOUND DESIGN PLACEHOLDERS
+
+var/global/list/digest_cyber = list(
+		'sound/machines/boobeebeep.ogg',
+		'sound/machines/buzzbeep.ogg') // TERRIBLE PRE-SOUND DESIGN PLACEHOLDERS
+
 var/global/list/death_sounds = list(
+		"organic" = gdeath_organic,
+		"none" = gdeath_none/*, // NEED NOISES FOR THE REST,
+		"mech" = gdeath_mech,
+		"goop" = gdeath_goop,
+		"cyber" = gdeath_cyber*/)
+
+var/global/list/gdeath_organic = list(
 		'sound/vore/death1.ogg',
 		'sound/vore/death2.ogg',
 		'sound/vore/death3.ogg',
@@ -67,6 +97,18 @@ var/global/list/death_sounds = list(
 		'sound/vore/death8.ogg',
 		'sound/vore/death9.ogg',
 		'sound/vore/death10.ogg')
+
+var/global/list/gdeath_none = list(null)
+
+var/global/list/gdeath_mech = list(
+		'sound/mecha/mechdrill.ogg',
+		'sound/machines/juicer.ogg') // TERRIBLE PRE-SOUND DESIGN PLACEHOLDERS
+
+var/global/list/gdeath_goop = list(
+		'sound/effects/blobattack.ogg') // TERRIBLE PRE-SOUND DESIGN PLACEHOLDERS
+
+var/global/list/gdeath_cyber = list(
+		'sound/machines/ding.ogg') // TERRIBLE PRE-SOUND DESIGN PLACEHOLDERS
 
 var/global/list/hunger_sounds = list(
 		'sound/vore/growl1.ogg',
@@ -87,6 +129,29 @@ var/global/list/vore_sounds = list(
 		"Squish3" = 'sound/vore/squish3.ogg',
 		"Squish4" = 'sound/vore/squish4.ogg',
 		"Rustle (cloth)" = 'sound/effects/rustle5.ogg',
+		"Disposal unit" = 'sound/machines/disposalflush.ogg',
+		"Chew" = 'sound/items/eatfood.ogg',
+		"Shred" = 'sound/items/pshred.ogg',
+		"Firelock" = 'sound/machines/firelockopen.ogg',
+		"None" = null)
+
+var/global/list/release_sounds = list(
+		"F cough" = 'sound/effects/mob_effects/f_cougha.ogg',
+		"M cough" = 'sound/effects/mob_effects/m_cougha.ogg',
+		"Synthcough" = 'sound/effects/mob_effects/m_machine_coughc.ogg',
+		"Tesh cough" = 'sound/effects/mob_effects/tesharicougha.ogg',
+		"Insert" = 'sound/vore/insert.ogg',
+		"Insertion1" = 'sound/vore/insertion1.ogg',
+		"Insertion2" = 'sound/vore/insertion2.ogg',
+		"Insertion3" = 'sound/vore/insertion3.ogg',
+		"Schlorp" = 'sound/vore/schlorp.ogg',
+		"Squish1" = 'sound/vore/squish1.ogg',
+		"Squish2" = 'sound/vore/squish2.ogg',
+		"Squish3" = 'sound/vore/squish3.ogg',
+		"Squish4" = 'sound/vore/squish4.ogg',
+		"Rustle (cloth)" = 'sound/effects/rustle5.ogg',
+		"Disposal unit" = 'sound/machines/disposalflush.ogg',
+		"Shred" = 'sound/items/pshred.ogg',
 		"None" = null)
 
 var/global/list/struggle_sounds = list(

--- a/code/modules/vore/eating/belly_vr.dm
+++ b/code/modules/vore/eating/belly_vr.dm
@@ -12,7 +12,11 @@
 	var/name								// Name of this location
 	var/inside_flavor						// Flavor text description of inside sight/sound/smells/feels.
 	var/vore_sound = 'sound/vore/gulp.ogg'	// Sound when ingesting someone
+	var/digestion_sounds_pref				// Digestion sound set.
+	var/death_sounds_pref					// Gurgledeath sound set.
+	var/release_sound = 'sound/effects/splat.ogg'	// Release sound.
 	var/vore_verb = "ingest"				// Verb for eating with this in messages
+	var/release_verb = "expels"				// Verb for releasing with this in messages
 	var/human_prey_swallow_time = 100		// Time in deciseconds to swallow /mob/living/carbon/human
 	var/nonhuman_prey_swallow_time = 30		// Time in deciseconds to swallow anything else
 	var/emoteTime = 600						// How long between stomach emotes at prey
@@ -117,6 +121,7 @@
 /datum/belly/proc/release_all_contents()
 	if (internal_contents.len == 0)
 		return 0
+	playsound(owner, release_sound, 50, 1)
 	for (var/atom/movable/M in internal_contents)
 		if(istype(M,/mob/living))
 			var/mob/living/ML = M
@@ -130,7 +135,7 @@
 			B.internal_contents += M
 	items_preserved.Cut()
 	checked_slots.Cut()
-	owner.visible_message("<font color='green'><b>[owner] expels everything from their [lowertext(name)]!</b></font>")
+	owner.visible_message("<font color='green'><b>[owner] [release_verb] everything from their [lowertext(name)]!</b></font>")
 	return 1
 
 // Release a specific atom from the contents of this belly into the owning mob's location.
@@ -164,7 +169,8 @@
 	if(B)
 		B.internal_contents += M
 
-	owner.visible_message("<font color='green'><b>[owner] expels [M] from their [lowertext(name)]!</b></font>")
+	owner.visible_message("<font color='green'><b>[owner] [release_verb] [M] from their [lowertext(name)]!</b></font>")
+	playsound(owner, release_sound, 50, 1)
 	owner.update_icons()
 	return 1
 
@@ -544,6 +550,10 @@
 	dupe.inside_flavor = inside_flavor
 	dupe.vore_sound = vore_sound
 	dupe.vore_verb = vore_verb
+	dupe.digestion_sounds_pref = digestion_sounds_pref
+	dupe.death_sounds_pref = death_sounds_pref
+	dupe.release_sound = release_sound
+	dupe.release_verb = release_verb
 	dupe.human_prey_swallow_time = human_prey_swallow_time
 	dupe.nonhuman_prey_swallow_time = nonhuman_prey_swallow_time
 	dupe.emoteTime = emoteTime

--- a/code/modules/vore/eating/bellymodes_vr.dm
+++ b/code/modules/vore/eating/bellymodes_vr.dm
@@ -27,7 +27,7 @@
 		var/mob/living/silicon/robot/s_owner = null
 
 		if(prob(50)) //Was SO OFTEN. AAAA.
-			var/churnsound = pick(digestion_sounds)
+			var/churnsound = pick(digestion_sounds_pref)
 			for(var/mob/hearer in range(1,owner))
 				hearer << sound(churnsound,volume=80)
 
@@ -58,7 +58,7 @@
 				if(isrobot(owner))
 					s_owner = owner
 					s_owner.cell.charge += 200
-				var/deathsound = pick(death_sounds)
+				var/deathsound = pick(death_sounds_pref)
 				for(var/mob/hearer in range(1,owner))
 					hearer << deathsound
 				digestion_death(M)
@@ -222,7 +222,7 @@
 		var/mob/living/silicon/robot/s_owner = null
 
 		if(prob(50))
-			var/churnsound = pick(digestion_sounds)
+			var/churnsound = pick(digestion_sounds_pref)
 			for(var/mob/hearer in range(1,owner))
 				hearer << sound(churnsound,volume=80)
 
@@ -346,7 +346,7 @@
 		for (var/mob/living/M in internal_contents)
 
 			if(prob(10)) //Less often than gurgles. People might leave this on forever.
-				var/absorbsound = pick(digestion_sounds)
+				var/absorbsound = pick(digestion_sounds_pref)
 				M << sound(absorbsound,volume=80)
 				owner << sound(absorbsound,volume=80)
 
@@ -382,7 +382,7 @@
 		for (var/mob/living/M in internal_contents)
 
 			if(prob(10)) //Less often than gurgles. People might leave this on forever.
-				var/drainsound = pick(digestion_sounds)
+				var/drainsound = pick(digestion_sounds_pref)
 				M << sound(drainsound,volume=80)
 				owner << sound(drainsound,volume=80)
 
@@ -399,7 +399,7 @@
 		for (var/mob/living/M in internal_contents)
 
 			if(prob(10)) //Infinite gurgles!
-				var/shrinksound = pick(digestion_sounds)
+				var/shrinksound = pick(digestion_sounds_pref)
 				M << sound(shrinksound,volume=80)
 				owner << sound(shrinksound,volume=80)
 
@@ -418,7 +418,7 @@
 		for (var/mob/living/M in internal_contents)
 
 			if(prob(10))
-				var/growsound = pick(digestion_sounds)
+				var/growsound = pick(digestion_sounds_pref)
 				M << sound(growsound,volume=80)
 				owner << sound(growsound,volume=80)
 
@@ -434,7 +434,7 @@
 		for (var/mob/living/M in internal_contents)
 
 			if(prob(10))
-				var/growsound = pick(digestion_sounds)
+				var/growsound = pick(digestion_sounds_pref)
 				M << sound(growsound,volume=80)
 				owner << sound(growsound,volume=80)
 
@@ -450,7 +450,7 @@
 ///////////////////////////// DM_HEAL /////////////////////////////
 	if(digest_mode == DM_HEAL)
 		if(prob(50)) //Wet heals!
-			var/healsound = pick(digestion_sounds)
+			var/healsound = pick(digestion_sounds_pref)
 			for(var/mob/hearer in range(1,owner))
 				hearer << sound(healsound,volume=80)
 

--- a/code/modules/vore/eating/living_vr.dm
+++ b/code/modules/vore/eating/living_vr.dm
@@ -54,6 +54,8 @@
 				B.name = "Stomach"
 				B.inside_flavor = "It appears to be rather warm and wet. Makes sense, considering it's inside \the [M.name]."
 				B.can_taste = 1
+				B.digestion_sounds_pref = digestion_sounds["organic"]
+				B.death_sounds_pref = death_sounds["organic"]
 				M.vore_organs[B.name] = B
 				M.vore_selected = B.name
 

--- a/code/modules/vore/eating/vorepanel_vr.dm
+++ b/code/modules/vore/eating/vorepanel_vr.dm
@@ -202,6 +202,10 @@
 		dat += "<br><a href='?src=\ref[src];b_verb=\ref[selected]'>Vore Verb:</a>"
 		dat += " '[selected.vore_verb]'"
 
+		//Release verb
+		dat += "<br><a href='?src=\ref[src];b_verb_release=\ref[selected]'>Release Verb:</a>"
+		dat += " '[selected.release_verb]'"
+
 		//Inside flavortext
 		dat += "<br><a href='?src=\ref[src];b_desc=\ref[selected]'>Flavor Text:</a>"
 		dat += " '[selected.inside_flavor]'"
@@ -209,6 +213,18 @@
 		//Belly sound
 		dat += "<br><a href='?src=\ref[src];b_sound=\ref[selected]'>Set Vore Sound</a>"
 		dat += "<a href='?src=\ref[src];b_soundtest=\ref[selected]'>Test</a>"
+
+		//Release sound
+		dat += "<br><a href='?src=\ref[src];b_sound_release=\ref[selected]'>Set Release Sound</a>"
+		dat += "<a href='?src=\ref[src];b_soundtest_release=\ref[selected]'>Test</a>"
+
+		//Gurgle sound
+		dat += "<br><a href='?src=\ref[src];b_sound_digest=\ref[selected]'>Set Digestion Soundtype</a>"
+		dat += "<a href='?src=\ref[src];b_soundtest_digest=\ref[selected]'>Test</a>"
+
+		//Death sound
+		dat += "<br><a href='?src=\ref[src];b_sound_death=\ref[selected]'>Set Digestion Death Soundtype</a>"
+		dat += "<a href='?src=\ref[src];b_soundtest_death=\ref[selected]'>Test</a>"
 
 		//Belly messages
 		dat += "<br><a href='?src=\ref[src];b_msgs=\ref[selected]'>Belly Messages</a>"
@@ -436,7 +452,6 @@
 					return 0
 
 				selected.release_specific_contents(tgt)
-				playsound(user, 'sound/effects/splat.ogg', 50, 1)
 
 			if("Move")
 				if(user.stat)
@@ -587,6 +602,15 @@
 
 		selected.vore_verb = new_verb
 
+	if(href_list["b_verb_release"])
+		var/new_verb_release = html_encode(input(usr,"New verb when releasing contents (present tense, e.g. expels or barfs):","New Verb") as text|null)
+
+		if(length(new_verb_release) > BELLIES_NAME_MAX || length(new_verb_release) < BELLIES_NAME_MIN)
+			alert("Entered verb length invalid (must be longer than [BELLIES_NAME_MIN], no longer than [BELLIES_NAME_MAX]).","Error")
+			return 0
+
+		selected.release_verb = new_verb_release
+
 	if(href_list["b_sound"])
 		var/choice = input(user,"Currently set to [selected.vore_sound]","Select Sound") in vore_sounds + "Cancel - No Changes"
 
@@ -597,6 +621,41 @@
 
 	if(href_list["b_soundtest"])
 		user << selected.vore_sound
+
+	if(href_list["b_sound_release"])
+		var/choice = input(user,"Currently set to [selected.release_sound]","Select Sound") in release_sounds + "Cancel - No Changes"
+
+		if(choice == "Cancel")
+			return 0
+
+		selected.release_sound = release_sounds[choice]
+
+	if(href_list["b_soundtest_release"])
+		user << selected.release_sound
+
+	if(href_list["b_sound_digest"])
+		var/choice = input(user,"","Select Sound Type") in digestion_sounds + "Cancel - No Changes"
+
+		if(choice == "Cancel")
+			return 0
+
+		selected.digestion_sounds_pref = digestion_sounds[choice]
+
+	if(href_list["b_soundtest_digest"])
+		var/sound = pick(selected.digestion_sounds_pref)
+		user << sound
+
+	if(href_list["b_sound_death"])
+		var/choice = input(user,"","Select Sound Type") in death_sounds + "Cancel - No Changes"
+
+		if(choice == "Cancel")
+			return 0
+
+		selected.death_sounds_pref = death_sounds[choice]
+
+	if(href_list["b_soundtest_death"])
+		var/sound = pick(selected.death_sounds_pref)
+		user << sound
 
 	if(href_list["b_tastes"])
 		selected.can_taste = !selected.can_taste


### PR DESCRIPTION
-With this stuff you can choose what sort of noises your guts make, were you a fleshbag, slimebag, scrapheap, or just otherwise acoustically deviant entity doing something beyond imagination to the poor sod inside you.
-This also allows you to set those to make no sound at all.
-In fact that is the only non-default option at this point. The other sets need their sounds made before they can be of use!
-Also allows picking sound and verb for ejection like it already is for insertion.
-Adds test preview button for gurgles and gurgledeaths that plays a random sound from the selected selection.
-Adds a couple extra insertion/ejection sounds. (existing ingame assets for now, some machine sounds and coughs)