### PR TITLE
Fixes merge errors with 6303

### DIFF
--- a/code/game/objects/mob_spawner_vr.dm
+++ b/code/game/objects/mob_spawner_vr.dm
@@ -84,7 +84,7 @@
 	if(destructible)
 		take_damage(Proj.get_structure_damage())
 
-/obj/structure/mob_spawner/proc/take_damage(var/damage)
+/obj/structure/mob_spawner/take_damage(var/damage)
 	health -= damage
 	if(health <= 0)
 		visible_message("<span class='warning'>\The [src] breaks apart!</span>")

--- a/code/modules/blob/blob.dm
+++ b/code/modules/blob/blob.dm
@@ -40,7 +40,7 @@
 	else
 		icon_state = "blob_damaged"
 
-/obj/effect/blob/proc/take_damage(var/damage)
+/obj/effect/blob/take_damage(var/damage)	// VOREStation Edit
 	health -= damage
 	if(health < 0)
 		playsound(loc, 'sound/effects/splat.ogg', 50, 1)


### PR DESCRIPTION
blob.dm was unused as a whole for Polaris, but it is still a Polaris file and we're using it, therefore //Vorestation edit.

mob_spawner_vr just needed to be updated approprietly.