### PR TITLE
Adds dufflebags and saddlebags to utility loadout.

### DIFF
--- a/code/game/objects/items/weapons/storage/backpack_vr.dm
+++ b/code/game/objects/items/weapons/storage/backpack_vr.dm
@@ -117,3 +117,8 @@
 	icon_base = "taurvest"
 	max_storage_space = INVENTORY_STANDARD_SPACE
 	slowdown = 0
+
+/obj/item/weapon/storage/backpack/dufflebag/fluff //Black dufflebag without syndie buffs.
+	name = "plain black dufflebag"
+	desc = "A large dufflebag for holding extra tactical supplies."
+	icon_state = "duffle_syndie"

--- a/code/modules/client/preference_setup/loadout/loadout_accessories_vr.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_accessories_vr.dm
@@ -35,26 +35,6 @@
 /datum/gear/accessory/white_vest
 	allowed_roles = list("Paramedic","Chief Medical Officer","Medical Doctor","Chemist")
 
-/datum/gear/accessory/saddlebag
-    display_name = "Saddle Bag, Horse"
-    path = /obj/item/weapon/storage/backpack/saddlebag
-    slot = slot_back
-
-/datum/gear/accessory/saddlebag_common
-    display_name = "Saddle Bag, Common"
-    path = /obj/item/weapon/storage/backpack/saddlebag_common
-    slot = slot_back
-
-/datum/gear/accessory/saddlebag_common/robust
-    display_name = "Saddle Bag, Robust"
-    path = /obj/item/weapon/storage/backpack/saddlebag_common/robust
-    slot = slot_back
-
-/datum/gear/accessory/saddlebag_common/vest
-    display_name = "Taur Duty Vest (backpack)"
-    path = /obj/item/weapon/storage/backpack/saddlebag_common/vest
-    slot = slot_back
-
 /datum/gear/accessory/khcrystal
 	display_name = "KH Life Crystal"
 	path = /obj/item/weapon/storage/box/khcrystal

--- a/code/modules/client/preference_setup/loadout/loadout_utility_vr.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_utility_vr.dm
@@ -35,7 +35,7 @@
 /datum/gear/utility/dufflebag/med
     display_name = "Medical Dufflebag"
     path = /obj/item/weapon/storage/backpack/dufflebag/med
-    allowed_roles = list("Medical Doctor","Chief Medical Officer","Chemist","Paramedic","Geneticist", "Psychiatrist")
+    allowed_roles = list("Medical Doctor","Chief Medical Officer","Chemist","Paramedic","Geneticist","Psychiatrist","Search and Rescue")
 
 /datum/gear/utility/dufflebag/med/emt
     display_name = "EMT Dufflebag"
@@ -44,14 +44,14 @@
 /datum/gear/utility/dufflebag/sec
     display_name = "Security Dufflebag"
     path = /obj/item/weapon/storage/backpack/dufflebag/sec
-    allowed_roles = list("Head of Security", "Warden", "Detective", "Security Officer")
+    allowed_roles = list("Head of Security","Warden","Detective","Security Officer")
 
 /datum/gear/utility/dufflebag/eng
     display_name = "Engineering Dufflebag"
     path = /obj/item/weapon/storage/backpack/dufflebag/eng
-    allowed_roles = list("Chief Engineer","Atmospheric Technician", "Station Engineer")
+    allowed_roles = list("Chief Engineer","Atmospheric Technician","Station Engineer")
 
 /datum/gear/utility/dufflebag/sci
     display_name = "Science Dufflebag"
     path = /obj/item/weapon/storage/backpack/dufflebag/sci
-    allowed_roles = list("Research Director","Scientist", "Roboticist", "Xenobiologist")
+    allowed_roles = list("Research Director","Scientist","Roboticist","Xenobiologist","Explorer")

--- a/code/modules/client/preference_setup/loadout/loadout_utility_vr.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_utility_vr.dm
@@ -1,0 +1,57 @@
+/datum/gear/utility/saddlebag
+    display_name = "Saddle Bag, Horse"
+    path = /obj/item/weapon/storage/backpack/saddlebag
+    slot = slot_back
+    cost = 2
+
+/datum/gear/utility/saddlebag_common
+    display_name = "Saddle Bag, Common"
+    path = /obj/item/weapon/storage/backpack/saddlebag_common
+    slot = slot_back
+    cost = 2
+
+/datum/gear/utility/saddlebag_common/robust
+    display_name = "Saddle Bag, Robust"
+    path = /obj/item/weapon/storage/backpack/saddlebag_common/robust
+    slot = slot_back
+    cost = 2
+
+/datum/gear/utility/saddlebag_common/vest
+    display_name = "Taur Duty Vest (backpack)"
+    path = /obj/item/weapon/storage/backpack/saddlebag_common/vest
+    slot = slot_back
+    cost = 1
+
+/datum/gear/utility/dufflebag
+    display_name = "Dufflebag"
+    path = /obj/item/weapon/storage/backpack/dufflebag
+    slot = slot_back
+    cost = 2
+
+/datum/gear/utility/dufflebag/black
+    display_name = "Black Dufflebag"
+    path = /obj/item/weapon/storage/backpack/dufflebag/fluff
+
+/datum/gear/utility/dufflebag/med
+    display_name = "Medical Dufflebag"
+    path = /obj/item/weapon/storage/backpack/dufflebag/med
+    allowed_roles = list("Medical Doctor","Chief Medical Officer","Chemist","Paramedic","Geneticist", "Psychiatrist")
+
+/datum/gear/utility/dufflebag/med/emt
+    display_name = "EMT Dufflebag"
+    path = /obj/item/weapon/storage/backpack/dufflebag/emt
+
+/datum/gear/utility/dufflebag/sec
+    display_name = "Security Dufflebag"
+    path = /obj/item/weapon/storage/backpack/dufflebag/sec
+    allowed_roles = list("Head of Security", "Warden", "Detective", "Security Officer")
+
+/datum/gear/utility/dufflebag/eng
+    display_name = "Engineering Dufflebag"
+    path = /obj/item/weapon/storage/backpack/dufflebag/eng
+    allowed_roles = list("Chief Engineer","Atmospheric Technician", "Station Engineer")
+
+/datum/gear/utility/dufflebag/sci
+    display_name = "Science Dufflebag"
+    path = /obj/item/weapon/storage/backpack/dufflebag/sci
+    allowed_roles = list("Research Director","Scientist", "Roboticist", "Xenobiologist")

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -1429,6 +1429,7 @@
 #include "code\modules\client\preference_setup\loadout\loadout_uniform.dm"
 #include "code\modules\client\preference_setup\loadout\loadout_uniform_vr.dm"
 #include "code\modules\client\preference_setup\loadout\loadout_utility.dm"
+#include "code\modules\client\preference_setup\loadout\loadout_utility_vr.dm"
 #include "code\modules\client\preference_setup\loadout\loadout_xeno.dm"
 #include "code\modules\client\preference_setup\loadout\loadout_xeno_vr.dm"
 #include "code\modules\client\preference_setup\occupation\occupation.dm"


### PR DESCRIPTION
-Adds dufflebags to loadout, including normal, black(cosmetic), and department specific versions with appropriate access restrictions to utility category.
-Adds a cosmetic black duffle without the syndie speed buff.
-Moves taur saddlebags from accessories category to utility category.

Just a little preference QoL thing when you don't feel like scavenging and littering the station with discarded starter bags.