### PR TITLE
Cleanup implementation of some traits

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1173,19 +1173,7 @@
 			vessel.remove_reagent("blood", vessel.total_volume - species.blood_volume)
 			vessel.maximum_volume = species.blood_volume
 		fixblood()
-		species.update_attack_types() //VOREStation Edit Start Required for any trait that updates unarmed_types in setup.
-		if(species.gets_food_nutrition != 1) //Bloodsucker trait. Tacking this on here.
-			verbs |= /mob/living/carbon/human/proc/bloodsuck
-		if(species.can_drain_prey)
-			verbs |= /mob/living/carbon/human/proc/succubus_drain //Succubus drain trait.
-			verbs |= /mob/living/carbon/human/proc/succubus_drain_finialize
-			verbs |= /mob/living/carbon/human/proc/succubus_drain_lethal
-		if(species.hard_vore_enabled) //Hardvore verb.
-			verbs |= /mob/living/carbon/human/proc/shred_limb
-		if(species.can_fly)
-			verbs |= /mob/living/proc/flying_toggle //Flying wings!
-			verbs |= /mob/living/proc/start_wings_hovering
-		//VOREStation Edit End
+		species.update_attack_types() //VOREStation Edit - Required for any trait that updates unarmed_types in setup.
 
 	// Rebuild the HUD. If they aren't logged in then login() should reinstantiate it for them.
 	if(client && client.screen)

--- a/code/modules/mob/living/carbon/human/species/station/blank_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/blank_vr.dm
@@ -1,11 +1,8 @@
 
 /datum/species
 	//var/vore_numbing = 0
-	var/gets_food_nutrition = 1 // If this is set to 0, the person can't get nutrrition from food.
-	var/can_drain_prey = 0 //Determines if the person can use the succubus drain or not.
-	var/hard_vore_enabled = 0 //Determines if the person has the hardvore verb or not.
+	var/gets_food_nutrition = 1 // If this is set to 0, the person can't get nutrition from food.
 	var/metabolism = 0.0015
-	var/can_fly = 0 //Determines if the species can fly if they have wings.
 	var/lightweight = 0 //Oof! Nonhelpful bump stumbles.
 	var/trashcan = 0 //It's always sunny in the wrestling ring.
 

--- a/code/modules/mob/living/carbon/human/species/station/prometheans_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/prometheans_vr.dm
@@ -18,7 +18,7 @@
 		/mob/living/carbon/human/proc/regenerate,
 		/mob/living/proc/set_size,
 		/mob/living/carbon/human/proc/succubus_drain,
-		/mob/living/carbon/human/proc/succubus_drain_finialize,
+		/mob/living/carbon/human/proc/succubus_drain_finalize,
 		/mob/living/carbon/human/proc/succubus_drain_lethal,
 		/mob/living/carbon/human/proc/slime_feed
 		)

--- a/code/modules/mob/living/carbon/human/species/station/station_special_abilities_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_special_abilities_vr.dm
@@ -672,7 +672,7 @@
 
 
 
-/mob/living/carbon/human/proc/succubus_drain_finialize()
+/mob/living/carbon/human/proc/succubus_drain_finalize()
 	set name = "Drain/Feed Finalization"
 	set desc = "Toggle to allow for draining to be prolonged. Turn this on to make it so prey will be knocked out/die while being drained, or you will feed yourself to the prey's selected stomach if you're feeding them. Can be toggled at any time."
 	set category = "Abilities"

--- a/code/modules/mob/living/carbon/human/species/station/station_special_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_special_vr.dm
@@ -14,7 +14,6 @@
 	slowdown = -0.2		//scuttly, but not as scuttly as a tajara or a teshari.
 	brute_mod = 0.8		//About as tanky to brute as a Unathi. They'll probably snap and go feral when hurt though.
 	burn_mod =  1.15	//As vulnerable to burn as a Tajara.
-	can_fly = 1 //They have wings by default.
 	var/base_species = "Xenochimera"
 
 	num_alternate_languages = 2
@@ -27,10 +26,12 @@
 		/mob/living/carbon/human/proc/sonar_ping,
 		/mob/living/carbon/human/proc/purge_impurities,
 		/mob/living/carbon/human/proc/succubus_drain,
-		/mob/living/carbon/human/proc/succubus_drain_finialize,
+		/mob/living/carbon/human/proc/succubus_drain_finalize,
 		/mob/living/carbon/human/proc/succubus_drain_lethal,
 		/mob/living/carbon/human/proc/bloodsuck,
-		/mob/living/carbon/human/proc/shred_limb) //Xenochimera get all the special verbs since they can't select traits.
+		/mob/living/carbon/human/proc/shred_limb,
+		/mob/living/proc/flying_toggle,
+		/mob/living/proc/start_wings_hovering) //Xenochimera get all the special verbs since they can't select traits.
 
 	min_age = 18
 	max_age = 80

--- a/code/modules/mob/living/carbon/human/species/station/station_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_vr.dm
@@ -120,8 +120,7 @@
 	secondary_langs = list(LANGUAGE_BIRDSONG)
 	name_language = LANGUAGE_BIRDSONG
 	color_mult = 1
-	can_fly = 1
-	inherent_verbs = list(/mob/living/carbon/human/proc/shred_limb)
+	inherent_verbs = list(/mob/living/carbon/human/proc/shred_limb,/mob/living/proc/flying_toggle,/mob/living/proc/start_wings_hovering)
 
 	min_age = 18
 	max_age = 80
@@ -376,7 +375,7 @@ datum/species/harpy
 	secondary_langs = list(LANGUAGE_BIRDSONG)
 	name_language = null
 	color_mult = 1
-	can_fly = 1
+	inherent_verbs = list(/mob/living/proc/flying_toggle,/mob/living/proc/start_wings_hovering)
 
 	min_age = 18
 	max_age = 80

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
@@ -18,13 +18,7 @@
 	cost = 0
 	var_changes = list("metabolic_rate" = 2, "hunger_factor" = 0.5, "metabolism" = 0.010) //Big boy level
 	excludes = list(/datum/trait/metabolism_up, /datum/trait/metabolism_down)
-/*
-/datum/trait/vore_numbing
-	name = "Prey Numbing"
-	desc = "Adds a 'Digest (Numbing)' belly mode, to douse prey in numbing enzymes during digestion."
-	cost = 0
-	var_changes = list("vore_numbing" = TRUE)
-*/
+
 /datum/trait/cold_discomfort
 	name = "Hot-Blooded"
 	desc = "You are too hot at the standard 20C. 18C is more suitable. Rolling down your jumpsuit or being unclothed helps."
@@ -71,17 +65,29 @@
 	cost = 0
 	var_changes = list("gets_food_nutrition" = 0) //The verb is given in human.dm
 
-/datum/trait/succubus_drain //Completely RP only trait.
+/datum/trait/bloodsucker/apply(var/datum/species/S,var/mob/living/carbon/human/H)
+	..(S,H)
+	H.verbs |= /mob/living/carbon/human/proc/bloodsuck
+
+/datum/trait/succubus_drain
 	name = "Succubus Drain"
 	desc = "Makes you able to gain nutrition from draining prey in your grasp."
 	cost = 0
-	var_changes = list("can_drain_prey" = 1) //The verb is given in human.dm
+
+/datum/trait/succubus_drain/apply(var/datum/species/S,var/mob/living/carbon/human/H)
+	..(S,H)
+	H.verbs |= /mob/living/carbon/human/proc/succubus_drain
+	H.verbs |= /mob/living/carbon/human/proc/succubus_drain_finalize
+	H.verbs |= /mob/living/carbon/human/proc/succubus_drain_lethal
 
 /datum/trait/hard_vore
 	name = "Brutal Predation"
 	desc = "Allows you to tear off limbs & tear out internal organs."
 	cost = 0 //I would make this cost a point, since it has some in game value, but there are easier, less damaging ways to perform the same functions.
-	var_changes = list("hard_vore_enabled" = 1) //The verb is given in human.dm
+
+/datum/trait/hard_vore/apply(var/datum/species/S,var/mob/living/carbon/human/H)
+	..(S,H)
+	H.verbs |= /mob/living/carbon/human/proc/shred_limb
 
 /datum/trait/trashcan
 	name = "Trash Can"

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/positive.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/positive.dm
@@ -124,7 +124,11 @@
 	name = "Winged Flight"
 	desc = "Allows you to fly by using your wings."
 	cost = 2 //Some in game value.
-	var_changes = list("can_fly" = 1)
+
+/datum/trait/winged_flight/apply(var/datum/species/S,var/mob/living/carbon/human/H)
+	..(S,H)
+	H.verbs |= /mob/living/proc/flying_toggle
+	H.verbs |= /mob/living/proc/start_wings_hovering
 
 /datum/trait/hardfeet
 	name = "Hard Feet"


### PR DESCRIPTION
Better implemented this way rather than with snowflake species vars (which are getting wiped on synths, so synths end up not being able to use these sometimes)