### PR TITLE
Removed unused fat genetics movement code

### DIFF
--- a/code/modules/mob/living/carbon/human/life_vr.dm
+++ b/code/modules/mob/living/carbon/human/life_vr.dm
@@ -66,8 +66,6 @@
 				src.nutrition -= DEFAULT_HUNGER_FACTOR/10
 				if(src.m_intent == "run")
 					src.nutrition -= DEFAULT_HUNGER_FACTOR/10
-		if((FAT in src.mutations) && src.m_intent == "run" && src.bodytemperature <= 360)
-			src.bodytemperature += 2
 		// Moving around increases germ_level faster
 		if(germ_level < GERM_LEVEL_MOVE_CAP && prob(8))
 			germ_level++


### PR DESCRIPTION
You can't get it in the game anyways w/o admin abuse. No reason to have an extra  if() check.