### PR TITLE
Allow ghosts to enter Soulcatchers

### DIFF
--- a/code/modules/mob/dead/observer/observer_vr.dm
+++ b/code/modules/mob/dead/observer/observer_vr.dm
@@ -10,3 +10,62 @@
 				PP.overlays += "pai-ghostalert"
 				spawn(54)
 					PP.overlays.Cut()
+
+/mob/observer/dead/verb/nifjoin()
+	set category = "Ghost"
+	set name = "Join Into Soulcatcher"
+	set desc = "Select a player with a working NIF + Soulcatcher NIFSoft to join into it."
+
+	var/picked = input("Pick a friend with NIF and Soulcatcher to join into. Harrass strangers, get banned. Not everyone has a NIF w/ Soulcatcher.","Select a player") as null|anything in player_list
+
+	//Didn't pick anyone or picked a null
+	if(!picked)
+		return
+
+	//Good choice testing and some instance-grabbing
+	if(!ishuman(picked))
+		to_chat(src,"<span class='warning'>[picked] isn't in a humanoid mob at the moment.</span>")
+		return
+
+	var/mob/living/carbon/human/H = picked
+
+	if(H.stat || !H.client)
+		to_chat(src,"<span class='warning'>[H] isn't awake/alive at the moment.</span>")
+		return
+
+	if(!H.nif)
+		to_chat(src,"<span class='warning'>[H] doesn't have a NIF installed.</span>")
+		return
+
+	var/datum/nifsoft/soulcatcher/SC = H.nif.imp_check(NIF_SOULCATCHER)
+	if(!SC)
+		to_chat(src,"<span class='warning'>[H] doesn't have the Soulcatcher NIFSoft installed, or their NIF is unpowered.</span>")
+		return
+
+	//Fine fine, we can ask.
+	var/obj/item/device/nif/nif = H.nif
+	to_chat(src,"<span class='notice'>Request sent to [H].</span>")
+
+	var/req_time = world.time
+	nif.notify("Transient mindstate detected, analyzing...")
+	sleep(15) //So if they are typing they get interrupted by sound and message, and don't type over the box
+	var/response = alert(H,"[src] ([src.key]) wants to join into your Soulcatcher.","Soulcatcher Request","Deny","Allow")
+
+	if(response == "Deny")
+		to_chat(src,"<span class='warning'>[H] denied your request.</span>")
+		return
+
+	if((world.time - req_time) > 1 MINUTES)
+		to_chat(H,"<span class='warning'>The request had already expired. (1 minute waiting max)</span>")
+		return
+
+	//Final check since we waited for input a couple times.
+	if(H && src && src.key && !H.stat && nif && SC)
+		if(!mind) //No mind yet, aka haven't played in this round.
+			mind = new(key)
+
+		mind.name = name
+		mind.current = src
+		mind.active = TRUE
+
+		SC.catch_mob(src) //This will result in us being deleted so...

--- a/code/modules/mob/living/carbon/human/emote_vr.dm
+++ b/code/modules/mob/living/carbon/human/emote_vr.dm
@@ -20,37 +20,11 @@
 			message = "awoos loudly. AwoooOOOOoooo!"
 			m_type = 2
 		if ("nsay")
-			if(!nif)
-				to_chat(src,"<span class='warning'>You can't use *nsay without a NIF.</span>")
-				return 1
-			var/datum/nifsoft/soulcatcher/SC = nif.imp_check(NIF_SOULCATCHER)
-			if(!SC)
-				to_chat(src,"<span class='warning'>You need the Soulcatcher software to use *nme.</span>")
-				return 1
-			if(!SC.brainmobs.len)
-				to_chat(src,"<span class='warning'>You need a loaded mind to use *nme.</span>")
-				return 1
-			var/nifmessage = sanitize(input("Type a message to say.","Speak into NIF") as text|null)
-			if(nifmessage)
-				SC.say_into(nifmessage,src)
-			return 1
-
+			nsay()
+			return TRUE
 		if ("nme")
-			if(!nif)
-				to_chat(src,"<span class='warning'>You can't use *nme without a NIF.</span>")
-				return 1
-			var/datum/nifsoft/soulcatcher/SC = nif.imp_check(NIF_SOULCATCHER)
-			if(!SC)
-				to_chat(src,"<span class='warning'>You need the Soulcatcher software to use *nme.</span>")
-				return 1
-			if(!SC.brainmobs.len)
-				to_chat(src,"<span class='warning'>You need a loaded mind to use *nme.</span>")
-				return 1
-			var/nifmessage = sanitize(input("Type an action to perform.","Emote into NIF") as text|null)
-			if(nifmessage)
-				SC.emote_into(nifmessage,src)
-			return 1
-
+			nme()
+			return TRUE
 		if ("flip")
 			var/danger = 1 //Base 1% chance to break something.
 			var/list/involved_parts = list(BP_L_LEG, BP_R_LEG, BP_L_FOOT, BP_R_FOOT)


### PR DESCRIPTION
Ghosts now have a verb "Join Into Soulcatcher" (Ghost tab) that lists all players, and they can pick one to ask them if they can join into their SC. If they don't have one, it notifies the ghost (this is less expensive than trying to crunch who has a soulcatcher and shortening the list. You can just deal with it okay??). You cannot get backed up if you joined this way, like there's no way to move from being a ghost to being in someone's head to being in a mob. You'd need to ghost and respawn normally. (This is intentional... no sneaky no-manifest people getting in).

And various other SC QOL things:
- Adds NMe and NSay verbs when you get a soulcatcher installed so you can use them in the text parser at the bottom of the window or click them in the verb list like a crazy person. The older emotes also still work.
- Prevents 'loop of madness' where both pred and prey have soulcatchers and it floods your log as it tries to decide who catches who
- Removes minds if the client is disconnected for a long time, or if the player ghosts out of the NIF