### PR TITLE
Removes trash piles hidden inside wall pockets

### DIFF
--- a/maps/tether/tether-06-station2.dmm
+++ b/maps/tether/tether-06-station2.dmm
@@ -3499,6 +3499,14 @@
 /turf/simulated/floor/plating,
 /area/engineering/shaft)
 "fy" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/clean,
+/obj/random/tool,
+/turf/simulated/floor,
+/area/medical/virology)
+"fz" = (
 /obj/structure/shuttle/engine/propulsion{
 	dir = 8;
 	icon_state = "propulsion_l"
@@ -3508,19 +3516,9 @@
 /area/shuttle/large_escape_pod1/station{
 	base_turf = /turf/simulated/mineral/floor/vacuum
 	})
-"fz" = (
-/obj/structure/shuttle/engine/propulsion{
-	dir = 8
-	},
-/turf/space,
-/turf/simulated/shuttle/plating/airless/carry,
-/area/shuttle/large_escape_pod1/station{
-	base_turf = /turf/simulated/mineral/floor/vacuum
-	})
 "fA" = (
 /obj/structure/shuttle/engine/propulsion{
-	dir = 8;
-	icon_state = "propulsion_r"
+	dir = 8
 	},
 /turf/space,
 /turf/simulated/shuttle/plating/airless/carry,
@@ -3531,6 +3529,16 @@
 /obj/structure/stairs/south,
 /turf/simulated/floor/tiled,
 /area/security/brig/visitation)
+"fC" = (
+/obj/structure/shuttle/engine/propulsion{
+	dir = 8;
+	icon_state = "propulsion_r"
+	},
+/turf/space,
+/turf/simulated/shuttle/plating/airless/carry,
+/area/shuttle/large_escape_pod1/station{
+	base_turf = /turf/simulated/mineral/floor/vacuum
+	})
 "fD" = (
 /obj/effect/floor_decal/industrial/warning/corner,
 /obj/machinery/cryopod{
@@ -8577,11 +8585,6 @@
 /area/medical/virology)
 "pt" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor,
-/area/medical/virology)
-"pu" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/random/trash_pile,
 /turf/simulated/floor,
 /area/medical/virology)
 "pv" = (
@@ -30090,11 +30093,11 @@ AN
 AN
 Bw
 yY
-fy
-fz
-fz
 fz
 fA
+fA
+fA
+fC
 yY
 ac
 ac
@@ -31910,7 +31913,7 @@ WG
 nP
 ot
 oW
-pu
+fy
 pZ
 qP
 rD

--- a/maps/tether/tether-06-station2.dmm
+++ b/maps/tether/tether-06-station2.dmm
@@ -3995,6 +3995,13 @@
 "gw" = (
 /turf/simulated/open,
 /area/engineering/locker_room)
+"gx" = (
+/obj/random/tool,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/clean,
+/obj/structure/closet,
+/turf/simulated/floor,
+/area/medical/virology)
 "gy" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1;
@@ -31912,7 +31919,7 @@ WG
 nP
 ot
 oW
-fy
+gx
 pZ
 qP
 rD

--- a/maps/tether/tether-07-station3.dmm
+++ b/maps/tether/tether-07-station3.dmm
@@ -20488,6 +20488,14 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/reception)
+"Gu" = (
+/obj/structure/catwalk,
+/obj/structure/closet/crate,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/cargo,
+/obj/random/maintenance/engineering,
+/turf/simulated/floor,
+/area/maintenance/security_starboard)
 "Gv" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -21235,11 +21243,6 @@
 "HK" = (
 /obj/structure/catwalk,
 /obj/effect/floor_decal/rust,
-/turf/simulated/floor,
-/area/maintenance/security_starboard)
-"HL" = (
-/obj/structure/catwalk,
-/obj/random/trash_pile,
 /turf/simulated/floor,
 /area/maintenance/security_starboard)
 "HM" = (
@@ -34287,7 +34290,7 @@ ED
 Fs
 Gj
 GT
-HL
+Gu
 Ix
 Je
 JV


### PR DESCRIPTION
Particularly one near public teleporter and one near virology. Seriously, people breaking down walls to dig in trash has gotten too much, and trash piles are MEANT to be accessible without too much a hassle. For those worrying about total amount of them, the few new ones in atmos maints compensate for those two.

As a note, pockets still exist, and trash piles have been replaced by some random maint loot instead.