### PR TITLE
Attempt to clean up player_list if an issue is found

### DIFF
--- a/code/_helpers/game.dm
+++ b/code/_helpers/game.dm
@@ -281,9 +281,12 @@
 
 	//A list of every mob with a client
 	for(var/mob in player_list)
+		//VOREStation Edit - Trying to fix some vorestation bug.
 		if(!istype(mob, /mob))
-			crash_with("There is a null or non-mob reference inside player_list.")
+			player_list -= mob
+			crash_with("There is a null or non-mob reference inside player_list ([mob]).")
 			continue
+		//VOREStation Edit End - Trying to fix some vorestation bug.
 		if(get_turf(mob) in hearturfs)
 			mobs |= mob
 			continue


### PR DESCRIPTION
Dangerous? Not any more than just leaving it, probably. I can't think of a case where player_list -= something wouldn't work, even in the case of nulls probably. And the no-depth [mob] lookup at the end is probably fine, even if it's a null, since it'll use byond's internal "what is this" handler to print the name or an icon or whatever it is.