### PR TITLE
Fix map unit tests to test more than Z1

### DIFF
--- a/code/unit_tests/map_tests.dm
+++ b/code/unit_tests/map_tests.dm
@@ -39,8 +39,10 @@
 	exempt_from_atmos += using_map.unit_test_exempt_from_atmos.Copy()
 	exempt_from_apc += using_map.unit_test_exempt_from_apc.Copy()
 
+	var/list/zs_to_test = using_map.unit_test_z_levels || list(1) //Either you set it, or you just get z1
+
 	for(var/area/A in world)
-		if(A.z == 1 && !(A.type in exempt_areas))
+		if((A.z in zs_to_test) && !(A.type in exempt_areas))
 			area_test_count++
 			var/area_good = 1
 			var/bad_msg = "--------------- [A.name]([A.type])"

--- a/maps/tether/tether_defines.dm
+++ b/maps/tether/tether_defines.dm
@@ -125,6 +125,14 @@
 		/area/tether/surfacebase/mining_main/airlock, //  Its an airlock,
 		/area/tether/surfacebase/emergency_storage/rnd,
 		/area/tether/surfacebase/emergency_storage/atrium)
+	unit_test_z_levels = list(
+		Z_LEVEL_SURFACE_LOW,
+		Z_LEVEL_SURFACE_MID,
+		Z_LEVEL_SURFACE_HIGH,
+		Z_LEVEL_SPACE_LOW,
+		Z_LEVEL_SPACE_MID,
+		Z_LEVEL_SPACE_HIGH)
+
 
 /datum/map/tether/perform_map_generation()
 

--- a/maps/~map_system/maps.dm
+++ b/maps/~map_system/maps.dm
@@ -93,6 +93,7 @@ var/list/all_maps = list()
 	var/list/unit_test_exempt_areas = list()
 	var/list/unit_test_exempt_from_atmos = list()
 	var/list/unit_test_exempt_from_apc = list()
+	var/list/unit_test_z_levels //To test more than Z1, set your z-levels to test here.
 
 /datum/map/New()
 	..()


### PR DESCRIPTION
This PR very likely to have Travis errors because it will discover all the map problems on Z2-7 that we didn't know about, because it's always only been running unit tests on Z1. Whups.