### PR TITLE
Request Spice

### DIFF
--- a/code/modules/admin/verbs/adminhelp_vr.dm
+++ b/code/modules/admin/verbs/adminhelp_vr.dm
@@ -1,8 +1,8 @@
-/datum/admin_help/proc/send2adminchat()	
+/datum/admin_help/proc/send2adminchat()
 	if(!config.chat_webhook_url)
 		return
 
-	var/list/adm = get_admin_counts()	
+	var/list/adm = get_admin_counts()
 	var/list/afkmins = adm["afk"]
 	var/list/allmins = adm["total"]
 
@@ -14,3 +14,23 @@
 		query_string += "&admin_number=[allmins.len]"
 		query_string += "&admin_number_afk=[afkmins.len]"
 		world.Export("[config.chat_webhook_url]?[query_string]")
+
+/client/verb/adminspice()
+	set category = "Admin"
+	set name = "Request Spice"
+
+	//handle muting and automuting
+	if(prefs.muted & MUTE_ADMINHELP)
+		to_chat(usr, "<span class='danger'>Error: You cannot request spice (muted from adminhelps).</span>")
+		return
+
+	if(alert(usr, "Are you sure you want to request the admins spice things up for you? You accept the consequences if you do.",,"No","Yes") != "No")
+		message_admins("[ADMIN_FULLMONTY(usr)] has requested the round be spiced up a little.")
+	else
+		to_chat(usr, "<span class='notice'>Spice request cancelled.</span>")
+		return
+
+	//if they requested spice, then remove spice verb temporarily to prevent spamming
+	usr.verbs -= /client/verb/adminspice
+	spawn(1200)
+		usr.verbs += /client/verb/adminspice	// 2 minute cool-down for spice request

--- a/code/modules/admin/verbs/adminhelp_vr.dm
+++ b/code/modules/admin/verbs/adminhelp_vr.dm
@@ -32,5 +32,5 @@
 
 	//if they requested spice, then remove spice verb temporarily to prevent spamming
 	usr.verbs -= /client/verb/adminspice
-	spawn(1200)
-		usr.verbs += /client/verb/adminspice	// 2 minute cool-down for spice request
+	spawn(6000)
+		usr.verbs += /client/verb/adminspice	// 10 minute cool-down for spice request


### PR DESCRIPTION
Have you been sitting in your department's foyer for 45 minutes with nothing to do? Do you want a little flavor added to the round? Are you too scared to adminhelp and go "give us something to do" because bwoink.ogg terrifies you?

If you answered 'yes' to one or more of the above questions, you may like the new verb - *Request Spice*. Available in the Admin tab (same place as Adminhelp), Request Spice will inform the admins that you want something interesting to happen- whether it's the sudden and inexplicable appearance of a giant spider in your office, a breach in a deserted room, or a visitor with critical injuries, you'll probably get something to do.

The spice button has a two minute cooldown when used, so no spammy-spammy. If you spammy-spammy anyway, expect the spice to be far too much for you.

After requesting spice, if your face and body itch as though insects were crawling over them, if your hands and feet swell dropsically, if you cannot stand the smell of food and bring it up after you have eaten it, if you feel as though you were going to be sick most of the time, if you experience weakness in the four limbs, if you have to go often to the latrine, or if your head or stomach violently ache—do not be alarmed or disturbed. All these effects are merely proofs that the spice you have requested is being delivered.

TL;DR: Bored? Now there's a button to gently nudge the admins to spice things up a little.