### PR TITLE
Collar tweaks

### DIFF
--- a/code/controllers/Processes/scheduler.dm
+++ b/code/controllers/Processes/scheduler.dm
@@ -137,6 +137,7 @@
 	var/datum/callback/callback
 
 /datum/scheduled_task/callback/New(var/trigger_time, var/datum/callback, var/proc/task_after_process, var/list/task_after_process_args)
+	src.callback = callback
 	..(trigger_time = trigger_time, task_after_process = task_after_process, task_after_process_args = task_after_process_args)
 
 /datum/scheduled_task/callback/process()

--- a/code/modules/clothing/under/accessories/accessory_vr.dm
+++ b/code/modules/clothing/under/accessories/accessory_vr.dm
@@ -27,7 +27,7 @@
 	icon_state = "collar_bell"
 	item_state = "collar_bell_overlay"
 	overlay_state = "collar_bell_overlay"
-	var/nospam = 0
+	var/jingled = 0
 	
 /obj/item/clothing/accessory/collar/bell/verb/jinglebell()
 	set name = "Jingle Bell"
@@ -36,11 +36,11 @@
 	if(!istype(usr, /mob/living)) return
 	if(usr.stat) return
 	
-	if(!nospam)
+	if(!jingled)
 		usr.audible_message("[usr] jingles the [src]'s bell.")
-		nospam = 1
+		jingled = 1
 		sleep(30)
-		nospam = 0
+		jingled = 0
 	return
 
 /obj/item/clothing/accessory/collar/shock

--- a/code/modules/clothing/under/accessories/accessory_vr.dm
+++ b/code/modules/clothing/under/accessories/accessory_vr.dm
@@ -6,6 +6,7 @@
 	slot_flags = SLOT_TIE | SLOT_OCLOTHING
 	icon = 'icons/obj/clothing/collars_vr.dmi'
 	icon_override = 'icons/obj/clothing/collars_vr.dmi'
+	var/writtenon = 0
 
 /obj/item/clothing/accessory/collar/silver
 	name = "Silver tag collar"
@@ -28,14 +29,14 @@
 	item_state = "collar_bell_overlay"
 	overlay_state = "collar_bell_overlay"
 	var/jingled = 0
-	
+
 /obj/item/clothing/accessory/collar/bell/verb/jinglebell()
 	set name = "Jingle Bell"
 	set category = "Object"
 	set src in usr
 	if(!istype(usr, /mob/living)) return
 	if(usr.stat) return
-	
+
 	if(!jingled)
 		usr.audible_message("[usr] jingles the [src]'s bell.")
 		jingled = 1
@@ -182,6 +183,8 @@
 	if(istype(src,/obj/item/clothing/accessory/collar/holo))
 		to_chat(user,"<span class='notice'>[name]'s interface is projected onto your hand.</span>")
 	else
+		if(writtenon)
+			return
 		to_chat(user,"<span class='notice'>You adjust the [name]'s tag.</span>")
 
 	var/str = copytext(reject_bad_text(input(user,"Tag text?","Set tag","")),1,MAX_NAME_LEN)
@@ -193,7 +196,49 @@
 	else
 		to_chat(user,"<span class='notice'>You set the [name]'s tag to '[str]'.</span>")
 		name = initial(name) + " ([str])"
-		desc = initial(desc) + " The tag says \"[str]\"."
+		if(istype(src,/obj/item/clothing/accessory/collar/holo))
+			desc = initial(desc) + " The tag says \"[str]\"."
+		else
+			desc = initial(desc) + " \"[str]\" has been engraved on the tag."
+		writtenon = 1
+
+/obj/item/clothing/accessory/collar/attackby(obj/item/I, mob/user)
+	if(istype(src,/obj/item/clothing/accessory/collar/holo))
+		return
+	
+	if(istype(I,/obj/item/weapon/tool/screwdriver))
+		update_collartag(user, I, "scratched out", "scratch out", "engraved")
+		return
+		
+	if(istype(I,/obj/item/weapon/pen))
+		update_collartag(user, I, "crossed out", "cross out", "written")
+		return
+	
+	to_chat(user,"<span class='notice'>You need a pen or a screwdriver to edit the tag on this collar.</span>")
+	
+/obj/item/clothing/accessory/collar/proc/update_collartag(mob/user, obj/item/I, var/erasemethod, var/erasing, var/writemethod)
+	if(!(istype(user.get_active_hand(),I)) || !(istype(user.get_inactive_hand(),src)) || (user.stat))
+		return
+	
+	var/str = copytext(reject_bad_text(input(user,"Tag text?","Set tag","")),1,MAX_NAME_LEN)
+	
+	if(!str || !length(str))
+		if(!writtenon)
+			to_chat(user,"<span class='notice'>You don't write anything.</span>")
+		else
+			to_chat(user,"<span class='notice'>You [erasing] the words with the [I].</span>")
+			name = initial(name)
+			desc = initial(desc) + " The tag has had the words [erasemethod]."
+	else
+		if(!writtenon)
+			to_chat(user,"<span class='notice'>You write '[str]' on the tag with the [I].</span>")
+			name = initial(name) + " ([str])"
+			desc = initial(desc) + " \"[str]\" has been [writemethod] on the tag."
+			writtenon = 1
+		else
+			to_chat(user,"<span class='notice'>You [erasing] the words on the tag with the [I], and write '[str]'.</span>")
+			name = initial(name) + " ([str])"
+			desc = initial(desc) + " Something has been [erasemethod] on the tag, and it now has \"[str]\" [writemethod] on it."
 
 //Machete Holsters
 /obj/item/clothing/accessory/holster/machete

--- a/code/modules/clothing/under/accessories/accessory_vr.dm
+++ b/code/modules/clothing/under/accessories/accessory_vr.dm
@@ -184,6 +184,7 @@
 		to_chat(user,"<span class='notice'>[name]'s interface is projected onto your hand.</span>")
 	else
 		if(writtenon)
+			to_chat(user,"<span class='notice'>You need a pen or a screwdriver to edit the tag on this collar.</span>")
 			return
 		to_chat(user,"<span class='notice'>You adjust the [name]'s tag.</span>")
 

--- a/code/modules/clothing/under/accessories/accessory_vr.dm
+++ b/code/modules/clothing/under/accessories/accessory_vr.dm
@@ -39,8 +39,7 @@
 	if(!jingled)
 		usr.audible_message("[usr] jingles the [src]'s bell.")
 		jingled = 1
-		sleep(30)
-		jingled = 0
+		schedule_callback_in(5 SECONDS, VARSET_CALLBACK(src, jingled, 0))
 	return
 
 /obj/item/clothing/accessory/collar/shock

--- a/code/modules/clothing/under/accessories/accessory_vr.dm
+++ b/code/modules/clothing/under/accessories/accessory_vr.dm
@@ -27,6 +27,21 @@
 	icon_state = "collar_bell"
 	item_state = "collar_bell_overlay"
 	overlay_state = "collar_bell_overlay"
+	var/nospam = 0
+	
+/obj/item/clothing/accessory/collar/bell/verb/jinglebell()
+	set name = "Jingle Bell"
+	set category = "Object"
+	set src in usr
+	if(!istype(usr, /mob/living)) return
+	if(usr.stat) return
+	
+	if(!nospam)
+		usr.audible_message("[usr] jingles the [src]'s bell.")
+		nospam = 1
+		sleep(30)
+		nospam = 0
+	return
 
 /obj/item/clothing/accessory/collar/shock
 	name = "Shock collar"
@@ -164,8 +179,11 @@
 	item_state = "collar_holo_overlay"
 	overlay_state = "collar_holo_overlay"
 
-/obj/item/clothing/accessory/collar/holo/attack_self(mob/user as mob)
-	to_chat(user,"<span class='notice'>[name]'s interface is projected onto your hand.</span>")
+/obj/item/clothing/accessory/collar/attack_self(mob/user as mob)
+	if(istype(src,/obj/item/clothing/accessory/collar/holo))
+		to_chat(user,"<span class='notice'>[name]'s interface is projected onto your hand.</span>")
+	else
+		to_chat(user,"<span class='notice'>You adjust the [name]'s tag.</span>")
 
 	var/str = copytext(reject_bad_text(input(user,"Tag text?","Set tag","")),1,MAX_NAME_LEN)
 


### PR DESCRIPTION
This PR does two things.
- Makes it so you can add a tag/change the tag of any collar, including shock collars and life crystals.  For any collar other than the shock collar and life crystal, you can set an initial name without requirements by clicking on the collar in your active hand, for purposes like simulating having come on to the station with the collar tag already set.  After that, for any tag changes, or if you're tagging a shock collar or life crystal, you need to use a **screwdriver** or a **pen**, to scratch in/engrave the tag or write on it.
-- The messages will change depending on whether you use a screwdriver or a pen, and whether something was already written on the tag.  If you use the initial free tag setting, it will default to "engraved".
-- Holo collars are exempt from all requirements; they will work like they've always had.

- Adds a verb to bell collars, that lets you jingle the bell if you're holding it or wearing it in your oversuit slot (but not while attached, sadly).  Has a 5 second cooldown to hopefully prevent too much spam.

Screenshots:
![image](https://user-images.githubusercontent.com/19196710/48389864-27bd0180-e6b4-11e8-98a5-903cefc2d7a5.png)

![image](https://user-images.githubusercontent.com/19196710/48389877-31466980-e6b4-11e8-9402-906e4b30c509.png)

![image](https://user-images.githubusercontent.com/19196710/48346529-4e395900-e630-11e8-951d-dc07f487151c.png)

![image](https://user-images.githubusercontent.com/19196710/48346535-5396a380-e630-11e8-9a5e-31285a7c6fc2.png)
