### PR TITLE
Brings amount of supplies in xenobio to pre-remap levels

### DIFF
--- a/maps/tether/tether-03-surface3.dmm
+++ b/maps/tether/tether-03-surface3.dmm
@@ -24686,7 +24686,7 @@
 "QH" = (
 /obj/structure/table/wooden_reinforced,
 /obj/item/stack/material/phoron{
-	amount = 12
+	amount = 4
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -25878,13 +25878,8 @@
 /obj/item/weapon/storage/box/monkeycubes,
 /obj/item/weapon/storage/box/monkeycubes,
 /obj/item/weapon/storage/box/monkeycubes,
-/obj/item/weapon/storage/box/monkeycubes,
-/obj/item/weapon/storage/box/monkeycubes,
-/obj/item/weapon/storage/box/monkeycubes,
-/obj/item/weapon/storage/box/monkeycubes,
-/obj/item/weapon/storage/box/monkeycubes,
-/obj/item/weapon/storage/box/monkeycubes,
-/obj/item/weapon/storage/box/monkeycubes,
+/obj/item/weapon/reagent_containers/food/snacks/monkeycube/wrapped,
+/obj/item/weapon/reagent_containers/food/snacks/monkeycube/wrapped,
 /obj/machinery/alarm{
 	dir = 8;
 	pixel_x = 22;


### PR DESCRIPTION
Phoron, back down to four sheets. Its more than enough to last until either Darkpurples breeding or Mining arrival already.

Monkeycube boxes, down to three boxes and two unboxed cubes. That many boxes was needless excess. And lack of unboxed cubes made it impossible to do solo xenobio as a borg.