### PR TITLE
Fixes soulcatcher gender runtime spam

### DIFF
--- a/code/modules/nifsoft/software/13_soulcatcher.dm
+++ b/code/modules/nifsoft/software/13_soulcatcher.dm
@@ -270,10 +270,12 @@
 
 	var/obj/item/device/nif/nif
 	var/datum/nifsoft/soulcatcher/soulcatcher
+	var/identifying_gender
 
 /mob/living/carbon/brain/caught_soul/Login()
 	..()
 	plane_holder.set_vis(VIS_AUGMENTED, TRUE)
+	identifying_gender = client.prefs.identifying_gender
 
 /mob/living/carbon/brain/caught_soul/Destroy()
 	if(soulcatcher)


### PR DESCRIPTION
Soulcatchers were trying to periodically backup the caught mind but stumbling into runtimes because the mind backups were relying on humanmob exclusive gender var that the brainmobs did not have.