### PR TITLE
Adds blacklist for item ingestion (borg and trashcanfolk)

### DIFF
--- a/code/_helpers/global_lists_vr.dm
+++ b/code/_helpers/global_lists_vr.dm
@@ -28,24 +28,17 @@ var/global/list/vantag_choices_list = list(
 		VANTAG_KIDNAP	=	"Be Kidnapped",
 		VANTAG_KILL		=	"Be Killed")
 
-/* Time to finally undo this. Replaced with digest_act on these items.
-//Important items that are preserved when people are digested, etc.
-//On Polaris, different from Cryo list as MMIs need to be removed for FBPs to be logged out.
-var/global/list/important_items = list(
+//Blacklist to exclude items from object ingestion. Digestion blacklist located in digest_act_vr.dm
+var/global/list/item_vore_blacklist = list(
 		/obj/item/weapon/hand_tele,
 		/obj/item/weapon/card/id/gold/captain/spare,
-		/obj/item/device/aicard,
-		/obj/item/device/mmi/digital/posibrain,
-		/obj/item/device/paicard,
 		/obj/item/weapon/gun,
 		/obj/item/weapon/pinpointer,
 		/obj/item/clothing/shoes/magboots,
 		/obj/item/blueprints,
 		/obj/item/clothing/head/helmet/space,
 		/obj/item/weapon/disk/nuclear,
-		/obj/item/clothing/suit/storage/hooded/wintercoat/roiz,
-		/obj/item/device/perfect_tele_beacon)
-*/
+		/obj/item/clothing/suit/storage/hooded/wintercoat/roiz)
 
 var/global/list/digestion_sounds = list(
 		'sound/vore/digest1.ogg',

--- a/code/modules/mob/living/silicon/robot/dogborg/dog_sleeper_vr.dm
+++ b/code/modules/mob/living/silicon/robot/dogborg/dog_sleeper_vr.dm
@@ -60,6 +60,9 @@
 		return
 
 	if(compactor)
+		if(is_type_in_list(target,item_vore_blacklist))
+			to_chat(user, "<span class='warning'>You are hard-wired to not ingest this item.</span>")
+			return
 		if(istype(target, /obj/item) || istype(target, /obj/effect/decal/remains))
 			var/obj/target_obj = target
 			if(target_obj.w_class > ITEMSIZE_LARGE)

--- a/code/modules/vore/eating/living_vr.dm
+++ b/code/modules/vore/eating/living_vr.dm
@@ -553,6 +553,10 @@
 		to_chat(src, "<span class='notice'>You are not holding anything.</span>")
 		return
 
+	if(is_type_in_list(I,item_vore_blacklist))
+		to_chat(src, "<span class='warning'>You are not allowed to eat this.</span>")
+		return
+
 	if(is_type_in_list(I,edible_trash))
 		if(I.hidden_uplink)
 			to_chat(src, "<span class='warning'>You really should not be eating this.</span>")


### PR DESCRIPTION
-Certain items blacklisted for digestion can still be eaten. (pAI, posibrain, AIcard, handtele beacon)
-Implemented for borg sleepers and trash eaters to prevent ABOOSE

Yeah the trasheater one is currently somewhat redundant considering it uses a whitelist, but I implemented the thing anyway in case of future additions and also to add a little more specific warning for people if they even attempt to do it on the blacklist stuff.

Fixes #4601