### PR TITLE
Adds the character directory

### DIFF
--- a/code/game/verbs/character_directory.dm
+++ b/code/game/verbs/character_directory.dm
@@ -15,8 +15,11 @@
 		if(C.prefs && !C.prefs.show_in_directory)
 			continue
 		if(ishuman(C.mob))
-			curID++
 			var/mob/living/carbon/human/H = C.mob
+			if(data_core && data_core.general)
+				if(!find_general_record("name", H.real_name))
+					continue
+			curID++
 			html += "<div class='block'>"
 			html += "<h3 class='uiContent highlight' style='font-size:16px'>[H.real_name]</h3><br>"
 			if(H.flavor_texts["general"])

--- a/code/game/verbs/character_directory.dm
+++ b/code/game/verbs/character_directory.dm
@@ -1,0 +1,32 @@
+/client/verb/show_character_directory()
+	set name = "Character Directory"
+	set category = "OOC"
+	set desc = "Shows a listing of all active characters, along with their associated OOC notes, flavor text, and more."
+
+	if(mob.next_move >= world.time)	//This is primarily to stop malicious users from trying to lag the server by spamming this verb
+		return
+
+	mob.next_move = world.time + 10
+
+	var/html = "<script> function togglesection(targetsection) { var targettext = document.getElementById(targetsection); if (targettext.style.display === 'none') { targettext.style.display = ''; } else { targettext.style.display = 'none'; } } </script>"
+
+	var/curID = 0
+	for(var/client/C in clients)
+		if(ishuman(C.mob))
+			curID++
+			var/mob/living/carbon/human/H = C.mob
+			html += "<div class='block'>"
+			html += "<h3 class='uiContent highlight' style='font-size:16px'>[H.real_name]</h3><br>"
+			if(H.flavor_texts["general"])
+				html += "<a onclick='togglesection(\"[H.real_name] [curID] flavor\")'>Flavor text</a>"
+				html += "<p class='uiContent' style='display:none' id='[H.real_name] [curID] flavor'>[H.flavor_texts["general"]]</p>"
+			if(H.ooc_notes)
+				html += "<a onclick='togglesection(\"[H.real_name] [curID] ooc\")'>OOC notes</a>"
+				html += "<p class='uiContent' style='display:none' id='[H.real_name] [curID] ooc'>[H.ooc_notes]</p>"
+			html += "</div>"
+	if(!curID)
+		html += "<p class='uiContent'>404: Station not found</p>"
+
+	var/datum/browser/popup = new(mob, "chardir", "Character Directory", 640, 480)
+	popup.set_content(html)
+	popup.open()

--- a/code/game/verbs/character_directory.dm
+++ b/code/game/verbs/character_directory.dm
@@ -12,6 +12,8 @@
 
 	var/curID = 0
 	for(var/client/C in clients)
+		if(C.prefs && !C.prefs.show_in_directory)
+			continue
 		if(ishuman(C.mob))
 			curID++
 			var/mob/living/carbon/human/H = C.mob

--- a/code/modules/client/preference_setup/vore/09_misc.dm
+++ b/code/modules/client/preference_setup/vore/09_misc.dm
@@ -1,0 +1,26 @@
+/datum/preferences
+	var/show_in_directory = TRUE
+
+/datum/category_item/player_setup_item/vore/misc
+	name = "Misc Settings"
+	sort_order = 9
+
+/datum/category_item/player_setup_item/vore/misc/load_character(var/savefile/S)
+	S["show_in_directory"]		>> pref.show_in_directory
+
+
+/datum/category_item/player_setup_item/vore/misc/save_character(var/savefile/S)
+	S["show_in_directory"]		<< pref.show_in_directory
+
+/datum/category_item/player_setup_item/vore/misc/sanitize_character()
+	pref.show_in_directory		= sanitize_integer(pref.show_in_directory, 0, 1, initial(pref.show_in_directory))
+
+/datum/category_item/player_setup_item/vore/misc/content(var/mob/user)
+	. += "<br>"
+	. += "<b>Appear in Character Directory:</b> <a [pref.show_in_directory ? "class='linkOn'" : ""] href='?src=\ref[src];toggle_show_in_directory=1'><b>[pref.show_in_directory ? "Yes" : "No"]</b></a><br>"
+
+/datum/category_item/player_setup_item/vore/misc/OnTopic(var/href, var/list/href_list, var/mob/user)
+	if(href_list["toggle_show_in_directory"])
+		pref.show_in_directory = pref.show_in_directory ? 0 : 1;
+		return TOPIC_REFRESH
+	return ..();

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -1294,6 +1294,7 @@
 #include "code\game\turfs\unsimulated\sky_vr.dm"
 #include "code\game\turfs\unsimulated\walls.dm"
 #include "code\game\verbs\advanced_who.dm"
+#include "code\game\verbs\character_directory.dm"
 #include "code\game\verbs\ignore.dm"
 #include "code\game\verbs\ooc.dm"
 #include "code\game\verbs\suicide.dm"

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -1509,6 +1509,7 @@
 #include "code\modules\client\preference_setup\vore\06_vantag.dm"
 #include "code\modules\client\preference_setup\vore\07_traits.dm"
 #include "code\modules\client\preference_setup\vore\08_nif.dm"
+#include "code\modules\client\preference_setup\vore\09_misc.dm"
 #include "code\modules\clothing\chameleon.dm"
 #include "code\modules\clothing\clothing.dm"
 #include "code\modules\clothing\clothing_accessories.dm"


### PR DESCRIPTION
The character directory is a new menu accessible through a verb in the OOC tab. It lists every single living player, alongside their OOC notes and general flavor text, all wrapped up in a hopefully easy-to-understand-and-read menu.

Idea came from Scree on the Discord. It seemed like a nifty feature to have

Here's how it looks (on a local server with only one active player)
![image](https://user-images.githubusercontent.com/6356337/44141446-2d0d374a-a04b-11e8-8983-f93f67f39cfc.png)

It should be relatively easy to figure out what does what. Here's how a player block looks like with the OOC notes and flavor text both expanded
![image](https://user-images.githubusercontent.com/6356337/44141586-889be53e-a04b-11e8-8181-ed0367d16b5f.png)
