### PR TITLE
Fixes the prototype trait showing up

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/trait.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/trait.dm
@@ -1,5 +1,5 @@
 /datum/trait
-	var/name = "Prototype Trait"
+	var/name
 	var/desc = "Contact a developer if you see this trait."
 
 	var/cost = 0			// 0 is neutral, negative cost means negative, positive cost means positive.


### PR DESCRIPTION
Aro supposedly fixed this in #3765, but it still shows up, because Aro added a check for a name, and it still has a name.
This makes that work by removing the name on the Prototype trait.
I did test this, and the traits system seems to work fine, with the only difference being a lack of the prototype trait.

Am I missing something here? I feel like I'm missing something here. I don't want to sound pretentious or insulting or anything, but did I catch this when neither Aro nor Leshana did? Is there a reason the prototype trait needs a name?