### PR TITLE
Adds timegate to pathfinder

### DIFF
--- a/maps/southern_cross/southern_cross_jobs_vr.dm
+++ b/maps/southern_cross/southern_cross_jobs_vr.dm
@@ -18,7 +18,8 @@ var/const/PATHFINDER 		=(1<<13) //VOREStation Edit - Added Pathfinder
 	selection_color = "#AD6BAD"
 	idtype = /obj/item/weapon/card/id/science/head/pathfinder
 	economic_modifier = 7
-	
+	minimal_player_age = 7
+
 	access = list(access_eva, access_maint_tunnels, access_external_airlocks, access_pilot, access_explorer, access_research, access_gateway)
 	minimal_access = list(access_eva, access_pilot, access_explorer, access_research, access_gateway)
 	outfit_type = /decl/hierarchy/outfit/job/pathfinder


### PR DESCRIPTION
Adds a short wait on playing the pathfinder role in keeping with other leadership roles. Still a shorter wait than actual heads given that it's really only the expedition that suffers if they screw up.
Explorer, pilot and SAR are still unrestricted so in theory it's still possible to send out a complete day-0 expedition, and playing explorer instead of PF for a week is pretty low-impact for new players.