### PR TITLE
Move photosensitive to be a neutral trait

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/negative.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/negative.dm
@@ -90,12 +90,6 @@
 	cost = -2
 	var_changes = list("siemens_coefficient" = 2.0) //This makes you extremely weak to tasers.
 
-/datum/trait/photosensitive
-	name = "Photosensitive"
-	desc = "Increases stun duration from flashes and other light-based stuns."
-	cost = -1
-	var_changes = list("flash_mod" = 2.0)
-
 /datum/trait/hollow
 	name = "Hollow Bones/Aluminum Alloy"
 	desc = "Your bones and robot limbs are much easier to break."

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
@@ -113,3 +113,9 @@
 	..(S,H)
 	H.verbs |= /mob/living/proc/glow_toggle
 	H.verbs |= /mob/living/proc/glow_color
+
+/datum/trait/photosensitive
+	name = "Photosensitive"
+	desc = "Increases stun duration from flashes and other light-based stuns."
+	cost = 0
+	var_changes = list("flash_mod" = 2.0)


### PR DESCRIPTION
It appears that everyone and their dog takes photosensitive, probably because it never comes up in the game at all, and gives what amounts to a free point.

It's the most popular negative trait by a decent margin.