### PR TITLE
Mob spawner hotfix

### DIFF
--- a/maps/tether/submaps/_tether_submaps.dm
+++ b/maps/tether/submaps/_tether_submaps.dm
@@ -193,7 +193,7 @@
 	if(my_mob && my_mob.stat != DEAD)
 		return //No need
 
-	if(LAZYLEN(human_mobs(world.view)))
+	if(LAZYLEN(loc.human_mobs(world.view)))
 		return //I'll wait.
 
 	if(prob(prob_spawn))


### PR DESCRIPTION
They're not supposed to spawn when humans are nearby, but the proc that they use, `human_mobs()`, checks if any humans in range can see the spawner. The spawner is invisible.
This still has some issues but should prevent spawning in plain sight.