### PR TITLE
Buffs Air Vents to Baystation Standard

### DIFF
--- a/code/ATMOSPHERICS/components/unary/vent_pump.dm
+++ b/code/ATMOSPHERICS/components/unary/vent_pump.dm
@@ -16,7 +16,7 @@
 	desc = "Has a valve and pump attached to it"
 	use_power = 0
 	idle_power_usage = 150		//internal circuitry, friction losses and stuff
-	power_rating = 7500			//7500 W ~ 10 HP
+	power_rating = 30000			//7500 W ~ 10 HP //VOREStation Edit - 30000 W
 
 	connect_types = CONNECT_TYPE_REGULAR|CONNECT_TYPE_SUPPLY //connects to regular and supply pipes
 
@@ -89,7 +89,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/high_volume
 	name = "Large Air Vent"
 	power_channel = EQUIP
-	power_rating = 15000	//15 kW ~ 20 HP
+	power_rating = 45000	//15 kW ~ 20 HP //VOREStation Edit - 45000
 
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/New()
 	..()


### PR DESCRIPTION
...this should probably be ported to Polaris but too lazy right now.

Should alleviate problems with both Phoronlocks and all airlocks, including the expedition shuttle airlock.