### PR TITLE
Adds a traitless nutriment sink speed ability.

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/station_special_abilities_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_special_abilities_vr.dm
@@ -669,9 +669,6 @@
 			C.absorbing_prey = 0
 			return
 
-
-
-
 /mob/living/carbon/human/proc/succubus_drain_finialize()
 	set name = "Drain/Feed Finalization"
 	set desc = "Toggle to allow for draining to be prolonged. Turn this on to make it so prey will be knocked out/die while being drained, or you will feed yourself to the prey's selected stomach if you're feeding them. Can be toggled at any time."
@@ -840,4 +837,23 @@
 		spawn(6) //.6 seconds.
 			C.anchored = 0
 	else
+		return
+
+/mob/living/carbon/human/proc/hastemode()
+	set name = "Haste Mode"
+	set desc = "Run slightly faster with high nutriment drain."
+	set category = "Abilities"
+
+	var/mob/living/carbon/human/C = src
+	if(C.haste_run != 1)
+		C.haste_run = 1
+		to_chat(C, "<span class='notice'>Haste Mode enabled.</span>")
+		C.species.slowdown -= 0.25
+		C.species.hunger_factor += 0.5
+		return
+	if(C.haste_run == 1)
+		C.haste_run = 0
+		to_chat(C, "<span class='notice'>Haste Mode disabled.</span>")
+		C.species.slowdown += 0.25
+		C.species.hunger_factor -= 0.5
 		return

--- a/code/modules/mob/living/carbon/human/species/station/station_special_abilities_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_special_abilities_vr.dm
@@ -848,12 +848,12 @@
 	if(C.haste_run != 1)
 		C.haste_run = 1
 		to_chat(C, "<span class='notice'>Haste Mode enabled.</span>")
-		C.species.slowdown -= 0.25
+		C.species.slowdown -= 0.2
 		C.species.hunger_factor += 0.5
 		return
 	if(C.haste_run == 1)
 		C.haste_run = 0
 		to_chat(C, "<span class='notice'>Haste Mode disabled.</span>")
-		C.species.slowdown += 0.25
+		C.species.slowdown += 0.2
 		C.species.hunger_factor -= 0.5
 		return

--- a/code/modules/mob/living/carbon/human/species/station/station_special_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_special_vr.dm
@@ -29,7 +29,8 @@
 		/mob/living/carbon/human/proc/succubus_drain_finialize,
 		/mob/living/carbon/human/proc/succubus_drain_lethal,
 		/mob/living/carbon/human/proc/bloodsuck,
-		/mob/living/carbon/human/proc/shred_limb) //Xenochimera get all the special verbs since they can't select traits.
+		/mob/living/carbon/human/proc/shred_limb,
+		/mob/living/carbon/human/proc/hastemode) //Xenochimera get all the special verbs since they can't select traits.
 
 	min_age = 18
 	max_age = 80

--- a/code/modules/mob/living/carbon/human/species/station/station_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_vr.dm
@@ -32,7 +32,9 @@
 
 	spawn_flags = SPECIES_CAN_JOIN
 	appearance_flags = HAS_HAIR_COLOR | HAS_LIPS | HAS_UNDERWEAR | HAS_SKIN_COLOR | HAS_EYE_COLOR
-	inherent_verbs = list(/mob/living/carbon/human/proc/shred_limb)
+	inherent_verbs = list(
+		/mob/living/carbon/human/proc/shred_limb,
+		/mob/living/carbon/human/proc/hastemode)
 
 	flesh_color = "#AFA59E"
 	base_color = "#777777"
@@ -76,7 +78,9 @@
 	secondary_langs = list(LANGUAGE_SKRELLIAN)
 	name_language = LANGUAGE_SKRELLIAN
 	color_mult = 1
-	inherent_verbs = list(/mob/living/carbon/human/proc/shred_limb)
+	inherent_verbs = list(
+		/mob/living/carbon/human/proc/shred_limb,
+		/mob/living/carbon/human/proc/hastemode)
 
 	min_age = 18
 	max_age = 80

--- a/code/modules/vore/eating/living_vr.dm
+++ b/code/modules/vore/eating/living_vr.dm
@@ -20,6 +20,7 @@
 	var/absorbing_prey = 0 				// Determines if the person is using the succubus drain or not. See station_special_abilities_vr.
 	var/drain_finalized = 0				// Determines if the succubus drain will be KO'd/absorbed. Can be toggled on at any time.
 	var/fuzzy = 1						// Preference toggle for sharp/fuzzy icon.
+	var/haste_run = 0					// Toggle for nutriment sink minor haste for non-trait species.
 
 //
 // Hook for generic creation of stuff on new creatures
@@ -31,8 +32,6 @@
 		M << "<span class='warning'>The creature that you are can not eat others.</span>"
 		return 1
 	M.verbs += /mob/living/proc/insidePanel
-
-	//M.appearance_flags |= PIXEL_SCALE // Moved to 02_size.dm
 
 	//Tries to load prefs if a client is present otherwise gives freebie stomach
 	if(!M.vore_organs || !M.vore_organs.len)


### PR DESCRIPTION
-Activating it gives a slight boost to movement speed (40% of minor haste) with the drawback of full apex mode hunger drain (both passive and motion based when active).
-Added the ability for couple species (sergal, akula, xenochimera)
-Mostly just did it because of such predatory species being locked to the pathetic default drain that gives very little incentive to even search for a snack vendor more than once in a blue moon.

Opinions?