### PR TITLE
Makes the door button in EVA ACTUALLY WORK

### DIFF
--- a/maps/tether/tether-06-station2.dmm
+++ b/maps/tether/tether-06-station2.dmm
@@ -8938,6 +8938,7 @@
 /area/ai_monitored/storage/eva)
 "pa" = (
 /obj/machinery/door/airlock/glass_command{
+	id_tag = "evadoors";
 	name = "E.V.A.";
 	req_one_access = list(18)
 	},
@@ -8958,6 +8959,7 @@
 /area/ai_monitored/storage/eva)
 "pc" = (
 /obj/machinery/door/airlock/glass_command{
+	id_tag = "evadoors";
 	name = "E.V.A.";
 	req_one_access = list(18)
 	},


### PR DESCRIPTION
Didn't think to put up an issue for this, something I've noticed in round. The Button inside EVA wasn't actually linked to any doors. This rectifies that.