### PR TITLE
Removes pistols from SecVend

### DIFF
--- a/code/game/machinery/vending_vr.dm
+++ b/code/game/machinery/vending_vr.dm
@@ -6,7 +6,6 @@
 /obj/machinery/vending/security/New()
 	products += list(/obj/item/weapon/gun/energy/taser = 8,/obj/item/weapon/gun/energy/stunrevolver = 4,
 					/obj/item/weapon/reagent_containers/spray/pepper = 6,/obj/item/taperoll/police = 6,
-					/obj/item/weapon/gun/projectile/sec/flash = 4, /obj/item/ammo_magazine/m45/flash = 8,
 					/obj/item/clothing/glasses/omnihud/sec = 6)
 	..()
 


### PR DESCRIPTION
This is a potential direct solution to #5239, not directly conflicting with #5373, but adressing same issue in different way. Both solutions can be implemented, but its better that only one is.

Simply removes both flash pistols and flash rounds from SecVends.