### PR TITLE
Adds pilot access to Tether backup shuttle

### DIFF
--- a/maps/tether/tether_shuttles.dm
+++ b/maps/tether/tether_shuttles.dm
@@ -5,7 +5,7 @@
 /obj/machinery/computer/shuttle_control/tether_backup
 	name = "tether backup shuttle control console"
 	shuttle_tag = "Tether Backup"
-	req_one_access = list(access_heads)
+	req_one_access = list(access_heads,access_pilot)
 
 /obj/machinery/computer/shuttle_control/multi/tether_antag_ground
 	name = "land crawler control console"


### PR DESCRIPTION
What it says! They're a pilot, they can fly and maintain the shuttle, that's like, part of their job.

Reminder on crash mechanics:
There are 3 engines, each rolls a 0-100% chance of crashing each time you fly. The % chance it rolls is based on 'wear', which starts at 0. It's impossible to crash the shuttle on the first flight.

Each trip it adds 5-20% (random) to each engine's 'wear'. So if you end up with 8, 12, 14 wear engines it will roll 8%, 12%, and 14% chances for those engines to fail.

If one engine fails: Nothing happens.
If two engines fail: It returns to the start.
If three engines fail: It crashes.

Repairing the engines reduces them to 20 wear, each. 20%/20%/20% is a 0.8% chance of crashing, 4% chance of returning to the start, and a 20% chance to get a scary message saying one engine failed.