### PR TITLE
Splits first aid kit spawning

### DIFF
--- a/code/game/objects/random/random_vr.dm
+++ b/code/game/objects/random/random_vr.dm
@@ -201,9 +201,31 @@
 			this_mob.forceMove(T)
 
 //Just overriding this here, no more super medkit so those can be reserved for PoIs and such
-/obj/random/firstaid/item_to_spawn()
+/obj/random/tetheraid
+	name = "Random First Aid Kit"
+	desc = "This is a random first aid kit. Does not include Combat Kits."
+	icon = 'icons/obj/storage.dmi'
+	icon_state = "firstaid"
+
+/obj/random/tetheraid/item_to_spawn()
 	return pick(prob(4);/obj/item/weapon/storage/firstaid/regular,
 				prob(3);/obj/item/weapon/storage/firstaid/toxin,
 				prob(3);/obj/item/weapon/storage/firstaid/o2,
 				prob(2);/obj/item/weapon/storage/firstaid/adv,
 				prob(3);/obj/item/weapon/storage/firstaid/fire)
+
+//Override from maintenance.dm to prevent combat kits from spawning in Tether maintenance
+/obj/random/maintenance/item_to_spawn()
+	return pick(prob(300);/obj/random/tech_supply,
+				prob(200);/obj/random/medical,
+				prob(100);/obj/random/tetheraid,
+				prob(10);/obj/random/contraband,
+				prob(50);/obj/random/action_figure,
+				prob(50);/obj/random/plushie,
+				prob(200);/obj/random/junk,
+				prob(200);/obj/random/material,
+				prob(50);/obj/random/toy,
+				prob(100);/obj/random/tank,
+				prob(50);/obj/random/soap,
+				prob(60);/obj/random/drinkbottle,
+				prob(500);/obj/random/maintenance/clean)

--- a/maps/tether/tether-03-surface3.dmm
+++ b/maps/tether/tether-03-surface3.dmm
@@ -253,7 +253,7 @@
 /area/tether/surfacebase/medical/triage)
 "aE" = (
 /obj/structure/table/rack,
-/obj/random/firstaid,
+/obj/random/tetheraid,
 /obj/random/maintenance/medical,
 /turf/simulated/floor/wood,
 /area/vacant/vacant_site2)
@@ -1787,7 +1787,7 @@
 	dir = 4;
 	pixel_x = 24
 	},
-/obj/random/firstaid,
+/obj/random/tetheraid,
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/triage)
 "dB" = (
@@ -2249,11 +2249,11 @@
 /obj/effect/floor_decal/corner/red/border{
 	dir = 4
 	},
-/obj/random/firstaid,
+/obj/random/tetheraid,
 /obj/machinery/vending/wallmed1{
 	pixel_x = 32
 	},
-/obj/random/firstaid,
+/obj/random/tetheraid,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/common)
 "ev" = (
@@ -20740,8 +20740,8 @@
 /turf/simulated/floor/reinforced,
 /area/tether/surfacebase/shuttle_pad)
 "JI" = (
-/turf/simulated/floor/reinforced,
 /obj/structure/shuttle/engine/propulsion,
+/turf/simulated/floor/reinforced,
 /turf/simulated/shuttle/plating/carry,
 /area/shuttle/tether/surface)
 "JJ" = (

--- a/maps/tether/tether-06-station2.dmm
+++ b/maps/tether/tether-06-station2.dmm
@@ -13945,8 +13945,8 @@
 	dir = 8
 	},
 /obj/structure/table/standard,
-/obj/random/firstaid,
-/obj/random/firstaid,
+/obj/random/tetheraid,
+/obj/random/tetheraid,
 /obj/item/device/radio/intercom{
 	dir = 8;
 	pixel_x = -24

--- a/maps/tether/tether-07-station3.dmm
+++ b/maps/tether/tether-07-station3.dmm
@@ -21673,7 +21673,7 @@
 /obj/random/maintenance/clean,
 /obj/random/maintenance/medical,
 /obj/random/junk,
-/obj/random/firstaid,
+/obj/random/tetheraid,
 /obj/random/medical/lite,
 /obj/random/maintenance/medical,
 /obj/effect/decal/cleanable/dirt,


### PR DESCRIPTION
Removes the override on first aid kit spawning preventing combat kits from being spawned, but adds a new 'Tetheraid' first aid kit spawn to prevent combat kits from spawning on the Tether, but allows them for expedition sites which still use random spawns.

Also changes the obj/random/maintenance randomly generated item to also only spawn 'Tetheraid' first aid kits, since it shows up twice on the Tether.

TL;DR, it splits first aid kit spawns into one for use on the Tether, which do not have a combat first aid kit, and one used outside the tether (such as POIs) which do have the possibility of spawning a combat first aid kit.