### PR TITLE
Makes Monster Tamer give nutrition

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks_vr.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks_vr.dm
@@ -37,6 +37,8 @@
 	strength = 50
 	color = "#d3785d"
 	metabolism = REM * 2.5 // about right for mixing nutriment and ethanol.
+	var/alt_nutriment_factor = 5 //half as much as protein since it's half protein.
+	//using a new variable instead of nutriment_factor so we can call ..() without that adding nutrition for us without taking factors for protein into account
 
 	glass_name = "Monster Tamer"
 	glass_desc = "This looks like a vaguely-alcoholic slurry of meat. Gross."
@@ -45,7 +47,18 @@
 	..()
 
 	if(M.species.gets_food_nutrition) //it's still food!
-		M.nutrition += (nutriment_factor * removed)/2 // For hunger and fatness
+		switch(alien)
+			if(IS_DIONA) //Diona don't get any nutrition from nutriment or protein.
+			if(IS_SKRELL) 
+				M.adjustToxLoss(0.25 * removed)  //Equivalent to half as much protein, since it's half protein.
+			if(IS_TESHARI)
+				M.nutrition += (alt_nutriment_factor * 1.2 * removed) //Give them the same nutrition they would get from protein.
+			if(IS_UNATHI)
+				M.nutrition += (alt_nutriment_factor * 1.125 * removed) //Give them the same nutrition they would get from protein.
+				//Takes into account the 0.5 factor for all nutriment which is applied on top of the 2.25 factor for protein.
+			//Chimera don't need their own case here since their factors for nutriment and protein cancel out.
+			else 
+				M.nutrition += (alt_nutriment_factor * removed)
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
 		if(H.feral > 0 && H.nutrition > 100 && H.traumatic_shock < min(60, H.nutrition/10) && H.jitteriness < 100) // same check as feral triggers to stop them immediately re-feralling
@@ -54,3 +67,11 @@
 				H.feral = 0
 				H << "<span class='info'>Your mind starts to clear, soothed into a state of clarity as your senses return.</span>"
 				log_and_message_admins("is no longer feral.", H)
+
+/datum/reagent/ethanol/monstertamer/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
+	..()
+	if(alien == IS_SKRELL)
+		M.adjustToxLoss(removed)  //Equivalent to half as much protein, since it's half protein.
+	if(M.species.gets_food_nutrition)
+		if(alien == IS_SLIME || alien == IS_CHIMERA) //slimes and chimera can get nutrition from injected nutriment and protein
+			M.nutrition += (alt_nutriment_factor * removed)


### PR DESCRIPTION
Seems to have been intended anyway but wasn't working because the nutriment factor was zero.  Made it work similar to protein since it's made with protein.