### PR TITLE
Temporarily removes update_client_z from /logout

### DIFF
--- a/code/modules/mob/logout.dm
+++ b/code/modules/mob/logout.dm
@@ -2,7 +2,7 @@
 	SSnanoui.user_logout(src) // this is used to clean up (remove) this user's Nano UIs
 	player_list -= src
 	disconnect_time = world.realtime	//VOREStation Addition: logging when we disappear.
-	update_client_z(null)
+	//update_client_z(null)				//VOREStation TEST Removal: potential source of restart crashes
 	log_access_out(src)
 	if(admin_datums[src.ckey])
 		if (ticker && ticker.current_state == GAME_STATE_PLAYING) //Only report this stuff if we are currently playing.


### PR DESCRIPTION
It's sort of a shot in the dark, but that proc affects surprisingly little. And if theory is correct, it might be the solution to the restart crashing, so here's a sort of test merge.