### PR TITLE
Actually fixes icon scaling on later byond versions

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -1,6 +1,6 @@
 /atom/movable
 	layer = OBJ_LAYER
-	appearance_flags = TILE_BOUND|PIXEL_SCALE
+	appearance_flags = TILE_BOUND|PIXEL_SCALE|KEEP_TOGETHER //VOREStation Edit
 	var/last_move = null
 	var/anchored = 0
 	// var/elevation = 2    - not used anywhere

--- a/code/modules/client/preference_setup/vore/02_size.dm
+++ b/code/modules/client/preference_setup/vore/02_size.dm
@@ -46,7 +46,6 @@
 	character.weight_loss		= pref.weight_loss
 	character.fuzzy				= pref.fuzzy
 	character.appearance_flags	-= pref.fuzzy*PIXEL_SCALE
-	character.appearance_flags	|= KEEP_TOGETHER
 	character.resize(pref.size_multiplier, animate = FALSE)
 
 /datum/category_item/player_setup_item/vore/size/content(var/mob/user)

--- a/code/modules/vore/eating/living_vr.dm
+++ b/code/modules/vore/eating/living_vr.dm
@@ -658,7 +658,6 @@
 	set category = "Preferences"
 	set desc = "Switch sharp/fuzzy scaling for current mob."
 	appearance_flags ^= PIXEL_SCALE
-	appearance_flags ^= KEEP_TOGETHER
 
 /mob/living/examine(mob/user, distance, infix, suffix)
 	. = ..(user, distance, infix, suffix)


### PR DESCRIPTION
-Fixes the missing KEEP_TOGETHER flag required for overlay scaling in the newer versions.
-Fixes it for all atoms, not just mobs that have gone through vore setup. Literally nothing needs mismatched overlay scaling.
-Fixes the toggle scaling mode verb having been made to toggle the inheritance flag as well for no fucking reason what the hell.
-Actually tested working before pushing.