### PR TITLE
Cleanup of Tether camera networks

### DIFF
--- a/maps/tether/tether-01-surface1.dmm
+++ b/maps/tether/tether-01-surface1.dmm
@@ -2960,16 +2960,23 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/mining_main/lobby)
 "aeT" = (
-/obj/structure/table/glass,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/borderfloor{
-	dir = 1
+	dir = 4
 	},
-/obj/effect/floor_decal/corner/brown/border{
-	dir = 1
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 4
 	},
-/obj/machinery/camera/network/cargo,
+/obj/machinery/camera/network/tether{
+	dir = 9
+	},
 /turf/simulated/floor/tiled,
-/area/tether/surfacebase/mining_main/lobby)
+/area/tether/surfacebase/public_garden)
 "aeU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -3273,6 +3280,17 @@
 /obj/random/tech_supply,
 /turf/simulated/floor/tiled,
 /area/storage/primary)
+"afs" = (
+/obj/structure/table/glass,
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 1
+	},
+/obj/machinery/camera/network/cargo,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/mining_main/lobby)
 "aft" = (
 /obj/machinery/camera/network/civilian{
 	dir = 2
@@ -3314,6 +3332,33 @@
 	},
 /turf/simulated/floor/tiled,
 /area/storage/primary)
+"afx" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/brown/bordercorner2{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 5
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 6
+	},
+/obj/machinery/camera/network/cargo{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/mining_main/lobby)
 "afy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -3332,6 +3377,20 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/tether/surfacebase/mining_main/eva)
+"afz" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/obj/machinery/camera/network/tether,
+/turf/simulated/floor/tiled,
+/area/hallway/lower/first_west)
 "afA" = (
 /obj/structure/catwalk,
 /turf/simulated/floor/tiled/techfloor,
@@ -3394,6 +3453,20 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/mining_main/eva)
+"afG" = (
+/obj/structure/bed/chair,
+/obj/machinery/camera/network/civilian,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/tram)
+"afH" = (
+/obj/effect/floor_decal/techfloor/orange{
+	dir = 4
+	},
+/obj/machinery/camera/network/civilian{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/tether/surfacebase/tram)
 "afI" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
@@ -3534,6 +3607,18 @@
 "afT" = (
 /turf/simulated/floor/tiled,
 /area/storage/primary)
+"afU" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/camera/network/civilian{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/tram)
 "afV" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled,
@@ -3548,6 +3633,40 @@
 	},
 /turf/simulated/floor,
 /area/maintenance/substation/mining)
+"afY" = (
+/obj/machinery/camera/network/civilian,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/tram)
+"afZ" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/grey/border{
+	icon_state = "bordercolor";
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 10
+	},
+/obj/machinery/camera/network/civilian{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/crew_quarters/visitor_laundry)
+"aga" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/grey/border{
+	icon_state = "bordercolor";
+	dir = 4
+	},
+/obj/machinery/vending/coffee,
+/obj/machinery/camera/network/civilian{
+	dir = 9
+	},
+/turf/simulated/floor/tiled,
+/area/crew_quarters/visitor_laundry)
 "agd" = (
 /obj/random/trash_pile,
 /turf/simulated/floor/tiled/techfloor,
@@ -3675,33 +3794,6 @@
 /obj/machinery/vending/tool,
 /turf/simulated/floor/tiled,
 /area/storage/primary)
-"agC" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/brown/border{
-	dir = 8
-	},
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/brown/bordercorner2{
-	dir = 8
-	},
-/obj/machinery/camera/network/cargo{
-	dir = 4
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 4
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 5
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 6
-	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/mining_main/lobby)
 "agD" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -19181,6 +19273,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/atrium_one)
+"bmh" = (
+/obj/machinery/camera/network/research{
+	dir = 4;
+	network = list("Xenobiology")
+	},
+/turf/simulated/floor/reinforced,
+/area/rnd/xenobiology)
 "bmm" = (
 /obj/machinery/door/window/brigdoor/eastleft{
 	name = "Containment Pen";
@@ -20311,24 +20410,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/atrium_one)
-"btx" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/borderfloor{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 4
-	},
-/obj/machinery/camera/network/civilian{
-	dir = 9
-	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/public_garden)
 "btD" = (
 /obj/effect/floor_decal/steeldecal/steel_decals6{
 	dir = 5
@@ -21716,6 +21797,13 @@
 	dir = 1
 	},
 /obj/structure/closet/firecloset/full,
+/turf/simulated/floor/tiled,
+/area/rnd/xenobiology)
+"bEd" = (
+/obj/machinery/computer/security/mining{
+	name = "xenobiology camera monitor";
+	network = list("Xenobiology")
+	},
 /turf/simulated/floor/tiled,
 /area/rnd/xenobiology)
 "bEf" = (
@@ -32207,19 +32295,19 @@ axf
 bhp
 azr
 azX
-adj
+bmh
 aDa
 bqk
 aDa
-adk
+bmh
 aBu
 azr
 azU
-adu
+bmh
 aBu
 azr
 azU
-adH
+bmh
 aBu
 azr
 aah
@@ -32934,7 +33022,7 @@ bNQ
 bQw
 bSu
 azU
-adI
+bmh
 azU
 azr
 aad
@@ -33493,7 +33581,7 @@ aDA
 bvF
 byz
 aHb
-adF
+bEd
 aAO
 aGt
 aAO
@@ -33502,7 +33590,7 @@ bOf
 bQK
 bSH
 bTk
-adJ
+bmh
 aDa
 bWk
 aad
@@ -34452,7 +34540,7 @@ aah
 aah
 aah
 ahl
-acN
+afz
 aiE
 ajq
 ako
@@ -35437,7 +35525,7 @@ wIm
 thL
 kuC
 xED
-btx
+aeT
 qGm
 aYz
 dYl
@@ -41548,7 +41636,7 @@ afk
 anL
 agl
 agx
-agC
+afx
 agN
 ahd
 ahv
@@ -42679,7 +42767,7 @@ afL
 adE
 aeg
 abP
-aeT
+afs
 afo
 afo
 agr
@@ -43597,7 +43685,7 @@ cce
 cda
 cjs
 ceK
-adh
+afZ
 cfL
 cgk
 chl
@@ -44595,7 +44683,7 @@ cfx
 cfU
 cfv
 chu
-adi
+aga
 ciK
 cjA
 ceM
@@ -44690,7 +44778,7 @@ aah
 aah
 aah
 apP
-acT
+afG
 arm
 arm
 arm
@@ -44704,7 +44792,7 @@ azl
 azR
 avb
 apP
-add
+afY
 arm
 cfi
 cfy
@@ -45125,7 +45213,7 @@ atu
 atu
 avX
 axd
-ada
+afU
 azo
 azS
 aAJ
@@ -46823,7 +46911,7 @@ apR
 aqG
 aTI
 aqG
-acV
+afH
 aTI
 aqG
 aqG
@@ -46835,7 +46923,7 @@ aTI
 aqG
 aqG
 aTI
-acV
+afH
 aqG
 aTI
 aqG

--- a/maps/tether/tether-01-surface1.dmm
+++ b/maps/tether/tether-01-surface1.dmm
@@ -2967,7 +2967,7 @@
 /obj/effect/floor_decal/corner/brown/border{
 	dir = 1
 	},
-/obj/machinery/camera/network/mining,
+/obj/machinery/camera/network/cargo,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/mining_main/lobby)
 "aeU" = (
@@ -3688,7 +3688,7 @@
 /obj/effect/floor_decal/corner/brown/bordercorner2{
 	dir = 8
 	},
-/obj/machinery/camera/network/mining{
+/obj/machinery/camera/network/cargo{
 	dir = 4
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals4{
@@ -4130,22 +4130,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/lower/first_west)
-"ahH" = (
-/obj/machinery/camera/network/civilian{
-	dir = 2
-	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 1
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7,
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/lower/first_west)
 "ahI" = (
 /obj/machinery/status_display{
 	pixel_y = 30
@@ -4246,7 +4230,7 @@
 /turf/simulated/floor/tiled,
 /area/hallway/lower/first_west)
 "ahR" = (
-/obj/machinery/camera/network/northern_star,
+/obj/machinery/camera/network/tether,
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
 	},
@@ -4414,7 +4398,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/camera/network/northern_star,
+/obj/machinery/camera/network/tether,
 /obj/effect/floor_decal/corner/lightgrey/border{
 	dir = 1
 	},
@@ -4528,7 +4512,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/camera/network/northern_star,
+/obj/machinery/camera/network/tether,
 /obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 4
 	},
@@ -6158,7 +6142,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/camera/network/northern_star{
+/obj/machinery/camera/network/tether{
 	dir = 5
 	},
 /obj/effect/floor_decal/corner/lightgrey/border{
@@ -6180,7 +6164,7 @@
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
 	},
-/obj/machinery/camera/network/northern_star{
+/obj/machinery/camera/network/tether{
 	dir = 9
 	},
 /obj/effect/floor_decal/corner/lightgrey/border{
@@ -7340,11 +7324,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/locker)
-"aqx" = (
-/obj/structure/bed/chair,
-/obj/machinery/camera/network/northern_star,
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/tram)
 "aqz" = (
 /obj/structure/bed/chair,
 /obj/machinery/status_display{
@@ -7910,7 +7889,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/camera/network/northern_star{
+/obj/machinery/camera/network/tether{
 	dir = 5
 	},
 /obj/effect/floor_decal/corner/lightgrey/border{
@@ -8047,15 +8026,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
-/area/tether/surfacebase/tram)
-"asK" = (
-/obj/effect/floor_decal/techfloor/orange{
-	dir = 4
-	},
-/obj/machinery/camera/network/northern_star{
-	dir = 9
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
 /area/tether/surfacebase/tram)
 "asL" = (
 /obj/effect/floor_decal/industrial/warning/corner,
@@ -8858,7 +8828,7 @@
 /area/tether/surfacebase/atrium_one)
 "auN" = (
 /obj/effect/floor_decal/borderfloor,
-/obj/machinery/camera/network/northern_star{
+/obj/machinery/camera/network/tether{
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/lightgrey/border,
@@ -10232,7 +10202,7 @@
 /area/tether/surfacebase/atrium_one)
 "axK" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/machinery/camera/network/northern_star,
+/obj/machinery/camera/network/tether,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -11283,7 +11253,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/camera/network/northern_star{
+/obj/machinery/camera/network/tether{
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/lightgrey/border,
@@ -11302,7 +11272,7 @@
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
 	},
-/obj/machinery/camera/network/northern_star{
+/obj/machinery/camera/network/tether{
 	dir = 8;
 	icon_state = "camera"
 	},
@@ -12532,7 +12502,7 @@
 "aCA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/rust,
-/obj/machinery/camera/network/northern_star{
+/obj/machinery/camera/network/tether{
 	dir = 4
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -13762,7 +13732,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/camera/network/northern_star{
+/obj/machinery/camera/network/tether{
 	dir = 8;
 	icon_state = "camera"
 	},
@@ -16606,7 +16576,7 @@
 /obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 10
 	},
-/obj/machinery/camera/network/northern_star{
+/obj/machinery/camera/network/tether{
 	dir = 8;
 	icon_state = "camera"
 	},
@@ -18228,7 +18198,7 @@
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
 	},
-/obj/machinery/camera/network/northern_star,
+/obj/machinery/camera/network/tether,
 /obj/effect/floor_decal/corner/lightgrey/border{
 	dir = 1
 	},
@@ -18256,10 +18226,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/visitor_dining)
-"bfC" = (
-/obj/machinery/camera/network/northern_star,
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/tram)
 "bfF" = (
 /obj/machinery/status_display{
 	pixel_y = 30
@@ -18456,7 +18422,7 @@
 	icon_state = "4-8";
 	pixel_x = 0
 	},
-/obj/machinery/camera/network/northern_star{
+/obj/machinery/camera/network/tether{
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/lightgrey/border,
@@ -18572,18 +18538,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/atrium_one)
-"bhj" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/obj/machinery/camera/network/northern_star{
-	dir = 5
-	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/tram)
 "bhk" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -19227,13 +19181,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/atrium_one)
-"bmh" = (
-/obj/machinery/camera/network/research{
-	dir = 4;
-	network = list("Xenobiology")
-	},
-/turf/simulated/floor/reinforced,
-/area/rnd/xenobiology)
 "bmm" = (
 /obj/machinery/door/window/brigdoor/eastleft{
 	name = "Containment Pen";
@@ -21771,13 +21718,6 @@
 /obj/structure/closet/firecloset/full,
 /turf/simulated/floor/tiled,
 /area/rnd/xenobiology)
-"bEd" = (
-/obj/machinery/computer/security/mining{
-	name = "xenobiology camera monitor";
-	network = list("Xenobiology")
-	},
-/turf/simulated/floor/tiled,
-/area/rnd/xenobiology)
 "bEf" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -22408,7 +22348,7 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/atrium_one)
 "bLY" = (
-/obj/machinery/camera/network/northern_star,
+/obj/machinery/camera/network/tether,
 /obj/effect/floor_decal/borderfloor{
 	dir = 5
 	},
@@ -23686,7 +23626,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/camera/network/northern_star{
+/obj/machinery/camera/network/tether{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
@@ -24517,7 +24457,7 @@
 /obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 10
 	},
-/obj/machinery/camera/network/northern_star{
+/obj/machinery/camera/network/tether{
 	dir = 9
 	},
 /obj/structure/disposalpipe/junction{
@@ -25898,19 +25838,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/atrium_one)
-"cft" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/grey/border{
-	icon_state = "bordercolor";
-	dir = 8
-	},
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 10
-	},
-/turf/simulated/floor/tiled,
-/area/crew_quarters/visitor_laundry)
 "cfv" = (
 /turf/simulated/floor/tiled,
 /area/crew_quarters/visitor_laundry)
@@ -26792,17 +26719,6 @@
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_6)
-"chW" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/grey/border{
-	icon_state = "bordercolor";
-	dir = 4
-	},
-/obj/machinery/vending/coffee,
-/turf/simulated/floor/tiled,
-/area/crew_quarters/visitor_laundry)
 "chY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/spline/plain{
@@ -32291,19 +32207,19 @@ axf
 bhp
 azr
 azX
-bmh
+adj
 aDa
 bqk
 aDa
-bmh
+adk
 aBu
 azr
 azU
-bmh
+adu
 aBu
 azr
 azU
-bmh
+adH
 aBu
 azr
 aah
@@ -33018,7 +32934,7 @@ bNQ
 bQw
 bSu
 azU
-bmh
+adI
 azU
 azr
 aad
@@ -33577,7 +33493,7 @@ aDA
 bvF
 byz
 aHb
-bEd
+adF
 aAO
 aGt
 aAO
@@ -33586,7 +33502,7 @@ bOf
 bQK
 bSH
 bTk
-bmh
+adJ
 aDa
 bWk
 aad
@@ -34536,7 +34452,7 @@ aah
 aah
 aah
 ahl
-ahH
+acN
 aiE
 ajq
 ako
@@ -43681,7 +43597,7 @@ cce
 cda
 cjs
 ceK
-cft
+adh
 cfL
 cgk
 chl
@@ -44679,7 +44595,7 @@ cfx
 cfU
 cfv
 chu
-chW
+adi
 ciK
 cjA
 ceM
@@ -44774,7 +44690,7 @@ aah
 aah
 aah
 apP
-aqx
+acT
 arm
 arm
 arm
@@ -44788,7 +44704,7 @@ azl
 azR
 avb
 apP
-bfC
+add
 arm
 cfi
 cfy
@@ -45209,7 +45125,7 @@ atu
 atu
 avX
 axd
-bhj
+ada
 azo
 azS
 aAJ
@@ -46907,7 +46823,7 @@ apR
 aqG
 aTI
 aqG
-asK
+acV
 aTI
 aqG
 aqG
@@ -46919,7 +46835,7 @@ aTI
 aqG
 aqG
 aTI
-asK
+acV
 aqG
 aTI
 aqG

--- a/maps/tether/tether-02-surface2.dmm
+++ b/maps/tether/tether-02-surface2.dmm
@@ -2199,7 +2199,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/camera/network/northern_star,
+/obj/machinery/camera/network/tether,
 /turf/simulated/floor/tiled/techmaint,
 /area/tether/surfacebase/atrium_two)
 "fe" = (
@@ -2406,7 +2406,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/camera/network/northern_star,
+/obj/machinery/camera/network/tether,
 /turf/simulated/floor/tiled/techmaint,
 /area/tether/surfacebase/atrium_two)
 "fr" = (
@@ -3177,7 +3177,7 @@
 /turf/simulated/wall,
 /area/tether/surfacebase/north_staires_two)
 "hd" = (
-/obj/machinery/camera/network/northern_star{
+/obj/machinery/camera/network/tether{
 	dir = 4
 	},
 /turf/simulated/open,
@@ -3219,7 +3219,7 @@
 /obj/effect/floor_decal/borderfloor/corner2{
 	dir = 10
 	},
-/obj/machinery/camera/network/northern_star{
+/obj/machinery/camera/network/tether{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techmaint,
@@ -3231,7 +3231,7 @@
 /obj/effect/floor_decal/borderfloor/corner2{
 	dir = 6
 	},
-/obj/machinery/camera/network/northern_star{
+/obj/machinery/camera/network/tether{
 	dir = 9
 	},
 /turf/simulated/floor/tiled/techmaint,
@@ -4603,7 +4603,7 @@
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
 	},
-/obj/machinery/camera/network/northern_star{
+/obj/machinery/camera/network/tether{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techmaint,
@@ -4612,7 +4612,7 @@
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
 	},
-/obj/machinery/camera/network/northern_star{
+/obj/machinery/camera/network/tether{
 	dir = 9
 	},
 /turf/simulated/floor/tiled/techmaint,
@@ -5652,7 +5652,7 @@
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
 	},
-/obj/machinery/camera/network/northern_star,
+/obj/machinery/camera/network/tether,
 /obj/machinery/firealarm{
 	dir = 2;
 	layer = 3.3;
@@ -6126,7 +6126,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/camera/network/northern_star{
+/obj/machinery/camera/network/tether{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -6371,7 +6371,7 @@
 /area/tether/surfacebase/atrium_two)
 "nG" = (
 /obj/effect/floor_decal/borderfloor,
-/obj/machinery/camera/network/northern_star{
+/obj/machinery/camera/network/tether{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/techmaint,
@@ -15944,7 +15944,7 @@
 	name = "\improper Telecomms Lobby"
 	})
 "EX" = (
-/obj/machinery/camera/network/telecom,
+/obj/machinery/camera/network/tcomms,
 /turf/simulated/floor/tiled/dark,
 /area/tcomsat{
 	name = "\improper Telecomms Lobby"
@@ -16085,7 +16085,7 @@
 	name = "\improper Telecomms Lobby"
 	})
 "Fk" = (
-/obj/machinery/camera/network/telecom,
+/obj/machinery/camera/network/tcomms,
 /obj/structure/sign/electricshock{
 	pixel_y = 32
 	},
@@ -16142,7 +16142,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
-/obj/machinery/camera/network/telecom{
+/obj/machinery/camera/network/tcomms{
 	dir = 4
 	},
 /obj/item/device/radio/intercom{
@@ -16532,7 +16532,7 @@
 	name = "\improper Telecomms Entrance"
 	})
 "FW" = (
-/obj/machinery/camera/network/telecom{
+/obj/machinery/camera/network/tcomms{
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
@@ -17207,7 +17207,7 @@
 	name = "\improper Telecomms Storage"
 	})
 "Hc" = (
-/obj/machinery/camera/network/telecom{
+/obj/machinery/camera/network/tcomms{
 	dir = 4
 	},
 /turf/simulated/floor/bluegrid{
@@ -17229,7 +17229,7 @@
 	},
 /area/tcommsat/chamber)
 "He" = (
-/obj/machinery/camera/network/telecom{
+/obj/machinery/camera/network/tcomms{
 	dir = 8
 	},
 /turf/simulated/floor/bluegrid{
@@ -17262,7 +17262,7 @@
 /obj/item/weapon/stock_parts/subspace/sub_filter,
 /obj/item/weapon/stock_parts/subspace/sub_filter,
 /obj/item/weapon/stock_parts/subspace/sub_filter,
-/obj/machinery/camera/network/telecom{
+/obj/machinery/camera/network/tcomms{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/techmaint,
@@ -17518,7 +17518,7 @@
 	},
 /area/tcommsat/chamber)
 "HI" = (
-/obj/machinery/camera/network/telecom{
+/obj/machinery/camera/network/tcomms{
 	dir = 1
 	},
 /turf/simulated/floor/bluegrid{

--- a/maps/tether/tether-03-surface3.dmm
+++ b/maps/tether/tether-03-surface3.dmm
@@ -9,7 +9,7 @@
 /turf/simulated/floor/outdoors/grass/sif/virgo3b,
 /area/tether/surfacebase/outside/outside3)
 "ad" = (
-/obj/machinery/camera/network/northern_star{
+/obj/machinery/camera/network/outside{
 	dir = 1
 	},
 /turf/simulated/floor/outdoors/grass/sif/virgo3b,
@@ -497,11 +497,10 @@
 /turf/simulated/floor/plating,
 /area/tether/surfacebase/reading_room)
 "bg" = (
-/obj/machinery/camera/network/security{
-	dir = 9
-	},
-/turf/simulated/floor/outdoors/grass/sif/virgo3b,
-/area/tether/surfacebase/outside/outside3)
+/obj/structure/shuttle/engine/propulsion,
+/turf/simulated/floor/reinforced,
+/turf/simulated/shuttle/plating/carry,
+/area/shuttle/tether/surface)
 "bh" = (
 /turf/simulated/wall/r_wall,
 /area/gateway/prep_room)
@@ -2895,7 +2894,7 @@
 /turf/simulated/floor/plating,
 /area/tether/surfacebase/medical/lobby)
 "fF" = (
-/obj/machinery/camera/network/northern_star{
+/obj/machinery/camera/network/outside{
 	dir = 8
 	},
 /turf/simulated/floor/outdoors/grass/sif/virgo3b,
@@ -4723,7 +4722,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/machinery/camera/network/northern_star,
+/obj/machinery/camera/network/tether,
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
 	},
@@ -4963,7 +4962,7 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/atrium_three)
 "iK" = (
-/obj/machinery/camera/network/northern_star,
+/obj/machinery/camera/network/tether,
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
 	},
@@ -5066,7 +5065,7 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals7,
-/obj/machinery/camera/network/northern_star,
+/obj/machinery/camera/network/tether,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/atrium_three)
 "iR" = (
@@ -5244,7 +5243,7 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/atrium_three)
 "jc" = (
-/obj/machinery/camera/network/northern_star,
+/obj/machinery/camera/network/tether,
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
 	},
@@ -5885,7 +5884,7 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/panic_shelter)
 "kk" = (
-/obj/machinery/camera/network/northern_star{
+/obj/machinery/camera/network/outside{
 	dir = 4
 	},
 /turf/simulated/floor/outdoors/grass/sif/virgo3b,
@@ -5935,15 +5934,15 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/atrium_three)
 "ko" = (
-/obj/machinery/camera/network/civilian{
-	dir = 1
-	},
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/lightgrey/border,
 /obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 8
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 1
+	},
+/obj/machinery/camera/network/tether{
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
@@ -6257,7 +6256,7 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/atrium_three)
 "kM" = (
-/obj/machinery/camera/network/northern_star{
+/obj/machinery/camera/network/tether{
 	dir = 9
 	},
 /obj/effect/floor_decal/borderfloor{
@@ -6548,7 +6547,7 @@
 /obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 10
 	},
-/obj/machinery/camera/network/northern_star{
+/obj/machinery/camera/network/tether{
 	dir = 9
 	},
 /turf/simulated/floor/tiled,
@@ -7408,7 +7407,7 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/tether/surfacebase/north_stairs_three)
 "nd" = (
-/obj/machinery/camera/network/northern_star{
+/obj/machinery/camera/network/tether{
 	dir = 4
 	},
 /turf/simulated/open,
@@ -7423,7 +7422,7 @@
 /turf/simulated/wall,
 /area/tether/surfacebase/north_stairs_three)
 "ng" = (
-/obj/machinery/camera/network/northern_star{
+/obj/machinery/camera/network/tether{
 	dir = 4
 	},
 /obj/effect/floor_decal/borderfloor{
@@ -9594,7 +9593,7 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/atrium_three)
 "qS" = (
-/obj/machinery/camera/network/northern_star{
+/obj/machinery/camera/network/tether{
 	dir = 9
 	},
 /obj/effect/floor_decal/borderfloor{
@@ -9795,7 +9794,7 @@
 	name = "\improper Recreation Area Showers"
 	})
 "rn" = (
-/obj/machinery/camera/network/northern_star{
+/obj/machinery/camera/network/tether{
 	dir = 4
 	},
 /obj/effect/floor_decal/borderfloor{
@@ -10262,7 +10261,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/camera/network/northern_star,
+/obj/machinery/camera/network/tether,
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
 	},
@@ -11746,7 +11745,7 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals7,
-/obj/machinery/camera/network/northern_star,
+/obj/machinery/camera/network/tether,
 /obj/item/device/radio/intercom{
 	dir = 1;
 	pixel_y = 24;
@@ -12643,7 +12642,7 @@
 /turf/simulated/floor/tiled,
 /area/hallway/lower/third_south)
 "wh" = (
-/obj/machinery/camera/network/northern_star{
+/obj/machinery/camera/network/tether{
 	dir = 1
 	},
 /obj/effect/floor_decal/borderfloor,
@@ -13912,7 +13911,7 @@
 /area/hallway/lower/third_south)
 "yw" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/camera/network/northern_star{
+/obj/machinery/camera/network/tether{
 	dir = 9
 	},
 /obj/effect/floor_decal/borderfloor{
@@ -15271,12 +15270,6 @@
 /obj/machinery/computer/arcade,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
-"AS" = (
-/obj/machinery/camera/network/northern_star{
-	dir = 9
-	},
-/turf/simulated/floor/outdoors/grass/sif/virgo3b,
-/area/tether/surfacebase/outside/outside3)
 "AT" = (
 /obj/structure/railing,
 /turf/simulated/open,
@@ -16416,7 +16409,7 @@
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/mauve/border,
 /obj/effect/floor_decal/steeldecal/steel_decals4,
-/obj/machinery/camera/network/northern_star{
+/obj/machinery/camera/network/tether{
 	dir = 1
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals7{
@@ -17883,10 +17876,11 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/assembly/robotics)
 "EV" = (
-/obj/structure/shuttle/engine/propulsion,
-/turf/simulated/floor/reinforced,
-/turf/simulated/shuttle/plating/carry,
-/area/shuttle/tether/surface)
+/obj/machinery/camera/network/civilian{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/tether/surfacebase/shuttle_pad)
 "EW" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
@@ -18222,7 +18216,7 @@
 /turf/simulated/floor/tiled,
 /area/hallway/lower/third_south)
 "Fs" = (
-/obj/machinery/camera/network/northern_star,
+/obj/machinery/camera/network/tether,
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
 	},
@@ -18471,6 +18465,10 @@
 	},
 /turf/simulated/floor/lino,
 /area/crew_quarters/bar)
+"FK" = (
+/obj/machinery/camera/network/outside,
+/turf/simulated/floor/outdoors/grass/sif/virgo3b,
+/area/tether/surfacebase/outside/outside3)
 "FM" = (
 /obj/structure/sink{
 	dir = 4;
@@ -19026,7 +19024,7 @@
 /turf/simulated/floor/tiled,
 /area/hallway/lower/third_south)
 "GJ" = (
-/obj/machinery/camera/network/northern_star{
+/obj/machinery/camera/network/tether{
 	dir = 1
 	},
 /obj/effect/floor_decal/borderfloor,
@@ -19175,7 +19173,7 @@
 /turf/simulated/floor/tiled,
 /area/hallway/lower/third_south)
 "GU" = (
-/obj/machinery/camera/network/northern_star{
+/obj/machinery/camera/network/tether{
 	dir = 1
 	},
 /obj/effect/floor_decal/borderfloor,
@@ -20024,7 +20022,7 @@
 "It" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/camera/network/northern_star{
+/obj/machinery/camera/network/tether{
 	dir = 4
 	},
 /obj/effect/floor_decal/borderfloor{
@@ -20609,7 +20607,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/camera/network/northern_star{
+/obj/machinery/camera/network/tether{
 	dir = 9
 	},
 /obj/effect/floor_decal/borderfloor{
@@ -21067,7 +21065,7 @@
 /turf/simulated/floor/tiled,
 /area/hallway/lower/third_south)
 "Kk" = (
-/obj/machinery/camera/network/northern_star{
+/obj/machinery/camera/network/tether{
 	dir = 1
 	},
 /obj/effect/floor_decal/borderfloor,
@@ -21277,12 +21275,6 @@
 /obj/machinery/light,
 /turf/simulated/floor/reinforced,
 /area/tether/surfacebase/shuttle_pad)
-"KJ" = (
-/obj/machinery/camera/network/engineering{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/tether/surfacebase/shuttle_pad)
 "KK" = (
 /obj/structure/table/steel,
 /turf/simulated/floor/tiled/techfloor,
@@ -21294,10 +21286,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/tether/surfacebase/shuttle_pad)
-"KM" = (
-/obj/machinery/camera/network/northern_star,
-/turf/simulated/floor/outdoors/grass/sif/virgo3b,
-/area/tether/surfacebase/outside/outside3)
 "KO" = (
 /obj/structure/table/marble,
 /obj/item/weapon/flame/lighter/zippo,
@@ -28270,7 +28258,7 @@ ac
 ac
 ac
 ac
-bg
+fF
 ac
 ac
 ac
@@ -29245,7 +29233,7 @@ ac
 ac
 ac
 ac
-bg
+fF
 ac
 ac
 ac
@@ -29432,7 +29420,7 @@ ac
 ac
 ac
 ac
-AS
+fF
 ac
 ac
 ac
@@ -33429,7 +33417,7 @@ ac
 ac
 ac
 ac
-AS
+fF
 ac
 ac
 ac
@@ -35854,7 +35842,7 @@ IR
 IR
 IR
 IR
-KM
+FK
 ac
 ac
 ac
@@ -36270,7 +36258,7 @@ Jr
 Jv
 Jz
 JE
-EV
+bg
 JM
 IY
 IY
@@ -36412,7 +36400,7 @@ Js
 Js
 Jz
 JE
-EV
+bg
 JM
 IY
 IY
@@ -36554,7 +36542,7 @@ Jt
 Js
 Jz
 JE
-EV
+bg
 JM
 IY
 IY
@@ -36685,7 +36673,7 @@ Gm
 GW
 Hr
 ac
-AS
+fF
 ac
 IS
 IY
@@ -37556,7 +37544,7 @@ IR
 Kv
 Kv
 KE
-KJ
+EV
 IR
 ac
 ac
@@ -38126,7 +38114,7 @@ IR
 IR
 IR
 IR
-KM
+FK
 ac
 ac
 ac

--- a/maps/tether/tether-05-station1.dmm
+++ b/maps/tether/tether-05-station1.dmm
@@ -923,10 +923,9 @@
 /turf/simulated/floor,
 /area/maintenance/station/eng_lower)
 "abU" = (
-/obj/machinery/camera/network/northern_star,
-/obj/effect/floor_decal/steeldecal/steel_decals6{
-	dir = 10
-	},
+/obj/effect/floor_decal/borderfloorblack,
+/obj/effect/floor_decal/industrial/danger,
+/obj/machinery/camera/network/exploration,
 /turf/simulated/floor/tiled,
 /area/tether/station/excursion_dock)
 "abV" = (
@@ -2085,7 +2084,7 @@
 /obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 4
 	},
-/obj/machinery/camera/network/northern_star{
+/obj/machinery/camera/network/tether{
 	dir = 2
 	},
 /turf/simulated/floor/tiled,
@@ -2944,7 +2943,7 @@
 /turf/simulated/wall/r_wall,
 /area/hallway/station/atrium)
 "afD" = (
-/obj/machinery/camera/network/northern_star{
+/obj/machinery/camera/network/tether{
 	dir = 4
 	},
 /obj/effect/floor_decal/borderfloor{
@@ -3170,10 +3169,10 @@
 /turf/simulated/floor/tiled,
 /area/bridge_hallway)
 "afW" = (
-/obj/structure/shuttle/engine/propulsion,
-/turf/simulated/floor/reinforced,
-/turf/simulated/shuttle/plating/airless/carry,
-/area/shuttle/excursion/tether)
+/obj/structure/closet/secure_closet/pilot,
+/obj/machinery/camera/network/exploration,
+/turf/simulated/floor/tiled,
+/area/tether/station/explorer_prep)
 "afX" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -3416,6 +3415,72 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/carpet,
 /area/library)
+"agq" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/machinery/camera/network/exploration,
+/turf/simulated/floor/tiled/monotile,
+/area/tether/station/excursion_dock)
+"agr" = (
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 10
+	},
+/obj/machinery/camera/network/exploration,
+/turf/simulated/floor/tiled,
+/area/tether/station/excursion_dock)
+"ags" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/machinery/camera/network/exploration{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/pathfinder_office)
+"agt" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/machinery/camera/network/exploration,
+/turf/simulated/floor/tiled/monotile,
+/area/tether/station/excursion_dock)
+"agu" = (
+/obj/structure/shuttle/engine/propulsion,
+/turf/simulated/floor/reinforced,
+/turf/simulated/shuttle/plating/airless/carry,
+/area/shuttle/excursion/tether)
+"agv" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/camera/network/exploration{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/tether/station/excursion_dock)
+"agw" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/purple/border{
+	icon_state = "bordercolor";
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 4;
+	icon_state = "extinguisher_closed";
+	pixel_x = -30
+	},
+/obj/machinery/camera/network/exploration{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/explorer_meeting)
 "agx" = (
 /obj/structure/bed/chair/comfy/blue{
 	icon_state = "comfychair_preview";
@@ -3423,6 +3488,20 @@
 	},
 /turf/simulated/shuttle/floor/black,
 /area/shuttle/excursion/tether)
+"agy" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/purple/border{
+	icon_state = "bordercolor";
+	dir = 4
+	},
+/obj/machinery/photocopier,
+/obj/machinery/camera/network/exploration{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/explorer_meeting)
 "agF" = (
 /obj/effect/floor_decal/industrial/warning{
 	icon_state = "warning";
@@ -3647,7 +3726,7 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals7,
-/obj/machinery/camera/network/northern_star,
+/obj/machinery/camera/network/tether,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -6534,7 +6613,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/camera/network/northern_star{
+/obj/machinery/camera/network/tether{
 	dir = 1
 	},
 /obj/effect/floor_decal/borderfloor,
@@ -8447,7 +8526,7 @@
 /obj/effect/floor_decal/industrial/loading{
 	dir = 1
 	},
-/obj/machinery/camera/network/northern_star{
+/obj/machinery/camera/network/tether{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
@@ -9398,7 +9477,7 @@
 /area/storage/tools)
 "azQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/machinery/camera/network/northern_star{
+/obj/machinery/camera/network/tether{
 	dir = 5
 	},
 /obj/effect/floor_decal/borderfloor{
@@ -9631,7 +9710,7 @@
 	dir = 2;
 	icon_state = "pipe-c"
 	},
-/obj/machinery/camera/network/northern_star,
+/obj/machinery/camera/network/tether,
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
 	},
@@ -9863,7 +9942,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/camera/network/northern_star,
+/obj/machinery/camera/network/tether,
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
 	},
@@ -10182,7 +10261,7 @@
 /area/crew_quarters/sleep/engi_wash)
 "aAX" = (
 /obj/structure/bed/chair,
-/obj/machinery/camera/network/northern_star,
+/obj/machinery/camera/network/tether,
 /turf/simulated/floor/tiled,
 /area/hallway/station/docks)
 "aAZ" = (
@@ -10571,7 +10650,7 @@
 /turf/simulated/floor/tiled,
 /area/hallway/station/atrium)
 "aCc" = (
-/obj/machinery/camera/network/northern_star{
+/obj/machinery/camera/network/tether{
 	dir = 9
 	},
 /turf/simulated/floor/tiled,
@@ -11189,7 +11268,7 @@
 /obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 6
 	},
-/obj/machinery/camera/network/northern_star{
+/obj/machinery/camera/network/tether{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
@@ -11735,7 +11814,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/camera/network/northern_star{
+/obj/machinery/camera/network/tether{
 	dir = 9
 	},
 /obj/effect/floor_decal/borderfloor{
@@ -12202,7 +12281,7 @@
 "aHs" = (
 /obj/machinery/door/firedoor/glass/hidden/steel,
 /obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/machinery/camera/network/northern_star{
+/obj/machinery/camera/network/tether{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
@@ -12627,7 +12706,7 @@
 /turf/simulated/floor/tiled,
 /area/tether/station/dock_two)
 "aIS" = (
-/obj/machinery/camera/network/northern_star{
+/obj/machinery/camera/network/tether{
 	dir = 9
 	},
 /turf/simulated/floor/tiled,
@@ -15539,7 +15618,7 @@
 	icon_state = "4-8";
 	pixel_x = 0
 	},
-/obj/machinery/camera/network/northern_star{
+/obj/machinery/camera/network/tether{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -16549,7 +16628,7 @@
 	pixel_x = 25;
 	pixel_y = 0
 	},
-/obj/machinery/camera/network/northern_star,
+/obj/machinery/camera/network/tether,
 /obj/effect/floor_decal/borderfloor{
 	dir = 1;
 	icon_state = "borderfloor";
@@ -17521,7 +17600,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/camera/network/northern_star{
+/obj/machinery/camera/network/tether{
 	dir = 1
 	},
 /obj/effect/floor_decal/borderfloor,
@@ -18078,7 +18157,7 @@
 	pixel_x = 0;
 	pixel_y = 26
 	},
-/obj/machinery/camera/network/northern_star,
+/obj/machinery/camera/network/tether,
 /turf/simulated/floor/tiled,
 /area/hallway/station/docks)
 "bsv" = (
@@ -20103,7 +20182,7 @@
 /turf/simulated/floor/tiled,
 /area/tether/station/dock_two)
 "bHY" = (
-/obj/machinery/camera/network/northern_star{
+/obj/machinery/camera/network/tether{
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -20820,7 +20899,7 @@
 	req_access = list(13)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/machinery/camera/network/northern_star{
+/obj/machinery/camera/network/tether{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
@@ -20984,7 +21063,7 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 10
 	},
-/obj/machinery/camera/network/northern_star{
+/obj/machinery/camera/network/tether{
 	dir = 4
 	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
@@ -21447,7 +21526,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 6
 	},
-/obj/machinery/camera/network/northern_star{
+/obj/machinery/camera/network/tether{
 	dir = 4
 	},
 /obj/machinery/newscaster{
@@ -21614,20 +21693,6 @@
 	dir = 4
 	},
 /obj/machinery/vending/snack,
-/turf/simulated/floor/tiled,
-/area/tether/station/explorer_meeting)
-"dPZ" = (
-/obj/machinery/camera/network/northern_star{
-	dir = 8
-	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/purple/border{
-	icon_state = "bordercolor";
-	dir = 4
-	},
-/obj/machinery/photocopier,
 /turf/simulated/floor/tiled,
 /area/tether/station/explorer_meeting)
 "edg" = (
@@ -21989,12 +22054,6 @@
 /obj/machinery/vending/cola,
 /turf/simulated/floor/tiled,
 /area/tether/station/explorer_meeting)
-"mcB" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/tether/station/pathfinder_office)
 "mtd" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/folder/yellow,
@@ -22031,25 +22090,6 @@
 	},
 /obj/effect/landmark/start{
 	name = "Field Medic"
-	},
-/turf/simulated/floor/tiled,
-/area/tether/station/explorer_meeting)
-"mJI" = (
-/obj/machinery/camera/network/northern_star{
-	dir = 5
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/borderfloor{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/purple/border{
-	icon_state = "bordercolor";
-	dir = 8
-	},
-/obj/structure/extinguisher_cabinet{
-	dir = 4;
-	icon_state = "extinguisher_closed";
-	pixel_x = -30
 	},
 /turf/simulated/floor/tiled,
 /area/tether/station/explorer_meeting)
@@ -22118,10 +22158,6 @@
 	},
 /turf/simulated/floor/carpet,
 /area/hallway/station/atrium)
-"nOF" = (
-/obj/structure/closet/secure_closet/pilot,
-/turf/simulated/floor/tiled,
-/area/tether/station/explorer_prep)
 "nSw" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
@@ -22307,12 +22343,6 @@
 /obj/item/device/binoculars,
 /turf/simulated/floor/tiled,
 /area/tether/station/pathfinder_office)
-"rhA" = (
-/obj/effect/floor_decal/borderfloorblack,
-/obj/effect/floor_decal/industrial/danger,
-/obj/machinery/camera/network/northern_star,
-/turf/simulated/floor/tiled,
-/area/tether/station/excursion_dock)
 "rRn" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 1
@@ -22333,13 +22363,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/station/explorer_meeting)
-"soc" = (
-/obj/machinery/camera/network/northern_star,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/tether/station/excursion_dock)
 "sSn" = (
 /obj/effect/floor_decal/steeldecal/steel_decals5{
 	dir = 4
@@ -22570,13 +22593,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/station/explorer_meeting)
-"wbr" = (
-/obj/machinery/camera/network/northern_star,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/tether/station/excursion_dock)
 "wcD" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
@@ -22666,18 +22682,6 @@
 /obj/structure/table/bench/padded,
 /turf/simulated/floor/carpet,
 /area/hallway/station/atrium)
-"xhk" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/camera/network/northern_star{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/tether/station/excursion_dock)
 "xhv" = (
 /obj/machinery/door/airlock/glass{
 	name = "Shuttle Bay"
@@ -33262,7 +33266,7 @@ aah
 aah
 aaP
 aad
-wbr
+agq
 aah
 akC
 aah
@@ -33556,7 +33560,7 @@ aao
 aao
 aao
 asY
-xhk
+agv
 aad
 ack
 aaT
@@ -33682,7 +33686,7 @@ aat
 aat
 aat
 aad
-rhA
+abU
 aap
 aap
 aap
@@ -33696,7 +33700,7 @@ aeo
 aaq
 aaq
 aau
-afW
+agu
 avK
 avN
 aad
@@ -33838,7 +33842,7 @@ amF
 avG
 adB
 aaq
-afW
+agu
 avK
 avN
 aad
@@ -33980,7 +33984,7 @@ amF
 avG
 adB
 aaq
-afW
+agu
 avK
 auH
 aad
@@ -34832,7 +34836,7 @@ aaD
 avG
 tIi
 aaq
-afW
+agu
 avK
 auQ
 aad
@@ -34974,7 +34978,7 @@ amL
 aob
 dbI
 aaq
-afW
+agu
 avK
 qgR
 aad
@@ -35102,7 +35106,7 @@ aat
 aat
 aat
 aad
-rhA
+abU
 aap
 aap
 aap
@@ -35116,7 +35120,7 @@ aep
 aeu
 aev
 aau
-afW
+agu
 avK
 qgR
 aad
@@ -35534,14 +35538,14 @@ aah
 pTz
 abc
 aad
-abU
+agr
 acN
 jdD
 adP
 amP
 fmN
 aad
-soc
+agt
 nxL
 coV
 abc
@@ -35829,7 +35833,7 @@ hCe
 oaO
 wFb
 vUO
-mJI
+agw
 mCP
 epz
 ash
@@ -35966,7 +35970,7 @@ amU
 hCe
 adO
 afe
-mcB
+ags
 hCe
 fsu
 sbI
@@ -36100,7 +36104,7 @@ aaa
 aaa
 aac
 aad
-nOF
+afW
 akL
 bQQ
 adj
@@ -36965,7 +36969,7 @@ hCe
 qzk
 dMN
 mcn
-dPZ
+agy
 afT
 ixk
 ash

--- a/maps/tether/tether-06-station2.dmm
+++ b/maps/tether/tether-06-station2.dmm
@@ -3367,15 +3367,14 @@
 /turf/simulated/floor/plating,
 /area/hallway/station/starboard)
 "fh" = (
-/obj/structure/shuttle/engine/propulsion{
-	dir = 8;
-	icon_state = "propulsion_l"
+/obj/effect/floor_decal/techfloor{
+	dir = 8
 	},
-/turf/space,
-/turf/simulated/shuttle/plating/airless/carry,
-/area/shuttle/large_escape_pod1/station{
-	base_turf = /turf/simulated/mineral/floor/vacuum
-	})
+/obj/machinery/camera/network/command{
+	dir = 4
+	},
+/turf/simulated/floor/bluegrid,
+/area/ai_upload)
 "fi" = (
 /obj/machinery/alarm{
 	dir = 4;
@@ -3434,17 +3433,18 @@
 /turf/simulated/wall,
 /area/chapel/main)
 "fp" = (
-/obj/effect/floor_decal/techfloor{
-	dir = 8
+/obj/structure/sink{
+	dir = 4;
+	icon_state = "sink";
+	pixel_x = 11;
+	pixel_y = 0
 	},
-/obj/machinery/camera/motion/security{
-	dir = 4
-	},
-/turf/simulated/floor/bluegrid,
-/area/ai_upload)
+/turf/simulated/floor/tiled/white,
+/area/medical/virologyaccess)
 "fq" = (
 /obj/structure/shuttle/engine/propulsion{
-	dir = 8
+	dir = 8;
+	icon_state = "propulsion_l"
 	},
 /turf/space,
 /turf/simulated/shuttle/plating/airless/carry,
@@ -3477,8 +3477,7 @@
 /area/ai_upload)
 "fu" = (
 /obj/structure/shuttle/engine/propulsion{
-	dir = 8;
-	icon_state = "propulsion_r"
+	dir = 8
 	},
 /turf/space,
 /turf/simulated/shuttle/plating/airless/carry,
@@ -3494,6 +3493,16 @@
 	},
 /turf/simulated/floor/bluegrid,
 /area/ai_upload)
+"fw" = (
+/obj/structure/shuttle/engine/propulsion{
+	dir = 8;
+	icon_state = "propulsion_r"
+	},
+/turf/space,
+/turf/simulated/shuttle/plating/airless/carry,
+/area/shuttle/large_escape_pod1/station{
+	base_turf = /turf/simulated/mineral/floor/vacuum
+	})
 "fx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/rack{
@@ -5838,7 +5847,7 @@
 /turf/simulated/floor/tiled,
 /area/hallway/station/starboard)
 "la" = (
-/obj/machinery/camera/network/northern_star,
+/obj/machinery/camera/network/tether,
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
 	},
@@ -7094,7 +7103,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/camera/network/northern_star,
+/obj/machinery/camera/network/tether,
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
 	},
@@ -7841,7 +7850,7 @@
 /turf/simulated/floor/tiled,
 /area/hallway/station/starboard)
 "op" = (
-/obj/machinery/camera/network/northern_star{
+/obj/machinery/camera/network/tether{
 	dir = 1
 	},
 /obj/structure/cable{
@@ -7949,7 +7958,7 @@
 /turf/simulated/floor/tiled,
 /area/hallway/station/starboard)
 "ow" = (
-/obj/machinery/camera/network/northern_star{
+/obj/machinery/camera/network/tether{
 	dir = 1
 	},
 /obj/effect/floor_decal/borderfloor,
@@ -9235,7 +9244,7 @@
 	icon_state = "4-8";
 	pixel_x = 0
 	},
-/obj/machinery/camera/network/northern_star,
+/obj/machinery/camera/network/tether,
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
 	},
@@ -10066,7 +10075,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/camera/network/northern_star{
+/obj/machinery/camera/network/tether{
 	dir = 1
 	},
 /obj/effect/floor_decal/borderfloor,
@@ -12225,7 +12234,7 @@
 /turf/simulated/floor/tiled,
 /area/tether/station/stairs_two)
 "vQ" = (
-/obj/machinery/camera/network/northern_star{
+/obj/machinery/camera/network/tether{
 	dir = 1
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals6{
@@ -13939,18 +13948,6 @@
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 5
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/virologyaccess)
-"yH" = (
-/obj/structure/sink{
-	dir = 4;
-	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
-	},
-/obj/machinery/camera/network/medbay{
-	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virologyaccess)
@@ -30104,11 +30101,11 @@ AN
 AN
 Bw
 yY
-fh
-fq
-fq
 fq
 fu
+fu
+fu
+fw
 yY
 ac
 ac
@@ -30520,7 +30517,7 @@ wF
 xn
 xE
 yd
-yH
+fp
 yX
 zv
 zW
@@ -31054,7 +31051,7 @@ bg
 db
 dE
 To
-fp
+fh
 eE
 gm
 dE

--- a/maps/tether/tether-07-station3.dmm
+++ b/maps/tether/tether-07-station3.dmm
@@ -14335,7 +14335,7 @@
 	pixel_x = -27;
 	pixel_y = 0
 	},
-/obj/machinery/camera/network/northern_star{
+/obj/machinery/camera/network/tether{
 	dir = 4
 	},
 /obj/effect/floor_decal/borderfloor{
@@ -14630,7 +14630,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/camera/network/northern_star,
+/obj/machinery/camera/network/tether,
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
 	},
@@ -15194,7 +15194,7 @@
 	pixel_x = -27;
 	pixel_y = 0
 	},
-/obj/machinery/camera/network/northern_star{
+/obj/machinery/camera/network/tether{
 	dir = 4
 	},
 /obj/effect/floor_decal/borderfloor{
@@ -15673,7 +15673,7 @@
 /obj/effect/floor_decal/corner/lightgrey{
 	dir = 6
 	},
-/obj/machinery/camera/network/northern_star,
+/obj/machinery/camera/network/tether,
 /obj/structure/table/bench/standard,
 /obj/effect/floor_decal/steeldecal/steel_decals6{
 	dir = 9
@@ -15936,7 +15936,7 @@
 /turf/simulated/floor/tiled,
 /area/hallway/station/upper)
 "yR" = (
-/obj/machinery/camera/network/northern_star{
+/obj/machinery/camera/network/tether{
 	dir = 1
 	},
 /obj/effect/floor_decal/borderfloor,
@@ -16675,7 +16675,7 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals7,
-/obj/machinery/camera/network/northern_star,
+/obj/machinery/camera/network/tether,
 /turf/simulated/floor/tiled,
 /area/hallway/station/upper)
 "zY" = (
@@ -16861,7 +16861,7 @@
 /turf/simulated/floor/tiled,
 /area/hallway/station/upper)
 "Aj" = (
-/obj/machinery/camera/network/northern_star,
+/obj/machinery/camera/network/tether,
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
 	},
@@ -18048,7 +18048,7 @@
 /turf/simulated/floor/tiled,
 /area/hallway/station/upper)
 "Cg" = (
-/obj/machinery/camera/network/northern_star{
+/obj/machinery/camera/network/tether{
 	dir = 1
 	},
 /obj/effect/floor_decal/borderfloor,
@@ -19446,7 +19446,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
-/obj/machinery/camera/network/northern_star{
+/obj/machinery/camera/network/tether{
 	dir = 9
 	},
 /obj/effect/floor_decal/industrial/warning,

--- a/maps/tether/tether_defines.dm
+++ b/maps/tether/tether_defines.dm
@@ -41,6 +41,13 @@
 #define Z_LEVEL_AEROSTAT					17
 #define Z_LEVEL_AEROSTAT_SURFACE			18
 
+//Camera networks
+#define NETWORK_TETHER "Tether"
+#define NETWORK_TCOMMS "Telecommunications" //Using different from Polaris one for better name
+#define NETWORK_OUTSIDE "Outside"
+#define NETWORK_EXPLORATION "Exploration"
+#define NETWORK_XENOBIO "Xenobiology"
+
 /datum/map/tether
 	name = "Virgo"
 	full_name = "NSB Adephagia"
@@ -84,17 +91,17 @@
 							NETWORK_COMMAND,
 							NETWORK_ENGINE,
 							NETWORK_ENGINEERING,
-							NETWORK_ENGINEERING_OUTPOST,
-							NETWORK_DEFAULT,
+							NETWORK_EXPLORATION,
+							//NETWORK_DEFAULT,  //Is this even used for anything? Robots show up here, but they show up in ROBOTS network too
 							NETWORK_MEDICAL,
 							NETWORK_MINE,
-							NETWORK_NORTHERN_STAR,
+							NETWORK_OUTSIDE,
 							NETWORK_RESEARCH,
 							NETWORK_RESEARCH_OUTPOST,
 							NETWORK_ROBOTS,
-							NETWORK_PRISON,
 							NETWORK_SECURITY,
-							NETWORK_INTERROGATION
+							NETWORK_TCOMMS,
+							NETWORK_TETHER
 							)
 
 	allowed_spawns = list("Tram Station","Gateway","Cryogenic Storage","Cyborg Storage")

--- a/maps/tether/tether_things.dm
+++ b/maps/tether/tether_things.dm
@@ -435,6 +435,38 @@ var/global/list/latejoin_tram   = list()
 /obj/machinery/cryopod/robot/door/dorms
 	spawnpoint_type = /datum/spawnpoint/tram
 
+//Tether-unique network cameras
+/obj/machinery/camera/network/tether
+	network = list(NETWORK_TETHER)
+
+/obj/machinery/camera/network/tcomms
+	network = list(NETWORK_TCOMMS)
+
+/obj/machinery/camera/network/outside
+	network = list(NETWORK_OUTSIDE)
+
+/obj/machinery/camera/network/exploration
+	network = list(NETWORK_EXPLORATION)
+
+/obj/machinery/camera/network/research/xenobio
+	network = list(NETWORK_RESEARCH, NETWORK_XENOBIO)
+
+//Camera monitors
+/obj/machinery/computer/security/xenobio
+	name = "xenobiology camera monitor"
+	desc = "Used to access the xenobiology cell cameras."
+	icon_keyboard = "mining_key"
+	icon_screen = "mining"
+	network = list(NETWORK_XENOBIO)
+	circuit = /obj/item/weapon/circuitboard/security/xenobio
+	light_color = "#F9BBFC"
+
+/obj/item/weapon/circuitboard/security/xenobio
+	name = T_BOARD("xenobiology camera monitor")
+	build_path = /obj/machinery/computer/security/xenobio
+	network = list(NETWORK_XENOBIO)
+	req_access = list()
+
 //
 // ### Wall Machines On Full Windows ###
 // To make sure wall-mounted machines placed on full-tile windows are clickable they must be above the window


### PR DESCRIPTION
Sorts specific cameras better, removes unused categories, adds new ones for Tether specifically.

- Removed Interrogation, Station, Engineering Outpost networks.

- Replaced Northern Star catergory with Tether. Most cameras from previous Northern Star moved there.

- Added Telecommunications category. All telecomms cameras are now accessible.

- Added Outside category. All cameras outside on z-3 are now in this category.

- Added Exploration category. Expedition hangar and its facilities are now in this category.

- Given naming to the xenobiology pen cameras, changed console slightly on code level (no practical changes). Pen cameras are now also visible on Research network.

- Added cameras to Arrivals Laundry, Civilian category.

- Fixed weird categorization for Mining Lobby, one of shuttle pad and one of upload's cameras. Mining Lobby cameras are now on Cargo network, Shuttle pad camera in maintenance room on Civilian network and Upload camera on Command network. Fixes #4826.

- Removed camera in virology airlock because its literally two next to each other, and seriously, way too close.

- Moved Tram Station cameras to Civilian category.

P.S. Mining Outpost network is still sorta empty, but another PR adds cameras to outpost and they use this category so I kept it in.