### PR TITLE
Tweak Tesla Grounding Rods

### DIFF
--- a/code/modules/power/tesla/energy_ball.dm
+++ b/code/modules/power/tesla/energy_ball.dm
@@ -218,7 +218,8 @@
 			continue //no need checking these other things
 
 		else if(istype(A, /obj/machinery/power/grounding_rod))
-			var/dist = get_dist(source, A)-2
+			var/obj/machinery/power/grounding_rod/G = A
+			var/dist = get_dist(source, A) - (G.anchored ? 2 : 0)
 			if(dist <= zap_range && (dist < closest_dist || !closest_grounding_rod))
 				closest_grounding_rod = A
 				closest_atom = A


### PR DESCRIPTION
Grounding rods that are anchored can be struck two turfs farther away than unanchored.  This makes it possible to leapfrog towards a tesla because an unanchored one can be protected in the "shadow" of the anchored one.