### PR TITLE
Adds AI shell landmark to the map

### DIFF
--- a/maps/tether/tether-06-station2.dmm
+++ b/maps/tether/tether-06-station2.dmm
@@ -6049,6 +6049,7 @@
 	icon_state = "tube1";
 	dir = 4
 	},
+/obj/effect/landmark/free_ai_shell,
 /turf/simulated/floor/tiled/techfloor,
 /area/ai_cyborg_station)
 "ls" = (


### PR DESCRIPTION
In case we ever do end up making use of AI shells. The landmark won't do anything without appropriate config options both being on, but its good thing to have all usable landmarks in appropriate places. Otherwise we might end up getting situation similar to electrical storm event not working down the line.

Placed in cyborg station near the core.