### PR TITLE
Fix bridge power and access oversights

### DIFF
--- a/maps/tether/tether-01-surface1.dmm
+++ b/maps/tether/tether-01-surface1.dmm
@@ -20131,8 +20131,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/camera/network/cargo{
-	c_tag = "CRG - Cargo Warehouse";
-	dir = 9
+	icon_state = "camera";
+	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/mining_main/lobby)

--- a/maps/tether/tether-02-surface2.dmm
+++ b/maps/tether/tether-02-surface2.dmm
@@ -26430,6 +26430,28 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/north)
+"aVu" = (
+/obj/machinery/power/sensor{
+	name = "Powernet Sensor - Command Subgrid";
+	name_tag = "Command Subgrid"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/industrial/warning{
+	icon_state = "warning";
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable/green,
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/substation/command)
 "aVv" = (
 /obj/structure/bed/chair,
 /turf/simulated/floor/tiled/dark,
@@ -29417,28 +29439,6 @@
 	},
 /turf/simulated/open,
 /area/tether/surfacebase/surface_two_hall)
-"baQ" = (
-/obj/machinery/power/sensor{
-	name = "Powernet Sensor - Surface Civilian Subgrid";
-	name_tag = "Surface Civilian Subgrid"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
-	dir = 1
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable/green,
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/substation/command)
 "baU" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -42766,7 +42766,7 @@ arr
 anK
 anv
 aXs
-baQ
+aVu
 aYg
 aXt
 baI

--- a/maps/tether/tether-02-surface2.dmm
+++ b/maps/tether/tether-02-surface2.dmm
@@ -9075,11 +9075,10 @@
 /turf/simulated/wall/r_wall,
 /area/bridge/meeting_room)
 "asd" = (
-/obj/machinery/door/airlock/command{
-	name = "Teleport Access";
-	req_access = list(17)
-	},
 /obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/command{
+	name = "Command Meeting Room"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/meeting_room)
 "ase" = (
@@ -9091,10 +9090,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
 "asf" = (
-/obj/machinery/door/airlock/command{
-	name = "Teleport Access";
-	req_access = list(17)
-	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
 	icon_state = "1-2";
@@ -9103,6 +9098,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/command{
+	name = "Command Meeting Room"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/meeting_room)
 "asg" = (

--- a/maps/tether/tether-03-surface3.dmm
+++ b/maps/tether/tether-03-surface3.dmm
@@ -4001,9 +4001,8 @@
 /obj/effect/floor_decal/corner/lightgrey/border{
 	dir = 6
 	},
-/obj/machinery/camera/network/security{
-	icon_state = "camera";
-	dir = 8
+/obj/machinery/camera/network/tether{
+	dir = 9
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_three_hall)

--- a/maps/tether/tether-03-surface3.dmm
+++ b/maps/tether/tether-03-surface3.dmm
@@ -479,17 +479,11 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/tether/surfacebase/shuttle_pad)
 "abh" = (
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 8
-	},
-/obj/machinery/camera/network/security{
+/obj/machinery/camera/network/medbay{
 	icon_state = "camera";
-	dir = 5
+	dir = 10
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/open,
 /area/tether/surfacebase/medical/triage)
 "abi" = (
 /obj/effect/floor_decal/borderfloor{
@@ -2253,25 +2247,15 @@
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/armory)
 "aec" = (
-/obj/structure/table/glass,
-/obj/item/weapon/storage/box/syringes,
 /obj/effect/floor_decal/borderfloorwhite{
-	dir = 10
+	dir = 8
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
-	dir = 10
+	dir = 8
 	},
-/obj/machinery/requests_console{
-	announcementConsole = 1;
-	department = "Medical Department";
-	departmentType = 3;
-	name = "Medical RC";
-	pixel_x = -30;
-	pixel_y = 0
-	},
-/obj/machinery/camera/network/security{
+/obj/machinery/camera/network/medbay{
 	icon_state = "camera";
-	dir = 10
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/triage)
@@ -3288,20 +3272,25 @@
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/patient_b)
 "afF" = (
+/obj/machinery/disposal,
 /obj/effect/floor_decal/borderfloorwhite{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 1
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals6{
 	dir = 9
 	},
-/obj/structure/disposalpipe/segment{
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 9
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/machinery/status_display{
+	pixel_y = 30
+	},
+/obj/machinery/camera/network/medbay{
+	icon_state = "camera";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/triage)
+/area/tether/surfacebase/medical/lobby)
 "afG" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
@@ -4745,25 +4734,22 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/frontdesk)
 "ahW" = (
-/obj/machinery/disposal,
 /obj/effect/floor_decal/borderfloorwhite{
-	dir = 9
+	dir = 1
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
-	dir = 9
+	dir = 1
 	},
-/obj/structure/disposalpipe/trunk{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/status_display{
-	pixel_y = 30
-	},
-/obj/machinery/camera/network/security{
-	icon_state = "camera";
-	dir = 5
+/obj/item/device/radio/intercom{
+	dir = 1;
+	pixel_y = 24;
+	req_access = list()
 	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/triage)
+/area/tether/surfacebase/medical/lobby)
 "ahX" = (
 /obj/structure/table/reinforced,
 /obj/effect/floor_decal/borderfloor{
@@ -4786,16 +4772,14 @@
 /obj/effect/floor_decal/corner/paleblue/border{
 	dir = 1
 	},
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 9
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/item/device/radio/intercom{
-	dir = 1;
-	pixel_y = 24;
-	req_access = list()
-	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/triage)
+/area/tether/surfacebase/medical/lobby)
 "ahZ" = (
 /obj/structure/cable/green{
 	icon_state = "1-4"
@@ -5162,7 +5146,7 @@
 	req_access = list(5)
 	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/triage)
+/area/tether/surfacebase/medical/lobby)
 "aiC" = (
 /obj/structure/disposalpipe/junction{
 	icon_state = "pipe-j2";
@@ -15282,10 +15266,28 @@
 /turf/simulated/wall,
 /area/hydroponics)
 "azu" = (
-/obj/structure/shuttle/engine/propulsion,
-/turf/simulated/floor/reinforced,
-/turf/simulated/shuttle/plating/carry,
-/area/shuttle/tether/surface)
+/obj/structure/table/glass,
+/obj/item/weapon/storage/box/syringes,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 10
+	},
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Medical Department";
+	departmentType = 3;
+	name = "Medical RC";
+	pixel_x = -30;
+	pixel_y = 0
+	},
+/obj/machinery/camera/network/medbay{
+	icon_state = "camera";
+	dir = 10
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/triage)
 "azv" = (
 /obj/structure/sign/double/barsign{
 	dir = 8
@@ -21696,12 +21698,22 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "aIR" = (
-/obj/machinery/camera/network/security{
-	icon_state = "camera";
-	dir = 10
+/obj/structure/disposalpipe/trunk{
+	dir = 8
 	},
-/turf/simulated/open,
-/area/tether/surfacebase/medical/triage)
+/obj/machinery/disposal,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 4
+	},
+/obj/machinery/camera/network/medbay{
+	icon_state = "camera";
+	dir = 9
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/chemistry)
 "aIS" = (
 /obj/structure/table/marble,
 /obj/item/weapon/reagent_containers/glass/rag,
@@ -21953,10 +21965,6 @@
 	dir = 4
 	},
 /obj/machinery/chemical_dispenser/full,
-/obj/machinery/camera/network/security{
-	icon_state = "camera";
-	dir = 8
-	},
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/chemistry)
 "aJm" = (
@@ -26566,6 +26574,11 @@
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/tiled/steel,
 /area/rnd/outpost/xenobiology/outpost_first_aid)
+"aSC" = (
+/obj/structure/shuttle/engine/propulsion,
+/turf/simulated/floor/reinforced,
+/turf/simulated/shuttle/plating/carry,
+/area/shuttle/tether/surface)
 "aSD" = (
 /obj/structure/sign/redcross,
 /turf/simulated/wall,
@@ -27234,19 +27247,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/chemistry)
-"aUF" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/machinery/disposal,
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 4
-	},
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/chemistry)
 "aUG" = (
@@ -43510,7 +43510,7 @@ afa
 aag
 aag
 aag
-aag
+aeG
 aeG
 aeG
 aeG
@@ -43650,9 +43650,9 @@ adM
 aea
 afb
 aga
-aec
+azu
 aag
-ahW
+afF
 aja
 aTK
 aVF
@@ -43794,7 +43794,7 @@ aSR
 aTj
 abv
 aag
-ahY
+ahW
 aig
 agj
 agX
@@ -43927,7 +43927,7 @@ aaD
 aag
 aao
 aeH
-abh
+aec
 aaH
 aaR
 aba
@@ -43936,7 +43936,7 @@ acb
 acN
 aUA
 agn
-afF
+ahY
 afz
 agk
 agX
@@ -44065,7 +44065,7 @@ aab
 aac
 aag
 aat
-aIR
+abh
 aag
 aad
 aaZ
@@ -45212,7 +45212,7 @@ aSK
 aSP
 aTd
 aTq
-aUF
+aIR
 aeA
 aUS
 aJl
@@ -45274,7 +45274,7 @@ aNk
 aNl
 aNJ
 aNP
-azu
+aSC
 aKU
 abg
 aOk
@@ -45416,7 +45416,7 @@ aNl
 aNl
 aNK
 aNP
-azu
+aSC
 aKU
 abg
 aOk
@@ -45558,7 +45558,7 @@ aNm
 aNl
 aNK
 aNP
-azu
+aSC
 aKU
 abg
 aOk

--- a/maps/tether/tether-05-station1.dmm
+++ b/maps/tether/tether-05-station1.dmm
@@ -4852,7 +4852,9 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor/glass,
-/obj/machinery/door/airlock/maintenance/engi,
+/obj/machinery/door/airlock/maintenance/engi{
+	name = "Space Civ/Com Substation"
+	},
 /turf/simulated/floor,
 /area/maintenance/substation/spacecommand)
 "aio" = (
@@ -11108,7 +11110,7 @@
 /area/hallway/station/atrium)
 "aun" = (
 /obj/machinery/power/breakerbox/activated{
-	RCon_tag = "Civilian Substation Bypass"
+	RCon_tag = "Space Civ/Com Substation Bypass"
 	},
 /obj/machinery/light/small{
 	dir = 8;
@@ -11294,7 +11296,7 @@
 	charge = 0;
 	output_attempt = 0;
 	outputting = 0;
-	RCon_tag = "Substation - Civilian"
+	RCon_tag = "Substation - Space Civ/Com"
 	},
 /obj/structure/cable/green,
 /obj/structure/cable/green{
@@ -11352,17 +11354,14 @@
 /turf/simulated/floor/tiled,
 /area/tether/station/stairs_one)
 "auQ" = (
-/obj/structure/cable/green,
+/obj/machinery/door/firedoor/glass,
 /obj/structure/cable/green{
-	icon_state = "0-4"
-	},
-/obj/structure/cable/green{
+	d1 = 4;
 	d2 = 8;
-	icon_state = "0-8"
+	icon_state = "4-8"
 	},
-/obj/machinery/power/sensor{
-	name = "Powernet Sensor - Civilian Subgrid";
-	name_tag = "Civilian Subgrid"
+/obj/machinery/door/airlock/maintenance/engi{
+	name = "Space Civ/Com Substation"
 	},
 /turf/simulated/floor,
 /area/maintenance/substation/spacecommand)
@@ -11603,12 +11602,17 @@
 /turf/simulated/floor/tiled,
 /area/engineering/workshop)
 "avp" = (
-/obj/machinery/door/firedoor/glass,
-/obj/machinery/door/airlock/maintenance/engi,
+/obj/structure/cable/green,
 /obj/structure/cable/green{
-	d1 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/cable/green{
 	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "0-8"
+	},
+/obj/machinery/power/sensor{
+	name = "Powernet Sensor - Space Civ/Com Subgrid";
+	name_tag = "Space Civ/Com Subgrid"
 	},
 /turf/simulated/floor,
 /area/maintenance/substation/spacecommand)
@@ -12452,6 +12456,11 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled,
 /area/bridge/secondary/hallway)
@@ -16404,6 +16413,18 @@
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/hallway)
+"aCW" = (
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/cable/green{
+	d1 = 16;
+	d2 = 0;
+	icon_state = "16-0"
+	},
+/turf/simulated/floor/tiled,
+/area/bridge/secondary/hallway)
 "aDh" = (
 /obj/machinery/door/airlock{
 	name = "Unit 3"
@@ -33445,7 +33466,7 @@ adj
 adj
 adj
 adj
-avp
+auQ
 avb
 avV
 awA
@@ -33587,7 +33608,7 @@ adj
 ait
 aun
 auL
-auQ
+avp
 avb
 avW
 axq
@@ -34584,7 +34605,7 @@ azc
 ahe
 ahm
 avY
-axy
+aCW
 ahN
 aiE
 axI

--- a/maps/tether/tether-05-station1.dmm
+++ b/maps/tether/tether-05-station1.dmm
@@ -16425,6 +16425,27 @@
 	},
 /turf/simulated/floor/tiled,
 /area/bridge/secondary/hallway)
+"aCX" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/item/device/radio/beacon,
+/turf/simulated/floor/tiled,
+/area/hallway/station/atrium)
+"aCY" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/item/device/radio/beacon,
+/turf/simulated/floor/tiled,
+/area/hallway/station/docks)
 "aDh" = (
 /obj/machinery/door/airlock{
 	name = "Unit 3"
@@ -29773,7 +29794,7 @@ bou
 azN
 aws
 aBb
-btF
+aCY
 aBZ
 aCJ
 aaa
@@ -34164,7 +34185,7 @@ acy
 adc
 adc
 acT
-acp
+aCX
 aCr
 acV
 aAv

--- a/maps/tether/tether-06-station2.dmm
+++ b/maps/tether/tether-06-station2.dmm
@@ -15141,28 +15141,27 @@
 /turf/simulated/floor,
 /area/maintenance/station/micro)
 "wS" = (
+/obj/machinery/door/firedoor/glass,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/maintenance/command{
+	req_access = list(19)
+	},
+/turf/simulated/floor,
+/area/maintenance/station/micro)
+"wT" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/maintenance/common,
-/turf/simulated/floor,
-/area/maintenance/station/micro)
-"wT" = (
+/obj/machinery/door/airlock/maintenance/command{
+	req_access = list(19)
+	},
 /obj/machinery/door/firedoor/glass,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/maintenance/common,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor,
 /area/maintenance/station/micro)
 "wU" = (
@@ -34231,7 +34230,7 @@ yJ
 yJ
 yJ
 yJ
-wS
+wT
 sB
 ac
 ac
@@ -35082,7 +35081,7 @@ xr
 wQ
 wR
 wR
-wT
+wS
 yI
 sB
 ac

--- a/maps/tether/tether-06-station2.dmm
+++ b/maps/tether/tether-06-station2.dmm
@@ -318,6 +318,7 @@
 /obj/effect/floor_decal/corner/red/bordercorner2{
 	dir = 5
 	},
+/obj/machinery/camera/network/security,
 /turf/simulated/floor/tiled,
 /area/security/security_cell_hallway)
 "aI" = (
@@ -553,6 +554,10 @@
 	name = "Cell 2 Door";
 	pixel_x = -28;
 	req_access = list(1,2)
+	},
+/obj/machinery/camera/network/security{
+	icon_state = "camera";
+	dir = 5
 	},
 /turf/simulated/floor/tiled,
 /area/security/security_cell_hallway)


### PR DESCRIPTION
Fixxes powernet settings on the space and surface command substation equipment, connects z5 power to z6 power so EVA will get power, and re-adds command doors to the south side of the old command meeting room because it allowed public access to the space bridge hallway.

also fixxes the meeting room access

ALSO makes all the medical cameras on z3 not be security cameras

also adds a couple of new teleporter beacons to z5 for the docks and the bridge