### PR TITLE
Reduce armor on industrial rig

### DIFF
--- a/code/modules/clothing/spacesuits/rig/suits/station_vr.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/station_vr.dm
@@ -1,3 +1,4 @@
+//Drill added for hazmat suit
 /obj/item/weapon/rig/hazmat/equipped
 	req_access = list(access_xenoarch)
 	initial_modules = list(
@@ -7,8 +8,8 @@
 		/obj/item/rig_module/device/drill //The suit has nothing to mine with otherwise.
 		)
 
+//Access restriction and seal delay, plus pat_module and rescue_pharm for medical suit
 /obj/item/weapon/rig/medical/equipped
-
 	req_access = list(access_medical)
 	seal_delay = 5
 
@@ -18,6 +19,10 @@
 		/obj/item/rig_module/pat_module,
 		/obj/item/rig_module/rescue_pharm
 		)
+
+//Armor reduction for industrial suit
+/obj/item/weapon/rig/industrial
+	armor = list(melee = 50, bullet = 10, laser = 20, energy = 15, bomb = 30, bio = 100, rad = 50)
 
 //Area allowing backpacks to be placed on rigsuits.
 /obj/item/weapon/rig/vox


### PR DESCRIPTION
Now that we hand them out like candy, they probably shouldn't have way better stats than the security and exploration armors

(Also labeled the reasons for the other things being in there while I was in there