### PR TITLE
Refactors regeneration of ravenous races

### DIFF
--- a/code/__defines/misc_vr.dm
+++ b/code/__defines/misc_vr.dm
@@ -21,9 +21,9 @@
 #define MAX_SPECIES_TRAITS 5
 
 // Xenochimera thing mostly
-#define REVIVING_NOW		1
-#define REVIVING_DONE		2
-#define REVIVING_COOLDOWN	3
+#define REVIVING_NOW		-1
+#define REVIVING_DONE		0
+#define REVIVING_READY		1
 
 // Resleeving Mind Record Status
 #define MR_NORMAL 0

--- a/code/modules/mob/living/carbon/human/species/station/station_special_abilities_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_special_abilities_vr.dm
@@ -10,16 +10,16 @@
 
 /mob/living/carbon/human/proc/chimera_regenerate()
 	//If they're already regenerating
-	switch(reviving)
+	switch(revive_ready)
 		if(REVIVING_NOW)
 			to_chat(src, "You are already reconstructing, just wait for the reconstruction to finish!")
 			return
 		if(REVIVING_DONE)
 			to_chat(src, "Your reconstruction is done, but you need to hatch now.")
 			return
-		if(REVIVING_COOLDOWN)
-			to_chat(src, "You can't use that ability again so soon!")
-			return
+	if(revive_ready > world.time)
+		to_chat(src, "You can't use that ability again so soon!")
+		return
 
 	var/nutrition_used = nutrition * 0.5
 	var/time = (240+960/(1 + nutrition_used/75))
@@ -32,18 +32,18 @@
 			to_chat(src, "You begin to reconstruct your form. You will not be able to move during this time. It should take aproximately [round(time)] seconds.")
 
 			//Scary spawnerization.
-			reviving = REVIVING_NOW
+			revive_ready = REVIVING_NOW
 			spawn(time SECONDS)
 				// Was dead, now not dead.
 				if(stat != DEAD)
 					to_chat(src, "<span class='notice'>Your body has recovered from its ordeal, ready to regenerate itself again.</span>")
-					reviving = 0 //Not bool
+					revive_ready = REVIVING_READY //reset their cooldown
 
 				// Was dead, still dead.
 				else
 					to_chat(src, "<span class='notice'>Consciousness begins to stir as your new body awakens, ready to hatch.</span>")
 					verbs |= /mob/living/carbon/human/proc/hatch
-					reviving = REVIVING_DONE
+					revive_ready = REVIVING_DONE
 
 		//Dead until nutrition injected.
 		else
@@ -54,25 +54,25 @@
 		to_chat(src, "You begin to reconstruct your form. You will not be able to move during this time. It should take aproximately [round(time)] seconds.")
 
 		//Waiting for regen after being alive
-		reviving = REVIVING_NOW
+		revive_ready = REVIVING_NOW
 		spawn(time SECONDS)
 
 			//If they're still alive after regenning.
 			if(stat != DEAD)
 				to_chat(src, "<span class='notice'>Consciousness begins to stir as your new body awakens, ready to hatch..</span>")
 				verbs |= /mob/living/carbon/human/proc/hatch
-				reviving = REVIVING_DONE
+				revive_ready = REVIVING_DONE
 
 			//Was alive, now dead
 			else if(hasnutriment())
 				to_chat(src, "<span class='notice'>Consciousness begins to stir as your new body awakens, ready to hatch..</span>")
 				verbs |= /mob/living/carbon/human/proc/hatch
-				reviving = REVIVING_DONE
+				revive_ready = REVIVING_DONE
 
 			//Dead until nutrition injected.
 			else
 				to_chat(src, "<span class='warning'>Your body was unable to regenerate, what few living cells remain require additional nutrients to complete the process.</span>")
-				reviving = 0 //Not boolean
+				revive_ready = REVIVING_READY //reset their cooldown
 
 /mob/living/carbon/human/proc/hasnutriment()
 	if (bloodstr.has_reagent("nutriment", 30) || src.bloodstr.has_reagent("protein", 15)) //protein needs half as much. For reference, a steak contains 9u protein.
@@ -86,7 +86,7 @@
 	set name = "Hatch"
 	set category = "Abilities"
 
-	if(reviving != REVIVING_DONE)
+	if(revive_ready != REVIVING_DONE)
 		//Hwhat?
 		verbs -= /mob/living/carbon/human/proc/hatch
 		return
@@ -107,7 +107,7 @@
 			else
 				to_chat(src, "Your body was unable to regenerate, what few living cells remain require additional nutrients to complete the process.")
 				verbs -= /mob/living/carbon/human/proc/hatch
-				reviving = 0 //So they can try again when they're given a kickstart
+				revive_ready = REVIVING_READY //reset their cooldown they can try again when they're given a kickstart
 
 		//Alive when hatching
 		else
@@ -141,11 +141,10 @@
 	var/T = get_turf(src)
 	new /obj/effect/gibspawner/human/xenochimera(T)
 
-	reviving = REVIVING_COOLDOWN
-	addtimer(CALLBACK(src, .proc/revivingreset), 36000)
+	revive_ready = world.time + 1 HOUR //set the cooldown
 
-/mob/living/carbon/human/proc/revivingreset()
-		reviving = 0
+/mob/living/carbon/human/proc/revivingreset() // keep this as a debug proc or potential future use
+		revive_ready = REVIVING_READY
 
 /obj/effect/gibspawner/human/xenochimera
 	fleshcolor = "#14AD8B"

--- a/code/modules/mob/living/carbon/human/species/station/station_special_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_special_vr.dm
@@ -75,7 +75,7 @@
 		handle_feralness(H)
 
 	//While regenerating
-	if(H.reviving && H.reviving != REVIVING_COOLDOWN)
+	if(H.revive_ready == REVIVING_NOW || H.revive_ready == REVIVING_DONE)
 		H.weakened = 5
 		H.canmove = 0
 		H.does_not_breathe = TRUE

--- a/code/modules/reagents/Chemistry-Recipes_vr.dm
+++ b/code/modules/reagents/Chemistry-Recipes_vr.dm
@@ -58,7 +58,7 @@
 		var/mob/living/carbon/human/H = holder.my_atom
 		if(H.stat == DEAD && (/mob/living/carbon/human/proc/reconstitute_form in H.verbs)) //no magical regen for non-regenners, and can't force the reaction on live ones
 			if(H.hasnutriment()) // make sure it actually has the conditions to revive
-				if(!H.reviving) // if it's not reviving, start doing so
+				if(H.revive_ready >= 1) // if it's not reviving, start doing so
 					H.visible_message("<span class='info'>[H] shudders briefly, then relaxes, faint movements stirring within.</span>")
 					H.chimera_regenerate()
 				else if (/mob/living/carbon/human/proc/hatch in H.verbs)// already reviving, check if they're ready to hatch

--- a/code/modules/vore/eating/living_vr.dm
+++ b/code/modules/vore/eating/living_vr.dm
@@ -11,7 +11,7 @@
 	var/weight_loss = 0.5 				// How fast you lose weight
 	var/vore_egg_type = "egg" 				// Default egg type.
 	var/feral = 0 						// How feral the mob is, if at all. Does nothing for non xenochimera at the moment.
-	var/reviving = 0					// Only used for creatures that have the xenochimera regen ability, so far.
+	var/revive_ready = REVIVING_READY	// Only used for creatures that have the xenochimera regen ability, so far.
 	var/metabolism = 0.0015
 	var/vore_taste = null				// What the character tastes like
 	var/no_vore = 0 					// If the character/mob can vore.


### PR DESCRIPTION
Tweaks the xenochimera regeneration proc. Instead of being a 4-state system and using a callback to set the state from "cooldown" to "ready" after an hour, the proc now just sets the var to the value that world.time will be at when they're ready to revive again.
Negative and zero values are used for the active revival states.
This has no in-game effect other than making it easier to debug broken players.