### PR TITLE
A stray attempt at fixing the lacking manifest entries

### DIFF
--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -126,7 +126,7 @@ var/global/datum/controller/gameticker/ticker
 	create_characters() //Create player characters and transfer them.
 	collect_minds()
 	equip_characters()
-	data_core.manifest()
+	//data_core.manifest()	//VOREStation Removal
 
 	callHook("roundstart")
 
@@ -280,8 +280,13 @@ var/global/datum/controller/gameticker/ticker
 				else if(!player.mind.assigned_role)
 					continue
 				else
-					if (player.create_character()) // VOREStation Edit
+					//VOREStation Edit Start
+					var/mob/living/carbon/human/new_char = player.create_character()
+					if(new_char)
 						qdel(player)
+					if(istype(new_char))
+						data_core.manifest_inject(new_char)
+					//VOREStation Edit End
 
 
 	proc/collect_minds()


### PR DESCRIPTION
Manifest entries (or any records for that matter) seem to not generate properly if player lags out during specific ticks of the round start. This could possibly fix that, making character creation and addition to manifest a single action, rather than two separated by two more things needing doing, giving too much room for difference between list of players at start of initialization and at the 'manifest-filling' stage.

Tested as much as possible alone, seemed to create roundstart manifest entries just fine? Still a bit unsure about other potential aspects, admittedly.