### PR TITLE
Suit Sensors Selectable

### DIFF
--- a/code/_helpers/global_lists_vr.dm
+++ b/code/_helpers/global_lists_vr.dm
@@ -11,6 +11,8 @@ var/global/list/positive_traits = list()	// Positive custom species traits, inde
 var/global/list/traits_costs = list()		// Just path = cost list, saves time in char setup
 var/global/list/all_traits = list()			// All of 'em at once (same instances)
 
+var/global/list/sensorpreflist = list("Off", "Binary", "Vitals", "Tracking", "No Preference")	//TFF 5/8/19 - Suit Sensors global list
+
 var/global/list/custom_species_bases = list() // Species that can be used for a Custom Species icon base
 
 //stores numeric player size options indexed by name

--- a/code/modules/client/preference_setup/vore/09_misc.dm
+++ b/code/modules/client/preference_setup/vore/09_misc.dm
@@ -1,5 +1,4 @@
-/datum/preferences
-	var/show_in_directory = TRUE
+//TFF 5/8/19 - moved /datum/preferences to preferences_vr.dm
 
 /datum/category_item/player_setup_item/vore/misc
 	name = "Misc Settings"
@@ -7,20 +6,35 @@
 
 /datum/category_item/player_setup_item/vore/misc/load_character(var/savefile/S)
 	S["show_in_directory"]		>> pref.show_in_directory
-
+	S["sensorpref"]				>> pref.sensorpref	//TFF 5/8/19 - add sensor pref setting to load after saved
 
 /datum/category_item/player_setup_item/vore/misc/save_character(var/savefile/S)
 	S["show_in_directory"]		<< pref.show_in_directory
+	S["sensorpref"]				<< pref.sensorpref	//TFF 5/8/19 - add sensor pref setting to be saveable
+
+//TFF 5/8/19 - add new datum category to allow for setting multiple settings when this is selected in the loadout.
+/datum/category_item/player_setup_item/vore/misc/copy_to_mob(var/mob/living/carbon/human/character)
+	if(pref.sensorpref > 5 || pref.sensorpref < 1)
+		pref.sensorpref = 5
+	character.sensorpref = pref.sensorpref
 
 /datum/category_item/player_setup_item/vore/misc/sanitize_character()
 	pref.show_in_directory		= sanitize_integer(pref.show_in_directory, 0, 1, initial(pref.show_in_directory))
+	pref.sensorpref				= sanitize_integer(pref.sensorpref, 1, sensorpreflist.len, initial(pref.sensorpref))	//TFF - 5/8/19 - add santisation for sensor prefs
 
 /datum/category_item/player_setup_item/vore/misc/content(var/mob/user)
 	. += "<br>"
 	. += "<b>Appear in Character Directory:</b> <a [pref.show_in_directory ? "class='linkOn'" : ""] href='?src=\ref[src];toggle_show_in_directory=1'><b>[pref.show_in_directory ? "Yes" : "No"]</b></a><br>"
+	. += "<b>Sensor Preferences:</b> <a [pref.sensorpref ? "class='linkOn'" : ""] href='?src=\ref[src];toggle_sensor_setting=1'><b>[sensorpreflist[pref.sensorpref]]</b></a><br>"	//TFF 5/8/19 - Allow selection of sensor settings from off, binary, vitals, tracking, or random
 
 /datum/category_item/player_setup_item/vore/misc/OnTopic(var/href, var/list/href_list, var/mob/user)
 	if(href_list["toggle_show_in_directory"])
 		pref.show_in_directory = pref.show_in_directory ? 0 : 1;
 		return TOPIC_REFRESH
+	//TFF 5/8/19 - add new thing so you can choose the sensor setting your character can get.
+	else if(href_list["toggle_sensor_setting"])
+		var/new_sensorpref = input(user, "Choose your character's sensor preferences:", "Character Preferences", sensorpreflist[pref.sensorpref]) as null|anything in sensorpreflist
+		if (!isnull(new_sensorpref) && CanUseTopic(user))
+			pref.sensorpref = sensorpreflist.Find(new_sensorpref)
+			return TOPIC_REFRESH
 	return ..();

--- a/code/modules/client/preferences_vr.dm
+++ b/code/modules/client/preferences_vr.dm
@@ -1,1 +1,4 @@
-//File isn't currently being used.
+//TFF 5/8/19 - minor refactoring of this thing from 09_misc.dm to call this for preferences.
+datum/preferences
+	var/show_in_directory = 1	//TFF 5/8/19 - show in Character Directory
+	var/sensorpref = 5			//TFF 5/8/19 - set character's suit sensor level

--- a/code/modules/clothing/clothing_vr.dm
+++ b/code/modules/clothing/clothing_vr.dm
@@ -132,3 +132,22 @@
 		standing.pixel_x = -16
 		standing.layer = BODY_LAYER + 15 // 15 is above tail layer, so will not be covered by taurbody.
 	return standing
+
+//TFF 5/8/19 - sets Vorestation /obj/item/clothing/under sensor setting default?
+/obj/item/clothing/under
+	sensor_mode = 3
+	var/sensorpref = 5
+
+//TFF 5/8/19 - define numbers and specifics for suit sensor settings
+/obj/item/clothing/under/New(var/mob/living/carbon/human/H)
+	..()
+	sensorpref = isnull(H) ? 1 : (ishuman(H) ? H.sensorpref : 1)
+	switch(sensorpref)
+		if(1) sensor_mode = 0				//Sensors off
+		if(2) sensor_mode = 1				//Sensors on binary
+		if(3) sensor_mode = 2				//Sensors display vitals
+		if(4) sensor_mode = 3				//Sensors display vitals and enables tracking
+		if(5) sensor_mode = pick(0,1,2,3)	//Select a random setting
+		else
+			sensor_mode = pick(0,1,2,3)
+			log_debug("Invalid switch for suit sensors, defaulting to random. [sensorpref] chosen")

--- a/code/modules/mob/living/carbon/human/human_defines_vr.dm
+++ b/code/modules/mob/living/carbon/human/human_defines_vr.dm
@@ -7,3 +7,6 @@
 	var/flapping = 0
 	var/vantag_pref = VANTAG_NONE //What's my status?
 	var/impersonate_bodytype //For impersonating a bodytype
+
+	//TFF 5/8/19 - add and set suit sensor setting define to 5 for random setting
+	var/sensorpref = 5

--- a/code/modules/mob/new_player/preferences_setup_vr.dm
+++ b/code/modules/mob/new_player/preferences_setup_vr.dm
@@ -23,3 +23,7 @@
 	preview_icon.Blend(stamp, ICON_OVERLAY, 112-stamp.Width()/2, 5)
 
 	preview_icon.Scale(preview_icon.Width() * 2, preview_icon.Height() * 2) // Scaling here to prevent blurring in the browser.
+
+//TFF 5/8/19 - add randomised sensor setting for random button clicking
+/datum/preferences/randomize_appearance_and_body_for(var/mob/living/carbon/human/H)
+	sensorpref = rand(1,5)


### PR DESCRIPTION
Allows selection of suit sensor settings in VORE tab on Character Setup. Work credited to https://github.com/PolarisSS13/Polaris/pull/4354 Adjustments made as needed to account for outdated code as well as making use of preferences_vr at last.