### PR TITLE
Loadout adjustments for access and swimsuits

### DIFF
--- a/code/modules/client/preference_setup/loadout/loadout_uniform_vr.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_uniform_vr.dm
@@ -21,7 +21,7 @@
 /datum/gear/uniform/job_khi/med
 	display_name = "khi uniform, med"
 	path = /obj/item/clothing/under/rank/khi/med
-	allowed_roles = list("Chief Medical Officer","Medical Doctor","Chemist","Paramedic","Geneticist")
+	allowed_roles = list("Chief Medical Officer","Medical Doctor","Chemist","Paramedic","Geneticist","Field Medic")
 
 /datum/gear/uniform/job_khi/eng
 	display_name = "khi uniform, eng"
@@ -31,7 +31,7 @@
 /datum/gear/uniform/job_khi/sci
 	display_name = "khi uniform, sci"
 	path = /obj/item/clothing/under/rank/khi/sci
-	allowed_roles = list("Research Director","Scientist", "Roboticist", "Xenobiologist")
+	allowed_roles = list("Research Director", "Scientist", "Roboticist", "Xenobiologist", "Pathfinder", "Explorer")
 
 //Federation jackets
 /datum/gear/suit/job_fed/sec
@@ -42,7 +42,7 @@
 /datum/gear/suit/job_fed/medsci
 	display_name = "fed uniform, med/sci"
 	path = /obj/item/clothing/suit/storage/fluff/fedcoat/fedblue
-	allowed_roles = list("Chief Medical Officer","Medical Doctor","Chemist","Paramedic","Geneticist","Research Director","Scientist", "Roboticist", "Xenobiologist")
+	allowed_roles = list("Chief Medical Officer","Medical Doctor","Chemist","Paramedic","Geneticist","Research Director","Scientist", "Roboticist", "Xenobiologist","Pathfinder","Explorer","Field Medic")
 
 /datum/gear/suit/job_fed/eng
 	display_name = "fed uniform, eng"
@@ -59,7 +59,7 @@
 /datum/gear/uniform/job_trek/medsci/tos
 	display_name = "TOS uniform, med/sci"
 	path = /obj/item/clothing/under/rank/trek/medsci
-	allowed_roles = list("Chief Medical Officer","Medical Doctor","Chemist","Paramedic","Geneticist","Research Director","Scientist", "Roboticist", "Xenobiologist")
+	allowed_roles = list("Chief Medical Officer","Medical Doctor","Chemist","Paramedic","Geneticist","Research Director","Scientist", "Roboticist", "Xenobiologist", "Pathfinder", "Explorer", "Field Medic")
 
 /datum/gear/uniform/job_trek/eng/tos
 	display_name = "TOS uniform, eng/sec"
@@ -75,7 +75,7 @@
 /datum/gear/uniform/job_trek/medsci/tng
 	display_name = "TNG uniform, med/sci"
 	path = /obj/item/clothing/under/rank/trek/medsci/next
-	allowed_roles = list("Chief Medical Officer","Medical Doctor","Chemist","Paramedic","Geneticist","Research Director","Scientist", "Roboticist", "Xenobiologist")
+	allowed_roles = list("Chief Medical Officer","Medical Doctor","Chemist","Paramedic","Geneticist","Research Director","Scientist", "Roboticist", "Xenobiologist", "Pathfinder", "Explorer", "Field Medic")
 
 /datum/gear/uniform/job_trek/eng/tng
 	display_name = "TNG uniform, eng/sec"
@@ -91,7 +91,7 @@
 /datum/gear/uniform/job_trek/medsci/voy
 	display_name = "VOY uniform, med/sci"
 	path = /obj/item/clothing/under/rank/trek/medsci/voy
-	allowed_roles = list("Chief Medical Officer","Medical Doctor","Chemist","Paramedic","Geneticist","Research Director","Scientist", "Roboticist", "Xenobiologist")
+	allowed_roles = list("Chief Medical Officer","Medical Doctor","Chemist","Paramedic","Geneticist","Research Director","Scientist", "Roboticist", "Xenobiologist", "Pathfinder", "Explorer", "Field Medic")
 
 /datum/gear/uniform/job_trek/eng/voy
 	display_name = "VOY uniform, eng/sec"
@@ -106,7 +106,7 @@
 	allowed_roles = list("Head of Security","Colony Director","Head of Personnel","Chief Engineer","Research Director",
 						"Chief Medical Officer","Medical Doctor","Chemist","Paramedic","Geneticist",
 						"Scientist","Roboticist","Xenobiologist","Atmospheric Technician",
-						"Station Engineer","Warden","Detective","Security Officer")
+						"Station Engineer","Warden","Detective","Security Officer", "Pathfinder", "Explorer", "Field Medic")
 
 
 /datum/gear/uniform/job_trek/cmd/ds9
@@ -117,7 +117,7 @@
 /datum/gear/uniform/job_trek/medsci/ds9
 	display_name = "DS9 uniform, med/sci"
 	path = /obj/item/clothing/under/rank/trek/medsci/ds9
-	allowed_roles = list("Chief Medical Officer","Medical Doctor","Chemist","Paramedic","Geneticist","Research Director","Scientist", "Roboticist", "Xenobiologist")
+	allowed_roles = list("Chief Medical Officer","Medical Doctor","Chemist","Paramedic","Geneticist","Research Director","Scientist", "Roboticist", "Xenobiologist", "Pathfinder", "Explorer", "Field Medic")
 
 /datum/gear/uniform/job_trek/eng/ds9
 	display_name = "DS9 uniform, eng/sec"
@@ -134,7 +134,7 @@
 /datum/gear/uniform/job_trek/medsci/ent
 	display_name = "ENT uniform, med/sci"
 	path = /obj/item/clothing/under/rank/trek/medsci/ent
-	allowed_roles = list("Chief Medical Officer","Medical Doctor","Chemist","Paramedic","Geneticist","Research Director","Scientist", "Roboticist", "Xenobiologist")
+	allowed_roles = list("Chief Medical Officer","Medical Doctor","Chemist","Paramedic","Geneticist","Research Director","Scientist", "Roboticist", "Xenobiologist", "Pathfinder", "Explorer", "Field Medic")
 
 /datum/gear/uniform/job_trek/eng/ent
 	display_name = "ENT uniform, eng/sec"

--- a/code/modules/vore/fluffstuff/custom_boxes_vr.dm
+++ b/code/modules/vore/fluffstuff/custom_boxes_vr.dm
@@ -284,6 +284,18 @@ Swimsuits, for general use, to avoid arriving to work with your swimsuit.
 	name = "Red Swimsuit capsule"
 	has_items = list(/obj/item/clothing/under/swimsuit/red)
 
+/obj/item/weapon/storage/box/fluff/swimsuit/white
+	name = "White Swimsuit capsule"
+	has_items = list(/obj/item/clothing/under/swimsuit/white)
+
+/obj/item/weapon/storage/box/fluff/swimsuit/blue
+	name = "Striped Swimsuit capsule"
+	has_items = list(/obj/item/clothing/under/swimsuit/striped)
+
+/obj/item/weapon/storage/box/fluff/swimsuit/earth
+	name = "Earthen Swimsuit capsule"
+	has_items = list(/obj/item/clothing/under/swimsuit/earth)
+
 /obj/item/weapon/storage/box/fluff/swimsuit/engineering
 	name = "Engineering Swimsuit capsule"
 	has_items = list(/obj/item/clothing/under/swimsuit/fluff/engineering)


### PR DESCRIPTION
Allows explorers, field medics and pathfinders to use various medsci uniforms

Fixed White, Striped and Earthen swimsuit capsules missing from loadout, fixes #4618