### PR TITLE
Makes flash pistols only be able to use flash magazines

### DIFF
--- a/code/modules/projectiles/guns/projectile/pistol_vr.dm
+++ b/code/modules/projectiles/guns/projectile/pistol_vr.dm
@@ -1,5 +1,5 @@
 /obj/item/weapon/gun/projectile/sec/flash
-	name = ".45 pistol"
+	allowed_magazines = list(/obj/item/ammo_magazine/m45/flash)
 
 /obj/item/weapon/gun/projectile/p92x/sec
 	magazine_type = /obj/item/ammo_magazine/m9mm/rubber


### PR DESCRIPTION
This is a potential indirect solution to #5239, not directly conflicting with #5374 , but adressing same issue in different way. Both solutions can be implemented, but its better that only one is.

Removes name change virgo-side to flash pistols (back to ".45 signal pistol") and limits them to flash magazines exclusively.