### PR TITLE
Runtime Fixes - March

### DIFF
--- a/code/modules/reagents/reagent_containers/syringes_vr.dm
+++ b/code/modules/reagents/reagent_containers/syringes_vr.dm
@@ -14,7 +14,7 @@
 
 /obj/item/weapon/reagent_containers/syringe/Destroy()
 	qdel_null_list(viruses)
-	targets.Cut()
+	LAZYCLEARLIST(targets)
 	return ..()
 
 /obj/item/weapon/reagent_containers/syringe/process()

--- a/config/custom_items.txt
+++ b/config/custom_items.txt
@@ -470,11 +470,11 @@ character_name: Chakat Taiga
 item_path: /obj/item/clothing/under/fluff/taiga
 }
 
-{
-ckey: kligor
-character_name: Andy Gettemy
-item_path: /obj/item/device/pda_mod/fluff/kligor
-}
+#{
+#ckey: kligor
+#character_name: Andy Gettemy
+#item_path: /obj/item/device/pda_mod/fluff/kligor
+#}
 
 {
 ckey: konabird
@@ -858,11 +858,11 @@ item_path: /obj/item/clothing/mask/gas/sexymime
 }
 
 # ######## W CKEYS
-{
-ckey: warbrand2
-character_name: Brandy draca
-item_path: /obj/item/device/pda_mod/fluff/warbrand2
-}
+#{
+#ckey: warbrand2
+#character_name: Brandy draca
+#item_path: /obj/item/device/pda_mod/fluff/warbrand2
+#}
 
 {
 ckey: werebear


### PR DESCRIPTION
- Fix DEBUG: Runtime in syringes_vr.dm,17: Cannot execute null.Cut()
- Fixes Runtime in item_spawning.dm,38: Cannot create objects of type null by removing obsolete custom items. There is no such type as `/obj/item/device/pda_mod`, and there has not ever been such a type on this codebase.  Last time it existed was in pre-github baystation code.