### PR TITLE
Add ability for 'extensive' mob controller logging

### DIFF
--- a/code/controllers/subsystems/mobs.dm
+++ b/code/controllers/subsystems/mobs.dm
@@ -1,6 +1,10 @@
 //
 // Mobs Subsystem - Process mob.Life()
 //
+
+//VOREStation Edits - Contains temporary debugging code to diagnose extreme tick consumption.
+//Revert file to Polaris version when done.
+
 SUBSYSTEM_DEF(mobs)
 	name = "Mobs"
 	priority = 100
@@ -9,6 +13,8 @@ SUBSYSTEM_DEF(mobs)
 	runlevels = RUNLEVEL_GAME | RUNLEVEL_POSTGAME
 
 	var/list/currentrun = list()
+	var/log_extensively = FALSE
+	var/list/timelog = list()
 
 /datum/controller/subsystem/mobs/stat_entry()
 	..("P: [global.mob_list.len]")
@@ -16,6 +22,7 @@ SUBSYSTEM_DEF(mobs)
 /datum/controller/subsystem/mobs/fire(resumed = 0)
 	if (!resumed)
 		src.currentrun = mob_list.Copy()
+		if(log_extensively) timelog = list("-Start- [world.tick_usage]")
 
 	//cache for sanic speed (lists are references anyways)
 	var/list/currentrun = src.currentrun
@@ -30,7 +37,10 @@ SUBSYSTEM_DEF(mobs)
 			// Right now mob.Life() is unstable enough I think we need to use a try catch.
 			// Obviously we should try and get rid of this for performance reasons when we can.
 			try
+				var/time_before = world.tick_usage
 				M.Life(times_fired)
+				var/time_after = world.tick_usage
+				if(log_extensively) timelog += list("[time_before] - [M] - [time_after]")
 			catch(var/exception/e)
 				log_runtime(e, M, "Caught by [name] subsystem")
 


### PR DESCRIPTION
Requires mid-round var edit to enable, can be used to determine how much of each tick each mob's Life call uses. Will not tell you WHY, of course, but will aim you at a specific mob hopefully. Worst case, we find out that it's actually just every mob.