### PR TITLE
Post-patch Bug Fixes

### DIFF
--- a/code/modules/mob/new_player/sprite_accessories_vr.dm
+++ b/code/modules/mob/new_player/sprite_accessories_vr.dm
@@ -378,7 +378,7 @@
 		gender = NEUTER
 
 	vulp_hair_bun
-		name = "Bun"
+		name = "Vulp Bun"
 		icon = 'icons/mob/human_face_vr.dmi'
 		icon_add = 'icons/mob/human_face_vr_add.dmi'
 		icon_state = "bun"

--- a/config/custom_items.txt
+++ b/config/custom_items.txt
@@ -482,7 +482,7 @@ item_path: /obj/item/clothing/accessory/storage/knifeharness
 
 {
 ckey: kitchifox
-character_name: Rana Uma
+character_name: Rana Starsong-Uma
 item_path: /obj/item/clothing/accessory/medal/silver/unity
 }
 

--- a/maps/tether/tether-10-colony.dmm
+++ b/maps/tether/tether-10-colony.dmm
@@ -17623,7 +17623,8 @@
 	cur_coils = 4;
 	input_attempt = 1;
 	input_level = 1e+006;
-	output_level = 1e+006
+	output_level = 1e+006;
+	RCon = 0
 	},
 /obj/structure/cable/cyan{
 	d2 = 2;


### PR DESCRIPTION
- Rana Starsong-Uma's fluff item is keyed to the right character (Fixes #5992 )
- Fixes an error where a Vorestation hair style was overriding a Polaris one
- Houseboat's SMES will no longer show up on RCON