### PR TITLE
Adds a small cargo office to mining, and adds a glorious cargo pipeline

### DIFF
--- a/maps/tether/tether-01-surface1.dmm
+++ b/maps/tether/tether-01-surface1.dmm
@@ -1657,6 +1657,7 @@
 /obj/effect/floor_decal/corner/brown/border{
 	dir = 8
 	},
+/obj/vehicle/train/engine,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/mining_main/storage)
 "acV" = (
@@ -2693,15 +2694,11 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/mining_eva)
 "aeC" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
+/obj/structure/sign/department/miner_dock{
+	name = "MINING"
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 30
-	},
-/obj/vehicle/train/engine,
-/turf/simulated/floor/tiled/steel_dirty,
-/area/tether/surfacebase/mining_main/ore)
+/turf/simulated/wall,
+/area/tether/surfacebase/mining_main/eva)
 "aeD" = (
 /obj/effect/floor_decal/rust,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -2717,10 +2714,13 @@
 /turf/simulated/floor/tiled/steel_dirty,
 /area/tether/surfacebase/mining_main/ore)
 "aeE" = (
-/obj/effect/floor_decal/rust,
-/obj/machinery/alarm{
-	pixel_y = 22
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
 	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 30
+	},
+/obj/vehicle/train/trolley,
 /turf/simulated/floor/tiled/steel_dirty,
 /area/tether/surfacebase/mining_main/ore)
 "aeF" = (
@@ -2805,6 +2805,15 @@
 	},
 /obj/effect/floor_decal/corner/brown/border{
 	dir = 1
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_x = 0;
+	pixel_y = 28
+	},
+/obj/structure/cable/green{
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/mining_main/lobby)
@@ -3096,7 +3105,7 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/mining_eva)
 "afe" = (
-/obj/structure/closet/crate,
+/obj/effect/floor_decal/rust,
 /turf/simulated/floor/tiled/steel_dirty,
 /area/tether/surfacebase/mining_main/ore)
 "aff" = (
@@ -3166,8 +3175,17 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/mining_main/lobby)
 "afk" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/brown/bordercorner2{
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/mining_main/lobby)
@@ -3367,7 +3385,10 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/mining_eva)
 "afD" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/vehicle/train/trolley,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/steel_dirty,
 /area/tether/surfacebase/mining_main/ore)
 "afE" = (
@@ -3511,12 +3532,13 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/mining_main/lobby)
 "afP" = (
-/obj/structure/table/glass,
-/obj/effect/floor_decal/borderfloor{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/floor_decal/corner/brown/border{
-	dir = 4
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/mining_main/lobby)
@@ -3626,23 +3648,22 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/mining_eva)
 "age" = (
-/obj/effect/floor_decal/rust,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
 /obj/vehicle/train/trolley,
+/obj/machinery/alarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -22;
+	pixel_y = 0
+	},
 /turf/simulated/floor/tiled/steel_dirty,
 /area/tether/surfacebase/mining_main/ore)
 "agf" = (
-/obj/effect/floor_decal/rust,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/closet/crate,
 /turf/simulated/floor/tiled/steel_dirty,
 /area/tether/surfacebase/mining_main/ore)
 "agg" = (
-/obj/structure/closet/crate,
-/obj/machinery/light,
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/steel_dirty,
 /area/tether/surfacebase/mining_main/ore)
 "agh" = (
@@ -3670,10 +3691,6 @@
 /obj/effect/floor_decal/corner/brown/bordercorner2{
 	dir = 8
 	},
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/mining_main/lobby)
 "agk" = (
@@ -3681,40 +3698,29 @@
 /turf/simulated/floor/tiled,
 /area/rnd/xenoarch_storage)
 "agl" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/junction,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/mining_main/lobby)
 "agm" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
 	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/mining_main/lobby)
 "agn" = (
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/brown/border,
-/obj/effect/floor_decal/borderfloor/corner2,
-/obj/effect/floor_decal/corner/brown/bordercorner2,
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/mining_main/lobby)
 "ago" = (
-/obj/machinery/light,
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/brown/border,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/mining_main/lobby)
 "agp" = (
@@ -3781,26 +3787,18 @@
 /turf/simulated/floor/tiled,
 /area/rnd/xenoarch_storage)
 "agx" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+	dir = 6
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/mining_main/lobby)
 "agy" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/mining_main/lobby)
 "agz" = (
@@ -3836,12 +3834,8 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/rnd/xenoarch_storage)
 "agD" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/mining_main/lobby)
 "agE" = (
@@ -3915,13 +3909,10 @@
 /turf/simulated/wall,
 /area/tether/surfacebase/atrium_one)
 "agN" = (
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals6{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/mining_main/lobby)
 "agO" = (
@@ -4095,51 +4086,29 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/tether/surfacebase/atrium_one)
 "ahd" = (
+/obj/structure/table/glass,
 /obj/effect/floor_decal/borderfloor{
-	dir = 8
+	dir = 4
 	},
 /obj/effect/floor_decal/corner/brown/border{
-	dir = 8
+	dir = 4
 	},
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 10
-	},
-/obj/effect/floor_decal/corner/brown/bordercorner2{
-	dir = 10
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 5
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 5
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 6
+/obj/machinery/newscaster{
+	pixel_x = 30;
+	pixel_y = 0
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/mining_main/lobby)
 "ahe" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 4
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/corner/brown/border{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 5
-	},
-/obj/effect/floor_decal/corner/brown/bordercorner2{
-	dir = 5
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 8
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 10
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 9
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/mining_main/lobby)
@@ -4303,27 +4272,28 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/tether/surfacebase/atrium_one)
 "ahv" = (
-/obj/machinery/door/airlock/multi_tile/glass{
-	name = "Mining Lobby"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/machinery/door/firedoor/glass,
-/obj/effect/floor_decal/steeldecal/steel_decals_central1{
-	dir = 8
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/brown/border,
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 9
 	},
-/turf/simulated/floor/tiled/monofloor{
-	dir = 8
+/obj/effect/floor_decal/corner/brown/bordercorner2{
+	dir = 9
 	},
-/area/tether/surfacebase/atrium_one)
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/mining_main/lobby)
 "ahw" = (
-/obj/machinery/door/firedoor/glass,
-/obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/steeldecal/steel_decals_central1{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/tiled/monofloor{
-	dir = 4
-	},
-/area/tether/surfacebase/atrium_one)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/mining_main/lobby)
 "ahx" = (
 /turf/simulated/wall,
 /area/tether/surfacebase/emergency_storage/atrium)
@@ -4636,13 +4606,19 @@
 /turf/simulated/wall,
 /area/tether/surfacebase/north_stairs_one)
 "ahY" = (
-/obj/machinery/door/airlock/maintenance/common{
-	name = "Mining Maintenance Access"
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor/glass,
-/obj/structure/catwalk,
-/turf/simulated/floor/tiled/techfloor,
-/area/tether/surfacebase/north_stairs_one)
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/steel_dirty,
+/area/tether/surfacebase/mining_main/ore)
 "ahZ" = (
 /obj/structure/sign/directions/cargo{
 	dir = 4
@@ -4758,21 +4734,16 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/atrium_one)
 "aih" = (
-/obj/effect/floor_decal/borderfloor{
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/brown/border,
+/obj/machinery/computer/supplycomp{
+	icon_state = "computer";
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 1
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7,
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 4
-	},
+/obj/effect/floor_decal/borderfloor/corner2,
+/obj/effect/floor_decal/corner/brown/bordercorner2,
 /turf/simulated/floor/tiled,
-/area/tether/surfacebase/atrium_one)
+/area/tether/surfacebase/mining_main/lobby)
 "aii" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -4800,48 +4771,36 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/chemistry_lab)
 "aik" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/brown/border{
-	dir = 1
-	},
+/obj/machinery/light,
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/brown/border,
 /obj/effect/floor_decal/borderfloor/corner2{
-	dir = 1
+	dir = 9
 	},
 /obj/effect/floor_decal/corner/brown/bordercorner2{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7,
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 1
+	dir = 9
 	},
 /turf/simulated/floor/tiled,
-/area/tether/surfacebase/atrium_one)
+/area/tether/surfacebase/mining_main/lobby)
 "ail" = (
-/obj/structure/disposalpipe/segment{
+/obj/effect/floor_decal/rust,
+/obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals6{
-	dir = 1
+/obj/structure/plasticflaps,
+/obj/machinery/disposal/deliveryChute{
+	dir = 4
 	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/atrium_one)
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "gloriouscargopipeline"
+	},
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/mining_main/ore)
 "aim" = (
-/obj/structure/disposalpipe/junction{
-	dir = 8
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals6{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
-/area/tether/surfacebase/atrium_one)
+/area/tether/surfacebase/mining_main/lobby)
 "ain" = (
 /obj/machinery/chem_master,
 /obj/effect/floor_decal/borderfloor{
@@ -4857,22 +4816,15 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/chemistry_lab)
 "aio" = (
-/obj/effect/floor_decal/borderfloor{
+/obj/structure/bed/chair{
 	dir = 1
 	},
-/obj/effect/floor_decal/corner/brown/border{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/camera/network/tether,
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 4
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/brown/border,
+/obj/effect/floor_decal/borderfloor/corner2,
+/obj/effect/floor_decal/corner/brown/bordercorner2,
 /turf/simulated/floor/tiled,
-/area/tether/surfacebase/atrium_one)
+/area/tether/surfacebase/mining_main/lobby)
 "aip" = (
 /obj/structure/table/glass,
 /obj/item/weapon/storage/box/beakers,
@@ -4901,18 +4853,9 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/mining_main/eva)
 "air" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 5
-	},
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 5
-	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/atrium_one)
+/obj/structure/closet/firecloset,
+/turf/simulated/floor/plating,
+/area/maintenance/lower/mining_eva)
 "ais" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9;
@@ -5150,30 +5093,10 @@
 /turf/simulated/floor/tiled/monofloor,
 /area/tether/surfacebase/north_stairs_one)
 "aiQ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 1
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 4
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7,
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/lightgrey/bordercorner2{
-	dir = 4
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 6
-	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
-/area/tether/surfacebase/north_stairs_one)
+/area/tether/surfacebase/mining_main/lobby)
 "aiR" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -6747,21 +6670,11 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/mining_main/lobby)
 "alJ" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
 	},
-/obj/effect/floor_decal/corner/brown/border{
-	dir = 1
-	},
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/brown/bordercorner2{
-	dir = 1
-	},
-/obj/structure/flora/pottedplant,
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/mining_main/lobby)
+/turf/simulated/floor/tiled/steel_dirty,
+/area/tether/surfacebase/mining_main/ore)
 "alK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -6946,7 +6859,14 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/mining_eva)
 "alY" = (
-/obj/vehicle/train/trolley,
+/obj/effect/floor_decal/rust,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "gloriouscargopipeline"
+	},
 /turf/simulated/floor/tiled/steel_dirty,
 /area/tether/surfacebase/mining_main/ore)
 "alZ" = (
@@ -6967,22 +6887,22 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/mining_main/lobby)
 "amb" = (
-/obj/structure/disposalpipe/junction,
-/obj/effect/floor_decal/steeldecal/steel_decals6,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/mining_main/lobby)
-"amc" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/brown/border,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment{
-	dir = 8;
+	dir = 4;
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/mining_main/lobby)
+"amc" = (
+/turf/simulated/wall,
+/area/tether/surfacebase/mining_main/surfacecargo)
 "amd" = (
 /obj/structure/table/glass,
 /obj/effect/floor_decal/borderfloor{
@@ -7143,15 +7063,13 @@
 /turf/simulated/floor/tiled/steel_dirty,
 /area/tether/surfacebase/mining_main/ore)
 "ams" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "gloriouscargopipeline"
 	},
 /turf/simulated/floor/tiled/steel_dirty,
 /area/tether/surfacebase/mining_main/ore)
@@ -7192,13 +7110,9 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/mining_main/lobby)
 "amw" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/mining_main/lobby)
+/obj/structure/sign/department/cargo,
+/turf/simulated/wall,
+/area/tether/surfacebase/mining_main/surfacecargo)
 "amx" = (
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/steeldecal/steel_decals_central1{
@@ -7208,13 +7122,13 @@
 	name = "Mining Lobby"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/monofloor{
 	dir = 8
 	},
 /area/tether/surfacebase/mining_main/lobby)
 "amy" = (
 /obj/machinery/door/firedoor/glass,
-/obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/steeldecal/steel_decals_central1{
 	dir = 4
 	},
@@ -7224,33 +7138,32 @@
 	},
 /area/tether/surfacebase/mining_main/lobby)
 "amz" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 8
+/obj/machinery/button/remote/blast_door{
+	id = "mine_warehouse";
+	name = "Warehouse Door Control";
+	pixel_x = -26;
+	pixel_y = 24;
+	req_access = list(31)
 	},
-/obj/effect/floor_decal/corner/brown/border{
-	dir = 8
+/obj/machinery/button/remote/blast_door{
+	id = "surfcargooffice";
+	name = "Office Shutters";
+	pixel_x = -34;
+	pixel_y = 24;
+	req_access = list(31)
 	},
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/brown/bordercorner2{
-	dir = 8
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 4
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 5
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 6
-	},
-/obj/machinery/camera/network/cargo{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/landmark/start{
+	name = "Cargo Technician"
+	},
+/obj/structure/bed/chair/office/dark{
+	dir = 1
+	},
 /turf/simulated/floor/tiled,
-/area/tether/surfacebase/mining_main/lobby)
+/area/tether/surfacebase/mining_main/surfacecargo)
 "amA" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 10
@@ -7416,58 +7329,31 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/mining_eva)
 "amN" = (
-/obj/machinery/power/apc{
-	dir = 2;
-	name = "south bump";
-	pixel_y = -28
+/obj/machinery/light,
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "gloriouscargopipeline"
 	},
-/obj/structure/cable/green,
-/obj/structure/closet/crate,
 /turf/simulated/floor/tiled/steel_dirty,
 /area/tether/surfacebase/mining_main/ore)
 "amO" = (
-/obj/machinery/button/remote/blast_door{
-	id = "mine_warehouse";
-	name = "Warehouse Door Control";
-	pixel_x = 26;
-	pixel_y = 0;
-	req_access = list(31)
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "gloriouscargopipeline"
 	},
-/obj/structure/closet/crate,
 /turf/simulated/floor/tiled/steel_dirty,
 /area/tether/surfacebase/mining_main/ore)
 "amP" = (
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/brown/border,
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 9
-	},
-/obj/effect/floor_decal/corner/brown/bordercorner2{
-	dir = 9
-	},
-/obj/machinery/newscaster{
-	pixel_x = 0;
-	pixel_y = -30
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/machinery/camera/network/cargo,
 /turf/simulated/floor/tiled,
-/area/tether/surfacebase/mining_main/lobby)
+/area/tether/surfacebase/mining_main/surfacecargo)
 "amQ" = (
-/obj/structure/bed/chair{
-	dir = 1
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
 	},
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/brown/border,
-/obj/machinery/power/apc{
-	dir = 2;
-	name = "south bump";
-	pixel_y = -28
-	},
-/obj/structure/cable/green,
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/mining_main/lobby)
+/turf/simulated/floor/plating,
+/area/maintenance/lower/mining_eva)
 "amR" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 6
@@ -7623,14 +7509,9 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/public_garden)
 "anc" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/obj/machinery/door/airlock/maintenance/common{
-	name = "Mining Maintenance Access"
+/obj/machinery/door/airlock/maintenance/common,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/plating,
@@ -7646,31 +7527,20 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/mining_eva)
 "ane" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 4
+/obj/machinery/door/airlock/glass_mining{
+	id_tag = "cargodoor";
+	name = "Cargo Office";
+	req_access = list(31);
+	req_one_access = list()
 	},
-/obj/effect/floor_decal/corner/brown/border{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 6
-	},
-/obj/effect/floor_decal/corner/brown/bordercorner2{
-	dir = 6
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 9
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 10
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
-/area/tether/surfacebase/mining_main/lobby)
+/area/tether/surfacebase/mining_main/surfacecargo)
 "anf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/rust,
@@ -7789,51 +7659,45 @@
 /turf/simulated/floor/tiled,
 /area/storage/primary)
 "anm" = (
-/obj/structure/catwalk,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/obj/machinery/power/apc{
+	dir = 2;
+	name = "south bump";
+	pixel_y = -28
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/maintenance/lower/mining_eva)
+/obj/structure/cable/green,
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "gloriouscargopipeline"
+	},
+/turf/simulated/floor/tiled/steel_dirty,
+/area/tether/surfacebase/mining_main/ore)
 "ann" = (
-/obj/structure/catwalk,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+/obj/machinery/button/remote/blast_door{
+	id = "mine_warehouse";
+	name = "Warehouse Door Control";
+	pixel_x = 0;
+	pixel_y = -22;
+	req_access = list(31)
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/maintenance/lower/mining_eva)
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "gloriouscargopipeline"
+	},
+/turf/simulated/floor/tiled/steel_dirty,
+/area/tether/surfacebase/mining_main/ore)
 "ano" = (
-/obj/structure/catwalk,
-/obj/machinery/alarm{
-	pixel_y = 22
+/obj/machinery/door/airlock/maintenance/cargo{
+	name = "Mining Maintenance Access";
+	req_one_access = list(48)
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/maintenance/lower/mining_eva)
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/mining_main/ore)
 "anp" = (
-/obj/structure/catwalk,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/tiled/techfloor,
+/turf/simulated/floor/plating,
 /area/maintenance/lower/mining_eva)
 "anq" = (
 /obj/effect/decal/cleanable/dirt,
@@ -8026,94 +7890,51 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/atrium_one)
 "anE" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/brown/border{
-	dir = 1
-	},
-/obj/machinery/newscaster{
-	pixel_x = 0;
-	pixel_y = 30
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7,
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/atrium_one)
-"anF" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/brown/border{
-	dir = 1
-	},
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/brown/bordercorner2{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 4
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7,
-/obj/item/device/radio/intercom{
-	dir = 1;
-	pixel_y = 24;
-	req_access = list()
-	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/atrium_one)
-"anG" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 1
-	},
-/obj/machinery/firealarm{
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/window/northright{
 	dir = 2;
+	name = "Mailing Room";
+	req_access = list(50)
+	},
+/obj/structure/noticeboard{
+	pixel_x = 32
+	},
+/obj/machinery/door/blast/shutters{
+	dir = 2;
+	id = "surfcargooffice";
 	layer = 3.3;
-	pixel_x = 0;
-	pixel_y = 26
+	name = "Cargo Office Shutters"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 1
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 4
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
-/area/tether/surfacebase/atrium_one)
-"anH" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 1
+/area/tether/surfacebase/mining_main/surfacecargo)
+"anF" = (
+/obj/machinery/door/airlock/maintenance/cargo{
+	name = "Mining Maintenance Access";
+	req_one_access = list(48)
 	},
-/obj/machinery/status_display{
-	pixel_y = 30
-	},
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/mining_main/surfacecargo)
+"anG" = (
 /obj/structure/disposalpipe/junction{
 	dir = 8;
 	icon_state = "pipe-j2"
 	},
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 1
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
+/obj/effect/floor_decal/steeldecal/steel_decals6{
 	dir = 4
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals7,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/atrium_one)
+"anH" = (
+/obj/structure/plasticflaps,
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "gloriouscargopipeline"
+	},
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/mining_main/lobby)
 "anI" = (
 /obj/structure/cable{
 	icon_state = "0-2";
@@ -11100,23 +10921,28 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/xenoflora)
 "asH" = (
-/obj/structure/catwalk,
-/obj/machinery/atmospherics/pipe/simple/visible/scrubbers{
-	dir = 4
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
 	},
-/obj/machinery/alarm{
-	pixel_y = 22
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
-/obj/effect/floor_decal/rust,
-/turf/simulated/floor/tiled/techfloor,
-/area/maintenance/lower/xenoflora)
+/turf/simulated/floor/plating,
+/area/maintenance/lower/mining_eva)
 "asI" = (
-/obj/structure/catwalk,
-/obj/machinery/atmospherics/pipe/simple/visible/scrubbers{
-	dir = 10
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/maintenance/lower/xenoflora)
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/maintenance/lower/mining_eva)
 "asJ" = (
 /obj/structure/catwalk,
 /obj/machinery/firealarm{
@@ -11983,12 +11809,19 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/xenoflora)
 "aup" = (
-/obj/structure/catwalk,
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 4
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/maintenance/lower/xenoflora)
+/obj/machinery/door/airlock/maintenance/common{
+	name = "Mining Maintenance Access"
+	},
+/obj/machinery/door/firedoor/glass,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/maintenance/lower/mining_eva)
 "auq" = (
 /obj/structure/railing{
 	dir = 8
@@ -12539,12 +12372,16 @@
 "avl" = (
 /obj/structure/catwalk,
 /obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/tiled/techfloor,
-/area/maintenance/lower/xenoflora)
+/area/maintenance/lower/mining_eva)
 "avm" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -20187,18 +20024,23 @@
 /obj/effect/floor_decal/corner/brown/border{
 	dir = 8
 	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/brown/bordercorner2{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 4
+	},
 /obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 5
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 6
 	},
-/obj/structure/sign/nosmoking_2{
-	pixel_x = -32
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/mining_main/lobby)
 "aGL" = (
@@ -20260,20 +20102,25 @@
 /obj/effect/floor_decal/corner/brown/border{
 	dir = 4
 	},
-/obj/machinery/alarm{
-	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 24
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 6
 	},
-/obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/corner/brown/bordercorner2{
+	dir = 6
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
+	},
 /obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 10
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 9
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/camera/network/cargo{
+	c_tag = "CRG - Cargo Warehouse";
+	dir = 9
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/mining_main/lobby)
@@ -20843,6 +20690,29 @@
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/tiled/steel_dirty/virgo3b,
 /area/tether/surfacebase/outside/outside1)
+"aHM" = (
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = -25
+	},
+/obj/structure/bed/chair/sofa/corner{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 10
+	},
+/obj/effect/landmark/start{
+	name = "Cargo Technician"
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/mining_main/surfacecargo)
 "aHN" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -21195,6 +21065,33 @@
 /obj/structure/bed/chair/wood,
 /turf/simulated/floor/lino,
 /area/crew_quarters/visitor_dining)
+"aIA" = (
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/brown/bordercorner2{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/brown/bordercorner2{
+	dir = 1
+	},
+/obj/machinery/light_switch{
+	dir = 2;
+	name = "light switch ";
+	pixel_x = 10;
+	pixel_y = 32
+	},
+/obj/machinery/conveyor_switch/oneway{
+	id = "gloriouscargopipeline";
+	layer = 3.3;
+	name = "outbound conveyor";
+	pixel_y = 14
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/mining_main/surfacecargo)
 "aIB" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -25748,6 +25645,15 @@
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/atmos)
+"aQE" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/mining_main/surfacecargo)
 "aQF" = (
 /obj/machinery/light{
 	dir = 8
@@ -30871,6 +30777,801 @@
 /obj/effect/step_trigger/teleporter/to_plains,
 /turf/simulated/floor/tiled/steel_dirty/virgo3b,
 /area/tether/surfacebase/outside/outside1)
+"baY" = (
+/obj/structure/table/standard,
+/obj/item/weapon/stamp/cargo,
+/obj/item/weapon/stamp/denied{
+	pixel_x = 4;
+	pixel_y = -2
+	},
+/obj/item/weapon/clipboard,
+/obj/item/weapon/folder/yellow,
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/brown/bordercorner2{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/brown/bordercorner2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/mining_main/surfacecargo)
+"baZ" = (
+/obj/machinery/alarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -22
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/lower/mining_eva)
+"bba" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 5
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 6
+	},
+/obj/structure/sign/nosmoking_2{
+	pixel_x = -32
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/mining_main/lobby)
+"bbb" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 4
+	},
+/obj/machinery/alarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 10
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 9
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/mining_main/lobby)
+"bbc" = (
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 25;
+	pixel_y = 0
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/lower/mining_eva)
+"bbd" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/alarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -22
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/lower/xenoflora)
+"bbe" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/maintenance/lower/mining_eva)
+"bbf" = (
+/obj/machinery/computer/supplycomp/control{
+	icon_state = "computer";
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 5
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/brown/bordercorner2{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/mining_main/surfacecargo)
+"bbg" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/brown/bordercorner2{
+	dir = 10
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 5
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 6
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/mining_main/lobby)
+"bbh" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/brown/bordercorner2{
+	dir = 5
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 10
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 9
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/mining_main/lobby)
+"bbi" = (
+/obj/machinery/door/airlock/multi_tile/glass{
+	name = "Mining Lobby"
+	},
+/obj/machinery/door/firedoor/glass,
+/obj/effect/floor_decal/steeldecal/steel_decals_central1{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/monofloor{
+	dir = 8
+	},
+/area/tether/surfacebase/atrium_one)
+"bbj" = (
+/obj/machinery/door/firedoor/glass,
+/obj/effect/floor_decal/steeldecal/steel_decals_central1{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/monofloor{
+	dir = 4
+	},
+/area/tether/surfacebase/atrium_one)
+"bbk" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 2;
+	layer = 3.3;
+	pixel_x = 0;
+	pixel_y = 26
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/atrium_one)
+"bbl" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/machinery/newscaster{
+	pixel_x = 0;
+	pixel_y = 30
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/atrium_one)
+"bbm" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/atrium_one)
+"bbn" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/atrium_one)
+"bbo" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/atrium_one)
+"bbp" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/item/device/radio/intercom{
+	dir = 1;
+	pixel_y = 24;
+	req_access = list()
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/atrium_one)
+"bbq" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/camera/network/tether,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/brown/bordercorner2{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/atrium_one)
+"bbr" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/blast/shutters{
+	dir = 8;
+	id = "surfcargooffice";
+	layer = 3.3;
+	name = "Cargo Office Shutters"
+	},
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/mining_main/surfacecargo)
+"bbs" = (
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -28
+	},
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/bed/chair/sofa/left{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 8;
+	icon_state = "borderfloor";
+	pixel_x = 0
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/brown/bordercorner2{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/mining_main/surfacecargo)
+"bbt" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 5
+	},
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 5
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/brown/bordercorner2{
+	dir = 4
+	},
+/obj/machinery/status_display{
+	pixel_x = 32
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/atrium_one)
+"bbu" = (
+/obj/structure/disposalpipe/junction{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/atrium_one)
+"bbv" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/mining_main/surfacecargo)
+"bbw" = (
+/obj/machinery/alarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -22
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/lower/xenoflora)
+"bbx" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/mining_main/surfacecargo)
+"bby" = (
+/obj/structure/table/standard,
+/obj/item/weapon/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/weapon/pen/red{
+	pixel_x = 2;
+	pixel_y = 6
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/mining_main/surfacecargo)
+"bbz" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/mining_main/surfacecargo)
+"bbA" = (
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/mining_main/surfacecargo)
+"bbB" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -25
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/lower/xenoflora)
+"bbC" = (
+/obj/structure/bed/chair/sofa/left{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/brown/border,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/mining_main/surfacecargo)
+"bbD" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/brown/border,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/mining_main/surfacecargo)
+"bbE" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/lower/mining_eva)
+"bbF" = (
+/obj/structure/filingcabinet/chestdrawer,
+/obj/effect/floor_decal/borderfloor{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 6
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/mining_main/surfacecargo)
+"bbG" = (
+/obj/machinery/door/airlock/maintenance/common,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/plating,
+/area/hallway/lower/first_west)
+"bbH" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled,
+/area/hallway/lower/first_west)
+"bbI" = (
+/obj/structure/catwalk,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/lower/mining_eva)
+"bbJ" = (
+/obj/structure/catwalk,
+/obj/machinery/alarm{
+	pixel_y = 22
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/lower/mining_eva)
+"bbK" = (
+/obj/structure/catwalk,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/lower/mining_eva)
+"bbL" = (
+/obj/machinery/door/airlock/maintenance/common{
+	name = "Mining Maintenance Access"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/lower/mining_eva)
+"bbM" = (
+/obj/machinery/door/airlock/maintenance/common{
+	name = "Mining Maintenance Access"
+	},
+/obj/machinery/door/firedoor/glass,
+/obj/structure/catwalk,
+/turf/simulated/floor/tiled/techfloor,
+/area/tether/surfacebase/north_stairs_one)
+"bbN" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/lower/first_west)
+"bbO" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/lower/first_west)
+"bbP" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/lower/first_west)
+"bbQ" = (
+/turf/simulated/mineral,
+/area/tether/surfacebase/atrium_one)
+"bbR" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/lightgrey/bordercorner2{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 6
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/north_stairs_one)
+"bbS" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/lightgrey/border,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled,
+/area/hallway/lower/first_west)
+"bbT" = (
+/turf/simulated/mineral,
+/area/maintenance/lower/mining_eva)
+"bbU" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/maintenance/lower/xenoflora)
+"bbV" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/brown/border,
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -25
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/mining_main/surfacecargo)
+"bbW" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/blast/shutters{
+	dir = 2;
+	id = "surfcargooffice";
+	layer = 3.3;
+	name = "Cargo Office Shutters"
+	},
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/mining_main/surfacecargo)
+"bbX" = (
+/obj/machinery/door/airlock/maintenance/common,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/plating,
+/area/maintenance/lower/xenoflora)
+"bbY" = (
+/obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/simple/visible/scrubbers{
+	dir = 4
+	},
+/obj/machinery/alarm{
+	pixel_y = 22
+	},
+/obj/effect/floor_decal/rust,
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/lower/xenoflora)
+"bbZ" = (
+/obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/simple/visible/scrubbers{
+	dir = 10
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/lower/xenoflora)
+"bca" = (
+/obj/structure/catwalk,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/lower/xenoflora)
+"bcb" = (
+/obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/lower/xenoflora)
+"bcc" = (
+/obj/structure/catwalk,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/lower/xenoflora)
+"bcd" = (
+/turf/simulated/mineral,
+/area/maintenance/lower/xenoflora)
+"bce" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/airlock/maintenance/common,
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/plating,
+/area/maintenance/lower/xenoflora)
+"bcf" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/lower/xenoflora)
+"bcg" = (
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/lower/xenoflora)
+"bch" = (
+/obj/machinery/door/airlock/maintenance/common,
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/lower/xenoflora)
+"bci" = (
+/obj/structure/disposalpipe/up{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/lower/xenoflora)
 "cGJ" = (
 /turf/simulated/floor/plating,
 /area/maintenance/lower/mining_eva)
@@ -38881,15 +39582,15 @@ aah
 aah
 aah
 aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
+abT
+abT
+abT
+abT
+abT
+abT
+abT
+abT
+abT
 ahl
 ahL
 anP
@@ -39023,15 +39724,15 @@ aah
 aah
 aah
 aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
+abT
+cGJ
+cGJ
+baZ
+cGJ
+cGJ
+cGJ
+cGJ
+cGJ
 ahl
 ahK
 add
@@ -39165,18 +39866,18 @@ aah
 aah
 aah
 aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-ahl
-ahL
-anP
+abT
+amQ
+bbe
+bbe
+bbe
+bbe
+bbe
+bbe
+bbe
+bbG
+bbH
+bbN
 adu
 ahl
 apj
@@ -39307,8 +40008,8 @@ aah
 aah
 aah
 aah
-aah
-aah
+abT
+anp
 aeW
 aeW
 aeW
@@ -39318,16 +40019,16 @@ aeW
 aeW
 aeW
 ahL
-anP
+bbO
 adu
 ahl
-apj
-apj
-apj
-apj
-apj
-apj
-apj
+apu
+apu
+apu
+apu
+apu
+apu
+apu
 apu
 asG
 atc
@@ -39449,8 +40150,8 @@ aah
 aah
 aah
 aah
-aah
-aah
+abT
+anp
 aeW
 amk
 amF
@@ -39460,23 +40161,23 @@ agI
 ani
 aeW
 ahS
-anP
-adu
-ahl
-apj
-apj
-apj
-apj
-apj
-apj
-apj
+bbP
+bbS
+bbG
+bbU
+bbU
+bbU
+bbd
+axS
+axS
+axS
 apu
-asH
-aqb
-aqb
-aup
-aqb
-avl
+bbY
+bca
+bca
+bcb
+bca
+bcc
 avS
 awC
 axd
@@ -39591,8 +40292,8 @@ aah
 aah
 aah
 aah
-aah
-aah
+abT
+anp
 aeW
 aml
 afT
@@ -39605,20 +40306,20 @@ anC
 adh
 adO
 ahl
-apj
-apj
-apj
-apj
-apj
-apj
-apj
-apu
-asI
+axS
+axS
+axS
+bcg
+bbU
+bbU
+bbU
+bbX
+bbZ
 atd
 atJ
 auq
 apu
-apu
+bce
 avT
 avT
 axe
@@ -39733,8 +40434,8 @@ aah
 aah
 aah
 aah
-aah
-aah
+abT
+anp
 aeW
 aft
 amG
@@ -39751,16 +40452,16 @@ aoH
 aoH
 aoH
 aoH
-apj
-apj
-apj
+apu
+apu
+apu
 apu
 aqb
 ate
 atK
 aur
 apu
-aah
+bcf
 avT
 awD
 axf
@@ -39875,8 +40576,8 @@ aah
 aah
 aah
 aah
-aah
-aah
+abT
+anp
 aeW
 amm
 amH
@@ -39902,7 +40603,7 @@ ate
 apu
 apu
 apu
-aah
+bcf
 avT
 agb
 agb
@@ -40017,8 +40718,8 @@ aah
 aah
 aah
 aah
-aah
-aah
+abT
+anp
 aeW
 afv
 amG
@@ -40042,9 +40743,9 @@ apu
 asJ
 ate
 apu
-aah
-aah
-aah
+bcd
+apu
+bcf
 avT
 agb
 agc
@@ -40159,8 +40860,8 @@ aah
 aah
 aah
 aah
-aah
-aah
+abT
+anp
 aeW
 afw
 afV
@@ -40184,9 +40885,9 @@ apu
 aqb
 arL
 apu
-aah
-aah
-aah
+bcd
+apu
+bcf
 avT
 agb
 agc
@@ -40301,8 +41002,8 @@ aah
 aah
 aah
 aah
-aah
-aah
+abT
+anp
 aeW
 afr
 afW
@@ -40326,9 +41027,9 @@ apu
 aqb
 arL
 apu
-aah
-aah
-aah
+bcd
+apu
+bbB
 avT
 agb
 agc
@@ -40443,8 +41144,8 @@ aah
 aah
 aah
 aah
-aah
-aah
+abT
+anp
 aeW
 aeW
 aeW
@@ -40468,9 +41169,9 @@ apu
 aqb
 arL
 apu
-aah
-aah
-aah
+bcd
+apu
+bcf
 avT
 agb
 agc
@@ -40585,9 +41286,9 @@ aah
 aah
 aah
 aah
-aah
-aah
-aah
+abT
+anp
+adK
 aah
 aah
 aah
@@ -40610,9 +41311,9 @@ apu
 aqb
 arL
 apu
-aah
-aah
-aah
+bcd
+apu
+bcf
 avU
 agb
 agb
@@ -40728,7 +41429,7 @@ abT
 abT
 abT
 abT
-abT
+anc
 abT
 abT
 abT
@@ -40737,8 +41438,8 @@ abT
 abT
 afA
 afA
-ahY
-aiQ
+bbM
+bbR
 aez
 aoL
 apv
@@ -40752,9 +41453,9 @@ apu
 aqb
 atf
 apu
-aah
-aah
-aah
+bcd
+apu
+bcf
 agM
 agM
 axg
@@ -40870,14 +41571,14 @@ ajI
 ajI
 ajI
 ajI
-ajI
-ajI
-ajI
-ajI
-ajI
-ajI
-anc
-anm
+asH
+asI
+asI
+asI
+asI
+asI
+aup
+avl
 ahp
 ahX
 anQ
@@ -40894,10 +41595,10 @@ apu
 aqb
 atg
 apu
-aah
-aah
-aah
-agM
+bcd
+apu
+bcf
+bbQ
 agM
 axh
 axU
@@ -41019,7 +41720,7 @@ aex
 aex
 abT
 abT
-ann
+bbI
 ahq
 ahX
 aiS
@@ -41036,10 +41737,10 @@ asq
 asK
 apu
 apu
-aah
-aah
-aah
-aah
+apu
+apu
+bce
+apu
 agM
 agM
 axV
@@ -41161,7 +41862,7 @@ afX
 aex
 aah
 abT
-ano
+bbJ
 ahr
 ahX
 anR
@@ -41177,12 +41878,12 @@ apu
 apu
 asL
 ath
-aah
-aah
-aah
-aah
-aah
-aah
+axS
+apu
+bbw
+bcg
+bci
+axS
 agM
 axW
 ayI
@@ -41303,7 +42004,7 @@ amI
 aex
 aah
 abT
-ann
+bbI
 ahq
 ahX
 anS
@@ -41319,12 +42020,12 @@ aah
 apu
 asL
 apu
-aah
-aah
-aah
-aah
-aah
-aah
+axS
+apu
+axS
+axS
+apu
+apu
 agM
 axX
 ayG
@@ -41445,7 +42146,7 @@ amJ
 aex
 aah
 abT
-ann
+bbI
 ahs
 ahZ
 aiV
@@ -41461,12 +42162,12 @@ aah
 apu
 asL
 apu
-aah
-aah
-aah
-aah
-aah
-aah
+axS
+apu
+axS
+axS
+apu
+bcd
 agM
 axY
 ayG
@@ -41587,7 +42288,7 @@ amK
 alC
 abT
 abT
-ann
+bbI
 ahs
 ahX
 anT
@@ -41606,7 +42307,7 @@ ati
 apu
 apu
 apu
-apu
+bch
 agM
 agM
 agM
@@ -41729,7 +42430,7 @@ amL
 amW
 amW
 and
-anp
+bbK
 anv
 aia
 aiX
@@ -41871,7 +42572,7 @@ amM
 abT
 abT
 abT
-abT
+bbL
 abT
 ahX
 aiY
@@ -42011,10 +42712,10 @@ afd
 afC
 agd
 abT
-aah
-aah
-aah
-aah
+amQ
+bbe
+bbE
+bbT
 ahX
 aiZ
 afc
@@ -42153,9 +42854,9 @@ aer
 aer
 aer
 aer
-aah
-aah
-aah
+anp
+abT
+abT
 agM
 agM
 aja
@@ -42290,14 +42991,14 @@ aeU
 acx
 adS
 aer
-aeC
-alY
-alY
+aeE
 age
+afD
+ail
 aer
-aah
-aah
-aah
+anp
+air
+cGJ
 agM
 anD
 anU
@@ -42434,12 +43135,12 @@ adT
 aes
 aeD
 aff
-afD
-agf
+alJ
+alY
 aer
-aah
-aah
-aah
+anp
+cGJ
+cGJ
 agM
 aic
 anV
@@ -42574,14 +43275,14 @@ aeZ
 acx
 adc
 aer
-aeE
-aeF
-aeF
-aeF
-aer
-aah
-aah
-aah
+afe
+agf
+agf
+ams
+ano
+bbE
+cGJ
+cGJ
 agM
 aid
 anW
@@ -42717,13 +43418,13 @@ adt
 adG
 aer
 aeF
-aeF
-aeF
+agf
 agg
+amN
 aer
-aah
-aah
-aah
+cGJ
+bbc
+air
 agM
 aie
 anW
@@ -42861,9 +43562,9 @@ alu
 alE
 alZ
 amr
-afe
+amO
 aer
-aah
+cGJ
 agM
 agM
 agM
@@ -43001,11 +43702,11 @@ acx
 adX
 aer
 alF
-aeF
-ams
-amN
+agf
+ahY
+anm
 aer
-aah
+cGJ
 agM
 ahc
 ahu
@@ -43145,13 +43846,13 @@ aer
 aeI
 aeF
 amt
-amO
-aer
-aah
-agM
-agM
-agM
-aih
+ann
+amc
+anF
+amc
+amc
+amc
+bbk
 anW
 aoj
 aoS
@@ -43287,12 +43988,12 @@ abL
 aeJ
 ama
 amu
-aeJ
-aeJ
-aah
-aah
-aah
-agM
+anH
+amc
+amP
+bbs
+aHM
+amc
 aii
 anW
 aoj
@@ -43430,12 +44131,12 @@ alG
 afi
 amv
 agj
-aeJ
-aah
-aah
-aah
-agM
-anE
+amw
+aIA
+bbv
+bbC
+amc
+bbl
 anX
 aoj
 aoS
@@ -43570,14 +44271,14 @@ aea
 abL
 alH
 afj
-amw
-amP
-aeJ
-aeJ
-aeJ
-aeJ
-agM
-aik
+ahe
+amb
+ane
+aQE
+bbx
+bbD
+bbW
+bbm
 anW
 aoj
 aoS
@@ -43711,15 +44412,15 @@ aeb
 aea
 abL
 aeL
-afk
-agl
-agN
-amx
-amz
-aGK
-ahd
+afP
+ago
 ahv
-ail
+amc
+baY
+bby
+bbD
+bbW
+bbn
 anW
 aoj
 aoS
@@ -43854,14 +44555,14 @@ adU
 abL
 alI
 afx
-agm
-amb
-amy
-ane
-aGO
-ahe
+agx
 ahw
-aim
+anE
+amz
+bbz
+bbV
+amc
+bbo
 anW
 aoj
 aoS
@@ -43996,14 +44697,14 @@ abL
 abL
 aeN
 afm
-agx
-agn
-aeJ
-aeJ
-aeJ
-aeJ
-agM
-anF
+agy
+aih
+amc
+bbf
+bbA
+bbF
+amc
+bbp
 anW
 aoj
 aoS
@@ -44135,17 +44836,17 @@ acI
 afB
 adA
 aec
-abL
-alJ
+aeC
+afk
 afm
-agy
-ago
-aeJ
-aah
-aah
-aah
-agM
-aio
+afN
+aik
+amc
+bbr
+amc
+bbr
+amc
+bbq
 anW
 aoj
 aoR
@@ -44279,15 +44980,15 @@ adB
 aed
 aeu
 alK
-amc
+agl
 agD
-amQ
-aeJ
-aah
-aah
-aah
-agM
-anG
+aiQ
+amx
+aGK
+bba
+bbg
+bbi
+bbu
 anW
 aoi
 aoj
@@ -44421,15 +45122,15 @@ adx
 aee
 aev
 aeQ
-afo
-afN
-agq
-aeJ
-aah
-aah
-aah
-agM
-anH
+agm
+agN
+aim
+amy
+aGO
+bbb
+bbh
+bbj
+anG
 anY
 aok
 aok
@@ -44565,13 +45266,13 @@ abL
 aeR
 afo
 afN
-agq
+aio
 aeJ
-aah
-aah
-aah
+aeJ
+aeJ
+aeJ
 agM
-air
+bbt
 anZ
 aol
 aoT
@@ -44705,7 +45406,7 @@ aiu
 abL
 abL
 aeS
-afo
+agn
 afO
 agq
 aeJ
@@ -44990,7 +45691,7 @@ aeh
 abP
 alL
 amd
-afP
+ahd
 amR
 aeJ
 aah

--- a/maps/tether/tether-01-surface1.dmm
+++ b/maps/tether/tether-01-surface1.dmm
@@ -2347,6 +2347,16 @@
 /obj/effect/floor_decal/corner/brown/border,
 /obj/effect/floor_decal/borderfloor/corner2,
 /obj/effect/floor_decal/corner/brown/bordercorner2,
+/obj/item/device/destTagger{
+	pixel_x = 4;
+	pixel_y = 3
+	},
+/obj/item/weapon/packageWrap,
+/obj/item/weapon/paper{
+	desc = "";
+	info = "There is a pipe you can send stuff through in the warehouse. This is primarily a direct pipeline between mining and cargo. However, it can mail things to the 'Research' tag. If you tag anything else, it will just go to cargo! Keep it in mind.";
+	name = "note to mining staff"
+	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/mining_main/storage)
 "adY" = (
@@ -4606,17 +4616,15 @@
 /turf/simulated/wall,
 /area/tether/surfacebase/north_stairs_one)
 "ahY" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_x = 0;
+	pixel_y = 24
 	},
 /obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+	icon_state = "0-4"
 	},
-/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/steel_dirty,
 /area/tether/surfacebase/mining_main/ore)
 "ahZ" = (
@@ -4792,7 +4800,7 @@
 	dir = 4
 	},
 /obj/machinery/conveyor{
-	dir = 8;
+	dir = 4;
 	id = "gloriouscargopipeline"
 	},
 /turf/simulated/floor/plating,
@@ -6605,6 +6613,9 @@
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 4
 	},
+/obj/structure/cable/green{
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/tiled/steel_dirty,
 /area/tether/surfacebase/mining_main/ore)
 "alF" = (
@@ -6864,7 +6875,7 @@
 	dir = 4
 	},
 /obj/machinery/conveyor{
-	dir = 8;
+	dir = 4;
 	id = "gloriouscargopipeline"
 	},
 /turf/simulated/floor/tiled/steel_dirty,
@@ -7068,7 +7079,7 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/conveyor{
-	dir = 8;
+	dir = 4;
 	id = "gloriouscargopipeline"
 	},
 /turf/simulated/floor/tiled/steel_dirty,
@@ -7331,14 +7342,14 @@
 "amN" = (
 /obj/machinery/light,
 /obj/machinery/conveyor{
-	dir = 8;
+	dir = 4;
 	id = "gloriouscargopipeline"
 	},
 /turf/simulated/floor/tiled/steel_dirty,
 /area/tether/surfacebase/mining_main/ore)
 "amO" = (
 /obj/machinery/conveyor{
-	dir = 8;
+	dir = 4;
 	id = "gloriouscargopipeline"
 	},
 /turf/simulated/floor/tiled/steel_dirty,
@@ -7352,6 +7363,7 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
+/obj/random/junk,
 /turf/simulated/floor/plating,
 /area/maintenance/lower/mining_eva)
 "amR" = (
@@ -7659,16 +7671,12 @@
 /turf/simulated/floor/tiled,
 /area/storage/primary)
 "anm" = (
-/obj/machinery/power/apc{
-	dir = 2;
-	name = "south bump";
-	pixel_y = -28
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/structure/cable/green,
-/obj/machinery/conveyor{
-	dir = 8;
-	id = "gloriouscargopipeline"
-	},
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/steel_dirty,
 /area/tether/surfacebase/mining_main/ore)
 "ann" = (
@@ -7680,7 +7688,7 @@
 	req_access = list(31)
 	},
 /obj/machinery/conveyor{
-	dir = 8;
+	dir = 4;
 	id = "gloriouscargopipeline"
 	},
 /turf/simulated/floor/tiled/steel_dirty,
@@ -7930,7 +7938,7 @@
 "anH" = (
 /obj/structure/plasticflaps,
 /obj/machinery/conveyor{
-	dir = 8;
+	dir = 4;
 	id = "gloriouscargopipeline"
 	},
 /turf/simulated/floor/plating,
@@ -12109,11 +12117,10 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/xenoflora)
 "auM" = (
-/obj/machinery/alarm{
-	pixel_y = 22
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/maintenance/lower/xenoflora)
+/obj/structure/table/rack,
+/obj/random/junk,
+/turf/simulated/floor/plating,
+/area/maintenance/lower/mining_eva)
 "auN" = (
 /obj/machinery/light{
 	dir = 8
@@ -30865,17 +30872,13 @@
 /turf/simulated/floor/plating,
 /area/maintenance/lower/mining_eva)
 "bbd" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/obj/machinery/alarm{
-	dir = 4;
-	icon_state = "alarm0";
-	pixel_x = -22
-	},
+/obj/random/cash,
+/obj/random/contraband,
+/obj/random/mre,
+/obj/structure/closet/crate,
+/obj/effect/decal/cleanable/cobweb,
 /turf/simulated/floor/plating,
-/area/maintenance/lower/xenoflora)
+/area/maintenance/lower/mining_eva)
 "bbe" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
@@ -31180,13 +31183,12 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/mining_main/surfacecargo)
 "bbw" = (
-/obj/machinery/alarm{
-	dir = 4;
-	icon_state = "alarm0";
-	pixel_x = -22
-	},
+/obj/structure/table/rack,
+/obj/random/maintenance/cargo,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/medical,
 /turf/simulated/floor/plating,
-/area/maintenance/lower/xenoflora)
+/area/maintenance/lower/mining_eva)
 "bbx" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -31245,14 +31247,13 @@
 /area/tether/surfacebase/mining_main/surfacecargo)
 "bbB" = (
 /obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-c"
 	},
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -25
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/cobweb,
 /turf/simulated/floor/plating,
-/area/maintenance/lower/xenoflora)
+/area/maintenance/lower/mining_eva)
 "bbC" = (
 /obj/structure/bed/chair/sofa/left{
 	dir = 1
@@ -31268,9 +31269,9 @@
 /area/tether/surfacebase/mining_main/surfacecargo)
 "bbE" = (
 /obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
+	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/lower/mining_eva)
 "bbF" = (
@@ -31455,9 +31456,13 @@
 /turf/simulated/mineral,
 /area/maintenance/lower/mining_eva)
 "bbU" = (
-/obj/structure/disposalpipe/segment,
+/obj/structure/table/rack,
+/obj/random/maintenance/cargo,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/engineering,
+/obj/random/maintenance/medical,
 /turf/simulated/floor/plating,
-/area/maintenance/lower/xenoflora)
+/area/maintenance/lower/mining_eva)
 "bbV" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/brown/border,
@@ -31542,33 +31547,182 @@
 /area/maintenance/lower/xenoflora)
 "bce" = (
 /obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/maintenance/lower/mining_eva)
+"bcf" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/maintenance/lower/mining_eva)
+"bcg" = (
+/obj/structure/table/rack,
+/obj/random/maintenance/cargo,
+/turf/simulated/floor/plating,
+/area/maintenance/lower/mining_eva)
+"bch" = (
+/obj/random/junk,
+/turf/simulated/floor/plating,
+/area/maintenance/lower/mining_eva)
+"bci" = (
+/obj/structure/disposalpipe/segment,
+/obj/random/junk,
+/turf/simulated/floor/plating,
+/area/maintenance/lower/mining_eva)
+"bcj" = (
+/obj/structure/table/standard,
+/obj/item/weapon/storage/firstaid/surgery,
+/obj/item/weapon/paper{
+	desc = "";
+	info = "Stop installing NIFs in here you clods! Unless it's on a synth. Otherwise, STOP DOING IT! You're killing people! -Management";
+	name = "note to science staff"
+	},
+/obj/item/device/robotanalyzer,
+/obj/item/device/robotanalyzer,
+/turf/simulated/floor/tiled/white,
+/area/space)
+"bck" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/maintenance/lower/xenoflora)
+"bcl" = (
+/obj/random/junk,
+/turf/simulated/floor/plating,
+/area/maintenance/lower/xenoflora)
+"bcm" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/lower/xenoflora)
+"bcn" = (
+/obj/structure/closet/crate,
+/obj/random/tool,
+/obj/random/tool,
+/obj/random/tool,
+/obj/random/cigarettes,
+/obj/random/coin,
+/obj/random/drinkbottle,
+/obj/effect/decal/cleanable/cobweb{
+	icon_state = "cobweb2"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/lower/xenoflora)
+"bco" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/maintenance/lower/xenoflora)
+"bcp" = (
+/obj/machinery/alarm{
+	pixel_y = 22
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/lower/xenoflora)
+"bcq" = (
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/door/airlock/maintenance/common,
 /obj/machinery/door/firedoor/glass,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/lower/xenoflora)
-"bcf" = (
+"bcr" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/lower/xenoflora)
-"bcg" = (
+"bcs" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -25
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/maintenance/lower/xenoflora)
+"bct" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
 	icon_state = "pipe-c"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/lower/xenoflora)
-"bch" = (
+"bcu" = (
 /obj/machinery/door/airlock/maintenance/common,
 /obj/machinery/door/firedoor/glass,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/xenoflora)
-"bci" = (
+"bcv" = (
 /obj/structure/disposalpipe/up{
 	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/maintenance/lower/xenoflora)
+"bcw" = (
+/obj/structure/disposalpipe/segment,
+/obj/random/junk,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/maintenance/lower/xenoflora)
+"bcx" = (
+/obj/random/junk,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/maintenance/lower/xenoflora)
+"bcy" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/alarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -22
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/maintenance/lower/xenoflora)
+"bcz" = (
+/obj/machinery/alarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -22
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/random/trash,
+/obj/effect/decal/cleanable/cobweb,
+/turf/simulated/floor/plating,
+/area/maintenance/lower/xenoflora)
+"bcA" = (
+/obj/structure/table,
+/turf/simulated/floor/plating,
+/area/maintenance/lower/xenoflora)
+"bcB" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/random/trash,
+/turf/simulated/floor/plating,
+/area/maintenance/lower/xenoflora)
+"bcC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate,
+/obj/random/unidentified_medicine,
+/obj/random/firstaid,
+/obj/random/drinkbottle,
+/obj/effect/decal/cleanable/cobweb{
+	icon_state = "cobweb2"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/lower/xenoflora)
@@ -39725,14 +39879,14 @@ aah
 aah
 aah
 abT
-cGJ
-cGJ
+bbd
+auM
 baZ
+bbw
+bbU
 cGJ
-cGJ
-cGJ
-cGJ
-cGJ
+bch
+air
 ahl
 ahK
 add
@@ -39874,7 +40028,7 @@ bbe
 bbe
 bbe
 bbe
-bbe
+bci
 bbG
 bbH
 bbN
@@ -40164,13 +40318,13 @@ ahS
 bbP
 bbS
 bbG
-bbU
-bbU
-bbU
-bbd
-axS
-axS
-axS
+bck
+bcw
+bck
+bcy
+bco
+bco
+bcl
 apu
 bbY
 bca
@@ -40306,20 +40460,20 @@ anC
 adh
 adO
 ahl
-axS
-axS
-axS
-bcg
-bbU
-bbU
-bbU
+bcn
+bco
+bcx
+bct
+bck
+bck
+bck
 bbX
 bbZ
 atd
 atJ
 auq
 apu
-bce
+bcq
 avT
 avT
 axe
@@ -40461,7 +40615,7 @@ ate
 atK
 aur
 apu
-bcf
+bcr
 avT
 awD
 axf
@@ -40603,7 +40757,7 @@ ate
 apu
 apu
 apu
-bcf
+bcr
 avT
 agb
 agb
@@ -40745,7 +40899,7 @@ ate
 apu
 bcd
 apu
-bcf
+bcr
 avT
 agb
 agc
@@ -40887,7 +41041,7 @@ arL
 apu
 bcd
 apu
-bcf
+bcB
 avT
 agb
 agc
@@ -41029,7 +41183,7 @@ arL
 apu
 bcd
 apu
-bbB
+bcs
 avT
 agb
 agc
@@ -41171,7 +41325,7 @@ arL
 apu
 bcd
 apu
-bcf
+bcr
 avT
 agb
 agc
@@ -41313,7 +41467,7 @@ arL
 apu
 bcd
 apu
-bcf
+bcr
 avU
 agb
 agb
@@ -41455,7 +41609,7 @@ atf
 apu
 bcd
 apu
-bcf
+bcr
 agM
 agM
 axg
@@ -41597,7 +41751,7 @@ atg
 apu
 bcd
 apu
-bcf
+bcr
 bbQ
 agM
 axh
@@ -41739,7 +41893,7 @@ apu
 apu
 apu
 apu
-bce
+bcq
 apu
 agM
 agM
@@ -41880,10 +42034,10 @@ asL
 ath
 axS
 apu
-bbw
-bcg
-bci
-axS
+bcz
+bct
+bcv
+bco
 agM
 axW
 ayI
@@ -42022,8 +42176,8 @@ asL
 apu
 axS
 apu
-axS
-axS
+bcA
+bco
 apu
 apu
 agM
@@ -42164,8 +42318,8 @@ asL
 apu
 axS
 apu
-axS
-axS
+bcC
+bco
 apu
 bcd
 agM
@@ -42307,7 +42461,7 @@ ati
 apu
 apu
 apu
-bch
+bcu
 agM
 agM
 agM
@@ -42447,9 +42601,9 @@ apu
 asL
 atj
 atL
-atL
-atL
-atL
+bcm
+bcm
+bcm
 agM
 ahc
 ahu
@@ -42590,8 +42744,8 @@ asL
 apu
 agM
 agM
-atL
-atL
+bcm
+bcm
 agM
 agM
 agM
@@ -42712,9 +42866,9 @@ afd
 afC
 agd
 abT
-amQ
+bbB
 bbe
-bbE
+bce
 bbT
 ahX
 aiZ
@@ -42732,9 +42886,9 @@ asL
 apu
 ahc
 agM
-auM
-atL
-atL
+bcp
+bcm
+bcm
 atL
 atj
 ayc
@@ -42854,7 +43008,7 @@ aer
 aer
 aer
 aer
-anp
+bbE
 abT
 abT
 agM
@@ -42996,9 +43150,9 @@ age
 afD
 ail
 aer
-anp
+bbE
 air
-cGJ
+bcg
 agM
 anD
 anU
@@ -43138,9 +43292,9 @@ aff
 alJ
 alY
 aer
-anp
-cGJ
-cGJ
+bbE
+bcf
+bcg
 agM
 aic
 anV
@@ -43280,8 +43434,8 @@ agf
 agf
 ams
 ano
-bbE
-cGJ
+bce
+bcf
 cGJ
 agM
 aid
@@ -43417,12 +43571,12 @@ afl
 adt
 adG
 aer
-aeF
+ahY
 agf
 agg
 amN
 aer
-cGJ
+bcf
 bbc
 air
 agM
@@ -43564,7 +43718,7 @@ alZ
 amr
 amO
 aer
-cGJ
+bcf
 agM
 agM
 agM
@@ -43703,8 +43857,8 @@ adX
 aer
 alF
 agf
-ahY
 anm
+amO
 aer
 cGJ
 agM
@@ -45695,7 +45849,7 @@ ahd
 amR
 aeJ
 aah
-aah
+bcj
 aah
 ahx
 ait

--- a/maps/tether/tether-02-surface2.dmm
+++ b/maps/tether/tether-02-surface2.dmm
@@ -4548,10 +4548,21 @@
 /turf/simulated/floor/plating,
 /area/maintenance/lower/rnd)
 "jO" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/symbol/da{
-	pixel_x = 32
+/obj/structure/cable{
+	icon_state = "16-0"
 	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/up,
 /turf/simulated/floor/plating,
 /area/maintenance/lower/rnd)
 "jP" = (
@@ -6100,20 +6111,8 @@
 /turf/simulated/floor/plating,
 /area/maintenance/lower/rnd)
 "my" = (
-/obj/structure/cable{
-	icon_state = "16-0"
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/effect/floor_decal/industrial/outline/yellow,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/lower/rnd)
 "mz" = (
@@ -25644,6 +25643,14 @@
 	},
 /turf/simulated/floor,
 /area/tether/surfacebase/security/gasstorage)
+"UE" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/maintenance/lower/rnd)
 "UF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/green{
 	icon_state = "intact";
@@ -27380,6 +27387,30 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/interrogation)
+"WQ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/lower/rnd)
+"WR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/lower/rnd)
+"WS" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/symbol/da{
+	pixel_x = 32
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/maintenance/lower/rnd)
 "WT" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -27398,6 +27429,14 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/lowerhallway)
+"WU" = (
+/obj/structure/lattice,
+/obj/machinery/door/firedoor/glass,
+/obj/structure/disposalpipe/down{
+	dir = 4
+	},
+/turf/simulated/open,
+/area/maintenance/lower/rnd)
 "Xa" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -37757,7 +37796,7 @@ ii
 ii
 ii
 ii
-il
+WU
 il
 oA
 oY
@@ -37893,13 +37932,13 @@ im
 mx
 iV
 jk
-il
-il
-jO
-il
-il
-il
-il
+WQ
+my
+WS
+my
+my
+my
+WR
 il
 dY
 oZ
@@ -38032,10 +38071,10 @@ iA
 lP
 ge
 il
+jO
 my
-il
-jf
-il
+UE
+WR
 ii
 ii
 dY

--- a/maps/tether/tether-03-surface3.dmm
+++ b/maps/tether/tether-03-surface3.dmm
@@ -2822,17 +2822,20 @@
 /turf/simulated/wall,
 /area/crew_quarters/recreation_area_restroom)
 "fk" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/machinery/door/firedoor,
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "32-4"
 	},
-/obj/structure/disposalpipe/segment{
+/obj/structure/lattice,
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_x = 0
+	},
+/obj/machinery/door/firedoor/glass,
+/obj/structure/disposalpipe/down{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/rnd/research_storage)
+/turf/simulated/open,
+/area/tether/surfacebase/atrium_three)
 "fl" = (
 /obj/machinery/recharger/wallcharger{
 	pixel_x = 30;
@@ -3173,14 +3176,14 @@
 /turf/simulated/wall,
 /area/rnd/research_storage)
 "fN" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/machinery/door/firedoor,
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/rnd/research_storage)
+/area/tether/surfacebase/atrium_three)
 "fO" = (
 /obj/machinery/door/airlock{
 	name = "Unit 1"
@@ -3577,15 +3580,16 @@
 /turf/simulated/wall,
 /area/tether/surfacebase/atrium_three)
 "gx" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/machinery/door/firedoor,
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/machinery/door/firedoor/glass,
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/airlock/maintenance/common,
 /turf/simulated/floor/plating,
-/area/rnd/research_storage)
+/area/tether/surfacebase/atrium_three)
 "gy" = (
 /obj/machinery/atmospherics/pipe/simple/visible/supply,
 /obj/machinery/atmospherics/pipe/simple/visible/scrubbers,
@@ -3598,40 +3602,67 @@
 /turf/simulated/floor/plating,
 /area/rnd/research_storage)
 "gz" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/structure/table/steel,
-/obj/item/weapon/implantcase/chem,
-/obj/machinery/light/small{
+/obj/effect/floor_decal/borderfloor{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/rust,
-/turf/simulated/floor/plating,
-/area/rnd/research_storage)
-"gA" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 8
 	},
-/obj/structure/table/steel,
-/obj/random/tech_supply,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/rust,
-/turf/simulated/floor/plating,
-/area/rnd/research_storage)
-"gB" = (
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 6
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 5
+	},
 /obj/structure/disposalpipe/segment{
-	dir = 8;
+	dir = 2;
 	icon_state = "pipe-c"
 	},
-/obj/structure/table/steel,
-/obj/item/weapon/locator,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/rust,
-/turf/simulated/floor/plating,
-/area/rnd/research_storage)
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/atrium_three)
+"gA" = (
+/obj/structure/extinguisher_cabinet{
+	dir = 4;
+	icon_state = "extinguisher_closed";
+	pixel_x = -30
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 6
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 5
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/atrium_three)
+"gB" = (
+/obj/machinery/camera/network/tether{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 6
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 5
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/atrium_three)
 "gC" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/zpipe/down{
@@ -3665,11 +3696,25 @@
 /turf/simulated/floor/plating,
 /area/rnd/research_storage)
 "gE" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/rust,
-/turf/simulated/floor/plating,
-/area/rnd/research_storage)
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 6
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 5
+	},
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/atrium_three)
 "gF" = (
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/recreation_area_restroom)
@@ -3950,10 +3995,21 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/tether/surfacebase/atrium_three)
 "he" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/rnd/research_storage)
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey/bordercorner{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 5
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/atrium_three)
 "hf" = (
 /turf/simulated/floor/tiled,
 /area/rnd/research/researchdivision)
@@ -4013,19 +4069,18 @@
 /turf/simulated/floor/plating,
 /area/rnd/research_storage)
 "hl" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
+	dir = 4
 	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/rnd/research_storage)
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/atrium_three)
 "hm" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -8359,21 +8414,17 @@
 /turf/simulated/wall,
 /area/rnd/staircase/thirdfloor)
 "oz" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 8
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/lightgrey/border,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 1
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 6
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 5
-	},
-/obj/machinery/light{
-	icon_state = "tube1";
 	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/atrium_three)
@@ -9178,46 +9229,66 @@
 	name = "\improper Recreation Area Showers"
 	})
 "pX" = (
-/obj/structure/cable{
-	icon_state = "32-4"
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/lightgrey/border,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 1
 	},
-/obj/structure/lattice,
-/obj/machinery/light/small{
-	dir = 8;
-	pixel_x = 0
-	},
-/obj/machinery/door/firedoor/glass,
-/turf/simulated/open,
-/area/tether/surfacebase/atrium_three)
-"pY" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/tether/surfacebase/atrium_three)
-"pZ" = (
-/obj/machinery/door/airlock/maintenance/engi,
-/obj/machinery/door/firedoor/glass,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/tether/surfacebase/atrium_three)
-"qa" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/floor_decal/borderfloor{
+/obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 8
 	},
-/obj/effect/floor_decal/corner/lightgrey/border{
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/atrium_three)
+"pY" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/lightgrey/border,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 8
+	},
+/obj/machinery/computer/timeclock/premade/south,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/atrium_three)
+"pZ" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/lightgrey/border,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/glass,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/atrium_three)
+"qa" = (
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/lightgrey/bordercorner{
 	dir = 8
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 6
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 5
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/atrium_three)
@@ -9734,24 +9805,12 @@
 /turf/simulated/floor/plating,
 /area/tether/surfacebase/atrium_three)
 "qP" = (
-/obj/structure/extinguisher_cabinet{
-	dir = 4;
-	icon_state = "extinguisher_closed";
-	pixel_x = -30
-	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 8
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 6
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 5
-	},
-/turf/simulated/floor/tiled,
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/machinery/door/firedoor,
+/obj/structure/window/reinforced,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
 /area/tether/surfacebase/atrium_three)
 "qQ" = (
 /obj/structure/cable{
@@ -10009,23 +10068,11 @@
 	name = "\improper Recreation Area Showers"
 	})
 "rn" = (
-/obj/machinery/camera/network/tether{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 8
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 6
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 5
-	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/atrium_three)
+/turf/simulated/floor/outdoors/grass/sif/virgo3b,
+/area/tether/surfacebase/outside/outside3)
 "ro" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -10505,20 +10552,12 @@
 /turf/simulated/floor/tiled,
 /area/rnd/outpost/xenobiology/outpost_north_airlock)
 "se" = (
-/obj/effect/floor_decal/borderfloor/corner{
-	dir = 1
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
-/obj/effect/floor_decal/corner/lightgrey/bordercorner{
-	dir = 1
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 5
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/atrium_three)
+/turf/simulated/floor/outdoors/grass/sif/virgo3b,
+/area/tether/surfacebase/outside/outside3)
 "sf" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -18469,17 +18508,14 @@
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
 "Ei" = (
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/lightgrey/border,
-/obj/effect/floor_decal/steeldecal/steel_decals7{
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/machinery/door/firedoor,
+/obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 8
-	},
-/obj/machinery/computer/timeclock/premade/south,
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/atrium_three)
+/turf/simulated/floor/plating,
+/area/rnd/research_storage)
 "Ej" = (
 /obj/structure/bed/chair/wood,
 /obj/structure/window/basic{
@@ -30164,10 +30200,103 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/outpost/xenobiology/outpost_first_aid)
 "XG" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/machinery/door/firedoor,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/rnd/research_storage)
+"XH" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/table/steel,
+/obj/item/weapon/implantcase/chem,
+/turf/simulated/floor/plating,
+/area/rnd/research_storage)
+"XI" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/table/steel,
+/obj/random/tech_supply,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/rust,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/rnd/research_storage)
+"XJ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/table/steel,
+/obj/item/weapon/locator,
+/turf/simulated/floor/plating,
+/area/rnd/research_storage)
+"XK" = (
 /obj/structure/shuttle/engine/propulsion,
 /turf/simulated/floor/reinforced,
 /turf/simulated/shuttle/plating/carry,
 /area/shuttle/tether/surface)
+"XL" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/rnd/research_storage)
+"XM" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/rnd/research_storage)
+"XN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/rust,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/rnd/research_storage)
+"XO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/rust,
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plating,
+/area/rnd/research_storage)
+"XP" = (
+/obj/structure/disposalpipe/up{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/rnd/research_storage)
+"XQ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor/plating,
+/area/rnd/research_storage)
+"XR" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/rnd/research_storage)
 "Zf" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -38195,7 +38324,7 @@ ac
 ac
 ac
 ac
-ac
+fF
 ac
 ac
 ac
@@ -38336,8 +38465,8 @@ fj
 fj
 fj
 ac
-ac
-ad
+fM
+fM
 fM
 fM
 fM
@@ -38478,10 +38607,10 @@ fQ
 wL
 fj
 ac
-ac
-ac
-fN
-gz
+Ei
+XH
+XM
+XN
 gD
 hk
 iz
@@ -38619,13 +38748,13 @@ vF
 fj
 fj
 fj
-ac
-ac
-ac
-fN
-gA
-gE
-hl
+fi
+XG
+XI
+XM
+XO
+XQ
+XR
 iA
 tF
 wD
@@ -38761,12 +38890,12 @@ gF
 fP
 wM
 fj
-ac
-ac
-fi
-gx
-gB
-he
+rn
+Ei
+XJ
+fh
+XL
+fh
 hm
 jy
 tE
@@ -38903,11 +39032,11 @@ wm
 fj
 fj
 fj
-ac
+rn
 fh
-fk
+XL
 fh
-fh
+XP
 fh
 hn
 jE
@@ -39045,7 +39174,7 @@ wo
 fO
 wM
 fj
-ac
+rn
 fh
 fL
 gy
@@ -39187,7 +39316,7 @@ fj
 fj
 fj
 fj
-ac
+rn
 tG
 ud
 ud
@@ -39329,7 +39458,7 @@ ha
 ss
 sR
 gw
-ac
+rn
 tG
 ud
 ux
@@ -39469,9 +39598,9 @@ kE
 kE
 kE
 st
-kx
-lP
-ac
+oz
+qP
+se
 tG
 ud
 ux
@@ -39611,7 +39740,7 @@ pS
 pS
 pS
 jR
-kx
+pX
 lP
 ac
 tG
@@ -39753,7 +39882,7 @@ rk
 hc
 rX
 su
-kx
+pX
 gw
 ac
 tG
@@ -39895,7 +40024,7 @@ oX
 oX
 rY
 jX
-kx
+pX
 lP
 ac
 tG
@@ -40037,7 +40166,7 @@ pv
 oX
 rZ
 sv
-kx
+pX
 lP
 ac
 ts
@@ -40179,7 +40308,7 @@ rl
 oX
 hs
 sw
-kx
+pX
 gw
 ac
 ac
@@ -40321,7 +40450,7 @@ rm
 oX
 sa
 sx
-kx
+pX
 lP
 ac
 ac
@@ -40463,7 +40592,7 @@ py
 oX
 ix
 jR
-kx
+pX
 lP
 ac
 ac
@@ -40605,7 +40734,7 @@ gw
 oX
 sc
 jR
-kx
+pX
 gw
 ac
 ac
@@ -40741,13 +40870,13 @@ ne
 ne
 lc
 pz
-pX
+fk
 qN
 gw
 rE
 ix
 jR
-Ei
+pY
 gw
 ts
 ts
@@ -40883,13 +41012,13 @@ ne
 ne
 lc
 iv
-pY
+fN
 qO
 gw
 rF
 ix
 jR
-kx
+pX
 gw
 ts
 tH
@@ -41025,13 +41154,13 @@ lc
 lc
 lc
 gw
-pZ
+gx
 gw
 gw
 gw
 jj
 sy
-kC
+pZ
 gw
 ts
 ts
@@ -41167,13 +41296,13 @@ oi
 oC
 oY
 pB
+gz
+gA
+gB
+gE
+he
+hl
 qa
-qP
-rn
-oz
-se
-jR
-sS
 ha
 tt
 ha
@@ -44049,7 +44178,7 @@ Nk
 Nl
 NJ
 NP
-XG
+XK
 KU
 bg
 Ok
@@ -44191,7 +44320,7 @@ Nl
 Nl
 NK
 NP
-XG
+XK
 KU
 bg
 Ok
@@ -44333,7 +44462,7 @@ Nm
 Nl
 NK
 NP
-XG
+XK
 KU
 bg
 Ok

--- a/maps/tether/tether-03-surface3.dmm
+++ b/maps/tether/tether-03-surface3.dmm
@@ -11896,14 +11896,11 @@
 /area/rnd/research)
 "ut" = (
 /obj/machinery/camera/network/research,
-/obj/effect/floor_decal/borderfloor{
-	dir = 9
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 4
 	},
-/obj/effect/floor_decal/corner/mauve/border{
-	dir = 9
-	},
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 10
+/obj/effect/floor_decal/corner/mauve/bordercorner{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/research/researchdivision)
@@ -13602,23 +13599,12 @@
 /turf/simulated/wall,
 /area/library)
 "xh" = (
-/obj/machinery/disposal,
-/obj/effect/floor_decal/borderfloor{
-	dir = 8;
-	icon_state = "borderfloor";
-	pixel_x = 0
+/obj/structure/disposalpipe/junction{
+	icon_state = "pipe-j2";
+	dir = 2
 	},
-/obj/effect/floor_decal/corner/mauve/border{
-	dir = 8
-	},
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/mauve/bordercorner2{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/rnd/research)
+/turf/simulated/floor/plating,
+/area/rnd/research_storage)
 "xi" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
@@ -14299,27 +14285,12 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "yi" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/borderfloor{
-	dir = 4
+/obj/structure/disposalpipe/sortjunction{
+	name = "Research";
+	sortType = "Research"
 	},
-/obj/effect/floor_decal/corner/mauve/border{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 6
-	},
-/obj/effect/floor_decal/corner/mauve/bordercorner2{
-	dir = 6
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 9
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 10
-	},
-/turf/simulated/floor/tiled,
-/area/rnd/research/researchdivision)
+/turf/simulated/floor/plating,
+/area/rnd/research_storage)
 "yj" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 6
@@ -14487,21 +14458,16 @@
 /turf/simulated/floor/tiled,
 /area/rnd/research/researchdivision)
 "yv" = (
-/obj/structure/disposalpipe/sortjunction{
-	name = "Research";
-	sortType = "Research"
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/effect/floor_decal/borderfloor/corner{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/mauve/bordercorner{
-	dir = 1
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 5
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/research/researchdivision)
@@ -14602,21 +14568,27 @@
 /turf/simulated/floor/tiled,
 /area/hallway/lower/third_south)
 "yH" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+/obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/effect/floor_decal/corner/mauve/border{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
+/obj/effect/floor_decal/corner/mauve/bordercorner2{
+	dir = 6
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 9
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 10
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/research/researchdivision)
@@ -14946,56 +14918,44 @@
 /turf/simulated/floor/tiled,
 /area/rnd/research_foyer)
 "zc" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/machinery/door/firedoor/glass/hidden/steel{
+/turf/simulated/floor/plating,
+/area/rnd/research)
+"zd" = (
+/obj/machinery/disposal,
+/obj/effect/floor_decal/borderfloor{
+	dir = 8;
+	icon_state = "borderfloor";
+	pixel_x = 0
+	},
+/obj/effect/floor_decal/corner/mauve/border{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/effect/floor_decal/corner/mauve/bordercorner2{
+	dir = 8
 	},
-/turf/simulated/floor/tiled,
-/area/rnd/research/researchdivision)
-"zd" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/structure/disposalpipe/trunk{
+	dir = 8
 	},
 /turf/simulated/floor/tiled,
-/area/rnd/research/researchdivision)
+/area/rnd/research)
 "ze" = (
-/obj/machinery/hologram/holopad,
 /obj/structure/cable/green{
 	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/rnd/research/researchdivision)
 "zf" = (
@@ -15389,11 +15349,15 @@
 "zJ" = (
 /obj/structure/cable/green{
 	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/glass/hidden/steel{
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/rnd/research/researchdivision)
 "zK" = (
@@ -15776,27 +15740,29 @@
 /turf/simulated/floor/tiled,
 /area/rnd/research/testingrange)
 "Am" = (
-/obj/machinery/door/firedoor/glass,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/glass_research{
-	name = "Weapons Testing Range";
-	req_access = list(47)
-	},
-/turf/simulated/floor/tiled,
-/area/rnd/research/testingrange)
-"An" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/mauve/border{
 	dir = 1
 	},
-/obj/structure/disposalpipe/trunk,
-/obj/machinery/disposal,
+/turf/simulated/floor/tiled,
+/area/rnd/research/researchdivision)
+"An" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/junction{
+	icon_state = "pipe-j1";
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/rnd/research/researchdivision)
 "Ao" = (
@@ -16239,13 +16205,19 @@
 /turf/simulated/floor/tiled,
 /area/rnd/research/researchdivision)
 "AT" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/corner/mauve/bordercorner{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 5
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/obj/structure/disposalpipe/junction,
 /turf/simulated/floor/tiled,
 /area/rnd/research/researchdivision)
 "AU" = (
@@ -16682,15 +16654,26 @@
 /area/tether/surfacebase/atrium_three)
 "Bp" = (
 /obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
 /turf/simulated/floor/tiled,
-/area/rnd/research/testingrange)
+/area/rnd/research/researchdivision)
 "Bq" = (
 /obj/structure/table/woodentable,
 /obj/item/device/taperecorder,
@@ -16749,27 +16732,21 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/item/device/radio/intercom{
-	dir = 1;
-	pixel_y = 24;
-	req_access = list()
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 1;
-	icon_state = "borderfloor";
-	pixel_y = 0
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/obj/effect/floor_decal/corner/mauve/border{
-	dir = 1
-	},
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/mauve/bordercorner2{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
-/area/rnd/research/testingrange)
+/area/rnd/research/researchdivision)
 "Bx" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -17100,15 +17077,22 @@
 /area/rnd/research/testingrange)
 "BX" = (
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor/glass/hidden/steel{
-	dir = 1
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/rnd/research/researchdivision)
 "BY" = (
@@ -17409,19 +17393,15 @@
 /turf/simulated/floor/tiled,
 /area/rnd/research/researchdivision)
 "Ct" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 4
+	dir = 5
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/rnd/research/researchdivision)
 "Cu" = (
@@ -17528,16 +17508,19 @@
 /turf/simulated/floor/tiled,
 /area/rnd/research/testingrange)
 "CD" = (
+/obj/machinery/door/firedoor/glass,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 5
+/obj/machinery/door/airlock/glass_research{
+	name = "Weapons Testing Range";
+	req_access = list(47)
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
-/area/rnd/research/researchdivision)
+/area/rnd/research/testingrange)
 "CE" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -19462,46 +19445,35 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/steel_dirty,
-/area/rnd/research/researchdivision)
-"FN" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 5
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 6
-	},
-/obj/structure/disposalpipe/junction{
-	icon_state = "pipe-j2";
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/research/researchdivision)
+"FN" = (
+/obj/structure/table/reinforced,
+/obj/machinery/recharger/wallcharger{
+	pixel_x = 4;
+	pixel_y = 28
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 1;
+	icon_state = "borderfloor";
+	pixel_y = 0
+	},
+/obj/effect/floor_decal/corner/mauve/border{
+	dir = 1
+	},
+/obj/item/weapon/storage/bag/trash,
+/obj/item/weapon/storage/bag/trash,
+/turf/simulated/floor/tiled,
+/area/rnd/research/testingrange)
 "FO" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -19537,24 +19509,19 @@
 /area/rnd/research/researchdivision)
 "FQ" = (
 /obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/green{
 	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/tiled,
-/area/rnd/research/researchdivision)
+/area/rnd/research/testingrange)
 "FR" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -19912,15 +19879,6 @@
 /turf/simulated/floor/tiled,
 /area/rnd/outpost/xenobiology/outpost_north_airlock)
 "Gq" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 10
-	},
-/obj/effect/floor_decal/corner/mauve/border{
-	dir = 10
-	},
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 8
-	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 8;
@@ -19932,6 +19890,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
+/obj/effect/floor_decal/borderfloor/corner,
+/obj/effect/floor_decal/corner/mauve/bordercorner,
 /turf/simulated/floor/tiled,
 /area/rnd/research/researchdivision)
 "Gr" = (
@@ -19981,32 +19941,41 @@
 /turf/simulated/floor/tiled,
 /area/rnd/outpost/xenobiology/outpost_hallway)
 "Gu" = (
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/mauve/border,
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 8
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 1
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor/glass/hidden/steel{
-	dir = 1
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/research/researchdivision)
 "Gv" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/borderfloor/corner{
-	dir = 8
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/corner/mauve/bordercorner{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 6
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 1
+/obj/structure/disposalpipe/sortjunction{
+	name = "Research";
+	sortType = "Research"
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/research/researchdivision)
@@ -30241,10 +30210,27 @@
 /turf/simulated/floor/plating,
 /area/rnd/research_storage)
 "XK" = (
-/obj/structure/shuttle/engine/propulsion,
-/turf/simulated/floor/reinforced,
-/turf/simulated/shuttle/plating/carry,
-/area/shuttle/tether/surface)
+/obj/machinery/hologram/holopad,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	icon_state = "map-scrubbers";
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled,
+/area/rnd/research/researchdivision)
 "XL" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
@@ -30255,9 +30241,23 @@
 /turf/simulated/floor/plating,
 /area/rnd/research_storage)
 "XM" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plating,
-/area/rnd/research_storage)
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/mauve/border,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/glass/hidden/steel{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled,
+/area/rnd/research/researchdivision)
 "XN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/rust,
@@ -30297,6 +30297,75 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/rnd/research_storage)
+"XS" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/mauve/bordercorner{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 6
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/rnd/research/researchdivision)
+"XT" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled,
+/area/rnd/research/researchdivision)
+"XU" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/item/device/radio/intercom{
+	dir = 1;
+	pixel_y = 24;
+	req_access = list()
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 1;
+	icon_state = "borderfloor";
+	pixel_y = 0
+	},
+/obj/effect/floor_decal/corner/mauve/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/mauve/bordercorner2{
+	dir = 4
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/machinery/disposal,
+/turf/simulated/floor/tiled,
+/area/rnd/research/testingrange)
+"XV" = (
+/obj/structure/shuttle/engine/propulsion,
+/turf/simulated/floor/reinforced,
+/turf/simulated/shuttle/plating/carry,
+/area/shuttle/tether/surface)
 "Zf" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -37346,10 +37415,10 @@ fK
 fK
 oy
 ut
-FM
+Bp
 Gq
 zL
-Bb
+FN
 BW
 BW
 JG
@@ -37487,8 +37556,8 @@ xF
 yr
 Be
 fK
-An
-FN
+Am
+FM
 Cf
 zL
 Bb
@@ -37913,11 +37982,11 @@ xO
 yN
 Bj
 Fl
+An
+Bw
 Ct
-FQ
 CD
-Am
-Bp
+FQ
 BW
 BW
 JK
@@ -38059,7 +38128,7 @@ Bf
 FR
 CK
 zL
-Bw
+XU
 BW
 CB
 JL
@@ -38482,8 +38551,8 @@ zG
 fK
 fK
 yR
-zc
 Gu
+XM
 zL
 zL
 zL
@@ -38609,7 +38678,7 @@ fj
 ac
 Ei
 XH
-XM
+xh
 XN
 gD
 hk
@@ -38623,9 +38692,9 @@ xP
 Ar
 yu
 Fm
-yv
-zd
+AT
 Gv
+XS
 GR
 HI
 It
@@ -38751,7 +38820,7 @@ fj
 fi
 XG
 XI
-XM
+yi
 XO
 XQ
 XR
@@ -38761,13 +38830,13 @@ wD
 xI
 xN
 yO
-AT
-AT
-BX
-AT
-yH
+yv
 ze
 zJ
+ze
+BX
+XK
+XT
 Ao
 BL
 hf
@@ -38903,7 +38972,7 @@ wx
 wB
 xD
 xH
-yi
+yH
 wB
 yQ
 AM
@@ -39045,7 +39114,7 @@ tU
 uY
 uY
 wE
-uY
+zc
 uY
 tU
 AS
@@ -39187,7 +39256,7 @@ ur
 vt
 vS
 wK
-xh
+zd
 xC
 uY
 AW
@@ -44178,7 +44247,7 @@ Nk
 Nl
 NJ
 NP
-XK
+XV
 KU
 bg
 Ok
@@ -44320,7 +44389,7 @@ Nl
 Nl
 NK
 NP
-XK
+XV
 KU
 bg
 Ok
@@ -44462,7 +44531,7 @@ Nm
 Nl
 NK
 NP
-XK
+XV
 KU
 bg
 Ok

--- a/maps/tether/tether-04-transit.dmm
+++ b/maps/tether/tether-04-transit.dmm
@@ -21,6 +21,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
+/obj/machinery/alarm{
+	pixel_y = 26
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/tether_midpoint)
 "d" = (
@@ -49,23 +52,15 @@
 /turf/simulated/floor/holofloor/tiled/dark,
 /area/tether/elevator)
 "g" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/door/airlock/maintenance/engi,
+/obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/plating,
-/area/maintenance/tether_midpoint)
+/area/tether/midpoint)
 "h" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -92,6 +87,7 @@
 	},
 /obj/structure/disposalpipe/down,
 /obj/effect/ceiling,
+/obj/machinery/door/firedoor/glass,
 /turf/simulated/open,
 /area/maintenance/tether_midpoint)
 "j" = (
@@ -214,7 +210,10 @@
 	icon_state = "1-2";
 	pixel_y = 0
 	},
-/turf/simulated/floor/plating,
+/obj/structure/lattice,
+/obj/structure/disposalpipe/down,
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/open,
 /area/maintenance/tether_midpoint)
 "u" = (
 /obj/effect/step_trigger/teleporter/planetary_fall/virgo3b,
@@ -229,15 +228,19 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
+/obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/plating,
 /area/tether/midpoint)
 "w" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
-/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
 /obj/structure/window/reinforced{
 	dir = 4
 	},
+/obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/plating,
 /area/tether/midpoint)
 "x" = (
@@ -271,10 +274,17 @@
 	pixel_x = -24
 	},
 /obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/tether_midpoint)
 "A" = (
 /obj/effect/ceiling,
+/obj/structure/disposalpipe/up{
+	dir = 8
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/tether_midpoint)
 "B" = (
@@ -313,19 +323,32 @@
 /turf/simulated/floor/plating,
 /area/maintenance/tether_midpoint)
 "H" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/door/airlock/maintenance/engi,
+/obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/plating,
-/area/tether/midpoint)
+/area/maintenance/tether_midpoint)
 "I" = (
 /obj/structure/closet,
 /obj/random/plushie,
 /turf/simulated/floor/plating,
 /area/maintenance/tether_midpoint)
+"J" = (
+/turf/simulated/floor/wood,
+/area/space)
 "K" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -341,15 +364,14 @@
 	},
 /turf/simulated/floor/wood,
 /area/tether/midpoint)
-"N" = (
+"M" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
+/obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 4
 	},
+/obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/plating,
 /area/tether/midpoint)
 "O" = (
@@ -10177,7 +10199,7 @@ u
 u
 u
 b
-g
+H
 d
 d
 f
@@ -10601,7 +10623,7 @@ u
 u
 u
 u
-H
+g
 k
 q
 q
@@ -10612,7 +10634,7 @@ F
 q
 E
 p
-H
+g
 u
 u
 u
@@ -10743,10 +10765,10 @@ u
 u
 u
 u
-H
+g
 U
 q
-q
+J
 T
 n
 n
@@ -10754,7 +10776,7 @@ R
 q
 q
 U
-H
+g
 u
 u
 u
@@ -10885,7 +10907,7 @@ u
 u
 u
 u
-H
+g
 n
 q
 q
@@ -10896,7 +10918,7 @@ F
 q
 q
 n
-H
+g
 u
 u
 u
@@ -11027,7 +11049,7 @@ u
 u
 u
 u
-H
+g
 L
 q
 q
@@ -11038,7 +11060,7 @@ q
 q
 q
 L
-H
+g
 u
 u
 u
@@ -11170,17 +11192,17 @@ u
 u
 u
 v
-N
-N
-N
-N
-N
-N
-N
-N
-N
-N
 w
+w
+w
+w
+w
+w
+w
+w
+w
+w
+M
 u
 u
 u

--- a/maps/tether/tether-05-station1.dmm
+++ b/maps/tether/tether-05-station1.dmm
@@ -1486,6 +1486,16 @@
 	},
 /turf/simulated/floor/grass,
 /area/hallway/station/atrium)
+"adb" = (
+/obj/machinery/door/blast/shutters{
+	dir = 2;
+	id = "surfcargooffice";
+	layer = 3.3;
+	name = "Cargo Office Shutters"
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/tiled/dark,
+/area/gateway)
 "adc" = (
 /obj/structure/bed/chair/wood{
 	dir = 8
@@ -5646,11 +5656,22 @@
 /turf/simulated/floor/tiled/dark,
 /area/gateway/prep_room)
 "akc" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /obj/machinery/door/blast/shutters{
-	dir = 8;
-	id = "PubPrep";
+	dir = 2;
+	id = "surfcargooffice";
 	layer = 3.3;
-	name = "Public Access Shutter"
+	name = "Cargo Office Shutters"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/tiled/dark,
@@ -5831,26 +5852,15 @@
 /turf/simulated/floor/tiled,
 /area/gateway/prep_room)
 "akv" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/door/blast/shutters{
-	dir = 8;
-	id = "PubPrep";
-	layer = 3.3;
-	name = "Public Access Shutter"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/lattice,
 /obj/machinery/door/firedoor/glass,
-/turf/simulated/floor/tiled/dark,
-/area/gateway)
+/obj/structure/disposalpipe/down{
+	dir = 8
+	},
+/turf/simulated/open,
+/area/maintenance/station/eng_lower)
 "akw" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -6995,6 +7005,49 @@
 /obj/item/weapon/reagent_containers/food/snacks/donut/jelly,
 /turf/simulated/floor/wood,
 /area/hallway/station/atrium)
+"amz" = (
+/obj/machinery/alarm{
+	pixel_y = 22
+	},
+/obj/structure/table/rack{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/engineering,
+/obj/random/tool,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/random/maintenance/engineering,
+/obj/random/maintenance/clean,
+/turf/simulated/floor,
+/area/maintenance/station/eng_lower)
+"amA" = (
+/obj/structure/disposalpipe/up{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor,
+/area/maintenance/station/eng_lower)
+"amB" = (
+/obj/machinery/atmospherics/valve/digital/open,
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/maintenance/station/eng_lower)
 "amC" = (
 /obj/structure/table/woodentable,
 /obj/machinery/door/blast/shutters{
@@ -9408,6 +9461,20 @@
 /area/maintenance/abandonedlibraryconference)
 "arb" = (
 /obj/machinery/atmospherics/valve/digital/open,
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor,
 /area/maintenance/station/eng_lower)
 "arc" = (
@@ -9417,8 +9484,15 @@
 /turf/simulated/floor/wood,
 /area/maintenance/abandonedlibraryconference)
 "ard" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/structure/reagent_dispensers/watertank,
+/obj/structure/railing{
+	icon_state = "railing0";
+	dir = 1
+	},
 /turf/simulated/floor,
 /area/maintenance/station/eng_lower)
 "are" = (
@@ -10029,6 +10103,28 @@
 /obj/machinery/floodlight,
 /turf/simulated/floor,
 /area/storage/emergency_storage/emergency4)
+"asv" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/structure/railing,
+/obj/random/junk,
+/turf/simulated/floor/plating,
+/area/maintenance/station/eng_lower)
 "asw" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green,
 /obj/machinery/atmospherics/pipe/simple/visible/green{
@@ -14242,30 +14338,6 @@
 	},
 /turf/simulated/floor,
 /area/maintenance/station/eng_lower)
-"aIq" = (
-/obj/machinery/alarm{
-	pixel_y = 22
-	},
-/obj/structure/table/rack{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/random/maintenance/clean,
-/obj/random/maintenance/engineering,
-/obj/random/tool,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor,
-/area/maintenance/station/eng_lower)
 "aIs" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -15325,27 +15397,6 @@
 /obj/structure/railing,
 /turf/simulated/floor,
 /area/maintenance/station/eng_lower)
-"aMu" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/structure/railing,
-/turf/simulated/floor/plating,
-/area/maintenance/station/eng_lower)
 "aMx" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -15652,35 +15703,6 @@
 	},
 /turf/simulated/floor/carpet,
 /area/engineering/foyer)
-"aPG" = (
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/structure/table/rack{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/random/maintenance/clean,
-/obj/random/maintenance/engineering,
-/obj/random/junk,
-/turf/simulated/floor,
-/area/maintenance/station/eng_lower)
-"aPH" = (
-/obj/machinery/atmospherics/valve/digital/open,
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/turf/simulated/floor,
-/area/maintenance/station/eng_lower)
 "aQa" = (
 /obj/structure/table/rack{
 	dir = 8;
@@ -15866,14 +15888,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/atmos/backup)
-"aRi" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/obj/structure/reagent_dispensers/watertank,
-/turf/simulated/floor,
-/area/maintenance/station/eng_lower)
 "aRr" = (
 /obj/machinery/atmospherics/valve/open,
 /obj/structure/railing{
@@ -31155,8 +31169,8 @@ atp
 api
 aMt
 aqs
-aPG
-aRi
+amA
+ard
 arZ
 aUE
 aqs
@@ -31297,7 +31311,7 @@ aIo
 aKr
 aMr
 aqt
-arb
+amB
 arA
 asa
 asD
@@ -31435,11 +31449,11 @@ aaV
 aaV
 aaV
 aaV
-aIq
+amz
 aUX
 aMx
 aOj
-aPH
+arb
 aRr
 aSO
 aUI
@@ -31579,9 +31593,9 @@ apU
 aGy
 aIp
 aKz
-aMu
+asv
 aYf
-ard
+akv
 arC
 asc
 aUF
@@ -36108,9 +36122,9 @@ adO
 adO
 adO
 adP
+adb
 akc
-akv
-akc
+adb
 adP
 adP
 adP

--- a/maps/tether/tether-06-station2.dmm
+++ b/maps/tether/tether-06-station2.dmm
@@ -4240,24 +4240,13 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/ai_upload)
 "go" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/floor_decal/borderfloor/corner,
-/obj/effect/floor_decal/corner/lightgrey/bordercorner,
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 8
+/obj/structure/cable/green{
+	icon_state = "32-2"
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 9
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/station/starboard)
+/obj/structure/lattice,
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/open,
+/area/maintenance/station/exploration)
 "gp" = (
 /obj/effect/floor_decal/techfloor,
 /obj/structure/cable/cyan{
@@ -4867,11 +4856,14 @@
 /turf/simulated/wall/r_wall,
 /area/ai_cyborg_station)
 "hm" = (
-/obj/structure/cable/green{
-	icon_state = "32-2"
+/obj/structure/railing{
+	dir = 8
 	},
-/obj/structure/lattice,
-/turf/simulated/open,
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor,
 /area/maintenance/station/exploration)
 "hn" = (
 /obj/effect/floor_decal/borderfloor,
@@ -5367,6 +5359,9 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/up{
+	dir = 8
 	},
 /turf/simulated/floor,
 /area/maintenance/station/exploration)
@@ -8826,12 +8821,23 @@
 /turf/simulated/floor/tiled,
 /area/engineering/foyer_mezzenine)
 "mR" = (
-/obj/structure/railing{
-	dir = 1
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/structure/reagent_dispensers/watertank,
-/turf/simulated/floor/plating,
-/area/maintenance/station/eng_upper)
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/catwalk,
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor,
+/area/maintenance/station/exploration)
 "mS" = (
 /obj/random/junk,
 /obj/effect/decal/cleanable/dirt,
@@ -9191,8 +9197,17 @@
 /turf/simulated/floor/tiled,
 /area/hallway/station/starboard)
 "nr" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /obj/structure/railing{
 	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor,
 /area/maintenance/station/exploration)
@@ -9404,11 +9419,12 @@
 /turf/simulated/floor/plating,
 /area/maintenance/station/eng_upper)
 "nF" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/station/eng_upper)
+/obj/machinery/door/airlock/maintenance/common,
+/obj/machinery/door/firedoor/glass,
+/obj/structure/catwalk,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor,
+/area/maintenance/station/exploration)
 "nG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -9432,27 +9448,10 @@
 /turf/simulated/floor/plating,
 /area/maintenance/station/eng_upper)
 "nI" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 1
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 4
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/station/starboard)
+/obj/structure/catwalk,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor,
+/area/maintenance/station/exploration)
 "nJ" = (
 /obj/machinery/door/firedoor/glass/hidden/steel{
 	dir = 1
@@ -9745,46 +9744,49 @@
 /turf/simulated/floor/plating,
 /area/maintenance/station/eng_upper)
 "ol" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/maintenance/station/eng_upper)
+/obj/structure/catwalk,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor,
+/area/maintenance/station/exploration)
 "om" = (
 /obj/structure/cable{
-	icon_state = "1-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/structure/railing{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/station/eng_upper)
+/obj/structure/catwalk,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor,
+/area/maintenance/station/exploration)
 "on" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled,
 /area/hallway/station/starboard)
 "oo" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
 	},
 /obj/structure/cable{
-	icon_state = "1-8"
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/turf/simulated/floor/tiled,
-/area/hallway/station/starboard)
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/structure/catwalk,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor,
+/area/maintenance/station/exploration)
 "op" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -9798,40 +9800,38 @@
 /turf/simulated/floor/tiled,
 /area/hallway/station/starboard)
 "oq" = (
-/obj/machinery/power/apc{
-	dir = 2;
-	name = "south bump";
-	pixel_y = -32
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
 	},
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/lightgrey/border,
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 8
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 25;
+	pixel_y = 0
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/simulated/floor/tiled,
-/area/hallway/station/starboard)
+/obj/structure/catwalk,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor,
+/area/maintenance/station/exploration)
 "or" = (
 /obj/machinery/computer/aifixer,
 /turf/simulated/floor/tiled/techfloor,
 /area/ai_cyborg_station)
 "os" = (
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/lightgrey/border,
-/obj/machinery/door/firedoor/glass/hidden/steel{
-	dir = 1
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/maintenance/common,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 8
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/station/starboard)
+/obj/structure/catwalk,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor,
+/area/maintenance/station/exploration)
 "ot" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/lightgrey/border,
@@ -9860,88 +9860,64 @@
 /turf/simulated/floor/tiled,
 /area/hallway/station/starboard)
 "ov" = (
-/obj/machinery/light,
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/lightgrey/border,
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 8
+/obj/machinery/door/firedoor/glass,
+/obj/structure/lattice,
+/obj/structure/disposalpipe/down{
+	dir = 4
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/station/starboard)
+/turf/simulated/open,
+/area/maintenance/station/eng_upper)
 "ow" = (
-/obj/machinery/camera/network/tether{
-	dir = 1
-	},
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/lightgrey/border,
-/obj/effect/floor_decal/steeldecal/steel_decals7{
+/obj/random/junk,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/railing{
 	dir = 8
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 1
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/tiled,
-/area/hallway/station/starboard)
+/turf/simulated/floor/plating,
+/area/maintenance/station/eng_upper)
 "ox" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/lightgrey/border,
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 8
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
+/obj/effect/floor_decal/borderfloor{
 	dir = 1
 	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/hallway/station/starboard)
 "oy" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/lightgrey/border,
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 8
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
+/obj/structure/railing{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
-/area/hallway/station/starboard)
+/turf/simulated/floor/plating,
+/area/maintenance/station/eng_upper)
 "oz" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/lightgrey/border,
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 9
-	},
-/obj/effect/floor_decal/corner/lightgrey/bordercorner2{
-	dir = 9
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 8
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/station/starboard)
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/maintenance/station/eng_upper)
 "oA" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -10144,14 +10120,18 @@
 /turf/simulated/floor/plating,
 /area/maintenance/station/eng_upper)
 "oQ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/maintenance/station/eng_upper)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled,
+/area/hallway/station/starboard)
 "oR" = (
 /obj/structure/table/rack{
 	dir = 8;
@@ -10207,33 +10187,12 @@
 /turf/simulated/floor/tiled,
 /area/hallway/station/starboard)
 "oV" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1";
-	pixel_x = 0
-	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 4
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 10
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 9
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/station/starboard)
+/turf/simulated/floor/plating,
+/area/maintenance/station/eng_upper)
 "oW" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/paleblue/border,
@@ -10362,17 +10321,35 @@
 /turf/simulated/floor/plating,
 /area/maintenance/station/eng_upper)
 "ph" = (
-/obj/machinery/light/small,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/station/eng_upper)
 "pi" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/floor_decal/rust,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/station/eng_upper)
 "pj" = (
@@ -10423,28 +10400,25 @@
 /turf/simulated/floor/tiled,
 /area/hallway/station/starboard)
 "pm" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/borderfloor/corner,
+/obj/effect/floor_decal/corner/lightgrey/bordercorner,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 8
+	},
 /obj/structure/cable{
 	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 4
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 10
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 9
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/station/starboard)
@@ -10739,15 +10713,22 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/engineering/foyer_mezzenine)
 "pN" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/camera/network/tether{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor/glass,
-/obj/machinery/door/airlock/maintenance/common,
-/turf/simulated/floor/plating,
-/area/maintenance/station/eng_upper)
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/lightgrey/border,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/starboard)
 "pO" = (
 /turf/simulated/wall/r_wall,
 /area/hallway/station/port)
@@ -10772,55 +10753,39 @@
 /turf/simulated/floor/tiled,
 /area/hallway/station/port)
 "pQ" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
-	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/lightgrey/border,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 8
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals7,
 /turf/simulated/floor/tiled,
-/area/hallway/station/port)
+/area/hallway/station/starboard)
 "pR" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+/obj/machinery/power/apc{
+	dir = 2;
+	name = "south bump";
+	pixel_y = -32
 	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/lightgrey/border,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 8
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals7,
 /turf/simulated/floor/tiled,
-/area/hallway/station/port)
+/area/hallway/station/starboard)
 "pS" = (
 /turf/simulated/wall/r_wall,
 /area/hallway/station/starboard)
@@ -11206,122 +11171,97 @@
 /turf/simulated/floor/tiled,
 /area/hallway/station/port)
 "qy" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/lightgrey/border,
+/obj/machinery/door/firedoor/glass/hidden/steel{
+	dir = 1
 	},
-/obj/structure/cable{
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/starboard)
+"qz" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/lightgrey/border,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 1
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 1;
+	icon_state = "extinguisher_closed";
+	pixel_y = -32
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/starboard)
+"qA" = (
+/obj/machinery/light,
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/lightgrey/border,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/starboard)
+"qB" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/green{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 1
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/lightgrey/border,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 8
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals7,
 /turf/simulated/floor/tiled,
-/area/hallway/station/port)
-"qz" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
-	},
-/obj/machinery/camera/network/tether,
-/obj/effect/floor_decal/borderfloor{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 1
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 4
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7,
-/turf/simulated/floor/tiled,
-/area/hallway/station/port)
-"qA" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
-	},
-/obj/machinery/status_display{
-	pixel_y = 30
-	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 1
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 4
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7,
-/turf/simulated/floor/tiled,
-/area/hallway/station/port)
-"qB" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
-	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 4
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7,
-/turf/simulated/floor/tiled,
-/area/hallway/station/port)
+/area/hallway/station/starboard)
 "qC" = (
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/glass/hidden/steel{
-	dir = 2
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/lightgrey/border,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 8
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals7,
 /turf/simulated/floor/tiled,
-/area/hallway/station/port)
+/area/hallway/station/starboard)
 "qD" = (
 /obj/machinery/light/small{
 	icon_state = "bulb1";
@@ -11346,30 +11286,41 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/medical/morgue)
 "qF" = (
-/obj/structure/cable{
-	d1 = 1;
+/obj/structure/cable/green{
+	d1 = 4;
 	d2 = 8;
-	icon_state = "1-8"
+	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/borderfloor/corner{
-	dir = 1
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/lightgrey/border,
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 9
 	},
-/obj/effect/floor_decal/corner/lightgrey/bordercorner{
-	dir = 1
+/obj/effect/floor_decal/corner/lightgrey/bordercorner2{
+	dir = 9
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 4
+	dir = 8
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 5
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/station/starboard)
 "qG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled,
-/area/hallway/station/starboard)
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/maintenance/station/eng_upper)
 "qH" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 9
@@ -19615,19 +19566,34 @@
 /turf/simulated/floor/tiled,
 /area/hallway/station/starboard)
 "DJ" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/green{
+/obj/structure/cable{
 	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
 	},
-/obj/structure/catwalk,
-/turf/simulated/floor,
-/area/maintenance/station/exploration)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1";
+	pixel_x = 0
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 10
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 9
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled,
+/area/hallway/station/starboard)
 "DK" = (
 /obj/effect/floor_decal/rust,
 /obj/effect/decal/cleanable/dirt,
@@ -19663,16 +19629,11 @@
 /turf/simulated/floor/tiled,
 /area/hallway/station/starboard)
 "DO" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/railing{
-	dir = 8
-	},
-/turf/simulated/floor,
-/area/maintenance/station/exploration)
+/obj/machinery/light/small,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/reagent_dispensers/watertank,
+/turf/simulated/floor/plating,
+/area/maintenance/station/eng_upper)
 "DP" = (
 /obj/structure/railing{
 	dir = 1
@@ -19686,11 +19647,15 @@
 /turf/simulated/floor,
 /area/maintenance/station/exploration)
 "DQ" = (
-/obj/machinery/door/airlock/maintenance/common,
-/obj/machinery/door/firedoor/glass,
-/obj/structure/catwalk,
-/turf/simulated/floor,
-/area/maintenance/station/exploration)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/rust,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/maintenance/station/eng_upper)
 "DR" = (
 /obj/random/trash,
 /obj/effect/floor_decal/techfloor{
@@ -19700,23 +19665,42 @@
 /area/maintenance/station/sec_lower)
 "DS" = (
 /obj/structure/cable{
-	d1 = 2;
+	d1 = 1;
 	d2 = 8;
-	icon_state = "2-8"
+	icon_state = "1-8"
 	},
-/obj/structure/catwalk,
-/turf/simulated/floor,
-/area/maintenance/station/exploration)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 10
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 9
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled,
+/area/hallway/station/starboard)
 "DT" = (
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
-/obj/structure/catwalk,
-/turf/simulated/floor,
-/area/maintenance/station/exploration)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/maintenance/common,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/maintenance/station/eng_upper)
 "DU" = (
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -19733,23 +19717,21 @@
 /turf/simulated/floor,
 /area/maintenance/station/exploration)
 "DV" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/light/small{
+/obj/effect/floor_decal/borderfloor{
 	dir = 4
 	},
-/obj/structure/catwalk,
-/turf/simulated/floor,
-/area/maintenance/station/exploration)
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 10
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 9
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled,
+/area/hallway/station/starboard)
 "DW" = (
 /obj/structure/railing{
 	dir = 4
@@ -19760,19 +19742,36 @@
 /area/maintenance/station/exploration)
 "DX" = (
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 25;
-	pixel_y = 0
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/obj/structure/catwalk,
-/turf/simulated/floor,
-/area/maintenance/station/exploration)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/port)
 "DY" = (
 /obj/structure/railing{
 	dir = 4
@@ -19793,17 +19792,28 @@
 /turf/simulated/floor,
 /area/maintenance/station/exploration)
 "Ea" = (
-/obj/machinery/door/firedoor/glass,
-/obj/machinery/door/airlock/maintenance/common,
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
 	},
-/obj/structure/catwalk,
-/turf/simulated/floor,
-/area/maintenance/station/exploration)
+/obj/machinery/camera/network/tether,
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/port)
 "Eb" = (
 /obj/structure/ladder/up,
 /turf/simulated/floor,
@@ -20586,6 +20596,163 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/resleeving)
+"Fk" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
+	},
+/obj/machinery/status_display{
+	pixel_y = 30
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/port)
+"Fl" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/port)
+"Fm" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/port)
+"Fn" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/port)
+"Fo" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/glass/hidden/steel{
+	dir = 2
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/port)
+"Fp" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey/bordercorner{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 5
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/starboard)
 "Fq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -20605,6 +20772,14 @@
 /obj/structure/table/steel,
 /turf/simulated/floor/tiled/freezer,
 /area/security/brig/bathroom)
+"Fr" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/starboard)
 "Fs" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 1
@@ -20622,6 +20797,25 @@
 /obj/item/clothing/under/seromi/smock/medical,
 /turf/simulated/floor,
 /area/maintenance/station/sec_lower)
+"Fu" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 10
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 9
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/starboard)
 "Fv" = (
 /obj/machinery/door/airlock/maintenance/common,
 /obj/machinery/door/firedoor/glass,
@@ -31314,8 +31508,8 @@ ki
 kU
 lD
 mp
-mR
-nF
+ov
+oy
 ok
 oO
 mp
@@ -31456,9 +31650,9 @@ hr
 kV
 lE
 mq
-mS
-nF
-jL
+ow
+oz
+oV
 oP
 pg
 hr
@@ -31600,9 +31794,9 @@ lF
 mr
 mT
 nG
-ol
-mS
 ph
+mS
+DO
 hr
 qx
 Vw
@@ -31742,11 +31936,11 @@ lG
 ms
 mU
 nH
-om
-oQ
 pi
-pN
-qy
+qG
+DQ
+DT
+DX
 rm
 fJ
 oX
@@ -31888,7 +32082,7 @@ fq
 jj
 pj
 kj
-qz
+Ea
 rk
 fM
 pn
@@ -32030,7 +32224,7 @@ fq
 jj
 kj
 pO
-qA
+Fk
 ei
 fO
 pn
@@ -32172,7 +32366,7 @@ fq
 jL
 kj
 pP
-qB
+Fl
 ev
 fO
 pn
@@ -32314,7 +32508,7 @@ fq
 oR
 kj
 eJ
-pQ
+Fm
 eU
 uz
 po
@@ -32456,7 +32650,7 @@ fq
 oS
 kj
 eN
-pR
+Fn
 eX
 fO
 pp
@@ -32598,7 +32792,7 @@ fq
 kj
 kj
 pO
-qC
+Fo
 fp
 fQ
 pq
@@ -32740,7 +32934,7 @@ on
 oT
 pk
 pT
-qF
+Fp
 fG
 gx
 pr
@@ -32882,7 +33076,7 @@ lJ
 oU
 pl
 lK
-qG
+Fr
 fH
 op
 ps
@@ -33020,11 +33214,11 @@ lJ
 lJ
 lJ
 nL
-go
-oV
 pm
-pU
-pU
+DJ
+DS
+DV
+Fu
 pU
 oW
 pt
@@ -33162,7 +33356,7 @@ hy
 hy
 hC
 nM
-ow
+pN
 DL
 DL
 DL
@@ -33304,7 +33498,7 @@ lJ
 mu
 mW
 nN
-ot
+pQ
 DL
 ac
 ac
@@ -33446,7 +33640,7 @@ lJ
 lJ
 mW
 nN
-ot
+pQ
 DL
 ac
 ac
@@ -33588,7 +33782,7 @@ lJ
 lJ
 mW
 nN
-ot
+pQ
 DL
 ac
 ac
@@ -33730,7 +33924,7 @@ lM
 mv
 mX
 nO
-oq
+pR
 DL
 ac
 ac
@@ -33872,7 +34066,7 @@ kp
 kp
 mY
 nQ
-os
+qy
 DL
 ac
 ac
@@ -34014,7 +34208,7 @@ yA
 kp
 mZ
 nN
-ot
+pQ
 DL
 ac
 ac
@@ -34156,7 +34350,7 @@ yH
 kp
 na
 nN
-ou
+qz
 DL
 ac
 ac
@@ -34298,7 +34492,7 @@ zA
 kp
 nb
 nN
-ov
+qA
 DL
 ac
 ac
@@ -34440,7 +34634,7 @@ zA
 kp
 li
 nN
-ow
+pN
 DL
 ac
 ac
@@ -34582,7 +34776,7 @@ As
 kp
 nc
 nN
-ot
+pQ
 DL
 ac
 ac
@@ -34724,7 +34918,7 @@ As
 kp
 nh
 nN
-ot
+pQ
 DL
 ac
 ac
@@ -34866,7 +35060,7 @@ As
 kp
 nh
 nR
-ot
+pQ
 DL
 ac
 ac
@@ -35008,7 +35202,7 @@ Bt
 kp
 ng
 nR
-ot
+pQ
 DL
 ac
 ac
@@ -35150,7 +35344,7 @@ kt
 kt
 WG
 nR
-ot
+pQ
 DL
 ac
 ac
@@ -35292,7 +35486,7 @@ BU
 kt
 nh
 nR
-ot
+pQ
 dA
 dA
 dA
@@ -35434,7 +35628,7 @@ Cm
 kt
 ni
 nV
-ox
+qB
 eh
 pv
 qa
@@ -35576,7 +35770,7 @@ Cn
 kt
 nh
 nR
-oy
+qC
 oY
 oY
 oY
@@ -35718,7 +35912,7 @@ Dh
 kt
 nh
 nR
-oy
+qC
 oY
 pw
 er
@@ -35860,7 +36054,7 @@ kt
 kt
 nh
 nR
-oy
+qC
 oY
 pw
 qc
@@ -36002,7 +36196,7 @@ DZ
 bg
 nk
 nR
-oy
+qC
 oY
 px
 qd
@@ -36131,20 +36325,20 @@ ko
 lR
 hg
 mB
-DJ
-DQ
-ko
-ko
-DS
-DT
-DV
-DX
-DT
-DT
-Ea
+mR
+nF
 nI
+nI
+ol
+om
 oo
-oz
+oq
+om
+om
+os
+ox
+oQ
+qF
 oZ
 py
 qe
@@ -36272,8 +36466,8 @@ bg
 ll
 bg
 bg
+hm
 nr
-DO
 dZ
 dZ
 dZ
@@ -36413,7 +36607,7 @@ by
 bg
 Eb
 bg
-hm
+go
 ib
 jz
 dZ

--- a/maps/tether/tether-07-station3.dmm
+++ b/maps/tether/tether-07-station3.dmm
@@ -8430,26 +8430,16 @@
 /turf/simulated/floor/bluegrid,
 /area/ai_core_foyer)
 "nb" = (
-/obj/structure/table/standard,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/catwalk,
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
 	},
-/obj/effect/floor_decal/corner/brown/border{
-	dir = 8
-	},
-/obj/item/weapon/folder/yellow,
-/obj/item/weapon/stamp/denied{
-	pixel_x = 4;
-	pixel_y = -2
-	},
-/obj/item/weapon/stamp/cargo,
-/turf/simulated/floor/tiled,
-/area/quartermaster/office)
+/turf/simulated/floor,
+/area/maintenance/station/ai)
 "nc" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -11528,73 +11518,38 @@
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
 "rS" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/railing{
+	dir = 8
 	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/brown/border{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/quartermaster/office)
-"rT" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/effect/floor_decal/borderfloor{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/brown/border{
-	dir = 1
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 10
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4,
-/turf/simulated/floor/tiled,
-/area/quartermaster/office)
-"rU" = (
-/obj/machinery/door/airlock/glass_mining{
-	id_tag = "cargodoor";
-	name = "Cargo Office";
-	req_access = list(31);
-	req_one_access = list()
-	},
+/obj/structure/lattice,
 /obj/machinery/door/firedoor/glass,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/disposalpipe/down{
+	dir = 8
 	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/quartermaster/office)
+/turf/simulated/open,
+/area/maintenance/station/ai)
+"rT" = (
+/obj/structure/catwalk,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor,
+/area/maintenance/station/ai)
+"rU" = (
+/obj/structure/catwalk,
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor,
+/area/maintenance/station/ai)
 "rV" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+/obj/structure/catwalk,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/brown/border{
-	dir = 1
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 1
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 6
-	},
-/turf/simulated/floor/tiled,
-/area/quartermaster/office)
+/turf/simulated/floor,
+/area/maintenance/station/ai)
 "rW" = (
 /obj/effect/floor_decal/borderfloor/corner{
 	dir = 1
@@ -12077,28 +12032,13 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/quartermaster/office)
 "sH" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
+/obj/effect/floor_decal/rust,
 /obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-c"
 	},
-/obj/effect/floor_decal/borderfloor/corner{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/brown/bordercorner{
-	dir = 8
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 1
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 6
-	},
-/turf/simulated/floor/tiled,
-/area/quartermaster/office)
+/turf/simulated/floor,
+/area/maintenance/station/ai)
 "sI" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -13394,33 +13334,14 @@
 /turf/simulated/floor/tiled,
 /area/quartermaster/foyer)
 "uC" = (
-/obj/item/weapon/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
+/obj/structure/catwalk,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
-/obj/item/weapon/clipboard,
-/obj/item/weapon/pen/red{
-	pixel_x = 2;
-	pixel_y = 6
-	},
-/obj/structure/table/standard,
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/brown/border{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/quartermaster/office)
+/turf/simulated/floor,
+/area/maintenance/station/ai)
 "uD" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -13865,25 +13786,13 @@
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
 "vo" = (
-/obj/structure/bed/chair/office/dark{
-	dir = 4
+/obj/random/trash,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
-/obj/effect/landmark/start{
-	name = "Cargo Technician"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/brown/border{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/quartermaster/office)
+/turf/simulated/floor,
+/area/maintenance/station/ai)
 "vp" = (
 /obj/structure/disposalpipe/sortjunction{
 	dir = 1;
@@ -14338,22 +14247,9 @@
 /turf/simulated/floor/plating,
 /area/quartermaster/office)
 "wb" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/brown/border{
-	dir = 8
-	},
-/obj/machinery/computer/supplycomp/control{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/quartermaster/office)
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor,
+/area/maintenance/station/ai)
 "wc" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled,
@@ -14605,21 +14501,15 @@
 /turf/simulated/floor/plating,
 /area/quartermaster/delivery)
 "wE" = (
-/obj/structure/table/steel_reinforced,
-/obj/item/weapon/folder/yellow,
-/obj/item/weapon/pen{
-	pixel_x = 4;
-	pixel_y = 4
+/obj/structure/cable/green{
+	icon_state = "32-2"
 	},
-/obj/machinery/door/window/northright{
-	name = "Mailing Room";
-	req_access = list(50)
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled,
-/area/quartermaster/delivery)
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/zpipe/down/supply,
+/obj/machinery/atmospherics/pipe/zpipe/down/scrubbers,
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/open,
+/area/tether/exploration)
 "wF" = (
 /obj/machinery/newscaster{
 	layer = 3.3;
@@ -14669,29 +14559,12 @@
 /turf/simulated/floor/tiled,
 /area/quartermaster/foyer)
 "wJ" = (
-/obj/structure/filingcabinet/filingcabinet,
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+/obj/machinery/door/airlock/maintenance/cargo{
+	req_access = list(50);
+	req_one_access = list(48)
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/brown/border{
-	dir = 8
-	},
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 10
-	},
-/obj/effect/floor_decal/corner/brown/bordercorner2{
-	dir = 10
-	},
-/turf/simulated/floor/tiled,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor,
 /area/quartermaster/office)
 "wK" = (
 /obj/structure/table/standard,
@@ -15174,18 +15047,19 @@
 /area/quartermaster/office)
 "xq" = (
 /obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 6
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
+/obj/effect/floor_decal/borderfloor{
 	dir = 1
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
@@ -15662,31 +15536,23 @@
 /area/quartermaster/office)
 "ye" = (
 /obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable/green{
-	d1 = 2;
+	d1 = 4;
 	d2 = 8;
-	icon_state = "2-8"
+	icon_state = "4-8"
 	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 10
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4,
+/obj/structure/disposalpipe/segment{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 6
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
@@ -16304,27 +16170,22 @@
 /turf/simulated/floor/tiled,
 /area/quartermaster/foyer)
 "yZ" = (
+/obj/machinery/door/airlock/glass_mining{
+	id_tag = "cargodoor";
+	name = "Cargo Office";
+	req_access = list(31);
+	req_one_access = list()
+	},
+/obj/machinery/door/firedoor/glass,
 /obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -27
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/machinery/camera/network/cargo{
-	c_tag = "CRG - Cargo Office South";
-	dir = 5
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 5
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/steel_grid,
 /area/quartermaster/office)
 "za" = (
 /obj/structure/disposalpipe/segment,
@@ -16829,21 +16690,28 @@
 /turf/simulated/wall,
 /area/quartermaster/storage)
 "zP" = (
-/obj/machinery/door/airlock/glass_mining{
-	name = "Cargo Bay";
-	req_access = list(31);
-	req_one_access = list()
-	},
-/obj/machinery/door/firedoor/glass,
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/steel_grid,
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 6
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled,
 /area/quartermaster/office)
 "zQ" = (
 /obj/machinery/door/airlock/glass_mining{
@@ -17569,21 +17437,24 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/floor_decal/steeldecal/steel_decals4{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 9
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 8
 	},
+/obj/effect/floor_decal/corner/brown/bordercorner{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 6
+	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
-/area/quartermaster/storage)
+/area/quartermaster/office)
 "AS" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/steeldecal/steel_decals4{
@@ -18238,15 +18109,27 @@
 /turf/simulated/floor/tiled,
 /area/quartermaster/storage)
 "BS" = (
+/obj/structure/table/standard,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 8
+	},
+/obj/item/weapon/folder/yellow,
+/obj/item/weapon/stamp/denied{
+	pixel_x = 4;
+	pixel_y = -2
+	},
+/obj/item/weapon/stamp/cargo,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
-/area/quartermaster/storage)
+/area/quartermaster/office)
 "BT" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
@@ -18755,20 +18638,34 @@
 /turf/simulated/floor/tiled,
 /area/quartermaster/storage)
 "CK" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+/obj/item/weapon/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/item/weapon/clipboard,
+/obj/item/weapon/pen/red{
+	pixel_x = 2;
+	pixel_y = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+/obj/structure/table/standard,
+/obj/machinery/light{
+	icon_state = "tube1";
 	dir = 8
 	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
-/area/quartermaster/storage)
+/area/quartermaster/office)
 "CL" = (
 /obj/structure/disposalpipe/sortjunction/flipped{
 	dir = 1;
@@ -19197,12 +19094,26 @@
 /turf/simulated/floor/tiled,
 /area/quartermaster/storage)
 "DA" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+/obj/structure/bed/chair/office/dark{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/landmark/start{
+	name = "Cargo Technician"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
-/area/quartermaster/storage)
+/area/quartermaster/office)
 "DB" = (
 /obj/effect/floor_decal/industrial/loading{
 	dir = 8
@@ -19799,10 +19710,23 @@
 /turf/simulated/floor/tiled,
 /area/quartermaster/storage)
 "Ev" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 8
+	},
+/obj/machinery/computer/supplycomp/control{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
-/area/quartermaster/storage)
+/area/quartermaster/office)
 "Ew" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -20279,11 +20203,31 @@
 /turf/simulated/floor/tiled,
 /area/quartermaster/storage)
 "Fl" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/hologram/holopad,
+/obj/structure/filingcabinet/filingcabinet,
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 8
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/brown/bordercorner2{
+	dir = 10
+	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
-/area/quartermaster/storage)
+/area/quartermaster/office)
 "Fm" = (
 /obj/machinery/embedded_controller/radio/simple_docking_controller{
 	frequency = 1380;
@@ -20503,13 +20447,23 @@
 /turf/simulated/floor,
 /area/maintenance/substation/cargo)
 "FE" = (
-/obj/machinery/light/small{
-	dir = 8;
-	pixel_y = 0
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 6
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
-/area/quartermaster/warehouse)
+/area/quartermaster/office)
 "FF" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -21212,8 +21166,36 @@
 /turf/simulated/floor/tiled,
 /area/quartermaster/warehouse)
 "GI" = (
-/turf/simulated/floor/tiled/steel,
-/area/quartermaster/warehouse)
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 6
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled,
+/area/quartermaster/office)
 "GJ" = (
 /obj/machinery/power/apc{
 	dir = 4;
@@ -21252,12 +21234,29 @@
 /turf/simulated/floor/tiled,
 /area/quartermaster/storage)
 "GN" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
+	},
+/obj/machinery/camera/network/cargo{
+	c_tag = "CRG - Cargo Office South";
+	dir = 5
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
-/area/quartermaster/storage)
+/area/quartermaster/office)
 "GO" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
@@ -21826,15 +21825,23 @@
 /turf/simulated/floor/tiled,
 /area/quartermaster/storage)
 "HC" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/door/airlock/glass_mining{
+	name = "Cargo Bay";
+	req_access = list(31);
+	req_one_access = list()
+	},
+/obj/machinery/door/firedoor/glass,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/quartermaster/storage)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/steel_grid,
+/area/quartermaster/office)
 "HD" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -22314,91 +22321,81 @@
 /turf/simulated/floor/tiled/steel,
 /area/quartermaster/warehouse)
 "In" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
+	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
-/area/quartermaster/warehouse)
+/area/quartermaster/storage)
 "Io" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
-/area/quartermaster/warehouse)
+/area/quartermaster/storage)
 "Ip" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals6,
-/obj/effect/floor_decal/steeldecal/steel_decals6{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/quartermaster/warehouse)
-"Iq" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/door/blast/shutters{
-	dir = 8;
-	id = "qm_warehouse";
-	name = "Warehouse Shutters"
-	},
-/obj/machinery/door/firedoor/glass,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/quartermaster/warehouse)
-"Ir" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals6{
-	dir = 1
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals6{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled,
+/area/quartermaster/storage)
+"Iq" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled,
+/area/quartermaster/storage)
+"Ir" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/quartermaster/storage)
 "Is" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/hologram/holopad,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/quartermaster/storage)
 "It" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/quartermaster/storage)
 "Iu" = (
@@ -23176,9 +23173,13 @@
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/heads/cmo)
 "JH" = (
-/obj/structure/closet/crate/freezer,
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_y = 0
+	},
 /obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/steel,
+/obj/structure/closet/crate/freezer,
+/turf/simulated/floor/tiled,
 /area/quartermaster/warehouse)
 "JI" = (
 /obj/structure/closet/crate/internals,
@@ -23884,28 +23885,40 @@
 /turf/simulated/floor/plating,
 /area/maintenance/station/cargo)
 "KS" = (
-/obj/structure/shuttle/engine/propulsion{
-	dir = 8;
-	icon_state = "propulsion_l"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/space,
-/turf/simulated/shuttle/plating/airless/carry,
-/area/shuttle/large_escape_pod1/station)
-"KT" = (
-/obj/structure/shuttle/engine/propulsion{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
-/turf/space,
-/turf/simulated/shuttle/plating/airless/carry,
-/area/shuttle/large_escape_pod1/station)
-"KU" = (
-/obj/structure/shuttle/engine/propulsion{
-	dir = 8;
-	icon_state = "propulsion_r"
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled,
+/area/quartermaster/storage)
+"KT" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/weapon/folder/yellow,
+/obj/item/weapon/pen{
+	pixel_x = 4;
+	pixel_y = 4
 	},
-/turf/space,
-/turf/simulated/shuttle/plating/airless/carry,
-/area/shuttle/large_escape_pod1/station)
+/obj/machinery/door/window/northright{
+	dir = 2;
+	name = "Mailing Room";
+	req_access = list(50)
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled,
+/area/quartermaster/delivery)
+"KU" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/warehouse)
 "KV" = (
 /obj/structure/undies_wardrobe,
 /turf/simulated/floor/tiled/white,
@@ -23954,6 +23967,19 @@
 /obj/effect/floor_decal/corner/paleblue/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/medbreak)
+"Lb" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/warehouse)
 "Lc" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal,
 /obj/effect/floor_decal/steeldecal/steel_decals4{
@@ -24185,6 +24211,19 @@
 /obj/random/maintenance/cargo,
 /turf/simulated/floor/plating,
 /area/maintenance/station/cargo)
+"LA" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/warehouse)
 "LB" = (
 /obj/structure/sign/nosmoking_1,
 /turf/simulated/wall/r_wall,
@@ -24503,12 +24542,52 @@
 /obj/random/maintenance/cargo,
 /turf/simulated/floor/plating,
 /area/maintenance/station/cargo)
+"Mc" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals6,
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/warehouse)
 "Md" = (
 /obj/machinery/door/airlock/medical{
 	name = "Rest Room"
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/medical_restroom)
+"Me" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/door/blast/shutters{
+	dir = 8;
+	id = "qm_warehouse";
+	name = "Warehouse Shutters"
+	},
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/quartermaster/warehouse)
 "Mf" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -24518,6 +24597,24 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/medical_restroom)
+"Mg" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/storage)
 "Mh" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -24845,6 +24942,32 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/hallway/secondary/escape/medical_escape_pod_hallway)
+"Mz" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/storage)
+"MA" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9;
+	pixel_y = 0
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/storage)
 "MB" = (
 /obj/machinery/light{
 	dir = 8;
@@ -24870,6 +24993,10 @@
 /obj/effect/floor_decal/corner/paleblue/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/medbreak)
+"MD" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/steel,
+/area/quartermaster/warehouse)
 "ME" = (
 /obj/structure/table/glass,
 /obj/item/weapon/deck/cards,
@@ -24945,6 +25072,19 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/hallway/secondary/escape/medical_escape_pod_hallway)
+"MN" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/conveyor_switch/oneway{
+	id = "gloriouscargopipeline";
+	layer = 3.3;
+	name = "Surface delivery conveyor";
+	pixel_x = 14;
+	pixel_y = -3
+	},
+/turf/simulated/floor/tiled/steel,
+/area/quartermaster/warehouse)
 "MO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -25253,12 +25393,30 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/medical_restroom)
+"Nn" = (
+/obj/structure/plasticflaps,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/machinery/disposal/deliveryChute{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/quartermaster/warehouse)
 "No" = (
 /obj/structure/table/standard,
 /obj/item/weapon/storage/box/cups,
 /obj/effect/floor_decal/corner/paleblue/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/medbreak)
+"Np" = (
+/obj/structure/shuttle/engine/propulsion{
+	dir = 8;
+	icon_state = "propulsion_l"
+	},
+/turf/space,
+/turf/simulated/shuttle/plating/airless/carry,
+/area/shuttle/large_escape_pod1/station)
 "Nq" = (
 /obj/structure/table/standard,
 /obj/item/weapon/storage/box/donkpockets,
@@ -25352,6 +25510,13 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ai_core_foyer)
+"Nx" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/steel,
+/area/quartermaster/warehouse)
 "Ny" = (
 /obj/structure/table/standard,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -25479,6 +25644,13 @@
 /obj/effect/floor_decal/corner/paleblue/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/medbreak)
+"NI" = (
+/obj/structure/shuttle/engine/propulsion{
+	dir = 8
+	},
+/turf/space,
+/turf/simulated/shuttle/plating/airless/carry,
+/area/shuttle/large_escape_pod1/station)
 "NJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/universal{
 	dir = 4
@@ -25616,6 +25788,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow,
 /turf/simulated/floor/tiled/white,
 /area/medical/virologyaccess)
+"NY" = (
+/obj/structure/shuttle/engine/propulsion{
+	dir = 8;
+	icon_state = "propulsion_r"
+	},
+/turf/space,
+/turf/simulated/shuttle/plating/airless/carry,
+/area/shuttle/large_escape_pod1/station)
 "NZ" = (
 /obj/structure/shuttle/engine/heater{
 	dir = 8
@@ -26499,15 +26679,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virologyisolation)
-"PI" = (
-/obj/structure/cable/green{
-	icon_state = "32-2"
-	},
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/zpipe/down/supply,
-/obj/machinery/atmospherics/pipe/zpipe/down/scrubbers,
-/turf/simulated/open,
-/area/tether/exploration)
 "PJ" = (
 /obj/structure/bed/padded,
 /obj/item/weapon/bedsheet/green,
@@ -27423,13 +27594,6 @@
 	},
 /turf/simulated/floor,
 /area/maintenance/station/ai)
-"Sj" = (
-/obj/structure/catwalk,
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/simulated/floor,
-/area/maintenance/station/ai)
 "Sk" = (
 /obj/structure/railing{
 	dir = 4
@@ -27454,10 +27618,6 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor,
-/area/maintenance/station/ai)
-"So" = (
-/obj/random/trash,
 /turf/simulated/floor,
 /area/maintenance/station/ai)
 "Sp" = (
@@ -39029,11 +39189,11 @@ MK
 Iy
 ab
 NL
-KS
-KT
-KT
-KT
-KU
+Np
+NI
+NI
+NI
+NY
 NL
 vt
 vt
@@ -41286,8 +41446,8 @@ EX
 FD
 FY
 GC
-ab
-ab
+Fj
+Fj
 ab
 ab
 ab
@@ -41428,8 +41588,8 @@ Fj
 Fj
 Fj
 Fj
+Nn
 Fj
-ab
 ab
 ab
 ab
@@ -41554,7 +41714,7 @@ tx
 uu
 vh
 vX
-wE
+KT
 xl
 xZ
 yS
@@ -41567,10 +41727,10 @@ AI
 zL
 Ed
 GF
-FE
+JH
 Im
 IR
-Fj
+MN
 Fj
 ab
 ab
@@ -41710,9 +41870,9 @@ zL
 Ee
 EY
 FF
-GG
-GI
-JH
+KU
+MD
+Nx
 Fj
 ab
 ab
@@ -41852,7 +42012,7 @@ zL
 Ga
 GH
 Hw
-In
+Lb
 IS
 JI
 Fj
@@ -41994,7 +42154,7 @@ zK
 Gb
 XO
 Hx
-Io
+LA
 GG
 Hg
 Fj
@@ -42136,7 +42296,7 @@ zK
 Gc
 GJ
 Hy
-Ip
+Mc
 IT
 JK
 Fj
@@ -42248,7 +42408,7 @@ db
 mt
 nz
 be
-PI
+wE
 QK
 be
 Si
@@ -42278,7 +42438,7 @@ zL
 Fj
 Fj
 Hz
-Iq
+Me
 Fj
 JL
 Fj
@@ -42397,10 +42557,10 @@ Si
 gJ
 gJ
 gJ
-RX
-gJ
-qu
-rS
+sH
+wb
+wJ
+xq
 sE
 tA
 uA
@@ -42420,7 +42580,7 @@ Fk
 Gd
 GK
 HA
-Ir
+Mg
 IU
 nh
 zO
@@ -42538,11 +42698,11 @@ be
 Si
 gJ
 pZ
-RX
-So
+sH
+vo
 gJ
 qu
-rT
+ye
 sF
 qu
 uB
@@ -42562,7 +42722,7 @@ BU
 BU
 GL
 HB
-Is
+Mz
 Sy
 JN
 zO
@@ -42679,12 +42839,12 @@ Ss
 Sd
 Si
 Sk
-ib
-Sl
+rU
+uC
 gJ
 gJ
 qu
-rU
+yZ
 sG
 tB
 rZ
@@ -42704,7 +42864,7 @@ Eu
 Eu
 GM
 HB
-Is
+Mz
 BU
 JO
 zO
@@ -42819,23 +42979,13 @@ RF
 RA
 RA
 RA
-Sj
-Sl
-ib
-gJ
-gJ
-qu
-qu
-rV
-sH
 nb
-uC
-vo
-wb
-wJ
-xq
-ye
-yZ
+rT
+rV
+gJ
+gJ
+qu
+qu
 zP
 AR
 BS
@@ -42843,10 +42993,20 @@ CK
 DA
 Ev
 Fl
-Ev
+FE
+GI
 GN
 HC
+In
+Io
+Ip
+Iq
+Ir
+Is
+Ir
 It
+KS
+MA
 IV
 zO
 zO
@@ -42961,7 +43121,7 @@ eI
 nV
 pZ
 iJ
-RN
+rS
 Sm
 gJ
 gJ

--- a/maps/tether/tether_areas2.dm
+++ b/maps/tether/tether_areas2.dm
@@ -132,6 +132,9 @@
 	name = "\improper Mining Bathroom"
 /area/tether/surfacebase/mining_main/lobby
 	name = "\improper Mining Lobby"
+/area/tether/surfacebase/mining_main/surfacecargo
+	name = "\improper Surface Cargo Office"
+	lightswitch = 0
 
 // Mining Underdark
 /area/mine/unexplored/underdark


### PR DESCRIPTION
This started as a project to add a small cargo office to mining. 

![z1](https://user-images.githubusercontent.com/24854483/66747119-bc465b80-ee51-11e9-9db0-a5d095e73311.png)

But then I decided that it would be fun if there was a delivery pipe between the two.

Also, forgot to mention: Adds some firelocks in places where firelocks ought to be. Also changes one pointless engineering maintenance airlock to a regular maintenance airlock on Z3

---
Added a connection to research on the mining-cargo pipeline, so materials can be delivered to research by mail from mining. It ONLY goes to 'Research' or up to cargo though. So if you want to mail things around properly you still need to go up to the actual mail room.

Also adds a little wrapping paper and a destination tagger to mining. (Along with a helpful instructive note)

Also fixxes the fact that the RnD disposals bin wasn't connected to the pipes. The 'Research' tag now delivers to this bin. Also tidied up some floor decorations at the xenobio entrance.