### PR TITLE
Reduce lightweight trait point return

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/negative.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/negative.dm
@@ -110,7 +110,7 @@
 /datum/trait/lightweight
 	name = "Lightweight"
 	desc = "Your light weight and poor balance make you very susceptible to unhelpful bumping. Think of it like a bowling ball versus a pin."
-	cost = -4
+	cost = -2
 	var_changes = list("lightweight" = 1)
 
 /datum/trait/colorblind

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -137,8 +137,6 @@ default behaviour is:
 				return
 
 			// VOREStation Edit - Begin
-			// Handle grabbing, stomping, and such of micros!
-			if(handle_micro_bump_other(tmob)) return
 			// Plow that nerd.
 			if(ishuman(tmob))
 				var/mob/living/carbon/human/H = tmob
@@ -147,6 +145,8 @@ default behaviour is:
 					H.Weaken(20)
 					now_pushing = 0
 					return
+			// Handle grabbing, stomping, and such of micros!
+			if(handle_micro_bump_other(tmob)) return
 			// VOREStation Edit - End
 
 			if(istype(tmob, /mob/living/carbon/human) && (FAT in tmob.mutations))


### PR DESCRIPTION
No single "Free Haste+" traits pls.

Given that it only has a 50% chance of happening, and causes no damage, this isn't worth -4.

Also this was basically 4 free points for any micro, because it completely ignored it for size-difference steps, thus resulting in a trait that did literally nothing, and gave you 4 points.