### PR TITLE
Some outposts tweaks

### DIFF
--- a/maps/tether/tether-01-surface1.dmm
+++ b/maps/tether/tether-01-surface1.dmm
@@ -37,14 +37,17 @@
 /turf/simulated/floor/tiled/steel_dirty/virgo3b,
 /area/tether/surfacebase/mining_main/external)
 "aaj" = (
-/obj/machinery/power/apc{
-	dir = 2;
-	name = "south bump";
-	pixel_y = -28
+/obj/structure/railing{
+	dir = 8
 	},
-/obj/structure/cable/green,
-/turf/simulated/floor/tiled/steel_dirty/virgo3b,
-/area/tether/surfacebase/mining_main/external)
+/obj/structure/cable/heavyduty{
+	icon_state = "1-2"
+	},
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/simulated/floor/virgo3b,
+/area/tether/surfacebase/outside/outside1)
 "aak" = (
 /obj/machinery/light,
 /turf/simulated/floor/tiled/steel_dirty/virgo3b,
@@ -4085,12 +4088,17 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/mining_eva)
 "ahb" = (
-/obj/structure/catwalk,
-/obj/machinery/alarm{
-	pixel_y = 22
+/obj/machinery/power/apc{
+	dir = 2;
+	name = "south bump";
+	pixel_y = -28
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/maintenance/lower/mining_eva)
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/tiled/steel_dirty/virgo3b,
+/area/tether/surfacebase/mining_main/external)
 "ahc" = (
 /obj/machinery/portable_atmospherics/powered/scrubber/huge/stationary{
 	scrub_id = "atrium"
@@ -5212,6 +5220,18 @@
 /obj/effect/floor_decal/steeldecal/steel_decals7,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/north_stairs_one)
+"aiT" = (
+/obj/structure/cable/heavyduty{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/glass,
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/lower/mining_eva)
 "aiU" = (
 /obj/machinery/door/firedoor/glass,
 /obj/structure/disposalpipe/segment{
@@ -5717,37 +5737,27 @@
 /area/tether/surfacebase/outside/outside1)
 "ajG" = (
 /obj/structure/cable/heavyduty{
-	icon_state = "1-4"
+	icon_state = "1-2"
 	},
-/obj/structure/railing{
-	dir = 8
-	},
-/turf/simulated/floor/virgo3b,
-/area/tether/surfacebase/outside/outside1)
+/turf/simulated/floor/plating,
+/area/maintenance/lower/mining_eva)
 "ajH" = (
-/obj/structure/cable/heavyduty{
-	icon_state = "4-8"
+/obj/structure/cable/heavyduty,
+/obj/structure/cable{
+	icon_state = "0-2";
+	d2 = 2
 	},
-/obj/structure/railing{
-	dir = 1
-	},
-/turf/simulated/floor/virgo3b,
-/area/tether/surfacebase/outside/outside1)
+/turf/simulated/floor/plating,
+/area/maintenance/lower/mining_eva)
 "ajI" = (
-/obj/structure/cable/green{
-	icon_state = "0-4"
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
 	},
-/obj/structure/cable/heavyduty{
-	icon_state = "0-8"
-	},
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/structure/railing{
-	dir = 4
-	},
-/turf/simulated/floor/virgo3b,
-/area/tether/surfacebase/outside/outside1)
+/turf/simulated/floor/plating,
+/area/maintenance/lower/mining_eva)
 "ajJ" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 1
@@ -7251,6 +7261,66 @@
 	},
 /turf/simulated/floor/tiled/steel_dirty/virgo3b,
 /area/engineering/atmos/intake)
+"amW" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/alarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -22;
+	pixel_y = 0
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/lower/mining_eva)
+"amX" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/door/airlock/maintenance/common{
+	name = "Mining Maintenance Access"
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/plating,
+/area/maintenance/lower/mining_eva)
+"amY" = (
+/obj/structure/catwalk,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/lower/mining_eva)
+"amZ" = (
+/obj/structure/catwalk,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/lower/mining_eva)
+"ana" = (
+/obj/structure/catwalk,
+/obj/machinery/alarm{
+	pixel_y = 22
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/lower/mining_eva)
 "anb" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
@@ -7312,6 +7382,21 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/lower/first_west)
+"anh" = (
+/obj/structure/catwalk,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/lower/mining_eva)
 "anl" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -28073,19 +28158,6 @@
 /obj/structure/window/reinforced,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/public_garden_one)
-"kfl" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/tiled/steel_dirty/virgo3b,
-/area/tether/surfacebase/mining_main/external)
 "kfZ" = (
 /turf/simulated/wall,
 /area/crew_quarters/sleep/maintDorm2)
@@ -29510,14 +29582,6 @@
 /obj/machinery/disposal,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/atrium_one)
-"oPX" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/steel_dirty/virgo3b,
-/area/tether/surfacebase/mining_main/external)
 "oRd" = (
 /obj/structure/table/woodentable,
 /turf/simulated/floor/wood,
@@ -31486,14 +31550,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/atmos)
-"vCB" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/steel_dirty/virgo3b,
-/area/tether/surfacebase/mining_main/external)
 "vCV" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
@@ -42018,26 +42074,26 @@ aad
 aad
 aad
 aad
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
+abT
+abT
+abT
+abT
+abT
+abT
+abT
+abT
+abT
+abT
+abT
+abT
+abT
+abT
+abT
+abT
+abT
+abT
+abT
+abT
 abT
 afA
 afA
@@ -42158,30 +42214,30 @@ ajE
 ajE
 ajF
 ajC
+aaj
+aDx
+aiT
 ajG
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-abT
-afA
+ajG
+ajG
+ajG
+ajH
+ajI
+ajI
+ajI
+amW
+ajI
+ajI
+ajI
+ajI
+ajI
+ajI
+ajI
+ajI
+ajI
+ajI
+amX
+amY
 ahp
 ahX
 axw
@@ -42300,17 +42356,17 @@ aad
 aad
 aad
 aad
-ajH
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
+aad
+aad
+abT
+abT
+abT
+abT
+abT
+abT
+abT
+abT
+abT
 abT
 abT
 abT
@@ -42321,9 +42377,9 @@ aex
 aex
 aex
 aex
-aah
 abT
-afA
+abT
+amZ
 ahq
 ahX
 aiS
@@ -42442,9 +42498,9 @@ aad
 aad
 aad
 aad
-ajH
-aah
-aah
+aad
+aad
+adK
 aah
 aah
 aah
@@ -42465,7 +42521,7 @@ afX
 aex
 aah
 abT
-ahb
+ana
 ahr
 ahX
 axA
@@ -42584,8 +42640,8 @@ aad
 aFv
 aad
 aad
-ajI
-aah
+aad
+aad
 aao
 aao
 aao
@@ -42607,7 +42663,7 @@ aoY
 aex
 aah
 abT
-afA
+amZ
 ahq
 ahX
 axK
@@ -42726,7 +42782,7 @@ aae
 aae
 aae
 aae
-oPX
+aaf
 aaf
 aao
 aau
@@ -42749,7 +42805,7 @@ aoT
 aex
 aah
 abT
-afA
+amZ
 ahs
 ahZ
 aiV
@@ -42868,8 +42924,8 @@ aae
 aae
 aae
 aae
-kfl
-aaj
+aaf
+ahb
 aao
 aav
 aav
@@ -42891,7 +42947,7 @@ apj
 akz
 abT
 abT
-afA
+amZ
 ahs
 ahX
 axO
@@ -43010,8 +43066,8 @@ aae
 aae
 aae
 aae
+aaf
 aai
-vCB
 aap
 aaw
 aaB
@@ -43033,7 +43089,7 @@ apc
 aqW
 aqW
 asv
-asv
+anh
 avh
 aia
 aiX

--- a/maps/tether/tether-08-mining.dmm
+++ b/maps/tether/tether-08-mining.dmm
@@ -313,16 +313,64 @@
 	},
 /turf/simulated/floor/virgo3b,
 /area/mine/explored)
-"aR" = (
-/obj/structure/window/reinforced/full,
-/obj/machinery/door/firedoor/glass,
-/obj/structure/window/reinforced{
-	dir = 8
+"aP" = (
+/obj/machinery/atmospherics/pipe/tank/air{
+	dir = 4
 	},
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/obj/structure/cable/heavyduty{
-	icon_state = "1-2"
+/turf/simulated/floor/plating,
+/area/outpost/mining_main/maintenance)
+"aQ" = (
+/obj/machinery/atmospherics/pipe/manifold/visible/cyan{
+	dir = 1
+	},
+/obj/machinery/meter{
+	frequency = 1443;
+	id = "mair_mining_meter";
+	name = "Mixed Air Tank"
+	},
+/turf/simulated/floor/plating,
+/area/outpost/mining_main/maintenance)
+"aR" = (
+/obj/machinery/atmospherics/pipe/manifold/visible/cyan{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/outpost/mining_main/maintenance)
+"aS" = (
+/obj/machinery/camera/network/mining,
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	dir = 10
+	},
+/turf/simulated/floor/plating,
+/area/outpost/mining_main/maintenance)
+"aT" = (
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_x = 0;
+	pixel_y = 24
+	},
+/obj/structure/cable/green{
+	icon_state = "0-2"
+	},
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_x = 12;
+	pixel_y = 24
+	},
+/turf/simulated/floor/plating,
+/area/outpost/mining_main/maintenance)
+"aU" = (
+/obj/machinery/alarm{
+	pixel_y = 22
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/plating,
+/area/outpost/mining_main/maintenance)
+"aV" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/atmospherics/portables_connector{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/outpost/mining_main/maintenance)
@@ -386,6 +434,63 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/outpost/mining_main/break_room)
+"ba" = (
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/cyan,
+/turf/simulated/floor/plating,
+/area/outpost/mining_main/maintenance)
+"bb" = (
+/obj/machinery/atmospherics/omni/atmos_filter{
+	tag_east = 1;
+	tag_north = 3;
+	tag_south = 2
+	},
+/turf/simulated/floor/plating,
+/area/outpost/mining_main/maintenance)
+"bc" = (
+/obj/machinery/atmospherics/omni/atmos_filter{
+	tag_east = 1;
+	tag_north = 4;
+	tag_west = 2
+	},
+/turf/simulated/floor/plating,
+/area/outpost/mining_main/maintenance)
+"bd" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/universal{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/outpost/mining_main/maintenance)
+"be" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/visible/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/visible/scrubbers{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/outpost/mining_main/maintenance)
+"bf" = (
+/obj/machinery/atmospherics/pipe/manifold/visible/cyan,
+/turf/simulated/floor/plating,
+/area/outpost/mining_main/maintenance)
 "bg" = (
 /obj/structure/bed/chair{
 	dir = 4
@@ -447,6 +552,102 @@
 /obj/item/weapon/storage/box/donkpockets,
 /turf/simulated/floor/tiled,
 /area/outpost/mining_main/break_room)
+"bj" = (
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/red,
+/turf/simulated/floor/plating,
+/area/outpost/mining_main/maintenance)
+"bk" = (
+/obj/effect/floor_decal/industrial/outline/blue,
+/obj/machinery/atmospherics/binary/pump/on{
+	dir = 4;
+	name = "Air to Supply"
+	},
+/turf/simulated/floor/plating,
+/area/outpost/mining_main/maintenance)
+"bl" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/universal{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/outpost/mining_main/maintenance)
+"bm" = (
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1";
+	pixel_x = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/scrubbers,
+/turf/simulated/floor/plating,
+/area/outpost/mining_main/maintenance)
+"bn" = (
+/obj/machinery/atmospherics/pipe/simple/visible/red{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/outpost/mining_main/maintenance)
+"bo" = (
+/obj/machinery/atmospherics/pipe/simple/visible/red{
+	dir = 9
+	},
+/turf/simulated/floor/plating,
+/area/outpost/mining_main/maintenance)
+"bp" = (
+/turf/simulated/floor/plating,
+/area/outpost/mining_main/maintenance)
+"bq" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/outpost/mining_main/maintenance)
+"br" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/outpost/mining_main/maintenance)
+"bs" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plating,
+/area/outpost/mining_main/maintenance)
+"bt" = (
+/obj/machinery/portable_atmospherics/powered/scrubber/huge/stationary/phoronlock{
+	frequency = 1379;
+	scrub_id = "mining_outpost_airlock_scrubber";
+	scrubbing_gas = list("phoron")
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/outpost/mining_main/airlock)
+"bu" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/outpost/mining_main/maintenance)
 "bv" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -466,6 +667,22 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/outpost/mining_main/break_room)
+"bw" = (
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/terminal,
+/turf/simulated/floor/plating,
+/area/outpost/mining_main/maintenance)
+"bx" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plating,
+/area/outpost/mining_main/maintenance)
 "by" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -477,10 +694,89 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/outpost/mining_main/break_room)
+"bz" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plating,
+/area/outpost/mining_main/maintenance)
+"bA" = (
+/obj/structure/table/standard,
+/obj/item/weapon/storage/briefcase/inflatable,
+/turf/simulated/floor/plating,
+/area/outpost/mining_main/maintenance)
+"bB" = (
+/obj/structure/cable/heavyduty{
+	icon_state = "0-2"
+	},
+/obj/structure/cable,
+/turf/simulated/floor/plating,
+/area/outpost/mining_main/maintenance)
+"bC" = (
+/obj/machinery/power/breakerbox/activated{
+	RCon_tag = "Mining Outpost Substation Bypass"
+	},
+/turf/simulated/floor/plating,
+/area/outpost/mining_main/maintenance)
+"bD" = (
+/obj/machinery/power/smes/buildable{
+	charge = 0;
+	output_attempt = 0;
+	outputting = 0;
+	RCon_tag = "Substation - Mining Outpost"
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/outpost/mining_main/maintenance)
 "bE" = (
 /obj/effect/floor_decal/rust/steel_decals_rusted2,
 /turf/simulated/floor/tiled/steel_dirty/virgo3b,
 /area/mine/explored)
+"bF" = (
+/obj/machinery/power/sensor{
+	long_range = 1;
+	name = "Powernet Sensor - Mining Outpost Subgrid";
+	name_tag = "Mining Outpost Subgrid"
+	},
+/obj/structure/cable/green{
+	icon_state = "0-8"
+	},
+/obj/structure/cable/green,
+/turf/simulated/floor/plating,
+/area/outpost/mining_main/maintenance)
+"bG" = (
+/obj/machinery/telecomms/relay/preset/underdark,
+/turf/simulated/floor/plating,
+/area/outpost/mining_main/maintenance)
+"bH" = (
+/obj/machinery/telecomms/relay/preset/mining,
+/turf/simulated/floor/plating,
+/area/outpost/mining_main/maintenance)
+"bI" = (
+/obj/structure/window/reinforced/full,
+/obj/machinery/door/firedoor/glass,
+/obj/structure/grille,
+/obj/structure/window/reinforced,
+/obj/structure/cable/heavyduty{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/outpost/mining_main/maintenance)
+"bJ" = (
+/obj/machinery/atmospherics/pipe/tank/air{
+	dir = 1
+	},
+/turf/simulated/floor/bluegrid,
+/area/outpost/mining_main/airlock)
 "bW" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/brown/border,
@@ -602,32 +898,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/mining_main/break_room)
-"jq" = (
-/obj/effect/floor_decal/techfloor{
-	dir = 8
-	},
-/obj/structure/cable/green,
-/obj/structure/cable/heavyduty{
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/outpost/mining_main/maintenance)
-"jV" = (
-/obj/machinery/atmospherics/omni/atmos_filter{
-	tag_east = 1;
-	tag_north = 3;
-	tag_south = 2
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/outpost/mining_main/maintenance)
-"kc" = (
-/obj/effect/floor_decal/industrial/outline/blue,
-/obj/machinery/atmospherics/binary/pump/on{
-	dir = 4;
-	name = "Air to Supply"
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/outpost/mining_main/maintenance)
 "kB" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 10
@@ -644,97 +914,16 @@
 /obj/machinery/vending/cola,
 /turf/simulated/floor/tiled,
 /area/outpost/mining_main/break_room)
-"mH" = (
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/red,
-/turf/simulated/floor/tiled/techfloor,
-/area/outpost/mining_main/maintenance)
-"ol" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/red{
-	dir = 9
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/outpost/mining_main/maintenance)
-"om" = (
-/obj/machinery/portable_atmospherics/powered/scrubber/huge/stationary{
-	frequency = 1379;
-	scrub_id = "mining_outpost_airlock_scrubber"
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/outpost/mining_main/airlock)
-"po" = (
-/obj/structure/window/reinforced/full,
-/obj/machinery/door/firedoor/glass,
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/outpost/mining_main/maintenance)
 "qx" = (
 /obj/machinery/mech_recharger,
 /turf/simulated/floor/tiled/steel_dirty/virgo3b,
 /area/outpost/mining_main/storage)
-"rp" = (
-/obj/machinery/atmospherics/portables_connector{
-	dir = 1
-	},
-/obj/machinery/portable_atmospherics/canister/air,
-/turf/simulated/floor/bluegrid,
-/area/outpost/mining_main/airlock)
 "rH" = (
 /obj/effect/floor_decal/rust/steel_decals_rusted1{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/steel_dirty/virgo3b,
 /area/outpost/mining_main/airlock)
-"sg" = (
-/obj/machinery/atmospherics/omni/atmos_filter{
-	tag_east = 1;
-	tag_north = 4;
-	tag_west = 2
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/outpost/mining_main/maintenance)
-"si" = (
-/obj/structure/cable/green{
-	icon_state = "0-8"
-	},
-/obj/structure/cable/green{
-	icon_state = "0-4"
-	},
-/obj/machinery/power/sensor{
-	long_range = 1;
-	name = "Powernet Sensor - Mining Station";
-	name_tag = "Mining Station"
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/red{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/outpost/mining_main/maintenance)
-"so" = (
-/obj/effect/floor_decal/techfloor{
-	dir = 8
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/red{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/outpost/mining_main/maintenance)
 "tk" = (
 /obj/structure/window/reinforced/full,
 /obj/structure/window/reinforced{
@@ -776,13 +965,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/outpost/mining_main/break_room)
-"uo" = (
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/cyan,
-/turf/simulated/floor/tiled/techfloor,
-/area/outpost/mining_main/maintenance)
 "uE" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -817,24 +999,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/outpost/mining_main/airlock)
-"xA" = (
-/obj/effect/floor_decal/techfloor{
-	dir = 10
-	},
-/obj/structure/cable/heavyduty{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/outpost/mining_main/maintenance)
-"xC" = (
-/obj/effect/floor_decal/techfloor{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/tank/air{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/outpost/mining_main/maintenance)
 "BD" = (
 /obj/machinery/embedded_controller/radio/airlock/phoron{
 	id_tag = "mining_outpost_airlock";
@@ -854,21 +1018,6 @@
 	},
 /turf/simulated/floor/bluegrid,
 /area/outpost/mining_main/airlock)
-"BR" = (
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1";
-	pixel_x = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/supply{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/scrubbers,
-/obj/effect/floor_decal/techfloor{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/outpost/mining_main/maintenance)
 "Cx" = (
 /turf/simulated/mineral/floor/virgo3b{
 	color = "#AAAAAA"
@@ -919,26 +1068,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/outpost/mining_main/airlock)
-"Ex" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 24
-	},
-/obj/structure/cable/green{
-	icon_state = "0-2"
-	},
-/obj/machinery/light_switch{
-	dir = 1;
-	pixel_x = 12;
-	pixel_y = 24
-	},
-/obj/effect/floor_decal/techfloor{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/outpost/mining_main/maintenance)
 "Fa" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -985,16 +1114,6 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/outpost/mining_main/break_room)
-"Fo" = (
-/obj/structure/window/reinforced/full,
-/obj/machinery/door/firedoor/glass,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/turf/simulated/floor/plating,
-/area/outpost/mining_main/maintenance)
 "Gs" = (
 /obj/machinery/power/apc{
 	dir = 1;
@@ -1007,15 +1126,6 @@
 	},
 /turf/simulated/floor/bluegrid,
 /area/outpost/mining_main/airlock)
-"Gw" = (
-/obj/machinery/atmospherics/pipe/tank/air{
-	dir = 4
-	},
-/obj/effect/floor_decal/techfloor{
-	dir = 9
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/outpost/mining_main/maintenance)
 "GU" = (
 /obj/machinery/status_display,
 /turf/simulated/wall/r_wall,
@@ -1027,14 +1137,6 @@
 /obj/structure/ore_box,
 /turf/simulated/floor/tiled/steel_dirty/virgo3b,
 /area/outpost/mining_main/storage)
-"Hl" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/outpost/mining_main/maintenance)
 "HP" = (
 /obj/effect/floor_decal/rust/steel_decals_rusted1{
 	dir = 8
@@ -1045,19 +1147,6 @@
 	},
 /turf/simulated/floor/tiled/steel_dirty/virgo3b,
 /area/outpost/mining_main/airlock)
-"HS" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/cyan,
-/turf/simulated/floor/tiled/techfloor,
-/area/outpost/mining_main/maintenance)
-"Ir" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/obj/effect/floor_decal/techfloor{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/outpost/mining_main/maintenance)
 "IA" = (
 /obj/structure/closet/firecloset,
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
@@ -1067,20 +1156,6 @@
 	},
 /turf/simulated/floor/bluegrid,
 /area/outpost/mining_main/airlock)
-"IX" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/cyan{
-	dir = 1
-	},
-/obj/machinery/meter{
-	frequency = 1443;
-	id = "mair_mining_meter";
-	name = "Mixed Air Tank"
-	},
-/obj/effect/floor_decal/techfloor{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/outpost/mining_main/maintenance)
 "IY" = (
 /obj/effect/step_trigger/teleporter/to_underdark{
 	dir = 4;
@@ -1094,31 +1169,6 @@
 /obj/structure/bed/padded,
 /turf/simulated/floor/wood,
 /area/outpost/mining_main/dorms)
-"Kj" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/universal{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/outpost/mining_main/maintenance)
-"KJ" = (
-/obj/effect/floor_decal/techfloor,
-/turf/simulated/floor/tiled/techfloor,
-/area/outpost/mining_main/maintenance)
-"KL" = (
-/obj/machinery/telecomms/relay/preset/underdark,
-/obj/effect/floor_decal/techfloor,
-/turf/simulated/floor/tiled/techfloor,
-/area/outpost/mining_main/maintenance)
 "Ma" = (
 /obj/machinery/door/airlock/mining{
 	name = "Quarters"
@@ -1137,9 +1187,6 @@
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/wood,
 /area/outpost/mining_main/dorms)
-"MV" = (
-/turf/simulated/floor/tiled/techfloor,
-/area/outpost/mining_main/maintenance)
 "Nh" = (
 /obj/structure/railing{
 	icon_state = "railing0";
@@ -1147,30 +1194,9 @@
 	},
 /turf/simulated/floor/outdoors/grass/sif/virgo3b,
 /area/mine/explored)
-"Pr" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/cyan{
-	dir = 1
-	},
-/obj/effect/floor_decal/techfloor{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/outpost/mining_main/maintenance)
 "Px" = (
 /turf/simulated/wall/r_wall,
 /area/outpost/mining_main/airlock)
-"QH" = (
-/obj/structure/window/reinforced/full,
-/obj/machinery/door/firedoor/glass,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/outpost/mining_main/maintenance)
 "QI" = (
 /obj/structure/sign/mining,
 /turf/simulated/wall/r_wall,
@@ -1194,14 +1220,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/outpost/mining_main/airlock)
-"RB" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/outpost/mining_main/maintenance)
 "Sq" = (
 /obj/structure/window/reinforced/full,
 /obj/structure/window/reinforced{
@@ -1221,34 +1239,10 @@
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
 /area/outpost/mining_main/maintenance)
-"SQ" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/visible/supply{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/visible/scrubbers{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/outpost/mining_main/maintenance)
 "SW" = (
 /obj/structure/railing,
 /turf/simulated/floor/outdoors/grass/sif/virgo3b,
 /area/mine/explored)
-"TC" = (
-/obj/machinery/camera/network/mining,
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 10
-	},
-/obj/effect/floor_decal/techfloor{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/outpost/mining_main/maintenance)
 "Uk" = (
 /turf/simulated/floor/tiled/steel_grid,
 /area/outpost/mining_main/break_room)
@@ -1280,13 +1274,6 @@
 /obj/machinery/vending/snack,
 /turf/simulated/floor/tiled,
 /area/outpost/mining_main/break_room)
-"Vk" = (
-/obj/effect/floor_decal/techfloor{
-	dir = 6
-	},
-/obj/machinery/telecomms/relay/preset/mining,
-/turf/simulated/floor/tiled/techfloor,
-/area/outpost/mining_main/maintenance)
 "VG" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -1355,24 +1342,6 @@
 /obj/structure/closet/secure_closet/miner,
 /turf/simulated/floor/tiled,
 /area/outpost/mining_main/break_room)
-"XA" = (
-/obj/structure/table/standard,
-/obj/item/weapon/storage/briefcase/inflatable,
-/obj/effect/floor_decal/techfloor{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/outpost/mining_main/maintenance)
-"XR" = (
-/obj/effect/floor_decal/techfloor{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/atmospherics/portables_connector{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/outpost/mining_main/maintenance)
 "YA" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -1389,17 +1358,6 @@
 /obj/structure/closet/secure_closet/miner,
 /turf/simulated/floor/tiled,
 /area/outpost/mining_main/break_room)
-"Zg" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/universal{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/outpost/mining_main/maintenance)
 "Zn" = (
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/borderfloorblack{
@@ -1415,16 +1373,6 @@
 /obj/machinery/meter,
 /turf/simulated/floor/tiled/dark,
 /area/outpost/mining_main/airlock)
-"Zy" = (
-/obj/machinery/alarm{
-	pixel_y = 22
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/effect/floor_decal/techfloor{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/outpost/mining_main/maintenance)
 "ZC" = (
 /obj/structure/window/reinforced/full,
 /obj/machinery/door/firedoor/glass,
@@ -3427,12 +3375,12 @@ ab
 ab
 ab
 ay
-QH
+vo
 vo
 vo
 ZC
 vo
-Fo
+vo
 ay
 ab
 ab
@@ -3569,13 +3517,13 @@ ab
 ab
 ab
 ay
-Gw
-XR
-xC
-so
-jq
-xA
-aR
+aP
+aV
+aP
+bn
+bs
+bB
+bI
 aA
 aB
 ab
@@ -3711,12 +3659,12 @@ ab
 ab
 ab
 ay
-IX
-uo
-HS
-si
-MV
-KJ
+aQ
+ba
+bf
+bn
+bu
+bC
 SF
 ab
 aF
@@ -3853,12 +3801,12 @@ ab
 ab
 ab
 ay
-Pr
-jV
-mH
-ol
-MV
-KJ
+aR
+bb
+bj
+bo
+bw
+bD
 SF
 ab
 aF
@@ -3995,12 +3943,12 @@ ab
 ab
 ab
 ay
-TC
-sg
-kc
-Hl
-MV
-KJ
+aS
+bc
+bk
+bp
+bx
+bF
 SF
 ab
 aF
@@ -4137,12 +4085,12 @@ ab
 ab
 ab
 ay
-Ex
-Kj
-Zg
-RB
-MV
-KL
+aT
+bd
+bl
+bq
+bz
+bG
 SF
 ab
 aF
@@ -4279,13 +4227,13 @@ ab
 ab
 ab
 ay
-Zy
-SQ
-BR
-Ir
-XA
-Vk
-po
+aU
+be
+bm
+br
+bA
+bH
+SF
 ab
 aF
 ab
@@ -5560,9 +5508,9 @@ ab
 ab
 ab
 Px
-om
+bt
 VG
-om
+bt
 Px
 ab
 aF
@@ -5702,9 +5650,9 @@ ab
 ab
 ab
 Px
-om
+bt
 DX
-om
+bt
 Px
 ab
 aF
@@ -6130,7 +6078,7 @@ ab
 Px
 IA
 vG
-rp
+bJ
 Px
 ab
 aF

--- a/maps/tether/tether-09-solars.dmm
+++ b/maps/tether/tether-09-solars.dmm
@@ -1174,15 +1174,16 @@
 	pixel_x = 0;
 	pixel_y = 28
 	},
-/obj/machinery/portable_atmospherics/powered/scrubber/huge/stationary{
-	frequency = 1379;
-	scrub_id = "sci_outpost_scrubber"
-	},
 /obj/structure/cable/green{
 	icon_state = "0-4"
 	},
 /obj/structure/railing{
 	dir = 4
+	},
+/obj/machinery/portable_atmospherics/powered/scrubber/huge/stationary/phoronlock{
+	frequency = 1379;
+	scrub_id = "sci_outpost_scrubber";
+	scrubbing_gas = list("phoron")
 	},
 /turf/simulated/floor/plating,
 /area/rnd/outpost/airlock)
@@ -1201,13 +1202,14 @@
 /turf/simulated/floor/tiled,
 /area/rnd/outpost/airlock)
 "cF" = (
-/obj/machinery/portable_atmospherics/powered/scrubber/huge/stationary{
-	frequency = 1379;
-	scrub_id = "sci_outpost_scrubber"
-	},
 /obj/structure/railing,
 /obj/structure/railing{
 	dir = 8
+	},
+/obj/machinery/portable_atmospherics/powered/scrubber/huge/stationary/phoronlock{
+	frequency = 1379;
+	scrub_id = "sci_outpost_scrubber";
+	scrubbing_gas = list("phoron")
 	},
 /turf/simulated/floor/plating,
 /area/rnd/outpost/airlock)
@@ -1405,15 +1407,16 @@
 /turf/simulated/floor/tiled,
 /area/rnd/outpost/eva)
 "cZ" = (
-/obj/machinery/portable_atmospherics/powered/scrubber/huge/stationary{
-	frequency = 1379;
-	scrub_id = "sci_outpost_scrubber"
-	},
 /obj/structure/railing{
 	dir = 4
 	},
 /obj/machinery/camera/network/research_outpost{
 	dir = 4
+	},
+/obj/machinery/portable_atmospherics/powered/scrubber/huge/stationary/phoronlock{
+	frequency = 1379;
+	scrub_id = "sci_outpost_scrubber";
+	scrubbing_gas = list("phoron")
 	},
 /turf/simulated/floor/plating,
 /area/rnd/outpost/airlock)
@@ -1620,12 +1623,13 @@
 /turf/simulated/floor/tiled,
 /area/rnd/outpost/eva)
 "dA" = (
-/obj/machinery/portable_atmospherics/powered/scrubber/huge/stationary{
-	frequency = 1379;
-	scrub_id = "sci_outpost_scrubber"
-	},
 /obj/structure/railing{
 	dir = 4
+	},
+/obj/machinery/portable_atmospherics/powered/scrubber/huge/stationary/phoronlock{
+	frequency = 1379;
+	scrub_id = "sci_outpost_scrubber";
+	scrubbing_gas = list("phoron")
 	},
 /turf/simulated/floor/plating,
 /area/rnd/outpost/airlock)
@@ -1655,15 +1659,16 @@
 /turf/simulated/floor/tiled,
 /area/rnd/outpost/airlock)
 "dD" = (
-/obj/machinery/portable_atmospherics/powered/scrubber/huge/stationary{
-	frequency = 1379;
-	scrub_id = "sci_outpost_scrubber"
-	},
 /obj/structure/railing{
 	dir = 1
 	},
 /obj/structure/railing{
 	dir = 8
+	},
+/obj/machinery/portable_atmospherics/powered/scrubber/huge/stationary/phoronlock{
+	frequency = 1379;
+	scrub_id = "sci_outpost_scrubber";
+	scrubbing_gas = list("phoron")
 	},
 /turf/simulated/floor/plating,
 /area/rnd/outpost/airlock)
@@ -3358,8 +3363,7 @@
 /turf/simulated/floor/tiled,
 /area/rnd/outpost)
 "gn" = (
-/obj/machinery/atmospherics/portables_connector,
-/obj/machinery/portable_atmospherics/canister/air,
+/obj/machinery/atmospherics/pipe/tank/air,
 /turf/simulated/floor,
 /area/rnd/outpost/atmos)
 "go" = (
@@ -4700,8 +4704,8 @@
 /obj/machinery/atmospherics/pipe/vent{
 	dir = 8
 	},
-/turf/simulated/floor/outdoors/grass/sif/virgo3b,
-/area/tether/outpost/solars_outside)
+/turf/simulated/floor/virgo3b,
+/area/rnd/outpost/atmos)
 "iL" = (
 /obj/machinery/door/blast/regular{
 	dir = 8;
@@ -21611,8 +21615,8 @@ gK
 gK
 gK
 gK
-ab
-ab
+gj
+gj
 jE
 jR
 ki


### PR DESCRIPTION
Mining outpost:

Backroom now uses plating instead of techfloor.
Backroom now houses a substation, with SMES and breaker box, the usual stuff.
Mining Outpost is now its own energy subgrid.
The airlock now properly uses phoronlock scrubbers.
Airlock canister is now big static one, same as station airlocks.

Research outpost:

Slightly adjusted area under external vent near atmos room to actually work.
The airlock now properly uses phoronlock scrubbers.
Airlock canister is now big static one, same as station airlocks.
Adds two pieces of lattice for symmetry near burn chamber.

Station Surface 1:

Changed maintenance near mining. Now has additional tunnel behind the substation, going to the connection point with the industrial cable.
Mining outpost industrial cable is now on Master power grid rather than Mining.

Screenshots:
Mining backroom: http://prntscr.com/oirc7r
New mining maintenance + outside: http://prntscr.com/oirdgu