### PR TITLE
Adds "monster tamer" drink, plus some chimera tweaks.

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/station_special_abilities_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_special_abilities_vr.dm
@@ -159,187 +159,188 @@
 	handling_hal = 1
 
 	if(client && feral >= 10) // largely a copy of handle_hallucinations() without the fake attackers. Unlike hallucinations, only fires once - if they're still feral they'll get hit again anyway.
-		sleep(rand(200,500)/(feral/10))
-		var/halpick = rand(1,100)
-		switch(halpick)
-			if(0 to 15) //15% chance
-				//Screwy HUD
-				//src << "Screwy HUD"
-				hal_screwyhud = pick(1,2,3,3,4,4)
-				spawn(rand(100,250))
-					hal_screwyhud = 0
-			if(16 to 25) //10% chance
-				//Strange items
-				//src << "Traitor Items"
-				if(!halitem)
-					halitem = new
-					var/list/slots_free = list(ui_lhand,ui_rhand)
-					if(l_hand) slots_free -= ui_lhand
-					if(r_hand) slots_free -= ui_rhand
-					if(istype(src,/mob/living/carbon/human))
-						var/mob/living/carbon/human/H = src
-						if(!H.belt) slots_free += ui_belt
-						if(!H.l_store) slots_free += ui_storage1
-						if(!H.r_store) slots_free += ui_storage2
-					if(slots_free.len)
-						halitem.screen_loc = pick(slots_free)
-						halitem.layer = 50
-						switch(rand(1,6))
-							if(1) //revolver
-								halitem.icon = 'icons/obj/gun.dmi'
-								halitem.icon_state = "revolver"
-								halitem.name = "Revolver"
-							if(2) //c4
-								halitem.icon = 'icons/obj/assemblies.dmi'
-								halitem.icon_state = "plastic-explosive0"
-								halitem.name = "Mysterious Package"
-								if(prob(25))
-									halitem.icon_state = "c4small_1"
-							if(3) //sword
-								halitem.icon = 'icons/obj/weapons.dmi'
-								halitem.icon_state = "sword1"
-								halitem.name = "Sword"
-							if(4) //stun baton
-								halitem.icon = 'icons/obj/weapons.dmi'
-								halitem.icon_state = "stunbaton"
-								halitem.name = "Stun Baton"
-							if(5) //emag
-								halitem.icon = 'icons/obj/card.dmi'
-								halitem.icon_state = "emag"
-								halitem.name = "Cryptographic Sequencer"
-							if(6) //flashbang
-								halitem.icon = 'icons/obj/grenade.dmi'
-								halitem.icon_state = "flashbang1"
-								halitem.name = "Flashbang"
-						if(client) client.screen += halitem
-						spawn(rand(100,250))
-							if(client)
-								client.screen -= halitem
-							halitem = null
-			if(26 to 35) //10% chance
-				//Flashes of danger
-				//src << "Danger Flash"
-				if(!halimage)
-					var/list/possible_points = list()
-					for(var/turf/simulated/floor/F in view(src,world.view))
-						possible_points += F
-					if(possible_points.len)
-						var/turf/simulated/floor/target = pick(possible_points)
+		spawn(rand(200,500)/(feral/10))
+			var/halpick = rand(1,100)
+			switch(halpick)
+				if(0 to 15) //15% chance
+					//Screwy HUD
+					//src << "Screwy HUD"
+					hal_screwyhud = pick(1,2,3,3,4,4)
+					spawn(rand(100,250))
+						hal_screwyhud = 0
+				if(16 to 25) //10% chance
+					//Strange items
+					//src << "Traitor Items"
+					if(!halitem)
+						halitem = new
+						var/list/slots_free = list(ui_lhand,ui_rhand)
+						if(l_hand) slots_free -= ui_lhand
+						if(r_hand) slots_free -= ui_rhand
+						if(istype(src,/mob/living/carbon/human))
+							var/mob/living/carbon/human/H = src
+							if(!H.belt) slots_free += ui_belt
+							if(!H.l_store) slots_free += ui_storage1
+							if(!H.r_store) slots_free += ui_storage2
+						if(slots_free.len)
+							halitem.screen_loc = pick(slots_free)
+							halitem.layer = 50
+							switch(rand(1,6))
+								if(1) //revolver
+									halitem.icon = 'icons/obj/gun.dmi'
+									halitem.icon_state = "revolver"
+									halitem.name = "Revolver"
+								if(2) //c4
+									halitem.icon = 'icons/obj/assemblies.dmi'
+									halitem.icon_state = "plastic-explosive0"
+									halitem.name = "Mysterious Package"
+									if(prob(25))
+										halitem.icon_state = "c4small_1"
+								if(3) //sword
+									halitem.icon = 'icons/obj/weapons.dmi'
+									halitem.icon_state = "sword1"
+									halitem.name = "Sword"
+								if(4) //stun baton
+									halitem.icon = 'icons/obj/weapons.dmi'
+									halitem.icon_state = "stunbaton"
+									halitem.name = "Stun Baton"
+								if(5) //emag
+									halitem.icon = 'icons/obj/card.dmi'
+									halitem.icon_state = "emag"
+									halitem.name = "Cryptographic Sequencer"
+								if(6) //flashbang
+									halitem.icon = 'icons/obj/grenade.dmi'
+									halitem.icon_state = "flashbang1"
+									halitem.name = "Flashbang"
+							if(client) client.screen += halitem
+							spawn(rand(100,250))
+								if(client)
+									client.screen -= halitem
+								halitem = null
+				if(26 to 35) //10% chance
+					//Flashes of danger
+					//src << "Danger Flash"
+					if(!halimage)
+						var/list/possible_points = list()
+						for(var/turf/simulated/floor/F in view(src,world.view))
+							possible_points += F
+						if(possible_points.len)
+							var/turf/simulated/floor/target = pick(possible_points)
 
-						switch(rand(1,3))
-							if(1)
-								//src << "Space"
-								halimage = image('icons/turf/space.dmi',target,"[rand(1,25)]",TURF_LAYER)
-							if(2)
-								//src << "Fire"
-								halimage = image('icons/effects/fire.dmi',target,"1",TURF_LAYER)
-							if(3)
-								//src << "C4"
-								halimage = image('icons/obj/assemblies.dmi',target,"plastic-explosive2",OBJ_LAYER+0.01)
+							switch(rand(1,3))
+								if(1)
+									//src << "Space"
+									halimage = image('icons/turf/space.dmi',target,"[rand(1,25)]",TURF_LAYER)
+								if(2)
+									//src << "Fire"
+									halimage = image('icons/effects/fire.dmi',target,"1",TURF_LAYER)
+								if(3)
+									//src << "C4"
+									halimage = image('icons/obj/assemblies.dmi',target,"plastic-explosive2",OBJ_LAYER+0.01)
 
 
-						if(client) client.images += halimage
-						spawn(rand(10,50)) //Only seen for a brief moment.
-							if(client) client.images -= halimage
-							halimage = null
+							if(client) client.images += halimage
+							spawn(rand(10,50)) //Only seen for a brief moment.
+								if(client) client.images -= halimage
+								halimage = null
 
-			if(36 to 55) //20% chance
-				//Strange audio
-				//src << "Strange Audio"
-				switch(rand(1,12))
-					if(1) src << 'sound/machines/airlock.ogg'
-					if(2)
-						if(prob(50))src << 'sound/effects/Explosion1.ogg'
-						else src << 'sound/effects/Explosion2.ogg'
-					if(3) src << 'sound/effects/explosionfar.ogg'
-					if(4) src << 'sound/effects/Glassbr1.ogg'
-					if(5) src << 'sound/effects/Glassbr2.ogg'
-					if(6) src << 'sound/effects/Glassbr3.ogg'
-					if(7) src << 'sound/machines/twobeep.ogg'
-					if(8) src << 'sound/machines/windowdoor.ogg'
-					if(9)
-						//To make it more realistic, I added two gunshots (enough to kill)
-						src << 'sound/weapons/Gunshot.ogg'
-						spawn(rand(10,30))
+				if(36 to 55) //20% chance
+					//Strange audio
+					//src << "Strange Audio"
+					switch(rand(1,12))
+						if(1) src << 'sound/machines/airlock.ogg'
+						if(2)
+							if(prob(50))src << 'sound/effects/Explosion1.ogg'
+							else src << 'sound/effects/Explosion2.ogg'
+						if(3) src << 'sound/effects/explosionfar.ogg'
+						if(4) src << 'sound/effects/Glassbr1.ogg'
+						if(5) src << 'sound/effects/Glassbr2.ogg'
+						if(6) src << 'sound/effects/Glassbr3.ogg'
+						if(7) src << 'sound/machines/twobeep.ogg'
+						if(8) src << 'sound/machines/windowdoor.ogg'
+						if(9)
+							//To make it more realistic, I added two gunshots (enough to kill)
 							src << 'sound/weapons/Gunshot.ogg'
-					if(10) src << 'sound/weapons/smash.ogg'
-					if(11)
-						//Same as above, but with tasers.
-						src << 'sound/weapons/Taser.ogg'
-						spawn(rand(10,30))
+							spawn(rand(10,30))
+								src << 'sound/weapons/Gunshot.ogg'
+						if(10) src << 'sound/weapons/smash.ogg'
+						if(11)
+							//Same as above, but with tasers.
 							src << 'sound/weapons/Taser.ogg'
-				//Rare audio
-					if(12)
-//These sounds are (mostly) taken from Hidden: Source
-						var/list/creepyasssounds = list('sound/effects/ghost.ogg', 'sound/effects/ghost2.ogg', 'sound/effects/Heart Beat.ogg', 'sound/effects/screech.ogg',\
-							'sound/hallucinations/behind_you1.ogg', 'sound/hallucinations/behind_you2.ogg', 'sound/hallucinations/far_noise.ogg', 'sound/hallucinations/growl1.ogg', 'sound/hallucinations/growl2.ogg',\
-							'sound/hallucinations/growl3.ogg', 'sound/hallucinations/im_here1.ogg', 'sound/hallucinations/im_here2.ogg', 'sound/hallucinations/i_see_you1.ogg', 'sound/hallucinations/i_see_you2.ogg',\
-							'sound/hallucinations/look_up1.ogg', 'sound/hallucinations/look_up2.ogg', 'sound/hallucinations/over_here1.ogg', 'sound/hallucinations/over_here2.ogg', 'sound/hallucinations/over_here3.ogg',\
-							'sound/hallucinations/turn_around1.ogg', 'sound/hallucinations/turn_around2.ogg', 'sound/hallucinations/veryfar_noise.ogg', 'sound/hallucinations/wail.ogg')
-						src << pick(creepyasssounds)
-			if(56 to 60) //5% chance
-				//Flashes of danger
-				//src << "Danger Flash"
-				if(!halbody)
-					var/list/possible_points = list()
-					for(var/turf/simulated/floor/F in view(src,world.view))
-						possible_points += F
-					if(possible_points.len)
-						var/turf/simulated/floor/target = pick(possible_points)
-						switch(rand(1,4))
-							if(1)
-								halbody = image('icons/mob/human.dmi',target,"husk_l",TURF_LAYER)
-							if(2,3)
-								halbody = image('icons/mob/human.dmi',target,"husk_s",TURF_LAYER)
-							if(4)
-								halbody = image('icons/mob/alien.dmi',target,"alienother",TURF_LAYER)
-	//						if(5)
-	//							halbody = image('xcomalien.dmi',target,"chryssalid",TURF_LAYER)
+							spawn(rand(10,30))
+								src << 'sound/weapons/Taser.ogg'
+					//Rare audio
+						if(12)
+	//These sounds are (mostly) taken from Hidden: Source
+							var/list/creepyasssounds = list('sound/effects/ghost.ogg', 'sound/effects/ghost2.ogg', 'sound/effects/Heart Beat.ogg', 'sound/effects/screech.ogg',\
+								'sound/hallucinations/behind_you1.ogg', 'sound/hallucinations/behind_you2.ogg', 'sound/hallucinations/far_noise.ogg', 'sound/hallucinations/growl1.ogg', 'sound/hallucinations/growl2.ogg',\
+								'sound/hallucinations/growl3.ogg', 'sound/hallucinations/im_here1.ogg', 'sound/hallucinations/im_here2.ogg', 'sound/hallucinations/i_see_you1.ogg', 'sound/hallucinations/i_see_you2.ogg',\
+								'sound/hallucinations/look_up1.ogg', 'sound/hallucinations/look_up2.ogg', 'sound/hallucinations/over_here1.ogg', 'sound/hallucinations/over_here2.ogg', 'sound/hallucinations/over_here3.ogg',\
+								'sound/hallucinations/turn_around1.ogg', 'sound/hallucinations/turn_around2.ogg', 'sound/hallucinations/veryfar_noise.ogg', 'sound/hallucinations/wail.ogg')
+							src << pick(creepyasssounds)
+				if(56 to 60) //5% chance
+					//Flashes of danger
+					//src << "Danger Flash"
+					if(!halbody)
+						var/list/possible_points = list()
+						for(var/turf/simulated/floor/F in view(src,world.view))
+							possible_points += F
+						if(possible_points.len)
+							var/turf/simulated/floor/target = pick(possible_points)
+							switch(rand(1,4))
+								if(1)
+									halbody = image('icons/mob/human.dmi',target,"husk_l",TURF_LAYER)
+								if(2,3)
+									halbody = image('icons/mob/human.dmi',target,"husk_s",TURF_LAYER)
+								if(4)
+									halbody = image('icons/mob/alien.dmi',target,"alienother",TURF_LAYER)
+		//						if(5)
+		//							halbody = image('xcomalien.dmi',target,"chryssalid",TURF_LAYER)
 
-						if(client) client.images += halbody
-						spawn(rand(50,80)) //Only seen for a brief moment.
-							if(client) client.images -= halbody
-							halbody = null
-			if(61 to 85) //25% chance
-				//food
-				if(!halbody)
-					var/list/possible_points = list()
-					for(var/turf/simulated/floor/F in view(src,world.view))
-						possible_points += F
-					if(possible_points.len)
-						var/turf/simulated/floor/target = pick(possible_points)
-						switch(rand(1,10))
-							if(1)
-								halbody = image('icons/mob/animal.dmi',target,"cow",TURF_LAYER)
-							if(2)
-								halbody = image('icons/mob/animal.dmi',target,"chicken",TURF_LAYER)
-							if(3)
-								halbody = image('icons/obj/food.dmi',target,"bigbiteburger",TURF_LAYER)
-							if(4)
-								halbody = image('icons/obj/food.dmi',target,"meatbreadslice",TURF_LAYER)
-							if(5)
-								halbody = image('icons/obj/food.dmi',target,"sausage",TURF_LAYER)
-							if(6)
-								halbody = image('icons/obj/food.dmi',target,"bearmeat",TURF_LAYER)
-							if(7)
-								halbody = image('icons/obj/food.dmi',target,"fishfillet",TURF_LAYER)
-							if(8)
-								halbody = image('icons/obj/food.dmi',target,"meat",TURF_LAYER)
-							if(9)
-								halbody = image('icons/obj/food.dmi',target,"meatstake",TURF_LAYER)
-							if(10)
-								halbody = image('icons/obj/food.dmi',target,"monkeysdelight",TURF_LAYER)
+							if(client) client.images += halbody
+							spawn(rand(50,80)) //Only seen for a brief moment.
+								if(client) client.images -= halbody
+								halbody = null
+				if(61 to 85) //25% chance
+					//food
+					if(!halbody)
+						var/list/possible_points = list()
+						for(var/turf/simulated/floor/F in view(src,world.view))
+							possible_points += F
+						if(possible_points.len)
+							var/turf/simulated/floor/target = pick(possible_points)
+							switch(rand(1,10))
+								if(1)
+									halbody = image('icons/mob/animal.dmi',target,"cow",TURF_LAYER)
+								if(2)
+									halbody = image('icons/mob/animal.dmi',target,"chicken",TURF_LAYER)
+								if(3)
+									halbody = image('icons/obj/food.dmi',target,"bigbiteburger",TURF_LAYER)
+								if(4)
+									halbody = image('icons/obj/food.dmi',target,"meatbreadslice",TURF_LAYER)
+								if(5)
+									halbody = image('icons/obj/food.dmi',target,"sausage",TURF_LAYER)
+								if(6)
+									halbody = image('icons/obj/food.dmi',target,"bearmeat",TURF_LAYER)
+								if(7)
+									halbody = image('icons/obj/food.dmi',target,"fishfillet",TURF_LAYER)
+								if(8)
+									halbody = image('icons/obj/food.dmi',target,"meat",TURF_LAYER)
+								if(9)
+									halbody = image('icons/obj/food.dmi',target,"meatstake",TURF_LAYER)
+								if(10)
+									halbody = image('icons/obj/food.dmi',target,"monkeysdelight",TURF_LAYER)
 
-						if(client) client.images += halbody
-						spawn(rand(50,80)) //Only seen for a brief moment.
-							if(client) client.images -= halbody
-							halbody = null
-			if(86 to 100) //15% chance
-				//disorientation
-				if(client)
-					client.dir = pick(2,4,8)
-					spawn(rand(20,50))
-						client.dir = 1
+							if(client) client.images += halbody
+							spawn(rand(50,80)) //Only seen for a brief moment.
+								if(client) client.images -= halbody
+								halbody = null
+				if(86 to 100) //15% chance
+					//hear voices. Could make the voice pick from nearby creatures, but nearby creatures make feral hallucinations rare so don't bother.
+					var/list/hiddenspeakers = list("Someone distant", "A voice nearby","A familiar voice", "An echoing voice", "A cautious voice", "A scared voice", "Someone around the corner", "Someone", "Something", "Something scary", "An urgent voice", "An angry voice")
+					var/list/speakerverbs = list("calls out", "yells", "screams", "exclaims", "shrieks", "shouts", "hisses", "snarls")
+					var/list/spookyphrases = list("It's over here!","Stop it!", "Hunt it down!", "Get it!", "Quick, over here!", "Anyone there?", "Who's there?", "Catch that thing!", "Stop it! Kill it!", "Anyone there?", "Where is it?", "Find it!", "There it is!")
+					to_chat(src, "<span class='game say'><span class='name'>[pick(hiddenspeakers)]</span> [pick(speakerverbs)], \"[pick(spookyphrases)]\"</span>")
+
 
 	handling_hal = 0
 	return

--- a/code/modules/mob/living/carbon/human/species/station/station_special_abilities_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_special_abilities_vr.dm
@@ -158,7 +158,7 @@
 	if(handling_hal) return //avoid conflict with actual hallucinations
 	handling_hal = 1
 
-	if(client && feral) // largely a copy of handle_hallucinations() without the fake attackers. Unlike hallucinations, only fires once - if they're still feral they'll get hit again anyway.
+	if(client && feral >= 10) // largely a copy of handle_hallucinations() without the fake attackers. Unlike hallucinations, only fires once - if they're still feral they'll get hit again anyway.
 		sleep(rand(200,500)/(feral/10))
 		var/halpick = rand(1,100)
 		switch(halpick)

--- a/code/modules/mob/living/carbon/human/species/station/station_special_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_special_vr.dm
@@ -24,7 +24,6 @@
 	inherent_verbs = list(
 		/mob/living/carbon/human/proc/begin_reconstitute_form,
 		/mob/living/carbon/human/proc/sonar_ping,
-		/mob/living/carbon/human/proc/purge_impurities,
 		/mob/living/carbon/human/proc/succubus_drain,
 		/mob/living/carbon/human/proc/succubus_drain_finalize,
 		/mob/living/carbon/human/proc/succubus_drain_lethal,
@@ -48,7 +47,7 @@
 	//primitive_form = "Farwa"
 
 	spawn_flags = SPECIES_CAN_JOIN | SPECIES_IS_WHITELISTED //Whitelisted as restricted is broken.
-	flags = NO_SCAN //Dying as a chimera is, quite literally, a death sentence. Well, if it wasn't for their revive, that is.
+	flags = NO_SCAN | NO_INFECT //Dying as a chimera is, quite literally, a death sentence. Well, if it wasn't for their revive, that is.
 	appearance_flags = HAS_HAIR_COLOR | HAS_LIPS | HAS_UNDERWEAR | HAS_SKIN_COLOR | HAS_EYE_COLOR
 
 	flesh_color = "#AFA59E"
@@ -145,10 +144,10 @@
 						H << "<span class='danger'> Every movement, every flick, every sight and sound has your full attention, your hunting instincts on high alert... In fact, [M] looks extremely appetizing...</span>"
 					if(H.stat == CONSCIOUS)
 						H.emote("twitch")
-					if(!H.handling_hal)
+					spawn(0)
 						H.handle_feral()
 			else // nobody around
-				if(!H.handling_hal)
+				spawn(0)
 					H.handle_feral()
 				if(prob(2)) //periodic nagmessages
 					if(H.nutrition <= 100) //If hungry, nag them to go and find someone or something to eat.

--- a/code/modules/mob/living/carbon/human/species/station/station_special_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_special_vr.dm
@@ -144,11 +144,9 @@
 						H << "<span class='danger'> Every movement, every flick, every sight and sound has your full attention, your hunting instincts on high alert... In fact, [M] looks extremely appetizing...</span>"
 					if(H.stat == CONSCIOUS)
 						H.emote("twitch")
-					spawn(0)
-						H.handle_feral()
-			else // nobody around
-				spawn(0)
 					H.handle_feral()
+			else // nobody around
+				H.handle_feral()
 				if(prob(2)) //periodic nagmessages
 					if(H.nutrition <= 100) //If hungry, nag them to go and find someone or something to eat.
 						H << "<span class='danger'> Confusing sights and sounds and smells surround you - scary and disorienting it may be, but the drive to hunt, to feed, to survive, compels you.</span>"

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks_vr.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks_vr.dm
@@ -28,3 +28,29 @@
 		M.make_dizzy(24) // Intentionally higher than normal to compensate for it's previous effects.
 	if(dose * strength >= strength * 2.5) // Slurring takes longer. Again, intentional.
 		M.slurring = max(M.slurring, 30)
+
+/datum/reagent/ethanol/monstertamer
+	name = "Monster Tamer"
+	id = "monstertamer"
+	description = "A questionably-delicious blend of a carnivore's favorite food and a potent neural depressant."
+	taste_description = "the gross yet satisfying combination of chewing on a raw steak while downing a shot of whiskey"
+	strength = 50
+	color = "#d3785d"
+	metabolism = REM * 2.5 // about right for mixing nutriment and ethanol.
+
+	glass_name = "Monster Tamer"
+	glass_desc = "This looks like a vaguely-alcoholic slurry of meat. Gross."
+
+/datum/reagent/ethanol/monstertamer/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed)
+	..()
+
+	if(M.species.gets_food_nutrition) //it's still food!
+		M.nutrition += (nutriment_factor * removed)/2 // For hunger and fatness
+	if(ishuman(M))
+		var/mob/living/carbon/human/H = M
+		if(H.feral > 0 && H.nutrition > 100 && H.traumatic_shock < min(60, H.nutrition/10) && H.jitteriness < 100) // same check as feral triggers to stop them immediately re-feralling
+			H.feral -= removed * 3 // should calm them down quick, provided they're actually in a state to STAY calm.
+			if (H.feral <=0) //check if they're unferalled
+				H.feral = 0
+				H << "<span class='info'>Your mind starts to clear, soothed into a state of clarity as your senses return.</span>"
+				log_and_message_admins("is no longer feral.", H)

--- a/code/modules/reagents/Chemistry-Recipes_vr.dm
+++ b/code/modules/reagents/Chemistry-Recipes_vr.dm
@@ -48,8 +48,8 @@
 	holder.clear_reagents()
 
 /datum/chemical_reaction/xenolazarus
-	name = "Discount Lazarus Injector"
-	id = "discountlazarusinjector"
+	name = "Discount Lazarus"
+	id = "discountlazarus"
 	result = null
 	required_reagents = list("monstertamer" = 5, "clonexadone" = 5)
 
@@ -105,7 +105,7 @@
 	result = "grubshake"
 	required_reagents = list("shockchem" = 5, "water" = 25)
 	result_amount = 30
-	
+
 /datum/chemical_reaction/drinks/deathbell
 	name = "Deathbell"
 	id = "deathbell"

--- a/code/modules/reagents/Chemistry-Recipes_vr.dm
+++ b/code/modules/reagents/Chemistry-Recipes_vr.dm
@@ -47,6 +47,22 @@
 	s.start()
 	holder.clear_reagents()
 
+/datum/chemical_reaction/xenolazarus
+	name = "Discount Lazarus Injector"
+	id = "discountlazarusinjector"
+	result = null
+	required_reagents = list("monstertamer" = 5, "clonexadone" = 5)
+
+/datum/chemical_reaction/xenolazarus/on_reaction(var/datum/reagents/holder, var/created_volume) //literally all this does is mash the regenerate button
+	if(ishuman(holder.my_atom))
+		var/mob/living/carbon/human/H = holder.my_atom
+		if(H.stat == DEAD && (/mob/living/carbon/human/proc/begin_reconstitute_form in H.verbs)) //no magical regen for non-regenners, and can't force the reaction on live ones
+			if(H.hasnutriment() && !H.reviving) // make sure it actually has the conditions to revive
+				H.visible_message("<span class='info'>[H] shudders briefly, then relaxes, faint movements stirring within.</span>")
+				H.chimera_regenerate()
+			else
+				H.visible_message("<span class='info'>[H] twitches for a moment, but remains still.</span>")
+
 ///////////////////////////////////////////////////////////////////////////////////
 /// Vore Drugs
 
@@ -96,6 +112,13 @@
 	result = "deathbell"
 	required_reagents = list("antifreeze" = 1, "gargleblaster" = 1, "syndicatebomb" =1)
 	result_amount = 3
+
+/datum/chemical_reaction/drinks/monstertamer
+	name = "Monster Tamer"
+	id = "monstertamer"
+	result = "monstertamer"
+	required_reagents = list("whiskey" = 1, "protein" = 1)
+	result_amount = 2
 
 ///////////////////////////////
 //SLIME CORES BELOW HERE///////


### PR DESCRIPTION
- Adds "monster tamer", a drink made by mixing animal protein and whiskey. Combination of good ol' meat with a neural depressant calms them down from feralness faster (provided they're not still in the state that MADE them feral)

- Renamed "begin reconstitute form" into just "reconstitute form".

- Moved their revive into its own proc so it can be called without the verb.

- Added a chemical reaction (5u monster tamer, 5u clonexadone) that will do the above. Will give feedback as to whether it was successful or not, ie. whether they have nutriment in them, aren't reviving already. Has no effect on live ones. Mainly exists so the chimera in deadchat don't have to keep returning to their body and mashing the button to see if they've been injected with enough nutriment yet.

- Made them NO_INFECT, removed Purge Impurities. (no slyly removing toxloss with a verb that's meant to reflect their strong immune systems. They have actually strong immune systems now)

- Moved handle_feral calls under a spawn(0) because the first thing that happens in that proc after the "am I handling hallucinations already" check is a sleep() and that doesn't seem like a good thing to have happening in a critter's life() ticks. Removed redundant if(!handling_hal) checks because the first thing in the proc they call is that exact check.