### PR TITLE
Some runtime spam fixes. Also fixes fake AO.

### DIFF
--- a/code/__defines/lighting.dm
+++ b/code/__defines/lighting.dm
@@ -84,4 +84,4 @@
 #define LIGHT_COLOR_INCANDESCENT_FLASHLIGHT "#FFCC66"
 
 //Fake ambient occlusion filter
-#define AMBIENT_OCCLUSION filter(type="drop_shadow", x=0, y=-2, size=4, border=4, color="#04080FAA")
+#define AMBIENT_OCCLUSION filter(type="drop_shadow", x=0, y=-2, size=4, offset=4, color="#04080FAA")

--- a/code/modules/nifsoft/nifsoft.dm
+++ b/code/modules/nifsoft/nifsoft.dm
@@ -61,13 +61,15 @@
 
 //Called when the software is installed in the NIF
 /datum/nifsoft/proc/install()
+	if(!nif)
+		return
 	return nif.install(src)
 
 //Called when the software is removed from the NIF
 /datum/nifsoft/proc/uninstall()
-	if(active)
-		deactivate()
 	if(nif)
+		if(active)
+			deactivate()
 		. = nif.uninstall(src)
 		nif = null
 	if(!QDESTROYING(src))

--- a/code/modules/nifsoft/software/13_soulcatcher.dm
+++ b/code/modules/nifsoft/software/13_soulcatcher.dm
@@ -55,10 +55,14 @@
 			nif.human.verbs -= /mob/living/carbon/human/proc/nme
 
 	proc/save_settings()
+		if(!nif)
+			return
 		nif.save_data["[list_pos]"] = inside_flavor
 		return TRUE
 
 	proc/load_settings()
+		if(!nif)
+			return
 		var/load = nif.save_data["[list_pos]"]
 		if(load)
 			inside_flavor = load


### PR DESCRIPTION
-Fixes several instances of runtime spam caused by lack of sanity checks in nifsoft procs.
-Fixes a runtime spam caused by 512>513 transition having renamed a fake ao filter argument.
-This also fixes the fake ao.