### PR TITLE
Fixes a typo in an area name

### DIFF
--- a/maps/tether/tether_areas.dm
+++ b/maps/tether/tether_areas.dm
@@ -10,7 +10,7 @@
 	name = "Tether Debug Space"
 	requires_power = 0
 
-// Teather Areas itself
+// Tether Areas itself
 /area/tether/surfacebase/tether
 	icon = 'icons/turf/areas_vr.dmi'
 	icon_state = "tether1"

--- a/maps/tether/tether_areas2.dm
+++ b/maps/tether/tether_areas2.dm
@@ -245,7 +245,7 @@
 	name = "\improper Surface EVA Access"
 
 /area/tether/surfacebase/shuttle_pad
-	name = "\improper Teather Shuttle Pad"
+	name = "\improper Tether Shuttle Pad"
 /area/tether/surfacebase/reading_room
 	name = "\improper Reading Room"
 /area/tether/surfacebase/vacant_site


### PR DESCRIPTION
Noticed this when an atmos alarm went off and then became utterly unable
not to notice it.