### PR TITLE
Fixes colorblindness disabling HUDs

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/negative.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/negative.dm
@@ -111,6 +111,8 @@
 	..(S,H)
 	if(!H.plane_holder)
 		H.plane_holder = new(H)
+	if(!H.vis_enabled)
+		H.vis_enabled = list()
 	H.plane_holder.set_vis(VIS_D_COLORBLIND,TRUE) //The default is monocrhomia, no need to set values
 
 /datum/trait/colorblind/para_vulp


### PR DESCRIPTION
->Thing that updates hud visuals requires vis_enabled list in the mob to work.
->The thing that creates the vis_enabled list in the first place is in mob login proc.
->The forementioned list is only created alongside the mob's plane_holder if the mob getting logged in lacks plane_holder.
->The trait created plane_holder for the mob on spawn, skipping the forementioned login proc.
->Fixed the thing by making the trait also create the vis_enabled list while at it.

![kuva](https://user-images.githubusercontent.com/13697337/35975328-05020680-0ce5-11e8-97e8-eb5f20c0498e.png)
