### PR TITLE
Fixes #3209, fixes the cancel button in ears/wings/tail selection clearing the respective selection

### DIFF
--- a/code/modules/client/preference_setup/vore/01_ears.dm
+++ b/code/modules/client/preference_setup/vore/01_ears.dm
@@ -186,8 +186,9 @@
 				pretty_ear_styles[instance.name] = path
 
 		// Present choice to user
-		var/selection = input(user, "Pick ears", "Character Preference") as null|anything in pretty_ear_styles
-		pref.ear_style = pretty_ear_styles[selection]
+		var/new_ear_style = input(user, "Pick ears", "Character Preference", pref.ear_style) as null|anything in pretty_ear_styles
+		if(new_ear_style)
+			pref.ear_style = pretty_ear_styles[new_ear_style]
 
 		return TOPIC_REFRESH_UPDATE_PREVIEW
 
@@ -218,8 +219,9 @@
 				pretty_tail_styles[instance.name] = path
 
 		// Present choice to user
-		var/selection = input(user, "Pick tails", "Character Preference") as null|anything in pretty_tail_styles
-		pref.tail_style = pretty_tail_styles[selection]
+		var/new_tail_style = input(user, "Pick tails", "Character Preference", pref.tail_style) as null|anything in pretty_tail_styles
+		if(new_tail_style)
+			pref.tail_style = pretty_tail_styles[new_tail_style]
 
 		return TOPIC_REFRESH_UPDATE_PREVIEW
 
@@ -250,8 +252,9 @@
 				pretty_wing_styles[instance.name] = path
 
 		// Present choice to user
-		var/selection = input(user, "Pick wings", "Character Preference") as null|anything in pretty_wing_styles
-		pref.wing_style = pretty_wing_styles[selection]
+		var/new_wing_style = input(user, "Pick wings", "Character Preference", pref.wing_style) as null|anything in pretty_wing_styles
+		if(new_wing_style)
+			pref.wing_style = pretty_wing_styles[new_wing_style]
 
 		return TOPIC_REFRESH_UPDATE_PREVIEW
 

--- a/code/modules/mob/living/simple_animal/vore/shadekin/shadekin.dm
+++ b/code/modules/mob/living/simple_animal/vore/shadekin/shadekin.dm
@@ -447,6 +447,6 @@
 	speech_verb = "mars"
 	ask_verb = "mars"
 	exclaim_verb = "mars"
-	key = "s"
+	key = "m"
 	machine_understands = 0
 	flags = RESTRICTED | HIVEMIND


### PR DESCRIPTION
The shadekin empathy key is now "m" for mar. I've tested shadekin empathy, sign language, and medical radio to make sure they work. Fixes #3209

Also fixes the ears/wings/tail selection being cleared when the cancel button in the menu for selecting the respective thing is clicked. Also changes the name of the variable that stores the new selection to match the ones for hair, why not. (Sorry if those two sentences don't make any sense, I can't find better ways to word them.)