### PR TITLE
Debug Action: Disable Mob Spawner

### DIFF
--- a/code/game/objects/mob_spawner_vr.dm
+++ b/code/game/objects/mob_spawner_vr.dm
@@ -51,7 +51,7 @@
 	return 1
 
 /obj/structure/mob_spawner/proc/choose_spawn()
-	return pickweight(spawn_types)
+	return 0//pickweight(spawn_types)
 
 /obj/structure/mob_spawner/proc/do_spawn(var/mob_path)
 	if(!ispath(mob_path))


### PR DESCRIPTION
This disables all spawners to help Virgo track down why the Mob
Controller is at 668%

Relevant to #2581 discussion.