### PR TITLE
Some more simplemob QoL and fixes.

### DIFF
--- a/code/game/objects/items/devices/radio/headset_vr.dm
+++ b/code/game/objects/items/devices/radio/headset_vr.dm
@@ -22,12 +22,12 @@
 						SPECIES_WEREBEAST = 'icons/mob/species/werebeast/ears.dmi')
 
 /obj/item/device/radio/headset/mob_headset	//Adminbus headset for simplemob shenanigans.
-	name = "nonhuman radio implant"
-	desc = "An updated, modular intercom that requires no hands to operate. Takes encryption keys"
+	name = "nonhuman radio receiver"
+	desc = "An updated, self-adhesive modular intercom that requires no hands to operate or ears to hold, just stick it on. Takes encryption keys"
 
 /obj/item/device/radio/headset/mob_headset/receive_range(freq, level)
 	if(ismob(src.loc))
-		return ..(freq, level)
+		return ..(freq, level, 1)
 	return -1
 
 /obj/item/device/radio/headset/mob_headset/afterattack(var/atom/movable/target, mob/living/user, proximity)
@@ -36,6 +36,7 @@
 	if(istype(target,/mob/living/simple_mob))
 		var/mob/living/simple_mob/M = target
 		if(!M.mob_radio)
+			user.drop_item()
 			forceMove(M)
 			M.mob_radio = src
 			return

--- a/code/modules/mob/living/carbon/human/species/station/protean_vr/protean_blob.dm
+++ b/code/modules/mob/living/carbon/human/species/station/protean_vr/protean_blob.dm
@@ -17,9 +17,9 @@
 	// ai_inactive = TRUE //Always off //VORESTATION AI TEMPORARY REMOVAL
 	show_stat_health = FALSE //We will do it ourselves
 
-	response_help = "pats the"
-	response_disarm = "gently pushes aside the"
-	response_harm = "hits the"
+	response_help = "pets"
+	response_disarm = "gently pushes aside"
+	response_harm = "hits"
 
 	harm_intent_damage = 2
 	melee_damage_lower = 10

--- a/code/modules/mob/living/simple_mob/subtypes/vore/bee.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/bee.dm
@@ -7,9 +7,9 @@
 	icon_dead = "bee-dead"
 	icon = 'icons/mob/vore.dmi'
 
-	response_help = "pets the"
-	response_disarm = "gently pushes aside the"
-	response_harm = "hits the"
+	response_help = "pets"
+	response_disarm = "gently pushes aside"
+	response_harm = "hits"
 
 	movement_cooldown = 5
 //	speed = 5

--- a/code/modules/mob/living/simple_mob/subtypes/vore/catgirl.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/catgirl.dm
@@ -10,9 +10,9 @@
 	melee_damage_lower = 2
 	melee_damage_upper = 5
 
-	response_help = "pets the"
-	response_disarm = "gently baps the"
-	response_harm = "hits the"
+	response_help = "pets"
+	response_disarm = "gently baps"
+	response_harm = "hits"
 
 	attacktext = list("swatted","bapped")
 

--- a/code/modules/mob/living/simple_mob/subtypes/vore/corrupt_hounds.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/corrupt_hounds.dm
@@ -27,14 +27,15 @@
 	maxHealth = 200
 	health = 200
 	movement_sound = 'sound/effects/houndstep.ogg'
+	see_in_dark = 8
 
 	melee_damage_lower = 5
 	melee_damage_upper = 10 //makes it so 4 max dmg hits don't instakill you.
 	grab_resist = 100
 
-	response_help = "pets the"
-	response_disarm = "bops the"
-	response_harm = "hits the"
+	response_help = "pets"
+	response_disarm = "bops"
+	response_harm = "hits"
 	attacktext = list("ravaged")
 	friendly = list("nuzzles", "slobberlicks", "noses softly at", "noseboops", "headbumps against", "leans on", "nibbles affectionately on")
 
@@ -111,6 +112,7 @@
 	if(!riding_datum)
 		riding_datum = new /datum/riding/simple_mob(src)
 	verbs |= /mob/living/simple_mob/proc/animal_mount
+	movement_cooldown = 0
 
 /mob/living/simple_mob/vore/aggressive/corrupthound/MouseDrop_T(mob/living/M, mob/living/user)
 	return

--- a/code/modules/mob/living/simple_mob/subtypes/vore/deathclaw.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/deathclaw.dm
@@ -20,6 +20,7 @@
 
 	maxHealth = 200
 	health = 200
+	see_in_dark = 8
 
 	melee_damage_lower = 5
 	melee_damage_upper = 30
@@ -48,16 +49,15 @@
 	vore_pounce_chance = 0 // Beat them into crit before eating.
 	vore_icons = SA_ICON_LIVING
 
-/* //VOREStation AI Temporary Removal
-/mob/living/simple_animal/hostile/deathclaw/Login()
+/mob/living/simple_mob/vore/aggressive/deathclaw/Login()
 	. = ..()
 	if(!riding_datum)
-		riding_datum = new /datum/riding/simple_animal(src)
-	verbs |= /mob/living/simple_animal/proc/animal_mount
+		riding_datum = new /datum/riding/simple_mob(src)
+	verbs |= /mob/living/simple_mob/proc/animal_mount
+	movement_cooldown = 0
 
-/mob/living/simple_animal/hostile/deathclaw/MouseDrop_T(mob/living/M, mob/living/user)
+/mob/living/simple_mob/vore/aggressive/deathclaw/MouseDrop_T(mob/living/M, mob/living/user)
 	return
-*/
 
 /datum/ai_holder/simple_mob/melee/deathclaw
 	can_breakthrough = TRUE

--- a/code/modules/mob/living/simple_mob/subtypes/vore/dragon.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/dragon.dm
@@ -10,6 +10,7 @@
 	faction = "dragon"
 	maxHealth = 500 // Boss
 	health = 500
+	see_in_dark = 8
 
 	melee_damage_lower = 5
 	melee_damage_upper = 30
@@ -55,16 +56,15 @@
 	health = 200
 	faction = "virgo3b"
 
-/* //VOREStation AI Temporary Removal
-/mob/living/simple_animal/hostile/dragon/Login()
+/mob/living/simple_mob/vore/aggressive/dragon/Login()
 	. = ..()
 	if(!riding_datum)
-		riding_datum = new /datum/riding/simple_animal(src)
-	verbs |= /mob/living/simple_animal/proc/animal_mount
+		riding_datum = new /datum/riding/simple_mob(src)
+	verbs |= /mob/living/simple_mob/proc/animal_mount
+	movement_cooldown = 0
 
-/mob/living/simple_animal/hostile/dragon/MouseDrop_T(mob/living/M, mob/living/user)
+/mob/living/simple_mob/vore/aggressive/dragon/MouseDrop_T(mob/living/M, mob/living/user)
 	return
-*/
 
 /datum/say_list/dragonboss
 	say_got_target = list("roars and snaps it jaws!")

--- a/code/modules/mob/living/simple_mob/subtypes/vore/dragon.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/dragon.dm
@@ -27,6 +27,10 @@
 	minbodytemp = 0
 	maxbodytemp = 700
 
+	response_help = "pats"
+	response_disarm = "tries to shove"
+	response_harm = "hits"
+
 	old_x = -16
 	old_y = 0
 	default_pixel_x = -16

--- a/code/modules/mob/living/simple_mob/subtypes/vore/fennec.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/fennec.dm
@@ -21,9 +21,9 @@
 	maxHealth = 30
 	health = 30
 
-	response_help = "pats the"
-	response_disarm = "gently pushes aside the"
-	response_harm = "hits the"
+	response_help = "pats"
+	response_disarm = "gently pushes aside"
+	response_harm = "hits"
 
 	harm_intent_damage = 5
 	melee_damage_lower = 1

--- a/code/modules/mob/living/simple_mob/subtypes/vore/fennix.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/fennix.dm
@@ -12,9 +12,9 @@
 	maxHealth = 60
 	health = 60
 
-	response_help = "pats the"
-	response_disarm = "gently pushes aside the"
-	response_harm = "hits the"
+	response_help = "pats"
+	response_disarm = "gently pushes aside"
+	response_harm = "hits"
 
 	harm_intent_damage = 20
 	melee_damage_lower = 1

--- a/code/modules/mob/living/simple_mob/subtypes/vore/hippo.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/hippo.dm
@@ -66,13 +66,15 @@
 	vore_stomach_flavor	= "You are squeezed into the sweltering insides of the herbivore rumen."
 	vore_icons = SA_ICON_LIVING
 
-/* //VOREStation AI Temporary Removal
 /mob/living/simple_mob/vore/hippo/Login()
 	. = ..()
 	if(!riding_datum)
-		riding_datum = new /datum/riding/simple_animal(src)
-	verbs |= /mob/living/simple_animal/proc/animal_mount
-*/
+		riding_datum = new /datum/riding/simple_mob(src)
+	verbs |= /mob/living/simple_mob/proc/animal_mount
+	movement_cooldown = 0
+
+/mob/living/simple_mob/vore/hippo/MouseDrop_T(mob/living/M, mob/living/user)
+	return
 
 /mob/living/simple_mob/vore/hippo/MouseDrop_T(mob/living/M, mob/living/user)
 	return

--- a/code/modules/mob/living/simple_mob/subtypes/vore/hippo.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/hippo.dm
@@ -23,9 +23,9 @@
 		"bio" = 0,
 		"rad" = 0)
 
-	response_help = "pets the"
-	response_disarm = "gently pushes aside the"
-	response_harm = "hits the"
+	response_help = "pets"
+	response_disarm = "gently pushes aside"
+	response_harm = "hits"
 	attacktext = list("bit")
 
 	melee_damage_upper = 12

--- a/code/modules/mob/living/simple_mob/subtypes/vore/horse.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/horse.dm
@@ -40,16 +40,15 @@
 	vore_active = 1
 	vore_icons = SA_ICON_LIVING
 
-/* //VOREStation AI Temporary Removal
-/mob/living/simple_animal/horse/Login()
+/mob/living/simple_mob/vore/horse/Login()
 	. = ..()
 	if(!riding_datum)
-		riding_datum = new /datum/riding/simple_animal(src)
-	verbs |= /mob/living/simple_animal/proc/animal_mount
+		riding_datum = new /datum/riding/simple_mob(src)
+	verbs |= /mob/living/simple_mob/proc/animal_mount
+	movement_cooldown = 0
 
-/mob/living/simple_animal/horse/MouseDrop_T(mob/living/M, mob/living/user)
+/mob/living/simple_mob/vore/horse/MouseDrop_T(mob/living/M, mob/living/user)
 	return
-*/
 
 /datum/say_list/horse
 	speak = list("NEHEHEHEHEH","Neh?")

--- a/code/modules/mob/living/simple_mob/subtypes/vore/otie.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/otie.dm
@@ -21,9 +21,10 @@
 	minbodytemp = 200
 	melee_damage_lower = 2
 	melee_damage_upper = 7 //Don't break my bones bro
-	response_help = "pets the"
-	response_disarm = "bops the"
-	response_harm = "hits the"
+	see_in_dark = 8
+	response_help = "pets"
+	response_disarm = "bops"
+	response_harm = "hits"
 	attacktext = list("mauled")
 	friendly = list("nuzzles", "slobberlicks", "noses softly at", "noseboops", "headbumps against", "leans on", "nibbles affectionately on")
 	meat_amount = 6
@@ -261,6 +262,7 @@
 	if(!riding_datum)
 		riding_datum = new /datum/riding/simple_mob(src)
 	verbs |= /mob/living/simple_mob/proc/animal_mount
+	movement_cooldown = 0
 
 /mob/living/simple_mob/otie/MouseDrop_T(mob/living/M, mob/living/user)
 	return

--- a/code/modules/mob/living/simple_mob/subtypes/vore/panther.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/panther.dm
@@ -40,14 +40,14 @@
 	vore_pounce_chance = 10
 	vore_icons = SA_ICON_LIVING | SA_ICON_REST
 
-/mob/living/simple_mob/vore/panther/Login()
+/mob/living/simple_mob/vore/aggressive/panther/Login()
 	. = ..()
 	if(!riding_datum)
 		riding_datum = new /datum/riding/simple_mob(src)
 	verbs |= /mob/living/simple_mob/proc/animal_mount
 	movement_cooldown = 0
 
-/mob/living/simple_mob/vore/panther/MouseDrop_T(mob/living/M, mob/living/user)
+/mob/living/simple_mob/vore/aggressive/panther/MouseDrop_T(mob/living/M, mob/living/user)
 	return
 
 /datum/say_list/panther

--- a/code/modules/mob/living/simple_mob/subtypes/vore/panther.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/panther.dm
@@ -18,6 +18,10 @@
 	melee_damage_upper = 15
 	attack_sharp = TRUE
 
+	response_help = "pats"
+	response_disarm = "tries to shove"
+	response_harm = "hits"
+
 	old_x = -16
 	old_y = 0
 	default_pixel_x = -16

--- a/code/modules/mob/living/simple_mob/subtypes/vore/panther.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/panther.dm
@@ -12,6 +12,7 @@
 	maxHealth = 200
 	health = 200
 	movement_cooldown = 4
+	see_in_dark = 8
 
 	melee_damage_lower = 5
 	melee_damage_upper = 15
@@ -39,16 +40,15 @@
 	vore_pounce_chance = 10
 	vore_icons = SA_ICON_LIVING | SA_ICON_REST
 
-/* //VOREStation AI Temporary Removal
-/mob/living/simple_animal/vore/panther/Login()
+/mob/living/simple_mob/vore/panther/Login()
 	. = ..()
 	if(!riding_datum)
-		riding_datum = new /datum/riding/simple_animal(src)
-	verbs |= /mob/living/simple_animal/proc/animal_mount
+		riding_datum = new /datum/riding/simple_mob(src)
+	verbs |= /mob/living/simple_mob/proc/animal_mount
+	movement_cooldown = 0
 
-/mob/living/simple_animal/vore/panther/MouseDrop_T(mob/living/M, mob/living/user)
+/mob/living/simple_mob/vore/panther/MouseDrop_T(mob/living/M, mob/living/user)
 	return
-*/
 
 /datum/say_list/panther
 	speak = list("RAWR!","Rawr!","GRR!","Growl!")

--- a/code/modules/mob/living/simple_mob/subtypes/vore/rat.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/rat.dm
@@ -169,14 +169,14 @@
 	playsound(src, 'sound/effects/mouse_squeak_loud.ogg', 50, 1)
 	..()
 
-/mob/living/simple_mob/rat/panther/Login()
+/mob/living/simple_mob/vore/aggressive/rat/Login()
 	. = ..()
 	if(!riding_datum)
 		riding_datum = new /datum/riding/simple_mob(src)
 	verbs |= /mob/living/simple_mob/proc/animal_mount
 	movement_cooldown = 0
 
-/mob/living/simple_mob/vore/rat/MouseDrop_T(mob/living/M, mob/living/user)
+/mob/living/simple_mob/vore/aggressive/rat/MouseDrop_T(mob/living/M, mob/living/user)
 	return
 
 /mob/living/simple_mob/vore/aggressive/rat/phoron

--- a/code/modules/mob/living/simple_mob/subtypes/vore/rat.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/rat.dm
@@ -23,10 +23,11 @@
 	melee_damage_lower = 2
 	melee_damage_upper = 7
 	grab_resist = 100
+	see_in_dark = 8
 
-	response_help = "pets the"
-	response_disarm = "bops the"
-	response_harm = "hits the"
+	response_help = "pets"
+	response_disarm = "bops"
+	response_harm = "hits"
 	attacktext = list("ravaged")
 	friendly = list("nuzzles", "licks", "noses softly at", "noseboops", "headbumps against", "leans on", "nibbles affectionately on")
 
@@ -168,16 +169,15 @@
 	playsound(src, 'sound/effects/mouse_squeak_loud.ogg', 50, 1)
 	..()
 
-/* //VOREStation AI Temporary Removal
-/mob/living/simple_mob/vore/rat/Login()
+/mob/living/simple_mob/rat/panther/Login()
 	. = ..()
 	if(!riding_datum)
-		riding_datum = new /datum/riding/simple_animal(src)
-	verbs |= /mob/living/simple_animal/proc/animal_mount
+		riding_datum = new /datum/riding/simple_mob(src)
+	verbs |= /mob/living/simple_mob/proc/animal_mount
+	movement_cooldown = 0
 
-/mob/living/simple_mob/vore/aggressive/rat/MouseDrop_T(mob/living/M, mob/living/user)
+/mob/living/simple_mob/vore/rat/MouseDrop_T(mob/living/M, mob/living/user)
 	return
-*/
 
 /mob/living/simple_mob/vore/aggressive/rat/phoron
 	name = "phoron rat"

--- a/code/modules/mob/living/simple_mob/subtypes/vore/redpanda.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/redpanda.dm
@@ -13,9 +13,9 @@
 	maxHealth = 30
 	health = 30
 
-	response_help = "pats the"
-	response_disarm = "gently pushes aside the"
-	response_harm = "hits the"
+	response_help = "pats"
+	response_disarm = "gently pushes aside"
+	response_harm = "hits"
 
 	harm_intent_damage = 3
 	melee_damage_lower = 3

--- a/code/modules/mob/living/simple_mob/subtypes/vore/shadekin/shadekin.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/shadekin/shadekin.dm
@@ -36,9 +36,9 @@
 
 	say_list_type = /datum/say_list/shadekin
 
-	response_help = "pets the"
-	response_disarm = "bops the"
-	response_harm = "hits the"
+	response_help = "pets"
+	response_disarm = "bops"
+	response_harm = "hits"
 
 	attacktext = list("mauled","slashed","clawed")
 	friendly = list("boops", "pawbs", "mars softly at", "sniffs on")

--- a/code/modules/mob/living/simple_mob/subtypes/vore/snake.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/snake.dm
@@ -14,6 +14,10 @@
 	melee_damage_lower = 5
 	melee_damage_upper = 12
 
+	response_help = "pats"
+	response_disarm = "tries to shove"
+	response_harm = "hits"
+
 	old_x = -16
 	old_y = -16
 	default_pixel_x = -16

--- a/code/modules/mob/living/simple_mob/subtypes/vore/wolf.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/wolf.dm
@@ -15,6 +15,10 @@
 	icon_state = "wolf"
 	icon = 'icons/mob/vore.dmi'
 
+	response_help = "pets"
+	response_disarm = "bops"
+	response_harm = "hits"
+
 	movement_cooldown = 5
 
 	harm_intent_damage = 5

--- a/code/modules/mob/living/simple_mob/subtypes/vore/wolfgirl.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/wolfgirl.dm
@@ -2,7 +2,7 @@
 	name = "wolfgirl"
 	desc = "AwooOOOOoooo!"
 	tt_desc = "Homo lupus"
-	
+
 	icon_state = "wolfgirl"
 	icon_living = "wolfgirl"
 	icon_dead = "wolfgirl-dead"
@@ -12,9 +12,9 @@
 	maxHealth = 30
 	health = 30
 
-	response_help = "pats the"
-	response_disarm = "gently pushes aside the"
-	response_harm = "hits the"
+	response_help = "pats"
+	response_disarm = "gently pushes aside"
+	response_harm = "hits"
 
 	harm_intent_damage = 8
 	melee_damage_lower = 7

--- a/code/modules/mob/living/simple_mob/subtypes/vore/zz_vore_overrides.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/zz_vore_overrides.dm
@@ -31,6 +31,9 @@
 	icon_dead = "xenohunter-dead"
 	icon_gib = "gibbed-a"
 	vore_icons = SA_ICON_LIVING
+	response_help = "pets"
+	response_disarm = "gently pushes aside"
+	response_harm = "hits"
 
 /mob/living/simple_mob/animal/space/alien/drone
 	vore_active = 1
@@ -90,6 +93,9 @@
 	icon_dead = "spacebear-dead"
 	icon_gib = "bear-gib"
 	vore_icons = SA_ICON_LIVING
+	response_help = "pets"
+	response_disarm = "gently pushes aside"
+	response_harm = "hits"
 
 /mob/living/simple_mob/animal/space/bear/hudson
 	name = "Hudson"
@@ -108,6 +114,9 @@
 	icon = 'icons/mob/vore.dmi'
 	vore_active = 1
 	vore_icons = SA_ICON_LIVING
+	response_help = "pets"
+	response_disarm = "gently pushes aside"
+	response_harm = "hits"
 
 /* //VOREStation AI Temporary removal
 /mob/living/simple_mob/hostile/creature/vore
@@ -225,11 +234,17 @@
 	vore_active = 1
 	// NO VORE SPRITES
 	vore_max_size = RESIZE_SMALL
+	response_help = "pets"
+	response_disarm = "gently pushes aside"
+	response_harm = "hits"
 
 /mob/living/simple_mob/animal/passive/penguin
 	vore_active = 1
 	// NO VORE SPRITES
 	vore_max_size = RESIZE_SMALL
+	response_help = "pets"
+	response_disarm = "gently pushes aside"
+	response_harm = "hits"
 
 
 /mob/living/simple_mob/hostile/carp/pike


### PR DESCRIPTION
-Fixes mob radio headset. Now actually hearable and able to be properly put into the mob.
-Makes a bunch of voremobs start with darksight enabled.
-Makes at least the mountable mobs remove the redundant movement cooldown on player control presence.
-Makes some formerly mountable mobs mountable again. (deathclaw, dragon, hippo, horse, panther, rat)
-Snips some redundant the's out of the petting resposes. (No more player pets the the mob)