### PR TITLE
Adds 'Intercom Convo' verb

### DIFF
--- a/code/controllers/subsystems/transcore_vr.dm
+++ b/code/controllers/subsystems/transcore_vr.dm
@@ -152,9 +152,7 @@ SUBSYSTEM_DEF(transcore)
 // Send a past-due notification to the medical radio channel.
 /datum/controller/subsystem/transcore/proc/notify(var/name)
 	ASSERT(name)
-	var/obj/item/device/radio/headset/a = new /obj/item/device/radio/headset/heads/captain(null)
-	a.autosay("[name] is past-due for a mind backup. This will be the only notification.", "TransCore Oversight", "Medical")
-	qdel(a)
+	global_announcer.autosay("[name] is past-due for a mind backup. This will be the only notification.", "TransCore Oversight", "Medical")
 
 // Called from mind_record to add itself to the transcore.
 /datum/controller/subsystem/transcore/proc/add_backup(var/datum/transhuman/mind_record/MR)
@@ -187,10 +185,8 @@ SUBSYSTEM_DEF(transcore)
 // Moves all mind records from the databaes into the disk and shuts down all backup canary processing.
 /datum/controller/subsystem/transcore/proc/core_dump(var/obj/item/weapon/disk/transcore/disk)
 	ASSERT(disk)
-	var/obj/item/device/radio/headset/a = new /obj/item/device/radio/headset/heads/captain(null)
-	a.autosay("An emergency core dump has been initiated!", "TransCore Oversight", "Command")
-	a.autosay("An emergency core dump has been initiated!", "TransCore Oversight", "Medical")
-	qdel(a)
+	global_announcer.autosay("An emergency core dump has been initiated!", "TransCore Oversight", "Command")
+	global_announcer.autosay("An emergency core dump has been initiated!", "TransCore Oversight", "Medical")
 
 	disk.stored += backed_up
 	backed_up.Cut()

--- a/code/game/objects/items/devices/radio/intercom.dm
+++ b/code/game/objects/items/devices/radio/intercom.dm
@@ -50,6 +50,12 @@
 	name = "entertainment intercom"
 	frequency = ENT_FREQ
 
+/obj/item/device/radio/intercom/omni
+	name = "global announcer"
+/obj/item/device/radio/intercom/omni/initialize()
+	channels = radiochannels.Copy()
+	return ..()
+
 /obj/item/device/radio/intercom/New()
 	..()
 	processing_objects += src

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -53,14 +53,13 @@ var/global/list/default_medbay_channels = list(
 	var/const/FREQ_LISTENING = 1
 	var/list/internal_channels
 
-/obj/item/device/radio
 	var/datum/radio_frequency/radio_connection
 	var/list/datum/radio_frequency/secure_radio_connections = new
 
-	proc/set_frequency(new_frequency)
-		radio_controller.remove_object(src, frequency)
-		frequency = new_frequency
-		radio_connection = radio_controller.add_object(src, frequency, RADIO_CHAT)
+/obj/item/device/radio/proc/set_frequency(new_frequency)
+	radio_controller.remove_object(src, frequency)
+	frequency = new_frequency
+	radio_connection = radio_controller.add_object(src, frequency, RADIO_CHAT)
 
 /obj/item/device/radio/New()
 	..()

--- a/code/global.dm
+++ b/code/global.dm
@@ -184,7 +184,7 @@ var/static/list/scarySounds = list(
 var/max_explosion_range = 14
 
 // Announcer intercom, because too much stuff creates an intercom for one message then hard del()s it.
-var/global/obj/item/device/radio/intercom/global_announcer = new /obj/item/device/radio/intercom{channels=list("Engineering")}(null)
+var/global/obj/item/device/radio/intercom/omni/global_announcer = new /obj/item/device/radio/intercom/omni(null)
 
 var/list/station_departments = list("Command", "Medical", "Engineering", "Science", "Security", "Cargo", "Civilian")
 

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -380,7 +380,7 @@ proc/admin_notice(var/message, var/rights)
 		if(3)
 			dat+={"
 				Creating new Feed Message...
-				<HR><B><A href='?src=\ref[src];ac_set_channel_receiving=1'>Receiving Channel</A>:</B> [src.admincaster_feed_channel.channel_name]<BR>" //MARK
+				<HR><B><A href='?src=\ref[src];ac_set_channel_receiving=1'>Receiving Channel</A>:</B> [src.admincaster_feed_channel.channel_name]<BR>
 				<B>Message Author:</B> <FONT COLOR='green'>[src.admincaster_signature]</FONT><BR>
 				<B><A href='?src=\ref[src];ac_set_new_message=1'>Message Body</A>:</B> [src.admincaster_feed_message.body] <BR>
 				<BR><A href='?src=\ref[src];ac_submit_new_message=1'>Submit</A><BR><BR><A href='?src=\ref[src];ac_setScreen=[0]'>Cancel</A><BR>
@@ -677,10 +677,7 @@ var/datum/announcement/minor/admin_min_announcer = new
 	set desc = "Send an intercom message, like an arrivals announcement."
 	if(!check_rights(0))	return
 
-	//This is basically how death alarms do it
-	var/obj/item/device/radio/headset/a = new /obj/item/device/radio/headset/omni(null)
-
-	var/channel = input("Channel for message:","Channel", null) as null|anything in (list("Common") + a.keyslot2.channels) // + a.keyslot1.channels
+	var/channel = input("Channel for message:","Channel", null) as null|anything in radiochannels
 
 	if(channel) //They picked a channel
 		var/sender = input("Name of sender (max 75):", "Announcement", "Announcement Computer") as null|text
@@ -691,10 +688,93 @@ var/datum/announcement/minor/admin_min_announcer = new
 
 			if(message) //They put a message
 				message = sanitize(message, 500, extra = 0)
-				a.autosay("[message]", "[sender]", "[channel == "Common" ? null : channel]") //Common is a weird case, as it's not a "channel", it's just talking into a radio without a channel set.
+				global_announcer.autosay("[message]", "[sender]", "[channel == "Common" ? null : channel]") //Common is a weird case, as it's not a "channel", it's just talking into a radio without a channel set.
 				log_admin("Intercom: [key_name(usr)] : [sender]:[message]")
-	qdel(a)
+
 	feedback_add_details("admin_verb","IN") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+
+/datum/admins/proc/intercom_convo()
+	set category = "Fun"
+	set name = "Intercom Convo"
+	set desc = "Send an intercom conversation, like several uses of the Intercom Msg verb."
+	set waitfor = FALSE //Why bother? We have some sleeps. You can leave tho!
+	if(!check_rights(0))	return
+
+	var/channel = input("Channel for message:","Channel", null) as null|anything in radiochannels
+
+	if(!channel) //They picked a channel
+		return
+
+	to_chat(usr,"<span class='notice'><B>Intercom Convo Directions</B><br>Start the conversation with the sender, a pipe (|), and then the message on one line. Then hit enter to \
+		add another line, and type a (whole) number of seconds to pause between that message, and the next message, then repeat the message syntax up to 20 times. For example:<br>\
+		--- --- ---<br>\
+		Some Guy|Hello guys, what's up?<br>\
+		5<br>\
+		Other Guy|Hey, good to see you.<br>\
+		5<br>\
+		Some Guy|Yeah, you too.<br>\
+		--- --- ---<br>\
+		The above will result in those messages playing, with a 5 second gap between each. Maximum of 20 messages allowed.</span>")
+
+	var/list/decomposed
+	var/message = input(usr,"See your chat box for instructions. Keep a copy elsewhere in case it is rejected when you click OK.", "Input Conversation", "") as null|message
+
+	if(!message)
+		return
+
+	//Split on pipe or \n
+	decomposed = splittext(message,regex("\\||$","m"))
+	decomposed += "0" //Tack on a final 0 sleep to make 3-per-message evenly
+	
+	//Time to find how they screwed up.
+	//Wasn't the right length
+	if((decomposed.len) % 3) //+1 to accomidate the lack of a wait time for the last message
+		to_chat(usr,"<span class='warning'>You passed [decomposed.len] segments (senders+messages+pauses). You must pass a multiple of 3, minus 1 (no pause after the last message). That means a sender and message on every other line (starting on the first), separated by a pipe character (|), and a number every other line that is a pause in seconds.</span>")
+		return
+	
+	//Too long a conversation
+	if((decomposed.len / 3) > 20)
+		to_chat(usr,"<span class='warning'>This conversation is too long! 20 messages maximum, please.</span>")
+		return
+	
+	//Missed some sleeps, or sanitized to nothing.
+	for(var/i = 1; i < decomposed.len; i++)
+		
+		//Sanitize sender
+		var/clean_sender = sanitize(decomposed[i])
+		if(!clean_sender)
+			to_chat(usr,"<span class='warning'>One part of your conversation was not able to be sanitized. It was the sender of the [(i+2)/3]\th message.</span>")
+			return
+		decomposed[i] = clean_sender
+		
+		//Sanitize message
+		var/clean_message = sanitize(decomposed[++i])
+		if(!clean_message)
+			to_chat(usr,"<span class='warning'>One part of your conversation was not able to be sanitized. It was the body of the [(i+2)/3]\th message.</span>")
+			return
+		decomposed[i] = clean_message
+
+		//Sanitize wait time
+		var/clean_time = text2num(decomposed[++i])
+		if(!isnum(clean_time))
+			to_chat(usr,"<span class='warning'>One part of your conversation was not able to be sanitized. It was the wait time after the [(i+2)/3]\th message.</span>")
+			return
+		if(clean_time > 60)
+			to_chat(usr,"<span class='warning'>Max 60 second wait time between messages for sanity's sake please.</span>")
+			return
+		decomposed[i] = clean_time
+
+	log_admin("Intercom convo started by: [key_name(usr)] : [sanitize(message)]")
+	feedback_add_details("admin_verb","IN") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+
+	//Sanitized AND we still have a chance to send it? Wow!
+	if(LAZYLEN(decomposed))
+		for(var/i = 1; i < decomposed.len; i++)
+			var/this_sender = decomposed[i]
+			var/this_message = decomposed[++i]
+			var/this_wait = decomposed[++i]
+			global_announcer.autosay("[this_message]", "[this_sender]", "[channel == "Common" ? null : channel]") //Common is a weird case, as it's not a "channel", it's just talking into a radio without a channel set.
+			sleep(this_wait SECONDS)
 
 /datum/admins/proc/toggleooc()
 	set category = "Server"

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -26,6 +26,7 @@ var/list/admin_verbs_admin = list(
 	/datum/admins/proc/toggleguests,	//toggles whether guests can join the current game,
 	/datum/admins/proc/announce,		//priority announce something to all clients.,
 	/datum/admins/proc/intercom,		//send a fake intercom message, like an arrivals announcement,
+	/datum/admins/proc/intercom_convo,	//send a fake intercom conversation, like an ATC exchange,
 	/client/proc/colorooc,				//allows us to set a custom colour for everythign we say in ooc,
 	/client/proc/admin_ghost,			//allows us to ghost/reenter body at will,
 	/client/proc/toggle_view_range,		//changes how far we can see,

--- a/code/modules/clothing/spacesuits/rig/modules/utility_vr.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/utility_vr.dm
@@ -83,12 +83,8 @@
 
 	var/username = FindNameFromID(H) || "Unknown"
 	var/message = "[username] has overridden [A] (airlock) in \the [get_area(A)] at [A.x],[A.y],[A.z] with \the [src]."
-	var/obj/item/device/radio/headset/a = new /obj/item/device/radio/headset/heads/captain(null)
-	a.icon = icon
-	a.icon_state = icon_state
-	a.autosay(message, "Security Subsystem", "Command")
-	a.autosay(message, "Security Subsystem", "Security")
-	qdel(a)
+	global_announcer.autosay(message, "Security Subsystem", "Command")
+	global_announcer.autosay(message, "Security Subsystem", "Security")
 	return 1
 
 /obj/item/rig_module/rescue_pharm


### PR DESCRIPTION
Allows an admin to 'schedule' up to 20 messages to play on the radio.
The syntax is printed to your chat box for helping you out if you've never used it or forget how it works, but you just do repeats of:
```
Sender Name|Message Body
Delay Time
```

So, for example:
```
Blooper|Gosh I love not being a fox.
5
Bleeper|Wow you suck, foxes are the best!!!
5
Foxes|We are the best, aren't we
```
Says those 3 messages, with 5 second gaps between them:
![image](https://user-images.githubusercontent.com/15028025/36766426-da037b66-1c03-11e8-91e8-40e2cf30a1d3.png)

While I was in there, I fixed:
* The global announcer is now able to talk on any channel, which fixes anything that previously was trying to send messages on specific channels (morgue trays is one example)
* Some dumb relative pathing in radio.dm
