### PR TITLE
makes vermicetol more potent.

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine_vr.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine_vr.dm
@@ -73,4 +73,4 @@
 
 /datum/reagent/vermicetol/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	if(alien != IS_DIONA)
-		M.heal_organ_damage(0, 110 * removed) //Not as potent as ketolade, but lasts LONG.
+		M.heal_organ_damage(0, 110 * removed) //Not as potent as Kelotane, but lasts LONG.

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine_vr.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine_vr.dm
@@ -73,4 +73,4 @@
 
 /datum/reagent/vermicetol/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	if(alien != IS_DIONA)
-		M.heal_organ_damage(0, 21 * removed) //more potent than keloderm
+		M.heal_organ_damage(0, 110 * removed) //Not as potent as ketolade, but lasts LONG.


### PR DESCRIPTION
Seeing as I disregarded the effect of metabolism, vermicetol was unintentionally weak. So incredibly slow that the effect was barely noticable.

The potency now should cause vermicetol to heal at a rate of 2.2. which is roughly 63% lower than ketolade, but lasts a whole lot longer.