### PR TITLE
Changes lobby screen name to match server name

### DIFF
--- a/code/modules/mob/new_player/login_vr.dm
+++ b/code/modules/mob/new_player/login_vr.dm
@@ -1,0 +1,2 @@
+/obj/effect/lobby_image
+	name = "VORE Station"

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -2474,6 +2474,7 @@
 #include "code\modules\mob\living\simple_mob\subtypes\vore\shadekin\~defines.dm"
 #include "code\modules\mob\living\voice\voice.dm"
 #include "code\modules\mob\new_player\login.dm"
+#include "code\modules\mob\new_player\login_vr.dm"
 #include "code\modules\mob\new_player\logout.dm"
 #include "code\modules\mob\new_player\new_player.dm"
 #include "code\modules\mob\new_player\new_player_vr.dm"


### PR DESCRIPTION
The one that appears in bottom left when you hover over title image. From "Polaris" to "VORE Station".