### PR TITLE
Adds a button to view the mechanical voreprefs of a mob when examining

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -329,7 +329,7 @@
 		else if(disconnect_time)
 			msg += "\[Disconnected/ghosted [round(((world.realtime - disconnect_time)/10)/60)] minutes ago\]\n"
 		//VOREStation Add End
-	
+
 	var/list/wound_flavor_text = list()
 	var/list/is_bleeding = list()
 	var/applying_pressure = ""
@@ -439,6 +439,9 @@
 	// VOREStation Start
 	if(ooc_notes)
 		msg += "<span class = 'deptradio'>OOC Notes:</span> <a href='?src=\ref[src];ooc_notes=1'>\[View\]</a>\n"
+
+	msg += "<span class='deptradio'><a href='?src=\ref[src];vore_prefs=1'>\[Mechanical Vore Preferences\]</a></span>\n"
+
 	// VOREStation End
 	msg += "*---------*</span><br>"
 	msg += applying_pressure

--- a/code/modules/vore/eating/living_vr.dm
+++ b/code/modules/vore/eating/living_vr.dm
@@ -612,7 +612,7 @@
 
 /mob/living/examine(mob/user)
 	. = ..()
-	to_chat(user, "<span class='deptradio'><a href='?src=\ref[src];vore_prefs=1'>\[Mechanical Vore Preferences\]</a></span>\n")
+	to_chat(user, "<span class='deptradio'><a href='?src=\ref[src];vore_prefs=1'>\[Mechanical Vore Preferences\]</a></span>")
 
 /mob/living/Topic(href, href_list)	//Can't find any instances of Topic() being overridden by /mob/living in polaris' base code, even though /mob/living/carbon/human's Topic() has a ..() call
 	if(href_list["vore_prefs"])
@@ -622,11 +622,11 @@
 /mob/living/proc/display_voreprefs(mob/user)	//Called by Topic() calls on instances of /mob/living (and subtypes) containing vore_prefs as an argument
 	if(!user)
 		CRASH("display_voreprefs() was called without an associated user.")
-	var/dispvoreprefs = "<bold>[src]'s vore preferences</bold><br><br><br>"
-	dispvoreprefs += "<bold>Digestable:</bold> [digestable ? "Enabled" : "Disabled"]<br>"
-	dispvoreprefs += "<bold>Mob Vore:</bold> [allowmobvore ? "Enabled" : "Disabled"]<br>"
-	dispvoreprefs += "<bold>Drop-nom prey:</bold> [can_be_drop_prey ? "Enabled" : "Disabled"]<br>"
-	dispvoreprefs += "<bold>Drop-nom pred:</bold> [can_be_drop_pred ? "Enabled" : "Disabled"]<br>"
+	var/dispvoreprefs = "<b>[src]'s vore preferences</b><br><br><br>"
+	dispvoreprefs += "<b>Digestable:</b> [digestable ? "Enabled" : "Disabled"]<br>"
+	dispvoreprefs += "<b>Mob Vore:</b> [allowmobvore ? "Enabled" : "Disabled"]<br>"
+	dispvoreprefs += "<b>Drop-nom prey:</b> [can_be_drop_prey ? "Enabled" : "Disabled"]<br>"
+	dispvoreprefs += "<b>Drop-nom pred:</b> [can_be_drop_pred ? "Enabled" : "Disabled"]<br>"
 	user << browse("<html><head><title>Vore prefs: [src]</title></head><body><center>[dispvoreprefs]</center></body></html>", "window=[name];size=200x300;can_resize=0;can_minimize=0")
 	onclose(user, "[name]")
 	return

--- a/code/modules/vore/eating/living_vr.dm
+++ b/code/modules/vore/eating/living_vr.dm
@@ -355,7 +355,7 @@
 		var/obj/effect/overlay/aiholo/holo = loc
 		holo.drop_prey() //Easiest way
 		log_and_message_admins("[key_name(src)] used the OOC escape button to get out of [key_name(holo.master)] (AI HOLO) ([holo ? "<a href='?_src_=holder;adminplayerobservecoodjump=1;X=[holo.x];Y=[holo.y];Z=[holo.z]'>JMP</a>" : "null"])")
-	
+
 	//Don't appear to be in a vore situation
 	else
 		to_chat(src,"<span class='alert'>You aren't inside anyone, though, is the thing.</span>")
@@ -609,3 +609,24 @@
 	set category = "Preferences"
 	set desc = "Switch sharp/fuzzy scaling for current mob."
 	appearance_flags ^= PIXEL_SCALE
+
+/mob/living/examine(mob/user)
+	. = ..()
+	to_chat(user, "<span class='deptradio'><a href='?src=\ref[src];vore_prefs=1'>\[Mechanical Vore Preferences\]</a></span>\n")
+
+/mob/living/Topic(href, href_list)	//Can't find any instances of Topic() being overridden by /mob/living in polaris' base code, even though /mob/living/carbon/human's Topic() has a ..() call
+	if(href_list["vore_prefs"])
+		display_voreprefs(usr)
+	return ..()
+
+/mob/living/proc/display_voreprefs(mob/user)	//Called by Topic() calls on instances of /mob/living (and subtypes) containing vore_prefs as an argument
+	if(!user)
+		CRASH("display_voreprefs() was called without an associated user.")
+	var/dispvoreprefs = "<bold>[src]'s vore preferences</bold><br><br><br>"
+	dispvoreprefs += "<bold>Digestable:</bold> [digestable ? "Enabled" : "Disabled"]<br>"
+	dispvoreprefs += "<bold>Mob Vore:</bold> [allowmobvore ? "Enabled" : "Disabled"]<br>"
+	dispvoreprefs += "<bold>Drop-nom prey:</bold> [can_be_drop_prey ? "Enabled" : "Disabled"]<br>"
+	dispvoreprefs += "<bold>Drop-nom pred:</bold> [can_be_drop_pred ? "Enabled" : "Disabled"]<br>"
+	user << browse("<html><head><title>Vore prefs: [src]</title></head><body><center>[dispvoreprefs]</center></body></html>", "window=[name];size=200x300;can_resize=0;can_minimize=0")
+	onclose(user, "[name]")
+	return


### PR DESCRIPTION
Closes #3848 
This PR will add a little nifty button to the examine text that shows on mobs when you examine them! This will let preds approach prey a little more confidently, since they won't have to looc "hey do you have dropnoms enabled" before making a move. The button will show for the examine text of all living mobs, so the information will be fully present during ~~magical mishaps~~ admin events involving player-controlled mobs.

Right now, the only vars shown with the mechanical voreprefs button are digestable, allowmobvore, can_be_drop_prey, and can_be_drop_pred. If there's any mechanical vore prefs I've missed, yell at me in this PR's comments!

Here's screenshots of how it looks ingame
![image](https://user-images.githubusercontent.com/6356337/41191024-eafcbb14-6bb6-11e8-9c8f-cced3aa0cef2.png)
![image](https://user-images.githubusercontent.com/6356337/41191034-0a5e65a2-6bb7-11e8-9977-c9b5ab067957.png)
