### PR TITLE
Fixes bluespace harpoon targeting obstructed tiles

### DIFF
--- a/code/modules/vore/fluffstuff/guns/bsharpoon.dm
+++ b/code/modules/vore/fluffstuff/guns/bsharpoon.dm
@@ -43,6 +43,9 @@
 	if(get_area(A).flags & BLUE_SHIELDED)
 		to_chat(user, "<span class='warning'>The target area protected by bluespace shielding!</span>")
 		return
+	if(!(A in view(user, world.view)))
+		to_chat(user, "<span class='warning'>Harpoon fails to lock on the obstructed target!</span>")
+		return
 
 	last_fire = current_fire
 	playsound(user, 'sound/weapons/wave.ogg', 60, 1)


### PR DESCRIPTION
Specifically, tiles you cannot actually normally see, targeted via usage of mesons, materials or thermals.