### PR TITLE
Fixes undefined z-levels shitting caves all over the place

### DIFF
--- a/code/modules/maps/tg/reader.dm
+++ b/code/modules/maps/tg/reader.dm
@@ -99,6 +99,11 @@ var/global/use_preloader = FALSE
 			var/ycrd = text2num(dmmRegex.group[4]) + y_offset - 1
 			var/zcrd = text2num(dmmRegex.group[5]) + z_offset - 1
 
+			if(orientation & (EAST | WEST)) //VOREStation edit we just have to pray the upstream spacebrains take into consideration before their refator is done.
+				xcrd = ycrd // temp variable
+				ycrd = xcrdStart
+				xcrdStart = xcrd
+
 			var/zexpansion = zcrd > world.maxz
 			if(zexpansion && !measureOnly)
 				if(cropMap)

--- a/maps/tether/submaps/_tether_submaps.dm
+++ b/maps/tether/submaps/_tether_submaps.dm
@@ -37,12 +37,13 @@
 	name = "Underdark"
 	flags = MAP_LEVEL_CONTACT|MAP_LEVEL_PLAYER
 	base_turf = /turf/simulated/mineral/floor/virgo3b
+	z = Z_LEVEL_UNDERDARK
 
 /datum/map_template/tether_lateload/tether_underdark/on_map_loaded(z)
 	. = ..()
-	seed_submaps(list(z), 100, /area/mine/unexplored/underdark, /datum/map_template/underdark)
-	new /datum/random_map/automata/cave_system/no_cracks(null, 1, 1, z, world.maxx, world.maxy) // Create the mining Z-level.
-	new /datum/random_map/noise/ore(null, 1, 1, z, 64, 64)         // Create the mining ore distribution map.
+	seed_submaps(list(Z_LEVEL_UNDERDARK), 100, /area/mine/unexplored/underdark, /datum/map_template/underdark)
+	new /datum/random_map/automata/cave_system/no_cracks(null, 1, 1, Z_LEVEL_UNDERDARK, world.maxx, world.maxy) // Create the mining Z-level.
+	new /datum/random_map/noise/ore(null, 1, 1, Z_LEVEL_UNDERDARK, 64, 64)         // Create the mining ore distribution map.
 
 //////////////////////////////////////////////////////////////////////////////
 /// Away Missions
@@ -63,6 +64,7 @@
 
 /datum/map_z_level/tether_lateload/away_beach
 	name = "Away Mission - Desert Beach"
+	z = Z_LEVEL_BEACH
 
 /datum/map_template/tether_lateload/away_beach_cave
 	name = "Desert Planet - Z2 Cave"
@@ -70,8 +72,18 @@
 	mappath = 'beach/cave.dmm'
 	associated_map_datum = /datum/map_z_level/tether_lateload/away_beach_cave
 
+/datum/map_template/tether_lateload/away_beach_cave/on_map_loaded(z)
+	. = ..()
+	seed_submaps(list(Z_LEVEL_BEACH_CAVE), 50, /area/tether_away/cave/unexplored/normal, /datum/map_template/surface/mountains/normal)
+	seed_submaps(list(Z_LEVEL_BEACH_CAVE), 50, /area/tether_away/cave/unexplored/deep, /datum/map_template/surface/mountains/deep)
+
+	// Now for the tunnels.
+	new /datum/random_map/automata/cave_system/no_cracks(null, 1, 1, Z_LEVEL_BEACH_CAVE, world.maxx, world.maxy)
+	new /datum/random_map/noise/ore/beachmine(null, 1, 1, Z_LEVEL_BEACH_CAVE, 64, 64)
+
 /datum/map_z_level/tether_lateload/away_beach_cave
 	name = "Away Mission - Desert Cave"
+	z = Z_LEVEL_BEACH_CAVE
 
 /obj/effect/step_trigger/zlevel_fall/beach
 	var/static/target_z
@@ -86,6 +98,7 @@
 
 /datum/map_z_level/tether_lateload/away_alienship
 	name = "Away Mission - Alien Ship"
+	z = Z_LEVEL_ALIENSHIP
 
 
 #include "aerostat/_aerostat.dm"
@@ -97,6 +110,7 @@
 
 /datum/map_z_level/tether_lateload/away_aerostat
 	name = "Away Mission - Aerostat"
+	z = Z_LEVEL_AEROSTAT
 
 /datum/map_template/tether_lateload/away_aerostat_surface
 	name = "Remmi Aerostat - Z2 Surface"
@@ -104,8 +118,15 @@
 	mappath = 'aerostat/surface.dmm'
 	associated_map_datum = /datum/map_z_level/tether_lateload/away_aerostat_surface
 
+/datum/map_template/tether_lateload/away_aerostat_surface/on_map_loaded(z)
+	. = ..()
+	seed_submaps(list(Z_LEVEL_AEROSTAT_SURFACE), 50, /area/tether_away/aerostat/surface/unexplored, /datum/map_template/virgo2)
+	new /datum/random_map/automata/cave_system/no_cracks(null, 1, 1, Z_LEVEL_AEROSTAT_SURFACE, world.maxx, world.maxy)
+	new /datum/random_map/noise/ore/virgo2(null, 1, 1, Z_LEVEL_AEROSTAT_SURFACE, 64, 64)
+
 /datum/map_z_level/tether_lateload/away_aerostat_surface
 	name = "Away Mission - Aerostat Surface"
+	z = Z_LEVEL_AEROSTAT_SURFACE
 
 
 //////////////////////////////////////////////////////////////////////////////////////
@@ -144,7 +165,7 @@
 	flags = MAP_LEVEL_SEALED
 
 /datum/map_z_level/tether_lateload/New(var/datum/map/map, mapZ)
-	if(mapZ)
+	if(mapZ && !z)
 		z = mapZ
 	return ..(map)
 

--- a/maps/tether/submaps/aerostat/_aerostat.dm
+++ b/maps/tether/submaps/aerostat/_aerostat.dm
@@ -49,9 +49,9 @@
 	destinations = list(/datum/shuttle_destination/excursion/virgo2orbit, /datum/shuttle_destination/excursion/aerostat)
 
 /obj/away_mission_init/aerostat/initialize()
-	seed_submaps(list(z), 50, /area/tether_away/aerostat/surface/unexplored, /datum/map_template/virgo2)
-	new /datum/random_map/automata/cave_system/no_cracks(null, 1, 1, z, world.maxx, world.maxy)
-	new /datum/random_map/noise/ore/virgo2(null, 1, 1, z, 64, 64)
+	/*seed_submaps(list(Z_LEVEL_AEROSTAT_SURFACE), 50, /area/tether_away/aerostat/surface/unexplored, /datum/map_template/virgo2)
+	new /datum/random_map/automata/cave_system/no_cracks(null, 1, 1, Z_LEVEL_AEROSTAT_SURFACE, world.maxx, world.maxy)
+	new /datum/random_map/noise/ore/virgo2(null, 1, 1, Z_LEVEL_AEROSTAT_SURFACE, 64, 64)*/
 
 	initialized = TRUE
 	return INITIALIZE_HINT_QDEL

--- a/maps/tether/submaps/beach/_beach.dm
+++ b/maps/tether/submaps/beach/_beach.dm
@@ -74,12 +74,12 @@
 //In our case, it initializes the ores and random submaps in the beach's cave, then deletes itself
 /obj/away_mission_init/beachcave/initialize()
 	// Cave submaps are first.
-	seed_submaps(list(z), 50, /area/tether_away/cave/unexplored/normal, /datum/map_template/surface/mountains/normal)
+	/*seed_submaps(list(z), 50, /area/tether_away/cave/unexplored/normal, /datum/map_template/surface/mountains/normal)
 	seed_submaps(list(z), 50, /area/tether_away/cave/unexplored/deep, /datum/map_template/surface/mountains/deep)
 
 	// Now for the tunnels.
-	new /datum/random_map/automata/cave_system/no_cracks(null, 1, 1, z, world.maxx, world.maxy)
-	new /datum/random_map/noise/ore/beachmine(null, 1, 1, z, 64, 64)
+	new /datum/random_map/automata/cave_system/no_cracks(null, 1, 1, Z_LEVEL_BEACH_CAVE, world.maxx, world.maxy)
+	new /datum/random_map/noise/ore/beachmine(null, 1, 1, Z_LEVEL_BEACH_CAVE, 64, 64)*/
 
 	initialized = TRUE
 	return INITIALIZE_HINT_QDEL

--- a/maps/tether/tether_defines.dm
+++ b/maps/tether/tether_defines.dm
@@ -35,6 +35,11 @@
 #define Z_LEVEL_MISC						11
 #define Z_LEVEL_SHIPS						12
 #define Z_LEVEL_UNDERDARK					13
+#define Z_LEVEL_ALIENSHIP					14
+#define Z_LEVEL_BEACH						15
+#define Z_LEVEL_BEACH_CAVE					16
+#define Z_LEVEL_AEROSTAT					17
+#define Z_LEVEL_AEROSTAT_SURFACE			18
 
 /datum/map/tether
 	name = "Virgo"


### PR DESCRIPTION
-Basically just gives the tether lateload z-levels actual z-levels and assigns them for use.
-Also moves the cave/ore generation for beach cave and V2 caves for the actual map loader instead of some awaymap temp objects that had apparently didn't have enough concept for proper z definitions.
-Fixes the forementioned things constantly bugging out and spawning all those caves and ores into the surface level foundations.

-Also fixes PoIs getting squished at least until Polaris gets their shit together with yet another submap rotation refactor.

God let me get some fucking rest fsghjasf

Fixes #4425 
Fixes #4386 for now. (Yet another upstream refactor pending. We'll see.)

The PoI squish fix here is kinda hacky though. It will fix the squishing, but while at it, it also kinda brings back the possible risk of PoIs overlapping with bad rng luck. This is because the root of the issue is that the submap rotation code currently sets the y-bounds in stone before applying the rotation and setting the x-bounds. The proper solution would be moving the y-bound to be also applied _after_ the rotation.