### PR TITLE
Limits grub spawning areas.

### DIFF
--- a/code/modules/events/grubinfestation_vr.dm
+++ b/code/modules/events/grubinfestation_vr.dm
@@ -13,9 +13,13 @@
 
 
 /datum/event/grub_infestation/start()
+	var/list/blacklist
+	blacklist = list(/area/crew_quarters/sleep, /area/security/armory/red, /area/teleporter
+	, /area/ai/foyer, /area/ai_upload, /area/ai_upload_foyer, /area/ai_server_room, /area/medical/virology
+	, /area/medical/virologyaccess, /area/medical/virologyisolation, /area/tether/surfacebase/shuttle_pad)
 	var/list/vents = list()
 	for(var/obj/machinery/atmospherics/unary/vent_pump/temp_vent in machines)
-		if(istype(get_area(temp_vent), /area/crew_quarters/sleep, /area/security/armory/red, /area/teleporter, /area/ai/foyer, /area/medical/virology))
+		if(istype(get_area(temp_vent), blacklist))
 			continue
 		if(!temp_vent.welded && temp_vent.network && temp_vent.loc.z in using_map.station_levels)
 			if(temp_vent.network.normal_members.len > 50)

--- a/code/modules/events/grubinfestation_vr.dm
+++ b/code/modules/events/grubinfestation_vr.dm
@@ -15,8 +15,7 @@
 /datum/event/grub_infestation/start()
 	var/list/vents = list()
 	for(var/obj/machinery/atmospherics/unary/vent_pump/temp_vent in machines)
-		if(istype(get_area(temp_vent), /area/crew_quarters/sleep, /area/security/armory/red,
-		/area/teleporter, /area/ai/foyer, /area/medical/virology))
+		if(istype(get_area(temp_vent), /area/crew_quarters/sleep, /area/security/armory/red, /area/teleporter, /area/ai/foyer, /area/medical/virology))
 			continue
 		if(!temp_vent.welded && temp_vent.network && temp_vent.loc.z in using_map.station_levels)
 			if(temp_vent.network.normal_members.len > 50)

--- a/code/modules/events/grubinfestation_vr.dm
+++ b/code/modules/events/grubinfestation_vr.dm
@@ -13,8 +13,7 @@
 
 
 /datum/event/grub_infestation/start()
-	var/list/blacklist
-	blacklist = list(/area/crew_quarters/sleep, /area/security/armory/red, /area/teleporter
+	var/list/blacklist = list(/area/crew_quarters/sleep, /area/security/armory/red, /area/teleporter
 	, /area/ai/foyer, /area/ai_upload, /area/ai_upload_foyer, /area/ai_server_room, /area/medical/virology
 	, /area/medical/virologyaccess, /area/medical/virologyisolation, /area/tether/surfacebase/shuttle_pad)
 	var/list/vents = list()

--- a/code/modules/events/grubinfestation_vr.dm
+++ b/code/modules/events/grubinfestation_vr.dm
@@ -15,7 +15,8 @@
 /datum/event/grub_infestation/start()
 	var/list/vents = list()
 	for(var/obj/machinery/atmospherics/unary/vent_pump/temp_vent in machines)
-		if(istype(get_area(temp_vent), /area/crew_quarters/sleep))
+		if(istype(get_area(temp_vent), /area/crew_quarters/sleep, /area/crew_quarters/captain, /area/security/armory/red,
+		/area/teleporter, /area/ai/foyer, /area/medical/virology))
 			continue
 		if(!temp_vent.welded && temp_vent.network && temp_vent.loc.z in using_map.station_levels)
 			if(temp_vent.network.normal_members.len > 50)

--- a/code/modules/events/grubinfestation_vr.dm
+++ b/code/modules/events/grubinfestation_vr.dm
@@ -15,7 +15,7 @@
 /datum/event/grub_infestation/start()
 	var/list/vents = list()
 	for(var/obj/machinery/atmospherics/unary/vent_pump/temp_vent in machines)
-		if(istype(get_area(temp_vent), /area/crew_quarters/sleep, /area/crew_quarters/captain, /area/security/armory/red,
+		if(istype(get_area(temp_vent), /area/crew_quarters/sleep, /area/security/armory/red,
 		/area/teleporter, /area/ai/foyer, /area/medical/virology))
 			continue
 		if(!temp_vent.welded && temp_vent.network && temp_vent.loc.z in using_map.station_levels)


### PR DESCRIPTION
Prevents grubs from spawning in additional locations, to make hunting them down less tedious.
- teleporter room. (far from halls, hard to hear sparks.)
- Captains quarters. (counter-intuitive, many doors!)
- red armory (Tedious to break into)
- Virology (Bolted doors why)
- AI core (Other than where turrets spawn, counter-intuitive, need high access, isolated)