### PR TITLE
A whole bunch of vore related fixes.

### DIFF
--- a/code/modules/mob/death.dm
+++ b/code/modules/mob/death.dm
@@ -70,7 +70,7 @@
 
 	if(stat == DEAD)
 		return 0
-	if(src.loc && istype(loc,/mob/living)) deathmessage = "no message" //VOREStation Add - Prevents death messages from inside mobs
+	if(src.loc && istype(loc,/obj/belly)) deathmessage = "no message" //VOREStation Add - Prevents death messages from inside mobs
 	facing_dir = null
 
 	if(!gibbed && deathmessage != "no message") // This is gross, but reliable. Only brains use it.

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -901,6 +901,11 @@
 		if(overeatduration > 1)
 			overeatduration -= 2 //doubled the unfat rate
 
+	if(noisy == TRUE && nutrition < 250 && prob(10)) //VOREStation edit for hunger noises.
+		var/growlsound = pick(hunger_sounds)
+		var/growlmultiplier = 100 - (nutrition / 250 * 100)
+		playsound(src, growlsound, vol = growlmultiplier, vary = 1, falloff = 0.1, ignore_walls = FALSE, preference = /datum/client_preference/digestion_noises)
+
 	if(!isSynthetic() && (species.flags & IS_PLANT) && (!light_organ || light_organ.is_broken()))
 		if(nutrition < 200)
 			take_overall_damage(2,0)

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -904,7 +904,7 @@
 	if(noisy == TRUE && nutrition < 250 && prob(10)) //VOREStation edit for hunger noises.
 		var/growlsound = pick(hunger_sounds)
 		var/growlmultiplier = 100 - (nutrition / 250 * 100)
-		playsound(src, growlsound, vol = growlmultiplier, vary = 1, falloff = 0.1, ignore_walls = FALSE, preference = /datum/client_preference/digestion_noises)
+		playsound(src, growlsound, vol = growlmultiplier, vary = 1, falloff = 0.1, ignore_walls = TRUE, preference = /datum/client_preference/digestion_noises)
 
 	if(!isSynthetic() && (species.flags & IS_PLANT) && (!light_organ || light_organ.is_broken()))
 		if(nutrition < 200)

--- a/code/modules/mob/living/silicon/robot/robot_modules/station_vr.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules/station_vr.dm
@@ -123,6 +123,7 @@
 	//R.icon_state = "k9"
 	R.pixel_x 	 = -16
 	R.old_x 	 = -16
+	R.default_pixel_x = -16
 	R.dogborg = TRUE
 	..()
 
@@ -174,6 +175,7 @@
 	//R.icon_state = "medihound"
 	R.pixel_x 	 = -16
 	R.old_x  	 = -16
+	R.default_pixel_x = -16
 	R.dogborg = TRUE
 	..()
 
@@ -200,6 +202,7 @@
 	R.hands.icon = 'icons/mob/screen1_robot_vr.dmi'
 	R.pixel_x 	 = -16
 	R.old_x 	 = -16
+	R.default_pixel_x = -16
 	R.dogborg = TRUE
 	..()
 
@@ -223,6 +226,7 @@
 	//R.icon_state = "scrubpup"
 	R.pixel_x 	 = -16
 	R.old_x 	 = -16
+	R.default_pixel_x = -16
 	R.dogborg = TRUE
 	..()
 
@@ -255,6 +259,7 @@
 	//R.icon_state = "science"
 	R.pixel_x 	 = -16
 	R.old_x 	 = -16
+	R.default_pixel_x = -16
 	R.dogborg = TRUE
 	..()
 

--- a/code/modules/mob/living/simple_animal/simple_animal_vr.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal_vr.dm
@@ -89,7 +89,7 @@
 	if(M.size_multiplier < vore_min_size || M.size_multiplier > vore_max_size)
 		ai_log("vr/wont eat [M] because they too small or too big", 3)
 		return 0
-	if(vore_capacity != 0 && (vore_fullness + M.size_multiplier > vore_capacity)) // We're too full to fit them
+	if(vore_capacity != 0 && (vore_fullness >= vore_capacity)) // We're too full to fit them
 		ai_log("vr/wont eat [M] because I am too full", 3)
 		return 0
 	return 1
@@ -188,7 +188,7 @@
 		"The juices pooling beneath you sizzle against your sore skin.",
 		"The churning walls slowly pulverize you into meaty nutrients.",
 		"The stomach glorps and gurgles as it tries to work you into slop.")
-	
+
 /mob/living/simple_animal/Bumped(var/atom/movable/AM, yes)
 	if(ismob(AM))
 		var/mob/tmob = AM

--- a/code/modules/mob/living/simple_animal/vore/badboi.dm
+++ b/code/modules/mob/living/simple_animal/vore/badboi.dm
@@ -33,6 +33,7 @@
 
 	old_x = -16
 	old_y = 0
+	default_pixel_x = -16
 	pixel_x = -16
 	pixel_y = 0
 

--- a/code/modules/mob/living/simple_animal/vore/carp.dm
+++ b/code/modules/mob/living/simple_animal/vore/carp.dm
@@ -5,7 +5,7 @@
 	icon_dead = "megacarp-dead"
 	icon_living = "megacarp"
 	icon_state = "megacarp"
-	
+
 	maxHealth = 600 // Boss
 	health = 600
 	speed = 3
@@ -16,6 +16,8 @@
 	melee_damage_upper = 25
 	old_x = -16
 	old_y = -16
+	default_pixel_x = -16
+	default_pixel_y = -16
 	pixel_x = -16
 	pixel_y = -16
 	vore_capacity = 2

--- a/code/modules/mob/living/simple_animal/vore/deathclaw.dm
+++ b/code/modules/mob/living/simple_animal/vore/deathclaw.dm
@@ -19,7 +19,6 @@
 	old_x = -16
 	old_y = 0
 	default_pixel_x = -16
-	default_pixel_y = -16
 	pixel_x = -16
 	pixel_y = 0
 

--- a/code/modules/mob/living/simple_animal/vore/deathclaw.dm
+++ b/code/modules/mob/living/simple_animal/vore/deathclaw.dm
@@ -18,6 +18,8 @@
 
 	old_x = -16
 	old_y = 0
+	default_pixel_x = -16
+	default_pixel_y = -16
 	pixel_x = -16
 	pixel_y = 0
 

--- a/code/modules/mob/living/simple_animal/vore/dragon.dm
+++ b/code/modules/mob/living/simple_animal/vore/dragon.dm
@@ -26,6 +26,7 @@
 
 	old_x = -16
 	old_y = 0
+	default_pixel_x = -16
 	pixel_x = -16
 	pixel_y = 0
 

--- a/code/modules/mob/living/simple_animal/vore/otie.dm
+++ b/code/modules/mob/living/simple_animal/vore/otie.dm
@@ -41,6 +41,7 @@
 	meat_amount = 6
 	old_x = -16
 	old_y = 0
+	default_pixel_x = -16
 	pixel_x = -16
 	pixel_y = 0
 
@@ -193,7 +194,7 @@
 	. = ..()
 
 /mob/living/simple_animal/otie/security/feed_grabbed_to_self(var/mob/living/user, var/mob/living/prey) // Make the gut start out safe for bellybrigging.
-	if(ishuman(target_mob))
+	if(ishuman(prey))
 		vore_selected.digest_mode = DM_HOLD
 	if(istype(prey,/mob/living/simple_animal/mouse))
 		vore_selected.digest_mode = DM_DIGEST

--- a/code/modules/mob/living/simple_animal/vore/panther.dm
+++ b/code/modules/mob/living/simple_animal/vore/panther.dm
@@ -22,6 +22,7 @@
 
 	old_x = -16
 	old_y = 0
+	default_pixel_x = -16
 	pixel_x = -16
 	pixel_y = 0
 

--- a/code/modules/mob/living/simple_animal/vore/snake.dm
+++ b/code/modules/mob/living/simple_animal/vore/snake.dm
@@ -15,6 +15,8 @@
 
 	old_x = -16
 	old_y = -16
+	default_pixel_x = -16
+	default_pixel_y = -16
 	pixel_x = -16
 	pixel_y = -16
 

--- a/code/modules/mob/living/simple_animal/vore/zz_vore_overrides.dm
+++ b/code/modules/mob/living/simple_animal/vore/zz_vore_overrides.dm
@@ -68,6 +68,7 @@
 	vore_icons = SA_ICON_LIVING
 	old_x = -16
 	old_y = 0
+	default_pixel_x = -16
 	pixel_x = -16
 	pixel_y = 0
 

--- a/code/modules/vore/eating/belly_obj_vr.dm
+++ b/code/modules/vore/eating/belly_obj_vr.dm
@@ -1,4 +1,4 @@
-#define VORE_SOUND_FALLOFF 0.05
+#define VORE_SOUND_FALLOFF 0.1
 
 //
 //  Belly system 2.0, now using objects instead of datums because EH at datums.
@@ -44,7 +44,7 @@
 	var/tmp/list/items_preserved = list()		// Stuff that wont digest so we shouldn't process it again.
 	var/tmp/next_emote = 0						// When we're supposed to print our next emote, as a belly controller tick #
 	var/tmp/recent_sound = FALSE				// Prevent audio spam
-	
+
 	// Don't forget to watch your commas at the end of each line if you change these.
 	var/list/struggle_messages_outside = list(
 		"%pred's %belly wobbles with a squirming meal.",
@@ -152,14 +152,14 @@
 
 	//Generic entered message
 	to_chat(owner,"<span class='notice'>[thing] slides into your [lowertext(name)].</span>")
-	
+
 	//Sound w/ antispam flag setting
 	if(vore_sound && !recent_sound)
 		var/soundfile = vore_sounds[vore_sound]
 		if(soundfile)
 			playsound(src, soundfile, vol = 100, vary = 1, falloff = VORE_SOUND_FALLOFF, preference = /datum/client_preference/eating_noises)
 			recent_sound = TRUE
-	
+
 	//Messages if it's a mob
 	if(isliving(thing))
 		var/mob/living/M = thing
@@ -168,7 +168,7 @@
 		var/taste
 		if(can_taste && (taste = M.get_taste_message(FALSE)))
 			to_chat(owner, "<span class='notice'>[M] tastes of [taste].</span>")
-	
+
 // Release all contents of this belly into the owning mob's location.
 // If that location is another mob, contents are transferred into whichever of its bellies the owning mob is in.
 // Returns the number of mobs so released.

--- a/code/modules/vore/eating/belly_obj_vr.dm
+++ b/code/modules/vore/eating/belly_obj_vr.dm
@@ -173,6 +173,8 @@
 // If that location is another mob, contents are transferred into whichever of its bellies the owning mob is in.
 // Returns the number of mobs so released.
 /obj/belly/proc/release_all_contents(var/include_absorbed = FALSE)
+	if(!contents.len)
+		return 0
 	var/atom/destination = drop_location()
 	var/count = 0
 	for(var/thing in contents)

--- a/code/modules/vore/eating/bellymodes_vr.dm
+++ b/code/modules/vore/eating/bellymodes_vr.dm
@@ -472,7 +472,5 @@
 			put_in_egg(P,1)
 
 	if(play_sound)
-		for (var/mob/living/M in contents)
-			M << sound(play_sound)
-		playsound(src, play_sound, vol = 100, vary = 1, falloff = VORE_SOUND_FALLOFF, ignore_walls = FALSE, preference = /datum/client_preference/digestion_noises)
+		playsound(src, play_sound, vol = 100, vary = 1, falloff = VORE_SOUND_FALLOFF, ignore_walls = TRUE, preference = /datum/client_preference/digestion_noises)
 	return SSBELLIES_PROCESSED

--- a/code/modules/vore/eating/bellymodes_vr.dm
+++ b/code/modules/vore/eating/bellymodes_vr.dm
@@ -3,7 +3,7 @@
 	if((times_fired < next_process) || !contents.len)
 		recent_sound = FALSE
 		return SSBELLIES_IGNORED
-	
+
 	if(loc != owner)
 		if(istype(owner))
 			loc = owner
@@ -41,7 +41,7 @@
 
 		if(prob(50)) //Was SO OFTEN. AAAA.
 			play_sound = pick(digestion_sounds)
-			
+
 		for (var/mob/living/M in contents)
 			//Pref protection!
 			if (!M.digestable || M.absorbed)
@@ -472,5 +472,7 @@
 			put_in_egg(P,1)
 
 	if(play_sound)
+		for (var/mob/living/M in contents)
+			M << sound(play_sound)
 		playsound(src, play_sound, vol = 100, vary = 1, falloff = VORE_SOUND_FALLOFF, ignore_walls = FALSE, preference = /datum/client_preference/digestion_noises)
 	return SSBELLIES_PROCESSED


### PR DESCRIPTION
-Fixes prey not hearing gurgles from inside the gut.
-Tweaked the miniscule vore sound falloff that made things barely audible at all. People not in the immediately adjacent tiles may hear some faint noises if they listen intently enough, but that feels like a less of a problem compared to the stuff being barely hearable on ground zero tile. We already have a toggle pref now for the gurgle intolerant crowd.
-Fixes hunger noises.
-Hunger noises now scale gradually from 0 to 100% vol in the span of 250 to 0 nutrition.
-Fixes attack anims messing up pixel offsets on our big voremobs and dogborgs.
-Removes prey size multiplier from mob vore "fullness" will_eat blocker that would prevent 1-seater mobs from touching any even slightly taller than average chars. They already have a separate max size blocker in the will_eat thing.
-Makes bellies hide prey deathmessages again.
-Fixes security oties not changing to hold mode for human arrests.(I swear I had fixed this thing before???)
-Also disables the loud and spammy ejection on empty guts. Mobs were literally doing the thing every time they'd get killed, digested, or deleted and I found that extra bothersome while testing on the other stuffs. Gurgling a belly enabled mob caused at least 2 **SPLATS** every time.

Fixes #3173