### PR TITLE
Fix #3521 - Loadout Implants Properly go in Mob, not on Floor

### DIFF
--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -389,9 +389,6 @@ var/global/datum/controller/occupations/job_master
 							H << "<span class='warning'>Your current species, job or whitelist status does not permit you to spawn with [thing]!</span>"
 							continue
 
-						if(G.exploitable)
-							H.amend_exploitable(G.path)
-
 						if(G.slot == "implant")
 							var/obj/item/weapon/implant/I = G.spawn_item(H)
 							I.invisibility = 100

--- a/code/game/objects/items/weapons/implants/implant.dm
+++ b/code/game/objects/items/weapons/implants/implant.dm
@@ -66,8 +66,7 @@
 
 /obj/item/weapon/implant/proc/implant_loadout(var/mob/living/carbon/human/H)
 	if(H)
-		var/obj/item/organ/external/affected = H.organs_by_name[initialize_loc]
-		if(handle_implant(H, affected))
+		if(handle_implant(H, initialize_loc))
 			invisibility = initial(invisibility)
 			post_implant(H)
 

--- a/code/game/objects/items/weapons/implants/implantdud.dm
+++ b/code/game/objects/items/weapons/implants/implantdud.dm
@@ -19,12 +19,3 @@
 	icon = 'icons/obj/device.dmi'
 	icon_state = "implant"
 	roundstart = FALSE
-
-/obj/item/weapon/implant/dud/Initialize()
-	..()
-	if(roundstart)
-		invisibility = 100
-		..()
-		spawn(3)
-			if(!ishuman(loc) && !QDELETED(src))
-				qdel(src)

--- a/code/game/objects/items/weapons/implants/neuralbasic.dm
+++ b/code/game/objects/items/weapons/implants/neuralbasic.dm
@@ -105,10 +105,3 @@ Implant Specifics:<BR>"}
 		my_brain.take_damage(15)
 		my_brain = null
 	return
-
-/obj/item/weapon/implant/neural/roundstart/Initialize()
-	invisibility = 100
-	..()
-	spawn(3)
-		if(!ishuman(loc) && !QDELETED(src))
-			qdel(src)

--- a/code/modules/client/preference_setup/loadout/loadout.dm
+++ b/code/modules/client/preference_setup/loadout/loadout.dm
@@ -70,10 +70,10 @@ var/list/gear_datums = list()
 			continue
 		if(max_cost && G.cost > max_cost)
 			continue
-		if(G.ckeywhitelist && !(preference_mob.ckey in G.ckeywhitelist)) //Vorestation Edit 
-			continue  //Vorestation Edit 
-		if(G.character_name && !(preference_mob.client.prefs.real_name in G.character_name))  //Vorestation Edit 
-			continue  //Vorestation Edit 
+		if(G.ckeywhitelist && !(preference_mob.ckey in G.ckeywhitelist)) //Vorestation Edit
+			continue  //Vorestation Edit
+		if(G.character_name && !(preference_mob.client.prefs.real_name in G.character_name))  //Vorestation Edit
+			continue  //Vorestation Edit
 		. += gear_name
 
 /datum/category_item/player_setup_item/loadout/sanitize_character()
@@ -271,4 +271,7 @@ var/list/gear_datums = list()
 	var/item = new gd.path(gd.location)
 	for(var/datum/gear_tweak/gt in gear_tweaks)
 		gt.tweak_item(item, metadata["[gt]"])
+	var/mob/M = location
+	if(istype(M) && exploitable) //Update exploitable info records for the mob without creating a duplicate object at their feet.
+		M.amend_exploitable(item)
 	return item

--- a/code/modules/client/preference_setup/loadout/loadout_utility.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_utility.dm
@@ -127,7 +127,7 @@
 /datum/gear/utility/implant/neural
 	display_name = "implant, neural assistance web"
 	description = "A complex web implanted into the subject, medically in order to compensate for neurological disease."
-	path = /obj/item/weapon/implant/neural/roundstart
+	path = /obj/item/weapon/implant/neural
 	cost = 6
 
 /datum/gear/utility/implant/dud1

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1110,10 +1110,10 @@ mob/proc/yank_out_object()
 //Exploitable Info Update
 
 /mob/proc/amend_exploitable(var/obj/item/I)
-	var/obj/item/exploit_item = new I(src.loc)
-	exploit_addons |= exploit_item
-	var/exploitmsg = html_decode("\n" + "Has " + exploit_item.name + ".")
-	exploit_record += exploitmsg
+	if(istype(I))
+		exploit_addons |= I
+		var/exploitmsg = html_decode("\n" + "Has " + I.name + ".")
+		exploit_record += exploitmsg
 
 /client/proc/check_has_body_select()
 	return mob && mob.hud_used && istype(mob.zone_sel, /obj/screen/zone_sel)


### PR DESCRIPTION
Fixes #3521

The main cause is the 'exploitable' check from `code/game/jobs/job_controller.dm` because the proc `amend_exploitable` from `code/modules/mob/mob.dm` spawns a duplicate of the implant at the mob's feet.
This was less apparent because for all the other implants (dud, neural, etc.) the `Initialize()` behaviours deleted them so they wouldn't be visible on the ground, so the indication they had the same issue was that they weren't present in the appropriate parent organ's `contents` or `implants` lists.

Tertiary issues were...
- The `implant_loadout` proc in `code/game/objects/items/weapons/implants/implant.dm` not inserting the implant in the correct location (was passing an organ instead of a zone define like BP_HEAD, which has a string value of "head".)
- There were unnecessary post-spawn behaviours for dud and neural fluff implants.

What now happens:
- The exploitable check now occurs in the `spawn_item` proc from `code/modules/client/preference_setup/loadout/loadout.dm`.
- The loadout implants are now inserted into the correct locations within a mob.
- There won't be implants created on the floor anymore.

-------------------

I verified this by spawning in with every implant, checking the parent organs (chest & head), referring to the `contents` & `implants` lists and seeing that for the head the brain was "assisted". No implants were on the floor.