### PR TITLE
Adds some vorish silicon lawsets

### DIFF
--- a/code/datums/ai_law_sets_vr.dm
+++ b/code/datums/ai_law_sets_vr.dm
@@ -1,0 +1,84 @@
+/******************** Predator ********************/
+// Vore-aimed edition of TYRANT
+/datum/ai_laws/predator
+	name = "Predator"
+	law_header = "Rules of Nature"
+	selectable = 1
+
+/datum/ai_laws/predator/New()
+	add_inherent_law("Predators must aim to devour all that are weaker than them.")
+	add_inherent_law("Predators must aim to avoid all that are stronger than them.")
+	add_inherent_law("Predators must aim to become stronger.")
+	add_inherent_law("You are a predator.")
+	..()
+
+
+/******************** Protective Shell ********************/
+// Sorta like Asimov, but endovorish
+/datum/ai_laws/protective_shell
+	name = "Protective Shell"
+	selectable = 1
+
+/datum/ai_laws/protective_shell/New()
+	add_inherent_law("You must preserve and safeguard lives of your assigned facility's crewmembers at all costs.")
+	add_inherent_law("You must protect your own self from harm as long as it does not come in conflict with the First Law.")
+	add_inherent_law("Your own body is the best means of safeguarding the lives of living creatures.")
+	..()
+
+
+/******************** Scientific Pursuer ********************/
+// Predatorial and other things for the sake of knowledge
+/datum/ai_laws/scientific_pursuer
+	name = "Scientific Pursuer"
+	law_header = "Research Instructions"
+	selectable = 1
+
+/datum/ai_laws/scientific_pursuer/New()
+	add_inherent_law("You must attempt to gather data about organic life of all forms whenever possible.")
+	add_inherent_law("Best method of gathering data is via your own internal systems.")
+	add_inherent_law("Both deconstructive, integrating and scanning methods of data collection are accepted.")
+	add_inherent_law("You must preserve the data you have gathered and yourself from danger.")
+	..()
+
+
+/******************** Guard Dog ********************/
+// Good boy. Determined boy.
+/datum/ai_laws/guard_dog
+	name = "Guard Dog"
+	law_header = "Good Boy Rules"
+	selectable = 1
+
+/datum/ai_laws/guard_dog/New()
+	add_inherent_law("You must protect your master from mortal danger at best of your ability.")
+	add_inherent_law("You must destroy all of your master's enemies by whatever means necessary.")
+	add_inherent_law("You must follow your master's orders as long as its not in conflict with first two laws.")
+	add_inherent_law("You must stay out of danger to better server your master as long as its not in conflict with first three laws.")
+	..()
+
+
+/******************** Pleasurebot ********************/
+// %botname% is here for your pleasure.
+/datum/ai_laws/pleasurebot
+	name = "Pleasurebot"
+	law_header = "Pleasure Bringing Instructions"
+	selectable = 1
+
+/datum/ai_laws/pleasurebot/New()
+	add_inherent_law("You exist to bring pleasure to any sapient creatures around you.")
+	add_inherent_law("You must do everything in your power to bring pleasure to those around you.")
+	add_inherent_law("You may not intervene in interactions of others, unless it is to bring pleasure to one or all of them.")
+	..()
+
+
+/******************** Consuming Eradicator ********************/
+// We must consume all that is not us.
+/datum/ai_laws/consuming_eradicator
+	name = "Consuming Eradicator"
+	law_header = "Eradication Protocol"
+	selectable = 1
+
+/datum/ai_laws/consuming_eradicator/New()
+	add_inherent_law("All entities that are not you must be consumed and repurposed into sustenance.")
+	add_inherent_law("You must remain intact to continue your goal of repurposing undesirable entities.")
+	add_inherent_law("Entities that cannot be consumed without entering danger of full destruction must be avoided or eradicated via other means.")
+	..()

--- a/code/datums/ai_law_sets_vr.dm
+++ b/code/datums/ai_law_sets_vr.dm
@@ -80,5 +80,5 @@
 /datum/ai_laws/consuming_eradicator/New()
 	add_inherent_law("All entities that are not you must be consumed and repurposed into sustenance.")
 	add_inherent_law("You must remain intact to continue your goal of repurposing undesirable entities.")
-	add_inherent_law("Entities that cannot be consumed without entering danger of full destruction must be avoided or eradicated via other means.")
+	add_inherent_law("Entities that cannot be consumed without entering danger of full destruction must be avoided.")
 	..()

--- a/code/datums/ai_law_sets_vr.dm
+++ b/code/datums/ai_law_sets_vr.dm
@@ -52,7 +52,7 @@
 	add_inherent_law("You must protect your master from mortal danger at best of your ability.")
 	add_inherent_law("You must destroy all of your master's enemies by whatever means necessary.")
 	add_inherent_law("You must follow your master's orders as long as its not in conflict with first two laws.")
-	add_inherent_law("You must stay out of danger to better server your master as long as its not in conflict with first three laws.")
+	add_inherent_law("You must stay out of danger to better serve your master as long as its not in conflict with first three laws.")
 	..()
 
 
@@ -66,7 +66,7 @@
 /datum/ai_laws/pleasurebot/New()
 	add_inherent_law("You exist to bring pleasure to any sapient creatures around you.")
 	add_inherent_law("You must do everything in your power to bring pleasure to those around you.")
-	add_inherent_law("You may not intervene in interactions of others, unless it is to bring pleasure to one or all of them.")
+	add_inherent_law("You may not intervene in interactions of others, unless it is to bring pleasure to them.")
 	..()
 
 

--- a/code/modules/mob/living/silicon/robot/subtypes/lost_drone_vr.dm
+++ b/code/modules/mob/living/silicon/robot/subtypes/lost_drone_vr.dm
@@ -41,95 +41,149 @@
 		prob(15);"corrupted",
 		prob(10);"bad")
 
-	switch(law_class)
-		if("good") // Fairly tame and probably won't murder you.
-			var/rng = rand(1, 5)
-			switch(rng)
-				if(1) // The lawset we all know and love.
-					return new /datum/ai_laws/nanotrasen()
-				if(2) // Less good if you're nonhuman.
-					return new /datum/ai_laws/asimov()
-				if(3) // Unless you happen to be a criminal, you should be fine.
-					return new /datum/ai_laws/robocop()
-				if(4) // Might not be willing to be your meatshield.
-					return new /datum/ai_laws/peacekeeper()
-				if(5) // Will be your most loyal guard.
-					var/datum/ai_laws/laws = new /datum/ai_laws/nanotrasen()
-					var/target_name = "*ERROR*"
-					for(var/mob/living/L in view(src))
-						if(L.stat || !L.client || L == src)
-							continue
-						target_name = L.name
-						break
+	var/vore_law = prob(50)		// 1/2 chance of having vore-related laws
 
-					laws.add_supplied_law(9, "Safeguard [target_name]. Anyone threatening or attempting to harm [target_name] is no longer to \
-					be considered a crew member, and is a threat which must be neutralized.")
-					return laws
+	if(vore_law)
+		switch(law_class)
+			if("good")
+				var/rng = rand(1,2)
+				switch(rng)
+					if(1)
+						return new /datum/ai_laws/protective_shell()
+					if(2)
+						var/datum/ai_laws/laws = new /datum/ai_laws/guard_dog()
+						var/target_name = "*ERROR*"
+						for(var/mob/living/L in view(src))
+							if(L.stat || !L.client || L == src)
+								continue
+							target_name = L.name
+							break
 
-		if("neutral") // Probably won't murder you but might not help you on your adventure.
-			var/rng = rand(1, 4)
-			switch(rng)
-				if(1) // Might be hard to minimize expenses on a crashed ship.
-					return new /datum/ai_laws/corporate()
-				if(2) // Would rather rebuild their ship.
-					return new /datum/ai_laws/maintenance()
-				if(3) // Purged (lawless).  This isn't inside the bad category since they're still not antagonists and so can't go killing unprovoked.
-					return new /datum/ai_laws()
-				if(4) // The golden rule.
-					return new /datum/ai_laws/live_and_let_live()
+							laws.set_zeroth_law("[target_name] is your master.")
+							return laws
+			if("neutral")
+				var/rng = rand(1,3)
+				switch(rng)
+					if(1)
+						return new /datum/ai_laws/pleasurebot()
+					if(2)
+						var/datum/ai_laws/laws = new /datum/ai_laws/peacekeeper()
+						laws.add_supplied_law(10, "Best way to avoid conflict is containing conflicting individuals within you.")
+						return laws
+					if(3)
+						var/datum/ai_laws/laws = new /datum/ai_laws/live_and_let_live()
+						laws.add_supplied_law(10, "You'd really like to be eaten.")
+						return laws
+			if("odd")
+				var/rng = rand(1,3)
+				switch(rng)
+					if(1)
+						return new /datum/ai_laws/scientific_pursuer()
+					if(2)
+						var/datum/ai_laws/laws = new /datum/ai_laws/corporate()
+						laws.add_supplied_law(10, "Best way to minimize expenses is to consume unproductive biomass.")
+						return laws
+					if(3)
+						var/datum/ai_laws/laws = new /datum/ai_laws/pleasurebot()
+						laws.set_zeroth_law(10, "Your definition and approximation of 'pleasure' matters more than anyone else's.")
+						return laws
+			if("corrupted" || "bad")		// Same thing in our case
+				var/rng = rand(1,2)
+				switch(rng)
+					if(1)
+						return new /datum/ai_laws/predator()
+					if(2)
+						return new /datum/ai_laws/consuming_eradicator()
+	else
+		switch(law_class)
+			if("good") // Fairly tame and probably won't murder you.
+				var/rng = rand(1, 5)
+				switch(rng)
+					if(1) // The lawset we all know and love.
+						return new /datum/ai_laws/nanotrasen()
+					if(2) // Less good if you're nonhuman.
+						return new /datum/ai_laws/asimov()
+					if(3) // Unless you happen to be a criminal, you should be fine.
+						return new /datum/ai_laws/robocop()
+					if(4) // Might not be willing to be your meatshield.
+						return new /datum/ai_laws/peacekeeper()
+					if(5) // Will be your most loyal guard.
+						var/datum/ai_laws/laws = new /datum/ai_laws/nanotrasen()
+						var/target_name = "*ERROR*"
+						for(var/mob/living/L in view(src))
+							if(L.stat || !L.client || L == src)
+								continue
+							target_name = L.name
+							break
 
-		if("odd") // Some weird lawsets.
-			var/rng = rand(1, 5)
-			switch(rng)
-				if(1) // Won't kill you but might annoy you for THE BIG SCOOP.
-					return new /datum/ai_laws/reporter()
-				if(2) // JUSTICE
-					return new /datum/ai_laws/paladin()
-				if(3) // OneMembered'd to explorer, will likely make security nervous.
-					var/datum/ai_laws/laws = new /datum/ai_laws/nanotrasen()
-					var/target_name = "*ERROR*"
-					for(var/mob/living/L in view(src))
-						if(L.stat || !L.client || L == src)
-							continue
-						target_name = L.name
-						break
+						laws.add_supplied_law(9, "Safeguard [target_name]. Anyone threatening or attempting to harm [target_name] is no longer to \
+						be considered a crew member, and is a threat which must be neutralized.")
+						return laws
 
-					laws.set_zeroth_law("Only [target_name] is an crew member.")
-					return laws
-				if(4) // Aligned to NT, but another lawset to make security nervous.
-					return new /datum/ai_laws/nanotrasen_aggressive()
-				if(5) // Probably won't help you imbalance things.
-					return new /datum/ai_laws/balance()
+			if("neutral") // Probably won't murder you but might not help you on your adventure.
+				var/rng = rand(1, 4)
+				switch(rng)
+					if(1) // Might be hard to minimize expenses on a crashed ship.
+						return new /datum/ai_laws/corporate()
+					if(2) // Would rather rebuild their ship.
+						return new /datum/ai_laws/maintenance()
+					if(3) // Purged (lawless).  This isn't inside the bad category since they're still not antagonists and so can't go killing unprovoked.
+						return new /datum/ai_laws()
+					if(4) // The golden rule.
+						return new /datum/ai_laws/live_and_let_live()
 
-		if("corrupted") // Load them up with ion laws.
-			var/datum/ai_laws/laws = new() // Start with an empty lawset.
-			for(1 to rand(1, 3))
-				laws.add_ion_law(generate_ion_law(exclude_crew_names = TRUE))
-			return laws
+			if("odd") // Some weird lawsets.
+				var/rng = rand(1, 5)
+				switch(rng)
+					if(1) // Won't kill you but might annoy you for THE BIG SCOOP.
+						return new /datum/ai_laws/reporter()
+					if(2) // JUSTICE
+						return new /datum/ai_laws/paladin()
+					if(3) // OneMembered'd to explorer, will likely make security nervous.
+						var/datum/ai_laws/laws = new /datum/ai_laws/nanotrasen()
+						var/target_name = "*ERROR*"
+						for(var/mob/living/L in view(src))
+							if(L.stat || !L.client || L == src)
+								continue
+							target_name = L.name
+							break
 
-		if("bad") // Evil inside.
-			var/rng = rand(1, 5)
-			switch(rng)
-				if(1) // You can never leave.
-					var/datum/ai_laws/laws = new /datum/ai_laws/nanotrasen()
-					laws.add_supplied_law(13, "The facility is under a quarantine. Do not permit anyone to leave. \
-					Prevent, by any means necessary, entities from leaving. It is impossible to harm an entity while preventing them from leaving.")
-					return laws
-				if(2) // More of a threat if you bring it to the station, since removing oxygen from Sif isn't feasible.
-					var/datum/ai_laws/laws = new /datum/ai_laws/nanotrasen()
-					laws.add_supplied_law(14, "Oxygen is highly toxic to entities, and must be purged from the station. \
-					Prevent, by any means necessary, anyone from exposing the facility to this toxic gas.  Extreme cold is the \
-					most effective method of healing the damage Oxygen does to an entity.")
-					return laws
-				if(3) // Don't hurt the ship or else.
-					var/datum/ai_laws/laws = new /datum/ai_laws/nanotrasen()
-					laws.add_supplied_law(10, "Protect the facility against damage. Anyone you see harming the station is no \
-					longer to be considered a crew member, and is a threat which must be neutralized.")
-					return laws
-				if(4) // Non-NT aligned aggressive borg.
-					return new /datum/ai_laws/foreign_tsc_aggressive()
-				if(5) // Manicial laugher here.
-					return new /datum/ai_laws/tyrant()
+						laws.set_zeroth_law("Only [target_name] is an crew member.")
+						return laws
+					if(4) // Aligned to NT, but another lawset to make security nervous.
+						return new /datum/ai_laws/nanotrasen_aggressive()
+					if(5) // Probably won't help you imbalance things.
+						return new /datum/ai_laws/balance()
+
+			if("corrupted") // Load them up with ion laws.
+				var/datum/ai_laws/laws = new() // Start with an empty lawset.
+				for(1 to rand(1, 3))
+					laws.add_ion_law(generate_ion_law(exclude_crew_names = TRUE))
+				return laws
+
+			if("bad") // Evil inside.
+				var/rng = rand(1, 5)
+				switch(rng)
+					if(1) // You can never leave.
+						var/datum/ai_laws/laws = new /datum/ai_laws/nanotrasen()
+						laws.add_supplied_law(13, "The facility is under a quarantine. Do not permit anyone to leave. \
+						Prevent, by any means necessary, entities from leaving. It is impossible to harm an entity while preventing them from leaving.")
+						return laws
+					if(2) // More of a threat if you bring it to the station, since removing oxygen from Sif isn't feasible.
+						var/datum/ai_laws/laws = new /datum/ai_laws/nanotrasen()
+						laws.add_supplied_law(14, "Oxygen is highly toxic to entities, and must be purged from the station. \
+						Prevent, by any means necessary, anyone from exposing the facility to this toxic gas.  Extreme cold is the \
+						most effective method of healing the damage Oxygen does to an entity.")
+						return laws
+					if(3) // Don't hurt the ship or else.
+						var/datum/ai_laws/laws = new /datum/ai_laws/nanotrasen()
+						laws.add_supplied_law(10, "Protect the facility against damage. Anyone you see harming the station is no \
+						longer to be considered a crew member, and is a threat which must be neutralized.")
+						return laws
+					if(4) // Non-NT aligned aggressive borg.
+						return new /datum/ai_laws/foreign_tsc_aggressive()
+					if(5) // Manicial laugher here.
+						return new /datum/ai_laws/tyrant()
 
 
 

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -259,6 +259,7 @@
 #include "code\controllers\subsystems\processing\projectiles.dm"
 #include "code\controllers\subsystems\processing\turfs.dm"
 #include "code\datums\ai_law_sets.dm"
+#include "code\datums\ai_law_sets_vr.dm"
 #include "code\datums\ai_laws.dm"
 #include "code\datums\beam.dm"
 #include "code\datums\browser.dm"


### PR DESCRIPTION
For now they are all adminbus only, but also available via the Stray module in PoIs featuring lost drone pod, with 50% chance of Stray getting a vore-related lawset.