### PR TITLE
Dogborg equipment/belly tweaks and fixes. (Ready)

### DIFF
--- a/code/modules/mob/living/silicon/robot/dogborg/dog_modules_vr.dm
+++ b/code/modules/mob/living/silicon/robot/dogborg/dog_modules_vr.dm
@@ -142,14 +142,26 @@
 	chargecost = 500
 
 /obj/item/weapon/shockpaddles/robot/hound/jumper
-	name = "paws of life"
-	icon = 'icons/mob/dogborg_vr.dmi'
-	icon_state = "defibpaddles0"
+	name = "jumper paws"
 	desc = "Zappy paws. For rebooting a full body prostetic."
-	combat = 1
-	attack_verb = list("batted", "pawed", "bopped", "whapped")
-	chargecost = 500
 	use_on_synthetic = 1
+
+/obj/item/weapon/reagent_containers/borghypo/hound
+	name = "MediHound hypospray"
+	desc = "An advanced chemical synthesizer and injection system utilizing carrier's reserves, designed for heavy-duty medical equipment."
+	charge_cost = 10
+	var/datum/matter_synth/water = null
+
+/obj/item/weapon/reagent_containers/borghypo/hound/process() //Recharges in smaller steps and uses the water reserves as well.
+	if(isrobot(loc))
+		var/mob/living/silicon/robot/R = loc
+		if(R && R.cell)
+			for(var/T in reagent_ids)
+				if(reagent_volumes[T] < volume && water.energy >= charge_cost)
+					R.cell.use(charge_cost)
+					water.use_charge(charge_cost)
+					reagent_volumes[T] = min(reagent_volumes[T] + 1, volume)
+	return 1
 
 //Tongue stuff
 /obj/item/device/dogborg/tongue
@@ -188,7 +200,14 @@
 	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 	if(user.client && (target in user.client.screen))
 		to_chat(user, "<span class='warning'>You need to take \the [target.name] off before cleaning it!</span>")
-	else if(istype(target,/obj/effect/decal/cleanable) && water.energy >= 5)
+	if(istype(target, /obj/structure/sink) || istype(target, /obj/structure/toilet)) //Dog vibes.
+		user.visible_message("[user] begins to lap up water from [target.name].", "<span class='notice'>You begin to lap up water from [target.name].</span>")
+		if(do_after (user, 50))
+			water.add_charge(50)
+	else if(water.energy < 5)
+		to_chat(user, "<span class='notice'>Your mouth feels dry.</span>")
+		return
+	else if(istype(target,/obj/effect/decal/cleanable))
 		user.visible_message("[user] begins to lick off \the [target.name].", "<span class='notice'>You begin to lick off \the [target.name]...</span>")
 		if(do_after (user, 50))
 			to_chat(user, "<span class='notice'>You finish licking off \the [target.name].</span>")
@@ -196,7 +215,7 @@
 			qdel(target)
 			var/mob/living/silicon/robot.R = user
 			R.cell.charge += 50
-	else if(istype(target,/obj/item) && water.energy >= 5)
+	else if(istype(target,/obj/item))
 		if(istype(target,/obj/item/trash))
 			user.visible_message("[user] nibbles away at \the [target.name].", "<span class='notice'>You begin to nibble away at \the [target.name]...</span>")
 			if(do_after (user, 50))
@@ -238,25 +257,14 @@
 								"<span class='userdanger'>[user] has shocked you with its tongue! You can feel the betrayal.</span>")
 			playsound(loc, 'sound/weapons/Egloves.ogg', 50, 1, -1)
 			R.cell.charge -= 666
-		else if(water.energy >= 5)
+		else
 			user.visible_message("<span class='notice'>\the [user] affectionally licks all over \the [target]'s face!</span>", "<span class='notice'>You affectionally lick all over \the [target]'s face!</span>")
 			playsound(src.loc, 'sound/effects/attackblob.ogg', 50, 1)
 			water.use_charge(5)
 			var/mob/living/carbon/human/H = target
 			if(H.species.lightweight == 1)
 				H.Weaken(3)
-			return
-	else if(istype(target, /obj/structure/window) && water.energy >= 1)
-		user.visible_message("[user] begins to lick \the [target.name] clean...", "<span class='notice'>You begin to lick \the [target.name] clean...</span>")
-		if(do_after (user, 50))
-			to_chat(user, "<span class='notice'>You clean \the [target.name].</span>")
-			water.use_charge(5)
-			target.color = initial(target.color)
-	else if(istype(target, /obj/structure/sink) || istype(target, /obj/structure/toilet)) //Dog vibes.
-		user.visible_message("[user] begins to lap up water from [target.name].", "<span class='notice'>You begin to lap up water from [target.name].</span>")
-		if(do_after (user, 50))
-			water.add_charge(100)
-	else if(water.energy >= 5)
+	else
 		user.visible_message("[user] begins to lick \the [target.name] clean...", "<span class='notice'>You begin to lick \the [target.name] clean...</span>")
 		if(do_after (user, 50))
 			to_chat(user, "<span class='notice'>You clean \the [target.name].</span>")

--- a/code/modules/mob/living/silicon/robot/dogborg/dog_sleeper_vr.dm
+++ b/code/modules/mob/living/silicon/robot/dogborg/dog_sleeper_vr.dm
@@ -11,7 +11,6 @@
 	var/min_health = -100
 	var/cleaning = 0
 	var/patient_laststat = null
-	var/mob_energy = -100 //Energy gained from digesting dead mobs (including PCs)
 	var/list/injection_chems = list("inaprovaline", "dexalin", "bicaridine", "kelotane","anti_toxin", "alkysine", "imidazoline", "spaceacillin", "paracetamol") //The borg is able to heal every damage type. As a nerf, they use 750 charge per injection.
 	var/eject_port = "ingestion"
 	var/list/items_preserved = list()
@@ -70,8 +69,6 @@
 					for(var/T in tech_item.origin_tech)
 						to_chat(user, "<span class='notice'>\The [tech_item] has level [tech_item.origin_tech[T]] in [CallTechName(T)].</span>")
 				update_patient()
-				if(UI_open == TRUE)
-					sleeperUI(usr)
 			return
 
 		else if(ishuman(target))
@@ -90,8 +87,6 @@
 				user.visible_message("<span class='warning'>[hound.name]'s internal analyzer groans lightly as [trashman] slips inside.</span>", "<span class='notice'>Your internal analyzer groans lightly as [trashman] slips inside.</span>")
 				playsound(hound, gulpsound, vol = 100, vary = 1, falloff = 0.1, preference = /datum/client_preference/eating_noises)
 				update_patient()
-				if(UI_open == TRUE)
-					sleeperUI(usr)
 			return
 		return
 
@@ -107,8 +102,6 @@
 				user.visible_message("<span class='warning'>[hound.name]'s garbage processor groans lightly as [target.name] slips inside.</span>", "<span class='notice'>Your garbage compactor groans lightly as [target] slips inside.</span>")
 				playsound(hound, gulpsound, vol = 60, vary = 1, falloff = 0.1, preference = /datum/client_preference/eating_noises)
 				update_patient()
-				if(UI_open == TRUE)
-					sleeperUI(usr)
 			return
 
 		if(istype(target, /mob/living/simple_animal/mouse)) //Edible mice, dead or alive whatever. Mostly for carcass picking you cruel bastard :v
@@ -120,8 +113,6 @@
 				user.visible_message("<span class='warning'>[hound.name]'s garbage processor groans lightly as [trashmouse] slips inside.</span>", "<span class='notice'>Your garbage compactor groans lightly as [trashmouse] slips inside.</span>")
 				playsound(hound, gulpsound, vol = 60, vary = 1, falloff = 0.1, preference = /datum/client_preference/eating_noises)
 				update_patient()
-				if(UI_open == TRUE)
-					sleeperUI(usr)
 			return
 
 		else if(ishuman(target))
@@ -140,8 +131,6 @@
 				user.visible_message("<span class='warning'>[hound.name]'s garbage processor groans lightly as [trashman] slips inside.</span>", "<span class='notice'>Your garbage compactor groans lightly as [trashman] slips inside.</span>")
 				playsound(hound, gulpsound, vol = 100, vary = 1, falloff = 0.1, preference = /datum/client_preference/eating_noises)
 				update_patient()
-				if(UI_open == TRUE)
-					sleeperUI(usr)
 			return
 		return
 	else if(ishuman(target))
@@ -167,8 +156,6 @@
 				user.visible_message("<span class='warning'>[hound.name]'s medical pod lights up as [H.name] slips inside into their [src.name].</span>", "<span class='notice'>Your medical pod lights up as [H] slips into your [src]. Life support functions engaged.</span>")
 				message_admins("[key_name(hound)] has eaten [key_name(patient)] as a dogborg. ([hound ? "<a href='?_src_=holder;adminplayerobservecoodjump=1;X=[hound.x];Y=[hound.y];Z=[hound.z]'>JMP</a>" : "null"])")
 				playsound(hound, gulpsound, vol = 100, vary = 1, falloff = 0.1, preference = /datum/client_preference/eating_noises)
-				if(UI_open == TRUE)
-					sleeperUI(usr)
 
 /obj/item/device/dogborg/sleeper/proc/go_out(var/target)
 	hound = src.loc
@@ -208,10 +195,9 @@
 	if(..())
 		return
 	sleeperUI(user)
-	UI_open = TRUE
 
 /obj/item/device/dogborg/sleeper/proc/sleeperUI(mob/user)
-	var/dat
+	var/dat = "<TITLE>[name] Console</TITLE><BR>"
 
 	if(islist(injection_chems)) //Only display this if we're a drug-dispensing doggo.
 		dat += "<h3>Injector</h3>"
@@ -295,10 +281,10 @@
 				dat += "<div class='line'><div style='width: 170px;' class='statusLabel'>[R.name]:</div><div class='statusValue'>[round(R.volume, 0.1)] units</div></div><br>"
 	dat += "</div>"
 
-	var/datum/browser/popup = new(user, "sleeper", "[name] Console", 520, 540)	//Set up the popup browser window
-	//popup.set_title_image(user.browse_rsc_icon(icon, icon_state)) //I have no idea what this is, but it feels irrelevant and causes runtimes idk.
+	var/datum/browser/popup = new(user, "sleeper_b", "[name] Console", 400, 500, src)
 	popup.set_content(dat)
 	popup.open()
+	UI_open = TRUE
 	return
 
 /obj/item/device/dogborg/sleeper/Topic(href, href_list)
@@ -328,7 +314,6 @@
 					drain(startdrain)
 					processing_objects |= src
 					update_patient()
-					sleeperUI(usr)
 					if(patient)
 						to_chat(patient, "<span class='danger'>[hound.name]'s [src.name] fills with caustic enzymes around you!</span>")
 					return
@@ -392,6 +377,8 @@
 //For if the dogborg's existing patient uh, doesn't make it.
 /obj/item/device/dogborg/sleeper/proc/update_patient()
 	hound = src.loc
+	if(UI_open == TRUE)
+		sleeperUI(hound)
 
 	//Well, we HAD one, what happened to them?
 	if(patient in contents)
@@ -411,8 +398,6 @@
 			//Update icon
 			hound.updateicon()
 		//Return original patient
-		if(UI_open == TRUE)
-			sleeperUI(usr)
 		return(patient)
 
 	//Check for a new patient
@@ -433,8 +418,6 @@
 				patient_laststat = patient.stat
 			//Update icon and return new patient
 			hound.updateicon()
-			if(UI_open == TRUE)
-				sleeperUI(usr)
 			return(C)
 
 	//Cleaning looks better with red on, even with nobody in it
@@ -455,8 +438,6 @@
 	patient_laststat = null
 	patient = null
 	hound.updateicon()
-	if(UI_open == TRUE)
-		sleeperUI(usr)
 	return
 
 //Gurgleborg process
@@ -470,7 +451,7 @@
 	var/list/touchable_items = contents - items_preserved
 
 	//Belly is entirely empty
-	if(!length(contents))
+	if(!length(touchable_items))
 		var/finisher = pick(
 			'sound/vore/death1.ogg',
 			'sound/vore/death2.ogg',
@@ -508,7 +489,9 @@
 	if(air_master.current_cycle%3==1 && length(touchable_items))
 
 		//Burn all the mobs or add them to the exclusion list
+		var/volume = 0
 		for(var/mob/living/T in (touchable_items))
+			touchable_items -= T //Exclude mobs from loose item picking.
 			if((T.status_flags & GODMODE) || !T.digestable)
 				items_preserved += T
 			else
@@ -520,66 +503,55 @@
 				var/actual_burn = T.getFireLoss() - old_burn
 				var/damage_gain = actual_brute + actual_burn
 				drain(-25 * damage_gain) //25*total loss as with voreorgan stats.
-				update_patient()
+				water.add_charge(damage_gain)
+				if(T.stat == DEAD)
+					if(ishuman(T))
+						message_admins("[key_name(hound)] has digested [key_name(T)] as a dogborg. ([hound ? "<a href='?_src_=holder;adminplayerobservecoodjump=1;X=[hound.x];Y=[hound.y];Z=[hound.z]'>JMP</a>" : "null"])")
+					to_chat(hound, "<span class='notice'>You feel your belly slowly churn around [T], breaking them down into a soft slurry to be used as power for your systems.</span>")
+					to_chat(T, "<span class='notice'>You feel [hound]'s belly slowly churn around your form, breaking you down into a soft slurry to be used as power for [hound]'s systems.</span>")
+					var/deathsound = pick(
+						'sound/vore/death1.ogg',
+						'sound/vore/death2.ogg',
+						'sound/vore/death3.ogg',
+						'sound/vore/death4.ogg',
+						'sound/vore/death5.ogg',
+						'sound/vore/death6.ogg',
+						'sound/vore/death7.ogg',
+						'sound/vore/death8.ogg',
+						'sound/vore/death9.ogg',
+						'sound/vore/death10.ogg')
+					playsound(hound, deathsound, vol = 100, vary = 1, falloff = 0.1, ignore_walls = TRUE, preference = /datum/client_preference/digestion_noises)
+					if(is_vore_predator(T))
+						for(var/belly in T.vore_organs)
+							var/obj/belly/B = belly
+							for(var/atom/movable/thing in B)
+								thing.forceMove(src)
+								if(ismob(thing))
+									to_chat(thing, "As [T] melts away around you, you find yourself in [hound]'s [name]")
+					for(var/obj/item/I in T)
+						if(istype(I,/obj/item/organ/internal/mmi_holder/posibrain))
+							var/obj/item/organ/internal/mmi_holder/MMI = I
+							var/atom/movable/brain = MMI.removed()
+							if(brain)
+								hound.remove_from_mob(brain,src)
+								brain.forceMove(src)
+								items_preserved += brain
+						else
+							T.drop_from_inventory(I, src)
+					if(ishuman(T))
+						var/mob/living/carbon/human/Prey = T
+						volume = (Prey.bloodstr.total_volume + Prey.ingested.total_volume + Prey.touching.total_volume + Prey.weight) * Prey.size_multiplier
+						water.add_charge(volume)
+					if(T.reagents)
+						volume = T.reagents.total_volume
+						water.add_charge(volume)
+					qdel(T)
 
 		//Pick a random item to deal with (if there are any)
-		var/atom/target = pick(touchable_items)
-		var/volume = 0
+		if(length(touchable_items))
+			var/atom/target = pick(touchable_items)
 
-		//Handle the target being a mob
-		if(isliving(target))
-			var/mob/living/T = target
-
-			//Mob is now dead
-			if(T.stat == DEAD)
-				if(ishuman(target))
-					message_admins("[key_name(hound)] has digested [key_name(T)] as a dogborg. ([hound ? "<a href='?_src_=holder;adminplayerobservecoodjump=1;X=[hound.x];Y=[hound.y];Z=[hound.z]'>JMP</a>" : "null"])")
-				to_chat(hound, "<span class='notice'>You feel your belly slowly churn around [T], breaking them down into a soft slurry to be used as power for your systems.</span>")
-				to_chat(T, "<span class='notice'>You feel [hound]'s belly slowly churn around your form, breaking you down into a soft slurry to be used as power for [hound]'s systems.</span>")
-				drain(mob_energy) //Fueeeeellll
-				var/deathsound = pick(
-					'sound/vore/death1.ogg',
-					'sound/vore/death2.ogg',
-					'sound/vore/death3.ogg',
-					'sound/vore/death4.ogg',
-					'sound/vore/death5.ogg',
-					'sound/vore/death6.ogg',
-					'sound/vore/death7.ogg',
-					'sound/vore/death8.ogg',
-					'sound/vore/death9.ogg',
-					'sound/vore/death10.ogg')
-				playsound(hound, deathsound, vol = 100, vary = 1, falloff = 0.1, ignore_walls = TRUE, preference = /datum/client_preference/digestion_noises)
-				if(is_vore_predator(T))
-					for(var/belly in T.vore_organs)
-						var/obj/belly/B = belly
-						for(var/atom/movable/thing in B)
-							thing.forceMove(src)
-							if(ismob(thing))
-								to_chat(thing, "As [T] melts away around you, you find yourself in [hound]'s [name]")
-				for(var/obj/item/I in T)
-					if(istype(I,/obj/item/organ/internal/mmi_holder/posibrain))
-						var/obj/item/organ/internal/mmi_holder/MMI = I
-						var/atom/movable/brain = MMI.removed()
-						if(brain)
-							hound.remove_from_mob(brain,src)
-							brain.forceMove(src)
-							items_preserved += brain
-					else
-						T.drop_from_inventory(I, src)
-				if(ishuman(T))
-					var/mob/living/carbon/human/Prey = T
-					volume = (Prey.bloodstr.total_volume + Prey.ingested.total_volume + Prey.touching.total_volume + Prey.weight) * Prey.size_multiplier
-					water.add_charge(volume)
-				if(T.reagents)
-					volume = T.reagents.total_volume
-					water.add_charge(volume)
-				qdel(T)
-				update_patient()
-				if(UI_open == TRUE)
-					sleeperUI(hound)
-
-		//Handle the target being anything but a /mob/living
-		else
+			//Handle the target being anything but a /mob/living
 			var/obj/item/T = target
 			if(istype(T))
 				if(T.reagents)
@@ -618,10 +590,8 @@
 				drain(-100)
 			else
 				items_preserved |= target
-			if(UI_open == TRUE)
-				update_patient()
-				sleeperUI(hound)
-		return
+		update_patient()
+	return
 
 /obj/item/device/dogborg/sleeper/process()
 

--- a/code/modules/mob/living/silicon/robot/robot_modules/station_vr.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules/station_vr.dm
@@ -148,7 +148,7 @@
 	var/datum/matter_synth/water = new /datum/matter_synth()
 	water.name = "Water reserves"
 	water.recharge_rate = 0
-	water.max_energy = 1000
+	water.max_energy = 500
 	water.energy = 0
 	R.water_res = water
 	synths += water
@@ -159,6 +159,7 @@
 
 	var/obj/item/device/dogborg/sleeper/K9/B = new /obj/item/device/dogborg/sleeper/K9(src) //Eat criminals. Bring them to the brig.
 	B.water = water
+	src.modules += B
 
 	R.icon 		 = 'icons/mob/widerobot_vr.dmi'
 	R.hands.icon = 'icons/mob/screen1_robot_vr.dmi'
@@ -216,7 +217,7 @@
 	var/datum/matter_synth/water = new /datum/matter_synth()
 	water.name = "Water reserves"
 	water.recharge_rate = 0
-	water.max_energy = 1000
+	water.max_energy = 500
 	water.energy = 0
 	R.water_res = water
 	synths += water
@@ -227,6 +228,7 @@
 
 	var/obj/item/device/dogborg/sleeper/B = new /obj/item/device/dogborg/sleeper(src) //So they can nom people and heal them
 	B.water = water
+	src.modules += B
 
 	R.icon = 'icons/mob/widerobot_vr.dmi'
 	R.hands.icon = 'icons/mob/screen1_robot_vr.dmi'
@@ -260,7 +262,7 @@
 	var/datum/matter_synth/water = new /datum/matter_synth()
 	water.name = "Water reserves"
 	water.recharge_rate = 0
-	water.max_energy = 1000
+	water.max_energy = 500
 	water.energy = 0
 	R.water_res = water
 	synths += water
@@ -271,6 +273,7 @@
 
 	var/obj/item/device/dogborg/sleeper/K9/B = new /obj/item/device/dogborg/sleeper/K9(src)
 	B.water = water
+	src.modules += B
 
 	R.icon 		 = 'icons/mob/64x64robot_vr.dmi'
 	R.hands.icon = 'icons/mob/screen1_robot_vr.dmi'
@@ -301,17 +304,17 @@
 	var/datum/matter_synth/metal = new /datum/matter_synth/metal()
 	metal.name = "Steel reserves"
 	metal.recharge_rate = 0
-	metal.max_energy = 100000
+	metal.max_energy = 50000
 	metal.energy = 0
 	var/datum/matter_synth/glass = new /datum/matter_synth/glass()
 	glass.name = "Glass reserves"
 	glass.recharge_rate = 0
-	glass.max_energy = 100000
+	glass.max_energy = 50000
 	glass.energy = 0
 	var/datum/matter_synth/water = new /datum/matter_synth()
 	water.name = "Water reserves"
 	water.recharge_rate = 0
-	water.max_energy = 1000
+	water.max_energy = 500
 	water.energy = 0
 	R.water_res = water
 
@@ -383,7 +386,7 @@
 	var/datum/matter_synth/water = new /datum/matter_synth()
 	water.name = "Water reserves"
 	water.recharge_rate = 0
-	water.max_energy = 1000
+	water.max_energy = 500
 	water.energy = 0
 	R.water_res = water
 	synths += water
@@ -394,6 +397,7 @@
 
 	var/obj/item/device/dogborg/sleeper/compactor/analyzer/B = new /obj/item/device/dogborg/sleeper/compactor/analyzer(src)
 	B.water = water
+	src.modules += B
 
 	R.icon 		 = 'icons/mob/widerobot_vr.dmi'
 	R.hands.icon = 'icons/mob/screen1_robot_vr.dmi'
@@ -426,7 +430,7 @@
 	src.modules += new /obj/item/device/t_scanner(src)
 	src.modules += new /obj/item/taperoll/engineering(src)
 	src.modules += new /obj/item/weapon/inflatable_dispenser/robot(src)
-	src.modules += new /obj/item/device/geiger(src)
+	src.modules += new /obj/item/weapon/pickaxe(src)
 	src.modules += new /obj/item/weapon/dogborg/jaws/small(src)
 	src.modules += new /obj/item/device/dogborg/boop_module(src)
 	src.emag 	 = new /obj/item/weapon/dogborg/pounce(src)
@@ -435,27 +439,27 @@
 	var/datum/matter_synth/metal = new /datum/matter_synth/metal()
 	metal.name = "Steel reserves"
 	metal.recharge_rate = 50
-	metal.max_energy = 100000
+	metal.max_energy = 50000
 	metal.energy = 5000
 	var/datum/matter_synth/glass = new /datum/matter_synth/glass()
 	glass.name = "Glass reserves"
 	glass.recharge_rate = 50
-	glass.max_energy = 100000
+	glass.max_energy = 50000
 	glass.energy = 5000
 	var/datum/matter_synth/wood = new /datum/matter_synth/wood()
 	wood.name = "Wood reserves"
 	wood.recharge_rate = 50
-	wood.max_energy = 100000
+	wood.max_energy = 50000
 	wood.energy = 5000
 	var/datum/matter_synth/plastic = new /datum/matter_synth/plastic()
 	plastic.name = "Plastic reserves"
 	plastic.recharge_rate = 50
-	plastic.max_energy = 100000
+	plastic.max_energy = 50000
 	plastic.energy = 5000
 	var/datum/matter_synth/water = new /datum/matter_synth()
 	water.name = "Water reserves"
 	water.recharge_rate = 0
-	water.max_energy = 1000
+	water.max_energy = 500
 	water.energy = 0
 	R.water_res = water
 

--- a/code/modules/mob/living/silicon/robot/robot_modules/station_vr.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules/station_vr.dm
@@ -207,7 +207,6 @@
 	src.modules += new /obj/item/weapon/dogborg/jaws/small(src) //In case a patient is being attacked by carp.
 	src.modules += new /obj/item/device/dogborg/boop_module(src) //Boop the crew.
 	src.modules += new /obj/item/device/healthanalyzer(src) // See who's hurt specificially.
-	src.modules += new /obj/item/weapon/reagent_containers/borghypo(src)//So medi-hounds aren't nearly useless
 	src.modules += new /obj/item/weapon/reagent_containers/syringe(src) //In case the chemist is nice!
 	src.modules += new /obj/item/weapon/reagent_containers/glass/beaker(src)//For holding the chemicals when the chemist is nice
 	src.modules += new /obj/item/device/sleevemate(src) //Lets them scan people.
@@ -221,6 +220,10 @@
 	water.energy = 0
 	R.water_res = water
 	synths += water
+
+	var/obj/item/weapon/reagent_containers/borghypo/hound/H = new /obj/item/weapon/reagent_containers/borghypo/hound(src)
+	H.water = water
+	src.modules += H
 
 	var/obj/item/device/dogborg/tongue/T = new /obj/item/device/dogborg/tongue(src)
 	T.water = water

--- a/code/modules/mob/living/silicon/robot/robot_modules/station_vr.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules/station_vr.dm
@@ -480,6 +480,7 @@
 	MD.glass = glass
 	MD.wood = wood
 	MD.plastic = plastic
+	MD.water = water
 	src.modules += MD
 
 	var/obj/item/stack/material/cyborg/steel/M = new (src)

--- a/code/modules/vore/eating/digest_act_vr.dm
+++ b/code/modules/vore/eating/digest_act_vr.dm
@@ -19,23 +19,23 @@
 /////////////
 // Some indigestible stuff
 /////////////
-/obj/item/weapon/hand_tele/digest_act(...)
+/obj/item/weapon/hand_tele/digest_act(var/atom/movable/item_storage = null)
 	return FALSE
-/obj/item/weapon/card/id/gold/captain/spare/digest_act(...)
+/obj/item/weapon/card/id/gold/captain/spare/digest_act(var/atom/movable/item_storage = null)
 	return FALSE
-/obj/item/device/aicard/digest_act(...)
+/obj/item/device/aicard/digest_act(var/atom/movable/item_storage = null)
 	return FALSE
-/obj/item/device/paicard/digest_act(...)
+/obj/item/device/paicard/digest_act(var/atom/movable/item_storage = null)
 	return FALSE
-/obj/item/weapon/gun/digest_act(...)
+/obj/item/weapon/gun/digest_act(var/atom/movable/item_storage = null)
 	return FALSE
-/obj/item/weapon/pinpointer/digest_act(...)
+/obj/item/weapon/pinpointer/digest_act(var/atom/movable/item_storage = null)
 	return FALSE
-/obj/item/blueprints/digest_act(...)
+/obj/item/blueprints/digest_act(var/atom/movable/item_storage = null)
 	return FALSE
-/obj/item/weapon/disk/nuclear/digest_act(...)
+/obj/item/weapon/disk/nuclear/digest_act(var/atom/movable/item_storage = null)
 	return FALSE
-/obj/item/device/perfect_tele_beacon/digest_act(...)
+/obj/item/device/perfect_tele_beacon/digest_act(var/atom/movable/item_storage = null)
 	return FALSE //Sorta important to not digest your own beacons.
 
 /////////////


### PR DESCRIPTION
-Fixes UI autoupdates firing off the popups after closing the window.
-Fixes mob digestion order for clean cycle. Dead mobs will no longer linger on the mercy of the rng against other loose crap.
-Makes the gurgledamages draw water from mobs as well.
-Removes redundant mob_energy corpse gain since corpse handling now comes after the damage gains.
-Sanitizes a whole bunch of UI update stuff.
-The UI window now starts with a less cluttery size.
-Makes clean cycle actually finish the limbo when nothing but protected stuff is left.
-Fixes Pupdozer belly not connecting to water reserves.
-Nerfs maximum material/water reserves to half.
-Various other fixes and streamlining for sleeperbellies.
-Fixes recycled stack materials causing double reserve output for some reason.
-Adds unfinished cargo delivery belly. Not implemented currently, still under testing, but was too far in to remove for the other small updates while waiting for the PR to get merged already in vain.
-Reduces amount of water acquired from sinks/toilets per chug.
-Adds new type of borg hypo for medihound, uses both, cell and water to recharge.
-Added "dry mouth" message to tongue along with some other little cleanups.

-Also fixed runtimes on digest_act for protected items while at it.