### PR TITLE
Adds vore panel preference to enable/disable being eaten by mobs

### DIFF
--- a/code/modules/mob/living/simple_animal/simple_animal_vr.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal_vr.dm
@@ -75,6 +75,9 @@
 	if(vore_ignores_undigestable && !M.digestable) //Don't eat people with nogurgle prefs
 		ai_log("vr/wont eat [M] because I am picky", 3)
 		return 0
+	if(!M.allowmobvore) // Don't eat people who don't want to be ate by mobs
+		ai_log("vr/wont eat [M] because they don't allow mob vore", 3)
+		return 0
 	if(M in prey_excludes) // They're excluded
 		ai_log("vr/wont eat [M] because they are excluded", 3)
 		return 0

--- a/code/modules/vore/eating/living_vr.dm
+++ b/code/modules/vore/eating/living_vr.dm
@@ -1,6 +1,7 @@
 ///////////////////// Mob Living /////////////////////
 /mob/living
 	var/digestable = 1					// Can the mob be digested inside a belly?
+	var/allowmobvore = 1				// Will simplemobs attempt to eat the mob?
 	var/vore_selected					// Default to no vore capability.
 	var/list/vore_organs = list()		// List of vore containers inside a mob
 	var/absorbed = 0					// If a mob is absorbed into another
@@ -232,6 +233,7 @@
 	var/datum/vore_preferences/P = client.prefs_vr
 
 	P.digestable = src.digestable
+	P.allowmobvore = src.allowmobvore
 	P.belly_prefs = src.vore_organs
 	P.vore_taste = src.vore_taste
 	P.nif_examine = src.nif_examine
@@ -252,6 +254,7 @@
 	var/datum/vore_preferences/P = client.prefs_vr
 
 	src.digestable = P.digestable
+	src.allowmobvore = P.allowmobvore
 	src.vore_organs = list()
 	src.vore_taste = P.vore_taste
 	src.nif_examine = P.nif_examine

--- a/code/modules/vore/eating/vore_vr.dm
+++ b/code/modules/vore/eating/vore_vr.dm
@@ -42,6 +42,7 @@ V::::::V           V::::::VO:::::::OOO:::::::ORR:::::R     R:::::REE::::::EEEEEE
 /datum/vore_preferences
 	//Actual preferences
 	var/digestable = 1
+	var/allowmobvore = 1
 	var/list/belly_prefs = list()
 	var/vore_taste
 	var/conceal_nif
@@ -105,6 +106,7 @@ V::::::V           V::::::VO:::::::OOO:::::::ORR:::::R     R:::::REE::::::EEEEEE
 	S.cd = "/character[slot]"
 
 	S["digestable"] >> digestable
+	S["allowmobvore"] >> allowmobvore
 	S["belly_prefs"] >> belly_prefs
 	S["vore_taste"] >> vore_taste
 	S["conceal_nif"] >> conceal_nif
@@ -114,6 +116,8 @@ V::::::V           V::::::VO:::::::OOO:::::::ORR:::::R     R:::::REE::::::EEEEEE
 
 	if(isnull(digestable))
 		digestable = 1
+	if(isnull(allowmobvore))
+		allowmobvore = 1
 	if(isnull(belly_prefs))
 		belly_prefs = list()
 
@@ -127,6 +131,7 @@ V::::::V           V::::::VO:::::::OOO:::::::ORR:::::R     R:::::REE::::::EEEEEE
 	S.cd = "/character[slot]"
 
 	S["digestable"] << digestable
+	S["allowmobvore"] << allowmobvore
 	S["belly_prefs"] << belly_prefs
 	S["vore_taste"] << vore_taste
 	S["conceal_nif"] << conceal_nif

--- a/code/modules/vore/eating/vorepanel_vr.dm
+++ b/code/modules/vore/eating/vorepanel_vr.dm
@@ -281,6 +281,12 @@
 		if(0)
 			dat += "<a href='?src=\ref[src];toggledg=1'><span style='color:green;'>Toggle Digestable</span></a>"
 
+	switch(user.allowmobvore)
+		if(1)
+			dat += "<a href='?src=\ref[src];togglemv=1'>Toggle Mob Vore</a>"
+		if(0)
+			dat += "<a href='?src=\ref[src];togglemv=1'><span style='color:green;'>Toggle Mob Vore</span></a>"
+
 	dat += "<br><a href='?src=\ref[src];toggle_nif=1'>Set NIF concealment</a>" //These two get their own, custom row.
 	dat += "<a href='?src=\ref[src];set_nif_flavor=1'>Set NIF Examine Message.</a>"
 
@@ -788,6 +794,21 @@
 
 		if(user.client.prefs_vr)
 			user.client.prefs_vr.digestable = user.digestable
+
+	if(href_list["togglemv"])
+		var/choice = alert(user, "This button is for those who don't like being eaten by mobs. Don't abuse this button by toggling it back and forth in combat or whatever, or you'll make the admins cry. Mobs are currently: [user.allowmobvore ? "Allowed to eat" : "Prevented from eating"] you.", "", "Allow Mob Predation", "Cancel", "Prevent Mob Predation")
+		switch(choice)
+			if("Cancel")
+				return 0
+			if("Allow Mob Predation")
+				user.allowmobvore = 1
+			if("Prevent Mob Predation")
+				user.allowmobvore = 0
+
+		message_admins("[key_name(user)] toggled their mob vore preference to [user.allowmobvore] ([user ? "<a href='?_src_=holder;adminplayerobservecoodjump=1;X=[user.loc.];Y=[user.loc.y];Z=[user.loc.z]'>JMP</a>" : "null"])")
+
+		if(user.client.prefs_vr)
+			user.client.prefs_vr.allowmobvore = user.allowmobvore
 
 	if(href_list["togglenoisy"])
 		var/choice = alert(user, "Toggle audible hunger noises. Currently: [user.noisy ? "Enabled" : "Disabled"]", "", "Enable audible hunger", "Cancel", "Disable audible hunger")


### PR DESCRIPTION
Adds a toggle to the vore panel, next to the digestion pref, to toggle whether you want to allow the possibility of mobs eating you. The preference, like digestion, defaults to ON so if you're pred-only or don't like NPC/animal preds then turn it off.

It will disable bumpnoms and also prevent cats and foxes from targeting you.

Hostile mobs (or retaliate mobs that you aggro'd like a dumbass) will skip eating and just murder you instead, just as though they were picky eaters and you had your digestible pref toggled off.
  
Fixes #2626 