### PR TITLE
Holdout Sizegun

### DIFF
--- a/code/modules/client/preference_setup/loadout/loadout_utility_vr.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_utility_vr.dm
@@ -55,3 +55,8 @@
     display_name = "science dufflebag"
     path = /obj/item/weapon/storage/backpack/dufflebag/sci
     allowed_roles = list("Research Director","Scientist","Roboticist","Xenobiologist","Explorer")
+
+/datum/gear/utility/sizegun_small
+    display_name = "holdout size gun"
+    path = /obj/item/weapon/gun/energy/sizegun/small
+    cost = 4

--- a/code/modules/vore/resizing/sizegun_vr.dm
+++ b/code/modules/vore/resizing/sizegun_vr.dm
@@ -82,3 +82,9 @@
 			H.updateicon()
 		else
 			return 1
+
+//Two shot version for loadouts
+/obj/item/weapon/gun/energy/sizegun/small
+	name = "holdout size gun" //I have no idea why this was called shrink ray when this increased and decreased size.
+	desc = "A two shot raygun, able to change the size of a shot creature. Warning: Do not insert into mouth."
+	charge_cost = 1200


### PR DESCRIPTION
Adds the holdout sizegun, a 2 shot version of the weapon that can be selected in the utility section of the loadout panel. Costs 4 points. 

https://forum.vore-station.net/viewtopic.php?f=26&p=8922#p8921