### PR TITLE
Small NIFSoft disks change, minor fix and refactor

### DIFF
--- a/code/modules/nifsoft/nifsoft.dm
+++ b/code/modules/nifsoft/nifsoft.dm
@@ -176,7 +176,6 @@
 	item_state = "card-id"
 	w_class = ITEMSIZE_SMALL
 	var/datum/nifsoft/stored = null
-	var/laws = ""
 
 /obj/item/weapon/disk/nifsoft/afterattack(var/A, mob/user, flag, params)
 	if(!in_range(user, A))
@@ -192,9 +191,13 @@
 		to_chat(user,"<span class='warning'>Either they don't have a NIF, or the disk can't connect.</span>")
 		return
 
-	Ht.visible_message("<span class='warning'>[Hu] begins uploading new NIFSoft into [Ht]!</span>","<span class='danger'>[Hu] is uploading new NIFSoft into you!</span>")
-	if(do_after(Hu,10 SECONDS,Ht))
-		var/extra = extra_params()
+	var/extra = extra_params()
+	if(A == user)
+		to_chat(user,"<span class='notice'>You upload [src] into your NIF.</span>")
+	else
+		Ht.visible_message("<span class='warning'>[Hu] begins uploading [src] into [Ht]!</span>","<span class='danger'>[Hu] is uploading [src] into you!</span>")
+
+	if(A == user || do_after(Hu,10 SECONDS,Ht))
 		new stored(Ht.nif,extra)
 		qdel(src)
 
@@ -208,8 +211,11 @@
 	name = "NIFSoft Disk (Compliance)"
 	desc = "Wow, adding laws to people? That seems illegal. It probably is. Okay, it really is."
 	stored = /datum/nifsoft/compliance
+	var/laws
 
 /obj/item/weapon/disk/nifsoft/compliance/afterattack(var/A, mob/user, flag, params)
+	if(!ishuman(A))
+		return
 	if(!laws)
 		to_chat(user,"<span class='warning'>You haven't set any laws yet. Use the disk in-hand first.</span>")
 		return


### PR DESCRIPTION
* Feature: You can now upload NIFSoft disks into yourself instantly, instead of it being identical to uploading NIFSoft into other people.
* Minor Fix: Compliance disks now only show the message saying you need to upload laws when you attempt to upload it into someone, instead of whenever you click anything with it, including tables.
* Minor Refactor: Moved laws variable to the compliance disk instead of all NIFSoft disks, and made it not an empty string by default. As far as I can see, there's no reason for either of those things, and I didn't run into any problems or runtime errors during the test.