### PR TITLE
Sebastian permit & magazine update & fix

### DIFF
--- a/code/modules/vore/fluffstuff/custom_boxes_vr.dm
+++ b/code/modules/vore/fluffstuff/custom_boxes_vr.dm
@@ -190,8 +190,8 @@
 	name = "Sebastian's Lumoco Arms P3 Box"
 	has_items = list(
 		/obj/item/weapon/gun/projectile/pistol,
-		/obj/item/ammo_magazine/m9mm/flash,
-		/obj/item/ammo_magazine/m9mm/flash,
+		/obj/item/ammo_magazine/m9mm/compact/flash,
+		/obj/item/ammo_magazine/m9mm/compact/flash,
 		/obj/item/clothing/accessory/permit/gun/fluff/sebastian_aji)
 
 /obj/item/weapon/storage/box/fluff/briana_moore

--- a/code/modules/vore/fluffstuff/custom_permits_vr.dm
+++ b/code/modules/vore/fluffstuff/custom_permits_vr.dm
@@ -9,7 +9,7 @@
 // aerowing:Sebastian Aji
 /obj/item/clothing/accessory/permit/gun/fluff/sebastian_aji
 	name = "Sebastian Aji's Sidearm Permit"
-	desc = "A card indicating that the owner is allowed to carry a sidearm. It is issued by CentCom, so it is valid until it expires on April 17th, 2562."
+	desc = "A card indicating that the owner is allowed to carry a sidearm. It is issued by CentCom, so it is valid until it expires on April 17th, 2563."
 
 // arokha:Aronai Kadigan
 /obj/item/clothing/accessory/permit/gun/fluff/aronai_kadigan


### PR DESCRIPTION
They are supposed to spawn with the compact ones, not the normal mags.
- Makes their magazines compact
- Updates their permit. Adds 1 year to the expiration date.