### PR TITLE
Fix a call to the wrong update icons in prom regen

### DIFF
--- a/code/modules/mob/living/carbon/human/human_powers.dm
+++ b/code/modules/mob/living/carbon/human/human_powers.dm
@@ -273,7 +273,7 @@
 				var/obj/item/organ/O = new limb_path(src)
 				organ_data["descriptor"] = O.name
 				to_chat(src, "<span class='notice'>You feel a slithering sensation as your [O.name] reform.</span>")
-		update_icons_all()
+		update_icons_body()
 		active_regen = FALSE
 	else
 		to_chat(src, "<span class='critical'>Your regeneration is interrupted!</span>")


### PR DESCRIPTION
Fixes promethean limbs staying gone. You can get them to come back meanwhile by doing anything that would cause your body to update, like changing your skin color slightly.