### PR TITLE
Nerfs the exponential infection toxloss.

### DIFF
--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -163,7 +163,7 @@ var/list/organ_cache = list()
 		infection_damage = max(0.25, 0.25 + round((germ_level - INFECTION_LEVEL_TWO)/200,0.25))
 
 	if(infection_damage)
-		owner.adjustToxLoss(infection_damage)
+		owner.adjustToxLoss(infection_damage/8) //VOREStation Edit for little more reasonable numbers. Divided by half of the average organ count to make up for the exponential spreading of the infection causing death within seconds. (Would've gone with full average but didn't wanna go that far yet.)
 
 	if (germ_level > 0 && germ_level < INFECTION_LEVEL_ONE/2 && prob(30))
 		adjust_germ_level(-antibiotics)


### PR DESCRIPTION
-Divides the toxloss output of infected organs by 8 (as half the average organ count, would've gone with full but didn't wanna go that far _yet_.)

Thing is that even _the most potent venoms_ in the world still take significantly longer to be fatal (I did my research.) than _simply getting a merely inconveniencing boo boo_ on station treated with a _non-advanced_ medkit is just preposterous on every degree imaginable. The infection math in the game is currently immediately dispensing between **0.25-5.25 toxloss _per_ infected organ _every tick_** while _every single one of the involved organs begins spreading infection to another in **exponentially growing numbers**_ as soon as the "first warning" itching phase is over. The infection levels 3 and MAX are practically obsolete and completely unreachable due to the premature death caused by mere level two infection going exponentially haywire with toxloss. Going from mere itching (level 1) to fatality before you can even type two ahelps smh.

Let's not allow _meme mechanics_ be this sort of excessively robust scenestompers in HRP.
_"It's a baymed meme hur hur deal with it."_