### PR TITLE
POLARIS: Hide higher planes from alt-turf menu

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -707,6 +707,8 @@
 							continue
 						if(is_type_in_list(A, shouldnt_see))
 							continue
+						if(A.plane > plane)
+							continue
 						stat(A)
 
 


### PR DESCRIPTION
Hides things from higher planes in the alt-examine menu. Too spooky! Fixes #2749