### PR TITLE
Fixes #3368 - Teleporting now often respects dropnom pref

### DIFF
--- a/code/datums/helper_datums/teleport_vr.dm
+++ b/code/datums/helper_datums/teleport_vr.dm
@@ -1,13 +1,17 @@
 /datum/teleport/proc/try_televore()
 	//Destination is in a belly
-	if(isbelly(destination.loc))
+	if(isbelly(destination.loc) && isliving(teleatom))
+		var/mob/living/L = teleatom
 		var/obj/belly/B = destination.loc
-	
+		
+		if(!L.can_be_drop_prey) //Overloading this as a pref for 'want to be unexpectedly eaten'
+			return FALSE
+		
 		teleatom.forceMove(get_turf(B)) //So we can splash the sound and sparks and everything.
 		playSpecials(destination,effectout,soundout)
 		teleatom.forceMove(B)
-		return 1
+		return TRUE
 
 	//No fun!
-	return 0
+	return FALSE
 	

--- a/code/modules/vore/fluffstuff/custom_items_vr.dm
+++ b/code/modules/vore/fluffstuff/custom_items_vr.dm
@@ -1448,24 +1448,27 @@
 
 	//Destination beacon vore checking
 	var/atom/real_dest = dT
-	var/televored = FALSE //UR GONNA GET VORED
 
 	var/atom/real_loc = destination.loc
 	if(isbelly(real_loc))
 		real_dest = real_loc
-		televored = TRUE
 	if(isliving(real_loc))
 		var/mob/living/L = real_loc
 		if(L.vore_selected)
 			real_dest = L.vore_selected
-			televored = TRUE
 		else if(L.vore_organs.len)
 			real_dest = pick(L.vore_organs)
+
+	//Confirm televore
+	var/televored = FALSE
+	if(isbelly(real_dest))
+		var/obj/belly/B = real_dest
+		if(!target.can_be_drop_prey && B.owner != user)
+			to_chat(target,"<span class='warning'>\The [src] narrowly avoids teleporting you right into \a [lowertext(real_dest.name)]!</span>")
+			real_dest = dT //Nevermind!
+		else
 			televored = TRUE
-			
-	//Televore fluff stuff
-	if(televored)
-		to_chat(target,"<span class='warning'>\The [src] teleports you right into \a [lowertext(real_dest.name)]!</span>")
+			to_chat(target,"<span class='warning'>\The [src] teleports you right into \a [lowertext(real_dest.name)]!</span>")
 
 	//Phase-out effect
 	phase_out(target,get_turf(target))
@@ -1496,7 +1499,7 @@
 		ready = 1
 		update_icon()
 
-	logged_events["[world.time]"] = "[user] teleported [target] to [real_dest] [televored ? "(Belly: [lowertext(real_loc.name)])" : null]"
+	logged_events["[world.time]"] = "[user] teleported [target] to [real_dest] [televored ? "(Belly: [lowertext(real_dest.name)])" : null]"
 
 /obj/item/device/perfect_tele/proc/phase_out(var/mob/M,var/turf/T)
 


### PR DESCRIPTION
If you are teleporting someone to a beacon inside yourself, it's assumed that you know what you're doing (since it's ahelpable to just knowingly prefbreak people), but otherwise for standing teleporters and translocators, 'accidental' televore only happens if you have can_be_drop_prey on.