### PR TITLE
Redistributes maint wealth

### DIFF
--- a/maps/tether/tether-01-surface1.dmm
+++ b/maps/tether/tether-01-surface1.dmm
@@ -2500,24 +2500,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/lower/trash_pit)
 "ael" = (
-/obj/effect/floor_decal/techfloor,
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/random/trash_pile,
-/turf/simulated/floor/plating,
-/area/maintenance/lower/trash_pit)
-"aem" = (
-/obj/effect/floor_decal/techfloor,
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small,
-/turf/simulated/floor/plating,
-/area/maintenance/lower/trash_pit)
-"aen" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 4
 	},
@@ -2531,7 +2513,23 @@
 	icon_state = "alarm0";
 	pixel_x = 24
 	},
-/obj/random/trash_pile,
+/turf/simulated/floor/plating,
+/area/maintenance/lower/trash_pit)
+"aem" = (
+/obj/effect/floor_decal/techfloor,
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small,
+/turf/simulated/floor/plating,
+/area/maintenance/lower/trash_pit)
+"aen" = (
+/obj/effect/floor_decal/techfloor,
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/lower/trash_pit)
 "aeo" = (
@@ -3654,9 +3652,15 @@
 /turf/simulated/floor/holofloor/tiled/dark,
 /area/tether/elevator)
 "agd" = (
-/obj/random/trash_pile,
-/turf/simulated/floor/tiled/techfloor,
-/area/maintenance/lower/mining_eva)
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/maintenance/lower/trash_pit)
 "age" = (
 /obj/vehicle/train/trolley,
 /obj/machinery/alarm{
@@ -3952,12 +3956,13 @@
 /area/maintenance/lower/trash_pit)
 "agQ" = (
 /obj/structure/railing{
-	dir = 8
-	},
-/obj/structure/railing{
 	dir = 1
 	},
+/obj/structure/railing{
+	dir = 4
+	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/rust,
 /obj/random/trash_pile,
 /turf/simulated/floor/plating,
 /area/maintenance/lower/trash_pit)
@@ -3974,14 +3979,11 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/chemistry_lab)
 "agS" = (
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/structure/railing{
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/industrial/warning{
+	icon_state = "warning";
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating,
 /area/maintenance/lower/trash_pit)
 "agT" = (
@@ -7718,14 +7720,14 @@
 /turf/simulated/floor/plating,
 /area/maintenance/lower/trash_pit)
 "anr" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/structure/railing{
 	dir = 4
 	},
-/obj/random/trash_pile,
 /turf/simulated/floor/plating,
-/area/maintenance/lower/trash_pit)
+/area/maintenance/lower/vacant_site)
 "ans" = (
 /obj/machinery/door/airlock/multi_tile/glass{
 	name = "Public Gardens"
@@ -9864,6 +9866,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/lower/vacant_site)
+"aqS" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/trash_pile,
+/turf/simulated/floor/plating,
+/area/maintenance/lower/xenoflora)
 "aqT" = (
 /turf/simulated/wall/r_wall,
 /area/storage/surface_eva/external)
@@ -10037,6 +10044,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/lower/vacant_site)
+"arm" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/lower/xenoflora)
 "arn" = (
 /obj/structure/table/glass,
 /obj/item/weapon/storage/toolbox/emergency,
@@ -10218,6 +10234,13 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/plating,
 /area/maintenance/lower/vacant_site)
+"arD" = (
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/lower/xenoflora)
 "arE" = (
 /obj/structure/table/rack,
 /obj/item/bodybag/cryobag,
@@ -10342,10 +10365,9 @@
 /obj/structure/railing{
 	dir = 4
 	},
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/random/trash_pile,
+/obj/machinery/atmospherics/pipe/simple/visible/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/visible/supply,
+/obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/xenoflora)
 "arN" = (
@@ -11112,12 +11134,13 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/xenoflora)
 "atf" = (
+/obj/effect/floor_decal/rust,
 /obj/structure/railing{
+	icon_state = "railing0";
 	dir = 1
 	},
-/obj/random/trash_pile,
-/turf/simulated/floor/tiled/techfloor,
-/area/maintenance/lower/xenoflora)
+/turf/simulated/floor/plating,
+/area/maintenance/lower/research)
 "atg" = (
 /obj/structure/railing{
 	dir = 1
@@ -11429,13 +11452,12 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/xenoflora)
 "atK" = (
-/obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 0
+/obj/structure/railing,
+/obj/structure/railing{
+	dir = 4
 	},
-/obj/random/trash_pile,
-/turf/simulated/floor/tiled/techfloor,
-/area/maintenance/lower/xenoflora)
+/turf/simulated/floor/plating,
+/area/maintenance/lower/research)
 "atL" = (
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/xenoflora)
@@ -14127,16 +14149,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/xenobiology/xenoflora/lab_atmos)
-"axQ" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/visible/supply,
-/obj/machinery/atmospherics/pipe/simple/visible/yellow,
-/obj/random/trash_pile,
-/turf/simulated/floor/tiled/techfloor,
-/area/maintenance/lower/xenoflora)
 "axR" = (
 /obj/structure/catwalk,
 /obj/structure/cable{
@@ -16868,11 +16880,6 @@
 /obj/random/maintenance/clean,
 /turf/simulated/floor/plating,
 /area/maintenance/lower/research)
-"aBN" = (
-/obj/random/trash_pile,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/maintenance/lower/research)
 "aBO" = (
 /turf/simulated/wall,
 /area/maintenance/lower/research)
@@ -18479,12 +18486,6 @@
 	},
 /obj/structure/closet/crate,
 /obj/random/cigarettes,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/maintenance/lower/research)
-"aED" = (
-/obj/random/trash_pile,
-/obj/structure/railing,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/lower/research)
@@ -20506,15 +20507,6 @@
 "aHv" = (
 /turf/simulated/wall/r_wall,
 /area/maintenance/substation/surface_atmos)
-"aHw" = (
-/obj/effect/floor_decal/rust,
-/obj/random/trash_pile,
-/obj/structure/railing{
-	icon_state = "railing0";
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/lower/research)
 "aHx" = (
 /obj/effect/floor_decal/rust,
 /obj/structure/railing{
@@ -20819,14 +20811,6 @@
 /obj/random/maintenance/research,
 /obj/random/maintenance/research,
 /obj/random/cigarettes,
-/turf/simulated/floor/plating,
-/area/maintenance/lower/research)
-"aIc" = (
-/obj/structure/railing,
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/random/trash_pile,
 /turf/simulated/floor/plating,
 /area/maintenance/lower/research)
 "aId" = (
@@ -28657,10 +28641,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/lower/atmos)
-"aWv" = (
-/obj/random/trash_pile,
-/turf/simulated/floor/plating,
-/area/maintenance/lower/atmos)
 "aWw" = (
 /obj/structure/closet/crate,
 /obj/random/maintenance/engineering,
@@ -31694,16 +31674,6 @@
 /obj/random/maintenance/cargo,
 /obj/random/maintenance/cargo,
 /obj/random/drinkbottle,
-/turf/simulated/floor/plating,
-/area/maintenance/lower/vacant_site)
-"nlo" = (
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/random/trash_pile,
 /turf/simulated/floor/plating,
 /area/maintenance/lower/vacant_site)
 "obY" = (
@@ -40164,7 +40134,7 @@ avk
 avR
 awB
 axc
-axQ
+arM
 ayF
 acb
 apu
@@ -40293,7 +40263,7 @@ bck
 bcw
 bck
 bcy
-bco
+aqS
 bco
 bcl
 apu
@@ -40583,7 +40553,7 @@ apu
 apu
 aqb
 ate
-atK
+arD
 aur
 apu
 bcr
@@ -41172,7 +41142,7 @@ aah
 aBO
 aBO
 aBO
-aIc
+atK
 aIJ
 aIh
 aKl
@@ -41576,7 +41546,7 @@ arL
 arX
 apu
 aqb
-atf
+ate
 apu
 bcd
 apu
@@ -41625,7 +41595,7 @@ aah
 aah
 aVn
 aUE
-aWv
+aTZ
 aVn
 aXf
 aTZ
@@ -41714,7 +41684,7 @@ ahX
 apu
 apu
 aqb
-arM
+arm
 arY
 apu
 aqb
@@ -42307,7 +42277,7 @@ aah
 aah
 aBO
 aHf
-aHw
+atf
 aIh
 aIP
 aJH
@@ -42440,7 +42410,7 @@ axZ
 ayJ
 azR
 agM
-aBN
+aHZ
 aCw
 aBO
 aah
@@ -42835,7 +42805,7 @@ abn
 aeB
 afd
 afC
-agd
+afd
 abT
 bbB
 bbe
@@ -44432,7 +44402,7 @@ aBT
 aCG
 aDo
 ayh
-aED
+aEv
 aFl
 aBO
 aah
@@ -46377,7 +46347,7 @@ akg
 ace
 akp
 acq
-aen
+ael
 abH
 aiF
 aek
@@ -46522,7 +46492,7 @@ aaU
 aaU
 abH
 aiF
-ael
+aen
 aaU
 aah
 aah
@@ -46814,7 +46784,7 @@ aaU
 aaU
 aaU
 agF
-agQ
+agd
 anq
 ahz
 anK
@@ -47098,8 +47068,8 @@ aaU
 aaU
 aaU
 agH
+agQ
 agS
-anr
 ahB
 abH
 aaU
@@ -47534,7 +47504,7 @@ aah
 apF
 apF
 aql
-nlo
+anr
 apF
 aah
 aah

--- a/maps/tether/tether-02-surface2.dmm
+++ b/maps/tether/tether-02-surface2.dmm
@@ -621,9 +621,15 @@
 /turf/simulated/floor/plating,
 /area/maintenance/lower/mining)
 "abm" = (
-/obj/random/trash_pile,
-/turf/simulated/floor/plating,
-/area/maintenance/lower/mining)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/lower/north)
 "abn" = (
 /turf/simulated/wall,
 /area/maintenance/lower/public_garden_maintenence/upper)
@@ -1358,16 +1364,12 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/north)
 "adb" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+/obj/structure/railing{
+	dir = 4
 	},
 /obj/random/trash_pile,
-/turf/simulated/floor/tiled/techfloor,
-/area/maintenance/lower/north)
+/turf/simulated/floor/tiled/techmaint,
+/area/maintenance/lower/bar)
 "adc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -1977,7 +1979,6 @@
 "aeo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/rust,
-/obj/random/trash_pile,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/mining)
 "aep" = (
@@ -2040,7 +2041,6 @@
 /obj/structure/railing{
 	dir = 4
 	},
-/obj/random/trash_pile,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/bar)
 "aew" = (
@@ -2242,7 +2242,6 @@
 /obj/effect/floor_decal/techfloor{
 	dir = 10
 	},
-/obj/random/trash_pile,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/north)
 "aeW" = (
@@ -3184,7 +3183,6 @@
 	dir = 4
 	},
 /obj/structure/railing,
-/obj/random/trash_pile,
 /turf/simulated/floor/tiled/techmaint,
 /area/maintenance/lower/bar)
 "agK" = (
@@ -3832,10 +3830,17 @@
 /turf/simulated/floor/plating,
 /area/maintenance/lower/rnd)
 "aim" = (
-/obj/random/trash_pile,
+/obj/effect/floor_decal/techfloor{
+	dir = 4
+	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/maintenance/lower/rnd)
+/obj/effect/floor_decal/rust,
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/asmaint2)
 "ain" = (
 /obj/structure/cable/green{
 	d1 = 32;
@@ -4487,9 +4492,12 @@
 /turf/simulated/mineral,
 /area/maintenance/lower/rnd)
 "ajz" = (
-/obj/random/trash_pile,
-/turf/simulated/floor/plating,
-/area/maintenance/lower/rnd)
+/obj/effect/floor_decal/corner_techfloor_grid/full{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/lower/south)
 "ajA" = (
 /obj/structure/closet/crate,
 /obj/random/maintenance/clean,
@@ -6457,6 +6465,44 @@
 	},
 /turf/simulated/floor/lino,
 /area/chapel/office)
+"ang" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/maintenance/lower/south)
+"anh" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/rust,
+/obj/random/trash_pile,
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/asmaint2)
+"ani" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 5
+	},
+/obj/structure/railing,
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/lower/atmos)
+"anj" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/effect/floor_decal/techfloor,
+/obj/machinery/atmospherics/pipe/simple/visible/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/lower/south)
 "ank" = (
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/asmaint2)
@@ -6532,6 +6578,41 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/techmaint,
 /area/tether/surfacebase/atrium_two)
+"anu" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/effect/floor_decal/techfloor,
+/obj/machinery/atmospherics/pipe/simple/visible/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/supply{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/lower/south)
+"anv" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/lower/atmos)
+"anw" = (
+/obj/machinery/light/small,
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/maintenance/lower/atmos)
+"anx" = (
+/obj/random/trash_pile,
+/turf/simulated/floor/plating,
+/area/maintenance/lower/atmos)
 "any" = (
 /turf/simulated/mineral,
 /area/maintenance/lower/bar)
@@ -6631,19 +6712,6 @@
 /obj/machinery/atmospherics/pipe/simple/visible/purple{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/maintenance/asmaint2)
-"anM" = (
-/obj/effect/floor_decal/techfloor{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/rust,
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/random/trash_pile,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/asmaint2)
 "anN" = (
@@ -6822,25 +6890,6 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/maintenance/asmaint2)
-"aoj" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/effect/floor_decal/techfloor{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/black{
-	dir = 1
-	},
-/obj/random/trash_pile,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/asmaint2)
 "aok" = (
@@ -10841,20 +10890,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/south)
-"awa" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/effect/floor_decal/techfloor{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/visible/purple{
-	dir = 1
-	},
-/obj/random/trash_pile,
-/turf/simulated/floor/tiled/techfloor,
-/area/maintenance/asmaint2)
 "awb" = (
 /obj/structure/railing{
 	dir = 8
@@ -11779,18 +11814,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/rust,
-/turf/simulated/floor/tiled/techfloor,
-/area/maintenance/asmaint2)
-"axG" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/effect/floor_decal/techfloor{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/rust,
-/obj/random/trash_pile,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/asmaint2)
 "axH" = (
@@ -13925,14 +13948,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/south)
-"aAJ" = (
-/obj/effect/floor_decal/corner_techfloor_grid/full{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/random/trash_pile,
-/turf/simulated/floor/tiled/techfloor,
-/area/maintenance/lower/south)
 "aAK" = (
 /obj/structure/railing{
 	dir = 4
@@ -15610,17 +15625,6 @@
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating,
 /area/engineering/drone_fabrication)
-"aDY" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/random/trash_pile,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/maintenance/lower/south)
 "aDZ" = (
 /obj/structure/railing{
 	dir = 1
@@ -15689,10 +15693,6 @@
 	pixel_y = 0
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/techfloor,
-/area/maintenance/lower/south)
-"aEh" = (
-/obj/random/trash_pile,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/south)
 "aEi" = (
@@ -15807,11 +15807,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel_dirty,
 /area/maintenance/asmaint2)
-"aEx" = (
-/obj/random/trash_pile,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/maintenance/lower/atmos)
 "aEy" = (
 /obj/structure/catwalk,
 /obj/random/junk,
@@ -16345,14 +16340,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/atmos)
-"aFP" = (
-/obj/effect/floor_decal/techfloor{
-	dir = 5
-	},
-/obj/structure/railing,
-/obj/random/trash_pile,
-/turf/simulated/floor/tiled/techfloor,
-/area/maintenance/lower/atmos)
 "aFQ" = (
 /obj/structure/catwalk,
 /obj/effect/decal/cleanable/cobweb,
@@ -16859,21 +16846,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/south)
-"aGP" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/effect/floor_decal/techfloor,
-/obj/machinery/atmospherics/pipe/simple/visible/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/supply{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/random/trash_pile,
-/turf/simulated/floor/tiled/techfloor,
-/area/maintenance/lower/south)
 "aGQ" = (
 /obj/structure/catwalk,
 /obj/effect/floor_decal/techfloor,
@@ -17009,13 +16981,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/outpost/xenobiology/outpost_slimepens)
-"aHf" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/random/trash_pile,
-/turf/simulated/floor/plating,
-/area/maintenance/lower/atmos)
 "aHg" = (
 /obj/structure/table/steel,
 /obj/item/weapon/tape_roll,
@@ -17524,13 +17489,6 @@
 /area/maintenance/lower/atmos)
 "aIg" = (
 /obj/machinery/vending/assist,
-/turf/simulated/floor/plating,
-/area/maintenance/lower/atmos)
-"aIh" = (
-/obj/random/trash_pile,
-/obj/structure/railing{
-	dir = 4
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/lower/atmos)
 "aIi" = (
@@ -20833,18 +20791,6 @@
 /obj/random/maintenance/clean,
 /obj/random/maintenance/clean,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/maintenance/lower/atmos)
-"aOd" = (
-/obj/machinery/light/small,
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/random/trash_pile,
 /turf/simulated/floor/plating,
 /area/maintenance/lower/atmos)
 "aOe" = (
@@ -27093,16 +27039,6 @@
 	can_open = 1
 	},
 /area/maintenance/lower/bar)
-"aXT" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/effect/floor_decal/techfloor/orange{
-	dir = 4
-	},
-/obj/random/trash_pile,
-/turf/simulated/floor/tiled/techfloor,
-/area/maintenance/lower/bar)
 "aYd" = (
 /turf/simulated/wall,
 /area/chapel/main)
@@ -27726,20 +27662,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/corner_techfloor_grid{
-	dir = 4
-	},
-/obj/random/trash_pile,
-/turf/simulated/floor/tiled/techfloor,
-/area/maintenance/lower/south)
-"aZC" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/effect/floor_decal/techfloor,
-/obj/machinery/atmospherics/pipe/simple/visible/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/supply{
 	dir = 4
 	},
 /obj/random/trash_pile,
@@ -34171,12 +34093,12 @@ aog
 aog
 ars
 asg
-asg
+anh
 aog
 auh
 aog
 avr
-awa
+aog
 aog
 axF
 aog
@@ -34589,8 +34511,8 @@ akb
 amU
 ann
 anC
-anM
-aoj
+aim
+auT
 anC
 apr
 aqb
@@ -34604,7 +34526,7 @@ auT
 anC
 awb
 awP
-axG
+ayr
 ayr
 azb
 anm
@@ -37030,8 +36952,8 @@ aCV
 aBV
 aDH
 aDS
-aEn
-aEx
+anx
+aEo
 aEP
 aDS
 aFp
@@ -37751,7 +37673,7 @@ aFW
 aEo
 aEn
 aDS
-aHf
+anv
 aHD
 aIb
 aEQ
@@ -38558,7 +38480,7 @@ aik
 amw
 aiT
 ail
-ajz
+ajx
 ajy
 ajy
 ajy
@@ -38619,7 +38541,7 @@ aMq
 aMq
 aDS
 aEQ
-aOd
+anw
 aDS
 aac
 aac
@@ -38838,7 +38760,7 @@ ahe
 ahH
 alO
 age
-aim
+ail
 amx
 aiV
 ajk
@@ -39031,7 +38953,7 @@ aEQ
 aGX
 aHj
 aHj
-aIh
+anv
 aDS
 aEo
 aDS
@@ -40383,7 +40305,7 @@ aci
 act
 acH
 acP
-adb
+abm
 aac
 aac
 adY
@@ -40444,7 +40366,7 @@ aAX
 aFd
 aFb
 azl
-aFP
+ani
 aGd
 aDT
 aGC
@@ -41289,7 +41211,7 @@ aCH
 aCH
 aDB
 aDN
-aDY
+ang
 arZ
 aBO
 aCH
@@ -42293,7 +42215,7 @@ aEs
 avp
 aGe
 aGt
-aZC
+anj
 arZ
 aac
 aac
@@ -42719,7 +42641,7 @@ arZ
 avp
 aGg
 aGv
-aGP
+anu
 arZ
 aac
 aHP
@@ -43419,7 +43341,7 @@ arZ
 arZ
 arZ
 aDQ
-aEh
+avp
 axC
 aEK
 avp
@@ -43837,7 +43759,7 @@ avp
 avp
 avp
 azT
-aAJ
+ajz
 arZ
 aac
 aac
@@ -43940,7 +43862,7 @@ aee
 aez
 aeS
 afy
-aXT
+afy
 afy
 agr
 agE
@@ -44083,7 +44005,7 @@ aeA
 aeT
 afz
 afO
-afO
+adb
 afz
 afO
 agJ
@@ -44355,7 +44277,7 @@ aQs
 aSn
 aSC
 aad
-abm
+abV
 aby
 abW
 acl

--- a/maps/tether/tether-03-surface3.dmm
+++ b/maps/tether/tether-03-surface3.dmm
@@ -4645,7 +4645,6 @@
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/triage)
 "ic" = (
-/obj/random/trash_pile,
 /obj/effect/floor_decal/techfloor{
 	dir = 10
 	},

--- a/maps/tether/tether-05-station1.dmm
+++ b/maps/tether/tether-05-station1.dmm
@@ -1148,6 +1148,10 @@
 	},
 /turf/simulated/floor,
 /area/maintenance/station/eng_lower)
+"acc" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor,
+/area/hallway/station/docks)
 "acd" = (
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'RADIOACTIVE AREA'";
@@ -7475,11 +7479,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet,
 /area/maintenance/abandonedlibrary)
-"api" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/random/trash_pile,
-/turf/simulated/floor,
-/area/maintenance/station/eng_lower)
 "apj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -10465,11 +10464,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor,
 /area/maintenance/station/bridge)
-"axl" = (
-/obj/random/trash_pile,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor,
-/area/maintenance/station/bridge)
 "axt" = (
 /obj/random/trash_pile,
 /turf/simulated/floor,
@@ -11280,11 +11274,6 @@
 	dir = 5
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/station/docks)
-"aAq" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/random/trash_pile,
-/turf/simulated/floor,
 /area/hallway/station/docks)
 "aAG" = (
 /obj/structure/bed/chair{
@@ -30082,7 +30071,7 @@ aef
 abP
 abC
 adG
-ahq
+ack
 aJs
 aiV
 aJV
@@ -30251,7 +30240,7 @@ aLl
 aET
 aaV
 atp
-api
+acj
 aMt
 aqs
 amA
@@ -30513,7 +30502,7 @@ ack
 ach
 ack
 akq
-api
+acj
 ahY
 aiR
 amR
@@ -30696,7 +30685,7 @@ bXs
 bnl
 azl
 azl
-aAq
+acc
 awu
 aac
 aac
@@ -30802,7 +30791,7 @@ aik
 aik
 aik
 aik
-ack
+ahq
 ack
 ack
 jRS
@@ -30810,7 +30799,7 @@ ach
 ach
 acj
 aiR
-api
+acj
 aiX
 abC
 anE
@@ -34098,7 +34087,7 @@ acy
 acp
 aqg
 awK
-axl
+aEG
 axM
 bmc
 aza

--- a/maps/tether/tether-06-station2.dmm
+++ b/maps/tether/tether-06-station2.dmm
@@ -396,10 +396,14 @@
 /turf/simulated/floor,
 /area/maintenance/station/sec_lower)
 "aO" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	icon_state = "bulb1";
+	dir = 1
+	},
+/obj/structure/railing,
 /obj/random/trash_pile,
 /turf/simulated/floor,
-/area/maintenance/station/sec_lower)
+/area/maintenance/station/exploration)
 "aP" = (
 /turf/simulated/mineral/floor/vacuum,
 /area/mine/explored/upper_level)
@@ -3935,9 +3939,12 @@
 /turf/simulated/floor/tiled,
 /area/hallway/station/port)
 "fN" = (
-/obj/random/trash_pile,
+/obj/structure/railing,
+/obj/structure/railing{
+	dir = 4
+	},
 /turf/simulated/floor,
-/area/maintenance/station/sec_lower)
+/area/maintenance/station/exploration)
 "fO" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/steeldecal/steel_decals7{
@@ -6482,13 +6489,9 @@
 /turf/simulated/floor/tiled,
 /area/tether/exploration/crew)
 "ju" = (
-/obj/machinery/light/small{
-	icon_state = "bulb1";
-	dir = 1
-	},
-/obj/structure/railing,
-/turf/simulated/floor,
-/area/maintenance/station/exploration)
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor/plating,
+/area/maintenance/station/sec_lower)
 "jv" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -6506,13 +6509,10 @@
 /turf/simulated/floor/tiled,
 /area/tether/exploration/staircase)
 "jw" = (
-/obj/structure/railing,
-/obj/structure/railing{
-	dir = 4
-	},
+/obj/effect/decal/cleanable/dirt,
 /obj/random/trash_pile,
-/turf/simulated/floor,
-/area/maintenance/station/exploration)
+/turf/simulated/floor/plating,
+/area/maintenance/station/sec_lower)
 "jx" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/purple/border,
@@ -8293,9 +8293,12 @@
 /area/storage/tech)
 "mf" = (
 /obj/structure/railing,
-/obj/random/trash_pile,
+/obj/structure/railing{
+	icon_state = "railing0";
+	dir = 4
+	},
 /turf/simulated/floor,
-/area/maintenance/station/exploration)
+/area/maintenance/station/medbay)
 "mg" = (
 /obj/structure/cable/green{
 	d2 = 2;
@@ -17477,15 +17480,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery_hallway)
-"AD" = (
-/obj/structure/railing,
-/obj/structure/railing{
-	icon_state = "railing0";
-	dir = 4
-	},
-/obj/random/trash_pile,
-/turf/simulated/floor,
-/area/maintenance/station/medbay)
 "AE" = (
 /obj/machinery/door/firedoor/glass,
 /obj/structure/grille,
@@ -22935,11 +22929,6 @@
 /obj/machinery/vending/cola,
 /turf/simulated/floor/tiled,
 /area/engineering/foyer_mezzenine)
-"YU" = (
-/obj/effect/floor_decal/rust,
-/obj/random/trash_pile,
-/turf/simulated/floor/plating,
-/area/maintenance/station/sec_lower)
 "Za" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -27532,7 +27521,7 @@ at
 at
 XM
 Ny
-Zr
+jw
 Zr
 FR
 DA
@@ -32212,7 +32201,7 @@ fb
 WL
 hZ
 fd
-fN
+RS
 jQ
 kk
 fq
@@ -32772,8 +32761,8 @@ XM
 be
 Uf
 at
-YU
-fN
+ju
+RS
 RS
 RS
 RS
@@ -32904,7 +32893,7 @@ OA
 FA
 QG
 at
-aO
+bf
 bf
 bx
 bS
@@ -34234,7 +34223,7 @@ xf
 xf
 xf
 Ar
-AD
+mf
 AT
 xg
 ac
@@ -35472,7 +35461,7 @@ dF
 bT
 fg
 cZ
-mf
+mx
 ns
 mB
 ic
@@ -36037,7 +36026,7 @@ bg
 bg
 bg
 bg
-ju
+aO
 ls
 bg
 mx
@@ -36179,7 +36168,7 @@ gO
 bU
 ip
 bg
-jw
+fN
 lP
 bg
 Ec

--- a/maps/tether/tether-07-station3.dmm
+++ b/maps/tether/tether-07-station3.dmm
@@ -1551,7 +1551,6 @@
 /turf/simulated/floor/tiled/monotile,
 /area/tether/exploration)
 "cq" = (
-/obj/random/trash_pile,
 /obj/effect/decal/cleanable/cobweb{
 	icon_state = "cobweb2"
 	},
@@ -6693,7 +6692,6 @@
 /obj/structure/railing{
 	dir = 4
 	},
-/obj/random/trash_pile,
 /turf/simulated/floor,
 /area/maintenance/station/sec_upper)
 "kv" = (
@@ -6870,7 +6868,6 @@
 /obj/structure/railing{
 	dir = 4
 	},
-/obj/random/trash_pile,
 /turf/simulated/floor,
 /area/maintenance/station/sec_upper)
 "kK" = (
@@ -8352,7 +8349,6 @@
 /obj/structure/railing{
 	dir = 4
 	},
-/obj/random/trash_pile,
 /turf/simulated/floor,
 /area/maintenance/cargo)
 "mW" = (
@@ -9518,7 +9514,6 @@
 /turf/simulated/floor,
 /area/maintenance/cargo)
 "oR" = (
-/obj/random/trash_pile,
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor,
 /area/maintenance/cargo)
@@ -10805,6 +10800,7 @@
 "qV" = (
 /obj/effect/floor_decal/rust,
 /obj/effect/decal/cleanable/cobweb,
+/obj/random/trash_pile,
 /turf/simulated/floor,
 /area/maintenance/station/elevator)
 "qW" = (
@@ -14119,7 +14115,6 @@
 	d2 = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/random/trash_pile,
 /obj/structure/disposalpipe/segment{
 	dir = 4;
 	icon_state = "pipe-c"
@@ -19913,7 +19908,6 @@
 /area/medical/medbay_emt_bay)
 "EP" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/random/trash_pile,
 /obj/structure/railing{
 	icon_state = "railing0";
 	dir = 4


### PR DESCRIPTION
This makes there be less trash piles in maint. This is intended to go with a buff to trash piles so they'll ideally give you less straight up garbo. 

There were 62 before. Now there's 12.

None of the trash piles are in any of the rooms, they are only in maint tunnels specifically.