### PR TITLE
Indoor fishing tweaks

### DIFF
--- a/code/modules/fishing/fishing_vr.dm
+++ b/code/modules/fishing/fishing_vr.dm
@@ -5,8 +5,8 @@ GLOBAL_LIST_INIT(indoor_fishing_junk_list, list(
 		))
 
 /turf/simulated/floor/water/indoors
-	min_fishing_time = 45
-	max_fishing_time = 120
+	min_fishing_time = 33
+	max_fishing_time = 99
 
 /turf/simulated/floor/water/indoors/handle_fish()
 	if(has_fish)

--- a/maps/tether/tether-02-surface2.dmm
+++ b/maps/tether/tether-02-surface2.dmm
@@ -10102,11 +10102,11 @@
 /area/tether/surfacebase/east_stairs_two)
 "ue" = (
 /obj/structure/table/rack,
-/obj/item/weapon/material/fishing_rod/modern,
-/obj/item/weapon/material/fishing_rod/modern,
-/obj/item/weapon/material/fishing_rod/modern,
-/obj/item/weapon/material/fishing_rod/modern,
-/obj/item/weapon/material/fishing_rod/modern,
+/obj/item/weapon/material/fishing_rod/modern/cheap,
+/obj/item/weapon/material/fishing_rod/modern/cheap,
+/obj/item/weapon/material/fishing_rod/modern/cheap,
+/obj/item/weapon/material/fishing_rod/modern/cheap,
+/obj/item/weapon/material/fishing_rod/modern/cheap,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/fish_farm)
 "uf" = (


### PR DESCRIPTION
- softens the recent extra 50% fishing time increase  added here: https://github.com/VOREStation/VOREStation/pull/5595

- Now just a 10% increase compared to outdoors fishing.

-  Titanium fishing rods replaced by plastic rods. 25% increased speed down to 10% compared to wooden fishing rods.

All in all this slows down fishing again without making the RNG on fishing time even more insane. Miners get rewarded for buying a better fishing rod, and no one will have to rush to get to the good rods first. A total of 11 rods are in the fishing area. six in the vendor, five on the racks.