### PR TITLE
Fixes belly contents showing up on screen inventory

### DIFF
--- a/code/modules/vore/eating/belly_vr.dm
+++ b/code/modules/vore/eating/belly_vr.dm
@@ -186,6 +186,9 @@
 	if(inside_flavor)
 		prey << "<span class='notice'><B>[inside_flavor]</B></span>"
 
+	for(var/obj/item/weapon/storage/S in prey)
+		S.hide_from(owner)
+
 // Get the line that should show up in Examine message if the owner of this belly
 // is examined.   By making this a proc, we not only take advantage of polymorphism,
 // but can easily make the message vary based on how many people are inside, etc.

--- a/code/modules/vore/eating/digest_act_vr.dm
+++ b/code/modules/vore/eating/digest_act_vr.dm
@@ -92,6 +92,11 @@
 	if((. = ..()))
 		. += 70 //Organs give a little more
 
+/obj/item/weapon/storage/digest_act(var/list/internal_contents = null, var/atom/movable/item_storage = null)
+	for(var/obj/item/I in contents)
+		I.screen_loc = null
+	.=..()
+
 /////////////
 // Some more complicated stuff
 /////////////

--- a/code/modules/vore/eating/living_vr.dm
+++ b/code/modules/vore/eating/living_vr.dm
@@ -599,10 +599,10 @@
 		to_chat(src, "<span class='notice'>You are not holding anything.</span>")
 		return
 	if(is_type_in_list(I,edible_trash))
-		playsound(src.loc,'sound/vore/gulp.ogg', 20, 1)
 		drop_item()
 		var/belly = vore_selected
 		var/datum/belly/selected = vore_organs[belly]
+		playsound(src.loc, selected.vore_sound, 20, 1)
 		I.forceMove(src)
 		selected.internal_contents |= I
 		updateVRPanel()


### PR DESCRIPTION
-Fixes prey backpack contents popping up on pred's screen after getting dumped.
-Adds an automatic closing of prey's storage for pred upon ingestion to prevent "secret backpacks"
-Also makes trash vorings use selected belly sound while at it.

Fixes #2120