### PR TITLE
Tether Station 2 Map QoL Additions Attempt 3

### DIFF
--- a/maps/tether/tether-06-station2.dmm
+++ b/maps/tether/tether-06-station2.dmm
@@ -4432,9 +4432,6 @@
 /area/tether/exploration/crew)
 "gC" = (
 /obj/item/weapon/stool/padded,
-/obj/item/weapon/paper{
-	pixel_y = 31
-	},
 /turf/simulated/mineral/floor/vacuum,
 /area/mine/explored/upper_level)
 "gD" = (
@@ -7756,9 +7753,7 @@
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/structure/table/steel,
-/obj/item/weapon/paper{
-	pixel_y = 31
-	},
+/obj/item/weapon/paper,
 /obj/item/weapon/pen/blue{
 	pixel_x = 5;
 	pixel_y = 5
@@ -15385,24 +15380,18 @@
 /area/medical/morgue)
 "xy" = (
 /obj/effect/decal/cleanable/blood,
-/obj/item/weapon/paper{
-	pixel_y = 31
-	},
+/obj/item/weapon/paper,
 /turf/simulated/floor,
 /area/maintenance/station/sec_lower)
 "xz" = (
-/obj/item/weapon/paper{
-	pixel_y = 31
-	},
+/obj/item/weapon/paper,
 /obj/effect/rune,
 /obj/effect/decal/cleanable/blood,
 /obj/random/maintenance/engineering,
 /turf/simulated/floor,
 /area/maintenance/station/sec_lower)
 "xA" = (
-/obj/item/weapon/paper{
-	pixel_y = 31
-	},
+/obj/item/weapon/paper,
 /turf/simulated/floor,
 /area/maintenance/station/sec_lower)
 "xB" = (

--- a/maps/tether/tether-06-station2.dmm
+++ b/maps/tether/tether-06-station2.dmm
@@ -1732,27 +1732,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/interrogation)
 "cy" = (
-/obj/effect/floor_decal/borderfloor/shifted{
-	icon_state = "borderfloor_shifted";
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/lightorange/border/shifted{
-	icon_state = "bordercolor_shifted";
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/lightorange{
-	icon_state = "corner_white";
-	dir = 5
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/structure/table/steel,
-/obj/item/weapon/paper,
-/obj/item/weapon/pen/blue{
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/turf/simulated/floor/tiled,
-/area/security/security_cell_hallway)
+/obj/structure/device/piano,
+/turf/simulated/mineral/floor/vacuum,
+/area/mine/explored/upper_level)
 "cz" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -4449,10 +4431,12 @@
 /turf/simulated/floor/tiled,
 /area/tether/exploration/crew)
 "gC" = (
-/obj/effect/decal/cleanable/blood,
-/obj/item/weapon/paper,
-/turf/simulated/floor,
-/area/maintenance/station/sec_lower)
+/obj/item/weapon/stool/padded,
+/obj/item/weapon/paper{
+	pixel_y = 31
+	},
+/turf/simulated/mineral/floor/vacuum,
+/area/mine/explored/upper_level)
 "gD" = (
 /obj/structure/table/woodentable,
 /turf/simulated/floor/tiled,
@@ -7210,9 +7194,9 @@
 /area/tether/exploration/hallway)
 "kC" = (
 /obj/item/weapon/material/twohanded/spear/foam,
-/obj/item/weapon/storage/mre/menu12{
+/obj/item/weapon/storage/fancy/crayons{
 	desc = "Special food for special warriors of the expedition force.";
-	name = "spearman MRE"
+	name = "spearman ration"
 	},
 /turf/simulated/floor,
 /area/tether/exploration/hallway)
@@ -7758,29 +7742,29 @@
 /turf/simulated/floor/tiled,
 /area/tether/exploration/equipment)
 "lp" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 1;
-	icon_state = "borderfloor";
-	pixel_y = 0
-	},
-/obj/effect/floor_decal/corner/purple/border{
-	icon_state = "bordercolor";
+/obj/effect/floor_decal/borderfloor/shifted{
+	icon_state = "borderfloor_shifted";
 	dir = 1
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals7,
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 4
+/obj/effect/floor_decal/corner/lightorange/border/shifted{
+	icon_state = "bordercolor_shifted";
+	dir = 1
 	},
-/obj/machinery/camera/network/exploration,
-/obj/structure/table/rack/shelf,
-/obj/item/device/multitool/tether_buffered{
-	pixel_y = 2
+/obj/effect/floor_decal/corner/lightorange{
+	icon_state = "corner_white";
+	dir = 5
 	},
-/obj/item/weapon/storage/toolbox/mechanical{
-	pixel_y = -4
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/structure/table/steel,
+/obj/item/weapon/paper{
+	pixel_y = 31
+	},
+/obj/item/weapon/pen/blue{
+	pixel_x = 5;
+	pixel_y = 5
 	},
 /turf/simulated/floor/tiled,
-/area/tether/exploration/equipment)
+/area/security/security_cell_hallway)
 "lq" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 5
@@ -15400,27 +15384,27 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/medical/morgue)
 "xy" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+/obj/effect/decal/cleanable/blood,
+/obj/item/weapon/paper{
+	pixel_y = 31
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/medical/morgue)
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
 "xz" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
+/obj/item/weapon/paper{
+	pixel_y = 31
 	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/techfloor,
-/area/medical/morgue)
+/obj/effect/rune,
+/obj/effect/decal/cleanable/blood,
+/obj/random/maintenance/engineering,
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
 "xA" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
+/obj/item/weapon/paper{
+	pixel_y = 31
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/techfloor,
-/area/medical/morgue)
+/turf/simulated/floor,
+/area/maintenance/station/sec_lower)
 "xB" = (
 /turf/simulated/floor/tiled/techfloor,
 /area/medical/morgue)
@@ -15689,14 +15673,30 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/medical/morgue)
 "ya" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+/obj/effect/floor_decal/borderfloor{
+	dir = 1;
+	icon_state = "borderfloor";
+	pixel_y = 0
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
+/obj/effect/floor_decal/corner/purple/border{
+	icon_state = "bordercolor";
+	dir = 1
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/medical/morgue)
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/obj/machinery/camera/network/exploration,
+/obj/structure/table/rack/shelf,
+/obj/item/device/multitool/tether_buffered{
+	pixel_y = 2
+	},
+/obj/item/weapon/storage/toolbox/mechanical{
+	pixel_y = -4
+	},
+/obj/item/weapon/hand_labeler,
+/turf/simulated/floor/tiled,
+/area/tether/exploration/equipment)
 "yb" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
@@ -16041,26 +16041,39 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/medical/morgue)
 "yC" = (
-/obj/structure/table/steel,
-/obj/machinery/camera/network/medbay{
-	dir = 1
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
-/obj/effect/floor_decal/techfloor,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/medical/morgue)
 "yD" = (
-/obj/structure/table/steel,
-/obj/machinery/alarm{
-	dir = 1;
-	icon_state = "alarm0";
-	pixel_y = -22
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
 	},
-/obj/effect/floor_decal/techfloor,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/medical/morgue)
 "yE" = (
-/obj/effect/floor_decal/techfloor{
-	dir = 6
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/medical/morgue)
@@ -19088,12 +19101,19 @@
 /turf/simulated/floor/tiled/dark,
 /area/tether/station/public_meeting_room)
 "Dp" = (
-/obj/item/weapon/paper,
-/obj/effect/rune,
-/obj/effect/decal/cleanable/blood,
-/obj/random/maintenance/engineering,
-/turf/simulated/floor,
-/area/maintenance/station/sec_lower)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/medical/morgue)
 "Dq" = (
 /obj/machinery/camera/network/security{
 	icon_state = "camera";
@@ -19520,9 +19540,18 @@
 /turf/simulated/floor,
 /area/maintenance/station/exploration)
 "Ed" = (
-/obj/item/weapon/paper,
-/turf/simulated/floor,
-/area/maintenance/station/sec_lower)
+/obj/structure/table/steel,
+/obj/machinery/camera/network/medbay{
+	dir = 1
+	},
+/obj/effect/floor_decal/techfloor,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/medical/morgue)
 "Ee" = (
 /obj/item/weapon/paper_bin,
 /turf/simulated/floor,
@@ -19830,24 +19859,37 @@
 /turf/simulated/floor/tiled,
 /area/engineering/foyer_mezzenine)
 "EF" = (
-/obj/structure/shuttle/engine/propulsion{
-	dir = 8;
-	icon_state = "propulsion_l"
+/obj/structure/table/steel,
+/obj/machinery/alarm{
+	dir = 1;
+	icon_state = "alarm0";
+	pixel_y = -22
 	},
-/turf/space,
-/turf/simulated/shuttle/plating/airless/carry,
-/area/shuttle/large_escape_pod1/station{
-	base_turf = /turf/simulated/mineral/floor/vacuum
-	})
+/obj/effect/floor_decal/techfloor,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/medical/morgue)
 "EG" = (
-/obj/structure/shuttle/engine/propulsion{
-	dir = 8
+/obj/effect/floor_decal/techfloor{
+	dir = 6
 	},
-/turf/space,
-/turf/simulated/shuttle/plating/airless/carry,
-/area/shuttle/large_escape_pod1/station{
-	base_turf = /turf/simulated/mineral/floor/vacuum
-	})
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/button/crematorium{
+	req_access = list(6);
+	req_one_access = list(5);
+	pixel_x = -25;
+	pixel_y = 2
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/medical/morgue)
 "EH" = (
 /obj/random/junk,
 /obj/effect/floor_decal/techfloor{
@@ -19857,6 +19899,39 @@
 /turf/simulated/floor,
 /area/maintenance/station/sec_lower)
 "EI" = (
+/obj/effect/floor_decal/techfloor,
+/obj/effect/floor_decal/techfloor{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/morgue/crematorium{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/medical/morgue)
+"EJ" = (
+/obj/structure/shuttle/engine/propulsion{
+	dir = 8;
+	icon_state = "propulsion_l"
+	},
+/turf/space,
+/turf/simulated/shuttle/plating/airless/carry,
+/area/shuttle/large_escape_pod1/station{
+	base_turf = /turf/simulated/mineral/floor/vacuum
+	})
+"EK" = (
+/obj/structure/shuttle/engine/propulsion{
+	dir = 8
+	},
+/turf/space,
+/turf/simulated/shuttle/plating/airless/carry,
+/area/shuttle/large_escape_pod1/station{
+	base_turf = /turf/simulated/mineral/floor/vacuum
+	})
+"EL" = (
 /obj/structure/shuttle/engine/propulsion{
 	dir = 8;
 	icon_state = "propulsion_r"
@@ -31444,10 +31519,10 @@ TW
 PV
 RS
 aj
-cy
+lp
 cD
 aj
-cy
+lp
 cD
 cA
 as
@@ -31770,7 +31845,7 @@ vy
 vW
 wx
 xi
-xy
+yC
 xY
 fM
 uW
@@ -31912,7 +31987,7 @@ vy
 vX
 wy
 xj
-xz
+yD
 xZ
 yB
 yV
@@ -32054,9 +32129,9 @@ vz
 vY
 wz
 xk
-xA
-ya
-yC
+yE
+Dp
+Ed
 xg
 zo
 zP
@@ -32198,7 +32273,7 @@ wA
 xl
 xB
 xB
-yD
+EF
 uW
 zp
 zQ
@@ -32297,7 +32372,7 @@ RS
 Qs
 at
 cY
-gC
+xy
 RS
 cY
 cY
@@ -32340,7 +32415,7 @@ wB
 wB
 wB
 wB
-yE
+EG
 uW
 zq
 zR
@@ -32440,9 +32515,9 @@ Qs
 at
 fr
 RS
-Ed
+xA
 RS
-Ed
+xA
 RS
 bA
 cE
@@ -32482,7 +32557,7 @@ wC
 wC
 wC
 wC
-wC
+EI
 uW
 zr
 zS
@@ -32581,7 +32656,7 @@ RS
 Qs
 at
 RS
-Dp
+xz
 Ee
 RS
 RS
@@ -32634,11 +32709,11 @@ AN
 Ci
 Bw
 yY
-EF
-EG
-EG
-EG
-EI
+EJ
+EK
+EK
+EK
+EL
 yY
 ac
 ac
@@ -32713,8 +32788,8 @@ aa
 aa
 ac
 ac
-aP
-aP
+cy
+gC
 ac
 aP
 UZ
@@ -32726,7 +32801,7 @@ fT
 RS
 Ef
 RS
-gC
+xy
 cY
 bA
 cG
@@ -34161,7 +34236,7 @@ cZ
 iJ
 jy
 kp
-lp
+ya
 lk
 pF
 As

--- a/maps/tether/tether-06-station2.dmm
+++ b/maps/tether/tether-06-station2.dmm
@@ -7191,10 +7191,6 @@
 /area/tether/exploration/hallway)
 "kC" = (
 /obj/item/weapon/material/twohanded/spear/foam,
-/obj/item/weapon/storage/fancy/crayons{
-	desc = "Special food for special warriors of the expedition force.";
-	name = "spearman ration"
-	},
 /turf/simulated/floor,
 /area/tether/exploration/hallway)
 "kD" = (


### PR DESCRIPTION
Basically:

1. Adds a crematorium to the medical morgue for disposing of accidentally printed bodies (discussed it with medical a while back, they approved of it at the time). It's in the southeast corner, worked fine during local testing. Debated between adding it to the chapel or medical, decided on medical since we rarely have chaplains and medical needs to use it the most anyways. By the way, it doesn't glow while burning bodies and likes to lock up for a weird amount of time when you ignite without a corpse inside. If anyone experienced with code wants to try to fix that, i'd love it. I'd offer myself but icon_state updates are my bane right now.
2. Adds a hand labeller to explorer prep on the rack. Now you can label your locker so people don't loot the hell out of it (hopefully).
3. Adds a piano to maintenance. It alternates between a piano and minimoog, but they sound the same. I know people bitch at me every single time i discuss adding instruments, but for pete's sake the code got improved and you can just mute instruments if you don't wanna hear it. Stop whining and let people have their fun, for god's sake.

Images:
https://gyazo.com/81b8e10c8bcc27b03f8a32a090e895d3 - Explorer prep
https://gyazo.com/c85053dccbe991392f1cd0b3cd3a1167 - Morgue (button repositioned to look a bit better, but forgot a new screenie)
https://gyazo.com/2faec21a7d5f72df08ce85b0e9b0c477 - Maint piano

Hopefully working this time. Sorry for the PRs, but I'm still brand new to this mess.