### PR TITLE
Adds 'mode addons' feature to bellies to replace several modes

### DIFF
--- a/code/__defines/belly_modes_vr.dm
+++ b/code/__defines/belly_modes_vr.dm
@@ -1,28 +1,38 @@
-// Belly Mode Constants
+// Normal digestion modes
 #define DM_HOLD									"Hold"
-#define DM_DIGEST									"Digest"
-#define DM_ITEMWEAK									"Digest (Item Friendly)"
-#define DM_STRIPDIGEST									"Strip Digest (Items Only)"
-#define DM_DIGEST_NUMB							"Digest (Numbing)"
+#define DM_DIGEST								"Digest"
+#define DM_ABSORB								"Absorb"
+#define DM_UNABSORB								"Unabsorb"
+#define DM_DRAIN								"Drain"
+#define DM_SHRINK								"Shrink"
+#define DM_GROW									"Grow"
+#define DM_SIZE_STEAL							"Size Steal"
 #define DM_HEAL									"Heal"
-#define DM_ABSORB									"Absorb"
+#define DM_EGG 									"Encase In Egg"
+#define DM_TRANSFORM							"Transform"
+
+//#define DM_ITEMWEAK							"Digest (Item Friendly)"
+//#define DM_STRIPDIGEST						"Strip Digest (Items Only)"
+//#define DM_DIGEST_NUMB						"Digest (Numbing)"
+
+//TF modes
 #define DM_TRANSFORM_HAIR_AND_EYES					"Transform (Hair and eyes)"
 #define DM_TRANSFORM_MALE							"Transform (Male)"
-#define DM_TRANSFORM_FEMALE						"Transform (Female)"
+#define DM_TRANSFORM_FEMALE							"Transform (Female)"
 #define DM_TRANSFORM_KEEP_GENDER					"Transform (Keep Gender)"
 #define DM_TRANSFORM_REPLICA						"Transform (Replica Of Self)"
 #define DM_TRANSFORM_CHANGE_SPECIES_AND_TAUR		"Transform (Change Species and Taur)"
-#define DM_TRANSFORM_CHANGE_SPECIES_AND_TAUR_EGG		"Transform (Change Species and Taur) (EGG)"
+#define DM_TRANSFORM_CHANGE_SPECIES_AND_TAUR_EGG	"Transform (Change Species and Taur) (EGG)"
 #define DM_TRANSFORM_REPLICA_EGG					"Transform (Replica Of Self) (EGG)"
 #define DM_TRANSFORM_KEEP_GENDER_EGG				"Transform (Keep Gender) (EGG)"
 #define DM_TRANSFORM_MALE_EGG						"Transform (Male) (EGG)"
-#define DM_TRANSFORM_FEMALE_EGG					"Transform (Female) (EGG)"
-#define DM_EGG 									"Encase In Egg"
-#define DM_DRAIN									"Drain"
-#define DM_UNABSORB								"Unabsorb"
-#define DM_SHRINK									"Shrink"
-#define DM_GROW									"Grow"
-#define DM_SIZE_STEAL								"Size Steal"
+#define DM_TRANSFORM_FEMALE_EGG						"Transform (Female) (EGG)"
+
+//Addon mode flags
+#define DM_FLAG_NUMBING		0x1
+#define DM_FLAG_ITEMWEAK	0x2
+#define DM_FLAG_STRIPPING	0x4
+
 // Stance for hostile mobs to be in while devouring someone.
 #define HOSTILE_STANCE_EATING	99
 

--- a/code/_macros_vr.dm
+++ b/code/_macros_vr.dm
@@ -1,2 +1,3 @@
 #define isbelly(A) istype(A, /obj/belly)
 #define isstorage(A) istype(A, /obj/item/weapon/storage)
+#define isitem(A) istype(A, /obj/item)

--- a/code/modules/mob/living/simple_animal/animals/cat_vr.dm
+++ b/code/modules/mob/living/simple_animal/animals/cat_vr.dm
@@ -20,14 +20,6 @@
 		"Runtime flops onto their side for a minute, spilling acids over your form as you remain trapped in them.",
 		"The CMO's pet doesn't seem to think you're any different from any other meal. At least, their stomach doesn't.")
 
-	B.emote_lists[DM_ITEMWEAK] = list(
-		"Runtime's stomach is treating you rather like a mouse, kneading acids into you with vigor.",
-		"A thick dollop of bellyslime drips from above while the CMO's pet's gut works on churning you up.",
-		"Runtime seems to have decided you're food, based on the acrid air in her guts and the pooling fluids.",
-		"Runtime's stomach tries to claim you, kneading and pressing inwards again and again against your form.",
-		"Runtime flops onto their side for a minute, spilling acids over your form as you remain trapped in them.",
-		"The CMO's pet doesn't seem to think you're any different from any other meal. At least, their stomach doesn't.")
-
 	B.digest_messages_prey = list(
 		"Runtime's stomach slowly melts your body away. Her stomach refuses to give up it's onslaught, continuing until you're nothing more than nutrients for her body to absorb.",
 		"After an agonizing amount of time, Runtime's stomach finally manages to claim you, melting you down and adding you to her stomach.",

--- a/code/modules/mob/living/simple_animal/animals/fox_vr.dm
+++ b/code/modules/mob/living/simple_animal/animals/fox_vr.dm
@@ -61,14 +61,6 @@
 		"The fox's stomach churns hungrily over your form, trying to take you.",
 		"With a loud glorp, the stomach spills more acids onto you.")
 
-	B.emote_lists[DM_ITEMWEAK] = list(
-		"The guts knead at you, trying to work you into thick soup.",
-		"You're ground on by the slimey walls, treated like a mouse.",
-		"The acrid air is hard to breathe, and stings at your lungs.",
-		"You can feel the acids coating you, ground in by the slick walls.",
-		"The fox's stomach churns hungrily over your form, trying to take you.",
-		"With a loud glorp, the stomach spills more acids onto you.")
-
 // All them complicated fox procedures.
 /mob/living/simple_animal/fox/Life()
 	. = ..()
@@ -202,14 +194,6 @@
 		"Renault's stomach walls squeeze closer, as he belches quietly, before swallowing more air. Does he do that on purpose?")
 
 	B.emote_lists[DM_DIGEST] = list(
-		"Renault's stomach walls grind hungrily inwards, kneading acids against your form, and treating you like any other food.",
-		"The captain's fox impatiently kneads and works acids against you, trying to claim your body for fuel.",
-		"The walls knead in firmly, squeezing and tossing you around briefly in disorienting aggression.",
-		"Renault belches, letting the remaining air grow more acrid. It burns your lungs with each breath.",
-		"A thick glob of acids drip down from above, adding to the pool of caustic fluids in Renault's belly.",
-		"There's a loud gurgle as the stomach declares the intent to make you a part of Renault.")
-
-	B.emote_lists[DM_ITEMWEAK] = list(
 		"Renault's stomach walls grind hungrily inwards, kneading acids against your form, and treating you like any other food.",
 		"The captain's fox impatiently kneads and works acids against you, trying to claim your body for fuel.",
 		"The walls knead in firmly, squeezing and tossing you around briefly in disorienting aggression.",

--- a/code/modules/mob/living/simple_animal/simple_animal_vr.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal_vr.dm
@@ -15,7 +15,8 @@
 	var/vore_standing_too = 0			// Can also eat non-stunned mobs
 	var/vore_ignores_undigestable = 1	// Refuse to eat mobs who are undigestable by the prefs toggle.
 
-	var/vore_default_mode = DM_ITEMWEAK	// Default bellymode (DM_DIGEST, DM_HOLD, DM_ABSORB)
+	var/vore_default_mode = DM_DIGEST	// Default bellymode (DM_DIGEST, DM_HOLD, DM_ABSORB)
+	var/vore_default_flags = DM_FLAG_ITEMWEAK // Itemweak by default
 	var/vore_digest_chance = 25			// Chance to switch to digest mode if resisted
 	var/vore_absorb_chance = 0			// Chance to switch to absorb mode if resisted
 	var/vore_escape_chance = 25			// Chance of resisting out of mob
@@ -147,6 +148,7 @@
 	B.name = vore_stomach_name ? vore_stomach_name : "stomach"
 	B.desc = vore_stomach_flavor ? vore_stomach_flavor : "Your surroundings are warm, soft, and slimy. Makes sense, considering you're inside \the [name]."
 	B.digest_mode = vore_default_mode
+	B.mode_flags = vore_default_flags
 	B.escapable = vore_escape_chance > 0
 	B.escapechance = vore_escape_chance
 	B.digestchance = vore_digest_chance
@@ -165,16 +167,6 @@
 		"The sound of bodily movements drown out everything for a moment.",
 		"The predator's movements gently force you into a different position.")
 	B.emote_lists[DM_DIGEST] = list(
-		"The burning acids eat away at your form.",
-		"The muscular stomach flesh grinds harshly against you.",
-		"The caustic air stings your chest when you try to breathe.",
-		"The slimy guts squeeze inward to help the digestive juices soften you up.",
-		"The onslaught against your body doesn't seem to be letting up; you're food now.",
-		"The predator's body ripples and crushes against you as digestive enzymes pull you apart.",
-		"The juices pooling beneath you sizzle against your sore skin.",
-		"The churning walls slowly pulverize you into meaty nutrients.",
-		"The stomach glorps and gurgles as it tries to work you into slop.")
-	B.emote_lists[DM_ITEMWEAK] = list(
 		"The burning acids eat away at your form.",
 		"The muscular stomach flesh grinds harshly against you.",
 		"The caustic air stings your chest when you try to breathe.",

--- a/code/modules/mob/living/simple_animal/vore/shadekin/shadekin.dm
+++ b/code/modules/mob/living/simple_animal/vore/shadekin/shadekin.dm
@@ -154,12 +154,6 @@
 		"The grip of that stomach is harsh. Eagerly mushing and rubbing that slime into your body in attempts to break you down!",
 		"The intense churning and grinding jostles your around within the thick slime as you're slowly broken down!"
 		)
-	B.emote_lists[DM_ITEMWEAK] = list(
-		"The walls slop thick slime across your body! It tingles briefly before the sting and ache sets in!",
-		"The sound of your body slipping and sliding against the powerfully churning stomach fills the air!",
-		"The grip of that stomach is harsh. Eagerly mushing and rubbing that slime into your body in attempts to break you down!",
-		"The intense churning and grinding jostles your around within the thick slime as you're slowly broken down!"
-		)
 	B.emote_lists[DM_ABSORB] = list(
 		"The walls cling to you awfully close... It's almost like you're sinking into them.",
 		"You can feel the walls press in tightly against you, clinging to you posessively!",

--- a/code/modules/mob/living/simple_animal/vore/solargrub.dm
+++ b/code/modules/mob/living/simple_animal/vore/solargrub.dm
@@ -96,7 +96,7 @@ List of things solar grubs should be able to do:
 	vore_active = 1
 	vore_capacity = 1
 	vore_pounce_chance = 0 //grubs only eat incapacitated targets
-	vore_default_mode = DM_ITEMWEAK //item friendly digestions, they just want your chemical energy :3
+	vore_default_mode = DM_DIGEST
 
 /mob/living/simple_animal/retaliate/solargrub/PunchTarget()
 	. = ..()

--- a/code/modules/vore/eating/belly_dat_vr.dm
+++ b/code/modules/vore/eating/belly_dat_vr.dm
@@ -30,7 +30,7 @@
 	var/datum/belly/transferlocation = null	// Location that the prey is released if they struggle and get dropped off.
 
 	var/tmp/digest_mode = DM_HOLD				// Whether or not to digest. Default to not digest.
-	var/tmp/list/digest_modes = list(DM_HOLD,DM_DIGEST,DM_ITEMWEAK,DM_STRIPDIGEST,DM_HEAL,DM_ABSORB,DM_DRAIN,DM_UNABSORB,DM_SHRINK,DM_GROW,DM_SIZE_STEAL,DM_DIGEST_NUMB)	// Possible digest modes
+	var/tmp/list/digest_modes = list(DM_HOLD,DM_DIGEST,DM_HEAL,DM_ABSORB,DM_DRAIN,DM_UNABSORB,DM_SHRINK,DM_GROW,DM_SIZE_STEAL)	// Possible digest modes
 	var/tmp/list/transform_modes = list(DM_TRANSFORM_MALE,DM_TRANSFORM_FEMALE,DM_TRANSFORM_KEEP_GENDER,DM_TRANSFORM_CHANGE_SPECIES_AND_TAUR,DM_TRANSFORM_CHANGE_SPECIES_AND_TAUR_EGG,DM_TRANSFORM_REPLICA,DM_TRANSFORM_REPLICA_EGG,DM_TRANSFORM_KEEP_GENDER_EGG,DM_TRANSFORM_MALE_EGG,DM_TRANSFORM_FEMALE_EGG, DM_EGG)
 	var/tmp/mob/living/owner					// The mob whose belly this is.
 	var/tmp/list/internal_contents = list()		// People/Things you've eaten into this belly!

--- a/code/modules/vore/eating/belly_obj_vr.dm
+++ b/code/modules/vore/eating/belly_obj_vr.dm
@@ -32,14 +32,22 @@
 	var/shrink_grow_size = 1				// This horribly named variable determines the minimum/maximum size it will shrink/grow prey to.
 	var/transferlocation					// Location that the prey is released if they struggle and get dropped off.
 	var/release_sound = TRUE				// Boolean for now, maybe replace with something else later
+	var/mode_flags = 0						// Stripping, numbing, etc.
 
 	//I don't think we've ever altered these lists. making them static until someone actually overrides them somewhere.
-	var/tmp/static/list/digest_modes = list(DM_HOLD,DM_DIGEST,DM_ITEMWEAK,DM_STRIPDIGEST,DM_HEAL,DM_ABSORB,DM_DRAIN,DM_UNABSORB,DM_SHRINK,DM_GROW,DM_SIZE_STEAL,DM_DIGEST_NUMB)	// Possible digest modes
+	//Actual full digest modes
+	var/tmp/static/list/digest_modes = list(DM_HOLD,DM_DIGEST,DM_ABSORB,DM_DRAIN,DM_UNABSORB,DM_HEAL,DM_SHRINK,DM_GROW,DM_SIZE_STEAL)
+	//Digest mode addon flags
+	var/tmp/static/list/mode_flag_list = list("Numbing" = DM_FLAG_NUMBING, "Itemweak" = DM_FLAG_ITEMWEAK, "Stripping" = DM_FLAG_STRIPPING)
+	//Transformation modes
 	var/tmp/static/list/transform_modes = list(DM_TRANSFORM_MALE,DM_TRANSFORM_FEMALE,DM_TRANSFORM_KEEP_GENDER,DM_TRANSFORM_CHANGE_SPECIES_AND_TAUR,DM_TRANSFORM_CHANGE_SPECIES_AND_TAUR_EGG,DM_TRANSFORM_REPLICA,DM_TRANSFORM_REPLICA_EGG,DM_TRANSFORM_KEEP_GENDER_EGG,DM_TRANSFORM_MALE_EGG,DM_TRANSFORM_FEMALE_EGG, DM_EGG)
+	
+	//List of slots that stripping handles strips
 	var/tmp/static/list/slots = list(slot_back,slot_handcuffed,slot_l_store,slot_r_store,slot_wear_mask,slot_l_hand,slot_r_hand,slot_wear_id,slot_glasses,slot_gloves,slot_head,slot_shoes,slot_belt,slot_wear_suit,slot_w_uniform,slot_s_store,slot_l_ear,slot_r_ear)
 
 	var/tmp/mob/living/owner					// The mob whose belly this is.
 	var/tmp/digest_mode = DM_HOLD				// Current mode the belly is set to from digest_modes (+transform_modes if human)
+	var/tmp/tf_mode = DM_TRANSFORM_REPLICA		// Current transformation mode.
 	var/tmp/next_process = 0					// Waiting for this SSbellies times_fired to process again.
 	var/tmp/list/items_preserved = list()		// Stuff that wont digest so we shouldn't process it again.
 	var/tmp/next_emote = 0						// When we're supposed to print our next emote, as a belly controller tick #
@@ -127,7 +135,8 @@
 		"digest_messages_owner",
 		"digest_messages_prey",
 		"examine_messages",
-		"emote_lists"
+		"emote_lists",
+		"mode_flags"
 		)
 
 /obj/belly/New(var/newloc)
@@ -359,9 +368,12 @@
 					brain.forceMove(src)
 					items_preserved += brain
 			for(var/slot in slots)
-				var/obj/item/thingy = M.get_equipped_item(slot = slot)
-				if(thingy)
-					M.unEquip(thingy,force = TRUE)
+				var/obj/item/I = M.get_equipped_item(slot = slot)
+				if(I)
+					M.unEquip(I,force = TRUE)
+					I.gurgle_contaminate(contents, owner) //We do an initial contamination pass to get stuff like IDs wet.
+					if(mode_flags & DM_FLAG_ITEMWEAK)
+						items_preserved |= I
 
 	//Reagent transfer
 	if(ishuman(owner))
@@ -535,17 +547,12 @@
 			digest_mode = DM_ABSORB
 			return
 
-		else if(prob(digestchance) && digest_mode != DM_ITEMWEAK && digest_mode != DM_DIGEST) //Finally, let's see if it should run the digest chance.
+		else if(prob(digestchance) && digest_mode != DM_DIGEST) //Finally, let's see if it should run the digest chance.
 			to_chat(R,"<span class='warning'>In response to your struggling, \the [lowertext(name)] begins to get more active...</span>")
 			to_chat(owner,"<span class='warning'>You feel your [lowertext(name)] beginning to become active!</span>")
-			digest_mode = DM_ITEMWEAK
-			return
-
-		else if(prob(digestchance) && digest_mode == DM_ITEMWEAK) //Oh god it gets even worse if you fail twice!
-			to_chat(R,"<span class='warning'>In response to your struggling, \the [lowertext(name)] begins to get even more active!</span>")
-			to_chat(owner,"<span class='warning'>You feel your [lowertext(name)] beginning to become even more active!</span>")
 			digest_mode = DM_DIGEST
 			return
+
 		else //Nothing interesting happened.
 			to_chat(R,"<span class='warning'>You make no progress in escaping [owner]'s [lowertext(name)].</span>")
 			to_chat(owner,"<span class='warning'>Your prey appears to be unable to make any progress in escaping your [lowertext(name)].</span>")
@@ -603,6 +610,7 @@
 	dupe.transferlocation = transferlocation
 	dupe.bulge_size = bulge_size
 	dupe.shrink_grow_size = shrink_grow_size
+	dupe.mode_flags = mode_flags
 
 	//// Object-holding variables
 	//struggle_messages_outside - strings

--- a/code/modules/vore/eating/bellymodes_tf_vr.dm
+++ b/code/modules/vore/eating/bellymodes_tf_vr.dm
@@ -1,0 +1,237 @@
+/obj/belly/proc/process_tf(var/mode,var/list/touchable_mobs) //We pass mode so it's mega-ultra local.
+	/* May not be necessary... Transform only shows up in the panel for humans.
+	if(!ishuman(owner))
+		return //Need DNA and junk for this.
+	*/
+
+	//Cast here for reduced duplication
+	var/mob/living/carbon/human/O = owner
+
+///////////////////////////// DM_TRANSFORM_HAIR_AND_EYES /////////////////////////////
+	if(mode == DM_TRANSFORM_HAIR_AND_EYES)
+		for (var/mob/living/carbon/human/P in touchable_mobs)
+			if(P.stat == DEAD)
+				continue
+
+			if(O.nutrition > 400 && P.nutrition < 400)
+				O.nutrition -= 2
+				P.nutrition += 1.5
+
+			if(check_eyes(P) || check_hair(P))
+				change_eyes(P)
+				change_hair(P,1)
+
+///////////////////////////// DM_TRANSFORM_MALE /////////////////////////////
+	else if(mode == DM_TRANSFORM_MALE)
+		for (var/mob/living/carbon/human/P in touchable_mobs)
+			if(P.stat == DEAD)
+				continue
+
+			if(O.nutrition > 400 && P.nutrition < 400)
+				O.nutrition -= 2
+				P.nutrition += 1.5
+
+			if(check_eyes(P))
+				change_eyes(P,1)
+				continue
+
+			if(check_hair(P) || check_skin(P))
+				change_hair(P)
+				change_skin(P,1)
+				continue
+
+			if(check_gender(P,MALE))
+				change_gender(P,MALE,1)
+
+///////////////////////////// DM_TRANSFORM_FEMALE /////////////////////////////
+	else if(mode == DM_TRANSFORM_FEMALE)
+		for (var/mob/living/carbon/human/P in touchable_mobs)
+			if(P.stat == DEAD)
+				continue
+
+			if(O.nutrition > 400 && P.nutrition < 400)
+				O.nutrition -= 2
+				P.nutrition += 1.5
+
+			if(check_eyes(P))
+				change_eyes(P,1)
+				continue
+
+			if(check_hair(P) || check_skin(P))
+				change_hair(P)
+				change_skin(P,1)
+				continue
+
+			if(check_gender(P,FEMALE))
+				change_gender(P,FEMALE,1)
+
+///////////////////////////// DM_TRANSFORM_KEEP_GENDER  /////////////////////////////
+	else if(mode == DM_TRANSFORM_KEEP_GENDER)
+		for (var/mob/living/carbon/human/P in touchable_mobs)
+			if(P.stat == DEAD)
+				continue
+
+			if(O.nutrition > 400 && P.nutrition < 400)
+				O.nutrition -= 2
+				P.nutrition += 1.5
+
+			if(check_eyes(P))
+				change_eyes(P,1)
+				continue
+
+			if(check_hair(P) || check_skin(P))
+				change_hair(P)
+				change_skin(P,1)
+
+///////////////////////////// DM_TRANSFORM_CHANGE_SPECIES_AND_TAUR  /////////////////////////////
+	else if(mode == DM_TRANSFORM_CHANGE_SPECIES_AND_TAUR)
+		for (var/mob/living/carbon/human/P in touchable_mobs)
+			if(P.stat == DEAD)
+				continue
+
+			if(O.nutrition > 400 && P.nutrition < 400)
+				O.nutrition -= 2
+				P.nutrition += 1.5
+
+			if(check_ears(P) || check_tail_nocolor(P) || check_wing_nocolor(P) || check_species(P))
+				change_ears(P)
+				change_tail_nocolor(P)
+				change_wing_nocolor(P)
+				change_species(P,1)
+
+///////////////////////////// DM_TRANSFORM_REPLICA /////////////////////////////
+	else if(mode == DM_TRANSFORM_REPLICA)
+		for (var/mob/living/carbon/human/P in touchable_mobs)
+			if(P.stat == DEAD)
+				continue
+
+			if(O.nutrition > 400 && P.nutrition < 400)
+				O.nutrition -= 2
+				P.nutrition += 1.5
+
+			if(check_eyes(P))
+				change_eyes(P,1)
+				continue
+
+			if(check_hair(P) || check_skin(P))
+				change_hair(P)
+				change_skin(P,1)
+				continue
+
+			if(check_ears(P) || check_tail(P) || check_wing(P) || check_species(P))
+				change_ears(P)
+				change_tail(P)
+				change_wing(P)
+				change_species(P,1)
+
+///////////////////////////// DM_TRANSFORM_CHANGE_SPECIES_AND_TAUR_EGG /////////////////////////////
+	else if(mode == DM_TRANSFORM_CHANGE_SPECIES_AND_TAUR_EGG)
+		for (var/mob/living/carbon/human/P in touchable_mobs)
+			if(P.stat == DEAD)
+				continue
+
+			if(check_ears(P) || check_tail_nocolor(P) || check_wing_nocolor(P)|| check_species(P))
+				change_ears(P)
+				change_tail_nocolor(P)
+				change_wing_nocolor(P)
+				change_species(P,1)
+				continue
+
+			if(!P.absorbed)
+				put_in_egg(P,1)
+
+///////////////////////////// DM_TRANSFORM_KEEP_GENDER_EGG  /////////////////////////////
+	else if(mode == DM_TRANSFORM_KEEP_GENDER_EGG)
+		for (var/mob/living/carbon/human/P in touchable_mobs)
+			if(P.stat == DEAD)
+				continue
+
+			if(check_eyes(P))
+				change_eyes(P,1)
+				continue
+
+			if(check_hair(P) || check_skin(P))
+				change_hair(P)
+				change_skin(P,1)
+				continue
+
+			if(!P.absorbed)
+				put_in_egg(P,1)
+
+///////////////////////////// DM_TRANSFORM_REPLICA_EGG /////////////////////////////
+	else if(mode == DM_TRANSFORM_REPLICA_EGG)
+		for (var/mob/living/carbon/human/P in touchable_mobs)
+			if(P.stat == DEAD)
+				continue
+
+			if(check_eyes(P))
+				change_eyes(P,1)
+				continue
+
+			if(check_hair(P) || check_skin(P))
+				change_hair(P)
+				change_skin(P,1)
+				continue
+
+			if(check_ears(P) || check_tail(P) || check_wing(P) || check_species(P))
+				change_ears(P)
+				change_tail(P)
+				change_wing(P)
+				change_species(P,1)
+				continue
+
+			if(!P.absorbed)
+				put_in_egg(P,1)
+
+///////////////////////////// DM_TRANSFORM_MALE_EGG /////////////////////////////
+	else if(mode == DM_TRANSFORM_MALE_EGG)
+		for (var/mob/living/carbon/human/P in touchable_mobs)
+			if(P.stat == DEAD)
+				continue
+
+			if(check_eyes(P))
+				change_eyes(P,1)
+				continue
+
+			if(check_hair(P) || check_skin(P))
+				change_hair(P)
+				change_skin(P,1)
+				continue
+
+			if(check_gender(P,MALE))
+				change_gender(P,MALE,1)
+				continue
+
+			if(!P.absorbed)
+				put_in_egg(P,1)
+
+///////////////////////////// DM_TRANSFORM_FEMALE_EGG /////////////////////////////
+	else if(mode == DM_TRANSFORM_FEMALE_EGG)
+		for (var/mob/living/carbon/human/P in touchable_mobs)
+			if(P.stat == DEAD)
+				continue
+
+			if(check_eyes(P))
+				change_eyes(P,1)
+				continue
+
+			if(check_hair(P) || check_skin(P))
+				change_hair(P)
+				change_skin(P,1)
+				continue
+
+			if(check_gender(P,MALE))
+				change_gender(P,MALE,1)
+				continue
+
+			if(!P.absorbed)
+				put_in_egg(P,1)
+
+///////////////////////////// DM_EGG /////////////////////////////
+	else if(mode == DM_EGG)
+		for (var/mob/living/carbon/human/P in touchable_mobs)
+			if(P.absorbed || P.stat == DEAD)
+				continue
+
+			put_in_egg(P,1)
+

--- a/code/modules/vore/eating/bellymodes_vr.dm
+++ b/code/modules/vore/eating/bellymodes_vr.dm
@@ -20,30 +20,74 @@
 		var/list/EL = emote_lists[digest_mode]
 		if(LAZYLEN(EL))
 			for(var/mob/living/M in contents)
-				if(M.digestable || !(digest_mode == DM_DIGEST || digest_mode == DM_DIGEST_NUMB || digest_mode == DM_ITEMWEAK)) // don't give digesty messages to indigestible people
+				if(M.digestable || digest_mode != DM_DIGEST) // don't give digesty messages to indigestible people
 					to_chat(M,"<span class='notice'>[pick(EL)]</span>")
 
 /////////////////////////// Exit Early ////////////////////////////
-	var/list/touchable_items = contents - items_preserved
-	if(!length(touchable_items))
+	var/list/touchable_atoms = contents - items_preserved
+	if(!length(touchable_atoms))
 		return SSBELLIES_PROCESSED
 
-//////////////////////// Absorbed Handling ////////////////////////
-	for(var/mob/living/M in contents)
-		if(M.absorbed)
-			M.Weaken(5)
+	var/list/touchable_mobs = list()
+
+///////////////////// Early Non-Mode Handling /////////////////////
+	var/did_an_item = FALSE
+	for(var/A in touchable_atoms)
+		//Handle stray items
+		if(isitem(A) && !did_an_item)
+			var/obj/item/I = A
+			if(mode_flags & DM_FLAG_ITEMWEAK)
+				I.gurgle_contaminate(contents, owner)
+				items_preserved |= I
+			else
+				digest_item(I)
+			owner.updateVRPanel()
+			did_an_item = TRUE
+
+		//Handle eaten mobs
+		else if(isliving(A))
+			var/mob/living/L = A
+			touchable_mobs += L
+
+			if(L.absorbed)
+				L.Weaken(5)
+			
+			//Handle 'human'
+			if(ishuman(L))
+				var/mob/living/carbon/human/H = L
+				
+				//Numbing flag
+				if(mode_flags & DM_FLAG_NUMBING)
+					if(H.bloodstr.get_reagent_amount("numbenzyme") < 2)
+						H.bloodstr.add_reagent("numbenzyme",4)
+
+				//Stripping flag
+				if(mode_flags & DM_FLAG_STRIPPING)
+					for(var/slot in slots)
+						var/obj/item/I = H.get_equipped_item(slot = slot)
+						if(I)
+							H.unEquip(I,force = TRUE)
+							if(mode_flags & DM_FLAG_ITEMWEAK)
+								I.gurgle_contaminate(contents, owner)
+								items_preserved |= I
+							else
+								digest_item(I)
+							owner.updateVRPanel()
+							H.updateVRPanel()
+							break
 
 ///////////////////////////// DM_HOLD /////////////////////////////
 	if(digest_mode == DM_HOLD)
 		return SSBELLIES_PROCESSED //Pretty boring, huh
 
 //////////////////////////// DM_DIGEST ////////////////////////////
-	else if(digest_mode == DM_DIGEST || digest_mode == DM_DIGEST_NUMB || digest_mode == DM_ITEMWEAK)
+	else if(digest_mode == DM_DIGEST)
 
 		if(prob(50)) //Was SO OFTEN. AAAA.
 			play_sound = pick(digestion_sounds)
 
-		for (var/mob/living/M in contents)
+		for (var/target in touchable_mobs)
+			var/mob/living/M = target
 			//Pref protection!
 			if (!M.digestable || M.absorbed)
 				continue
@@ -71,11 +115,6 @@
 				owner.update_icons()
 				continue
 
-			if(digest_mode == DM_DIGEST_NUMB && ishuman(M))
-				var/mob/living/carbon/human/H = M
-				if(H.bloodstr.get_reagent_amount("numbenzyme") < 5)
-					H.bloodstr.add_reagent("numbenzyme",10)
-
 			// Deal digestion damage (and feed the pred)
 			M.adjustBruteLoss(digest_brute)
 			M.adjustFireLoss(digest_burn)
@@ -91,49 +130,13 @@
 				owner.nutrition += 2*(digest_brute+digest_burn)/difference
 			M.updateVRPanel()
 
-		//Contaminate or gurgle items
-		var/obj/item/T = pick(touchable_items)
-		if(istype(T))
-			if(digest_mode == DM_ITEMWEAK)
-				if(istype(T,/obj/item/weapon/reagent_containers/food) || istype(T,/obj/item/weapon/holder) || istype(T,/obj/item/organ))
-					digest_item(T)
-				else
-					T.gurgle_contaminate(contents, owner)
-					items_preserved |= T
-			else
-				digest_item(T)
-
-		owner.updateVRPanel()
-
-//////////////////////////// DM_STRIPDIGEST ////////////////////////////
-	else if(digest_mode == DM_STRIPDIGEST) // Only gurgle the gear off your prey.
-
-		if(prob(50))
-			play_sound = pick(digestion_sounds)
-
-		// Handle loose items first.
-		var/obj/item/T = pick(touchable_items)
-		if(istype(T))
-			digest_item(T)
-
-		for(var/mob/living/carbon/human/M in contents)
-			if (M.absorbed)
-				continue
-			for(var/slot in slots)
-				var/obj/item/thingy = M.get_equipped_item(slot = slot)
-				if(thingy)
-					M.unEquip(thingy,force = TRUE)
-					digest_item(thingy)
-					break
-			M.updateVRPanel()
-
 		owner.updateVRPanel()
 
 //////////////////////////// DM_ABSORB ////////////////////////////
 	else if(digest_mode == DM_ABSORB)
 
-		for (var/mob/living/M in contents)
-
+		for (var/target in touchable_mobs)
+			var/mob/living/M = target
 			if(prob(10)) //Less often than gurgles. People might leave this on forever.
 				play_sound = pick(digestion_sounds)
 
@@ -150,7 +153,9 @@
 //////////////////////////// DM_UNABSORB ////////////////////////////
 	else if(digest_mode == DM_UNABSORB)
 
-		for (var/mob/living/M in contents)
+		for (var/target in touchable_mobs)
+			var/mob/living/M = target
+			
 			if(M.absorbed && owner.nutrition >= 100)
 				M.absorbed = 0
 				to_chat(M,"<span class='notice'>You suddenly feel solid again </span>")
@@ -160,8 +165,9 @@
 //////////////////////////// DM_DRAIN ////////////////////////////
 	else if(digest_mode == DM_DRAIN)
 
-		for (var/mob/living/M in contents)
-
+		for (var/target in touchable_mobs)
+			var/mob/living/M = target
+			
 			if(prob(10)) //Less often than gurgles. People might leave this on forever.
 				play_sound = pick(digestion_sounds)
 
@@ -173,13 +179,15 @@
 //////////////////////////// DM_SHRINK ////////////////////////////
 	else if(digest_mode == DM_SHRINK)
 
-		for (var/mob/living/M in contents)
-
+		for (var/target in touchable_mobs)
+			var/mob/living/M = target
+			
 			if(prob(10)) //Infinite gurgles!
 				play_sound = pick(digestion_sounds)
 
 			if(M.size_multiplier > shrink_grow_size) //Shrink until smol.
 				M.resize(M.size_multiplier-0.01) //Shrink by 1% per tick.
+				
 				if(M.nutrition >= 100) //Absorbing bodymass results in nutrition if possible.
 					var/oldnutrition = (M.nutrition * 0.05)
 					M.nutrition = (M.nutrition * 0.95)
@@ -188,8 +196,9 @@
 //////////////////////////// DM_GROW ////////////////////////////
 	else if(digest_mode == DM_GROW)
 
-		for (var/mob/living/M in contents)
-
+		for (var/target in touchable_mobs)
+			var/mob/living/M = target
+			
 			if(prob(10))
 				play_sound = pick(digestion_sounds)
 
@@ -201,14 +210,16 @@
 //////////////////////////// DM_SIZE_STEAL ////////////////////////////
 	else if(digest_mode == DM_SIZE_STEAL)
 
-		for (var/mob/living/M in contents)
-
+		for (var/target in touchable_mobs)
+			var/mob/living/M = target
+			
 			if(prob(10))
 				play_sound = pick(digestion_sounds)
 
 			if(M.size_multiplier > shrink_grow_size && owner.size_multiplier < 2) //Grow until either pred is large or prey is small.
 				owner.resize(owner.size_multiplier+0.01) //Grow by 1% per tick.
 				M.resize(M.size_multiplier-0.01) //Shrink by 1% per tick
+				
 				if(M.nutrition >= 100)
 					var/oldnutrition = (M.nutrition * 0.05)
 					M.nutrition = (M.nutrition * 0.95)
@@ -216,261 +227,31 @@
 
 ///////////////////////////// DM_HEAL /////////////////////////////
 	else if(digest_mode == DM_HEAL)
-		if(prob(50)) //Wet heals!
+		
+		if(prob(50)) //Wet heals! The secret is you can leave this on for gurgle noises for fun.
 			play_sound = pick(digestion_sounds)
 
-		for (var/mob/living/M in contents)
-			if(M.stat != DEAD)
-				if(owner.nutrition > 90 && (M.health < M.maxHealth))
-					M.adjustBruteLoss(-5)
-					M.adjustFireLoss(-5)
-					owner.nutrition -= 2
-					if(M.nutrition <= 400)
-						M.nutrition += 1
-				else if(owner.nutrition > 90 && (M.nutrition <= 400))
-					owner.nutrition -= 1
+		for (var/target in touchable_mobs)
+			var/mob/living/M = target
+
+			if(M.stat == DEAD)
+				continue
+
+			if(owner.nutrition > 90 && (M.health < M.maxHealth))
+				M.adjustBruteLoss(-5)
+				M.adjustFireLoss(-5)
+				owner.nutrition -= 2
+				if(M.nutrition <= 400)
 					M.nutrition += 1
+			else if(owner.nutrition > 90 && (M.nutrition <= 400))
+				owner.nutrition -= 1
+				M.nutrition += 1
 
-///////////////////////////// DM_TRANSFORM_HAIR_AND_EYES /////////////////////////////
-	else if(digest_mode == DM_TRANSFORM_HAIR_AND_EYES && ishuman(owner))
-		for (var/mob/living/carbon/human/P in contents)
-			if(P.stat == DEAD)
-				continue
+/////////////////////////// DM_TRANSFORM ///////////////////////////
+	else if(digest_mode == DM_TRANSFORM)
+		process_tf(tf_mode, touchable_mobs)
 
-			var/mob/living/carbon/human/O = owner
-
-			if(O.nutrition > 400 && P.nutrition < 400)
-				O.nutrition -= 2
-				P.nutrition += 1.5
-
-			if(check_eyes(P) || check_hair(P))
-				change_eyes(P)
-				change_hair(P,1)
-
-///////////////////////////// DM_TRANSFORM_MALE /////////////////////////////
-	else if(digest_mode == DM_TRANSFORM_MALE && ishuman(owner))
-		for (var/mob/living/carbon/human/P in contents)
-			if(P.stat == DEAD)
-				continue
-
-			var/mob/living/carbon/human/O = owner
-
-			if(O.nutrition > 400 && P.nutrition < 400)
-				O.nutrition -= 2
-				P.nutrition += 1.5
-
-			if(check_eyes(P))
-				change_eyes(P,1)
-				continue
-
-			if(check_hair(P) || check_skin(P))
-				change_hair(P)
-				change_skin(P,1)
-				continue
-
-			if(check_gender(P,MALE))
-				change_gender(P,MALE,1)
-
-///////////////////////////// DM_TRANSFORM_FEMALE /////////////////////////////
-	else if(digest_mode == DM_TRANSFORM_FEMALE && ishuman(owner))
-		for (var/mob/living/carbon/human/P in contents)
-			if(P.stat == DEAD)
-				continue
-
-			var/mob/living/carbon/human/O = owner
-
-			if(O.nutrition > 400 && P.nutrition < 400)
-				O.nutrition -= 2
-				P.nutrition += 1.5
-
-			if(check_eyes(P))
-				change_eyes(P,1)
-				continue
-
-			if(check_hair(P) || check_skin(P))
-				change_hair(P)
-				change_skin(P,1)
-				continue
-
-			if(check_gender(P,FEMALE))
-				change_gender(P,FEMALE,1)
-
-///////////////////////////// DM_TRANSFORM_KEEP_GENDER  /////////////////////////////
-	else if(digest_mode == DM_TRANSFORM_KEEP_GENDER && ishuman(owner))
-		for (var/mob/living/carbon/human/P in contents)
-			if(P.stat == DEAD)
-				continue
-
-			var/mob/living/carbon/human/O = owner
-
-			if(O.nutrition > 400 && P.nutrition < 400)
-				O.nutrition -= 2
-				P.nutrition += 1.5
-
-			if(check_eyes(P))
-				change_eyes(P,1)
-				continue
-
-			if(check_hair(P) || check_skin(P))
-				change_hair(P)
-				change_skin(P,1)
-
-///////////////////////////// DM_TRANSFORM_CHANGE_SPECIES_AND_TAUR  /////////////////////////////
-	else if(digest_mode == DM_TRANSFORM_CHANGE_SPECIES_AND_TAUR && ishuman(owner))
-		for (var/mob/living/carbon/human/P in contents)
-			if(P.stat == DEAD)
-				continue
-
-			var/mob/living/carbon/human/O = owner
-
-			if(O.nutrition > 400 && P.nutrition < 400)
-				O.nutrition -= 2
-				P.nutrition += 1.5
-
-			if(check_ears(P) || check_tail_nocolor(P) || check_wing_nocolor(P) || check_species(P))
-				change_ears(P)
-				change_tail_nocolor(P)
-				change_wing_nocolor(P)
-				change_species(P,1)
-
-///////////////////////////// DM_TRANSFORM_REPLICA /////////////////////////////
-	else if(digest_mode == DM_TRANSFORM_REPLICA && ishuman(owner))
-		for (var/mob/living/carbon/human/P in contents)
-			if(P.stat == DEAD)
-				continue
-
-			var/mob/living/carbon/human/O = owner
-
-			if(O.nutrition > 400 && P.nutrition < 400)
-				O.nutrition -= 2
-				P.nutrition += 1.5
-
-			if(check_eyes(P))
-				change_eyes(P,1)
-				continue
-
-			if(check_hair(P) || check_skin(P))
-				change_hair(P)
-				change_skin(P,1)
-				continue
-
-			if(check_ears(P) || check_tail(P) || check_wing(P) || check_species(P))
-				change_ears(P)
-				change_tail(P)
-				change_wing(P)
-				change_species(P,1)
-
-///////////////////////////// DM_TRANSFORM_CHANGE_SPECIES_AND_TAUR_EGG /////////////////////////////
-	else if(digest_mode == DM_TRANSFORM_CHANGE_SPECIES_AND_TAUR_EGG && ishuman(owner))
-		for (var/mob/living/carbon/human/P in contents)
-			if(P.stat == DEAD)
-				continue
-
-			if(check_ears(P) || check_tail_nocolor(P) || check_wing_nocolor(P)|| check_species(P))
-				change_ears(P)
-				change_tail_nocolor(P)
-				change_wing_nocolor(P)
-				change_species(P,1)
-				continue
-
-			if(!P.absorbed)
-				put_in_egg(P,1)
-
-///////////////////////////// DM_TRANSFORM_KEEP_GENDER_EGG  /////////////////////////////
-	else if(digest_mode == DM_TRANSFORM_KEEP_GENDER_EGG && ishuman(owner))
-		for (var/mob/living/carbon/human/P in contents)
-			if(P.stat == DEAD)
-				continue
-
-			if(check_eyes(P))
-				change_eyes(P,1)
-				continue
-
-			if(check_hair(P) || check_skin(P))
-				change_hair(P)
-				change_skin(P,1)
-				continue
-
-			if(!P.absorbed)
-				put_in_egg(P,1)
-
-///////////////////////////// DM_TRANSFORM_REPLICA_EGG /////////////////////////////
-	else if(digest_mode == DM_TRANSFORM_REPLICA_EGG && ishuman(owner))
-		for (var/mob/living/carbon/human/P in contents)
-			if(P.stat == DEAD)
-				continue
-
-			if(check_eyes(P))
-				change_eyes(P,1)
-				continue
-
-			if(check_hair(P) || check_skin(P))
-				change_hair(P)
-				change_skin(P,1)
-				continue
-
-			if(check_ears(P) || check_tail(P) || check_wing(P) || check_species(P))
-				change_ears(P)
-				change_tail(P)
-				change_wing(P)
-				change_species(P,1)
-				continue
-
-			if(!P.absorbed)
-				put_in_egg(P,1)
-
-///////////////////////////// DM_TRANSFORM_MALE_EGG /////////////////////////////
-	else if(digest_mode == DM_TRANSFORM_MALE_EGG && ishuman(owner))
-		for (var/mob/living/carbon/human/P in contents)
-			if(P.stat == DEAD)
-				continue
-
-			if(check_eyes(P))
-				change_eyes(P,1)
-				continue
-
-			if(check_hair(P) || check_skin(P))
-				change_hair(P)
-				change_skin(P,1)
-				continue
-
-			if(check_gender(P,MALE))
-				change_gender(P,MALE,1)
-				continue
-
-			if(!P.absorbed)
-				put_in_egg(P,1)
-
-///////////////////////////// DM_TRANSFORM_FEMALE_EGG /////////////////////////////
-	else if(digest_mode == DM_TRANSFORM_FEMALE_EGG && ishuman(owner))
-		for (var/mob/living/carbon/human/P in contents)
-			if(P.stat == DEAD)
-				continue
-
-			if(check_eyes(P))
-				change_eyes(P,1)
-				continue
-
-			if(check_hair(P) || check_skin(P))
-				change_hair(P)
-				change_skin(P,1)
-				continue
-
-			if(check_gender(P,MALE))
-				change_gender(P,MALE,1)
-				continue
-
-			if(!P.absorbed)
-				put_in_egg(P,1)
-
-///////////////////////////// DM_EGG /////////////////////////////
-	else if(digest_mode == DM_EGG && ishuman(owner))
-		for (var/mob/living/carbon/human/P in contents)
-			if(P.absorbed || P.stat == DEAD)
-				continue
-
-			put_in_egg(P,1)
-
+/////////////////////////// Make any noise ///////////////////////////
 	if(play_sound)
 		playsound(src, play_sound, vol = 100, vary = 1, falloff = VORE_SOUND_FALLOFF, ignore_walls = TRUE, preference = /datum/client_preference/digestion_noises)
 	return SSBELLIES_PROCESSED

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -2716,6 +2716,7 @@
 #include "code\modules\vore\appearance\update_icons_vr.dm"
 #include "code\modules\vore\eating\belly_dat_vr.dm"
 #include "code\modules\vore\eating\belly_obj_vr.dm"
+#include "code\modules\vore\eating\bellymodes_tf_vr.dm"
 #include "code\modules\vore\eating\bellymodes_vr.dm"
 #include "code\modules\vore\eating\contaminate_vr.dm"
 #include "code\modules\vore\eating\digest_act_vr.dm"


### PR DESCRIPTION
Removes several 'hybrid' digestion modes, like 'digest itemweak' and 'strip digest' and 'numbing digest' and instead just adds toggles for these features to be applied to any mode.
* Stripping: Strips items off one at a time, and digests them one at a time unless itemweak is on.
* Itemweak: Does not digest items, and instead just leaves them slimy.
* Numbing: Numbs prey to pain (or just for RP purposes).

**These DO save, unlike the main belly mode setting, so make sure to save them once you've got them set how you prefer.**

**An important thing to add, for 'reasons', all modes now 'deal with' items in your belly. Even 'Hold' will digest items, unless you have 'Itemweak' turned on.**

You can apply the above in any combination with any other mode.

For example:
![image](https://user-images.githubusercontent.com/15028025/38648200-f71ba008-3dbd-11e8-9b33-69aeaf98f401.png)

Will drain nutrients from the prey, numb them, strip them of their clothes, and not digest the clothes.

If you want to recreate the three removed modes, that's simply the 'Digest' mode, with only one of the modes turned on.

Also, all the transformation settings were moved to a separate menu. One of the digest modes simply says 'Transform'. Picking that presents a separate menu of transform modes that you can select.

Also also, increased the default size of the Vore Panel window, to accommodate how it's grown over the years (+50px to width, +100px to height).

Also also also, increased the efficiency of processing bellies by a little by reworking how things are done and in what order.