### PR TITLE
Make syringes not require 3 clicks to inject

### DIFF
--- a/code/_helpers/mobs.dm
+++ b/code/_helpers/mobs.dm
@@ -213,6 +213,8 @@ Proc for attack log creation, because really why not
 /proc/do_after(mob/user, delay, atom/target = null, needhand = 1, progress = 1, var/incapacitation_flags = INCAPACITATION_DEFAULT)
 	if(!user)
 		return 0
+	if(!delay)
+		return 1 //Okay. Done.
 	var/atom/target_loc = null
 	if(target)
 		target_loc = target.loc

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -214,13 +214,13 @@
 				mode = SYRINGE_DRAW
 				update_icon()
 
-				dirty(target,affected) //VOREStation Add
 			if(trans)
 				to_chat(user, "<span class='notice'>You inject [trans] units of the solution. The syringe now contains [src.reagents.total_volume] units.</span>")
 				admin_inject_log(user, target, src, contained, trans)
 			else
 				to_chat(user, "<span class='notice'>The syringe is empty.</span>")
 
+			dirty(target,affected) //VOREStation Add
 
 	return
 /* VOREStation Edit - See syringes_vr.dm

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -67,6 +67,7 @@
 		syringestab(target, user)
 		return
 
+	var/injtime = time // Calculated 'true' injection time (as added to by hardsuits and whatnot), 66% of this goes to warmup, then every 33% after injects 5u
 	switch(mode)
 		if(SYRINGE_DRAW)
 			if(!reagents.get_free_space())
@@ -170,9 +171,10 @@
 					to_chat(user, "<span class='danger'>You cannot inject a robotic limb.</span>")
 					return
 
+			var/warmup_time = 0 //None if we're using this on ourselves.
+			var/cycle_time = injtime*0.33 //33% of the time slept between 5u doses
 			if(ismob(target) && target != user)
-
-				var/injtime = time //Injecting through a hardsuit takes longer due to needing to find a port.
+				warmup_time = injtime*0.66 //66% of the time is warmup
 
 				if(istype(H))
 					if(H.wear_suit)
@@ -188,32 +190,37 @@
 						return
 
 				if(injtime == time)
-					user.visible_message("<span class='warning'>[user] is trying to inject [target] with [visible_name]!</span>")
+					user.visible_message("<span class='warning'>[user] is trying to inject [target] with [visible_name]!</span>","<span class='notice'>You begin injecting [target] with [visible_name].</span>")
 				else
-					user.visible_message("<span class='warning'>[user] begins hunting for an injection port on [target]'s suit!</span>")
+					user.visible_message("<span class='warning'>[user] begins hunting for an injection port on [target]'s suit!</span>","<span class='notice'>You begin hunting for an injection port on [target]'s suit!</span>")
 
-				user.setClickCooldown(DEFAULT_QUICK_COOLDOWN)
+			//The warmup
+			user.setClickCooldown(DEFAULT_QUICK_COOLDOWN)
+			if(!do_after(user,warmup_time,target))
+				return
 
-				if(!do_mob(user, target, injtime))
-					return
-
-				user.visible_message("<span class='warning'>[user] injects [target] with the syringe!</span>")
-
-			var/trans
-			if(ismob(target))
-				var/contained = reagentlist()
-				trans = reagents.trans_to_mob(target, amount_per_transfer_from_this, CHEM_BLOOD)
-				dirty(target,affected) //VOREStation Add
-				admin_inject_log(user, target, src, contained, trans)
-			else
-				trans = reagents.trans_to_obj(target, amount_per_transfer_from_this)
-			if(trans)
-				to_chat(user, "<span class='notice'>You inject [trans] units of the solution. The syringe now contains [src.reagents.total_volume] units.</span>")
-			else
-				to_chat(user, "<span class='notice'>The syringe is empty.</span>")
+			var/trans = 0
+			var/contained = reagentlist()
+			while(reagents.total_volume)
+				if(ismob(target))
+					trans += reagents.trans_to_mob(target, amount_per_transfer_from_this, CHEM_BLOOD)	
+				else
+					trans += reagents.trans_to_obj(target, amount_per_transfer_from_this)
+				update_icon()
+				if(!reagents.total_volume || !do_after(user,cycle_time,target))
+					break
+			
 			if (reagents.total_volume <= 0 && mode == SYRINGE_INJECT)
 				mode = SYRINGE_DRAW
 				update_icon()
+
+				dirty(target,affected) //VOREStation Add
+			if(trans)
+				to_chat(user, "<span class='notice'>You inject [trans] units of the solution. The syringe now contains [src.reagents.total_volume] units.</span>")
+				admin_inject_log(user, target, src, contained, trans)
+			else
+				to_chat(user, "<span class='notice'>The syringe is empty.</span>")
+
 
 	return
 /* VOREStation Edit - See syringes_vr.dm


### PR DESCRIPTION
Previously they took (usually) 30ds to inject and you'd click 3 times to stack them and inject 5u each time. A little silly if you ask me, kind of a weird mechanic.

Now they take their injection time (so 30ds usually) and 66% of that is for starting the first injection, then it repeats the remaining 33% for it's injection size until it's empty.

So for a normal syringe this would be one click to get: 2s to do the first 5u, then 1s for the next 5u, then 1s more for the last 5u. Assuming there's that much in the syringe, anyway.