### PR TITLE
Make turf obfuscation lists lazy

### DIFF
--- a/code/modules/mob/freelook/chunk.dm
+++ b/code/modules/mob/freelook/chunk.dm
@@ -100,6 +100,7 @@
 	for(var/turf in visRemoved)
 		var/turf/t = turf
 		if(obscuredTurfs[t])
+			LAZYINITLIST(t.obfuscations)
 			if(!t.obfuscations[obfuscation.type])
 				var/image/ob_image = image(obfuscation.icon, t, obfuscation.icon_state, OBFUSCATION_LAYER)
 				ob_image.plane = PLANE_FULLSCREEN
@@ -141,6 +142,7 @@
 
 	for(var/turf in obscuredTurfs)
 		var/turf/t = turf
+		LAZYINITLIST(t.obfuscations)
 		if(!t.obfuscations[obfuscation.type])
 			var/image/ob_image = image(obfuscation.icon, t, obfuscation.icon_state, OBFUSCATION_LAYER)
 			ob_image.plane = PLANE_FULLSCREEN

--- a/code/modules/mob/freelook/update_triggers.dm
+++ b/code/modules/mob/freelook/update_triggers.dm
@@ -8,7 +8,7 @@
 			VN.updateVisibility(A, opacity_check)
 
 /turf
-	var/list/image/obfuscations = new()
+	var/list/image/obfuscations
 
 /turf/drain_power()
 	return -1


### PR DESCRIPTION
These are for storing the AI static image, but there are hundreds of thousands of turfs that the AI will never look at, and thus this list doesn't need to exist on those unless it needs to.