### PR TITLE
Corrects explorer permit language

### DIFF
--- a/code/modules/clothing/under/accessories/permits_vr.dm
+++ b/code/modules/clothing/under/accessories/permits_vr.dm
@@ -1,3 +1,3 @@
 /obj/item/clothing/accessory/permit/gun/planetside
-	name = "exploration gun permit"
+	name = "explorer gun permit"
 	desc = "A card indicating that the owner is allowed to carry a firearm during active exploration missions."

--- a/code/modules/clothing/under/accessories/permits_vr.dm
+++ b/code/modules/clothing/under/accessories/permits_vr.dm
@@ -1,0 +1,3 @@
+/obj/item/clothing/accessory/permit/gun/planetside
+	name = "exploration gun permit"
+	desc = "A card indicating that the owner is allowed to carry a firearm during active exploration missions."

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -1611,6 +1611,7 @@
 #include "code\modules\clothing\under\accessories\holster.dm"
 #include "code\modules\clothing\under\accessories\lockets.dm"
 #include "code\modules\clothing\under\accessories\permits.dm"
+#include "code\modules\clothing\under\accessories\permits_vr.dm"
 #include "code\modules\clothing\under\accessories\storage.dm"
 #include "code\modules\clothing\under\jobs\civilian.dm"
 #include "code\modules\clothing\under\jobs\engineering.dm"


### PR DESCRIPTION
Permit doesn't let them carry guns "on the surface", it lets them carry guns while exploring.