### PR TITLE
Reworks taur riding system.

### DIFF
--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -36,6 +36,16 @@
 		if(shock_stage >= 10) tally -= 1.5 //this gets a +3 later, feral critters take reduced penalty
 	if(reagents.has_reagent("numbenzyme"))
 		tally += 1.5 //A tad bit of slowdown.
+	if(riding_datum) //Bit of slowdown for taur rides if rider is bigger or fatter than mount.
+		var/datum/riding/R = riding_datum
+		var/mob/living/L = R.ridden
+		for(var/mob/living/M in L.buckled_mobs)
+			if(ishuman(M))
+				var/mob/living/carbon/human/H = M
+				if(H.size_multiplier > L.size_multiplier)
+					tally += 1
+				if(H.weight > L.weight)
+					tally += 1
 	//VOREstation end
 
 	if(istype(buckled, /obj/structure/bed/chair/wheelchair))

--- a/code/modules/vore/appearance/sprite_accessories_taur_vr.dm
+++ b/code/modules/vore/appearance/sprite_accessories_taur_vr.dm
@@ -32,8 +32,8 @@
 	var/list/values = list(
 		"[NORTH]" = list(0, 8*scale, ABOVE_MOB_LAYER),
 		"[SOUTH]" = list(0, 8*scale, BELOW_MOB_LAYER),
-		"[EAST]" = list(-10*scale, 8*scale, BELOW_MOB_LAYER),
-		"[WEST]" = list(10*scale, 8*scale, BELOW_MOB_LAYER))
+		"[EAST]" = list(-10*scale, 8*scale, ABOVE_MOB_LAYER),
+		"[WEST]" = list(10*scale, 8*scale, ABOVE_MOB_LAYER))
 
 	return values
 
@@ -45,8 +45,13 @@
 	buckle_lying = FALSE
 
 /mob/living/carbon/human/New()
-	..()
-	riding_datum = new /datum/riding/taur(src)
+	.=..()
+	spawn(2 SECONDS)
+	if(isTaurTail(tail_style))
+		var/datum/sprite_accessory/tail/taur/taurtype = tail_style
+		if(taurtype.can_ride)
+			riding_datum = new /datum/riding/taur(src)
+			verbs |= /mob/living/carbon/human/proc/taur_mount
 
 /mob/living/carbon/human/buckle_mob(mob/living/M, forced = FALSE, check_loc = TRUE)
 	if(forced)
@@ -61,25 +66,44 @@
 		return FALSE
 	if(!ishuman(M))
 		return FALSE
-	if(M.size_multiplier > size_multiplier)
-		to_chat(M,"<span class='warning'>This isn't a pony show! They need to be bigger to ride.</span>")
+	if(M in buckled_mobs)
 		return FALSE
+	if(M.size_multiplier > size_multiplier * 1.2)
+		to_chat(M,"<span class='warning'>This isn't a pony show! You need to be bigger for them to ride.</span>")
+		return FALSE
+	if(M.loc != src.loc)
+		if(M.Adjacent(src))
+			M.forceMove(get_turf(src))
 
 	var/mob/living/carbon/human/H = M
 
 	if(isTaurTail(H.tail_style))
-		to_chat(H,"<span class='warning'>Too many legs. TOO MANY LEGS!!</span>")
+		to_chat(src,"<span class='warning'>Too many legs. TOO MANY LEGS!!</span>")
 		return FALSE
 
 	. = ..()
 	if(.)
 		buckled_mobs[M] = "riding"
 
-/mob/living/carbon/human/MouseDrop_T(mob/living/M, mob/living/user)
-	if(can_buckle && istype(M))
-		if(user_buckle_mob(M, user, silent = TRUE))
-			visible_message("<span class='notice'>[M] starts riding [name]!</span>")
-			return TRUE
+/mob/living/carbon/human/MouseDrop_T(mob/living/M, mob/living/user) //Prevention for forced relocation caused by can_buckle. Base proc has no other use.
+	return
+
+/mob/living/carbon/human/proc/taur_mount(var/mob/living/M in living_mobs(1))
+	set name = "Taur Mount/Dismount"
+	set category = "Abilities"
+	set desc = "Let people ride on you."
+
+	if(LAZYLEN(buckled_mobs))
+		var/datum/riding/R = riding_datum
+		for(var/rider in buckled_mobs)
+			R.force_dismount(rider)
+		return
+	if (stat != CONSCIOUS)
+		return
+	if(!can_buckle || !istype(M) || !M.Adjacent(src) || M.buckled)
+		return
+	if(buckle_mob(M))
+		visible_message("<span class='notice'>[M] starts riding [name]!</span>")
 
 /mob/living/carbon/human/attack_hand(mob/user as mob)
 	if(LAZYLEN(buckled_mobs))


### PR DESCRIPTION
- Made the buckling a verb for the mountable person to use instead of free drag action by anyone.
- This however makes it require the mount's consent and input to let people hop right on.
- The verb has all the sanity checks and such without overriding other actions on the drawback of being available to the mount only.
- Made the riding datum and verb to be applied on on spawn to taurs only instead of everyone.
- Made the riding allow a 20% size difference leeway between rider and mount.
- And made riders bigger or heavier than the mount to cause slowdown while at it.
- Changed side oriented views to layer rider above the mount.

Fixes #3901 
Fixes #3773
Fixes #3526
Fixes #3512

This PR's done sitting.