### PR TITLE
Medical Tweaks

### DIFF
--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -64,8 +64,6 @@
 	singular_name = "gauze length"
 	desc = "Some sterile gauze to wrap around bloody stumps."
 	icon_state = "brutepack"
-	amount = 15 //VOREStation Edit
-	max_amount = 15 //VOREStation Edit
 	origin_tech = list(TECH_BIO = 1)
 	no_variants = FALSE
 	apply_sounds = list('sound/effects/rip1.ogg','sound/effects/rip2.ogg')
@@ -132,7 +130,7 @@
 	gender = PLURAL
 	singular_name = "ointment"
 	icon_state = "ointment"
-	heal_burn = 3
+	heal_burn = 1
 	origin_tech = list(TECH_BIO = 1)
 	no_variants = FALSE
 	apply_sounds = list('sound/effects/ointment.ogg')
@@ -172,9 +170,7 @@
 	singular_name = "advanced trauma kit"
 	desc = "An advanced trauma kit for severe injuries."
 	icon_state = "traumakit"
-	heal_brute = 6 //VOREStation Edit
-	amount = 20 //VOREStation Edit
-	max_amount = 20 //VOREStation Edit
+	heal_brute = 5 //VOREStation Edit
 	origin_tech = list(TECH_BIO = 1)
 	apply_sounds = list('sound/effects/rip1.ogg','sound/effects/rip2.ogg','sound/effects/tape.ogg')
 
@@ -202,8 +198,8 @@
 					continue
 				if (W.bandaged && W.disinfected)
 					continue
-				if(used == amount)
-					break
+				//if(used == amount) //VOREStation Edit
+				//	break //VOREStation Edit
 				if(!do_mob(user, M, W.damage/5))
 					to_chat(user, "<span class='notice'>You must stand still to bandage wounds.</span>")
 					break
@@ -223,7 +219,7 @@
 				W.disinfect()
 				W.heal_damage(heal_brute)
 				playsound(src, pick(apply_sounds), 25)
-				used++
+				used = 1 //VOREStation Edit
 			affecting.update_damages()
 			if(used == amount)
 				if(affecting.is_bandaged())
@@ -237,7 +233,7 @@
 	singular_name = "advanced burn kit"
 	desc = "An advanced treatment kit for severe burns."
 	icon_state = "burnkit"
-	heal_burn = 12 //VOREStation Edit
+	heal_burn = 7 //VOREStation Edit
 	origin_tech = list(TECH_BIO = 1)
 	apply_sounds = list('sound/effects/ointment.ogg')
 

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -170,7 +170,7 @@
 	singular_name = "advanced trauma kit"
 	desc = "An advanced trauma kit for severe injuries."
 	icon_state = "traumakit"
-	heal_brute = 5 //VOREStation Edit
+	heal_brute = 7 //VOREStation Edit
 	origin_tech = list(TECH_BIO = 1)
 	apply_sounds = list('sound/effects/rip1.ogg','sound/effects/rip2.ogg','sound/effects/tape.ogg')
 

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -130,7 +130,7 @@
 	gender = PLURAL
 	singular_name = "ointment"
 	icon_state = "ointment"
-	heal_burn = 1
+	heal_burn = 3
 	origin_tech = list(TECH_BIO = 1)
 	no_variants = FALSE
 	apply_sounds = list('sound/effects/ointment.ogg')
@@ -170,7 +170,9 @@
 	singular_name = "advanced trauma kit"
 	desc = "An advanced trauma kit for severe injuries."
 	icon_state = "traumakit"
-	heal_brute = 3
+	heal_brute = 6 //VOREStation Edit
+	amount = 20 //VOREStation Edit
+	max_amount = 20 //VOREStation Edit
 	origin_tech = list(TECH_BIO = 1)
 	apply_sounds = list('sound/effects/rip1.ogg','sound/effects/rip2.ogg','sound/effects/tape.ogg')
 
@@ -233,7 +235,7 @@
 	singular_name = "advanced burn kit"
 	desc = "An advanced treatment kit for severe burns."
 	icon_state = "burnkit"
-	heal_burn = 3
+	heal_burn = 12 //VOREStation Edit
 	origin_tech = list(TECH_BIO = 1)
 	apply_sounds = list('sound/effects/ointment.ogg')
 

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -64,6 +64,8 @@
 	singular_name = "gauze length"
 	desc = "Some sterile gauze to wrap around bloody stumps."
 	icon_state = "brutepack"
+	amount = 15 //VOREStation Edit
+	max_amount = 15 //VOREStation Edit
 	origin_tech = list(TECH_BIO = 1)
 	no_variants = FALSE
 	apply_sounds = list('sound/effects/rip1.ogg','sound/effects/rip2.ogg')

--- a/code/modules/clothing/spacesuits/rig/modules/utility_vr.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/utility_vr.dm
@@ -104,14 +104,14 @@
 	interface_name = "mounted chem injector"
 	interface_desc = "Dispenses loaded chemicals via an arm-mounted injector."
 
-	var/max_reagent_volume = 10 //Regen to this volume
+	var/max_reagent_volume = 20 //Regen to this volume
 	var/chems_to_use = 5 //Per injection
 
 	charges = list(
-		list("inaprovaline",  "inaprovaline",  0, 10),
-		list("tricordrazine", "tricordrazine", 0, 10),
-		list("tramadol",      "tramadol",      0, 10),
-		list("dexalin plus",  "dexalinp",      0, 10)
+		list("inaprovaline",  "inaprovaline",  0, 20),
+		list("dylovene",  "dylovene",  0, 20),
+		list("paracetamol",      "paracetamol",      0, 20),
+		list("dexalin",  "dexalin",      0, 20)
 		)
 
 /obj/item/rig_module/rescue_pharm/process()

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -141,21 +141,21 @@
 	color = "#0080FF"
 	overdose = REAGENTS_OVERDOSE
 	scannable = 1
-	metabolism = 0.2 //VOREStation Edit
+	metabolism = REM * 0.25 //VOREStation Edit
 
 /datum/reagent/dexalin/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	if(alien == IS_VOX)
-		M.adjustToxLoss(removed * 30) //VOREStation Edit
+		M.adjustToxLoss(removed * 24) //VOREStation Edit
 	else if(alien == IS_SLIME && dose >= 15)
 		M.add_chemical_effect(CE_PAINKILLER, 15)
 		if(prob(15))
 			to_chat(M, "<span class='notice'>You have a moment of clarity as you collapse.</span>")
-			M.adjustBrainLoss(-25 * removed) //VOREStation Edit
+			M.adjustBrainLoss(-20 * removed) //VOREStation Edit
 			M.Weaken(6)
 	else if(alien != IS_DIONA)
-		M.adjustOxyLoss(-150 * removed) //VOREStation Edit
+		M.adjustOxyLoss(-60 * removed) //VOREStation Edit
 
-	holder.remove_reagent("lexorin", 10 * removed) //VOREStation Edit
+	holder.remove_reagent("lexorin", 8 * removed) //VOREStation Edit
 
 /datum/reagent/dexalinp
 	name = "Dexalin Plus"

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -32,7 +32,7 @@
 	if(alien == IS_SLIME)
 		chem_effective = 0.75
 	if(alien != IS_DIONA)
-		M.heal_organ_damage(6 * removed * chem_effective, 0)
+		M.heal_organ_damage(4 * removed * chem_effective, 0) //VOREStation Edit
 
 /datum/reagent/bicaridine/overdose(var/mob/living/carbon/M, var/alien, var/removed)
 	..()

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -67,7 +67,7 @@
 		chem_effective = 0.5
 		M.adjustBruteLoss(2 * removed) //Mends burns, but has negative effects with a Promethean's skeletal structure.
 	if(alien != IS_DIONA)
-		M.heal_organ_damage(0, 6 * removed * chem_effective)
+		M.heal_organ_damage(0, 4 * removed * chem_effective) //VOREStation edit
 
 /datum/reagent/dermaline
 	name = "Dermaline"
@@ -85,7 +85,7 @@
 	if(alien == IS_SLIME)
 		chem_effective = 0.75
 	if(alien != IS_DIONA)
-		M.heal_organ_damage(0, 12 * removed * chem_effective)
+		M.heal_organ_damage(0, 8 * removed * chem_effective) //VOREStation edit
 
 /datum/reagent/dylovene
 	name = "Dylovene"
@@ -141,20 +141,21 @@
 	color = "#0080FF"
 	overdose = REAGENTS_OVERDOSE
 	scannable = 1
+	metabolism = 0.2 //VOREStation Edit
 
 /datum/reagent/dexalin/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	if(alien == IS_VOX)
-		M.adjustToxLoss(removed * 6)
+		M.adjustToxLoss(removed * 30) //VOREStation Edit
 	else if(alien == IS_SLIME && dose >= 15)
 		M.add_chemical_effect(CE_PAINKILLER, 15)
 		if(prob(15))
 			to_chat(M, "<span class='notice'>You have a moment of clarity as you collapse.</span>")
-			M.adjustBrainLoss(-5 * removed)
+			M.adjustBrainLoss(-25 * removed) //VOREStation Edit
 			M.Weaken(6)
 	else if(alien != IS_DIONA)
-		M.adjustOxyLoss(-15 * removed)
+		M.adjustOxyLoss(-150 * removed) //VOREStation Edit
 
-	holder.remove_reagent("lexorin", 2 * removed)
+	holder.remove_reagent("lexorin", 10 * removed) //VOREStation Edit
 
 /datum/reagent/dexalinp
 	name = "Dexalin Plus"
@@ -399,7 +400,7 @@
 			M.Weaken(5)
 		if(dose >= 10 && M.paralysis < 40)
 			M.AdjustParalysis(1) //Messing with the core with a simple chemical probably isn't the best idea.
-	M.adjustBrainLoss(-30 * removed * chem_effective)
+	M.adjustBrainLoss(-8 * removed * chem_effective) //VOREStation Edit
 	M.add_chemical_effect(CE_PAINKILLER, 10 * chem_effective)
 
 /datum/reagent/imidazoline

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine_vr.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine_vr.dm
@@ -62,15 +62,20 @@
 /datum/reagent/vermicetol
 	name = "Vermicetol"
 	id = "vermicetol"
-	description = "A potent chemical that treats burn damage at an exceptional rate and lasts a while."
+	description = "A potent chemical that treats all damage at an exceptional rate and lasts a while."
 	taste_description = "sparkles"
 	reagent_state = SOLID
 	color = "#964e06"
-	overdose = 10
+	overdose = 15
 	scannable = 1
-	metabolism = 0.02
+	metabolism = 0.05
 	mrate_static = TRUE
 
 /datum/reagent/vermicetol/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	if(alien != IS_DIONA)
-		M.heal_organ_damage(0, 110 * removed) //Not as potent as Kelotane, but lasts LONG.
+		var/chem_effective = 1
+		if(alien == IS_SLIME)
+			chem_effective = 0.5
+		M.heal_organ_damage(60 * removed, 60 * removed * chem_effective)
+		M.adjustOxyLoss(-120 * removed * chem_effective)
+		M.adjustToxLoss(-60 * removed * chem_effective)

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine_vr.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine_vr.dm
@@ -62,20 +62,17 @@
 /datum/reagent/vermicetol
 	name = "Vermicetol"
 	id = "vermicetol"
-	description = "A potent chemical that treats all damage at an exceptional rate and lasts a while."
+	description = "A potent chemical that treats physical damage at an exceptional rate."
 	taste_description = "sparkles"
+	taste_mult = 3
 	reagent_state = SOLID
 	color = "#964e06"
-	overdose = 15
+	overdose = REAGENTS_OVERDOSE * 0.5
 	scannable = 1
-	metabolism = 0.05
-	mrate_static = TRUE
 
 /datum/reagent/vermicetol/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
+	var/chem_effective = 1
+	if(alien == IS_SLIME)
+		chem_effective = 0.75
 	if(alien != IS_DIONA)
-		var/chem_effective = 1
-		if(alien == IS_SLIME)
-			chem_effective = 0.5
-		M.heal_organ_damage(60 * removed, 60 * removed * chem_effective)
-		M.adjustOxyLoss(-120 * removed * chem_effective)
-		M.adjustToxLoss(-60 * removed * chem_effective)
+		M.heal_organ_damage(8 * removed * chem_effective, 0)

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -333,8 +333,8 @@
 /obj/item/weapon/reagent_containers/syringe/inaprovaline/New()
 	..()
 	reagents.add_reagent("inaprovaline", 15)
-	mode = SYRINGE_INJECT
-	update_icon()
+	//mode = SYRINGE_INJECT //VOREStation Edit - Starts capped
+	//update_icon()
 
 /obj/item/weapon/reagent_containers/syringe/antitoxin
 	name = "Syringe (anti-toxin)"
@@ -343,8 +343,8 @@
 /obj/item/weapon/reagent_containers/syringe/antitoxin/New()
 	..()
 	reagents.add_reagent("anti_toxin", 15)
-	mode = SYRINGE_INJECT
-	update_icon()
+	//mode = SYRINGE_INJECT //VOREStation Edit - Starts capped
+	//update_icon()
 
 /obj/item/weapon/reagent_containers/syringe/antiviral
 	name = "Syringe (spaceacillin)"
@@ -353,8 +353,8 @@
 /obj/item/weapon/reagent_containers/syringe/antiviral/New()
 	..()
 	reagents.add_reagent("spaceacillin", 15)
-	mode = SYRINGE_INJECT
-	update_icon()
+	//mode = SYRINGE_INJECT //VOREStation Edit - Starts capped
+	//update_icon()
 
 /obj/item/weapon/reagent_containers/syringe/drugs
 	name = "Syringe (drugs)"
@@ -365,8 +365,8 @@
 	reagents.add_reagent("space_drugs",  5)
 	reagents.add_reagent("mindbreaker",  5)
 	reagents.add_reagent("cryptobiolin", 5)
-	mode = SYRINGE_INJECT
-	update_icon()
+	//mode = SYRINGE_INJECT //VOREStation Edit - Starts capped
+	//update_icon()
 
 /obj/item/weapon/reagent_containers/syringe/ld50_syringe/choral/New()
 	..()

--- a/code/modules/reagents/reagent_containers/syringes_vr.dm
+++ b/code/modules/reagents/reagent_containers/syringes_vr.dm
@@ -43,7 +43,11 @@
 
 	//Dirtiness should be very low if you're the first injectee. If you're spam-injecting 4 people in a row around you though,
 	//This gives the last one a 30% chance of infection.
-	if(prob(dirtiness+(targets.len-1)*10))
+	var/infect_chance = dirtiness        //Start with dirtiness
+	if(infect_chance <= 10 && (hash in targets)) //Extra fast uses on target is free
+		infect_chance = 0
+	infect_chance += (targets.len-1)*10    //Extra 10% per extra target
+	if(prob(infect_chance))
 		log_and_message_admins("[loc] infected [target]'s [eo.name] with \the [src].")
 		infect_limb(eo)
 


### PR DESCRIPTION
Minor balance changes and tweaks. The syringe infection chance tweak is probably the biggest change.

- Advanced Trauma Kits treat 7 damage per application, and are now used only once per body part (instead of once per wound like gauze)
- Advanced Burn Kits treat 7 damage per application
- Medical Rescue Suit injector now has 20 units per chem, and uses Inaprovaline, Dylovene, Paracematol, and Dexalin
- Bicard effectiveness reduced from 6 damage per unit to 4 damage per unit
- Kelotane effectiveness reduced from 6 damage per unit to 4 damage per unit
- Dermaline effectiveness reduced from 12 damage per unit to 8 damage per unit
- Dexalin metabolizes at 25% of the rate of Dexalin Plus, stats adjusted so that the effects are the same, just that it takes longer to wear off (Natje's suggestion)
- Reduced brain healing of Alkysine from 30 to 8 per unit
- Vermicetol is now a T2 brute chem, healing 8 brute damage per unit and metabolizing at normal rates
- All pre-filled syringes start capped.
- There is now a 20-second grace period where infection chance is 0 (Note: Using syringes on multiple people renders grace period null and void)