### PR TITLE
Adjust winged flight

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
@@ -36,7 +36,7 @@
 /datum/trait/winged_flight
 	name = "Winged Flight"
 	desc = "Allows you to fly by using your wings."
-	cost = 2 //Some in game value.
+	cost = 1
 
 /datum/trait/winged_flight/apply(var/datum/species/S,var/mob/living/carbon/human/H)
 	..(S,H)

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
@@ -33,6 +33,16 @@
 	var_changes = list("cold_discomfort_level" = T0C+21)
 	excludes = list(/datum/trait/cold_discomfort)
 
+/datum/trait/winged_flight
+	name = "Winged Flight"
+	desc = "Allows you to fly by using your wings."
+	cost = 2 //Some in game value.
+
+/datum/trait/winged_flight/apply(var/datum/species/S,var/mob/living/carbon/human/H)
+	..(S,H)
+	H.verbs |= /mob/living/proc/flying_toggle
+	H.verbs |= /mob/living/proc/start_wings_hovering
+
 /datum/trait/autohiss_unathi
 	name = "Autohiss (Unathi)"
 	desc = "You roll your S's and x's"

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/positive.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/positive.dm
@@ -94,16 +94,6 @@
 	cost = 1
 	var_changes = list("flash_mod" = 0.5)
 
-/datum/trait/winged_flight
-	name = "Winged Flight"
-	desc = "Allows you to fly by using your wings."
-	cost = 2 //Some in game value.
-
-/datum/trait/winged_flight/apply(var/datum/species/S,var/mob/living/carbon/human/H)
-	..(S,H)
-	H.verbs |= /mob/living/proc/flying_toggle
-	H.verbs |= /mob/living/proc/start_wings_hovering
-
 /datum/trait/hardfeet
 	name = "Hard Feet"
 	desc = "Makes your nice clawed, scaled, hooved, armored, or otherwise just awfully calloused feet immune to glass shards."


### PR DESCRIPTION
**Moves winged flight into neutral from positive traits.**
This is done to give this trait better price quality, especially compared to other perks you could take for 2 points such as non conductivity or *darksight major*.

**Reduce it's cost by half.**
The change in category was motivated by how little use this perk actually has and the numbers of downsides such as, few areas worth using this perk in, little flight time or the magic ability to stumble into any impassable atom like tables or doors (even if you have access) and receive 5 whole brute for it. 
In it's current state, it is very likely the worst "positive" trait within the game.