### PR TITLE
Drastically reduce Virgo 2 mob respawn count

### DIFF
--- a/maps/tether/submaps/aerostat/_aerostat.dm
+++ b/maps/tether/submaps/aerostat/_aerostat.dm
@@ -61,7 +61,7 @@
 	faction = "aerostat_inside"
 	atmos_comp = TRUE
 	prob_spawn = 100
-	prob_fall = 10
+	prob_fall = 50
 	guard = 20
 	mobs_to_pick_from = list(
 		/mob/living/simple_animal/hostile/hivebot/range = 3,
@@ -75,7 +75,7 @@
 	faction = "aerostat_surface"
 	atmos_comp = TRUE
 	prob_spawn = 100
-	prob_fall = 10
+	prob_fall = 50
 	guard = 20
 	mobs_to_pick_from = list(
 		/mob/living/simple_animal/hostile/jelly = 3,


### PR DESCRIPTION
Instead of respawning up to 10 times from each spawner if you're unlucky, Virgo 2 air and surface mobs will respawn a maximum of 2 times (the 2nd time is a 50/50 chance, they may not spawn again at all).

This should make them vastly easier to clean out of both the aerostat and surface.