### PR TITLE
Fixes vorestation species without eyecolor being able to have eyecolor

### DIFF
--- a/code/modules/organs/subtypes/standard_vr.dm
+++ b/code/modules/organs/subtypes/standard_vr.dm
@@ -20,7 +20,8 @@
 		if(eye_icon)
 			var/icon/eyes_icon = new/icon(eye_icons_vr, eye_icon_vr)
 			if(eyes)
-				eyes_icon.Blend(rgb(eyes.eye_colour[1], eyes.eye_colour[2], eyes.eye_colour[3]), ICON_ADD)
+				if(owner.species.appearance_flags & HAS_EYE_COLOR)
+					eyes_icon.Blend(rgb(eyes.eye_colour[1], eyes.eye_colour[2], eyes.eye_colour[3]), ICON_ADD)
 			else
 				eyes_icon.Blend(rgb(128,0,0), ICON_ADD)
 			mob_icon.Blend(eyes_icon, ICON_OVERLAY)


### PR DESCRIPTION
Was issue exclusively with species using vorestation head subtype. Only surfaced recently with Black-Eyed kin, but might affect stuff down the line, so fix.

Bug happened if you set an eye color on other species and then switch to species without it.