### PR TITLE
Fixes #2450 that the sync conflicts broke.

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -1,6 +1,6 @@
 /atom/movable
 	layer = 3
-	appearance_flags = TILE_BOUND|PIXEL_SCALE
+	appearance_flags = TILE_BOUND // VOREStation edit. Our PIXEL_SCALE is applied by pref in 02_size.dm
 	var/last_move = null
 	var/anchored = 0
 	// var/elevation = 2    - not used anywhere

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -1,6 +1,6 @@
 /atom/movable
 	layer = 3
-	appearance_flags = TILE_BOUND // VOREStation edit. Our PIXEL_SCALE is applied by pref in 02_size.dm
+	appearance_flags = TILE_BOUND | PIXEL_SCALE
 	var/last_move = null
 	var/anchored = 0
 	// var/elevation = 2    - not used anywhere

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -1,6 +1,6 @@
 /atom/movable
 	layer = 3
-	appearance_flags = TILE_BOUND | PIXEL_SCALE
+	appearance_flags = TILE_BOUND|PIXEL_SCALE
 	var/last_move = null
 	var/anchored = 0
 	// var/elevation = 2    - not used anywhere

--- a/code/modules/client/preference_setup/vore/02_size.dm
+++ b/code/modules/client/preference_setup/vore/02_size.dm
@@ -11,7 +11,7 @@
 	var/weight_vr = 137		// bodyweight of character (pounds, because I'm not doing the math again -Spades)
 	var/weight_gain = 100	// Weight gain rate.
 	var/weight_loss = 50	// Weight loss rate.
-	var/fuzzy = 1			// Preference toggle for sharp/fuzzy icon. Default sharp.
+	var/fuzzy = 0			// Preference toggle for sharp/fuzzy icon. Default sharp.
 
 // Definition of the stuff for Sizing
 /datum/category_item/player_setup_item/vore/size
@@ -45,12 +45,12 @@
 	character.weight_gain		= pref.weight_gain
 	character.weight_loss		= pref.weight_loss
 	character.fuzzy				= pref.fuzzy
-	character.appearance_flags	|= pref.fuzzy*PIXEL_SCALE
+	character.appearance_flags	-= pref.fuzzy*PIXEL_SCALE
 
 /datum/category_item/player_setup_item/vore/size/content(var/mob/user)
 	. += "<br>"
 	. += "<b>Scale:</b> <a href='?src=\ref[src];size_multiplier=1'>[round(pref.size_multiplier*100)]%</a><br>"
-	. += "<b>Scaled Appearance:</b> <a [pref.fuzzy ? "" : ""] href='?src=\ref[src];toggle_fuzzy=1'><b>[pref.fuzzy ? "Sharp" : "Fuzzy"]</b></a><br>"
+	. += "<b>Scaled Appearance:</b> <a [pref.fuzzy ? "" : ""] href='?src=\ref[src];toggle_fuzzy=1'><b>[pref.fuzzy ? "Fuzzy" : "Sharp"]</b></a><br>"
 	. += "<br>"
 	. += "<b>Relative Weight:</b>  <a href='?src=\ref[src];weight=1'>[pref.weight_vr]</a><br>"
 	. += "<b>Weight Gain Rate:</b> <a href='?src=\ref[src];weight_gain=1'>[pref.weight_gain]</a><br>"


### PR DESCRIPTION
-Oh neato beans the conflict update actually made fixing my toggle update easier than it was to get working with the old placement of bixel scale.

-Fixes #2450 that the sync conflicts loss.jpg'd on the last second reee.

![kuva](https://user-images.githubusercontent.com/13697337/32981972-4acc9c84-cc85-11e7-8e42-72e8cc9bee4d.png)
