### PR TITLE
Removed clicking sound from timeclocks

### DIFF
--- a/code/game/machinery/computer/timeclock_vr.dm
+++ b/code/game/machinery/computer/timeclock_vr.dm
@@ -15,6 +15,7 @@
 	layer = ABOVE_WINDOW_LAYER
 	density = FALSE
 	circuit = /obj/item/weapon/circuitboard/timeclock
+	clicksound = null
 
 	var/obj/item/weapon/card/id/card // Inserted Id card
 


### PR DESCRIPTION
Because touchscreen display that doubles as clock makes no sense to make clicking noises.