### PR TITLE
POLARIS: Fix GetFlatIcon so that cameras and id pictures don't show the HUD overlays.

### DIFF
--- a/code/_helpers/icons.dm
+++ b/code/_helpers/icons.dm
@@ -635,7 +635,7 @@ The _flatIcons list is a cache for generated icon files.
 */
 
 proc // Creates a single icon from a given /atom or /image.  Only the first argument is required.
-	getFlatIcon(image/A, defdir=2, deficon=null, defstate="", defblend=BLEND_DEFAULT, always_use_defdir = 0)
+	getFlatIcon(image/A, defdir=2, deficon=null, defstate="", defblend=BLEND_DEFAULT, always_use_defdir = 0, picture_planes = list(PLANE_WORLD))
 		// We start with a blank canvas, otherwise some icon procs crash silently
 		var/icon/flat = icon('icons/effects/effects.dmi', "icon_state"="nothing") // Final flattened icon
 		if(!A)
@@ -700,6 +700,10 @@ proc // Creates a single icon from a given /atom or /image.  Only the first argu
 			if(curIndex<=process.len)
 				current = process[curIndex]
 				if(current)
+					var/currentPlane = current:plane
+					if (currentPlane != FLOAT_PLANE && !(currentPlane in picture_planes))
+						curIndex++
+						continue;
 					currentLayer = current:layer
 					if(currentLayer<0) // Special case for FLY_LAYER
 						if(currentLayer <= -1000) return flat
@@ -760,7 +764,7 @@ proc // Creates a single icon from a given /atom or /image.  Only the first argu
 						// Pull the default direction.
 						add = icon(I:icon, I:icon_state)
 			else // 'I' is an appearance object.
-				add = getFlatIcon(new/image(I), curdir, curicon, curstate, curblend)
+				add = getFlatIcon(new/image(I), curdir, curicon, curstate, curblend, picture_planes = picture_planes)
 
 			// Find the new dimensions of the flat icon to fit the added overlay
 			addX1 = min(flatX1, I:pixel_x+1)

--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -191,7 +191,7 @@ var/global/photo_count = 0
 	for(var/i; i <= sorted.len; i++)
 		var/atom/A = sorted[i]
 		if(A)
-			var/icon/img = getFlatIcon(A)//build_composite_icon(A)
+			var/icon/img = getFlatIcon(A, picture_planes = picture_planes)//build_composite_icon(A)
 
 			// If what we got back is actually a picture, draw it.
 			if(istype(img, /icon))


### PR DESCRIPTION
We must filter all overlays to show only FLOAT_PLANE (the default) and ones specifically allowed.