### PR TITLE
Chaplain PDA Bug Fix & Atmos Dedupe

### DIFF
--- a/code/game/jobs/job/civilian_chaplain.dm
+++ b/code/game/jobs/job/civilian_chaplain.dm
@@ -149,5 +149,7 @@
 		feedback_set_details("religion_book","[new_book_style]")
 	return 1
 
+/* IF you uncomment this, every time the mob preview updates it makes a new PDA. It seems to work just fine and display without it, so why this exists, haven't a clue. -Hawk
 /datum/job/chaplain/equip_preview(var/mob/living/carbon/human/H, var/alt_title)
 	return equip(H, alt_title, FALSE)
+*/

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -87,7 +87,6 @@
 		/obj/item/weapon/weldingtool,
 		/obj/item/weapon/crowbar,
 		/obj/item/weapon/wirecutters,
-		/obj/item/device/t_scanner
 	)
 
 /obj/item/weapon/storage/belt/utility/chief


### PR DESCRIPTION
-Chaplain PDA bug: Caused by the chaplain custom preview calling equip. Disabling it seems to have no issues with the preview and stops it making a new PDA every time it generates a new preview.

-Atmos Tech Dedupe: All engineers start with a T-Ray in their right pocket. Atmos techs also had one in their toolbelts. And now the extra one in the toolbelts is gone.