### PR TITLE
Reverts species settings

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station.dm
@@ -41,7 +41,7 @@
 	primitive_form = SPECIES_MONKEY_UNATHI
 	darksight = 3
 	ambiguous_genders = TRUE
-	//gluttonous = 1 //VOREStation Edit - Redundant
+	gluttonous = 1
 	slowdown = 0.5
 	total_health = 125
 	brute_mod = 0.85
@@ -79,6 +79,7 @@
 	heat_level_1 = 420 //Default 360 - Higher is better
 	heat_level_2 = 480 //Default 400
 	heat_level_3 = 1100 //Default 1000
+
 	breath_heat_level_1 = 450	//Default 380 - Higher is better
 	breath_heat_level_2 = 530	//Default 450
 	breath_heat_level_3 = 1400	//Default 1250
@@ -184,11 +185,6 @@
 	cold_level_2 = 140 //Default 200
 	cold_level_3 = 80  //Default 120
 
-	heat_level_1 = 330 //Default 360
-	heat_level_2 = 380 //Default 400
-	heat_level_3 = 800 //Default 1000
-
-
 	breath_cold_level_1 = 180	//Default 240 - Lower is better
 	breath_cold_level_2 = 100	//Default 180
 	breath_cold_level_3 = 60	//Default 100
@@ -211,13 +207,15 @@
 
 	reagent_tag = IS_TAJARA
 
-	heat_discomfort_level = 294 //VOREStation Edit - 292 - Prevents heat discomfort spam at 20c
 	move_trail = /obj/effect/decal/cleanable/blood/tracks/paw
+
+	heat_discomfort_level = 292
 	heat_discomfort_strings = list(
 		"Your fur prickles in the heat.",
 		"You feel uncomfortably warm.",
 		"Your overheated skin itches."
 		)
+
 	cold_discomfort_level = 275
 
 	has_organ = list(    //No appendix.
@@ -287,11 +285,11 @@
 	heat_level_2 = 480 //Default 400
 	heat_level_3 = 1100 //Default 1000
 
-	reagent_tag = IS_SKRELL
-
 	breath_heat_level_1 = 400	//Default 380 - Higher is better
 	breath_heat_level_2 = 500	//Default 450
 	breath_heat_level_3 = 1350	//Default 1250
+
+	reagent_tag = IS_SKRELL
 
 	has_limbs = list(
 		BP_TORSO =  list("path" = /obj/item/organ/external/chest),

--- a/code/modules/mob/living/carbon/human/species/station/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station.dm
@@ -289,7 +289,7 @@
 	breath_heat_level_2 = 500	//Default 450
 	breath_heat_level_3 = 1350	//Default 1250
 
-	reagent_tag = IS_SKRELL
+	//reagent_tag = IS_SKRELL //VOREStation Edit
 
 	has_limbs = list(
 		BP_TORSO =  list("path" = /obj/item/organ/external/chest),

--- a/code/modules/mob/living/carbon/human/species/station/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station.dm
@@ -67,7 +67,7 @@
 	planet, they mostly hold ideals of honesty, virtue, proficiency and bravery above all \
 	else, frequently even their own lives. They prefer warmer temperatures than most species and \
 	their native tongue is a heavy hissing laungage called Sinta'Unathi."
-/* VOREStation Removal
+
 	cold_level_1 = 280 //Default 260 - Lower is better
 	cold_level_2 = 220 //Default 200
 	cold_level_3 = 130 //Default 120
@@ -84,7 +84,7 @@
 	breath_heat_level_3 = 1400	//Default 1250
 
 	minimum_breath_pressure = 18	//Bigger, means they need more air
-*/
+
 	body_temperature = T20C
 
 	spawn_flags = SPECIES_CAN_JOIN | SPECIES_IS_WHITELISTED
@@ -94,7 +94,7 @@
 	blood_color = "#b3cbc3"
 	base_color = "#066000"
 
-	//reagent_tag = IS_UNATHI //VOREStation Edit
+	reagent_tag = IS_UNATHI
 
 	move_trail = /obj/effect/decal/cleanable/blood/tracks/claw
 
@@ -122,14 +122,14 @@
 		)
 
 
-	//heat_discomfort_level = 295 //VOREStation Edit
+	heat_discomfort_level = 295
 	heat_discomfort_strings = list(
 		"You feel soothingly warm.",
 		"You feel the heat sink into your bones.",
 		"You feel warm enough to take a nap."
 		)
 
-	//cold_discomfort_level = 292 //VOREStation Removal
+	cold_discomfort_level = 292
 	cold_discomfort_strings = list(
 		"You feel chilly.",
 		"You feel sluggish and cold.",
@@ -183,7 +183,7 @@
 	cold_level_1 = 200 //Default 260
 	cold_level_2 = 140 //Default 200
 	cold_level_3 = 80  //Default 120
-/* VOREStation Removal
+
 	heat_level_1 = 330 //Default 360
 	heat_level_2 = 380 //Default 400
 	heat_level_3 = 800 //Default 1000
@@ -200,7 +200,7 @@
 	breath_heat_level_1 = 360	//Default 380 - Higher is better
 	breath_heat_level_2 = 430	//Default 450
 	breath_heat_level_3 = 1000	//Default 1250
-*/
+
 	primitive_form = SPECIES_MONKEY_TAJ
 
 	spawn_flags = SPECIES_CAN_JOIN | SPECIES_IS_WHITELISTED
@@ -209,16 +209,16 @@
 	flesh_color = "#AFA59E"
 	base_color = "#333333"
 
-	//reagent_tag = IS_TAJARA //VOREStation Removal
+	reagent_tag = IS_TAJARA
 
-	//heat_discomfort_level = 292 //VOREStation Removal
+	heat_discomfort_level = 294 //VOREStation Edit - 292 - Prevents heat discomfort spam at 20c
 	move_trail = /obj/effect/decal/cleanable/blood/tracks/paw
 	heat_discomfort_strings = list(
 		"Your fur prickles in the heat.",
 		"You feel uncomfortably warm.",
 		"Your overheated skin itches."
 		)
-	//cold_discomfort_level = 275 //VOREStation Removal
+	cold_discomfort_level = 275
 
 	has_organ = list(    //No appendix.
 		O_HEART =    /obj/item/organ/internal/heart,
@@ -287,7 +287,7 @@
 	heat_level_2 = 480 //Default 400
 	heat_level_3 = 1100 //Default 1000
 
-	//reagent_tag = IS_SKRELL //VOREStation Edit
+	reagent_tag = IS_SKRELL
 
 	breath_heat_level_1 = 400	//Default 380 - Higher is better
 	breath_heat_level_2 = 500	//Default 450

--- a/code/modules/mob/living/carbon/human/species/station/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station.dm
@@ -289,7 +289,7 @@
 	breath_heat_level_2 = 500	//Default 450
 	breath_heat_level_3 = 1350	//Default 1250
 
-	//reagent_tag = IS_SKRELL //VOREStation Edit
+	reagent_tag = IS_SKRELL
 
 	has_limbs = list(
 		BP_TORSO =  list("path" = /obj/item/organ/external/chest),

--- a/code/modules/mob/living/carbon/human/species/station/station_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_vr.dm
@@ -326,6 +326,7 @@
 	deform = 'icons/mob/human_races/r_def_skrell_vr.dmi'
 	color_mult = 1
 	min_age = 18
+	reagent_tag = 0
 
 /datum/species/diona
 	spawn_flags = SPECIES_CAN_JOIN | SPECIES_IS_WHITELISTED

--- a/code/modules/mob/living/carbon/human/species/station/station_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_vr.dm
@@ -306,6 +306,7 @@
 	tail_animation = 'icons/mob/species/unathi/tail_vr.dmi'
 	color_mult = 1
 	min_age = 18
+	gluttonous = 0
 	inherent_verbs = list(/mob/living/proc/shred_limb)
 
 /datum/species/tajaran
@@ -317,6 +318,7 @@
 	min_age = 18
 	gluttonous = 0 //Moving this here so I don't have to fix this conflict every time polaris glances at station.dm
 	inherent_verbs = list(/mob/living/proc/shred_limb)
+	heat_discomfort_level = 294 //Prevents heat discomfort spam at 20c
 
 /datum/species/skrell
 	spawn_flags = SPECIES_CAN_JOIN

--- a/code/modules/mob/living/carbon/human/species/station/station_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_vr.dm
@@ -326,7 +326,7 @@
 	deform = 'icons/mob/human_races/r_def_skrell_vr.dmi'
 	color_mult = 1
 	min_age = 18
-	reagent_tag = 0
+	reagent_tag = null
 
 /datum/species/diona
 	spawn_flags = SPECIES_CAN_JOIN | SPECIES_IS_WHITELISTED


### PR DESCRIPTION
With custom species existing now, it might be possible to implement many of the commented out things in the vanilla species file.

Some changes/reversions can be made based on feedback/quality of life. Feedback welcome.

Adjustments made based on case situations:
- Tajaran heat discomfort treshhold increased by 2 kelvin (prevents heat discomfort spam at 20c)
- Skrell no longer get sick from meat