### PR TITLE
Reenable organ rejection but make it work correctly

### DIFF
--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -129,7 +129,7 @@ var/list/organ_cache = list()
 	else if(owner && owner.bodytemperature >= 170)	//cryo stops germs from moving and doing their bad stuffs
 		//** Handle antibiotics and curing infections
 		handle_antibiotics()
-		//handle_rejection() //VOREStation Edit. Was causing major issues.
+		handle_rejection()
 		handle_germ_effects()
 
 	//check if we've hit max_damage
@@ -189,7 +189,7 @@ var/list/organ_cache = list()
 	// immunosuppressant that changes transplant data to make it match.
 	if(dna)
 		if(!rejecting)
-			if(blood_incompatible(dna.b_type, owner.dna.b_type, species, owner.species))
+			if(blood_incompatible(dna.b_type, owner.dna.b_type, species.name, owner.species.name)) //VOREStation Edit - Process species by name.
 				rejecting = 1
 		else
 			rejecting++ //Rejection severity increases over time.


### PR DESCRIPTION
Based on the name of the species, rather than datum, so printed/former bodies of the same species used as donors (or anyone with the same species name, really, if you want to do certain things, like "Chakat" organs would be compatible with each other).