### PR TITLE
Fixes food not getting digested on itemweak.

### DIFF
--- a/code/modules/vore/eating/digest_act_vr.dm
+++ b/code/modules/vore/eating/digest_act_vr.dm
@@ -87,7 +87,8 @@
 		else if(isrobot(B.owner))
 			var/mob/living/silicon/robot/R = B.owner
 			R.cell.charge += 150
-
+		qdel(src)
+		return w_class
 	. = ..()
 
 /obj/item/weapon/holder/digest_act(var/atom/movable/item_storage = null)


### PR DESCRIPTION
Well it would have been digesting if the belly had enough damage to oneshot it with the slow code. The problem was just that the itemweak mode was only applying one single hit on the food before excluding it from the loop for some reason.