### PR TITLE
Fixes dropnom prefs disappearing from vore panel sometimes

### DIFF
--- a/code/modules/vore/eating/vore_vr.dm
+++ b/code/modules/vore/eating/vore_vr.dm
@@ -138,9 +138,9 @@ V::::::V           V::::::VO:::::::OOO:::::::ORR:::::R     R:::::REE::::::EEEEEE
 	if(isnull(permit_healbelly))
 		permit_healbelly = TRUE
 	if(isnull(can_be_drop_prey))
-		allowmobvore = FALSE
+		can_be_drop_prey = FALSE
 	if(isnull(can_be_drop_pred))
-		allowmobvore = FALSE
+		can_be_drop_pred = FALSE
 	if(isnull(belly_prefs))
 		belly_prefs = list()
 


### PR DESCRIPTION
For some reason sanitization reset mobvore vars instead of dropnom vars if those ended up as nulls. ANGERY. Also no idea why it took so long to crop up as an issue.