### PR TITLE
makes glasses mass producable

### DIFF
--- a/code/datums/autolathe/general_vr.dm
+++ b/code/datums/autolathe/general_vr.dm
@@ -1,3 +1,32 @@
 /datum/category_item/autolathe/general/holocollar
 	name = "Holo-collar"
 	path =/obj/item/clothing/accessory/collar/holo
+
+/datum/category_item/autolathe/general/drinkingglass_square
+	is_stack = TRUE
+
+/datum/category_item/autolathe/general/drinkingglass_rocks
+	is_stack = TRUE
+
+/datum/category_item/autolathe/general/drinkingglass_shake
+	is_stack = TRUE
+
+/datum/category_item/autolathe/general/drinkingglass_cocktail
+	is_stack = TRUE
+
+/datum/category_item/autolathe/general/drinkingglass_shot
+	is_stack = TRUE
+
+/datum/category_item/autolathe/general/drinkingglass_pint
+	is_stack = TRUE
+
+/datum/category_item/autolathe/general/drinkingglass_mug
+	is_stack = TRUE
+
+/datum/category_item/autolathe/general/drinkingglass_wine
+	is_stack = TRUE
+
+/datum/category_item/autolathe/general/metaglass
+	name = "metamorphic glass"
+	path =/obj/item/weapon/reagent_containers/food/drinks/metaglass
+	is_stack = TRUE

--- a/maps/tether/tether-03-surface3.dmm
+++ b/maps/tether/tether-03-surface3.dmm
@@ -23345,6 +23345,38 @@
 	dir = 1;
 	pixel_y = -24
 	},
+/obj/item/weapon/reagent_containers/food/drinks/metaglass{
+	step_x = 0;
+	step_y = 0
+	},
+/obj/item/weapon/reagent_containers/food/drinks/metaglass{
+	step_x = 0;
+	step_y = 0
+	},
+/obj/item/weapon/reagent_containers/food/drinks/metaglass{
+	step_x = 0;
+	step_y = 0
+	},
+/obj/item/weapon/reagent_containers/food/drinks/metaglass{
+	step_x = 0;
+	step_y = 0
+	},
+/obj/item/weapon/reagent_containers/food/drinks/metaglass{
+	step_x = 0;
+	step_y = 0
+	},
+/obj/item/weapon/reagent_containers/food/drinks/metaglass{
+	step_x = 0;
+	step_y = 0
+	},
+/obj/item/weapon/reagent_containers/food/drinks/metaglass{
+	step_x = 0;
+	step_y = 0
+	},
+/obj/item/weapon/reagent_containers/food/drinks/metaglass{
+	step_x = 0;
+	step_y = 0
+	},
 /turf/simulated/floor/wood,
 /area/tether/surfacebase/bar_backroom)
 "aLF" = (

--- a/maps/tether/tether-03-surface3.dmm
+++ b/maps/tether/tether-03-surface3.dmm
@@ -23346,36 +23346,20 @@
 	pixel_y = -24
 	},
 /obj/item/weapon/reagent_containers/food/drinks/metaglass{
-	step_x = 0;
-	step_y = 0
 	},
 /obj/item/weapon/reagent_containers/food/drinks/metaglass{
-	step_x = 0;
-	step_y = 0
 	},
 /obj/item/weapon/reagent_containers/food/drinks/metaglass{
-	step_x = 0;
-	step_y = 0
 	},
 /obj/item/weapon/reagent_containers/food/drinks/metaglass{
-	step_x = 0;
-	step_y = 0
 	},
 /obj/item/weapon/reagent_containers/food/drinks/metaglass{
-	step_x = 0;
-	step_y = 0
 	},
 /obj/item/weapon/reagent_containers/food/drinks/metaglass{
-	step_x = 0;
-	step_y = 0
 	},
 /obj/item/weapon/reagent_containers/food/drinks/metaglass{
-	step_x = 0;
-	step_y = 0
 	},
 /obj/item/weapon/reagent_containers/food/drinks/metaglass{
-	step_x = 0;
-	step_y = 0
 	},
 /turf/simulated/floor/wood,
 /area/tether/surfacebase/bar_backroom)


### PR DESCRIPTION
Makes it so glasses can be mass produces in the autolathe, including metamorphic glasses.
Also added a few more glasses to spawn in the bartender's room, because 10 is quite limiting considering you'd pour cocktails in these glasses 90% of the time.