### PR TITLE
Message send failure reflection

### DIFF
--- a/code/__defines/misc.dm
+++ b/code/__defines/misc.dm
@@ -104,7 +104,7 @@
 #define WAIT_FINISH  4
 
 // Setting this much higher than 1024 could allow spammers to DOS the server easily.
-#define MAX_MESSAGE_LEN       1024
+#define MAX_MESSAGE_LEN       2048 //VOREStation Edit - I'm not sure about "easily". It can be a little longer.
 #define MAX_PAPER_MESSAGE_LEN 6144
 #define MAX_BOOK_MESSAGE_LEN  24576
 #define MAX_RECORD_LENGTH	  24576

--- a/code/modules/mob/emote.dm
+++ b/code/modules/mob/emote.dm
@@ -11,7 +11,7 @@
 
 	var/input
 	if(!message)
-		input = sanitize(input(src,"Choose an emote to display.") as text|null)
+		input = sanitize_or_reflect(input(src,"Choose an emote to display.") as text|null, src) //VOREStation Edit - Reflect too long messages, within reason
 	else
 		input = message
 	if(input)
@@ -70,7 +70,7 @@
 
 	var/input
 	if(!message)
-		input = sanitize(input(src, "Choose an emote to display.") as text|null)
+		input = sanitize_or_reflect(input(src, "Choose an emote to display.") as text|null, src) //VOREStation Edit - Reflect too long messages, within reason
 	else
 		input = message
 

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -3,7 +3,7 @@
 	if(name != GetVoice())
 		alt_name = "(as [get_id_name("Unknown")])"
 
-	message = sanitize(message)
+	message = sanitize_or_reflect(message,src) //VOREStation Edit - Reflect too-long messages, within reason
 	..(message, alt_name = alt_name, whispering = whispering)
 
 /mob/living/carbon/human/proc/forcesay(list/append)

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -21,8 +21,8 @@
 	if(say_disabled)	//This is here to try to identify lag problems
 		usr << "<font color='red'>Speech is currently admin-disabled.</font>"
 		return
-
-	message = sanitize(message)
+	
+	message = sanitize_or_reflect(message,src) //VOREStation Edit - Reflect too-long messages (within reason)
 
 	set_typing_indicator(FALSE)
 	if(use_me)


### PR DESCRIPTION
When a post is too long to send, reflect it back to the user in the chatbox so they can copypaste it into separate messages. Also increases the message limit from 1024 to 2048. If a message is longer than 5-messages worth, it is not reflected and a warning is sent instead to avoid easily consuming bandwidth for DDOS purposes with long messages.

I'd like to add markers in the message where the posts would have been truncated but that's... complicated.

![2018-05-16_17-53-02](https://user-images.githubusercontent.com/15028025/40146260-dd858b14-5932-11e8-9810-cedb835d9479.gif)

Fixes #3046
