### PR TITLE
Some cyborg adjustments for map

### DIFF
--- a/maps/tether/tether-02-surface2.dmm
+++ b/maps/tether/tether-02-surface2.dmm
@@ -5038,6 +5038,10 @@
 "lc" = (
 /turf/simulated/wall/r_wall,
 /area/maintenance/lower/rnd)
+"ld" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/tiled/techmaint,
+/area/engineering/drone_fabrication)
 "le" = (
 /obj/structure/railing{
 	dir = 4
@@ -12251,13 +12255,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/engineering/drone_fabrication)
-"AO" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/effect/landmark{
-	name = "JoinLateCyborg"
-	},
-/turf/simulated/floor/tiled/techmaint,
 /area/engineering/drone_fabrication)
 "AZ" = (
 /obj/structure/catwalk,
@@ -28630,7 +28627,7 @@ Xm
 zk
 zR
 As
-AO
+ld
 Bd
 Tn
 BK

--- a/maps/tether/tether-05-station1.dmm
+++ b/maps/tether/tether-05-station1.dmm
@@ -1023,6 +1023,11 @@
 "ack" = (
 /turf/simulated/floor,
 /area/maintenance/station/eng_lower)
+"acl" = (
+/obj/structure/shuttle/engine/propulsion,
+/turf/simulated/floor/reinforced,
+/turf/simulated/shuttle/plating/airless/carry,
+/area/shuttle/excursion/tether)
 "acm" = (
 /turf/simulated/floor/tiled,
 /area/hallway/station/atrium)
@@ -2065,10 +2070,17 @@
 /turf/simulated/shuttle/floor/black,
 /area/shuttle/excursion/tether)
 "aeq" = (
-/obj/structure/shuttle/engine/propulsion,
-/turf/simulated/floor/reinforced,
-/turf/simulated/shuttle/plating/airless/carry,
-/area/shuttle/excursion/tether)
+/obj/machinery/computer/cryopod{
+	pixel_y = 32
+	},
+/obj/effect/floor_decal/techfloor{
+	dir = 5
+	},
+/obj/effect/landmark{
+	name = "JoinLateCyborg"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/crew_quarters/sleep/cryo)
 "aer" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -3498,6 +3510,20 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/station/explorer_meeting)
+"agz" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 6
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = -24
+	},
+/obj/effect/landmark{
+	name = "JoinLateCyborg"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/crew_quarters/sleep/cryo)
 "agF" = (
 /obj/effect/floor_decal/industrial/warning{
 	icon_state = "warning";
@@ -8124,15 +8150,6 @@
 	},
 /obj/effect/floor_decal/techfloor/corner{
 	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/crew_quarters/sleep/cryo)
-"avb" = (
-/obj/machinery/computer/cryopod{
-	pixel_y = 32
-	},
-/obj/effect/floor_decal/techfloor{
-	dir = 5
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/sleep/cryo)
@@ -16329,17 +16346,6 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/techfloor,
-/turf/simulated/floor/tiled/techfloor,
-/area/crew_quarters/sleep/cryo)
-"bff" = (
-/obj/effect/floor_decal/techfloor{
-	dir = 6
-	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_x = 0;
-	pixel_y = -24
-	},
 /turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/sleep/cryo)
 "bfk" = (
@@ -33818,7 +33824,7 @@ aeo
 aaq
 aaq
 aau
-aeq
+acl
 avK
 avN
 aad
@@ -33960,7 +33966,7 @@ amF
 rje
 adB
 aaq
-aeq
+acl
 avK
 avN
 aad
@@ -34102,7 +34108,7 @@ amF
 rje
 adB
 aaq
-aeq
+acl
 avK
 auH
 aad
@@ -34954,7 +34960,7 @@ aaD
 avG
 tIi
 aaq
-aeq
+acl
 avK
 auQ
 aad
@@ -35096,7 +35102,7 @@ amL
 aob
 dbI
 aaq
-aeq
+acl
 avK
 qgR
 aad
@@ -35238,7 +35244,7 @@ aep
 aeu
 aev
 aau
-aeq
+acl
 avK
 qgR
 aad
@@ -36538,8 +36544,8 @@ asN
 asN
 asN
 asI
-avb
-bff
+aeq
+agz
 asI
 bhL
 aus

--- a/maps/tether/tether-06-station2.dmm
+++ b/maps/tether/tether-06-station2.dmm
@@ -3499,38 +3499,56 @@
 /turf/simulated/floor/plating,
 /area/engineering/shaft)
 "fy" = (
-/obj/structure/shuttle/engine/propulsion{
-	dir = 8;
-	icon_state = "propulsion_l"
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 28
 	},
-/turf/space,
-/turf/simulated/shuttle/plating/airless/carry,
-/area/shuttle/large_escape_pod1/station{
-	base_turf = /turf/simulated/mineral/floor/vacuum
-	})
+/obj/structure/cable/cyan{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/effect/landmark/free_ai_shell,
+/turf/simulated/floor/tiled/techfloor,
+/area/ai_upload_foyer)
 "fz" = (
-/obj/structure/shuttle/engine/propulsion{
-	dir = 8
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
-/turf/space,
-/turf/simulated/shuttle/plating/airless/carry,
-/area/shuttle/large_escape_pod1/station{
-	base_turf = /turf/simulated/mineral/floor/vacuum
-	})
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/effect/landmark/start{
+	name = "Cyborg"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ai_cyborg_station)
 "fA" = (
-/obj/structure/shuttle/engine/propulsion{
-	dir = 8;
-	icon_state = "propulsion_r"
+/obj/machinery/hologram/holopad,
+/obj/effect/landmark/start{
+	name = "Cyborg"
 	},
-/turf/space,
-/turf/simulated/shuttle/plating/airless/carry,
-/area/shuttle/large_escape_pod1/station{
-	base_turf = /turf/simulated/mineral/floor/vacuum
-	})
+/turf/simulated/floor/tiled/techfloor,
+/area/ai_cyborg_station)
 "fB" = (
 /obj/structure/stairs/south,
 /turf/simulated/floor/tiled,
 /area/security/brig/visitation)
+"fC" = (
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 4
+	},
+/obj/effect/landmark{
+	name = "JoinLateCyborg"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ai_cyborg_station)
 "fD" = (
 /obj/effect/floor_decal/industrial/warning/corner,
 /obj/machinery/cryopod{
@@ -3542,6 +3560,45 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/brig)
+"fE" = (
+/obj/machinery/cryopod/robot,
+/turf/simulated/floor/tiled/techfloor,
+/area/ai_cyborg_station)
+"fF" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 9
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 10
+	},
+/obj/machinery/recharge_station,
+/turf/simulated/floor/tiled,
+/area/hallway/station/starboard)
+"fG" = (
+/obj/structure/shuttle/engine/propulsion{
+	dir = 8;
+	icon_state = "propulsion_l"
+	},
+/turf/space,
+/turf/simulated/shuttle/plating/airless/carry,
+/area/shuttle/large_escape_pod1/station{
+	base_turf = /turf/simulated/mineral/floor/vacuum
+	})
+"fH" = (
+/obj/structure/shuttle/engine/propulsion{
+	dir = 8
+	},
+/turf/space,
+/turf/simulated/shuttle/plating/airless/carry,
+/area/shuttle/large_escape_pod1/station{
+	base_turf = /turf/simulated/mineral/floor/vacuum
+	})
 "fI" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -3562,6 +3619,16 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/security_cell_hallway)
+"fJ" = (
+/obj/structure/shuttle/engine/propulsion{
+	dir = 8;
+	icon_state = "propulsion_r"
+	},
+/turf/space,
+/turf/simulated/shuttle/plating/airless/carry,
+/area/shuttle/large_escape_pod1/station{
+	base_turf = /turf/simulated/mineral/floor/vacuum
+	})
 "fK" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/structure/bed/chair,
@@ -5625,18 +5692,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/techfloor,
 /area/ai_upload_foyer)
-"ku" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 28
-	},
-/obj/structure/cable/cyan{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ai_upload_foyer)
 "kv" = (
 /obj/structure/cable/cyan{
 	d2 = 2;
@@ -6026,32 +6081,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ai_cyborg_station)
-"lo" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ai_cyborg_station)
-"lp" = (
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/tiled/techfloor,
-/area/ai_cyborg_station)
-"lq" = (
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
-	},
-/obj/effect/landmark/free_ai_shell,
-/turf/simulated/floor/tiled/techfloor,
-/area/ai_cyborg_station)
 "ls" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor,
@@ -6338,10 +6367,6 @@
 /obj/machinery/camera/network/command{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ai_cyborg_station)
-"lV" = (
-/obj/machinery/recharge_station,
 /turf/simulated/floor/tiled/techfloor,
 /area/ai_cyborg_station)
 "ma" = (
@@ -7637,25 +7662,6 @@
 "nU" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/station/starboard)
-"nV" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 25;
-	pixel_y = 0
-	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 4
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 9
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 10
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/station/starboard)
@@ -30090,11 +30096,11 @@ AN
 AN
 Bw
 yY
-fy
-fz
-fz
-fz
-fA
+fG
+fH
+fH
+fH
+fJ
 yY
 ac
 ac
@@ -31618,7 +31624,7 @@ in
 iU
 jr
 ka
-ku
+fy
 ll
 lS
 mx
@@ -31903,7 +31909,7 @@ dE
 dE
 kb
 kv
-lo
+fz
 lT
 kb
 WG
@@ -32045,7 +32051,7 @@ iW
 dE
 kb
 kw
-lp
+fA
 lU
 kb
 nh
@@ -32187,8 +32193,8 @@ iX
 dE
 kb
 kx
-lq
-lV
+fC
+fE
 kb
 ni
 nQ
@@ -33754,7 +33760,7 @@ Nh
 fg
 nl
 nU
-ot
+ou
 oY
 pE
 qc
@@ -33895,7 +33901,7 @@ jx
 js
 fg
 nr
-nV
+fF
 oF
 oY
 pE


### PR DESCRIPTION
Adds a new Cyborg Storage to Cyborg Station

Moved one of rechargers from Cyborg Station to end of Station 2 Hallway. Fixes #2569

Removes latejoin spawnpoint for cyborgs from Drone Fabrication

Adds latejoin spawnpoints for cyborgs to Cryogenic Storage and Cyborg Station

Adds roundstart spawnpoints for cyborgs to Cyborg Station (we didn't have any aparently?)