### PR TITLE
Fix a runtime with snacks

### DIFF
--- a/code/modules/reagents/reagent_containers/food/z_custom_food_vr.dm
+++ b/code/modules/reagents/reagent_containers/food/z_custom_food_vr.dm
@@ -48,8 +48,10 @@ var/global/ingredientLimit = 20
 			return*/
 		user.drop_item()
 		I.forceMove(src)
-
-		S.reagents.trans_to(src,S.reagents.total_volume)
+		
+		if(S.reagents)
+			S.reagents.trans_to(src,S.reagents.total_volume)
+		
 		ingredients += S
 
 		if(src.addTop)


### PR DESCRIPTION
Seeing a runtime on these when they don't have reagents for w/e reason. Simple safety check to stop it.