### PR TITLE
Fixes Laundry air alarm not detecting breaches

### DIFF
--- a/maps/tether/tether-01-surface1.dmm
+++ b/maps/tether/tether-01-surface1.dmm
@@ -26175,7 +26175,6 @@
 	},
 /obj/structure/closet/crate,
 /obj/machinery/alarm{
-	breach_detection = 0;
 	dir = 8;
 	pixel_x = 25;
 	pixel_y = 0;


### PR DESCRIPTION
Pretty much. The atmos rework re-did Laundry and that air alarm returned to pre-fixed state.