### PR TITLE
Macros can pickup unanchored structures and machinery

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -488,7 +488,8 @@ emp_act
 	catch_chance = between(1, catch_chance, 100)
 
 	if(prob(catch_chance))
-		return TRUE
+		if(istype(O,/obj/item) || size_multiplier >= RESIZE_BIG)		//VOREstation edit
+			return TRUE
 	return FALSE
 
 /mob/living/carbon/human/embed(var/obj/O, var/def_zone=null)

--- a/code/modules/vore/resizing/holder_micro_vr.dm
+++ b/code/modules/vore/resizing/holder_micro_vr.dm
@@ -35,3 +35,89 @@
 	for(var/atom/movable/A in src)
 		A.forceMove(here)
 	return ..()
+
+
+
+/obj/item/weapon/holder/structure
+	w_class = ITEMSIZE_HUGE
+	slot_flags = null
+	item_icons = list()
+	pixel_y = 0
+	var/mob/living/grabber
+
+
+/obj/item/weapon/holder/structure/sync(obj/M)
+	dir = 2
+	overlays.Cut()
+	icon = M.icon
+	icon_state = M.icon_state
+	item_state = M.item_state
+	color = M.color
+	name = M.name
+	desc = M.desc
+	overlays |= M.overlays
+	var/mob/living/carbon/human/H = loc
+	if(istype(H))
+		if(H.l_hand == src)
+			H.update_inv_l_hand()
+		else if(H.r_hand == src)
+			H.update_inv_r_hand()
+
+/obj/item/weapon/holder/structure/process()
+	if(grabber.size_multiplier < RESIZE_BIG)
+		grabber.drop_from_inventory(src)
+	update_state()
+
+/obj/item/weapon/holder/structure/update_state()
+	if(istype(loc,/turf))
+		qdel(src)
+
+/obj/item/weapon/holder/structure/Destroy()
+	for(var/atom/movable/A in src)
+		A.forceMove(get_turf(src))
+	return ..()
+
+/obj/structure/AltClick(mob/living/carbon/human/H)			// I use AltClick because attack_hand is used by many objects and may result in unpredictable fun
+	if(istype(H) && Adjacent(H) && H.a_intent != I_HELP && !anchored && !H.lying)		//Intent is for the case we want to use original AltClick function (if any), not pick object up
+		if(H.size_multiplier  >= RESIZE_BIG)
+			get_picked_up(H)
+			return
+	return ..()
+
+/obj/machinery/AltClick(mob/living/carbon/human/H)
+	if(istype(H) && Adjacent(H) && H.a_intent != I_HELP && !anchored && !H.lying)
+		if(H.size_multiplier  >= RESIZE_BIG)
+			get_picked_up(H)
+			return
+	return ..()
+
+
+/obj/structure/proc/get_picked_up(var/mob/living/carbon/human/grabber)
+	if(grabber.incapacitated())
+		return
+
+	var/obj/item/weapon/holder/structure/H = new /obj/item/weapon/holder/structure(get_turf(src))
+	H.grabber = grabber
+	src.forceMove(H)
+	grabber.put_in_hands(H)
+
+	grabber.visible_message("<span class='warning'>[grabber] lifts up [src]!</span>")
+
+	H.sync(src)
+	return H
+
+/obj/machinery/proc/get_picked_up(var/mob/living/carbon/human/grabber)
+	if(grabber.incapacitated())
+		return
+
+	var/obj/item/weapon/holder/structure/H = new /obj/item/weapon/holder/structure(get_turf(src))
+	H.grabber = grabber
+	src.forceMove(H)
+	grabber.put_in_hands(H)
+
+	grabber.visible_message("<span class='warning'>[grabber] lifts up [src]!</span>")
+
+	H.sync(src)
+	return H
+
+//You can't resist out of closet if said closet was picked up. Feature? Like, you holding the door, not allowing people to break outside


### PR DESCRIPTION
If you are above 150% size, you can pick up unanchored structures and machinery. To do so, you need to altclick it while NOT being on help intent. 

Demo:
https://www.youtube.com/watch?v=xHm3kDdOzHk

Those macros finally will be useful in cargo.