### PR TITLE
Makes the monstertamer/clonexadone reaction force hatching too

### DIFF
--- a/code/modules/reagents/Chemistry-Recipes_vr.dm
+++ b/code/modules/reagents/Chemistry-Recipes_vr.dm
@@ -57,11 +57,19 @@
 	if(ishuman(holder.my_atom))
 		var/mob/living/carbon/human/H = holder.my_atom
 		if(H.stat == DEAD && (/mob/living/carbon/human/proc/begin_reconstitute_form in H.verbs)) //no magical regen for non-regenners, and can't force the reaction on live ones
-			if(H.hasnutriment() && !H.reviving) // make sure it actually has the conditions to revive
-				H.visible_message("<span class='info'>[H] shudders briefly, then relaxes, faint movements stirring within.</span>")
-				H.chimera_regenerate()
+			if(H.hasnutriment()) // make sure it actually has the conditions to revive
+				if(!H.reviving) // if it's not reviving, start doing so
+					H.visible_message("<span class='info'>[H] shudders briefly, then relaxes, faint movements stirring within.</span>")
+					H.chimera_regenerate()
+				else if (/mob/living/carbon/human/proc/hatch in H.verbs)// already reviving, check if they're ready to hatch
+					H.chimera_hatch()
+					H.visible_message("<span class='danger'><p><font size=4>[H] violently convulses and then bursts open, revealing a new, intact copy in the pool of viscera.</font></p></span>") // Hope you were wearing waterproofs, doc...
+					H.adjustBrainLoss(10) // they're reviving from dead, so take 10 brainloss
+				else //they're already reviving but haven't hatched. Give a little message to tell them to wait.
+					H.visible_message("<span class='info'>[H] stirs faintly, but doesn't appear to be ready to wake up yet.</span>")
 			else
-				H.visible_message("<span class='info'>[H] twitches for a moment, but remains still.</span>")
+				H.visible_message("<span class='info'>[H] twitches for a moment, but remains still.</span>") // no nutriment
+
 
 ///////////////////////////////////////////////////////////////////////////////////
 /// Vore Drugs


### PR DESCRIPTION
It's a bit of an edge case, but there was a potential problem where a dead chimera could be sleevecarded by a doctor that didn't know any better, and because they're dead would be unable to sleeve their mind back into the body, thus leaving them unable to hit the revive button and taking them out of the round permanently without admin intervention.

Rather than yelling "no don't sleevecard m- oh for fuck's sake" in LOOC, figured it'd be better to let the existing reaction mash the buttons on the chimera's behalf. Now if you encounter a deadmera, you can happily sleevecard them, give them a whole bunch of injections, wait for them to bake at gas mark 5 for 20 minutes while you do teasy things to them in your nif or whatever, give them another injection to wake them up, then sleeve their mind back into their newly-hatched body.

I swear I'd catch these edge cases more often if I wasn't so risk-averse in game. Like seriously when was the last time Scree actually had to use his revive? I caught a bug in the code that time too.