### PR TITLE
Make travis not compile Tether twice

### DIFF
--- a/maps/tether/tether.dm
+++ b/maps/tether/tether.dm
@@ -1,34 +1,36 @@
-#if !defined(USING_MAP_DATUM)
+#if !MAP_TEST //Exclude these from the 'minimap' compile tests. They get full testing after.
+	#if !defined(USING_MAP_DATUM)
 
-	#include "tether_defines.dm"
-	#include "tether_turfs.dm"
-	#include "tether_things.dm"
-	#include "tether_phoronlock.dm"
-	#include "tether_areas.dm"
-	#include "tether_areas2.dm"
-	#include "tether_shuttle_defs.dm"
-	#include "tether_shuttles.dm"
-	#include "tether_telecomms.dm"
-	#include "tether_virgo3b.dm"
+		#include "tether_defines.dm"
+		#include "tether_turfs.dm"
+		#include "tether_things.dm"
+		#include "tether_phoronlock.dm"
+		#include "tether_areas.dm"
+		#include "tether_areas2.dm"
+		#include "tether_shuttle_defs.dm"
+		#include "tether_shuttles.dm"
+		#include "tether_telecomms.dm"
+		#include "tether_virgo3b.dm"
 
-	#include "tether-01-surface.dmm"
-	#include "tether-02-transit.dmm"
-	#include "tether-03-station.dmm"
-	#include "tether-04-mining.dmm"
-	#include "tether-05-solars.dmm"
-	#include "tether-06-colony.dmm"
-	#include "tether-07-misc.dmm"
-	#include "tether-08-ships.dmm"
-	#include "tether-09-empty-surface.dmm"
-	#include "tether-10-empty-space.dmm"
-	//#include "tether-11-wild-surface.dmm"
-	//#include "tether-12-wild-crash-alt.dmm"
-	//#include "tether-13-wild-temple.dmm"
+		#include "tether-01-surface.dmm"
+		#include "tether-02-transit.dmm"
+		#include "tether-03-station.dmm"
+		#include "tether-04-mining.dmm"
+		#include "tether-05-solars.dmm"
+		#include "tether-06-colony.dmm"
+		#include "tether-07-misc.dmm"
+		#include "tether-08-ships.dmm"
+		#include "tether-09-empty-surface.dmm"
+		#include "tether-10-empty-space.dmm"
+		//#include "tether-11-wild-surface.dmm"
+		//#include "tether-12-wild-crash-alt.dmm"
+		//#include "tether-13-wild-temple.dmm"
 
-	#define USING_MAP_DATUM /datum/map/tether
+		#define USING_MAP_DATUM /datum/map/tether
 
-#elif !defined(MAP_OVERRIDE)
+	#elif !defined(MAP_OVERRIDE)
 
-	#warn A map has already been included, ignoring Tether
+		#warn A map has already been included, ignoring Tether
 
+	#endif
 #endif


### PR DESCRIPTION
What it says. Prevents tether from being compiled on the 'premaptest' time.