### PR TITLE
Teshari no longer get passtable

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/station_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_vr.dm
@@ -337,6 +337,7 @@
 	min_age = 18
 	push_flags = ~HEAVY //Allows them to use micro step code.
 	swap_flags = ~HEAVY
+	pass_flags = 0
 
 	inherent_verbs = list(
 		/mob/living/carbon/human/proc/sonar_ping,


### PR DESCRIPTION
It's quite silly and strange that Teshari get this while no other species does. It causes more problems than it is worth. Many of the Teshari players that spoke out in Discord do not want it either. 

Future solutions that are out of scope:
- Make only mobs under a certain scale get pass table
