### PR TITLE
Shadekin set realname when shifting

### DIFF
--- a/code/modules/mob/living/simple_animal/vore/shadekin/ability_procs.dm
+++ b/code/modules/mob/living/simple_animal/vore/shadekin/ability_procs.dm
@@ -70,8 +70,8 @@
 		overlays.Cut()
 		flick("tp_out",src)
 		sleep(5)
-		invisibility = INVISIBILITY_LEVEL_ONE
-		see_invisible = INVISIBILITY_LEVEL_ONE
+		invisibility = INVISIBILITY_LEVEL_TWO
+		see_invisible = INVISIBILITY_LEVEL_TWO
 		update_icon()
 		alpha = 127
 

--- a/code/modules/mob/living/simple_animal/vore/shadekin/ability_procs.dm
+++ b/code/modules/mob/living/simple_animal/vore/shadekin/ability_procs.dm
@@ -60,6 +60,7 @@
 	else
 		ability_flags |= AB_PHASE_SHIFTED
 		custom_emote(1,"phases out!")
+		real_name = name
 		name = "Something"
 
 		for(var/belly in vore_organs)


### PR DESCRIPTION
Only humans do automatically, it seems. Not an issue for admins, but later it might be.