### PR TITLE
Makes belly transfers update contamination.

### DIFF
--- a/code/modules/vore/eating/belly_obj_vr.dm
+++ b/code/modules/vore/eating/belly_obj_vr.dm
@@ -578,6 +578,11 @@
 	if(!(content in src) || !istype(target))
 		return
 	content.forceMove(target)
+	if(isitem(content))
+		var/obj/item/I = content
+		if(I.gurgled && (target.mode_flags & DM_FLAG_ITEMWEAK))
+			I.decontaminate()
+			I.gurgle_contaminate(target.contents, target.cont_flavor)
 	items_preserved -= content
 	if(!silent && target.vore_sound && !recent_sound)
 		var/soundfile = vore_sounds[target.vore_sound]


### PR DESCRIPTION
-Transfers from itemweak belly to another now reset the contamination according to the target gut's settings.