### PR TITLE
I improved mice

### DIFF
--- a/code/modules/mob/holder.dm
+++ b/code/modules/mob/holder.dm
@@ -134,6 +134,8 @@ var/list/holder_mob_icon_cache = list()
 /mob/living/MouseDrop(var/atom/over_object)
 	var/mob/living/carbon/human/H = over_object
 	if(holder_type && issmall(src) && istype(H) && !H.lying && Adjacent(H) && (src.a_intent == I_HELP && H.a_intent == I_HELP)) //VOREStation Edit
+		if(istype(src, /mob/living/simple_mob/animal/passive/mouse)) //vorestation edit
+			return ..() //vorestation edit
 		if(!issmall(H) || !istype(src, /mob/living/carbon/human))
 			get_scooped(H, (usr == src))
 		return

--- a/code/modules/mob/living/simple_mob/subtypes/animal/passive/mouse_vr.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/passive/mouse_vr.dm
@@ -37,7 +37,7 @@
 	if(istype(O, /obj/item/weapon/storage) && O.Adjacent(src)) //controls diving into storage
 		var/obj/item/weapon/storage/S = O
 		var/obj/item/weapon/holder/H = new holder_type(get_turf(src)) //this works weird, but it creates an empty holder, to see if that holder can fit
-		if(S.can_be_inserted(H))
+		if(S.can_be_inserted(H) && (src.size_multiplier <= 0.75))
 			H.held_mob = src
 			src.forceMove(H)
 			visible_message("<span class='notice'>\the [src] squeezes into \the [S].</span>")

--- a/code/modules/mob/living/simple_mob/subtypes/animal/passive/mouse_vr.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/passive/mouse_vr.dm
@@ -20,3 +20,20 @@
 		if((I_HELP) && U.canClick()) //a little snowflakey, but makes it use the same cooldown as interacting with non-inventory objects
 			U.setClickCooldown(U.get_attack_speed()) //if there's a cleaner way in baycode, I'll change this
 			U.visible_message("<span class='notice'>[U] [M.response_help] \the [M].</span>")
+
+/mob/living/simple_mob/animal/passive/mouse/MouseDrop(var/obj/item/weapon/storage/S)
+	if(istype(S, /obj/item/weapon/storage))
+		var/obj/item/weapon/holder/H = new holder_type(get_turf(src)) //this works weird, but it creates an empty holder, to see if that holder can fit
+		if(S.can_be_inserted(H))
+			H.held_mob = src
+			src.forceMove(H)
+			visible_message("<span class='notice'>\the [src] squeezes into \the [S].</span>")
+			H.forceMove(S)
+			H.sync(src)
+			return 1
+		else
+			qdel(H) //this deletes the empty holder if it doesnt work
+			to_chat(usr,"<span class='notice'>You can't fit inside \the [S]!</span>")
+			return 0
+	else
+		..()

--- a/code/modules/vore/resizing/resize_vr.dm
+++ b/code/modules/vore/resizing/resize_vr.dm
@@ -125,7 +125,7 @@ var/const/RESIZE_A_SMALLTINY = (RESIZE_SMALL + RESIZE_TINY) / 2
  * Attempt to scoop up this mob up into H's hands, if the size difference is large enough.
  * @return false if normal code should continue, 1 to prevent normal code.
  */
-/mob/living/proc/attempt_to_scoop(var/mob/living/M)
+/mob/living/proc/attempt_to_scoop(var/mob/living/M, var/mob/living/G) //second one is for the Grabber, only exists for animals to self-grab
 	var/size_diff = M.get_effective_size() - get_effective_size()
 	if(!holder_default && holder_type)
 		holder_default = holder_type
@@ -140,7 +140,7 @@ var/const/RESIZE_A_SMALLTINY = (RESIZE_SMALL + RESIZE_TINY) / 2
 		return 0
 	if(size_diff >= 0.50)
 		holder_type = /obj/item/weapon/holder/micro
-		var/obj/item/weapon/holder/m_holder = get_scooped(M)
+		var/obj/item/weapon/holder/m_holder = get_scooped(M, G)
 		holder_type = holder_default
 		if (m_holder)
 			return 1


### PR DESCRIPTION
Made some changes to how mice work, in particular player controlled mice, but it will have effects on NPC ones too.

I don't think anything here should be particularly contraversial, but I've not done much with this codebase and so obviously I'm happy to change things if needed. I appreciate you're a downstream, so there are only two lines of upstream code changed, and both are commented. I tried to comment clearly with regards to anything that might not be obvious, for sanity's sake.

Almost all this code could be very easily applied to any animals with appropriate holders as a straight improvement. I'd do it, but I'm not 100% confident with baycode, I'd rather not reinvent the wheel with my second PR, and I'm still not entirely sure about some aspects of the codebase like the holders you use for humanoids that might be needed. So this could be considered a trial.

Changes from the top:

- Mice can jump inside storage items like bags and boxes if there is enough room for them to fit. They were already able to be inside storage items, they just had to be put there by a person. Update: This is now size limited, so a person-sized mouse can't crawl into a backpack.
- Uneducated Mice disabled, Universal Understand enabled. Mice can understand but not speak other languages. Standard on every other server in the world and absolutely blows if absent tbh.
- Movement speed increased slightly. Makes a mouse move about half the speed of a person instead of roughly 1/8th the speed as before, which was just painful.
- Mice now use the attempt_to_scoop proc for being picked up and climbing on a person.
  What this means:
   - Mice behave according to their size. A maximum sized mouse can't be scooped up by a normal person, and a tiny person cant scoop up a normal mouse that's their size or bigger. This also applies to the mouse being unable to clamber onto someone small.
   - Mice use the same code as people to determine if they can be grabbed, which is generally good code consistency. This could be very easily applied to all simplemobs if it was wanted.
   - Code is a little more flexible; mouse strip menu, while useless, can be accessed. Mice too big to be picked up will be petted instead.
   - Doesn't use the weird default code that checks for a size variable that's apparently in complete disuse, instead uses the one that's actually used to check for this stuff