### PR TITLE
Small Map Tweaks

### DIFF
--- a/maps/tether/tether-05-station1.dmm
+++ b/maps/tether/tether-05-station1.dmm
@@ -5627,7 +5627,7 @@
 /area/gateway/prep_room)
 "akc" = (
 /obj/machinery/door/blast/shutters{
-	dir = 2;
+	dir = 8;
 	id = "PubPrep";
 	layer = 3.3;
 	name = "Public Access Shutter"
@@ -5817,7 +5817,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/blast/shutters{
-	dir = 2;
+	dir = 8;
 	id = "PubPrep";
 	layer = 3.3;
 	name = "Public Access Shutter"

--- a/maps/tether/tether-06-station2.dmm
+++ b/maps/tether/tether-06-station2.dmm
@@ -16219,7 +16219,6 @@
 /area/medical/surgery2)
 "yx" = (
 /obj/structure/table/standard,
-/obj/item/stack/nanopaste,
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 6
 	},
@@ -20512,7 +20511,6 @@
 /area/maintenance/station/sec_lower)
 "Fg" = (
 /obj/structure/table/standard,
-/obj/item/stack/nanopaste,
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 5
 	},

--- a/maps/tether/tether-10-colony.dmm
+++ b/maps/tether/tether-10-colony.dmm
@@ -1098,7 +1098,8 @@
 /area/centcom/specops)
 "bP" = (
 /obj/machinery/door/blast/regular{
-	name = "When Everything else fails."
+	name = "When Everything else fails.";
+	dir = 4
 	},
 /turf/unsimulated/floor{
 	icon_state = "dark"


### PR DESCRIPTION
- Fixes orientation of gateway shutters
- Fixes orientation of HAP Blast Doors
- Reduces Medical starting Nanopaste to 1 (Same as old Medbay)