### PR TITLE
QM Console Fix

### DIFF
--- a/maps/tether/tether-07-station3.dmm
+++ b/maps/tether/tether-07-station3.dmm
@@ -17466,10 +17466,10 @@
 /turf/simulated/floor/tiled,
 /area/maintenance/station/cargo)
 "BL" = (
-/obj/machinery/computer/supplycomp{
+/obj/machinery/camera/network/cargo{
 	dir = 4
 	},
-/obj/machinery/camera/network/cargo{
+/obj/machinery/computer/supplycomp/control{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,


### PR DESCRIPTION
The paths for these consoles changed during an upstream cargo code refactor, and only 1 of the 2 was updated on the map to the new correct one. Missed this one since I didn't realize the QM had one.