### PR TITLE
Added supply shuttle export reports

### DIFF
--- a/code/game/machinery/computer/supply.dm
+++ b/code/game/machinery/computer/supply.dm
@@ -40,6 +40,8 @@
 		<BR>\n<A href='?src=\ref[src];order=categories'>Request items</A><BR><BR>
 		<A href='?src=\ref[src];vieworders=1'>View approved orders</A><BR><BR>
 		<A href='?src=\ref[src];viewrequests=1'>View requests</A><BR><BR>
+		"} // VOREStation Edit - Export reports
+		dat += {"\n<A href='?src=\ref[src];viewexport=1'>View export report</A><BR><BR>
 		<A href='?src=\ref[user];mach_close=computer'>Close</A>"}
 
 	user << browse(dat, "window=computer;size=575x450")
@@ -198,6 +200,8 @@
 		\n<A href='?src=\ref[src];order=categories'>Order items</A><BR>\n<BR>
 		\n<A href='?src=\ref[src];viewrequests=1'>View requests</A><BR>\n<BR>
 		\n<A href='?src=\ref[src];vieworders=1'>View orders</A><BR>\n<BR>
+		"} // VOREStation Edit - Export reports
+		dat += {"\n<A href='?src=\ref[src];viewexport=1'>View export report</A><BR>\n<BR>
 		\n<A href='?src=\ref[user];mach_close=computer'>Close</A>"}
 
 
@@ -366,6 +370,20 @@
 
 		temp += "<BR><A href='?src=\ref[src];clearreq=1'>Clear list</A>"
 		temp += "<BR><A href='?src=\ref[src];mainmenu=1'>OK</A>"
+
+	//VOREStation Edit - Export reports
+	else if (href_list["viewexport"])
+		temp = "Previous shuttle export report: <BR><BR>"
+		var/cratecount = 0
+		var/totalvalue = 0
+		for(var/S in supply_controller.exported_crates)
+			var/datum/exported_crate/EC = S
+			cratecount += 1
+			totalvalue += EC.value
+			temp += "[EC.name] exported for [EC.value] supply points<BR>"
+		temp += "<BR>Shipment of [cratecount] crates exported for [totalvalue] supply points.<BR>"
+		temp += "<BR><A href='?src=\ref[src];mainmenu=1'>OK</A>"
+	//VOREStation Edit End
 
 	else if (href_list["rreq"])
 		var/ordernum = text2num(href_list["rreq"])

--- a/code/game/supplyshuttle.dm
+++ b/code/game/supplyshuttle.dm
@@ -134,6 +134,12 @@ var/list/mechtoys = list(
     var/orderedby = null
     var/comment = null
 
+//VOREStation Edit - Export reports
+/datum/exported_crate
+    var/name
+    var/value
+//VOREStation Edit End
+
 /datum/controller/supply
     //supply points
     var/points = 50
@@ -147,6 +153,7 @@ var/list/mechtoys = list(
     var/list/shoppinglist = list()
     var/list/requestlist = list()
     var/list/supply_packs = list()
+    var/list/exported_crates = list() //VOREStation Edit - Export reports
     //shuttle movement
     var/movetime = 1200
     var/datum/shuttle/ferry/supply/shuttle
@@ -190,11 +197,20 @@ var/list/mechtoys = list(
         var/plat_count = 0
         var/money_count = 0
 
+        exported_crates = list() //VOREStation Edit - Export reports
+
         for(var/atom/movable/MA in area_shuttle)
             if(MA.anchored) continue
 
             // Must be in a crate!
             if(istype(MA,/obj/structure/closet/crate))
+                //VOREStation Edit - Export reports
+                var/oldpoints = points
+                var/oldphoron = phoron_count
+                var/oldplatinum = plat_count
+                var/oldmoney = money_count
+                //VOREStation Edit End
+
                 var/obj/structure/closet/crate/CR = MA
                 callHook("sell_crate", list(CR, area_shuttle))
 
@@ -222,6 +238,17 @@ var/list/mechtoys = list(
                     if(istype(A, /obj/item/weapon/spacecash))
                         var/obj/item/weapon/spacecash/cashmoney = A
                         money_count += cashmoney.worth
+
+                //VOREStation Edit - Export reports
+                var/datum/exported_crate/EC = new /datum/exported_crate()
+                EC.name = CR.name
+                EC.value = points - oldpoints
+                EC.value += (phoron_count - oldphoron) * points_per_phoron
+                EC.value += (plat_count - oldplatinum) * points_per_platinum
+                EC.value += (money_count - oldmoney) * points_per_money
+                exported_crates += EC
+                //VOREStation Edit End
+
             qdel(MA)
 
         if(phoron_count)


### PR DESCRIPTION
Added a new option to the cargo console to view supply points gained
from the most recent shuttle trip.

![image](https://user-images.githubusercontent.com/34605836/34700331-8809788a-f4b0-11e7-9586-adb5c652bad2.png)

It breaks down the value per crate, but to preserve the fun of trial and
error for folks that enjoy that doesn't itemize exactly what inside the
crate provided that value.

Part of the supply shuttle changes could probably be instead done as a
sell_crate hook, but because of where that's called it would have to
duplicate all the manifest-detection code.