### PR TITLE
Screaming in map fixes

### DIFF
--- a/maps/tether/tether-05-station1.dmm
+++ b/maps/tether/tether-05-station1.dmm
@@ -7041,6 +7041,11 @@
 /obj/machinery/light/flamp/noshade,
 /turf/simulated/floor/grass,
 /area/hallway/station/atrium)
+"amJ" = (
+/obj/machinery/light/flamp/noshade,
+/obj/structure/flora/ausbushes/brflowers,
+/turf/simulated/floor/grass,
+/area/hallway/station/atrium)
 "amM" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
@@ -33612,11 +33617,11 @@ abh
 agv
 acp
 acy
-acy
-acy
-acy
+acG
 acF
-acT
+acG
+acF
+amJ
 acm
 acm
 acF
@@ -33753,7 +33758,7 @@ acV
 afW
 agB
 acp
-acy
+acF
 acD
 acI
 acI
@@ -33895,7 +33900,7 @@ aiI
 abh
 agC
 acp
-acT
+amJ
 amC
 acE
 acE
@@ -34605,7 +34610,7 @@ acN
 afC
 ajr
 acp
-acT
+amJ
 amD
 ami
 ami
@@ -34747,7 +34752,7 @@ ajo
 afC
 ajs
 acp
-acy
+acF
 acD
 acK
 acK
@@ -34890,11 +34895,11 @@ afC
 afe
 acp
 acy
-acy
-acy
-acy
+acG
 acF
-acT
+acG
+acF
+amJ
 acm
 acm
 acF

--- a/maps/tether/tether-05-station1.dmm
+++ b/maps/tether/tether-05-station1.dmm
@@ -1731,19 +1731,15 @@
 /area/maintenance/station/eng_lower)
 "adx" = (
 /obj/structure/table/marble,
-/obj/item/weapon/hand_labeler,
 /obj/machinery/floor_light/prebuilt{
 	on = 1
 	},
-/obj/item/weapon/reagent_containers/glass/rag,
 /obj/machinery/door/blast/shutters{
 	dir = 2;
 	id = "cafe2";
 	layer = 3.1;
 	name = "Cafe Shutters"
 	},
-/obj/item/weapon/reagent_containers/food/condiment/sugar,
-/obj/item/weapon/reagent_containers/spray/cleaner,
 /turf/simulated/floor/tiled,
 /area/hallway/station/atrium)
 "ady" = (
@@ -1751,15 +1747,11 @@
 /obj/machinery/floor_light/prebuilt{
 	on = 1
 	},
-/obj/machinery/chemical_dispenser/bar_coffee/full,
-/obj/machinery/button/remote/blast_door{
-	desc = "A remote control-switch for shutters.";
+/obj/machinery/door/blast/shutters{
+	dir = 2;
 	id = "cafe2";
-	name = "Cafe Shutters";
-	pixel_x = -10;
-	pixel_y = 36;
-	req_access = list();
-	req_one_access = list(25)
+	layer = 3.1;
+	name = "Cafe Shutters"
 	},
 /turf/simulated/floor/wood,
 /area/hallway/station/atrium)
@@ -6681,14 +6673,19 @@
 /obj/machinery/floor_light/prebuilt{
 	on = 1
 	},
-/obj/machinery/door/blast/shutters{
-	dir = 2;
+/obj/machinery/button/remote/blast_door{
+	desc = "A remote control-switch for shutters.";
 	id = "cafe2";
-	layer = 3.1;
-	name = "Cafe Shutters"
+	name = "Cafe Shutters";
+	pixel_x = -10;
+	pixel_y = 36;
+	req_access = list();
+	req_one_access = list(25)
 	},
-/obj/item/weapon/reagent_containers/food/drinks/shaker,
-/obj/item/weapon/reagent_containers/food/snacks/donut/jelly,
+/obj/item/weapon/hand_labeler,
+/obj/item/weapon/reagent_containers/glass/rag,
+/obj/item/weapon/reagent_containers/food/condiment/sugar,
+/obj/item/weapon/reagent_containers/spray/cleaner,
 /turf/simulated/floor/wood,
 /area/hallway/station/atrium)
 "amb" = (
@@ -6964,6 +6961,16 @@
 	},
 /turf/simulated/floor/water/pool,
 /area/hallway/station/atrium)
+"amy" = (
+/obj/structure/table/marble,
+/obj/machinery/floor_light/prebuilt{
+	on = 1
+	},
+/obj/item/weapon/reagent_containers/food/drinks/shaker,
+/obj/item/device/flashlight/lamp/green,
+/obj/item/weapon/reagent_containers/food/snacks/donut/jelly,
+/turf/simulated/floor/wood,
+/area/hallway/station/atrium)
 "amz" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/reagent_containers/food/snacks/donut/chaos,
@@ -7012,6 +7019,14 @@
 	layer = 3.1;
 	name = "Cafe Shutters"
 	},
+/turf/simulated/floor/wood,
+/area/hallway/station/atrium)
+"amG" = (
+/obj/structure/table/marble,
+/obj/machinery/floor_light/prebuilt{
+	on = 1
+	},
+/obj/machinery/chemical_dispenser/bar_coffee/full,
 /turf/simulated/floor/wood,
 /area/hallway/station/atrium)
 "amH" = (
@@ -34167,8 +34182,8 @@ acp
 acm
 adx
 adn
-ady
-acH
+ama
+amG
 acH
 amF
 amB
@@ -34307,10 +34322,10 @@ afa
 afg
 acp
 acm
-ama
+ady
 aga
+amy
 adM
-acH
 acH
 amF
 amB

--- a/maps/tether/tether-07-station3.dmm
+++ b/maps/tether/tether-07-station3.dmm
@@ -19553,7 +19553,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/wall,
+/turf/simulated/floor,
 /area/quartermaster/warehouse)
 "Ed" = (
 /obj/structure/cable/green{


### PR DESCRIPTION
Fixes a wall-door in cargo, to maint

Adds more tables to new cafe and moves stuff onto them to prevent snatching from under shutters. Also adds desk lamp to alleviate the fact that there is no lighting there.