### PR TITLE
Changes fishing loot pools for indoor fishing

### DIFF
--- a/code/modules/fishing/fishing_vr.dm
+++ b/code/modules/fishing/fishing_vr.dm
@@ -1,4 +1,4 @@
-GLOBAL_LIST_INIT(indoor_fishing_chance_list, list(FISHING_RARE = 5, FISHING_UNCOMMON = 20, FISHING_COMMON = 30, FISHING_JUNK = 15, FISHING_NOTHING = 50))
+GLOBAL_LIST_INIT(indoor_fishing_chance_list, list(FISHING_RARE = 5, FISHING_UNCOMMON = 20, FISHING_COMMON = 30, FISHING_JUNK = 5, FISHING_NOTHING = 50))
 GLOBAL_LIST_INIT(indoor_fishing_junk_list, list(
 		/obj/random/junk = 15,
 		/obj/random/maintenance/clean = 1

--- a/code/modules/fishing/fishing_vr.dm
+++ b/code/modules/fishing/fishing_vr.dm
@@ -1,0 +1,29 @@
+GLOBAL_LIST_INIT(indoor_fishing_chance_list, list(FISHING_RARE = 5, FISHING_UNCOMMON = 20, FISHING_COMMON = 30, FISHING_JUNK = 15, FISHING_NOTHING = 50))
+GLOBAL_LIST_INIT(indoor_fishing_junk_list, list(
+		/obj/random/junk = 15,
+		/obj/random/maintenance/clean = 1
+		))
+
+/turf/simulated/floor/water/indoors
+	min_fishing_time = 45
+	max_fishing_time = 120
+
+/turf/simulated/floor/water/indoors/handle_fish()
+	if(has_fish)
+		rare_fish_list = GLOB.generic_fishing_rare_list
+		uncommon_fish_list = GLOB.generic_fishing_uncommon_list
+		common_fish_list = GLOB.generic_fishing_common_list
+		junk_list = GLOB.indoor_fishing_junk_list
+		fishing_loot = GLOB.indoor_fishing_chance_list
+
+/turf/simulated/floor/water/deep/indoors
+	min_fishing_time = 45
+	max_fishing_time = 120
+
+/turf/simulated/floor/water/deep/indoors/handle_fish()
+	if(has_fish)
+		rare_fish_list = GLOB.generic_fishing_rare_list
+		uncommon_fish_list = GLOB.generic_fishing_uncommon_list
+		common_fish_list = GLOB.generic_fishing_common_list
+		junk_list = GLOB.indoor_fishing_junk_list
+		fishing_loot = GLOB.indoor_fishing_chance_list

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -1820,6 +1820,7 @@
 #include "code\modules\fishing\fishing_net.dm"
 #include "code\modules\fishing\fishing_rod.dm"
 #include "code\modules\fishing\fishing_rod_vr.dm"
+#include "code\modules\fishing\fishing_vr.dm"
 #include "code\modules\flufftext\Dreaming.dm"
 #include "code\modules\flufftext\Hallucination.dm"
 #include "code\modules\flufftext\look_up.dm"


### PR DESCRIPTION
Removes the 'random fishing loot' object since that was intended primarily for exploration areas, and rebalances chances. Also makes indoor fishing take slightly longer than outdoor.