### PR TITLE
Makes trash pile components have random sprites.

### DIFF
--- a/code/game/objects/structures/trash_pile.dm
+++ b/code/game/objects/structures/trash_pile.dm
@@ -132,7 +132,7 @@
 					prob(5);/obj/item/weapon/storage/backpack/satchel/norm,
 					prob(5);/obj/item/weapon/storage/box,
 				//	prob(5);/obj/random/cigarettes,
-					prob(4);/obj/item/broken_device,
+					prob(4);/obj/item/broken_device/random,
 					prob(4);/obj/item/clothing/head/hardhat,
 					prob(4);/obj/item/clothing/mask/breath,
 					prob(4);/obj/item/clothing/shoes/black,


### PR DESCRIPTION
A virgo-side followup to #5391. Makes broken components from trash piles use random non-placeholder icon.