### PR TITLE
Fixes shellguard-noble sprites not actually having sprites

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_vr.dm
+++ b/code/modules/mob/living/silicon/robot/robot_vr.dm
@@ -29,7 +29,14 @@
 					   "mechoid-Service",
 					   "mechoid-Janitor",
 					   "mechoid-Combat",
-					   "mechoid-Combat-roll"
+					   "mechoid-Combat-roll",
+					   "Noble-CLN",
+					   "Noble-SRV",
+					   "Noble-DIG",
+					   "Noble-MED",
+					   "Noble-SEC",
+					   "Noble-ENG",
+					   "Noble-STD"
 					   )					//List of all used sprites that are in robots_vr.dmi
 
 


### PR DESCRIPTION
Seems like either at some point this file got reverted... or I made a big whoopsie when re-adding them in the first place.

Credit for them still goes to Travelling Merchant, first uploaded on Paradise Station.