### PR TITLE
Fix un-eqipping gear with a single click.

### DIFF
--- a/code/modules/clothing/clothing_accessories.dm
+++ b/code/modules/clothing/clothing_accessories.dm
@@ -29,7 +29,7 @@
 		return
 	if (ishuman(user) && src.loc == user)
 		var/mob/living/carbon/human/H = user
-		if(src != H.l_store && src != H.r_store && src != H.s_store)
+		if(src == H.w_uniform) // VOREStation Edit - Un-equip on single click, but not on uniform.
 			return
 	return ..()
 


### PR DESCRIPTION
Restored this functionality to the way it was, with the exception of uniforms.  That drops everything when you remove it, so is still protected.