### PR TITLE
Allows to compress coal into carbon sheets

### DIFF
--- a/code/modules/mining/ore_datum_vr.dm
+++ b/code/modules/mining/ore_datum_vr.dm
@@ -1,0 +1,2 @@
+/ore/coal
+	compresses_to = "carbon"

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -2036,6 +2036,7 @@
 #include "code\modules\mining\money_bag.dm"
 #include "code\modules\mining\ore.dm"
 #include "code\modules\mining\ore_datum.dm"
+#include "code\modules\mining\ore_datum_vr.dm"
 #include "code\modules\mining\resonator_vr.dm"
 #include "code\modules\mining\satchel_ore_boxdm.dm"
 #include "code\modules\mining\shelter_atoms.dm"


### PR DESCRIPTION
Carbon sheets are pretty much useless beyond decor. But we have them, and I think it makes sense to have that option to make them in mining, even if its not too useful. Worst case scenario, can undo if Polaris adds something for coal to naturally compress into.