### PR TITLE
Adds hollow bones trait

### DIFF
--- a/code/modules/mob/living/carbon/human/human_powers.dm
+++ b/code/modules/mob/living/carbon/human/human_powers.dm
@@ -173,7 +173,7 @@
 
 	for(var/obj/item/organ/external/EO in organs)
 		if(EO.brute_dam || EO.burn_dam)
-			output += "[EO.name] - <span class='warning'>[EO.burn_dam + EO.brute_dam > ROBOLIMB_REPAIR_CAP ? "Heavy Damage" : "Light Damage"]</span>\n"
+			output += "[EO.name] - <span class='warning'>[EO.burn_dam + EO.brute_dam > EO.min_broken_damage ? "Heavy Damage" : "Light Damage"]</span>\n" //VOREStation Edit - Makes robotic limb damage scalable
 		else
 			output += "[EO.name] - <span style='color:green;'>OK</span>\n"
 

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/negative.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/negative.dm
@@ -96,6 +96,17 @@
 	cost = -1
 	var_changes = list("flash_mod" = 2.0)
 
+/datum/trait/hollow
+	name = "Hollow Bones/Aluminum Alloy"
+	desc = "Your bones and robot limbs are much easier to break."
+	cost = -2 //I feel like this should be higher, but let's see where it goes
+
+/datum/trait/hollow/apply(var/datum/species/S,var/mob/living/carbon/human/H)
+	..(S,H)
+	for(var/obj/item/organ/external/O in H.organs)
+		O.min_broken_damage *= 0.5
+		O.min_bruised_damage *= 0.5
+
 /datum/trait/lightweight
 	name = "Lightweight"
 	desc = "Your light weight and poor balance make you very susceptible to unhelpful bumping. Think of it like a bowling ball versus a pin."

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -400,7 +400,7 @@
 		user << "<span class='notice'>Nothing to fix!</span>"
 		return 0
 
-	if(damage_amount >= ROBOLIMB_REPAIR_CAP)
+	if(damage_amount >= min_broken_damage) //VOREStation Edit - Makes robotic limb damage scalable
 		user << "<span class='danger'>The damage is far too severe to patch over externally.</span>"
 		return 0
 
@@ -1085,6 +1085,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 
 	dislocated = -1
 	cannot_break = 1
+	min_broken_damage = ROBOLIMB_REPAIR_CAP //VOREStation Addition - Makes robotic limb damage scalable
 	remove_splint()
 	get_icon()
 	unmutate()
@@ -1133,7 +1134,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 	return !(status & (ORGAN_MUTATED|ORGAN_DEAD))
 
 /obj/item/organ/external/proc/is_malfunctioning()
-	return ((robotic >= ORGAN_ROBOT) && (brute_dam + burn_dam) >= 25 && prob(brute_dam + burn_dam))
+	return ((robotic >= ORGAN_ROBOT) && (brute_dam + burn_dam) >= min_broken_damage*0.83 && prob(brute_dam + burn_dam)) //VOREStation Edit - Makes robotic limb damage scalable
 
 /obj/item/organ/external/proc/embed(var/obj/item/weapon/W, var/silent = 0)
 	if(!owner || loc != owner)


### PR DESCRIPTION
~~DO NOT MERGE - Requesting help~~

This adds a new negative trait which will cause all limbs to be much, much easier to break. Most are decreased to around 20-15 damage before break, as opposed to 35-30, with the exception of hands/feet, which were already fragile as heck and only see a minor decrease since any more would result in way too many breaks.

~~However, as I tested, I had a thought: "What about robot limbs? Will this apply to them too?"~~

~~And irritatingly, after testing, I found that it did not in fact pass the new limbs to FBPs when initializing them. Everything else works as expected, but I need help locating why the roboticize() isn't simply running on the /weak versions of limbs.~~

~~Until this is fixed this should not be merged; it'd basically give FBP powergamers a free 4 trait points. Anyone able to tell where I went wrong?~~

Edit: Fixed the issue with help from Arokha. It should be solid now.