### PR TITLE
Eliminated duplicate code in trinary components.

### DIFF
--- a/code/ATMOSPHERICS/atmospherics.dm
+++ b/code/ATMOSPHERICS/atmospherics.dm
@@ -46,6 +46,11 @@ Pipelines + Other Objects -> Pipe network
 /obj/machinery/atmospherics/proc/init_dir()
 	return
 
+// Get the direction each node is facing to connect.
+// It now returns as a list so it can be fetched nicely, each entry corresponds to node of same number.
+/obj/machinery/atmospherics/proc/get_node_connect_dirs()
+	return
+
 // Initializes nodes by looking at neighboring atmospherics machinery to connect to.
 // When we're being constructed at runtime, atmos_init() is called by the construction code.
 // When dynamically loading a map atmos_init is called by the maploader (initTemplateBounds proc)

--- a/code/ATMOSPHERICS/components/trinary_devices/filter.dm
+++ b/code/ATMOSPHERICS/components/trinary_devices/filter.dm
@@ -72,31 +72,6 @@
 		icon_state += "off"
 		use_power = 0
 
-/obj/machinery/atmospherics/trinary/atmos_filter/update_underlays()
-	if(..())
-		underlays.Cut()
-		var/turf/T = get_turf(src)
-		if(!istype(T))
-			return
-
-		add_underlay(T, node1, turn(dir, -180))
-
-		if(istype(src, /obj/machinery/atmospherics/trinary/atmos_filter/m_filter))
-			add_underlay(T, node2, turn(dir, 90))
-		else
-			add_underlay(T, node2, turn(dir, -90))
-
-		add_underlay(T, node3, dir)
-
-/obj/machinery/atmospherics/trinary/atmos_filter/hide(var/i)
-	update_underlays()
-
-/obj/machinery/atmospherics/trinary/atmos_filter/power_change()
-	var/old_stat = stat
-	..()
-	if(old_stat != stat)
-		update_icon()
-
 /obj/machinery/atmospherics/trinary/atmos_filter/process()
 	..()
 
@@ -241,7 +216,7 @@
 	dir = SOUTH
 	initialize_directions = SOUTH|NORTH|EAST
 
-obj/machinery/atmospherics/trinary/atmos_filter/m_filter/init_dir()
+/obj/machinery/atmospherics/trinary/atmos_filter/m_filter/init_dir()
 	switch(dir)
 		if(NORTH)
 			initialize_directions = WEST|NORTH|SOUTH
@@ -252,27 +227,8 @@ obj/machinery/atmospherics/trinary/atmos_filter/m_filter/init_dir()
 		if(WEST)
 			initialize_directions = WEST|SOUTH|EAST
 
-/obj/machinery/atmospherics/trinary/atmos_filter/m_filter/atmos_init()
-	if(node1 && node2 && node3) return
-
+/obj/machinery/atmospherics/trinary/atmos_filter/m_filter/get_node_connect_dirs()
 	var/node1_connect = turn(dir, -180)
 	var/node2_connect = turn(dir, 90)
 	var/node3_connect = dir
-
-	for(var/obj/machinery/atmospherics/target in get_step(src,node1_connect))
-		if(target.initialize_directions & get_dir(target,src))
-			node1 = target
-			break
-
-	for(var/obj/machinery/atmospherics/target in get_step(src,node2_connect))
-		if(target.initialize_directions & get_dir(target,src))
-			node2 = target
-			break
-
-	for(var/obj/machinery/atmospherics/target in get_step(src,node3_connect))
-		if(target.initialize_directions & get_dir(target,src))
-			node3 = target
-			break
-
-	update_icon()
-	update_underlays()
+	return list(node1_connect, node2_connect, node3_connect)

--- a/code/ATMOSPHERICS/components/trinary_devices/mixer.dm
+++ b/code/ATMOSPHERICS/components/trinary_devices/mixer.dm
@@ -35,34 +35,6 @@
 		icon_state += "off"
 		use_power = 0
 
-/obj/machinery/atmospherics/trinary/mixer/update_underlays()
-	if(..())
-		underlays.Cut()
-		var/turf/T = get_turf(src)
-		if(!istype(T))
-			return
-
-		if(istype(src, /obj/machinery/atmospherics/trinary/mixer/t_mixer))
-			add_underlay(T, node1, turn(dir, -90))
-		else
-			add_underlay(T, node1, turn(dir, -180))
-
-		if(istype(src, /obj/machinery/atmospherics/trinary/mixer/m_mixer) || istype(src, /obj/machinery/atmospherics/trinary/mixer/t_mixer))
-			add_underlay(T, node2, turn(dir, 90))
-		else
-			add_underlay(T, node2, turn(dir, -90))
-
-		add_underlay(T, node3, dir)
-
-/obj/machinery/atmospherics/trinary/mixer/hide(var/i)
-	update_underlays()
-
-/obj/machinery/atmospherics/trinary/mixer/power_change()
-	var/old_stat = stat
-	..()
-	if(old_stat != stat)
-		update_icon()
-
 /obj/machinery/atmospherics/trinary/mixer/New()
 	..()
 	air1.volume = ATMOS_DEFAULT_VOLUME_MIXER
@@ -173,6 +145,9 @@
 	src.updateUsrDialog()
 	return
 
+//
+// "T" Orientation - Inputs are on oposite sides instead of adjacent
+//
 obj/machinery/atmospherics/trinary/mixer/t_mixer
 	icon_state = "tmap"
 
@@ -181,7 +156,7 @@ obj/machinery/atmospherics/trinary/mixer/t_mixer
 
 	//node 3 is the outlet, nodes 1 & 2 are intakes
 
-obj/machinery/atmospherics/trinary/mixer/t_mixer/init_dir()
+/obj/machinery/atmospherics/trinary/mixer/t_mixer/init_dir()
 	switch(dir)
 		if(NORTH)
 			initialize_directions = EAST|NORTH|WEST
@@ -192,33 +167,16 @@ obj/machinery/atmospherics/trinary/mixer/t_mixer/init_dir()
 		if(WEST)
 			initialize_directions = WEST|NORTH|SOUTH
 
-obj/machinery/atmospherics/trinary/mixer/t_mixer/atmos_init()
-	..()
-	if(node1 && node2 && node3) return
-
+/obj/machinery/atmospherics/trinary/mixer/t_mixer/get_node_connect_dirs()
 	var/node1_connect = turn(dir, -90)
 	var/node2_connect = turn(dir, 90)
 	var/node3_connect = dir
+	return list(node1_connect, node2_connect, node3_connect)
 
-	for(var/obj/machinery/atmospherics/target in get_step(src,node1_connect))
-		if(target.initialize_directions & get_dir(target,src))
-			node1 = target
-			break
-
-	for(var/obj/machinery/atmospherics/target in get_step(src,node2_connect))
-		if(target.initialize_directions & get_dir(target,src))
-			node2 = target
-			break
-
-	for(var/obj/machinery/atmospherics/target in get_step(src,node3_connect))
-		if(target.initialize_directions & get_dir(target,src))
-			node3 = target
-			break
-
-	update_icon()
-	update_underlays()
-
-obj/machinery/atmospherics/trinary/mixer/m_mixer
+//
+// Mirrored Orientation - Flips the output dir to opposite side from normal.
+//
+/obj/machinery/atmospherics/trinary/mixer/m_mixer
 	icon_state = "mmap"
 
 	dir = SOUTH
@@ -226,7 +184,7 @@ obj/machinery/atmospherics/trinary/mixer/m_mixer
 
 	//node 3 is the outlet, nodes 1 & 2 are intakes
 
-obj/machinery/atmospherics/trinary/mixer/m_mixer/init_dir()
+/obj/machinery/atmospherics/trinary/mixer/m_mixer/init_dir()
 	switch(dir)
 		if(NORTH)
 			initialize_directions = WEST|NORTH|SOUTH
@@ -237,28 +195,8 @@ obj/machinery/atmospherics/trinary/mixer/m_mixer/init_dir()
 		if(WEST)
 			initialize_directions = WEST|SOUTH|EAST
 
-obj/machinery/atmospherics/trinary/mixer/m_mixer/atmos_init()
-	..()
-	if(node1 && node2 && node3) return
-
+/obj/machinery/atmospherics/trinary/mixer/m_mixer/get_node_connect_dirs()
 	var/node1_connect = turn(dir, -180)
 	var/node2_connect = turn(dir, 90)
 	var/node3_connect = dir
-
-	for(var/obj/machinery/atmospherics/target in get_step(src,node1_connect))
-		if(target.initialize_directions & get_dir(target,src))
-			node1 = target
-			break
-
-	for(var/obj/machinery/atmospherics/target in get_step(src,node2_connect))
-		if(target.initialize_directions & get_dir(target,src))
-			node2 = target
-			break
-
-	for(var/obj/machinery/atmospherics/target in get_step(src,node3_connect))
-		if(target.initialize_directions & get_dir(target,src))
-			node3 = target
-			break
-
-	update_icon()
-	update_underlays()
+	return list(node1_connect, node2_connect, node3_connect)

--- a/code/ATMOSPHERICS/components/tvalve.dm
+++ b/code/ATMOSPHERICS/components/tvalve.dm
@@ -34,14 +34,10 @@
 		var/turf/T = get_turf(src)
 		if(!istype(T))
 			return
-		add_underlay(T, node1, turn(dir, -180))
-
-		if(istype(src, /obj/machinery/atmospherics/tvalve/mirrored))
-			add_underlay(T, node2, turn(dir, 90))
-		else
-			add_underlay(T, node2, turn(dir, -90))
-
-		add_underlay(T, node3, dir)
+		var/list/node_connects = get_node_connect_dirs()
+		add_underlay(T, node1, node_connects[1])
+		add_underlay(T, node2, node_connects[2])
+		add_underlay(T, node3, node_connects[3])
 
 /obj/machinery/atmospherics/tvalve/hide(var/i)
 	update_underlays()
@@ -179,26 +175,29 @@
 
 	return
 
+/obj/machinery/atmospherics/tvalve/get_node_connect_dirs()
+	var/node1_connect = turn(dir, 180)
+	var/node2_connect = turn(dir, -90)
+	var/node3_connect = dir
+	return list(node1_connect, node2_connect, node3_connect)
+
 /obj/machinery/atmospherics/tvalve/atmos_init()
-	var/node1_dir
-	var/node2_dir
-	var/node3_dir
+	if(node1 && node2 && node3)
+		return
 
-	node1_dir = turn(dir, 180)
-	node2_dir = turn(dir, -90)
-	node3_dir = dir
+	var/list/node_connects = get_node_connect_dirs()
 
-	for(var/obj/machinery/atmospherics/target in get_step(src,node1_dir))
+	for(var/obj/machinery/atmospherics/target in get_step(src,node_connects[1]))
 		if(target.initialize_directions & get_dir(target,src))
 			if (check_connect_types(target,src))
 				node1 = target
 				break
-	for(var/obj/machinery/atmospherics/target in get_step(src,node2_dir))
+	for(var/obj/machinery/atmospherics/target in get_step(src,node_connects[2]))
 		if(target.initialize_directions & get_dir(target,src))
 			if (check_connect_types(target,src))
 				node2 = target
 				break
-	for(var/obj/machinery/atmospherics/target in get_step(src,node3_dir))
+	for(var/obj/machinery/atmospherics/target in get_step(src,node_connects[3]))
 		if(target.initialize_directions & get_dir(target,src))
 			if (check_connect_types(target,src))
 				node3 = target
@@ -379,30 +378,11 @@
 		if(WEST)
 			initialize_directions = EAST|WEST|SOUTH
 
-/obj/machinery/atmospherics/tvalve/mirrored/atmos_init()
-	var/node1_dir
-	var/node2_dir
-	var/node3_dir
-
-	node1_dir = turn(dir, 180)
-	node2_dir = turn(dir, 90)
-	node3_dir = dir
-
-	for(var/obj/machinery/atmospherics/target in get_step(src,node1_dir))
-		if(target.initialize_directions & get_dir(target,src))
-			node1 = target
-			break
-	for(var/obj/machinery/atmospherics/target in get_step(src,node2_dir))
-		if(target.initialize_directions & get_dir(target,src))
-			node2 = target
-			break
-	for(var/obj/machinery/atmospherics/target in get_step(src,node3_dir))
-		if(target.initialize_directions & get_dir(target,src))
-			node3 = target
-			break
-
-	update_icon()
-	update_underlays()
+/obj/machinery/atmospherics/tvalve/mirrored/get_node_connect_dirs()
+	var/node1_connect = turn(dir, 180)
+	var/node2_connect = turn(dir, 90)
+	var/node3_connect = dir
+	return list(node1_connect, node2_connect, node3_connect)
 
 /obj/machinery/atmospherics/tvalve/mirrored/update_icon(animation)
 	if(animation)


### PR DESCRIPTION
- Consolidate common functions into trinary_base
- The only real difference in atmos_init was which direction each node would connect in.  Delegated that to an overridable proc, and the rest can be consolidated. Same story for update_underlays()
- Used similar patterns on tvalves which also are trinary even tho they are not subtyes of trinary (for some reason)

Testing shows it still works!
![image](https://user-images.githubusercontent.com/14110581/36517401-e66d1f78-174f-11e8-8dd6-ee75f69d79a1.png)
