### PR TITLE
Fixes some problems with species TF

### DIFF
--- a/code/modules/vore/eating/transforming_vr.dm
+++ b/code/modules/vore/eating/transforming_vr.dm
@@ -215,13 +215,15 @@
 	if(!istype(M) || !istype(O))
 		return
 
-	if (M.species == "Promethean" && O.species != "Promethean") //If the person was a promethean before TF, remove all their verbs!
-		M.verbs -=  /mob/living/carbon/human/proc/shapeshifter_select_shape
-		M.verbs -=  /mob/living/carbon/human/proc/shapeshifter_select_colour
-		M.verbs -=  /mob/living/carbon/human/proc/shapeshifter_select_hair
-		M.verbs -=  /mob/living/carbon/human/proc/shapeshifter_select_gender
-		M.verbs -=  /mob/living/carbon/human/proc/regenerate
-		M.verbs -=  /mob/living/proc/set_size
+	M.verbs -=  M.species.inherent_verbs	//Take away their unique stuff
+
+	var/list/backup_implants = list()
+	for(var/obj/item/organ/I in M.organs)
+		for(var/obj/item/weapon/implant/backup/BI in I.contents)
+			backup_implants += BI
+	if(backup_implants.len)
+		for(var/obj/item/weapon/implant/backup/BI in backup_implants)
+			BI.forceMove(src)
 
 	M.species = O.species
 	M.custom_species = O.custom_species
@@ -235,17 +237,18 @@
 	M.fixblood()
 	M.update_icons_body()
 	M.update_tail_showing()
+
+	if(backup_implants.len)
+		var/obj/item/organ/external/torso = M.get_organ(BP_TORSO)
+		for(var/obj/item/weapon/implant/backup/BI in backup_implants)
+			BI.forceMove(torso)
+			torso.implants += BI
+
+
 	if(message)
 		to_chat(M, "<span class='notice'>You lose sensation of your body, feeling only the warmth of everything around you... </span>")
 		to_chat(O, "<span class='notice'>Your body shifts as you make dramatic changes to your captive's body.</span>")
-	if (M.species == "Promethean") //Did they get TF'd into a promethean?
-		M.verbs +=  /mob/living/carbon/human/proc/shapeshifter_select_shape
-		M.verbs +=  /mob/living/carbon/human/proc/shapeshifter_select_colour
-		M.verbs +=  /mob/living/carbon/human/proc/shapeshifter_select_hair
-		M.verbs +=  /mob/living/carbon/human/proc/shapeshifter_select_gender
-		M.verbs +=  /mob/living/carbon/human/proc/regenerate
-		M.verbs +=  /mob/living/proc/set_size
-		M.shapeshifter_select_shape()
+	M.verbs += M.species.inherent_verbs	//Give new unique stuff
 
 /obj/belly/proc/put_in_egg(var/atom/movable/M, message=0)
 	var/mob/living/carbon/human/O = owner


### PR DESCRIPTION
Fixes species-specifc verbs not being properly removed/added to the results

Fixes backup implants disappearing (all other implants will still disappear). Instead the shifting process will cause them to migrate to center of body mass (chest). Should not affect their ability to work

Fixes #4803 