### PR TITLE
Fix vent shutdown in loaded templates

### DIFF
--- a/code/ATMOSPHERICS/components/unary/vent_pump.dm
+++ b/code/ATMOSPHERICS/components/unary/vent_pump.dm
@@ -106,8 +106,6 @@
 /obj/machinery/atmospherics/unary/vent_pump/update_icon(var/safety = 0)
 	if(!check_icon_cache())
 		return
-	if (!node)
-		use_power = 0
 
 	overlays.Cut()
 
@@ -122,10 +120,10 @@
 
 	if(welded)
 		vent_icon += "weld"
-	else if(!powered())
+	else if(!use_power || !node || (stat & (NOPOWER|BROKEN)))
 		vent_icon += "off"
 	else
-		vent_icon += "[use_power ? "[pump_direction ? "out" : "in"]" : "off"]"
+		vent_icon += "[pump_direction ? "out" : "in"]"
 
 	overlays += icon_manager.get_atmos_icon("device", , , vent_icon)
 

--- a/code/controllers/master_controller.dm
+++ b/code/controllers/master_controller.dm
@@ -60,6 +60,7 @@ datum/controller/game_controller/proc/setup_objects()
 	//Set up spawn points.
 	populate_spawn_points()
 
+	to_world_log("Initializing Floor Decals") // VOREStation Edit
 	admin_notice("<span class='danger'>Initializing Floor Decals</span>", R_DEBUG)
 	var/list/turfs_with_decals = list()
 	for(var/obj/effect/floor_decal/D in world)
@@ -73,6 +74,7 @@ datum/controller/game_controller/proc/setup_objects()
 	floor_decals_initialized = TRUE
 	sleep(1)
 
+	to_world_log("Initializing objects") // VOREStation Edit
 	admin_notice("<span class='danger'>Initializing objects</span>", R_DEBUG)
 	for(var/atom/movable/object in world)
 		if(!QDELETED(object))
@@ -80,22 +82,26 @@ datum/controller/game_controller/proc/setup_objects()
 			CHECK_SLEEP_MASTER
 	sleep(1)
 
+	to_world_log("Initializing areas") // VOREStation Edit
 	admin_notice("<span class='danger'>Initializing areas</span>", R_DEBUG)
 	for(var/area/area in all_areas)
 		area.initialize()
 		CHECK_SLEEP_MASTER
 	sleep(1)
 
+	to_world_log("Initializing atmos machinery connections.") // VOREStation Edit
 	admin_notice("<span class='danger'>Initializing atmos machinery connections.</span>", R_DEBUG)
 	for(var/obj/machinery/atmospherics/machine in machines)
 		machine.atmos_init()
 		CHECK_SLEEP_MASTER
 
+	to_world_log("Initializing pipe networks") // VOREStation Edit
 	admin_notice("<span class='danger'>Initializing pipe networks</span>", R_DEBUG)
 	for(var/obj/machinery/atmospherics/machine in machines)
 		machine.build_network()
 		CHECK_SLEEP_MASTER
 
+	to_world_log("Initializing atmos machinery.") // VOREStation Edit
 	admin_notice("<span class='danger'>Initializing atmos machinery.</span>", R_DEBUG)
 	for(var/obj/machinery/atmospherics/unary/U in machines)
 		if(istype(U, /obj/machinery/atmospherics/unary/vent_pump))
@@ -106,6 +112,7 @@ datum/controller/game_controller/proc/setup_objects()
 			T.broadcast_status()
 		CHECK_SLEEP_MASTER
 
+	to_world_log("Initializing turbolifts") // VOREStation Edit
 	admin_notice("<span class='danger'>Initializing turbolifts</span>", R_DEBUG)
 	for(var/thing in turbolifts)
 		var/obj/turbolift_map_holder/lift = thing


### PR DESCRIPTION
Fixes #2820 
The specific situation happens when power_change() is called before atmos_init is called for the first time(), which is happening because the APC in the engine room is being deleted (during the step where it clears out existing atoms to make room for the new template)
To fix well... `update_icons` has no business modifying variables like `use_power`.  Just update the icon!
Also adds some useful world.log messages we've been wanting.