### PR TITLE
Ensure the right species are in suit cyclers

### DIFF
--- a/code/game/machinery/suit_storage_unit_vr.dm
+++ b/code/game/machinery/suit_storage_unit_vr.dm
@@ -1,2 +1,19 @@
 /obj/machinery/suit_cycler
-	species = list("Human","Skrell","Unathi","Tajara", "Teshari", "Nevrean", "Akula", "Sergal", "Flatland Zorren", "Highlander Zorren", "Vulpkanin", "Promethean", "Xenomorph Hybrid", "Xenochimera","Vasilissan", "Rapala") //Added xenochimera while I was at it. Someone put in an issue about it.
+	species = list(
+		SPECIES_HUMAN,
+		SPECIES_SKRELL,
+		SPECIES_UNATHI,
+		SPECIES_TAJ,
+		SPECIES_TESHARI,
+		SPECIES_AKULA,
+		SPECIES_ALRAUNE,
+		SPECIES_NEVREAN,
+		SPECIES_RAPALA,
+		SPECIES_SERGAL,
+		SPECIES_VASILISSAN,
+		SPECIES_VULPKANIN,
+		SPECIES_XENOCHIMERA,
+		SPECIES_XENOHYBRID,
+		SPECIES_ZORREN_FLAT,
+		SPECIES_ZORREN_HIGH
+	)


### PR DESCRIPTION
Fixes #3582 

Basically removes promethean, protean, because you need to customize the suit to your current species shape, not just your imaginary 'base' species.

~Someone should really do this for Xenochimera too @Screemonster ;o~

Actually it looks like this doesn't need to be messed with for Xenochimera since they have the proper get_bodytype() return on species.