### PR TITLE
Adds ability to select scene traits without being custom species

### DIFF
--- a/code/modules/client/preference_setup/vore/07_traits.dm
+++ b/code/modules/client/preference_setup/vore/07_traits.dm
@@ -15,6 +15,11 @@
 	var/starting_trait_points = STARTING_SPECIES_POINTS
 	var/max_traits = MAX_SPECIES_TRAITS
 
+	var/trait_trash_eater = 0
+	var/trait_brutal_predation = 0
+	var/trait_bloodsucker = 0
+	var/trait_succubus_drain = 0
+
 // Definition of the stuff for Ears
 /datum/category_item/player_setup_item/vore/traits
 	name = "Traits"
@@ -90,9 +95,20 @@
 		//Statistics for this would be nice
 		var/english_traits = english_list(new_CS.traits, and_text = ";", comma_text = ";")
 		log_game("TRAITS [pref.client_ckey]/([character]) with: [english_traits]") //Terrible 'fake' key_name()... but they aren't in the same entity yet
-		
+
 		//Any additional non-trait settings can be applied here
 		new_CS.blood_color = pref.blood_color
+	else
+		if(pref.trait_trash_eater)
+			character.verbs |= /mob/living/proc/eat_trash
+		if(pref.trait_brutal_predation)
+			character.verbs |= /mob/living/proc/shred_limb
+		if(pref.trait_bloodsucker)
+			character.verbs |= /mob/living/carbon/human/proc/bloodsuck
+		if(pref.trait_succubus_drain)
+			character.verbs |= /mob/living/carbon/human/proc/succubus_drain
+			character.verbs |= /mob/living/carbon/human/proc/succubus_drain_finalize
+			character.verbs |= /mob/living/carbon/human/proc/succubus_drain_lethal
 
 /datum/category_item/player_setup_item/vore/traits/content(var/mob/user)
 	. += "<b>Custom Species</b> "
@@ -135,6 +151,11 @@
 			var/datum/trait/trait = negative_traits[T]
 			. += "<li>- <a href='?src=\ref[src];clicked_neg_trait=[T]'>[trait.name] ([trait.cost])</a></li>"
 		. += "</ul>"
+	else
+		. += "<b>Enable Trash Can:</b> <a [pref.trait_trash_eater ? "class='linkOn'" : ""] href='?src=\ref[src];toggle_trait_trash_eater=0'><b>[pref.trait_trash_eater ? "Yes" : "No"]</b></a><br>"
+		. += "<b>Enable Brutal Predation:</b> <a [pref.trait_brutal_predation ? "class='linkOn'" : ""] href='?src=\ref[src];toggle_trait_brutal_predation=0'><b>[pref.trait_brutal_predation ? "Yes" : "No"]</b></a><br>"
+		. += "<b>Enable Bloodsucker:</b> <a [pref.trait_bloodsucker ? "class='linkOn'" : ""] href='?src=\ref[src];toggle_trait_bloodsucker=0'><b>[pref.trait_bloodsucker ? "Yes" : "No"]</b></a><br>"
+		. += "<b>Enable Succubus Drain:</b> <a [pref.trait_succubus_drain ? "class='linkOn'" : ""] href='?src=\ref[src];toggle_trait_succubus_drain=0'><b>[pref.trait_succubus_drain ? "Yes" : "No"]</b></a><br>"
 	. += "<b>Blood Color: </b>" //People that want to use a certain species to have that species traits (xenochimera/promethean/spider) should be able to set their own blood color.
 	. += "<a href='?src=\ref[src];blood_color=1'>Set Color</a>"
 	. += "<a href='?src=\ref[src];blood_reset=1'>R</a><br>"
@@ -276,6 +297,22 @@
 
 			mylist += path
 			return TOPIC_REFRESH
+
+	else if(href_list["toggle_trait_trash_eater"])
+		pref.trait_trash_eater = pref.trait_trash_eater ? 0 : 1;
+		return TOPIC_REFRESH
+
+	else if(href_list["toggle_trait_brutal_predation"])
+		pref.trait_brutal_predation = pref.trait_brutal_predation ? 0 : 1;
+		return TOPIC_REFRESH
+
+	else if(href_list["toggle_trait_bloodsucker"])
+		pref.trait_bloodsucker = pref.trait_bloodsucker ? 0 : 1;
+		return TOPIC_REFRESH
+
+	else if(href_list["toggle_trait_succubus_drain"])
+		pref.trait_succubus_drain = pref.trait_succubus_drain ? 0 : 1;
+		return TOPIC_REFRESH
 
 	return ..()
 

--- a/code/modules/client/preference_setup/vore/07_traits.dm
+++ b/code/modules/client/preference_setup/vore/07_traits.dm
@@ -37,6 +37,11 @@
 	S["max_traits"]		>> pref.max_traits
 	S["trait_points"]	>> pref.starting_trait_points
 
+	S["trait_trash_eater"]			>> pref.trait_trash_eater
+	S["trait_brutal_predation"]		>> pref.trait_brutal_predation
+	S["trait_bloodsucker"]			>> pref.trait_bloodsucker
+	S["trait_succubus_drain"]		>> pref.trait_succubus_drain
+
 /datum/category_item/player_setup_item/vore/traits/save_character(var/savefile/S)
 	S["custom_species"]	<< pref.custom_species
 	S["custom_base"]	<< pref.custom_base
@@ -48,6 +53,11 @@
 	S["traits_cheating"]<< pref.traits_cheating
 	S["max_traits"]		<< pref.max_traits
 	S["trait_points"]	<< pref.starting_trait_points
+
+	S["trait_trash_eater"]			<< pref.trait_trash_eater
+	S["trait_brutal_predation"]		<< pref.trait_brutal_predation
+	S["trait_bloodsucker"]			<< pref.trait_bloodsucker
+	S["trait_succubus_drain"]		<< pref.trait_succubus_drain
 
 /datum/category_item/player_setup_item/vore/traits/sanitize_character()
 	if(!pref.pos_traits) pref.pos_traits = list()
@@ -151,7 +161,7 @@
 			var/datum/trait/trait = negative_traits[T]
 			. += "<li>- <a href='?src=\ref[src];clicked_neg_trait=[T]'>[trait.name] ([trait.cost])</a></li>"
 		. += "</ul>"
-	else
+	else if (!(pref.species == SPECIES_XENOCHIMERA))
 		. += "<b>Enable Trash Can:</b> <a [pref.trait_trash_eater ? "class='linkOn'" : ""] href='?src=\ref[src];toggle_trait_trash_eater=0'><b>[pref.trait_trash_eater ? "Yes" : "No"]</b></a><br>"
 		. += "<b>Enable Brutal Predation:</b> <a [pref.trait_brutal_predation ? "class='linkOn'" : ""] href='?src=\ref[src];toggle_trait_brutal_predation=0'><b>[pref.trait_brutal_predation ? "Yes" : "No"]</b></a><br>"
 		. += "<b>Enable Bloodsucker:</b> <a [pref.trait_bloodsucker ? "class='linkOn'" : ""] href='?src=\ref[src];toggle_trait_bloodsucker=0'><b>[pref.trait_bloodsucker ? "Yes" : "No"]</b></a><br>"

--- a/code/modules/mob/living/carbon/human/species/station/alraune.dm
+++ b/code/modules/mob/living/carbon/human/species/station/alraune.dm
@@ -46,10 +46,10 @@
 	appearance_flags = HAS_HAIR_COLOR | HAS_LIPS | HAS_UNDERWEAR | HAS_SKIN_COLOR | HAS_EYE_COLOR
 
 	inherent_verbs = list(
-		/mob/living/carbon/human/proc/succubus_drain,
+		/*/mob/living/carbon/human/proc/succubus_drain,
 		/mob/living/carbon/human/proc/succubus_drain_finalize,
 		/mob/living/carbon/human/proc/succubus_drain_lethal,
-		/mob/living/carbon/human/proc/bloodsuck,
+		/mob/living/carbon/human/proc/bloodsuck,*/
 		/mob/living/carbon/human/proc/alraune_fruit_select) //Give them the voremodes related to wrapping people in vines and sapping their fluids
 
 	color_mult = 1

--- a/code/modules/mob/living/carbon/human/species/station/alraune.dm
+++ b/code/modules/mob/living/carbon/human/species/station/alraune.dm
@@ -45,12 +45,7 @@
 	flags = NO_SCAN | IS_PLANT | NO_MINOR_CUT
 	appearance_flags = HAS_HAIR_COLOR | HAS_LIPS | HAS_UNDERWEAR | HAS_SKIN_COLOR | HAS_EYE_COLOR
 
-	inherent_verbs = list(
-		/*/mob/living/carbon/human/proc/succubus_drain,
-		/mob/living/carbon/human/proc/succubus_drain_finalize,
-		/mob/living/carbon/human/proc/succubus_drain_lethal,
-		/mob/living/carbon/human/proc/bloodsuck,*/
-		/mob/living/carbon/human/proc/alraune_fruit_select) //Give them the voremodes related to wrapping people in vines and sapping their fluids
+	inherent_verbs = list(/mob/living/carbon/human/proc/alraune_fruit_select) //Removed fluid/energy sapping traits due to being put into prefs
 
 	color_mult = 1
 	icobase = 'icons/mob/human_races/r_human_vr.dmi'

--- a/code/modules/mob/living/carbon/human/species/station/prometheans_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/prometheans_vr.dm
@@ -28,10 +28,10 @@
 		/mob/living/carbon/human/proc/shapeshifter_select_hair_colors,
 		/mob/living/carbon/human/proc/shapeshifter_select_gender,
 		/mob/living/carbon/human/proc/regenerate,
-		/mob/living/proc/set_size,
+		/mob/living/proc/set_size,/*
 		/mob/living/carbon/human/proc/succubus_drain,
 		/mob/living/carbon/human/proc/succubus_drain_finalize,
-		/mob/living/carbon/human/proc/succubus_drain_lethal,
-		/mob/living/carbon/human/proc/slime_feed,
-		/mob/living/proc/eat_trash
+		/mob/living/carbon/human/proc/succubus_drain_lethal,*/
+		/mob/living/carbon/human/proc/slime_feed/*,
+		/mob/living/proc/eat_trash*/
 		)

--- a/code/modules/mob/living/carbon/human/species/station/prometheans_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/prometheans_vr.dm
@@ -28,10 +28,6 @@
 		/mob/living/carbon/human/proc/shapeshifter_select_hair_colors,
 		/mob/living/carbon/human/proc/shapeshifter_select_gender,
 		/mob/living/carbon/human/proc/regenerate,
-		/mob/living/proc/set_size,/*
-		/mob/living/carbon/human/proc/succubus_drain,
-		/mob/living/carbon/human/proc/succubus_drain_finalize,
-		/mob/living/carbon/human/proc/succubus_drain_lethal,*/
-		/mob/living/carbon/human/proc/slime_feed/*,
-		/mob/living/proc/eat_trash*/
-		)
+		/mob/living/proc/set_size,
+		/mob/living/carbon/human/proc/slime_feed
+		)	//Removed trash eater and energy sapping traits due to being put into prefs

--- a/code/modules/mob/living/carbon/human/species/station/station_special_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_special_vr.dm
@@ -30,6 +30,7 @@
 		/mob/living/carbon/human/proc/succubus_drain_lethal,
 		/mob/living/carbon/human/proc/bloodsuck,
 		/mob/living/proc/shred_limb,
+		/mob/living/proc/eat_trash,
 		/mob/living/proc/flying_toggle,
 		/mob/living/proc/start_wings_hovering) //Xenochimera get all the special verbs since they can't select traits.
 

--- a/code/modules/mob/living/carbon/human/species/station/station_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_vr.dm
@@ -32,7 +32,7 @@
 
 	spawn_flags = SPECIES_CAN_JOIN
 	appearance_flags = HAS_HAIR_COLOR | HAS_LIPS | HAS_UNDERWEAR | HAS_SKIN_COLOR | HAS_EYE_COLOR
-	//inherent_verbs = list(/mob/living/proc/shred_limb)
+	//inherent_verbs = list(/mob/living/proc/shred_limb)	//Removed hardvore trait due to being put into prefs
 
 	flesh_color = "#AFA59E"
 	base_color = "#777777"
@@ -76,7 +76,7 @@
 	secondary_langs = list(LANGUAGE_SKRELLIAN)
 	name_language = LANGUAGE_SKRELLIAN
 	color_mult = 1
-	//inherent_verbs = list(/mob/living/proc/shred_limb)
+	//inherent_verbs = list(/mob/living/proc/shred_limb)	//Removed hardvore trait due to being put into prefs
 	assisted_langs = list(LANGUAGE_EAL, LANGUAGE_ROOTLOCAL, LANGUAGE_ROOTGLOBAL, LANGUAGE_VOX)
 
 	min_age = 18
@@ -121,7 +121,7 @@
 	secondary_langs = list(LANGUAGE_BIRDSONG)
 	name_language = LANGUAGE_BIRDSONG
 	color_mult = 1
-	inherent_verbs = list(/*/mob/living/proc/shred_limb,*//mob/living/proc/flying_toggle,/mob/living/proc/start_wings_hovering)
+	inherent_verbs = list(/mob/living/proc/flying_toggle,/mob/living/proc/start_wings_hovering)	//Removed hardvore trait due to being put into prefs
 
 	min_age = 18
 	max_age = 80
@@ -185,7 +185,7 @@
 		"You feel uncomfortably warm.",
 		"Your overheated skin itches."
 		)
-	//inherent_verbs = list(/mob/living/proc/shred_limb)
+	//inherent_verbs = list(/mob/living/proc/shred_limb)	//Removed hardvore trait due to being put into prefs
 
 /datum/species/fl_zorren
 	name = SPECIES_ZORREN_FLAT
@@ -218,7 +218,7 @@
 	base_color = "#333333"
 	blood_color = "#240bc4"
 	color_mult = 1
-	//inherent_verbs = list(/mob/living/proc/shred_limb)
+	//inherent_verbs = list(/mob/living/proc/shred_limb)	//Removed hardvore trait due to being put into prefs
 
 	heat_discomfort_strings = list(
 		"Your fur prickles in the heat.",
@@ -244,7 +244,7 @@
 	//gluttonous = 1
 	num_alternate_languages = 3
 	color_mult = 1
-	//inherent_verbs = list(/mob/living/proc/shred_limb)
+	//inherent_verbs = list(/mob/living/proc/shred_limb)	//Removed hardvore trait due to being put into prefs
 
 	blurb = "Vulpkanin are a species of sharp-witted canine-pideds residing on the planet Altam just barely within the \
 	dual-star Vazzend system. Their politically de-centralized society and independent natures have led them to become a species and \
@@ -298,7 +298,7 @@
 		"You feel uncomfortably warm.",
 		"Your chitin feels hot."
 		)
-	//inherent_verbs = list(/mob/living/proc/shred_limb)
+	//inherent_verbs = list(/mob/living/proc/shred_limb)	//Removed hardvore trait due to being put into prefs
 
 /datum/species/unathi
 	spawn_flags = SPECIES_CAN_JOIN //Species_can_join is the only spawn flag all the races get, so that none of them will be whitelist only if whitelist is enabled.
@@ -308,7 +308,7 @@
 	color_mult = 1
 	min_age = 18
 	gluttonous = 0
-	//inherent_verbs = list(/mob/living/proc/shred_limb)
+	//inherent_verbs = list(/mob/living/proc/shred_limb)	//Removed hardvore trait due to being put into prefs
 
 /datum/species/tajaran
 	spawn_flags = SPECIES_CAN_JOIN
@@ -318,7 +318,7 @@
 	color_mult = 1
 	min_age = 18
 	gluttonous = 0 //Moving this here so I don't have to fix this conflict every time polaris glances at station.dm
-	//inherent_verbs = list(/mob/living/proc/shred_limb)
+	//inherent_verbs = list(/mob/living/proc/shred_limb)	//Removed hardvore trait due to being put into prefs
 	heat_discomfort_level = 294 //Prevents heat discomfort spam at 20c
 
 /datum/species/skrell
@@ -347,9 +347,8 @@
 	inherent_verbs = list(
 		/mob/living/carbon/human/proc/sonar_ping,
 		/mob/living/proc/hide,
-		/*/mob/living/proc/shred_limb,*/
 		/mob/living/proc/toggle_pass_table
-		)
+		)	//Removed hardvore trait due to being put into prefs
 
 /datum/species/shapeshifter/promethean
 	spawn_flags = SPECIES_CAN_JOIN
@@ -368,7 +367,7 @@
 	min_age = 18
 	icobase = 'icons/mob/human_races/r_vox_old.dmi'
 	deform = 'icons/mob/human_races/r_def_vox_old.dmi'
-	//inherent_verbs = list(/mob/living/proc/shred_limb, /mob/living/proc/eat_trash)
+	//inherent_verbs = list(/mob/living/proc/shred_limb, /mob/living/proc/eat_trash)	//Removed trash eater and hardvore traits due to being put into prefs
 
 datum/species/harpy
 	name = SPECIES_RAPALA

--- a/code/modules/mob/living/carbon/human/species/station/station_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_vr.dm
@@ -32,7 +32,7 @@
 
 	spawn_flags = SPECIES_CAN_JOIN
 	appearance_flags = HAS_HAIR_COLOR | HAS_LIPS | HAS_UNDERWEAR | HAS_SKIN_COLOR | HAS_EYE_COLOR
-	inherent_verbs = list(/mob/living/proc/shred_limb)
+	//inherent_verbs = list(/mob/living/proc/shred_limb)
 
 	flesh_color = "#AFA59E"
 	base_color = "#777777"
@@ -76,7 +76,7 @@
 	secondary_langs = list(LANGUAGE_SKRELLIAN)
 	name_language = LANGUAGE_SKRELLIAN
 	color_mult = 1
-	inherent_verbs = list(/mob/living/proc/shred_limb)
+	//inherent_verbs = list(/mob/living/proc/shred_limb)
 	assisted_langs = list(LANGUAGE_EAL, LANGUAGE_ROOTLOCAL, LANGUAGE_ROOTGLOBAL, LANGUAGE_VOX)
 
 	min_age = 18
@@ -121,7 +121,7 @@
 	secondary_langs = list(LANGUAGE_BIRDSONG)
 	name_language = LANGUAGE_BIRDSONG
 	color_mult = 1
-	inherent_verbs = list(/mob/living/proc/shred_limb,/mob/living/proc/flying_toggle,/mob/living/proc/start_wings_hovering)
+	inherent_verbs = list(/*/mob/living/proc/shred_limb,*//mob/living/proc/flying_toggle,/mob/living/proc/start_wings_hovering)
 
 	min_age = 18
 	max_age = 80
@@ -185,7 +185,7 @@
 		"You feel uncomfortably warm.",
 		"Your overheated skin itches."
 		)
-	inherent_verbs = list(/mob/living/proc/shred_limb)
+	//inherent_verbs = list(/mob/living/proc/shred_limb)
 
 /datum/species/fl_zorren
 	name = SPECIES_ZORREN_FLAT
@@ -218,7 +218,7 @@
 	base_color = "#333333"
 	blood_color = "#240bc4"
 	color_mult = 1
-	inherent_verbs = list(/mob/living/proc/shred_limb)
+	//inherent_verbs = list(/mob/living/proc/shred_limb)
 
 	heat_discomfort_strings = list(
 		"Your fur prickles in the heat.",
@@ -232,8 +232,8 @@
 	name_plural = "Vulpkanin"
 	icobase = 'icons/mob/human_races/r_vulpkanin.dmi'
 	deform = 'icons/mob/human_races/r_vulpkanin.dmi'
-//	path = /mob/living/carbon/human/vulpkanin
-//	default_language = "Sol Common"
+	//path = /mob/living/carbon/human/vulpkanin
+	//default_language = "Sol Common"
 	secondary_langs = list(LANGUAGE_CANILUNZT)
 	name_language = LANGUAGE_CANILUNZT
 	primitive_form = "Wolpin"
@@ -241,10 +241,10 @@
 	tail_animation = 'icons/mob/species/vulpkanin/tail.dmi' // probably need more than just one of each, but w/e
 	unarmed_types = list(/datum/unarmed_attack/stomp, /datum/unarmed_attack/kick, /datum/unarmed_attack/claws, /datum/unarmed_attack/bite/sharp)
 	darksight = 5 //worse than cats, but better than lizards. -- Poojawa
-//	gluttonous = 1
+	//gluttonous = 1
 	num_alternate_languages = 3
 	color_mult = 1
-	inherent_verbs = list(/mob/living/proc/shred_limb)
+	//inherent_verbs = list(/mob/living/proc/shred_limb)
 
 	blurb = "Vulpkanin are a species of sharp-witted canine-pideds residing on the planet Altam just barely within the \
 	dual-star Vazzend system. Their politically de-centralized society and independent natures have led them to become a species and \
@@ -298,7 +298,7 @@
 		"You feel uncomfortably warm.",
 		"Your chitin feels hot."
 		)
-	inherent_verbs = list(/mob/living/proc/shred_limb)
+	//inherent_verbs = list(/mob/living/proc/shred_limb)
 
 /datum/species/unathi
 	spawn_flags = SPECIES_CAN_JOIN //Species_can_join is the only spawn flag all the races get, so that none of them will be whitelist only if whitelist is enabled.
@@ -308,7 +308,7 @@
 	color_mult = 1
 	min_age = 18
 	gluttonous = 0
-	inherent_verbs = list(/mob/living/proc/shred_limb)
+	//inherent_verbs = list(/mob/living/proc/shred_limb)
 
 /datum/species/tajaran
 	spawn_flags = SPECIES_CAN_JOIN
@@ -318,7 +318,7 @@
 	color_mult = 1
 	min_age = 18
 	gluttonous = 0 //Moving this here so I don't have to fix this conflict every time polaris glances at station.dm
-	inherent_verbs = list(/mob/living/proc/shred_limb)
+	//inherent_verbs = list(/mob/living/proc/shred_limb)
 	heat_discomfort_level = 294 //Prevents heat discomfort spam at 20c
 
 /datum/species/skrell
@@ -347,7 +347,7 @@
 	inherent_verbs = list(
 		/mob/living/carbon/human/proc/sonar_ping,
 		/mob/living/proc/hide,
-		/mob/living/proc/shred_limb,
+		/*/mob/living/proc/shred_limb,*/
 		/mob/living/proc/toggle_pass_table
 		)
 
@@ -368,7 +368,7 @@
 	min_age = 18
 	icobase = 'icons/mob/human_races/r_vox_old.dmi'
 	deform = 'icons/mob/human_races/r_def_vox_old.dmi'
-	inherent_verbs = list(/mob/living/proc/shred_limb, /mob/living/proc/eat_trash)
+	//inherent_verbs = list(/mob/living/proc/shred_limb, /mob/living/proc/eat_trash)
 
 datum/species/harpy
 	name = SPECIES_RAPALA


### PR DESCRIPTION
Feature freeze just moments before I was about to post this, heck. Whatever, its ready and its awesome, IMO.

If you are not a custom species or xenochimera, you will now see four new toggles in custom species category. They allow obtaining of traits appropriate to names, Trash Eater, Brutal Predation, Bloodsucker and Succubus Drain.

If you are a custom species, you will have to select them same way you did before and nothing changes for you.

As a countereffect, all species except xenochimerae that had those traits inheirently (Predation for majority, Drain for Alraune and Prometheans, Trash eater for Vox and Prometheans, Bloodsuck for Alraune) are no longer inheirent. If you had them before, and were actually interested in using/actively using them, do not forget to enable them in VORE category of the character setup.

Those four traits do not add any actual effect unless you use them, so having them be an option for everyone who wants, and not just custom species, I think is good idea. Some people only select custom species at all just for those, which, for 'scene traits' isn't most fair. Also gives option to remove the verbs for people completely uninterested in those traits, but play species that does had them.



In addition to all mentioned, gives xenochimerae the one 'trait verb' they were missing: Trash Eater.