### PR TITLE
Removes carp burgers from burger crates, replaces with fries

### DIFF
--- a/code/datums/supplypacks/hospitality_vr.dm
+++ b/code/datums/supplypacks/hospitality_vr.dm
@@ -5,7 +5,7 @@
 			/obj/item/weapon/reagent_containers/food/snacks/cheeseburger,
 			/obj/item/weapon/reagent_containers/food/snacks/jellyburger,
 			/obj/item/weapon/reagent_containers/food/snacks/tofuburger,
-			/obj/item/weapon/reagent_containers/food/snacks/fishburger
+			/obj/item/weapon/reagent_containers/food/snacks/fries
 			)
 	name = "Burger crate"
 	cost = 25


### PR DESCRIPTION
The fast food crate we added for the specific purpose of allowing people to eat something other than pizzas or vendor food when the service department is unstaffed is now filled only with things that are useful for that specific purpose.