### PR TITLE
Fix nifsoft vendor runtime

### DIFF
--- a/code/modules/nifsoft/nif_softshop.dm
+++ b/code/modules/nifsoft/nif_softshop.dm
@@ -217,3 +217,8 @@
 		currently_vending = null
 		SSnanoui.update_uis(src)
 	return 1
+
+//Can't throw intangible software at people.
+/obj/machinery/vending/nifsoft_shop/throw_item()
+	//TODO: Make it throw disks at people with random software? That might be fun. EVEN THE ILLEGAL ONES? ;o
+	return 0


### PR DESCRIPTION
Caused by the vendor attempting to throw intangible software at people either due to wires cut or vendor virus.