### PR TITLE
Removes redundant hypospray

### DIFF
--- a/code/game/objects/items/weapons/storage/fancy.dm
+++ b/code/game/objects/items/weapons/storage/fancy.dm
@@ -279,7 +279,7 @@
 /obj/item/weapon/storage/fancy/vials/New()
 	..()
 	for(var/i=1 to 6)
-		new /obj/item/weapon/reagent_containers/glass/beaker/vial/vr(src) //VOREStation Edit - Better vials
+		new /obj/item/weapon/reagent_containers/glass/beaker/vial(src)
 	return
 
 /obj/item/weapon/storage/lockbox/vials

--- a/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
@@ -204,9 +204,8 @@
 		new /obj/item/device/radio/headset/heads/cmo(src)
 		new /obj/item/device/radio/headset/heads/cmo/alt(src)
 		new /obj/item/device/flash(src)
-		new /obj/item/weapon/reagent_containers/hypospray/vr(src) //VOREStation Edit - MKII Hypospray
-		new /obj/item/weapon/reagent_containers/glass/beaker/vial/vr(src) //VOREStation Edit - A vial for hypo
 		new /obj/item/weapon/reagent_containers/hypospray/vial(src)
+		new /obj/item/weapon/reagent_containers/glass/beaker/vial(src) //VOREStation Edit - An extra vial for the hypo
 		new /obj/item/clothing/suit/storage/hooded/wintercoat/medical(src)
 		new /obj/item/clothing/shoes/boots/winter/medical(src)
 		new /obj/item/weapon/storage/box/freezer(src)

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -19,6 +19,8 @@
 
 	var/label_text = ""
 
+	var/list/prefill = list()	//Reagents to fill the container with on New()
+
 	var/list/can_be_placed_into = list(
 		/obj/machinery/chem_master/,
 		/obj/machinery/chemical_dispenser,
@@ -47,6 +49,10 @@
 
 /obj/item/weapon/reagent_containers/glass/New()
 	..()
+	if(prefill.len)
+		for(var/R in prefill)
+			reagents.add_reagent(R,prefill[R])
+		update_icon()
 	base_name = name
 	base_desc = desc
 
@@ -225,15 +231,11 @@
 	possible_transfer_amounts = list(5,10,15,25)
 	flags = OPENCONTAINER
 
-/obj/item/weapon/reagent_containers/glass/beaker/cryoxadone/New()
-	..()
-	reagents.add_reagent("cryoxadone", 30)
-	update_icon()
+/obj/item/weapon/reagent_containers/glass/beaker/cryoxadone
+	prefill = list("cryoxadone" = 30)
 
-/obj/item/weapon/reagent_containers/glass/beaker/sulphuric/New()
-		..()
-		reagents.add_reagent("sacid", 60)
-		update_icon()
+/obj/item/weapon/reagent_containers/glass/beaker/sulphuric
+	prefill = list("sacid" = 60)
 
 /obj/item/weapon/reagent_containers/glass/bucket
 	desc = "It's a bucket."

--- a/code/modules/reagents/reagent_containers/glass/bottle.dm
+++ b/code/modules/reagents/reagent_containers/glass/bottle.dm
@@ -61,11 +61,7 @@
 	desc = "A small bottle. Contains inaprovaline - used to stabilize patients."
 	icon = 'icons/obj/chemical.dmi'
 	icon_state = "bottle-4"
-
-/obj/item/weapon/reagent_containers/glass/bottle/inaprovaline/New()
-	..()
-	reagents.add_reagent("inaprovaline", 60)
-	update_icon()
+	prefill = list("inaprovaline" = 60)
 
 
 /obj/item/weapon/reagent_containers/glass/bottle/toxin
@@ -73,11 +69,7 @@
 	desc = "A small bottle of toxins. Do not drink, it is poisonous."
 	icon = 'icons/obj/chemical.dmi'
 	icon_state = "bottle-3"
-
-/obj/item/weapon/reagent_containers/glass/bottle/toxin/New()
-	..()
-	reagents.add_reagent("toxin", 60)
-	update_icon()
+	prefill = list("toxin" = 60)
 
 
 /obj/item/weapon/reagent_containers/glass/bottle/cyanide
@@ -85,23 +77,15 @@
 	desc = "A small bottle of cyanide. Bitter almonds?"
 	icon = 'icons/obj/chemical.dmi'
 	icon_state = "bottle-3"
+	prefill = list("cyanide" = 30) //volume changed to match chloral
 
-
-/obj/item/weapon/reagent_containers/glass/bottle/cyanide/New()
-	..()
-	reagents.add_reagent("cyanide", 30) //volume changed to match chloral
-	update_icon()
 
 /obj/item/weapon/reagent_containers/glass/bottle/stoxin
 	name = "soporific bottle"
 	desc = "A small bottle of soporific. Just the fumes make you sleepy."
 	icon = 'icons/obj/chemical.dmi'
 	icon_state = "bottle-3"
-
-/obj/item/weapon/reagent_containers/glass/bottle/stoxin/New()
-	..()
-	reagents.add_reagent("stoxin", 60)
-	update_icon()
+	prefill = list("stoxin" = 60)
 
 
 /obj/item/weapon/reagent_containers/glass/bottle/chloralhydrate
@@ -109,11 +93,7 @@
 	desc = "A small bottle of Choral Hydrate. Mickey's Favorite!"
 	icon = 'icons/obj/chemical.dmi'
 	icon_state = "bottle-3"
-
-/obj/item/weapon/reagent_containers/glass/bottle/chloralhydrate/New()
-	..()
-	reagents.add_reagent("chloralhydrate", 30)		//Intentionally low since it is so strong. Still enough to knock someone out.
-	update_icon()
+	prefill = list("chloralhydrate" = 30) //Intentionally low since it is so strong. Still enough to knock someone out.
 
 
 /obj/item/weapon/reagent_containers/glass/bottle/antitoxin
@@ -121,11 +101,7 @@
 	desc = "A small bottle of dylovene. Counters poisons, and repairs damage. A wonder drug."
 	icon = 'icons/obj/chemical.dmi'
 	icon_state = "bottle-4"
-
-/obj/item/weapon/reagent_containers/glass/bottle/antitoxin/New()
-	..()
-	reagents.add_reagent("anti_toxin", 60)
-	update_icon()
+	prefill = list("anti_toxin" = 60)
 
 
 /obj/item/weapon/reagent_containers/glass/bottle/mutagen
@@ -133,11 +109,7 @@
 	desc = "A small bottle of unstable mutagen. Randomly changes the DNA structure of whoever comes in contact."
 	icon = 'icons/obj/chemical.dmi'
 	icon_state = "bottle-1"
-
-/obj/item/weapon/reagent_containers/glass/bottle/mutagen/New()
-	..()
-	reagents.add_reagent("mutagen", 60)
-	update_icon()
+	prefill = list("mutagen" = 60)
 
 
 /obj/item/weapon/reagent_containers/glass/bottle/ammonia
@@ -145,11 +117,7 @@
 	desc = "A small bottle."
 	icon = 'icons/obj/chemical.dmi'
 	icon_state = "bottle-1"
-
-/obj/item/weapon/reagent_containers/glass/bottle/ammonia/New()
-	..()
-	reagents.add_reagent("ammonia", 60)
-	update_icon()
+	prefill = list("ammonia" = 60)
 
 
 /obj/item/weapon/reagent_containers/glass/bottle/eznutrient
@@ -157,11 +125,7 @@
 	desc = "A small bottle."
 	icon = 'icons/obj/chemical.dmi'
 	icon_state = "bottle-4"
-
-/obj/item/weapon/reagent_containers/glass/bottle/eznutrient/New()
-	..()
-	reagents.add_reagent("eznutrient", 60)
-	update_icon()
+	prefill = list("eznutrient" = 60)
 
 
 /obj/item/weapon/reagent_containers/glass/bottle/left4zed
@@ -169,11 +133,7 @@
 	desc = "A small bottle."
 	icon = 'icons/obj/chemical.dmi'
 	icon_state = "bottle-4"
-
-/obj/item/weapon/reagent_containers/glass/bottle/left4zed/New()
-	..()
-	reagents.add_reagent("left4zed", 60)
-	update_icon()
+	prefill = list("left4zed" = 60)
 
 
 /obj/item/weapon/reagent_containers/glass/bottle/robustharvest
@@ -181,11 +141,7 @@
 	desc = "A small bottle."
 	icon = 'icons/obj/chemical.dmi'
 	icon_state = "bottle-4"
-
-/obj/item/weapon/reagent_containers/glass/bottle/robustharvest/New()
-	..()
-	reagents.add_reagent("robustharvest", 60)
-	update_icon()
+	prefill = list("robustharvest" = 60)
 
 
 /obj/item/weapon/reagent_containers/glass/bottle/diethylamine
@@ -193,23 +149,14 @@
 	desc = "A small bottle."
 	icon = 'icons/obj/chemical.dmi'
 	icon_state = "bottle-4"
-
-/obj/item/weapon/reagent_containers/glass/bottle/diethylamine/New()
-	..()
-	reagents.add_reagent("diethylamine", 60)
-	update_icon()
-
+	prefill = list("diethylamine" = 60)
 
 /obj/item/weapon/reagent_containers/glass/bottle/pacid
 	name = "Polytrinic Acid Bottle"
 	desc = "A small bottle. Contains a small amount of Polytrinic Acid"
 	icon = 'icons/obj/chemical.dmi'
 	icon_state = "bottle-4"
-
-/obj/item/weapon/reagent_containers/glass/bottle/pacid/New()
-	..()
-	reagents.add_reagent("pacid", 60)
-	update_icon()
+	prefill = list("pacid" = 60)
 
 
 /obj/item/weapon/reagent_containers/glass/bottle/adminordrazine
@@ -217,12 +164,7 @@
 	desc = "A small bottle. Contains the liquid essence of the gods."
 	icon = 'icons/obj/drinks.dmi'
 	icon_state = "holyflask"
-
-
-/obj/item/weapon/reagent_containers/glass/bottle/adminordrazine/New()
-	..()
-	reagents.add_reagent("adminordrazine", 60)
-	update_icon()
+	prefill = list("adminordrazine" = 60)
 
 
 /obj/item/weapon/reagent_containers/glass/bottle/capsaicin
@@ -230,11 +172,7 @@
 	desc = "A small bottle. Contains hot sauce."
 	icon = 'icons/obj/chemical.dmi'
 	icon_state = "bottle-4"
-
-/obj/item/weapon/reagent_containers/glass/bottle/capsaicin/New()
-	..()
-	reagents.add_reagent("capsaicin", 60)
-	update_icon()
+	prefill = list("capsaicin" = 60)
 
 
 /obj/item/weapon/reagent_containers/glass/bottle/frostoil
@@ -242,8 +180,4 @@
 	desc = "A small bottle. Contains cold sauce."
 	icon = 'icons/obj/chemical.dmi'
 	icon_state = "bottle-4"
-
-/obj/item/weapon/reagent_containers/glass/bottle/frostoil/New()
-	..()
-	reagents.add_reagent("frostoil", 60)
-	update_icon()
+	prefill = list("frostoil" = 60)

--- a/code/modules/reagents/reagent_containers/glass/bottle/robot.dm
+++ b/code/modules/reagents/reagent_containers/glass/bottle/robot.dm
@@ -13,11 +13,7 @@
 	icon = 'icons/obj/chemical.dmi'
 	icon_state = "bottle-4"
 	reagent = "inaprovaline"
-
-/obj/item/weapon/reagent_containers/glass/bottle/robot/inaprovaline/New()
-	..()
-	reagents.add_reagent("inaprovaline", 60)
-	update_icon()
+	prefill = list("inaprovaline" = 60)
 
 
 /obj/item/weapon/reagent_containers/glass/bottle/robot/antitoxin
@@ -26,9 +22,4 @@
 	icon = 'icons/obj/chemical.dmi'
 	icon_state = "bottle-4"
 	reagent = "anti_toxin"
-
-/obj/item/weapon/reagent_containers/glass/bottle/robot/antitoxin/New()
-	..()
-	reagents.add_reagent("anti_toxin", 60)
-	update_icon()
-
+	prefill = list("anti_toxin" = 60)

--- a/code/modules/reagents/reagent_containers/glass_vr.dm
+++ b/code/modules/reagents/reagent_containers/glass_vr.dm
@@ -1,63 +1,51 @@
 /obj/item/weapon/reagent_containers/glass/beaker/neurotoxin
-	New()
-		..()
-		reagents.add_reagent("neurotoxin",50)
-		update_icon()
+	prefill = list("neurotoxin" = 50)
 
-/obj/item/weapon/reagent_containers/glass/beaker/vial/vr
-	possible_transfer_amounts = list(5,10,15,30) //Dunno why there was no '30' option before.
-	w_class = ITEMSIZE_SMALL //Why would it be the same size as a beaker?
-	var/comes_with = list() //Easy way of doing this.
 
-/obj/item/weapon/reagent_containers/glass/beaker/vial/vr/New()
-	..()
-	for(var/R in comes_with)
-		reagents.add_reagent(R,comes_with[R])
-
-/obj/item/weapon/reagent_containers/glass/beaker/vial/vr/bicaridine
+/obj/item/weapon/reagent_containers/glass/beaker/vial/bicaridine
 	name = "vial (bicaridine)"
-	comes_with = list("bicaridine" = 30)
+	prefill = list("bicaridine" = 30)
 
-/obj/item/weapon/reagent_containers/glass/beaker/vial/vr/dylovene
+/obj/item/weapon/reagent_containers/glass/beaker/vial/dylovene
 	name = "vial (dylovene)"
-	comes_with = list("dylovene" = 30)
+	prefill = list("dylovene" = 30)
 
-/obj/item/weapon/reagent_containers/glass/beaker/vial/vr/dermaline
+/obj/item/weapon/reagent_containers/glass/beaker/vial/dermaline
 	name = "vial (dermaline)"
-	comes_with = list("dermaline" = 30)
+	prefill = list("dermaline" = 30)
 
-/obj/item/weapon/reagent_containers/glass/beaker/vial/vr/kelotane
+/obj/item/weapon/reagent_containers/glass/beaker/vial/kelotane
 	name = "vial (kelotane)"
-	comes_with = list("kelotane" = 30)
+	prefill = list("kelotane" = 30)
 
-/obj/item/weapon/reagent_containers/glass/beaker/vial/vr/inaprovaline
+/obj/item/weapon/reagent_containers/glass/beaker/vial/inaprovaline
 	name = "vial (inaprovaline)"
-	comes_with = list("inaprovaline" = 30)
+	prefill = list("inaprovaline" = 30)
 
-/obj/item/weapon/reagent_containers/glass/beaker/vial/vr/dexalin
+/obj/item/weapon/reagent_containers/glass/beaker/vial/dexalin
 	name = "vial (dexalin)"
-	comes_with = list("dexalin" = 30)
+	prefill = list("dexalin" = 30)
 
-/obj/item/weapon/reagent_containers/glass/beaker/vial/vr/dexalinplus
+/obj/item/weapon/reagent_containers/glass/beaker/vial/dexalinplus
 	name = "vial (dexalinp)"
-	comes_with = list("dexalinp" = 30)
+	prefill = list("dexalinp" = 30)
 
-/obj/item/weapon/reagent_containers/glass/beaker/vial/vr/tricordrazine
+/obj/item/weapon/reagent_containers/glass/beaker/vial/tricordrazine
 	name = "vial (tricordrazine)"
-	comes_with = list("tricordrazine" = 30)
+	prefill = list("tricordrazine" = 30)
 
-/obj/item/weapon/reagent_containers/glass/beaker/vial/vr/alkysine
+/obj/item/weapon/reagent_containers/glass/beaker/vial/alkysine
 	name = "vial (alkysine)"
-	comes_with = list("alkysine" = 30)
+	prefill = list("alkysine" = 30)
 
-/obj/item/weapon/reagent_containers/glass/beaker/vial/vr/imidazoline
+/obj/item/weapon/reagent_containers/glass/beaker/vial/imidazoline
 	name = "vial (imidazoline)"
-	comes_with = list("imidazoline" = 30)
+	prefill = list("imidazoline" = 30)
 
-/obj/item/weapon/reagent_containers/glass/beaker/vial/vr/peridaxon
+/obj/item/weapon/reagent_containers/glass/beaker/vial/peridaxon
 	name = "vial (peridaxon)"
-	comes_with = list("peridaxon" = 30)
+	prefill = list("peridaxon" = 30)
 
-/obj/item/weapon/reagent_containers/glass/beaker/vial/vr/hyronalin
+/obj/item/weapon/reagent_containers/glass/beaker/vial/hyronalin
 	name = "vial (hyronalin)"
-	comes_with = list("hyronalin" = 30)
+	prefill = list("hyronalin" = 30)

--- a/code/modules/reagents/reagent_containers/hypospray_vr.dm
+++ b/code/modules/reagents/reagent_containers/hypospray_vr.dm
@@ -1,54 +1,3 @@
-//A vial-loaded hypospray. Cartridge-based!
-/obj/item/weapon/reagent_containers/hypospray/vr
-	name = "hypospray mkII"
-	desc = "A new development from DeForest Medical, this new hypospray takes 30-unit vials as the drug supply for easy swapping."
-	var/obj/item/weapon/reagent_containers/glass/beaker/vial/loaded_vial //Wow, what a name.
-	volume = 0
-
-/obj/item/weapon/reagent_containers/hypospray/vr/New()
-	..()
-	loaded_vial = new /obj/item/weapon/reagent_containers/glass/beaker/vial/vr(src) //Comes with an empty vial
-	volume = loaded_vial.volume
-	reagents.maximum_volume = loaded_vial.reagents.maximum_volume
-
-/obj/item/weapon/reagent_containers/hypospray/vr/attack_hand(mob/user as mob)
-	if(user.get_inactive_hand() == src)
-		if(loaded_vial)
-			reagents.trans_to_holder(loaded_vial.reagents,volume)
-			reagents.maximum_volume = 0
-			loaded_vial.update_icon()
-			user.put_in_hands(loaded_vial)
-			loaded_vial = null
-			user << "<span class='notice'>You remove the vial from the [src].</span>"
-			update_icon()
-			playsound(src.loc, 'sound/weapons/flipblade.ogg', 50, 1)
-			return
-		..()
-	else
-		return ..()
-
-/obj/item/weapon/reagent_containers/hypospray/vr/attackby(obj/item/weapon/W, mob/user as mob)
-	if(istype(W, /obj/item/weapon/reagent_containers/glass/beaker/vial))
-		if(!loaded_vial)
-			user.visible_message("<span class='notice'>[user] begins loading [W] into \the [src].</span>","<span class='notice'>You start loading [W] into \the [src].</span>")
-			if(!do_after(user,30) || loaded_vial || !(W in user))
-				return 0
-			if(W.is_open_container())
-				W.flags ^= OPENCONTAINER
-				W.update_icon()
-			user.drop_item()
-			W.loc = src
-			loaded_vial = W
-			reagents.maximum_volume = loaded_vial.reagents.maximum_volume
-			loaded_vial.reagents.trans_to_holder(reagents,volume)
-			user.visible_message("<span class='notice'>[user] has loaded [W] into \the [src].</span>","<span class='notice'>You have loaded [W] into \the [src].</span>")
-			update_icon()
-			playsound(src.loc, 'sound/weapons/empty.ogg', 50, 1)
-		else
-			user << "<span class='notice'>\The [src] already has a vial.</span>"
-	else
-		..()
-
 /obj/item/weapon/reagent_containers/hypospray/autoinjector/beltminer
 	name = "Emergency trauma injector"
 	desc = "A rapid injector for emergency treatment of injuries. The warning label advises that it is not a substitute for proper medical treatment."
@@ -63,7 +12,6 @@
 	reagents.add_reagent("tricordrazine", 3)
 	reagents.add_reagent("tramadol", 2)
 	update_icon()
-	return
 
 /obj/item/weapon/storage/box/traumainjectors
 	name = "box of emergency trauma injectors"

--- a/code/modules/vore/fluffstuff/custom_items_vr.dm
+++ b/code/modules/vore/fluffstuff/custom_items_vr.dm
@@ -363,35 +363,35 @@
 	H.update_inv_glasses()
 
 //arokha:Aronai Kadigan - Fluff hypospray
-/obj/item/weapon/reagent_containers/hypospray/vr/fluff/aronai
+/obj/item/weapon/reagent_containers/hypospray/vial/fluff/aronai
 	name = "worn hypospray"
 	desc = "This hypospray seems a bit well-used. The blue band indicates it's from the CentCom medical division. There's an 'A' scratched into the bottom."
 	icon = 'icons/vore/custom_items_vr.dmi'
 	icon_state = "aro_hypo"
 
-/obj/item/weapon/reagent_containers/hypospray/vr/fluff/aronai/New()
+/obj/item/weapon/reagent_containers/hypospray/vial/fluff/aronai/New()
 	..()
 	loaded_vial.name = "[initial(loaded_vial.name)] (tricord)"
 	loaded_vial.desc = "30 Tricordrazine"
 	reagents.add_reagent("tricordrazine", 30)
 
 //arokha:Aronai Kadigan - Vials to go with mk2 hypo
-/obj/item/weapon/reagent_containers/glass/beaker/vial/vr/fluff/aro_st
+/obj/item/weapon/reagent_containers/glass/beaker/vial/fluff/aro_st
 	name = "vial (stabilize)"
 	desc = "10 Tricordrazine, 10 Dexalin Plus, 5 Tramadol, 5 Inaprovaline"
-	comes_with = list("tricordrazine"=10,"dexalinp"=10,"tramadol"=5,"inaprovaline"=5)
-/obj/item/weapon/reagent_containers/glass/beaker/vial/vr/fluff/aro_bt
+	prefill = list("tricordrazine"=10,"dexalinp"=10,"tramadol"=5,"inaprovaline"=5)
+/obj/item/weapon/reagent_containers/glass/beaker/vial/fluff/aro_bt
 	name = "vial (brute)"
 	desc = "25 Bicaridine, 5 Tricordrazine"
-	comes_with = list("bicaridine"=25,"tricordrazine"=5)
-/obj/item/weapon/reagent_containers/glass/beaker/vial/vr/fluff/aro_bu
+	prefill = list("bicaridine"=25,"tricordrazine"=5)
+/obj/item/weapon/reagent_containers/glass/beaker/vial/fluff/aro_bu
 	name = "vial (burn)"
 	desc = "10 Kelotane, 15 Dermaline, 5 Tricordrazine"
-	comes_with = list("kelotane"=10,"dermaline"=15,"tricordrazine"=5)
-/obj/item/weapon/reagent_containers/glass/beaker/vial/vr/fluff/aro_tx
+	prefill = list("kelotane"=10,"dermaline"=15,"tricordrazine"=5)
+/obj/item/weapon/reagent_containers/glass/beaker/vial/fluff/aro_tx
 	name = "vial (toxins)"
 	desc = "25 Dylovene, 2 Hyronalin, 3 Tricordrazine"
-	comes_with = list("anti_toxin"=25,"hyronalin"=2,"tricordrazine"=3)
+	prefill = list("anti_toxin"=25,"hyronalin"=2,"tricordrazine"=3)
 
 //Swat43:Fortune Bloise
 /obj/item/weapon/storage/backpack/satchel/fluff/swat43bag
@@ -659,7 +659,7 @@
 		return
 
 //WickedTempest: Chakat Tempest
-/obj/item/weapon/reagent_containers/hypospray/vr/tempest
+/obj/item/weapon/reagent_containers/hypospray/vial/tempest
 	name = "Tempest's Hypospray"
 	desc = "A custom-made MKII hypospray belonging to Chakat Tempest. There's small print engraved on the handle: A medicine-cat has no time for doubt. Act now, act swiftly."
 	icon = 'icons/vore/custom_items_vr.dmi'

--- a/code/modules/xenobio/items/extracts.dm
+++ b/code/modules/xenobio/items/extracts.dm
@@ -141,11 +141,7 @@
 	desc = "A small bottle. Contains some really weird liquid metal."
 	icon = 'icons/obj/chemical.dmi'
 	icon_state = "bottle-4"
-
-/obj/item/weapon/reagent_containers/glass/bottle/metamorphic/New()
-	..()
-	reagents.add_reagent("metamorphic", 60)
-	update_icon()
+	prefill = list("metamorphic" = 60)
 
 
 // This is kind of a waste since iron is in the chem dispenser but it would be inconsistent if this wasn't here.
@@ -216,11 +212,7 @@
 	desc = "A small bottle. Contains some really weird liquid metal."
 	icon = 'icons/obj/chemical.dmi'
 	icon_state = "bottle-4"
-
-/obj/item/weapon/reagent_containers/glass/bottle/binding/New()
-	..()
-	reagents.add_reagent("binding", 60)
-	update_icon()
+	prefill = list("binding" = 60)
 
 
 /datum/chemical_reaction/binding

--- a/config/custom_items.txt
+++ b/config/custom_items.txt
@@ -861,7 +861,7 @@ item_path: /obj/item/clothing/glasses/omnihud/med/fluff/wickedtemphud
 {
 ckey: wickedtemp
 character_name: Chakat Tempest
-item_path: /obj/item/weapon/reagent_containers/hypospray/vr/tempest
+item_path: /obj/item/weapon/reagent_containers/hypospray/vial/tempest
 }
 
 {


### PR DESCRIPTION
Removes hypospray/vr, which was previously ported to Polaris as hypospray/vial.
Removes the vial/vr subtype.
Includes some QOL stuff that's already been sent to Polaris.