### PR TITLE
Adds handheld translators to the loadout

### DIFF
--- a/code/modules/client/preference_setup/loadout/loadout_utility_vr.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_utility_vr.dm
@@ -55,3 +55,8 @@
     display_name = "science dufflebag"
     path = /obj/item/weapon/storage/backpack/dufflebag/sci
     allowed_roles = list("Research Director","Scientist","Roboticist","Xenobiologist","Explorer","Pathfinder")
+
+/datum/gear/utility/translator
+	display_name = "handheld translator"
+	path = /obj/item/device/universal_translator
+	cost = 3


### PR DESCRIPTION
Adds handheld translators to the loadout (again), for 3 points. You can now listen in on cliques and/or talk in your native language while having your friends actually understand you! Since it's handheld, it's pretty obvious, so if you're sharing your deepest secrets in a public location in a language other people might speak (hint: don't do this), probably a good idea to stop if you see someone pull out a translator. Or just shout at them for being nosy.