### PR TITLE
Balance pass on custom species traits

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/negative.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/negative.dm
@@ -1,13 +1,13 @@
 /datum/trait/speed_slow
 	name = "Slowdown"
 	desc = "Allows you to move slower on average than baseline."
-	cost = -3
+	cost = -2
 	var_changes = list("slowdown" = 0.5)
 
 /datum/trait/speed_slow_plus
 	name = "Major Slowdown"
 	desc = "Allows you to move MUCH slower on average than baseline."
-	cost = -5
+	cost = -3
 	var_changes = list("slowdown" = 1.0)
 
 /datum/trait/weakling
@@ -81,13 +81,13 @@
 /datum/trait/conductive
 	name = "Conductive"
 	desc = "Increases your susceptibility to electric shocks by 50%"
-	cost = -2
+	cost = -1
 	var_changes = list("siemens_coefficient" = 1.5) //This makes you a lot weaker to tasers.
 
 /datum/trait/conductive_plus
 	name = "Major Conductive"
 	desc = "Increases your susceptibility to electric shocks by 100%"
-	cost = -3
+	cost = -2
 	var_changes = list("siemens_coefficient" = 2.0) //This makes you extremely weak to tasers.
 
 /datum/trait/photosensitive
@@ -116,7 +116,7 @@
 /datum/trait/colorblind
 	name = "Colorblindness (Monochromancy)"
 	desc = "You simply can't see colors at all, period. You are 100% colorblind."
-	cost = -3
+	cost = -1
 
 /datum/trait/colorblind/apply(var/datum/species/S,var/mob/living/carbon/human/H)
 	..(S,H)
@@ -127,7 +127,7 @@
 /datum/trait/colorblind/para_vulp
 	name = "Colorblindness (Para Vulp)"
 	desc = "You have a severe issue with green colors and have difficulty recognizing them from red colors."
-	cost = -2
+	cost = -1
 
 /datum/trait/colorblind/para_vulp/apply(var/datum/species/S,var/mob/living/carbon/human/H)
 	..(S,H)

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/positive.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/positive.dm
@@ -1,14 +1,8 @@
 /datum/trait/speed_fast
 	name = "Haste"
 	desc = "Allows you to move faster on average than baseline."
-	cost = 3
+	cost = 4
 	var_changes = list("slowdown" = -0.5)
-
-/datum/trait/speed_fast_plus
-	name = "Major Haste"
-	desc = "Allows you to move MUCH faster on average than baseline."
-	cost = 5
-	var_changes = list("slowdown" = -1.0)
 
 /datum/trait/hardy
 	name = "Hardy"
@@ -25,18 +19,8 @@
 /datum/trait/endurance_high
 	name = "High Endurance"
 	desc = "Increases your maximum total hitpoints to 125"
-	cost = 2
+	cost = 4
 	var_changes = list("total_health" = 125)
-
-	apply(var/datum/species/S,var/mob/living/carbon/human/H)
-		..(S,H)
-		H.setMaxHealth(S.total_health)
-
-/datum/trait/endurance_very_high
-	name = "Very High Endurance"
-	desc = "Increases your maximum total hitpoints to 150"
-	cost = 3
-	var_changes = list("total_health" = 150)
 
 	apply(var/datum/species/S,var/mob/living/carbon/human/H)
 		..(S,H)
@@ -81,38 +65,28 @@
 /datum/trait/minor_brute_resist
 	name = "Minor Brute Resist"
 	desc = "Adds 15% resistance to brute damage sources."
-	cost = 1
+	cost = 2
 	var_changes = list("brute_mod" = 0.85)
 
 /datum/trait/brute_resist
 	name = "Brute Resist"
 	desc = "Adds 25% resistance to brute damage sources."
-	cost = 2
-	var_changes = list("brute_mod" = 0.75)
-
-/datum/trait/brute_resist_plus
-	name = "Major Brute Resist"
-	desc = "Adds 50% resistance to brute damage sources."
 	cost = 3
-	var_changes = list("brute_mod" = 0.5)
+	var_changes = list("brute_mod" = 0.75)
+	excludes = list(/datum/trait/minor_burn_resist,/datum/trait/burn_resist)
 
 /datum/trait/minor_burn_resist
 	name = "Minor Burn Resist"
 	desc = "Adds 15% resistance to burn damage sources."
-	cost = 1
+	cost = 2
 	var_changes = list("burn_mod" = 0.85)
 
 /datum/trait/burn_resist
 	name = "Burn Resist"
 	desc = "Adds 25% resistance to burn damage sources."
-	cost = 2
-	var_changes = list("burn_mod" = 0.75)
-
-/datum/trait/burn_resist_plus
-	name = "Major Burn Resist"
-	desc = "Adds 50% resistance to burn damage sources."
 	cost = 3
-	var_changes = list("burn_mod" = 0.5)
+	var_changes = list("burn_mod" = 0.75)
+	excludes = list(/datum/trait/minor_brute_resist,/datum/trait/brute_resist)
 
 /datum/trait/photoresistant
 	name = "Photoresistant"


### PR DESCRIPTION
Custom species have been facing some severe powercreep. The original design intent for these was to allow some extra flexibility for people who wanted custom things, but that stock species would always have a slight edge in terms of stats, but trait costs haven't really reflected this, as well as some being outright superior to anything stock species get, _especially_ when you stack them.

Generally speaking, some of the crazier positive traits have had their costs increased or been outright removed, while negative traits have had their point rebates reduced to discourage stacking.

The changes are as follows:

POSITIVE TRAITS:
- Haste costs 4 points, up from 3. Haste plus removed (wanna go sonic, be a tesh).
- High Endurance increased from 2 to 4. Very High Endurance removed.
- 15% Brute/Burn resistance trait costs increased from 1 to 2.
- 25% resistances increased from 2 to 3 points, and cannot be stacked with the other resistance.
- 50% resistance traits removed.

NEGATIVE TRAITS:
- Slow reduced from 3 to 2. Major slow reduced from 5 to 3.
- Conductive reduced from 2 to 1, Major conductive reduced from 3 to 2.
- Colorblindness traits reduced to 1.