### PR TITLE
Fixes syringes cutting apples

### DIFF
--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -17,7 +17,7 @@
 	volume = 15
 	w_class = ITEMSIZE_TINY
 	slot_flags = SLOT_EARS
-	sharp = 1
+	sharp = 0 //this is to prevent them from slicing apples and so on.
 	unacidable = 1 //glass
 	var/mode = SYRINGE_DRAW
 	var/image/filling //holds a reference to the current filling overlay


### PR DESCRIPTION
This makes syringes not sharp. I was able to take a blood sample from someone and put it within a beaker with those settings.
Fixes #1779