### PR TITLE
Making Circuit debugger fit in toolbelt

### DIFF
--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -67,6 +67,7 @@
 		/obj/item/weapon/extinguisher/mini,
 		/obj/item/weapon/tape_roll,
 		/obj/item/device/integrated_electronics/wirer,
+		/obj/item/device/integrated_electronics/debugger, //Vorestation edit adding debugger to toolbelt can hold list
 		)
 
 /obj/item/weapon/storage/belt/utility/full


### PR DESCRIPTION
Because both the multitool and the Circuit wirer fit in already.