### PR TITLE
Adjusts SME areas

### DIFF
--- a/maps/submaps/engine_submaps/engine_rust.dmm
+++ b/maps/submaps/engine_submaps/engine_rust.dmm
@@ -1,214 +1,2450 @@
-"aa" = (/turf/template_noop,/area/template_noop)
-"ab" = (/turf/space,/area/space)
-"ac" = (/obj/item/weapon/book/manual/rust_engine,/turf/template_noop,/area/template_noop)
-"ad" = (/obj/machinery/computer/general_air_control/supermatter_core{dir = 1; frequency = 1438; input_tag = "cooling_in"; name = "Engine Cooling Control"; output_tag = "cooling_out"; pressure_setting = 100; sensors = list("engine_sensor" = "Engine Core"); throwpass = 1},/turf/template_noop,/area/template_noop)
-"ae" = (/obj/machinery/button/remote/blast_door{desc = "A remote control-switch for the engine charging port."; id = "SupermatterPort"; name = "Radiation Collector Blast Doors"; pixel_x = -6; pixel_y = 7; req_access = list(10)},/obj/machinery/button/remote/blast_door{desc = "A remote control-switch for the engine control room blast doors."; id = "EngineBlast"; name = "Engine Monitoring Room Blast Doors"; pixel_x = 0; pixel_y = -3; req_access = list(10)},/turf/template_noop,/area/template_noop)
-"af" = (/obj/machinery/light{dir = 1},/turf/simulated/floor,/area/engineering/engine_room)
-"ag" = (/obj/structure/cable/cyan{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/machinery/door/airlock/hatch{icon_state = "door_locked"; id_tag = "engine_access_hatch"; locked = 1; name = "Fusion Core Access"; req_access = list(11)},/turf/simulated/floor,/area/engineering/engine_room)
-"ah" = (/obj/machinery/computer/fusion_fuel_control{id_tag = "engine"},/turf/simulated/floor,/area/engineering/engine_room)
-"ai" = (/obj/structure/lattice,/obj/structure/grille,/turf/space,/area/space)
-"aj" = (/obj/structure/lattice,/turf/space,/area/space)
-"ak" = (/turf/simulated/wall/r_wall,/area/engineering/engine_room)
-"al" = (/obj/machinery/door/blast/regular{dir = 4; icon_state = "pdoor1"; id = "EngineVent"; name = "Reactor Vent"; p_open = 0},/turf/simulated/floor/reinforced,/area/engineering/engine_room)
-"am" = (/obj/structure/sign/securearea{desc = "A warning sign which reads 'RADIOACTIVE AREA'"; icon_state = "radiation"; name = "RADIOACTIVE AREA"; pixel_x = 0; pixel_y = 0},/turf/simulated/wall/r_wall,/area/engineering/engine_room)
-"an" = (/turf/simulated/floor/reinforced,/area/engineering/engine_room)
-"ao" = (/obj/structure/window/phoronreinforced/full{icon_state = "phoronwindow0"},/obj/structure/grille,/turf/simulated/floor,/area/engineering/engine_room)
-"ap" = (/turf/space,/area/engineering/engine_smes)
-"aq" = (/turf/simulated/floor,/area/engineering/engine_room)
-"ar" = (/obj/structure/grille,/obj/structure/window/reinforced/full,/obj/machinery/door/firedoor/glass,/turf/simulated/floor,/area/engineering/engine_room)
-"as" = (/obj/structure/table/reinforced,/obj/fiftyspawner/deuterium,/turf/simulated/floor,/area/engineering/engine_room)
-"at" = (/obj/structure/table/reinforced,/obj/fiftyspawner/tritium,/turf/simulated/floor,/area/engineering/engine_room)
-"au" = (/obj/machinery/fusion_fuel_compressor,/turf/simulated/floor,/area/engineering/engine_room)
-"av" = (/obj/machinery/atmospherics/pipe/simple/heat_exchanging{dir = 6},/turf/space,/area/space)
-"aw" = (/obj/machinery/atmospherics/pipe/simple/heat_exchanging{dir = 4},/turf/space,/area/space)
-"ax" = (/obj/machinery/atmospherics/pipe/simple/heat_exchanging{dir = 4},/obj/structure/lattice,/turf/space,/area/space)
-"ay" = (/obj/machinery/atmospherics/pipe/simple/heat_exchanging{dir = 10},/turf/space,/area/space)
-"az" = (/obj/structure/cable/cyan{d1 = 2; d2 = 4; icon_state = "2-4"},/turf/simulated/floor/reinforced,/area/engineering/engine_room)
-"aA" = (/obj/structure/cable/cyan{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/reinforced,/area/engineering/engine_room)
-"aB" = (/obj/machinery/light{icon_state = "tube1"; dir = 8},/turf/simulated/floor,/area/engineering/engine_room)
-"aC" = (/obj/structure/cable/cyan{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor,/area/engineering/engine_room)
-"aD" = (/obj/structure/cable/cyan{d1 = 2; d2 = 8; icon_state = "2-8"},/turf/simulated/floor,/area/engineering/engine_room)
-"aE" = (/obj/machinery/door/firedoor/glass,/obj/machinery/door/airlock/glass_engineering,/turf/simulated/floor,/area/engineering/engine_room)
-"aF" = (/obj/machinery/atmospherics/pipe/simple/heat_exchanging,/obj/structure/lattice,/turf/space,/area/space)
-"aG" = (/obj/machinery/atmospherics/pipe/simple/heat_exchanging{dir = 6},/obj/structure/lattice,/turf/space,/area/space)
-"aH" = (/obj/machinery/atmospherics/pipe/simple/heat_exchanging{dir = 9},/obj/structure/lattice,/turf/space,/area/space)
-"aI" = (/obj/structure/cable/cyan{d1 = 1; d2 = 2; icon_state = "1-2"},/turf/simulated/floor/reinforced,/area/engineering/engine_room)
-"aJ" = (/obj/machinery/fusion_fuel_injector/mapped{dir = 8; id_tag = "engine"},/turf/simulated/floor,/area/engineering/engine_room)
-"aK" = (/obj/structure/cable/cyan{d1 = 1; d2 = 2; icon_state = "1-2"},/turf/simulated/floor,/area/engineering/engine_room)
-"aL" = (/obj/machinery/computer/gyrotron_control{id_tag = "engine"},/turf/simulated/floor,/area/engineering/engine_room)
-"aM" = (/obj/machinery/alarm{dir = 8; pixel_x = 25; pixel_y = 0},/turf/simulated/floor,/area/engineering/engine_room)
-"aN" = (/obj/machinery/atmospherics/pipe/simple/heat_exchanging,/turf/space,/area/space)
-"aO" = (/obj/machinery/atmospherics/pipe/simple/heat_exchanging{dir = 5},/turf/space,/area/space)
-"aP" = (/obj/machinery/power/fusion_core/mapped{id_tag = "engine"},/obj/structure/cable/cyan,/turf/simulated/floor/reinforced,/area/engineering/engine_room)
-"aQ" = (/obj/machinery/computer/fusion_core_control{id_tag = "engine"},/turf/simulated/floor,/area/engineering/engine_room)
-"aR" = (/obj/machinery/atmospherics/unary/outlet_injector{unacidable = 1; use_power = 1},/turf/simulated/floor/reinforced,/area/engineering/engine_room)
-"aS" = (/obj/machinery/air_sensor{frequency = 1438; id_tag = "engine_sensor"; output = 63},/turf/simulated/floor/reinforced,/area/engineering/engine_room)
-"aT" = (/obj/machinery/atmospherics/unary/vent_pump/high_volume{pump_direction = 0; use_power = 1},/turf/simulated/floor/reinforced,/area/engineering/engine_room)
-"aU" = (/obj/machinery/camera/network/engine,/obj/machinery/button/remote/airlock{id = "engine_access_hatch"; name = "Door Bolt Control"; pixel_x = -4; pixel_y = 28; req_access = list(10); specialfunctions = 4},/turf/simulated/floor,/area/engineering/engine_room)
-"aV" = (/obj/structure/table/reinforced,/obj/item/weapon/book/manual/rust_engine,/turf/simulated/floor,/area/engineering/engine_room)
-"aW" = (/obj/machinery/atmospherics/unary/outlet_injector{dir = 4; use_power = 1},/turf/simulated/floor/reinforced,/area/engineering/engine_room)
-"aX" = (/obj/machinery/atmospherics/pipe/manifold4w/visible/yellow,/turf/simulated/floor/reinforced,/area/engineering/engine_room)
-"aY" = (/obj/machinery/atmospherics/unary/outlet_injector{dir = 8; use_power = 1},/turf/simulated/floor/reinforced,/area/engineering/engine_room)
-"aZ" = (/obj/machinery/atmospherics/unary/vent_pump/high_volume{dir = 4; pump_direction = 0; use_power = 1},/turf/simulated/floor/reinforced,/area/engineering/engine_room)
-"ba" = (/obj/machinery/atmospherics/pipe/manifold4w/visible/red,/turf/simulated/floor/reinforced,/area/engineering/engine_room)
-"bb" = (/obj/machinery/atmospherics/unary/vent_pump/high_volume{dir = 8; pump_direction = 0; use_power = 1},/turf/simulated/floor/reinforced,/area/engineering/engine_room)
-"bc" = (/turf/simulated/wall/r_wall,/area/template_noop)
-"bd" = (/obj/machinery/atmospherics/pipe/simple/visible/yellow,/turf/simulated/floor/reinforced,/area/engineering/engine_room)
-"be" = (/obj/machinery/atmospherics/pipe/simple/visible/red,/turf/simulated/floor/reinforced,/area/engineering/engine_room)
-"bf" = (/obj/machinery/camera/network/engine{dir = 8},/turf/simulated/floor,/area/engineering/engine_room)
-"bg" = (/obj/machinery/atmospherics/pipe/simple/visible/yellow,/obj/structure/window/phoronreinforced/full{icon_state = "phoronwindow0"},/obj/structure/grille,/turf/simulated/floor,/area/engineering/engine_room)
-"bh" = (/obj/machinery/atmospherics/pipe/simple/visible/red,/obj/structure/window/phoronreinforced/full{icon_state = "phoronwindow0"},/obj/structure/grille,/turf/simulated/floor,/area/engineering/engine_room)
-"bi" = (/obj/structure/cable/cyan{d2 = 2; icon_state = "0-2"},/obj/machinery/power/apc{dir = 4; name = "east bump"; pixel_x = 28},/turf/simulated/floor,/area/engineering/engine_room)
-"bj" = (/obj/machinery/power/emitter/gyrotron/anchored{dir = 1; id_tag = "engine"},/obj/structure/cable/cyan{d2 = 2; icon_state = "0-2"},/obj/effect/floor_decal/industrial/warning{dir = 1},/turf/simulated/floor,/area/engineering/engine_room)
-"bk" = (/obj/machinery/atmospherics/pipe/simple/visible/yellow,/turf/simulated/floor,/area/engineering/engine_room)
-"bl" = (/obj/machinery/atmospherics/pipe/simple/visible/red,/turf/simulated/floor,/area/engineering/engine_room)
-"bm" = (/obj/structure/cable/cyan{d1 = 1; d2 = 4; icon_state = "1-4"},/obj/structure/cable/cyan{d1 = 2; d2 = 4; icon_state = "2-4"},/turf/simulated/floor,/area/engineering/engine_room)
-"bn" = (/obj/structure/cable/cyan{d1 = 1; d2 = 4; icon_state = "1-4"},/obj/structure/cable/cyan{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor,/area/engineering/engine_room)
-"bo" = (/turf/simulated/floor/tiled/techmaint,/area/template_noop)
-"bp" = (/obj/machinery/atmospherics/pipe/simple/visible/yellow,/obj/effect/floor_decal/industrial/warning{dir = 1},/turf/simulated/floor,/area/engineering/engine_room)
-"bq" = (/obj/effect/floor_decal/industrial/warning{dir = 1},/turf/simulated/floor,/area/engineering/engine_room)
-"br" = (/obj/machinery/atmospherics/pipe/simple/visible/red,/obj/effect/floor_decal/industrial/warning{dir = 1},/turf/simulated/floor,/area/engineering/engine_room)
-"bs" = (/obj/structure/cable/cyan{d1 = 1; d2 = 8; icon_state = "1-8"},/turf/simulated/floor,/area/engineering/engine_room)
-"bt" = (/obj/structure/cable/yellow{d1 = 2; d2 = 4; icon_state = "2-4"},/turf/simulated/floor,/area/engineering/engine_room)
-"bu" = (/obj/structure/cable/yellow{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/machinery/light{dir = 4; icon_state = "tube1"},/turf/simulated/floor,/area/engineering/engine_room)
-"bv" = (/obj/machinery/atmospherics/pipe/simple/visible/red{icon_state = "intact"; dir = 5},/turf/simulated/floor,/area/engineering/engine_room)
-"bw" = (/obj/machinery/atmospherics/pipe/simple/visible/red{icon_state = "intact"; dir = 4},/turf/simulated/floor,/area/engineering/engine_room)
-"bx" = (/obj/machinery/atmospherics/pipe/simple/visible/red{icon_state = "intact"; dir = 10},/turf/simulated/floor,/area/engineering/engine_room)
-"by" = (/obj/structure/cable/yellow{d1 = 1; d2 = 2; icon_state = "1-2"},/turf/simulated/floor,/area/engineering/engine_room)
-"bz" = (/turf/simulated/floor,/area/template_noop)
-"bA" = (/obj/structure/cable/cyan{d1 = 1; d2 = 4; icon_state = "1-4"},/obj/machinery/camera/network/engine{dir = 4},/obj/effect/floor_decal/industrial/warning{dir = 1},/turf/simulated/floor,/area/engineering/engine_room)
-"bB" = (/obj/structure/cable/cyan{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/machinery/atmospherics/pipe/simple/visible/yellow,/obj/effect/floor_decal/industrial/warning{dir = 1},/turf/simulated/floor,/area/engineering/engine_room)
-"bC" = (/obj/effect/floor_decal/industrial/warning/corner{dir = 8},/obj/machinery/button/remote/blast_door{desc = "A remote control-switch for the engine radiator viewport shutters."; id = "EngineRadiatorViewport"; name = "Engine Radiator Viewport Shutters"; pixel_x = -25; pixel_y = 0; req_access = list(10)},/turf/simulated/floor,/area/engineering/engine_room)
-"bD" = (/obj/machinery/atmospherics/pipe/manifold/visible/yellow{dir = 8},/turf/simulated/floor,/area/engineering/engine_room)
-"bE" = (/obj/machinery/atmospherics/pipe/manifold/visible/yellow{dir = 1},/turf/simulated/floor,/area/engineering/engine_room)
-"bF" = (/obj/machinery/atmospherics/pipe/simple/visible/yellow{dir = 4},/turf/simulated/floor,/area/engineering/engine_room)
-"bG" = (/obj/machinery/atmospherics/pipe/simple/visible/yellow{dir = 4},/obj/machinery/atmospherics/pipe/simple/visible/red,/turf/simulated/floor,/area/engineering/engine_room)
-"bH" = (/obj/machinery/atmospherics/pipe/simple/visible/yellow{dir = 10},/turf/simulated/floor,/area/engineering/engine_room)
-"bI" = (/obj/structure/cable/yellow{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/machinery/atmospherics/unary/vent_scrubber/on,/turf/simulated/floor,/area/engineering/engine_room)
-"bJ" = (/obj/structure/cable/cyan{d1 = 1; d2 = 4; icon_state = "1-4"},/obj/structure/cable/cyan{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/effect/floor_decal/industrial/warning{dir = 1},/turf/simulated/floor,/area/engineering/engine_room)
-"bK" = (/obj/machinery/atmospherics/pipe/simple/heat_exchanging{dir = 5},/obj/structure/lattice,/turf/space,/area/space)
-"bL" = (/obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction{dir = 8},/obj/structure/lattice,/turf/space,/area/space)
-"bM" = (/obj/structure/grille,/obj/structure/window/reinforced/full,/obj/structure/window/reinforced{dir = 8; health = 1e+006},/obj/machinery/door/blast/regular{density = 0; icon_state = "pdoor0"; id = "EngineRadiatorViewport"; name = "Engine Radiator Viewport Shutter"; opacity = 0},/obj/machinery/door/firedoor/glass,/obj/machinery/atmospherics/pipe/simple/visible/green{dir = 4},/turf/simulated/floor,/area/engineering/engine_room)
-"bN" = (/obj/effect/floor_decal/industrial/warning{dir = 8},/obj/machinery/atmospherics/pipe/simple/visible/green{dir = 4},/turf/simulated/floor,/area/engineering/engine_room)
-"bO" = (/obj/machinery/atmospherics/pipe/simple/visible/green{dir = 4},/obj/machinery/atmospherics/pipe/simple/visible/yellow,/turf/simulated/floor,/area/engineering/engine_room)
-"bP" = (/obj/machinery/atmospherics/pipe/manifold/visible/green{dir = 1},/obj/machinery/meter,/turf/simulated/floor,/area/engineering/engine_room)
-"bQ" = (/obj/machinery/atmospherics/pipe/manifold/visible/green{dir = 1},/turf/simulated/floor,/area/engineering/engine_room)
-"bR" = (/obj/machinery/atmospherics/pipe/simple/visible/green{dir = 4},/turf/simulated/floor,/area/engineering/engine_room)
-"bS" = (/obj/machinery/atmospherics/pipe/manifold/visible/green{dir = 1},/obj/effect/floor_decal/industrial/warning/corner,/turf/simulated/floor,/area/engineering/engine_room)
-"bT" = (/obj/machinery/atmospherics/pipe/simple/visible/green{dir = 10; icon_state = "intact";},/obj/effect/floor_decal/industrial/warning,/turf/simulated/floor,/area/engineering/engine_room)
-"bU" = (/obj/effect/floor_decal/industrial/warning,/turf/simulated/floor,/area/engineering/engine_room)
-"bV" = (/obj/effect/floor_decal/industrial/warning,/obj/machinery/atmospherics/pipe/manifold/visible/red{dir = 8; icon_state = "map";},/turf/simulated/floor,/area/engineering/engine_room)
-"bW" = (/obj/structure/cable/yellow{d2 = 2; icon_state = "0-2"},/obj/structure/cable/yellow,/obj/machinery/power/sensor{name = "Powernet Sensor - Engine Output"; name_tag = "Engine Output"},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 6},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 5},/turf/simulated/floor,/area/engineering/engine_room)
-"bX" = (/obj/structure/cable/cyan{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/effect/floor_decal/industrial/warning{dir = 1},/turf/simulated/floor,/area/engineering/engine_room)
-"bY" = (/obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction{dir = 8},/turf/space,/area/space)
-"bZ" = (/obj/structure/grille,/obj/structure/window/reinforced/full,/obj/structure/window/reinforced{dir = 8; health = 1e+006},/obj/machinery/door/blast/regular{density = 0; icon_state = "pdoor0"; id = "EngineRadiatorViewport"; name = "Engine Radiator Viewport Shutter"; opacity = 0},/obj/machinery/door/firedoor/glass,/obj/machinery/atmospherics/pipe/simple/visible/cyan{dir = 4},/turf/simulated/floor,/area/engineering/engine_room)
-"ca" = (/obj/machinery/atmospherics/pipe/simple/visible/cyan{dir = 10},/obj/effect/floor_decal/industrial/warning{dir = 8},/turf/simulated/floor,/area/engineering/engine_room)
-"cb" = (/obj/machinery/atmospherics/binary/pump,/turf/simulated/floor,/area/engineering/engine_room)
-"cc" = (/obj/machinery/atmospherics/binary/pump{dir = 1},/turf/simulated/floor,/area/engineering/engine_room)
-"cd" = (/obj/machinery/atmospherics/pipe/simple/visible/green,/obj/effect/floor_decal/industrial/warning{icon_state = "warning"; dir = 4},/turf/simulated/floor,/area/engineering/engine_room)
-"ce" = (/obj/machinery/atmospherics/binary/circulator{anchored = 1; dir = 1},/turf/simulated/floor,/area/engineering/engine_room)
-"cf" = (/obj/machinery/power/generator{anchored = 1; dir = 4},/obj/structure/cable/yellow{d2 = 2; icon_state = "0-2"},/turf/simulated/floor,/area/engineering/engine_room)
-"cg" = (/obj/machinery/atmospherics/binary/circulator{anchored = 1},/turf/simulated/floor,/area/engineering/engine_room)
-"ch" = (/obj/machinery/atmospherics/pipe/simple/visible/red,/obj/effect/floor_decal/industrial/warning{dir = 8},/turf/simulated/floor,/area/engineering/engine_room)
-"ci" = (/obj/structure/cable/yellow{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/machinery/atmospherics/unary/vent_pump/on{dir = 1},/turf/simulated/floor,/area/engineering/engine_room)
-"cj" = (/obj/machinery/atmospherics/pipe/simple/heat_exchanging{dir = 10},/obj/structure/lattice,/turf/space,/area/space)
-"ck" = (/obj/structure/grille,/obj/structure/window/reinforced/full,/obj/structure/window/reinforced{dir = 8; health = 1e+006},/obj/machinery/door/blast/regular{density = 0; icon_state = "pdoor0"; id = "EngineRadiatorViewport"; name = "Engine Radiator Viewport Shutter"; opacity = 0},/obj/machinery/door/firedoor/glass,/turf/simulated/floor,/area/engineering/engine_room)
-"cl" = (/obj/effect/floor_decal/industrial/warning{dir = 8},/obj/machinery/atmospherics/binary/pump/high_power,/turf/simulated/floor,/area/engineering/engine_room)
-"cm" = (/obj/machinery/atmospherics/portables_connector{dir = 1},/obj/effect/floor_decal/industrial/outline/yellow,/turf/simulated/floor,/area/engineering/engine_room)
-"cn" = (/obj/machinery/atmospherics/portables_connector{dir = 1},/obj/effect/floor_decal/industrial/outline/blue,/turf/simulated/floor,/area/engineering/engine_room)
-"co" = (/obj/machinery/atmospherics/pipe/simple/visible/cyan{dir = 6},/turf/simulated/floor,/area/engineering/engine_room)
-"cp" = (/obj/machinery/atmospherics/pipe/simple/visible/green,/obj/machinery/atmospherics/pipe/simple/visible/cyan{dir = 4},/obj/effect/floor_decal/industrial/warning/corner{dir = 4},/turf/simulated/floor,/area/engineering/engine_room)
-"cq" = (/obj/machinery/atmospherics/pipe/simple/visible/cyan{dir = 9},/obj/effect/floor_decal/industrial/warning{dir = 1},/turf/simulated/floor,/area/engineering/engine_room)
-"cr" = (/obj/effect/floor_decal/industrial/warning{dir = 1},/obj/structure/cable/yellow{d1 = 1; d2 = 4; icon_state = "1-4"},/turf/simulated/floor,/area/engineering/engine_room)
-"cs" = (/obj/machinery/atmospherics/pipe/simple/visible/yellow{dir = 5},/obj/effect/floor_decal/industrial/warning{dir = 1},/obj/structure/cable/yellow{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor,/area/engineering/engine_room)
-"ct" = (/obj/machinery/atmospherics/pipe/simple/visible/yellow{dir = 4},/obj/machinery/atmospherics/pipe/simple/visible/red,/obj/effect/floor_decal/industrial/warning/corner{dir = 1},/obj/structure/cable/yellow{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor,/area/engineering/engine_room)
-"cu" = (/obj/machinery/atmospherics/pipe/manifold/visible/yellow{dir = 4},/obj/structure/cable/yellow{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor,/area/engineering/engine_room)
-"cv" = (/obj/structure/cable/yellow{d1 = 1; d2 = 8; icon_state = "1-8"},/obj/structure/cable/yellow{d1 = 1; d2 = 2; icon_state = "1-2"},/turf/simulated/floor,/area/engineering/engine_room)
-"cw" = (/obj/machinery/atmospherics/pipe/simple/heat_exchanging{dir = 9},/turf/space,/area/space)
-"cx" = (/obj/machinery/atmospherics/pipe/simple/visible/cyan{dir = 5},/obj/effect/floor_decal/industrial/warning/corner{dir = 1},/turf/simulated/floor,/area/engineering/engine_room)
-"cy" = (/obj/machinery/atmospherics/pipe/simple/visible/cyan{dir = 4},/turf/simulated/floor,/area/engineering/engine_room)
-"cz" = (/obj/machinery/atmospherics/pipe/simple/visible/cyan{dir = 4},/obj/machinery/meter,/turf/simulated/floor,/area/engineering/engine_room)
-"cA" = (/obj/machinery/atmospherics/pipe/manifold/visible/cyan{dir = 4},/turf/simulated/floor,/area/engineering/engine_room)
-"cB" = (/obj/machinery/atmospherics/pipe/simple/visible/green{icon_state = "intact"; dir = 5},/obj/effect/floor_decal/industrial/warning/corner,/turf/simulated/floor,/area/engineering/engine_room)
-"cC" = (/obj/machinery/atmospherics/pipe/simple/visible/red{icon_state = "intact"; dir = 6},/obj/effect/floor_decal/industrial/warning,/turf/simulated/floor,/area/engineering/engine_room)
-"cD" = (/obj/machinery/atmospherics/pipe/manifold/visible/red{icon_state = "map"; dir = 4},/obj/machinery/meter,/turf/simulated/floor,/area/engineering/engine_room)
-"cE" = (/obj/machinery/atmospherics/pipe/simple/visible/yellow,/obj/machinery/meter,/turf/simulated/floor,/area/engineering/engine_room)
-"cF" = (/obj/structure/cable/yellow{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/machinery/camera/network/engine{dir = 8},/obj/machinery/firealarm{dir = 4; layer = 3.3; pixel_x = 26},/turf/simulated/floor,/area/engineering/engine_room)
-"cG" = (/turf/simulated/wall/r_wall,/area/engineering/engine_gas)
-"cH" = (/turf/simulated/floor,/area/engineering/engine_gas)
-"cI" = (/obj/effect/floor_decal/industrial/warning/corner,/obj/machinery/button/remote/blast_door{desc = "A remote control-switch for the engine control room blast doors."; id = "EngineEmitterPortWest"; name = "Engine Room Blast Doors"; pixel_x = 0; pixel_y = -25; req_access = null; req_one_access = list(11,24)},/obj/machinery/camera/network/engine{dir = 1},/turf/simulated/floor,/area/engineering/engine_gas)
-"cJ" = (/obj/effect/floor_decal/industrial/warning,/turf/simulated/floor,/area/engineering/engine_gas)
-"cK" = (/obj/effect/floor_decal/industrial/warning/corner{dir = 8},/turf/simulated/floor,/area/engineering/engine_gas)
-"cL" = (/obj/machinery/atmospherics/pipe/simple/visible/cyan,/turf/simulated/floor,/area/engineering/engine_room)
-"cM" = (/obj/effect/floor_decal/industrial/warning{icon_state = "warning"; dir = 4},/turf/simulated/floor,/area/engineering/engine_room)
-"cN" = (/obj/structure/cable/yellow{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/machinery/airlock_sensor/airlock_interior{id_tag = "eng_al_int_snsr"; master_tag = "engine_room_airlock"; pixel_x = 22; pixel_y = 0; req_access = list(10)},/turf/simulated/floor,/area/engineering/engine_room)
-"cO" = (/obj/machinery/door/blast/regular{dir = 4; icon_state = "pdoor1"; id = "EngineEmitterPortWest"; layer = 3.3; name = "Engine Gas Storage"},/obj/machinery/door/firedoor/glass,/turf/simulated/floor,/area/engineering/engine_gas)
-"cP" = (/obj/machinery/atmospherics/pipe/simple/visible/cyan{dir = 5},/turf/simulated/floor,/area/engineering/engine_room)
-"cQ" = (/obj/machinery/atmospherics/pipe/simple/visible/cyan{dir = 4},/obj/effect/floor_decal/industrial/warning/corner{dir = 4},/turf/simulated/floor,/area/engineering/engine_room)
-"cR" = (/obj/machinery/atmospherics/pipe/manifold/visible/cyan{dir = 4},/obj/effect/floor_decal/industrial/warning{dir = 1},/turf/simulated/floor,/area/engineering/engine_room)
-"cS" = (/obj/machinery/atmospherics/pipe/simple/visible/yellow{dir = 9},/obj/structure/cable/yellow{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor,/area/engineering/engine_room)
-"cT" = (/obj/structure/cable/yellow{d1 = 1; d2 = 8; icon_state = "1-8"},/turf/simulated/floor,/area/engineering/engine_room)
-"cU" = (/turf/simulated/floor/plating,/area/template_noop)
-"cV" = (/obj/effect/floor_decal/industrial/outline/blue,/obj/machinery/portable_atmospherics/canister/nitrogen,/turf/simulated/floor,/area/engineering/engine_gas)
-"cW" = (/obj/effect/floor_decal/industrial/outline/blue,/obj/machinery/portable_atmospherics/canister/nitrogen,/obj/machinery/button/remote/blast_door{desc = "A remote control-switch for the engine control room blast doors."; id = "EngineEmitterPortWest"; name = "Engine Room Blast Doors"; pixel_x = 0; pixel_y = 25; req_access = null; req_one_access = list(11,24)},/turf/simulated/floor,/area/engineering/engine_gas)
-"cX" = (/obj/effect/floor_decal/industrial/outline/yellow,/obj/machinery/portable_atmospherics/canister/carbon_dioxide,/obj/structure/extinguisher_cabinet{dir = 1; icon_state = "extinguisher_closed"; pixel_y = 32;},/turf/simulated/floor,/area/engineering/engine_gas)
-"cY" = (/obj/effect/floor_decal/industrial/warning/corner,/turf/simulated/floor,/area/engineering/engine_room)
-"cZ" = (/obj/machinery/button/remote/blast_door{id = "EngineVent"; name = "Reactor Ventillatory Control"; pixel_x = 0; pixel_y = -25; req_access = list(10)},/obj/effect/floor_decal/industrial/warning,/turf/simulated/floor,/area/engineering/engine_room)
-"da" = (/obj/machinery/atmospherics/pipe/simple/visible/cyan{dir = 5},/obj/effect/floor_decal/industrial/warning/corner{dir = 8},/turf/simulated/floor,/area/engineering/engine_room)
-"db" = (/obj/machinery/atmospherics/valve/digital{dir = 4; name = "Emergency Cooling Valve 2"},/obj/machinery/light,/turf/simulated/floor,/area/engineering/engine_room)
-"dc" = (/obj/machinery/atmospherics/pipe/simple/visible/red{icon_state = "intact"; dir = 4},/obj/machinery/alarm{dir = 1; icon_state = "alarm0"; pixel_y = -22},/turf/simulated/floor,/area/engineering/engine_room)
-"dd" = (/obj/machinery/atmospherics/pipe/simple/visible/red{icon_state = "intact"; dir = 9},/turf/simulated/floor,/area/engineering/engine_room)
-"de" = (/obj/item/device/radio/intercom{dir = 2; pixel_y = -24},/turf/simulated/floor,/area/engineering/engine_room)
-"df" = (/obj/effect/floor_decal/industrial/outline/blue,/obj/machinery/portable_atmospherics/canister/nitrogen,/obj/machinery/camera/network/engineering{dir = 4},/turf/simulated/floor,/area/engineering/engine_gas)
-"dg" = (/obj/machinery/atmospherics/unary/vent_pump/on{dir = 4},/turf/simulated/floor,/area/engineering/engine_gas)
-"dh" = (/obj/effect/decal/cleanable/dirt,/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 10},/turf/simulated/floor,/area/engineering/engine_gas)
-"di" = (/obj/effect/floor_decal/industrial/outline/yellow,/obj/machinery/portable_atmospherics/canister/carbon_dioxide,/obj/machinery/light/small{dir = 4; pixel_y = 0},/obj/machinery/alarm{dir = 8; pixel_x = 25; pixel_y = 0},/turf/simulated/floor,/area/engineering/engine_gas)
-"dj" = (/obj/structure/sign/securearea{desc = "A warning sign which reads 'HIGH VOLTAGE'"; icon_state = "shock"; name = "HIGH VOLTAGE"; pixel_y = 0},/turf/simulated/wall/r_wall,/area/engineering/engine_room)
-"dk" = (/obj/effect/floor_decal/industrial/outline/blue,/obj/machinery/portable_atmospherics/canister/phoron,/obj/machinery/light/small{dir = 8; pixel_x = 0},/turf/simulated/floor,/area/engineering/engine_gas)
-"dl" = (/obj/effect/floor_decal/industrial/outline/blue,/obj/machinery/portable_atmospherics/canister/phoron,/turf/simulated/floor,/area/engineering/engine_gas)
-"dm" = (/obj/effect/decal/cleanable/dirt,/obj/machinery/atmospherics/unary/vent_scrubber/on{dir = 4},/turf/simulated/floor,/area/engineering/engine_gas)
-"dn" = (/obj/effect/decal/cleanable/dirt,/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 10},/turf/simulated/floor,/area/engineering/engine_gas)
-"do" = (/obj/structure/window/reinforced{dir = 1},/obj/structure/cable/green{d2 = 2; icon_state = "0-2"},/obj/machinery/power/apc{dir = 4; name = "east bump"; pixel_x = 28},/obj/structure/closet/radiation,/obj/item/clothing/glasses/meson,/obj/item/clothing/glasses/meson,/turf/simulated/floor,/area/engineering/engine_gas)
-"dp" = (/obj/effect/floor_decal/industrial/outline/blue,/obj/machinery/portable_atmospherics/canister/phoron,/obj/machinery/firealarm{dir = 1; pixel_y = -24},/turf/simulated/floor,/area/engineering/engine_gas)
-"dq" = (/obj/effect/decal/cleanable/dirt,/obj/effect/floor_decal/industrial/warning/corner,/turf/simulated/floor,/area/engineering/engine_gas)
-"dr" = (/obj/effect/floor_decal/rust,/obj/effect/floor_decal/industrial/warning,/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/turf/simulated/floor,/area/engineering/engine_gas)
-"ds" = (/obj/effect/floor_decal/industrial/warning,/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/machinery/button/remote/blast_door{desc = "A remote control-switch for the engine control room blast doors."; id = "EngineEmitterPortWest2"; name = "Engine Room Blast Doors"; pixel_x = 25; pixel_y = 0; req_access = null; req_one_access = list(11,24)},/turf/simulated/floor,/area/engineering/engine_gas)
-"dt" = (/obj/structure/sign/securearea{desc = "A warning sign which reads 'RADIOACTIVE AREA'"; icon_state = "radiation"; name = "RADIOACTIVE AREA"; pixel_x = 0; pixel_y = 0},/turf/simulated/wall/r_wall,/area/template_noop)
-"du" = (/obj/machinery/door/firedoor/glass,/obj/machinery/door/blast/regular{dir = 4; icon_state = "pdoor1"; id = "EngineEmitterPortWest2"; layer = 3.3; name = "Engine Gas Storage"},/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/turf/simulated/floor/tiled/steel_grid,/area/template_noop)
-"dv" = (/obj/machinery/door/firedoor/glass,/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/machinery/door/blast/regular{dir = 4; icon_state = "pdoor1"; id = "EngineEmitterPortWest2"; layer = 3.3; name = "Engine Gas Storage"},/turf/simulated/floor/tiled/steel_grid,/area/template_noop)
-"dw" = (/obj/structure/cable/cyan{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/machinery/atmospherics/pipe/simple/visible/red,/obj/effect/floor_decal/industrial/warning{dir = 1},/turf/simulated/floor,/area/engineering/engine_room)
-"dx" = (/obj/machinery/power/emitter/gyrotron/anchored{dir = 1; id_tag = "engine"},/obj/structure/cable/cyan{d2 = 2; icon_state = "0-2"},/obj/effect/floor_decal/industrial/warning{dir = 1},/obj/effect/floor_decal/industrial/warning{dir = 8},/turf/simulated/floor,/area/engineering/engine_room)
-"dy" = (/obj/machinery/power/emitter/gyrotron/anchored{dir = 1; id_tag = "engine"},/obj/structure/cable/cyan{d2 = 2; icon_state = "0-2"},/obj/effect/floor_decal/industrial/warning{dir = 1},/obj/effect/floor_decal/industrial/warning{icon_state = "warning"; dir = 4},/turf/simulated/floor,/area/engineering/engine_room)
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"aa" = (
+/turf/template_noop,
+/area/template_noop)
+"ab" = (
+/turf/space,
+/area/space)
+"ac" = (
+/obj/item/weapon/book/manual/rust_engine,
+/turf/template_noop,
+/area/template_noop)
+"ad" = (
+/obj/machinery/computer/general_air_control/supermatter_core{
+	dir = 1;
+	frequency = 1438;
+	input_tag = "cooling_in";
+	name = "Engine Cooling Control";
+	output_tag = "cooling_out";
+	pressure_setting = 100;
+	sensors = list("engine_sensor" = "Engine Core");
+	throwpass = 1
+	},
+/turf/template_noop,
+/area/template_noop)
+"ae" = (
+/obj/machinery/button/remote/blast_door{
+	desc = "A remote control-switch for the engine charging port.";
+	id = "SupermatterPort";
+	name = "Radiation Collector Blast Doors";
+	pixel_x = -6;
+	pixel_y = 7;
+	req_access = list(10)
+	},
+/obj/machinery/button/remote/blast_door{
+	desc = "A remote control-switch for the engine control room blast doors.";
+	id = "EngineBlast";
+	name = "Engine Monitoring Room Blast Doors";
+	pixel_x = 0;
+	pixel_y = -3;
+	req_access = list(10)
+	},
+/turf/template_noop,
+/area/template_noop)
+"af" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"ag" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/hatch{
+	icon_state = "door_locked";
+	id_tag = "engine_access_hatch";
+	locked = 1;
+	name = "Fusion Core Access";
+	req_access = list(11)
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"ah" = (
+/obj/machinery/computer/fusion_fuel_control{
+	id_tag = "engine"
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"ai" = (
+/obj/structure/lattice,
+/obj/structure/grille,
+/turf/space,
+/area/space)
+"aj" = (
+/obj/structure/lattice,
+/turf/space,
+/area/space)
+"ak" = (
+/turf/simulated/wall/r_wall,
+/area/engineering/engine_room)
+"al" = (
+/obj/machinery/door/blast/regular{
+	dir = 4;
+	icon_state = "pdoor1";
+	id = "EngineVent";
+	name = "Reactor Vent";
+	p_open = 0
+	},
+/turf/simulated/floor/reinforced,
+/area/engineering/engine_room)
+"am" = (
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'RADIOACTIVE AREA'";
+	icon_state = "radiation";
+	name = "RADIOACTIVE AREA";
+	pixel_x = 0;
+	pixel_y = 0
+	},
+/turf/simulated/wall/r_wall,
+/area/engineering/engine_room)
+"an" = (
+/turf/simulated/floor/reinforced,
+/area/engineering/engine_room)
+"ao" = (
+/obj/structure/window/phoronreinforced/full{
+	icon_state = "phoronwindow0"
+	},
+/obj/structure/grille,
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"ap" = (
+/turf/space,
+/area/engineering/engine_smes)
+"aq" = (
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"ar" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"as" = (
+/obj/structure/table/reinforced,
+/obj/fiftyspawner/deuterium,
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"at" = (
+/obj/structure/table/reinforced,
+/obj/fiftyspawner/tritium,
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"au" = (
+/obj/machinery/fusion_fuel_compressor,
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"av" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 6
+	},
+/turf/space,
+/area/space)
+"aw" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 4
+	},
+/turf/space,
+/area/space)
+"ax" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 4
+	},
+/obj/structure/lattice,
+/turf/space,
+/area/space)
+"ay" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 10
+	},
+/turf/space,
+/area/space)
+"az" = (
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/reinforced,
+/area/engineering/engine_room)
+"aA" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/reinforced,
+/area/engineering/engine_room)
+"aB" = (
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"aC" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"aD" = (
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"aE" = (
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/glass_engineering,
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"aF" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging,
+/obj/structure/lattice,
+/turf/space,
+/area/space)
+"aG" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 6
+	},
+/obj/structure/lattice,
+/turf/space,
+/area/space)
+"aH" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 9
+	},
+/obj/structure/lattice,
+/turf/space,
+/area/space)
+"aI" = (
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/reinforced,
+/area/engineering/engine_room)
+"aJ" = (
+/obj/machinery/fusion_fuel_injector/mapped{
+	dir = 8;
+	id_tag = "engine"
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"aK" = (
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"aL" = (
+/obj/machinery/computer/gyrotron_control{
+	id_tag = "engine"
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"aM" = (
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 25;
+	pixel_y = 0
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"aN" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging,
+/turf/space,
+/area/space)
+"aO" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 5
+	},
+/turf/space,
+/area/space)
+"aP" = (
+/obj/machinery/power/fusion_core/mapped{
+	id_tag = "engine"
+	},
+/obj/structure/cable/cyan,
+/turf/simulated/floor/reinforced,
+/area/engineering/engine_room)
+"aQ" = (
+/obj/machinery/computer/fusion_core_control{
+	id_tag = "engine"
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"aR" = (
+/obj/machinery/atmospherics/unary/outlet_injector{
+	unacidable = 1;
+	use_power = 1
+	},
+/turf/simulated/floor/reinforced,
+/area/engineering/engine_room)
+"aS" = (
+/obj/machinery/air_sensor{
+	frequency = 1438;
+	id_tag = "engine_sensor";
+	output = 63
+	},
+/turf/simulated/floor/reinforced,
+/area/engineering/engine_room)
+"aT" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	pump_direction = 0;
+	use_power = 1
+	},
+/turf/simulated/floor/reinforced,
+/area/engineering/engine_room)
+"aU" = (
+/obj/machinery/camera/network/engine,
+/obj/machinery/button/remote/airlock{
+	id = "engine_access_hatch";
+	name = "Door Bolt Control";
+	pixel_x = -4;
+	pixel_y = 28;
+	req_access = list(10);
+	specialfunctions = 4
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"aV" = (
+/obj/structure/table/reinforced,
+/obj/item/weapon/book/manual/rust_engine,
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"aW" = (
+/obj/machinery/atmospherics/unary/outlet_injector{
+	dir = 4;
+	use_power = 1
+	},
+/turf/simulated/floor/reinforced,
+/area/engineering/engine_room)
+"aX" = (
+/obj/machinery/atmospherics/pipe/manifold4w/visible/yellow,
+/turf/simulated/floor/reinforced,
+/area/engineering/engine_room)
+"aY" = (
+/obj/machinery/atmospherics/unary/outlet_injector{
+	dir = 8;
+	use_power = 1
+	},
+/turf/simulated/floor/reinforced,
+/area/engineering/engine_room)
+"aZ" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 4;
+	pump_direction = 0;
+	use_power = 1
+	},
+/turf/simulated/floor/reinforced,
+/area/engineering/engine_room)
+"ba" = (
+/obj/machinery/atmospherics/pipe/manifold4w/visible/red,
+/turf/simulated/floor/reinforced,
+/area/engineering/engine_room)
+"bb" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 8;
+	pump_direction = 0;
+	use_power = 1
+	},
+/turf/simulated/floor/reinforced,
+/area/engineering/engine_room)
+"bc" = (
+/turf/simulated/wall/r_wall,
+/area/template_noop)
+"bd" = (
+/obj/machinery/atmospherics/pipe/simple/visible/yellow,
+/turf/simulated/floor/reinforced,
+/area/engineering/engine_room)
+"be" = (
+/obj/machinery/atmospherics/pipe/simple/visible/red,
+/turf/simulated/floor/reinforced,
+/area/engineering/engine_room)
+"bf" = (
+/obj/machinery/camera/network/engine{
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"bg" = (
+/obj/machinery/atmospherics/pipe/simple/visible/yellow,
+/obj/structure/window/phoronreinforced/full{
+	icon_state = "phoronwindow0"
+	},
+/obj/structure/grille,
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"bh" = (
+/obj/machinery/atmospherics/pipe/simple/visible/red,
+/obj/structure/window/phoronreinforced/full{
+	icon_state = "phoronwindow0"
+	},
+/obj/structure/grille,
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"bi" = (
+/obj/structure/cable/cyan{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 28
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"bj" = (
+/obj/machinery/power/emitter/gyrotron/anchored{
+	dir = 1;
+	id_tag = "engine"
+	},
+/obj/structure/cable/cyan{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"bk" = (
+/obj/machinery/atmospherics/pipe/simple/visible/yellow,
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"bl" = (
+/obj/machinery/atmospherics/pipe/simple/visible/red,
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"bm" = (
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"bn" = (
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"bo" = (
+/turf/simulated/floor/tiled/techmaint,
+/area/template_noop)
+"bp" = (
+/obj/machinery/atmospherics/pipe/simple/visible/yellow,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"bq" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"br" = (
+/obj/machinery/atmospherics/pipe/simple/visible/red,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"bs" = (
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"bt" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"bu" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1"
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"bv" = (
+/obj/machinery/atmospherics/pipe/simple/visible/red{
+	icon_state = "intact";
+	dir = 5
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"bw" = (
+/obj/machinery/atmospherics/pipe/simple/visible/red{
+	icon_state = "intact";
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"bx" = (
+/obj/machinery/atmospherics/pipe/simple/visible/red{
+	icon_state = "intact";
+	dir = 10
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"by" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"bz" = (
+/turf/simulated/floor,
+/area/template_noop)
+"bA" = (
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/camera/network/engine{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"bB" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/yellow,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"bC" = (
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 8
+	},
+/obj/machinery/button/remote/blast_door{
+	desc = "A remote control-switch for the engine radiator viewport shutters.";
+	id = "EngineRadiatorViewport";
+	name = "Engine Radiator Viewport Shutters";
+	pixel_x = -25;
+	pixel_y = 0;
+	req_access = list(10)
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"bD" = (
+/obj/machinery/atmospherics/pipe/manifold/visible/yellow{
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"bE" = (
+/obj/machinery/atmospherics/pipe/manifold/visible/yellow{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"bF" = (
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"bG" = (
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/red,
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"bH" = (
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 10
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"bI" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"bJ" = (
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"bK" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 5
+	},
+/obj/structure/lattice,
+/turf/space,
+/area/space)
+"bL" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction{
+	dir = 8
+	},
+/obj/structure/lattice,
+/turf/space,
+/area/space)
+"bM" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced{
+	dir = 8;
+	health = 1e+006
+	},
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "EngineRadiatorViewport";
+	name = "Engine Radiator Viewport Shutter";
+	opacity = 0
+	},
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"bN" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"bO" = (
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/yellow,
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"bP" = (
+/obj/machinery/atmospherics/pipe/manifold/visible/green{
+	dir = 1
+	},
+/obj/machinery/meter,
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"bQ" = (
+/obj/machinery/atmospherics/pipe/manifold/visible/green{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"bR" = (
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"bS" = (
+/obj/machinery/atmospherics/pipe/manifold/visible/green{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning/corner,
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"bT" = (
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	dir = 10;
+	icon_state = "intact";
+	
+	},
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"bU" = (
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"bV" = (
+/obj/effect/floor_decal/industrial/warning,
+/obj/machinery/atmospherics/pipe/manifold/visible/red{
+	dir = 8;
+	icon_state = "map";
+	
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"bW" = (
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/structure/cable/yellow,
+/obj/machinery/power/sensor{
+	name = "Powernet Sensor - Engine Output";
+	name_tag = "Engine Output"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"bX" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"bY" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction{
+	dir = 8
+	},
+/turf/space,
+/area/space)
+"bZ" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced{
+	dir = 8;
+	health = 1e+006
+	},
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "EngineRadiatorViewport";
+	name = "Engine Radiator Viewport Shutter";
+	opacity = 0
+	},
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"ca" = (
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	dir = 10
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"cb" = (
+/obj/machinery/atmospherics/binary/pump,
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"cc" = (
+/obj/machinery/atmospherics/binary/pump{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"cd" = (
+/obj/machinery/atmospherics/pipe/simple/visible/green,
+/obj/effect/floor_decal/industrial/warning{
+	icon_state = "warning";
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"ce" = (
+/obj/machinery/atmospherics/binary/circulator{
+	anchored = 1;
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"cf" = (
+/obj/machinery/power/generator{
+	anchored = 1;
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"cg" = (
+/obj/machinery/atmospherics/binary/circulator{
+	anchored = 1
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"ch" = (
+/obj/machinery/atmospherics/pipe/simple/visible/red,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"ci" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"cj" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 10
+	},
+/obj/structure/lattice,
+/turf/space,
+/area/space)
+"ck" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced{
+	dir = 8;
+	health = 1e+006
+	},
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "EngineRadiatorViewport";
+	name = "Engine Radiator Viewport Shutter";
+	opacity = 0
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"cl" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/machinery/atmospherics/binary/pump/high_power,
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"cm" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"cn" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/outline/blue,
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"co" = (
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	dir = 6
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"cp" = (
+/obj/machinery/atmospherics/pipe/simple/visible/green,
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"cq" = (
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	dir = 9
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"cr" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"cs" = (
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 5
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"ct" = (
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/red,
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"cu" = (
+/obj/machinery/atmospherics/pipe/manifold/visible/yellow{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"cv" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"cw" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 9
+	},
+/turf/space,
+/area/space)
+"cx" = (
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	dir = 5
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"cy" = (
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"cz" = (
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	dir = 4
+	},
+/obj/machinery/meter,
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"cA" = (
+/obj/machinery/atmospherics/pipe/manifold/visible/cyan{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"cB" = (
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	icon_state = "intact";
+	dir = 5
+	},
+/obj/effect/floor_decal/industrial/warning/corner,
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"cC" = (
+/obj/machinery/atmospherics/pipe/simple/visible/red{
+	icon_state = "intact";
+	dir = 6
+	},
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"cD" = (
+/obj/machinery/atmospherics/pipe/manifold/visible/red{
+	icon_state = "map";
+	dir = 4
+	},
+/obj/machinery/meter,
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"cE" = (
+/obj/machinery/atmospherics/pipe/simple/visible/yellow,
+/obj/machinery/meter,
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"cF" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/camera/network/engine{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	layer = 3.3;
+	pixel_x = 26
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"cG" = (
+/turf/simulated/wall/r_wall,
+/area/engineering/engine_gas)
+"cH" = (
+/turf/simulated/floor,
+/area/engineering/engine_gas)
+"cI" = (
+/obj/effect/floor_decal/industrial/warning/corner,
+/obj/machinery/button/remote/blast_door{
+	desc = "A remote control-switch for the engine control room blast doors.";
+	id = "EngineEmitterPortWest";
+	name = "Engine Room Blast Doors";
+	pixel_x = 0;
+	pixel_y = -25;
+	req_access = null;
+	req_one_access = list(11,24)
+	},
+/obj/machinery/camera/network/engine{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/engineering/engine_gas)
+"cJ" = (
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor,
+/area/engineering/engine_gas)
+"cK" = (
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/engineering/engine_gas)
+"cL" = (
+/obj/machinery/atmospherics/pipe/simple/visible/cyan,
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"cM" = (
+/obj/effect/floor_decal/industrial/warning{
+	icon_state = "warning";
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"cN" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/airlock_sensor/airlock_interior{
+	id_tag = "eng_al_int_snsr";
+	master_tag = "engine_room_airlock";
+	pixel_x = 22;
+	pixel_y = 0;
+	req_access = list(10)
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"cO" = (
+/obj/machinery/door/blast/regular{
+	dir = 4;
+	icon_state = "pdoor1";
+	id = "EngineEmitterPortWest";
+	layer = 3.3;
+	name = "Engine Gas Storage"
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor,
+/area/engineering/engine_gas)
+"cP" = (
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	dir = 5
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"cQ" = (
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"cR" = (
+/obj/machinery/atmospherics/pipe/manifold/visible/cyan{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"cS" = (
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 9
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"cT" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"cU" = (
+/turf/simulated/floor/plating,
+/area/template_noop)
+"cV" = (
+/obj/effect/floor_decal/industrial/outline/blue,
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/turf/simulated/floor,
+/area/engineering/engine_gas)
+"cW" = (
+/obj/effect/floor_decal/industrial/outline/blue,
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/obj/machinery/button/remote/blast_door{
+	desc = "A remote control-switch for the engine control room blast doors.";
+	id = "EngineEmitterPortWest";
+	name = "Engine Room Blast Doors";
+	pixel_x = 0;
+	pixel_y = 25;
+	req_access = null;
+	req_one_access = list(11,24)
+	},
+/turf/simulated/floor,
+/area/engineering/engine_gas)
+"cX" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/obj/structure/extinguisher_cabinet{
+	dir = 1;
+	icon_state = "extinguisher_closed";
+	pixel_y = 32;
+	
+	},
+/turf/simulated/floor,
+/area/engineering/engine_gas)
+"cY" = (
+/obj/effect/floor_decal/industrial/warning/corner,
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"cZ" = (
+/obj/machinery/button/remote/blast_door{
+	id = "EngineVent";
+	name = "Reactor Ventillatory Control";
+	pixel_x = 0;
+	pixel_y = -25;
+	req_access = list(10)
+	},
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"da" = (
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	dir = 5
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"db" = (
+/obj/machinery/atmospherics/valve/digital{
+	dir = 4;
+	name = "Emergency Cooling Valve 2"
+	},
+/obj/machinery/light,
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"dc" = (
+/obj/machinery/atmospherics/pipe/simple/visible/red{
+	icon_state = "intact";
+	dir = 4
+	},
+/obj/machinery/alarm{
+	dir = 1;
+	icon_state = "alarm0";
+	pixel_y = -22
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"dd" = (
+/obj/machinery/atmospherics/pipe/simple/visible/red{
+	icon_state = "intact";
+	dir = 9
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"de" = (
+/obj/item/device/radio/intercom{
+	dir = 2;
+	pixel_y = -24
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"df" = (
+/obj/effect/floor_decal/industrial/outline/blue,
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/obj/machinery/camera/network/engineering{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/engineering/engine_gas)
+"dg" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/engineering/engine_gas)
+"dh" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/turf/simulated/floor,
+/area/engineering/engine_gas)
+"di" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_y = 0
+	},
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 25;
+	pixel_y = 0
+	},
+/turf/simulated/floor,
+/area/engineering/engine_gas)
+"dj" = (
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'HIGH VOLTAGE'";
+	icon_state = "shock";
+	name = "HIGH VOLTAGE";
+	pixel_y = 0
+	},
+/turf/simulated/wall/r_wall,
+/area/engineering/engine_room)
+"dk" = (
+/obj/effect/floor_decal/industrial/outline/blue,
+/obj/machinery/portable_atmospherics/canister/phoron,
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_x = 0
+	},
+/turf/simulated/floor,
+/area/engineering/engine_gas)
+"dl" = (
+/obj/effect/floor_decal/industrial/outline/blue,
+/obj/machinery/portable_atmospherics/canister/phoron,
+/turf/simulated/floor,
+/area/engineering/engine_gas)
+"dm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/engineering/engine_gas)
+"dn" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/turf/simulated/floor,
+/area/engineering/engine_gas)
+"do" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 28
+	},
+/obj/structure/closet/radiation,
+/obj/item/clothing/glasses/meson,
+/obj/item/clothing/glasses/meson,
+/turf/simulated/floor,
+/area/engineering/engine_gas)
+"dp" = (
+/obj/effect/floor_decal/industrial/outline/blue,
+/obj/machinery/portable_atmospherics/canister/phoron,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/turf/simulated/floor,
+/area/engineering/engine_gas)
+"dq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/industrial/warning/corner,
+/turf/simulated/floor,
+/area/engineering/engine_gas)
+"dr" = (
+/obj/effect/floor_decal/rust,
+/obj/effect/floor_decal/industrial/warning,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor,
+/area/engineering/engine_gas)
+"ds" = (
+/obj/effect/floor_decal/industrial/warning,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/button/remote/blast_door{
+	desc = "A remote control-switch for the engine control room blast doors.";
+	id = "EngineEmitterPortWest2";
+	name = "Engine Room Blast Doors";
+	pixel_x = 25;
+	pixel_y = 0;
+	req_access = null;
+	req_one_access = list(11,24)
+	},
+/turf/simulated/floor,
+/area/engineering/engine_gas)
+"dt" = (
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'RADIOACTIVE AREA'";
+	icon_state = "radiation";
+	name = "RADIOACTIVE AREA";
+	pixel_x = 0;
+	pixel_y = 0
+	},
+/turf/simulated/wall/r_wall,
+/area/template_noop)
+"du" = (
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/blast/regular{
+	dir = 4;
+	icon_state = "pdoor1";
+	id = "EngineEmitterPortWest2";
+	layer = 3.3;
+	name = "Engine Gas Storage"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/steel_grid,
+/area/template_noop)
+"dv" = (
+/obj/machinery/door/firedoor/glass,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/blast/regular{
+	dir = 4;
+	icon_state = "pdoor1";
+	id = "EngineEmitterPortWest2";
+	layer = 3.3;
+	name = "Engine Gas Storage"
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/template_noop)
+"dw" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/red,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"dx" = (
+/obj/machinery/power/emitter/gyrotron/anchored{
+	dir = 1;
+	id_tag = "engine"
+	},
+/obj/structure/cable/cyan{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"dy" = (
+/obj/machinery/power/emitter/gyrotron/anchored{
+	dir = 1;
+	id_tag = "engine"
+	},
+/obj/structure/cable/cyan{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning{
+	icon_state = "warning";
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
 
 (1,1,1) = {"
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaabababababababababababababababababababababababababababaaaa
-aaabababababababababababababababababababababababababababaaaa
-aaaiaiaiaiaiajaiaiaiakakakakalakakakakakakakakakakamababaaaa
-aaaiababababajapababakanananananananaoaUafarasatauakababaaaa
-aaaiabavawawaxawawayakanananazaAaAaAagaCaDaEaqaqaqakababaaaa
-aaajajaFaGaxaxaxaxaHakanananaIanananaoaJaKaraLaqaMakababaaaa
-aaaiabaNaOawaxawawayakanananaPanananaoaJaKaraQaqaqakababaaaa
-aaaiajaFaGaxaxaxaxaHakanaRanaSanaTanaoaJaKarahaqaVakababaaaa
-aaaiabaNaOawaxawawayakaWaXaYanaZbabbaoaqaKararararbcbcbcaaaa
-aaaiajaFaGaxaxaxaxaHakanbdanananbeanaoaqaKaqaqaqbfbcaaaaaaaa
-aaaiabaNaOawaxawawayakaobgaoaoaobhaoakaqaKaqaqaqbibcaaaaaaaa
-aaaiajaFaGaxaxaxaxaHakdxbpbjbqbjbrdyaqaqbmaCaCaCbnboaaaaaaaa
-aaaiabaNaOawaxawawayakbAbBbJbXbJdwbJaCaCbsaqaqaqbtboaaaaaaaa
-aaaiajaFaGaxaxaxaxaHakaBbkaqaqaqblaqaqaqaqaqaqaqbubcbcbcaaaa
-aaaiabaNaOawaxawawayakaqbkaqaqaqbvbwbwbwbwbxaqaqbybzacadaaaa
-aaajajaFaGaxaxaxaxaHakbCbDbEbFbFbFbFbFbFbFbGbFbHbIbzaaaaaaaa
-aaajajaFbKaxaxaxaxbLbMbNbObObPbQbRbRbSbTbUbVbxbkbWbzaaaeaaaa
-aaaiabaNavawaxawawbYbZcacbcccccbaqaqcdcecfcgchbkcibzaaaaaaaa
-aaaiajaFbKaxaxaxaxcjckclcmcncncmaqcocpcqcrcsctcucvbzaaaaaaaa
-aaaiabaNavawaxawawcwamcxcycyczcycycAcBbTbUcCcDcEcFbcbcbcaaaa
-aaaiajaFbKaxaxaxaxcjcGcHcIcJcJcKcHcLcMcecfcgchbkcNbcaaaaaaaa
-aaaiabaNavawaxawawcwcGcGcGcOcOcGcGcPcQcRcrcsctcScTcUaaaaaaaa
-aaaiajaFbKaxaxaxaxcjcGcVcWcHcHcXcGcYcZdadbdcddaqdebcaaaaaaaa
-aaaiabaNavawaxawawcwcGdfcVdgdhdicGakakakdjakakakakbcbcbcaaaa
-aaaiajaFbKaxaxaxaxcjcGdkdldmdndocGaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaiabaNavawaxawawcwcGdldpdqdrdscGaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaajajaFbKaxaxaxaxcjcGcGcGdtdudvbcaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaiabaOawawaxawawcwaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(2,1,1) = {"
+aa
+ab
+ab
+ai
+ai
+ai
+aj
+ai
+ai
+ai
+ai
+ai
+ai
+ai
+ai
+ai
+aj
+aj
+ai
+ai
+ai
+ai
+ai
+ai
+ai
+ai
+ai
+aj
+ai
+aa
+"}
+(3,1,1) = {"
+aa
+ab
+ab
+ai
+ab
+ab
+aj
+ab
+aj
+ab
+aj
+ab
+aj
+ab
+aj
+ab
+aj
+aj
+ab
+aj
+ab
+aj
+ab
+aj
+ab
+aj
+ab
+aj
+ab
+aa
+"}
+(4,1,1) = {"
+aa
+ab
+ab
+ai
+ab
+av
+aF
+aN
+aF
+aN
+aF
+aN
+aF
+aN
+aF
+aN
+aF
+aF
+aN
+aF
+aN
+aF
+aN
+aF
+aN
+aF
+aN
+aF
+aO
+aa
+"}
+(5,1,1) = {"
+aa
+ab
+ab
+ai
+ab
+aw
+aG
+aO
+aG
+aO
+aG
+aO
+aG
+aO
+aG
+aO
+aG
+bK
+av
+bK
+av
+bK
+av
+bK
+av
+bK
+av
+bK
+aw
+aa
+"}
+(6,1,1) = {"
+aa
+ab
+ab
+ai
+ab
+aw
+ax
+aw
+ax
+aw
+ax
+aw
+ax
+aw
+ax
+aw
+ax
+ax
+aw
+ax
+aw
+ax
+aw
+ax
+aw
+ax
+aw
+ax
+aw
+aa
+"}
+(7,1,1) = {"
+aa
+ab
+ab
+aj
+aj
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+aa
+"}
+(8,1,1) = {"
+aa
+ab
+ab
+ai
+ap
+aw
+ax
+aw
+ax
+aw
+ax
+aw
+ax
+aw
+ax
+aw
+ax
+ax
+aw
+ax
+aw
+ax
+aw
+ax
+aw
+ax
+aw
+ax
+aw
+aa
+"}
+(9,1,1) = {"
+aa
+ab
+ab
+ai
+ab
+aw
+ax
+aw
+ax
+aw
+ax
+aw
+ax
+aw
+ax
+aw
+ax
+ax
+aw
+ax
+aw
+ax
+aw
+ax
+aw
+ax
+aw
+ax
+aw
+aa
+"}
+(10,1,1) = {"
+aa
+ab
+ab
+ai
+ab
+ay
+aH
+ay
+aH
+ay
+aH
+ay
+aH
+ay
+aH
+ay
+aH
+bL
+bY
+cj
+cw
+cj
+cw
+cj
+cw
+cj
+cw
+cj
+cw
+aa
+"}
+(11,1,1) = {"
+aa
+ab
+ab
+ak
+ak
+ak
+ak
+ak
+ak
+ak
+ak
+ak
+ak
+ak
+ak
+ak
+ak
+bM
+bZ
+ck
+am
+cG
+cG
+cG
+cG
+cG
+cG
+cG
+aa
+aa
+"}
+(12,1,1) = {"
+aa
+ab
+ab
+ak
+an
+an
+an
+an
+an
+aW
+an
+ao
+dx
+bA
+aB
+aq
+bC
+bN
+ca
+cl
+cx
+cH
+cG
+cV
+df
+dk
+dl
+cG
+aa
+aa
+"}
+(13,1,1) = {"
+aa
+ab
+ab
+ak
+an
+an
+an
+an
+aR
+aX
+bd
+bg
+bp
+bB
+bk
+bk
+bD
+bO
+cb
+cm
+cy
+cI
+cG
+cW
+cV
+dl
+dp
+cG
+aa
+aa
+"}
+(14,1,1) = {"
+aa
+ab
+ab
+ak
+an
+an
+an
+an
+an
+aY
+an
+ao
+bj
+bJ
+aq
+aq
+bE
+bO
+cc
+cn
+cy
+cJ
+cO
+cH
+dg
+dm
+dq
+dt
+aa
+aa
+"}
+(15,1,1) = {"
+aa
+ab
+ab
+al
+an
+az
+aI
+aP
+aS
+an
+an
+ao
+bq
+bX
+aq
+aq
+bF
+bP
+cc
+cn
+cz
+cJ
+cO
+cH
+dh
+dn
+dr
+du
+aa
+aa
+"}
+(16,1,1) = {"
+aa
+ab
+ab
+ak
+an
+aA
+an
+an
+an
+aZ
+an
+ao
+bj
+bJ
+aq
+aq
+bF
+bQ
+cb
+cm
+cy
+cK
+cG
+cX
+di
+do
+ds
+dv
+aa
+aa
+"}
+(17,1,1) = {"
+aa
+ab
+ab
+ak
+an
+aA
+an
+an
+aT
+ba
+be
+bh
+br
+dw
+bl
+bv
+bF
+bR
+aq
+aq
+cy
+cH
+cG
+cG
+cG
+cG
+cG
+bc
+aa
+aa
+"}
+(18,1,1) = {"
+aa
+ab
+ab
+ak
+an
+aA
+an
+an
+an
+bb
+an
+ao
+dy
+bJ
+aq
+bw
+bF
+bR
+aq
+co
+cA
+cL
+cP
+cY
+ak
+aa
+aa
+aa
+aa
+aa
+"}
+(19,1,1) = {"
+aa
+ab
+ab
+ak
+ao
+ag
+ao
+ao
+ao
+ao
+ao
+ak
+aq
+aC
+aq
+bw
+bF
+bS
+cd
+cp
+cB
+cM
+cQ
+cZ
+ak
+aa
+aa
+aa
+aa
+aa
+"}
+(20,1,1) = {"
+aa
+ab
+ab
+ak
+aU
+aC
+aJ
+aJ
+aJ
+aq
+aq
+aq
+aq
+aC
+aq
+bw
+bF
+bT
+ce
+cq
+bT
+ce
+cR
+da
+ak
+aa
+aa
+aa
+aa
+aa
+"}
+(21,1,1) = {"
+aa
+ab
+ab
+ak
+af
+aD
+aK
+aK
+aK
+aK
+aK
+aK
+bm
+bs
+aq
+bw
+bF
+bU
+cf
+cr
+bU
+cf
+cr
+db
+dj
+aa
+aa
+aa
+aa
+aa
+"}
+(22,1,1) = {"
+aa
+ab
+ab
+ak
+ar
+aE
+ar
+ar
+ar
+ar
+aq
+aq
+aC
+aq
+aq
+bx
+bG
+bV
+cg
+cs
+cC
+cg
+cs
+dc
+ak
+aa
+aa
+aa
+aa
+aa
+"}
+(23,1,1) = {"
+aa
+ab
+ab
+ak
+as
+aq
+aL
+aQ
+ah
+ar
+aq
+aq
+aC
+aq
+aq
+aq
+bF
+bx
+ch
+ct
+cD
+ch
+ct
+dd
+ak
+aa
+aa
+aa
+aa
+aa
+"}
+(24,1,1) = {"
+aa
+ab
+ab
+ak
+at
+aq
+aq
+aq
+aq
+ar
+aq
+aq
+aC
+aq
+aq
+aq
+bH
+bk
+bk
+cu
+cE
+bk
+cS
+aq
+ak
+aa
+aa
+aa
+aa
+aa
+"}
+(25,1,1) = {"
+aa
+ab
+ab
+ak
+au
+aq
+aM
+aq
+aV
+ar
+bf
+bi
+bn
+bt
+bu
+by
+bI
+bW
+ci
+cv
+cF
+cN
+cT
+de
+ak
+aa
+aa
+aa
+aa
+aa
+"}
+(26,1,1) = {"
+aa
+ab
+ab
+am
+ak
+ak
+ak
+ak
+ak
+bc
+bc
+bc
+bo
+bo
+bc
+bz
+bz
+bz
+bz
+bz
+bc
+bc
+cU
+bc
+bc
+aa
+aa
+aa
+aa
+aa
+"}
+(27,1,1) = {"
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+bc
+aa
+aa
+aa
+aa
+bc
+ac
+aa
+aa
+aa
+aa
+bc
+aa
+aa
+aa
+bc
+aa
+aa
+aa
+aa
+aa
+"}
+(28,1,1) = {"
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+bc
+aa
+aa
+aa
+aa
+bc
+ad
+aa
+ae
+aa
+aa
+bc
+aa
+aa
+aa
+bc
+aa
+aa
+aa
+aa
+aa
+"}
+(29,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(30,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 "}

--- a/maps/submaps/engine_submaps/engine_sme.dmm
+++ b/maps/submaps/engine_submaps/engine_sme.dmm
@@ -1,214 +1,2623 @@
-"aa" = (/turf/template_noop,/area/template_noop)
-"ab" = (/turf/space,/area/space)
-"ac" = (/obj/structure/lattice,/obj/structure/grille,/turf/space,/area/space)
-"ad" = (/obj/structure/lattice,/turf/space,/area/space)
-"ae" = (/obj/machinery/atmospherics/pipe/simple/heat_exchanging{dir = 6},/turf/space,/area/space)
-"af" = (/obj/machinery/atmospherics/pipe/simple/heat_exchanging{dir = 4},/turf/space,/area/space)
-"ag" = (/obj/machinery/atmospherics/pipe/simple/heat_exchanging{dir = 4},/obj/structure/lattice,/turf/space,/area/space)
-"ah" = (/obj/machinery/atmospherics/pipe/simple/heat_exchanging{dir = 10},/turf/space,/area/space)
-"ai" = (/obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction{dir = 8},/turf/space,/area/space)
-"aj" = (/obj/machinery/atmospherics/pipe/manifold/visible/black{icon_state = "map"; dir = 1},/obj/structure/lattice,/turf/space,/area/space)
-"ak" = (/obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction{icon_state = "intact"; dir = 4},/turf/space,/area/space)
-"al" = (/obj/machinery/atmospherics/pipe/simple/heat_exchanging,/obj/structure/lattice,/turf/space,/area/space)
-"am" = (/obj/machinery/atmospherics/pipe/simple/heat_exchanging{dir = 6},/obj/structure/lattice,/turf/space,/area/space)
-"an" = (/obj/machinery/atmospherics/pipe/simple/heat_exchanging{dir = 9},/obj/structure/lattice,/turf/space,/area/space)
-"ao" = (/obj/machinery/atmospherics/pipe/simple/heat_exchanging{dir = 5},/turf/space,/area/space)
-"ap" = (/obj/machinery/atmospherics/pipe/manifold4w/visible/black,/obj/structure/lattice,/turf/space,/area/space)
-"aq" = (/obj/machinery/atmospherics/pipe/simple/heat_exchanging{dir = 9},/turf/space,/area/space)
-"ar" = (/obj/machinery/atmospherics/pipe/simple/heat_exchanging,/turf/space,/area/space)
-"as" = (/turf/simulated/wall/r_wall,/area/engineering/engine_room)
-"at" = (/obj/structure/sign/securearea{desc = "A warning sign which reads 'RADIOACTIVE AREA'"; icon_state = "radiation"; name = "RADIOACTIVE AREA"; pixel_x = 0; pixel_y = 0},/turf/simulated/wall/r_wall,/area/engineering/engine_room)
-"au" = (/obj/machinery/atmospherics/pipe/simple/visible/black,/turf/simulated/wall/r_wall,/area/engineering/engine_room)
-"av" = (/turf/simulated/wall/r_wall,/area/template_noop)
-"aw" = (/obj/machinery/atmospherics/portables_connector{dir = 4},/obj/effect/floor_decal/industrial/outline/yellow,/obj/machinery/portable_atmospherics/canister/empty,/turf/simulated/floor,/area/engineering/engine_room)
-"ax" = (/obj/machinery/atmospherics/pipe/simple/visible/black{dir = 4},/turf/simulated/floor,/area/engineering/engine_room)
-"ay" = (/obj/machinery/atmospherics/pipe/manifold/visible/black{icon_state = "map"; dir = 1},/turf/simulated/floor,/area/engineering/engine_room)
-"az" = (/obj/machinery/atmospherics/unary/heat_exchanger{dir = 8},/turf/simulated/floor,/area/engineering/engine_room)
-"aA" = (/obj/machinery/atmospherics/unary/heat_exchanger{dir = 4},/turf/simulated/floor,/area/engineering/engine_room)
-"aB" = (/obj/machinery/atmospherics/pipe/manifold4w/visible/black,/turf/simulated/floor,/area/engineering/engine_room)
-"aC" = (/obj/machinery/atmospherics/binary/pump{dir = 8},/turf/simulated/floor,/area/engineering/engine_room)
-"aD" = (/obj/machinery/atmospherics/portables_connector{dir = 8},/obj/effect/floor_decal/industrial/outline/yellow,/turf/simulated/floor,/area/engineering/engine_room)
-"aE" = (/turf/simulated/floor,/area/engineering/engine_room)
-"aF" = (/obj/machinery/door/blast/regular{dir = 4; icon_state = "pdoor1"; id = "EngineVent"; name = "Reactor Vent"; p_open = 0},/turf/simulated/floor/reinforced/nitrogen{nitrogen = 82.1472},/area/engineering/engine_room)
-"aG" = (/obj/machinery/atmospherics/portables_connector{dir = 4},/obj/effect/floor_decal/industrial/outline/yellow,/obj/effect/floor_decal/industrial/warning/corner{dir = 8},/turf/simulated/floor,/area/engineering/engine_room)
-"aH" = (/obj/machinery/atmospherics/pipe/manifold4w/visible/black,/obj/machinery/meter,/turf/simulated/floor,/area/engineering/engine_room)
-"aI" = (/obj/machinery/atmospherics/pipe/manifold/visible/black,/obj/machinery/meter,/turf/simulated/floor,/area/engineering/engine_room)
-"aJ" = (/obj/machinery/atmospherics/binary/pump{dir = 4},/turf/simulated/floor,/area/engineering/engine_room)
-"aK" = (/obj/structure/cable/cyan{d2 = 2; icon_state = "0-2"},/obj/machinery/power/apc{dir = 4; name = "east bump"; pixel_x = 28},/turf/simulated/floor,/area/engineering/engine_room)
-"aL" = (/obj/effect/floor_decal/industrial/warning/cee{icon_state = "warningcee"; dir = 1},/turf/simulated/floor/reinforced/nitrogen{nitrogen = 82.1472},/area/engineering/engine_room)
-"aM" = (/turf/simulated/floor/greengrid/nitrogen,/area/engineering/engine_room)
-"aN" = (/obj/effect/floor_decal/industrial/warning/cee{icon_state = "warningcee"; dir = 1},/obj/machinery/atmospherics/unary/vent_pump/engine{dir = 4; external_pressure_bound = 100; external_pressure_bound_default = 0; frequency = 1438; icon_state = "map_vent_in"; id_tag = "cooling_out"; initialize_directions = 4; pressure_checks = 1; pressure_checks_default = 1; pump_direction = 0; use_power = 1},/turf/simulated/floor/reinforced/nitrogen{nitrogen = 82.1472},/area/engineering/engine_room)
-"aO" = (/obj/machinery/atmospherics/pipe/simple/visible/red{icon_state = "intact"; dir = 4},/obj/structure/grille,/obj/structure/window/phoronreinforced{icon_state = "phoronrwindow"; dir = 1},/obj/structure/window/phoronreinforced{icon_state = "phoronrwindow"; dir = 8},/obj/structure/window/phoronreinforced{icon_state = "phoronrwindow"; dir = 4},/obj/machinery/door/blast/regular{dir = 2; id = "SupermatterPort"; layer = 3.3; name = "Reactor Blast Door"},/turf/simulated/floor,/area/engineering/engine_room)
-"aP" = (/obj/machinery/atmospherics/pipe/simple/visible/red{icon_state = "intact"; dir = 4},/obj/effect/floor_decal/industrial/warning{dir = 10},/turf/simulated/floor,/area/engineering/engine_room)
-"aQ" = (/obj/machinery/atmospherics/pipe/simple/visible/red{icon_state = "intact"; dir = 4},/obj/effect/floor_decal/industrial/warning,/turf/simulated/floor,/area/engineering/engine_room)
-"aR" = (/obj/effect/floor_decal/industrial/warning/corner{dir = 8},/obj/machinery/atmospherics/pipe/simple/visible/black,/obj/machinery/atmospherics/pipe/simple/visible/red{icon_state = "intact"; dir = 4},/turf/simulated/floor,/area/engineering/engine_room)
-"aS" = (/obj/machinery/atmospherics/pipe/simple/visible/red{icon_state = "intact"; dir = 4},/turf/simulated/floor,/area/engineering/engine_room)
-"aT" = (/obj/machinery/atmospherics/pipe/simple/visible/red{icon_state = "intact"; dir = 10},/obj/machinery/meter,/turf/simulated/floor,/area/engineering/engine_room)
-"aU" = (/obj/structure/cable/cyan{d1 = 2; d2 = 4; icon_state = "2-4"},/obj/structure/cable/cyan{d1 = 1; d2 = 4; icon_state = "1-4"},/turf/simulated/floor,/area/engineering/engine_room)
-"aV" = (/turf/simulated/floor/tiled/techmaint,/area/template_noop)
-"aW" = (/obj/effect/floor_decal/industrial/warning{icon_state = "warning"; dir = 4},/obj/effect/floor_decal/industrial/warning{icon_state = "warning"; dir = 8},/obj/machinery/camera/network/engine{dir = 4},/turf/simulated/floor/reinforced/nitrogen{nitrogen = 82.1472},/area/engineering/engine_room)
-"aX" = (/obj/machinery/mass_driver{dir = 1; id = "enginecore"},/obj/machinery/power/supermatter{layer = 4},/turf/simulated/floor/greengrid/nitrogen,/area/engineering/engine_room)
-"aY" = (/obj/effect/floor_decal/industrial/warning{icon_state = "warning"; dir = 4},/obj/effect/floor_decal/industrial/warning{icon_state = "warning"; dir = 8},/turf/simulated/floor/reinforced/nitrogen{nitrogen = 82.1472},/area/engineering/engine_room)
-"aZ" = (/obj/structure/grille,/obj/structure/window/phoronreinforced{icon_state = "phoronrwindow"; dir = 8},/obj/structure/window/phoronreinforced{icon_state = "phoronrwindow"; dir = 4},/obj/machinery/door/blast/regular{dir = 2; id = "SupermatterPort"; layer = 3.3; name = "Reactor Blast Door"},/turf/simulated/floor,/area/engineering/engine_room)
-"ba" = (/obj/effect/floor_decal/steeldecal/steel_decals_central4{dir = 8},/turf/simulated/floor/tiled/monotile,/area/engineering/engine_room)
-"bb" = (/obj/machinery/power/emitter{anchored = 1; dir = 8; id = "EngineEmitter"; pixel_y = 8; state = 2},/obj/structure/cable/cyan{d1 = 0; d2 = 4; icon_state = "0-4"},/obj/effect/floor_decal/steeldecal/steel_decals6{dir = 6},/obj/effect/floor_decal/steeldecal/steel_decals6{dir = 10},/obj/effect/floor_decal/steeldecal/steel_decals6{dir = 9},/obj/effect/floor_decal/steeldecal/steel_decals6{dir = 5},/turf/simulated/floor/tiled/monotile,/area/engineering/engine_room)
-"bc" = (/obj/structure/cable/cyan{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/effect/floor_decal/industrial/warning{dir = 8},/obj/machinery/atmospherics/binary/pump{dir = 1},/turf/simulated/floor,/area/engineering/engine_room)
-"bd" = (/obj/structure/cable/cyan{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor,/area/engineering/engine_room)
-"be" = (/obj/machinery/atmospherics/pipe/simple/visible/red,/obj/structure/cable/cyan{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor,/area/engineering/engine_room)
-"bf" = (/obj/structure/cable/cyan{d2 = 8; icon_state = "0-8"},/obj/structure/cable/cyan{d1 = 0; d2 = 4; icon_state = "0-4"},/obj/machinery/power/sensor{name = "Powernet Sensor - Engine Power"; name_tag = "Engine Power"},/turf/simulated/floor,/area/engineering/engine_room)
-"bg" = (/obj/structure/cable/yellow{d1 = 2; d2 = 4; icon_state = "2-4"},/obj/structure/cable/cyan{d1 = 1; d2 = 8; icon_state = "1-8"},/turf/simulated/floor,/area/engineering/engine_room)
-"bh" = (/obj/effect/floor_decal/industrial/warning/corner{icon_state = "warningcorner"; dir = 4},/obj/effect/floor_decal/industrial/warning{dir = 10},/obj/machinery/atmospherics/unary/outlet_injector{dir = 2; frequency = 1438; icon_state = "map_injector"; id = "cooling_in"; name = "Coolant Injector"; pixel_y = 1; power_rating = 30000; use_power = 1; volume_rate = 700},/turf/simulated/floor/reinforced/nitrogen{nitrogen = 82.1472},/area/engineering/engine_room)
-"bi" = (/obj/effect/floor_decal/industrial/warning{icon_state = "warning"; dir = 1},/obj/effect/floor_decal/industrial/warning,/turf/simulated/floor/reinforced/nitrogen{nitrogen = 82.1472},/area/engineering/engine_room)
-"bj" = (/obj/effect/floor_decal/industrial/warning/corner{dir = 1},/obj/effect/floor_decal/industrial/warning{dir = 6},/obj/machinery/air_sensor{frequency = 1438; id_tag = "engine_sensor"; output = 63},/turf/simulated/floor/reinforced/nitrogen{nitrogen = 82.1472},/area/engineering/engine_room)
-"bk" = (/obj/structure/grille,/obj/structure/window/phoronreinforced,/obj/structure/window/phoronreinforced{icon_state = "phoronrwindow"; dir = 8},/obj/structure/window/phoronreinforced{icon_state = "phoronrwindow"; dir = 4},/obj/machinery/door/blast/regular{dir = 2; id = "SupermatterPort"; layer = 3.3; name = "Reactor Blast Door"},/turf/simulated/floor,/area/engineering/engine_room)
-"bl" = (/obj/effect/floor_decal/industrial/warning{icon_state = "warning"; dir = 9},/turf/simulated/floor,/area/engineering/engine_room)
-"bm" = (/obj/effect/floor_decal/industrial/warning{dir = 1},/turf/simulated/floor,/area/engineering/engine_room)
-"bn" = (/obj/effect/floor_decal/industrial/warning/corner{dir = 1},/obj/machinery/atmospherics/pipe/manifold/visible/black{dir = 8},/turf/simulated/floor,/area/engineering/engine_room)
-"bo" = (/obj/machinery/atmospherics/pipe/simple/visible/black{icon_state = "intact"; dir = 10},/turf/simulated/floor,/area/engineering/engine_room)
-"bp" = (/obj/machinery/atmospherics/pipe/simple/visible/red,/turf/simulated/floor,/area/engineering/engine_room)
-"bq" = (/obj/structure/cable/yellow{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/machinery/light{dir = 4; icon_state = "tube1"},/turf/simulated/floor,/area/engineering/engine_room)
-"br" = (/obj/machinery/atmospherics/pipe/simple/visible/yellow,/obj/structure/grille,/obj/structure/window/phoronreinforced,/obj/structure/window/phoronreinforced{icon_state = "phoronrwindow"; dir = 1},/obj/structure/window/phoronreinforced{icon_state = "phoronrwindow"; dir = 8},/obj/structure/window/phoronreinforced{icon_state = "phoronrwindow"; dir = 4},/obj/machinery/door/blast/regular{dir = 4; id = "SupermatterPort"; layer = 3.3; name = "Reactor Blast Door"},/turf/simulated/floor,/area/engineering/engine_room)
-"bs" = (/obj/machinery/door/airlock/hatch{icon_state = "door_locked"; id_tag = "engine_access_hatch"; locked = 1; req_access = list(11)},/turf/simulated/floor/reinforced,/area/engineering/engine_room)
-"bt" = (/obj/structure/grille,/obj/structure/window/phoronreinforced,/obj/structure/window/phoronreinforced{icon_state = "phoronrwindow"; dir = 1},/obj/structure/window/phoronreinforced{icon_state = "phoronrwindow"; dir = 8},/obj/structure/window/phoronreinforced{icon_state = "phoronrwindow"; dir = 4},/obj/machinery/door/blast/regular{dir = 4; id = "SupermatterPort"; layer = 3.3; name = "Reactor Blast Door"},/turf/simulated/floor,/area/engineering/engine_room)
-"bu" = (/obj/machinery/atmospherics/pipe/simple/visible/yellow{dir = 6},/obj/effect/floor_decal/industrial/warning{dir = 8},/obj/machinery/button/remote/blast_door{desc = "A remote control-switch for the engine control room blast doors."; id = "EngineBlast"; name = "Engine Monitoring Room Blast Doors"; pixel_x = -25; pixel_y = 5; req_access = list(10)},/obj/machinery/button/remote/blast_door{desc = "A remote control-switch for the engine charging port."; id = "SupermatterPort"; name = "Reactor Blast Doors"; pixel_x = -25; pixel_y = -5; req_access = list(10)},/obj/machinery/light{dir = 8; icon_state = "tube1"; pixel_y = 0},/turf/simulated/floor,/area/engineering/engine_room)
-"bv" = (/obj/machinery/atmospherics/pipe/manifold/visible/yellow{dir = 1},/turf/simulated/floor,/area/engineering/engine_room)
-"bw" = (/obj/machinery/atmospherics/trinary/atmos_filter/m_filter{dir = 1; use_power = 0},/turf/simulated/floor,/area/engineering/engine_room)
-"bx" = (/obj/machinery/atmospherics/pipe/simple/visible/yellow{dir = 10},/turf/simulated/floor,/area/engineering/engine_room)
-"by" = (/obj/structure/cable/yellow{d1 = 1; d2 = 2; icon_state = "1-2"},/turf/simulated/floor,/area/engineering/engine_room)
-"bz" = (/turf/simulated/floor,/area/template_noop)
-"bA" = (/obj/item/weapon/book/manual/supermatter_engine,/turf/template_noop,/area/template_noop)
-"bB" = (/obj/machinery/computer/general_air_control/supermatter_core{dir = 1; frequency = 1438; input_tag = "cooling_in"; name = "Engine Cooling Control"; output_tag = "cooling_out"; pressure_setting = 100; sensors = list("engine_sensor" = "Engine Core"); throwpass = 1},/turf/template_noop,/area/template_noop)
-"bC" = (/obj/effect/floor_decal/industrial/warning/corner{dir = 4},/obj/effect/floor_decal/industrial/warning/corner{dir = 8},/obj/machinery/button/remote/blast_door{desc = "A remote control-switch for the engine radiator viewport shutters."; id = "EngineRadiatorViewport"; name = "Engine Radiator Viewport Shutters"; pixel_x = -25; pixel_y = 0; req_access = list(10)},/turf/simulated/floor,/area/engineering/engine_room)
-"bD" = (/obj/machinery/atmospherics/pipe/manifold/visible/yellow{dir = 8},/obj/effect/floor_decal/industrial/warning{dir = 1},/turf/simulated/floor,/area/engineering/engine_room)
-"bE" = (/obj/machinery/atmospherics/pipe/manifold/visible/yellow{dir = 1},/obj/effect/floor_decal/industrial/warning{dir = 1},/obj/machinery/meter,/turf/simulated/floor,/area/engineering/engine_room)
-"bF" = (/obj/machinery/atmospherics/pipe/simple/visible/yellow{dir = 4},/obj/effect/floor_decal/industrial/warning{dir = 1},/turf/simulated/floor,/area/engineering/engine_room)
-"bG" = (/obj/machinery/atmospherics/pipe/simple/visible/yellow{dir = 4},/obj/effect/floor_decal/industrial/warning{dir = 1},/obj/machinery/light{dir = 1},/turf/simulated/floor,/area/engineering/engine_room)
-"bH" = (/obj/machinery/atmospherics/pipe/simple/visible/yellow{dir = 4},/obj/machinery/atmospherics/valve/digital{dir = 2; name = "Emergency Cooling Valve 1"},/obj/effect/floor_decal/industrial/warning/corner{dir = 1},/turf/simulated/floor,/area/engineering/engine_room)
-"bI" = (/obj/machinery/atmospherics/pipe/manifold/visible/yellow,/turf/simulated/floor,/area/engineering/engine_room)
-"bJ" = (/obj/machinery/atmospherics/pipe/simple/visible/yellow{dir = 4},/turf/simulated/floor,/area/engineering/engine_room)
-"bK" = (/obj/machinery/atmospherics/pipe/simple/visible/yellow{dir = 4},/obj/machinery/atmospherics/pipe/simple/visible/red,/turf/simulated/floor,/area/engineering/engine_room)
-"bL" = (/obj/structure/cable/yellow{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/machinery/atmospherics/unary/vent_scrubber/on,/turf/simulated/floor,/area/engineering/engine_room)
-"bM" = (/obj/machinery/button/remote/blast_door{desc = "A remote control-switch for the engine charging port."; id = "SupermatterPort"; name = "Reactor Blast Doors"; pixel_x = -6; pixel_y = 7; req_access = list(10)},/obj/machinery/button/remote/emitter{desc = "A remote control-switch for the engine emitter."; id = "EngineEmitter"; name = "Engine Emitter"; pixel_x = 6; pixel_y = 7; req_access = list(10)},/obj/machinery/button/remote/blast_door{desc = "A remote control-switch for the engine control room blast doors."; id = "EngineBlast"; name = "Engine Monitoring Room Blast Doors"; pixel_x = 0; pixel_y = -3; req_access = list(10)},/turf/template_noop,/area/template_noop)
-"bN" = (/obj/machinery/atmospherics/pipe/simple/heat_exchanging{dir = 5},/obj/structure/lattice,/turf/space,/area/space)
-"bO" = (/obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction{dir = 8},/obj/structure/lattice,/turf/space,/area/space)
-"bP" = (/obj/structure/grille,/obj/structure/window/reinforced/full,/obj/structure/window/reinforced{dir = 8; health = 1e+006},/obj/machinery/door/blast/regular{density = 0; icon_state = "pdoor0"; id = "EngineRadiatorViewport"; name = "Engine Radiator Viewport Shutter"; opacity = 0},/obj/machinery/door/firedoor/glass,/obj/machinery/atmospherics/pipe/simple/visible/green{dir = 4},/turf/simulated/floor,/area/engineering/engine_room)
-"bQ" = (/obj/effect/floor_decal/industrial/warning{dir = 8},/obj/machinery/atmospherics/pipe/simple/visible/green{dir = 4},/turf/simulated/floor,/area/engineering/engine_room)
-"bR" = (/obj/machinery/atmospherics/pipe/simple/visible/green{dir = 4},/obj/machinery/atmospherics/pipe/simple/visible/yellow,/turf/simulated/floor,/area/engineering/engine_room)
-"bS" = (/obj/machinery/atmospherics/pipe/manifold/visible/green{dir = 1},/obj/machinery/meter,/turf/simulated/floor,/area/engineering/engine_room)
-"bT" = (/obj/machinery/atmospherics/pipe/manifold/visible/green{dir = 1},/turf/simulated/floor,/area/engineering/engine_room)
-"bU" = (/obj/machinery/atmospherics/pipe/manifold/visible/green,/turf/simulated/floor,/area/engineering/engine_room)
-"bV" = (/obj/machinery/atmospherics/pipe/simple/visible/green{dir = 4},/turf/simulated/floor,/area/engineering/engine_room)
-"bW" = (/obj/machinery/atmospherics/pipe/manifold/visible/green{dir = 1},/obj/effect/floor_decal/industrial/warning/corner,/turf/simulated/floor,/area/engineering/engine_room)
-"bX" = (/obj/machinery/atmospherics/pipe/simple/visible/green{dir = 10; icon_state = "intact"},/obj/effect/floor_decal/industrial/warning,/turf/simulated/floor,/area/engineering/engine_room)
-"bY" = (/obj/effect/floor_decal/industrial/warning,/turf/simulated/floor,/area/engineering/engine_room)
-"bZ" = (/obj/machinery/atmospherics/pipe/simple/visible/red{icon_state = "intact"; dir = 6},/obj/effect/floor_decal/industrial/warning,/turf/simulated/floor,/area/engineering/engine_room)
-"ca" = (/obj/machinery/atmospherics/pipe/manifold/visible/red{icon_state = "map"; dir = 4},/obj/effect/floor_decal/industrial/warning/corner{dir = 8},/turf/simulated/floor,/area/engineering/engine_room)
-"cb" = (/obj/machinery/atmospherics/pipe/simple/visible/yellow,/turf/simulated/floor,/area/engineering/engine_room)
-"cc" = (/obj/structure/cable/yellow{d2 = 2; icon_state = "0-2"},/obj/structure/cable/yellow,/obj/machinery/power/sensor{name = "Powernet Sensor - Engine Output"; name_tag = "Engine Output"},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 6},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 5},/turf/simulated/floor,/area/engineering/engine_room)
-"cd" = (/obj/machinery/atmospherics/trinary/atmos_filter{dir = 1; use_power = 0},/turf/simulated/floor,/area/engineering/engine_room)
-"ce" = (/obj/structure/grille,/obj/structure/window/reinforced/full,/obj/structure/window/reinforced{dir = 8; health = 1e+006},/obj/machinery/door/blast/regular{density = 0; icon_state = "pdoor0"; id = "EngineRadiatorViewport"; name = "Engine Radiator Viewport Shutter"; opacity = 0},/obj/machinery/door/firedoor/glass,/obj/machinery/atmospherics/pipe/simple/visible/cyan{dir = 4},/turf/simulated/floor,/area/engineering/engine_room)
-"cf" = (/obj/machinery/atmospherics/pipe/simple/visible/cyan{dir = 10},/obj/effect/floor_decal/industrial/warning{dir = 8},/turf/simulated/floor,/area/engineering/engine_room)
-"cg" = (/obj/machinery/atmospherics/binary/pump,/turf/simulated/floor,/area/engineering/engine_room)
-"ch" = (/obj/machinery/atmospherics/binary/pump{dir = 1},/turf/simulated/floor,/area/engineering/engine_room)
-"ci" = (/obj/machinery/atmospherics/pipe/simple/visible/green,/obj/effect/floor_decal/industrial/warning{icon_state = "warning"; dir = 4},/turf/simulated/floor,/area/engineering/engine_room)
-"cj" = (/obj/machinery/atmospherics/binary/circulator{anchored = 1; dir = 1},/turf/simulated/floor,/area/engineering/engine_room)
-"ck" = (/obj/machinery/power/generator{anchored = 1; dir = 4},/obj/structure/cable/yellow{d2 = 2; icon_state = "0-2"},/turf/simulated/floor,/area/engineering/engine_room)
-"cl" = (/obj/machinery/atmospherics/binary/circulator{anchored = 1},/turf/simulated/floor,/area/engineering/engine_room)
-"cm" = (/obj/machinery/atmospherics/pipe/simple/visible/red,/obj/effect/floor_decal/industrial/warning{dir = 8},/turf/simulated/floor,/area/engineering/engine_room)
-"cn" = (/obj/structure/cable/yellow{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/machinery/atmospherics/unary/vent_pump/on{dir = 1},/turf/simulated/floor,/area/engineering/engine_room)
-"co" = (/obj/machinery/atmospherics/pipe/simple/heat_exchanging{dir = 10},/obj/structure/lattice,/turf/space,/area/space)
-"cp" = (/obj/structure/grille,/obj/structure/window/reinforced/full,/obj/structure/window/reinforced{dir = 8; health = 1e+006},/obj/machinery/door/blast/regular{density = 0; icon_state = "pdoor0"; id = "EngineRadiatorViewport"; name = "Engine Radiator Viewport Shutter"; opacity = 0},/obj/machinery/door/firedoor/glass,/turf/simulated/floor,/area/engineering/engine_room)
-"cq" = (/obj/effect/floor_decal/industrial/warning{dir = 8},/obj/machinery/atmospherics/binary/pump/high_power,/turf/simulated/floor,/area/engineering/engine_room)
-"cr" = (/obj/machinery/atmospherics/portables_connector{dir = 1},/obj/effect/floor_decal/industrial/outline/yellow,/turf/simulated/floor,/area/engineering/engine_room)
-"cs" = (/obj/machinery/atmospherics/portables_connector{dir = 1},/obj/effect/floor_decal/industrial/outline/blue,/turf/simulated/floor,/area/engineering/engine_room)
-"ct" = (/obj/machinery/atmospherics/pipe/simple/visible/cyan{dir = 6},/turf/simulated/floor,/area/engineering/engine_room)
-"cu" = (/obj/machinery/atmospherics/pipe/simple/visible/green,/obj/machinery/atmospherics/pipe/simple/visible/cyan{dir = 4},/obj/effect/floor_decal/industrial/warning/corner{dir = 4},/turf/simulated/floor,/area/engineering/engine_room)
-"cv" = (/obj/machinery/atmospherics/pipe/simple/visible/cyan{dir = 9},/obj/effect/floor_decal/industrial/warning{dir = 1},/turf/simulated/floor,/area/engineering/engine_room)
-"cw" = (/obj/effect/floor_decal/industrial/warning{dir = 1},/obj/structure/cable/yellow{d1 = 1; d2 = 4; icon_state = "1-4"},/turf/simulated/floor,/area/engineering/engine_room)
-"cx" = (/obj/machinery/atmospherics/pipe/simple/visible/yellow{dir = 5},/obj/effect/floor_decal/industrial/warning{dir = 1},/obj/structure/cable/yellow{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor,/area/engineering/engine_room)
-"cy" = (/obj/machinery/atmospherics/pipe/simple/visible/yellow{dir = 4},/obj/machinery/atmospherics/pipe/simple/visible/red,/obj/effect/floor_decal/industrial/warning/corner{dir = 1},/obj/structure/cable/yellow{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor,/area/engineering/engine_room)
-"cz" = (/obj/machinery/atmospherics/pipe/manifold/visible/yellow{dir = 4},/obj/structure/cable/yellow{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor,/area/engineering/engine_room)
-"cA" = (/obj/structure/cable/yellow{d1 = 1; d2 = 8; icon_state = "1-8"},/obj/structure/cable/yellow{d1 = 1; d2 = 2; icon_state = "1-2"},/turf/simulated/floor,/area/engineering/engine_room)
-"cB" = (/obj/machinery/atmospherics/pipe/simple/visible/cyan{dir = 5},/obj/effect/floor_decal/industrial/warning/corner{dir = 1},/turf/simulated/floor,/area/engineering/engine_room)
-"cC" = (/obj/machinery/atmospherics/pipe/simple/visible/cyan{dir = 4},/turf/simulated/floor,/area/engineering/engine_room)
-"cD" = (/obj/machinery/atmospherics/pipe/simple/visible/cyan{dir = 4},/obj/machinery/meter,/turf/simulated/floor,/area/engineering/engine_room)
-"cE" = (/obj/machinery/atmospherics/pipe/manifold/visible/cyan{dir = 4},/turf/simulated/floor,/area/engineering/engine_room)
-"cF" = (/obj/machinery/atmospherics/pipe/simple/visible/green{icon_state = "intact"; dir = 5},/obj/effect/floor_decal/industrial/warning/corner,/turf/simulated/floor,/area/engineering/engine_room)
-"cG" = (/obj/machinery/atmospherics/pipe/manifold/visible/red{icon_state = "map"; dir = 4},/obj/machinery/meter,/turf/simulated/floor,/area/engineering/engine_room)
-"cH" = (/obj/machinery/atmospherics/pipe/simple/visible/yellow,/obj/machinery/meter,/turf/simulated/floor,/area/engineering/engine_room)
-"cI" = (/obj/structure/cable/yellow{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/machinery/camera/network/engine{dir = 8},/obj/machinery/firealarm{dir = 4; layer = 3.3; pixel_x = 26},/turf/simulated/floor,/area/engineering/engine_room)
-"cJ" = (/turf/simulated/wall/r_wall,/area/engineering/engine_gas)
-"cK" = (/turf/simulated/floor,/area/engineering/engine_gas)
-"cL" = (/obj/effect/floor_decal/industrial/warning/corner,/obj/machinery/button/remote/blast_door{desc = "A remote control-switch for the engine control room blast doors."; id = "EngineEmitterPortWest"; name = "Engine Room Blast Doors"; pixel_x = 0; pixel_y = -25; req_access = null; req_one_access = list(11,24)},/obj/machinery/camera/network/engine{dir = 1},/turf/simulated/floor,/area/engineering/engine_gas)
-"cM" = (/obj/effect/floor_decal/industrial/warning,/turf/simulated/floor,/area/engineering/engine_gas)
-"cN" = (/obj/effect/floor_decal/industrial/warning/corner{dir = 8},/turf/simulated/floor,/area/engineering/engine_gas)
-"cO" = (/obj/machinery/atmospherics/pipe/simple/visible/cyan,/turf/simulated/floor,/area/engineering/engine_room)
-"cP" = (/obj/effect/floor_decal/industrial/warning{icon_state = "warning"; dir = 4},/turf/simulated/floor,/area/engineering/engine_room)
-"cQ" = (/obj/structure/cable/yellow{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/machinery/airlock_sensor/airlock_interior{id_tag = "eng_al_int_snsr"; master_tag = "engine_room_airlock"; pixel_x = 22; pixel_y = 0; req_access = list(10)},/turf/simulated/floor,/area/engineering/engine_room)
-"cR" = (/obj/machinery/door/blast/regular{dir = 4; icon_state = "pdoor1"; id = "EngineEmitterPortWest"; layer = 3.3; name = "Engine Gas Storage"},/obj/machinery/door/firedoor/glass,/turf/simulated/floor,/area/engineering/engine_gas)
-"cS" = (/obj/machinery/atmospherics/pipe/simple/visible/cyan{dir = 5},/turf/simulated/floor,/area/engineering/engine_room)
-"cT" = (/obj/machinery/atmospherics/pipe/simple/visible/cyan{dir = 4},/obj/effect/floor_decal/industrial/warning/corner{dir = 4},/turf/simulated/floor,/area/engineering/engine_room)
-"cU" = (/obj/machinery/atmospherics/pipe/manifold/visible/cyan{dir = 4},/obj/effect/floor_decal/industrial/warning{dir = 1},/turf/simulated/floor,/area/engineering/engine_room)
-"cV" = (/obj/machinery/atmospherics/pipe/simple/visible/yellow{dir = 9},/obj/structure/cable/yellow{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor,/area/engineering/engine_room)
-"cW" = (/obj/structure/cable/yellow{d1 = 1; d2 = 8; icon_state = "1-8"},/turf/simulated/floor,/area/engineering/engine_room)
-"cX" = (/turf/simulated/floor/plating,/area/template_noop)
-"cY" = (/obj/effect/floor_decal/industrial/outline/blue,/obj/machinery/portable_atmospherics/canister/nitrogen,/turf/simulated/floor,/area/engineering/engine_gas)
-"cZ" = (/obj/effect/floor_decal/industrial/outline/blue,/obj/machinery/portable_atmospherics/canister/nitrogen,/obj/machinery/button/remote/blast_door{desc = "A remote control-switch for the engine control room blast doors."; id = "EngineEmitterPortWest"; name = "Engine Room Blast Doors"; pixel_x = 0; pixel_y = 25; req_access = null; req_one_access = list(11,24)},/turf/simulated/floor,/area/engineering/engine_gas)
-"da" = (/obj/effect/floor_decal/industrial/outline/yellow,/obj/machinery/portable_atmospherics/canister/carbon_dioxide,/obj/structure/extinguisher_cabinet{dir = 1; icon_state = "extinguisher_closed"; pixel_y = 32},/turf/simulated/floor,/area/engineering/engine_gas)
-"db" = (/obj/effect/floor_decal/industrial/warning/corner,/turf/simulated/floor,/area/engineering/engine_room)
-"dc" = (/obj/machinery/button/remote/blast_door{id = "EngineVent"; name = "Reactor Ventillatory Control"; pixel_x = 0; pixel_y = -25; req_access = list(10)},/obj/effect/floor_decal/industrial/warning,/turf/simulated/floor,/area/engineering/engine_room)
-"dd" = (/obj/machinery/atmospherics/pipe/simple/visible/cyan{dir = 5},/obj/effect/floor_decal/industrial/warning/corner{dir = 8},/turf/simulated/floor,/area/engineering/engine_room)
-"de" = (/obj/machinery/atmospherics/valve/digital{dir = 4; name = "Emergency Cooling Valve 2"},/obj/machinery/light,/turf/simulated/floor,/area/engineering/engine_room)
-"df" = (/obj/machinery/atmospherics/pipe/simple/visible/red{icon_state = "intact"; dir = 4},/obj/machinery/alarm{dir = 1; icon_state = "alarm0"; pixel_y = -22},/turf/simulated/floor,/area/engineering/engine_room)
-"dg" = (/obj/machinery/atmospherics/pipe/simple/visible/red{icon_state = "intact"; dir = 9},/turf/simulated/floor,/area/engineering/engine_room)
-"dh" = (/obj/item/device/radio/intercom{dir = 2; pixel_y = -24},/turf/simulated/floor,/area/engineering/engine_room)
-"di" = (/obj/effect/floor_decal/industrial/outline/blue,/obj/machinery/portable_atmospherics/canister/nitrogen,/obj/machinery/camera/network/engineering{dir = 4},/turf/simulated/floor,/area/engineering/engine_gas)
-"dj" = (/obj/machinery/atmospherics/unary/vent_pump/on{dir = 4},/turf/simulated/floor,/area/engineering/engine_gas)
-"dk" = (/obj/effect/decal/cleanable/dirt,/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 10},/turf/simulated/floor,/area/engineering/engine_gas)
-"dl" = (/obj/effect/floor_decal/industrial/outline/yellow,/obj/machinery/portable_atmospherics/canister/carbon_dioxide,/obj/machinery/light/small{dir = 4; pixel_y = 0},/obj/machinery/alarm{dir = 8; pixel_x = 25; pixel_y = 0},/turf/simulated/floor,/area/engineering/engine_gas)
-"dm" = (/obj/structure/sign/securearea{desc = "A warning sign which reads 'HIGH VOLTAGE'"; icon_state = "shock"; name = "HIGH VOLTAGE"; pixel_y = 0},/turf/simulated/wall/r_wall,/area/engineering/engine_room)
-"dn" = (/obj/effect/floor_decal/industrial/outline/blue,/obj/machinery/portable_atmospherics/canister/phoron,/obj/machinery/light/small{dir = 8; pixel_x = 0},/turf/simulated/floor,/area/engineering/engine_gas)
-"do" = (/obj/effect/floor_decal/industrial/outline/blue,/obj/machinery/portable_atmospherics/canister/phoron,/turf/simulated/floor,/area/engineering/engine_gas)
-"dp" = (/obj/effect/decal/cleanable/dirt,/obj/machinery/atmospherics/unary/vent_scrubber/on{dir = 4},/turf/simulated/floor,/area/engineering/engine_gas)
-"dq" = (/obj/effect/decal/cleanable/dirt,/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 10},/turf/simulated/floor,/area/engineering/engine_gas)
-"dr" = (/obj/structure/window/reinforced{dir = 1},/obj/structure/cable/green{d2 = 2; icon_state = "0-2"},/obj/machinery/power/apc{dir = 4; name = "east bump"; pixel_x = 28},/obj/structure/closet/radiation,/obj/item/clothing/glasses/meson,/obj/item/clothing/glasses/meson,/turf/simulated/floor,/area/engineering/engine_gas)
-"ds" = (/obj/effect/floor_decal/industrial/outline/blue,/obj/machinery/portable_atmospherics/canister/phoron,/obj/machinery/firealarm{dir = 1; pixel_y = -24},/turf/simulated/floor,/area/engineering/engine_gas)
-"dt" = (/obj/effect/decal/cleanable/dirt,/obj/effect/floor_decal/industrial/warning/corner,/turf/simulated/floor,/area/engineering/engine_gas)
-"du" = (/obj/effect/floor_decal/rust,/obj/effect/floor_decal/industrial/warning,/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/turf/simulated/floor,/area/engineering/engine_gas)
-"dv" = (/obj/effect/floor_decal/industrial/warning,/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/machinery/button/remote/blast_door{desc = "A remote control-switch for the engine control room blast doors."; id = "EngineEmitterPortWest2"; name = "Engine Room Blast Doors"; pixel_x = 25; pixel_y = 0; req_access = null; req_one_access = list(11,24)},/turf/simulated/floor,/area/engineering/engine_gas)
-"dw" = (/obj/structure/sign/securearea{desc = "A warning sign which reads 'RADIOACTIVE AREA'"; icon_state = "radiation"; name = "RADIOACTIVE AREA"; pixel_x = 0; pixel_y = 0},/turf/simulated/wall/r_wall,/area/template_noop)
-"dx" = (/obj/machinery/door/firedoor/glass,/obj/machinery/door/blast/regular{dir = 4; icon_state = "pdoor1"; id = "EngineEmitterPortWest2"; layer = 3.3; name = "Engine Gas Storage"},/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/turf/simulated/floor/tiled/steel_grid,/area/template_noop)
-"dy" = (/obj/machinery/door/firedoor/glass,/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/machinery/door/blast/regular{dir = 4; icon_state = "pdoor1"; id = "EngineEmitterPortWest2"; layer = 3.3; name = "Engine Gas Storage"},/turf/simulated/floor/tiled/steel_grid,/area/template_noop)
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"aa" = (
+/turf/template_noop,
+/area/template_noop)
+"ab" = (
+/turf/space,
+/area/space)
+"ac" = (
+/obj/structure/lattice,
+/obj/structure/grille,
+/turf/space,
+/area/space)
+"ad" = (
+/obj/structure/lattice,
+/turf/space,
+/area/space)
+"ae" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 6
+	},
+/turf/space,
+/area/space)
+"af" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 4
+	},
+/turf/space,
+/area/space)
+"ag" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 4
+	},
+/obj/structure/lattice,
+/turf/space,
+/area/space)
+"ah" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 10
+	},
+/turf/space,
+/area/space)
+"ai" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction{
+	dir = 8
+	},
+/turf/space,
+/area/space)
+"aj" = (
+/obj/machinery/atmospherics/pipe/manifold/visible/black{
+	icon_state = "map";
+	dir = 1
+	},
+/obj/structure/lattice,
+/turf/space,
+/area/space)
+"ak" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction{
+	icon_state = "intact";
+	dir = 4
+	},
+/turf/space,
+/area/space)
+"al" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging,
+/obj/structure/lattice,
+/turf/space,
+/area/space)
+"am" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 6
+	},
+/obj/structure/lattice,
+/turf/space,
+/area/space)
+"an" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 9
+	},
+/obj/structure/lattice,
+/turf/space,
+/area/space)
+"ao" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 5
+	},
+/turf/space,
+/area/space)
+"ap" = (
+/obj/machinery/atmospherics/pipe/manifold4w/visible/black,
+/obj/structure/lattice,
+/turf/space,
+/area/space)
+"aq" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 9
+	},
+/turf/space,
+/area/space)
+"ar" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging,
+/turf/space,
+/area/space)
+"as" = (
+/turf/simulated/wall/r_wall,
+/area/engineering/engine_room)
+"at" = (
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'RADIOACTIVE AREA'";
+	icon_state = "radiation";
+	name = "RADIOACTIVE AREA";
+	pixel_x = 0;
+	pixel_y = 0
+	},
+/turf/simulated/wall/r_wall,
+/area/engineering/engine_room)
+"au" = (
+/obj/machinery/atmospherics/pipe/simple/visible/black,
+/turf/simulated/wall/r_wall,
+/area/engineering/engine_room)
+"av" = (
+/turf/simulated/wall/r_wall,
+/area/template_noop)
+"aw" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/portable_atmospherics/canister/empty,
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"ax" = (
+/obj/machinery/atmospherics/pipe/simple/visible/black{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"ay" = (
+/obj/machinery/atmospherics/pipe/manifold/visible/black{
+	icon_state = "map";
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"az" = (
+/obj/machinery/atmospherics/unary/heat_exchanger{
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"aA" = (
+/obj/machinery/atmospherics/unary/heat_exchanger{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"aB" = (
+/obj/machinery/atmospherics/pipe/manifold4w/visible/black,
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"aC" = (
+/obj/machinery/atmospherics/binary/pump{
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"aD" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"aE" = (
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"aF" = (
+/obj/machinery/door/blast/regular{
+	dir = 4;
+	icon_state = "pdoor1";
+	id = "EngineVent";
+	name = "Reactor Vent";
+	p_open = 0
+	},
+/turf/simulated/floor/reinforced/nitrogen{
+	nitrogen = 82.1472
+	},
+/area/engineering/engine_room)
+"aG" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"aH" = (
+/obj/machinery/atmospherics/pipe/manifold4w/visible/black,
+/obj/machinery/meter,
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"aI" = (
+/obj/machinery/atmospherics/pipe/manifold/visible/black,
+/obj/machinery/meter,
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"aJ" = (
+/obj/machinery/atmospherics/binary/pump{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"aK" = (
+/obj/structure/cable/cyan{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 28
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"aL" = (
+/obj/effect/floor_decal/industrial/warning/cee{
+	icon_state = "warningcee";
+	dir = 1
+	},
+/turf/simulated/floor/reinforced/nitrogen{
+	nitrogen = 82.1472
+	},
+/area/engineering/engine_room)
+"aM" = (
+/turf/simulated/floor/greengrid/nitrogen,
+/area/engineering/engine_room)
+"aN" = (
+/obj/effect/floor_decal/industrial/warning/cee{
+	icon_state = "warningcee";
+	dir = 1
+	},
+/obj/machinery/atmospherics/unary/vent_pump/engine{
+	dir = 4;
+	external_pressure_bound = 100;
+	external_pressure_bound_default = 0;
+	frequency = 1438;
+	icon_state = "map_vent_in";
+	id_tag = "cooling_out";
+	initialize_directions = 4;
+	pressure_checks = 1;
+	pressure_checks_default = 1;
+	pump_direction = 0;
+	use_power = 1
+	},
+/turf/simulated/floor/reinforced/nitrogen{
+	nitrogen = 82.1472
+	},
+/area/engineering/engine_room)
+"aO" = (
+/obj/machinery/atmospherics/pipe/simple/visible/red{
+	icon_state = "intact";
+	dir = 4
+	},
+/obj/structure/grille,
+/obj/structure/window/phoronreinforced{
+	icon_state = "phoronrwindow";
+	dir = 1
+	},
+/obj/structure/window/phoronreinforced{
+	icon_state = "phoronrwindow";
+	dir = 8
+	},
+/obj/structure/window/phoronreinforced{
+	icon_state = "phoronrwindow";
+	dir = 4
+	},
+/obj/machinery/door/blast/regular{
+	dir = 2;
+	id = "SupermatterPort";
+	layer = 3.3;
+	name = "Reactor Blast Door"
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"aP" = (
+/obj/machinery/atmospherics/pipe/simple/visible/red{
+	icon_state = "intact";
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 10
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"aQ" = (
+/obj/machinery/atmospherics/pipe/simple/visible/red{
+	icon_state = "intact";
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"aR" = (
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/black,
+/obj/machinery/atmospherics/pipe/simple/visible/red{
+	icon_state = "intact";
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"aS" = (
+/obj/machinery/atmospherics/pipe/simple/visible/red{
+	icon_state = "intact";
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"aT" = (
+/obj/machinery/atmospherics/pipe/simple/visible/red{
+	icon_state = "intact";
+	dir = 10
+	},
+/obj/machinery/meter,
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"aU" = (
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"aV" = (
+/turf/simulated/floor/tiled/techmaint,
+/area/template_noop)
+"aW" = (
+/obj/effect/floor_decal/industrial/warning{
+	icon_state = "warning";
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning{
+	icon_state = "warning";
+	dir = 8
+	},
+/obj/machinery/camera/network/engine{
+	dir = 4
+	},
+/turf/simulated/floor/reinforced/nitrogen{
+	nitrogen = 82.1472
+	},
+/area/engineering/engine_room)
+"aX" = (
+/obj/machinery/mass_driver{
+	dir = 1;
+	id = "enginecore"
+	},
+/obj/machinery/power/supermatter{
+	layer = 4
+	},
+/turf/simulated/floor/greengrid/nitrogen,
+/area/engineering/engine_room)
+"aY" = (
+/obj/effect/floor_decal/industrial/warning{
+	icon_state = "warning";
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning{
+	icon_state = "warning";
+	dir = 8
+	},
+/turf/simulated/floor/reinforced/nitrogen{
+	nitrogen = 82.1472
+	},
+/area/engineering/engine_room)
+"aZ" = (
+/obj/structure/grille,
+/obj/structure/window/phoronreinforced{
+	icon_state = "phoronrwindow";
+	dir = 8
+	},
+/obj/structure/window/phoronreinforced{
+	icon_state = "phoronrwindow";
+	dir = 4
+	},
+/obj/machinery/door/blast/regular{
+	dir = 2;
+	id = "SupermatterPort";
+	layer = 3.3;
+	name = "Reactor Blast Door"
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"ba" = (
+/obj/effect/floor_decal/steeldecal/steel_decals_central4{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/engineering/engine_room)
+"bb" = (
+/obj/machinery/power/emitter{
+	anchored = 1;
+	dir = 8;
+	id = "EngineEmitter";
+	pixel_y = 8;
+	state = 2
+	},
+/obj/structure/cable/cyan{
+	d1 = 0;
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 6
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 10
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 9
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/engineering/engine_room)
+"bc" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/machinery/atmospherics/binary/pump{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"bd" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"be" = (
+/obj/machinery/atmospherics/pipe/simple/visible/red,
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"bf" = (
+/obj/structure/cable/cyan{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/cable/cyan{
+	d1 = 0;
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/power/sensor{
+	name = "Powernet Sensor - Engine Power";
+	name_tag = "Engine Power"
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"bg" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"bh" = (
+/obj/effect/floor_decal/industrial/warning/corner{
+	icon_state = "warningcorner";
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 10
+	},
+/obj/machinery/atmospherics/unary/outlet_injector{
+	dir = 2;
+	frequency = 1438;
+	icon_state = "map_injector";
+	id = "cooling_in";
+	name = "Coolant Injector";
+	pixel_y = 1;
+	power_rating = 30000;
+	use_power = 1;
+	volume_rate = 700
+	},
+/turf/simulated/floor/reinforced/nitrogen{
+	nitrogen = 82.1472
+	},
+/area/engineering/engine_room)
+"bi" = (
+/obj/effect/floor_decal/industrial/warning{
+	icon_state = "warning";
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/reinforced/nitrogen{
+	nitrogen = 82.1472
+	},
+/area/engineering/engine_room)
+"bj" = (
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 6
+	},
+/obj/machinery/air_sensor{
+	frequency = 1438;
+	id_tag = "engine_sensor";
+	output = 63
+	},
+/turf/simulated/floor/reinforced/nitrogen{
+	nitrogen = 82.1472
+	},
+/area/engineering/engine_room)
+"bk" = (
+/obj/structure/grille,
+/obj/structure/window/phoronreinforced,
+/obj/structure/window/phoronreinforced{
+	icon_state = "phoronrwindow";
+	dir = 8
+	},
+/obj/structure/window/phoronreinforced{
+	icon_state = "phoronrwindow";
+	dir = 4
+	},
+/obj/machinery/door/blast/regular{
+	dir = 2;
+	id = "SupermatterPort";
+	layer = 3.3;
+	name = "Reactor Blast Door"
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"bl" = (
+/obj/effect/floor_decal/industrial/warning{
+	icon_state = "warning";
+	dir = 9
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"bm" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"bn" = (
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/visible/black{
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"bo" = (
+/obj/machinery/atmospherics/pipe/simple/visible/black{
+	icon_state = "intact";
+	dir = 10
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"bp" = (
+/obj/machinery/atmospherics/pipe/simple/visible/red,
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"bq" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1"
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"br" = (
+/obj/machinery/atmospherics/pipe/simple/visible/yellow,
+/obj/structure/grille,
+/obj/structure/window/phoronreinforced,
+/obj/structure/window/phoronreinforced{
+	icon_state = "phoronrwindow";
+	dir = 1
+	},
+/obj/structure/window/phoronreinforced{
+	icon_state = "phoronrwindow";
+	dir = 8
+	},
+/obj/structure/window/phoronreinforced{
+	icon_state = "phoronrwindow";
+	dir = 4
+	},
+/obj/machinery/door/blast/regular{
+	dir = 4;
+	id = "SupermatterPort";
+	layer = 3.3;
+	name = "Reactor Blast Door"
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"bs" = (
+/obj/machinery/door/airlock/hatch{
+	icon_state = "door_locked";
+	id_tag = "engine_access_hatch";
+	locked = 1;
+	req_access = list(11)
+	},
+/turf/simulated/floor/reinforced,
+/area/engineering/engine_room)
+"bt" = (
+/obj/structure/grille,
+/obj/structure/window/phoronreinforced,
+/obj/structure/window/phoronreinforced{
+	icon_state = "phoronrwindow";
+	dir = 1
+	},
+/obj/structure/window/phoronreinforced{
+	icon_state = "phoronrwindow";
+	dir = 8
+	},
+/obj/structure/window/phoronreinforced{
+	icon_state = "phoronrwindow";
+	dir = 4
+	},
+/obj/machinery/door/blast/regular{
+	dir = 4;
+	id = "SupermatterPort";
+	layer = 3.3;
+	name = "Reactor Blast Door"
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"bu" = (
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 6
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/machinery/button/remote/blast_door{
+	desc = "A remote control-switch for the engine control room blast doors.";
+	id = "EngineBlast";
+	name = "Engine Monitoring Room Blast Doors";
+	pixel_x = -25;
+	pixel_y = 5;
+	req_access = list(10)
+	},
+/obj/machinery/button/remote/blast_door{
+	desc = "A remote control-switch for the engine charging port.";
+	id = "SupermatterPort";
+	name = "Reactor Blast Doors";
+	pixel_x = -25;
+	pixel_y = -5;
+	req_access = list(10)
+	},
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube1";
+	pixel_y = 0
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"bv" = (
+/obj/machinery/atmospherics/pipe/manifold/visible/yellow{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"bw" = (
+/obj/machinery/atmospherics/trinary/atmos_filter/m_filter{
+	dir = 1;
+	use_power = 0
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"bx" = (
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 10
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"by" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"bz" = (
+/turf/simulated/floor,
+/area/template_noop)
+"bA" = (
+/obj/item/weapon/book/manual/supermatter_engine,
+/turf/template_noop,
+/area/template_noop)
+"bB" = (
+/obj/machinery/computer/general_air_control/supermatter_core{
+	dir = 1;
+	frequency = 1438;
+	input_tag = "cooling_in";
+	name = "Engine Cooling Control";
+	output_tag = "cooling_out";
+	pressure_setting = 100;
+	sensors = list("engine_sensor" = "Engine Core");
+	throwpass = 1
+	},
+/turf/template_noop,
+/area/template_noop)
+"bC" = (
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 8
+	},
+/obj/machinery/button/remote/blast_door{
+	desc = "A remote control-switch for the engine radiator viewport shutters.";
+	id = "EngineRadiatorViewport";
+	name = "Engine Radiator Viewport Shutters";
+	pixel_x = -25;
+	pixel_y = 0;
+	req_access = list(10)
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"bD" = (
+/obj/machinery/atmospherics/pipe/manifold/visible/yellow{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"bE" = (
+/obj/machinery/atmospherics/pipe/manifold/visible/yellow{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/machinery/meter,
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"bF" = (
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"bG" = (
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"bH" = (
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 4
+	},
+/obj/machinery/atmospherics/valve/digital{
+	dir = 2;
+	name = "Emergency Cooling Valve 1"
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"bI" = (
+/obj/machinery/atmospherics/pipe/manifold/visible/yellow,
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"bJ" = (
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"bK" = (
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/red,
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"bL" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"bM" = (
+/obj/machinery/button/remote/blast_door{
+	desc = "A remote control-switch for the engine charging port.";
+	id = "SupermatterPort";
+	name = "Reactor Blast Doors";
+	pixel_x = -6;
+	pixel_y = 7;
+	req_access = list(10)
+	},
+/obj/machinery/button/remote/emitter{
+	desc = "A remote control-switch for the engine emitter.";
+	id = "EngineEmitter";
+	name = "Engine Emitter";
+	pixel_x = 6;
+	pixel_y = 7;
+	req_access = list(10)
+	},
+/obj/machinery/button/remote/blast_door{
+	desc = "A remote control-switch for the engine control room blast doors.";
+	id = "EngineBlast";
+	name = "Engine Monitoring Room Blast Doors";
+	pixel_x = 0;
+	pixel_y = -3;
+	req_access = list(10)
+	},
+/turf/template_noop,
+/area/template_noop)
+"bN" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 5
+	},
+/obj/structure/lattice,
+/turf/space,
+/area/space)
+"bO" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction{
+	dir = 8
+	},
+/obj/structure/lattice,
+/turf/space,
+/area/space)
+"bP" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced{
+	dir = 8;
+	health = 1e+006
+	},
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "EngineRadiatorViewport";
+	name = "Engine Radiator Viewport Shutter";
+	opacity = 0
+	},
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"bQ" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"bR" = (
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/yellow,
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"bS" = (
+/obj/machinery/atmospherics/pipe/manifold/visible/green{
+	dir = 1
+	},
+/obj/machinery/meter,
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"bT" = (
+/obj/machinery/atmospherics/pipe/manifold/visible/green{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"bU" = (
+/obj/machinery/atmospherics/pipe/manifold/visible/green,
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"bV" = (
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"bW" = (
+/obj/machinery/atmospherics/pipe/manifold/visible/green{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning/corner,
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"bX" = (
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	dir = 10;
+	icon_state = "intact"
+	},
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"bY" = (
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"bZ" = (
+/obj/machinery/atmospherics/pipe/simple/visible/red{
+	icon_state = "intact";
+	dir = 6
+	},
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"ca" = (
+/obj/machinery/atmospherics/pipe/manifold/visible/red{
+	icon_state = "map";
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"cb" = (
+/obj/machinery/atmospherics/pipe/simple/visible/yellow,
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"cc" = (
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/structure/cable/yellow,
+/obj/machinery/power/sensor{
+	name = "Powernet Sensor - Engine Output";
+	name_tag = "Engine Output"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"cd" = (
+/obj/machinery/atmospherics/trinary/atmos_filter{
+	dir = 1;
+	use_power = 0
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"ce" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced{
+	dir = 8;
+	health = 1e+006
+	},
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "EngineRadiatorViewport";
+	name = "Engine Radiator Viewport Shutter";
+	opacity = 0
+	},
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"cf" = (
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	dir = 10
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"cg" = (
+/obj/machinery/atmospherics/binary/pump,
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"ch" = (
+/obj/machinery/atmospherics/binary/pump{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"ci" = (
+/obj/machinery/atmospherics/pipe/simple/visible/green,
+/obj/effect/floor_decal/industrial/warning{
+	icon_state = "warning";
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"cj" = (
+/obj/machinery/atmospherics/binary/circulator{
+	anchored = 1;
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"ck" = (
+/obj/machinery/power/generator{
+	anchored = 1;
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"cl" = (
+/obj/machinery/atmospherics/binary/circulator{
+	anchored = 1
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"cm" = (
+/obj/machinery/atmospherics/pipe/simple/visible/red,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"cn" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"co" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 10
+	},
+/obj/structure/lattice,
+/turf/space,
+/area/space)
+"cp" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced{
+	dir = 8;
+	health = 1e+006
+	},
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "EngineRadiatorViewport";
+	name = "Engine Radiator Viewport Shutter";
+	opacity = 0
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"cq" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/machinery/atmospherics/binary/pump/high_power,
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"cr" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"cs" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/outline/blue,
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"ct" = (
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	dir = 6
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"cu" = (
+/obj/machinery/atmospherics/pipe/simple/visible/green,
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"cv" = (
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	dir = 9
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"cw" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"cx" = (
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 5
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"cy" = (
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/red,
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"cz" = (
+/obj/machinery/atmospherics/pipe/manifold/visible/yellow{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"cA" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"cB" = (
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	dir = 5
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"cC" = (
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"cD" = (
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	dir = 4
+	},
+/obj/machinery/meter,
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"cE" = (
+/obj/machinery/atmospherics/pipe/manifold/visible/cyan{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"cF" = (
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	icon_state = "intact";
+	dir = 5
+	},
+/obj/effect/floor_decal/industrial/warning/corner,
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"cG" = (
+/obj/machinery/atmospherics/pipe/manifold/visible/red{
+	icon_state = "map";
+	dir = 4
+	},
+/obj/machinery/meter,
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"cH" = (
+/obj/machinery/atmospherics/pipe/simple/visible/yellow,
+/obj/machinery/meter,
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"cI" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/camera/network/engine{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	layer = 3.3;
+	pixel_x = 26
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"cJ" = (
+/turf/simulated/wall/r_wall,
+/area/engineering/engine_gas)
+"cK" = (
+/turf/simulated/floor,
+/area/engineering/engine_gas)
+"cL" = (
+/obj/effect/floor_decal/industrial/warning/corner,
+/obj/machinery/button/remote/blast_door{
+	desc = "A remote control-switch for the engine control room blast doors.";
+	id = "EngineEmitterPortWest";
+	name = "Engine Room Blast Doors";
+	pixel_x = 0;
+	pixel_y = -25;
+	req_access = null;
+	req_one_access = list(11,24)
+	},
+/obj/machinery/camera/network/engine{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/engineering/engine_gas)
+"cM" = (
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor,
+/area/engineering/engine_gas)
+"cN" = (
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/engineering/engine_gas)
+"cO" = (
+/obj/machinery/atmospherics/pipe/simple/visible/cyan,
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"cP" = (
+/obj/effect/floor_decal/industrial/warning{
+	icon_state = "warning";
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"cQ" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/airlock_sensor/airlock_interior{
+	id_tag = "eng_al_int_snsr";
+	master_tag = "engine_room_airlock";
+	pixel_x = 22;
+	pixel_y = 0;
+	req_access = list(10)
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"cR" = (
+/obj/machinery/door/blast/regular{
+	dir = 4;
+	icon_state = "pdoor1";
+	id = "EngineEmitterPortWest";
+	layer = 3.3;
+	name = "Engine Gas Storage"
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor,
+/area/engineering/engine_gas)
+"cS" = (
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	dir = 5
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"cT" = (
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"cU" = (
+/obj/machinery/atmospherics/pipe/manifold/visible/cyan{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"cV" = (
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 9
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"cW" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"cX" = (
+/turf/simulated/floor/plating,
+/area/template_noop)
+"cY" = (
+/obj/effect/floor_decal/industrial/outline/blue,
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/turf/simulated/floor,
+/area/engineering/engine_gas)
+"cZ" = (
+/obj/effect/floor_decal/industrial/outline/blue,
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/obj/machinery/button/remote/blast_door{
+	desc = "A remote control-switch for the engine control room blast doors.";
+	id = "EngineEmitterPortWest";
+	name = "Engine Room Blast Doors";
+	pixel_x = 0;
+	pixel_y = 25;
+	req_access = null;
+	req_one_access = list(11,24)
+	},
+/turf/simulated/floor,
+/area/engineering/engine_gas)
+"da" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/obj/structure/extinguisher_cabinet{
+	dir = 1;
+	icon_state = "extinguisher_closed";
+	pixel_y = 32
+	},
+/turf/simulated/floor,
+/area/engineering/engine_gas)
+"db" = (
+/obj/effect/floor_decal/industrial/warning/corner,
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"dc" = (
+/obj/machinery/button/remote/blast_door{
+	id = "EngineVent";
+	name = "Reactor Ventillatory Control";
+	pixel_x = 0;
+	pixel_y = -25;
+	req_access = list(10)
+	},
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"dd" = (
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	dir = 5
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"de" = (
+/obj/machinery/atmospherics/valve/digital{
+	dir = 4;
+	name = "Emergency Cooling Valve 2"
+	},
+/obj/machinery/light,
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"df" = (
+/obj/machinery/atmospherics/pipe/simple/visible/red{
+	icon_state = "intact";
+	dir = 4
+	},
+/obj/machinery/alarm{
+	dir = 1;
+	icon_state = "alarm0";
+	pixel_y = -22
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"dg" = (
+/obj/machinery/atmospherics/pipe/simple/visible/red{
+	icon_state = "intact";
+	dir = 9
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"dh" = (
+/obj/item/device/radio/intercom{
+	dir = 2;
+	pixel_y = -24
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"di" = (
+/obj/effect/floor_decal/industrial/outline/blue,
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/obj/machinery/camera/network/engineering{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/engineering/engine_gas)
+"dj" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/engineering/engine_gas)
+"dk" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/turf/simulated/floor,
+/area/engineering/engine_gas)
+"dl" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_y = 0
+	},
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 25;
+	pixel_y = 0
+	},
+/turf/simulated/floor,
+/area/engineering/engine_gas)
+"dm" = (
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'HIGH VOLTAGE'";
+	icon_state = "shock";
+	name = "HIGH VOLTAGE";
+	pixel_y = 0
+	},
+/turf/simulated/wall/r_wall,
+/area/engineering/engine_room)
+"dn" = (
+/obj/effect/floor_decal/industrial/outline/blue,
+/obj/machinery/portable_atmospherics/canister/phoron,
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_x = 0
+	},
+/turf/simulated/floor,
+/area/engineering/engine_gas)
+"do" = (
+/obj/effect/floor_decal/industrial/outline/blue,
+/obj/machinery/portable_atmospherics/canister/phoron,
+/turf/simulated/floor,
+/area/engineering/engine_gas)
+"dp" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/engineering/engine_gas)
+"dq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/turf/simulated/floor,
+/area/engineering/engine_gas)
+"dr" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 28
+	},
+/obj/structure/closet/radiation,
+/obj/item/clothing/glasses/meson,
+/obj/item/clothing/glasses/meson,
+/turf/simulated/floor,
+/area/engineering/engine_gas)
+"ds" = (
+/obj/effect/floor_decal/industrial/outline/blue,
+/obj/machinery/portable_atmospherics/canister/phoron,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/turf/simulated/floor,
+/area/engineering/engine_gas)
+"dt" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/industrial/warning/corner,
+/turf/simulated/floor,
+/area/engineering/engine_gas)
+"du" = (
+/obj/effect/floor_decal/rust,
+/obj/effect/floor_decal/industrial/warning,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor,
+/area/engineering/engine_gas)
+"dv" = (
+/obj/effect/floor_decal/industrial/warning,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/button/remote/blast_door{
+	desc = "A remote control-switch for the engine control room blast doors.";
+	id = "EngineEmitterPortWest2";
+	name = "Engine Room Blast Doors";
+	pixel_x = 25;
+	pixel_y = 0;
+	req_access = null;
+	req_one_access = list(11,24)
+	},
+/turf/simulated/floor,
+/area/engineering/engine_gas)
+"dw" = (
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'RADIOACTIVE AREA'";
+	icon_state = "radiation";
+	name = "RADIOACTIVE AREA";
+	pixel_x = 0;
+	pixel_y = 0
+	},
+/turf/simulated/wall/r_wall,
+/area/template_noop)
+"dx" = (
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/blast/regular{
+	dir = 4;
+	icon_state = "pdoor1";
+	id = "EngineEmitterPortWest2";
+	layer = 3.3;
+	name = "Engine Gas Storage"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/steel_grid,
+/area/template_noop)
+"dy" = (
+/obj/machinery/door/firedoor/glass,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/blast/regular{
+	dir = 4;
+	icon_state = "pdoor1";
+	id = "EngineEmitterPortWest2";
+	layer = 3.3;
+	name = "Engine Gas Storage"
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/template_noop)
 
 (1,1,1) = {"
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaabababababababababababababababababababababababababababaaaa
-aaacacacacacadacacacacacabababacacacacacacadacacacacacacaaaa
-aaacababababadabababadacabababacababadababadababadabababaaaa
-aaacabaeafafagafafahadacabababacaeafagafaiajakafagafahabaaaa
-aaadadalamagagagaganadadabababadaoafagafaiapakafagafaqabaaaa
-aaacabaraoafagafafahadacabababacaeafagafaiapakafagafahabaaaa
-aaacadalamagagagaganadacabababacaoafagafaiapakafagafaqabaaaa
-aaacabaraoafagafafahadacabababasasasasasatauasasasavavavaaaa
-aaacadalamagagagaganadacabababasawaxayazaAaBaCaDaEavaaaaaaaa
-aaacabaraoafagafafahadatasaFasasaGaCaHazaAaIaJaDaKavaaaaaaaa
-aaacadalamagagagaganadasaLaMaNaOaPaQaRaSaSaSaTaEaUaVaaaaaaaa
-aaacabaraoafagafafahadasaWaXaYaZbabbbcbdbdbdbebfbgaVaaaaaaaa
-aaacadalamagagagaganadasbhbibjbkblbmbnboaEaEbpaEbqavavavaaaa
-aaacabaraoafagafafahasasbrbsbtasbubvbwcdbxaEbpaEbybzbAbBaaaa
-aaadadalamagagagaganasbCbDbEbFbGbHbIbIbIbIbJbKbxbLbzaaaaaaaa
-aaadadalbNagagagagbObPbQbRbRbSbTbUbVbWbXbYbZcacbccaaaabMaaaa
-aaacabaraeafagafafaicecfcgchchcgaEaEcicjckclcmcbcnbzaaaaaaaa
-aaacadalbNagagagagcocpcqcrcscscraEctcucvcwcxcyczcAbzaaaaaaaa
-aaacabaraeafagafafaqatcBcCcCcDcCcCcEcFbXbYbZcGcHcIavavavaaaa
-aaacadalbNagagagagcocJcKcLcMcMcNcKcOcPcjckclcmcbcQavaaaaaaaa
-aaacabaraeafagafafaqcJcJcJcRcRcJcJcScTcUcwcxcycVcWcXaaaaaaaa
-aaacadalbNagagagagcocJcYcZcKcKdacJdbdcdddedfdgaEdhavaaaaaaaa
-aaacabaraeafagafafaqcJdicYdjdkdlcJasasasdmasasasasavavavaaaa
-aaacadalbNagagagagcocJdndodpdqdrcJaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaacabaraeafagafafaqcJdodsdtdudvcJaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaadadalbNagagagagcocJcJcJdwdxdyavaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaacabaoafafagafafaqaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(2,1,1) = {"
+aa
+aa
+ab
+ac
+ac
+ac
+ad
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ad
+ad
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ad
+ac
+aa
+"}
+(3,1,1) = {"
+aa
+aa
+ab
+ac
+ab
+ab
+ad
+ab
+ad
+ab
+ad
+ab
+ad
+ab
+ad
+ab
+ad
+ad
+ab
+ad
+ab
+ad
+ab
+ad
+ab
+ad
+ab
+ad
+ab
+aa
+"}
+(4,1,1) = {"
+aa
+aa
+ab
+ac
+ab
+ae
+al
+ar
+al
+ar
+al
+ar
+al
+ar
+al
+ar
+al
+al
+ar
+al
+ar
+al
+ar
+al
+ar
+al
+ar
+al
+ao
+aa
+"}
+(5,1,1) = {"
+aa
+aa
+ab
+ac
+ab
+af
+am
+ao
+am
+ao
+am
+ao
+am
+ao
+am
+ao
+am
+bN
+ae
+bN
+ae
+bN
+ae
+bN
+ae
+bN
+ae
+bN
+af
+aa
+"}
+(6,1,1) = {"
+aa
+aa
+ab
+ac
+ab
+af
+ag
+af
+ag
+af
+ag
+af
+ag
+af
+ag
+af
+ag
+ag
+af
+ag
+af
+ag
+af
+ag
+af
+ag
+af
+ag
+af
+aa
+"}
+(7,1,1) = {"
+aa
+aa
+ab
+ad
+ad
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+aa
+"}
+(8,1,1) = {"
+aa
+aa
+ab
+ac
+ab
+af
+ag
+af
+ag
+af
+ag
+af
+ag
+af
+ag
+af
+ag
+ag
+af
+ag
+af
+ag
+af
+ag
+af
+ag
+af
+ag
+af
+aa
+"}
+(9,1,1) = {"
+aa
+aa
+ab
+ac
+ab
+af
+ag
+af
+ag
+af
+ag
+af
+ag
+af
+ag
+af
+ag
+ag
+af
+ag
+af
+ag
+af
+ag
+af
+ag
+af
+ag
+af
+aa
+"}
+(10,1,1) = {"
+aa
+aa
+ab
+ac
+ab
+ah
+an
+ah
+an
+ah
+an
+ah
+an
+ah
+an
+ah
+an
+bO
+ai
+co
+aq
+co
+aq
+co
+aq
+co
+aq
+co
+aq
+aa
+"}
+(11,1,1) = {"
+aa
+aa
+ab
+ac
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+as
+as
+bP
+ce
+cp
+at
+cJ
+cJ
+cJ
+cJ
+cJ
+cJ
+cJ
+aa
+aa
+"}
+(12,1,1) = {"
+aa
+aa
+ab
+ac
+ac
+ac
+ad
+ac
+ac
+ac
+ac
+at
+as
+as
+as
+as
+bC
+bQ
+cf
+cq
+cB
+cK
+cJ
+cY
+di
+dn
+do
+cJ
+aa
+aa
+"}
+(13,1,1) = {"
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+as
+aL
+aW
+bh
+br
+bD
+bR
+cg
+cr
+cC
+cL
+cJ
+cZ
+cY
+do
+ds
+cJ
+aa
+aa
+"}
+(14,1,1) = {"
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+aF
+aM
+aX
+bi
+bs
+bE
+bR
+ch
+cs
+cC
+cM
+cR
+cK
+dj
+dp
+dt
+dw
+aa
+aa
+"}
+(15,1,1) = {"
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+as
+aN
+aY
+bj
+bt
+bF
+bS
+ch
+cs
+cD
+cM
+cR
+cK
+dk
+dq
+du
+dx
+aa
+aa
+"}
+(16,1,1) = {"
+aa
+aa
+ab
+ac
+ac
+ac
+ad
+ac
+ac
+as
+as
+as
+aO
+aZ
+bk
+as
+bG
+bT
+cg
+cr
+cC
+cN
+cJ
+da
+dl
+dr
+dv
+dy
+aa
+aa
+"}
+(17,1,1) = {"
+aa
+aa
+ab
+ac
+ab
+ae
+ao
+ae
+ao
+as
+aw
+aG
+aP
+ba
+bl
+bu
+bH
+bU
+aE
+aE
+cC
+cK
+cJ
+cJ
+cJ
+cJ
+cJ
+av
+aa
+aa
+"}
+(18,1,1) = {"
+aa
+aa
+ab
+ac
+ab
+af
+af
+af
+af
+as
+ax
+aC
+aQ
+bb
+bm
+bv
+bI
+bV
+aE
+ct
+cE
+cO
+cS
+db
+as
+aa
+aa
+aa
+aa
+aa
+"}
+(19,1,1) = {"
+aa
+aa
+ab
+ac
+ad
+ag
+ag
+ag
+ag
+as
+ay
+aH
+aR
+bc
+bn
+bw
+bI
+bW
+ci
+cu
+cF
+cP
+cT
+dc
+as
+aa
+aa
+aa
+aa
+aa
+"}
+(20,1,1) = {"
+aa
+aa
+ab
+ac
+ab
+af
+af
+af
+af
+as
+az
+az
+aS
+bd
+bo
+cd
+bI
+bX
+cj
+cv
+bX
+cj
+cU
+dd
+as
+aa
+aa
+aa
+aa
+aa
+"}
+(21,1,1) = {"
+aa
+aa
+ab
+ac
+ab
+ai
+ai
+ai
+ai
+at
+aA
+aA
+aS
+bd
+aE
+bx
+bI
+bY
+ck
+cw
+bY
+ck
+cw
+de
+dm
+aa
+aa
+aa
+aa
+aa
+"}
+(22,1,1) = {"
+aa
+aa
+ab
+ad
+ad
+aj
+ap
+ap
+ap
+au
+aB
+aI
+aS
+bd
+aE
+aE
+bJ
+bZ
+cl
+cx
+bZ
+cl
+cx
+df
+as
+aa
+aa
+aa
+aa
+aa
+"}
+(23,1,1) = {"
+aa
+aa
+ab
+ac
+ab
+ak
+ak
+ak
+ak
+as
+aC
+aJ
+aT
+be
+bp
+bp
+bK
+ca
+cm
+cy
+cG
+cm
+cy
+dg
+as
+aa
+aa
+aa
+aa
+aa
+"}
+(24,1,1) = {"
+aa
+aa
+ab
+ac
+ab
+af
+af
+af
+af
+as
+aD
+aD
+aE
+bf
+aE
+aE
+bx
+cb
+cb
+cz
+cH
+cb
+cV
+aE
+as
+aa
+aa
+aa
+aa
+aa
+"}
+(25,1,1) = {"
+aa
+aa
+ab
+ac
+ad
+ag
+ag
+ag
+ag
+as
+aE
+aK
+aU
+bg
+bq
+by
+bL
+cc
+cn
+cA
+cI
+cQ
+cW
+dh
+as
+aa
+aa
+aa
+aa
+aa
+"}
+(26,1,1) = {"
+aa
+aa
+ab
+ac
+ab
+af
+af
+af
+af
+av
+av
+av
+aV
+aV
+av
+bz
+bz
+aa
+bz
+bz
+av
+av
+cX
+av
+av
+aa
+aa
+aa
+aa
+aa
+"}
+(27,1,1) = {"
+aa
+aa
+ab
+ac
+ab
+ah
+aq
+ah
+aq
+av
+aa
+aa
+aa
+aa
+av
+bA
+aa
+aa
+aa
+aa
+av
+aa
+aa
+aa
+av
+aa
+aa
+aa
+aa
+aa
+"}
+(28,1,1) = {"
+aa
+aa
+ab
+ac
+ab
+ab
+ab
+ab
+ab
+av
+aa
+aa
+aa
+aa
+av
+bB
+aa
+bM
+aa
+aa
+av
+aa
+aa
+aa
+av
+aa
+aa
+aa
+aa
+aa
+"}
+(29,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(30,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 "}

--- a/maps/submaps/engine_submaps/engine_tesla.dmm
+++ b/maps/submaps/engine_submaps/engine_tesla.dmm
@@ -1,178 +1,2649 @@
-"aa" = (/turf/template_noop,/area/template_noop)
-"ab" = (/turf/space,/area/space)
-"ac" = (/obj/structure/lattice,/obj/structure/grille,/turf/space,/area/space)
-"ad" = (/obj/structure/lattice,/turf/space,/area/space)
-"ae" = (/turf/simulated/wall/r_wall,/area/engineering/engine_gas)
-"af" = (/turf/simulated/wall/r_wall,/area/engineering/engine_room)
-"ag" = (/obj/machinery/atmospherics/portables_connector{dir = 4},/obj/machinery/portable_atmospherics/canister/air/airlock,/turf/simulated/floor,/area/engineering/engine_gas)
-"ah" = (/obj/machinery/field_generator,/obj/machinery/light/small{dir = 1},/obj/machinery/atmospherics/pipe/simple/hidden{dir = 10; icon_state = "intact"},/turf/simulated/floor,/area/engineering/engine_gas)
-"ai" = (/obj/machinery/field_generator,/turf/simulated/floor,/area/engineering/engine_gas)
-"aj" = (/turf/simulated/floor/airless,/area/space)
-"ak" = (/obj/structure/cable/cyan{d1 = 2; d2 = 4; icon_state = "2-4"},/turf/simulated/floor/airless,/area/space)
-"al" = (/obj/structure/cable/cyan{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/airless,/area/space)
-"am" = (/obj/structure/cable/cyan{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/structure/cable/cyan{d1 = 2; d2 = 4; icon_state = "2-4"},/turf/simulated/floor/airless,/area/space)
-"an" = (/obj/structure/cable/cyan{d1 = 2; d2 = 8; icon_state = "2-8"},/turf/simulated/floor/airless,/area/space)
-"ao" = (/obj/structure/closet/emcloset,/obj/machinery/embedded_controller/radio/airlock/airlock_controller{frequency = 1379; id_tag = "eng_north_airlock"; pixel_x = 24; pixel_y = 0; req_one_access = list(10,11); tag_airpump = "eng_north_pump"; tag_chamber_sensor = "eng_north_sensor"; tag_exterior_door = "eng_north_outer"; tag_interior_door = "eng_north_inner"},/turf/simulated/floor/tiled/dark,/area/engineering/engine_room)
-"ap" = (/obj/machinery/atmospherics/pipe/manifold/hidden{dir = 4; icon_state = "map"},/turf/simulated/floor,/area/engineering/engine_gas)
-"aq" = (/obj/machinery/alarm{dir = 8; icon_state = "alarm0"; pixel_x = 24},/obj/structure/table/standard,/obj/item/stack/cable_coil/random,/obj/item/weapon/tool/wrench,/obj/item/weapon/tool/screwdriver,/turf/simulated/floor,/area/engineering/engine_gas)
-"ar" = (/obj/structure/cable/cyan,/obj/machinery/power/emitter{anchored = 1; state = 1},/turf/simulated/floor/airless,/area/space)
-"as" = (/obj/structure/cable/cyan{d1 = 1; d2 = 4; icon_state = "1-4"},/obj/effect/floor_decal/rust/mono_rusted1,/turf/simulated/floor/airless,/area/space)
-"at" = (/obj/machinery/access_button{command = "cycle_exterior"; frequency = 1379; master_tag = "eng_north_airlock"; name = "exterior access button"; pixel_x = -5; pixel_y = -26; req_one_access = list(10,11,13)},/obj/machinery/door/airlock/glass_external{frequency = 1379; icon_state = "door_locked"; id_tag = "eng_north_outer"; locked = 1; name = "Engine North Airlock Exterior"},/obj/structure/cable/cyan{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/tiled/dark,/area/engineering/engine_room)
-"au" = (/obj/machinery/atmospherics/unary/vent_pump/high_volume{dir = 4; frequency = 1379; id_tag = "eng_north_pump"},/obj/machinery/light/small,/obj/machinery/airlock_sensor{frequency = 1379; id_tag = "eng_north_sensor"; pixel_x = 0; pixel_y = -25},/obj/structure/cable/cyan{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/tiled/dark,/area/engineering/engine_room)
-"av" = (/obj/machinery/door/airlock/glass_external{frequency = 1379; icon_state = "door_locked"; id_tag = "eng_north_inner"; locked = 1; name = "Engine North Airlock Interior"},/obj/machinery/atmospherics/pipe/simple/hidden{dir = 4},/obj/structure/cable/cyan{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/tiled/dark,/area/engineering/engine_room)
-"aw" = (/obj/machinery/access_button{command = "cycle_interior"; frequency = 1379; master_tag = "eng_north_airlock"; name = "interior access button"; pixel_x = -28; pixel_y = 26; req_one_access = list(10,11)},/obj/structure/cable/cyan{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/structure/sign/securearea{desc = "A warning sign which reads 'EXTERNAL AIRLOCK'"; icon_state = "space"; layer = 4; name = "EXTERNAL AIRLOCK"; pixel_x = 0; pixel_y = 32},/obj/machinery/atmospherics/pipe/simple/hidden{dir = 10; icon_state = "intact"},/obj/effect/floor_decal/borderfloor{dir = 1},/obj/effect/floor_decal/corner/yellow/border{dir = 1},/obj/effect/floor_decal/borderfloor/corner2{dir = 4},/obj/effect/floor_decal/corner/yellow/bordercorner2{dir = 4},/obj/effect/floor_decal/industrial/warning{dir = 8},/turf/simulated/floor/tiled,/area/engineering/engine_room)
-"ax" = (/obj/structure/cable/cyan{d1 = 2; d2 = 8; icon_state = "2-8"},/obj/effect/floor_decal/borderfloor{dir = 5},/obj/effect/floor_decal/corner/yellow/border{dir = 5},/turf/simulated/floor/tiled,/area/engineering/engine_room)
-"ay" = (/obj/structure/cable/cyan{d1 = 0; d2 = 4; icon_state = "0-4"},/obj/machinery/power/apc{dir = 8; name = "west bump"; pixel_x = -28},/turf/simulated/floor,/area/engineering/engine_gas)
-"az" = (/obj/structure/cable/cyan{d1 = 2; d2 = 8; icon_state = "2-8"},/obj/machinery/power/sensor{name = "Powernet Sensor - Engine Power"; name_tag = "Engine Power"},/obj/structure/cable/cyan{d2 = 2; icon_state = "0-2"},/obj/machinery/atmospherics/pipe/simple/hidden,/turf/simulated/floor,/area/engineering/engine_gas)
-"aA" = (/obj/machinery/camera/network/engine{dir = 1},/obj/structure/table/standard,/obj/item/weapon/circuitboard/grounding_rod{pixel_x = 2; pixel_y = 2},/obj/item/weapon/circuitboard/grounding_rod{pixel_x = -2; pixel_y = -2},/turf/simulated/floor,/area/engineering/engine_gas)
-"aB" = (/obj/machinery/camera/network/engine{dir = 8},/turf/space,/area/space)
-"aC" = (/obj/structure/sign/securearea{desc = "A warning sign which reads 'RADIOACTIVE AREA'"; icon_state = "radiation"; name = "RADIOACTIVE AREA"; pixel_x = 0; pixel_y = 0},/turf/simulated/wall/r_wall,/area/engineering/engine_room)
-"aD" = (/obj/machinery/atmospherics/pipe/simple/hidden,/obj/effect/floor_decal/industrial/warning/corner{icon_state = "warningcorner"; dir = 1},/turf/simulated/floor/tiled,/area/engineering/engine_room)
-"aE" = (/obj/structure/cable/cyan{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/effect/floor_decal/borderfloor{dir = 4},/obj/effect/floor_decal/corner/yellow/border{dir = 4},/turf/simulated/floor/tiled,/area/engineering/engine_room)
-"aF" = (/obj/structure/cable/cyan{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/machinery/door/airlock/engineering,/obj/machinery/atmospherics/pipe/simple/hidden,/obj/machinery/door/firedoor/glass,/turf/simulated/floor,/area/engineering/engine_gas)
-"aG" = (/obj/machinery/button/remote/blast_door{desc = "A remote control-switch for the engine charging port."; dir = 1; id = "SupermatterPort"; name = "Observation Blast Doors"; pixel_x = -4; pixel_y = -24; req_access = list(10)},/turf/simulated/floor/tiled,/area/engineering/engine_room)
-"aH" = (/obj/machinery/button/remote/blast_door{desc = "A remote control-switch for the engine charging port."; id = "SupermatterPort"; name = "Observation Blast Doors"; pixel_x = -4; pixel_y = 24; req_access = list(10)},/turf/simulated/floor/tiled,/area/engineering/engine_room)
-"aI" = (/obj/item/weapon/extinguisher,/turf/space,/area/space)
-"aJ" = (/obj/machinery/atmospherics/pipe/simple/hidden,/turf/simulated/floor/tiled,/area/engineering/engine_room)
-"aK" = (/obj/structure/cable/cyan{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/structure/cable/cyan{d1 = 1; d2 = 4; icon_state = "1-4"},/obj/effect/floor_decal/borderfloor/corner{dir = 4},/obj/effect/floor_decal/corner/yellow/bordercorner{dir = 4},/turf/simulated/floor/tiled,/area/engineering/engine_room)
-"aL" = (/obj/structure/cable/cyan{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/machinery/light{dir = 1},/obj/effect/floor_decal/borderfloor{dir = 1},/obj/effect/floor_decal/corner/yellow/border{dir = 1},/turf/simulated/floor/tiled,/area/engineering/engine_room)
-"aM" = (/obj/structure/cable/cyan{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/machinery/light_switch{pixel_y = 24},/obj/machinery/atmospherics/unary/vent_scrubber/on,/obj/effect/floor_decal/borderfloor{dir = 1; icon_state = "borderfloor"; pixel_y = 0},/obj/effect/floor_decal/corner/yellow/border{dir = 1},/obj/effect/floor_decal/borderfloor/corner2{dir = 1},/obj/effect/floor_decal/corner/yellow/bordercorner2{dir = 1},/turf/simulated/floor/tiled,/area/engineering/engine_room)
-"aN" = (/obj/structure/cable/cyan{d1 = 2; d2 = 8; icon_state = "2-8"},/obj/structure/cable/cyan{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/machinery/atmospherics/pipe/simple/hidden,/turf/simulated/floor/tiled,/area/engineering/engine_room)
-"aO" = (/obj/machinery/power/apc{dir = 4; name = "east bump"; pixel_x = 28},/obj/structure/cable/cyan{d2 = 2; icon_state = "0-2"},/obj/effect/floor_decal/borderfloor{dir = 5},/obj/effect/floor_decal/corner/yellow/border{dir = 5},/obj/effect/floor_decal/borderfloor/corner2{dir = 4},/obj/effect/floor_decal/borderfloor/corner2{dir = 5},/obj/effect/floor_decal/corner/yellow/bordercorner2{dir = 5},/obj/effect/floor_decal/corner/yellow/bordercorner2{dir = 4},/turf/simulated/floor/tiled,/area/engineering/engine_room)
-"aP" = (/obj/structure/cable/yellow{d1 = 2; d2 = 4; icon_state = "2-4"},/obj/structure/cable/yellow{d1 = 1; d2 = 4; icon_state = "1-4"},/turf/simulated/floor/airless,/area/space)
-"aQ" = (/obj/machinery/atmospherics/pipe/simple/hidden{dir = 5; icon_state = "intact"},/turf/simulated/floor/tiled,/area/engineering/engine_room)
-"aR" = (/obj/structure/cable/cyan{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/machinery/atmospherics/pipe/simple/hidden{dir = 4},/turf/simulated/floor/tiled,/area/engineering/engine_room)
-"aS" = (/obj/machinery/atmospherics/pipe/simple/hidden{dir = 4},/turf/simulated/floor/tiled,/area/engineering/engine_room)
-"aT" = (/obj/structure/cable/yellow{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/machinery/atmospherics/pipe/simple/hidden{dir = 4},/turf/simulated/floor/tiled,/area/engineering/engine_room)
-"aU" = (/obj/effect/floor_decal/steeldecal/steel_decals_central5{icon_state = "steel_decals_central5"; dir = 8},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 6},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 5},/obj/machinery/atmospherics/pipe/simple/hidden{dir = 4},/turf/simulated/floor/tiled,/area/engineering/engine_room)
-"aV" = (/obj/structure/cable/cyan{d1 = 1; d2 = 4; icon_state = "1-4"},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 10},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 10},/obj/machinery/atmospherics/pipe/manifold/hidden{dir = 4; icon_state = "map"},/turf/simulated/floor/tiled,/area/engineering/engine_room)
-"aW" = (/obj/structure/cable/cyan{d1 = 2; d2 = 4; icon_state = "2-4"},/obj/structure/cable/cyan{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/structure/cable/cyan{d1 = 1; d2 = 4; icon_state = "1-4"},/turf/simulated/floor/tiled,/area/engineering/engine_room)
-"aX" = (/obj/machinery/field_generator{anchored = 1; state = 1},/turf/simulated/floor/airless,/area/space)
-"aY" = (/obj/structure/grille,/obj/structure/window/reinforced/full,/obj/machinery/door/firedoor/glass,/obj/structure/window/reinforced{dir = 8; health = 1e+006},/obj/structure/window/reinforced{dir = 1},/obj/machinery/door/blast/regular{density = 0; icon_state = "pdoor0"; id = "EngineRadiatorViewport"; name = "Engine Radiator Viewport Shutter"; opacity = 0},/turf/simulated/floor,/area/submap/pa_room)
-"aZ" = (/obj/structure/cable/yellow{d1 = 2; d2 = 4; icon_state = "2-4"},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/machinery/atmospherics/pipe/simple/hidden,/obj/effect/floor_decal/borderfloor/corner{dir = 8},/turf/simulated/floor/tiled,/area/engineering/engine_room)
-"ba" = (/obj/structure/cable/cyan{d1 = 1; d2 = 2; icon_state = "1-2"},/turf/simulated/floor/tiled,/area/engineering/engine_room)
-"bb" = (/obj/machinery/camera/network/engine{dir = 1},/obj/effect/floor_decal/borderfloor,/obj/effect/floor_decal/borderfloor/corner2,/turf/simulated/floor/tiled,/area/engineering/engine_room)
-"bc" = (/obj/machinery/atmospherics/unary/vent_pump/on{dir = 1},/obj/effect/floor_decal/borderfloor,/turf/simulated/floor/tiled,/area/engineering/engine_room)
-"bd" = (/obj/structure/grille,/obj/structure/window/reinforced/full,/obj/machinery/door/firedoor/glass,/obj/structure/window/reinforced{dir = 8; health = 1e+006},/obj/structure/window/reinforced,/obj/machinery/door/blast/regular{density = 0; icon_state = "pdoor0"; id = "EngineRadiatorViewport"; name = "Engine Radiator Viewport Shutter"; opacity = 0},/turf/simulated/floor,/area/submap/pa_room)
-"be" = (/obj/structure/cable/yellow{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/structure/cable/cyan{d1 = 1; d2 = 2; icon_state = "1-2"},/turf/simulated/floor/tiled,/area/engineering/engine_room)
-"bf" = (/turf/simulated/floor/tiled,/area/submap/pa_room)
-"bg" = (/obj/machinery/power/grounding_rod,/turf/simulated/floor/airless,/area/space)
-"bh" = (/obj/structure/sign/securearea{desc = "A warning sign which reads 'RADIOACTIVE AREA'"; icon_state = "radiation"; name = "RADIOACTIVE AREA"; pixel_x = 0; pixel_y = 0},/turf/simulated/wall/r_wall,/area/submap/pa_room)
-"bi" = (/turf/simulated/wall/r_wall,/area/submap/pa_room)
-"bj" = (/obj/structure/cable/yellow{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/machinery/power/tesla_coil,/obj/structure/cable/yellow{d2 = 4; icon_state = "0-4"},/turf/simulated/floor/airless,/area/space)
-"bk" = (/obj/structure/cable/yellow{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/machinery/atmospherics/pipe/simple/hidden,/obj/effect/floor_decal/borderfloor{dir = 8},/turf/simulated/floor/tiled,/area/engineering/engine_room)
-"bl" = (/obj/structure/cable/cyan{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/machinery/light{dir = 4; icon_state = "tube1"; pixel_x = 0},/obj/effect/floor_decal/borderfloor{dir = 4},/obj/effect/floor_decal/corner/yellow/border{dir = 4},/obj/effect/floor_decal/borderfloor/corner2{dir = 6},/obj/effect/floor_decal/corner/yellow/bordercorner2{dir = 6},/turf/simulated/floor/tiled,/area/engineering/engine_room)
-"bm" = (/turf/simulated/wall/r_wall,/area/template_noop)
-"bn" = (/obj/structure/grille,/obj/structure/window/reinforced/full,/obj/structure/window/reinforced{dir = 8; health = 1e+006},/obj/machinery/door/blast/regular{density = 0; icon_state = "pdoor0"; id = "EngineRadiatorViewport"; name = "Engine Radiator Viewport Shutter"; opacity = 0},/obj/machinery/door/firedoor/glass,/turf/simulated/floor,/area/submap/pa_room)
-"bo" = (/obj/effect/floor_decal/techfloor/orange{dir = 5},/turf/simulated/floor/tiled/techfloor/grid,/area/submap/pa_room)
-"bp" = (/obj/structure/cable/yellow{d1 = 2; d2 = 8; icon_state = "2-8"},/obj/item/clothing/head/hardhat,/turf/simulated/floor/airless,/area/space)
-"bq" = (/obj/effect/floor_decal/steeldecal,/turf/simulated/floor/tiled,/area/submap/pa_room)
-"br" = (/obj/machinery/light{dir = 1},/obj/machinery/button/remote/blast_door{desc = "A remote control-switch for the engine charging port."; id = "EngineRadiatorViewport"; name = "Viewport Blast Doors"; pixel_x = -4; pixel_y = 24; req_access = list(10)},/turf/simulated/floor/tiled,/area/submap/pa_room)
-"bs" = (/obj/structure/cable/cyan{d1 = 1; d2 = 4; icon_state = "1-4"},/turf/simulated/floor/tiled,/area/submap/pa_room)
-"bt" = (/obj/structure/cable/cyan{d2 = 8; icon_state = "0-8"},/obj/machinery/power/apc{dir = 4; name = "east bump"; pixel_x = 28},/obj/machinery/light_switch{pixel_y = 24},/turf/simulated/floor/tiled,/area/submap/pa_room)
-"bu" = (/obj/item/weapon/book/manual/engineering_particle_accelerator{pixel_x = 5; pixel_y = 5},/obj/item/weapon/book/manual/tesla_engine,/turf/template_noop,/area/template_noop)
-"bv" = (/obj/structure/table/rack{dir = 8; layer = 2.6},/obj/item/clothing/shoes/magboots,/obj/item/clothing/mask/breath,/obj/item/clothing/suit/space/void/engineering,/obj/item/clothing/mask/breath,/obj/item/clothing/head/helmet/space/void/engineering,/turf/template_noop,/area/template_noop)
-"bw" = (/obj/effect/floor_decal/techfloor/orange/corner{icon_state = "techfloororange_corners"; dir = 4},/turf/simulated/floor/tiled/techfloor/grid,/area/submap/pa_room)
-"bx" = (/obj/structure/particle_accelerator/particle_emitter/left{dir = 8},/obj/effect/floor_decal/techfloor/orange{dir = 1},/turf/simulated/floor/tiled/techfloor,/area/submap/pa_room)
-"by" = (/obj/effect/floor_decal/techfloor/orange{dir = 1},/turf/simulated/floor/tiled/techfloor,/area/submap/pa_room)
-"bz" = (/obj/machinery/particle_accelerator/control_box,/obj/effect/floor_decal/techfloor/orange{dir = 1},/turf/simulated/floor/tiled/techfloor,/area/submap/pa_room)
-"bA" = (/obj/structure/cable/cyan{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/machinery/door/airlock/glass_engineering,/obj/machinery/door/firedoor/glass,/turf/simulated/floor/tiled,/area/submap/pa_room)
-"bB" = (/obj/machinery/atmospherics/unary/vent_scrubber/on,/turf/simulated/floor/tiled,/area/submap/pa_room)
-"bC" = (/obj/structure/grille,/obj/structure/window/reinforced/full,/obj/machinery/door/firedoor/glass,/obj/structure/cable/yellow{d2 = 4; icon_state = "0-4"},/turf/simulated/floor,/area/submap/pa_room)
-"bD" = (/obj/structure/cable/yellow{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/machinery/atmospherics/pipe/simple/hidden,/obj/effect/floor_decal/borderfloor{dir = 8},/obj/structure/cable/yellow{d1 = 2; d2 = 8; icon_state = "2-8"},/turf/simulated/floor/tiled,/area/engineering/engine_room)
-"bE" = (/obj/machinery/the_singularitygen/tesla{anchored = 1},/turf/simulated/floor/airless,/area/space)
-"bF" = (/obj/structure/grille,/obj/structure/window/reinforced/full,/obj/structure/window/reinforced{dir = 8; health = 1e+006},/obj/machinery/door/blast/regular{density = 0; icon_state = "pdoor0"; id = "EngineRadiatorViewport"; name = "Engine Radiator Viewport Shutter"; opacity = 0},/obj/machinery/door/firedoor/glass,/obj/structure/cable/yellow{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor,/area/submap/pa_room)
-"bG" = (/obj/structure/particle_accelerator/particle_emitter/center{dir = 8},/turf/simulated/floor/tiled/techfloor,/area/submap/pa_room)
-"bH" = (/obj/structure/particle_accelerator/power_box{dir = 8},/turf/simulated/floor/tiled/techfloor,/area/submap/pa_room)
-"bI" = (/obj/structure/particle_accelerator/fuel_chamber{dir = 8},/turf/simulated/floor/tiled/techfloor,/area/submap/pa_room)
-"bJ" = (/obj/structure/particle_accelerator/end_cap{dir = 8},/obj/effect/floor_decal/techfloor/orange{dir = 4},/obj/effect/floor_decal/techfloor/hole{dir = 4},/turf/simulated/floor/tiled/techfloor,/area/submap/pa_room)
-"bK" = (/obj/machinery/camera/network/engine{dir = 8},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 5},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 6},/turf/simulated/floor/tiled,/area/submap/pa_room)
-"bL" = (/obj/structure/grille,/obj/structure/window/reinforced/full,/obj/machinery/door/firedoor/glass,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/structure/cable/yellow{d2 = 4; icon_state = "0-4"},/turf/simulated/floor,/area/submap/pa_room)
-"bM" = (/obj/structure/cable/yellow{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,/obj/machinery/atmospherics/pipe/simple/hidden,/obj/effect/floor_decal/borderfloor{dir = 8},/obj/structure/cable/yellow{d1 = 2; d2 = 8; icon_state = "2-8"},/turf/simulated/floor/tiled,/area/engineering/engine_room)
-"bN" = (/obj/structure/cable/cyan{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/effect/floor_decal/borderfloor{dir = 4},/obj/effect/floor_decal/corner/yellow/border{dir = 4},/turf/simulated/floor/tiled,/area/engineering/engine_room)
-"bO" = (/obj/machinery/button/remote/blast_door{desc = "A remote control-switch for the engine charging port."; id = "SupermatterPort"; name = "Radiation Collector Blast Doors"; pixel_x = -6; pixel_y = 7; req_access = list(10)},/obj/machinery/button/remote/blast_door{name = "Engine Monitoring Room Blast Doors"; desc = "A remote control-switch for the engine control room blast doors."; pixel_x = 5; pixel_y = 7; req_access = list(10); id = "EngineBlast"},/turf/template_noop,/area/template_noop)
-"bP" = (/obj/structure/grille,/obj/structure/window/reinforced/full,/obj/machinery/door/firedoor/glass,/obj/machinery/door/blast/regular{density = 0; icon_state = "pdoor0"; id = "EngineRadiatorViewport"; name = "Engine Radiator Viewport Shutter"; opacity = 0},/obj/structure/window/reinforced{dir = 1},/turf/simulated/floor,/area/submap/pa_room)
-"bQ" = (/obj/structure/cable/yellow{d1 = 2; d2 = 8; icon_state = "2-8"},/turf/simulated/floor/tiled/techfloor/grid,/area/submap/pa_room)
-"bR" = (/obj/structure/particle_accelerator/particle_emitter/right{dir = 8},/obj/effect/floor_decal/techfloor/orange,/turf/simulated/floor/tiled/techfloor,/area/submap/pa_room)
-"bS" = (/obj/effect/floor_decal/techfloor/orange,/turf/simulated/floor/tiled/techfloor,/area/submap/pa_room)
-"bT" = (/obj/effect/floor_decal/techfloor/orange,/obj/effect/floor_decal/techfloor/hole,/turf/simulated/floor/tiled/techfloor,/area/submap/pa_room)
-"bU" = (/obj/effect/floor_decal/techfloor/orange{icon_state = "techfloororange_edges"; dir = 6},/turf/simulated/floor/tiled/techfloor,/area/submap/pa_room)
-"bV" = (/obj/machinery/atmospherics/unary/vent_pump/on{dir = 1},/turf/simulated/floor/tiled,/area/submap/pa_room)
-"bW" = (/obj/effect/floor_decal/techfloor/orange/corner,/obj/structure/cable/yellow{d1 = 1; d2 = 2; icon_state = "1-2"},/turf/simulated/floor/tiled/techfloor/grid,/area/submap/pa_room)
-"bX" = (/obj/effect/floor_decal/techfloor/orange{icon_state = "techfloororange_edges"; dir = 6},/obj/structure/cable/yellow{d1 = 1; d2 = 4; icon_state = "1-4"},/turf/simulated/floor/tiled/techfloor/grid,/area/submap/pa_room)
-"bY" = (/obj/machinery/alarm{dir = 8; pixel_x = 25; pixel_y = 0},/obj/effect/floor_decal/steeldecal/steel_decals8,/obj/structure/table/standard,/obj/item/weapon/book/manual/tesla_engine,/obj/item/weapon/book/manual/engineering_particle_accelerator{pixel_x = 5; pixel_y = 5},/turf/simulated/floor/tiled,/area/submap/pa_room)
-"bZ" = (/obj/structure/cable/yellow{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/structure/cable/yellow{d2 = 2; icon_state = "0-2"},/obj/machinery/power/tesla_coil,/turf/simulated/floor/airless,/area/space)
-"ca" = (/obj/structure/cable/yellow{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/tiled,/area/submap/pa_room)
-"cb" = (/obj/structure/cable/cyan{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/machinery/light{dir = 4; icon_state = "tube1"; pixel_x = 0},/obj/effect/floor_decal/borderfloor{dir = 4},/obj/effect/floor_decal/corner/yellow/border{dir = 4},/obj/effect/floor_decal/borderfloor/corner2{dir = 5},/obj/effect/floor_decal/corner/yellow/bordercorner2{dir = 5},/turf/simulated/floor/tiled,/area/engineering/engine_room)
-"cc" = (/obj/machinery/atmospherics/pipe/simple/hidden{dir = 6},/turf/simulated/floor/tiled,/area/engineering/engine_room)
-"cd" = (/obj/machinery/light,/obj/machinery/button/remote/blast_door{desc = "A remote control-switch for the engine charging port."; dir = 1; id = "EngineRadiatorViewport"; name = "Viewport Blast Doors"; pixel_x = -4; pixel_y = -24; req_access = list(10)},/obj/structure/cable/yellow{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/tiled,/area/submap/pa_room)
-"ce" = (/obj/machinery/camera/network/engine,/obj/effect/floor_decal/borderfloor{dir = 1},/obj/effect/floor_decal/borderfloor/corner2{dir = 4},/turf/simulated/floor/tiled,/area/engineering/engine_room)
-"cf" = (/obj/machinery/atmospherics/unary/vent_scrubber/on,/obj/effect/floor_decal/borderfloor{dir = 1},/turf/simulated/floor/tiled,/area/engineering/engine_room)
-"cg" = (/obj/structure/cable/yellow{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/machinery/atmospherics/pipe/simple/hidden,/obj/effect/floor_decal/borderfloor/corner{dir = 1},/turf/simulated/floor/tiled,/area/engineering/engine_room)
-"ch" = (/obj/machinery/atmospherics/pipe/simple/hidden{dir = 4},/obj/structure/cable/yellow{d1 = 1; d2 = 4; icon_state = "1-4"},/turf/simulated/floor/tiled,/area/engineering/engine_room)
-"ci" = (/obj/machinery/atmospherics/pipe/simple/hidden,/obj/effect/floor_decal/industrial/warning/corner{icon_state = "warningcorner"; dir = 8},/turf/simulated/floor/tiled,/area/engineering/engine_room)
-"cj" = (/obj/structure/cable/yellow{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/effect/floor_decal/steeldecal/steel_decals_central5{icon_state = "steel_decals_central5"; dir = 8},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 5},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 6},/obj/machinery/atmospherics/pipe/simple/hidden{dir = 4},/turf/simulated/floor/tiled,/area/engineering/engine_room)
-"ck" = (/obj/structure/cable/yellow{d1 = 1; d2 = 8; icon_state = "1-8"},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 9; pixel_y = 0},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 9},/obj/machinery/atmospherics/pipe/simple/hidden{dir = 9; icon_state = "intact"},/turf/simulated/floor/tiled,/area/engineering/engine_room)
-"cl" = (/obj/structure/cable/cyan{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/effect/floor_decal/borderfloor{dir = 4},/obj/effect/floor_decal/corner/yellow/border{dir = 4},/obj/effect/floor_decal/borderfloor/corner2{dir = 6},/obj/effect/floor_decal/corner/yellow/bordercorner2{dir = 6},/turf/simulated/floor/tiled,/area/engineering/engine_room)
-"cm" = (/obj/structure/grille,/obj/structure/window/reinforced/full,/obj/machinery/door/firedoor/glass,/obj/machinery/door/blast/regular{density = 0; icon_state = "pdoor0"; id = "EngineRadiatorViewport"; name = "Engine Radiator Viewport Shutter"; opacity = 0},/obj/structure/window/reinforced,/turf/simulated/floor,/area/submap/pa_room)
-"cn" = (/obj/structure/cable/cyan{d1 = 2; d2 = 4; icon_state = "2-4"},/obj/effect/floor_decal/borderfloor/corner,/obj/effect/floor_decal/corner/yellow/bordercorner,/turf/simulated/floor/tiled,/area/engineering/engine_room)
-"co" = (/obj/machinery/power/tesla_coil,/obj/structure/cable/yellow{d2 = 4; icon_state = "0-4"},/turf/simulated/floor/airless,/area/space)
-"cp" = (/obj/structure/cable/cyan{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/machinery/atmospherics/unary/vent_pump/on{dir = 1},/obj/effect/floor_decal/borderfloor,/obj/effect/floor_decal/corner/yellow/border,/turf/simulated/floor/tiled,/area/engineering/engine_room)
-"cq" = (/obj/structure/cable/cyan{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/machinery/alarm{dir = 1; icon_state = "alarm0"; pixel_y = -22},/obj/effect/floor_decal/borderfloor,/obj/effect/floor_decal/corner/yellow/border,/turf/simulated/floor/tiled,/area/engineering/engine_room)
-"cr" = (/obj/structure/cable/cyan{d1 = 1; d2 = 8; icon_state = "1-8"},/obj/effect/floor_decal/borderfloor{dir = 6},/obj/effect/floor_decal/corner/yellow/border{dir = 6},/obj/effect/floor_decal/industrial/hatch/yellow,/obj/structure/reagent_dispensers/fueltank,/turf/simulated/floor/tiled,/area/engineering/engine_room)
-"cs" = (/obj/item/weapon/weldingtool,/turf/simulated/floor/airless,/area/space)
-"ct" = (/obj/machinery/access_button{command = "cycle_exterior"; frequency = 1379; master_tag = "eng_south_airlock"; name = "exterior access button"; pixel_x = -5; pixel_y = 26; req_one_access = list(10,11,13)},/obj/machinery/door/airlock/glass_external{frequency = 1379; icon_state = "door_locked"; id_tag = "eng_south_outer"; locked = 1; name = "Engine South Airlock Exterior"},/obj/structure/cable/cyan{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/tiled/dark,/area/engineering/engine_room)
-"cu" = (/obj/machinery/atmospherics/unary/vent_pump/high_volume{dir = 4; frequency = 1379; id_tag = "eng_south_pump"},/obj/machinery/airlock_sensor{frequency = 1379; id_tag = "eng_south_sensor"; pixel_x = 0; pixel_y = 25},/obj/structure/cable/cyan{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/machinery/light/small{dir = 1},/turf/simulated/floor/tiled/dark,/area/engineering/engine_room)
-"cv" = (/obj/machinery/door/airlock/glass_external{frequency = 1379; icon_state = "door_locked"; id_tag = "eng_south_inner"; locked = 1; name = "Engine South Airlock Interior"},/obj/machinery/atmospherics/pipe/simple/hidden{dir = 4},/obj/structure/cable/cyan{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/machinery/access_button{command = "cycle_interior"; frequency = 1379; master_tag = "eng_south_airlock"; name = "interior access button"; pixel_x = 8; pixel_y = -26; req_one_access = list(10,11)},/turf/simulated/floor/tiled/dark,/area/engineering/engine_room)
-"cw" = (/obj/structure/cable/cyan{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/structure/sign/securearea{desc = "A warning sign which reads 'EXTERNAL AIRLOCK'"; icon_state = "space"; layer = 4; name = "EXTERNAL AIRLOCK"; pixel_x = 0; pixel_y = -32},/obj/machinery/atmospherics/pipe/simple/hidden{dir = 9; icon_state = "intact"},/obj/effect/floor_decal/borderfloor,/obj/effect/floor_decal/corner/yellow/border,/obj/effect/floor_decal/borderfloor/corner2,/obj/effect/floor_decal/corner/yellow/bordercorner2,/obj/effect/floor_decal/industrial/warning{dir = 8},/turf/simulated/floor/tiled,/area/engineering/engine_room)
-"cx" = (/obj/structure/cable/cyan{d1 = 1; d2 = 8; icon_state = "1-8"},/obj/effect/floor_decal/borderfloor{dir = 6},/obj/effect/floor_decal/corner/yellow/border{dir = 6},/turf/simulated/floor/tiled,/area/engineering/engine_room)
-"cy" = (/obj/structure/cable/cyan{d1 = 1; d2 = 4; icon_state = "1-4"},/turf/simulated/floor/airless,/area/space)
-"cz" = (/obj/structure/cable/cyan{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/structure/cable/cyan{d1 = 1; d2 = 4; icon_state = "1-4"},/turf/simulated/floor/airless,/area/space)
-"cA" = (/obj/structure/cable/cyan{d1 = 1; d2 = 8; icon_state = "1-8"},/obj/effect/floor_decal/rust,/turf/simulated/floor/airless,/area/space)
-"cB" = (/obj/structure/closet/emcloset,/obj/machinery/embedded_controller/radio/airlock/airlock_controller{frequency = 1379; id_tag = "eng_south_airlock"; pixel_x = 24; pixel_y = 0; req_one_access = list(10,11); tag_airpump = "eng_south_pump"; tag_chamber_sensor = "eng_south_sensor"; tag_exterior_door = "eng_south_outer"; tag_interior_door = "eng_south_inner"},/turf/simulated/floor/tiled/dark,/area/engineering/engine_room)
-"cC" = (/turf/simulated/wall/r_wall,/area/space)
-"cD" = (/obj/effect/floor_decal/techfloor/orange{dir = 5},/turf/simulated/floor/tiled/techfloor,/area/submap/pa_room)
-"cE" = (/obj/machinery/door/blast/regular{density = 0; dir = 2; icon_state = "pdoor0"; id = "SupermatterPort"; layer = 2.7; name = "Reactor Blast Door"; opacity = 0},/obj/machinery/door/firedoor/glass,/obj/structure/grille,/obj/structure/window/reinforced/full,/obj/structure/window/reinforced{dir = 8; health = 1e+006},/turf/simulated/floor,/area/engineering/engine_room)
-"cF" = (/obj/structure/cable/yellow{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/structure/cable/yellow,/obj/machinery/power/tesla_coil,/turf/simulated/floor/airless,/area/space)
-"cG" = (/obj/structure/cable/yellow{d1 = 2; d2 = 8; icon_state = "2-8"},/turf/simulated/floor/tiled,/area/submap/pa_room)
-"cH" = (/obj/machinery/door/airlock/glass_engineering,/obj/structure/cable/yellow{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/machinery/door/firedoor/glass,/turf/simulated/floor/tiled,/area/submap/pa_room)
-"cI" = (/obj/structure/cable/yellow{d1 = 1; d2 = 2; icon_state = "1-2"},/turf/simulated/floor/tiled,/area/engineering/engine_room)
-"cJ" = (/obj/item/weapon/tool/wirecutters,/turf/simulated/floor/airless,/area/space)
-"cK" = (/obj/structure/cable/yellow{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/airless,/area/space)
-"cL" = (/obj/structure/cable/cyan{d2 = 2; icon_state = "0-2"},/obj/machinery/power/emitter{dir = 1; anchored = 1; state = 1},/turf/simulated/floor/airless,/area/space)
-"cM" = (/obj/structure/cable/cyan{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/machinery/light,/obj/effect/floor_decal/borderfloor,/obj/effect/floor_decal/corner/yellow/border,/turf/simulated/floor/tiled,/area/engineering/engine_room)
-"cN" = (/obj/structure/cable/yellow{d1 = 1; d2 = 2; icon_state = "1-2"},/turf/simulated/floor/airless,/area/space)
-"cQ" = (/obj/structure/cable/yellow{d1 = 1; d2 = 8; icon_state = "1-8"},/turf/simulated/floor/airless,/area/space)
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"aa" = (
+/turf/template_noop,
+/area/template_noop)
+"ab" = (
+/turf/space,
+/area/space)
+"ac" = (
+/obj/structure/lattice,
+/obj/structure/grille,
+/turf/space,
+/area/space)
+"ad" = (
+/obj/structure/lattice,
+/turf/space,
+/area/space)
+"ae" = (
+/turf/simulated/wall/r_wall,
+/area/engineering/engine_gas)
+"af" = (
+/turf/simulated/wall/r_wall,
+/area/engineering/engine_room)
+"ag" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/canister/air/airlock,
+/turf/simulated/floor,
+/area/engineering/engine_gas)
+"ah" = (
+/obj/machinery/field_generator,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 10;
+	icon_state = "intact"
+	},
+/turf/simulated/floor,
+/area/engineering/engine_gas)
+"ai" = (
+/obj/machinery/field_generator,
+/turf/simulated/floor,
+/area/engineering/engine_gas)
+"aj" = (
+/turf/simulated/floor/airless,
+/area/space)
+"ak" = (
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/airless,
+/area/space)
+"al" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/airless,
+/area/space)
+"am" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/airless,
+/area/space)
+"an" = (
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/airless,
+/area/space)
+"ao" = (
+/obj/structure/closet/emcloset,
+/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
+	frequency = 1379;
+	id_tag = "eng_north_airlock";
+	pixel_x = 24;
+	pixel_y = 0;
+	req_one_access = list(10,11);
+	tag_airpump = "eng_north_pump";
+	tag_chamber_sensor = "eng_north_sensor";
+	tag_exterior_door = "eng_north_outer";
+	tag_interior_door = "eng_north_inner"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/engineering/engine_room)
+"ap" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 4;
+	icon_state = "map"
+	},
+/turf/simulated/floor,
+/area/engineering/engine_gas)
+"aq" = (
+/obj/machinery/alarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
+	},
+/obj/structure/table/standard,
+/obj/item/stack/cable_coil/random,
+/obj/item/weapon/tool/wrench,
+/obj/item/weapon/tool/screwdriver,
+/turf/simulated/floor,
+/area/engineering/engine_gas)
+"ar" = (
+/obj/structure/cable/cyan,
+/obj/machinery/power/emitter{
+	anchored = 1;
+	state = 1
+	},
+/turf/simulated/floor/airless,
+/area/space)
+"as" = (
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/effect/floor_decal/rust/mono_rusted1,
+/turf/simulated/floor/airless,
+/area/space)
+"at" = (
+/obj/machinery/access_button{
+	command = "cycle_exterior";
+	frequency = 1379;
+	master_tag = "eng_north_airlock";
+	name = "exterior access button";
+	pixel_x = -5;
+	pixel_y = -26;
+	req_one_access = list(10,11,13)
+	},
+/obj/machinery/door/airlock/glass_external{
+	frequency = 1379;
+	icon_state = "door_locked";
+	id_tag = "eng_north_outer";
+	locked = 1;
+	name = "Engine North Airlock Exterior"
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/engineering/engine_room)
+"au" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 4;
+	frequency = 1379;
+	id_tag = "eng_north_pump"
+	},
+/obj/machinery/light/small,
+/obj/machinery/airlock_sensor{
+	frequency = 1379;
+	id_tag = "eng_north_sensor";
+	pixel_x = 0;
+	pixel_y = -25
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/engineering/engine_room)
+"av" = (
+/obj/machinery/door/airlock/glass_external{
+	frequency = 1379;
+	icon_state = "door_locked";
+	id_tag = "eng_north_inner";
+	locked = 1;
+	name = "Engine North Airlock Interior"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/engineering/engine_room)
+"aw" = (
+/obj/machinery/access_button{
+	command = "cycle_interior";
+	frequency = 1379;
+	master_tag = "eng_north_airlock";
+	name = "interior access button";
+	pixel_x = -28;
+	pixel_y = 26;
+	req_one_access = list(10,11)
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
+	icon_state = "space";
+	layer = 4;
+	name = "EXTERNAL AIRLOCK";
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 10;
+	icon_state = "intact"
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/yellow/bordercorner2{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/engine_room)
+"ax" = (
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 5
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/engine_room)
+"ay" = (
+/obj/structure/cable/cyan{
+	d1 = 0;
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -28
+	},
+/turf/simulated/floor,
+/area/engineering/engine_gas)
+"az" = (
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/power/sensor{
+	name = "Powernet Sensor - Engine Power";
+	name_tag = "Engine Power"
+	},
+/obj/structure/cable/cyan{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/turf/simulated/floor,
+/area/engineering/engine_gas)
+"aA" = (
+/obj/machinery/camera/network/engine{
+	dir = 1
+	},
+/obj/structure/table/standard,
+/obj/item/weapon/circuitboard/grounding_rod{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/weapon/circuitboard/grounding_rod{
+	pixel_x = -2;
+	pixel_y = -2
+	},
+/turf/simulated/floor,
+/area/engineering/engine_gas)
+"aB" = (
+/obj/machinery/camera/network/engine{
+	dir = 8
+	},
+/turf/space,
+/area/space)
+"aC" = (
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'RADIOACTIVE AREA'";
+	icon_state = "radiation";
+	name = "RADIOACTIVE AREA";
+	pixel_x = 0;
+	pixel_y = 0
+	},
+/turf/simulated/wall/r_wall,
+/area/engineering/engine_room)
+"aD" = (
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/effect/floor_decal/industrial/warning/corner{
+	icon_state = "warningcorner";
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/engine_room)
+"aE" = (
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/engine_room)
+"aF" = (
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/engineering,
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor,
+/area/engineering/engine_gas)
+"aG" = (
+/obj/machinery/button/remote/blast_door{
+	desc = "A remote control-switch for the engine charging port.";
+	dir = 1;
+	id = "SupermatterPort";
+	name = "Observation Blast Doors";
+	pixel_x = -4;
+	pixel_y = -24;
+	req_access = list(10)
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/engine_room)
+"aH" = (
+/obj/machinery/button/remote/blast_door{
+	desc = "A remote control-switch for the engine charging port.";
+	id = "SupermatterPort";
+	name = "Observation Blast Doors";
+	pixel_x = -4;
+	pixel_y = 24;
+	req_access = list(10)
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/engine_room)
+"aI" = (
+/obj/item/weapon/extinguisher,
+/turf/space,
+/area/space)
+"aJ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/turf/simulated/floor/tiled,
+/area/engineering/engine_room)
+"aK" = (
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/yellow/bordercorner{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/engine_room)
+"aL" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/engine_room)
+"aM" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/light_switch{
+	pixel_y = 24
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/effect/floor_decal/borderfloor{
+	dir = 1;
+	icon_state = "borderfloor";
+	pixel_y = 0
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/yellow/bordercorner2{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/engine_room)
+"aN" = (
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/turf/simulated/floor/tiled,
+/area/engineering/engine_room)
+"aO" = (
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 28
+	},
+/obj/structure/cable/cyan{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 5
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/yellow/bordercorner2{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/yellow/bordercorner2{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/engine_room)
+"aP" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/airless,
+/area/space)
+"aQ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 5;
+	icon_state = "intact"
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/engine_room)
+"aR" = (
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/engine_room)
+"aS" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/engine_room)
+"aT" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/engine_room)
+"aU" = (
+/obj/effect/floor_decal/steeldecal/steel_decals_central5{
+	icon_state = "steel_decals_central5";
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/engine_room)
+"aV" = (
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 4;
+	icon_state = "map"
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/engine_room)
+"aW" = (
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/engine_room)
+"aX" = (
+/obj/machinery/field_generator{
+	anchored = 1;
+	state = 1
+	},
+/turf/simulated/floor/airless,
+/area/space)
+"aY" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/machinery/door/firedoor/glass,
+/obj/structure/window/reinforced{
+	dir = 8;
+	health = 1e+006
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "EngineRadiatorViewport";
+	name = "Engine Radiator Viewport Shutter";
+	opacity = 0
+	},
+/turf/simulated/floor,
+/area/submap/pa_room)
+"aZ" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/engine_room)
+"ba" = (
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/engine_room)
+"bb" = (
+/obj/machinery/camera/network/engine{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/borderfloor/corner2,
+/turf/simulated/floor/tiled,
+/area/engineering/engine_room)
+"bc" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloor,
+/turf/simulated/floor/tiled,
+/area/engineering/engine_room)
+"bd" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/machinery/door/firedoor/glass,
+/obj/structure/window/reinforced{
+	dir = 8;
+	health = 1e+006
+	},
+/obj/structure/window/reinforced,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "EngineRadiatorViewport";
+	name = "Engine Radiator Viewport Shutter";
+	opacity = 0
+	},
+/turf/simulated/floor,
+/area/submap/pa_room)
+"be" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/engine_room)
+"bf" = (
+/turf/simulated/floor/tiled,
+/area/submap/pa_room)
+"bg" = (
+/obj/machinery/power/grounding_rod,
+/turf/simulated/floor/airless,
+/area/space)
+"bh" = (
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'RADIOACTIVE AREA'";
+	icon_state = "radiation";
+	name = "RADIOACTIVE AREA";
+	pixel_x = 0;
+	pixel_y = 0
+	},
+/turf/simulated/wall/r_wall,
+/area/submap/pa_room)
+"bi" = (
+/turf/simulated/wall/r_wall,
+/area/submap/pa_room)
+"bj" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/power/tesla_coil,
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/airless,
+/area/space)
+"bk" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/engine_room)
+"bl" = (
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1";
+	pixel_x = 0
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/yellow/bordercorner2{
+	dir = 6
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/engine_room)
+"bm" = (
+/turf/simulated/wall/r_wall,
+/area/template_noop)
+"bn" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced{
+	dir = 8;
+	health = 1e+006
+	},
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "EngineRadiatorViewport";
+	name = "Engine Radiator Viewport Shutter";
+	opacity = 0
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor,
+/area/submap/pa_room)
+"bo" = (
+/obj/effect/floor_decal/techfloor/orange{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/submap/pa_room)
+"bp" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/item/clothing/head/hardhat,
+/turf/simulated/floor/airless,
+/area/space)
+"bq" = (
+/obj/effect/floor_decal/steeldecal,
+/turf/simulated/floor/tiled,
+/area/submap/pa_room)
+"br" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/button/remote/blast_door{
+	desc = "A remote control-switch for the engine charging port.";
+	id = "EngineRadiatorViewport";
+	name = "Viewport Blast Doors";
+	pixel_x = -4;
+	pixel_y = 24;
+	req_access = list(10)
+	},
+/turf/simulated/floor/tiled,
+/area/submap/pa_room)
+"bs" = (
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled,
+/area/submap/pa_room)
+"bt" = (
+/obj/structure/cable/cyan{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 28
+	},
+/obj/machinery/light_switch{
+	pixel_y = 24
+	},
+/turf/simulated/floor/tiled,
+/area/submap/pa_room)
+"bu" = (
+/obj/item/weapon/book/manual/engineering_particle_accelerator{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/item/weapon/book/manual/tesla_engine,
+/turf/template_noop,
+/area/template_noop)
+"bv" = (
+/obj/structure/table/rack{
+	dir = 8;
+	layer = 2.6
+	},
+/obj/item/clothing/shoes/magboots,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/suit/space/void/engineering,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/head/helmet/space/void/engineering,
+/turf/template_noop,
+/area/template_noop)
+"bw" = (
+/obj/effect/floor_decal/techfloor/orange/corner{
+	icon_state = "techfloororange_corners";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/submap/pa_room)
+"bx" = (
+/obj/structure/particle_accelerator/particle_emitter/left{
+	dir = 8
+	},
+/obj/effect/floor_decal/techfloor/orange{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/submap/pa_room)
+"by" = (
+/obj/effect/floor_decal/techfloor/orange{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/submap/pa_room)
+"bz" = (
+/obj/machinery/particle_accelerator/control_box,
+/obj/effect/floor_decal/techfloor/orange{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/submap/pa_room)
+"bA" = (
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/glass_engineering,
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/tiled,
+/area/submap/pa_room)
+"bB" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/tiled,
+/area/submap/pa_room)
+"bC" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/machinery/door/firedoor/glass,
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor,
+/area/submap/pa_room)
+"bD" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/engine_room)
+"bE" = (
+/obj/machinery/the_singularitygen/tesla{
+	anchored = 1
+	},
+/turf/simulated/floor/airless,
+/area/space)
+"bF" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced{
+	dir = 8;
+	health = 1e+006
+	},
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "EngineRadiatorViewport";
+	name = "Engine Radiator Viewport Shutter";
+	opacity = 0
+	},
+/obj/machinery/door/firedoor/glass,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/submap/pa_room)
+"bG" = (
+/obj/structure/particle_accelerator/particle_emitter/center{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/submap/pa_room)
+"bH" = (
+/obj/structure/particle_accelerator/power_box{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/submap/pa_room)
+"bI" = (
+/obj/structure/particle_accelerator/fuel_chamber{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/submap/pa_room)
+"bJ" = (
+/obj/structure/particle_accelerator/end_cap{
+	dir = 8
+	},
+/obj/effect/floor_decal/techfloor/orange{
+	dir = 4
+	},
+/obj/effect/floor_decal/techfloor/hole{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/submap/pa_room)
+"bK" = (
+/obj/machinery/camera/network/engine{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/turf/simulated/floor/tiled,
+/area/submap/pa_room)
+"bL" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor,
+/area/submap/pa_room)
+"bM" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/engine_room)
+"bN" = (
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/engine_room)
+"bO" = (
+/obj/machinery/button/remote/blast_door{
+	desc = "A remote control-switch for the engine charging port.";
+	id = "SupermatterPort";
+	name = "Radiation Collector Blast Doors";
+	pixel_x = -6;
+	pixel_y = 7;
+	req_access = list(10)
+	},
+/obj/machinery/button/remote/blast_door{
+	name = "Engine Monitoring Room Blast Doors";
+	desc = "A remote control-switch for the engine control room blast doors.";
+	pixel_x = 5;
+	pixel_y = 7;
+	req_access = list(10);
+	id = "EngineBlast"
+	},
+/turf/template_noop,
+/area/template_noop)
+"bP" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "EngineRadiatorViewport";
+	name = "Engine Radiator Viewport Shutter";
+	opacity = 0
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/submap/pa_room)
+"bQ" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/submap/pa_room)
+"bR" = (
+/obj/structure/particle_accelerator/particle_emitter/right{
+	dir = 8
+	},
+/obj/effect/floor_decal/techfloor/orange,
+/turf/simulated/floor/tiled/techfloor,
+/area/submap/pa_room)
+"bS" = (
+/obj/effect/floor_decal/techfloor/orange,
+/turf/simulated/floor/tiled/techfloor,
+/area/submap/pa_room)
+"bT" = (
+/obj/effect/floor_decal/techfloor/orange,
+/obj/effect/floor_decal/techfloor/hole,
+/turf/simulated/floor/tiled/techfloor,
+/area/submap/pa_room)
+"bU" = (
+/obj/effect/floor_decal/techfloor/orange{
+	icon_state = "techfloororange_edges";
+	dir = 6
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/submap/pa_room)
+"bV" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/submap/pa_room)
+"bW" = (
+/obj/effect/floor_decal/techfloor/orange/corner,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/submap/pa_room)
+"bX" = (
+/obj/effect/floor_decal/techfloor/orange{
+	icon_state = "techfloororange_edges";
+	dir = 6
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/submap/pa_room)
+"bY" = (
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 25;
+	pixel_y = 0
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals8,
+/obj/structure/table/standard,
+/obj/item/weapon/book/manual/tesla_engine,
+/obj/item/weapon/book/manual/engineering_particle_accelerator{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/turf/simulated/floor/tiled,
+/area/submap/pa_room)
+"bZ" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/tesla_coil,
+/turf/simulated/floor/airless,
+/area/space)
+"ca" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled,
+/area/submap/pa_room)
+"cb" = (
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1";
+	pixel_x = 0
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/yellow/bordercorner2{
+	dir = 5
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/engine_room)
+"cc" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 6
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/engine_room)
+"cd" = (
+/obj/machinery/light,
+/obj/machinery/button/remote/blast_door{
+	desc = "A remote control-switch for the engine charging port.";
+	dir = 1;
+	id = "EngineRadiatorViewport";
+	name = "Viewport Blast Doors";
+	pixel_x = -4;
+	pixel_y = -24;
+	req_access = list(10)
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled,
+/area/submap/pa_room)
+"ce" = (
+/obj/machinery/camera/network/engine,
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/engine_room)
+"cf" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/engine_room)
+"cg" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/engine_room)
+"ch" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/engine_room)
+"ci" = (
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/effect/floor_decal/industrial/warning/corner{
+	icon_state = "warningcorner";
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/engine_room)
+"cj" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals_central5{
+	icon_state = "steel_decals_central5";
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/engine_room)
+"ck" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9;
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 9;
+	icon_state = "intact"
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/engine_room)
+"cl" = (
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/yellow/bordercorner2{
+	dir = 6
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/engine_room)
+"cm" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "EngineRadiatorViewport";
+	name = "Engine Radiator Viewport Shutter";
+	opacity = 0
+	},
+/obj/structure/window/reinforced,
+/turf/simulated/floor,
+/area/submap/pa_room)
+"cn" = (
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/effect/floor_decal/borderfloor/corner,
+/obj/effect/floor_decal/corner/yellow/bordercorner,
+/turf/simulated/floor/tiled,
+/area/engineering/engine_room)
+"co" = (
+/obj/machinery/power/tesla_coil,
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/airless,
+/area/space)
+"cp" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/yellow/border,
+/turf/simulated/floor/tiled,
+/area/engineering/engine_room)
+"cq" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/alarm{
+	dir = 1;
+	icon_state = "alarm0";
+	pixel_y = -22
+	},
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/yellow/border,
+/turf/simulated/floor/tiled,
+/area/engineering/engine_room)
+"cr" = (
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 6
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/reagent_dispensers/fueltank,
+/turf/simulated/floor/tiled,
+/area/engineering/engine_room)
+"cs" = (
+/obj/item/weapon/weldingtool,
+/turf/simulated/floor/airless,
+/area/space)
+"ct" = (
+/obj/machinery/access_button{
+	command = "cycle_exterior";
+	frequency = 1379;
+	master_tag = "eng_south_airlock";
+	name = "exterior access button";
+	pixel_x = -5;
+	pixel_y = 26;
+	req_one_access = list(10,11,13)
+	},
+/obj/machinery/door/airlock/glass_external{
+	frequency = 1379;
+	icon_state = "door_locked";
+	id_tag = "eng_south_outer";
+	locked = 1;
+	name = "Engine South Airlock Exterior"
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/engineering/engine_room)
+"cu" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 4;
+	frequency = 1379;
+	id_tag = "eng_south_pump"
+	},
+/obj/machinery/airlock_sensor{
+	frequency = 1379;
+	id_tag = "eng_south_sensor";
+	pixel_x = 0;
+	pixel_y = 25
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/engineering/engine_room)
+"cv" = (
+/obj/machinery/door/airlock/glass_external{
+	frequency = 1379;
+	icon_state = "door_locked";
+	id_tag = "eng_south_inner";
+	locked = 1;
+	name = "Engine South Airlock Interior"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/access_button{
+	command = "cycle_interior";
+	frequency = 1379;
+	master_tag = "eng_south_airlock";
+	name = "interior access button";
+	pixel_x = 8;
+	pixel_y = -26;
+	req_one_access = list(10,11)
+	},
+/turf/simulated/floor/tiled/dark,
+/area/engineering/engine_room)
+"cw" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
+	icon_state = "space";
+	layer = 4;
+	name = "EXTERNAL AIRLOCK";
+	pixel_x = 0;
+	pixel_y = -32
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 9;
+	icon_state = "intact"
+	},
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/yellow/border,
+/obj/effect/floor_decal/borderfloor/corner2,
+/obj/effect/floor_decal/corner/yellow/bordercorner2,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/engine_room)
+"cx" = (
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 6
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/engine_room)
+"cy" = (
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/airless,
+/area/space)
+"cz" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/airless,
+/area/space)
+"cA" = (
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor/airless,
+/area/space)
+"cB" = (
+/obj/structure/closet/emcloset,
+/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
+	frequency = 1379;
+	id_tag = "eng_south_airlock";
+	pixel_x = 24;
+	pixel_y = 0;
+	req_one_access = list(10,11);
+	tag_airpump = "eng_south_pump";
+	tag_chamber_sensor = "eng_south_sensor";
+	tag_exterior_door = "eng_south_outer";
+	tag_interior_door = "eng_south_inner"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/engineering/engine_room)
+"cC" = (
+/turf/simulated/wall/r_wall,
+/area/space)
+"cD" = (
+/obj/effect/floor_decal/techfloor/orange{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/submap/pa_room)
+"cE" = (
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 2;
+	icon_state = "pdoor0";
+	id = "SupermatterPort";
+	layer = 2.7;
+	name = "Reactor Blast Door";
+	opacity = 0
+	},
+/obj/machinery/door/firedoor/glass,
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced{
+	dir = 8;
+	health = 1e+006
+	},
+/turf/simulated/floor,
+/area/engineering/engine_room)
+"cF" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow,
+/obj/machinery/power/tesla_coil,
+/turf/simulated/floor/airless,
+/area/space)
+"cG" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled,
+/area/submap/pa_room)
+"cH" = (
+/obj/machinery/door/airlock/glass_engineering,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/tiled,
+/area/submap/pa_room)
+"cI" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/engine_room)
+"cJ" = (
+/obj/item/weapon/tool/wirecutters,
+/turf/simulated/floor/airless,
+/area/space)
+"cK" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/airless,
+/area/space)
+"cL" = (
+/obj/structure/cable/cyan{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/emitter{
+	dir = 1;
+	anchored = 1;
+	state = 1
+	},
+/turf/simulated/floor/airless,
+/area/space)
+"cM" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/light,
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/yellow/border,
+/turf/simulated/floor/tiled,
+/area/engineering/engine_room)
+"cN" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/airless,
+/area/space)
+"cQ" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/airless,
+/area/space)
 
 (1,1,1) = {"
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaabababababababababababababababababababababababababababaaaa
-aaacacacacacadacacacacacabababacacacacacacadacacacacacacaaaa
-aaacababababababababababababababababababababababababababaaaa
-aaacababababababababababababababababababababababababababaaaa
-aaadabababababababababababababababababababaeaeaeaeaeababaaaa
-aaacacacacacacacacacacacacacacacafafafababaeagahaiaeababaaaa
-aaacababajajakalalalalalamalalanafaoafafafaeagapaqaeababaaaa
-aaacabababajarajajajajajarajadasatauavawaxaeayazaAaaaaaaaaaa
-aaacababababadababadababadababaBafafaCaDaEaeaeaFaeaaaaaaaaaa
-aaacababababadababadababadabababababcEaJaKaLaMaNaOaaaaaaaaaa
-aaacababaIabadababadababadadbgabababcEaQaRaSaUaVaWaaaaaaaaaa
-aaacabababbgajcocKcKcKbjcKbpadabababcEaGbabbbcaZbeaaaaaaaaaa
-aaacadadadajaXabadabadabaXcNadaYbPbPbhbibAbibibkblbmbmaaaaaa
-aaacabababajababadabadababbZadbnbobfbqbrbsbtbibkaEaabubvaaaa
-aaacabababajadadcsajajadadcNadbnbwbxbybzcDbBbCbDaEaaaaaaaaaa
-aaacabababajababajbEajababaPcKbFbQbGbHbIbJbKbLbMbNaaaabOaaaa
-aaacabababajadadajajajadadcNadbnbWbRbSbTbUbVbCbDaEaaaaaaaaaa
-aaacabababajababadabadababcFadbnbXcacacdcGbYbibkaEaaaaaaaaaa
-aaacadadadajaXabadabadabaXcNadbdcmcmbhbicHbibibkcbbmbmaaaaaa
-aaacabababbgajcocKcKcKbjcKcQadabababcEaHcIcecfcgbaaaaaaaaaaa
-aaacababababadababadababadadbgabababcEccchaTcjckclaaaaaaaaaa
-aaacababababadababadababadabababababcEaJcncMcpcqcraaaaaaaaaa
-aaacababababadababadababadababaBafafaCciaEafafafafaaaaaaaaaa
-aaacabababcJcLajajajajajcLajadakctcucvcwcxafaaaaaaaaaaaaaaaa
-aaacabadajajcyalalalalalczalalcAafcBafafafafaaaaaaaaaaaaaaaa
-aaacadadcCcCcCcCcCcCcCcCcCcCcCcCafafaCaaaaaaaaaaaaaaaaaaaaaa
-aaacababababababababaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(2,1,1) = {"
+aa
+aa
+ab
+ac
+ac
+ac
+ad
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+aa
+"}
+(3,1,1) = {"
+aa
+aa
+ab
+ac
+ab
+ab
+ab
+ac
+ab
+ab
+ab
+ab
+ab
+ab
+ad
+ab
+ab
+ab
+ab
+ab
+ad
+ab
+ab
+ab
+ab
+ab
+ab
+ad
+ab
+aa
+"}
+(4,1,1) = {"
+aa
+aa
+ab
+ac
+ab
+ab
+ab
+ac
+ab
+ab
+ab
+ab
+ab
+ab
+ad
+ab
+ab
+ab
+ab
+ab
+ad
+ab
+ab
+ab
+ab
+ab
+ad
+ad
+ab
+aa
+"}
+(5,1,1) = {"
+aa
+aa
+ab
+ac
+ab
+ab
+ab
+ac
+aj
+ab
+ab
+ab
+aI
+ab
+ad
+ab
+ab
+ab
+ab
+ab
+ad
+ab
+ab
+ab
+ab
+ab
+aj
+cC
+ab
+aa
+"}
+(6,1,1) = {"
+aa
+aa
+ab
+ac
+ab
+ab
+ab
+ac
+aj
+aj
+ab
+ab
+ab
+bg
+aj
+aj
+aj
+aj
+aj
+aj
+aj
+bg
+ab
+ab
+ab
+cJ
+aj
+cC
+ab
+aa
+"}
+(7,1,1) = {"
+aa
+aa
+ab
+ad
+ab
+ab
+ab
+ac
+ak
+ar
+ad
+ad
+ad
+aj
+aX
+ab
+ad
+ab
+ad
+ab
+aX
+aj
+ad
+ad
+ad
+cL
+cy
+cC
+ab
+aa
+"}
+(8,1,1) = {"
+aa
+aa
+ab
+ac
+ab
+ab
+ab
+ac
+al
+aj
+ab
+ab
+ab
+co
+ab
+ab
+ad
+ab
+ad
+ab
+ab
+co
+ab
+ab
+ab
+aj
+al
+cC
+ab
+aa
+"}
+(9,1,1) = {"
+aa
+aa
+ab
+ac
+ab
+ab
+ab
+ac
+al
+aj
+ab
+ab
+ab
+cK
+ad
+ad
+cs
+aj
+aj
+ad
+ad
+cK
+ab
+ab
+ab
+aj
+al
+cC
+ab
+aa
+"}
+(10,1,1) = {"
+aa
+aa
+ab
+ac
+ab
+ab
+ab
+ac
+al
+aj
+ad
+ad
+ad
+cK
+ab
+ab
+aj
+bE
+aj
+ab
+ab
+cK
+ad
+ad
+ad
+aj
+al
+cC
+ab
+aa
+"}
+(11,1,1) = {"
+aa
+aa
+ab
+ac
+ab
+ab
+ab
+ac
+al
+aj
+ab
+ab
+ab
+cK
+ad
+ad
+aj
+aj
+aj
+ad
+ad
+cK
+ab
+ab
+ab
+aj
+al
+cC
+aa
+aa
+"}
+(12,1,1) = {"
+aa
+aa
+ab
+ac
+ab
+ab
+ab
+ac
+al
+aj
+ab
+ab
+ab
+bj
+ab
+ab
+ad
+ab
+ad
+ab
+ab
+bj
+ab
+ab
+ab
+aj
+al
+cC
+aa
+aa
+"}
+(13,1,1) = {"
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+ac
+am
+ar
+ad
+ad
+ad
+cK
+aX
+ab
+ad
+ab
+ad
+ab
+aX
+cK
+ad
+ad
+ad
+cL
+cz
+cC
+aa
+aa
+"}
+(14,1,1) = {"
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+ac
+al
+aj
+ab
+ab
+ad
+bp
+cN
+bZ
+cN
+aP
+cN
+cF
+cN
+cQ
+ad
+ab
+ab
+aj
+al
+cC
+aa
+aa
+"}
+(15,1,1) = {"
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+ac
+al
+ad
+ab
+ab
+bg
+ad
+ad
+ad
+ad
+cK
+ad
+ad
+ad
+ad
+bg
+ab
+ab
+ad
+al
+cC
+aa
+aa
+"}
+(16,1,1) = {"
+aa
+aa
+ab
+ac
+ab
+ab
+ab
+ac
+an
+as
+aB
+ab
+ab
+ab
+aY
+bn
+bn
+bF
+bn
+bn
+bd
+ab
+ab
+ab
+aB
+ak
+cA
+cC
+aa
+aa
+"}
+(17,1,1) = {"
+aa
+aa
+ab
+ac
+ab
+ab
+ab
+af
+af
+at
+af
+ab
+ab
+ab
+bP
+bo
+bw
+bQ
+bW
+bX
+cm
+ab
+ab
+ab
+af
+ct
+af
+af
+aa
+aa
+"}
+(18,1,1) = {"
+aa
+aa
+ab
+ac
+ab
+ab
+ab
+af
+ao
+au
+af
+ab
+ab
+ab
+bP
+bf
+bx
+bG
+bR
+ca
+cm
+ab
+ab
+ab
+af
+cu
+cB
+af
+aa
+aa
+"}
+(19,1,1) = {"
+aa
+aa
+ab
+ac
+ab
+ab
+ab
+af
+af
+av
+aC
+cE
+cE
+cE
+bh
+bq
+by
+bH
+bS
+ca
+bh
+cE
+cE
+cE
+aC
+cv
+af
+aC
+aa
+aa
+"}
+(20,1,1) = {"
+aa
+aa
+ab
+ac
+ab
+ab
+ab
+ab
+af
+aw
+aD
+aJ
+aQ
+aG
+bi
+br
+bz
+bI
+bT
+cd
+bi
+aH
+cc
+aJ
+ci
+cw
+af
+aa
+aa
+aa
+"}
+(21,1,1) = {"
+aa
+aa
+ab
+ac
+ab
+ab
+ab
+ab
+af
+ax
+aE
+aK
+aR
+ba
+bA
+bs
+cD
+bJ
+bU
+cG
+cH
+cI
+ch
+cn
+aE
+cx
+af
+aa
+aa
+aa
+"}
+(22,1,1) = {"
+aa
+aa
+ab
+ad
+ab
+ab
+ae
+ae
+ae
+ae
+ae
+aL
+aS
+bb
+bi
+bt
+bB
+bK
+bV
+bY
+bi
+ce
+aT
+cM
+af
+af
+af
+aa
+aa
+aa
+"}
+(23,1,1) = {"
+aa
+aa
+ab
+ac
+ab
+ab
+ae
+ag
+ag
+ay
+ae
+aM
+aU
+bc
+bi
+bi
+bC
+bL
+bC
+bi
+bi
+cf
+cj
+cp
+af
+aa
+aa
+aa
+aa
+aa
+"}
+(24,1,1) = {"
+aa
+aa
+ab
+ac
+ab
+ab
+ae
+ah
+ap
+az
+aF
+aN
+aV
+aZ
+bk
+bk
+bD
+bM
+bD
+bk
+bk
+cg
+ck
+cq
+af
+aa
+aa
+aa
+aa
+aa
+"}
+(25,1,1) = {"
+aa
+aa
+ab
+ac
+ab
+ab
+ae
+ai
+aq
+aA
+ae
+aO
+aW
+be
+bl
+aE
+aE
+bN
+aE
+aE
+cb
+ba
+cl
+cr
+af
+aa
+aa
+aa
+aa
+aa
+"}
+(26,1,1) = {"
+aa
+aa
+ab
+ac
+ab
+ab
+ae
+ae
+ae
+aa
+aa
+aa
+aa
+aa
+bm
+aa
+aa
+aa
+aa
+aa
+bm
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(27,1,1) = {"
+aa
+aa
+ab
+ac
+ab
+ab
+ab
+ab
+ab
+aa
+aa
+aa
+aa
+aa
+bm
+bu
+aa
+aa
+aa
+aa
+bm
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(28,1,1) = {"
+aa
+aa
+ab
+ac
+ab
+ab
+ab
+ab
+ab
+aa
+aa
+aa
+aa
+aa
+aa
+bv
+aa
+bO
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(29,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(30,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 "}


### PR DESCRIPTION
Adjusts area of gas storage being one tile taller than storage is

Replaces camera in the gas storage to be on Engine subgrid rather than Engineering


Runs mapmerge on all four engine submaps since it wasn't for some reason