### PR TITLE
Changes wedding rings to be a subtype of ring

### DIFF
--- a/code/modules/client/preference_setup/loadout/loadout_gloves_vr.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_gloves_vr.dm
@@ -1,10 +1,10 @@
 /datum/gear/gloves/goldring
 	display_name = "wedding ring, gold"
-	path = /obj/item/clothing/gloves/weddingring
+	path = /obj/item/clothing/gloves/ring/wedding
 
 /datum/gear/gloves/silverring
 	display_name = "wedding ring, silver"
-	path = /obj/item/clothing/gloves/weddingring/silver
+	path = /obj/item/clothing/gloves/ring/wedding/silver
 
 /datum/gear/gloves/colored
 	display_name = "gloves, colorable"

--- a/code/modules/clothing/gloves/miscellaneous_vr.dm
+++ b/code/modules/clothing/gloves/miscellaneous_vr.dm
@@ -1,20 +1,3 @@
-/obj/item/clothing/gloves/weddingring
-	name = "golden wedding ring"
-	desc = "For showing your devotion to another person. It has a golden glimmer to it."
-	icon = 'icons/obj/clothing/gloves_vr.dmi'
-	icon_state = "wedring_g"
-	item_state = "wedring_g"
-	var/partnername = ""
-
-/obj/item/clothing/gloves/weddingring/attack_self(mob/user)
-	partnername = copytext(sanitize(input(user, "Would you like to change the holoengraving on the ring?", "Name your betrothed", "Bae") as null|text),1,MAX_NAME_LEN)
-	name = "[initial(name)] - [partnername]"
-
-/obj/item/clothing/gloves/weddingring/silver
-	name = "silver wedding ring"
-	icon_state = "wedring_s"
-	item_state = "wedring_s"
-
 /obj/item/clothing/gloves/color
 	desc = "A pair of gloves, they don't look special in any way."
 	item_state_slots = list(slot_r_hand_str = "white", slot_l_hand_str = "white")

--- a/code/modules/clothing/rings/rings_vr.dm
+++ b/code/modules/clothing/rings/rings_vr.dm
@@ -1,0 +1,17 @@
+/obj/item/clothing/gloves/ring/wedding
+	name = "golden wedding ring"
+	desc = "For showing your devotion to another person. It has a golden glimmer to it."
+	icon = 'icons/obj/clothing/gloves_vr.dmi'
+	icon_state = "wedring_g"
+	item_state = "wedring_g"
+	var/partnername = ""
+
+/obj/item/clothing/gloves/ring/wedding/attack_self(mob/user)
+	partnername = copytext(sanitize(input(user, "Would you like to change the holoengraving on the ring?", "Name your spouse", "Bae") as null|text),1,MAX_NAME_LEN)
+	name = "[initial(name)] - [partnername]"
+
+/obj/item/clothing/gloves/ring/wedding/silver
+	name = "silver wedding ring"
+	desc = "For showing your devotion to another person. It has a silver glimmer to it."
+	icon_state = "wedring_s"
+	item_state = "wedring_s"

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -1517,6 +1517,7 @@
 #include "code\modules\clothing\masks\voice.dm"
 #include "code\modules\clothing\rings\material.dm"
 #include "code\modules\clothing\rings\rings.dm"
+#include "code\modules\clothing\rings\rings_vr.dm"
 #include "code\modules\clothing\shoes\boots.dm"
 #include "code\modules\clothing\shoes\colour.dm"
 #include "code\modules\clothing\shoes\leg_guards.dm"


### PR DESCRIPTION
Also moves them to their own .dm, since they're now a subtype of the thing in rings.dm. Also changed bethrothed to spouse, as the former is usually before marriage and not after.

Benefits of this include: Being able to wear gloves over wedding rings. Making them tiny instead of small. Making their gender neuter instead of plural, so it wont say "some wedding ring" when you examine someone wearing them. Probably more good things.

Issue reported by HzDonut.

I'm really tired, so forgive me for any mistakes, please.