### PR TITLE
Disables bot patrolling on the Tether

### DIFF
--- a/maps/tether/tether_defines.dm
+++ b/maps/tether/tether_defines.dm
@@ -116,6 +116,8 @@
 							NETWORK_ALARM_FIRE
 							)
 
+	bot_patrolling = FALSE
+
 	allowed_spawns = list("Tram Station","Gateway","Cryogenic Storage","Cyborg Storage")
 	spawnpoint_died = /datum/spawnpoint/tram
 	spawnpoint_left = /datum/spawnpoint/tram


### PR DESCRIPTION
It was broken and not working to begin with, and also a suspected cause of lag as bots infinitely tried to find a patrol route and couldn't. Either way, we don't have beacon system so it shouldn't be there regardless.

A followup to #5585 and will not compile until after its merged