### PR TITLE
Removes Binoculars from Pathfinder Office

### DIFF
--- a/maps/tether/tether-05-station1.dmm
+++ b/maps/tether/tether-05-station1.dmm
@@ -22208,7 +22208,6 @@
 	pixel_x = 26;
 	pixel_y = -26
 	},
-/obj/item/device/binoculars,
 /turf/simulated/floor/tiled,
 /area/tether/station/pathfinder_office)
 "rhA" = (


### PR DESCRIPTION
When the pathfinder update was originally put together, one of the admins (@DemgelZalvine) left [a note ](https://github.com/VOREStation/VOREStation/pull/3777#issuecomment-393013147) stating to remove the binoculars from the Pathfinder office. This change was not made. With binoculars being removed from mining, this PR removes the last set from the station.