### PR TITLE
Some borg sleeper tweaks

### DIFF
--- a/code/modules/mob/living/silicon/robot/dogborg/dog_sleeper_vr.dm
+++ b/code/modules/mob/living/silicon/robot/dogborg/dog_sleeper_vr.dm
@@ -44,9 +44,6 @@
 	if(length(contents) > (max_item_count - 1))
 		to_chat(user, "<span class='warning'>Your [src.name] is full. Eject or process contents to continue.</span>")
 		return
-	if(target.buckled)
-		to_chat(user, "<span class='warning'>The user is buckled and can not be put into your [src.name].</span>")
-		return
 	
 	if(analyzer == TRUE)
 		if(istype(target, /obj/item))
@@ -138,28 +135,31 @@
 					sleeperUI(usr)
 			return
 		return
-	if(!ishuman(target))
-		return
-	if(patient)
-		to_chat(user, "<span class='warning'>Your [src.name] is already occupied.</span>")
-		return
-	user.visible_message("<span class='warning'>[hound.name] is ingesting [target.name] into their [src.name].</span>", "<span class='notice'>You start ingesting [target] into your [src]...</span>")
-	if(!patient && ishuman(target) && !target.buckled && do_after (user, 50, target))
+	else if(ishuman(target))
+		var/mob/living/carbon/human/H = target
+		if(H.buckled)
+			to_chat(user, "<span class='warning'>The user is buckled and can not be put into your [src.name].</span>")
+			return
+		if(patient)
+			to_chat(user, "<span class='warning'>Your [src.name] is already occupied.</span>")
+			return
+		user.visible_message("<span class='warning'>[hound.name] is ingesting [H.name] into their [src.name].</span>", "<span class='notice'>You start ingesting [H] into your [src]...</span>")
+		if(!patient && !H.buckled && do_after (user, 50, H))
 
-		if(!proximity) return //If they moved away, you can't eat them.
+			if(!proximity) return //If they moved away, you can't eat them.
 
-		if(patient) return //If you try to eat two people at once, you can only eat one.
+			if(patient) return //If you try to eat two people at once, you can only eat one.
 
-		else //If you don't have someone in you, proceed.
-			target.forceMove(src)
-			target.reset_view(src)
-			update_patient()
-			processing_objects.Add(src)
-			user.visible_message("<span class='warning'>[hound.name]'s medical pod lights up as [target.name] slips inside into their [src.name].</span>", "<span class='notice'>Your medical pod lights up as [target] slips into your [src]. Life support functions engaged.</span>")
-			message_admins("[key_name(hound)] has eaten [key_name(patient)] as a dogborg. ([hound ? "<a href='?_src_=holder;adminplayerobservecoodjump=1;X=[hound.x];Y=[hound.y];Z=[hound.z]'>JMP</a>" : "null"])")
-			playsound(hound, 'sound/vore/gulp.ogg', 100, 1) //POLARISTODO
-			if(UI_open == TRUE)
-				sleeperUI(usr)
+			else //If you don't have someone in you, proceed.
+				H.forceMove(src)
+				H.reset_view(src)
+				update_patient()
+				processing_objects.Add(src)
+				user.visible_message("<span class='warning'>[hound.name]'s medical pod lights up as [H.name] slips inside into their [src.name].</span>", "<span class='notice'>Your medical pod lights up as [H] slips into your [src]. Life support functions engaged.</span>")
+				message_admins("[key_name(hound)] has eaten [key_name(patient)] as a dogborg. ([hound ? "<a href='?_src_=holder;adminplayerobservecoodjump=1;X=[hound.x];Y=[hound.y];Z=[hound.z]'>JMP</a>" : "null"])")
+				playsound(hound, 'sound/vore/gulp.ogg', 100, 1) //POLARISTODO
+				if(UI_open == TRUE)
+					sleeperUI(usr)
 
 /obj/item/device/dogborg/sleeper/proc/go_out(var/target)
 	hound = src.loc

--- a/code/modules/mob/living/silicon/robot/dogborg/dog_sleeper_vr.dm
+++ b/code/modules/mob/living/silicon/robot/dogborg/dog_sleeper_vr.dm
@@ -30,15 +30,114 @@
 /obj/item/device/dogborg/sleeper/Exit(atom/movable/O)
 	return 0
 
-/obj/item/device/dogborg/sleeper/afterattack(mob/living/carbon/target, mob/living/silicon/user, proximity)
+/obj/item/device/dogborg/sleeper/afterattack(var/atom/movable/target, mob/living/silicon/user, proximity)
 	hound = loc
+	if(!istype(target))
+		return
 	if(!proximity)
 		return
-	if(!ishuman(target))
+	if(target.anchored)
+		return
+	if(target in hound.module.modules)
+		return
+	if(length(contents) > (max_item_count - 1))
+		to_chat(user, "<span class='warning'>Your [src.name] is full. Eject or process contents to continue.</span>")
 		return
 	if(target.buckled)
 		to_chat(user, "<span class='warning'>The user is buckled and can not be put into your [src.name].</span>")
 		return
+	
+	if(analyzer == TRUE)
+		if(istype(target, /obj/item))
+			var/obj/target_obj = target
+			if(target_obj.w_class > ITEMSIZE_LARGE)
+				to_chat(user, "<span class='warning'>\The [target] is too large to fit into your [src.name]</span>")
+				return
+			user.visible_message("<span class='warning'>[hound.name] is ingesting [target.name] into their [src.name].</span>", "<span class='notice'>You start ingesting [target] into your [src.name]...</span>")
+			if(do_after(user, 30, target) && length(contents) < max_item_count)
+				target.forceMove(src)
+				user.visible_message("<span class='warning'>[hound.name]'s internal analyzer groans lightly as [target.name] slips inside.</span>", "<span class='notice'>Your internal analyzer groans lightly as [target] slips inside.</span>")
+				playsound(hound, 'sound/vore/gulp.ogg', 30, 1)
+				if(istype(target,/obj/item))
+					var/obj/item/tech_item = target
+					for(var/T in tech_item.origin_tech)
+						to_chat(user, "<span class='notice'>\The [tech_item] has level [tech_item.origin_tech[T]] in [CallTechName(T)].</span>")
+				update_patient()
+				if(UI_open == TRUE)
+					sleeperUI(usr)
+			return
+
+		else if(ishuman(target))
+			var/mob/living/carbon/human/trashman = target
+			if(patient)
+				to_chat(user, "<span class='warning'>Your [src.name] is already occupied.</span>")
+				return
+			if(trashman.buckled)
+				to_chat(user, "<span class='warning'>[trashman] is buckled and can not be put into your [src.name].</span>")
+				return
+			user.visible_message("<span class='warning'>[hound.name] is ingesting [trashman] into their [src.name].</span>", "<span class='notice'>You start ingesting [trashman] into your [src.name]...</span>")
+			if(do_after(user, 30, trashman) && !patient && !trashman.buckled && length(contents) < max_item_count)
+				trashman.forceMove(src)
+				trashman.reset_view(src)
+				processing_objects.Add(src)
+				user.visible_message("<span class='warning'>[hound.name]'s internal analyzer groans lightly as [trashman] slips inside.</span>", "<span class='notice'>Your internal analyzer groans lightly as [trashman] slips inside.</span>")
+				playsound(hound, 'sound/vore/gulp.ogg', 80, 1)
+				update_patient()
+				if(UI_open == TRUE)
+					sleeperUI(usr)
+			return
+		return
+	
+	if(compactor == TRUE)
+		if(istype(target, /obj/item) || istype(target, /obj/effect/decal/remains))
+			var/obj/target_obj = target
+			if(target_obj.w_class > ITEMSIZE_LARGE)
+				to_chat(user, "<span class='warning'>\The [target] is too large to fit into your [src.name]</span>")
+				return
+			user.visible_message("<span class='warning'>[hound.name] is ingesting [target.name] into their [src.name].</span>", "<span class='notice'>You start ingesting [target] into your [src.name]...</span>")
+			if(do_after(user, 30, target) && length(contents) < max_item_count)
+				target.forceMove(src)
+				user.visible_message("<span class='warning'>[hound.name]'s garbage processor groans lightly as [target.name] slips inside.</span>", "<span class='notice'>Your garbage compactor groans lightly as [target] slips inside.</span>")
+				playsound(hound, 'sound/vore/gulp.ogg', 30, 1)
+				update_patient()
+				if(UI_open == TRUE)
+					sleeperUI(usr)
+			return
+
+		if(istype(target, /mob/living/simple_animal/mouse)) //Edible mice, dead or alive whatever. Mostly for carcass picking you cruel bastard :v
+			var/mob/living/simple_animal/trashmouse = target
+			user.visible_message("<span class='warning'>[hound.name] is ingesting [trashmouse] into their [src.name].</span>", "<span class='notice'>You start ingesting [trashmouse] into your [src.name]...</span>")
+			if(do_after(user, 30, trashmouse) && length(contents) < max_item_count)
+				trashmouse.forceMove(src)
+				trashmouse.reset_view(src)
+				user.visible_message("<span class='warning'>[hound.name]'s garbage processor groans lightly as [trashmouse] slips inside.</span>", "<span class='notice'>Your garbage compactor groans lightly as [trashmouse] slips inside.</span>")
+				playsound(hound, 'sound/vore/gulp.ogg', 30, 1)
+				update_patient()
+				if(UI_open == TRUE)
+					sleeperUI(usr)
+			return
+
+		else if(ishuman(target))
+			var/mob/living/carbon/human/trashman = target
+			if(patient)
+				to_chat(user, "<span class='warning'>Your [src.name] is already occupied.</span>")
+				return
+			if(trashman.buckled)
+				to_chat(user, "<span class='warning'>[trashman] is buckled and can not be put into your [src.name].</span>")
+				return
+			user.visible_message("<span class='warning'>[hound.name] is ingesting [trashman] into their [src.name].</span>", "<span class='notice'>You start ingesting [trashman] into your [src.name]...</span>")
+			if(do_after(user, 30, trashman) && !patient && !trashman.buckled && length(contents) < max_item_count)
+				trashman.forceMove(src)
+				trashman.reset_view(src)
+				processing_objects.Add(src)
+				user.visible_message("<span class='warning'>[hound.name]'s garbage processor groans lightly as [trashman] slips inside.</span>", "<span class='notice'>Your garbage compactor groans lightly as [trashman] slips inside.</span>")
+				playsound(hound, 'sound/vore/gulp.ogg', 80, 1)
+				update_patient()
+				if(UI_open == TRUE)
+					sleeperUI(usr)
+			return
+		return
+	
 	if(patient)
 		to_chat(user, "<span class='warning'>Your [src.name] is already occupied.</span>")
 		return
@@ -518,108 +617,3 @@
 	max_item_count = 1
 	startdrain = 100
 	analyzer = TRUE
-
-/obj/item/device/dogborg/sleeper/compactor/afterattack(var/atom/movable/target, mob/living/silicon/user, proximity)//GARBO NOMS
-	hound = loc
-
-	if(!istype(target))
-		return
-	if(!proximity)
-		return
-	if(target.anchored)
-		return
-	if(target in hound.module.modules)
-		return
-	if(length(contents) > (max_item_count - 1))
-		to_chat(user, "<span class='warning'>Your [src.name] is full. Eject or process contents to continue.</span>")
-		return
-
-	if(analyzer == TRUE)
-		if(istype(target, /obj/item))
-			var/obj/target_obj = target
-			if(target_obj.w_class > ITEMSIZE_LARGE)
-				to_chat(user, "<span class='warning'>\The [target] is too large to fit into your [src.name]</span>")
-				return
-			user.visible_message("<span class='warning'>[hound.name] is ingesting [target.name] into their [src.name].</span>", "<span class='notice'>You start ingesting [target] into your [src.name]...</span>")
-			if(do_after(user, 30, target) && length(contents) < max_item_count)
-				target.forceMove(src)
-				user.visible_message("<span class='warning'>[hound.name]'s internal analyzer groans lightly as [target.name] slips inside.</span>", "<span class='notice'>Your internal analyzer groans lightly as [target] slips inside.</span>")
-				playsound(hound, 'sound/vore/gulp.ogg', 30, 1)
-				if(istype(target,/obj/item))
-					var/obj/item/tech_item = target
-					for(var/T in tech_item.origin_tech)
-						to_chat(user, "<span class='notice'>\The [tech_item] has level [tech_item.origin_tech[T]] in [CallTechName(T)].</span>")
-				update_patient()
-				if(UI_open == TRUE)
-					sleeperUI(usr)
-			return
-
-		else if(ishuman(target))
-			var/mob/living/carbon/human/trashman = target
-			if(patient)
-				to_chat(user, "<span class='warning'>Your [src.name] is already occupied.</span>")
-				return
-			if(trashman.buckled)
-				to_chat(user, "<span class='warning'>[trashman] is buckled and can not be put into your [src.name].</span>")
-				return
-			user.visible_message("<span class='warning'>[hound.name] is ingesting [trashman] into their [src.name].</span>", "<span class='notice'>You start ingesting [trashman] into your [src.name]...</span>")
-			if(do_after(user, 30, trashman) && !patient && !trashman.buckled && length(contents) < max_item_count)
-				trashman.forceMove(src)
-				trashman.reset_view(src)
-				processing_objects.Add(src)
-				user.visible_message("<span class='warning'>[hound.name]'s internal analyzer groans lightly as [trashman] slips inside.</span>", "<span class='notice'>Your internal analyzer groans lightly as [trashman] slips inside.</span>")
-				playsound(hound, 'sound/vore/gulp.ogg', 80, 1)
-				update_patient()
-				if(UI_open == TRUE)
-					sleeperUI(usr)
-			return
-		return
-
-	if(istype(target, /obj/item) || istype(target, /obj/effect/decal/remains))
-		var/obj/target_obj = target
-		if(target_obj.w_class > ITEMSIZE_LARGE)
-			to_chat(user, "<span class='warning'>\The [target] is too large to fit into your [src.name]</span>")
-			return
-		user.visible_message("<span class='warning'>[hound.name] is ingesting [target.name] into their [src.name].</span>", "<span class='notice'>You start ingesting [target] into your [src.name]...</span>")
-		if(do_after(user, 30, target) && length(contents) < max_item_count)
-			target.forceMove(src)
-			user.visible_message("<span class='warning'>[hound.name]'s garbage processor groans lightly as [target.name] slips inside.</span>", "<span class='notice'>Your garbage compactor groans lightly as [target] slips inside.</span>")
-			playsound(hound, 'sound/vore/gulp.ogg', 30, 1)
-			update_patient()
-			if(UI_open == TRUE)
-				sleeperUI(usr)
-		return
-
-	if(istype(target, /mob/living/simple_animal/mouse)) //Edible mice, dead or alive whatever. Mostly for carcass picking you cruel bastard :v
-		var/mob/living/simple_animal/trashmouse = target
-		user.visible_message("<span class='warning'>[hound.name] is ingesting [trashmouse] into their [src.name].</span>", "<span class='notice'>You start ingesting [trashmouse] into your [src.name]...</span>")
-		if(do_after(user, 30, trashmouse) && length(contents) < max_item_count)
-			trashmouse.forceMove(src)
-			trashmouse.reset_view(src)
-			user.visible_message("<span class='warning'>[hound.name]'s garbage processor groans lightly as [trashmouse] slips inside.</span>", "<span class='notice'>Your garbage compactor groans lightly as [trashmouse] slips inside.</span>")
-			playsound(hound, 'sound/vore/gulp.ogg', 30, 1)
-			update_patient()
-			if(UI_open == TRUE)
-				sleeperUI(usr)
-		return
-
-	else if(ishuman(target))
-		var/mob/living/carbon/human/trashman = target
-		if(patient)
-			to_chat(user, "<span class='warning'>Your [src.name] is already occupied.</span>")
-			return
-		if(trashman.buckled)
-			to_chat(user, "<span class='warning'>[trashman] is buckled and can not be put into your [src.name].</span>")
-			return
-		user.visible_message("<span class='warning'>[hound.name] is ingesting [trashman] into their [src.name].</span>", "<span class='notice'>You start ingesting [trashman] into your [src.name]...</span>")
-		if(do_after(user, 30, trashman) && !patient && !trashman.buckled && length(contents) < max_item_count)
-			trashman.forceMove(src)
-			trashman.reset_view(src)
-			processing_objects.Add(src)
-			user.visible_message("<span class='warning'>[hound.name]'s garbage processor groans lightly as [trashman] slips inside.</span>", "<span class='notice'>Your garbage compactor groans lightly as [trashman] slips inside.</span>")
-			playsound(hound, 'sound/vore/gulp.ogg', 80, 1)
-			update_patient()
-			if(UI_open == TRUE)
-				sleeperUI(usr)
-		return
-	return

--- a/code/modules/mob/living/silicon/robot/dogborg/dog_sleeper_vr.dm
+++ b/code/modules/mob/living/silicon/robot/dogborg/dog_sleeper_vr.dm
@@ -16,6 +16,8 @@
 	var/eject_port = "ingestion"
 	var/list/items_preserved = list()
 	var/UI_open = FALSE
+	var/compactor = FALSE
+	var/analyzer = FALSE
 	var/datum/research/techonly/files //Analyzerbelly var.
 	var/synced = FALSE
 	var/startdrain = 500
@@ -125,12 +127,12 @@
 
 	dat += "<div class='statusDisplay'>"
 
-	if(istype(/obj/item/device/dogborg/sleeper/compactor) && length(contents))//garbage counter for trashpup
+	if(compactor == TRUE && length(contents))//garbage counter for trashpup
 		var/obj/item/device/dogborg/sleeper/compactor/garbo = src
 		dat += "<font color='red'><B>Current load:</B> [length(contents)] / [garbo.max_item_count] objects.</font><BR>"
 		dat += "<font color='gray'>([list2text(contents,", ")])</font><BR><BR>"
 
-	if(istype(/obj/item/device/dogborg/sleeper/compactor/analyzer) && synced == FALSE)
+	if(analyzer == TRUE && synced == FALSE)
 		dat += "<A href='?src=\ref[src];sync=1'>Sync Files</A><BR>"
 
 	//Cleaning and there are still un-preserved items
@@ -331,7 +333,7 @@
 		hound.sleeper_g = FALSE
 
 	//Letting analyzer gut swell if overloaded.
-	if(istype(/obj/item/device/dogborg/sleeper/compactor/analyzer) && (length(contents) > 1))
+	if(analyzer == TRUE && (length(contents) > 1))
 		hound.sleeper_r = TRUE
 		hound.sleeper_g = FALSE
 
@@ -452,7 +454,7 @@
 		else
 			var/obj/item/T = target
 			if(istype(T))
-				if(istype(/obj/item/device/dogborg/sleeper/compactor/analyzer))
+				if(analyzer == TRUE)
 					var/obj/item/tech_item = T
 					for(var/tech in tech_item.origin_tech)
 						files.UpdateTech(tech, tech_item.origin_tech[tech])
@@ -506,6 +508,7 @@
 	desc = "A mounted garbage compactor unit with fuel processor."
 	icon_state = "compactor"
 	injection_chems = null //So they don't have all the same chems as the medihound!
+	compactor = TRUE
 	var/max_item_count = 25
 
 /obj/item/device/dogborg/sleeper/compactor/analyzer //sci-borg gut.
@@ -514,6 +517,7 @@
 	icon_state = "analyzer"
 	max_item_count = 1
 	startdrain = 100
+	analyzer = TRUE
 
 /obj/item/device/dogborg/sleeper/compactor/afterattack(var/atom/movable/target, mob/living/silicon/user, proximity)//GARBO NOMS
 	hound = loc
@@ -530,7 +534,7 @@
 		to_chat(user, "<span class='warning'>Your [src.name] is full. Eject or process contents to continue.</span>")
 		return
 
-	if(istype(/obj/item/device/dogborg/sleeper/compactor/analyzer))
+	if(analyzer == TRUE)
 		if(istype(target, /obj/item))
 			var/obj/target_obj = target
 			if(target_obj.w_class > ITEMSIZE_LARGE)

--- a/code/modules/mob/living/silicon/robot/dogborg/dog_sleeper_vr.dm
+++ b/code/modules/mob/living/silicon/robot/dogborg/dog_sleeper_vr.dm
@@ -125,12 +125,12 @@
 
 	dat += "<div class='statusDisplay'>"
 
-	if(istype(src, /obj/item/device/dogborg/sleeper/compactor) && length(contents))//garbage counter for trashpup
+	if(istype(/obj/item/device/dogborg/sleeper/compactor) && length(contents))//garbage counter for trashpup
 		var/obj/item/device/dogborg/sleeper/compactor/garbo = src
 		dat += "<font color='red'><B>Current load:</B> [length(contents)] / [garbo.max_item_count] objects.</font><BR>"
 		dat += "<font color='gray'>([list2text(contents,", ")])</font><BR><BR>"
 
-	if(istype(src, /obj/item/device/dogborg/sleeper/compactor/analyzer) && synced == FALSE)
+	if(istype(/obj/item/device/dogborg/sleeper/compactor/analyzer) && synced == FALSE)
 		dat += "<A href='?src=\ref[src];sync=1'>Sync Files</A><BR>"
 
 	//Cleaning and there are still un-preserved items
@@ -202,7 +202,7 @@
 		go_out()
 		sleeperUI(usr)
 		return
-	if( href_list["close"] )
+	if(href_list["close"])
 		UI_open = FALSE
 		return
 	if(href_list["clean"])
@@ -259,7 +259,7 @@
 	else
 		to_chat(usr, "<span class='notice'>ERROR: Subject cannot metabolise chemicals.</span>")
 
-	src.updateUsrDialog()
+	updateUsrDialog()
 	sleeperUI(usr) //Needs a callback to boop the page to refresh.
 	return
 
@@ -284,7 +284,11 @@
 	//Well, we HAD one, what happened to them?
 	if(patient in contents)
 		if(patient_laststat != patient.stat)
-			if((patient.stat & DEAD) || cleaning)
+			if(cleaning)
+				hound.sleeper_r = TRUE
+				hound.sleeper_g = FALSE
+				patient_laststat = patient.stat
+			else if(patient.stat & DEAD)
 				hound.sleeper_r = TRUE
 				hound.sleeper_g = FALSE
 				patient_laststat = patient.stat
@@ -303,7 +307,11 @@
 	else
 		for(var/mob/living/carbon/human/C in contents)
 			patient = C
-			if((patient.stat & DEAD) || cleaning)
+			if(cleaning)
+				hound.sleeper_r = TRUE
+				hound.sleeper_g = FALSE
+				patient_laststat = patient.stat
+			else if(patient.stat & DEAD)
 				hound.sleeper_r = TRUE
 				hound.sleeper_g = FALSE
 				patient_laststat = patient.stat
@@ -323,7 +331,7 @@
 		hound.sleeper_g = FALSE
 
 	//Letting analyzer gut swell if overloaded.
-	if(istype(src,/obj/item/device/dogborg/sleeper/compactor/analyzer) && (length(contents) > 1))
+	if(istype(/obj/item/device/dogborg/sleeper/compactor/analyzer) && (length(contents) > 1))
 		hound.sleeper_r = TRUE
 		hound.sleeper_g = FALSE
 
@@ -444,7 +452,7 @@
 		else
 			var/obj/item/T = target
 			if(istype(T))
-				if(istype(src,/obj/item/device/dogborg/sleeper/compactor/analyzer))
+				if(istype(/obj/item/device/dogborg/sleeper/compactor/analyzer))
 					var/obj/item/tech_item = T
 					for(var/tech in tech_item.origin_tech)
 						files.UpdateTech(tech, tech_item.origin_tech[tech])
@@ -522,7 +530,7 @@
 		to_chat(user, "<span class='warning'>Your [src.name] is full. Eject or process contents to continue.</span>")
 		return
 
-	if(istype(src,/obj/item/device/dogborg/sleeper/compactor/analyzer))
+	if(istype(/obj/item/device/dogborg/sleeper/compactor/analyzer))
 		if(istype(target, /obj/item))
 			var/obj/target_obj = target
 			if(target_obj.w_class > ITEMSIZE_LARGE)

--- a/code/modules/mob/living/silicon/robot/dogborg/dog_sleeper_vr.dm
+++ b/code/modules/mob/living/silicon/robot/dogborg/dog_sleeper_vr.dm
@@ -453,10 +453,10 @@
 				if(!digested)
 					items_preserved |= T
 				else
-					hound.cell.charge += (50 * digested)
+					drain(-50 * digested)
 			else if(istype(target,/obj/effect/decal/remains))
 				qdel(target)
-				hound.cell.charge += 50
+				drain(-100)
 			else
 				items_preserved |= target
 
@@ -525,7 +525,7 @@
 	if(istype(src,/obj/item/device/dogborg/sleeper/compactor/analyzer))
 		if(istype(target, /obj/item))
 			var/obj/target_obj = target
-			if(target_obj.w_class >= ITEMSIZE_LARGE)
+			if(target_obj.w_class > ITEMSIZE_LARGE)
 				to_chat(user, "<span class='warning'>\The [target] is too large to fit into your [src.name]</span>")
 				return
 			user.visible_message("<span class='warning'>[hound.name] is ingesting [target.name] into their [src.name].</span>", "<span class='notice'>You start ingesting [target] into your [src.name]...</span>")

--- a/code/modules/mob/living/silicon/robot/dogborg/dog_sleeper_vr.dm
+++ b/code/modules/mob/living/silicon/robot/dogborg/dog_sleeper_vr.dm
@@ -21,6 +21,7 @@
 	var/datum/research/techonly/files //Analyzerbelly var.
 	var/synced = FALSE
 	var/startdrain = 500
+	var/max_item_count = 1
 
 /obj/item/device/dogborg/sleeper/New()
 	..()
@@ -609,7 +610,7 @@
 	icon_state = "compactor"
 	injection_chems = null //So they don't have all the same chems as the medihound!
 	compactor = TRUE
-	var/max_item_count = 25
+	max_item_count = 25
 
 /obj/item/device/dogborg/sleeper/compactor/analyzer //sci-borg gut.
 	name = "Digestive Analyzer"

--- a/code/modules/mob/living/silicon/robot/dogborg/dog_sleeper_vr.dm
+++ b/code/modules/mob/living/silicon/robot/dogborg/dog_sleeper_vr.dm
@@ -137,7 +137,8 @@
 					sleeperUI(usr)
 			return
 		return
-	
+	if(!ishuman(target))
+		return
 	if(patient)
 		to_chat(user, "<span class='warning'>Your [src.name] is already occupied.</span>")
 		return


### PR DESCRIPTION
-Cleans up some redundant srcs.
-Tweaks and fixes some patient update and overlay behavior.
-Makes the sleeper gurgles use damage based gains instead of big crunch after prey death. Also drastically reduces the dead mob gain.
-Moves the reduced dead mob gain back to its original non-human exclusive spot.
-Utilizes more drain proc instead of clunky cell charge hardcode.
-Removes an unbenefitical DA nerf. (can take same size stuff as janigut again. using this to gamblefeed loaded backpacks still makes you look like an idiot shooting your own foot though.)
-Makes compactor and analyzer functions a variant in base sleeper afterattack proc instead of separate subtype proc.