### PR TITLE
Prevents low health bodies from dying on creation

### DIFF
--- a/code/modules/resleeving/machines.dm
+++ b/code/modules/resleeving/machines.dm
@@ -70,7 +70,7 @@
 	H.original_player = current_project.ckey
 
 	//Apply damage
-	H.adjustCloneLoss(150)
+	H.adjustCloneLoss((H.getMaxHealth() - config.health_threshold_dead)*0.75)
 	H.Paralyse(4)
 	H.updatehealth()
 


### PR DESCRIPTION
Humans with the -50% max health trait will no longer die instantly when the growing process starts.