### PR TITLE
[5723] Makes this PR compile (+ return of commented out feature)

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/prometheans.dm
+++ b/code/modules/mob/living/carbon/human/species/station/prometheans.dm
@@ -153,15 +153,9 @@ var/datum/species/shapeshifter/promethean/prometheans
 			H.gib()
 
 /datum/species/shapeshifter/promethean/handle_environment_special(var/mob/living/carbon/human/H)
-<<<<<<< HEAD
-/* VOREStation Removal - Too crazy with our uncapped hunger and slowdown stuff.
-=======
-	var/regen_brute = 1
-	var/regen_burn = 1
-	var/regen_tox = 1
-	var/regen_oxy = 1
 
->>>>>>> 927311c... Merge pull request #5723 from Mechoid/PrometheanTweakening_The_Agonizing_One
+/* VOREStation Removal - Too crazy with our uncapped hunger and slowdown stuff.
+
 	var/turf/T = H.loc
 	if(istype(T))
 		var/obj/effect/decal/cleanable/C = locate() in T
@@ -170,11 +164,16 @@ var/datum/species/shapeshifter/promethean/prometheans
 			if (istype(T, /turf/simulated))
 				var/turf/simulated/S = T
 				S.dirt = 0
-
-<<<<<<< HEAD
 			H.nutrition = min(500, max(0, H.nutrition + rand(15, 30)))
 VOREStation Removal End */
-=======
+
+	var/regen_brute = 1
+	var/regen_burn = 1
+	var/regen_tox = 1
+	var/regen_oxy = 1
+
+	var/turf/T = H.loc	//VOREStation Addition: get the location as originally commented out
+
 	T = get_turf(H) // Swap over to an actual turf, because we need to get the pressure.
 	if(istype(T)) // Make sure it exists, and is a turf again.
 		var/datum/gas_mixture/environment = T.return_air()
@@ -184,7 +183,6 @@ VOREStation Removal End */
 			regen_brute = 0
 			regen_burn = 0
 
->>>>>>> 927311c... Merge pull request #5723 from Mechoid/PrometheanTweakening_The_Agonizing_One
 	// Heal remaining damage.
 	if(H.fire_stacks >= 0)
 		if(H.getBruteLoss() || H.getFireLoss() || H.getOxyLoss() || H.getToxLoss())
@@ -216,18 +214,13 @@ VOREStation Removal End */
 
 			H.nutrition -= (3 * nutrition_cost) //Costs Nutrition when damage is being repaired, corresponding to the amount of damage being repaired.
 			H.nutrition = max(0, H.nutrition) //Ensure it's not below 0.
-<<<<<<< HEAD
-	//else//VOREStation Removal
-		//H.adjustToxLoss(2*heal_rate)	// Doubled because 0.5 is miniscule, and fire_stacks are capped in both directions
-=======
 
 			var/agony_to_apply = ((1 / starve_mod) * nutrition_cost) //Regenerating damage causes minor pain over time. Small injures will be no issue, large ones will cause problems.
 			if((H.getHalLoss() + agony_to_apply) <= 70) // Don't permalock, but make it far easier to knock them down.
 				H.apply_damage(agony_to_apply, HALLOSS)
 
-	else
-		H.adjustToxLoss(2*heal_rate)	// Doubled because 0.5 is miniscule, and fire_stacks are capped in both directions
->>>>>>> 927311c... Merge pull request #5723 from Mechoid/PrometheanTweakening_The_Agonizing_One
+	//else//VOREStation Removal
+		//H.adjustToxLoss(2*heal_rate)	// Doubled because 0.5 is miniscule, and fire_stacks are capped in both directions
 
 /datum/species/shapeshifter/promethean/get_blood_colour(var/mob/living/carbon/human/H)
 	return (H ? rgb(H.r_skin, H.g_skin, H.b_skin) : ..())

--- a/code/modules/mob/living/carbon/human/species/station/prometheans.dm
+++ b/code/modules/mob/living/carbon/human/species/station/prometheans.dm
@@ -153,8 +153,10 @@ var/datum/species/shapeshifter/promethean/prometheans
 			H.gib()
 
 /datum/species/shapeshifter/promethean/handle_environment_special(var/mob/living/carbon/human/H)
-
-/* VOREStation Removal - Too crazy with our uncapped hunger and slowdown stuff.
+	var/regen_brute = 1
+	var/regen_burn = 1
+	var/regen_tox = 1
+	var/regen_oxy = 1
 
 	var/turf/T = H.loc
 	if(istype(T))
@@ -164,15 +166,7 @@ var/datum/species/shapeshifter/promethean/prometheans
 			if (istype(T, /turf/simulated))
 				var/turf/simulated/S = T
 				S.dirt = 0
-			H.nutrition = min(500, max(0, H.nutrition + rand(15, 30)))
-VOREStation Removal End */
-
-	var/regen_brute = 1
-	var/regen_burn = 1
-	var/regen_tox = 1
-	var/regen_oxy = 1
-
-	var/turf/T = H.loc	//VOREStation Addition: get the location as originally commented out
+			H.nutrition = max(H.nutrition, min(500, H.nutrition + rand(15, 30)))	//VOREStation Edit: Gives nutrition up to a point instead of being capped
 
 	T = get_turf(H) // Swap over to an actual turf, because we need to get the pressure.
 	if(istype(T)) // Make sure it exists, and is a turf again.


### PR DESCRIPTION
Fixes conflicts in #4539 

Also returns ability for barefoot prometheans to eat dirt. The nutrition gainable by this method is capped at 500 (but you can still go beyond by normal eating methods).