### PR TITLE
Adds the Dark Bar to the Tether

### DIFF
--- a/code/modules/tables/presets.dm
+++ b/code/modules/tables/presets.dm
@@ -75,6 +75,15 @@
 	material = get_material_by_name("glass")
 	..()
 
+/obj/structure/table/borosilicate
+	icon_state = "plain_preview"
+	color = "#4D3EAC"
+	alpha = 77
+
+/obj/structure/table/borosilicate/New()
+	material = get_material_by_name("borosilicate glass")
+	..()
+
 /obj/structure/table/holotable
 	icon_state = "holo_preview"
 	color = "#EEEEEE"

--- a/maps/tether/tether-01-surface1.dmm
+++ b/maps/tether/tether-01-surface1.dmm
@@ -15640,10 +15640,8 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/item/weapon/caution/cone,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/maintenance/lower/atmos)
+/turf/simulated/floor/wood,
+/area/vacant/vacant_bar)
 "aOf" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -21762,11 +21760,6 @@
 "bPA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/lower/atmos)
 "bPI" = (
@@ -21900,7 +21893,11 @@
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
+/obj/machinery/holosign/bar{
+	id = "maintbar";
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled/steel_dirty,
 /area/maintenance/lower/atmos)
 "bQB" = (
 /obj/structure/cable/green{
@@ -22496,10 +22493,6 @@
 /obj/structure/disposalpipe/trunk,
 /turf/simulated/floor/lino,
 /area/crew_quarters/visitor_dining)
-"bTM" = (
-/obj/structure/closet,
-/turf/simulated/floor/plating,
-/area/crew_quarters/sleep/maintDorm4)
 "bTQ" = (
 /turf/simulated/wall,
 /area/engineering/atmos)
@@ -25788,13 +25781,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/showers)
-"ckE" = (
-/obj/machinery/door/firedoor,
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/structure/window/reinforced,
-/turf/simulated/floor/plating,
-/area/crew_quarters/sleep/maintDorm4)
 "clb" = (
 /obj/structure/sign/warning/caution{
 	desc = "No unarmed personnel beyond this point.";
@@ -25900,6 +25886,16 @@
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/atmos/processing)
+"cmD" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/vacant/vacant_bar)
 "crL" = (
 /obj/structure/table/rack,
 /obj/random/maintenance/clean,
@@ -25912,13 +25908,8 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/crew_quarters/sleep/maintDorm4)
+/turf/simulated/floor/wood,
+/area/vacant/vacant_bar)
 "cyE" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
@@ -25933,15 +25924,10 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/public_garden)
 "cHO" = (
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 25;
-	pixel_y = 0
-	},
-/obj/structure/table/woodentable,
+/obj/structure/table/bench/padded,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood,
-/area/crew_quarters/sleep/maintDorm4)
+/turf/simulated/floor/plating,
+/area/vacant/vacant_bar)
 "cHS" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 9
@@ -26035,10 +26021,8 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/maintDorm1)
 "cTp" = (
-/obj/structure/table/steel,
-/obj/effect/decal/cleanable/cobweb,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
+/obj/machinery/vending/boozeomat,
+/turf/simulated/floor/wood,
 /area/vacant/vacant_bar)
 "cVX" = (
 /obj/machinery/light{
@@ -26102,6 +26086,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/public_garden_maintenence)
+"dfa" = (
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/multi_tile/metal/mait{
+	dir = 1;
+	name = "Maintenance Access"
+	},
+/turf/simulated/floor/wood,
+/area/maintenance/lower/atmos)
 "dhv" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/tiled/freezer,
@@ -26113,10 +26105,6 @@
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
 /area/crew_quarters/sleep/maintDorm3)
-"dmW" = (
-/obj/structure/symbol/fe,
-/turf/simulated/wall,
-/area/vacant/vacant_bar)
 "drg" = (
 /obj/machinery/light{
 	icon_state = "tube1";
@@ -26151,8 +26139,7 @@
 /obj/structure/sink/kitchen{
 	pixel_y = 28
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/wood,
 /area/vacant/vacant_bar)
 "dwT" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
@@ -26165,16 +26152,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/atmos)
-"dym" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/turf/simulated/floor/plating,
-/area/vacant/vacant_bar)
 "dAk" = (
 /obj/effect/floor_decal/borderfloor/corner{
 	dir = 4
@@ -26209,11 +26186,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/atrium_one)
-"dDr" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/vacant/vacant_bar)
 "dFd" = (
 /obj/machinery/power/apc/super{
 	dir = 4;
@@ -26226,12 +26198,6 @@
 	},
 /turf/simulated/floor/tiled/steel_dirty/virgo3b,
 /area/engineering/atmos/intake)
-"dGG" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/item/weapon/stool,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/vacant/vacant_bar)
 "dLl" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 10
@@ -26307,6 +26273,15 @@
 /obj/effect/floor_decal/corner/lightgrey/border,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/public_garden_one)
+"dPo" = (
+/obj/machinery/light,
+/obj/structure/ladder/up,
+/obj/structure/cable/green{
+	icon_state = "16-0"
+	},
+/obj/structure/cable/green,
+/turf/simulated/floor/plating,
+/area/vacant/vacant_bar)
 "dQB" = (
 /obj/machinery/alarm{
 	frequency = 1441;
@@ -26321,18 +26296,7 @@
 /turf/simulated/floor/tiled,
 /area/engineering/atmos/processing)
 "dRx" = (
-/obj/machinery/power/apc{
-	cell_type = /obj/item/weapon/cell/apc;
-	dir = 8;
-	name = "west bump";
-	pixel_x = -28
-	},
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/structure/table/woodentable,
-/obj/item/weapon/storage/box/donkpockets,
+/obj/machinery/vending/cigarette,
 /turf/simulated/floor/plating,
 /area/crew_quarters/sleep/maintDorm3)
 "dSz" = (
@@ -26404,23 +26368,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
-/turf/simulated/floor/plating,
-/area/crew_quarters/sleep/maintDorm4)
-"dYy" = (
-/obj/machinery/door/firedoor/glass,
-/turf/simulated/floor/plating,
+/obj/structure/table/bench/padded,
+/turf/simulated/floor/wood,
 /area/vacant/vacant_bar)
 "eaK" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/vacant/vacant_bar)
-"eaW" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/machinery/disposal,
-/turf/simulated/floor/plating,
-/area/crew_quarters/sleep/maintDorm3)
 "eca" = (
 /turf/simulated/floor/plating,
 /area/crew_quarters/sleep/maintDorm2)
@@ -26431,13 +26385,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/glass,
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/plating,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood,
 /area/vacant/vacant_bar)
 "egX" = (
 /obj/structure/cable{
@@ -26456,21 +26410,6 @@
 "epw" = (
 /turf/simulated/wall/r_wall,
 /area/crew_quarters/sleep/Dorm_3)
-"euU" = (
-/obj/machinery/power/apc{
-	cell_type = /obj/item/weapon/cell/apc;
-	dir = 8;
-	name = "west bump";
-	pixel_x = -28
-	},
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/structure/table,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood,
-/area/crew_quarters/sleep/maintDorm4)
 "ewA" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -26501,11 +26440,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/atmos)
-"eFJ" = (
-/obj/structure/table,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/crew_quarters/sleep/maintDorm4)
 "eGQ" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -26530,16 +26464,18 @@
 /area/crew_quarters/showers)
 "eLg" = (
 /obj/structure/table/steel,
-/turf/simulated/floor/plating,
+/obj/item/weapon/paper_bin,
+/obj/item/weapon/pen,
+/turf/simulated/floor/wood,
 /area/vacant/vacant_bar)
 "eNp" = (
-/obj/structure/table/steel,
-/obj/machinery/light/small{
-	icon_state = "bulb1";
+/obj/structure/table/woodentable,
+/obj/item/weapon/reagent_containers/food/drinks/jar,
+/obj/machinery/light_construct{
+	icon_state = "tube-construct-stage1";
 	dir = 1
 	},
-/obj/random/cigarettes,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/wood,
 /area/vacant/vacant_bar)
 "ePE" = (
 /obj/effect/floor_decal/borderfloor{
@@ -26704,6 +26640,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/crew_quarters/sleep/maintDorm2)
+"foy" = (
+/obj/machinery/light_construct{
+	icon_state = "tube-construct-stage1";
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/vacant/vacant_bar)
 "fqS" = (
 /obj/random/trash_pile,
 /turf/simulated/floor/plating,
@@ -26789,18 +26732,14 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/public_garden_one)
 "fER" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/vacant/vacant_bar)
 "fFa" = (
@@ -26834,18 +26773,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/atrium_one)
-"fKm" = (
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -22
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/plating,
-/area/vacant/vacant_bar)
 "fLT" = (
 /obj/machinery/alarm{
 	dir = 4;
@@ -26853,7 +26780,8 @@
 	pixel_x = -22;
 	pixel_y = 0
 	},
-/turf/simulated/floor/plating,
+/obj/structure/table/steel,
+/turf/simulated/floor/wood,
 /area/vacant/vacant_bar)
 "fPW" = (
 /obj/structure/table/rack,
@@ -26884,9 +26812,8 @@
 	pixel_x = 0;
 	pixel_y = 32
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white,
-/area/crew_quarters/sleep/maintDorm4)
+/area/vacant/vacant_bar)
 "fRH" = (
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/airlock/multi_tile/glass{
@@ -26953,14 +26880,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
-"gaW" = (
-/obj/machinery/holosign/bar{
-	id = "maintbar"
-	},
-/turf/simulated/wall,
-/area/vacant/vacant_bar)
 "gcD" = (
-/obj/effect/floor_decal/rust,
 /obj/machinery/shower{
 	dir = 1
 	},
@@ -26975,7 +26895,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/tiled,
-/area/crew_quarters/sleep/maintDorm4)
+/area/vacant/vacant_bar)
 "gcG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -27294,20 +27214,10 @@
 /obj/machinery/portable_atmospherics/powered/scrubber,
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/atmos)
-"hHW" = (
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/lower/atmos)
 "hKw" = (
-/obj/structure/table/steel,
-/obj/random/junk,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood,
 /area/vacant/vacant_bar)
 "hNn" = (
 /obj/structure/table/rack,
@@ -27336,10 +27246,10 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/plating,
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/wood,
 /area/maintenance/lower/atmos)
 "hQO" = (
-/obj/random/junk,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
@@ -27351,7 +27261,12 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/simulated/floor/plating,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood,
+/area/vacant/vacant_bar)
+"hSp" = (
+/obj/structure/symbol/sa,
+/turf/simulated/wall,
 /area/vacant/vacant_bar)
 "hSO" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
@@ -27398,6 +27313,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/maintDorm2)
+"ija" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/structure/table/bench/padded,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood,
+/area/vacant/vacant_bar)
 "ijo" = (
 /obj/machinery/alarm{
 	dir = 4;
@@ -27473,8 +27399,7 @@
 /area/crew_quarters/showers)
 "itW" = (
 /obj/structure/table,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/wood,
 /area/vacant/vacant_bar)
 "iuw" = (
 /obj/machinery/atmospherics/pipe/simple/visible/supply{
@@ -27507,6 +27432,14 @@
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/atmos)
+"iyj" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/wood,
+/area/vacant/vacant_bar)
 "izr" = (
 /obj/effect/floor_decal/borderfloor/corner{
 	dir = 8
@@ -27570,11 +27503,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/atrium_one)
-"iHh" = (
-/obj/structure/table/steel,
-/obj/machinery/reagentgrinder,
-/turf/simulated/floor/plating,
-/area/vacant/vacant_bar)
 "iJC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -27602,14 +27530,12 @@
 /turf/simulated/floor/tiled,
 /area/engineering/atmos)
 "iMg" = (
-/obj/structure/table/steel,
-/obj/item/weapon/paper_bin,
-/obj/item/weapon/pen,
 /obj/machinery/button/holosign{
 	id = "maintbar";
 	pixel_x = -24
 	},
-/turf/simulated/floor/plating,
+/obj/structure/table,
+/turf/simulated/floor/wood,
 /area/vacant/vacant_bar)
 "iNX" = (
 /obj/structure/railing,
@@ -27667,20 +27593,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/atmos/processing)
-"iQg" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/lower/atmos)
 "iQr" = (
 /obj/item/stack/material/steel,
 /obj/effect/decal/cleanable/dirt,
@@ -27801,8 +27713,8 @@
 /obj/structure/toilet{
 	pixel_y = 10
 	},
-/turf/simulated/floor/plating,
-/area/crew_quarters/sleep/maintDorm4)
+/turf/simulated/floor/tiled/white,
+/area/vacant/vacant_bar)
 "jky" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -27824,9 +27736,10 @@
 /turf/simulated/floor/tiled,
 /area/engineering/atmos/processing)
 "jmP" = (
-/obj/machinery/door/firedoor,
-/obj/structure/grille,
-/turf/simulated/floor/plating,
+/obj/structure/table/alien{
+	name = "sleek table"
+	},
+/turf/simulated/floor/wood,
 /area/vacant/vacant_bar)
 "jod" = (
 /obj/effect/floor_decal/borderfloor{
@@ -27952,7 +27865,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/steel_dirty,
 /area/maintenance/lower/atmos)
 "jLy" = (
 /obj/structure/disposalpipe/segment,
@@ -27965,17 +27878,11 @@
 	},
 /obj/structure/cable/green{
 	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/maintenance/lower/atmos)
+/turf/simulated/floor/wood,
+/area/vacant/vacant_bar)
 "jLF" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /turf/simulated/floor/tiled,
@@ -28033,7 +27940,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/steel_dirty,
 /area/maintenance/lower/atmos)
 "jXa" = (
 /obj/machinery/alarm{
@@ -28059,9 +27966,8 @@
 	pixel_x = 25;
 	pixel_y = 0
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/crew_quarters/sleep/maintDorm4)
+/turf/simulated/floor/tiled/white,
+/area/vacant/vacant_bar)
 "kaj" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/red{
 	icon_state = "map";
@@ -28093,18 +27999,13 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/firedoor/glass,
-/obj/machinery/door/airlock{
-	id_tag = "maintdorm4";
-	name = "Room 4"
+/obj/machinery/vending/cigarette,
+/obj/machinery/light_construct{
+	icon_state = "tube-construct-stage1";
+	dir = 4
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/crew_quarters/sleep/maintDorm4)
+/turf/simulated/floor/wood,
+/area/vacant/vacant_bar)
 "kgW" = (
 /obj/structure/window/reinforced,
 /obj/structure/closet/masks,
@@ -28133,7 +28034,6 @@
 /turf/simulated/floor/plating,
 /area/crew_quarters/sleep/maintDorm2)
 "kjb" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
@@ -28143,13 +28043,16 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/plating,
+/obj/item/weapon/stool/padded,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood,
 /area/vacant/vacant_bar)
 "kjZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plating,
-/area/crew_quarters/sleep/maintDorm4)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood,
+/area/vacant/vacant_bar)
 "kkf" = (
 /obj/machinery/atmospherics/pipe/tank/phoron{
 	dir = 8;
@@ -28223,7 +28126,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/steel_dirty,
 /area/maintenance/lower/atmos)
 "kHg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -28231,16 +28134,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/lower/research)
 "kMh" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/green{
-	icon_state = "0-4"
-	},
-/obj/machinery/power/apc{
-	cell_type = /obj/item/weapon/cell/apc;
-	dir = 8;
-	name = "west bump";
-	pixel_x = -28
-	},
+/obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/plating,
 /area/vacant/vacant_bar)
 "kMU" = (
@@ -28287,8 +28181,13 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/wood,
 /area/vacant/vacant_bar)
 "kVd" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/purple{
@@ -28328,9 +28227,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/crew_quarters/sleep/maintDorm4)
+/turf/simulated/floor/tiled/white,
+/area/vacant/vacant_bar)
 "kZc" = (
 /obj/structure/railing{
 	dir = 4
@@ -28347,7 +28245,6 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/public_garden_maintenence)
 "kZI" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
@@ -28355,7 +28252,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/wood,
 /area/vacant/vacant_bar)
 "laN" = (
 /obj/structure/cable/cyan{
@@ -28430,6 +28327,17 @@
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/atmos)
+"lhq" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/table/woodentable,
+/obj/machinery/light_construct,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood,
+/area/vacant/vacant_bar)
 "liI" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/machinery/light_construct{
@@ -28461,7 +28369,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/steel_dirty,
 /area/maintenance/lower/atmos)
 "lnR" = (
 /obj/machinery/atmospherics/binary/passive_gate{
@@ -28558,12 +28466,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/atmos/processing)
-"lJn" = (
-/obj/structure/bed/chair/comfy/black{
-	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/sleep/maintDorm4)
 "lJJ" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1;
@@ -28575,6 +28477,9 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/public_garden)
+"lNF" = (
+/turf/simulated/floor/wood,
+/area/vacant/vacant_bar)
 "lNY" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -28642,10 +28547,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/hallway/lower/first_west)
-"lXf" = (
-/obj/structure/symbol/sa,
-/turf/simulated/wall,
-/area/crew_quarters/sleep/maintDorm4)
 "lYE" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -28684,16 +28585,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/atmos)
-"lZQ" = (
-/obj/machinery/door/firedoor/glass,
-/obj/machinery/door/airlock/maintenance/common,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/lower/atmos)
 "maK" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -28721,13 +28612,8 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/lower/atmos)
+/turf/simulated/floor/wood,
+/area/vacant/vacant_bar)
 "mdV" = (
 /obj/machinery/atmospherics/pipe/simple/visible/scrubbers{
 	dir = 10
@@ -28781,6 +28667,13 @@
 "moi" = (
 /turf/simulated/floor/plating,
 /area/crew_quarters/sleep/maintDorm1)
+"mos" = (
+/obj/machinery/door/firedoor,
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced,
+/turf/simulated/floor/plating,
+/area/vacant/vacant_bar)
 "mpN" = (
 /obj/random/junk,
 /turf/simulated/floor/tiled/techfloor,
@@ -28827,7 +28720,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/crew_quarters/sleep/maintDorm4)
+/area/vacant/vacant_bar)
 "mwy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -28888,19 +28781,22 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/atrium_one)
-"mDm" = (
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 28
-	},
-/turf/simulated/floor/plating,
+"mDl" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/oil,
+/turf/simulated/floor/tiled/steel_dirty,
 /area/maintenance/lower/atmos)
+"mDm" = (
+/obj/structure/table/alien{
+	name = "sleek table"
+	},
+/obj/effect/immovablerod{
+	density = 0;
+	desc = "Engineered for your entertainment.";
+	name = "Dance Pole"
+	},
+/turf/simulated/floor/wood,
+/area/vacant/vacant_bar)
 "mEg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -29037,10 +28933,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/atmos)
-"njh" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/crew_quarters/sleep/maintDorm4)
 "njo" = (
 /obj/structure/disposalpipe/junction{
 	icon_state = "pipe-j1";
@@ -29062,7 +28954,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/steel_dirty,
 /area/maintenance/lower/atmos)
 "nlQ" = (
 /obj/effect/decal/cleanable/dirt,
@@ -29113,6 +29005,10 @@
 /obj/effect/floor_decal/corner/black/bordercorner,
 /turf/simulated/floor/tiled,
 /area/engineering/atmos)
+"nsF" = (
+/obj/structure/table/bench/padded,
+/turf/simulated/floor/wood,
+/area/vacant/vacant_bar)
 "nuR" = (
 /obj/machinery/atmospherics/binary/pump,
 /turf/simulated/floor/tiled,
@@ -29161,23 +29057,15 @@
 /area/crew_quarters/sleep/maintDorm2)
 "nzZ" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/machinery/light_construct{
-	icon_state = "tube-construct-stage1";
-	dir = 1
-	},
-/obj/structure/table/woodentable,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
-/area/crew_quarters/sleep/maintDorm4)
+/area/vacant/vacant_bar)
 "nCo" = (
 /obj/machinery/atmospherics/pipe/simple/visible/universal{
 	name = "Distro Loop Drain"
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/atmos)
-"nCz" = (
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/vacant/vacant_bar)
 "nCB" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -29200,11 +29088,10 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/public_garden)
 "nED" = (
-/obj/structure/bed/double/padded,
+/obj/structure/table/bench/padded,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/weapon/bedsheet/rainbowdouble,
 /turf/simulated/floor/wood,
-/area/crew_quarters/sleep/maintDorm4)
+/area/vacant/vacant_bar)
 "nHz" = (
 /obj/machinery/alarm{
 	dir = 4;
@@ -29303,11 +29190,12 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/atmos)
 "nUf" = (
-/obj/structure/closet/gmcloset{
-	icon_closed = "black";
-	icon_state = "black";
-	name = "formal wardrobe"
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/vacant/vacant_bar)
 "nVZ" = (
@@ -29406,9 +29294,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/atmos/processing)
-"ouI" = (
-/turf/simulated/floor/wood,
-/area/crew_quarters/sleep/maintDorm4)
 "owQ" = (
 /turf/simulated/wall{
 	can_open = 1
@@ -29522,11 +29407,6 @@
 /obj/structure/table/woodentable,
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/maintDorm2)
-"oRr" = (
-/obj/structure/table/woodentable,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood,
-/area/crew_quarters/sleep/maintDorm4)
 "oRG" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/purple{
 	icon_state = "map";
@@ -29678,46 +29558,22 @@
 "ppK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
 /obj/machinery/light_switch{
 	dir = 8;
 	pixel_x = 24;
 	pixel_y = 6
 	},
-/obj/machinery/button/remote/airlock{
-	id = "maintdorm4";
-	name = "Room 4 Lock";
-	pixel_x = 23;
-	pixel_y = -4;
-	specialfunctions = 4
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
-/area/crew_quarters/sleep/maintDorm4)
-"pqF" = (
-/obj/structure/table/woodentable,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/crew_quarters/sleep/maintDorm4)
+/area/vacant/vacant_bar)
 "pqJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/crew_quarters/sleep/maintDorm4)
+/turf/simulated/floor/wood,
+/area/vacant/vacant_bar)
 "prt" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/purple,
 /obj/machinery/meter,
@@ -29734,11 +29590,6 @@
 /area/crew_quarters/sleep/maintDorm2)
 "pvj" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/effect/decal/cleanable/blood/oil,
 /turf/simulated/floor/plating,
 /area/maintenance/lower/atmos)
@@ -29750,6 +29601,22 @@
 /obj/random/maintenance/clean,
 /turf/simulated/floor/plating,
 /area/maintenance/lower/atmos)
+"pxj" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/table/woodentable,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood,
+/area/vacant/vacant_bar)
 "pxR" = (
 /obj/effect/floor_decal/corner/lightgrey{
 	dir = 10
@@ -29773,12 +29640,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/lower/public_garden_maintenence)
-"pxZ" = (
-/obj/structure/bed/chair/comfy/black{
-	dir = 8
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/sleep/maintDorm4)
 "pyO" = (
 /obj/structure/railing,
 /obj/effect/floor_decal/borderfloor{
@@ -29839,8 +29700,10 @@
 /turf/simulated/floor/plating,
 /area/maintenance/lower/research)
 "pTB" = (
-/turf/simulated/wall,
-/area/crew_quarters/sleep/maintDorm4)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/oil,
+/turf/simulated/floor/plating,
+/area/vacant/vacant_bar)
 "pUD" = (
 /obj/machinery/atmospherics/pipe/tank/carbon_dioxide{
 	dir = 8;
@@ -29889,12 +29752,6 @@
 /obj/machinery/portable_atmospherics/powered/scrubber,
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/atmos)
-"qdF" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/crew_quarters/sleep/maintDorm4)
 "qfJ" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 10
@@ -29974,8 +29831,8 @@
 /area/crew_quarters/showers)
 "qsL" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/item/weapon/stool,
-/turf/simulated/floor/plating,
+/obj/item/weapon/stool/padded,
+/turf/simulated/floor/wood,
 /area/vacant/vacant_bar)
 "qtf" = (
 /obj/machinery/camera/network/tether,
@@ -29994,8 +29851,9 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
-/turf/simulated/floor/plating,
-/area/crew_quarters/sleep/maintDorm4)
+/obj/structure/table/woodentable,
+/turf/simulated/floor/wood,
+/area/vacant/vacant_bar)
 "qyw" = (
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -30103,12 +29961,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
-/obj/item/stack/material/wood{
-	amount = 10
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/crew_quarters/sleep/maintDorm4)
+/obj/structure/table/bench/padded,
+/turf/simulated/floor/wood,
+/area/vacant/vacant_bar)
 "qQA" = (
 /obj/random/trash_pile,
 /obj/structure/railing,
@@ -30210,7 +30065,8 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
-/turf/simulated/floor/plating,
+/obj/item/weapon/stool/padded,
+/turf/simulated/floor/wood,
 /area/vacant/vacant_bar)
 "rhY" = (
 /obj/structure/cable/green{
@@ -30237,13 +30093,12 @@
 /turf/simulated/floor/plating,
 /area/maintenance/lower/atmos)
 "rlN" = (
-/obj/effect/floor_decal/rust,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
-/obj/machinery/light_construct/small,
+/obj/machinery/light/small,
 /turf/simulated/floor/tiled/white,
-/area/crew_quarters/sleep/maintDorm4)
+/area/vacant/vacant_bar)
 "rmb" = (
 /obj/machinery/power/apc{
 	cell_type = /obj/item/weapon/cell/apc;
@@ -30300,15 +30155,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/crew_quarters/sleep/maintDorm3)
-"rrW" = (
-/obj/machinery/light/small{
-	icon_state = "bulb1";
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/plating,
-/area/vacant/vacant_bar)
 "rtj" = (
 /obj/machinery/atmospherics/omni/mixer{
 	name = "Air Mixer";
@@ -30464,11 +30310,6 @@
 /obj/structure/window/reinforced/full,
 /turf/simulated/floor/plating,
 /area/engineering/atmos/processing)
-"seb" = (
-/obj/structure/table,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood,
-/area/crew_quarters/sleep/maintDorm4)
 "sfi" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 6
@@ -30517,7 +30358,6 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/tether/surfacebase/public_garden_one)
 "sma" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -30529,7 +30369,8 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/plating,
+/obj/structure/table/woodentable,
+/turf/simulated/floor/wood,
 /area/vacant/vacant_bar)
 "soV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -30635,13 +30476,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/lower/first_west)
-"sDR" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/machinery/disposal,
-/turf/simulated/floor/wood,
-/area/crew_quarters/sleep/maintDorm4)
 "sHl" = (
 /obj/machinery/alarm{
 	dir = 4;
@@ -30653,9 +30487,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/lower/atmos)
 "sHx" = (
-/obj/machinery/light/small,
+/obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/wood,
 /area/vacant/vacant_bar)
 "sJs" = (
 /obj/effect/floor_decal/borderfloor{
@@ -30730,6 +30564,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos/processing)
+"taf" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood,
+/area/vacant/vacant_bar)
 "taQ" = (
 /obj/machinery/atmospherics/pipe/tank/oxygen{
 	icon_state = "o2_map";
@@ -30866,15 +30704,6 @@
 /obj/machinery/meter,
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/atmos)
-"ttM" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/lower/atmos)
 "tux" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -31044,10 +30873,19 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/public_garden)
-"tPN" = (
-/obj/random/junk,
+"tVd" = (
+/obj/structure/cable/green{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc{
+	cell_type = /obj/item/weapon/cell/apc;
+	dir = 8;
+	name = "west bump";
+	pixel_x = -28
+	},
+/obj/structure/table/bench/padded,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/wood,
 /area/vacant/vacant_bar)
 "tXm" = (
 /obj/effect/floor_decal/corner/lightgrey{
@@ -31110,14 +30948,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/maintDorm3)
-"uep" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/lower/atmos)
 "ugE" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
@@ -31173,9 +31003,6 @@
 /obj/machinery/meter,
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/atmos/processing)
-"uux" = (
-/turf/simulated/floor/plating,
-/area/crew_quarters/sleep/maintDorm4)
 "uuF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -31183,11 +31010,12 @@
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/showers)
 "uvM" = (
-/obj/structure/table,
-/obj/random/junk,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/crew_quarters/sleep/maintDorm4)
+/obj/machinery/light_construct{
+	icon_state = "tube-construct-stage1";
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/vacant/vacant_bar)
 "uwI" = (
 /obj/effect/floor_decal/borderfloor/corner{
 	dir = 1
@@ -31364,13 +31192,20 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/crew_quarters/sleep/maintDorm1)
+"vjL" = (
+/obj/item/weapon/stool/padded,
+/turf/simulated/floor/wood,
+/area/vacant/vacant_bar)
 "vjX" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/engineering/atmos/processing)
 "vko" = (
-/obj/machinery/smartfridge,
-/turf/simulated/floor/plating,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/table,
+/turf/simulated/floor/wood,
 /area/vacant/vacant_bar)
 "vkK" = (
 /turf/simulated/wall,
@@ -31478,7 +31313,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/steel_dirty,
 /area/maintenance/lower/atmos)
 "vBY" = (
 /obj/structure/railing{
@@ -31568,9 +31403,9 @@
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/sleep/maintDorm2)
 "vMa" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood,
-/area/crew_quarters/sleep/maintDorm4)
+/obj/structure/table,
+/turf/simulated/floor/plating,
+/area/vacant/vacant_bar)
 "vMY" = (
 /obj/machinery/alarm{
 	dir = 8;
@@ -31629,9 +31464,8 @@
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/sleep/maintDorm3)
 "vVa" = (
-/obj/structure/table/steel,
-/obj/item/weapon/reagent_containers/food/drinks/smallmilk,
-/turf/simulated/floor/plating,
+/obj/structure/table/woodentable,
+/turf/simulated/floor/wood,
 /area/vacant/vacant_bar)
 "vXn" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/purple,
@@ -31691,8 +31525,8 @@
 /area/engineering/atmos/processing)
 "wtU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/item/weapon/stool,
-/turf/simulated/floor/plating,
+/obj/item/weapon/stool/padded,
+/turf/simulated/floor/wood,
 /area/vacant/vacant_bar)
 "wxS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -31872,20 +31706,12 @@
 /obj/item/clothing/head/soft/purple,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/showers)
-"wXS" = (
-/obj/machinery/door/firedoor/glass,
-/obj/machinery/door/airlock{
-	name = "Bar Backroom";
-	welded = 1
+"wWI" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
+/obj/structure/table/bench/padded,
+/turf/simulated/floor/wood,
 /area/vacant/vacant_bar)
 "wYi" = (
 /turf/simulated/floor/plating,
@@ -31997,14 +31823,13 @@
 /turf/simulated/floor/plating,
 /area/crew_quarters/sleep/maintDorm1)
 "xDD" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/table/bench/padded,
+/obj/machinery/light_construct{
+	icon_state = "tube-construct-stage1";
+	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/lower/atmos)
+/turf/simulated/floor/wood,
+/area/vacant/vacant_bar)
 "xDX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -32185,9 +32010,8 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/public_garden)
 "yka" = (
-/obj/structure/table/steel,
-/obj/item/frame,
-/turf/simulated/floor/plating,
+/obj/machinery/smartfridge,
+/turf/simulated/floor/wood,
 /area/vacant/vacant_bar)
 "ylA" = (
 /obj/effect/floor_decal/borderfloor{
@@ -42685,7 +42509,7 @@ aah
 aah
 aah
 aah
-aah
+aad
 aad
 aad
 aad
@@ -42826,9 +42650,9 @@ azI
 aah
 aah
 aah
-aah
-aah
-aah
+aad
+aad
+aad
 aad
 aad
 aad
@@ -42965,12 +42789,12 @@ azI
 azI
 azI
 azI
-aah
-aah
-aah
-aah
-aah
-aah
+jiZ
+jiZ
+aad
+aad
+aad
+aad
 aad
 aad
 aad
@@ -43102,16 +42926,16 @@ vko
 iMg
 eLg
 fLT
-jiZ
-jBQ
+foy
+taf
 jBQ
 kMh
-jiZ
-aah
-aah
-aah
-aah
-aah
+nsF
+tVd
+mos
+aad
+aad
+aad
 aad
 aad
 aad
@@ -43239,19 +43063,19 @@ cyE
 cyE
 azI
 duL
-jBQ
-eaK
-jBQ
+lNF
+taf
+taf
 hQO
 kZI
-wXS
 kZI
+cmD
 fER
-fKm
+kZI
+pxj
+lhq
 jiZ
-aah
-aah
-aah
+aad
 aad
 aad
 aad
@@ -43383,17 +43207,17 @@ azI
 eNp
 vVa
 itW
-itW
+vVa
 sma
 sHx
-jiZ
-rrW
-dym
+itW
+lNF
+jBQ
 hKw
-jiZ
-aah
-aah
-aah
+ija
+wWI
+mos
+aad
 aad
 aad
 aad
@@ -43520,22 +43344,22 @@ uiB
 cet
 bEX
 aLC
-hHW
+aLC
 azI
 qsL
 wtU
-dGG
-dDr
+wtU
+wtU
 kjb
 rfP
-jiZ
-jBQ
+vjL
+lNF
 eaK
-iHh
-dmW
-aah
-aah
-aah
+lNF
+lNF
+jiZ
+jiZ
+aad
 aad
 aad
 aad
@@ -43664,20 +43488,20 @@ bEX
 cyE
 bPA
 azI
-jBQ
-itW
-tPN
-eaK
+nsF
+nsF
+nsF
+lNF
 kRQ
-jBQ
-jiZ
+iyj
+iyj
 nUf
-eLg
-eLg
+nUf
+iyj
+iyj
+dPo
 jiZ
-aah
-aah
-aah
+aad
 aad
 aad
 aad
@@ -43807,20 +43631,20 @@ aLC
 pvj
 azI
 jmP
-nCz
-dYy
-gaW
+jmP
+nsF
+jBQ
 eel
+lNF
+jBQ
+eaK
 pTB
-pTB
-pTB
-pTB
-lXf
-pTB
-pTB
-pTB
-pTB
-pTB
+lNF
+lNF
+hSp
+jiZ
+jiZ
+jiZ
 mqx
 aad
 aad
@@ -43946,23 +43770,23 @@ aLk
 aLC
 cyE
 cyE
-uep
+aLC
 azI
 mDm
-cyE
-cyE
-aLC
+jmP
+nsF
+lNF
 aOd
-pTB
-sDR
-seb
-euU
-pqF
-bTM
-ouI
-vMa
-lJn
-ckE
+jBQ
+lNF
+lNF
+taf
+taf
+jBQ
+nsF
+nsF
+nsF
+mos
 mqx
 mqx
 aad
@@ -44088,10 +43912,10 @@ bEX
 aLD
 gzM
 cyE
-ttM
-lZQ
-iQg
-xDD
+cyE
+azI
+jmP
+jmP
 xDD
 mbM
 jLy
@@ -44100,11 +43924,11 @@ ppK
 cws
 pqJ
 kjZ
-qdF
+kjZ
 qPT
 vMa
-oRr
-ckE
+vVa
+mos
 mqx
 mqx
 aad
@@ -44236,17 +44060,17 @@ aLE
 aLE
 aLE
 hQI
-cyE
-pTB
-pTB
+dfa
+jiZ
+jiZ
 mvw
-pTB
-pTB
+jiZ
+jiZ
 nzZ
 dYn
 qwy
-pxZ
-pTB
+vVa
+jiZ
 mqx
 mqx
 aad
@@ -44378,17 +44202,17 @@ pUG
 eUB
 aLE
 bQA
-aLC
-pTB
+rPU
+jiZ
 fRb
 kYv
 rlN
-pTB
+jiZ
 uvM
-njh
-uux
-vMa
-ckE
+nsF
+sHx
+sHx
+mos
 mqx
 mqx
 aad
@@ -44520,17 +44344,17 @@ eUB
 eUB
 aLE
 vBq
-wle
-pTB
+mDl
+jiZ
 jkn
 jYN
 gcD
-pTB
-eFJ
+jiZ
+lNF
 cHO
 nED
-ouI
-ckE
+nsF
+mos
 aad
 aad
 aad
@@ -44661,18 +44485,18 @@ toz
 lcu
 eUB
 aLE
-bQA
-cyE
-pTB
-pTB
-pTB
-pTB
-pTB
-pTB
-pTB
-pTB
-pTB
-pTB
+wOg
+wle
+adK
+jiZ
+jiZ
+jiZ
+jiZ
+jiZ
+jiZ
+jiZ
+jiZ
+jiZ
 aad
 aad
 aad
@@ -44803,10 +44627,10 @@ aLE
 iXb
 nmr
 aLE
-bQA
-aLC
+wOg
+rPU
 loJ
-eaW
+oZQ
 brB
 dRx
 qPz
@@ -45229,8 +45053,8 @@ toz
 lcu
 mgm
 aLE
-hQI
-aLC
+lYJ
+rPU
 loJ
 fah
 srm
@@ -45372,7 +45196,7 @@ iXb
 dhv
 aLE
 jWP
-aLC
+rPU
 loJ
 cLW
 tEU
@@ -45513,7 +45337,7 @@ qqu
 pUG
 mgm
 aLE
-bQA
+wOg
 wle
 loJ
 loJ
@@ -45655,8 +45479,8 @@ eJQ
 eJQ
 uuF
 aLE
-hQI
-cyE
+lYJ
+wle
 kfZ
 qUj
 vbQ
@@ -46082,7 +45906,7 @@ lYE
 xEo
 aLE
 tKM
-aLC
+rPU
 kfZ
 kip
 kva
@@ -46224,7 +46048,7 @@ maK
 mnZ
 aLE
 wOg
-cyE
+wle
 kfZ
 nzv
 eGQ
@@ -46365,8 +46189,8 @@ jod
 pYp
 qNc
 aLE
-bQA
-cyE
+wOg
+wle
 kfZ
 kfZ
 kfZ
@@ -46507,7 +46331,7 @@ aLE
 aLE
 aLE
 aLE
-hQI
+lYJ
 qRQ
 qKd
 jfn

--- a/maps/tether/tether-01-surface1.dmm
+++ b/maps/tether/tether-01-surface1.dmm
@@ -25894,6 +25894,11 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/plating,
 /area/vacant/vacant_bar)
 "crL" = (
@@ -26297,6 +26302,12 @@
 /area/engineering/atmos/processing)
 "dRx" = (
 /obj/machinery/vending/cigarette,
+/obj/machinery/power/apc{
+	cell_type = /obj/item/weapon/cell/apc;
+	dir = 8;
+	name = "west bump";
+	pixel_x = -28
+	},
 /turf/simulated/floor/plating,
 /area/crew_quarters/sleep/maintDorm3)
 "dSz" = (
@@ -27196,6 +27207,15 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/public_garden)
+"hxf" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/wood,
+/area/vacant/vacant_bar)
 "hAF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/freezer,
@@ -27535,6 +27555,9 @@
 	pixel_x = -24
 	},
 /obj/structure/table,
+/obj/item/stack/material/wood{
+	amount = 10
+	},
 /turf/simulated/floor/wood,
 /area/vacant/vacant_bar)
 "iNX" = (
@@ -27736,9 +27759,7 @@
 /turf/simulated/floor/tiled,
 /area/engineering/atmos/processing)
 "jmP" = (
-/obj/structure/table/alien{
-	name = "sleek table"
-	},
+/obj/structure/table/borosilicate,
 /turf/simulated/floor/wood,
 /area/vacant/vacant_bar)
 "jod" = (
@@ -28085,6 +28106,14 @@
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/plating,
 /area/maintenance/lower/atmos)
+"kuB" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/stack/material/wood{
+	amount = 10
+	},
+/turf/simulated/floor/wood,
+/area/vacant/vacant_bar)
 "kuC" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 5
@@ -28149,6 +28178,18 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/atrium_one)
+"kOq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/green{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 28
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/lower/atmos)
 "kOB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
@@ -28787,14 +28828,12 @@
 /turf/simulated/floor/tiled/steel_dirty,
 /area/maintenance/lower/atmos)
 "mDm" = (
-/obj/structure/table/alien{
-	name = "sleek table"
-	},
 /obj/effect/immovablerod{
 	density = 0;
 	desc = "Engineered for your entertainment.";
 	name = "Dance Pole"
 	},
+/obj/structure/table/borosilicate,
 /turf/simulated/floor/wood,
 /area/vacant/vacant_bar)
 "mEg" = (
@@ -28833,6 +28872,16 @@
 /obj/machinery/atmospherics/pipe/tank/air,
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/atmos)
+"mUc" = (
+/obj/machinery/door/airlock/maintenance/common,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/plating,
+/area/maintenance/lower/atmos)
 "mUG" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -29215,6 +29264,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos/processing)
+"ocj" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/lower/atmos)
 "ocQ" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green,
 /obj/effect/floor_decal/borderfloor{
@@ -42642,8 +42699,8 @@ aLC
 gtV
 cyE
 pGN
-cyE
-aLC
+kOq
+ocj
 aLC
 mMD
 azI
@@ -42785,7 +42842,7 @@ azI
 azI
 azI
 azI
-azI
+mUc
 azI
 azI
 azI
@@ -42927,7 +42984,7 @@ iMg
 eLg
 fLT
 foy
-taf
+hxf
 jBQ
 kMh
 nsF
@@ -44211,7 +44268,7 @@ jiZ
 uvM
 nsF
 sHx
-sHx
+kuB
 mos
 mqx
 mqx
@@ -44487,7 +44544,7 @@ eUB
 aLE
 wOg
 wle
-adK
+jiZ
 jiZ
 jiZ
 jiZ

--- a/maps/tether/tether-02-surface2.dmm
+++ b/maps/tether/tether-02-surface2.dmm
@@ -16737,6 +16737,13 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/bar)
+"Mz" = (
+/obj/machinery/alarm{
+	frequency = 1441;
+	pixel_y = 22
+	},
+/turf/simulated/floor/wood,
+/area/vacant/vacant_bar_upper)
 "MA" = (
 /obj/structure/table/steel,
 /obj/item/device/nif/bad,
@@ -30574,7 +30581,7 @@ Ud
 Eu
 JU
 Ih
-Eu
+Mz
 JU
 Ud
 Eu

--- a/maps/tether/tether-02-surface2.dmm
+++ b/maps/tether/tether-02-surface2.dmm
@@ -11982,6 +11982,18 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/asmaint2)
+"xn" = (
+/obj/structure/table/rack/shelf/steel,
+/obj/item/weapon/reagent_containers/food/drinks/bottle/goldschlager,
+/obj/item/weapon/reagent_containers/food/drinks/bottle/sake,
+/obj/item/weapon/reagent_containers/food/drinks/bottle/kahlua,
+/obj/item/weapon/reagent_containers/food/drinks/bottle/wine,
+/obj/item/weapon/reagent_containers/food/drinks/bottle/patron,
+/obj/item/weapon/reagent_containers/food/drinks/bottle/absinthe,
+/obj/item/weapon/reagent_containers/food/drinks/bottle/tequilla,
+/obj/item/weapon/reagent_containers/food/drinks/bottle/specialwhiskey,
+/turf/simulated/floor/wood,
+/area/vacant/vacant_bar_upper)
 "xs" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -13223,6 +13235,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/south)
+"Cc" = (
+/obj/structure/simple_door/wood,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/wood,
+/area/vacant/vacant_bar_upper)
 "Cg" = (
 /obj/structure/railing,
 /obj/machinery/light{
@@ -13514,6 +13535,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/lower/atmos)
+"Dw" = (
+/obj/structure/cable/green{
+	icon_state = "32-1"
+	},
+/obj/structure/ladder,
+/turf/simulated/floor/wood,
+/area/vacant/vacant_bar_upper)
 "Dy" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 10
@@ -13921,6 +13949,9 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/south)
+"Eu" = (
+/turf/simulated/floor/wood,
+/area/vacant/vacant_bar_upper)
 "Ev" = (
 /obj/structure/railing{
 	dir = 8
@@ -15901,6 +15932,11 @@
 /obj/machinery/light,
 /turf/simulated/floor/wood,
 /area/engineering/lower/breakroom)
+"Ih" = (
+/turf/simulated/wall{
+	can_open = 1
+	},
+/area/vacant/vacant_bar_upper)
 "Ij" = (
 /obj/machinery/alarm{
 	dir = 4;
@@ -15932,10 +15968,11 @@
 /turf/simulated/floor/tiled,
 /area/janitor)
 "Iu" = (
-/obj/structure/table/steel,
-/obj/item/weapon/reagent_containers/food/drinks/bottle/goldschlager,
-/turf/simulated/floor/plating,
-/area/maintenance/lower/atmos)
+/obj/structure/table/rack/shelf/steel,
+/obj/item/weapon/reagent_containers/food/drinks/bottle/space_mountain_wind,
+/obj/item/weapon/reagent_containers/food/drinks/bottle/cola,
+/turf/simulated/floor/wood,
+/area/vacant/vacant_bar_upper)
 "Iw" = (
 /obj/effect/floor_decal/borderfloor/corner{
 	dir = 8
@@ -16141,9 +16178,12 @@
 /turf/simulated/floor/plating,
 /area/maintenance/lower/atmos)
 "JG" = (
-/obj/structure/lattice,
-/turf/simulated/open,
-/area/maintenance/lower/atmos)
+/obj/structure/bed/double/padded,
+/obj/item/weapon/bedsheet/double,
+/obj/structure/curtain/open/privacy,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood,
+/area/vacant/vacant_bar_upper)
 "JJ" = (
 /obj/structure/closet,
 /obj/structure/catwalk,
@@ -16170,10 +16210,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/lower/south)
 "JU" = (
-/obj/random/obstruction,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood,
-/area/maintenance/lower/atmos)
+/turf/simulated/floor/plating,
+/area/vacant/vacant_bar_upper)
 "JV" = (
 /obj/structure/railing{
 	dir = 4
@@ -16325,14 +16364,12 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/atmos)
 "KG" = (
-/obj/structure/table/steel,
-/obj/item/weapon/reagent_containers/food/drinks/bottle/lemonjuice,
-/obj/item/weapon/reagent_containers/food/drinks/bottle/limejuice,
-/obj/item/weapon/reagent_containers/food/drinks/bottle/cream,
-/obj/item/weapon/reagent_containers/food/drinks/bottle/orangejuice,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/maintenance/lower/atmos)
+/obj/structure/table/rack/shelf/steel,
+/obj/item/weapon/reagent_containers/food/drinks/bottle/vermouth,
+/obj/item/weapon/reagent_containers/food/drinks/bottle/rum,
+/obj/item/weapon/reagent_containers/food/drinks/bottle/cognac,
+/turf/simulated/floor/wood,
+/area/vacant/vacant_bar_upper)
 "KH" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1;
@@ -16364,6 +16401,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/public_garden_two)
+"KM" = (
+/obj/structure/bed/double/padded,
+/obj/item/weapon/bedsheet/double,
+/obj/structure/curtain/open/privacy,
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/wood,
+/area/vacant/vacant_bar_upper)
 "KR" = (
 /obj/machinery/light_switch{
 	pixel_y = 28
@@ -16611,10 +16655,8 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/bar)
 "LN" = (
-/obj/item/weapon/contraband/poster,
-/obj/structure/table/steel,
-/turf/simulated/floor/wood,
-/area/maintenance/lower/atmos)
+/turf/simulated/floor/plating,
+/area/vacant/vacant_bar_upper)
 "LP" = (
 /obj/structure/table/rack,
 /obj/random/maintenance/clean,
@@ -16628,11 +16670,6 @@
 /obj/item/device/flashlight/lamp,
 /turf/simulated/floor/plating,
 /area/maintenance/lower/atmos)
-"LR" = (
-/obj/structure/ladder_assembly,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/maintenance/lower/atmos)
 "LY" = (
 /obj/machinery/camera/network/tether{
 	dir = 4
@@ -16644,11 +16681,6 @@
 /obj/item/weapon/hand_labeler,
 /obj/item/weapon/storage/fancy/candle_box,
 /turf/simulated/floor/plating,
-/area/maintenance/lower/atmos)
-"Mk" = (
-/obj/structure/ladder_assembly,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood,
 /area/maintenance/lower/atmos)
 "Mn" = (
 /obj/structure/catwalk,
@@ -16723,13 +16755,16 @@
 /area/engineering/lower/lobby)
 "MH" = (
 /obj/structure/table/rack/shelf/steel,
-/obj/item/weapon/reagent_containers/food/drinks/bottle/patron,
-/obj/item/weapon/reagent_containers/food/drinks/bottle/wine,
-/obj/item/weapon/reagent_containers/food/drinks/bottle/kahlua,
-/obj/item/weapon/reagent_containers/food/drinks/bottle/sake,
-/obj/effect/decal/cleanable/dirt,
+/obj/item/weapon/reagent_containers/food/drinks/bottle/orangejuice,
+/obj/item/weapon/reagent_containers/food/drinks/bottle/cream,
+/obj/item/weapon/reagent_containers/food/drinks/bottle/limejuice,
+/obj/item/weapon/reagent_containers/food/drinks/bottle/lemonjuice,
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 4
+	},
 /turf/simulated/floor/wood,
-/area/maintenance/lower/atmos)
+/area/vacant/vacant_bar_upper)
 "MI" = (
 /obj/structure/table/steel,
 /obj/item/clothing/head/welding/demon,
@@ -16797,6 +16832,14 @@
 /obj/machinery/camera/network/civilian,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/public_garden_two)
+"Nc" = (
+/obj/machinery/light_construct{
+	icon_state = "tube-construct-stage1";
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/vacant/vacant_bar_upper)
 "Ne" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
@@ -16966,9 +17009,13 @@
 /turf/simulated/floor/plating,
 /area/maintenance/lower/atmos)
 "Ob" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood,
-/area/maintenance/lower/atmos)
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/vacant/vacant_bar_upper)
 "Od" = (
 /obj/structure/table/steel,
 /obj/item/stack/medical/splint/ghetto,
@@ -17148,6 +17195,14 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/public_garden_two)
+"OI" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/wood,
+/area/vacant/vacant_bar_upper)
 "OL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -17204,10 +17259,6 @@
 /obj/machinery/portable_atmospherics/powered/pump/filled,
 /turf/simulated/floor/tiled,
 /area/engineering/lower/lobby)
-"OS" = (
-/obj/effect/floor_decal/rust,
-/turf/simulated/floor/plating,
-/area/maintenance/lower/atmos)
 "OT" = (
 /obj/structure/table/rack,
 /obj/item/device/flashlight,
@@ -17438,9 +17489,11 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/south)
 "PT" = (
-/obj/item/weapon/reagent_containers/food/drinks/bottle/vodka,
-/turf/simulated/floor/plating,
-/area/maintenance/lower/atmos)
+/obj/structure/bed/double/padded,
+/obj/item/weapon/bedsheet/double,
+/obj/structure/curtain/open/privacy,
+/turf/simulated/floor/wood,
+/area/vacant/vacant_bar_upper)
 "PV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -17479,6 +17532,14 @@
 	},
 /turf/simulated/floor/tiled,
 /area/janitor)
+"Qj" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/wood,
+/area/vacant/vacant_bar_upper)
 "Qm" = (
 /obj/machinery/door/airlock/maintenance/engi{
 	name = "Pump Station"
@@ -17817,6 +17878,14 @@
 /obj/machinery/vending/assist,
 /turf/simulated/floor/plating,
 /area/maintenance/lower/atmos)
+"Sj" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/wood,
+/area/vacant/vacant_bar_upper)
 "Sl" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/yellow/border,
@@ -18032,6 +18101,14 @@
 /obj/random/maintenance/clean,
 /turf/simulated/floor/plating,
 /area/maintenance/lower/south)
+"TH" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/plating,
+/area/vacant/vacant_bar_upper)
 "TN" = (
 /obj/structure/table/steel,
 /obj/item/weapon/paper_bin,
@@ -18112,12 +18189,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/lower/south)
 "Ud" = (
-/obj/structure/table/rack/shelf/steel,
-/obj/item/weapon/reagent_containers/food/drinks/bottle/vermouth,
-/obj/item/weapon/reagent_containers/food/drinks/bottle/rum,
-/obj/item/weapon/reagent_containers/food/drinks/bottle/cognac,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
-/area/maintenance/lower/atmos)
+/area/vacant/vacant_bar_upper)
 "Uf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
@@ -18462,10 +18536,13 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/atmos)
 "VD" = (
-/obj/structure/closet/crate,
-/obj/random/contraband,
+/obj/machinery/alarm{
+	frequency = 1441;
+	pixel_y = 22
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
-/area/maintenance/lower/atmos)
+/area/vacant/vacant_bar_upper)
 "VE" = (
 /obj/structure/cable{
 	d2 = 2;
@@ -18524,9 +18601,14 @@
 /turf/simulated/floor/plating,
 /area/maintenance/lower/atmos)
 "VQ" = (
-/obj/item/weapon/contraband/poster,
-/turf/simulated/floor/wood,
-/area/maintenance/lower/atmos)
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/vacant/vacant_bar_upper)
 "VR" = (
 /turf/simulated/floor/outdoors/rocks/virgo3b,
 /area/tether/surfacebase/outside/outside2)
@@ -19239,12 +19321,9 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/public_garden_two)
 "YU" = (
-/obj/structure/table/rack/shelf/steel,
-/obj/item/weapon/reagent_containers/food/drinks/bottle/specialwhiskey,
-/obj/item/weapon/reagent_containers/food/drinks/bottle/tequilla,
-/obj/item/weapon/reagent_containers/food/drinks/bottle/absinthe,
-/turf/simulated/floor/plating,
-/area/maintenance/lower/atmos)
+/obj/structure/closet/secure_closet/personal,
+/turf/simulated/floor/wood,
+/area/vacant/vacant_bar_upper)
 "YX" = (
 /obj/structure/catwalk,
 /obj/effect/decal/cleanable/dirt,
@@ -19276,11 +19355,18 @@
 /turf/simulated/floor/carpet,
 /area/maintenance/lower/atmos)
 "Zj" = (
-/obj/structure/table/rack/shelf/steel,
-/obj/item/weapon/reagent_containers/food/drinks/bottle/space_mountain_wind,
-/obj/item/weapon/reagent_containers/food/drinks/bottle/cola,
-/turf/simulated/floor/plating,
-/area/maintenance/lower/atmos)
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_x = 0;
+	pixel_y = 28
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/wood,
+/area/vacant/vacant_bar_upper)
 "Zk" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -19290,10 +19376,9 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/tether/surfacebase/east_stairs_two)
-"Zn" = (
-/obj/item/weapon/reagent_containers/food/drinks/bottle/gin,
-/turf/simulated/floor/plating,
-/area/maintenance/lower/atmos)
+"Zl" = (
+/turf/simulated/wall,
+/area/vacant/vacant_bar_upper)
 "Zo" = (
 /obj/structure/table/bench/steel,
 /obj/effect/floor_decal/borderfloor/corner{
@@ -19349,11 +19434,13 @@
 /turf/simulated/floor/plating,
 /area/maintenance/lower/south)
 "ZB" = (
-/obj/machinery/light/small{
+/obj/machinery/light_construct{
+	icon_state = "tube-construct-stage1";
 	dir = 8
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/lower/atmos)
+/obj/structure/closet/secure_closet/personal,
+/turf/simulated/floor/wood,
+/area/vacant/vacant_bar_upper)
 "ZC" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 9
@@ -30197,18 +30284,18 @@ Nx
 Tx
 VA
 UN
-VA
-VA
-VA
-VA
-VA
-VA
-VA
-VA
-VA
-VA
-VA
-VA
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
 VA
 ac
 ac
@@ -30339,18 +30426,18 @@ VA
 VA
 VA
 Ne
-VA
+Zl
 YU
-Ne
+YU
 ZB
-Jt
-VA
+YU
+Zl
 PT
-Ne
-UN
-VA
-ac
-ac
+Eu
+JG
+JU
+PT
+Zl
 ac
 ac
 ac
@@ -30481,18 +30568,18 @@ Yy
 UN
 ZY
 UN
-VA
+Zl
 Ud
-Ob
-Ob
+Ud
+Eu
 JU
-ZY
-Ne
-OS
-Zn
-RF
-ac
-ac
+Ih
+Eu
+JU
+Ud
+Eu
+Eu
+Zl
 ac
 ab
 ab
@@ -30623,18 +30710,18 @@ Kz
 TN
 VA
 VA
-VA
+Zl
 Zj
 Ob
 VQ
-Jt
-VA
+Sj
+Zl
 JG
-UN
-Ne
-VA
-ac
-ac
+Eu
+PT
+Eu
+KM
+Zl
 ac
 ab
 ab
@@ -30765,18 +30852,18 @@ No
 LQ
 VA
 RF
-VA
+Zl
 VD
-Mk
-Ob
-Ne
-VA
-QV
-JG
-UN
-RF
-ac
-ac
+LN
+Eu
+Qj
+Zl
+Eu
+Eu
+JU
+JU
+Eu
+Zl
 ac
 ab
 ab
@@ -30907,18 +30994,18 @@ Yb
 Ne
 VA
 RF
-VA
+Zl
 LN
-UN
-Yy
-Ob
-VA
-UW
-LR
-UN
-VA
-ac
-ac
+Eu
+Eu
+TH
+Cc
+OI
+OI
+VQ
+OI
+Dw
+Zl
 ac
 ab
 ab
@@ -31049,18 +31136,18 @@ UN
 UN
 VA
 RF
-VA
+Zl
 KG
 Iu
 MH
-Jt
-VA
-VA
-VA
-RF
-RF
-ac
-ac
+xn
+Zl
+Eu
+Ud
+Nc
+Eu
+LN
+Zl
 ac
 ac
 ac
@@ -31191,18 +31278,18 @@ VA
 VA
 VA
 VA
-VA
-VA
-VA
-VA
-VA
-VA
-ac
-ac
-ac
-ac
-ac
-ac
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
 ac
 ac
 ac

--- a/maps/tether/tether_areas2.dm
+++ b/maps/tether/tether_areas2.dm
@@ -89,6 +89,8 @@
 	name = "\improper Atrium Construction Site"
 /area/vacant/vacant_bar
 	name = "\improper Vacant Bar"
+/area/vacant/vacant_bar_upper
+	name = "\improper Upper Vacant Bar"
 /area/vacant/vacant_site/gateway
 	name = "\improper Vacant Prep Area"
 /area/vacant/vacant_site/gateway/lower


### PR DESCRIPTION
Adds the dark bar, officially, to the tether. 
The Dark Bar is a player run area that's been ongoing, periodically, for the past 3 months or so. A group of players will get together, renovate a section of maint (near the construction dorms), and turn it into a type of seedy bar for the purpose of kinks and activities that normally wouldn't be acceptable in the public eye. This PR maps in the bar properly, in a fashion that still requires some work to make it fully functional, while also dramatically cutting down on the setup time (which previously was upwards of an hour, plus admin intervention). No admin assistance will be needed, moving forward, to get the bar up and running.

Screenshots:
Fullbright
https://files.catbox.moe/478e6o.png
https://files.catbox.moe/2858zi.png
Darkness Enabled
https://files.catbox.moe/pdgtdy.png
https://files.catbox.moe/c7wvp8.png