### PR TITLE
Commlink QoL

### DIFF
--- a/code/game/objects/items/devices/communicator/phone.dm
+++ b/code/game/objects/items/devices/communicator/phone.dm
@@ -207,8 +207,15 @@
 	for(var/obj/item/device/communicator/comm in communicating)
 		var/turf/T = get_turf(comm)
 		if(!T) return
-		var/list/in_range = get_mobs_and_objs_in_view_fast(T,world.view,0) //Range of 3 since it's a tiny video display
-		var/list/mobs_to_relay = in_range["mobs"]
+		//VOREStation Edit Start for commlinks
+		var/list/mobs_to_relay
+		if(istype(comm,/obj/item/device/communicator/commlink))
+			var/obj/item/device/communicator/commlink/CL = comm
+			mobs_to_relay = list(CL.nif.human)
+		else
+			var/list/in_range = get_mobs_and_objs_in_view_fast(T,world.view,0) //Range of 3 since it's a tiny video display
+			mobs_to_relay = in_range["mobs"]
+		//VOREStation Edit End
 
 		for(var/mob/mob in mobs_to_relay) //We can't use visible_message(), or else we will get an infinite loop if two communicators hear each other.
 			var/dst = get_dist(get_turf(mob),get_turf(comm))
@@ -228,8 +235,15 @@
 
 		var/turf/T = get_turf(comm)
 		if(!T) return
-		var/list/in_range = get_mobs_and_objs_in_view_fast(T,world.view,0)
-		var/list/mobs_to_relay = in_range["mobs"]
+		//VOREStation Edit Start for commlinks
+		var/list/mobs_to_relay
+		if(istype(comm,/obj/item/device/communicator/commlink))
+			var/obj/item/device/communicator/commlink/CL = comm
+			mobs_to_relay = list(CL.nif.human)
+		else
+			var/list/in_range = get_mobs_and_objs_in_view_fast(T,world.view,0) //Range of 3 since it's a tiny video display
+			mobs_to_relay = in_range["mobs"]
+		//VOREStation Edit End
 
 		for(var/mob/mob in mobs_to_relay)
 			//Can whoever is hearing us understand?

--- a/code/modules/nifsoft/software/14_commlink.dm
+++ b/code/modules/nifsoft/software/14_commlink.dm
@@ -42,7 +42,7 @@
 		..()
 		nif = newloc
 		nifsoft = soft
-		register_device(nif.human)
+		spawn(10) register_device(nif.human) //Need to outwait the other spawn in communicators, sigh.
 		qdel_null(camera) //Not supported on internal one.
 
 	Destroy()


### PR DESCRIPTION
Makes it properly auto-register your name instead of coming as Unset every time.
Makes messages to Commlinks properly stay in the commlink user's head.