### PR TITLE
Implements switching on/off duty midround via timeclock terminals

### DIFF
--- a/code/controllers/configuration_vr.dm
+++ b/code/controllers/configuration_vr.dm
@@ -5,6 +5,7 @@
 /datum/configuration
 	var/list/engine_map	// Comma separated list of engines to choose from.  Blank means fully random.
 	var/time_off = FALSE
+	var/pto_job_change = FALSE
 	var/limit_interns = -1 //Unlimited by default
 	var/limit_visitors = -1 //Unlimited by default
 	var/pto_cap = 100 //Hours
@@ -52,5 +53,7 @@
 				config.pto_cap = text2num(value)
 			if ("time_off")
 				config.time_off = TRUE
+			if ("pto_job_change")
+				config.pto_job_change = TRUE
 
 	return 1

--- a/code/game/jobs/job/offduty_vr.dm
+++ b/code/game/jobs/job/offduty_vr.dm
@@ -3,7 +3,7 @@
 //
 
 /datum/job/offduty_civilian
-	title = "Off-Duty Worker"
+	title = "Off-duty Worker"
 	latejoin_only = TRUE
 	timeoff_factor = -1
 	total_positions = -1

--- a/code/game/machinery/computer/timeclock_vr.dm
+++ b/code/game/machinery/computer/timeclock_vr.dm
@@ -85,8 +85,8 @@
 				"timeoff_factor" = job.timeoff_factor
 			)
 		// TODO - Once job changing is implemented, we will want to list jobs to change into.
-		// if(job && job.timeoff_factor < 0) // Currently are Off Duty, so gotta lookup what on-duty jobs are open
-		// 	data["job_choices"] = getOpenOnDutyJobs(user, job.department)
+		if(job && job.timeoff_factor < 0) // Currently are Off Duty, so gotta lookup what on-duty jobs are open
+			data["job_choices"] = getOpenOnDutyJobs(user, job.department)
 
 	ui = SSnanoui.try_update_ui(user, src, ui_key, ui, data, force_open)
 	if (!ui)
@@ -101,7 +101,7 @@
 	src.add_fingerprint(usr)
 
 	if (href_list["id"])
-		if (card)
+		if(card)
 			usr.put_in_hands(card)
 			card = null
 		else
@@ -110,7 +110,26 @@
 				I.forceMove(src)
 				card = I
 		update_icon()
+		return
+	if(href_list["switch-to-onduty"])
+		if(card)
+			makeOnDuty(href_list["switch-to-onduty"])
+			usr.put_in_hands(card)
 	return 1 // Return 1 to update UI
+
+/obj/machinery/computer/timeclock/proc/getOpenOnDutyJobs(var/mob/user, var/department)
+	var/list/available_jobs = list()
+	for(var/datum/job/job in job_master.occupations)
+		if(job && job.is_position_available() && !job.whitelist_only)	// && job.player_old_enough(user.client) && !jobban_isbanned(user,job.title)
+			if(job.department == department && !job.head_position && job.timeoff_factor > 0 && !(job.title == "Internal Affairs Agent"))
+				available_jobs += job.title
+				if(job.alt_titles)
+					for(var/alt_job in job.alt_titles)
+						available_jobs += alt_job
+	return available_jobs
+
+/obj/machinery/computer/timeclock/proc/makeOnDuty(var/newjob)
+	return
 
 //
 // Frame type for construction
@@ -145,3 +164,12 @@
 /obj/machinery/computer/timeclock/premade/west
 	dir = 4
 	pixel_x = -26
+
+/mob/verb/gain_pto()
+	set name = "Gain PTO"
+	set category = "Debug"
+
+	if(!client)
+		return FALSE
+	else
+		client.department_hours += list("Security" = 30)

--- a/code/game/machinery/computer/timeclock_vr.dm
+++ b/code/game/machinery/computer/timeclock_vr.dm
@@ -156,6 +156,8 @@
 		if(newjob in job.alt_titles)
 			foundjob = job
 			break
+	if(!newjob in getOpenOnDutyJobs(usr, job_master.GetJob(card.rank).department))
+		return
 	if(foundjob && card)
 		card.access = foundjob.get_access()
 		card.rank = foundjob.title

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -407,6 +407,9 @@ ENGINE_MAP Supermatter Engine,Edison's Bane
 # Controls if the 'time off' system is used for determining if players can play 'Off-Duty' jobs (requires SQL)
 # TIME_OFF
 
+# If 'time off' system is on, controls whether or not players can switch on/off duty midround using timeclocks
+# PTO_JOB_CHANGE
+
 # Applies a limit to the number of assistants and visitors respectively
 # LIMIT_INTERNS 6
 # LIMIT_VISITORS 6

--- a/nano/templates/timeclock_vr.tmpl
+++ b/nano/templates/timeclock_vr.tmpl
@@ -56,7 +56,7 @@
 	{{/if}}
 </div>
 
-{{if data.job_datum && data.job_datum.timeoff_factor != 0 }}
+{{if data.job_datum && data.job_datum.timeoff_factor != 0 && !(data.assignment == "Terminated")}}
 <h3>Employment Actions</h3>
 <div class='itemGroup'>
 	<div class='item'>

--- a/nano/templates/timeclock_vr.tmpl
+++ b/nano/templates/timeclock_vr.tmpl
@@ -56,24 +56,21 @@
 	{{/if}}
 </div>
 
-{{if data.allow_change_job && data.job_datum && data.job_datum.timeoff_factor != 0 }}
+{{if data.job_datum && data.job_datum.timeoff_factor != 0 }}
 <h3>Employment Actions</h3>
 <div class='itemGroup'>
 	<div class='item'>
-		{{if data.job_datum.head_position }}
-			<i class='uiIcon16 icon-alert'></i>
-			<span class='average'>NT policy does not permit head positions to go off duty mid-shift.</span>
-		{{else (data.job_datum.timeoff_factor > 0) }}
+		{{if (data.job_datum.timeoff_factor > 0) }}
 			{{if helper.round(data.department_hours[data.job_datum.department]) > 0 }}
-				{{:helper.link('Go Off Duty', 'alert', {'switch-to-offduty': 1})}}
+				{{:helper.link('Go Off-Duty', 'alert', {'switch-to-offduty': 1})}}
 			{{else}}
 				<i class='uiIcon16 icon-alert-red'></i>
 				<span class='bad'>Insufficent Time Off Accrued</span>
 			{{/if}}
 		{{else (data.job_datum.timeoff_factor < 0) }}
-			{{for data.job_choices }}
+			{{props data.job_choices }}
 				<div class='itemLabelWide'>{{:value}}</div>
-				<div class='itemContentMedium'>{{:helper.link("Issue Guest Pass", 'suitcase', {'guest-pass' : value})}}</div>
+				<div class='itemContentMedium'>{{:helper.link("Go On-Duty", 'suitcase', {'switch-to-onduty' : value})}}</div>
 			{{empty}}
 				<div class='notice'>No Open Positions - See Head of Personnel</div>
 			{{/for}}

--- a/nano/templates/timeclock_vr.tmpl
+++ b/nano/templates/timeclock_vr.tmpl
@@ -56,12 +56,12 @@
 	{{/if}}
 </div>
 
-{{if data.job_datum && data.job_datum.timeoff_factor != 0 && !(data.assignment == "Terminated")}}
+{{if data.allow_change_job && data.job_datum && data.job_datum.timeoff_factor != 0 && !(data.assignment == "Terminated")}}
 <h3>Employment Actions</h3>
 <div class='itemGroup'>
 	<div class='item'>
 		{{if (data.job_datum.timeoff_factor > 0) }}
-			{{if helper.round(data.department_hours[data.job_datum.department]) > 0 }}
+			{{if helper.round(data.department_hours[data.job_datum.department]) > 0 || (data.job_datum.department == "Command" && helper.round(data.department_hours["Civilian"]) > 0)}}
 				{{:helper.link('Go Off-Duty', 'alert', {'switch-to-offduty': 1})}}
 			{{else}}
 				<i class='uiIcon16 icon-alert-red'></i>


### PR DESCRIPTION
Well, that was what timeclocks were for in the first place, so here you have it.

Allows to switch off-duty if PTO of your current department is positive and allows to go on-duty as any non-head, non-IAA, non-secretary job you are not jobbanned from (including alt-titles), all using timeclock terminal.

15 minute cooldown between joining and first ability to switch, and further 15 minute cooldown after every switch.

Switches are announced over common channel, similar to arrival/departure.

A config option, by default it is OFF (same as PTO gathering in general).