### PR TITLE
Fixes open spaces appearing on z-4 after explosions

### DIFF
--- a/code/game/turfs/turf_changing.dm
+++ b/code/game/turfs/turf_changing.dm
@@ -28,7 +28,7 @@
 
 	if(N == /turf/space)
 		var/turf/below = GetBelow(src)
-		if(istype(below) && (air_master.has_valid_zone(below) || air_master.has_valid_zone(src)))
+		if(istype(below) && (air_master.has_valid_zone(below) || air_master.has_valid_zone(src)) && !istype(below, /turf/unsimulated/wall))	// VOREStation Edit: Weird open space
 			N = /turf/simulated/open
 
 	var/obj/fire/old_fire = fire


### PR DESCRIPTION
Fixes #5144

A bit bruteforce-y, but it works and is exactly for the Tether map's quirks.