### PR TITLE
Makes morphs sturdier

### DIFF
--- a/code/modules/mob/living/simple_mob/subtypes/vore/morph/morph.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/morph/morph.dm
@@ -24,9 +24,10 @@
 	max_n2 = 0
 
 	minbodytemp = 0
-	maxHealth = 150
-	health = 150
-	melee_damage_lower = 20
+	maxHealth = 250
+	health = 250
+	taser_kill = FALSE
+	melee_damage_lower = 15
 	melee_damage_upper = 20
 	see_in_dark = 8
 	attacktext = "glomps"


### PR DESCRIPTION
Increased health to 250

Removed the 'simplemob that takes damage from tasers' thing from them

Fixed damage range to be 15-20 rather than 20-20

All of those numbers originally were pretty much placeholders since they were not expected to get into direct combat or be under direct attack under normal circumstances, being adminspawn-only, player-control-only mob on HRP server, but whatdayaknow. These new numbers are meant to be more 'balanced' for what mob is.