### PR TITLE
Combine photosensitive trait with darksight

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/negative.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/negative.dm
@@ -90,12 +90,6 @@
 	cost = -2
 	var_changes = list("siemens_coefficient" = 2.0) //This makes you extremely weak to tasers.
 
-/datum/trait/photosensitive
-	name = "Photosensitive"
-	desc = "Increases stun duration from flashes and other light-based stuns."
-	cost = -1
-	var_changes = list("flash_mod" = 2.0)
-
 /datum/trait/hollow
 	name = "Hollow Bones/Aluminum Alloy"
 	desc = "Your bones and robot limbs are much easier to break."

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/positive.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/positive.dm
@@ -42,13 +42,13 @@
 	name = "Darksight"
 	desc = "Allows you to see a short distance in the dark."
 	cost = 1
-	var_changes = list("darksight" = 3)
+	var_changes = list("darksight" = 3, "flash_mod" = 2.0)
 
 /datum/trait/darksight_plus
 	name = "Darksight (Major)"
 	desc = "Allows you to see in the dark for the whole screen."
 	cost = 2
-	var_changes = list("darksight" = 7)
+	var_changes = list("darksight" = 7, "flash_mod" = 3.0)
 
 /datum/trait/melee_attack
 	name = "Sharp Melee"


### PR DESCRIPTION
Combines the traits, because photosensitive was 'the meta' free trait that never came up. And darksight was the most popular trait. So combine the two most meta traits to blunt both? Ok. By popular request in the other PR: https://github.com/VOREStation/VOREStation/pull/4464