### PR TITLE
Remove Spaceacillin

### DIFF
--- a/code/__defines/chemistry.dm
+++ b/code/__defines/chemistry.dm
@@ -36,6 +36,10 @@
 
 #define REAGENTS_PER_SHEET 20
 
+#define ANTIBIO_NORM	1
+#define ANTIBIO_OD		2
+#define ANTIBIO_SUPER	3
+
 // Chemistry lists.
 var/list/tachycardics  = list("coffee", "inaprovaline", "hyperzine", "nitroglycerin", "thirteenloko", "nicotine") // Increase heart rate.
 var/list/bradycardics  = list("neurotoxin", "cryoxadone", "clonexadone", "space_drugs", "stoxin")                 // Decrease heart rate.

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -148,25 +148,25 @@ var/list/organ_cache = list()
 		germ_level = 0
 		return 0
 
-	var/antibiotics = owner.reagents.get_reagent_amount("spaceacillin")
+	var/antibiotics = owner.chem_effects[CE_ANTIBIOTIC] || 0
 
 	var/infection_damage = 0
 
-	if((status & ORGAN_DEAD) && antibiotics < 30) //Sepsis from 'dead' organs
+	if((status & ORGAN_DEAD) && antibiotics < ANTIBIO_OD) //Sepsis from 'dead' organs
 		infection_damage = min(1, 1 + round((germ_level - INFECTION_LEVEL_THREE)/200,0.25)) //1 Tox plus a little based on germ level
 
-	else if(germ_level > INFECTION_LEVEL_TWO && antibiotics < 30)
+	else if(germ_level > INFECTION_LEVEL_TWO && antibiotics < ANTIBIO_OD)
 		infection_damage = min(0.25, 0.25 + round((germ_level - INFECTION_LEVEL_TWO)/200,0.25))
 
 	if(infection_damage)
 		owner.adjustToxLoss(infection_damage)
 
 	if (germ_level > 0 && germ_level < INFECTION_LEVEL_ONE/2 && prob(30))
-		adjust_germ_level(-1)
+		adjust_germ_level(-antibiotics)
 
 	if (germ_level >= INFECTION_LEVEL_ONE/2)
 		//aiming for germ level to go from ambient to INFECTION_LEVEL_TWO in an average of 15 minutes
-		if(antibiotics < 5 && prob(round(germ_level/6)))
+		if(!antibiotics && prob(round(germ_level/6)))
 			adjust_germ_level(1)
 
 	if(germ_level >= INFECTION_LEVEL_ONE)
@@ -181,7 +181,7 @@ var/list/organ_cache = list()
 		. = 2 //Organ qualifies for effect-specific processing
 		//No particular effect on the general 'organ' at 3
 
-	if (germ_level >= INFECTION_LEVEL_THREE && antibiotics < 30)
+	if (germ_level >= INFECTION_LEVEL_THREE && antibiotics < ANTIBIO_OD)
 		. = 3 //Organ qualifies for effect-specific processing
 		adjust_germ_level(rand(5,10)) //Germ_level increases without overdose of antibiotics
 
@@ -234,19 +234,19 @@ var/list/organ_cache = list()
 
 //Germs
 /obj/item/organ/proc/handle_antibiotics()
-	var/antibiotics = owner.reagents.get_reagent_amount("spaceacillin")
+	var/antibiotics = owner.chem_effects[CE_ANTIBIOTIC] || 0
 
-	if (!germ_level || antibiotics < 5)
+	if (!germ_level || antibiotics < ANTIBIO_NORM)
 		return
 
 	if (germ_level < INFECTION_LEVEL_ONE)
 		germ_level = 0	//cure instantly
 	else if (germ_level < INFECTION_LEVEL_TWO)
-		adjust_germ_level(-6)	//at germ_level < 500, this should cure the infection in a minute
+		adjust_germ_level(-antibiotics*4)	//at germ_level < 500, this should cure the infection in a minute
 	else if (germ_level < INFECTION_LEVEL_THREE)
-		adjust_germ_level(-2) //at germ_level < 1000, this will cure the infection in 5 minutes
+		adjust_germ_level(-antibiotics*2) //at germ_level < 1000, this will cure the infection in 5 minutes
 	else
-		adjust_germ_level(-1)	// You waited this long to get treated, you don't really deserve this organ
+		adjust_germ_level(-antibiotics)	// You waited this long to get treated, you don't really deserve this organ
 
 //Adds autopsy data for used_weapon.
 /obj/item/organ/proc/add_autopsy_data(var/used_weapon, var/damage)

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -101,7 +101,7 @@
 /datum/reagent/proc/affect_touch(var/mob/living/carbon/M, var/alien, var/removed)
 	return
 
-/datum/reagent/proc/overdose(var/mob/living/carbon/M, var/alien, var/removed) // Overdose effect. Doesn't happen instantly.
+/datum/reagent/proc/overdose(var/mob/living/carbon/M, var/alien, var/removed) // Overdose effect.
 	if(alien == IS_DIONA)
 		return
 	if(ishuman(M))

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -509,10 +509,45 @@
 	taste_description = "bitterness"
 	reagent_state = LIQUID
 	color = "#C1C1C1"
-	metabolism = REM * 0.05
+	metabolism = REM * 0.25
 	mrate_static = TRUE
 	overdose = REAGENTS_OVERDOSE
 	scannable = 1
+
+/datum/reagent/spaceacillin/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
+	..()
+	M.add_chemical_effect(CE_ANTIBIOTIC, dose >= overdose ? ANTIBIO_OD : ANTIBIO_NORM)
+
+/datum/reagent/corophizine
+	name = "Corophizine"
+	id = "corophizine"
+	description = "A wide-spectrum antibiotic drug. Powerful and uncomfortable in equal doses."
+	taste_description = "burnt toast"
+	reagent_state = LIQUID
+	color = "#FFB0B0"
+	mrate_static = TRUE
+	overdose = 10
+	scannable = 1
+
+/datum/reagent/corophizine/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
+	..()
+	M.add_chemical_effect(CE_ANTIBIOTIC, ANTIBIO_SUPER)
+	
+	//Based roughly on Levofloxacin's rather severe side-effects
+	if(prob(20))
+		M.Confuse(5)
+	if(prob(20))
+		M.Weaken(5)
+	if(prob(20))
+		M.make_dizzy(5)
+	if(prob(20))
+		M.hallucination = max(M.hallucination, 10)
+	
+	//One of the levofloxacin side effects is 'spontaneous tendon rupture', which I'll immitate here. 1:1000 chance, so, pretty darn rare.
+	if(ishuman(M) && rand(1,1000) == 1)
+		var/mob/living/carbon/human/H = M
+		var/obj/item/organ/external/eo = pick(H.organs) //Misleading variable name, 'organs' is only external organs
+		eo.fracture()
 
 /datum/reagent/sterilizine
 	name = "Sterilizine"

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -417,6 +417,14 @@
 	required_reagents = list("cryptobiolin" = 1, "inaprovaline" = 1)
 	result_amount = 2
 
+/datum/chemical_reaction/corophizine
+	name = "Corophizine"
+	id = "corophizine"
+	result = "corophizine"
+	required_reagents = list("spaceacillin" = 1, "carbon" = 1, "phoron" = 0.1)
+	catalysts = list("phoron" = 5)
+	result_amount = 2
+
 /datum/chemical_reaction/imidazoline
 	name = "imidazoline"
 	id = "imidazoline"


### PR DESCRIPTION
's dominance in the antibiotic market by adding another antibiotic, plus make spaceacillin work when ingested because it was coded in a weird way originally that made it totally ineffective when used as a drink or pill.

The numeric effects of spaceacillin are not EXACTLY the same as before, but mostly change in the player's favor: ODing spaceacillin generally removes infection twice as fast, so you can do that if you really want. Previously it did nothing, and only had an effect if they were in late-stage infections.

Also adds "Corophizine"
* OD Level: 10u
* Effects: Extreme antibiotic, more effective than spaceacillin, but with side effects that make it a very poor choice outside of a hospital setting.
* Recipe: Spaceacillin 1, Carbon 1, Phoron 0.1 (+5 Phoron catalyst) = 2 corophizine

Fixes #3176 
