### PR TITLE
Readd include_name param on key_name because it's used

### DIFF
--- a/code/_helpers/logging.dm
+++ b/code/_helpers/logging.dm
@@ -140,7 +140,7 @@
 
 //more or less a logging utility
 //Always return "Something/(Something)", even if it's an error message.
-/proc/key_name(var/whom, var/include_link = null, var/highlight_special_characters = 1)
+/proc/key_name(var/whom, var/include_link = FALSE, var/include_name = TRUE, var/highlight_special_characters = TRUE)
 	var/mob/M
 	var/client/C
 	var/key
@@ -186,17 +186,18 @@
 	else
 		. += "INVALID"
 
-	var/name = "INVALID"
-	if(M)
-		if(M.real_name)
-			name = M.real_name
-		else if(M.name)
-			name = M.name
+	if(include_name)
+		var/name = "INVALID"
+		if(M)
+			if(M.real_name)
+				name = M.real_name
+			else if(M.name)
+				name = M.name
 
-		if(include_link && is_special_character(M) && highlight_special_characters)
-			name = "<font color='#FFA500'>[name]</font>" //Orange
-	
-	. += "/([name])"
+			if(include_link && is_special_character(M) && highlight_special_characters)
+				name = "<font color='#FFA500'>[name]</font>" //Orange
+		
+		. += "/([name])"
 
 	return .
 


### PR DESCRIPTION
Fixes #3222 