### PR TITLE
Some more gurgle related fixes and tweaks.

### DIFF
--- a/code/modules/mob/living/silicon/robot/dogborg/dog_sleeper_vr.dm
+++ b/code/modules/mob/living/silicon/robot/dogborg/dog_sleeper_vr.dm
@@ -77,7 +77,7 @@
 			if(do_after(user, 30, trashman) && !patient && !trashman.buckled && length(contents) < max_item_count)
 				trashman.forceMove(src)
 				trashman.reset_view(src)
-				processing_objects.Add(src)
+				processing_objects |= src
 				user.visible_message("<span class='warning'>[hound.name]'s internal analyzer groans lightly as [trashman] slips inside.</span>", "<span class='notice'>Your internal analyzer groans lightly as [trashman] slips inside.</span>")
 				playsound(hound, 'sound/vore/gulp.ogg', 80, 1)
 				update_patient()
@@ -127,7 +127,7 @@
 			if(do_after(user, 30, trashman) && !patient && !trashman.buckled && length(contents) < max_item_count)
 				trashman.forceMove(src)
 				trashman.reset_view(src)
-				processing_objects.Add(src)
+				processing_objects |= src
 				user.visible_message("<span class='warning'>[hound.name]'s garbage processor groans lightly as [trashman] slips inside.</span>", "<span class='notice'>Your garbage compactor groans lightly as [trashman] slips inside.</span>")
 				playsound(hound, 'sound/vore/gulp.ogg', 80, 1)
 				update_patient()
@@ -154,7 +154,7 @@
 				H.forceMove(src)
 				H.reset_view(src)
 				update_patient()
-				processing_objects.Add(src)
+				processing_objects |= src
 				user.visible_message("<span class='warning'>[hound.name]'s medical pod lights up as [H.name] slips inside into their [src.name].</span>", "<span class='notice'>Your medical pod lights up as [H] slips into your [src]. Life support functions engaged.</span>")
 				message_admins("[key_name(hound)] has eaten [key_name(patient)] as a dogborg. ([hound ? "<a href='?_src_=holder;adminplayerobservecoodjump=1;X=[hound.x];Y=[hound.y];Z=[hound.z]'>JMP</a>" : "null"])")
 				playsound(hound, 'sound/vore/gulp.ogg', 80, 1)
@@ -317,7 +317,7 @@
 				else
 					cleaning = 1
 					drain(startdrain)
-					processing_objects.Add(src)
+					processing_objects |= src
 					update_patient()
 					sleeperUI(usr)
 					if(patient)

--- a/code/modules/vore/eating/belly_vr.dm
+++ b/code/modules/vore/eating/belly_vr.dm
@@ -489,9 +489,6 @@
 		return
 	internal_contents -= content
 	target.internal_contents += content
-	if(content in items_preserved)
-		items_preserved -= content
-		target.items_preserved += content
 	if(isliving(content))
 		var/mob/living/M = content
 		if(target.inside_flavor)

--- a/code/modules/vore/eating/living_vr.dm
+++ b/code/modules/vore/eating/living_vr.dm
@@ -605,6 +605,7 @@
 		var/datum/belly/selected = vore_organs[belly]
 		I.forceMove(src)
 		selected.internal_contents |= I
+		updateVRPanel()
 		if(istype(I,/obj/item/device/flashlight/flare) || istype(I,/obj/item/weapon/flame/match) || istype(I,/obj/item/weapon/storage/box/matches))
 			to_chat(src, "<span class='notice'>You can taste the flavor of spicy cardboard.</span>")
 		else if(istype(I,/obj/item/device/flashlight/glowstick))


### PR DESCRIPTION
-Makes trash gains more consistent. Basically everything else is more or less 1/10 ratio between nutrition and borg cell charge and now this is too.
-Removes gut transfers passing along the preserved items list. (redundant with modern digest_act)
-Fixes borg sleeper gurgles causing double, maybe even triple damage due to being added to processing_objects list multiple times.
-Adds vore panel update to trash eating.