### PR TITLE
Rebalances zoom pills

### DIFF
--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -292,9 +292,12 @@
 
 /obj/item/weapon/reagent_containers/pill/zoom/Initialize()
 	. = ..()
-	reagents.add_reagent("impedrezene", 10)
-	reagents.add_reagent("synaptizine", 5)
-	reagents.add_reagent("hyperzine", 5)
+	if(prob(50))						//VOREStation edit begin: Zoom pill adjustments
+		reagents.add_reagent("expired_medicine", 5)
+	else
+		reagents.add_reagent("mold", 5)
+	reagents.add_reagent("fertilizer", 5)
+	reagents.add_reagent("stimm", 5)	//VOREStation edit end: Zoom pill adjustments
 
 /obj/item/weapon/reagent_containers/pill/diet
 	name = "diet pill"

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -293,9 +293,8 @@
 /obj/item/weapon/reagent_containers/pill/zoom/Initialize()
 	. = ..()
 	if(prob(50))						//VOREStation edit begin: Zoom pill adjustments
-		reagents.add_reagent("expired_medicine", 5)
-	else
-		reagents.add_reagent("mold", 5)
+		reagents.add_reagent("mold", 2)	//Chance to be more dangerous
+	reagents.add_reagent("expired_medicine", 5)
 	reagents.add_reagent("fertilizer", 5)
 	reagents.add_reagent("stimm", 5)	//VOREStation edit end: Zoom pill adjustments
 

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -295,7 +295,6 @@
 	if(prob(50))						//VOREStation edit begin: Zoom pill adjustments
 		reagents.add_reagent("mold", 2)	//Chance to be more dangerous
 	reagents.add_reagent("expired_medicine", 5)
-	reagents.add_reagent("fertilizer", 5)
 	reagents.add_reagent("stimm", 5)	//VOREStation edit end: Zoom pill adjustments
 
 /obj/item/weapon/reagent_containers/pill/diet


### PR DESCRIPTION
Replaces reagents because in current state its not too good at punishing floor pills or at giving zoomies.

Now instead has stimm (short term speed boost), and some toxic reagents that will start causing vomiting by the  time stimm wears off (or if you're specifically unlucky, before it wears off). One pill is not enough to be deadly, but will give noticable toxins. Two or more will start being hurtful for organs.

Resolves #4660 