### PR TITLE
Duplicate PR revert and minor bugfix

### DIFF
--- a/code/__defines/species_languages_vr.dm
+++ b/code/__defines/species_languages_vr.dm
@@ -4,7 +4,6 @@
 #define LANGUAGE_ECUREUILIAN "Ecureuilian"
 #define LANGUAGE_DAEMON "Daemon"
 #define LANGUAGE_ENOCHIAN "Enochian"
-#define LANGUAGE_SIIK_TAJR "Siik'Tajr"
 
 #define LANGUAGE_CHIMPANZEE "Chimpanzee"
 #define LANGUAGE_NEAERA "Neaera"

--- a/code/modules/mob/language/station_vr.dm
+++ b/code/modules/mob/language/station_vr.dm
@@ -71,14 +71,6 @@
 	"mihi","wan","six","salve","tartu")
 	machine_understands = FALSE
 
-/datum/language/tajsign
-	name = LANGUAGE_SIIK_TAJR
-	desc = "A type of sign language mostly based on tail movements that was used during the Tajaran rebellion."
-	signlang_verb = list("uses their tail to convey", "gestures with their tail", "gestures with their tail elaborately")
-	colour = "tajaran"
-	key = "l"
-	flags = WHITELISTED | SIGNLANG | NO_STUTTER | NONVERBAL
-
 /datum/language/unathi
 	flags = 0
 /datum/language/tajaran

--- a/code/modules/mob/living/carbon/human/species/station/station_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_vr.dm
@@ -313,7 +313,6 @@
 	icobase = 'icons/mob/human_races/r_tajaran_vr.dmi'
 	deform = 'icons/mob/human_races/r_def_tajaran_vr.dmi'
 	tail_animation = 'icons/mob/species/tajaran/tail_vr.dmi'
-	secondary_langs = list(LANGUAGE_SIIK, LANGUAGE_AKHANI, LANGUAGE_SIIK_TAJR)
 	color_mult = 1
 	min_age = 18
 	gluttonous = 0 //Moving this here so I don't have to fix this conflict every time polaris glances at station.dm

--- a/maps/southern_cross/structures/closets/misc_vr.dm
+++ b/maps/southern_cross/structures/closets/misc_vr.dm
@@ -29,7 +29,7 @@
 		/obj/item/clothing/accessory/holster/machete,
 		/obj/item/weapon/reagent_containers/food/snacks/liquidfood = 2)
 
-/obj/structure/closet/secure_closet/explorer/initialize()
+/obj/structure/closet/secure_closet/pathfinder/initialize()
 	if(prob(50))
 		starts_with += /obj/item/weapon/storage/backpack
 	else


### PR DESCRIPTION
- Reverts Virgo Siik'Tajr, since Polaris decided to implement it upstream
- Fixes a bug that caused the Pathfinder's locker script to instead trigger on explorer lockers