### PR TITLE
Speedup Travis and Upgrade Byond used by Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ sudo: false
 
 env:
   BYOND_MAJOR="512"
-  BYOND_MINOR="1392"
+  BYOND_MINOR="1403"
   MACRO_COUNT=4
 
 cache:

--- a/code/__defines/_compile_options.dm
+++ b/code/__defines/_compile_options.dm
@@ -6,3 +6,9 @@
 								1 to use the default behaviour (preload compiled in recourses, not player uploaded ones);
 								2 for preloading absolutely everything;
 								*/
+
+// If we are doing the map test build, do not include the main maps, only the submaps.
+#if MAP_TEST
+	#define USING_MAP_DATUM /datum/map
+	#define MAP_OVERRIDE 1
+#endif


### PR DESCRIPTION
The first round of compiling done in travis build is to test the submaps. It will complete faster if we do not include the main map during this round; the main map gets compiled and checked in the second round anyway.

Also upgrade the BYOND version Travis tests with to 512.1403, the same installed on production.