### PR TITLE
Removes the usage of non-working is_tool procs

### DIFF
--- a/code/game/machinery/airconditioner_vr.dm
+++ b/code/game/machinery/airconditioner_vr.dm
@@ -45,7 +45,7 @@
 			disconnect_from_network()
 			turn_off()
 		return
-	if(I.is_multitool())
+	if(istype(I, /obj/item/device/multitool))
 		var/new_temp = input("Input a new target temperature, in degrees C.","Target Temperature", 20) as num
 		if(!Adjacent(user) || user.incapacitated())
 			return

--- a/code/modules/power/fusion/core/core_control.dm
+++ b/code/modules/power/fusion/core/core_control.dm
@@ -11,7 +11,7 @@
 
 /obj/machinery/computer/fusion_core_control/attackby(var/obj/item/thing, var/mob/user)
 	..()
-	if(thing.is_multitool()) //VOREStation Edit
+	if(istype(thing, /obj/item/device/multitool))
 		var/new_ident = input("Enter a new ident tag.", "Core Control", id_tag) as null|text
 		if(new_ident && user.Adjacent(src))
 			id_tag = new_ident

--- a/code/modules/power/fusion/fuel_assembly/fuel_control.dm
+++ b/code/modules/power/fusion/fuel_assembly/fuel_control.dm
@@ -96,7 +96,7 @@
 
 /obj/machinery/computer/fusion_fuel_control/attackby(var/obj/item/W, var/mob/user)
 	..()
-	if(W.is_multitool()) //VOREStation Edit
+	if(istype(W, /obj/item/device/multitool))
 		var/new_ident = input("Enter a new ident tag.", "Fuel Control", id_tag) as null|text
 		if(new_ident && user.Adjacent(src))
 			id_tag = new_ident

--- a/code/modules/power/fusion/gyrotron/gyrotron_control.dm
+++ b/code/modules/power/fusion/gyrotron/gyrotron_control.dm
@@ -96,7 +96,7 @@
 
 /obj/machinery/computer/gyrotron_control/attackby(var/obj/item/W, var/mob/user)
 	..()
-	if(W.is_multitool()) //VOREStation Edit
+	if(istype(W, /obj/item/device/multitool))
 		var/new_ident = input("Enter a new ident tag.", "Gyrotron Control", id_tag) as null|text
 		if(new_ident && user.Adjacent(src))
 			id_tag = new_ident

--- a/code/modules/power/lightswitch_vr.dm
+++ b/code/modules/power/lightswitch_vr.dm
@@ -83,7 +83,7 @@
 
 /obj/structure/construction/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	add_fingerprint(user)
-	if(W.is_welder())
+	if(istype(W, /obj/item/weapon/weldingtool))
 		if(stage == FRAME_UNFASTENED)
 			var/obj/item/weapon/weldingtool/WT = W
 			if(!WT.remove_fuel(0, user))
@@ -117,7 +117,7 @@
 			update_icon()
 		return
 
-	else if(W.is_cable_coil())
+	else if(istype(W, /obj/item/stack/cable_coil))
 		if (stage == FRAME_FASTENED)
 			var/obj/item/stack/cable_coil/coil = W
 			if (coil.use(1))


### PR DESCRIPTION
Removes vorestation edits in polaris files that used it and replaces the proc in vr files that used it. Whoever thought this was a good idea and wanted to make it work can put it back in when they come back to the project of making all tool-type checks into procs, until then I'd like functioning machinery, thanks.

Thermal regulator and R-UST stuff will be affected, right now you cannot multitool them for configuration.

Also removes use of is_welder and is_cable_coil

That should fix construction/deconstruction of light switches.