### PR TITLE
Refactor Digestion

### DIFF
--- a/code/_helpers/global_lists_vr.dm
+++ b/code/_helpers/global_lists_vr.dm
@@ -26,6 +26,7 @@ var/global/list/vantag_choices_list = list(
 		VANTAG_KIDNAP	=	"Be Kidnapped",
 		VANTAG_KILL		=	"Be Killed")
 
+/* Time to finally undo this. Replaced with digest_act on these items.
 //Important items that are preserved when people are digested, etc.
 //On Polaris, different from Cryo list as MMIs need to be removed for FBPs to be logged out.
 var/global/list/important_items = list(
@@ -40,7 +41,9 @@ var/global/list/important_items = list(
 		/obj/item/blueprints,
 		/obj/item/clothing/head/helmet/space,
 		/obj/item/weapon/disk/nuclear,
-		/obj/item/clothing/suit/storage/hooded/wintercoat/roiz)
+		/obj/item/clothing/suit/storage/hooded/wintercoat/roiz,
+		/obj/item/device/perfect_tele_beacon)
+*/
 
 var/global/list/digestion_sounds = list(
 		'sound/vore/digest1.ogg',

--- a/code/datums/helper_datums/teleport_vr.dm
+++ b/code/datums/helper_datums/teleport_vr.dm
@@ -14,7 +14,7 @@
 	if(target_belly)
 		teleatom.forceMove(destination.loc)
 		playSpecials(destination,effectout,soundout)
-		target_belly.internal_contents += teleatom
+		target_belly.internal_contents |= teleatom
 		playsound(destination, target_belly.vore_sound, 100, 1)
 		return 1
 

--- a/code/game/objects/items/trash_vr.dm
+++ b/code/game/objects/items/trash_vr.dm
@@ -15,7 +15,7 @@
 			var/belly = H.vore_selected
 			var/datum/belly/selected = H.vore_organs[belly]
 			src.forceMove(H)
-			selected.internal_contents += src
+			selected.internal_contents |= src
 			to_chat(H, "<span class='notice'>You can taste the flavor of garbage. Wait what?</span>")
 			return
 
@@ -27,7 +27,7 @@
 			var/belly = R.vore_selected
 			var/datum/belly/selected = R.vore_organs[belly]
 			src.forceMove(R)
-			selected.internal_contents += src // Too many hoops and obstacles to stick it into the sleeper module.
+			selected.internal_contents |= src // Too many hoops and obstacles to stick it into the sleeper module.
 			R.visible_message("<span class='warning'>[user] feeds [R] with [src]!</span>")
 			return
 	..()

--- a/code/game/objects/structures/crates_lockers/closets/egg_vr.dm
+++ b/code/game/objects/structures/crates_lockers/closets/egg_vr.dm
@@ -22,7 +22,7 @@
 	var/datum/belly/belly = check_belly(src)
 	if(belly)
 		for(var/atom/movable/M in src)
-			belly.internal_contents += M
+			belly.internal_contents |= M
 	return ..()
 
 /obj/structure/closet/secure_closet/egg/unathi

--- a/code/modules/mob/living/silicon/robot/dogborg/dog_sleeper_vr.dm
+++ b/code/modules/mob/living/silicon/robot/dogborg/dog_sleeper_vr.dm
@@ -402,53 +402,16 @@
 
 		//Handle the target being anything but a /mob/living/carbon/human
 		else
-			var/obj/T = target
-			if(!(T in items_preserved))
-				if(T.type in important_items)
-					src.items_preserved += T
+			var/obj/item/T = target
+			if(istype(T))
+				var/digested = T.digest_act()
+				if(!digested)
+					items_preserved |= T
 					return
-				if(T in items_preserved)
-					return
-				//If the object is not one to preserve
-				if(istype(T, /obj/item/device/pda))
-					var/obj/item/device/pda/PDA = T
-					if (PDA.id)
-						PDA.id.forceMove(src)
-						PDA.id = null
-					src.hound.cell.charge += (50 * T.w_class)
-					contents -= T
-					qdel(T)
-					src.update_patient()
-				//Special case for IDs to make them digested
-				if(istype(T, /obj/item/weapon/card/id))
-					var/obj/item/weapon/card/id/ID = T
-					ID.desc = "A partially digested card that has seen better days.  Much of it's data has been destroyed."
-					ID.icon = 'icons/obj/card_vr.dmi'
-					ID.icon_state = "digested"
-					ID.access = list() // No access
-					src.items_preserved += ID
-					return
-				//Anything not preserved, PDA, or ID
-				else if(istype(T, /obj/item))
-					for(var/obj/item/SubItem in T)
-						if(istype(SubItem,/obj/item/weapon/storage/internal))
-							var/obj/item/weapon/storage/internal/SI = SubItem
-							for(var/obj/item/SubSubItem in SI)
-								SubSubItem.forceMove(src)
-							qdel(SI)
-						else
-							SubItem.forceMove(src)
-					src.hound.cell.charge += (50 * T.w_class)
-					contents -= T
-					qdel(T)
-					src.update_patient()
-				else
-					src.hound.cell.charge += 120
-					contents -= T
-					qdel(T)
-					src.update_patient()
-				if(UI_open == 1)
-					sleeperUI(hound)
+
+			if(UI_open == 1)
+				update_patient()
+				sleeperUI(hound)
 
 		return
 

--- a/code/modules/mob/living/silicon/robot/dogborg/dog_sleeper_vr.dm
+++ b/code/modules/mob/living/silicon/robot/dogborg/dog_sleeper_vr.dm
@@ -404,10 +404,11 @@
 		else
 			var/obj/item/T = target
 			if(istype(T))
-				var/digested = T.digest_act()
+				var/digested = T.digest_act(item_storage = src)
 				if(!digested)
 					items_preserved |= T
-					return
+				else
+					hound.cell.charge += (50 * digested)
 
 			if(UI_open == 1)
 				update_patient()

--- a/code/modules/vore/eating/belly_vr.dm
+++ b/code/modules/vore/eating/belly_vr.dm
@@ -37,7 +37,7 @@
 	var/tmp/mob/living/owner					// The mob whose belly this is.
 	var/tmp/list/internal_contents = list()		// People/Things you've eaten into this belly!
 	var/tmp/is_full								// Flag for if digested remeans are present. (for disposal messages)
-	var/tmp/emotePend = 0						// If there's already a spawned thing counting for the next emote
+	var/tmp/emotePend = FALSE						// If there's already a spawned thing counting for the next emote
 	var/tmp/list/items_preserved = list()		// Stuff that wont digest.
 	var/tmp/list/checked_slots = list()			// Checked gear slots for strip digest.
 	var/list/slots = list(slot_back,slot_handcuffed,slot_l_store,slot_r_store,slot_wear_mask,slot_l_hand,slot_r_hand,slot_wear_id,slot_glasses,slot_gloves,slot_head,slot_shoes,slot_belt,slot_wear_suit,slot_w_uniform,slot_s_store,slot_l_ear,slot_r_ear)
@@ -95,7 +95,7 @@
 	//Mostly for being overridden on precreated bellies on mobs. Could be VV'd into
 	//a carbon's belly if someone really wanted. No UI for carbons to adjust this.
 	//List has indexes that are the digestion mode strings, and keys that are lists of strings.
-	var/list/emote_lists = list()
+	var/tmp/list/emote_lists = list()
 
 // Constructor that sets the owning mob
 /datum/belly/New(var/mob/living/owning_mob)
@@ -294,7 +294,6 @@
 		if(!H)
 			H = owner
 		for(var/obj/item/W in H)
-			//_handle_digested_item(W,M) //The gut handles them now.
 			if(istype(W,/obj/item/organ/internal/mmi_holder/posibrain))
 				var/obj/item/organ/internal/mmi_holder/MMI = W
 				var/atom/movable/brain = MMI.removed()
@@ -303,22 +302,12 @@
 					brain.forceMove(owner)
 					items_preserved += brain
 					internal_contents += brain
-			if(W == H.get_equipped_item(slot_wear_id))
-				H.remove_from_mob(W,owner)
-				internal_contents += W
-			if(W == H.get_equipped_item(slot_w_uniform))
-				var/list/stash = list(slot_r_store,slot_l_store,slot_wear_id,slot_belt)
-				for(var/stashslot in stash)
-					var/obj/item/SL = H.get_equipped_item(stashslot)
-					if(SL)
-						SL.forceMove(owner)
-						internal_contents += SL
-				H.remove_from_mob(W,owner)
-				internal_contents += W
-			else
-				if(!(istype(W,/obj/item/organ) || istype(W,/obj/item/weapon/storage/internal) || istype(W,/obj/screen)))//Don't drop organs or pocket spaces
-					H.remove_from_mob(W,owner)
-					internal_contents += W
+			for(var/slot in slots)
+				var/obj/item/thingy = M.get_equipped_item(slot = slot)
+				if(thingy)
+					M.unEquip(thingy,force = TRUE)
+					thingy.forceMove(owner)
+					internal_contents |= thingy
 
 	//Reagent transfer
 	if(ishuman(owner))
@@ -333,50 +322,6 @@
 
 	// Delete the digested mob
 	qdel(M)
-
-// Recursive method - To recursively scan thru someone's inventory for digestable/indigestable.
-/datum/belly/proc/_handle_digested_item(var/obj/item/W,var/mob/M)
-	// SOME mob has to use some procs. If somehow they're gone, then the pred can handle it.
-	if(!M)
-		M = owner
-
-	// IDs are handled specially to 'digest' them
-	if(istype(W,/obj/item/weapon/card/id))
-		var/obj/item/weapon/card/id/ID = W
-		ID.desc = "A partially digested card that has seen better days.  Much of it's data has been destroyed."
-		ID.icon = 'icons/obj/card_vr.dmi'
-		ID.icon_state = "digested"
-		ID.access = list() // No access
-		M.remove_from_mob(ID,owner)
-		items_preserved += ID
-
-	// Posibrains have to be pulled 'out' of their organ version.
-
-	if(istype(W,/obj/item/organ/internal/mmi_holder/posibrain))
-		var/obj/item/organ/internal/mmi_holder/MMI = W
-		var/atom/movable/brain = MMI.removed()
-		if(brain)
-			M.remove_from_mob(brain,owner)
-			brain.forceMove(owner)
-			items_preserved += brain
-			internal_contents += brain
-
-	if(!_is_digestable(W))
-		items_preserved += W
-		M.remove_from_mob(W,owner)
-		internal_contents += W
-
-	else
-		for(var/obj/item/SubItem in W)
-			_handle_digested_item(SubItem,M)
-		if(!(istype(W,/obj/item/organ) || istype(W,/obj/item/weapon/storage/internal) || istype(W,/obj/screen)))// Don't drop organs or pocket spaces.
-			M.remove_from_mob(W,owner)
-			internal_contents += W
-
-/datum/belly/proc/_is_digestable(var/obj/item/I)
-	if(is_type_in_list(I,important_items))
-		return 0
-	return 1
 
 // Handle a mob being absorbed
 /datum/belly/proc/absorb_living(var/mob/living/M)

--- a/code/modules/vore/eating/belly_vr.dm
+++ b/code/modules/vore/eating/belly_vr.dm
@@ -355,6 +355,20 @@
 				B.internal_contents -= Mm
 				absorb_living(Mm)
 
+//Digest a single item
+//Receives a return value from digest_act that's how much nutrition
+//the item should be worth
+/datum/belly/proc/digest_item(var/obj/item/item)
+	var/digested = item.digest_act(internal_contents, owner)
+	if(!digested)
+		items_preserved |= item
+	else
+		internal_contents -= item
+		owner.nutrition += (digested)
+		if(isrobot(owner))
+			var/mob/living/silicon/robot/R = owner
+			R.cell.charge += (50 * digested)
+
 //Handle a mob struggling
 // Called from /mob/living/carbon/relaymove()
 /datum/belly/proc/relay_resist(var/mob/living/R)

--- a/code/modules/vore/eating/bellymodes_vr.dm
+++ b/code/modules/vore/eating/bellymodes_vr.dm
@@ -4,13 +4,13 @@
 
 /////////////////////////// Auto-Emotes ///////////////////////////
 	if((digest_mode in emote_lists) && !emotePend)
-		emotePend = 1
+		emotePend = TRUE
 
 		spawn(emoteTime)
 			var/list/EL = emote_lists[digest_mode]
 			for(var/mob/living/M in internal_contents)
 				M << "<span class='notice'>[pick(EL)]</span>"
-			src.emotePend = 0
+			src.emotePend = FALSE
 
 //////////////////////// Absorbed Handling ////////////////////////
 	for(var/mob/living/M in internal_contents)
@@ -24,7 +24,6 @@
 //////////////////////////// DM_DIGEST ////////////////////////////
 	if(digest_mode == DM_DIGEST || digest_mode == DM_DIGEST_NUMB || digest_mode == DM_ITEMWEAK)
 		var/list/touchable_items = internal_contents - items_preserved
-		var/mob/living/silicon/robot/s_owner = null
 		if(!length(touchable_items))
 			return
 
@@ -56,10 +55,6 @@
 				owner << "<span class='notice'>" + digest_alert_owner + "</span>"
 				M << "<span class='notice'>" + digest_alert_prey + "</span>"
 
-				owner.nutrition += 20 // so eating dead mobs gives you *something* (that's 0.66u nutriment yo)
-				if(isrobot(owner))
-					s_owner = owner
-					s_owner.cell.charge += 200
 				var/deathsound = pick(death_sounds)
 				for(var/mob/hearer in range(1,owner))
 					hearer << deathsound
@@ -80,142 +75,26 @@
 				var/offset = (1 + ((M.weight - 137) / 137)) // 130 pounds = .95 140 pounds = 1.02
 				var/difference = owner.size_multiplier / M.size_multiplier
 				if(isrobot(owner))
-					s_owner = owner
-					s_owner.cell.charge += 20*(digest_brute+digest_burn)
+					var/mob/living/silicon/robot/R = owner
+					R.cell.charge += 20*(digest_brute+digest_burn)
 				if(offset) // If any different than default weight, multiply the % of offset.
 					owner.nutrition += offset*(2*(digest_brute+digest_burn)/difference) // 9.5 nutrition per digestion tick if they're 130 pounds and it's same size. 10.2 per digestion tick if they're 140 and it's same size. Etc etc.
 				else
 					owner.nutrition += 2*(digest_brute+digest_burn)/difference
 			M.updateVRPanel()
 
-		if(digest_mode == DM_ITEMWEAK)
-			var/obj/item/T = pick(touchable_items)
-			if(istype(T, /obj/item))
-				if(istype(T, /obj/item) && _is_digestable(T) && !(T in items_preserved))
-					if(T in items_preserved)// Doublecheck just in case.
-						return
-					if(istype(T,/obj/item/weapon/card/id))// Mess up unprotected IDs
-						var/obj/item/weapon/card/id/ID = T
-						ID.desc = "A partially digested card that has seen better days.  Much of it's data has been destroyed."
-						ID.icon = 'icons/obj/card_vr.dmi'
-						ID.icon_state = "digested"
-						ID.access = list() // No access
-						items_preserved += ID
-						return
-					for(var/obj/item/SubItem in T)
-						if(istype(SubItem,/obj/item/weapon/reagent_containers/food))
-							var/obj/item/weapon/reagent_containers/food/SF = SubItem
-							if(istype(owner,/mob/living/carbon/human))
-								var/mob/living/carbon/human/howner = owner
-								SF.reagents.trans_to_holder(howner.ingested, (SF.reagents.total_volume * 0.3), 1, 0)
-							internal_contents -= SF
-							qdel(SF)
-						SubItem.gurglecontaminate()
-						if(istype(SubItem,/obj/item/weapon/storage))
-							for(var/obj/item/SubSubItem in SubItem)
-								if(istype(SubSubItem,/obj/item/weapon/reagent_containers/food))
-									var/obj/item/weapon/reagent_containers/food/SSF = SubSubItem
-									if(istype(owner,/mob/living/carbon/human))
-										var/mob/living/carbon/human/howner = owner
-										SSF.reagents.trans_to_holder(howner.ingested, (SSF.reagents.total_volume * 0.3), 1, 0)
-									internal_contents -= SSF
-									qdel(SSF)
-								SubSubItem.gurglecontaminate()
-					if(istype(T, /obj/item/weapon/reagent_containers/food)) // Weakgurgles still act on foodstuff. Hopefully your prey didn't load their bag with donk boxes.
-						var/obj/item/weapon/reagent_containers/food/F = T
-						if(istype(owner,/mob/living/carbon/human))
-							var/mob/living/carbon/human/howner = owner
-							F.reagents.trans_to_holder(howner.reagents, (F.reagents.total_volume * 0.3), 1, 0)
-						if(isrobot(owner))
-							s_owner = owner
-							s_owner.cell.charge += 150
-						internal_contents -= F
-						qdel(F)
-					if(istype(T,/obj/item/weapon/holder))
-						var/obj/item/weapon/holder/H = T
-						for(var/mob/living/M in H.contents)
-							M.loc = owner
-							internal_contents += M
-						internal_contents -= H
-						qdel(H)
-					if(istype(T,/obj/item/organ))
-						owner.nutrition += (66)
-						internal_contents -= T
-						qdel(T)
-					else
-						items_preserved += T
-						T.gurglecontaminate() // Someone got gurgled in this crap. You wouldn't wear/use it unwashed. :v
+		//Contaminate or gurgle items
+		var/obj/item/T = pick(touchable_items)
+		if(istype(T))
+			if(digest_mode == DM_ITEMWEAK)
+				T.gurgle_contaminate(src)
+				items_preserved |= T
+			else
+				var/digested = T.digest_act(belly = src) //Isn't this much better?
+				if(!digested)
+					items_preserved |= T
 				else
-					return
-			owner.updateVRPanel()
-			return
-		else
-		// Handle leftovers.
-			var/obj/item/T = pick(touchable_items)
-			if(istype(T, /obj/item))
-				if(istype(T, /obj/item) && _is_digestable(T) && !(T in items_preserved))
-					if(T in items_preserved)// Doublecheck just in case.
-						return
-					if(istype(T, /obj/item/device/pda))
-						var/obj/item/device/pda/PDA = T
-						if(PDA.id)
-							PDA.id.forceMove(owner)
-							internal_contents += PDA.id
-							PDA.id = null
-						owner.nutrition += (2)
-						if(isrobot(owner))
-							s_owner = owner
-							s_owner.cell.charge += 100
-						internal_contents -= PDA
-						qdel(PDA)
-					for(var/obj/item/SubItem in T)
-						if(istype(SubItem,/obj/item/weapon/storage/internal))
-							var/obj/item/weapon/storage/internal/SI = SubItem
-							for(var/obj/item/SubSubItem in SI)
-								SubSubItem.forceMove(owner)
-								internal_contents += SubSubItem
-							qdel(SI)
-						else
-							SubItem.forceMove(owner)
-							internal_contents += SubItem
-					if(istype(T,/obj/item/weapon/card/id))// In case the ID didn't come from gurgle drop.
-						var/obj/item/weapon/card/id/ID = T
-						ID.desc = "A partially digested card that has seen better days.  Much of it's data has been destroyed."
-						ID.icon = 'icons/obj/card_vr.dmi'
-						ID.icon_state = "digested"
-						ID.access = list() // No access
-						items_preserved += ID
-						return
-					if(istype(T, /obj/item/weapon/reagent_containers/food/snacks)) // Food gets its own treatment now. Hopefully your prey didn't load their bag with donk boxes.
-						var/obj/item/weapon/reagent_containers/food/snacks/F = T
-						if(istype(owner,/mob/living/carbon/human))
-							var/mob/living/carbon/human/howner = owner
-							F.reagents.trans_to_holder(howner.ingested, (F.reagents.total_volume * 0.3), 1, 0)
-						if(isrobot(owner))
-							s_owner = owner
-							s_owner.cell.charge += 150
-						internal_contents -= F
-						qdel(F)
-					if(istype(T,/obj/item/weapon/holder))
-						var/obj/item/weapon/holder/H = T
-						for(var/mob/living/M in H.contents)
-							M.loc = owner
-							internal_contents += M
-						internal_contents -= H
-						qdel(H)
-					if(istype(T,/obj/item/organ))
-						owner.nutrition += (66)
-						internal_contents -= T
-						qdel(T)
-					else
-						owner.nutrition += (1 * T.w_class)
-						if(isrobot(owner))
-							s_owner = owner
-							s_owner.cell.charge += (50 * T.w_class)
-						internal_contents -= T
-						qdel(T)
-				else
-					return
+					internal_contents -= T
 
 		owner.updateVRPanel()
 		return
@@ -223,7 +102,6 @@
 //////////////////////////// DM_STRIPDIGEST ////////////////////////////
 	if(digest_mode == DM_STRIPDIGEST) // Only gurgle the gear off your prey.
 		var/list/touchable_items = internal_contents - items_preserved
-		var/mob/living/silicon/robot/s_owner = null
 		if(!length(touchable_items))
 			return
 
@@ -234,114 +112,23 @@
 
 		// Handle loose items first.
 		var/obj/item/T = pick(touchable_items)
-		if(istype(T, /obj/item))
-			if(istype(T, /obj/item) && _is_digestable(T) && !(T in items_preserved))
-				if(T in items_preserved)// Doublecheck just in case.
-					return
-				if(istype(T, /obj/item/device/pda))
-					var/obj/item/device/pda/PDA = T
-					if(PDA.id)
-						PDA.id.forceMove(owner)
-						internal_contents += PDA.id
-						PDA.id = null
-					owner.nutrition += (2)
-					if(isrobot(owner))
-						s_owner = owner
-						s_owner.cell.charge += (100)
-					internal_contents -= PDA
-					qdel(PDA)
-
-				if(istype(T,/obj/item/weapon/card/id))
-					var/obj/item/weapon/card/id/ID = T
-					ID.desc = "A partially digested card that has seen better days.  Much of it's data has been destroyed."
-					ID.icon = 'icons/obj/card_vr.dmi'
-					ID.icon_state = "digested"
-					ID.access = list() // No access
-					items_preserved += ID
-					return
-				for(var/obj/item/SubItem in T)
-					if(istype(SubItem,/obj/item/weapon/storage/internal))
-						var/obj/item/weapon/storage/internal/SI = SubItem
-						for(var/obj/item/SubSubItem in SI)
-							SubSubItem.forceMove(owner)
-							internal_contents += SubSubItem
-						qdel(SI)
-					else
-						SubItem.forceMove(owner)
-						internal_contents += SubItem
-				if(istype(T, /obj/item/weapon/reagent_containers/food/snacks)) // Food gets its own treatment now. Hopefully your prey didn't load their bag with donk boxes.
-					var/obj/item/weapon/reagent_containers/food/snacks/F = T
-					if(istype(owner,/mob/living/carbon/human))
-						var/mob/living/carbon/human/howner = owner
-						F.reagents.trans_to_holder(howner.ingested, (F.reagents.total_volume * 0.3), 1, 0)
-					if(isrobot(owner))
-						s_owner = owner
-						s_owner.cell.charge += (150)
-					internal_contents -= F
-					qdel(F)
-				if(istype(T,/obj/item/weapon/holder))
-					var/obj/item/weapon/holder/H = T
-					for(var/mob/living/M in H.contents)
-						M.loc = owner
-						internal_contents += M
-					internal_contents -= H
-					qdel(H)
-				if(istype(T,/obj/item/organ))
-					owner.nutrition += (66)
-					internal_contents -= T
-					qdel(T)
-				else
-					owner.nutrition += (1 * T.w_class)
-					if(isrobot(owner))
-						s_owner = owner
-						s_owner.cell.charge += (50 * T.w_class)
-					internal_contents -= T
-					qdel(T)
-				for(var/mob/living/carbon/human/M in internal_contents)
-					M.updateVRPanel()
+		if(istype(T))
+			var/digested = T.digest_act(belly = src) //Isn't this much better?
+			if(!digested)
+				items_preserved |= T
+			else
+				internal_contents -= T
 
 		for(var/mob/living/carbon/human/M in internal_contents)
-			if(!M)
-				M = owner
-			//Pref protection!
-			if (!M.digestable || M.absorbed)
+			if (M.absorbed)
 				continue
-			if(length(slots - checked_slots) < 1)
-				checked_slots.Cut()
-			var/validslot = pick(slots - checked_slots)
-			checked_slots += validslot // Avoid wasting cycles on already checked slots.
-			var/obj/item/I = M.get_equipped_item(validslot)
-			if(!I)
-				return
-			if(istype(I,/obj/item/weapon/card/id))
-				var/obj/item/weapon/card/id/ID = I
-				ID.desc = "A partially digested card that has seen better days.  Much of it's data has been destroyed."
-				ID.icon = 'icons/obj/card_vr.dmi'
-				ID.icon_state = "digested"
-				ID.access = list() // No access
-				M.remove_from_mob(ID,owner)
-				internal_contents += ID
-				items_preserved += ID
-				return
-			if(!_is_digestable(I))
-				M.remove_from_mob(I,owner)
-				items_preserved += I
-				internal_contents += I
-				return
-			if(I == M.get_equipped_item(slot_w_uniform))
-				var/list/stash = list(slot_r_store,slot_l_store,slot_wear_id,slot_belt)
-				for(var/stashslot in stash)
-					var/obj/item/SL = M.get_equipped_item(stashslot)
-					if(SL)
-						M.remove_from_mob(SL,owner)
-						internal_contents += SL
-				M.remove_from_mob(I,owner)
-				internal_contents += I
-				return
-			else
-				if(!(istype(I,/obj/item/organ) || istype(I,/obj/item/weapon/storage/internal) || istype(I,/obj/screen)))
-					M.remove_from_mob(I,owner)
-					internal_contents += I
+			for(var/slot in slots)
+				var/obj/item/thingy = M.get_equipped_item(slot = slot)
+				if(thingy)
+					M.unEquip(thingy,force = TRUE)
+					thingy.forceMove(owner)
+					internal_contents |= thingy
+					thingy.digest_act(src) //Shame to move it just before gurgling it, but it might be indigestible.
 			M.updateVRPanel()
 
 		owner.updateVRPanel()
@@ -727,7 +514,6 @@
 				put_in_egg(P,1)
 
 		return
-
 
 ///////////////////////////// DM_EGG /////////////////////////////
 	if(digest_mode == DM_EGG && ishuman(owner))

--- a/code/modules/vore/eating/bellymodes_vr.dm
+++ b/code/modules/vore/eating/bellymodes_vr.dm
@@ -87,14 +87,10 @@
 		var/obj/item/T = pick(touchable_items)
 		if(istype(T))
 			if(digest_mode == DM_ITEMWEAK)
-				T.gurgle_contaminate(src)
+				T.gurgle_contaminate(internal_contents, owner)
 				items_preserved |= T
 			else
-				var/digested = T.digest_act(belly = src) //Isn't this much better?
-				if(!digested)
-					items_preserved |= T
-				else
-					internal_contents -= T
+				digest_item(T)
 
 		owner.updateVRPanel()
 		return
@@ -113,11 +109,7 @@
 		// Handle loose items first.
 		var/obj/item/T = pick(touchable_items)
 		if(istype(T))
-			var/digested = T.digest_act(belly = src) //Isn't this much better?
-			if(!digested)
-				items_preserved |= T
-			else
-				internal_contents -= T
+			digest_item(T)
 
 		for(var/mob/living/carbon/human/M in internal_contents)
 			if (M.absorbed)
@@ -128,7 +120,7 @@
 					M.unEquip(thingy,force = TRUE)
 					thingy.forceMove(owner)
 					internal_contents |= thingy
-					thingy.digest_act(src) //Shame to move it just before gurgling it, but it might be indigestible.
+					digest_item(T)
 			M.updateVRPanel()
 
 		owner.updateVRPanel()

--- a/code/modules/vore/eating/contaminate_vr.dm
+++ b/code/modules/vore/eating/contaminate_vr.dm
@@ -5,7 +5,7 @@ var/image/gurgled_overlay = image('icons/effects/sludgeoverlay_vr.dmi')
 	var/cleanname
 	var/cleandesc
 
-/obj/item/proc/gurgle_contaminate(var/datum/belly/belly = null)
+/obj/item/proc/gurgle_contaminate(var/list/internal_contents = null, var/atom/movable/item_storage = null)
 	if(!can_gurgle())
 		return FALSE
 
@@ -18,7 +18,7 @@ var/image/gurgled_overlay = image('icons/effects/sludgeoverlay_vr.dmi')
 		name = "[gurgleflavor] [cleanname]"
 		desc = "[cleandesc] It seems to be covered in ominously foul residue and needs a wash."
 		for(var/obj/item/O in contents)
-			gurgle_contaminate(belly)
+			gurgle_contaminate(internal_contents, item_storage)
 		return TRUE
 
 /obj/item/proc/can_gurgle()
@@ -93,34 +93,34 @@ var/image/gurgled_overlay = image('icons/effects/sludgeoverlay_vr.dmi')
 //////////////
 // Special handling of gurgle_contaminate
 //////////////
-/obj/item/weapon/card/id/gurgle_contaminate(var/datum/belly/belly = null)
-	digest_act(belly) //Digesting these anyway
+/obj/item/weapon/card/id/gurgle_contaminate(var/list/internal_contents = null, var/atom/movable/item_storage = null)
+	digest_act(internal_contents, item_storage) //Digesting these anyway
 	return TRUE
 
-/obj/item/weapon/reagent_containers/food/gurgle_contaminate(var/datum/belly/belly = null)
-	digest_act(belly)
+/obj/item/weapon/reagent_containers/food/gurgle_contaminate(var/list/internal_contents = null, var/atom/movable/item_storage = null)
+	digest_act(internal_contents, item_storage)
 	return TRUE
 
-/obj/item/weapon/holder/gurgle_contaminate(var/datum/belly/belly = null)
-	digest_act(belly)
+/obj/item/weapon/holder/gurgle_contaminate(var/list/internal_contents = null, var/atom/movable/item_storage = null)
+	digest_act(internal_contents, item_storage)
 	return TRUE
 
-/obj/item/organ/gurgle_contaminate(var/datum/belly/belly = null)
-	digest_act(belly)
+/obj/item/organ/gurgle_contaminate(var/list/internal_contents = null, var/atom/movable/item_storage = null)
+	digest_act(internal_contents, item_storage)
 	return TRUE
 
-/obj/item/weapon/cell/gurgle_contaminate(var/datum/belly/belly = null)
+/obj/item/weapon/cell/gurgle_contaminate(var/list/internal_contents = null, var/atom/movable/item_storage = null)
 	if(!gurgled)
 	//Don't make them wet, just drain
 		var/obj/item/weapon/cell/C = src
 		C.charge = 0
 	return TRUE
 
-/obj/item/weapon/storage/box/gurgle_contaminate(var/datum/belly/belly = null)
+/obj/item/weapon/storage/box/gurgle_contaminate(var/list/internal_contents = null, var/atom/movable/item_storage = null)
 	if((. = ..()))
 		name = "soggy [cleanname]"
 		desc = "This soggy box is about to fall apart any time."
 
-/obj/item/device/pda/gurgle_contaminate(var/datum/belly/belly = null)
+/obj/item/device/pda/gurgle_contaminate(var/list/internal_contents = null, var/atom/movable/item_storage = null)
 	if((. = ..()))
 		desc = "This device seems completely unresponsive while drenched with sludge. Perhaps you could still wash it."

--- a/code/modules/vore/eating/contaminate_vr.dm
+++ b/code/modules/vore/eating/contaminate_vr.dm
@@ -1,45 +1,39 @@
 var/image/gurgled_overlay = image('icons/effects/sludgeoverlay_vr.dmi')
 
 /obj/item
-	var/gurgled = 0
+	var/gurgled = FALSE
 	var/cleanname
 	var/cleandesc
 
-/obj/item/proc/gurglecontaminate()
+/obj/item/proc/gurgle_contaminate(var/datum/belly/belly = null)
 	if(!can_gurgle())
-		return
-	else
-		if(istype(src,/obj/item/weapon/cell)) //Drain powercells without contaminating.
-			var/obj/item/weapon/cell/C = src
-			C.charge = 0
-		else if(src.gurgled == 0)
-			gurgled = 1
-			overlays += gurgled_overlay
-			var/gurgleflavor = pick("soggy","soaked","dirty","nasty","slimy","drenched","sloppy")
-			cleanname = src.name
-			cleandesc = src.desc
-			name = "[gurgleflavor] [cleanname]"
-			desc = "[cleandesc] It seems to be covered in ominously foul residue and needs a wash."
-			if(istype(src,/obj/item/weapon/storage/box))
-				name = "soggy [cleanname]"
-				desc = "This soggy box is about to fall apart any time."
-			if(istype(src,/obj/item/device/pda))
-				desc = "This device seems completely unresponsive while drenched with sludge. Perhaps you could still wash it."
+		return FALSE
 
+	if(!gurgled)
+		gurgled = TRUE
+		overlays += gurgled_overlay
+		var/gurgleflavor = pick("soggy","soaked","dirty","nasty","slimy","drenched","sloppy")
+		cleanname = src.name
+		cleandesc = src.desc
+		name = "[gurgleflavor] [cleanname]"
+		desc = "[cleandesc] It seems to be covered in ominously foul residue and needs a wash."
+		for(var/obj/item/O in contents)
+			gurgle_contaminate(belly)
+		return TRUE
 
 /obj/item/proc/can_gurgle()
 	if(flags & PHORONGUARD)
-		return 0
-	else if(phoronproof == 1)
-		return 0
+		return FALSE
+	else if(phoronproof == TRUE)
+		return FALSE
 	else if(unacidable)
-		return 0
+		return FALSE
 	else
-		return 1
+		return TRUE
 
 /obj/item/decontaminate() //Decontaminate the sogginess as well.
 	..()
-	gurgled = 0
+	gurgled = FALSE
 	overlays -= gurgled_overlay
 	if(cleanname)
 		name = cleanname
@@ -48,17 +42,17 @@ var/image/gurgled_overlay = image('icons/effects/sludgeoverlay_vr.dmi')
 
 /obj/item/clean_blood() //Make this type of contamination sink washable as well.
 	..()
-	if(gurgled == 1)
+	if(gurgled)
 		decontaminate()
 
 /obj/item/device/pda/can_use() //Get your rice bowl ready.
-	if(src.gurgled == 1)
-		return 0
+	if(gurgled)
+		return FALSE
 	else
 		return ..()
 
 /obj/structure/sink/attackby(obj/item/O as obj, mob/user as mob) //Wash the soggy item before it can interact with the sink.
-	if(O.gurgled == 1)
+	if(O.gurgled)
 		var/turf/location = user.loc
 		if(!isturf(location)) return
 
@@ -67,9 +61,9 @@ var/image/gurgled_overlay = image('icons/effects/sludgeoverlay_vr.dmi')
 
 		to_chat(usr, "<span class='notice'>You start washing \the [I].</span>")
 
-		busy = 1
+		busy = TRUE
 		sleep(40)
-		busy = 0
+		busy = FALSE
 
 		if(user.loc != location) return				//User has moved
 		if(!I) return 								//Item's been destroyed while washing
@@ -82,8 +76,11 @@ var/image/gurgled_overlay = image('icons/effects/sludgeoverlay_vr.dmi')
 	else
 		..()
 
+//////////////
+// Special things that happen when wet
+//////////////
 /obj/item/weapon/storage/box/open(mob/user as mob)
-	if(src.gurgled == 1)
+	if(gurgled)
 		usr << "The soggy box falls apart in your hands."
 		var/turf/T = get_turf(src)
 		for(var/obj/item/I in contents)
@@ -92,3 +89,38 @@ var/image/gurgled_overlay = image('icons/effects/sludgeoverlay_vr.dmi')
 		qdel()
 		return
 	..()
+
+//////////////
+// Special handling of gurgle_contaminate
+//////////////
+/obj/item/weapon/card/id/gurgle_contaminate(var/datum/belly/belly = null)
+	digest_act(belly) //Digesting these anyway
+	return TRUE
+
+/obj/item/weapon/reagent_containers/food/gurgle_contaminate(var/datum/belly/belly = null)
+	digest_act(belly)
+	return TRUE
+
+/obj/item/weapon/holder/gurgle_contaminate(var/datum/belly/belly = null)
+	digest_act(belly)
+	return TRUE
+
+/obj/item/organ/gurgle_contaminate(var/datum/belly/belly = null)
+	digest_act(belly)
+	return TRUE
+
+/obj/item/weapon/cell/gurgle_contaminate(var/datum/belly/belly = null)
+	if(!gurgled)
+	//Don't make them wet, just drain
+		var/obj/item/weapon/cell/C = src
+		C.charge = 0
+	return TRUE
+
+/obj/item/weapon/storage/box/gurgle_contaminate(var/datum/belly/belly = null)
+	if((. = ..()))
+		name = "soggy [cleanname]"
+		desc = "This soggy box is about to fall apart any time."
+
+/obj/item/device/pda/gurgle_contaminate(var/datum/belly/belly = null)
+	if((. = ..()))
+		desc = "This device seems completely unresponsive while drenched with sludge. Perhaps you could still wash it."

--- a/code/modules/vore/eating/digest_act_vr.dm
+++ b/code/modules/vore/eating/digest_act_vr.dm
@@ -1,0 +1,88 @@
+//Please make sure to:
+//return FALSE: You are not going away, stop asking me to digest.
+//return TRUE: You are going away.
+
+// Ye default implementation.
+/obj/item/proc/digest_act(var/datum/belly/belly = null)
+	if(belly)
+		for(var/obj/item/AM in contents)
+			AM.forceMove(belly.owner)
+			belly.internal_contents |= AM
+
+		belly.owner.nutrition += (1 * w_class)
+		if(isrobot(belly.owner))
+			var/mob/living/silicon/robot/R = belly.owner
+			R.cell.charge += (50 * w_class)
+	qdel(src)
+	return TRUE
+
+/////////////
+// Some indigestible stuff
+/////////////
+/obj/item/weapon/hand_tele/digest_act(var/datum/belly/belly = null)
+	return FALSE
+/obj/item/weapon/card/id/gold/captain/spare/digest_act(var/datum/belly/belly = null)
+	return FALSE
+/obj/item/device/aicard/digest_act(var/datum/belly/belly = null)
+	return FALSE
+/obj/item/device/paicard/digest_act(var/datum/belly/belly = null)
+	return FALSE
+/obj/item/weapon/gun/digest_act(var/datum/belly/belly = null)
+	return FALSE
+/obj/item/weapon/pinpointer/digest_act(var/datum/belly/belly = null)
+	return FALSE
+/obj/item/blueprints/digest_act(var/datum/belly/belly = null)
+	return FALSE
+/obj/item/weapon/disk/nuclear/digest_act(var/datum/belly/belly = null)
+	return FALSE
+/obj/item/device/perfect_tele_beacon/digest_act(var/datum/belly/belly = null)
+	return FALSE //Sorta important to not digest your own beacons.
+
+/////////////
+// Some special treatment
+/////////////
+//PDAs need to lose their ID to not take it with them, so we can get a digested ID
+/obj/item/device/pda/digest_act(var/datum/belly/belly = null)
+	if(id)
+		id = null
+		if(belly)
+			id.forceMove(belly.owner)
+
+	. = ..()
+
+/obj/item/weapon/card/id/digest_act(var/datum/belly/belly = null)
+	desc = "A partially digested card that has seen better days.  Much of it's data has been destroyed."
+	icon = 'icons/obj/card_vr.dmi'
+	icon_state = "digested"
+	access = list() // No access
+	return FALSE
+
+/obj/item/weapon/reagent_containers/food/digest_act(var/datum/belly/belly = null)
+	if(belly)
+		if(istype(belly.owner,/mob/living/carbon/human))
+			var/mob/living/carbon/human/H = belly.owner
+			reagents.trans_to_holder(H.ingested, (reagents.total_volume * 0.3), 1, 0)
+
+		else if(isrobot(belly.owner))
+			var/mob/living/silicon/robot/R = belly.owner
+			R.cell.charge += 150
+
+	. = ..()
+
+/obj/item/weapon/holder/digest_act(var/datum/belly/belly = null)
+	held_mob = null
+
+	. = ..()
+
+/obj/item/organ/digest_act(var/datum/belly/belly = null)
+	if(belly)
+		belly.owner.nutrition += 66
+
+	. = ..()
+
+/////////////
+// Some more complicated stuff
+/////////////
+/obj/item/device/mmi/digital/posibrain/digest_act(var/datum/belly/belly = null)
+	//Replace this with a VORE setting so all types of posibrains can/can't be digested on a whim
+	return FALSE

--- a/code/modules/vore/eating/digest_act_vr.dm
+++ b/code/modules/vore/eating/digest_act_vr.dm
@@ -1,88 +1,88 @@
 //Please make sure to:
 //return FALSE: You are not going away, stop asking me to digest.
-//return TRUE: You are going away.
+//return non-negative integer: Amount of nutrition/charge gained (scaled to nutrition, other end can multiply for charge scale).
 
 // Ye default implementation.
-/obj/item/proc/digest_act(var/datum/belly/belly = null)
-	if(belly)
-		for(var/obj/item/AM in contents)
-			AM.forceMove(belly.owner)
-			belly.internal_contents |= AM
+/obj/item/proc/digest_act(var/list/internal_contents = null, var/atom/movable/item_storage = null)
+	for(var/obj/item/O in contents)
+		if(internal_contents)
+			internal_contents |= O
+		if(item_storage)
+			O.forceMove(item_storage)
 
-		belly.owner.nutrition += (1 * w_class)
-		if(isrobot(belly.owner))
-			var/mob/living/silicon/robot/R = belly.owner
-			R.cell.charge += (50 * w_class)
 	qdel(src)
-	return TRUE
+	return w_class
 
 /////////////
 // Some indigestible stuff
 /////////////
-/obj/item/weapon/hand_tele/digest_act(var/datum/belly/belly = null)
+/obj/item/weapon/hand_tele/digest_act(var/list/internal_contents = null, var/atom/movable/item_storage = null)
 	return FALSE
-/obj/item/weapon/card/id/gold/captain/spare/digest_act(var/datum/belly/belly = null)
+/obj/item/weapon/card/id/gold/captain/spare/digest_act(var/list/internal_contents = null, var/atom/movable/item_storage = null)
 	return FALSE
-/obj/item/device/aicard/digest_act(var/datum/belly/belly = null)
+/obj/item/device/aicard/digest_act(var/list/internal_contents = null, var/atom/movable/item_storage = null)
 	return FALSE
-/obj/item/device/paicard/digest_act(var/datum/belly/belly = null)
+/obj/item/device/paicard/digest_act(var/list/internal_contents = null, var/atom/movable/item_storage = null)
 	return FALSE
-/obj/item/weapon/gun/digest_act(var/datum/belly/belly = null)
+/obj/item/weapon/gun/digest_act(var/list/internal_contents = null, var/atom/movable/item_storage = null)
 	return FALSE
-/obj/item/weapon/pinpointer/digest_act(var/datum/belly/belly = null)
+/obj/item/weapon/pinpointer/digest_act(var/list/internal_contents = null, var/atom/movable/item_storage = null)
 	return FALSE
-/obj/item/blueprints/digest_act(var/datum/belly/belly = null)
+/obj/item/blueprints/digest_act(var/list/internal_contents = null, var/atom/movable/item_storage = null)
 	return FALSE
-/obj/item/weapon/disk/nuclear/digest_act(var/datum/belly/belly = null)
+/obj/item/weapon/disk/nuclear/digest_act(var/list/internal_contents = null, var/atom/movable/item_storage = null)
 	return FALSE
-/obj/item/device/perfect_tele_beacon/digest_act(var/datum/belly/belly = null)
+/obj/item/device/perfect_tele_beacon/digest_act(var/list/internal_contents = null, var/atom/movable/item_storage = null)
 	return FALSE //Sorta important to not digest your own beacons.
 
 /////////////
 // Some special treatment
 /////////////
 //PDAs need to lose their ID to not take it with them, so we can get a digested ID
-/obj/item/device/pda/digest_act(var/datum/belly/belly = null)
+/obj/item/device/pda/digest_act(var/list/internal_contents = null, var/atom/movable/item_storage = null)
 	if(id)
 		id = null
-		if(belly)
-			id.forceMove(belly.owner)
+
+		/* Doesn't appear to be necessary anymore.
+		if(item_storage)
+			id.forceMove(item_storage)
+		if(internal_contents)
+			internal_contents |= id
+		*/
 
 	. = ..()
 
-/obj/item/weapon/card/id/digest_act(var/datum/belly/belly = null)
+/obj/item/weapon/card/id/digest_act(var/list/internal_contents = null, var/atom/movable/item_storage = null)
 	desc = "A partially digested card that has seen better days.  Much of it's data has been destroyed."
 	icon = 'icons/obj/card_vr.dmi'
 	icon_state = "digested"
 	access = list() // No access
 	return FALSE
 
-/obj/item/weapon/reagent_containers/food/digest_act(var/datum/belly/belly = null)
-	if(belly)
-		if(istype(belly.owner,/mob/living/carbon/human))
-			var/mob/living/carbon/human/H = belly.owner
-			reagents.trans_to_holder(H.ingested, (reagents.total_volume * 0.3), 1, 0)
+/obj/item/weapon/reagent_containers/food/digest_act(var/list/internal_contents = null, var/atom/movable/item_storage = null)
+	if(ishuman(item_storage))
+		var/mob/living/carbon/human/H = item_storage
+		reagents.trans_to_holder(H.ingested, (reagents.total_volume * 0.3), 1, 0)
 
-		else if(isrobot(belly.owner))
-			var/mob/living/silicon/robot/R = belly.owner
-			R.cell.charge += 150
+	else if(isrobot(item_storage))
+		var/mob/living/silicon/robot/R = item_storage
+		R.cell.charge += 150
 
 	. = ..()
 
-/obj/item/weapon/holder/digest_act(var/datum/belly/belly = null)
+/obj/item/weapon/holder/digest_act(var/list/internal_contents = null, var/atom/movable/item_storage = null)
 	held_mob = null
 
 	. = ..()
 
-/obj/item/organ/digest_act(var/datum/belly/belly = null)
-	if(belly)
-		belly.owner.nutrition += 66
+/obj/item/organ/digest_act(var/list/internal_contents = null, var/atom/movable/item_storage = null)
+	if((. = ..()))
+		. += 70 //Organs give a little more
 
-	. = ..()
 
 /////////////
 // Some more complicated stuff
 /////////////
-/obj/item/device/mmi/digital/posibrain/digest_act(var/datum/belly/belly = null)
+/obj/item/device/mmi/digital/posibrain/digest_act(var/list/internal_contents = null, var/atom/movable/item_storage = null)
 	//Replace this with a VORE setting so all types of posibrains can/can't be digested on a whim
 	return FALSE

--- a/code/modules/vore/eating/living_vr.dm
+++ b/code/modules/vore/eating/living_vr.dm
@@ -145,7 +145,7 @@
 			if(do_after(user,30,src))
 				user.drop_item()
 				I.loc = src
-				B.internal_contents += I
+				B.internal_contents |= I
 				src.visible_message("<span class='warning'>[src] is fed the beacon!</span>","You're fed the beacon!")
 				playsound(src, B.vore_sound, 100, 1)
 				return 1
@@ -486,7 +486,7 @@
 			src.loc = H.loc
 			var/datum/belly/B = check_belly(H)
 			if(B)
-				B.internal_contents += src
+				B.internal_contents |= src
 			return
 		else //Being held by a human
 			src << "<font color='blue'>You start to climb out of \the [C]!</font>"
@@ -504,7 +504,7 @@
 			src.loc = H.loc
 			var/datum/belly/B = check_belly(H)
 			if(B)
-				B.internal_contents += src
+				B.internal_contents |= src
 			return
 
 	src << "<font color='blue'>You start to climb out of \the [C]!</font>"
@@ -516,7 +516,7 @@
 		if(check_belly(C)) B = check_belly(C)
 		if(check_belly(C.loc)) B = check_belly(C.loc)
 		if(B)
-			B.internal_contents += src
+			B.internal_contents |= src
 		return
 	return
 

--- a/code/modules/vore/eating/transforming_vr.dm
+++ b/code/modules/vore/eating/transforming_vr.dm
@@ -260,7 +260,7 @@
 	M.forceMove(egg)
 	egg.name = egg_name
 	internal_contents -= M
-	internal_contents += egg
+	internal_contents |= egg
 	if(message)
 		to_chat(M, "<span class='notice'>You lose sensation of your body, feeling only the warmth around you as you're encased in an egg.</span>")
 		to_chat(O, "<span class='notice'>Your body shifts as you encase [M] in an egg.</span>")

--- a/code/modules/vore/eating/vorepanel_vr.dm
+++ b/code/modules/vore/eating/vorepanel_vr.dm
@@ -7,7 +7,6 @@
 #define BELLIES_NAME_MAX 12
 #define BELLIES_DESC_MAX 1024
 #define FLAVOR_MAX 40
-#define NIF_EXAMINE_MAX 100
 
 /mob/living/proc/insidePanel()
 	set name = "Vore Panel"
@@ -269,12 +268,6 @@
 
 	dat += "<HR>"
 
-	//Under the last HR, save and stuff.
-	dat += "<a href='?src=\ref[src];saveprefs=1'>Save Prefs</a>"
-	dat += "<a href='?src=\ref[src];refresh=1'>Refresh</a>"
-	dat += "<a href='?src=\ref[src];setflavor=1'>Set Flavor</a>"
-	dat += "<br><a href='?src=\ref[src];togglenoisy=1'>Toggle Hunger Noises</a>"
-
 	switch(user.digestable)
 		if(1)
 			dat += "<a href='?src=\ref[src];toggledg=1'>Toggle Digestable</a>"
@@ -287,11 +280,16 @@
 		if(0)
 			dat += "<a href='?src=\ref[src];togglemv=1'><span style='color:green;'>Toggle Mob Vore</span></a>"
 
-	dat += "<br><a href='?src=\ref[src];toggle_nif=1'>Set NIF concealment</a>" //These two get their own, custom row.
-	dat += "<a href='?src=\ref[src];set_nif_flavor=1'>Set NIF Examine Message.</a>"
+	dat += "<br><a href='?src=\ref[src];toggle_dropnom_prey=1'>Toggle Drop-nom Prey</a>" //These two get their own, custom row, too.
+	dat += "<a href='?src=\ref[src];toggle_dropnom_pred=1'>Toggle Drop-nom Pred</a>"
+	dat += "<br><a href='?src=\ref[src];setflavor=1'>Set Your Taste</a>"
+	dat += "<a href='?src=\ref[src];togglenoisy=1'>Toggle Hunger Noises</a>"
 
-	dat += "<br><a href='?src=\ref[src];toggle_dropnom_prey=1'>Toggle Drop-nom Prey Mode</a>" //These two get their own, custom row, too.
-	dat += "<a href='?src=\ref[src];toggle_dropnom_pred=1'>Toggle Drop-nom Pred Mode</a>"
+	dat += "<HR>"
+
+	//Under the last HR, save and stuff.
+	dat += "<a href='?src=\ref[src];saveprefs=1'>Save Prefs</a>"
+	dat += "<a href='?src=\ref[src];refresh=1'>Refresh</a>"
 
 	//Returns the dat html to the vore_look
 	return dat
@@ -519,6 +517,7 @@
 					selected.digest_mode = selected.digest_modes[1]
 		else
 			selected.digest_mode = input("Choose Mode (currently [selected.digest_mode])") in menu_list
+			selected.items_preserved.Cut() //Re-evaltuate all items in belly on belly-mode change
 
 	if(href_list["b_desc"])
 		var/new_desc = html_encode(input(usr,"Belly Description (1024 char limit):","New Description",selected.inside_flavor) as message|null)
@@ -735,28 +734,6 @@
 				alert("Entered flavor/taste text too long. [FLAVOR_MAX] character limit.","Error")
 				return 0
 			user.vore_taste = new_flavor
-		else //Returned null
-			return 0
-
-	if(href_list["toggle_nif"])
-		var/choice = alert(user, "Your nif is currently: [user.conceal_nif ? "Not able to be seen" : "Able to be seen"]", "", "Conceal NIF", "Cancel", "Show NIF")
-		switch(choice)
-			if("Cancel")
-				return 0
-			if("Conceal NIF")
-				user.conceal_nif = 1
-			if("Show NIF")
-				user.conceal_nif = 0
-
-	if(href_list["set_nif_flavor"])
-		var/new_nif_examine = html_encode(input(usr,"How people will see your NIF on examine (100ch limit):","Character Flavor",user.nif_examine) as text|null)
-
-		if(new_nif_examine)
-			new_nif_examine = readd_quotes(new_nif_examine)
-			if(length(new_nif_examine) > NIF_EXAMINE_MAX)
-				alert("Entered NIF examine text too long. [NIF_EXAMINE_MAX] character limit.","Error")
-				return 0
-			user.nif_examine = new_nif_examine
 		else //Returned null
 			return 0
 

--- a/code/modules/vore/fluffstuff/custom_boxes_vr.dm
+++ b/code/modules/vore/fluffstuff/custom_boxes_vr.dm
@@ -182,6 +182,9 @@
 		new /obj/item/ammo_casing/nsfw_batt/net(src)
 		new /obj/item/clothing/accessory/holster(src)
 
+/obj/item/weapon/storage/backpack/satchel/gen/fluff/aronai/digest_act(var/datum/belly/belly = null)
+	return FALSE //I get eaten a lot, okay
+
 //Aerowing:Sebastian Aji
 /obj/item/weapon/storage/box/fluff/sebastian_aji
 	name = "Sebastian's Lumoco Arms P3 Box"

--- a/code/modules/vore/fluffstuff/custom_clothes_vr.dm
+++ b/code/modules/vore/fluffstuff/custom_clothes_vr.dm
@@ -105,7 +105,7 @@
 	else
 		RemoveHood_roiz()
 
-/obj/item/clothing/suit/storage/hooded/wintercoat/roiz/digest_act(var/datum/belly/belly = null)
+/obj/item/clothing/suit/storage/hooded/wintercoat/roiz/digest_act(var/list/internal_contents = null, var/atom/movable/item_storage = null)
 	return FALSE
 
 //ketrai:Ketrai
@@ -679,7 +679,7 @@
 		else
 			return 1
 
-/obj/item/clothing/under/fluff/screesuit/digest_act(var/datum/belly/belly = null)
+/obj/item/clothing/under/fluff/screesuit/digest_act(var/list/internal_contents = null, var/atom/movable/item_storage = null)
 	return FALSE
 
 //HOS Hardsuit
@@ -769,7 +769,7 @@
 
 	action_button_name = "Toggle pom-pom"
 
-/obj/item/clothing/head/fluff/pompom/digest_act(var/datum/belly/belly = null)
+/obj/item/clothing/head/fluff/pompom/digest_act(var/list/internal_contents = null, var/atom/movable/item_storage = null)
 	return FALSE
 
 /obj/item/clothing/head/fluff/pompom/attack_self(mob/user)

--- a/code/modules/vore/fluffstuff/custom_clothes_vr.dm
+++ b/code/modules/vore/fluffstuff/custom_clothes_vr.dm
@@ -105,6 +105,9 @@
 	else
 		RemoveHood_roiz()
 
+/obj/item/clothing/suit/storage/hooded/wintercoat/roiz/digest_act(var/datum/belly/belly = null)
+	return FALSE
+
 //ketrai:Ketrai
 /obj/item/clothing/head/fluff/ketrai
 	name = "Pink Bear Hat"
@@ -676,6 +679,9 @@
 		else
 			return 1
 
+/obj/item/clothing/under/fluff/screesuit/digest_act(var/datum/belly/belly = null)
+	return FALSE
+
 //HOS Hardsuit
 /obj/item/clothing/suit/space/void/security/fluff/hos // ToDo: Rig version.
 	name = "\improper prototype voidsuit"
@@ -762,6 +768,9 @@
 	light_overlay = null
 
 	action_button_name = "Toggle pom-pom"
+
+/obj/item/clothing/head/fluff/pompom/digest_act(var/datum/belly/belly = null)
+	return FALSE
 
 /obj/item/clothing/head/fluff/pompom/attack_self(mob/user)
 	//if(!isturf(user.loc)) -- doesn't seem to cause problems to allow this and it's silly not to

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -2604,6 +2604,7 @@
 #include "code\modules\vore\eating\belly_vr.dm"
 #include "code\modules\vore\eating\bellymodes_vr.dm"
 #include "code\modules\vore\eating\contaminate_vr.dm"
+#include "code\modules\vore\eating\digest_act_vr.dm"
 #include "code\modules\vore\eating\living_vr.dm"
 #include "code\modules\vore\eating\silicon_vr.dm"
 #include "code\modules\vore\eating\simple_animal_vr.dm"


### PR DESCRIPTION
Refactors digestion to be about 220 lines less. Now items have a `digest_act(var/belly)` instead of having snowflake code repeated several times.

This also makes it possible for each item to easily have special things that happens when digested. Refactored a little of contamination as well.

Also in case it's important, removed the 'digestable' person check on digesting people's items. Not having your PDA digested is not an ERP pref. And in fact lots of people have the pref for the opposite (having their clothes/other stuff digested off).

NB: Also removed the NIF flavortext, it doesn't belong in the *vore* panel. Left the vars on humans so it can be readded to be settings on the NIF in another PR.