### PR TITLE
Adds Junior Explorers

### DIFF
--- a/code/game/jobs/job/assistant.dm
+++ b/code/game/jobs/job/assistant.dm
@@ -13,7 +13,7 @@
 	access = list()			//See /datum/job/assistant/get_access()
 	minimal_access = list()	//See /datum/job/assistant/get_access()
 	outfit_type = /decl/hierarchy/outfit/job/assistant/intern
-	alt_titles = list("Apprentice Engineer","Medical Intern","Lab Assistant","Security Cadet","Jr. Cargo Tech") //VOREStation Edit
+	alt_titles = list("Apprentice Engineer","Medical Intern","Lab Assistant","Security Cadet","Jr. Cargo Tech", "Jr. Explorer") //VOREStation Edit
 	timeoff_factor = 0 //VOREStation Edit - Interns, noh
 
 //VOREStation Add


### PR DESCRIPTION
A new intern alt-title, since none of existing ones could really be applied to Explorers in proper way. Is exactly same as other intern alt-titles in terms of everything, just geared towards learning in Exploration.