### PR TITLE
Fixes icon scaling on later byond versions

### DIFF
--- a/code/modules/client/preference_setup/vore/02_size.dm
+++ b/code/modules/client/preference_setup/vore/02_size.dm
@@ -46,6 +46,7 @@
 	character.weight_loss		= pref.weight_loss
 	character.fuzzy				= pref.fuzzy
 	character.appearance_flags	-= pref.fuzzy*PIXEL_SCALE
+	character.appearance_flags	|= KEEP_TOGETHER
 	character.resize(pref.size_multiplier, animate = FALSE)
 
 /datum/category_item/player_setup_item/vore/size/content(var/mob/user)

--- a/code/modules/vore/eating/living_vr.dm
+++ b/code/modules/vore/eating/living_vr.dm
@@ -652,6 +652,7 @@
 	set category = "Preferences"
 	set desc = "Switch sharp/fuzzy scaling for current mob."
 	appearance_flags ^= PIXEL_SCALE
+	appearance_flags ^= KEEP_TOGETHER
 
 /mob/living/examine(mob/user, distance, infix, suffix)
 	. = ..(user, distance, infix, suffix)


### PR DESCRIPTION
From version 1468 and up, Byond decided "Hey, lets remove the overlays inheiriting PIXEL_SCALE from the base icon they're applied to and offer no graceful alternative to people that did use it!". Well. This is the ungraceful solution that they had offered to anyone still wanting old system. Hopefully doesn't break anything elsewhere, but from initial overview, nothing really is, and if something will be, it shouldn't be too problematic.