### PR TITLE
Add synth reagent purge verb

### DIFF
--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -97,6 +97,7 @@
 	var/obj/item/organ/external/T = organs_by_name[BP_TORSO]
 	if(T && T.robotic >= ORGAN_ROBOT)
 		src.verbs += /mob/living/carbon/human/proc/self_diagnostics
+		src.verbs += /mob/living/carbon/human/proc/reagent_purge //VOREStation Add
 		var/datum/robolimb/R = all_robolimbs[T.model]
 		synthetic = R
 		return synthetic

--- a/code/modules/mob/living/carbon/human/human_powers_vr.dm
+++ b/code/modules/mob/living/carbon/human/human_powers_vr.dm
@@ -1,0 +1,16 @@
+/mob/living/carbon/human/proc/purge_reagents()
+	set name = "Purge Reagents"
+	set desc = "Empty yourself of any reagents you may have consumed or come into contact with."
+	set category = "IC"
+
+	if(stat == DEAD) return
+
+	to_chat(src, "<span class='notice'>Performing reagent purge, please wait...</span>")
+	sleep(50)
+	src.bloodstr.clear_reagents()
+	src.ingested.clear_reagents()
+	src.touching.clear_reagents()
+	to_chat(src, "<span class='notice'>Reagents purged!</span>")
+
+	return true
+	

--- a/code/modules/mob/living/carbon/human/human_powers_vr.dm
+++ b/code/modules/mob/living/carbon/human/human_powers_vr.dm
@@ -12,5 +12,5 @@
 	src.touching.clear_reagents()
 	to_chat(src, "<span class='notice'>Reagents purged!</span>")
 
-	return true
+	return TRUE
 	

--- a/code/modules/mob/living/carbon/human/human_powers_vr.dm
+++ b/code/modules/mob/living/carbon/human/human_powers_vr.dm
@@ -1,4 +1,4 @@
-/mob/living/carbon/human/proc/purge_reagents()
+/mob/living/carbon/human/proc/reagent_purge()
 	set name = "Purge Reagents"
 	set desc = "Empty yourself of any reagents you may have consumed or come into contact with."
 	set category = "IC"

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -2258,6 +2258,7 @@
 #include "code\modules\mob\living\carbon\human\human_movement.dm"
 #include "code\modules\mob\living\carbon\human\human_organs.dm"
 #include "code\modules\mob\living\carbon\human\human_powers.dm"
+#include "code\modules\mob\living\carbon\human\human_powers_vr.dm"
 #include "code\modules\mob\living\carbon\human\human_resist.dm"
 #include "code\modules\mob\living\carbon\human\human_species.dm"
 #include "code\modules\mob\living\carbon\human\human_species_vr.dm"


### PR DESCRIPTION
Allows synths to purge reagents in them. Not really a balance issue since the reagents can't affect them, pretty much just affects vore. And flavoring I guess!

Probably works? Probably. ... Probably.

Fixes #5199