### PR TITLE
Making mining drills faster.

### DIFF
--- a/code/modules/mining/code/modules/mining/mine_items_vr.dm
+++ b/code/modules/mining/code/modules/mining/mine_items_vr.dm
@@ -1,0 +1,256 @@
+/**********************Miner Lockers**************************/
+
+/obj/structure/closet/secure_closet/miner
+	name = "miner's equipment"
+	icon_state = "miningsec1"
+	icon_closed = "miningsec"
+	icon_locked = "miningsec1"
+	icon_opened = "miningsecopen"
+	icon_broken = "miningsecbroken"
+	icon_off = "miningsecoff"
+	req_access = list(access_mining)
+
+/obj/structure/closet/secure_closet/miner/New()
+	..()
+	sleep(2)
+	if(prob(50))
+		new /obj/item/weapon/storage/backpack/industrial(src)
+	else
+		new /obj/item/weapon/storage/backpack/satchel/eng(src)
+	new /obj/item/device/radio/headset/headset_cargo(src)
+	new /obj/item/clothing/under/rank/miner(src)
+	new /obj/item/clothing/gloves/black(src)
+	new /obj/item/clothing/shoes/black(src)
+	new /obj/item/device/analyzer(src)
+	new /obj/item/weapon/storage/bag/ore(src)
+	new /obj/item/device/flashlight/lantern(src)
+	new /obj/item/weapon/shovel(src)
+	new /obj/item/weapon/pickaxe(src)
+	new /obj/item/clothing/glasses/material(src)
+	new /obj/item/clothing/suit/storage/hooded/wintercoat/miner(src)
+	new /obj/item/clothing/shoes/boots/winter/mining(src)
+
+/******************************Lantern*******************************/
+
+/obj/item/device/flashlight/lantern
+	name = "lantern"
+	icon_state = "lantern"
+	desc = "A mining lantern."
+	brightness_on = 6			// luminosity when on
+	light_color = "FF9933" // A slight yellow/orange color.
+
+/*****************************Pickaxe********************************/
+
+/obj/item/weapon/pickaxe
+	name = "mining drill"
+	desc = "The most basic of mining drills, for short excavations and small mineral extractions."
+	icon = 'icons/obj/items.dmi'
+	flags = CONDUCT
+	slot_flags = SLOT_BELT
+	force = 15.0
+	throwforce = 4.0
+	icon_state = "pickaxe"
+	item_state = "jackhammer"
+	w_class = ITEMSIZE_LARGE
+	matter = list(DEFAULT_WALL_MATERIAL = 3750)
+	var/digspeed = 36 //moving the delay to an item var so R&D can make improved picks. --NEO
+	origin_tech = list(TECH_MATERIAL = 1, TECH_ENGINEERING = 1)
+	attack_verb = list("hit", "pierced", "sliced", "attacked")
+	var/drill_sound = 'sound/weapons/Genhit.ogg'
+	var/drill_verb = "drilling"
+	sharp = 1
+
+	var/excavation_amount = 200
+
+/obj/item/weapon/pickaxe/hammer
+	name = "sledgehammer"
+	//icon_state = "sledgehammer" Waiting on sprite
+	desc = "A mining hammer made of reinforced metal. You feel like smashing your boss in the face with this."
+
+/obj/item/weapon/pickaxe/silver
+	name = "silver pickaxe"
+	icon_state = "spickaxe"
+	item_state = "spickaxe"
+	digspeed = 27
+	origin_tech = list(TECH_MATERIAL = 3)
+	desc = "This makes no metallurgic sense."
+
+/obj/item/weapon/pickaxe/drill
+	name = "advanced mining drill" // Can dig sand as well!
+	icon_state = "handdrill"
+	item_state = "jackhammer"
+	digspeed = 27
+	origin_tech = list(TECH_MATERIAL = 2, TECH_POWER = 3, TECH_ENGINEERING = 2)
+	desc = "Yours is the drill that will pierce through the rock walls."
+	drill_verb = "drilling"
+
+/obj/item/weapon/pickaxe/jackhammer
+	name = "sonic jackhammer"
+	icon_state = "jackhammer"
+	item_state = "jackhammer"
+	digspeed = 18 //faster than drill, but cannot dig
+	origin_tech = list(TECH_MATERIAL = 3, TECH_POWER = 2, TECH_ENGINEERING = 2)
+	desc = "Cracks rocks with sonic blasts, perfect for killing cave lizards."
+	drill_verb = "hammering"
+
+/obj/item/weapon/pickaxe/gold
+	name = "golden pickaxe"
+	icon_state = "gpickaxe"
+	item_state = "gpickaxe"
+	digspeed = 18
+	origin_tech = list(TECH_MATERIAL = 4)
+	desc = "This makes no metallurgic sense."
+	drill_verb = "picking"
+
+/obj/item/weapon/pickaxe/plasmacutter
+	name = "plasma cutter"
+	icon_state = "plasmacutter"
+	item_state = "gun"
+	w_class = ITEMSIZE_NORMAL //it is smaller than the pickaxe
+	damtype = "fire"
+	digspeed = 18 //Can slice though normal walls, all girders, or be used in reinforced wall deconstruction/ light thermite on fire
+	origin_tech = list(TECH_MATERIAL = 4, TECH_PHORON = 3, TECH_ENGINEERING = 3)
+	desc = "A rock cutter that uses bursts of hot plasma. You could use it to cut limbs off of xenos! Or, you know, mine stuff."
+	drill_verb = "cutting"
+	drill_sound = 'sound/items/Welder.ogg'
+	sharp = 1
+	edge = 1
+
+/obj/item/weapon/pickaxe/diamond
+	name = "diamond pickaxe"
+	icon_state = "dpickaxe"
+	item_state = "dpickaxe"
+	digspeed = 9
+	origin_tech = list(TECH_MATERIAL = 6, TECH_ENGINEERING = 4)
+	desc = "A pickaxe with a diamond pick head."
+	drill_verb = "picking"
+
+/obj/item/weapon/pickaxe/diamonddrill //When people ask about the badass leader of the mining tools, they are talking about ME!
+	name = "diamond mining drill"
+	icon_state = "diamonddrill"
+	item_state = "jackhammer"
+	digspeed = 4 //Digs through walls, girders, and can dig up sand
+	origin_tech = list(TECH_MATERIAL = 6, TECH_POWER = 4, TECH_ENGINEERING = 5)
+	desc = "Yours is the drill that will pierce the heavens!"
+	drill_verb = "drilling"
+
+/obj/item/weapon/pickaxe/borgdrill
+	name = "enhanced sonic jackhammer"
+	icon_state = "jackhammer"
+	item_state = "jackhammer"
+	digspeed = 13
+	desc = "Cracks rocks with sonic blasts. This one seems like an improved design."
+	drill_verb = "hammering"
+
+/*****************************Shovel********************************/
+
+/obj/item/weapon/shovel
+	name = "shovel"
+	desc = "A large tool for digging and moving dirt."
+	icon = 'icons/obj/items.dmi'
+	icon_state = "shovel"
+	flags = CONDUCT
+	slot_flags = SLOT_BELT
+	force = 8.0
+	throwforce = 4.0
+	item_state = "shovel"
+	w_class = ITEMSIZE_NORMAL
+	origin_tech = list(TECH_MATERIAL = 1, TECH_ENGINEERING = 1)
+	matter = list(DEFAULT_WALL_MATERIAL = 50)
+	attack_verb = list("bashed", "bludgeoned", "thrashed", "whacked")
+	sharp = 0
+	edge = 1
+
+/obj/item/weapon/shovel/spade
+	name = "spade"
+	desc = "A small tool for digging and moving dirt."
+	icon_state = "spade"
+	item_state = "spade"
+	force = 5.0
+	throwforce = 7.0
+	w_class = ITEMSIZE_SMALL
+
+
+/**********************Mining car (Crate like thing, not the rail car)**************************/
+
+/obj/structure/closet/crate/miningcar
+	desc = "A mining car. This one doesn't work on rails, but has to be dragged."
+	name = "Mining car (not for rails)"
+	icon = 'icons/obj/storage.dmi'
+	icon_state = "miningcar"
+	density = 1
+	icon_opened = "miningcaropen"
+	icon_closed = "miningcar"
+
+// Flags.
+
+/obj/item/stack/flag
+	name = "flags"
+	desc = "Some colourful flags."
+	singular_name = "flag"
+	amount = 10
+	max_amount = 10
+	icon = 'icons/obj/mining.dmi'
+	var/upright = 0
+	var/base_state
+
+/obj/item/stack/flag/New()
+	..()
+	base_state = icon_state
+
+/obj/item/stack/flag/blue
+	name = "blue flags"
+	singular_name = "blue flag"
+	icon_state = "blueflag"
+
+/obj/item/stack/flag/red
+	name = "red flags"
+	singular_name = "red flag"
+	icon_state = "redflag"
+
+/obj/item/stack/flag/yellow
+	name = "yellow flags"
+	singular_name = "yellow flag"
+	icon_state = "yellowflag"
+
+/obj/item/stack/flag/green
+	name = "green flags"
+	singular_name = "green flag"
+	icon_state = "greenflag"
+
+/obj/item/stack/flag/attackby(obj/item/W as obj, mob/user as mob)
+	if(upright && istype(W,src.type))
+		src.attack_hand(user)
+	else
+		..()
+
+/obj/item/stack/flag/attack_hand(user as mob)
+	if(upright)
+		upright = 0
+		icon_state = base_state
+		anchored = 0
+		src.visible_message("<b>[user]</b> knocks down [src].")
+	else
+		..()
+
+/obj/item/stack/flag/attack_self(mob/user as mob)
+
+	var/obj/item/stack/flag/F = locate() in get_turf(src)
+
+	var/turf/T = get_turf(src)
+	if(!T || !istype(T,/turf/simulated/mineral))
+		user << "The flag won't stand up in this terrain."
+		return
+
+	if(F && F.upright)
+		user << "There is already a flag here."
+		return
+
+	var/obj/item/stack/flag/newflag = new src.type(T)
+	newflag.amount = 1
+	newflag.upright = 1
+	anchored = 1
+	newflag.name = newflag.singular_name
+	newflag.icon_state = "[newflag.base_state]_open"
+	newflag.visible_message("<b>[user]</b> plants [newflag] firmly in the ground.")
+	src.use(1)

--- a/code/modules/mining/code/modules/mining/mine_items_vr.dm
+++ b/code/modules/mining/code/modules/mining/mine_items_vr.dm
@@ -1,256 +1,29 @@
-/**********************Miner Lockers**************************/
 
-/obj/structure/closet/secure_closet/miner
-	name = "miner's equipment"
-	icon_state = "miningsec1"
-	icon_closed = "miningsec"
-	icon_locked = "miningsec1"
-	icon_opened = "miningsecopen"
-	icon_broken = "miningsecbroken"
-	icon_off = "miningsecoff"
-	req_access = list(access_mining)
-
-/obj/structure/closet/secure_closet/miner/New()
-	..()
-	sleep(2)
-	if(prob(50))
-		new /obj/item/weapon/storage/backpack/industrial(src)
-	else
-		new /obj/item/weapon/storage/backpack/satchel/eng(src)
-	new /obj/item/device/radio/headset/headset_cargo(src)
-	new /obj/item/clothing/under/rank/miner(src)
-	new /obj/item/clothing/gloves/black(src)
-	new /obj/item/clothing/shoes/black(src)
-	new /obj/item/device/analyzer(src)
-	new /obj/item/weapon/storage/bag/ore(src)
-	new /obj/item/device/flashlight/lantern(src)
-	new /obj/item/weapon/shovel(src)
-	new /obj/item/weapon/pickaxe(src)
-	new /obj/item/clothing/glasses/material(src)
-	new /obj/item/clothing/suit/storage/hooded/wintercoat/miner(src)
-	new /obj/item/clothing/shoes/boots/winter/mining(src)
-
-/******************************Lantern*******************************/
-
-/obj/item/device/flashlight/lantern
-	name = "lantern"
-	icon_state = "lantern"
-	desc = "A mining lantern."
-	brightness_on = 6			// luminosity when on
-	light_color = "FF9933" // A slight yellow/orange color.
-
-/*****************************Pickaxe********************************/
+//Vorestation edit, upgrades the speed of all drills and pickaxes.
 
 /obj/item/weapon/pickaxe
-	name = "mining drill"
-	desc = "The most basic of mining drills, for short excavations and small mineral extractions."
-	icon = 'icons/obj/items.dmi'
-	flags = CONDUCT
-	slot_flags = SLOT_BELT
-	force = 15.0
-	throwforce = 4.0
-	icon_state = "pickaxe"
-	item_state = "jackhammer"
-	w_class = ITEMSIZE_LARGE
-	matter = list(DEFAULT_WALL_MATERIAL = 3750)
-	var/digspeed = 36 //moving the delay to an item var so R&D can make improved picks. --NEO
-	origin_tech = list(TECH_MATERIAL = 1, TECH_ENGINEERING = 1)
-	attack_verb = list("hit", "pierced", "sliced", "attacked")
-	var/drill_sound = 'sound/weapons/Genhit.ogg'
-	var/drill_verb = "drilling"
-	sharp = 1
-
-	var/excavation_amount = 200
-
-/obj/item/weapon/pickaxe/hammer
-	name = "sledgehammer"
-	//icon_state = "sledgehammer" Waiting on sprite
-	desc = "A mining hammer made of reinforced metal. You feel like smashing your boss in the face with this."
+	var/digspeed = 36 
 
 /obj/item/weapon/pickaxe/silver
-	name = "silver pickaxe"
-	icon_state = "spickaxe"
-	item_state = "spickaxe"
 	digspeed = 27
-	origin_tech = list(TECH_MATERIAL = 3)
-	desc = "This makes no metallurgic sense."
 
 /obj/item/weapon/pickaxe/drill
-	name = "advanced mining drill" // Can dig sand as well!
-	icon_state = "handdrill"
-	item_state = "jackhammer"
 	digspeed = 27
-	origin_tech = list(TECH_MATERIAL = 2, TECH_POWER = 3, TECH_ENGINEERING = 2)
-	desc = "Yours is the drill that will pierce through the rock walls."
-	drill_verb = "drilling"
 
 /obj/item/weapon/pickaxe/jackhammer
-	name = "sonic jackhammer"
-	icon_state = "jackhammer"
-	item_state = "jackhammer"
-	digspeed = 18 //faster than drill, but cannot dig
-	origin_tech = list(TECH_MATERIAL = 3, TECH_POWER = 2, TECH_ENGINEERING = 2)
-	desc = "Cracks rocks with sonic blasts, perfect for killing cave lizards."
-	drill_verb = "hammering"
+	digspeed = 18 
 
 /obj/item/weapon/pickaxe/gold
-	name = "golden pickaxe"
-	icon_state = "gpickaxe"
-	item_state = "gpickaxe"
 	digspeed = 18
-	origin_tech = list(TECH_MATERIAL = 4)
-	desc = "This makes no metallurgic sense."
-	drill_verb = "picking"
 
 /obj/item/weapon/pickaxe/plasmacutter
-	name = "plasma cutter"
-	icon_state = "plasmacutter"
-	item_state = "gun"
-	w_class = ITEMSIZE_NORMAL //it is smaller than the pickaxe
-	damtype = "fire"
-	digspeed = 18 //Can slice though normal walls, all girders, or be used in reinforced wall deconstruction/ light thermite on fire
-	origin_tech = list(TECH_MATERIAL = 4, TECH_PHORON = 3, TECH_ENGINEERING = 3)
-	desc = "A rock cutter that uses bursts of hot plasma. You could use it to cut limbs off of xenos! Or, you know, mine stuff."
-	drill_verb = "cutting"
-	drill_sound = 'sound/items/Welder.ogg'
-	sharp = 1
-	edge = 1
-
+	digspeed = 18 
+	
 /obj/item/weapon/pickaxe/diamond
-	name = "diamond pickaxe"
-	icon_state = "dpickaxe"
-	item_state = "dpickaxe"
 	digspeed = 9
-	origin_tech = list(TECH_MATERIAL = 6, TECH_ENGINEERING = 4)
-	desc = "A pickaxe with a diamond pick head."
-	drill_verb = "picking"
 
-/obj/item/weapon/pickaxe/diamonddrill //When people ask about the badass leader of the mining tools, they are talking about ME!
-	name = "diamond mining drill"
-	icon_state = "diamonddrill"
-	item_state = "jackhammer"
-	digspeed = 4 //Digs through walls, girders, and can dig up sand
-	origin_tech = list(TECH_MATERIAL = 6, TECH_POWER = 4, TECH_ENGINEERING = 5)
-	desc = "Yours is the drill that will pierce the heavens!"
-	drill_verb = "drilling"
+/obj/item/weapon/pickaxe/diamonddrill
+	digspeed = 4
 
 /obj/item/weapon/pickaxe/borgdrill
-	name = "enhanced sonic jackhammer"
-	icon_state = "jackhammer"
-	item_state = "jackhammer"
 	digspeed = 13
-	desc = "Cracks rocks with sonic blasts. This one seems like an improved design."
-	drill_verb = "hammering"
-
-/*****************************Shovel********************************/
-
-/obj/item/weapon/shovel
-	name = "shovel"
-	desc = "A large tool for digging and moving dirt."
-	icon = 'icons/obj/items.dmi'
-	icon_state = "shovel"
-	flags = CONDUCT
-	slot_flags = SLOT_BELT
-	force = 8.0
-	throwforce = 4.0
-	item_state = "shovel"
-	w_class = ITEMSIZE_NORMAL
-	origin_tech = list(TECH_MATERIAL = 1, TECH_ENGINEERING = 1)
-	matter = list(DEFAULT_WALL_MATERIAL = 50)
-	attack_verb = list("bashed", "bludgeoned", "thrashed", "whacked")
-	sharp = 0
-	edge = 1
-
-/obj/item/weapon/shovel/spade
-	name = "spade"
-	desc = "A small tool for digging and moving dirt."
-	icon_state = "spade"
-	item_state = "spade"
-	force = 5.0
-	throwforce = 7.0
-	w_class = ITEMSIZE_SMALL
-
-
-/**********************Mining car (Crate like thing, not the rail car)**************************/
-
-/obj/structure/closet/crate/miningcar
-	desc = "A mining car. This one doesn't work on rails, but has to be dragged."
-	name = "Mining car (not for rails)"
-	icon = 'icons/obj/storage.dmi'
-	icon_state = "miningcar"
-	density = 1
-	icon_opened = "miningcaropen"
-	icon_closed = "miningcar"
-
-// Flags.
-
-/obj/item/stack/flag
-	name = "flags"
-	desc = "Some colourful flags."
-	singular_name = "flag"
-	amount = 10
-	max_amount = 10
-	icon = 'icons/obj/mining.dmi'
-	var/upright = 0
-	var/base_state
-
-/obj/item/stack/flag/New()
-	..()
-	base_state = icon_state
-
-/obj/item/stack/flag/blue
-	name = "blue flags"
-	singular_name = "blue flag"
-	icon_state = "blueflag"
-
-/obj/item/stack/flag/red
-	name = "red flags"
-	singular_name = "red flag"
-	icon_state = "redflag"
-
-/obj/item/stack/flag/yellow
-	name = "yellow flags"
-	singular_name = "yellow flag"
-	icon_state = "yellowflag"
-
-/obj/item/stack/flag/green
-	name = "green flags"
-	singular_name = "green flag"
-	icon_state = "greenflag"
-
-/obj/item/stack/flag/attackby(obj/item/W as obj, mob/user as mob)
-	if(upright && istype(W,src.type))
-		src.attack_hand(user)
-	else
-		..()
-
-/obj/item/stack/flag/attack_hand(user as mob)
-	if(upright)
-		upright = 0
-		icon_state = base_state
-		anchored = 0
-		src.visible_message("<b>[user]</b> knocks down [src].")
-	else
-		..()
-
-/obj/item/stack/flag/attack_self(mob/user as mob)
-
-	var/obj/item/stack/flag/F = locate() in get_turf(src)
-
-	var/turf/T = get_turf(src)
-	if(!T || !istype(T,/turf/simulated/mineral))
-		user << "The flag won't stand up in this terrain."
-		return
-
-	if(F && F.upright)
-		user << "There is already a flag here."
-		return
-
-	var/obj/item/stack/flag/newflag = new src.type(T)
-	newflag.amount = 1
-	newflag.upright = 1
-	anchored = 1
-	newflag.name = newflag.singular_name
-	newflag.icon_state = "[newflag.base_state]_open"
-	newflag.visible_message("<b>[user]</b> plants [newflag] firmly in the ground.")
-	src.use(1)

--- a/code/modules/mining/code/modules/mining/mine_items_vr.dm
+++ b/code/modules/mining/code/modules/mining/mine_items_vr.dm
@@ -2,7 +2,7 @@
 //Vorestation edit, upgrades the speed of all drills and pickaxes.
 
 /obj/item/weapon/pickaxe
-	var/digspeed = 36 
+	digspeed = 36 
 
 /obj/item/weapon/pickaxe/silver
 	digspeed = 27

--- a/code/modules/mining/code/modules/mining/mine_items_vr.dm
+++ b/code/modules/mining/code/modules/mining/mine_items_vr.dm
@@ -1,4 +1,3 @@
-
 //Vorestation edit, upgrades the speed of all drills and pickaxes.
 
 /obj/item/weapon/pickaxe

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -1796,6 +1796,7 @@
 #include "code\modules\mining\machine_stacking.dm"
 #include "code\modules\mining\machine_unloading.dm"
 #include "code\modules\mining\mine_items.dm"
+#include "code\modules\mining\mine_items_vr.dm"
 #include "code\modules\mining\mine_turfs.dm"
 #include "code\modules\mining\mineral_effect.dm"
 #include "code\modules\mining\mint.dm"


### PR DESCRIPTION
All drills but borgdrill, and diamond drill are now 10% faster, which is a significant boost.
Diamond drill is 20% faster
Borg drill is roughly ~ 15% faster
Felt like with the removal of the rigsuit, mining feels extremely slow and clunky again. Ripley has gotten buffed, which makes it an excellent contendor now, with it being slightly slower whilst restricting movement, but better at tunneling, and gathering up veins. As well as allowing the hauling of large amouns of crates, and stationary drills.

This change should make the normal drill feel smooth enough for the early stages, especially nice if there is no research, such as on skeleton shifts, yet you wanna do some mining for abandoned crates and such. It also makes upgrading the drills feel even nicer.

Before update:
Basic drill is 8x as slow as a diamond drill.
Advanced drill is 6x as slow as a diamond drill.
Even the best drill, aka jackhammer and plasma cutter, is 4x as slow as a diamond drill.
Borgs were around 3x as slow as a diamond drill; Meaning they start with far superior gear compared to a miner.

After update:
Basic drills are still 8x times as slow as a diamond drill, so that upgrade still feels just as powerful
Advanced drills are now 6.75x as slow as a diamond drill.
Jackhammer/plasma cutters are now 4.5x as slow as a diamond drill.
Borg drills are now 3.25x as slow as a diamond drill.