### PR TITLE
Makes it possible to mobswap with Fluffy

### DIFF
--- a/code/modules/mob/living/simple_mob/subtypes/animal/sif/fluffy_vr.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/sif/fluffy_vr.dm
@@ -18,6 +18,7 @@
 	see_in_dark = 5
 	mob_size = MOB_TINY
 	makes_dirt = FALSE	// No more dirt
+	mob_bump_flag = 0
 
 	response_help  = "scritches"
 	response_disarm = "bops"


### PR DESCRIPTION
When pets were restored that aspect Fluffy, due to being subtype of normally aggressive mob, got missed out. Fixes.

Also hopefully will discourage incidents involving murderboning QMs killing their pet since that is a thing now.