### PR TITLE
Redo almost all the cameras, also delete old space bridge's meeting room

### DIFF
--- a/maps/tether/tether-02-surface2.dmm
+++ b/maps/tether/tether-02-surface2.dmm
@@ -100,6 +100,39 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/tether/surfacebase/medical/lowerhall)
 "aas" = (
+/obj/structure/closet/secure_closet/warden,
+/obj/item/weapon/gun/projectile/shotgun/pump/combat{
+	ammo_type = /obj/item/ammo_casing/a12g/beanbag;
+	desc = "Built for close quarters combat, the Hesphaistos Industries KS-40 is widely regarded as a weapon of choice for repelling boarders. This one has 'Property of the Warden' inscribed on the stock.";
+	name = "warden's shotgun"
+	},
+/obj/item/weapon/book/manual/security_space_law,
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/obj/structure/cable/green{
+	icon_state = "0-8"
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/dark,
+/area/tether/surfacebase/security/warden)
+"aat" = (
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/maintenance/common,
+/turf/simulated/floor/plating,
+/area/maintenance/lower/public_garden_maintenence/upper)
+"aau" = (
+/obj/structure/stairs/west,
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/lower/bar)
+"aav" = (
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 9
 	},
@@ -117,18 +150,8 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/camera/network/medbay,
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/surgery)
-"aat" = (
-/obj/machinery/door/firedoor/glass,
-/obj/machinery/door/airlock/maintenance/common,
-/turf/simulated/floor/plating,
-/area/maintenance/lower/public_garden_maintenence/upper)
-"aau" = (
-/obj/structure/stairs/west,
-/turf/simulated/floor/tiled/techfloor,
-/area/maintenance/lower/bar)
 "aaw" = (
 /obj/machinery/power/breakerbox/activated{
 	RCon_tag = "MedSec Substation Bypass"
@@ -153,12 +176,20 @@
 /turf/simulated/floor,
 /area/maintenance/substation/medsec)
 "aay" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 5
 	},
-/obj/machinery/camera/network/engineering,
-/turf/simulated/floor,
-/area/maintenance/substation/medsec)
+/obj/effect/floor_decal/corner/white/border{
+	dir = 5
+	},
+/obj/structure/table/standard,
+/obj/item/device/defib_kit/loaded,
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1"
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/surgery)
 "aaz" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -234,18 +265,12 @@
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 5
 	},
-/obj/effect/floor_decal/corner/white/border{
+/obj/effect/floor_decal/corner/paleblue/border{
 	dir = 5
 	},
-/obj/structure/table/standard,
-/obj/item/device/defib_kit/loaded,
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
-	},
-/obj/machinery/camera/network/medbay,
+/obj/machinery/organ_printer/flesh,
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/surgery)
+/area/tether/surfacebase/medical/resleeving)
 "aaF" = (
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 9
@@ -274,6 +299,27 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/resleeving)
+"aaI" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 6
+	},
+/obj/machinery/camera/network/medbay,
+/turf/simulated/floor/tiled/dark,
+/area/tether/surfacebase/medical/resleeving)
+"aaJ" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 1
+	},
+/obj/machinery/vending/medical,
+/obj/machinery/camera/network/medbay,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/storage)
 "aaK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -379,6 +425,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/camera/network/engineering{
+	dir = 1
+	},
 /turf/simulated/floor,
 /area/maintenance/substation/medsec)
 "aaU" = (
@@ -445,16 +494,21 @@
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/resleeving)
 "aaX" = (
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 5
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 5
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/machinery/organ_printer/flesh,
-/obj/machinery/camera/network/medbay,
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/resleeving)
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/red/border,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/security/lowerhallway)
 "aaY" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 9
@@ -1214,20 +1268,14 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
 "acN" = (
-/obj/structure/closet/secure_closet/RD,
-/obj/item/device/aicard,
-/obj/item/clothing/glasses/omnihud/rnd,
-/obj/effect/floor_decal/borderfloor{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/obj/effect/floor_decal/corner/mauve/border{
-	dir = 9
-	},
-/obj/machinery/camera/network/research{
-	dir = 4
+/obj/structure/bed/chair{
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
-/area/rnd/rdoffice)
+/area/tether/surfacebase/security/solitary)
 "acO" = (
 /obj/structure/sign/nanotrasen,
 /turf/simulated/wall,
@@ -1260,15 +1308,9 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/mining)
 "acT" = (
-/obj/effect/floor_decal/techfloor{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 6
-	},
 /obj/machinery/camera/network/medbay,
-/turf/simulated/floor/tiled/dark,
-/area/tether/surfacebase/medical/resleeving)
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lowerhall)
 "acU" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -2295,24 +2337,24 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/tether/surfacebase/surface_two_hall)
 "afd" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 1
-	},
-/obj/effect/floor_decal/borderfloor/corner2{
+/obj/machinery/atmospherics/pipe/simple/hidden/green{
+	icon_state = "intact";
 	dir = 4
 	},
-/obj/structure/cable{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	icon_state = "intact-scrubbers";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/camera/network/tether,
-/turf/simulated/floor/tiled/techmaint,
-/area/tether/surfacebase/surface_two_hall)
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/security/lowerhallway)
 "afe" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -2508,18 +2550,19 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/tether/surfacebase/surface_two_hall)
 "afq" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 1
+/obj/effect/floor_decal/borderfloorblack,
+/obj/structure/closet{
+	name = "Evidence Closet"
 	},
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 1
+/obj/machinery/alarm{
+	alarm_id = null;
+	breach_detection = 0;
+	dir = 1;
+	icon_state = "alarm0";
+	pixel_y = -22
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/camera/network/tether,
-/turf/simulated/floor/tiled/techmaint,
-/area/tether/surfacebase/surface_two_hall)
+/turf/simulated/floor/tiled/dark,
+/area/tether/surfacebase/security/evidence)
 "afr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -3264,11 +3307,11 @@
 /turf/simulated/wall,
 /area/tether/surfacebase/north_staires_two)
 "ahd" = (
-/obj/machinery/camera/network/tether{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/turf/simulated/open,
-/area/tether/surfacebase/north_staires_two)
+/turf/simulated/floor,
+/area/maintenance/substation/medsec)
 "ahe" = (
 /obj/structure/sign/directions/medical{
 	dir = 1;
@@ -3300,29 +3343,25 @@
 /turf/simulated/wall,
 /area/tether/surfacebase/surface_two_hall)
 "ahh" = (
-/obj/effect/floor_decal/borderfloor{
+/obj/machinery/suit_cycler/medical,
+/obj/machinery/camera/network/medbay{
+	icon_state = "camera";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/paramed)
+"ahi" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 4
+	},
+/obj/structure/bed/chair/wheelchair{
 	dir = 8
 	},
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 10
-	},
-/obj/machinery/camera/network/tether{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/tether/surfacebase/surface_two_hall)
-"ahi" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 6
-	},
-/obj/machinery/camera/network/tether{
-	dir = 9
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/tether/surfacebase/surface_two_hall)
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/storage)
 "ahj" = (
 /obj/structure/catwalk,
 /obj/structure/cable{
@@ -3425,12 +3464,15 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/bar)
 "ahy" = (
-/obj/effect/floor_decal/techfloor{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/machinery/camera/network/civilian,
-/turf/simulated/floor/tiled/techfloor,
-/area/maintenance/lower/bar)
+/obj/machinery/camera/network/security{
+	icon_state = "camera";
+	dir = 10
+	},
+/turf/simulated/floor/tiled/dark,
+/area/tether/surfacebase/security/brig)
 "ahz" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 5
@@ -3624,6 +3666,15 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/tether/surfacebase/surface_two_hall)
+"ahO" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lowerhall)
 "ahP" = (
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/bar)
@@ -4496,6 +4547,9 @@
 /obj/effect/floor_decal/corner/lime/border{
 	dir = 5
 	},
+/obj/machinery/camera/network/civilian{
+	dir = 9
+	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/public_garden_two)
 "ajG" = (
@@ -4521,20 +4575,16 @@
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
 "ajK" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 4
+/obj/structure/bed/chair,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
 	},
-/obj/machinery/camera/network/tether{
-	dir = 9
-	},
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 6
-	},
-/obj/effect/floor_decal/borderfloor/corner2{
+/obj/machinery/camera/network/security{
+	icon_state = "camera";
 	dir = 5
 	},
-/turf/simulated/floor/tiled/techmaint,
-/area/tether/surfacebase/surface_two_hall)
+/turf/simulated/floor/tiled/dark,
+/area/tether/surfacebase/security/interrogation)
 "ajL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -4629,23 +4679,14 @@
 /turf/simulated/wall,
 /area/chapel/chapel_morgue)
 "ajU" = (
-/obj/structure/closet/wardrobe/chaplain_black,
-/obj/item/weapon/storage/fancy/crayons,
-/obj/machinery/camera/network/civilian{
-	dir = 8
+/obj/effect/floor_decal/borderfloor{
+	dir = 9
 	},
-/obj/item/weapon/flame/candle/candelabra,
-/obj/item/weapon/flame/candle/candelabra,
-/obj/item/weapon/flame/candle/candelabra,
-/obj/item/weapon/flame/candle/candelabra,
-/obj/machinery/firealarm{
-	dir = 2;
-	layer = 3.3;
-	pixel_x = 0;
-	pixel_y = 26
+/obj/effect/floor_decal/corner/lime/border{
+	dir = 9
 	},
-/turf/simulated/floor/lino,
-/area/chapel/office)
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden_two)
 "ajV" = (
 /obj/structure/extinguisher_cabinet{
 	dir = 1;
@@ -4754,6 +4795,14 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/public_garden_two)
+"akg" = (
+/obj/machinery/vending/hydronutrients,
+/obj/machinery/camera/network/security{
+	icon_state = "camera";
+	dir = 5
+	},
+/turf/simulated/floor/tiled/dark,
+/area/tether/surfacebase/security/brig)
 "akh" = (
 /obj/machinery/firealarm{
 	dir = 2;
@@ -4827,15 +4876,36 @@
 /turf/simulated/floor/plating,
 /area/maintenance/lower/public_garden_maintenence/upper)
 "ako" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /obj/effect/floor_decal/borderfloor{
-	dir = 9
+	dir = 4
 	},
-/obj/effect/floor_decal/corner/lime/border{
-	dir = 9
+/obj/effect/floor_decal/corner/red/border{
+	dir = 4
 	},
-/obj/machinery/camera/network/civilian,
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/red/bordercorner2{
+	dir = 5
+	},
 /turf/simulated/floor/tiled,
-/area/tether/surfacebase/public_garden_two)
+/area/tether/surfacebase/security/lowerhallway)
 "akp" = (
 /obj/effect/floor_decal/borderfloor/corner{
 	dir = 1
@@ -5272,6 +5342,9 @@
 	dir = 2;
 	pixel_y = -24
 	},
+/obj/machinery/camera/network/civilian{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/public_garden_two)
 "alc" = (
@@ -5392,6 +5465,9 @@
 /obj/item/weapon/material/fishing_net,
 /obj/item/weapon/material/fishing_net,
 /obj/item/weapon/material/fishing_net,
+/obj/machinery/camera/network/civilian{
+	dir = 9
+	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/fish_farm)
 "als" = (
@@ -5401,13 +5477,22 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/tether/surfacebase/fish_farm)
 "alt" = (
-/obj/structure/railing{
-	icon_state = "railing0";
-	dir = 4
+/obj/structure/table/bench/standard,
+/obj/effect/landmark/start{
+	name = "Medical Doctor"
 	},
-/obj/machinery/camera/network/civilian,
-/turf/simulated/floor/water/deep/indoors,
-/area/tether/surfacebase/fish_farm)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	icon_state = "intact-supply";
+	dir = 5
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/breakroom)
 "alu" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
@@ -5419,15 +5504,23 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/fish_farm)
 "alv" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
 	},
-/obj/machinery/camera/network/civilian{
-	icon_state = "camera";
-	dir = 10
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 4
 	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/fish_farm)
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/tether/surfacebase/surface_two_hall)
 "alw" = (
 /obj/effect/floor_decal/rust,
 /obj/structure/cable{
@@ -5536,24 +5629,16 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/fish_farm)
 "alG" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
 	},
-/obj/machinery/camera/network/tether{
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 8;
-	icon_state = "borderfloor";
-	pixel_x = 0
-	},
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techmaint,
 /area/tether/surfacebase/surface_two_hall)
 "alH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -5887,11 +5972,14 @@
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
 "amf" = (
-/obj/machinery/camera/network/civilian{
-	dir = 4
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/tether/surfacebase/fish_farm)
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/tether/surfacebase/surface_two_hall)
 "amg" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
@@ -6138,16 +6226,17 @@
 /turf/simulated/floor/plating,
 /area/maintenance/lower/rnd)
 "amA" = (
-/obj/structure/railing{
-	icon_state = "railing0";
-	dir = 4
+/obj/structure/cable/green{
+	icon_state = "4-8"
 	},
-/obj/machinery/camera/network/civilian{
-	icon_state = "camera";
-	dir = 10
+/obj/machinery/light_switch{
+	dir = 1;
+	on = 0;
+	pixel_x = -10;
+	pixel_y = -24
 	},
-/turf/simulated/floor/water/deep/indoors,
-/area/tether/surfacebase/fish_farm)
+/turf/simulated/floor/tiled/dark,
+/area/teleporter)
 "amB" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
@@ -6277,6 +6366,9 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
+/obj/machinery/camera/network/civilian{
+	dir = 1
+	},
 /mob/living/simple_mob/animal/passive/mouse/white,
 /turf/simulated/floor/grass,
 /area/chapel/office)
@@ -6376,10 +6468,10 @@
 /area/maintenance/lower/rnd)
 "anc" = (
 /obj/effect/floor_decal/borderfloor{
-	dir = 8
-	},
-/obj/machinery/camera/network/tether{
 	dir = 4
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 6
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/tether/surfacebase/surface_two_hall)
@@ -6492,9 +6584,12 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/asmaint2)
 "ano" = (
-/obj/machinery/camera/network/research,
-/turf/simulated/floor/reinforced,
-/area/maintenance/lower/rnd)
+/obj/structure/railing{
+	icon_state = "railing0";
+	dir = 4
+	},
+/turf/simulated/floor/water/deep/indoors,
+/area/tether/surfacebase/fish_farm)
 "anp" = (
 /obj/machinery/light{
 	dir = 1
@@ -7192,16 +7287,11 @@
 	},
 /area/server)
 "aoJ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 6;
-	icon_state = "intact"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
 	},
-/obj/effect/floor_decal/techfloor{
-	dir = 1
-	},
-/obj/machinery/camera/network/research,
-/turf/simulated/floor/tiled/techfloor,
-/area/server)
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/fish_farm)
 "aoK" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 5
@@ -7267,6 +7357,10 @@
 	},
 /obj/effect/floor_decal/corner/mauve/border{
 	dir = 4
+	},
+/obj/machinery/camera/network/research{
+	icon_state = "camera";
+	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/rdoffice)
@@ -7345,9 +7439,7 @@
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
 	},
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/camera/network/tether,
 /turf/simulated/floor/tiled/techmaint,
 /area/tether/surfacebase/surface_two_hall)
 "aoY" = (
@@ -7651,19 +7743,16 @@
 /turf/simulated/floor,
 /area/maintenance/substation/research)
 "apB" = (
-/obj/effect/floor_decal/industrial/warning/corner{
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/green/border,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/camera/network/tether{
 	dir = 1
 	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/camera/network/engineering{
-	dir = 1
-	},
-/turf/simulated/floor,
-/area/maintenance/substation/research)
+/turf/simulated/floor/tiled/techmaint,
+/area/tether/surfacebase/surface_two_hall)
 "apC" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -7892,6 +7981,7 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
+/obj/machinery/camera/network/engineering,
 /turf/simulated/floor/plating,
 /area/maintenance/substation/command)
 "apY" = (
@@ -8050,11 +8140,24 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/tether/surfacebase/surface_two_hall)
 "aqq" = (
-/obj/effect/floor_decal/borderfloor,
-/obj/machinery/camera/network/tether{
-	dir = 1
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
 	},
-/turf/simulated/floor/tiled/techmaint,
+/obj/effect/floor_decal/borderfloor{
+	dir = 8;
+	icon_state = "borderfloor";
+	pixel_x = 0
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 8
+	},
+/obj/machinery/camera/network/tether{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_two_hall)
 "aqr" = (
 /obj/effect/floor_decal/borderfloor,
@@ -8131,13 +8234,20 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/tether/surfacebase/surface_two_hall)
 "aqy" = (
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/yellow/border,
-/obj/machinery/camera/network/tether{
-	dir = 1
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/techmaint,
-/area/tether/surfacebase/surface_two_hall)
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge_hallway)
 "aqz" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/steeldecal/steel_decals4{
@@ -8201,10 +8311,10 @@
 /area/tether/surfacebase/surface_two_hall)
 "aqG" = (
 /obj/effect/floor_decal/borderfloor{
-	dir = 6
+	dir = 4
 	},
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 6
+/obj/machinery/camera/network/tether{
+	dir = 9
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/tether/surfacebase/surface_two_hall)
@@ -8362,34 +8472,10 @@
 /turf/simulated/floor/tiled,
 /area/rnd/rdoffice)
 "aqT" = (
-/obj/structure/table/standard,
-/obj/item/device/taperecorder{
-	pixel_x = -3
-	},
-/obj/item/device/paicard{
-	pixel_x = 4
-	},
-/obj/item/weapon/circuitboard/teleporter,
-/obj/item/weapon/circuitboard/aicore{
-	pixel_x = -2;
-	pixel_y = 4
-	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 6
-	},
-/obj/effect/floor_decal/corner/mauve/border{
-	dir = 6
-	},
-/obj/machinery/camera/network/research{
-	dir = 8
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/tiled,
-/area/rnd/rdoffice)
+/obj/structure/table/bench/padded,
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/tiled/dark,
+/area/chapel/main)
 "aqU" = (
 /obj/structure/closet/secure_closet/scientist,
 /obj/effect/floor_decal/industrial/outline,
@@ -8407,6 +8493,7 @@
 /obj/structure/closet/secure_closet/scientist,
 /obj/effect/floor_decal/industrial/outline,
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/machinery/camera/network/research,
 /turf/simulated/floor/tiled/dark,
 /area/rnd/lockers)
 "aqX" = (
@@ -8421,13 +8508,20 @@
 /turf/simulated/floor/tiled/dark,
 /area/rnd/lockers)
 "aqY" = (
-/obj/structure/closet/secure_closet/scientist,
-/obj/effect/floor_decal/industrial/outline,
-/obj/machinery/camera/network/research{
-	dir = 8
+/obj/structure/closet/wardrobe/chaplain_black,
+/obj/item/weapon/storage/fancy/crayons,
+/obj/item/weapon/flame/candle/candelabra,
+/obj/item/weapon/flame/candle/candelabra,
+/obj/item/weapon/flame/candle/candelabra,
+/obj/item/weapon/flame/candle/candelabra,
+/obj/machinery/firealarm{
+	dir = 2;
+	layer = 3.3;
+	pixel_x = 0;
+	pixel_y = 26
 	},
-/turf/simulated/floor/tiled/dark,
-/area/rnd/lockers)
+/turf/simulated/floor/lino,
+/area/chapel/office)
 "aqZ" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/structure/closet/firecloset,
@@ -8542,20 +8636,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/commandmaint)
 "arq" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/machinery/camera/network/command{
-	dir = 1
-	},
-/obj/machinery/light_switch{
-	dir = 1;
-	on = 0;
-	pixel_x = -10;
-	pixel_y = -24
-	},
+/obj/structure/morgue/crematorium,
 /turf/simulated/floor/tiled/dark,
-/area/teleporter)
+/area/chapel/chapel_morgue)
 "arr" = (
 /obj/machinery/power/apc{
 	dir = 2;
@@ -9405,14 +9488,17 @@
 /turf/simulated/floor/plating,
 /area/tether/surfacebase/emergency_storage/atmos)
 "asB" = (
-/obj/machinery/light_switch{
-	dir = 4;
-	pixel_x = -28
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
 	},
-/obj/machinery/camera/network/engineering,
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/tiled,
-/area/engineering/lower/lobby)
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 6
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/tether/surfacebase/surface_two_hall)
 "asC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
 	icon_state = "intact";
@@ -9559,6 +9645,9 @@
 "asT" = (
 /obj/structure/table/steel,
 /obj/effect/floor_decal/techfloor,
+/obj/machinery/camera/network/research{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/server)
 "asU" = (
@@ -9607,23 +9696,8 @@
 /turf/simulated/floor/tiled,
 /area/rnd/staircase/secondfloor)
 "asZ" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/mauve/border{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 6
-	},
-/obj/effect/floor_decal/corner/mauve/bordercorner2{
-	dir = 6
-	},
-/obj/machinery/camera/network/research{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/rnd/staircase/secondfloor)
+/turf/simulated/floor/reinforced,
+/area/maintenance/lower/rnd)
 "ata" = (
 /obj/machinery/door/firedoor/glass,
 /obj/structure/disposalpipe/segment,
@@ -9957,12 +10031,17 @@
 /turf/simulated/wall,
 /area/rnd/breakroom)
 "atC" = (
-/obj/structure/bed/chair/comfy,
-/obj/machinery/camera/network/research{
-	dir = 4
+/obj/structure/closet/secure_closet/RD,
+/obj/item/device/aicard,
+/obj/item/clothing/glasses/omnihud/rnd,
+/obj/effect/floor_decal/borderfloor{
+	dir = 9
 	},
-/turf/simulated/floor/wood,
-/area/rnd/breakroom)
+/obj/effect/floor_decal/corner/mauve/border{
+	dir = 9
+	},
+/turf/simulated/floor/tiled,
+/area/rnd/rdoffice)
 "atD" = (
 /obj/machinery/firealarm{
 	dir = 2;
@@ -10026,15 +10105,15 @@
 /turf/simulated/floor/wood,
 /area/rnd/breakroom)
 "atK" = (
-/obj/machinery/alarm{
-	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 24
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 6;
+	icon_state = "intact"
 	},
-/obj/machinery/camera/network/research,
-/obj/structure/flora/pottedplant/stoutbush,
-/turf/simulated/floor/wood,
-/area/rnd/breakroom)
+/obj/effect/floor_decal/techfloor{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/server)
 "atL" = (
 /obj/structure/table/rack{
 	dir = 1
@@ -10186,6 +10265,9 @@
 /obj/structure/table/glass,
 /obj/item/weapon/storage/box/cups,
 /obj/item/weapon/storage/box/cups,
+/obj/machinery/camera/network/engineering{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/lower/breakroom)
 "auc" = (
@@ -10417,6 +10499,9 @@
 /obj/structure/bed/chair{
 	dir = 1
 	},
+/obj/machinery/camera/network/engineering{
+	dir = 1
+	},
 /turf/simulated/floor/tiled,
 /area/engineering/lower/lobby)
 "auB" = (
@@ -10521,11 +10606,19 @@
 /turf/simulated/floor/wood,
 /area/engineering/lower/breakroom)
 "auK" = (
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /obj/machinery/camera/network/engineering{
 	dir = 1
 	},
-/turf/simulated/floor/wood,
-/area/engineering/lower/breakroom)
+/turf/simulated/floor,
+/area/maintenance/substation/research)
 "auL" = (
 /obj/structure/table/glass,
 /obj/machinery/chemical_dispenser/bar_soft/full,
@@ -10777,17 +10870,24 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/tether/surfacebase/east_stairs_two)
 "avi" = (
-/obj/effect/floor_decal/borderfloor{
+/obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/simple/visible/scrubbers{
 	dir = 4
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/visible/supply{
+	dir = 4
 	},
-/obj/machinery/camera/network/tether{
-	dir = 9
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/techmaint,
-/area/tether/surfacebase/east_stairs_two)
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/lower/south)
 "avj" = (
 /obj/machinery/light_switch{
 	dir = 2;
@@ -10995,6 +11095,7 @@
 	dir = 9
 	},
 /obj/structure/closet/secure_closet/atmos_personal,
+/obj/machinery/camera/network/engineering,
 /turf/simulated/floor/tiled,
 /area/engineering/lower/atmos_lockers)
 "avC" = (
@@ -11146,13 +11247,31 @@
 /turf/simulated/wall/r_wall,
 /area/engineering/atmos/storage)
 "avL" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/shieldgen,
-/obj/machinery/camera/network/engineering{
-	dir = 4
+/obj/structure/table/standard,
+/obj/item/device/taperecorder{
+	pixel_x = -3
 	},
-/turf/simulated/floor/plating,
-/area/engineering/atmos/storage)
+/obj/item/device/paicard{
+	pixel_x = 4
+	},
+/obj/item/weapon/circuitboard/teleporter,
+/obj/item/weapon/circuitboard/aicore{
+	pixel_x = -2;
+	pixel_y = 4
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/mauve/border{
+	dir = 6
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled,
+/area/rnd/rdoffice)
 "avM" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/atmospherics/unary/vent_pump/on,
@@ -11234,6 +11353,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
+	},
+/obj/machinery/camera/network/tether{
+	dir = 9
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/tether/surfacebase/east_stairs_two)
@@ -11795,7 +11917,13 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/asmaint2)
 "awV" = (
+/obj/machinery/alarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
+	},
 /obj/structure/flora/pottedplant/stoutbush,
+/obj/machinery/camera/network/research,
 /turf/simulated/floor/wood,
 /area/rnd/breakroom)
 "awW" = (
@@ -12124,18 +12252,19 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
+/obj/machinery/camera/network/engineering{
+	dir = 8
+	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos/storage)
 "axv" = (
-/obj/machinery/atmospherics/portables_connector{
-	dir = 4
+/obj/machinery/light_switch{
+	dir = 4;
+	pixel_x = -28
 	},
-/obj/machinery/portable_atmospherics/powered/pump/filled,
-/obj/machinery/camera/network/engineering{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/engineering/pumpstation)
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/tiled,
+/area/engineering/lower/lobby)
 "axw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
@@ -12298,22 +12427,24 @@
 /turf/simulated/floor/tiled/monotile,
 /area/rnd/breakroom)
 "axO" = (
-/obj/effect/floor_decal/steeldecal/steel_decals9,
-/obj/effect/floor_decal/steeldecal/steel_decals9{
+/obj/effect/floor_decal/borderfloor{
 	dir = 4
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals9{
-	dir = 1
+/obj/effect/floor_decal/corner/mauve/border{
+	dir = 4
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals9{
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/mauve/bordercorner2{
+	dir = 6
+	},
+/obj/machinery/camera/network/research{
+	icon_state = "camera";
 	dir = 8
 	},
-/obj/machinery/vending/coffee,
-/obj/machinery/camera/network/research{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/rnd/breakroom)
+/turf/simulated/floor/tiled,
+/area/rnd/staircase/secondfloor)
 "axP" = (
 /obj/effect/floor_decal/steeldecal/steel_decals9,
 /obj/effect/floor_decal/steeldecal/steel_decals9{
@@ -12344,6 +12475,9 @@
 	dir = 9
 	},
 /obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/machinery/camera/network/engineering{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/engineering/lower/atmos_eva)
 "axR" = (
@@ -12479,23 +12613,9 @@
 /turf/simulated/floor/tiled/monotile,
 /area/engineering/atmos)
 "aya" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/red,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/camera/network/engineering{
-	dir = 8
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 8
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 5
-	},
-/turf/simulated/floor/tiled,
-/area/engineering/atmos)
+/obj/structure/bed/chair/comfy,
+/turf/simulated/floor/wood,
+/area/rnd/breakroom)
 "ayb" = (
 /obj/machinery/light_switch{
 	pixel_y = -28
@@ -12569,6 +12689,7 @@
 	icon_state = "bordercolor_shifted";
 	dir = 1
 	},
+/obj/machinery/camera/network/civilian,
 /turf/simulated/floor/tiled,
 /area/janitor)
 "ayj" = (
@@ -13193,6 +13314,7 @@
 	icon_state = "bordercolor";
 	dir = 9
 	},
+/obj/machinery/camera/network/engineering,
 /turf/simulated/floor/tiled,
 /area/engineering/atmos)
 "azn" = (
@@ -13995,16 +14117,12 @@
 /turf/simulated/floor/tiled,
 /area/engineering/atmos)
 "aAi" = (
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/yellow/border,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/camera/network/engineering{
+/obj/structure/flora/pottedplant/stoutbush,
+/obj/machinery/camera/network/research{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
-/area/engineering/atmos)
+/turf/simulated/floor/wood,
+/area/rnd/breakroom)
 "aAj" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/yellow/border,
@@ -14250,17 +14368,14 @@
 /turf/simulated/floor/tiled,
 /area/engineering/atmos)
 "aAA" = (
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/yellow/border,
-/obj/machinery/atmospherics/pipe/simple/hidden/red{
-	icon_state = "intact";
+/obj/effect/floor_decal/borderfloor{
 	dir = 4
 	},
-/obj/machinery/camera/network/engineering{
-	dir = 1
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
 	},
-/turf/simulated/floor/tiled,
-/area/engineering/atmos)
+/turf/simulated/floor/tiled/techmaint,
+/area/tether/surfacebase/east_stairs_two)
 "aAB" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -14284,6 +14399,9 @@
 /obj/effect/floor_decal/corner/yellow/border{
 	icon_state = "bordercolor";
 	dir = 6
+	},
+/obj/machinery/camera/network/engineering{
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/atmos)
@@ -14871,32 +14989,19 @@
 /turf/simulated/open,
 /area/engineering/atmos)
 "aBF" = (
-/obj/machinery/light_switch{
-	dir = 4;
-	pixel_x = -28
-	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 9
-	},
-/obj/effect/floor_decal/corner/yellow/border{
-	icon_state = "bordercolor";
-	dir = 9
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/camera/network/engineering{
+/obj/effect/floor_decal/steeldecal/steel_decals9,
+/obj/effect/floor_decal/steeldecal/steel_decals9{
 	dir = 4
 	},
-/obj/machinery/computer/general_air_control/large_tank_control{
-	frequency = 1441;
-	input_tag = "atmos_out";
-	name = "Atmos Intake Control";
-	output_tag = "atmos_in";
-	sensors = list("atmos_intake" = "Tank")
+/obj/effect/floor_decal/steeldecal/steel_decals9{
+	dir = 1
 	},
-/turf/simulated/floor/tiled,
-/area/engineering/atmos/monitoring)
+/obj/effect/floor_decal/steeldecal/steel_decals9{
+	dir = 8
+	},
+/obj/machinery/vending/coffee,
+/turf/simulated/floor/tiled/monotile,
+/area/rnd/breakroom)
 "aBG" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1;
@@ -15418,11 +15523,23 @@
 /turf/simulated/floor/plating,
 /area/maintenance/lower/south)
 "aCI" = (
-/obj/machinery/camera/network/tether{
+/obj/machinery/atmospherics/pipe/simple/hidden/red,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/techmaint,
-/area/tether/surfacebase/east_stairs_two)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
+	},
+/obj/machinery/camera/network/engineering{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/atmos)
 "aCJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -15794,15 +15911,13 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
 "aDs" = (
-/obj/effect/floor_decal/techfloor/corner,
-/obj/machinery/drone_fabricator{
-	fabricator_tag = "Atmos"
-	},
-/obj/machinery/camera/network/engineering{
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/yellow/border,
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/engineering/drone_fabrication)
+/turf/simulated/floor/tiled,
+/area/engineering/atmos)
 "aDt" = (
 /obj/effect/floor_decal/techfloor,
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -15831,14 +15946,15 @@
 /turf/simulated/floor/tiled,
 /area/engineering/atmos/monitoring)
 "aDx" = (
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/yellow/border,
-/obj/machinery/computer/atmos_alert{
-	icon_state = "computer";
-	dir = 1
+/obj/machinery/atmospherics/portables_connector{
+	dir = 4
 	},
-/turf/simulated/floor/tiled,
-/area/engineering/atmos/monitoring)
+/obj/machinery/portable_atmospherics/powered/pump/filled,
+/obj/machinery/camera/network/engineering{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/engineering/pumpstation)
 "aDy" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 6
@@ -16645,11 +16761,13 @@
 /turf/simulated/open,
 /area/engineering/atmos)
 "aFw" = (
-/obj/structure/catwalk,
-/obj/machinery/camera/network/engineering{
-	dir = 1
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/yellow/border,
+/obj/machinery/atmospherics/pipe/simple/hidden/red{
+	icon_state = "intact";
+	dir = 4
 	},
-/turf/simulated/open,
+/turf/simulated/floor/tiled,
 /area/engineering/atmos)
 "aFx" = (
 /obj/structure/catwalk,
@@ -17343,11 +17461,29 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/south)
 "aGS" = (
-/obj/machinery/camera/network/outside{
+/obj/machinery/light_switch{
+	dir = 4;
+	pixel_x = -28
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	icon_state = "bordercolor";
+	dir = 9
+	},
+/obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/open/virgo3b,
-/area/tether/surfacebase/outside/outside2)
+/obj/machinery/computer/general_air_control/large_tank_control{
+	frequency = 1441;
+	input_tag = "atmos_out";
+	name = "Atmos Intake Control";
+	output_tag = "atmos_in";
+	sensors = list("atmos_intake" = "Tank")
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/atmos/monitoring)
 "aGT" = (
 /obj/structure/plushie/drone{
 	icon_state = "droneplushie";
@@ -17621,19 +17757,15 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/outpost/xenobiology/outpost_slimepens)
 "aHz" = (
-/obj/item/device/radio/intercom{
-	dir = 1;
-	name = "Station Intercom (General)";
-	pixel_y = 21
+/obj/structure/railing{
+	icon_state = "railing0";
+	dir = 1
 	},
-/obj/machinery/alarm{
-	pixel_x = 0;
-	pixel_y = 30
+/obj/machinery/camera/network/engineering{
+	dir = 4
 	},
-/obj/machinery/camera/network/research,
-/obj/machinery/computer/security/xenobio,
-/turf/simulated/floor/tiled/white,
-/area/rnd/outpost/xenobiology/outpost_slimepens)
+/turf/simulated/open,
+/area/engineering/atmos)
 "aHA" = (
 /obj/machinery/smartfridge/secure/extract,
 /turf/simulated/floor/tiled/white,
@@ -17767,18 +17899,18 @@
 /turf/simulated/floor/plating,
 /area/maintenance/substation/tcomms)
 "aHO" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 28
+/obj/item/device/radio/intercom{
+	dir = 1;
+	name = "Station Intercom (General)";
+	pixel_y = 21
 	},
-/obj/machinery/camera/network/engineering,
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
+/obj/machinery/alarm{
+	pixel_x = 0;
+	pixel_y = 30
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/substation/tcomms)
+/obj/machinery/computer/security/xenobio,
+/turf/simulated/floor/tiled/white,
+/area/rnd/outpost/xenobiology/outpost_slimepens)
 "aHP" = (
 /turf/simulated/wall/r_wall,
 /area/tcommsat/computer)
@@ -17837,35 +17969,17 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/outpost/xenobiology/outpost_slimepens)
 "aHV" = (
-/obj/machinery/button/remote/blast_door{
-	id = "xenobiodiv7";
-	name = "Divider 7 Blast Doors";
-	pixel_x = -30;
-	pixel_y = -5;
-	req_access = list(55)
-	},
-/obj/machinery/button/remote/blast_door{
-	id = "xenobiopen9";
-	name = "Pen 9 Containment";
-	pixel_x = -30;
-	pixel_y = 8
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/camera/network/research{
-	dir = 4
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 28
 	},
 /obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
+	d2 = 2;
+	icon_state = "0-2"
 	},
-/obj/machinery/power/apc/super{
-	dir = 1;
-	pixel_y = 24
-	},
-/turf/simulated/floor/tiled/dark,
-/area/rnd/outpost/xenobiology/outpost_slimepens)
+/turf/simulated/floor/plating,
+/area/maintenance/substation/tcomms)
 "aHW" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
@@ -18046,6 +18160,9 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/light/small,
+/obj/machinery/camera/network/engineering{
+	dir = 8
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/tcomms)
 "aIq" = (
@@ -18337,11 +18454,13 @@
 /turf/simulated/floor/tiled/dark,
 /area/tcommsat/computer)
 "aIX" = (
-/obj/machinery/camera/network/outside{
-	dir = 8
+/obj/machinery/alarm/monitor/isolation{
+	alarm_id = "slime_pens";
+	dir = 4;
+	pixel_x = -22
 	},
-/turf/simulated/open/virgo3b,
-/area/tether/surfacebase/outside/outside2)
+/turf/simulated/floor/reinforced,
+/area/rnd/outpost/xenobiology/outpost_slimepens)
 "aIY" = (
 /obj/machinery/door/blast/regular{
 	id = "xenobiodiv1";
@@ -18389,6 +18508,22 @@
 /turf/simulated/floor/tiled/dark,
 /area/rnd/outpost/xenobiology/outpost_slimepens)
 "aJc" = (
+/obj/machinery/alarm/monitor/isolation{
+	alarm_id = "slime_pens";
+	dir = 8;
+	pixel_x = 22
+	},
+/turf/simulated/floor/reinforced,
+/area/rnd/outpost/xenobiology/outpost_slimepens)
+"aJd" = (
+/obj/machinery/door/blast/regular{
+	id = "xenobiodiv2";
+	layer = 8;
+	name = "Divider 2 Blast Door"
+	},
+/turf/simulated/floor/reinforced,
+/area/rnd/outpost/xenobiology/outpost_slimepens)
+"aJe" = (
 /obj/machinery/button/remote/blast_door{
 	id = "xenobiodiv2";
 	name = "Divider 2 Blast Doors";
@@ -18410,25 +18545,8 @@
 	pixel_y = -8;
 	req_access = list(55)
 	},
-/obj/machinery/camera/network/research{
-	dir = 8
-	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/outpost/xenobiology/outpost_slimepens)
-"aJd" = (
-/obj/machinery/door/blast/regular{
-	id = "xenobiodiv2";
-	layer = 8;
-	name = "Divider 2 Blast Door"
-	},
-/turf/simulated/floor/reinforced,
-/area/rnd/outpost/xenobiology/outpost_slimepens)
-"aJe" = (
-/obj/machinery/camera/network/outside{
-	dir = 4
-	},
-/turf/simulated/open/virgo3b,
-/area/tether/surfacebase/outside/outside2)
 "aJf" = (
 /obj/structure/morgue,
 /turf/simulated/floor/plating,
@@ -19730,9 +19848,6 @@
 	pixel_y = 0;
 	req_access = list(55)
 	},
-/obj/machinery/camera/network/research{
-	dir = 4
-	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/outpost/xenobiology/outpost_slimepens)
 "aLu" = (
@@ -20271,16 +20386,28 @@
 /turf/simulated/floor/reinforced,
 /area/rnd/outpost/xenobiology/outpost_slimepens)
 "aMn" = (
-/obj/machinery/camera/network/research/xenobio{
-	dir = 4;
-	network = list("Xenobiology")
+/obj/machinery/button/remote/blast_door{
+	id = "xenobiodiv6";
+	name = "Divider 6 Blast Doors";
+	pixel_x = 38;
+	pixel_y = 0;
+	req_access = list(55)
 	},
-/obj/machinery/alarm/monitor/isolation{
-	alarm_id = "slime_pens";
-	dir = 4;
-	pixel_x = -22
+/obj/machinery/button/remote/blast_door{
+	id = "xenobiopen6";
+	name = "Pen 6 Containment";
+	pixel_x = 30;
+	pixel_y = 8;
+	req_access = list(55)
 	},
-/turf/simulated/floor/reinforced,
+/obj/machinery/button/remote/blast_door{
+	id = "xenobiopen8";
+	name = "Pen 8 Containment";
+	pixel_x = 30;
+	pixel_y = -8;
+	req_access = list(55)
+	},
+/turf/simulated/floor/tiled/dark,
 /area/rnd/outpost/xenobiology/outpost_slimepens)
 "aMo" = (
 /obj/machinery/light/small{
@@ -20588,28 +20715,28 @@
 /area/rnd/outpost/xenobiology/outpost_slimepens)
 "aMR" = (
 /obj/machinery/button/remote/blast_door{
-	id = "xenobiodiv6";
-	name = "Divider 6 Blast Doors";
-	pixel_x = 38;
-	pixel_y = 0;
+	id = "xenobiodiv7";
+	name = "Divider 7 Blast Doors";
+	pixel_x = -30;
+	pixel_y = -5;
 	req_access = list(55)
 	},
 /obj/machinery/button/remote/blast_door{
-	id = "xenobiopen6";
-	name = "Pen 6 Containment";
-	pixel_x = 30;
-	pixel_y = 8;
-	req_access = list(55)
+	id = "xenobiopen9";
+	name = "Pen 9 Containment";
+	pixel_x = -30;
+	pixel_y = 8
 	},
-/obj/machinery/button/remote/blast_door{
-	id = "xenobiopen8";
-	name = "Pen 8 Containment";
-	pixel_x = 30;
-	pixel_y = -8;
-	req_access = list(55)
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/machinery/camera/network/research{
-	dir = 8
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc/super{
+	dir = 1;
+	pixel_y = 24
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/outpost/xenobiology/outpost_slimepens)
@@ -21360,16 +21487,23 @@
 /turf/simulated/floor/tiled/dark,
 /area/rnd/outpost/xenobiology/outpost_slimepens)
 "aOk" = (
-/obj/machinery/alarm/monitor/isolation{
-	alarm_id = "slime_pens";
-	dir = 4;
-	pixel_x = -22
+/obj/machinery/button/remote/blast_door{
+	id = "xenobiodiv8";
+	name = "Divider 8 Blast Doors";
+	pixel_x = 30;
+	pixel_y = -5;
+	req_access = list(55)
 	},
-/obj/machinery/camera/network/research/xenobio{
-	dir = 4;
-	network = list("Xenobiology")
+/obj/machinery/button/remote/blast_door{
+	id = "xenobiopen10";
+	name = "Pen 10 Containment";
+	pixel_x = 30;
+	pixel_y = 8
 	},
-/turf/simulated/floor/reinforced,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
 /area/rnd/outpost/xenobiology/outpost_slimepens)
 "aOl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -21414,17 +21548,18 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/atmos)
 "aOo" = (
-/obj/machinery/camera/network/research/xenobio{
-	dir = 8;
-	network = list("Xenobiology")
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/machinery/alarm/monitor/isolation{
-	alarm_id = "slime_pens";
-	dir = 8;
-	pixel_x = 22
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/turf/simulated/floor/reinforced,
-/area/rnd/outpost/xenobiology/outpost_slimepens)
+/obj/structure/cable/green{
+	icon_state = "2-4"
+	},
+/obj/machinery/camera/network/command,
+/turf/simulated/floor/tiled/dark,
+/area/bridge_hallway)
 "aOp" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
@@ -21508,12 +21643,12 @@
 /turf/simulated/floor/tiled/dark,
 /area/rnd/outpost/xenobiology/outpost_slimepens)
 "aOw" = (
-/obj/machinery/camera/network/research/xenobio{
-	dir = 8;
-	network = list("Xenobiology")
+/obj/machinery/camera/network/command{
+	icon_state = "camera";
+	dir = 4
 	},
-/turf/simulated/floor/reinforced,
-/area/rnd/outpost/xenobiology/outpost_slimepens)
+/turf/simulated/floor/tiled/dark,
+/area/bridge_hallway)
 "aOx" = (
 /obj/machinery/light{
 	dir = 8
@@ -21723,27 +21858,14 @@
 /turf/simulated/floor/reinforced,
 /area/rnd/outpost/xenobiology/outpost_slimepens)
 "aOL" = (
-/obj/machinery/button/remote/blast_door{
-	id = "xenobiodiv8";
-	name = "Divider 8 Blast Doors";
-	pixel_x = 30;
-	pixel_y = -5;
-	req_access = list(55)
-	},
-/obj/machinery/button/remote/blast_door{
-	id = "xenobiopen10";
-	name = "Pen 10 Containment";
-	pixel_x = 30;
-	pixel_y = 8
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/camera/network/research{
-	dir = 8
+/obj/machinery/shieldwallgen,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/camera/network/command{
+	icon_state = "camera";
+	dir = 10
 	},
 /turf/simulated/floor/tiled/dark,
-/area/rnd/outpost/xenobiology/outpost_slimepens)
+/area/teleporter)
 "aOM" = (
 /obj/structure/railing{
 	icon_state = "railing0";
@@ -21752,12 +21874,14 @@
 /turf/simulated/floor/tiled/dark,
 /area/rnd/outpost/xenobiology/outpost_slimepens)
 "aON" = (
-/obj/machinery/camera/network/research/xenobio{
-	dir = 4;
-	network = list("Xenobiology")
+/obj/structure/table/woodentable,
+/obj/item/weapon/storage/box/cups,
+/obj/machinery/camera/network/command{
+	icon_state = "camera";
+	dir = 9
 	},
-/turf/simulated/floor/reinforced,
-/area/rnd/outpost/xenobiology/outpost_slimepens)
+/turf/simulated/floor/wood,
+/area/bridge/meeting_room)
 "aOO" = (
 /obj/structure/window/reinforced/full,
 /obj/structure/window/reinforced,
@@ -21804,6 +21928,7 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
+/obj/machinery/camera/network/research/xenobio,
 /turf/simulated/floor/tiled/dark,
 /area/rnd/outpost/xenobiology/outpost_slimepens)
 "aOR" = (
@@ -21854,6 +21979,369 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/dark,
 /area/rnd/outpost/xenobiology/outpost_slimepens)
+"aOW" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/yellow/border,
+/obj/machinery/computer/atmos_alert{
+	icon_state = "computer";
+	dir = 1
+	},
+/obj/machinery/camera/network/engineering{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/atmos/monitoring)
+"aOX" = (
+/obj/structure/catwalk,
+/obj/machinery/camera/network/engineering{
+	dir = 1
+	},
+/turf/simulated/open,
+/area/engineering/atmos)
+"aOY" = (
+/obj/structure/railing{
+	icon_state = "railing0";
+	dir = 1
+	},
+/obj/machinery/camera/network/engineering{
+	dir = 8
+	},
+/turf/simulated/open,
+/area/engineering/atmos)
+"aOZ" = (
+/obj/effect/floor_decal/techfloor/corner,
+/obj/machinery/drone_fabricator{
+	fabricator_tag = "Atmos"
+	},
+/obj/machinery/camera/network/engineering{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/engineering/drone_fabrication)
+"aPa" = (
+/obj/machinery/camera/network/research/xenobio,
+/turf/simulated/floor/reinforced,
+/area/rnd/outpost/xenobiology/outpost_slimepens)
+"aPb" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/structure/disposaloutlet{
+	dir = 8
+	},
+/obj/machinery/camera/network/research/xenobio{
+	icon_state = "camera";
+	dir = 9
+	},
+/turf/simulated/floor/reinforced,
+/area/rnd/outpost/xenobiology/outpost_slimepens)
+"aPc" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/structure/disposaloutlet{
+	dir = 4
+	},
+/obj/machinery/camera/network/research/xenobio{
+	icon_state = "camera";
+	dir = 4
+	},
+/turf/simulated/floor/reinforced,
+/area/rnd/outpost/xenobiology/outpost_slimepens)
+"aPd" = (
+/obj/machinery/portable_atmospherics/powered/scrubber/huge/stationary{
+	scrub_id = "xeno_phoron_pen_scrubbers"
+	},
+/obj/machinery/camera/network/research/xenobio{
+	icon_state = "camera";
+	dir = 10
+	},
+/turf/simulated/floor/reinforced,
+/area/rnd/outpost/xenobiology/outpost_slimepens)
+"aPe" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/red/border,
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/red/bordercorner2{
+	dir = 9
+	},
+/obj/machinery/camera/network/security{
+	icon_state = "camera";
+	dir = 10
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/security/lowerhallway)
+"aPf" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/red/bordercorner2{
+	dir = 6
+	},
+/obj/machinery/camera/network/security{
+	icon_state = "camera";
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/security/lowerhallway)
+"aPg" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 6
+	},
+/obj/structure/closet{
+	name = "Evidence Closet"
+	},
+/obj/machinery/camera/network/security{
+	icon_state = "camera";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/tether/surfacebase/security/evidence)
+"aPh" = (
+/obj/machinery/camera/network/security{
+	icon_state = "camera";
+	dir = 10
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/tether/surfacebase/security/lowerhallway)
+"aPi" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/green{
+	icon_state = "intact";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/camera/network/security{
+	icon_state = "camera";
+	dir = 10
+	},
+/turf/simulated/floor/tiled/dark,
+/area/tether/surfacebase/security/brig)
+"aPj" = (
+/obj/machinery/camera/network/interrogation,
+/turf/simulated/floor/tiled/dark,
+/area/tether/surfacebase/security/interrogation)
+"aPk" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/power/apc{
+	dir = 2;
+	name = "south bump";
+	pixel_y = -28
+	},
+/obj/structure/cable/green{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor,
+/area/maintenance/lower/security)
+"aPl" = (
+/obj/structure/table/reinforced,
+/obj/machinery/photocopier/faxmachine{
+	department = "Warden's Office"
+	},
+/obj/item/device/radio/intercom/department/security{
+	dir = 8;
+	icon_state = "secintercom";
+	pixel_x = -24;
+	pixel_y = 0
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 10
+	},
+/obj/machinery/camera/network/security{
+	icon_state = "camera";
+	dir = 10
+	},
+/turf/simulated/floor/tiled/dark,
+/area/tether/surfacebase/security/warden)
+"aPm" = (
+/obj/effect/floor_decal/borderfloor/shifted{
+	icon_state = "borderfloor_shifted";
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightorange/border/shifted{
+	icon_state = "bordercolor_shifted";
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightorange{
+	icon_state = "corner_white";
+	dir = 5
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/structure/table/steel,
+/obj/item/weapon/paper,
+/obj/item/weapon/pen/blue{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/machinery/firealarm{
+	dir = 2;
+	layer = 3.3;
+	pixel_x = 0;
+	pixel_y = 26
+	},
+/obj/machinery/camera/network/security{
+	icon_state = "camera";
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/security/solitary)
+"aPn" = (
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 10
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 4;
+	icon_state = "extinguisher_closed";
+	pixel_x = -30
+	},
+/obj/machinery/camera/network/medbay{
+	icon_state = "camera";
+	dir = 10
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/resleeving)
+"aPo" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 5
+	},
+/obj/effect/floor_decal/borderfloorwhite/corner2{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner2{
+	dir = 5
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/machinery/camera/network/medbay,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lowerhall)
+"aPp" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 8
+	},
+/obj/machinery/camera/network/medbay{
+	icon_state = "camera";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lowerhall)
+"aPq" = (
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/paleblue/border,
+/obj/machinery/camera/network/medbay{
+	icon_state = "camera";
+	dir = 10
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lowerhall)
+"aPr" = (
+/obj/structure/table/bench/standard,
+/obj/effect/landmark/start{
+	name = "Medical Doctor"
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 9
+	},
+/obj/machinery/camera/network/medbay,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/breakroom)
+"aPs" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 10
+	},
+/obj/effect/floor_decal/borderfloorwhite/corner2{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner2{
+	dir = 8
+	},
+/obj/machinery/camera/network/medbay{
+	icon_state = "camera";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lowerhall)
+"aPt" = (
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/white/border,
+/obj/effect/floor_decal/borderfloorwhite/corner2{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/white/bordercorner2{
+	dir = 9;
+	icon_state = "bordercolorcorner2"
+	},
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/obj/machinery/camera/network/medbay{
+	icon_state = "camera";
+	dir = 10
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/surgery)
+"aPu" = (
+/obj/structure/morgue,
+/obj/machinery/camera/network/civilian{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/chapel/chapel_morgue)
 "aPv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -22092,16 +22580,21 @@
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/storage)
 "aPT" = (
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 1
+/obj/structure/table/woodentable,
+/obj/item/weapon/pen/blue{
+	pixel_x = 2;
+	pixel_y = 1
 	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 1
+/obj/item/weapon/paper_bin{
+	pixel_x = -2;
+	pixel_y = 8
 	},
-/obj/machinery/vending/medical,
-/obj/machinery/camera/network/medbay,
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/storage)
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/machinery/camera/network/civilian{
+	dir = 4
+	},
+/turf/simulated/floor/lino,
+/area/chapel/office)
 "aPU" = (
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 1
@@ -22440,12 +22933,11 @@
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/storage)
 "aQu" = (
-/obj/machinery/suit_cycler/medical,
-/obj/machinery/camera/network/medbay{
-	dir = 4
+/obj/machinery/camera/network/civilian{
+	dir = 1
 	},
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/paramed)
+/turf/simulated/floor/tiled/dark,
+/area/chapel/main)
 "aQv" = (
 /obj/structure/table/rack,
 /obj/item/clothing/suit/space/void/medical/emt,
@@ -22854,20 +23346,10 @@
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/surgery)
 "aQW" = (
-/obj/effect/floor_decal/borderfloorwhite,
-/obj/effect/floor_decal/corner/white/border,
-/obj/effect/floor_decal/borderfloorwhite/corner2{
-	dir = 9
-	},
-/obj/effect/floor_decal/corner/white/bordercorner2{
-	dir = 9;
-	icon_state = "bordercolorcorner2"
-	},
-/obj/structure/bed/chair{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/surgery)
+/obj/structure/table/bench/padded,
+/obj/machinery/camera/network/civilian,
+/turf/simulated/floor/tiled/dark,
+/area/chapel/main)
 "aQX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -22908,22 +23390,12 @@
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/surgery)
 "aRa" = (
-/obj/structure/bed/chair{
+/obj/structure/table/bench/padded,
+/obj/machinery/camera/network/civilian{
 	dir = 1
 	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 10
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 10
-	},
-/obj/structure/extinguisher_cabinet{
-	dir = 4;
-	icon_state = "extinguisher_closed";
-	pixel_x = -30
-	},
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/resleeving)
+/turf/simulated/floor/tiled/dark,
+/area/chapel/main)
 "aRb" = (
 /obj/effect/floor_decal/borderfloorwhite,
 /obj/effect/floor_decal/corner/paleblue/border,
@@ -23336,17 +23808,11 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/north)
 "aRE" = (
-/obj/machinery/camera/network/medbay{
+/obj/machinery/camera/network/civilian{
 	dir = 4
 	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/lowerhall)
+/turf/simulated/floor/tiled/techfloor,
+/area/tether/surfacebase/fish_farm)
 "aRF" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -23592,21 +24058,15 @@
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/lowerhall)
 "aRR" = (
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 5
+/obj/effect/floor_decal/industrial/warning{
+	icon_state = "warning";
+	dir = 1
 	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 5
+/obj/machinery/camera/network/tether{
+	dir = 4
 	},
-/obj/effect/floor_decal/borderfloorwhite/corner2{
-	dir = 5
-	},
-/obj/effect/floor_decal/corner/paleblue/bordercorner2{
-	dir = 5
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/lowerhall)
+/turf/simulated/floor/tiled/techmaint,
+/area/tether/surfacebase/east_stairs_two)
 "aRS" = (
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 8
@@ -23652,20 +24112,14 @@
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/storage)
 "aRV" = (
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 4
-	},
-/obj/structure/bed/chair/wheelchair{
+/obj/effect/floor_decal/borderfloor{
 	dir = 8
 	},
-/obj/machinery/camera/network/medbay{
-	dir = 8
+/obj/machinery/camera/network/tether{
+	dir = 5
 	},
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/storage)
+/turf/simulated/floor/tiled/techmaint,
+/area/tether/surfacebase/surface_two_hall)
 "aRW" = (
 /obj/structure/catwalk,
 /obj/structure/cable/green{
@@ -24054,18 +24508,12 @@
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/storage)
 "aSF" = (
-/obj/structure/table/bench/standard,
-/obj/effect/landmark/start{
-	name = "Medical Doctor"
+/obj/effect/floor_decal/techfloor{
+	dir = 1
 	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 9
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 9
-	},
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/breakroom)
+/obj/machinery/camera/network/tether,
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/lower/bar)
 "aSG" = (
 /obj/structure/table/bench/standard,
 /obj/machinery/power/apc{
@@ -24153,17 +24601,17 @@
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/lowerhall)
 "aSL" = (
-/obj/machinery/camera/network/medbay{
-	dir = 8
+/obj/effect/floor_decal/borderfloor{
+	dir = 6
 	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 4
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 6
 	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 4
+/obj/machinery/camera/network/tether{
+	dir = 9
 	},
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/lowerhall)
+/turf/simulated/floor/tiled/techmaint,
+/area/tether/surfacebase/surface_two_hall)
 "aSM" = (
 /obj/structure/table/standard,
 /obj/machinery/firealarm{
@@ -24293,25 +24741,14 @@
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/lowerhall)
 "aSU" = (
-/obj/structure/table/bench/standard,
-/obj/effect/landmark/start{
-	name = "Medical Doctor"
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 5
+/obj/machinery/camera/network/tether{
+	dir = 4
 	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 10
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 10
-	},
-/obj/machinery/camera/network/medbay{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/breakroom)
+/turf/simulated/floor/tiled/techmaint,
+/area/tether/surfacebase/surface_two_hall)
 "aSV" = (
 /obj/structure/table/bench/standard,
 /obj/effect/landmark/start{
@@ -24377,22 +24814,17 @@
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/breakroom)
 "aSZ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 10
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 10
-	},
-/obj/effect/floor_decal/borderfloorwhite/corner2{
+/obj/effect/floor_decal/borderfloor{
 	dir = 8
 	},
-/obj/effect/floor_decal/corner/paleblue/bordercorner2{
+/obj/effect/floor_decal/corner/green/border{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/lowerhall)
+/obj/machinery/camera/network/tether{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/tether/surfacebase/surface_two_hall)
 "aTa" = (
 /obj/machinery/light/small,
 /obj/effect/floor_decal/borderfloorwhite,
@@ -24544,30 +24976,12 @@
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/warden)
 "aTq" = (
-/obj/structure/closet/secure_closet/warden,
-/obj/item/weapon/gun/projectile/shotgun/pump/combat{
-	ammo_type = /obj/item/ammo_casing/a12g/beanbag;
-	desc = "Built for close quarters combat, the Hesphaistos Industries KS-40 is widely regarded as a weapon of choice for repelling boarders. This one has 'Property of the Warden' inscribed on the stock.";
-	name = "warden's shotgun"
+/obj/effect/floor_decal/borderfloor,
+/obj/machinery/camera/network/tether{
+	dir = 1
 	},
-/obj/item/weapon/book/manual/security_space_law,
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
-/obj/structure/cable/green{
-	icon_state = "0-8"
-	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 5
-	},
-/obj/effect/floor_decal/corner/red/border{
-	dir = 5
-	},
-/obj/machinery/camera/network/security,
-/turf/simulated/floor/tiled/dark,
-/area/tether/surfacebase/security/warden)
+/turf/simulated/floor/tiled/techmaint,
+/area/tether/surfacebase/surface_two_hall)
 "aTr" = (
 /turf/simulated/wall/r_wall,
 /area/tether/surfacebase/security/lowerhallway)
@@ -24823,33 +25237,13 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/solitary)
 "aTK" = (
-/obj/effect/floor_decal/borderfloor/shifted{
-	icon_state = "borderfloor_shifted";
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/paleblue/border,
+/obj/machinery/camera/network/medbay{
 	dir = 1
 	},
-/obj/effect/floor_decal/corner/lightorange/border/shifted{
-	icon_state = "bordercolor_shifted";
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/lightorange{
-	icon_state = "corner_white";
-	dir = 5
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/structure/table/steel,
-/obj/item/weapon/paper,
-/obj/item/weapon/pen/blue{
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/obj/machinery/firealarm{
-	dir = 2;
-	layer = 3.3;
-	pixel_x = 0;
-	pixel_y = 26
-	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/security/solitary)
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/storage)
 "aTL" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -24869,24 +25263,11 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/lowerhallway)
 "aTM" = (
-/obj/structure/table/reinforced,
-/obj/machinery/photocopier/faxmachine{
-	department = "Warden's Office"
+/obj/machinery/camera/network/tether{
+	dir = 9
 	},
-/obj/item/device/radio/intercom/department/security{
-	dir = 8;
-	icon_state = "secintercom";
-	pixel_x = -24;
-	pixel_y = 0
-	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 10
-	},
-/obj/effect/floor_decal/corner/red/border{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/dark,
-/area/tether/surfacebase/security/warden)
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/north_staires_two)
 "aTN" = (
 /obj/structure/table/reinforced,
 /obj/item/device/retail_scanner/security,
@@ -25085,38 +25466,19 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/solitary)
 "aUa" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/camera/network/outside{
+	icon_state = "camera";
+	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/red/border,
-/obj/machinery/camera/network/security{
-	c_tag = "SEC - Vault Exterior North";
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/security/lowerhallway)
+/turf/simulated/floor/tiled/steel_dirty/virgo3b,
+/area/tether/surfacebase/outside/outside2)
 "aUb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/machinery/camera/network/outside{
+	icon_state = "camera";
 	dir = 9
 	},
-/obj/structure/bed/chair{
-	dir = 1
-	},
-/obj/machinery/camera/network/security{
-	icon_state = "camera";
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/security/solitary)
+/turf/simulated/open/virgo3b,
+/area/tether/surfacebase/outside/outside2)
 "aUc" = (
 /turf/simulated/wall/r_wall,
 /area/tether/surfacebase/security/gasstorage)
@@ -25227,20 +25589,12 @@
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/brig)
 "aUj" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/camera/network/outside{
+	icon_state = "camera";
+	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/red/border,
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 9
-	},
-/obj/effect/floor_decal/corner/red/bordercorner2{
-	dir = 9
-	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/security/lowerhallway)
+/turf/simulated/open/virgo3b,
+/area/tether/surfacebase/outside/outside2)
 "aUk" = (
 /turf/simulated/wall/r_wall,
 /area/tether/surfacebase/security/evidence)
@@ -25523,38 +25877,6 @@
 /area/tether/surfacebase/security/evidence)
 "aUI" = (
 /obj/effect/floor_decal/borderfloorblack,
-/obj/structure/closet{
-	name = "Evidence Closet"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/tether/surfacebase/security/evidence)
-"aUJ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/green{
-	icon_state = "intact";
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/camera/network/security{
-	c_tag = "SEC - Vault Exterior North";
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/security/lowerhallway)
-"aUK" = (
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 6
-	},
 /obj/structure/closet{
 	name = "Evidence Closet"
 	},
@@ -26001,24 +26323,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/brig)
-"aVn" = (
-/obj/effect/floor_decal/borderfloorblack,
-/obj/structure/closet{
-	name = "Evidence Closet"
-	},
-/obj/machinery/alarm{
-	alarm_id = null;
-	breach_detection = 0;
-	dir = 1;
-	icon_state = "alarm0";
-	pixel_y = -22
-	},
-/obj/machinery/camera/network/security{
-	c_tag = "SEC - Vault Exterior North";
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/tether/surfacebase/security/evidence)
 "aVo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -26116,13 +26420,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/north)
-"aVu" = (
-/obj/structure/bed/chair,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/tether/surfacebase/security/interrogation)
 "aVv" = (
 /obj/structure/bed/chair,
 /turf/simulated/floor/tiled/dark,
@@ -26312,16 +26609,6 @@
 	},
 /turf/simulated/floor,
 /area/tether/surfacebase/security/interrogation)
-"aVI" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/camera/network/security{
-	c_tag = "SEC - Vault Exterior North";
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/tether/surfacebase/security/brig)
 "aVJ" = (
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/brig)
@@ -26454,13 +26741,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/tether/surfacebase/security/brig)
-"aVV" = (
-/obj/machinery/vending/hydronutrients,
-/obj/machinery/camera/network/security{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
@@ -27112,63 +27392,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/outpost/xenobiology/outpost_slimepens)
-"aWM" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/green{
-	icon_state = "intact";
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/camera/network/security{
-	c_tag = "SEC - Vault Exterior North";
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/tether/surfacebase/security/brig)
-"aWN" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/red/border{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 5
-	},
-/obj/effect/floor_decal/corner/red/bordercorner2{
-	dir = 5
-	},
-/obj/machinery/camera/network/security{
-	c_tag = "SEC - Vault Exterior West";
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/security/lowerhallway)
 "aWO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/green{
 	icon_state = "intact";
@@ -27193,13 +27416,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/lowerhallway)
-"aWP" = (
-/obj/machinery/camera/network/interrogation{
-	icon_state = "camera";
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/tether/surfacebase/security/interrogation)
 "aWQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
@@ -27278,23 +27494,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/bridge/meeting_room)
-"aXa" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/floor_decal/borderfloor{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/red/border{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 6
-	},
-/obj/effect/floor_decal/corner/red/bordercorner2{
-	dir = 6
-	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/security/lowerhallway)
 "aXb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -27624,18 +27823,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/teleporter)
-"aXI" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge_hallway)
 "aXJ" = (
 /obj/structure/closet/firecloset,
 /obj/machinery/light/small{
@@ -27812,23 +27999,12 @@
 /obj/machinery/chemical_dispenser/bar_soft/full,
 /turf/simulated/floor/wood,
 /area/bridge/meeting_room)
-"aYi" = (
-/obj/structure/table/bench/padded,
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/machinery/camera/network/civilian,
-/turf/simulated/floor/tiled/dark,
-/area/chapel/main)
 "aYj" = (
 /obj/machinery/alarm{
 	pixel_y = 22
 	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
-"aYk" = (
-/obj/structure/table/woodentable,
-/obj/item/weapon/storage/box/cups,
-/turf/simulated/floor/wood,
-/area/bridge/meeting_room)
 "aYl" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -27860,13 +28036,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge_hallway)
-"aYo" = (
-/obj/structure/morgue/crematorium,
-/obj/machinery/camera/network/civilian{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/chapel/chapel_morgue)
 "aYp" = (
 /turf/simulated/floor/tiled/dark,
 /area/chapel/chapel_morgue)
@@ -28022,28 +28191,6 @@
 	},
 /turf/simulated/floor/lino,
 /area/chapel/office)
-"aYC" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/camera/network/command{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge_hallway)
-"aYD" = (
-/obj/structure/morgue,
-/turf/simulated/floor/tiled/dark,
-/area/chapel/chapel_morgue)
 "aYE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -28076,19 +28223,6 @@
 /obj/effect/floor_decal/chapel,
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
-"aYI" = (
-/obj/structure/table/woodentable,
-/obj/item/weapon/pen/blue{
-	pixel_x = 2;
-	pixel_y = 1
-	},
-/obj/item/weapon/paper_bin{
-	pixel_x = -2;
-	pixel_y = 8
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/lino,
-/area/chapel/office)
 "aYJ" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -28735,13 +28869,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/tether/surfacebase/surface_two_hall)
-"aZO" = (
-/obj/machinery/camera/network/command{
-	c_tag = "Command Meeting Room East";
-	dir = 9
-	},
-/turf/simulated/floor/wood,
-/area/bridge/meeting_room)
 "aZP" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -28895,28 +29022,6 @@
 	},
 /obj/machinery/alarm{
 	pixel_y = 22
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/maintenance/lower/south)
-"bab" = (
-/obj/structure/catwalk,
-/obj/machinery/atmospherics/pipe/simple/visible/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/camera/network/tether{
-	dir = 1
-	},
-/obj/machinery/light/small{
-	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/south)
@@ -29369,13 +29474,6 @@
 /obj/structure/table/bench/padded,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/chapel/main)
-"bbd" = (
-/obj/machinery/camera/network/civilian{
-	icon_state = "camera";
-	dir = 10
 	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
@@ -33765,7 +33863,6 @@ aab
 aab
 aab
 aab
-aIX
 aab
 aab
 aab
@@ -33777,7 +33874,8 @@ aab
 aab
 aab
 aab
-aIX
+aab
+aUb
 aab
 aab
 aab
@@ -34047,19 +34145,19 @@ aab
 aab
 aHc
 aHs
-aMn
+aIX
 aIy
 aIY
 aHs
-aMn
+aIX
 aIy
 aLs
 aHs
-aMn
+aIX
 aIy
 aMP
 aNu
-aOk
+aIX
 aIy
 aOJ
 aHt
@@ -34188,7 +34286,7 @@ aab
 aab
 aab
 aHc
-aHt
+aPa
 aHt
 aHt
 aIY
@@ -34207,7 +34305,7 @@ aOJ
 aHt
 aNS
 aKX
-aOK
+aPd
 aHc
 aab
 aab
@@ -34260,7 +34358,7 @@ aac
 aac
 acq
 acq
-ako
+ajU
 akd
 akI
 akP
@@ -34346,7 +34444,7 @@ aHt
 aKk
 aKW
 aOJ
-aOw
+aHt
 aNV
 aKW
 aOK
@@ -34476,15 +34574,15 @@ aHv
 aHS
 aIz
 aIY
-aIz
+aPb
 aKl
 aKX
 aLs
-aIz
+aPb
 aKl
 aKX
 aMP
-aIz
+aPb
 aKl
 aKX
 aHc
@@ -34612,7 +34710,7 @@ aab
 aab
 aab
 aab
-aGS
+aab
 aHc
 aHw
 aHx
@@ -34630,7 +34728,7 @@ aNk
 aNv
 aND
 aHc
-aHV
+aMR
 aOj
 aJa
 aWK
@@ -35040,7 +35138,7 @@ aab
 aab
 aab
 aHc
-aHz
+aHO
 aHW
 aID
 aJb
@@ -35274,7 +35372,7 @@ ahD
 als
 alz
 alR
-amf
+aRE
 alz
 als
 ahD
@@ -35327,7 +35425,7 @@ aHc
 aHQ
 aHU
 aIE
-aJc
+aJe
 aJF
 aKr
 aLa
@@ -35335,7 +35433,7 @@ aLu
 aJF
 aMl
 aLa
-aMR
+aMn
 aJF
 aNx
 aLa
@@ -35464,7 +35562,7 @@ aab
 aab
 aab
 aab
-aGS
+aab
 aHc
 aHB
 aHT
@@ -35482,7 +35580,7 @@ aNm
 aNy
 aNE
 aNW
-aOL
+aOk
 aMj
 aJa
 aWL
@@ -35612,15 +35710,15 @@ aHv
 aHY
 aIG
 aJd
-aIG
+aPc
 aKt
 aKX
 aLv
-aIG
+aPc
 aKt
 aKX
 aMS
-aIG
+aPc
 aKt
 aKX
 aHc
@@ -35766,7 +35864,7 @@ aHt
 aKu
 aKW
 aNX
-aON
+aHt
 aKt
 aKX
 aOK
@@ -35839,12 +35937,12 @@ ahs
 ahs
 aho
 alm
-alt
+ano
 alB
 alS
 alS
 amq
-amA
+ano
 alm
 aho
 aho
@@ -35892,7 +35990,7 @@ aab
 aab
 aab
 aHc
-aHt
+aPa
 aHt
 aHt
 aJd
@@ -35911,7 +36009,7 @@ aNX
 aHt
 aKu
 aKW
-aOK
+aPd
 aHc
 aab
 aab
@@ -36035,19 +36133,19 @@ aab
 aab
 aHc
 aHC
-aOo
+aJc
 aIH
 aJd
 aHC
-aOo
+aJc
 aIH
 aLv
 aHC
-aOo
+aJc
 aIH
 aMS
 aHC
-aOo
+aJc
 aIH
 aNX
 aHt
@@ -36135,11 +36233,11 @@ aho
 ajy
 abz
 aii
-ano
+asZ
 anD
 anN
 aok
-aoJ
+atK
 apu
 aqe
 aqO
@@ -36321,7 +36419,6 @@ aab
 aab
 aab
 aab
-aJe
 aab
 aab
 aab
@@ -36333,7 +36430,8 @@ aab
 aab
 aab
 aab
-aJe
+aab
+aUj
 aab
 aab
 aab
@@ -36562,7 +36660,7 @@ ajy
 amH
 amV
 acF
-acN
+atC
 anQ
 aol
 aoL
@@ -37136,7 +37234,7 @@ aop
 aoP
 apz
 aqj
-aqT
+avL
 ary
 asp
 asX
@@ -37281,7 +37379,7 @@ acF
 acF
 acF
 asq
-asZ
+axO
 atA
 atz
 atz
@@ -37525,7 +37623,7 @@ aUz
 aUN
 aVg
 aVx
-aVV
+akg
 aVQ
 aWe
 aWo
@@ -37560,18 +37658,18 @@ ail
 anU
 aor
 aoR
-apB
+auK
 aqk
 aqU
 arA
 ass
 aqk
-atC
+aya
 auo
 auW
 avu
 awj
-awV
+aAi
 atB
 ayC
 azg
@@ -37943,7 +38041,7 @@ aab
 abE
 acd
 aTu
-aTM
+aPl
 abE
 abE
 aUC
@@ -38130,7 +38228,7 @@ aov
 anX
 apF
 aqm
-aqY
+aqU
 arE
 asw
 aqk
@@ -38253,7 +38351,7 @@ ale
 alh
 all
 alq
-alv
+aoJ
 ahD
 alW
 amh
@@ -38375,13 +38473,13 @@ aTz
 aUF
 aUN
 aUW
-aVI
+ahy
 aUN
 aUW
-aWM
+aPi
 aUN
 aUW
-aVI
+ahy
 aUN
 acW
 acW
@@ -38509,12 +38607,12 @@ aab
 aab
 aab
 abE
-aTq
+aas
 aTy
 aUe
 aWF
 aTz
-aUJ
+afd
 aUN
 aUd
 aVo
@@ -38566,7 +38664,7 @@ aut
 aut
 aut
 atJ
-axO
+aBF
 auv
 azl
 aAe
@@ -38575,7 +38673,7 @@ aAT
 aBW
 aCx
 aCZ
-aDs
+aOZ
 aDJ
 aAT
 aAT
@@ -38680,7 +38778,7 @@ agZ
 aha
 adY
 ahG
-alG
+aqq
 alZ
 amk
 adY
@@ -38702,7 +38800,7 @@ anZ
 arF
 asx
 atb
-atK
+awV
 auu
 auZ
 auu
@@ -38946,9 +39044,9 @@ aVZ
 aWw
 aWC
 aWD
-aWN
+ako
 aWT
-aXa
+aPf
 aXb
 aTr
 acW
@@ -39079,10 +39177,10 @@ aab
 aab
 aTs
 aTE
-aUa
+aaX
 aTr
 aUs
-aUs
+aPh
 aUQ
 aVb
 aUQ
@@ -39137,7 +39235,7 @@ axd
 axR
 ayG
 azp
-aAi
+aDs
 aAU
 aBC
 aCa
@@ -39227,9 +39325,9 @@ aUt
 aUt
 aUQ
 aVc
-aVu
+ajK
 aVF
-aWP
+aVP
 aWa
 aWl
 aUQ
@@ -39371,7 +39469,7 @@ aUQ
 aVd
 aVv
 aVG
-aVP
+aPj
 aWb
 aWm
 aUQ
@@ -39422,7 +39520,7 @@ avA
 ayH
 azr
 aAk
-aAW
+aHz
 aAX
 aAX
 aAX
@@ -39434,7 +39532,7 @@ aAX
 aAX
 aER
 aFb
-aFb
+aOX
 azl
 aEp
 aEQ
@@ -39505,7 +39603,7 @@ aab
 aab
 aTs
 aTH
-aUj
+aPe
 aUk
 aUu
 aUH
@@ -39530,7 +39628,7 @@ age
 agt
 agt
 agt
-ahd
+agt
 aiC
 alM
 age
@@ -39549,10 +39647,10 @@ adY
 ahY
 aoX
 afG
-aqq
+aqE
 arb
 arc
-asB
+axv
 atg
 atO
 aux
@@ -39792,7 +39890,7 @@ aTQ
 aUp
 aUk
 aUw
-aVn
+afq
 aUR
 aVE
 aUS
@@ -40076,7 +40174,7 @@ aTI
 aTZ
 aUk
 aUy
-aUK
+aPg
 aUR
 aVO
 aUS
@@ -40098,7 +40196,7 @@ age
 agu
 age
 agQ
-ahf
+aTM
 aiA
 aly
 amd
@@ -40220,7 +40318,7 @@ aUk
 aUk
 aUk
 aUR
-aVE
+aPk
 aUS
 abD
 aca
@@ -40275,7 +40373,7 @@ ayI
 azv
 aAp
 aBb
-aBF
+aGS
 aCd
 aCB
 aDd
@@ -40356,8 +40454,8 @@ aab
 aab
 aab
 aTt
-aTK
-aUb
+aPm
+acN
 aaS
 aWG
 aUq
@@ -40379,26 +40477,26 @@ afa
 afB
 afV
 agf
-afV
+aRV
 agG
 afV
-ahh
+amf
 ahu
 ahK
 ahZ
 afV
-afV
+aSU
 afV
 ajm
 afV
 agG
 afB
 ajQ
-anc
+afV
 ans
 agG
 afV
-afV
+aRV
 apd
 apJ
 afG
@@ -40428,7 +40526,7 @@ aAX
 aAX
 aAX
 aES
-aFw
+aFb
 azl
 aFK
 aGa
@@ -40563,7 +40661,7 @@ aBH
 aCf
 aCD
 aDf
-aDx
+aOW
 aBc
 aAX
 aAX
@@ -40696,7 +40794,7 @@ ave
 avJ
 awz
 axo
-aya
+aCI
 ayL
 azy
 aAs
@@ -40801,7 +40899,7 @@ aap
 aap
 aap
 adY
-afd
+alv
 afE
 afY
 agi
@@ -40969,7 +41067,7 @@ agw
 aoC
 apf
 apN
-aqy
+aqs
 arg
 arh
 arh
@@ -40977,7 +41075,7 @@ atm
 arh
 arh
 avf
-avL
+avN
 awB
 axq
 ayb
@@ -41068,9 +41166,9 @@ aab
 aac
 aNz
 aPW
-aQu
+ahh
 aan
-aay
+ahd
 aaN
 aaU
 aan
@@ -41522,7 +41620,7 @@ aob
 apT
 aXU
 atu
-aXU
+aOw
 aXU
 asd
 asQ
@@ -41685,7 +41783,7 @@ arS
 asK
 atp
 atZ
-auK
+arS
 avf
 avK
 avK
@@ -41694,7 +41792,7 @@ avK
 avK
 azD
 aAy
-aAW
+aOY
 aAX
 aAX
 aAX
@@ -41775,7 +41873,7 @@ aab
 aab
 aac
 aaf
-aao
+acT
 aao
 aao
 aQz
@@ -41784,9 +41882,9 @@ aRp
 aap
 aap
 aSr
-aSF
+aPr
 aSM
-aSU
+alt
 aSr
 acQ
 add
@@ -41805,7 +41903,7 @@ aob
 aob
 aXo
 aXY
-aYC
+aqy
 aob
 aZb
 asc
@@ -41815,7 +41913,7 @@ aXh
 aXz
 aWY
 aXZ
-aYk
+aON
 baN
 aXS
 aXV
@@ -41831,7 +41929,7 @@ arS
 avf
 avP
 awF
-axv
+aDx
 avP
 ayM
 azE
@@ -41955,7 +42053,7 @@ aYN
 aWZ
 aXj
 aXM
-aZO
+aSx
 aYb
 asc
 asc
@@ -41977,7 +42075,7 @@ axw
 ayg
 ayN
 azF
-aAA
+aFw
 azl
 aBM
 aCi
@@ -42081,7 +42179,7 @@ aac
 adY
 afl
 afG
-agk
+apB
 anK
 anK
 anK
@@ -42207,7 +42305,7 @@ aQc
 aQB
 aQS
 aRr
-aRE
+aPp
 aSa
 aSs
 aSI
@@ -42230,7 +42328,7 @@ apm
 aqH
 aqH
 anK
-aXI
+aOo
 aYJ
 aob
 aZe
@@ -42389,7 +42487,7 @@ agw
 aoC
 apf
 apN
-aqD
+aTq
 adY
 adY
 adY
@@ -42512,7 +42610,7 @@ anK
 aoe
 apo
 aqK
-arq
+amA
 anK
 aob
 aob
@@ -42547,9 +42645,9 @@ arl
 azI
 azI
 azI
-aBP
+aRR
 aCm
-aCI
+aCK
 aDi
 arl
 aDN
@@ -42638,7 +42736,7 @@ aSc
 aSt
 aSK
 aTl
-aSZ
+aPs
 aTc
 aTd
 aTf
@@ -42673,7 +42771,7 @@ aXS
 aXV
 apf
 apN
-aqq
+aqD
 adY
 arW
 arl
@@ -42708,7 +42806,7 @@ arZ
 aGK
 avp
 aHr
-aHO
+aHV
 aIp
 aIO
 aJq
@@ -42769,7 +42867,7 @@ aab
 aab
 aab
 aag
-aas
+aav
 aPD
 aQe
 aQE
@@ -42796,7 +42894,7 @@ anK
 aph
 apY
 apY
-aqH
+aOL
 anK
 apX
 aXE
@@ -42915,12 +43013,12 @@ aaA
 aPE
 aQf
 aQF
-aQW
+aPt
 aRu
 aRJ
 aao
 aSu
-aSL
+ahO
 aST
 aTn
 aaf
@@ -42931,7 +43029,7 @@ acy
 adf
 aeq
 adY
-afq
+alG
 afI
 agk
 anK
@@ -42964,7 +43062,7 @@ arY
 arY
 arY
 auN
-avi
+aAA
 avU
 awK
 axA
@@ -43203,7 +43301,7 @@ aQY
 aRu
 aRL
 aSd
-aSb
+aPq
 aad
 aaY
 abs
@@ -43228,7 +43326,7 @@ aqJ
 aqJ
 aqJ
 aqJ
-aqJ
+aSZ
 bbl
 baM
 aXA
@@ -43337,7 +43435,7 @@ aab
 aab
 aab
 aag
-aaE
+aay
 aPH
 aQi
 aQI
@@ -43502,11 +43600,11 @@ adY
 afu
 afM
 afM
-afM
+aqG
 agz
 agH
 agR
-ahi
+anc
 afM
 ahN
 aib
@@ -43518,14 +43616,14 @@ aZN
 aZP
 ajC
 ajI
-ajK
+asB
 afG
 anu
 afM
 afM
 aiE
 apP
-aqG
+aSL
 adY
 aZx
 aZz
@@ -43625,7 +43723,7 @@ aaF
 aPI
 aQj
 aQJ
-aRa
+aPn
 aah
 aRN
 aao
@@ -43940,7 +44038,7 @@ ain
 adu
 ajp
 aYd
-aYi
+aqT
 aYu
 aYH
 aYS
@@ -44092,7 +44190,7 @@ aro
 aXq
 aZX
 aYd
-bab
+avi
 arZ
 aFR
 avp
@@ -44189,7 +44287,7 @@ aab
 aab
 aab
 aah
-aaX
+aaE
 aPM
 aQn
 aQN
@@ -44217,14 +44315,14 @@ adu
 adu
 agV
 adu
-ahy
+aSF
 aju
 aju
 ais
 adu
 ajb
 aYd
-aXy
+aQW
 aYv
 aXy
 aro
@@ -44232,7 +44330,7 @@ anh
 aro
 aXy
 aZK
-aXy
+aRa
 aYd
 bac
 arZ
@@ -44473,7 +44571,7 @@ aab
 aab
 aab
 aah
-acT
+aaI
 aPN
 aQp
 aQO
@@ -44621,7 +44719,7 @@ aQq
 aQP
 aRg
 aah
-aRR
+aPo
 aSi
 aSy
 aad
@@ -44800,7 +44898,7 @@ aZi
 aZr
 aZG
 aro
-bbd
+aro
 aYd
 avp
 avp
@@ -45220,7 +45318,7 @@ ait
 aiG
 aih
 aYB
-aYI
+aPT
 aZW
 aZp
 api
@@ -45468,14 +45566,14 @@ aab
 aab
 aac
 aKv
-aPT
+aaJ
 aQs
 aQs
 aRk
 aRB
 aRU
 aSo
-aSB
+aTK
 aad
 aad
 aad
@@ -45502,7 +45600,7 @@ aiL
 aiL
 aiL
 aoE
-ajU
+aqY
 anf
 aYK
 amL
@@ -45757,7 +45855,7 @@ aQt
 aQR
 aRl
 aRC
-aRV
+ahi
 aSp
 aSE
 aKv
@@ -45786,8 +45884,8 @@ ahP
 ahP
 ahP
 ajT
-aYo
-aYD
+arq
+aPu
 aYY
 aYZ
 baZ
@@ -46078,7 +46176,7 @@ aZn
 aZv
 ajT
 aiN
-aro
+aQu
 aYd
 apq
 apq
@@ -46499,7 +46597,7 @@ aab
 aab
 ajM
 ajM
-ajM
+aUa
 ajM
 ajM
 ajM

--- a/maps/tether/tether-03-surface3.dmm
+++ b/maps/tether/tether-03-surface3.dmm
@@ -9,11 +9,14 @@
 /turf/simulated/floor/outdoors/grass/sif/virgo3b,
 /area/tether/surfacebase/outside/outside3)
 "aad" = (
-/obj/machinery/camera/network/outside{
+/obj/effect/floor_decal/borderfloorwhite{
 	dir = 1
 	},
-/turf/simulated/floor/outdoors/grass/sif/virgo3b,
-/area/tether/surfacebase/outside/outside3)
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/triage)
 "aae" = (
 /obj/structure/flora/pottedplant/stoutbush,
 /obj/machinery/light{
@@ -109,13 +112,25 @@
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/triage)
 "aap" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /obj/effect/floor_decal/borderfloorwhite{
-	dir = 1
+	dir = 4
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
-	dir = 1
+	dir = 4
 	},
-/obj/machinery/camera/network/medbay,
+/obj/effect/floor_decal/borderfloorwhite/corner2{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner2{
+	dir = 6
+	},
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/triage)
 "aaq" = (
@@ -470,6 +485,10 @@
 /obj/effect/floor_decal/corner/paleblue/border{
 	dir = 8
 	},
+/obj/machinery/camera/network/security{
+	icon_state = "camera";
+	dir = 5
+	},
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/triage)
 "abi" = (
@@ -753,22 +772,15 @@
 /turf/simulated/floor/plating,
 /area/tether/surfacebase/surface_three_hall)
 "abC" = (
-/obj/machinery/camera/network/tether,
+/obj/machinery/vending/snack,
 /obj/effect/floor_decal/borderfloor{
-	dir = 1
+	dir = 10
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 4
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7,
-/obj/machinery/door/firedoor/glass/hidden/steel{
-	dir = 2
-	},
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 1
+/obj/effect/floor_decal/corner/red/border{
+	dir = 10
 	},
 /turf/simulated/floor/tiled,
-/area/tether/surfacebase/surface_three_hall)
+/area/tether/surfacebase/security/breakroom)
 "abD" = (
 /obj/structure/bed/chair{
 	dir = 1
@@ -1151,18 +1163,20 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_three_hall)
 "acm" = (
-/obj/machinery/camera/network/research,
-/obj/machinery/firealarm{
-	dir = 2;
-	layer = 3.3;
-	pixel_x = 4;
-	pixel_y = 26
+/obj/structure/sink{
+	dir = 4;
+	icon_state = "sink";
+	pixel_x = 11;
+	pixel_y = 0
 	},
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 9
+/obj/effect/floor_decal/borderfloor{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/lime/border{
+	dir = 5
 	},
 /turf/simulated/floor/tiled,
-/area/rnd/outpost/xenobiology/outpost_hallway)
+/area/tether/surfacebase/public_garden_three)
 "acn" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -1736,13 +1750,27 @@
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/armory)
 "adg" = (
+/obj/structure/table/steel,
+/obj/effect/floor_decal/borderfloor{
+	dir = 1;
+	icon_state = "borderfloor";
+	pixel_y = 0
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 1
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/machinery/camera/network/security,
-/turf/simulated/open,
-/area/tether/surfacebase/security/upperhall)
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/security/processing)
 "adh" = (
 /obj/machinery/vending/cola,
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/red/border,
+/obj/machinery/camera/network/security{
+	icon_state = "camera";
+	dir = 10
+	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/breakroom)
 "adi" = (
@@ -1934,30 +1962,18 @@
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/triage)
 "adx" = (
-/obj/machinery/camera/network/medbay{
+/obj/structure/table/steel,
+/obj/item/weapon/storage/box/evidence,
+/obj/effect/floor_decal/borderfloor{
+	dir = 8;
+	icon_state = "borderfloor";
+	pixel_x = 0
+	},
+/obj/effect/floor_decal/corner/red/border{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloorwhite/corner2{
-	dir = 6
-	},
-/obj/effect/floor_decal/corner/paleblue/bordercorner2{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/triage)
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/security/processing)
 "ady" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -2046,6 +2062,9 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/machinery/status_display{
 	pixel_y = 30
+	},
+/obj/machinery/camera/network/civilian{
+	dir = 9
 	},
 /turf/simulated/floor/wood,
 /area/tether/surfacebase/reading_room)
@@ -2234,10 +2253,28 @@
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/armory)
 "aec" = (
-/obj/structure/shuttle/engine/propulsion,
-/turf/simulated/floor/reinforced,
-/turf/simulated/shuttle/plating/carry,
-/area/shuttle/tether/surface)
+/obj/structure/table/glass,
+/obj/item/weapon/storage/box/syringes,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 10
+	},
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Medical Department";
+	departmentType = 3;
+	name = "Medical RC";
+	pixel_x = -30;
+	pixel_y = 0
+	},
+/obj/machinery/camera/network/security{
+	icon_state = "camera";
+	dir = 10
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/triage)
 "aed" = (
 /turf/simulated/wall,
 /area/tether/surfacebase/medical/patient_b)
@@ -2269,11 +2306,17 @@
 	},
 /area/tether/surfacebase/medical/triage)
 "aef" = (
-/obj/machinery/camera/network/civilian{
-	dir = 4
+/obj/machinery/papershredder,
+/obj/effect/floor_decal/borderfloor{
+	dir = 1;
+	icon_state = "borderfloor";
+	pixel_y = 0
 	},
-/turf/simulated/floor/wood,
-/area/tether/surfacebase/reading_room)
+/obj/effect/floor_decal/corner/red/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/security/frontdesk)
 "aeg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -2527,31 +2570,32 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/common)
 "aeA" = (
-/obj/machinery/vending/snack,
-/obj/effect/floor_decal/borderfloor{
-	dir = 10
-	},
-/obj/effect/floor_decal/corner/red/border{
-	dir = 10
-	},
-/obj/machinery/camera/network/security{
+/obj/structure/table/reinforced,
+/obj/effect/floor_decal/borderfloorwhite{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/security/breakroom)
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 4
+	},
+/obj/machinery/reagentgrinder,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/chemistry)
 "aeB" = (
-/obj/structure/table/steel,
 /obj/effect/floor_decal/borderfloor{
-	dir = 1;
-	icon_state = "borderfloor";
-	pixel_y = 0
+	dir = 4
 	},
 /obj/effect/floor_decal/corner/red/border{
-	dir = 1
+	dir = 4
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/machinery/camera/network/security{
+	icon_state = "camera";
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
-/area/tether/surfacebase/security/processing)
+/area/tether/surfacebase/security/common)
 "aeC" = (
 /obj/machinery/light_switch{
 	dir = 8;
@@ -3244,11 +3288,20 @@
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/patient_b)
 "afF" = (
-/obj/machinery/camera/network/outside{
-	dir = 8
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
 	},
-/turf/simulated/floor/outdoors/grass/sif/virgo3b,
-/area/tether/surfacebase/outside/outside3)
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 9
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/triage)
 "afG" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
@@ -3341,14 +3394,19 @@
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/recreation_area_restroom)
 "afR" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/closet/secure_closet/security,
-/obj/item/device/holowarrant,
-/obj/machinery/camera/network/security{
+/obj/effect/floor_decal/borderfloor{
 	dir = 8
 	},
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/obj/machinery/flasher{
+	id = "Drunk Tank";
+	pixel_x = -28;
+	pixel_y = 0
+	},
 /turf/simulated/floor/tiled/dark,
-/area/tether/surfacebase/security/armory)
+/area/tether/surfacebase/security/common)
 "afS" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -3531,6 +3589,10 @@
 	},
 /obj/effect/floor_decal/corner/red/bordercorner2{
 	dir = 8
+	},
+/obj/machinery/camera/network/security{
+	icon_state = "camera";
+	dir = 5
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/common)
@@ -3783,24 +3845,23 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_three_hall)
 "agB" = (
-/obj/machinery/camera/network/tether{
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/red/border,
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 8
+/obj/machinery/camera/network/security{
+	icon_state = "camera";
+	dir = 10
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 6
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 5
-	},
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
-/area/tether/surfacebase/surface_three_hall)
+/area/tether/surfacebase/security/lobby)
 "agC" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/zpipe/down{
@@ -3873,18 +3934,21 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/common)
 "agI" = (
-/obj/machinery/camera/network/security{
-	c_tag = "SEC - Vault Exterior West";
-	dir = 8
-	},
 /obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 4
 	},
-/obj/effect/floor_decal/corner/red/border{
-	dir = 4
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/machinery/door/firedoor/glass/hidden/steel{
+	dir = 2
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
-/area/tether/surfacebase/security/common)
+/area/tether/surfacebase/surface_three_hall)
 "agJ" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 8
@@ -3942,27 +4006,18 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/vacant/vacant_site2)
 "agN" = (
-/obj/structure/table/glass,
-/obj/item/weapon/storage/box/syringes,
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 10
+/obj/effect/floor_decal/borderfloor{
+	dir = 6
 	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 10
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 6
 	},
-/obj/machinery/requests_console{
-	announcementConsole = 1;
-	department = "Medical Department";
-	departmentType = 3;
-	name = "Medical RC";
-	pixel_x = -30;
-	pixel_y = 0
+/obj/machinery/camera/network/security{
+	icon_state = "camera";
+	dir = 8
 	},
-/obj/machinery/camera/network/medbay{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/triage)
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/surface_three_hall)
 "agO" = (
 /obj/structure/table/steel,
 /obj/item/weapon/paper_bin{
@@ -4256,6 +4311,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/rnd/workshop)
+"ahq" = (
+/obj/structure/closet/secure_closet/personal,
+/obj/effect/floor_decal/spline/plain{
+	dir = 1
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/tiled/freezer,
+/area/crew_quarters/pool)
 "ahr" = (
 /obj/structure/flora/pottedplant/stoutbush,
 /obj/effect/floor_decal/techfloor{
@@ -4282,6 +4345,11 @@
 /obj/effect/floor_decal/steeldecal/steel_decals7,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_three_hall)
+"aht" = (
+/obj/machinery/space_heater,
+/obj/effect/floor_decal/techfloor,
+/turf/simulated/floor/tiled/techfloor,
+/area/crew_quarters/panic_shelter)
 "ahu" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -4387,21 +4455,26 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/frontdesk)
 "ahB" = (
-/obj/structure/table/steel,
-/obj/item/weapon/storage/box/evidence,
 /obj/effect/floor_decal/borderfloor{
-	dir = 8;
-	icon_state = "borderfloor";
-	pixel_x = 0
-	},
-/obj/effect/floor_decal/corner/red/border{
 	dir = 8
 	},
-/obj/machinery/camera/network/security{
-	dir = 4
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/lightgrey/bordercorner2{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 6
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 5
 	},
 /turf/simulated/floor/tiled,
-/area/tether/surfacebase/security/processing)
+/area/tether/surfacebase/surface_three_hall)
 "ahC" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -4685,6 +4758,10 @@
 /obj/machinery/status_display{
 	pixel_y = 30
 	},
+/obj/machinery/camera/network/security{
+	icon_state = "camera";
+	dir = 5
+	},
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/triage)
 "ahX" = (
@@ -4745,21 +4822,9 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/frontdesk)
 "aib" = (
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 1
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals6{
-	dir = 9
-	},
-/obj/machinery/camera/network/medbay,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/triage)
+/obj/structure/closet/crate/freezer,
+/turf/simulated/floor/tiled/freezer,
+/area/crew_quarters/freezer)
 "aic" = (
 /obj/random/trash_pile,
 /obj/effect/floor_decal/techfloor{
@@ -5132,6 +5197,9 @@
 /obj/effect/floor_decal/corner/lightgrey/bordercorner2{
 	dir = 9
 	},
+/obj/machinery/camera/network/tether{
+	dir = 1
+	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_three_hall)
 "aiE" = (
@@ -5186,20 +5254,19 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/recreation_area_restroom)
-"aiK" = (
-/obj/machinery/camera/network/tether,
-/obj/effect/floor_decal/borderfloor{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 1
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
+"aiJ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/captain)
+"aiK" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
-/area/tether/surfacebase/surface_three_hall)
+/area/crew_quarters/pool)
 "aiL" = (
 /turf/simulated/floor/outdoors/grass/sif/virgo3b,
 /area/tether/surfacebase/surface_three_hall)
@@ -5408,6 +5475,22 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/lobby)
+"ajb" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 6
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 5
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/surface_three_hall)
 "ajc" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -5713,6 +5796,48 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_three_hall)
+"ajB" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	icon_state = "map-scrubbers";
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge_hallway)
+"ajC" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/surface_three_hall)
+"ajD" = (
+/obj/effect/floor_decal/corner/grey/diagonal,
+/obj/structure/closet/secure_closet/freezer/kitchen,
+/obj/item/device/radio/intercom{
+	dir = 4;
+	pixel_x = 24
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/kitchen)
 "ajE" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -5747,22 +5872,9 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_three_hall)
 "ajH" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 8
-	},
-/obj/machinery/camera/network/security{
-	dir = 4
-	},
-/obj/structure/bed/chair{
-	dir = 4
-	},
-/obj/machinery/flasher{
-	id = "Drunk Tank";
-	pixel_x = -28;
-	pixel_y = 0
-	},
+/obj/machinery/computer/secure_data,
 /turf/simulated/floor/tiled/dark,
-/area/tether/surfacebase/security/common)
+/area/bridge)
 "ajI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/up{
@@ -6075,11 +6187,19 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/panic_shelter)
 "akk" = (
-/obj/machinery/camera/network/outside{
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 4
 	},
-/turf/simulated/floor/outdoors/grass/sif/virgo3b,
-/area/tether/surfacebase/outside/outside3)
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/machinery/camera/network/tether,
+/turf/simulated/floor/tiled,
+/area/hallway/lower/third_south)
 "akl" = (
 /obj/machinery/vending/cola,
 /obj/effect/floor_decal/corner/lightgrey{
@@ -6125,19 +6245,16 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_three_hall)
 "ako" = (
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/lightgrey/border,
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 8
+/obj/structure/table/marble,
+/obj/item/weapon/reagent_containers/food/condiment/small/saltshaker{
+	pixel_x = -3;
+	pixel_y = 0
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 1
+/obj/item/weapon/reagent_containers/food/condiment/small/peppermill{
+	pixel_x = 3
 	},
-/obj/machinery/camera/network/tether{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/surface_three_hall)
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/bar)
 "akp" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/lightgrey/border,
@@ -6188,6 +6305,19 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_three_hall)
+"akt" = (
+/obj/structure/table/steel,
+/obj/item/device/integrated_electronics/debugger{
+	pixel_x = -5;
+	pixel_y = 0
+	},
+/obj/item/device/integrated_electronics/wirer{
+	pixel_x = 5;
+	pixel_y = 0
+	},
+/obj/effect/floor_decal/techfloor,
+/turf/simulated/floor/tiled/techfloor,
+/area/rnd/workshop)
 "aku" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/lightgrey/border,
@@ -6224,6 +6354,10 @@
 	},
 /obj/effect/floor_decal/corner/red/border{
 	dir = 6
+	},
+/obj/machinery/camera/network/security{
+	icon_state = "camera";
+	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/frontdesk)
@@ -6444,17 +6578,12 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_three_hall)
 "akM" = (
-/obj/machinery/camera/network/tether{
-	dir = 9
+/obj/machinery/door/window/southleft{
+	name = "Library Desk Door";
+	req_access = list(37)
 	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 6
-	},
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 6
-	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/surface_three_hall)
+/turf/simulated/floor/carpet,
+/area/library)
 "akN" = (
 /obj/structure/closet,
 /obj/item/clothing/mask/gas,
@@ -6556,6 +6685,20 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/outpost/xenobiology/outpost_hallway)
+"akX" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/lime/border{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 4;
+	icon_state = "extinguisher_closed";
+	pixel_x = -30
+	},
+/turf/simulated/floor/tiled,
+/area/hydroponics)
 "akY" = (
 /turf/simulated/wall,
 /area/crew_quarters/recreation_area)
@@ -6770,6 +6913,9 @@
 /obj/effect/floor_decal/techfloor{
 	dir = 8
 	},
+/obj/machinery/camera/network/civilian{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/panic_shelter)
 "alt" = (
@@ -6827,14 +6973,26 @@
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/pool)
 "alz" = (
-/obj/structure/closet/secure_closet/personal,
-/obj/effect/floor_decal/spline/plain{
-	dir = 1
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/machinery/camera/network/civilian,
-/turf/simulated/floor/tiled/freezer,
-/area/crew_quarters/pool)
+/obj/effect/floor_decal/corner/lime/border{
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/lime/bordercorner2{
+	dir = 10
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 5
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 6
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/lower/third_south)
 "alA" = (
 /obj/effect/floor_decal/spline/plain{
 	dir = 1
@@ -6845,6 +7003,7 @@
 	icon_state = "cabinet_closed";
 	name = "Clothing Storage"
 	},
+/obj/machinery/camera/network/civilian,
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/pool)
 "alB" = (
@@ -6925,6 +7084,26 @@
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/tiled,
 /area/rnd/outpost/xenobiology/outpost_hallway)
+"alI" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/floor_decal/techfloor{
+	dir = 6
+	},
+/obj/machinery/camera/network/research{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/rnd/workshop)
 "alJ" = (
 /obj/machinery/vending/fitness,
 /turf/simulated/floor/tiled,
@@ -6941,9 +7120,11 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/recreation_area)
 "alM" = (
-/obj/machinery/camera/network/civilian,
+/obj/structure/bed/chair/wood{
+	dir = 4
+	},
 /turf/simulated/floor/wood,
-/area/crew_quarters/recreation_area)
+/area/crew_quarters/bar)
 "alN" = (
 /obj/machinery/fitness/heavy/lifter,
 /turf/simulated/floor/wood,
@@ -7098,13 +7279,23 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/panic_shelter)
 "amh" = (
-/obj/machinery/space_heater,
-/obj/effect/floor_decal/techfloor,
-/obj/machinery/camera/network/civilian{
+/obj/effect/floor_decal/borderfloor{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/crew_quarters/panic_shelter)
+/obj/effect/floor_decal/corner/mauve/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals5,
+/obj/effect/floor_decal/steeldecal/steel_decals3{
+	dir = 9
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals3{
+	dir = 8
+	},
+/obj/structure/table/reinforced,
+/obj/machinery/camera/network/research,
+/turf/simulated/floor/tiled,
+/area/rnd/research_foyer)
 "ami" = (
 /obj/machinery/space_heater,
 /obj/effect/floor_decal/techfloor,
@@ -7235,6 +7426,18 @@
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/pool)
+"amu" = (
+/obj/machinery/firealarm{
+	dir = 2;
+	layer = 3.3;
+	pixel_x = 4;
+	pixel_y = 26
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 9
+	},
+/turf/simulated/floor/tiled,
+/area/rnd/outpost/xenobiology/outpost_hallway)
 "amv" = (
 /turf/simulated/floor/tiled,
 /area/crew_quarters/pool)
@@ -7286,7 +7489,6 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/north_stairs_three)
 "amC" = (
-/obj/machinery/light/small,
 /obj/effect/floor_decal/industrial/warning/corner,
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -7297,6 +7499,9 @@
 /obj/item/device/radio/intercom{
 	dir = 2;
 	pixel_y = -24
+	},
+/obj/machinery/camera/network/tether{
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/north_stairs_three)
@@ -7485,6 +7690,15 @@
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/pool)
+"amT" = (
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/mauve/bordercorner{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/rnd/research/researchdivision)
 "amU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -7500,22 +7714,30 @@
 /turf/simulated/floor/tiled,
 /area/crew_quarters/pool)
 "amV" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/effect/floor_decal/borderfloor{
+	dir = 1;
+	icon_state = "borderfloor";
+	pixel_y = 0
+	},
+/obj/effect/floor_decal/corner/mauve/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
 	dir = 4
 	},
-/obj/machinery/camera/network/civilian{
-	dir = 9
+/obj/effect/floor_decal/corner/mauve/bordercorner2{
+	dir = 4
 	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
 	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
 /turf/simulated/floor/tiled,
-/area/crew_quarters/pool)
+/area/rnd/research/researchdivision)
 "amW" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
@@ -7591,11 +7813,27 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/tether/surfacebase/north_stairs_three)
 "and" = (
-/obj/machinery/camera/network/tether{
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = -25
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/open,
-/area/tether/surfacebase/north_stairs_three)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
 "ane" = (
 /turf/simulated/open,
 /area/tether/surfacebase/north_stairs_three)
@@ -7606,29 +7844,24 @@
 /turf/simulated/wall,
 /area/tether/surfacebase/north_stairs_three)
 "ang" = (
-/obj/machinery/camera/network/tether{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	icon_state = "intact-scrubbers";
+	dir = 4
 	},
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 8
+/obj/item/device/radio/intercom{
+	pixel_y = -24
 	},
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/lightgrey/bordercorner2{
-	dir = 8
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 6
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 5
+/obj/effect/floor_decal/borderfloorblack,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
-/area/tether/surfacebase/surface_three_hall)
+/area/rnd/outpost/xenobiology/outpost_north_airlock)
 "anh" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -8527,10 +8760,20 @@
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/freezer)
 "aoL" = (
-/obj/structure/closet/crate/freezer,
-/obj/machinery/camera/network/civilian,
-/turf/simulated/floor/tiled/freezer,
-/area/crew_quarters/freezer)
+/obj/structure/table/reinforced,
+/obj/effect/floor_decal/borderfloor{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/mauve/border{
+	dir = 9
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 4;
+	icon_state = "extinguisher_closed";
+	pixel_x = -30
+	},
+/turf/simulated/floor/tiled,
+/area/rnd/research/testingrange)
 "aoM" = (
 /obj/structure/kitchenspike,
 /obj/machinery/alarm{
@@ -8554,9 +8797,16 @@
 /turf/simulated/floor/grass,
 /area/hydroponics/cafegarden)
 "aoQ" = (
-/obj/machinery/camera/network/civilian,
-/turf/simulated/floor/grass,
-/area/hydroponics/cafegarden)
+/obj/structure/table/reinforced,
+/obj/machinery/cell_charger,
+/obj/effect/floor_decal/borderfloor{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/mauve/border{
+	dir = 5
+	},
+/turf/simulated/floor/tiled,
+/area/rnd/research/testingrange)
 "aoR" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
@@ -9094,6 +9344,24 @@
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/pool)
+"apK" = (
+/obj/structure/sign/department/robo{
+	pixel_x = 32
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/mauve/border{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 9
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 10
+	},
+/turf/simulated/floor/tiled,
+/area/rnd/research/researchdivision)
 "apL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -9593,12 +9861,16 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/rnd/research)
 "aqz" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/camera/network/civilian{
-	dir = 9
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/simulated/floor/tiled,
-/area/crew_quarters/pool)
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/machinery/camera/network/research{
+	icon_state = "camera";
+	dir = 5
+	},
+/turf/simulated/floor/tiled/dark,
+/area/rnd/outpost/xenobiology/outpost_north_airlock)
 "aqA" = (
 /obj/machinery/firealarm{
 	dir = 2;
@@ -9851,23 +10123,12 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_three_hall)
 "aqS" = (
-/obj/machinery/camera/network/tether{
-	dir = 9
-	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 4
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 9
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 10
+/obj/effect/floor_decal/industrial/warning/corner{
+	icon_state = "warningcorner";
+	dir = 8
 	},
 /turf/simulated/floor/tiled,
-/area/tether/surfacebase/surface_three_hall)
+/area/hallway/lower/third_south)
 "aqT" = (
 /obj/structure/sign/directions/medical{
 	dir = 1;
@@ -10071,15 +10332,15 @@
 /turf/simulated/floor/outdoors/grass/sif/virgo3b,
 /area/tether/surfacebase/outside/outside3)
 "aro" = (
-/obj/machinery/camera/network/civilian{
+/obj/effect/floor_decal/spline/plain{
 	dir = 4
 	},
-/obj/machinery/door/window/southleft{
-	name = "Library Desk Door";
-	req_access = list(37)
+/obj/effect/floor_decal/spline/plain{
+	dir = 8
 	},
-/turf/simulated/floor/carpet,
-/area/library)
+/obj/machinery/media/jukebox,
+/turf/simulated/floor/lino,
+/area/crew_quarters/bar)
 "arp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -10159,12 +10420,10 @@
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/pool)
 "arx" = (
-/obj/effect/floor_decal/spline/plain,
-/obj/machinery/camera/network/civilian{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/freezer,
-/area/crew_quarters/pool)
+/obj/structure/table/marble,
+/obj/machinery/chemical_dispenser/bar_soft/full,
+/turf/simulated/floor/lino,
+/area/crew_quarters/bar)
 "ary" = (
 /obj/effect/floor_decal/spline/plain,
 /obj/machinery/light,
@@ -10185,6 +10444,9 @@
 "arB" = (
 /obj/structure/closet/lasertag/red,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/machinery/camera/network/civilian{
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
@@ -10328,6 +10590,9 @@
 /obj/structure/table/bench/wooden,
 /obj/machinery/alarm{
 	pixel_y = 22
+	},
+/obj/machinery/camera/network/civilian{
+	dir = 9
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
@@ -10488,25 +10753,17 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_three_hall)
 "asa" = (
-/obj/machinery/camera/network/tether,
+/obj/machinery/computer/rdconsole/robotics{
+	dir = 8
+	},
 /obj/effect/floor_decal/borderfloor{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 4
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals7,
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/surface_three_hall)
+/obj/effect/floor_decal/corner/mauve/border{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/assembly/robotics)
 "asb" = (
 /obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -10613,19 +10870,12 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "asl" = (
-/obj/structure/table/woodentable,
-/obj/machinery/camera/network/civilian{
-	dir = 9
+/obj/machinery/recharge_station,
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 4
 	},
-/obj/item/weapon/reagent_containers/food/condiment/small/peppermill{
-	pixel_x = 3
-	},
-/obj/item/weapon/reagent_containers/food/condiment/small/saltshaker{
-	pixel_x = -3;
-	pixel_y = 0
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/bar)
+/turf/simulated/floor/tiled/steel_grid,
+/area/assembly/chargebay)
 "asm" = (
 /obj/effect/floor_decal/corner/grey/diagonal,
 /obj/structure/closet/secure_closet/freezer/fridge,
@@ -10684,17 +10934,11 @@
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
 "asr" = (
-/obj/effect/floor_decal/corner/grey/diagonal,
-/obj/structure/closet/secure_closet/freezer/kitchen,
-/obj/machinery/camera/network/civilian{
-	dir = 9
+/obj/structure/bed/chair/comfy{
+	dir = 8
 	},
-/obj/item/device/radio/intercom{
-	dir = 4;
-	pixel_x = 24
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/kitchen)
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/bar_backroom)
 "ass" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -11551,6 +11795,9 @@
 /obj/structure/cable/green{
 	icon_state = "0-8"
 	},
+/obj/machinery/camera/network/civilian{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
 "atS" = (
@@ -11586,21 +11833,22 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/rnd/workshop)
 "atX" = (
-/obj/structure/table/steel,
-/obj/item/device/integrated_electronics/debugger{
-	pixel_x = -5;
-	pixel_y = 0
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
 	},
-/obj/item/device/integrated_electronics/wirer{
-	pixel_x = 5;
-	pixel_y = 0
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/mauve/border{
+	dir = 4
 	},
 /obj/machinery/camera/network/research{
-	dir = 1
+	icon_state = "camera";
+	dir = 8
 	},
-/obj/effect/floor_decal/techfloor,
-/turf/simulated/floor/tiled/techfloor,
-/area/rnd/workshop)
+/turf/simulated/floor/tiled/steel_grid,
+/area/assembly/robotics)
 "atY" = (
 /obj/structure/table/steel,
 /obj/machinery/recharger{
@@ -11658,22 +11906,28 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/rnd/workshop)
 "auc" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/table/glass,
+/obj/machinery/recharger{
+	pixel_y = 0
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/mauve/border,
+/obj/effect/floor_decal/borderfloor/corner2,
+/obj/effect/floor_decal/corner/mauve/bordercorner2,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 8
 	},
-/obj/effect/floor_decal/techfloor{
-	dir = 6
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 1
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/rnd/workshop)
+/obj/machinery/camera/network/research{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/rnd/staircase/thirdfloor)
 "aud" = (
 /turf/simulated/shuttle/wall/voidcraft/green{
 	hard_corner = 1
@@ -11694,12 +11948,15 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/hallway/lower/third_south)
 "aug" = (
-/obj/machinery/camera/network/command,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
 	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge_hallway)
+/obj/effect/floor_decal/steeldecal/steel_decals5{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals5,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/shuttle_pad)
 "auh" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -11743,12 +12000,15 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "aul" = (
-/obj/structure/table/bench/wooden,
-/obj/machinery/camera/network/civilian{
-	dir = 9
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
 	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/bar)
+/obj/machinery/light_switch{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/simulated/floor/tiled,
+/area/rnd/outpost/xenobiology/outpost_hallway)
 "aum" = (
 /obj/effect/floor_decal/corner/grey/diagonal,
 /obj/machinery/door/blast/shutters{
@@ -11832,6 +12092,7 @@
 /obj/effect/floor_decal/corner/mauve/border{
 	dir = 9
 	},
+/obj/machinery/camera/network/research,
 /turf/simulated/floor/tiled,
 /area/rnd/research)
 "aus" = (
@@ -11856,15 +12117,23 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/rnd/research)
 "aut" = (
-/obj/machinery/camera/network/research,
-/obj/effect/floor_decal/borderfloor/corner{
+/obj/structure/cable/green{
+	icon_state = "0-2"
+	},
+/obj/structure/cable,
+/obj/machinery/power/smes/buildable{
+	charge = 0;
+	output_attempt = 0;
+	outputting = 0;
+	RCon_tag = "Substation - Surface Civilian"
+	},
+/obj/machinery/camera/network/engineering{
 	dir = 4
 	},
-/obj/effect/floor_decal/corner/mauve/bordercorner{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/rnd/research/researchdivision)
+/turf/simulated/floor/plating,
+/area/maintenance/substation/bar{
+	name = "\improper Surface Civilian Substation"
+	})
 "auu" = (
 /turf/simulated/open,
 /area/rnd/staircase/thirdfloor)
@@ -11927,24 +12196,25 @@
 /turf/simulated/floor/tiled,
 /area/hallway/lower/third_south)
 "auz" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 1
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 4
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7,
-/obj/machinery/camera/network/tether,
 /obj/item/device/radio/intercom{
 	dir = 1;
 	pixel_y = 24;
 	req_access = list()
 	},
-/turf/simulated/floor/tiled,
-/area/hallway/lower/third_south)
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/obj/structure/cable/green{
+	icon_state = "0-8"
+	},
+/obj/structure/closet/wardrobe/science_white,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/rnd/outpost/xenobiology/outpost_south_airlock)
 "auA" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -12143,6 +12413,7 @@
 	dir = 8
 	},
 /obj/machinery/recharger,
+/obj/machinery/camera/network/civilian,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/bar)
 "auR" = (
@@ -12446,19 +12717,18 @@
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/bar)
 "avs" = (
-/obj/structure/table/marble,
-/obj/machinery/camera/network/civilian{
-	dir = 9
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
 	},
-/obj/item/weapon/reagent_containers/food/condiment/small/saltshaker{
-	pixel_x = -3;
-	pixel_y = 0
+/obj/effect/floor_decal/industrial/danger{
+	dir = 1
 	},
-/obj/item/weapon/reagent_containers/food/condiment/small/peppermill{
-	pixel_x = 3
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -22
 	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/bar)
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/shuttle_pad)
 "avt" = (
 /obj/structure/table/standard,
 /obj/item/weapon/stock_parts/micro_laser,
@@ -13730,17 +14000,11 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/rnd/research)
 "axB" = (
-/obj/machinery/camera/network/research{
-	dir = 8
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
 	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/mauve/border{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/rnd/research)
+/turf/simulated/floor/tiled/techmaint,
+/area/tether/surfacebase/shuttle_pad)
 "axC" = (
 /obj/structure/table/standard,
 /obj/item/stack/cable_coil,
@@ -13967,32 +14231,16 @@
 /turf/simulated/open,
 /area/rnd/staircase/thirdfloor)
 "axP" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/camera/network/research{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 8;
-	icon_state = "borderfloor";
-	pixel_x = 0
-	},
-/obj/effect/floor_decal/corner/mauve/border{
+/obj/machinery/holoplant,
+/obj/effect/floor_decal/borderfloorblack{
 	dir = 8
 	},
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 10
-	},
-/obj/effect/floor_decal/corner/mauve/bordercorner2{
-	dir = 10
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
+/obj/machinery/camera/network/research{
+	icon_state = "camera";
 	dir = 5
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 6
-	},
 /turf/simulated/floor/tiled,
-/area/rnd/research/researchdivision)
+/area/rnd/outpost/xenobiology/outpost_hallway)
 "axQ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -14376,24 +14624,15 @@
 /turf/simulated/floor/tiled,
 /area/rnd/research/researchdivision)
 "ayw" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/camera/network/tether{
-	dir = 9
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
 	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 4
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
 	},
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 4
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 10
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 9
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/lower/third_south)
+/turf/simulated/floor/tiled/dark,
+/area/rnd/outpost/xenobiology/outpost_main)
 "ayx" = (
 /turf/simulated/wall/r_wall,
 /area/crew_quarters/heads/hop)
@@ -15010,22 +15249,19 @@
 /turf/simulated/floor/tiled,
 /area/rnd/research/researchdivision)
 "azr" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/lime/border{
-	dir = 8
-	},
-/obj/machinery/camera/network/civilian{
+/obj/structure/bed/chair/wood{
 	dir = 4
 	},
-/obj/structure/extinguisher_cabinet{
-	dir = 4;
-	icon_state = "extinguisher_closed";
-	pixel_x = -30
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24;
+	pixel_y = 0
+	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
-/area/hydroponics)
+/area/rnd/outpost/xenobiology/outpost_breakroom)
 "azs" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -15046,29 +15282,19 @@
 /turf/simulated/wall,
 /area/hydroponics)
 "azu" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 8
+/obj/machinery/shower{
+	dir = 4;
+	icon_state = "shower";
+	pixel_x = 5;
+	pixel_y = 0
 	},
-/obj/effect/floor_decal/corner/lime/border{
-	dir = 8
-	},
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 10
-	},
-/obj/effect/floor_decal/corner/lime/bordercorner2{
-	dir = 10
-	},
-/obj/machinery/camera/network/civilian{
-	dir = 4
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
+/obj/structure/curtain/open/shower,
+/obj/machinery/camera/network/research{
+	icon_state = "camera";
 	dir = 5
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 6
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/lower/third_south)
+/turf/simulated/floor/tiled/dark,
+/area/rnd/outpost/xenobiology/outpost_south_airlock)
 "azv" = (
 /obj/structure/sign/double/barsign{
 	dir = 8
@@ -15415,25 +15641,18 @@
 /turf/simulated/floor/wood,
 /area/library)
 "azU" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 1
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = -28
 	},
-/obj/effect/floor_decal/corner/mauve/border{
-	dir = 1
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals5,
-/obj/effect/floor_decal/steeldecal/steel_decals3{
-	dir = 9
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals3{
-	dir = 8
-	},
-/obj/structure/table/reinforced,
-/obj/machinery/camera/network/research,
 /turf/simulated/floor/tiled,
-/area/rnd/research_foyer)
+/area/rnd/outpost/xenobiology/outpost_breakroom)
 "azV" = (
 /obj/machinery/libraryscanner,
+/obj/machinery/camera/network/civilian{
+	dir = 9
+	},
 /turf/simulated/floor/wood,
 /area/library)
 "azW" = (
@@ -15567,6 +15786,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/camera/network/tether{
+	dir = 9
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/lower/third_south)
 "aAg" = (
@@ -15620,12 +15842,17 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "aAk" = (
-/obj/machinery/camera/network/civilian{
-	dir = 9
+/obj/structure/flora/pottedplant/unusual,
+/obj/machinery/firealarm{
+	dir = 4;
+	layer = 3.3;
+	pixel_x = 26
 	},
-/obj/structure/flora/pottedplant,
+/obj/machinery/camera/network/research{
+	dir = 1
+	},
 /turf/simulated/floor/wood,
-/area/crew_quarters/bar)
+/area/rnd/outpost/xenobiology/outpost_office)
 "aAl" = (
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -15724,15 +15951,11 @@
 /turf/simulated/floor/tiled,
 /area/hallway/lower/third_south)
 "aAt" = (
-/obj/machinery/camera/network/tether{
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/warning/corner{
-	icon_state = "warningcorner";
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/lower/third_south)
+/obj/structure/table/wooden_reinforced,
+/obj/item/weapon/paperplane,
+/obj/machinery/camera/network/research,
+/turf/simulated/floor/wood,
+/area/rnd/outpost/xenobiology/outpost_office)
 "aAu" = (
 /obj/machinery/alarm{
 	dir = 8;
@@ -16059,14 +16282,10 @@
 /turf/simulated/open,
 /area/hallway/lower/third_south)
 "aAO" = (
-/obj/machinery/camera/network/civilian{
-	dir = 4
-	},
-/obj/structure/bed/chair/wood{
-	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/bar)
+/obj/machinery/recharge_station,
+/obj/machinery/camera/network/research,
+/turf/simulated/floor/tiled,
+/area/rnd/outpost/xenobiology/outpost_breakroom)
 "aAP" = (
 /obj/structure/bed/chair/wood,
 /turf/simulated/floor/wood,
@@ -16081,6 +16300,9 @@
 /area/crew_quarters/bar)
 "aAR" = (
 /obj/machinery/computer/arcade,
+/obj/machinery/camera/network/civilian{
+	dir = 4
+	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "aAS" = (
@@ -16324,19 +16546,25 @@
 /obj/effect/floor_decal/corner/mauve/bordercorner2{
 	dir = 5
 	},
+/obj/machinery/camera/network/research,
 /turf/simulated/floor/tiled/steel_grid,
 /area/assembly/robotics)
 "aBa" = (
-/obj/structure/table/reinforced,
-/obj/machinery/camera/network/research,
-/obj/effect/floor_decal/borderfloor{
-	dir = 9
+/obj/structure/table/standard,
+/obj/item/device/lightreplacer,
+/obj/item/weapon/storage/box/lights/mixed,
+/obj/item/weapon/storage/box/lights/mixed,
+/obj/machinery/power/apc{
+	cell_type = /obj/item/weapon/cell/apc;
+	dir = 8;
+	name = "west bump";
+	pixel_x = -28
 	},
-/obj/effect/floor_decal/corner/mauve/border{
-	dir = 9
+/obj/structure/cable/green{
+	icon_state = "0-4"
 	},
-/turf/simulated/floor/tiled,
-/area/rnd/research/testingrange)
+/turf/simulated/floor/tiled/techmaint,
+/area/rnd/outpost/xenobiology/outpost_storage)
 "aBb" = (
 /obj/structure/table/reinforced,
 /obj/machinery/recharger/wallcharger{
@@ -16403,31 +16631,10 @@
 /turf/simulated/floor/tiled,
 /area/rnd/staircase/thirdfloor)
 "aBf" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/camera/network/research,
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/effect/floor_decal/borderfloor{
-	dir = 1;
-	icon_state = "borderfloor";
-	pixel_y = 0
-	},
-/obj/effect/floor_decal/corner/mauve/border{
-	dir = 1
-	},
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/mauve/bordercorner2{
-	dir = 4
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 4
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7,
-/turf/simulated/floor/tiled,
-/area/rnd/research/researchdivision)
+/obj/machinery/hologram/holopad,
+/obj/machinery/camera/network/research/xenobio,
+/turf/simulated/floor/tiled/dark,
+/area/rnd/outpost/xenobiology/outpost_stairs)
 "aBg" = (
 /obj/structure/cable/green{
 	icon_state = "0-4"
@@ -16598,28 +16805,12 @@
 /turf/simulated/floor/wood,
 /area/library)
 "aBu" = (
-/obj/structure/table/glass,
-/obj/machinery/recharger{
-	pixel_y = 0
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
 	},
-/obj/machinery/camera/network/research{
-	dir = 1
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/mauve/border,
-/obj/effect/floor_decal/borderfloor/corner2,
-/obj/effect/floor_decal/corner/mauve/bordercorner2,
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 8
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/rnd/staircase/thirdfloor)
+/obj/machinery/camera/network/research,
+/turf/simulated/floor/tiled/white,
+/area/rnd/outpost/xenobiology/outpost_autopsy)
 "aBv" = (
 /obj/structure/bed/chair/office/dark,
 /turf/simulated/floor/wood,
@@ -16774,17 +16965,14 @@
 /turf/simulated/floor/tiled,
 /area/rnd/research/testingrange)
 "aBJ" = (
-/obj/structure/table/reinforced,
-/obj/machinery/cell_charger,
-/obj/machinery/camera/network/research,
-/obj/effect/floor_decal/borderfloor{
-	dir = 5
+/obj/structure/cable/green{
+	icon_state = "1-4"
 	},
-/obj/effect/floor_decal/corner/mauve/border{
-	dir = 5
+/obj/machinery/camera/network/research{
+	dir = 1
 	},
-/turf/simulated/floor/tiled,
-/area/rnd/research/testingrange)
+/turf/simulated/floor/tiled/white,
+/area/rnd/outpost/xenobiology/outpost_decon)
 "aBK" = (
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/borderfloorblack,
@@ -16825,26 +17013,13 @@
 /turf/simulated/floor/tiled,
 /area/rnd/research/researchdivision)
 "aBM" = (
+/obj/machinery/hologram/holopad,
 /obj/machinery/camera/network/research{
+	icon_state = "camera";
 	dir = 8
 	},
-/obj/structure/sign/department/robo{
-	pixel_x = 32
-	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/mauve/border{
-	dir = 4
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 9
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 10
-	},
-/turf/simulated/floor/tiled,
-/area/rnd/research/researchdivision)
+/turf/simulated/floor/tiled/white,
+/area/rnd/outpost/xenobiology/outpost_first_aid)
 "aBN" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -17118,6 +17293,9 @@
 "aCf" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/mauve/border,
+/obj/machinery/camera/network/research{
+	dir = 1
+	},
 /turf/simulated/floor/tiled,
 /area/rnd/research/researchdivision)
 "aCg" = (
@@ -17432,6 +17610,9 @@
 /obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 9
 	},
+/obj/machinery/camera/network/tether{
+	dir = 9
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/lower/third_south)
 "aCF" = (
@@ -17742,6 +17923,7 @@
 	pixel_x = -24
 	},
 /obj/machinery/portable_atmospherics/hydroponics/soil,
+/obj/machinery/camera/network/civilian,
 /turf/simulated/floor/grass,
 /area/tether/surfacebase/public_garden_three)
 "aDj" = (
@@ -17814,21 +17996,15 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/public_garden_three)
 "aDo" = (
-/obj/structure/sink{
-	dir = 4;
-	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
+/obj/structure/table/standard,
+/obj/item/device/slime_scanner,
+/obj/item/device/slime_scanner,
+/obj/item/device/multitool,
+/obj/machinery/camera/network/research{
+	dir = 1
 	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 5
-	},
-/obj/effect/floor_decal/corner/lime/border{
-	dir = 5
-	},
-/obj/machinery/camera/network/civilian,
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/public_garden_three)
+/turf/simulated/floor/tiled/techmaint,
+/area/rnd/outpost/xenobiology/outpost_storage)
 "aDp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -18171,6 +18347,9 @@
 /obj/effect/floor_decal/corner/lime/border{
 	dir = 6
 	},
+/obj/machinery/camera/network/civilian{
+	dir = 1
+	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/public_garden_three)
 "aDP" = (
@@ -18217,6 +18396,15 @@
 /obj/structure/table/bench/wooden,
 /turf/simulated/floor/grass,
 /area/tether/surfacebase/public_garden_three)
+"aDU" = (
+/obj/structure/bed/chair/wood{
+	dir = 1
+	},
+/obj/machinery/camera/network/research{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/rnd/outpost/xenobiology/outpost_breakroom)
 "aDV" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -18364,9 +18552,12 @@
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
 "aEf" = (
-/obj/machinery/camera/network/outside,
-/turf/simulated/floor/outdoors/grass/sif/virgo3b,
-/area/tether/surfacebase/outside/outside3)
+/obj/machinery/camera/network/research{
+	icon_state = "camera";
+	dir = 5
+	},
+/turf/simulated/floor/tiled/dark,
+/area/rnd/outpost/xenobiology/outpost_main)
 "aEg" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -18552,19 +18743,16 @@
 /turf/simulated/floor/plating,
 /area/maintenance/commandmaint)
 "aEw" = (
-/obj/machinery/camera/network/tether{
-	dir = 1
+/obj/structure/flora/pottedplant/subterranean,
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
 	},
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/lightgrey/border,
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 1
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
+/obj/machinery/camera/network/research{
+	icon_state = "camera";
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
-/area/tether/surfacebase/surface_three_hall)
+/area/rnd/outpost/xenobiology/outpost_hallway)
 "aEx" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/lime/border,
@@ -19100,20 +19288,19 @@
 /turf/simulated/floor/wood,
 /area/library)
 "aFw" = (
-/obj/structure/cable/green{
-	icon_state = "0-2"
+/obj/structure/closet/crate,
+/obj/item/target,
+/obj/item/target,
+/obj/item/target,
+/obj/item/target,
+/obj/item/target,
+/obj/structure/window/reinforced,
+/obj/machinery/camera/network/research{
+	icon_state = "camera";
+	dir = 5
 	},
-/obj/structure/cable,
-/obj/machinery/power/smes/buildable{
-	charge = 0;
-	output_attempt = 0;
-	outputting = 0;
-	RCon_tag = "Substation - Surface Civilian"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/substation/bar{
-	name = "\improper Surface Civilian Substation"
-	})
+/turf/simulated/floor/tiled/dark,
+/area/rnd/research/testingrange)
 "aFx" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -19242,30 +19429,26 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "aFF" = (
-/obj/machinery/camera/network/civilian{
-	dir = 1
-	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_x = 0;
-	pixel_y = -25
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	icon_state = "1-2"
 	},
 /obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "1-4"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/cable/green{
+	icon_state = "1-8"
 	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/bar)
+/obj/structure/disposalpipe/junction{
+	dir = 1;
+	icon_state = "pipe-j2"
+	},
+/obj/machinery/camera/network/research{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/rnd/outpost/xenobiology/outpost_main)
 "aFG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -19690,27 +19873,16 @@
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/bar)
 "aGl" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
-	},
-/obj/item/device/radio/intercom{
-	pixel_y = -24
-	},
+/obj/structure/table/reinforced,
+/obj/item/clothing/ears/earmuffs,
+/obj/item/clothing/glasses/goggles,
+/obj/structure/window/reinforced,
 /obj/machinery/camera/network/research{
-	dir = 1
+	icon_state = "camera";
+	dir = 8
 	},
-/obj/effect/floor_decal/borderfloorblack,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled,
-/area/rnd/outpost/xenobiology/outpost_north_airlock)
+/turf/simulated/floor/tiled/dark,
+/area/rnd/research/testingrange)
 "aGm" = (
 /obj/structure/closet/secure_closet/personal/patient,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -20392,22 +20564,33 @@
 /turf/simulated/floor/tiled,
 /area/hallway/lower/third_south)
 "aHj" = (
-/obj/machinery/camera/network/tether,
+/obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/borderfloor{
-	dir = 1
+	dir = 8;
+	icon_state = "borderfloor";
+	pixel_x = 0
 	},
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 1
+/obj/effect/floor_decal/corner/mauve/border{
+	dir = 8
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/mauve/bordercorner2{
+	dir = 10
+	},
 /obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 4
+	dir = 5
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 6
+	},
+/obj/machinery/camera/network/research{
+	icon_state = "camera";
+	dir = 5
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/lower/third_south)
+/area/rnd/research/researchdivision)
 "aHk" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -20713,28 +20896,12 @@
 /turf/simulated/floor/tiled/dark,
 /area/rnd/outpost/xenobiology/outpost_hallway)
 "aHG" = (
+/obj/machinery/cryopod/robot,
 /obj/machinery/camera/network/research{
-	dir = 8
+	dir = 1
 	},
-/obj/item/device/radio/intercom{
-	dir = 1;
-	pixel_y = 24;
-	req_access = list()
-	},
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
-/obj/structure/cable/green{
-	icon_state = "0-8"
-	},
-/obj/structure/closet/wardrobe/science_white,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
-/area/rnd/outpost/xenobiology/outpost_south_airlock)
+/turf/simulated/floor/tiled/steel_grid,
+/area/assembly/chargebay)
 "aHH" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -21220,15 +21387,25 @@
 /turf/simulated/floor/tiled,
 /area/rnd/outpost/xenobiology/outpost_hallway)
 "aIq" = (
-/obj/structure/flora/pottedplant/subterranean,
-/obj/machinery/camera/network/research{
-	dir = 8
-	},
-/obj/effect/floor_decal/borderfloorblack{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/recharge_station,
+/obj/effect/floor_decal/borderfloor{
+	dir = 1;
+	icon_state = "borderfloor";
+	pixel_y = 0
+	},
+/obj/effect/floor_decal/corner/mauve/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/machinery/camera/network/research,
 /turf/simulated/floor/tiled,
-/area/rnd/outpost/xenobiology/outpost_hallway)
+/area/rnd/research/researchdivision)
 "aIr" = (
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/airlock/research{
@@ -21276,29 +21453,19 @@
 /turf/simulated/floor/tiled/dark,
 /area/rnd/outpost/xenobiology/outpost_south_airlock)
 "aIt" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/borderfloor{
-	dir = 8;
-	icon_state = "borderfloor";
-	pixel_x = 0
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/red/border,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/corner/mauve/border{
-	dir = 8
-	},
-/obj/effect/floor_decal/borderfloor/corner2{
+/obj/machinery/camera/network/security{
+	icon_state = "camera";
 	dir = 10
-	},
-/obj/effect/floor_decal/corner/mauve/bordercorner2{
-	dir = 10
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 5
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 6
 	},
 /turf/simulated/floor/tiled,
-/area/rnd/research/researchdivision)
+/area/tether/surfacebase/security/common)
 "aIu" = (
 /obj/machinery/computer/transhuman/resleeving{
 	dir = 4
@@ -21441,19 +21608,15 @@
 /turf/simulated/floor/tiled,
 /area/hallway/lower/third_south)
 "aIF" = (
-/obj/machinery/camera/network/tether{
-	dir = 1
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/closet/secure_closet/security,
+/obj/item/device/holowarrant,
+/obj/machinery/camera/network/security{
+	icon_state = "camera";
+	dir = 5
 	},
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/lightgrey/border,
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 8
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/lower/third_south)
+/turf/simulated/floor/tiled/dark,
+/area/tether/surfacebase/security/armory)
 "aIG" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/lightgrey/border,
@@ -21486,6 +21649,9 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
+/obj/machinery/camera/network/civilian{
+	dir = 4
+	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "aIK" = (
@@ -21494,18 +21660,9 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "aIL" = (
-/obj/effect/floor_decal/spline/plain{
-	dir = 4
-	},
-/obj/effect/floor_decal/spline/plain{
-	dir = 8
-	},
-/obj/machinery/camera/network/civilian{
-	dir = 1
-	},
-/obj/machinery/media/jukebox,
-/turf/simulated/floor/lino,
-/area/crew_quarters/bar)
+/obj/machinery/camera/network/security,
+/turf/simulated/open,
+/area/tether/surfacebase/security/upperhall)
 "aIM" = (
 /obj/structure/table/marble,
 /obj/machinery/door/blast/shutters{
@@ -21536,18 +21693,19 @@
 /turf/simulated/floor/lino,
 /area/crew_quarters/bar)
 "aIQ" = (
-/obj/structure/table/marble,
-/obj/machinery/chemical_dispenser/bar_alc/full,
-/turf/simulated/floor/lino,
+/obj/structure/flora/pottedplant,
+/obj/machinery/camera/network/civilian{
+	dir = 9
+	},
+/turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "aIR" = (
-/obj/structure/table/marble,
-/obj/machinery/chemical_dispenser/bar_soft/full,
-/obj/machinery/camera/network/civilian{
-	dir = 1
+/obj/machinery/camera/network/security{
+	icon_state = "camera";
+	dir = 10
 	},
-/turf/simulated/floor/lino,
-/area/crew_quarters/bar)
+/turf/simulated/open,
+/area/tether/surfacebase/medical/triage)
 "aIS" = (
 /obj/structure/table/marble,
 /obj/item/weapon/reagent_containers/glass/rag,
@@ -21792,20 +21950,19 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/assembly/robotics)
 "aJl" = (
-/obj/machinery/computer/rdconsole/robotics{
-	dir = 8
-	},
-/obj/machinery/camera/network/research{
-	dir = 8
-	},
-/obj/effect/floor_decal/borderfloor{
+/obj/effect/floor_decal/borderfloorwhite{
 	dir = 4
 	},
-/obj/effect/floor_decal/corner/mauve/border{
+/obj/effect/floor_decal/corner/paleblue/border{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/assembly/robotics)
+/obj/machinery/chemical_dispenser/full,
+/obj/machinery/camera/network/security{
+	icon_state = "camera";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/chemistry)
 "aJm" = (
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/blast/regular{
@@ -22196,13 +22353,13 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/assembly/chargebay)
 "aJV" = (
-/obj/machinery/recharge_station,
-/obj/machinery/camera/network/research,
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 4
+/obj/structure/table/marble,
+/obj/machinery/chemical_dispenser/bar_alc/full,
+/obj/machinery/camera/network/civilian{
+	dir = 1
 	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/assembly/chargebay)
+/turf/simulated/floor/lino,
+/area/crew_quarters/bar)
 "aJW" = (
 /obj/effect/floor_decal/industrial/warning{
 	icon_state = "warning";
@@ -22254,11 +22411,11 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/shuttle_pad)
 "aKc" = (
-/obj/effect/floor_decal/borderfloorblack,
-/obj/effect/floor_decal/industrial/danger,
-/obj/machinery/camera/network/tether,
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/shuttle_pad)
+/obj/machinery/camera/network/civilian{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/crew_quarters/freezer)
 "aKd" = (
 /obj/effect/floor_decal/borderfloorblack/corner{
 	icon_state = "borderfloorcorner_black";
@@ -22346,6 +22503,9 @@
 /obj/structure/closet/secure_closet/bar{
 	req_access = list(25)
 	},
+/obj/machinery/camera/network/civilian{
+	dir = 4
+	},
 /turf/simulated/floor/wood,
 /area/tether/surfacebase/bar_backroom)
 "aKp" = (
@@ -22390,12 +22550,9 @@
 /turf/simulated/floor/wood,
 /area/tether/surfacebase/bar_backroom)
 "aKt" = (
-/obj/structure/bed/chair/comfy{
-	dir = 8
-	},
 /obj/machinery/camera/network/civilian,
-/turf/simulated/floor/wood,
-/area/tether/surfacebase/bar_backroom)
+/turf/simulated/floor/grass,
+/area/hydroponics/cafegarden)
 "aKu" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -22478,15 +22635,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/rnd/outpost/xenobiology/outpost_south_airlock)
 "aKD" = (
-/obj/structure/closet/crate,
-/obj/item/target,
-/obj/item/target,
-/obj/item/target,
-/obj/item/target,
-/obj/item/target,
-/obj/structure/window/reinforced,
-/turf/simulated/floor/tiled/dark,
-/area/rnd/research/testingrange)
+/obj/effect/floor_decal/borderfloorblack,
+/obj/effect/floor_decal/industrial/danger,
+/obj/machinery/camera/network/civilian,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/shuttle_pad)
 "aKE" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/door/window/brigdoor/southleft{
@@ -22519,17 +22672,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/rnd/research/testingrange)
 "aKI" = (
-/obj/structure/table/reinforced,
-/obj/item/clothing/ears/earmuffs,
-/obj/item/clothing/glasses/goggles,
-/obj/structure/window/reinforced,
-/obj/structure/extinguisher_cabinet{
-	dir = 8;
-	icon_state = "extinguisher_closed";
-	pixel_x = 30
+/obj/machinery/camera/network/civilian{
+	dir = 9
 	},
-/turf/simulated/floor/tiled/dark,
-/area/rnd/research/testingrange)
+/turf/simulated/floor/reinforced,
+/area/tether/surfacebase/shuttle_pad)
 "aKJ" = (
 /obj/structure/table/standard,
 /obj/machinery/cell_charger,
@@ -22689,11 +22836,15 @@
 /turf/simulated/floor/tiled,
 /area/hallway/lower/third_south)
 "aLa" = (
-/obj/machinery/camera/network/tether{
-	dir = 9
+/obj/item/stack/material/plastic,
+/obj/structure/table/rack,
+/obj/item/stack/material/steel{
+	amount = 3
 	},
-/turf/simulated/floor/tiled,
-/area/hallway/lower/third_south)
+/obj/random/maintenance/engineering,
+/obj/machinery/camera/network/civilian,
+/turf/simulated/floor/tiled/techfloor,
+/area/tether/surfacebase/shuttle_pad)
 "aLb" = (
 /obj/structure/table/woodentable,
 /obj/machinery/alarm{
@@ -22804,12 +22955,17 @@
 /turf/simulated/floor/tiled/dark,
 /area/rnd/research/testingrange)
 "aLn" = (
-/obj/effect/floor_decal/industrial/warning{
+/obj/effect/floor_decal/borderfloorblack{
 	dir = 1
 	},
-/obj/machinery/camera/network/research,
-/turf/simulated/floor/tiled/dark,
-/area/rnd/research/testingrange)
+/obj/effect/floor_decal/industrial/danger{
+	dir = 1
+	},
+/obj/machinery/camera/network/civilian{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/shuttle_pad)
 "aLo" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
@@ -23037,14 +23193,11 @@
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/barrestroom)
 "aLL" = (
-/obj/machinery/camera/network/research{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 8
+/obj/machinery/camera/network/civilian{
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
-/area/rnd/outpost/xenobiology/outpost_hallway)
+/area/tether/surfacebase/shuttle_pad)
 "aLM" = (
 /obj/machinery/light{
 	dir = 8
@@ -23075,10 +23228,9 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/rnd/outpost/xenobiology/outpost_storage)
 "aLP" = (
-/obj/machinery/hologram/holopad,
-/obj/machinery/camera/network/research,
-/turf/simulated/floor/tiled/dark,
-/area/rnd/outpost/xenobiology/outpost_stairs)
+/obj/machinery/camera/network/civilian,
+/turf/simulated/floor/wood,
+/area/library)
 "aLQ" = (
 /obj/machinery/alarm{
 	alarm_id = "anomaly_testing";
@@ -23291,15 +23443,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/rnd/outpost/xenobiology/outpost_south_airlock)
 "aMk" = (
-/obj/machinery/light_switch{
-	dir = 8;
-	pixel_x = 24
+/obj/machinery/camera/network/civilian{
+	dir = 9
 	},
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/rnd/outpost/xenobiology/outpost_hallway)
+/turf/simulated/floor/wood,
+/area/library)
 "aMl" = (
 /turf/simulated/open,
 /area/rnd/outpost/xenobiology/outpost_stairs)
@@ -23401,9 +23549,11 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/assembly/chargebay)
 "aMw" = (
-/obj/machinery/cryopod/robot,
-/turf/simulated/floor/tiled/steel_grid,
-/area/assembly/chargebay)
+/obj/machinery/camera/network/civilian{
+	dir = 9
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/recreation_area)
 "aMx" = (
 /obj/machinery/computer/cryopod/robot{
 	dir = 1;
@@ -23480,6 +23630,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/outpost/xenobiology/outpost_hallway)
+"aMI" = (
+/obj/effect/floor_decal/spline/plain,
+/obj/machinery/camera/network/civilian{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/crew_quarters/pool)
 "aMJ" = (
 /obj/structure/table/glass,
 /obj/item/bodybag,
@@ -23570,21 +23727,10 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/assembly/robotics)
 "aMS" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/machinery/camera/network/research{
-	dir = 8
-	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/mauve/border{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/assembly/robotics)
+/obj/machinery/vending/fitness,
+/obj/machinery/camera/network/civilian,
+/turf/simulated/floor/tiled,
+/area/crew_quarters/pool)
 "aMT" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 4
@@ -23622,6 +23768,9 @@
 	icon_state = "extinguisher_closed";
 	pixel_x = -30
 	},
+/obj/machinery/camera/network/civilian{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/shuttle_pad)
 "aMW" = (
@@ -23639,18 +23788,28 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/shuttle_pad)
 "aMX" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals5{
-	dir = 1
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals5,
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 9
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 10
+	},
 /obj/machinery/camera/network/tether{
 	dir = 9
 	},
 /turf/simulated/floor/tiled,
-/area/tether/surfacebase/shuttle_pad)
+/area/tether/surfacebase/surface_three_hall)
 "aMY" = (
 /obj/effect/floor_decal/steeldecal/steel_decals_central5{
 	icon_state = "steel_decals_central5";
@@ -23791,22 +23950,31 @@
 /turf/simulated/floor/tiled,
 /area/rnd/outpost/xenobiology/outpost_hallway)
 "aNo" = (
-/obj/machinery/camera/network/research{
-	dir = 4
+/obj/effect/floor_decal/corner/lightgrey{
+	dir = 9
 	},
-/obj/machinery/holoplant,
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 8
+/obj/effect/floor_decal/corner/lightgrey{
+	dir = 6
+	},
+/obj/machinery/camera/network/tether{
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
-/area/rnd/outpost/xenobiology/outpost_hallway)
+/area/tether/surfacebase/surface_three_hall)
 "aNp" = (
-/obj/structure/catwalk,
-/obj/machinery/camera/network/outside{
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/lightgrey/border,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 8
 	},
-/turf/simulated/open/virgo3b,
-/area/tether/surfacebase/outside/outside3)
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 1
+	},
+/obj/machinery/camera/network/tether{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/surface_three_hall)
 "aNq" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/effect/decal/cleanable/blood,
@@ -23957,11 +24125,19 @@
 /turf/simulated/open/virgo3b,
 /area/tether/surfacebase/outside/outside3)
 "aNE" = (
-/obj/machinery/camera/network/research{
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/lightgrey/border,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/dark,
-/area/rnd/research/testingrange)
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 8
+	},
+/obj/machinery/camera/network/tether{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/surface_three_hall)
 "aNF" = (
 /obj/machinery/door/firedoor,
 /obj/structure/grille,
@@ -24104,11 +24280,38 @@
 /obj/structure/sign/xenobio,
 /turf/simulated/wall,
 /area/rnd/outpost/xenobiology/outpost_hallway)
+"aOa" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/machinery/camera/network/tether,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/surface_three_hall)
 "aOb" = (
-/obj/structure/catwalk,
-/obj/machinery/camera/network/outside,
-/turf/simulated/open/virgo3b,
-/area/tether/surfacebase/outside/outside3)
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 5
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 6
+	},
+/obj/machinery/camera/network/tether{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/surface_three_hall)
 "aOc" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -24147,6 +24350,29 @@
 "aOf" = (
 /turf/simulated/wall/r_wall,
 /area/rnd/outpost/xenobiology/outpost_south_airlock)
+"aOg" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/beige/border{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 10
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 9
+	},
+/obj/machinery/camera/network/tether{
+	dir = 9
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/surface_three_hall)
 "aOh" = (
 /obj/structure/cable/green,
 /obj/machinery/power/apc{
@@ -24208,18 +24434,24 @@
 /turf/simulated/floor/tiled/dark,
 /area/rnd/outpost/xenobiology/outpost_south_airlock)
 "aOq" = (
-/obj/machinery/camera/network/research{
+/obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/borderfloor{
 	dir = 4
 	},
-/obj/machinery/shower{
-	dir = 4;
-	icon_state = "shower";
-	pixel_x = 5;
-	pixel_y = 0
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 4
 	},
-/obj/structure/curtain/open/shower,
-/turf/simulated/floor/tiled/dark,
-/area/rnd/outpost/xenobiology/outpost_south_airlock)
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 10
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 9
+	},
+/obj/machinery/camera/network/tether{
+	dir = 9
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/lower/third_south)
 "aOr" = (
 /obj/machinery/light{
 	dir = 4
@@ -24396,21 +24628,19 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/shuttle_pad)
 "aOJ" = (
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 1
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/lightgrey/border,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 8
 	},
-/obj/effect/floor_decal/industrial/danger{
+/obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 1
-	},
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -22
 	},
 /obj/machinery/camera/network/tether{
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
-/area/tether/surfacebase/shuttle_pad)
+/area/hallway/lower/third_south)
 "aOK" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
@@ -24464,14 +24694,11 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/tether/surfacebase/shuttle_pad)
 "aOQ" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
 /obj/machinery/camera/network/tether{
-	dir = 1
+	dir = 9
 	},
-/turf/simulated/floor/tiled/techmaint,
-/area/tether/surfacebase/shuttle_pad)
+/turf/simulated/floor/tiled,
+/area/hallway/lower/third_south)
 "aOR" = (
 /turf/simulated/wall,
 /area/rnd/outpost/xenobiology/outpost_office)
@@ -24487,6 +24714,31 @@
 /obj/structure/closet/radiation,
 /turf/simulated/floor/tiled/white,
 /area/rnd/outpost/xenobiology/outpost_decon)
+"aOT" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 9
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 10
+	},
+/obj/machinery/camera/network/tether{
+	dir = 9
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/surface_three_hall)
+"aOU" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/camera/network/command,
+/turf/simulated/floor/tiled/dark,
+/area/bridge_hallway)
 "aOV" = (
 /obj/structure/table/glass,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -24536,12 +24788,12 @@
 /turf/simulated/wall,
 /area/rnd/outpost/xenobiology/outpost_breakroom)
 "aPa" = (
-/obj/structure/catwalk,
-/obj/machinery/camera/network/outside{
+/obj/machinery/camera/network/command{
+	icon_state = "camera";
 	dir = 4
 	},
-/turf/simulated/open/virgo3b,
-/area/tether/surfacebase/outside/outside3)
+/turf/simulated/floor/carpet,
+/area/crew_quarters/heads/hop)
 "aPb" = (
 /obj/machinery/door/firedoor,
 /obj/structure/grille,
@@ -24572,10 +24824,20 @@
 /turf/simulated/floor/plating,
 /area/rnd/outpost/xenobiology/outpost_office)
 "aPe" = (
-/obj/structure/table/wooden_reinforced,
-/obj/item/weapon/paperplane,
-/turf/simulated/floor/wood,
-/area/rnd/outpost/xenobiology/outpost_office)
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/camera/network/command{
+	icon_state = "camera";
+	dir = 9
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge_hallway)
 "aPf" = (
 /obj/machinery/light{
 	dir = 8
@@ -24596,6 +24858,26 @@
 /obj/machinery/computer/security/xenobio,
 /turf/simulated/floor/wood,
 /area/rnd/outpost/xenobiology/outpost_office)
+"aPi" = (
+/obj/structure/bed/chair/office/dark{
+	dir = 4
+	},
+/obj/effect/landmark/start{
+	name = "Colony Director"
+	},
+/obj/machinery/button/remote/blast_door{
+	dir = 8;
+	id = "cap_office";
+	name = "Security Shutters";
+	pixel_x = 30;
+	pixel_y = 16
+	},
+/obj/machinery/camera/network/command{
+	icon_state = "camera";
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/captain)
 "aPj" = (
 /obj/machinery/door/firedoor/glass,
 /obj/structure/grille,
@@ -24619,9 +24901,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/rnd/outpost/xenobiology/outpost_south_airlock)
 "aPk" = (
-/obj/machinery/recharge_station,
-/turf/simulated/floor/tiled,
-/area/rnd/outpost/xenobiology/outpost_breakroom)
+/obj/machinery/camera/network/command,
+/turf/simulated/floor/tiled/dark,
+/area/bridge)
 "aPl" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/storage/box/donkpockets,
@@ -24657,14 +24939,12 @@
 /turf/simulated/floor/plating,
 /area/rnd/outpost/xenobiology/outpost_breakroom)
 "aPp" = (
-/obj/item/stack/material/plastic,
-/obj/structure/table/rack,
-/obj/item/stack/material/steel{
-	amount = 3
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/random/maintenance/engineering,
-/turf/simulated/floor/tiled/techfloor,
-/area/tether/surfacebase/shuttle_pad)
+/obj/machinery/camera/network/command,
+/turf/simulated/floor/tiled/dark,
+/area/bridge)
 "aPq" = (
 /obj/machinery/alarm{
 	pixel_y = 22
@@ -24766,6 +25046,39 @@
 /obj/machinery/vending/snack,
 /turf/simulated/floor/tiled,
 /area/rnd/outpost/xenobiology/outpost_breakroom)
+"aPC" = (
+/obj/machinery/computer/communications{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/camera/network/command{
+	icon_state = "camera";
+	dir = 10
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge)
+"aPD" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/item/device/radio/intercom{
+	dir = 1;
+	pixel_y = 24;
+	req_access = list()
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/lower/third_south)
 "aPE" = (
 /obj/item/device/radio/intercom{
 	dir = 8;
@@ -24921,23 +25234,11 @@
 /turf/simulated/floor/wood,
 /area/rnd/outpost/xenobiology/outpost_office)
 "aQd" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	icon_state = "1-2"
+/obj/machinery/light/small{
+	dir = 8
 	},
-/obj/structure/cable/green{
-	icon_state = "1-4"
-	},
-/obj/structure/cable/green{
-	icon_state = "1-8"
-	},
-/obj/structure/disposalpipe/junction{
-	dir = 1;
-	icon_state = "pipe-j2"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/rnd/outpost/xenobiology/outpost_main)
+/turf/simulated/open,
+/area/tether/surfacebase/north_stairs_three)
 "aQe" = (
 /obj/machinery/light_switch{
 	dir = 4;
@@ -24953,18 +25254,12 @@
 /turf/simulated/floor/tiled/dark,
 /area/rnd/outpost/xenobiology/outpost_main)
 "aQf" = (
-/obj/machinery/camera/network/research{
-	dir = 8
+/obj/machinery/camera/network/outside{
+	icon_state = "camera";
+	dir = 6
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
-/area/rnd/outpost/xenobiology/outpost_main)
+/turf/simulated/floor/outdoors/grass/sif/virgo3b,
+/area/tether/surfacebase/outside/outside3)
 "aQg" = (
 /obj/machinery/vending/cola,
 /turf/simulated/floor/tiled,
@@ -25207,22 +25502,13 @@
 /turf/simulated/floor/tiled/dark,
 /area/rnd/outpost/xenobiology/outpost_main)
 "aQD" = (
-/obj/structure/bed/chair/wood{
-	dir = 4
+/obj/structure/catwalk,
+/obj/machinery/camera/network/outside{
+	icon_state = "camera";
+	dir = 9
 	},
-/obj/machinery/camera/network/research{
-	dir = 4
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24;
-	pixel_y = 0
-	},
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled,
-/area/rnd/outpost/xenobiology/outpost_breakroom)
+/turf/simulated/open/virgo3b,
+/area/tether/surfacebase/outside/outside3)
 "aQE" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/storage/box/donut,
@@ -25353,17 +25639,12 @@
 /turf/simulated/floor/wood,
 /area/rnd/outpost/xenobiology/outpost_office)
 "aQU" = (
-/obj/structure/flora/pottedplant/unusual,
-/obj/machinery/camera/network/research{
-	dir = 8
+/obj/machinery/camera/network/outside{
+	icon_state = "camera";
+	dir = 9
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	layer = 3.3;
-	pixel_x = 26
-	},
-/turf/simulated/floor/wood,
-/area/rnd/outpost/xenobiology/outpost_office)
+/turf/simulated/floor/outdoors/grass/sif/virgo3b,
+/area/tether/surfacebase/outside/outside3)
 "aQV" = (
 /obj/machinery/power/apc{
 	cell_type = /obj/item/weapon/cell/apc;
@@ -25376,11 +25657,12 @@
 /turf/simulated/floor/tiled,
 /area/rnd/outpost/xenobiology/outpost_breakroom)
 "aQW" = (
-/obj/structure/bed/chair/wood{
+/obj/machinery/camera/network/outside{
+	icon_state = "camera";
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
-/area/rnd/outpost/xenobiology/outpost_breakroom)
+/turf/simulated/floor/outdoors/grass/sif/virgo3b,
+/area/tether/surfacebase/outside/outside3)
 "aQX" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/brigdoor/eastleft{
@@ -25479,12 +25761,13 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/outpost/xenobiology/outpost_autopsy)
 "aRh" = (
-/obj/machinery/camera/network/research,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
+/obj/structure/catwalk,
+/obj/machinery/camera/network/outside{
+	icon_state = "camera";
+	dir = 5
 	},
-/turf/simulated/floor/tiled/white,
-/area/rnd/outpost/xenobiology/outpost_autopsy)
+/turf/simulated/open/virgo3b,
+/area/tether/surfacebase/outside/outside3)
 "aRi" = (
 /turf/simulated/floor/tiled/white,
 /area/rnd/outpost/xenobiology/outpost_autopsy)
@@ -25520,11 +25803,12 @@
 /turf/simulated/wall,
 /area/rnd/outpost/xenobiology/outpost_autopsy)
 "aRm" = (
-/obj/machinery/camera/network/research{
-	dir = 4
+/obj/machinery/camera/network/outside{
+	icon_state = "camera";
+	dir = 5
 	},
-/turf/simulated/floor/tiled/dark,
-/area/rnd/outpost/xenobiology/outpost_main)
+/turf/simulated/floor/outdoors/grass/sif/virgo3b,
+/area/tether/surfacebase/outside/outside3)
 "aRn" = (
 /obj/machinery/newscaster,
 /turf/simulated/wall,
@@ -25785,6 +26069,13 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/outpost/xenobiology/outpost_autopsy)
+"aRJ" = (
+/obj/machinery/camera/network/outside{
+	icon_state = "camera";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/steel_dirty/virgo3b,
+/area/tether/surfacebase/outside/outside3)
 "aRK" = (
 /turf/simulated/wall,
 /area/tether/surfacebase/medical/patient_c)
@@ -25793,11 +26084,10 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/outpost/xenobiology/outpost_decon)
 "aRM" = (
-/obj/structure/cable/green{
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/tiled/white,
-/area/rnd/outpost/xenobiology/outpost_decon)
+/obj/structure/shuttle/engine/propulsion,
+/turf/simulated/floor/reinforced,
+/turf/simulated/shuttle/plating/carry,
+/area/shuttle/tether/surface)
 "aRN" = (
 /obj/effect/floor_decal/steeldecal/steel_decals10{
 	dir = 1
@@ -25882,13 +26172,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/outpost/xenobiology/outpost_main)
-"aRY" = (
-/obj/machinery/camera/network/research,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/rnd/outpost/xenobiology/outpost_main)
 "aRZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -25959,14 +26242,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
-	},
-/turf/simulated/floor/tiled,
-/area/rnd/outpost/xenobiology/outpost_main)
-"aSg" = (
-/obj/machinery/camera/network/research,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/outpost/xenobiology/outpost_main)
@@ -26646,13 +26921,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/chemistry)
-"aTe" = (
-/obj/machinery/camera/network/research{
-	dir = 8
-	},
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/tiled/white,
-/area/rnd/outpost/xenobiology/outpost_first_aid)
 "aTf" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -26663,25 +26931,6 @@
 "aTg" = (
 /turf/simulated/wall,
 /area/maintenance/lower/mining)
-"aTh" = (
-/obj/structure/table/standard,
-/obj/item/device/lightreplacer,
-/obj/item/weapon/storage/box/lights/mixed,
-/obj/item/weapon/storage/box/lights/mixed,
-/obj/machinery/power/apc{
-	cell_type = /obj/item/weapon/cell/apc;
-	dir = 8;
-	name = "west bump";
-	pixel_x = -28
-	},
-/obj/machinery/camera/network/research{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/rnd/outpost/xenobiology/outpost_storage)
 "aTi" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -26807,24 +27056,6 @@
 	},
 /obj/item/weapon/reagent_containers/spray,
 /obj/item/weapon/reagent_containers/spray,
-/turf/simulated/floor/tiled/techmaint,
-/area/rnd/outpost/xenobiology/outpost_storage)
-"aTu" = (
-/obj/machinery/camera/network/research{
-	dir = 1
-	},
-/obj/machinery/light_switch{
-	dir = 1;
-	pixel_x = 0;
-	pixel_y = -28
-	},
-/turf/simulated/floor/tiled,
-/area/rnd/outpost/xenobiology/outpost_breakroom)
-"aTv" = (
-/obj/structure/table/standard,
-/obj/item/device/slime_scanner,
-/obj/item/device/slime_scanner,
-/obj/item/device/multitool,
 /turf/simulated/floor/tiled/techmaint,
 /area/rnd/outpost/xenobiology/outpost_storage)
 "aTw" = (
@@ -27055,23 +27286,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/chemistry)
-"aUM" = (
-/obj/structure/table/reinforced,
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 4
-	},
-/obj/machinery/reagentgrinder,
-/obj/machinery/camera/network/medbay{
-	dir = 8
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/chemistry)
 "aUN" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -27248,16 +27462,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/chemistry)
-"aVb" = (
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 4
-	},
-/obj/machinery/chemical_dispenser/full,
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/chemistry)
 "aVc" = (
@@ -27692,16 +27896,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/common)
-"aVK" = (
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/red/border,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/security/common)
 "aVL" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/red/border,
@@ -27799,23 +27993,6 @@
 /obj/machinery/alarm{
 	dir = 1;
 	pixel_y = -25
-	},
-/obj/structure/bed/chair{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/security/lobby)
-"aVQ" = (
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/red/border,
-/obj/machinery/camera/network/security{
-	dir = 1
 	},
 /obj/structure/bed/chair{
 	dir = 1
@@ -28189,20 +28366,6 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals7,
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/surface_three_hall)
-"aWr" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/red/border{
-	dir = 1
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 4
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7,
-/obj/machinery/camera/network/tether,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_three_hall)
 "aWs" = (
@@ -28808,11 +28971,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/lower/third_south)
-"aXn" = (
-/obj/machinery/computer/secure_data,
-/obj/machinery/camera/network/command,
-/turf/simulated/floor/tiled/dark,
-/area/bridge)
 "aXo" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 4
@@ -28824,17 +28982,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
-	},
-/turf/simulated/floor/wood,
-/area/library)
-"aXp" = (
-/obj/structure/table/woodentable,
-/obj/item/device/flashlight/lamp/green{
-	pixel_x = 1;
-	pixel_y = 5
-	},
-/obj/machinery/camera/network/civilian{
-	dir = 1
 	},
 /turf/simulated/floor/wood,
 /area/library)
@@ -28991,19 +29138,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/outpost/xenobiology/outpost_first_aid)
-"aXB" = (
-/obj/machinery/papershredder,
-/obj/effect/floor_decal/borderfloor{
-	dir = 1;
-	icon_state = "borderfloor";
-	pixel_y = 0
-	},
-/obj/effect/floor_decal/corner/red/border{
-	dir = 1
-	},
-/obj/machinery/camera/network/security,
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/security/frontdesk)
 "aXC" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 8
@@ -29018,12 +29152,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/library)
-"aXD" = (
-/obj/machinery/camera/network/outside{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/steel_dirty/virgo3b,
-/area/tether/surfacebase/outside/outside3)
 "aXE" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -29710,17 +29838,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
-"aYN" = (
-/obj/machinery/computer/communications{
-	dir = 1
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge)
 "aYO" = (
 /turf/simulated/wall/r_wall,
 /area/maintenance/commandmaint)
@@ -29848,24 +29965,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge_hallway)
-"aZd" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/camera/network/command{
-	c_tag = "Command Meeting Room East";
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	icon_state = "map-scrubbers";
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge_hallway)
 "aZe" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -29878,17 +29977,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/outpost/xenobiology/outpost_first_aid)
-"aZg" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge_hallway)
 "aZh" = (
 /obj/machinery/door/airlock/glass_command{
 	name = "Bridge";
@@ -30403,13 +30491,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/wood,
 /area/crew_quarters/captain)
-"aZX" = (
-/obj/machinery/camera/network/command{
-	c_tag = "Bridge Hallway Central";
-	dir = 4
-	},
-/turf/simulated/floor/carpet,
-/area/crew_quarters/heads/hop)
 "aZY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -30544,16 +30625,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/captain)
-"bah" = (
-/obj/machinery/camera/network/command,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/captain)
@@ -30811,22 +30882,6 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/assembly/robotics)
-"baD" = (
-/obj/structure/bed/chair/office/dark{
-	dir = 4
-	},
-/obj/effect/landmark/start{
-	name = "Colony Director"
-	},
-/obj/machinery/button/remote/blast_door{
-	dir = 8;
-	id = "cap_office";
-	name = "Security Shutters";
-	pixel_x = 30;
-	pixel_y = 16
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/captain)
 "baE" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/steeldecal/steel_decals7{
@@ -35689,7 +35744,6 @@ aab
 aab
 aOm
 adG
-aNp
 adG
 adG
 adG
@@ -35701,15 +35755,16 @@ adG
 adG
 adG
 adG
-adG
-aNp
-adG
+aQD
 adG
 adG
 adG
 adG
 adG
 adG
+adG
+adG
+aQD
 adG
 aOi
 aab
@@ -35765,7 +35820,7 @@ aac
 aac
 aac
 aac
-afF
+aac
 aac
 aac
 aac
@@ -35852,7 +35907,7 @@ aSA
 aSA
 aSA
 aSA
-aOb
+adG
 aOi
 aab
 aab
@@ -35974,7 +36029,7 @@ aab
 aOm
 adG
 aOR
-aPe
+aAt
 aPw
 aPN
 aQb
@@ -36125,11 +36180,11 @@ aQy
 aQI
 aQS
 aRa
-aRh
+aBu
 aRu
 aRI
 aRO
-aRY
+aSx
 aSl
 aSD
 aSQ
@@ -36397,7 +36452,7 @@ aMG
 aNU
 adG
 adG
-adG
+aQD
 adG
 aOR
 aPh
@@ -36521,7 +36576,7 @@ aac
 aac
 aac
 aac
-afF
+aac
 aac
 aac
 aac
@@ -36533,7 +36588,7 @@ adG
 adG
 adG
 adG
-aNp
+adG
 adG
 adG
 adG
@@ -36549,7 +36604,7 @@ aQc
 aQo
 aQL
 aXz
-aQU
+aAk
 aRa
 aMM
 aRx
@@ -36559,7 +36614,7 @@ aMK
 aMq
 aSB
 aPV
-aTe
+aBM
 aXA
 aSA
 aCO
@@ -36683,7 +36738,7 @@ aNZ
 aOf
 aOo
 aHM
-aOq
+azu
 aOf
 aOR
 aPP
@@ -36802,7 +36857,7 @@ aac
 aac
 aac
 acj
-acm
+amu
 aBV
 aCc
 aGt
@@ -36813,13 +36868,13 @@ aCc
 aCc
 aBV
 aCc
-aLL
+aCc
 aIW
 aCc
 aMi
 aCc
 aCc
-aNo
+axP
 aNS
 aEt
 aGo
@@ -36833,9 +36888,9 @@ aQe
 aQA
 aQB
 aQM
-aQM
+aEf
 aMo
-aRm
+aQM
 aRz
 aPQ
 aRR
@@ -36942,7 +36997,7 @@ aac
 aac
 aac
 aac
-aad
+aac
 acj
 akW
 aFK
@@ -36982,14 +37037,14 @@ aRo
 aQC
 aRS
 aSe
-aQd
+aFF
 aSr
-aLP
+aBf
 aMl
 aMl
 aNR
 aCO
-aOb
+adG
 aOi
 aab
 aab
@@ -37051,13 +37106,13 @@ aac
 aac
 aac
 aac
+aQU
 aac
 aac
 aac
 aac
 aac
 aac
-afF
 aac
 aac
 aac
@@ -37091,15 +37146,15 @@ aCm
 awh
 aGM
 aNn
-aIq
+aEw
 aJB
 aNn
 aNn
 asf
 aNn
 aNn
+aul
 aNn
-aMk
 aMH
 aNc
 aNn
@@ -37113,7 +37168,7 @@ aMj
 aIs
 aJa
 aQM
-aQf
+ayw
 aQr
 aPS
 aQM
@@ -37182,7 +37237,7 @@ aac
 aac
 aDb
 aDc
-aDo
+acm
 aDv
 aDE
 aDO
@@ -37235,13 +37290,13 @@ aiE
 aGO
 acj
 acj
+aGO
+acj
 acj
 aGO
 acj
 acj
-acj
 aGO
-acj
 acj
 acj
 aNL
@@ -37249,7 +37304,7 @@ acj
 aNV
 aNZ
 aOf
-aHG
+auz
 aHS
 aHU
 aOf
@@ -37371,7 +37426,7 @@ aac
 aac
 aiE
 aqA
-azN
+aqz
 aFp
 aGN
 aac
@@ -37399,7 +37454,7 @@ aPB
 aPU
 aQg
 aQt
-aQD
+azr
 aQN
 aQV
 aRe
@@ -37411,7 +37466,7 @@ aMK
 aSv
 aSI
 aRk
-aTh
+aBa
 aRw
 aSI
 aCO
@@ -37533,17 +37588,17 @@ aNM
 aNW
 adG
 adG
-adG
+aRh
 adG
 aOW
-aPk
+aAO
 aPG
 aJb
 aQh
 aQu
 aQE
 aQO
-aQW
+aDU
 aRe
 aRp
 aRD
@@ -37613,7 +37668,7 @@ aDy
 aDH
 aDP
 aac
-aad
+aac
 agw
 agw
 agw
@@ -37621,7 +37676,7 @@ air
 ajv
 akn
 akS
-alz
+ahq
 amo
 amO
 anw
@@ -37652,7 +37707,7 @@ aac
 aac
 aac
 aac
-aac
+aQW
 aiE
 aqF
 aBN
@@ -37761,7 +37816,7 @@ ahd
 ahS
 ais
 ajw
-ako
+akn
 akS
 alA
 amp
@@ -37774,7 +37829,7 @@ anx
 anx
 aqt
 are
-arw
+aMI
 akS
 aac
 aac
@@ -37798,7 +37853,7 @@ aac
 aiE
 aqx
 awb
-aGl
+ang
 aiE
 aac
 aac
@@ -37827,18 +37882,18 @@ aTB
 aQj
 aQG
 aQG
-aTu
+azU
 aRe
 aRr
 aRF
-aRM
+aBJ
 aRe
-aSg
+aSl
 aSx
 aSJ
 aSY
 aTk
-aTv
+aDo
 aSI
 adG
 aOi
@@ -37951,8 +38006,8 @@ aac
 aac
 aac
 aac
-aac
-aNp
+aQU
+adG
 adG
 adG
 adG
@@ -38032,7 +38087,7 @@ aac
 aac
 aac
 aac
-afF
+aac
 aac
 aac
 aac
@@ -38058,7 +38113,7 @@ anx
 anx
 aqt
 are
-arx
+arw
 arV
 aac
 aac
@@ -38124,7 +38179,7 @@ aSI
 aSI
 aSI
 aSI
-aOb
+adG
 aOi
 aab
 aab
@@ -38172,7 +38227,7 @@ aac
 aac
 aac
 aac
-aac
+aQW
 alo
 alo
 alo
@@ -38218,7 +38273,7 @@ aac
 aac
 aac
 aac
-afF
+aac
 aac
 aac
 aiE
@@ -38226,11 +38281,11 @@ arj
 aBP
 aFo
 aGQ
-aBa
+aoL
 aBU
 aCx
 aJF
-aKD
+aFw
 aLl
 aLS
 aLS
@@ -38245,7 +38300,6 @@ adG
 aOi
 aOm
 adG
-aPa
 adG
 adG
 adG
@@ -38257,15 +38311,16 @@ adG
 adG
 adG
 adG
-adG
-aPa
-adG
+aRh
 adG
 adG
 adG
 adG
 adG
 adG
+adG
+adG
+aRh
 adG
 aOi
 aab
@@ -38364,7 +38419,7 @@ afK
 afK
 afK
 aoy
-aut
+amT
 aBp
 aGq
 azL
@@ -38486,7 +38541,7 @@ aqu
 are
 arw
 akS
-aEf
+aac
 aac
 aac
 aac
@@ -38521,7 +38576,7 @@ aLS
 aLS
 aLS
 aLS
-aNE
+aLS
 azL
 azL
 azL
@@ -38782,7 +38837,7 @@ aac
 ahj
 ahT
 atq
-atX
+akt
 ahh
 auu
 auu
@@ -38799,7 +38854,7 @@ aCa
 aJc
 aJJ
 aKG
-aLn
+aLl
 aLS
 aLS
 aLS
@@ -38809,7 +38864,7 @@ aLS
 azL
 azL
 azL
-aOb
+adG
 aOi
 aab
 aab
@@ -38895,7 +38950,7 @@ aqO
 aqO
 aqO
 alo
-abC
+agI
 acX
 aks
 akT
@@ -39072,9 +39127,9 @@ auu
 auu
 axO
 ayP
-aBu
+auc
 afK
-aBf
+amV
 aFR
 aCK
 azL
@@ -39089,7 +39144,7 @@ aLS
 aLS
 aLS
 aLS
-aNE
+aLS
 azL
 azL
 azL
@@ -39183,7 +39238,7 @@ air
 aWJ
 aku
 akS
-alJ
+aMS
 amv
 amU
 amv
@@ -39308,7 +39363,7 @@ aac
 aac
 aac
 aac
-aad
+aac
 alo
 aqO
 aqO
@@ -39327,14 +39382,14 @@ akv
 akS
 alJ
 amv
-amV
+amU
 anB
 aoa
 aot
 aoa
 amv
 apM
-aqz
+aiK
 ari
 arC
 akS
@@ -39343,14 +39398,14 @@ aac
 aac
 aac
 aac
-afF
+aac
 aac
 aac
 aac
 ahj
 aiy
 atD
-auc
+alI
 ahh
 auW
 awO
@@ -39358,15 +39413,15 @@ ayl
 azl
 aFi
 afK
-aBi
+aIq
 aFS
 aCr
 azL
-aBJ
+aoQ
 aCb
 aCC
 aJM
-aKI
+aGl
 aLp
 aLS
 aLS
@@ -39597,7 +39652,7 @@ aac
 adW
 aeq
 afn
-ahB
+adx
 agQ
 afc
 aqO
@@ -39607,7 +39662,7 @@ aqO
 alo
 acn
 aWD
-akx
+aNE
 akY
 alK
 amw
@@ -39638,7 +39693,7 @@ ahi
 awA
 awW
 axG
-axP
+aHj
 aAr
 ayu
 aFm
@@ -39647,7 +39702,7 @@ aGv
 aXS
 aGR
 aHI
-aIt
+aHj
 aJd
 aJN
 azo
@@ -39877,7 +39932,7 @@ aaM
 aam
 abU
 acz
-aeA
+abC
 afc
 aes
 afp
@@ -39930,7 +39985,7 @@ ayS
 azf
 azK
 aAp
-aBM
+apK
 aCe
 aJf
 aJP
@@ -40035,7 +40090,7 @@ aix
 ajM
 akx
 akZ
-alM
+amw
 amw
 amY
 anD
@@ -40084,7 +40139,7 @@ azH
 azE
 azE
 azE
-aEf
+aac
 aac
 aac
 aac
@@ -40153,7 +40208,7 @@ aab
 aab
 aOm
 aaq
-aXD
+aRJ
 adT
 aal
 aax
@@ -40305,7 +40360,7 @@ acq
 acC
 adp
 afc
-aeB
+adg
 afS
 age
 ahv
@@ -40457,7 +40512,7 @@ aiL
 aiL
 aiL
 agw
-aiK
+aOa
 aWF
 aWO
 akY
@@ -40465,15 +40520,15 @@ alO
 amx
 ana
 anF
-amw
+aMw
 aou
 akY
-aiK
+aix
 apQ
 asS
 aha
 aha
-aha
+aOb
 ass
 asR
 agw
@@ -40737,7 +40792,7 @@ agf
 agT
 ahG
 aiM
-ajH
+afR
 aiM
 aVH
 aVY
@@ -40784,13 +40839,13 @@ azE
 aAV
 aBO
 aCu
-aJl
+asa
 aJT
 aKM
 aLu
 aLX
 aMu
-aMS
+atX
 aNh
 aNw
 azE
@@ -40916,10 +40971,10 @@ auX
 avQ
 avX
 axa
-axB
+axa
 ayj
 atU
-azU
+amh
 ayZ
 azA
 azE
@@ -41009,7 +41064,7 @@ aaq
 aaq
 aac
 aaf
-adg
+aaX
 aaX
 abZ
 acJ
@@ -41151,7 +41206,7 @@ aaq
 aac
 aac
 aaf
-aaX
+aIL
 aaX
 aco
 acK
@@ -41165,7 +41220,7 @@ ahI
 agG
 ajN
 aUi
-aVK
+aIt
 adP
 aWo
 aWF
@@ -41211,11 +41266,11 @@ azE
 aHP
 azE
 azD
-aJV
+asl
 aKP
 aLx
 aMa
-aMw
+aHG
 azD
 aac
 aac
@@ -41332,7 +41387,7 @@ agw
 aac
 aac
 ats
-auz
+aPD
 ava
 avy
 awa
@@ -41442,7 +41497,7 @@ add
 adn
 adQ
 agd
-agI
+aeB
 aHH
 ahu
 ahJ
@@ -41467,7 +41522,7 @@ apV
 aqL
 arm
 aoX
-asa
+ajC
 asx
 apX
 alP
@@ -41595,7 +41650,7 @@ aVN
 aWb
 aWn
 ajM
-akx
+aNE
 alc
 alR
 amB
@@ -41609,21 +41664,21 @@ apW
 aqM
 apy
 aoX
-aix
+aOa
 ajR
 apX
 alP
 aac
 aac
 aue
-auA
+akk
 avc
 avA
 awc
 awH
 axe
 awH
-ayw
+aOq
 azg
 azO
 aAu
@@ -41649,7 +41704,7 @@ aac
 aac
 aac
 aac
-afF
+aac
 aac
 aac
 aac
@@ -41724,7 +41779,7 @@ abK
 acs
 adm
 adr
-adX
+aIF
 act
 aeI
 ahx
@@ -41735,7 +41790,7 @@ akA
 aUT
 aVO
 ajT
-aWr
+aWn
 ajM
 akx
 alc
@@ -41777,7 +41832,7 @@ axg
 aXk
 aGX
 aIa
-aAt
+aqS
 azD
 azD
 azD
@@ -41883,7 +41938,7 @@ akx
 ald
 alT
 amD
-and
+aQd
 ane
 ane
 ane
@@ -42012,12 +42067,12 @@ aeb
 act
 agb
 ahx
-aXB
+aef
 aia
 aiW
 akB
 aVy
-aVQ
+agB
 ajT
 aWt
 aWH
@@ -42051,7 +42106,7 @@ axV
 azj
 aAy
 axg
-azT
+aLP
 azT
 aEU
 aBs
@@ -42220,7 +42275,7 @@ aKU
 aKU
 aKU
 aKU
-aOI
+aLn
 aKj
 aac
 aac
@@ -42292,7 +42347,7 @@ abN
 acx
 aeC
 aXb
-afR
+adX
 afl
 aeI
 ahx
@@ -42309,7 +42364,7 @@ akD
 alg
 alW
 amG
-ang
+ahB
 anK
 aoi
 aoC
@@ -42317,14 +42372,14 @@ aoY
 apB
 agz
 agA
-agB
+ajb
 agE
 ahe
 ahl
 aqa
 aha
 att
-aha
+aOb
 aha
 auF
 avg
@@ -42471,12 +42526,12 @@ alh
 auG
 avh
 avE
-aEw
+akx
 axi
 awd
 azQ
 aAz
-aro
+akM
 azT
 aEH
 aAA
@@ -42597,7 +42652,7 @@ ali
 ali
 ali
 ali
-ali
+aOT
 ali
 baQ
 baJ
@@ -42631,7 +42686,7 @@ aXq
 aHZ
 aIy
 ats
-aKc
+aKD
 aKU
 aKU
 aKU
@@ -42646,7 +42701,7 @@ aKU
 aKU
 aKU
 aKU
-aOJ
+avs
 aKj
 aac
 aac
@@ -42711,7 +42766,7 @@ aab
 aab
 aac
 aac
-aad
+aac
 aaE
 aaE
 aaE
@@ -42884,13 +42939,13 @@ aZJ
 alj
 baf
 bar
-baD
+aPi
 baX
 bab
 bbC
 bbE
 asT
-aYb
+aPk
 asT
 alY
 alY
@@ -43050,12 +43105,12 @@ aEK
 aFd
 aFs
 azT
-azT
+aMk
 aXx
 axg
 aXt
 aIa
-aIz
+aOJ
 ats
 aKa
 aKU
@@ -43166,7 +43221,7 @@ aZm
 aZy
 aZM
 alj
-bah
+aiJ
 bat
 baG
 bba
@@ -43299,7 +43354,7 @@ aVV
 aWf
 aWA
 aWL
-akn
+aNp
 alj
 alj
 alj
@@ -43473,7 +43528,7 @@ aBl
 awJ
 aED
 aEQ
-aXp
+aEE
 aAB
 aAB
 aAB
@@ -43573,7 +43628,7 @@ adM
 aea
 afb
 aga
-agN
+aec
 aag
 ahW
 aja
@@ -43587,7 +43642,7 @@ baz
 aYV
 aEj
 awn
-aug
+aOU
 aYQ
 aYU
 aYU
@@ -43618,10 +43673,10 @@ awJ
 awJ
 aAB
 aCL
-aFw
+aut
 aFV
 aAB
-aHj
+aHf
 aHW
 aIz
 aJn
@@ -43859,7 +43914,7 @@ acb
 acN
 aUA
 agn
-aib
+afF
 afz
 agk
 agX
@@ -43867,7 +43922,7 @@ ahK
 aUU
 ajd
 ajV
-ako
+akn
 aYO
 aZs
 awI
@@ -43879,19 +43934,19 @@ aYS
 aYY
 aZa
 aZc
-aZd
-aZg
+ajB
+aPe
 aZh
 aZA
 aZO
 aYo
 aYu
 aYI
-aYN
+aPC
 bay
 bbF
 avG
-akx
+aNE
 awJ
 axn
 aEM
@@ -43924,13 +43979,13 @@ aNX
 aKj
 aKe
 aKg
-aKg
+aLL
 aKj
-aPp
+aLa
 aPL
 aKj
 aKj
-aEf
+aac
 aac
 aac
 aac
@@ -43988,9 +44043,9 @@ aab
 aac
 aag
 aat
-aat
+aIR
 aag
-aap
+aad
 aaZ
 aaA
 aaI
@@ -44024,7 +44079,7 @@ ayx
 ayx
 ayx
 asT
-aXn
+ajH
 aYf
 bae
 aYv
@@ -44033,7 +44088,7 @@ aYJ
 baw
 bbF
 ajR
-aEw
+akx
 awP
 awP
 awP
@@ -44159,7 +44214,7 @@ ayx
 aZn
 aYq
 aZN
-aZX
+aPa
 aZY
 bav
 baN
@@ -44180,7 +44235,7 @@ awP
 axo
 axY
 ayC
-azr
+akX
 azZ
 aAF
 aBx
@@ -44340,7 +44395,7 @@ aKX
 aLB
 aMc
 aMB
-aMX
+aug
 aKe
 aKg
 aKg
@@ -44438,7 +44493,7 @@ ajX
 akn
 alk
 bbs
-alk
+aNo
 ayx
 aZp
 aZB
@@ -44558,7 +44613,7 @@ aac
 aag
 aaU
 ace
-adx
+aap
 afx
 agZ
 aRG
@@ -44696,7 +44751,7 @@ aab
 aab
 aab
 aab
-aac
+aQW
 aaz
 abd
 acf
@@ -44759,7 +44814,7 @@ aGc
 awR
 aHo
 aIa
-aIF
+aIz
 ats
 ats
 ats
@@ -44878,7 +44933,7 @@ ayx
 aqO
 aqO
 asT
-aYp
+aPp
 asT
 alY
 alY
@@ -45136,9 +45191,9 @@ aSP
 aTd
 aTq
 aUF
-aUM
+aeA
 aUS
-aVb
+aJl
 aVj
 aSP
 aVr
@@ -45174,7 +45229,7 @@ awS
 axv
 axv
 axv
-azu
+alz
 aAd
 aAL
 aBB
@@ -45197,7 +45252,7 @@ aNk
 aNl
 aNJ
 aNP
-aec
+aRM
 aKU
 abg
 aOk
@@ -45339,7 +45394,7 @@ aNl
 aNl
 aNK
 aNP
-aec
+aRM
 aKU
 abg
 aOk
@@ -45430,7 +45485,7 @@ agw
 aix
 aka
 akI
-ama
+aMX
 ama
 amI
 anj
@@ -45440,7 +45495,7 @@ aoD
 apd
 apC
 aqf
-aqS
+aOT
 aqU
 arG
 apS
@@ -45451,7 +45506,7 @@ atu
 atK
 auh
 auK
-avn
+aOg
 avn
 avn
 awU
@@ -45472,7 +45527,7 @@ aIf
 aII
 aJr
 aKm
-aLa
+aOQ
 aJn
 aKU
 aMF
@@ -45481,14 +45536,14 @@ aNm
 aNl
 aNK
 aNP
-aec
+aRM
 aKU
 abg
 aOk
 aOB
 aOP
 aKj
-aac
+aQf
 aac
 aac
 aac
@@ -45628,7 +45683,7 @@ aKU
 abg
 aOk
 aOC
-aOQ
+axB
 aKj
 aac
 aac
@@ -45704,7 +45759,7 @@ abt
 acg
 acS
 acg
-aef
+acg
 aeO
 afG
 agp
@@ -45746,7 +45801,7 @@ aBG
 aEY
 asX
 asX
-aAO
+alM
 asX
 asX
 aGg
@@ -45762,7 +45817,7 @@ aKU
 aKU
 aKU
 aKU
-aKU
+aKI
 aKU
 aKU
 aKU
@@ -45997,7 +46052,7 @@ ahR
 ain
 aDV
 akd
-akM
+agN
 alr
 amd
 aio
@@ -46037,7 +46092,7 @@ aGi
 aGE
 aHw
 aIj
-aIL
+aro
 aJt
 aKo
 aLb
@@ -46048,7 +46103,7 @@ aac
 aac
 aac
 aac
-akk
+aac
 aac
 aac
 aac
@@ -46295,13 +46350,13 @@ aoJ
 aoJ
 aoJ
 arM
-asl
+auP
 asH
 asX
 ati
 asX
 atO
-aul
+auk
 auP
 auk
 asX
@@ -46430,7 +46485,7 @@ amK
 anp
 anS
 aoo
-aoK
+aKc
 aph
 apF
 aql
@@ -46572,7 +46627,7 @@ aio
 anq
 anT
 aon
-aoL
+aib
 aoK
 aoK
 aqm
@@ -46709,7 +46764,7 @@ ajo
 akf
 akP
 akf
-amh
+aht
 aio
 anr
 anU
@@ -46747,9 +46802,9 @@ asX
 aGG
 aHz
 aIm
-aIQ
+aJV
 aJt
-aKt
+asr
 aLg
 aLH
 aJt
@@ -46834,7 +46889,7 @@ aac
 aac
 aac
 aac
-aad
+aac
 abe
 abe
 abe
@@ -46845,7 +46900,7 @@ aeW
 afJ
 aac
 aac
-aad
+aac
 aio
 ajp
 akf
@@ -46889,14 +46944,14 @@ asX
 aGG
 aHA
 aIm
-aIR
+arx
 aJt
 aJt
 aJt
 aJt
 aJt
 aGK
-aac
+aQf
 aac
 aac
 aac
@@ -46980,7 +47035,7 @@ aac
 aac
 aac
 aac
-aac
+aRm
 aac
 aac
 aac
@@ -47310,7 +47365,7 @@ asX
 asX
 asX
 asX
-aFF
+and
 arJ
 arJ
 arJ
@@ -47424,14 +47479,14 @@ aio
 ajs
 anY
 aop
-aoQ
+aKt
 apl
 apH
 apk
 arb
 ars
 arT
-asr
+ajD
 asP
 atc
 ato
@@ -47439,7 +47494,7 @@ atA
 atS
 aup
 auU
-avs
+ako
 avO
 aww
 asX
@@ -47447,7 +47502,7 @@ axx
 auk
 ayM
 azx
-aAk
+aIQ
 asX
 asX
 asX
@@ -47558,7 +47613,7 @@ aac
 aac
 aac
 aac
-akk
+aac
 aac
 aac
 aac
@@ -47721,7 +47776,7 @@ aac
 aac
 aac
 aac
-akk
+aac
 aac
 aac
 aac

--- a/maps/tether/tether-04-transit.dmm
+++ b/maps/tether/tether-04-transit.dmm
@@ -347,8 +347,10 @@
 /turf/simulated/floor/plating,
 /area/maintenance/tether_midpoint)
 "J" = (
+/obj/structure/table/woodentable,
+/obj/machinery/camera/network/civilian,
 /turf/simulated/floor/wood,
-/area/space)
+/area/tether/midpoint)
 "K" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -373,6 +375,13 @@
 	},
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/plating,
+/area/tether/midpoint)
+"N" = (
+/obj/structure/table/woodentable,
+/obj/machinery/camera/network/civilian{
+	dir = 1
+	},
+/turf/simulated/floor/wood,
 /area/tether/midpoint)
 "O" = (
 /obj/structure/cable{
@@ -10768,7 +10777,7 @@ u
 g
 U
 q
-J
+q
 T
 n
 n
@@ -10908,7 +10917,7 @@ u
 u
 u
 g
-n
+J
 q
 q
 F
@@ -10917,7 +10926,7 @@ F
 F
 q
 q
-n
+N
 g
 u
 u

--- a/maps/tether/tether-05-station1.dmm
+++ b/maps/tether/tether-05-station1.dmm
@@ -16,7 +16,7 @@
 /obj/structure/extinguisher_cabinet{
 	dir = 1;
 	icon_state = "extinguisher_closed";
-	pixel_y = -32
+	pixel_y = 32
 	},
 /obj/vehicle/train/trolley,
 /turf/simulated/floor/tiled/monotile,
@@ -33,7 +33,7 @@
 /obj/structure/extinguisher_cabinet{
 	dir = 1;
 	icon_state = "extinguisher_closed";
-	pixel_y = -32
+	pixel_y = 32
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/atmos/backup)
@@ -128,7 +128,7 @@
 /obj/structure/extinguisher_cabinet{
 	dir = 1;
 	icon_state = "extinguisher_closed";
-	pixel_y = -32
+	pixel_y = 32
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/hallway)
@@ -273,7 +273,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/machinery/camera/network/engineering,
+/obj/machinery/camera/network/engine,
 /turf/simulated/floor,
 /area/engineering/engine_smes)
 "aaA" = (
@@ -671,11 +671,25 @@
 /turf/simulated/floor/reinforced,
 /area/engineering/engine_room)
 "abl" = (
-/obj/machinery/camera/network/civilian{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
 	},
-/turf/simulated/floor/tiled/dark,
-/area/tether/station/burial)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 5
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 6
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/hallway)
 "abm" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -995,28 +1009,13 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/engine_smes)
 "abN" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
+/obj/machinery/alarm{
+	dir = 1;
+	icon_state = "alarm0";
+	pixel_y = -22
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 5
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 6
-	},
-/obj/machinery/camera/network/engineering{
-	dir = 8
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/tiled,
-/area/engineering/hallway)
+/turf/simulated/floor,
+/area/maintenance/substation/engineering)
 "abO" = (
 /obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 9
@@ -1498,6 +1497,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/machinery/camera/network/engineering,
 /turf/simulated/floor,
 /area/maintenance/substation/engineering)
 "acP" = (
@@ -1513,6 +1513,7 @@
 /obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 1
 	},
+/obj/machinery/camera/network/engineering,
 /turf/simulated/floor/tiled,
 /area/engineering/hallway)
 "acS" = (
@@ -1691,6 +1692,9 @@
 /obj/machinery/floor_light/prebuilt{
 	on = 1
 	},
+/obj/machinery/camera/network/civilian{
+	dir = 9
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/station/atrium)
 "ado" = (
@@ -1761,6 +1765,10 @@
 /obj/structure/flora/pottedplant,
 /obj/effect/floor_decal/corner/blue/full{
 	dir = 8
+	},
+/obj/machinery/camera/network/command{
+	icon_state = "camera";
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/secondary)
@@ -1863,38 +1871,14 @@
 /turf/simulated/floor/grass,
 /area/hallway/station/atrium)
 "adA" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/blue/border,
-/obj/effect/floor_decal/borderfloor/corner2,
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 9
-	},
-/obj/effect/floor_decal/corner/blue/bordercorner2,
-/obj/effect/floor_decal/corner/blue/bordercorner2{
-	dir = 9
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
+/obj/effect/floor_decal/borderfloor{
 	dir = 8
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 1
-	},
-/obj/machinery/camera/network/command{
-	dir = 1
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 8
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/station/atrium)
+/area/engineering/hallway)
 "adB" = (
 /obj/item/device/radio/intercom{
 	dir = 1;
@@ -2158,16 +2142,23 @@
 /turf/simulated/floor/tiled,
 /area/engineering/atmos/backup)
 "adZ" = (
-/obj/machinery/alarm{
-	dir = 1;
-	icon_state = "alarm0";
-	pixel_y = -22
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
 	},
-/obj/machinery/camera/network/engineering{
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 1
 	},
-/turf/simulated/floor,
-/area/maintenance/substation/engineering)
+/obj/machinery/firealarm{
+	dir = 2;
+	layer = 3.3;
+	pixel_x = 0;
+	pixel_y = 26
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/hallway)
 "aea" = (
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/engine_smes)
@@ -2295,21 +2286,27 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/sleep/cryo)
 "aer" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 1
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7,
-/obj/effect/floor_decal/steeldecal/steel_decals7{
+/obj/machinery/atmospherics/pipe/simple/hidden/red{
+	icon_state = "intact";
 	dir = 4
 	},
-/obj/machinery/camera/network/tether{
-	dir = 2
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/yellow/border,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 1
+	},
+/obj/item/device/radio/intercom{
+	dir = 2;
+	pixel_y = -24
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/station/atrium)
+/area/engineering/hallway)
 "aes" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -2741,16 +2738,14 @@
 /turf/simulated/floor/tiled/dark,
 /area/bridge/secondary)
 "afb" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/obj/structure/table/reinforced,
-/obj/item/weapon/folder/white,
-/obj/machinery/camera/network/command{
+/obj/structure/closet/excavation,
+/obj/item/device/multitool,
+/obj/item/device/multitool,
+/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
-/area/bridge/secondary)
+/area/gateway/prep_room)
 "afc" = (
 /obj/machinery/door/airlock/command{
 	name = "Secondary Command Office"
@@ -3135,29 +3130,13 @@
 /turf/simulated/wall/r_wall,
 /area/hallway/station/atrium)
 "afD" = (
-/obj/machinery/camera/network/tether{
+/obj/structure/table/reinforced,
+/obj/machinery/camera/network/command{
+	icon_state = "camera";
 	dir = 4
 	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 8
-	},
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/lightgrey/bordercorner2{
-	dir = 8
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 5
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 6
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/station/atrium)
+/turf/simulated/floor/tiled/dark,
+/area/gateway/prep_room)
 "afE" = (
 /obj/machinery/vending/cola,
 /obj/effect/floor_decal/corner/lightgrey{
@@ -3335,6 +3314,7 @@
 	pixel_x = 2;
 	pixel_y = 2
 	},
+/obj/machinery/camera/network/command,
 /turf/simulated/floor/tiled,
 /area/bridge/secondary)
 "afS" = (
@@ -3350,22 +3330,16 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/engineering/engine_monitoring)
 "afT" = (
-/obj/structure/table/reinforced,
-/obj/machinery/photocopier/faxmachine{
-	department = "Secondary Command Office"
+/obj/machinery/atmospherics/pipe/manifold/visible/yellow{
+	dir = 4
 	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 5
-	},
-/obj/effect/floor_decal/corner/blue/border{
-	dir = 5
-	},
-/obj/machinery/camera/network/command{
-	c_tag = "Head of Personnel Office";
-	dir = 9
+/obj/machinery/meter,
+/obj/machinery/light_switch{
+	dir = 8;
+	pixel_x = 24
 	},
 /turf/simulated/floor/tiled,
-/area/bridge/secondary)
+/area/engineering/atmos/backup)
 "afU" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -3418,25 +3392,24 @@
 /turf/simulated/floor/tiled,
 /area/hallway/station/atrium)
 "afX" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/purple/border,
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/borderfloor/corner2,
+/obj/effect/floor_decal/corner/purple/bordercorner2,
+/obj/effect/floor_decal/corner/purple/bordercorner2{
+	dir = 9
+	},
 /obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 5
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 6
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/camera/network/engineering{
 	dir = 8
 	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 1
+	},
 /turf/simulated/floor/tiled,
-/area/engineering/hallway)
+/area/hallway/station/atrium)
 "afY" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -3500,33 +3473,15 @@
 /turf/simulated/floor,
 /area/crew_quarters/heads/chief)
 "agd" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/table/reinforced,
+/obj/fiftyspawner/rods,
+/obj/fiftyspawner/rods,
+/obj/item/stack/material/glass/phoronrglass{
+	amount = 20
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 1
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 4
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7,
-/obj/machinery/camera/network/tether,
+/obj/fiftyspawner/wood,
 /turf/simulated/floor/tiled,
-/area/hallway/station/atrium)
+/area/engineering/workshop)
 "age" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -3985,20 +3940,11 @@
 /turf/simulated/floor/tiled,
 /area/bridge/secondary)
 "agH" = (
-/obj/machinery/computer/card{
-	dir = 1
-	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 10
-	},
-/obj/effect/floor_decal/corner/blue/border{
-	dir = 10
-	},
-/obj/machinery/camera/network/command{
-	dir = 1
-	},
+/obj/structure/table/reinforced,
+/obj/effect/floor_decal/corner/white/diagonal,
+/obj/item/weapon/folder/yellow,
 /turf/simulated/floor/tiled,
-/area/bridge/secondary)
+/area/engineering/break_room)
 "agI" = (
 /obj/effect/floor_decal/industrial/warning{
 	icon_state = "warning";
@@ -4241,22 +4187,28 @@
 /turf/simulated/floor/tiled,
 /area/hallway/station/atrium)
 "ahc" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 1
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 9
 	},
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 1
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 4
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 4
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7,
-/obj/machinery/camera/network/tether,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 10
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/station/atrium)
+/area/engineering/hallway)
 "ahd" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -4843,6 +4795,33 @@
 	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/tether/station/visitorhallway/office)
+"aih" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/turf/simulated/floor/tiled,
+/area/hallway/station/atrium)
 "aii" = (
 /obj/machinery/gateway{
 	dir = 10
@@ -5451,7 +5430,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/camera/network/tether,
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
 	},
@@ -5766,6 +5744,10 @@
 "akb" = (
 /obj/machinery/suit_cycler/mining{
 	req_access = null
+	},
+/obj/machinery/camera/network/command{
+	icon_state = "camera";
+	dir = 10
 	},
 /turf/simulated/floor/tiled/dark,
 /area/gateway/prep_room)
@@ -6100,9 +6082,23 @@
 /turf/simulated/floor/tiled,
 /area/gateway/prep_room)
 "akJ" = (
-/obj/structure/table/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/closet/emcloset,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning{
+	icon_state = "warning";
+	dir = 1
+	},
+/obj/machinery/camera/network/command{
+	icon_state = "camera";
+	dir = 10
+	},
 /turf/simulated/floor/tiled/dark,
-/area/gateway/prep_room)
+/area/gateway)
 "akK" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -6181,16 +6177,32 @@
 /obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 1
 	},
+/obj/machinery/camera/network/tether{
+	dir = 1
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/station/atrium)
 "akR" = (
-/obj/machinery/camera/network/engineering{
-	dir = 4
+/obj/structure/table/reinforced,
+/obj/item/weapon/storage/briefcase/inflatable{
+	pixel_x = 3;
+	pixel_y = 6
 	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/shieldgen,
-/turf/simulated/floor,
-/area/engineering/storage)
+/obj/item/weapon/storage/briefcase/inflatable{
+	pixel_y = 3
+	},
+/obj/item/weapon/storage/briefcase/inflatable{
+	pixel_x = -3;
+	pixel_y = 0
+	},
+/obj/machinery/firealarm{
+	dir = 2;
+	layer = 3.3;
+	pixel_x = 0;
+	pixel_y = 26
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/engine_eva)
 "akS" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/shieldgen,
@@ -6387,13 +6399,31 @@
 /turf/simulated/floor/tiled,
 /area/hallway/station/atrium)
 "alh" = (
-/obj/structure/table/reinforced,
-/obj/machinery/recharger,
-/obj/machinery/camera/network/exploration{
-	dir = 1
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/dark,
-/area/gateway/prep_room)
+/obj/structure/extinguisher_cabinet{
+	dir = 4;
+	icon_state = "extinguisher_closed";
+	pixel_x = -30
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 5
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 6
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled,
+/area/hallway/station/atrium)
 "ali" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -6442,21 +6472,28 @@
 /turf/simulated/floor/carpet/purcarpet,
 /area/bridge/secondary/meeting_room)
 "alo" = (
-/obj/machinery/camera/network/exploration,
-/turf/simulated/floor/bluegrid,
-/area/gateway/prep_room)
-"alp" = (
-/obj/structure/closet/excavation,
-/obj/item/device/multitool,
-/obj/item/device/multitool,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
+/obj/structure/table/standard,
+/obj/machinery/light{
+	dir = 4
 	},
-/obj/machinery/camera/network/exploration{
-	dir = 1
+/obj/machinery/camera/network/civilian,
+/turf/simulated/floor/tiled,
+/area/holodeck_control)
+"alp" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 8;
+	icon_state = "map"
+	},
+/obj/machinery/meter{
+	frequency = 1443;
+	id = "dist_aux_meter";
+	name = "Distribution Loop"
+	},
+/obj/machinery/camera/network/engineering{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
-/area/gateway/prep_room)
+/area/engineering/engineering_airlock)
 "alq" = (
 /obj/structure/closet/excavation,
 /obj/item/device/multitool,
@@ -6494,22 +6531,19 @@
 /turf/simulated/floor,
 /area/engineering/engineering_monitoring)
 "alu" = (
-/obj/structure/window/reinforced{
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 4
 	},
-/obj/structure/closet/emcloset,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 1
-	},
-/obj/machinery/camera/network/exploration{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/gateway)
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/tiled,
+/area/engineering/hallway)
 "alv" = (
 /turf/simulated/wall/r_wall,
 /area/engineering/engineering_monitoring)
@@ -6631,27 +6665,35 @@
 /turf/simulated/floor,
 /area/engineering/shaft)
 "alL" = (
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/purple/border,
-/obj/effect/floor_decal/borderfloor/corner2{
+/obj/effect/floor_decal/borderfloor/corner,
+/obj/effect/floor_decal/corner_steel_grid{
+	icon_state = "steel_grid";
 	dir = 9
 	},
-/obj/effect/floor_decal/borderfloor/corner2,
-/obj/effect/floor_decal/corner/purple/bordercorner2,
-/obj/effect/floor_decal/corner/purple/bordercorner2{
-	dir = 9
+/obj/effect/floor_decal/industrial/warning{
+	icon_state = "warning";
+	dir = 8
 	},
+/obj/effect/floor_decal/corner/yellow/bordercorner,
 /obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 8
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 1
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/machinery/camera/network/tether{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/camera/network/engineering{
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/station/atrium)
+/area/engineering/hallway)
 "alM" = (
 /obj/machinery/door/firedoor/glass/hidden/steel,
 /obj/effect/floor_decal/borderfloor{
@@ -7016,6 +7058,7 @@
 	pixel_x = 25;
 	pixel_y = 0
 	},
+/obj/machinery/camera/network/engineering,
 /turf/simulated/floor/tiled,
 /area/engineering/hallway)
 "amq" = (
@@ -7034,24 +7077,12 @@
 /turf/simulated/floor/water/pool,
 /area/hallway/station/atrium)
 "ams" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
+/obj/machinery/newscaster{
+	pixel_y = 32
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 8
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 1
-	},
-/obj/machinery/camera/network/engineering,
-/obj/machinery/firealarm{
-	dir = 2;
-	layer = 3.3;
-	pixel_x = 0;
-	pixel_y = 26
-	},
-/turf/simulated/floor/tiled,
-/area/engineering/hallway)
+/obj/structure/bed/chair,
+/turf/simulated/floor/carpet,
+/area/engineering/foyer)
 "amt" = (
 /obj/machinery/door/window{
 	dir = 1;
@@ -7228,10 +7259,10 @@
 /area/holodeck_control)
 "amN" = (
 /obj/structure/table/standard,
+/obj/item/weapon/soap/nanotrasen,
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/camera/network/civilian,
 /turf/simulated/floor/tiled,
 /area/holodeck_control)
 "amO" = (
@@ -7385,9 +7416,6 @@
 /obj/machinery/computer/atmoscontrol{
 	dir = 4
 	},
-/obj/machinery/camera/network/engineering{
-	dir = 4
-	},
 /turf/simulated/floor/tiled,
 /area/engineering/engineering_monitoring)
 "ane" = (
@@ -7400,11 +7428,26 @@
 /turf/simulated/floor,
 /area/engineering/shaft)
 "anf" = (
-/obj/machinery/camera/network/civilian{
-	dir = 2
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/abandonedlibrary)
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/lightgrey/bordercorner2{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 5
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 6
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/atrium)
 "ang" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor,
@@ -7786,6 +7829,7 @@
 /area/maintenance/abandonedlibrary)
 "anP" = (
 /obj/effect/floor_decal/steeldecal/steel_decals_central1,
+/obj/machinery/camera/network/engineering,
 /turf/simulated/floor/tiled/monotile,
 /area/engineering/hallway)
 "anQ" = (
@@ -7795,15 +7839,27 @@
 /turf/simulated/floor/tiled,
 /area/engineering/engineering_monitoring)
 "anR" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 8
+/obj/effect/floor_decal/industrial/warning/corner,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/effect/floor_decal/corner/yellow/border{
-	dir = 8
+/obj/machinery/button/remote/blast_door{
+	desc = "A remote control-switch for engine core.";
+	id = "EngineVent";
+	name = "Engine Ventillatory Control";
+	pixel_x = 6;
+	pixel_y = -32
 	},
-/obj/machinery/camera/network/engineering,
+/obj/machinery/button/remote/airlock{
+	desc = "A remote control-switch for the engine core airlock hatch bolts.";
+	id = "engine_access_hatch";
+	name = "Engine Hatch Bolt Control";
+	pixel_x = -6;
+	pixel_y = -32;
+	specialfunctions = 4
+	},
 /turf/simulated/floor/tiled,
-/area/engineering/hallway)
+/area/crew_quarters/heads/chief)
 "anS" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -8024,16 +8080,13 @@
 /turf/simulated/floor/tiled,
 /area/engineering/atmos/backup)
 "aoo" = (
-/obj/machinery/atmospherics/pipe/simple/visible/supply{
-	icon_state = "intact-supply";
-	dir = 10
+/obj/machinery/power/emitter,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/camera/network/engineering{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 10
-	},
-/turf/simulated/floor/tiled,
-/area/engineering/atmos/backup)
+/turf/simulated/floor,
+/area/engineering/storage)
 "aop" = (
 /obj/machinery/vending/cola,
 /obj/effect/floor_decal/steeldecal/steel_decals9{
@@ -8578,6 +8631,7 @@
 /obj/effect/floor_decal/corner/yellow/border{
 	dir = 9
 	},
+/obj/machinery/camera/network/engineering,
 /turf/simulated/floor/tiled,
 /area/engineering/hallway)
 "apx" = (
@@ -9053,30 +9107,23 @@
 /turf/simulated/floor/tiled,
 /area/engineering/atmos/backup)
 "aqk" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/red{
-	icon_state = "intact";
-	dir = 4
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/yellow/border,
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 8
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 1
-	},
-/obj/machinery/camera/network/engineering{
-	dir = 1
-	},
-/obj/item/device/radio/intercom{
+/obj/machinery/power/apc{
 	dir = 2;
-	pixel_y = -24
+	name = "south bump";
+	pixel_y = -32
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/camera/network/civilian{
+	dir = 9
 	},
 /turf/simulated/floor/tiled,
-/area/engineering/hallway)
+/area/holodeck_control)
 "aql" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
 	icon_state = "intact";
@@ -9613,16 +9660,21 @@
 /turf/simulated/floor/plating,
 /area/maintenance/abandonedlibraryconference)
 "arh" = (
-/obj/structure/table/standard,
-/obj/item/weapon/soap/nanotrasen,
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/camera/network/civilian{
+/obj/effect/floor_decal/borderfloor{
 	dir = 1
 	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
-/area/holodeck_control)
+/area/hallway/station/atrium)
 "ari" = (
 /turf/simulated/floor/plating,
 /area/maintenance/abandonedlibraryconference)
@@ -9871,11 +9923,19 @@
 /turf/simulated/floor/carpet,
 /area/engineering/break_room)
 "arO" = (
-/obj/structure/table/reinforced,
-/obj/machinery/microwave,
-/obj/effect/floor_decal/corner/white/diagonal,
+/obj/machinery/atmospherics/pipe/simple/visible/supply{
+	icon_state = "intact-supply";
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/scrubbers{
+	icon_state = "intact-scrubbers";
+	dir = 10
+	},
+/obj/machinery/camera/network/engineering{
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
-/area/engineering/break_room)
+/area/engineering/atmos/backup)
 "arP" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
@@ -10106,12 +10166,16 @@
 /turf/simulated/floor/carpet,
 /area/engineering/break_room)
 "aso" = (
-/obj/machinery/camera/network/civilian{
-	dir = 1
+/obj/effect/floor_decal/techfloor,
+/obj/effect/floor_decal/techfloor/hole,
+/obj/machinery/alarm{
+	dir = 1;
+	icon_state = "alarm0";
+	pixel_y = -22
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood,
-/area/maintenance/abandonedlibraryconference)
+/obj/machinery/telecomms/relay/preset/tether/station_mid,
+/turf/simulated/floor/tiled/techfloor,
+/area/crew_quarters/heads/chief)
 "asp" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -10230,6 +10294,9 @@
 	},
 /obj/item/weapon/reagent_containers/spray/cleaner,
 /obj/item/device/closet_painter,
+/obj/machinery/camera/network/engineering{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/engineering/workshop)
 "asB" = (
@@ -10262,12 +10329,12 @@
 /turf/simulated/floor/carpet/bcarpet,
 /area/tether/station/visitorhallway/office)
 "asF" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
+/obj/machinery/camera/network/command{
+	icon_state = "camera";
+	dir = 9
 	},
-/turf/simulated/floor/wood,
-/area/bridge/secondary/meeting_room)
+/turf/simulated/floor/tiled,
+/area/bridge/secondary/hallway)
 "asG" = (
 /turf/simulated/wall/r_wall,
 /area/maintenance/abandonedlibraryconference)
@@ -10406,16 +10473,18 @@
 /area/bridge/secondary/meeting_room)
 "asY" = (
 /obj/effect/floor_decal/borderfloor{
-	dir = 4
+	dir = 1
 	},
 /obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 4
 	},
-/obj/machinery/camera/network/civilian{
-	dir = 8
-	},
+/obj/machinery/camera/network/tether,
 /turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway/office)
+/area/hallway/station/atrium)
 "asZ" = (
 /obj/structure/table/woodentable,
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
@@ -10934,14 +11003,12 @@
 /turf/simulated/floor/tiled,
 /area/engineering/break_room)
 "aua" = (
-/obj/machinery/camera/network/engineering{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
 	},
-/obj/structure/table/reinforced,
-/obj/effect/floor_decal/corner/white/diagonal,
-/obj/item/weapon/folder/yellow,
-/turf/simulated/floor/tiled,
-/area/engineering/break_room)
+/obj/effect/floor_decal/techfloor,
+/turf/simulated/floor/tiled/techfloor,
+/area/crew_quarters/sleep/cryo)
 "aub" = (
 /obj/structure/bed/chair/comfy/blue{
 	icon_state = "comfychair_preview";
@@ -11217,6 +11284,9 @@
 	icon_state = "1-2";
 	pixel_y = 0
 	},
+/obj/machinery/camera/network/engineering{
+	dir = 8
+	},
 /turf/simulated/floor,
 /area/maintenance/substation/spacecommand)
 "auL" = (
@@ -11259,6 +11329,28 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/station/visitorhallway/office)
+"auP" = (
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 25;
+	pixel_y = 0
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 1;
+	icon_state = "borderfloor";
+	pixel_y = 0
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey/bordercorner2{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/stairs_one)
 "auQ" = (
 /obj/structure/cable/green,
 /obj/structure/cable/green{
@@ -11287,17 +11379,13 @@
 /turf/simulated/floor,
 /area/maintenance/substation/spacecommand)
 "auS" = (
-/obj/structure/table/woodentable,
-/obj/item/device/flashlight/lamp/green{
-	pixel_x = 1;
-	pixel_y = 5
+/obj/machinery/vending/tool,
+/obj/machinery/ai_status_display{
+	pixel_x = -32;
+	pixel_y = 0
 	},
-/obj/machinery/camera/network/command{
-	c_tag = "Command Meeting Room West";
-	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/bridge/secondary/meeting_room)
+/turf/simulated/floor/tiled,
+/area/storage/tools)
 "auT" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -11337,19 +11425,13 @@
 /turf/simulated/floor/tiled,
 /area/engineering/atmos/backup)
 "auX" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/yellow{
-	dir = 4
-	},
-/obj/machinery/camera/network/engineering{
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/obj/machinery/meter,
-/obj/machinery/light_switch{
-	dir = 8;
-	pixel_x = 24
-	},
-/turf/simulated/floor/tiled,
-/area/engineering/atmos/backup)
+/obj/structure/table/reinforced,
+/obj/item/weapon/folder/white,
+/turf/simulated/floor/tiled/dark,
+/area/bridge/secondary)
 "auY" = (
 /obj/machinery/atmospherics/omni/atmos_filter{
 	tag_east = 2;
@@ -11858,6 +11940,7 @@
 /obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 4
 	},
+/obj/machinery/camera/network/civilian,
 /turf/simulated/floor/tiled,
 /area/tether/station/visitorhallway)
 "avP" = (
@@ -12004,25 +12087,32 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/sleep/cryo)
 "awa" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/cryopod,
+/obj/effect/floor_decal/corner_techfloor_grid{
+	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+/obj/effect/floor_decal/corner_techfloor_grid{
+	dir = 5
 	},
-/obj/effect/floor_decal/techfloor,
+/obj/machinery/camera/network/tether,
 /turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/sleep/cryo)
 "awb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
 	},
-/obj/machinery/camera/network/civilian{
-	dir = 1
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 8
 	},
-/obj/effect/floor_decal/techfloor,
-/turf/simulated/floor/tiled/techfloor,
-/area/crew_quarters/sleep/cryo)
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 5
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 6
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/docks)
 "awc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -12101,33 +12191,18 @@
 /turf/simulated/floor/tiled,
 /area/tether/station/visitorhallway)
 "awg" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/table/reinforced,
+/obj/machinery/photocopier/faxmachine{
+	department = "Secondary Command Office"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/effect/floor_decal/borderfloor{
+	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/lightgrey/border,
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 9
-	},
-/obj/effect/floor_decal/corner/lightgrey/bordercorner2{
-	dir = 9
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 1
-	},
-/obj/machinery/camera/network/civilian{
-	dir = 1
+/obj/effect/floor_decal/corner/blue/border{
+	dir = 5
 	},
 /turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway)
+/area/bridge/secondary)
 "awh" = (
 /obj/structure/closet/emcloset,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -12445,15 +12520,15 @@
 /turf/simulated/floor/tiled,
 /area/crew_quarters/sleep/spacedorm2)
 "awH" = (
-/obj/structure/dispenser{
-	phorontanks = 0
+/obj/structure/flora/pottedplant,
+/obj/machinery/firealarm{
+	dir = 2;
+	layer = 3.3;
+	pixel_x = 0;
+	pixel_y = 26
 	},
-/obj/machinery/camera/network/command{
-	c_tag = "Command Meeting Room West";
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge/secondary/teleporter)
+/turf/simulated/floor/tiled,
+/area/hallway/station/docks)
 "awI" = (
 /obj/machinery/light_switch{
 	dir = 4;
@@ -12554,11 +12629,15 @@
 /turf/simulated/floor/tiled,
 /area/engineering/hallway)
 "awP" = (
-/obj/effect/floor_decal/steeldecal/steel_decals6{
+/obj/effect/floor_decal/borderfloor{
 	dir = 1
 	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 1
+	},
+/obj/machinery/camera/network/tether,
 /turf/simulated/floor/tiled,
-/area/tether/station/stairs_one)
+/area/hallway/station/atrium)
 "awQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	icon_state = "intact-scrubbers";
@@ -12836,6 +12915,15 @@
 	},
 /turf/simulated/floor/tiled,
 /area/bridge/secondary/hallway)
+"axr" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 6
+	},
+/obj/machinery/newscaster{
+	pixel_x = -30
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/docks)
 "axs" = (
 /turf/simulated/wall/r_wall,
 /area/bridge/secondary/hallway)
@@ -13336,25 +13424,17 @@
 /turf/space,
 /area/shuttle/excursion/tether_dockarm)
 "ayq" = (
+/obj/machinery/computer/card{
+	dir = 1
+	},
 /obj/effect/floor_decal/borderfloor{
-	dir = 8;
-	icon_state = "borderfloor";
-	pixel_x = 0
+	dir = 10
 	},
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 8
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 6
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 5
-	},
-/obj/machinery/camera/network/civilian{
-	dir = 4
+/obj/effect/floor_decal/corner/blue/border{
+	dir = 10
 	},
 /turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway)
+/area/bridge/secondary)
 "ayr" = (
 /obj/structure/bed/double/padded,
 /obj/item/weapon/bedsheet/browndouble,
@@ -13594,14 +13674,14 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/spacedorm3)
 "ayK" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/table/woodentable,
+/obj/item/device/flashlight/lamp/green{
+	pixel_x = 1;
+	pixel_y = 5
 	},
 /obj/machinery/camera/network/command{
-	c_tag = "Head of Personnel Office";
-	dir = 9
+	icon_state = "camera";
+	dir = 4
 	},
 /turf/simulated/floor/wood,
 /area/bridge/secondary/meeting_room)
@@ -13751,37 +13831,15 @@
 /turf/simulated/floor/tiled,
 /area/tether/station/visitorhallway)
 "ayR" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/dispenser{
+	phorontanks = 0
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/machinery/camera/network/command{
+	icon_state = "camera";
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 1;
-	pixel_y = 0
-	},
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 1
-	},
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/lightgrey/bordercorner2{
-	dir = 1
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7,
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 4
-	},
-/obj/machinery/camera/network/civilian,
-/turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway)
+/turf/simulated/floor/tiled/dark,
+/area/bridge/secondary/teleporter)
 "ayS" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -14018,31 +14076,15 @@
 /turf/simulated/floor/tiled/monotile,
 /area/engineering/workshop)
 "azf" = (
-/obj/effect/floor_decal/steeldecal/steel_decals7{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/yellow/border{
-	dir = 4
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 10
-	},
-/obj/machinery/camera/network/engineering{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9;
+	pixel_y = 0
 	},
 /turf/simulated/floor/tiled,
-/area/engineering/hallway)
+/area/tether/station/dock_two)
 "azg" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -14114,6 +14156,9 @@
 	},
 /obj/effect/floor_decal/corner/lightgrey/bordercorner2{
 	dir = 8
+	},
+/obj/machinery/camera/network/tether{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/station/docks)
@@ -14264,6 +14309,9 @@
 /obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 1
 	},
+/obj/machinery/camera/network/civilian{
+	dir = 9
+	},
 /turf/simulated/floor/tiled,
 /area/tether/station/visitorhallway)
 "azu" = (
@@ -14304,12 +14352,25 @@
 /turf/simulated/wall/r_wall,
 /area/tether/station/visitorhallway/laundry)
 "azA" = (
-/obj/structure/disposalpipe/trunk{
+/obj/effect/floor_decal/borderfloor{
+	dir = 8;
+	icon_state = "borderfloor";
+	pixel_x = 0
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 6
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 5
+	},
+/obj/machinery/camera/network/civilian{
 	dir = 4
 	},
-/obj/machinery/disposal,
 /turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway/lounge)
+/area/tether/station/visitorhallway)
 "azB" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -14449,24 +14510,13 @@
 /turf/simulated/floor/tiled,
 /area/tether/station/visitorhallway/lounge)
 "azQ" = (
+/obj/machinery/door/firedoor/glass/hidden/steel,
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/camera/network/tether{
-	dir = 5
-	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 8
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 5
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 6
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/station/docks)
+/area/tether/station/dock_one)
 "azR" = (
 /obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 9
@@ -14584,12 +14634,36 @@
 /turf/simulated/floor/tiled,
 /area/tether/station/visitorhallway/lounge)
 "aAc" = (
-/obj/structure/undies_wardrobe,
-/obj/machinery/camera/network/civilian{
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 1;
+	pixel_y = 0
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey/bordercorner2{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway/laundry)
+/area/tether/station/visitorhallway)
 "aAd" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -15070,25 +15144,13 @@
 /turf/simulated/floor/tiled,
 /area/hallway/station/atrium)
 "aAJ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/camera/network/tether{
-	dir = 1
-	},
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 8
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/blue/border,
-/turf/simulated/floor/tiled,
-/area/hallway/station/atrium)
+/turf/simulated/floor/wood,
+/area/bridge/secondary/meeting_room)
 "aAK" = (
 /obj/structure/closet/wardrobe/black,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -15102,10 +15164,14 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /obj/effect/floor_decal/borderfloor{
-	dir = 1;
-	icon_state = "borderfloor";
-	pixel_y = 0
+	dir = 1
 	},
 /obj/effect/floor_decal/corner/lightgrey/border{
 	dir = 1
@@ -15114,12 +15180,7 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals7,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
+/obj/machinery/camera/network/tether,
 /turf/simulated/floor/tiled,
 /area/hallway/station/atrium)
 "aAM" = (
@@ -15234,10 +15295,9 @@
 /turf/simulated/wall,
 /area/crew_quarters/sleep/engi_wash)
 "aAX" = (
-/obj/structure/bed/chair,
-/obj/machinery/camera/network/tether,
+/obj/structure/undies_wardrobe,
 /turf/simulated/floor/tiled,
-/area/hallway/station/docks)
+/area/tether/station/visitorhallway/laundry)
 "aAY" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
@@ -15340,27 +15400,23 @@
 /turf/simulated/floor/tiled,
 /area/engineering/engine_eva)
 "aBm" = (
-/obj/structure/table/reinforced,
-/obj/item/weapon/storage/briefcase/inflatable{
-	pixel_x = 3;
-	pixel_y = 6
+/obj/effect/floor_decal/industrial/warning,
+/obj/machinery/access_button{
+	command = "cycle_interior";
+	frequency = 1380;
+	master_tag = "trade_shuttle_dock_airlock";
+	name = "interior access button";
+	pixel_x = -28;
+	pixel_y = -26;
+	req_access = list(13)
 	},
-/obj/item/weapon/storage/briefcase/inflatable{
-	pixel_y = 3
-	},
-/obj/item/weapon/storage/briefcase/inflatable{
-	pixel_x = -3;
-	pixel_y = 0
-	},
-/obj/machinery/camera/network/engineering,
+/obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/firealarm{
-	dir = 2;
-	layer = 3.3;
-	pixel_x = 0;
-	pixel_y = 26
+	dir = 8;
+	pixel_x = -26
 	},
 /turf/simulated/floor/tiled,
-/area/engineering/engine_eva)
+/area/tether/station/dock_one)
 "aBn" = (
 /obj/machinery/alarm{
 	dir = 4;
@@ -15407,13 +15463,11 @@
 /turf/simulated/floor/tiled,
 /area/engineering/engine_eva)
 "aBq" = (
-/obj/structure/table/reinforced,
-/obj/item/weapon/cell/high{
-	charge = 100;
-	maxcharge = 15000
+/obj/machinery/camera/network/engineering{
+	dir = 8
 	},
 /turf/simulated/floor/tiled,
-/area/engineering/engine_eva)
+/area/engineering/workshop)
 "aBr" = (
 /obj/structure/table/woodentable,
 /obj/machinery/firealarm{
@@ -15686,6 +15740,17 @@
 /obj/structure/cable/green,
 /turf/simulated/floor/tiled,
 /area/bridge/secondary/hallway)
+"aBQ" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 10
+	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 1;
+	frequency = 1380;
+	id_tag = "trade_shuttle_dock_pump"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/tether/station/dock_one)
 "aBR" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -15698,6 +15763,36 @@
 	},
 /turf/simulated/floor,
 /area/maintenance/substation/civilian)
+"aBS" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	icon_state = "intact-scrubbers";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/camera/network/command,
+/turf/simulated/floor/tiled,
+/area/bridge/secondary/hallway)
+"aBT" = (
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/machinery/camera/network/command{
+	icon_state = "camera";
+	dir = 9
+	},
+/turf/simulated/floor/wood,
+/area/bridge/secondary/meeting_room)
 "aBU" = (
 /obj/machinery/door/airlock{
 	name = "Unit 2"
@@ -15708,6 +15803,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/toilet)
+"aBW" = (
+/obj/machinery/camera/network/command{
+	icon_state = "camera";
+	dir = 9
+	},
+/turf/simulated/floor/wood,
+/area/bridge/secondary/meeting_room)
 "aBX" = (
 /obj/machinery/door/airlock{
 	name = "Restroom"
@@ -15715,18 +15817,71 @@
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/sleep/engi_wash)
+"aBY" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/blue/border{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 6
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 5
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/camera/network/command{
+	icon_state = "camera";
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/bridge/secondary)
 "aBZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/station/docks)
-"aCc" = (
-/obj/machinery/camera/network/tether{
-	dir = 9
+"aCa" = (
+/obj/machinery/recharge_station,
+/obj/machinery/camera/network/engineering{
+	dir = 8
+	},
+/turf/simulated/floor/carpet,
+/area/engineering/foyer)
+"aCb" = (
+/obj/machinery/computer/security/engineering{
+	dir = 1
+	},
+/obj/machinery/camera/network/engineering{
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/station/docks)
+/area/engineering/engineering_monitoring)
+"aCc" = (
+/obj/structure/table/reinforced,
+/obj/machinery/light_switch{
+	dir = 2;
+	name = "light switch ";
+	pixel_x = 10;
+	pixel_y = 36
+	},
+/obj/machinery/camera/network/engineering,
+/turf/simulated/floor/tiled,
+/area/crew_quarters/heads/chief)
+"aCd" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/obj/effect/floor_decal/techfloor{
+	dir = 9
+	},
+/obj/machinery/camera/network/engineering{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/crew_quarters/heads/chief)
 "aCe" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -15734,6 +15889,255 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/station/atrium)
+"aCf" = (
+/obj/structure/table/reinforced,
+/obj/item/weapon/cell/high{
+	charge = 100;
+	maxcharge = 15000
+	},
+/obj/machinery/camera/network/engineering,
+/turf/simulated/floor/tiled,
+/area/engineering/engine_eva)
+"aCg" = (
+/obj/machinery/camera/network/engineering{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/engine_eva)
+"aCh" = (
+/obj/structure/table/reinforced,
+/obj/machinery/microwave,
+/obj/effect/floor_decal/corner/white/diagonal,
+/obj/machinery/camera/network/engineering{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/break_room)
+"aCi" = (
+/obj/machinery/atmospherics/pipe/tank/air{
+	dir = 4
+	},
+/obj/machinery/camera/network/engineering{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/atmos/backup)
+"aCj" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 5
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 6
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/camera/network/engineering{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/hallway)
+"aCk" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 8;
+	icon_state = "borderfloor";
+	pixel_x = 0
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 8
+	},
+/obj/machinery/camera/network/civilian{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway/office)
+"aCl" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/machinery/disposal,
+/obj/machinery/camera/network/civilian,
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway/lounge)
+"aCm" = (
+/obj/machinery/washing_machine,
+/obj/machinery/camera/network/civilian,
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway/laundry)
+"aCn" = (
+/obj/machinery/camera/network/civilian{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/tether/station/burial)
+"aCo" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/camera/network/command{
+	icon_state = "camera";
+	dir = 9
+	},
+/turf/simulated/floor/tiled/dark,
+/area/gateway/prep_room)
+"aCp" = (
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 1
+	},
+/obj/machinery/camera/network/tether{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/stairs_one)
+"aCq" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey/border,
+/obj/machinery/camera/network/tether{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/atrium)
+"aCr" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/blue/border,
+/obj/effect/floor_decal/borderfloor/corner2,
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/blue/bordercorner2,
+/obj/effect/floor_decal/corner/blue/bordercorner2{
+	dir = 9
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 1
+	},
+/obj/machinery/camera/network/tether{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/atrium)
+"aCs" = (
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 9
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 10
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/camera/network/tether{
+	dir = 9
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/atrium)
+"aCt" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 1;
+	icon_state = "borderfloor";
+	pixel_y = 0
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/camera/network/tether,
+/turf/simulated/floor/tiled,
+/area/hallway/station/atrium)
+"aCu" = (
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 9
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 10
+	},
+/obj/machinery/camera/network/tether{
+	dir = 9
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/atrium)
+"aCv" = (
+/obj/structure/reagent_dispensers/water_cooler/full,
+/obj/machinery/camera/network/tether{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/docks)
 "aCw" = (
 /obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 9
@@ -15774,6 +16178,20 @@
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/plating,
 /area/holodeck_control)
+"aCz" = (
+/obj/structure/bed/chair,
+/obj/machinery/camera/network/tether,
+/turf/simulated/floor/tiled,
+/area/hallway/station/docks)
+"aCA" = (
+/obj/machinery/door/firedoor/glass/hidden/steel{
+	dir = 8
+	},
+/obj/machinery/camera/network/tether{
+	dir = 9
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/dock_two)
 "aCB" = (
 /obj/machinery/door/airlock/glass_external{
 	frequency = 1379;
@@ -15817,6 +16235,21 @@
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/tiled/steel_grid,
 /area/tether/station/dock_one)
+"aCH" = (
+/obj/structure/closet/emcloset,
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 8;
+	icon_state = "extinguisher_closed";
+	pixel_x = 30
+	},
+/obj/machinery/camera/network/tether{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/dock_one)
 "aCI" = (
 /obj/machinery/door/airlock/glass,
 /obj/machinery/door/firedoor/glass,
@@ -15850,6 +16283,14 @@
 /obj/machinery/door/airlock/glass,
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/tiled/steel_grid,
+/area/tether/station/dock_two)
+"aCO" = (
+/obj/structure/closet/emcloset,
+/obj/effect/floor_decal/industrial/warning/corner,
+/obj/machinery/camera/network/tether{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
 /area/tether/station/dock_two)
 "aCP" = (
 /obj/structure/table/reinforced,
@@ -15898,6 +16339,18 @@
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/hallway)
+"aCS" = (
+/obj/structure/table/standard,
+/obj/random/tech_supply,
+/obj/random/tech_supply,
+/obj/random/tech_supply,
+/obj/random/tech_supply,
+/obj/random/tech_supply,
+/obj/random/tech_supply,
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/machinery/camera/network/civilian,
+/turf/simulated/floor/tiled,
+/area/storage/tools)
 "aCT" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 4
@@ -15913,6 +16366,19 @@
 	icon_state = "monotile"
 	},
 /area/engineering/hallway)
+"aCU" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/effect/floor_decal/techfloor,
+/obj/machinery/camera/network/tether{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/crew_quarters/sleep/cryo)
 "aCV" = (
 /obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 9
@@ -16062,35 +16528,6 @@
 /obj/random/maintenance/clean,
 /turf/simulated/floor/plating,
 /area/storage/emergency_storage/emergency4)
-"aDV" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/extinguisher_cabinet{
-	dir = 4;
-	icon_state = "extinguisher_closed";
-	pixel_x = -30
-	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 8
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 5
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 6
-	},
-/obj/machinery/camera/network/tether{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled,
-/area/hallway/station/atrium)
 "aDZ" = (
 /obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 9
@@ -16414,31 +16851,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/station/dock_two)
-"aFz" = (
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 9
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/camera/network/tether{
-	dir = 9
-	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 4
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 10
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/station/atrium)
 "aFI" = (
 /obj/structure/table/standard,
 /obj/machinery/firealarm{
@@ -16471,21 +16883,6 @@
 	tag_chamber_sensor = "eng_starboard_sensor";
 	tag_exterior_door = "eng_starboard_outer";
 	tag_interior_door = "eng_starboard_inner"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/engineering/engineering_airlock)
-"aFK" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden{
-	dir = 8;
-	icon_state = "map"
-	},
-/obj/machinery/meter{
-	frequency = 1443;
-	id = "dist_aux_meter";
-	name = "Distribution Loop"
-	},
-/obj/machinery/camera/network/engineering{
-	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/engineering_airlock)
@@ -16757,14 +17154,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/tiled,
 /area/tether/station/dock_two)
-"aHs" = (
-/obj/machinery/door/firedoor/glass/hidden/steel,
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/machinery/camera/network/tether{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/tether/station/dock_one)
 "aHt" = (
 /obj/machinery/door/firedoor/glass/hidden/steel{
 	dir = 1
@@ -16787,12 +17176,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled,
-/area/tether/station/dock_two)
-"aHx" = (
-/obj/machinery/door/firedoor/glass/hidden/steel{
-	dir = 8
-	},
 /turf/simulated/floor/tiled,
 /area/tether/station/dock_two)
 "aHz" = (
@@ -17022,12 +17405,6 @@
 /obj/effect/floor_decal/sign/dock/two,
 /turf/simulated/floor/tiled,
 /area/tether/station/dock_two)
-"aIS" = (
-/obj/machinery/camera/network/tether{
-	dir = 9
-	},
-/turf/simulated/floor/tiled,
-/area/tether/station/dock_two)
 "aIT" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -17059,11 +17436,6 @@
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled,
 /area/tether/station/dock_one)
-"aJa" = (
-/obj/structure/closet/emcloset,
-/obj/effect/floor_decal/industrial/warning/corner,
-/turf/simulated/floor/tiled,
-/area/tether/station/dock_two)
 "aJh" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
@@ -17396,36 +17768,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/engineering_airlock)
-"aLr" = (
-/obj/effect/floor_decal/borderfloor/corner,
-/obj/effect/floor_decal/corner_steel_grid{
-	icon_state = "steel_grid";
-	dir = 9
-	},
-/obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/yellow/bordercorner,
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 8
-	},
-/obj/machinery/camera/network/engineering{
-	dir = 1
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/engineering/hallway)
 "aLt" = (
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/blast/regular{
@@ -18919,21 +19261,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/hallway)
-"aUp" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/yellow/border{
-	dir = 1
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7,
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 4
-	},
-/obj/machinery/camera/network/engineering,
-/obj/machinery/door/firedoor/glass,
-/turf/simulated/floor/tiled,
-/area/engineering/hallway)
 "aUE" = (
 /obj/structure/railing,
 /obj/structure/disposalpipe/segment,
@@ -19013,31 +19340,6 @@
 	name = "Chief Engineer RC";
 	pixel_x = 0;
 	pixel_y = -32
-	},
-/turf/simulated/floor/tiled,
-/area/crew_quarters/heads/chief)
-"aVB" = (
-/obj/effect/floor_decal/industrial/warning/corner,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/camera/network/engineering{
-	dir = 1
-	},
-/obj/machinery/button/remote/blast_door{
-	desc = "A remote control-switch for engine core.";
-	id = "EngineVent";
-	name = "Engine Ventillatory Control";
-	pixel_x = 6;
-	pixel_y = -32
-	},
-/obj/machinery/button/remote/airlock{
-	desc = "A remote control-switch for the engine core airlock hatch bolts.";
-	id = "engine_access_hatch";
-	name = "Engine Hatch Bolt Control";
-	pixel_x = -6;
-	pixel_y = -32;
-	specialfunctions = 4
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/heads/chief)
@@ -19202,24 +19504,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/holodeck_control)
-"aXy" = (
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/power/apc{
-	dir = 2;
-	name = "south bump";
-	pixel_y = -32
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/machinery/camera/network/civilian{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/holodeck_control)
 "aXC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -19372,16 +19656,6 @@
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/tiled,
 /area/hallway/station/atrium)
-"aYE" = (
-/obj/structure/table/reinforced,
-/obj/machinery/light_switch{
-	dir = 2;
-	name = "light switch ";
-	pixel_x = 10;
-	pixel_y = 36
-	},
-/turf/simulated/floor/tiled,
-/area/crew_quarters/heads/chief)
 "aYF" = (
 /obj/structure/table/reinforced,
 /obj/machinery/computer/skills,
@@ -19424,12 +19698,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/heads/chief)
-"aZn" = (
-/obj/machinery/computer/security/engineering{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/engineering/engineering_monitoring)
 "aZq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -19572,20 +19840,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor,
 /area/crew_quarters/sleep/cryo)
-"baV" = (
-/obj/effect/floor_decal/techfloor,
-/obj/effect/floor_decal/techfloor/hole,
-/obj/machinery/camera/network/engineering{
-	dir = 1
-	},
-/obj/machinery/alarm{
-	dir = 1;
-	icon_state = "alarm0";
-	pixel_y = -22
-	},
-/obj/machinery/telecomms/relay/preset/tether/station_mid,
-/turf/simulated/floor/tiled/techfloor,
-/area/crew_quarters/heads/chief)
 "bbs" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 4
@@ -19799,32 +20053,6 @@
 /obj/effect/floor_decal/corner/lightgrey/border,
 /obj/effect/floor_decal/borderfloor/corner2,
 /obj/effect/floor_decal/corner/lightgrey/bordercorner2,
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 1
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/station/atrium)
-"bdr" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
-	},
-/obj/machinery/camera/network/tether{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/lightgrey/border,
 /obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 1
 	},
@@ -20142,14 +20370,6 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled,
 /area/engineering/foyer)
-"beP" = (
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
-/obj/structure/bed/chair,
-/obj/machinery/camera/network/engineering,
-/turf/simulated/floor/carpet,
-/area/engineering/foyer)
 "beS" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -20402,29 +20622,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/station/stairs_one)
-"bgN" = (
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 25;
-	pixel_y = 0
-	},
-/obj/machinery/camera/network/tether,
-/obj/effect/floor_decal/borderfloor{
-	dir = 1;
-	icon_state = "borderfloor";
-	pixel_y = 0
-	},
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 1
-	},
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/lightgrey/bordercorner2{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/tether/station/stairs_one)
 "bgO" = (
 /obj/structure/table/standard,
 /obj/random/tech_supply,
@@ -20638,32 +20835,6 @@
 /obj/random/tech_supply,
 /turf/simulated/floor/tiled,
 /area/storage/tools)
-"bjX" = (
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 9
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/floor_decal/borderfloor{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 4
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 10
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/station/atrium)
 "bkm" = (
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/airlock{
@@ -20772,17 +20943,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/station/atrium)
-"bne" = (
-/obj/machinery/vending/tool,
-/obj/machinery/ai_status_display{
-	pixel_x = -32;
-	pixel_y = 0
-	},
-/obj/machinery/camera/network/civilian{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/storage/tools)
 "bnl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 9;
@@ -20892,31 +21052,6 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/steeldecal/steel_decals6,
-/turf/simulated/floor/tiled,
-/area/hallway/station/atrium)
-"bph" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/camera/network/tether{
-	dir = 1
-	},
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/lightgrey/border,
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 8
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 1
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/station/atrium)
 "bpi" = (
@@ -21032,17 +21167,6 @@
 /obj/random/tool,
 /turf/simulated/floor,
 /area/hallway/station/docks)
-"brv" = (
-/obj/structure/table/standard,
-/obj/random/tech_supply,
-/obj/random/tech_supply,
-/obj/random/tech_supply,
-/obj/random/tech_supply,
-/obj/random/tech_supply,
-/obj/random/tech_supply,
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/tiled,
-/area/storage/tools)
 "brV" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -21076,17 +21200,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/toilet)
-"bsl" = (
-/obj/structure/flora/pottedplant,
-/obj/machinery/firealarm{
-	dir = 2;
-	layer = 3.3;
-	pixel_x = 0;
-	pixel_y = 26
-	},
-/obj/machinery/camera/network/tether,
-/turf/simulated/floor/tiled,
-/area/hallway/station/docks)
 "bsv" = (
 /obj/structure/bed/chair,
 /obj/machinery/power/apc{
@@ -21692,19 +21805,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/station/dock_two)
-"bHY" = (
-/obj/machinery/camera/network/tether{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled,
-/area/tether/station/dock_two)
 "bJl" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
@@ -21962,39 +22062,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/station/dock_two)
-"bPP" = (
-/obj/effect/floor_decal/industrial/warning,
-/obj/machinery/access_button{
-	command = "cycle_interior";
-	frequency = 1380;
-	master_tag = "trade_shuttle_dock_airlock";
-	name = "interior access button";
-	pixel_x = -28;
-	pixel_y = -26;
-	req_access = list(13)
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/machinery/camera/network/tether{
-	dir = 4
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -26
-	},
-/turf/simulated/floor/tiled,
-/area/tether/station/dock_one)
-"bPQ" = (
-/obj/structure/closet/emcloset,
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 8
-	},
-/obj/structure/extinguisher_cabinet{
-	dir = 8;
-	icon_state = "extinguisher_closed";
-	pixel_x = 30
-	},
-/turf/simulated/floor/tiled,
-/area/tether/station/dock_one)
 "bPS" = (
 /obj/machinery/access_button{
 	command = "cycle_interior";
@@ -22135,20 +22202,6 @@
 	id_tag = "trade_shuttle_dock_sensor";
 	pixel_x = 30;
 	pixel_y = 8
-	},
-/turf/simulated/floor/tiled/dark,
-/area/tether/station/dock_one)
-"bQq" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 10
-	},
-/obj/machinery/camera/network/tether{
-	dir = 4
-	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 1;
-	frequency = 1380;
-	id_tag = "trade_shuttle_dock_pump"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/tether/station/dock_one)
@@ -22353,15 +22406,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/engineering/foyer)
-"bYf" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
-/obj/effect/floor_decal/techfloor{
-	dir = 9
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/crew_quarters/heads/chief)
 "bYg" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -22417,10 +22461,6 @@
 	},
 /turf/simulated/floor/carpet,
 /area/engineering/foyer)
-"bYE" = (
-/obj/machinery/recharge_station,
-/turf/simulated/floor/carpet,
-/area/engineering/foyer)
 "bYJ" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 10
@@ -22442,19 +22482,6 @@
 "bYP" = (
 /turf/simulated/wall,
 /area/vacant/vacant_restaurant_lower)
-"bZc" = (
-/obj/structure/table/reinforced,
-/obj/fiftyspawner/rods,
-/obj/fiftyspawner/rods,
-/obj/item/stack/material/glass/phoronrglass{
-	amount = 20
-	},
-/obj/fiftyspawner/wood,
-/obj/machinery/camera/network/engineering{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/engineering/workshop)
 "bZd" = (
 /obj/structure/window/reinforced,
 /turf/simulated/floor/tiled,
@@ -22547,25 +22574,9 @@
 /obj/structure/stairs/west,
 /turf/simulated/floor,
 /area/vacant/vacant_restaurant_lower)
-"bZY" = (
-/obj/structure/reagent_dispensers/water_cooler/full,
-/turf/simulated/floor/tiled,
-/area/hallway/station/docks)
 "bZZ" = (
 /obj/structure/bed/chair,
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/tiled,
-/area/hallway/station/docks)
-"cae" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 6
-	},
-/obj/machinery/camera/network/tether{
-	dir = 4
-	},
-/obj/machinery/newscaster{
-	pixel_x = -30
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/station/docks)
 "cah" = (
@@ -27014,7 +27025,7 @@ ahW
 avf
 aCB
 aEa
-aFK
+alp
 aHT
 aJk
 aJk
@@ -27292,7 +27303,7 @@ aqf
 arz
 arl
 arl
-arl
+aCi
 abZ
 abZ
 atO
@@ -27438,20 +27449,20 @@ arn
 ark
 aue
 aAR
-auA
+aCg
 aEb
 aFL
 atO
 aJm
-aLr
+alL
 aRb
-aYE
+aCc
 aQa
 aSa
 bft
 bhj
 aRb
-bYf
+aCd
 bYJ
 aRb
 bZv
@@ -27594,7 +27605,7 @@ bfv
 bnw
 aXC
 bYh
-baV
+aso
 aRb
 bZv
 bZv
@@ -27875,7 +27886,7 @@ aYJ
 baA
 bcn
 aTR
-aVB
+anR
 aRb
 aRb
 aRb
@@ -28001,7 +28012,7 @@ apq
 adY
 ade
 atf
-auX
+afT
 asy
 axG
 aue
@@ -28138,7 +28149,7 @@ aac
 aac
 aac
 abZ
-aoo
+arO
 apu
 aqj
 aqM
@@ -28172,9 +28183,9 @@ bYP
 bYj
 bYj
 awu
-bZY
+aCv
 btt
-cae
+axr
 aCG
 byE
 aDE
@@ -28184,7 +28195,7 @@ bFE
 aFV
 bHy
 aHa
-aHs
+azQ
 aDE
 aDE
 aDE
@@ -28192,10 +28203,10 @@ bFE
 aFV
 bPs
 aIU
-bPP
+aBm
 bPY
 bQj
-bQq
+aBQ
 bQz
 aJr
 aJr
@@ -28289,7 +28300,7 @@ avd
 asA
 bkx
 aqM
-aBm
+akR
 auA
 auA
 bZt
@@ -28476,7 +28487,7 @@ bHz
 aDG
 uWS
 aDG
-bPQ
+aCH
 aFU
 aDH
 aDH
@@ -28566,14 +28577,14 @@ xMk
 hPi
 acz
 apv
-aqk
+aer
 aqM
 arr
 avg
 aen
 axO
 aqM
-aBq
+aCf
 aJw
 aJw
 cak
@@ -28713,7 +28724,7 @@ acS
 aru
 avh
 aen
-bZc
+agd
 acS
 aqN
 aCM
@@ -29295,7 +29306,7 @@ alI
 amY
 awm
 aXX
-aZn
+aCb
 alv
 bYl
 adp
@@ -29308,7 +29319,7 @@ bYj
 bYj
 bYj
 awu
-bsl
+awH
 btu
 oEH
 awu
@@ -29566,7 +29577,7 @@ arF
 asm
 awB
 axY
-aen
+aBq
 awl
 aCQ
 aen
@@ -29585,7 +29596,7 @@ agR
 adT
 ajK
 awp
-awP
+aCp
 axu
 bkm
 ayw
@@ -29714,7 +29725,7 @@ acS
 aqN
 aqN
 acS
-aUp
+alu
 aLU
 aXZ
 aZr
@@ -29982,7 +29993,7 @@ aiM
 aiM
 acz
 anl
-anR
+adA
 ano
 apb
 apJ
@@ -30018,7 +30029,7 @@ ayy
 aws
 bQa
 aws
-aAV
+aCz
 btu
 aBZ
 awu
@@ -30153,7 +30164,7 @@ agV
 aee
 bdu
 aws
-bgN
+auP
 biC
 axR
 ayy
@@ -30252,14 +30263,14 @@ acz
 acR
 adu
 abx
-abN
+abl
 acq
 adq
 adU
 aeD
 aeV
 afm
-afX
+aCj
 aeV
 ahM
 aiG
@@ -30276,7 +30287,7 @@ atF
 avx
 awO
 ayb
-azf
+ahc
 aBA
 aCV
 aEA
@@ -30293,7 +30304,7 @@ bXJ
 aYb
 agU
 acp
-bdr
+bdu
 aws
 aws
 aws
@@ -30440,11 +30451,11 @@ awt
 awU
 axz
 bkp
-bne
+auS
 azh
 azO
 awt
-aAX
+aAV
 btu
 aBZ
 aCJ
@@ -30544,7 +30555,7 @@ aJs
 aiT
 afp
 akm
-akR
+akS
 alB
 aLh
 ajG
@@ -30569,7 +30580,7 @@ aBC
 aAW
 aMl
 aoJ
-beP
+ams
 aQX
 bYt
 bgF
@@ -30681,7 +30692,7 @@ aac
 arM
 acO
 adF
-adZ
+abN
 aJs
 aiT
 ajD
@@ -30711,17 +30722,17 @@ aBX
 aAW
 aBX
 aoJ
-bYE
+aCa
 aRc
 aSL
 aoJ
 aoJ
 aoJ
-agY
+awP
 acp
 bdK
 awt
-brv
+aCS
 biK
 bks
 ayB
@@ -31010,7 +31021,7 @@ axC
 bky
 ayD
 azj
-azQ
+awb
 aAm
 aBh
 btS
@@ -31032,7 +31043,7 @@ aDJ
 aGa
 alV
 bPN
-aJa
+aCO
 aFZ
 bzq
 bzq
@@ -31127,7 +31138,7 @@ asp
 atJ
 ajF
 apQ
-aua
+agH
 auz
 aAW
 aKU
@@ -31254,13 +31265,13 @@ aJs
 ccl
 afs
 ako
-akT
+aoo
 alH
 amq
 ajI
 akp
 aJs
-ams
+adZ
 anC
 apg
 apQ
@@ -31296,7 +31307,7 @@ afG
 awZ
 azR
 aAo
-aCc
+aBi
 aBi
 auJ
 aCN
@@ -31306,15 +31317,15 @@ bBo
 bDr
 bFH
 aDK
-bHY
+azf
 aDL
-aHx
+aCA
 aDL
 aIc
 bDr
 bPc
 bPl
-aIS
+aDL
 bPO
 bPS
 bQd
@@ -31408,7 +31419,7 @@ apg
 apX
 aqH
 ass
-arO
+aCh
 avL
 awT
 auc
@@ -31587,7 +31598,7 @@ awF
 aya
 aya
 aya
-ayq
+azA
 aya
 aya
 ayA
@@ -31595,7 +31606,7 @@ ayM
 aya
 ayZ
 azv
-azA
+aCl
 azP
 azY
 aAg
@@ -31711,7 +31722,7 @@ asc
 aUF
 atq
 afC
-ahc
+arh
 acp
 bdT
 aaT
@@ -32001,14 +32012,14 @@ afW
 agj
 ahr
 ahU
-ahU
+aCk
 ahU
 ahU
 atw
 auO
 afI
 avK
-awg
+awq
 acP
 awI
 axj
@@ -32018,7 +32029,7 @@ ayg
 ayI
 aBs
 ayf
-ayR
+aAc
 azo
 azv
 azF
@@ -32423,7 +32434,7 @@ afN
 agg
 acr
 acp
-atM
+aCq
 afI
 ahE
 aie
@@ -32449,7 +32460,7 @@ azq
 azx
 azH
 azT
-aAc
+aAX
 aAK
 aBc
 aBj
@@ -32702,7 +32713,7 @@ aeU
 aeU
 afz
 afA
-afD
+anf
 aWn
 agh
 acp
@@ -32838,7 +32849,7 @@ alT
 aFe
 alT
 alT
-aer
+asY
 acm
 acm
 acm
@@ -32873,7 +32884,7 @@ ayt
 ayX
 azt
 azx
-azH
+aCm
 azW
 aAf
 aAU
@@ -32976,7 +32987,7 @@ ack
 afC
 azX
 agw
-aDV
+alh
 aFh
 aHb
 aIs
@@ -32995,7 +33006,7 @@ atM
 ahi
 ahQ
 aif
-asY
+aif
 atl
 atv
 auC
@@ -33400,7 +33411,7 @@ ack
 ack
 ack
 aaT
-agd
+aih
 acm
 acy
 acy
@@ -33435,7 +33446,7 @@ awA
 ahj
 aqg
 aAs
-awH
+ayR
 avr
 awW
 aAt
@@ -33684,7 +33695,7 @@ ack
 ack
 ack
 aaT
-afg
+aAL
 acp
 acy
 acG
@@ -33714,7 +33725,7 @@ auK
 auN
 auR
 avb
-avY
+aBS
 axy
 ahj
 ayz
@@ -33992,11 +34003,11 @@ agm
 agm
 agm
 agm
-agm
+aBY
 agr
 ags
 agx
-agH
+ayq
 acV
 avY
 axy
@@ -34127,7 +34138,7 @@ adc
 adc
 acT
 acp
-adA
+aCr
 acV
 aAv
 agn
@@ -34144,7 +34155,7 @@ avY
 aAE
 ahN
 aht
-auS
+ayK
 awy
 aia
 aiB
@@ -34809,7 +34820,7 @@ aac
 adO
 ajv
 aje
-akJ
+afD
 ajm
 ajM
 adO
@@ -34860,10 +34871,10 @@ aia
 atR
 aia
 ayv
-ayK
+aAJ
 ayN
 aza
-aia
+aBW
 atz
 aat
 aat
@@ -34987,16 +34998,16 @@ aev
 aej
 afa
 afx
-afT
+awg
 agt
 agG
 ahk
 acV
 awh
-axy
+asF
 ahN
 aiI
-asF
+aBT
 atc
 atP
 asG
@@ -35095,14 +35106,14 @@ ahv
 ajj
 aey
 ajq
-alh
+ajQ
 adO
-alo
+ajT
 ajV
 aka
 adO
 ahw
-alL
+afX
 afC
 agv
 acp
@@ -35127,7 +35138,7 @@ adN
 ahu
 aeH
 aeN
-afb
+auX
 acV
 acV
 acV
@@ -35263,7 +35274,7 @@ acZ
 amH
 acy
 acp
-aAJ
+aAI
 acV
 acV
 acV
@@ -35530,7 +35541,7 @@ akP
 alU
 akQ
 afC
-aAL
+aCt
 aCx
 bNZ
 adH
@@ -35555,7 +35566,7 @@ acm
 amQ
 aum
 amV
-anf
+anp
 ans
 anI
 anS
@@ -35675,24 +35686,24 @@ afC
 aAH
 aCw
 aDZ
-aFz
+aCw
 aHz
 aIT
 aKQ
 aML
-aFz
 aCw
+aCu
 aCw
 aTA
 aCw
 aWJ
-aFz
+aCw
 baI
 bch
 beS
 bgf
 bhH
-bjX
+aCs
 bmv
 amS
 amT
@@ -35714,7 +35725,7 @@ aqY
 aro
 arG
 arY
-aso
+arP
 ast
 aat
 aat
@@ -35951,7 +35962,7 @@ alj
 alj
 akt
 akC
-alp
+afb
 adO
 aac
 aac
@@ -36087,7 +36098,7 @@ aac
 adO
 ajx
 ajX
-ajx
+aCo
 alC
 aey
 all
@@ -36257,13 +36268,13 @@ atx
 atx
 auo
 auZ
-awa
+aCU
 asI
 bhL
 aus
-age
+asY
 acm
-bph
+bpi
 aaT
 anm
 anA
@@ -36399,7 +36410,7 @@ aty
 aty
 baQ
 ava
-awb
+aua
 asI
 bid
 aus
@@ -36536,7 +36547,7 @@ amg
 amg
 amg
 ash
-asN
+awa
 asN
 asN
 asI
@@ -36803,7 +36814,7 @@ aiL
 aiS
 akz
 akG
-alu
+akJ
 adP
 adP
 aac
@@ -37247,7 +37258,7 @@ amg
 amg
 asi
 aVx
-aXy
+aqk
 alA
 aus
 aus
@@ -37258,8 +37269,8 @@ aus
 aav
 aaJ
 aaW
+aCn
 abd
-abl
 abd
 abd
 abd
@@ -37378,14 +37389,14 @@ aac
 aac
 ash
 alA
-amN
+alo
 aFI
 alA
 alA
 alA
 alA
 aOO
-arh
+amN
 alA
 alA
 alA

--- a/maps/tether/tether-06-station2.dmm
+++ b/maps/tether/tether-06-station2.dmm
@@ -318,21 +318,17 @@
 /obj/effect/floor_decal/corner/red/bordercorner2{
 	dir = 5
 	},
-/obj/machinery/camera/network/security,
 /turf/simulated/floor/tiled,
 /area/security/security_cell_hallway)
 "aI" = (
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
 	},
-/obj/structure/table/steel,
-/obj/machinery/camera/network/security{
-	icon_state = "camera";
-	dir = 8
+/obj/structure/bed/chair{
+	dir = 1
 	},
-/obj/item/toy/stickhorse,
-/turf/simulated/floor/tiled/dark,
-/area/security/recstorage)
+/turf/simulated/floor/tiled,
+/area/security/security_cell_hallway)
 "aJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -1291,6 +1287,7 @@
 	icon_state = "bordercolor";
 	dir = 9
 	},
+/obj/machinery/camera/network/exploration,
 /turf/simulated/floor/tiled,
 /area/tether/exploration/crew)
 "bW" = (
@@ -1771,21 +1768,31 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/machinery/camera/network/security{
+	icon_state = "camera";
+	dir = 10
+	},
 /turf/simulated/floor/tiled,
 /area/security/security_cell_hallway)
 "cD" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+	dir = 5
 	},
-/obj/structure/bed/chair{
-	dir = 1
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/obj/machinery/camera/network/security{
-	icon_state = "camera";
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled,
-/area/security/security_cell_hallway)
+/area/security/brig)
 "cE" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1;
@@ -1836,26 +1843,25 @@
 /turf/simulated/floor/tiled,
 /area/tether/exploration/crew)
 "cG" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 1;
-	icon_state = "borderfloor";
-	pixel_y = 0
+/obj/effect/floor_decal/borderfloor/shifted{
+	icon_state = "borderfloor_shifted";
+	dir = 8
 	},
-/obj/effect/floor_decal/corner/purple/border{
-	icon_state = "bordercolor";
-	dir = 1
+/obj/effect/floor_decal/corner/red/border/shifted{
+	icon_state = "bordercolor_shifted";
+	dir = 8
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals7,
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 4
+/obj/effect/floor_decal/corner/red{
+	icon_state = "corner_white";
+	dir = 9
 	},
-/obj/structure/bed/chair/office/dark,
-/obj/effect/landmark/start{
-	name = "Pilot"
+/obj/structure/table/reinforced,
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/machinery/alarm{
+	pixel_y = 22
 	},
-/obj/machinery/camera/network/exploration,
 /turf/simulated/floor/tiled,
-/area/tether/exploration/crew)
+/area/security/brig/visitation)
 "cH" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1;
@@ -1983,6 +1989,10 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/machinery/camera/network/security{
+	icon_state = "camera";
+	dir = 10
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/brig)
@@ -2234,26 +2244,25 @@
 /turf/simulated/floor/plating,
 /area/engineering/shaft)
 "di" = (
-/obj/effect/floor_decal/borderfloor/shifted{
-	icon_state = "borderfloor_shifted";
-	dir = 8
+/obj/effect/floor_decal/borderfloor{
+	dir = 1;
+	icon_state = "borderfloor";
+	pixel_y = 0
 	},
-/obj/effect/floor_decal/corner/red/border/shifted{
-	icon_state = "bordercolor_shifted";
-	dir = 8
+/obj/effect/floor_decal/corner/purple/border{
+	icon_state = "bordercolor";
+	dir = 1
 	},
-/obj/effect/floor_decal/corner/red{
-	icon_state = "corner_white";
-	dir = 9
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
 	},
-/obj/structure/table/reinforced,
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/machinery/alarm{
-	pixel_y = 22
+/obj/structure/bed/chair/office/dark,
+/obj/effect/landmark/start{
+	name = "Pilot"
 	},
-/obj/machinery/camera/network/security,
 /turf/simulated/floor/tiled,
-/area/security/brig/visitation)
+/area/tether/exploration/crew)
 "dj" = (
 /turf/simulated/wall,
 /area/security/brig/visitation)
@@ -2894,7 +2903,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/maintenance/command,
+/obj/machinery/door/airlock/maintenance/common,
 /turf/simulated/floor,
 /area/maintenance/evahallway)
 "ei" = (
@@ -3289,6 +3298,7 @@
 	dir = 5
 	},
 /obj/machinery/vending/cigarette,
+/obj/machinery/camera/network/exploration,
 /turf/simulated/floor/tiled,
 /area/tether/exploration/hallway)
 "eL" = (
@@ -3309,6 +3319,10 @@
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
+	},
+/obj/machinery/camera/network/exploration{
+	icon_state = "camera";
+	dir = 5
 	},
 /turf/simulated/floor/tiled,
 /area/tether/exploration/staircase)
@@ -3405,18 +3419,8 @@
 /turf/simulated/floor/tiled,
 /area/security/brig)
 "eT" = (
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 1
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 8
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals5,
-/obj/machinery/alarm{
-	pixel_y = 22
-	},
-/turf/simulated/floor/tiled,
-/area/bridge/meeting_room)
+/turf/simulated/floor,
+/area/maintenance/station/micro)
 "eU" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -3525,27 +3529,17 @@
 /turf/simulated/floor,
 /area/security/interrogation)
 "fc" = (
-/obj/effect/floor_decal/borderfloor{
+/obj/effect/floor_decal/borderfloorblack{
 	dir = 4
 	},
-/obj/effect/floor_decal/corner/red/border{
-	dir = 4
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/alarm{
-	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 24
-	},
+/obj/structure/table/steel,
+/obj/item/toy/stickhorse,
 /obj/machinery/camera/network/security{
 	icon_state = "camera";
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
-/area/security/security_cell_hallway)
+/turf/simulated/floor/tiled/dark,
+/area/security/recstorage)
 "fd" = (
 /turf/simulated/wall/r_wall,
 /area/security/interrogation)
@@ -3586,14 +3580,23 @@
 /turf/simulated/floor,
 /area/tether/exploration/staircase)
 "fh" = (
-/obj/effect/floor_decal/techfloor{
-	dir = 8
-	},
-/obj/machinery/camera/network/command{
+/obj/effect/floor_decal/borderfloor{
 	dir = 4
 	},
-/turf/simulated/floor/bluegrid,
-/area/ai_upload)
+/obj/effect/floor_decal/corner/red/border{
+	dir = 4
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/alarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
+	},
+/turf/simulated/floor/tiled,
+/area/security/security_cell_hallway)
 "fi" = (
 /obj/machinery/alarm{
 	dir = 4;
@@ -3832,10 +3835,6 @@
 /obj/machinery/cryopod{
 	dir = 4
 	},
-/obj/machinery/camera/network/security{
-	icon_state = "camera";
-	dir = 4
-	},
 /turf/simulated/floor/tiled,
 /area/security/brig)
 "fE" = (
@@ -3913,15 +3912,31 @@
 "fK" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/structure/bed/chair,
+/obj/machinery/camera/network/interrogation,
 /turf/simulated/floor/tiled/dark,
 /area/security/interrogation)
 "fL" = (
-/obj/machinery/camera/network/security{
-	icon_state = "camera";
+/obj/effect/floor_decal/borderfloor{
+	dir = 8;
+	icon_state = "borderfloor";
+	pixel_x = 0
+	},
+/obj/effect/floor_decal/corner/purple/border{
+	icon_state = "bordercolor";
 	dir = 8
 	},
-/turf/simulated/floor/tiled/dark,
-/area/security/interrogation)
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 6
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 5
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/machinery/photocopier,
+/turf/simulated/floor/tiled,
+/area/tether/exploration/crew)
 "fM" = (
 /obj/machinery/light,
 /obj/effect/floor_decal/borderfloor,
@@ -4198,6 +4213,10 @@
 "gk" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 10
+	},
+/obj/machinery/camera/network/command{
+	icon_state = "camera";
+	dir = 4
 	},
 /turf/simulated/floor/bluegrid,
 /area/ai_upload)
@@ -4490,9 +4509,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
-/obj/machinery/camera/network/exploration{
-	dir = 8
-	},
 /turf/simulated/floor/tiled,
 /area/tether/exploration/hallway)
 "gJ" = (
@@ -4667,13 +4683,6 @@
 /obj/effect/floor_decal/corner/red/border{
 	dir = 1
 	},
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/red/bordercorner2{
-	dir = 1
-	},
-/obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled,
 /area/security/security_cell_hallway)
 "gX" = (
@@ -4717,6 +4726,10 @@
 	},
 /obj/structure/bed/chair/comfy/beige{
 	icon_state = "comfychair_preview";
+	dir = 1
+	},
+/obj/machinery/camera/network/exploration{
+	icon_state = "camera";
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
@@ -4866,6 +4879,24 @@
 /turf/simulated/floor,
 /area/maintenance/station/exploration)
 "hn" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1;
+	pixel_y = 0
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/red/bordercorner2{
+	dir = 1
+	},
+/obj/machinery/hologram/holopad,
+/obj/machinery/camera/network/security,
+/turf/simulated/floor/tiled,
+/area/security/security_cell_hallway)
+"ho" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/purple/border,
 /obj/effect/floor_decal/borderfloor/corner2,
@@ -4876,28 +4907,8 @@
 /obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 8
 	},
-/obj/machinery/camera/network/exploration{
-	dir = 1
-	},
 /turf/simulated/floor/tiled,
 /area/tether/exploration/staircase)
-"ho" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/yellow/border{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/table/reinforced,
-/obj/random/maintenance/engineering,
-/obj/random/maintenance/engineering,
-/obj/random/tech_supply,
-/obj/machinery/camera/network/engineering{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/engineering/locker_room)
 "hp" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -5326,19 +5337,19 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/interrogation)
 "hZ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
 	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 8
 	},
-/obj/machinery/camera/network/security{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/security/interrogation)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/table/reinforced,
+/obj/random/maintenance/engineering,
+/obj/random/maintenance/engineering,
+/obj/random/tech_supply,
+/turf/simulated/floor/tiled,
+/area/engineering/locker_room)
 "ia" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -5387,6 +5398,7 @@
 /obj/effect/floor_decal/techfloor{
 	dir = 9
 	},
+/obj/machinery/camera/network/command,
 /turf/simulated/floor/bluegrid,
 /area/ai_upload)
 "ie" = (
@@ -5456,6 +5468,7 @@
 /obj/effect/floor_decal/techfloor{
 	dir = 5
 	},
+/obj/machinery/camera/network/command,
 /turf/simulated/floor/bluegrid,
 /area/ai_upload)
 "il" = (
@@ -5544,6 +5557,9 @@
 /obj/structure/table/reinforced,
 /obj/random/powercell,
 /obj/random/tech_supply,
+/obj/machinery/camera/network/engineering{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/engineering/locker_room)
 "ir" = (
@@ -5594,12 +5610,20 @@
 /turf/simulated/floor/tiled,
 /area/engineering/foyer_mezzenine)
 "iw" = (
-/obj/structure/closet/secure_closet/engineering_personal,
-/obj/machinery/camera/network/engineering{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/turf/simulated/floor/tiled,
-/area/engineering/locker_room)
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/camera/network/security{
+	icon_state = "camera";
+	dir = 10
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/interrogation)
 "ix" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -5657,10 +5681,6 @@
 	},
 /obj/machinery/alarm{
 	pixel_y = 22
-	},
-/obj/machinery/camera/network/security{
-	icon_state = "camera";
-	dir = 8
 	},
 /turf/simulated/floor,
 /area/security/riot_control)
@@ -5838,23 +5858,14 @@
 /turf/simulated/floor/tiled,
 /area/tether/exploration/hallway)
 "iK" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 1;
-	icon_state = "borderfloor";
-	pixel_y = 0
+/obj/effect/floor_decal/techfloor{
+	dir = 6
 	},
-/obj/effect/floor_decal/corner/purple/border{
-	icon_state = "bordercolor";
+/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals7,
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 4
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/machinery/camera/network/exploration,
-/turf/simulated/floor/tiled,
-/area/tether/exploration/hallway)
+/turf/simulated/floor/bluegrid,
+/area/ai_upload)
 "iL" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1;
@@ -5920,6 +5931,10 @@
 	dir = 4
 	},
 /obj/structure/flora/pottedplant/crystal,
+/obj/machinery/camera/network/exploration{
+	icon_state = "camera";
+	dir = 9
+	},
 /turf/simulated/floor/tiled,
 /area/tether/exploration/hallway)
 "iP" = (
@@ -6057,6 +6072,10 @@
 	dir = 5
 	},
 /obj/machinery/vending/coffee,
+/obj/machinery/camera/network/exploration{
+	icon_state = "camera";
+	dir = 5
+	},
 /turf/simulated/floor/tiled,
 /area/tether/exploration/hallway)
 "iZ" = (
@@ -6281,33 +6300,14 @@
 /turf/simulated/floor,
 /area/maintenance/station/sec_lower)
 "jm" = (
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/purple/border,
-/obj/effect/floor_decal/steeldecal/steel_decals7{
+/obj/effect/floor_decal/techfloor{
+	dir = 10
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/camera/network/exploration{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/tether/exploration/hallway)
+/turf/simulated/floor/bluegrid,
+/area/ai_upload)
 "jn" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/purple/border,
@@ -6407,6 +6407,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/machinery/camera/network/exploration{
+	icon_state = "camera";
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/tether/exploration/hallway)
@@ -6848,13 +6852,8 @@
 /obj/effect/floor_decal/techfloor{
 	dir = 6
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/machinery/camera/network/command{
-	dir = 1
-	},
-/turf/simulated/floor/bluegrid,
+/obj/effect/floor_decal/techfloor/hole,
+/turf/simulated/floor/tiled/techfloor,
 /area/ai_upload)
 "jV" = (
 /turf/simulated/wall/r_wall,
@@ -6908,17 +6907,29 @@
 /turf/simulated/floor/bluegrid,
 /area/ai_upload)
 "kc" = (
-/obj/effect/floor_decal/techfloor{
-	dir = 10
+/obj/effect/floor_decal/borderfloor{
+	dir = 1;
+	icon_state = "borderfloor";
+	pixel_y = 0
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
+/obj/effect/floor_decal/corner/purple/border{
+	icon_state = "bordercolor";
 	dir = 1
 	},
-/obj/machinery/camera/network/command{
-	dir = 1
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
 	},
-/turf/simulated/floor/bluegrid,
-/area/ai_upload)
+/obj/structure/table/rack/shelf,
+/obj/item/device/multitool/tether_buffered{
+	pixel_y = 2
+	},
+/obj/item/weapon/storage/toolbox/mechanical{
+	pixel_y = -4
+	},
+/obj/item/weapon/hand_labeler,
+/turf/simulated/floor/tiled,
+/area/tether/exploration/equipment)
 "kd" = (
 /obj/structure/table/standard,
 /obj/item/weapon/aiModule/freeform,
@@ -6963,9 +6974,6 @@
 /obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 9
 	},
-/obj/machinery/camera/network/engineering{
-	dir = 4
-	},
 /turf/simulated/floor/tiled,
 /area/engineering/foyer_mezzenine)
 "kh" = (
@@ -6985,6 +6993,9 @@
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 6
+	},
+/obj/machinery/camera/network/tether{
+	dir = 9
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/foyer_mezzenine)
@@ -7098,6 +7109,10 @@
 	dir = 10
 	},
 /obj/effect/floor_decal/techfloor/hole/right,
+/obj/machinery/camera/network/command{
+	icon_state = "camera";
+	dir = 10
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ai_upload)
 "kw" = (
@@ -7114,15 +7129,18 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/ai_upload)
 "kx" = (
-/obj/effect/floor_decal/techfloor{
-	dir = 6
-	},
-/obj/effect/floor_decal/techfloor/hole,
-/obj/machinery/camera/network/command{
+/obj/effect/floor_decal/borderfloor{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ai_upload)
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/starboard)
 "ky" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 10
@@ -7263,6 +7281,9 @@
 	pixel_y = 0
 	},
 /obj/structure/cable/green,
+/obj/machinery/camera/network/engineering{
+	dir = 4
+	},
 /turf/simulated/floor,
 /area/maintenance/substation/exploration)
 "kI" = (
@@ -7316,6 +7337,7 @@
 	pixel_x = 3;
 	pixel_y = -3
 	},
+/obj/machinery/camera/network/engineering,
 /turf/simulated/floor/plating,
 /area/storage/tech)
 "kP" = (
@@ -7482,19 +7504,19 @@
 /turf/simulated/floor/tiled,
 /area/hallway/station/starboard)
 "la" = (
-/obj/machinery/camera/network/tether,
 /obj/effect/floor_decal/borderfloor{
-	dir = 1
+	dir = 6
 	},
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 1
+/obj/effect/floor_decal/corner/purple/border{
+	dir = 6
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals7,
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 4
+/obj/item/device/radio/intercom{
+	dir = 4;
+	pixel_x = 24
 	},
+/obj/structure/filingcabinet/filingcabinet,
 /turf/simulated/floor/tiled,
-/area/hallway/station/starboard)
+/area/tether/exploration/pathfinder_office)
 "lb" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -7512,6 +7534,7 @@
 /obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 4
 	},
+/obj/machinery/camera/network/tether,
 /turf/simulated/floor/tiled,
 /area/hallway/station/starboard)
 "lc" = (
@@ -7670,6 +7693,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/machinery/camera/network/tether,
 /turf/simulated/floor/tiled,
 /area/hallway/station/starboard)
 "ln" = (
@@ -8289,6 +8313,7 @@
 	pixel_x = 1;
 	pixel_y = -1
 	},
+/obj/machinery/camera/network/engineering,
 /turf/simulated/floor/tiled/dark,
 /area/storage/tech)
 "mf" = (
@@ -8544,6 +8569,7 @@
 /area/tether/exploration/pathfinder_office)
 "mA" = (
 /obj/machinery/message_server,
+/obj/machinery/camera/network/command,
 /turf/simulated/floor/tiled/techfloor,
 /area/ai_server_room)
 "mB" = (
@@ -9029,22 +9055,8 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/ai_upload_foyer)
 "ng" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/camera/network/tether,
-/obj/effect/floor_decal/borderfloor{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 1
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 4
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7,
-/turf/simulated/floor/tiled,
-/area/hallway/station/starboard)
+/turf/simulated/floor/tiled/techfloor,
+/area/ai_server_room)
 "nh" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -9240,25 +9252,16 @@
 /turf/simulated/floor/tiled/dark,
 /area/storage/tech)
 "nu" = (
+/obj/machinery/light,
 /obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/machinery/camera/network/engineering{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
-/area/storage/tech)
-"nv" = (
-/obj/machinery/requests_console{
-	department = "Tech storage";
-	pixel_x = -28;
-	pixel_y = 0
-	},
-/obj/machinery/camera/network/engineering{
 	dir = 4
 	},
-/turf/simulated/floor,
-/area/storage/tech)
+/turf/simulated/floor/tiled/techfloor,
+/area/ai_upload_foyer)
+"nv" = (
+/obj/machinery/recharge_station,
+/turf/simulated/floor/tiled/techfloor,
+/area/ai_cyborg_station)
 "nw" = (
 /obj/structure/table/rack{
 	dir = 8;
@@ -9661,17 +9664,14 @@
 /turf/simulated/floor,
 /area/storage/tech)
 "od" = (
-/obj/structure/table/steel,
-/obj/item/weapon/cell/high{
-	charge = 100;
-	maxcharge = 15000
+/obj/effect/floor_decal/borderfloor{
+	dir = 5
 	},
-/obj/item/stack/cable_coil,
-/obj/machinery/camera/network/engineering{
-	dir = 8
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 5
 	},
-/turf/simulated/floor,
-/area/storage/tech)
+/turf/simulated/floor/tiled,
+/area/engineering/foyer_mezzenine)
 "oe" = (
 /obj/structure/railing{
 	dir = 1
@@ -9817,6 +9817,7 @@
 /area/maintenance/station/exploration)
 "or" = (
 /obj/machinery/computer/aifixer,
+/obj/machinery/camera/network/command,
 /turf/simulated/floor/tiled/techfloor,
 /area/ai_cyborg_station)
 "os" = (
@@ -10068,6 +10069,9 @@
 /obj/structure/table/steel,
 /obj/item/device/aicard,
 /obj/item/weapon/aiModule/reset,
+/obj/machinery/camera/network/engineering{
+	dir = 1
+	},
 /turf/simulated/floor,
 /area/storage/tech)
 "oK" = (
@@ -10288,22 +10292,11 @@
 /turf/simulated/floor/tiled,
 /area/engineering/foyer_mezzenine)
 "pf" = (
-/obj/effect/floor_decal/borderfloor/corner{
+/obj/structure/catwalk,
+/obj/machinery/camera/network/tether{
 	dir = 4
 	},
-/obj/effect/floor_decal/corner/yellow/bordercorner{
-	dir = 4
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 10
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 8
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 5
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/open,
 /area/engineering/foyer_mezzenine)
 "pg" = (
 /obj/structure/railing{
@@ -10554,30 +10547,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/ai_monitored/storage/eva)
 "pA" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/button/remote/airlock{
-	desc = "A remote control switch for exiting EVA.";
-	id = "evadoors";
-	name = "EVA Door Control";
-	pixel_x = 0;
-	pixel_y = 28
-	},
-/obj/machinery/camera/network/command{
-	c_tag = "EVA - Fore"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/dark,
-/area/ai_monitored/storage/eva)
+/area/storage/tech)
 "pB" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -10713,22 +10687,13 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/engineering/foyer_mezzenine)
 "pN" = (
-/obj/machinery/camera/network/tether{
-	dir = 1
+/obj/machinery/requests_console{
+	department = "Tech storage";
+	pixel_x = -28;
+	pixel_y = 0
 	},
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/lightgrey/border,
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 8
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/station/starboard)
+/turf/simulated/floor,
+/area/storage/tech)
 "pO" = (
 /turf/simulated/wall/r_wall,
 /area/hallway/station/port)
@@ -11152,24 +11117,26 @@
 /turf/simulated/floor/tiled,
 /area/hallway/station/port)
 "qx" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
-	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 1
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
+/obj/effect/floor_decal/borderfloor/corner{
 	dir = 4
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/effect/floor_decal/corner/yellow/bordercorner{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 10
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
+	},
+/obj/machinery/camera/network/tether{
+	dir = 9
+	},
 /turf/simulated/floor/tiled,
-/area/hallway/station/port)
+/area/engineering/foyer_mezzenine)
 "qy" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/lightgrey/border,
@@ -11337,20 +11304,14 @@
 /turf/simulated/floor/tiled/dark,
 /area/tether/station/public_meeting_room)
 "qI" = (
-/obj/structure/table/woodentable,
-/obj/structure/plushie/ian{
-	dir = 8;
-	icon_state = "ianplushie";
-	pixel_y = 6
+/obj/structure/table/steel,
+/obj/item/weapon/cell/high{
+	charge = 100;
+	maxcharge = 15000
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
-/obj/machinery/camera/network/medbay{
-	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/medical/psych)
+/obj/item/stack/cable_coil,
+/turf/simulated/floor,
+/area/storage/tech)
 "qJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -11359,6 +11320,10 @@
 /area/medical/psych)
 "qK" = (
 /obj/structure/flora/pottedplant/fern,
+/obj/machinery/camera/network/medbay{
+	icon_state = "camera";
+	dir = 9
+	},
 /turf/simulated/floor/wood,
 /area/medical/psych)
 "qL" = (
@@ -11541,6 +11506,10 @@
 /obj/structure/table/woodentable,
 /obj/machinery/photocopier/faxmachine{
 	department = "Pathfinder's Office"
+	},
+/obj/machinery/camera/network/exploration{
+	icon_state = "camera";
+	dir = 9
 	},
 /turf/simulated/floor/tiled,
 /area/tether/exploration/pathfinder_office)
@@ -11725,15 +11694,27 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/medical/morgue)
 "ro" = (
-/obj/structure/table/steel,
-/obj/machinery/camera/network/medbay{
-	dir = 8
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/techfloor{
-	dir = 4
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/medical/morgue)
+/obj/machinery/button/remote/airlock{
+	desc = "A remote control switch for exiting EVA.";
+	id = "evadoors";
+	name = "EVA Door Control";
+	pixel_x = 0;
+	pixel_y = 28
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/dark,
+/area/ai_monitored/storage/eva)
 "rp" = (
 /obj/item/device/radio/intercom{
 	dir = 8;
@@ -11825,6 +11806,10 @@
 	},
 /obj/effect/floor_decal/techfloor{
 	dir = 4
+	},
+/obj/machinery/camera/network/medbay{
+	icon_state = "camera";
+	dir = 9
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/medical/morgue)
@@ -11942,6 +11927,10 @@
 /obj/fiftyspawner/glass,
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
+	},
+/obj/machinery/camera/network/command{
+	icon_state = "camera";
+	dir = 9
 	},
 /turf/simulated/floor/tiled,
 /area/ai_monitored/storage/eva)
@@ -12085,18 +12074,21 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "4-8";
+	pixel_x = 0
 	},
-/obj/machinery/camera/network/tether{
+/obj/effect/floor_decal/borderfloor{
 	dir = 1
 	},
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/lightgrey/border,
-/obj/effect/floor_decal/steeldecal/steel_decals7{
+/obj/effect/floor_decal/corner/lightgrey/border{
 	dir = 1
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 8
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/station/port)
@@ -12149,16 +12141,18 @@
 /turf/simulated/floor/tiled,
 /area/hallway/station/port)
 "rZ" = (
-/obj/structure/bed/chair{
-	dir = 1
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 4
 	},
-/obj/machinery/camera/network/medbay{
-	dir = 1
+/obj/structure/table/reinforced,
+/obj/fiftyspawner/rglass,
+/obj/fiftyspawner/rods,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
 	},
-/obj/effect/floor_decal/borderfloorwhite,
-/obj/effect/floor_decal/corner/paleblue/border,
-/turf/simulated/floor/tiled/white,
-/area/medical/surgery_hallway)
+/turf/simulated/floor/tiled,
+/area/ai_monitored/storage/eva)
 "sa" = (
 /obj/structure/bed/chair{
 	dir = 1
@@ -12376,21 +12370,17 @@
 /turf/simulated/floor/tiled,
 /area/ai_monitored/storage/eva)
 "sq" = (
-/obj/machinery/light{
-	icon_state = "tube1";
+/obj/structure/table/woodentable,
+/obj/structure/plushie/ian{
+	dir = 8;
+	icon_state = "ianplushie";
+	pixel_y = 6
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
-/obj/structure/table/reinforced,
-/obj/machinery/camera/network/security{
-	dir = 8
-	},
-/obj/fiftyspawner/rglass,
-/obj/fiftyspawner/rods,
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/ai_monitored/storage/eva)
+/turf/simulated/floor/wood,
+/area/medical/psych)
 "sr" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/grille,
@@ -12561,9 +12551,17 @@
 /turf/simulated/floor/wood,
 /area/medical/psych)
 "sH" = (
-/obj/structure/closet/crate/bin,
-/turf/simulated/floor/wood,
-/area/medical/psych)
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/paleblue/border,
+/obj/machinery/camera/network/medbay{
+	icon_state = "camera";
+	dir = 10
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/surgery_hallway)
 "sI" = (
 /obj/structure/sign/nosmoking_1,
 /turf/simulated/wall,
@@ -12653,25 +12651,9 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/morgue)
 "sN" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/structure/table/steel,
+/obj/effect/floor_decal/techfloor{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
-	},
-/obj/machinery/camera/network/medbay{
-	dir = 1
-	},
-/obj/effect/floor_decal/techfloor,
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/medical/morgue)
@@ -12997,20 +12979,9 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery_hallway)
 "tt" = (
-/obj/structure/sign/department/morgue{
-	pixel_x = 32
-	},
-/obj/machinery/camera/network/medbay{
-	dir = 8
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/surgery_hallway)
+/obj/structure/closet/crate/bin,
+/turf/simulated/floor/wood,
+/area/medical/psych)
 "tu" = (
 /turf/simulated/wall,
 /area/medical/resleeving)
@@ -13023,15 +12994,19 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/resleeving)
 "tw" = (
-/obj/structure/closet/secure_closet/chemical{
-	req_access = list(64);
-	req_one_access = list(5)
+/obj/structure/table/reinforced,
+/obj/item/clothing/head/welding,
+/obj/item/weapon/storage/belt/utility,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/machinery/camera/network/medbay{
-	dir = 4
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
 	},
-/turf/simulated/floor/carpet/blue,
-/area/medical/psych)
+/turf/simulated/floor/tiled,
+/area/ai_monitored/storage/eva)
 "tx" = (
 /obj/machinery/suit_cycler/security{
 	req_access = null
@@ -13438,23 +13413,25 @@
 /turf/simulated/floor/tiled,
 /area/medical/resleeving)
 "tY" = (
-/obj/structure/table/glass,
-/obj/item/weapon/reagent_containers/glass/beaker/cryoxadone{
-	pixel_x = 7;
-	pixel_y = 1
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/machinery/camera/network/medbay,
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	icon_state = "intact-scrubbers";
+	dir = 4
 	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
+/obj/effect/floor_decal/techfloor,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/tiled/white,
-/area/medical/resleeving)
+/turf/simulated/floor/tiled/techfloor,
+/area/medical/morgue)
 "tZ" = (
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 1
@@ -13798,19 +13775,10 @@
 /turf/simulated/floor/plating,
 /area/ai_monitored/storage/eva)
 "uG" = (
-/obj/structure/table/reinforced,
-/obj/item/clothing/head/welding,
-/obj/item/weapon/storage/belt/utility,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
+/obj/effect/floor_decal/industrial/warning,
 /obj/machinery/camera/network/command{
-	dir = 4
+	icon_state = "camera";
+	dir = 10
 	},
 /turf/simulated/floor/tiled,
 /area/ai_monitored/storage/eva)
@@ -13912,6 +13880,7 @@
 	pixel_x = 0;
 	pixel_y = -25
 	},
+/obj/machinery/camera/network/command,
 /turf/simulated/floor/tiled,
 /area/ai_monitored/storage/eva)
 "uO" = (
@@ -14386,6 +14355,10 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/techfloor,
+/obj/machinery/camera/network/medbay{
+	icon_state = "camera";
+	dir = 10
+	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/resleeving)
 "vB" = (
@@ -14498,12 +14471,14 @@
 /turf/simulated/floor/tiled,
 /area/ai_monitored/storage/eva)
 "vJ" = (
-/obj/effect/floor_decal/industrial/warning,
-/obj/machinery/camera/network/command{
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 5
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
-/area/ai_monitored/storage/eva)
+/area/tether/station/stairs_two)
 "vK" = (
 /obj/effect/floor_decal/industrial/warning/corner,
 /obj/structure/cable/green,
@@ -14553,23 +14528,31 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/ai_cyborg_station)
 "vP" = (
-/obj/machinery/door/firedoor/glass/hidden/steel{
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/lightgrey/border,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
-/area/tether/station/stairs_two)
-"vQ" = (
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 8
+	},
 /obj/machinery/camera/network/tether{
 	dir = 1
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals6{
-	dir = 5
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
 /turf/simulated/floor/tiled,
-/area/tether/station/stairs_two)
+/area/hallway/station/port)
+"vQ" = (
+/obj/structure/sign/department/morgue{
+	pixel_x = 32
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/surgery_hallway)
 "vR" = (
 /obj/machinery/door/airlock/multi_tile/glass{
 	dir = 2;
@@ -14832,8 +14815,14 @@
 /turf/simulated/floor,
 /area/maintenance/evahallway)
 "wo" = (
-/turf/simulated/wall/r_wall,
-/area/bridge/meeting_room)
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/plating,
+/area/maintenance/station/micro)
 "wp" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -14885,25 +14874,12 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/biostorage)
 "wt" = (
-/obj/structure/bed/chair/wheelchair{
-	dir = 4
+/obj/structure/closet/secure_closet/chemical{
+	req_access = list(64);
+	req_one_access = list(5)
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/camera/network/medbay{
-	dir = 8
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/biostorage)
+/turf/simulated/floor/carpet/blue,
+/area/medical/psych)
 "wu" = (
 /obj/structure/flora/ausbushes/brflowers,
 /turf/simulated/floor/grass,
@@ -14911,6 +14887,10 @@
 "wv" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/clipboard,
+/obj/machinery/camera/network/medbay{
+	icon_state = "camera";
+	dir = 10
+	},
 /turf/simulated/floor/carpet/blue,
 /area/medical/psych)
 "ww" = (
@@ -15166,66 +15146,73 @@
 /turf/simulated/floor,
 /area/maintenance/evahallway)
 "wQ" = (
-/obj/structure/table/woodentable,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -27
+/obj/machinery/door/firedoor/glass,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/computer/guestpass{
-	pixel_y = 32
+/obj/machinery/door/airlock/maintenance/common,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/wood,
-/area/bridge/meeting_room)
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor,
+/area/maintenance/station/micro)
 "wR" = (
-/obj/structure/table/woodentable,
-/obj/machinery/chemical_dispenser/bar_soft/full,
-/obj/machinery/keycard_auth{
-	pixel_y = 28
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/wood,
-/area/bridge/meeting_room)
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor,
+/area/maintenance/station/micro)
 "wS" = (
-/obj/structure/table/woodentable,
-/obj/machinery/photocopier/faxmachine{
-	department = "Command Conf Room"
-	},
-/turf/simulated/floor/wood,
-/area/bridge/meeting_room)
-"wT" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/wood,
-/area/bridge/meeting_room)
-"wU" = (
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
-/turf/simulated/floor/wood,
-/area/bridge/meeting_room)
-"wV" = (
-/turf/simulated/floor/wood,
-/area/bridge/meeting_room)
-"wW" = (
-/obj/machinery/atm{
-	pixel_y = 30
-	},
-/turf/simulated/floor/wood,
-/area/bridge/meeting_room)
-"wX" = (
-/obj/structure/flora/pottedplant,
-/turf/simulated/floor/wood,
-/area/bridge/meeting_room)
-"wY" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/structure/window/reinforced{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/maintenance/common,
+/turf/simulated/floor,
+/area/maintenance/station/micro)
+"wT" = (
 /obj/machinery/door/firedoor/glass,
-/turf/simulated/floor/plating,
-/area/bridge/meeting_room)
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/maintenance/common,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor,
+/area/maintenance/station/micro)
+"wU" = (
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 28
+	},
+/obj/structure/cable/green,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/pink/border{
+	dir = 6
+	},
+/obj/machinery/camera/network/medbay{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/exam_room)
 "wZ" = (
 /obj/effect/landmark/start{
 	name = "Medical Doctor"
@@ -15256,20 +15243,23 @@
 /turf/simulated/wall,
 /area/medical/surgery)
 "xc" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
-/obj/machinery/camera/network/medbay{
-	dir = 4
+/obj/structure/table/glass,
+/obj/item/weapon/reagent_containers/glass/beaker/cryoxadone{
+	pixel_x = 7;
+	pixel_y = 1
 	},
 /obj/effect/floor_decal/borderfloorwhite{
-	dir = 8
+	dir = 1
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning{
 	dir = 8
 	},
+/obj/machinery/camera/network/medbay,
 /turf/simulated/floor/tiled/white,
-/area/medical/surgery_hallway)
+/area/medical/resleeving)
 "xd" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -15311,37 +15301,6 @@
 "xg" = (
 /turf/simulated/wall,
 /area/maintenance/station/medbay)
-"xh" = (
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 4
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7,
-/obj/effect/floor_decal/steeldecal/steel_decals5{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/glass/hidden/steel{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/bridge/meeting_room)
-"xi" = (
-/obj/item/clothing/suit/straight_jacket,
-/obj/item/clothing/mask/muzzle,
-/obj/structure/table/standard,
-/obj/machinery/camera/network/medbay{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/biostorage)
 "xj" = (
 /obj/structure/window/reinforced,
 /turf/simulated/floor/tiled/white,
@@ -15413,22 +15372,26 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery_hallway)
 "xo" = (
-/obj/structure/table/standard,
-/obj/item/weapon/reagent_containers/spray/cleaner{
-	desc = "Someone has crossed out the Space from Space Cleaner and written in Surgery. 'Do not remove under punishment of death!!!' is scrawled on the back.";
-	name = "Surgery Cleaner";
-	pixel_x = 2;
-	pixel_y = 2
+/obj/structure/bed/chair/wheelchair{
+	dir = 4
 	},
-/obj/machinery/camera/network/medbay,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /obj/effect/floor_decal/borderfloorwhite{
-	dir = 9
+	dir = 4
 	},
-/obj/effect/floor_decal/corner/white/border{
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 4
+	},
+/obj/machinery/camera/network/medbay{
+	icon_state = "camera";
 	dir = 9
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/surgery)
+/area/medical/biostorage)
 "xp" = (
 /obj/structure/table/standard,
 /obj/item/weapon/storage/firstaid/surgery,
@@ -15472,25 +15435,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor,
 /area/maintenance/evahallway)
-"xs" = (
-/obj/structure/table/woodentable,
-/obj/item/weapon/storage/box/cups,
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/power/apc{
-	cell_type = /obj/item/weapon/cell/super;
-	dir = 8;
-	name = "west bump";
-	pixel_x = -28
-	},
-/turf/simulated/floor/wood,
-/area/bridge/meeting_room)
-"xt" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/wood,
-/area/bridge/meeting_room)
 "xu" = (
 /obj/structure/bed/chair,
 /obj/machinery/power/apc{
@@ -15636,22 +15580,21 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery2)
 "xG" = (
-/obj/structure/table/standard,
-/obj/item/weapon/reagent_containers/spray/cleaner{
-	desc = "Someone has crossed out the Space from Space Cleaner and written in Surgery. 'Do not remove under punishment of death!!!' is scrawled on the back.";
-	name = "Surgery Cleaner";
-	pixel_x = 2;
-	pixel_y = 2
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
 	},
-/obj/machinery/camera/network/medbay,
 /obj/effect/floor_decal/borderfloorwhite{
-	dir = 5
+	dir = 8
 	},
-/obj/effect/floor_decal/corner/white/border{
-	dir = 5
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 8
+	},
+/obj/machinery/camera/network/medbay{
+	icon_state = "camera";
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/surgery2)
+/area/medical/surgery_hallway)
 "xH" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -15675,46 +15618,18 @@
 /obj/structure/railing,
 /turf/simulated/floor,
 /area/maintenance/station/medbay)
-"xJ" = (
-/obj/machinery/door/firedoor/glass,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/maintenance/command{
-	req_access = list(19)
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor,
-/area/bridge/meeting_room)
 "xK" = (
-/obj/structure/table/woodentable,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/item/clothing/suit/straight_jacket,
+/obj/item/clothing/mask/muzzle,
+/obj/structure/table/standard,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 8
 	},
-/obj/machinery/camera/network/command{
-	c_tag = "Command Meeting Room West";
-	dir = 4
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 8
 	},
-/turf/simulated/floor/wood,
-/area/bridge/meeting_room)
-"xL" = (
-/obj/machinery/hologram/holopad,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/carpet/sblucarpet,
-/area/bridge/meeting_room)
-"xM" = (
-/obj/structure/bed/chair/comfy/black,
-/turf/simulated/floor/carpet/sblucarpet,
-/area/bridge/meeting_room)
-"xN" = (
-/turf/simulated/floor/carpet/sblucarpet,
-/area/bridge/meeting_room)
+/turf/simulated/floor/tiled/white,
+/area/medical/biostorage)
 "xO" = (
 /obj/structure/table/standard,
 /obj/item/weapon/storage/box/syringegun,
@@ -15862,6 +15777,10 @@
 /obj/effect/floor_decal/corner/paleblue/border{
 	dir = 4
 	},
+/obj/machinery/camera/network/medbay{
+	icon_state = "camera";
+	dir = 9
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery_hallway)
 "xZ" = (
@@ -15884,30 +15803,21 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery)
 "ya" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 1;
-	icon_state = "borderfloor";
-	pixel_y = 0
-	},
-/obj/effect/floor_decal/corner/purple/border{
-	icon_state = "bordercolor";
-	dir = 1
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7,
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 4
-	},
-/obj/machinery/camera/network/exploration,
-/obj/structure/table/rack/shelf,
-/obj/item/device/multitool/tether_buffered{
+/obj/structure/table/standard,
+/obj/item/weapon/reagent_containers/spray/cleaner{
+	desc = "Someone has crossed out the Space from Space Cleaner and written in Surgery. 'Do not remove under punishment of death!!!' is scrawled on the back.";
+	name = "Surgery Cleaner";
+	pixel_x = 2;
 	pixel_y = 2
 	},
-/obj/item/weapon/storage/toolbox/mechanical{
-	pixel_y = -4
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 9
 	},
-/obj/item/weapon/hand_labeler,
-/turf/simulated/floor/tiled,
-/area/tether/exploration/equipment)
+/obj/effect/floor_decal/corner/white/border{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/surgery)
 "yb" = (
 /obj/effect/floor_decal/industrial/loading,
 /turf/simulated/floor/tiled/white,
@@ -15990,149 +15900,22 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery2)
-"yh" = (
-/turf/simulated/open,
-/area/bridge/meeting_room)
-"yi" = (
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 1
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 8
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals5,
-/turf/simulated/floor/tiled,
-/area/bridge/meeting_room)
-"yj" = (
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 1
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 8
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals5,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/bridge/meeting_room)
-"yk" = (
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 1
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 8
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals5,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/disposalpipe/junction{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/bridge/meeting_room)
-"yl" = (
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 1
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 8
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals5,
-/obj/machinery/door/firedoor/glass/hidden/steel{
-	dir = 2
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/bridge/meeting_room)
-"ym" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/bridge/meeting_room)
-"yn" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/bridge/meeting_room)
-"yo" = (
-/obj/structure/bed/chair/comfy/black{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/landmark/start{
-	name = "Command Secretary"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/carpet/sblucarpet,
-/area/bridge/meeting_room)
-"yp" = (
-/obj/structure/table/woodentable,
-/obj/item/weapon/book/manual/security_space_law,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
-/turf/simulated/floor/carpet/sblucarpet,
-/area/bridge/meeting_room)
-"yq" = (
-/obj/structure/table/woodentable,
-/obj/item/weapon/folder/red,
-/turf/simulated/floor/carpet/sblucarpet,
-/area/bridge/meeting_room)
-"yr" = (
-/obj/structure/bed/chair/comfy/black{
-	dir = 8
-	},
-/obj/effect/landmark/start{
-	name = "Command Secretary"
-	},
-/turf/simulated/floor/carpet/sblucarpet,
-/area/bridge/meeting_room)
 "ys" = (
-/obj/machinery/camera/network/command{
-	c_tag = "Command Meeting Room East";
-	dir = 9
+/obj/structure/table/standard,
+/obj/item/weapon/reagent_containers/spray/cleaner{
+	desc = "Someone has crossed out the Space from Space Cleaner and written in Surgery. 'Do not remove under punishment of death!!!' is scrawled on the back.";
+	name = "Surgery Cleaner";
+	pixel_x = 2;
+	pixel_y = 2
 	},
-/turf/simulated/floor/wood,
-/area/bridge/meeting_room)
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/white/border{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/surgery2)
 "yt" = (
 /obj/machinery/light{
 	icon_state = "tube1";
@@ -16215,17 +15998,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/exploration/equipment)
-"yB" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/maintenance/command{
-	req_access = list(19)
-	},
-/obj/machinery/door/firedoor/glass,
-/turf/simulated/floor,
-/area/maintenance/station/micro)
 "yC" = (
 /obj/structure/lattice,
 /obj/machinery/door/firedoor/glass,
@@ -16322,102 +16094,6 @@
 "yJ" = (
 /turf/simulated/wall/r_wall,
 /area/maintenance/station/micro)
-"yK" = (
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 4
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7,
-/obj/effect/floor_decal/steeldecal/steel_decals5{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/bridge/meeting_room)
-"yL" = (
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 4
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7,
-/obj/effect/floor_decal/steeldecal/steel_decals5{
-	dir = 1
-	},
-/obj/machinery/light,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/bridge/meeting_room)
-"yM" = (
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 4
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7,
-/obj/effect/floor_decal/steeldecal/steel_decals5{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled,
-/area/bridge/meeting_room)
-"yN" = (
-/obj/machinery/photocopier,
-/turf/simulated/floor/wood,
-/area/bridge/meeting_room)
-"yO" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/bridge/meeting_room)
-"yP" = (
-/obj/structure/bed/chair/comfy/black{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/carpet/sblucarpet,
-/area/bridge/meeting_room)
-"yQ" = (
-/obj/structure/table/woodentable,
-/obj/item/weapon/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
-/obj/item/weapon/pen,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/simulated/floor/carpet/sblucarpet,
-/area/bridge/meeting_room)
-"yR" = (
-/obj/structure/table/woodentable,
-/obj/item/weapon/folder/blue,
-/turf/simulated/floor/carpet/sblucarpet,
-/area/bridge/meeting_room)
-"yS" = (
-/obj/structure/bed/chair/comfy/black{
-	dir = 8
-	},
-/turf/simulated/floor/carpet/sblucarpet,
-/area/bridge/meeting_room)
-"yT" = (
-/obj/machinery/alarm{
-	dir = 1;
-	icon_state = "alarm0";
-	pixel_y = -22
-	},
-/obj/structure/table/woodentable,
-/turf/simulated/floor/wood,
-/area/bridge/meeting_room)
-"yU" = (
-/obj/machinery/light,
-/turf/simulated/floor/wood,
-/area/bridge/meeting_room)
 "yV" = (
 /obj/structure/table/standard,
 /obj/item/device/glasses_kit,
@@ -16489,25 +16165,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery)
-"zb" = (
-/obj/machinery/door/firedoor/glass,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/maintenance/command{
-	req_access = list(19)
-	},
-/turf/simulated/floor,
-/area/bridge/meeting_room)
-"zc" = (
-/obj/structure/bed/chair/comfy/black{
-	dir = 1
-	},
-/turf/simulated/floor/carpet/sblucarpet,
-/area/bridge/meeting_room)
 "zd" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -16736,6 +16393,10 @@
 /obj/effect/floor_decal/corner/white/bordercorner2{
 	dir = 6
 	},
+/obj/machinery/camera/network/medbay{
+	icon_state = "camera";
+	dir = 9
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery)
 "zu" = (
@@ -16752,6 +16413,10 @@
 	},
 /obj/effect/floor_decal/corner/white/bordercorner2{
 	dir = 8
+	},
+/obj/machinery/camera/network/medbay{
+	icon_state = "camera";
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery2)
@@ -16903,13 +16568,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/medical/patient_a)
-"zG" = (
-/obj/structure/table/woodentable,
-/obj/structure/flora/pottedplant/small{
-	pixel_y = 12
-	},
-/turf/simulated/floor/wood,
-/area/bridge/meeting_room)
 "zH" = (
 /obj/structure/table/standard,
 /obj/effect/floor_decal/borderfloorwhite{
@@ -17131,9 +16789,6 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
-/obj/machinery/camera/network/medbay{
-	dir = 8
-	},
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 4
 	},
@@ -17176,9 +16831,6 @@
 /area/medical/surgery_hallway)
 "Ab" = (
 /obj/machinery/door/firedoor/glass/hidden/steel{
-	dir = 8
-	},
-/obj/machinery/camera/network/medbay{
 	dir = 8
 	},
 /obj/effect/floor_decal/borderfloorwhite{
@@ -17253,6 +16905,7 @@
 	dir = 8
 	},
 /obj/machinery/vending/coffee,
+/obj/machinery/camera/network/medbay,
 /turf/simulated/floor/wood,
 /area/medical/surgery_hallway)
 "Ah" = (
@@ -17345,7 +16998,6 @@
 /area/medical/surgery_hallway)
 "Ap" = (
 /obj/structure/table/glass,
-/obj/machinery/camera/network/medbay,
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 1
 	},
@@ -17576,7 +17228,6 @@
 /obj/machinery/door/firedoor/glass/hidden/steel{
 	dir = 2
 	},
-/obj/machinery/camera/network/medbay,
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 1
 	},
@@ -18171,6 +17822,10 @@
 /obj/item/weapon/storage/box/masks,
 /obj/effect/floor_decal/borderfloorwhite,
 /obj/effect/floor_decal/corner/paleblue/border,
+/obj/machinery/camera/network/medbay{
+	icon_state = "camera";
+	dir = 10
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery_hallway)
 "BB" = (
@@ -18925,14 +18580,15 @@
 /area/medical/surgery_hallway)
 "CG" = (
 /obj/structure/closet/emcloset,
-/obj/machinery/camera/network/medbay{
-	dir = 8
-	},
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 6
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
 	dir = 6
+	},
+/obj/machinery/camera/network/medbay{
+	icon_state = "camera";
+	dir = 9
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery_hallway)
@@ -19087,6 +18743,10 @@
 	},
 /obj/effect/floor_decal/corner/paleblue/bordercorner2{
 	dir = 8
+	},
+/obj/machinery/camera/network/medbay{
+	icon_state = "camera";
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/ward)
@@ -19250,23 +18910,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/ward)
-"Dh" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 6
-	},
-/obj/effect/floor_decal/corner/purple/border{
-	dir = 6
-	},
-/obj/item/device/radio/intercom{
-	dir = 4;
-	pixel_x = 24
-	},
-/obj/machinery/camera/network/exploration{
-	dir = 1
-	},
-/obj/structure/filingcabinet/filingcabinet,
-/turf/simulated/floor/tiled,
-/area/tether/exploration/pathfinder_office)
 "Di" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -19287,11 +18930,22 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/ai_server_room)
 "Dk" = (
-/obj/machinery/camera/network/command{
-	dir = 1
+/obj/structure/bed/padded,
+/obj/item/weapon/bedsheet/medical,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ai_server_room)
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloorwhite/corner2{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner2{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/ward)
 "Dl" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -19299,15 +18953,12 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/ai_server_room)
 "Dm" = (
-/obj/machinery/light,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
+/obj/structure/closet/secure_closet/engineering_personal,
+/obj/machinery/camera/network/engineering{
+	dir = 8
 	},
-/obj/machinery/camera/network/command{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ai_upload_foyer)
+/turf/simulated/floor/tiled,
+/area/engineering/locker_room)
 "Dn" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -19356,13 +19007,6 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/ward)
 "Dq" = (
-/obj/machinery/camera/network/security{
-	icon_state = "camera";
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/security/brig/visitation)
-"Dr" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -19372,8 +19016,16 @@
 	icon_state = "intercom";
 	pixel_x = 32
 	},
+/obj/machinery/camera/network/command{
+	icon_state = "camera";
+	dir = 9
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ai_upload_foyer)
+"Dr" = (
+/obj/machinery/camera/network/medbay,
+/turf/simulated/floor/tiled/white,
+/area/medical/surgery_hallway)
 "Ds" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 9
@@ -19480,13 +19132,6 @@
 	},
 /turf/simulated/floor,
 /area/maintenance/station/sec_lower)
-"Dz" = (
-/obj/machinery/recharge_station,
-/obj/machinery/camera/network/command{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ai_cyborg_station)
 "DA" = (
 /obj/structure/railing{
 	dir = 4
@@ -19792,28 +19437,17 @@
 /turf/simulated/floor,
 /area/maintenance/station/exploration)
 "Ea" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
-	},
-/obj/machinery/camera/network/tether,
 /obj/effect/floor_decal/borderfloor{
-	dir = 1
+	dir = 4
 	},
 /obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 1
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 4
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals7,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/camera/network/civilian{
+	dir = 9
 	},
-/turf/simulated/floor/tiled,
-/area/hallway/station/port)
+/turf/simulated/floor/tiled/dark,
+/area/tether/station/public_meeting_room)
 "Eb" = (
 /obj/structure/ladder/up,
 /turf/simulated/floor,
@@ -19892,30 +19526,14 @@
 /turf/simulated/floor/tiled,
 /area/tether/exploration/crew)
 "Ei" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 8;
-	icon_state = "borderfloor";
-	pixel_x = 0
-	},
-/obj/effect/floor_decal/corner/purple/border{
-	icon_state = "bordercolor";
+/obj/machinery/atmospherics/portables_connector{
 	dir = 8
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 6
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 5
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/machinery/camera/network/exploration{
-	dir = 4
-	},
-/obj/machinery/photocopier,
-/turf/simulated/floor/tiled,
-/area/tether/exploration/crew)
+/obj/machinery/portable_atmospherics/canister/air/airlock,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/camera/network/command,
+/turf/simulated/floor/tiled/dark,
+/area/ai_monitored/storage/eva)
 "Ej" = (
 /obj/effect/floor_decal/rust,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -20162,17 +19780,12 @@
 /turf/simulated/floor,
 /area/maintenance/station/sec_lower)
 "EE" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 5
-	},
-/obj/effect/floor_decal/corner/yellow/border{
-	dir = 5
-	},
-/obj/machinery/camera/network/engineering{
+/obj/effect/floor_decal/corner/white/border{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
-/area/engineering/foyer_mezzenine)
+/obj/machinery/camera/network/security,
+/turf/simulated/floor/tiled/monotile,
+/area/security/brig)
 "EF" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -20266,23 +19879,16 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/exam_room)
 "EM" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 28
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
 	},
-/obj/structure/cable/green,
-/obj/machinery/camera/network/medbay{
-	dir = 1
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/camera/network/security{
+	icon_state = "camera";
+	dir = 10
 	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 6
-	},
-/obj/effect/floor_decal/corner/pink/border{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/exam_room)
+/turf/simulated/floor/tiled,
+/area/security/brig)
 "EN" = (
 /obj/structure/table/glass,
 /obj/item/weapon/paper_bin{
@@ -20313,25 +19919,24 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/ward)
 "EP" = (
-/obj/structure/bed/padded,
-/obj/item/weapon/bedsheet/medical,
-/obj/machinery/camera/network/medbay{
-	dir = 8
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloorwhite/corner2{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
-/obj/effect/floor_decal/corner/paleblue/bordercorner2{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
-/turf/simulated/floor/tiled/white,
-/area/medical/ward)
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/camera/network/security{
+	icon_state = "camera";
+	dir = 5
+	},
+/turf/simulated/floor/tiled,
+/area/security/brig/visitation)
 "EQ" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
@@ -20457,6 +20062,10 @@
 	icon_state = "1-4"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/camera/network/security{
+	icon_state = "camera";
+	dir = 5
+	},
 /turf/simulated/floor/tiled,
 /area/security/brig/visitation)
 "Fa" = (
@@ -20470,12 +20079,12 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/ward)
 "Fb" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
+/obj/machinery/camera/network/security{
+	icon_state = "camera";
+	dir = 10
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled,
-/area/security/brig)
+/area/security/brig/visitation)
 "Fc" = (
 /obj/structure/bed/padded,
 /obj/item/weapon/bedsheet/medical,
@@ -20798,24 +20407,25 @@
 /turf/simulated/floor,
 /area/maintenance/station/sec_lower)
 "Fu" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
+	},
 /obj/effect/floor_decal/borderfloor{
-	dir = 4
+	dir = 1
 	},
 /obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 4
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 10
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 9
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/machinery/camera/network/tether,
 /turf/simulated/floor/tiled,
-/area/hallway/station/starboard)
+/area/hallway/station/port)
 "Fv" = (
 /obj/machinery/door/airlock/maintenance/common,
 /obj/machinery/door/firedoor/glass,
@@ -20838,6 +20448,53 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel_dirty,
 /area/security/brig)
+"Fx" = (
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/powered/scrubber/huge/stationary{
+	scrub_id = "sec_riot_control"
+	},
+/obj/machinery/camera/network/security{
+	icon_state = "camera";
+	dir = 5
+	},
+/turf/simulated/floor/plating,
+/area/security/brig)
+"Fy" = (
+/obj/structure/closet/secure_closet/explorer,
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/purple/border,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 8
+	},
+/obj/machinery/camera/network/exploration{
+	icon_state = "camera";
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/tether/exploration/equipment)
+"Fz" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/lightgrey/border,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/camera/network/tether{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/starboard)
 "FA" = (
 /obj/structure/railing{
 	dir = 8
@@ -20848,6 +20505,28 @@
 	},
 /turf/simulated/floor,
 /area/maintenance/station/sec_lower)
+"FB" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 10
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 9
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/camera/network/tether{
+	dir = 9
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/starboard)
 "FC" = (
 /obj/structure/table/rack{
 	dir = 8;
@@ -20857,6 +20536,15 @@
 /obj/random/maintenance/engineering,
 /turf/simulated/floor,
 /area/maintenance/station/sec_lower)
+"FD" = (
+/obj/machinery/door/firedoor/glass/hidden/steel{
+	dir = 1
+	},
+/obj/machinery/camera/network/tether{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/stairs_two)
 "FI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -20962,13 +20650,6 @@
 	},
 /turf/simulated/floor,
 /area/maintenance/station/sec_lower)
-"Hg" = (
-/obj/machinery/keycard_auth{
-	pixel_y = -28
-	},
-/obj/structure/flora/pottedplant,
-/turf/simulated/floor/wood,
-/area/bridge/meeting_room)
 "Hq" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
@@ -21788,29 +21469,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/brig/visitation)
-"PP" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/camera/network/security{
-	icon_state = "camera";
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/security/brig)
 "PR" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 8
@@ -22339,16 +21997,6 @@
 	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/tether/station/public_meeting_room)
-"Us" = (
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
-	},
-/obj/machinery/portable_atmospherics/powered/scrubber/huge/stationary{
-	scrub_id = "sec_riot_control"
-	},
-/turf/simulated/floor/plating,
-/area/security/brig)
 "UE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -22570,17 +22218,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor,
 /area/maintenance/station/sec_lower)
-"Wk" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 1;
-	pixel_y = 0
-	},
-/obj/effect/floor_decal/corner/red/border{
-	dir = 1
-	},
-/obj/machinery/camera/network/security,
-/turf/simulated/floor/tiled,
-/area/security/security_cell_hallway)
 "Ww" = (
 /obj/effect/floor_decal/rust,
 /obj/structure/closet,
@@ -22648,12 +22285,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/maintenance/station/sec_lower)
-"Xd" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/wood,
-/area/bridge/meeting_room)
 "Xk" = (
 /obj/structure/table/steel,
 /obj/item/device/flashlight/lamp{
@@ -22789,30 +22420,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/brig)
-"XX" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled,
-/area/security/brig/visitation)
-"Yc" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/tether/station/public_meeting_room)
 "Yd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -28385,7 +27992,7 @@ aP
 lv
 ej
 mE
-nu
+pA
 nY
 aP
 pd
@@ -28659,7 +28266,7 @@ bW
 fX
 gs
 gS
-ho
+hZ
 hL
 iq
 iZ
@@ -28669,7 +28276,7 @@ kK
 lx
 mg
 mG
-nv
+pN
 nZ
 oa
 kJ
@@ -29217,12 +28824,12 @@ ch
 ch
 af
 RE
-XX
+EP
 PM
 an
 EZ
 Ix
-Dq
+BV
 dx
 fX
 gw
@@ -29522,7 +29129,7 @@ lA
 ml
 mK
 nz
-od
+qI
 oL
 kJ
 pJ
@@ -29642,7 +29249,7 @@ ax
 Za
 Fq
 af
-di
+cG
 do
 dt
 af
@@ -29786,7 +29393,7 @@ bj
 af
 aq
 cp
-BV
+Fb
 af
 bN
 ep
@@ -29797,7 +29404,7 @@ gw
 gw
 gw
 hP
-iw
+Dm
 jb
 jF
 fX
@@ -29805,7 +29412,7 @@ ac
 ac
 kf
 mM
-mO
+pf
 oe
 oM
 oM
@@ -30067,7 +29674,7 @@ ah
 aA
 MC
 HH
-PP
+cD
 Qy
 cr
 Lx
@@ -30078,7 +29685,7 @@ eS
 fD
 Pm
 aS
-Us
+Fx
 Op
 hQ
 iu
@@ -30103,7 +29710,7 @@ sw
 sw
 uQ
 vp
-vP
+FD
 sw
 ac
 ac
@@ -30347,7 +29954,7 @@ at
 UO
 XH
 aS
-ak
+EE
 aB
 ak
 bm
@@ -30380,20 +29987,20 @@ oM
 pK
 qp
 re
-rP
+vP
 sw
 te
 te
 te
 te
 vr
-vQ
+vJ
 sw
 uu
 vC
 wl
 wM
-xi
+xK
 xO
 vT
 aP
@@ -30502,7 +30109,7 @@ bw
 bD
 bF
 ZH
-Fb
+EM
 Rq
 cs
 cu
@@ -30930,7 +30537,7 @@ aS
 Ld
 Ui
 aS
-Wk
+gW
 Eu
 dR
 aJ
@@ -31224,15 +30831,15 @@ TY
 TY
 kj
 kf
-EE
+od
 nD
 oj
 oN
-pf
+qx
 pM
 qt
 rj
-rW
+rV
 KI
 qH
 rp
@@ -31243,7 +30850,7 @@ Yf
 vT
 uA
 vU
-wt
+xo
 xa
 xk
 xS
@@ -31498,7 +31105,7 @@ aS
 bq
 fZ
 aS
-gW
+hn
 ht
 hV
 hV
@@ -31778,7 +31385,7 @@ QH
 ds
 dT
 Vm
-fc
+fh
 fI
 ga
 cq
@@ -31798,14 +31405,14 @@ ph
 mS
 DO
 hr
-qx
+Fu
 Vw
 Xq
 TO
 Do
 VK
 Gf
-Yc
+Ea
 LL
 po
 po
@@ -31950,7 +31557,7 @@ KI
 KI
 KI
 po
-tw
+wt
 uU
 vX
 wv
@@ -32082,11 +31689,11 @@ fq
 jj
 pj
 kj
-Ea
+rW
 rk
 fM
 pn
-qI
+sq
 rq
 rA
 sh
@@ -32097,7 +31704,7 @@ tK
 tK
 ww
 xb
-xo
+ya
 xZ
 yY
 An
@@ -32210,7 +31817,7 @@ gb
 gE
 fb
 WL
-hZ
+iw
 fd
 fN
 jQ
@@ -32337,17 +31944,17 @@ PV
 RS
 aj
 lp
-cD
+aI
 aj
 lp
-cD
+aI
 cA
 as
 az
-aI
+fc
 Kv
 fd
-fL
+Mp
 gc
 Mp
 fe
@@ -32540,7 +32147,7 @@ Cs
 CJ
 CS
 De
-EM
+wU
 BF
 aa
 aa
@@ -32658,7 +32265,7 @@ qL
 ru
 rD
 pp
-sH
+tt
 tq
 tO
 uZ
@@ -32798,7 +32405,7 @@ fQ
 pq
 qM
 rv
-rZ
+sH
 pp
 sI
 po
@@ -32813,7 +32420,7 @@ zf
 xw
 xw
 zY
-rv
+Dr
 rv
 AK
 Ba
@@ -32948,7 +32555,7 @@ tQ
 vb
 wb
 wC
-xc
+xG
 wb
 yf
 tQ
@@ -33058,7 +32665,7 @@ de
 de
 eB
 Eh
-Ei
+fL
 gz
 gN
 hI
@@ -33067,7 +32674,7 @@ iY
 ke
 ky
 ea
-la
+kx
 lJ
 lJ
 lJ
@@ -33218,7 +32825,7 @@ pm
 DJ
 DS
 DV
-Fu
+FB
 pU
 oW
 pt
@@ -33227,7 +32834,7 @@ ry
 sc
 pp
 sj
-tt
+vQ
 tS
 vc
 wd
@@ -33356,7 +32963,7 @@ hy
 hy
 hC
 nM
-pN
+pQ
 DL
 DL
 DL
@@ -33392,7 +32999,7 @@ Cw
 Fi
 CW
 Dp
-EP
+Dk
 EV
 Fc
 BL
@@ -33510,7 +33117,7 @@ pV
 pV
 pV
 sk
-sN
+tY
 tu
 tU
 vd
@@ -33621,7 +33228,7 @@ RS
 xy
 cY
 bA
-cG
+di
 dy
 dm
 eF
@@ -33631,7 +33238,7 @@ Ek
 gZ
 bA
 iy
-jm
+jK
 kn
 kn
 ea
@@ -34080,12 +33687,12 @@ pV
 so
 ti
 tu
-tY
+xc
 Fj
 wi
 wI
 xf
-xG
+ys
 yx
 zm
 Fg
@@ -34500,7 +34107,7 @@ ac
 ac
 uW
 qE
-ro
+sN
 rz
 sf
 sE
@@ -34634,7 +34241,7 @@ zA
 kp
 li
 nN
-pN
+pQ
 DL
 ac
 ac
@@ -34650,11 +34257,11 @@ uW
 tu
 tu
 vx
-wo
-wo
-wo
-wo
-yB
+yJ
+yJ
+yJ
+yJ
+wS
 sB
 ac
 ac
@@ -34772,7 +34379,7 @@ ks
 Es
 El
 pF
-As
+Fy
 kp
 nc
 nN
@@ -34792,10 +34399,10 @@ ac
 tu
 uq
 vy
-wo
-yh
-yh
-wo
+yJ
+eT
+eT
+yJ
 yC
 sB
 ac
@@ -34906,7 +34513,7 @@ eW
 fC
 eb
 eb
-hn
+ho
 cZ
 iy
 jx
@@ -34918,7 +34525,7 @@ As
 kp
 nh
 nN
-pQ
+Fz
 DL
 ac
 ac
@@ -34934,10 +34541,10 @@ ac
 tu
 ur
 vz
-wo
-yh
-yh
-wo
+yJ
+eT
+eT
+yJ
 yD
 sB
 ac
@@ -35053,7 +34660,7 @@ cZ
 iJ
 jy
 kp
-ya
+kc
 lk
 pF
 As
@@ -35076,10 +34683,10 @@ ac
 tu
 us
 vA
-wo
-yi
-yK
-wo
+yJ
+eT
+eT
+yJ
 yE
 sB
 ac
@@ -35192,7 +34799,7 @@ gj
 gL
 hB
 cZ
-iK
+iB
 jo
 kp
 lq
@@ -35200,7 +34807,7 @@ lY
 qb
 Bt
 kp
-ng
+nh
 nR
 pQ
 DL
@@ -35218,10 +34825,10 @@ ac
 tu
 ut
 vB
-wo
+yJ
 eT
-yK
-wo
+eT
+yJ
 yF
 sB
 ac
@@ -35360,10 +34967,10 @@ sF
 sF
 sF
 sF
-wo
-yj
-yL
-wo
+yJ
+eT
+eT
+yJ
 yG
 sB
 ac
@@ -35502,10 +35109,10 @@ vF
 wn
 wP
 xr
-xJ
-yk
-yM
-zb
+wQ
+wR
+wR
+wT
 yI
 sB
 ac
@@ -35641,13 +35248,13 @@ uc
 pv
 pv
 vG
-wo
-wo
-wo
-wo
-yl
-xh
-wo
+yJ
+yJ
+yJ
+yJ
+eT
+eT
+yJ
 yJ
 yJ
 ac
@@ -35783,15 +35390,15 @@ oY
 oY
 oY
 oY
-wo
-wQ
-xs
-xK
-ym
-yO
-wV
-zG
-wo
+yJ
+eT
+eT
+eT
+eT
+eT
+eT
+eT
+yJ
 ac
 ac
 ac
@@ -35908,7 +35515,7 @@ kt
 lO
 mz
 qZ
-Dh
+la
 kt
 nh
 nR
@@ -35925,15 +35532,15 @@ ud
 uE
 vi
 oY
-wo
-wR
-wV
-wV
-yn
-yO
-wV
-yN
-wo
+yJ
+eT
+eT
+eT
+eT
+eT
+eT
+eT
+yJ
 ac
 ac
 ac
@@ -36067,15 +35674,15 @@ qc
 qc
 qc
 oY
-wo
-wS
-wV
-wV
-yn
-yO
-wV
-yT
-wo
+yJ
+eT
+eT
+eT
+eT
+eT
+eT
+eT
+yJ
 ac
 ac
 ac
@@ -36209,16 +35816,16 @@ ue
 uF
 tD
 oY
-wo
-wT
-xt
-xL
-yo
-yP
-xN
-yU
-wo
-wo
+yJ
+eT
+eT
+eT
+eT
+eT
+eT
+eT
+yJ
+yJ
 ac
 ac
 ac
@@ -36348,19 +35955,19 @@ qe
 sP
 ty
 qe
-uG
+tw
 vj
 vH
-wo
-wU
-wV
-xM
-yp
-yQ
-zc
-wV
-wV
-wo
+yJ
+eT
+eT
+eT
+eT
+eT
+eT
+eT
+eT
+yJ
 aP
 aP
 aP
@@ -36493,16 +36100,16 @@ qc
 pz
 qc
 vI
-wo
-wV
-wV
-xM
-yq
-yR
-zc
-wV
-wV
-wo
+yJ
+eT
+eT
+eT
+eT
+eT
+eT
+eT
+eT
+yJ
 aP
 aP
 aP
@@ -36624,7 +36231,7 @@ kG
 kY
 le
 pb
-pA
+ro
 qf
 qS
 rI
@@ -36634,17 +36241,17 @@ tA
 uf
 pz
 qc
-vJ
-wo
-wW
-wV
-xN
-yr
-yS
-xN
-wV
-wV
-wo
+uG
+yJ
+eT
+eT
+eT
+eT
+eT
+eT
+eT
+eT
+yJ
 aP
 aP
 aP
@@ -36755,12 +36362,12 @@ dZ
 dZ
 ie
 iQ
-jU
+iK
 dZ
 hh
 mV
 rf
-Dk
+ng
 hh
 lm
 lJ
@@ -36777,16 +36384,16 @@ ug
 pB
 qg
 vK
-wo
-Xd
-wV
-wV
-wV
-wV
-wV
-wV
-yU
-wo
+yJ
+eT
+eT
+eT
+eT
+eT
+eT
+eT
+eT
+yJ
 aP
 aP
 aP
@@ -36890,7 +36497,7 @@ aP
 aP
 dZ
 ek
-fh
+fE
 fE
 gk
 dZ
@@ -36912,23 +36519,23 @@ pC
 qh
 qU
 rK
-sq
+rZ
 sS
 tC
 uh
 uH
 vk
 vL
-wo
-wX
-wV
-wV
-ys
-wV
-wV
-wV
-Hg
-wo
+yJ
+eT
+eT
+eT
+eT
+eT
+eT
+eT
+eT
+yJ
 aP
 aP
 aP
@@ -37062,15 +36669,15 @@ uI
 tD
 oY
 oY
-wY
-wY
-wY
-wY
-wY
-wY
-wY
-wY
 wo
+wo
+wo
+wo
+wo
+wo
+wo
+wo
+yJ
 aP
 aP
 aP
@@ -37186,7 +36793,7 @@ kv
 hA
 ne
 sV
-Dm
+nu
 hA
 Dt
 nU
@@ -37466,11 +37073,11 @@ hG
 ii
 iV
 ka
-kx
+jU
 lS
 nj
 sV
-Dr
+Dq
 DH
 Dv
 lJ
@@ -37765,7 +37372,7 @@ ac
 ac
 aa
 oY
-sX
+Ei
 sX
 oY
 uN
@@ -37891,12 +37498,12 @@ dZ
 dZ
 ij
 iW
-kc
+jm
 dZ
 hl
 np
 xX
-Dz
+nv
 hl
 ac
 ac

--- a/maps/tether/tether-07-station3.dmm
+++ b/maps/tether/tether-07-station3.dmm
@@ -167,12 +167,21 @@
 /turf/simulated/floor/tiled,
 /area/security/briefing_room)
 "ar" = (
-/obj/structure/table/woodentable,
-/obj/machinery/photocopier/faxmachine{
-	department = "Head of Security"
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 8;
+	icon_state = "map"
 	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/heads/hos)
+/obj/machinery/meter{
+	frequency = 1443;
+	id = "dist_aux_meter";
+	name = "Distribution Loop"
+	},
+/obj/machinery/camera/network/security{
+	icon_state = "camera";
+	dir = 5
+	},
+/turf/simulated/floor/tiled,
+/area/security/eva)
 "as" = (
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/airlock/glass_security{
@@ -225,20 +234,19 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/heads/hos)
 "aw" = (
-/obj/machinery/door/window/northright,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/camera/network/security{
-	icon_state = "camera";
-	dir = 8
-	},
-/obj/item/device/radio/intercom/department/security{
-	dir = 4;
-	icon_state = "secintercom";
-	pixel_x = 24;
+/obj/effect/floor_decal/borderfloor{
+	dir = 1;
 	pixel_y = 0
 	},
-/turf/simulated/floor/tiled/dark,
-/area/security/range)
+/obj/effect/floor_decal/corner/red/border{
+	dir = 1
+	},
+/obj/structure/table/reinforced,
+/obj/item/device/suit_cooling_unit,
+/obj/item/device/suit_cooling_unit,
+/obj/machinery/camera/network/security,
+/turf/simulated/floor/tiled,
+/area/security/eva)
 "ax" = (
 /obj/machinery/access_button{
 	command = "cycle_interior";
@@ -384,14 +392,15 @@
 /turf/simulated/floor/tiled,
 /area/security/hallway)
 "aH" = (
-/obj/machinery/camera/network/security{
-	dir = 1
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 9
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
+	dir = 4
 	},
-/turf/simulated/floor/tiled,
-/area/security/eva)
+/obj/structure/table/rack/steel,
+/turf/simulated/floor/tiled/dark,
+/area/security/armory/blue)
 "aI" = (
 /turf/simulated/wall,
 /area/maintenance/station/sec_upper)
@@ -653,20 +662,20 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/range)
 "bb" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden{
-	dir = 8;
-	icon_state = "map"
+/obj/machinery/door/window/northright,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/item/device/radio/intercom/department/security{
+	dir = 4;
+	icon_state = "secintercom";
+	pixel_x = 24;
+	pixel_y = 0
 	},
-/obj/machinery/meter{
-	frequency = 1443;
-	id = "dist_aux_meter";
-	name = "Distribution Loop"
+/obj/machinery/camera/network/security{
+	icon_state = "camera";
+	dir = 8
 	},
-/obj/machinery/camera/network/engineering{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/security/eva)
+/turf/simulated/floor/tiled/dark,
+/area/security/range)
 "bc" = (
 /turf/simulated/wall,
 /area/security/eva)
@@ -689,6 +698,10 @@
 /obj/effect/floor_decal/borderfloorblack/corner2{
 	dir = 1
 	},
+/obj/machinery/camera/network/security{
+	icon_state = "camera";
+	dir = 5
+	},
 /turf/simulated/floor/tiled/dark,
 /area/security/armory/red)
 "bh" = (
@@ -703,6 +716,10 @@
 	},
 /obj/effect/floor_decal/borderfloorblack/corner2{
 	dir = 4
+	},
+/obj/machinery/camera/network/security{
+	icon_state = "camera";
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/armory/red)
@@ -757,10 +774,6 @@
 /area/maintenance/substation/security)
 "bn" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
-/obj/machinery/camera/network/security{
-	icon_state = "camera";
 	dir = 4
 	},
 /obj/machinery/light_switch{
@@ -992,6 +1005,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/machinery/camera/network/engineering,
 /turf/simulated/floor,
 /area/maintenance/substation/security)
 "bB" = (
@@ -1128,16 +1142,15 @@
 /turf/simulated/floor/tiled,
 /area/security/hallwayaux)
 "bL" = (
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/red/border,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/obj/machinery/camera/network/security{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/security/hallwayaux)
+/turf/simulated/floor/tiled/monotile,
+/area/tether/exploration)
 "bM" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/red/border,
@@ -1205,20 +1218,23 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/armory/blue)
 "bS" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 1;
-	pixel_y = 0
+/obj/effect/floor_decal/borderfloorblack,
+/obj/effect/floor_decal/borderfloorblack/corner2{
+	dir = 9
 	},
-/obj/effect/floor_decal/corner/red/border{
-	dir = 1
+/obj/structure/table/steel,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
 	},
-/obj/machinery/photocopier,
-/obj/machinery/camera/network/security,
-/obj/machinery/alarm{
-	pixel_y = 22
+/obj/machinery/button/remote/blast_door{
+	id = "armoryred";
+	name = "Red Armory Access";
+	pixel_x = 8;
+	pixel_y = -24;
+	req_access = list(3)
 	},
 /turf/simulated/floor/tiled/dark,
-/area/security/warden)
+/area/security/armory/red)
 "bT" = (
 /obj/structure/table/steel,
 /obj/machinery/cell_charger,
@@ -1505,6 +1521,10 @@
 "cm" = (
 /obj/effect/floor_decal/borderfloorblack/full,
 /obj/structure/closet/bombcloset/double,
+/obj/machinery/camera/network/security{
+	icon_state = "camera";
+	dir = 5
+	},
 /turf/simulated/floor/tiled/dark,
 /area/security/armory/blue)
 "cn" = (
@@ -1541,15 +1561,11 @@
 /turf/simulated/floor/tiled,
 /area/security/hallwayaux)
 "cp" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/camera/network/exploration,
-/turf/simulated/floor/tiled/monotile,
-/area/tether/exploration)
+/turf/simulated/floor/tiled,
+/area/security/eva)
 "cq" = (
 /obj/random/trash_pile,
 /obj/effect/decal/cleanable/cobweb{
@@ -2103,12 +2119,15 @@
 /turf/simulated/floor/carpet,
 /area/security/breakroom)
 "du" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 1
+/obj/effect/landmark{
+	name = "tripai"
 	},
-/obj/machinery/disposal,
-/turf/simulated/floor/wood,
-/area/security/breakroom)
+/obj/machinery/camera/network/command{
+	icon_state = "camera";
+	dir = 4
+	},
+/turf/simulated/floor/bluegrid,
+/area/ai)
 "dv" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -2416,13 +2435,19 @@
 /turf/simulated/floor,
 /area/maintenance/cargo)
 "dU" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/camera/network/exploration{
-	dir = 4
+/obj/effect/floor_decal/borderfloor{
+	dir = 1;
+	pixel_y = 0
 	},
-/turf/simulated/floor/tiled/monotile,
-/area/tether/exploration)
+/obj/effect/floor_decal/corner/red/border{
+	dir = 1
+	},
+/obj/machinery/photocopier,
+/obj/machinery/alarm{
+	pixel_y = 22
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/warden)
 "dV" = (
 /turf/simulated/wall/r_wall,
 /area/maintenance/station/ai)
@@ -2599,16 +2624,8 @@
 "ej" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/red/border,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_x = 0;
-	pixel_y = -24
-	},
-/obj/machinery/camera/network/security{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
 	},
 /turf/simulated/floor/tiled,
 /area/security/hallwayaux)
@@ -2639,25 +2656,51 @@
 /turf/simulated/floor/wood,
 /area/security/breakroom)
 "em" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/camera/network/exploration{
-	dir = 8
-	},
-/obj/structure/cable/green{
-	d1 = 2;
+/obj/structure/cable{
+	d1 = 4;
 	d2 = 8;
-	icon_state = "2-8"
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/monotile,
-/area/tether/exploration)
+/turf/simulated/floor/bluegrid,
+/area/ai)
 "en" = (
-/obj/machinery/camera/network/security{
-	icon_state = "camera";
-	dir = 8
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
 	},
-/turf/simulated/floor/wood,
-/area/security/breakroom)
+/obj/effect/floor_decal/corner/blue/border{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloorblack/corner2{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/blue/bordercorner2{
+	dir = 5
+	},
+/obj/structure/table/steel,
+/obj/item/weapon/storage/box/stunshells{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/weapon/storage/box/flashshells{
+	pixel_x = 1;
+	pixel_y = 0
+	},
+/obj/item/weapon/storage/box/beanbags{
+	pixel_x = 4;
+	pixel_y = -5
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/machinery/button/remote/blast_door{
+	id = "armoryblue";
+	name = "Blue Armory Access";
+	pixel_x = 24;
+	pixel_y = -8;
+	req_access = list(3)
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/armory/blue)
 "eo" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -2684,10 +2727,18 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/security_lockerroom)
 "er" = (
-/obj/structure/shuttle/engine/propulsion,
-/turf/simulated/floor/reinforced,
-/turf/simulated/shuttle/plating/airless/carry,
-/area/shuttle/excursion/tether)
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/red/border,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = -24
+	},
+/turf/simulated/floor/tiled,
+/area/security/hallwayaux)
 "es" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/railing{
@@ -2798,6 +2849,10 @@
 	dir = 8
 	},
 /obj/machinery/vending/snack,
+/obj/machinery/camera/network/security{
+	icon_state = "camera";
+	dir = 10
+	},
 /turf/simulated/floor/tiled,
 /area/security/hallwayaux)
 "eB" = (
@@ -3542,37 +3597,17 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/evidence_storage)
 "fJ" = (
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 6
 	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 5
+/obj/effect/floor_decal/borderfloorblack/corner2,
+/obj/structure/table/rack/shelf/steel,
+/obj/machinery/camera/network/security{
+	icon_state = "camera";
+	dir = 8
 	},
-/obj/effect/floor_decal/corner/white/border{
-	dir = 5
-	},
-/obj/effect/floor_decal/borderfloorwhite/corner2{
-	dir = 5
-	},
-/obj/effect/floor_decal/corner/white/bordercorner2{
-	icon_state = "bordercolorcorner2";
-	dir = 5
-	},
-/obj/structure/table/reinforced,
-/obj/machinery/computer/med_data/laptop,
-/obj/machinery/camera/network/security,
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 24
-	},
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/tiled/white,
-/area/security/forensics)
+/turf/simulated/floor/tiled/dark,
+/area/security/armory/blue)
 "fK" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -3719,32 +3754,11 @@
 /turf/simulated/floor/tiled,
 /area/hallway/station/upper)
 "fU" = (
-/obj/machinery/camera/network/tether,
-/obj/effect/floor_decal/borderfloor{
-	dir = 1
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
 	},
-/obj/effect/floor_decal/corner/red/border{
-	dir = 1
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7,
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/red/bordercorner2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/station/upper)
+/turf/simulated/floor/bluegrid,
+/area/ai)
 "fV" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -3842,6 +3856,10 @@
 /obj/effect/floor_decal/borderfloorwhite,
 /obj/effect/floor_decal/corner/white/border,
 /obj/machinery/dnaforensics,
+/obj/machinery/camera/network/security{
+	icon_state = "camera";
+	dir = 10
+	},
 /turf/simulated/floor/tiled/white,
 /area/security/forensics)
 "gd" = (
@@ -4307,16 +4325,14 @@
 /turf/simulated/floor/tiled,
 /area/security/eva)
 "gX" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 1;
-	pixel_y = 0
-	},
-/obj/effect/floor_decal/corner/red/border{
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
-/obj/structure/table/reinforced,
-/obj/item/device/suit_cooling_unit,
-/obj/item/device/suit_cooling_unit,
+/obj/machinery/camera/network/security{
+	icon_state = "camera";
+	dir = 10
+	},
 /turf/simulated/floor/tiled,
 /area/security/eva)
 "gY" = (
@@ -4371,16 +4387,13 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/shuttle/excursion/tether)
 "hd" = (
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 9
+/obj/structure/table/woodentable,
+/obj/machinery/photocopier/faxmachine{
+	department = "Head of Security"
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
-/obj/structure/table/rack/steel,
 /obj/machinery/camera/network/security,
-/turf/simulated/floor/tiled/dark,
-/area/security/armory/blue)
+/turf/simulated/floor/wood,
+/area/crew_quarters/heads/hos)
 "he" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -4601,12 +4614,19 @@
 /area/security/armory/blue)
 "hC" = (
 /obj/effect/floor_decal/borderfloorblack{
-	dir = 6
+	dir = 8
 	},
-/obj/effect/floor_decal/borderfloorblack/corner2,
-/obj/structure/table/rack/shelf/steel,
+/obj/structure/table/steel,
+/obj/item/weapon/storage/box/flashbangs{
+	pixel_x = -2;
+	pixel_y = -2
+	},
+/obj/machinery/camera/network/security{
+	icon_state = "camera";
+	dir = 5
+	},
 /turf/simulated/floor/tiled/dark,
-/area/security/armory/blue)
+/area/security/security_equiptment_storage)
 "hD" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 10
@@ -4675,26 +4695,31 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/armory/red)
 "hH" = (
-/obj/effect/floor_decal/borderfloorblack,
-/obj/effect/floor_decal/borderfloorblack/corner2{
-	dir = 9
-	},
-/obj/structure/table/steel,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/obj/machinery/camera/network/security{
 	dir = 1
 	},
-/obj/machinery/button/remote/blast_door{
-	id = "armoryred";
-	name = "Red Armory Access";
-	pixel_x = 8;
-	pixel_y = -24;
-	req_access = list(3)
+/obj/machinery/power/apc{
+	dir = 2;
+	name = "south bump";
+	pixel_y = -32
 	},
-/turf/simulated/floor/tiled/dark,
-/area/security/armory/red)
+/obj/structure/table/reinforced,
+/obj/item/weapon/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/weapon/folder/red,
+/obj/item/weapon/pen,
+/obj/item/device/megaphone,
+/obj/effect/floor_decal/borderfloor/shifted,
+/obj/effect/floor_decal/corner/red/border/shifted,
+/obj/effect/floor_decal/corner/red{
+	icon_state = "corner_white";
+	dir = 10
+	},
+/obj/structure/cable/green,
+/turf/simulated/floor/tiled,
+/area/security/observation)
 "hI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -4779,21 +4804,46 @@
 /turf/simulated/floor/tiled,
 /area/security/eva)
 "hQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
+/obj/effect/floor_decal/borderfloor{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 6
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/red/bordercorner2{
+	dir = 6
+	},
+/obj/machinery/suit_cycler/security,
+/obj/machinery/camera/network/security{
+	icon_state = "camera";
+	dir = 10
 	},
 /turf/simulated/floor/tiled,
 /area/security/eva)
 "hR" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
 	},
-/obj/machinery/camera/network/command,
-/turf/simulated/floor/bluegrid,
-/area/ai)
+/obj/effect/floor_decal/corner/red/border{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/turf/simulated/floor/tiled,
+/area/security/hallwayaux)
 "hS" = (
 /obj/machinery/door/firedoor/glass,
 /obj/structure/cable/green{
@@ -4949,6 +4999,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
+/obj/machinery/camera/network/command,
 /turf/simulated/floor/bluegrid,
 /area/ai)
 "id" = (
@@ -5110,6 +5161,10 @@
 	name = "RED ARMORY";
 	pixel_y = 32
 	},
+/obj/machinery/camera/network/security{
+	icon_state = "camera";
+	dir = 5
+	},
 /turf/simulated/floor/tiled/dark,
 /area/security/warden)
 "ik" = (
@@ -5237,6 +5292,10 @@
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
+	},
+/obj/machinery/camera/network/security{
+	icon_state = "camera";
+	dir = 5
 	},
 /turf/simulated/floor/tiled,
 /area/security/hallway)
@@ -5709,13 +5768,10 @@
 /turf/simulated/floor/tiled,
 /area/security/hallwayaux)
 "iS" = (
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/red/border,
-/obj/machinery/camera/network/security{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/security/hallwayaux)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/weapon/bone/skull/unathi,
+/turf/simulated/floor/carpet,
+/area/crew_quarters/heads/hos)
 "iT" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 6
@@ -5994,46 +6050,21 @@
 /area/security/armory/blue)
 "jv" = (
 /obj/effect/floor_decal/borderfloorblack{
-	dir = 4
+	dir = 5
 	},
-/obj/effect/floor_decal/corner/blue/border{
-	dir = 4
+/obj/effect/floor_decal/corner/red/border{
+	dir = 5
 	},
 /obj/effect/floor_decal/borderfloorblack/corner2{
-	dir = 5
+	dir = 4
 	},
-/obj/effect/floor_decal/corner/blue/bordercorner2{
-	dir = 5
+/obj/effect/floor_decal/corner/red/bordercorner2{
+	dir = 4
 	},
-/obj/structure/table/steel,
-/obj/item/weapon/storage/box/stunshells{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/weapon/storage/box/flashshells{
-	pixel_x = 1;
-	pixel_y = 0
-	},
-/obj/item/weapon/storage/box/beanbags{
-	pixel_x = 4;
-	pixel_y = -5
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/obj/machinery/camera/network/security{
-	icon_state = "camera";
-	dir = 8
-	},
-/obj/machinery/button/remote/blast_door{
-	id = "armoryblue";
-	name = "Blue Armory Access";
-	pixel_x = 24;
-	pixel_y = -8;
-	req_access = list(3)
-	},
+/obj/structure/closet/wardrobe/red,
+/obj/machinery/camera/network/security,
 /turf/simulated/floor/tiled/dark,
-/area/security/armory/blue)
+/area/security/security_lockerroom)
 "jw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -6874,20 +6905,15 @@
 /turf/simulated/floor,
 /area/maintenance/station/sec_upper)
 "kK" = (
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 8
+/obj/effect/landmark{
+	name = "tripai"
 	},
-/obj/structure/table/steel,
-/obj/item/weapon/storage/box/flashbangs{
-	pixel_x = -2;
-	pixel_y = -2
-	},
-/obj/machinery/camera/network/security{
+/obj/machinery/camera/network/command{
 	icon_state = "camera";
-	dir = 4
+	dir = 9
 	},
-/turf/simulated/floor/tiled/dark,
-/area/security/security_equiptment_storage)
+/turf/simulated/floor/bluegrid,
+/area/ai)
 "kL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -6927,59 +6953,27 @@
 /turf/simulated/floor/tiled,
 /area/security/observation)
 "kO" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/obj/machinery/power/apc{
-	dir = 2;
-	name = "south bump";
-	pixel_y = -32
-	},
-/obj/structure/table/reinforced,
-/obj/item/weapon/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
-/obj/item/weapon/folder/red,
-/obj/item/weapon/pen,
-/obj/machinery/camera/network/security{
-	dir = 1
-	},
-/obj/item/device/megaphone,
-/obj/effect/floor_decal/borderfloor/shifted,
-/obj/effect/floor_decal/corner/red/border/shifted,
-/obj/effect/floor_decal/corner/red{
-	icon_state = "corner_white";
-	dir = 10
-	},
-/obj/structure/cable/green,
-/turf/simulated/floor/tiled,
-/area/security/observation)
-"kP" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/red/border{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/camera/network/security{
-	icon_state = "camera";
+/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
-/obj/machinery/firealarm{
+/obj/item/device/radio/intercom/department/security{
 	dir = 4;
-	pixel_x = 24
+	icon_state = "secintercom";
+	pixel_x = 24;
+	pixel_y = 0
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/heads/hos)
+"kP" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/red/border,
+/obj/item/device/radio/intercom/department/security{
+	dir = 2;
+	icon_state = "secintercom";
+	pixel_y = -24
 	},
 /turf/simulated/floor/tiled,
-/area/security/hallwayaux)
+/area/security/briefing_room)
 "kQ" = (
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 4
@@ -6997,11 +6991,15 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/shuttle/excursion/tether)
 "kS" = (
-/obj/effect/landmark{
-	name = "tripai"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/turf/simulated/floor/bluegrid,
-/area/ai)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/camera/network/exploration,
+/turf/simulated/floor/tiled/monotile,
+/area/tether/exploration)
 "kT" = (
 /obj/effect/floor_decal/techfloor,
 /obj/effect/floor_decal/techfloor{
@@ -7657,6 +7655,10 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
+/obj/machinery/camera/network/command{
+	icon_state = "camera";
+	dir = 10
+	},
 /turf/simulated/floor/bluegrid,
 /area/ai)
 "lT" = (
@@ -7680,14 +7682,33 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/ai)
 "lU" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
+/obj/effect/floor_decal/borderfloor{
 	dir = 8
 	},
-/obj/machinery/camera/network/command{
-	dir = 1
+/obj/effect/floor_decal/corner/red/border{
+	dir = 8
 	},
-/turf/simulated/floor/bluegrid,
-/area/ai)
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 10;
+	icon_state = "borderfloorcorner2";
+	pixel_x = 0
+	},
+/obj/effect/floor_decal/corner/red/bordercorner2{
+	dir = 10
+	},
+/obj/item/device/radio/intercom{
+	dir = 8;
+	pixel_x = -24
+	},
+/obj/structure/table/steel,
+/obj/item/weapon/folder/red,
+/obj/item/weapon/folder/red{
+	pixel_x = 2;
+	pixel_y = 4
+	},
+/obj/machinery/recharger,
+/turf/simulated/floor/tiled,
+/area/security/security_processing)
 "lV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -7886,21 +7907,21 @@
 /area/security/security_lockerroom)
 "mg" = (
 /obj/effect/floor_decal/borderfloorblack{
-	dir = 5
-	},
-/obj/effect/floor_decal/corner/red/border{
-	dir = 5
+	dir = 8
 	},
 /obj/effect/floor_decal/borderfloorblack/corner2{
-	dir = 4
+	icon_state = "borderfloorcorner2_black";
+	dir = 8
 	},
-/obj/effect/floor_decal/corner/red/bordercorner2{
-	dir = 4
+/obj/structure/closet{
+	name = "Evidence Closet"
 	},
-/obj/structure/closet/wardrobe/red,
-/obj/machinery/camera/network/security,
+/obj/machinery/camera/network/security{
+	icon_state = "camera";
+	dir = 5
+	},
 /turf/simulated/floor/tiled/dark,
-/area/security/security_lockerroom)
+/area/security/evidence_storage)
 "mh" = (
 /obj/machinery/door/firedoor/glass,
 /obj/structure/grille,
@@ -8031,13 +8052,14 @@
 /turf/simulated/floor/tiled/monotile,
 /area/tether/exploration)
 "mu" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/camera/network/exploration{
+	icon_state = "camera";
+	dir = 5
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/tether/exploration)
 "mv" = (
@@ -8160,17 +8182,36 @@
 /turf/simulated/floor,
 /area/security/forensics)
 "mG" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/machinery/camera/network/security{
-	dir = 1
-	},
 /obj/structure/window/reinforced{
-	dir = 8
+	dir = 4
 	},
-/turf/simulated/open,
-/area/security/hallway)
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/white/border{
+	dir = 5
+	},
+/obj/effect/floor_decal/borderfloorwhite/corner2{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/white/bordercorner2{
+	icon_state = "bordercolorcorner2";
+	dir = 5
+	},
+/obj/structure/table/reinforced,
+/obj/machinery/computer/med_data/laptop,
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_x = 0;
+	pixel_y = 24
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/tiled/white,
+/area/security/forensics)
 "mH" = (
 /turf/simulated/wall/r_wall,
 /area/security/hallway)
@@ -8509,16 +8550,10 @@
 /turf/simulated/floor/tiled,
 /area/hallway/station/upper)
 "nh" = (
-/obj/structure/table/standard,
-/obj/item/weapon/hand_labeler,
-/obj/item/weapon/stamp{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/weapon/hand_labeler,
-/obj/item/weapon/folder/yellow,
-/turf/simulated/floor/tiled,
-/area/quartermaster/storage)
+/obj/structure/shuttle/engine/propulsion,
+/turf/simulated/floor/reinforced,
+/turf/simulated/shuttle/plating/airless/carry,
+/area/shuttle/excursion/tether)
 "ni" = (
 /obj/structure/bookcase,
 /obj/item/weapon/book/manual/security_space_law,
@@ -8716,11 +8751,36 @@
 /turf/simulated/floor/tiled/monotile,
 /area/tether/exploration)
 "nA" = (
-/obj/machinery/camera/network/exploration{
-	dir = 1
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/monotile,
-/area/tether/exploration)
+/obj/effect/floor_decal/corner/red/border{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/red/bordercorner2{
+	dir = 6
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/extinguisher_cabinet{
+	dir = 8;
+	icon_state = "extinguisher_closed";
+	pixel_x = 30
+	},
+/turf/simulated/floor/tiled,
+/area/security/hallway)
 "nB" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -8808,21 +8868,27 @@
 /turf/simulated/floor/carpet,
 /area/crew_quarters/heads/hos)
 "nG" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
 	},
-/obj/item/device/radio/intercom/department/security{
-	dir = 4;
-	icon_state = "secintercom";
-	pixel_x = 24;
-	pixel_y = 0
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_x = 0;
+	pixel_y = 28
 	},
-/obj/machinery/camera/network/security{
-	icon_state = "camera";
-	dir = 8
+/obj/structure/cable/green{
+	icon_state = "0-8"
 	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/heads/hos)
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/delivery)
 "nH" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
@@ -9343,6 +9409,7 @@
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/machinery/computer/secure_data,
+/obj/machinery/camera/network/security,
 /turf/simulated/floor/tiled,
 /area/security/security_processing)
 "oD" = (
@@ -9440,18 +9507,20 @@
 /turf/simulated/floor/tiled,
 /area/security/briefing_room)
 "oK" = (
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/red/border,
-/obj/item/device/radio/intercom/department/security{
-	dir = 2;
-	icon_state = "secintercom";
-	pixel_y = -24
+/obj/structure/table/standard,
+/obj/item/weapon/hand_labeler,
+/obj/item/weapon/stamp{
+	pixel_x = -3;
+	pixel_y = 3
 	},
-/obj/machinery/camera/network/security{
-	dir = 1
+/obj/item/weapon/hand_labeler,
+/obj/item/weapon/folder/yellow,
+/obj/machinery/camera/network/cargo{
+	dir = 1;
+	name = "security camera"
 	},
 /turf/simulated/floor/tiled,
-/area/security/briefing_room)
+/area/quartermaster/storage)
 "oL" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/red/border,
@@ -9838,37 +9907,18 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/evidence_storage)
 "pl" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/red/border{
-	dir = 8
-	},
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 10;
-	icon_state = "borderfloorcorner2";
-	pixel_x = 0
-	},
-/obj/effect/floor_decal/corner/red/bordercorner2{
-	dir = 10
-	},
-/obj/item/device/radio/intercom{
-	dir = 8;
-	pixel_x = -24
-	},
-/obj/machinery/camera/network/security{
-	icon_state = "camera";
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/table/steel,
-/obj/item/weapon/folder/red,
-/obj/item/weapon/folder/red{
-	pixel_x = 2;
-	pixel_y = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/machinery/recharger,
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/brown/border,
+/obj/effect/floor_decal/borderfloor/corner2,
+/obj/effect/floor_decal/corner/brown/bordercorner2,
 /turf/simulated/floor/tiled,
-/area/security/security_processing)
+/area/quartermaster/office)
 "pm" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 8
@@ -10089,10 +10139,21 @@
 /turf/simulated/floor/tiled,
 /area/security/hallway)
 "pH" = (
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/red/border,
-/obj/machinery/camera/network/security{
+/obj/effect/floor_decal/borderfloor{
+	dir = 1;
+	pixel_y = 0
+	},
+/obj/effect/floor_decal/corner/red/border{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/security/hallway)
@@ -10315,22 +10376,16 @@
 /turf/simulated/floor,
 /area/security/detectives_office)
 "qg" = (
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 8
+/obj/structure/table/woodentable,
+/obj/item/device/taperecorder{
+	pixel_x = -4;
+	pixel_y = 2
 	},
-/obj/effect/floor_decal/borderfloorblack/corner2{
-	icon_state = "borderfloorcorner2_black";
-	dir = 8
+/obj/item/device/radio/intercom/department/security{
+	pixel_y = -24
 	},
-/obj/structure/closet{
-	name = "Evidence Closet"
-	},
-/obj/machinery/camera/network/security{
-	icon_state = "camera";
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/security/evidence_storage)
+/turf/simulated/floor/carpet,
+/area/security/detectives_office)
 "qh" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -10761,40 +10816,17 @@
 /turf/simulated/floor/tiled,
 /area/security/hallway)
 "qS" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 4
+/obj/effect/floor_decal/spline/plain{
+	icon_state = "spline_plain";
+	dir = 9
 	},
-/obj/effect/floor_decal/corner/red/border{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 6
-	},
-/obj/effect/floor_decal/corner/red/bordercorner2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
+/obj/structure/closet/lawcloset,
 /obj/machinery/camera/network/security{
 	icon_state = "camera";
-	dir = 8
+	dir = 5
 	},
-/obj/structure/extinguisher_cabinet{
-	dir = 8;
-	icon_state = "extinguisher_closed";
-	pixel_x = 30
-	},
-/turf/simulated/floor/tiled,
-/area/security/hallway)
+/turf/simulated/floor/tiled/dark,
+/area/lawoffice)
 "qT" = (
 /turf/simulated/floor,
 /area/maintenance/station/elevator)
@@ -10839,18 +10871,16 @@
 /turf/simulated/floor,
 /area/quartermaster/delivery)
 "qZ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
+/obj/structure/flora/pottedplant/stoutbush,
 /obj/effect/floor_decal/borderfloor{
-	dir = 9
+	dir = 5
 	},
 /obj/effect/floor_decal/corner/brown/border{
-	dir = 9
+	dir = 5
 	},
+/obj/machinery/camera/network/cargo,
 /turf/simulated/floor/tiled,
-/area/quartermaster/delivery)
+/area/quartermaster/office)
 "ra" = (
 /obj/structure/disposalpipe/sortjunction/untagged/flipped{
 	dir = 1
@@ -11388,28 +11418,20 @@
 /turf/simulated/floor/tiled,
 /area/quartermaster/delivery)
 "rM" = (
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
+/obj/effect/floor_decal/spline/plain{
+	icon_state = "spline_plain";
+	dir = 5
 	},
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 28
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
 	},
-/obj/structure/cable/green{
-	icon_state = "0-8"
+/obj/machinery/camera/network/security{
+	icon_state = "camera";
+	dir = 8
 	},
-/obj/machinery/camera/network/cargo,
-/obj/effect/floor_decal/borderfloor{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/brown/border{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/quartermaster/delivery)
+/turf/simulated/floor/tiled/dark,
+/area/lawoffice)
 "rN" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -11569,16 +11591,19 @@
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
 "rY" = (
-/obj/structure/flora/pottedplant/stoutbush,
-/obj/machinery/camera/network/cargo,
+/obj/structure/table/steel,
+/obj/item/weapon/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
 /obj/effect/floor_decal/borderfloor{
-	dir = 5
+	dir = 6
 	},
 /obj/effect/floor_decal/corner/brown/border{
-	dir = 5
+	dir = 6
 	},
 /turf/simulated/floor/tiled,
-/area/quartermaster/office)
+/area/quartermaster/delivery)
 "rZ" = (
 /obj/structure/noticeboard,
 /turf/simulated/wall,
@@ -11958,6 +11983,10 @@
 /obj/effect/floor_decal/corner/brown/bordercorner2{
 	dir = 9
 	},
+/obj/machinery/camera/network/cargo{
+	dir = 1;
+	name = "security camera"
+	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
 "sD" = (
@@ -11979,22 +12008,28 @@
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
 "sE" = (
-/obj/structure/disposalpipe/segment{
+/obj/machinery/newscaster{
+	layer = 3.3;
+	pixel_x = -27;
+	pixel_y = 0
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 6
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 5
+	},
+/obj/structure/bed/chair{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/camera/network/cargo{
-	dir = 1;
-	name = "security camera"
-	},
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/brown/border,
-/obj/effect/floor_decal/borderfloor/corner2,
-/obj/effect/floor_decal/corner/brown/bordercorner2,
 /turf/simulated/floor/tiled,
-/area/quartermaster/office)
+/area/quartermaster/foyer)
 "sF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -12225,6 +12260,7 @@
 	icon_state = "pipe-j1";
 	dir = 4
 	},
+/obj/machinery/camera/network/security,
 /turf/simulated/floor/tiled,
 /area/security/hallway)
 "sY" = (
@@ -12292,25 +12328,12 @@
 /turf/simulated/floor/tiled,
 /area/security/hallway)
 "tb" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 1;
-	pixel_y = 0
+/obj/machinery/camera/network/security{
+	icon_state = "camera";
+	dir = 10
 	},
-/obj/effect/floor_decal/corner/red/border{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/camera/network/security,
-/turf/simulated/floor/tiled,
-/area/security/hallway)
+/turf/simulated/mineral/floor/vacuum,
+/area/security/nuke_storage)
 "tc" = (
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 5
@@ -12616,6 +12639,9 @@
 	},
 /obj/effect/floor_decal/corner/paleblue/bordercorner2{
 	dir = 9
+	},
+/obj/machinery/camera/network/tether{
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/station/upper)
@@ -13835,17 +13861,24 @@
 /turf/simulated/wall,
 /area/lawoffice)
 "vv" = (
-/obj/effect/floor_decal/spline/plain{
-	icon_state = "spline_plain";
-	dir = 9
+/obj/machinery/door/firedoor/glass/hidden/steel{
+	dir = 2
 	},
-/obj/structure/closet/lawcloset,
-/obj/machinery/camera/network/security{
-	icon_state = "camera";
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
-/area/lawoffice)
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/upper)
 "vw" = (
 /obj/effect/floor_decal/spline/plain{
 	icon_state = "spline_plain";
@@ -13964,20 +13997,17 @@
 /turf/simulated/floor/tiled/dark,
 /area/lawoffice)
 "vD" = (
-/obj/effect/floor_decal/spline/plain{
-	icon_state = "spline_plain";
-	dir = 5
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
 	},
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
+/obj/structure/disposalpipe/segment,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
 	},
-/obj/machinery/camera/network/security{
-	icon_state = "camera";
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
-/area/lawoffice)
+/turf/simulated/floor/tiled,
+/area/security/lobby)
 "vE" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 9
@@ -14030,6 +14060,10 @@
 	dir = 5
 	},
 /obj/machinery/computer/security,
+/obj/machinery/camera/network/security{
+	icon_state = "camera";
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
 /area/security/lobby)
 "vH" = (
@@ -14219,23 +14253,37 @@
 /turf/simulated/floor/tiled,
 /area/quartermaster/delivery)
 "vY" = (
-/obj/structure/table/steel,
-/obj/item/weapon/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
 	},
-/obj/machinery/camera/network/cargo{
-	dir = 1;
-	name = "security camera"
+/obj/machinery/newscaster{
+	layer = 3.3;
+	pixel_x = -27;
+	pixel_y = 0
 	},
 /obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/lightgrey/bordercorner2{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 6
 	},
-/obj/effect/floor_decal/corner/brown/border{
-	dir = 6
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
 	},
 /turf/simulated/floor/tiled,
-/area/quartermaster/delivery)
+/area/hallway/station/upper)
 "vZ" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled,
@@ -14511,31 +14559,18 @@
 /turf/simulated/open,
 /area/tether/exploration)
 "wF" = (
-/obj/machinery/newscaster{
-	layer = 3.3;
-	pixel_x = -27;
-	pixel_y = 0
+/obj/effect/floor_decal/corner/lightgrey{
+	dir = 9
 	},
-/obj/machinery/camera/network/tether{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/brown/border{
-	dir = 8
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
+/obj/effect/floor_decal/corner/lightgrey{
 	dir = 6
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 5
-	},
-/obj/structure/bed/chair{
-	dir = 4
+/obj/structure/table/bench/standard,
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 9
 	},
 /turf/simulated/floor/tiled,
-/area/quartermaster/foyer)
+/area/hallway/station/upper)
 "wG" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -14584,11 +14619,16 @@
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
 "wL" = (
-/obj/machinery/camera/network/security{
-	c_tag = "SEC - Vault Exterior South"
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/lightgrey/border,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 8
 	},
-/turf/simulated/mineral/floor/vacuum,
-/area/security/nuke_storage)
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/foyer)
 "wM" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/structure/table/reinforced,
@@ -14788,25 +14828,25 @@
 /turf/simulated/floor/tiled,
 /area/hallway/station/upper)
 "xc" = (
-/obj/machinery/door/firedoor/glass/hidden/steel{
-	dir = 2
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
 	},
-/obj/machinery/camera/network/tether,
-/obj/effect/floor_decal/borderfloor{
-	dir = 1
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
 	},
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 1
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals7,
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 4
-	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
-/area/hallway/station/upper)
+/area/quartermaster/office)
 "xd" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -14884,17 +14924,11 @@
 /turf/simulated/floor/tiled,
 /area/hallway/station/upper)
 "xg" = (
-/obj/effect/floor_decal/borderfloor{
+/obj/structure/table/bench/wooden,
+/obj/machinery/camera/network/tether{
 	dir = 1
 	},
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 1
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7,
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/wood,
 /area/hallway/station/upper)
 "xh" = (
 /obj/structure/sign/directions/cargo{
@@ -15122,12 +15156,24 @@
 /turf/simulated/wall/r_wall,
 /area/security/nuke_storage)
 "xx" = (
-/obj/machinery/camera/network/security{
-	c_tag = "SEC - Vault Exterior North";
+/obj/effect/floor_decal/borderfloor{
 	dir = 1
 	},
-/turf/simulated/mineral/floor/vacuum,
-/area/security/nuke_storage)
+/obj/effect/floor_decal/corner/red/border{
+	dir = 1
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/item/device/radio/intercom{
+	dir = 1;
+	name = "Station Intercom (General)";
+	pixel_y = 21
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/turf/simulated/floor/tiled,
+/area/hallway/station/upper)
 "xy" = (
 /obj/effect/floor_decal/spline/plain{
 	icon_state = "spline_plain";
@@ -15317,21 +15363,31 @@
 /turf/simulated/floor/tiled,
 /area/security/lobby)
 "xM" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 1
 	},
-/obj/machinery/camera/network/security{
-	icon_state = "camera";
-	dir = 8
+/obj/effect/floor_decal/corner/red/bordercorner2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	icon_state = "intact-scrubbers";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/security/lobby)
+/area/hallway/station/upper)
 "xN" = (
 /obj/structure/lattice,
 /obj/machinery/door/firedoor/glass,
@@ -15357,40 +15413,14 @@
 /turf/simulated/floor,
 /area/maintenance/station/elevator)
 "xP" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
+/obj/structure/table/standard,
+/obj/item/weapon/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
 	},
-/obj/machinery/newscaster{
-	layer = 3.3;
-	pixel_x = -27;
-	pixel_y = 0
-	},
-/obj/machinery/camera/network/tether{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 8
-	},
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/lightgrey/bordercorner2{
-	dir = 8
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 6
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/station/upper)
+/obj/item/device/megaphone,
+/turf/simulated/floor/wood,
+/area/quartermaster/qm)
 "xQ" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -15830,19 +15860,12 @@
 /turf/simulated/floor/tiled,
 /area/hallway/station/upper)
 "yB" = (
-/obj/effect/floor_decal/corner/lightgrey{
-	dir = 9
+/obj/machinery/camera/network/security{
+	icon_state = "camera";
+	dir = 8
 	},
-/obj/effect/floor_decal/corner/lightgrey{
-	dir = 6
-	},
-/obj/machinery/camera/network/tether,
-/obj/structure/table/bench/standard,
-/obj/effect/floor_decal/steeldecal/steel_decals6{
-	dir = 9
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/station/upper)
+/turf/space,
+/area/security/nuke_storage)
 "yC" = (
 /obj/effect/floor_decal/corner/lightgrey{
 	dir = 6
@@ -16069,19 +16092,15 @@
 /turf/simulated/floor/tiled,
 /area/hallway/station/upper)
 "yR" = (
-/obj/machinery/camera/network/tether{
-	dir = 1
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
 	},
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/lightgrey/border,
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 8
+/obj/machinery/camera/network/security{
+	icon_state = "camera";
+	dir = 5
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/quartermaster/foyer)
+/turf/simulated/floor/tiled/dark,
+/area/security/nuke_storage)
 "yS" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/brown/border,
@@ -16149,26 +16168,19 @@
 /turf/simulated/floor/tiled,
 /area/quartermaster/foyer)
 "yY" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
 	},
 /obj/effect/floor_decal/borderfloor{
-	dir = 6
+	dir = 9
 	},
 /obj/effect/floor_decal/corner/brown/border{
-	dir = 6
+	dir = 9
 	},
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 6
-	},
-/obj/effect/floor_decal/corner/brown/bordercorner2{
-	dir = 6
-	},
-/obj/structure/closet/emcloset,
+/obj/machinery/camera/network/cargo,
 /turf/simulated/floor/tiled,
-/area/quartermaster/foyer)
+/area/quartermaster/delivery)
 "yZ" = (
 /obj/machinery/door/airlock/glass_mining{
 	id_tag = "cargodoor";
@@ -16198,20 +16210,15 @@
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
 "zb" = (
-/obj/structure/table/standard,
-/obj/machinery/light_switch{
-	pixel_x = -12;
-	pixel_y = -24
+/obj/machinery/conveyor{
+	dir = 1;
+	id = "packageSort1"
 	},
-/obj/item/device/retail_scanner/civilian{
-	dir = 1
+/obj/machinery/camera/network/cargo{
+	dir = 4
 	},
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/brown/border,
-/obj/effect/floor_decal/borderfloor/corner2,
-/obj/effect/floor_decal/corner/brown/bordercorner2,
-/turf/simulated/floor/tiled,
-/area/quartermaster/office)
+/turf/simulated/floor,
+/area/quartermaster/delivery)
 "zc" = (
 /obj/structure/table/standard,
 /obj/item/weapon/hand_labeler,
@@ -16789,23 +16796,24 @@
 /turf/simulated/floor/tiled,
 /area/hallway/station/upper)
 "zX" = (
-/obj/effect/floor_decal/borderfloor{
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/lightgrey/border,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 1
-	},
-/obj/effect/floor_decal/corner/red/border{
-	dir = 1
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/item/device/radio/intercom{
-	dir = 1;
-	name = "Station Intercom (General)";
-	pixel_y = 21
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 4
+	dir = 8
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals7,
-/obj/machinery/camera/network/tether,
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/lightgrey/bordercorner2{
+	dir = 9
+	},
+/obj/item/device/radio/intercom{
+	dir = 2;
+	pixel_y = -24
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/station/upper)
 "zY" = (
@@ -17233,6 +17241,10 @@
 /obj/effect/floor_decal/corner/paleblue/border{
 	dir = 5
 	},
+/obj/machinery/camera/network/medbay{
+	icon_state = "camera";
+	dir = 9
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/chemistry)
 "AA" = (
@@ -17360,15 +17372,16 @@
 /turf/simulated/floor/wood,
 /area/quartermaster/qm)
 "AK" = (
-/obj/structure/table/standard,
-/obj/item/weapon/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/item/device/megaphone,
-/obj/machinery/camera/network/cargo,
-/turf/simulated/floor/wood,
-/area/quartermaster/qm)
+/obj/effect/floor_decal/corner_steel_grid{
+	dir = 10
+	},
+/turf/simulated/floor/tiled,
+/area/teleporter/departing)
 "AL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -17514,14 +17527,11 @@
 /area/medical/reception)
 "Ba" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
+	dir = 1
 	},
-/obj/machinery/camera/network/security{
-	c_tag = "SEC - Vault";
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/security/nuke_storage)
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/tiled,
+/area/tether/station/stairs_three)
 "Bb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -17957,6 +17967,10 @@
 /obj/effect/floor_decal/steeldecal/steel_decals9{
 	dir = 4
 	},
+/obj/machinery/camera/network/medbay{
+	icon_state = "camera";
+	dir = 9
+	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/medbay_emt_bay)
 "BC" = (
@@ -18035,20 +18049,18 @@
 /turf/simulated/floor/tiled,
 /area/maintenance/station/cargo)
 "BL" = (
-/obj/structure/bed/chair{
-	dir = 4
+/obj/machinery/embedded_controller/radio/simple_docking_controller{
+	frequency = 1380;
+	id_tag = "cargo_bay";
+	layer = 3.3;
+	name = "cargo bay hatch controller";
+	pixel_x = 30;
+	pixel_y = 0;
+	req_one_access = list(13,31);
+	tag_door = "cargo_bay_door"
 	},
-/obj/machinery/camera/network/medbay{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/reception)
+/turf/simulated/floor/tiled,
+/area/quartermaster/storage)
 "BM" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 8
@@ -18098,12 +18110,24 @@
 /turf/simulated/floor/wood,
 /area/quartermaster/qm)
 "BQ" = (
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/camera/network/cargo{
+/obj/structure/table/reinforced,
+/obj/machinery/reagentgrinder,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
-/area/quartermaster/storage)
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 4;
+	icon_state = "extinguisher_closed";
+	pixel_x = -30
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/chemistry)
 "BR" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled,
@@ -18270,29 +18294,15 @@
 /turf/simulated/floor/tiled,
 /area/hallway/station/upper)
 "Cg" = (
-/obj/machinery/camera/network/tether{
-	dir = 1
+/obj/structure/table/rack{
+	dir = 8;
+	layer = 2.9
 	},
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/lightgrey/border,
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 1
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 8
-	},
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 9
-	},
-/obj/effect/floor_decal/corner/lightgrey/bordercorner2{
-	dir = 9
-	},
-/obj/item/device/radio/intercom{
-	dir = 2;
-	pixel_y = -24
+/obj/effect/decal/cleanable/cobweb{
+	icon_state = "cobweb2"
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/station/upper)
+/area/quartermaster/warehouse)
 "Ch" = (
 /obj/effect/floor_decal/steeldecal/steel_decals6{
 	dir = 8
@@ -18937,27 +18947,26 @@
 /turf/simulated/wall,
 /area/medical/reception)
 "Dm" = (
-/obj/structure/table/reinforced,
-/obj/machinery/reagentgrinder,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
+/obj/structure/table/rack,
+/obj/item/device/defib_kit/compact/loaded,
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 6
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals9{
 	dir = 4
 	},
-/obj/machinery/camera/network/medbay{
-	dir = 4
+/obj/effect/floor_decal/steeldecal/steel_decals9{
+	dir = 1
 	},
-/obj/effect/floor_decal/borderfloorwhite{
+/obj/effect/floor_decal/steeldecal/steel_decals9{
 	dir = 8
 	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 8
-	},
-/obj/structure/extinguisher_cabinet{
-	dir = 4;
-	icon_state = "extinguisher_closed";
-	pixel_x = -30
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/chemistry)
+/obj/effect/floor_decal/steeldecal/steel_decals9,
+/turf/simulated/floor/tiled/dark,
+/area/medical/medbay_emt_bay)
 "Dn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	icon_state = "intact-scrubbers";
@@ -19165,17 +19174,26 @@
 /turf/simulated/floor/tiled,
 /area/teleporter/departing)
 "DF" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/table/glass,
+/obj/item/weapon/storage/box/cups,
+/obj/item/weapon/storage/box/cups{
+	pixel_x = 4;
+	pixel_y = 4
 	},
-/obj/effect/floor_decal/corner_steel_grid{
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/paleblue/border,
+/obj/effect/floor_decal/borderfloorwhite/corner2{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner2{
+	dir = 9
+	},
+/obj/machinery/camera/network/medbay{
+	icon_state = "camera";
 	dir = 10
 	},
-/obj/machinery/camera/network/civilian,
-/turf/simulated/floor/tiled,
-/area/teleporter/departing)
+/turf/simulated/floor/tiled/white,
+/area/medical/reception)
 "DG" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -19239,6 +19257,9 @@
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals6{
 	dir = 1
+	},
+/obj/machinery/camera/network/tether{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/tether/station/stairs_three)
@@ -19399,6 +19420,9 @@
 	icon_state = "0-2"
 	},
 /obj/structure/cable/green,
+/obj/machinery/camera/network/engineering{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/medical)
 "DV" = (
@@ -19656,11 +19680,15 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/reception)
 "Ep" = (
-/obj/structure/table/standard,
-/obj/machinery/photocopier/faxmachine{
-	department = "Quartermaster-Office"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
 	},
-/turf/simulated/floor/wood,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/item/toy/plushie/squid/blue,
+/obj/machinery/camera/network/cargo,
+/turf/simulated/floor/outdoors/grass/forest,
 /area/quartermaster/qm)
 "Eq" = (
 /obj/structure/table/standard,
@@ -19799,29 +19827,30 @@
 /turf/simulated/floor/tiled,
 /area/tether/station/stairs_three)
 "EF" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
+/obj/machinery/button/remote/blast_door{
+	id = "qm_warehouse";
+	name = "Warehouse Door Control";
+	pixel_x = -26;
+	pixel_y = 0;
+	req_access = list(31)
 	},
-/obj/machinery/camera/network/tether{
-	dir = 9
-	},
-/obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled,
-/area/tether/station/stairs_three)
+/area/quartermaster/storage)
 "EG" = (
-/obj/structure/table/woodentable,
-/obj/item/device/taperecorder{
-	pixel_x = -4;
-	pixel_y = 2
-	},
-/obj/machinery/camera/network/security{
+/obj/effect/floor_decal/borderfloorwhite{
 	dir = 1
 	},
-/obj/item/device/radio/intercom/department/security{
-	pixel_y = -24
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 1
 	},
-/turf/simulated/floor/carpet,
-/area/security/detectives_office)
+/obj/effect/floor_decal/borderfloorwhite/corner2{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner2{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/sleeper)
 "EH" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -20160,29 +20189,16 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/reception)
 "Fi" = (
-/obj/structure/table/rack,
-/obj/item/device/defib_kit/compact/loaded,
-/obj/machinery/camera/network/medbay{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 9
-	},
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 6
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals9{
-	dir = 4
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals9{
-	dir = 1
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals9{
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals9,
-/turf/simulated/floor/tiled/dark,
-/area/medical/medbay_emt_bay)
+/obj/machinery/camera/network/medbay{
+	icon_state = "camera";
+	dir = 9
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/heads/cmo)
 "Fj" = (
 /turf/simulated/wall,
 /area/quartermaster/warehouse)
@@ -20229,22 +20245,12 @@
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
 "Fm" = (
-/obj/machinery/embedded_controller/radio/simple_docking_controller{
-	frequency = 1380;
-	id_tag = "cargo_bay";
-	layer = 3.3;
-	name = "cargo bay hatch controller";
-	pixel_x = 30;
-	pixel_y = 0;
-	req_one_access = list(13,31);
-	tag_door = "cargo_bay_door"
-	},
-/obj/machinery/camera/network/cargo{
-	c_tag = "CRG - Cargo Bay East";
-	dir = 9
-	},
-/turf/simulated/floor/tiled,
-/area/quartermaster/storage)
+/obj/structure/closet/secure_closet/medical3,
+/obj/item/weapon/soap/nanotrasen,
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/paleblue/border,
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay_primary_storage)
 "Fn" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
@@ -20748,19 +20754,17 @@
 /turf/simulated/floor/tiled/steel,
 /area/quartermaster/warehouse)
 "Gc" = (
-/obj/structure/table/rack{
-	dir = 8;
-	layer = 2.9
+/obj/structure/table/glass,
+/obj/machinery/recharger,
+/obj/item/weapon/tool/screwdriver,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 8
 	},
-/obj/machinery/camera/network/cargo{
-	c_tag = "CRG - Cargo Warehouse";
-	dir = 9
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 8
 	},
-/obj/effect/decal/cleanable/cobweb{
-	icon_state = "cobweb2"
-	},
-/turf/simulated/floor/tiled,
-/area/quartermaster/warehouse)
+/turf/simulated/floor/tiled/white,
+/area/medical/sleeper)
 "Gd" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/vehicle/train/trolley,
@@ -20793,6 +20797,9 @@
 /area/teleporter/departing)
 "Gh" = (
 /obj/effect/floor_decal/techfloor/orange,
+/obj/machinery/camera/network/tether{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/teleporter/departing)
 "Gi" = (
@@ -20882,17 +20889,23 @@
 /area/medical/reception)
 "Gp" = (
 /obj/structure/table/glass,
-/obj/item/weapon/storage/box/cups,
-/obj/item/weapon/storage/box/cups{
-	pixel_x = 4;
-	pixel_y = 4
+/obj/item/weapon/storage/box/body_record_disk,
+/obj/item/device/sleevemate,
+/obj/item/weapon/paper{
+	desc = "";
+	info = "Bodies designed on the design console must be saved to a disk, provided on the front desk counter, then placed into the resleeving console for printing.";
+	name = "Body Designer Note"
 	},
-/obj/effect/floor_decal/borderfloorwhite,
-/obj/effect/floor_decal/corner/paleblue/border,
-/obj/effect/floor_decal/borderfloorwhite/corner2{
-	dir = 9
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 6
 	},
-/obj/effect/floor_decal/corner/paleblue/bordercorner2{
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 6
+	},
+/obj/effect/floor_decal/borderfloorwhite/corner2,
+/obj/effect/floor_decal/corner/paleblue/bordercorner2,
+/obj/machinery/camera/network/medbay{
+	icon_state = "camera";
 	dir = 9
 	},
 /turf/simulated/floor/tiled/white,
@@ -21019,27 +21032,22 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/reception)
 "Gx" = (
+/obj/item/roller,
+/obj/item/roller{
+	pixel_y = 8
+	},
+/obj/item/roller{
+	pixel_y = 16
+	},
 /obj/structure/table/glass,
-/obj/item/weapon/storage/box/body_record_disk,
-/obj/item/device/sleevemate,
-/obj/item/weapon/paper{
-	desc = "";
-	info = "Bodies designed on the design console must be saved to a disk, provided on the front desk counter, then placed into the resleeving console for printing.";
-	name = "Body Designer Note"
-	},
-/obj/machinery/camera/network/medbay{
-	dir = 8
-	},
 /obj/effect/floor_decal/borderfloorwhite{
-	dir = 6
+	dir = 4
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
-	dir = 6
+	dir = 4
 	},
-/obj/effect/floor_decal/borderfloorwhite/corner2,
-/obj/effect/floor_decal/corner/paleblue/bordercorner2,
 /turf/simulated/floor/tiled/white,
-/area/medical/reception)
+/area/medical/sleeper)
 "Gy" = (
 /obj/machinery/power/apc{
 	dir = 2;
@@ -21234,29 +21242,10 @@
 /turf/simulated/floor/tiled,
 /area/quartermaster/storage)
 "GN" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -27
-	},
-/obj/machinery/camera/network/cargo{
-	c_tag = "CRG - Cargo Office South";
-	dir = 5
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 5
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled,
-/area/quartermaster/office)
+/obj/structure/flora/pottedplant,
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/medbreak)
 "GO" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
@@ -21950,22 +21939,32 @@
 	pixel_x = 0;
 	pixel_y = 32
 	},
+/obj/machinery/camera/network/medbay{
+	icon_state = "camera";
+	dir = 4
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
 "HL" = (
-/obj/machinery/camera/network/medbay,
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 1
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 1
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/obj/effect/floor_decal/borderfloorwhite/corner2{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
 	},
-/obj/effect/floor_decal/corner/paleblue/bordercorner2{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	icon_state = "intact-scrubbers";
+	dir = 5
 	},
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/paleblue/border,
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
 "HM" = (
@@ -22062,6 +22061,10 @@
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
 	dir = 8
+	},
+/obj/machinery/camera/network/medbay{
+	icon_state = "camera";
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay_primary_storage)
@@ -22721,6 +22724,9 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/machinery/camera/network/engineering{
+	dir = 1
+	},
 /turf/simulated/floor,
 /area/maintenance/substation/cargo)
 "IQ" = (
@@ -22758,18 +22764,12 @@
 /turf/simulated/floor/tiled,
 /area/quartermaster/warehouse)
 "IU" = (
-/obj/machinery/button/remote/blast_door{
-	id = "qm_warehouse";
-	name = "Warehouse Door Control";
-	pixel_x = -26;
-	pixel_y = 0;
-	req_access = list(31)
-	},
-/obj/machinery/camera/network/cargo{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/quartermaster/storage)
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/paleblue/border,
+/obj/effect/floor_decal/borderfloorwhite/corner2,
+/obj/effect/floor_decal/corner/paleblue/bordercorner2,
+/turf/simulated/floor/tiled/white,
+/area/medical/sleeper)
 "IV" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 5;
@@ -22909,15 +22909,21 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/heads/cmo)
 "Jk" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 4
 	},
 /obj/machinery/camera/network/medbay{
-	dir = 8
+	icon_state = "camera";
+	dir = 9
 	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/heads/cmo)
+/turf/simulated/floor/tiled/white,
+/area/hallway/secondary/escape/medical_escape_pod_hallway)
 "Jl" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -23112,6 +23118,10 @@
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
 	dir = 4
+	},
+/obj/machinery/camera/network/medbay{
+	icon_state = "camera";
+	dir = 9
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
@@ -23423,15 +23433,19 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/virologyaccess)
 "Kc" = (
-/obj/structure/closet/secure_closet/medical3,
-/obj/item/weapon/soap/nanotrasen,
-/obj/machinery/camera/network/medbay{
-	dir = 1
+/obj/structure/closet/wardrobe/virology_white,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
 	},
-/obj/effect/floor_decal/borderfloorwhite,
-/obj/effect/floor_decal/corner/paleblue/border,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 9
+	},
 /turf/simulated/floor/tiled/white,
-/area/medical/medbay_primary_storage)
+/area/medical/virologyaccess)
 "Kd" = (
 /obj/structure/closet/secure_closet/medical3,
 /obj/item/weapon/soap/nanotrasen,
@@ -23480,20 +23494,10 @@
 /turf/simulated/open,
 /area/medical/medbay_primary_storage)
 "Kj" = (
-/obj/structure/table/glass,
-/obj/machinery/recharger,
-/obj/item/weapon/tool/screwdriver,
-/obj/machinery/camera/network/medbay{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 8
-	},
+/obj/machinery/vending/cola,
+/obj/effect/floor_decal/corner/paleblue/diagonal,
 /turf/simulated/floor/tiled/white,
-/area/medical/sleeper)
+/area/crew_quarters/medbreak)
 "Kk" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -23562,32 +23566,30 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
 "Kq" = (
-/obj/machinery/camera/network/security{
-	c_tag = "SEC - Vault Exterior West";
-	dir = 8
-	},
-/turf/space,
+/obj/machinery/camera/network/security,
+/turf/simulated/mineral/floor/vacuum,
 /area/security/nuke_storage)
 "Kr" = (
-/obj/item/roller,
-/obj/item/roller{
-	pixel_y = 8
-	},
-/obj/item/roller{
-	pixel_y = 16
-	},
-/obj/structure/table/glass,
-/obj/machinery/camera/network/medbay{
+/obj/effect/floor_decal/borderfloor{
 	dir = 8
 	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 4
+/obj/effect/floor_decal/corner/red/border{
+	dir = 8
 	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/white,
-/area/medical/sleeper)
+/obj/structure/disposalpipe/segment,
+/obj/machinery/camera/network/security{
+	icon_state = "camera";
+	dir = 5
+	},
+/turf/simulated/floor/tiled,
+/area/security/hallway)
 "Ks" = (
 /obj/structure/table/glass,
 /obj/item/bodybag/cryobag,
@@ -24014,11 +24016,12 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
 "Lf" = (
-/obj/structure/flora/pottedplant,
-/obj/machinery/camera/network/medbay,
-/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9;
+	pixel_y = 0
+	},
 /turf/simulated/floor/tiled/white,
-/area/crew_quarters/medbreak)
+/area/medical/virology)
 "Lg" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
@@ -24377,30 +24380,10 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
 "LS" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 5
-	},
-/obj/machinery/camera/network/medbay{
-	dir = 1
-	},
-/obj/effect/floor_decal/borderfloorwhite,
-/obj/effect/floor_decal/corner/paleblue/border,
-/turf/simulated/floor/tiled/white,
-/area/medical/sleeper)
+/obj/machinery/camera/network/security,
+/mob/living/simple_mob/animal/sif/shantak/scruffy,
+/turf/simulated/floor/carpet,
+/area/crew_quarters/heads/hos)
 "LT" = (
 /obj/effect/landmark/start{
 	name = "Paramedic"
@@ -25302,15 +25285,16 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
 "Ne" = (
-/obj/machinery/camera/network/medbay{
-	dir = 1
+/obj/structure/closet/crate/freezer,
+/obj/item/weapon/virusdish/random,
+/obj/item/weapon/virusdish/random,
+/obj/item/weapon/virusdish/random,
+/obj/item/weapon/virusdish/random,
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 4
 	},
-/obj/effect/floor_decal/borderfloorwhite,
-/obj/effect/floor_decal/corner/paleblue/border,
-/obj/effect/floor_decal/borderfloorwhite/corner2,
-/obj/effect/floor_decal/corner/paleblue/bordercorner2,
 /turf/simulated/floor/tiled/white,
-/area/medical/sleeper)
+/area/medical/virology)
 "Nf" = (
 /obj/structure/bed/chair{
 	dir = 1
@@ -25368,20 +25352,21 @@
 /turf/simulated/floor/tiled/white,
 /area/hallway/secondary/escape/medical_escape_pod_hallway)
 "Nk" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/obj/machinery/camera/network/medbay{
-	dir = 8
-	},
-/obj/effect/floor_decal/borderfloorwhite{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 4
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/white,
-/area/hallway/secondary/escape/medical_escape_pod_hallway)
+/obj/machinery/camera/network/exploration{
+	icon_state = "camera";
+	dir = 9
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/tether/exploration)
 "Nl" = (
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/medical_restroom)
@@ -25407,16 +25392,29 @@
 /obj/structure/table/standard,
 /obj/item/weapon/storage/box/cups,
 /obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/machinery/camera/network/medbay{
+	icon_state = "camera";
+	dir = 4
+	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/medbreak)
 "Np" = (
-/obj/structure/shuttle/engine/propulsion{
-	dir = 8;
-	icon_state = "propulsion_l"
+/obj/structure/closet/secure_closet/detective,
+/obj/item/weapon/reagent_containers/spray/pepper,
+/obj/item/weapon/gun/energy/taser,
+/obj/item/device/camera{
+	desc = "A one use - polaroid camera. 30 photos left.";
+	name = "detectives camera";
+	pictures_left = 30;
+	pixel_x = 2;
+	pixel_y = 3
 	},
-/turf/space,
-/turf/simulated/shuttle/plating/airless/carry,
-/area/shuttle/large_escape_pod1/station)
+/obj/machinery/camera/network/security{
+	icon_state = "camera";
+	dir = 10
+	},
+/turf/simulated/floor/carpet,
+/area/security/detectives_office)
 "Nq" = (
 /obj/structure/table/standard,
 /obj/item/weapon/storage/box/donkpockets,
@@ -25585,20 +25583,41 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
 "NE" = (
-/obj/structure/closet/wardrobe/virology_white,
-/obj/machinery/firealarm{
+/obj/effect/floor_decal/borderfloor{
 	dir = 4;
-	pixel_x = 24
+	pixel_x = -16
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
+/obj/effect/floor_decal/corner/red/border{
+	dir = 4;
+	pixel_x = -16
 	},
-/obj/machinery/camera/network/medbay,
-/obj/effect/floor_decal/industrial/warning{
-	dir = 9
+/obj/effect/floor_decal/corner/red{
+	icon_state = "corner_white";
+	dir = 6
 	},
-/turf/simulated/floor/tiled/white,
-/area/medical/virologyaccess)
+/obj/structure/table/steel,
+/obj/item/bodybag/cryobag{
+	pixel_x = 6
+	},
+/obj/item/weapon/storage/firstaid/regular{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/machinery/recharger/wallcharger{
+	pixel_x = 32;
+	pixel_y = -9
+	},
+/obj/machinery/recharger/wallcharger{
+	pixel_x = 32;
+	pixel_y = 2
+	},
+/obj/item/weapon/reagent_containers/spray/cleaner,
+/obj/machinery/camera/network/security{
+	icon_state = "camera";
+	dir = 10
+	},
+/turf/simulated/floor/tiled,
+/area/security/hallway)
 "NF" = (
 /obj/machinery/embedded_controller/radio/simple_docking_controller/escape_pod_berth{
 	frequency = 1380;
@@ -25645,12 +25664,14 @@
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/medbreak)
 "NI" = (
-/obj/structure/shuttle/engine/propulsion{
-	dir = 8
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/red/border,
+/obj/machinery/camera/network/security{
+	icon_state = "camera";
+	dir = 10
 	},
-/turf/space,
-/turf/simulated/shuttle/plating/airless/carry,
-/area/shuttle/large_escape_pod1/station)
+/turf/simulated/floor/tiled,
+/area/security/hallwayaux)
 "NJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/universal{
 	dir = 4
@@ -25717,24 +25738,29 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/virologyaccess)
 "NQ" = (
-/obj/structure/closet/l3closet/virology,
-/obj/machinery/access_button{
-	command = "cycle_interior";
-	frequency = 1379;
-	master_tag = "virology_airlock_control";
-	name = "Virology Access Button";
-	pixel_x = -8;
-	pixel_y = -28;
-	req_access = list(39)
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
-/obj/machinery/light{
-	dir = 4
+/obj/effect/floor_decal/borderfloor{
+	dir = 6
 	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 10
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 6
 	},
-/turf/simulated/floor/tiled/white,
-/area/medical/virologyaccess)
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/brown/bordercorner2{
+	dir = 6
+	},
+/obj/structure/closet/emcloset,
+/obj/machinery/camera/network/tether{
+	dir = 9
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/foyer)
 "NR" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
@@ -25789,13 +25815,30 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/virologyaccess)
 "NY" = (
-/obj/structure/shuttle/engine/propulsion{
-	dir = 8;
-	icon_state = "propulsion_r"
+/obj/effect/floor_decal/borderfloor{
+	dir = 1;
+	pixel_y = 0
 	},
-/turf/space,
-/turf/simulated/shuttle/plating/airless/carry,
-/area/shuttle/large_escape_pod1/station)
+/obj/effect/floor_decal/corner/red/border{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/camera/network/security,
+/turf/simulated/floor/tiled,
+/area/security/hallwayaux)
 "NZ" = (
 /obj/structure/shuttle/engine/heater{
 	dir = 8
@@ -25966,14 +26009,27 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
 "Or" = (
-/obj/machinery/disease2/diseaseanalyser,
-/obj/machinery/alarm{
-	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 24
+/obj/structure/closet/l3closet/virology,
+/obj/machinery/access_button{
+	command = "cycle_interior";
+	frequency = 1379;
+	master_tag = "virology_airlock_control";
+	name = "Virology Access Button";
+	pixel_x = -8;
+	pixel_y = -28;
+	req_access = list(39)
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 10
+	},
+/obj/machinery/camera/network/medbay{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/virology)
+/area/medical/virologyaccess)
 "Os" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -26217,18 +26273,23 @@
 	dir = 8
 	},
 /obj/machinery/disposal,
+/obj/machinery/camera/network/medbay{
+	icon_state = "camera";
+	dir = 10
+	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/medbreak)
 "OQ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
-	},
-/obj/machinery/camera/network/medbay{
+/obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/white,
-/area/medical/virology)
+/obj/machinery/disposal,
+/obj/machinery/camera/network/security{
+	icon_state = "camera";
+	dir = 10
+	},
+/turf/simulated/floor/wood,
+/area/security/breakroom)
 "OR" = (
 /obj/structure/table/glass,
 /obj/item/weapon/storage/fancy/vials,
@@ -26287,6 +26348,15 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
+"OW" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/red/border,
+/obj/machinery/camera/network/security{
+	icon_state = "camera";
+	dir = 10
+	},
+/turf/simulated/floor/tiled,
+/area/security/briefing_room)
 "OX" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 8
@@ -26298,14 +26368,12 @@
 /turf/simulated/floor/bluegrid,
 /area/ai_core_foyer)
 "OY" = (
-/obj/item/weapon/storage/secure/safe{
-	pixel_x = -28
+/obj/machinery/camera/network/cargo{
+	icon_state = "camera";
+	dir = 8
 	},
-/obj/structure/table/glass,
-/obj/item/weapon/storage/lockbox/vials,
-/obj/item/weapon/reagent_containers/dropper,
-/turf/simulated/floor/tiled/white,
-/area/medical/virology)
+/turf/simulated/floor/tiled,
+/area/quartermaster/storage)
 "OZ" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -26509,6 +26577,21 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
+"Pq" = (
+/obj/machinery/camera/network/security{
+	icon_state = "camera";
+	dir = 10
+	},
+/turf/simulated/open,
+/area/security/hallway)
+"Pr" = (
+/obj/effect/floor_decal/techfloor,
+/obj/machinery/camera/network/command{
+	icon_state = "camera";
+	dir = 10
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ai_core_foyer)
 "Ps" = (
 /obj/machinery/atmospherics/tvalve/bypass,
 /obj/machinery/light{
@@ -26519,6 +26602,18 @@
 	},
 /turf/simulated/floor/plating,
 /area/medical/virology)
+"Pt" = (
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/paleblue/border,
+/obj/machinery/camera/network/medbay{
+	icon_state = "camera";
+	dir = 10
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/sleeper)
 "Pu" = (
 /obj/structure/table/glass,
 /obj/item/weapon/storage/box/monkeycubes,
@@ -26548,26 +26643,22 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
 "Pw" = (
-/obj/structure/closet/crate/freezer,
-/obj/item/weapon/virusdish/random,
-/obj/item/weapon/virusdish/random,
-/obj/item/weapon/virusdish/random,
-/obj/item/weapon/virusdish/random,
-/obj/machinery/camera/network/medbay{
-	dir = 1
+/obj/machinery/disease2/diseaseanalyser,
+/obj/machinery/alarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
 	},
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 4
-	},
+/obj/machinery/camera/network/medbay,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
 "Px" = (
-/obj/machinery/smartfridge/secure/virology,
-/obj/machinery/atmospherics/pipe/simple/hidden/black{
+/obj/machinery/camera/network/exploration{
+	icon_state = "camera";
 	dir = 5
 	},
-/turf/simulated/floor/tiled/white,
-/area/medical/virology)
+/turf/simulated/floor/tiled/monotile,
+/area/tether/exploration)
 "Py" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
 	dir = 4
@@ -26612,15 +26703,16 @@
 /turf/simulated/floor/bluegrid,
 /area/ai_core_foyer)
 "PD" = (
-/obj/structure/reagent_dispensers/water_cooler/full,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
+/obj/machinery/smartfridge/secure/virology,
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 5
 	},
 /obj/machinery/camera/network/medbay{
-	dir = 4
+	icon_state = "camera";
+	dir = 9
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/virologyisolation)
+/area/medical/virology)
 "PE" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -26675,6 +26767,17 @@
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/virologyisolation)
+"PI" = (
+/obj/structure/reagent_dispensers/water_cooler/full,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/machinery/camera/network/medbay{
+	icon_state = "camera";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
@@ -26814,18 +26917,168 @@
 /obj/item/weapon/stool/padded,
 /turf/simulated/floor/tiled/white,
 /area/medical/virologyisolation)
+"PZ" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/camera/network/exploration{
+	icon_state = "camera";
+	dir = 9
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/tether/exploration)
 "Qa" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
 /area/medical/virologyisolation)
+"Qb" = (
+/obj/machinery/camera/network/exploration{
+	icon_state = "camera";
+	dir = 9
+	},
+/turf/simulated/open,
+/area/tether/exploration)
+"Qc" = (
+/obj/structure/table/standard,
+/obj/machinery/light_switch{
+	pixel_x = -12;
+	pixel_y = -24
+	},
+/obj/item/device/retail_scanner/civilian{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/brown/border,
+/obj/effect/floor_decal/borderfloor/corner2,
+/obj/effect/floor_decal/corner/brown/bordercorner2,
+/obj/machinery/camera/network/cargo{
+	dir = 1;
+	name = "security camera"
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/office)
+"Qd" = (
+/obj/structure/table/standard,
+/obj/machinery/photocopier/faxmachine{
+	department = "Quartermaster-Office"
+	},
+/turf/simulated/floor/wood,
+/area/quartermaster/qm)
+"Qe" = (
+/obj/machinery/conveyor{
+	dir = 1;
+	id = "QMLoad"
+	},
+/obj/machinery/camera/network/cargo{
+	icon_state = "camera";
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/quartermaster/storage)
 "Qf" = (
 /obj/structure/toilet{
 	pixel_y = 15
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/medical_restroom)
+"Qg" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/camera/network/cargo{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/storage)
+"Qh" = (
+/obj/structure/shuttle/engine/propulsion{
+	dir = 8;
+	icon_state = "propulsion_l"
+	},
+/turf/space,
+/turf/simulated/shuttle/plating/airless/carry,
+/area/shuttle/large_escape_pod1/station)
+"Qi" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/obj/machinery/camera/network/tether,
+/turf/simulated/floor/tiled,
+/area/hallway/station/upper)
+"Qj" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/paleblue/border,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 1
+	},
+/obj/machinery/camera/network/tether{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/upper)
+"Qk" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/lightgrey/border,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 8
+	},
+/obj/machinery/camera/network/tether{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/upper)
+"Ql" = (
+/obj/machinery/camera/network/security{
+	icon_state = "camera";
+	dir = 10
+	},
+/turf/simulated/open,
+/area/security/brig)
+"Qm" = (
+/obj/structure/shuttle/engine/propulsion{
+	dir = 8
+	},
+/turf/space,
+/turf/simulated/shuttle/plating/airless/carry,
+/area/shuttle/large_escape_pod1/station)
+"Qn" = (
+/obj/structure/shuttle/engine/propulsion{
+	dir = 8;
+	icon_state = "propulsion_r"
+	},
+/turf/space,
+/turf/simulated/shuttle/plating/airless/carry,
+/area/shuttle/large_escape_pod1/station)
+"Qo" = (
+/obj/item/weapon/storage/secure/safe{
+	pixel_x = -28
+	},
+/obj/structure/table/glass,
+/obj/item/weapon/storage/lockbox/vials,
+/obj/item/weapon/reagent_containers/dropper,
+/obj/machinery/camera/network/medbay{
+	icon_state = "camera";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/virology)
 "Qr" = (
 /obj/machinery/shower{
 	pixel_y = 10
@@ -27026,13 +27279,6 @@
 	},
 /turf/simulated/floor,
 /area/maintenance/station/sec_upper)
-"QZ" = (
-/obj/effect/floor_decal/techfloor,
-/obj/machinery/camera/network/command{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ai_core_foyer)
 "Ra" = (
 /obj/structure/railing,
 /obj/structure/railing{
@@ -27120,22 +27366,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor,
 /area/maintenance/station/elevator)
-"Rl" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 6
-	},
-/obj/effect/floor_decal/corner/red/border{
-	dir = 6
-	},
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 6
-	},
-/obj/effect/floor_decal/corner/red/bordercorner2{
-	dir = 6
-	},
-/obj/machinery/suit_cycler/security,
-/turf/simulated/floor/tiled,
-/area/security/eva)
 "Rm" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 6
@@ -27808,38 +28038,6 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled,
 /area/hallway/station/upper)
-"SJ" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 4;
-	pixel_x = -16
-	},
-/obj/effect/floor_decal/corner/red/border{
-	dir = 4;
-	pixel_x = -16
-	},
-/obj/effect/floor_decal/corner/red{
-	icon_state = "corner_white";
-	dir = 6
-	},
-/obj/structure/table/steel,
-/obj/item/bodybag/cryobag{
-	pixel_x = 6
-	},
-/obj/item/weapon/storage/firstaid/regular{
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/obj/machinery/recharger/wallcharger{
-	pixel_x = 32;
-	pixel_y = -9
-	},
-/obj/machinery/recharger/wallcharger{
-	pixel_x = 32;
-	pixel_y = 2
-	},
-/obj/item/weapon/reagent_containers/spray/cleaner,
-/turf/simulated/floor/tiled,
-/area/security/hallway)
 "SK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -28028,16 +28226,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/shuttle/excursion/tether)
-"Tv" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/item/toy/plushie/squid/blue,
-/turf/simulated/floor/outdoors/grass/forest,
-/area/quartermaster/qm)
 "TD" = (
 /obj/structure/table/woodentable,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -28488,13 +28676,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/shuttle/excursion/tether)
-"Vb" = (
-/obj/machinery/camera/network/exploration{
-	dir = 1
-	},
-/obj/structure/stasis_cage,
-/turf/simulated/floor/tiled/monotile,
-/area/tether/exploration)
 "Vd" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 6
@@ -28735,15 +28916,6 @@
 "VM" = (
 /turf/simulated/open,
 /area/ai_core_foyer)
-"VN" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/camera/network/security{
-	icon_state = "camera";
-	dir = 8
-	},
-/obj/item/weapon/bone/skull/unathi,
-/turf/simulated/floor/carpet,
-/area/crew_quarters/heads/hos)
 "VQ" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 8;
@@ -28888,14 +29060,6 @@
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/plating,
 /area/shuttle/excursion/tether)
-"Wz" = (
-/obj/machinery/vending/cola,
-/obj/machinery/camera/network/medbay{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/paleblue/diagonal,
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/medbreak)
 "WB" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -29152,19 +29316,6 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/quartermaster/warehouse)
-"XR" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/camera/network/exploration{
-	dir = 8
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/tether/exploration)
 "XT" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -29224,18 +29375,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/medical_restroom)
-"Yi" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/tether/exploration)
 "Yj" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 10
@@ -29337,10 +29476,6 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled,
 /area/shuttle/excursion/tether)
-"YO" = (
-/mob/living/simple_mob/animal/sif/shantak/scruffy,
-/turf/simulated/floor/carpet,
-/area/crew_quarters/heads/hos)
 "YQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -33484,7 +33619,7 @@ aa
 aa
 ae
 aa
-Kq
+yB
 aa
 ae
 aa
@@ -33602,7 +33737,7 @@ aa
 ab
 ZF
 je
-YO
+LS
 WH
 Uk
 my
@@ -33745,7 +33880,7 @@ ab
 ZF
 je
 Ui
-VN
+iS
 TZ
 Yu
 Vp
@@ -33910,7 +34045,7 @@ xw
 xw
 ze
 zS
-Ba
+yR
 BV
 CT
 xw
@@ -34039,7 +34174,7 @@ ov
 oZ
 fr
 qc
-fJ
+mG
 rh
 wS
 sO
@@ -34047,7 +34182,7 @@ tJ
 qc
 vs
 vt
-xx
+tb
 xw
 xw
 zf
@@ -34057,7 +34192,7 @@ BW
 CU
 xw
 xw
-wL
+Kq
 vt
 vt
 vt
@@ -34315,7 +34450,7 @@ ab
 ab
 ab
 je
-ar
+hd
 WN
 et
 Yx
@@ -34459,7 +34594,7 @@ ab
 je
 kI
 Uy
-nG
+kO
 oa
 ox
 ff
@@ -34723,7 +34858,7 @@ ab
 ab
 ao
 ao
-hd
+aH
 hA
 hS
 ig
@@ -34737,7 +34872,7 @@ ja
 kc
 ko
 tQ
-kK
+hC
 kY
 eT
 mc
@@ -35008,14 +35143,14 @@ ai
 ai
 ao
 hf
-hC
+fJ
 bx
 ii
 bd
 iN
 jc
 ji
-jv
+en
 kd
 jS
 rA
@@ -35045,7 +35180,7 @@ nn
 nn
 vu
 uO
-zX
+xx
 Bi
 Cb
 sp
@@ -35179,9 +35314,9 @@ qG
 ro
 sj
 sT
-EG
+qg
 uJ
-vv
+qS
 wg
 wg
 xy
@@ -35189,7 +35324,7 @@ yi
 og
 zY
 Bj
-Ca
+Qk
 Da
 Da
 Da
@@ -35450,7 +35585,7 @@ kC
 fB
 fY
 eT
-mg
+jv
 mD
 nl
 nM
@@ -35463,7 +35598,7 @@ qI
 rm
 sl
 sR
-tN
+Np
 uJ
 vx
 wh
@@ -35475,7 +35610,7 @@ Aa
 Bl
 SI
 Da
-DF
+AK
 EB
 Fp
 Gf
@@ -35599,7 +35734,7 @@ mh
 mh
 ep
 pg
-pH
+pG
 fH
 qe
 eO
@@ -35720,7 +35855,7 @@ gP
 bZ
 bv
 dI
-bS
+dU
 ez
 bE
 RB
@@ -35739,7 +35874,7 @@ dX
 ew
 lz
 lz
-lz
+Kr
 ph
 pI
 aA
@@ -36002,7 +36137,7 @@ gr
 gE
 gO
 hi
-hH
+bS
 dI
 dI
 bq
@@ -36011,7 +36146,7 @@ cd
 dI
 mv
 dM
-ej
+er
 cP
 cP
 jL
@@ -36019,7 +36154,7 @@ eD
 cP
 lB
 lB
-mG
+lB
 no
 as
 as
@@ -36157,7 +36292,7 @@ ek
 cP
 QV
 kD
-kO
+hH
 cP
 lC
 lC
@@ -36168,7 +36303,7 @@ nN
 oz
 pj
 pJ
-qg
+mg
 qK
 rt
 oz
@@ -36183,7 +36318,7 @@ yo
 og
 Af
 Bp
-Cg
+zX
 Df
 Df
 Df
@@ -36317,7 +36452,7 @@ fN
 sZ
 tW
 uO
-vD
+rM
 wi
 wN
 xG
@@ -36348,7 +36483,7 @@ MB
 MS
 No
 Jm
-Wz
+Kj
 KW
 vt
 vt
@@ -36470,7 +36605,7 @@ Br
 Ci
 Dh
 DL
-EF
+Ba
 Fu
 Gk
 Gk
@@ -36573,7 +36708,7 @@ ai
 ai
 ai
 ai
-ci
+NY
 iR
 cg
 jk
@@ -36598,7 +36733,7 @@ oA
 oA
 oA
 oA
-tb
+pH
 tT
 uQ
 vE
@@ -36623,7 +36758,7 @@ Hj
 HV
 ID
 Jp
-Kc
+Fm
 Jr
 KZ
 LE
@@ -36734,7 +36869,7 @@ jk
 jk
 lv
 oB
-pl
+lU
 pM
 qh
 fK
@@ -36755,7 +36890,7 @@ Ck
 yl
 Al
 BE
-Dm
+BQ
 Ef
 EZ
 FH
@@ -37000,7 +37135,7 @@ aC
 aR
 bf
 bs
-bL
+ej
 cf
 cT
 jy
@@ -37015,7 +37150,7 @@ jk
 jk
 jk
 jk
-jk
+Ql
 of
 oD
 pn
@@ -37319,7 +37454,7 @@ yu
 zq
 fT
 kn
-Ck
+Qj
 yJ
 Az
 BG
@@ -37335,7 +37470,7 @@ II
 Ju
 Ki
 KG
-Lf
+GN
 Ld
 Mn
 MI
@@ -37421,7 +37556,7 @@ gk
 gf
 gk
 gR
-aw
+bb
 aE
 dQ
 bf
@@ -37459,7 +37594,7 @@ wU
 xL
 yv
 zq
-fU
+xM
 kw
 pN
 yl
@@ -37606,7 +37741,7 @@ mX
 pS
 Dl
 AA
-BL
+FK
 Dq
 Ek
 Fe
@@ -37617,7 +37752,7 @@ HK
 HZ
 IK
 Jv
-Kj
+Gc
 KH
 Li
 LG
@@ -37719,7 +37854,7 @@ jU
 cY
 kr
 kr
-kP
+hR
 ld
 lF
 mk
@@ -37731,7 +37866,7 @@ oG
 pq
 pR
 qm
-qS
+nA
 rz
 aL
 ti
@@ -37740,7 +37875,7 @@ aN
 vL
 wq
 wV
-xM
+vD
 yx
 yL
 jf
@@ -37753,7 +37888,7 @@ Cl
 El
 Cl
 Cl
-Gp
+DF
 Iy
 Hq
 Lh
@@ -37773,11 +37908,11 @@ ab
 NW
 Ok
 OA
-OQ
+Lf
 NW
 Ok
 OA
-OQ
+Lf
 NW
 aa
 aa
@@ -37872,12 +38007,12 @@ at
 eX
 pr
 lC
-lC
+Pq
 mH
 rB
 mH
 tj
-SJ
+NE
 mH
 uP
 uP
@@ -38002,7 +38137,7 @@ eJ
 el
 kh
 kh
-du
+OQ
 YT
 dO
 lG
@@ -38058,7 +38193,7 @@ Nr
 Om
 OC
 OR
-OY
+Qo
 Pf
 OC
 KA
@@ -38205,7 +38340,7 @@ Pg
 Po
 Pu
 NW
-PD
+PI
 PN
 PS
 PW
@@ -38278,7 +38413,7 @@ hM
 aW
 aU
 iG
-iS
+NI
 YT
 jo
 ds
@@ -38333,11 +38468,11 @@ LN
 Jz
 Mt
 Lh
-Ne
+IU
 Nt
-NE
+Kc
 NK
-NQ
+Or
 Nr
 Oo
 OE
@@ -38437,7 +38572,7 @@ lH
 jh
 lH
 ok
-oK
+kP
 le
 mH
 mH
@@ -38475,7 +38610,7 @@ LO
 JA
 Mu
 Lh
-Nf
+Pt
 Nr
 Nr
 Nr
@@ -38556,7 +38691,7 @@ ab
 ab
 ab
 aU
-gX
+aw
 hr
 hM
 aY
@@ -38593,7 +38728,7 @@ tn
 tn
 tn
 sp
-yB
+wF
 zw
 Ar
 Ax
@@ -38629,7 +38764,7 @@ OU
 OE
 Pl
 NR
-Pw
+Ne
 NW
 PH
 PQ
@@ -38701,7 +38836,7 @@ aU
 bk
 hr
 hP
-Rl
+hQ
 aU
 iH
 iT
@@ -38709,7 +38844,7 @@ YT
 ni
 dg
 tP
-en
+eJ
 eF
 Xe
 YH
@@ -38721,7 +38856,7 @@ mN
 nt
 nS
 om
-oI
+OW
 le
 tl
 tl
@@ -38765,13 +38900,13 @@ ab
 ab
 ab
 NW
-Or
+Pw
 OG
 OV
 Pd
 Pm
 Ps
-Px
+PD
 NW
 PJ
 PR
@@ -38889,7 +39024,7 @@ Du
 EJ
 Fh
 FP
-Gx
+Gp
 Iy
 HI
 Ig
@@ -38981,7 +39116,7 @@ gg
 gj
 gl
 gx
-bb
+ar
 gY
 hv
 hP
@@ -39037,7 +39172,7 @@ HJ
 Ih
 Jb
 JD
-Kr
+Gx
 KO
 Ll
 LM
@@ -39171,7 +39306,7 @@ Bu
 Cs
 DM
 EL
-Fi
+Dm
 FQ
 FQ
 yT
@@ -39189,11 +39324,11 @@ MK
 Iy
 ab
 NL
-Np
-NI
-NI
-NI
-NY
+Qh
+Qm
+Qm
+Qm
+Qn
 NL
 vt
 vt
@@ -39268,7 +39403,7 @@ aU
 aU
 aU
 ay
-aH
+cp
 bm
 bB
 by
@@ -39317,7 +39452,7 @@ Ct
 Ct
 Gy
 yT
-HL
+EG
 Ij
 Jd
 JE
@@ -39410,7 +39545,7 @@ aa
 bc
 bJ
 Ur
-hQ
+gX
 bm
 bm
 bm
@@ -39444,7 +39579,7 @@ uY
 uY
 ww
 wY
-xP
+vY
 yG
 zA
 Av
@@ -39608,7 +39743,7 @@ JF
 Kt
 KQ
 Lq
-LS
+HL
 Iy
 MK
 MK
@@ -39867,7 +40002,7 @@ sq
 tr
 um
 uZ
-uZ
+xg
 wx
 xb
 xR
@@ -39977,21 +40112,21 @@ cC
 cI
 df
 dm
-dU
 cC
 cC
 cC
-df
+cC
+mu
 dm
 cI
 cC
 cC
 cC
-dU
+cC
 dm
 lQ
 lV
-mq
+Px
 mq
 be
 es
@@ -40037,7 +40172,7 @@ Lt
 LW
 My
 MM
-Nk
+Jk
 Nv
 NG
 NM
@@ -40398,7 +40533,7 @@ aa
 aa
 aa
 be
-bX
+kS
 cE
 cK
 cK
@@ -40416,7 +40551,7 @@ Zy
 WG
 dj
 XA
-er
+nh
 ms
 Oz
 be
@@ -40437,7 +40572,7 @@ sq
 sq
 sq
 sq
-xc
+vv
 xS
 fF
 AH
@@ -40540,7 +40675,7 @@ aa
 aa
 aa
 be
-cp
+bX
 cE
 cK
 cK
@@ -40558,7 +40693,7 @@ UJ
 Xb
 dj
 XN
-er
+nh
 ms
 Xq
 be
@@ -40597,7 +40732,7 @@ GS
 Hd
 HR
 IA
-Jk
+Fi
 JS
 Ky
 Fz
@@ -40700,9 +40835,9 @@ iW
 WS
 dj
 XN
-er
+nh
 ms
-Vb
+Xq
 be
 os
 oV
@@ -40983,7 +41118,7 @@ jZ
 WR
 Xo
 XN
-er
+nh
 cK
 ms
 Xq
@@ -41005,7 +41140,7 @@ qr
 qr
 qr
 qr
-xg
+Qi
 xR
 yQ
 zF
@@ -41141,7 +41276,7 @@ pX
 qs
 qY
 rJ
-rJ
+zb
 tu
 ur
 ve
@@ -41413,7 +41548,7 @@ dj
 cK
 ms
 mq
-Ox
+Qb
 Ox
 Ox
 be
@@ -41423,7 +41558,7 @@ iV
 px
 pt
 qr
-qZ
+yY
 rK
 sw
 sw
@@ -41551,7 +41686,7 @@ ea
 kx
 dj
 XN
-er
+nh
 cK
 ms
 mq
@@ -41575,10 +41710,10 @@ vW
 wD
 xk
 xY
-yR
+wL
 zJ
 zL
-Tv
+Ep
 Vl
 TU
 zL
@@ -41708,7 +41843,7 @@ iV
 iV
 qr
 qr
-rM
+nG
 sy
 tx
 uu
@@ -41836,9 +41971,9 @@ kQ
 TG
 dj
 XN
-er
+nh
 ms
-nA
+mq
 be
 oU
 RV
@@ -41855,7 +41990,7 @@ sz
 ty
 uv
 vi
-vY
+rY
 wD
 xm
 ya
@@ -41865,7 +42000,7 @@ AJ
 BM
 CD
 ZV
-Ep
+Qd
 zL
 Ee
 EY
@@ -41960,7 +42095,7 @@ aa
 aa
 aa
 be
-cp
+bX
 cE
 cK
 cK
@@ -41978,7 +42113,7 @@ kR
 Vd
 dj
 XN
-er
+nh
 ms
 QL
 be
@@ -42003,7 +42138,7 @@ he
 ht
 hO
 zL
-AK
+xP
 BN
 CE
 Dv
@@ -42102,7 +42237,7 @@ aa
 aa
 aa
 be
-bX
+kS
 cE
 cK
 cK
@@ -42120,7 +42255,7 @@ ZE
 ZB
 dj
 XB
-er
+nh
 ms
 Sq
 be
@@ -42140,7 +42275,7 @@ qu
 ux
 vj
 vj
-wF
+sE
 xn
 yb
 yU
@@ -42293,7 +42428,7 @@ CG
 CD
 Es
 zK
-Gc
+Cg
 GJ
 Hy
 Mc
@@ -42533,21 +42668,21 @@ cC
 dc
 dl
 dH
-em
+bL
 Wk
 Wk
 Wk
-Yi
+Nk
 VI
 YQ
 SK
 Wk
 Wk
-XR
+Wk
 VI
 YQ
 lW
-mu
+PZ
 nB
 Ro
 PP
@@ -42561,7 +42696,7 @@ sH
 wb
 wJ
 xq
-sE
+pl
 tA
 uA
 vk
@@ -42572,7 +42707,7 @@ ya
 yX
 zO
 SD
-BQ
+Qg
 CI
 Dx
 Et
@@ -42581,8 +42716,8 @@ Gd
 GK
 HA
 Mg
-IU
-nh
+EF
+oK
 zO
 ab
 ab
@@ -42711,7 +42846,7 @@ vZ
 vZ
 xo
 yc
-yY
+NQ
 zO
 AP
 BR
@@ -42995,7 +43130,7 @@ Ev
 Fl
 FE
 GI
-GN
+xc
 HC
 In
 Io
@@ -43110,7 +43245,7 @@ dV
 Rx
 fy
 fy
-kS
+du
 fy
 fy
 RI
@@ -43279,7 +43414,7 @@ wc
 sJ
 xs
 yg
-zb
+Qc
 qu
 AT
 BU
@@ -43412,7 +43547,7 @@ gJ
 gJ
 qu
 qu
-rY
+qZ
 rX
 sJ
 sJ
@@ -43533,7 +43668,7 @@ gK
 gK
 eI
 fy
-hR
+em
 jt
 kl
 kX
@@ -43708,15 +43843,15 @@ qu
 qu
 qu
 AW
-BU
+OY
 CO
 DC
 Ey
-Fm
+BL
 Ge
 GP
 HF
-HF
+Qe
 IY
 zO
 ab
@@ -43829,7 +43964,7 @@ mZ
 Nw
 Pe
 QI
-QZ
+Pr
 fP
 gJ
 gJ
@@ -43965,7 +44100,7 @@ jD
 lk
 jD
 lN
-lU
+fU
 fy
 na
 qa
@@ -44530,7 +44665,7 @@ aa
 aa
 fy
 fy
-kS
+kK
 fy
 fy
 ab


### PR DESCRIPTION
Deletes every camera from z2-z7 and puts them back. 
Purpose being that some of the cameras had preset IDs and they keep getting copied around by accident. This -should- fix that.

I left out Z1 because I have pending map changes to that one. Will do it later.

Also actually deletes the bridge meeting room from Z6.