### PR TITLE
Fixed an issue with multiple boot/shoe overlays.

### DIFF
--- a/code/game/objects/effects/decals/Cleanable/humans.dm
+++ b/code/game/objects/effects/decals/Cleanable/humans.dm
@@ -93,7 +93,6 @@ var/global/list/image/splatter_cache=list()
 				S.overlays += S.blood_overlay
 			if(S.blood_overlay && S.blood_overlay.color != basecolor)
 				S.blood_overlay.color = basecolor
-				S.overlays.Cut()
 				S.overlays += S.blood_overlay
 			S.blood_DNA |= blood_DNA.Copy()
 			perp.update_inv_shoes()

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -513,6 +513,7 @@
 	if(usr.put_in_hands(holding))
 		usr.visible_message("<span class='danger'>\The [usr] pulls a knife out of their boot!</span>")
 		holding = null
+		overlays -= image(icon, "[icon_state]_knife")
 	else
 		usr << "<span class='warning'>Your need an empty, unbroken hand to do that.</span>"
 		holding.forceMove(src)
@@ -557,7 +558,6 @@
 	update_icon()
 
 /obj/item/clothing/shoes/update_icon()
-	overlays.Cut()
 	if(holding)
 		overlays += image(icon, "[icon_state]_knife")
 	if(ismob(usr))


### PR DESCRIPTION
Fixed an issue where boot/shoe overlays would magically be cleaned by putting in a knife and stepping on blood.

Before this, putting a knife into a boot would cut (remove) all overlays, along with anything that called update_icon on them, which included by stepping on blood/oil.

This meant that phoron contaminated shoes could be "cleaned" by stepping on blood, masking the fact they were still contaminated. This also meant that you could "clean" blood off by putting in a knife.

With this, it makes it so putting in a knife/stepping into blood would work as expected. (See: https://i.imgur.com/z0jL4pt.gifv)

Additionally, it makes it so if you step into multiple blood stains with the same pair of shoes, they will mix. (See: https://i.imgur.com/SWoXrOM.png This is normal blood + Skrell blood.)

Boots used to test this was the Workboots, and I also made sure to put on a pair on magboots and enable/disable them just to ensure that the light still worked on them.

Was told to upload this here by Ascian