### PR TITLE
Couple clown tweaks.

### DIFF
--- a/code/game/jobs/job/special.dm
+++ b/code/game/jobs/job/special.dm
@@ -109,10 +109,10 @@
 
 		if(H.backbag > 0)
 			H.equip_to_slot_or_del(new /obj/item/weapon/stamp/clown(H.back), slot_in_backpack)
-			H.equip_to_slot_or_del(new /obj/item/weapon/bikehorn(H.back), slot_in_backpack)
+			H.equip_to_slot_or_del(new /obj/item/weapon/bikehorn(H.back), slot_in_backpack) //VOREStation Edit
 		else
 			H.equip_to_slot_or_del(new /obj/item/weapon/stamp/clown(H), slot_l_hand)
-			H.equip_to_slot_or_del(new /obj/item/weapon/bikehorn(H.back), slot_l_hand)
+			H.equip_to_slot_or_del(new /obj/item/weapon/bikehorn(H.back), slot_l_hand) //VOREStation Edit
 
 		return 1
 

--- a/code/game/jobs/job/special.dm
+++ b/code/game/jobs/job/special.dm
@@ -109,8 +109,10 @@
 
 		if(H.backbag > 0)
 			H.equip_to_slot_or_del(new /obj/item/weapon/stamp/clown(H.back), slot_in_backpack)
+			H.equip_to_slot_or_del(new /obj/item/weapon/bikehorn(H.back), slot_in_backpack)
 		else
 			H.equip_to_slot_or_del(new /obj/item/weapon/stamp/clown(H), slot_l_hand)
+			H.equip_to_slot_or_del(new /obj/item/weapon/bikehorn(H.back), slot_l_hand)
 
 		return 1
 

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -482,9 +482,10 @@
 
 	if(mind)
 		mind.active = 0					//we wish to transfer the key manually
-		if(mind.assigned_role == "Clown")				//give them a clownname if they are a clown
-			new_character.real_name = pick(clown_names)	//I hate this being here of all places but unfortunately dna is based on real_name!
-			new_character.rename_self("clown")
+		// VOREStation edit to disable the destructive forced renaming for our responsible whitelist clowns.
+		//if(mind.assigned_role == "Clown")				//give them a clownname if they are a clown
+		//	new_character.real_name = pick(clown_names)	//I hate this being here of all places but unfortunately dna is based on real_name!
+		//	new_character.rename_self("clown")
 		mind.original = new_character
 		// VOREStation
 		mind.loaded_from_ckey = client.ckey


### PR DESCRIPTION
-Allows our responsible whitelist clowns spawn with the bikehorn.
-Disables the destructive forced name randomization and lossy rename BS on join.