### PR TITLE
Adds Search and Rescue and Scientist to loadouts

### DIFF
--- a/code/modules/client/preference_setup/loadout/loadout_accessories.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_accessories.dm
@@ -135,32 +135,38 @@
 /datum/gear/accessory/brown_vest
 	display_name = "webbing, brown"
 	path = /obj/item/clothing/accessory/storage/brown_vest
-	allowed_roles = list("Station Engineer","Atmospheric Technician","Chief Engineer","Security Officer","Detective","Head of Security","Warden","Paramedic","Chief Medical Officer","Medical Doctor")
+	//VOREStation Edit - Adds Search and Rescue to allowed roles
+	allowed_roles = list("Station Engineer","Atmospheric Technician","Chief Engineer","Security Officer","Detective","Head of Security","Warden","Paramedic","Search and Rescue","Chief Medical Officer","Medical Doctor")
 
 /datum/gear/accessory/black_vest
 	display_name = "webbing, black"
 	path = /obj/item/clothing/accessory/storage/black_vest
-	allowed_roles = list("Station Engineer","Atmospheric Technician","Chief Engineer","Security Officer","Detective","Head of Security","Warden","Paramedic","Chief Medical Officer","Medical Doctor")
+	//VOREStation Edit - Adds Search and Rescue to allowed roles
+	allowed_roles = list("Station Engineer","Atmospheric Technician","Chief Engineer","Security Officer","Detective","Head of Security","Warden","Paramedic","Search and Rescue","Chief Medical Officer","Medical Doctor")
 
 /datum/gear/accessory/white_vest
 	display_name = "webbing, white"
 	path = /obj/item/clothing/accessory/storage/white_vest
-	allowed_roles = list("Station Engineer","Atmospheric Technician","Chief Engineer","Security Officer","Detective","Head of Security","Warden","Paramedic","Chief Medical Officer","Medical Doctor")
+	//VOREStation Edit - Adds Search and Rescue to allowed roles
+	allowed_roles = list("Station Engineer","Atmospheric Technician","Chief Engineer","Security Officer","Detective","Head of Security","Warden","Paramedic","Search and Rescue","Chief Medical Officer","Medical Doctor")
 
 /datum/gear/accessory/brown_drop_pouches
 	display_name = "drop pouches, brown"
 	path = /obj/item/clothing/accessory/storage/brown_drop_pouches
-	allowed_roles = list("Station Engineer","Atmospheric Technician","Chief Engineer","Security Officer","Detective","Head of Security","Warden","Paramedic","Chief Medical Officer","Medical Doctor")
+	//VOREStation Edit - Adds Search and Rescue to allowed roles
+	allowed_roles = list("Station Engineer","Atmospheric Technician","Chief Engineer","Security Officer","Detective","Head of Security","Warden","Paramedic","Search and Rescue","Chief Medical Officer","Medical Doctor")
 
 /datum/gear/accessory/black_drop_pouches
 	display_name = "drop pouches, black"
 	path = /obj/item/clothing/accessory/storage/black_drop_pouches
-	allowed_roles = list("Station Engineer","Atmospheric Technician","Chief Engineer","Security Officer","Detective","Head of Security","Warden","Paramedic","Chief Medical Officer","Medical Doctor")
+	//VOREStation Edit - Adds Search and Rescue to allowed roles
+	allowed_roles = list("Station Engineer","Atmospheric Technician","Chief Engineer","Security Officer","Detective","Head of Security","Warden","Paramedic","Search and Rescue","Chief Medical Officer","Medical Doctor")
 
 /datum/gear/accessory/white_drop_pouches
 	display_name = "drop pouches, white"
 	path = /obj/item/clothing/accessory/storage/white_drop_pouches
-	allowed_roles = list("Station Engineer","Atmospheric Technician","Chief Engineer","Security Officer","Detective","Head of Security","Warden","Paramedic","Chief Medical Officer","Medical Doctor")
+	//VOREStation Edit - Adds Search and Rescue to allowed roles
+	allowed_roles = list("Station Engineer","Atmospheric Technician","Chief Engineer","Security Officer","Detective","Head of Security","Warden","Paramedic","Search and Rescue","Chief Medical Officer","Medical Doctor")
 
 /datum/gear/accessory/fannypack
 	display_name = "fannypack selection"
@@ -239,7 +245,8 @@
 /datum/gear/accessory/stethoscope
 	display_name = "stethoscope"
 	path = /obj/item/clothing/accessory/stethoscope
-	allowed_roles = list("Chief Medical Officer","Medical Doctor","Chemist","Psychiatrist","Paramedic")
+	//VOREStation Edit - Adds Search and Rescue to allowed roles
+	allowed_roles = list("Chief Medical Officer","Medical Doctor","Chemist","Psychiatrist","Paramedic","Search and Rescue")
 
 /datum/gear/accessory/locket
 	display_name = "locket"

--- a/code/modules/client/preference_setup/loadout/loadout_accessories_vr.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_accessories_vr.dm
@@ -31,10 +31,10 @@
 	path = /obj/item/clothing/accessory/collar/holo
 
 /datum/gear/accessory/white_drop_pouches
-	allowed_roles = list("Paramedic","Chief Medical Officer","Medical Doctor","Chemist")
+	allowed_roles = list("Paramedic","Search and Rescue","Chief Medical Officer","Medical Doctor","Chemist")
 
 /datum/gear/accessory/white_vest
-	allowed_roles = list("Paramedic","Chief Medical Officer","Medical Doctor","Chemist")
+	allowed_roles = list("Paramedic","Search and Rescue","Chief Medical Officer","Medical Doctor","Chemist")
 
 /datum/gear/accessory/khcrystal
 	display_name = "KH Life Crystal"

--- a/code/modules/client/preference_setup/loadout/loadout_eyes.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_eyes.dm
@@ -57,7 +57,8 @@
 /datum/gear/eyes/medical
 	display_name = "Medical HUD (Medical)"
 	path = /obj/item/clothing/glasses/hud/health
-	allowed_roles = list("Medical Doctor","Chief Medical Officer","Chemist","Paramedic","Geneticist", "Psychiatrist")
+	//VOREStation Edit - Adds Search and Rescue to allowed roles
+	allowed_roles = list("Medical Doctor","Chief Medical Officer","Chemist","Paramedic","Search and Rescue","Geneticist", "Psychiatrist")
 
 /datum/gear/eyes/medical/prescriptionmed
 	display_name = "Medical HUD, prescription (Medical)"

--- a/code/modules/client/preference_setup/loadout/loadout_eyes.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_eyes.dm
@@ -75,7 +75,8 @@
 /datum/gear/eyes/meson
 	display_name = "Optical Meson Scanners (Engineering, Science)"
 	path = /obj/item/clothing/glasses/meson
-	allowed_roles = list("Station Engineer","Chief Engineer","Atmospheric Technician", "Scientist", "Research Director")
+	//VOREStation Edit - Adds Explorer to allowed roles
+	allowed_roles = list("Station Engineer","Chief Engineer","Atmospheric Technician", "Scientist", "Explorer", "Research Director")
 
 /datum/gear/eyes/meson/prescription
 	display_name = "Optical Meson Scanners, prescription (Engineering, Science)"

--- a/code/modules/client/preference_setup/loadout/loadout_shoes.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_shoes.dm
@@ -203,7 +203,8 @@
 /datum/gear/shoes/boots/winter/medical
 	display_name = "medical winter boots"
 	path = /obj/item/clothing/shoes/boots/winter/medical
-	allowed_roles = list("Medical Doctor","Chief Medical Officer","Chemist","Paramedic","Geneticist", "Psychiatrist")
+	//VOREStation Edit - Adds Search and Rescue to allowed roles
+	allowed_roles = list("Medical Doctor","Chief Medical Officer","Chemist","Paramedic","Search and Rescue","Geneticist", "Psychiatrist")
 
 /datum/gear/shoes/boots/winter/mining
 	display_name = "mining winter boots"

--- a/code/modules/client/preference_setup/loadout/loadout_shoes.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_shoes.dm
@@ -183,7 +183,8 @@
 /datum/gear/shoes/boots/winter/science
 	display_name = "science winter boots"
 	path = /obj/item/clothing/shoes/boots/winter/science
-	allowed_roles = list("Research Director","Scientist", "Roboticist", "Xenobiologist")
+	//VOREStation Edit - Adds Explorer to allowed roles
+	allowed_roles = list("Research Director","Scientist", "Explorer", "Roboticist", "Xenobiologist")
 
 /datum/gear/shoes/boots/winter/command
 	display_name = "colony director's winter boots"

--- a/code/modules/client/preference_setup/loadout/loadout_suit.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_suit.dm
@@ -153,7 +153,8 @@
 /datum/gear/suit/labcoat/emt
 	display_name = "labcoat, EMT (Medical)"
 	path = /obj/item/clothing/suit/storage/toggle/labcoat/emt
-	allowed_roles = list("Medical Doctor","Chief Medical Officer","Chemist","Paramedic","Geneticist", "Psychiatrist")
+	//VOREStation Edit - Adds Search and Rescue to allowed roles
+	allowed_roles = list("Medical Doctor","Chief Medical Officer","Chemist","Paramedic","Search and Rescue","Geneticist", "Psychiatrist")
 
 /datum/gear/suit/roles/surgical_apron
 	display_name = "surgical apron"
@@ -186,7 +187,8 @@
 /datum/gear/suit/roles/poncho/medical
 	display_name = "poncho, medical"
 	path = /obj/item/clothing/accessory/poncho/roles/medical
-	allowed_roles = list("Medical Doctor","Chief Medical Officer","Chemist","Paramedic","Geneticist", "Psychiatrist")
+	//VOREStation Edit - Adds Search and Rescue to allowed roles
+	allowed_roles = list("Medical Doctor","Chief Medical Officer","Chemist","Paramedic","Search and Rescue","Geneticist", "Psychiatrist")
 
 /datum/gear/suit/roles/poncho/engineering
 	display_name = "poncho, engineering"
@@ -296,7 +298,8 @@
 /datum/gear/suit/wintercoat/medical
 	display_name = "winter coat, medical"
 	path = /obj/item/clothing/suit/storage/hooded/wintercoat/medical
-	allowed_roles = list("Medical Doctor","Chief Medical Officer","Chemist","Paramedic","Geneticist", "Psychiatrist")
+	//VOREStation Edit - Adds Search and Rescue to allowed roles
+	allowed_roles = list("Medical Doctor","Chief Medical Officer","Chemist","Paramedic","Search and Rescue","Geneticist", "Psychiatrist")
 
 /datum/gear/suit/wintercoat/science
 	display_name = "winter coat, science"
@@ -437,7 +440,8 @@
 /datum/gear/suit/snowsuit/medical
 	display_name = "snowsuit, medical"
 	path = /obj/item/clothing/suit/storage/snowsuit/medical
-	allowed_roles = list("Medical Doctor","Chief Medical Officer","Chemist","Paramedic","Geneticist", "Psychiatrist")
+	//VOREStation Edit - Adds Search and Rescue to allowed roles
+	allowed_roles = list("Medical Doctor","Chief Medical Officer","Chemist","Paramedic","Search and Rescue","Geneticist", "Psychiatrist")
 
 /datum/gear/suit/snowsuit/science
 	display_name = "snowsuit, science"

--- a/code/modules/client/preference_setup/loadout/loadout_suit.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_suit.dm
@@ -198,7 +198,8 @@
 /datum/gear/suit/roles/poncho/science
 	display_name = "poncho, science"
 	path = /obj/item/clothing/accessory/poncho/roles/science
-	allowed_roles = list("Research Director","Scientist", "Roboticist", "Xenobiologist")
+	//VOREStation Edit - Adds Explorer to allowed roles
+	allowed_roles = list("Research Director","Scientist", "Explorer", "Roboticist", "Xenobiologist")
 
 /datum/gear/suit/roles/poncho/cargo
 	display_name = "poncho, cargo"
@@ -304,7 +305,8 @@
 /datum/gear/suit/wintercoat/science
 	display_name = "winter coat, science"
 	path = /obj/item/clothing/suit/storage/hooded/wintercoat/science
-	allowed_roles = list("Research Director","Scientist", "Roboticist", "Xenobiologist")
+	//VOREStation Edit - Adds Explorer to allowed roles
+	allowed_roles = list("Research Director","Scientist", "Explorer", "Roboticist", "Xenobiologist")
 
 /datum/gear/suit/wintercoat/engineering
 	display_name = "winter coat, engineering"
@@ -446,7 +448,8 @@
 /datum/gear/suit/snowsuit/science
 	display_name = "snowsuit, science"
 	path = /obj/item/clothing/suit/storage/snowsuit/science
-	allowed_roles = list("Research Director","Scientist", "Roboticist", "Xenobiologist")
+	//VOREStation Edit - Adds Explorer to allowed roles
+	allowed_roles = list("Research Director","Scientist", "Explorer", "Roboticist", "Xenobiologist")
 
 /datum/gear/suit/snowsuit/engineering
 	display_name = "snowsuit, engineering"

--- a/code/modules/client/preference_setup/loadout/loadout_uniform.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_uniform.dm
@@ -134,7 +134,8 @@
 /datum/gear/uniform/job_skirt/sci
 	display_name = "skirt, scientist"
 	path = /obj/item/clothing/under/rank/scientist/skirt
-	allowed_roles = list("Research Director","Scientist", "Xenobiologist")
+	//VOREStation Edit - Adds Explorer to allowed roles
+	allowed_roles = list("Research Director","Scientist", "Explorer", "Xenobiologist")
 
 /datum/gear/uniform/job_skirt/cargo
 	display_name = "skirt, cargo"

--- a/code/modules/client/preference_setup/loadout/loadout_uniform_vr.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_uniform_vr.dm
@@ -31,7 +31,7 @@
 /datum/gear/uniform/job_khi/sci
 	display_name = "khi uniform, sci"
 	path = /obj/item/clothing/under/rank/khi/sci
-	allowed_roles = list("Research Director","Scientist", "Roboticist", "Xenobiologist")
+	allowed_roles = list("Research Director","Scientist", "Explorer", "Roboticist", "Xenobiologist")
 
 //Federation jackets
 /datum/gear/suit/job_fed/sec
@@ -42,7 +42,7 @@
 /datum/gear/suit/job_fed/medsci
 	display_name = "fed uniform, med/sci"
 	path = /obj/item/clothing/suit/storage/fluff/fedcoat/fedblue
-	allowed_roles = list("Chief Medical Officer","Medical Doctor","Chemist","Paramedic","Search and Rescue","Geneticist","Research Director","Scientist", "Roboticist", "Xenobiologist")
+	allowed_roles = list("Chief Medical Officer","Medical Doctor","Chemist","Paramedic","Search and Rescue","Geneticist","Research Director","Scientist", "Explorer", "Roboticist", "Xenobiologist")
 
 /datum/gear/suit/job_fed/eng
 	display_name = "fed uniform, eng"
@@ -59,7 +59,7 @@
 /datum/gear/uniform/job_trek/medsci/tos
 	display_name = "TOS uniform, med/sci"
 	path = /obj/item/clothing/under/rank/trek/medsci
-	allowed_roles = list("Chief Medical Officer","Medical Doctor","Chemist","Paramedic","Search and Rescue","Geneticist","Research Director","Scientist", "Roboticist", "Xenobiologist")
+	allowed_roles = list("Chief Medical Officer","Medical Doctor","Chemist","Paramedic","Search and Rescue","Geneticist","Research Director","Scientist", "Explorer", "Roboticist", "Xenobiologist")
 
 /datum/gear/uniform/job_trek/eng/tos
 	display_name = "TOS uniform, eng/sec"
@@ -75,7 +75,7 @@
 /datum/gear/uniform/job_trek/medsci/tng
 	display_name = "TNG uniform, med/sci"
 	path = /obj/item/clothing/under/rank/trek/medsci/next
-	allowed_roles = list("Chief Medical Officer","Medical Doctor","Chemist","Paramedic","Search and Rescue","Geneticist","Research Director","Scientist", "Roboticist", "Xenobiologist")
+	allowed_roles = list("Chief Medical Officer","Medical Doctor","Chemist","Paramedic","Search and Rescue","Geneticist","Research Director","Scientist", "Explorer", "Roboticist", "Xenobiologist")
 
 /datum/gear/uniform/job_trek/eng/tng
 	display_name = "TNG uniform, eng/sec"
@@ -91,7 +91,7 @@
 /datum/gear/uniform/job_trek/medsci/voy
 	display_name = "VOY uniform, med/sci"
 	path = /obj/item/clothing/under/rank/trek/medsci/voy
-	allowed_roles = list("Chief Medical Officer","Medical Doctor","Chemist","Paramedic","Search and Rescue","Geneticist","Research Director","Scientist", "Roboticist", "Xenobiologist")
+	allowed_roles = list("Chief Medical Officer","Medical Doctor","Chemist","Paramedic","Search and Rescue","Geneticist","Research Director","Scientist", "Explorer", "Roboticist", "Xenobiologist")
 
 /datum/gear/uniform/job_trek/eng/voy
 	display_name = "VOY uniform, eng/sec"
@@ -105,7 +105,7 @@
 	path = /obj/item/clothing/suit/storage/trek/ds9
 	allowed_roles = list("Head of Security","Colony Director","Head of Personnel","Chief Engineer","Research Director",
 						"Chief Medical Officer","Medical Doctor","Chemist","Paramedic","Search and Rescue","Geneticist",
-						"Scientist","Roboticist","Xenobiologist","Atmospheric Technician",
+						"Scientist", "Explorer","Roboticist","Xenobiologist","Atmospheric Technician",
 						"Station Engineer","Warden","Detective","Security Officer")
 
 
@@ -117,7 +117,7 @@
 /datum/gear/uniform/job_trek/medsci/ds9
 	display_name = "DS9 uniform, med/sci"
 	path = /obj/item/clothing/under/rank/trek/medsci/ds9
-	allowed_roles = list("Chief Medical Officer","Medical Doctor","Chemist","Paramedic","Search and Rescue","Geneticist","Research Director","Scientist", "Roboticist", "Xenobiologist")
+	allowed_roles = list("Chief Medical Officer","Medical Doctor","Chemist","Paramedic","Search and Rescue","Geneticist","Research Director","Scientist", "Explorer", "Roboticist", "Xenobiologist")
 
 /datum/gear/uniform/job_trek/eng/ds9
 	display_name = "DS9 uniform, eng/sec"
@@ -134,7 +134,7 @@
 /datum/gear/uniform/job_trek/medsci/ent
 	display_name = "ENT uniform, med/sci"
 	path = /obj/item/clothing/under/rank/trek/medsci/ent
-	allowed_roles = list("Chief Medical Officer","Medical Doctor","Chemist","Paramedic","Search and Rescue","Geneticist","Research Director","Scientist", "Roboticist", "Xenobiologist")
+	allowed_roles = list("Chief Medical Officer","Medical Doctor","Chemist","Paramedic","Search and Rescue","Geneticist","Research Director","Scientist", "Explorer", "Roboticist", "Xenobiologist")
 
 /datum/gear/uniform/job_trek/eng/ent
 	display_name = "ENT uniform, eng/sec"

--- a/code/modules/client/preference_setup/loadout/loadout_uniform_vr.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_uniform_vr.dm
@@ -21,7 +21,7 @@
 /datum/gear/uniform/job_khi/med
 	display_name = "khi uniform, med"
 	path = /obj/item/clothing/under/rank/khi/med
-	allowed_roles = list("Chief Medical Officer","Medical Doctor","Chemist","Paramedic","Geneticist")
+	allowed_roles = list("Chief Medical Officer","Medical Doctor","Chemist","Paramedic","Search and Rescue","Geneticist")
 
 /datum/gear/uniform/job_khi/eng
 	display_name = "khi uniform, eng"
@@ -42,7 +42,7 @@
 /datum/gear/suit/job_fed/medsci
 	display_name = "fed uniform, med/sci"
 	path = /obj/item/clothing/suit/storage/fluff/fedcoat/fedblue
-	allowed_roles = list("Chief Medical Officer","Medical Doctor","Chemist","Paramedic","Geneticist","Research Director","Scientist", "Roboticist", "Xenobiologist")
+	allowed_roles = list("Chief Medical Officer","Medical Doctor","Chemist","Paramedic","Search and Rescue","Geneticist","Research Director","Scientist", "Roboticist", "Xenobiologist")
 
 /datum/gear/suit/job_fed/eng
 	display_name = "fed uniform, eng"
@@ -59,7 +59,7 @@
 /datum/gear/uniform/job_trek/medsci/tos
 	display_name = "TOS uniform, med/sci"
 	path = /obj/item/clothing/under/rank/trek/medsci
-	allowed_roles = list("Chief Medical Officer","Medical Doctor","Chemist","Paramedic","Geneticist","Research Director","Scientist", "Roboticist", "Xenobiologist")
+	allowed_roles = list("Chief Medical Officer","Medical Doctor","Chemist","Paramedic","Search and Rescue","Geneticist","Research Director","Scientist", "Roboticist", "Xenobiologist")
 
 /datum/gear/uniform/job_trek/eng/tos
 	display_name = "TOS uniform, eng/sec"
@@ -75,7 +75,7 @@
 /datum/gear/uniform/job_trek/medsci/tng
 	display_name = "TNG uniform, med/sci"
 	path = /obj/item/clothing/under/rank/trek/medsci/next
-	allowed_roles = list("Chief Medical Officer","Medical Doctor","Chemist","Paramedic","Geneticist","Research Director","Scientist", "Roboticist", "Xenobiologist")
+	allowed_roles = list("Chief Medical Officer","Medical Doctor","Chemist","Paramedic","Search and Rescue","Geneticist","Research Director","Scientist", "Roboticist", "Xenobiologist")
 
 /datum/gear/uniform/job_trek/eng/tng
 	display_name = "TNG uniform, eng/sec"
@@ -91,7 +91,7 @@
 /datum/gear/uniform/job_trek/medsci/voy
 	display_name = "VOY uniform, med/sci"
 	path = /obj/item/clothing/under/rank/trek/medsci/voy
-	allowed_roles = list("Chief Medical Officer","Medical Doctor","Chemist","Paramedic","Geneticist","Research Director","Scientist", "Roboticist", "Xenobiologist")
+	allowed_roles = list("Chief Medical Officer","Medical Doctor","Chemist","Paramedic","Search and Rescue","Geneticist","Research Director","Scientist", "Roboticist", "Xenobiologist")
 
 /datum/gear/uniform/job_trek/eng/voy
 	display_name = "VOY uniform, eng/sec"
@@ -104,7 +104,7 @@
 	display_name = "DS9 Overcoat (use uniform)"
 	path = /obj/item/clothing/suit/storage/trek/ds9
 	allowed_roles = list("Head of Security","Colony Director","Head of Personnel","Chief Engineer","Research Director",
-						"Chief Medical Officer","Medical Doctor","Chemist","Paramedic","Geneticist",
+						"Chief Medical Officer","Medical Doctor","Chemist","Paramedic","Search and Rescue","Geneticist",
 						"Scientist","Roboticist","Xenobiologist","Atmospheric Technician",
 						"Station Engineer","Warden","Detective","Security Officer")
 
@@ -117,7 +117,7 @@
 /datum/gear/uniform/job_trek/medsci/ds9
 	display_name = "DS9 uniform, med/sci"
 	path = /obj/item/clothing/under/rank/trek/medsci/ds9
-	allowed_roles = list("Chief Medical Officer","Medical Doctor","Chemist","Paramedic","Geneticist","Research Director","Scientist", "Roboticist", "Xenobiologist")
+	allowed_roles = list("Chief Medical Officer","Medical Doctor","Chemist","Paramedic","Search and Rescue","Geneticist","Research Director","Scientist", "Roboticist", "Xenobiologist")
 
 /datum/gear/uniform/job_trek/eng/ds9
 	display_name = "DS9 uniform, eng/sec"
@@ -134,7 +134,7 @@
 /datum/gear/uniform/job_trek/medsci/ent
 	display_name = "ENT uniform, med/sci"
 	path = /obj/item/clothing/under/rank/trek/medsci/ent
-	allowed_roles = list("Chief Medical Officer","Medical Doctor","Chemist","Paramedic","Geneticist","Research Director","Scientist", "Roboticist", "Xenobiologist")
+	allowed_roles = list("Chief Medical Officer","Medical Doctor","Chemist","Paramedic","Search and Rescue","Geneticist","Research Director","Scientist", "Roboticist", "Xenobiologist")
 
 /datum/gear/uniform/job_trek/eng/ent
 	display_name = "ENT uniform, eng/sec"

--- a/code/modules/client/preference_setup/loadout/loadout_utility_vr.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_utility_vr.dm
@@ -54,4 +54,4 @@
 /datum/gear/utility/dufflebag/sci
     display_name = "science dufflebag"
     path = /obj/item/weapon/storage/backpack/dufflebag/sci
-    allowed_roles = list("Research Director","Scientist","Roboticist","Xenobiologist","Explorer")
+    allowed_roles = list("Research Director","Scientist", "Explorer","Roboticist","Xenobiologist","Explorer")

--- a/code/modules/client/preference_setup/loadout/loadout_utility_vr.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_utility_vr.dm
@@ -35,7 +35,7 @@
 /datum/gear/utility/dufflebag/med
     display_name = "medical dufflebag"
     path = /obj/item/weapon/storage/backpack/dufflebag/med
-    allowed_roles = list("Medical Doctor","Chief Medical Officer","Chemist","Paramedic","Geneticist","Psychiatrist","Search and Rescue")
+    allowed_roles = list("Medical Doctor","Chief Medical Officer","Chemist","Paramedic","Search and Rescue","Geneticist","Psychiatrist","Search and Rescue")
 
 /datum/gear/utility/dufflebag/med/emt
     display_name = "EMT dufflebag"


### PR DESCRIPTION
This will allow anything a Paramedic could spawn with to also be spawned with by Search and Rescue, fixing #2999. 

It also does the same with Scientist and Explorer, but leaves Pilot untouched because they're only civilian, and not medical or science. 

Now you can finally spawn with drop pouches as an SaR instead of waiting to raid the locker and praying the vest is still there and not given to some explorer! You can also totally wear the Star Trek jumpsuits down on the planets and be a walking reference!