### PR TITLE
Makes gurgle gains scale according to actual received damage.

### DIFF
--- a/code/modules/mob/living/silicon/robot/dogborg/dog_sleeper_vr.dm
+++ b/code/modules/mob/living/silicon/robot/dogborg/dog_sleeper_vr.dm
@@ -23,6 +23,8 @@
 	var/startdrain = 500
 	var/max_item_count = 1
 	var/gulpsound = 'sound/vore/gulp.ogg'
+	var/digest_brute = 2
+	var/digest_burn = 3
 
 /obj/item/device/dogborg/sleeper/New()
 	..()
@@ -504,9 +506,14 @@
 			if((T.status_flags & GODMODE) || !T.digestable)
 				items_preserved += T
 			else
-				T.adjustBruteLoss(2)
-				T.adjustFireLoss(3)
-				drain(-100) //20*total loss as with voreorgan stats.
+				var/old_brute = T.getBruteLoss()
+				var/old_burn = T.getFireLoss()
+				T.adjustBruteLoss(digest_brute)
+				T.adjustFireLoss(digest_burn)
+				var/actual_brute = T.getBruteLoss() - old_brute
+				var/actual_burn = T.getFireLoss() - old_burn
+				var/damage_gain = actual_brute + actual_burn
+				drain(-25 * damage_gain) //25*total loss as with voreorgan stats.
 				update_patient()
 
 		//Pick a random item to deal with (if there are any)

--- a/code/modules/vore/eating/bellymodes_vr.dm
+++ b/code/modules/vore/eating/bellymodes_vr.dm
@@ -126,18 +126,23 @@
 				continue
 
 			// Deal digestion damage (and feed the pred)
+			var/old_brute = M.getBruteLoss()
+			var/old_burn = M.getFireLoss()
 			M.adjustBruteLoss(digest_brute)
 			M.adjustFireLoss(digest_burn)
+			var/actual_brute = M.getBruteLoss() - old_brute
+			var/actual_burn = M.getFireLoss() - old_burn
+			var/damage_gain = actual_brute + actual_burn
 
 			var/offset = (1 + ((M.weight - 137) / 137)) // 130 pounds = .95 140 pounds = 1.02
 			var/difference = owner.size_multiplier / M.size_multiplier
 			if(isrobot(owner))
 				var/mob/living/silicon/robot/R = owner
-				R.cell.charge += 25*(digest_brute+digest_burn)
+				R.cell.charge += 25*damage_gain
 			if(offset) // If any different than default weight, multiply the % of offset.
-				owner.nutrition += offset*(4.5*(digest_brute+digest_burn)/difference) //4.5 nutrition points per health point. Normal same size 100+100 health prey with average weight would give 900 points if the digestion was instant. With all the size/weight offset taxes plus over time oxyloss+hunger taxes deducted with non-instant digestion, this should be enough to not leave the pred starved.
+				owner.nutrition += offset*(4.5*(damage_gain)/difference) //4.5 nutrition points per health point. Normal same size 100+100 health prey with average weight would give 900 points if the digestion was instant. With all the size/weight offset taxes plus over time oxyloss+hunger taxes deducted with non-instant digestion, this should be enough to not leave the pred starved.
 			else
-				owner.nutrition += 4.5*(digest_brute+digest_burn)/difference
+				owner.nutrition += 4.5*(damage_gain)/difference
 
 
 //////////////////////////// DM_ABSORB ////////////////////////////


### PR DESCRIPTION
-Fixes armored, synthetic, and otherwise resistant prey giving several times more nutrition than their squishy counterparts.
-They will still take longer to digest, but what would ya expect for armor, at least the gains are at the correct level now.
-Same for sleeperbellies.
-Also made sleeperbelly gurgledamages non-hardcoded vars but there's no knob for them yet.