### PR TITLE
Fixed pAI OOC info

### DIFF
--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -104,12 +104,6 @@
 	verbs += /mob/living/silicon/pai/proc/choose_chassis
 	verbs += /mob/living/silicon/pai/proc/choose_verbs
 
-	// Vorestation Edit: Meta Info for pAI's
-	if (client)
-		var/meta_info = client.prefs.metadata
-		if (meta_info)
-			ooc_notes = meta_info
-
 	//PDA
 	pda = new(src)
 	spawn(5)
@@ -121,6 +115,9 @@
 
 /mob/living/silicon/pai/Login()
 	..()
+	// Vorestation Edit: Meta Info for pAI
+	if (client.prefs)
+		ooc_notes = client.prefs.metadata
 
 
 // this function shows the information about being silenced as a pAI in the Status panel


### PR DESCRIPTION
This is my first VS13 code change, but I think I didn't do anything stupid.

Previously, pAI OOC info didn't appear to be getting set correctly,
whether installed through the normal recruit dialog or through an
observer directly inhabiting a loose pAI card.

There was a VOREStation-specific check during pAI creation to copy over
OOC info from preferences, but I tested multiple ways and it didn't seem
to ever succeed.

This change moves that check from creation to chassis unfold. This is
tested to work correctly with recruit, observer-inhabit, and admin
force-pAI modes of becoming a pAI. OOC notes were already intentionally
only displayed for unfolded pAI, so the OOC notes not copying until they
unfold doesn't get in the way of anything.

This delayed check also has the unintentional bonus that if you play as
a pAI, you can change your OOC notes between the time you inhabit the
card and the time you unfold, in case you have different prefs for the
same character in normal mode and pAI mode.