### PR TITLE
Making mining drills faster. (fix)

### DIFF
--- a/code/modules/mining/mine_items_vr.dm
+++ b/code/modules/mining/mine_items_vr.dm
@@ -1,0 +1,28 @@
+//upgrades the speed of all drills and pickaxes.
+
+/obj/item/weapon/pickaxe
+	digspeed = 36 
+
+/obj/item/weapon/pickaxe/silver
+	digspeed = 27
+
+/obj/item/weapon/pickaxe/drill
+	digspeed = 27
+
+/obj/item/weapon/pickaxe/jackhammer
+	digspeed = 18 
+
+/obj/item/weapon/pickaxe/gold
+	digspeed = 18
+
+/obj/item/weapon/pickaxe/plasmacutter
+	digspeed = 18 
+	
+/obj/item/weapon/pickaxe/diamond
+	digspeed = 9
+
+/obj/item/weapon/pickaxe/diamonddrill
+	digspeed = 4
+
+/obj/item/weapon/pickaxe/borgdrill
+	digspeed = 13

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -1796,6 +1796,7 @@
 #include "code\modules\mining\machine_stacking.dm"
 #include "code\modules\mining\machine_unloading.dm"
 #include "code\modules\mining\mine_items.dm"
+#include "code\modules\mining\mine_items_vr.dm"
 #include "code\modules\mining\mine_turfs.dm"
 #include "code\modules\mining\mineral_effect.dm"
 #include "code\modules\mining\mint.dm"


### PR DESCRIPTION
All drills but borgdrill, and diamond drill are now 10% faster, which is a significant boost.
Diamond drill is 20% faster
Borg drill is roughly ~ 15% faster
Felt like with the removal of the rigsuit, mining feels extremely slow and clunky again. Ripley has gotten buffed, which makes it an excellent contendor now, with it being slightly slower whilst restricting movement, but better at tunneling, and gathering up veins. As well as allowing the hauling of large amouns of crates, and stationary drills.

This change should make the normal drill feel smooth enough for the early stages, especially nice if there is no research, such as on skeleton shifts, yet you wanna do some mining for abandoned crates and such. It also makes upgrading the drills feel even nicer.

Before update:
Basic drill is 8x as slow as a diamond drill.
Advanced drill is 6x as slow as a diamond drill.
Even the best drill, aka jackhammer and plasma cutter, is 4x as slow as a diamond drill.
Borgs were around 3x as slow as a diamond drill; Meaning they start with far superior gear compared to a miner.

After update:
Basic drills are still 8x times as slow as a diamond drill, so that upgrade still feels just as powerful
Advanced drills are now 6.75x as slow as a diamond drill.
Jackhammer/plasma cutters are now 4.5x as slow as a diamond drill.
Borg drills are now 3.25x as slow as a diamond drill.