### PR TITLE
Fixes vox not having hardsuit sprites.

### DIFF
--- a/code/modules/clothing/clothing_vr.dm
+++ b/code/modules/clothing/clothing_vr.dm
@@ -85,17 +85,17 @@
 	slot_flags = SLOT_MASK
 	body_parts_covered = FACE|EYES
 	sprite_sheets = list(
-		"Teshari"		= 'icons/mob/species/seromi/masks_vr.dmi',
-		"Vox" 			= 'icons/mob/species/vox/masks.dmi',
-		"Tajara" 		= 'icons/mob/species/tajaran/mask_vr.dmi',
-		"Unathi" 		= 'icons/mob/species/unathi/mask_vr.dmi',
-		"Sergal" 		= 'icons/mob/species/sergal/mask_vr.dmi',
-		"Nevrean" 		= 'icons/mob/species/nevrean/mask_vr.dmi',
-		"Fox" 			= 'icons/mob/species/fox/mask_vr.dmi',
-		"Fennec" 		= 'icons/mob/species/fennec/mask_vr.dmi',
-		"Akula" 		= 'icons/mob/species/akula/mask_vr.dmi',
-		"Vulpkanin" 	= 'icons/mob/species/vulpkanin/mask.dmi',
-		"Xenochimera"	= 'icons/mob/species/tajaran/mask_vr.dmi'
+		SPECIES_TESHARI		= 'icons/mob/species/seromi/masks_vr.dmi',
+		SPECIES_VOX 		= 'icons/mob/species/vox/masks.dmi',
+		SPECIES_TAJ 		= 'icons/mob/species/tajaran/mask_vr.dmi',
+		SPECIES_UNATHI 		= 'icons/mob/species/unathi/mask_vr.dmi',
+		SPECIES_SERGAL 		= 'icons/mob/species/sergal/mask_vr.dmi',
+		SPECIES_NEVREAN 	= 'icons/mob/species/nevrean/mask_vr.dmi',
+		SPECIES_ZORREN_HIGH	= 'icons/mob/species/fox/mask_vr.dmi',
+		SPECIES_ZORREN_FLAT = 'icons/mob/species/fennec/mask_vr.dmi',
+		SPECIES_AKULA 		= 'icons/mob/species/akula/mask_vr.dmi',
+		SPECIES_VULPKANIN 	= 'icons/mob/species/vulpkanin/mask.dmi',
+		SPECIES_XENOCHIMERA	= 'icons/mob/species/tajaran/mask_vr.dmi'
 		)
 //"Spider" 		= 'icons/mob/species/spider/mask_vr.dmi' Add this later when they have custom mask sprites and everything.
 

--- a/code/modules/clothing/spacesuits/rig/rig_pieces_vr.dm
+++ b/code/modules/clothing/spacesuits/rig/rig_pieces_vr.dm
@@ -1,33 +1,35 @@
 /obj/item/clothing/head/helmet/space/rig
 	sprite_sheets = list(
-		"Tajara" 				= 'icons/mob/species/tajaran/helmet.dmi',
-		"Skrell" 				= 'icons/mob/species/skrell/helmet.dmi',
-		"Unathi" 				= 'icons/mob/species/unathi/helmet.dmi',
-		"Nevrean" 				= 'icons/mob/species/nevrean/helmet_vr.dmi',
-		"Akula" 				= 'icons/mob/species/akula/helmet_vr.dmi',
-		"Sergal"				= 'icons/mob/species/sergal/helmet_vr.dmi',
-		"Flatland Zorren" 		= 'icons/mob/species/fennec/helmet_vr.dmi',
-		"Highlander Zorren" 	= 'icons/mob/species/fox/helmet_vr.dmi',
-		"Vulpkanin"				= 'icons/mob/species/vulpkanin/helmet.dmi',
-		"Promethean"			= 'icons/mob/species/skrell/helmet.dmi',
-		"Xenomorph Hybrid"		= 'icons/mob/species/unathi/helmet.dmi'
+		SPECIES_TAJ 			= 'icons/mob/species/tajaran/helmet.dmi',
+		SPECIES_SKRELL 			= 'icons/mob/species/skrell/helmet.dmi',
+		SPECIES_UNATHI 			= 'icons/mob/species/unathi/helmet.dmi',
+		SPECIES_NEVREAN			= 'icons/mob/species/nevrean/helmet_vr.dmi',
+		SPECIES_AKULA 			= 'icons/mob/species/akula/helmet_vr.dmi',
+		SPECIES_SERGAL			= 'icons/mob/species/sergal/helmet_vr.dmi',
+		SPECIES_ZORREN_FLAT		= 'icons/mob/species/fennec/helmet_vr.dmi',
+		SPECIES_ZORREN_HIGH 	= 'icons/mob/species/fox/helmet_vr.dmi',
+		SPECIES_VULPKANI 		= 'icons/mob/species/vulpkanin/helmet.dmi',
+		SPECIES_PROMETHEAN		= 'icons/mob/species/skrell/helmet.dmi',
+		SPECIES_XENOHYBRID		= 'icons/mob/species/unathi/helmet.dmi',
+		SPECIES_VOX 			= 'icons/mob/species/vox/head.dmi'
 		)
 
 
 
 /obj/item/clothing/suit/space/rig
 	sprite_sheets = list(
-		"Tajara" 				= 'icons/mob/species/tajaran/suit.dmi',
-		"Skrell" 				= 'icons/mob/species/skrell/suit.dmi',
-		"Unathi" 				= 'icons/mob/species/unathi/suit.dmi',
-		"Nevrean" 				= 'icons/mob/species/nevrean/suit_vr.dmi',
-		"Akula" 				= 'icons/mob/species/akula/suit_vr.dmi',
-		"Sergal"				= 'icons/mob/species/sergal/suit_vr.dmi',
-		"Flatland Zorren" 		= 'icons/mob/species/fennec/suit_vr.dmi',
-		"Highlander Zorren" 	= 'icons/mob/species/fox/suit_vr.dmi',
-		"Vulpkanin"				= 'icons/mob/species/vulpkanin/suit.dmi',
-		"Promethean"			= 'icons/mob/species/skrell/suit.dmi',
-		"Xenomorph Hybrid"		= 'icons/mob/species/unathi/suit.dmi'
+		SPECIES_TAJ 			= 'icons/mob/species/tajaran/suit.dmi',
+		SPECIES_SKRELL 			= 'icons/mob/species/skrell/suit.dmi',
+		SPECIES_UNATHI 			= 'icons/mob/species/unathi/suit.dmi',
+		SPECIES_NEVREAN 		= 'icons/mob/species/nevrean/suit_vr.dmi',
+		SPECIES_AKULA 			= 'icons/mob/species/akula/suit_vr.dmi',
+		SPECIES_SERGAL			= 'icons/mob/species/sergal/suit_vr.dmi',
+		SPECIES_ZORREN_FLAT		= 'icons/mob/species/fennec/suit_vr.dmi',
+		SPECIES_ZORREN_HIGH 	= 'icons/mob/species/fox/suit_vr.dmi',
+		SPECIES_VULPKANIN		= 'icons/mob/species/vulpkanin/suit.dmi',
+		SPECIES_PROMETHEAN		= 'icons/mob/species/skrell/suit.dmi',
+		SPECIES_XENOHYBRID		= 'icons/mob/species/unathi/suit.dmi',
+		SPECIES_VOX 			= 'icons/mob/species/vox/suit.dmi'
 		)
 
 /obj/item/clothing/suit/space/rig


### PR DESCRIPTION
- Fixes vox not having hardsuit/rigsuit sprites, whatever you wanna call them
- Makes a few areas use the defines instead of the old "tajaran" and all that

https://i.imgur.com/Xhv85bd.png

https://i.imgur.com/3fOHahO.png

In case you're wondering why the lines look misaligned in github, ignore it. It looks perfect in dream daemon https://i.imgur.com/hcyEkxo.png