### PR TITLE
Lowers respawn timer back to 1 minute

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -373,8 +373,8 @@
 		var/deathtimeseconds = round((deathtime - deathtimeminutes * 600) / 10,1)
 		to_chat(usr, "You have been dead for[pluralcheck] [deathtimeseconds] seconds.")
 
-		if ((deathtime < (5 * 600)) && (ticker && ticker.current_state > GAME_STATE_PREGAME))
-			to_chat(usr, "You must wait 5 minutes to respawn!")
+		if ((deathtime < (1 * 600)) && (ticker && ticker.current_state > GAME_STATE_PREGAME))	//VOREStation Edit: lower respawn timer
+			to_chat(usr, "You must wait 1 minute to respawn!")
 			return
 		else
 			to_chat(usr, "You can respawn now, enjoy your new life!")
@@ -716,7 +716,7 @@
 
 			if(statpanel("Tickets"))
 				GLOB.ahelp_tickets.stat_entry()
-				
+
 
 			if(length(GLOB.sdql2_queries))
 				if(statpanel("SDQL2"))


### PR DESCRIPTION
Because general consensus on respawn timer is that 5 minute is long enough to get bored, but not long enough to discourage PGing. Plus PGing using the round-exit is already rare and when it is used, its either endorsed because emergencies or punished by admins.

Posted mostly due to people getting mad at me fixing unintended behavior of tram bump-leave (and just bump version of leave) skipping setting of the deathtime in #4955 