### PR TITLE
Fixes Stairs in BYOND 512.1436

### DIFF
--- a/code/modules/multiz/structures.dm
+++ b/code/modules/multiz/structures.dm
@@ -142,19 +142,20 @@
 		if(!istype(above))
 			above.ChangeTurf(/turf/simulated/open)
 
-/obj/structure/stairs/Uncross(atom/movable/A)
-	if(A.dir == dir && upperStep(A.loc))
-		// This is hackish but whatever.
-		var/turf/target = get_step(GetAbove(A), dir)
-		var/turf/source = A.loc
-		if(target.Enter(A, source))
-			A.forceMove(target)
-			if(isliving(A))
-				var/mob/living/L = A
-				if(L.pulling)
-					L.pulling.forceMove(target)
-		return 0
-	return 1
+/obj/structure/stairs/CheckExit(atom/movable/mover as mob|obj, turf/target as turf)
+	if(get_dir(loc, target) == dir && upperStep(mover.loc))
+		return FALSE
+	. = ..()
+
+/obj/structure/stairs/Bumped(atom/movable/A)
+	// This is hackish but whatever.
+	var/turf/target = get_step(GetAbove(A), dir)
+	if(target.Enter(A, src)) // Pass src to be ignored to avoid infinate loop
+		A.forceMove(target)
+		if(isliving(A))
+			var/mob/living/L = A
+			if(L.pulling)
+				L.pulling.forceMove(target)
 
 /obj/structure/stairs/proc/upperStep(var/turf/T)
 	return (T == loc)


### PR DESCRIPTION
BYOND no longer calls Uncross reliably, to fix this we switch to using CheckExit and Bumped.  This solution is probably the right way to do it anyway.