### PR TITLE
Add a Help Prompt (*vhelp) for Virgo-Specific Emotes

### DIFF
--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -732,7 +732,7 @@
 					twitch_v, vomit, whimper, wink, yawn. Synthetics: beep, buzz, yes, no, rcough, rsneeze, ping")
 
 		else
-			to_chat(src, "<font color='blue'>Unusable emote '[act]'. Say *help for a list.</font>")
+			to_chat(src, "<font color='blue'>Unusable emote '[act]'. Say *help or *vhelp for a list.</font>") //VOREStation Edit, mention *vhelp for Virgo-specific emotes located in emote_vr.dm.
 
 	if (message)
 		custom_emote(m_type,message)

--- a/code/modules/mob/living/carbon/human/emote_vr.dm
+++ b/code/modules/mob/living/carbon/human/emote_vr.dm
@@ -76,7 +76,7 @@
 				message = "does a flip!"
 				m_type = 1
 		if ("vhelp") //Help for Virgo-specific emotes.
-			to_chat(src, "vwag, vflap, mlem, awoo, nya, peep, chirp, weh, merp, bark, his, squeak, nsay, nme, flip")
+			to_chat(src, "vwag, vflap, mlem, awoo, nya, peep, chirp, weh, merp, bark, hiss, squeak, nsay, nme, flip")
 
 	if (message)
 		custom_emote(m_type,message)

--- a/code/modules/mob/living/carbon/human/emote_vr.dm
+++ b/code/modules/mob/living/carbon/human/emote_vr.dm
@@ -35,7 +35,7 @@
 			message = "peeps like a bird."
 			m_type = 2
 			playsound(loc, 'sound/voice/peep.ogg', 50, 1, -1)
-		if("chirp")
+		if ("chirp")
 			message = "chirps!"
 			playsound(src.loc, 'sound/misc/nymphchirp.ogg', 50, 0)
 			m_type = 2
@@ -75,6 +75,8 @@
 				src.SpinAnimation(7,1)
 				message = "does a flip!"
 				m_type = 1
+		if ("vhelp") //Help for Virgo-specific emotes.
+			to_chat(src, "vwag, vflap, mlem, awoo, nya, peep, chirp, weh, merp, bark, his, squeak, nsay, nme, flip")
 
 	if (message)
 		custom_emote(m_type,message)


### PR DESCRIPTION
So you can easily get a list of all these fun emotes without code-diving, `say *vhelp` will do the trick.

Related PRs: #6185, #6228