### PR TITLE
Hides mechanical vore preferences for mimics

### DIFF
--- a/code/modules/mob/living/simple_animal/aliens/mimic.dm
+++ b/code/modules/mob/living/simple_animal/aliens/mimic.dm
@@ -39,6 +39,8 @@
 
 	meat_type = /obj/item/weapon/reagent_containers/food/snacks/carpmeat
 
+	showvoreprefs = 0 //VOREStation Edit - Hides mechanical vore prefs for mimics. You can't see their gaping maws when they're just sitting idle.
+
 /mob/living/simple_animal/hostile/mimic/set_target()
 	. = ..()
 	if(.)

--- a/code/modules/vore/eating/living_vr.dm
+++ b/code/modules/vore/eating/living_vr.dm
@@ -2,6 +2,7 @@
 /mob/living
 	var/digestable = 1					// Can the mob be digested inside a belly?
 	var/allowmobvore = 1				// Will simplemobs attempt to eat the mob?
+	var/showvoreprefs = 1				// Determines if the mechanical vore preferences button will be displayed on the mob or not.
 	var/obj/belly/vore_selected			// Default to no vore capability.
 	var/list/vore_organs = list()		// List of vore containers inside a mob
 	var/absorbed = 0					// If a mob is absorbed into another
@@ -612,7 +613,8 @@
 
 /mob/living/examine(mob/user)
 	. = ..()
-	to_chat(user, "<span class='deptradio'><a href='?src=\ref[src];vore_prefs=1'>\[Mechanical Vore Preferences\]</a></span>")
+	if(showvoreprefs)
+		to_chat(user, "<span class='deptradio'><a href='?src=\ref[src];vore_prefs=1'>\[Mechanical Vore Preferences\]</a></span>")
 
 /mob/living/Topic(href, href_list)	//Can't find any instances of Topic() being overridden by /mob/living in polaris' base code, even though /mob/living/carbon/human's Topic() has a ..() call
 	if(href_list["vore_prefs"])


### PR DESCRIPTION
Fixes #4046 

While it would be kinda nice for mimics to have some kind of hard tell outside of getting chomped by one, being able to spot a mimic just by squinting your eyes at it is pretty silly. It'd be neat if mimics occasionally rarely opened up to lick their "lips" when no other mobs are nearby, but that's outside of the scope of this PR.