### PR TITLE
Provides outposts with proper first aid

### DIFF
--- a/maps/tether/tether-08-mining.dmm
+++ b/maps/tether/tether-08-mining.dmm
@@ -265,6 +265,7 @@
 	pixel_x = 12;
 	pixel_y = 24
 	},
+/obj/structure/closet/secure_closet/miner,
 /turf/simulated/floor/tiled,
 /area/outpost/mining_main/break_room)
 "aL" = (
@@ -426,14 +427,29 @@
 /turf/simulated/floor/tiled,
 /area/outpost/mining_main/break_room)
 "aZ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+/obj/machinery/firealarm{
+	dir = 2;
+	layer = 3.3;
+	pixel_x = 0;
+	pixel_y = 26
 	},
-/turf/simulated/floor/tiled/steel_grid,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/closet/secure_closet/miner,
+/turf/simulated/floor/tiled,
 /area/outpost/mining_main/break_room)
 "ba" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
@@ -493,31 +509,17 @@
 /turf/simulated/floor/plating,
 /area/outpost/mining_main/maintenance)
 "bg" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9;
+	pixel_y = 0
+	},
 /obj/structure/bed/chair{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloor{
 	dir = 1
 	},
-/obj/effect/floor_decal/corner/brown/border{
-	dir = 1
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7,
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 4
-	},
-/obj/machinery/firealarm{
-	dir = 2;
-	layer = 3.3;
-	pixel_x = 0;
-	pixel_y = 26
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/steel_grid,
 /area/outpost/mining_main/break_room)
 "bh" = (
 /obj/structure/table/glass,
@@ -551,6 +553,9 @@
 	pixel_y = 3
 	},
 /obj/item/weapon/storage/box/donkpockets,
+/obj/machinery/vending/wallmed1{
+	pixel_y = -30
+	},
 /turf/simulated/floor/tiled,
 /area/outpost/mining_main/break_room)
 "bj" = (
@@ -778,6 +783,45 @@
 	},
 /turf/simulated/floor/bluegrid,
 /area/outpost/mining_main/airlock)
+"bK" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 9
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 10
+	},
+/obj/machinery/vending/wallmed_airlock{
+	pixel_x = 30
+	},
+/turf/simulated/floor/tiled,
+/area/outpost/mining_main/break_room)
+"bL" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/brown/bordercorner2{
+	dir = 5
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 9
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 10
+	},
+/turf/simulated/floor/tiled,
+/area/outpost/mining_main/break_room)
 "bW" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/brown/border,
@@ -1321,44 +1365,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/outpost/mining_main/dorms)
-"WV" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/brown/border{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 5
-	},
-/obj/effect/floor_decal/corner/brown/bordercorner2{
-	dir = 5
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 9
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 10
-	},
-/obj/structure/closet/secure_closet/miner,
-/turf/simulated/floor/tiled,
-/area/outpost/mining_main/break_room)
-"YA" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/brown/border{
-	dir = 4
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 9
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 10
-	},
-/obj/structure/closet/secure_closet/miner,
-/turf/simulated/floor/tiled,
-/area/outpost/mining_main/break_room)
 "Zn" = (
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/borderfloorblack{
@@ -4938,7 +4944,7 @@ at
 qx
 aC
 aE
-bg
+aZ
 bv
 ZV
 ty
@@ -5081,7 +5087,7 @@ ao
 ao
 VK
 aM
-aZ
+bg
 Uk
 Uk
 by
@@ -5224,8 +5230,8 @@ ab
 VK
 Uy
 hW
-YA
-WV
+bK
+bL
 by
 US
 az

--- a/maps/tether/tether-09-solars.dmm
+++ b/maps/tether/tether-09-solars.dmm
@@ -394,6 +394,18 @@
 	},
 /turf/simulated/floor/outdoors/dirt/virgo3b,
 /area/tether/outpost/solars_outside)
+"aQ" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/purple/border{
+	dir = 4
+	},
+/obj/machinery/vending/wallmed_airlock{
+	pixel_x = 30
+	},
+/turf/simulated/floor/tiled,
+/area/rnd/outpost)
 "aR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/solar_control,
@@ -6767,9 +6779,14 @@
 /turf/simulated/floor/tiled,
 /area/rnd/outpost/anomaly_lab)
 "mm" = (
-/obj/structure/table/standard,
+/obj/structure/table/woodentable,
+/obj/item/weapon/storage/box/donkpockets,
+/obj/machinery/light_switch{
+	dir = 4;
+	pixel_x = -28
+	},
 /turf/simulated/floor/tiled,
-/area/rnd/outpost/anomaly_lab)
+/area/rnd/outpost/breakroom)
 "mn" = (
 /obj/machinery/washing_machine,
 /obj/structure/window/reinforced{
@@ -7166,14 +7183,10 @@
 /turf/simulated/floor/tiled,
 /area/rnd/outpost/anomaly_lab)
 "mV" = (
-/obj/structure/table/standard,
-/obj/item/weapon/reagent_containers/glass/beaker/large,
-/obj/item/weapon/reagent_containers/dropper,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/rnd/outpost/anomaly_lab)
+/obj/effect/floor_decal/rust,
+/obj/structure/reagent_dispensers/coolanttank,
+/turf/simulated/floor/tiled/steel_dirty,
+/area/rnd/outpost/storage)
 "mW" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 4
@@ -7237,13 +7250,12 @@
 /turf/simulated/floor/tiled,
 /area/rnd/outpost/anomaly_lab)
 "nf" = (
-/obj/structure/table/standard,
-/obj/item/weapon/storage/box/beakers,
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/structure/table/woodentable,
+/obj/machinery/vending/wallmed1{
+	pixel_x = -30
 	},
 /turf/simulated/floor/tiled,
-/area/rnd/outpost/anomaly_lab)
+/area/rnd/outpost/breakroom)
 "ng" = (
 /obj/effect/floor_decal/industrial/warning/corner,
 /obj/effect/floor_decal/industrial/warning/corner{
@@ -7257,11 +7269,12 @@
 /turf/simulated/floor/tiled,
 /area/rnd/outpost/anomaly_lab)
 "ni" = (
-/obj/structure/table/standard,
-/obj/machinery/chemical_dispenser/full,
-/obj/machinery/light,
+/obj/structure/table/woodentable,
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
-/area/rnd/outpost/anomaly_lab)
+/area/rnd/outpost/breakroom)
 "nj" = (
 /obj/structure/filingcabinet/chestdrawer,
 /obj/structure/window/reinforced{
@@ -7759,14 +7772,12 @@
 /turf/simulated/floor/tiled,
 /area/rnd/outpost/xenoarch_storage)
 "of" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/purple/border{
-	dir = 4
+/obj/structure/table/standard,
+/obj/machinery/vending/wallmed1{
+	pixel_y = 30
 	},
 /turf/simulated/floor/tiled,
-/area/rnd/outpost)
+/area/rnd/outpost/anomaly_lab)
 "og" = (
 /obj/structure/dispenser/oxygen,
 /turf/simulated/floor/tiled,
@@ -7910,10 +7921,12 @@
 /turf/simulated/floor/wood,
 /area/rnd/outpost/breakroom)
 "ow" = (
-/obj/structure/table/woodentable,
-/obj/item/weapon/storage/box/donkpockets,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/tiled,
-/area/rnd/outpost/breakroom)
+/area/rnd/outpost/anomaly_lab)
 "ox" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -7984,10 +7997,13 @@
 /turf/simulated/floor/tiled,
 /area/rnd/outpost/breakroom)
 "oH" = (
-/obj/structure/table/woodentable,
-/obj/machinery/microwave,
+/obj/structure/table/standard,
+/obj/machinery/light,
+/obj/item/weapon/storage/box/beakers,
+/obj/item/weapon/reagent_containers/glass/beaker/large,
+/obj/item/weapon/reagent_containers/dropper,
 /turf/simulated/floor/tiled,
-/area/rnd/outpost/breakroom)
+/area/rnd/outpost/anomaly_lab)
 "oI" = (
 /obj/structure/table/woodentable,
 /obj/machinery/microwave,
@@ -8073,6 +8089,17 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/outpost/anomaly_lab)
+"oS" = (
+/obj/structure/table/standard,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/reagent_dispensers/acid{
+	pixel_y = -32
+	},
+/obj/machinery/reagentgrinder,
+/turf/simulated/floor/tiled,
+/area/rnd/outpost/anomaly_lab)
 "oT" = (
 /obj/structure/bed/chair/wood{
 	dir = 8
@@ -8116,18 +8143,6 @@
 "oZ" = (
 /obj/structure/sign/science,
 /turf/simulated/wall,
-/area/rnd/outpost/breakroom)
-"pa" = (
-/obj/structure/table/woodentable,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/light_switch{
-	dir = 4;
-	pixel_x = -28
-	},
-/obj/item/weapon/storage/box/donkpockets,
-/turf/simulated/floor/tiled,
 /area/rnd/outpost/breakroom)
 "pb" = (
 /obj/machinery/alarm{
@@ -22502,7 +22517,7 @@ jE
 ml
 mG
 mU
-ni
+oH
 jx
 ab
 ab
@@ -22641,10 +22656,10 @@ ng
 nV
 lH
 jE
-mm
+of
 mG
-mV
-nf
+ow
+oS
 jx
 ab
 ab
@@ -24608,7 +24623,7 @@ dD
 ch
 lS
 oc
-of
+aQ
 fd
 fy
 fQ
@@ -24626,9 +24641,9 @@ ft
 lc
 oZ
 oI
-ow
-oH
-pa
+mm
+nf
+ni
 oG
 oP
 oX
@@ -25336,7 +25351,7 @@ iU
 jf
 jo
 ji
-hM
+mV
 hM
 ov
 op


### PR DESCRIPTION
- Adds an airlock and a normal wall-med dispensers to mining outpost

- Adds an airlock and two normal wall-med dispensers to research outpost (one in breakroom, one in anomaly lab)

- Replaces ugly wall corner in gas storage with extra coolant tank

- Removes chem dispenser from anomaly lab, adds acid dispenser, extra watertank and a grinder.