### PR TITLE
Promethean Water Edits

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/prometheans.dm
+++ b/code/modules/mob/living/carbon/human/species/station/prometheans.dm
@@ -156,9 +156,9 @@ VOREStation Removal End */
 			H.adjustFireLoss(-heal_rate)
 			H.adjustOxyLoss(-heal_rate)
 			H.adjustToxLoss(-heal_rate)
-/*	else
+/*	else //VOREStation Edit Start.
 		H.adjustToxLoss(2*heal_rate)	// Doubled because 0.5 is miniscule, and fire_stacks are capped in both directions
-*/
+*/ //VOREStation Edit End
 /datum/species/shapeshifter/promethean/get_blood_colour(var/mob/living/carbon/human/H)
 	return (H ? rgb(H.r_skin, H.g_skin, H.b_skin) : ..())
 

--- a/code/modules/mob/living/carbon/human/species/station/prometheans.dm
+++ b/code/modules/mob/living/carbon/human/species/station/prometheans.dm
@@ -156,9 +156,9 @@ VOREStation Removal End */
 			H.adjustFireLoss(-heal_rate)
 			H.adjustOxyLoss(-heal_rate)
 			H.adjustToxLoss(-heal_rate)
-	else
+/*	else
 		H.adjustToxLoss(2*heal_rate)	// Doubled because 0.5 is miniscule, and fire_stacks are capped in both directions
-
+*/
 /datum/species/shapeshifter/promethean/get_blood_colour(var/mob/living/carbon/human/H)
 	return (H ? rgb(H.r_skin, H.g_skin, H.b_skin) : ..())
 

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Core.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Core.dm
@@ -170,10 +170,10 @@
 		remove_self(needed)
 
 /datum/reagent/water/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
-	if(alien == IS_SLIME)
+	/*if(alien == IS_SLIME) //VOREStation Edit Start. Stops slimes from dying from water.
 		M.adjustToxLoss(6 * removed)
-	else
-		..()
+	else*/
+	..() //VOREStation Edit End.
 
 /datum/reagent/fuel/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed)
 	if(alien == IS_SLIME)

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Core.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Core.dm
@@ -170,7 +170,7 @@
 		remove_self(needed)
 /*  //VOREStation Edit Start. Stops slimes from dying from water. Fixes fuel affect_ingest, too.
 /datum/reagent/water/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
-	if(alien == IS_SLIME) //VOREStation Edit Start. Stops slimes from dying from water.
+	if(alien == IS_SLIME)
 		M.adjustToxLoss(6 * removed)
 	else
 		..()
@@ -180,7 +180,7 @@
 		M.adjustToxLoss(6 * removed)
 	else
 		..()
-/*  //VOREStation Edit End.
+*/  //VOREStation Edit End.
 /datum/reagent/fuel
 	name = "Welding fuel"
 	id = "fuel"

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Core.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Core.dm
@@ -168,19 +168,19 @@
 			L.ExtinguishMob()
 		L.adjust_fire_stacks(-(amount / 5))
 		remove_self(needed)
-
+/*  //VOREStation Edit Start. Stops slimes from dying from water. Fixes fuel affect_ingest, too.
 /datum/reagent/water/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
-	/*if(alien == IS_SLIME) //VOREStation Edit Start. Stops slimes from dying from water.
+	if(alien == IS_SLIME) //VOREStation Edit Start. Stops slimes from dying from water.
 		M.adjustToxLoss(6 * removed)
-	else*/
-	..() //VOREStation Edit End.
+	else
+		..()
 
 /datum/reagent/fuel/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed)
 	if(alien == IS_SLIME)
 		M.adjustToxLoss(6 * removed)
 	else
 		..()
-
+/*  //VOREStation Edit End.
 /datum/reagent/fuel
 	name = "Welding fuel"
 	id = "fuel"


### PR DESCRIPTION
Resolves #3136

- Makes prometheans not die to water. Seriously, it's flat out annoying and a dumb 'feature.'
- Keeps the promethean weakness to water, however. They won't heal if they have water _on_ them. 
Due to the way the code works, they still heal if water is injected into them or drank by them, but that's simply how it's coded.