### PR TITLE
Makes drone pods remain active after first attempt

### DIFF
--- a/code/game/objects/structures/ghost_pods/ghost_pods.dm
+++ b/code/game/objects/structures/ghost_pods/ghost_pods.dm
@@ -49,6 +49,10 @@
 			if(alert(user, "Are you sure you want to touch \the [src]?", "Confirm", "No", "Yes") == "No")
 				return
 		trigger()
+		// VOREStation Addition Start
+		if(!used)
+			activated = TRUE
+		// VOREStation Addition End
 
 /obj/structure/ghost_pod/manual/attack_ai(var/mob/living/silicon/user)
 	if(Adjacent(user))

--- a/code/game/objects/structures/ghost_pods/ghost_pods_vr.dm
+++ b/code/game/objects/structures/ghost_pods/ghost_pods_vr.dm
@@ -1,0 +1,31 @@
+/obj/structure/ghost_pod/manual
+	var/remains_active = FALSE
+	var/activated = FALSE
+
+/obj/structure/ghost_pod/manual/attack_ghost(var/mob/observer/dead/user)
+	if(!remains_active || busy)
+		return
+
+	if(!activated)
+		to_chat(user, "<span class='warning'>\the [src] has not yet been activated.  Sorry.</span>")
+		return
+
+	if(used)
+		to_chat(user, "<span class='warning'>Another spirit appears to have gotten to \the [src] before you.  Sorry.</span>")
+		return
+
+	busy = TRUE
+	var/choice = input(user, "Are you certain you wish to activate this pod?", "Control Pod") as null|anything in list("Yes", "No")
+
+	if(!choice || choice == "No")
+		busy = FALSE
+		return
+
+	else if(used)
+		to_chat(user, "<span class='warning'>Another spirit appears to have gotten to \the [src] before you.  Sorry.</span>")
+		busy = FALSE
+		return
+
+	busy = FALSE
+
+	create_occupant(user)

--- a/code/game/objects/structures/ghost_pods/silicon_vr.dm
+++ b/code/game/objects/structures/ghost_pods/silicon_vr.dm
@@ -1,4 +1,5 @@
 /obj/structure/ghost_pod/manual/lost_drone/dogborg
+	remains_active = TRUE
 
 /obj/structure/ghost_pod/manual/lost_drone/dogborg/create_occupant(var/mob/M)
 	var/response = alert(M, "What type of lost drone are you? Do note, that dogborgs may have experienced different type of corruption ((Potential for having vore-related laws))", "Drone Type", "Regular", "Dogborg")

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -1353,6 +1353,7 @@
 #include "code\game\objects\structures\flora\grass.dm"
 #include "code\game\objects\structures\flora\trees.dm"
 #include "code\game\objects\structures\ghost_pods\ghost_pods.dm"
+#include "code\game\objects\structures\ghost_pods\ghost_pods_vr.dm"
 #include "code\game\objects\structures\ghost_pods\human.dm"
 #include "code\game\objects\structures\ghost_pods\mysterious.dm"
 #include "code\game\objects\structures\ghost_pods\silicon.dm"


### PR DESCRIPTION
Will allow ghosts to enter it by clicking it after the initial activation attempt. This does not prevent any more attempts by players themselves though.