### PR TITLE
Species Tweaks

### DIFF
--- a/code/__defines/chemistry_vr.dm
+++ b/code/__defines/chemistry_vr.dm
@@ -1,5 +1,2 @@
 // More for our custom races
-//#define IS_SERGAL  10
-//#define IS_AKULA   11
-//#define IS_NEVREAN 12
-#define IS_CHIMERA 11
+#define IS_CHIMERA 12

--- a/code/__defines/chemistry_vr.dm
+++ b/code/__defines/chemistry_vr.dm
@@ -1,4 +1,5 @@
 // More for our custom races
-#define IS_SERGAL  10
-#define IS_AKULA   11
-#define IS_NEVREAN 12
+//#define IS_SERGAL  10
+//#define IS_AKULA   11
+//#define IS_NEVREAN 12
+#define IS_CHIMERA 11

--- a/code/modules/client/preference_setup/vore/07_traits.dm
+++ b/code/modules/client/preference_setup/vore/07_traits.dm
@@ -87,12 +87,13 @@
 		var/S = pref.custom_base ? pref.custom_base : "Human"
 		var/datum/species/custom/new_CS = CS.produceCopy(S, pref.pos_traits + pref.neu_traits + pref.neg_traits, character)
 
-		//Statistics for this would be nice
-		var/english_traits = english_list(new_CS.traits, and_text = ";", comma_text = ";")
-		log_game("TRAITS [pref.client_ckey]/([character]) with: [english_traits]") //Terrible 'fake' key_name()... but they aren't in the same entity yet
-		
 		//Any additional non-trait settings can be applied here
 		new_CS.blood_color = pref.blood_color
+
+		if(pref.species == SPECIES_CUSTOM)
+			//Statistics for this would be nice
+			var/english_traits = english_list(new_CS.traits, and_text = ";", comma_text = ";")
+			log_game("TRAITS [pref.client_ckey]/([character]) with: [english_traits]") //Terrible 'fake' key_name()... but they aren't in the same entity yet
 
 /datum/category_item/player_setup_item/vore/traits/content(var/mob/user)
 	. += "<b>Custom Species</b> "

--- a/code/modules/mob/living/carbon/human/species/station/station_special_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_special_vr.dm
@@ -66,6 +66,7 @@
 	base_color 	= "#333333"
 	blood_color = "#14AD8B"
 
+	reagent_tag = IS_CHIMERA
 
 /datum/species/xenochimera/handle_environment_special(var/mob/living/carbon/human/H)
 	//If they're KO'd/dead, they're probably not thinking a lot about much of anything.

--- a/code/modules/mob/living/carbon/human/species/station/station_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_vr.dm
@@ -319,7 +319,7 @@
 	min_age = 18
 	gluttonous = 0 //Moving this here so I don't have to fix this conflict every time polaris glances at station.dm
 	inherent_verbs = list(/mob/living/proc/shred_limb)
-	heat_discomfort_level = 300 //Prevents heat discomfort spam at 20c
+	heat_discomfort_level = 295 //Prevents heat discomfort spam at 20c
 
 /datum/species/skrell
 	spawn_flags = SPECIES_CAN_JOIN

--- a/code/modules/mob/living/carbon/human/species/station/station_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_vr.dm
@@ -37,7 +37,7 @@
 	flesh_color = "#AFA59E"
 	base_color = "#777777"
 
-	reagent_tag = IS_SERGAL
+	//reagent_tag = IS_SERGAL
 
 	heat_discomfort_strings = list(
 		"Your fur prickles in the heat.",
@@ -99,7 +99,7 @@
 	base_color = "#777777"
 	blood_color = "#1D2CBF"
 
-	reagent_tag = IS_AKULA
+	//reagent_tag = IS_AKULA
 
 /datum/species/akula/can_breathe_water()
 	return TRUE // Surprise, SHERKS.
@@ -140,7 +140,7 @@
 	flesh_color = "#AFA59E"
 	base_color = "#333333"
 
-	reagent_tag = IS_SERGAL
+	//reagent_tag = IS_SERGAL
 
 	heat_discomfort_strings = list(
 		"Your fur prickles in the heat.",
@@ -319,7 +319,7 @@
 	min_age = 18
 	gluttonous = 0 //Moving this here so I don't have to fix this conflict every time polaris glances at station.dm
 	inherent_verbs = list(/mob/living/proc/shred_limb)
-	heat_discomfort_level = 294 //Prevents heat discomfort spam at 20c
+	heat_discomfort_level = 300 //Prevents heat discomfort spam at 20c
 
 /datum/species/skrell
 	spawn_flags = SPECIES_CAN_JOIN

--- a/code/modules/mob/living/carbon/human/species/station/station_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_vr.dm
@@ -37,8 +37,6 @@
 	flesh_color = "#AFA59E"
 	base_color = "#777777"
 
-	//reagent_tag = IS_SERGAL
-
 	heat_discomfort_strings = list(
 		"Your fur prickles in the heat.",
 		"You feel uncomfortably warm.",
@@ -99,8 +97,6 @@
 	base_color = "#777777"
 	blood_color = "#1D2CBF"
 
-	//reagent_tag = IS_AKULA
-
 /datum/species/akula/can_breathe_water()
 	return TRUE // Surprise, SHERKS.
 
@@ -139,8 +135,6 @@
 
 	flesh_color = "#AFA59E"
 	base_color = "#333333"
-
-	//reagent_tag = IS_SERGAL
 
 	heat_discomfort_strings = list(
 		"Your fur prickles in the heat.",

--- a/code/modules/mob/new_player/sprite_accessories_vr.dm
+++ b/code/modules/mob/new_player/sprite_accessories_vr.dm
@@ -209,6 +209,31 @@
 		icon_state = "hair_messy"
 		species_allowed = list(SPECIES_TAJ, SPECIES_XENOCHIMERA, SPECIES_PROTEAN)
 
+	taj_ears_curls
+		name = "Tajaran Curly"
+		icon_state = "hair_curly"
+		species_allowed = list(SPECIES_TAJ, SPECIES_XENOCHIMERA, SPECIES_PROTEAN)
+
+	taj_ears_wife
+		name = "Tajaran Housewife"
+		icon_state = "hair_wife"
+		species_allowed = list(SPECIES_TAJ, SPECIES_XENOCHIMERA, SPECIES_PROTEAN)
+
+	taj_ears_victory
+		name = "Tajaran Victory Curls"
+		icon_state = "hair_victory"
+		species_allowed = list(SPECIES_TAJ, SPECIES_XENOCHIMERA, SPECIES_PROTEAN)
+
+	taj_ears_bob
+		name = "Tajaran Bob"
+		icon_state = "hair_tbob"
+		species_allowed = list(SPECIES_TAJ, SPECIES_XENOCHIMERA, SPECIES_PROTEAN)
+
+	taj_ears_fingercurl
+		name = "Tajaran Finger Curls"
+		icon_state = "hair_fingerwave"
+		species_allowed = list(SPECIES_TAJ, SPECIES_XENOCHIMERA, SPECIES_PROTEAN)
+
 	teshari_fluffymohawk
 		name = "Teshari Fluffy Mohawk"
 		icon =  'icons/mob/human_face_vr.dmi'

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
@@ -34,7 +34,6 @@
 				data -= taste
 
 /datum/reagent/nutriment/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
-
 	if(!injectable && alien != IS_SLIME && alien != IS_CHIMERA) //VOREStation Edit
 		M.adjustToxLoss(0.1 * removed)
 		return

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
@@ -74,6 +74,10 @@
 			return
 		if(IS_UNATHI)
 			..(M, alien, removed*2.25) //Unathi get most of their nutrition from meat.
+		//VOREStation Edit Start
+		if(IS_CHIMERA)
+			..(M, alien, removed*4) //Xenochimera are obligate carnivores.
+		//VOREStation Edit End
 	..()
 
 /datum/reagent/nutriment/protein/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
@@ -47,6 +47,7 @@
 	switch(alien)
 		if(IS_DIONA) return
 		if(IS_UNATHI) removed *= 0.5
+		if(IS_CHIMERA) removed *= 0.25 //VOREStation Edit
 	if(issmall(M)) removed *= 2 // Small bodymass, more effect from lower volume.
 	M.heal_organ_damage(0.5 * removed, 0)
 	if(M.species.gets_food_nutrition) //VOREStation edit. If this is set to 0, they don't get nutrition from food.

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
@@ -34,14 +34,11 @@
 				data -= taste
 
 /datum/reagent/nutriment/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
-	/* VOREStation Removal
-	if(!injectable && alien != IS_SLIME)
+
+	if(!injectable && alien != IS_SLIME && alien != IS_CHIMERA) //VOREStation Edit
 		M.adjustToxLoss(0.1 * removed)
 		return
-	affect_ingest(M, alien, removed) 
-	*/ //VOREStation Removal End
-	if(injectable) //vorestation addition/replacement
-		affect_ingest(M, alien, removed)
+	affect_ingest(M, alien, removed)
 
 /datum/reagent/nutriment/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed)
 	switch(alien)


### PR DESCRIPTION
- Removes Reagent tags for Akula, Neverean, and Sergals, as they were not used at all.
- Adds Reagent tag for Xenochimera.
- Xenochimera now get 25% Hunger satisfaction from Nutriment (Previously 100%)
- Fixes a Xenochimera-related runtime
- Increases the heat discomfort level of Tajarans by 1 kelvin
Note: This is the same heat discomfort level as Teshari, whom do not have the issue.
- Reverts a vorestation edit allowing Prometheans to process injected reagents again.
- Xenochimera can now process injected nutriment (and, more importantly, protein)
- Adds new Tajaran hairstyles to Xenochimera and Proteans

Fixes #4840 