### PR TITLE
Cargo hardsuit changes

### DIFF
--- a/code/datums/supplypacks/misc_vr.dm
+++ b/code/datums/supplypacks/misc_vr.dm
@@ -38,3 +38,43 @@
 	access = list(access_mining,
 				  access_eva)
 	one_access = TRUE
+
+/datum/supply_pack/misc/medical_rig
+	name = "medical hardsuit (empty)"
+	contains = list(
+			/obj/item/weapon/rig/medical = 1
+			)
+	cost = 150
+	containertype = /obj/structure/closet/crate/secure/gear
+	containername = "medical hardsuit crate"
+	access = access_medical
+
+/datum/supply_pack/misc/security_rig
+	name = "hazard hardsuit (empty)"
+	contains = list(
+			/obj/item/weapon/rig/hazard = 1
+			)
+	cost = 150
+	containertype = /obj/structure/closet/crate/secure/gear
+	containername = "hazard hardsuit crate"
+	access = access_armory
+
+/datum/supply_pack/misc/science_rig
+	name = "ami hardsuit (empty)"
+	contains = list(
+			/obj/item/weapon/rig/hazmat = 1
+			)
+	cost = 150
+	containertype = /obj/structure/closet/crate/secure/gear
+	containername = "ami hardsuit crate"
+	access = access_rd
+
+/datum/supply_pack/misc/ce_rig
+	name = "advanced voidsuit (empty)"
+	contains = list(
+			/obj/item/weapon/rig/ce = 1
+			)
+	cost = 150
+	containertype = /obj/structure/closet/crate/secure/gear
+	containername = "advanced voidsuit crate"
+	access = access_ce

--- a/code/modules/clothing/spacesuits/rig/suits/station_vr.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/station_vr.dm
@@ -21,7 +21,8 @@
 		)
 
 //Armor reduction for industrial suit
-/obj/item/weapon/rig/industrial
+/obj/item/weapon/rig/industrial/vendor
+	desc = "A heavy, powerful hardsuit used by construction crews and mining corporations. This is a mass production model with reduced armor."
 	armor = list(melee = 50, bullet = 10, laser = 20, energy = 15, bomb = 30, bio = 100, rad = 50)
 
 /obj/item/weapon/rig/ert/assetprotection

--- a/code/modules/mining/ore_redemption_machine/equipment_vendor.dm
+++ b/code/modules/mining/ore_redemption_machine/equipment_vendor.dm
@@ -38,7 +38,7 @@
 		new /datum/data/mining_equipment("Silver Pickaxe",				/obj/item/weapon/pickaxe/silver,									1200),
 		// new /datum/data/mining_equipment("Mining Conscription Kit",	/obj/item/storage/backpack/duffelbag/mining_conscript,				1000),
 		new /datum/data/mining_equipment("Space Cash",					/obj/item/weapon/spacecash/c100,									1000),
-		new /datum/data/mining_equipment("Hardsuit - Control Module",	/obj/item/weapon/rig/industrial,									2000),
+		new /datum/data/mining_equipment("Hardsuit - Control Module",	/obj/item/weapon/rig/industrial/vendor,									2000),
 		new /datum/data/mining_equipment("Hardsuit - Plasma Cutter",		/obj/item/rig_module/device/plasmacutter,						800),
 		new /datum/data/mining_equipment("Hardsuit - Drill",				/obj/item/rig_module/device/drill,								5000),
 		new /datum/data/mining_equipment("Hardsuit - Ore Scanner",		/obj/item/rig_module/device/orescanner,								1000),


### PR DESCRIPTION
- Adds new empty hardsuits to cargo.
- Splits the mining vendor Industrial suit from the cargo ordered one

https://github.com/VOREStation/VOREStation/pull/3736
Since the main reason for the nerf was due to the industrial hardsuit's availability in the mining vendor, probably should just nerf the one in the vendor instead of both the one in vendor and the one in cargo.