### PR TITLE
Removed underdark apc from alarm consoles

### DIFF
--- a/maps/tether/submaps/tether_underdark.dmm
+++ b/maps/tether/submaps/tether_underdark.dmm
@@ -7,7 +7,8 @@
 	dir = 1;
 	name = "north bump";
 	pixel_x = 0;
-	pixel_y = 24
+	pixel_y = 24;
+	alarms_hidden = TRUE
 	},
 /turf/simulated/floor/outdoors/dirt/virgo3b,
 /area/mine/explored/underdark)


### PR DESCRIPTION
Because screw that eternal source of flashing red.