### PR TITLE
Minor Fixes

### DIFF
--- a/code/datums/supplypacks/hospitality_vr.dm
+++ b/code/datums/supplypacks/hospitality_vr.dm
@@ -1,3 +1,6 @@
+/datum/supply_pack/randomised/hospitality/pizza
+	cost = 50
+
 /datum/supply_pack/randomised/hospitality/burgers_vr
 	num_contained = 5
 	contains = list(

--- a/code/game/objects/items/weapons/storage/firstaid_vr.dm
+++ b/code/game/objects/items/weapons/storage/firstaid_vr.dm
@@ -12,51 +12,61 @@
 	name = "bottle of Rezadone pills"
 	desc = "A powder with almost magical properties, this substance can effectively treat genetic damage in humanoids, though excessive consumption has side effects."
 	starts_with = list(/obj/item/weapon/reagent_containers/pill/rezadone = 7)
+	wrapper_color = COLOR_GREEN_GRAY
 
 /obj/item/weapon/storage/pill_bottle/peridaxon
 	name = "bottle of Peridaxon pills"
 	desc = "Used to encourage recovery of internal organs and nervous systems. Medicate cautiously."
 	starts_with = list(/obj/item/weapon/reagent_containers/pill/peridaxon = 7)
+	wrapper_color = COLOR_PURPLE
 
 /obj/item/weapon/storage/pill_bottle/carthatoline
 	name = "bottle of Carthatoline pills"
 	desc = "Carthatoline is strong evacuant used to treat severe poisoning."
 	starts_with = list(/obj/item/weapon/reagent_containers/pill/carthatoline = 7)
+	wrapper_color = COLOR_GREEN_GRAY
 
 /obj/item/weapon/storage/pill_bottle/alkysine
 	name = "bottle of Alkysine pills"
 	desc = "Alkysine is a drug used to lessen the damage to neurological tissue after a catastrophic injury. Can heal brain tissue."
 	starts_with = list(/obj/item/weapon/reagent_containers/pill/alkysine = 7)
+	wrapper_color = COLOR_YELLOW
 
 /obj/item/weapon/storage/pill_bottle/imidazoline
 	name = "bottle of Imidazoline pills"
 	desc = "Heals eye damage."
 	starts_with = list(/obj/item/weapon/reagent_containers/pill/imidazoline = 7)
+	wrapper_color = COLOR_PURPLE_GRAY
 
 /obj/item/weapon/storage/pill_bottle/osteodaxon
 	name = "bottle of Osteodaxon pills"
 	desc = "An experimental drug used to heal bone fractures."
 	starts_with = list(/obj/item/weapon/reagent_containers/pill/osteodaxon = 7)
+	wrapper_color = COLOR_WHITE
 
 /obj/item/weapon/storage/pill_bottle/myelamine
 	name = "bottle of Myelamine pills"
 	desc = "Used to rapidly clot internal hemorrhages by increasing the effectiveness of platelets."
 	starts_with = list(/obj/item/weapon/reagent_containers/pill/myelamine = 7)
+	wrapper_color = COLOR_PALE_PURPLE_GRAY
 
 /obj/item/weapon/storage/pill_bottle/hyronalin
 	name = "bottle of Hyronalin pills"
 	desc = "Hyronalin is a medicinal drug used to counter the effect of radiation poisoning."
 	starts_with = list(/obj/item/weapon/reagent_containers/pill/hyronalin = 7)
+	wrapper_color = COLOR_TEAL
 
 /obj/item/weapon/storage/pill_bottle/arithrazine
 	name = "bottle of Arithrazine pills"
 	desc = "Arithrazine is an unstable medication used for the most extreme cases of radiation poisoning."
 	starts_with = list(/obj/item/weapon/reagent_containers/pill/arithrazine = 7)
+	wrapper_color = COLOR_TEAL
 
 /obj/item/weapon/storage/pill_bottle/corophizine
 	name = "bottle of Corophizine pills"
 	desc = "A wide-spectrum antibiotic drug. Powerful and uncomfortable in equal doses."
 	starts_with = list(/obj/item/weapon/reagent_containers/pill/corophizine = 7)
+	wrapper_color = COLOR_PALE_GREEN_GRAY
 
 /obj/item/weapon/storage/pill_bottle/healing_nanites
 	name = "bottle of Healing nanites capsules"

--- a/code/modules/mob/living/simple_mob/subtypes/humanoid/mercs/mercs_vr.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/humanoid/mercs/mercs_vr.dm
@@ -11,3 +11,15 @@
 	name = "mercenary commando"
 
 	maxbodytemp = 700
+
+/mob/living/simple_mob/humanoid/merc/ranged/virgo
+	name = "suspicious individual"
+	min_oxy = 0
+	max_oxy = 0
+	min_tox = 0
+	max_tox = 0
+	min_co2 = 0
+	max_co2 = 0
+	min_n2 = 0
+	max_n2 = 0
+	minbodytemp = 0

--- a/code/modules/reagents/reagent_containers/pill_vr.dm
+++ b/code/modules/reagents/reagent_containers/pill_vr.dm
@@ -1,7 +1,7 @@
 /obj/item/weapon/reagent_containers/pill/nutriment
 	name = "Nutriment pill"
 	desc = "Used to feed people on the field. Contains 30 units of Nutriment."
-	icon_state = "pill6"
+	icon_state = "pill10"
 
 /obj/item/weapon/reagent_containers/pill/nutriment/Initialize()
 	..()
@@ -10,7 +10,7 @@
 /obj/item/weapon/reagent_containers/pill/protein
 	name = "Meat pill"
 	desc = "Used to feed carnivores on the field. Contains 30 units of Protein."
-	icon_state = "pill20"
+	icon_state = "pill24"
 
 /obj/item/weapon/reagent_containers/pill/protein/Initialize()
 	..()
@@ -19,11 +19,12 @@
 /obj/item/weapon/reagent_containers/pill/rezadone
 	name = "Rezadone pill"
 	desc = "A powder with almost magical properties, this substance can effectively treat genetic damage in humanoids, though excessive consumption has side effects."
-	icon_state = "pill13"
+	icon_state = "pill2"
 
 /obj/item/weapon/reagent_containers/pill/rezadone/Initialize()
 	..()
 	reagents.add_reagent("rezadone", 5)
+	color = reagents.get_color()
 
 /obj/item/weapon/reagent_containers/pill/peridaxon
 	name = "Peridaxon pill"
@@ -37,38 +38,42 @@
 /obj/item/weapon/reagent_containers/pill/carthatoline
 	name = "Carthatoline pill"
 	desc = "Carthatoline is strong evacuant used to treat severe poisoning."
-	icon_state = "pill17"
+	icon_state = "pill4"
 
 /obj/item/weapon/reagent_containers/pill/carthatoline/Initialize()
 	..()
 	reagents.add_reagent("carthatoline", 10)
+	color = reagents.get_color()
 
 /obj/item/weapon/reagent_containers/pill/alkysine
 	name = "Alkysine pill"
 	desc = "Alkysine is a drug used to lessen the damage to neurological tissue after a catastrophic injury. Can heal brain tissue."
-	icon_state = "pill7"
+	icon_state = "pill3"
 
 /obj/item/weapon/reagent_containers/pill/alkysine/Initialize()
 	..()
 	reagents.add_reagent("alkysine", 10)
+	color = reagents.get_color()
 
 /obj/item/weapon/reagent_containers/pill/imidazoline
 	name = "Imidazoline pill"
 	desc = "Heals eye damage."
-	icon_state = "pill9"
+	icon_state = "pill3"
 
 /obj/item/weapon/reagent_containers/pill/imidazoline/Initialize()
 	..()
 	reagents.add_reagent("imidazoline", 15)
+	color = reagents.get_color()
 
 /obj/item/weapon/reagent_containers/pill/osteodaxon
 	name = "Osteodaxon pill"
 	desc = "An experimental drug used to heal bone fractures."
-	icon_state = "pill19"
+	icon_state = "pill2"
 
 /obj/item/weapon/reagent_containers/pill/osteodaxon/Initialize()
 	..()
 	reagents.add_reagent("osteodaxon", 10)
+	color = reagents.get_color()
 
 /obj/item/weapon/reagent_containers/pill/myelamine
 	name = "Myelamine pill"
@@ -78,15 +83,17 @@
 /obj/item/weapon/reagent_containers/pill/myelamine/Initialize()
 	..()
 	reagents.add_reagent("myelamine", 10)
+	color = reagents.get_color()
 
 /obj/item/weapon/reagent_containers/pill/hyronalin
 	name = "Hyronalin pill"
 	desc = "Hyronalin is a medicinal drug used to counter the effect of radiation poisoning."
-	icon_state = "pill17"
+	icon_state = "pill4"
 
 /obj/item/weapon/reagent_containers/pill/hyronalin/Initialize()
 	..()
 	reagents.add_reagent("hyronalin", 15)
+	color = reagents.get_color()
 
 /obj/item/weapon/reagent_containers/pill/arithrazine
 	name = "Arithrazine pill"
@@ -96,21 +103,24 @@
 /obj/item/weapon/reagent_containers/pill/arithrazine/Initialize()
 	..()
 	reagents.add_reagent("arithrazine", 5)
+	color = reagents.get_color()
 
 /obj/item/weapon/reagent_containers/pill/corophizine
 	name = "Corophizine pill"
 	desc = "A wide-spectrum antibiotic drug. Powerful and uncomfortable in equal doses."
-	icon_state = "pill9"
+	icon_state = "pill2"
 
 /obj/item/weapon/reagent_containers/pill/corophizine/Initialize()
 	..()
 	reagents.add_reagent("corophizine", 5)
+	color = reagents.get_color()
 
 /obj/item/weapon/reagent_containers/pill/healing_nanites
 	name = "Healing nanites capsule"
 	desc = "Miniature medical robots that swiftly restore bodily damage."
-	icon_state = "pill5"
+	icon_state = "pill1"
 
 /obj/item/weapon/reagent_containers/pill/healing_nanites/Initialize()
 	..()
 	reagents.add_reagent("healing_nanites", 30)
+	color = reagents.get_color()

--- a/code/modules/vore/fluffstuff/custom_clothes_vr.dm
+++ b/code/modules/vore/fluffstuff/custom_clothes_vr.dm
@@ -693,9 +693,6 @@
 	icon_override = 'icons/vore/custom_clothes_vr.dmi'
 	item_state = "rig-hos_mob"
 
-	//Slightly improved security voidsuit, which when made, was:
-	//armor = list(melee = 50, bullet = 25, laser = 25, energy = 5, bomb = 45, bio = 100, rad = 10)
-	armor = list("melee" = 60, "bullet" = 35, "laser" = 35, "energy" = 15, "bomb" = 50, "bio" = 100, "rad" = 10)
 	species_restricted = null
 
 //HOS Hardsuit Helmet
@@ -709,7 +706,6 @@
 	icon_override = 'icons/vore/custom_clothes_vr.dmi'
 	item_state = "rig0-hos_mob"
 
-	armor = list("melee" = 60, "bullet" = 35, "laser" = 35, "energy" = 15, "bomb" = 50, "bio" = 100, "rad" = 10)
 	species_restricted = null
 
 //adk09:Lethe

--- a/maps/submaps/surface_submaps/plains/Thiefc_vr.dmm
+++ b/maps/submaps/surface_submaps/plains/Thiefc_vr.dmm
@@ -64,23 +64,27 @@
 "j" = (
 /obj/structure/table/steel,
 /obj/item/weapon/beartrap,
+/obj/item/device/survivalcapsule,
 /turf/simulated/floor/outdoors/dirt{
 	outdoors = 0
 	},
 /area/submap/Thiefc)
 "k" = (
 /obj/vehicle/train/trolley,
-/obj/item/weapon/storage/firstaid/combat,
+/obj/random/firstaid,
+/obj/random/firstaid,
+/obj/random/firstaid,
+/obj/random/firstaid,
+/obj/random/firstaid,
 /turf/simulated/floor/outdoors/dirt{
 	outdoors = 0
 	},
 /area/submap/Thiefc)
 "l" = (
 /obj/structure/closet/crate,
-/obj/item/weapon/folder/blue,
-/obj/item/weapon/folder/red,
-/obj/item/weapon/folder/white,
-/obj/item/weapon/folder/yellow,
+/obj/item/device/nif,
+/obj/item/device/nif/bad,
+/obj/item/device/nif/bad,
 /turf/simulated/floor/outdoors/dirt{
 	outdoors = 0
 	},
@@ -97,6 +101,9 @@
 /area/submap/Thiefc)
 "n" = (
 /obj/vehicle/train/trolley,
+/obj/random/multiple/voidsuit,
+/obj/random/multiple/voidsuit,
+/obj/random/multiple/voidsuit,
 /turf/simulated/floor/outdoors/dirt{
 	outdoors = 0
 	},
@@ -105,6 +112,9 @@
 /obj/structure/closet/crate,
 /obj/item/weapon/cell/device/weapon,
 /obj/item/weapon/cell/device/weapon,
+/obj/item/weapon/cell/device/weapon,
+/obj/item/weapon/cell/device/weapon,
+/obj/item/device/perfect_tele/one_beacon,
 /turf/simulated/floor/outdoors/dirt{
 	outdoors = 0
 	},
@@ -113,12 +123,19 @@
 /obj/structure/closet/crate,
 /obj/item/weapon/storage/box/shotgunammo,
 /obj/item/weapon/storage/box/practiceshells,
+/obj/item/weapon/grenade/spawnergrenade/manhacks/station,
 /turf/simulated/floor/outdoors/dirt{
 	outdoors = 0
 	},
 /area/submap/Thiefc)
-"I" = (
-/mob/living/simple_mob/humanoid/merc/melee/sword/space,
+"u" = (
+/mob/living/simple_mob/humanoid/merc/ranged/virgo,
+/turf/simulated/floor/outdoors/dirt{
+	outdoors = 0
+	},
+/area/submap/Thiefc)
+"P" = (
+/obj/machinery/door/airlock,
 /turf/simulated/floor/outdoors/dirt{
 	outdoors = 0
 	},
@@ -269,7 +286,7 @@ c
 c
 c
 c
-h
+P
 c
 c
 b
@@ -305,7 +322,7 @@ a
 c
 c
 c
-h
+u
 h
 h
 h
@@ -371,7 +388,7 @@ a
 c
 e
 h
-I
+u
 h
 h
 h
@@ -397,7 +414,7 @@ i
 h
 h
 h
-h
+u
 c
 c
 c

--- a/maps/tether/tether-02-surface2.dmm
+++ b/maps/tether/tether-02-surface2.dmm
@@ -5685,6 +5685,9 @@
 /obj/effect/floor_decal/corner/mauve/bordercorner2{
 	dir = 10
 	},
+/obj/machinery/computer/communications{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/rnd/rdoffice)
 "md" = (

--- a/maps/tether/tether-02-surface2.dmm
+++ b/maps/tether/tether-02-surface2.dmm
@@ -5685,7 +5685,7 @@
 /obj/effect/floor_decal/corner/mauve/bordercorner2{
 	dir = 10
 	},
-/obj/machinery/computer/communications{
+/obj/item/modular_computer/console/preset/command{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,

--- a/maps/tether/tether-05-station1.dmm
+++ b/maps/tether/tether-05-station1.dmm
@@ -17153,7 +17153,7 @@
 /turf/simulated/floor/carpet,
 /area/engineering/foyer)
 "bft" = (
-/obj/machinery/computer/atmos_alert{
+/obj/item/modular_computer/console/preset/command{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
@@ -22332,12 +22332,6 @@
 /obj/machinery/status_display,
 /turf/simulated/wall/r_wall,
 /area/bridge)
-"hhC" = (
-/obj/machinery/computer/communications{
-	dir = 1
-	},
-/turf/simulated/floor/carpet/oracarpet,
-/area/crew_quarters/heads/chief)
 "hPi" = (
 /obj/machinery/light/small,
 /turf/simulated/floor,
@@ -27420,7 +27414,7 @@ agc
 aYF
 aRX
 aSe
-hhC
+aRX
 aVz
 aRb
 bYg

--- a/maps/tether/tether-05-station1.dmm
+++ b/maps/tether/tether-05-station1.dmm
@@ -22328,6 +22328,16 @@
 	},
 /turf/simulated/floor/tiled,
 /area/bridge_hallway)
+"gkC" = (
+/obj/machinery/status_display,
+/turf/simulated/wall/r_wall,
+/area/bridge)
+"hhC" = (
+/obj/machinery/computer/communications{
+	dir = 1
+	},
+/turf/simulated/floor/carpet/oracarpet,
+/area/crew_quarters/heads/chief)
 "hPi" = (
 /obj/machinery/light/small,
 /turf/simulated/floor,
@@ -27410,7 +27420,7 @@ agc
 aYF
 aRX
 aSe
-aRX
+hhC
 aVz
 aRb
 bYg
@@ -31538,7 +31548,7 @@ awy
 awy
 awy
 awy
-awy
+gkC
 awy
 awy
 awy
@@ -32958,7 +32968,7 @@ awA
 awE
 awE
 awy
-awy
+gkC
 boL
 awy
 bqR

--- a/maps/tether/tether-06-station2.dmm
+++ b/maps/tether/tether-06-station2.dmm
@@ -15085,6 +15085,9 @@
 "wR" = (
 /obj/structure/table/woodentable,
 /obj/machinery/chemical_dispenser/bar_soft/full,
+/obj/machinery/keycard_auth{
+	pixel_y = 28
+	},
 /turf/simulated/floor/wood,
 /area/bridge/meeting_room)
 "wS" = (
@@ -20152,6 +20155,12 @@
 	},
 /turf/simulated/floor,
 /area/maintenance/station/sec_lower)
+"HU" = (
+/obj/machinery/keycard_auth{
+	pixel_y = -28
+	},
+/turf/simulated/floor/wood,
+/area/bridge/meeting_room)
 "Ik" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -35883,7 +35892,7 @@ wV
 ys
 wV
 wV
-wV
+HU
 wo
 ac
 ac

--- a/maps/tether/tether-07-station3.dmm
+++ b/maps/tether/tether-07-station3.dmm
@@ -2681,14 +2681,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/security_lockerroom)
-"er" = (
-/obj/machinery/shuttle_sensor{
-	dir = 5;
-	id_tag = "shuttlesens_exp";
-	pixel_y = -6
-	},
-/turf/simulated/wall/thull,
-/area/shuttle/excursion/tether)
 "es" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/railing{
@@ -41527,7 +41519,7 @@ cG
 VB
 WD
 dE
-er
+dj
 TY
 dj
 dj

--- a/maps/tether/tether-07-station3.dmm
+++ b/maps/tether/tether-07-station3.dmm
@@ -12478,13 +12478,15 @@
 /turf/simulated/wall,
 /area/quartermaster/office)
 "tC" = (
-/obj/structure/table/standard,
 /obj/effect/floor_decal/borderfloorwhite,
 /obj/effect/floor_decal/corner/white/border,
 /obj/machinery/button/windowtint{
 	id = "surgery_2";
 	pixel_y = -26
 	},
+/obj/item/weapon/reagent_containers/blood/OMinus,
+/obj/item/weapon/reagent_containers/blood/OMinus,
+/obj/structure/closet/crate/freezer,
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery2)
 "tD" = (
@@ -21000,7 +21002,6 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery)
 "Hn" = (
-/obj/structure/table/standard,
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 1
 	},
@@ -21013,6 +21014,7 @@
 	pixel_x = 0;
 	pixel_y = 26
 	},
+/obj/structure/closet/crate/freezer,
 /obj/item/weapon/reagent_containers/blood/OMinus,
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery)
@@ -23618,7 +23620,6 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay_primary_storage)
 "Lv" = (
-/obj/structure/table/standard,
 /obj/item/weapon/reagent_containers/blood/OMinus,
 /obj/item/weapon/reagent_containers/blood/OMinus,
 /obj/item/weapon/reagent_containers/blood/OMinus,
@@ -23634,6 +23635,7 @@
 /obj/effect/floor_decal/corner/paleblue/bordercorner2{
 	dir = 8
 	},
+/obj/structure/closet/crate/freezer,
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery_hallway)
 "Lw" = (
@@ -24204,7 +24206,6 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/exam_room)
 "Mp" = (
-/obj/structure/table/standard,
 /obj/item/weapon/reagent_containers/blood/AMinus,
 /obj/item/weapon/reagent_containers/blood/APlus,
 /obj/item/weapon/reagent_containers/blood/BMinus,
@@ -24216,6 +24217,7 @@
 /obj/effect/floor_decal/corner/paleblue/border{
 	dir = 8
 	},
+/obj/structure/closet/crate/freezer,
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery_hallway)
 "Mq" = (
@@ -25101,8 +25103,6 @@
 /obj/structure/table/standard,
 /obj/effect/floor_decal/borderfloorwhite,
 /obj/effect/floor_decal/corner/white/border,
-/obj/item/weapon/reagent_containers/blood/OMinus,
-/obj/item/weapon/reagent_containers/blood/OMinus,
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery2)
 "Nt" = (

--- a/maps/tether/tether-07-station3.dmm
+++ b/maps/tether/tether-07-station3.dmm
@@ -1984,7 +1984,7 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/shuttle/excursion/tether)
 "dj" = (
-/turf/simulated/wall/thull,
+/turf/simulated/wall/rshull,
 /area/shuttle/excursion/tether)
 "dk" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -3112,7 +3112,7 @@
 /obj/machinery/light/spot{
 	pixel_y = 32
 	},
-/turf/simulated/wall/thull,
+/turf/simulated/wall/rshull,
 /area/shuttle/excursion/tether)
 "fi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -5533,13 +5533,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 6
 	},
-/turf/simulated/wall/thull,
+/turf/simulated/wall/rshull,
 /area/shuttle/excursion/tether)
 "iY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 4
 	},
-/turf/simulated/wall/thull,
+/turf/simulated/wall/rshull,
 /area/shuttle/excursion/tether)
 "iZ" = (
 /obj/effect/floor_decal/borderfloorblack/full,
@@ -27731,7 +27731,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 10
 	},
-/turf/simulated/wall/thull,
+/turf/simulated/wall/rshull,
 /area/shuttle/excursion/tether)
 "Rw" = (
 /obj/structure/catwalk,
@@ -28774,7 +28774,7 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/wall/thull,
+/turf/simulated/wall/rshull,
 /area/shuttle/excursion/tether)
 "UK" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -28832,7 +28832,7 @@
 	dir = 6;
 	icon_state = "intact"
 	},
-/turf/simulated/wall/thull,
+/turf/simulated/wall/rshull,
 /area/shuttle/excursion/tether)
 "US" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -28968,7 +28968,7 @@
 	dir = 2;
 	id_tag = "shuttlesens_exp_psg"
 	},
-/turf/simulated/wall/thull,
+/turf/simulated/wall/rshull,
 /area/shuttle/excursion/tether)
 "Vm" = (
 /obj/structure/bed/chair/shuttle{
@@ -29091,7 +29091,7 @@
 	dir = 8;
 	icon_state = "map"
 	},
-/turf/simulated/wall/thull,
+/turf/simulated/wall/rshull,
 /area/shuttle/excursion/tether)
 "VR" = (
 /obj/machinery/atmospherics/binary/pump{
@@ -29149,7 +29149,7 @@
 	dir = 5;
 	id_tag = "shuttlesens_exp_int"
 	},
-/turf/simulated/wall/thull,
+/turf/simulated/wall/rshull,
 /area/shuttle/excursion/tether)
 "Wo" = (
 /obj/structure/bed/chair/shuttle,
@@ -29160,7 +29160,7 @@
 /area/shuttle/excursion/tether)
 "Ws" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
-/turf/simulated/wall/thull,
+/turf/simulated/wall/rshull,
 /area/shuttle/excursion/tether)
 "Wx" = (
 /obj/structure/grille,
@@ -29240,7 +29240,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/wall/thull,
+/turf/simulated/wall/rshull,
 /area/shuttle/excursion/tether)
 "Xc" = (
 /obj/structure/grille,
@@ -29329,7 +29329,7 @@
 /area/tether/exploration)
 "Xr" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/yellow,
-/turf/simulated/wall/thull,
+/turf/simulated/wall/rshull,
 /area/shuttle/excursion/tether)
 "XA" = (
 /obj/structure/shuttle/engine/heater,
@@ -29355,7 +29355,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 5
 	},
-/turf/simulated/wall/thull,
+/turf/simulated/wall/rshull,
 /area/shuttle/excursion/tether)
 "XE" = (
 /obj/machinery/conveyor_switch/oneway{
@@ -29597,13 +29597,13 @@
 	dir = 5;
 	id_tag = "shuttlesens_exp"
 	},
-/turf/simulated/wall/thull,
+/turf/simulated/wall/rshull,
 /area/shuttle/excursion/tether)
 "ZD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 9
 	},
-/turf/simulated/wall/thull,
+/turf/simulated/wall/rshull,
 /area/shuttle/excursion/tether)
 "ZE" = (
 /obj/machinery/door/airlock/glass_external{

--- a/maps/tether/tether-07-station3.dmm
+++ b/maps/tether/tether-07-station3.dmm
@@ -6334,12 +6334,6 @@
 	},
 /turf/simulated/floor/bluegrid,
 /area/ai)
-"kn" = (
-/obj/machinery/cryopod{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/shuttle/excursion/tether)
 "ko" = (
 /turf/simulated/wall/r_wall,
 /area/security/security_equiptment_storage)
@@ -40818,7 +40812,7 @@ Um
 dj
 iK
 jY
-kn
+iW
 WS
 dj
 XN

--- a/maps/tether/tether-07-station3.dmm
+++ b/maps/tether/tether-07-station3.dmm
@@ -9253,6 +9253,13 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/item/device/taperecorder{
+	pixel_y = 0
+	},
+/obj/item/weapon/reagent_containers/food/drinks/flask/barflask{
+	pixel_x = -4;
+	pixel_y = 8
+	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/heads/hos)
 "oX" = (
@@ -14091,6 +14098,7 @@
 	pixel_x = -20;
 	pixel_y = -25
 	},
+/obj/structure/flora/pottedplant/stoutbush,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/heads/cmo)
 "wg" = (
@@ -24323,7 +24331,6 @@
 /turf/simulated/open,
 /area/medical/surgery_hallway)
 "My" = (
-/obj/structure/flora/pottedplant/stoutbush,
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 9
 	},
@@ -24339,6 +24346,7 @@
 /obj/machinery/camera/network/medbay{
 	dir = 4
 	},
+/obj/machinery/computer/communications,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/heads/cmo)
 "Mz" = (
@@ -28415,13 +28423,8 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/shuttle/excursion/tether)
 "SP" = (
-/obj/structure/table/woodentable,
-/obj/item/device/taperecorder{
-	pixel_y = 0
-	},
-/obj/item/weapon/reagent_containers/food/drinks/flask/barflask{
-	pixel_x = -4;
-	pixel_y = 8
+/obj/machinery/computer/communications{
+	dir = 1
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/heads/hos)
@@ -35038,12 +35041,12 @@ ab
 ab
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
+ad
+ad
+ae
+ad
+ad
+ae
 aa
 aa
 aa
@@ -35182,10 +35185,10 @@ ab
 ab
 aa
 aa
+ae
 aa
 aa
-aa
-aa
+ad
 aa
 aa
 aa
@@ -35324,10 +35327,10 @@ ab
 ab
 aa
 aa
+ae
 aa
 aa
-aa
-aa
+ad
 aa
 aa
 aa
@@ -35467,9 +35470,9 @@ Me
 uK
 uK
 Me
-aa
-aa
-aa
+ae
+ae
+ad
 aa
 aa
 aa
@@ -35611,7 +35614,7 @@ wf
 xh
 aa
 aa
-aa
+ae
 aa
 aa
 aa
@@ -35753,7 +35756,7 @@ NP
 xh
 aa
 aa
-aa
+ad
 aa
 aa
 aa
@@ -35895,7 +35898,7 @@ NP
 xh
 aa
 aa
-aa
+ad
 aa
 aa
 aa
@@ -36037,7 +36040,7 @@ NQ
 Me
 ab
 aa
-aa
+ad
 aa
 aa
 aa

--- a/maps/tether/tether-07-station3.dmm
+++ b/maps/tether/tether-07-station3.dmm
@@ -24346,7 +24346,7 @@
 /obj/machinery/camera/network/medbay{
 	dir = 4
 	},
-/obj/machinery/computer/communications,
+/obj/item/modular_computer/console/preset/command,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/heads/cmo)
 "Mz" = (
@@ -28423,7 +28423,7 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/shuttle/excursion/tether)
 "SP" = (
-/obj/machinery/computer/communications{
+/obj/item/modular_computer/console/preset/command{
 	dir = 1
 	},
 /turf/simulated/floor/wood,

--- a/maps/tether/tether-10-colony.dmm
+++ b/maps/tether/tether-10-colony.dmm
@@ -16848,6 +16848,24 @@
 	icon_state = "dark"
 	},
 /area/centcom/specops)
+"Hv" = (
+/obj/machinery/telecomms/relay/preset/centcom/tether/station_mid,
+/turf/unsimulated/floor{
+	icon_state = "steel"
+	},
+/area/centcom/command)
+"HL" = (
+/obj/machinery/telecomms/relay/preset/centcom/tether/midpoint,
+/turf/unsimulated/floor{
+	icon_state = "steel"
+	},
+/area/centcom/command)
+"JB" = (
+/obj/machinery/telecomms/relay/preset/centcom/tether/station_low,
+/turf/unsimulated/floor{
+	icon_state = "steel"
+	},
+/area/centcom/command)
 "JC" = (
 /obj/machinery/power/thermoregulator,
 /turf/unsimulated/floor{
@@ -16860,6 +16878,18 @@
 	icon_state = "dark"
 	},
 /area/centcom/specops)
+"JW" = (
+/obj/machinery/telecomms/relay/preset/centcom/tether/base_low,
+/turf/unsimulated/floor{
+	icon_state = "steel"
+	},
+/area/centcom/command)
+"Lb" = (
+/obj/machinery/telecomms/relay/preset/centcom/tether/base_high,
+/turf/unsimulated/floor{
+	icon_state = "steel"
+	},
+/area/centcom/command)
 "Nt" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/unsimulated/floor{
@@ -16893,6 +16923,18 @@
 	icon_state = "dark"
 	},
 /area/centcom/specops)
+"Rx" = (
+/obj/machinery/telecomms/relay/preset/centcom/underdark,
+/turf/unsimulated/floor{
+	icon_state = "steel"
+	},
+/area/centcom/command)
+"Sp" = (
+/obj/machinery/telecomms/relay/preset/centcom/tether/station_high,
+/turf/unsimulated/floor{
+	icon_state = "steel"
+	},
+/area/centcom/command)
 "UC" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/stack/cable_coil,
@@ -16911,6 +16953,12 @@
 	icon_state = "dark"
 	},
 /area/centcom/specops)
+"Xi" = (
+/obj/machinery/telecomms/relay/preset/centcom/tether/base_mid,
+/turf/unsimulated/floor{
+	icon_state = "steel"
+	},
+/area/centcom/command)
 "XA" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/weapon/smes_coil,
@@ -16922,6 +16970,12 @@
 	icon_state = "dark"
 	},
 /area/centcom/specops)
+"YM" = (
+/obj/machinery/telecomms/relay/preset/centcom/tether/sci_outpost,
+/turf/unsimulated/floor{
+	icon_state = "steel"
+	},
+/area/centcom/command)
 
 (1,1,1) = {"
 aa
@@ -34372,7 +34426,7 @@ ac
 nK
 nK
 nK
-nK
+CZ
 nK
 nK
 ac
@@ -34511,12 +34565,12 @@ Cg
 ho
 ho
 ac
-ac
-ac
-ac
-ac
-ac
-ac
+nK
+JW
+CE
+CE
+JB
+nK
 ac
 ac
 ac
@@ -34653,12 +34707,12 @@ Ch
 Ct
 ho
 ac
-ac
-ac
-ac
-ac
-ac
-ac
+nK
+Xi
+CE
+CE
+Hv
+nK
 ac
 ac
 ac
@@ -34795,12 +34849,12 @@ Ch
 BW
 ho
 ac
-ac
-ac
-ac
-ac
-ac
-ac
+nK
+Lb
+CE
+CE
+Sp
+nK
 ac
 ac
 ac
@@ -34937,12 +34991,12 @@ Ch
 Ct
 ho
 ac
-ac
-ac
-ac
-ac
-ac
-ac
+nK
+CE
+CE
+CE
+YM
+nK
 ac
 ac
 ac
@@ -35079,12 +35133,12 @@ Ch
 BW
 ho
 ac
-ac
-ac
-ac
-ac
-ac
-ac
+nK
+HL
+CE
+CE
+Rx
+nK
 ac
 ac
 ac
@@ -35221,12 +35275,12 @@ Ch
 Ct
 ho
 ac
-ac
-ac
-ac
-ac
-ac
-ac
+nK
+nK
+nK
+nK
+nK
+nK
 ac
 ac
 ac

--- a/maps/tether/tether_telecomms.dm
+++ b/maps/tether/tether_telecomms.dm
@@ -8,15 +8,24 @@
 	listening_level = Z_LEVEL_SURFACE_LOW
 	autolinkers = list("tbl_relay")
 
+/obj/machinery/telecomms/relay/preset/centcom/tether/base_low
+	listening_level = Z_LEVEL_SURFACE_LOW
+
 /obj/machinery/telecomms/relay/preset/tether/base_mid
 	id = "Base Relay 2"
 	listening_level = Z_LEVEL_SURFACE_MID
 	autolinkers = list("tbm_relay")
 
+/obj/machinery/telecomms/relay/preset/centcom/tether/base_mid
+	listening_level = Z_LEVEL_SURFACE_MID
+
 /obj/machinery/telecomms/relay/preset/tether/base_high
 	id = "Base Relay 3"
 	listening_level = Z_LEVEL_SURFACE_HIGH
 	autolinkers = list("tbh_relay")
+
+/obj/machinery/telecomms/relay/preset/centcom/tether/base_high
+	listening_level = Z_LEVEL_SURFACE_HIGH
 
 //Some coverage for midpoint
 /obj/machinery/telecomms/relay/preset/tether/midpoint
@@ -24,31 +33,49 @@
 	listening_level = Z_LEVEL_TRANSIT
 	autolinkers = list("tmp_relay")
 
+/obj/machinery/telecomms/relay/preset/centcom/tether/midpoint
+	listening_level = Z_LEVEL_TRANSIT
+
 // The station of course needs relays fluff-wise to connect to ground station. But again, no multi-z so, we need one for each z level.
 /obj/machinery/telecomms/relay/preset/tether/station_low
 	id = "Station Relay 1"
 	listening_level = Z_LEVEL_SPACE_LOW
 	autolinkers = list("tsl_relay")
 
+/obj/machinery/telecomms/relay/preset/centcom/tether/station_low
+	listening_level = Z_LEVEL_SPACE_LOW
+
 /obj/machinery/telecomms/relay/preset/tether/station_mid
 	id = "Station Relay 2"
 	listening_level = Z_LEVEL_SPACE_MID
 	autolinkers = list("tsm_relay")
+
+/obj/machinery/telecomms/relay/preset/centcom/tether/station_mid
+	listening_level = Z_LEVEL_SPACE_MID
 
 /obj/machinery/telecomms/relay/preset/tether/station_high
 	id = "Station Relay 3"
 	listening_level = Z_LEVEL_SPACE_HIGH
 	autolinkers = list("tsh_relay")
 
+/obj/machinery/telecomms/relay/preset/centcom/tether/station_high
+	listening_level = Z_LEVEL_SPACE_HIGH
+
 /obj/machinery/telecomms/relay/preset/tether/sci_outpost
 	id = "Science Outpost Relay"
 	listening_level = Z_LEVEL_SOLARS
 	autolinkers = list("sci_o_relay")
 
+/obj/machinery/telecomms/relay/preset/centcom/tether/sci_outpost
+	listening_level = Z_LEVEL_SOLARS
+
 /obj/machinery/telecomms/relay/preset/underdark
 	id = "Mining Underground Relay"
 	listening_level = Z_LEVEL_UNDERDARK
 	autolinkers = list("ud_relay")
+
+/obj/machinery/telecomms/relay/preset/centcom/underdark
+	listening_level = Z_LEVEL_UNDERDARK
 
 // #### Hub ####
 /obj/machinery/telecomms/hub/preset/tether


### PR DESCRIPTION
- Brings pizza back at 50 points which it was supposed to be.
- Changes the Thieves Cave POI, it is more difficult with less reliable (but still decent) loot
- Adds an airlock to the thieves cave POI so the mobs do not wander around.
- Removes an extra, unused enviornment sensor from the expedition shuttle
- Temporarily removes the cryopod from the shuttle Fixes #5714
- Moves medical's blood packs into freezers
- Changes shuttle walls to reinforced steel
- Adds Modular Command Consoles to Heads of Staff Offices (except HoP/CD since they are next to the bridge)
- Adds two keycard authentication devices in the command conference room - Headmin request
- Adds some micrometeorite shielding for the CMO's office, because runtime must live.
- Reduces armor of the HoS Voidsuit (Now equivalent to a security voidsuit) - Headmin request
- Fixes some graphical errors on pills and pillbottles.
- Allows ERT Frequencies to work on the Tether again