### PR TITLE
Removes an inconsistency in custom species code

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/blank_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/blank_vr.dm
@@ -87,7 +87,6 @@
 
 	//Set up a mob
 	H.species = new_copy
-	H.icon_state = lowertext(new_copy.get_bodytype())
 
 	if(new_copy.holder_type)
 		H.holder_type = new_copy.holder_type


### PR DESCRIPTION
This line had no real use at all. It may even have contributed to various issues.
All basic humanoid species have had their appearances constructed onto an _existing_ blank 32x32 icon_state named and called for as "nothing" inside the effects.dmi.
There are no untitled blanks either inside the effects.dmi file, so the funky deviant custom species icon_states would never have had any proper fallback.