### PR TITLE
Cataloguer placeholders

### DIFF
--- a/code/game/objects/items/devices/radio/radio_vr.dm
+++ b/code/game/objects/items/devices/radio/radio_vr.dm
@@ -21,6 +21,7 @@
 /obj/item/device/subspaceradio
 	name = "subspace radio"
 	desc = "A powerful new radio recently gifted to Nanotrasen from KHI, this communications device has the ability to send and recieve transmissions from anywhere."
+	catalogue_data = list(/datum/category_item/catalogue/information/organization/khi)
 	icon = 'icons/vore/custom_items_vr.dmi'
 	icon_override = 'icons/mob/back_vr.dmi'
 	icon_state = "radiopack"

--- a/code/game/objects/structures/signs.dm
+++ b/code/game/objects/structures/signs.dm
@@ -515,6 +515,7 @@
 	name = "\improper NanoTrasen"
 	desc = "An old metal sign which reads 'NanoTrasen'."
 	icon_state = "NT"
+	catalogue_data = list(/datum/category_item/catalogue/information/organization/nanotrasen)
 
 // Eris standards compliant hazards
 /obj/structure/sign/signnew

--- a/code/modules/catalogue/catalogue_data_vr.dm
+++ b/code/modules/catalogue/catalogue_data_vr.dm
@@ -1,0 +1,76 @@
+//TODO: VIRGO_LORE_WRITING_WIP - this whole file
+
+/datum/category_item/catalogue/fauna/akula
+	name = "Sapients - Akula"
+	desc = ""
+	value = CATALOGUER_REWARD_TRIVIAL
+
+/datum/category_item/catalogue/fauna/sergal
+	name = "Sapients - Sergal"
+	desc = ""
+	value = CATALOGUER_REWARD_TRIVIAL
+
+/datum/category_item/catalogue/fauna/nevrean
+	name = "Sapients - Nevrean"
+	desc = ""
+	value = CATALOGUER_REWARD_TRIVIAL
+
+/datum/category_item/catalogue/fauna/rapala
+	name = "Sapients - Rapala"
+	desc = ""
+	value = CATALOGUER_REWARD_TRIVIAL
+
+/datum/category_item/catalogue/fauna/xenochimera
+	name = "Sapients - Xenochimera"
+	desc = ""
+	value = CATALOGUER_REWARD_TRIVIAL
+
+/datum/category_item/catalogue/fauna/vulpkanin
+	name = "Sapients - Vulpkanin"
+	desc = ""
+	value = CATALOGUER_REWARD_TRIVIAL
+
+/datum/category_item/catalogue/fauna/alraune
+	name = "Sapients - Alraune"
+	desc = ""
+	value = CATALOGUER_REWARD_TRIVIAL
+
+/datum/category_item/catalogue/fauna/vasilissan
+	name = "Sapients - Vasilissan"
+	desc = ""
+	value = CATALOGUER_REWARD_TRIVIAL
+
+/datum/category_item/catalogue/fauna/xenohybrid
+	name = "Sapients - Xenomorph Hybrid"
+	desc = ""
+	value = CATALOGUER_REWARD_TRIVIAL
+
+/datum/category_item/catalogue/fauna/zorren
+	name = "Sapients - Zorren"
+	desc = ""
+	value = CATALOGUER_REWARD_TRIVIAL
+
+/datum/category_item/catalogue/fauna/highzorren
+	name = "Sapients - Highlander Zorren"
+	desc = ""
+	value = CATALOGUER_REWARD_TRIVIAL
+
+/datum/category_item/catalogue/fauna/flatzorren
+	name = "Sapients - Flatlander Zorren"
+	desc = ""
+	value = CATALOGUER_REWARD_TRIVIAL
+
+/datum/category_item/catalogue/fauna/custom_species
+	name = "Sapients - Other"
+	desc = "Remote frontiers require people of all sorts of life...\
+	Sometimes species one would never see anywhere close to core worlds can be met here."
+	value = CATALOGUER_REWARD_TRIVIAL
+
+/datum/category_item/catalogue/technology/resleeving
+	name = "Resleeving"
+	desc = ""
+	value = CATALOGUER_REWARD_TRIVIAL
+
+/datum/category_item/catalogue/information/organization/khi
+	name = "Government - Kitsuhana Heavy Industries"
+	datum_to_copy = /datum/lore/organization/gov/kitsuhana

--- a/code/modules/mob/living/carbon/human/species/station/alraune.dm
+++ b/code/modules/mob/living/carbon/human/species/station/alraune.dm
@@ -67,6 +67,7 @@
 	\
 	However, after their discovery by the angels of Sanctum, many alraunes succumbed to their curiosity, and took the offer\
 	to learn of the world and venture out, whether it's to Sanctum, or elsewhere in the galaxy."
+	catalogue_data = list(/datum/category_item/catalogue/fauna/alraune)
 
 	has_limbs = list(
 		BP_TORSO =  list("path" = /obj/item/organ/external/chest),

--- a/code/modules/mob/living/carbon/human/species/station/blank_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/blank_vr.dm
@@ -19,6 +19,7 @@
 	blurb = "This is a custom species where you can assign various species traits to them as you wish, to \
 	create a (hopefully) balanced species. You will see the options to customize them on the VORE tab once \
 	you select and set this species as your species. Please look at the VORE tab if you select this species."
+	catalogue_data = list(/datum/category_item/catalogue/fauna/custom_species)
 
 	name_language = null // Use the first-name last-name generator rather than a language scrambler
 	min_age = 18

--- a/code/modules/mob/living/carbon/human/species/station/station_special_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_special_vr.dm
@@ -41,6 +41,7 @@
 	blurb = "Some amalgamation of different species from across the universe,with extremely unstable DNA, making them unfit for regular cloners. \
 	Widely known for their voracious nature and violent tendencies when stressed or left unfed for long periods of time. \
 	Most, if not all chimeras possess the ability to undergo some type of regeneration process, at the cost of energy."
+	catalogue_data = list(/datum/category_item/catalogue/fauna/xenochimera)
 
 	hazard_low_pressure = -1 //Prevents them from dying normally in space. Special code handled below.
 	cold_level_1 = -1     // All cold debuffs are handled below in handle_environment_special
@@ -341,6 +342,7 @@
 	from their mandible lined mouths.  They are a recent discovery by Nanotrasen, only being discovered roughly seven years ago.  \
 	Before they were found they built great cities out of their silk, being united and subjugated in warring factions under great Star Queens  \
 	Who forced the working class to build huge, towering cities to attempt to reach the stars, which they worship as gems of great spiritual and magical significance."
+	catalogue_data = list(/datum/category_item/catalogue/fauna/vasilissan)
 
 	hazard_low_pressure = 20 //Prevents them from dying normally in space. Special code handled below.
 	cold_level_1 = -1    // All cold debuffs are handled below in handle_environment_special

--- a/code/modules/mob/living/carbon/human/species/station/station_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_vr.dm
@@ -27,6 +27,7 @@
 	racial tensions which has resulted in more than a number of wars and outright attempts at genocide. Sergals have an incredibly long \
 	lifespan, but due to their lust for violence, only a handful have ever survived beyond the age of 80, such as the infamous and \
 	legendary General Rain Silves who is claimed to have lived to 5000."
+	catalogue_data = list(/datum/category_item/catalogue/fauna/sergal)
 
 	primitive_form = "Saru"
 
@@ -87,6 +88,7 @@
 	allies over the next few hundred years. With the help of Skrellean technology, the Akula had their genome modified to be capable of \
 	surviving in open air for long periods of time. However, Akula even today still require a high humidity environment to avoid drying out \
 	after a few days, which would make life on an arid world like Virgo-Prime nearly impossible if it were not for Skrellean technology to aid them."
+	catalogue_data = list(/datum/category_item/catalogue/fauna/akula)
 
 	primitive_form = "Sobaka"
 
@@ -127,6 +129,7 @@
 	intelligence and very skillful hands that are put use for constructing precision instruments, but tire-out fast when repeatedly working \
 	over and over again. Consequently, they struggle to make copies of same things. Both genders have a voice that echoes a lot. Their natural \
 	tone oscillates between tenor and soprano. They are excessively noisy when they quarrel in their native language."
+	catalogue_data = list(/datum/category_item/catalogue/fauna/nevrean)
 
 	primitive_form = "Sparra"
 
@@ -165,6 +168,8 @@
 	mountainous areas, they have a differing societal structure than the Flatland Zorren having a more feudal social structure, like the Flatland Zorren, \
 	the Highland Zorren have also only recently been hired by the Trans-Stellar Corporations, but thanks to the different social structure they seem to \
 	have adjusted better to their new lives. Though similar fox-like beings have been seen they are different than the Zorren."
+	catalogue_data = list(/datum/category_item/catalogue/fauna/zorren,
+						/datum/category_item/catalogue/fauna/highzorren)
 
 	//primitive_form = "" //We don't have fox-monkey sprites.
 
@@ -205,6 +210,8 @@
 	mountainous areas, they have a differing societal structure than the Flatland Zorren having a more feudal social structure, like the Flatland Zorren, \
 	the Highland Zorren have also only recently been hired by the Trans-Stellar Corporations, but thanks to the different social structure they \
 	seem to have adjusted better to their new lives. Though similar fox-like beings have been seen they are different than the Zorren."
+	catalogue_data = list(/datum/category_item/catalogue/fauna/zorren,
+						/datum/category_item/catalogue/fauna/flatzorren)
 
 	//primitive_form = "" //We don't have fennec-monkey sprites.
 	spawn_flags = SPECIES_CAN_JOIN
@@ -247,6 +254,7 @@
 	culture both feared and respected for their scientific breakthroughs. Discovery, loyalty, and utilitarianism dominates their lifestyles \
 	to the degree it can cause conflict with more rigorous and strict authorities. They speak a guttural language known as 'Canilunzt' \
     which has a heavy emphasis on utilizing tail positioning and ear twitches to communicate intent."
+	catalogue_data = list(/datum/category_item/catalogue/fauna/vulpkanin)
 
 	primitive_form = "Wolpin"
 
@@ -279,6 +287,7 @@
 	although there are some exceptions, such as when they are harmed. Most xenomorph hybrids are female, due to their natural xenomorph genes, \
 	but there are multiple exceptions. All xenomorph hybrids have had their ability to lay eggs containing facehuggers \
 	removed if they had the ability to, although hybrids that previously contained this ability is extremely rare."
+	catalogue_data = list(/datum/category_item/catalogue/fauna/xenohybrid)
 
 	//primitive_form = "" //None for these guys
 
@@ -399,6 +408,7 @@ datum/species/harpy
 	Sol researchers have commented on them having a very close resemblance to the mythical race called 'Harpies',\
 	who are known for having massive winged arms and talons as feet. They've been clocked at speeds of over 35 miler per hour chasing the planet's many fish-like fauna.\
 	The Rapalan's home-world 'Verita' is a strangely habitable gas giant, while no physical earth exists, there are fertile floating islands orbiting around the planet from past asteroid activity."
+	catalogue_data = list(/datum/category_item/catalogue/fauna/rapala)
 
 	//primitive_form = "Saru"
 

--- a/code/modules/mob/living/simple_mob/subtypes/animal/sif/fluffy_vr.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/sif/fluffy_vr.dm
@@ -2,6 +2,7 @@
 	name = "Fluffy"
 	desc = "It's a pink Diyaab! It seems to be very tame and quiet."
 	tt_desc = "S Choeros hirtus"
+	catalogue_data = list(/datum/category_item/catalogue/fauna/diyaab)
 
 	icon_state = "fluffy"
 	icon_living = "fluffy"

--- a/code/modules/mob/living/simple_mob/subtypes/animal/space/gaslamp_vr.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/space/gaslamp_vr.dm
@@ -10,10 +10,16 @@ kills them.
 TODO: Make them light up and heat the air when exposed to oxygen.
 */
 
+/datum/category_item/catalogue/fauna/gaslamp		//TODO: VIRGO_LORE_WRITING_WIP
+	name = "Virgo 3b Fauna - Gaslamp"
+	desc = ""
+	value = CATALOGUER_REWARD_TRIVIAL
+
 /mob/living/simple_mob/animal/passive/gaslamp
 	name = "gaslamp"
 	desc = "Some sort of floaty alien with a warm glow. This creature is endemic to Virgo-3B."
 	tt_desc = "Semaeostomeae virginus"
+	catalogue_data = list(/datum/category_item/catalogue/fauna/gaslamp)
 
 	icon_state = "gaslamp"
 	icon_living = "gaslamp"

--- a/code/modules/mob/living/simple_mob/subtypes/vore/corrupt_hounds.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/corrupt_hounds.dm
@@ -1,6 +1,12 @@
+/datum/category_item/catalogue/technology/drone/corrupt_hound		//TODO: VIRGO_LORE_WRITING_WIP
+	name = "Drone - Corrupt Hound"
+	desc = ""
+	value = CATALOGUER_REWARD_MEDIUM
+
 /mob/living/simple_mob/vore/aggressive/corrupthound
 	name = "corrupt hound"
 	desc = "Good boy machine broke. This is definitely no good news for the organic lifeforms in vicinity."
+	catalogue_data = list(/datum/category_item/catalogue/technology/drone/corrupt_hound)
 
 	icon_state = "badboi"
 	icon_living = "badboi"

--- a/code/modules/mob/living/simple_mob/subtypes/vore/shadekin/shadekin.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/shadekin/shadekin.dm
@@ -1,6 +1,12 @@
+/datum/category_item/catalogue/fauna/shadekin		//TODO: VIRGO_LORE_WRITING_WIP
+	name = "Sapients - Shadekin"
+	desc = ""
+	value = CATALOGUER_REWARD_EASY
+
 /mob/living/simple_mob/shadekin //Spawning the prototype spawns a random one, see initialize()
 	name = "shadekin"
 	desc = "Some sort of fluffer. Big ears, long tail."
+	catalogue_data = list(/datum/category_item/catalogue/fauna/shadekin)
 	icon = 'icons/mob/vore_shadekin.dmi'
 	icon_state = "map_example"
 	icon_living = "map_example"

--- a/code/modules/projectiles/guns/energy/netgun_vr.dm
+++ b/code/modules/projectiles/guns/energy/netgun_vr.dm
@@ -2,6 +2,7 @@
 	name = "energy net gun"
 	desc = "A Kitsuhana-designed, usually dubbed 'Hunter' or 'non-lethal capture device' stunner and energy net launcher, \
 			for when you want criminals to stop acting like they're on a 20th century British comedy sketch show."
+	catalogue_data = list(/datum/category_item/catalogue/information/organization/khi)
 	icon = 'icons/obj/gun_vr.dmi'
 	icon_state = "hunter"
 	item_state = "gun" // Placeholder

--- a/code/modules/resleeving/computers.dm
+++ b/code/modules/resleeving/computers.dm
@@ -1,5 +1,7 @@
 /obj/machinery/computer/transhuman/resleeving
 	name = "resleeving control console"
+	catalogue_data = list(/datum/category_item/catalogue/information/organization/khi,
+						/datum/category_item/catalogue/technology/resleeving)
 	icon_keyboard = "med_key"
 	icon_screen = "dna"
 	light_color = "#315ab4"
@@ -382,6 +384,7 @@
 /obj/item/weapon/cmo_disk_holder
 	name = "cmo emergency packet"
 	desc = "A small paper packet with printing on one side. \"Tear open in case of Code Delta or Emergency Evacuation ONLY. Use in any other case is UNLAWFUL.\""
+	catalogue_data = list(/datum/category_item/catalogue/technology/resleeving)
 	icon = 'icons/vore/custom_items_vr.dmi'
 	icon_state = "cmoemergency"
 	item_state = "card-id"
@@ -400,6 +403,7 @@
 	\"1.INSERT DISK INTO RESLEEVING CONSOLE\n\
 	2. BEGIN CORE DUMP PROCEDURE\n\
 	3. ENSURE DISK SAFETY WHEN EJECTED\""
+	catalogue_data = list(/datum/category_item/catalogue/technology/resleeving)
 	icon = 'icons/obj/cloning.dmi'
 	icon_state = "harddisk"
 	item_state = "card-id"

--- a/code/modules/resleeving/designer.dm
+++ b/code/modules/resleeving/designer.dm
@@ -3,6 +3,8 @@
 
 /obj/machinery/computer/transhuman/designer
 	name = "body design console"
+	catalogue_data = list(/datum/category_item/catalogue/information/organization/khi,
+						/datum/category_item/catalogue/technology/resleeving)
 	icon = 'icons/obj/computer_vr.dmi'
 	icon_keyboard = "med_key"
 	icon_screen = "explosive"

--- a/code/modules/resleeving/implant.dm
+++ b/code/modules/resleeving/implant.dm
@@ -7,6 +7,8 @@
 /obj/item/weapon/implant/backup
 	name = "backup implant"
 	desc = "A mindstate backup implant that occasionally stores a copy of one's mind on a central server for backup purposes."
+	catalogue_data = list(/datum/category_item/catalogue/information/organization/khi,
+						/datum/category_item/catalogue/technology/resleeving)
 	icon = 'icons/vore/custom_items_vr.dmi'
 	icon_state = "backup_implant"
 
@@ -38,6 +40,8 @@
 /obj/item/weapon/backup_implanter
 	name = "backup implanter"
 	desc = "After discovering that Nanotrasen was just re-using the same implanters over and over again on organics, leading to cross-contamination, Kitsuhana Heavy industries designed this self-cleaning model. Holds four backup implants at a time."
+	catalogue_data = list(/datum/category_item/catalogue/information/organization/khi,
+						/datum/category_item/catalogue/technology/resleeving)
 	icon = 'icons/obj/device_alt.dmi'
 	icon_state = "bimplant"
 	item_state = "syringe_0"

--- a/code/modules/resleeving/machines.dm
+++ b/code/modules/resleeving/machines.dm
@@ -6,6 +6,8 @@
 /////// Grower Pod ///////
 /obj/machinery/clonepod/transhuman
 	name = "grower pod"
+	catalogue_data = list(/datum/category_item/catalogue/information/organization/khi,
+						/datum/category_item/catalogue/technology/resleeving)
 	circuit = /obj/item/weapon/circuitboard/transhuman_clonepod
 
 //A full version of the pod
@@ -170,6 +172,8 @@
 /obj/machinery/transhuman/synthprinter
 	name = "SynthFab 3000"
 	desc = "A rapid fabricator for synthetic bodies."
+	catalogue_data = list(/datum/category_item/catalogue/information/organization/khi,
+						/datum/category_item/catalogue/technology/resleeving)
 	icon = 'icons/obj/machines/synthpod.dmi'
 	icon_state = "pod_0"
 	circuit = /obj/item/weapon/circuitboard/transhuman_synthprinter
@@ -395,6 +399,8 @@
 /obj/machinery/transhuman/resleever
 	name = "resleeving pod"
 	desc = "Used to combine mind and body into one unit."
+	catalogue_data = list(/datum/category_item/catalogue/information/organization/khi,
+						/datum/category_item/catalogue/technology/resleeving)
 	icon = 'icons/obj/machines/implantchair.dmi'
 	icon_state = "implantchair"
 	circuit = /obj/item/weapon/circuitboard/transhuman_resleever

--- a/code/modules/resleeving/sleevecard.dm
+++ b/code/modules/resleeving/sleevecard.dm
@@ -4,6 +4,8 @@
 /obj/item/device/sleevecard
 	name = "sleevecard"
 	desc = "This KHI-upgraded pAI module has enough capacity to run a whole mind of human-level intelligence."
+	catalogue_data = list(/datum/category_item/catalogue/information/organization/khi,
+						/datum/category_item/catalogue/technology/resleeving)
 
 	icon = 'icons/obj/pda.dmi'
 	icon_state = "pai"

--- a/code/modules/vore/fluffstuff/custom_clothes_vr.dm
+++ b/code/modules/vore/fluffstuff/custom_clothes_vr.dm
@@ -907,6 +907,7 @@
 /obj/item/clothing/under/rank/khi
 	name = "Delete Me"
 	desc = "Why did you spawn this one? Dork."
+	catalogue_data = list(/datum/category_item/catalogue/information/organization/khi)
 	sensor_mode = 3
 
 	icon = 'icons/vore/custom_clothes_vr.dmi'

--- a/code/modules/vore/fluffstuff/guns/nsfw.dm
+++ b/code/modules/vore/fluffstuff/guns/nsfw.dm
@@ -4,6 +4,7 @@
 	desc = "Variety is the spice of life! The KHI-102b 'Nanotech Selectable-Fire Weapon', or NSFW for short, is an unholy hybrid of an ammo-driven  \
 	energy weapon that allows the user to mix and match their own fire modes. Up to three combinations of \
 	energy beams can be configured at once. Ammo not included."
+	catalogue_data = list(/datum/category_item/catalogue/information/organization/khi)
 
 	description_info = "This gun is an energy weapon that uses interchangable microbatteries in a magazine. Each battery is a different beam type, and up to three can be loaded in the magazine. Each battery usually provides four discharges of that beam type, and multiple from the same type may be loaded to increase the number of shots for that type."
 	description_fluff = "The Kitsuhana 'Nanotech Selectable Fire Weapon' allows one to customize their loadout in the field, or before deploying, to achieve various results in a weapon they are already familiar with wielding."
@@ -145,6 +146,7 @@
 /obj/item/ammo_magazine/nsfw_mag
 	name = "microbattery magazine"
 	desc = "A microbattery holder for the \'NSFW\'"
+	catalogue_data = list(/datum/category_item/catalogue/information/organization/khi)
 
 	description_info = "This magazine holds NSFW microbatteries to power the NSFW handgun. Up to three can be loaded at once, and each provides four shots of their respective energy type. Loading multiple of the same type will provide additional shots of that type. The batteries can be recharged in a normal recharger."
 
@@ -186,6 +188,7 @@
 /obj/item/ammo_casing/nsfw_batt
 	name = "\'NSFW\' microbattery - UNKNOWN"
 	desc = "A miniature battery for an energy weapon."
+	catalogue_data = list(/datum/category_item/catalogue/information/organization/khi)
 	icon = 'icons/obj/ammo_vr.dmi'
 	icon_state = "nsfw_batt"
 	slot_flags = SLOT_BELT | SLOT_EARS

--- a/code/modules/vore/fluffstuff/guns/protector.dm
+++ b/code/modules/vore/fluffstuff/guns/protector.dm
@@ -3,6 +3,7 @@
 	name = "small energy gun"
 	desc = "The KHI-98a 'Protector' is the first firearm custom-designed for Nanotrasen by KHI. It features a powerful stun mode, and \
 	an alert-level-locked lethal mode, only usable on code blue and higher. It also features an integrated flashlight!"
+	catalogue_data = list(/datum/category_item/catalogue/information/organization/khi)
 
 	description_info = "This gun can only be fired in lethal mode while on higher security alert levels. It is legal for sec to carry for this reason, since it cannot be used for lethal force until SOP allows it, in essence."
 	description_fluff = "The first 'commission' from a Kitsuhana citizen for NanoTrasen, this gun has a wireless connection to the computer's datacore to ensure it can't be used without authorization from heads of staff who have raised the alert level. Until then, *click*!"

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -1529,6 +1529,7 @@
 #include "code\modules\busy_space_vr\organizations.dm"
 #include "code\modules\catalogue\atoms.dm"
 #include "code\modules\catalogue\catalogue_data.dm"
+#include "code\modules\catalogue\catalogue_data_vr.dm"
 #include "code\modules\catalogue\cataloguer.dm"
 #include "code\modules\catalogue\cataloguer_visuals.dm"
 #include "code\modules\client\client defines.dm"


### PR DESCRIPTION
Adds some placeholder entries to cataloguer, regarding virgo-unique stuff specifically. TODO notes to fill them out are present as well. This is primarily to allow point-earning despite lack of entries for now and as general markdown of what exactly needs to be written out.