### PR TITLE
Fixes synth legs being broken causing feedback loop

### DIFF
--- a/code/modules/mob/living/carbon/human/human_organs.dm
+++ b/code/modules/mob/living/carbon/human/human_organs.dm
@@ -86,7 +86,7 @@
 		var/obj/item/organ/external/E = organs_by_name[limb_tag]
 		if(!E || !E.is_usable())
 			stance_damage += 2 // let it fail even if just foot&leg
-		else if (E.is_malfunctioning())
+		else if (E.is_malfunctioning() && !(lying || resting))	//VOREStation Edit: no sparking/falling for synths with legs manually off
 			//malfunctioning only happens intermittently so treat it as a missing limb when it procs
 			stance_damage += 2
 			if(isturf(loc) && prob(10))


### PR DESCRIPTION
Including sparking regardless of resting and never being able to get up. Possibly intentional originally, but its stupid for us, especially with phoronlocks being a thing.

Now resting now properly prevents any sparks from generating because of broken synth legs and will make usage of airlocks safe assuming you rest while the cycling process is happening (which you probably should regardless if you are being rescued by someone else)