### PR TITLE
Restricts random dirt spawning to plating tiles

### DIFF
--- a/code/game/turfs/simulated_vr.dm
+++ b/code/game/turfs/simulated_vr.dm
@@ -1,0 +1,5 @@
+/turf/simulated
+	can_start_dirty = FALSE	// We have enough premapped dirt where needed
+
+/turf/simulated/floor/plating
+	can_start_dirty = TRUE	// But let maints and decrepit areas have some randomness

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -1295,6 +1295,7 @@
 #include "code\game\objects\structures\stool_bed_chair_nest\stools.dm"
 #include "code\game\objects\structures\stool_bed_chair_nest\wheelchair.dm"
 #include "code\game\turfs\simulated.dm"
+#include "code\game\turfs\simulated_vr.dm"
 #include "code\game\turfs\turf.dm"
 #include "code\game\turfs\turf_changing.dm"
 #include "code\game\turfs\turf_flick_animations.dm"


### PR DESCRIPTION
Mostly because
A) We already have specific spots with mapped in dirt
B) Our map is big and rounds are long, so janitors wouldn't have a problem finding stuff to do anyway

But maint in general could use more random patches of dust so that one stays.