### PR TITLE
Fixes #4173, tidies up promethean file

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/prometheans_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/prometheans_vr.dm
@@ -1,13 +1,7 @@
 /datum/species/shapeshifter/promethean
 	min_age = 18 //Required for server rules
 	max_age = 80
-	valid_transform_species = list(
-		"Human", "Unathi", "Tajara", "Skrell",
-		"Diona", "Teshari", "Monkey","Sergal",
-		"Akula","Nevrean","Highlander Zorren",
-		"Flatland Zorren", "Vulpkanin", "Vasilissan",
-		"Rapala", "Neaera", "Stok", "Farwa", "Sobaka",
-		"Wolpin", "Saru", "Sparra")
+	valid_transform_species = list(SPECIES_HUMAN, SPECIES_HUMAN_VATBORN, SPECIES_UNATHI, SPECIES_TAJ, SPECIES_SKRELL, SPECIES_DIONA, SPECIES_TESHARI, SPECIES_MONKEY, SPECIES_MONKEY_TAJ, SPECIES_MONKEY_SKRELL, SPECIES_MONKEY_STOK, SPECIES_SERGAL, SPECIES_AKULA, SPECIES_NEVREAN, SPECIES_ZORREN_HIGH, SPECIES_ZORREN_FLAT, SPECIES_VULPKANIN, SPECIES_VASILISSAN, SPECIES_RAPALA, "Sobaka", "Wolpin", "Saru", "Sparra")
 
 	heal_rate = 0.2 //As of writing, original was 0.5 - Slows regen speed (bad)
 	hunger_factor = 0.1 //As of writing, original was 0.2 - Slows hunger rate (good)
@@ -16,7 +10,7 @@
 
 	color_mult = 1
 	mob_size = MOB_MEDIUM //As of writing, original was MOB_SMALL - Allows normal swapping (good)
-	num_alternate_languages = 1 //Might be outdated: They currently have 3 in the other file
+	num_alternate_languages = 3
 	trashcan = 1 //They have goopy bodies. They can just dissolve things within them.
 
 	appearance_flags = HAS_SKIN_COLOR | HAS_EYE_COLOR | HAS_HAIR_COLOR | RADIATION_GLOWS | HAS_UNDERWEAR
@@ -27,6 +21,9 @@
 		/mob/living/carbon/human/proc/shapeshifter_select_hair,
 		/mob/living/carbon/human/proc/shapeshifter_select_hair_colors,
 		/mob/living/carbon/human/proc/shapeshifter_select_gender,
+		/mob/living/carbon/human/proc/shapeshifter_select_wings,
+		/mob/living/carbon/human/proc/shapeshifter_select_tail,
+		/mob/living/carbon/human/proc/shapeshifter_select_ears,
 		/mob/living/carbon/human/proc/regenerate,
 		/mob/living/proc/set_size,
 		/mob/living/carbon/human/proc/succubus_drain,


### PR DESCRIPTION
Re-adds verbs that were accidentally overwritten. Also converts `valid_transform_species` to use macros, as intended.