### PR TITLE
Fix mode_name on guns always being null

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -18,7 +18,7 @@
 
 		if(propname == "mode_name")
 			name = propvalue
-		else if(isnull(propvalue))
+		if(isnull(propvalue))
 			settings[propname] = gun.vars[propname] //better than initial() as it handles list vars like burst_accuracy
 		else
 			settings[propname] = propvalue


### PR DESCRIPTION
Fixes the protector being usable on other alert levels