### PR TITLE
Adds tracking implants to security

### DIFF
--- a/maps/tether/tether-07-station3.dmm
+++ b/maps/tether/tether-07-station3.dmm
@@ -5383,6 +5383,8 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
+/obj/item/weapon/storage/box/trackimp,
+/obj/item/weapon/storage/box/trackimp,
 /turf/simulated/floor/tiled/dark,
 /area/security/armory/blue)
 "iM" = (


### PR DESCRIPTION
Adds two boxes of tracking implants to security, within the blue armory. Several corporate regs mention tracking implants as a punishment, which is impossible as of right now.