### PR TITLE
Improves NIFSoft heatsink for synths

### DIFF
--- a/code/modules/nifsoft/software/15_misc.dm
+++ b/code/modules/nifsoft/software/15_misc.dm
@@ -71,8 +71,8 @@
 
 	activate()
 		if((. = ..()))
-			if(used >= 50)
-				nif.notify("Heat sinks not safe to operate again yet!",TRUE)
+			if(used >= 1500)
+				nif.notify("Heat sinks not safe to operate again yet! Max 75% on activation.",TRUE)
 				spawn(0)
 					deactivate()
 				return FALSE
@@ -82,6 +82,9 @@
 		if((. = ..()))
 			nif.clear_flag(NIF_O_HEATSINKS,NIF_FLAGS_OTHER)
 
+	stat_text()
+		return "[active ? "Active" : "Disabled"] (Stored Heat: [Floor(used/20)]%)"
+
 	life()
 		if((. = ..()))
 			//Not being used, all clean.
@@ -89,7 +92,7 @@
 				return TRUE
 
 			//Being used, and running out.
-			else if(active && ++used == 100)
+			else if(active && ++used == 2000)
 				nif.notify("Heat sinks overloaded! Shutting down!",TRUE)
 				deactivate()
 


### PR DESCRIPTION
Wow, this ran out super fast. You get like 2 minutes of use, jeez. This makes it much longer. You also get a % heat sunk thing next to it in the NIF menu so you can see how far along you are. For being one of the most expensive NIFSofts I was expecting better.

Makes it last 20x longer. Takes 20x longer to cool down too, though.