### PR TITLE
Makes promethean cores indigestible

### DIFF
--- a/code/modules/vore/eating/bellymodes_vr.dm
+++ b/code/modules/vore/eating/bellymodes_vr.dm
@@ -85,6 +85,9 @@
 								digest_item(I)
 							to_update = TRUE
 							break
+		//get rid of things like blood drops and gibs that end up in there
+		else if(istype(A,/obj/effect/decal/cleanable/))
+			qdel(A)
 
 ///////////////////////////// DM_HOLD /////////////////////////////
 	if(digest_mode == DM_HOLD)

--- a/code/modules/vore/eating/digest_act_vr.dm
+++ b/code/modules/vore/eating/digest_act_vr.dm
@@ -58,6 +58,8 @@
 	return FALSE
 /obj/item/device/perfect_tele_beacon/digest_act(var/atom/movable/item_storage = null)
 	return FALSE //Sorta important to not digest your own beacons.
+/obj/item/organ/internal/brain/slime/digest_act(var/atom/movable/item_storage = null)
+	return FALSE //so prometheans can be recovered
 
 /////////////
 // Some special treatment


### PR DESCRIPTION
as per #4158 - promethean cores now survive where the rest of them does not.

Also made stomachs delete cleanable decals 'cause otherwise eating a prommie would fill your stomach with gibs the instant their limbs popped.