### PR TITLE
Fixes some bugs relating to absorption and struggling, makes struggle feedback messages clearer

### DIFF
--- a/code/modules/mob/living/simple_animal/simple_animal_vr.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal_vr.dm
@@ -36,6 +36,8 @@
 /mob/living/simple_animal/Destroy()
 	for(var/I in vore_organs)
 		var/datum/belly/B = vore_organs[I]
+		for(var/mob/living/M in B.internal_contents) // because release_all_contents doesn't release absorbed things
+			M.absorbed = 0
 		B.release_all_contents() // When your stomach is empty
 	prey_excludes.Cut()
 	. = ..()
@@ -127,6 +129,8 @@
 /mob/living/simple_animal/death()
 	for(var/I in vore_organs)
 		var/datum/belly/B = vore_organs[I]
+		for(var/mob/living/M in B.internal_contents) // because release_all_contents doesn't release absorbed things
+			M.absorbed = 0
 		B.release_all_contents() // When your stomach is empty
 	..() // then you have my permission to die.
 

--- a/code/modules/mob/living/simple_animal/simple_animal_vr.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal_vr.dm
@@ -36,9 +36,7 @@
 /mob/living/simple_animal/Destroy()
 	for(var/I in vore_organs)
 		var/datum/belly/B = vore_organs[I]
-		for(var/mob/living/M in B.internal_contents) // because release_all_contents doesn't release absorbed things
-			M.absorbed = 0
-		B.release_all_contents() // When your stomach is empty
+		B.release_all_contents(include_absorbed = TRUE) // When your stomach is empty
 	prey_excludes.Cut()
 	. = ..()
 
@@ -129,9 +127,7 @@
 /mob/living/simple_animal/death()
 	for(var/I in vore_organs)
 		var/datum/belly/B = vore_organs[I]
-		for(var/mob/living/M in B.internal_contents) // because release_all_contents doesn't release absorbed things
-			M.absorbed = 0
-		B.release_all_contents() // When your stomach is empty
+		B.release_all_contents(include_absorbed = TRUE) // When your stomach is empty
 	..() // then you have my permission to die.
 
 // Simple animals have only one belly.  This creates it (if it isn't already set up)

--- a/code/modules/vore/eating/belly_vr.dm
+++ b/code/modules/vore/eating/belly_vr.dm
@@ -454,11 +454,11 @@
 	playsound(R.loc, strsound, 50, 1)
 
 	if(escapable) //If the stomach has escapable enabled.
-		R << "<span class='warning'>You attempt to climb out of \the [name].</span>"
-		owner << "<span class='warning'>Someone is attempting to climb out of your [name]!</span>"
 		if(prob(escapechance)) //Let's have it check to see if the prey escapes first.
+			R << "<span class='warning'>You start to climb out of \the [name].</span>"
+			owner << "<span class='warning'>Someone is attempting to climb out of your [name]!</span>"
 			if(do_after(R, escapetime))
-				if((escapable) && (R in internal_contents)) //Does the owner still have escapable enabled?
+				if((escapable) && (R in internal_contents) && !R.absorbed) //Does the owner still have escapable enabled?
 					release_specific_contents(R)
 					R << "<span class='warning'>You climb out of \the [name].</span>"
 					owner << "<span class='warning'>[R] climbs out of your [name]!</span>"
@@ -467,10 +467,10 @@
 					return
 				else if(!(R in internal_contents)) //Aren't even in the belly. Quietly fail.
 					return
-			else //Belly became inescapable.
-				R << "<span class='warning'>Your attempt to escape [name] has failed!</span>"
-				owner << "<span class='notice'>The attempt to escape from your [name] has failed!</span>"
-				return
+				else //Belly became inescapable.
+					R << "<span class='warning'>Your attempt to escape [name] has failed!</span>"
+					owner << "<span class='notice'>The attempt to escape from your [name] has failed!</span>"
+					return
 
 		else if(prob(transferchance) && istype(transferlocation)) //Next, let's have it see if they end up getting into an even bigger mess then when they started.
 			var/location_found = 0
@@ -499,20 +499,20 @@
 			transfer_contents(R, transferlocation)
 			return
 
-		else if(prob(absorbchance)) //After that, let's have it run the absorb chance.
-			R << "<span class='warning'>In response to your struggling, \the [name] begins to get more active...</span>"
-			owner << "<span class='warning'>You feel your [name] beginning to become active!</span>"
+		else if(prob(absorbchance) && digest_mode != DM_ABSORB) //After that, let's have it run the absorb chance.
+			R << "<span class='warning'>In response to your struggling, \the [name] begins to cling more tightly...</span>"
+			owner << "<span class='warning'>You feel your [name] start to cling onto its contents...</span>"
 			digest_mode = DM_ABSORB
 			return
 
-		else if(prob(digestchance)) //Finally, let's see if it should run the digest chance.
+		else if(prob(digestchance) && digest_mode != DM_DIGEST) //Finally, let's see if it should run the digest chance.
 			R << "<span class='warning'>In response to your struggling, \the [name] begins to get more active...</span>"
 			owner << "<span class='warning'>You feel your [name] beginning to become active!</span>"
 			digest_mode = DM_DIGEST
 			return
 		else //Nothing interesting happened.
-			R << "<span class='warning'>But make no progress in escaping [owner]'s [name].</span>"
-			owner << "<span class='warning'>But appears to be unable to make any progress in escaping your [name].</span>"
+			R << "<span class='warning'>You make no progress in escaping [owner]'s [name].</span>"
+			owner << "<span class='warning'>Your prey appears to be unable to make any progress in escaping your [name].</span>"
 			return
 
 //Transfers contents from one belly to another

--- a/code/modules/vore/eating/belly_vr.dm
+++ b/code/modules/vore/eating/belly_vr.dm
@@ -114,20 +114,22 @@
 // Release all contents of this belly into the owning mob's location.
 // If that location is another mob, contents are transferred into whichever of its bellies the owning mob is in.
 // Returns the number of mobs so released.
-/datum/belly/proc/release_all_contents()
+/datum/belly/proc/release_all_contents(var/include_absorbed = FALSE)
 	if (internal_contents.len == 0)
 		return 0
-	for (var/atom/movable/M in internal_contents)
+	for (var/M in internal_contents)
 		if(istype(M,/mob/living))
 			var/mob/living/ML = M
-			if(ML.absorbed)
+			if(ML.absorbed && !include_absorbed)
 				continue
+			ML.absorbed = FALSE
 
-		M.forceMove(owner.loc)  // Move the belly contents into the same location as belly's owner.
-		internal_contents -= M  // Remove from the belly contents
+		var/atom/movable/AM = M
+		AM.forceMove(owner.loc)  // Move the belly contents into the same location as belly's owner.
+		internal_contents -= AM  // Remove from the belly contents
 		var/datum/belly/B = check_belly(owner) // This makes sure that the mob behaves properly if released into another mob
 		if(B)
-			B.internal_contents += M
+			B.internal_contents += AM
 	items_preserved.Cut()
 	checked_slots.Cut()
 	owner.visible_message("<font color='green'><b>[owner] expels everything from their [lowertext(name)]!</b></font>")


### PR DESCRIPTION
- Fixes a bug where absorbed prey in simplemobs wouldn't get released when the predator was killed, which in some cases resulted in prey getting GC'd.
- Fixes an indentation error in the messages given to prey when an otherwise successful escape attempt is blocked by the predator setting their belly to inescapable before the escape timer is up.
- Fixes an edge case where prey could roll a successful escape attempt, get absorbed in the meantime, and then somehow manage to escape anyway.
- Makes struggle messages a little clearer as to the outcome, hopefully fixes #1998 as it's obvious when you're actually successfully resisting now. (previously, it displayed the "you attempt to climb out" message in all cases, then gave _no_ further message if your attempt was successful)
- Random mode-switches will no longer tell you they're changing mode if they're already in the mode that is being switched to.
- Changed "switching to absorb mode" messages so you can tell the difference between a belly that just started absorbing and one that just started digesting.