### PR TITLE
Adjusts xenobio closer to pre-refactor state

### DIFF
--- a/code/modules/mob/living/simple_mob/subtypes/slime/xenobio/consumption.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/slime/xenobio/consumption.dm
@@ -140,6 +140,13 @@
 	if(L.getCloneLoss() >= L.getMaxHealth() * 1.5)
 		to_chat(src, "This subject does not have an edible life energy...")
 		return FALSE
+	//VOREStation Addition start
+	if(istype(L, /mob/living/carbon/human))
+		var/mob/living/carbon/human/H = L
+		if(H.species.flags & NO_SCAN)
+			to_chat(src, "This subject's life energy is beyond my reach...")
+			return FALSE
+	//VOREStation Addition end
 	if(L.has_buckled_mobs())
 		for(var/A in L.buckled_mobs)
 			if(istype(A, /mob/living/simple_mob/slime/xenobio))

--- a/code/modules/mob/living/simple_mob/subtypes/slime/xenobio/subtypes_vr.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/slime/xenobio/subtypes_vr.dm
@@ -1,2 +1,6 @@
-/mob/living/simple_mob/slime/xenobio/rainbow/kendrick
+/mob/living/simple_mob/slime/xenobio
 	mob_bump_flag = 0
+
+/mob/living/simple_mob/slime/xenobio/Initialize(mapload, var/mob/living/simple_mob/slime/xenobio/my_predecessor)
+	..()
+	Weaken(10)


### PR DESCRIPTION
Returns proper swapping flags to xenobio slimes (ferals in exploration areas remain same aggressive and non-pushable selves)

Forces a delay on ability to act after being born out of core or splitting

Slimes no longer latch onto noscan species