### PR TITLE
Replaces chem dispenser in xenoflora with one that only dispenses botany-related chems

### DIFF
--- a/code/modules/reagents/dispenser/cartridge_presets_vr.dm
+++ b/code/modules/reagents/dispenser/cartridge_presets_vr.dm
@@ -1,0 +1,6 @@
+/obj/item/weapon/reagent_containers/chem_disp_cartridge
+	//Xenoflora
+	ammonia		spawn_reagent = "ammonia"
+	diethylamine	spawn_reagent = "diethylamine"
+	plantbgone	spawn_reagent = "plantbgone"
+	mutagen		spawn_reagent = "mutagen"

--- a/code/modules/reagents/dispenser/dispenser_presets_vr.dm
+++ b/code/modules/reagents/dispenser/dispenser_presets_vr.dm
@@ -1,0 +1,30 @@
+/obj/machinery/chemical_dispenser/research
+	name = "xenoflora chem dispenser"
+	spawn_cartridges = list(
+			/obj/item/weapon/reagent_containers/chem_disp_cartridge/hydrogen,
+			/obj/item/weapon/reagent_containers/chem_disp_cartridge/lithium,
+			/obj/item/weapon/reagent_containers/chem_disp_cartridge/carbon,
+			/obj/item/weapon/reagent_containers/chem_disp_cartridge/nitrogen,
+			/obj/item/weapon/reagent_containers/chem_disp_cartridge/oxygen,
+			/obj/item/weapon/reagent_containers/chem_disp_cartridge/fluorine,
+			/obj/item/weapon/reagent_containers/chem_disp_cartridge/sodium,
+			/obj/item/weapon/reagent_containers/chem_disp_cartridge/aluminum,
+			/obj/item/weapon/reagent_containers/chem_disp_cartridge/silicon,
+			/obj/item/weapon/reagent_containers/chem_disp_cartridge/phosphorus,
+			/obj/item/weapon/reagent_containers/chem_disp_cartridge/sulfur,
+			/obj/item/weapon/reagent_containers/chem_disp_cartridge/chlorine,
+			/obj/item/weapon/reagent_containers/chem_disp_cartridge/potassium,
+			/obj/item/weapon/reagent_containers/chem_disp_cartridge/iron,
+			/obj/item/weapon/reagent_containers/chem_disp_cartridge/copper,
+			/obj/item/weapon/reagent_containers/chem_disp_cartridge/mercury,
+			/obj/item/weapon/reagent_containers/chem_disp_cartridge/radium,
+			/obj/item/weapon/reagent_containers/chem_disp_cartridge/water,
+			/obj/item/weapon/reagent_containers/chem_disp_cartridge/ethanol,
+			/obj/item/weapon/reagent_containers/chem_disp_cartridge/sugar,
+			/obj/item/weapon/reagent_containers/chem_disp_cartridge/sacid,
+			/obj/item/weapon/reagent_containers/chem_disp_cartridge/tungsten
+		)
+	dispense_reagents = list(
+		"coffee", "cafe_latte", "soy_latte", "hot_coco", "milk", "cream", "tea", "ice",
+		"orangejuice", "lemonjuice", "limejuice", "berryjuice", "mint"
+		)

--- a/code/modules/reagents/dispenser/dispenser_presets_vr.dm
+++ b/code/modules/reagents/dispenser/dispenser_presets_vr.dm
@@ -2,6 +2,7 @@
 	name = "xenoflora chem dispenser"
 	spawn_cartridges = list(
 			/obj/item/weapon/reagent_containers/chem_disp_cartridge/water,
+			/obj/item/weapon/reagent_containers/chem_disp_cartridge/sugar,
 			/obj/item/weapon/reagent_containers/chem_disp_cartridge/ethanol,
 			/obj/item/weapon/reagent_containers/chem_disp_cartridge/radium,
 			/obj/item/weapon/reagent_containers/chem_disp_cartridge/ammonia,
@@ -10,5 +11,5 @@
 			/obj/item/weapon/reagent_containers/chem_disp_cartridge/mutagen
 		)
 	dispense_reagents = list(
-		"water", "ethanol", "radium", "ammonia", "diethylamine", "plantbgone", "mutagen"
+		"water", "sugar", "ethanol", "radium", "ammonia", "diethylamine", "plantbgone", "mutagen"
 		)

--- a/code/modules/reagents/dispenser/dispenser_presets_vr.dm
+++ b/code/modules/reagents/dispenser/dispenser_presets_vr.dm
@@ -1,30 +1,14 @@
-/obj/machinery/chemical_dispenser/research
+/obj/machinery/chemical_dispenser/xenoflora
 	name = "xenoflora chem dispenser"
 	spawn_cartridges = list(
-			/obj/item/weapon/reagent_containers/chem_disp_cartridge/hydrogen,
-			/obj/item/weapon/reagent_containers/chem_disp_cartridge/lithium,
-			/obj/item/weapon/reagent_containers/chem_disp_cartridge/carbon,
-			/obj/item/weapon/reagent_containers/chem_disp_cartridge/nitrogen,
-			/obj/item/weapon/reagent_containers/chem_disp_cartridge/oxygen,
-			/obj/item/weapon/reagent_containers/chem_disp_cartridge/fluorine,
-			/obj/item/weapon/reagent_containers/chem_disp_cartridge/sodium,
-			/obj/item/weapon/reagent_containers/chem_disp_cartridge/aluminum,
-			/obj/item/weapon/reagent_containers/chem_disp_cartridge/silicon,
-			/obj/item/weapon/reagent_containers/chem_disp_cartridge/phosphorus,
-			/obj/item/weapon/reagent_containers/chem_disp_cartridge/sulfur,
-			/obj/item/weapon/reagent_containers/chem_disp_cartridge/chlorine,
-			/obj/item/weapon/reagent_containers/chem_disp_cartridge/potassium,
-			/obj/item/weapon/reagent_containers/chem_disp_cartridge/iron,
-			/obj/item/weapon/reagent_containers/chem_disp_cartridge/copper,
-			/obj/item/weapon/reagent_containers/chem_disp_cartridge/mercury,
-			/obj/item/weapon/reagent_containers/chem_disp_cartridge/radium,
 			/obj/item/weapon/reagent_containers/chem_disp_cartridge/water,
 			/obj/item/weapon/reagent_containers/chem_disp_cartridge/ethanol,
-			/obj/item/weapon/reagent_containers/chem_disp_cartridge/sugar,
-			/obj/item/weapon/reagent_containers/chem_disp_cartridge/sacid,
-			/obj/item/weapon/reagent_containers/chem_disp_cartridge/tungsten
+			/obj/item/weapon/reagent_containers/chem_disp_cartridge/radium,
+			/obj/item/weapon/reagent_containers/chem_disp_cartridge/ammonia,
+			/obj/item/weapon/reagent_containers/chem_disp_cartridge/diethylamine,
+			/obj/item/weapon/reagent_containers/chem_disp_cartridge/plantbgone,
+			/obj/item/weapon/reagent_containers/chem_disp_cartridge/mutagen
 		)
 	dispense_reagents = list(
-		"coffee", "cafe_latte", "soy_latte", "hot_coco", "milk", "cream", "tea", "ice",
-		"orangejuice", "lemonjuice", "limejuice", "berryjuice", "mint"
+		"water", "ethanol", "radium", "ammonia", "diethylamine", "plantbgone", "mutagen"
 		)

--- a/maps/tether/tether-01-surface1.dmm
+++ b/maps/tether/tether-01-surface1.dmm
@@ -18036,7 +18036,7 @@
 	req_access = list()
 	},
 /obj/structure/table/glass,
-/obj/machinery/chemical_dispenser/full,
+/obj/machinery/chemical_dispenser/xenoflora,
 /turf/simulated/floor/tiled,
 /area/rnd/xenobiology/xenoflora)
 "bfR" = (

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -2627,6 +2627,7 @@
 #include "code\modules\reagents\dispenser\dispenser2.dm"
 #include "code\modules\reagents\dispenser\dispenser2_energy.dm"
 #include "code\modules\reagents\dispenser\dispenser_presets.dm"
+#include "code\modules\reagents\dispenser\dispenser_presets_vr.dm"
 #include "code\modules\reagents\dispenser\supply.dm"
 #include "code\modules\reagents\reagent_containers\blood_pack.dm"
 #include "code\modules\reagents\reagent_containers\blood_pack_vr.dm"

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -2623,6 +2623,7 @@
 #include "code\modules\reagents\dispenser\_defines.dm"
 #include "code\modules\reagents\dispenser\cartridge.dm"
 #include "code\modules\reagents\dispenser\cartridge_presets.dm"
+#include "code\modules\reagents\dispenser\cartridge_presets_vr.dm"
 #include "code\modules\reagents\dispenser\cartridge_spawn.dm"
 #include "code\modules\reagents\dispenser\dispenser2.dm"
 #include "code\modules\reagents\dispenser\dispenser2_energy.dm"


### PR DESCRIPTION
Research department has a pretty long history abusing the chem dispenser in xenoflora for nearly anything except xenoflora most of time. Dodging having to go to medical by brewing any medicine needed primarily. While I'm not saying 'only chemists should know how to chemistry', purpose of it being in xenoflora lab always seemed to me as more "get mutagen and fertilizers without need for chemists" rather than "get whatever you can imagine by doing it with no need of involving chemists".

Reagents it produces (8 total):
Water
Sugar
Ethanol
Radium
Ammonia
Diethylamine
Plant-B-Gone
Unstable Mutagen