### PR TITLE
Fixes bugs related to picking shit from empty belly content lists.

### DIFF
--- a/code/modules/vore/eating/bellymodes_vr.dm
+++ b/code/modules/vore/eating/bellymodes_vr.dm
@@ -25,6 +25,8 @@
 	if(digest_mode == DM_DIGEST || digest_mode == DM_DIGEST_NUMB || digest_mode == DM_ITEMWEAK)
 		var/list/touchable_items = internal_contents - items_preserved
 		var/mob/living/silicon/robot/s_owner = null
+		if(!length(touchable_items))
+			return
 
 		if(prob(50)) //Was SO OFTEN. AAAA.
 			var/churnsound = pick(digestion_sounds)
@@ -222,6 +224,8 @@
 	if(digest_mode == DM_STRIPDIGEST) // Only gurgle the gear off your prey.
 		var/list/touchable_items = internal_contents - items_preserved
 		var/mob/living/silicon/robot/s_owner = null
+		if(!length(touchable_items))
+			return
 
 		if(prob(50))
 			var/churnsound = pick(digestion_sounds)


### PR DESCRIPTION
-Makes digestion modes "finish" once everything unprotected is gone.
-This also means your guts will no longer permagurgle fruitlessly while nothing but a shitty ID is left in there.

Fixes #2655