### PR TITLE
Fixes slime miss chance

### DIFF
--- a/code/modules/mob/living/simple_mob/subtypes/slime/feral/feral_vr.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/slime/feral/feral_vr.dm
@@ -1,0 +1,2 @@
+/mob/living/simple_mob/slime/feral/dark_blue
+	base_attack_cooldown = 3 SECONDS

--- a/code/modules/mob/living/simple_mob/subtypes/slime/slime.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/slime/slime.dm
@@ -164,8 +164,16 @@
 		give_hat(I, user)
 		return
 
+	//VOREStation Edit Start
+	var/can_miss = TRUE
+	for(var/item_type in allowed_attack_types)
+		if(istype(I, item_type))
+			can_miss = FALSE
+			break
+	//VOREStation Edit End
+
 	// Otherwise they're probably fighting the slime.
-	if(prob(25))
+	if(prob(25) && can_miss)	//VOREStation Edit
 		visible_message(span("warning", "\The [user]'s [I] passes right through \the [src]!"))
 		user.setClickCooldown(user.get_attack_speed(I))
 		return

--- a/code/modules/mob/living/simple_mob/subtypes/slime/slime_vr.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/slime/slime_vr.dm
@@ -1,2 +1,5 @@
 /mob/living/simple_mob/slime
 	base_attack_cooldown = 2 SECONDS
+	var/allowed_attack_types = list(
+							/obj/item/weapon/melee/baton/slime,
+							/obj/item/slimepotion)

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -2499,6 +2499,7 @@
 #include "code\modules\mob\living\simple_mob\subtypes\slime\slime.dm"
 #include "code\modules\mob\living\simple_mob\subtypes\slime\slime_vr.dm"
 #include "code\modules\mob\living\simple_mob\subtypes\slime\feral\feral.dm"
+#include "code\modules\mob\living\simple_mob\subtypes\slime\feral\feral_vr.dm"
 #include "code\modules\mob\living\simple_mob\subtypes\slime\xenobio\combat.dm"
 #include "code\modules\mob\living\simple_mob\subtypes\slime\xenobio\consumption.dm"
 #include "code\modules\mob\living\simple_mob\subtypes\slime\xenobio\defense.dm"


### PR DESCRIPTION
Slime baton and slime potions are no longer subject to hardcoded 25% melee weapon evasion chance slimes have

Also nerfs feral blue slimes' attack speed, was missed when nerfing other mobs