### PR TITLE
Removes Points of Interest that are too hard from spawn pool

### DIFF
--- a/maps/tether/submaps/aerostat/submaps/virgo2.dm
+++ b/maps/tether/submaps/aerostat/submaps/virgo2.dm
@@ -113,13 +113,13 @@
 	desc = "You REALLY shouldn't be near this."
 	mappath = 'Blackshuttledown.dmm'
 	cost = 30
-
+/*
 /datum/map_template/virgo2/Rockybase
 	name = "Rocky Base"
 	desc = "A guide to upsetting Icarus and the EIO"
 	mappath = 'Rockybase.dmm'
 	cost = 35
-
+*/
 /datum/map_template/virgo2/MHR
 	name = "Manhack Rock"
 	desc = "A rock filled with nasty Synthetics."
@@ -137,13 +137,13 @@
 	desc = "A damaged fission engine jettisoned from a starship long ago."
 	mappath = 'DecoupledEngine.dmm'
 	cost = 15
-
+/*
 /datum/map_template/virgo2/DoomP
 	name = "DoomP"
 	desc = "Witty description here."
 	mappath = 'DoomP.dmm'
 	cost = 30
-
+*/
 /datum/map_template/virgo2/Cave
 	name = "CaveS"
 	desc = "Chitter chitter!"


### PR DESCRIPTION
According to staff some points of interest are simply too hard for exploration to handle without powergaming, so to make sure poor explorers don't have to powergame during expeditions, this removes two of hardest PoIs from the potential spawn pool to help expeditions be more balanced.