### PR TITLE
Amends Clipping Logic - Fixes Issue with Space-suits & Taurs

### DIFF
--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -585,7 +585,7 @@ var/global/list/damage_icon_parts = list() //see UpdateDamageIcon()
 	var/icon/c_mask = null
 	if(tail_style && tail_style.clip_mask_icon && tail_style.clip_mask_state)
 		var/obj/item/clothing/suit/S = wear_suit
-		if(!(wear_suit && ((wear_suit.flags_inv & HIDETAIL) || (istype(S) && S.taurized)))) //Clip the lower half of the suit off using the tail's clip mask.
+		if(!(wear_suit && ((wear_suit.flags_inv & HIDETAIL) || (istype(S) && S.taurized)))) //Clip the lower half of the uniform off using the tail's clip mask.
 			c_mask = new /icon(tail_style.clip_mask_icon, tail_style.clip_mask_state)
 	overlays_standing[UNIFORM_LAYER] = w_uniform.make_worn_icon(body_type = species.get_bodytype(src), slot_name = slot_w_uniform_str, default_icon = INV_W_UNIFORM_DEF_ICON, default_layer = UNIFORM_LAYER, clip_mask = c_mask)
 	//VOREStation Edit end.
@@ -768,7 +768,10 @@ var/global/list/damage_icon_parts = list() //see UpdateDamageIcon()
 
 	//VOREStation Edit start.
 	var/icon/c_mask = null
-	if((tail_style && tail_style.clip_mask_icon && tail_style.clip_mask_state) && !(wear_suit.flags_inv & HIDETAIL) && !(S && S.taurized)) //Clip the lower half of the suit off using the tail's clip mask.
+	var/tail_is_rendered = (overlays_standing[TAIL_LAYER] || overlays_standing[TAIL_LAYER_ALT])
+	var/valid_clip_mask = (tail_style && tail_style.clip_mask_icon && tail_style.clip_mask_state)
+
+	if(tail_is_rendered && valid_clip_mask && !(S && S.taurized)) //Clip the lower half of the suit off using the tail's clip mask for taurs since taur bodies aren't hidden.
 		c_mask = new /icon(tail_style.clip_mask_icon, tail_style.clip_mask_state)
 	overlays_standing[SUIT_LAYER] = wear_suit.make_worn_icon(body_type = species.get_bodytype(src), slot_name = slot_wear_suit_str, default_icon = iconFile, default_layer = SUIT_LAYER, clip_mask = c_mask)
 	//VOREStation Edit end.


### PR DESCRIPTION
Fixes an issue whereby a suit that has the HIDETAIL flag that is worn by a taur would not be clipped.

This presents itself as tails sprited into spacesuits sticking out beneath a taur. Looks wack!

![virgo ss13 fix suit clipping](https://user-images.githubusercontent.com/12377767/67836081-8c4eb780-fae3-11e9-9ba4-3e805f801178.png)
