### PR TITLE
'alangesic' -> 'analgesic'

### DIFF
--- a/maps/tether/tether_things.dm
+++ b/maps/tether/tether_things.dm
@@ -369,7 +369,7 @@ var/global/list/latejoin_tram   = list()
 
 /obj/item/weapon/reagent_containers/pill/airlock
 	name = "\'Airlock\' Pill"
-	desc = "Neutralizes toxins and provides a mild alangesic effect."
+	desc = "Neutralizes toxins and provides a mild analgesic effect."
 	icon_state = "pill2"
 
 /obj/item/weapon/reagent_containers/pill/airlock/New()


### PR DESCRIPTION
Small spelling fix -- alangesic -> analgesic on Airlock Pills.