### PR TITLE
Fixed creation of borgs through non-spawn method

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_vr.dm
+++ b/code/modules/mob/living/silicon/robot/robot_vr.dm
@@ -166,7 +166,7 @@
 	buckle_movable = TRUE
 	buckle_lying = FALSE
 
-/mob/living/silicon/robot/New()
+/mob/living/silicon/robot/New(loc,var/unfinished = 0)
 	..()
 	riding_datum = new /datum/riding/dogborg(src)
 


### PR DESCRIPTION
I have no idea why that unfinished var even exists, considering its use is completely commented out, but its Polaris stuff, so I just brought our modified proc to match.