### PR TITLE
Adds exotic meats supply pack.

### DIFF
--- a/code/datums/supplypacks/supply_vr.dm
+++ b/code/datums/supplypacks/supply_vr.dm
@@ -1,0 +1,14 @@
+/datum/supply_packs/supply/exoticmeat
+	name = "Exotic Meat Crate"
+	contains = list(
+			/obj/item/weapon/reagent_containers/food/snacks/meat/grubmeat = 2,
+			/obj/item/weapon/reagent_containers/food/snacks/carpmeat = 1,
+			/obj/item/weapon/reagent_containers/food/snacks/bearmeat = 2,
+			/obj/item/weapon/reagent_containers/food/snacks/xenomeat = 1,
+			/obj/item/weapon/reagent_containers/food/snacks/xenomeat/spidermeat = 2,
+			/obj/item/weapon/reagent_containers/food/snacks/meat = 1
+			)
+	cost = 25
+	containertype = /obj/structure/closet/crate/secure
+	containername = "Exotic Meat Crate"
+	access = access_kitchen

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -318,6 +318,7 @@
 #include "code\datums\supplypacks\security.dm"
 #include "code\datums\supplypacks\security_vr.dm"
 #include "code\datums\supplypacks\supply.dm"
+#include "code\datums\supplypacks\supply_vr.dm"
 #include "code\datums\supplypacks\supplypacks.dm"
 #include "code\datums\supplypacks\voidsuits.dm"
 #include "code\datums\supplypacks\voidsuits_vr.dm"


### PR DESCRIPTION
Basically adds the options for cargo to order in exotic meat.

There's multiple reasons why I want this to be a thing.
- Currently medical just orders in clotting crates, some people every shift. It's a little too easy to use clotting meds to trivialize internal bleeding. This way chefs can play a role in the process by extracting toxins from meat per request. Medical can then use the toxins and reagants to make alternative medicine. I also reccomend removing the clotting medicine crate altogether. But I'll leave the vorestation editing of non _vr files to the regular coders.

- Some dishes just can't be made, and a chef has little to no power over the obtainment of these meats. Some can only be gained through events, some through expiditions, some through cargo, albeit with some effort of security. looking at you dangerous predator crate. This allows for them to get access to a small amount of these. Cook all the things!

Justification for crate pricing, amounts, etc.

- I included all special meats, so they can be obtained.
- Carpmeat and Xenomeat are limited to 1 per crate, because of the strength of rezardone (medicine made using carptoxins.) And the danger of the acid in xenomeat. Also to prevent abuse, so people won't order these JUST for the medicine. as it can be seen as a whaste to order 5 of these just to get a bit more rezadone out of it.
- 25 points cost just to prevent people from ordering these in large quantities for reagents, these medicine have to be valuable, for emergencies. Don't want medical to get lazy by popping any ol person with 5% cloning damage with rezadone.
- Access restriction to the kitchen, just to prevent medical from opening these themselves, and stabbing the meat with syringes to extract chems. (last part is just a joke, they'd probably use the chemmaster)