### PR TITLE
Improves idle-kick admin awareness, cryo verb

### DIFF
--- a/code/controllers/Processes/inactivity.dm
+++ b/code/controllers/Processes/inactivity.dm
@@ -7,8 +7,30 @@
 		for(last_object in clients)
 			var/client/C = last_object
 			if(C.is_afk(config.kick_inactive MINUTES))
-				if(!istype(C.mob, /mob/observer/dead))
-					log_access("AFK: [key_name(C)]")
-					C << "<SPAN CLASS='warning'>You have been inactive for more than [config.kick_inactive] minute\s and have been disconnected.</SPAN>"
-					del(C)	// Don't qdel, cannot override finalize_qdel behaviour for clients.
+				if(!istype(C.mob, /mob/observer/dead) && !istype(C.mob, /mob/new_player))
+					to_chat(C,"<span class='warning'>You have been inactive for more than [config.kick_inactive] minute\s and have been disconnected.</span>")
+					var/information
+
+					if(ishuman(C.mob))
+						var/job
+						var/mob/living/carbon/human/H = C.mob
+						var/datum/data/record/R = find_general_record("name", H.real_name)
+						if(R)
+							job = R.fields["real_rank"]
+						if(!job && H.mind)
+							job = H.mind.assigned_role
+						if(!job && H.job)
+							job = H.job
+						if(job)
+							information = " while [job]."
+
+					else if(issilicon(C.mob))
+						information = " while a silicon."
+
+					var/adminlinks
+					adminlinks = " (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[C.mob.x];Y=[C.mob.y];Z=[C.mob.z]'>JMP</a>|<A HREF='?_src_=holder;cryoplayer=\ref[C.mob]'>CRYO</a>)"
+
+					log_and_message_admins("being kicked for AFK[information][adminlinks]", C.mob)
+
+					qdel(C)
 			SCHECK

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -348,8 +348,8 @@
 
 // This function can not be undone; do not call this unless you are sure
 // Also make sure there is a valid control computer
-/obj/machinery/cryopod/robot/despawn_occupant()
-	var/mob/living/silicon/robot/R = occupant
+/obj/machinery/cryopod/robot/despawn_occupant(var/mob/to_despawn)
+	var/mob/living/silicon/robot/R = to_despawn
 	if(!istype(R)) return ..()
 
 	qdel(R.mmi)

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -103,7 +103,8 @@ var/list/admin_verbs_admin = list(
 	/datum/admins/proc/paralyze_mob,
 	/client/proc/fixatmos,
 	/datum/admins/proc/quick_nif, //VOREStation Add,
-	/datum/admins/proc/sendFax
+	/datum/admins/proc/sendFax,
+	/client/proc/despawn_player
 	)
 
 var/list/admin_verbs_ban = list(

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1873,6 +1873,17 @@
 
 			show_player_panel(M)
 
+	else if(href_list["cryoplayer"])
+		if(!check_rights(R_ADMIN))	return
+
+		var/mob/M = locate(href_list["cryoplayer"])
+		if(!istype(M))
+			to_chat(usr,"<span class='warning'>Mob doesn't exist!</span>")
+			return
+
+		var/client/C = usr.client
+		C.despawn_player(M)
+
 	// player info stuff
 
 	if(href_list["add_player_info"])


### PR DESCRIPTION
Notifies online admins and writes to log whenever someone is kicked due to idle (as long as they are not an observer, or new_player, which are never kicked). Provides their job, and JMP and CRYO buttons on said message, the latter allowing you to pick any cryopod to automatically remove them from the round.

That is also available with the Cryo Player admin verb, which does much the same thing.

![image](https://user-images.githubusercontent.com/15028025/35774761-07b96cb6-0947-11e8-8efd-2e9ac2343180.png)
