### PR TITLE
Makes solars and substation smes start with output off

### DIFF
--- a/maps/tether/tether-01-surface1.dmm
+++ b/maps/tether/tether-01-surface1.dmm
@@ -6528,6 +6528,7 @@
 "amI" = (
 /obj/machinery/power/smes/buildable{
 	charge = 0;
+	output_attempt = 0;
 	RCon_tag = "Substation - Mining"
 	},
 /obj/structure/cable/green,
@@ -15457,6 +15458,7 @@
 "aSM" = (
 /obj/machinery/power/smes/buildable{
 	charge = 0;
+	output_attempt = 0;
 	RCon_tag = "Substation - Civ West"
 	},
 /obj/structure/cable/green{
@@ -32048,6 +32050,7 @@
 	},
 /obj/machinery/power/smes/buildable{
 	charge = 2e+006;
+	output_attempt = 0;
 	RCon_tag = "Substation - Atmospherics"
 	},
 /turf/simulated/floor/plating,

--- a/maps/tether/tether-01-surface1.dmm
+++ b/maps/tether/tether-01-surface1.dmm
@@ -32050,7 +32050,6 @@
 	},
 /obj/machinery/power/smes/buildable{
 	charge = 2e+006;
-	output_attempt = 0;
 	RCon_tag = "Substation - Atmospherics"
 	},
 /turf/simulated/floor/plating,

--- a/maps/tether/tether-02-surface2.dmm
+++ b/maps/tether/tether-02-surface2.dmm
@@ -225,6 +225,7 @@
 	},
 /obj/machinery/power/smes/buildable{
 	charge = 0;
+	output_attempt = 0;
 	RCon_tag = "Substation - MedSec"
 	},
 /turf/simulated/floor,
@@ -5575,6 +5576,7 @@
 "mg" = (
 /obj/machinery/power/smes/buildable{
 	charge = 0;
+	output_attempt = 0;
 	RCon_tag = "Substation - Research"
 	},
 /obj/structure/cable/green,
@@ -13246,6 +13248,7 @@
 "EI" = (
 /obj/machinery/power/smes/buildable{
 	charge = 100000;
+	output_attempt = 0;
 	RCon_tag = "Substation - Telecomms"
 	},
 /obj/structure/cable/green{

--- a/maps/tether/tether-03-surface3.dmm
+++ b/maps/tether/tether-03-surface3.dmm
@@ -21912,6 +21912,7 @@
 /obj/structure/cable,
 /obj/machinery/power/smes/buildable{
 	charge = 0;
+	output_attempt = 0;
 	RCon_tag = "Substation - Surface Civilian"
 	},
 /turf/simulated/floor/plating,

--- a/maps/tether/tether-05-station1.dmm
+++ b/maps/tether/tether-05-station1.dmm
@@ -1247,6 +1247,7 @@
 "acO" = (
 /obj/machinery/power/smes/buildable{
 	charge = 0;
+	output_attempt = 0;
 	RCon_tag = "Substation - Engineering"
 	},
 /obj/structure/cable/green{
@@ -11594,6 +11595,7 @@
 "aEX" = (
 /obj/machinery/power/smes/buildable{
 	charge = 0;
+	output_attempt = 0;
 	RCon_tag = "Substation - Civilian"
 	},
 /obj/structure/cable/green{
@@ -19625,6 +19627,7 @@
 "bFg" = (
 /obj/machinery/power/smes/buildable{
 	charge = 0;
+	output_attempt = 0;
 	RCon_tag = "Substation - Command"
 	},
 /obj/structure/cable/green{

--- a/maps/tether/tether-06-station2.dmm
+++ b/maps/tether/tether-06-station2.dmm
@@ -11034,6 +11034,7 @@
 "tN" = (
 /obj/machinery/power/smes/buildable{
 	charge = 0;
+	output_attempt = 0;
 	RCon_tag = "Substation - Medical"
 	},
 /obj/structure/cable/green,

--- a/maps/tether/tether-07-station3.dmm
+++ b/maps/tether/tether-07-station3.dmm
@@ -966,6 +966,7 @@
 "bA" = (
 /obj/machinery/power/smes/buildable{
 	charge = 0;
+	output_attempt = 0;
 	RCon_tag = "Substation - Security"
 	},
 /obj/structure/cable/green{
@@ -21965,6 +21966,7 @@
 "IP" = (
 /obj/machinery/power/smes/buildable{
 	charge = 0;
+	output_attempt = 0;
 	RCon_tag = "Substation - Cargo"
 	},
 /obj/structure/cable/green{

--- a/maps/tether/tether-09-solars.dmm
+++ b/maps/tether/tether-09-solars.dmm
@@ -353,6 +353,7 @@
 "aM" = (
 /obj/machinery/power/smes/buildable{
 	charge = 0;
+	output_attempt = 0;
 	RCon_tag = "Solar Farm - SMES 1"
 	},
 /obj/structure/cable/heavyduty,
@@ -361,6 +362,7 @@
 "aN" = (
 /obj/machinery/power/smes/buildable{
 	charge = 0;
+	output_attempt = 0;
 	RCon_tag = "Solar Farm - SMES 2"
 	},
 /obj/structure/cable/heavyduty,
@@ -370,6 +372,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/smes/buildable{
 	charge = 0;
+	output_attempt = 0;
 	RCon_tag = "Solar Farm - SMES 3"
 	},
 /obj/structure/cable/heavyduty,
@@ -2622,6 +2625,8 @@
 /area/maintenance/substation/outpost)
 "ff" = (
 /obj/machinery/power/smes/buildable{
+	charge = 0;
+	output_attempt = 0;
 	RCon_tag = "Substation - Science Outpost"
 	},
 /obj/structure/cable/green,


### PR DESCRIPTION
Mostly because they are all completely empty. Atmos starts on as it used before.