### PR TITLE
Renames Syndicate Commandos to Mercenary Commandos

### DIFF
--- a/code/modules/mob/living/simple_mob/subtypes/humanoid/mercs/mercs_vr.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/humanoid/mercs/mercs_vr.dm
@@ -1,3 +1,9 @@
 /datum/say_list/merc/unknown_ind
 	speak = list("One day the'll fix that damn engine..","Next time, We're hidding on the tropical beach planet.","Wish I had better equipment...","I knew I should have been a line chef...","Fuckin' helmet keeps fogging up.","Hate this blocky ass ship.")
 	say_got_target = list("Looks like trouble!","Contact!","We've got company!","Perimeter Breached!!")
+
+/mob/living/simple_mob/humanoid/merc/melee/sword/space
+	name = "mercenary commando"
+
+/mob/living/simple_mob/humanoid/merc/ranged/space
+	name = "mercenary commando"


### PR DESCRIPTION
I believe the intent used to be 'no syndicate presense on Virgo' and most mob renames used to be _vr edits. After the port of ai refactor, some PoI mobs seem to have become Syndicate Commandos. Renames them to Mercenary Commandos.