### PR TITLE
Makes mice start with 0 nutrition

### DIFF
--- a/code/modules/mob/living/simple_mob/subtypes/animal/passive/mouse_vr.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/passive/mouse_vr.dm
@@ -1,4 +1,6 @@
 /mob/living/simple_mob/animal/passive/mouse
+	nutrition = 0	//To prevent draining maint mice for infinite food. Low nutrition has no mechanical effect on simplemobs, so wont hurt mice themselves.
+
 	no_vore = 1 //Mice can't eat others due to the amount of bugs caused by it.
 	vore_taste = "cheese"
 


### PR DESCRIPTION
This will have no mechanical impact on mice themselves, as only simplemobs actually affected by nutrition in any way are xenobio slimes.

But it will prevent ability to get absolutely ridiculously disproportional amount of nutrition out of few mice by using Drain belly mode.