### PR TITLE
Changes Security Processing

### DIFF
--- a/maps/tether/tether-07-station3.dmm
+++ b/maps/tether/tether-07-station3.dmm
@@ -8455,13 +8455,11 @@
 	opacity = 0
 	},
 /obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/turf/simulated/floor,
-/area/security/security_processing)
-"oh" = (
-/obj/machinery/door/firedoor/glass,
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced/polarized{
+	dir = 10;
+	icon_state = "fwindow";
+	id = "sec_processing"
+	},
 /turf/simulated/floor,
 /area/security/security_processing)
 "oi" = (
@@ -35028,7 +35026,7 @@ cS
 jk
 jk
 jk
-oh
+qQ
 oE
 po
 pO
@@ -35170,7 +35168,7 @@ cT
 jy
 jk
 jk
-oh
+qQ
 oF
 pp
 pP
@@ -35313,9 +35311,9 @@ mH
 lD
 lD
 of
-oh
-oh
-oh
+qQ
+qQ
+qQ
 qk
 qQ
 qQ


### PR DESCRIPTION
Changes all windows in security processing to be tinted windows. This prevents prisoners in the brig from being able to eavesdrop on processing (as anybody in the lower level could hear every word from processing, previously).