### PR TITLE
Gives the HoS a KHI-102b NSFW

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -147,8 +147,9 @@
 		new /obj/item/ammo_magazine/m44/rubber(src)
 		new /obj/item/ammo_magazine/m44(src)
 		new /obj/item/ammo_magazine/m44(src)*/ // NO YOU DO NOT GET A .44 MAGNUM! -Ace
-		new /obj/item/weapon/gun/energy/gun(src)
-		new /obj/item/weapon/cell/device/weapon(src)
+		//new /obj/item/weapon/gun/energy/gun(src) //VOREStation Edit
+		new /obj/item/weapon/storage/secure/briefcase/nsfw_pack_hos(src) //VOREStation Edit - No need with NSFW
+		//new /obj/item/weapon/cell/device/weapon(src) //VOREStation Edit - No need with NSFW
 		new /obj/item/weapon/melee/telebaton(src)
 		new /obj/item/clothing/head/beret/sec/corporate/hos(src)
 		new /obj/item/clothing/suit/storage/hooded/wintercoat/security(src)

--- a/code/modules/vore/fluffstuff/guns/nsfw.dm
+++ b/code/modules/vore/fluffstuff/guns/nsfw.dm
@@ -381,3 +381,20 @@
 	new /obj/item/ammo_magazine/nsfw_mag(src)
 	for(var/path in typesof(/obj/item/ammo_casing/nsfw_batt))
 		new path(src)
+
+/obj/item/weapon/storage/secure/briefcase/nsfw_pack_hos
+	name = "\improper KHI-102b \'NSFW\' gun kit"
+	desc = "A storage case for a multi-purpose handgun. Variety hour!"
+	max_w_class = ITEMSIZE_NORMAL
+
+/obj/item/weapon/storage/secure/briefcase/nsfw_pack_hos/New()
+	..()
+	new /obj/item/weapon/gun/projectile/nsfw(src)
+	new /obj/item/ammo_magazine/nsfw_mag(src)
+	new /obj/item/ammo_casing/nsfw_batt(src)
+	new /obj/item/ammo_casing/nsfw_batt(src)
+	new /obj/item/ammo_casing/nsfw_batt/stun(src)
+	new /obj/item/ammo_casing/nsfw_batt/stun(src)
+	new /obj/item/ammo_casing/nsfw_batt/net(src)
+	new /obj/item/ammo_casing/nsfw_batt/ion(src)
+


### PR DESCRIPTION
It's just my fluff gun. But sharing is caring.

From the ingame fluff:
"Variety is the spice of life! The 'Nanotech Selectable-Fire Weapon' is an unholy hybrid of an ammo-driven energy weapon that allows the user to mix and match their own fire modes. Up to three combinations of energy beams can be configured at once. Ammo not included."
"This gun is an energy weapon that uses interchangable microbatteries in a magazine. Each battery is a different beam type, and up to three can be loaded in the magazine. Each battery usually provides four discharges of that beam type, and multiple from the same type may be loaded to increase the number of shots for that type."
"The Kitsuhana 'Nanotech Selectable Fire Weapon' allows one to customize their loadout in the field, or before deploying, to achieve various results in a weapon they are already familiar with wielding."

The HoS's includes 2 lethal, 2 stun, 1 net, and 1 ion battery. There are other batteries (like instagib!) but there's no way to get them normally. There's also one that strips people. 👀 

![image](https://user-images.githubusercontent.com/15028025/34596089-05d2047a-f1ab-11e7-8f10-372cef4005a7.png)

![image](https://user-images.githubusercontent.com/15028025/34596297-91399db0-f1ac-11e7-86be-185b35c999a3.png)

![image](https://user-images.githubusercontent.com/15028025/34596318-b5a2445e-f1ac-11e7-833e-5d953de0b652.png)

  