### PR TITLE
Rewrites beach mission to be on Virgo 4

### DIFF
--- a/maps/tether/submaps/alienship/alienship.dm
+++ b/maps/tether/submaps/alienship/alienship.dm
@@ -1,7 +1,7 @@
 // -- Datums -- //
 
 /datum/shuttle_destination/excursion/alienship1
-	name = "Virgo 2 Orbit"
+	name = "Virgo 4 Orbit"
 	my_area = /area/shuttle/excursion/space
 	preferred_interim_area = /area/shuttle/excursion/space_moving
 	skip_me = TRUE
@@ -11,7 +11,7 @@
 	)
 
 /datum/shuttle_destination/excursion/alienship2
-	name = "Virgo 2 Orbit...?"
+	name = "Virgo 4 Orbit...?"
 	my_area = /area/shuttle/excursion/space
 	preferred_interim_area = /area/shuttle/excursion/space_moving
 	skip_me = TRUE
@@ -21,7 +21,7 @@
 	)
 
 /datum/shuttle_destination/excursion/alienship3
-	name = "Virgo-2 Orbit????"
+	name = "Virgo 4 Orbit????"
 	my_area = /area/shuttle/excursion/space
 	preferred_interim_area = /area/shuttle/excursion/space_moving
 	skip_me = TRUE

--- a/maps/tether/submaps/beach/beach.dm
+++ b/maps/tether/submaps/beach/beach.dm
@@ -1,8 +1,8 @@
 // -- Datums -- //
 
 //We're including two new shuttle destinations. One is in orbit of our 'desert planet'
-/datum/shuttle_destination/excursion/virgo2orbit //Must be a unique path
-	name = "Virgo 2 Orbit" //The name of the destination
+/datum/shuttle_destination/excursion/virgo4orbit //Must be a unique path
+	name = "Virgo 4 Orbit" //The name of the destination
 	my_area = /area/shuttle/excursion/space //The area the shuttle goes when it's settled at this destination
 	preferred_interim_area = /area/shuttle/excursion/space_moving //The area the shuttle goes while it's moving there
 	skip_me = TRUE //Must be TRUE on all away-mission destinations for reasons
@@ -19,7 +19,7 @@
 	skip_me = TRUE
 
 	routes_to_make = list(
-		/datum/shuttle_destination/excursion/virgo2orbit = 30 SECONDS //This is the above one
+		/datum/shuttle_destination/excursion/virgo4orbit = 30 SECONDS //This is the above one
 	)
 
 //This is a special subtype of the thing that generates ores on a map
@@ -64,7 +64,7 @@
 	name = "shuttle connector - beach"
 	shuttle_name = "Excursion Shuttle"
 	//This list needs to be in the correct order, and start with the one that connects to the rest of the shuttle 'network'
-	destinations = list(/datum/shuttle_destination/excursion/virgo2orbit, /datum/shuttle_destination/excursion/beach)
+	destinations = list(/datum/shuttle_destination/excursion/virgo4orbit, /datum/shuttle_destination/excursion/beach)
 
 //This object simply performs any map setup that needs to happen on our map if it loads.
 //As with the above, you do need to place this object on the map somewhere.


### PR DESCRIPTION
As per the Lore Book on Virgo Erigone, https://github.com/VOREStation/VOREStation/blob/release/code/modules/lore_codex/lore_data_vr/important_locations.dm.

Virgo 2 is described with things like ```The very high temperatures, dangerous (sometimes magma-filled) caves, and the only presence of civilization being mining operations has made tourism for Virgo 2 mostly non-existent, with the exception of explorers who specifically seek out hellish landscapes, which are plentiful with all the ruins, volcanoes, twisting caves, and general lawlessness. The occasional remains of previous explorers near certain hotspots somehow does not deter them."```
There shouldn't be an ocean for beaches, the atmosphere should be unbreathable. This is almost a perfect description for a Lavaland style environment, which could be explored in future away missions.

In comparison, ```Virgo Prime is the fourth planet of Virgo-Eirgone. Although primarily desert, temperatures linger around only 287 kelvin (~14°C). It is the only planet in the system with an environment that supports oxygen-breathing lifeforms. The planet has a very shallow ocean, which is only an average of 1000 meters deep.```
This is almost perfect for the beach area, and adds more possibilities for future missions on the planet.