### PR TITLE
Removes ability for non-player mice to interact with doors

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -109,6 +109,8 @@
 		M.last_bumped = world.time
 		if(M.restrained() && !check_access(null))
 			return
+		else if(istype(M, /mob/living/simple_mob/animal/passive/mouse) && !(M.ckey))	//VOREStation Edit: Make wild mice
+			return																		//VOREStation Edit: unable to open doors
 		else
 			bumpopen(M)
 


### PR DESCRIPTION
What it says on the tin. If mouse is not player-controlled, bumping door won't even deny with red flash and bleep, but absolutely nothing will happen. Player-controlled mice can still open all-access doors and bump with the bleeps into restricted ones.