### PR TITLE
Nerfs Chemistry Bag Toting

### DIFF
--- a/code/game/objects/items/weapons/storage/bags_vr.dm
+++ b/code/game/objects/items/weapons/storage/bags_vr.dm
@@ -1,0 +1,2 @@
+/obj/item/weapon/storage/bag/chemistry
+	slot_flags = null

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -1177,6 +1177,7 @@
 #include "code\game\objects\items\weapons\storage\backpack.dm"
 #include "code\game\objects\items\weapons\storage\backpack_vr.dm"
 #include "code\game\objects\items\weapons\storage\bags.dm"
+#include "code\game\objects\items\weapons\storage\bags_vr.dm"
 #include "code\game\objects\items\weapons\storage\belt.dm"
 #include "code\game\objects\items\weapons\storage\belt_vr.dm"
 #include "code\game\objects\items\weapons\storage\bible.dm"


### PR DESCRIPTION
Chemistry bags can no longer be carried around in the belt slot, considering the number of chems they can carry they are probably a bit too large for that.