### PR TITLE
Unrestricts medical and research cloaks

### DIFF
--- a/code/modules/client/preference_setup/loadout/loadout_suit_vr.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_suit_vr.dm
@@ -1,9 +1,3 @@
-/datum/gear/suit/roles/poncho/cloak/research
-	allowed_roles = list("Research Director","Scientist", "Roboticist", "Xenobiologist", "Explorer", "Pathfinder")
-
-/datum/gear/suit/roles/poncho/cloak/medical
-	allowed_roles = list("Medical Doctor","Chief Medical Officer","Chemist","Paramedic","Geneticist", "Psychiatrist", "Field Medic")
-
 /datum/gear/suit/wintercoat/medical
 	allowed_roles = list("Medical Doctor","Chief Medical Officer","Chemist","Paramedic","Geneticist", "Psychiatrist", "Field Medic")
 


### PR DESCRIPTION
All other non-head cloaks have been unrestricted, but these had exceptions in _vr file and ended up being skipped over. Fixes that.