### PR TITLE
Adds quick wiki links to species pages

### DIFF
--- a/code/modules/client/preference_setup/general/03_body.dm
+++ b/code/modules/client/preference_setup/general/03_body.dm
@@ -818,7 +818,12 @@ var/global/list/valid_bloodtypes = list("A+", "A-", "B+", "B-", "AB+", "AB-", "O
 	dat += "<center><h2>[current_species.name] \[<a href='?src=\ref[src];show_species=1'>change</a>\]</h2></center><hr/>"
 	dat += "<table padding='8px'>"
 	dat += "<tr>"
-	dat += "<td width = 400>[current_species.blurb]</td>"
+	//vorestation edit begin
+	if(current_species.wikilink)
+		dat += "<td width = 400>[current_species.blurb]<br><br>See <a href=[current_species.wikilink]>the wiki</a> for more details.</td>"
+	else
+		dat += "<td width = 400>[current_species.blurb]</td>"
+	//vorestation edit end
 	dat += "<td width = 200 align='center'>"
 	if("preview" in icon_states(current_species.icobase))
 		usr << browse_rsc(icon(current_species.icobase,"preview"), "species_preview_[current_species.name].png")

--- a/code/modules/mob/living/carbon/human/species/species_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/species_vr.dm
@@ -17,6 +17,7 @@
 	var/wing
 	var/wing_animation
 	var/icobase_wing
+	var/wikilink = null //link to wiki page for species
 
 /datum/species/proc/update_attack_types()
 	unarmed_attacks = list()

--- a/code/modules/mob/living/carbon/human/species/station/station_special_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_special_vr.dm
@@ -41,6 +41,9 @@
 	blurb = "Some amalgamation of different species from across the universe,with extremely unstable DNA, making them unfit for regular cloners. \
 	Widely known for their voracious nature and violent tendencies when stressed or left unfed for long periods of time. \
 	Most, if not all chimeras possess the ability to undergo some type of regeneration process, at the cost of energy."
+
+	wikilink = "https://wiki.vore-station.net/Xenochimera"
+
 	catalogue_data = list(/datum/category_item/catalogue/fauna/xenochimera)
 
 	hazard_low_pressure = -1 //Prevents them from dying normally in space. Special code handled below.
@@ -342,6 +345,9 @@
 	from their mandible lined mouths.  They are a recent discovery by Nanotrasen, only being discovered roughly seven years ago.  \
 	Before they were found they built great cities out of their silk, being united and subjugated in warring factions under great Star Queens  \
 	Who forced the working class to build huge, towering cities to attempt to reach the stars, which they worship as gems of great spiritual and magical significance."
+
+	wikilink = "https://wiki.vore-station.net/Vasilissans"
+
 	catalogue_data = list(/datum/category_item/catalogue/fauna/vasilissan)
 
 	hazard_low_pressure = 20 //Prevents them from dying normally in space. Special code handled below.

--- a/code/modules/mob/living/carbon/human/species/station/station_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_vr.dm
@@ -27,6 +27,9 @@
 	racial tensions which has resulted in more than a number of wars and outright attempts at genocide. Sergals have an incredibly long \
 	lifespan, but due to their lust for violence, only a handful have ever survived beyond the age of 80, such as the infamous and \
 	legendary General Rain Silves who is claimed to have lived to 5000."
+
+	wikilink="https://wiki.vore-station.net/Backstory#Sergal"
+
 	catalogue_data = list(/datum/category_item/catalogue/fauna/sergal)
 
 	primitive_form = "Saru"
@@ -88,6 +91,9 @@
 	allies over the next few hundred years. With the help of Skrellean technology, the Akula had their genome modified to be capable of \
 	surviving in open air for long periods of time. However, Akula even today still require a high humidity environment to avoid drying out \
 	after a few days, which would make life on an arid world like Virgo-Prime nearly impossible if it were not for Skrellean technology to aid them."
+
+	wikilink="https://wiki.vore-station.net/Backstory#Akula"
+
 	catalogue_data = list(/datum/category_item/catalogue/fauna/akula)
 
 	primitive_form = "Sobaka"
@@ -129,6 +135,9 @@
 	intelligence and very skillful hands that are put use for constructing precision instruments, but tire-out fast when repeatedly working \
 	over and over again. Consequently, they struggle to make copies of same things. Both genders have a voice that echoes a lot. Their natural \
 	tone oscillates between tenor and soprano. They are excessively noisy when they quarrel in their native language."
+
+	wikilink="https://wiki.vore-station.net/Backstory#Nevrean"
+
 	catalogue_data = list(/datum/category_item/catalogue/fauna/nevrean)
 
 	primitive_form = "Sparra"
@@ -168,6 +177,8 @@
 	mountainous areas, they have a differing societal structure than the Flatland Zorren having a more feudal social structure, like the Flatland Zorren, \
 	the Highland Zorren have also only recently been hired by the Trans-Stellar Corporations, but thanks to the different social structure they seem to \
 	have adjusted better to their new lives. Though similar fox-like beings have been seen they are different than the Zorren."
+	wikilink="https://wiki.vore-station.net/Zorren"
+
 	catalogue_data = list(/datum/category_item/catalogue/fauna/zorren,
 						/datum/category_item/catalogue/fauna/highzorren)
 
@@ -210,6 +221,8 @@
 	mountainous areas, they have a differing societal structure than the Flatland Zorren having a more feudal social structure, like the Flatland Zorren, \
 	the Highland Zorren have also only recently been hired by the Trans-Stellar Corporations, but thanks to the different social structure they \
 	seem to have adjusted better to their new lives. Though similar fox-like beings have been seen they are different than the Zorren."
+	wikilink="https://wiki.vore-station.net/Zorren"
+
 	catalogue_data = list(/datum/category_item/catalogue/fauna/zorren,
 						/datum/category_item/catalogue/fauna/flatzorren)
 
@@ -254,6 +267,9 @@
 	culture both feared and respected for their scientific breakthroughs. Discovery, loyalty, and utilitarianism dominates their lifestyles \
 	to the degree it can cause conflict with more rigorous and strict authorities. They speak a guttural language known as 'Canilunzt' \
     which has a heavy emphasis on utilizing tail positioning and ear twitches to communicate intent."
+
+	wikilink="https://wiki.vore-station.net/Backstory#Vulpkanin"
+
 	catalogue_data = list(/datum/category_item/catalogue/fauna/vulpkanin)
 
 	primitive_form = "Wolpin"
@@ -288,6 +304,7 @@
 	but there are multiple exceptions. All xenomorph hybrids have had their ability to lay eggs containing facehuggers \
 	removed if they had the ability to, although hybrids that previously contained this ability is extremely rare."
 	catalogue_data = list(/datum/category_item/catalogue/fauna/xenohybrid)
+	// No wiki page for xenohybrids at present
 
 	//primitive_form = "" //None for these guys
 
@@ -315,6 +332,7 @@
 	gluttonous = 0
 	inherent_verbs = list(/mob/living/proc/shred_limb)
 	descriptors = list()
+	wikilink="https://wiki.vore-station.net/Unathi"
 
 /datum/species/tajaran
 	spawn_flags = SPECIES_CAN_JOIN
@@ -326,6 +344,7 @@
 	gluttonous = 0 //Moving this here so I don't have to fix this conflict every time polaris glances at station.dm
 	inherent_verbs = list(/mob/living/proc/shred_limb, /mob/living/carbon/human/proc/lick_wounds)
 	heat_discomfort_level = 295 //Prevents heat discomfort spam at 20c
+	wikilink="https://wiki.vore-station.net/Tajaran"
 
 /datum/species/skrell
 	spawn_flags = SPECIES_CAN_JOIN
@@ -335,12 +354,14 @@
 	min_age = 18
 	reagent_tag = null
 	assisted_langs = list(LANGUAGE_EAL, LANGUAGE_ROOTLOCAL, LANGUAGE_ROOTGLOBAL, LANGUAGE_VOX)
+	wikilink="https://wiki.vore-station.net/Skrell"
 
 /datum/species/zaddat
 	spawn_flags = SPECIES_CAN_JOIN
 	min_age = 18
 	gluttonous = 0
 	descriptors = list()
+	// no wiki link exists for Zaddat yet
 
 /datum/species/zaddat/equip_survival_gear(var/mob/living/carbon/human/H)
 	.=..()
@@ -353,6 +374,7 @@
 /datum/species/diona
 	spawn_flags = SPECIES_CAN_JOIN | SPECIES_IS_WHITELISTED
 	min_age = 18
+	wikilink="https://wiki.vore-station.net/Diona"
 
 /datum/species/teshari
 	mob_size = MOB_MEDIUM
@@ -366,6 +388,7 @@
 	swap_flags = ~HEAVY
 	gluttonous = 0
 	descriptors = list()
+	wikilink="https://wiki.vore-station.net/Teshari"
 
 	inherent_verbs = list(
 		/mob/living/carbon/human/proc/sonar_ping,
@@ -376,6 +399,7 @@
 
 /datum/species/shapeshifter/promethean
 	spawn_flags = SPECIES_CAN_JOIN
+	wikilink="https://wiki.vore-station.net/Promethean"
 
 /datum/species/human
 	color_mult = 1
@@ -384,6 +408,7 @@
 	appearance_flags = HAS_HAIR_COLOR | HAS_SKIN_COLOR | HAS_LIPS | HAS_UNDERWEAR | HAS_EYE_COLOR
 	min_age = 18
 	base_color = "#EECEB3"
+	wikilink="https://wiki.vore-station.net/Human"
 
 /datum/species/vox
 	gluttonous = 0
@@ -395,6 +420,7 @@
 	descriptors = list(
 		/datum/mob_descriptor/vox_markings = 0
 		)
+	wikilink="https://wiki.vore-station.net/Vox"
 
 datum/species/harpy
 	name = SPECIES_RAPALA
@@ -419,6 +445,9 @@ datum/species/harpy
 	Sol researchers have commented on them having a very close resemblance to the mythical race called 'Harpies',\
 	who are known for having massive winged arms and talons as feet. They've been clocked at speeds of over 35 miler per hour chasing the planet's many fish-like fauna.\
 	The Rapalan's home-world 'Verita' is a strangely habitable gas giant, while no physical earth exists, there are fertile floating islands orbiting around the planet from past asteroid activity."
+
+	wikilink="https://wiki.vore-station.net/Backstory#Rapala"
+
 	catalogue_data = list(/datum/category_item/catalogue/fauna/rapala)
 
 	spawn_flags = SPECIES_CAN_JOIN


### PR DESCRIPTION
fixes #1336.

Species datums now have a wikilink var that'll take you to whatever wiki page is most appropriate for them. Those without any pages have been linked to the appropriate part of the backstory page.

At the moment it only opens it in the same page as the species selection thingy, because byond is absolutely awful and trying to craft a topic() link or whatever the hell it is I need to do to open it all nice-like in the user's browser made my brain melt.

It could be niced-up a bit by pointing it at the config and having it concatenate the config wiki and the species link but it works.