### PR TITLE
Fixes a runtime and potential future runtime

### DIFF
--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -135,7 +135,7 @@
 
 	for(var/slot in slots)
 		var/obj/item/clothing/O = get_equipped_item(slot) //Change this type if you move the vision stuff to item or something.
-		if(O && O.enables_planes && (slot in O.plane_slots))
+		if(istype(O) && O.enables_planes && (slot in O.plane_slots))
 			compiled_vis |= O.enables_planes
 
 	//Check to see if we have a rig (ugh, blame rigs, desnowflake this)

--- a/code/modules/mob/mob_planes.dm
+++ b/code/modules/mob/mob_planes.dm
@@ -36,9 +36,7 @@
 	..()
 
 /datum/plane_holder/Destroy()
-	if(my_mob)
-		my_mob.plane_holder = null
-		my_mob = null
+	my_mob = null
 	plane_masters.Cut() //Goodbye my children, be free
 	return ..()
 


### PR DESCRIPTION
If we're being Destroyed, the mob probably is too. Their job to remove references to us though.

Doesn't cause any issues right now, but makes this code more standards-compliant.