### PR TITLE
Adds Atmos Gas Storage area

### DIFF
--- a/maps/tether/tether-01-surface1.dmm
+++ b/maps/tether/tether-01-surface1.dmm
@@ -6363,9 +6363,17 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/atmos)
+"akU" = (
+/turf/simulated/wall/r_wall,
+/area/engineering/atmos/gas_storage)
 "akV" = (
 /turf/simulated/mineral,
 /area/vacant/vacant_site)
+"akW" = (
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/techmaint,
+/area/engineering/atmos/gas_storage)
 "akX" = (
 /turf/simulated/floor/plating,
 /area/vacant/vacant_site)
@@ -6375,6 +6383,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/vacant/vacant_site)
+"akZ" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/techmaint,
+/area/engineering/atmos/gas_storage)
 "ala" = (
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating,
@@ -6396,6 +6412,11 @@
 "ald" = (
 /turf/simulated/floor/tiled,
 /area/storage/art)
+"ale" = (
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/techmaint,
+/area/engineering/atmos/gas_storage)
 "alf" = (
 /obj/structure/table/standard,
 /obj/item/stack/cable_coil/random,
@@ -6478,9 +6499,49 @@
 	},
 /turf/simulated/floor/water/pool,
 /area/tether/surfacebase/atrium_one)
+"alq" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/techmaint,
+/area/engineering/atmos/gas_storage)
 "alr" = (
 /turf/simulated/wall,
 /area/maintenance/lower/vacant_site)
+"als" = (
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/power/apc{
+	cell_type = /obj/item/weapon/cell/super;
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/obj/structure/cable/cyan{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/engineering/atmos/gas_storage)
+"alt" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/engineering/atmos/gas_storage)
+"alu" = (
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/engineering/atmos/gas_storage)
 "alv" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/effect/floor_decal/steeldecal/steel_decals4{
@@ -6563,6 +6624,14 @@
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor,
 /area/maintenance/substation/mining)
+"alB" = (
+/obj/machinery/alarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -22
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/engineering/atmos/gas_storage)
 "alC" = (
 /obj/effect/floor_decal/steeldecal/steel_decals5{
 	dir = 8
@@ -6642,6 +6711,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/vacant/vacant_site)
+"alL" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/engineering/atmos/gas_storage)
 "alM" = (
 /obj/structure/railing{
 	dir = 8
@@ -6675,6 +6750,17 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/xenoflora)
+"alP" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/engineering/atmos/gas_storage)
 "alQ" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -6807,6 +6893,49 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/mining_main/lobby)
+"ame" = (
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/glass_atmos{
+	name = "Canister Storage";
+	req_access = list(24)
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/engineering/atmos/gas_storage)
+"amf" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/atmos)
+"amg" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/atmos)
 "amh" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/structure/table/rack{
@@ -6822,6 +6951,13 @@
 /obj/item/weapon/tank/emergency/oxygen/engi,
 /turf/simulated/floor/tiled/dark,
 /area/storage/surface_eva)
+"ami" = (
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/engineering/atmos/gas_storage)
 "amj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -6845,6 +6981,12 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/lower/first_west)
+"amk" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/engineering/atmos/gas_storage)
 "aml" = (
 /obj/random/junk,
 /turf/simulated/floor/plating,
@@ -6859,6 +7001,12 @@
 /obj/structure/cable/green,
 /turf/simulated/floor/plating,
 /area/vacant/vacant_site)
+"amo" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/engineering/atmos/gas_storage)
 "amp" = (
 /obj/structure/table/standard,
 /obj/random/tech_supply,
@@ -6881,6 +7029,17 @@
 	},
 /turf/simulated/floor/tiled,
 /area/storage/primary)
+"amr" = (
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/glass_atmos{
+	name = "Canister Storage";
+	req_access = list(24)
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/engineering/atmos/gas_storage)
 "ams" = (
 /obj/machinery/light_switch{
 	pixel_y = -25
@@ -6936,6 +7095,28 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/lower/vacant_site)
+"amz" = (
+/obj/machinery/portable_atmospherics/canister/phoron,
+/obj/machinery/camera/network/engineering{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/techmaint,
+/area/engineering/atmos/gas_storage)
+"amA" = (
+/obj/machinery/portable_atmospherics/canister/sleeping_agent,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/techmaint,
+/area/engineering/atmos/gas_storage)
+"amB" = (
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/light_switch{
+	dir = 8;
+	pixel_x = 28
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/engineering/atmos/gas_storage)
 "amC" = (
 /obj/structure/ladder/up,
 /obj/structure/catwalk,
@@ -6990,6 +7171,11 @@
 	},
 /turf/simulated/floor,
 /area/maintenance/substation/mining)
+"amJ" = (
+/obj/machinery/portable_atmospherics/canister/phoron,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/techmaint,
+/area/engineering/atmos/gas_storage)
 "amK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -7019,6 +7205,11 @@
 	},
 /turf/simulated/floor/tiled,
 /area/storage/art)
+"amN" = (
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/techmaint,
+/area/engineering/atmos/gas_storage)
 "amO" = (
 /obj/structure/flora/ausbushes/brflowers,
 /turf/simulated/floor/grass,
@@ -7065,6 +7256,18 @@
 /obj/random/trash_pile,
 /turf/simulated/floor/plating,
 /area/maintenance/lower/vacant_site)
+"amU" = (
+/obj/machinery/portable_atmospherics/canister/sleeping_agent,
+/obj/machinery/light/small,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/techmaint,
+/area/engineering/atmos/gas_storage)
+"amV" = (
+/obj/machinery/camera/network/engineering{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/steel_dirty/virgo3b,
+/area/engineering/atmos/intake)
 "anb" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
@@ -14486,14 +14689,6 @@
 /obj/effect/floor_decal/industrial/warning/dust,
 /turf/simulated/floor/tiled/steel_dirty,
 /area/rnd/xenobiology/xenoflora_storage)
-"aGY" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/techmaint,
-/area/engineering/atmos)
 "aGZ" = (
 /obj/structure/table/standard,
 /obj/machinery/requests_console{
@@ -14565,12 +14760,6 @@
 /obj/machinery/portable_atmospherics/canister/sleeping_agent,
 /turf/simulated/floor/tiled/steel_dirty,
 /area/rnd/xenobiology/xenoflora_storage)
-"aHo" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/engineering/atmos)
 "aHv" = (
 /obj/structure/table/standard,
 /obj/effect/floor_decal/borderfloor{
@@ -14766,17 +14955,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/maintenance/lower/research)
-"aHZ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled,
-/area/engineering/atmos)
 "aId" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -24854,11 +25032,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_7)
-"chB" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/techmaint,
-/area/engineering/atmos)
 "chC" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -25749,12 +25922,6 @@
 /obj/random/maintenance/clean,
 /turf/simulated/floor/plating,
 /area/maintenance/lower/research)
-"csS" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/engineering/atmos)
 "cws" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
@@ -25812,11 +25979,6 @@
 	dir = 6
 	},
 /turf/simulated/floor/tiled,
-/area/engineering/atmos)
-"cKH" = (
-/obj/machinery/portable_atmospherics/canister/air,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/techmaint,
 /area/engineering/atmos)
 "cLz" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/red{
@@ -25950,17 +26112,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/lower/public_garden_maintenence)
-"dby" = (
-/obj/machinery/door/firedoor/glass,
-/obj/machinery/door/airlock/glass_atmos{
-	name = "Canister Storage";
-	req_access = list(24)
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/engineering/atmos)
 "deS" = (
 /obj/structure/railing{
 	dir = 4
@@ -26061,12 +26212,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/lower/research)
-"dCw" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/engineering/atmos)
 "dCM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -26328,12 +26473,6 @@
 "epw" = (
 /turf/simulated/wall/r_wall,
 /area/crew_quarters/sleep/Dorm_3)
-"erR" = (
-/obj/machinery/camera/network/outside{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/steel_dirty/virgo3b,
-/area/engineering/atmos/intake)
 "euU" = (
 /obj/machinery/power/apc{
 	cell_type = /obj/item/weapon/cell/apc;
@@ -26998,12 +27137,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/tether/surfacebase/public_garden)
-"gFH" = (
-/obj/machinery/portable_atmospherics/canister/sleeping_agent,
-/obj/machinery/light/small,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/techmaint,
-/area/engineering/atmos)
 "gHF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
@@ -27203,11 +27336,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/vacant/vacant_bar)
-"hLA" = (
-/obj/machinery/portable_atmospherics/canister/nitrogen,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/techmaint,
-/area/engineering/atmos)
 "hNn" = (
 /obj/structure/table/rack,
 /obj/random/maintenance/engineering,
@@ -27281,11 +27409,6 @@
 "ieJ" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/pipedispenser,
-/turf/simulated/floor/tiled/techmaint,
-/area/engineering/atmos)
-"ifc" = (
-/obj/machinery/portable_atmospherics/canister/sleeping_agent,
-/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/atmos)
 "igB" = (
@@ -27691,17 +27814,6 @@
 /obj/item/weapon/bedsheet/mimedouble,
 /turf/simulated/floor/plating,
 /area/crew_quarters/sleep/maintDorm1)
-"jcl" = (
-/obj/machinery/door/firedoor/glass,
-/obj/machinery/door/airlock/glass_atmos{
-	name = "Canister Storage";
-	req_access = list(24)
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/engineering/atmos)
 "jec" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/effect/floor_decal/borderfloor/corner{
@@ -28234,12 +28346,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/vacant/vacant_site/east)
-"kXi" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/engineering/atmos)
 "kYa" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -28553,11 +28659,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/public_garden_one)
-"lUB" = (
-/obj/machinery/portable_atmospherics/canister/phoron,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/techmaint,
-/area/engineering/atmos)
 "lVl" = (
 /obj/structure/railing{
 	icon_state = "railing0";
@@ -29017,13 +29118,6 @@
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/showers)
-"nod" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/engineering/atmos)
 "npt" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 4
@@ -29773,14 +29867,6 @@
 "pTB" = (
 /turf/simulated/wall,
 /area/crew_quarters/sleep/maintDorm4)
-"pTP" = (
-/obj/machinery/alarm{
-	dir = 4;
-	icon_state = "alarm0";
-	pixel_x = -22
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/engineering/atmos)
 "pUD" = (
 /obj/machinery/atmospherics/pipe/tank/carbon_dioxide{
 	dir = 8;
@@ -30093,14 +30179,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/public_garden_one)
-"rbh" = (
-/obj/machinery/portable_atmospherics/canister/phoron,
-/obj/machinery/camera/network/engineering{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/techmaint,
-/area/engineering/atmos)
 "rbv" = (
 /obj/effect/floor_decal/corner/lightgrey{
 	dir = 10
@@ -31632,11 +31710,6 @@
 /obj/structure/table/rack,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/public_garden_maintenence)
-"wDZ" = (
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/techmaint,
-/area/engineering/atmos)
 "wEU" = (
 /obj/structure/closet,
 /obj/random/maintenance/clean,
@@ -40869,15 +40942,15 @@ aah
 aEU
 aFX
 rcO
-giF
-bEX
-bEX
-bEX
-bEX
-bEX
-bEX
-bEX
-bEX
+akU
+akU
+akU
+akU
+akU
+akU
+akU
+akU
+akU
 bEX
 iVW
 aJs
@@ -40895,7 +40968,7 @@ ajg
 ajh
 rab
 rab
-erR
+amV
 aJt
 aJt
 aah
@@ -41011,15 +41084,15 @@ aah
 aEU
 oUO
 fEe
-giF
-hLA
-hLA
-hLA
-pTP
-nod
-rbh
-lUB
-lUB
+akU
+akW
+akW
+als
+alB
+ami
+amz
+amJ
+amJ
 bEX
 tIj
 fRH
@@ -41153,15 +41226,15 @@ aah
 aEU
 aFX
 rcO
-giF
-aGY
-chB
-chB
-dCw
-csS
-ifc
-ifc
-gFH
+akU
+akZ
+alq
+alt
+alL
+amk
+amA
+amA
+amU
 bEX
 sVp
 dAD
@@ -41295,15 +41368,15 @@ aah
 aEU
 aFX
 gTS
-giF
-cKH
-cKH
-cKH
-aHo
-kXi
-wDZ
-wDZ
-wDZ
+akU
+ale
+ale
+alu
+alP
+amo
+amB
+amN
+amN
 bEX
 soV
 phh
@@ -41437,15 +41510,15 @@ aah
 aEU
 roN
 npw
-bEX
-bEX
-bEX
-bEX
-jcl
-dby
-bEX
-bEX
-bEX
+akU
+akU
+akU
+akU
+ame
+amr
+akU
+akU
+akU
 bEX
 tIj
 bXm
@@ -41583,7 +41656,7 @@ bEX
 aGZ
 akp
 aHM
-mwy
+amf
 aIk
 cVX
 vgd
@@ -41725,7 +41798,7 @@ bEX
 gjQ
 kwi
 aHN
-aHZ
+amg
 aIl
 uPe
 lda

--- a/maps/tether/tether_areas2.dm
+++ b/maps/tether/tether_areas2.dm
@@ -201,6 +201,10 @@
 	icon_state = "atmos"
 	sound_env = LARGE_ENCLOSED
 
+/area/engineering/atmos/gas_storage
+	name = "Atmospherics Gas Storage"
+	icon_state = "atmos"
+
 /area/engineering/atmos/intake
 	name = "\improper Atmospherics Intake"
 	icon_state = "atmos"


### PR DESCRIPTION
Separates the gas storage room with canisters from rest of atmos area-wise. Mostly because its a separate enough area with separate enough purpose. Plus no reason to raise air alarm in entire atmos over a small contained room having a random broken canister.