### PR TITLE
Removes Command PTO from appearing for players who had it

### DIFF
--- a/code/controllers/subsystems/persist_vr.dm
+++ b/code/controllers/subsystems/persist_vr.dm
@@ -92,3 +92,4 @@ SUBSYSTEM_DEF(persist)
 	LAZYINITLIST(C.department_hours)
 	if(C.department_hours["Command"])
 		C.department_hours["Command"] = null
+		C.department_hours.Remove("Command")


### PR DESCRIPTION
...or at least supposed to.