### PR TITLE
Borgs are now in on fun of size-related features

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades_vr.dm
+++ b/code/game/objects/items/robot/robot_upgrades_vr.dm
@@ -9,3 +9,21 @@
 		return 1
 	else
 		return 0
+
+//Robot resizing module
+
+/obj/item/borg/upgrade/sizeshift
+	name = "robot size alteration module"
+	desc = "Using technology similar to one used in sizeguns, allows cyborgs to adjust their own size as neccesary."
+	icon_state = "cyborg_upgrade2"
+	item_state = "cyborg_upgrade"
+	require_module = 1
+
+/obj/item/borg/upgrade/sizeshift/action(var/mob/living/silicon/robot/R)
+	if(..()) return 0
+
+	if(/mob/living/proc/set_size in R.verbs)
+		return 0
+
+	R.verbs += /mob/living/proc/set_size
+	return 1

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -182,6 +182,8 @@
 		var/datum/preferences/B = O.client.prefs
 		for(var/language in B.alternate_languages)
 			O.add_language(language)
+		O.resize(B.size_multiplier, animate = FALSE)	//VOREStation Addition: add size prefs to borgs
+		O.fuzzy = B.fuzzy								//VOREStation Addition: add size prefs to borgs
 
 	callHook("borgify", list(O))
 	O.Namepick()

--- a/code/modules/research/designs_vr.dm
+++ b/code/modules/research/designs_vr.dm
@@ -316,3 +316,13 @@
 	id = "rigmod_orescanner"
 	build_path = /obj/item/rig_module/device/orescanner
 	sort_string = "HCAAI"
+
+//Prosfab stuff for borgs and such
+
+/datum/design/item/robot_upgrade/sizeshift
+	name = "Size Alteration Module"
+	desc = "Used to allow robot to freely alter their size."
+	id = "borg_sizeshift_module"
+	req_tech = list(TECH_BLUESPACE = 3, TECH_MATERIAL = 3, TECH_POWER = 2)
+	materials = list(DEFAULT_WALL_MATERIAL = 4000, "glass" = 4000)
+	build_path = /obj/item/borg/upgrade/sizeshift


### PR DESCRIPTION
All borgs spawned will now have same size scale as set in character setup. Borgs made in round via brain extraction and such will still be 100% regardless of who they are made from though.

Also, added borg size alteration module. Requires Mat 3, Bluespace 3 and Power 2 to unlock, same material cost as bluespace jumpsuit. Made on prosfab, same as other cyborg upgrades. When installed, gives cyborg access to Alter Mass verb (basically size-change) in abilities tab.