### PR TITLE
Adds Subspace Radio

### DIFF
--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -18,7 +18,7 @@
 			            access_heads, access_hos, access_RC_announce, access_keycard_auth, access_gateway, access_external_airlocks)//VOREStation Edit
 	minimal_access = list(access_security, access_eva, access_sec_doors, access_brig, access_armory,
 			            access_forensics_lockers, access_morgue, access_maint_tunnels, access_all_personal_lockers,
-			            access_research, access_engine, access_mining, access_medical, access_construction, access_mailsorting,
+			            access_research, access_engine, access_mining, access_construction, access_mailsorting,
 			            access_heads, access_hos, access_RC_announce, access_keycard_auth, access_gateway, access_external_airlocks)//VOREStation Edit
 	minimum_character_age = 25
 	minimal_player_age = 14

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -1,25 +1,28 @@
 // Access check is of the type requires one. These have been carefully selected to avoid allowing the janitor to see channels he shouldn't
+//VOREStation Edit Start - Updating this for Virgo
 var/global/list/default_internal_channels = list(
 	num2text(PUB_FREQ) = list(),
-	num2text(AI_FREQ)  = list(access_synth),
 	num2text(ENT_FREQ) = list(),
+	num2text(AI_FREQ)  = list(access_synth),
 	num2text(ERT_FREQ) = list(access_cent_specops),
 	num2text(COMM_FREQ)= list(access_heads),
 	num2text(ENG_FREQ) = list(access_engine_equip, access_atmospherics),
-	num2text(MED_FREQ) = list(access_medical_equip),
-	num2text(MED_I_FREQ)=list(access_medical_equip),
+	num2text(MED_FREQ) = list(access_medical),
+	num2text(MED_I_FREQ)=list(access_medical),
 	num2text(SEC_FREQ) = list(access_security),
 	num2text(SEC_I_FREQ)=list(access_security),
-	num2text(SCI_FREQ) = list(access_tox,access_robotics,access_xenobiology),
-	num2text(SUP_FREQ) = list(access_cargo),
-	num2text(SRV_FREQ) = list(access_janitor, access_hydroponics)
+	num2text(SCI_FREQ) = list(access_research),
+	num2text(SUP_FREQ) = list(access_cargo, access_mining),
+	num2text(SRV_FREQ) = list(access_janitor, access_hydroponics),
+	num2text(EXP_FREQ) = list(access_pilot, access_explorer, access_rd)
 )
 
 var/global/list/default_medbay_channels = list(
 	num2text(PUB_FREQ) = list(),
-	num2text(MED_FREQ) = list(access_medical_equip),
-	num2text(MED_I_FREQ) = list(access_medical_equip)
+	num2text(MED_FREQ) = list(),
+	num2text(MED_I_FREQ) = list()
 )
+//VOREStation Edit End
 
 /obj/item/device/radio
 	icon = 'icons/obj/radio_vr.dmi' //VOREStation Edit

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -2,8 +2,8 @@
 //VOREStation Edit Start - Updating this for Virgo
 var/global/list/default_internal_channels = list(
 	num2text(PUB_FREQ) = list(),
-	num2text(ENT_FREQ) = list(),
 	num2text(AI_FREQ)  = list(access_synth),
+	num2text(ENT_FREQ) = list(),
 	num2text(ERT_FREQ) = list(access_cent_specops),
 	num2text(COMM_FREQ)= list(access_heads),
 	num2text(ENG_FREQ) = list(access_engine_equip, access_atmospherics),

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -7,14 +7,14 @@ var/global/list/default_internal_channels = list(
 	num2text(ERT_FREQ) = list(access_cent_specops),
 	num2text(COMM_FREQ)= list(access_heads),
 	num2text(ENG_FREQ) = list(access_engine_equip, access_atmospherics),
-	num2text(MED_FREQ) = list(access_medical),
-	num2text(MED_I_FREQ)=list(access_medical),
+	num2text(MED_FREQ) = list(access_medical_equip),
+	num2text(MED_I_FREQ)=list(access_medical_equip),
 	num2text(SEC_FREQ) = list(access_security),
 	num2text(SEC_I_FREQ)=list(access_security),
-	num2text(SCI_FREQ) = list(access_research),
+	num2text(SCI_FREQ) = list(access_tox, access_robotics, access_xenobiology, access_explorer),
 	num2text(SUP_FREQ) = list(access_cargo, access_mining),
 	num2text(SRV_FREQ) = list(access_janitor, access_library, access_hydroponics, access_bar, access_kitchen),
-	num2text(EXP_FREQ) = list(access_pilot, access_explorer, access_rd)
+	num2text(EXP_FREQ) = list(access_explorer, access_pilot, access_rd)
 )
 
 var/global/list/default_medbay_channels = list(

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -12,7 +12,7 @@ var/global/list/default_internal_channels = list(
 	num2text(SEC_FREQ) = list(access_security),
 	num2text(SEC_I_FREQ)=list(access_security),
 	num2text(SCI_FREQ) = list(access_tox, access_robotics, access_xenobiology, access_explorer),
-	num2text(SUP_FREQ) = list(access_cargo, access_mining),
+	num2text(SUP_FREQ) = list(access_cargo, access_mining_station),
 	num2text(SRV_FREQ) = list(access_janitor, access_library, access_hydroponics, access_bar, access_kitchen),
 	num2text(EXP_FREQ) = list(access_explorer, access_pilot, access_rd)
 )

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -13,7 +13,7 @@ var/global/list/default_internal_channels = list(
 	num2text(SEC_I_FREQ)=list(access_security),
 	num2text(SCI_FREQ) = list(access_research),
 	num2text(SUP_FREQ) = list(access_cargo, access_mining),
-	num2text(SRV_FREQ) = list(access_janitor, access_hydroponics),
+	num2text(SRV_FREQ) = list(access_janitor, access_library, access_hydroponics, access_bar, access_kitchen),
 	num2text(EXP_FREQ) = list(access_pilot, access_explorer, access_rd)
 )
 

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -40,7 +40,6 @@ var/global/list/default_medbay_channels = list(
 	var/list/channels = list() //see communications.dm for full list. First channel is a "default" for :h
 	var/subspace_transmission = 0
 	var/adhoc_fallback = FALSE //Falls back to 'radio' mode if subspace not available
-	var/bluespace_radio = FALSE //VOREStation Add - Long Range Radio
 	var/syndie = 0//Holder to see if it's a syndicate encrypted radio
 	var/centComm = 0//Holder to see if it's a CentCom encrypted radio
 	flags = CONDUCT
@@ -475,18 +474,18 @@ var/global/list/default_medbay_channels = list(
 		// we're done here.
 		return 1
 
+	// Oh my god; the comms are down or something because the signal hasn't been broadcasted yet in our level.
+	// Send a mundane broadcast with limited targets:
+
+	//THIS IS TEMPORARY. YEAH RIGHT
+	if(!connection)	return 0	//~Carn
+
 //VOREStation Add Start
 	if(bluespace_radio)
 		return Broadcast_Message(connection, M, voicemask, pick(M.speak_emote),
 					  src, message, displayname, jobname, real_name, M.voice_name,
 					  0, signal.data["compression"], list(0), connection.frequency,verb,speaking)
 //VOREStation Add End
-
-	// Oh my god; the comms are down or something because the signal hasn't been broadcasted yet in our level.
-	// Send a mundane broadcast with limited targets:
-
-	//THIS IS TEMPORARY. YEAH RIGHT
-	if(!connection)	return 0	//~Carn
 
 	return Broadcast_Message(connection, M, voicemask, pick(M.speak_emote),
 					  src, message, displayname, jobname, real_name, M.voice_name,
@@ -526,7 +525,7 @@ var/global/list/default_medbay_channels = list(
 	if(!(0 in level))
 		var/turf/position = get_turf(src)
 		if(!position || !(position.z in level))
-			if(!bluespace_radio && !(src.bluespace_radio)) //VOREStation Edit
+			if(!bluespace_radio) //VOREStation Edit
 				return -1
 	if(freq in ANTAG_FREQS)
 		if(!(src.syndie))//Checks to see if it's allowed on that frequency, based on the encryption keys

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -40,6 +40,7 @@ var/global/list/default_medbay_channels = list(
 	var/list/channels = list() //see communications.dm for full list. First channel is a "default" for :h
 	var/subspace_transmission = 0
 	var/adhoc_fallback = FALSE //Falls back to 'radio' mode if subspace not available
+	var/bluespace_radio = FALSE //VOREStation Add - Long Range Radio
 	var/syndie = 0//Holder to see if it's a syndicate encrypted radio
 	var/centComm = 0//Holder to see if it's a CentCom encrypted radio
 	flags = CONDUCT
@@ -474,6 +475,13 @@ var/global/list/default_medbay_channels = list(
 		// we're done here.
 		return 1
 
+//VOREStation Add Start
+	if(bluespace_radio)
+		return Broadcast_Message(connection, M, voicemask, pick(M.speak_emote),
+					  src, message, displayname, jobname, real_name, M.voice_name,
+					  0, signal.data["compression"], list(0), connection.frequency,verb,speaking)
+//VOREStation Add End
+
 	// Oh my god; the comms are down or something because the signal hasn't been broadcasted yet in our level.
 	// Send a mundane broadcast with limited targets:
 
@@ -518,7 +526,8 @@ var/global/list/default_medbay_channels = list(
 	if(!(0 in level))
 		var/turf/position = get_turf(src)
 		if(!position || !(position.z in level))
-			return -1
+			if(!bluespace_radio && !(src.bluespace_radio)) //VOREStation Edit
+				return -1
 	if(freq in ANTAG_FREQS)
 		if(!(src.syndie))//Checks to see if it's allowed on that frequency, based on the encryption keys
 			return -1

--- a/code/game/objects/items/devices/radio/radio_vr.dm
+++ b/code/game/objects/items/devices/radio/radio_vr.dm
@@ -54,14 +54,14 @@
 		..()
 
 /obj/item/device/subspaceradio/MouseDrop()
-	if(ismob(src.loc))
-		if(!CanMouseDrop(src))
-			return
-		var/mob/M = src.loc
-		if(!M.unEquip(src))
-			return
-		src.add_fingerprint(usr)
-		M.put_in_any_hand_if_possible(src)
+    if(ismob(loc))
+        if(!CanMouseDrop(src))
+            return
+        var/mob/M = loc
+        if(!M.unEquip(src))
+            return
+        add_fingerprint(usr)
+        M.put_in_any_hand_if_possible(src)
 
 /obj/item/device/subspaceradio/attackby(obj/item/weapon/W, mob/user, params)
 	if(W == handset)

--- a/code/game/objects/items/devices/radio/radio_vr.dm
+++ b/code/game/objects/items/devices/radio/radio_vr.dm
@@ -1,0 +1,127 @@
+//Pathfinder's Subspace Radio
+/obj/item/device/subspaceradio
+	name = "subspace radio"
+	desc = "A powerful new radio recently gifted to Nanotrasen from KHI, this communications device has the ability to send and recieve transmissions from anywhere."
+	icon = 'icons/vore/custom_items_vr.dmi'
+	icon_state = "radiopack"
+	item_state = "parachute"
+	slot_flags = SLOT_BACK
+	force = 5
+	throwforce = 6
+	preserve_item = 1
+	w_class = ITEMSIZE_LARGE
+	action_button_name = "Remove/Replace Headset"
+
+	var/obj/item/device/radio/subspaceradio/linked/headset
+
+/obj/item/device/subspaceradio/New() //starts without a cell for rnd
+	..()
+	if(ispath(headset))
+		headset = new headset(src, src)
+	else
+		headset = new(src, src)
+
+/obj/item/device/subspaceradio/Destroy()
+	. = ..()
+	QDEL_NULL(headset)
+
+/obj/item/device/subspaceradio/ui_action_click()
+	toggle_headset()
+
+/obj/item/device/subspaceradio/attack_hand(mob/user)
+	if(loc == user)
+		toggle_headset()
+	else
+		..()
+
+/obj/item/device/subspaceradio/MouseDrop()
+	if(ismob(src.loc))
+		if(!CanMouseDrop(src))
+			return
+		var/mob/M = src.loc
+		if(!M.unEquip(src))
+			return
+		src.add_fingerprint(usr)
+		M.put_in_any_hand_if_possible(src)
+
+/obj/item/device/subspaceradio/attackby(obj/item/weapon/W, mob/user, params)
+	if(W == headset)
+		reattach_headset(user)
+	else
+		return ..()
+
+/obj/item/device/subspaceradio/verb/toggle_headset()
+	set name = "Toggle Headset"
+	set category = "Object"
+
+	var/mob/living/carbon/human/user = usr
+	if(!headset)
+		to_chat(user, "<span class='warning'>The headset is missing!</span>")
+		return
+
+	if(headset.loc != src)
+		reattach_headset(user) //Remove from their hands and back onto the defib unit
+		return
+
+	if(!slot_check())
+		to_chat(user, "<span class='warning'>You need to equip [src] before taking out [headset].</span>")
+	else
+		if(!usr.put_in_hands(headset)) //Detach the headset into the user's hands
+			to_chat(user, "<span class='warning'>You need a free hand to hold the headset!</span>")
+		update_icon() //success
+
+//checks that the base unit is in the correct slot to be used
+/obj/item/device/subspaceradio/proc/slot_check()
+	var/mob/M = loc
+	if(!istype(M))
+		return 0 //not equipped
+
+	if((slot_flags & SLOT_BACK) && M.get_equipped_item(slot_back) == src)
+		return 1
+	if((slot_flags & SLOT_BELT) && M.get_equipped_item(slot_belt) == src)
+		return 1
+
+	return 0
+
+/obj/item/device/subspaceradio/dropped(mob/user)
+	..()
+	reattach_headset(user) //headset attached to a base unit should never exist outside of their base unit or the mob equipping the base unit
+
+/obj/item/device/subspaceradio/proc/reattach_headset(mob/user)
+	if(!headset) return
+
+	if(ismob(headset.loc))
+		var/mob/M = headset.loc
+		if(M.drop_from_inventory(headset, src))
+			to_chat(user, "<span class='notice'>\The [headset] snap back into the main unit.</span>")
+	else
+		headset.forceMove(src)
+
+//Subspace Radio Headset
+/obj/item/device/radio/subspaceradio
+	name = "subspace radio headset"
+	desc = "A large walkie talkie attached to the subspace radio by a retractable cord. It sits comfortably on a slot in the radio when not in use."
+	bluespace_radio = TRUE
+	icon_state = "signaller"
+	slot_flags = null
+	w_class = ITEMSIZE_LARGE
+
+/obj/item/device/radio/subspaceradio/linked
+	var/obj/item/device/subspaceradio/base_unit
+
+/obj/item/device/radio/subspaceradio/linked/New(newloc, obj/item/device/subspaceradio/radio)
+	base_unit = radio
+	..(newloc)
+
+/obj/item/device/radio/subspaceradio/linked/Destroy()
+	if(base_unit)
+		//ensure the base unit's icon updates
+		if(base_unit.headset == src)
+			base_unit.headset = null
+		base_unit = null
+	return ..()
+
+/obj/item/device/radio/subspaceradio/linked/dropped(mob/user)
+	..() //update twohanding
+	if(base_unit)
+		base_unit.reattach_headset(user) //headset attached to a base unit should never exist outside of their base unit or the mob equipping the base unit

--- a/code/game/objects/items/devices/radio/radio_vr.dm
+++ b/code/game/objects/items/devices/radio/radio_vr.dm
@@ -1,10 +1,10 @@
+/obj/item/device/radio
+	var/bluespace_radio = FALSE
+
 /obj/item/device/radio/phone
 	subspace_transmission = 1
 	canhear_range = 0
 	adhoc_fallback = TRUE
-
-/obj/item/device/radio
-	var/bluespace_radio = FALSE
 
 /obj/item/device/radio/emergency
 	name = "Medbay Emergency Radio Link"

--- a/code/game/objects/items/devices/radio/radio_vr.dm
+++ b/code/game/objects/items/devices/radio/radio_vr.dm
@@ -1,5 +1,21 @@
+/obj/item/device/radio/phone
+	subspace_transmission = 1
+	canhear_range = 0
+	adhoc_fallback = TRUE
+
 /obj/item/device/radio
 	var/bluespace_radio = FALSE
+
+/obj/item/device/radio/emergency
+	name = "Medbay Emergency Radio Link"
+	icon_state = "med_walkietalkie"
+	frequency = MED_I_FREQ
+	subspace_transmission = 1
+	adhoc_fallback = TRUE
+
+/obj/item/device/radio/emergency/New()
+	..()
+	internal_channels = default_medbay_channels.Copy()
 
 //Pathfinder's Subspace Radio
 /obj/item/device/subspaceradio

--- a/code/game/objects/items/devices/radio/radio_vr.dm
+++ b/code/game/objects/items/devices/radio/radio_vr.dm
@@ -1,3 +1,6 @@
+/obj/item/device/radio
+	var/bluespace_radio = FALSE
+
 //Pathfinder's Subspace Radio
 /obj/item/device/subspaceradio
 	name = "subspace radio"
@@ -10,27 +13,27 @@
 	throwforce = 6
 	preserve_item = 1
 	w_class = ITEMSIZE_LARGE
-	action_button_name = "Remove/Replace Headset"
+	action_button_name = "Remove/Replace Handset"
 
-	var/obj/item/device/radio/subspaceradio/linked/headset
+	var/obj/item/device/radio/subspacehandset/linked/handset
 
 /obj/item/device/subspaceradio/New() //starts without a cell for rnd
 	..()
-	if(ispath(headset))
-		headset = new headset(src, src)
+	if(ispath(handset))
+		handset = new handset(src, src)
 	else
-		headset = new(src, src)
+		handset = new(src, src)
 
 /obj/item/device/subspaceradio/Destroy()
 	. = ..()
-	QDEL_NULL(headset)
+	QDEL_NULL(handset)
 
 /obj/item/device/subspaceradio/ui_action_click()
-	toggle_headset()
+	toggle_handset()
 
 /obj/item/device/subspaceradio/attack_hand(mob/user)
 	if(loc == user)
-		toggle_headset()
+		toggle_handset()
 	else
 		..()
 
@@ -45,29 +48,29 @@
 		M.put_in_any_hand_if_possible(src)
 
 /obj/item/device/subspaceradio/attackby(obj/item/weapon/W, mob/user, params)
-	if(W == headset)
-		reattach_headset(user)
+	if(W == handset)
+		reattach_handset(user)
 	else
 		return ..()
 
-/obj/item/device/subspaceradio/verb/toggle_headset()
-	set name = "Toggle Headset"
+/obj/item/device/subspaceradio/verb/toggle_handset()
+	set name = "Toggle Handset"
 	set category = "Object"
 
 	var/mob/living/carbon/human/user = usr
-	if(!headset)
-		to_chat(user, "<span class='warning'>The headset is missing!</span>")
+	if(!handset)
+		to_chat(user, "<span class='warning'>The handset is missing!</span>")
 		return
 
-	if(headset.loc != src)
-		reattach_headset(user) //Remove from their hands and back onto the defib unit
+	if(handset.loc != src)
+		reattach_handset(user) //Remove from their hands and back onto the defib unit
 		return
 
 	if(!slot_check())
-		to_chat(user, "<span class='warning'>You need to equip [src] before taking out [headset].</span>")
+		to_chat(user, "<span class='warning'>You need to equip [src] before taking out [handset].</span>")
 	else
-		if(!usr.put_in_hands(headset)) //Detach the headset into the user's hands
-			to_chat(user, "<span class='warning'>You need a free hand to hold the headset!</span>")
+		if(!usr.put_in_hands(handset)) //Detach the handset into the user's hands
+			to_chat(user, "<span class='warning'>You need a free hand to hold the handset!</span>")
 		update_icon() //success
 
 //checks that the base unit is in the correct slot to be used
@@ -85,43 +88,43 @@
 
 /obj/item/device/subspaceradio/dropped(mob/user)
 	..()
-	reattach_headset(user) //headset attached to a base unit should never exist outside of their base unit or the mob equipping the base unit
+	reattach_handset(user) //handset attached to a base unit should never exist outside of their base unit or the mob equipping the base unit
 
-/obj/item/device/subspaceradio/proc/reattach_headset(mob/user)
-	if(!headset) return
+/obj/item/device/subspaceradio/proc/reattach_handset(mob/user)
+	if(!handset) return
 
-	if(ismob(headset.loc))
-		var/mob/M = headset.loc
-		if(M.drop_from_inventory(headset, src))
-			to_chat(user, "<span class='notice'>\The [headset] snap back into the main unit.</span>")
+	if(ismob(handset.loc))
+		var/mob/M = handset.loc
+		if(M.drop_from_inventory(handset, src))
+			to_chat(user, "<span class='notice'>\The [handset] snap back into the main unit.</span>")
 	else
-		headset.forceMove(src)
+		handset.forceMove(src)
 
-//Subspace Radio Headset
-/obj/item/device/radio/subspaceradio
-	name = "subspace radio headset"
+//Subspace Radio Handset
+/obj/item/device/radio/subspacehandset
+	name = "subspace radio handset"
 	desc = "A large walkie talkie attached to the subspace radio by a retractable cord. It sits comfortably on a slot in the radio when not in use."
 	bluespace_radio = TRUE
 	icon_state = "signaller"
 	slot_flags = null
 	w_class = ITEMSIZE_LARGE
 
-/obj/item/device/radio/subspaceradio/linked
+/obj/item/device/radio/subspacehandset/linked
 	var/obj/item/device/subspaceradio/base_unit
 
-/obj/item/device/radio/subspaceradio/linked/New(newloc, obj/item/device/subspaceradio/radio)
+/obj/item/device/radio/subspacehandset/linked/New(newloc, obj/item/device/subspaceradio/radio)
 	base_unit = radio
 	..(newloc)
 
-/obj/item/device/radio/subspaceradio/linked/Destroy()
+/obj/item/device/radio/subspacehandset/linked/Destroy()
 	if(base_unit)
 		//ensure the base unit's icon updates
-		if(base_unit.headset == src)
-			base_unit.headset = null
+		if(base_unit.handset == src)
+			base_unit.handset = null
 		base_unit = null
 	return ..()
 
-/obj/item/device/radio/subspaceradio/linked/dropped(mob/user)
+/obj/item/device/radio/subspacehandset/linked/dropped(mob/user)
 	..() //update twohanding
 	if(base_unit)
-		base_unit.reattach_headset(user) //headset attached to a base unit should never exist outside of their base unit or the mob equipping the base unit
+		base_unit.reattach_handset(user) //handset attached to a base unit should never exist outside of their base unit or the mob equipping the base unit

--- a/maps/southern_cross/structures/closets/misc_vr.dm
+++ b/maps/southern_cross/structures/closets/misc_vr.dm
@@ -23,6 +23,7 @@
 		/obj/item/device/geiger,
 		/obj/item/weapon/cell/device,
 		/obj/item/device/radio,
+		/obj/item/device/subspaceradio,
 		/obj/item/stack/marker_beacon/thirty,
 		/obj/item/weapon/material/knife/tacknife/survival,
 		/obj/item/weapon/material/knife/machete/deluxe,

--- a/maps/tether/tether-01-surface1.dmm
+++ b/maps/tether/tether-01-surface1.dmm
@@ -13773,11 +13773,7 @@
 "aGx" = (
 /obj/structure/table/glass,
 /obj/item/weapon/storage/toolbox/emergency,
-/obj/item/device/radio{
-	frequency = 1487;
-	icon_state = "med_walkietalkie";
-	name = "Medbay Emergency Radio Link"
-	},
+/obj/item/device/radio/emergency,
 /obj/machinery/recharger,
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/first_aid_west)
@@ -14750,14 +14746,7 @@
 /area/engineering/atmos/processing)
 "aJj" = (
 /obj/structure/table/glass,
-/obj/item/device/radio{
-	anchored = 1;
-	broadcasting = 0;
-	canhear_range = 1;
-	frequency = 1487;
-	icon = 'icons/obj/items.dmi';
-	icon_state = "red_phone";
-	listening = 1;
+/obj/item/device/radio/phone/medbay{
 	name = "Medical Emergency Phone"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -1000,6 +1000,7 @@
 #include "code\game\objects\items\devices\radio\intercom.dm"
 #include "code\game\objects\items\devices\radio\jammer.dm"
 #include "code\game\objects\items\devices\radio\radio.dm"
+#include "code\game\objects\items\devices\radio\radio_vr.dm"
 #include "code\game\objects\items\robot\robot_items.dm"
 #include "code\game\objects\items\robot\robot_parts.dm"
 #include "code\game\objects\items\robot\robot_upgrades.dm"


### PR DESCRIPTION
A backpack radio that mechanically works similar to a defibrillator, that can send and receive messages from anywhere regardless of telecoms. Is still susceptible to the usual methods of signal disruption such as jamming.

- Adds the Pathfinder's radio, currently spawns in the Pathfinder's locker.
- Overhauls default channel list, fixing access as well as adding the exploration channel
- Fixes the emergency medical phone and emergency medbay radio link
- Fixes an oversight where access_medical was not properly removed from HoS