### PR TITLE
Fixes bump-swapping for prometheans

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/prometheans.dm
+++ b/code/modules/mob/living/carbon/human/species/station/prometheans.dm
@@ -47,7 +47,7 @@ var/datum/species/shapeshifter/promethean/prometheans
 
 	economic_modifier = 3
 
-	//gluttonous =	1 // VOREStation Edit. Redundant feature.
+	gluttonous =	1
 	virus_immune =	1
 	blood_volume =	560
 	brute_mod =		0.75

--- a/code/modules/mob/living/carbon/human/species/station/prometheans_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/prometheans_vr.dm
@@ -1,6 +1,9 @@
 /datum/species/shapeshifter/promethean
 	min_age = 18 //Required for server rules
 	max_age = 80
+	push_flags = ~HEAVY
+	swap_flags = ~HEAVY
+	gluttonous = 0
 	valid_transform_species = list(
 		"Human", "Unathi", "Tajara", "Skrell",
 		"Diona", "Teshari", "Monkey","Sergal",

--- a/code/modules/mob/living/simple_mob/subtypes/slime/xenobio/subtypes_vr.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/slime/xenobio/subtypes_vr.dm
@@ -1,6 +1,6 @@
 /mob/living/simple_mob/slime/xenobio
 	temperature_range = 5
-	mob_bump_flag = 0
+	mob_bump_flag = SLIME
 
 /mob/living/simple_mob/slime/xenobio/Initialize(mapload, var/mob/living/simple_mob/slime/xenobio/my_predecessor)
 	..()

--- a/code/modules/mob/living/simple_mob/subtypes/vore/morph/morph.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/morph/morph.dm
@@ -12,7 +12,7 @@
 	movement_cooldown = 1
 	status_flags = CANPUSH
 	pass_flags = PASSTABLE
-	mob_bump_flag = 0
+	mob_bump_flag = SLIME
 
 	min_oxy = 0
 	max_oxy = 0

--- a/code/modules/mob/living/simple_mob/subtypes/vore/shadekin/shadekin.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/shadekin/shadekin.dm
@@ -13,7 +13,7 @@
 	faction = "shadekin"
 	ui_icons = 'icons/mob/shadekin_hud.dmi'
 	mob_class = MOB_CLASS_HUMANOID
-	mob_bump_flag = 0
+	mob_bump_flag = HUMAN
 
 	maxHealth = 200
 	health = 200

--- a/code/modules/mob/living/simple_mob/subtypes/vore/vore.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/vore.dm
@@ -3,4 +3,4 @@
 	mob_bump_flag = 0
 
 /mob/living/simple_mob/vore/aggressive
-	mob_bump_flag = 1
+	mob_bump_flag = HEAVY


### PR DESCRIPTION
Fixes bump-swapping for prometheans (Fixes #5773)

Fixes being able to swap with hostile voremobs

Assigns more proper swapflags for slimes, shadekin and morphs (no gameplay changes)

Moves unnecesary vorestation edit from promethean file to _vr file