### PR TITLE
Fix compile warning

### DIFF
--- a/code/modules/mob/living/silicon/say.dm
+++ b/code/modules/mob/living/silicon/say.dm
@@ -73,7 +73,6 @@
 
 	var/obj/machinery/hologram/holopad/T = src.holo
 	if(T && T.masters[src])//If there is a hologram and its master is the user.
-		var/obj/effect/overlay/aiholo/hologram = T.masters[src] //VOREStation Add for people in the hologram to hear the messages
 		//Human-like, sorta, heard by those who understand humans.
 		var/rendered_a
 		//Speech distorted, heard by those who do not understand AIs.


### PR DESCRIPTION
Cyantime removed the uses of this var but didn't remove the definition, so this removes that too, to prevent that compiletime warning.