### PR TITLE
Colorblindness Tweaks

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/negative.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/negative.dm
@@ -105,18 +105,18 @@
 /datum/trait/colorblind
 	name = "Colorblindness (Monochromancy)"
 	desc = "You simply can't see colors at all, period. You are 100% colorblind."
-	cost = -4
+	cost = -3
 
 /datum/trait/colorblind/apply(var/datum/species/S,var/mob/living/carbon/human/H)
 	..(S,H)
 	if(!H.plane_holder)
-		H.plane_holder = new
+		H.plane_holder = new(src)
 	H.plane_holder.set_vis(VIS_D_COLORBLIND,TRUE) //The default is monocrhomia, no need to set values
 
 /datum/trait/colorblind/para_vulp
 	name = "Colorblindness (Para Vulp)"
 	desc = "You have a severe issue with green colors and have difficulty recognizing them from red colors."
-	cost = -3
+	cost = -2
 
 /datum/trait/colorblind/para_vulp/apply(var/datum/species/S,var/mob/living/carbon/human/H)
 	..(S,H)
@@ -125,7 +125,7 @@
 /datum/trait/colorblind/para_taj
 	name = "Colorblindness (Para Taj)"
 	desc = "You have a minor issue with blue colors and have difficulty recognizing them from red colors."
-	cost = -2
+	cost = -1
 
 /datum/trait/colorblind/para_taj/apply(var/datum/species/S,var/mob/living/carbon/human/H)
 	..(S,H)

--- a/code/modules/mob/mob_planes.dm
+++ b/code/modules/mob/mob_planes.dm
@@ -7,6 +7,7 @@
 	var/list/plane_masters[VIS_COUNT]
 
 /datum/plane_holder/New(mob/this_guy)
+	ASSERT(ismob(this_guy))
 	my_mob = this_guy
 
 	//It'd be nice to lazy init these but some of them are important to just EXIST. Like without ghost planemaster, you can see ghosts. Go figure.


### PR DESCRIPTION
Fix a bug that prevents colorblind people from seeing HUDs, reduce profit from traits, and add a sanity check.