### PR TITLE
Comments out design for DNA console

### DIFF
--- a/code/modules/research/designs/circuits.dm
+++ b/code/modules/research/designs/circuits.dm
@@ -75,11 +75,13 @@ CIRCUITS BELOW
 	build_path = /obj/item/weapon/circuitboard/operating
 	sort_string = "FACAA"
 
+/*		//VOREStation Removal: DNA modification specifically, cloning is still a thing that actually reasonably works
 /datum/design/circuit/scan_console
 	name = "DNA machine"
 	id = "scan_console"
 	build_path = /obj/item/weapon/circuitboard/scan_consolenew
 	sort_string = "FAGAA"
+*/
 
 /datum/design/circuit/clonecontrol
 	name = "cloning control console"


### PR DESCRIPTION
Primarily because of how broken it is, and it should really have been done back when genetics in general was being ripped and removed. This is basically last leftover remnant of it.

Does not touch cloning console, or scanner/grower pods for it as it actually seems to function reasonably well.