### PR TITLE
Adds explorer alt titles back

### DIFF
--- a/code/game/jobs/job/z_all_jobs_vr.dm
+++ b/code/game/jobs/job/z_all_jobs_vr.dm
@@ -47,3 +47,8 @@
 /datum/job/atmos
 	total_positions = 3
 	spawn_positions = 3
+
+/datum/job/explorer
+	alt_titles = list(
+ 		"Explorer Technician" = /decl/hierarchy/outfit/job/explorer2/technician,
+		"Explorer Medic" = /decl/hierarchy/outfit/job/explorer2/medic)


### PR DESCRIPTION
Got pinged that people that wanted the alt titles back since they got removed for whatever reason.

They each have their own specialized items they spawn with. Nothing too gamechanging, however.
These items can be seen here:
https://github.com/VOREStation/VOREStation/blob/300bcd123f71d3698ced93452699bedc3eb9ea3c/maps/southern_cross/job/outfits.dm#L20-L30

Tech spawns with a full toolbelt. Medic spawns with a first aid kit.

Really nothing major/anything that can't be obtained in ~1 minute.