### PR TITLE
Adds grubs to the dangerous predator crate.

### DIFF
--- a/code/game/objects/structures/crates_lockers/largecrate_vr.dm
+++ b/code/game/objects/structures/crates_lockers/largecrate_vr.dm
@@ -54,6 +54,8 @@
 						/mob/living/simple_animal/hostile/bear/brown;0.5,
 						/mob/living/simple_animal/hostile/carp,
 						/mob/living/simple_animal/hostile/mimic,
+						/mob/living/simple_animal/retaliate/solargrub;0.5,
+						/mob/living/simple_animal/hostile/solargrubknight,
 						/mob/living/simple_animal/otie;0.5)
 	..()
 


### PR DESCRIPTION
In order to avoid over-saturating the chance of grubs coming out of these, default solargrubs spawn half as frequent as knights.

- DO NOT MERGE BEFORE #2968 is merged.