### PR TITLE
Final LeMat Fix

### DIFF
--- a/code/modules/vore/fluffstuff/custom_guns_vr.dm
+++ b/code/modules/vore/fluffstuff/custom_guns_vr.dm
@@ -352,6 +352,10 @@
 	name = "Modified LeMat"
 	desc = "The LeMat Revolver is a 9 shot revolver with a secondary firing barrel for loading shotgun shells. Uses .38-Special and 12g rounds depending on the barrel. This one appears to have had it's secondary barrel sealed off and looks to be in pristine condition. Either it's brand new, or its owner takes very good care of it."
 	icon_state = "lemat"
+	max_shells = 9
+	caliber = ".38"
+	ammo_type = /obj/item/ammo_casing/a38
+	preserve_item = FALSE
 
 //////////////////// Energy Weapons ////////////////////
 


### PR DESCRIPTION
So turns out a lot of the stuff I was told to remove was actually necessary in the end since my nine-shot .38 LeMat ended up being a six-shot .357 LeMat. Also makes it so the cryo consoles don't store the revolver. No I'm not listening to people saying to change it anymore, no I'm not ever messing with this code ever again. It _finally_ works as intended. On the upside, it didn't inherit the 'projectile_type = /obj/item/projectile/bullet/pistol/strong' from /obj/item/weapon/gun/projectile/revolver which would've given me a gun that does about 60 damage a shot, so I can keep playing until this merges since it's just a revolver that takes .357 ammo but does .38 damage. This whole nightmare would've been avoided if I just ignored the 'advice' and orders from the very start.