### PR TITLE
Fixes at least 1/3 of the surface level cave/ore generation bugs.

### DIFF
--- a/maps/tether/submaps/_tether_submaps.dm
+++ b/maps/tether/submaps/_tether_submaps.dm
@@ -40,9 +40,9 @@
 
 /datum/map_template/tether_lateload/tether_underdark/on_map_loaded(z)
 	. = ..()
-	seed_submaps(list(z), 100, /area/mine/unexplored/underdark, /datum/map_template/underdark)
-	new /datum/random_map/automata/cave_system/no_cracks(null, 1, 1, z, world.maxx, world.maxy) // Create the mining Z-level.
-	new /datum/random_map/noise/ore(null, 1, 1, z, 64, 64)         // Create the mining ore distribution map.
+	seed_submaps(list(Z_LEVEL_UNDERDARK), 100, /area/mine/unexplored/underdark, /datum/map_template/underdark)
+	new /datum/random_map/automata/cave_system/no_cracks(null, 1, 1, Z_LEVEL_UNDERDARK, world.maxx, world.maxy) // Create the mining Z-level.
+	new /datum/random_map/noise/ore(null, 1, 1, Z_LEVEL_UNDERDARK, 64, 64)         // Create the mining ore distribution map.
 
 //////////////////////////////////////////////////////////////////////////////
 /// Away Missions


### PR DESCRIPTION
After some extensive research and loads of test runs, I finally managed to pinpoint the issue to underdark ore generation thingy.
Apparently the original cave/ore generation for underdark wasn't using a solid value for its z-level, and because of this, the initial generation would work fine, BUT in case of the underdark ore roll landing on an insufficient amount of the good stuff, it would reroll the cave/ore generator after having already forgotten what the first roll had given for the z value.

5 runs with fix: no caves/ores ever, 1 startup reported reroll case.
5 confirmation runs without the fix: 4 runs with no caves/ores, 1 run with reroll report that did get caves.

Fixes  #4425