### PR TITLE
Rearranges Security

### DIFF
--- a/maps/tether/tether-07-station3.dmm
+++ b/maps/tether/tether-07-station3.dmm
@@ -122,14 +122,6 @@
 	},
 /turf/simulated/floor,
 /area/security/eva)
-"an" = (
-/obj/machinery/door/firedoor/glass,
-/obj/machinery/door/airlock/security{
-	name = "Security Restroom";
-	req_one_access = list(1,38)
-	},
-/turf/simulated/floor/tiled/white,
-/area/security/security_bathroom)
 "ao" = (
 /turf/simulated/wall/r_wall,
 /area/security/armory/blue)
@@ -167,20 +159,12 @@
 /turf/simulated/floor/tiled,
 /area/security/briefing_room)
 "ar" = (
-/obj/machinery/door/firedoor/glass,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/table/woodentable,
+/obj/machinery/photocopier/faxmachine{
+	department = "Head of Security"
 	},
-/obj/machinery/door/airlock/security{
-	name = "Security Restroom";
-	req_one_access = list(1,38)
-	},
-/turf/simulated/floor/tiled,
-/area/security/security_bathroom)
+/turf/simulated/floor/wood,
+/area/crew_quarters/heads/hos)
 "as" = (
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/airlock/glass_security{
@@ -222,15 +206,16 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/glass_security{
-	name = "Break Room";
-	req_one_access = list(1,38)
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/door/airlock/command{
+	id_tag = "HoSdoor";
+	name = "Head of Security";
+	req_access = list(58)
+	},
 /turf/simulated/floor/wood,
-/area/security/breakroom)
+/area/crew_quarters/heads/hos)
 "aw" = (
 /obj/machinery/door/window/northright,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -1206,6 +1191,12 @@
 	maxcharge = 15000
 	},
 /obj/machinery/light/small,
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'HIGH VOLTAGE'";
+	icon_state = "shock";
+	name = "HIGH VOLTAGE";
+	pixel_y = -32
+	},
 /turf/simulated/floor,
 /area/maintenance/substation/security)
 "bU" = (
@@ -1470,16 +1461,6 @@
 /obj/structure/closet/bombcloset/double,
 /turf/simulated/floor/tiled/dark,
 /area/security/armory/blue)
-"cn" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/red/border{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/glass,
-/turf/simulated/floor/tiled,
-/area/security/hallwayaux)
 "co" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -1496,6 +1477,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/glass_security,
 /turf/simulated/floor/tiled,
 /area/security/hallwayaux)
 "cp" = (
@@ -1504,23 +1486,10 @@
 	},
 /area/maintenance/cargo)
 "cq" = (
-/obj/machinery/door/firedoor/glass,
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
 /obj/structure/grille,
-/obj/structure/window/reinforced/polarized{
-	dir = 10;
-	icon_state = "fwindow";
-	id = "hos_office"
-	},
+/obj/structure/window/reinforced/full,
 /turf/simulated/floor,
-/area/crew_quarters/heads/hos)
+/area/security/breakroom)
 "cr" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -1533,20 +1502,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/hallwayaux)
-"cs" = (
-/obj/machinery/door/firedoor/glass,
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/structure/grille,
-/obj/structure/window/reinforced/polarized{
-	dir = 10;
-	icon_state = "fwindow";
-	id = "hos_office"
-	},
-/turf/simulated/floor,
-/area/crew_quarters/heads/hos)
 "ct" = (
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/blast/regular{
@@ -1571,16 +1526,6 @@
 "cv" = (
 /turf/simulated/wall/r_wall,
 /area/security/range)
-"cw" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/engineering{
-	name = "Security Substation";
-	req_one_access = list(1,11,24)
-	},
-/turf/simulated/floor,
-/area/maintenance/substation/security)
 "cx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -1606,14 +1551,13 @@
 /turf/simulated/floor,
 /area/maintenance/station/ai)
 "cz" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
 /obj/random/junk,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /turf/simulated/floor,
 /area/maintenance/substation/security)
 "cA" = (
@@ -1757,33 +1701,21 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/warden)
 "cO" = (
-/obj/structure/bed/chair/comfy/black{
-	dir = 8
+/obj/structure/table/woodentable,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/machinery/button/remote/blast_door{
-	id = "security_lockdown";
-	name = "Brig Lockdown";
-	pixel_x = -28;
-	pixel_y = -36;
-	req_access = list(2)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/machinery/button/remote/airlock{
-	id = "HoSdoor";
-	name = "Office Door";
-	pixel_x = -28;
-	pixel_y = -24
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/machinery/button/windowtint{
-	id = "hos_office";
-	pixel_x = -36;
-	pixel_y = -26;
-	req_access = list(58)
-	},
-/obj/effect/landmark/start{
-	name = "Head of Security"
-	},
+/obj/item/weapon/deck/cards,
 /turf/simulated/floor/carpet,
-/area/crew_quarters/heads/hos)
+/area/security/breakroom)
 "cP" = (
 /turf/simulated/wall,
 /area/security/observation)
@@ -1893,38 +1825,18 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/heads/hos)
 "da" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/table/woodentable,
+/obj/structure/bed/chair/office/dark{
+	dir = 1
+	},
 /turf/simulated/floor/carpet,
-/area/crew_quarters/heads/hos)
-"db" = (
-/obj/random/trash_pile,
-/turf/simulated/floor,
-/area/maintenance/station/sec_upper)
+/area/security/breakroom)
 "dc" = (
 /turf/simulated/floor/plating,
 /area/maintenance/station/ai)
 "dd" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor,
-/area/maintenance/station/sec_upper)
-"de" = (
-/obj/effect/floor_decal/rust,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor,
-/area/maintenance/station/sec_upper)
-"df" = (
-/obj/structure/sign/securearea{
-	desc = "A warning sign which reads 'HIGH VOLTAGE'";
-	icon_state = "shock";
-	name = "HIGH VOLTAGE";
-	pixel_y = 0
-	},
-/turf/simulated/wall,
-/area/maintenance/substation/security)
+/obj/machinery/recharge_station,
+/turf/simulated/floor/tiled/white,
+/area/security/security_bathroom)
 "dg" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 9
@@ -2006,44 +1918,36 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled,
 /area/security/hallwayaux)
-"dq" = (
-/obj/machinery/door/firedoor/glass,
-/obj/structure/cable/green,
-/obj/structure/grille,
-/obj/structure/window/reinforced/polarized{
-	dir = 10;
-	icon_state = "fwindow";
-	id = "hos_office"
+"ds" = (
+/obj/structure/bed/chair/office/dark{
+	dir = 8
 	},
-/turf/simulated/floor,
-/area/crew_quarters/heads/hos)
-"dr" = (
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/hos)
-"ds" = (
-/turf/simulated/floor/wood,
-/area/crew_quarters/heads/hos)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/carpet,
+/area/security/breakroom)
 "dt" = (
-/obj/machinery/alarm{
-	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 24
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/heads/hos)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/turf/simulated/floor/carpet,
+/area/security/breakroom)
 "du" = (
-/obj/structure/table/woodentable,
-/obj/machinery/newscaster/security_unit{
-	pixel_y = -32
+/obj/structure/disposalpipe/trunk{
+	dir = 1
 	},
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/hos)
+/obj/machinery/disposal,
+/turf/simulated/floor/wood,
+/area/security/breakroom)
 "dv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /obj/machinery/door/firedoor/glass,
@@ -2055,19 +1959,14 @@
 /obj/structure/catwalk,
 /turf/simulated/floor,
 /area/maintenance/station/sec_upper)
-"dx" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
+"dy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/catwalk,
-/turf/simulated/floor,
-/area/maintenance/station/sec_upper)
-"dy" = (
 /obj/structure/cable{
-	icon_state = "4-8"
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/obj/structure/catwalk,
 /turf/simulated/floor,
 /area/maintenance/station/sec_upper)
 "dz" = (
@@ -2079,6 +1978,10 @@
 /area/security/security_equiptment_storage)
 "dA" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/catwalk,
 /turf/simulated/floor,
 /area/maintenance/station/sec_upper)
 "dB" = (
@@ -2266,17 +2169,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/hallwayaux)
-"dN" = (
-/obj/structure/table/woodentable,
-/obj/machinery/photocopier/faxmachine{
-	department = "Head of Security"
-	},
-/obj/item/device/radio/intercom{
-	dir = 4;
-	pixel_x = 24
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/heads/hos)
 "dO" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 9
@@ -2290,12 +2182,6 @@
 /area/security/briefing_room)
 "dP" = (
 /turf/simulated/wall,
-/area/security/security_bathroom)
-"dQ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
 /area/security/security_bathroom)
 "dR" = (
 /turf/simulated/wall/r_wall,
@@ -2510,29 +2396,23 @@
 /turf/simulated/floor/tiled,
 /area/security/hallwayaux)
 "el" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/hos)
+/turf/simulated/floor/wood,
+/area/security/breakroom)
 "em" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -2543,28 +2423,12 @@
 /turf/simulated/wall,
 /area/maintenance/station/ai)
 "en" = (
-/obj/structure/table/woodentable,
-/obj/item/weapon/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
-/obj/item/weapon/folder/red_hos,
-/obj/item/weapon/pen/multi,
-/obj/item/device/radio/intercom/department/security{
-	dir = 4;
-	icon_state = "secintercom";
-	pixel_x = 24;
-	pixel_y = 0
+/obj/machinery/camera/network/security{
+	c_tag = "SEC - Vault Exterior West";
+	dir = 8
 	},
 /turf/simulated/floor/wood,
-/area/crew_quarters/heads/hos)
-"eo" = (
-/obj/machinery/light_switch{
-	dir = 1;
-	pixel_y = -24
-	},
-/turf/simulated/floor/tiled/white,
-/area/security/security_bathroom)
+/area/security/breakroom)
 "ep" = (
 /turf/simulated/wall,
 /area/security/security_lockerroom)
@@ -2600,15 +2464,11 @@
 /turf/simulated/floor,
 /area/maintenance/cargo)
 "et" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/turf/simulated/floor/wood,
-/area/security/breakroom)
+/turf/simulated/floor/carpet,
+/area/crew_quarters/heads/hos)
 "eu" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
@@ -2748,51 +2608,32 @@
 /obj/structure/window/reinforced/full,
 /turf/simulated/floor,
 /area/security/observation)
-"eE" = (
-/obj/machinery/computer/secure_data{
-	dir = 1
-	},
-/turf/simulated/floor/carpet,
-/area/crew_quarters/heads/hos)
 "eF" = (
-/obj/structure/table/woodentable,
-/obj/item/clothing/accessory/permit/gun,
-/obj/item/clothing/accessory/permit/gun,
-/obj/item/clothing/accessory/permit/gun,
-/obj/item/clothing/accessory/permit/gun,
-/obj/item/clothing/accessory/permit/gun,
-/obj/item/weapon/paper{
-	desc = "";
-	info = "In the event that more weapon permits are needed, please fax Central Command to request more. Please also include a reason for the request. Blank permits will be shipped to cargo for pickup. If long-term permits are desired, please contact your NanoTrasen Employee Representitive for more information.";
-	name = "note from CentCom about permits"
-	},
-/obj/item/weapon/storage/secure/safe{
-	pixel_x = 38;
-	pixel_y = 0
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/heads/hos)
-"eG" = (
 /obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/structure/table/woodentable,
-/obj/machinery/atmospherics/unary/vent_pump/on{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/carpet,
-/area/security/breakroom)
-"eH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/bed/chair{
-	dir = 8
-	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/wood,
 /area/security/breakroom)
+"eG" = (
+/obj/structure/table/woodentable,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/carpet,
+/area/crew_quarters/heads/hos)
+"eH" = (
+/obj/structure/table/woodentable,
+/obj/item/weapon/folder/red_hos,
+/obj/item/weapon/stamp/hos,
+/turf/simulated/floor/carpet,
+/area/crew_quarters/heads/hos)
 "eI" = (
 /obj/machinery/door/firedoor/glass,
 /obj/structure/catwalk,
@@ -2820,9 +2661,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/security_lockerroom)
-"eL" = (
-/turf/simulated/floor/tiled/white,
-/area/security/security_bathroom)
 "eM" = (
 /obj/item/weapon/coin/gold,
 /obj/item/weapon/coin/silver,
@@ -2964,17 +2802,11 @@
 /turf/simulated/floor,
 /area/security/briefing_room)
 "eY" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 28
-	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
 	},
 /turf/simulated/floor/wood,
-/area/crew_quarters/heads/hos)
+/area/security/breakroom)
 "eZ" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 5
@@ -2987,32 +2819,14 @@
 /obj/structure/table/reinforced,
 /turf/simulated/floor/tiled,
 /area/security/briefing_room)
-"fa" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/wood,
-/area/security/breakroom)
 "fb" = (
-/obj/effect/floor_decal/rust,
-/obj/structure/railing{
-	dir = 4
+/obj/machinery/light_switch{
+	dir = 4;
+	icon_state = "light1";
+	pixel_x = -24
 	},
-/obj/structure/table/rack{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/random/maintenance/security,
-/obj/random/maintenance/security,
-/obj/random/maintenance/clean,
-/turf/simulated/floor,
-/area/maintenance/station/sec_upper)
+/turf/simulated/floor/tiled/white,
+/area/security/security_bathroom)
 "fc" = (
 /obj/structure/catwalk,
 /turf/simulated/floor,
@@ -3054,10 +2868,14 @@
 /turf/simulated/floor/tiled,
 /area/security/hallway)
 "ff" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/structure/cable/green{
@@ -3065,12 +2883,8 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
 /turf/simulated/floor/wood,
-/area/security/breakroom)
+/area/crew_quarters/heads/hos)
 "fg" = (
 /obj/machinery/alarm{
 	dir = 1;
@@ -3231,13 +3045,15 @@
 /turf/simulated/floor,
 /area/maintenance/station/sec_upper)
 "fr" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_x = 0;
-	pixel_y = -24
+/obj/machinery/photocopier,
+/obj/machinery/power/apc{
+	dir = 2;
+	name = "south bump";
+	pixel_y = -28
 	},
+/obj/structure/cable/green,
 /turf/simulated/floor/wood,
-/area/security/breakroom)
+/area/crew_quarters/heads/hos)
 "fs" = (
 /obj/structure/flora/pottedplant/stoutbush,
 /turf/simulated/floor/tiled,
@@ -3391,11 +3207,19 @@
 /turf/simulated/open,
 /area/maintenance/station/ai)
 "fG" = (
-/obj/structure/railing{
-	dir = 4
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 10
 	},
-/turf/simulated/floor,
-/area/maintenance/station/sec_upper)
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 9
+	},
+/obj/machinery/shower{
+	icon_state = "shower";
+	dir = 1
+	},
+/obj/structure/curtain/open/shower/security,
+/turf/simulated/floor/tiled,
+/area/security/security_bathroom)
 "fH" = (
 /turf/simulated/wall,
 /area/security/detectives_office)
@@ -3434,6 +3258,12 @@
 /obj/structure/table/reinforced,
 /obj/machinery/computer/med_data/laptop,
 /obj/machinery/camera/network/security,
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_x = 0;
+	pixel_y = 24
+	},
 /turf/simulated/floor/tiled/white,
 /area/security/forensics)
 "fK" = (
@@ -4355,6 +4185,10 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/eva)
+"hx" = (
+/obj/structure/undies_wardrobe,
+/turf/simulated/floor/tiled/white,
+/area/security/security_bathroom)
 "hy" = (
 /turf/simulated/mineral/floor/cave,
 /area/maintenance/station/ai)
@@ -4916,10 +4750,6 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 8;
@@ -5647,60 +5477,13 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/security/hallwayaux)
-"jm" = (
-/obj/structure/disposalpipe/trunk,
-/obj/machinery/disposal,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/hos)
 "jn" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
+/obj/machinery/newscaster/security_unit{
+	pixel_y = 32
 	},
-/obj/structure/table/woodentable,
-/obj/item/weapon/reagent_containers/food/drinks/flask/barflask{
-	pixel_x = -4;
-	pixel_y = 8
-	},
-/obj/item/device/taperecorder{
-	pixel_y = 0
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/hos)
+/turf/simulated/floor/wood,
+/area/security/breakroom)
 "jo" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/structure/table/woodentable,
-/obj/item/device/radio/off,
-/obj/item/device/megaphone,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/light{
 	dir = 1
 	},
@@ -5711,19 +5494,13 @@
 	pixel_y = 26
 	},
 /turf/simulated/floor/wood,
-/area/crew_quarters/heads/hos)
+/area/security/breakroom)
 "jp" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/obj/machinery/photocopier,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+/obj/machinery/alarm{
+	pixel_y = 22
 	},
 /turf/simulated/floor/wood,
-/area/crew_quarters/heads/hos)
+/area/security/breakroom)
 "jq" = (
 /obj/machinery/space_heater,
 /turf/simulated/floor,
@@ -5856,13 +5633,13 @@
 /turf/simulated/floor/tiled,
 /area/security/hallwayaux)
 "jB" = (
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/hos)
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/carpet,
+/area/security/breakroom)
 "jC" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/wood,
-/area/crew_quarters/heads/hos)
+/obj/structure/bed/chair/office/dark,
+/turf/simulated/floor/carpet,
+/area/security/breakroom)
 "jD" = (
 /obj/random/junk,
 /turf/simulated/mineral/floor/cave,
@@ -5998,29 +5775,10 @@
 /turf/simulated/floor/carpet,
 /area/crew_quarters/heads/hos)
 "jN" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/table/woodentable,
-/obj/machinery/computer/skills{
-	icon_state = "laptop";
-	dir = 4
-	},
-/obj/item/clothing/accessory/permit/gun{
-	desc = "An example of a card indicating that the owner is allowed to carry a firearm. There's a note saying to fax CentCom if you want to order more blank permits.";
-	name = "sample weapon permit";
-	owner = 1
-	},
-/obj/item/weapon/paper{
-	desc = "";
-	info = "The Chief of Security at CentCom is debating a new policy. It's not official yet, and probably won't be since it's hard to enforce, but I suggest following it anyway. That policy is, if a security officer claims they need more than two extra magazines (or batteries) to go on routine patrols, fire them. If they cannot subdue a single suspect using all that ammo, they are not competent as Security.\[br]-Jeremiah Acacius";
-	name = "note to the Head of Security"
-	},
+/obj/item/weapon/storage/box/donut,
 /turf/simulated/floor/carpet,
-/area/crew_quarters/heads/hos)
-"jO" = (
-/obj/machinery/computer/security,
-/turf/simulated/floor/carpet,
-/area/crew_quarters/heads/hos)
+/area/security/breakroom)
 "jP" = (
 /obj/structure/table/rack{
 	dir = 4
@@ -6094,14 +5852,14 @@
 /turf/simulated/floor/tiled,
 /area/security/hallwayaux)
 "jV" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/door/airlock/glass_security{
+	name = "Break Room";
+	req_one_access = list(1,38)
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/glass,
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/structure/cable/green{
@@ -6109,41 +5867,43 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/command{
-	id_tag = "HoSdoor";
-	name = "Head of Security";
-	req_access = list(58)
-	},
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/hos)
-"jW" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/security/breakroom)
+"jW" = (
+/obj/structure/bed/chair/office/dark{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/bed/chair{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/floor/carpet,
-/area/crew_quarters/heads/hos)
+/area/security/breakroom)
 "jX" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
 /obj/structure/table/woodentable,
-/obj/item/weapon/stamp/hos,
-/obj/item/device/flashlight/lamp/green{
-	dir = 2;
-	pixel_x = -4;
-	pixel_y = 12
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/carpet,
-/area/crew_quarters/heads/hos)
+/area/security/breakroom)
 "jY" = (
 /obj/random/trash_pile,
 /turf/simulated/mineral/floor/cave,
@@ -6225,18 +5985,9 @@
 /turf/simulated/wall/r_wall,
 /area/security/armory/blue)
 "kh" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/light_switch{
-	dir = 4;
-	pixel_x = -28;
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/hos)
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/wood,
+/area/security/breakroom)
 "ki" = (
 /obj/structure/closet/crate,
 /obj/random/maintenance/clean,
@@ -6318,37 +6069,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/security/hallwayaux)
-"ks" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/hos)
-"kt" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/hos)
-"ku" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/heads/hos)
 "kv" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -6470,49 +6190,23 @@
 /turf/simulated/floor/tiled,
 /area/security/observation)
 "kF" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_y = -24
 	},
-/obj/structure/table/woodentable,
-/obj/machinery/recharger{
-	pixel_y = 4
-	},
-/obj/machinery/requests_console{
-	announcementConsole = 1;
-	department = "Head of Security's Desk";
-	departmentType = 5;
-	name = "Head of Security RC";
-	pixel_x = 0;
-	pixel_y = -32
-	},
-/obj/machinery/camera/network/security{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/heads/hos)
+/turf/simulated/floor/wood,
+/area/security/breakroom)
 "kG" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/structure/closet/secure_closet/hos2,
+/obj/structure/table/woodentable,
+/obj/machinery/chemical_dispenser/bar_soft/full,
 /obj/machinery/light,
-/obj/machinery/keycard_auth{
-	pixel_y = -28
-	},
 /turf/simulated/floor/wood,
-/area/crew_quarters/heads/hos)
+/area/security/breakroom)
 "kH" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/obj/structure/closet/secure_closet/hos,
-/obj/item/clothing/suit/space/void/security/fluff/hos,
-/obj/item/clothing/head/helmet/space/void/security/fluff/hos,
+/obj/structure/table/woodentable,
+/obj/item/weapon/storage/box/glasses/square,
 /turf/simulated/floor/wood,
-/area/crew_quarters/heads/hos)
+/area/security/breakroom)
 "kI" = (
 /obj/structure/bookcase,
 /obj/item/weapon/book/manual/security_space_law,
@@ -6520,20 +6214,6 @@
 /obj/item/weapon/book/manual/command_guide,
 /turf/simulated/floor/wood,
 /area/crew_quarters/heads/hos)
-"kJ" = (
-/obj/effect/floor_decal/steeldecal/steel_decals5,
-/obj/effect/floor_decal/steeldecal/steel_decals10{
-	dir = 5
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals10{
-	dir = 6
-	},
-/obj/machinery/shower{
-	pixel_y = 16
-	},
-/obj/structure/curtain/open/shower/security,
-/turf/simulated/floor/tiled,
-/area/security/security_bathroom)
 "kK" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
@@ -6560,6 +6240,12 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/catwalk,
 /turf/simulated/floor,
 /area/maintenance/station/sec_upper)
 "kN" = (
@@ -6629,6 +6315,10 @@
 	icon_state = "camera";
 	dir = 8
 	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
 /turf/simulated/floor/tiled,
 /area/security/hallwayaux)
 "kQ" = (
@@ -6674,23 +6364,9 @@
 	},
 /turf/simulated/floor,
 /area/maintenance/station/ai)
-"kV" = (
-/obj/machinery/recharge_station,
-/obj/machinery/light/small{
-	icon_state = "bulb1";
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/security/security_bathroom)
 "kW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
-	},
-/turf/simulated/floor/tiled/white,
-/area/security/security_bathroom)
-"kX" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
 /area/security/security_bathroom)
@@ -6765,8 +6441,10 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/glass_security,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/glass_security{
+	req_one_access = list(1,38)
+	},
 /turf/simulated/floor/tiled,
 /area/security/hallwayaux)
 "le" = (
@@ -6836,21 +6514,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/briefing_room)
-"lj" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/structure/table/rack{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/random/maintenance,
-/turf/simulated/floor,
-/area/maintenance/station/sec_upper)
 "lk" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 8
@@ -6928,34 +6591,6 @@
 	},
 /turf/simulated/floor,
 /area/maintenance/station/ai)
-"lu" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/structure/undies_wardrobe,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/security/security_bathroom)
-"lv" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/white,
-/area/security/security_bathroom)
-"lw" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/alarm{
-	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 24
-	},
-/turf/simulated/floor/tiled/white,
-/area/security/security_bathroom)
 "lx" = (
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/airlock/security{
@@ -7125,11 +6760,9 @@
 /turf/simulated/floor/tiled,
 /area/security/briefing_room)
 "lL" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/random/trash_pile,
+/obj/structure/catwalk,
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/maintenance/common,
 /turf/simulated/floor,
 /area/maintenance/station/sec_upper)
 "lM" = (
@@ -7251,37 +6884,6 @@
 "lY" = (
 /turf/space,
 /area/shuttle/antag_space/north)
-"lZ" = (
-/obj/structure/toilet{
-	dir = 4
-	},
-/obj/machinery/light/small{
-	icon_state = "bulb1";
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/security/security_bathroom)
-"ma" = (
-/obj/machinery/power/apc{
-	dir = 2;
-	name = "south bump";
-	pixel_y = -28
-	},
-/obj/structure/cable/green{
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/tiled/white,
-/area/security/security_bathroom)
-"mb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/tiled/white,
-/area/security/security_bathroom)
 "mc" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 9
@@ -7573,9 +7175,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/security_lockerroom)
 "my" = (
-/obj/structure/sign/warning/secure_area,
-/turf/simulated/wall/r_wall,
-/area/security/security_bathroom)
+/obj/structure/closet/secure_closet/hos,
+/obj/item/clothing/suit/space/void/security/fluff/hos,
+/obj/item/clothing/head/helmet/space/void/security/fluff/hos,
+/turf/simulated/floor/wood,
+/area/crew_quarters/heads/hos)
 "mz" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -7777,12 +7381,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor,
 /area/maintenance/station/sec_upper)
-"mS" = (
-/obj/structure/catwalk,
-/obj/machinery/door/firedoor/glass,
-/obj/machinery/door/airlock/maintenance/common,
-/turf/simulated/floor,
-/area/maintenance/cargo)
 "mT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/catwalk,
@@ -7846,32 +7444,6 @@
 	dir = 1;
 	icon_state = "extinguisher_closed";
 	pixel_y = 32
-	},
-/turf/simulated/floor/wood,
-/area/security/breakroom)
-"nf" = (
-/obj/machinery/camera/network/security,
-/obj/machinery/newscaster/security_unit{
-	pixel_y = 32
-	},
-/turf/simulated/floor/wood,
-/area/security/breakroom)
-"ng" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 24
-	},
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/wood,
-/area/security/breakroom)
-"nh" = (
-/obj/machinery/light{
-	dir = 1
 	},
 /turf/simulated/floor/wood,
 /area/security/breakroom)
@@ -8123,45 +7695,85 @@
 /turf/simulated/floor,
 /area/maintenance/station/ai)
 "nD" = (
-/obj/machinery/door/firedoor/glass,
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
 	},
-/obj/machinery/door/blast/regular{
-	density = 0;
-	dir = 1;
-	icon_state = "pdoor0";
+/obj/machinery/newscaster/security_unit{
+	pixel_x = -32;
+	pixel_y = 0
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/heads/hos)
+"nE" = (
+/obj/structure/table/woodentable,
+/obj/item/weapon/paper{
+	desc = "";
+	info = "The Chief of Security at CentCom is debating a new policy. It's not official yet, and probably won't be since it's hard to enforce, but I suggest following it anyway. That policy is, if a security officer claims they need more than two extra magazines (or batteries) to go on routine patrols, fire them. If they cannot subdue a single suspect using all that ammo, they are not competent as Security.\[br]-Jeremiah Acacius";
+	name = "note to the Head of Security"
+	},
+/obj/item/clothing/accessory/permit/gun{
+	desc = "An example of a card indicating that the owner is allowed to carry a firearm. There's a note saying to fax CentCom if you want to order more blank permits.";
+	name = "sample weapon permit";
+	owner = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/item/weapon/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/weapon/pen/multi,
+/turf/simulated/floor/carpet,
+/area/crew_quarters/heads/hos)
+"nF" = (
+/obj/structure/bed/chair/comfy/black,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/button/windowtint{
+	id = "hos_office";
+	pixel_x = -36;
+	pixel_y = -26;
+	req_access = list(58)
+	},
+/obj/machinery/button/remote/airlock{
+	id = "HoSdoor";
+	name = "Office Door";
+	pixel_x = -28;
+	pixel_y = -24
+	},
+/obj/machinery/button/remote/blast_door{
 	id = "security_lockdown";
-	name = "Security Blast Doors";
-	opacity = 0
+	name = "Brig Lockdown";
+	pixel_x = -28;
+	pixel_y = -36;
+	req_access = list(2)
 	},
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/structure/window/reinforced{
+/obj/effect/landmark/start{
+	name = "Head of Security"
+	},
+/turf/simulated/floor/carpet,
+/area/crew_quarters/heads/hos)
+"nG" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
-/turf/simulated/floor,
-/area/security/breakroom)
-"nE" = (
-/obj/structure/bed/chair,
-/turf/simulated/floor/carpet,
-/area/security/breakroom)
-"nF" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/item/device/radio/intercom/department/security{
+	dir = 4;
+	icon_state = "secintercom";
+	pixel_x = 24;
+	pixel_y = 0
 	},
-/obj/structure/bed/chair,
-/turf/simulated/floor/carpet,
-/area/security/breakroom)
-"nG" = (
-/obj/structure/table/steel,
-/obj/machinery/chemical_dispenser/bar_soft/full,
-/obj/item/weapon/storage/box/glasses/square,
+/obj/machinery/camera/network/security{
+	icon_state = "camera";
+	dir = 8
+	},
 /turf/simulated/floor/wood,
-/area/security/breakroom)
+/area/crew_quarters/heads/hos)
 "nH" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
@@ -8341,59 +7953,39 @@
 /turf/simulated/floor,
 /area/maintenance/station/ai)
 "nW" = (
-/obj/machinery/door/firedoor/glass,
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26
 	},
-/obj/structure/cable/green,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	dir = 1;
-	icon_state = "pdoor0";
-	id = "security_lockdown";
-	name = "Security Blast Doors";
-	opacity = 0
-	},
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/structure/window/reinforced{
+/obj/machinery/light{
+	icon_state = "tube1";
 	dir = 8
 	},
-/turf/simulated/floor,
-/area/security/breakroom)
+/turf/simulated/floor/wood,
+/area/crew_quarters/heads/hos)
 "nX" = (
-/obj/structure/bed/chair{
-	dir = 4
-	},
-/turf/simulated/floor/carpet,
-/area/security/breakroom)
-"nY" = (
-/obj/structure/table/woodentable,
-/turf/simulated/floor/carpet,
-/area/security/breakroom)
-"nZ" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/carpet,
+/area/crew_quarters/heads/hos)
+"nY" = (
+/obj/structure/table/woodentable,
+/turf/simulated/floor/carpet,
 /area/security/breakroom)
 "oa" = (
-/obj/structure/table/steel,
-/obj/machinery/microwave,
-/obj/machinery/alarm{
-	dir = 8;
-	icon_state = "alarm0";
+/obj/item/device/radio/intercom{
+	dir = 4;
 	pixel_x = 24
 	},
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1"
+	},
 /turf/simulated/floor/wood,
-/area/security/breakroom)
+/area/crew_quarters/heads/hos)
 "ob" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 10
@@ -8597,44 +8189,25 @@
 /obj/structure/grille,
 /turf/space,
 /area/space)
-"ou" = (
-/obj/structure/table/woodentable,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
-/turf/simulated/floor/carpet,
-/area/security/breakroom)
 "ov" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/bed/chair/office/dark{
+	dir = 1
 	},
-/obj/structure/table/woodentable,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/item/weapon/deck/cards,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/carpet,
-/area/security/breakroom)
+/area/crew_quarters/heads/hos)
 "ow" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/bed/chair{
-	dir = 8
-	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/carpet,
-/area/security/breakroom)
+/area/crew_quarters/heads/hos)
 "ox" = (
-/obj/structure/table/steel,
-/obj/item/weapon/storage/box/donkpockets,
 /obj/machinery/light_switch{
 	dir = 8;
-	pixel_x = 24
+	pixel_x = 28
 	},
 /turf/simulated/floor/wood,
-/area/security/breakroom)
+/area/crew_quarters/heads/hos)
 "oy" = (
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -8906,72 +8479,24 @@
 /turf/simulated/floor,
 /area/maintenance/station/ai)
 "oW" = (
-/obj/machinery/door/firedoor/glass,
-/obj/structure/cable/green,
+/obj/structure/table/woodentable,
 /obj/structure/cable/green{
-	icon_state = "0-4"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/machinery/door/blast/regular{
-	density = 0;
-	dir = 1;
-	icon_state = "pdoor0";
-	id = "security_lockdown";
-	name = "Security Blast Doors";
-	opacity = 0
-	},
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/simulated/floor,
-/area/security/breakroom)
+/turf/simulated/floor/wood,
+/area/crew_quarters/heads/hos)
 "oX" = (
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/carpet,
-/area/security/breakroom)
-"oY" = (
 /obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/bed/chair{
-	dir = 1
-	},
-/turf/simulated/floor/carpet,
-/area/security/breakroom)
-"oZ" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
+	d1 = 2;
 	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/bed/chair{
-	dir = 1
-	},
-/turf/simulated/floor/carpet,
-/area/security/breakroom)
-"pa" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "2-4"
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -8979,7 +8504,45 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/wood,
-/area/security/breakroom)
+/area/crew_quarters/heads/hos)
+"oZ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/heads/hos)
+"pa" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/heads/hos)
 "pb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -9384,21 +8947,21 @@
 /obj/random/maintenance/medical,
 /turf/simulated/floor,
 /area/maintenance/station/ai)
-"pB" = (
-/obj/machinery/light,
-/turf/simulated/floor/wood,
-/area/security/breakroom)
 "pC" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
 /turf/simulated/floor/wood,
-/area/security/breakroom)
+/area/crew_quarters/heads/hos)
 "pD" = (
 /obj/machinery/door/firedoor/glass,
 /obj/structure/grille,
-/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced/polarized{
+	dir = 10;
+	icon_state = "fwindow";
+	id = "hos_office"
+	},
 /turf/simulated/floor,
 /area/security/breakroom)
 "pE" = (
@@ -9842,9 +9405,6 @@
 	},
 /obj/structure/table/reinforced,
 /obj/machinery/microscope,
-/obj/machinery/alarm{
-	pixel_y = 22
-	},
 /turf/simulated/floor/tiled/white,
 /area/security/forensics)
 "qy" = (
@@ -9855,12 +9415,6 @@
 	dir = 1
 	},
 /obj/machinery/dnaforensics,
-/obj/machinery/firealarm{
-	dir = 2;
-	layer = 3.3;
-	pixel_x = 0;
-	pixel_y = 26
-	},
 /turf/simulated/floor/tiled/white,
 /area/security/forensics)
 "qz" = (
@@ -9879,12 +9433,6 @@
 /obj/structure/cable/green{
 	d2 = 2;
 	icon_state = "0-2"
-	},
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 24
 	},
 /obj/structure/closet{
 	name = "Evidence Closet"
@@ -9923,12 +9471,6 @@
 	dir = 5
 	},
 /obj/structure/disposalpipe/trunk,
-/obj/machinery/light_switch{
-	dir = 2;
-	name = "light switch ";
-	pixel_x = 10;
-	pixel_y = 36
-	},
 /turf/simulated/floor/tiled/white,
 /area/security/forensics)
 "qC" = (
@@ -10302,6 +9844,11 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/window/eastleft,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/tiled/white,
 /area/security/forensics)
 "ri" = (
@@ -10309,11 +9856,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
 	},
 /obj/structure/cable/green{
 	d1 = 2;
@@ -11002,6 +10544,12 @@
 	icon_state = "tube1";
 	dir = 8
 	},
+/obj/machinery/alarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -22;
+	pixel_y = 0
+	},
 /turf/simulated/floor/tiled/white,
 /area/security/forensics)
 "sb" = (
@@ -11104,10 +10652,9 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/alarm{
+/obj/machinery/light_switch{
 	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 24
+	pixel_x = 28
 	},
 /turf/simulated/floor/tiled/white,
 /area/security/forensics)
@@ -12203,6 +11750,11 @@
 	dir = 6
 	},
 /obj/structure/filingcabinet,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = -24
+	},
 /turf/simulated/floor/tiled/white,
 /area/security/forensics)
 "tK" = (
@@ -12223,14 +11775,24 @@
 	},
 /obj/structure/cable/green{
 	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/alarm{
+	dir = 1;
+	icon_state = "alarm0";
+	pixel_y = -22
 	},
 /turf/simulated/floor/tiled/white,
 /area/security/forensics)
 "tL" = (
 /obj/effect/floor_decal/borderfloorwhite,
 /obj/effect/floor_decal/corner/red/border,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/tiled/white,
 /area/security/forensics)
 "tM" = (
@@ -12821,15 +12383,12 @@
 	opacity = 0
 	},
 /obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/structure/cable/green{
 	icon_state = "0-4"
 	},
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
 /obj/structure/window/reinforced,
+/obj/structure/cable/green,
 /turf/simulated/floor,
 /area/security/forensics)
 "uI" = (
@@ -27226,30 +26785,9 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/hallway)
-"QX" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/catwalk,
-/obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 0
-	},
-/turf/simulated/floor,
-/area/maintenance/station/sec_upper)
 "QY" = (
 /obj/structure/railing{
 	dir = 8
-	},
-/obj/structure/railing{
-	icon_state = "railing0";
-	dir = 1
-	},
-/turf/simulated/floor,
-/area/maintenance/station/sec_upper)
-"QZ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/railing{
-	icon_state = "railing0";
-	dir = 1
 	},
 /turf/simulated/floor,
 /area/maintenance/station/sec_upper)
@@ -27386,6 +26924,15 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/station/upper)
+"Rq" = (
+/obj/structure/table/woodentable,
+/obj/item/device/flashlight/lamp/green{
+	dir = 2;
+	pixel_x = -4;
+	pixel_y = 12
+	},
+/turf/simulated/floor/carpet,
+/area/crew_quarters/heads/hos)
 "Rs" = (
 /obj/machinery/button/windowtint{
 	id = "sec_processing";
@@ -27404,6 +26951,18 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/warden)
+"RN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/random/trash_pile,
+/turf/simulated/floor,
+/area/maintenance/cargo)
+"RT" = (
+/obj/structure/toilet,
+/turf/simulated/floor/tiled/white,
+/area/security/security_bathroom)
 "Sa" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -27411,6 +26970,24 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/eva)
+"Sc" = (
+/obj/structure/table/woodentable,
+/obj/item/device/megaphone,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/heads/hos)
+"Sz" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/heads/hos)
 "SD" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -27418,9 +26995,99 @@
 	},
 /turf/simulated/floor/bluegrid,
 /area/ai/foyer)
-"SW" = (
-/turf/simulated/mineral/vacuum,
-/area/space)
+"SP" = (
+/obj/structure/table/woodentable,
+/obj/item/device/taperecorder{
+	pixel_y = 0
+	},
+/obj/item/weapon/reagent_containers/food/drinks/flask/barflask{
+	pixel_x = -4;
+	pixel_y = 8
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/heads/hos)
+"ST" = (
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26
+	},
+/turf/simulated/floor/tiled/white,
+/area/security/security_bathroom)
+"SX" = (
+/obj/machinery/door/airlock/security{
+	name = "Security Restroom";
+	req_one_access = list(1,38)
+	},
+/turf/simulated/floor/tiled/white,
+/area/security/security_bathroom)
+"Tb" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/polarized{
+	dir = 10;
+	icon_state = "fwindow";
+	id = "hos_office"
+	},
+/obj/structure/cable/green,
+/obj/structure/cable/green{
+	icon_state = "0-8"
+	},
+/obj/machinery/door/firedoor/glass,
+/obj/structure/cable/green{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor,
+/area/security/forensics)
+"Tc" = (
+/obj/structure/railing{
+	icon_state = "railing0";
+	dir = 1
+	},
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/maintenance/cargo)
+"Td" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/turf/simulated/floor/carpet,
+/area/security/breakroom)
+"Th" = (
+/obj/structure/bed/chair/office/dark{
+	dir = 4
+	},
+/turf/simulated/floor/carpet,
+/area/security/breakroom)
+"Tp" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/maintenance/station/sec_upper)
+"TD" = (
+/obj/structure/table/woodentable,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/computer/skills{
+	icon_state = "laptop";
+	dir = 8
+	},
+/turf/simulated/floor/carpet,
+/area/crew_quarters/heads/hos)
 "TL" = (
 /obj/machinery/ai_slipper{
 	icon_state = "motion0"
@@ -27430,6 +27097,21 @@
 	},
 /turf/simulated/floor/bluegrid,
 /area/ai/foyer)
+"TO" = (
+/obj/structure/table/woodentable,
+/obj/item/weapon/storage/secure/safe{
+	pixel_x = -30
+	},
+/obj/item/clothing/accessory/permit/gun,
+/obj/item/clothing/accessory/permit/gun,
+/obj/item/clothing/accessory/permit/gun,
+/obj/item/weapon/paper{
+	desc = "";
+	info = "In the event that more weapon permits are needed, please fax Central Command to request more. Please also include a reason for the request. Blank permits will be shipped to cargo for pickup. If long-term permits are desired, please contact your NanoTrasen Employee Representitive for more information.";
+	name = "note from CentCom about permits"
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/heads/hos)
 "TP" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -27437,15 +27119,39 @@
 	},
 /turf/simulated/floor/bluegrid,
 /area/ai/foyer)
+"TQ" = (
+/obj/structure/table/woodentable,
+/obj/item/weapon/storage/box/donkpockets,
+/turf/simulated/floor/wood,
+/area/security/breakroom)
+"TX" = (
+/obj/machinery/alarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
+	},
+/turf/simulated/floor/tiled/white,
+/area/security/security_bathroom)
+"Ub" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/white,
+/area/security/security_bathroom)
 "Un" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/carpet,
-/area/security/breakroom)
+/turf/simulated/floor/wood,
+/area/crew_quarters/heads/hos)
 "Up" = (
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/blast/regular{
@@ -27468,6 +27174,19 @@
 	},
 /turf/simulated/floor,
 /area/security/eva)
+"Uq" = (
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_x = 0;
+	pixel_y = 28
+	},
+/turf/simulated/floor/wood,
+/area/security/breakroom)
 "Ur" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
@@ -27478,6 +27197,192 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/eva)
+"Uu" = (
+/obj/machinery/computer/security,
+/turf/simulated/floor/wood,
+/area/crew_quarters/heads/hos)
+"Uw" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/structure/table/standard,
+/obj/random/soap,
+/turf/simulated/floor/tiled/white,
+/area/security/security_bathroom)
+"Uy" = (
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Head of Security's Desk";
+	departmentType = 5;
+	name = "Head of Security RC";
+	pixel_x = 32;
+	pixel_y = 0
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/heads/hos)
+"UA" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/polarized{
+	dir = 10;
+	icon_state = "fwindow";
+	id = "hos_office"
+	},
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor,
+/area/security/forensics)
+"UC" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/glass_security{
+	req_one_access = list(1,38)
+	},
+/turf/simulated/floor/tiled,
+/area/security/hallwayaux)
+"UH" = (
+/obj/machinery/door/firedoor/glass,
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced/polarized{
+	dir = 10;
+	icon_state = "fwindow";
+	id = "hos_office"
+	},
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 1;
+	icon_state = "pdoor0";
+	id = "security_lockdown";
+	name = "Security Blast Doors";
+	opacity = 0
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/crew_quarters/heads/hos)
+"UM" = (
+/turf/simulated/wall/r_wall,
+/area/maintenance/cargo)
+"UO" = (
+/obj/machinery/door/firedoor/glass,
+/obj/structure/cable/green,
+/obj/structure/grille,
+/obj/structure/window/reinforced/polarized{
+	dir = 10;
+	icon_state = "fwindow";
+	id = "hos_office"
+	},
+/obj/structure/cable/green{
+	icon_state = "0-4"
+	},
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 1;
+	icon_state = "pdoor0";
+	id = "security_lockdown";
+	name = "Security Blast Doors";
+	opacity = 0
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/crew_quarters/heads/hos)
+"US" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/white,
+/area/security/security_bathroom)
+"UT" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/security/security_bathroom)
+"UV" = (
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 6
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 5
+	},
+/turf/simulated/floor/tiled,
+/area/security/security_bathroom)
+"Vb" = (
+/obj/machinery/door/firedoor/glass,
+/obj/structure/cable/green,
+/obj/structure/grille,
+/obj/structure/window/reinforced/polarized{
+	dir = 10;
+	icon_state = "fwindow";
+	id = "hos_office"
+	},
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 1;
+	icon_state = "pdoor0";
+	id = "security_lockdown";
+	name = "Security Blast Doors";
+	opacity = 0
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/crew_quarters/heads/hos)
+"Ve" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/carpet,
+/area/crew_quarters/heads/hos)
+"Vk" = (
+/obj/effect/floor_decal/rust,
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/structure/table/rack{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/random/maintenance/security,
+/obj/random/maintenance/security,
+/obj/random/maintenance/clean,
+/turf/simulated/floor,
+/area/maintenance/cargo)
 "Vn" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 4
@@ -27490,6 +27395,14 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/lobby)
+"Vp" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/carpet,
+/area/crew_quarters/heads/hos)
 "Vr" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 1
@@ -27501,6 +27414,40 @@
 	},
 /turf/simulated/floor/bluegrid,
 /area/ai/foyer)
+"VB" = (
+/obj/machinery/washing_machine,
+/turf/simulated/floor/tiled/white,
+/area/security/security_bathroom)
+"VJ" = (
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -28
+	},
+/turf/simulated/floor/tiled/white,
+/area/security/security_bathroom)
+"VK" = (
+/obj/structure/table/woodentable,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/keycard_auth{
+	pixel_y = 32
+	},
+/obj/machinery/recharger{
+	pixel_y = 4
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/heads/hos)
+"VL" = (
+/obj/structure/grille,
+/obj/structure/lattice,
+/turf/space,
+/area/space)
 "VM" = (
 /turf/simulated/open,
 /area/ai/foyer)
@@ -27513,10 +27460,63 @@
 	},
 /turf/simulated/floor/bluegrid,
 /area/ai/foyer)
+"Wc" = (
+/obj/machinery/door/airlock/engineering{
+	name = "Security Substation";
+	req_one_access = list(1,11,24)
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
+	},
+/turf/space,
+/area/maintenance/substation/security)
+"Wj" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/polarized{
+	dir = 10;
+	icon_state = "fwindow";
+	id = "hos_office"
+	},
+/obj/structure/cable/green{
+	icon_state = "0-8"
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor,
+/area/security/forensics)
+"WB" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/structure/sink{
+	dir = 4;
+	icon_state = "sink";
+	pixel_x = 11;
+	pixel_y = 0
+	},
+/obj/structure/mirror{
+	pixel_x = 30
+	},
+/turf/simulated/floor/tiled/white,
+/area/security/security_bathroom)
+"WX" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/security/breakroom)
 "WY" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/dark,
 /area/security/evidence_storage)
+"Xe" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/security/breakroom)
 "XG" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled,
@@ -27530,6 +27530,11 @@
 	},
 /turf/simulated/floor/bluegrid,
 /area/ai/foyer)
+"XP" = (
+/obj/effect/floor_decal/rust,
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/maintenance/cargo)
 "XT" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -27552,10 +27557,99 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/station/upper)
+"Yu" = (
+/obj/structure/closet/secure_closet/hos2,
+/turf/simulated/floor/wood,
+/area/crew_quarters/heads/hos)
+"YF" = (
+/obj/structure/bed/chair/office/dark{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/carpet,
+/area/security/breakroom)
+"YH" = (
+/obj/structure/table/woodentable,
+/obj/machinery/microwave,
+/turf/simulated/floor/wood,
+/area/security/breakroom)
+"YT" = (
+/turf/simulated/wall,
+/area/security/breakroom)
+"YV" = (
+/obj/machinery/computer/secure_data,
+/obj/machinery/alarm{
+	frequency = 1441;
+	pixel_y = 22
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/heads/hos)
+"YW" = (
+/obj/structure/lattice,
+/obj/structure/sign/warning/secure_area{
+	pixel_x = 32
+	},
+/turf/space,
+/area/space)
+"Ze" = (
+/obj/machinery/door/airlock/security{
+	name = "Security Restroom";
+	req_one_access = list(1,38)
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/security/security_bathroom)
+"ZM" = (
+/obj/structure/table/woodentable,
+/obj/item/device/radio/off,
+/turf/simulated/floor/wood,
+/area/crew_quarters/heads/hos)
 "ZO" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled,
 /area/security/eva)
+"ZP" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/maintenance/station/sec_upper)
+"ZT" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/random/trash_pile,
+/turf/simulated/floor,
+/area/maintenance/cargo)
+"ZY" = (
+/turf/simulated/wall/r_wall,
+/area/security/security_lockerroom)
 
 (1,1,1) = {"
 aa
@@ -31015,8 +31109,8 @@ aa
 aa
 aa
 aa
-aa
-aa
+VL
+ae
 ad
 ad
 ad
@@ -31157,7 +31251,7 @@ aa
 aa
 aa
 aa
-aa
+VL
 aa
 ae
 aa
@@ -31299,8 +31393,8 @@ aa
 aa
 aa
 aa
-aa
-aa
+VL
+YW
 ae
 ae
 ae
@@ -31308,7 +31402,7 @@ ae
 ae
 ae
 ae
-ae
+YW
 ae
 ae
 ae
@@ -31438,18 +31532,18 @@ aa
 aa
 aa
 aa
+aa
+aa
 ab
 ab
-ab
-aa
-aa
-ae
-aa
-aa
-ae
-aa
-aa
-aa
+je
+UH
+UO
+je
+je
+je
+UH
+Vb
 qc
 qv
 rd
@@ -31579,20 +31673,20 @@ aa
 aa
 aa
 aa
-aa
 ab
-dS
-dS
-dS
-dS
+ab
+ab
+ab
+ab
+je
 my
-dR
+kv
 nD
 nW
-nW
+TO
 oW
-dR
-qc
+ZM
+UA
 qw
 re
 sa
@@ -31723,24 +31817,24 @@ ab
 ab
 ab
 ab
-dS
-kV
-dP
-lZ
-dP
-ne
-ey
+ab
+ab
+ab
+je
+Yu
+Vp
+Ve
 nX
 nX
 oX
-eJ
-qd
+Sc
+Tb
 qx
 rf
 sb
 sM
 tI
-uH
+uI
 vs
 ae
 aa
@@ -31864,25 +31958,25 @@ ab
 ab
 ab
 ab
-dS
-dS
-an
-dP
-an
-dP
-nf
+ab
+ab
+ab
+ab
+je
+Uu
+jM
 nE
-nY
-ou
-oY
-eJ
-qd
+Rq
+jM
+kv
+SP
+Wj
 qy
 rg
 sc
 sN
 gc
-uI
+qc
 vs
 vs
 vs
@@ -32006,19 +32100,19 @@ ab
 ab
 ab
 ab
-dS
-kJ
-eL
-lu
-eL
-dP
-ng
+ab
+ab
+ab
+ab
+je
+VK
+jM
 nF
 eG
 ov
 oZ
 fr
-qd
+qc
 fJ
 rh
 wS
@@ -32148,25 +32242,25 @@ ao
 ao
 ao
 ao
-dS
-kJ
-eL
-dQ
-ma
-dP
-nh
-ey
+ab
+ab
+ab
+ab
+je
+YV
+jM
+TD
 eH
 ow
 Un
-pB
-qd
+cZ
+UA
 qz
 ri
 sd
 sP
 tK
-uG
+qc
 vt
 vt
 vt
@@ -32290,19 +32384,19 @@ ao
 ao
 ao
 ao
-dS
-kJ
-kW
-lv
-mb
+ab
+ab
+ab
+ab
+je
 ar
+jM
 et
-et
-nZ
-fa
+jM
+jM
 pa
-eJ
-qd
+Sz
+Tb
 qA
 rj
 se
@@ -32432,19 +32526,19 @@ jR
 ju
 ju
 ao
-dS
-kJ
-kX
-lw
-eo
-dP
-ni
+ab
+ab
+ab
+ab
+je
+kI
+Uy
 nG
 oa
 ox
 ff
 pC
-qd
+Wj
 qB
 rk
 sf
@@ -32575,15 +32669,15 @@ ju
 ju
 ko
 ko
-eT
-eT
-eT
-ep
-ep
-ep
-ep
-ep
-ep
+ko
+ko
+ko
+ZY
+ZY
+ZY
+ZY
+ZY
+ZY
 av
 pD
 qd
@@ -35549,7 +35643,7 @@ cv
 cv
 iC
 bP
-cn
+lc
 cX
 jz
 ik
@@ -35558,7 +35652,7 @@ cM
 kq
 cM
 cM
-lc
+UC
 lE
 lE
 mK
@@ -35680,7 +35774,7 @@ Rg
 Rg
 Rg
 gg
-SW
+ab
 ab
 ab
 aU
@@ -35822,7 +35916,7 @@ Rh
 Ri
 Rj
 gg
-SW
+ab
 ab
 ab
 aU
@@ -35833,15 +35927,15 @@ aT
 in
 bt
 iR
-je
+YT
 cq
-dq
-je
+cq
+cq
 jV
-je
 cq
-dq
-je
+cq
+cq
+dR
 le
 eX
 aq
@@ -35964,7 +36058,7 @@ ae
 aa
 ed
 gg
-SW
+ab
 ab
 ab
 aU
@@ -35975,15 +36069,15 @@ hr
 io
 iE
 iR
-cq
-jm
-dr
-dr
+YT
+ne
+eJ
+eJ
 el
 kh
-ks
+kh
 du
-je
+YT
 dO
 lG
 ml
@@ -36117,15 +36211,15 @@ aV
 cb
 iF
 iR
-cs
+YT
 jn
 jB
-jM
+Th
 jW
-jM
-kt
+ey
+eJ
 kF
-je
+YT
 lf
 lH
 mm
@@ -36259,15 +36353,15 @@ aW
 aU
 iG
 iS
-je
+YT
 jo
 jC
 jN
 jX
 da
-ku
+eJ
 kG
-je
+YT
 lg
 lH
 mn
@@ -36401,15 +36495,15 @@ aX
 in
 bu
 iR
-cq
+YT
 jp
-ds
-jO
+jC
+nY
 cO
-eE
-kv
+da
+eJ
 kH
-je
+YT
 lh
 lH
 lH
@@ -36543,15 +36637,15 @@ aY
 in
 bu
 iR
-cs
-cZ
+YT
+Uq
 dt
 ds
-ds
-ds
+YF
+Td
 eY
-kI
-je
+TQ
+YT
 li
 lH
 mm
@@ -36685,15 +36779,15 @@ Rl
 aU
 iH
 iT
-je
-je
-je
-dN
+YT
+ni
+WX
+eJ
 en
 eF
-je
-je
-je
+Xe
+YH
+YT
 eZ
 lI
 mn
@@ -36827,15 +36921,15 @@ aU
 aU
 iI
 iU
-iU
-db
-je
-je
-je
-je
-je
-db
-af
+dS
+dP
+dP
+dP
+dP
+Ze
+dP
+dP
+dP
 le
 lJ
 mo
@@ -36969,14 +37063,14 @@ bm
 bz
 bw
 cl
-bm
-jq
-jq
-qU
-qU
-aI
+dS
+RT
+SX
+ST
+VJ
+UT
 fb
-fq
+UV
 fG
 le
 lK
@@ -37111,15 +37205,15 @@ bm
 bA
 bW
 bT
-df
-iq
-dw
-dw
-dw
-eI
-fc
-fc
-dw
+dS
+dP
+dP
+hx
+kW
+US
+Ub
+UV
+fG
 af
 af
 af
@@ -37253,18 +37347,18 @@ bm
 bB
 by
 cz
-cw
+dS
 dd
-dx
-aI
-aI
-aI
-aI
-dA
-dw
+SX
+TX
+WB
+VB
+Uw
+UV
+fG
+af
 fc
 fc
-eI
 fc
 fc
 dw
@@ -37394,20 +37488,20 @@ hQ
 bm
 bm
 bm
-bm
-bm
-iq
-dy
-aI
-ab
-ab
-aI
-dA
-QX
-lj
+Wc
+af
+af
+af
+af
+af
+af
+UM
+UM
+UM
+af
 lL
 aI
-mR
+aI
 QY
 Ra
 fc
@@ -37534,23 +37628,23 @@ gZ
 ha
 hw
 hZ
-dA
-iq
+dw
+fc
 dA
 kM
-de
-dy
+jq
+jq
+qU
+qU
 aI
-ab
-ab
+Vk
+RN
+ZT
 aI
+XP
+Tc
+iV
 aI
-aI
-aI
-aI
-aI
-mR
-QZ
 aI
 aI
 aI
@@ -37679,21 +37773,21 @@ bc
 pS
 eW
 pN
-iq
-iq
+ZP
+Tp
 dy
-aI
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+dw
+dw
+eI
+nx
+nx
+nx
+nx
+nx
+nx
+Tc
 iV
-mS
-iV
-iV
+ab
 ab
 ab
 ab
@@ -37825,17 +37919,17 @@ aI
 aI
 dB
 aI
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+aI
+aI
 iV
-mT
+iV
+iV
+iV
+iV
+nx
 nx
 iV
+ab
 ab
 ab
 ab
@@ -37973,11 +38067,11 @@ ab
 ab
 ab
 ab
-ab
 iV
 es
 mT
 iV
+ab
 ab
 ab
 ab
@@ -38116,10 +38210,10 @@ ab
 ab
 iV
 iV
-iV
 mU
 mT
 iV
+ab
 ab
 ab
 ab
@@ -38256,11 +38350,11 @@ iV
 iV
 iV
 iV
-iV
 lM
 mq
 mV
 mT
+iV
 iV
 iV
 iV


### PR DESCRIPTION
Swaps the position of the HoS Office and Sec Break Room

This change makes the HoS office closer to the working areas of the department, and allows for easier communication. The breakroom has been moved as well, with windows added into the hall, making the area in general brighter and more approachable.

This is going to have a conflict with #4605. I've spoken with Heroman, and I'll be remaking his work in a separate PR, as I had to rearrange maint slightly to allow for the new breakroom placement.