### PR TITLE
makes the pompom uncontaminatable

### DIFF
--- a/code/modules/vore/fluffstuff/custom_clothes_vr.dm
+++ b/code/modules/vore/fluffstuff/custom_clothes_vr.dm
@@ -780,6 +780,9 @@
 /obj/item/clothing/head/fluff/pompom/digest_act(var/atom/movable/item_storage = null)
 	return FALSE
 
+/obj/item/clothing/head/fluff/pompom/gurgle_contaminate(var/atom/movable/item_storage = null)
+	return FALSE
+
 /obj/item/clothing/head/fluff/pompom/attack_self(mob/user)
 	//if(!isturf(user.loc)) -- doesn't seem to cause problems to allow this and it's silly not to
 	//	to_chat(user, "You cannot turn the light on while in this [user.loc]")


### PR DESCRIPTION
Ideally I'd make it so bellies couldn't strip it either 'cause it's part of his damn head, but I can't think of an elegant way to do that right now with the way that vore itemstripping is written. At least this lets me put it back on again afterwards.

(really though force-unequipping even nodrop items is probably kinda broken and there should be some way to make it so items can't be vorestripped considering that it lets you completely bypass hardsuit removal surgery and the like if I'm reading it right)