### PR TITLE
Fixes a bunch of NIF/resleeving related issues (and a tiny otherthing i discovered during tests)

### DIFF
--- a/code/controllers/subsystems/transcore_vr.dm
+++ b/code/controllers/subsystems/transcore_vr.dm
@@ -139,10 +139,12 @@ SUBSYSTEM_DEF(transcore)
 					var/datum/nifsoft/nifsoft = N
 					nifsofts += nifsoft.type
 			MR.nif_software = nifsofts
+			MR.nif_savedata = nif.save_data.Copy()
 		else if(isnull(nif)) //Didn't pass anything, so no NIF
 			MR.nif_path = null
 			MR.nif_durability = null
 			MR.nif_software = null
+			MR.nif_savedata = null
 
 	else
 		MR = new(mind, mind.current, add_to_db = TRUE, one_time = one_time)

--- a/code/modules/mob/living/carbon/human/species/species_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/species_vr.dm
@@ -33,9 +33,10 @@
 		var/type = H.nif.type
 		var/durability = H.nif.durability
 		var/list/nifsofts = H.nif.nifsofts
+		var/list/nif_savedata = H.nif.save_data.Copy()
 		..()
 
-		var/obj/item/device/nif/nif = new type(H,durability)
+		var/obj/item/device/nif/nif = new type(H,durability,nif_savedata)
 		nif.nifsofts = nifsofts
 	else
 		..()

--- a/code/modules/nifsoft/software/13_soulcatcher.dm
+++ b/code/modules/nifsoft/software/13_soulcatcher.dm
@@ -230,6 +230,7 @@
 		if(ishuman(M))
 			var/mob/living/carbon/human/H = M
 			brainmob.dna = H.dna
+			brainmob.ooc_notes = H.ooc_notes
 			brainmob.timeofhostdeath = H.timeofdeath
 			SStranscore.m_backup(brainmob.mind,0) //It does ONE, so medical will hear about it.
 
@@ -461,6 +462,8 @@
 		if(istype(HP) && HP.nif && HP.nif.flag_check(NIF_O_SCOTHERS,NIF_FLAGS_OTHER))
 			var/datum/nifsoft/soulcatcher/SC = HP.nif.imp_check(NIF_SOULCATCHER)
 			SC.catch_mob(H)
+		else if(H.nif && H.nif.flag_check(NIF_SC_BACKUPS))
+			SStranscore.m_backup(H,0) //If dying inside a pred who lacks SC, let ours do a backup if enabled before it's gone for good.
 	else if(H.nif && H.nif.flag_check(NIF_O_SCMYSELF,NIF_FLAGS_OTHER)) //They are caught in their own NIF
 		var/datum/nifsoft/soulcatcher/SC = H.nif.imp_check(NIF_SOULCATCHER)
 		SC.catch_mob(H)

--- a/code/modules/nifsoft/software/13_soulcatcher.dm
+++ b/code/modules/nifsoft/software/13_soulcatcher.dm
@@ -462,8 +462,6 @@
 		if(istype(HP) && HP.nif && HP.nif.flag_check(NIF_O_SCOTHERS,NIF_FLAGS_OTHER))
 			var/datum/nifsoft/soulcatcher/SC = HP.nif.imp_check(NIF_SOULCATCHER)
 			SC.catch_mob(H)
-		else if(H.nif && H.nif.flag_check(NIF_SC_BACKUPS))
-			SStranscore.m_backup(H,0) //If dying inside a pred who lacks SC, let ours do a backup if enabled before it's gone for good.
 	else if(H.nif && H.nif.flag_check(NIF_O_SCMYSELF,NIF_FLAGS_OTHER)) //They are caught in their own NIF
 		var/datum/nifsoft/soulcatcher/SC = H.nif.imp_check(NIF_SOULCATCHER)
 		SC.catch_mob(H)

--- a/code/modules/resleeving/infocore_records.dm
+++ b/code/modules/resleeving/infocore_records.dm
@@ -26,6 +26,7 @@
 	var/nif_path
 	var/nif_durability
 	var/list/nif_software
+	var/list/nif_savedata = list()
 
 	var/one_time = FALSE
 
@@ -42,7 +43,7 @@
 	cryo_at = 0
 
 	//Mental stuff the game doesn't keep mentally
-	if(istype(M))
+	if(istype(M) || istype(M,/mob/living/carbon/brain/caught_soul))
 		id_gender = M.identifying_gender
 		languages = M.languages.Copy()
 		mind_oocnotes = M.ooc_notes
@@ -55,6 +56,7 @@
 					var/datum/nifsoft/nifsoft = N
 					nifsofts += nifsoft.type
 			nif_software = nifsofts
+			nif_savedata = M.nif.save_data.Copy()
 
 	last_update = world.time
 

--- a/code/modules/resleeving/machines.dm
+++ b/code/modules/resleeving/machines.dm
@@ -529,6 +529,7 @@
 		var/obj/item/device/nif/nif = new MR.nif_path(occupant,MR.nif_durability)
 		for(var/path in MR.nif_software)
 			new path(nif)
+		nif.durability = MR.nif_durability //Restore backed up durability as the line above forces reinstall wear for each soft.
 
 	// If it was a custom sleeve (not owned by anyone), update namification sequences
 	if(!occupant.original_player)

--- a/code/modules/resleeving/machines.dm
+++ b/code/modules/resleeving/machines.dm
@@ -526,7 +526,7 @@
 
 	//Re-supply a NIF if one was backed up with them.
 	if(MR.nif_path)
-		var/obj/item/device/nif/nif = new MR.nif_path(occupant,,MR.nif_savedata)
+		var/obj/item/device/nif/nif = new MR.nif_path(occupant,null,MR.nif_savedata)
 		for(var/path in MR.nif_software)
 			new path(nif)
 		nif.durability = MR.nif_durability //Restore backed up durability after restoring the softs.

--- a/code/modules/resleeving/machines.dm
+++ b/code/modules/resleeving/machines.dm
@@ -526,10 +526,10 @@
 
 	//Re-supply a NIF if one was backed up with them.
 	if(MR.nif_path)
-		var/obj/item/device/nif/nif = new MR.nif_path(occupant,MR.nif_durability)
+		var/obj/item/device/nif/nif = new MR.nif_path(occupant,,MR.nif_savedata)
 		for(var/path in MR.nif_software)
 			new path(nif)
-		nif.durability = MR.nif_durability //Restore backed up durability as the line above forces reinstall wear for each soft.
+		nif.durability = MR.nif_durability //Restore backed up durability after restoring the softs.
 
 	// If it was a custom sleeve (not owned by anyone), update namification sequences
 	if(!occupant.original_player)

--- a/code/modules/vore/eating/contaminate_vr.dm
+++ b/code/modules/vore/eating/contaminate_vr.dm
@@ -103,8 +103,10 @@ var/image/gurgled_overlay = image('icons/effects/sludgeoverlay_vr.dmi')
 	return TRUE
 
 /obj/item/weapon/holder/gurgle_contaminate(var/atom/movable/item_storage = null)
-	digest_act(item_storage)
-	return TRUE
+	if(isbelly(loc))
+		digest_act(item_storage)
+		return TRUE
+	return FALSE
 
 /obj/item/organ/gurgle_contaminate(var/atom/movable/item_storage = null)
 	digest_act(item_storage)


### PR DESCRIPTION
-Fixes resleeving forcing reinstall wear for each backed up soft-
-Seems like an oversight that's been bugging people who never brought it up before as resleeving is supposed to restore the backed up nif with the softs included, not wear it out reinstalling everything on empty secondhand nif.
-Basically just restores the backed up nif durability after restoring the nifsofts upon resleeving.

Added stuff:
-Applies the suggested durability tweak.
-Makes backups save nif examine message.
-Makes new nifs spawn with the examine message if provided upon resleeving and such. Basically the initial character spawn pref loading was the only case that wasn't resetting the message to default.
-Fixes soulcatcher backups breaking ooc notes. (Applies ooc notes from character to the brainmob before saving it. Also includes brainmobs into the formerly human exclusive backup part responsible of saving nif and ooc notes to backups.)
~~-Makes soulcatcher backup feature back up the owner if dying inside a belly of a soulcatcher lacking pred. (SC backup setting was completely voided if the pred didn't have SC themselves so your shit would be gone for good)~~

The otherthing:
-Fixes contaminate/digest_act sending holder mobs to shadow realm if holder is contained inside the equipment(storage/pockets) of a prey getting gurgled instead of the pred's gut. (As prey gear gets all contaminated at once while getting dumped in the gut, which would contaminate>digest_act the holder items prematurely during the dump and causing issues.)