### PR TITLE
Makes testing chamber air alarm not flash red

### DIFF
--- a/maps/tether/tether-09-solars.dmm
+++ b/maps/tether/tether-09-solars.dmm
@@ -6441,10 +6441,12 @@
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/alarm{
 	alarm_id = "anomaly_testing";
+	breach_detection = 0;
 	dir = 8;
 	frequency = 1439;
 	pixel_x = 22;
-	pixel_y = 0
+	pixel_y = 0;
+	report_danger_level = 0
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/outpost/anomaly_lab/testing)


### PR DESCRIPTION
One on the outpost. Research regularly fails to understand the purpose of flush button and floods it. And to fulfill its purpose, the chamber isn't connected to outpost's atmos. So its red forever. No more.