### PR TITLE
Fixes sleeperbellies not ejecting contents on borg death.

### DIFF
--- a/code/modules/mob/living/silicon/robot/death.dm
+++ b/code/modules/mob/living/silicon/robot/death.dm
@@ -15,6 +15,8 @@
 	if(module)
 		var/obj/item/weapon/gripper/G = locate(/obj/item/weapon/gripper) in module
 		if(G) G.drop_item()
+		var/obj/item/device/dogborg/sleeper/S = locate(/obj/item/device/dogborg/sleeper) in module //VOREStation edit.
+		if(S) S.go_out() //VOREStation edit.
 	remove_robot_verbs()
 	sql_report_cyborg_death(src)
 	..(gibbed,"shudders violently for a moment, then becomes motionless, its eyes slowly darkening.")


### PR DESCRIPTION
-Wow it sure took a while before we found out what was forgotten during the original citadel port.

What comes to the vorepanel bellies though, their issue will be a shared one with human mobs alike, and currently the only fix to that is using the sickshot gun.