### PR TITLE
Colorblindness Traits

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/negative.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/negative.dm
@@ -101,3 +101,32 @@
 	desc = "Your light weight and poor balance make you very susceptible to unhelpful bumping. Think of it like a bowling ball versus a pin."
 	cost = -4
 	var_changes = list("lightweight" = 1)
+
+/datum/trait/colorblind
+	name = "Colorblindness (Monochromancy)"
+	desc = "You simply can't see colors at all, period. You are 100% colorblind."
+	cost = -4
+
+/datum/trait/colorblind/apply(var/datum/species/S,var/mob/living/carbon/human/H)
+	..(S,H)
+	if(!H.plane_holder)
+		H.plane_holder = new
+	H.plane_holder.set_vis(VIS_D_COLORBLIND,TRUE) //The default is monocrhomia, no need to set values
+
+/datum/trait/colorblind/para_vulp
+	name = "Colorblindness (Para Vulp)"
+	desc = "You have a severe issue with green colors and have difficulty recognizing them from red colors."
+	cost = -3
+
+/datum/trait/colorblind/para_vulp/apply(var/datum/species/S,var/mob/living/carbon/human/H)
+	..(S,H)
+	H.plane_holder.alter_values(VIS_D_COLORBLIND,list("variety" = "Paradise Vulp"))
+
+/datum/trait/colorblind/para_taj
+	name = "Colorblindness (Para Taj)"
+	desc = "You have a minor issue with blue colors and have difficulty recognizing them from red colors."
+	cost = -2
+
+/datum/trait/colorblind/para_taj/apply(var/datum/species/S,var/mob/living/carbon/human/H)
+	..(S,H)
+	H.plane_holder.alter_values(VIS_D_COLORBLIND,list("variety" = "Paradise Taj"))

--- a/code/modules/mob/mob_planes.dm
+++ b/code/modules/mob/mob_planes.dm
@@ -63,6 +63,17 @@
 		for(var/SP in subplanes)
 			set_vis(which = SP, new_alpha = new_alpha)
 
+/datum/plane_holder/proc/alter_values(var/which = null, var/list/values = null)
+	ASSERT(which)
+	var/obj/screen/plane_master/PM = plane_masters[which]
+	if(!PM)
+		crash_with("Tried to alter [which] in plane_holder on [my_mob]!")
+	PM.alter_plane_values(arglist(values))
+	if(PM.sub_planes)
+		var/list/subplanes = PM.sub_planes
+		for(var/SP in subplanes)
+			alter_values(SP, values)
+
 ////////////////////
 // The Plane Master
 ////////////////////
@@ -102,6 +113,9 @@
 	if(new_alpha != alpha)
 		new_alpha = sanitize_integer(new_alpha, 0, 255, 255)
 		alpha = new_alpha
+
+/obj/screen/plane_master/proc/alter_plane_values()
+	return //Stub
 
 ////////////////////
 // Special masters
@@ -162,11 +176,11 @@
 		"Paradise Taj"		= MATRIX_Taj_Colorblind
 		)
 
-/obj/screen/plane_master/colorblindness/proc/set_variety(var/which = null)
-	var/new_type = varieties[which]
-	if(!new_type) return
+/obj/screen/plane_master/colorblindness/alter_plane_values(var/variety = null)
+	var/new_matrix = varieties[variety]
+	if(!new_matrix) return
 
-	color = new_type
+	color = new_matrix
 
 /obj/screen/plane_master/colorblindness/proc/debug_variety()
 	var/choice = input(usr,"Pick a type of colorblindness","Which?") as null|anything in varieties


### PR DESCRIPTION
Adds Monochromia, and the Vulpkanin and Tajaran colorblindness from Paradise. Can add other varieties if people want, I have all the RL varieties available in the backend.

For comparison
### Normal Vision
![2018-01-15_00-59-12](https://user-images.githubusercontent.com/15028025/34933449-d81df38e-f9a4-11e7-9892-4f6158b59a89.png)

### Monochromia (-4 pts)
![2018-01-15_01-00-16](https://user-images.githubusercontent.com/15028025/34933459-de911a2a-f9a4-11e7-832a-44b928c6afa4.png)

### Paradise Vulpkanin (-3 pts)
![2018-01-15_01-00-33](https://user-images.githubusercontent.com/15028025/34933461-e3bb6dfc-f9a4-11e7-831f-154659173a12.png)

### Paradise Tajaran (-2 pts)
![2018-01-15_01-01-03](https://user-images.githubusercontent.com/15028025/34933467-eb059f42-f9a4-11e7-9856-cb44e86ad5a7.png)
