### PR TITLE
Updates mining job slots to match actual equipment counts

### DIFF
--- a/code/game/jobs/job/z_all_jobs_vr.dm
+++ b/code/game/jobs/job/z_all_jobs_vr.dm
@@ -26,7 +26,6 @@
 	disallow_jobhop = TRUE
 
 /datum/job/doctor
-	total_positions = 5
 	spawn_positions = 5
 
 /datum/job/janitor //Lots of janitor substations on station.
@@ -37,40 +36,19 @@
 /datum/job/librarian
 	alt_titles = list("Journalist", "Historian", "Writer")
 
-/datum/job/officer
-	total_positions = 4
-	spawn_positions = 4
-
 /datum/job/cargo_tech
 	total_positions = 3
 	spawn_positions = 3
-
-/datum/job/psychiatrist
-	total_positions = 1
-	spawn_positions = 1
-
-/datum/job/mining
-	total_positions = 4
-	spawn_positions = 4
 
 /datum/job/cyborg
 	total_positions = 4 //Along with one able to spawn later in the round.
 	spawn_positions = 3 //Let's have 3 able to spawn in roundstart
 
-/datum/job/bartender
-	total_positions = 2
-	spawn_positions = 2
-
 /datum/job/chef
 	total_positions = 2 //IT TAKES A LOT TO MAKE A STEW
 	spawn_positions = 2 //A PINCH OF SALT AND LAUGHTER, TOO
 
-/datum/job/engineer
-	total_positions = 5
-	spawn_positions = 5
-
 /datum/job/atmos
-	total_positions = 3
 	spawn_positions = 3
 
 /datum/job/scientist


### PR DESCRIPTION
I dunno when why it was set to four of all numbers back in 2017 of all times... But map is simply not designed to support that many miners being normally present and practice proves that three miners being around is more than enough to provide anything station may need and more.

Also purges a ton of unnecessary redefines/overrides in override file that would be same even without overriding.