### PR TITLE
Make farmbots fill 10x faster

### DIFF
--- a/code/modules/mob/living/bot/farmbot.dm
+++ b/code/modules/mob/living/bot/farmbot.dm
@@ -221,7 +221,7 @@
 
 		busy = 1
 		while(do_after(src, 10) && tank.reagents.total_volume < tank.reagents.maximum_volume)
-			tank.reagents.add_reagent("water", 10)
+			tank.reagents.add_reagent("water", 100) //VOREStation Edit
 			if(prob(5))
 				playsound(loc, 'sound/effects/slosh.ogg', 25, 1)
 


### PR DESCRIPTION
Fixes #3476 

Farmbots now fill 100 at a time, not 10.