### PR TITLE
Ups the paper text limit.

### DIFF
--- a/code/__defines/misc.dm
+++ b/code/__defines/misc.dm
@@ -105,7 +105,7 @@
 
 // Setting this much higher than 1024 could allow spammers to DOS the server easily.
 #define MAX_MESSAGE_LEN       2048 //VOREStation Edit - I'm not sure about "easily". It can be a little longer.
-#define MAX_PAPER_MESSAGE_LEN 6144
+#define MAX_PAPER_MESSAGE_LEN 24576 //VOREStation Edit - Quick QoL for librarians, since you can write HTML onto paper and put it in a book binder, but can't write HTML onto a book.
 #define MAX_BOOK_MESSAGE_LEN  24576
 #define MAX_RECORD_LENGTH	  24576
 #define MAX_LNAME_LEN         64


### PR DESCRIPTION
Not to big of a change, just makes librarian's job a bit easier.

**Please do tell me if there is a better method of going about this.** I was thinking of replacing the sanitize when you write in books with the pencode 
(https://github.com/VOREStation/VOREStation/blob/c8dd30846cfba8b058ec97399e98e8ac3649924b/code/modules/paperwork/paper.dm#L286)

But I wasn't sure if that would break everything and open it up to exploits, especially since I couldn't 'test' such a thing due to lacking a book database. Please do tell me if this would work, however.