### PR TITLE
PDA Status Display Tweak

### DIFF
--- a/nano/templates/pda.tmpl
+++ b/nano/templates/pda.tmpl
@@ -348,7 +348,8 @@ Used In File(s): \code\game\objects\items\devices\PDA\PDA.dm
             </div>
             <div class="itemContent">
                 {{:helper.link('Clear', 'trash', {'cartmenu' : "1", 'choice' : "Status", 'statdisp' : "blank"}, null, null)}}
-                {{:helper.link('Shuttle ETA', 'gear', {'cartmenu' : "1", 'choice' : "Status",'statdisp' : "shuttle"}, null, null)}}
+                <!-- VOREStation Edit TFF 21/12/2563 - Virgo = Tram. Not shuttle -->
+		{{:helper.link('Tram ETA', 'gear', {'cartmenu' : "1", 'choice' : "Status",'statdisp' : "shuttle"}, null, null)}}
                 {{:helper.link('Message', 'gear', {'cartmenu' : "1", 'choice' : "Status",'statdisp' : "message"}, null, null)}}
             </div>
         </div>

--- a/nano/templates/pda.tmpl
+++ b/nano/templates/pda.tmpl
@@ -349,7 +349,7 @@ Used In File(s): \code\game\objects\items\devices\PDA\PDA.dm
             <div class="itemContent">
                 {{:helper.link('Clear', 'trash', {'cartmenu' : "1", 'choice' : "Status", 'statdisp' : "blank"}, null, null)}}
                 <!-- VOREStation Edit TFF 21/12/19 - Virgo = Tram. Not shuttle -->
-		{{:helper.link('Tram ETA', 'gear', {'cartmenu' : "1", 'choice' : "Status",'statdisp' : "shuttle"}, null, null)}}
+                {{:helper.link('Tram ETA', 'gear', {'cartmenu' : "1", 'choice' : "Status",'statdisp' : "shuttle"}, null, null)}}
                 {{:helper.link('Message', 'gear', {'cartmenu' : "1", 'choice' : "Status",'statdisp' : "message"}, null, null)}}
             </div>
         </div>

--- a/nano/templates/pda.tmpl
+++ b/nano/templates/pda.tmpl
@@ -348,7 +348,7 @@ Used In File(s): \code\game\objects\items\devices\PDA\PDA.dm
             </div>
             <div class="itemContent">
                 {{:helper.link('Clear', 'trash', {'cartmenu' : "1", 'choice' : "Status", 'statdisp' : "blank"}, null, null)}}
-                <!-- VOREStation Edit TFF 21/12/2563 - Virgo = Tram. Not shuttle -->
+                <!-- VOREStation Edit TFF 21/12/19 - Virgo = Tram. Not shuttle -->
 		{{:helper.link('Tram ETA', 'gear', {'cartmenu' : "1", 'choice' : "Status",'statdisp' : "shuttle"}, null, null)}}
                 {{:helper.link('Message', 'gear', {'cartmenu' : "1", 'choice' : "Status",'statdisp' : "message"}, null, null)}}
             </div>


### PR DESCRIPTION
Changelog Note:

- Changes the .tmpl file for PDAs' Status Display function to read out Tram ETA, not Shuttle ETA since we're Virgo here. No shuttles for transfer.