### PR TITLE
Expedition Balance Tweaks

### DIFF
--- a/code/datums/supplypacks/munitions_vr.dm
+++ b/code/datums/supplypacks/munitions_vr.dm
@@ -1,7 +1,8 @@
 /datum/supply_pack/munitions/expeditionguns
 	name = "Frontier phaser (station-locked) crate"
 	contains = list(
-			/obj/item/weapon/gun/energy/frontier/locked = 2,
+			/obj/item/weapon/gun/energy/frontier/locked/basic = 2,
+			/obj/item/weapon/gun/energy/frontier/locked/holdout = 1,
 			)
 	cost = 35
 	containertype = /obj/structure/closet/crate/secure

--- a/code/modules/mob/living/simple_animal/animals/giant_spider_vr.dm
+++ b/code/modules/mob/living/simple_animal/animals/giant_spider_vr.dm
@@ -1,0 +1,23 @@
+// Slightly placeholder, mostly to replace ion hivebots on V4
+/mob/living/simple_animal/hostile/giant_spider/ion
+	desc = "Furry and green, it makes you shudder to look at it. This one has brilliant green eyes and a hint of static discharge."
+	tt_desc = "X Brachypelma phorus ionus"
+	icon_state = "webslinger"
+	icon_living = "webslinger"
+	icon_dead = "webslinger_dead"
+
+	maxHealth = 90
+	health = 90
+
+	melee_damage_lower = 8
+	melee_damage_upper = 15
+
+	ranged = 1
+	projectilesound = 'sound/weapons/taser2.ogg'
+	projectiletype = /obj/item/projectile/ion/small
+	firing_lines = 1
+	cooperative = 1
+
+	poison_chance = 15
+	poison_per_bite = 2
+	poison_type = "psilocybin"

--- a/code/modules/vore/fluffstuff/custom_guns_vr.dm
+++ b/code/modules/vore/fluffstuff/custom_guns_vr.dm
@@ -744,8 +744,8 @@
 
 	projectile_type = /obj/item/projectile/beam
 	firemodes = list(
-		list(mode_name="normal", fire_delay=12, projectile_type=/obj/item/projectile/beam, charge_cost = 300),
-		list(mode_name="low-power", fire_delay=8, projectile_type=/obj/item/projectile/beam/weaklaser, charge_cost = 60),
+		list(mode_name="normal", fire_delay=12, projectile_type=/obj/item/projectile/beam, charge_cost = 600),
+		list(mode_name="low-power", fire_delay=8, projectile_type=/obj/item/projectile/beam/weaklaser, charge_cost = 120),
 		)
 
 /obj/item/weapon/gun/energy/frontier/unload_ammo(var/mob/user)

--- a/code/modules/vore/fluffstuff/custom_guns_vr.dm
+++ b/code/modules/vore/fluffstuff/custom_guns_vr.dm
@@ -743,10 +743,6 @@
 	var/recharging = 0
 
 	projectile_type = /obj/item/projectile/beam
-	firemodes = list(
-		list(mode_name="normal", fire_delay=12, projectile_type=/obj/item/projectile/beam, charge_cost = 600),
-		list(mode_name="low-power", fire_delay=8, projectile_type=/obj/item/projectile/beam/weaklaser, charge_cost = 120),
-		)
 
 /obj/item/weapon/gun/energy/frontier/unload_ammo(var/mob/user)
 	if(recharging)
@@ -778,6 +774,13 @@
 /obj/item/weapon/gun/energy/frontier/ex_act() //|rugged|
 	return
 
+//Needed to fix a bug with the holdout phaser
+/obj/item/weapon/gun/energy/frontier/basic
+	firemodes = list(
+		list(mode_name="normal", fire_delay=12, projectile_type=/obj/item/projectile/beam, charge_cost = 600),
+		list(mode_name="low-power", fire_delay=8, projectile_type=/obj/item/projectile/beam/weaklaser, charge_cost = 120),
+	)
+
 /obj/item/weapon/gun/energy/frontier/locked
 	desc = "An extraordinarily rugged laser weapon, built to last and requiring effectively no maintenance. Includes a built-in crank charger for recharging away from civilization. This one has a safety interlock that prevents firing while in proximity to the facility."
 	req_access = list(access_armory) //for toggling safety
@@ -807,6 +810,13 @@
 			to_chat(user, "<span class='warning'>The safety device prevents the gun from firing this close to the facility.</span>")
 			return 0
 	return ..()
+
+//Needed to fix a bug with the holdout phaser
+/obj/item/weapon/gun/energy/frontier/locked/basic
+	firemodes = list(
+		list(mode_name="normal", fire_delay=12, projectile_type=/obj/item/projectile/beam, charge_cost = 600),
+		list(mode_name="low-power", fire_delay=8, projectile_type=/obj/item/projectile/beam/weaklaser, charge_cost = 120),
+	)
 
 //Expeditionary Holdout Phaser
 /obj/item/weapon/gun/energy/frontier/locked/holdout

--- a/code/modules/vore/fluffstuff/custom_guns_vr.dm
+++ b/code/modules/vore/fluffstuff/custom_guns_vr.dm
@@ -777,8 +777,8 @@
 //Needed to fix a bug with the holdout phaser
 /obj/item/weapon/gun/energy/frontier/basic
 	firemodes = list(
-		list(mode_name="normal", fire_delay=12, projectile_type=/obj/item/projectile/beam, charge_cost = 600),
-		list(mode_name="low-power", fire_delay=8, projectile_type=/obj/item/projectile/beam/weaklaser, charge_cost = 120),
+		list(mode_name="normal", fire_delay=12, projectile_type=/obj/item/projectile/beam, charge_cost = 300),
+		list(mode_name="low-power", fire_delay=8, projectile_type=/obj/item/projectile/beam/weaklaser, charge_cost = 60),
 	)
 
 /obj/item/weapon/gun/energy/frontier/locked
@@ -814,8 +814,8 @@
 //Needed to fix a bug with the holdout phaser
 /obj/item/weapon/gun/energy/frontier/locked/basic
 	firemodes = list(
-		list(mode_name="normal", fire_delay=12, projectile_type=/obj/item/projectile/beam, charge_cost = 600),
-		list(mode_name="low-power", fire_delay=8, projectile_type=/obj/item/projectile/beam/weaklaser, charge_cost = 120),
+		list(mode_name="normal", fire_delay=12, projectile_type=/obj/item/projectile/beam, charge_cost = 300),
+		list(mode_name="low-power", fire_delay=8, projectile_type=/obj/item/projectile/beam/weaklaser, charge_cost = 60),
 	)
 
 //Expeditionary Holdout Phaser

--- a/maps/tether/submaps/beach/_beach.dm
+++ b/maps/tether/submaps/beach/_beach.dm
@@ -118,7 +118,7 @@
 	guard = 20
 	mobs_to_pick_from = list(
 		/mob/living/simple_animal/hostile/frog = 3, //Frogs are 3x more likely to spawn than,
-		/mob/living/simple_animal/hostile/deathclaw = 1, //these deathclaws are, with these values
+		/mob/living/simple_animal/hostile/deathclaw = 1, //these deathclaws are, with these values,
 		/mob/living/simple_animal/hostile/giant_spider = 3,
 		/mob/living/simple_animal/hostile/giant_snake = 1,
 		/mob/living/simple_animal/hostile/giant_spider/ion = 2

--- a/maps/tether/submaps/beach/_beach.dm
+++ b/maps/tether/submaps/beach/_beach.dm
@@ -95,8 +95,9 @@
 	prob_fall = 25 //Chance goes down by this much each time it spawns one (not defining and prob_spawn 100 means they spawn as soon as one dies)
 	guard = 40 //They'll stay within this range (not defining this disables them staying nearby and they will wander the map (and through step teleports))
 	mobs_to_pick_from = list(
-		/mob/living/simple_animal/hostile/giant_snake = 3, //Snakes are 3x more likely to spawn than,
-		/mob/living/simple_animal/hostile/frog = 1 //these frogs are, with these values
+		/mob/living/simple_animal/snake
+		// /mob/living/simple_animal/hostile/giant_snake = 3, //Snakes are 3x more likely to spawn than,
+		// /mob/living/simple_animal/hostile/frog = 1 //these frogs are, with these values
 	)
 
 /obj/tether_away_spawner/beach_outside_friendly
@@ -115,12 +116,14 @@
 	faction = "beach_cave"
 	atmos_comp = TRUE
 	prob_spawn = 100
-	prob_fall = 10
+	prob_fall = 40
 	guard = 20
 	mobs_to_pick_from = list(
-		/mob/living/simple_animal/hostile/deathclaw,
-		/mob/living/simple_animal/hostile/frog,
-		/mob/living/simple_animal/hostile/hivebot/range/ion
+		/mob/living/simple_animal/hostile/giant_snake = 1,
+		/mob/living/simple_animal/hostile/deathclaw = 1,
+		/mob/living/simple_animal/hostile/frog = 3,
+		/mob/living/simple_animal/hostile/giant_spider = 3,
+		/mob/living/simple_animal/hostile/giant_spider/ion = 2
 	)
 
 // These are step-teleporters, for map edge transitions

--- a/maps/tether/submaps/beach/_beach.dm
+++ b/maps/tether/submaps/beach/_beach.dm
@@ -96,8 +96,6 @@
 	guard = 40 //They'll stay within this range (not defining this disables them staying nearby and they will wander the map (and through step teleports))
 	mobs_to_pick_from = list(
 		/mob/living/simple_animal/snake
-		// /mob/living/simple_animal/hostile/giant_snake = 3, //Snakes are 3x more likely to spawn than,
-		// /mob/living/simple_animal/hostile/frog = 1 //these frogs are, with these values
 	)
 
 /obj/tether_away_spawner/beach_outside_friendly

--- a/maps/tether/submaps/beach/_beach.dm
+++ b/maps/tether/submaps/beach/_beach.dm
@@ -117,10 +117,10 @@
 	prob_fall = 40
 	guard = 20
 	mobs_to_pick_from = list(
-		/mob/living/simple_animal/hostile/giant_snake = 1,
-		/mob/living/simple_animal/hostile/deathclaw = 1,
-		/mob/living/simple_animal/hostile/frog = 3,
+		/mob/living/simple_animal/hostile/frog = 3, //Frogs are 3x more likely to spawn than,
+		/mob/living/simple_animal/hostile/deathclaw = 1, //these deathclaws are, with these values
 		/mob/living/simple_animal/hostile/giant_spider = 3,
+		/mob/living/simple_animal/hostile/giant_snake = 1,
 		/mob/living/simple_animal/hostile/giant_spider/ion = 2
 	)
 

--- a/maps/tether/tether_things.dm
+++ b/maps/tether/tether_things.dm
@@ -395,7 +395,7 @@ var/global/list/latejoin_tram   = list()
 /obj/structure/closet/secure_closet/guncabinet/excursion/New()
 	..()
 	for(var/i = 1 to 4)
-		new /obj/item/weapon/gun/energy/frontier/locked(src)
+		new /obj/item/weapon/gun/energy/frontier/locked/basic(src)
 	for(var/i = 1 to 4)
 		new /obj/item/weapon/gun/energy/frontier/locked/holdout(src)
 

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -2225,6 +2225,7 @@
 #include "code\modules\mob\living\simple_animal\animals\fluffy_vr.dm"
 #include "code\modules\mob\living\simple_animal\animals\fox_vr.dm"
 #include "code\modules\mob\living\simple_animal\animals\giant_spider.dm"
+#include "code\modules\mob\living\simple_animal\animals\giant_spider_vr.dm"
 #include "code\modules\mob\living\simple_animal\animals\goose.dm"
 #include "code\modules\mob\living\simple_animal\animals\lizard.dm"
 #include "code\modules\mob\living\simple_animal\animals\miscellaneous.dm"


### PR DESCRIPTION
- Removes hostile mobs from V4 Beach
- Adds Giant Snakes and Giant spiders in generic V4 Cave spawners
- Reduced respawn rates to cut down on incidences of 'deathclaw swarms'
- Giant Snakes and Deathclaws have reduced overall spawn rates, Giant Spiders and Frogs will generally be more common.
- Replaced Ion hivebots with Ion Spiders
- Fixes a bug with the holdout phaser getting the main phaser's fire modes
- Adds a single holdout phaser to the expedition phaser supply crate