### PR TITLE
Fixes snowfield SMES showing up on RCON

### DIFF
--- a/maps/tether/submaps/gateway/snowfield.dmm
+++ b/maps/tether/submaps/gateway/snowfield.dmm
@@ -108,7 +108,6 @@
 	input_level = 250000;
 	inputting = 1;
 	output_level = 250000;
-	RCon_tag = "Telecommunications Satellite"
 	},
 /obj/structure/cable{
 	icon_state = "0-2";


### PR DESCRIPTION
title. Of 3 gateway destinations, it was the only one that had it with a tag for some reason and tag was mismatched so was annoying to track down where it came from.