### PR TITLE
Medal Whitelists from abduction event

### DIFF
--- a/code/modules/clothing/under/accessories/accessory_vr.dm
+++ b/code/modules/clothing/under/accessories/accessory_vr.dm
@@ -188,3 +188,9 @@
 	can_hold = list(/obj/item/weapon/material/knife/machete)
 	//sound_in = 'sound/effects/holster/sheathin.ogg'
 	//sound_out = 'sound/effects/holster/sheathout.ogg'
+
+//Medals
+
+/obj/item/clothing/accessory/medal/silver/unity
+	name = "medal of unity"
+	desc = "A silver medal awarded to a group which has demonstrated exceptional teamwork to achieve a notable feat."

--- a/code/modules/vore/fluffstuff/custom_boxes_vr.dm
+++ b/code/modules/vore/fluffstuff/custom_boxes_vr.dm
@@ -221,11 +221,18 @@
 // Mewchild: Phi Vietsi
 /obj/item/weapon/storage/box/fluff/vietsi
 	name = "Phi's Personal Items"
-	desc = "A small box containing Phi's small things"
 	has_items = list(
 		/obj/item/clothing/accessory/medal/bronze_heart,
 		/obj/item/clothing/gloves/ring/seal/signet/fluff/vietsi)
 
+// Draycu: Schae Yonra
+/obj/item/weapon/storage/box/fluff/yonra
+	name = "Yonra's Starting Kit"
+	desc = "A small box containing Yonra's personal effects"
+	has_items = list(
+		item_path: /obj/item/weapon/melee/fluff/holochain/mass,
+		item_path: /obj/item/weapon/implanter/reagent_generator/yonra,
+		item_path: /obj/item/clothing/accessory/medal/silver/unity)
 /*
 Swimsuits, for general use, to avoid arriving to work with your swimsuit.
 */

--- a/config/custom_items.txt
+++ b/config/custom_items.txt
@@ -232,13 +232,7 @@ item_desc: An engraved coin made of diamond. On the side for heads is printed th
 {
 ckey: draycu
 character_name: Schae Yonra
-item_path: /obj/item/weapon/melee/fluff/holochain/mass
-}
-
-{
-ckey: draycu
-character_name: Schae Yonra
-item_path: /obj/item/weapon/implanter/reagent_generator/yonra
+item_path: /obj/item/weapon/storage/box/fluff/yonra
 }
 
 # ######## E CKEYS
@@ -474,6 +468,18 @@ item_path: /obj/item/device/modkit_conversion/fluff/harmonyspace
 
 # ######## K CKEYS
 {
+ckey: kazkin
+character_name: Ahzrukhal Ahkeen
+item_path: /obj/item/clothing/accessory/medal/silver/unity
+}
+
+{
+ckey: keekenox
+character_name: SMU-453
+item_path: /obj/item/clothing/accessory/medal/nobel_science
+}
+
+{
 ckey: ketrai
 character_name: Ketrai
 item_path: /obj/item/clothing/head/fluff/ketrai
@@ -495,6 +501,12 @@ item_path: /obj/item/clothing/glasses/omnihud/kamina
 ckey: Killjaden
 character_name: Lassara Faaira'Nrezi
 item_path: /obj/item/clothing/accessory/storage/knifeharness
+}
+
+{
+ckey: kitchifox
+character_name: Rana Uma
+item_path: /obj/item/clothing/accessory/medal/silver/unity
 }
 
 {
@@ -645,6 +657,12 @@ ckey: pawoverlord
 character_name: Sorrel Cavalet
 item_path: /obj/item/weapon/gun/projectile/colt
 item_desc: "A cheap Martian knock-off of a Colt M1911. It has the word 'Cavalet' etched on the side. Uses .45 rounds."
+}
+
+{
+ckey: phoaly
+character_name: Lily Maximus
+item_path: /obj/item/clothing/accessory/medal/silver/unity
 }
 
 {
@@ -814,9 +832,21 @@ item_path: /obj/item/clothing/under/sexymime
 
 # ######## T CKEYS
 {
+ckey: tabiranth
+character_name: Ascian
+item_path: /obj/item/clothing/accessory/medal/silver/unity
+}
+
+{
 ckey: techtypes
 character_name: Lasshseeki Korss
 item_path: /obj/item/weapon/implant/language/eal
+}
+
+{
+ckey: tinydude16
+character_name: Konor Foxe
+item_path: /obj/item/clothing/accessory/medal/silver/unity
 }
 
 {
@@ -962,6 +992,12 @@ item_path: /obj/item/weapon/storage/box/fluff/penelope
 ckey: Xennith
 character_name: Amy Lessen
 item_path: /obj/item/weapon/card/id/fluff/xennith
+}
+
+{
+ckey: Xonkon
+character_name: Ali
+item_path: /obj/item/clothing/accessory/medal/silver/unity
 }
 
 # ######## Y CKEYS


### PR DESCRIPTION
Adds Medal of Unity to accessories_vr. It existed on the wiki, just not in code. Subclass of medal/silver. Will try to get this to Polaris later.
Consolidates Yonra's fluff items into a box, QoL change
Adds Medal of Unity to the following characters: Ahzrukhal Ahkeen, Ali, Ascian, Konor Foxe, Lily Maximus, Rana Uma, and Schae Yonra.
Adds Nobel Sciences medal to SMU-453

Applications: 
Ahzruhkal: https://forum.vore-station.net/viewtopic.php?f=27&t=1440
Ali: https://forum.vore-station.net/viewtopic.php?f=27&t=1436
Ascian: https://forum.vore-station.net/viewtopic.php?f=27&t=1439
Konor: https://forum.vore-station.net/viewtopic.php?f=27&t=1442
Lily: https://forum.vore-station.net/viewtopic.php?f=27&t=1438
Rana: https://forum.vore-station.net/viewtopic.php?f=27&t=1437
SMU: https://forum.vore-station.net/viewtopic.php?f=27&t=1444
Yonra: https://forum.vore-station.net/viewtopic.php?f=27&t=1440