### PR TITLE
Fixes grub event end announcement not functioning

### DIFF
--- a/code/_helpers/global_lists_vr.dm
+++ b/code/_helpers/global_lists_vr.dm
@@ -428,6 +428,8 @@ var/global/list/remainless_species = list(SPECIES_PROMETHEAN,
 				SPECIES_GOLEM,					//Some special species that may or may not be ever used in event too,
 				SPECIES_SHADEKIN)			//Shadefluffers just poof away
 
+/var/global/list/existing_solargrubs = list()
+
 /hook/startup/proc/init_vore_datum_ref_lists()
 	var/paths
 

--- a/code/modules/events/grubinfestation_vr.dm
+++ b/code/modules/events/grubinfestation_vr.dm
@@ -3,7 +3,6 @@
 	endWhen			= 200
 	var/spawncount = 1
 	var/list/vents = list()
-	var/list/grubs = list()
 	var/give_positions = 0
 
 /datum/event/grub_infestation/setup()
@@ -31,7 +30,7 @@
 
 /datum/event/grub_infestation/end()
 	var/list/area_names = list()
-	for(var/grub in grubs)
+	for(var/grub in existing_solargrubs)
 		var/mob/living/G = grub
 		if(!G || G.stat == DEAD)
 			continue
@@ -44,4 +43,3 @@
 	if(area_names.len)
 		var/english_list = english_list(area_names)
 		command_announcement.Announce("Sensors have narrowed down remaining active solargrubs to the followng areas: [english_list]", "Lifesign Alert", new_sound = 'sound/AI/aliens.ogg')
-	grubs.Cut()

--- a/code/modules/mob/living/simple_mob/subtypes/vore/solargrub.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/solargrub.dm
@@ -54,6 +54,10 @@ List of things solar grubs should be able to do:
 /datum/say_list/solargrub
 	emote_see = list("squelches", "squishes")
 
+/mob/living/simple_mob/vore/solargrub/New()
+	existing_solargrubs += src
+	..()
+
 /mob/living/simple_mob/vore/solargrub/Life()
 	. = ..()
 	if(!.) return
@@ -121,6 +125,10 @@ List of things solar grubs should be able to do:
 /mob/living/simple_mob/vore/solargrub/death()
 	src.anchored = 0
 	set_light(0)
+	..()
+
+/mob/living/simple_mob/vore/solargrub/Destroy()
+	existing_solargrubs -= src
 	..()
 
 /mob/living/simple_mob/vore/solargrub/handle_light()

--- a/code/modules/mob/living/simple_mob/subtypes/vore/solargrub_larva.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/solargrub_larva.dm
@@ -50,6 +50,7 @@ var/global/list/grub_machine_overlays = list()
 
 /mob/living/simple_mob/animal/solargrub_larva/New()
 	..()
+	existing_solargrubs += src
 	powermachine = new(src)
 	sparks = new(src)
 	sparks.set_up()
@@ -62,6 +63,7 @@ var/global/list/grub_machine_overlays = list()
 	return ..()
 
 /mob/living/simple_mob/animal/solargrub_larva/Destroy()
+	existing_solargrubs -= src
 	QDEL_NULL(powermachine)
 	QDEL_NULL(sparks)
 	QDEL_NULL(machine_effect)


### PR DESCRIPTION
Turns out the event had a broken feature of announcing the list of locations where living grubs still remain after some time. This should fix that.