### PR TITLE
Trades an antibody scanner for a health analyzer

### DIFF
--- a/maps/tether/tether-06-station2.dmm
+++ b/maps/tether/tether-06-station2.dmm
@@ -17874,8 +17874,8 @@
 /area/maintenance/station/sec_lower)
 "Os" = (
 /obj/structure/table/glass,
-/obj/item/device/antibody_scanner,
 /obj/item/clothing/accessory/stethoscope,
+/obj/item/device/healthanalyzer,
 /turf/simulated/floor/tiled/white,
 /area/maintenance/station/sec_lower)
 "OA" = (


### PR DESCRIPTION
I copied what I thought was a health analyzer from virology to put into ghetto surgery.

But it was accidentally an antibody scanner. This fixxes that.