### PR TITLE
Adjusts modes of some buttons in character creation

### DIFF
--- a/code/modules/client/preference_setup/vore/06_vantag.dm
+++ b/code/modules/client/preference_setup/vore/06_vantag.dm
@@ -27,7 +27,7 @@
 
 /datum/category_item/player_setup_item/vore/vantag/content(var/mob/user)
 	. += "<br>"
-	. += "<b>Event Volunteer:</b> <a href='?src=\ref[src];toggle_vantag_volunteer=1'><b>[pref.vantag_volunteer ? "Yes" : "No"]</b></a><br>"
+	. += "<b>Event Volunteer:</b> <a [pref.vantag_volunteer ? "class='linkOn'" : ""] href='?src=\ref[src];toggle_vantag_volunteer=1'><b>[pref.vantag_volunteer ? "Yes" : "No"]</b></a><br>"
 	. += "<b>Event Pref:</b> <a href='?src=\ref[src];change_vantag=1'><b>[vantag_choices_list[pref.vantag_preference]]</b></a><br>"
 
 /datum/category_item/player_setup_item/vore/vantag/OnTopic(var/href, var/list/href_list, var/mob/user)

--- a/code/modules/client/preference_setup/vore/09_misc.dm
+++ b/code/modules/client/preference_setup/vore/09_misc.dm
@@ -25,7 +25,7 @@
 /datum/category_item/player_setup_item/vore/misc/content(var/mob/user)
 	. += "<br>"
 	. += "<b>Appear in Character Directory:</b> <a [pref.show_in_directory ? "class='linkOn'" : ""] href='?src=\ref[src];toggle_show_in_directory=1'><b>[pref.show_in_directory ? "Yes" : "No"]</b></a><br>"
-	. += "<b>Sensor Preferences:</b> <a [pref.sensorpref ? "class='linkOn'" : ""] href='?src=\ref[src];toggle_sensor_setting=1'><b>[sensorpreflist[pref.sensorpref]]</b></a><br>"	//TFF 5/8/19 - Allow selection of sensor settings from off, binary, vitals, tracking, or random
+	. += "<b>Suit Sensors Preference:</b> <a [pref.sensorpref ? "" : ""] href='?src=\ref[src];toggle_sensor_setting=1'><b>[sensorpreflist[pref.sensorpref]]</b></a><br>"	//TFF 5/8/19 - Allow selection of sensor settings from off, binary, vitals, tracking, or random
 
 /datum/category_item/player_setup_item/vore/misc/OnTopic(var/href, var/list/href_list, var/mob/user)
 	if(href_list["toggle_show_in_directory"])


### PR DESCRIPTION
The new sensors button is now blue like a standard selection and not permanently highlighted green like an active yes-no toggle.
Sensors button renamed to "Suit Sensors Preference" since initially there was minor confusion initially (was just "Sensor Preferences")
Event participation preference button now works like other yes-no toggles and will be highlighted green when in Yes position