### PR TITLE
Adds ability to change gender identity mid-round

### DIFF
--- a/code/modules/mob/living/carbon/human/emote_vr.dm
+++ b/code/modules/mob/living/carbon/human/emote_vr.dm
@@ -122,3 +122,13 @@
 
 	update_wing_showing()
 	return 1
+
+/mob/living/carbon/human/verb/toggle_gender_identity_vr()
+	set name = "Set Gender Identity"
+	set desc = "Sets the pronouns when examined and performing an emote."
+	set category = "IC"
+	var/new_gender_identity = input("Please select a gender Identity.") as null|anything in list(FEMALE, MALE, NEUTER, PLURAL)
+	if(!new_gender_identity)
+		return 0
+	change_gender_identity(new_gender_identity)
+	return 1

--- a/html/changelogs/RunaDacin-GenderIdentityToggle.yml
+++ b/html/changelogs/RunaDacin-GenderIdentityToggle.yml
@@ -1,0 +1,5 @@
+author: Runa-Dacino
+delete-after: True
+changes: 
+  - rscadd: "Adds the ability to change gender identity on the fly. It can be found under "IC" tab."
+

--- a/html/changelogs/RunaDacin-GenderIdentityToggle.yml
+++ b/html/changelogs/RunaDacin-GenderIdentityToggle.yml
@@ -1,5 +1,0 @@
-author: Runa-Dacino
-delete-after: True
-changes: 
-  - rscadd: "Adds the ability to change gender identity on the fly. It can be found under "IC" tab."
-


### PR DESCRIPTION
Adds the ability for any carbon to change their gender identity mid round. This does NOT change the sex of the individual. Tested and works.

**Reasons for this feature:**

1. Makes it possible to "hide" your gender identity on chargen until you get resleeved or TF'd. At the moment, getting resleeved wouldn't change the identity, forcing you to either start as target gender and reveal your cards, or be stuck with non-prefered pronouns until round end or despawn/respawn. Basically, support for dubious con TG/TF.
2. Enables people to "disguise" their gender. Useful for drag, trap and sissy folks.
3. Enables gender fluid people to be fluid without being squishy 


Includes changelog for player notification