### PR TITLE
Fixes mouse nutrition runtime spam.

### DIFF
--- a/code/modules/mob/living/simple_mob/subtypes/animal/passive/mouse_vr.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/passive/mouse_vr.dm
@@ -1,5 +1,5 @@
 /mob/living/simple_mob/animal/passive/mouse
-	nutrition = 0	//To prevent draining maint mice for infinite food. Low nutrition has no mechanical effect on simplemobs, so wont hurt mice themselves.
+	nutrition = 20	//To prevent draining maint mice for infinite food. Low nutrition has no mechanical effect on simplemobs, so wont hurt mice themselves.
 
 	no_vore = 1 //Mice can't eat others due to the amount of bugs caused by it.
 	vore_taste = "cheese"


### PR DESCRIPTION
No more dividing by zero every life tick while also letting the mice have a mouse-appropriate non-powergamey amount of nutrition to drain. (ps. it's not "infinite food", the bellymode is called "drain" for a reason)