### PR TITLE
Changes one engi door to a maint door

### DIFF
--- a/maps/tether/tether-05-station1.dmm
+++ b/maps/tether/tether-05-station1.dmm
@@ -8263,8 +8263,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/maintenance/engi,
 /obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/maintenance/common,
 /turf/simulated/floor,
 /area/maintenance/station/eng_lower)
 "ayw" = (


### PR DESCRIPTION
Let's face it, this area gets broken into nearly every shift because there's this one engineering door behind engineering which leads to trash piles and a really neat hangout spot.

![doortime](https://user-images.githubusercontent.com/24854483/40702836-503513b8-63b1-11e8-8032-00eaebb82464.png)

It is now a regular maint door.