### PR TITLE
Fixes unlocking cyborgs with wallets/micros

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -628,7 +628,7 @@
 		else
 			to_chat(user, "Unable to locate a radio.")
 
-	else if (istype(W, /obj/item/weapon/card/id)||istype(W, /obj/item/device/pda)||istype(W, /obj/item/weapon/card/robot))			// trying to unlock the interface with an ID card
+	else if (W.GetID())			// trying to unlock the interface with an ID card
 		if(emagged)//still allow them to open the cover
 			to_chat(user, "The interface seems slightly damaged")
 		if(opened)
@@ -729,7 +729,7 @@
 	var/list/L = req_access
 	if(!L.len) //no requirements
 		return 1
-	if(!I || !(istype(I, /obj/item/weapon/card/id) || istype(I, /obj/item/device/pda))) //not ID or PDA
+	if(!I) //nothing to check with..?
 		return 0
 	var/access_found = I.GetAccess()
 	for(var/req in req_access)


### PR DESCRIPTION
PDAs were made an exception originally. This way is much better.