### PR TITLE
Makes mechanical prefs show disabled OOC/LOOC

### DIFF
--- a/code/modules/vore/eating/living_vr.dm
+++ b/code/modules/vore/eating/living_vr.dm
@@ -667,6 +667,11 @@
 	if(!user)
 		CRASH("display_voreprefs() was called without an associated user.")
 	var/dispvoreprefs = "<b>[src]'s vore preferences</b><br><br><br>"
+	if(client && client.prefs)
+		if("CHAT_OOC" in client.prefs.preferences_disabled)
+			dispvoreprefs += "<font color='red'><b>OOC DISABLED</b></font><br>"
+		if("CHAT_LOOC" in client.prefs.preferences_disabled)
+			dispvoreprefs += "<font color='red'><b>LOOC DISABLED</b></font><br>"
 	dispvoreprefs += "<b>Digestable:</b> [digestable ? "Enabled" : "Disabled"]<br>"
 	dispvoreprefs += "<b>Leaves Remains:</b> [digest_leave_remains ? "Enabled" : "Disabled"]<br>"
 	dispvoreprefs += "<b>Mob Vore:</b> [allowmobvore ? "Enabled" : "Disabled"]<br>"


### PR DESCRIPTION
Salt PR to rob people from their ability to conceal whether they're ignoring other players' ooc messages mechanically or on purpose and then wondering why things are going to shit and people are getting mad at them.
![kuva](https://user-images.githubusercontent.com/13697337/59282486-ae00ec80-8c71-11e9-8c3b-0debc774eb2b.png)
