### PR TITLE
Silver-ContrabandUpdate

### DIFF
--- a/code/datums/supplypacks/contraband_vr.dm
+++ b/code/datums/supplypacks/contraband_vr.dm
@@ -6,14 +6,16 @@
 	containername = "Stolen crate"
 	contraband = 1
 
-/datum/supply_packs/supply/awoo
+/datum/supply_packs/supply/wolfgirl
 	name = "Wolfgirl Crate"
 	cost = 200 //I mean, it's a whole wolfgirl
-	containertype = /obj/structure/largecrate/animal/awoo
+	containertype = /obj/structure/largecrate/animal/wolfgirl
 	containername = "Wolfgirl crate"
+	contraband = 1
 
-/datum/supply_packs/supply/mlem
+/datum/supply_packs/supply/catgirl
 	name = "Catgirl Crate"
 	cost = 200 //I mean, it's a whole catgirl
-	containertype = /obj/structure/largecrate/animal/mlem
+	containertype = /obj/structure/largecrate/animal/catgirl
 	containername = "Catgirl crate"
+	contraband = 1

--- a/code/datums/supplypacks/contraband_vr.dm
+++ b/code/datums/supplypacks/contraband_vr.dm
@@ -5,3 +5,15 @@
 	containertype = /obj/structure/closet/crate
 	containername = "Stolen crate"
 	contraband = 1
+
+/datum/supply_packs/supply/awoo
+	name = "Wolfgirl Crate"
+	cost = 200 //I mean, it's a whole wolfgirl
+	containertype = /obj/structure/largecrate/animal/awoo
+	containername = "Wolfgirl crate"
+
+/datum/supply_packs/supply/mlem
+	name = "Catgirl Crate"
+	cost = 200 //I mean, it's a whole catgirl
+	containertype = /obj/structure/largecrate/animal/mlem
+	containername = "Catgirl crate"

--- a/code/game/objects/structures/crates_lockers/largecrate_vr.dm
+++ b/code/game/objects/structures/crates_lockers/largecrate_vr.dm
@@ -107,3 +107,13 @@
 		icon_state = "otiecrate"
 		taped = 0
 	..()
+
+/obj/structure/largecrate/animal/mlem
+	name = "Catgirl Crate"
+	desc = "A sketchy looking crate that seems to have had most marks and stickers removed. You can almost make out 'genetically-engineered subject'."
+	held_type = /mob/living/simple_animal/catgirl
+
+/obj/structure/largecrate/animal/awoo
+	name = "Wolfgirl Crate"
+	desc = "A sketchy looking crate that shakes and thuds every now and then. Someone seems to be demanding they be let out."
+	held_type = /mob/living/simple_animal/retaliate/awoo

--- a/code/game/objects/structures/crates_lockers/largecrate_vr.dm
+++ b/code/game/objects/structures/crates_lockers/largecrate_vr.dm
@@ -108,12 +108,12 @@
 		taped = 0
 	..()
 
-/obj/structure/largecrate/animal/mlem
+/obj/structure/largecrate/animal/catgirl
 	name = "Catgirl Crate"
-	desc = "A sketchy looking crate that seems to have had most marks and stickers removed. You can almost make out 'genetically-engineered subject'."
+	desc = "A sketchy looking crate with airholes that seems to have had most marks and stickers removed. You can almost make out 'genetically-engineered subject' written on it."
 	held_type = /mob/living/simple_animal/catgirl
 
-/obj/structure/largecrate/animal/awoo
+/obj/structure/largecrate/animal/wolfgirl
 	name = "Wolfgirl Crate"
-	desc = "A sketchy looking crate that shakes and thuds every now and then. Someone seems to be demanding they be let out."
+	desc = "A sketchy looking crate with airholes that shakes and thuds every now and then. Someone seems to be demanding they be let out."
 	held_type = /mob/living/simple_animal/retaliate/awoo


### PR DESCRIPTION
I asked around for thoughts on this, both in #development and to a few headmins directly, but it was kind of hard to get a really get centralized discussion on the matter outside of what people felt about these things, personally, so I figured the worst that could happen is I submit this and we see how it goes.

This adds a Wolfgirl Crate and Catgirl Crate to the Contraband Supplypacks. (These show up under 'supplies' in a hacked cargo console and are quite expensive).

Reason I want to add them is because currently they don't have a whole lot of use outside of admin events, and I feel that's a shame considering that they're fun voremobs and at the very least they seem to be well-received (the catgirls certainly are, at least).

The reason they're in Contraband is because some people voiced concerns over the idea of shipping sentient creatures and the idea that NT would condone this (For the record, Catgirls have a chance to be shipped already in the Dangerous Predator Crate).

My way around that is to posit that NT doesn't condone it. This is human or near-human trafficking and some brave cargo tech needs to save up enough supply points to rescue one poor catgirl or wolfgirl from space pirates who are selling them... Or just buy a slave, if you're an evil monster.