### PR TITLE
Adds an OOC note to timeclock interface

### DIFF
--- a/nano/templates/timeclock_vr.tmpl
+++ b/nano/templates/timeclock_vr.tmpl
@@ -5,6 +5,7 @@
 
 <!-- Always show person's status display -->
 <div class="statusDisplay">
+	<h3><div class='notice'>OOC Note: PTO acquired is account-wide and shared across all characters. Info listed below is not IC information.</div></h3>
 	<h3>Time Off Balance for {{:config.user.name}}</h3>
 	{{props data.department_hours}}
 		<div class="line">


### PR DESCRIPTION
Particularly, about the fact that PTO is actually account-wide and its amounts is moreso OOC info than IC. because way too regularly people ICly question the fact that character who never worked other jobs has PTO from departments their alts reside in.

Appearance of the notice: http://prntscr.com/oj8wc5