### PR TITLE
Spider Rebalance

### DIFF
--- a/code/modules/mob/living/silicon/robot/drone/drone_items.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_items.dm
@@ -157,8 +157,8 @@
 	desc = "A specialized grasping tool used to preserve and manipulate organic material."
 
 	can_hold = list(
-		/obj/item/organ,
-		/obj/item/device/nif //VOREStation edit
+		/obj/item/device/nif, //VOREStation edit,
+		/obj/item/organ
 		)
 
 /obj/item/weapon/gripper/no_use/organ/Entered(var/atom/movable/AM)
@@ -183,11 +183,11 @@
 	desc = "A specialized grasping tool used in robotics work."
 
 	can_hold = list(
+		/obj/item/device/nif, //VOREStation edit,
 		/obj/item/organ/external,
 		/obj/item/organ/internal/brain, //to insert into MMIs,
 		/obj/item/organ/internal/cell,
-		/obj/item/organ/internal/eyes/robot,
-		/obj/item/device/nif //VOREStation edit
+		/obj/item/organ/internal/eyes/robot
 		)
 
 /obj/item/weapon/gripper/no_use/mech

--- a/code/modules/mob/living/silicon/robot/drone/drone_items.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_items.dm
@@ -158,7 +158,7 @@
 
 	can_hold = list(
 		/obj/item/organ,
-		/obj/item/device/nif
+		/obj/item/device/nif //VOREStation edit
 		)
 
 /obj/item/weapon/gripper/no_use/organ/Entered(var/atom/movable/AM)
@@ -187,7 +187,7 @@
 		/obj/item/organ/internal/brain, //to insert into MMIs,
 		/obj/item/organ/internal/cell,
 		/obj/item/organ/internal/eyes/robot,
-		/obj/item/device/nif
+		/obj/item/device/nif //VOREStation edit
 		)
 
 /obj/item/weapon/gripper/no_use/mech

--- a/code/modules/mob/living/silicon/robot/drone/drone_items.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_items.dm
@@ -157,7 +157,8 @@
 	desc = "A specialized grasping tool used to preserve and manipulate organic material."
 
 	can_hold = list(
-		/obj/item/organ
+		/obj/item/organ,
+		/obj/item/device/nif
 		)
 
 /obj/item/weapon/gripper/no_use/organ/Entered(var/atom/movable/AM)
@@ -185,7 +186,8 @@
 		/obj/item/organ/external,
 		/obj/item/organ/internal/brain, //to insert into MMIs,
 		/obj/item/organ/internal/cell,
-		/obj/item/organ/internal/eyes/robot
+		/obj/item/organ/internal/eyes/robot,
+		/obj/item/device/nif
 		)
 
 /obj/item/weapon/gripper/no_use/mech

--- a/code/modules/mob/living/silicon/robot/drone/drone_items.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_items.dm
@@ -157,7 +157,6 @@
 	desc = "A specialized grasping tool used to preserve and manipulate organic material."
 
 	can_hold = list(
-		/obj/item/device/nif, //VOREStation edit,
 		/obj/item/organ
 		)
 
@@ -183,7 +182,6 @@
 	desc = "A specialized grasping tool used in robotics work."
 
 	can_hold = list(
-		/obj/item/device/nif, //VOREStation edit,
 		/obj/item/organ/external,
 		/obj/item/organ/internal/brain, //to insert into MMIs,
 		/obj/item/organ/internal/cell,

--- a/code/modules/mob/living/simple_mob/subtypes/animal/giant_spider/_giant_spider.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/giant_spider/_giant_spider.dm
@@ -70,8 +70,8 @@
 	has_eye_glow = TRUE
 
 	faction = "spiders"
-	maxHealth = 200
-	health = 200
+	maxHealth = 120 //VOREStation edit
+	health = 120 //VOREStation edit
 	pass_flags = PASSTABLE
 	movement_cooldown = 10
 	poison_resist = 0.5

--- a/code/modules/mob/living/simple_mob/subtypes/animal/giant_spider/carrier.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/giant_spider/carrier.dm
@@ -20,8 +20,8 @@
 	icon_living = "carrier"
 	icon_dead = "carrier_dead"
 
-	maxHealth = 100
-	health = 100
+	maxHealth = 60 //VOREStation edit
+	health = 60 //VOREStation edit
 
 	melee_damage_lower = 8
 	melee_damage_upper = 25

--- a/code/modules/mob/living/simple_mob/subtypes/animal/giant_spider/electric.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/giant_spider/electric.dm
@@ -25,8 +25,8 @@
 	icon_living = "spark"
 	icon_dead = "spark_dead"
 
-	maxHealth = 210
-	health = 210
+	maxHealth = 120 //VOREStation edit
+	health = 120 //VOREStation edit
 
 	taser_kill = 0 //It -is- the taser.
 

--- a/code/modules/mob/living/simple_mob/subtypes/animal/giant_spider/frost.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/giant_spider/frost.dm
@@ -23,8 +23,8 @@
 	icon_living = "frost"
 	icon_dead = "frost_dead"
 
-	maxHealth = 175
-	health = 175
+	maxHealth = 110 //VOREStation edit
+	health = 110 //VOREStation edit
 
 	poison_per_bite = 5
 	poison_type = "cryotoxin"

--- a/code/modules/mob/living/simple_mob/subtypes/animal/giant_spider/giant_spider_vr.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/giant_spider/giant_spider_vr.dm
@@ -1,17 +1,17 @@
 // Slightly placeholder, mostly to replace ion hivebots on V4
-/mob/living/simple_mob/animal/giant_spider/ion
-	desc = "Furry and green, it makes you shudder to look at it. This one has brilliant green eyes and a hint of static discharge."
-	tt_desc = "X Brachypelma phorus ionus"
+/mob/living/simple_mob/animal/giant_spider/ion //Used to shoot ions, now shoots lasers.
+	desc = "Furry and green, it makes you shudder to look at it. This one has brilliant green eyes and a hint of photonic discharge."
+	tt_desc = "X Brachypelma phorus photonus"
 	icon_state = "webslinger"
 	icon_living = "webslinger"
 	icon_dead = "webslinger_dead"
 
-	maxHealth = 90
-	health = 90
+	maxHealth = 60
+	health = 60
 
 	base_attack_cooldown = 10
 	projectilesound = 'sound/weapons/taser2.ogg'
-	projectiletype = /obj/item/projectile/ion/small
+	projectiletype = /obj/item/projectile/beam/weaklaser
 
 	melee_damage_lower = 8
 	melee_damage_upper = 15
@@ -32,8 +32,8 @@
 	icon_living = "spider_queen"
 	icon_dead = "spider_queen_dead"
 
-	maxHealth = 320
-	health = 320
+	maxHealth = 250
+	health = 250
 
 	melee_damage_lower = 20
 	melee_damage_upper = 30

--- a/code/modules/mob/living/simple_mob/subtypes/animal/giant_spider/giant_spider_vr.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/giant_spider/giant_spider_vr.dm
@@ -1,7 +1,7 @@
 // Slightly placeholder, mostly to replace ion hivebots on V4
 /mob/living/simple_mob/animal/giant_spider/ion //Used to shoot ions, now shoots lasers.
-	desc = "Furry and green, it makes you shudder to look at it. This one has brilliant green eyes and a hint of photonic discharge."
-	tt_desc = "X Brachypelma phorus photonus"
+	desc = "Furry and green, it makes you shudder to look at it. This one has brilliant green eyes and a hint of static discharge."
+	tt_desc = "X Brachypelma phorus ionus"
 	icon_state = "webslinger"
 	icon_living = "webslinger"
 	icon_dead = "webslinger_dead"
@@ -11,7 +11,7 @@
 
 	base_attack_cooldown = 10
 	projectilesound = 'sound/weapons/taser2.ogg'
-	projectiletype = /obj/item/projectile/beam/weaklaser
+	projectiletype = /obj/item/projectile/ion/small //Needs rebalancing- OHKOs synths.
 
 	melee_damage_lower = 8
 	melee_damage_upper = 15

--- a/code/modules/mob/living/simple_mob/subtypes/animal/giant_spider/giant_spider_vr.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/giant_spider/giant_spider_vr.dm
@@ -1,5 +1,5 @@
 // Slightly placeholder, mostly to replace ion hivebots on V4
-/mob/living/simple_mob/animal/giant_spider/ion //Used to shoot ions, now shoots lasers.
+/mob/living/simple_mob/animal/giant_spider/ion
 	desc = "Furry and green, it makes you shudder to look at it. This one has brilliant green eyes and a hint of static discharge."
 	tt_desc = "X Brachypelma phorus ionus"
 	icon_state = "webslinger"
@@ -11,7 +11,7 @@
 
 	base_attack_cooldown = 10
 	projectilesound = 'sound/weapons/taser2.ogg'
-	projectiletype = /obj/item/projectile/ion/small //Needs rebalancing- OHKOs synths.
+	projectiletype = /obj/item/projectile/ion/small
 
 	melee_damage_lower = 8
 	melee_damage_upper = 15

--- a/code/modules/mob/living/simple_mob/subtypes/animal/giant_spider/hunter.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/giant_spider/hunter.dm
@@ -23,8 +23,8 @@
 	icon_living = "hunter"
 	icon_dead = "hunter_dead"
 
-	maxHealth = 120
-	health = 120
+	maxHealth = 75 //VOREStation edit
+	health = 75 //VOREStation edit
 
 	poison_per_bite = 5
 	melee_damage_lower = 9

--- a/code/modules/mob/living/simple_mob/subtypes/animal/giant_spider/hunter.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/giant_spider/hunter.dm
@@ -23,8 +23,8 @@
 	icon_living = "hunter"
 	icon_dead = "hunter_dead"
 
-	maxHealth = 75 //VOREStation edit
-	health = 75 //VOREStation edit
+	maxHealth = 60 //VOREStation edit
+	health = 60 //VOREStation edit
 
 	poison_per_bite = 5
 	melee_damage_lower = 9

--- a/code/modules/mob/living/simple_mob/subtypes/animal/giant_spider/lurker.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/giant_spider/lurker.dm
@@ -28,8 +28,8 @@
 	icon_living = "lurker"
 	icon_dead = "lurker_dead"
 
-	maxHealth = 100
-	health = 100
+	maxHealth = 60 //VOREStation edit
+	health = 60 //VOREStation edit
 
 	poison_per_bite = 5
 

--- a/code/modules/mob/living/simple_mob/subtypes/animal/giant_spider/nurse.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/giant_spider/nurse.dm
@@ -30,8 +30,8 @@
 	icon_living = "nurse"
 	icon_dead = "nurse_dead"
 
-	maxHealth = 40
-	health = 40
+	maxHealth = 30 //VOREStation edit
+	health = 30 //VOREStation edit
 
 	movement_cooldown = 5	// A bit faster so that they can inject the eggs easier.
 

--- a/code/modules/mob/living/simple_mob/subtypes/animal/giant_spider/pepper.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/giant_spider/pepper.dm
@@ -19,8 +19,8 @@
 	icon_living = "pepper"
 	icon_dead = "pepper_dead"
 
-	maxHealth = 210
-	health = 210
+	maxHealth = 120 //VOREStation edit
+	health = 120 //VOREStation edit
 
 	melee_damage_lower = 8
 	melee_damage_upper = 15

--- a/code/modules/mob/living/simple_mob/subtypes/animal/giant_spider/phorogenic.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/giant_spider/phorogenic.dm
@@ -31,8 +31,8 @@
 	icon_living = "phoron"
 	icon_dead = "phoron_dead"
 
-	maxHealth = 225
-	health = 225
+	maxHealth = 135 //VOREStation edit
+	health = 135 //VOREStation edit
 	taser_kill = FALSE //You will need more than a peashooter to kill the juggernaut.
 
 	melee_damage_lower = 25

--- a/code/modules/mob/living/simple_mob/subtypes/animal/giant_spider/phorogenic.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/giant_spider/phorogenic.dm
@@ -31,8 +31,8 @@
 	icon_living = "phoron"
 	icon_dead = "phoron_dead"
 
-	maxHealth = 135 //VOREStation edit
-	health = 135 //VOREStation edit
+	maxHealth = 120 //VOREStation edit
+	health = 120 //VOREStation edit
 	taser_kill = FALSE //You will need more than a peashooter to kill the juggernaut.
 
 	melee_damage_lower = 25

--- a/code/modules/mob/living/simple_mob/subtypes/animal/giant_spider/thermic.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/giant_spider/thermic.dm
@@ -23,8 +23,8 @@
 	icon_living = "pit"
 	icon_dead = "pit_dead"
 
-	maxHealth = 175
-	health = 175
+	maxHealth = 110 //VOREStation edit
+	health = 110 //VOREStation edit
 
 	melee_damage_lower = 10
 	melee_damage_upper = 25

--- a/code/modules/mob/living/simple_mob/subtypes/animal/giant_spider/tunneler.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/giant_spider/tunneler.dm
@@ -32,8 +32,8 @@
 	icon_living = "tunneler"
 	icon_dead = "tunneler_dead"
 
-	maxHealth = 120
-	health = 120
+	maxHealth = 75 //VOREStation edit
+	health = 75 //VOREStation edit
 
 	melee_damage_lower = 10
 	melee_damage_upper = 10

--- a/code/modules/mob/living/simple_mob/subtypes/animal/giant_spider/tunneler.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/giant_spider/tunneler.dm
@@ -32,8 +32,8 @@
 	icon_living = "tunneler"
 	icon_dead = "tunneler_dead"
 
-	maxHealth = 75 //VOREStation edit
-	health = 75 //VOREStation edit
+	maxHealth = 60 //VOREStation edit
+	health = 60 //VOREStation edit
 
 	melee_damage_lower = 10
 	melee_damage_upper = 10

--- a/code/modules/mob/living/simple_mob/subtypes/animal/giant_spider/webslinger.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/giant_spider/webslinger.dm
@@ -22,8 +22,8 @@
 	icon_state = "webslinger"
 	icon_living = "webslinger"
 	icon_dead = "webslinger_dead"
-	maxHealth = 90
-	health = 90
+	maxHealth = 60 //VOREStation edit
+	health = 60 //VOREStation edit
 	projectilesound = 'sound/weapons/thudswoosh.ogg'
 	projectiletype = /obj/item/projectile/webball
 	base_attack_cooldown = 10


### PR DESCRIPTION
So you know how giant spiders are Polaris mobs, right?
And you know how Polaris has special guns that deal a shitton of damage to giant spiders (50-75), that all explorers get?
And you know how we don't have those guns, and we have frontier phasers instead, that don't do a shitton of damage to giant spiders?

Yeah, as a result, the TTK on giant spiders is way too long, and since they usually have super cool abilities, they end up wrecking folks way more than they're intended to. (Oh, and being bullet sponges.)

This PR reduces the health of all giant spiders to 60% of their original values. It doesn't change the damage on the frontier phasers, but you should find your TTK is about the same as Polaris.

Also, those ion spiders that oneshot synth explorers and destroy borgs? They fire lasers now. Still dangerous, but not as obnoxious.

~~(Also, unrelated but requested- organ grippers can now hold NIFs. Surgery/science borgs, you're welcome.)~~ never mind it still wouldn't let them implant it because cavity implant surgery does not like grippers