### PR TITLE
Fixes tram not killing people who jump off it while its moving

### DIFF
--- a/maps/tether/submaps/tether_misc.dmm
+++ b/maps/tether/submaps/tether_misc.dmm
@@ -61,23 +61,20 @@
 /turf/simulated/shuttle/floor/black,
 /area/shuttle/trade/centcom)
 "ai" = (
-/obj/machinery/power/emitter/gyrotron/anchored{
-	desc = "It is a heavy duty pulse laser emitter.";
-	dir = 8;
-	icon_state = "emitter-off";
-	name = "pulse laser"
+/obj/effect/floor_decal/transit/orange{
+	dir = 8
 	},
-/turf/space,
-/turf/simulated/shuttle/plating/airless/carry,
-/area/syndicate_station/start)
+/obj/effect/step_trigger/lost_in_space/tram,
+/turf/unsimulated/floor/techfloor_grid{
+	icon = 'icons/turf/transit_vr.dmi'
+	},
+/area/centcom/ferry)
 "aj" = (
-/obj/structure/shuttle/engine/propulsion{
-	icon_state = "propulsion_r";
-	dir = 4
+/obj/effect/step_trigger/lost_in_space/tram,
+/turf/unsimulated/floor/techfloor_grid{
+	icon = 'icons/turf/transit_vr.dmi'
 	},
-/turf/space,
-/turf/simulated/shuttle/plating/airless/carry,
-/area/syndicate_station/start)
+/area/centcom/ferry)
 "ak" = (
 /obj/machinery/fitness/heavy/lifter,
 /obj/effect/floor_decal/steeldecal/steel_decals10{
@@ -91,12 +88,11 @@
 	},
 /area/antag/antag_base)
 "al" = (
-/obj/structure/shuttle/engine/propulsion{
-	dir = 4
+/obj/effect/step_trigger/lost_in_space/tram,
+/turf/unsimulated/floor/maglev{
+	icon = 'icons/turf/transit_vr.dmi'
 	},
-/turf/space,
-/turf/simulated/shuttle/plating/airless/carry,
-/area/syndicate_station/start)
+/area/centcom/ferry)
 "am" = (
 /obj/machinery/door/airlock/glass_external{
 	frequency = 1380;
@@ -1625,8 +1621,27 @@
 /turf/simulated/floor/holofloor/tiled/dark,
 /area/holodeck/source_boxingcourt)
 "dZ" = (
+/obj/effect/floor_decal/transit/orange{
+	dir = 4
+	},
+/obj/effect/step_trigger/lost_in_space/tram,
+/turf/unsimulated/floor/techfloor_grid{
+	icon = 'icons/turf/transit_vr.dmi'
+	},
+/area/centcom/ferry)
+"ea" = (
+/obj/machinery/power/emitter/gyrotron/anchored{
+	desc = "It is a heavy duty pulse laser emitter.";
+	dir = 8;
+	icon_state = "emitter-off";
+	name = "pulse laser"
+	},
+/turf/space,
+/turf/simulated/shuttle/plating/airless/carry,
+/area/syndicate_station/start)
+"eb" = (
 /obj/structure/shuttle/engine/propulsion{
-	icon_state = "propulsion_l";
+	icon_state = "propulsion_r";
 	dir = 4
 	},
 /turf/space,
@@ -1844,6 +1859,13 @@
 /obj/structure/sign/department/operational,
 /turf/simulated/shuttle/wall/dark,
 /area/syndicate_station/start)
+"eG" = (
+/obj/structure/shuttle/engine/propulsion{
+	dir = 4
+	},
+/turf/space,
+/turf/simulated/shuttle/plating/airless/carry,
+/area/syndicate_station/start)
 "eH" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -2043,6 +2065,14 @@
 	dir = 4
 	},
 /turf/simulated/shuttle/plating/airless,
+/area/syndicate_station/start)
+"fl" = (
+/obj/structure/shuttle/engine/propulsion{
+	icon_state = "propulsion_l";
+	dir = 4
+	},
+/turf/space,
+/turf/simulated/shuttle/plating/airless/carry,
 /area/syndicate_station/start)
 "fm" = (
 /obj/item/device/radio/intercom{
@@ -11082,7 +11112,7 @@ hm
 hv
 hm
 hm
-hm
+ai
 mu
 ap
 mv
@@ -11224,7 +11254,7 @@ hn
 hn
 hn
 hn
-hn
+aj
 gX
 ap
 mv
@@ -11366,7 +11396,7 @@ ho
 ho
 ho
 ho
-ho
+al
 gX
 ap
 mv
@@ -11508,7 +11538,7 @@ hn
 hn
 hn
 hn
-hn
+aj
 gX
 ap
 mv
@@ -11650,7 +11680,7 @@ hn
 hn
 hn
 hn
-hn
+aj
 gX
 ap
 mv
@@ -11792,7 +11822,7 @@ hn
 hn
 hn
 hn
-hn
+aj
 gX
 ap
 mv
@@ -11934,7 +11964,7 @@ hn
 hn
 hn
 hn
-hn
+aj
 gX
 ap
 mv
@@ -12076,7 +12106,7 @@ ho
 ho
 ho
 ho
-ho
+al
 gX
 ap
 mv
@@ -12218,7 +12248,7 @@ hn
 hn
 hn
 hn
-hn
+aj
 gX
 ap
 mv
@@ -12360,7 +12390,7 @@ hp
 hp
 hI
 hp
-hp
+dZ
 gX
 ap
 mv
@@ -25295,7 +25325,7 @@ ap
 ap
 ap
 aC
-ai
+ea
 aC
 ap
 hb
@@ -25304,7 +25334,7 @@ gL
 ik
 ap
 aC
-ai
+ea
 aC
 ap
 ap
@@ -29132,10 +29162,10 @@ aC
 aC
 cJ
 fk
-aj
-al
-al
-dZ
+eb
+eG
+eG
+fl
 fk
 cJ
 aC
@@ -29273,12 +29303,12 @@ aC
 aC
 cJ
 fk
-aj
+eb
 ap
 ap
 ap
 ap
-dZ
+fl
 fk
 cJ
 aC
@@ -29414,14 +29444,14 @@ aC
 aC
 aC
 fk
-aj
+eb
 ap
 ap
 ap
 ap
 ap
 ap
-dZ
+fl
 fk
 aC
 aC
@@ -29555,7 +29585,7 @@ ap
 ap
 aC
 cJ
-aj
+eb
 ap
 ap
 ap
@@ -29564,7 +29594,7 @@ ap
 ap
 ap
 ap
-dZ
+fl
 cJ
 aC
 ap

--- a/maps/tether/tether_things.dm
+++ b/maps/tether/tether_things.dm
@@ -134,6 +134,9 @@
 	else
 		return ..()
 
+/obj/effect/step_trigger/lost_in_space/tram
+	deathmessage = "You fly down the tunnel of the tram at high speed for a few moments before impact kills you with sheer concussive force."
+
 
 // Invisible object that blocks z transfer to/from its turf and the turf above.
 /obj/effect/ceiling


### PR DESCRIPTION
Aparently kill switches were there before but got lost? Either way they are back in appropriate place.