### PR TITLE
Alter gateway access on 2 jobs

### DIFF
--- a/code/game/jobs/job/captain.dm
+++ b/code/game/jobs/job/captain.dm
@@ -60,13 +60,13 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 1)
 			            access_all_personal_lockers, access_maint_tunnels, access_bar, access_janitor, access_construction, access_morgue,
 			            access_crematorium, access_kitchen, access_cargo, access_cargo_bot, access_mailsorting, access_qm, access_hydroponics, access_lawyer,
 			            access_chapel_office, access_library, access_research, access_mining, access_heads_vault, access_mining_station,
-			            access_hop, access_RC_announce, access_keycard_auth, access_gateway)
+			            access_hop, access_RC_announce, access_keycard_auth) //, access_gateway) //VOREStation Edit
 	minimal_access = list(access_security, access_sec_doors, access_brig, access_forensics_lockers,
 			            access_medical, access_engine, access_change_ids, access_ai_upload, access_eva, access_heads,
 			            access_all_personal_lockers, access_maint_tunnels, access_bar, access_janitor, access_construction, access_morgue,
 			            access_crematorium, access_kitchen, access_cargo, access_cargo_bot, access_mailsorting, access_qm, access_hydroponics, access_lawyer,
 			            access_chapel_office, access_library, access_research, access_mining, access_heads_vault, access_mining_station,
-			            access_hop, access_RC_announce, access_keycard_auth, access_gateway)
+			            access_hop, access_RC_announce, access_keycard_auth) //, access_gateway) //VOREStation Edit
 
 /datum/job/secretary
 	title = "Command Secretary"

--- a/maps/southern_cross/southern_cross_jobs_vr.dm
+++ b/maps/southern_cross/southern_cross_jobs_vr.dm
@@ -19,6 +19,6 @@ var/const/PATHFINDER 		=(1<<13) //VOREStation Edit - Added Pathfinder
 	idtype = /obj/item/weapon/card/id/science/head/pathfinder
 	economic_modifier = 7
 	
-	access = list(access_eva, access_maint_tunnels, access_external_airlocks, access_pilot, access_explorer, access_research)
-	minimal_access = list(access_eva, access_pilot, access_explorer, access_research)
+	access = list(access_eva, access_maint_tunnels, access_external_airlocks, access_pilot, access_explorer, access_research, access_gateway)
+	minimal_access = list(access_eva, access_pilot, access_explorer, access_research, access_gateway)
 	outfit_type = /decl/hierarchy/outfit/job/pathfinder


### PR DESCRIPTION
Add gateway access to pathfinder, exploring is their job
Removed from HoP (who can readd it to themselves in emergencies if they need it, otherwise during 'normal times' there's no reason they'd need it)

Justifcations for leaving it with other jobs:
HoS - gateway area is classified as a high-security area, and is an area on the station that has an attack surface from unknown things, so it makes sense they have access to defend it. HoS abusing the access for 'not defense of station' reasons, such as 'I'm going to lead my own expedition, fuck explorers', is ahelpable.
CD - literally has all station access, doesn't even have a specific list
RD - generally has a superset of all pathfinder access, and the physical gateway structure is their machine, pretty sure

Changes based on admin discussion.