### PR TITLE
Increases main engine SMES default output

### DIFF
--- a/maps/tether/tether-03-station.dmm
+++ b/maps/tether/tether-03-station.dmm
@@ -144,7 +144,7 @@
 "acN" = (/obj/machinery/power/terminal{dir = 4},/obj/structure/cable/yellow{d2 = 2; icon_state = "0-2"},/obj/machinery/camera/network/engineering,/turf/simulated/floor,/area/engineering/engine_smes)
 "acO" = (/obj/machinery/power/terminal{tag = "icon-term (WEST)"; icon_state = "term"; dir = 8},/obj/structure/cable/yellow{d2 = 2; icon_state = "0-2"},/turf/simulated/floor,/area/engineering/engine_smes)
 "acP" = (/obj/machinery/power/grid_checker,/obj/structure/cable{d2 = 8; icon_state = "0-8"},/obj/structure/cable{icon_state = "0-4"; d2 = 4},/turf/simulated/floor,/area/engineering/engine_smes)
-"acQ" = (/obj/machinery/power/smes/buildable{charge = 2e+007; cur_coils = 4; input_attempt = 1; input_level = 500000; output_level = 500000; RCon_tag = "Power - Main"},/obj/structure/cable{icon_state = "0-4"; d2 = 4},/turf/simulated/floor,/area/engineering/engine_smes)
+"acQ" = (/obj/machinery/power/smes/buildable{charge = 2e+007; cur_coils = 4; input_attempt = 1; input_level = 500000; output_level = 1000000; RCon_tag = "Power - Main"},/obj/structure/cable{icon_state = "0-4"; d2 = 4},/turf/simulated/floor,/area/engineering/engine_smes)
 "acR" = (/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 6},/obj/effect/floor_decal/steeldecal/steel_decals7{dir = 1},/turf/simulated/floor/tiled,/area/engineering/hallway)
 "acS" = (/turf/simulated/wall/r_wall,/area/engineering/workshop)
 "acT" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/effect/floor_decal/spline/plain{dir = 8},/turf/simulated/floor/wood,/area/crew_quarters/sleep/Dorm_5)


### PR DESCRIPTION
This prevents the tram and cafe area from blacking out within minutes of roundstart, and gives engineers more time to arrive and start setting up power before people start yelling about being trapped in the tram spawnpoint.