### PR TITLE
Fixes micromechs using normal equipment

### DIFF
--- a/code/game/mecha/equipment/mecha_equipment.dm
+++ b/code/game/mecha/equipment/mecha_equipment.dm
@@ -4,6 +4,10 @@
 #define EQUIP_WEAPON 2
 #define EQUIP_UTILITY 3
 #define EQUIP_SPECIAL 4
+//VOREStation Addition begin: MICROMECHS
+#define EQUIP_MICRO_UTILITY 5
+#define EQUIP_MICRO_WEAPON 6
+//VOREStation Addition end: MICROMECHS
 
 /obj/item/mecha_parts/mecha_equipment
 	name = "mecha equipment"
@@ -64,6 +68,14 @@
 			if(equip_type == EQUIP_SPECIAL)
 				chassis.special_equipment -= src
 				listclearnulls(chassis.special_equipment)
+			//VOREStation Addition begin: MICROMECHS
+			if(equip_type == EQUIP_MICRO_UTILITY)
+				chassis.micro_utility_equipment -= src
+				listclearnulls(chassis.micro_utility_equipment)
+			if(equip_type == EQUIP_MICRO_WEAPON)
+				chassis.micro_weapon_equipment -= src
+				listclearnulls(chassis.micro_weapon_equipment)
+			//VOREStation Addition end: MICROMECHS
 		chassis.universal_equipment -= src
 		chassis.equipment -= src
 		listclearnulls(chassis.equipment)
@@ -140,6 +152,12 @@
 		return 1
 	if(equip_type == EQUIP_SPECIAL && M.special_equipment.len < M.max_special_equip)
 		return 1
+	//VOREStation Addition begin: MICROMECHS
+	if(equip_type == EQUIP_MICRO_UTILITY && M.micro_utility_equipment.len < M.max_micro_utility_equip)
+		return 1
+	if(equip_type == EQUIP_MICRO_WEAPON && M.micro_weapon_equipment.len < M.max_micro_weapon_equip)
+		return 1
+	//VOREStation Addition end: MICROMECHS
 	if(equip_type != EQUIP_SPECIAL && M.universal_equipment.len < M.max_universal_equip) //The exosuit needs to be military grade to actually have a universal slot capable of accepting a true weapon.
 		if(equip_type == EQUIP_WEAPON && !istype(M, /obj/mecha/combat))
 			return 0
@@ -168,6 +186,14 @@
 	if(equip_type == EQUIP_SPECIAL && M.special_equipment.len < M.max_special_equip && !has_equipped)
 		M.special_equipment += src
 		has_equipped = 1
+	//VOREStation Addition begin: MICROMECHS
+	if(equip_type == EQUIP_MICRO_UTILITY && M.micro_utility_equipment.len < M.max_micro_utility_equip && !has_equipped)
+		M.micro_utility_equipment += src
+		has_equipped = 1
+	if(equip_type == EQUIP_MICRO_WEAPON && M.micro_weapon_equipment.len < M.max_micro_weapon_equip && !has_equipped)
+		M.micro_weapon_equipment += src
+		has_equipped = 1
+	//VOREStation Addition end: MICROMECHS
 	if(equip_type != EQUIP_SPECIAL && M.universal_equipment.len < M.max_universal_equip && !has_equipped)
 		M.universal_equipment += src
 	M.equipment += src
@@ -194,6 +220,12 @@
 					chassis.utility_equipment -= src
 				if(EQUIP_SPECIAL)
 					chassis.special_equipment -= src
+				//VOREStation Addition begin: MICROMECHS
+				if(EQUIP_UTILITY)
+					chassis.micro_utility_equipment -= src
+				if(EQUIP_SPECIAL)
+					chassis.micro_weapon_equipment -= src
+				//VOREStation Addition end: MICROMECHS
 		if(chassis.selected == src)
 			chassis.selected = null
 		update_chassis_page()

--- a/code/game/mecha/micro/micro.dm
+++ b/code/game/mecha/micro/micro.dm
@@ -1,3 +1,11 @@
+/obj/mecha
+	var/max_micro_utility_equip = 0
+	var/max_micro_weapon_equip = 0
+	var/list/micro_utility_equipment = new
+	var/list/micro_weapon_equipment = new
+
+
+
 /obj/mecha/micro
 	icon = 'icons/mecha/micro.dmi'
 	force = 10 //still a robot
@@ -9,6 +17,13 @@
 	var/list/destroyable_obj = list(/obj/mecha, /obj/structure/window, /obj/structure/grille, /turf/simulated/wall)
 	internal_damage_threshold = 50
 	maint_access = 0
+	max_hull_equip = 1
+	max_weapon_equip = 0
+	max_utility_equip = 0
+	max_universal_equip = 0
+	max_special_equip = 1
+	max_micro_utility_equip = 1
+	max_micro_weapon_equip = 1
 	//add_req_access = 0
 	//operation_req_access = list(access_hos)
 	damage_absorption = list("brute"=1,"fire"=1,"bullet"=1,"laser"=1,"energy"=1,"bomb"=1)

--- a/code/game/mecha/micro/micro_equipment.dm
+++ b/code/game/mecha/micro/micro_equipment.dm
@@ -14,6 +14,7 @@
 	energy_drain = 50
 	projectile = /obj/item/projectile/beam
 	fire_sound = 'sound/weapons/Laser.ogg'
+	equip_type = EQUIP_MICRO_WEAPON
 	required_type = list(/obj/mecha/micro/sec)
 
 /obj/item/mecha_parts/mecha_equipment/weapon/energy/laser/microheavy
@@ -26,6 +27,7 @@
 	energy_drain = 120
 	projectile = /obj/item/projectile/beam/heavylaser
 	fire_sound = 'sound/weapons/lasercannonfire.ogg'
+	equip_type = EQUIP_MICRO_WEAPON
 	required_type = list(/obj/mecha/micro/sec)
 
 /obj/item/mecha_parts/mecha_equipment/weapon/energy/microtaser
@@ -38,6 +40,7 @@
 	equip_cooldown = 10
 	projectile = /obj/item/projectile/beam/stun
 	fire_sound = 'sound/weapons/Taser.ogg'
+	equip_type = EQUIP_MICRO_WEAPON
 	required_type = list(/obj/mecha/micro/sec)
 
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/microshotgun
@@ -55,6 +58,7 @@
 	projectiles_per_shot = 1
 	deviation = 0.7
 	projectile_energy_cost = 100
+	equip_type = EQUIP_MICRO_WEAPON
 	required_type = list(/obj/mecha/micro/sec)
 
 	Topic(href,href_list)
@@ -89,6 +93,7 @@
 	projectile_energy_cost = 800
 	equip_cooldown = 30
 	det_time = 15
+	equip_type = EQUIP_MICRO_WEAPON
 	required_type = list(/obj/mecha/micro/sec)
 
 
@@ -105,6 +110,7 @@
 	equip_cooldown = 30
 	energy_drain = 10
 	force = 15
+	equip_type = EQUIP_MICRO_UTILITY
 	required_type = list(/obj/mecha/micro/utility)
 
 	action(atom/target)
@@ -155,6 +161,7 @@
 	icon_state = "microscoop"
 	equip_cooldown = 5
 	energy_drain = 0
+	equip_type = EQUIP_MICRO_UTILITY
 	required_type = list(/obj/mecha/micro/utility)
 	var/orecapacity = 500
 

--- a/code/game/mecha/micro/security.dm
+++ b/code/game/mecha/micro/security.dm
@@ -30,6 +30,8 @@
 	wreckage = /obj/effect/decal/mecha_wreckage/micro/sec/polecat
 	internal_damage_threshold = 35
 	max_equip = 3
+	max_micro_utility_equip = 0
+	max_micro_weapon_equip = 3
 
 /obj/effect/decal/mecha_wreckage/micro/sec/polecat
 	name = "Polecat wreckage"
@@ -52,6 +54,8 @@
 	wreckage = /obj/effect/decal/mecha_wreckage/micro/sec/weasel
 	internal_damage_threshold = 20
 	max_equip = 2
+	max_micro_utility_equip = 0
+	max_micro_weapon_equip = 2
 
 /obj/effect/decal/mecha_wreckage/micro/sec/weasel
 	name = "Weasel wreckage"

--- a/code/game/mecha/micro/utility.dm
+++ b/code/game/mecha/micro/utility.dm
@@ -16,6 +16,8 @@
 	var/overload_coeff = 2
 	wreckage = /obj/effect/decal/mecha_wreckage/micro/utility/gopher
 	internal_damage_threshold = 35
+	max_micro_utility_equip = 2
+	max_micro_weapon_equip = 0
 	max_equip = 2
 
 /obj/effect/decal/mecha_wreckage/micro/utility/gopher


### PR DESCRIPTION
Oh god, the vorestation edits, they are everywhere

Anyway, micromechs no longer have universal, weapon or utility slots, and only 1 hull and 1 special slot.

Instead new slot types are added: Micro Utility and Micro Weapon. Only micromechs have these slots. Gopher has 2 micro utility slots, Weasel has 2 micro weapon slots and Polecat has 3 micro weapon slots.

Fixes #4871