### PR TITLE
Updates permits, adds Ace's pistol

### DIFF
--- a/code/modules/projectiles/guns/projectile/pistol_vr.dm
+++ b/code/modules/projectiles/guns/projectile/pistol_vr.dm
@@ -3,3 +3,7 @@
 
 /obj/item/weapon/gun/projectile/p92x/sec
 	magazine_type = /obj/item/ammo_magazine/m9mm/rubber
+
+/obj/item/weapon/gun/projectile/p92x/large/preban
+	icon_state = "p92x-brown"
+	magazine_type = /obj/item/ammo_magazine/m9mm/large/preban // Spawns with big magazines that are legal.

--- a/code/modules/vore/fluffstuff/custom_boxes_vr.dm
+++ b/code/modules/vore/fluffstuff/custom_boxes_vr.dm
@@ -1,4 +1,5 @@
 // ToDo: Alphabetize by ckey.
+// Also these things might be mildly obsolete considering the update to inventory.
 
 // BEGIN - DO NOT EDIT PROTOTYPE
 /obj/item/weapon/storage/box/fluff
@@ -39,6 +40,20 @@
 		/obj/item/clothing/under/fluff/kilanosuit/purple,
 		/obj/item/clothing/shoes/boots/fluff/kilano/purple)
 
+//BeyondMyLife: Ne'tra Ky'ram //Made a box because they have so many items that it'd spam the debug log.
+/obj/item/weapon/storage/box/fluff/kilano
+	name = "Ne'tra Ky'ram's Kit"
+	desc = "A kit containing Ne'tra Ky'ram's clothing."
+	has_items = list(
+		/obj/item/clothing/suit/storage/hooded/wintercoat/kilanocoat,
+		/obj/item/clothing/under/fluff/kilanosuit,
+		/obj/item/weapon/storage/backpack/messenger/sec/fluff/kilano,
+		/obj/item/weapon/storage/belt/security/fluff/kilano,
+		/obj/item/clothing/gloves/fluff/kilano/netra,
+		/obj/item/clothing/shoes/boots/fluff/kilano,
+		/obj/item/clothing/accessory/storage/black_vest/fluff/kilano
+		)
+
 // bwoincognito:Tasald Corlethian
 /obj/item/weapon/storage/box/fluff/tasald
 	name = "Tasald's Kit"
@@ -47,8 +62,8 @@
 		/obj/item/clothing/suit/storage/det_suit/fluff/tasald,
 		/obj/item/clothing/suit/storage/det_suit/fluff/tas_coat,
 		/obj/item/clothing/under/det/fluff/tasald,
-		/obj/item/clothing/accessory/permit/gun/fluff/tasald_corlethian,
-		/obj/item/weapon/gun/projectile/revolver/mateba/fluff/tasald_corlethian,
+		//	/obj/item/clothing/accessory/permit/gun/fluff/tasald_corlethian,
+		//	/obj/item/weapon/gun/projectile/revolver/mateba/fluff/tasald_corlethian,
 		/obj/item/weapon/implanter/loyalty)
 
 //bwoincognito:Octavious Ward
@@ -64,6 +79,39 @@
 		/obj/item/weapon/cane/fluff/tasald,
 		/obj/item/clothing/glasses/hud/health/octaviousmonicle
 		)
+
+//drakefrostpaw:Drake Frostpaw
+/obj/item/weapon/storage/box/fluff/drake
+	name = "United Federation Uniform Kit"
+	desc = "A box containing all the parts of a United Federation Uniform"
+	has_items = list(
+		/obj/item/clothing/under/rank/internalaffairs/fluff/joan,
+		/obj/item/clothing/suit/storage/fluff/modernfedcoat/modernfedsec,
+		/obj/item/clothing/head/caphat/formal/fedcover/fedcoversec,
+		/obj/item/clothing/gloves/white,
+		)
+
+// Draycu: Schae Yonra
+/obj/item/weapon/storage/box/fluff/yonra
+	name = "Yonra's Starting Kit"
+	desc = "A small box containing Yonra's personal effects"
+	has_items = list(
+		/obj/item/weapon/melee/fluff/holochain/mass,
+		/obj/item/weapon/implanter/reagent_generator/yonra,
+		/obj/item/clothing/accessory/medal/silver/unity)
+
+//ivymoomoo:Ivy Baladeva
+/obj/item/weapon/storage/backpack/messenger/sec/fluff/ivymoomoo
+	name = "Ivy's Courier"
+	desc = "A bag resembling something used by college students. Contains items for ''MooMoo''."
+
+	New()
+		..()
+		new /obj/item/clothing/head/beretg(src)
+		new /obj/item/device/fluff/id_kit_ivy(src)
+		new /obj/item/weapon/storage/fancy/cigarettes/dromedaryco(src)
+		new /obj/item/weapon/storage/box/matches(src)
+		new /obj/item/weapon/reagent_containers/food/snacks/sliceable/plaincake(src)
 
 // jemli:Cirra Mayhem
 /obj/item/weapon/storage/box/fluff/cirra
@@ -127,43 +175,10 @@
 		new /obj/item/weapon/material/knife/tacknife/combatknife/fluff/katarina(src)
 		new /obj/item/clothing/under/rank/internalaffairs/fluff/joan(src)
 
-//drakefrostpaw:Drake Frostpaw
-/obj/item/weapon/storage/box/fluff/drake
-	name = "United Federation Uniform Kit"
-	desc = "A box containing all the parts of a United Federation Uniform"
-	has_items = list(
-		/obj/item/clothing/under/rank/internalaffairs/fluff/joan,
-		/obj/item/clothing/suit/storage/fluff/modernfedcoat/modernfedsec,
-		/obj/item/clothing/head/caphat/formal/fedcover/fedcoversec,
-		/obj/item/clothing/gloves/white,
-		)
-
-// Draycu: Schae Yonra
-/obj/item/weapon/storage/box/fluff/yonra
-	name = "Yonra's Starting Kit"
-	desc = "A small box containing Yonra's personal effects"
-	has_items = list(
-		/obj/item/weapon/melee/fluff/holochain/mass,
-		/obj/item/weapon/implanter/reagent_generator/yonra,
-		/obj/item/clothing/accessory/medal/silver/unity)
-
 //Razerwing:Archer Maximus
 /obj/item/weapon/storage/box/fluff/archermaximus
 	desc = "Personal Effects"
 	has_items = list()
-
-//ivymoomoo:Ivy Baladeva
-/obj/item/weapon/storage/backpack/messenger/sec/fluff/ivymoomoo
-	name = "Ivy's Courier"
-	desc = "A bag resembling something used by college students. Contains items for ''MooMoo''."
-
-	New()
-		..()
-		new /obj/item/clothing/head/beretg(src)
-		new /obj/item/device/fluff/id_kit_ivy(src)
-		new /obj/item/weapon/storage/fancy/cigarettes/dromedaryco(src)
-		new /obj/item/weapon/storage/box/matches(src)
-		new /obj/item/weapon/reagent_containers/food/snacks/sliceable/plaincake(src)
 
 //Xsdew:Penelope Allen
 /obj/item/weapon/storage/box/fluff/penelope
@@ -203,20 +218,6 @@
 		/obj/item/clothing/accessory/permit/gun/fluff/silencedmp5a5,
 		/obj/item/weapon/gun/projectile/colt/fluff/serdy)
 */
-
-//BeyondMyLife: Ne'tra Ky'ram //Made a box because they have so many items that it'd spam the debug log.
-/obj/item/weapon/storage/box/fluff/kilano
-	name = "Ne'tra Ky'ram's Kit"
-	desc = "A kit containing Ne'tra Ky'ram's clothing."
-	has_items = list(
-		/obj/item/clothing/suit/storage/hooded/wintercoat/kilanocoat,
-		/obj/item/clothing/under/fluff/kilanosuit,
-		/obj/item/weapon/storage/backpack/messenger/sec/fluff/kilano,
-		/obj/item/weapon/storage/belt/security/fluff/kilano,
-		/obj/item/clothing/gloves/fluff/kilano/netra,
-		/obj/item/clothing/shoes/boots/fluff/kilano,
-		/obj/item/clothing/accessory/storage/black_vest/fluff/kilano
-		)
 
 // JackNoir413: Mor Xaina
 /obj/item/weapon/storage/box/fluff/morxaina

--- a/code/modules/vore/fluffstuff/custom_guns_vr.dm
+++ b/code/modules/vore/fluffstuff/custom_guns_vr.dm
@@ -120,6 +120,11 @@
 	ammo_type = /obj/item/ammo_casing/a12g/stunshell
 	max_shells = 6
 
+/* // jertheace : Jeremiah 'Ace' Acacius
+/obj/item/ammo_magazine/m9mm/large/preban/hp // Not yet implemented. Waiting on a PR to Polaris. -Ace
+	ammo_type = /obj/item/ammo_casing/a9mm/hp
+*/
+
 // bwoincognito:Tasald Corlethian
 /obj/item/weapon/gun/projectile/revolver/mateba/fluff/tasald_corlethian //Now that it is actually Single-Action and not hacky broken SA, I see no reason to nerf this down to .38. --Joan Risu
 	name = "\improper \"Big Iron\" revolver"

--- a/code/modules/vore/fluffstuff/custom_permits_vr.dm
+++ b/code/modules/vore/fluffstuff/custom_permits_vr.dm
@@ -18,21 +18,23 @@
 	desc = "A card indicating that the owner is allowed to carry a sidearm. It is issued by CentCom, so it is valid until it expires on February 16th, 2562."
 */
 
+/*
 // bwoincognito:Tasald Corlethian
 /obj/item/clothing/accessory/permit/gun/fluff/tasald_corlethian
 	name = "Tasald Ajax Corlethian's Sidearm Permit"
 	desc = "A card indicating that the owner is allowed to carry a sidearm. It is issued by CentCom, so it is valid until it expires on August 2nd, 2562."
+*/
 
 /* dhaeleena:Dhaeleena M'iar
 /obj/item/clothing/accessory/permit/gun/fluff/dhaeleena_miar
 	name = "Dhaeleena M'iar's Sidearm Permit"
-	desc = "A card indicating that the owner is allowed to carry a sidearm that uses less-than-lethal munitions. It is issued by CentCom, so it is valid until it expires on March 1st, 2562."
+	desc = "A card indicating that the owner is allowed to carry a sidearm. It is issued by CentCom, so it is valid until it expires on March 1st, 2562."
 */
 
 // jertheace:Jeremiah 'Ace' Acacius
 /obj/item/clothing/accessory/permit/gun/fluff/ace
-	name = "Ace's Shotgun Permit"
-	desc = "A card indicating that the owner is allowed to carry a firearm. It is issued by CentCom, so it is valid until it expires on October 1st, 2562."
+	name = "Jeremiah Acacius's Sidearm Permit"
+	desc = "A card indicating that the owner is allowed to carry a sidearm. It is issued by CentCom, so it is valid until it expires on November 10th, 2563."
 
 /* joanrisu:Joan Risu
 /obj/item/clothing/accessory/permit/gun/fluff/joanrisu
@@ -52,15 +54,17 @@
 	desc = "A card indicating that the owner is allowed to carry a sidearm that uses less-than-lethal munitions. It is issued by CentCom, so it is valid until it expires on April 24th, 2562."
 */
 
+/*
 // pawoverlord:Sorrel Cavalet
 /obj/item/clothing/accessory/permit/gun/fluff/sorrel_cavalet
 	name = "Sorrel Cavalet's Sidearm Permit"
 	desc = "A card indicating that the owner is allowed to carry a sidearm. It is issued by CentCom, so it is valid until it expires on September 26th, 2562."
+*/
 
 /*  hzdonut:Jesse Soemmer
 /obj/item/clothing/accessory/permit/gun/fluff/JesseSoemmer
 	name = "Jesse Soemmer's Sidearm Permit"
-	desc = "A card indicating that the owner is allowed to carry a sidearm. It is issued by CentCom, so it is valid until it expires on March 4, 2563."
+	desc = "A card indicating that the owner is allowed to carry a sidearm. It is issued by CentCom, so it is valid until it expires on March 4, 2563." // Apparently revoked? -Ace
 */
 
 /* Legacy Permits

--- a/config/custom_items.txt
+++ b/config/custom_items.txt
@@ -383,15 +383,29 @@ item_path: /obj/item/clothing/head/fedora/fluff/jemli
 {
 ckey: jertheace
 character_name: Jeremiah Acacius
-item_path: /obj/item/weapon/gun/projectile/shotgun/pump/USDF/fluff/ace
-req_access = 58
+item_path: /obj/item/clothing/accessory/permit/gun/fluff/ace
+req_access = 2
 }
 
 {
 ckey: jertheace
 character_name: Jeremiah Acacius
-item_path: /obj/item/clothing/accessory/permit/gun/fluff/ace
-req_access = 58
+item_path: /obj/item/weapon/gun/projectile/p92x/large/preban #Todo: Replace with HP version allowed in the application.
+req_access = 2
+}
+
+{
+ckey: jertheace
+character_name: Jeremiah Acacius
+item_path: /obj/item/ammo_magazine/m9mm/large/preban #Spare ammo. #Todo: Replace with HP version allowed in the application.
+req_access = 2
+}
+
+{
+ckey: jertheace
+character_name: Jeremiah Acacius
+item_path: /obj/item/clothing/accessory/holster/armpit
+req_access = 2
 }
 
 {
@@ -404,12 +418,6 @@ item_path: /obj/item/clothing/shoes/boots/combat
 ckey: jertheace
 character_name: Jeremiah Acacius
 item_path: /obj/item/clothing/under/syndicate/combat
-}
-
-{
-ckey: jertheace
-character_name: Jeremiah Acacius
-item_path: /obj/item/clothing/suit/armor/tactical/officer/fluff/ace
 }
 
 {
@@ -646,18 +654,18 @@ item_path: /obj/item/weapon/melee/fluff/holochain
 
 # ######## P CKEYS
 
-{
-ckey: pawoverlord
-character_name: Sorrel Cavalet
-item_path: /obj/item/clothing/accessory/permit/gun/fluff/sorrel_cavalet
-}
+#{
+#ckey: pawoverlord
+#character_name: Sorrel Cavalet
+#item_path: /obj/item/clothing/accessory/permit/gun/fluff/sorrel_cavalet
+#}
 
-{
-ckey: pawoverlord
-character_name: Sorrel Cavalet
-item_path: /obj/item/weapon/gun/projectile/colt
-item_desc: "A cheap Martian knock-off of a Colt M1911. It has the word 'Cavalet' etched on the side. Uses .45 rounds."
-}
+#{
+#ckey: pawoverlord
+#character_name: Sorrel Cavalet
+#item_path: /obj/item/weapon/gun/projectile/colt
+#item_desc: "A cheap Martian knock-off of a Colt M1911. It has the word 'Cavalet' etched on the side. Uses .45 rounds."
+#}
 
 {
 ckey: phoaly

--- a/config/custom_items.txt
+++ b/config/custom_items.txt
@@ -384,28 +384,28 @@ item_path: /obj/item/clothing/head/fedora/fluff/jemli
 ckey: jertheace
 character_name: Jeremiah Acacius
 item_path: /obj/item/clothing/accessory/permit/gun/fluff/ace
-req_access = 2
+req_access = 3
 }
 
 {
 ckey: jertheace
 character_name: Jeremiah Acacius
 item_path: /obj/item/weapon/gun/projectile/p92x/large/preban #Todo: Replace with HP version allowed in the application.
-req_access = 2
+req_access = 3
 }
 
 {
 ckey: jertheace
 character_name: Jeremiah Acacius
 item_path: /obj/item/ammo_magazine/m9mm/large/preban #Spare ammo. #Todo: Replace with HP version allowed in the application.
-req_access = 2
+req_access = 3
 }
 
 {
 ckey: jertheace
 character_name: Jeremiah Acacius
 item_path: /obj/item/clothing/accessory/holster/armpit
-req_access = 2
+req_access = 3
 }
 
 {


### PR DESCRIPTION
- Fixed some permit stuff.
- Removed expired permits and associated items.
- Added Ace's pistol plus a spare mag.
- Locked items to armory access, covering warden, HoS, and Captain, but not roles like HoP.

https://forum.vore-station.net/viewtopic.php?f=27&t=1445