### PR TITLE
Mapfixes: Cafeteria, Medbay toilet, Mirrors, Walls, Virology.

### DIFF
--- a/maps/tether/tether-01-surface1.dmm
+++ b/maps/tether/tether-01-surface1.dmm
@@ -6870,6 +6870,7 @@
 	icon_state = "0-2"
 	},
 /obj/effect/floor_decal/industrial/warning,
+/obj/random/drinkbottle,
 /turf/simulated/floor,
 /area/maintenance/substation/mining)
 "alT" = (
@@ -6897,9 +6898,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
-	},
-/obj/machinery/alarm{
-	pixel_y = 22
 	},
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor,
@@ -23106,6 +23104,7 @@
 	pixel_x = 0;
 	pixel_y = 26
 	},
+/obj/random/drinkbottle,
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_8)
 "aLT" = (
@@ -23944,8 +23943,8 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_8)
 "aNr" = (
-/obj/item/weapon/bedsheet/double,
 /obj/structure/bed/double/padded,
+/obj/item/weapon/bedsheet/bluedouble,
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_8)
 "aNs" = (
@@ -24443,6 +24442,7 @@
 	pixel_x = 0;
 	pixel_y = 26
 	},
+/obj/random/carp_plushie,
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_6)
 "aOr" = (
@@ -24985,8 +24985,8 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_6)
 "aPh" = (
-/obj/item/weapon/bedsheet/double,
 /obj/structure/bed/double/padded,
+/obj/item/weapon/bedsheet/reddouble,
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_6)
 "aPi" = (
@@ -25748,9 +25748,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/atmos)
-"aQE" = (
-/turf/simulated/wall/r_wall,
-/area/crew_quarters/sleep/Dorm_3)
 "aQF" = (
 /obj/machinery/light{
 	dir = 8
@@ -26194,8 +26191,8 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_4)
 "aRq" = (
-/obj/item/weapon/bedsheet/double,
 /obj/structure/bed/double/padded,
+/obj/item/weapon/bedsheet/yellowdouble,
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_4)
 "aRr" = (
@@ -26701,6 +26698,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/random/action_figure,
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_2)
 "aSr" = (
@@ -27328,8 +27326,8 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_2)
 "aTF" = (
-/obj/item/weapon/bedsheet/double,
 /obj/structure/bed/double/padded,
+/obj/item/weapon/bedsheet/orangedouble,
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/Dorm_2)
 "aTG" = (
@@ -30873,6 +30871,29 @@
 /obj/effect/step_trigger/teleporter/to_plains,
 /turf/simulated/floor/tiled/steel_dirty/virgo3b,
 /area/tether/surfacebase/outside/outside1)
+"cGJ" = (
+/turf/simulated/floor/plating,
+/area/maintenance/lower/mining_eva)
+"guV" = (
+/obj/structure/closet,
+/obj/random/drinkbottle,
+/obj/random/maintenance/cargo,
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/lower/vacant_site)
+"obY" = (
+/obj/machinery/alarm{
+	pixel_y = 22
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/substation/mining)
+"vNx" = (
+/turf/simulated/floor/plating,
+/area/maintenance/substation/mining)
+"yiv" = (
+/obj/structure/closet/crate,
+/obj/random/maintenance/cargo,
+/turf/simulated/floor/plating,
+/area/maintenance/substation/mining)
 
 (1,1,1) = {"
 aaa
@@ -33923,7 +33944,7 @@ aah
 aah
 aah
 aah
-azs
+auK
 auK
 auK
 auK
@@ -34065,7 +34086,7 @@ aah
 aah
 aah
 aah
-azs
+auK
 aAs
 aBu
 aCc
@@ -34207,7 +34228,7 @@ aah
 aah
 aah
 aah
-azs
+auK
 aAt
 aBv
 aBv
@@ -34349,7 +34370,7 @@ aah
 aah
 aah
 aah
-azs
+auK
 aAu
 aBv
 aah
@@ -34491,7 +34512,7 @@ aah
 aah
 aah
 aah
-azs
+auK
 aAu
 aBv
 aah
@@ -34633,7 +34654,7 @@ aah
 aah
 aah
 aah
-azs
+auK
 abB
 aBv
 aah
@@ -34775,7 +34796,7 @@ aah
 aah
 aah
 aah
-azs
+auK
 aAu
 aBv
 aah
@@ -34917,7 +34938,7 @@ aah
 aah
 aah
 aah
-azs
+auK
 aAv
 aBv
 aah
@@ -40990,7 +41011,7 @@ abT
 abT
 abT
 abT
-abT
+aex
 aex
 aex
 aex
@@ -41128,12 +41149,12 @@ aah
 aah
 aah
 abT
-abT
+cGJ
 acS
 acS
 adp
-abT
 aex
+yiv
 alS
 amn
 afX
@@ -41274,8 +41295,8 @@ acj
 acX
 acX
 adL
-abT
 aex
+vNx
 alT
 amo
 amI
@@ -41416,8 +41437,8 @@ acQ
 adl
 ado
 adM
-abT
 aex
+obY
 alU
 amp
 amJ
@@ -41558,7 +41579,7 @@ abn
 abn
 abT
 adN
-abT
+aex
 alC
 alV
 aex
@@ -43889,7 +43910,7 @@ aOj
 aOj
 aOj
 aQb
-aQE
+aQb
 aQb
 aQb
 aSi
@@ -44838,7 +44859,7 @@ anI
 aob
 aom
 ahx
-apF
+guV
 apF
 ahc
 apF

--- a/maps/tether/tether-02-surface2.dmm
+++ b/maps/tether/tether-02-surface2.dmm
@@ -23233,6 +23233,11 @@
 	dir = 9
 	},
 /obj/machinery/light/small,
+/obj/structure/mirror{
+	dir = 4;
+	pixel_x = 25;
+	pixel_y = 0
+	},
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/medical/resleeving)
 "Rh" = (
@@ -27401,6 +27406,23 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/lowerhallway)
+"XK" = (
+/turf/simulated/wall{
+	can_open = 1
+	},
+/area/maintenance/lower/bar)
+"Za" = (
+/turf/simulated/wall{
+	can_open = 0
+	},
+/area/maintenance/lower/bar)
+"Zt" = (
+/obj/structure/closet/crate,
+/obj/random/cash,
+/obj/random/contraband,
+/obj/random/drinkbottle,
+/turf/simulated/floor/plating,
+/area/maintenance/lower/mining)
 
 (1,1,1) = {"
 aa
@@ -41927,7 +41949,7 @@ dJ
 df
 ad
 Th
-Th
+Zt
 ny
 ny
 dY
@@ -42212,8 +42234,8 @@ ec
 du
 du
 du
-du
-du
+Za
+XK
 du
 du
 du

--- a/maps/tether/tether-03-surface3.dmm
+++ b/maps/tether/tether-03-surface3.dmm
@@ -5024,7 +5024,11 @@
 	dir = 8;
 	icon_state = "sink";
 	pixel_x = -12;
-	pixel_y = 8
+	pixel_y = 0
+	},
+/obj/structure/mirror{
+	pixel_x = -25;
+	pixel_y = 0
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/recreation_area_restroom)

--- a/maps/tether/tether-05-station1.dmm
+++ b/maps/tether/tether-05-station1.dmm
@@ -1316,10 +1316,6 @@
 	},
 /turf/simulated/floor/water/pool,
 /area/hallway/station/atrium)
-"acD" = (
-/obj/structure/table/woodentable,
-/turf/simulated/floor/wood,
-/area/hallway/station/atrium)
 "acE" = (
 /obj/structure/table/woodentable,
 /obj/machinery/door/blast/shutters{
@@ -1479,12 +1475,9 @@
 /turf/simulated/floor/water/pool,
 /area/hallway/station/atrium)
 "ada" = (
-/obj/structure/table/wooden_reinforced,
-/turf/simulated/floor/grass,
-/area/hallway/station/atrium)
-"adb" = (
-/obj/structure/bed/chair/wood{
-	dir = 1
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
 	},
 /turf/simulated/floor/grass,
 /area/hallway/station/atrium)
@@ -1740,10 +1733,12 @@
 	layer = 3.1;
 	name = "Cafe Shutters"
 	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/station/atrium)
 "ady" = (
-/obj/structure/table/marble,
 /obj/machinery/floor_light/prebuilt{
 	on = 1
 	},
@@ -1752,6 +1747,13 @@
 	id = "cafe2";
 	layer = 3.1;
 	name = "Cafe Shutters"
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
 	},
 /turf/simulated/floor/wood,
 /area/hallway/station/atrium)
@@ -3611,6 +3613,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/borderfloor/corner{
 	dir = 8
 	},
@@ -3632,6 +3635,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/hallway/station/atrium)
 "agq" = (
@@ -6986,20 +6990,11 @@
 /obj/item/weapon/reagent_containers/food/snacks/donut/jelly,
 /turf/simulated/floor/wood,
 /area/hallway/station/atrium)
-"amz" = (
-/obj/structure/table/woodentable,
-/obj/item/weapon/reagent_containers/food/snacks/donut/chaos,
-/turf/simulated/floor/wood,
-/area/hallway/station/atrium)
 "amA" = (
 /obj/structure/table/wooden_reinforced,
 /obj/item/weapon/reagent_containers/food/snacks/donut/cherryjelly,
-/turf/simulated/floor/grass,
-/area/hallway/station/atrium)
-"amB" = (
 /obj/structure/table/woodentable,
-/obj/item/weapon/reagent_containers/food/condiment/small/sugar,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/grass,
 /area/hallway/station/atrium)
 "amC" = (
 /obj/structure/table/woodentable,
@@ -7034,6 +7029,8 @@
 	layer = 3.1;
 	name = "Cafe Shutters"
 	},
+/obj/structure/table/woodentable,
+/obj/item/weapon/reagent_containers/food/condiment/small/sugar,
 /turf/simulated/floor/wood,
 /area/hallway/station/atrium)
 "amG" = (
@@ -13804,7 +13801,7 @@
 "aGx" = (
 /obj/structure/mirror{
 	dir = 4;
-	pixel_x = 32;
+	pixel_x = 28;
 	pixel_y = 0
 	},
 /obj/structure/sink{
@@ -14204,7 +14201,7 @@
 	},
 /obj/structure/mirror{
 	dir = 4;
-	pixel_x = 32;
+	pixel_x = 28;
 	pixel_y = 0
 	},
 /obj/structure/sink{
@@ -19600,7 +19597,7 @@
 	},
 /obj/structure/mirror{
 	dir = 4;
-	pixel_x = 32;
+	pixel_x = 28;
 	pixel_y = 0
 	},
 /turf/simulated/floor/tiled/white,
@@ -19920,7 +19917,7 @@
 	},
 /obj/structure/mirror{
 	dir = 4;
-	pixel_x = 32;
+	pixel_x = 28;
 	pixel_y = 0
 	},
 /turf/simulated/floor/tiled/white,
@@ -21526,6 +21523,16 @@
 	},
 /turf/simulated/floor/tiled,
 /area/teleporter)
+"bNZ" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 1;
+	icon_state = "pipe-j2"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/atrium)
 "bPc" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -22564,6 +22571,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/tether/station/dock_one)
+"mbn" = (
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/structure/disposalpipe/sortjunction{
+	dir = 4;
+	icon_state = "pipe-j1s";
+	name = "Library";
+	sortType = "Library"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/atrium)
 "mNU" = (
 /obj/machinery/door/firedoor/glass,
 /obj/structure/grille,
@@ -22591,6 +22608,13 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled,
 /area/hallway/station/docks)
+"qBc" = (
+/obj/structure/disposalpipe/junction{
+	dir = 1;
+	icon_state = "pipe-j2"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/atrium)
 "scB" = (
 /obj/machinery/computer/shuttle_control/tether_backup{
 	icon_state = "computer";
@@ -22626,6 +22650,11 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/tether/station/dock_one)
+"uiN" = (
+/obj/structure/table/woodentable,
+/obj/item/weapon/reagent_containers/food/snacks/donut/chaos,
+/turf/simulated/floor/grass,
+/area/hallway/station/atrium)
 "uWS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
@@ -22661,6 +22690,13 @@
 /obj/structure/window/reinforced/full,
 /turf/simulated/floor/plating,
 /area/tether/station/dock_one)
+"xfY" = (
+/obj/structure/disposalpipe/junction{
+	dir = 8;
+	icon_state = "pipe-j2"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/atrium)
 "xMk" = (
 /obj/structure/cable/green{
 	icon_state = "16-0"
@@ -33246,7 +33282,7 @@ acm
 acy
 acy
 amA
-ada
+adl
 acy
 acy
 acm
@@ -33670,13 +33706,13 @@ afW
 agB
 acp
 acF
-acD
 acI
 acI
 acI
 acI
-amz
-acU
+acI
+acI
+acH
 acH
 acG
 acy
@@ -34102,7 +34138,7 @@ ama
 amG
 acH
 amF
-amB
+acU
 acH
 acm
 acm
@@ -34236,15 +34272,15 @@ ags
 aiE
 afa
 afg
-acp
-acm
+xfY
+adH
 ady
 aga
 amy
 adM
 acH
 amF
-amB
+acU
 acH
 acm
 acm
@@ -34532,7 +34568,7 @@ acU
 acH
 acF
 acy
-adl
+uiN
 adl
 acy
 acp
@@ -34664,13 +34700,13 @@ afC
 ajs
 acp
 acF
-acD
 acK
 acK
 acK
 acK
-amz
-acU
+acK
+acK
+acH
 acH
 acG
 acy
@@ -35089,10 +35125,10 @@ ala
 alg
 ald
 acr
-acY
 acy
-ada
-ada
+acy
+uiN
+adl
 acy
 acy
 acm
@@ -35232,7 +35268,7 @@ afC
 aju
 act
 ada
-adb
+acy
 adc
 adc
 acy
@@ -35245,7 +35281,7 @@ acy
 acy
 acy
 acy
-ahH
+mbn
 ago
 alM
 amL
@@ -35373,7 +35409,7 @@ akQ
 afC
 aAL
 aCx
-acW
+bNZ
 adH
 adH
 adH
@@ -35387,7 +35423,7 @@ adH
 adH
 adH
 acW
-bay
+qBc
 agp
 aeP
 acm

--- a/maps/tether/tether-06-station2.dmm
+++ b/maps/tether/tether-06-station2.dmm
@@ -15240,11 +15240,11 @@
 /turf/simulated/floor/wood,
 /area/bridge/meeting_room)
 "wT" = (
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk,
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk,
 /turf/simulated/floor/wood,
 /area/bridge/meeting_room)
 "wU" = (
@@ -19212,7 +19212,7 @@
 	},
 /obj/structure/mirror{
 	dir = 4;
-	pixel_x = 32;
+	pixel_x = 28;
 	pixel_y = 0
 	},
 /turf/simulated/floor/tiled/white,
@@ -20200,7 +20200,7 @@
 	},
 /obj/structure/mirror{
 	dir = 4;
-	pixel_x = 32;
+	pixel_x = 28;
 	pixel_y = 0
 	},
 /obj/machinery/power/apc{
@@ -22454,6 +22454,12 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/maintenance/station/sec_lower)
+"Xd" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/bridge/meeting_room)
 "Xk" = (
 /obj/structure/table/steel,
 /obj/item/device/flashlight/lamp{
@@ -36018,7 +36024,7 @@ yP
 xN
 yU
 wo
-ac
+wo
 ac
 ac
 ac
@@ -36578,14 +36584,14 @@ pB
 qg
 vK
 wo
+Xd
 wV
 wV
 wV
 wV
 wV
 wV
-wV
-wV
+yU
 wo
 aP
 aP
@@ -37001,8 +37007,8 @@ qc
 qc
 uj
 uJ
+qc
 vl
-oY
 oY
 aP
 aP
@@ -37143,8 +37149,8 @@ sU
 tE
 uk
 uK
+qc
 vl
-oY
 oY
 aa
 aa
@@ -37287,7 +37293,7 @@ oY
 uL
 oY
 oY
-aa
+oY
 aa
 aa
 aa

--- a/maps/tether/tether-07-station3.dmm
+++ b/maps/tether/tether-07-station3.dmm
@@ -21450,16 +21450,8 @@
 /turf/simulated/floor,
 /area/maintenance/station/cargo)
 "Hf" = (
-/obj/structure/table/standard,
-/obj/random/soap,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/machinery/light_switch{
-	dir = 8;
-	pixel_x = 24
-	},
-/turf/simulated/floor/tiled/white,
+/obj/machinery/recharge_station,
+/turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/medical_restroom)
 "Hg" = (
 /obj/machinery/firealarm{
@@ -22936,15 +22928,7 @@
 	pixel_x = -27;
 	pixel_y = 0
 	},
-/obj/machinery/camera/network/medbay{
-	dir = 1
-	},
-/obj/effect/floor_decal/spline/plain{
-	dir = 4
-	},
-/obj/machinery/light_switch{
-	pixel_y = -25
-	},
+/obj/effect/floor_decal/corner/paleblue/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/medbreak)
 "Jn" = (
@@ -23889,28 +23873,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/station/cargo)
-"KS" = (
-/obj/machinery/recharge_station,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/crew_quarters/medical_restroom)
-"KT" = (
-/obj/machinery/door/airlock/medical{
-	name = "Rest Room"
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/crew_quarters/medical_restroom)
-"KU" = (
-/obj/machinery/alarm{
-	pixel_y = 22
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/medical_restroom)
 "KV" = (
 /obj/structure/undies_wardrobe,
 /turf/simulated/floor/tiled/white,
@@ -23925,9 +23887,6 @@
 	},
 /obj/item/weapon/book/manual/stasis,
 /obj/item/weapon/book/manual/resleeving,
-/obj/effect/floor_decal/spline/plain{
-	dir = 4
-	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/medbreak)
 "KY" = (
@@ -23959,11 +23918,6 @@
 "La" = (
 /obj/machinery/washing_machine,
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/effect/floor_decal/corner/paleblue/diagonal,
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/medbreak)
-"Lb" = (
-/obj/structure/reagent_dispensers/water_cooler/full,
 /obj/effect/floor_decal/corner/paleblue/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/medbreak)
@@ -24120,15 +24074,14 @@
 /area/medical/sleeper)
 "Lr" = (
 /obj/machinery/vending/fitness,
-/obj/effect/floor_decal/spline/plain{
-	dir = 4
-	},
+/obj/effect/floor_decal/spline/plain,
 /obj/machinery/status_display{
 	density = 0;
 	layer = 4;
 	pixel_x = -32;
 	pixel_y = 0
 	},
+/obj/effect/floor_decal/corner/paleblue/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/medbreak)
 "Ls" = (
@@ -24199,26 +24152,13 @@
 /obj/random/maintenance/cargo,
 /turf/simulated/floor/plating,
 /area/maintenance/station/cargo)
-"LA" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24;
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/medical_restroom)
 "LB" = (
 /obj/structure/sign/nosmoking_1,
 /turf/simulated/wall/r_wall,
 /area/medical/chemistry)
 "LC" = (
 /obj/machinery/vending/snack,
-/obj/effect/floor_decal/spline/plain{
-	dir = 4
-	},
+/obj/effect/floor_decal/corner/paleblue/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/medbreak)
 "LD" = (
@@ -24530,38 +24470,20 @@
 /obj/random/maintenance/cargo,
 /turf/simulated/floor/plating,
 /area/maintenance/station/cargo)
-"Mc" = (
-/obj/structure/toilet{
-	dir = 4
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/medical_restroom)
 "Md" = (
 /obj/machinery/door/airlock/medical{
 	name = "Rest Room"
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/medical_restroom)
-"Me" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/medical_restroom)
 "Mf" = (
-/obj/structure/table/standard,
-/obj/random/soap,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
+/obj/machinery/light/small{
 	dir = 8
 	},
-/obj/machinery/light{
-	dir = 4
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/medical_restroom)
 "Mg" = (
 /obj/structure/shuttle/engine/propulsion{
@@ -24606,7 +24528,6 @@
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/medbreak)
 "Mj" = (
-/obj/structure/bed/chair,
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -24617,13 +24538,9 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/effect/floor_decal/corner/paleblue/diagonal,
-/obj/effect/landmark/start{
-	name = "Medical Doctor"
-	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/medbreak)
 "Mk" = (
-/obj/structure/bed/chair,
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -24637,9 +24554,6 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/paleblue/diagonal,
-/obj/effect/landmark/start{
-	name = "Medical Doctor"
-	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/medbreak)
 "Ml" = (
@@ -24906,43 +24820,18 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/hallway/secondary/escape/medical_escape_pod_hallway)
-"Mz" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -28
-	},
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/medical_restroom)
-"MA" = (
-/obj/structure/sink{
-	dir = 4;
-	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
-	},
-/obj/structure/mirror{
-	dir = 4;
-	pixel_x = 32;
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/medical_restroom)
 "MB" = (
-/obj/machinery/vending/cola,
 /obj/machinery/light{
 	dir = 8;
 	icon_state = "tube1"
 	},
-/obj/effect/floor_decal/spline/plain{
-	dir = 4
+/obj/machinery/light_switch{
+	dir = 4;
+	icon_state = "light1";
+	pixel_x = -24
 	},
+/obj/structure/reagent_dispensers/water_cooler/full,
+/obj/effect/floor_decal/corner/paleblue/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/medbreak)
 "MC" = (
@@ -24954,16 +24843,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/corner/paleblue/diagonal,
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/medbreak)
-"MD" = (
-/obj/structure/bed/chair{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/paleblue/diagonal,
-/obj/effect/landmark/start{
-	name = "Medical Doctor"
-	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/medbreak)
 "ME" = (
@@ -25041,50 +24920,35 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/hallway/secondary/escape/medical_escape_pod_hallway)
-"MN" = (
-/obj/structure/curtain/open/shower,
-/obj/machinery/shower{
-	pixel_y = 10
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals5,
-/obj/effect/floor_decal/steeldecal/steel_decals5{
-	dir = 1
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals10{
-	dir = 5
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals10{
+"MO" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/medical_restroom)
-"MO" = (
-/obj/machinery/light{
-	dir = 4
+/obj/machinery/alarm{
+	pixel_y = 22
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/medical_restroom)
 "MP" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+	dir = 4
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_x = 0;
+	pixel_y = 28
+	},
+/obj/structure/cable/green{
+	icon_state = "0-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	icon_state = "intact-scrubbers";
-	dir = 5
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/medical_restroom)
 "MQ" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -25092,9 +24956,10 @@
 	icon_state = "intact-scrubbers";
 	dir = 4
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals4,
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 10
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/medical_restroom)
@@ -25115,6 +24980,15 @@
 	icon_state = "intact-scrubbers";
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	icon_state = "intact-scrubbers";
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/medbreak)
 "MS" = (
@@ -25130,15 +25004,13 @@
 	icon_state = "intact-scrubbers";
 	dir = 4
 	},
-/obj/effect/floor_decal/spline/plain{
-	dir = 4
-	},
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 6
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 1
 	},
+/obj/effect/floor_decal/corner/paleblue/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/medbreak)
 "MT" = (
@@ -25230,18 +25102,23 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
 "Nc" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 8
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	icon_state = "intact-scrubbers";
+	dir = 5
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
@@ -25250,12 +25127,18 @@
 /obj/effect/floor_decal/corner/paleblue/border,
 /obj/effect/floor_decal/borderfloorwhite/corner2,
 /obj/effect/floor_decal/corner/paleblue/bordercorner2,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/structure/cable/green{
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
 "Ne" = (
-/obj/structure/bed/chair{
-	dir = 1
-	},
 /obj/machinery/camera/network/medbay{
 	dir = 1
 	},
@@ -25287,6 +25170,9 @@
 	},
 /obj/effect/floor_decal/borderfloorwhite,
 /obj/effect/floor_decal/corner/paleblue/border,
+/obj/structure/bed/chair{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
 "Ni" = (
@@ -25335,42 +25221,17 @@
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/medical_restroom)
 "Nm" = (
-/obj/machinery/alarm{
-	dir = 1;
-	icon_state = "alarm0";
-	pixel_y = -22
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 10
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4,
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/medical_restroom)
-"Nn" = (
-/obj/effect/floor_decal/steeldecal/steel_decals4{
+/obj/structure/table/standard,
+/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 6
-	},
+/obj/machinery/light/small,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/medical_restroom)
 "No" = (
 /obj/structure/table/standard,
 /obj/item/weapon/storage/box/cups,
-/obj/effect/floor_decal/spline/plain{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/medbreak)
-"Np" = (
-/obj/structure/bed/chair{
-	dir = 1
-	},
 /obj/effect/floor_decal/corner/paleblue/diagonal,
-/obj/effect/landmark/start{
-	name = "Paramedic"
-	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/medbreak)
 "Nq" = (
@@ -25466,13 +25327,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ai_core_foyer)
-"Nx" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/structure/window/reinforced,
-/obj/machinery/door/firedoor/glass,
-/turf/simulated/floor/plating,
-/area/crew_quarters/medical_restroom)
 "Ny" = (
 /obj/structure/table/standard,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -25487,26 +25341,18 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
 "Nz" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
 /obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/medbreak)
 "NA" = (
-/obj/machinery/disposal,
 /obj/item/device/radio/intercom{
 	dir = 4;
 	pixel_x = 24
 	},
-/obj/item/device/radio/intercom/department/medbay{
-	pixel_y = -24
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
 /obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/structure/table/standard,
+/obj/item/weapon/storage/mre/random,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/medbreak)
 "NB" = (
@@ -25604,11 +25450,9 @@
 /turf/simulated/floor/tiled/white,
 /area/hallway/secondary/escape/medical_escape_pod_hallway)
 "NH" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/structure/window/reinforced,
-/obj/machinery/door/firedoor/glass,
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/turf/simulated/floor/tiled/white,
 /area/crew_quarters/medbreak)
 "NI" = (
 /obj/structure/shuttle/engine/propulsion{
@@ -26173,6 +26017,18 @@
 /obj/structure/closet/walllocker/emerglocker/south,
 /turf/simulated/shuttle/floor,
 /area/shuttle/large_escape_pod1/station)
+"OP" = (
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/item/device/radio/intercom/department/medbay{
+	dir = 4;
+	pixel_x = 24
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/machinery/disposal,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/medbreak)
 "OQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9;
@@ -26783,6 +26639,29 @@
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
 /area/medical/virologyisolation)
+"Qf" = (
+/obj/structure/toilet{
+	pixel_y = 15
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/medical_restroom)
+"Qr" = (
+/obj/machinery/shower{
+	pixel_y = 10
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals5,
+/obj/effect/floor_decal/steeldecal/steel_decals5{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 5
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 6
+	},
+/obj/structure/curtain/open/shower,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/medical_restroom)
 "Qt" = (
 /turf/simulated/wall,
 /area/tether/exploration)
@@ -26795,10 +26674,27 @@
 	},
 /turf/simulated/floor/bluegrid,
 /area/ai_core_foyer)
+"Qx" = (
+/obj/machinery/light/small{
+	icon_state = "bulb1";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/medical_restroom)
 "Qz" = (
 /obj/structure/railing,
 /turf/simulated/floor,
 /area/maintenance/cargo)
+"QE" = (
+/obj/effect/landmark/start{
+	name = "Medical Doctor"
+	},
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/medbreak)
 "QI" = (
 /obj/structure/cable/cyan{
 	icon_state = "32-1"
@@ -27855,6 +27751,15 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/security/security_bathroom)
+"Tb" = (
+/obj/structure/window/reinforced{
+	dir = 8;
+	health = 1e+006
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/turf/simulated/floor/plating,
+/area/crew_quarters/medical_restroom)
 "Tc" = (
 /obj/structure/handrail{
 	dir = 4
@@ -27878,6 +27783,25 @@
 	},
 /turf/simulated/floor/carpet,
 /area/security/breakroom)
+"Tf" = (
+/obj/structure/table/standard,
+/obj/random/soap,
+/obj/random/soap,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/medical_restroom)
+"Th" = (
+/obj/effect/landmark/start{
+	name = "Medical Doctor"
+	},
+/obj/structure/bed/chair{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/medbreak)
 "Ti" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -27914,6 +27838,12 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/shuttle/excursion/tether)
+"Tt" = (
+/obj/structure/toilet{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/medical_restroom)
 "Tu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	icon_state = "intact-supply";
@@ -27985,6 +27915,12 @@
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/heads/hos)
+"TP" = (
+/obj/structure/window/reinforced,
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/turf/simulated/floor/plating,
+/area/crew_quarters/medbreak)
 "TQ" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/storage/box/donkpockets,
@@ -28178,6 +28114,16 @@
 	},
 /turf/simulated/floor/tiled,
 /area/shuttle/excursion/tether)
+"Ut" = (
+/obj/effect/landmark/start{
+	name = "Medical Doctor"
+	},
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/medbreak)
 "Uu" = (
 /obj/machinery/computer/security,
 /turf/simulated/floor/wood,
@@ -28190,6 +28136,14 @@
 /obj/random/soap,
 /turf/simulated/floor/tiled/white,
 /area/security/security_bathroom)
+"Ux" = (
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/medbreak)
 "Uy" = (
 /obj/machinery/requests_console{
 	announcementConsole = 1;
@@ -28499,12 +28453,34 @@
 /obj/structure/flight_left,
 /turf/simulated/floor/tiled,
 /area/shuttle/excursion/tether)
+"Vv" = (
+/obj/structure/sink{
+	pixel_y = 26
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24;
+	pixel_y = 0
+	},
+/obj/structure/mirror{
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/medical_restroom)
 "Vw" = (
 /obj/machinery/sleeper{
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/shuttle/excursion/tether)
+"VA" = (
+/obj/effect/landmark/start{
+	name = "Medical Doctor"
+	},
+/obj/structure/bed/chair,
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/medbreak)
 "VB" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
@@ -28697,10 +28673,34 @@
 	},
 /turf/simulated/floor/tiled,
 /area/shuttle/excursion/tether)
+"Wr" = (
+/obj/structure/table/standard,
+/obj/item/weapon/towel/random,
+/obj/item/weapon/towel/random,
+/obj/item/weapon/towel/random,
+/obj/item/weapon/towel/random,
+/obj/item/weapon/towel/random,
+/obj/item/weapon/towel/random,
+/obj/item/weapon/towel/random,
+/obj/item/weapon/towel/random,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/medical_restroom)
 "Ws" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/wall/rshull,
 /area/shuttle/excursion/tether)
+"Wv" = (
+/obj/machinery/alarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -22;
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/medical_restroom)
+"Ww" = (
+/turf/simulated/wall,
+/area/crew_quarters/heads/cmo)
 "Wx" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
@@ -28718,6 +28718,14 @@
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/plating,
 /area/shuttle/excursion/tether)
+"Wz" = (
+/obj/machinery/vending/cola,
+/obj/machinery/camera/network/medbay{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/medbreak)
 "WB" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -28729,7 +28737,7 @@
 	pixel_y = 0
 	},
 /obj/structure/mirror{
-	pixel_x = 30
+	pixel_x = 25
 	},
 /turf/simulated/floor/tiled/white,
 /area/security/security_bathroom)
@@ -28737,6 +28745,23 @@
 /obj/structure/flight_right,
 /turf/simulated/floor/tiled,
 /area/shuttle/excursion/tether)
+"WE" = (
+/obj/effect/decal/remains,
+/obj/item/clothing/under/rank/centcom_officer,
+/obj/item/clothing/head/beret/centcom/officer,
+/obj/item/clothing/shoes/laceup,
+/turf/simulated/mineral/floor/vacuum,
+/area/mine/explored/upper_level)
+"WF" = (
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8;
+	health = 1e+006
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/turf/simulated/floor/plating,
+/area/crew_quarters/medical_restroom)
 "WG" = (
 /obj/machinery/disposal/deliveryChute{
 	dir = 8
@@ -29016,6 +29041,19 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/shuttle/excursion/tether)
+"Yh" = (
+/obj/structure/sink{
+	dir = 4;
+	icon_state = "sink";
+	pixel_x = 11;
+	pixel_y = 0
+	},
+/obj/structure/mirror{
+	pixel_x = 25;
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/medical_restroom)
 "Yi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -29054,6 +29092,11 @@
 	},
 /turf/simulated/floor/tiled,
 /area/shuttle/excursion/tether)
+"Yp" = (
+/turf/simulated/wall{
+	can_open = 0
+	},
+/area/crew_quarters/medical_restroom)
 "Ys" = (
 /obj/structure/bed/chair/shuttle{
 	icon_state = "shuttle_chair";
@@ -29084,6 +29127,12 @@
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/heads/hos)
+"Yz" = (
+/obj/structure/window/reinforced,
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/turf/simulated/floor/plating,
+/area/crew_quarters/medical_restroom)
 "YC" = (
 /obj/effect/floor_decal/carpet,
 /turf/simulated/floor/carpet,
@@ -29220,6 +29269,21 @@
 /obj/structure/bookcase,
 /turf/simulated/floor/wood,
 /area/crew_quarters/heads/cmo)
+"Zu" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/medical_restroom)
+"Zx" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/medical_restroom)
 "Zy" = (
 /obj/structure/disposaloutlet{
 	dir = 8
@@ -34829,13 +34893,13 @@ ab
 ab
 ab
 ab
-ab
-ab
-aa
-aa
-aa
-aa
-aa
+KE
+KE
+KE
+KE
+KE
+Tb
+WF
 aa
 aa
 aa
@@ -34971,13 +35035,13 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-aa
-aa
+KE
+Qr
+Wv
+KE
+Vv
+Nl
+Yz
 aa
 aa
 aa
@@ -35113,15 +35177,15 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
 KE
-KE
-KE
-KE
-aa
-aa
+Qx
+Nl
+Md
+Nl
+Nl
+Yz
+vt
+vt
 aa
 aa
 aa
@@ -35254,17 +35318,17 @@ ab
 ab
 ab
 ab
+ab
 KE
+Tt
+Yh
 KE
-KE
-KE
-KE
-MN
 Nl
+Wr
 KE
 vt
-aa
-aa
+vt
+vt
 aa
 aa
 aa
@@ -35396,17 +35460,17 @@ ab
 ab
 ab
 ab
+ab
 KE
-KS
+Yp
 KE
-Mc
 KE
 MO
 Nm
 KE
 vt
-aa
-aa
+vt
+vt
 aa
 aa
 aa
@@ -35538,18 +35602,18 @@ ab
 ab
 ab
 ab
+ab
 KE
-KT
-KE
+Qf
+Zx
 Md
+Zu
+Tf
 KE
-KE
-Md
-KE
+ab
 vt
-aa
-aa
-aa
+vt
+vt
 aa
 aa
 aa
@@ -35680,18 +35744,18 @@ ab
 ab
 ab
 ab
+ab
 KE
-KU
-LA
-Me
-Mz
+KE
+KE
+KE
 MP
-Nn
-Nx
+Nl
+KE
+ab
+ab
 vt
 vt
-aa
-aa
 aa
 aa
 aa
@@ -35822,18 +35886,18 @@ ab
 ab
 ab
 ab
+ab
 KE
-KV
 Hf
 Mf
-MA
+Md
 MQ
-MA
-Nx
+KV
+KE
+ab
+ab
 vt
 vt
-aa
-aa
 aa
 aa
 aa
@@ -35973,9 +36037,9 @@ MR
 KW
 KW
 KW
+KW
 vt
 vt
-aa
 aa
 aa
 aa
@@ -36114,10 +36178,10 @@ MB
 MS
 No
 Jm
+Wz
 KW
 vt
 vt
-aa
 aa
 aa
 aa
@@ -36256,8 +36320,8 @@ MC
 MT
 Ld
 Ld
-NH
-vt
+Ld
+TP
 vt
 vt
 aa
@@ -36394,15 +36458,15 @@ Jr
 KZ
 LE
 Mi
-MD
+Ld
 MU
+Ut
 Ld
 Ld
-NH
+TP
 vt
 vt
 vt
-aa
 aa
 aa
 aa
@@ -36536,15 +36600,15 @@ Jr
 La
 LF
 Mj
-ME
+VA
 MV
-Np
+ME
+QE
 Ld
-NH
+TP
 vt
 vt
 vt
-aa
 aa
 aa
 aa
@@ -36675,18 +36739,18 @@ IF
 LT
 Ke
 Lp
-Lb
+Ld
 Ld
 Mk
-MF
+VA
 MW
-Np
-Ld
+MF
+QE
 NH
+TP
 vt
 vt
 vt
-aa
 aa
 aa
 aa
@@ -36820,16 +36884,16 @@ KF
 Lc
 Ld
 Ml
+Ld
 MG
-MG
+Th
 Ld
 Ld
-NH
+TP
 vt
 vt
 vt
 vt
-aa
 aa
 aa
 aa
@@ -36966,12 +37030,12 @@ MH
 MH
 MH
 Nz
-NH
+Ux
+TP
 vt
 vt
 vt
 vt
-aa
 aa
 aa
 aa
@@ -37108,17 +37172,17 @@ MI
 MY
 Nq
 NA
+OP
 KW
-ab
-NW
-NW
-NW
-NW
-NW
-NW
-NW
-NW
-NW
+vt
+vt
+vt
+vt
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -37251,15 +37315,15 @@ Lg
 KW
 KW
 KW
-ab
+KW
 NW
-Oj
-Oy
-Ny
 NW
-Oj
-Oy
-Ny
+NW
+NW
+NW
+NW
+NW
+NW
 NW
 aa
 aa
@@ -37395,13 +37459,13 @@ ab
 ab
 ab
 NW
-Ok
-OA
-OQ
+Oj
+Oy
+Ny
 NW
-Ok
-OA
-OQ
+Oj
+Oy
+Ny
 NW
 aa
 aa
@@ -37532,18 +37596,18 @@ Lh
 Mq
 Lh
 Na
-Nr
-Nr
-Nr
-Nr
+Iy
+ab
+ab
+ab
 NW
-Ol
-OB
-Ol
+Ok
+OA
+OQ
 NW
-Ol
-Pn
-Ol
+Ok
+OA
+OQ
 NW
 aa
 aa
@@ -37675,23 +37739,23 @@ Mr
 Lh
 Nb
 Nr
-NB
-JZ
-NN
 Nr
-Om
-OC
-OR
-OY
-Pf
-OC
-KA
+Nr
+Nr
 NW
-PB
-PM
-PM
-PB
-PB
+Ol
+OB
+Ol
+NW
+Ol
+Pn
+Ol
+NW
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -37816,23 +37880,23 @@ LI
 Ms
 MJ
 Nc
-Ns
-NC
-Kb
-NP
-NX
-On
-OD
-OS
-Pa
-Pg
-Po
-Pu
+Nr
+NB
+JZ
+NN
+Nr
+Om
+OC
+OR
+OY
+Pf
+OC
+KA
 NW
-PD
-PN
-PS
-PW
+PB
+PM
+PM
+PB
 PB
 aa
 aa
@@ -37958,24 +38022,24 @@ Jy
 Mt
 Lh
 Nd
-Nt
-NE
-NK
-NQ
-Nr
-Oo
-OE
-OE
-Pb
-Pi
-Pp
-Pv
-PA
-PE
-PO
-PT
-PX
-Qa
+Ns
+NC
+Kb
+NP
+NX
+On
+OD
+OS
+Pa
+Pg
+Po
+Pu
+NW
+PD
+PN
+PS
+PW
+PB
 aa
 aa
 aa
@@ -38100,23 +38164,23 @@ Jz
 Mt
 Lh
 Ne
+Nt
+NE
+NK
+NQ
 Nr
-Nr
-Nr
-Nr
-Nr
-Op
+Oo
 OE
-OT
 OE
-Pj
-NJ
-OE
-Ol
-PG
-PQ
-PU
-PQ
+Pb
+Pi
+Pp
+Pv
+PA
+PE
+PO
+PT
+PX
 Qa
 aa
 aa
@@ -38242,23 +38306,23 @@ JA
 Mu
 Lh
 Nf
-Iy
-ab
-ab
-ab
-NW
-Oq
-OF
-OU
+Nr
+Nr
+Nr
+Nr
+Nr
+Op
 OE
-Pl
-NR
-Pw
-NW
-PH
+OT
+OE
+Pj
+NJ
+OE
+Ol
+PG
 PQ
+PU
 PQ
-PY
 Qa
 aa
 aa
@@ -38389,19 +38453,19 @@ ab
 ab
 ab
 NW
-Or
-OG
-OV
-Pd
-Pm
-Ps
-Px
+Oq
+OF
+OU
+OE
+Pl
+NR
+Pw
 NW
-PJ
-PR
-PV
-KB
-PB
+PH
+PQ
+PQ
+PY
+Qa
 aa
 aa
 aa
@@ -38531,18 +38595,18 @@ ab
 ab
 ab
 NW
+Or
+OG
+OV
+Pd
+Pm
+Ps
+Px
 NW
-NW
-NW
-NW
-NW
-NW
-Py
-NW
-PK
-PB
-PB
-PB
+PJ
+PR
+PV
+KB
 PB
 aa
 aa
@@ -38672,20 +38736,20 @@ Iy
 ab
 ab
 ab
-ab
-ab
-ab
-vt
-vt
-vt
-vt
-Pz
-aa
-PL
-aa
-aa
-aa
-aa
+NW
+NW
+NW
+NW
+NW
+NW
+NW
+Py
+NW
+PK
+PB
+PB
+PB
+PB
 aa
 aa
 aa
@@ -38814,16 +38878,16 @@ Iy
 ab
 NL
 NL
-Lu
+NL
 NL
 NL
 NL
 NL
 vt
 vt
+Pz
 aa
-aa
-aa
+PL
 aa
 aa
 aa
@@ -39508,7 +39572,7 @@ EO
 Fy
 FS
 GB
-Fz
+Ww
 HN
 HN
 HN
@@ -41644,7 +41708,7 @@ ab
 ab
 ab
 ab
-ab
+WE
 ab
 ab
 ab


### PR DESCRIPTION
1. Fixed:

- Medbay restroom(everything remains in place but water cooler, tables, chairs and disposal unit were moved) now muh comfortable
- Some station and surface walls
- ALL(i suppose) mirrors(added where it should be and fixed pixel_y or pixel_x)

2. Added:

- Medbay restroom: 1 table and 1 random MRE on it
- Some loot in maintenance. https://i.imgur.com/16Myhh2.png
- "Easter egg"(centcom officer's clothes, shoes and beret)
- Colored bedsheets: blue in room 8, red in room 6, yellow in room 4, oragne in room 2; random drink in room 8 + random carp plushie in room 6 + random action figure in room 2
- 2 extra tiles in EVA near exit to space

3. Reworked:

- Cafeteria(tables, dispocial units, windows)
- Virology was moved 1 tile to right
- Medbay toilet near restroom, now feels more comfy