### PR TITLE
Adds telecomm coverage to midpoint

### DIFF
--- a/maps/tether/tether-02-surface2.dmm
+++ b/maps/tether/tether-02-surface2.dmm
@@ -17653,6 +17653,15 @@
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/tiled,
 /area/tcommsat/chamber)
+"HR" = (
+/obj/machinery/telecomms/relay/preset/tether/midpoint,
+/turf/simulated/floor/bluegrid{
+	name = "Mainframe Base";
+	nitrogen = 100;
+	oxygen = 0;
+	temperature = 80
+	},
+/area/tcommsat/chamber)
 "HT" = (
 /obj/item/weapon/storage/box/glasses/pint,
 /obj/item/weapon/storage/box/glass_extras/straws,
@@ -32865,7 +32874,7 @@ Gg
 Gq
 GD
 GP
-Gz
+HR
 Hd
 Hn
 Gz

--- a/maps/tether/tether_telecomms.dm
+++ b/maps/tether/tether_telecomms.dm
@@ -18,6 +18,12 @@
 	listening_level = Z_LEVEL_SURFACE_HIGH
 	autolinkers = list("tbh_relay")
 
+//Some coverage for midpoint
+/obj/machinery/telecomms/relay/preset/tether/midpoint
+	id = "Midpoint Relay"
+	listening_level = Z_LEVEL_TRANSIT
+	autolinkers = list("tmp_relay")
+
 // The station of course needs relays fluff-wise to connect to ground station. But again, no multi-z so, we need one for each z level.
 /obj/machinery/telecomms/relay/preset/tether/station_low
 	id = "Station Relay 1"
@@ -49,7 +55,7 @@
 	id = "Hub"
 	network = "tcommsat"
 	autolinkers = list("hub",
-		"tbl_relay", "tbm_relay", "tbh_relay", "tsl_relay", "tsm_relay", "tsh_relay",
+		"tbl_relay", "tbm_relay", "tbh_relay", "tmp_relay", "tsl_relay", "tsm_relay", "tsh_relay",
 		"c_relay", "m_relay", "r_relay", "sci_o_relay", "ud_relay",
 		"science", "medical", "supply", "service", "common", "command", "engineering", "security", "explorer", "unused",
 		"hb_relay", "receiverA", "broadcasterA"


### PR DESCRIPTION
Another potentially controversial thing, putting separately. Adds a fourth relay to surface telecomms, with coverage to the z-4/tether midpoint.

On one hand, it makes sense it would not be covered and it is occasioanlly used as a playground for event areas.
On the other it is really annoying to miss a single message or have to re-type yours duting those 2 seconds on midpoint.

Gonna see what admins think, really, was just suggested make a PR.

EDIT:To specify, which relay is Midpoint in case at any point admins want to make use of midpoint: https://imgur.com/yTH4C4M