### PR TITLE
All air alarms on station now properly report breaches, without select few refusing.

### DIFF
--- a/maps/tether/tether-01-surface1.dmm
+++ b/maps/tether/tether-01-surface1.dmm
@@ -27109,11 +27109,9 @@
 /obj/structure/closet/crate,
 /obj/item/weapon/bedsheet/green,
 /obj/machinery/alarm{
-	breach_detection = 0;
 	dir = 8;
 	pixel_x = 25;
-	pixel_y = 0;
-	report_danger_level = 0
+	pixel_y = 0
 	},
 /obj/machinery/light{
 	dir = 4;
@@ -27898,11 +27896,9 @@
 "lCL" = (
 /obj/structure/catwalk,
 /obj/machinery/alarm{
-	breach_detection = 0;
 	dir = 8;
 	pixel_x = 25;
-	pixel_y = 0;
-	report_danger_level = 0
+	pixel_y = 0
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/lower/public_garden_maintenence)

--- a/maps/tether/tether-03-surface3.dmm
+++ b/maps/tether/tether-03-surface3.dmm
@@ -21496,11 +21496,9 @@
 /area/tether/surfacebase/atrium_three)
 "NA" = (
 /obj/machinery/alarm{
-	breach_detection = 0;
 	dir = 8;
 	pixel_x = 25;
-	pixel_y = 0;
-	report_danger_level = 0
+	pixel_y = 0
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 6

--- a/maps/tether/tether-06-station2.dmm
+++ b/maps/tether/tether-06-station2.dmm
@@ -19339,11 +19339,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/alarm{
-	breach_detection = 0;
 	dir = 8;
 	pixel_x = 25;
-	pixel_y = 0;
-	report_danger_level = 0
+	pixel_y = 0
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/airless,

--- a/maps/tether/tether-07-station3.dmm
+++ b/maps/tether/tether-07-station3.dmm
@@ -12702,11 +12702,9 @@
 /obj/random/maintenance/cargo,
 /obj/random/maintenance/cargo,
 /obj/machinery/alarm{
-	breach_detection = 0;
 	dir = 8;
 	pixel_x = 25;
-	pixel_y = 0;
-	report_danger_level = 0
+	pixel_y = 0
 	},
 /obj/item/weapon/storage/box/lights/mixed,
 /obj/item/weapon/storage/box/lights/mixed,

--- a/maps/tether/tether-09-solars.dmm
+++ b/maps/tether/tether-09-solars.dmm
@@ -4616,11 +4616,9 @@
 /area/rnd/outpost/storage)
 "iB" = (
 /obj/machinery/alarm{
-	breach_detection = 0;
 	dir = 8;
 	pixel_x = 25;
-	pixel_y = 0;
-	report_danger_level = 0
+	pixel_y = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{


### PR DESCRIPTION
Fixes air alarms in:
- Public Garden Maintenance
- Visitor Laundry
- Public Garden Third Floor
- Primary Emergency Storage
- Lower Security Maintenance


Fixes #4744 