### PR TITLE
Xenochimera fixes post-cleanup

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/station_special_abilities_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_special_abilities_vr.dm
@@ -43,6 +43,7 @@
 				else
 					to_chat(src, "<span class='notice'>Consciousness begins to stir as your new body awakens, ready to hatch.</span>")
 					verbs |= /mob/living/carbon/human/proc/hatch
+					reviving = REVIVING_DONE
 
 		//Dead until nutrition injected.
 		else
@@ -60,11 +61,13 @@
 			if(stat != DEAD)
 				to_chat(src, "<span class='notice'>Consciousness begins to stir as your new body awakens, ready to hatch..</span>")
 				verbs |= /mob/living/carbon/human/proc/hatch
+				reviving = REVIVING_DONE
 
 			//Was alive, now dead
 			else if(hasnutriment())
 				to_chat(src, "<span class='notice'>Consciousness begins to stir as your new body awakens, ready to hatch..</span>")
 				verbs |= /mob/living/carbon/human/proc/hatch
+				reviving = REVIVING_DONE
 
 			//Dead until nutrition injected.
 			else
@@ -96,6 +99,7 @@
 			//Check again for nutriment (necessary?)
 			if(hasnutriment())
 				chimera_hatch()
+				adjustBrainLoss(10) // if they're reviving from dead, they come back with 10 brainloss on top of whatever's unhealed.
 				visible_message("<span class='danger'><p><font size=4>The lifeless husk of [src] bursts open, revealing a new, intact copy in the pool of viscera.</font></p></span>") //Bloody hell...
 				return
 
@@ -116,7 +120,7 @@
 
 	//Modify and record values (half nutrition and braindamage)
 	var/old_nutrition = nutrition * 0.5
-	var/braindamage = (brainloss * 0.5) + 10 //A little damage from the process.
+	var/braindamage = (brainloss * 0.5) //Can only heal half brain damage.
 
 	//I did have special snowflake code, but this is easier.
 	revive()

--- a/code/modules/mob/living/carbon/human/species/station/station_special_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_special_vr.dm
@@ -102,7 +102,7 @@
 	if(!feral && (hungry || shock || jittery))
 
 		// If they're hungry, give nag messages (when not bellied)
-		if(H.nutrition >= 100 && prob(0.5) && !ismob(H.loc))
+		if(H.nutrition >= 100 && prob(0.5) && !isbelly(H.loc))
 			switch(H.nutrition)
 				if(150 to 200)
 					to_chat(H,"<span class='info'>You feel rather hungry. It might be a good idea to find some some food...</span>")
@@ -110,7 +110,7 @@
 					to_chat(H,"<span class='warning'>You feel like you're going to snap and give in to your hunger soon... It would be for the best to find some [pick("food","prey")] to eat...</span>")
 
 		// Going feral due to hunger
-		else if(H.nutrition < 100)
+		else if(H.nutrition < 100 && !isbelly(H.loc))
 			to_chat(H,"<span class='danger'><big>Something in your mind flips, your instincts taking over, no longer able to fully comprehend your surroundings as survival becomes your primary concern - you must feed, survive, there is nothing else. Hunt. Eat. Hide. Repeat.</big></span>")
 			log_and_message_admins("has gone feral due to hunger.", H)
 			feral = 5
@@ -190,8 +190,8 @@
 			//This is basically the 'lite' version of the below block.
 			var/list/nearby = H.living_mobs(world.view)
 
-			//Not in the dark.
-			if(!darkish)
+			//Not in the dark and out in the open.
+			if(!darkish && isturf(H.loc))
 
 				//Always handle feral if nobody's around and not in the dark.
 				if(!nearby.len)
@@ -204,8 +204,8 @@
 			//And bail
 			return
 
-		// In the darkness. No need for custom scene-protection checks as it's just an occational infomessage.
-		if(darkish)
+		// In the darkness or "hidden". No need for custom scene-protection checks as it's just an occational infomessage.
+		if(darkish || !isturf(H.loc))
 			// If hurt, tell 'em to heal up
 			if (shock)
 				to_chat(H,"<span class='info'>This place seems safe, secure, hidden, a place to lick your wounds and recover...</span>")


### PR DESCRIPTION
Mostly things that I missed or left in comments but were out-of-scope, makes it behave as it did before but with aro's far cleaner code.

- Sets REVIVING_DONE when they're ready to hatch so they're able to do so.
- Only inflicts brainloss-on-revive when they're reviving from dead.
- Being in a non-turf container (ahem) counts as "dark" for feral purposes.
- Nagmessages and feral triggers for hunger abort if they're in a belly.

Fixes #3417.