### PR TITLE
Cleans up custom species icon base code

### DIFF
--- a/code/__defines/mobs_vr.dm
+++ b/code/__defines/mobs_vr.dm
@@ -26,3 +26,4 @@
 #define SPECIES_XENOHYBRID		"Xenomorph Hybrid"
 #define SPECIES_ZORREN_FLAT		"Flatland Zorren"
 #define SPECIES_ZORREN_HIGH		"Highlander Zorren"
+#define SPECIES_CUSTOM			"Custom Species"

--- a/code/_helpers/global_lists.dm
+++ b/code/_helpers/global_lists.dm
@@ -32,7 +32,7 @@ var/global/list/all_species[0]
 var/global/list/all_languages[0]
 var/global/list/language_keys[0]					// Table of say codes for all languages
 var/global/list/whitelisted_species = list(SPECIES_HUMAN) // Species that require a whitelist check.
-var/global/list/playable_species = list("Custom Species", SPECIES_HUMAN)    // A list of ALL playable species, whitelisted, latejoin or otherwise. //VOREStation Edit - Making sure custom species is obvious.
+var/global/list/playable_species = list(SPECIES_CUSTOM, SPECIES_HUMAN)    // A list of ALL playable species, whitelisted, latejoin or otherwise. //VOREStation Edit - Making sure custom species is obvious.
 
 var/list/mannequins_
 

--- a/code/_helpers/global_lists_vr.dm
+++ b/code/_helpers/global_lists_vr.dm
@@ -11,6 +11,8 @@ var/global/list/positive_traits = list()	// Positive custom species traits, inde
 var/global/list/traits_costs = list()		// Just path = cost list, saves time in char setup
 var/global/list/all_traits = list()			// All of 'em at once (same instances)
 
+var/global/list/custom_species_bases = list() // Species that can be used for a Custom Species icon base
+
 //stores numeric player size options indexed by name
 var/global/list/player_sizes_list = list(
 		"Macro" 	= RESIZE_HUGE,
@@ -194,5 +196,15 @@ var/global/list/edible_trash = list(/obj/item/trash,
 				neutral_traits[path] = instance
 			if(0.1 to INFINITY)
 				positive_traits[path] = instance
+
+	// Custom species icon bases
+	var/list/blacklisted_icons = list("Custom Species","Promethean") //Just ones that won't work well.
+	for(var/species_name in playable_species)
+		if(species_name in blacklisted_icons)
+			continue
+		var/datum/species/S = all_species[species_name]
+		if(S.spawn_flags & SPECIES_IS_WHITELISTED)
+			continue
+		custom_species_bases += species_name
 
 	return 1 // Hooks must return 1

--- a/code/_helpers/global_lists_vr.dm
+++ b/code/_helpers/global_lists_vr.dm
@@ -198,7 +198,7 @@ var/global/list/edible_trash = list(/obj/item/trash,
 				positive_traits[path] = instance
 
 	// Custom species icon bases
-	var/list/blacklisted_icons = list("Custom Species","Promethean") //Just ones that won't work well.
+	var/list/blacklisted_icons = list(SPECIES_CUSTOM,SPECIES_PROMETHEAN) //Just ones that won't work well.
 	for(var/species_name in playable_species)
 		if(species_name in blacklisted_icons)
 			continue

--- a/code/modules/client/preference_setup/vore/07_traits.dm
+++ b/code/modules/client/preference_setup/vore/07_traits.dm
@@ -55,7 +55,7 @@
 		pref.starting_trait_points = STARTING_SPECIES_POINTS
 		pref.max_traits = MAX_SPECIES_TRAITS
 
-	if(pref.species != "Custom Species")
+	if(pref.species != SPECIES_CUSTOM)
 		pref.pos_traits.Cut()
 		pref.neu_traits.Cut()
 		pref.neg_traits.Cut()
@@ -73,23 +73,15 @@
 			if(!(path in negative_traits))
 				pref.neg_traits -= path
 
-	if(!pref.custom_base || (pref.custom_base != "Xenochimera" && !(pref.custom_base in playable_species - whitelisted_species)))
+	if(!pref.custom_base || !(pref.custom_base in custom_species_bases))
 		pref.custom_base = "Human"
 
 /datum/category_item/player_setup_item/vore/traits/copy_to_mob(var/mob/living/carbon/human/character)
 	character.custom_species	= pref.custom_species
-	if(pref.species == "Custom Species")
+	if(pref.species == SPECIES_CUSTOM || pref.species == SPECIES_XENOCHIMERA)
 		var/datum/species/custom/CS = character.species
 		var/S = pref.custom_base ? pref.custom_base : "Human"
 		var/datum/species/custom/new_CS = CS.produceCopy(S, pref.pos_traits + pref.neu_traits + pref.neg_traits, character)
-
-		//Any additional non-trait settings can be applied here
-		new_CS.blood_color = pref.blood_color
-
-	if(pref.species == "Xenochimera")
-		var/datum/species/xenochimera/CS = character.species
-		var/S = pref.custom_base ? pref.custom_base : "Human"
-		var/datum/species/xenochimera/new_CS = CS.produceCopy(S, pref.pos_traits + pref.neu_traits + pref.neg_traits, character)
 
 		//Any additional non-trait settings can be applied here
 		new_CS.blood_color = pref.blood_color
@@ -98,11 +90,11 @@
 	. += "<b>Custom Species</b> "
 	. += "<a href='?src=\ref[src];custom_species=1'>[pref.custom_species ? pref.custom_species : "-Input Name-"]</a><br>"
 
-	if(pref.species == "Custom Species" || pref.species == "Xenochimera")
+	if(pref.species == SPECIES_CUSTOM || pref.species == SPECIES_XENOCHIMERA)
 		. += "<b>Icon Base: </b> "
 		. += "<a href='?src=\ref[src];custom_base=1'>[pref.custom_base ? pref.custom_base : "Human"]</a><br>"
 
-	if(pref.species == "Custom Species")
+	if(pref.species == SPECIES_CUSTOM)
 		var/points_left = pref.starting_trait_points
 		var/traits_left = pref.max_traits
 		for(var/T in pref.pos_traits + pref.neg_traits)
@@ -157,7 +149,7 @@
 
 	else if(href_list["custom_base"])
 		var/text_choice = input("Pick an icon set for your species:","Icon Base") in custom_species_bases
-		if(text_choice in playable_species)
+		if(text_choice in custom_species_bases)
 			pref.custom_base = text_choice
 		return TOPIC_REFRESH_UPDATE_PREVIEW
 

--- a/code/modules/client/preference_setup/vore/07_traits.dm
+++ b/code/modules/client/preference_setup/vore/07_traits.dm
@@ -98,16 +98,11 @@
 	. += "<b>Custom Species</b> "
 	. += "<a href='?src=\ref[src];custom_species=1'>[pref.custom_species ? pref.custom_species : "-Input Name-"]</a><br>"
 
-	if(pref.species == "Custom Species")
+	if(pref.species == "Custom Species" || pref.species == "Xenochimera")
 		. += "<b>Icon Base: </b> "
 		. += "<a href='?src=\ref[src];custom_base=1'>[pref.custom_base ? pref.custom_base : "Human"]</a><br>"
 
-	if(pref.species == "Xenochimera")
-		. += "<b>Icon Base: </b> "
-		. += "<a href='?src=\ref[src];custom_base_xenochimera=1'>[pref.custom_base ? pref.custom_base : "Human"]</a><br>"
-
 	if(pref.species == "Custom Species")
-
 		var/points_left = pref.starting_trait_points
 		var/traits_left = pref.max_traits
 		for(var/T in pref.pos_traits + pref.neg_traits)
@@ -161,13 +156,7 @@
 		return TOPIC_REFRESH
 
 	else if(href_list["custom_base"])
-		var/text_choice = input("Pick an icon set for your species:","Icon Base") in playable_species - whitelisted_species - "Custom Species" - "Promethean"
-		if(text_choice in playable_species)
-			pref.custom_base = text_choice
-		return TOPIC_REFRESH_UPDATE_PREVIEW
-
-	else if(href_list["custom_base_xenochimera"])
-		var/text_choice = input("Pick an icon set for your species:","Icon Base") in playable_species - whitelisted_species - "Custom Species" - "Promethean" + "Xenochimera"
+		var/text_choice = input("Pick an icon set for your species:","Icon Base") in custom_species_bases
 		if(text_choice in playable_species)
 			pref.custom_base = text_choice
 		return TOPIC_REFRESH_UPDATE_PREVIEW

--- a/code/modules/mob/living/carbon/human/species/station/blank_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/blank_vr.dm
@@ -7,7 +7,7 @@
 	var/trashcan = 0 //It's always sunny in the wrestling ring.
 
 /datum/species/custom
-	name = "Custom Species"
+	name = SPECIES_CUSTOM
 	name_plural = "Custom"
 	var/base_species = "Human"
 


### PR DESCRIPTION
Fixes #3478 

Prevents you from picking 'Custom Species' as an icon base.