### PR TITLE
Disable random blackouts during NIF adaptation

### DIFF
--- a/code/modules/nifsoft/nif.dm
+++ b/code/modules/nifsoft/nif.dm
@@ -255,7 +255,7 @@ You can also set the stat of a NIF to NIF_TEMPFAIL without any issues to disable
 			install_done = world.time + 1 MINUTE
 			notify("Welcome back, [owner]! Performing quick-calibration...")
 		else if(!owner)
-			install_done = world.time + 30 MINUTES
+			install_done = world.time + 35 MINUTES
 			notify("Adapting to new user...")
 			sleep(5 SECONDS)
 			notify("Adjoining optic [human.isSynthetic() ? "interface" : "nerve"], please be patient.",TRUE)
@@ -265,7 +265,7 @@ You can also set the stat of a NIF to NIF_TEMPFAIL without any issues to disable
 			stat = NIF_TEMPFAIL
 			return FALSE
 
-	var/percent_done = (world.time - (install_done - (30 MINUTES))) / (30 MINUTES)
+	var/percent_done = (world.time - (install_done - (35 MINUTES))) / (35 MINUTES)
 
 	if(human.client)
 		human.client.screen.Add(global_hud.whitense) //This is the camera static
@@ -294,9 +294,9 @@ You can also set the stat of a NIF to NIF_TEMPFAIL without any issues to disable
 				if(2)
 					human.Weaken(5)
 					to_chat(human,"<span class='danger'>A wave of weakness rolls over you.</span>")
-				if(3)
-					human.Sleeping(5)
-					to_chat(human,"<span class='danger'>You suddenly black out!</span>")
+				/*if(3)
+					human.Sleeping(5) //Disabled for being boring
+					to_chat(human,"<span class='danger'>You suddenly black out!</span>")*/
 
 		//Finishing up
 		if(1.0 to INFINITY)


### PR DESCRIPTION
### **About The Pull Request**
- Disable blackouts from the list of effects of a NIF installation 
- Extend the timer by 5 minutes as a counterbalance. This is not necessary and can be reverted.

### **Why It's Good For The Game**
It disable something which hindered roleplay and gameplay potential from the procedure.
Blacking out was random, short and without any form of warning, meaning you can't really RP around it or just walk about without getting dragged to medical because you fell on the floor.
