### PR TITLE
Restricts AI intercepting messages

### DIFF
--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -1096,7 +1096,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 			P.conversations.Add("\ref[src]")
 
 
-		if (prob(15)) //Give the AI a chance of intercepting the message
+		if (prob(5) && security_level >= SEC_LEVEL_BLUE) //Give the AI a chance of intercepting the message		//VOREStation Edit: no spam interception on lower codes + lower interception chance
 			var/who = src.owner
 			if(prob(50))
 				who = P.owner

--- a/code/modules/events/money_spam.dm
+++ b/code/modules/events/money_spam.dm
@@ -101,11 +101,13 @@
 
 			last_spam_time = world.time
 
+			/*	//VOREStation Removal: no need to spam the AI tenfold
 			if (prob(50)) //Give the AI an increased chance to intercept the message
 				for(var/mob/living/silicon/ai/ai in mob_list)
 					// Allows other AIs to intercept the message but the AI won't intercept their own message.
 					if(ai.aiPDA != P && ai.aiPDA != src)
 						ai.show_message("<i>Intercepted message from <b>[sender]</b></i> (Unknown / spam?) <i>to <b>[P:owner]</b>: [message]</i>")
+			*/
 
 			//Commented out because we don't send messages like this anymore.  Instead it will just popup in their chat window.
 			//P.tnote += "<i><b>&larr; From [sender] (Unknown / spam?):</b></i><br>[message]<br>"

--- a/code/modules/gamemaster/actions/money_spam.dm
+++ b/code/modules/gamemaster/actions/money_spam.dm
@@ -101,11 +101,13 @@
 
 				last_spam_time = world.time
 
+				/*	//VOREStation Removal: no need to spam the AI tenfold
 				if (prob(50)) //Give the AI an increased chance to intercept the message
 					for(var/mob/living/silicon/ai/ai in mob_list)
 						// Allows other AIs to intercept the message but the AI won't intercept their own message.
 						if(ai.aiPDA != P && ai.aiPDA != src)
 							ai.show_message("<i>Intercepted message from <b>[sender]</b></i> (Unknown / spam?) <i>to <b>[P:owner]</b>: [message]</i>")
+				*/
 
 				//Commented out because we don't send messages like this anymore.  Instead it will just popup in their chat window.
 				//P.tnote += "<i><b>&larr; From [sender] (Unknown / spam?):</b></i><br>[message]<br>"


### PR DESCRIPTION
AIs can now only randomly intercept PDA messsages on codes Blue, Red and Delta, and only with 5% chance (down from 15%).

Also, stops intercepting spam messages entirely, on any code.

Resolves #1360