### PR TITLE
Adds Secondary Command Office

### DIFF
--- a/maps/tether/tether-02-surface2.dmm
+++ b/maps/tether/tether-02-surface2.dmm
@@ -12,8 +12,8 @@
 /turf/simulated/wall,
 /area/maintenance/lower/mining)
 "ae" = (
-/turf/simulated/wall,
-/area/vacant/vacant_site/gateway/lower)
+/turf/simulated/wall/r_wall,
+/area/bridge/secondary/meeting_room)
 "af" = (
 /obj/structure/table/steel,
 /obj/item/weapon/storage/box/bodybags,
@@ -41,21 +41,8 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/mining)
 "ak" = (
-/obj/machinery/door/firedoor/glass,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/door/airlock/maintenance/common,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/lower/public_garden_maintenence/upper)
+/turf/simulated/floor/carpet/purcarpet,
+/area/bridge/secondary/meeting_room)
 "al" = (
 /obj/effect/floor_decal/rust,
 /obj/effect/decal/cleanable/dirt,
@@ -72,8 +59,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/lower/public_garden_maintenence/upper)
 "am" = (
-/turf/simulated/floor/plating,
-/area/vacant/vacant_site/gateway/lower)
+/obj/structure/bed/chair/comfy/black,
+/turf/simulated/floor/carpet/purcarpet,
+/area/bridge/secondary/meeting_room)
 "an" = (
 /turf/simulated/wall,
 /area/maintenance/substation/medsec)
@@ -104,36 +92,24 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/mining)
 "at" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/structure/bed/chair/comfy/black{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/vacant/vacant_site/gateway/lower)
-"au" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/cap/visible/supply{
+/obj/machinery/light{
 	dir = 8
 	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/plating,
-/area/vacant/vacant_site/gateway/lower)
+/turf/simulated/floor/carpet/purcarpet,
+/area/bridge/secondary/meeting_room)
+"au" = (
+/obj/structure/table/woodentable,
+/obj/item/weapon/book/manual/security_space_law,
+/turf/simulated/floor/carpet/purcarpet,
+/area/bridge/secondary/meeting_room)
 "av" = (
-/obj/structure/closet/crate,
-/turf/simulated/floor/plating,
-/area/vacant/vacant_site/gateway/lower)
+/obj/structure/table/woodentable,
+/obj/item/weapon/folder/blue,
+/turf/simulated/floor/carpet/purcarpet,
+/area/bridge/secondary/meeting_room)
 "aw" = (
 /obj/machinery/power/breakerbox/activated{
 	RCon_tag = "MedSec Substation Bypass"
@@ -226,9 +202,11 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/mining)
 "aI" = (
-/obj/structure/stairs/south,
-/turf/simulated/floor/plating,
-/area/vacant/vacant_site/gateway/lower)
+/obj/structure/bed/chair/comfy/black{
+	dir = 8
+	},
+/turf/simulated/floor/carpet/purcarpet,
+/area/bridge/secondary/meeting_room)
 "aJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/rust,
@@ -4690,11 +4668,11 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/public_garden_two)
 "kg" = (
-/obj/machinery/atmospherics/pipe/cap/visible/scrubbers{
-	dir = 8
+/obj/structure/bed/chair/comfy/black{
+	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/vacant/vacant_site/gateway/lower)
+/turf/simulated/floor/carpet/purcarpet,
+/area/bridge/secondary/meeting_room)
 "kh" = (
 /obj/machinery/firealarm{
 	dir = 2;
@@ -21808,6 +21786,192 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/tiled/dark,
 /area/rnd/outpost/xenobiology/outpost_slimepens)
+"OW" = (
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/structure/table/woodentable,
+/obj/item/weapon/paper_bin,
+/obj/item/weapon/pen,
+/turf/simulated/floor/carpet/purcarpet,
+/area/bridge/secondary/meeting_room)
+"OX" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/structure/table/woodentable,
+/obj/item/weapon/folder/red,
+/turf/simulated/floor/carpet/purcarpet,
+/area/bridge/secondary/meeting_room)
+"OY" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/bed/chair/comfy/black{
+	dir = 1
+	},
+/turf/simulated/floor/carpet/purcarpet,
+/area/bridge/secondary/meeting_room)
+"OZ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/bed/chair/comfy/black{
+	dir = 1
+	},
+/turf/simulated/floor/carpet/purcarpet,
+/area/bridge/secondary/meeting_room)
+"Pa" = (
+/obj/machinery/light_switch{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/simulated/floor/carpet/purcarpet,
+/area/bridge/secondary/meeting_room)
+"Pb" = (
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24;
+	pixel_y = 0
+	},
+/turf/simulated/floor/wood,
+/area/bridge/secondary/meeting_room)
+"Pc" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/wood,
+/area/bridge/secondary/meeting_room)
+"Pd" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/wood,
+/area/bridge/secondary/meeting_room)
+"Pe" = (
+/turf/simulated/floor/wood,
+/area/bridge/secondary/meeting_room)
+"Pf" = (
+/obj/machinery/camera/network/command{
+	dir = 8
+	},
+/obj/structure/reagent_dispensers/water_cooler/full,
+/turf/simulated/floor/wood,
+/area/bridge/secondary/meeting_room)
+"Pg" = (
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 1;
+	icon_state = "pdoor0";
+	id = "secondary_bridge_blast";
+	name = "Secondary Command Office Blast Doors";
+	opacity = 0
+	},
+/obj/machinery/door/airlock/maintenance/command,
+/turf/simulated/floor/plating,
+/area/bridge/secondary/meeting_room)
+"Ph" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/wood,
+/area/bridge/secondary/meeting_room)
+"Pi" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/turf/simulated/floor/wood,
+/area/bridge/secondary/meeting_room)
+"Pj" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/wood,
+/area/bridge/secondary/meeting_room)
+"Pk" = (
+/obj/structure/table/woodentable,
+/obj/item/weapon/storage/box/cups,
+/obj/machinery/alarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
+	},
+/turf/simulated/floor/wood,
+/area/bridge/secondary/meeting_room)
+"Pl" = (
+/obj/structure/cable/green,
+/obj/machinery/power/apc{
+	cell_type = /obj/item/weapon/cell/apc;
+	dir = 8;
+	name = "west bump";
+	pixel_x = -28
+	},
+/turf/simulated/floor/wood,
+/area/bridge/secondary/meeting_room)
+"Pm" = (
+/obj/structure/table/woodentable,
+/obj/machinery/newscaster{
+	pixel_x = 28
+	},
+/turf/simulated/floor/wood,
+/area/bridge/secondary/meeting_room)
+"Pn" = (
+/obj/machinery/keycard_auth{
+	pixel_x = -24
+	},
+/turf/simulated/floor/wood,
+/area/bridge/secondary/meeting_room)
+"Po" = (
+/obj/machinery/keycard_auth{
+	pixel_x = 24
+	},
+/turf/simulated/floor/wood,
+/area/bridge/secondary/meeting_room)
+"Pp" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/bridge/secondary/meeting_room)
+"Pq" = (
+/obj/machinery/photocopier,
+/turf/simulated/floor/wood,
+/area/bridge/secondary/meeting_room)
+"Pr" = (
+/obj/structure/stairs/south,
+/turf/simulated/floor/wood,
+/area/bridge/secondary/meeting_room)
+"Ps" = (
+/obj/structure/table/woodentable,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/item/weapon/folder/blue,
+/turf/simulated/floor/wood,
+/area/bridge/secondary/meeting_room)
+"Pt" = (
+/obj/structure/table/woodentable,
+/obj/machinery/light,
+/obj/item/weapon/paper_bin,
+/obj/item/weapon/pen,
+/turf/simulated/floor/wood,
+/area/bridge/secondary/meeting_room)
+"Pu" = (
+/obj/structure/filingcabinet/chestdrawer,
+/turf/simulated/floor/wood,
+/area/bridge/secondary/meeting_room)
 
 (1,1,1) = {"
 aa
@@ -28653,14 +28817,14 @@ ae
 ae
 ae
 ae
-bn
-bn
-ak
-bn
-bn
-bn
-bn
-bn
+ae
+ae
+Pg
+ae
+ae
+ae
+ae
+ae
 bn
 bn
 bn
@@ -28792,16 +28956,16 @@ ac
 ac
 ac
 ae
-am
-am
-am
-am
-am
+ak
 at
-am
-am
-am
-aI
+kg
+ak
+Pb
+Ph
+Pl
+Pn
+Pe
+Pr
 ae
 cW
 cW
@@ -28935,15 +29099,15 @@ ac
 ac
 ae
 am
-am
-am
-am
-am
 au
-am
-am
-am
-aI
+OW
+OY
+Pc
+Pi
+Pe
+Pe
+Pe
+Pr
 ae
 cW
 cW
@@ -29077,15 +29241,15 @@ ac
 ac
 ae
 am
-am
-am
-am
-am
-kg
-am
-am
-ae
-ae
+av
+OX
+OZ
+Pd
+Pj
+Pe
+Pe
+Pp
+Ps
 ae
 cW
 cW
@@ -29218,16 +29382,16 @@ ac
 ac
 ac
 ae
-ae
-ae
-ae
-ae
-am
-am
-am
-am
-am
-av
+ak
+aI
+aI
+Pa
+Pe
+Pe
+Pe
+Pe
+Pe
+Pt
 ae
 cW
 cW
@@ -29359,17 +29523,17 @@ ac
 ac
 ac
 ac
-ac
-ac
-ac
-ac
 ae
-am
-am
-am
-am
-av
-av
+ae
+ae
+ae
+ae
+Pf
+Pk
+Pm
+Po
+Pq
+Pu
 ae
 cW
 cW

--- a/maps/tether/tether-03-surface3.dmm
+++ b/maps/tether/tether-03-surface3.dmm
@@ -669,7 +669,7 @@
 /area/tether/surfacebase/atrium_three)
 "bC" = (
 /obj/machinery/status_display{
-	pixel_y = 30
+	pixel_y = 32
 	},
 /obj/machinery/computer/supplycomp,
 /turf/simulated/floor/tiled/dark,
@@ -27309,7 +27309,7 @@
 	},
 /obj/machinery/door/blast/regular{
 	density = 0;
-	dir = 1;
+	dir = 8;
 	icon_state = "pdoor0";
 	id = "secondary_bridge_blast";
 	name = "Secondary Command Office Blast Doors";
@@ -27333,7 +27333,7 @@
 	},
 /obj/machinery/door/blast/regular{
 	density = 0;
-	dir = 1;
+	dir = 8;
 	icon_state = "pdoor0";
 	id = "secondary_bridge_blast";
 	name = "Secondary Command Office Blast Doors";
@@ -27354,7 +27354,7 @@
 	},
 /obj/machinery/door/blast/regular{
 	density = 0;
-	dir = 1;
+	dir = 8;
 	icon_state = "pdoor0";
 	id = "secondary_bridge_blast";
 	name = "Secondary Command Office Blast Doors";
@@ -27374,7 +27374,7 @@
 	},
 /obj/machinery/door/blast/regular{
 	density = 0;
-	dir = 1;
+	dir = 8;
 	icon_state = "pdoor0";
 	id = "secondary_bridge_blast";
 	name = "Secondary Command Office Blast Doors";
@@ -27398,7 +27398,7 @@
 	},
 /obj/machinery/door/blast/regular{
 	density = 0;
-	dir = 1;
+	dir = 8;
 	icon_state = "pdoor0";
 	id = "secondary_bridge_blast";
 	name = "Secondary Command Office Blast Doors";
@@ -27418,7 +27418,7 @@
 	},
 /obj/machinery/door/blast/regular{
 	density = 0;
-	dir = 1;
+	dir = 8;
 	icon_state = "pdoor0";
 	id = "secondary_bridge_blast";
 	name = "Secondary Command Office Blast Doors";

--- a/maps/tether/tether-03-surface3.dmm
+++ b/maps/tether/tether-03-surface3.dmm
@@ -507,8 +507,8 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/tether/surfacebase/shuttle_pad)
 "bh" = (
-/turf/simulated/wall,
-/area/vacant/vacant_site/gateway)
+/turf/simulated/wall/r_wall,
+/area/bridge/secondary)
 "bi" = (
 /turf/simulated/wall/r_wall,
 /area/tether/surfacebase/security/armory)
@@ -616,17 +616,24 @@
 /area/tether/surfacebase/reading_room)
 "bv" = (
 /turf/simulated/open,
-/area/vacant/vacant_site/gateway)
+/area/bridge/secondary)
 "bw" = (
-/turf/simulated/floor/plating,
-/area/vacant/vacant_site/gateway)
+/obj/structure/flora/pottedplant,
+/obj/effect/floor_decal/corner/blue/full{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/secondary)
 "bx" = (
 /turf/simulated/wall,
 /area/tether/surfacebase/security/armory)
 "by" = (
-/obj/machinery/atmospherics/pipe/cap/visible/supply,
-/turf/simulated/floor/plating,
-/area/vacant/vacant_site/gateway)
+/obj/machinery/ai_status_display{
+	pixel_y = 32
+	},
+/obj/machinery/computer/security,
+/turf/simulated/floor/tiled/dark,
+/area/bridge/secondary)
 "bz" = (
 /obj/structure/lattice,
 /obj/machinery/door/firedoor/glass,
@@ -640,16 +647,14 @@
 /turf/simulated/open,
 /area/tether/surfacebase/atrium_three)
 "bA" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/item/device/radio/intercom{
+	dir = 1;
+	pixel_y = 24;
+	req_access = list()
 	},
-/turf/simulated/floor/plating,
-/area/vacant/vacant_site/gateway)
+/obj/machinery/computer/communications,
+/turf/simulated/floor/tiled/dark,
+/area/bridge/secondary)
 "bB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -663,25 +668,12 @@
 /turf/simulated/floor/plating,
 /area/tether/surfacebase/atrium_three)
 "bC" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/steeldecal/steel_decals_central1{
-	dir = 8
+/obj/machinery/status_display{
+	pixel_y = 30
 	},
-/obj/machinery/door/firedoor/glass,
-/obj/machinery/door/airlock/multi_tile/metal/mait{
-	name = "Maintenance Access"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/monofloor{
-	dir = 8
-	},
-/area/tether/surfacebase/atrium_three)
+/obj/machinery/computer/supplycomp,
+/turf/simulated/floor/tiled/dark,
+/area/bridge/secondary)
 "bD" = (
 /obj/structure/table/rack,
 /obj/item/weapon/gun/energy/stunrevolver,
@@ -1073,40 +1065,19 @@
 /turf/simulated/wall,
 /area/rnd/outpost/xenobiology/outpost_hallway)
 "ck" = (
-/obj/effect/floor_decal/borderfloor{
+/obj/structure/flora/pottedplant,
+/obj/effect/floor_decal/corner/blue/full{
 	dir = 1
 	},
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 1
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7,
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/atrium_three)
+/turf/simulated/floor/tiled/dark,
+/area/bridge/secondary)
 "cl" = (
-/obj/machinery/firealarm{
-	dir = 2;
-	layer = 3.3;
-	pixel_x = 0;
-	pixel_y = 26
-	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 1
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7,
-/obj/effect/floor_decal/steeldecal/steel_decals7{
+/obj/machinery/computer/station_alert/all{
+	icon_state = "computer";
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/atrium_three)
+/turf/simulated/floor/tiled/dark,
+/area/bridge/secondary)
 "cm" = (
 /obj/machinery/camera/network/research,
 /obj/machinery/firealarm{
@@ -1121,21 +1092,8 @@
 /turf/simulated/floor/tiled,
 /area/rnd/outpost/xenobiology/outpost_hallway)
 "cn" = (
-/obj/machinery/atm{
-	pixel_y = 31
-	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 1
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 4
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7,
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/atrium_three)
+/turf/simulated/floor/tiled/dark,
+/area/bridge/secondary)
 "co" = (
 /obj/structure/table/rack,
 /obj/item/weapon/gun/energy/taser,
@@ -1504,80 +1462,32 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/reading_room)
 "cV" = (
-/obj/machinery/camera/network/tether,
-/obj/effect/floor_decal/borderfloor{
+/obj/structure/bed/chair/office/dark{
 	dir = 1
 	},
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 1
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 4
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7,
-/obj/machinery/door/firedoor/glass/hidden/steel{
-	dir = 2
-	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/atrium_three)
+/turf/simulated/floor/tiled/dark,
+/area/bridge/secondary)
 "cW" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 1
+/obj/machinery/computer/transhuman/resleeving{
+	dir = 8
 	},
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 1
-	},
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/lightgrey/bordercorner2{
-	dir = 1
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 4
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7,
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/atrium_three)
+/turf/simulated/floor/tiled/dark,
+/area/bridge/secondary)
 "cX" = (
-/obj/effect/floor_decal/steeldecal/steel_decals6{
-	dir = 1
+/obj/machinery/light{
+	dir = 8
 	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/computer/power_monitor{
+	dir = 4
 	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/atrium_three)
+/turf/simulated/floor/tiled/dark,
+/area/bridge/secondary)
 "cY" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 1
+/obj/structure/bed/chair/office/dark{
+	dir = 8
 	},
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 1
-	},
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/lightgrey/bordercorner2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 4
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7,
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/atrium_three)
+/turf/simulated/floor/tiled/dark,
+/area/bridge/secondary)
 "cZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -2278,14 +2188,11 @@
 /turf/simulated/floor/tiled/steel_dirty/virgo3b,
 /area/tether/surfacebase/outside/outside3)
 "eo" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central1{
+/obj/structure/bed/chair/office/dark{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/glass,
-/turf/simulated/floor/tiled/monofloor{
-	dir = 4
-	},
-/area/tether/surfacebase/atrium_three)
+/turf/simulated/floor/tiled/dark,
+/area/bridge/secondary)
 "ep" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/trash,
@@ -4026,17 +3933,14 @@
 /turf/simulated/floor/plating,
 /area/rnd/workshop)
 "hq" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals6{
+/obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/atrium_three)
+/obj/machinery/computer/crew{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/secondary)
 "hr" = (
 /obj/structure/flora/pottedplant/stoutbush,
 /obj/effect/floor_decal/techfloor{
@@ -4064,24 +3968,18 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/atrium_three)
 "ht" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 1
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Secondary Bridge";
+	departmentType = 5;
+	name = "Secondary Bridge RC";
+	pixel_x = -32;
+	pixel_y = 0
 	},
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 4
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7,
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/atrium_three)
+/obj/structure/table/reinforced,
+/obj/item/weapon/book/codex,
+/turf/simulated/floor/tiled/dark,
+/area/bridge/secondary)
 "hu" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 10
@@ -18136,15 +18034,9 @@
 /turf/simulated/floor/grass,
 /area/tether/surfacebase/public_garden_three)
 "DU" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/broken,
-/obj/machinery/atmospherics/pipe/cap/visible/scrubbers,
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/plating,
-/area/vacant/vacant_site/gateway)
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/dark,
+/area/bridge/secondary)
 "DV" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -23460,10 +23352,17 @@
 /turf/simulated/floor/tiled,
 /area/rnd/outpost/xenobiology/outpost_hallway)
 "MI" = (
-/obj/structure/shuttle/engine/propulsion,
-/turf/simulated/floor/reinforced,
-/turf/simulated/shuttle/plating/carry,
-/area/shuttle/tether/surface)
+/obj/machinery/alarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
+	},
+/obj/structure/table/reinforced,
+/obj/machinery/computer/med_data/laptop{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/secondary)
 "MJ" = (
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/airlock/research{
@@ -24120,6 +24019,14 @@
 /obj/structure/sign/xenobio,
 /turf/simulated/wall,
 /area/rnd/outpost/xenobiology/outpost_hallway)
+"Oa" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/structure/table/reinforced,
+/obj/item/weapon/folder/blue,
+/turf/simulated/floor/tiled/dark,
+/area/bridge/secondary)
 "Ob" = (
 /obj/structure/catwalk,
 /obj/machinery/camera/network/outside,
@@ -24163,6 +24070,12 @@
 "Of" = (
 /turf/simulated/wall/r_wall,
 /area/rnd/outpost/xenobiology/outpost_south_airlock)
+"Og" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/secondary)
 "Oh" = (
 /obj/machinery/light{
 	dir = 8;
@@ -24569,6 +24482,21 @@
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled/dark,
 /area/rnd/outpost/xenobiology/outpost_main)
+"OT" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/secondary)
+"OU" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/secondary)
 "OV" = (
 /obj/machinery/door/blast/regular{
 	density = 0;
@@ -24696,6 +24624,14 @@
 /obj/machinery/computer/security/xenobio,
 /turf/simulated/floor/wood,
 /area/rnd/outpost/xenobiology/outpost_office)
+"Pi" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/structure/table/reinforced,
+/obj/item/weapon/folder/white,
+/turf/simulated/floor/tiled/dark,
+/area/bridge/secondary)
 "Pj" = (
 /obj/machinery/door/firedoor/glass,
 /obj/structure/grille,
@@ -24881,6 +24817,48 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/outpost/xenobiology/outpost_autopsy)
+"PC" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/blue/border{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 6
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 5
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/blue/bordercorner2{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/bridge/secondary)
+"PD" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/blue/border{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 9
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 10
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/blue/bordercorner2{
+	dir = 6
+	},
+/turf/simulated/floor/tiled,
+/area/bridge/secondary)
 "PE" = (
 /obj/item/device/radio/intercom{
 	dir = 8;
@@ -25820,6 +25798,16 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/outpost/xenobiology/outpost_autopsy)
+"RJ" = (
+/obj/machinery/door/firedoor/glass,
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/turf/simulated/floor/plating,
+/area/bridge/secondary)
 "RK" = (
 /obj/structure/closet/bombcloset,
 /obj/machinery/light,
@@ -26228,6 +26216,20 @@
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/tiled/steel,
 /area/rnd/outpost/xenobiology/outpost_first_aid)
+"SC" = (
+/obj/machinery/door/firedoor/glass,
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/turf/simulated/floor/plating,
+/area/bridge/secondary)
 "SD" = (
 /obj/structure/sign/redcross,
 /turf/simulated/wall,
@@ -26236,6 +26238,25 @@
 /obj/structure/sign/department/xenolab,
 /turf/simulated/wall,
 /area/rnd/outpost/xenobiology/outpost_main)
+"SF" = (
+/obj/machinery/door/firedoor/glass,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/airlock/glass_command{
+	name = "Secondary Control Room"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/secondary)
 "SG" = (
 /obj/structure/window/reinforced/full,
 /obj/structure/grille,
@@ -26251,6 +26272,20 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/rnd/outpost/xenobiology/outpost_main)
+"SH" = (
+/obj/machinery/door/firedoor/glass,
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/turf/simulated/floor/plating,
+/area/bridge/secondary)
 "SI" = (
 /turf/simulated/wall,
 /area/rnd/outpost/xenobiology/outpost_storage)
@@ -26649,6 +26684,36 @@
 /obj/structure/window/basic,
 /turf/simulated/floor/plating,
 /area/rnd/outpost/xenobiology/outpost_first_aid)
+"Ty" = (
+/obj/machinery/door/firedoor/glass,
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/turf/simulated/floor/plating,
+/area/bridge/secondary)
+"Tz" = (
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24;
+	pixel_y = 0
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/blue/border{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 6
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 5
+	},
+/turf/simulated/floor/tiled,
+/area/bridge/secondary)
 "TA" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/wood,
@@ -26657,6 +26722,838 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled,
 /area/rnd/outpost/xenobiology/outpost_breakroom)
+"TC" = (
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/blue/bordercorner{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 10
+	},
+/turf/simulated/floor/tiled,
+/area/bridge/secondary)
+"TD" = (
+/obj/machinery/button/windowtint{
+	id = "secondary_bridge";
+	pixel_x = 4;
+	pixel_y = 26
+	},
+/obj/structure/table/reinforced,
+/obj/machinery/button/remote/blast_door{
+	id = "secondary_bridge_blast";
+	name = "Secondary Command Office Blastdoors";
+	pixel_x = -6;
+	pixel_y = 28
+	},
+/obj/machinery/recharger,
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/blue/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/bridge/secondary)
+"TE" = (
+/obj/structure/table/reinforced,
+/obj/item/device/radio{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/device/radio{
+	pixel_x = -2;
+	pixel_y = -2
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/blue/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/bridge/secondary)
+"TF" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/blue/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/blue/bordercorner2{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/bridge/secondary)
+"TG" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
+	},
+/turf/simulated/floor/tiled,
+/area/bridge/secondary)
+"TH" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/camera/network/command,
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/blue/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 4;
+	icon_state = "borderfloorcorner2";
+	pixel_y = 0
+	},
+/obj/effect/floor_decal/corner/blue/bordercorner2{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/bridge/secondary)
+"TI" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/blue/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/bridge/secondary)
+"TJ" = (
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_x = 0;
+	pixel_y = 28
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/blue/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/bridge/secondary)
+"TK" = (
+/obj/structure/table/reinforced,
+/obj/machinery/photocopier/faxmachine{
+	department = "Secondary Command Office"
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/blue/border{
+	dir = 5
+	},
+/turf/simulated/floor/tiled,
+/area/bridge/secondary)
+"TL" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/blue/border{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 6
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 5
+	},
+/turf/simulated/floor/tiled,
+/area/bridge/secondary)
+"TM" = (
+/turf/simulated/floor/tiled,
+/area/bridge/secondary)
+"TN" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled,
+/area/bridge/secondary)
+"TO" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled,
+/area/bridge/secondary)
+"TP" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/photocopier,
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/blue/border{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 9
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 10
+	},
+/turf/simulated/floor/tiled,
+/area/bridge/secondary)
+"TQ" = (
+/obj/machinery/light_switch{
+	dir = 4;
+	pixel_x = -28;
+	pixel_y = 0
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/blue/border{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 6
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 5
+	},
+/turf/simulated/floor/tiled,
+/area/bridge/secondary)
+"TR" = (
+/obj/structure/bed/chair/office/dark,
+/turf/simulated/floor/tiled,
+/area/bridge/secondary)
+"TS" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/turf/simulated/floor/tiled,
+/area/bridge/secondary)
+"TT" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/bed/chair/office/dark,
+/turf/simulated/floor/tiled,
+/area/bridge/secondary)
+"TU" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/bridge/secondary)
+"TV" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/turf/simulated/floor/tiled,
+/area/bridge/secondary)
+"TW" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/turf/simulated/floor/tiled,
+/area/bridge/secondary)
+"TX" = (
+/obj/machinery/alarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
+	},
+/obj/machinery/papershredder,
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/blue/border{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 9
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 10
+	},
+/turf/simulated/floor/tiled,
+/area/bridge/secondary)
+"TY" = (
+/obj/machinery/computer/card{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/blue/border{
+	dir = 10
+	},
+/turf/simulated/floor/tiled,
+/area/bridge/secondary)
+"TZ" = (
+/obj/machinery/computer/secure_data{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/blue/border,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/bridge/secondary)
+"Ua" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/structure/table/reinforced,
+/obj/machinery/computer/skills{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/blue/border,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/bridge/secondary)
+"Ub" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/structure/table/reinforced,
+/obj/item/weapon/paper_bin,
+/obj/item/weapon/pen,
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/blue/border,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/bridge/secondary)
+"Uc" = (
+/obj/structure/filingcabinet/filingcabinet,
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/blue/border,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/bridge/secondary)
+"Ud" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/atrium_three)
+"Ue" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/blue/border,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/blue/bordercorner2{
+	dir = 9
+	},
+/turf/simulated/floor/tiled,
+/area/bridge/secondary)
+"Uf" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/bridge/secondary)
+"Ug" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/blue/border,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloor/corner2,
+/obj/effect/floor_decal/corner/blue/bordercorner2,
+/turf/simulated/floor/tiled,
+/area/bridge/secondary)
+"Uh" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/blue/border,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/bridge/secondary)
+"Ui" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/machinery/disposal,
+/obj/effect/floor_decal/borderfloor{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/blue/border{
+	dir = 6
+	},
+/turf/simulated/floor/tiled,
+/area/bridge/secondary)
+"Uj" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 2;
+	layer = 3.3;
+	pixel_x = 0;
+	pixel_y = 26
+	},
+/obj/effect/floor_decal/corner/blue/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/atrium_three)
+"Uk" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/blue/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/atrium_three)
+"Ul" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/blue/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/atrium_three)
+"Um" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/effect/floor_decal/corner/blue/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/atrium_three)
+"Un" = (
+/obj/machinery/door/firedoor/glass,
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced/polarized/full{
+	id = "secondary_bridge"
+	},
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 1;
+	icon_state = "pdoor0";
+	id = "secondary_bridge_blast";
+	name = "Secondary Command Office Blast Doors";
+	opacity = 0
+	},
+/turf/simulated/floor/plating,
+/area/bridge/secondary)
+"Uo" = (
+/obj/machinery/door/firedoor/glass,
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced/polarized/full{
+	id = "secondary_bridge"
+	},
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 1;
+	icon_state = "pdoor0";
+	id = "secondary_bridge_blast";
+	name = "Secondary Command Office Blast Doors";
+	opacity = 0
+	},
+/turf/simulated/floor/plating,
+/area/bridge/secondary)
+"Up" = (
+/obj/machinery/door/firedoor/glass,
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/cable/green,
+/obj/structure/grille,
+/obj/structure/window/reinforced/polarized/full{
+	id = "secondary_bridge"
+	},
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 1;
+	icon_state = "pdoor0";
+	id = "secondary_bridge_blast";
+	name = "Secondary Command Office Blast Doors";
+	opacity = 0
+	},
+/turf/simulated/floor/plating,
+/area/bridge/secondary)
+"Uq" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 1;
+	icon_state = "pdoor0";
+	id = "secondary_bridge_blast";
+	name = "Secondary Command Office Blast Doors";
+	opacity = 0
+	},
+/obj/machinery/door/airlock/command{
+	name = "Secondary Command Office"
+	},
+/turf/simulated/floor/tiled,
+/area/bridge/secondary)
+"Ur" = (
+/obj/machinery/door/firedoor/glass,
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/cable/green,
+/obj/structure/grille,
+/obj/structure/window/reinforced/polarized/full{
+	id = "secondary_bridge"
+	},
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 1;
+	icon_state = "pdoor0";
+	id = "secondary_bridge_blast";
+	name = "Secondary Command Office Blast Doors";
+	opacity = 0
+	},
+/turf/simulated/floor/plating,
+/area/bridge/secondary)
+"Us" = (
+/obj/machinery/door/firedoor/glass,
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced/polarized/full{
+	id = "secondary_bridge"
+	},
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 1;
+	icon_state = "pdoor0";
+	id = "secondary_bridge_blast";
+	name = "Secondary Command Office Blast Doors";
+	opacity = 0
+	},
+/turf/simulated/floor/plating,
+/area/bridge/secondary)
+"Ut" = (
+/obj/machinery/camera/network/tether,
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/machinery/door/firedoor/glass/hidden/steel{
+	dir = 2
+	},
+/obj/effect/floor_decal/corner/blue/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/atrium_three)
+"Uu" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/effect/floor_decal/corner/blue/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/blue/bordercorner2{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/atrium_three)
+"Uv" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/blue/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 4;
+	icon_state = "borderfloorcorner2";
+	pixel_y = 0
+	},
+/obj/effect/floor_decal/corner/blue/bordercorner2{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/atrium_three)
+"Uw" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/effect/floor_decal/corner/blue/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/atrium_three)
+"Ux" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/effect/floor_decal/corner/blue/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/atrium_three)
+"Uy" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/machinery/atm{
+	pixel_y = 31
+	},
+/obj/effect/floor_decal/corner/blue/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/atrium_three)
+"Uz" = (
+/obj/structure/shuttle/engine/propulsion,
+/turf/simulated/floor/reinforced,
+/turf/simulated/shuttle/plating/carry,
+/area/shuttle/tether/surface)
 
 (1,1,1) = {"
 aa
@@ -33514,8 +34411,8 @@ bh
 bh
 bh
 bh
-gw
-ir
+bh
+Uj
 DW
 kn
 kS
@@ -33651,13 +34548,13 @@ bv
 bv
 bv
 bv
-bw
-bw
-bw
-bw
-bw
-gw
-ck
+PC
+Tz
+TL
+TQ
+TY
+bh
+Uk
 DW
 kn
 kT
@@ -33793,13 +34690,13 @@ bv
 bv
 bv
 bv
-bw
-bw
-bw
-bw
-bw
-gw
-cl
+PD
+TC
+TM
+TR
+TZ
+Un
+Ul
 jA
 kp
 kT
@@ -33936,12 +34833,12 @@ bh
 bh
 bh
 bh
-bw
-bw
-bw
-bw
-gw
-ix
+TD
+TM
+TS
+Ua
+Uo
+Um
 DW
 kq
 kU
@@ -34073,17 +34970,17 @@ ac
 ac
 bh
 bw
-bw
-bw
-bw
-bw
-bw
-bw
-bw
-bw
-bw
-gw
-cn
+cl
+cX
+ht
+Oa
+RJ
+TE
+TM
+TT
+Ub
+Uo
+Um
 jB
 kr
 kV
@@ -34214,18 +35111,18 @@ ac
 ac
 ac
 bh
-bw
-bw
-bw
-bw
-bw
-bw
-bw
-bw
-bw
-bw
-gw
-cV
+by
+cn
+cY
+cn
+Og
+SC
+TF
+TM
+TU
+Uc
+Uo
+Ut
 jC
 ks
 kT
@@ -34356,18 +35253,18 @@ ac
 ac
 ac
 bh
-bw
-bw
-bw
-bw
-bw
-bw
-bw
-bw
-bw
-bw
-gw
-cW
+bA
+cV
+cn
+DU
+OT
+SF
+TG
+TN
+TV
+Ue
+Up
+Uu
 jD
 kt
 kX
@@ -34498,18 +35395,18 @@ ac
 ac
 ac
 bh
-bw
-bw
-bw
-bw
-bw
-bw
-bw
-by
-DU
-bA
 bC
-cX
+cn
+eo
+cn
+OU
+SH
+TH
+TO
+TW
+Uf
+Uq
+Ud
 dK
 ku
 kS
@@ -34640,18 +35537,18 @@ ac
 ac
 ac
 bh
-bw
-bw
-bw
-bw
-bw
-bw
-bw
-bw
-bw
-bw
-eo
+ck
+cW
 hq
+MI
+Pi
+Ty
+TI
+TM
+TM
+Ug
+Ur
+Uv
 jF
 kv
 kS
@@ -34788,12 +35685,12 @@ bh
 bh
 bh
 bh
-bw
-bw
-bw
-bw
-gw
-cY
+TJ
+TM
+TM
+Uh
+Us
+Uw
 jG
 kw
 kY
@@ -34929,13 +35826,13 @@ ep
 eq
 eZ
 fa
-bx
-bw
-bw
-bw
-bw
-gw
-hs
+bh
+TK
+TP
+TX
+Ui
+bh
+Ux
 jH
 kx
 kY
@@ -35071,13 +35968,13 @@ bi
 bi
 bi
 bi
-bi
 bh
 bh
 bh
 bh
-gw
-ht
+bh
+bh
+Uy
 pS
 kx
 kZ
@@ -40527,7 +41424,7 @@ Nk
 Nl
 NJ
 NP
-MI
+Uz
 KU
 bg
 Ok
@@ -40669,7 +41566,7 @@ Nl
 Nl
 NK
 NP
-MI
+Uz
 KU
 bg
 Ok
@@ -40811,7 +41708,7 @@ Nm
 Nl
 NK
 NP
-MI
+Uz
 KU
 bg
 Ok

--- a/maps/tether/tether_areas2.dm
+++ b/maps/tether/tether_areas2.dm
@@ -672,6 +672,12 @@
 /area/hallway/station/docks
 	name = "\improper Docks Hallway"
 
+/area/bridge/secondary
+	name = "\improper Secondary Command Office"
+
+/area/bridge/secondary/meeting_room
+	name = "\improper Secondary Command Meeting Room"
+
 /area/maintenance/station
 	icon_state = "fsmaint"
 /area/maintenance/station/bridge


### PR DESCRIPTION
A secondary command office, mini-bridge away from bridge on the  Surface half of the station for when you need to get to needed control consoles without traversing elevator or real bridge is screwed. Located where gateway abandoned construction area used to be.

Screenshots:
Surface 3:
![Surface 3](https://image.prntscr.com/image/aChnbj7WTaKTKw8DmtVY_Q.png)
Surface 2:
![Surface 2](https://image.prntscr.com/image/-pYGQUs6SxyYR05wlyUMuw.png)
Surface 3, locked down (maint airlock on Surface 2 affected as well):
![Surface 3, locked down](https://image.prntscr.com/image/ZDf5eP0FQLawSjd5Msp_pA.png)

Windows between hallway and office are tintable, but not windows between office and control room.

This was originally a build for Building Competition, screenshots of original build below:
Surface 3: https://image.prntscr.com/image/DtOWOzU4ThiX_jBJn4Ik_Q.png
Surface 2: https://image.prntscr.com/image/LJAb29puThyvCUZFt-90Qw.png