### PR TITLE
Planet controller startup delay

### DIFF
--- a/code/controllers/Processes/planet.dm
+++ b/code/controllers/Processes/planet.dm
@@ -8,6 +8,7 @@ var/datum/controller/process/planet/planet_controller = null
 	name = "planet controller"
 	planet_controller = src
 	schedule_interval = 1 MINUTE
+	start_delay = 20 SECONDS
 
 	var/list/planet_datums = typesof(/datum/planet) - /datum/planet
 	for(var/P in planet_datums)

--- a/code/game/objects/effects/decals/Cleanable/humans.dm
+++ b/code/game/objects/effects/decals/Cleanable/humans.dm
@@ -248,6 +248,6 @@ var/global/list/image/splatter_cache=list()
 
 //This version should be used for admin spawns and pre-mapped virus vectors (e.g. in PoIs), this version does not dry
 /obj/effect/decal/cleanable/mucus/mapped/New()
-	...()
+	..()
 	virus2 = new /datum/disease2/disease
 	virus2.makerandom()


### PR DESCRIPTION
Fixes problems with random failure of Travis due to active edges.

Basically it was changing the unsimulated planetary walls to match the new weather's temperature before the round started, because it's much faster with the vis_contents weather. Previously it probably took so long that it finished after the active edges check.