### PR TITLE
Allows remote access to atmos intake air alarm.

### DIFF
--- a/maps/tether/tether-01-surface.dmm
+++ b/maps/tether/tether-01-surface.dmm
@@ -1903,7 +1903,7 @@
 "aKE" = (/obj/machinery/atmospherics/pipe/tank/carbon_dioxide{dir = 8; start_pressure = 3039.75},/obj/effect/floor_decal/industrial/outline/yellow,/turf/simulated/floor/tiled/techmaint,/area/engineering/atmos/processing)
 "aKF" = (/obj/effect/floor_decal/industrial/warning{dir = 8},/turf/simulated/floor/tiled/techmaint,/area/engineering/atmos/processing)
 "aKG" = (/obj/effect/floor_decal/borderfloor{dir = 4},/obj/structure/extinguisher_cabinet{dir = 8; icon_state = "extinguisher_closed"; pixel_x = 30; tag = "icon-extinguisher_closed (WEST)"},/turf/simulated/floor/tiled/techmaint,/area/tether/surfacebase/atrium_two)
-"aKH" = (/obj/machinery/light/small{dir = 4; pixel_y = 0},/obj/machinery/alarm{breach_detection = 0; dir = 8; pixel_x = 25; pixel_y = 0; report_danger_level = 0},/turf/simulated/floor/tiled/steel_dirty/virgo3b,/area/engineering/atmos/intake)
+"aKH" = (/obj/machinery/light/small{dir = 4; pixel_y = 0},/obj/machinery/alarm/monitor{dir = 8; pixel_x = 25; pixel_y = 0; rcon_setting = 3},/turf/simulated/floor/tiled/steel_dirty/virgo3b,/area/engineering/atmos/intake)
 "aKI" = (/obj/effect/floor_decal/techfloor{dir = 8},/obj/machinery/light{dir = 8; icon_state = "tube1"; pixel_y = 0},/obj/machinery/atmospherics/pipe/simple/visible/black{dir = 5},/turf/simulated/floor/tiled/techfloor,/area/engineering/atmos/processing)
 "aKJ" = (/obj/machinery/atmospherics/pipe/manifold/visible/black{tag = "icon-map (EAST)"; icon_state = "map"; dir = 4},/turf/simulated/floor/tiled/techfloor,/area/engineering/atmos/processing)
 "aKK" = (/obj/structure/cable/cyan{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/machinery/atmospherics/pipe/simple/visible/yellow{dir = 5},/turf/simulated/floor/tiled/techfloor,/area/engineering/atmos/processing)


### PR DESCRIPTION
Instead of needing CE access or to manually run outside to turn on the intake scrubbers.