### PR TITLE
MouseDown closes tooltips too

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1153,6 +1153,11 @@ mob/proc/yank_out_object()
 
 	..()
 
+/mob/MouseDown()
+	closeToolTip(usr) //No reason not to, really
+
+	..()
+
 /mob/MouseExited()
 	closeToolTip(usr) //No reason not to, really
 


### PR DESCRIPTION
Makes click-drag easier if you're dragging to the south as MouseExited apparently isn't called until you let go