### PR TITLE
A variet of minor mapfixes

### DIFF
--- a/maps/tether/tether-01-surface1.dmm
+++ b/maps/tether/tether-01-surface1.dmm
@@ -5641,6 +5641,7 @@
 /obj/structure/railing{
 	dir = 1
 	},
+/obj/effect/floor_decal/rust,
 /turf/simulated/floor/virgo3b,
 /area/tether/surfacebase/outside/outside1)
 "ajE" = (
@@ -5648,6 +5649,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/catwalk,
+/obj/effect/floor_decal/rust,
 /turf/simulated/floor/virgo3b,
 /area/tether/surfacebase/outside/outside1)
 "ajF" = (
@@ -5656,12 +5658,14 @@
 	},
 /obj/structure/catwalk,
 /obj/structure/railing,
+/obj/effect/floor_decal/rust,
 /turf/simulated/floor/virgo3b,
 /area/tether/surfacebase/outside/outside1)
 "ajG" = (
 /obj/structure/cable/heavyduty{
 	icon_state = "1-2"
 	},
+/obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating,
 /area/maintenance/lower/mining_eva)
 "ajH" = (
@@ -5670,6 +5674,7 @@
 	icon_state = "0-2";
 	d2 = 2
 	},
+/obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating,
 /area/maintenance/lower/mining_eva)
 "ajI" = (
@@ -5679,6 +5684,7 @@
 	icon_state = "1-2";
 	pixel_y = 0
 	},
+/obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating,
 /area/maintenance/lower/mining_eva)
 "ajJ" = (
@@ -5995,6 +6001,7 @@
 	pixel_x = -22;
 	pixel_y = 0
 	},
+/obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating,
 /area/maintenance/lower/mining_eva)
 "akD" = (
@@ -10945,10 +10952,8 @@
 	icon_state = "1-2";
 	pixel_y = 0
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
+/obj/effect/floor_decal/rust,
+/obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating,
 /area/maintenance/lower/mining_eva)
 "asI" = (
@@ -10958,7 +10963,11 @@
 	icon_state = "1-2";
 	pixel_y = 0
 	},
-/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating,
 /area/maintenance/lower/mining_eva)
 "asJ" = (
@@ -30937,11 +30946,14 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/mining_main/lobby)
 "bbc" = (
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 25;
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
 	pixel_y = 0
 	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating,
 /area/maintenance/lower/mining_eva)
 "bbd" = (
@@ -31526,7 +31538,16 @@
 /turf/simulated/floor/tiled,
 /area/hallway/lower/first_west)
 "bbT" = (
-/turf/simulated/mineral,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/rust,
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor/plating,
 /area/maintenance/lower/mining_eva)
 "bbU" = (
 /obj/structure/table/rack,
@@ -31982,6 +32003,25 @@
 	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos/processing)
+"bcQ" = (
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 25;
+	pixel_y = 0
+	},
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor/plating,
+/area/maintenance/lower/mining_eva)
+"bcR" = (
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor/plating,
+/area/maintenance/lower/mining_eva)
+"bcS" = (
+/obj/structure/closet/crate,
+/obj/random/maintenance/cargo,
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor/plating,
+/area/maintenance/lower/mining_eva)
 "cGJ" = (
 /turf/simulated/floor/plating,
 /area/maintenance/lower/mining_eva)
@@ -41998,14 +42038,14 @@ ajI
 akC
 ajI
 ajI
-ajI
-ajI
 asH
+ajI
 asI
-asI
-asI
-asI
-asI
+bbc
+bbT
+bbT
+bbT
+bbc
 aup
 avl
 ahp
@@ -43144,7 +43184,7 @@ abT
 bbB
 bbe
 bce
-bbT
+bcS
 ahX
 aiZ
 afc
@@ -43711,7 +43751,7 @@ amO
 ano
 bcf
 bcf
-cGJ
+bcR
 agM
 aid
 anW
@@ -43852,7 +43892,7 @@ agg
 amN
 aer
 bcf
-bbc
+bcQ
 air
 agM
 aie

--- a/maps/tether/tether-02-surface2.dmm
+++ b/maps/tether/tether-02-surface2.dmm
@@ -61,6 +61,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/structure/cable/green{
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/lower/public_garden_maintenence/upper)
 "aal" = (
@@ -79,9 +82,8 @@
 /turf/simulated/floor/plating,
 /area/maintenance/lower/public_garden_maintenence/upper)
 "aam" = (
-/obj/structure/stairs/south,
-/turf/simulated/floor/plating,
-/area/maintenance/lower/public_garden_maintenence/upper)
+/turf/simulated/wall/r_wall,
+/area/vacant/vacant_site/gateway/lower)
 "aan" = (
 /turf/simulated/wall,
 /area/maintenance/substation/medsec)
@@ -131,6 +133,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/lower/public_garden_maintenence/upper)
@@ -24212,6 +24219,9 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/lowerhall)
+"aSf" = (
+/turf/simulated/floor/plating,
+/area/vacant/vacant_site/gateway/lower)
 "aSg" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -24866,6 +24876,20 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/lower/mining)
+"aTi" = (
+/obj/machinery/atmospherics/pipe/cap/visible/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	dir = 2;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/vacant/vacant_site/gateway/lower)
 "aTj" = (
 /obj/effect/floor_decal/borderfloorwhite,
 /obj/effect/floor_decal/corner/paleblue/border,
@@ -27183,14 +27207,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/brig)
 "aWr" = (
-/obj/machinery/atmospherics/pipe/cap/visible/scrubbers{
+/obj/machinery/atmospherics/pipe/cap/visible/supply{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /turf/simulated/floor/plating,
-/area/maintenance/lower/public_garden_maintenence/upper)
+/area/vacant/vacant_site/gateway/lower)
 "aWs" = (
 /obj/machinery/door/firedoor/glass,
 /obj/structure/cable/green{
@@ -27559,11 +27580,9 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/lowerhallway)
 "aWP" = (
-/obj/machinery/atmospherics/pipe/cap/visible/supply{
-	dir = 8
-	},
+/obj/structure/stairs/south,
 /turf/simulated/floor/plating,
-/area/maintenance/lower/public_garden_maintenence/upper)
+/area/vacant/vacant_site/gateway/lower)
 "aWQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
@@ -36442,10 +36461,10 @@ aac
 aac
 aac
 aac
-aae
-aae
-aae
-aae
+aam
+aam
+aam
+aam
 aae
 aae
 aat
@@ -36584,18 +36603,18 @@ aac
 aac
 aac
 aac
-aae
-akn
-akn
-akn
-akn
-akn
-aWr
-akn
-akn
-akn
 aam
-aae
+aSf
+aSf
+aSf
+aSf
+aSf
+aTi
+aSf
+aSf
+aSf
+aWP
+aam
 acW
 acW
 acW
@@ -36726,18 +36745,18 @@ aac
 aac
 aac
 aac
-aae
-akn
-akn
-akn
-akn
-akn
-aWP
-akn
-akn
-akn
 aam
-aae
+aSf
+aSf
+aSf
+aSf
+aSf
+aWr
+aSf
+aSf
+aSf
+aWP
+aam
 acW
 acW
 acW
@@ -36868,18 +36887,18 @@ aac
 aac
 aac
 aac
-aae
-akn
-akn
-akn
-akn
-akn
-akn
-akn
-akn
-akn
-akn
-aae
+aam
+aSf
+aSf
+aSf
+aSf
+aSf
+aSf
+aSf
+aSf
+aSf
+aSf
+aam
 acW
 acW
 acW
@@ -37010,18 +37029,18 @@ aac
 aac
 aac
 aac
-aae
-akn
-akn
-akn
-akn
-akn
-akn
-akn
-akn
-akn
-akn
-aae
+aam
+aSf
+aSf
+aSf
+aSf
+aSf
+aSf
+aSf
+aSf
+aSf
+aSf
+aam
 acW
 acW
 acW
@@ -37152,18 +37171,18 @@ aac
 aac
 aac
 aac
-aae
-aae
-aae
-aae
-aae
-akn
-akn
-akn
-akn
-akn
-akn
-aae
+aam
+aam
+aam
+aam
+aam
+aSf
+aSf
+aSf
+aSf
+aSf
+aSf
+aam
 acW
 acW
 acW
@@ -37298,14 +37317,14 @@ aac
 aac
 aac
 aac
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
+aam
+aam
+aam
+aam
+aam
+aam
+aam
+aam
 acW
 acW
 acW

--- a/maps/tether/tether-03-surface3.dmm
+++ b/maps/tether/tether-03-surface3.dmm
@@ -1659,29 +1659,18 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_three_hall)
 "acW" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/surface_three_hall)
+/obj/machinery/atmospherics/pipe/cap/visible/scrubbers,
+/turf/simulated/floor/plating,
+/area/vacant/vacant_site/gateway)
 "acX" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/structure/cable/green{
+	icon_state = "0-1";
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/glass/hidden/steel,
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/surface_three_hall)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/cap/visible/supply,
+/turf/simulated/floor/plating,
+/area/vacant/vacant_site/gateway)
 "acY" = (
 /obj/effect/floor_decal/spline/plain{
 	dir = 5
@@ -15686,25 +15675,8 @@
 /turf/simulated/floor/tiled,
 /area/hallway/lower/third_south)
 "azP" = (
-/obj/machinery/door/morgue{
-	dir = 2;
-	name = "Private Study";
-	req_access = list(37)
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/glass,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/carpet,
-/area/library)
+/turf/simulated/wall,
+/area/tether/surfacebase/library/study)
 "azQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -23341,22 +23313,14 @@
 	dir = 1;
 	pixel_y = -24
 	},
-/obj/item/weapon/reagent_containers/food/drinks/metaglass{
-	},
-/obj/item/weapon/reagent_containers/food/drinks/metaglass{
-	},
-/obj/item/weapon/reagent_containers/food/drinks/metaglass{
-	},
-/obj/item/weapon/reagent_containers/food/drinks/metaglass{
-	},
-/obj/item/weapon/reagent_containers/food/drinks/metaglass{
-	},
-/obj/item/weapon/reagent_containers/food/drinks/metaglass{
-	},
-/obj/item/weapon/reagent_containers/food/drinks/metaglass{
-	},
-/obj/item/weapon/reagent_containers/food/drinks/metaglass{
-	},
+/obj/item/weapon/reagent_containers/food/drinks/metaglass,
+/obj/item/weapon/reagent_containers/food/drinks/metaglass,
+/obj/item/weapon/reagent_containers/food/drinks/metaglass,
+/obj/item/weapon/reagent_containers/food/drinks/metaglass,
+/obj/item/weapon/reagent_containers/food/drinks/metaglass,
+/obj/item/weapon/reagent_containers/food/drinks/metaglass,
+/obj/item/weapon/reagent_containers/food/drinks/metaglass,
+/obj/item/weapon/reagent_containers/food/drinks/metaglass,
 /turf/simulated/floor/wood,
 /area/tether/surfacebase/bar_backroom)
 "aLF" = (
@@ -27730,13 +27694,139 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_three_hall)
 "aTT" = (
+/obj/machinery/door/morgue{
+	dir = 2;
+	name = "Private Study";
+	req_access = list(37)
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/glass,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/carpet,
+/area/tether/surfacebase/library/study)
+"aTU" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled,
+/area/crew_quarters/heads/hop)
+"aTV" = (
+/turf/simulated/wall,
+/area/vacant/vacant_site/gateway)
+"aTW" = (
+/turf/simulated/floor/plating,
+/area/vacant/vacant_site/gateway)
+"aTX" = (
+/turf/simulated/floor/tiled/dark,
+/area/tether/surfacebase/security/common)
+"aTY" = (
+/turf/simulated/wall/r_wall,
+/area/vacant/vacant_site/gateway)
+"aTZ" = (
+/turf/simulated/open,
+/area/vacant/vacant_site/gateway)
+"aUa" = (
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/multi_tile/metal/mait{
+	name = "Maintenance Access"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/surface_three_hall)
+"aUb" = (
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/surface_three_hall)
+"aUc" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/surface_three_hall)
+"aUd" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/surface_three_hall)
+"aUe" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/glass/hidden/steel,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/surface_three_hall)
+"aUf" = (
+/obj/structure/cable/green{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/surface_three_hall)
+"aUg" = (
 /obj/structure/shuttle/engine/propulsion,
 /turf/simulated/floor/reinforced,
 /turf/simulated/shuttle/plating/carry,
 /area/shuttle/tether/surface)
-"aTX" = (
-/turf/simulated/floor/tiled/dark,
-/area/tether/surfacebase/security/common)
 "aUi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -30799,23 +30889,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_three_hall)
-"aZT" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/effect/landmark{
-	name = "lightsout"
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/tiled,
-/area/crew_quarters/heads/hop)
 "aZU" = (
 /obj/structure/table/woodentable,
 /obj/machinery/computer/skills{
@@ -38545,19 +38618,19 @@ aac
 aac
 aac
 aac
-aQW
-alo
-alo
-alo
-alo
-alo
-alo
-alo
-alo
-alo
-alo
-alo
-alo
+aac
+aac
+aac
+aTV
+aTV
+aTV
+aTV
+aTV
+aTV
+aTV
+agw
+agw
+agw
 aby
 aDW
 akn
@@ -38688,18 +38761,18 @@ aac
 aac
 aac
 aac
-alo
-aqO
-aqO
-aqO
-alY
-alY
-aqO
-aqO
-aqO
-aqO
-aqO
-alo
+aac
+aac
+aTV
+aTZ
+aTZ
+aTZ
+aTW
+aTW
+aTW
+aTW
+aTW
+agw
 abA
 aDW
 akn
@@ -38830,18 +38903,18 @@ aac
 aac
 aac
 aac
-alo
-aqO
-aqO
-aqO
-alY
-alY
-aqO
-aqO
-aqO
-aqO
-aqO
-alo
+aac
+aac
+aTV
+aTZ
+aTZ
+aTZ
+aTW
+aTW
+aTW
+aTW
+aTW
+agw
 air
 ajA
 akp
@@ -38971,19 +39044,19 @@ aac
 aac
 aac
 aac
-aac
-alo
-aqO
-aqO
-aqO
-aqO
-aqO
-aqO
-aqO
-aqO
-aqO
-aqO
-alo
+aQW
+aTV
+aTV
+aTV
+aTV
+aTV
+aTV
+aTV
+aTW
+aTW
+aTW
+aTW
+agw
 air
 aDW
 akq
@@ -39114,20 +39187,20 @@ aac
 aac
 aac
 aac
-alo
-aqO
-aqO
-aqO
-aqO
-aqO
-aqO
-aqO
-aqO
-aqO
-aqO
-alo
+aTV
+aTW
+aTW
+aTW
+aTW
+aTW
+aTW
+aTW
+aTW
+aTW
+aTW
+agw
 air
-acW
+aUd
 akr
 akV
 alG
@@ -39256,20 +39329,20 @@ aac
 aac
 aac
 aac
-alo
-aqO
-aqO
-aqO
-aqO
-aqO
-aqO
-aqO
-aqO
-aqO
-aqO
-alo
+aTV
+aTW
+aTW
+aTW
+aTW
+aTW
+aTW
+aTW
+aTW
+aTW
+aTW
+agw
 agI
-acX
+aUe
 aks
 akT
 alE
@@ -39398,20 +39471,20 @@ aac
 aac
 aac
 aac
-alo
-aqO
-aqO
-aqO
-aqO
-aqO
-aqO
-aqO
-aqO
-aqO
-aqO
-alo
-air
-aWF
+aTV
+aTW
+aTW
+aTW
+aTW
+aTW
+aTW
+aTW
+aTW
+acW
+acX
+aUa
+aUc
+aUf
 akx
 akT
 acY
@@ -39540,18 +39613,18 @@ aac
 aac
 aac
 aac
-alo
-aqO
-aqO
-aqO
-aqO
-aqO
-aqO
-aqO
-aqO
-aqO
-aqO
-alo
+aTV
+aTW
+aTW
+aTW
+aTW
+aTW
+aTW
+aTW
+aTW
+aTW
+aTW
+aUb
 air
 aWF
 aku
@@ -39682,18 +39755,18 @@ aac
 aac
 aac
 aac
-alo
-aqO
-aqO
-aqO
-aqO
-aqO
-aqO
-aqO
-aqO
-aqO
-aqO
-alo
+aTV
+aTW
+aTW
+aTW
+aTW
+aTW
+aTW
+aTW
+aTW
+aTW
+aTW
+agw
 ack
 ajF
 akv
@@ -39824,18 +39897,18 @@ aac
 aac
 aac
 aac
-alo
-alo
-alo
-alo
-alo
-alo
-alo
-aqO
-aqO
-aqO
-aqO
-alo
+aTV
+aTY
+aTY
+aTY
+aTY
+aTY
+aTY
+aTW
+aTW
+aTW
+aTW
+agw
 acl
 ajG
 aWN
@@ -39973,11 +40046,11 @@ afn
 adx
 agQ
 afc
-aqO
-aqO
-aqO
-aqO
-alo
+aTW
+aTW
+aTW
+aTW
+agw
 acn
 aWD
 aNE
@@ -40115,11 +40188,11 @@ afo
 age
 agR
 afc
-alo
-alo
-alo
-alo
-alo
+agw
+agw
+agw
+agw
+agw
 acV
 apS
 akx
@@ -42135,11 +42208,11 @@ auB
 avd
 avB
 aff
-axg
-axg
-axg
-axg
-axg
+azP
+azP
+azP
+azP
+azP
 axg
 axg
 axg
@@ -42277,11 +42350,11 @@ auC
 ave
 avC
 awe
-axg
+azP
 axU
 azi
 aAw
-axg
+azP
 aCG
 aEE
 aER
@@ -42419,11 +42492,11 @@ auD
 ave
 avC
 awf
-axg
+azP
 axV
 azj
 aAy
-axg
+azP
 aLP
 azT
 aEU
@@ -42561,11 +42634,11 @@ auE
 avf
 avD
 awg
-axg
+azP
 axW
 azm
 aCM
-axg
+azP
 aCH
 azT
 azT
@@ -42703,11 +42776,11 @@ auF
 avg
 ajX
 akx
-axg
-axg
 azP
-axg
-axg
+azP
+aTT
+azP
+azP
 aIE
 aEP
 aEG
@@ -42949,7 +43022,7 @@ abO
 acy
 abS
 adV
-aep
+aaE
 afm
 aXd
 ahx
@@ -44675,7 +44748,7 @@ aZo
 aYW
 aZb
 aZz
-aZT
+aTU
 baa
 bal
 bam
@@ -45570,7 +45643,7 @@ aNk
 aNl
 aNJ
 aNP
-aTT
+aUg
 aKU
 abg
 aOk
@@ -45712,7 +45785,7 @@ aNl
 aNl
 aNK
 aNP
-aTT
+aUg
 aKU
 abg
 aOk
@@ -45854,7 +45927,7 @@ aNm
 aNl
 aNK
 aNP
-aTT
+aUg
 aKU
 abg
 aOk

--- a/maps/tether/tether-05-station1.dmm
+++ b/maps/tether/tether-05-station1.dmm
@@ -1114,7 +1114,21 @@
 /turf/simulated/wall/r_wall,
 /area/engineering/engine_monitoring)
 "abX" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 9
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/station/atrium)
 "abY" = (
@@ -1148,28 +1162,34 @@
 /turf/simulated/floor,
 /area/maintenance/station/eng_lower)
 "acc" = (
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
 	dir = 1
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 8
+	dir = 4
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 5
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/machinery/atm{
+	pixel_y = 30
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 8
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/station/atrium)
@@ -1347,8 +1367,23 @@
 /turf/simulated/floor,
 /area/vacant/vacant_restaurant_lower)
 "acw" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 5
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 6
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/computer/guestpass{
+	dir = 4;
+	pixel_x = -28;
+	pixel_y = 0
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/station/atrium)
@@ -1461,24 +1496,11 @@
 /turf/simulated/floor,
 /area/vacant/vacant_restaurant_lower)
 "acN" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/blue/border,
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 1
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/station/atrium)
@@ -1633,8 +1655,26 @@
 /turf/simulated/floor,
 /area/maintenance/station/eng_lower)
 "adj" = (
-/turf/simulated/wall,
-/area/maintenance/substation/spacecommand)
+/obj/structure/extinguisher_cabinet{
+	dir = 4;
+	icon_state = "extinguisher_closed";
+	pixel_x = -30
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 5
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 6
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled,
+/area/hallway/station/atrium)
 "adk" = (
 /obj/structure/railing{
 	dir = 1
@@ -1880,14 +1920,16 @@
 /turf/simulated/floor/tiled,
 /area/engineering/hallway)
 "adB" = (
-/obj/item/device/radio/intercom{
-	dir = 1;
-	pixel_y = 24;
-	req_access = list()
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
 	},
-/obj/machinery/computer/communications,
-/turf/simulated/floor/tiled/dark,
-/area/bridge/secondary)
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/atrium)
 "adC" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -2247,11 +2289,26 @@
 /turf/simulated/floor,
 /area/hallway/station/docks)
 "aem" = (
-/obj/structure/bed/chair/office/dark{
-	dir = 1
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
 	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge/secondary)
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 5
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 6
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/atrium)
 "aen" = (
 /turf/simulated/floor/tiled,
 /area/engineering/workshop)
@@ -2581,9 +2638,18 @@
 /turf/simulated/floor/tiled/dark,
 /area/bridge/secondary)
 "aeK" = (
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/tiled/dark,
-/area/bridge/secondary)
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/atrium)
 "aeL" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -2724,14 +2790,30 @@
 /turf/simulated/floor/tiled/dark,
 /area/bridge/secondary)
 "aeZ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
+/obj/machinery/power/apc{
+	cell_type = /obj/item/weapon/cell/apc;
+	dir = 8;
+	name = "west bump";
+	pixel_x = -28
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 5
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 6
 	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge/secondary)
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/green{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/atrium)
 "afa" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -2962,15 +3044,13 @@
 /turf/simulated/floor/tiled,
 /area/hallway/station/atrium)
 "afo" = (
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
-/area/hallway/station/docks)
+/area/hallway/station/atrium)
 "afp" = (
 /obj/machinery/light{
 	dir = 8;
@@ -3077,24 +3157,10 @@
 /turf/simulated/floor/tiled,
 /area/engineering/hallway)
 "afv" = (
-/obj/machinery/door/firedoor/glass,
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/airlock/glass_command{
-	name = "Secondary Control Room"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge/secondary)
+/obj/structure/table/woodentable,
+/obj/item/weapon/reagent_containers/food/snacks/donut/normal,
+/turf/simulated/floor/grass,
+/area/hallway/station/atrium)
 "afw" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -3416,6 +3482,12 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/lightgrey/border,
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/lightgrey/bordercorner2{
+	dir = 9
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/station/atrium)
 "afX" = (
@@ -3438,29 +3510,14 @@
 /turf/simulated/floor/tiled,
 /area/hallway/station/atrium)
 "afY" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
+/obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 1
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 4
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7,
-/obj/machinery/atm{
-	pixel_y = 30
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/station/atrium)
@@ -3583,9 +3640,16 @@
 /turf/simulated/floor,
 /area/crew_quarters/heads/chief)
 "agj" = (
-/obj/machinery/status_display,
-/turf/simulated/wall,
-/area/tether/station/visitorhallway/office)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/atrium)
 "agk" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
@@ -3623,23 +3687,14 @@
 /turf/simulated/floor/tiled,
 /area/bridge/secondary)
 "ago" = (
-/obj/structure/cable{
+/obj/structure/disposalpipe/junction{
+	dir = 8
+	},
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 8
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/lightgrey/border,
 /turf/simulated/floor/tiled,
 /area/hallway/station/atrium)
 "agp" = (
@@ -3782,28 +3837,17 @@
 /turf/simulated/floor/tiled,
 /area/hallway/station/atrium)
 "agw" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/multi_tile/glass{
+	dir = 2
+	},
 /obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 8
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 5
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 6
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/computer/guestpass{
-	dir = 4;
-	pixel_x = -28;
-	pixel_y = 0
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/station/atrium)
@@ -4299,9 +4343,17 @@
 /turf/simulated/floor/tiled,
 /area/bridge/secondary)
 "ahi" = (
-/obj/machinery/ai_status_display,
-/turf/simulated/wall,
-/area/tether/station/visitorhallway/office)
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/atrium)
 "ahj" = (
 /turf/simulated/wall/r_wall,
 /area/bridge/secondary/teleporter)
@@ -4407,18 +4459,32 @@
 /turf/simulated/floor,
 /area/maintenance/station/eng_lower)
 "ahr" = (
-/obj/machinery/light{
-	icon_state = "tube1";
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 8
 	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 9
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 1
 	},
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 9
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
 	},
 /turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway/office)
+/area/hallway/station/atrium)
 "ahs" = (
 /obj/effect/floor_decal/industrial/warning{
 	icon_state = "warning";
@@ -4599,17 +4665,22 @@
 /turf/simulated/floor/tiled,
 /area/hallway/station/atrium)
 "ahI" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/glass,
-/obj/machinery/door/airlock/multi_tile/glass{
-	dir = 2
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/station/atrium)
 "ahJ" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/station/atrium)
 "ahK" = (
@@ -4713,6 +4784,9 @@
 	},
 /obj/effect/floor_decal/corner/lightgrey/border{
 	dir = 5
+	},
+/obj/machinery/status_display{
+	pixel_y = 30
 	},
 /turf/simulated/floor/tiled,
 /area/tether/station/visitorhallway/office)
@@ -4833,11 +4907,17 @@
 /turf/simulated/floor/tiled,
 /area/tether/station/visitorhallway/office)
 "aig" = (
-/obj/structure/bed/chair/office/dark{
-	dir = 4
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/tether/station/visitorhallway/office)
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
+/turf/simulated/floor/tiled,
+/area/hallway/station/atrium)
 "aih" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -4895,16 +4975,28 @@
 /area/hallway/station/atrium)
 "ain" = (
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor/glass,
-/obj/machinery/door/airlock/maintenance/engi{
-	name = "Space Civ/Com Substation"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/turf/simulated/floor,
-/area/maintenance/substation/spacecommand)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey/border,
+/obj/effect/floor_decal/borderfloor/corner2,
+/obj/effect/floor_decal/corner/lightgrey/bordercorner2,
+/turf/simulated/floor/tiled,
+/area/hallway/station/atrium)
 "aio" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/structure/disposalpipe/segment{
@@ -4925,8 +5017,25 @@
 /turf/simulated/floor/tiled,
 /area/hallway/station/atrium)
 "aiq" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment{
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/lightgrey/border,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	icon_state = "intact-scrubbers";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
@@ -6431,29 +6540,21 @@
 /turf/simulated/floor/tiled,
 /area/hallway/station/atrium)
 "alh" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/light,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/structure/extinguisher_cabinet{
-	dir = 4;
-	icon_state = "extinguisher_closed";
-	pixel_x = -30
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 8
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 1
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 5
+	dir = 8
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 6
-	},
-/obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/corner/lightgrey/border,
 /turf/simulated/floor/tiled,
 /area/hallway/station/atrium)
 "ali" = (
@@ -6755,24 +6856,45 @@
 /turf/simulated/wall/r_wall,
 /area/maintenance/abandonedlibrary)
 "alO" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/effect/landmark/start,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/lightgrey/border,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
-/area/storage/tools)
+/area/hallway/station/atrium)
 "alP" = (
-/obj/structure/cable{
-	icon_state = "1-4"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/effect/landmark/start{
-	name = "Assistant"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/blue/border,
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/blue/bordercorner2{
+	dir = 9
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
-/area/storage/tools)
+/area/hallway/station/atrium)
 "alQ" = (
 /turf/simulated/wall/r_wall,
 /area/maintenance/substation/civilian)
@@ -7381,10 +7503,6 @@
 /turf/simulated/wall,
 /area/maintenance/abandonedlibrary)
 "amV" = (
-/obj/structure/sign/department/biblio,
-/turf/simulated/wall,
-/area/hallway/station/atrium)
-"amW" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -7396,11 +7514,31 @@
 	dir = 8
 	},
 /obj/machinery/door/firedoor/glass,
-/obj/machinery/door/airlock/multi_tile/glass,
+/obj/machinery/door/airlock/multi_tile/metal/mait{
+	name = "Maintenance Access"
+	},
 /turf/simulated/floor/tiled/monofloor{
 	dir = 8
 	},
 /area/hallway/station/atrium)
+"amW" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/lightgrey/border,
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/lightgrey/bordercorner2{
+	dir = 9
+	},
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_y = -24
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway/office)
 "amX" = (
 /obj/machinery/door/firedoor/glass,
 /obj/structure/disposalpipe/segment,
@@ -10497,10 +10635,21 @@
 /turf/simulated/floor/tiled/monotile,
 /area/engineering/workshop)
 "asV" = (
-/obj/machinery/door/firedoor/glass,
-/obj/machinery/door/airlock/maintenance/command,
-/turf/simulated/floor,
-/area/bridge/secondary/meeting_room)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/atrium)
 "asW" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/paper_bin,
@@ -10829,20 +10978,73 @@
 /turf/simulated/floor/tiled/monotile,
 /area/engineering/workshop)
 "atC" = (
-/turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway/office)
-"atD" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway/office)
-"atE" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/blue/border,
+/obj/effect/floor_decal/borderfloor/corner2,
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/blue/bordercorner2,
+/obj/effect/floor_decal/corner/blue/bordercorner2{
+	dir = 9
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 1
+	},
+/obj/machinery/camera/network/tether{
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway/office)
+/area/hallway/station/atrium)
+"atD" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/atrium)
+"atE" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/blue/border,
+/obj/effect/floor_decal/borderfloor/corner2,
+/obj/effect/floor_decal/corner/blue/bordercorner2,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/atrium)
 "atF" = (
 /obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 9
@@ -10989,37 +11191,19 @@
 /turf/simulated/floor,
 /area/maintenance/station/eng_lower)
 "atU" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/lightgrey/border,
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 8
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 5
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 8
-	},
+/obj/effect/floor_decal/corner/blue/border,
 /obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/station/atrium)
@@ -11100,12 +11284,13 @@
 /turf/simulated/floor,
 /area/maintenance/station/spacecommandmaint)
 "aug" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor/glass/hidden/steel{
+	dir = 1
 	},
-/turf/simulated/floor,
-/area/maintenance/station/spacecommandmaint)
+/turf/simulated/floor/tiled,
+/area/hallway/station/atrium)
 "auh" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 10
@@ -11116,17 +11301,16 @@
 /turf/simulated/floor/tiled,
 /area/hallway/station/atrium)
 "aui" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/obj/machinery/door/airlock/maintenance/engi{
+	name = "Asteroid Command Substation";
+	req_one_access = list(19)
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
+/obj/structure/cable/green{
+	icon_state = "1-2"
 	},
+/obj/machinery/door/firedoor/glass,
 /turf/simulated/floor,
-/area/maintenance/station/spacecommandmaint)
+/area/maintenance/substation/spacecommand)
 "auj" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -11166,15 +11350,15 @@
 /turf/simulated/floor/tiled,
 /area/hallway/station/atrium)
 "aun" = (
-/obj/machinery/power/breakerbox/activated{
-	RCon_tag = "Space Civ/Com Substation Bypass"
+/obj/machinery/door/firedoor/glass,
+/obj/structure/cable/green{
+	icon_state = "1-2"
 	},
-/obj/machinery/light/small{
-	dir = 8;
-	pixel_y = 0
+/obj/machinery/door/airlock/glass{
+	name = "Visitor Office"
 	},
-/turf/simulated/floor,
-/area/maintenance/substation/spacecommand)
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway/office)
 "auo" = (
 /obj/machinery/light{
 	dir = 8
@@ -11202,9 +11386,24 @@
 /turf/simulated/floor,
 /area/maintenance/substation/spacecommand)
 "auq" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor,
-/area/maintenance/station/spacecommandmaint)
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 9
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey/bordercorner2{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway/office)
 "aur" = (
 /turf/simulated/floor,
 /area/crew_quarters/sleep/cryo)
@@ -11220,12 +11419,33 @@
 /turf/simulated/floor,
 /area/maintenance/station/spacecommandmaint)
 "auu" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
+/obj/machinery/door/firedoor/glass,
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
 	},
-/turf/simulated/floor,
-/area/maintenance/station/spacecommandmaint)
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced/polarized/full{
+	id = "secondary_bridge"
+	},
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 8;
+	icon_state = "pdoor0";
+	id = "secondary_bridge_blast";
+	name = "Secondary Command Office Blast Doors";
+	opacity = 0
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/bridge/secondary)
 "auv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -11302,33 +11522,25 @@
 /turf/simulated/wall/r_wall,
 /area/maintenance/station/spacecommandmaint)
 "auE" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
+/obj/machinery/door/firedoor/glass,
 /obj/structure/cable/green{
-	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "0-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/structure/grille,
+/obj/structure/window/reinforced/polarized/full{
+	id = "secondary_bridge"
 	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 6
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 8;
+	icon_state = "pdoor0";
+	id = "secondary_bridge_blast";
+	name = "Secondary Command Office Blast Doors";
+	opacity = 0
 	},
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 6
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4,
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway)
+/turf/simulated/floor/plating,
+/area/bridge/secondary)
 "auF" = (
 /obj/effect/floor_decal/industrial/warning{
 	icon_state = "warning";
@@ -11356,14 +11568,25 @@
 /turf/simulated/floor/tiled/dark,
 /area/bridge/secondary/teleporter)
 "auJ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/structure/table/standard,
+/obj/random/tech_supply,
+/obj/random/tech_supply,
+/obj/random/tech_supply,
+/obj/random/tech_supply,
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_x = 0;
+	pixel_y = 28
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/random/tech_supply,
+/obj/random/tech_supply,
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/station/docks)
+/area/storage/tools)
 "auK" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -11380,19 +11603,17 @@
 /turf/simulated/floor,
 /area/maintenance/substation/spacecommand)
 "auL" = (
-/obj/machinery/power/smes/buildable{
-	charge = 0;
-	output_attempt = 0;
-	outputting = 0;
-	RCon_tag = "Substation - Space Civ/Com"
-	},
-/obj/structure/cable/green,
 /obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
+	icon_state = "1-2"
 	},
-/turf/simulated/floor,
-/area/maintenance/substation/spacecommand)
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway/office)
 "auM" = (
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/airlock/maintenance/command,
@@ -11445,40 +11666,26 @@
 /turf/simulated/floor/tiled,
 /area/tether/station/stairs_one)
 "auQ" = (
-/obj/machinery/door/firedoor/glass,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/maintenance/engi{
-	name = "Space Civ/Com Substation"
-	},
-/obj/effect/floor_decal/industrial/warning/corner{
-	icon_state = "warningcorner";
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/maintenance/substation/spacecommand)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled,
+/area/hallway/station/docks)
 "auR" = (
-/obj/structure/cable/green,
-/obj/structure/cable/green{
-	icon_state = "0-4"
+/obj/effect/floor_decal/borderfloor{
+	dir = 1;
+	pixel_y = 0
 	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/power/sensor{
-	name = "Powernet Sensor - Space Civ/Com Subgrid";
-	name_tag = "Space Civ/Com Subgrid"
-	},
-/obj/effect/floor_decal/industrial/warning{
-	icon_state = "warning";
+/obj/effect/floor_decal/corner/lightgrey/border{
 	dir = 1
 	},
-/turf/simulated/floor,
-/area/maintenance/substation/spacecommand)
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/lightgrey/bordercorner2{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway/office)
 "auS" = (
 /obj/machinery/vending/tool,
 /obj/machinery/ai_status_display{
@@ -11488,19 +11695,19 @@
 /turf/simulated/floor/tiled,
 /area/storage/tools)
 "auT" = (
-/obj/structure/cable{
+/obj/item/device/radio/intercom{
+	dir = 1;
+	pixel_y = 24;
+	req_access = list()
+	},
+/obj/machinery/computer/communications,
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/station/docks)
+/turf/simulated/floor/tiled/dark,
+/area/bridge/secondary)
 "auU" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/lightgrey/border,
@@ -11596,24 +11803,12 @@
 /turf/simulated/floor/tiled,
 /area/engineering/workshop)
 "ave" = (
-/obj/machinery/door/firedoor/glass,
-/obj/machinery/door/airlock/maintenance/common,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/effect/landmark/start,
 /obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/tether/station/visitorhallway)
+/turf/simulated/floor/tiled,
+/area/storage/tools)
 "avf" = (
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/airless,
@@ -11651,22 +11846,14 @@
 /turf/simulated/floor/tiled,
 /area/engineering/engine_eva)
 "avk" = (
-/obj/machinery/power/apc{
-	dir = 2;
-	name = "south bump";
-	pixel_y = -28;
-	req_access = list(67)
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
 	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
 	},
-/obj/structure/cable/green{
-	icon_state = "0-4"
-	},
-/turf/simulated/floor,
-/area/maintenance/station/spacecommandmaint)
+/turf/simulated/floor/tiled,
+/area/hallway/station/docks)
 "avl" = (
 /obj/machinery/teleport/station{
 	dir = 2
@@ -11685,24 +11872,12 @@
 /turf/simulated/floor/tiled/monotile,
 /area/engineering/workshop)
 "avn" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
+/obj/machinery/door/firedoor/glass/hidden/steel{
+	dir = 2
 	},
-/obj/machinery/light_switch{
-	dir = 1;
-	pixel_x = 0;
-	pixel_y = -26
-	},
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/lightgrey/border,
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 9
-	},
-/obj/effect/floor_decal/corner/lightgrey/bordercorner2{
-	dir = 9
-	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway/office)
+/area/hallway/station/atrium)
 "avo" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -11715,22 +11890,11 @@
 /turf/simulated/floor/tiled,
 /area/engineering/workshop)
 "avp" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 28
-	},
 /obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
+	icon_state = "1-2"
 	},
-/obj/random/junk,
-/obj/effect/floor_decal/industrial/warning/corner{
-	icon_state = "warningcorner";
-	dir = 1
-	},
-/turf/simulated/floor,
-/area/maintenance/substation/spacecommand)
+/turf/simulated/floor/carpet/bcarpet,
+/area/tether/station/visitorhallway/office)
 "avq" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -11889,7 +12053,6 @@
 /area/engineering/break_room)
 "avE" = (
 /obj/machinery/door/firedoor/glass,
-/obj/machinery/door/airlock/glass,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
 	d1 = 1;
@@ -11898,6 +12061,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/airlock/glass{
+	name = "Visitor Office"
+	},
 /turf/simulated/floor/tiled,
 /area/tether/station/visitorhallway/office)
 "avF" = (
@@ -12091,28 +12257,16 @@
 /turf/simulated/floor/tiled,
 /area/bridge/secondary)
 "avR" = (
-/obj/structure/disposalpipe/sortjunction{
-	name = "Visitor Office";
-	sortType = "Visitor Office"
+/obj/structure/bed/chair/office/dark{
+	dir = 1
 	},
 /obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/turf/simulated/floor,
-/area/maintenance/station/spacecommandmaint)
+/turf/simulated/floor/tiled/dark,
+/area/bridge/secondary)
 "avS" = (
 /obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
@@ -12139,48 +12293,41 @@
 /turf/simulated/wall,
 /area/tether/station/visitorhallway)
 "avV" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor,
-/area/maintenance/station/spacecommandmaint)
-"avW" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
+/obj/effect/landmark/start{
+	name = "Assistant"
 	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	icon_state = "intact-supply";
-	dir = 5
+/turf/simulated/floor/tiled,
+/area/storage/tools)
+"avW" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/turf/simulated/floor,
-/area/maintenance/station/spacecommandmaint)
-"avX" = (
-/obj/machinery/door/firedoor/glass,
-/obj/machinery/door/airlock/multi_tile/glass{
-	dir = 2
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/effect/floor_decal/steeldecal/steel_decals4,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway)
+/area/storage/tools)
+"avX" = (
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/glass{
+	name = "Auxiliary Tool Storage"
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/hallway/station/docks)
 "avY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	icon_state = "intact-scrubbers";
@@ -12237,34 +12384,29 @@
 /turf/simulated/floor/tiled,
 /area/hallway/station/docks)
 "awc" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals6{
+/obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 6
 	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway)
+/area/hallway/station/docks)
 "awd" = (
-/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
 	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/effect/floor_decal/borderfloor/corner,
-/obj/effect/floor_decal/corner/lightgrey/bordercorner,
 /turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway)
+/area/hallway/station/docks)
 "awe" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	icon_state = "intact-scrubbers";
@@ -12474,33 +12616,14 @@
 /turf/simulated/floor/tiled,
 /area/tether/station/visitorhallway)
 "awr" = (
-/obj/machinery/door/firedoor/glass,
-/obj/machinery/door/airlock/maintenance/command,
-/obj/structure/disposalpipe/segment{
+/obj/structure/bed/chair/office/dark{
 	dir = 4
 	},
 /obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
-	},
-/obj/machinery/door/blast/regular{
-	density = 0;
-	dir = 1;
-	icon_state = "pdoor0";
-	id = "secondary_bridge_blast";
-	name = "Secondary Command Office Blast Doors";
-	opacity = 0
-	},
-/turf/simulated/floor,
-/area/bridge/secondary/hallway)
+/turf/simulated/floor/carpet/bcarpet,
+/area/tether/station/visitorhallway/office)
 "aws" = (
 /turf/simulated/wall,
 /area/tether/station/stairs_one)
@@ -12529,23 +12652,13 @@
 /turf/simulated/wall,
 /area/crew_quarters/sleep/spacedorm2)
 "awx" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/bridge/secondary/hallway)
+/turf/simulated/floor/tiled/dark,
+/area/bridge/secondary)
 "awy" = (
 /obj/structure/bed/chair/comfy/brown{
 	dir = 1
@@ -12611,30 +12724,20 @@
 /turf/simulated/floor/tiled,
 /area/engineering/hallway)
 "awE" = (
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
 /obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
-/area/bridge/secondary/hallway)
+/area/hallway/station/docks)
 "awF" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -12857,6 +12960,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/bridge/secondary/teleporter)
 "awZ" = (
@@ -13012,6 +13118,10 @@
 /obj/item/device/gps/command,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning{
+	icon_state = "warning";
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/secondary/teleporter)
@@ -14502,42 +14612,62 @@
 /turf/simulated/floor/tiled,
 /area/tether/station/visitorhallway)
 "azu" = (
-/turf/simulated/wall/r_wall,
-/area/tether/station/visitorhallway)
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor,
+/area/maintenance/station/spacecommandmaint)
 "azv" = (
 /turf/simulated/wall,
 /area/tether/station/visitorhallway/lounge)
 "azw" = (
-/obj/machinery/door/firedoor/glass,
-/obj/machinery/door/airlock/glass,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/power/breakerbox/activated{
+	RCon_tag = "Asteroid Command Substation Bypass"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway/lounge)
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_y = 0
+	},
+/turf/simulated/floor,
+/area/maintenance/substation/spacecommand)
 "azx" = (
 /turf/simulated/wall,
 /area/tether/station/visitorhallway/laundry)
 "azy" = (
-/obj/machinery/door/firedoor/glass,
-/obj/machinery/door/airlock/glass,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/power/smes/buildable{
+	charge = 0;
+	output_attempt = 0;
+	outputting = 0;
+	RCon_tag = "Substation - Asteroid Command"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway/laundry)
+/obj/structure/cable/green,
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor,
+/area/maintenance/substation/spacecommand)
 "azz" = (
-/turf/simulated/wall/r_wall,
-/area/tether/station/visitorhallway/laundry)
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor,
+/area/maintenance/station/spacecommandmaint)
 "azA" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8;
@@ -14760,28 +14890,14 @@
 /turf/simulated/floor/tiled,
 /area/tether/station/visitorhallway/laundry)
 "azX" = (
+/obj/machinery/hologram/holopad,
 /obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 9
-	},
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 9
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/station/atrium)
+/turf/simulated/floor/tiled/dark,
+/area/bridge/secondary)
 "azY" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -15127,95 +15243,46 @@
 /turf/simulated/floor/tiled/dark,
 /area/bridge/secondary/teleporter)
 "aAA" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/light,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 1
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/lightgrey/border,
 /turf/simulated/floor/tiled,
-/area/hallway/station/atrium)
+/area/hallway/station/docks)
 "aAB" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 5
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/station/atrium)
+/turf/simulated/floor,
+/area/maintenance/station/spacecommandmaint)
 "aAC" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+	dir = 6
 	},
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 8
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/blue/border,
-/turf/simulated/floor/tiled,
-/area/hallway/station/atrium)
+/turf/simulated/floor/tiled/dark,
+/area/bridge/secondary)
 "aAD" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/blue/border,
-/obj/effect/floor_decal/borderfloor/corner2,
-/obj/effect/floor_decal/corner/blue/bordercorner2,
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 8
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 1
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/station/atrium)
+/area/tether/station/visitorhallway/office)
 "aAE" = (
 /obj/effect/landmark{
 	name = "lightsout"
@@ -15227,55 +15294,27 @@
 /turf/simulated/floor/tiled,
 /area/bridge/secondary/hallway)
 "aAF" = (
-/obj/structure/cable{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/blue/border,
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 9
-	},
-/obj/effect/floor_decal/corner/blue/bordercorner2{
-	dir = 9
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 8
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 1
-	},
 /turf/simulated/floor/tiled,
-/area/hallway/station/atrium)
+/area/tether/station/visitorhallway/office)
 "aAG" = (
-/obj/structure/cable{
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/green{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 8
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/blue/border,
 /turf/simulated/floor/tiled,
-/area/hallway/station/atrium)
+/area/tether/station/visitorhallway/office)
 "aAH" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -15902,8 +15941,26 @@
 /turf/simulated/floor/tiled,
 /area/crew_quarters/sleep/spacedorm4)
 "aBO" = (
-/turf/simulated/wall/r_wall,
-/area/crew_quarters/sleep/spacedorm4)
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/maintenance/engi{
+	name = "Asteroid Command Substation";
+	req_one_access = list(10,19)
+	},
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 8;
+	icon_state = "pdoor0";
+	id = "secondary_bridge_blast";
+	name = "Secondary Command Office Blast Doors";
+	opacity = 0
+	},
+/turf/simulated/floor,
+/area/maintenance/substation/spacecommand)
 "aBP" = (
 /obj/machinery/power/apc{
 	dir = 2;
@@ -15937,24 +15994,29 @@
 /turf/simulated/floor,
 /area/maintenance/substation/civilian)
 "aBS" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	icon_state = "intact-scrubbers";
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/door/firedoor/glass,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/structure/cable/green{
-	d1 = 4;
+	d1 = 2;
 	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "2-8"
 	},
-/obj/machinery/camera/network/command,
-/turf/simulated/floor/tiled,
-/area/bridge/secondary/hallway)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/airlock/glass_command{
+	name = "Secondary Control Room"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bridge/secondary)
 "aBT" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -16188,38 +16250,18 @@
 /turf/simulated/floor/tiled,
 /area/hallway/station/atrium)
 "aCr" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/blue/border,
-/obj/effect/floor_decal/borderfloor/corner2,
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 9
-	},
-/obj/effect/floor_decal/corner/blue/bordercorner2,
-/obj/effect/floor_decal/corner/blue/bordercorner2{
-	dir = 9
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 8
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
+/obj/machinery/door/firedoor/glass/hidden/steel{
 	dir = 1
 	},
-/obj/machinery/camera/network/tether{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/station/atrium)
+/area/hallway/station/docks)
 "aCs" = (
 /obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 9
@@ -16594,17 +16636,17 @@
 /turf/simulated/floor/tiled,
 /area/hallway/station/atrium)
 "aCY" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+/obj/structure/bed/chair,
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_x = 0;
+	pixel_y = 24
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/item/device/radio/beacon,
 /turf/simulated/floor/tiled,
 /area/hallway/station/docks)
 "aCZ" = (
@@ -16631,16 +16673,17 @@
 /turf/simulated/floor/tiled,
 /area/tether/station/stairs_one)
 "aDb" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
+/obj/effect/floor_decal/sign/dock/one,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/station/docks)
@@ -16668,16 +16711,15 @@
 /turf/simulated/floor/tiled,
 /area/hallway/station/docks)
 "aDd" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-8"
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/hallway/station/docks)
 "aDe" = (
@@ -16701,17 +16743,16 @@
 /turf/simulated/floor/tiled,
 /area/hallway/station/docks)
 "aDf" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/station/docks)
@@ -16764,14 +16805,122 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/sleep/engi_wash)
-"aDn" = (
-/obj/structure/cable{
-	icon_state = "1-8"
+"aDk" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/docks)
+"aDl" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/item/device/radio/beacon,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/docks)
+"aDm" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/docks)
+"aDn" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/docks)
+"aDo" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/docks)
+"aDp" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/effect/floor_decal/sign/dock/two,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/docks)
+"aDq" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/maintenance/station/spacecommandmaint)
+"aDr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled,
-/area/tether/station/dock_two)
+/area/hallway/station/docks)
 "aDs" = (
 /obj/structure/cable/green{
 	d2 = 4;
@@ -16786,6 +16935,176 @@
 /obj/effect/floor_decal/industrial/warning/corner,
 /turf/simulated/floor,
 /area/maintenance/substation/civilian)
+"aDt" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/docks)
+"aDu" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/docks)
+"aDv" = (
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/multi_tile/glass{
+	dir = 2
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway)
+"aDw" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 6
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway)
+"aDx" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloor/corner,
+/obj/effect/floor_decal/corner/lightgrey/bordercorner,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway)
+"aDy" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway)
+"aDz" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 6
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway)
+"aDA" = (
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/maintenance/common,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/tether/station/visitorhallway)
+"aDB" = (
+/obj/structure/disposalpipe/sortjunction{
+	name = "Visitor Office";
+	sortType = "Visitor Office"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/turf/simulated/floor,
+/area/maintenance/station/spacecommandmaint)
+"aDC" = (
+/obj/machinery/power/apc{
+	dir = 2;
+	name = "south bump";
+	pixel_y = -28;
+	req_access = list(67)
+	},
+/obj/structure/cable,
+/turf/simulated/floor,
+/area/maintenance/station/spacecommandmaint)
 "aDD" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/structure/undies_wardrobe,
@@ -16812,6 +17131,21 @@
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/plating,
 /area/tether/station/dock_one)
+"aDI" = (
+/obj/structure/cable/green,
+/obj/structure/cable/green{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/sensor{
+	name = "Powernet Sensor - Asteroid Command Subgrid";
+	name_tag = "Asteroid Command Subgrid"
+	},
+/obj/effect/floor_decal/industrial/warning{
+	icon_state = "warning";
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/maintenance/substation/spacecommand)
 "aDJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/tiled,
@@ -16846,6 +17180,40 @@
 	},
 /turf/simulated/floor,
 /area/maintenance/substation/civilian)
+"aDN" = (
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 28
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/random/junk,
+/obj/effect/floor_decal/industrial/warning/corner{
+	icon_state = "warningcorner";
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor,
+/area/maintenance/substation/spacecommand)
+"aDO" = (
+/obj/machinery/door/airlock/glass,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor/glass,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/tether/station/dock_one)
 "aDP" = (
 /obj/structure/table/rack{
 	dir = 1
@@ -16871,6 +17239,104 @@
 /obj/random/maintenance/clean,
 /turf/simulated/floor/plating,
 /area/storage/emergency_storage/emergency4)
+"aDQ" = (
+/obj/machinery/door/airlock/glass,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor/glass,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/tether/station/dock_two)
+"aDR" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor,
+/area/maintenance/station/spacecommandmaint)
+"aDT" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/dock_one)
+"aDU" = (
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 28
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/dock_one)
+"aDV" = (
+/obj/machinery/power/apc{
+	cell_type = /obj/item/weapon/cell/super;
+	dir = 8;
+	name = "west bump";
+	pixel_x = -28
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/structure/cable/green{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/dock_two)
+"aDW" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/dock_two)
+"aDX" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	icon_state = "intact-supply";
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/turf/simulated/floor,
+/area/maintenance/station/spacecommandmaint)
+"aDY" = (
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/maintenance/command,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	icon_state = "intact-scrubbers";
+	dir = 4
+	},
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 1;
+	icon_state = "pdoor0";
+	id = "secondary_bridge_blast";
+	name = "Secondary Command Office Blast Doors";
+	opacity = 0
+	},
+/turf/simulated/floor,
+/area/bridge/secondary/hallway)
 "aDZ" = (
 /obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 9
@@ -16911,6 +17377,62 @@
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/engine_eva)
+"aEc" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	icon_state = "intact-scrubbers";
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/bridge/secondary/hallway)
+"aEd" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled,
+/area/bridge/secondary/hallway)
+"aEe" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	icon_state = "intact-scrubbers";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled,
+/area/bridge/secondary/hallway)
 "aEf" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -16923,6 +17445,55 @@
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/engine_eva)
+"aEg" = (
+/obj/machinery/camera/network/command{
+	icon_state = "camera";
+	dir = 10
+	},
+/turf/simulated/floor/tiled,
+/area/bridge/secondary/hallway)
+"aEh" = (
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/maintenance/command,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 1;
+	icon_state = "pdoor0";
+	id = "secondary_bridge_blast";
+	name = "Secondary Command Office Blast Doors";
+	opacity = 0
+	},
+/turf/simulated/floor,
+/area/bridge/secondary/meeting_room)
+"aEi" = (
+/obj/machinery/door/firedoor/glass,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/airlock/glass{
+	name = "Visitor Lounge"
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway/lounge)
+"aEj" = (
+/obj/machinery/door/firedoor/glass,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/airlock/glass{
+	name = "Visitor Laundry"
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway/laundry)
 "aEl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -17138,32 +17709,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor,
 /area/storage/emergency_storage/emergency4)
-"aFh" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 8
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 5
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 6
-	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled,
-/area/hallway/station/atrium)
 "aFq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -17460,29 +18005,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/tiled,
 /area/tether/station/dock_one)
-"aHb" = (
-/obj/structure/cable/green,
-/obj/machinery/power/apc{
-	cell_type = /obj/item/weapon/cell/apc;
-	dir = 8;
-	name = "west bump";
-	pixel_x = -28
-	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 8
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 5
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 6
-	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled,
-/area/hallway/station/atrium)
 "aHc" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
@@ -19926,13 +20448,6 @@
 /obj/structure/disposalpipe/junction,
 /turf/simulated/floor/tiled,
 /area/engineering/foyer)
-"bay" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/station/atrium)
 "baA" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/structure/table/reinforced,
@@ -20348,23 +20863,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/station/atrium)
-"bdL" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
-/turf/simulated/floor/tiled,
-/area/hallway/station/atrium)
 "bdS" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -20609,19 +21107,6 @@
 	},
 /turf/simulated/wall,
 /area/tether/station/stairs_one)
-"bfQ" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/firedoor/glass/hidden/steel{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/station/atrium)
 "bfT" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/carpet/oracarpet,
@@ -20760,37 +21245,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/station/stairs_one)
-"bgO" = (
-/obj/structure/table/standard,
-/obj/random/tech_supply,
-/obj/random/tech_supply,
-/obj/random/tech_supply,
-/obj/random/tech_supply,
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 28
-	},
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2";
-	pixel_y = 0
-	},
-/obj/random/tech_supply,
-/obj/random/tech_supply,
-/turf/simulated/floor/tiled,
-/area/storage/tools)
-"bha" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled,
-/area/hallway/station/docks)
 "bhc" = (
 /obj/structure/extinguisher_cabinet{
 	dir = 4;
@@ -20981,31 +21435,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/storage/tools)
-"bkq" = (
-/obj/machinery/door/firedoor/glass,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/glass{
-	name = "Auxiliary Tool Storage"
-	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/hallway/station/docks)
-"bks" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 10
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4,
-/turf/simulated/floor/tiled,
-/area/storage/tools)
 "bkx" = (
 /obj/structure/table/reinforced,
 /obj/item/stack/material/plasteel{
@@ -21015,20 +21444,6 @@
 /obj/fiftyspawner/plastic,
 /turf/simulated/floor/tiled,
 /area/engineering/workshop)
-"bky" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 6
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/station/docks)
 "bmv" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -21274,19 +21689,6 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/crew_quarters/toilet)
-"bqf" = (
-/obj/machinery/door/firedoor/glass/hidden/steel{
-	dir = 1
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled,
-/area/hallway/station/docks)
 "bqj" = (
 /obj/structure/table/rack{
 	dir = 8;
@@ -21330,20 +21732,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/toilet)
-"bsv" = (
-/obj/structure/bed/chair,
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 24
-	},
-/obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/station/docks)
 "bto" = (
 /obj/structure/cable/green,
 /obj/machinery/power/apc{
@@ -21369,135 +21757,12 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/toilet)
-"bts" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/effect/floor_decal/sign/dock/one,
-/turf/simulated/floor/tiled,
-/area/hallway/station/docks)
 "btt" = (
 /obj/machinery/computer/guestpass{
 	dir = 4;
 	pixel_x = -28;
 	pixel_y = 0
 	},
-/turf/simulated/floor/tiled,
-/area/hallway/station/docks)
-"btu" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/station/docks)
-"bty" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/station/docks)
-"btC" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/turf/simulated/floor/tiled,
-/area/hallway/station/docks)
-"btF" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/turf/simulated/floor/tiled,
-/area/hallway/station/docks)
-"btM" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/station/docks)
-"btO" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/obj/effect/floor_decal/sign/dock/two,
-/turf/simulated/floor/tiled,
-/area/hallway/station/docks)
-"btS" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/tiled,
 /area/hallway/station/docks)
 "bvs" = (
@@ -21514,19 +21779,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/toilet)
-"bvt" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/station/docks)
 "bvu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
@@ -21547,30 +21799,6 @@
 "bwb" = (
 /turf/space,
 /area/shuttle/tether/station)
-"bwV" = (
-/obj/machinery/door/airlock/glass,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/firedoor/glass,
-/turf/simulated/floor/tiled/steel_grid,
-/area/tether/station/dock_one)
-"bxe" = (
-/obj/machinery/door/airlock/glass,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/firedoor/glass,
-/turf/simulated/floor/tiled/steel_grid,
-/area/tether/station/dock_two)
 "byy" = (
 /obj/machinery/recharge_station,
 /obj/machinery/light/small{
@@ -21587,16 +21815,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/toilet)
-"byD" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled,
-/area/tether/station/dock_one)
 "byE" = (
 /obj/machinery/light{
 	dir = 8;
@@ -21606,32 +21824,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/tiled,
 /area/tether/station/dock_one)
-"byG" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 28
-	},
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/tiled,
-/area/tether/station/dock_one)
-"byN" = (
-/obj/machinery/power/apc{
-	cell_type = /obj/item/weapon/cell/super;
-	dir = 8;
-	name = "west bump";
-	pixel_x = -28
-	},
-/obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/turf/simulated/floor/tiled,
-/area/tether/station/dock_two)
 "byP" = (
 /obj/machinery/light{
 	dir = 4;
@@ -28462,10 +28654,10 @@ bYj
 bYj
 awu
 bzR
-bts
-bvt
-bwV
-byD
+aDb
+aDr
+aDO
+aDT
 aDF
 aEl
 aEN
@@ -28604,10 +28796,10 @@ bYl
 bYj
 aeF
 bZZ
-bty
+aDd
 aBZ
 aCI
-byG
+aDU
 aDG
 aEm
 aDF
@@ -28746,7 +28938,7 @@ bZD
 bZm
 aeF
 aAV
-btu
+aDf
 bvu
 aCF
 aCF
@@ -28888,7 +29080,7 @@ bZD
 bYj
 aeF
 aAV
-btu
+aDf
 aBZ
 awu
 aaa
@@ -29030,7 +29222,7 @@ bYj
 bYl
 awu
 bCg
-btu
+aDf
 aBZ
 aCJ
 aaa
@@ -29172,7 +29364,7 @@ bYl
 bZk
 aeI
 aBi
-btu
+aDf
 aBZ
 aCJ
 aaa
@@ -29314,7 +29506,7 @@ bYj
 bYj
 aeR
 aBi
-btu
+aDf
 aBZ
 aCJ
 aaa
@@ -29456,7 +29648,7 @@ bYj
 bYj
 awu
 awH
-btu
+aDf
 oEH
 awu
 aaa
@@ -29598,7 +29790,7 @@ aws
 aws
 aws
 aAZ
-btC
+aDk
 aBZ
 awu
 aaa
@@ -29740,7 +29932,7 @@ aCp
 aCZ
 aws
 aBa
-btu
+aDf
 aBZ
 aCJ
 aaa
@@ -29882,7 +30074,7 @@ bou
 aDa
 aws
 aBb
-aCY
+aDl
 aBZ
 aCJ
 aaa
@@ -30024,7 +30216,7 @@ aws
 aws
 aws
 bEW
-btu
+aDf
 aBZ
 aCJ
 aaa
@@ -30166,7 +30358,7 @@ aws
 bQa
 aws
 aCz
-btu
+aDf
 aBZ
 awu
 aaa
@@ -30308,7 +30500,7 @@ aws
 bQa
 aws
 aAV
-btu
+aDf
 oEH
 awu
 aaa
@@ -30450,7 +30642,7 @@ aws
 aws
 aws
 aBd
-btu
+aDf
 aBZ
 aCJ
 aaa
@@ -30592,7 +30784,7 @@ azh
 azO
 awt
 aAV
-btu
+aDf
 aBZ
 aCJ
 aaa
@@ -30726,15 +30918,15 @@ agW
 acp
 bdx
 awt
-bgO
-alO
-alP
+auJ
+ave
+avV
 alS
 alS
 azO
 awt
-bsv
-btM
+aCY
+aDm
 aBZ
 aCJ
 aaa
@@ -30870,13 +31062,13 @@ bdK
 awt
 aCS
 biK
-bks
+avW
 ayB
 azi
 bpv
 awt
 aBf
-btF
+aDn
 aBZ
 awu
 aaa
@@ -31012,13 +31204,13 @@ bdH
 awu
 awu
 awu
-bkq
+avX
 ayC
 awu
 awu
 awu
 bFf
-btu
+aDf
 bvu
 aCK
 aCK
@@ -31154,16 +31346,16 @@ bdS
 are
 bhc
 axC
-bky
+awc
 ayD
 azj
 awb
 aAm
 aBh
-btS
+aDo
 bvE
 aCL
-byN
+aDV
 aDJ
 aDJ
 aDJ
@@ -31292,20 +31484,20 @@ aik
 agb
 agZ
 aim
-bdL
-bfQ
-afo
-aDb
-aDd
-aDf
-bha
-bha
-bqf
-bha
-btO
-auT
-bxe
-aDn
+aig
+aug
+auQ
+avk
+awd
+awE
+aAA
+aAA
+aCr
+aAA
+aDp
+aDt
+aDQ
+aDW
 aDK
 aEn
 aEO
@@ -31445,7 +31637,7 @@ azR
 aAo
 aBi
 aBi
-auJ
+aDu
 aCN
 byP
 aDL
@@ -31587,7 +31779,7 @@ awu
 awu
 awu
 avG
-avX
+aDv
 aCK
 aCK
 aCK
@@ -31729,7 +31921,7 @@ bpz
 bqj
 awu
 avH
-awc
+aDw
 awF
 aya
 aya
@@ -31871,7 +32063,7 @@ azl
 aAq
 awu
 avJ
-awd
+aDx
 axa
 ayc
 ayo
@@ -32025,7 +32217,7 @@ ayf
 ayf
 ayQ
 azn
-azw
+aEi
 azE
 azS
 azZ
@@ -32145,8 +32337,8 @@ afn
 ahF
 aio
 afW
-agj
-ahr
+agk
+auq
 ahU
 aCk
 ahU
@@ -32284,16 +32476,16 @@ aeO
 afC
 afJ
 age
-ahH
-aiq
-ago
-agk
-ahC
-aic
-aig
-aig
-aic
-atC
+afY
+ahJ
+ahr
+aun
+auL
+avp
+awr
+awr
+avp
+aAD
 auU
 agk
 avK
@@ -32426,17 +32618,17 @@ aeO
 afC
 afF
 age
+agj
 acp
-acp
-atM
+ain
 agk
-ahC
+auR
 aie
 aiv
 asZ
 atm
-atD
-avn
+aAF
+amW
 afI
 avM
 awj
@@ -32456,8 +32648,8 @@ azx
 azx
 azx
 azx
-azz
-azz
+azx
+azx
 ahW
 aaa
 aaa
@@ -32568,7 +32760,7 @@ aeO
 afC
 afN
 agg
-acr
+ago
 acp
 aCq
 afI
@@ -32577,7 +32769,7 @@ aie
 aiA
 ate
 atn
-atE
+aAG
 avt
 avE
 avN
@@ -32710,7 +32902,7 @@ aeO
 afC
 afC
 aYt
-ahI
+agw
 air
 aAw
 afI
@@ -32735,7 +32927,7 @@ aBv
 ayt
 ayV
 azr
-azy
+aEj
 azK
 azU
 aAd
@@ -32852,7 +33044,7 @@ afA
 anf
 aWn
 agh
-acp
+agj
 acp
 atM
 agk
@@ -32865,7 +33057,7 @@ atV
 avy
 agk
 avK
-awi
+aDy
 awG
 axf
 axF
@@ -32994,7 +33186,7 @@ acm
 acm
 acm
 acm
-acp
+agj
 acp
 atM
 agk
@@ -33007,7 +33199,7 @@ aux
 avA
 afI
 avT
-auE
+aDz
 aww
 axg
 axM
@@ -33121,11 +33313,11 @@ ack
 ack
 ack
 afC
-azX
-agw
-alh
-aFh
-aHb
+abX
+acw
+adj
+aem
+aeZ
 aIs
 aeM
 adH
@@ -33136,10 +33328,10 @@ adH
 adH
 adH
 adH
-bay
+ahi
 acp
 atM
-ahi
+afI
 ahQ
 aif
 aif
@@ -33149,7 +33341,7 @@ auC
 avC
 afI
 avU
-ave
+aDA
 aww
 aww
 aww
@@ -33158,16 +33350,16 @@ aww
 ayt
 ayt
 ayt
-aBO
+ayt
 ayY
-azu
-azz
-azz
-azz
-azz
-azz
-azz
-azz
+avU
+azx
+azx
+azx
+azx
+azx
+azx
+azx
 ahW
 aaa
 aaa
@@ -33263,22 +33455,22 @@ ack
 ack
 ack
 afC
-afY
-abX
-acw
-acm
-acm
-acm
-acm
-acm
-acm
-acm
-acm
-acm
-acm
-acm
-acm
-ahJ
+acc
+acN
+adB
+aeK
+aeK
+afo
+afo
+afo
+afo
+afo
+afo
+afo
+afo
+afo
+afo
+ahI
 ais
 aAx
 afI
@@ -33291,9 +33483,9 @@ afI
 afI
 afI
 aAn
-avR
-avV
-avW
+aDB
+aDR
+aDX
 ail
 aBL
 ail
@@ -33306,7 +33498,7 @@ aBL
 auM
 ail
 aBF
-auD
+acQ
 aat
 aat
 aat
@@ -33427,15 +33619,15 @@ acQ
 ahp
 aud
 auf
-aug
-auq
-auq
-auq
-auq
-auu
-avk
+azu
+aAB
+aAB
+aAB
+aAB
+aDq
+aDC
 auD
-awr
+aDY
 axs
 ahj
 ahj
@@ -33448,7 +33640,7 @@ ahj
 ahj
 ail
 aBK
-auD
+acQ
 aat
 aat
 aat
@@ -33564,20 +33756,20 @@ acC
 adm
 acy
 aCx
-atU
+aiq
 agl
 ahL
 ahL
 ahL
-aui
+azz
 aBK
-adj
-adj
-adj
-adj
-auQ
 avb
-awx
+avb
+avb
+avb
+avb
+avb
+aEc
 awA
 ahj
 aqg
@@ -33590,7 +33782,7 @@ awW
 ahj
 ail
 aAv
-auD
+acQ
 aat
 aat
 aat
@@ -33706,20 +33898,20 @@ adE
 amv
 acy
 acm
-aAA
+alh
 acQ
 aAp
 ail
 ail
 auj
 aBL
-adj
-aiu
-aun
-auL
-auR
 avb
-awE
+aiu
+azw
+azy
+aDI
+avb
+aEd
 axq
 awN
 axh
@@ -33732,7 +33924,7 @@ awW
 axm
 ail
 aAr
-auD
+acQ
 aat
 aat
 aat
@@ -33848,21 +34040,21 @@ amu
 amv
 acy
 acm
-bdH
+alO
 acQ
 aBG
 aix
 aBx
 ait
 aut
-ain
+aBO
 aup
 auK
 auN
-avp
-avb
-aBS
-axy
+aDN
+aui
+aEe
+aEg
 ahj
 ayz
 auH
@@ -33874,7 +34066,7 @@ axl
 ahj
 aBL
 ail
-auD
+acQ
 aat
 aat
 aat
@@ -33990,7 +34182,7 @@ amr
 amw
 acy
 acm
-aAF
+alP
 acV
 acV
 acV
@@ -34016,7 +34208,7 @@ axl
 ahj
 aBz
 ail
-auD
+acQ
 aat
 aat
 aat
@@ -34132,7 +34324,7 @@ adl
 adl
 acy
 bbT
-aAB
+asV
 afc
 afH
 agm
@@ -34157,7 +34349,7 @@ ahN
 ahN
 ahN
 ahN
-asV
+aEh
 ahN
 ahN
 aat
@@ -34274,7 +34466,7 @@ adc
 adc
 acT
 aCX
-aCr
+atC
 acV
 afl
 agn
@@ -34416,7 +34608,7 @@ acm
 acm
 acm
 acp
-acc
+atD
 aiw
 asR
 afd
@@ -34558,7 +34750,7 @@ acm
 acm
 acm
 acp
-aAD
+atE
 acV
 acV
 acV
@@ -34700,8 +34892,8 @@ acY
 acY
 acT
 acp
-acN
-ahm
+atU
+ahl
 adr
 aeo
 aep
@@ -34838,11 +35030,11 @@ acU
 acH
 acF
 acy
-uiN
+afv
 adl
 acy
 acp
-acN
+atU
 ahm
 adJ
 aej
@@ -34984,14 +35176,14 @@ adk
 amx
 acy
 acp
+aAI
+auu
+auT
+avR
+awx
+azX
 aAC
-ahm
-adB
-aem
-aej
-aeK
-aeZ
-afv
+aBS
 ahh
 aom
 awg
@@ -35126,7 +35318,7 @@ adE
 amv
 acy
 acp
-aAG
+aAI
 ahm
 aed
 aej
@@ -35269,7 +35461,7 @@ amv
 acy
 acp
 aAI
-ahm
+auE
 adN
 ahu
 aeH
@@ -35695,13 +35887,13 @@ adH
 acW
 qBc
 agp
-aeP
-acm
+avn
+adH
 aCe
 acm
 amQ
 aum
-amV
+aaT
 anp
 ans
 anI
@@ -35843,7 +36035,7 @@ aCs
 bmv
 amS
 amT
-amW
+amV
 anh
 anv
 anJ

--- a/maps/tether/tether-05-station1.dmm
+++ b/maps/tether/tether-05-station1.dmm
@@ -23112,11 +23112,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/tether/station/dock_one)
-"uiN" = (
-/obj/structure/table/woodentable,
-/obj/item/weapon/reagent_containers/food/snacks/donut/chaos,
-/turf/simulated/floor/grass,
-/area/hallway/station/atrium)
 "uWS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
@@ -35589,7 +35584,7 @@ ald
 acr
 acy
 acy
-uiN
+afv
 adl
 acy
 acy

--- a/maps/tether/tether-06-station2.dmm
+++ b/maps/tether/tether-06-station2.dmm
@@ -15298,6 +15298,26 @@
 "xg" = (
 /turf/simulated/wall,
 /area/maintenance/station/medbay)
+"xh" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/power/apc{
+	dir = 2;
+	name = "south bump";
+	pixel_y = -28
+	},
+/obj/structure/cable/green{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor,
+/area/maintenance/station/micro)
 "xj" = (
 /obj/structure/window/reinforced,
 /turf/simulated/floor/tiled/white,
@@ -16070,24 +16090,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/exploration/equipment)
-"yI" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/obj/structure/cable/green,
-/obj/machinery/power/apc{
-	dir = 2;
-	name = "south bump";
-	pixel_y = -28
-	},
-/turf/simulated/floor,
-/area/maintenance/station/micro)
 "yJ" = (
 /turf/simulated/wall/r_wall,
 /area/maintenance/station/micro)
@@ -35051,7 +35053,7 @@ wQ
 wR
 wR
 wS
-yI
+xh
 sB
 ac
 ac

--- a/maps/tether/tether-07-station3.dmm
+++ b/maps/tether/tether-07-station3.dmm
@@ -2240,7 +2240,9 @@
 	pixel_x = 6;
 	pixel_y = 32
 	},
-/obj/machinery/light,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/shuttle/excursion/tether)
 "dF" = (

--- a/maps/tether/tether_areas2.dm
+++ b/maps/tether/tether_areas2.dm
@@ -844,11 +844,11 @@
 	name = "\improper Abandoned Library Conference"
 	icon_state = "library"
 /area/maintenance/station/spacecommandmaint
-	name = "\improper Space Command Maintenance"
+	name = "\improper Asteroid Command Maintenance"
 	icon_state = "bridge"
 	sound_env = SEWER_PIPE
 /area/maintenance/substation/spacecommand
-	name = "\improper Space Command Substation"
+	name = "\improper Asteroid Command Substation"
 	icon_state = "substation"
 
 /area/shuttle/tether/crash1


### PR DESCRIPTION
Renames the Space Civ/Com to Asteroid Command and rewires it accordingly

Properly connects new Civilian areas on asteroid to Civilian powernet

Re-adds the doors to access the old gateway construction area

Replaces library construction area door from glass to maintenance one, removes the sign

Replaces chaos donuts in asteroid cafe with normal ones

Some other minor stuff