### PR TITLE
Fixes high endurance bodies dying in grower pod

### DIFF
--- a/code/modules/resleeving/machines.dm
+++ b/code/modules/resleeving/machines.dm
@@ -85,7 +85,7 @@
 		H.add_modifier(modifier_type)
 
 	//Apply damage
-	H.adjustCloneLoss((H.getMaxHealth() - config.health_threshold_dead)*0.75)
+	H.adjustCloneLoss((H.getMaxHealth() - config.health_threshold_dead)*-0.75)
 	H.Paralyse(4)
 	H.updatehealth()
 


### PR DESCRIPTION
The math that was supposed to protect low endurance bodies had been mistakenly calculating the clone damage reduction with a double-negative, causing the opposite effect. The cloneloss to be taken from maxhealth apparently was intended to be maxhealth-75, but because the number to be substracted was already negative, it was instead causing a high endurance body (125 maxhealth) receive a total of 125+75 cloneloss = ded