### PR TITLE
Fixes a runtime with radio.dm

### DIFF
--- a/code/game/jobs/access_datum_vr.dm
+++ b/code/game/jobs/access_datum_vr.dm
@@ -1,0 +1,12 @@
+//Moved from southern_cross_jobs.vr to fix a runtime
+var/const/access_explorer = 43
+/datum/access/explorer
+	id = access_explorer
+	desc = "Explorer"
+	region = ACCESS_REGION_GENERAL
+
+var/const/access_pilot = 67
+/datum/access/pilot
+	id = access_pilot
+	desc = "Pilot"
+	region = ACCESS_REGION_SUPPLY

--- a/maps/southern_cross/southern_cross_jobs_vr.dm
+++ b/maps/southern_cross/southern_cross_jobs_vr.dm
@@ -3,19 +3,6 @@ var/const/PILOT 			=(1<<15)
 var/const/EXPLORER 			=(1<<12)
 var/const/PATHFINDER 		=(1<<13)
 
-var/const/access_pilot = 67
-var/const/access_explorer = 43
-
-/datum/access/pilot
-	id = access_pilot
-	desc = "Pilot"
-	region = ACCESS_REGION_SUPPLY
-
-/datum/access/explorer
-	id = access_explorer
-	desc = "Explorer"
-	region = ACCESS_REGION_GENERAL
-
 /obj/item/weapon/card/id/medical/sar
 	assignment = "Field Medic"
 	rank = "Field Medic"

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -642,6 +642,7 @@
 #include "code\game\jobs\_access_defs.dm"
 #include "code\game\jobs\access.dm"
 #include "code\game\jobs\access_datum.dm"
+#include "code\game\jobs\access_datum_vr.dm"
 #include "code\game\jobs\job_controller.dm"
 #include "code\game\jobs\jobs.dm"
 #include "code\game\jobs\whitelist.dm"


### PR DESCRIPTION
Load ordering was causing the access datums for explorer and pilot access to be defined after radio.dm was loaded, which caused radio.dm to look for access datums that did not exist at the time.

This changes the explorer and pilot access datums to load much earlier, fixing the runtime.