### PR TITLE
Make telecomms relays work even when shuttling places.

### DIFF
--- a/code/game/machinery/telecomms/telecomunications.dm
+++ b/code/game/machinery/telecomms/telecomunications.dm
@@ -352,6 +352,18 @@ var/global/list/obj/machinery/telecomms/telecomms_list = list()
 	var/broadcasting = 1
 	var/receiving = 1
 
+// VOREStation Edit - Make sure constructed relays keep relaying for their current Z when moved by shuttles.
+/obj/machinery/telecomms/relay/proc/update_z()
+	if (initial(listening_level) == 0)
+		var/turf/T = get_turf(src)
+		listening_level = T.z
+
+/area/shuttle_arrived()
+	. = ..()
+	for(var/obj/machinery/telecomms/relay/R in contents)
+		R.update_z()
+// VOREStation Edit End
+
 /obj/machinery/telecomms/relay/receive_information(datum/signal/signal, obj/machinery/telecomms/machine_from)
 
 	// Add our level and send it back


### PR DESCRIPTION
Previously they'd keep relaying for the level they were built on (the station).  That's silly! The whole point is to relay somewhere else.  Now when they get built on a shuttle, when the shuttle moves they will relay for wherever they end up.