### PR TITLE
Redo cryo item storage

### DIFF
--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -94,8 +94,8 @@
 	dat += "<a href='?src=\ref[src];log=1'>View storage log</a>.<br>"
 	if(allow_items)
 		dat += "<a href='?src=\ref[src];view=1'>View objects</a>.<br>"
-		dat += "<a href='?src=\ref[src];item=1'>Recover object</a>.<br>"
-		dat += "<a href='?src=\ref[src];allitems=1'>Recover all objects</a>.<br>"
+		//dat += "<a href='?src=\ref[src];item=1'>Recover object</a>.<br>" //VOREStation Removal - Just log them.
+		//dat += "<a href='?src=\ref[src];allitems=1'>Recover all objects</a>.<br>" //VOREStation Removal
 
 	user << browse(dat, "window=cryopod_console")
 	onclose(user, "cryopod_console")
@@ -122,8 +122,10 @@
 		if(!allow_items) return
 
 		var/dat = "<b>Recently stored objects</b><br/><hr/><br/>"
-		for(var/obj/item/I in frozen_items)
-			dat += "[I.name]<br/>"
+		//VOREStation Edit Start
+		for(var/I in frozen_items)
+			dat += "[I]<br/>"
+		//VOREStation Edit End
 		dat += "<hr/>"
 
 		user << browse(dat, "window=cryoitems")
@@ -429,12 +431,14 @@
 		if(!preserve)
 			qdel(W)
 		else
+			log_special_item(W,to_despawn) //VOREStation Add
+			/* VOREStation Removal - We do our own thing.
 			if(control_computer && control_computer.allow_items)
 				control_computer.frozen_items += W
 				W.loc = control_computer //VOREStation Edit
 			else
 				W.forceMove(src.loc)
-
+			VOREStation Removal End */
 	for(var/obj/structure/B in items)
 		if(istype(B,/obj/structure/bed))
 			qdel(B)

--- a/code/game/machinery/cryopod_vr.dm
+++ b/code/game/machinery/cryopod_vr.dm
@@ -32,3 +32,29 @@
 	name = "residential oversight console"
 	desc = "An interface between visitors and the residential oversight systems tasked with keeping track of all visitors in the residential district."
 */
+
+/obj/machinery/cryopod/proc/log_special_item(var/atom/movable/item,var/mob/to_despawn)
+	ASSERT(item && to_despawn)
+	
+	var/loaded_from_key
+	var/char_name = to_despawn.name
+	var/item_name = item.name
+	
+	// Best effort key aquisition
+	if(ishuman(to_despawn))
+		var/mob/living/carbon/human/H = to_despawn
+		if(H.original_player)
+			loaded_from_key = H.original_player
+	
+	if(!loaded_from_key && to_despawn.mind && to_despawn.mind.loaded_from_ckey)
+		loaded_from_key = to_despawn.mind.loaded_from_ckey
+	
+	else
+		loaded_from_key = "INVALID"
+	
+	// Log to harrass them later
+	log_game("CRYO [loaded_from_key]/([to_despawn.name]) cryo'd with [item_name] ([item.type])")
+	qdel(item)
+
+	if(control_computer && control_computer.allow_items)
+		control_computer.frozen_items += "[item_name] ([char_name])"


### PR DESCRIPTION
Fixes #2682, Fixes #2610

Cryo no longer stores any items, only logs for admin use and for player use who cryo'd with what 'important' items.