### PR TITLE
Ensure that EVERY mob give at least SOME nutrition when digested.

### DIFF
--- a/code/modules/vore/eating/bellymodes_vr.dm
+++ b/code/modules/vore/eating/bellymodes_vr.dm
@@ -186,6 +186,8 @@
 				digestion_death(M)
 				if(!ishuman(owner))
 					owner.update_icons()
+				if(compensation == 0) //Slightly sloppy way at making sure certain mobs don't give ZERO nutrition (fish and so on)
+					compensation = 21 //This reads as 20*4.5 due to the calculations afterward, making the backup nutrition value 94.5 per mob. Not op compared to regular prey.
 				if(compensation > 0)
 					if(isrobot(owner))
 						var/mob/living/silicon/robot/R = owner


### PR DESCRIPTION
This is a little hacky but this means the majority of the system doesn't have to be touched and retested.
The biggest target for this is fish from the pond, as they tend to die on their own.

In any case, this won't impact many things and won't slow down the game.

_This does mean we can now have gluttons stuffing themselves with fish now._