### PR TITLE
[FEATURE]Sleevemate new functions

### DIFF
--- a/code/game/objects/items/devices/scanners_vr.dm
+++ b/code/game/objects/items/devices/scanners_vr.dm
@@ -76,7 +76,9 @@ var/global/mob/living/carbon/human/dummy/mannequin/sleevemate_mob
 
 	//Mind/body comparison
 	output += "<b>Sleeve Pair:</b> "
-	if(H.mind && ckey(H.mind.key) != H.ckey)
+	if(!H.ckey)
+		output += "<span class='warning'>No mind in that body</span> [stored_mind != null ? "\[<a href='?src=\ref[src];target=\ref[H];mindupload=1'>Upload</a>\]" : null]<br>"
+	else if(H.mind && ckey(H.mind.key) != H.ckey)
 		output += "<span class='warning'>May not be correct body</span><br>"
 	else if(H.mind && ckey(H.mind.key) == H.ckey)
 		output += "Appears to be correct mind in body<br>"
@@ -98,10 +100,16 @@ var/global/mob/living/carbon/human/dummy/mannequin/sleevemate_mob
 		output += "<span class='warning'>Unable</span><br>"
 
 	//Soulcatcher transfer
-	if(stored_mind && H.nif)
+	if(H.nif)
 		var/datum/nifsoft/soulcatcher/SC = H.nif.imp_check(NIF_SOULCATCHER)
 		if(SC)
-			output += "<b>Store in Soulcatcher: </b>\[<a href='?src=\ref[src];target=\ref[H];mindput=1'>Perform</a>\]<br>"
+			output += "<br>"
+			output += "<b>Soulcatcher detected ([SC.brainmobs.len] minds)</b><br>"
+			for(var/mob/living/carbon/brain/caught_soul/mind in SC.brainmobs)
+				output += "<i>[mind.name]: </i>\[<a href='?src=\ref[src];target=\ref[H];mindrelease=[mind.name]'>Load</a>\]<br>"
+
+			if(stored_mind)
+				output += "<b>Store in Soulcatcher: </b>\[<a href='?src=\ref[src];target=\ref[H];mindput=1'>Perform</a>\]<br>"
 
 	to_chat(user,output)
 
@@ -166,6 +174,10 @@ var/global/mob/living/carbon/human/dummy/mannequin/sleevemate_mob
 			to_chat(usr,"<span class='warning'>Target seems totally braindead.</span>")
 			return
 
+		if(stored_mind)
+			to_chat(usr,"<span class='warning'>There is already someone's mind stored inside</span>")
+			return
+
 		var/choice = alert(usr,"This will remove the target's mind from their body. The only way to put it back is via a resleeving pod. Continue?","Confirmation","Continue","Cancel")
 		if(choice == "Continue" && usr.get_active_hand() == src && usr.Adjacent(target))
 
@@ -207,6 +219,46 @@ var/global/mob/living/carbon/human/dummy/mannequin/sleevemate_mob
 		stored_mind = null
 		to_chat(usr,"<span class='notice'>Mind transferred into Soulcatcher!</span>")
 		update_icon()
+
+	if(href_list["mindupload"])
+		if(!stored_mind)
+			to_chat(usr,"<span class='warning'>\The [src] no longer has a stored mind.</span>")
+			return
+
+
+		if(!istype(target))
+			return
+
+		usr.visible_message("<span class='warning'>[usr] begins uploading someone's mind into [target]!</span>","<span class='notice'>You begin uploading a mind into [target]!</span>")
+		if(do_after(usr,35 SECONDS,target))
+			if(!stored_mind)
+				to_chat(usr,"<span class='warning'>\The [src] no longer has a stored mind.</span>")
+				return
+			stored_mind.active = TRUE
+			stored_mind.transfer_to(target)
+			stored_mind = null
+			to_chat(usr,"<span class='notice'>Mind transferred into [target]!</span>")
+			update_icon()
+
+	if(href_list["mindrelease"])
+		if(stored_mind)
+			to_chat(usr,"<span class='warning'>There is already someone's mind stored inside</span>")
+			return
+		var/mob/living/carbon/human/H = target
+		var/datum/nifsoft/soulcatcher/SC = H.nif.imp_check(NIF_SOULCATCHER)
+		if(!SC)
+			return
+		for(var/mob/living/carbon/brain/caught_soul/soul in SC.brainmobs)
+			if(soul.name == href_list["mindrelease"])
+				stored_mind = soul.mind
+				stored_mind.current = null
+				soul.Destroy()
+				update_icon()
+				to_chat(usr,"<span class='notice'>Mind downloaded!</span>")
+				return
+		to_chat(usr,"<span class='notice'>Unable to find that mind in Soulcatcher!</span>")
+
+
 
 /obj/item/device/sleevemate/update_icon()
 	if(stored_mind)

--- a/code/game/objects/items/devices/scanners_vr.dm
+++ b/code/game/objects/items/devices/scanners_vr.dm
@@ -2,7 +2,7 @@ var/global/mob/living/carbon/human/dummy/mannequin/sleevemate_mob
 
 //SleeveMate!
 /obj/item/device/sleevemate
-	name = "\improper SleeveMate 3200"
+	name = "\improper SleeveMate 3700"
 	desc = "A hand-held sleeve management tool for performing one-time backups and managing mindstates."
 	icon = 'icons/obj/device_alt.dmi'
 	icon_state = "sleevemate"
@@ -225,9 +225,14 @@ var/global/mob/living/carbon/human/dummy/mannequin/sleevemate_mob
 			to_chat(usr,"<span class='warning'>\The [src] no longer has a stored mind.</span>")
 			return
 
-
 		if(!istype(target))
 			return
+
+		if(istype(target, /mob/living/carbon/human))
+			var/mob/living/carbon/human/H = target
+			if(H.resleeve_lock && stored_mind.loaded_from_ckey  != H.resleeve_lock)
+				to_chat(usr,"<span class='warning'>\[H] is protected from impersonation!</span>")
+				return
 
 		usr.visible_message("<span class='warning'>[usr] begins uploading someone's mind into [target]!</span>","<span class='notice'>You begin uploading a mind into [target]!</span>")
 		if(do_after(usr,35 SECONDS,target))

--- a/code/game/objects/items/devices/scanners_vr.dm
+++ b/code/game/objects/items/devices/scanners_vr.dm
@@ -106,7 +106,7 @@ var/global/mob/living/carbon/human/dummy/mannequin/sleevemate_mob
 			output += "<br>"
 			output += "<b>Soulcatcher detected ([SC.brainmobs.len] minds)</b><br>"
 			for(var/mob/living/carbon/brain/caught_soul/mind in SC.brainmobs)
-				output += "<i>[mind.name]: </i>\[<a href='?src=\ref[src];target=\ref[H];mindrelease=[mind.name]'>Load</a>\]<br>"
+				output += "<i>[mind.name]: </i> [mind.transient == FALSE ? "\[<a href='?src=\ref[src];target=\ref[H];mindrelease=[mind.name]'>Load</a>\]" : "<span class='warning'>Incompatible</span>"]<br>"
 
 			if(stored_mind)
 				output += "<b>Store in Soulcatcher: </b>\[<a href='?src=\ref[src];target=\ref[H];mindput=1'>Perform</a>\]<br>"

--- a/code/modules/research/designs_vr.dm
+++ b/code/modules/research/designs_vr.dm
@@ -30,7 +30,7 @@
 	sort_string = "TAAAC"
 
 /datum/design/item/sleevemate
-	name = "SleeveMate 3200"
+	name = "SleeveMate 3700"
 	id = "sleevemate"
 	req_tech = list(TECH_MATERIAL = 3, TECH_MAGNET = 2, TECH_BIO = 2)
 	materials = list(DEFAULT_WALL_MATERIAL = 4000, "glass" = 4000)


### PR DESCRIPTION
Sleevemate is now able to detect soulcatchers, and also load minds from soulcatchers, and upload them into bodies without mind. Because, why you can steal someone's mind and place it in your soulcatcher, but to do the reverse procedure, you require medbay help? Not gud.

Screenshots:
If you scan someone without mind:
![1](https://user-images.githubusercontent.com/7351585/43653740-27f30176-9773-11e8-9f1e-81fd409717e2.PNG)
If you scan someone without mind, but with stored mind in Sleevemate:
![2](https://user-images.githubusercontent.com/7351585/43653745-2b30ccd8-9773-11e8-9ea8-8f61151d36d0.PNG)
If you scan someone with soulcatcher:
![3](https://user-images.githubusercontent.com/7351585/43653751-2f271180-9773-11e8-9337-2afdebb332de.PNG)
If you scan someone with soulcatcher and with stored mind in Sleevemate:
![4](https://user-images.githubusercontent.com/7351585/43653754-3295a728-9773-11e8-8858-d10bf9702a8b.PNG)
If you scan someone with soulcatcher, with minds inside it:
![5](https://user-images.githubusercontent.com/7351585/43653759-3547e45e-9773-11e8-9405-82e0ae2092e1.PNG)
