### PR TITLE
Changes Secpatch Path in Loadout

### DIFF
--- a/code/modules/client/preference_setup/loadout/loadout_eyes_vr.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_eyes_vr.dm
@@ -14,6 +14,6 @@
 	display_name = "science goggles (no overlay)"
 	path = /obj/item/clothing/glasses/fluff/science_proper
 
-/datum/gear/eyes/secpatch
+/datum/gear/eyes/security/secpatch
 	display_name = "security hudpatch"
 	path = /obj/item/clothing/glasses/hud/security/eyepatch


### PR DESCRIPTION
Changes the path of the security eyepatch, to be a chiled of eyes/security (so it's only selectable by security).
Wasn't expecting #4226 to be merged, as it was a shitpost.