### PR TITLE
Nerfs solargrub drain speed.

### DIFF
--- a/code/modules/mob/living/simple_animal/vore/solargrub.dm
+++ b/code/modules/mob/living/simple_animal/vore/solargrub.dm
@@ -77,8 +77,8 @@ List of things solar grubs should be able to do:
 				sparks.start()
 			anchored = 1
 			PN = attached.powernet
-			PN.draw_power(150000)
-			var/apc_drain_rate = 750 //5000 seems a bit high, knocking it down to 4000
+			PN.draw_power(100000) // previous value 150000
+			var/apc_drain_rate = 750 //Going to see if grubs are better as a minimal bother. previous value : 4000
 			for(var/obj/machinery/power/terminal/T in PN.nodes)
 				if(istype(T.master, /obj/machinery/power/apc))
 					var/obj/machinery/power/apc/A = T.master

--- a/code/modules/mob/living/simple_animal/vore/solargrub.dm
+++ b/code/modules/mob/living/simple_animal/vore/solargrub.dm
@@ -78,7 +78,7 @@ List of things solar grubs should be able to do:
 			anchored = 1
 			PN = attached.powernet
 			PN.draw_power(150000)
-			var/apc_drain_rate = 4000 //5000 seems a bit high, knocking it down to 4000
+			var/apc_drain_rate = 750 //5000 seems a bit high, knocking it down to 4000
 			for(var/obj/machinery/power/terminal/T in PN.nodes)
 				if(istype(T.master, /obj/machinery/power/apc))
 					var/obj/machinery/power/apc/A = T.master


### PR DESCRIPTION
Due to the lack of saturation in the moderate event container, solargrubs show up way too frequently, and changing the frequency doesn't help. The container has to pick. This change will just bump the drain speed down so severely, that if you kill one or two grubs, the station should barely feel the impact anymore. As opposed to having to kill 4/5 grubs on average.

Gradual nerfs seem logical, as grubs get more and mroe of a day-to-day experience, and most people know about them now. Time to stop the witch hunting for those annoying grubs :p