### PR TITLE
Fixes portals being able to send ghosts and other technical mobs

### DIFF
--- a/code/game/objects/effects/portals.dm
+++ b/code/game/objects/effects/portals.dm
@@ -13,18 +13,24 @@ GLOBAL_LIST_BOILERPLATE(all_portals, /obj/effect/portal)
 	anchored = 1.0
 
 /obj/effect/portal/Bumped(mob/M as mob|obj)
+	if(istype(M,/mob) && !(istype(M,/mob/living)))
+		return	//do not send ghosts, zshadows, ai eyes, etc
 	spawn(0)
 		src.teleport(M)
 		return
 	return
 
 /obj/effect/portal/Crossed(AM as mob|obj)
+	if(istype(AM,/mob) && !(istype(AM,/mob/living)))
+		return	//do not send ghosts, zshadows, ai eyes, etc
 	spawn(0)
 		src.teleport(AM)
 		return
 	return
 
 /obj/effect/portal/attack_hand(mob/user as mob)
+	if(istype(user) && !(istype(user,/mob/living)))
+		return	//do not send ghosts, zshadows, ai eyes, etc
 	spawn(0)
 		src.teleport(user)
 		return


### PR DESCRIPTION
Direct port of Polaris 6060

No mechanical soul vore allowed.
But being serious, surprised this wasn't noticed and/or reported before. It did it with full fanfare of teleportation sparks too.