### PR TITLE
Adds proper exiting to step-code for non-human mobs on non-help intent

### DIFF
--- a/code/modules/vore/resizing/resize_vr.dm
+++ b/code/modules/vore/resizing/resize_vr.dm
@@ -218,10 +218,16 @@ var/const/RESIZE_A_SMALLTINY = (RESIZE_SMALL + RESIZE_TINY) / 2
 	var/mob/living/carbon/human/H
 	if(ishuman(src))
 		H = src
+	else
+		//If we're not human, can't do the steppy
+		return FALSE
 
 	var/mob/living/carbon/human/Ht
 	if(ishuman(tmob))
 		Ht = tmob
+	else
+		//If they're not human, steppy shouldn't happen
+		return FALSE
 
 	//Depending on intent...
 	switch(a_intent)


### PR DESCRIPTION
This basically means stomping/grabbing/pinning non-human micros will be impossible and non-humans cannot stomp/grab/pin. This is pretty much already how it worked, but it had chance of making weird bugs like attempting to make a simplemob bleed or trying to put a mob into foot slot a borg doesn't have, and most importantly, displayed messages to the stepper/steppee that said something happened when it didn't. Help intent is handled same as before, stepping over/running between legs is still cool. Other intents with simplemobs and borgs and potentially other non-human mob types will now be handled like a non-micro normal interaction.