### PR TITLE
Removes Mapgen from station levels

### DIFF
--- a/code/game/turfs/simulated/outdoors/atmoscaves_vr.dm
+++ b/code/game/turfs/simulated/outdoors/atmoscaves_vr.dm
@@ -17,3 +17,8 @@
 	oxygen = MOLES_O2STANDARD
 	nitrogen = MOLES_N2STANDARD
 	temperature	= T20C
+
+/turf/simulated/mineral/ignore_mapgen/vacuum
+	oxygen = 0
+	nitrogen = 0
+	temperature	= TCMB

--- a/maps/tether/tether-01-surface1.dmm
+++ b/maps/tether/tether-01-surface1.dmm
@@ -26,7 +26,7 @@
 /turf/simulated/floor/tiled/steel_dirty/virgo3b,
 /area/tether/surfacebase/mining_main/external)
 "aah" = (
-/turf/simulated/mineral,
+/turf/simulated/mineral/ignore_mapgen,
 /area/tether/surfacebase/outside/outside1)
 "aai" = (
 /obj/structure/cable/green{
@@ -4729,7 +4729,7 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/mining_main/lobby)
 "akV" = (
-/turf/simulated/mineral,
+/turf/simulated/mineral/ignore_mapgen,
 /area/vacant/vacant_site)
 "akX" = (
 /turf/simulated/floor/plating,
@@ -14248,7 +14248,7 @@
 /turf/simulated/floor/tiled/steel_dirty,
 /area/rnd/xenobiology/xenoflora_storage)
 "aHK" = (
-/turf/simulated/mineral,
+/turf/simulated/mineral/ignore_mapgen,
 /area/maintenance/lower/research)
 "aHL" = (
 /obj/effect/floor_decal/rust,
@@ -14439,7 +14439,7 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/engineering/drone_fabrication)
 "aIp" = (
-/turf/simulated/mineral,
+/turf/simulated/mineral/ignore_mapgen,
 /area/rnd/external)
 "aIq" = (
 /obj/effect/floor_decal/steeldecal/steel_decals10{
@@ -14846,7 +14846,7 @@
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/first_aid_west)
 "aJs" = (
-/turf/simulated/mineral,
+/turf/simulated/mineral/ignore_mapgen,
 /area/engineering/atmos/intake)
 "aJt" = (
 /turf/simulated/floor/tiled/steel_dirty/virgo3b,
@@ -28640,7 +28640,7 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/public_garden_maintenence)
 "wFT" = (
-/turf/simulated/mineral,
+/turf/simulated/mineral/ignore_mapgen,
 /area/maintenance/lower/public_garden_maintenence)
 "wIm" = (
 /obj/structure/table/rack,

--- a/maps/tether/tether-02-surface2.dmm
+++ b/maps/tether/tether-02-surface2.dmm
@@ -6,7 +6,7 @@
 /turf/simulated/open/virgo3b,
 /area/tether/surfacebase/outside/outside2)
 "ac" = (
-/turf/simulated/mineral,
+/turf/simulated/mineral/ignore_mapgen,
 /area/tether/surfacebase/outside/outside2)
 "ad" = (
 /turf/simulated/wall,
@@ -1189,7 +1189,7 @@
 /turf/simulated/floor/virgo3b,
 /area/tether/surfacebase/outside/outside2)
 "cW" = (
-/turf/simulated/mineral,
+/turf/simulated/mineral/ignore_mapgen,
 /area/maintenance/lower/north)
 "cX" = (
 /obj/effect/floor_decal/techfloor{
@@ -4326,7 +4326,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/lower/rnd)
 "jy" = (
-/turf/simulated/mineral,
+/turf/simulated/mineral/ignore_mapgen,
 /area/maintenance/lower/rnd)
 "jz" = (
 /obj/random/trash_pile,
@@ -4925,7 +4925,7 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/bar)
 "kR" = (
-/turf/simulated/mineral,
+/turf/simulated/mineral/ignore_mapgen,
 /area/maintenance/lower/bar)
 "kS" = (
 /obj/item/weapon/material/twohanded/baseballbat{
@@ -13601,7 +13601,7 @@
 /turf/simulated/floor,
 /area/engineering/atmos/storage)
 "zH" = (
-/turf/simulated/mineral,
+/turf/simulated/mineral/ignore_mapgen,
 /area/maintenance/lower/south)
 "zI" = (
 /obj/structure/cable/green{

--- a/maps/tether/tether-05-station1.dmm
+++ b/maps/tether/tether-05-station1.dmm
@@ -9,7 +9,7 @@
 /turf/space,
 /area/space)
 "aac" = (
-/turf/simulated/mineral/vacuum,
+/turf/simulated/mineral/ignore_mapgen/vacuum,
 /area/mine/explored/upper_level)
 "aad" = (
 /turf/simulated/wall/r_wall,
@@ -21275,7 +21275,7 @@
 /turf/simulated/floor/tiled,
 /area/engineering/engine_eva)
 "cbM" = (
-/turf/simulated/mineral/vacuum,
+/turf/simulated/mineral/ignore_mapgen/vacuum,
 /area/space)
 "cbY" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{

--- a/maps/tether/tether-06-station2.dmm
+++ b/maps/tether/tether-06-station2.dmm
@@ -6,7 +6,7 @@
 /turf/simulated/floor/airless,
 /area/space)
 "ac" = (
-/turf/simulated/mineral/vacuum,
+/turf/simulated/mineral/ignore_mapgen/vacuum,
 /area/mine/explored/upper_level)
 "ad" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -17423,7 +17423,7 @@
 /turf/simulated/floor,
 /area/maintenance/station/sec_lower)
 "Ko" = (
-/turf/simulated/mineral/vacuum,
+/turf/simulated/mineral/ignore_mapgen/vacuum,
 /area/space)
 "Kv" = (
 /obj/effect/floor_decal/borderfloorblack{
@@ -17966,7 +17966,7 @@
 /turf/simulated/wall,
 /area/maintenance/evahallway)
 "OQ" = (
-/turf/simulated/mineral/vacuum,
+/turf/simulated/mineral/ignore_mapgen/vacuum,
 /area/maintenance/evahallway)
 "OY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -18189,7 +18189,7 @@
 /turf/simulated/floor/tiled,
 /area/security/security_cell_hallway)
 "Qs" = (
-/turf/simulated/mineral/vacuum,
+/turf/simulated/mineral/ignore_mapgen/vacuum,
 /area/maintenance/station/sec_lower)
 "Qu" = (
 /obj/structure/catwalk,
@@ -18995,7 +18995,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/tether/station/public_meeting_room)
 "VL" = (
-/turf/simulated/mineral/vacuum,
+/turf/simulated/mineral/ignore_mapgen/vacuum,
 /area/chapel/chapel_morgue)
 "VU" = (
 /obj/effect/floor_decal/industrial/warning{

--- a/maps/tether/tether-07-station3.dmm
+++ b/maps/tether/tether-07-station3.dmm
@@ -3,7 +3,7 @@
 /turf/space,
 /area/space)
 "ab" = (
-/turf/simulated/mineral/vacuum,
+/turf/simulated/mineral/ignore_mapgen/vacuum,
 /area/mine/explored/upper_level)
 "ac" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -3988,7 +3988,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/range)
 "gJ" = (
-/turf/simulated/mineral/vacuum,
+/turf/simulated/mineral/ignore_mapgen/vacuum,
 /area/maintenance/station/ai)
 "gK" = (
 /turf/simulated/floor,
@@ -8075,7 +8075,7 @@
 /obj/structure/railing{
 	dir = 4
 	},
-/turf/simulated/mineral/vacuum,
+/turf/simulated/mineral/ignore_mapgen/vacuum,
 /area/maintenance/station/ai)
 "nz" = (
 /obj/structure/cable{
@@ -27338,8 +27338,7 @@
 	id = "sec_processing";
 	pixel_x = 26;
 	pixel_y = 6;
-	req_access = list(1);
-	
+	req_access = list(1)
 	},
 /turf/simulated/floor/tiled,
 /area/security/security_processing)
@@ -27367,7 +27366,7 @@
 /turf/simulated/floor/bluegrid,
 /area/ai/foyer)
 "SW" = (
-/turf/simulated/mineral/vacuum,
+/turf/simulated/mineral/ignore_mapgen/vacuum,
 /area/space)
 "TL" = (
 /obj/machinery/ai_slipper{


### PR DESCRIPTION
Closes #4425
- Replaces all instances, on station levels, of "/turf/simulated/mineral" with "/turf/simulated/mineral/ignore_mapgen" 
- Adds new ignore_mapgen type for vacuum tiles

Minerals and caves will no longer spawn on the main 6 station levels. Anomaly tiles can still spawn: https://i.imgur.com/IXzXIcw.png