### PR TITLE
Block prometheans from using synthparts

### DIFF
--- a/code/modules/organs/robolimbs.dm
+++ b/code/modules/organs/robolimbs.dm
@@ -42,7 +42,7 @@ var/const/standard_monitor_styles = "blank=ipc_blank;\
 	var/lifelike										 // If set, appears organic.
 	var/skin_tone										 // If set, applies skin tone rather than part color
 	var/blood_color = "#030303"
-	var/list/species_cannot_use = list("Teshari")
+	var/list/species_cannot_use = list("Teshari", "Promethean") //VOREStation Add
 	var/list/monitor_styles			 		 			 //If empty, the model of limbs offers a head compatible with monitors.
 	var/parts = BP_ALL						 			 //Defines what parts said brand can replace on a body.
 	var/health_hud_intensity = 1						 // Intensity modifier for the health GUI indicator.


### PR DESCRIPTION
Aside from being the most powergamey combination I can think of, it appears to make the game go insane trying to do all the special species things for you, PLUS all the special robolimbs things. It may make you explode randomly, which is probably not good, not to mention the verbs probably do completely insane things when you try to use them.