### PR TITLE
Amends body_hair Caching and Fixes Teshari Tail Hair Rendering

### DIFF
--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -871,8 +871,8 @@ var/global/list/damage_icon_parts = list() //see UpdateDamageIcon()
 		// The following will not work with animated tails.
 		var/use_species_tail = species.get_tail_hair(src)
 		if(use_species_tail)
-			var/icon/hair_icon = icon('icons/effects/species.dmi', "[species.get_tail(src)]_[use_species_tail]")
-			hair_icon.Blend(rgb(r_hair, g_hair, b_hair), ICON_ADD)
+			var/icon/hair_icon = icon('icons/effects/species.dmi', "[species.get_tail(src)]_[use_species_tail]_s")
+			hair_icon.Blend(rgb(r_hair, g_hair, b_hair), species.color_mult ? ICON_MULTIPLY : ICON_ADD) //VOREStation edit -- Check for species color_mult
 			tail_icon.Blend(hair_icon, ICON_OVERLAY)
 		tail_icon_cache[icon_key] = tail_icon
 

--- a/code/modules/organs/organ_icon.dm
+++ b/code/modules/organs/organ_icon.dm
@@ -159,12 +159,10 @@ var/global/list/limb_icon_cache = list()
 					icon_cache_key += "[M][markings[M]["color"]]"
 
 			if(body_hair && islist(h_col) && h_col.len >= 3)
-				var/cache_key = "[body_hair]-[icon_name]-[h_col[1]][h_col[2]][h_col[3]]"
-				if(!limb_icon_cache[cache_key])
-					var/icon/I = icon(species.get_icobase(owner), "[icon_name]_[body_hair]")
-					I.Blend(rgb(h_col[1],h_col[2],h_col[3]), ICON_MULTIPLY) //VOREStation edit
-					limb_icon_cache[cache_key] = I
-				mob_icon.Blend(limb_icon_cache[cache_key], ICON_OVERLAY)
+				var/icon/I = icon(species.get_icobase(owner), "[icon_name]_[body_hair]")
+				I.Blend(rgb(h_col[1],h_col[2],h_col[3]), ICON_MULTIPLY) //VOREStation edit
+				mob_icon.Blend(I, ICON_OVERLAY)
+				icon_cache_key += "[body_hair][rgb(h_col[1],h_col[2],h_col[3])]"
 
 	if(model)
 		icon_cache_key += "_model_[model]"
@@ -179,12 +177,10 @@ var/global/list/limb_icon_cache = list()
 			icon_cache_key += "[M][markings[M]["color"]]"
 
 		if(body_hair && islist(h_col) && h_col.len >= 3)
-			var/cache_key = "[body_hair]-[icon_name]-[h_col[1]][h_col[2]][h_col[3]]"
-			if(!limb_icon_cache[cache_key])
-				var/icon/I = icon(species.get_icobase(owner), "[icon_name]_[body_hair]")
-				I.Blend(rgb(h_col[1],h_col[2],h_col[3]), ICON_MULTIPLY) //VOREStation edit
-				limb_icon_cache[cache_key] = I
-			mob_icon.Blend(limb_icon_cache[cache_key], ICON_OVERLAY)
+			var/icon/I = icon(species.get_icobase(owner), "[icon_name]_[body_hair]")
+			I.Blend(rgb(h_col[1],h_col[2],h_col[3]), ICON_MULTIPLY) //VOREStation edit
+			mob_icon.Blend(I, ICON_OVERLAY)
+			icon_cache_key += "[body_hair][rgb(h_col[1],h_col[2],h_col[3])]"
 		// VOREStation edit ends here
 
 	dir = EAST


### PR DESCRIPTION
Was inspired to write this PR after witnessing a fiesta of crashes (bad enough to cue "Let the Bodies hit the Floor" and have it actually work for the situation) 😁.

The amendment to `body_hair` caching is purely speculative, but I saw no reason why limbs with `body_hair` shouldn't use the standard caching methods in limb icon generation. Mob health-doll still works just fine. _Can port to Polaris_

This PR also fixes Teshari tail hair not rendering at all. Polaris has this same issue from what I can tell by looking at their code. _Can port to Polaris_

_Teshari Tail Hair Busted_
![tesharitailhaircolourbusted](https://user-images.githubusercontent.com/12377767/37750507-cf0e29b0-2d63-11e8-9d08-1dd65141e915.PNG)

_Teshari Tail Hair Fixed_
![tesharitailhaircolourfixed](https://user-images.githubusercontent.com/12377767/37750426-4cc5915a-2d63-11e8-97a4-dcdbdee71810.PNG)
