### PR TITLE
Communicator + NIF Refactor

### DIFF
--- a/code/game/objects/items/devices/communicator/UI.dm
+++ b/code/game/objects/items/devices/communicator/UI.dm
@@ -133,11 +133,7 @@
 	if(href_list["rename"])
 		var/new_name = sanitizeSafe(input(usr,"Please enter your name.","Communicator",usr.name) )
 		if(new_name)
-			owner = new_name
-			name = "[owner]'s [initial(name)]"
-			if(camera)
-				camera.name = name
-				camera.c_tag = name
+			register_device(new_name)
 
 	if(href_list["toggle_visibility"])
 		switch(network_visibility)

--- a/code/game/objects/items/devices/communicator/communicator.dm
+++ b/code/game/objects/items/devices/communicator/communicator.dm
@@ -75,12 +75,12 @@ var/global/list/obj/item/device/communicator/all_communicators = list()
 	//This is a pretty terrible way of doing this.
 	spawn(5 SECONDS) //Wait for our mob to finish spawning.
 		if(ismob(loc))
-			register_device(loc)
+			register_device(loc.name)
 			initialize_exonet(loc)
 		else if(istype(loc, /obj/item/weapon/storage))
 			var/obj/item/weapon/storage/S = loc
 			if(ismob(S.loc))
-				register_device(S.loc)
+				register_device(S.loc.name)
 				initialize_exonet(S.loc)
 
 // Proc: examine()
@@ -268,12 +268,12 @@ var/global/list/obj/item/device/communicator/all_communicators = list()
 // Proc: register_device()
 // Parameters: 1 (user - the person to use their name for)
 // Description: Updates the owner's name and the device's name.
-/obj/item/device/communicator/proc/register_device(mob/user)
-	if(!user)
+/obj/item/device/communicator/proc/register_device(new_name)
+	if(!new_name)
 		return
-	owner = user.name
+	owner = new_name
 
-	name = "[owner]'s [initial(name)]"
+	name = "[new_name]'s [initial(name)]"
 	if(camera)
 		camera.name = name
 		camera.c_tag = name

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -263,7 +263,7 @@ var/list/ai_verbs_default = list(
 		aiPDA.name = pickedName + " (" + aiPDA.ownjob + ")"
 
 	if(aiCommunicator)
-		aiCommunicator.register_device(src)
+		aiCommunicator.register_device(src.name)
 
 /*
 	The AI Power supply is a dummy object used for powering the AI since only machinery should be using power.

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -210,7 +210,7 @@
 /mob/living/silicon/robot/proc/setup_communicator()
 	if (!communicator)
 		communicator = new/obj/item/device/communicator/integrated(src)
-	communicator.register_device(src, "[modtype] [braintype]")
+	communicator.register_device(src.name, "[modtype] [braintype]")
 
 //If there's an MMI in the robot, have it ejected when the mob goes away. --NEO
 //Improved /N

--- a/code/modules/nifsoft/nif.dm
+++ b/code/modules/nifsoft/nif.dm
@@ -42,6 +42,7 @@ You can also set the stat of a NIF to NIF_TEMPFAIL without any issues to disable
 	var/tmp/stat = NIF_PREINSTALL		// Status of the NIF
 	var/tmp/install_done				// Time when install will finish
 	var/tmp/open = FALSE				// If it's open for maintenance (1-3)
+	var/tmp/should_be_in = BP_HEAD		// Organ we're supposed to be held in
 
 	var/obj/item/device/communicator/commlink/comm		// The commlink requires this
 
@@ -110,7 +111,11 @@ You can also set the stat of a NIF to NIF_TEMPFAIL without any issues to disable
 
 //Being implanted in some mob
 /obj/item/device/nif/proc/implant(var/mob/living/carbon/human/H)
-	if(istype(H) && !H.nif && H.species && (loc == H.get_organ(BP_HEAD)))
+	var/obj/item/organ/brain = H.internal_organs_by_name[O_BRAIN]
+	if(istype(brain))
+		should_be_in = brain.parent_organ
+	
+	if(istype(H) && !H.nif && H.species && (loc == H.get_organ(should_be_in)))
 		if(!bioadap && (H.species.flags & NO_SCAN)) //NO_SCAN is the default 'too complicated' flag
 			return FALSE
 
@@ -125,11 +130,18 @@ You can also set the stat of a NIF to NIF_TEMPFAIL without any issues to disable
 //For debug or antag purposes
 /obj/item/device/nif/proc/quick_implant(var/mob/living/carbon/human/H)
 	if(istype(H))
-		var/obj/item/organ/external/head = H.get_organ(BP_HEAD)
-		if(!head)
+		var/obj/item/organ/external/parent
+		//Try to find their brain and put it near that
+		var/obj/item/organ/brain = H.internal_organs_by_name[O_BRAIN]
+		if(istype(brain))
+			should_be_in = brain.parent_organ
+		
+		parent = H.get_organ(should_be_in)
+		//Ok, nevermind then!
+		if(!istype(parent))
 			return FALSE
-		src.forceMove(head)
-		head.implants += src
+		forceMove(parent)
+		parent.implants += src
 		spawn(0) //Let the character finish spawning yo.
 			if(H.mind)
 				owner = H.mind.name
@@ -289,11 +301,17 @@ You can also set the stat of a NIF to NIF_TEMPFAIL without any issues to disable
 			stat = NIF_WORKING
 			owner = human.mind.name
 			name = initial(name) + " ([owner])"
+			if(comm)
+				var/saved_name = save_data["commlink_name"]
+				if(saved_name)
+					comm.register_device(saved_name)
+				else if(human)
+					comm.register_device(human.name)
 			notify("Calibration complete! User data stored!")
 
 //Called each life() tick on the mob
 /obj/item/device/nif/proc/life()
-	if(!human || loc != human.get_organ(BP_HEAD))
+	if(!human || loc != human.get_organ(should_be_in))
 		unimplant(human)
 		return FALSE
 
@@ -562,18 +580,18 @@ You can also set the stat of a NIF to NIF_TEMPFAIL without any issues to disable
 	var/mob/living/carbon/human/U = user
 	var/mob/living/carbon/human/T = M
 
-	if(istype(T.species,/datum/species/shapeshifter/promethean) && target_zone == BP_HEAD) //Are prommy, aimed at head.
+	if(istype(T.species,/datum/species/shapeshifter/promethean) && target_zone == should_be_in) //Are prommy, aimed at head.
 		if(T.head || T.glasses)
 			to_chat(user,"<span class='warning'>Remove any headgear they have on first, as it might interfere.</span>")
 			return
-		var/obj/item/organ/external/head = T.get_organ(BP_HEAD)
+		var/obj/item/organ/external/head = T.get_organ(should_be_in)
 		if(!T)
 			to_chat(user,"<span class='warning'>They should probably regrow their head first.</span>")
 			return
 		U.visible_message("<span class='notice'>[U] begins installing [src] into [T]'s head by just stuffing it in.</span>",
 		"<span class='notice'>You begin installing [src] into [T]'s head by just stuffing it in.</span>",
 		"There's a wet SQUISH noise.")
-		if(do_mob(user = user, target = T, time = 200, target_zone = BP_HEAD))
+		if(do_mob(user = user, target = T, time = 200, target_zone = should_be_in))
 			user.unEquip(src)
 			forceMove(head)
 			head.implants |= src

--- a/code/modules/nifsoft/software/14_commlink.dm
+++ b/code/modules/nifsoft/software/14_commlink.dm
@@ -43,7 +43,6 @@
 		..()
 		nif = newloc
 		nifsoft = soft
-		spawn(10) register_device(nif.human) //Need to outwait the other spawn in communicators, sigh.
 		qdel_null(camera) //Not supported on internal one.
 
 	Destroy()
@@ -52,6 +51,11 @@
 			nif = null
 		nifsoft = null
 		return ..()
+
+/obj/item/device/communicator/commlink/register_device(var/new_name)
+	owner = new_name
+	name = "[owner]'s [initial(name)]"
+	nif.save_data["commlink_name"] = owner
 
 //So that only the owner's chat is relayed to others.
 /obj/item/device/communicator/commlink/hear_talk(mob/living/M, text, verb, datum/language/speaking)


### PR DESCRIPTION
Refactors NIFs slightly:
* They now save your commlink name, so you can be named "FoxMaster 9000" each shift or whatever.
* Now work properly on species that don't have their brains in their head (and expect to be put into whatever organ that has the brain)

Refactors communicators slightly:
* Allows you to set the name without providing a mob (no mob-related features/vars were ever accessed so it was basically pointless)