### PR TITLE
Changes voremob default gurglemode to itemweak

### DIFF
--- a/code/modules/mob/living/simple_animal/simple_animal_vr.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal_vr.dm
@@ -15,7 +15,7 @@
 	var/vore_standing_too = 0			// Can also eat non-stunned mobs
 	var/vore_ignores_undigestable = 1	// Refuse to eat mobs who are undigestable by the prefs toggle.
 
-	var/vore_default_mode = DM_DIGEST	// Default bellymode (DM_DIGEST, DM_HOLD, DM_ABSORB)
+	var/vore_default_mode = DM_ITEMWEAK	// Default bellymode (DM_DIGEST, DM_HOLD, DM_ABSORB)
 	var/vore_digest_chance = 25			// Chance to switch to digest mode if resisted
 	var/vore_absorb_chance = 0			// Chance to switch to absorb mode if resisted
 	var/vore_escape_chance = 25			// Chance of resisting out of mob
@@ -164,6 +164,16 @@
 		"The sound of bodily movements drown out everything for a moment.",
 		"The predator's movements gently force you into a different position.")
 	B.emote_lists[DM_DIGEST] = list(
+		"The burning acids eat away at your form.",
+		"The muscular stomach flesh grinds harshly against you.",
+		"The caustic air stings your chest when you try to breathe.",
+		"The slimy guts squeeze inward to help the digestive juices soften you up.",
+		"The onslaught against your body doesn't seem to be letting up; you're food now.",
+		"The predator's body ripples and crushes against you as digestive enzymes pull you apart.",
+		"The juices pooling beneath you sizzle against your sore skin.",
+		"The churning walls slowly pulverize you into meaty nutrients.",
+		"The stomach glorps and gurgles as it tries to work you into slop.")
+	B.emote_lists[DM_ITEMWEAK] = list(
 		"The burning acids eat away at your form.",
 		"The muscular stomach flesh grinds harshly against you.",
 		"The caustic air stings your chest when you try to breathe.",

--- a/code/modules/vore/eating/belly_vr.dm
+++ b/code/modules/vore/eating/belly_vr.dm
@@ -466,7 +466,7 @@
 			digest_mode = DM_ABSORB
 			return
 		
-		else if(prob(digestchance) && digest_mode != (DM_ITEMWEAK | DM_DIGEST)) //Finally, let's see if it should run the digest chance.
+		else if(prob(digestchance) && digest_mode != DM_ITEMWEAK && digest_mode != DM_DIGEST) //Finally, let's see if it should run the digest chance.
 			R << "<span class='warning'>In response to your struggling, \the [name] begins to get more active...</span>"
 			owner << "<span class='warning'>You feel your [name] beginning to become active!</span>"
 			digest_mode = DM_ITEMWEAK

--- a/code/modules/vore/eating/belly_vr.dm
+++ b/code/modules/vore/eating/belly_vr.dm
@@ -465,10 +465,16 @@
 			owner << "<span class='warning'>You feel your [name] start to cling onto its contents...</span>"
 			digest_mode = DM_ABSORB
 			return
-
-		else if(prob(digestchance) && digest_mode != DM_DIGEST) //Finally, let's see if it should run the digest chance.
+		
+		else if(prob(digestchance) && digest_mode != (DM_ITEMWEAK | DM_DIGEST)) //Finally, let's see if it should run the digest chance.
 			R << "<span class='warning'>In response to your struggling, \the [name] begins to get more active...</span>"
 			owner << "<span class='warning'>You feel your [name] beginning to become active!</span>"
+			digest_mode = DM_ITEMWEAK
+			return
+
+		else if(prob(digestchance) && digest_mode == DM_ITEMWEAK) //Oh god it gets even worse if you fail twice!
+			R << "<span class='warning'>In response to your struggling, \the [name] begins to get even more active!</span>"
+			owner << "<span class='warning'>You feel your [name] beginning to become even more active!</span>"
 			digest_mode = DM_DIGEST
 			return
 		else //Nothing interesting happened.


### PR DESCRIPTION
It's just kind of a bummer to lose all your important gear after losing a fight if backup doesn't arrive in time. After all the item friendly mode was introduced way after vore mobs.

-Changes voremob default gurglemode to itemweak.
-Makes digest chance struggle failure trigger item-friendly gurgles first.
-Second struggle failure during itemweak gurgles kicks in the full gurgles.