### PR TITLE
Allows Brute/Burn Healing Surgeries On Corpses

### DIFF
--- a/code/modules/surgery/external_repair.dm
+++ b/code/modules/surgery/external_repair.dm
@@ -9,8 +9,6 @@
 	req_open = 1
 
 /datum/surgery_step/repairflesh/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
-	if (target.stat == DEAD) // Sorry defibs, your subjects need to have pumping fluids for these to work.
-		return 0
 	if (isslime(target))
 		return 0
 	if (target_zone == O_EYES || target_zone == O_MOUTH)

--- a/code/modules/surgery/external_repair.dm
+++ b/code/modules/surgery/external_repair.dm
@@ -9,6 +9,10 @@
 	req_open = 1
 
 /datum/surgery_step/repairflesh/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/*    VOREStation Removal for Mlem Reasons(TM)
+    if (target.stat == DEAD) // Sorry defibs, your subjects need to have pumping fluids for these to work.
+        return 0
+*/
 	if (isslime(target))
 		return 0
 	if (target_zone == O_EYES || target_zone == O_MOUTH)


### PR DESCRIPTION
Not going to lie, this would be a rather large change, so I'll be laying out the reasoning, pros, and cons.

Simply put, I don't really see why this wouldn't be possible, I don't see any balance concerns given that Virgo isn't as antag/death-focused as other servers so if somebody gets exploded super bad, there's no incentive to make sure they stay dead or otherwise prevent them from coming back outside of resleeving/cloning. We already can heal corpses through slime reactions - which are expensive, heal the same amount, but if you have them pre-made then they're actually faster and can be used outside of an OR, so neither option is made useless or obsolete by the other. There are already hard-coded thresholds as to whether or not someone can be resuscitated in the forms of a (roughly) ten minute timer that, once  expired, is done-so, don't pass go don't collect 200$ go straight to resleeving, genetic and toxin damage which can't be healed outside of the reactions, and corpses husking (being husked prevents a defib regardless of damage values being under 200)when they die of burn damage. It's possible that corpse husking may get its damage-cap raised from 200 to 280 or so, to prevent 1 burn damage over "dead" leaving you just done for, but it's going to remain a thing for severe, severe burns and I have no intention to change that.

The Pros:
- It gives an otherwise rarely used and not-so-useful surgery a genuine, extremely useful niche that isn't reliably covered by anything else ingame. 
- Skilled Surgeons, if they can get your corpse quickly, can reliably piece you back together even if you're totally dead. A dead patient is boring-as-shit. Resleeving is boring-as-shit. You click a button, you wait, you put the patient in a cryocell, you wait, and then you click another button. This gives Medical the opportunity to still, potentially, be able to actually do lifesaving stuff even when someone's super dead. 
- It allows corpses to be healed of brute and burn, even if you have no plans to resuscitate. Bored surgeons can repair morgue'd bodies, or they can do so for RP reasons. It's better to have a stitched-up corpse than one that was blown to bits.
- It's self balancing. It isn't an 'instant corpse fix-all'. Medical will need to locate the corpse, retrieve it or have it taken to an OR, operate, healing 25 damage per trauma/burn-kit step, getting you down below 200 damage, and then defib, all in under 10 minutes. The timer starts the second the patient died. It doesn't matter if Medical has a super-reagent that heals corpses to full health immediately if they administer it a second too late. 
- It doesn't make slime-reactions obsolete. It still doesn't heal genetic or toxin damage, and a bunch of slime-reactions already made and ready will be faster and more portable than surgery (as in, a limited-use upgrade) but the surgery will be able to serve as a cheaper baseline. One fewer thing to rely on Chemistry for and one more thing for Surgeons to be able to accomplish.

Cons:
- It's possible that Medical will spend time attempting to heal your corpse even after your defib-window timer has expired. There's actually no way to _check_ if your defib-timer has run out until you attempt to defib. But, generally, Medical is going to spend time trying to defib your character regardless of the surgeries being options, and the operations are rather short, taking only 6 steps in total where one is repeated "use a trauma kit to remove 25 damage, repeat as needed" and it won't really add more than a few minutes unless you're extremely fucked and have like 800+ damage. Or, maybe Medical will pull off something real fuckin' cool and save you then, too. Anyway, if someone makes a way to see if a corpse 'has time left', that'd pretty much solve this one, because then they'd ideally stop once they realize their time is up. **Edit:** _Misty made a PR to allow health analyzers to tell you if your corpse-patient has 'time left'. So this con is more or less removed!_
- Players will have differing opinions as to whether or not MD's and Surgeons should do these operations to defib deceased crew. We kind of already had this discussion with slime-reactions so personally, I think the answer would be the same; they probably shouldn't be OOCly expected to, and if you rant in LOOC about how you could have been operated on, you should probably be quiet and grateful that they found your body at all. 

So, thoughts? Comments? Questions? Concerns? Mlems? Please leave them below!