### PR TITLE
Changes way timeclock going on-duty restritctions work slightly

### DIFF
--- a/code/game/jobs/job/job_vr.dm
+++ b/code/game/jobs/job/job_vr.dm
@@ -8,6 +8,9 @@
 	//Every hour playing this role gains this much time off. (Can be negative for off duty jobs!)
 	var/timeoff_factor = 3
 
+	//Disallow joining as this job midround from off-duty position via going on-duty
+	var/disallow_jobhop = FALSE
+
 // Check client-specific availability rules.
 /datum/job/proc/player_has_enough_pto(client/C)
 	return timeoff_factor >= 0 || (C && LAZYACCESS(C.department_hours, department) > 0)

--- a/code/game/jobs/job/z_all_jobs_vr.dm
+++ b/code/game/jobs/job/z_all_jobs_vr.dm
@@ -1,7 +1,29 @@
 //Contains all modified jobs for easy access and editing.
 
+/datum/job/captain
+	disallow_jobhop = TRUE
+
 /datum/job/hop
+	disallow_jobhop = TRUE
 	alt_titles = list("Deputy Director", "Crew Resources Officer")
+
+/datum/job/hos
+	disallow_jobhop = TRUE
+
+/datum/job/chief_engineer
+	disallow_jobhop = TRUE
+
+/datum/job/cmo
+	disallow_jobhop = TRUE
+
+/datum/job/rd
+	disallow_jobhop = TRUE
+
+/datum/job/secretary
+	disallow_jobhop = TRUE
+
+/datum/job/lawyer
+	disallow_jobhop = TRUE
 
 /datum/job/doctor
 	total_positions = 5
@@ -50,6 +72,6 @@
 /datum/job/atmos
 	total_positions = 3
 	spawn_positions = 3
-	
+
 /datum/job/scientist
 	alt_titles = list("Xenoarcheologist", "Anomalist", "Phoron Researcher", "Circuit Designer")

--- a/code/game/machinery/computer/timeclock_vr.dm
+++ b/code/game/machinery/computer/timeclock_vr.dm
@@ -140,7 +140,7 @@
 	var/list/available_jobs = list()
 	for(var/datum/job/job in job_master.occupations)
 		if(job && job.is_position_available() && !job.whitelist_only && !jobban_isbanned(user,job.title) && job.player_old_enough(user.client))
-			if(job.department == department && !job.head_position && job.timeoff_factor > 0 && !(job.title == "Internal Affairs Agent"))
+			if(job.department == department && !job.disallow_jobhop && job.timeoff_factor > 0)
 				available_jobs += job.title
 				if(job.alt_titles)
 					for(var/alt_job in job.alt_titles)


### PR DESCRIPTION
Basically allows pathfinder and QM to be selectable, while making the ability to mark specific jobs as 'cant join from offduty' much less of a hassle. Probably should have done it in the first place. Heads of Staff, IAA and secretaries still restricted.