### PR TITLE
Changes vore egg_types to not interfere with mob egg_types.

### DIFF
--- a/code/_helpers/global_lists_vr.dm
+++ b/code/_helpers/global_lists_vr.dm
@@ -94,7 +94,7 @@ var/global/list/struggle_sounds = list(
 		"Squish4" = 'sound/vore/squish4.ogg')
 
 
-var/global/list/global_egg_types = list(
+var/global/list/global_vore_egg_types = list(
 		"Unathi" 		= UNATHI_EGG,
 		"Tajaran" 		= TAJARAN_EGG,
 		"Akula" 		= AKULA_EGG,
@@ -107,7 +107,7 @@ var/global/list/global_egg_types = list(
 		"Xenochimera" 		= XENOCHIMERA_EGG,
 		"Xenomorph"		= XENOMORPH_EGG)
 
-var/global/list/tf_egg_types = list(
+var/global/list/tf_vore_egg_types = list(
 	"Unathi" 		= /obj/structure/closet/secure_closet/egg/unathi,
 	"Tajara" 		= /obj/structure/closet/secure_closet/egg/tajaran,
 	"Akula" 		= /obj/structure/closet/secure_closet/egg/shark,

--- a/code/modules/client/preference_setup/vore/03_egg.dm
+++ b/code/modules/client/preference_setup/vore/03_egg.dm
@@ -12,7 +12,7 @@ var/XENOMORPH_EGG 	= "Xenomorph"
 
 // Define a place to save appearance in character setup
 /datum/preferences
-	var/egg_type = "Egg" //The egg type they have.
+	var/vore_egg_type = "Egg" //The egg type they have.
 
 // Definition of the stuff for the egg type.
 /datum/category_item/player_setup_item/vore/egg
@@ -20,31 +20,31 @@ var/XENOMORPH_EGG 	= "Xenomorph"
 	sort_order = 3
 
 /datum/category_item/player_setup_item/vore/egg/load_character(var/savefile/S)
-	S["egg_type"]		>> pref.egg_type
+	S["vore_egg_type"]		>> pref.vore_egg_type
 
 /datum/category_item/player_setup_item/vore/egg/save_character(var/savefile/S)
-	S["egg_type"]		<< pref.egg_type
+	S["vore_egg_type"]		<< pref.vore_egg_type
 
 /datum/category_item/player_setup_item/vore/egg/sanitize_character()
-	var/valid_egg_types = global_egg_types
-	pref.egg_type	 = sanitize_inlist(pref.egg_type, valid_egg_types, initial(pref.egg_type))
+	var/valid_vore_egg_types = global_vore_egg_types
+	pref.vore_egg_type	 = sanitize_inlist(pref.vore_egg_type, valid_vore_egg_types, initial(pref.vore_egg_type))
 
 /datum/category_item/player_setup_item/vore/egg/copy_to_mob(var/mob/living/carbon/human/character)
-	character.egg_type	= pref.egg_type
+	character.vore_egg_type	= pref.vore_egg_type
 
 /datum/category_item/player_setup_item/vore/egg/content(var/mob/user)
 	. += "<br>"
-	. += " Egg Type: <a href='?src=\ref[src];egg_type=1'>[pref.egg_type]</a><br>"
+	. += " Egg Type: <a href='?src=\ref[src];vore_egg_type=1'>[pref.vore_egg_type]</a><br>"
 
 /datum/category_item/player_setup_item/vore/egg/OnTopic(var/href, var/list/href_list, var/mob/user)
 	if(!CanUseTopic(user))
 		return TOPIC_NOACTION
 
-	else if(href_list["egg_type"])
-		var/list/egg_types = global_egg_types
-		var/selection = input(user, "Choose your character's egg type:", "Character Preference", pref.egg_type) as null|anything in egg_types
+	else if(href_list["vore_egg_type"])
+		var/list/vore_egg_types = global_vore_egg_types
+		var/selection = input(user, "Choose your character's egg type:", "Character Preference", pref.vore_egg_type) as null|anything in vore_egg_types
 		if(selection)
-			pref.egg_type = egg_types[selection]
+			pref.vore_egg_type = vore_egg_types[selection]
 			return TOPIC_REFRESH
 	else
 		return

--- a/code/modules/mob/living/simple_mob/subtypes/animal/giant_spider/nurse.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/giant_spider/nurse.dm
@@ -23,7 +23,7 @@
 
 	var/fed = 0 // Counter for how many egg laying 'charges' the spider has.
 	var/egg_inject_chance = 25 // One in four chance to get eggs.
-	egg_type = /obj/effect/spider/eggcluster/small //VORESTATION AI TEMPORARY EDIT
+	var/egg_type = /obj/effect/spider/eggcluster/small
 	var/web_type = /obj/effect/spider/stickyweb/dark
 
 

--- a/code/modules/vore/eating/living_vr.dm
+++ b/code/modules/vore/eating/living_vr.dm
@@ -9,7 +9,7 @@
 	var/weight = 137					// Weight for mobs for weightgain system
 	var/weight_gain = 1 				// How fast you gain weight
 	var/weight_loss = 0.5 				// How fast you lose weight
-	var/egg_type = "egg" 				// Default egg type.
+	var/vore_egg_type = "egg" 				// Default egg type.
 	var/feral = 0 						// How feral the mob is, if at all. Does nothing for non xenochimera at the moment.
 	var/reviving = 0					// Only used for creatures that have the xenochimera regen ability, so far.
 	var/metabolism = 0.0015

--- a/code/modules/vore/eating/transforming_vr.dm
+++ b/code/modules/vore/eating/transforming_vr.dm
@@ -252,9 +252,9 @@
 	var/egg_path = /obj/structure/closet/secure_closet/egg
 	var/egg_name = "odd egg"
 
-	if(O.egg_type in tf_egg_types)
-		egg_path = tf_egg_types[O.egg_type]
-		egg_name = "[O.egg_type] egg"
+	if(O.vore_egg_type in tf_vore_egg_types)
+		egg_path = tf_vore_egg_types[O.vore_egg_type]
+		egg_name = "[O.vore_egg_type] egg"
 
 	var/obj/structure/closet/secure_closet/egg/egg = new egg_path(src)
 	M.forceMove(egg)


### PR DESCRIPTION
Previously we used egg_types for vore shenanigans but the Nurse gianspider has decided  to use that too so now we have to change to avoid future conflicts.

Will also make the thing I commented in #4563 done.