### PR TITLE
Constructable Operating Table and sleeper/bodyscanner boards in RnD.

### DIFF
--- a/code/game/machinery/OpTable.dm
+++ b/code/game/machinery/OpTable.dm
@@ -90,7 +90,7 @@
 	C.resting = 1
 	C.loc = src.loc
 	for(var/obj/O in src)
-		O.loc = src.loc
+		if(!(O in component_parts) && !(O == circuit)) O.loc = src.loc	//VOREStation Edit: constructable optables
 	add_fingerprint(user)
 	if(ishuman(C))
 		var/mob/living/carbon/human/H = C

--- a/code/game/machinery/OpTable_vr.dm
+++ b/code/game/machinery/OpTable_vr.dm
@@ -1,0 +1,15 @@
+/obj/machinery/optable
+	circuit = /obj/item/weapon/circuitboard/optable
+
+/obj/machinery/optable/attackby(obj/item/weapon/W as obj, mob/living/carbon/user as mob)
+	..()
+	if(default_deconstruction_screwdriver(user, W))
+		return
+	else if(default_deconstruction_crowbar(user, W))
+		return
+
+/obj/machinery/optable/New()
+	..()
+	component_parts = list()
+	component_parts += new /obj/item/weapon/stock_parts/scanning_module(src)
+	RefreshParts()

--- a/code/game/objects/items/weapons/circuitboards/circuitboards_vr.dm
+++ b/code/game/objects/items/weapons/circuitboards/circuitboards_vr.dm
@@ -53,3 +53,12 @@
 	build_path = /obj/machinery/computer/timeclock
 	board_type = new /datum/frame/frame_types/timeclock_terminal
 	matter = list(DEFAULT_WALL_MATERIAL = 50, "glass" = 50)
+
+//Constructable optable voard
+/obj/item/weapon/circuitboard/optable
+	name = T_BOARD("operating table")
+	build_path = /obj/machinery/optable
+	board_type = new /datum/frame/frame_types/machine
+	origin_tech = list(TECH_MATERIAL = 2, TECH_BIO = 2)
+	req_components = list(
+							/obj/item/weapon/stock_parts/scanning_module = 1)

--- a/code/modules/research/designs_vr.dm
+++ b/code/modules/research/designs_vr.dm
@@ -181,6 +181,41 @@
 	build_path = /obj/item/weapon/circuitboard/bomb_tester
 	sort_string = "HABAG"
 
+/datum/design/circuit/sleeper
+	name = "sleeper"
+	id = "sleeper"
+	req_tech = list(TECH_MAGNET = 2, TECH_BIO = 2)
+	build_path = /obj/item/weapon/circuitboard/sleeper
+	sort_string = "FBAAA"
+
+/datum/design/circuit/sleeper_console
+	name = "sleeper console"
+	id = "sleeper_console"
+	req_tech = list(TECH_MAGNET = 2, TECH_BIO = 2)
+	build_path = /obj/item/weapon/circuitboard/sleeper_console
+	sort_string = "FBAAB"
+
+/datum/design/circuit/body_scanner
+	name = "body scanner"
+	id = "body_scanner"
+	req_tech = list(TECH_MAGNET = 2, TECH_BIO = 2)
+	build_path = /obj/item/weapon/circuitboard/body_scanner
+	sort_string = "FBAAC"
+
+/datum/design/circuit/scanner_console
+	name = "body scanner console"
+	id = "scanner_console"
+	req_tech = list(TECH_MAGNET = 2, TECH_BIO = 2)
+	build_path = /obj/item/weapon/circuitboard/scanner_console
+	sort_string = "FBAAD"
+
+/datum/design/circuit/OpTable
+	name = "operating table"
+	id = "optable"
+	req_tech = list(TECH_MATERIAL = 2, TECH_BIO = 2)
+	build_path = /obj/item/weapon/circuitboard/optable
+	sort_string = "FBAAE"
+
 ////// RIGSuit Stuff
 /*
 /datum/design/item/rig

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -679,6 +679,7 @@
 #include "code\game\machinery\newscaster.dm"
 #include "code\game\machinery\nuclear_bomb.dm"
 #include "code\game\machinery\OpTable.dm"
+#include "code\game\machinery\OpTable_vr.dm"
 #include "code\game\machinery\overview.dm"
 #include "code\game\machinery\oxygen_pump.dm"
 #include "code\game\machinery\partslathe_vr.dm"


### PR DESCRIPTION
Operating table is now constructable. Requires regular machine frame, a board (RnD level 2 in material and biology) and a scanning module.

Also added sleeper, bodyscanner and their consoles' boards to RnD (level 2 in magnets and bio).