### PR TITLE
Replaces "Terminated" with "Dismissed" as default rank removal

### DIFF
--- a/code/game/machinery/computer/card.dm
+++ b/code/game/machinery/computer/card.dm
@@ -279,7 +279,7 @@
 
 		if ("terminate")
 			if (is_authenticated())
-				modify.assignment = "Demoted"
+				modify.assignment = "Demoted"	//VOREStation Edit
 				modify.access = list()
 
 				callHook("terminate_employee", list(modify))

--- a/code/game/machinery/computer/card.dm
+++ b/code/game/machinery/computer/card.dm
@@ -279,7 +279,7 @@
 
 		if ("terminate")
 			if (is_authenticated())
-				modify.assignment = "Terminated"
+				modify.assignment = "Demoted"
 				modify.access = list()
 
 				callHook("terminate_employee", list(modify))

--- a/code/game/machinery/computer/card.dm
+++ b/code/game/machinery/computer/card.dm
@@ -279,7 +279,7 @@
 
 		if ("terminate")
 			if (is_authenticated())
-				modify.assignment = "Demoted"	//VOREStation Edit
+				modify.assignment = "Dismissed"	//VOREStation Edit: setting adjustment
 				modify.access = list()
 
 				callHook("terminate_employee", list(modify))

--- a/code/modules/modular_computers/file_system/programs/command/card.dm
+++ b/code/modules/modular_computers/file_system/programs/command/card.dm
@@ -167,7 +167,7 @@
 				computer.proc_eject_id(user)
 		if("terminate")
 			if(computer && can_run(user, 1))
-				id_card.assignment = "Demoted"	//VOREStation Edit: setting adjustment
+				id_card.assignment = "Dismissed"	//VOREStation Edit: setting adjustment
 				id_card.access = list()
 				callHook("terminate_employee", list(id_card))
 		if("edit")

--- a/code/modules/modular_computers/file_system/programs/command/card.dm
+++ b/code/modules/modular_computers/file_system/programs/command/card.dm
@@ -167,7 +167,7 @@
 				computer.proc_eject_id(user)
 		if("terminate")
 			if(computer && can_run(user, 1))
-				id_card.assignment = "Terminated"
+				id_card.assignment = "Demoted"	//VOREStation Edit: setting adjustment
 				id_card.access = list()
 				callHook("terminate_employee", list(id_card))
 		if("edit")

--- a/nano/templates/identification_computer.tmpl
+++ b/nano/templates/identification_computer.tmpl
@@ -126,10 +126,10 @@
 				<div class='item'>
 					<div class='itemLabel'>
 					<!-- VOREStation Edit Start -->
-						Demotions:
+						Dismissals:
 					</div>
 					<div class='itemContent'>
-						{{:helper.link('Demote ' + data.target_owner, 'gear', {'choice' : 'terminate'}, data.target_rank == "Demoted" ? 'disabled' : null, data.target_rank == "Demoted" ? 'disabled' : 'linkDanger')}}
+						{{:helper.link('Dismiss ' + data.target_owner, 'gear', {'choice' : 'terminate'}, data.target_rank == "Dismissed" ? 'disabled' : null, data.target_rank == "Dismissed" ? 'disabled' : 'linkDanger')}}
 					</div>
 					<!-- VOREStation Edit End -->
 				</div>

--- a/nano/templates/identification_computer.tmpl
+++ b/nano/templates/identification_computer.tmpl
@@ -125,11 +125,13 @@
 
 				<div class='item'>
 					<div class='itemLabel'>
-						Terminations:
+					<!-- VOREStation Edit Start -->
+						Demotions:
 					</div>
 					<div class='itemContent'>
-						{{:helper.link('Terminate ' + data.target_owner, 'gear', {'choice' : 'terminate'}, data.target_rank == "Terminated" ? 'disabled' : null, data.target_rank == "Terminated" ? 'disabled' : 'linkDanger')}}
+						{{:helper.link('Demote ' + data.target_owner, 'gear', {'choice' : 'terminate'}, data.target_rank == "Demoted" ? 'disabled' : null, data.target_rank == "Demoted" ? 'disabled' : 'linkDanger')}}
 					</div>
+					<!-- VOREStation Edit End -->
 				</div>
 
 				<div class='item'>

--- a/nano/templates/mod_identification_computer.tmpl
+++ b/nano/templates/mod_identification_computer.tmpl
@@ -56,10 +56,10 @@
 	<div class='item'>
 	  <div class='itemLabel'>
 		<!-- VOREStation Edit Start -->
-		Demotions:
+		Dismissals:
 	  </div>
 	  <div class='itemContent'>
-		{{:helper.link('Demote ' + data.id_owner, 'gear', {'action' : 'terminate'}, data.id_rank == "Demoted" ? 'disabled' : null, data.id_rank == "Demoted" ? 'disabled' : 'linkDanger')}}
+		{{:helper.link('Dismiss ' + data.id_owner, 'gear', {'action' : 'terminate'}, data.id_rank == "Dismissed" ? 'disabled' : null, data.id_rank == "Dismissed" ? 'disabled' : 'linkDanger')}}
 	  </div>
 		<!-- VOREStation Edit End -->
 	</div>

--- a/nano/templates/mod_identification_computer.tmpl
+++ b/nano/templates/mod_identification_computer.tmpl
@@ -55,11 +55,13 @@
 
 	<div class='item'>
 	  <div class='itemLabel'>
-		Terminations:
+		<!-- VOREStation Edit Start -->
+		Demotions:
 	  </div>
 	  <div class='itemContent'>
-		{{:helper.link('Terminate ' + data.id_owner, 'gear', {'action' : 'terminate'}, data.id_rank == "Terminated" ? 'disabled' : null, data.id_rank == "Terminated" ? 'disabled' : 'linkDanger')}}
+		{{:helper.link('Demote ' + data.id_owner, 'gear', {'action' : 'terminate'}, data.id_rank == "Demoted" ? 'disabled' : null, data.id_rank == "Demoted" ? 'disabled' : 'linkDanger')}}
 	  </div>
+		<!-- VOREStation Edit End -->
 	</div>
 
 	<div class='item'>


### PR DESCRIPTION
Primarily because with our SOP and continuity, onstation rank removal is never actually a 'Termination', but simply a demotion for the rest of the shift. Real terminations happen much more rarely and only with admins stepping in. I think it makes sense to use a more fitting term for the 'full rank removal' that conveys better what exactly we're doing.

EDIT: On Ace's request, changed the Demoted to Dismissed. Still fits the situation well, and doesn't imply full firing nearly as much so is good.