### PR TITLE
Rebalances Healbelly

### DIFF
--- a/code/modules/vore/eating/bellymodes_vr.dm
+++ b/code/modules/vore/eating/bellymodes_vr.dm
@@ -270,7 +270,7 @@
 				M.adjustToxLoss(-5)
 				M.adjustOxyLoss(-5)
 				M.adjustCloneLoss(-1.25)
-				owner.nutrition -= 4
+				owner.nutrition -= 2
 				if(M.nutrition <= 400)
 					M.nutrition += 1
 			else if(owner.nutrition > 90 && (M.nutrition <= 400))

--- a/code/modules/vore/eating/bellymodes_vr.dm
+++ b/code/modules/vore/eating/bellymodes_vr.dm
@@ -265,9 +265,12 @@
 				continue
 
 			if(owner.nutrition > 90 && (M.health < M.maxHealth))
-				M.adjustBruteLoss(-5)
-				M.adjustFireLoss(-5)
-				owner.nutrition -= 2
+				M.adjustBruteLoss(-2.5)
+				M.adjustFireLoss(-2.5)
+				M.adjustToxLoss(-5)
+				M.adjustOxyLoss(-5)
+				M.adjustCloneLoss(-1.25)
+				owner.nutrition -= 6
 				if(M.nutrition <= 400)
 					M.nutrition += 1
 			else if(owner.nutrition > 90 && (M.nutrition <= 400))

--- a/code/modules/vore/eating/bellymodes_vr.dm
+++ b/code/modules/vore/eating/bellymodes_vr.dm
@@ -270,7 +270,7 @@
 				M.adjustToxLoss(-5)
 				M.adjustOxyLoss(-5)
 				M.adjustCloneLoss(-1.25)
-				owner.nutrition -= 6
+				owner.nutrition -= 4
 				if(M.nutrition <= 400)
 					M.nutrition += 1
 			else if(owner.nutrition > 90 && (M.nutrition <= 400))


### PR DESCRIPTION
Resolves https://github.com/VOREStation/VOREStation/issues/4611

I've no idea how to actually add wound bandaging and disinfecting onto this, so while it was mentioned in the initial issue, it wasn't added. If someone more experienced than me wants to do it, go for it. 

After a little bit of messing around, I figured these values would be decent. It's rather close to tricordrazine. 

- Brute Heal, lowered from 5 to 2.5 per cycle, now healing at roughly 0.4 per tick. Compare with Tricord's 0.3 per tick.
- Burn Heal, lowered from 5 to 2.5 per cycle, now healing at roughly 0.4 per tick. Compare with Tricord's 0.3 per tick.
- Toxin Heal added at 5 per cycle, 0.8 per tick. More than Brute/Burn as this damage type is often expected to increase, allowing for stabilization of infections as long as it isn't progressed to L3. Also because 5 was the default value for the other damage types, and it works out nicely now being a clean double of the new 2.5 value for those types, additionally acting as a decent compensation for not being able to clear or prevent infections. Might as well be able to combat them before they go L3.
- Oxy Heal added at 5 per cycle, 0.8 per tick. Compared with Tricord's 0.6 heal per tick. This would be enough to prevent oxy in crit and help stabilize a ruptured lung. Plus, keeping with 5's and divisions of 5 because it pleases me.
- Genetic Heal, added at 1.25 per cycle, roughly 0.2 per tick. An un-upgraded resleever will produce a body with 80 genetic damage, providing default health. At this rate, it would take roughly 6-7 minutes to heal completely. Does *not* remove disabilities. Might allow it to, if it turns out all I have to do is add 'disabilities = 0'. It's nearly 5am and I'm too tired to do any more testing.
- Bumped nutrition cost from 2 to 6, since it's healing more than before. Might adjust at some point if it turns out this is becoming a hindrance. 

So, yeah. The git issue has been up for nearly a month, the general consensus seemed to support changes like the ones made. Healbelly will now actually be useful, but not a complete substitute for medical or even the common medical supplies used. Chems heal brute/burn faster than the belly mode, carthatoline is faster for toxins and dexalin plus is *much* faster. On top of that, we've had a rather robust brute/burn heal value for a long-ass time -faster than bicar/kelo -  and I can't really recall it ever coming up in Medical. I don't think I've ever had a patient "stolen" and healed up before I got there because of the healbelly existing. So, halving that value and giving the belly a broader range of healed damage types shouldn't cause a problem. This PR will likely be open for a looooong time considering everything's frozen, so we'll have plenty of time to discuss it further.

Now, what does this actually mean for Patients?
If you're okay with it, you can be healed pretty reliably through the vore panel. Your prefs matter, some Medical players will likely throw the Heal effect on whatever 'belly' you choose. It can take a few minutes to heal up to full health, providing nothing else is actively damaging you. It's a bit slower than chems, but I feel like that doesn't really matter, cause it's vore. Should go without saying that just because this is an option doesn't mean you'll always get treated this way. If you get upset because you get hurt and Medical comes by with chems and a first aid kit instead of swallowing you, am sorry, they aren't obligated to, even if you request it. It's a two-way thing.

For Medical, you now have a rather decent tool to use, should you want to use it. It only heals the 5 main damage types - brute, burn, toxin, oxy, genetic. It does not bandage or disinfect, so it's not a good idea to use this on someone still bleeding or go without infection treatment. You won't be able to monitor the patients vitals unless their sensors are on and you're viewing the monitor, so it's best to make sure they're stabilizing before leaving them in. It won't cure disabilities caused by resleeving, you'll still need ryetalyn or an upgraded sleever for that. Please keep everyone's prefs in mind and don't force the Healbelly as the only way you'll help a patient, it'd be unfair to players who just want regular treatment, make sure you have the usual gear in your bag and medbelt so you can help them, too. LOOC if you want to make sure it's okay! 

Expedition/Gateway Teams/Etc, please don't abuse this and make it the new meta. I was honestly on the fence about these changes to start with because I was worried that it'd just be used as a replacement for medical, when the change is intended to give Medical a way to better incorporate scenes and vore into a job that often crushes opportunities to *have* scenes in the first place. I guess one way to put it is, "This is the only way to save you, Medical wouldn't get here in time" is okay, but "Don't bother calling Medical, I can fix you" is perhaps a bit less fine, yeah? If it's abused badly, we'll have to tweak the nutrition costs and heal values and overall nerf it, and I really hate nerfing things in general so please be nice <3