### PR TITLE
Adds Nutrition Percentage to belly options

### DIFF
--- a/code/modules/vore/eating/belly_dat_vr.dm
+++ b/code/modules/vore/eating/belly_dat_vr.dm
@@ -14,6 +14,7 @@
 	var/human_prey_swallow_time = 100		// Time in deciseconds to swallow /mob/living/carbon/human
 	var/nonhuman_prey_swallow_time = 30		// Time in deciseconds to swallow anything else
 	var/emoteTime = 600						// How long between stomach emotes at prey
+	var/nutrition_percent = 100				// Nutritional percent per tick in digestion mode.
 	var/digest_brute = 2					// Brute damage per tick in digestion mode
 	var/digest_burn = 3						// Burn damage per tick in digestion mode
 	var/digest_tickrate = 3					// Modulus this of air controller tick number to iterate gurgles on
@@ -105,6 +106,7 @@
 	new_belly.human_prey_swallow_time = human_prey_swallow_time
 	new_belly.nonhuman_prey_swallow_time = nonhuman_prey_swallow_time
 	new_belly.emote_time = emoteTime
+	new_belly.nutrition_percent = nutrition_percent
 	new_belly.digest_brute = digest_brute
 	new_belly.digest_burn = digest_burn
 	new_belly.immutable = immutable

--- a/code/modules/vore/eating/belly_obj_vr.dm
+++ b/code/modules/vore/eating/belly_obj_vr.dm
@@ -19,6 +19,7 @@
 	var/human_prey_swallow_time = 100		// Time in deciseconds to swallow /mob/living/carbon/human
 	var/nonhuman_prey_swallow_time = 30		// Time in deciseconds to swallow anything else
 	var/emote_time = 60 SECONDS				// How long between stomach emotes at prey
+	var/nutrition_percent = 100				// Nutritional percentage per tick in digestion mode
 	var/digest_brute = 2					// Brute damage per tick in digestion mode
 	var/digest_burn = 2						// Burn damage per tick in digestion mode
 	var/immutable = FALSE					// Prevents this belly from being deleted
@@ -129,6 +130,7 @@
 		"human_prey_swallow_time",
 		"nonhuman_prey_swallow_time",
 		"emote_time",
+		"nutrition_percent",
 		"digest_brute",
 		"digest_burn",
 		"immutable",
@@ -478,7 +480,7 @@
 	if(!digested)
 		items_preserved |= item
 	else
-		owner.nutrition += (5 * digested)
+		owner.nutrition += ((nutrition_percent / 100) * 5 * digested)
 		if(isrobot(owner))
 			var/mob/living/silicon/robot/R = owner
 			R.cell.charge += (50 * digested)
@@ -661,6 +663,7 @@
 	dupe.human_prey_swallow_time = human_prey_swallow_time
 	dupe.nonhuman_prey_swallow_time = nonhuman_prey_swallow_time
 	dupe.emote_time = emote_time
+	dupe.nutrition_percent = nutrition_percent
 	dupe.digest_brute = digest_brute
 	dupe.digest_burn = digest_burn
 	dupe.immutable = immutable

--- a/code/modules/vore/eating/bellymodes_vr.dm
+++ b/code/modules/vore/eating/bellymodes_vr.dm
@@ -193,7 +193,7 @@
 						var/mob/living/silicon/robot/R = owner
 						R.cell.charge += 25*compensation
 					else
-						owner.nutrition += 4.5*compensation
+						owner.nutrition += (nutrition_percent / 100)*4.5*compensation
 				to_update = TRUE
 
 				continue
@@ -213,9 +213,9 @@
 				var/mob/living/silicon/robot/R = owner
 				R.cell.charge += 25*damage_gain
 			if(offset) // If any different than default weight, multiply the % of offset.
-				owner.nutrition += offset*(4.5*(damage_gain)/difference) //4.5 nutrition points per health point. Normal same size 100+100 health prey with average weight would give 900 points if the digestion was instant. With all the size/weight offset taxes plus over time oxyloss+hunger taxes deducted with non-instant digestion, this should be enough to not leave the pred starved.
+				owner.nutrition += offset*((nutrition_percent / 100)*4.5*(damage_gain)/difference) //4.5 nutrition points per health point. Normal same size 100+100 health prey with average weight would give 900 points if the digestion was instant. With all the size/weight offset taxes plus over time oxyloss+hunger taxes deducted with non-instant digestion, this should be enough to not leave the pred starved.
 			else
-				owner.nutrition += 4.5*(damage_gain)/difference
+				owner.nutrition += (nutrition_percent / 100)*4.5*(damage_gain)/difference
 
 
 //////////////////////////// DM_ABSORB ////////////////////////////

--- a/code/modules/vore/eating/vorepanel_vr.dm
+++ b/code/modules/vore/eating/vorepanel_vr.dm
@@ -255,6 +255,10 @@
 		dat += "<br><a href='?src=\ref[src];b_tastes=\ref[selected]'>Can Taste:</a>"
 		dat += " [selected.can_taste ? "Yes" : "No"]"
 
+		//Nutritional percentage
+		dat += "<br><a href='?src=\ref[src];b_nutritionpercent=\ref[selected]'>Nutritional Percentage:</a>"
+		dat += " [selected.nutrition_percent]%"
+
 		//How much brute damage
 		dat += "<br><a href='?src=\ref[src];b_brute_dmg=\ref[selected]'>Digest Brute Damage:</a>"
 		dat += " [selected.digest_brute]"
@@ -770,6 +774,13 @@
 			to_chat(user,"<span class='notice'>Invalid size.</span>")
 		else if(new_grow)
 			selected.shrink_grow_size = (new_grow*0.01)
+
+	if(href_list["b_nutritionpercent"])
+		var/new_damage = input(user, "Choose the percentage of nutrition you will recieve per tick from prey. Ranges from 0.01 to 100.", "Set Belly Brute Damage.", selected.digest_brute) as num|null
+		if(new_damage == null)
+			return
+		var/new_new_damage = CLAMP(new_damage, 0.01, 100)
+		selected.nutrition_percent = new_new_damage
 
 	if(href_list["b_burn_dmg"])
 		var/new_damage = input(user, "Choose the amount of burn damage prey will take per tick. Ranges from 0 to 6.", "Set Belly Burn Damage.", selected.digest_burn) as num|null

--- a/code/modules/vore/eating/vorepanel_vr.dm
+++ b/code/modules/vore/eating/vorepanel_vr.dm
@@ -256,7 +256,7 @@
 		dat += " [selected.can_taste ? "Yes" : "No"]"
 
 		//Nutritional percentage
-		dat += "<br><a href='?src=\ref[src];b_nutritionpercent=\ref[selected]'>Nutritional Percentage:</a>"
+		dat += "<br><a href='?src=\ref[src];b_nutritionpercent=\ref[selected]'>Nutritional Gain:</a>"
 		dat += " [selected.nutrition_percent]%"
 
 		//How much brute damage
@@ -776,7 +776,7 @@
 			selected.shrink_grow_size = (new_grow*0.01)
 
 	if(href_list["b_nutritionpercent"])
-		var/new_damage = input(user, "Choose the percentage of nutrition you will recieve per tick from prey. Ranges from 0.01 to 100.", "Set Belly Brute Damage.", selected.digest_brute) as num|null
+		var/new_damage = input(user, "Choose the nutrition gain percentage you will recieve per tick from prey. Ranges from 0.01 to 100.", "Set Nutrition Gain Percentage.", selected.digest_brute) as num|null
 		if(new_damage == null)
 			return
 		var/new_new_damage = CLAMP(new_damage, 0.01, 100)


### PR DESCRIPTION
Changelog:
Adds a Nutrition Percentage to belly options. It can range from 0.01 (mostly to avoid possible divide by zero issues) to 100, the default.

Affects both prey and all digestible items. Absorb is NOT affected at this time, only the Digest option.