### PR TITLE
Promethean tweaks (hunger, regen time)

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/prometheans_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/prometheans_vr.dm
@@ -1,15 +1,26 @@
 /datum/species/shapeshifter/promethean
-	min_age = 18
+	min_age = 18 //Required for server rules
 	max_age = 80
-	valid_transform_species = list("Human", "Unathi", "Tajara", "Skrell", "Diona", "Teshari", "Monkey","Sergal","Akula","Nevrean","Highlander Zorren","Flatland Zorren", "Vulpkanin", "Vasilissan", "Rapala", "Neaera", "Stok", "Farwa", "Sobaka", "Wolpin", "Saru", "Sparra")
-	heal_rate = 0.2 //They heal .2, along with the natural .2 heal per tick when below the  organ natural heal damage threshhold.
-	siemens_coefficient = 1 //Prevents them from being immune to tasers and stun weapons.
-	death_message = "goes limp, their body becoming softer..."
+	valid_transform_species = list(
+		"Human", "Unathi", "Tajara", "Skrell",
+		"Diona", "Teshari", "Monkey","Sergal",
+		"Akula","Nevrean","Highlander Zorren",
+		"Flatland Zorren", "Vulpkanin", "Vasilissan",
+		"Rapala", "Neaera", "Stok", "Farwa", "Sobaka",
+		"Wolpin", "Saru", "Sparra")
+	
+	heal_rate = 0.2 //As of writing, original was 0.5 - Slows regen speed (bad)
+	hunger_factor = 0.1 //As of writing, original was 0.2 - Slows hunger rate (good)
+	siemens_coefficient = 1 //As of writing, original was 0.4 (bad)
+	active_regen_mult = 0.66 //As of writing, original was 1 (good)
+	
 	color_mult = 1
-	mob_size = MOB_MEDIUM
-	num_alternate_languages = 1 //Let's at least give them one
-	appearance_flags = HAS_SKIN_COLOR | HAS_EYE_COLOR | HAS_HAIR_COLOR | RADIATION_GLOWS | HAS_UNDERWEAR
+	mob_size = MOB_MEDIUM //As of writing, original was MOB_SMALL - Allows normal swapping (good)
+	num_alternate_languages = 1 //Might be outdated: They currently have 3 in the other file
 	trashcan = 1 //They have goopy bodies. They can just dissolve things within them.
+
+	appearance_flags = HAS_SKIN_COLOR | HAS_EYE_COLOR | HAS_HAIR_COLOR | RADIATION_GLOWS | HAS_UNDERWEAR
+	
 	inherent_verbs = list(
 		/mob/living/carbon/human/proc/shapeshifter_select_shape,
 		/mob/living/carbon/human/proc/shapeshifter_select_colour,
@@ -25,6 +36,7 @@
 		/mob/living/proc/eat_trash
 		)
 
+	death_message = "goes limp, their body becoming softer..."
 
 /datum/species/shapeshifter/promethean/handle_death(var/mob/living/carbon/human/H)
 	return //This nullifies them gibbing.


### PR DESCRIPTION
* Half their hunger rate (from 4x human to 2x human)
* Decrease regenerate time by 10 seconds (from 30 to 20)