### PR TITLE
Fixes Merc Commando's corpse being named Syndie Commando

### DIFF
--- a/code/modules/mob/living/simple_animal/corpse_vr.dm
+++ b/code/modules/mob/living/simple_animal/corpse_vr.dm
@@ -1,0 +1,2 @@
+/obj/effect/landmark/mobcorpse/syndicatecommando
+	name = "Mercenary Commando"

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -2346,6 +2346,7 @@
 #include "code\modules\mob\living\silicon\robot\subtypes\lost_drone.dm"
 #include "code\modules\mob\living\silicon\robot\subtypes\syndicate.dm"
 #include "code\modules\mob\living\simple_animal\corpse.dm"
+#include "code\modules\mob\living\simple_animal\corpse_vr.dm"
 #include "code\modules\mob\living\simple_mob\appearance.dm"
 #include "code\modules\mob\living\simple_mob\combat.dm"
 #include "code\modules\mob\living\simple_mob\defense.dm"


### PR DESCRIPTION
Supposedly Fixes #5672 

Mob name itself got changed a while back and it was fine, but at the time, I forgot that there was also a corpse landmark for humanoids and it doesn't just generate random names. Now even after death, it will still be Mercenary and not transform into Syndicate.