### PR TITLE
Various borg sleeper tweaks and fixes (tested working)

### DIFF
--- a/code/modules/mob/living/silicon/robot/dogborg/dog_sleeper_vr.dm
+++ b/code/modules/mob/living/silicon/robot/dogborg/dog_sleeper_vr.dm
@@ -11,7 +11,7 @@
 	var/min_health = -100
 	var/cleaning = 0
 	var/patient_laststat = null
-	var/mob_energy = -200 //Energy gained from digesting dead mobs (including PCs)
+	var/mob_energy = -250 //Energy gained from digesting dead mobs (including PCs)
 	var/list/injection_chems = list("inaprovaline", "dexalin", "bicaridine", "kelotane","anti_toxin", "alkysine", "imidazoline", "spaceacillin", "paracetamol") //The borg is able to heal every damage type. As a nerf, they use 750 charge per injection.
 	var/eject_port = "ingestion"
 	var/list/items_preserved = list()
@@ -44,7 +44,7 @@
 	if(length(contents) > (max_item_count - 1))
 		to_chat(user, "<span class='warning'>Your [src.name] is full. Eject or process contents to continue.</span>")
 		return
-	
+
 	if(analyzer == TRUE)
 		if(istype(target, /obj/item))
 			var/obj/target_obj = target
@@ -85,7 +85,7 @@
 					sleeperUI(usr)
 			return
 		return
-	
+
 	if(compactor == TRUE)
 		if(istype(target, /obj/item) || istype(target, /obj/effect/decal/remains))
 			var/obj/target_obj = target


### PR DESCRIPTION
-Cleans up some redundant srcs.
-Tweaks and fixes some patient update and overlay behavior.
-Makes the sleeper gurgles use damage based gains instead of big crunch after prey death. Also drastically reduces the dead mob gain.
-Moves the reduced dead mob gain back to its original non-human exclusive spot.
-Utilizes more drain proc instead of clunky cell charge hardcode.
-Removes an unbenefitical DA nerf. (can take same size stuff as janigut again. using this to gamblefeed loaded backpacks still makes you look like an idiot shooting your own foot though.)
-Makes compactor and analyzer functions a variant in base sleeper afterattack proc instead of separate subtype proc.