### PR TITLE
Changes the crew transfer message to be more IC friendly.

### DIFF
--- a/code/controllers/subsystems/vote.dm
+++ b/code/controllers/subsystems/vote.dm
@@ -105,7 +105,7 @@ SUBSYSTEM_DEF(vote)
 						factor = 1.4
 				choices["Initiate Crew Transfer"] = round(choices["Initiate Crew Transfer"] * factor)
 				world << "<font color='purple'>Crew Transfer Factor: [factor]</font>"
-				greatest_votes = max(choices["Initiate Crew Transfer"], choices["Continue The Round"])
+				greatest_votes = max(choices["Initiate Crew Transfer"], choices["Extend the Shift"]) //Citadel change
 
 	. = list() // Get all options with that many votes and return them in a list
 	if(greatest_votes)
@@ -220,8 +220,8 @@ SUBSYSTEM_DEF(vote)
 					if(ticker.current_state <= GAME_STATE_SETTING_UP)
 						initiator_key << "The crew transfer button has been disabled!"
 						return 0
-				question = "End the shift?"
-				choices.Add("Initiate Crew Transfer", "Continue The Round")
+				question = "Your PDA beeps with a message from Central. Would you like an additional hour to finish ongoing projects?" //Citadel change
+				choices.Add("Initiate Crew Transfer", "Extend the Shift")  //Citadel change
 			if(VOTE_ADD_ANTAGONIST)
 				if(!config.allow_extra_antags || ticker.current_state >= GAME_STATE_SETTING_UP)
 					return 0

--- a/code/controllers/subsystems/vote.dm
+++ b/code/controllers/subsystems/vote.dm
@@ -105,7 +105,7 @@ SUBSYSTEM_DEF(vote)
 						factor = 1.4
 				choices["Initiate Crew Transfer"] = round(choices["Initiate Crew Transfer"] * factor)
 				world << "<font color='purple'>Crew Transfer Factor: [factor]</font>"
-				greatest_votes = max(choices["Initiate Crew Transfer"], choices["Extend the Shift"]) //Citadel change
+				greatest_votes = max(choices["Initiate Crew Transfer"], choices["Extend the Shift"]) //VOREStation Edit
 
 	. = list() // Get all options with that many votes and return them in a list
 	if(greatest_votes)
@@ -220,8 +220,8 @@ SUBSYSTEM_DEF(vote)
 					if(ticker.current_state <= GAME_STATE_SETTING_UP)
 						initiator_key << "The crew transfer button has been disabled!"
 						return 0
-				question = "Your PDA beeps with a message from Central. Would you like an additional hour to finish ongoing projects?" //Citadel change
-				choices.Add("Initiate Crew Transfer", "Extend the Shift")  //Citadel change
+				question = "Your PDA beeps with a message from Central. Would you like an additional hour to finish ongoing projects?" //VOREStation Edit
+				choices.Add("Initiate Crew Transfer", "Extend the Shift")  //VOREStation Edit
 			if(VOTE_ADD_ANTAGONIST)
 				if(!config.allow_extra_antags || ticker.current_state >= GAME_STATE_SETTING_UP)
 					return 0


### PR DESCRIPTION
A simple change that changes the crew transfer vote message to something that implies the crew is voting for extra work on their PDAs.  This makes the crew transfer make a bit more sense in character, because as it stands, our characters are currently coming to work not really knowing when they get off work.

Direct port of this: https://github.com/Citadel-Station-13/Citadel-Station-13-RP/pull/572