### PR TITLE
Add Resh's HOS Coat

### DIFF
--- a/code/modules/vore/fluffstuff/custom_boxes_vr.dm
+++ b/code/modules/vore/fluffstuff/custom_boxes_vr.dm
@@ -228,7 +228,7 @@
 		/obj/item/clothing/gloves/fluff/morsleeves,
 		/obj/item/clothing/under/fluff/morunder)
 
-// Mewchild: Phi Viesti
+// Mewchild: Phi Vietsi
 /obj/item/weapon/storage/box/fluff/phi
 	name = "Phi's Personal Items"
 	has_items = list(

--- a/code/modules/vore/fluffstuff/custom_boxes_vr.dm
+++ b/code/modules/vore/fluffstuff/custom_boxes_vr.dm
@@ -228,7 +228,7 @@
 		/obj/item/clothing/gloves/fluff/morsleeves,
 		/obj/item/clothing/under/fluff/morunder)
 
-// Mewchild: Phi Ahkeen
+// Mewchild: Phi Viesti
 /obj/item/weapon/storage/box/fluff/phi
 	name = "Phi's Personal Items"
 	has_items = list(

--- a/code/modules/vore/fluffstuff/custom_clothes_vr.dm
+++ b/code/modules/vore/fluffstuff/custom_clothes_vr.dm
@@ -1689,7 +1689,7 @@ Departamental Swimsuits, for general use
 	icon_state = "kilanosuit_p"
 	item_state = "kilanosuit_p"
 
-//Mewchild: Phi Ahkeen
+//Mewchild: Phi Viesti
 /obj/item/clothing/gloves/ring/seal/signet/fluff/phi
 	name = "Phi's Bone Signet Ring"
 	desc = "A signet ring belonging to Phi, carved from the bones of something long extinct, as a ward against bad luck."
@@ -1810,3 +1810,14 @@ Departamental Swimsuits, for general use
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|ARMS
 	w_class = ITEMSIZE_NORMAL
 	slot = ACCESSORY_SLOT_OVER
+
+//Mr_Signmeup: Reshskakskakss Seekiseekis
+/obj/item/clothing/suit/security/navyhos
+	name = "head of security's jacket"
+	desc = "This piece of clothing was specifically designed for asserting superior authority."
+	
+	icon = 'icons/vore/custom_clothes_vr.dmi'
+	icon_state = "hosbluejacket"
+	
+	icon_override = 'icons/vore/custom_clothes_vr.dmi'
+	item_state = "hosbluejacket"

--- a/code/modules/vore/fluffstuff/custom_clothes_vr.dm
+++ b/code/modules/vore/fluffstuff/custom_clothes_vr.dm
@@ -1689,7 +1689,7 @@ Departamental Swimsuits, for general use
 	icon_state = "kilanosuit_p"
 	item_state = "kilanosuit_p"
 
-//Mewchild: Phi Viesti
+//Mewchild: Phi Vietsi
 /obj/item/clothing/gloves/ring/seal/signet/fluff/phi
 	name = "Phi's Bone Signet Ring"
 	desc = "A signet ring belonging to Phi, carved from the bones of something long extinct, as a ward against bad luck."

--- a/config/custom_items.txt
+++ b/config/custom_items.txt
@@ -584,7 +584,7 @@ item_path: /obj/item/weapon/implanter/reagent_generator/savannah
 # ######## M CKEYS
 {
 ckey: mewchild
-character_name: Phi Ahkeen
+character_name: Phi Viesti
 item_path: /obj/item/weapon/storage/box/fluff/phi
 }
 

--- a/config/custom_items.txt
+++ b/config/custom_items.txt
@@ -584,7 +584,7 @@ item_path: /obj/item/weapon/implanter/reagent_generator/savannah
 # ######## M CKEYS
 {
 ckey: mewchild
-character_name: Phi Viesti
+character_name: Phi Vietsi
 item_path: /obj/item/weapon/storage/box/fluff/phi
 }
 


### PR DESCRIPTION
So, I saw a thing on forums here, https://forum.vore-station.net/viewtopic.php?f=26&t=1519 and thought, 'hey, I can fix that.' So, here we are. :> Also adjusts Phi's last name - in the comment for the listing - as I've seen it in-game, back to Vietsi.
Edit: Couple pushes with two additional file edits for Phi's name change, mostly to make sure that he still gets his box of items.
Edit2: Typo fixes for comments/text file for Phi's last name. 