### PR TITLE
Fixes resizing for icons taller than 32p

### DIFF
--- a/code/__defines/lighting.dm
+++ b/code/__defines/lighting.dm
@@ -84,4 +84,4 @@
 #define LIGHT_COLOR_INCANDESCENT_FLASHLIGHT "#FFCC66"
 
 //Fake ambient occlusion filter
-#define AMBIENT_OCCLUSION filter(type="drop_shadow", x=0, y=-2, size=4, offset=4, color="#04080FAA")
+#define AMBIENT_OCCLUSION filter(type="drop_shadow", x=0, y=-2, size=4, offset=3, color="#04080F80")

--- a/code/modules/mob/living/carbon/human/species/species_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/species_vr.dm
@@ -18,6 +18,7 @@
 	var/wing_animation
 	var/icobase_wing
 	var/wikilink = null //link to wiki page for species
+	var/icon_height = 32
 
 /datum/species/proc/update_attack_types()
 	unarmed_attacks = list()

--- a/code/modules/mob/living/carbon/human/species/station/station_special_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_special_vr.dm
@@ -406,6 +406,7 @@
 	name_language = LANGUAGE_CANILUNZT
 	primitive_form = "Wolpin"
 	color_mult = 1
+	icon_height = 64
 
 	min_age = 18
 	max_age = 200

--- a/code/modules/mob/living/silicon/pai/pai_vr.dm
+++ b/code/modules/mob/living/silicon/pai/pai_vr.dm
@@ -40,9 +40,11 @@
 	if(chassis in wide_chassis)
 		icon = 'icons/mob/pai_vr64x64.dmi'
 		pixel_x = -16
+		vis_height = 64
 	else
 		icon = 'icons/mob/pai_vr.dmi'
 		pixel_x = 0
+		vis_height = 32
 
 /mob/living/silicon/pai/update_icons() //And other functions cause this to occur, such as digesting someone.
 	..()

--- a/code/modules/mob/living/simple_mob/subtypes/animal/giant_spider/giant_spider_vr.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/giant_spider/giant_spider_vr.dm
@@ -34,6 +34,7 @@
 	desc = "Absolutely gigantic, this creature is horror itself."
 	tt_desc = "X Brachypelma phorus tyrannus"
 	icon = 'icons/mob/64x64.dmi'
+	vis_height = 64
 	icon_state = "spider_queen"
 	icon_living = "spider_queen"
 	icon_dead = "spider_queen_dead"

--- a/code/modules/mob/living/simple_mob/subtypes/animal/space/gaslamp_vr.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/space/gaslamp_vr.dm
@@ -25,6 +25,7 @@ TODO: Make them light up and heat the air when exposed to oxygen.
 	icon_living = "gaslamp"
 	icon_dead = "gaslamp-dead"
 	icon = 'icons/mob/vore32x64.dmi'
+	vis_height = 64
 
 	faction = "virgo3b"
 	maxHealth = 100

--- a/code/modules/mob/living/simple_mob/subtypes/horror/Master.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/horror/Master.dm
@@ -8,6 +8,7 @@
 	icon_rest = "Helix"
 	faction = "horror"
 	icon = 'icons/mob/horror_show/master.dmi'
+	vis_height = 64
 	icon_gib = "generic_gib"
 	anchored = 1
 

--- a/code/modules/mob/living/simple_mob/subtypes/horror/shittytim.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/horror/shittytim.dm
@@ -8,6 +8,7 @@
 	icon_rest = "shitty_tim"
 	faction = "horror"
 	icon = 'icons/mob/horror_show/tallhorror.dmi'
+	vis_height = 64
 	icon_gib = "generic_gib"
 
 	attack_sound = 'sound/h_sounds/youknowwhoitis.ogg'

--- a/code/modules/mob/living/simple_mob/subtypes/horror/timling.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/horror/timling.dm
@@ -8,6 +8,7 @@
 	icon_rest = "timling"
 	faction = "horror"
 	icon = 'icons/mob/horror_show/tallhorror.dmi'
+	vis_height = 64
 	icon_gib = "generic_gib"
 
 	attack_sound = 'sound/h_sounds/youknowwhoitis.ogg'

--- a/code/modules/mob/living/simple_mob/subtypes/vore/deathclaw.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/deathclaw.dm
@@ -13,6 +13,7 @@
 	icon_living = "deathclaw"
 	icon_state = "deathclaw"
 	icon = 'icons/mob/vore64x64.dmi'
+	vis_height = 64
 
 	attacktext = list("mauled")
 

--- a/code/modules/mob/living/simple_mob/subtypes/vore/demon/demon.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/demon/demon.dm
@@ -7,6 +7,7 @@
 	icon_dead = "boxfox_dead"
 	icon_rest = "boxfox_rest"
 	icon = 'icons/mob/demon_vr.dmi'
+	vis_height = 47
 
 	faction = "demon"
 	maxHealth = 30

--- a/code/modules/mob/living/simple_mob/subtypes/vore/dragon.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/dragon.dm
@@ -6,6 +6,7 @@
 	icon_living = "reddragon"
 	icon_state = "reddragon"
 	icon = 'icons/mob/vore64x64.dmi'
+	vis_height = 64
 
 	faction = "dragon"
 	maxHealth = 500 // Boss

--- a/code/modules/mob/living/simple_mob/subtypes/vore/panther.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/panther.dm
@@ -7,6 +7,7 @@
 	icon_living = "panther"
 	icon_dead = "panther-dead"
 	icon = 'icons/mob/vore64x64.dmi'
+	vis_height = 64
 
 	faction = "panther"
 	maxHealth = 200

--- a/code/modules/mob/living/simple_mob/subtypes/vore/snake.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/snake.dm
@@ -6,6 +6,7 @@
 	icon_living = "snake"
 	icon_state = "snake"
 	icon = 'icons/mob/vore64x64.dmi'
+	vis_height = 64
 
 	faction = "snake"
 	maxHealth = 200

--- a/code/modules/mob/living/simple_mob/subtypes/vore/zz_vore_overrides.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/zz_vore_overrides.dm
@@ -74,12 +74,14 @@
 	default_pixel_x = -16
 	pixel_x = -16
 	pixel_y = 0
+	vis_height = 64
 
 	vore_capacity = 3
 	vore_pounce_chance = 75
 
 /mob/living/simple_mob/animal/space/alien/sentinel/praetorian
 	icon = 'icons/mob/vore64x64.dmi'
+	vis_height = 64
 	vore_icons = SA_ICON_LIVING | SA_ICON_REST
 
 /mob/living/simple_mob/animal/space/alien/queen/empress/mother

--- a/code/modules/vore/eating/living_vr.dm
+++ b/code/modules/vore/eating/living_vr.dm
@@ -29,6 +29,7 @@
 	var/can_be_drop_pred = TRUE			// Mobs are pred by default.
 	var/next_preyloop					// For Fancy sound internal loop
 	var/adminbus_trash = FALSE			// For abusing trash eater for event shenanigans.
+	var/vis_height = 32					// Sprite height used for resize features.
 
 //
 // Hook for generic creation of stuff on new creatures

--- a/code/modules/vore/resizing/resize_vr.dm
+++ b/code/modules/vore/resizing/resize_vr.dm
@@ -71,7 +71,7 @@ var/const/RESIZE_A_SMALLTINY = (RESIZE_SMALL + RESIZE_TINY) / 2
 		var/duration = (abs(change)+0.25) SECONDS
 		var/matrix/resize = matrix() // Defines the matrix to change the player's size
 		resize.Scale(new_size) //Change the size of the matrix
-		resize.Translate(0, 16 * (new_size - 1)) //Move the player up in the tile so their feet align with the bottom
+		resize.Translate(0, (vis_height/2) * (new_size - 1)) //Move the player up in the tile so their feet align with the bottom
 		animate(src, transform = resize, time = duration) //Animate the player resizing
 
 		var/aura_grow_to = change > 0 ? 2 : 0.5
@@ -85,9 +85,11 @@ var/const/RESIZE_A_SMALLTINY = (RESIZE_SMALL + RESIZE_TINY) / 2
 		update_transform() //Lame way
 
 /mob/living/carbon/human/resize(var/new_size, var/animate = TRUE)
+	if(species)
+		vis_height = species.icon_height
 	. = ..()
 	if(LAZYLEN(hud_list) && has_huds)
-		var/new_y_offset = 32 * (size_multiplier - 1)
+		var/new_y_offset = vis_height * (size_multiplier - 1)
 		for(var/index = 1 to hud_list.len)
 			var/image/HI = grab_hud(index)
 			HI.pixel_y = new_y_offset


### PR DESCRIPTION
-Taller icons no longer sink into the tile below on the resize mechanics.
-Living mobs now have a var (vis_height) for their icon height, and humanmob species have a new var (icon_height) that overrides the vis_height for the resize proc.
-Also earlyports some tweaks to ambient occlusion. The new filter system took the old filter's settings as "make the shadows megathick and dummy intense" and that was ugly.