### PR TITLE
Gives pounces a chance to fail

### DIFF
--- a/code/modules/mob/living/simple_animal/simple_animal_vr.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal_vr.dm
@@ -118,7 +118,7 @@
 		return FALSE
 	if(will_eat(target_mob) && vore_standing_too) //100% chance of hitting people we can eat on the spot
 		return 100
-	var/TargetHealthPercent = (target_mob.health/target_mob.maxHealth)*100 //now we start looking at the target itself
+	var/TargetHealthPercent = (target_mob.health/target_mob.getMaxHealth())*100 //now we start looking at the target itself
 	if (TargetHealthPercent > vore_pounce_maxhealth) //target is too healthy to pounce
 		return FALSE
 	else

--- a/code/modules/mob/living/simple_animal/simple_animal_vr.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal_vr.dm
@@ -102,7 +102,7 @@
 
 	// If target is standing we might pounce and knock them down instead of attacking
 	if(target_mob.canmove && prob(vore_pounce_chance) && !issilicon(target_mob) && (world.time > vore_pounce_cooldown)) //pouncing is worth doing, we want to pounce and are not in cooldown. So attempt a pounce!
-		if(vore_standing_too) //creatures that can eat you on the spot don't care how healthy you are and get an autohit
+		if(will_eat(target_mob) && vore_standing_too) //creatures that can eat you on the spot don't care how healthy you are and get an autohit
 			return PounceTarget()
 
 		var/TargetHealthPercent = (target_mob.health/target_mob.maxHealth)*100

--- a/code/modules/mob/living/simple_animal/vore/zz_vore_overrides.dm
+++ b/code/modules/mob/living/simple_animal/vore/zz_vore_overrides.dm
@@ -162,6 +162,7 @@
 	vore_pounce_chance = 100
 	vore_digest_chance = 0 // just use the toggle
 	vore_default_mode = DM_HOLD //can use the toggle if you wanna be catfood
+	vore_standing_too = TRUE //gonna get pounced
 
 /mob/living/simple_animal/cat/fluff/EatTarget()
 	var/mob/living/TM = target_mob
@@ -201,6 +202,7 @@
 	vore_pounce_chance = 100
 	vore_digest_chance = 0 // just use the toggle
 	vore_default_mode = DM_HOLD //can use the toggle if you wanna be foxfood
+	vore_standing_too = TRUE // gonna get pounced
 
 /mob/living/simple_animal/fox/fluff/EatTarget()
 	var/mob/living/TM = target_mob


### PR DESCRIPTION
Instead of pouncing being a flat "if you roll a 20 then KD the mob" chance, mobs now have a probability of success/failure which can be adjusted per mob, and unless capable of eating standing mobs, will not attempt to pounce targets until the target dips below a health threshold (80% of full by default).

The chance of a pounce succeeding is a linear slope based on the target mob's health. By default, this starts at 20% when the target reaches 80% health, increasing to 100% as the target drops towards zero. If the mob misses a pounce, it will not attempt another for 20 seconds.

Mobs that are capable of eating standing mobs will always succeed on their pounce if they decide to pounce, since they don't punch normally and would otherwise never bring targets below the health threshold to start pouncing so you'd be able to just juke them forever by stepping away when they try to eat you.

If the mob does attempt a pounce, then regardless of success or failure it will not attack normally this round. Mobs will not waste their attack on trying to pounce silicons, which can't be stunned.

Gives the hungry pets the standing_too thing to make them always pounce as before.

Edit: just for clarification when it comes to setting the vars if anyone wants to change them from the default values, here's the sort of probability slope you'd get for the chances of a pounce succeeding versus a potential target's health, with a bunch of values picked purely for example purposes:
![image](https://user-images.githubusercontent.com/14942479/46877730-6eaba300-ce39-11e8-9f98-700e7678346a.png)

Here's the slope for the current default values:
![image](https://user-images.githubusercontent.com/14942479/46877750-7a976500-ce39-11e8-8db3-d8dc0d654afe.png)
