### PR TITLE
Custom Say Verbs

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1363,3 +1363,29 @@ default behaviour is:
 		BRAIN:<a href='?_src_=vars;mobToDamage=\ref[src];adjustDamage=brain'>[getBrainLoss()]</a>
 		</font>
 		"}
+//VOREStation edit, allows for custom say verbs
+/mob/living/verb/customsay()
+	set category = "IC"
+	set name = "Customise Say Verbs"
+	set desc = "Customise the text which appears when you type- e.g. 'says', 'asks', 'exclaims'."
+
+	if(src.client && src.client.holder)
+		var/customsaylist[] = list(
+				"Say",
+				"Whisper",
+				"Ask (?)",
+				"Exclaim/Shout/Yell (!)",
+				"Cancel"
+			)
+		var/sayselect = input("Which say-verb do you wish to customise?") as null|anything in customsaylist //we can't use alert() for this because there's too many terms
+
+		if(sayselect == "Say")
+			custom_say =  sanitize(input(usr, "This word or phrase will appear instead of 'says': [src] says, \"Hi.\"", "Custom Say", null)  as text)
+		else if(sayselect == "Whisper")
+			custom_whisper =  sanitize(input(usr, "This word or phrase will appear instead of 'whispers': [src] whispers, \"Hi...\"", "Custom Whisper", null)  as text)
+		else if(sayselect == "Ask (?)")
+			custom_ask =  sanitize(input(usr, "This word or phrase will appear instead of 'asks': [src] asks, \"Hi?\"", "Custom Ask", null)  as text)
+		else if(sayselect == "Exclaim/Shout/Yell (!)")
+			custom_exclaim =  sanitize(input(usr, "This word or phrase will appear instead of 'exclaims', 'shouts' or 'yells': [src] exclaims, \"Hi!\"", "Custom Exclaim", null)  as text)
+		else
+			return

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1389,3 +1389,4 @@ default behaviour is:
 			custom_exclaim =  sanitize(input(usr, "This word or phrase will appear instead of 'exclaims', 'shouts' or 'yells': [src] exclaims, \"Hi!\"", "Custom Exclaim", null)  as text)
 		else
 			return
+	//VOREStation edit ends

--- a/code/modules/mob/living/living_defines_vr.dm
+++ b/code/modules/mob/living/living_defines_vr.dm
@@ -1,3 +1,9 @@
 /mob/living
 	var/ooc_notes = null
 	var/obj/structure/mob_spawner/source_spawner = null
+
+//custom say verbs
+	var/custom_say = null
+	var/custom_ask = null
+	var/custom_exclaim = null
+	var/custom_whisper = null

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -287,6 +287,7 @@ proc/get_radio_key_from_channel(var/channel)
 		verb = "[custom_ask]"
 	else if(custom_say)
 		verb = "[custom_say]"
+	//VOREStation edit ends
 
 	//Handle nonverbal and sign languages here
 	if (speaking)

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -275,6 +275,19 @@ proc/get_radio_key_from_channel(var/channel)
 		message_range = 1
 		sound_vol *= 0.5
 
+	//VOREStation edit - allows for custom say verbs, overriding all other say-verb types- e.g. "says loudly" instead of "shouts"
+	//You'll still stammer if injured or slur if drunk, but it won't have those specific words
+	var/ending = copytext(message, length(message))
+
+	if(custom_whisper && whispering)
+		verb = "[custom_whisper]"
+	else if(custom_exclaim && ending=="!")
+		verb = "[custom_exclaim]"
+	else if(custom_ask && ending=="?")
+		verb = "[custom_ask]"
+	else if(custom_say)
+		verb = "[custom_say]"
+
 	//Handle nonverbal and sign languages here
 	if (speaking)
 		if (speaking.flags & SIGNLANG)

--- a/html/changelogs/mistyLuminescence - Sayverbs.yml
+++ b/html/changelogs/mistyLuminescence - Sayverbs.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Novacat
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "You can now select customised say-verbs in the IC tab. You know how when you use a question mark, you always 'ask' something? You don't have to "ask" any more, you can "query" instead, for example."


### PR DESCRIPTION
https://cdn.discordapp.com/attachments/173831852602294272/593482267733655582/unknown.png

A picture is worth a thousand words. This PR lets you customise the words that appear when you say something- it's usually language-based (with galcomm being 'say', 'ask', 'exclaim/shout/yell' and 'whisper'), but if you want to override it now, you can.

For example...

mistyLuminescence asks, "Hi?" could become...
mistyLuminescence 's TTS device queries, "Hi?"

Great for mute characters or ones with special ways of speaking. There is potential for abuse (e.g. setting it to WGW), but people could do it anyway with custom emotes. I can try and add a character limit if that's desired.