### PR TITLE
Access fixes for carogopacks

### DIFF
--- a/code/controllers/Processes/supply.dm
+++ b/code/controllers/Processes/supply.dm
@@ -226,7 +226,7 @@ var/datum/controller/supply/supply_controller = new()
 				A.req_access = list(SP.access)
 			else if(islist(SP.access))
 				var/list/L = SP.access // access var is a plain var, we need a list
-				A.req_access = L.Copy()
+				A.req_one_access = L.Copy()		//VOREStation Edit: Lets make sense
 			else
 				log_debug("<span class='danger'>Supply pack with invalid access restriction [SP.access] encountered!</span>")
 

--- a/code/datums/supplypacks/engineering_vr.dm
+++ b/code/datums/supplypacks/engineering_vr.dm
@@ -4,6 +4,7 @@
 	cost = 30
 	containertype = /obj/structure/closet/crate/large
 	containername = "thermal regulator crate"
+	access = access_atmospherics
 
 /datum/supply_pack/eng/radsuit
 	contains = list(

--- a/code/datums/supplypacks/misc_vr.dm
+++ b/code/datums/supplypacks/misc_vr.dm
@@ -39,7 +39,10 @@
 	cost = 150
 	containertype = /obj/structure/closet/crate/secure/gear
 	containername = "eva hardsuit crate"
-	access = access_mining
+	access = list(access_mining,
+				  access_eva,
+				  access_explorer,
+				  access_pilot)
 
 /datum/supply_pack/misc/mining_rig
 	name = "industrial hardsuit (empty)"
@@ -49,4 +52,5 @@
 	cost = 150
 	containertype = /obj/structure/closet/crate/secure/gear
 	containername = "industrial hardsuit crate"
-	access = access_mining
+	access = list(access_mining,
+				  access_eva)

--- a/code/datums/supplypacks/security.dm
+++ b/code/datums/supplypacks/security.dm
@@ -31,7 +31,7 @@
 	cost = 40
 	containertype = /obj/structure/closet/crate/secure/gear
 	containername = "Armor crate"
-	access_armory //VOREStation Add - Armor is for the armory.
+	access = access_armory //VOREStation Add - Armor is for the armory.
 
 /datum/supply_pack/security/riot_gear
 	name = "Gear - Riot"

--- a/code/datums/supplypacks/security.dm
+++ b/code/datums/supplypacks/security.dm
@@ -31,7 +31,6 @@
 	cost = 40
 	containertype = /obj/structure/closet/crate/secure/gear
 	containername = "Armor crate"
-	access = access_armory //VOREStation Add - Armor is for the armory.
 
 /datum/supply_pack/security/riot_gear
 	name = "Gear - Riot"

--- a/code/datums/supplypacks/security_vr.dm
+++ b/code/datums/supplypacks/security_vr.dm
@@ -17,6 +17,9 @@
 			access_xenobiology)
 */
 
+/datum/supply_pack/randomised/security/armor
+	access = access_armory
+
 /datum/supply_pack/security/biosuit
 	contains = list(
 			/obj/item/clothing/head/bio_hood/security = 3,

--- a/code/datums/supplypacks/voidsuits_vr.dm
+++ b/code/datums/supplypacks/voidsuits_vr.dm
@@ -62,7 +62,6 @@
 			)
 
 /datum/supply_pack/voidsuits/supply
-	name = "Mining voidsuits"
 	contains = list(
 			/obj/item/clothing/suit/space/void/mining = 3,
 			/obj/item/clothing/head/helmet/space/void/mining = 3,


### PR DESCRIPTION
- Fixes armor crate having security access instead of armory access

- Adds EVA, explorer and pilot to accesses of hardsuit crate

- Adds EVA to accesses of industrial hardsuit crate

- Adds atmospherics access restriction to thermal regulator crate