### PR TITLE
Lock Atmos Down Time

### DIFF
--- a/code/modules/holomap/holomap_area.dm
+++ b/code/modules/holomap/holomap_area.dm
@@ -33,7 +33,8 @@
 
 /area/engineering
 	holomap_color = HOLOMAP_AREACOLOR_ENGINEERING
-/area/engineering/atmos/intake
+//TFF 11/12/19 - Minor refactor, makes mice spawn only in Atmos.
+/area/engineering/atmos_intake
 	holomap_color = null
 /area/maintenance/substation/engineering
 	holomap_color = HOLOMAP_AREACOLOR_ENGINEERING

--- a/maps/tether/tether-01-surface1.dmm
+++ b/maps/tether/tether-01-surface1.dmm
@@ -5347,7 +5347,7 @@
 	report_danger_level = 0
 	},
 /turf/simulated/floor/tiled/steel_dirty/virgo3b,
-/area/engineering/atmos/intake)
+/area/engineering/atmos_intake)
 "ajg" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -5358,13 +5358,13 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/steel_dirty/virgo3b,
-/area/engineering/atmos/intake)
+/area/engineering/atmos_intake)
 "ajh" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/steel_dirty/virgo3b,
-/area/engineering/atmos/intake)
+/area/engineering/atmos_intake)
 "aji" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 6
@@ -27273,6 +27273,14 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
 /obj/structure/window/reinforced,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id = "atmoslockdown";
+	name = "Atmospherics Lockdown";
+	opacity = 0
+	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos/processing)
 "aTK" = (
@@ -27283,6 +27291,14 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
 /obj/structure/window/reinforced,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id = "atmoslockdown";
+	name = "Atmospherics Lockdown";
+	opacity = 0
+	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos/processing)
 "aTL" = (
@@ -27294,6 +27310,14 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
 /obj/structure/window/reinforced,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id = "atmoslockdown";
+	name = "Atmospherics Lockdown";
+	opacity = 0
+	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos/processing)
 "aTM" = (
@@ -27415,11 +27439,11 @@
 /area/crew_quarters/visitor_lodging)
 "aTW" = (
 /turf/simulated/floor/tiled/steel_dirty/virgo3b,
-/area/engineering/atmos/intake)
+/area/engineering/atmos_intake)
 "aTX" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction,
 /turf/simulated/floor/tiled/steel_dirty/virgo3b,
-/area/engineering/atmos/intake)
+/area/engineering/atmos_intake)
 "aTY" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/black,
 /turf/simulated/floor/tiled/techmaint,
@@ -27683,7 +27707,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/tiled/steel_dirty/virgo3b,
-/area/engineering/atmos/intake)
+/area/engineering/atmos_intake)
 "aUw" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 9
@@ -27692,19 +27716,19 @@
 	dir = 6
 	},
 /turf/simulated/floor/tiled/steel_dirty/virgo3b,
-/area/engineering/atmos/intake)
+/area/engineering/atmos_intake)
 "aUx" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 9
 	},
 /turf/simulated/floor/tiled/steel_dirty/virgo3b,
-/area/engineering/atmos/intake)
+/area/engineering/atmos_intake)
 "aUy" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 5
 	},
 /turf/simulated/floor/tiled/steel_dirty/virgo3b,
-/area/engineering/atmos/intake)
+/area/engineering/atmos_intake)
 "aUz" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 5
@@ -27713,13 +27737,13 @@
 	dir = 10
 	},
 /turf/simulated/floor/tiled/steel_dirty/virgo3b,
-/area/engineering/atmos/intake)
+/area/engineering/atmos_intake)
 "aUA" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 10
 	},
 /turf/simulated/floor/tiled/steel_dirty/virgo3b,
-/area/engineering/atmos/intake)
+/area/engineering/atmos_intake)
 "aUB" = (
 /obj/machinery/power/apc/super{
 	dir = 4;
@@ -27731,10 +27755,10 @@
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/tiled/steel_dirty/virgo3b,
-/area/engineering/atmos/intake)
+/area/engineering/atmos_intake)
 "aUC" = (
 /turf/simulated/wall/r_wall,
-/area/engineering/atmos/intake)
+/area/engineering/atmos_intake)
 "aUD" = (
 /obj/machinery/atmospherics/pipe/simple/visible/purple,
 /obj/structure/cable/cyan{
@@ -27743,7 +27767,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
-/area/engineering/atmos/intake)
+/area/engineering/atmos_intake)
 "aUE" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
@@ -27867,7 +27891,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging,
 /turf/simulated/floor/tiled/steel_dirty/virgo3b,
-/area/engineering/atmos/intake)
+/area/engineering/atmos_intake)
 "aUS" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /obj/machinery/light/small{
@@ -28051,6 +28075,14 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 1;
+	icon_state = "pdoor0";
+	id = "atmoslockdown";
+	name = "Atmospherics Lockdown";
+	opacity = 0
 	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos/processing)
@@ -28305,7 +28337,7 @@
 	id_tag = "atmos_intake"
 	},
 /turf/simulated/floor/tiled/steel_dirty/virgo3b,
-/area/engineering/atmos/intake)
+/area/engineering/atmos_intake)
 "aVF" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/visible/purple{
@@ -28315,6 +28347,14 @@
 /obj/structure/window/reinforced/full,
 /obj/structure/window/reinforced{
 	dir = 8
+	},
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 1;
+	icon_state = "pdoor0";
+	id = "atmoslockdown";
+	name = "Atmospherics Lockdown";
+	opacity = 0
 	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos/processing)
@@ -28490,7 +28530,7 @@
 	use_power = 1
 	},
 /turf/simulated/floor/tiled/steel_dirty/virgo3b,
-/area/engineering/atmos/intake)
+/area/engineering/atmos_intake)
 "aVV" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
@@ -28500,6 +28540,14 @@
 /obj/structure/window/reinforced/full,
 /obj/structure/window/reinforced{
 	dir = 8
+	},
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 1;
+	icon_state = "pdoor0";
+	id = "atmoslockdown";
+	name = "Atmospherics Lockdown";
+	opacity = 0
 	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos/processing)
@@ -28859,7 +28907,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/steel_dirty/virgo3b,
-/area/engineering/atmos/intake)
+/area/engineering/atmos_intake)
 "aWP" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
@@ -29002,7 +29050,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/steel_dirty/virgo3b,
-/area/engineering/atmos/intake)
+/area/engineering/atmos_intake)
 "aXe" = (
 /obj/structure/table/bench/steel,
 /turf/simulated/floor/plating,
@@ -31928,6 +31976,15 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/mining_main/surfacecargo)
+"bcP" = (
+/obj/machinery/atmospherics/pipe/simple/visible/yellow,
+/obj/machinery/alarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
+	},
+/turf/simulated/floor/plating,
+/area/engineering/atmos/processing)
 "cGJ" = (
 /turf/simulated/floor/plating,
 /area/maintenance/lower/mining_eva)
@@ -41159,7 +41216,7 @@ aRU
 aSC
 aTj
 aSC
-aSC
+bcP
 aSC
 aUS
 aVm

--- a/maps/tether/tether-01-surface1.dmm
+++ b/maps/tether/tether-01-surface1.dmm
@@ -2482,6 +2482,14 @@
 	name = "Atmospherics Substation"
 	},
 /obj/machinery/door/firedoor/glass,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id = "atmoslockdown";
+	name = "Atmospherics Lockdown";
+	opacity = 0
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/surface_atmos)
 "aek" = (
@@ -4936,6 +4944,14 @@
 	req_access = list(24)
 	},
 /obj/machinery/door/firedoor/glass,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id = "atmoslockdown";
+	name = "Atmospherics Lockdown";
+	opacity = 0
+	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
 "aiC" = (
@@ -22133,6 +22149,13 @@
 	dir = 1;
 	pixel_y = 28
 	},
+/obj/machinery/button/remote/blast_door{
+	id = "atmoslockdown";
+	name = "Atmospherics Lockdown";
+	pixel_x = 0;
+	pixel_y = 0;
+	req_one_access = list(10,24)
+	},
 /turf/simulated/floor/tiled,
 /area/engineering/atmos)
 "aKn" = (
@@ -24610,6 +24633,14 @@
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id = "atmoslockdown";
+	name = "Atmospherics Lockdown";
+	opacity = 0
+	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos/processing)
 "aOT" = (
@@ -27322,6 +27353,14 @@
 	req_access = list(24)
 	},
 /obj/machinery/door/firedoor,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id = "atmoslockdown";
+	name = "Atmospherics Lockdown";
+	opacity = 0
+	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
 "aTU" = (
@@ -28482,6 +28521,14 @@
 /obj/machinery/door/airlock/maintenance/engi{
 	name = "Atmospherics";
 	req_access = list(24)
+	},
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 1;
+	icon_state = "pdoor0";
+	id = "atmoslockdown";
+	name = "Atmospherics Lockdown";
+	opacity = 0
 	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos/processing)

--- a/maps/tether/tether-02-surface2.dmm
+++ b/maps/tether/tether-02-surface2.dmm
@@ -8548,16 +8548,8 @@
 /obj/machinery/door/firedoor/glass,
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	dir = 1;
-	icon_state = "pdoor0";
-	id = "atmoslockdown";
-	name = "Atmospherics Lockdown";
-	opacity = 0
-	},
 /turf/simulated/floor/plating,
-/area/engineering/lower/breakroom)
+/area/engineering/lower/lobby)
 "are" = (
 /obj/machinery/door/firedoor/glass,
 /obj/structure/grille,
@@ -8577,49 +8569,21 @@
 	name = "Atmospherics"
 	},
 /obj/machinery/door/firedoor/glass,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id = "atmoslockdown";
-	name = "Atmospherics Lockdown";
-	opacity = 0
-	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/engineering/lower/lobby)
 "arg" = (
 /turf/simulated/wall,
 /area/engineering/lower/breakroom)
 "arh" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/airlock/glass{
+	name = "Atmospherics"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/door/airlock/glass_atmos{
-	name = "Atmospherics";
-	req_access = list(24)
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor/glass,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	dir = 1;
-	icon_state = "pdoor0";
-	id = "atmoslockdown";
-	name = "Atmospherics Lockdown";
-	opacity = 0
-	},
-/turf/simulated/floor/wood,
-/area/engineering/lower/breakroom)
+/turf/simulated/floor/tiled/steel_grid,
+/area/engineering/lower/lobby)
 "ari" = (
 /obj/structure/grille,
 /obj/structure/railing{
@@ -14139,23 +14103,11 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
 "aAe" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/airlock/glass{
-	name = "Atmospherics"
-	},
-/obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor/glass,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id = "atmoslockdown";
-	name = "Atmospherics Lockdown";
-	opacity = 0
-	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/engineering/lower/lobby)
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/turf/simulated/floor/plating,
+/area/engineering/lower/breakroom)
 "aAf" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 10
@@ -14751,18 +14703,26 @@
 /turf/simulated/open,
 /area/engineering/atmos)
 "aBg" = (
-/obj/machinery/door/firedoor/glass,
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id = "atmoslockdown";
-	name = "Atmospherics Lockdown";
-	opacity = 0
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/door/airlock/glass_atmos{
+	name = "Atmospherics";
+	req_access = list(24)
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/wood,
 /area/engineering/lower/breakroom)
 "aBh" = (
 /obj/structure/railing{
@@ -40097,7 +40057,7 @@ adY
 aoZ
 afG
 aqs
-are
+ard
 arH
 asD
 ath
@@ -40239,7 +40199,7 @@ adY
 apa
 apI
 aqt
-are
+ard
 arH
 asE
 ath
@@ -40381,7 +40341,7 @@ aeK
 apb
 apJ
 aqs
-are
+ard
 arI
 asF
 ath
@@ -40807,7 +40767,7 @@ ajB
 ajB
 apL
 aqv
-are
+ard
 arL
 asF
 atj
@@ -40949,7 +40909,7 @@ aia
 ape
 apM
 aqw
-aAe
+arh
 arM
 asG
 atk
@@ -41234,11 +41194,11 @@ apf
 apN
 aqs
 arg
-ard
-ard
-arh
-ard
-ard
+aAe
+aAe
+aBg
+aAe
+aAe
 avf
 avN
 awB
@@ -41659,7 +41619,7 @@ aoC
 apf
 apN
 aqs
-aBg
+aAe
 arQ
 asK
 atp
@@ -41801,7 +41761,7 @@ aoC
 apf
 apN
 aqs
-aBg
+aAe
 arR
 asL
 atq
@@ -41943,7 +41903,7 @@ aoC
 apf
 apN
 aqs
-aBg
+aAe
 arS
 asK
 atp

--- a/maps/tether/tether-02-surface2.dmm
+++ b/maps/tether/tether-02-surface2.dmm
@@ -8548,33 +8548,77 @@
 /obj/machinery/door/firedoor/glass,
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 1;
+	icon_state = "pdoor0";
+	id = "atmoslockdown";
+	name = "Atmospherics Lockdown";
+	opacity = 0
+	},
+/turf/simulated/floor/plating,
+/area/engineering/lower/breakroom)
+"are" = (
+/obj/machinery/door/firedoor/glass,
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id = "atmoslockdown";
+	name = "Atmospherics Lockdown";
+	opacity = 0
+	},
 /turf/simulated/floor/plating,
 /area/engineering/lower/lobby)
-"are" = (
-/obj/machinery/door/airlock/glass{
-	name = "Atmospherics"
-	},
-/obj/machinery/door/firedoor/glass,
-/turf/simulated/floor/tiled/steel_grid,
-/area/engineering/lower/lobby)
 "arf" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/airlock/glass{
 	name = "Atmospherics"
 	},
-/obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor/glass,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id = "atmoslockdown";
+	name = "Atmospherics Lockdown";
+	opacity = 0
+	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/engineering/lower/lobby)
 "arg" = (
 /turf/simulated/wall,
 /area/engineering/lower/breakroom)
 "arh" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/door/airlock/glass_atmos{
+	name = "Atmospherics";
+	req_access = list(24)
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/machinery/door/firedoor/glass,
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/turf/simulated/floor/plating,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 1;
+	icon_state = "pdoor0";
+	id = "atmoslockdown";
+	name = "Atmospherics Lockdown";
+	opacity = 0
+	},
+/turf/simulated/floor/wood,
 /area/engineering/lower/breakroom)
 "ari" = (
 /obj/structure/grille,
@@ -9857,26 +9901,26 @@
 /area/engineering/lower/lobby)
 "atm" = (
 /obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /obj/machinery/door/airlock/glass_atmos{
 	name = "Atmospherics";
 	req_access = list(24)
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/door/firedoor/glass,
-/turf/simulated/floor/wood,
-/area/engineering/lower/breakroom)
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id = "atmoslockdown";
+	name = "Atmospherics Lockdown";
+	opacity = 0
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/lower/lobby)
 "atn" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
@@ -9924,6 +9968,13 @@
 /obj/structure/table/glass,
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/button/remote/blast_door{
+	id = "atmoslockdown";
+	name = "Atmospherics Lockdown";
+	pixel_x = 0;
+	pixel_y = 0;
+	req_one_access = list(10,24)
 	},
 /turf/simulated/floor/carpet,
 /area/engineering/lower/breakroom)
@@ -10829,20 +10880,6 @@
 /turf/simulated/wall/r_wall,
 /area/engineering/lower/lobby)
 "avd" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
-/obj/machinery/door/airlock/glass_atmos{
-	name = "Atmospherics";
-	req_access = list(24)
-	},
-/obj/machinery/door/firedoor/glass,
-/turf/simulated/floor/tiled,
-/area/engineering/lower/lobby)
-"ave" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/red,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -10852,8 +10889,46 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor/glass,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id = "atmoslockdown";
+	name = "Atmospherics Lockdown";
+	opacity = 0
+	},
 /turf/simulated/floor/tiled,
 /area/engineering/lower/lobby)
+"ave" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1;
+	icon_state = "borderfloor";
+	pixel_y = 0
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	icon_state = "bordercolor";
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/yellow/bordercorner2{
+	icon_state = "bordercolorcorner2";
+	dir = 1
+	},
+/obj/structure/table/standard,
+/obj/item/taperoll/atmos,
+/obj/random/tech_supply,
+/obj/random/tool,
+/obj/machinery/button/remote/blast_door{
+	id = "atmoslockdown";
+	name = "Atmospherics Lockdown";
+	pixel_x = 0;
+	pixel_y = 0;
+	req_one_access = list(10,24)
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/atmos/monitoring)
 "avf" = (
 /turf/simulated/wall/r_wall,
 /area/engineering/lower/breakroom)
@@ -14064,16 +14139,23 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
 "aAe" = (
-/obj/machinery/door/airlock/maintenance/engi{
-	name = "Atmospherics";
-	req_access = list(24)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/airlock/glass{
+	name = "Atmospherics"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor/glass,
-/turf/simulated/floor/plating,
-/area/engineering/atmos)
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id = "atmoslockdown";
+	name = "Atmospherics Lockdown";
+	opacity = 0
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/engineering/lower/lobby)
 "aAf" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 10
@@ -14669,15 +14751,19 @@
 /turf/simulated/open,
 /area/engineering/atmos)
 "aBg" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/airlock/maintenance/engi{
-	name = "Atmospherics";
-	req_access = list(24)
+/obj/machinery/door/firedoor/glass,
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id = "atmoslockdown";
+	name = "Atmospherics Lockdown";
+	opacity = 0
 	},
-/obj/structure/catwalk,
 /turf/simulated/floor/plating,
-/area/engineering/atmos)
+/area/engineering/lower/breakroom)
 "aBh" = (
 /obj/structure/railing{
 	dir = 8
@@ -15004,29 +15090,6 @@
 /obj/machinery/vending/coffee,
 /turf/simulated/floor/tiled/monotile,
 /area/rnd/breakroom)
-"aBG" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 1;
-	icon_state = "borderfloor";
-	pixel_y = 0
-	},
-/obj/effect/floor_decal/corner/yellow/border{
-	icon_state = "bordercolor";
-	dir = 1
-	},
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/yellow/bordercorner2{
-	icon_state = "bordercolorcorner2";
-	dir = 1
-	},
-/obj/structure/table/standard,
-/obj/item/taperoll/atmos,
-/obj/random/tech_supply,
-/obj/random/tool,
-/turf/simulated/floor/tiled,
-/area/engineering/atmos/monitoring)
 "aBH" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -15687,18 +15750,23 @@
 /area/maintenance/asmaint2)
 "aCY" = (
 /obj/machinery/door/airlock/maintenance/engi{
-	name = "Drone Bay";
+	name = "Atmospherics";
 	req_access = list(24)
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/door/firedoor/glass,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/engineering/drone_fabrication)
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 1;
+	icon_state = "pdoor0";
+	id = "atmoslockdown";
+	name = "Atmospherics Lockdown";
+	opacity = 0
+	},
+/turf/simulated/floor/plating,
+/area/engineering/atmos)
 "aCZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -16592,12 +16660,21 @@
 /turf/simulated/floor/tiled/steel_dirty,
 /area/maintenance/asmaint2)
 "aFa" = (
-/obj/machinery/door/firedoor/glass,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/airlock/maintenance/engi{
-	name = "Atmospherics Balcony";
+	name = "Atmospherics";
 	req_access = list(24)
 	},
 /obj/structure/catwalk,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id = "atmoslockdown";
+	name = "Atmospherics Lockdown";
+	opacity = 0
+	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
 "aFb" = (
@@ -26821,6 +26898,28 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/brig)
+"aVV" = (
+/obj/machinery/door/airlock/maintenance/engi{
+	name = "Drone Bay";
+	req_access = list(24)
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 1;
+	icon_state = "pdoor0";
+	id = "atmoslockdown";
+	name = "Atmospherics Lockdown";
+	opacity = 0
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/engineering/drone_fabrication)
 "aVW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -27479,6 +27578,23 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/rnd/outpost/xenobiology/outpost_slimepens)
+"aWN" = (
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/maintenance/engi{
+	name = "Atmospherics Balcony";
+	req_access = list(24)
+	},
+/obj/structure/catwalk,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 1;
+	icon_state = "pdoor0";
+	id = "atmoslockdown";
+	name = "Atmospherics Lockdown";
+	opacity = 0
+	},
+/turf/simulated/floor/plating,
+/area/engineering/atmos)
 "aWO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/green{
 	icon_state = "intact";
@@ -38579,7 +38695,7 @@ auk
 aAT
 aAT
 aAT
-aCY
+aVV
 aAT
 aAT
 aAT
@@ -38716,7 +38832,7 @@ atJ
 aBF
 auv
 azl
-aAe
+aCY
 aAT
 aAT
 aBW
@@ -39438,7 +39554,7 @@ aAU
 aAT
 azl
 azl
-aFa
+aWN
 azl
 azl
 aEp
@@ -39981,7 +40097,7 @@ adY
 aoZ
 afG
 aqs
-ard
+are
 arH
 asD
 ath
@@ -40123,7 +40239,7 @@ adY
 apa
 apI
 aqt
-ard
+are
 arH
 asE
 ath
@@ -40265,7 +40381,7 @@ aeK
 apb
 apJ
 aqs
-ard
+are
 arI
 asF
 ath
@@ -40549,13 +40665,13 @@ aRV
 apd
 apJ
 afG
-are
+arf
 arK
 asF
 ati
 atT
 auC
-avd
+atm
 avH
 awx
 axm
@@ -40564,7 +40680,7 @@ ayJ
 azw
 aAq
 aBc
-aBG
+ave
 aCe
 aCC
 aDe
@@ -40691,13 +40807,13 @@ ajB
 ajB
 apL
 aqv
-ard
+are
 arL
 asF
 atj
 atU
 auD
-ard
+are
 avI
 awy
 axn
@@ -40833,13 +40949,13 @@ aia
 ape
 apM
 aqw
-arf
+aAe
 arM
 asG
 atk
 atV
 auE
-ave
+avd
 avJ
 awz
 axo
@@ -41118,11 +41234,11 @@ apf
 apN
 aqs
 arg
+ard
+ard
 arh
-arh
-atm
-arh
-arh
+ard
+ard
 avf
 avN
 awB
@@ -41543,7 +41659,7 @@ aoC
 apf
 apN
 aqs
-arh
+aBg
 arQ
 asK
 atp
@@ -41685,7 +41801,7 @@ aoC
 apf
 apN
 aqs
-arh
+aBg
 arR
 asL
 atq
@@ -41827,7 +41943,7 @@ aoC
 apf
 apN
 aqs
-arh
+aBg
 arS
 asK
 atp
@@ -42267,7 +42383,7 @@ ayh
 ayO
 azG
 aAB
-aBg
+aFa
 aBN
 aCj
 aBO

--- a/maps/tether/tether-03-surface3.dmm
+++ b/maps/tether/tether-03-surface3.dmm
@@ -27249,10 +27249,12 @@
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
 "aTv" = (
-/obj/structure/shuttle/engine/propulsion,
-/turf/simulated/floor/reinforced,
-/turf/simulated/shuttle/plating/carry,
-/area/shuttle/tether/surface)
+/obj/machinery/computer/station_alert/all{
+	icon_state = "computer";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge)
 "aTw" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 4
@@ -27275,6 +27277,11 @@
 /obj/structure/window/basic,
 /turf/simulated/floor/plating,
 /area/rnd/outpost/xenobiology/outpost_first_aid)
+"aTy" = (
+/obj/structure/shuttle/engine/propulsion,
+/turf/simulated/floor/reinforced,
+/turf/simulated/shuttle/plating/carry,
+/area/shuttle/tether/surface)
 "aTA" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/wood,
@@ -29874,13 +29881,6 @@
 "aYB" = (
 /obj/machinery/computer/security{
 	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge)
-"aYC" = (
-/obj/machinery/computer/station_alert{
-	icon_state = "computer";
-	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
@@ -44318,7 +44318,7 @@ aXV
 aYg
 bae
 aYb
-aYC
+aTv
 aYK
 baw
 bbF
@@ -45345,7 +45345,7 @@ aNk
 aNl
 aNJ
 aNP
-aTv
+aTy
 aKU
 abg
 aOk
@@ -45487,7 +45487,7 @@ aNl
 aNl
 aNK
 aNP
-aTv
+aTy
 aKU
 abg
 aOk
@@ -45629,7 +45629,7 @@ aNm
 aNl
 aNK
 aNP
-aTv
+aTy
 aKU
 abg
 aOk

--- a/maps/tether/tether-06-station2.dmm
+++ b/maps/tether/tether-06-station2.dmm
@@ -30828,7 +30828,7 @@ Yq
 TY
 TY
 kj
-kf
+hQ
 od
 nD
 oj
@@ -30973,10 +30973,10 @@ KJ
 kj
 kj
 nE
-hr
-hr
-hr
-hr
+kj
+kj
+kj
+kj
 qu
 rk
 rX

--- a/maps/tether/tether-07-station3.dmm
+++ b/maps/tether/tether-07-station3.dmm
@@ -26684,20 +26684,13 @@
 /turf/simulated/floor/airless,
 /area/medical/virology)
 "PA" = (
-/obj/machinery/door/firedoor/glass,
-/obj/machinery/door/airlock/glass_medical{
-	name = "Virology Laboratory";
-	req_access = list(39)
+/obj/structure/shuttle/engine/propulsion{
+	dir = 8;
+	icon_state = "propulsion_l"
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
-/turf/simulated/floor/tiled/white,
-/area/medical/virology)
+/turf/space,
+/turf/simulated/shuttle/plating/airless/carry,
+/area/shuttle/large_escape_pod1/station)
 "PB" = (
 /turf/simulated/wall/r_wall,
 /area/medical/virologyisolation)
@@ -27103,15 +27096,15 @@
 /area/medical/virology)
 "Qp" = (
 /obj/structure/shuttle/engine/propulsion{
-	dir = 8;
-	icon_state = "propulsion_l"
+	dir = 8
 	},
 /turf/space,
 /turf/simulated/shuttle/plating/airless/carry,
 /area/shuttle/large_escape_pod1/station)
 "Qq" = (
 /obj/structure/shuttle/engine/propulsion{
-	dir = 8
+	dir = 8;
+	icon_state = "propulsion_r"
 	},
 /turf/space,
 /turf/simulated/shuttle/plating/airless/carry,
@@ -27134,13 +27127,21 @@
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/medical_restroom)
 "Qs" = (
-/obj/structure/shuttle/engine/propulsion{
-	dir = 8;
-	icon_state = "propulsion_r"
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/glass_medical{
+	name = "Virology Laboratory";
+	req_access = list(39)
 	},
-/turf/space,
-/turf/simulated/shuttle/plating/airless/carry,
-/area/shuttle/large_escape_pod1/station)
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/white,
+/area/medical/virology)
 "Qt" = (
 /turf/simulated/wall,
 /area/tether/exploration)
@@ -38506,7 +38507,7 @@ Pb
 Pi
 Pp
 Pv
-PA
+Qs
 PE
 PO
 PT
@@ -39349,11 +39350,11 @@ MK
 Iy
 ab
 NL
+PA
+Qp
+Qp
 Qp
 Qq
-Qq
-Qq
-Qs
 NL
 vt
 vt

--- a/maps/tether/tether_areas2.dm
+++ b/maps/tether/tether_areas2.dm
@@ -284,7 +284,8 @@
 	name = "Atmospherics Gas Storage"
 	icon_state = "atmos"
 
-/area/engineering/atmos/intake
+//TFF 11/12/19 - Minor refactor, makes mice spawn only in Atmos.
+/area/engineering/atmos_intake
 	name = "\improper Atmospherics Intake"
 	icon_state = "atmos"
 	sound_env = MOUNTAINS

--- a/maps/tether/tether_defines.dm
+++ b/maps/tether/tether_defines.dm
@@ -113,8 +113,8 @@
 		/area/crew_quarters/sleep/Dorm_5/holo,
 		/area/crew_quarters/sleep/Dorm_7/holo,
 		/area/rnd/miscellaneous_lab)	//TFF 31/8/19 - exempt new construction site from unit tests
+	//TFF 11/12/19 - Minor refactor, makes mice spawn only in Atmos.
 	unit_test_exempt_from_atmos = list(
-		//TFF 11/12/19 - Minor refactor, makes mice spawn only in Atmos.
 		/area/engineering/atmos_intake, // Outside,
 		/area/rnd/external, //  Outside,
 		/area/tether/surfacebase/mining_main/external, // Outside,

--- a/maps/tether/tether_defines.dm
+++ b/maps/tether/tether_defines.dm
@@ -114,7 +114,8 @@
 		/area/crew_quarters/sleep/Dorm_7/holo,
 		/area/rnd/miscellaneous_lab)	//TFF 31/8/19 - exempt new construction site from unit tests
 	unit_test_exempt_from_atmos = list(
-		/area/engineering/atmos/intake, // Outside,
+		//TFF 11/12/19 - Minor refactor, makes mice spawn only in Atmos.
+		/area/engineering/atmos_intake, // Outside,
 		/area/rnd/external, //  Outside,
 		/area/tether/surfacebase/mining_main/external, // Outside,
 		/area/tether/surfacebase/mining_main/airlock, //  Its an airlock,


### PR DESCRIPTION
Long overdue oversight fix for the Atmos Lockdown button up in Engineering never doing squat. Couple other fixes included for disposals and reinforced walls. And a missing air alarm as well as a minor tweak for a vermin event.

Changelog notes:

- Adds lockdown shutters for Atmospherics that was neglected after the Atmos overhaul several months earlier. Also adds lockdown buttons on surface 1 and 2. Missing air alarm added. Intake area windows with blast doors.

- Changes Engineering Lockdown walls to reinforced on asteroid two, close to Tech Storage.

- Missing disposal pipe in Virology fixed.

- Minor refactor so mice don't... Spawn outside because of the filepath being a child of atmos for the vermin event spawning.

- Fixes Alarms Console being the wrong type on Surface Bridge.