### PR TITLE
Added intelligence levels to some virgo mobs

### DIFF
--- a/code/modules/mob/living/simple_animal/vore/catgirl.dm
+++ b/code/modules/mob/living/simple_animal/vore/catgirl.dm
@@ -4,6 +4,7 @@
 	tt_desc = "Homo felinus"
 	icon = 'icons/mob/vore.dmi'
 	icon_state = "catgirl"
+	intelligence_level = SA_HUMANOID
 
 	speed = 5
 

--- a/code/modules/mob/living/simple_animal/vore/corrupt_hounds.dm
+++ b/code/modules/mob/living/simple_animal/vore/corrupt_hounds.dm
@@ -7,6 +7,7 @@
 	icon_dead = "badboi-dead"
 	icon_rest = "badboi_rest"
 	faction = "corrupt"
+	intelligence_level = SA_ROBOTIC
 
 	maxHealth = 200
 	health = 200

--- a/code/modules/mob/living/simple_animal/vore/shadekin/shadekin.dm
+++ b/code/modules/mob/living/simple_animal/vore/shadekin/shadekin.dm
@@ -6,6 +6,7 @@
 	icon_living = "map_example"
 	faction = "shadekin"
 	ui_icons = 'icons/mob/shadekin_hud.dmi'
+	intelligence_level = SA_HUMANOID
 
 	maxHealth = 200
 	health = 200

--- a/code/modules/mob/living/simple_animal/vore/wolfgirl.dm
+++ b/code/modules/mob/living/simple_animal/vore/wolfgirl.dm
@@ -6,6 +6,7 @@
 	icon_state = "wolfgirl"
 	icon_living = "wolfgirl"
 	icon_dead = "wolfgirl-dead"
+	intelligence_level = SA_HUMANOID
 
 	faction = "wolfgirl"
 	maxHealth = 30


### PR DESCRIPTION
I wanted to initially give wolf and catgirls an SA_PLANT, but then decided against furthering the meme.

All mobs listed previously had SA_ANIMAL level intelligence

New:
Shadekin (all types): SA_HUMANOID
Awoo (file name should really be un-memed at some point...): SA_HUMANOID
Catgirl: SA_HUMANOID
Corrupt Hound: SA_ROBOTIC


As far as I am aware, they are only a few checks using it right now, but may be more at later point?
Its in checks for slime potions, as those are only meant to work on mobs with animal or lower intelligence.
Additionally, slime baton and slime taser won't stun things smarter than animal.
Berserk artifact effect wont show for plants and robots.
And last bit of flavor, using ionic rapier on the robotic mobs makes them madder than normal.

So mostly, its for miscelaneous checks all around, that may or may not have further effect in future