### PR TITLE
Metabolism trait adjustments.

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
@@ -1,22 +1,22 @@
 /datum/trait/metabolism_up
 	name = "Fast Metabolism"
-	desc = "You process ingested and injected reagents faster, but get hungry faster."
+	desc = "You process ingested and injected reagents faster, but get hungry faster (Teshari speed)."
 	cost = 0
-	var_changes = list("metabolic_rate" = 1.2, "hunger_factor" = 0.2, "metabolism" = 0.005) //Teshari level
+	var_changes = list("metabolic_rate" = 1.2, "hunger_factor" = 0.2, "metabolism" = 0.06) // +20% rate and 4x hunger (Teshari level)
 	excludes = list(/datum/trait/metabolism_down, /datum/trait/metabolism_apex)
 
 /datum/trait/metabolism_down
 	name = "Slow Metabolism"
 	desc = "You process ingested and injected reagents slower, but get hungry slower."
 	cost = 0
-	var_changes = list("metabolic_rate" = 0.8, "hunger_factor" = 0.04, "metabolism" = 0.001)
+	var_changes = list("metabolic_rate" = 0.8, "hunger_factor" = 0.04, "metabolism" = 0.0012) // -20% of default.
 	excludes = list(/datum/trait/metabolism_up, /datum/trait/metabolism_apex)
 
 /datum/trait/metabolism_apex
 	name = "Apex Metabolism"
-	desc = "Finally a proper excuse for your predatory actions. Also makes you process reagents faster but that's totally irrelevant. May cause excessive immersions with large/taur characters. Not recommended for efficient law-abiding workers or eco-aware NIF users."
+	desc = "Finally a proper excuse for your predatory actions. Essentially doubles the fast trait rates. Good for characters with big appetites."
 	cost = 0
-	var_changes = list("metabolic_rate" = 1.5, "hunger_factor" = 0.3, "metabolism" = 0.0075)
+	var_changes = list("metabolic_rate" = 1.4, "hunger_factor" = 0.4, "metabolism" = 0.012) // +40% rate and 8x hunger (Double Teshari)
 	excludes = list(/datum/trait/metabolism_up, /datum/trait/metabolism_down)
 
 /datum/trait/cold_discomfort


### PR DESCRIPTION
-Adjusts the metabolism traits some more to get them in line with some sort of numerical logic with better documentation.
-Slow metabolism is now -20% of default on every field.
-Fast metabolism now gives +20% processing rate and hunger/WG are both scaled to Teshari level (4x default)
-Apex metabolism stats now scaled to double the fast metabolism (+40%, 8x, still lower than pre-nerf). Also restores consistency with apex hunger/WG ratio that got bloopered in the lazy nerf. (gains left way too fast compared to hunger nerf. Gael just gained 4 pounds within overeat duration of like ~15min lmao)