### PR TITLE
Tweaks borg belly passive drain.

### DIFF
--- a/code/modules/mob/living/silicon/robot/dogborg/dog_sleeper_vr.dm
+++ b/code/modules/mob/living/silicon/robot/dogborg/dog_sleeper_vr.dm
@@ -620,14 +620,15 @@
 		clean_cycle()
 		return
 
-	if(patient)	//We're caring for the patient. Medical emergency! Or endo scene.
+	if(patient && !compactor) //We're caring for the patient. Medical emergency! Or endo scene.
 		update_patient()
 		if(patient.health < 0)
 			patient.adjustOxyLoss(-1) //Heal some oxygen damage if they're in critical condition
 			patient.updatehealth()
+			drain()
 		patient.AdjustStunned(-4)
 		patient.AdjustWeakened(-4)
-		drain()
+		drain(1)
 		return
 
 	if(!patient && !cleaning) //We think we're done working.


### PR DESCRIPTION
-Disables "life support" passive drain for compactor type modules. (janitor, dozer, science)
-Reduces the passive drain for sleeper and brig-belly while slightly increasing it while the passive crit support is actually enabled.

Just a little bit of a QoL thing to reduce the cost of endo encounters.