### PR TITLE
Removes Awoo speech

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
@@ -59,16 +59,6 @@
 	autohiss_exempt = list("Siik"))
 	excludes = list(/datum/trait/autohiss_unathi)
 
-/datum/trait/autohiss_awootism
-	name = "Autohiss (Disability)"
-	desc = "You can't speak r's and l's properly."
-	cost = 0
-	var_changes = list(
-	autohiss_basic_map = list(
-			"l" = list("w", "ww"),
-			"r" = list("w", "ww")
-		))
-
 /datum/trait/bloodsucker
 	name = "Bloodsucker"
 	desc = "Makes you unable to gain nutrition from anything but blood. To compenstate, you get fangs that can be used to drain blood from prey."


### PR DESCRIPTION
Removes the Cursed Speech Autohiss/Awoo/Disability speech from traits, by community request.