### PR TITLE
Ports 'fake' SSAO from /tg/ as a preference

### DIFF
--- a/code/__defines/lighting.dm
+++ b/code/__defines/lighting.dm
@@ -73,3 +73,6 @@
 #define LIGHT_COLOR_SLIME_LAMP "#AFC84B" //Weird color, between yellow and green, very slimy. rgb(175, 200, 75)
 #define LIGHT_COLOR_TUNGSTEN   "#FAE1AF" //Extremely diluted yellow, close to skin color (for some reason). rgb(250, 225, 175)
 #define LIGHT_COLOR_HALOGEN    "#F0FAFA" //Barely visible cyan-ish hue, as the doctor prescribed. rgb(240, 250, 250)
+
+//Fake ambient occlusion filter
+#define AMBIENT_OCCLUSION filter(type="drop_shadow", x=0, y=-2, size=4, border=4, color="#04080FAA")

--- a/code/__defines/mobs.dm
+++ b/code/__defines/mobs.dm
@@ -299,7 +299,11 @@
 
 #define VIS_MESONS			18
 
-#define VIS_COUNT			18 //Must be highest number from above.
+#define VIS_TURFS			19
+#define VIS_OBJS			20
+#define VIS_MOBS			21
+
+#define VIS_COUNT			21 //Must be highest number from above.
 
 //Some mob icon layering defines
 #define BODY_LAYER		-100

--- a/code/__defines/mobs_vr.dm
+++ b/code/__defines/mobs_vr.dm
@@ -1,13 +1,13 @@
 #undef VIS_COUNT
 
-#define VIS_CH_STATUS_R		19
-#define VIS_CH_HEALTH_VR	20
-#define VIS_CH_BACKUP		21
-#define VIS_CH_VANTAG		22
+#define VIS_CH_STATUS_R		22
+#define VIS_CH_HEALTH_VR	23
+#define VIS_CH_BACKUP		24
+#define VIS_CH_VANTAG		25
 
-#define VIS_AUGMENTED		23
+#define VIS_AUGMENTED		26
 
-#define VIS_COUNT			23
+#define VIS_COUNT			26
 
 //Protean organs
 #define O_ORCH		"orchestrator"

--- a/code/modules/client/preference_setup/global/setting_datums.dm
+++ b/code/modules/client/preference_setup/global/setting_datums.dm
@@ -193,6 +193,20 @@ var/list/_client_preferences_by_type
 	enabled_description = "Fancy"
 	disabled_description = "Plain"
 
+/datum/client_preference/ambient_occlusion
+	description = "Fake Ambient Occlusion"
+	key = "AMBIENT_OCCLUSION_PREF"
+	enabled_by_default = FALSE
+	enabled_description = "On"
+	disabled_description = "Off"
+
+/datum/client_preference/ambient_occlusion/toggled(var/mob/preference_mob, var/enabled)
+	. = ..()
+	if(preference_mob && preference_mob.plane_holder)
+		var/datum/plane_holder/PH = preference_mob.plane_holder
+		PH.set_ao(VIS_OBJS, enabled)
+		PH.set_ao(VIS_MOBS, enabled)
+
 /********************
 * Staff Preferences *
 ********************/

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -56,6 +56,11 @@
 	client.screen += plane_holder.plane_masters
 	recalculate_vis()
 
+	// AO support
+	var/ao_enabled = client.is_preference_enabled(/datum/client_preference/ambient_occlusion)
+	plane_holder.set_ao(VIS_OBJS, ao_enabled)
+	plane_holder.set_ao(VIS_MOBS, ao_enabled)
+
 	//set macro to normal incase it was overriden (like cyborg currently does)
 	client.set_hotkeys_macro("macro", "hotkeymode")
 

--- a/code/modules/mob/mob_planes.dm
+++ b/code/modules/mob/mob_planes.dm
@@ -11,6 +11,8 @@
 	my_mob = this_guy
 
 	//It'd be nice to lazy init these but some of them are important to just EXIST. Like without ghost planemaster, you can see ghosts. Go figure.
+	
+	// 'Utility' planes
 	plane_masters[VIS_FULLBRIGHT] 	= new /obj/screen/plane_master/fullbright						//Lighting system (lighting_overlay objects)
 	plane_masters[VIS_LIGHTING] 	= new /obj/screen/plane_master/lighting							//Lighting system (but different!)
 	plane_masters[VIS_GHOSTS] 		= new /obj/screen/plane_master/ghosts							//Ghosts!
@@ -32,6 +34,11 @@
 	plane_masters[VIS_ADMIN3] 		= new /obj/screen/plane_master{plane = PLANE_ADMIN3}			//For admin use
 
 	plane_masters[VIS_MESONS]		= new /obj/screen/plane_master{plane = PLANE_MESONS} 			//Meson-specific things like open ceilings.
+
+	// Real tangible stuff planes
+	plane_masters[VIS_TURFS]	= new /obj/screen/plane_master{plane = TURF_PLANE; alpha = 255}
+	plane_masters[VIS_OBJS]		= new /obj/screen/plane_master{plane = OBJ_PLANE; alpha = 255}
+	plane_masters[VIS_MOBS]		= new /obj/screen/plane_master{plane = MOB_PLANE; alpha = 255}
 
 	..()
 
@@ -66,6 +73,17 @@
 		var/list/subplanes = PM.sub_planes
 		for(var/SP in subplanes)
 			set_vis(which = SP, new_alpha = new_alpha)
+
+/datum/plane_holder/proc/set_ao(var/which = null, var/enabled = FALSE)
+	ASSERT(which)
+	var/obj/screen/plane_master/PM = plane_masters[which]
+	if(!PM)
+		crash_with("Tried to set_ao [which] in plane_holder on [my_mob]!")
+	PM.set_ambient_occlusion(enabled)
+	if(PM.sub_planes)
+		var/list/subplanes = PM.sub_planes
+		for(var/SP in subplanes)
+			set_ao(SP, enabled)
 
 /datum/plane_holder/proc/alter_values(var/which = null, var/list/values = null)
 	ASSERT(which)
@@ -120,6 +138,11 @@
 	if(new_alpha != alpha)
 		new_alpha = sanitize_integer(new_alpha, 0, 255, 255)
 		alpha = new_alpha
+
+/obj/screen/plane_master/proc/set_ambient_occlusion(var/enabled = FALSE)
+	filters -= AMBIENT_OCCLUSION
+	if(enabled)
+		filters += AMBIENT_OCCLUSION
 
 /obj/screen/plane_master/proc/alter_plane_values()
 	return //Stub

--- a/html/changelogs/arokha - ssao.yml
+++ b/html/changelogs/arokha - ssao.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Arokha
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Added a 'fake SSAO' toggle to Global in character setup, ported from /tg/. Looks like drop shadows on everything."


### PR DESCRIPTION
Allows players to pick whether they want this visual feature or not. Basically adds drop-shadows to objects and stuff. It's off by default.

## Disabled (Default)
![image](https://user-images.githubusercontent.com/15028025/39833517-4034432c-5398-11e8-9e05-127a4659cbab.png)

## Enabled
![image](https://user-images.githubusercontent.com/15028025/39833522-43e5e426-5398-11e8-9a1b-7e79c8e170f1.png)
