### PR TITLE
Miscellaneous Fixes.

### DIFF
--- a/code/game/objects/items/weapons/storage/briefcase.dm
+++ b/code/game/objects/items/weapons/storage/briefcase.dm
@@ -12,7 +12,8 @@
 /obj/item/weapon/storage/briefcase/clutch
 	name = "clutch purse"
 	desc = "A fashionable handheld bag typically used by women."
-	icon_state = "lockbox" //VOREStation Edit - No clutch sprite
+	icon = 'icons/obj/clothing/backpack.dmi' //VOREStation Edit - Wrong sprite location
+	icon_state = "clutch"
 	item_state_slots = list(slot_r_hand_str = "smpurse", slot_l_hand_str = "smpurse")
 	force = 0
 	w_class = ITEMSIZE_NORMAL

--- a/code/game/objects/items/weapons/storage/briefcase.dm
+++ b/code/game/objects/items/weapons/storage/briefcase.dm
@@ -12,7 +12,7 @@
 /obj/item/weapon/storage/briefcase/clutch
 	name = "clutch purse"
 	desc = "A fashionable handheld bag typically used by women."
-	icon_state = "clutch"
+	icon_state = "lockbox" //VOREStation Edit - No clutch sprite
 	item_state_slots = list(slot_r_hand_str = "smpurse", slot_l_hand_str = "smpurse")
 	force = 0
 	w_class = ITEMSIZE_NORMAL

--- a/code/modules/planet/sif.dm
+++ b/code/modules/planet/sif.dm
@@ -564,5 +564,3 @@ var/datum/planet/sif/planet_sif = null
 		return
 	if(T.outdoors)
 		radiation_repository.radiate(T, rand(fallout_rad_low, fallout_rad_high))
->>>>>>> 5fb77b3... Merge pull request #5791 from Neerti/looping_sounds
->>>>>>> Adds Various Sounds, Looping Sound System

--- a/code/modules/research/designs/weapons.dm
+++ b/code/modules/research/designs/weapons.dm
@@ -164,6 +164,7 @@
 	build_path = /obj/item/weapon/gun/energy/taser/xeno
 	sort_string = "TBAAC"
 
+/* //VOREStation Edit
 // Phase Weapons
 /datum/design/item/weapon/phase_pistol
 	id = "phasepistol"
@@ -192,3 +193,4 @@
 	materials = list(DEFAULT_WALL_MATERIAL = 10000, "glass" = 2000, "silver" = 1000, "diamond" = 750)
 	build_path = /obj/item/weapon/gun/energy/phasegun/cannon
 	sort_string = "TPAAD"
+*/

--- a/maps/tether/submaps/beach/_beach.dm
+++ b/maps/tether/submaps/beach/_beach.dm
@@ -95,7 +95,7 @@
 	prob_fall = 25 //Chance goes down by this much each time it spawns one (not defining and prob_spawn 100 means they spawn as soon as one dies)
 	guard = 40 //They'll stay within this range (not defining this disables them staying nearby and they will wander the map (and through step teleports))
 	mobs_to_pick_from = list(
-		/mob/living/simple_mob/vore/giant_snake
+		/mob/living/simple_mob/animal/space/snake
 	)
 
 /obj/tether_away_spawner/beach_outside_friendly
@@ -164,6 +164,7 @@
 	//Not going to do sunlight simulations here like virgo3b
 	//So we just make the whole beach fullbright all the time
 	dynamic_lighting = 0
+	requires_power = 0
 
 /area/tether_away/beach/powershed
 	name = "\improper Away Mission - Virgo 4 Coast PS"

--- a/maps/tether/tether-05-station1.dmm
+++ b/maps/tether/tether-05-station1.dmm
@@ -3130,7 +3130,6 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/engineering/engine_monitoring)
 "afT" = (
-/obj/structure/table/woodentable,
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
 	},
@@ -3138,7 +3137,7 @@
 	icon_state = "bordercolor";
 	dir = 4
 	},
-/obj/item/device/camera,
+/obj/machinery/chemical_analyzer,
 /turf/simulated/floor/tiled,
 /area/tether/station/explorer_meeting)
 "afU" = (
@@ -21923,6 +21922,7 @@
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/purple/border,
 /obj/item/weapon/paper_bin,
+/obj/item/device/camera,
 /turf/simulated/floor/tiled,
 /area/tether/station/explorer_meeting)
 "jDS" = (

--- a/maps/tether/tether_shuttles.dm
+++ b/maps/tether/tether_shuttles.dm
@@ -63,6 +63,7 @@
 //
 // The backup tether shuttle uses experimental engines and can degrade and/or crash!
 //
+/* //Disabling the crash mechanics per request
 /datum/shuttle/ferry/tether_backup
 	crash_message = "Tether shuttle distress signal received. Shuttle location is approximately 200 meters from tether base."
 	category = /datum/shuttle/ferry/tether_backup // So shuttle_controller.dm doesn't try and instantiate this type as an acutal mapped in shuttle.
@@ -166,7 +167,7 @@
 	wear = 20
 	update_icon()
 	return 1
-
+*/
 ////////////////////////////////////////
 //////// Excursion Shuttle /////////////
 ////////////////////////////////////////

--- a/maps/tether/tether_virgo3b.dm
+++ b/maps/tether/tether_virgo3b.dm
@@ -114,7 +114,10 @@ var/datum/planet/virgo3b/planet_virgo3b = null
 		WEATHER_RAIN		= new /datum/weather/virgo3b/rain(),
 		WEATHER_STORM		= new /datum/weather/virgo3b/storm(),
 		WEATHER_HAIL		= new /datum/weather/virgo3b/hail(),
-		WEATHER_BLOOD_MOON	= new /datum/weather/virgo3b/blood_moon()
+		WEATHER_BLOOD_MOON	= new /datum/weather/virgo3b/blood_moon(),
+		WEATHER_EMBERFALL	= new /datum/weather/virgo3b/emberfall(),
+		WEATHER_ASH_STORM	= new /datum/weather/virgo3b/ash_storm(),
+		WEATHER_FALLOUT		= new /datum/weather/virgo3b/fallout()
 		)
 	roundstart_weather_chances = list(
 		WEATHER_CLEAR		= 30,
@@ -201,6 +204,8 @@ var/datum/planet/virgo3b/planet_virgo3b = null
 		"It's starting to snow.",
 		"The air feels much colder as snowflakes fall from above."
 	)
+	outdoor_sounds_type = /datum/looping_sound/weather/outside_snow
+	indoor_sounds_type = /datum/looping_sound/weather/inside_snow
 
 /datum/weather/virgo3b/snow/process_effects()
 	..()
@@ -230,6 +235,8 @@ var/datum/planet/virgo3b/planet_virgo3b = null
 		"Strong winds howl around you as a blizzard appears.",
 		"It starts snowing heavily, and it feels extremly cold now."
 	)
+	outdoor_sounds_type = /datum/looping_sound/weather/outside_blizzard
+	indoor_sounds_type = /datum/looping_sound/weather/inside_blizzard
 
 /datum/weather/virgo3b/blizzard/process_effects()
 	..()
@@ -436,3 +443,106 @@ var/datum/planet/virgo3b/planet_virgo3b = null
 	transition_messages = list(
 		"The sky turns blood red!"
 	)
+	outdoor_sounds_type = /datum/looping_sound/weather/wind
+	indoor_sounds_type = /datum/looping_sound/weather/wind/indoors
+
+// Ash and embers fall forever, such as from a volcano or something.
+/datum/weather/virgo3b/emberfall
+	name = "emberfall"
+	icon_state = "ashfall_light"
+	light_modifier = 0.7
+	light_color = "#880000"
+	temp_high = 293.15	// 20c
+	temp_low = 283.15	// 10c
+	flight_failure_modifier = 20
+	transition_chances = list(
+		WEATHER_EMBERFALL = 100
+		)
+	observed_message = "Soot, ash, and embers float down from above."
+	transition_messages = list(
+		"Gentle embers waft down around you like grotesque snow."
+	)
+	outdoor_sounds_type = /datum/looping_sound/weather/wind
+	indoor_sounds_type = /datum/looping_sound/weather/wind/indoors
+
+// Like the above but a lot more harmful.
+/datum/weather/virgo3b/ash_storm
+	name = "ash storm"
+	icon_state = "ashfall_heavy"
+	light_modifier = 0.1
+	light_color = "#FF0000"
+	temp_high = 323.15	// 50c
+	temp_low = 313.15	// 40c
+	flight_failure_modifier = 50
+	transition_chances = list(
+		WEATHER_ASH_STORM = 100
+		)
+	observed_message = "All that can be seen is black smoldering ash."
+	transition_messages = list(
+		"Smoldering clouds of scorching ash billow down around you!"
+	)
+	// Lets recycle.
+	outdoor_sounds_type = /datum/looping_sound/weather/outside_blizzard
+	indoor_sounds_type = /datum/looping_sound/weather/inside_blizzard
+
+/datum/weather/virgo3b/ash_storm/process_effects()
+	..()
+	for(var/thing in living_mob_list)
+		var/mob/living/L = thing
+		if(L.z in holder.our_planet.expected_z_levels)
+			var/turf/T = get_turf(L)
+			if(!T.outdoors)
+				continue // They're indoors, so no need to burn them with ash.
+
+			L.inflict_heat_damage(rand(1, 3))
+
+
+// Totally radical.
+/datum/weather/virgo3b/fallout
+	name = "fallout"
+	icon_state = "fallout"
+	light_modifier = 0.7
+	light_color = "#CCFFCC"
+	flight_failure_modifier = 30
+	transition_chances = list(
+		WEATHER_FALLOUT = 100
+		)
+	observed_message = "Radioactive soot and ash rains down from the heavens."
+	transition_messages = list(
+		"Radioactive soot and ash start to float down around you, contaminating whatever they touch."
+	)
+	outdoor_sounds_type = /datum/looping_sound/weather/wind
+	indoor_sounds_type = /datum/looping_sound/weather/wind/indoors
+
+	// How much radiation a mob gets while on an outside tile.
+	var/direct_rad_low = RAD_LEVEL_LOW
+	var/direct_rad_high = RAD_LEVEL_MODERATE
+
+	// How much radiation is bursted onto a random tile near a mob.
+	var/fallout_rad_low = RAD_LEVEL_HIGH
+	var/fallout_rad_high = RAD_LEVEL_VERY_HIGH
+
+/datum/weather/virgo3b/fallout/process_effects()
+	..()
+	for(var/thing in living_mob_list)
+		var/mob/living/L = thing
+		if(L.z in holder.our_planet.expected_z_levels)
+			irradiate_nearby_turf(L)
+			var/turf/T = get_turf(L)
+			if(!T.outdoors)
+				continue // They're indoors, so no need to irradiate them with fallout.
+
+			L.rad_act(rand(direct_rad_low, direct_rad_high))
+
+// This makes random tiles near people radioactive for awhile.
+// Tiles far away from people are left alone, for performance.
+/datum/weather/virgo3b/fallout/proc/irradiate_nearby_turf(mob/living/L)
+	if(!istype(L))
+		return
+	var/list/turfs = RANGE_TURFS(world.view, L)
+	var/turf/T = pick(turfs) // We get one try per tick.
+	if(!istype(T))
+		return
+	if(T.outdoors)
+		radiation_repository.radiate(T, rand(fallout_rad_low, fallout_rad_high))
+


### PR DESCRIPTION
- Adds a Chemical Analyzer, as a temporary measure, to the expedition breifing room. Long term plan is to move it into science near the chemistry lab.
- Disables the backup shuttle engine maintenance and crashing mechanics.
- Ports Weather stuff from Polaris. New weathers are currently adminbus only.
- Giant snakes no longer spawn on the beach, the beach is supposed to be a chill place.
- Beach now has power again. This is a temporary solution until something better can take its place.
- Removes Phase weapons from R&D
- Fixes clutch bag inventory sprite

Fixes #4481
Fixes #4237 
Fixes #4103 
Fixes #4809