### PR TITLE
Fixes gasmasks on human sprites appearing wrong

### DIFF
--- a/code/modules/clothing/clothing_vr.dm
+++ b/code/modules/clothing/clothing_vr.dm
@@ -84,6 +84,9 @@
 	body_parts_covered = HEAD
 	slot_flags = SLOT_MASK
 	body_parts_covered = FACE|EYES
+	item_icons = list(
+		slot_wear_mask_str = 'icons/mob/mask_vr.dmi'
+		)
 	sprite_sheets = list(
 		SPECIES_TESHARI		= 'icons/mob/species/seromi/masks_vr.dmi',
 		SPECIES_VOX 		= 'icons/mob/species/vox/masks.dmi',
@@ -105,7 +108,7 @@
 
 /obj/item/clothing/suit/equipped(var/mob/user, var/slot)
 	var/normalize = TRUE
-	
+
 	//Pyramid of doom-y. Improve somehow?
 	if(!taurized && slot == slot_wear_suit && ishuman(user))
 		var/mob/living/carbon/human/H = user


### PR DESCRIPTION
...I'm pretty sure there is more graceful way to do it elsewhere... But this is best and most practical way to achieve result I managed. The whole sprite overriding concept is a coding disaster with way sprites are handled..