### PR TITLE
Mewchild's Security fixes and tweaks

### DIFF
--- a/maps/tether/tether-06-station2.dmm
+++ b/maps/tether/tether-06-station2.dmm
@@ -996,7 +996,6 @@
 /turf/simulated/floor/tiled,
 /area/security/brig)
 "bE" = (
-/obj/item/weapon/stool/padded,
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/borderfloor/corner{
 	dir = 4
@@ -1009,6 +1008,9 @@
 /obj/effect/floor_decal/corner/lightorange/bordercorner{
 	icon_state = "bordercolorcorner";
 	dir = 4
+	},
+/obj/structure/bed/chair{
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/security/brig)
@@ -1723,6 +1725,7 @@
 	dir = 4;
 	pixel_x = 24
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled,
 /area/security/security_cell_hallway)
 "cA" = (
@@ -2502,6 +2505,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled,
 /area/security/brig/visitation)
 "dM" = (
@@ -2826,6 +2830,7 @@
 /area/security/brig)
 "es" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/steel_dirty,
 /area/security/brig)
 "ev" = (
@@ -3781,6 +3786,7 @@
 /obj/effect/floor_decal/corner/red/bordercorner2{
 	dir = 1
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled,
 /area/security/security_cell_hallway)
 "gX" = (

--- a/maps/tether/tether-07-station3.dmm
+++ b/maps/tether/tether-07-station3.dmm
@@ -34,7 +34,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/tiled,
 /area/security/eva)
 "ah" = (
 /obj/effect/floor_decal/borderfloorblack{
@@ -97,7 +97,7 @@
 	tag_exterior_door = "sec_fore_outer";
 	tag_interior_door = "sec_fore_inner"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/tiled,
 /area/security/eva)
 "al" = (
 /obj/effect/floor_decal/borderfloorblack{
@@ -254,14 +254,20 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/turf/simulated/floor/tiled,
 /area/security/eva)
 "ay" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
 /area/security/eva)
 "az" = (
 /obj/effect/floor_decal/borderfloorblack{
@@ -347,9 +353,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/range)
-"aF" = (
-/turf/simulated/floor,
-/area/security/eva)
 "aG" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -373,7 +376,10 @@
 /obj/machinery/camera/network/security{
 	dir = 1
 	},
-/turf/simulated/floor,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
 /area/security/eva)
 "aI" = (
 /turf/simulated/wall,
@@ -602,6 +608,7 @@
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/red/border,
 /obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled,
 /area/security/eva)
 "aY" = (
@@ -643,7 +650,7 @@
 /obj/machinery/camera/network/engineering{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/tiled,
 /area/security/eva)
 "bc" = (
 /turf/simulated/wall,
@@ -1081,7 +1088,7 @@
 "bJ" = (
 /obj/structure/closet/emcloset,
 /obj/effect/decal/cleanable/cobweb,
-/turf/simulated/floor,
+/turf/simulated/floor/tiled,
 /area/security/eva)
 "bK" = (
 /obj/effect/floor_decal/borderfloor,
@@ -1124,6 +1131,7 @@
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/red/border,
 /obj/machinery/light,
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled,
 /area/security/hallwayaux)
 "bP" = (
@@ -2016,9 +2024,7 @@
 /area/crew_quarters/heads/hos)
 "du" = (
 /obj/structure/table/woodentable,
-/obj/machinery/newscaster{
-	layer = 3.3;
-	pixel_x = 0;
+/obj/machinery/newscaster/security_unit{
 	pixel_y = -32
 	},
 /turf/simulated/floor/tiled/dark,
@@ -2053,6 +2059,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/dark,
 /area/security/security_equiptment_storage)
 "dA" = (
@@ -2489,6 +2496,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/heads/hos)
 "em" = (
@@ -3330,6 +3338,7 @@
 	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled,
 /area/security/hallway)
 "fE" = (
@@ -3804,7 +3813,7 @@
 	frequency = 1379;
 	id_tag = "sec_fore_pump"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/tiled,
 /area/security/eva)
 "gy" = (
 /turf/simulated/wall,
@@ -4107,7 +4116,7 @@
 	pixel_y = 22
 	},
 /obj/structure/closet/emcloset,
-/turf/simulated/floor,
+/turf/simulated/floor/tiled,
 /area/security/eva)
 "ha" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden{
@@ -4115,18 +4124,14 @@
 	icon_state = "map"
 	},
 /obj/machinery/meter,
-/turf/simulated/floor,
+/turf/simulated/floor/tiled,
 /area/security/eva)
 "hb" = (
-/obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 0
-	},
 /obj/machinery/atmospherics/portables_connector{
 	dir = 8
 	},
 /obj/machinery/portable_atmospherics/canister/air/airlock,
-/turf/simulated/floor,
+/turf/simulated/floor/tiled,
 /area/security/eva)
 "hc" = (
 /obj/machinery/alarm{
@@ -4274,18 +4279,6 @@
 "hr" = (
 /turf/simulated/floor/tiled,
 /area/security/eva)
-"hs" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/turf/simulated/floor/tiled,
-/area/security/eva)
-"ht" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/security/eva)
 "hu" = (
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/blast/regular{
@@ -4307,7 +4300,7 @@
 	dir = 5;
 	icon_state = "intact"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/tiled,
 /area/security/eva)
 "hw" = (
 /obj/effect/decal/cleanable/dirt,
@@ -4315,14 +4308,7 @@
 	dir = 5;
 	icon_state = "intact"
 	},
-/turf/simulated/floor,
-/area/security/eva)
-"hx" = (
-/obj/machinery/atmospherics/portables_connector{
-	dir = 8
-	},
-/obj/machinery/portable_atmospherics/canister/air/airlock,
-/turf/simulated/floor,
+/turf/simulated/floor/tiled,
 /area/security/eva)
 "hy" = (
 /turf/simulated/mineral/floor/cave,
@@ -4492,24 +4478,21 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/eva)
-"hO" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+"hP" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/turf/simulated/floor/tiled,
-/area/security/eva)
-"hP" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/security/eva)
 "hQ" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
 /area/security/eva)
 "hR" = (
 /obj/machinery/door/firedoor/border_only,
@@ -4635,7 +4618,7 @@
 "hZ" = (
 /obj/machinery/door/airlock/maintenance/sec{
 	name = "Security Airlock Access";
-	req_one_access = newlist()
+	req_access = list(1,2,18)
 	},
 /turf/simulated/floor,
 /area/security/eva)
@@ -4855,7 +4838,7 @@
 	dir = 5
 	},
 /obj/structure/filingcabinet/chestdrawer,
-/obj/machinery/newscaster{
+/obj/machinery/newscaster/security_unit{
 	pixel_y = 32
 	},
 /turf/simulated/floor/tiled/dark,
@@ -5929,12 +5912,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/hallwayaux)
-"jJ" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/open,
-/area/security/brig)
 "jK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -6193,13 +6170,6 @@
 /obj/structure/sign/warning/secure_area,
 /turf/simulated/wall/r_wall,
 /area/security/armory/blue)
-"kg" = (
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
-	},
-/turf/simulated/open,
-/area/security/brig)
 "kh" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -6254,8 +6224,14 @@
 /turf/simulated/wall/r_wall,
 /area/security/security_equiptment_storage)
 "kp" = (
-/obj/machinery/light/small,
-/turf/simulated/floor,
+/obj/machinery/light,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/turf/simulated/floor/tiled,
 /area/security/eva)
 "kq" = (
 /obj/effect/floor_decal/borderfloor{
@@ -6507,6 +6483,7 @@
 /obj/machinery/shower{
 	pixel_y = 16
 	},
+/obj/structure/curtain/open/shower/security,
 /turf/simulated/floor/tiled,
 /area/security/security_bathroom)
 "kK" = (
@@ -6977,6 +6954,9 @@
 /area/security/hallway)
 "lB" = (
 /obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
 	dir = 8
 	},
 /turf/simulated/open,
@@ -7633,30 +7613,14 @@
 /obj/machinery/camera/network/security{
 	dir = 1
 	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
 /turf/simulated/open,
 /area/security/hallway)
 "mH" = (
 /turf/simulated/wall/r_wall,
 /area/security/hallway)
-"mI" = (
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
-	},
-/turf/simulated/open,
-/area/security/brig)
-"mJ" = (
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/open,
-/area/security/brig)
 "mK" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -7858,7 +7822,7 @@
 /area/security/breakroom)
 "nf" = (
 /obj/machinery/camera/network/security,
-/obj/machinery/newscaster{
+/obj/machinery/newscaster/security_unit{
 	pixel_y = 32
 	},
 /turf/simulated/floor/wood,
@@ -7903,6 +7867,7 @@
 /obj/effect/floor_decal/borderfloorblack/corner,
 /obj/effect/floor_decal/corner/red/bordercorner,
 /obj/structure/table/bench/steel,
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/dark,
 /area/security/security_lockerroom)
 "nl" = (
@@ -11548,15 +11513,6 @@
 /area/security/hallway)
 "sW" = (
 /obj/machinery/door/firedoor/glass,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
 /obj/machinery/door/blast/regular{
 	density = 0;
 	dir = 1;
@@ -13783,7 +13739,6 @@
 /turf/simulated/floor/tiled,
 /area/security/lobby)
 "wk" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
 	d1 = 1;
@@ -13796,6 +13751,9 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
 /turf/simulated/floor/tiled,
 /area/security/lobby)
 "wl" = (
@@ -13805,11 +13763,13 @@
 /obj/effect/landmark/start{
 	name = "Security Officer"
 	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
 /area/security/lobby)
 "wm" = (
 /obj/machinery/door/firedoor/glass,
-/obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/machinery/door/blast/regular{
 	density = 0;
 	dir = 1;
@@ -14104,21 +14064,19 @@
 	icon_state = "tube1";
 	dir = 8
 	},
+/obj/machinery/newscaster/security_unit{
+	pixel_x = -32
+	},
 /turf/simulated/floor/tiled,
 /area/security/lobby)
 "wP" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/security/lobby)
 "wQ" = (
@@ -14133,12 +14091,6 @@
 	},
 /obj/effect/floor_decal/corner/red/bordercorner2{
 	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
 	},
 /obj/structure/table/reinforced,
 /obj/item/weapon/paper_bin{
@@ -14756,13 +14708,13 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
 /turf/simulated/floor/tiled,
 /area/security/lobby)
 "xJ" = (
 /obj/machinery/door/firedoor/glass,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
 /obj/machinery/door/blast/regular{
 	density = 0;
 	dir = 1;
@@ -27337,9 +27289,81 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/simulated/wall/r_wall,
 /area/security/lobby)
+"Sa" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/security/eva)
 "SW" = (
 /turf/simulated/mineral/vacuum,
 /area/space)
+"Un" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/carpet,
+/area/security/breakroom)
+"Up" = (
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 1;
+	icon_state = "pdoor0";
+	id = "security_lockdown";
+	name = "Security Blast Doors";
+	opacity = 0
+	},
+/obj/machinery/door/airlock/maintenance/sec{
+	name = "Security Airlock Access";
+	req_access = list(1,2,18)
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/security/eva)
+"Ur" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/turf/simulated/floor/tiled,
+/area/security/eva)
+"Vn" = (
+/obj/structure/bed/chair/office/dark{
+	dir = 4
+	},
+/obj/effect/landmark/start{
+	name = "Security Officer"
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/security/lobby)
+"WY" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/dark,
+/area/security/evidence_storage)
+"XG" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled,
+/area/security/eva)
+"ZO" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/tiled,
+/area/security/eva)
 
 (1,1,1) = {"
 aa
@@ -31942,7 +31966,7 @@ nh
 ey
 eH
 ow
-oX
+Un
 pB
 qd
 qz
@@ -34074,7 +34098,7 @@ nN
 oz
 fo
 pK
-pL
+WY
 qL
 fL
 fN
@@ -34344,14 +34368,14 @@ jk
 jk
 jk
 jk
-kg
+jk
 jk
 jk
 jk
 gb
 cT
 cT
-mI
+jy
 jk
 jk
 of
@@ -34652,7 +34676,7 @@ uS
 vG
 wl
 wQ
-wl
+Vn
 ys
 zp
 Ae
@@ -35052,7 +35076,7 @@ bN
 cg
 jk
 jk
-jJ
+jk
 jk
 jk
 jk
@@ -35061,7 +35085,7 @@ jk
 gb
 cT
 cT
-mJ
+jy
 jk
 jk
 oh
@@ -35895,7 +35919,7 @@ ab
 ab
 aU
 bj
-hr
+XG
 hN
 aV
 cb
@@ -36179,8 +36203,8 @@ ab
 ab
 aU
 gW
-hr
-hM
+ZO
+Sa
 aX
 in
 bu
@@ -36321,8 +36345,8 @@ ab
 ab
 aU
 gX
-hs
-hO
+hr
+hM
 aY
 in
 bu
@@ -36463,7 +36487,7 @@ ab
 ab
 aU
 bk
-ht
+hr
 hP
 Rl
 aU
@@ -36606,7 +36630,7 @@ aU
 aU
 aU
 hu
-hu
+Up
 aU
 aU
 iI
@@ -36748,7 +36772,7 @@ gx
 bb
 gY
 hv
-aF
+hP
 bm
 bz
 bw
@@ -37173,7 +37197,7 @@ aa
 ab
 bc
 bJ
-ay
+Ur
 hQ
 bm
 bm
@@ -37458,7 +37482,7 @@ ab
 bc
 bc
 hb
-hx
+hb
 bc
 pS
 eW

--- a/maps/tether/tether-07-station3.dmm
+++ b/maps/tether/tether-07-station3.dmm
@@ -10325,6 +10325,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/white,
 /area/security/forensics)
 "rm" = (

--- a/maps/tether/tether-07-station3.dmm
+++ b/maps/tether/tether-07-station3.dmm
@@ -1025,6 +1025,7 @@
 /obj/effect/landmark/start{
 	name = "Warden"
 	},
+/obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled/dark,
 /area/security/warden)
 "bF" = (
@@ -1288,6 +1289,12 @@
 	dir = 1;
 	pixel_x = 22;
 	pixel_y = -24
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/warden)
@@ -1984,6 +1991,9 @@
 	pixel_x = 6;
 	pixel_y = -39;
 	req_access = list(3)
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/warden)
@@ -27292,6 +27302,15 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/simulated/wall/r_wall,
 /area/security/lobby)
+"RB" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/warden)
 "Sa" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -33514,7 +33533,7 @@ dI
 bS
 ez
 bE
-ez
+RB
 fn
 dp
 dL


### PR DESCRIPTION
Fixes a few atmos piping issues
Changes newscasters in security to security newscasters. This allows arrest warrants to be put out
Tweaks security EVA access to be in line, stylistically, with other EVA outlets on asteroid. Changes Access door to reflect it being a security area.
Many AI holopads in security department, as they were missed
Removes Stool in brig, as it had an easy escape exploit. Replaced with chair. 
Adds glass to second floor staircase, isolating atmos regions.

Fixes #4054