### PR TITLE
Makes the typing indicator work as it previously did.

### DIFF
--- a/code/modules/mob/typing_indicator.dm
+++ b/code/modules/mob/typing_indicator.dm
@@ -1,4 +1,4 @@
-#define TYPING_INDICATOR_LIFETIME 30 * 10	//grace period after which typing indicator disappears regardless of text in chatbar
+#define TYPING_INDICATOR_LIFETIME 30 * 1000	//grace period after which typing indicator disappears regardless of text in chatbar //VOREStation Edit. Changed so people can use it to show if they're typing a /me.
 
 mob/var/hud_typing = 0 //set when typing in an input window instead of chatline
 mob/var/typing


### PR DESCRIPTION
It suddenly started functioning properly (see: Disappearing in 30 seconds) which made it so it was practically useless to show that you're typing up a /me, which is what it was used for prior.

This makes it so it doesn't just suddenly disappear after an obscenely short amount of time, simply lasting until you send a message/close the window.