### PR TITLE
Fix shuttle corner turfs disappearing when shuttle moves.

### DIFF
--- a/code/game/turfs/simulated/floor_types.dm
+++ b/code/game/turfs/simulated/floor_types.dm
@@ -105,6 +105,7 @@
 	if(landed_holder && !interior_corner)
 		var/mutable_appearance/landed_on = new(landed_holder)
 		landed_on.layer = FLOAT_LAYER //Not turf
+		landed_on.plane = FLOAT_PLANE //Not turf
 		us.underlays = list(landed_on)
 		appearance = us
 		return


### PR DESCRIPTION
When shuttles land on a turf, it takes the appearance of the turf it lands on as an underlay.  Must make sure this underlay is on FLOAT_PLANE otherwise it will likely end up OVER the turf itself.

So we don't get shuttles looking like this: ![](https://puu.sh/zZ91e/411ccc4032.png)
