### PR TITLE
Reverts Syringe infections

### DIFF
--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -96,8 +96,7 @@
 	name = "box of syringes"
 	desc = "A box full of syringes."
 	icon_state = "syringe"
-	can_hold = list(/obj/item/weapon/reagent_containers/syringe) //VOREStation Edit
-	starts_with = list(/obj/item/weapon/reagent_containers/syringe = 20) //VOREStation Edit
+	starts_with = list(/obj/item/weapon/reagent_containers/syringe = 7)
 
 /obj/item/weapon/storage/box/syringegun
 	name = "box of syringe gun cartridges"

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -221,7 +221,7 @@
 			else
 				to_chat(user, "<span class='notice'>The syringe is empty.</span>")
 
-			dirty(target,affected) //VOREStation Add
+//		dirty(target,affected) //VOREStation Add -- Removed by Request
 
 	return
 /* VOREStation Edit - See syringes_vr.dm


### PR DESCRIPTION
As per https://github.com/VOREStation/VOREStation/issues/3972#issuecomment-403142802

Removes chance for syringes to infect.
Restores Syringe boxes to 7 per box (polaris default), down from 20