### PR TITLE
Fix Teshari Tail-hair Rendering

### DIFF
--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -871,8 +871,8 @@ var/global/list/damage_icon_parts = list() //see UpdateDamageIcon()
 		// The following will not work with animated tails.
 		var/use_species_tail = species.get_tail_hair(src)
 		if(use_species_tail)
-			var/icon/hair_icon = icon('icons/effects/species.dmi', "[species.get_tail(src)]_[use_species_tail]")
-			hair_icon.Blend(rgb(r_hair, g_hair, b_hair), ICON_ADD)
+			var/icon/hair_icon = icon('icons/effects/species.dmi', "[species.get_tail(src)]_[use_species_tail]_s")	//VOREStation edit -- Suffix icon state string with '_s' to compensate for diff in .dmi b/w us & Polaris.
+			hair_icon.Blend(rgb(r_hair, g_hair, b_hair), species.color_mult ? ICON_MULTIPLY : ICON_ADD)				//VOREStation edit -- Check for species color_mult
 			tail_icon.Blend(hair_icon, ICON_OVERLAY)
 		tail_icon_cache[icon_key] = tail_icon
 


### PR DESCRIPTION
This PR fixes Teshari tail hair not rendering at all.
Polaris didn't have this issue because they fixed the name of the icon state in `icons/species/effects.dmi` some time ago, though due to restrictions on altering stock `.dmi` files a Virgo edit to the icon state string is necessary.

_Teshari Tail Hair Busted_
![tesharitailhaircolourbusted](https://user-images.githubusercontent.com/12377767/37750507-cf0e29b0-2d63-11e8-9d08-1dd65141e915.PNG)

_Teshari Tail Hair Fixed_
![tesharitailhaircolourfixed](https://user-images.githubusercontent.com/12377767/37750426-4cc5915a-2d63-11e8-97a4-dcdbdee71810.PNG)
