### PR TITLE
Adds public garden+juice bar, updates mapmerge2

### DIFF
--- a/maps/tether/tether-01-surface1.dmm
+++ b/maps/tether/tether-01-surface1.dmm
@@ -150,7 +150,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 10;
-	icon_state = "intact"
+	icon_state = "intact";
+	tag = "icon-intact-f (NORTHWEST)"
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/mining_main/airlock)
@@ -362,7 +363,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 5;
-	icon_state = "intact"
+	icon_state = "intact";
+	tag = "icon-intact-f (NORTHWEST)"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 4;
@@ -1496,7 +1498,8 @@
 "adl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 10;
-	icon_state = "intact"
+	icon_state = "intact";
+	tag = "icon-intact-f (NORTHWEST)"
 	},
 /obj/machinery/floodlight,
 /turf/simulated/floor/plating,
@@ -1504,7 +1507,8 @@
 "adm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 6;
-	icon_state = "intact"
+	icon_state = "intact";
+	tag = "icon-intact-f (SOUTHEAST)"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/alarm{
@@ -3329,6 +3333,12 @@
 /obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 4
 	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey/bordercorner2{
+	dir = 1
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/lower/first_west)
 "ahN" = (
@@ -3344,22 +3354,6 @@
 	},
 /obj/machinery/station_map{
 	pixel_y = 32
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/lower/first_west)
-"ahP" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 30
-	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 1
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7,
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/lower/first_west)
@@ -3880,7 +3874,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 9;
-	icon_state = "intact"
+	icon_state = "intact";
+	tag = "icon-intact-f (NORTHWEST)"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -5871,7 +5866,8 @@
 /obj/structure/extinguisher_cabinet{
 	dir = 8;
 	icon_state = "extinguisher_closed";
-	pixel_x = 30
+	pixel_x = 30;
+	tag = "icon-extinguisher_closed (WEST)"
 	},
 /obj/effect/floor_decal/borderfloor/corner2{
 	dir = 5
@@ -8586,7 +8582,8 @@
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 10;
-	icon_state = "intact"
+	icon_state = "intact";
+	tag = "icon-intact-f (NORTHWEST)"
 	},
 /obj/machinery/alarm{
 	dir = 8;
@@ -8691,25 +8688,6 @@
 /obj/machinery/alarm{
 	pixel_y = 22;
 	target_temperature = 293.15
-	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 1
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7,
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/lower/first_west)
-"avO" = (
-/obj/machinery/firealarm{
-	dir = 2;
-	layer = 3.3;
-	pixel_x = 0;
-	pixel_y = 26
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -9034,7 +9012,8 @@
 "awy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 9;
-	icon_state = "intact"
+	icon_state = "intact";
+	tag = "icon-intact-f (NORTHWEST)"
 	},
 /obj/machinery/floodlight,
 /turf/simulated/floor/plating,
@@ -9266,6 +9245,17 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/lower/first_west)
 "awX" = (
@@ -9322,6 +9312,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/lower/first_west)
 "axc" = (
@@ -9379,6 +9372,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/lower/first_west)
 "axl" = (
@@ -9459,6 +9455,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/lower/first_west)
 "axt" = (
@@ -9468,9 +9467,9 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
+/obj/structure/disposalpipe/junction{
+	icon_state = "pipe-j2";
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/lower/first_west)
@@ -9491,7 +9490,8 @@
 /obj/machinery/computer/guestpass{
 	dir = 2;
 	icon_state = "guest";
-	pixel_y = 28
+	pixel_y = 28;
+	tag = "icon-guest (NORTH)"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -10372,18 +10372,14 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/atrium_one)
 "aza" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/effect/floor_decal/steeldecal/steel_decals6,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/hallway/lower/first_west)
 "azb" = (
@@ -10817,7 +10813,8 @@
 	},
 /obj/machinery/camera/network/northern_star{
 	dir = 8;
-	icon_state = "camera"
+	icon_state = "camera";
+	tag = "icon-camera (NORTHWEST)"
 	},
 /obj/effect/floor_decal/corner/lightgrey/border{
 	dir = 4
@@ -10888,7 +10885,8 @@
 /obj/structure/extinguisher_cabinet{
 	dir = 1;
 	icon_state = "extinguisher_closed";
-	pixel_y = -32
+	pixel_y = -32;
+	tag = "icon-extinguisher_closed (NORTH)"
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/north_stairs_one)
@@ -11640,22 +11638,26 @@
 /obj/structure/sign/directions/medical{
 	dir = 1;
 	icon_state = "direction_med";
-	pixel_y = 8
+	pixel_y = 8;
+	tag = "icon-direction_med (EAST)"
 	},
 /obj/structure/sign/directions/science{
 	dir = 1;
 	icon_state = "direction_sci";
-	pixel_y = 3
+	pixel_y = 3;
+	tag = "icon-direction_sci (WEST)"
 	},
 /obj/structure/sign/directions/security{
 	dir = 1;
 	icon_state = "direction_sec";
-	pixel_y = -4
+	pixel_y = -4;
+	tag = "icon-direction_sec (WEST)"
 	},
 /obj/structure/sign/directions/engineering{
 	dir = 1;
 	icon_state = "direction_eng";
-	pixel_y = -10
+	pixel_y = -10;
+	tag = "icon-direction_eng (WEST)"
 	},
 /turf/simulated/wall,
 /area/tether/surfacebase/north_stairs_one)
@@ -11847,7 +11849,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 5;
-	icon_state = "intact"
+	icon_state = "intact";
+	tag = "icon-intact-f (NORTHEAST)"
 	},
 /turf/simulated/floor/tiled,
 /area/storage/surface_eva/external)
@@ -11926,7 +11929,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 9;
-	icon_state = "intact"
+	icon_state = "intact";
+	tag = "icon-intact-f (NORTHWEST)"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -13409,7 +13413,8 @@
 	},
 /obj/machinery/camera/network/northern_star{
 	dir = 8;
-	icon_state = "camera"
+	icon_state = "camera";
+	tag = "icon-camera (NORTHWEST)"
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -13931,8 +13936,7 @@
 /area/rnd/external)
 "aHg" = (
 /obj/machinery/camera/network/research{
-	dir = 4;
-	
+	dir = 4
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -14026,8 +14030,7 @@
 /area/rnd/anomaly_lab/containment_one)
 "aHt" = (
 /obj/machinery/camera/network/research{
-	dir = 4;
-	
+	dir = 4
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -15315,7 +15318,8 @@
 /obj/structure/extinguisher_cabinet{
 	dir = 4;
 	icon_state = "extinguisher_closed";
-	pixel_x = -30
+	pixel_x = -30;
+	tag = "icon-extinguisher_closed (EAST)"
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -15577,6 +15581,7 @@
 "aOF" = (
 /obj/effect/floor_decal/industrial/outline,
 /turf/simulated/floor/tiled{
+	tag = "icon-techmaint";
 	icon_state = "techmaint"
 	},
 /area/security/checkpoint)
@@ -15792,15 +15797,22 @@
 	dir = 6
 	},
 /turf/simulated/floor/tiled{
+	tag = "icon-monotile";
 	icon_state = "monotile"
 	},
 /area/security/checkpoint)
 "aQM" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled{
+	tag = "icon-techmaint";
 	icon_state = "techmaint"
 	},
 /area/security/checkpoint)
+"aRs" = (
+/obj/structure/catwalk,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/maintenance/lower/public_garden_maintenence)
 "aRH" = (
 /obj/structure/bed/chair,
 /obj/machinery/firealarm{
@@ -15968,7 +15980,8 @@
 	dir = 8;
 	icon_state = "phoron_map";
 	name = "Xenoflora Waste Buffer";
-	start_pressure = 0
+	start_pressure = 0;
+	tag = "icon-phoron_map (WEST)"
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/xenoflora)
@@ -15990,7 +16003,8 @@
 /obj/structure/extinguisher_cabinet{
 	dir = 4;
 	icon_state = "extinguisher_closed";
-	pixel_x = -30
+	pixel_x = -30;
+	tag = "icon-extinguisher_closed (EAST)"
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/atrium_one)
@@ -16051,7 +16065,8 @@
 /obj/structure/extinguisher_cabinet{
 	dir = 4;
 	icon_state = "extinguisher_closed";
-	pixel_x = -30
+	pixel_x = -30;
+	tag = "icon-extinguisher_closed (EAST)"
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/atrium_one)
@@ -16281,7 +16296,8 @@
 	},
 /obj/machinery/camera/network/northern_star{
 	dir = 8;
-	icon_state = "camera"
+	icon_state = "camera";
+	tag = "icon-camera (NORTHWEST)"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/lower/first_west)
@@ -16373,6 +16389,15 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/xenoflora)
+"aVT" = (
+/obj/effect/floor_decal/rust,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate,
+/obj/random/maintenance/research,
+/obj/random/maintenance/research,
+/obj/random/drinkbottle,
+/turf/simulated/floor/plating,
+/area/maintenance/lower/public_garden_maintenence)
 "aWe" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -16408,7 +16433,8 @@
 /obj/structure/extinguisher_cabinet{
 	dir = 4;
 	icon_state = "extinguisher_closed";
-	pixel_x = -30
+	pixel_x = -30;
+	tag = "icon-extinguisher_closed (EAST)"
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/tram)
@@ -16699,9 +16725,19 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled{
+	tag = "icon-monotile";
 	icon_state = "monotile"
 	},
 /area/security/checkpoint)
+"aYz" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden)
 "aYA" = (
 /obj/structure/sign/directions/evac{
 	dir = 4
@@ -16959,6 +16995,20 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/atrium_one)
+"baY" = (
+/obj/structure/table/woodentable,
+/obj/item/device/radio/intercom{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden)
 "baZ" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -17793,6 +17843,15 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/atrium_one)
+"bfg" = (
+/obj/structure/catwalk,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/maintenance/common,
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/public_garden)
 "bfn" = (
 /obj/structure/table/standard,
 /obj/item/weapon/storage/toolbox/mechanical{
@@ -19041,7 +19100,8 @@
 /obj/structure/extinguisher_cabinet{
 	dir = 8;
 	icon_state = "extinguisher_closed";
-	pixel_x = 30
+	pixel_x = 30;
+	tag = "icon-extinguisher_closed (WEST)"
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 6
@@ -19061,7 +19121,8 @@
 /obj/effect/floor_decal/borderfloor/corner2{
 	dir = 10;
 	icon_state = "borderfloorcorner2";
-	pixel_x = 0
+	pixel_x = 0;
+	tag = "icon-borderfloorcorner2 (SOUTHWEST)"
 	},
 /obj/effect/floor_decal/corner/lightgrey/bordercorner2{
 	dir = 10
@@ -19370,7 +19431,8 @@
 /obj/structure/extinguisher_cabinet{
 	dir = 4;
 	icon_state = "extinguisher_closed";
-	pixel_x = -30
+	pixel_x = -30;
+	tag = "icon-extinguisher_closed (EAST)"
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/tram)
@@ -19674,6 +19736,26 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/locker_room)
+"bri" = (
+/obj/effect/floor_decal/corner/lightgrey{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/lightgrey{
+	dir = 6
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals9,
+/obj/effect/floor_decal/steeldecal/steel_decals9{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals9{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals9{
+	dir = 8
+	},
+/obj/machinery/vending/coffee,
+/turf/simulated/floor/tiled/monotile,
+/area/tether/surfacebase/public_garden)
 "brk" = (
 /obj/effect/floor_decal/steeldecal/steel_decals6{
 	dir = 6
@@ -19951,6 +20033,9 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/locker_room)
+"bsU" = (
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/lower/public_garden_maintenence)
 "btk" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -19985,6 +20070,24 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/atrium_one)
+"btx" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 4
+	},
+/obj/machinery/camera/network/civilian{
+	dir = 9
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden)
 "btD" = (
 /obj/effect/floor_decal/steeldecal/steel_decals6{
 	dir = 5
@@ -20086,6 +20189,11 @@
 /obj/structure/flora/pottedplant,
 /turf/simulated/floor/grass,
 /area/tether/surfacebase/atrium_one)
+"bui" = (
+/obj/effect/floor_decal/rust,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/maintenance/lower/public_garden_maintenence)
 "buj" = (
 /obj/structure/table/marble,
 /obj/item/weapon/reagent_containers/food/drinks/glass2/square{
@@ -20949,7 +21057,8 @@
 /area/tether/surfacebase/outside/outside1)
 "bys" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "1-8"
+	icon_state = "1-8";
+	tag = "icon-1-4"
 	},
 /obj/structure/railing,
 /obj/structure/railing{
@@ -21048,7 +21157,8 @@
 /obj/machinery/computer/guestpass{
 	dir = 1;
 	icon_state = "guest";
-	pixel_y = -28
+	pixel_y = -28;
+	tag = "icon-guest (NORTH)"
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 1
@@ -21471,7 +21581,8 @@
 "bEn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 10;
-	icon_state = "intact"
+	icon_state = "intact";
+	tag = "icon-intact-f (NORTHWEST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
@@ -21816,7 +21927,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 10;
-	icon_state = "intact"
+	icon_state = "intact";
+	tag = "icon-intact-f (SOUTHWEST)"
 	},
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/plating,
@@ -22051,6 +22163,15 @@
 	},
 /turf/simulated/floor/tiled/steel_dirty,
 /area/rnd/xenobiology/xenoflora_storage)
+"bKM" = (
+/obj/structure/catwalk,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/lower/public_garden_maintenence)
 "bLV" = (
 /obj/effect/floor_decal/steeldecal/steel_decals6{
 	dir = 8
@@ -22466,7 +22587,8 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 8;
-	icon_state = "map"
+	icon_state = "map";
+	tag = "icon-manifold-f (WEST)"
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/external)
@@ -22715,7 +22837,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 5;
-	icon_state = "intact"
+	icon_state = "intact";
+	tag = "icon-intact-f (NORTHEAST)"
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/external)
@@ -23259,6 +23382,12 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/outpost/research/xenobiology)
+"bTl" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden_one)
 "bTD" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
@@ -23541,6 +23670,7 @@
 /area/crew_quarters/sleep/Dorm_6)
 "bVx" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
+	tag = "icon-intact (SOUTHEAST)";
 	icon_state = "intact";
 	dir = 6
 	},
@@ -23915,6 +24045,7 @@
 /obj/machinery/atmospherics/unary/outlet_injector{
 	dir = 4;
 	icon_state = "map_injector";
+	tag = "icon-map_injector (EAST)";
 	use_power = 1;
 	volume_rate = 700
 	},
@@ -23952,7 +24083,8 @@
 	},
 /obj/machinery/atmospherics/valve/digital/open{
 	dir = 4;
-	icon_state = "map_valve1"
+	icon_state = "map_valve1";
+	tag = "icon-map_valve1 (WEST)"
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/engineering/atmos/processing)
@@ -23970,6 +24102,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/black{
+	tag = "icon-intact (SOUTHEAST)";
 	icon_state = "intact";
 	dir = 6
 	},
@@ -24028,7 +24161,8 @@
 /obj/machinery/atmospherics/pipe/zpipe/up{
 	dir = 4;
 	icon_state = "up";
-	level = 2
+	level = 2;
+	tag = "icon-up (EAST)"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/atmos/processing)
@@ -24150,7 +24284,8 @@
 /obj/structure/extinguisher_cabinet{
 	dir = 4;
 	icon_state = "extinguisher_closed";
-	pixel_x = -30
+	pixel_x = -30;
+	tag = "icon-extinguisher_closed (EAST)"
 	},
 /obj/machinery/atmospherics/portables_connector,
 /turf/simulated/floor/tiled/techfloor,
@@ -24253,6 +24388,7 @@
 /area/crew_quarters/sleep/Dorm_4)
 "bZc" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
+	tag = "icon-intact (NORTHEAST)";
 	icon_state = "intact";
 	dir = 5
 	},
@@ -24280,6 +24416,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/visible/red{
+	tag = "icon-map (NORTH)";
 	icon_state = "map";
 	dir = 1
 	},
@@ -24305,6 +24442,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/blue{
+	tag = "icon-intact (NORTHWEST)";
 	icon_state = "intact";
 	dir = 9
 	},
@@ -24461,6 +24599,7 @@
 /area/crew_quarters/sleep/Dorm_4)
 "cae" = (
 /obj/machinery/atmospherics/pipe/cap/visible{
+	tag = "icon-cap (WEST)";
 	icon_state = "cap";
 	dir = 8
 	},
@@ -24526,6 +24665,7 @@
 "caH" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/manifold/visible/black{
+	tag = "icon-map (EAST)";
 	icon_state = "map";
 	dir = 4
 	},
@@ -24556,7 +24696,8 @@
 /obj/structure/extinguisher_cabinet{
 	dir = 8;
 	icon_state = "extinguisher_closed";
-	pixel_x = 30
+	pixel_x = 30;
+	tag = "icon-extinguisher_closed (WEST)"
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/engineering/atmos/processing)
@@ -24711,6 +24852,7 @@
 /area/engineering/atmos/processing)
 "cbE" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/black{
+	tag = "icon-map (EAST)";
 	icon_state = "map";
 	dir = 4
 	},
@@ -24850,6 +24992,7 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/cap/visible{
+	tag = "icon-cap (WEST)";
 	icon_state = "cap";
 	dir = 8
 	},
@@ -25027,6 +25170,7 @@
 /area/crew_quarters/sleep/Dorm_2)
 "cdf" = (
 /obj/machinery/door/airlock/multi_tile/metal/mait{
+	tag = "icon-door_closed";
 	name = "Atmospherics Maintenance";
 	icon_state = "door_closed";
 	dir = 2;
@@ -25037,6 +25181,7 @@
 /area/engineering/atmos/intake)
 "cdh" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
+	tag = "icon-map_scrubber_off (EAST)";
 	icon_state = "map_scrubber_off";
 	dir = 4
 	},
@@ -25044,6 +25189,7 @@
 /area/engineering/atmos/intake)
 "cdk" = (
 /obj/machinery/atmospherics/binary/pump/high_power/on{
+	tag = "icon-map_on (NORTH)";
 	icon_state = "map_on";
 	dir = 1
 	},
@@ -25097,6 +25243,7 @@
 /area/outpost/research/xenobiology)
 "cdu" = (
 /obj/machinery/atmospherics/binary/pump/high_power/on{
+	tag = "icon-map_on (NORTH)";
 	icon_state = "map_on";
 	dir = 1
 	},
@@ -25250,7 +25397,8 @@
 /obj/machinery/atmospherics/binary/pump/high_power/on{
 	dir = 4;
 	icon_state = "map_on";
-	name = "Waste to Filtering"
+	name = "Waste to Filtering";
+	tag = "icon-map_on (EAST)"
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/engineering/atmos/processing)
@@ -25285,6 +25433,7 @@
 	pixel_y = -25
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/black{
+	tag = "icon-intact (NORTHWEST)";
 	icon_state = "intact";
 	dir = 9
 	},
@@ -25358,7 +25507,8 @@
 /obj/effect/floor_decal/borderfloor{
 	dir = 1;
 	icon_state = "borderfloor";
-	pixel_y = 0
+	pixel_y = 0;
+	tag = "icon-borderfloor (NORTH)"
 	},
 /obj/effect/floor_decal/corner/grey/border{
 	icon_state = "bordercolor";
@@ -25371,7 +25521,8 @@
 /obj/effect/floor_decal/borderfloor{
 	dir = 1;
 	icon_state = "borderfloor";
-	pixel_y = 0
+	pixel_y = 0;
+	tag = "icon-borderfloor (NORTH)"
 	},
 /obj/effect/floor_decal/corner/grey/border{
 	icon_state = "bordercolor";
@@ -25384,7 +25535,8 @@
 /obj/effect/floor_decal/borderfloor{
 	dir = 1;
 	icon_state = "borderfloor";
-	pixel_y = 0
+	pixel_y = 0;
+	tag = "icon-borderfloor (NORTH)"
 	},
 /obj/effect/floor_decal/corner/grey/border{
 	icon_state = "bordercolor";
@@ -25397,7 +25549,8 @@
 /obj/effect/floor_decal/borderfloor{
 	dir = 1;
 	icon_state = "borderfloor";
-	pixel_y = 0
+	pixel_y = 0;
+	tag = "icon-borderfloor (NORTH)"
 	},
 /obj/effect/floor_decal/corner/grey/border{
 	icon_state = "bordercolor";
@@ -25410,7 +25563,8 @@
 /obj/effect/floor_decal/borderfloor{
 	dir = 1;
 	icon_state = "borderfloor";
-	pixel_y = 0
+	pixel_y = 0;
+	tag = "icon-borderfloor (NORTH)"
 	},
 /obj/effect/floor_decal/corner/grey/border{
 	icon_state = "bordercolor";
@@ -25423,7 +25577,8 @@
 /obj/effect/floor_decal/borderfloor{
 	dir = 1;
 	icon_state = "borderfloor";
-	pixel_y = 0
+	pixel_y = 0;
+	tag = "icon-borderfloor (NORTH)"
 	},
 /obj/effect/floor_decal/corner/grey/border{
 	icon_state = "bordercolor";
@@ -27194,6 +27349,823 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/atrium_one)
+"cBB" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden)
+"cHS" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 9
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden_one)
+"dbc" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/maintenance/lower/public_garden_maintenence)
+"deS" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/lower/public_garden_maintenence)
+"dAk" = (
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/lightgrey/bordercorner{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden_one)
+"dLl" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 10
+	},
+/obj/machinery/camera/network/civilian{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden_one)
+"dOn" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/lightgrey/border,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden_one)
+"dSz" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 9
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/tether/surfacebase/public_garden_one)
+"dYj" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/multi_tile/glass{
+	dir = 1;
+	name = "Public Gardens"
+	},
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals_central1,
+/turf/simulated/floor/tiled/monofloor,
+/area/tether/surfacebase/public_garden_one)
+"dYl" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/borderfloor/corner,
+/obj/effect/floor_decal/corner/lightgrey/bordercorner,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden)
+"egX" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 1;
+	icon_state = "borderfloor";
+	pixel_y = 0;
+	tag = "icon-borderfloor (NORTH)"
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden)
+"ePE" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 2;
+	layer = 3.3;
+	pixel_x = 0;
+	pixel_y = 26
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/lower/first_west)
+"eVp" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/lower/first_west)
+"fbF" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/alarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden)
+"frE" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 6
+	},
+/obj/machinery/light,
+/turf/simulated/floor/tiled/techfloor,
+/area/tether/surfacebase/public_garden_one)
+"ftb" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 10
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden_one)
+"fEQ" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1;
+	icon_state = "borderfloor";
+	pixel_y = 0;
+	tag = "icon-borderfloor (NORTH)"
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden_one)
+"fWK" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/tether/surfacebase/public_garden)
+"gaK" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/lower/public_garden_maintenence)
+"gri" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 10
+	},
+/obj/machinery/light,
+/turf/simulated/floor/tiled/techfloor,
+/area/tether/surfacebase/public_garden_one)
+"gwL" = (
+/obj/structure/window/reinforced{
+	dir = 4;
+	health = 1e+006
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden_one)
+"gwS" = (
+/obj/structure/cable,
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 28
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 6
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden_one)
+"gxP" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/lower/public_garden_maintenence)
+"gDo" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/tether/surfacebase/public_garden)
+"gPz" = (
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden_one)
+"gUy" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/lower/public_garden_maintenence)
+"gUX" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/lower/public_garden_maintenence)
+"gXh" = (
+/turf/simulated/wall,
+/area/tether/surfacebase/public_garden)
+"hbn" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 5
+	},
+/obj/machinery/computer/timeclock/premade/north,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden_one)
+"hcP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/junk,
+/turf/simulated/floor/plating,
+/area/maintenance/lower/public_garden_maintenence)
+"hqU" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/steeldecal/steel_decals_central1{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/monofloor{
+	dir = 4
+	},
+/area/hallway/lower/first_west)
+"hvW" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 8
+	},
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden)
+"idw" = (
+/obj/effect/floor_decal/techfloor/corner{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/tether/surfacebase/public_garden_one)
+"igB" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 5
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/tether/surfacebase/public_garden_one)
+"ijX" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/rack,
+/obj/random/maintenance/research,
+/obj/random/maintenance/research,
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/lower/public_garden_maintenence)
+"izr" = (
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/lightgrey/bordercorner{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden_one)
+"iPi" = (
+/obj/effect/floor_decal/techfloor/corner{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/tether/surfacebase/public_garden_one)
+"iVY" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden)
+"jec" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/lightgrey/bordercorner{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden_one)
+"jrI" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey/bordercorner2{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden_one)
+"kcR" = (
+/obj/structure/window/reinforced,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden_one)
+"kuC" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 5
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden)
+"kOB" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden_one)
+"kZc" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc{
+	cell_type = /obj/item/weapon/cell/super;
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/lower/public_garden_maintenence)
+"lFg" = (
+/obj/structure/grille,
+/obj/structure/railing,
+/turf/simulated/floor/tiled/techmaint,
+/area/tether/surfacebase/public_garden_one)
+"lJJ" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1;
+	icon_state = "borderfloor";
+	pixel_y = 0;
+	tag = "icon-borderfloor (NORTH)"
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden)
+"lNY" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/lightgrey/border,
+/obj/effect/floor_decal/borderfloor/corner2,
+/obj/effect/floor_decal/corner/lightgrey/bordercorner2,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden)
+"lUv" = (
+/obj/machinery/alarm{
+	pixel_y = 23
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 9
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden_one)
+"lWW" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled,
+/area/hallway/lower/first_west)
+"mpN" = (
+/obj/random/junk,
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/lower/public_garden_maintenence)
+"mpQ" = (
+/turf/simulated/wall,
+/area/tether/surfacebase/public_garden_one)
+"mtw" = (
+/obj/effect/floor_decal/techfloor/corner{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/tether/surfacebase/public_garden_one)
+"mUG" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden)
+"mXP" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden_one)
+"ncL" = (
+/obj/machinery/door/airlock/multi_tile/glass{
+	name = "Public Gardens"
+	},
+/obj/machinery/door/firedoor/glass,
+/obj/effect/floor_decal/steeldecal/steel_decals_central1{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/monofloor{
+	dir = 8
+	},
+/area/hallway/lower/first_west)
+"nxt" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/firecloset,
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/lower/public_garden_maintenence)
+"nCB" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/lightgrey/bordercorner2{
+	dir = 5
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden)
+"nJE" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/lightgrey/bordercorner{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden)
+"nMZ" = (
+/obj/structure/window/reinforced{
+	dir = 8;
+	health = 1e+006
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden_one)
+"ora" = (
+/obj/effect/floor_decal/techfloor/corner,
+/turf/simulated/floor/tiled/techfloor,
+/area/tether/surfacebase/public_garden_one)
+"ozv" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloor/corner,
+/obj/effect/floor_decal/corner/lightgrey/bordercorner,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden_one)
+"oAC" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/random/junk,
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/lower/public_garden_maintenence)
+"oOc" = (
+/obj/structure/bed/chair/wood,
+/obj/effect/floor_decal/borderfloor{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 5
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden)
+"piN" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/lightgrey/bordercorner{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden_one)
+"pjP" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 5
+	},
+/obj/effect/floor_decal/industrial/danger{
+	dir = 1
+	},
+/obj/effect/floor_decal/techfloor/hole,
+/turf/simulated/floor/tiled/techfloor,
+/area/tether/surfacebase/public_garden_one)
+"pxT" = (
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/maintenance/lower/public_garden_maintenence)
+"pCg" = (
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/public_garden_one)
+"qpB" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 8
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden)
+"qyw" = (
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc{
+	cell_type = /obj/item/weapon/cell/super;
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden)
+"qGm" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/lightgrey/bordercorner{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden)
+"qHo" = (
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 6
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden_one)
+"qMQ" = (
+/obj/effect/floor_decal/rust,
+/obj/random/junk,
+/turf/simulated/floor/plating,
+/area/maintenance/lower/public_garden_maintenence)
+"ram" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 5
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 30
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden_one)
+"rfg" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/lightgrey/border,
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/lightgrey/bordercorner2{
+	dir = 9
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden_one)
+"riT" = (
+/obj/machinery/door/airlock/maintenance/common,
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden_one)
+"rKM" = (
+/obj/structure/stairs/north,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden_one)
+"slR" = (
+/obj/machinery/portable_atmospherics/powered/scrubber/huge/stationary{
+	scrub_id = "atrium"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/tether/surfacebase/public_garden_one)
+"sCz" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/lightgrey/bordercorner2{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/lower/first_west)
+"sJs" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1;
+	icon_state = "borderfloor";
+	pixel_y = 0;
+	tag = "icon-borderfloor (NORTH)"
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/lightgrey/bordercorner2{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden)
 "sRi" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -27206,6 +28178,257 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/atrium_one)
+"tbZ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/lightgrey/border,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 1
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 1;
+	icon_state = "extinguisher_closed";
+	pixel_y = -32;
+	tag = "icon-extinguisher_closed (NORTH)"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/lower/first_west)
+"tzX" = (
+/obj/structure/grille,
+/turf/simulated/floor/tiled/techmaint,
+/area/tether/surfacebase/public_garden_one)
+"tLH" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 10
+	},
+/obj/effect/floor_decal/techfloor/hole{
+	dir = 1
+	},
+/obj/structure/closet/crate,
+/turf/simulated/floor/tiled/techfloor,
+/area/tether/surfacebase/public_garden_one)
+"tPq" = (
+/obj/structure/bed/chair/wood{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 6
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden)
+"tXm" = (
+/obj/effect/floor_decal/corner/lightgrey{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/lightgrey{
+	dir = 6
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals9,
+/obj/effect/floor_decal/steeldecal/steel_decals9{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals9{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals9{
+	dir = 8
+	},
+/obj/machinery/vending/snack,
+/turf/simulated/floor/tiled/monotile,
+/area/tether/surfacebase/public_garden)
+"tXv" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 9
+	},
+/obj/effect/floor_decal/industrial/danger{
+	dir = 1
+	},
+/obj/effect/floor_decal/techfloor/hole/right,
+/turf/simulated/floor/tiled/techfloor,
+/area/tether/surfacebase/public_garden_one)
+"uwI" = (
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey/bordercorner{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden_one)
+"uyO" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/lower/first_west)
+"uEZ" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden_one)
+"vkK" = (
+/turf/simulated/wall,
+/area/maintenance/lower/public_garden_maintenence)
+"vzE" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 6
+	},
+/obj/effect/floor_decal/techfloor/hole/right{
+	dir = 1
+	},
+/obj/structure/closet/crate,
+/turf/simulated/floor/tiled/techfloor,
+/area/tether/surfacebase/public_garden_one)
+"vHM" = (
+/obj/item/device/radio/intercom{
+	dir = 8;
+	pixel_x = -24
+	},
+/obj/structure/table/bench/steel,
+/obj/effect/floor_decal/borderfloor{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 9
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden_one)
+"vHS" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 10;
+	icon_state = "borderfloorcorner2";
+	pixel_x = 0;
+	tag = "icon-borderfloorcorner2 (SOUTHWEST)"
+	},
+/obj/effect/floor_decal/corner/lightgrey/bordercorner2{
+	dir = 10
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden)
+"vOI" = (
+/obj/structure/table/bench/steel,
+/obj/effect/floor_decal/borderfloor{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 10
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden_one)
+"vZw" = (
+/obj/machinery/door/firedoor/glass,
+/obj/effect/floor_decal/steeldecal/steel_decals_central1{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/monofloor{
+	dir = 1
+	},
+/area/tether/surfacebase/public_garden_one)
+"wzH" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/structure/table/rack,
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/lower/public_garden_maintenence)
+"wFT" = (
+/turf/simulated/mineral,
+/area/maintenance/lower/public_garden_maintenence)
+"wIm" = (
+/obj/structure/table/rack,
+/obj/random/maintenance/research,
+/obj/random/maintenance/research,
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/lower/public_garden_maintenence)
+"wYi" = (
+/turf/simulated/floor/plating,
+/area/maintenance/lower/public_garden_maintenence)
+"xED" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden)
+"xRo" = (
+/obj/structure/catwalk,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/lower/public_garden_maintenence)
+"xWa" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/borderfloor/corner,
+/obj/effect/floor_decal/corner/lightgrey/bordercorner,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden_one)
+"yiG" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/lightgrey/border,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden)
 
 (1,1,1) = {"
 aaa
@@ -29913,10 +31136,10 @@ aah
 aah
 aah
 aah
-aah
-aah
-aah
-aah
+mpQ
+mpQ
+mpQ
+mpQ
 aah
 aah
 aah
@@ -30034,12 +31257,12 @@ aah
 aah
 aah
 aah
-aah
-aah
-aah
-aah
-aah
-aah
+mpQ
+mpQ
+vHM
+vOI
+mpQ
+mpQ
 aah
 aah
 aah
@@ -30155,14 +31378,14 @@ aah
 aah
 aah
 aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
+mpQ
+mpQ
+cHS
+uwI
+izr
+ftb
+mpQ
+mpQ
 aah
 aah
 aah
@@ -30276,16 +31499,16 @@ aah
 aah
 aah
 aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
+mpQ
+mpQ
+lUv
+uwI
+gPz
+gPz
+piN
+dLl
+mpQ
+mpQ
 aah
 aah
 aah
@@ -30390,25 +31613,25 @@ aad
 aad
 aad
 aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
+vkK
+vkK
+vkK
+mpQ
+mpQ
+mpQ
+mpQ
+mpQ
+mpQ
+dSz
+fEQ
+gPz
+uEZ
+gPz
+bTl
+dOn
+gri
+mpQ
+mpQ
 aah
 aah
 aah
@@ -30512,25 +31735,25 @@ aad
 aad
 aah
 aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
+vkK
+pxT
+pxT
+riT
+pCg
+tzX
+slR
+lFg
+tXv
+iPi
+fEQ
+gPz
+gwL
+gPz
+bTl
+dOn
+mtw
+tLH
+mpQ
 aah
 aah
 aah
@@ -30634,25 +31857,25 @@ aad
 aad
 aah
 aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
+vkK
+aRs
+pxT
+riT
+pCg
+tzX
+slR
+lFg
+pjP
+idw
+fEQ
+kcR
+rKM
+gPz
+bTl
+dOn
+ora
+vzE
+mpQ
 aah
 aah
 aah
@@ -30756,25 +31979,25 @@ aad
 aad
 aah
 aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
+vkK
+pxT
+ijX
+mpQ
+mpQ
+mpQ
+mpQ
+mpQ
+mpQ
+igB
+fEQ
+gPz
+nMZ
+gPz
+bTl
+dOn
+frE
+mpQ
+mpQ
 aah
 aah
 aah
@@ -30878,24 +32101,24 @@ aad
 aad
 aad
 aah
+vkK
+xRo
+gaK
 aah
 aah
 aah
 aah
 aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
+mpQ
+mpQ
+ram
+jec
+kOB
+mXP
+xWa
+qHo
+mpQ
+mpQ
 aah
 aah
 aah
@@ -31000,23 +32223,23 @@ aad
 aad
 aad
 aah
+vkK
+pxT
+gUX
+oAC
+deS
+deS
+gUy
+mpN
 aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
+mpQ
+mpQ
+hbn
+dAk
+ozv
+gwS
+mpQ
+mpQ
 aah
 aah
 aah
@@ -31122,22 +32345,22 @@ aad
 aad
 aad
 aah
+vkK
+pxT
+aRs
+pxT
+pxT
+pxT
+pxT
+gxP
 aah
 aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
+mpQ
+mpQ
+jrI
+rfg
+mpQ
+mpQ
 aah
 aah
 aah
@@ -31244,21 +32467,21 @@ aad
 aad
 aad
 aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
+vkK
+vkK
+vkK
+vkK
+vkK
+vkK
+pxT
+gxP
+wFT
+wFT
+vkK
+mpQ
+vZw
+dYj
+mpQ
 aah
 aah
 aah
@@ -31371,20 +32594,20 @@ aah
 aah
 aah
 aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
+vkK
+pxT
+gUX
+gUy
+wzH
+kZc
+gXh
+sJs
+lNY
+gXh
+gXh
+gXh
+gXh
+gXh
 aah
 aah
 aah
@@ -31493,23 +32716,23 @@ aah
 aah
 aah
 aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
+vkK
+pxT
+pxT
+pxT
+pxT
+bKM
+bfg
+egX
+yiG
+gXh
+gXh
+bri
+tXm
+gXh
+gXh
+gXh
+gXh
 ahl
 ahM
 awH
@@ -31615,25 +32838,25 @@ aah
 aah
 aah
 aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-ahl
-ahL
+vkK
+vkK
+mpN
+bsU
+vkK
+nxt
+gXh
+lJJ
+nJE
+cBB
+hvW
+cBB
+cBB
+cBB
+qyw
+qpB
+vHS
+ncL
+ako
 awH
 ajv
 akr
@@ -31739,23 +32962,23 @@ aah
 aah
 aah
 aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-ahl
-ahN
+wFT
+dbc
+bsU
+wIm
+gXh
+kuC
+xED
+btx
+qGm
+aYz
+dYl
+fbF
+iVY
+mUG
+nCB
+hqU
+lWW
 awW
 aza
 aBc
@@ -31861,24 +33084,24 @@ aah
 aah
 aah
 aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
+aVT
+hcP
+dbc
+qMQ
+gXh
+fWK
+gDo
+gXh
+oOc
+baY
+tPq
+gXh
+gXh
+gXh
+gXh
 ahl
-ahL
-awH
+sCz
+uyO
 ajx
 akq
 ala
@@ -31983,24 +33206,24 @@ aah
 aah
 aah
 aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
+wFT
+wFT
+wYi
+wFT
+gXh
+gXh
+gXh
+gXh
+gXh
+gXh
+gXh
+gXh
 aah
 aah
 aah
 ahl
 avN
-awH
+uyO
 ajy
 ahl
 alb
@@ -32105,10 +33328,10 @@ aah
 aah
 aah
 aah
-aah
-aah
-aah
-aah
+wFT
+wFT
+bui
+hcP
 aah
 aah
 aah
@@ -32243,8 +33466,8 @@ aah
 aah
 aah
 ahl
-ahP
-awW
+ahN
+eVp
 azj
 ahl
 akV
@@ -32366,8 +33589,8 @@ aah
 aah
 ahl
 ahL
-awH
-ajy
+uyO
+tbZ
 ahl
 akV
 akV
@@ -32487,8 +33710,8 @@ aah
 aah
 aah
 ahl
-avO
-awH
+ahL
+uyO
 ajy
 ahl
 akV
@@ -32609,8 +33832,8 @@ aah
 aah
 aah
 ahl
-ahL
-awH
+ePE
+uyO
 ajy
 ahl
 akV
@@ -32732,7 +33955,7 @@ aah
 aah
 ahl
 ahR
-awH
+uyO
 ajy
 ahl
 akV
@@ -32854,7 +34077,7 @@ aah
 aah
 ahl
 ahL
-awH
+uyO
 ajy
 ahl
 akV
@@ -33098,7 +34321,7 @@ aah
 aah
 ahl
 ahL
-awH
+uyO
 ajy
 ahl
 akV
@@ -33220,7 +34443,7 @@ aeW
 aeW
 aeW
 ahL
-awH
+uyO
 ajy
 ahl
 akV
@@ -33342,7 +34565,7 @@ agI
 atU
 aeW
 ahS
-awH
+uyO
 ajy
 ahl
 akV
@@ -33586,7 +34809,7 @@ afT
 agX
 ahn
 ahU
-awH
+uyO
 ajy
 akt
 akt
@@ -33708,7 +34931,7 @@ aoB
 agY
 ahn
 ahL
-awH
+uyO
 ajy
 aku
 alc
@@ -33830,7 +35053,7 @@ afT
 agX
 ahn
 ahS
-awH
+uyO
 ajD
 aku
 ald

--- a/maps/tether/tether-02-surface2.dmm
+++ b/maps/tether/tether-02-surface2.dmm
@@ -3077,7 +3077,8 @@
 /obj/structure/extinguisher_cabinet{
 	dir = 8;
 	icon_state = "extinguisher_closed";
-	pixel_x = 30
+	pixel_x = 30;
+	tag = "icon-extinguisher_closed (WEST)"
 	},
 /turf/simulated/open,
 /area/tether/surfacebase/north_staires_two)
@@ -3177,22 +3178,26 @@
 /obj/structure/sign/directions/medical{
 	dir = 1;
 	icon_state = "direction_med";
-	pixel_y = 8
+	pixel_y = 8;
+	tag = "icon-direction_med (EAST)"
 	},
 /obj/structure/sign/directions/science{
 	dir = 1;
 	icon_state = "direction_sci";
-	pixel_y = 3
+	pixel_y = 3;
+	tag = "icon-direction_sci (WEST)"
 	},
 /obj/structure/sign/directions/security{
 	dir = 1;
 	icon_state = "direction_sec";
-	pixel_y = -4
+	pixel_y = -4;
+	tag = "icon-direction_sec (WEST)"
 	},
 /obj/structure/sign/directions/engineering{
 	dir = 4;
 	icon_state = "direction_eng";
-	pixel_y = -10
+	pixel_y = -10;
+	tag = "icon-direction_eng (WEST)"
 	},
 /turf/simulated/wall,
 /area/tether/surfacebase/north_staires_two)
@@ -4390,7 +4395,8 @@
 /obj/structure/extinguisher_cabinet{
 	dir = 8;
 	icon_state = "extinguisher_closed";
-	pixel_x = 30
+	pixel_x = 30;
+	tag = "icon-extinguisher_closed (WEST)"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/tether/surfacebase/atrium_two)
@@ -4712,6 +4718,7 @@
 "kt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/industrial/danger{
+	tag = "icon-danger (WEST)";
 	icon_state = "danger";
 	dir = 8
 	},
@@ -5259,7 +5266,8 @@
 /obj/structure/extinguisher_cabinet{
 	dir = 4;
 	icon_state = "extinguisher_closed";
-	pixel_x = -30
+	pixel_x = -30;
+	tag = "icon-extinguisher_closed (EAST)"
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/research/testingrange)
@@ -6569,11 +6577,13 @@
 "oe" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/eastleft{
+	tag = "icon-left";
 	name = "Janitorial Desk";
 	icon_state = "left";
 	dir = 2
 	},
 /obj/machinery/door/window/eastleft{
+	tag = "icon-left (NORTH)";
 	name = "Janitorial Desk";
 	icon_state = "left";
 	dir = 1
@@ -7570,7 +7580,8 @@
 /obj/structure/extinguisher_cabinet{
 	dir = 4;
 	icon_state = "extinguisher_closed";
-	pixel_x = -30
+	pixel_x = -30;
+	tag = "icon-extinguisher_closed (EAST)"
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/lockers)
@@ -8678,7 +8689,8 @@
 "rF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 10;
-	icon_state = "intact"
+	icon_state = "intact";
+	tag = "icon-intact-f (NORTHWEST)"
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/lower/lobby)
@@ -9560,7 +9572,8 @@
 "ti" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 10;
-	icon_state = "intact"
+	icon_state = "intact";
+	tag = "icon-intact-f (NORTHWEST)"
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals_central4,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -10191,7 +10204,8 @@
 /obj/structure/extinguisher_cabinet{
 	dir = 8;
 	icon_state = "extinguisher_closed";
-	pixel_x = 30
+	pixel_x = 30;
+	tag = "icon-extinguisher_closed (WEST)"
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/rnd/workshop)
@@ -10579,7 +10593,8 @@
 "uO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 5;
-	icon_state = "intact"
+	icon_state = "intact";
+	tag = "icon-intact (NORTHEAST)"
 	},
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -10872,7 +10887,8 @@
 /obj/machinery/computer/guestpass{
 	dir = 1;
 	icon_state = "guest";
-	pixel_y = -28
+	pixel_y = -28;
+	tag = "icon-guest (NORTH)"
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/research)
@@ -11169,7 +11185,8 @@
 "vB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 5;
-	icon_state = "intact"
+	icon_state = "intact";
+	tag = "icon-intact-f (NORTHWEST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -11219,7 +11236,8 @@
 "vD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 10;
-	icon_state = "intact"
+	icon_state = "intact";
+	tag = "icon-intact-f (NORTHWEST)"
 	},
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -11998,6 +12016,7 @@
 /area/engineering/atmos/hallway)
 "wQ" = (
 /obj/machinery/computer/atmos_alert{
+	tag = "icon-computer (NORTH)";
 	icon_state = "computer";
 	dir = 1
 	},
@@ -12020,6 +12039,7 @@
 /area/engineering/atmos/monitoring)
 "wT" = (
 /obj/machinery/computer/rcon{
+	tag = "icon-computer (NORTH)";
 	icon_state = "computer";
 	dir = 1
 	},
@@ -12033,6 +12053,7 @@
 /area/engineering/atmos/monitoring)
 "wV" = (
 /obj/machinery/computer/power_monitor{
+	tag = "icon-computer (NORTH)";
 	icon_state = "computer";
 	dir = 1
 	},
@@ -12212,14 +12233,16 @@
 "xq" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 8;
-	icon_state = "map"
+	icon_state = "map";
+	tag = "icon-manifold-f (WEST)"
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/server)
 "xr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 9;
-	icon_state = "intact"
+	icon_state = "intact";
+	tag = "icon-intact-f (NORTHWEST)"
 	},
 /obj/effect/floor_decal/techfloor{
 	dir = 4
@@ -12357,7 +12380,8 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 5;
-	icon_state = "intact"
+	icon_state = "intact";
+	tag = "icon-intact-f (NORTHWEST)"
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/atmos/hallway)
@@ -13860,7 +13884,8 @@
 /obj/structure/extinguisher_cabinet{
 	dir = 8;
 	icon_state = "extinguisher_closed";
-	pixel_x = 30
+	pixel_x = 30;
+	tag = "icon-extinguisher_closed (WEST)"
 	},
 /turf/simulated/floor/tiled/steel_dirty,
 /area/rnd/research_storage)
@@ -14104,7 +14129,8 @@
 "AW" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 5;
-	icon_state = "intact"
+	icon_state = "intact";
+	tag = "icon-intact (SOUTHEAST)"
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/engineering/atmos)
@@ -14118,12 +14144,14 @@
 "AY" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 9;
-	icon_state = "intact"
+	icon_state = "intact";
+	tag = "icon-intact (SOUTHEAST)"
 	},
 /obj/structure/extinguisher_cabinet{
 	dir = 8;
 	icon_state = "extinguisher_closed";
-	pixel_x = 30
+	pixel_x = 30;
+	tag = "icon-extinguisher_closed (WEST)"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/atmos)
@@ -14228,7 +14256,8 @@
 "Bl" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 9;
-	icon_state = "intact"
+	icon_state = "intact";
+	tag = "icon-intact (SOUTHEAST)"
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/engineering/atmos)
@@ -14305,6 +14334,7 @@
 /area/engineering/atmos)
 "Bv" = (
 /obj/machinery/atmospherics/binary/pump/high_power/on{
+	tag = "icon-map_on (NORTH)";
 	icon_state = "map_on";
 	dir = 1
 	},
@@ -14362,6 +14392,7 @@
 /area/engineering/atmos)
 "BD" = (
 /obj/machinery/atmospherics/binary/pump/high_power/on{
+	tag = "icon-map_on (EAST)";
 	icon_state = "map_on";
 	dir = 4
 	},
@@ -14417,7 +14448,8 @@
 "BL" = (
 /obj/machinery/atmospherics/valve/digital/open{
 	dir = 4;
-	icon_state = "map_valve1"
+	icon_state = "map_valve1";
+	tag = "icon-map_valve1 (WEST)"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/atmos)
@@ -14469,6 +14501,7 @@
 /area/engineering/atmos)
 "BU" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
+	tag = "icon-intact (NORTHEAST)";
 	icon_state = "intact";
 	dir = 5
 	},
@@ -14575,7 +14608,8 @@
 "Cg" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 9;
-	icon_state = "intact"
+	icon_state = "intact";
+	tag = "icon-intact (SOUTHEAST)"
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
@@ -14865,6 +14899,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/cap/visible{
+	tag = "icon-cap (NORTH)";
 	icon_state = "cap";
 	dir = 1
 	},
@@ -15033,7 +15068,8 @@
 /obj/structure/extinguisher_cabinet{
 	dir = 8;
 	icon_state = "extinguisher_closed";
-	pixel_x = 30
+	pixel_x = 30;
+	tag = "icon-extinguisher_closed (WEST)"
 	},
 /obj/effect/floor_decal/techfloor{
 	dir = 6
@@ -15939,7 +15975,8 @@
 "EZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 5;
-	icon_state = "intact"
+	icon_state = "intact";
+	tag = "icon-intact-f (NORTHEAST)"
 	},
 /turf/simulated/floor/tiled,
 /area/tcommsat/computer)
@@ -15961,7 +15998,8 @@
 "Fc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 10;
-	icon_state = "intact"
+	icon_state = "intact";
+	tag = "icon-intact-f (SOUTHWEST)"
 	},
 /turf/simulated/floor/tiled,
 /area/tcommsat/computer)
@@ -16634,7 +16672,8 @@
 "Gh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 5;
-	icon_state = "intact"
+	icon_state = "intact";
+	tag = "icon-intact-f (NORTHEAST)"
 	},
 /obj/machinery/airlock_sensor/airlock_exterior{
 	frequency = 1381;
@@ -17564,6 +17603,665 @@
 	temperature = 80
 	},
 /area/tcommsat/chamber)
+"HT" = (
+/obj/item/weapon/storage/box/glasses/pint,
+/obj/item/weapon/storage/box/glass_extras/straws,
+/obj/structure/table/standard{
+	name = "plastic table frame"
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/lime/border{
+	dir = 10
+	},
+/obj/item/device/radio/intercom{
+	dir = 2;
+	pixel_y = -24
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden_two)
+"HV" = (
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/lime/bordercorner{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden_two)
+"IB" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/cable{
+	icon_state = "16-0"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/rust,
+/obj/machinery/atmospherics/pipe/zpipe/up/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/zpipe/up/supply{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/public_garden_two)
+"IC" = (
+/obj/machinery/light,
+/obj/effect/floor_decal/borderfloor{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/lime/border{
+	dir = 6
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden_two)
+"IE" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden_two)
+"IT" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1;
+	icon_state = "borderfloor";
+	pixel_y = 0;
+	tag = "icon-borderfloor (NORTH)"
+	},
+/obj/effect/floor_decal/corner/lime/border{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden_two)
+"Kj" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/lime/border,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden_two)
+"Kn" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/lime/bordercorner{
+	icon_state = "bordercolorcorner";
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden_two)
+"Kt" = (
+/turf/simulated/wall,
+/area/tether/surfacebase/public_garden_two)
+"KL" = (
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/lime/bordercorner{
+	icon_state = "bordercolorcorner";
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden_two)
+"LG" = (
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lime/bordercorner{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden_two)
+"Mf" = (
+/obj/machinery/light/small,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/firecloset/full/double,
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/public_garden_two)
+"MX" = (
+/obj/structure/table/standard{
+	name = "plastic table frame"
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/lime/border{
+	dir = 9
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden_two)
+"Na" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/lime/border{
+	dir = 9
+	},
+/obj/machinery/camera/network/civilian,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden_two)
+"Nf" = (
+/turf/simulated/open,
+/area/tether/surfacebase/public_garden_two)
+"Nq" = (
+/obj/structure/table/bench/steel,
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lime/bordercorner{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden_two)
+"NV" = (
+/obj/structure/sign/nanotrasen,
+/turf/simulated/wall,
+/area/tether/surfacebase/public_garden_two)
+"NZ" = (
+/obj/structure/stairs/south,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden_two)
+"OG" = (
+/obj/machinery/light,
+/obj/effect/floor_decal/borderfloor{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/lime/border{
+	dir = 10
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden_two)
+"OL" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/lime/bordercorner{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden_two)
+"OQ" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/door/airlock/maintenance/common,
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/public_garden_two)
+"Po" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/lime/border{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden_two)
+"PC" = (
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lime/bordercorner{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden_two)
+"PP" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals5,
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/lime/border,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden_two)
+"Qr" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/effect/floor_decal/borderfloor/corner,
+/obj/effect/floor_decal/corner/lime/bordercorner,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden_two)
+"Qt" = (
+/obj/machinery/smartfridge,
+/obj/effect/floor_decal/borderfloor{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/lime/border{
+	dir = 6
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden_two)
+"Qu" = (
+/obj/structure/table/bench/steel,
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/lime/bordercorner{
+	icon_state = "bordercolorcorner";
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden_two)
+"Qz" = (
+/obj/structure/table/marble,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden_two)
+"QM" = (
+/obj/machinery/portable_atmospherics/powered/scrubber,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/public_garden_two)
+"Rc" = (
+/obj/structure/table/rack/holorack,
+/obj/random/maintenance/clean,
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/public_garden_two)
+"Rl" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden_two)
+"RL" = (
+/obj/machinery/firealarm{
+	dir = 2;
+	layer = 3.3;
+	pixel_x = 0;
+	pixel_y = 26
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/lime/border{
+	dir = 9
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden_two)
+"Sv" = (
+/obj/machinery/door/airlock/maintenance/engi,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/space,
+/area/gateway)
+"Sy" = (
+/obj/structure/sign/poster,
+/turf/simulated/wall,
+/area/tether/surfacebase/public_garden_two)
+"SE" = (
+/obj/structure/table/standard{
+	name = "plastic table frame"
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/lime/border{
+	dir = 5
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden_two)
+"SH" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 1;
+	icon_state = "borderfloor";
+	pixel_y = 0;
+	tag = "icon-borderfloor (NORTH)"
+	},
+/obj/effect/floor_decal/corner/lime/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden_two)
+"SS" = (
+/obj/structure/table/standard{
+	name = "plastic table frame"
+	},
+/obj/item/device/radio/intercom{
+	dir = 4;
+	pixel_x = -24
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/lime/border{
+	dir = 10
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden_two)
+"TV" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/lime/border{
+	dir = 9
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden_two)
+"Uh" = (
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden_two)
+"Uk" = (
+/obj/structure/symbol/gu,
+/turf/simulated/wall,
+/area/tether/surfacebase/public_garden_two)
+"UB" = (
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_x = 0;
+	pixel_y = 24
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/lime/border{
+	dir = 5
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden_two)
+"UX" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/public_garden_two)
+"Vk" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/lime/bordercorner{
+	icon_state = "bordercolorcorner";
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden_two)
+"VM" = (
+/obj/machinery/reagentgrinder,
+/obj/structure/table/standard{
+	name = "plastic table frame"
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/lime/border{
+	dir = 6
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden_two)
+"Wr" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/structure/table/marble,
+/obj/effect/floor_decal/borderfloor/corner,
+/obj/effect/floor_decal/corner/lime/bordercorner,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden_two)
+"WO" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/lime/border{
+	dir = 6
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden_two)
+"Xd" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/lime/border{
+	dir = 5
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden_two)
+"Xf" = (
+/obj/structure/table/standard{
+	name = "plastic table frame"
+	},
+/obj/item/device/radio/intercom{
+	dir = 1;
+	pixel_y = 24;
+	req_access = list()
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/lime/border{
+	dir = 9
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden_two)
+"Xk" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/lime/border{
+	dir = 5
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden_two)
+"Xx" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/public_garden_two)
+"Yq" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/lime/border{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 8;
+	health = 1e+006
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden_two)
+"YE" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/lime/border{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden_two)
+"YH" = (
+/obj/structure/window/reinforced{
+	dir = 4;
+	health = 1e+006
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/lime/border{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden_two)
+"YN" = (
+/obj/structure/closet/hydrant{
+	pixel_x = -32
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/lime/border{
+	dir = 10
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden_two)
+"YP" = (
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -25
+	},
+/obj/random/plushie,
+/obj/structure/table/standard{
+	name = "plastic table frame"
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/lime/border{
+	dir = 10
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden_two)
+"Zo" = (
+/obj/structure/table/bench/steel,
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/lime/bordercorner{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden_two)
+"Zp" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lime/bordercorner{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden_two)
+"Zt" = (
+/obj/effect/floor_decal/borderfloor/corner,
+/obj/effect/floor_decal/corner/lime/bordercorner,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden_two)
+"ZF" = (
+/obj/machinery/seed_extractor,
+/obj/effect/floor_decal/borderfloor{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/lime/border{
+	dir = 6
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden_two)
+"ZT" = (
+/obj/structure/closet/crate/bin{
+	anchored = 1;
+	pixel_y = 16
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/lime/border{
+	dir = 5
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden_two)
 
 (1,1,1) = {"
 aa
@@ -20271,10 +20969,10 @@ ac
 ac
 ac
 ac
-ac
-ac
-ac
-ac
+Kt
+Sy
+Kt
+Kt
 ac
 ac
 ac
@@ -20392,12 +21090,12 @@ ac
 ac
 ac
 ac
-ac
-ac
-ac
-ac
-ac
-ac
+Kt
+Kt
+MX
+SS
+Kt
+Kt
 ac
 ac
 ac
@@ -20513,14 +21211,14 @@ ac
 ac
 ac
 ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
+Kt
+Kt
+Na
+Nq
+Zo
+YN
+Kt
+Kt
 ac
 ac
 ac
@@ -20634,16 +21332,16 @@ ac
 ac
 ac
 ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
+Kt
+Kt
+RL
+LG
+Uh
+Uh
+HV
+YP
+Kt
+Kt
 ac
 ac
 ac
@@ -20755,18 +21453,18 @@ ac
 ac
 ac
 ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
+Kt
+Kt
+TV
+PC
+Qr
+YE
+YH
+KL
+HV
+OG
+Kt
+Kt
 ac
 ac
 ac
@@ -20877,18 +21575,18 @@ ac
 ac
 ac
 ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
+Kt
+Xf
+Nq
+Uh
+PP
+Rl
+NZ
+SH
+Qz
+HV
+HT
+Kt
 ac
 ac
 ac
@@ -20999,18 +21697,18 @@ ac
 ac
 ac
 ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
+NV
+SE
+Qu
+Uh
+Kj
+Nf
+Nf
+IT
+Qz
+Zt
+VM
+Kt
 ac
 ac
 ac
@@ -21121,18 +21819,18 @@ ac
 ac
 ac
 ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
+Kt
+Kt
+Xd
+KL
+OL
+Po
+Yq
+Zp
+Wr
+IC
+Kt
+Kt
 ac
 ac
 ac
@@ -21244,16 +21942,16 @@ ac
 ac
 ac
 ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
+Kt
+Kt
+UB
+Kn
+IE
+Uh
+Zt
+Qt
+Sy
+Kt
 ac
 ac
 ac
@@ -21367,14 +22065,14 @@ ac
 ac
 ac
 ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
+Kt
+Kt
+ZT
+Vk
+Zt
+ZF
+Kt
+Kt
 ac
 ac
 ac
@@ -21490,12 +22188,12 @@ ac
 ac
 ac
 ac
-ac
-ac
-ac
-ac
-ac
-ac
+Kt
+Kt
+Xk
+WO
+Kt
+Kt
 ac
 ac
 ac
@@ -21613,11 +22311,11 @@ ac
 ac
 ac
 ac
-ac
-ac
-ac
-ac
-ac
+Kt
+OQ
+Uk
+Kt
+Kt
 ac
 ac
 ac
@@ -21735,11 +22433,11 @@ ac
 ac
 ac
 ac
-ac
-ac
-ac
-ac
-ac
+Kt
+UX
+IB
+Mf
+Kt
 ac
 ac
 ac
@@ -21857,11 +22555,11 @@ ac
 ac
 ac
 ac
-ac
-ac
-ac
-ac
-ac
+Kt
+Xx
+QM
+Rc
+Kt
 ac
 ac
 ac
@@ -21980,7 +22678,7 @@ ae
 ae
 ae
 ae
-ae
+Sv
 ae
 ae
 ae

--- a/maps/tether/tether-03-surface3.dmm
+++ b/maps/tether/tether-03-surface3.dmm
@@ -767,7 +767,8 @@
 /obj/structure/extinguisher_cabinet{
 	dir = 8;
 	icon_state = "extinguisher_closed";
-	pixel_x = 30
+	pixel_x = 30;
+	tag = "icon-extinguisher_closed (WEST)"
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/common)
@@ -1598,7 +1599,8 @@
 	dir = 4;
 	icon_state = "secintercom";
 	pixel_x = 24;
-	pixel_y = 0
+	pixel_y = 0;
+	tag = "icon-secintercom (EAST)"
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/common)
@@ -3700,7 +3702,8 @@
 /obj/structure/extinguisher_cabinet{
 	dir = 8;
 	icon_state = "extinguisher_closed";
-	pixel_x = 30
+	pixel_x = 30;
+	tag = "icon-extinguisher_closed (WEST)"
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/lobby)
@@ -4272,7 +4275,8 @@
 /obj/structure/extinguisher_cabinet{
 	dir = 8;
 	icon_state = "extinguisher_closed";
-	pixel_x = 30
+	pixel_x = 30;
+	tag = "icon-extinguisher_closed (WEST)"
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -6433,7 +6437,8 @@
 /obj/structure/sign/directions/engineering{
 	dir = 10;
 	icon_state = "direction_eng";
-	pixel_y = -10
+	pixel_y = -10;
+	tag = "icon-direction_eng (WEST)"
 	},
 /turf/simulated/wall,
 /area/tether/surfacebase/north_stairs_three)
@@ -6445,12 +6450,14 @@
 /obj/structure/sign/directions/science{
 	dir = 2;
 	icon_state = "direction_sci";
-	pixel_y = 3
+	pixel_y = 3;
+	tag = "icon-direction_sci (WEST)"
 	},
 /obj/structure/sign/directions/security{
 	dir = 1;
 	icon_state = "direction_sec";
-	pixel_y = -4
+	pixel_y = -4;
+	tag = "icon-direction_sec (WEST)"
 	},
 /turf/simulated/wall,
 /area/tether/surfacebase/north_stairs_three)
@@ -6806,7 +6813,8 @@
 /obj/structure/extinguisher_cabinet{
 	dir = 4;
 	icon_state = "extinguisher_closed";
-	pixel_x = -30
+	pixel_x = -30;
+	tag = "icon-extinguisher_closed (EAST)"
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/north_stairs_three)
@@ -9541,7 +9549,8 @@
 /obj/structure/extinguisher_cabinet{
 	dir = 4;
 	icon_state = "extinguisher_closed";
-	pixel_x = -30
+	pixel_x = -30;
+	tag = "icon-extinguisher_closed (EAST)"
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -9619,22 +9628,26 @@
 /obj/structure/sign/directions/medical{
 	dir = 1;
 	icon_state = "direction_med";
-	pixel_y = 8
+	pixel_y = 8;
+	tag = "icon-direction_med (EAST)"
 	},
 /obj/structure/sign/directions/science{
 	dir = 2;
 	icon_state = "direction_sci";
-	pixel_y = 3
+	pixel_y = 3;
+	tag = "icon-direction_sci (WEST)"
 	},
 /obj/structure/sign/directions/security{
 	dir = 1;
 	icon_state = "direction_sec";
-	pixel_y = -4
+	pixel_y = -4;
+	tag = "icon-direction_sec (WEST)"
 	},
 /obj/structure/sign/directions/engineering{
 	dir = 1;
 	icon_state = "direction_eng";
-	pixel_y = -10
+	pixel_y = -10;
+	tag = "icon-direction_eng (WEST)"
 	},
 /turf/simulated/wall,
 /area/tether/surfacebase/atrium_three)
@@ -10464,7 +10477,8 @@
 /obj/structure/extinguisher_cabinet{
 	dir = 4;
 	icon_state = "extinguisher_closed";
-	pixel_x = -30
+	pixel_x = -30;
+	tag = "icon-extinguisher_closed (EAST)"
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
@@ -12690,7 +12704,8 @@
 /obj/machinery/computer/guestpass{
 	dir = 1;
 	icon_state = "guest";
-	pixel_y = -28
+	pixel_y = -28;
+	tag = "icon-guest (NORTH)"
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -13119,7 +13134,8 @@
 /obj/structure/extinguisher_cabinet{
 	dir = 4;
 	icon_state = "extinguisher_closed";
-	pixel_x = -30
+	pixel_x = -30;
+	tag = "icon-extinguisher_closed (EAST)"
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
@@ -14409,7 +14425,8 @@
 /obj/structure/extinguisher_cabinet{
 	dir = 4;
 	icon_state = "extinguisher_closed";
-	pixel_x = -30
+	pixel_x = -30;
+	tag = "icon-extinguisher_closed (EAST)"
 	},
 /turf/simulated/floor/tiled,
 /area/hydroponics)
@@ -14475,7 +14492,8 @@
 /obj/structure/extinguisher_cabinet{
 	dir = 8;
 	icon_state = "extinguisher_closed";
-	pixel_x = 30
+	pixel_x = 30;
+	tag = "icon-extinguisher_closed (WEST)"
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
@@ -14489,7 +14507,8 @@
 /obj/structure/extinguisher_cabinet{
 	dir = 4;
 	icon_state = "extinguisher_closed";
-	pixel_x = -30
+	pixel_x = -30;
+	tag = "icon-extinguisher_closed (EAST)"
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/research)
@@ -15499,7 +15518,8 @@
 /obj/structure/extinguisher_cabinet{
 	dir = 8;
 	icon_state = "extinguisher_closed";
-	pixel_x = 30
+	pixel_x = 30;
+	tag = "icon-extinguisher_closed (WEST)"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/borderfloor{
@@ -16382,7 +16402,8 @@
 /obj/machinery/computer/guestpass{
 	dir = 1;
 	icon_state = "guest";
-	pixel_y = -28
+	pixel_y = -28;
+	tag = "icon-guest (NORTH)"
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 8
@@ -16899,7 +16920,8 @@
 /obj/structure/extinguisher_cabinet{
 	dir = 8;
 	icon_state = "extinguisher_closed";
-	pixel_x = 30
+	pixel_x = 30;
+	tag = "icon-extinguisher_closed (WEST)"
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
@@ -17157,7 +17179,8 @@
 /obj/structure/extinguisher_cabinet{
 	dir = 4;
 	icon_state = "extinguisher_closed";
-	pixel_x = -30
+	pixel_x = -30;
+	tag = "icon-extinguisher_closed (EAST)"
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -17475,7 +17498,8 @@
 /obj/structure/sign/directions/medical{
 	dir = 1;
 	icon_state = "direction_med";
-	pixel_y = 8
+	pixel_y = 8;
+	tag = "icon-direction_med (EAST)"
 	},
 /obj/structure/sign/directions/science{
 	dir = 8;
@@ -17484,12 +17508,14 @@
 /obj/structure/sign/directions/security{
 	dir = 1;
 	icon_state = "direction_sec";
-	pixel_y = -4
+	pixel_y = -4;
+	tag = "icon-direction_sec (WEST)"
 	},
 /obj/structure/sign/directions/engineering{
 	dir = 1;
 	icon_state = "direction_eng";
-	pixel_y = -10
+	pixel_y = -10;
+	tag = "icon-direction_eng (WEST)"
 	},
 /turf/simulated/wall,
 /area/maintenance/engineering/pumpstation)
@@ -18405,7 +18431,8 @@
 /obj/structure/extinguisher_cabinet{
 	dir = 8;
 	icon_state = "extinguisher_closed";
-	pixel_x = 30
+	pixel_x = 30;
+	tag = "icon-extinguisher_closed (WEST)"
 	},
 /turf/simulated/floor/lino,
 /area/crew_quarters/bar)
@@ -19076,7 +19103,8 @@
 /obj/machinery/computer/guestpass{
 	dir = 1;
 	icon_state = "guest";
-	pixel_y = -28
+	pixel_y = -28;
+	tag = "icon-guest (NORTH)"
 	},
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/lightgrey/border,
@@ -19943,7 +19971,8 @@
 /obj/structure/extinguisher_cabinet{
 	dir = 8;
 	icon_state = "extinguisher_closed";
-	pixel_x = 30
+	pixel_x = 30;
+	tag = "icon-extinguisher_closed (WEST)"
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/assembly/robotics)
@@ -20691,7 +20720,8 @@
 /obj/structure/extinguisher_cabinet{
 	dir = 8;
 	icon_state = "extinguisher_closed";
-	pixel_x = 30
+	pixel_x = 30;
+	tag = "icon-extinguisher_closed (WEST)"
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -20718,7 +20748,8 @@
 /obj/structure/extinguisher_cabinet{
 	dir = 4;
 	icon_state = "extinguisher_closed";
-	pixel_x = -30
+	pixel_x = -30;
+	tag = "icon-extinguisher_closed (EAST)"
 	},
 /turf/simulated/floor/reinforced,
 /area/tether/surfacebase/shuttle_pad)
@@ -21016,7 +21047,8 @@
 /obj/structure/extinguisher_cabinet{
 	dir = 8;
 	icon_state = "extinguisher_closed";
-	pixel_x = 30
+	pixel_x = 30;
+	tag = "icon-extinguisher_closed (WEST)"
 	},
 /turf/simulated/floor/reinforced,
 /area/tether/surfacebase/shuttle_pad)
@@ -21241,7 +21273,8 @@
 /obj/structure/extinguisher_cabinet{
 	dir = 4;
 	icon_state = "extinguisher_closed";
-	pixel_x = -30
+	pixel_x = -30;
+	tag = "icon-extinguisher_closed (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -21285,7 +21318,8 @@
 /obj/structure/extinguisher_cabinet{
 	dir = 4;
 	icon_state = "extinguisher_closed";
-	pixel_x = -30
+	pixel_x = -30;
+	tag = "icon-extinguisher_closed (EAST)"
 	},
 /turf/simulated/floor/reinforced,
 /area/tether/surfacebase/shuttle_pad)
@@ -21314,6 +21348,246 @@
 /obj/machinery/camera/network/northern_star,
 /turf/simulated/floor/outdoors/grass/sif/virgo3b,
 /area/tether/surfacebase/outside/outside3)
+"KR" = (
+/obj/structure/lattice,
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/atmospherics/pipe/zpipe/down/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/zpipe/down/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/zpipe/down/scrubbers{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "32-1"
+	},
+/turf/simulated/open,
+/area/tether/surfacebase/public_garden_three)
+"Lr" = (
+/obj/structure/table/woodentable,
+/obj/random/maintenance/clean,
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lime/bordercorner{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals6,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden_three)
+"Mp" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lime/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden_three)
+"Mu" = (
+/obj/machinery/portable_atmospherics/hydroponics/soil,
+/turf/simulated/floor/grass,
+/area/tether/surfacebase/public_garden_three)
+"MO" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/seed_storage/garden,
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/lime/border,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden_three)
+"Nb" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloor/corner,
+/obj/effect/floor_decal/corner/lime/bordercorner,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden_three)
+"NA" = (
+/obj/machinery/alarm{
+	breach_detection = 0;
+	dir = 8;
+	pixel_x = 25;
+	pixel_y = 0;
+	report_danger_level = 0
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/lime/border{
+	dir = 6
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden_three)
+"NL" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/effect/floor_decal/borderfloor/corner,
+/obj/effect/floor_decal/corner/lime/bordercorner,
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 9
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 10
+	},
+/obj/structure/window/reinforced{
+	dir = 1;
+	health = 1e+006
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden_three)
+"Oa" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lime/bordercorner{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 5
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 6
+	},
+/obj/structure/window/reinforced,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden_three)
+"Op" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/machinery/door/firedoor,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/public_garden_three)
+"PD" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/structure/reagent_dispensers/watertank,
+/obj/item/weapon/reagent_containers/glass/bucket,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/effect/floor_decal/techfloor{
+	dir = 5
+	},
+/obj/effect/floor_decal/techfloor/hole/right{
+	dir = 1
+	},
+/obj/effect/floor_decal/techfloor/hole/right{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/tether/surfacebase/public_garden_three)
+"PF" = (
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/lime/bordercorner{
+	icon_state = "bordercolorcorner";
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden_three)
+"Qd" = (
+/obj/structure/table/woodentable,
+/obj/item/weapon/material/minihoe,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/item/device/analyzer/plant_analyzer,
+/obj/item/device/analyzer/plant_analyzer,
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8;
+	health = 1e+006
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden_three)
+"Qj" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/lime/bordercorner{
+	icon_state = "bordercolorcorner";
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 5
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 6
+	},
+/obj/structure/window/reinforced,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden_three)
+"Qx" = (
+/turf/simulated/wall,
+/area/tether/surfacebase/public_garden_three)
+"QC" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/public_garden_three)
+"QW" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/lime/border{
+	dir = 10
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden_three)
+"Rb" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/lime/border,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden_three)
+"Rh" = (
+/obj/structure/table/bench/wooden,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden_three)
+"Rw" = (
+/turf/simulated/open,
+/area/tether/surfacebase/public_garden_three)
 "RD" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/lightgrey/border,
@@ -21326,6 +21600,315 @@
 /obj/machinery/computer/timeclock/premade/south,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/atrium_three)
+"RE" = (
+/obj/machinery/hologram/holopad,
+/obj/effect/floor_decal/borderfloor{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/lime/border{
+	dir = 10
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden_three)
+"RS" = (
+/obj/structure/table/woodentable,
+/obj/item/weapon/reagent_containers/glass/bucket,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8;
+	health = 1e+006
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden_three)
+"Sg" = (
+/obj/structure/sink{
+	dir = 4;
+	icon_state = "sink";
+	pixel_x = 11;
+	pixel_y = 0
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/lime/border{
+	dir = 5
+	},
+/obj/machinery/camera/network/civilian,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden_three)
+"SJ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/lime/border{
+	dir = 5
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden_three)
+"Tt" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/machinery/door/firedoor,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/public_garden_three)
+"TQ" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/machinery/door/firedoor,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/public_garden_three)
+"Uu" = (
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/effect/floor_decal/borderfloor{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/lime/border{
+	dir = 9
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden_three)
+"Uv" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/machinery/door/firedoor,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/public_garden_three)
+"UH" = (
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_x = 0;
+	pixel_y = 28
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lime/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden_three)
+"UL" = (
+/obj/machinery/light,
+/obj/structure/table/bench/wooden,
+/turf/simulated/floor/grass,
+/area/tether/surfacebase/public_garden_three)
+"Ve" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/lime/border{
+	dir = 5
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden_three)
+"Vr" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lime/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden_three)
+"VF" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/table/bench/wooden,
+/turf/simulated/floor/grass,
+/area/tether/surfacebase/public_garden_three)
+"VG" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/machinery/door/firedoor,
+/obj/structure/window/reinforced,
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/public_garden_three)
+"VH" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/lime/border,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden_three)
+"VN" = (
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/obj/machinery/portable_atmospherics/hydroponics/soil,
+/turf/simulated/floor/grass,
+/area/tether/surfacebase/public_garden_three)
+"Ws" = (
+/obj/structure/table/bench/wooden,
+/turf/simulated/floor/grass,
+/area/tether/surfacebase/public_garden_three)
+"WA" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/lime/border{
+	dir = 6
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden_three)
+"WF" = (
+/obj/structure/table/bench/wooden,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden_three)
+"Yc" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/machinery/door/firedoor,
+/obj/structure/window/reinforced{
+	dir = 8;
+	health = 1e+006
+	},
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/public_garden_three)
+"Yz" = (
+/obj/item/device/radio/intercom{
+	broadcasting = 1;
+	dir = 8;
+	listening = 1;
+	name = "Common Channel";
+	pixel_x = -21;
+	pixel_y = 0
+	},
+/obj/machinery/portable_atmospherics/hydroponics/soil,
+/turf/simulated/floor/grass,
+/area/tether/surfacebase/public_garden_three)
+"YA" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/machinery/door/firedoor,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/public_garden_three)
+"YN" = (
+/obj/structure/table/woodentable,
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/lime/bordercorner{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals6,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden_three)
+"YV" = (
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/lime/bordercorner{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 10
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 9
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden_three)
+"Zn" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/vending/hydronutrients,
+/obj/effect/floor_decal/borderfloor{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/lime/border{
+	dir = 6
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden_three)
+"Zp" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/machinery/door/firedoor,
+/obj/structure/window/reinforced{
+	dir = 4;
+	health = 1e+006
+	},
+/obj/structure/window/reinforced,
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/public_garden_three)
+"Zq" = (
+/turf/simulated/floor/grass,
+/area/tether/surfacebase/public_garden_three)
+"ZQ" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/lime/border{
+	dir = 9
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden_three)
 
 (1,1,1) = {"
 aa
@@ -23914,7 +24497,7 @@ ac
 ac
 ac
 ac
-ac
+fF
 ac
 ac
 ac
@@ -24033,10 +24616,10 @@ ac
 ac
 ac
 ac
-ac
-ac
-ac
-ac
+Qx
+Yc
+Yc
+Qx
 ac
 ac
 ac
@@ -24154,12 +24737,12 @@ ac
 ac
 ac
 ac
-ac
-ac
-ac
-ac
-ac
-ac
+Uv
+Qx
+Mu
+Mu
+Qx
+Op
 ac
 ac
 ac
@@ -24275,14 +24858,14 @@ ac
 ac
 ac
 ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
+Uv
+QC
+VN
+Zq
+Zq
+Yz
+QC
+Op
 ac
 ac
 ac
@@ -24396,16 +24979,16 @@ ac
 ac
 ac
 ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
+Uv
+QC
+Ws
+Zq
+ZQ
+QW
+Zq
+Ws
+QC
+Op
 ac
 ac
 ac
@@ -24517,18 +25100,18 @@ ac
 ac
 ac
 ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
+Qx
+Qx
+VF
+Ws
+ZQ
+Lr
+YN
+RE
+Ws
+UL
+Qx
+Qx
 ac
 ac
 ac
@@ -24639,18 +25222,18 @@ ac
 ac
 ac
 ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
+Tt
+Mu
+Zq
+Uu
+Oa
+Rw
+Rw
+YV
+QW
+Zq
+Mu
+VG
 ac
 ac
 ac
@@ -24761,18 +25344,18 @@ ac
 ac
 ac
 ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
+Tt
+Mu
+Zq
+Ve
+Qj
+Rw
+Rw
+NL
+WA
+Zq
+Mu
+VG
 ac
 ac
 ac
@@ -24883,18 +25466,18 @@ ac
 ac
 ac
 ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
+Qx
+Qx
+VF
+Ws
+Vr
+Qd
+RS
+Rb
+Ws
+UL
+Qx
+Qx
 ac
 ac
 ac
@@ -25006,16 +25589,16 @@ ac
 ac
 ac
 ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
+YA
+QC
+Ws
+Mp
+Rh
+WF
+VH
+Ws
+QC
+Zp
 ac
 ac
 ac
@@ -25129,14 +25712,14 @@ ac
 ac
 ac
 ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
+YA
+QC
+Sg
+PF
+Nb
+NA
+QC
+Zp
 ac
 ac
 gw
@@ -25252,12 +25835,12 @@ ac
 ac
 ac
 ac
-ac
-ac
-ac
-ac
-ac
-ac
+YA
+Qx
+UH
+MO
+Qx
+Zp
 ac
 ac
 ac
@@ -25375,10 +25958,10 @@ ac
 ac
 ac
 ac
-ac
-ac
-ac
-ac
+Tt
+SJ
+Zn
+VG
 ac
 ac
 ac
@@ -25497,10 +26080,10 @@ ac
 ac
 ac
 ac
-ac
-ac
-ac
-ac
+Tt
+PD
+KR
+VG
 ac
 ad
 gw
@@ -25619,10 +26202,10 @@ ac
 ac
 ac
 ac
-ac
-ac
-ac
-ac
+Qx
+TQ
+TQ
+Qx
 ac
 ac
 gw

--- a/maps/tether/tether_areas2.dm
+++ b/maps/tether/tether_areas2.dm
@@ -57,6 +57,19 @@
 	name = "\improper North Stairwell Third Floor"
 	icon_state = "dk_yellow"
 
+/area/tether/surfacebase/public_garden_one
+	name = "\improper Public Garden First Floor"
+	icon_state = "green"
+/area/tether/surfacebase/public_garden_two
+	name = "\improper Public Garden Second Floor"
+	icon_state = "green"
+/area/tether/surfacebase/public_garden_three
+	name = "\improper Public Garden Third Floor"
+	icon_state = "green"
+/area/tether/surfacebase/public_garden
+	name = "\improper Public Garden"
+	icon_state = "purple"
+
 // /area/tether/surfacebase/east_stairs_one //This is just part of a lower hallway
 
 /area/tether/surfacebase/east_stairs_two
@@ -208,6 +221,8 @@
 	name = "\improper Solars maintenanceance"
 /area/maintenance/lower/mining_eva
 	name = "\improper Mining EVA Maintenance"
+/area/maintenance/lower/public_garden_maintenence
+	name = "\improper Public Garden Maintenence"
 
 // Research
 /area/rnd/xenobiology/xenoflora/lab_atmos

--- a/tools/mapmerge2/Prepare Maps.bat
+++ b/tools/mapmerge2/Prepare Maps.bat
@@ -1,0 +1,12 @@
+@echo off
+cd ../../_maps/
+
+for /R %%f in (*.dmm) do copy "%%f" "%%f.backup"
+
+cls
+echo All dmm files in _maps directories have been backed up
+echo Now you can make your changes...
+echo ---
+echo Remember to run mapmerge.bat just before you commit your changes!
+echo ---
+pause

--- a/tools/mapmerge2/dmm.py
+++ b/tools/mapmerge2/dmm.py
@@ -31,10 +31,12 @@ class DMM:
         return _parse(bytes.decode(ENCODING))
 
     def to_file(self, fname, tgm = True):
+        self._presave_checks()
         with open(fname, 'w', newline='\n', encoding=ENCODING) as f:
             (save_tgm if tgm else save_dmm)(self, f)
 
     def to_bytes(self, tgm = True):
+        self._presave_checks()
         bio = io.BytesIO()
         with io.TextIOWrapper(bio, newline='\n', encoding=ENCODING) as f:
             (save_tgm if tgm else save_dmm)(self, f)
@@ -42,12 +44,7 @@ class DMM:
             return bio.getvalue()
 
     def generate_new_key(self):
-        # ensure that free keys exist by increasing the key length if necessary
-        free_keys = (BASE ** self.key_length) - len(self.dictionary)
-        while free_keys <= 0:
-            self.key_length += 1
-            free_keys = (BASE ** self.key_length) - len(self.dictionary)
-
+        free_keys = self._ensure_free_keys(1)
         # choose one of the free keys at random
         key = 0
         while free_keys:
@@ -60,6 +57,32 @@ class DMM:
             key += 1
 
         raise RuntimeError("ran out of keys, this shouldn't happen")
+
+    def _presave_checks(self):
+        # last-second handling of bogus keys to help prevent and fix broken maps
+        self._ensure_free_keys(0)
+        max_key = max_key_for(self.key_length)
+        bad_keys = {key: 0 for key in self.dictionary.keys() if key > max_key}
+        if bad_keys:
+            print(f"Warning: fixing {len(bad_keys)} overflowing keys")
+            for k in bad_keys:
+                # create a new non-bogus key and transfer that value to it
+                new_key = bad_keys[k] = self.generate_new_key()
+                self.dictionary.forceput(new_key, self.dictionary[k])
+                print(f"    {num_to_key(k, self.key_length, True)} -> {num_to_key(new_key, self.key_length)}")
+            for k, v in self.grid.items():
+                # reassign the grid entries which used the old key
+                self.grid[k] = bad_keys.get(v, v)
+
+    def _ensure_free_keys(self, desired):
+        # ensure that free keys exist by increasing the key length if necessary
+        free_keys = max_key_for(self.key_length) - len(self.dictionary)
+        while free_keys < desired:
+            if self.key_length >= MAX_KEY_LENGTH:
+                raise KeyTooLarge(f"can't expand beyond key length {MAX_KEY_LENGTH} ({len(self.dictionary)} keys)")
+            self.key_length += 1
+            free_keys = max_key_for(self.key_length) - len(self.dictionary)
+        return free_keys
 
     @property
     def coords_zyx(self):
@@ -82,6 +105,7 @@ class DMM:
 # key handling
 
 # Base 52 a-z A-Z dictionary for fast conversion
+MAX_KEY_LENGTH = 3  # things will get ugly fast if you exceed this
 BASE = 52
 base52 = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'
 base52_r = {x: i for i, x in enumerate(base52)}
@@ -93,8 +117,8 @@ def key_to_num(key):
         num = BASE * num + base52_r[ch]
     return num
 
-def num_to_key(num, key_length):
-    if num >= BASE ** key_length:
+def num_to_key(num, key_length, allow_overflow=False):
+    if num >= (BASE ** key_length if allow_overflow else max_key_for(key_length)):
         raise KeyTooLarge(f"num={num} does not fit in key_length={key_length}")
 
     result = ''
@@ -104,6 +128,11 @@ def num_to_key(num, key_length):
 
     assert len(result) <= key_length
     return base52[0] * (key_length - len(result)) + result
+
+def max_key_for(key_length):
+    # keys only go up to "ymo" = 65534, under-estimated just in case
+    # https://secure.byond.com/forum/?post=2340796#comment23770802
+    return min(65530, BASE ** key_length)
 
 class KeyTooLarge(Exception):
     pass

--- a/tools/mapmerge2/dmm2tgm.bat
+++ b/tools/mapmerge2/dmm2tgm.bat
@@ -1,5 +1,5 @@
 @echo off
-set MAPROOT=../../maps/tether
+set MAPROOT=../../_maps/
 set TGM=1
 python convert.py
 pause

--- a/tools/mapmerge2/mapmerge.bat
+++ b/tools/mapmerge2/mapmerge.bat
@@ -1,5 +1,5 @@
 @echo off
-set MAPROOT=../../maps/tether
+set MAPROOT=../../_maps/
 set TGM=1
 python mapmerge.py
 pause

--- a/tools/mapmerge2/tgm2dmm.bat
+++ b/tools/mapmerge2/tgm2dmm.bat
@@ -1,5 +1,5 @@
 @echo off
-set MAPROOT=../../maps/tether
+set MAPROOT=../../_maps/
 set TGM=0
 python convert.py
 pause


### PR DESCRIPTION
### All credit goes to @Very-Soft for the map and design and everything.

Originally the public garden was going to take up this whole space, but I cut it back and then condensed it, and was able to do a little more with the space as a result.

![z3](https://user-images.githubusercontent.com/24854483/38905102-6ae51b82-427c-11e8-9cb8-3dafe209e22e.png)

This is the public garden! It has 8 growing plots, 2 plant analyzers, 2 buckets, 1 mini hoe, 1 sink, 1 water tank, 1 seed vendor, and 1 nutrimax

![z2](https://user-images.githubusercontent.com/24854483/38905100-6093d38a-427c-11e8-828b-28ae3053eb7e.png)

This is a juice bar. It has a seed extractor, a smartfridge, a grinder, a box of glasses, and a box of straws. It also has some fire safety gear, and a random plush.

![z1](https://user-images.githubusercontent.com/24854483/38905108-78a6ed90-427c-11e8-9017-41b6a5ed484e.png)

This is the entry area. It's mostly empty for now. I have some plans for it later maybe. There is also a section of maintenence here, so you can be the creep around in the dark or behind the scrubbers if you want to. There are also some places to sit and relax, as well as a hot drinks and snacks machine to shoot food at you while you do so.

The z05 change is removing keys beyond the ymp boundary that existed in the file. Unusual that byond allowed it to exist like that. Who knows what it could have caused.

The update to mapmerge fixes it so that it doesn't attempt to allocate keys beyond ymp.