### PR TITLE
Adds newspapering, fixes mob digestion toggle, and other tweaks

### DIFF
--- a/code/modules/mob/living/simple_animal/animals/cat_vr.dm
+++ b/code/modules/mob/living/simple_animal/animals/cat_vr.dm
@@ -1,38 +1,39 @@
-/mob/living/simple_animal/cat/fluff/Runtime/New()
-
-	if(!vore_organs.len)
-		var/datum/belly/B = new /datum/belly(src)
-		B.immutable = 1
-		B.name = "Stomach"
-		B.inside_flavor = "The slimy wet insides of Runtime! Not quite as clean as the cat on the outside."
-		B.human_prey_swallow_time = swallowTime
-		B.nonhuman_prey_swallow_time = swallowTime
-		vore_organs[B.name] = B
-		vore_selected = B.name
-
-		B.emote_lists[DM_HOLD] = list(
-			"Runtime's stomach kneads gently on you and you're fairly sure you can hear her start purring.",
-			"Most of what you can hear are slick noises, Runtime breathing, and distant purring.",
-			"Runtime seems perfectly happy to have you in there. She lays down for a moment to groom and squishes you against the walls.",
-			"The CMO's pet seems to have found a patient of her own, and is treating them with warm, wet kneading walls.",
-			"Runtime mostly just lazes about, and you're left to simmer in the hot, slick guts unharmed.",
-			"Runtime's master might let you out of this fleshy prison, eventually. Maybe. Hopefully?")
-
-		B.emote_lists[DM_DIGEST] = list(
-			"Runtime's stomach is treating you rather like a mouse, kneading acids into you with vigor.",
-			"A thick dollop of bellyslime drips from above while the CMO's pet's gut works on churning you up.",
-			"Runtime seems to have decided you're food, based on the acrid air in her guts and the pooling fluids.",
-			"Runtime's stomach tries to claim you, kneading and pressing inwards again and again against your form.",
-			"Runtime flops onto their side for a minute, spilling acids over your form as you remain trapped in them.",
-			"The CMO's pet doesn't seem to think you're any different from any other meal. At least, their stomach doesn't.")
-
-		B.digest_messages_prey = list(
-			"Runtime's stomach slowly melts your body away. Her stomach refuses to give up it's onslaught, continuing until you're nothing more than nutrients for her body to absorb.",
-			"After an agonizing amount of time, Runtime's stomach finally manages to claim you, melting you down and adding you to her stomach.",
-			"Runtime's stomach continues to slowly work away at your body before tightly squeezing around you once more, causing the remainder of your body to lose form and melt away into the digesting slop around you.",
-			"Runtime's slimy gut continues to constantly squeeze and knead away at your body, the bulge you create inside of her stomach growing smaller as time progresses before soon dissapearing completely as you melt away.",
-			"Runtime's belly lets off a soft groan as your body finally gives out, the cat's eyes growing heavy as it settles down to enjoy it's good meal.",
-			"Runtime purrs happily as you slowly slip away inside of her gut, your body's nutrients are then used to put a layer of padding on the now pudgy cat.",
-			"The acids inside of Runtime's stomach, aided by the constant motions of the smooth walls surrounding you finally manage to melt you away into nothing more mush. She curls up on the floor, slowly kneading the air as her stomach moves its contents — including you — deeper into her digestive system.",
-			"Your form begins to slowly soften and break apart, rounding out Runtime's swollen belly. The carnivorous cat rumbles and purrs happily at the feeling of such a filling meal.")
+/mob/living/simple_animal/cat/fluff/Runtime/init_belly()
 	..()
+	var/datum/belly/B = vore_organs[vore_selected]
+	B.name = "Stomach"
+	B.inside_flavor = "The slimy wet insides of Runtime! Not quite as clean as the cat on the outside."
+
+	B.emote_lists[DM_HOLD] = list(
+		"Runtime's stomach kneads gently on you and you're fairly sure you can hear her start purring.",
+		"Most of what you can hear are slick noises, Runtime breathing, and distant purring.",
+		"Runtime seems perfectly happy to have you in there. She lays down for a moment to groom and squishes you against the walls.",
+		"The CMO's pet seems to have found a patient of her own, and is treating them with warm, wet kneading walls.",
+		"Runtime mostly just lazes about, and you're left to simmer in the hot, slick guts unharmed.",
+		"Runtime's master might let you out of this fleshy prison, eventually. Maybe. Hopefully?")
+
+	B.emote_lists[DM_DIGEST] = list(
+		"Runtime's stomach is treating you rather like a mouse, kneading acids into you with vigor.",
+		"A thick dollop of bellyslime drips from above while the CMO's pet's gut works on churning you up.",
+		"Runtime seems to have decided you're food, based on the acrid air in her guts and the pooling fluids.",
+		"Runtime's stomach tries to claim you, kneading and pressing inwards again and again against your form.",
+		"Runtime flops onto their side for a minute, spilling acids over your form as you remain trapped in them.",
+		"The CMO's pet doesn't seem to think you're any different from any other meal. At least, their stomach doesn't.")
+
+	B.emote_lists[DM_ITEMWEAK] = list(
+		"Runtime's stomach is treating you rather like a mouse, kneading acids into you with vigor.",
+		"A thick dollop of bellyslime drips from above while the CMO's pet's gut works on churning you up.",
+		"Runtime seems to have decided you're food, based on the acrid air in her guts and the pooling fluids.",
+		"Runtime's stomach tries to claim you, kneading and pressing inwards again and again against your form.",
+		"Runtime flops onto their side for a minute, spilling acids over your form as you remain trapped in them.",
+		"The CMO's pet doesn't seem to think you're any different from any other meal. At least, their stomach doesn't.")
+
+	B.digest_messages_prey = list(
+		"Runtime's stomach slowly melts your body away. Her stomach refuses to give up it's onslaught, continuing until you're nothing more than nutrients for her body to absorb.",
+		"After an agonizing amount of time, Runtime's stomach finally manages to claim you, melting you down and adding you to her stomach.",
+		"Runtime's stomach continues to slowly work away at your body before tightly squeezing around you once more, causing the remainder of your body to lose form and melt away into the digesting slop around you.",
+		"Runtime's slimy gut continues to constantly squeeze and knead away at your body, the bulge you create inside of her stomach growing smaller as time progresses before soon dissapearing completely as you melt away.",
+		"Runtime's belly lets off a soft groan as your body finally gives out, the cat's eyes growing heavy as it settles down to enjoy it's good meal.",
+		"Runtime purrs happily as you slowly slip away inside of her gut, your body's nutrients are then used to put a layer of padding on the now pudgy cat.",
+		"The acids inside of Runtime's stomach, aided by the constant motions of the smooth walls surrounding you finally manage to melt you away into nothing more mush. She curls up on the floor, slowly kneading the air as her stomach moves its contents — including you — deeper into her digestive system.",
+		"Your form begins to slowly soften and break apart, rounding out Runtime's swollen belly. The carnivorous cat rumbles and purrs happily at the feeling of such a filling meal.")

--- a/code/modules/mob/living/simple_animal/animals/fox_vr.dm
+++ b/code/modules/mob/living/simple_animal/animals/fox_vr.dm
@@ -39,33 +39,35 @@
 	var/turns_since_scan = 0
 	var/mob/flee_target
 
-/mob/living/simple_animal/fox/New()
-	if(!vore_organs.len)
-		var/datum/belly/B = new /datum/belly(src)
-		B.immutable = 1
-		B.name = "Stomach"
-		B.inside_flavor = "Slick foxguts. Cute on the outside, slimy on the inside!"
-		B.human_prey_swallow_time = swallowTime
-		B.nonhuman_prey_swallow_time = swallowTime
-		vore_organs[B.name] = B
-		vore_selected = B.name
-
-		B.emote_lists[DM_HOLD] = list(
-			"The foxguts knead and churn around you harmlessly.",
-			"With a loud glorp, some air shifts inside the belly.",
-			"A thick drop of warm bellyslime drips onto you from above.",
-			"The fox turns suddenly, causing you to shift a little.",
-			"During a moment of relative silence, you can hear the fox breathing.",
-			"The slimey stomach walls squeeze you lightly, then relax.")
-
-		B.emote_lists[DM_DIGEST] = list(
-			"The guts knead at you, trying to work you into thick soup.",
-			"You're ground on by the slimey walls, treated like a mouse.",
-			"The acrid air is hard to breathe, and stings at your lungs.",
-			"You can feel the acids coating you, ground in by the slick walls.",
-			"The fox's stomach churns hungrily over your form, trying to take you.",
-			"With a loud glorp, the stomach spills more acids onto you.")
+/mob/living/simple_animal/fox/init_belly()
 	..()
+	var/datum/belly/B = vore_organs[vore_selected]
+	B.name = "Stomach"
+	B.inside_flavor = "Slick foxguts. Cute on the outside, slimy on the inside!"
+
+	B.emote_lists[DM_HOLD] = list(
+		"The foxguts knead and churn around you harmlessly.",
+		"With a loud glorp, some air shifts inside the belly.",
+		"A thick drop of warm bellyslime drips onto you from above.",
+		"The fox turns suddenly, causing you to shift a little.",
+		"During a moment of relative silence, you can hear the fox breathing.",
+		"The slimey stomach walls squeeze you lightly, then relax.")
+
+	B.emote_lists[DM_DIGEST] = list(
+		"The guts knead at you, trying to work you into thick soup.",
+		"You're ground on by the slimey walls, treated like a mouse.",
+		"The acrid air is hard to breathe, and stings at your lungs.",
+		"You can feel the acids coating you, ground in by the slick walls.",
+		"The fox's stomach churns hungrily over your form, trying to take you.",
+		"With a loud glorp, the stomach spills more acids onto you.")
+
+	B.emote_lists[DM_ITEMWEAK] = list(
+		"The guts knead at you, trying to work you into thick soup.",
+		"You're ground on by the slimey walls, treated like a mouse.",
+		"The acrid air is hard to breathe, and stings at your lungs.",
+		"You can feel the acids coating you, ground in by the slick walls.",
+		"The fox's stomach churns hungrily over your form, trying to take you.",
+		"With a loud glorp, the stomach spills more acids onto you.")
 
 // All them complicated fox procedures.
 /mob/living/simple_animal/fox/Life()
@@ -184,34 +186,35 @@
 	desc = "Renault, the Colony Director's trustworthy fox. I wonder what it says?"
 	befriend_job = "Colony Director"
 
-/mob/living/simple_animal/fox/fluff/Renault/New()
-	if(!vore_organs.len)
-		var/datum/belly/B = new /datum/belly(src)
-		B.immutable = 1
-		B.name = "Stomach"
-		B.inside_flavor = "Slick foxguts. They seem somehow more regal than perhaps other foxes!"
-		B.human_prey_swallow_time = swallowTime
-		B.nonhuman_prey_swallow_time = swallowTime
-		vore_organs[B.name] = B
-		vore_selected = B.name
-
-		B.emote_lists[DM_HOLD] = list(
-			"Renault's stomach walls squeeze around you more tightly for a moment, before relaxing, as if testing you a bit.",
-			"There's a sudden squeezing as Renault presses a forepaw against his gut over you, squeezng you against the slick walls.",
-			"The 'head fox' has a stomach that seems to think you belong to it. It might be hard to argue, as it kneads at your form.",
-			"If being in the captain's fox is a promotion, it might not feel like one. The belly just coats you with more thick foxslime.",
-			"It doesn't seem like Renault wants to let you out. The stomach and owner possessively squeeze around you.",
-			"Renault's stomach walls squeeze closer, as he belches quietly, before swallowing more air. Does he do that on purpose?")
-
-		B.emote_lists[DM_DIGEST] = list(
-			"Renault's stomach walls grind hungrily inwards, kneading acids against your form, and treating you like any other food.",
-			"The captain's fox impatiently kneads and works acids against you, trying to claim your body for fuel.",
-			"The walls knead in firmly, squeezing and tossing you around briefly in disorienting aggression.",
-			"Renault belches, letting the remaining air grow more acrid. It burns your lungs with each breath.",
-			"A thick glob of acids drip down from above, adding to the pool of caustic fluids in Renault's belly.",
-			"There's a loud gurgle as the stomach declares the intent to make you a part of Renault.")
-
+/mob/living/simple_animal/fox/fluff/Renault/init_belly()
 	..()
+	var/datum/belly/B = vore_organs[vore_selected]
+	B.name = "Stomach"
+	B.inside_flavor = "Slick foxguts. They seem somehow more regal than perhaps other foxes!"
+
+	B.emote_lists[DM_HOLD] = list(
+		"Renault's stomach walls squeeze around you more tightly for a moment, before relaxing, as if testing you a bit.",
+		"There's a sudden squeezing as Renault presses a forepaw against his gut over you, squeezing you against the slick walls.",
+		"The 'head fox' has a stomach that seems to think you belong to it. It might be hard to argue, as it kneads at your form.",
+		"If being in the captain's fox is a promotion, it might not feel like one. The belly just coats you with more thick foxslime.",
+		"It doesn't seem like Renault wants to let you out. The stomach and owner possessively squeeze around you.",
+		"Renault's stomach walls squeeze closer, as he belches quietly, before swallowing more air. Does he do that on purpose?")
+
+	B.emote_lists[DM_DIGEST] = list(
+		"Renault's stomach walls grind hungrily inwards, kneading acids against your form, and treating you like any other food.",
+		"The captain's fox impatiently kneads and works acids against you, trying to claim your body for fuel.",
+		"The walls knead in firmly, squeezing and tossing you around briefly in disorienting aggression.",
+		"Renault belches, letting the remaining air grow more acrid. It burns your lungs with each breath.",
+		"A thick glob of acids drip down from above, adding to the pool of caustic fluids in Renault's belly.",
+		"There's a loud gurgle as the stomach declares the intent to make you a part of Renault.")
+
+	B.emote_lists[DM_ITEMWEAK] = list(
+		"Renault's stomach walls grind hungrily inwards, kneading acids against your form, and treating you like any other food.",
+		"The captain's fox impatiently kneads and works acids against you, trying to claim your body for fuel.",
+		"The walls knead in firmly, squeezing and tossing you around briefly in disorienting aggression.",
+		"Renault belches, letting the remaining air grow more acrid. It burns your lungs with each breath.",
+		"A thick glob of acids drip down from above, adding to the pool of caustic fluids in Renault's belly.",
+		"There's a loud gurgle as the stomach declares the intent to make you a part of Renault.")
 
 /mob/living/simple_animal/fox/syndicate
 	name = "syndi-fox"

--- a/code/modules/mob/living/simple_animal/vore/zz_vore_overrides.dm
+++ b/code/modules/mob/living/simple_animal/vore/zz_vore_overrides.dm
@@ -155,6 +155,20 @@
 		return null
 	return ..()
 
+/mob/living/simple_animal/cat/fluff
+	vore_ignores_undigestable = 0
+	vore_pounce_chance = 100
+	vore_digest_chance = 0 // just use the toggle
+	vore_default_mode = DM_HOLD //can use the toggle if you wanna be catfood
+
+/mob/living/simple_animal/cat/fluff/EatTarget()
+	var/mob/living/TM = target_mob
+	prey_excludes += TM //so they won't immediately re-eat someone who struggles out (or gets newspapered out) as soon as they're ate
+	spawn(3600) // but if they hang around and get comfortable, they might get ate again
+		if(src && TM)
+			prey_excludes -= TM
+	..() // will_eat check is carried out before EatTarget is called, so prey on the prey_excludes list isn't a problem.
+
 /mob/living/simple_animal/fox
 	vore_active = 1
 	// NO VORE SPRITES
@@ -179,6 +193,20 @@
 	if (friend == found_atom)
 		return null
 	return ..()
+
+/mob/living/simple_animal/fox/fluff
+	vore_ignores_undigestable = 0
+	vore_pounce_chance = 100
+	vore_digest_chance = 0 // just use the toggle
+	vore_default_mode = DM_HOLD //can use the toggle if you wanna be foxfood
+
+/mob/living/simple_animal/fox/fluff/EatTarget()
+	var/mob/living/TM = target_mob
+	prey_excludes += TM //so they won't immediately re-eat someone who struggles out (or gets newspapered out) as soon as they're ate
+	spawn(3600) // but if they hang around and get comfortable, they might get ate again
+		if(src && TM)
+			prey_excludes -= TM
+	..() // will_eat check is carried out before EatTarget is called, so prey on the prey_excludes list isn't a problem.
 
 /mob/living/simple_animal/hostile/goose
 	vore_active = 1

--- a/code/modules/vore/eating/bellymodes_vr.dm
+++ b/code/modules/vore/eating/bellymodes_vr.dm
@@ -9,7 +9,8 @@
 		spawn(emoteTime)
 			var/list/EL = emote_lists[digest_mode]
 			for(var/mob/living/M in internal_contents)
-				M << "<span class='notice'>[pick(EL)]</span>"
+				if(M.digestable || !(digest_mode == DM_DIGEST || digest_mode == DM_DIGEST_NUMB || digest_mode == DM_ITEMWEAK)) // don't give digesty messages to indigestible people
+					M << "<span class='notice'>[pick(EL)]</span>"
 			src.emotePend = FALSE
 
 //////////////////////// Absorbed Handling ////////////////////////

--- a/code/modules/vore/eating/simple_animal_vr.dm
+++ b/code/modules/vore/eating/simple_animal_vr.dm
@@ -86,12 +86,16 @@ mob/living/simple_animal/say()
 				animal_nom(user)
 				update_icon()
 				stop_automated_movement = 0
+			else if (!target_mob) // no using this to clear a retaliate mob's target
+				target_mob = user //just because you're not tasty doesn't mean you get off the hook. A swat for a swat.
+				AttackTarget()
+				LoseTarget() // only make one attempt at an attack rather than going into full rage mode
 		else
 			user.visible_message("<span class='info'>\the [user] swats \the [src] with \the [O]!</span>!")
 			for(var/I in vore_organs)
 				var/datum/belly/B = vore_organs[I]
 				B.release_all_contents(include_absorbed = TRUE) // Until we can get a mob version of unsorbitol or whatever, release absorbed too
-			for(var/mob/living/L in range(1)) //add everyone on the tile to the do-not-eat list for a while
+			for(var/mob/living/L in living_mobs(0)) //add everyone on the tile to the do-not-eat list for a while
 				if(!(L in prey_excludes)) // Unless they're already on it, just to avoid fuckery.
 					prey_excludes += L
 					spawn(3600)


### PR DESCRIPTION
- Adds the ability to use NEWSPAPERS on simple animals to get them to cough their prey. Hostile mobs will ignore you, retaliate mobs have some chance of instead disregarding your attempts at discipline and just scarfing you up as well (or hitting you back if you're not tasty). Mobs that eject their prey will not attempt to eat them again for a few minutes.

- Fixes toggle_animal_digestion so you can actually toggle non-hostile, non-retaliate mob digestion again.

- Runtime and Renault init_belly proc has been fixed, as an outdated override was causing the belly to spawn without a bunch of parameters being set (such as escape chance)

- Runtime and Renault no longer digest by default. Use the verb.

- Runtime and Renault will now pounce micros instead of beating the shit out of them, giving you fucking murderhobos even less excuses to kill the damn pets. Upon eating someone, the prey are added to the do-not-eat list for a few minutes so someone who doesn't want to be ate by the pets can spam resist and get out, with time to leave the area without getting pounced again.

- Stops digestion-related belly messages displaying to indigestible prey.

Fixes #2963. Fixes #1130.