### PR TITLE
Renames leg cuffs to leg wraps, renames the gold ones

### DIFF
--- a/code/modules/vore/fluffstuff/custom_clothes_vr.dm
+++ b/code/modules/vore/fluffstuff/custom_clothes_vr.dm
@@ -1016,7 +1016,7 @@
 
 
 /obj/item/clothing/shoes/black/cuffs
-	name = "Gilded cuffs"
+	name = "gilded leg wraps"
 	desc = "Ankle coverings for digitigrade creatures. Gilded!"
 	icon = 'icons/vore/custom_clothes_vr.dmi'
 	icon_state = "gildedcuffs"
@@ -1029,13 +1029,13 @@
 	species_restricted = null
 
 /obj/item/clothing/shoes/black/cuffs/red
-	name = "Red Cuffs"
+	name = "red leg wraps"
 	desc = "Ankle coverings for digitigrade creatures. Red!"
 	icon_state = "redcuffs"
 	item_state = "redcuffs_mob"
 
 /obj/item/clothing/shoes/black/cuffs/blue
-	name = "Blue Cuffs"
+	name = "blue leg wraps"
 	desc = "Ankle coverings for digitigrade creatures. Blue!"
 	icon_state = "bluecuffs"
 	item_state = "bluecuffs_mob"


### PR DESCRIPTION
Mainly to fix the inconsistent capitalization, partially to make it consistent with the names in the loadout, partially because I think they're too long to be considered a cuff.

I'd also change the pathing so that the cuffs aren't a subtype of black shoes for no apparent reason, but I'd rather not accidentally break anything.

I'm also going to take this opportunity to say that I want an all-black/grey variant of these.