### PR TITLE
Customise Say Verb Change

### DIFF
--- a/code/modules/mob/living/living_vr.dm
+++ b/code/modules/mob/living/living_vr.dm
@@ -1,6 +1,6 @@
 /mob/living/verb/customsay()
 	set category = "IC"
-	set name = "Customise Say Verbs"
+	set name = "Customise Speech Verbs"
 	set desc = "Customise the text which appears when you type- e.g. 'says', 'asks', 'exclaims'."
 
 	if(src.client)


### PR DESCRIPTION
Changes the "customise say verb" verb to "customise speech verb", solving a small problem of inconvenience that arises when typing "say" incompletely into the command bar, such as if you have a bad habit solidifed into muscle memory.