### PR TITLE
New Species: Black-Eyed Shadekin

### DIFF
--- a/code/__defines/mobs_vr.dm
+++ b/code/__defines/mobs_vr.dm
@@ -17,12 +17,15 @@
 #define A_FRUIT	"fruit gland"
 
 //species defines
+
+//station species
 #define SPECIES_AKULA			"Akula"
 #define SPECIES_ALRAUNE			"Alraune"
 #define SPECIES_NEVREAN			"Nevrean"
 #define SPECIES_PROTEAN			"Protean"
 #define SPECIES_RAPALA			"Rapala"
 #define SPECIES_SERGAL			"Sergal"
+#define SPECIES_SHADEKIN_CREW	"Black-Eyed Shadekin"
 #define SPECIES_VASILISSAN		"Vasilissan"
 #define SPECIES_VULPKANIN		"Vulpkanin"
 #define SPECIES_XENOCHIMERA		"Xenochimera"
@@ -30,11 +33,11 @@
 #define SPECIES_ZORREN_FLAT		"Flatland Zorren"
 #define SPECIES_ZORREN_HIGH		"Highlander Zorren"
 #define SPECIES_CUSTOM			"Custom Species"
-
+//monkey species
 #define SPECIES_MONKEY_AKULA		"Sobaka"
 #define SPECIES_MONKEY_NEVREAN		"Sparra"
 #define SPECIES_MONKEY_SERGAL		"Saru"
 #define SPECIES_MONKEY_VULPKANIN	"Wolpin"
-
+//event species
 #define SPECIES_WEREBEAST			"Werebeast"
 #define SPECIES_SHADEKIN			"Shadekin"

--- a/code/modules/mob/living/carbon/human/species/shadekin/shadekin.dm
+++ b/code/modules/mob/living/carbon/human/species/shadekin/shadekin.dm
@@ -14,7 +14,10 @@
 	catalogue_data = list(/datum/category_item/catalogue/fauna/shadekin)
 
 	language = LANGUAGE_SHADEKIN
-	assisted_langs = list()
+	name_language = LANGUAGE_SHADEKIN
+	species_language = LANGUAGE_SHADEKIN
+	secondary_langs = list(LANGUAGE_SHADEKIN)
+	num_alternate_languages = 3
 	unarmed_types = list(/datum/unarmed_attack/stomp, /datum/unarmed_attack/kick, /datum/unarmed_attack/claws/shadekin, /datum/unarmed_attack/bite/sharp/shadekin)
 	rarity_value = 15	//INTERDIMENSIONAL FLUFFERS
 
@@ -50,6 +53,8 @@
 	blood_color = "#A10808"
 	base_color = "#f0f0f0"
 	color_mult = 1
+
+	inherent_verbs = list(/mob/living/proc/shred_limb)
 
 	has_glowing_eyes = TRUE
 

--- a/code/modules/mob/living/carbon/human/species/station/station_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_vr.dm
@@ -493,8 +493,8 @@ datum/species/harpy
 	item_slowdown_mod = 1.5
 
 	total_health = 75
-	brute_mod = 1.5 // Frail
-	burn_mod = 1.5	// Furry
+	brute_mod = 1.25 // Frail
+	burn_mod = 1.25	// Furry
 	blood_volume = 500
 	hunger_factor = 0.2
 
@@ -555,17 +555,17 @@ datum/species/harpy
 		)
 
 	has_limbs = list(
-		BP_TORSO =  list("path" = /obj/item/organ/external/chest),
-		BP_GROIN =  list("path" = /obj/item/organ/external/groin),
-		BP_HEAD =   list("path" = /obj/item/organ/external/head/vr/shadekin/crew),
-		BP_L_ARM =  list("path" = /obj/item/organ/external/arm),
-		BP_R_ARM =  list("path" = /obj/item/organ/external/arm/right),
-		BP_L_LEG =  list("path" = /obj/item/organ/external/leg),
-		BP_R_LEG =  list("path" = /obj/item/organ/external/leg/right),
-		BP_L_HAND = list("path" = /obj/item/organ/external/hand),
-		BP_R_HAND = list("path" = /obj/item/organ/external/hand/right),
-		BP_L_FOOT = list("path" = /obj/item/organ/external/foot),
-		BP_R_FOOT = list("path" = /obj/item/organ/external/foot/right)
+		BP_TORSO =  list("path" = /obj/item/organ/external/chest/crewkin),
+		BP_GROIN =  list("path" = /obj/item/organ/external/groin/crewkin),
+		BP_HEAD =   list("path" = /obj/item/organ/external/head/vr/crewkin),
+		BP_L_ARM =  list("path" = /obj/item/organ/external/arm/crewkin),
+		BP_R_ARM =  list("path" = /obj/item/organ/external/arm/right/crewkin),
+		BP_L_LEG =  list("path" = /obj/item/organ/external/leg/crewkin),
+		BP_R_LEG =  list("path" = /obj/item/organ/external/leg/right/crewkin),
+		BP_L_HAND = list("path" = /obj/item/organ/external/hand/crewkin),
+		BP_R_HAND = list("path" = /obj/item/organ/external/hand/right/crewkin),
+		BP_L_FOOT = list("path" = /obj/item/organ/external/foot/crewkin),
+		BP_R_FOOT = list("path" = /obj/item/organ/external/foot/right/crewkin)
 		)
 
 /datum/species/shadekin/get_bodytype()

--- a/code/modules/mob/living/carbon/human/species/station/station_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_vr.dm
@@ -489,7 +489,7 @@ datum/species/harpy
 	siemens_coefficient = 0
 	darksight = 10
 
-	slowdown = 1.1
+	slowdown = 0.5
 	item_slowdown_mod = 1.5
 
 	total_health = 75

--- a/code/modules/mob/living/carbon/human/species/station/station_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_vr.dm
@@ -410,6 +410,9 @@
 	base_color = "#EECEB3"
 	wikilink="https://wiki.vore-station.net/Human"
 
+/datum/species/human/vatgrown
+	spawn_flags = SPECIES_IS_RESTRICTED
+
 /datum/species/vox
 	gluttonous = 0
 	spawn_flags = SPECIES_CAN_JOIN | SPECIES_IS_WHITELISTED | SPECIES_WHITELIST_SELECTABLE
@@ -460,5 +463,113 @@ datum/species/harpy
 		"Your overheated skin itches."
 		)
 
-/datum/species/human/vatgrown
-	spawn_flags = SPECIES_IS_RESTRICTED
+/datum/species/crew_shadekin
+	name = SPECIES_SHADEKIN_CREW
+	name_plural = "Black-Eyed Shadekin"
+	icobase = 'icons/mob/human_races/r_shadekin_vr.dmi'
+	deform = 'icons/mob/human_races/r_shadekin_vr.dmi'
+	tail = "tail"
+	icobase_tail = 1
+	blurb = "Very little is known about these creatures. They appear to be largely mammalian in appearance. \
+	Seemingly very rare to encounter, there have been widespread myths of these creatures the galaxy over, \
+	but next to no verifiable evidence to their existence. However, they have recently been more verifiably \
+	documented in the Virgo system, following a mining bombardment of Virgo 3. The crew of NSB Adephagia have \
+	taken to calling these creatures 'Shadekin', and the name has generally stuck and spread. "		//TODO: Something more fitting for black-eyes
+	wikilink = "https://wiki.vore-station.net/Shadekin"
+	catalogue_data = list(/datum/category_item/catalogue/fauna/shadekin)
+
+	language = LANGUAGE_SHADEKIN
+	name_language = LANGUAGE_SHADEKIN
+	species_language = LANGUAGE_SHADEKIN
+	secondary_langs = list(LANGUAGE_SHADEKIN)
+	num_alternate_languages = 3
+	unarmed_types = list(/datum/unarmed_attack/stomp, /datum/unarmed_attack/kick, /datum/unarmed_attack/claws, /datum/unarmed_attack/bite/sharp)
+	rarity_value = 5	//INTERDIMENSIONAL FLUFFERS
+
+	siemens_coefficient = 0
+	darksight = 10
+
+	slowdown = 1.1
+	item_slowdown_mod = 1.5
+
+	total_health = 75
+	brute_mod = 1.5 // Frail
+	burn_mod = 1.5	// Furry
+	blood_volume = 500
+	hunger_factor = 0.2
+
+	warning_low_pressure = 50
+	hazard_low_pressure = -1
+
+	warning_high_pressure = 300
+	hazard_high_pressure = INFINITY
+
+	cold_level_1 = -1	//Immune to cold
+	cold_level_2 = -1
+	cold_level_3 = -1
+
+	heat_level_1 = 850	//Resistant to heat
+	heat_level_2 = 1000
+	heat_level_3 = 1150
+
+	flags =  NO_SCAN
+	spawn_flags = SPECIES_CAN_JOIN | SPECIES_IS_WHITELISTED | SPECIES_WHITELIST_SELECTABLE
+
+	reagent_tag = IS_SHADEKIN		// for shadekin-unqiue chem interactions
+
+	flesh_color = "#FFC896"
+	blood_color = "#A10808"
+	base_color = "#f0f0f0"
+	color_mult = 1
+
+	inherent_verbs = list(/mob/living/proc/shred_limb)
+
+	has_glowing_eyes = TRUE
+
+	male_cough_sounds = null
+	female_cough_sounds = null
+	male_sneeze_sound = null
+	female_sneeze_sound = null
+
+	speech_bubble_appearance = "ghost"
+
+	genders = list(PLURAL, NEUTER)		//no sexual dymorphism
+	ambiguous_genders = TRUE	//but just in case
+
+	breath_type = null
+	poison_type = null
+
+	appearance_flags = HAS_HAIR_COLOR | HAS_LIPS | HAS_SKIN_COLOR | HAS_UNDERWEAR
+
+	move_trail = /obj/effect/decal/cleanable/blood/tracks/paw
+
+	has_organ = list(
+		O_HEART =		/obj/item/organ/internal/heart,
+		O_VOICE = 		/obj/item/organ/internal/voicebox,
+		O_LIVER =		/obj/item/organ/internal/liver,
+		O_KIDNEYS =		/obj/item/organ/internal/kidneys,
+		O_BRAIN =		/obj/item/organ/internal/brain,
+		O_EYES =		/obj/item/organ/internal/eyes,
+		O_STOMACH =		/obj/item/organ/internal/stomach,
+		O_INTESTINE =	/obj/item/organ/internal/intestine
+		)
+
+	has_limbs = list(
+		BP_TORSO =  list("path" = /obj/item/organ/external/chest),
+		BP_GROIN =  list("path" = /obj/item/organ/external/groin),
+		BP_HEAD =   list("path" = /obj/item/organ/external/head/vr/shadekin/crew),
+		BP_L_ARM =  list("path" = /obj/item/organ/external/arm),
+		BP_R_ARM =  list("path" = /obj/item/organ/external/arm/right),
+		BP_L_LEG =  list("path" = /obj/item/organ/external/leg),
+		BP_R_LEG =  list("path" = /obj/item/organ/external/leg/right),
+		BP_L_HAND = list("path" = /obj/item/organ/external/hand),
+		BP_R_HAND = list("path" = /obj/item/organ/external/hand/right),
+		BP_L_FOOT = list("path" = /obj/item/organ/external/foot),
+		BP_R_FOOT = list("path" = /obj/item/organ/external/foot/right)
+		)
+
+/datum/species/shadekin/get_bodytype()
+	return SPECIES_SHADEKIN
+
+/datum/species/shadekin/can_breathe_water()
+	return TRUE	//they dont quite breathe

--- a/code/modules/mob/new_player/sprite_accessories_vr.dm
+++ b/code/modules/mob/new_player/sprite_accessories_vr.dm
@@ -8,7 +8,7 @@
 
 	//var/icon_add = 'icons/mob/human_face.dmi' //Already defined in sprite_accessories.dm line 49.
 	var/color_blend_mode = ICON_MULTIPLY
-	species_allowed = list(SPECIES_HUMAN, SPECIES_SKRELL, SPECIES_UNATHI, SPECIES_TAJ, SPECIES_TESHARI, SPECIES_NEVREAN, SPECIES_AKULA, SPECIES_SERGAL, SPECIES_ZORREN_FLAT, SPECIES_ZORREN_HIGH, SPECIES_VULPKANIN, SPECIES_XENOCHIMERA, SPECIES_XENOHYBRID, SPECIES_VASILISSAN, SPECIES_RAPALA, SPECIES_PROTEAN, SPECIES_ALRAUNE, SPECIES_WEREBEAST, SPECIES_SHADEKIN) //This lets all races use the default hairstyles.
+	species_allowed = list(SPECIES_HUMAN, SPECIES_SKRELL, SPECIES_UNATHI, SPECIES_TAJ, SPECIES_TESHARI, SPECIES_NEVREAN, SPECIES_AKULA, SPECIES_SERGAL, SPECIES_ZORREN_FLAT, SPECIES_ZORREN_HIGH, SPECIES_VULPKANIN, SPECIES_XENOCHIMERA, SPECIES_XENOHYBRID, SPECIES_VASILISSAN, SPECIES_RAPALA, SPECIES_PROTEAN, SPECIES_ALRAUNE, SPECIES_WEREBEAST, SPECIES_SHADEKIN, SPECIES_SHADEKIN_CREW) //This lets all races use the default hairstyles.
 
 	astolfo
 		name = "Astolfo"
@@ -481,7 +481,7 @@
 		icon = 'icons/mob/human_face_vr.dmi'
 		icon_add = 'icons/mob/human_face_vr_add.dmi'
 		icon_state = "shadekin_short"
-		species_allowed = list(SPECIES_SHADEKIN)
+		species_allowed = list(SPECIES_SHADEKIN, SPECIES_SHADEKIN_CREW)
 		gender = NEUTER
 
 	shadekin_hair_poofy
@@ -489,7 +489,7 @@
 		icon = 'icons/mob/human_face_vr.dmi'
 		icon_add = 'icons/mob/human_face_vr_add.dmi'
 		icon_state = "shadekin_poofy"
-		species_allowed = list(SPECIES_SHADEKIN)
+		species_allowed = list(SPECIES_SHADEKIN, SPECIES_SHADEKIN_CREW)
 		gender = NEUTER
 
 	shadekin_hair_long
@@ -497,7 +497,7 @@
 		icon = 'icons/mob/human_face_vr.dmi'
 		icon_add = 'icons/mob/human_face_vr_add.dmi'
 		icon_state = "shadekin_long"
-		species_allowed = list(SPECIES_SHADEKIN)
+		species_allowed = list(SPECIES_SHADEKIN, SPECIES_SHADEKIN_CREW)
 		gender = NEUTER
 
 	shadekin_hair_rivyr
@@ -506,7 +506,7 @@
 		icon_add = 'icons/mob/human_face_vr_add.dmi'
 		icon_state = "shadekin_rivyr"
 		ckeys_allowed = list("verysoft")
-		species_allowed = list(SPECIES_SHADEKIN)
+		species_allowed = list(SPECIES_SHADEKIN, SPECIES_SHADEKIN_CREW)
 		gender = NEUTER
 
 /datum/sprite_accessory/facial_hair
@@ -1096,7 +1096,7 @@
 		name = "Heterochromia"
 		icon_state = "heterochromia"
 		body_parts = list(BP_HEAD)
-		species_allowed = list(SPECIES_HUMAN, SPECIES_UNATHI, SPECIES_TAJ, SPECIES_NEVREAN, SPECIES_AKULA, SPECIES_ZORREN_FLAT, SPECIES_ZORREN_HIGH, SPECIES_VULPKANIN, SPECIES_XENOCHIMERA, SPECIES_XENOHYBRID, SPECIES_VASILISSAN, SPECIES_RAPALA, SPECIES_PROTEAN, SPECIES_ALRAUNE, SPECIES_WEREBEAST, SPECIES_SHADEKIN) //This lets all races use the default hairstyles.
+		species_allowed = list(SPECIES_HUMAN, SPECIES_UNATHI, SPECIES_TAJ, SPECIES_NEVREAN, SPECIES_AKULA, SPECIES_ZORREN_FLAT, SPECIES_ZORREN_HIGH, SPECIES_VULPKANIN, SPECIES_XENOCHIMERA, SPECIES_XENOHYBRID, SPECIES_VASILISSAN, SPECIES_RAPALA, SPECIES_PROTEAN, SPECIES_ALRAUNE, SPECIES_WEREBEAST) //This lets all races use the default hairstyles.
 
 	werewolf_nose
 		name = "Werewolf nose"
@@ -1135,4 +1135,4 @@
 		icon_state = "shadekin-snoot"
 		color_blend_mode = ICON_MULTIPLY
 		body_parts = list(BP_HEAD)
-		species_allowed = list(SPECIES_SHADEKIN)
+		species_allowed = list(SPECIES_SHADEKIN, SPECIES_SHADEKIN_CREW)

--- a/code/modules/organs/subtypes/shadekin_vr.dm
+++ b/code/modules/organs/subtypes/shadekin_vr.dm
@@ -1,0 +1,35 @@
+/obj/item/organ/external/chest/crewkin
+	min_broken_damage = 20
+
+/obj/item/organ/external/groin/crewkin
+	min_broken_damage = 20
+
+/obj/item/organ/external/head/vr/crewkin
+	min_broken_damage = 15
+
+	eye_icons_vr = 'icons/mob/human_face_vr.dmi'
+	eye_icon_vr = "eyes_shadekin_station"
+
+/obj/item/organ/external/arm/crewkin
+	min_broken_damage = 15
+
+/obj/item/organ/external/arm/right/crewkin
+	min_broken_damage = 15
+
+/obj/item/organ/external/leg/crewkin
+	min_broken_damage = 15
+
+/obj/item/organ/external/leg/right/crewkin
+	min_broken_damage = 15
+
+/obj/item/organ/external/foot/crewkin
+	min_broken_damage = 7
+
+/obj/item/organ/external/foot/right/crewkin
+	min_broken_damage = 7
+
+/obj/item/organ/external/hand/crewkin
+	min_broken_damage = 7
+
+/obj/item/organ/external/hand/right/crewkin
+	min_broken_damage = 7

--- a/code/modules/organs/subtypes/standard_vr.dm
+++ b/code/modules/organs/subtypes/standard_vr.dm
@@ -68,9 +68,3 @@
 
 	eye_icons_vr = 'icons/mob/human_face_vr.dmi'
 	eye_icon_vr = "eyes_shadekin"
-
-/obj/item/organ/external/head/vr/shadekin/crew
-	cannot_gib = 0
-	cannot_amputate = 0
-
-	eye_icon_vr = "eyes_shadekin_station"

--- a/code/modules/organs/subtypes/standard_vr.dm
+++ b/code/modules/organs/subtypes/standard_vr.dm
@@ -68,3 +68,9 @@
 
 	eye_icons_vr = 'icons/mob/human_face_vr.dmi'
 	eye_icon_vr = "eyes_shadekin"
+
+/obj/item/organ/external/head/vr/shadekin/crew
+	cannot_gib = 0
+	cannot_amputate = 0
+
+	eye_icon_vr = "eyes_shadekin_station"

--- a/code/modules/vore/appearance/sprite_accessories_taur_vr.dm
+++ b/code/modules/vore/appearance/sprite_accessories_taur_vr.dm
@@ -167,7 +167,7 @@
 	clip_mask_icon = null
 	clip_mask_state = null
 	apply_restrictions = TRUE
-	species_allowed = list(SPECIES_SHADEKIN)
+	species_allowed = list(SPECIES_SHADEKIN, SPECIES_SHADEKIN_CREW)
 
 /datum/sprite_accessory/tail/taur/shadekin_tail/shadekin_tail_2c
 	name = "Shadekin Tail dual-color (Shadekin)"

--- a/code/modules/vore/appearance/sprite_accessories_vr.dm
+++ b/code/modules/vore/appearance/sprite_accessories_vr.dm
@@ -39,7 +39,7 @@
 	do_colouration = 1
 	color_blend_mode = ICON_MULTIPLY
 	apply_restrictions = TRUE
-	species_allowed = list(SPECIES_SHADEKIN)
+	species_allowed = list(SPECIES_SHADEKIN, SPECIES_SHADEKIN_CREW)
 
 // Ears avaliable to anyone
 
@@ -692,7 +692,7 @@
 	do_colouration = 1
 	color_blend_mode = ICON_MULTIPLY
 	apply_restrictions = TRUE
-	species_allowed = list(SPECIES_SHADEKIN)
+	species_allowed = list(SPECIES_SHADEKIN, SPECIES_SHADEKIN_CREW)
 
 // Everyone tails
 

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -2733,6 +2733,7 @@
 #include "code\modules\organs\subtypes\replicant.dm"
 #include "code\modules\organs\subtypes\seromi.dm"
 #include "code\modules\organs\subtypes\shadekin.dm"
+#include "code\modules\organs\subtypes\shadekin_vr.dm"
 #include "code\modules\organs\subtypes\slime.dm"
 #include "code\modules\organs\subtypes\standard.dm"
 #include "code\modules\organs\subtypes\standard_vr.dm"


### PR DESCRIPTION
Shadekin, but with an unfortunate twist of having lost all their power in dangerous accident and stuck in realspace. Meant to be more of a for-crew version of the Shadekin.

They are much weaker physically, take more damage and have less health, slightly slower than average crew and much more affected by slowdown. They also don't have any of normal shadekin abilities or even the energy meter/darkness meter.

On the other hand they retain natural shadekin resistance to harsh environments, be it vacuum or poison, and don't need to breathe. They also retain their amazing dark vision.

Still waiting on some additional decisions regarding lore, but mechanically there's not much more that can be done other than potential balancing adjustments.

Species is whitelisted, and to my knowledge, will not be an event-only thing like werebeasts or regular shadekin, but actually whitelistable, but that is for admins to fully decide.

Also allows regular shadekin to actually select additional languages.