### PR TITLE
Sweeping AI QoL

### DIFF
--- a/maps/submaps/engine_submaps/engine_sme.dmm
+++ b/maps/submaps/engine_submaps/engine_sme.dmm
@@ -1,213 +1,2614 @@
-"aa" = (/turf/template_noop,/area/template_noop)
-"ab" = (/turf/space,/area/space)
-"ac" = (/obj/structure/lattice,/obj/structure/grille,/turf/space,/area/space)
-"ad" = (/obj/structure/lattice,/turf/space,/area/space)
-"ae" = (/obj/machinery/atmospherics/pipe/simple/heat_exchanging{dir = 6},/turf/space,/area/space)
-"af" = (/obj/machinery/atmospherics/pipe/simple/heat_exchanging{dir = 4},/turf/space,/area/space)
-"ag" = (/obj/machinery/atmospherics/pipe/simple/heat_exchanging{dir = 4},/obj/structure/lattice,/turf/space,/area/space)
-"ah" = (/obj/machinery/atmospherics/pipe/simple/heat_exchanging{dir = 10},/turf/space,/area/space)
-"ai" = (/obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction{dir = 8},/turf/space,/area/space)
-"aj" = (/obj/machinery/atmospherics/pipe/manifold/visible/black{icon_state = "map"; dir = 1},/obj/structure/lattice,/turf/space,/area/space)
-"ak" = (/obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction{icon_state = "intact"; dir = 4},/turf/space,/area/space)
-"al" = (/obj/machinery/atmospherics/pipe/simple/heat_exchanging,/obj/structure/lattice,/turf/space,/area/space)
-"am" = (/obj/machinery/atmospherics/pipe/simple/heat_exchanging{dir = 6},/obj/structure/lattice,/turf/space,/area/space)
-"an" = (/obj/machinery/atmospherics/pipe/simple/heat_exchanging{dir = 9},/obj/structure/lattice,/turf/space,/area/space)
-"ao" = (/obj/machinery/atmospherics/pipe/simple/heat_exchanging{dir = 5},/turf/space,/area/space)
-"ap" = (/obj/machinery/atmospherics/pipe/manifold4w/visible/black,/obj/structure/lattice,/turf/space,/area/space)
-"aq" = (/obj/machinery/atmospherics/pipe/simple/heat_exchanging{dir = 9},/turf/space,/area/space)
-"ar" = (/obj/machinery/atmospherics/pipe/simple/heat_exchanging,/turf/space,/area/space)
-"as" = (/turf/simulated/wall/r_wall,/area/engineering/engine_room)
-"at" = (/obj/structure/sign/securearea{desc = "A warning sign which reads 'RADIOACTIVE AREA'"; icon_state = "radiation"; name = "RADIOACTIVE AREA"; pixel_x = 0; pixel_y = 0},/turf/simulated/wall/r_wall,/area/engineering/engine_room)
-"au" = (/obj/machinery/atmospherics/pipe/simple/visible/black,/turf/simulated/wall/r_wall,/area/engineering/engine_room)
-"av" = (/turf/simulated/wall/r_wall,/area/template_noop)
-"aw" = (/obj/machinery/atmospherics/portables_connector{dir = 4},/obj/effect/floor_decal/industrial/outline/yellow,/obj/machinery/portable_atmospherics/canister/empty,/turf/simulated/floor,/area/engineering/engine_room)
-"ax" = (/obj/machinery/atmospherics/pipe/simple/visible/black{dir = 4},/turf/simulated/floor,/area/engineering/engine_room)
-"ay" = (/obj/machinery/atmospherics/pipe/manifold/visible/black{icon_state = "map"; dir = 1},/turf/simulated/floor,/area/engineering/engine_room)
-"az" = (/obj/machinery/atmospherics/unary/heat_exchanger{dir = 8},/turf/simulated/floor,/area/engineering/engine_room)
-"aA" = (/obj/machinery/atmospherics/unary/heat_exchanger{dir = 4},/turf/simulated/floor,/area/engineering/engine_room)
-"aB" = (/obj/machinery/atmospherics/pipe/manifold4w/visible/black,/turf/simulated/floor,/area/engineering/engine_room)
-"aC" = (/obj/machinery/atmospherics/binary/pump{dir = 8},/turf/simulated/floor,/area/engineering/engine_room)
-"aD" = (/obj/machinery/atmospherics/portables_connector{dir = 8},/obj/effect/floor_decal/industrial/outline/yellow,/turf/simulated/floor,/area/engineering/engine_room)
-"aE" = (/turf/simulated/floor,/area/engineering/engine_room)
-"aF" = (/obj/machinery/door/blast/regular{dir = 4; icon_state = "pdoor1"; id = "EngineVent"; name = "Reactor Vent"; p_open = 0},/turf/simulated/floor/reinforced/nitrogen{nitrogen = 82.1472},/area/engineering/engine_room)
-"aG" = (/obj/machinery/atmospherics/portables_connector{dir = 4},/obj/effect/floor_decal/industrial/outline/yellow,/obj/effect/floor_decal/industrial/warning/corner{dir = 8},/turf/simulated/floor,/area/engineering/engine_room)
-"aH" = (/obj/machinery/atmospherics/pipe/manifold4w/visible/black,/obj/machinery/meter,/turf/simulated/floor,/area/engineering/engine_room)
-"aI" = (/obj/machinery/atmospherics/pipe/manifold/visible/black,/obj/machinery/meter,/turf/simulated/floor,/area/engineering/engine_room)
-"aJ" = (/obj/machinery/atmospherics/binary/pump{dir = 4},/turf/simulated/floor,/area/engineering/engine_room)
-"aK" = (/obj/structure/cable/cyan{d2 = 2; icon_state = "0-2"},/obj/machinery/power/apc{dir = 4; name = "east bump"; pixel_x = 28},/turf/simulated/floor,/area/engineering/engine_room)
-"aL" = (/obj/effect/floor_decal/industrial/warning/cee{icon_state = "warningcee"; dir = 1},/turf/simulated/floor/reinforced/nitrogen{nitrogen = 82.1472},/area/engineering/engine_room)
-"aM" = (/turf/simulated/floor/greengrid/nitrogen,/area/engineering/engine_room)
-"aN" = (/obj/effect/floor_decal/industrial/warning/cee{icon_state = "warningcee"; dir = 1},/obj/machinery/atmospherics/unary/vent_pump/engine{dir = 4; external_pressure_bound = 100; external_pressure_bound_default = 0; frequency = 1438; icon_state = "map_vent_in"; id_tag = "cooling_out"; initialize_directions = 4; pressure_checks = 1; pressure_checks_default = 1; pump_direction = 0; use_power = 1},/turf/simulated/floor/reinforced/nitrogen{nitrogen = 82.1472},/area/engineering/engine_room)
-"aO" = (/obj/machinery/atmospherics/pipe/simple/visible/red{icon_state = "intact"; dir = 4},/obj/structure/grille,/obj/structure/window/phoronreinforced{icon_state = "phoronrwindow"; dir = 1},/obj/structure/window/phoronreinforced{icon_state = "phoronrwindow"; dir = 8},/obj/structure/window/phoronreinforced{icon_state = "phoronrwindow"; dir = 4},/obj/machinery/door/blast/regular{dir = 2; id = "SupermatterPort"; layer = 3.3; name = "Reactor Blast Door"},/turf/simulated/floor,/area/engineering/engine_room)
-"aP" = (/obj/machinery/atmospherics/pipe/simple/visible/red{icon_state = "intact"; dir = 4},/obj/effect/floor_decal/industrial/warning{dir = 10},/turf/simulated/floor,/area/engineering/engine_room)
-"aQ" = (/obj/machinery/atmospherics/pipe/simple/visible/red{icon_state = "intact"; dir = 4},/obj/effect/floor_decal/industrial/warning,/turf/simulated/floor,/area/engineering/engine_room)
-"aR" = (/obj/effect/floor_decal/industrial/warning/corner{dir = 8},/obj/machinery/atmospherics/pipe/simple/visible/black,/obj/machinery/atmospherics/pipe/simple/visible/red{icon_state = "intact"; dir = 4},/turf/simulated/floor,/area/engineering/engine_room)
-"aS" = (/obj/machinery/atmospherics/pipe/simple/visible/red{icon_state = "intact"; dir = 4},/turf/simulated/floor,/area/engineering/engine_room)
-"aT" = (/obj/machinery/atmospherics/pipe/simple/visible/red{icon_state = "intact"; dir = 10},/obj/machinery/meter,/turf/simulated/floor,/area/engineering/engine_room)
-"aU" = (/obj/structure/cable/cyan{d1 = 2; d2 = 4; icon_state = "2-4"},/obj/structure/cable/cyan{d1 = 1; d2 = 4; icon_state = "1-4"},/turf/simulated/floor,/area/engineering/engine_room)
-"aV" = (/turf/simulated/floor/tiled/techmaint,/area/template_noop)
-"aW" = (/obj/effect/floor_decal/industrial/warning{icon_state = "warning"; dir = 4},/obj/effect/floor_decal/industrial/warning{icon_state = "warning"; dir = 8},/obj/machinery/camera/network/engine{dir = 4},/turf/simulated/floor/reinforced/nitrogen{nitrogen = 82.1472},/area/engineering/engine_room)
-"aX" = (/obj/machinery/mass_driver{dir = 1; id = "enginecore"},/obj/machinery/power/supermatter{layer = 4},/turf/simulated/floor/greengrid/nitrogen,/area/engineering/engine_room)
-"aY" = (/obj/effect/floor_decal/industrial/warning{icon_state = "warning"; dir = 4},/obj/effect/floor_decal/industrial/warning{icon_state = "warning"; dir = 8},/turf/simulated/floor/reinforced/nitrogen{nitrogen = 82.1472},/area/engineering/engine_room)
-"aZ" = (/obj/structure/grille,/obj/structure/window/phoronreinforced{icon_state = "phoronrwindow"; dir = 8},/obj/structure/window/phoronreinforced{icon_state = "phoronrwindow"; dir = 4},/obj/machinery/door/blast/regular{dir = 2; id = "SupermatterPort"; layer = 3.3; name = "Reactor Blast Door"},/turf/simulated/floor,/area/engineering/engine_room)
-"ba" = (/obj/effect/floor_decal/steeldecal/steel_decals_central4{dir = 8},/turf/simulated/floor/tiled/monotile,/area/engineering/engine_room)
-"bb" = (/obj/machinery/power/emitter{anchored = 1; dir = 8; id = "EngineEmitter"; pixel_y = 8; state = 2},/obj/structure/cable/cyan{d1 = 0; d2 = 4; icon_state = "0-4"},/obj/effect/floor_decal/steeldecal/steel_decals6{dir = 6},/obj/effect/floor_decal/steeldecal/steel_decals6{dir = 10},/obj/effect/floor_decal/steeldecal/steel_decals6{dir = 9},/obj/effect/floor_decal/steeldecal/steel_decals6{dir = 5},/turf/simulated/floor/tiled/monotile,/area/engineering/engine_room)
-"bc" = (/obj/structure/cable/cyan{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/effect/floor_decal/industrial/warning{dir = 8},/obj/machinery/atmospherics/binary/pump{dir = 1},/turf/simulated/floor,/area/engineering/engine_room)
-"bd" = (/obj/structure/cable/cyan{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor,/area/engineering/engine_room)
-"be" = (/obj/machinery/atmospherics/pipe/simple/visible/red,/obj/structure/cable/cyan{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor,/area/engineering/engine_room)
-"bf" = (/obj/structure/cable/cyan{d2 = 8; icon_state = "0-8"},/obj/structure/cable/cyan{d1 = 0; d2 = 4; icon_state = "0-4"},/obj/machinery/power/sensor{name = "Powernet Sensor - Engine Power"; name_tag = "Engine Power"},/turf/simulated/floor,/area/engineering/engine_room)
-"bg" = (/obj/structure/cable/yellow{d1 = 2; d2 = 4; icon_state = "2-4"},/obj/structure/cable/cyan{d1 = 1; d2 = 8; icon_state = "1-8"},/turf/simulated/floor,/area/engineering/engine_room)
-"bh" = (/obj/effect/floor_decal/industrial/warning/corner{icon_state = "warningcorner"; dir = 4},/obj/effect/floor_decal/industrial/warning{dir = 10},/obj/machinery/atmospherics/unary/outlet_injector{dir = 2; frequency = 1438; icon_state = "map_injector"; id = "cooling_in"; name = "Coolant Injector"; pixel_y = 1; power_rating = 30000; use_power = 1; volume_rate = 700},/turf/simulated/floor/reinforced/nitrogen{nitrogen = 82.1472},/area/engineering/engine_room)
-"bi" = (/obj/effect/floor_decal/industrial/warning{icon_state = "warning"; dir = 1},/obj/effect/floor_decal/industrial/warning,/turf/simulated/floor/reinforced/nitrogen{nitrogen = 82.1472},/area/engineering/engine_room)
-"bj" = (/obj/effect/floor_decal/industrial/warning/corner{dir = 1},/obj/effect/floor_decal/industrial/warning{dir = 6},/obj/machinery/air_sensor{frequency = 1438; id_tag = "engine_sensor"; output = 63},/turf/simulated/floor/reinforced/nitrogen{nitrogen = 82.1472},/area/engineering/engine_room)
-"bk" = (/obj/structure/grille,/obj/structure/window/phoronreinforced,/obj/structure/window/phoronreinforced{icon_state = "phoronrwindow"; dir = 8},/obj/structure/window/phoronreinforced{icon_state = "phoronrwindow"; dir = 4},/obj/machinery/door/blast/regular{dir = 2; id = "SupermatterPort"; layer = 3.3; name = "Reactor Blast Door"},/turf/simulated/floor,/area/engineering/engine_room)
-"bl" = (/obj/effect/floor_decal/industrial/warning{icon_state = "warning"; dir = 9},/turf/simulated/floor,/area/engineering/engine_room)
-"bm" = (/obj/effect/floor_decal/industrial/warning{dir = 1},/turf/simulated/floor,/area/engineering/engine_room)
-"bn" = (/obj/effect/floor_decal/industrial/warning/corner{dir = 1},/obj/machinery/atmospherics/pipe/manifold/visible/black{dir = 8},/turf/simulated/floor,/area/engineering/engine_room)
-"bo" = (/obj/machinery/atmospherics/pipe/simple/visible/black{icon_state = "intact"; dir = 10},/turf/simulated/floor,/area/engineering/engine_room)
-"bp" = (/obj/machinery/atmospherics/pipe/simple/visible/red,/turf/simulated/floor,/area/engineering/engine_room)
-"bq" = (/obj/structure/cable/yellow{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/machinery/light{dir = 4; icon_state = "tube1"},/turf/simulated/floor,/area/engineering/engine_room)
-"br" = (/obj/machinery/atmospherics/pipe/simple/visible/yellow,/obj/structure/grille,/obj/structure/window/phoronreinforced,/obj/structure/window/phoronreinforced{icon_state = "phoronrwindow"; dir = 1},/obj/structure/window/phoronreinforced{icon_state = "phoronrwindow"; dir = 8},/obj/structure/window/phoronreinforced{icon_state = "phoronrwindow"; dir = 4},/obj/machinery/door/blast/regular{dir = 4; id = "SupermatterPort"; layer = 3.3; name = "Reactor Blast Door"},/turf/simulated/floor,/area/engineering/engine_room)
-"bs" = (/obj/machinery/door/airlock/hatch{icon_state = "door_locked"; id_tag = "engine_access_hatch"; locked = 1; req_access = list(11)},/turf/simulated/floor/reinforced,/area/engineering/engine_room)
-"bt" = (/obj/structure/grille,/obj/structure/window/phoronreinforced,/obj/structure/window/phoronreinforced{icon_state = "phoronrwindow"; dir = 1},/obj/structure/window/phoronreinforced{icon_state = "phoronrwindow"; dir = 8},/obj/structure/window/phoronreinforced{icon_state = "phoronrwindow"; dir = 4},/obj/machinery/door/blast/regular{dir = 4; id = "SupermatterPort"; layer = 3.3; name = "Reactor Blast Door"},/turf/simulated/floor,/area/engineering/engine_room)
-"bu" = (/obj/machinery/atmospherics/pipe/simple/visible/yellow{dir = 6},/obj/effect/floor_decal/industrial/warning{dir = 8},/obj/machinery/button/remote/blast_door{desc = "A remote control-switch for the engine control room blast doors."; id = "EngineBlast"; name = "Engine Monitoring Room Blast Doors"; pixel_x = -25; pixel_y = 5; req_access = list(10)},/obj/machinery/button/remote/blast_door{desc = "A remote control-switch for the engine charging port."; id = "SupermatterPort"; name = "Reactor Blast Doors"; pixel_x = -25; pixel_y = -5; req_access = list(10)},/obj/machinery/light{dir = 8; icon_state = "tube1"; pixel_y = 0},/turf/simulated/floor,/area/engineering/engine_room)
-"bv" = (/obj/machinery/atmospherics/pipe/manifold/visible/yellow{dir = 1},/turf/simulated/floor,/area/engineering/engine_room)
-"bw" = (/obj/machinery/atmospherics/omni/atmos_filter,/turf/simulated/floor,/area/engineering/engine_room)
-"bx" = (/obj/machinery/atmospherics/pipe/simple/visible/yellow{dir = 10},/turf/simulated/floor,/area/engineering/engine_room)
-"by" = (/obj/structure/cable/yellow{d1 = 1; d2 = 2; icon_state = "1-2"},/turf/simulated/floor,/area/engineering/engine_room)
-"bz" = (/turf/simulated/floor,/area/template_noop)
-"bA" = (/obj/item/weapon/book/manual/supermatter_engine,/turf/template_noop,/area/template_noop)
-"bB" = (/obj/machinery/computer/general_air_control/supermatter_core{dir = 1; frequency = 1438; input_tag = "cooling_in"; name = "Engine Cooling Control"; output_tag = "cooling_out"; pressure_setting = 100; sensors = list("engine_sensor" = "Engine Core"); throwpass = 1},/turf/template_noop,/area/template_noop)
-"bC" = (/obj/effect/floor_decal/industrial/warning/corner{dir = 4},/obj/effect/floor_decal/industrial/warning/corner{dir = 8},/obj/machinery/button/remote/blast_door{desc = "A remote control-switch for the engine radiator viewport shutters."; id = "EngineRadiatorViewport"; name = "Engine Radiator Viewport Shutters"; pixel_x = -25; pixel_y = 0; req_access = list(10)},/turf/simulated/floor,/area/engineering/engine_room)
-"bD" = (/obj/machinery/atmospherics/pipe/manifold/visible/yellow{dir = 8},/obj/effect/floor_decal/industrial/warning{dir = 1},/turf/simulated/floor,/area/engineering/engine_room)
-"bE" = (/obj/machinery/atmospherics/pipe/manifold/visible/yellow{dir = 1},/obj/effect/floor_decal/industrial/warning{dir = 1},/obj/machinery/meter,/turf/simulated/floor,/area/engineering/engine_room)
-"bF" = (/obj/machinery/atmospherics/pipe/simple/visible/yellow{dir = 4},/obj/effect/floor_decal/industrial/warning{dir = 1},/turf/simulated/floor,/area/engineering/engine_room)
-"bG" = (/obj/machinery/atmospherics/pipe/simple/visible/yellow{dir = 4},/obj/effect/floor_decal/industrial/warning{dir = 1},/obj/machinery/light{dir = 1},/turf/simulated/floor,/area/engineering/engine_room)
-"bH" = (/obj/machinery/atmospherics/pipe/simple/visible/yellow{dir = 4},/obj/machinery/atmospherics/valve/digital{dir = 2; name = "Emergency Cooling Valve 1"},/obj/effect/floor_decal/industrial/warning/corner{dir = 1},/turf/simulated/floor,/area/engineering/engine_room)
-"bI" = (/obj/machinery/atmospherics/pipe/manifold/visible/yellow,/turf/simulated/floor,/area/engineering/engine_room)
-"bJ" = (/obj/machinery/atmospherics/pipe/simple/visible/yellow{dir = 4},/turf/simulated/floor,/area/engineering/engine_room)
-"bK" = (/obj/machinery/atmospherics/pipe/simple/visible/yellow{dir = 4},/obj/machinery/atmospherics/pipe/simple/visible/red,/turf/simulated/floor,/area/engineering/engine_room)
-"bL" = (/obj/structure/cable/yellow{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/machinery/atmospherics/unary/vent_scrubber/on,/turf/simulated/floor,/area/engineering/engine_room)
-"bM" = (/obj/machinery/button/remote/blast_door{desc = "A remote control-switch for the engine charging port."; id = "SupermatterPort"; name = "Reactor Blast Doors"; pixel_x = -6; pixel_y = 7; req_access = list(10)},/obj/machinery/button/remote/emitter{desc = "A remote control-switch for the engine emitter."; id = "EngineEmitter"; name = "Engine Emitter"; pixel_x = 6; pixel_y = 7; req_access = list(10)},/obj/machinery/button/remote/blast_door{desc = "A remote control-switch for the engine control room blast doors."; id = "EngineBlast"; name = "Engine Monitoring Room Blast Doors"; pixel_x = 0; pixel_y = -3; req_access = list(10)},/turf/template_noop,/area/template_noop)
-"bN" = (/obj/machinery/atmospherics/pipe/simple/heat_exchanging{dir = 5},/obj/structure/lattice,/turf/space,/area/space)
-"bO" = (/obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction{dir = 8},/obj/structure/lattice,/turf/space,/area/space)
-"bP" = (/obj/structure/grille,/obj/structure/window/reinforced/full,/obj/structure/window/reinforced{dir = 8; health = 1e+006},/obj/machinery/door/blast/regular{density = 0; icon_state = "pdoor0"; id = "EngineRadiatorViewport"; name = "Engine Radiator Viewport Shutter"; opacity = 0},/obj/machinery/door/firedoor/glass,/obj/machinery/atmospherics/pipe/simple/visible/green{dir = 4},/turf/simulated/floor,/area/engineering/engine_room)
-"bQ" = (/obj/effect/floor_decal/industrial/warning{dir = 8},/obj/machinery/atmospherics/pipe/simple/visible/green{dir = 4},/turf/simulated/floor,/area/engineering/engine_room)
-"bR" = (/obj/machinery/atmospherics/pipe/simple/visible/green{dir = 4},/obj/machinery/atmospherics/pipe/simple/visible/yellow,/turf/simulated/floor,/area/engineering/engine_room)
-"bS" = (/obj/machinery/atmospherics/pipe/manifold/visible/green{dir = 1},/obj/machinery/meter,/turf/simulated/floor,/area/engineering/engine_room)
-"bT" = (/obj/machinery/atmospherics/pipe/manifold/visible/green{dir = 1},/turf/simulated/floor,/area/engineering/engine_room)
-"bU" = (/obj/machinery/atmospherics/pipe/manifold/visible/green,/turf/simulated/floor,/area/engineering/engine_room)
-"bV" = (/obj/machinery/atmospherics/pipe/simple/visible/green{dir = 4},/turf/simulated/floor,/area/engineering/engine_room)
-"bW" = (/obj/machinery/atmospherics/pipe/manifold/visible/green{dir = 1},/obj/effect/floor_decal/industrial/warning/corner,/turf/simulated/floor,/area/engineering/engine_room)
-"bX" = (/obj/machinery/atmospherics/pipe/simple/visible/green{dir = 10; icon_state = "intact";},/obj/effect/floor_decal/industrial/warning,/turf/simulated/floor,/area/engineering/engine_room)
-"bY" = (/obj/effect/floor_decal/industrial/warning,/turf/simulated/floor,/area/engineering/engine_room)
-"bZ" = (/obj/machinery/atmospherics/pipe/simple/visible/red{icon_state = "intact"; dir = 6},/obj/effect/floor_decal/industrial/warning,/turf/simulated/floor,/area/engineering/engine_room)
-"ca" = (/obj/machinery/atmospherics/pipe/manifold/visible/red{icon_state = "map"; dir = 4},/obj/effect/floor_decal/industrial/warning/corner{dir = 8},/turf/simulated/floor,/area/engineering/engine_room)
-"cb" = (/obj/machinery/atmospherics/pipe/simple/visible/yellow,/turf/simulated/floor,/area/engineering/engine_room)
-"cc" = (/obj/structure/cable/yellow{d2 = 2; icon_state = "0-2"},/obj/structure/cable/yellow,/obj/machinery/power/sensor{name = "Powernet Sensor - Engine Output"; name_tag = "Engine Output"},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 6},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 5},/turf/simulated/floor,/area/engineering/engine_room)
-"ce" = (/obj/structure/grille,/obj/structure/window/reinforced/full,/obj/structure/window/reinforced{dir = 8; health = 1e+006},/obj/machinery/door/blast/regular{density = 0; icon_state = "pdoor0"; id = "EngineRadiatorViewport"; name = "Engine Radiator Viewport Shutter"; opacity = 0},/obj/machinery/door/firedoor/glass,/obj/machinery/atmospherics/pipe/simple/visible/cyan{dir = 4},/turf/simulated/floor,/area/engineering/engine_room)
-"cf" = (/obj/machinery/atmospherics/pipe/simple/visible/cyan{dir = 10},/obj/effect/floor_decal/industrial/warning{dir = 8},/turf/simulated/floor,/area/engineering/engine_room)
-"cg" = (/obj/machinery/atmospherics/binary/pump,/turf/simulated/floor,/area/engineering/engine_room)
-"ch" = (/obj/machinery/atmospherics/binary/pump{dir = 1},/turf/simulated/floor,/area/engineering/engine_room)
-"ci" = (/obj/machinery/atmospherics/pipe/simple/visible/green,/obj/effect/floor_decal/industrial/warning{icon_state = "warning"; dir = 4},/turf/simulated/floor,/area/engineering/engine_room)
-"cj" = (/obj/machinery/atmospherics/binary/circulator{anchored = 1; dir = 1},/turf/simulated/floor,/area/engineering/engine_room)
-"ck" = (/obj/machinery/power/generator{anchored = 1; dir = 4},/obj/structure/cable/yellow{d2 = 2; icon_state = "0-2"},/turf/simulated/floor,/area/engineering/engine_room)
-"cl" = (/obj/machinery/atmospherics/binary/circulator{anchored = 1},/turf/simulated/floor,/area/engineering/engine_room)
-"cm" = (/obj/machinery/atmospherics/pipe/simple/visible/red,/obj/effect/floor_decal/industrial/warning{dir = 8},/turf/simulated/floor,/area/engineering/engine_room)
-"cn" = (/obj/structure/cable/yellow{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/machinery/atmospherics/unary/vent_pump/on{dir = 1},/turf/simulated/floor,/area/engineering/engine_room)
-"co" = (/obj/machinery/atmospherics/pipe/simple/heat_exchanging{dir = 10},/obj/structure/lattice,/turf/space,/area/space)
-"cp" = (/obj/structure/grille,/obj/structure/window/reinforced/full,/obj/structure/window/reinforced{dir = 8; health = 1e+006},/obj/machinery/door/blast/regular{density = 0; icon_state = "pdoor0"; id = "EngineRadiatorViewport"; name = "Engine Radiator Viewport Shutter"; opacity = 0},/obj/machinery/door/firedoor/glass,/turf/simulated/floor,/area/engineering/engine_room)
-"cq" = (/obj/effect/floor_decal/industrial/warning{dir = 8},/obj/machinery/atmospherics/binary/pump/high_power,/turf/simulated/floor,/area/engineering/engine_room)
-"cr" = (/obj/machinery/atmospherics/portables_connector{dir = 1},/obj/effect/floor_decal/industrial/outline/yellow,/turf/simulated/floor,/area/engineering/engine_room)
-"cs" = (/obj/machinery/atmospherics/portables_connector{dir = 1},/obj/effect/floor_decal/industrial/outline/blue,/turf/simulated/floor,/area/engineering/engine_room)
-"ct" = (/obj/machinery/atmospherics/pipe/simple/visible/cyan{dir = 6},/turf/simulated/floor,/area/engineering/engine_room)
-"cu" = (/obj/machinery/atmospherics/pipe/simple/visible/green,/obj/machinery/atmospherics/pipe/simple/visible/cyan{dir = 4},/obj/effect/floor_decal/industrial/warning/corner{dir = 4},/turf/simulated/floor,/area/engineering/engine_room)
-"cv" = (/obj/machinery/atmospherics/pipe/simple/visible/cyan{dir = 9},/obj/effect/floor_decal/industrial/warning{dir = 1},/turf/simulated/floor,/area/engineering/engine_room)
-"cw" = (/obj/effect/floor_decal/industrial/warning{dir = 1},/obj/structure/cable/yellow{d1 = 1; d2 = 4; icon_state = "1-4"},/turf/simulated/floor,/area/engineering/engine_room)
-"cx" = (/obj/machinery/atmospherics/pipe/simple/visible/yellow{dir = 5},/obj/effect/floor_decal/industrial/warning{dir = 1},/obj/structure/cable/yellow{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor,/area/engineering/engine_room)
-"cy" = (/obj/machinery/atmospherics/pipe/simple/visible/yellow{dir = 4},/obj/machinery/atmospherics/pipe/simple/visible/red,/obj/effect/floor_decal/industrial/warning/corner{dir = 1},/obj/structure/cable/yellow{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor,/area/engineering/engine_room)
-"cz" = (/obj/machinery/atmospherics/pipe/manifold/visible/yellow{dir = 4},/obj/structure/cable/yellow{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor,/area/engineering/engine_room)
-"cA" = (/obj/structure/cable/yellow{d1 = 1; d2 = 8; icon_state = "1-8"},/obj/structure/cable/yellow{d1 = 1; d2 = 2; icon_state = "1-2"},/turf/simulated/floor,/area/engineering/engine_room)
-"cB" = (/obj/machinery/atmospherics/pipe/simple/visible/cyan{dir = 5},/obj/effect/floor_decal/industrial/warning/corner{dir = 1},/turf/simulated/floor,/area/engineering/engine_room)
-"cC" = (/obj/machinery/atmospherics/pipe/simple/visible/cyan{dir = 4},/turf/simulated/floor,/area/engineering/engine_room)
-"cD" = (/obj/machinery/atmospherics/pipe/simple/visible/cyan{dir = 4},/obj/machinery/meter,/turf/simulated/floor,/area/engineering/engine_room)
-"cE" = (/obj/machinery/atmospherics/pipe/manifold/visible/cyan{dir = 4},/turf/simulated/floor,/area/engineering/engine_room)
-"cF" = (/obj/machinery/atmospherics/pipe/simple/visible/green{icon_state = "intact"; dir = 5},/obj/effect/floor_decal/industrial/warning/corner,/turf/simulated/floor,/area/engineering/engine_room)
-"cG" = (/obj/machinery/atmospherics/pipe/manifold/visible/red{icon_state = "map"; dir = 4},/obj/machinery/meter,/turf/simulated/floor,/area/engineering/engine_room)
-"cH" = (/obj/machinery/atmospherics/pipe/simple/visible/yellow,/obj/machinery/meter,/turf/simulated/floor,/area/engineering/engine_room)
-"cI" = (/obj/structure/cable/yellow{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/machinery/camera/network/engine{dir = 8},/obj/machinery/firealarm{dir = 4; layer = 3.3; pixel_x = 26},/turf/simulated/floor,/area/engineering/engine_room)
-"cJ" = (/turf/simulated/wall/r_wall,/area/engineering/engine_gas)
-"cK" = (/turf/simulated/floor,/area/engineering/engine_gas)
-"cL" = (/obj/effect/floor_decal/industrial/warning/corner,/obj/machinery/button/remote/blast_door{desc = "A remote control-switch for the engine control room blast doors."; id = "EngineEmitterPortWest"; name = "Engine Room Blast Doors"; pixel_x = 0; pixel_y = -25; req_access = null; req_one_access = list(11,24)},/obj/machinery/camera/network/engine{dir = 1},/turf/simulated/floor,/area/engineering/engine_gas)
-"cM" = (/obj/effect/floor_decal/industrial/warning,/turf/simulated/floor,/area/engineering/engine_gas)
-"cN" = (/obj/effect/floor_decal/industrial/warning/corner{dir = 8},/turf/simulated/floor,/area/engineering/engine_gas)
-"cO" = (/obj/machinery/atmospherics/pipe/simple/visible/cyan,/turf/simulated/floor,/area/engineering/engine_room)
-"cP" = (/obj/effect/floor_decal/industrial/warning{icon_state = "warning"; dir = 4},/turf/simulated/floor,/area/engineering/engine_room)
-"cQ" = (/obj/structure/cable/yellow{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/machinery/airlock_sensor/airlock_interior{id_tag = "eng_al_int_snsr"; master_tag = "engine_room_airlock"; pixel_x = 22; pixel_y = 0; req_access = list(10)},/turf/simulated/floor,/area/engineering/engine_room)
-"cR" = (/obj/machinery/door/blast/regular{dir = 4; icon_state = "pdoor1"; id = "EngineEmitterPortWest"; layer = 3.3; name = "Engine Gas Storage"},/obj/machinery/door/firedoor/glass,/turf/simulated/floor,/area/engineering/engine_gas)
-"cS" = (/obj/machinery/atmospherics/pipe/simple/visible/cyan{dir = 5},/turf/simulated/floor,/area/engineering/engine_room)
-"cT" = (/obj/machinery/atmospherics/pipe/simple/visible/cyan{dir = 4},/obj/effect/floor_decal/industrial/warning/corner{dir = 4},/turf/simulated/floor,/area/engineering/engine_room)
-"cU" = (/obj/machinery/atmospherics/pipe/manifold/visible/cyan{dir = 4},/obj/effect/floor_decal/industrial/warning{dir = 1},/turf/simulated/floor,/area/engineering/engine_room)
-"cV" = (/obj/machinery/atmospherics/pipe/simple/visible/yellow{dir = 9},/obj/structure/cable/yellow{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor,/area/engineering/engine_room)
-"cW" = (/obj/structure/cable/yellow{d1 = 1; d2 = 8; icon_state = "1-8"},/turf/simulated/floor,/area/engineering/engine_room)
-"cX" = (/turf/simulated/floor/plating,/area/template_noop)
-"cY" = (/obj/effect/floor_decal/industrial/outline/blue,/obj/machinery/portable_atmospherics/canister/nitrogen,/turf/simulated/floor,/area/engineering/engine_gas)
-"cZ" = (/obj/effect/floor_decal/industrial/outline/blue,/obj/machinery/portable_atmospherics/canister/nitrogen,/obj/machinery/button/remote/blast_door{desc = "A remote control-switch for the engine control room blast doors."; id = "EngineEmitterPortWest"; name = "Engine Room Blast Doors"; pixel_x = 0; pixel_y = 25; req_access = null; req_one_access = list(11,24)},/turf/simulated/floor,/area/engineering/engine_gas)
-"da" = (/obj/effect/floor_decal/industrial/outline/yellow,/obj/machinery/portable_atmospherics/canister/carbon_dioxide,/obj/structure/extinguisher_cabinet{dir = 1; icon_state = "extinguisher_closed"; pixel_y = 32;},/turf/simulated/floor,/area/engineering/engine_gas)
-"db" = (/obj/effect/floor_decal/industrial/warning/corner,/turf/simulated/floor,/area/engineering/engine_room)
-"dc" = (/obj/machinery/button/remote/blast_door{id = "EngineVent"; name = "Reactor Ventillatory Control"; pixel_x = 0; pixel_y = -25; req_access = list(10)},/obj/effect/floor_decal/industrial/warning,/turf/simulated/floor,/area/engineering/engine_room)
-"dd" = (/obj/machinery/atmospherics/pipe/simple/visible/cyan{dir = 5},/obj/effect/floor_decal/industrial/warning/corner{dir = 8},/turf/simulated/floor,/area/engineering/engine_room)
-"de" = (/obj/machinery/atmospherics/valve/digital{dir = 4; name = "Emergency Cooling Valve 2"},/obj/machinery/light,/turf/simulated/floor,/area/engineering/engine_room)
-"df" = (/obj/machinery/atmospherics/pipe/simple/visible/red{icon_state = "intact"; dir = 4},/obj/machinery/alarm{dir = 1; icon_state = "alarm0"; pixel_y = -22},/turf/simulated/floor,/area/engineering/engine_room)
-"dg" = (/obj/machinery/atmospherics/pipe/simple/visible/red{icon_state = "intact"; dir = 9},/turf/simulated/floor,/area/engineering/engine_room)
-"dh" = (/obj/item/device/radio/intercom{dir = 2; pixel_y = -24},/turf/simulated/floor,/area/engineering/engine_room)
-"di" = (/obj/effect/floor_decal/industrial/outline/blue,/obj/machinery/portable_atmospherics/canister/nitrogen,/obj/machinery/camera/network/engineering{dir = 4},/turf/simulated/floor,/area/engineering/engine_gas)
-"dj" = (/obj/machinery/atmospherics/unary/vent_pump/on{dir = 4},/turf/simulated/floor,/area/engineering/engine_gas)
-"dk" = (/obj/effect/decal/cleanable/dirt,/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 10},/turf/simulated/floor,/area/engineering/engine_gas)
-"dl" = (/obj/effect/floor_decal/industrial/outline/yellow,/obj/machinery/portable_atmospherics/canister/carbon_dioxide,/obj/machinery/light/small{dir = 4; pixel_y = 0},/obj/machinery/alarm{dir = 8; pixel_x = 25; pixel_y = 0},/turf/simulated/floor,/area/engineering/engine_gas)
-"dm" = (/obj/structure/sign/securearea{desc = "A warning sign which reads 'HIGH VOLTAGE'"; icon_state = "shock"; name = "HIGH VOLTAGE"; pixel_y = 0},/turf/simulated/wall/r_wall,/area/engineering/engine_room)
-"dn" = (/obj/effect/floor_decal/industrial/outline/blue,/obj/machinery/portable_atmospherics/canister/phoron,/obj/machinery/light/small{dir = 8; pixel_x = 0},/turf/simulated/floor,/area/engineering/engine_gas)
-"do" = (/obj/effect/floor_decal/industrial/outline/blue,/obj/machinery/portable_atmospherics/canister/phoron,/turf/simulated/floor,/area/engineering/engine_gas)
-"dp" = (/obj/effect/decal/cleanable/dirt,/obj/machinery/atmospherics/unary/vent_scrubber/on{dir = 4},/turf/simulated/floor,/area/engineering/engine_gas)
-"dq" = (/obj/effect/decal/cleanable/dirt,/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 10},/turf/simulated/floor,/area/engineering/engine_gas)
-"dr" = (/obj/structure/window/reinforced{dir = 1},/obj/structure/cable/green{d2 = 2; icon_state = "0-2"},/obj/machinery/power/apc{dir = 4; name = "east bump"; pixel_x = 28},/obj/structure/closet/radiation,/obj/item/clothing/glasses/meson,/obj/item/clothing/glasses/meson,/turf/simulated/floor,/area/engineering/engine_gas)
-"ds" = (/obj/effect/floor_decal/industrial/outline/blue,/obj/machinery/portable_atmospherics/canister/phoron,/obj/machinery/firealarm{dir = 1; pixel_y = -24},/turf/simulated/floor,/area/engineering/engine_gas)
-"dt" = (/obj/effect/decal/cleanable/dirt,/obj/effect/floor_decal/industrial/warning/corner,/turf/simulated/floor,/area/engineering/engine_gas)
-"du" = (/obj/effect/floor_decal/rust,/obj/effect/floor_decal/industrial/warning,/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/turf/simulated/floor,/area/engineering/engine_gas)
-"dv" = (/obj/effect/floor_decal/industrial/warning,/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/machinery/button/remote/blast_door{desc = "A remote control-switch for the engine control room blast doors."; id = "EngineEmitterPortWest2"; name = "Engine Room Blast Doors"; pixel_x = 25; pixel_y = 0; req_access = null; req_one_access = list(11,24)},/turf/simulated/floor,/area/engineering/engine_gas)
-"dw" = (/obj/structure/sign/securearea{desc = "A warning sign which reads 'RADIOACTIVE AREA'"; icon_state = "radiation"; name = "RADIOACTIVE AREA"; pixel_x = 0; pixel_y = 0},/turf/simulated/wall/r_wall,/area/template_noop)
-"dx" = (/obj/machinery/door/firedoor/glass,/obj/machinery/door/blast/regular{dir = 4; icon_state = "pdoor1"; id = "EngineEmitterPortWest2"; layer = 3.3; name = "Engine Gas Storage"},/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/turf/simulated/floor/tiled/steel_grid,/area/template_noop)
-"dy" = (/obj/machinery/door/firedoor/glass,/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/machinery/door/blast/regular{dir = 4; icon_state = "pdoor1"; id = "EngineEmitterPortWest2"; layer = 3.3; name = "Engine Gas Storage"},/turf/simulated/floor/tiled/steel_grid,/area/template_noop)
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"aa" = (
+/turf/template_noop,
+/area/template_noop)
+"ab" = (
+/turf/space,
+/area/space)
+"ac" = (
+/obj/structure/lattice,
+/obj/structure/grille,
+/turf/space,
+/area/space)
+"ad" = (
+/obj/structure/lattice,
+/turf/space,
+/area/space)
+"ae" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 6
+	},
+/turf/space,
+/area/space)
+"af" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 4
+	},
+/turf/space,
+/area/space)
+"ag" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 4
+	},
+/obj/structure/lattice,
+/turf/space,
+/area/space)
+"ah" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 10
+	},
+/turf/space,
+/area/space)
+"ai" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction{
+	dir = 8
+	},
+/turf/space,
+/area/space)
+"aj" = (
+/obj/machinery/atmospherics/pipe/manifold/visible/black{
+	icon_state = "map";
+	dir = 1
+	},
+/obj/structure/lattice,
+/turf/space,
+/area/space)
+"ak" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction{
+	icon_state = "intact";
+	dir = 4
+	},
+/turf/space,
+/area/space)
+"al" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging,
+/obj/structure/lattice,
+/turf/space,
+/area/space)
+"am" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 6
+	},
+/obj/structure/lattice,
+/turf/space,
+/area/space)
+"an" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 9
+	},
+/obj/structure/lattice,
+/turf/space,
+/area/space)
+"ao" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 5
+	},
+/turf/space,
+/area/space)
+"ap" = (
+/obj/machinery/atmospherics/pipe/manifold4w/visible/black,
+/obj/structure/lattice,
+/turf/space,
+/area/space)
+"aq" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 9
+	},
+/turf/space,
+/area/space)
+"ar" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging,
+/turf/space,
+/area/space)
+"as" = (
+/turf/simulated/wall/r_wall,
+/area/engineering/engine_room)
+"at" = (
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'RADIOACTIVE AREA'";
+	icon_state = "radiation";
+	name = "RADIOACTIVE AREA";
+	pixel_x = 0;
+	pixel_y = 0
+	},
+/turf/simulated/wall/r_wall,
+/area/engineering/engine_room)
+"au" = (
+/obj/machinery/atmospherics/pipe/simple/visible/black,
+/turf/simulated/wall/r_wall,
+/area/engineering/engine_room)
+"av" = (
+/turf/simulated/wall/r_wall,
+/area/template_noop)
+"aw" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/portable_atmospherics/canister/empty,
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"ax" = (
+/obj/machinery/atmospherics/pipe/simple/visible/black{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"ay" = (
+/obj/machinery/atmospherics/pipe/manifold/visible/black{
+	icon_state = "map";
+	dir = 1
+	},
+/obj/machinery/camera/network/engine,
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"az" = (
+/obj/machinery/atmospherics/unary/heat_exchanger{
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"aA" = (
+/obj/machinery/atmospherics/unary/heat_exchanger{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"aB" = (
+/obj/machinery/atmospherics/pipe/manifold4w/visible/black,
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"aC" = (
+/obj/machinery/atmospherics/binary/pump{
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"aD" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"aE" = (
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"aF" = (
+/obj/machinery/door/blast/regular{
+	dir = 4;
+	icon_state = "pdoor1";
+	id = "EngineVent";
+	name = "Reactor Vent";
+	p_open = 0
+	},
+/turf/simulated/floor/reinforced/nitrogen{
+	nitrogen = 82.1472
+	},
+/area/engineering/engine_room)
+"aG" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"aH" = (
+/obj/machinery/atmospherics/pipe/manifold4w/visible/black,
+/obj/machinery/meter,
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"aI" = (
+/obj/machinery/atmospherics/pipe/manifold/visible/black,
+/obj/machinery/meter,
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"aJ" = (
+/obj/machinery/atmospherics/binary/pump{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"aK" = (
+/obj/structure/cable/cyan{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 28
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"aL" = (
+/obj/effect/floor_decal/industrial/warning/cee{
+	icon_state = "warningcee";
+	dir = 1
+	},
+/turf/simulated/floor/reinforced/nitrogen{
+	nitrogen = 82.1472
+	},
+/area/engineering/engine_room)
+"aM" = (
+/turf/simulated/floor/greengrid/nitrogen,
+/area/engineering/engine_room)
+"aN" = (
+/obj/effect/floor_decal/industrial/warning/cee{
+	icon_state = "warningcee";
+	dir = 1
+	},
+/obj/machinery/atmospherics/unary/vent_pump/engine{
+	dir = 4;
+	external_pressure_bound = 100;
+	external_pressure_bound_default = 0;
+	frequency = 1438;
+	icon_state = "map_vent_in";
+	id_tag = "cooling_out";
+	initialize_directions = 4;
+	pressure_checks = 1;
+	pressure_checks_default = 1;
+	pump_direction = 0;
+	use_power = 1
+	},
+/turf/simulated/floor/reinforced/nitrogen{
+	nitrogen = 82.1472
+	},
+/area/engineering/engine_room)
+"aO" = (
+/obj/machinery/atmospherics/pipe/simple/visible/red{
+	icon_state = "intact";
+	dir = 4
+	},
+/obj/structure/grille,
+/obj/structure/window/phoronreinforced{
+	icon_state = "phoronrwindow";
+	dir = 1
+	},
+/obj/structure/window/phoronreinforced{
+	icon_state = "phoronrwindow";
+	dir = 8
+	},
+/obj/structure/window/phoronreinforced{
+	icon_state = "phoronrwindow";
+	dir = 4
+	},
+/obj/machinery/door/blast/regular{
+	dir = 2;
+	id = "SupermatterPort";
+	layer = 3.3;
+	name = "Reactor Blast Door"
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"aP" = (
+/obj/machinery/atmospherics/pipe/simple/visible/red{
+	icon_state = "intact";
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 10
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"aQ" = (
+/obj/machinery/atmospherics/pipe/simple/visible/red{
+	icon_state = "intact";
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"aR" = (
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/black,
+/obj/machinery/atmospherics/pipe/simple/visible/red{
+	icon_state = "intact";
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"aS" = (
+/obj/machinery/atmospherics/pipe/simple/visible/red{
+	icon_state = "intact";
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"aT" = (
+/obj/machinery/atmospherics/pipe/simple/visible/red{
+	icon_state = "intact";
+	dir = 10
+	},
+/obj/machinery/meter,
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"aU" = (
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"aV" = (
+/turf/simulated/floor/tiled/techmaint,
+/area/template_noop)
+"aW" = (
+/obj/effect/floor_decal/industrial/warning{
+	icon_state = "warning";
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning{
+	icon_state = "warning";
+	dir = 8
+	},
+/obj/machinery/camera/network/engine{
+	dir = 4
+	},
+/turf/simulated/floor/reinforced/nitrogen{
+	nitrogen = 82.1472
+	},
+/area/engineering/engine_room)
+"aX" = (
+/obj/machinery/mass_driver{
+	dir = 1;
+	id = "enginecore"
+	},
+/obj/machinery/power/supermatter{
+	layer = 4
+	},
+/turf/simulated/floor/greengrid/nitrogen,
+/area/engineering/engine_room)
+"aY" = (
+/obj/effect/floor_decal/industrial/warning{
+	icon_state = "warning";
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning{
+	icon_state = "warning";
+	dir = 8
+	},
+/turf/simulated/floor/reinforced/nitrogen{
+	nitrogen = 82.1472
+	},
+/area/engineering/engine_room)
+"aZ" = (
+/obj/structure/grille,
+/obj/structure/window/phoronreinforced{
+	icon_state = "phoronrwindow";
+	dir = 8
+	},
+/obj/structure/window/phoronreinforced{
+	icon_state = "phoronrwindow";
+	dir = 4
+	},
+/obj/machinery/door/blast/regular{
+	dir = 2;
+	id = "SupermatterPort";
+	layer = 3.3;
+	name = "Reactor Blast Door"
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"ba" = (
+/obj/effect/floor_decal/steeldecal/steel_decals_central4{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/engineering/engine_room)
+"bb" = (
+/obj/machinery/power/emitter{
+	anchored = 1;
+	dir = 8;
+	id = "EngineEmitter";
+	pixel_y = 8;
+	state = 2
+	},
+/obj/structure/cable/cyan{
+	d1 = 0;
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 6
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 10
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 9
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/engineering/engine_room)
+"bc" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/machinery/atmospherics/binary/pump{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"bd" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"be" = (
+/obj/machinery/atmospherics/pipe/simple/visible/red,
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"bf" = (
+/obj/structure/cable/cyan{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/cable/cyan{
+	d1 = 0;
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/power/sensor{
+	name = "Powernet Sensor - Engine Power";
+	name_tag = "Engine Power"
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"bg" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"bh" = (
+/obj/effect/floor_decal/industrial/warning/corner{
+	icon_state = "warningcorner";
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 10
+	},
+/obj/machinery/atmospherics/unary/outlet_injector{
+	dir = 2;
+	frequency = 1438;
+	icon_state = "map_injector";
+	id = "cooling_in";
+	name = "Coolant Injector";
+	pixel_y = 1;
+	power_rating = 30000;
+	use_power = 1;
+	volume_rate = 700
+	},
+/turf/simulated/floor/reinforced/nitrogen{
+	nitrogen = 82.1472
+	},
+/area/engineering/engine_room)
+"bi" = (
+/obj/effect/floor_decal/industrial/warning{
+	icon_state = "warning";
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/reinforced/nitrogen{
+	nitrogen = 82.1472
+	},
+/area/engineering/engine_room)
+"bj" = (
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 6
+	},
+/obj/machinery/air_sensor{
+	frequency = 1438;
+	id_tag = "engine_sensor";
+	output = 63
+	},
+/turf/simulated/floor/reinforced/nitrogen{
+	nitrogen = 82.1472
+	},
+/area/engineering/engine_room)
+"bk" = (
+/obj/structure/grille,
+/obj/structure/window/phoronreinforced,
+/obj/structure/window/phoronreinforced{
+	icon_state = "phoronrwindow";
+	dir = 8
+	},
+/obj/structure/window/phoronreinforced{
+	icon_state = "phoronrwindow";
+	dir = 4
+	},
+/obj/machinery/door/blast/regular{
+	dir = 2;
+	id = "SupermatterPort";
+	layer = 3.3;
+	name = "Reactor Blast Door"
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"bl" = (
+/obj/effect/floor_decal/industrial/warning{
+	icon_state = "warning";
+	dir = 9
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"bm" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"bn" = (
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/visible/black{
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"bo" = (
+/obj/machinery/atmospherics/pipe/simple/visible/black{
+	icon_state = "intact";
+	dir = 10
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"bp" = (
+/obj/machinery/atmospherics/pipe/simple/visible/red,
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"bq" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1"
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"br" = (
+/obj/machinery/atmospherics/pipe/simple/visible/yellow,
+/obj/structure/grille,
+/obj/structure/window/phoronreinforced,
+/obj/structure/window/phoronreinforced{
+	icon_state = "phoronrwindow";
+	dir = 1
+	},
+/obj/structure/window/phoronreinforced{
+	icon_state = "phoronrwindow";
+	dir = 8
+	},
+/obj/structure/window/phoronreinforced{
+	icon_state = "phoronrwindow";
+	dir = 4
+	},
+/obj/machinery/door/blast/regular{
+	dir = 4;
+	id = "SupermatterPort";
+	layer = 3.3;
+	name = "Reactor Blast Door"
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"bs" = (
+/obj/machinery/door/airlock/hatch{
+	icon_state = "door_locked";
+	id_tag = "engine_access_hatch";
+	locked = 1;
+	req_access = list(11)
+	},
+/turf/simulated/floor/reinforced,
+/area/engineering/engine_room)
+"bt" = (
+/obj/structure/grille,
+/obj/structure/window/phoronreinforced,
+/obj/structure/window/phoronreinforced{
+	icon_state = "phoronrwindow";
+	dir = 1
+	},
+/obj/structure/window/phoronreinforced{
+	icon_state = "phoronrwindow";
+	dir = 8
+	},
+/obj/structure/window/phoronreinforced{
+	icon_state = "phoronrwindow";
+	dir = 4
+	},
+/obj/machinery/door/blast/regular{
+	dir = 4;
+	id = "SupermatterPort";
+	layer = 3.3;
+	name = "Reactor Blast Door"
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"bu" = (
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 6
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/machinery/button/remote/blast_door{
+	desc = "A remote control-switch for the engine control room blast doors.";
+	id = "EngineBlast";
+	name = "Engine Monitoring Room Blast Doors";
+	pixel_x = -25;
+	pixel_y = 5;
+	req_access = list(10)
+	},
+/obj/machinery/button/remote/blast_door{
+	desc = "A remote control-switch for the engine charging port.";
+	id = "SupermatterPort";
+	name = "Reactor Blast Doors";
+	pixel_x = -25;
+	pixel_y = -5;
+	req_access = list(10)
+	},
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube1";
+	pixel_y = 0
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"bv" = (
+/obj/machinery/atmospherics/pipe/manifold/visible/yellow{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"bw" = (
+/obj/machinery/atmospherics/omni/atmos_filter,
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"bx" = (
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 10
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"by" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"bz" = (
+/turf/simulated/floor,
+/area/template_noop)
+"bA" = (
+/obj/item/weapon/book/manual/supermatter_engine,
+/turf/template_noop,
+/area/template_noop)
+"bB" = (
+/obj/machinery/computer/general_air_control/supermatter_core{
+	dir = 1;
+	frequency = 1438;
+	input_tag = "cooling_in";
+	name = "Engine Cooling Control";
+	output_tag = "cooling_out";
+	pressure_setting = 100;
+	sensors = list("engine_sensor" = "Engine Core");
+	throwpass = 1
+	},
+/turf/template_noop,
+/area/template_noop)
+"bC" = (
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 8
+	},
+/obj/machinery/button/remote/blast_door{
+	desc = "A remote control-switch for the engine radiator viewport shutters.";
+	id = "EngineRadiatorViewport";
+	name = "Engine Radiator Viewport Shutters";
+	pixel_x = -25;
+	pixel_y = 0;
+	req_access = list(10)
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"bD" = (
+/obj/machinery/atmospherics/pipe/manifold/visible/yellow{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"bE" = (
+/obj/machinery/atmospherics/pipe/manifold/visible/yellow{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/machinery/meter,
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"bF" = (
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"bG" = (
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"bH" = (
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 4
+	},
+/obj/machinery/atmospherics/valve/digital{
+	dir = 2;
+	name = "Emergency Cooling Valve 1"
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"bI" = (
+/obj/machinery/atmospherics/pipe/manifold/visible/yellow,
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"bJ" = (
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"bK" = (
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/red,
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"bL" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"bM" = (
+/obj/machinery/button/remote/blast_door{
+	desc = "A remote control-switch for the engine charging port.";
+	id = "SupermatterPort";
+	name = "Reactor Blast Doors";
+	pixel_x = -6;
+	pixel_y = 7;
+	req_access = list(10)
+	},
+/obj/machinery/button/remote/emitter{
+	desc = "A remote control-switch for the engine emitter.";
+	id = "EngineEmitter";
+	name = "Engine Emitter";
+	pixel_x = 6;
+	pixel_y = 7;
+	req_access = list(10)
+	},
+/obj/machinery/button/remote/blast_door{
+	desc = "A remote control-switch for the engine control room blast doors.";
+	id = "EngineBlast";
+	name = "Engine Monitoring Room Blast Doors";
+	pixel_x = 0;
+	pixel_y = -3;
+	req_access = list(10)
+	},
+/turf/template_noop,
+/area/template_noop)
+"bN" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 5
+	},
+/obj/structure/lattice,
+/turf/space,
+/area/space)
+"bO" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction{
+	dir = 8
+	},
+/obj/structure/lattice,
+/turf/space,
+/area/space)
+"bP" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced{
+	dir = 8;
+	health = 1e+006
+	},
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "EngineRadiatorViewport";
+	name = "Engine Radiator Viewport Shutter";
+	opacity = 0
+	},
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"bQ" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"bR" = (
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/yellow,
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"bS" = (
+/obj/machinery/atmospherics/pipe/manifold/visible/green{
+	dir = 1
+	},
+/obj/machinery/meter,
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"bT" = (
+/obj/machinery/atmospherics/pipe/manifold/visible/green{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"bU" = (
+/obj/machinery/atmospherics/pipe/manifold/visible/green,
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"bV" = (
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"bW" = (
+/obj/machinery/atmospherics/pipe/manifold/visible/green{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning/corner,
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"bX" = (
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	dir = 10;
+	icon_state = "intact"
+	},
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"bY" = (
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"bZ" = (
+/obj/machinery/atmospherics/pipe/simple/visible/red{
+	icon_state = "intact";
+	dir = 6
+	},
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"ca" = (
+/obj/machinery/atmospherics/pipe/manifold/visible/red{
+	icon_state = "map";
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"cb" = (
+/obj/machinery/atmospherics/pipe/simple/visible/yellow,
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"cc" = (
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/structure/cable/yellow,
+/obj/machinery/power/sensor{
+	name = "Powernet Sensor - Engine Output";
+	name_tag = "Engine Output"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"ce" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced{
+	dir = 8;
+	health = 1e+006
+	},
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "EngineRadiatorViewport";
+	name = "Engine Radiator Viewport Shutter";
+	opacity = 0
+	},
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"cf" = (
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	dir = 10
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"cg" = (
+/obj/machinery/atmospherics/binary/pump,
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"ch" = (
+/obj/machinery/atmospherics/binary/pump{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"ci" = (
+/obj/machinery/atmospherics/pipe/simple/visible/green,
+/obj/effect/floor_decal/industrial/warning{
+	icon_state = "warning";
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"cj" = (
+/obj/machinery/atmospherics/binary/circulator{
+	anchored = 1;
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"ck" = (
+/obj/machinery/power/generator{
+	anchored = 1;
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"cl" = (
+/obj/machinery/atmospherics/binary/circulator{
+	anchored = 1
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"cm" = (
+/obj/machinery/atmospherics/pipe/simple/visible/red,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"cn" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"co" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 10
+	},
+/obj/structure/lattice,
+/turf/space,
+/area/space)
+"cp" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced{
+	dir = 8;
+	health = 1e+006
+	},
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "EngineRadiatorViewport";
+	name = "Engine Radiator Viewport Shutter";
+	opacity = 0
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"cq" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/machinery/atmospherics/binary/pump/high_power,
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"cr" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"cs" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/outline/blue,
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"ct" = (
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	dir = 6
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"cu" = (
+/obj/machinery/atmospherics/pipe/simple/visible/green,
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"cv" = (
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	dir = 9
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"cw" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"cx" = (
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 5
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"cy" = (
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/red,
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"cz" = (
+/obj/machinery/atmospherics/pipe/manifold/visible/yellow{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"cA" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"cB" = (
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	dir = 5
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"cC" = (
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"cD" = (
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	dir = 4
+	},
+/obj/machinery/meter,
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"cE" = (
+/obj/machinery/atmospherics/pipe/manifold/visible/cyan{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"cF" = (
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	icon_state = "intact";
+	dir = 5
+	},
+/obj/effect/floor_decal/industrial/warning/corner,
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"cG" = (
+/obj/machinery/atmospherics/pipe/manifold/visible/red{
+	icon_state = "map";
+	dir = 4
+	},
+/obj/machinery/meter,
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"cH" = (
+/obj/machinery/atmospherics/pipe/simple/visible/yellow,
+/obj/machinery/meter,
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"cI" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/camera/network/engine{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	layer = 3.3;
+	pixel_x = 26
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"cJ" = (
+/turf/simulated/wall/r_wall,
+/area/engineering/engine_gas)
+"cK" = (
+/turf/simulated/floor,
+/area/engineering/engine_gas)
+"cL" = (
+/obj/effect/floor_decal/industrial/warning/corner,
+/obj/machinery/button/remote/blast_door{
+	desc = "A remote control-switch for the engine control room blast doors.";
+	id = "EngineEmitterPortWest";
+	name = "Engine Room Blast Doors";
+	pixel_x = 0;
+	pixel_y = -25;
+	req_access = null;
+	req_one_access = list(11,24)
+	},
+/obj/machinery/camera/network/engine{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/engineering/engine_gas)
+"cM" = (
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor,
+/area/engineering/engine_gas)
+"cN" = (
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/engineering/engine_gas)
+"cO" = (
+/obj/machinery/atmospherics/pipe/simple/visible/cyan,
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"cP" = (
+/obj/effect/floor_decal/industrial/warning{
+	icon_state = "warning";
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"cQ" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/airlock_sensor/airlock_interior{
+	id_tag = "eng_al_int_snsr";
+	master_tag = "engine_room_airlock";
+	pixel_x = 22;
+	pixel_y = 0;
+	req_access = list(10)
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"cR" = (
+/obj/machinery/door/blast/regular{
+	dir = 4;
+	icon_state = "pdoor1";
+	id = "EngineEmitterPortWest";
+	layer = 3.3;
+	name = "Engine Gas Storage"
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor,
+/area/engineering/engine_gas)
+"cS" = (
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	dir = 5
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"cT" = (
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"cU" = (
+/obj/machinery/atmospherics/pipe/manifold/visible/cyan{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"cV" = (
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 9
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"cW" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"cX" = (
+/turf/simulated/floor/plating,
+/area/template_noop)
+"cY" = (
+/obj/effect/floor_decal/industrial/outline/blue,
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/turf/simulated/floor,
+/area/engineering/engine_gas)
+"cZ" = (
+/obj/effect/floor_decal/industrial/outline/blue,
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/obj/machinery/button/remote/blast_door{
+	desc = "A remote control-switch for the engine control room blast doors.";
+	id = "EngineEmitterPortWest";
+	name = "Engine Room Blast Doors";
+	pixel_x = 0;
+	pixel_y = 25;
+	req_access = null;
+	req_one_access = list(11,24)
+	},
+/turf/simulated/floor,
+/area/engineering/engine_gas)
+"da" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/obj/structure/extinguisher_cabinet{
+	dir = 1;
+	icon_state = "extinguisher_closed";
+	pixel_y = 32
+	},
+/turf/simulated/floor,
+/area/engineering/engine_gas)
+"db" = (
+/obj/effect/floor_decal/industrial/warning/corner,
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"dc" = (
+/obj/machinery/button/remote/blast_door{
+	id = "EngineVent";
+	name = "Reactor Ventillatory Control";
+	pixel_x = 0;
+	pixel_y = -25;
+	req_access = list(10)
+	},
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"dd" = (
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	dir = 5
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"de" = (
+/obj/machinery/atmospherics/valve/digital{
+	dir = 4;
+	name = "Emergency Cooling Valve 2"
+	},
+/obj/machinery/light,
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"df" = (
+/obj/machinery/atmospherics/pipe/simple/visible/red{
+	icon_state = "intact";
+	dir = 4
+	},
+/obj/machinery/alarm{
+	dir = 1;
+	icon_state = "alarm0";
+	pixel_y = -22
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"dg" = (
+/obj/machinery/atmospherics/pipe/simple/visible/red{
+	icon_state = "intact";
+	dir = 9
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"dh" = (
+/obj/item/device/radio/intercom{
+	dir = 2;
+	pixel_y = -24
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"di" = (
+/obj/effect/floor_decal/industrial/outline/blue,
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/obj/machinery/camera/network/engineering{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/engineering/engine_gas)
+"dj" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/engineering/engine_gas)
+"dk" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/turf/simulated/floor,
+/area/engineering/engine_gas)
+"dl" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_y = 0
+	},
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 25;
+	pixel_y = 0
+	},
+/turf/simulated/floor,
+/area/engineering/engine_gas)
+"dm" = (
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'HIGH VOLTAGE'";
+	icon_state = "shock";
+	name = "HIGH VOLTAGE";
+	pixel_y = 0
+	},
+/turf/simulated/wall/r_wall,
+/area/engineering/engine_room)
+"dn" = (
+/obj/effect/floor_decal/industrial/outline/blue,
+/obj/machinery/portable_atmospherics/canister/phoron,
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_x = 0
+	},
+/turf/simulated/floor,
+/area/engineering/engine_gas)
+"do" = (
+/obj/effect/floor_decal/industrial/outline/blue,
+/obj/machinery/portable_atmospherics/canister/phoron,
+/turf/simulated/floor,
+/area/engineering/engine_gas)
+"dp" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/engineering/engine_gas)
+"dq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/turf/simulated/floor,
+/area/engineering/engine_gas)
+"dr" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 28
+	},
+/obj/structure/closet/radiation,
+/obj/item/clothing/glasses/meson,
+/obj/item/clothing/glasses/meson,
+/turf/simulated/floor,
+/area/engineering/engine_gas)
+"ds" = (
+/obj/effect/floor_decal/industrial/outline/blue,
+/obj/machinery/portable_atmospherics/canister/phoron,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/turf/simulated/floor,
+/area/engineering/engine_gas)
+"dt" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/industrial/warning/corner,
+/turf/simulated/floor,
+/area/engineering/engine_gas)
+"du" = (
+/obj/effect/floor_decal/rust,
+/obj/effect/floor_decal/industrial/warning,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor,
+/area/engineering/engine_gas)
+"dv" = (
+/obj/effect/floor_decal/industrial/warning,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/button/remote/blast_door{
+	desc = "A remote control-switch for the engine control room blast doors.";
+	id = "EngineEmitterPortWest2";
+	name = "Engine Room Blast Doors";
+	pixel_x = 25;
+	pixel_y = 0;
+	req_access = null;
+	req_one_access = list(11,24)
+	},
+/turf/simulated/floor,
+/area/engineering/engine_gas)
+"dw" = (
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'RADIOACTIVE AREA'";
+	icon_state = "radiation";
+	name = "RADIOACTIVE AREA";
+	pixel_x = 0;
+	pixel_y = 0
+	},
+/turf/simulated/wall/r_wall,
+/area/template_noop)
+"dx" = (
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/blast/regular{
+	dir = 4;
+	icon_state = "pdoor1";
+	id = "EngineEmitterPortWest2";
+	layer = 3.3;
+	name = "Engine Gas Storage"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/steel_grid,
+/area/template_noop)
+"dy" = (
+/obj/machinery/door/firedoor/glass,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/blast/regular{
+	dir = 4;
+	icon_state = "pdoor1";
+	id = "EngineEmitterPortWest2";
+	layer = 3.3;
+	name = "Engine Gas Storage"
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/template_noop)
 
 (1,1,1) = {"
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaabababababababababababababababababababababababababababaaaa
-aaacacacacacadacacacacacabababacacacacacacadacacacacacacaaaa
-aaacababababadabababadacabababacababadababadababadabababaaaa
-aaacabaeafafagafafahadacabababacaeafagafaiajakafagafahabaaaa
-aaadadalamagagagaganadadabababadaoafagafaiapakafagafaqabaaaa
-aaacabaraoafagafafahadacabababacaeafagafaiapakafagafahabaaaa
-aaacadalamagagagaganadacabababacaoafagafaiapakafagafaqabaaaa
-aaacabaraoafagafafahadacabababasasasasasatauasasasavavavaaaa
-aaacadalamagagagaganadacabababasawaxayazaAaBaCaDaEavaaaaaaaa
-aaacabaraoafagafafahadatasaFasasaGaCaHazaAaIaJaDaKavaaaaaaaa
-aaacadalamagagagaganadasaLaMaNaOaPaQaRaSaSaSaTaEaUaVaaaaaaaa
-aaacabaraoafagafafahadasaWaXaYaZbabbbcbdbdbdbebfbgaVaaaaaaaa
-aaacadalamagagagaganadasbhbibjbkblbmbnboaEaEbpaEbqavavavaaaa
-aaacabaraoafagafafahasasbrbsbtasbubvbwbwbxaEbpaEbybzbAbBaaaa
-aaadadalamagagagaganasbCbDbEbFbGbHbIbIbIbIbJbKbxbLbzaaaaaaaa
-aaadadalbNagagagagbObPbQbRbRbSbTbUbVbWbXbYbZcacbccaaaabMaaaa
-aaacabaraeafagafafaicecfcgchchcgaEaEcicjckclcmcbcnbzaaaaaaaa
-aaacadalbNagagagagcocpcqcrcscscraEctcucvcwcxcyczcAbzaaaaaaaa
-aaacabaraeafagafafaqatcBcCcCcDcCcCcEcFbXbYbZcGcHcIavavavaaaa
-aaacadalbNagagagagcocJcKcLcMcMcNcKcOcPcjckclcmcbcQavaaaaaaaa
-aaacabaraeafagafafaqcJcJcJcRcRcJcJcScTcUcwcxcycVcWcXaaaaaaaa
-aaacadalbNagagagagcocJcYcZcKcKdacJdbdcdddedfdgaEdhavaaaaaaaa
-aaacabaraeafagafafaqcJdicYdjdkdlcJasasasdmasasasasavavavaaaa
-aaacadalbNagagagagcocJdndodpdqdrcJaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaacabaraeafagafafaqcJdodsdtdudvcJaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaadadalbNagagagagcocJcJcJdwdxdyavaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaacabaoafafagafafaqaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(2,1,1) = {"
+aa
+aa
+ab
+ac
+ac
+ac
+ad
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ad
+ad
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ad
+ac
+aa
+"}
+(3,1,1) = {"
+aa
+aa
+ab
+ac
+ab
+ab
+ad
+ab
+ad
+ab
+ad
+ab
+ad
+ab
+ad
+ab
+ad
+ad
+ab
+ad
+ab
+ad
+ab
+ad
+ab
+ad
+ab
+ad
+ab
+aa
+"}
+(4,1,1) = {"
+aa
+aa
+ab
+ac
+ab
+ae
+al
+ar
+al
+ar
+al
+ar
+al
+ar
+al
+ar
+al
+al
+ar
+al
+ar
+al
+ar
+al
+ar
+al
+ar
+al
+ao
+aa
+"}
+(5,1,1) = {"
+aa
+aa
+ab
+ac
+ab
+af
+am
+ao
+am
+ao
+am
+ao
+am
+ao
+am
+ao
+am
+bN
+ae
+bN
+ae
+bN
+ae
+bN
+ae
+bN
+ae
+bN
+af
+aa
+"}
+(6,1,1) = {"
+aa
+aa
+ab
+ac
+ab
+af
+ag
+af
+ag
+af
+ag
+af
+ag
+af
+ag
+af
+ag
+ag
+af
+ag
+af
+ag
+af
+ag
+af
+ag
+af
+ag
+af
+aa
+"}
+(7,1,1) = {"
+aa
+aa
+ab
+ad
+ad
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+aa
+"}
+(8,1,1) = {"
+aa
+aa
+ab
+ac
+ab
+af
+ag
+af
+ag
+af
+ag
+af
+ag
+af
+ag
+af
+ag
+ag
+af
+ag
+af
+ag
+af
+ag
+af
+ag
+af
+ag
+af
+aa
+"}
+(9,1,1) = {"
+aa
+aa
+ab
+ac
+ab
+af
+ag
+af
+ag
+af
+ag
+af
+ag
+af
+ag
+af
+ag
+ag
+af
+ag
+af
+ag
+af
+ag
+af
+ag
+af
+ag
+af
+aa
+"}
+(10,1,1) = {"
+aa
+aa
+ab
+ac
+ab
+ah
+an
+ah
+an
+ah
+an
+ah
+an
+ah
+an
+ah
+an
+bO
+ai
+co
+aq
+co
+aq
+co
+aq
+co
+aq
+co
+aq
+aa
+"}
+(11,1,1) = {"
+aa
+aa
+ab
+ac
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+as
+as
+bP
+ce
+cp
+at
+cJ
+cJ
+cJ
+cJ
+cJ
+cJ
+cJ
+aa
+aa
+"}
+(12,1,1) = {"
+aa
+aa
+ab
+ac
+ac
+ac
+ad
+ac
+ac
+ac
+ac
+at
+as
+as
+as
+as
+bC
+bQ
+cf
+cq
+cB
+cK
+cJ
+cY
+di
+dn
+do
+cJ
+aa
+aa
+"}
+(13,1,1) = {"
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+as
+aL
+aW
+bh
+br
+bD
+bR
+cg
+cr
+cC
+cL
+cJ
+cZ
+cY
+do
+ds
+cJ
+aa
+aa
+"}
+(14,1,1) = {"
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+aF
+aM
+aX
+bi
+bs
+bE
+bR
+ch
+cs
+cC
+cM
+cR
+cK
+dj
+dp
+dt
+dw
+aa
+aa
+"}
+(15,1,1) = {"
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+as
+aN
+aY
+bj
+bt
+bF
+bS
+ch
+cs
+cD
+cM
+cR
+cK
+dk
+dq
+du
+dx
+aa
+aa
+"}
+(16,1,1) = {"
+aa
+aa
+ab
+ac
+ac
+ac
+ad
+ac
+ac
+as
+as
+as
+aO
+aZ
+bk
+as
+bG
+bT
+cg
+cr
+cC
+cN
+cJ
+da
+dl
+dr
+dv
+dy
+aa
+aa
+"}
+(17,1,1) = {"
+aa
+aa
+ab
+ac
+ab
+ae
+ao
+ae
+ao
+as
+aw
+aG
+aP
+ba
+bl
+bu
+bH
+bU
+aE
+aE
+cC
+cK
+cJ
+cJ
+cJ
+cJ
+cJ
+av
+aa
+aa
+"}
+(18,1,1) = {"
+aa
+aa
+ab
+ac
+ab
+af
+af
+af
+af
+as
+ax
+aC
+aQ
+bb
+bm
+bv
+bI
+bV
+aE
+ct
+cE
+cO
+cS
+db
+as
+aa
+aa
+aa
+aa
+aa
+"}
+(19,1,1) = {"
+aa
+aa
+ab
+ac
+ad
+ag
+ag
+ag
+ag
+as
+ay
+aH
+aR
+bc
+bn
+bw
+bI
+bW
+ci
+cu
+cF
+cP
+cT
+dc
+as
+aa
+aa
+aa
+aa
+aa
+"}
+(20,1,1) = {"
+aa
+aa
+ab
+ac
+ab
+af
+af
+af
+af
+as
+az
+az
+aS
+bd
+bo
+bw
+bI
+bX
+cj
+cv
+bX
+cj
+cU
+dd
+as
+aa
+aa
+aa
+aa
+aa
+"}
+(21,1,1) = {"
+aa
+aa
+ab
+ac
+ab
+ai
+ai
+ai
+ai
+at
+aA
+aA
+aS
+bd
+aE
+bx
+bI
+bY
+ck
+cw
+bY
+ck
+cw
+de
+dm
+aa
+aa
+aa
+aa
+aa
+"}
+(22,1,1) = {"
+aa
+aa
+ab
+ad
+ad
+aj
+ap
+ap
+ap
+au
+aB
+aI
+aS
+bd
+aE
+aE
+bJ
+bZ
+cl
+cx
+bZ
+cl
+cx
+df
+as
+aa
+aa
+aa
+aa
+aa
+"}
+(23,1,1) = {"
+aa
+aa
+ab
+ac
+ab
+ak
+ak
+ak
+ak
+as
+aC
+aJ
+aT
+be
+bp
+bp
+bK
+ca
+cm
+cy
+cG
+cm
+cy
+dg
+as
+aa
+aa
+aa
+aa
+aa
+"}
+(24,1,1) = {"
+aa
+aa
+ab
+ac
+ab
+af
+af
+af
+af
+as
+aD
+aD
+aE
+bf
+aE
+aE
+bx
+cb
+cb
+cz
+cH
+cb
+cV
+aE
+as
+aa
+aa
+aa
+aa
+aa
+"}
+(25,1,1) = {"
+aa
+aa
+ab
+ac
+ad
+ag
+ag
+ag
+ag
+as
+aE
+aK
+aU
+bg
+bq
+by
+bL
+cc
+cn
+cA
+cI
+cQ
+cW
+dh
+as
+aa
+aa
+aa
+aa
+aa
+"}
+(26,1,1) = {"
+aa
+aa
+ab
+ac
+ab
+af
+af
+af
+af
+av
+av
+av
+aV
+aV
+av
+bz
+bz
+aa
+bz
+bz
+av
+av
+cX
+av
+av
+aa
+aa
+aa
+aa
+aa
+"}
+(27,1,1) = {"
+aa
+aa
+ab
+ac
+ab
+ah
+aq
+ah
+aq
+av
+aa
+aa
+aa
+aa
+av
+bA
+aa
+aa
+aa
+aa
+av
+aa
+aa
+aa
+av
+aa
+aa
+aa
+aa
+aa
+"}
+(28,1,1) = {"
+aa
+aa
+ab
+ac
+ab
+ab
+ab
+ab
+ab
+av
+aa
+aa
+aa
+aa
+av
+bB
+aa
+bM
+aa
+aa
+av
+aa
+aa
+aa
+av
+aa
+aa
+aa
+aa
+aa
+"}
+(29,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(30,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 "}

--- a/maps/tether/tether-01-surface1.dmm
+++ b/maps/tether/tether-01-surface1.dmm
@@ -28176,9 +28176,6 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/techfloor/hole,
-/obj/machinery/camera/network/civilian{
-	dir = 9
-	},
 /turf/simulated/floor/tiled/techfloor,
 /area/tether/surfacebase/public_garden_one)
 "pxT" = (

--- a/maps/tether/tether-01-surface1.dmm
+++ b/maps/tether/tether-01-surface1.dmm
@@ -7919,13 +7919,13 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/atrium_one)
 "aue" = (
@@ -12024,6 +12024,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled,
 /area/storage/surface_eva)
 "aCl" = (
@@ -28017,6 +28018,16 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/public_garden_one)
+"mZP" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/atrium_one)
 "ncL" = (
 /obj/machinery/door/airlock/multi_tile/glass{
 	name = "Public Gardens"
@@ -28165,6 +28176,9 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/techfloor/hole,
+/obj/machinery/camera/network/civilian{
+	dir = 9
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/tether/surfacebase/public_garden_one)
 "pxT" = (
@@ -34449,7 +34463,7 @@ ako
 aoo
 ako
 apv
-ako
+aiE
 ako
 ako
 ako
@@ -40260,6 +40274,11 @@ agM
 aic
 axT
 aAq
+aKA
+aBz
+aBz
+aBz
+aBz
 aBz
 aBz
 aBz
@@ -40268,11 +40287,6 @@ aBz
 aBz
 aBz
 aKA
-aBz
-aBz
-aBz
-aBz
-aBz
 aBz
 aBz
 aBz
@@ -42248,19 +42262,19 @@ agM
 awo
 ayl
 ajV
-ajV
-ajV
-ajV
-ajV
-ajV
-ajV
-ajV
 aoc
+ajV
+ajV
+ajV
+ajV
+ajV
+ajV
+ajV
 ajV
 ape
 apJ
 ark
-asB
+mZP
 asB
 ats
 ava

--- a/maps/tether/tether-02-surface2.dmm
+++ b/maps/tether/tether-02-surface2.dmm
@@ -6034,6 +6034,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/techmaint,
 /area/tether/surfacebase/atrium_two)
 "nb" = (
@@ -10411,6 +10412,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled,
 /area/engineering/atmos/hallway)
 "uE" = (
@@ -11289,17 +11291,12 @@
 /turf/simulated/floor/tiled,
 /area/engineering/atmos/monitoring)
 "vJ" = (
+/obj/machinery/hologram/holopad,
 /obj/effect/floor_decal/steeldecal/steel_decals5{
 	dir = 4
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals5{
 	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/atmos/monitoring)
@@ -12602,6 +12599,7 @@
 	pixel_x = -22;
 	pixel_y = 0
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled,
 /area/engineering/lower/atmos_lockers)
 "xW" = (
@@ -12679,6 +12677,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled,
 /area/engineering/atmos/hallway)
 "ye" = (
@@ -16191,6 +16190,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled,
 /area/tcommsat/entrance{
 	name = "\improper Telecomms Entrance"
@@ -17624,6 +17624,13 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/public_garden_two)
+"IQ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/techmaint,
+/area/tether/surfacebase/atrium_two)
 "IT" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1;
@@ -17684,6 +17691,12 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/public_garden_two)
+"Lf" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/techmaint,
+/area/tether/surfacebase/atrium_two)
 "Lp" = (
 /obj/structure/frame{
 	anchored = 1
@@ -17734,6 +17747,9 @@
 /obj/effect/floor_decal/corner/lime/border{
 	dir = 9
 	},
+/obj/machinery/camera/network/civilian{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/public_garden_two)
 "Na" = (
@@ -17743,7 +17759,6 @@
 /obj/effect/floor_decal/corner/lime/border{
 	dir = 9
 	},
-/obj/machinery/camera/network/civilian,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/public_garden_two)
 "Nf" = (
@@ -17911,6 +17926,10 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/public_garden_two)
+"Qx" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/carpet,
+/area/engineering/lower/breakroom)
 "Qz" = (
 /obj/structure/table/marble,
 /turf/simulated/floor/tiled,
@@ -18127,6 +18146,9 @@
 	},
 /obj/effect/floor_decal/corner/lime/border{
 	dir = 6
+	},
+/obj/machinery/camera/network/civilian{
+	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/public_garden_two)
@@ -27675,7 +27697,7 @@ Cx
 CF
 CR
 Dd
-AB
+Bh
 AB
 Eg
 yW
@@ -29488,7 +29510,7 @@ jB
 jB
 jB
 jB
-jB
+Lf
 mV
 jR
 nZ
@@ -30175,7 +30197,7 @@ dY
 dY
 dY
 fg
-fG
+mQ
 fY
 gj
 gw
@@ -30632,7 +30654,7 @@ oK
 px
 ql
 ql
-px
+Qx
 su
 tq
 tt
@@ -32311,7 +32333,7 @@ gm
 gy
 gm
 gm
-gm
+IQ
 gm
 gm
 gm

--- a/maps/tether/tether-03-surface3.dmm
+++ b/maps/tether/tether-03-surface3.dmm
@@ -15095,6 +15095,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled,
 /area/hydroponics)
 "AI" = (
@@ -19867,7 +19868,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/steel_grid,
 /area/assembly/robotics)
 "If" = (
@@ -21367,6 +21367,10 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/public_garden_three)
+"Lt" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled,
+/area/rnd/rdoffice)
 "LP" = (
 /obj/structure/extinguisher_cabinet{
 	dir = 8;
@@ -21450,6 +21454,16 @@
 	},
 /turf/simulated/floor/wood,
 /area/tether/surfacebase/bar_backroom)
+"MK" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled,
+/area/hallway/lower/third_south)
 "MO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -21654,6 +21668,19 @@
 /obj/structure/cable/green,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/barrestroom)
+"OS" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/atrium_three)
 "OV" = (
 /obj/structure/table/woodentable,
 /obj/machinery/firealarm{
@@ -21804,6 +21831,14 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/tether/surfacebase/public_garden_three)
+"QE" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled,
+/area/rnd/reception_desk)
+"QH" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/wood,
+/area/rnd/breakroom)
 "QN" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/lightgrey/border,
@@ -22156,6 +22191,21 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/public_garden_three)
+"Vg" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/reading_room)
 "Vi" = (
 /obj/structure/closet/gmcloset{
 	icon_closed = "black";
@@ -22186,6 +22236,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/public_garden_three)
+"Vu" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/steel_grid,
+/area/assembly/robotics)
 "VF" = (
 /obj/machinery/light{
 	dir = 1
@@ -22223,6 +22280,10 @@
 "VW" = (
 /turf/simulated/floor/wood,
 /area/tether/surfacebase/bar_backroom)
+"Wh" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lobby)
 "Ws" = (
 /obj/structure/table/bench/wooden,
 /turf/simulated/floor/grass,
@@ -22374,7 +22435,7 @@
 /area/tether/surfacebase/atrium_three)
 "Yz" = (
 /obj/item/device/radio/intercom{
-	broadcasting = 1;
+	broadcasting = 0;
 	dir = 8;
 	listening = 1;
 	name = "Common Channel";
@@ -22499,6 +22560,12 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/barrestroom)
+"ZP" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/steel_grid,
+/area/assembly/robotics)
 "ZQ" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 9
@@ -30110,7 +30177,7 @@ ac
 tC
 tU
 tU
-tU
+QH
 tU
 vS
 tU
@@ -30414,7 +30481,7 @@ EO
 FO
 Gz
 Hl
-HC
+Lt
 HC
 HC
 Ix
@@ -31263,7 +31330,7 @@ Dd
 DB
 Em
 ET
-FT
+ZP
 FT
 Ho
 HH
@@ -31820,7 +31887,7 @@ ux
 ud
 xa
 xN
-ys
+QE
 zb
 zI
 As
@@ -32261,7 +32328,7 @@ FX
 GG
 Da
 HO
-If
+Vu
 Io
 IJ
 Da
@@ -33535,7 +33602,7 @@ Dj
 DJ
 yx
 Fj
-Gb
+MK
 wf
 AO
 HT
@@ -33830,7 +33897,7 @@ yG
 yG
 yG
 Jl
-yG
+Kc
 yG
 yG
 yG
@@ -34513,7 +34580,7 @@ lY
 lY
 uI
 vk
-ka
+OS
 wm
 wJ
 wJ
@@ -35053,7 +35120,7 @@ ec
 eJ
 fz
 gk
-gX
+Wh
 hK
 ig
 jd
@@ -35665,7 +35732,7 @@ ya
 DR
 wR
 Fx
-Gb
+MK
 GT
 ts
 ac
@@ -37321,7 +37388,7 @@ bt
 cg
 cT
 cg
-eh
+Vg
 eR
 be
 gs

--- a/maps/tether/tether-05-station1.dmm
+++ b/maps/tether/tether-05-station1.dmm
@@ -7938,6 +7938,7 @@
 /turf/simulated/floor/tiled,
 /area/bridge_hallway)
 "axf" = (
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/monotile,
 /area/bridge_hallway)
 "axg" = (
@@ -14324,6 +14325,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled,
 /area/holodeck_control)
 "aXy" = (
@@ -21877,6 +21879,31 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/station/pathfinder_office)
+"mlD" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled,
+/area/hallway/station/docks)
+"mrA" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/monotile,
+/area/bridge_hallway)
 "mtd" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/folder/yellow,
@@ -22063,6 +22090,17 @@
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled,
 /area/tether/station/explorer_prep)
+"okw" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/purple/border{
+	icon_state = "bordercolor";
+	dir = 1
+	},
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled,
+/area/tether/station/explorer_meeting)
 "oEH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
@@ -22217,6 +22255,12 @@
 /obj/machinery/camera/network/northern_star,
 /turf/simulated/floor/tiled,
 /area/tether/station/excursion_dock)
+"rBx" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled,
+/area/tether/station/dock_two)
 "rRn" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 1
@@ -22464,6 +22508,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/tether/station/pathfinder_office)
+"vGZ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled,
+/area/tether/station/dock_one)
 "vIv" = (
 /obj/structure/table/bench/padded,
 /obj/item/device/radio/intercom{
@@ -28173,7 +28223,7 @@ aFW
 aGz
 aDF
 aHt
-aDF
+vGZ
 aEl
 aEN
 aIy
@@ -29439,7 +29489,7 @@ axR
 azM
 aws
 aBa
-btu
+mlD
 aBZ
 aCJ
 aaa
@@ -31013,7 +31063,7 @@ aGb
 aGF
 aDK
 aHw
-aDK
+rBx
 aEn
 aEO
 aFt
@@ -33418,7 +33468,7 @@ bsN
 bsN
 bwn
 bxY
-bsN
+mrA
 bsN
 bBK
 bEN
@@ -36222,7 +36272,7 @@ ygn
 fpA
 pAD
 vEZ
-uDP
+okw
 mId
 wrg
 flX

--- a/maps/tether/tether-06-station2.dmm
+++ b/maps/tether/tether-06-station2.dmm
@@ -3427,6 +3427,12 @@
 /obj/effect/floor_decal/techfloor{
 	dir = 10
 	},
+/obj/machinery/turretid/stun{
+	control_area = "\improper AI Core Access";
+	name = "AI Core Access turret control";
+	pixel_x = -30;
+	pixel_y = 0
+	},
 /turf/simulated/floor/bluegrid,
 /area/ai_upload)
 "gn" = (
@@ -5175,6 +5181,9 @@
 /obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 9
 	},
+/obj/machinery/camera/network/northern_star{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/engineering/foyer_mezzenine)
 "kh" = (
@@ -6574,6 +6583,7 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/machinery/camera/network/northern_star,
 /turf/simulated/floor/tiled,
 /area/engineering/foyer_mezzenine)
 "mQ" = (
@@ -15302,6 +15312,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/camera/network/medbay{
+	c_tag = "MED - Chemistry";
+	dir = 8
+	},
 /turf/simulated/floor/tiled/white,
 /area/hallway/secondary/escape/medical_escape_pod_hallway)
 "AF" = (
@@ -17105,6 +17119,24 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/tether/station/public_meeting_room)
+"Gk" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled,
+/area/hallway/station/port)
 "Go" = (
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating,
@@ -17283,6 +17315,7 @@
 	pixel_x = 0;
 	pixel_y = 26
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/carpet/bcarpet,
 /area/tether/station/public_meeting_room)
 "IO" = (
@@ -17292,6 +17325,20 @@
 /obj/structure/disposalpipe/trunk,
 /turf/simulated/floor/airless,
 /area/space)
+"IR" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/lightgrey/border,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 8
+	},
+/obj/machinery/camera/network/northern_star{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/port)
 "IX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -17649,6 +17696,12 @@
 	},
 /turf/simulated/floor/bluegrid,
 /area/ai_upload)
+"Mk" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled,
+/area/hallway/station/starboard)
 "Mn" = (
 /obj/structure/table/steel,
 /turf/simulated/floor,
@@ -26480,7 +26533,7 @@ oM
 pK
 qp
 re
-rP
+IR
 sw
 tc
 sw
@@ -26621,7 +26674,7 @@ oM
 oM
 pK
 qp
-re
+Gk
 rQ
 sw
 sw
@@ -31443,7 +31496,7 @@ lm
 lR
 mw
 ne
-nM
+Mk
 ot
 oW
 ps

--- a/maps/tether/tether-07-station3.dmm
+++ b/maps/tether/tether-07-station3.dmm
@@ -2157,7 +2157,7 @@
 	pixel_x = 32
 	},
 /obj/item/device/radio/intercom{
-	broadcasting = 1;
+	broadcasting = 0;
 	dir = 8;
 	listening = 1;
 	name = "Common Channel";
@@ -18440,6 +18440,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled,
 /area/quartermaster/qm)
 "Dw" = (
@@ -21254,6 +21255,7 @@
 	dir = 5
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled,
 /area/quartermaster/warehouse)
 "Io" = (
@@ -24209,6 +24211,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/heads/cmo)
 "MS" = (
@@ -27404,6 +27407,35 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/warden)
+"RT" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
+	},
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/white,
+/area/medical/surgery_hallway)
 "Sa" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -37732,7 +37764,7 @@ MK
 Nq
 KV
 On
-OG
+RT
 Pi
 PE
 PY


### PR DESCRIPTION
Alright. Lots of tiny changes in this one.

- Adds a Turret control to the AI core, linked to the two turrets at the top of the stairs
- Sets Broadcast on the Public Garden Floor 3 intercomm to 0 (stops the mic from being on at round start)
- Adds several holopads across the station, improving coverage for the AI
- Adjusts the locations of/adds several cameras in public areas, removing inconvenient blind spots. These notably don't affect private spaces, such as the dorms/dorm hallways/laundry room
- Added a 5% increased chance of sexy AI interactions, across the board

Holopad coverage and strange camera blindspots were pointed out by Ech0 (Ismuth#3876).

Fixes #4595