### PR TITLE
Fixes prosthetic fabricator not printing our base colors on limbs.

### DIFF
--- a/code/modules/research/prosfab_designs.dm
+++ b/code/modules/research/prosfab_designs.dm
@@ -12,11 +12,18 @@
 		var/obj/machinery/pros_fabricator/prosfab = fabricator
 		var/obj/item/organ/O = new build_path(newloc)
 		//VOREStation Edit - Suggesting a species
+		var/newspecies = "Human"
 		if(prosfab.manufacturer)
 			var/datum/robolimb/manf = all_robolimbs[prosfab.manufacturer]
-			O.species = all_species["[manf.suggested_species]"]
-		else
-			O.species = all_species["Human"]
+			newspecies = manf.suggested_species
+		O.species = all_species[newspecies]
+		if(istype(O,/obj/item/organ/external))
+			var/obj/item/organ/external/EO = O
+			if(EO.species.base_color)
+				var/r_skin = hex2num(copytext(EO.species.base_color,2,4))
+				var/g_skin = hex2num(copytext(EO.species.base_color,4,6))
+				var/b_skin = hex2num(copytext(EO.species.base_color,6,8))
+				EO.s_col = list(r_skin, g_skin, b_skin)
 		//VOREStation Edit End
 		O.robotize(prosfab.manufacturer)
 		O.dna = new/datum/dna() //Uuughhhh... why do I have to do this?


### PR DESCRIPTION
-Lifelike torsos used to get our species base color applied because they were spawned as mobs with the base color being in the human set species proc.
-Made the prosfab look up and apply those base colors on mobless limbs as well.