### PR TITLE
Fixxes a few issues with the public gardens

### DIFF
--- a/maps/tether/tether-01-surface1.dmm
+++ b/maps/tether/tether-01-surface1.dmm
@@ -27363,6 +27363,12 @@
 /obj/effect/floor_decal/corner/lightgrey/border{
 	dir = 9
 	},
+/obj/machinery/firealarm{
+	dir = 2;
+	layer = 3.3;
+	pixel_x = 0;
+	pixel_y = 26
+	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/public_garden_one)
 "dbc" = (
@@ -27780,6 +27786,17 @@
 	pixel_x = -24
 	},
 /turf/simulated/floor/tiled/techfloor,
+/area/maintenance/lower/public_garden_maintenence)
+"lCL" = (
+/obj/structure/catwalk,
+/obj/machinery/alarm{
+	breach_detection = 0;
+	dir = 8;
+	pixel_x = 25;
+	pixel_y = 0;
+	report_danger_level = 0
+	},
+/turf/simulated/floor/plating,
 /area/maintenance/lower/public_garden_maintenence)
 "lFg" = (
 /obj/structure/grille,
@@ -28210,6 +28227,10 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/lower/first_west)
+"thL" = (
+/obj/structure/sign/poster,
+/turf/simulated/wall,
+/area/tether/surfacebase/public_garden)
 "tzX" = (
 /obj/structure/grille,
 /turf/simulated/floor/tiled/techmaint,
@@ -28290,6 +28311,19 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/public_garden_one)
+"uLU" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden)
 "vkK" = (
 /turf/simulated/wall,
 /area/maintenance/lower/public_garden_maintenence)
@@ -32357,7 +32391,7 @@ aah
 vkK
 pxT
 aRs
-pxT
+lCL
 pxT
 pxT
 pxT
@@ -32860,7 +32894,7 @@ cBB
 hvW
 cBB
 cBB
-cBB
+uLU
 qyw
 qpB
 vHS
@@ -32975,7 +33009,7 @@ wFT
 dbc
 bsU
 wIm
-gXh
+thL
 kuC
 xED
 btx

--- a/maps/tether/tether-02-surface2.dmm
+++ b/maps/tether/tether-02-surface2.dmm
@@ -17932,7 +17932,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/space,
+/turf/simulated/floor/plating,
 /area/gateway)
 "Sy" = (
 /obj/structure/sign/poster,
@@ -18249,6 +18249,28 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/public_garden_two)
+"ZO" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	icon_state = "map-scrubbers";
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/plating,
+/area/gateway)
 "ZT" = (
 /obj/structure/closet/crate/bin{
 	anchored = 1;
@@ -22800,7 +22822,7 @@ ae
 bz
 bX
 cm
-bX
+ZO
 bX
 cm
 bX


### PR DESCRIPTION
Adds missing fire alarms to the entry hallway area.

Also connects the juice bar and gardens to the power grid and pipes because that accidentally got undone.

ALSO makes it so there's not **SPACE** under the engineering door in the juice bar's maintenance.

Also adds an air alarm to the public gardens z1 maintenence, due to its proximity to the edge of the rocks.

Also adds a poster to the entry hallway wall which had originally been meant to be there.