### PR TITLE
Xenochimera bugfixes and tweaks

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/station_special_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_special_vr.dm
@@ -145,10 +145,10 @@
 					if(H.stat == CONSCIOUS)
 						H.emote("twitch")
 					if(!H.handling_hal)
-						spawn H.handle_feral()
+						H.handle_feral()
 			else // nobody around
 				if(!H.handling_hal)
-					spawn H.handle_feral()
+					H.handle_feral()
 				if(prob(2)) //periodic nagmessages
 					if(H.nutrition <= 100) //If hungry, nag them to go and find someone or something to eat.
 						H << "<span class='danger'> Confusing sights and sounds and smells surround you - scary and disorienting it may be, but the drive to hunt, to feed, to survive, compels you.</span>"

--- a/code/modules/mob/living/carbon/human/species/station/station_special_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_special_vr.dm
@@ -123,45 +123,45 @@
 
 		H.shock_stage = max(H.shock_stage-(H.feral/20), 0) //if they lose enough health to hit softcrit, handle_shock() will keep resetting this. Otherwise, pissed off critters will lose shock faster than they gain it.
 
-		for(var/mob/living/M in viewers(H))
-			if(M != H) // someone in view
-				if(prob(0.5)) // 1 in 200 chance of doing something so as not to interrupt scenes
-					if(light_amount <= 0.5) // in the darkness
-						if(H.nutrition <= 250 || H.jitteriness > 0) //tell them that person looks like food and is good to pounce.
-							H << "<span class='info'> Secure in your hiding place, you still feel the urge to hunt, and [M] looks like an extremely tempting target...</span>"
-					else // in lit area
-						if(H.nutrition <= 250 || H.jitteriness > 0) //tell them that person looks like food. It CAN happen when you're not hungry enough to be feral, especially if coffee is involved.
-							H << "<span class='danger'> Every movement, every flick, every sight and sound has your full attention, your hunting instincts on high alert... In fact, [M] looks extremely appetizing...</span>"
-							if(H.stat == CONSCIOUS)
-								H.emote("twitch")
-							if(!H.handling_hal)
-								spawn H.handle_feral()
-
-			else if(M == H) //nobody is in view.
-				if(light_amount <= 0.5) // in the darkness
-					if(prob(1)) //periodic nagmessages
-						if(H.nutrition <= 100) //If hungry, nag them to go and find someone or something to eat.
-							H << "<span class='info'> Secure in your hiding place, your hunger still gnaws at you. You need to track down some food...</span>"
-						else if(H.jitteriness >= 100)
-							H << "<span class='info'> sneakysneakyyesyesyescleverhidingfindthingsyessssss</span>"
-						else //otherwise, just tell them to hide.
-							H << "<span class='info'> ...safe...</span>"
-				else // in light
+		if(light_amount <= 0.5) // in the darkness. No need for custom scene-protection checks as it's just an occational infomessage.
+			if(prob(2)) //periodic nagmessages just to remind 'em they're still feral
+				if (H.traumatic_shock >=min(60, H.nutrition/10)) // if hurt, tell 'em to heal up
+					H << "<span class='info'> This place seems safe, secure, hidden, a place to lick your wounds and recover...</span>"
+				else if(H.nutrition <= 100) //If hungry, nag them to go and find someone or something to eat.
+					H << "<span class='info'> Secure in your hiding place, your hunger still gnaws at you. You need to catch some food...</span>"
+				else if(H.jitteriness >= 100)
+					H << "<span class='info'> sneakysneakyyesyesyescleverhidingfindthingsyessssss</span>"
+				else //otherwise, just tell them to keep hiding.
+					H << "<span class='info'> ...safe...</span>"
+		else // must be in a lit area
+			var/list/nearby = oviewers(H)
+			if (nearby.len) // someone's nearby
+				if(prob(1)) // 1 in 100 chance of doing something so as not to interrupt scenes
+					var/mob/M = pick(nearby)
+					if (H.traumatic_shock >=min(60, H.nutrition/10)) //tell 'em to be wary of a random person
+						H << "<span class='danger'> You're hurt, in danger, exposed, and [M] looks to be a little too close for comfort...</span>"
+					else if(H.nutrition <= 250 || H.jitteriness > 0) //tell them a random person in view looks like food. It CAN happen when you're not hungry enough to be feral, especially if coffee is involved.
+						H << "<span class='danger'> Every movement, every flick, every sight and sound has your full attention, your hunting instincts on high alert... In fact, [M] looks extremely appetizing...</span>"
+					if(H.stat == CONSCIOUS)
+						H.emote("twitch")
 					if(!H.handling_hal)
 						spawn H.handle_feral()
-					if(prob(1)) //periodic nagmessages
-						if(H.nutrition <= 100) //If hungry, nag them to go and find someone or something to eat.
-							H << "<span class='danger'> Confusing sights and sounds and smells surround you - scary and disorienting it may be, but the drive to hunt, to feed, to survive, compels you.</span>"
-							if(H.stat == CONSCIOUS)
-								H.emote("twitch")
-						else if(H.jitteriness >= 100)
-							H << "<span class='danger'> yesyesyesyesyesyesgetthethingGETTHETHINGfindfoodsfindpreypounceyesyesyes</span>"
-							if(H.stat == CONSCIOUS)
-								H.emote("twitch")
-						else //otherwise, just tell them to hide.
-							H << "<span class='danger'> Confusing sights and sounds and smells surround you, this place is wrong, confusing, frightening. You need to hide, go to ground...</span>"
-							if(H.stat == CONSCIOUS)
-								H.emote("twitch")
+			else // nobody around
+				if(!H.handling_hal)
+					spawn H.handle_feral()
+				if(prob(2)) //periodic nagmessages
+					if(H.nutrition <= 100) //If hungry, nag them to go and find someone or something to eat.
+						H << "<span class='danger'> Confusing sights and sounds and smells surround you - scary and disorienting it may be, but the drive to hunt, to feed, to survive, compels you.</span>"
+						if(H.stat == CONSCIOUS)
+							H.emote("twitch")
+					else if(H.jitteriness >= 100)
+						H << "<span class='danger'> yesyesyesyesyesyesgetthethingGETTHETHINGfindfoodsfindpreypounceyesyesyes</span>"
+						if(H.stat == CONSCIOUS)
+							H.emote("twitch")
+					else //otherwise, just tell them to hide.
+						H << "<span class='danger'> Confusing sights and sounds and smells surround you, this place is wrong, confusing, frightening. You need to hide, go to ground...</span>"
+						if(H.stat == CONSCIOUS)
+							H.emote("twitch")
 
 
 //////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Bugfixes:

- Fixes a bug in feralness where having a viewer wouldn't tone hallucinations down, and it wouldn't stop checking after the first.
- Fixes another bug in feralness where hallucinations wouldn't _stop_ when the conditions were met for them to be stopped.
- Fixes hatch() so it actually works with protein if reviving from dead. (fixed this in revive ages ago, forgot to do it in hatch)
- Makes regenerating fix the husk status like it should.

Tweaks:

- Tweaks order of checks in feral proc. Might be slightly faster? Definitely faster if they're hiding in the dark like they should be doing.
- Adjusts revival time 'cause originally forgot to divide by 2 in the proc when it was written, ended up with a starting-nutrition monster sitting out in medbay for 40 minutes the other day which is kind of unreasonable. New calculation is a touch simpler, being 4 minutes for infinite nutrition, 20 minutes for 0 nutrition, and scaled between those bounds on a 1/x curve that places 250 nutrition at the 10 minute mark, 500 at 7.6 minutes, and 1000 at 6 minutes.
- Makes grossness in the toxin purge proc actually have an effect. Doing a purge with more than a few toxloss in them will make a chimera regret being born (or hatching, or whatever) as they puke their guts up over and over.

Fixes #2518.