### PR TITLE
Cargo fixes

### DIFF
--- a/maps/tether/tether-07-station3.dmm
+++ b/maps/tether/tether-07-station3.dmm
@@ -6893,9 +6893,6 @@
 /turf/simulated/floor,
 /area/quartermaster/delivery)
 "lR" = (
-/obj/machinery/alarm{
-	pixel_y = 22
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4;
 	icon_state = "pipe-c"
@@ -8472,6 +8469,7 @@
 /obj/effect/floor_decal/corner/brown/border{
 	dir = 4
 	},
+/obj/machinery/atmospherics/unary/vent_pump/siphon/on/atmos,
 /turf/simulated/floor/tiled,
 /area/quartermaster/delivery)
 "oo" = (
@@ -8809,6 +8807,10 @@
 /obj/effect/floor_decal/corner/brown/border{
 	dir = 4
 	},
+/obj/item/weapon/packageWrap,
+/obj/item/weapon/packageWrap,
+/obj/item/weapon/packageWrap,
+/obj/machinery/atmospherics/pipe/simple/hidden/universal,
 /turf/simulated/floor/tiled,
 /area/quartermaster/delivery)
 "oU" = (
@@ -9361,24 +9363,27 @@
 /turf/simulated/floor/tiled,
 /area/quartermaster/delivery)
 "pI" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/delivery)
 "pJ" = (
 /obj/structure/table/steel,
-/obj/item/weapon/packageWrap,
-/obj/item/weapon/packageWrap,
-/obj/item/weapon/packageWrap,
-/obj/item/weapon/packageWrap,
-/obj/item/weapon/packageWrap,
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/brown/border{
 	dir = 4
+	},
+/obj/machinery/photocopier/faxmachine{
+	department = "Mailing-Room"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/delivery)
@@ -9650,6 +9655,10 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/rust,
+/obj/machinery/conveyor{
+	dir = 1;
+	id = "packageSort1"
+	},
 /turf/simulated/floor/plating,
 /area/quartermaster/delivery)
 "qn" = (
@@ -10075,9 +10084,13 @@
 /turf/simulated/floor/tiled,
 /area/quartermaster/foyer)
 "rc" = (
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /obj/machinery/hologram/holopad,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/foyer)
 "rd" = (
@@ -14764,14 +14777,8 @@
 /area/maintenance/station/cargo)
 "yz" = (
 /obj/structure/table/standard,
-/obj/item/weapon/cartridge/quartermaster{
-	pixel_x = 6;
-	pixel_y = 5
-	},
-/obj/item/weapon/cartridge/quartermaster,
-/obj/item/weapon/cartridge/quartermaster{
-	pixel_x = -4;
-	pixel_y = 7
+/obj/machinery/photocopier/faxmachine{
+	department = "Quartermaster-Office"
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/qm)
@@ -14788,6 +14795,15 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
+/obj/item/weapon/cartridge/quartermaster{
+	pixel_x = 6;
+	pixel_y = 5
+	},
+/obj/item/weapon/cartridge/quartermaster{
+	pixel_x = -4;
+	pixel_y = 7
+	},
+/obj/item/weapon/cartridge/quartermaster,
 /turf/simulated/floor/tiled,
 /area/quartermaster/qm)
 "yB" = (
@@ -22940,8 +22956,7 @@
 "Nn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 9;
-	icon_state = "intact";
-	
+	icon_state = "intact"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/station/ai)
@@ -23097,8 +23112,7 @@
 "Qi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 5;
-	icon_state = "intact";
-	
+	icon_state = "intact"
 	},
 /turf/simulated/floor,
 /area/maintenance/station/ai)
@@ -23111,8 +23125,7 @@
 "Qq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 10;
-	icon_state = "intact";
-	
+	icon_state = "intact"
 	},
 /turf/simulated/floor,
 /area/maintenance/station/ai)
@@ -23120,8 +23133,7 @@
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 10;
-	icon_state = "intact";
-	
+	icon_state = "intact"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/station/ai)

--- a/maps/tether/tether-07-station3.dmm
+++ b/maps/tether/tether-07-station3.dmm
@@ -8469,7 +8469,12 @@
 /obj/effect/floor_decal/corner/brown/border{
 	dir = 4
 	},
-/obj/machinery/atmospherics/unary/vent_pump/siphon/on/atmos,
+/obj/machinery/atmospherics/unary/vent_pump/siphon/on/atmos{
+	external_pressure_bound = 101.3;
+	external_pressure_bound_default = 101.3;
+	pressure_checks = 1;
+	pressure_checks_default = 1
+	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/delivery)
 "oo" = (


### PR DESCRIPTION
Misc fixes to cargo.
- Unfucks atmos in the mailing room
- Adds a fax machine to the QM office and Mailing room, each
- Replaces a 4 way supply and scrubber pipe with appropriate manifolds (oversight)
- Removes Redundant Air Alarm in mailing room (Fixes #3532)
- Extends disposals conveyor by one tile, to pull things that are trapped under the outlet (bodies, namely)