### PR TITLE
Unused Lore

### DIFF
--- a/code/game/objects/effects/decals/posters/polarisposters.dm
+++ b/code/game/objects/effects/decals/posters/polarisposters.dm
@@ -180,10 +180,14 @@
 	The poster's captions explain the importance of knowing how to operate a mechatronic vehicle safely, especially near other personnel.\
 	The image seems important."
 
+//VOREStation Removal Start TFF 17/12/19 - lore not used in our station's own lore.
+/*
 /datum/poster/nanotrasen/nt_4
 	icon_state = "ntposter04"
 	name = "Beware Aetotheans"
 	desc = "This poster displays a distinctly hostile-looking red Promethean in a black coat. The fine-print around the edges warns the reader about the dangers posed by Almachi Prometheans."
+*/
+//VOREstation Removal End
 
 /datum/poster/nanotrasen/nt_5
 	icon_state = "ntposter05"


### PR DESCRIPTION
Changelog Notes:

- Removes a poster that refers to sub-breeds of Prommies in lore that we don't use in Virgo's own lore.