### PR TITLE
Adds elevator doors to bot exceptions

### DIFF
--- a/code/modules/mob/living/bot/bot.dm
+++ b/code/modules/mob/living/bot/bot.dm
@@ -157,7 +157,7 @@
 /mob/living/bot/Bump(var/atom/A)
 	if(on && botcard && istype(A, /obj/machinery/door))
 		var/obj/machinery/door/D = A
-		if(!istype(D, /obj/machinery/door/firedoor) && !istype(D, /obj/machinery/door/blast) && D.check_access(botcard))
+		if(!istype(D, /obj/machinery/door/firedoor) && !istype(D, /obj/machinery/door/blast) && !istype(D, /obj/machinery/door/airlock/lift) && D.check_access(botcard))	//VOREStation Edit: Elevator safety precaution
 			D.open()
 	else
 		..()


### PR DESCRIPTION
In combination with https://github.com/PolarisSS13/Polaris/pull/6551 and permapowered elevator we had for a while, this should be fixing all 'accidental' situations of falling in. The only remaining potential cases are malicious hacking or negligence with usage of fireman mode.

Will be fixing #3254 and #1920 once both this and https://github.com/PolarisSS13/Polaris/pull/6551 are merged.

fixes #3254 and fixes #1920