### PR TITLE
Security Overhaul fixes.

### DIFF
--- a/maps/tether/tether-06-station2.dmm
+++ b/maps/tether/tether-06-station2.dmm
@@ -167,16 +167,13 @@
 /turf/simulated/floor/tiled,
 /area/security/brig/visitation)
 "ar" = (
-/obj/structure/bed/chair{
+/obj/structure/bed/chair,
+/obj/effect/floor_decal/borderfloor/corner,
+/obj/machinery/atmospherics/pipe/manifold/hidden/green{
+	icon_state = "map";
 	dir = 1
 	},
-/obj/effect/floor_decal/borderfloor/corner{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/green,
+/obj/effect/floor_decal/corner/lightorange/bordercorner,
 /turf/simulated/floor/tiled,
 /area/security/brig)
 "as" = (
@@ -190,16 +187,18 @@
 /turf/simulated/wall,
 /area/maintenance/station/sec_lower)
 "au" = (
-/obj/item/weapon/stool/padded,
-/obj/structure/disposalpipe/segment,
+/obj/structure/bed/chair,
 /obj/effect/floor_decal/borderfloor/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/green{
+	icon_state = "intact";
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
+/obj/effect/floor_decal/corner/lightorange/bordercorner{
+	icon_state = "bordercolorcorner";
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/green,
 /turf/simulated/floor/tiled,
 /area/security/brig)
 "av" = (
@@ -575,21 +574,28 @@
 /turf/simulated/floor/tiled,
 /area/security/security_cell_hallway)
 "bb" = (
-/obj/structure/bed/chair,
-/obj/effect/floor_decal/borderfloor/corner{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/green{
-	icon_state = "intact";
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/security/brig)
-"bc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/green,
 /obj/structure/table/steel,
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
+	},
+/obj/effect/floor_decal/corner/lightorange/border{
+	icon_state = "bordercolor";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel_dirty,
+/area/security/brig)
+"bc" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/structure/table/steel,
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/lightorange/border{
+	icon_state = "bordercolor";
+	dir = 8
 	},
 /turf/simulated/floor/tiled/steel_dirty,
 /area/security/brig)
@@ -716,9 +722,6 @@
 /turf/simulated/floor/tiled/steel_dirty,
 /area/security/brig)
 "bm" = (
-/obj/effect/floor_decal/borderfloor{
-	pixel_y = 16
-	},
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/spline/plain{
 	icon_state = "spline_plain";
@@ -727,6 +730,7 @@
 /obj/structure/railing{
 	dir = 8
 	},
+/obj/effect/floor_decal/borderfloor/shifted,
 /turf/simulated/floor/tiled,
 /area/security/brig)
 "bn" = (
@@ -809,15 +813,16 @@
 /turf/simulated/floor/plating,
 /area/security/brig)
 "br" = (
-/turf/space,
-/obj/structure/shuttle/engine/propulsion{
-	dir = 8;
-	icon_state = "propulsion_l"
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/spline/plain{
+	dir = 4
 	},
-/turf/simulated/shuttle/plating/airless/carry,
-/area/shuttle/large_escape_pod1/station{
-	base_turf = /turf/simulated/mineral/floor/vacuum
-	})
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloor/shifted,
+/turf/simulated/floor/tiled,
+/area/security/brig)
 "bs" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -843,24 +848,61 @@
 /turf/simulated/floor/tiled,
 /area/security/security_cell_hallway)
 "bt" = (
-/turf/space,
-/obj/structure/shuttle/engine/propulsion{
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/green,
+/obj/effect/floor_decal/corner/lightorange/bordercorner{
+	icon_state = "bordercolorcorner";
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/security/brig)
+"bu" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
-/turf/simulated/shuttle/plating/airless/carry,
-/area/shuttle/large_escape_pod1/station{
-	base_turf = /turf/simulated/mineral/floor/vacuum
-	})
-"bu" = (
-/turf/space,
-/obj/structure/shuttle/engine/propulsion{
-	dir = 8;
-	icon_state = "propulsion_r"
+/obj/structure/bed/chair{
+	dir = 1
 	},
-/turf/simulated/shuttle/plating/airless/carry,
-/area/shuttle/large_escape_pod1/station{
-	base_turf = /turf/simulated/mineral/floor/vacuum
-	})
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightorange/bordercorner{
+	icon_state = "bordercolorcorner";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/steel_dirty,
+/area/security/brig)
+"bv" = (
+/obj/machinery/portable_atmospherics/hydroponics,
+/obj/effect/floor_decal/borderfloor/corner,
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/green,
+/obj/effect/floor_decal/corner/lightorange/bordercorner,
+/turf/simulated/floor/tiled/steel_dirty,
+/area/security/brig)
+"bw" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/portable_atmospherics/hydroponics,
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/green{
+	icon_state = "intact";
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/lightorange/bordercorner{
+	icon_state = "bordercolorcorner";
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/security/brig)
 "bx" = (
 /obj/effect/floor_decal/rust,
 /obj/random/junk,
@@ -887,6 +929,26 @@
 /obj/structure/closet/coffin,
 /turf/simulated/floor/tiled/dark,
 /area/chapel/chapel_morgue)
+"bB" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/green,
+/obj/machinery/computer/arcade/orion_trail,
+/obj/item/clothing/suit/ianshirt,
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/lightorange/border{
+	icon_state = "bordercolor";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel_dirty,
+/area/security/brig)
 "bC" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -905,20 +967,57 @@
 /turf/simulated/floor/tiled,
 /area/security/security_cell_hallway)
 "bD" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
 	},
 /obj/structure/table/steel,
+/obj/machinery/microwave,
+/obj/item/weapon/storage/box/donkpockets,
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/steel_dirty,
+/obj/effect/floor_decal/corner/lightorange/border{
+	icon_state = "bordercolor";
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
 /area/security/brig)
 "bE" = (
-/obj/structure/bed/chair,
-/obj/effect/floor_decal/borderfloor/corner,
-/obj/machinery/atmospherics/pipe/manifold/hidden/green{
-	icon_state = "map";
+/obj/item/weapon/stool/padded,
+/obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/green,
+/obj/effect/floor_decal/corner/lightorange/bordercorner{
+	icon_state = "bordercolorcorner";
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/security/brig)
+"bF" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/structure/table/steel,
+/obj/item/weapon/paper_bin,
+/obj/item/weapon/pen/blue{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/item/device/taperecorder{
+	pixel_x = -4;
+	pixel_y = 2
+	},
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightorange/bordercorner{
+	icon_state = "bordercolorcorner";
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
@@ -1176,18 +1275,25 @@
 "bW" = (
 /turf/simulated/wall/r_wall,
 /area/engineering/shaft)
+"bX" = (
+/turf/space,
+/obj/structure/shuttle/engine/propulsion{
+	dir = 8;
+	icon_state = "propulsion_l"
+	},
+/turf/simulated/shuttle/plating/airless/carry,
+/area/shuttle/large_escape_pod1/station{
+	base_turf = /turf/simulated/mineral/floor/vacuum
+	})
 "bY" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+/turf/space,
+/obj/structure/shuttle/engine/propulsion{
 	dir = 8
 	},
-/obj/structure/bed/chair{
-	dir = 1
-	},
-/obj/effect/floor_decal/borderfloor/corner{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/steel_dirty,
-/area/security/brig)
+/turf/simulated/shuttle/plating/airless/carry,
+/area/shuttle/large_escape_pod1/station{
+	base_turf = /turf/simulated/mineral/floor/vacuum
+	})
 "bZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -1208,11 +1314,15 @@
 /turf/simulated/floor/tiled,
 /area/security/brig)
 "ca" = (
-/obj/machinery/portable_atmospherics/hydroponics,
-/obj/effect/floor_decal/borderfloor/corner,
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/green,
-/turf/simulated/floor/tiled/steel_dirty,
-/area/security/brig)
+/turf/space,
+/obj/structure/shuttle/engine/propulsion{
+	dir = 8;
+	icon_state = "propulsion_r"
+	},
+/turf/simulated/shuttle/plating/airless/carry,
+/area/shuttle/large_escape_pod1/station{
+	base_turf = /turf/simulated/mineral/floor/vacuum
+	})
 "cb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/unary/outlet_injector{
@@ -1223,46 +1333,6 @@
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/steel_dirty,
-/area/security/brig)
-"cc" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/portable_atmospherics/hydroponics,
-/obj/effect/floor_decal/borderfloor/corner{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/green{
-	icon_state = "intact";
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/security/brig)
-"cd" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/green,
-/obj/machinery/computer/arcade/orion_trail,
-/obj/item/clothing/suit/ianshirt,
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel_dirty,
-/area/security/brig)
-"ce" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/table/steel,
-/obj/machinery/microwave,
-/obj/item/weapon/storage/box/donkpockets,
-/obj/effect/floor_decal/borderfloor{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
 /area/security/brig)
 "cf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1306,25 +1376,6 @@
 /obj/structure/ladder,
 /turf/simulated/floor/plating,
 /area/engineering/shaft)
-"cl" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/structure/table/steel,
-/obj/item/weapon/paper_bin,
-/obj/item/weapon/pen/blue{
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/obj/item/device/taperecorder{
-	pixel_x = -4;
-	pixel_y = 2
-	},
-/obj/effect/floor_decal/borderfloor/corner{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/security/brig)
 "cp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -19399,19 +19450,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor,
 /area/maintenance/station/sec_lower)
-"ZP" = (
-/obj/effect/floor_decal/borderfloor{
-	pixel_y = 16
-	},
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/spline/plain{
-	dir = 4
-	},
-/obj/structure/railing{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/security/brig)
 "ZR" = (
 /obj/machinery/door/firedoor/glass,
 /obj/structure/cable/green{
@@ -26734,13 +26772,13 @@ aB
 ak
 bm
 DF
-bE
-bc
 ar
+bb
+bt
 cg
-ca
-cd
-au
+bv
+bB
+bE
 dQ
 Ye
 VB
@@ -26874,15 +26912,15 @@ aS
 Rg
 aC
 aC
-ZP
+br
 DF
-bb
-bD
-bY
+au
+bc
+bu
 bG
-cc
-ce
-cl
+bw
+bD
+bF
 ZH
 Fb
 Rq
@@ -29908,11 +29946,11 @@ AN
 AN
 Bw
 yY
-br
-bt
-bt
-bt
-bu
+bX
+bY
+bY
+bY
+ca
 yY
 ac
 ac

--- a/maps/tether/tether-07-station3.dmm
+++ b/maps/tether/tether-07-station3.dmm
@@ -35365,8 +35365,8 @@ aJ
 aJ
 aJ
 aJ
-aJ
-aa
+gg
+gg
 ab
 ab
 aU
@@ -35507,8 +35507,8 @@ aa
 ae
 aa
 aa
-aJ
-aa
+gg
+gg
 ab
 ab
 aU
@@ -35648,9 +35648,9 @@ aa
 aa
 ae
 aa
-aa
-aJ
-aa
+ed
+gg
+gg
 ab
 ab
 aU
@@ -35790,8 +35790,8 @@ aa
 aa
 aO
 aa
-aa
-aJ
+ed
+gg
 ab
 ab
 ab
@@ -35932,8 +35932,8 @@ aa
 aa
 aa
 aa
-aa
-aJ
+ed
+gg
 ab
 ab
 ab
@@ -36074,8 +36074,8 @@ aa
 aa
 aa
 aa
-aa
-aJ
+ed
+gg
 ab
 ab
 ab
@@ -36217,7 +36217,7 @@ aa
 aa
 aa
 aa
-aJ
+gg
 ab
 ab
 ab
@@ -36359,7 +36359,7 @@ aa
 aa
 aa
 aa
-aJ
+gg
 ab
 ab
 ab

--- a/maps/tether/tether-07-station3.dmm
+++ b/maps/tether/tether-07-station3.dmm
@@ -7521,11 +7521,6 @@
 	},
 /turf/simulated/floor,
 /area/maintenance/station/ai)
-"mx" = (
-/obj/structure/lattice,
-/obj/structure/lattice,
-/turf/space,
-/area/space)
 "my" = (
 /obj/structure/sign/warning/secure_area,
 /turf/simulated/wall/r_wall,
@@ -30850,7 +30845,7 @@ aa
 aa
 aa
 aa
-mx
+ae
 aa
 aa
 ae

--- a/maps/tether/tether-07-station3.dmm
+++ b/maps/tether/tether-07-station3.dmm
@@ -1244,24 +1244,36 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/armory/red)
 "ca" = (
-/obj/structure/bed/chair/office/dark{
-	dir = 1
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/airlock/glass_security{
+	name = "Firing Range";
+	req_access = list(1)
 	},
-/obj/machinery/button/remote/blast_door{
-	id = "security_lockdown";
-	name = "Brig Lockdown";
-	pixel_x = 29;
-	pixel_y = 40;
-	req_access = list(2)
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/dark,
-/area/security/warden)
+/turf/simulated/floor/tiled,
+/area/security/range)
 "cb" = (
-/obj/structure/table/reinforced,
-/obj/item/device/retail_scanner/security,
-/obj/machinery/recharger,
-/turf/simulated/floor/tiled/dark,
-/area/security/warden)
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/airlock/glass_security{
+	name = "Security EVA";
+	req_one_access = list(1,2,18)
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled,
+/area/security/eva)
 "cc" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -1727,19 +1739,9 @@
 /turf/simulated/floor/tiled,
 /area/security/hallwayaux)
 "cN" = (
-/obj/machinery/door/firedoor/glass,
 /obj/structure/table/reinforced,
-/obj/machinery/door/window/brigdoor/westleft{
-	dir = 1;
-	name = "Warden's Desk";
-	req_access = list(3)
-	},
-/obj/machinery/door/window/brigdoor/eastleft{
-	dir = 2;
-	name = "Warden's Desk";
-	req_access = list(1)
-	},
-/turf/simulated/floor/tiled,
+/obj/item/device/retail_scanner/security,
+/turf/simulated/floor/tiled/dark,
 /area/security/warden)
 "cO" = (
 /obj/structure/bed/chair/comfy/black{
@@ -1955,47 +1957,35 @@
 /turf/simulated/floor/bluegrid,
 /area/ai)
 "dn" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 8
+/obj/structure/bed/chair/office/dark{
+	dir = 1
 	},
-/obj/effect/floor_decal/corner/red/border{
-	dir = 8
-	},
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 10;
-	icon_state = "borderfloorcorner2";
-	pixel_x = 0
-	},
-/obj/effect/floor_decal/corner/red/bordercorner2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled,
-/area/security/hallway)
+/turf/simulated/floor/tiled/dark,
+/area/security/warden)
 "do" = (
-/obj/machinery/door/firedoor/glass,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/light,
+/obj/machinery/recharger/wallcharger{
+	pixel_x = 4;
+	pixel_y = -32
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/button/remote/blast_door{
+	dir = 4;
+	id = "security_lockdown";
+	name = "Brig Lockdown";
+	pixel_x = -6;
+	pixel_y = -40;
+	req_access = list(3)
 	},
-/obj/machinery/door/airlock/glass_security{
-	name = "Brig Observation"
+/obj/machinery/button/remote/blast_door{
+	dir = 8;
+	id = "warden";
+	name = "Office Shutters";
+	pixel_x = 6;
+	pixel_y = -39;
+	req_access = list(3)
 	},
-/turf/simulated/floor/tiled,
-/area/security/observation)
+/turf/simulated/floor/tiled/dark,
+/area/security/warden)
 "dp" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled,
@@ -3146,14 +3136,29 @@
 /turf/simulated/floor/tiled,
 /area/security/hallway)
 "fn" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/door/firedoor/glass,
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/brigdoor/westleft{
+	dir = 1;
+	name = "Warden's Desk";
+	req_access = list(3)
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/door/window/brigdoor/eastleft{
+	dir = 2;
+	name = "Warden's Desk";
+	req_access = list(1)
+	},
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id = "warden";
+	layer = 3.1;
+	name = "Warden's Office Shutters";
+	opacity = 0
 	},
 /turf/simulated/floor/tiled,
-/area/security/hallway)
+/area/security/warden)
 "fo" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
@@ -4817,13 +4822,27 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/warden)
 "ik" = (
-/obj/machinery/light,
-/obj/machinery/recharger/wallcharger{
-	pixel_x = 4;
-	pixel_y = -32
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
 	},
-/turf/simulated/floor/tiled/dark,
-/area/security/warden)
+/obj/effect/floor_decal/corner/red/border{
+	dir = 8
+	},
+/obj/machinery/power/apc{
+	cell_type = /obj/item/weapon/cell/super;
+	dir = 8;
+	name = "west bump";
+	pixel_x = -28
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/tiled,
+/area/security/hallwayaux)
 "il" = (
 /obj/machinery/power/apc{
 	dir = 4;
@@ -4853,16 +4872,39 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/warden)
 "im" = (
-/obj/machinery/door/firedoor/glass,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/airlock/glass_security{
-	name = "Firing Range";
-	req_access = list(1)
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/red/bordercorner2{
+	dir = 5
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/tiled,
-/area/security/range)
+/area/security/hallwayaux)
 "in" = (
 /obj/machinery/door/firedoor/glass,
 /obj/structure/grille,
@@ -4878,20 +4920,39 @@
 /turf/simulated/floor/tiled,
 /area/security/eva)
 "ip" = (
-/obj/machinery/door/firedoor/glass,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 10;
+	icon_state = "borderfloorcorner2";
+	pixel_x = 0
+	},
+/obj/effect/floor_decal/corner/red/bordercorner2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/glass_security{
-	name = "Security EVA";
-	req_one_access = list(1,2,18)
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled,
-/area/security/eva)
+/area/security/hallway)
 "iq" = (
 /turf/simulated/floor,
 /area/maintenance/station/sec_upper)
@@ -5888,52 +5949,37 @@
 /turf/simulated/open,
 /area/security/brig)
 "jK" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/red/border{
-	dir = 8
-	},
-/obj/machinery/power/apc{
-	cell_type = /obj/item/weapon/cell/super;
-	dir = 8;
-	name = "west bump";
-	pixel_x = -28
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
-/area/security/hallwayaux)
-"jL" = (
-/obj/effect/floor_decal/borderfloor{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
-	},
-/obj/effect/floor_decal/corner/red/border{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 5
-	},
-/obj/effect/floor_decal/corner/red/bordercorner2{
-	dir = 5
 	},
 /obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
-/area/security/hallwayaux)
+/area/security/hallway)
+"jL" = (
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/door/airlock/glass_security{
+	name = "Brig Observation"
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled,
+/area/security/observation)
 "jM" = (
 /turf/simulated/floor/carpet,
 /area/crew_quarters/heads/hos)
@@ -6393,6 +6439,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/tiled,
 /area/security/observation)
 "kE" = (
@@ -6541,6 +6592,7 @@
 	icon_state = "corner_white";
 	dir = 10
 	},
+/obj/structure/cable/green,
 /turf/simulated/floor/tiled,
 /area/security/observation)
 "kP" = (
@@ -6735,10 +6787,12 @@
 /obj/effect/floor_decal/corner/red/border{
 	dir = 1
 	},
-/obj/item/weapon/storage/box/nifsofts_security,
 /obj/structure/table/reinforced,
 /obj/machinery/alarm{
 	pixel_y = 22
+	},
+/obj/machinery/photocopier/faxmachine{
+	department = "Security"
 	},
 /turf/simulated/floor/tiled,
 /area/security/briefing_room)
@@ -7491,6 +7545,7 @@
 	pixel_x = -24
 	},
 /obj/structure/table/steel,
+/obj/item/weapon/storage/box/nifsofts_security,
 /turf/simulated/floor/tiled/dark,
 /area/security/security_lockerroom)
 "mA" = (
@@ -9990,6 +10045,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
+/obj/structure/filingcabinet/chestdrawer,
 /turf/simulated/floor/tiled,
 /area/security/security_processing)
 "qQ" = (
@@ -11641,6 +11697,10 @@
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/junction{
+	icon_state = "pipe-j1";
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/security/hallway)
@@ -17788,6 +17848,19 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/station/upper)
+"Cu" = (
+/obj/machinery/door/firedoor/glass,
+/obj/structure/grille,
+/obj/structure/window/reinforced/polarized{
+	dir = 10;
+	icon_state = "fwindow";
+	id = "lawyer_blast"
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/lawoffice)
 "Cv" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 6
@@ -32638,9 +32711,9 @@ sT
 tP
 uJ
 vu
-wf
-wf
-wf
+Cu
+Cu
+Cu
 vu
 uO
 zX
@@ -32894,8 +32967,8 @@ hD
 dI
 ij
 ez
-iP
 cu
+iP
 jj
 dI
 jH
@@ -33037,7 +33110,7 @@ hU
 ez
 ez
 bC
-ca
+dn
 cL
 dI
 dJ
@@ -33178,8 +33251,8 @@ hF
 dI
 bD
 fl
-cb
-ik
+cN
+do
 dI
 dI
 dK
@@ -33322,13 +33395,13 @@ bS
 ez
 bE
 ez
-cN
+fn
 dp
 dL
 eh
 eC
 eV
-dn
+ip
 fD
 ga
 lz
@@ -33470,7 +33543,7 @@ jI
 bI
 cR
 ei
-fn
+jK
 QW
 lb
 lA
@@ -33612,7 +33685,7 @@ dM
 ej
 cP
 cP
-do
+jL
 eD
 cP
 lB
@@ -34738,7 +34811,7 @@ gS
 au
 aD
 bG
-im
+ca
 iA
 bM
 cg
@@ -35170,7 +35243,7 @@ bP
 cn
 cX
 jz
-jK
+ik
 cM
 cM
 kq
@@ -35312,7 +35385,7 @@ bQ
 co
 jl
 jA
-jL
+im
 jU
 cY
 kr
@@ -35732,7 +35805,7 @@ bj
 hr
 hN
 aV
-ip
+cb
 iF
 iR
 cs

--- a/maps/tether/tether-07-station3.dmm
+++ b/maps/tether/tether-07-station3.dmm
@@ -7521,6 +7521,9 @@
 	},
 /turf/simulated/floor,
 /area/maintenance/station/ai)
+"mx" = (
+/turf/simulated/mineral/vacuum,
+/area/space)
 "my" = (
 /obj/structure/sign/warning/secure_area,
 /turf/simulated/wall/r_wall,
@@ -35365,8 +35368,8 @@ aJ
 aJ
 aJ
 aJ
-gg
-gg
+mx
+mx
 ab
 ab
 aU
@@ -35506,9 +35509,9 @@ aa
 aa
 ae
 aa
-aa
-gg
-gg
+aJ
+mx
+mx
 ab
 ab
 aU
@@ -35648,9 +35651,9 @@ aa
 aa
 ae
 aa
-ed
-gg
-gg
+aJ
+mx
+mx
 ab
 ab
 aU
@@ -35790,8 +35793,8 @@ aa
 aa
 aO
 aa
-ed
-gg
+aJ
+mx
 ab
 ab
 ab
@@ -35932,8 +35935,8 @@ aa
 aa
 aa
 aa
-ed
-gg
+aJ
+mx
 ab
 ab
 ab
@@ -36074,8 +36077,8 @@ aa
 aa
 aa
 aa
-ed
-gg
+aJ
+aJ
 ab
 ab
 ab
@@ -36217,7 +36220,7 @@ aa
 aa
 aa
 aa
-gg
+aJ
 ab
 ab
 ab
@@ -36359,7 +36362,7 @@ aa
 aa
 aa
 aa
-gg
+aJ
 ab
 ab
 ab

--- a/maps/tether/tether-07-station3.dmm
+++ b/maps/tether/tether-07-station3.dmm
@@ -7522,13 +7522,6 @@
 /turf/simulated/floor,
 /area/maintenance/station/ai)
 "mx" = (
-/turf/simulated/mineral/vacuum,
-/area/space)
-"my" = (
-/obj/structure/sign/warning/secure_area,
-/turf/simulated/wall/r_wall,
-/area/security/security_bathroom)
-"mz" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
 	},
@@ -7546,6 +7539,29 @@
 /obj/item/weapon/storage/box/nifsofts_security,
 /turf/simulated/floor/tiled/dark,
 /area/security/security_lockerroom)
+"my" = (
+/obj/structure/sign/warning/secure_area,
+/turf/simulated/wall/r_wall,
+/area/security/security_bathroom)
+"mz" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/red/bordercorner2{
+	dir = 6
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/structure/filingcabinet/chestdrawer,
+/turf/simulated/floor/tiled,
+/area/security/security_processing)
 "mA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -10029,23 +10045,29 @@
 /area/security/security_processing)
 "qP" = (
 /obj/effect/floor_decal/borderfloor{
-	dir = 4
+	dir = 1;
+	pixel_y = 0
 	},
 /obj/effect/floor_decal/corner/red/border{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/junction{
+	icon_state = "pipe-j1";
 	dir = 4
 	},
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 6
-	},
-/obj/effect/floor_decal/corner/red/bordercorner2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/obj/structure/filingcabinet/chestdrawer,
 /turf/simulated/floor/tiled,
-/area/security/security_processing)
+/area/security/hallway)
 "qQ" = (
 /obj/machinery/door/firedoor/glass,
 /obj/structure/grille,
@@ -11678,30 +11700,18 @@
 /turf/simulated/floor/tiled,
 /area/security/hallway)
 "tc" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 1;
-	pixel_y = 0
+/obj/machinery/door/firedoor/glass,
+/obj/structure/grille,
+/obj/structure/window/reinforced/polarized{
+	dir = 10;
+	icon_state = "fwindow";
+	id = "lawyer_blast"
 	},
-/obj/effect/floor_decal/corner/red/border{
-	dir = 1
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/disposalpipe/junction{
-	icon_state = "pipe-j1";
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/security/hallway)
+/turf/simulated/floor,
+/area/lawoffice)
 "td" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1;
@@ -17846,19 +17856,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/station/upper)
-"Cu" = (
-/obj/machinery/door/firedoor/glass,
-/obj/structure/grille,
-/obj/structure/window/reinforced/polarized{
-	dir = 10;
-	icon_state = "fwindow";
-	id = "lawyer_blast"
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/simulated/floor,
-/area/lawoffice)
 "Cv" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 6
@@ -27245,6 +27242,9 @@
 	},
 /turf/simulated/floor,
 /area/maintenance/station/sec_upper)
+"SW" = (
+/turf/simulated/mineral/vacuum,
+/area/space)
 
 (1,1,1) = {"
 aa
@@ -32410,7 +32410,7 @@ kK
 kY
 eT
 mc
-mz
+mx
 eu
 nH
 ob
@@ -32709,9 +32709,9 @@ sT
 tP
 uJ
 vu
-Cu
-Cu
-Cu
+tc
+tc
+tc
 vu
 uO
 zX
@@ -34409,7 +34409,7 @@ qh
 fK
 rv
 qQ
-tc
+qP
 tX
 uR
 vF
@@ -34974,7 +34974,7 @@ oF
 pp
 pP
 qi
-qP
+mz
 ry
 qQ
 tZ
@@ -35368,8 +35368,8 @@ aJ
 aJ
 aJ
 aJ
-mx
-mx
+SW
+SW
 ab
 ab
 aU
@@ -35510,8 +35510,8 @@ aa
 ae
 aa
 aJ
-mx
-mx
+SW
+SW
 ab
 ab
 aU
@@ -35652,8 +35652,8 @@ aa
 ae
 aa
 aJ
-mx
-mx
+SW
+SW
 ab
 ab
 aU
@@ -35794,7 +35794,7 @@ aa
 aO
 aa
 aJ
-mx
+SW
 ab
 ab
 ab
@@ -35936,7 +35936,7 @@ aa
 aa
 aa
 aJ
-mx
+SW
 ab
 ab
 ab


### PR DESCRIPTION
I swear half of these I fixed before. I blame the dmm to tgm conversions.
*The rest is incompetence.*

**Changes:**
Fixes yet more wires.
Fixes a missing disposal junction.
Adds window panes to the exterior window of IA.
Adds a shutter to the warden's office. Slightly shuffles a few items in their office as well.
Adds a fax machine to the briefing room for general security use.

It'd be naive of me to say that the fixes stop here. Leave this PR open until just before the update.