### PR TITLE
Makes donuts less of a strain on resources.

### DIFF
--- a/code/modules/food/recipes_microwave_vr.dm
+++ b/code/modules/food/recipes_microwave_vr.dm
@@ -9,6 +9,22 @@
 	result = /obj/item/weapon/reagent_containers/food/snacks/path_to_some_food
 */
 
+/datum/recipe/jellydonut
+	items = list(
+		/obj/item/weapon/reagent_containers/food/snacks/doughslice
+
+/datum/recipe/jellydonut/slime
+	items = list(
+		/obj/item/weapon/reagent_containers/food/snacks/doughslice
+
+/datum/recipe/jellydonut/cherry
+	items = list(
+		/obj/item/weapon/reagent_containers/food/snacks/doughslice
+
+/datum/recipe/donut
+	items = list(
+		/obj/item/weapon/reagent_containers/food/snacks/doughslice
+
 /datum/recipe/sushi
 	fruit = list("cabbage" = 1)
 	reagents = list("rice" = 20)

--- a/code/modules/food/recipes_microwave_vr.dm
+++ b/code/modules/food/recipes_microwave_vr.dm
@@ -11,19 +11,19 @@
 
 /datum/recipe/jellydonut
 	items = list(
-		/obj/item/weapon/reagent_containers/food/snacks/doughslice
+		/obj/item/weapon/reagent_containers/food/snacks/doughslice)
 
 /datum/recipe/jellydonut/slime
 	items = list(
-		/obj/item/weapon/reagent_containers/food/snacks/doughslice
+		/obj/item/weapon/reagent_containers/food/snacks/doughslice)
 
 /datum/recipe/jellydonut/cherry
 	items = list(
-		/obj/item/weapon/reagent_containers/food/snacks/doughslice
+		/obj/item/weapon/reagent_containers/food/snacks/doughslice)
 
 /datum/recipe/donut
 	items = list(
-		/obj/item/weapon/reagent_containers/food/snacks/doughslice
+		/obj/item/weapon/reagent_containers/food/snacks/doughslice)
 
 /datum/recipe/sushi
 	fruit = list("cabbage" = 1)


### PR DESCRIPTION
considering you can put 6 donuts in a box, and they're supposed to be a small food item... this overrides all the donuts to use dough slices instead of a full wad of dough. 

Literally, who would realistically use two boxes of flour, six eggs, and whatnot to make one batch of donuts? I know virgo isn't meant to be realistic, but at least now a chef doesn't have to feel bad when someone asks for a box of  these things.