### PR TITLE
Fixes default synth tails necessitating potentially harmful mystery delays in mannequin generation.

### DIFF
--- a/code/modules/mob/new_player/preferences_setup.dm
+++ b/code/modules/mob/new_player/preferences_setup.dm
@@ -195,7 +195,6 @@
 
 /datum/preferences/proc/dress_preview_mob(var/mob/living/carbon/human/mannequin)
 	copy_to(mannequin, TRUE)
-	sleep(1) //VOREStation Add - Not sure why this is required. Some race condition about robo manufacturers with tails.
 
 	if(!equip_preview_mob)
 		return

--- a/code/modules/vore/appearance/update_icons_vr.dm
+++ b/code/modules/vore/appearance/update_icons_vr.dm
@@ -17,11 +17,11 @@ var/global/list/wing_icon_cache = list()
 
 /mob/living/carbon/human/proc/get_tail_image()
 	//If you are FBP with tail style and didn't set a custom one
-	if(isSynthetic())
-		if(synthetic.includes_tail && !tail_style)
-			var/icon/tail_s = new/icon("icon" = synthetic.icon, "icon_state" = "tail")
-			tail_s.Blend(rgb(src.r_skin, src.g_skin, src.b_skin), species.color_mult ? ICON_MULTIPLY : ICON_ADD)
-			return image(tail_s)
+	var/datum/robolimb/model = isSynthetic()
+	if(istype(model) && model.includes_tail && !tail_style)
+		var/icon/tail_s = new/icon("icon" = synthetic.icon, "icon_state" = "tail")
+		tail_s.Blend(rgb(src.r_skin, src.g_skin, src.b_skin), species.color_mult ? ICON_MULTIPLY : ICON_ADD)
+		return image(tail_s)
 
 	//If you have a custom tail selected
 	if(tail_style && !(wear_suit && wear_suit.flags_inv & HIDETAIL && !isTaurTail(tail_style)))

--- a/code/modules/vore/appearance/update_icons_vr.dm
+++ b/code/modules/vore/appearance/update_icons_vr.dm
@@ -17,10 +17,11 @@ var/global/list/wing_icon_cache = list()
 
 /mob/living/carbon/human/proc/get_tail_image()
 	//If you are FBP with tail style and didn't set a custom one
-	if(synthetic && synthetic.includes_tail && !tail_style)
-		var/icon/tail_s = new/icon("icon" = synthetic.icon, "icon_state" = "tail")
-		tail_s.Blend(rgb(src.r_skin, src.g_skin, src.b_skin), species.color_mult ? ICON_MULTIPLY : ICON_ADD)
-		return image(tail_s)
+	if(isSynthetic())
+		if(synthetic.includes_tail && !tail_style)
+			var/icon/tail_s = new/icon("icon" = synthetic.icon, "icon_state" = "tail")
+			tail_s.Blend(rgb(src.r_skin, src.g_skin, src.b_skin), species.color_mult ? ICON_MULTIPLY : ICON_ADD)
+			return image(tail_s)
 
 	//If you have a custom tail selected
 	if(tail_style && !(wear_suit && wear_suit.flags_inv & HIDETAIL && !isTaurTail(tail_style)))


### PR DESCRIPTION
-Now get_tail_image() can check the owner's syntheticness without having to wait for dress_preview_mob() to crapshoot fingers crossed for some arbitrary irrelevant life tick function to unreliably call isSynthetic() to retrieve and apply the vars required by get_tail_image before the mannequin deletes itself.
-This also fixes default synth tails not showing up at all on previews with naked human bases.