### PR TITLE
Fix holders sending their held mob to nullspace

### DIFF
--- a/code/modules/mob/holder.dm
+++ b/code/modules/mob/holder.dm
@@ -39,10 +39,13 @@ var/list/holder_mob_icon_cache = list()
 		update_state()
 
 /obj/item/weapon/holder/proc/update_state()
-	if(istype(loc,/turf) || !(contents.len))
+	if(!(contents.len))
+		qdel(src)
+	else if(isturf(loc))
+		drop_items()
 		if(held_mob)
 			held_mob.forceMove(loc)
-		drop_items()
+			held_mob = null
 		qdel(src)
 
 /obj/item/weapon/holder/proc/drop_items()

--- a/code/modules/vore/eating/living_vr.dm
+++ b/code/modules/vore/eating/living_vr.dm
@@ -116,7 +116,6 @@
 		if (is_vore_predator(src))
 			for (var/mob/living/M in H.contents)
 				if (attacker.eat_held_mob(attacker, M, src))
-					H.contents -= M
 					if (H.held_mob == M)
 						H.held_mob = null
 			return 1 //Return 1 to exit upper procs


### PR DESCRIPTION
Fixes nullspacing when nomming things that aren't micros.
Also could happen on any other situation when the mob was removed from the holder.