### PR TITLE
Remove several admin verbs from context menu

### DIFF
--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -1372,7 +1372,7 @@ var/datum/announcement/minor/admin_min_announcer = new
 	set category = "Debug"
 	set name = "Set Telecrystals"
 	set desc = "Allows admins to change telecrystals of a user."
-
+	set popup_menu = FALSE //VOREStation Edit - Declutter.
 	var/crystals
 
 	if(check_rights(R_ADMIN))
@@ -1388,7 +1388,7 @@ var/datum/announcement/minor/admin_min_announcer = new
 	set category = "Debug"
 	set name = "Add Telecrystals"
 	set desc = "Allows admins to change telecrystals of a user by addition."
-
+	set popup_menu = FALSE //VOREStation Edit - Declutter.
 	var/crystals
 
 	if(check_rights(R_ADMIN))

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -731,6 +731,7 @@ var/list/admin_verbs_event_manager = list(
 	set category = "Debug"
 	set name = "Give Modifier"
 	set desc = "Makes a mob weaker or stronger by adding a specific modifier to them."
+	set popup_menu = FALSE //VOREStation Edit - Declutter.
 
 	if(!L)
 		to_chat(usr, "<span class='warning'>Looks like you didn't select a mob.</span>")
@@ -1051,6 +1052,7 @@ var/list/admin_verbs_event_manager = list(
 	set category = "Fun"
 	set name = "Man Up"
 	set desc = "Tells mob to man up and deal with it."
+	set popup_menu = FALSE //VOREStation Edit - Declutter.
 
 	if(alert("Are you sure you want to tell them to man up?","Confirmation","Deal with it","No")=="No") return
 

--- a/code/modules/admin/verbs/adminjump.dm
+++ b/code/modules/admin/verbs/adminjump.dm
@@ -39,7 +39,7 @@
 /client/proc/jumptomob(var/mob/M in mob_list)
 	set category = "Admin"
 	set name = "Jump to Mob"
-
+	set popup_menu = FALSE //VOREStation Edit - Declutter.
 	if(!check_rights(R_ADMIN|R_MOD|R_DEBUG))
 		return
 

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -758,6 +758,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 /client/proc/cmd_admin_check_contents(mob/living/M as mob in mob_list)
 	set category = "Special Verbs"
 	set name = "Check Contents"
+	set popup_menu = FALSE //VOREStation Edit - Declutter.
 
 	var/list/L = M.get_contents()
 	for(var/t in L)

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -390,7 +390,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	set category = "Ghost"
 	set name = "Jump to Mob"
 	set desc = "Teleport to a mob"
-
+	set popup_menu = FALSE //VOREStation Edit - Declutter.
 	if(istype(usr, /mob/observer/dead)) //Make sure they're an observer!
 
 		if (!target)//Make sure we actually have a target


### PR DESCRIPTION
Mostly because they're so rarely used. Like how often have you needed to give/set telecrystals on this server? ;v
* Add telecrystals
* Set telecrystals
* Man up
* Give modifier
* Jump to mob
* Check contents