### PR TITLE
Fixes borgs showing up in manifest in Misc category if they spawned roundstart

### DIFF
--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -284,7 +284,7 @@ var/global/datum/controller/gameticker/ticker
 					var/mob/living/carbon/human/new_char = player.create_character()
 					if(new_char)
 						qdel(player)
-					if(istype(new_char))
+					if(istype(new_char) && !player.mind.assigned_role=="Cyborg")
 						data_core.manifest_inject(new_char)
 					//VOREStation Edit End
 


### PR DESCRIPTION
Fix for missing manifest entries seems to have worked, but worked too well, giving borgs two. Now they will only have one and appropriate one too.