### PR TITLE
Minor shadekin fixes

### DIFF
--- a/code/modules/mob/living/simple_animal/vore/shadekin/shadekin.dm
+++ b/code/modules/mob/living/simple_animal/vore/shadekin/shadekin.dm
@@ -241,7 +241,7 @@
 	if(specific_targets && isliving(A)) //Healing!
 		var/mob/living/L = A
 		var/health_percent = (L.health/L.maxHealth)*100
-		if(health_percent <= 50)
+		if(health_percent <= 50 && will_eat(A))
 			return A
 	. = ..()
 

--- a/code/modules/mob/living/simple_animal/vore/shadekin/types.dm
+++ b/code/modules/mob/living/simple_animal/vore/shadekin/types.dm
@@ -17,7 +17,7 @@
 
 	eye_desc = "red eyes"
 
-	vore_stomach_flavor = "You slip passed pointy triangle teeth and down the slick, \
+	vore_stomach_flavor = "You slip past pointy triangle teeth and down the slick, \
 	slippery gullet of the creature. It's warm, and the air is thick. You can hear \
 	its body squelch and shift around you as you settle into its stomach! Thick digestive \
 	enzymes cling to you within that dark space, tingling and stinging immediately! The weight of \
@@ -64,7 +64,7 @@
 	eye_desc = "blue eyes"
 	shy_approach = TRUE
 	stalker = TRUE
-	vore_stomach_flavor = "You slip passed pointy triangle teeth and down the slick, \
+	vore_stomach_flavor = "You slip past pointy triangle teeth and down the slick, \
 	slippery gullet of the creature. It's warm, and the air is thick. You can hear its body \
 	squelch and shift around you as you settle into its stomach! It's oddly calm, and very dark. \
 	The doughy flesh rolls across your form in gentle waves. The aches and pains across your form slowly begin to \
@@ -106,7 +106,7 @@
 	eye_desc = "purple eyes"
 	shy_approach = TRUE
 	stalker = TRUE
-	vore_stomach_flavor = "You slip passed pointy triangle teeth and down the slick, slippery gullet of the creature. \
+	vore_stomach_flavor = "You slip past pointy triangle teeth and down the slick, slippery gullet of the creature. \
 	It's warm, and the air is thick. You can hear its body squelch and shift around you as you settle into its stomach! \
 	It’s relatively calm inside the dark organ. Wet and almost molten for how gooey your surroundings feel. \
 	You can feel the doughy walls cling to you posessively... It’s almost like you could sink into them. \
@@ -147,7 +147,7 @@
 
 	eye_desc = "yellow eyes"
 	stalker = FALSE
-	vore_stomach_flavor = "You slip passed pointy triangle teeth and down the slick, slippery gullet \
+	vore_stomach_flavor = "You slip past pointy triangle teeth and down the slick, slippery gullet \
 	of the creature. It's warm, and the air is thick. You can hear its body squelch and shift around you \
 	as you settle into its stomach! The doughy walls within cling to you heavily, churning down on you, wearing \
 	you out!! There doesn’t appear to be any actual danger here, harmless slime clings to you, but it’s getting \
@@ -187,7 +187,7 @@
 
 	eye_desc = "green eyes"
 	stalker = TRUE
-	vore_stomach_flavor = "You slip passed pointy triangle teeth and down the slick, slippery gullet \
+	vore_stomach_flavor = "You slip past pointy triangle teeth and down the slick, slippery gullet \
 	of the creature. It's warm, and the air is thick. You can hear its body squelch and shift around you \
 	as you settle into its stomach! The doughy walls within cling to you heavily, churning down on you, wearing \
 	you out!! There doesn’t appear to be any actual danger here, harmless slime clings to you, but it’s getting \
@@ -224,7 +224,7 @@
 
 	eye_desc = "orange eyes"
 
-	vore_stomach_flavor = "You slip passed pointy triangle teeth and down the slick, \
+	vore_stomach_flavor = "You slip past pointy triangle teeth and down the slick, \
 	slippery gullet of the creature. It's warm, and the air is thick. You can hear \
 	its body squelch and shift around you as you settle into its stomach! Thick digestive \
 	enzymes cling to you within that dark space, tingling and stinging immediately! The weight of \


### PR DESCRIPTION
Fixes a typo in the belly descriptions.

Fixes a situation where a blue-eyed shadekin would see an injured person with mobvore disabled, and beat the crap out of them because they can't eat them. Now if you don't have mobvore on they'll ignore you.