### PR TITLE
Replaces the full stacks of materials around station with fiftyspawners

### DIFF
--- a/maps/tether/tether-01-surface1.dmm
+++ b/maps/tether/tether-01-surface1.dmm
@@ -7948,9 +7948,7 @@
 	icon_state = "bordercolor";
 	dir = 5
 	},
-/obj/item/stack/material/steel{
-	amount = 50
-	},
+/obj/fiftyspawner/steel,
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/atmos)
 "asp" = (
@@ -32075,15 +32073,9 @@
 	pixel_y = 30
 	},
 /obj/structure/table/standard,
-/obj/item/stack/material/steel{
-	amount = 50
-	},
-/obj/item/stack/material/steel{
-	amount = 50
-	},
-/obj/item/stack/material/glass{
-	amount = 50
-	},
+/obj/fiftyspawner/steel,
+/obj/fiftyspawner/steel,
+/obj/fiftyspawner/steel},
 /turf/simulated/floor/tiled,
 /area/engineering/atmos)
 "vad" = (

--- a/maps/tether/tether-01-surface1.dmm
+++ b/maps/tether/tether-01-surface1.dmm
@@ -32075,7 +32075,7 @@
 /obj/structure/table/standard,
 /obj/fiftyspawner/steel,
 /obj/fiftyspawner/steel,
-/obj/fiftyspawner/steel},
+/obj/fiftyspawner/glass,
 /turf/simulated/floor/tiled,
 /area/engineering/atmos)
 "vad" = (

--- a/maps/tether/tether-02-surface2.dmm
+++ b/maps/tether/tether-02-surface2.dmm
@@ -6547,11 +6547,7 @@
 	dir = 5
 	},
 /obj/structure/table/steel,
-/obj/item/stack/material/glass{
-	amount = 50;
-	pixel_x = 3;
-	pixel_y = 3
-	},
+/obj/fiftyspawner/glass,
 /turf/simulated/floor/tiled/techfloor,
 /area/rnd/workshop)
 "oo" = (
@@ -7321,14 +7317,8 @@
 /obj/structure/table/standard{
 	name = "plastic table frame"
 	},
-/obj/item/stack/material/glass{
-	amount = 50;
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/stack/material/steel{
-	amount = 50
-	},
+/obj/fiftyspawner/glass,
+/obj/fiftyspawner/steel,
 /obj/item/clothing/glasses/welding,
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -9810,11 +9800,7 @@
 	dir = 10
 	},
 /obj/structure/table/steel,
-/obj/item/stack/material/glass{
-	amount = 50;
-	pixel_x = 3;
-	pixel_y = 3
-	},
+/obj/fiftyspawner/glass,
 /turf/simulated/floor/tiled/techfloor,
 /area/rnd/workshop)
 "vh" = (

--- a/maps/tether/tether-03-surface3.dmm
+++ b/maps/tether/tether-03-surface3.dmm
@@ -19192,41 +19192,15 @@
 /obj/structure/closet{
 	name = "materials"
 	},
-/obj/item/stack/material/steel{
-	amount = 50
-	},
-/obj/item/stack/material/steel{
-	amount = 50
-	},
-/obj/item/stack/material/steel{
-	amount = 50
-	},
-/obj/item/stack/material/steel{
-	amount = 50
-	},
-/obj/item/stack/material/steel{
-	amount = 50
-	},
-/obj/item/stack/material/glass{
-	amount = 50;
-	pixel_x = -2;
-	pixel_y = 2
-	},
-/obj/item/stack/material/glass{
-	amount = 50;
-	pixel_x = -2;
-	pixel_y = 2
-	},
-/obj/item/stack/material/glass{
-	amount = 50;
-	pixel_x = -2;
-	pixel_y = 2
-	},
-/obj/item/stack/material/glass{
-	amount = 50;
-	pixel_x = -2;
-	pixel_y = 2
-	},
+/obj/fiftyspawner/steel,
+/obj/fiftyspawner/steel,
+/obj/fiftyspawner/steel,
+/obj/fiftyspawner/steel,
+/obj/fiftyspawner/steel,
+/obj/fiftyspawner/glass,
+/obj/fiftyspawner/glass,
+/obj/fiftyspawner/glass,
+/obj/fiftyspawner/glass,
 /obj/item/stack/material/plasteel{
 	amount = 10
 	},

--- a/maps/tether/tether-05-station1.dmm
+++ b/maps/tether/tether-05-station1.dmm
@@ -5777,12 +5777,8 @@
 /area/holodeck_control)
 "aoX" = (
 /obj/structure/table/reinforced,
-/obj/item/stack/material/steel{
-	amount = 50
-	},
-/obj/item/stack/material/glass{
-	amount = 50
-	},
+/obj/fiftyspawner/steel,
+/obj/fiftyspawner/glass,
 /turf/simulated/floor/tiled,
 /area/engineering/atmos/backup)
 "aoZ" = (
@@ -8877,21 +8873,11 @@
 /area/maintenance/station/bridge)
 "axO" = (
 /obj/structure/table/reinforced,
-/obj/item/stack/material/glass{
-	amount = 50
-	},
-/obj/item/stack/material/glass{
-	amount = 50
-	},
-/obj/item/stack/material/glass{
-	amount = 50
-	},
-/obj/item/stack/material/glass{
-	amount = 50
-	},
-/obj/item/stack/material/glass{
-	amount = 50
-	},
+/obj/fiftyspawner/glass,
+/obj/fiftyspawner/glass,
+/obj/fiftyspawner/glass,
+/obj/fiftyspawner/glass,
+/obj/fiftyspawner/glass,
 /obj/machinery/alarm{
 	dir = 1;
 	icon_state = "alarm0";
@@ -8902,21 +8888,11 @@
 /area/engineering/workshop)
 "axP" = (
 /obj/structure/table/reinforced,
-/obj/item/stack/material/steel{
-	amount = 50
-	},
-/obj/item/stack/material/steel{
-	amount = 50
-	},
-/obj/item/stack/material/steel{
-	amount = 50
-	},
-/obj/item/stack/material/steel{
-	amount = 50
-	},
-/obj/item/stack/material/steel{
-	amount = 50
-	},
+/obj/fiftyspawner/steel,
+/obj/fiftyspawner/steel,
+/obj/fiftyspawner/steel,
+/obj/fiftyspawner/steel,
+/obj/fiftyspawner/steel,
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -24
@@ -17034,20 +17010,10 @@
 "bkx" = (
 /obj/structure/table/reinforced,
 /obj/item/stack/material/plasteel{
-	amount = 10
+	amount = 30
 	},
-/obj/item/stack/material/plasteel{
-	amount = 10
-	},
-/obj/item/stack/material/plasteel{
-	amount = 10
-	},
-/obj/item/stack/material/plastic{
-	amount = 50
-	},
-/obj/item/stack/material/plastic{
-	amount = 50
-	},
+/obj/fiftyspawner/plastic,
+/obj/fiftyspawner/plastic,
 /turf/simulated/floor/tiled,
 /area/engineering/workshop)
 "bky" = (
@@ -21382,18 +21348,12 @@
 /area/vacant/vacant_restaurant_lower)
 "bZc" = (
 /obj/structure/table/reinforced,
-/obj/item/stack/rods{
-	amount = 50
-	},
-/obj/item/stack/rods{
-	amount = 50
-	},
+/obj/fiftyspawner/rods,
+/obj/fiftyspawner/rods,
 /obj/item/stack/material/glass/phoronrglass{
 	amount = 20
 	},
-/obj/item/stack/material/wood{
-	amount = 50
-	},
+/obj/fiftyspawner/wood,
 /obj/machinery/camera/network/engineering{
 	dir = 1
 	},

--- a/maps/tether/tether-06-station2.dmm
+++ b/maps/tether/tether-06-station2.dmm
@@ -9933,15 +9933,9 @@
 /area/ai_monitored/storage/eva)
 "rK" = (
 /obj/structure/table/reinforced,
-/obj/item/stack/material/glass{
-	amount = 50
-	},
-/obj/item/stack/material/glass{
-	amount = 50
-	},
-/obj/item/stack/material/glass{
-	amount = 50
-	},
+/obj/fiftyspawner/glass,
+/obj/fiftyspawner/glass,
+/obj/fiftyspawner/glass,
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
@@ -10304,12 +10298,8 @@
 /obj/machinery/camera/network/security{
 	dir = 8
 	},
-/obj/item/stack/material/glass/reinforced{
-	amount = 50
-	},
-/obj/item/stack/rods{
-	amount = 50
-	},
+/obj/fiftyspawner/rglass,
+/obj/fiftyspawner/rods,
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
@@ -10560,15 +10550,9 @@
 /obj/item/stack/material/plasteel{
 	amount = 10
 	},
-/obj/item/stack/material/steel{
-	amount = 50
-	},
-/obj/item/stack/material/steel{
-	amount = 50
-	},
-/obj/item/stack/material/steel{
-	amount = 50
-	},
+/obj/fiftyspawner/steel,
+/obj/fiftyspawner/steel,
+/obj/fiftyspawner/steel,
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},


### PR DESCRIPTION
Just a minor refactor that shouldn't affect gameplay at all. Another minor change is that instead of three stacks with 10 sheets per stack of plasteel, engineering now has a single stack of 30 plasteel.