### PR TITLE
Fixes item 2 of #2106

### DIFF
--- a/code/game/jobs/job/engineering.dm
+++ b/code/game/jobs/job/engineering.dm
@@ -19,11 +19,11 @@
 
 	access = list(access_engine, access_engine_equip, access_tech_storage, access_maint_tunnels,
 			            access_teleporter, access_external_airlocks, access_atmospherics, access_emergency_storage, access_eva,
-			            access_heads, access_construction, access_sec_doors,
+			            access_heads, access_construction,
 			            access_ce, access_RC_announce, access_keycard_auth, access_tcomsat, access_ai_upload)
 	minimal_access = list(access_engine, access_engine_equip, access_tech_storage, access_maint_tunnels,
 			            access_teleporter, access_external_airlocks, access_atmospherics, access_emergency_storage, access_eva,
-			            access_heads, access_construction, access_sec_doors,
+			            access_heads, access_construction,
 			            access_ce, access_RC_announce, access_keycard_auth, access_tcomsat, access_ai_upload)
 	minimal_player_age = 7
 

--- a/code/game/jobs/job/engineering.dm
+++ b/code/game/jobs/job/engineering.dm
@@ -20,11 +20,11 @@
 	access = list(access_engine, access_engine_equip, access_tech_storage, access_maint_tunnels,
 			            access_teleporter, access_external_airlocks, access_atmospherics, access_emergency_storage, access_eva,
 			            access_heads, access_construction,
-			            access_ce, access_RC_announce, access_keycard_auth, access_tcomsat, access_ai_upload)
+			            access_ce, access_RC_announce, access_keycard_auth, access_tcomsat, access_ai_upload) //VOREStation Edit
 	minimal_access = list(access_engine, access_engine_equip, access_tech_storage, access_maint_tunnels,
 			            access_teleporter, access_external_airlocks, access_atmospherics, access_emergency_storage, access_eva,
 			            access_heads, access_construction,
-			            access_ce, access_RC_announce, access_keycard_auth, access_tcomsat, access_ai_upload)
+			            access_ce, access_RC_announce, access_keycard_auth, access_tcomsat, access_ai_upload) //VOREStation Edit
 	minimal_player_age = 7
 
 	outfit_type = /decl/hierarchy/outfit/job/engineering/chief_engineer

--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -14,10 +14,10 @@
 	economic_modifier = 10
 	access = list(access_medical, access_medical_equip, access_morgue, access_genetics, access_heads,
 			access_chemistry, access_virology, access_cmo, access_surgery, access_RC_announce,
-			access_keycard_auth, access_sec_doors, access_psychiatrist, access_eva, access_external_airlocks, access_maint_tunnels)
+			access_keycard_auth, access_psychiatrist, access_eva, access_external_airlocks, access_maint_tunnels)
 	minimal_access = list(access_medical, access_medical_equip, access_morgue, access_genetics, access_heads,
 			access_chemistry, access_virology, access_cmo, access_surgery, access_RC_announce,
-			access_keycard_auth, access_sec_doors, access_psychiatrist, access_eva, access_external_airlocks, access_maint_tunnels)
+			access_keycard_auth, access_psychiatrist, access_eva, access_external_airlocks, access_maint_tunnels)
 
 	minimum_character_age = 25
 	minimal_player_age = 10

--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -14,10 +14,10 @@
 	economic_modifier = 10
 	access = list(access_medical, access_medical_equip, access_morgue, access_genetics, access_heads,
 			access_chemistry, access_virology, access_cmo, access_surgery, access_RC_announce,
-			access_keycard_auth, access_psychiatrist, access_eva, access_external_airlocks, access_maint_tunnels)
+			access_keycard_auth, access_psychiatrist, access_eva, access_external_airlocks, access_maint_tunnels) //VOREStation Edit
 	minimal_access = list(access_medical, access_medical_equip, access_morgue, access_genetics, access_heads,
 			access_chemistry, access_virology, access_cmo, access_surgery, access_RC_announce,
-			access_keycard_auth, access_psychiatrist, access_eva, access_external_airlocks, access_maint_tunnels)
+			access_keycard_auth, access_psychiatrist, access_eva, access_external_airlocks, access_maint_tunnels) //VOREStation Edit
 
 	minimum_character_age = 25
 	minimal_player_age = 10

--- a/code/game/jobs/job/science.dm
+++ b/code/game/jobs/job/science.dm
@@ -13,11 +13,11 @@
 	req_admin_notify = 1
 	economic_modifier = 15
 	access = list(access_rd, access_heads, access_tox, access_genetics, access_morgue,
-			            access_tox_storage, access_teleporter, access_sec_doors,
+			            access_tox_storage, access_teleporter,
 			            access_research, access_robotics, access_xenobiology, access_ai_upload, access_tech_storage,
 			            access_RC_announce, access_keycard_auth, access_tcomsat, access_gateway, access_xenoarch, access_eva) //VOREStation Edit
 	minimal_access = list(access_rd, access_heads, access_tox, access_genetics, access_morgue,
-			            access_tox_storage, access_teleporter, access_sec_doors,
+			            access_tox_storage, access_teleporter,
 			            access_research, access_robotics, access_xenobiology, access_ai_upload, access_tech_storage,
 			            access_RC_announce, access_keycard_auth, access_tcomsat, access_gateway, access_xenoarch, access_eva) //VOREStation Edit
 	alt_titles = list("Research Supervisor")

--- a/maps/tether/tether-03-surface3.dmm
+++ b/maps/tether/tether-03-surface3.dmm
@@ -1266,7 +1266,8 @@
 	},
 /obj/machinery/door/airlock/glass_security{
 	name = "Break Room";
-	req_access = list(1)
+	req_access = list(63);
+	req_one_access = list(63)
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/tether/surfacebase/security/breakroom)
@@ -2763,7 +2764,8 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/glass_security{
 	name = "Break Room";
-	req_access = list(1)
+	req_access = list(63);
+	req_one_access = list(63)
 	},
 /obj/structure/cable/green{
 	d1 = 2;
@@ -3609,7 +3611,8 @@
 	id_tag = null;
 	layer = 2.8;
 	name = "Security";
-	req_access = list(1)
+	req_access = list(63);
+	req_one_access = list(63)
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/tether/surfacebase/security/lobby)

--- a/maps/tether/tether-07-station3.dmm
+++ b/maps/tether/tether-07-station3.dmm
@@ -2900,7 +2900,9 @@
 /area/security/breakroom)
 "ff" = (
 /obj/machinery/door/airlock/security{
-	name = "Security Restroom"
+	name = "Security Restroom";
+	req_access = list(63);
+	req_one_access = list(63)
 	},
 /turf/simulated/floor/tiled/white,
 /area/security/security_bathroom)
@@ -3273,7 +3275,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/security{
-	name = "Security Restroom"
+	name = "Security Restroom";
+	req_access = list(63);
+	req_one_access = list(63)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -3677,7 +3681,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/airlock/glass_security{
-	name = "Break Room"
+	name = "Break Room";
+	req_access = list(63);
+	req_one_access = list(63)
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/security/breakroom)
@@ -3689,7 +3695,9 @@
 	},
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/airlock/glass_security{
-	name = "Break Room"
+	name = "Break Room";
+	req_access = list(63);
+	req_one_access = list(63)
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/steel_grid,
@@ -5062,7 +5070,8 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/glass_security{
 	name = "Briefing Room";
-	req_access = list(1)
+	req_access = list(63);
+	req_one_access = list(63)
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/security/briefing_room)
@@ -6750,7 +6759,8 @@
 	},
 /obj/machinery/door/airlock/glass_security{
 	name = "Briefing Room";
-	req_access = list(1)
+	req_access = list(63);
+	req_one_access = list(63)
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/security/briefing_room)
@@ -7137,7 +7147,8 @@
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/airlock/glass_security{
 	name = "Briefing Room";
-	req_access = list(1)
+	req_access = list(63);
+	req_one_access = list(63)
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/security/briefing_room)
@@ -8338,7 +8349,8 @@
 	},
 /obj/machinery/door/airlock/maintenance/sec{
 	name = "Security Maintenance";
-	req_access = list(1,12)
+	req_access = list(12,63);
+	req_one_access = list(63)
 	},
 /turf/simulated/floor,
 /area/security/briefing_room)
@@ -8576,7 +8588,8 @@
 	id_tag = "BrigFoyer";
 	layer = 2.8;
 	name = "Security Wing";
-	req_access = list(1)
+	req_access = list(63);
+	req_one_access = list(63)
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/security/hallway)
@@ -8587,7 +8600,8 @@
 	id_tag = "BrigFoyer";
 	layer = 2.8;
 	name = "Security Wing";
-	req_access = list(1)
+	req_access = list(63);
+	req_one_access = list(63)
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/security/hallway)
@@ -8647,7 +8661,8 @@
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/airlock/security{
 	name = "Briefing Room";
-	req_access = list(1)
+	req_access = list(63);
+	req_one_access = list(63)
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/security/briefing_room)
@@ -10743,7 +10758,8 @@
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/airlock/glass_security{
 	name = "Front Desk";
-	req_access = list(1)
+	req_access = list(63);
+	req_one_access = list(63)
 	},
 /turf/simulated/floor/tiled,
 /area/security/lobby)


### PR DESCRIPTION
Changes access on some security doors from access_security (1) to access_sec_doors (63). This makes it so IAA can enter security, as well as fixes guest passes for the security common areas. Previously, letting someone into security with a pass meant you had to give them access to the green armory as well.

#2106 