### PR TITLE
Adds relay board to telecomm storage

### DIFF
--- a/maps/tether/tether-02-surface2.dmm
+++ b/maps/tether/tether-02-surface2.dmm
@@ -11573,6 +11573,24 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/drone_fabrication)
+"wK" = (
+/obj/structure/table/rack,
+/obj/item/weapon/circuitboard/telecomms/processor,
+/obj/item/weapon/circuitboard/telecomms/processor,
+/obj/item/weapon/circuitboard/telecomms/receiver,
+/obj/item/weapon/circuitboard/telecomms/server,
+/obj/item/weapon/circuitboard/telecomms/server,
+/obj/item/weapon/circuitboard/telecomms/bus,
+/obj/item/weapon/circuitboard/telecomms/bus,
+/obj/item/weapon/circuitboard/telecomms/broadcaster,
+/obj/item/weapon/circuitboard/telecomms/exonet_node,
+/obj/machinery/light/small,
+/obj/item/weapon/circuitboard/ntnet_relay,
+/obj/item/weapon/circuitboard/telecomms/relay,
+/turf/simulated/floor/tiled/techmaint,
+/area/tcomfoyer{
+	name = "\improper Telecomms Storage"
+	})
 "wL" = (
 /obj/structure/cable/cyan{
 	d1 = 2;
@@ -15357,22 +15375,6 @@
 	name = "\improper Telecomms Storage"
 	})
 "Ha" = (
-/turf/simulated/floor/tiled/techmaint,
-/area/tcomfoyer{
-	name = "\improper Telecomms Storage"
-	})
-"Hb" = (
-/obj/structure/table/rack,
-/obj/item/weapon/circuitboard/telecomms/processor,
-/obj/item/weapon/circuitboard/telecomms/processor,
-/obj/item/weapon/circuitboard/telecomms/receiver,
-/obj/item/weapon/circuitboard/telecomms/server,
-/obj/item/weapon/circuitboard/telecomms/server,
-/obj/item/weapon/circuitboard/telecomms/bus,
-/obj/item/weapon/circuitboard/telecomms/bus,
-/obj/item/weapon/circuitboard/telecomms/broadcaster,
-/obj/item/weapon/circuitboard/telecomms/exonet_node,
-/obj/machinery/light/small,
 /turf/simulated/floor/tiled/techmaint,
 /area/tcomfoyer{
 	name = "\improper Telecomms Storage"
@@ -32752,7 +32754,7 @@ Gl
 Gx
 GN
 GT
-Hb
+wK
 Gw
 Gw
 ac


### PR DESCRIPTION
For construction of telecomm relay. Of all telecomm machinery it was the only one missing and probably most desirable, as relay is the only piece that ever needs to be constructed in-round. All parts for various machines are present, even for relay, but not board for it. Adds a single one.

Also throws in a spare NTNet relay board, mostly for posterity.