### PR TITLE
Synced pAI translator languages with robot ones

### DIFF
--- a/code/modules/mob/living/silicon/pai/software_modules_vr.dm
+++ b/code/modules/mob/living/silicon/pai/software_modules_vr.dm
@@ -1,0 +1,35 @@
+/datum/pai_software/translator
+	name = "Universal Translator"
+	ram_cost = 35
+	id = "translator"
+
+	toggle(mob/living/silicon/pai/user)
+		// 	Sol Common, Tradeband, Terminus and Gutter are added with New() and are therefore the current default, always active languages
+		user.translator_on = !user.translator_on
+		if(user.translator_on)
+			user.add_language(LANGUAGE_BIRDSONG)
+			user.add_language(LANGUAGE_SAGARU)
+			user.add_language(LANGUAGE_CANILUNZT)
+			user.add_language(LANGUAGE_ECUREUILIAN)
+			user.add_language(LANGUAGE_DAEMON)
+			user.add_language(LANGUAGE_ENOCHIAN)
+			user.add_language(LANGUAGE_UNATHI)
+			user.add_language(LANGUAGE_SIIK)
+			user.add_language(LANGUAGE_AKHANI)
+			user.add_language(LANGUAGE_SKRELLIAN)
+			user.add_language(LANGUAGE_SCHECHI)
+		else
+			user.remove_language(LANGUAGE_BIRDSONG)
+			user.remove_language(LANGUAGE_SAGARU)
+			user.remove_language(LANGUAGE_CANILUNZT)
+			user.remove_language(LANGUAGE_ECUREUILIAN)
+			user.remove_language(LANGUAGE_DAEMON)
+			user.remove_language(LANGUAGE_ENOCHIAN)
+			user.remove_language(LANGUAGE_UNATHI)
+			user.remove_language(LANGUAGE_SIIK)
+			user.remove_language(LANGUAGE_AKHANI)
+			user.remove_language(LANGUAGE_SKRELLIAN)
+			user.remove_language(LANGUAGE_SCHECHI)
+
+	is_active(mob/living/silicon/pai/user)
+		return user.translator_on

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -2124,6 +2124,7 @@
 #include "code\modules\mob\living\silicon\pai\say.dm"
 #include "code\modules\mob\living\silicon\pai\software.dm"
 #include "code\modules\mob\living\silicon\pai\software_modules.dm"
+#include "code\modules\mob\living\silicon\pai\software_modules_vr.dm"
 #include "code\modules\mob\living\silicon\robot\analyzer.dm"
 #include "code\modules\mob\living\silicon\robot\component.dm"
 #include "code\modules\mob\living\silicon\robot\custom_sprites.dm"


### PR DESCRIPTION
This makes the 35-point universal translator module also provide the
vorestation-specific languages robots get, such as Canilunzt.

I'm reasonably sure at one point most (or at least several) of these
came for free to pAI without even needing a translator, and it doesn't
feel overpowered to me to allow a handless toolless character built for
communication and assisting people to spend 1/3 their upgrade budget to
gain borg-tier language skills.