### PR TITLE
Adds a sneaky room to Z2 bar maint

### DIFF
--- a/maps/tether/tether-02-surface2.dmm
+++ b/maps/tether/tether-02-surface2.dmm
@@ -17686,6 +17686,32 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/public_garden_two)
+"IX" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/machinery/door/firedoor,
+/obj/structure/window/reinforced{
+	dir = 8;
+	health = 1e+006
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/lower/bar)
+"IY" = (
+/turf/simulated/floor/outdoors/dirt/virgo3b,
+/area/tether/surfacebase/outside/outside2)
+"Jx" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/corner_techfloor_grid{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/lower/bar)
 "Kj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -17722,6 +17748,12 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/public_garden_two)
+"Lp" = (
+/obj/structure/frame{
+	anchored = 1
+	},
+/turf/simulated/floor,
+/area/maintenance/lower/bar)
 "LG" = (
 /obj/effect/floor_decal/borderfloor/corner{
 	dir = 1
@@ -17731,12 +17763,31 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/public_garden_two)
+"LI" = (
+/turf/simulated/floor/outdoors/grass/sif/virgo3b,
+/area/tether/surfacebase/outside/outside2)
+"LM" = (
+/obj/structure/frame{
+	anchored = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/lower/bar)
 "Mf" = (
 /obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/firecloset/full/double,
 /turf/simulated/floor/plating,
 /area/tether/surfacebase/public_garden_two)
+"Mv" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/corner_techfloor_grid{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner_techfloor_grid{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/lower/bar)
 "MX" = (
 /obj/structure/table/standard{
 	name = "plastic table frame"
@@ -17749,6 +17800,20 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/public_garden_two)
+"MZ" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/machinery/door/firedoor,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8;
+	health = 1e+006
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/lower/bar)
 "Na" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 9
@@ -17776,6 +17841,12 @@
 /obj/structure/sign/nanotrasen,
 /turf/simulated/wall,
 /area/tether/surfacebase/public_garden_two)
+"NY" = (
+/obj/structure/symbol/gu,
+/turf/simulated/wall{
+	can_open = 1
+	},
+/area/maintenance/lower/bar)
 "NZ" = (
 /obj/structure/stairs/south,
 /obj/structure/window/reinforced{
@@ -17805,6 +17876,11 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/public_garden_two)
+"ON" = (
+/obj/structure/closet,
+/obj/random/maintenance/clean,
+/turf/simulated/floor,
+/area/maintenance/lower/bar)
 "OQ" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -17821,6 +17897,17 @@
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/plating,
 /area/tether/surfacebase/public_garden_two)
+"OZ" = (
+/obj/effect/floor_decal/corner_techfloor_grid{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/lower/bar)
+"Pd" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/weapon/newspaper,
+/turf/simulated/floor,
+/area/maintenance/lower/bar)
 "Po" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -17836,6 +17923,9 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/public_garden_two)
+"Py" = (
+/turf/simulated/floor,
+/area/maintenance/lower/bar)
 "PC" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/effect/floor_decal/borderfloor/corner{
@@ -17846,6 +17936,29 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/public_garden_two)
+"PI" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/machinery/door/firedoor,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8;
+	health = 1e+006
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/lower/bar)
+"PL" = (
+/obj/effect/floor_decal/corner_techfloor_grid{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/lower/bar)
 "PP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -18018,6 +18131,18 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/public_garden_two)
+"UJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/alarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -22;
+	pixel_y = 0
+	},
+/obj/structure/table/rack,
+/obj/random/maintenance/clean,
+/turf/simulated/floor,
+/area/maintenance/lower/bar)
 "UX" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -18054,6 +18179,10 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/public_garden_two)
+"Vx" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor,
+/area/maintenance/lower/bar)
 "VM" = (
 /obj/machinery/reagentgrinder,
 /obj/structure/table/standard{
@@ -18067,6 +18196,9 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/public_garden_two)
+"VR" = (
+/turf/simulated/floor/outdoors/rocks/virgo3b,
+/area/tether/surfacebase/outside/outside2)
 "Wr" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -18085,6 +18217,14 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/public_garden_two)
+"Xc" = (
+/obj/structure/dogbed,
+/obj/effect/floor_decal/corner_techfloor_grid{
+	dir = 10
+	},
+/mob/living/simple_animal/lizard,
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/lower/bar)
 "Xd" = (
 /obj/machinery/light{
 	dir = 1
@@ -18149,6 +18289,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/tether/surfacebase/public_garden_two)
+"Ye" = (
+/obj/structure/frame/computer,
+/turf/simulated/floor,
+/area/maintenance/lower/bar)
 "Yq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/borderfloor{
@@ -18234,6 +18378,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/public_garden_two)
+"Zs" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/corner_techfloor_grid{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/lower/bar)
 "Zt" = (
 /obj/effect/floor_decal/borderfloor/corner,
 /obj/effect/floor_decal/corner/lime/bordercorner,
@@ -33971,12 +34122,12 @@ kR
 du
 ee
 du
-ac
-ac
-ac
-ac
-ac
-ac
+LM
+Xc
+Ye
+UJ
+PL
+LM
 rg
 rg
 rg
@@ -34113,13 +34264,13 @@ kR
 du
 ee
 du
-ac
-ac
-ac
-ac
-ac
-ac
-ac
+LM
+Jx
+Ye
+Pd
+Zs
+LM
+du
 ac
 ac
 ac
@@ -34254,18 +34405,18 @@ du
 du
 du
 ee
+NY
+Py
+iu
+Mv
+Mv
+iu
+ON
 du
 ac
 ac
 ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
+VR
 ac
 ac
 ac
@@ -34397,17 +34548,17 @@ ee
 ee
 ee
 du
+LM
+Jx
+Lp
+Lp
+Zs
+LM
+du
+IY
 ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
+VR
+VR
 ac
 ac
 ac
@@ -34539,16 +34690,16 @@ du
 du
 du
 du
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
+LM
+OZ
+Py
+Vx
+Zs
+LM
+du
+IY
+IY
+IY
 ac
 ac
 ac
@@ -34680,16 +34831,16 @@ ac
 ac
 ac
 ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
+du
+PI
+du
+IX
+MZ
+du
+PI
+du
+IY
+IY
 ac
 ac
 ac
@@ -34821,17 +34972,17 @@ ac
 ac
 ac
 ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
+VR
+VR
+IY
+IY
+IY
+IY
+LI
+LI
+IY
+IY
+LI
 ac
 ac
 ac
@@ -34964,16 +35115,16 @@ jM
 jM
 jM
 jM
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
+IY
+LI
+LI
+LI
+LI
+LI
+LI
+LI
+LI
+LI
 ac
 ac
 ac
@@ -35106,16 +35257,16 @@ jM
 jM
 jM
 jM
-ac
-ac
-ac
-ac
-ac
-ac
+LI
+LI
+LI
+LI
+LI
+LI
 jM
-ac
-ac
-ac
+LI
+LI
+LI
 jM
 jM
 jM
@@ -35248,9 +35399,9 @@ jM
 jM
 jM
 jM
-ac
-ac
-ac
+LI
+LI
+LI
 jM
 jM
 jM

--- a/maps/tether/tether-02-surface2.dmm
+++ b/maps/tether/tether-02-surface2.dmm
@@ -17686,22 +17686,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/public_garden_two)
-"IX" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/machinery/door/firedoor,
-/obj/structure/window/reinforced{
-	dir = 8;
-	health = 1e+006
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/lower/bar)
 "IY" = (
 /turf/simulated/floor/outdoors/dirt/virgo3b,
 /area/tether/surfacebase/outside/outside2)
@@ -17800,20 +17784,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/public_garden_two)
-"MZ" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/machinery/door/firedoor,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 8;
-	health = 1e+006
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/lower/bar)
 "Na" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 9
@@ -17940,16 +17910,8 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
 /obj/machinery/door/firedoor,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 8;
-	health = 1e+006
-	},
 /obj/structure/window/reinforced{
 	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/lower/bar)
@@ -34834,8 +34796,8 @@ ac
 du
 PI
 du
-IX
-MZ
+PI
+PI
 du
 PI
 du


### PR DESCRIPTION
Adds a dark, sneaky room to bar maintenence to sort of give a purpose to that little pointless side hallway.

Contains a bunch of machine frames, and 2 computer frames (they don't look like computer frames in DM sorry)

Also contains 1 pet bed, 1 lizard, and 1 newspaper.

![fuel processing](https://user-images.githubusercontent.com/24854483/39201612-8e6f108a-47bd-11e8-995e-2d36e4b073e5.png)

There is a false wall marked by a strange symbol on the north wall to serve as the intended entrance.

The thinking behind this one was that it was meant to be a sort of substation for processing air from the moon's atmosphere into usable starship fuel. The machines were stripped down though in favor of another option, or perhaps revisiting at a later date, and the room was sealed off. Since then, _someone_ has been slacking off in there! They even have a pet lizard.

For your consideration!