### PR TITLE
Fixes doublespawning of one of bridge's tables

### DIFF
--- a/maps/tether/tether-05-station1.dmm
+++ b/maps/tether/tether-05-station1.dmm
@@ -18545,7 +18545,6 @@
 /area/bridge)
 "bvW" = (
 /obj/structure/table/reinforced,
-/obj/structure/table/reinforced,
 /obj/item/weapon/storage/firstaid/regular,
 /obj/item/device/radio{
 	pixel_x = 2;


### PR DESCRIPTION
It resulted in one of said doublespawned tables to break apart, leaving behind two sheets of metal and one sheet of plastic.