### PR TITLE
 Enables prometheans to be able to select wings, tail, and ears.

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/prometheans.dm
+++ b/code/modules/mob/living/carbon/human/species/station/prometheans.dm
@@ -98,9 +98,15 @@ var/datum/species/shapeshifter/promethean/prometheans
 		/mob/living/carbon/human/proc/shapeshifter_select_eye_colour,
 		/mob/living/carbon/human/proc/shapeshifter_select_hair_colors,
 		/mob/living/carbon/human/proc/shapeshifter_select_gender,
-		/mob/living/carbon/human/proc/shapeshifter_select_wings, //VOREStation Add,
-		/mob/living/carbon/human/proc/shapeshifter_select_tail, //VOREStation Add,
-		/mob/living/carbon/human/proc/shapeshifter_select_ears, //VOREStation Add,
+		/mob/living/carbon/human/proc/shapeshifter_select_wings, //VOREStation Add Start,
+		/mob/living/carbon/human/proc/shapeshifter_select_tail, 
+		/mob/living/carbon/human/proc/shapeshifter_select_ears,
+		/mob/living/proc/set_size,
+		/mob/living/carbon/human/proc/succubus_drain,
+		/mob/living/carbon/human/proc/succubus_drain_finalize,
+		/mob/living/carbon/human/proc/succubus_drain_lethal,
+		/mob/living/carbon/human/proc/slime_feed,
+		/mob/living/proc/eat_trash, //VOREStation Add End,
 		/mob/living/carbon/human/proc/regenerate
 		)
 

--- a/code/modules/mob/living/carbon/human/species/station/prometheans_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/prometheans_vr.dm
@@ -20,7 +20,7 @@
 	trashcan = 1 //They have goopy bodies. They can just dissolve things within them.
 
 	appearance_flags = HAS_SKIN_COLOR | HAS_EYE_COLOR | HAS_HAIR_COLOR | RADIATION_GLOWS | HAS_UNDERWEAR
-
+/* //Use the list in prometheans_vr. This is done in order to cause conflicts if their verbs list is updated so if Polaris gives them a verb, we'll know about it and it doesn't get overlooked.
 	inherent_verbs = list(
 		/mob/living/carbon/human/proc/shapeshifter_select_shape,
 		/mob/living/carbon/human/proc/shapeshifter_select_colour,
@@ -35,3 +35,4 @@
 		/mob/living/carbon/human/proc/slime_feed,
 		/mob/living/proc/eat_trash
 		)
+*/

--- a/code/modules/mob/living/carbon/human/species/station/prometheans_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/prometheans_vr.dm
@@ -20,7 +20,7 @@
 	trashcan = 1 //They have goopy bodies. They can just dissolve things within them.
 
 	appearance_flags = HAS_SKIN_COLOR | HAS_EYE_COLOR | HAS_HAIR_COLOR | RADIATION_GLOWS | HAS_UNDERWEAR
-/* //Use the list in prometheans_vr. This is done in order to cause conflicts if their verbs list is updated so if Polaris gives them a verb, we'll know about it and it doesn't get overlooked.
+/* //Use the list in prometheans. This is done in order to cause conflicts if their verbs list is updated so if Polaris gives them a verb, we'll know about it and it doesn't get overlooked.
 	inherent_verbs = list(
 		/mob/living/carbon/human/proc/shapeshifter_select_shape,
 		/mob/living/carbon/human/proc/shapeshifter_select_colour,

--- a/code/modules/vore/eating/transforming_vr.dm
+++ b/code/modules/vore/eating/transforming_vr.dm
@@ -216,12 +216,22 @@
 		return
 
 	if (M.species == "Promethean" && O.species != "Promethean") //If the person was a promethean before TF, remove all their verbs!
-		M.verbs -=  /mob/living/carbon/human/proc/shapeshifter_select_shape
-		M.verbs -=  /mob/living/carbon/human/proc/shapeshifter_select_colour
-		M.verbs -=  /mob/living/carbon/human/proc/shapeshifter_select_hair
-		M.verbs -=  /mob/living/carbon/human/proc/shapeshifter_select_gender
+		M.verbs -= /mob/living/carbon/human/proc/shapeshifter_select_shape,
+		M.verbs -=  /mob/living/carbon/human/proc/shapeshifter_select_colour,
+		M.verbs -=  /mob/living/carbon/human/proc/shapeshifter_select_hair,
+		M.verbs -=  /mob/living/carbon/human/proc/shapeshifter_select_eye_colour,
+		M.verbs -=  /mob/living/carbon/human/proc/shapeshifter_select_hair_colors,
+		M.verbs -=  /mob/living/carbon/human/proc/shapeshifter_select_gender,
+		M.verbs -=  /mob/living/carbon/human/proc/shapeshifter_select_wings,
+		M.verbs -=  /mob/living/carbon/human/proc/shapeshifter_select_tail, 
+		M.verbs -=  /mob/living/carbon/human/proc/shapeshifter_select_ears,
+		M.verbs -=  /mob/living/proc/set_size,
+		M.verbs -=  /mob/living/carbon/human/proc/succubus_drain,
+		M.verbs -=  /mob/living/carbon/human/proc/succubus_drain_finalize,
+		M.verbs -=  /mob/living/carbon/human/proc/succubus_drain_lethal,
+		M.verbs -=  /mob/living/carbon/human/proc/slime_feed,
+		M.verbs -=  /mob/living/proc/eat_trash,
 		M.verbs -=  /mob/living/carbon/human/proc/regenerate
-		M.verbs -=  /mob/living/proc/set_size
 
 	M.species = O.species
 	M.custom_species = O.custom_species
@@ -239,12 +249,22 @@
 		to_chat(M, "<span class='notice'>You lose sensation of your body, feeling only the warmth of everything around you... </span>")
 		to_chat(O, "<span class='notice'>Your body shifts as you make dramatic changes to your captive's body.</span>")
 	if (M.species == "Promethean") //Did they get TF'd into a promethean?
-		M.verbs +=  /mob/living/carbon/human/proc/shapeshifter_select_shape
-		M.verbs +=  /mob/living/carbon/human/proc/shapeshifter_select_colour
-		M.verbs +=  /mob/living/carbon/human/proc/shapeshifter_select_hair
-		M.verbs +=  /mob/living/carbon/human/proc/shapeshifter_select_gender
+		M.verbs += /mob/living/carbon/human/proc/shapeshifter_select_shape,
+		M.verbs +=  /mob/living/carbon/human/proc/shapeshifter_select_colour,
+		M.verbs +=  /mob/living/carbon/human/proc/shapeshifter_select_hair,
+		M.verbs +=  /mob/living/carbon/human/proc/shapeshifter_select_eye_colour,
+		M.verbs +=  /mob/living/carbon/human/proc/shapeshifter_select_hair_colors,
+		M.verbs +=  /mob/living/carbon/human/proc/shapeshifter_select_gender,
+		M.verbs +=  /mob/living/carbon/human/proc/shapeshifter_select_wings,
+		M.verbs +=  /mob/living/carbon/human/proc/shapeshifter_select_tail, 
+		M.verbs +=  /mob/living/carbon/human/proc/shapeshifter_select_ears,
+		M.verbs +=  /mob/living/proc/set_size,
+		M.verbs +=  /mob/living/carbon/human/proc/succubus_drain,
+		M.verbs +=  /mob/living/carbon/human/proc/succubus_drain_finalize,
+		M.verbs +=  /mob/living/carbon/human/proc/succubus_drain_lethal,
+		M.verbs +=  /mob/living/carbon/human/proc/slime_feed,
+		M.verbs +=  /mob/living/proc/eat_trash,
 		M.verbs +=  /mob/living/carbon/human/proc/regenerate
-		M.verbs +=  /mob/living/proc/set_size
 		M.shapeshifter_select_shape()
 
 /obj/belly/proc/put_in_egg(var/atom/movable/M, message=0)

--- a/code/modules/vore/eating/transforming_vr.dm
+++ b/code/modules/vore/eating/transforming_vr.dm
@@ -216,21 +216,21 @@
 		return
 
 	if (M.species == "Promethean" && O.species != "Promethean") //If the person was a promethean before TF, remove all their verbs!
-		M.verbs -= /mob/living/carbon/human/proc/shapeshifter_select_shape,
-		M.verbs -=  /mob/living/carbon/human/proc/shapeshifter_select_colour,
-		M.verbs -=  /mob/living/carbon/human/proc/shapeshifter_select_hair,
-		M.verbs -=  /mob/living/carbon/human/proc/shapeshifter_select_eye_colour,
-		M.verbs -=  /mob/living/carbon/human/proc/shapeshifter_select_hair_colors,
-		M.verbs -=  /mob/living/carbon/human/proc/shapeshifter_select_gender,
-		M.verbs -=  /mob/living/carbon/human/proc/shapeshifter_select_wings,
-		M.verbs -=  /mob/living/carbon/human/proc/shapeshifter_select_tail, 
-		M.verbs -=  /mob/living/carbon/human/proc/shapeshifter_select_ears,
-		M.verbs -=  /mob/living/proc/set_size,
-		M.verbs -=  /mob/living/carbon/human/proc/succubus_drain,
-		M.verbs -=  /mob/living/carbon/human/proc/succubus_drain_finalize,
-		M.verbs -=  /mob/living/carbon/human/proc/succubus_drain_lethal,
-		M.verbs -=  /mob/living/carbon/human/proc/slime_feed,
-		M.verbs -=  /mob/living/proc/eat_trash,
+		M.verbs -=  /mob/living/carbon/human/proc/shapeshifter_select_shape
+		M.verbs -=  /mob/living/carbon/human/proc/shapeshifter_select_colour
+		M.verbs -=  /mob/living/carbon/human/proc/shapeshifter_select_hair
+		M.verbs -=  /mob/living/carbon/human/proc/shapeshifter_select_eye_colour
+		M.verbs -=  /mob/living/carbon/human/proc/shapeshifter_select_hair_colors
+		M.verbs -=  /mob/living/carbon/human/proc/shapeshifter_select_gender
+		M.verbs -=  /mob/living/carbon/human/proc/shapeshifter_select_wings
+		M.verbs -=  /mob/living/carbon/human/proc/shapeshifter_select_tail
+		M.verbs -=  /mob/living/carbon/human/proc/shapeshifter_select_ears
+		M.verbs -=  /mob/living/proc/set_size
+		M.verbs -=  /mob/living/carbon/human/proc/succubus_drain
+		M.verbs -=  /mob/living/carbon/human/proc/succubus_drain_finalize
+		M.verbs -=  /mob/living/carbon/human/proc/succubus_drain_lethal
+		M.verbs -=  /mob/living/carbon/human/proc/slime_feed
+		M.verbs -=  /mob/living/proc/eat_trash
 		M.verbs -=  /mob/living/carbon/human/proc/regenerate
 
 	M.species = O.species
@@ -249,21 +249,21 @@
 		to_chat(M, "<span class='notice'>You lose sensation of your body, feeling only the warmth of everything around you... </span>")
 		to_chat(O, "<span class='notice'>Your body shifts as you make dramatic changes to your captive's body.</span>")
 	if (M.species == "Promethean") //Did they get TF'd into a promethean?
-		M.verbs += /mob/living/carbon/human/proc/shapeshifter_select_shape,
-		M.verbs +=  /mob/living/carbon/human/proc/shapeshifter_select_colour,
-		M.verbs +=  /mob/living/carbon/human/proc/shapeshifter_select_hair,
-		M.verbs +=  /mob/living/carbon/human/proc/shapeshifter_select_eye_colour,
-		M.verbs +=  /mob/living/carbon/human/proc/shapeshifter_select_hair_colors,
-		M.verbs +=  /mob/living/carbon/human/proc/shapeshifter_select_gender,
-		M.verbs +=  /mob/living/carbon/human/proc/shapeshifter_select_wings,
-		M.verbs +=  /mob/living/carbon/human/proc/shapeshifter_select_tail, 
-		M.verbs +=  /mob/living/carbon/human/proc/shapeshifter_select_ears,
-		M.verbs +=  /mob/living/proc/set_size,
-		M.verbs +=  /mob/living/carbon/human/proc/succubus_drain,
-		M.verbs +=  /mob/living/carbon/human/proc/succubus_drain_finalize,
-		M.verbs +=  /mob/living/carbon/human/proc/succubus_drain_lethal,
-		M.verbs +=  /mob/living/carbon/human/proc/slime_feed,
-		M.verbs +=  /mob/living/proc/eat_trash,
+		M.verbs +=  /mob/living/carbon/human/proc/shapeshifter_select_shape
+		M.verbs +=  /mob/living/carbon/human/proc/shapeshifter_select_colour
+		M.verbs +=  /mob/living/carbon/human/proc/shapeshifter_select_hair
+		M.verbs +=  /mob/living/carbon/human/proc/shapeshifter_select_eye_colour
+		M.verbs +=  /mob/living/carbon/human/proc/shapeshifter_select_hair_colors
+		M.verbs +=  /mob/living/carbon/human/proc/shapeshifter_select_gender
+		M.verbs +=  /mob/living/carbon/human/proc/shapeshifter_select_wings
+		M.verbs +=  /mob/living/carbon/human/proc/shapeshifter_select_tail
+		M.verbs +=  /mob/living/carbon/human/proc/shapeshifter_select_ears
+		M.verbs +=  /mob/living/proc/set_size
+		M.verbs +=  /mob/living/carbon/human/proc/succubus_drain
+		M.verbs +=  /mob/living/carbon/human/proc/succubus_drain_finalize
+		M.verbs +=  /mob/living/carbon/human/proc/succubus_drain_lethal
+		M.verbs +=  /mob/living/carbon/human/proc/slime_feed
+		M.verbs +=  /mob/living/proc/eat_trash
 		M.verbs +=  /mob/living/carbon/human/proc/regenerate
 		M.shapeshifter_select_shape()
 


### PR DESCRIPTION
Changes which list they used, as the stock one was overwritten, causing problems and preventing them from using the three vorestation specific procs.

Updates transformations for being TF'd away and being TF'd into a promethean

Not only that, but this means in the future if Polaris adds anything to slimes, we'll know about it and it won't get accidentally overwritten.