### PR TITLE
Removes promethean language restriction

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/prometheans_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/prometheans_vr.dm
@@ -16,7 +16,6 @@
 
 	color_mult = 1
 	mob_size = MOB_MEDIUM //As of writing, original was MOB_SMALL - Allows normal swapping (good)
-	num_alternate_languages = 1 //Might be outdated: They currently have 3 in the other file
 	trashcan = 1 //They have goopy bodies. They can just dissolve things within them.
 
 	appearance_flags = HAS_SKIN_COLOR | HAS_EYE_COLOR | HAS_HAIR_COLOR | RADIATION_GLOWS | HAS_UNDERWEAR


### PR DESCRIPTION
Allows them to select 3 languages, just like every single other species in the game. There is no good reason for that restriction, really.

Resolves #4173, partially addresses #4795 