### PR TITLE
Earlyports fix for missing access

### DIFF
--- a/code/datums/outfits/outfit.dm
+++ b/code/datums/outfits/outfit.dm
@@ -87,7 +87,7 @@ var/list/outfits_decls_by_type_
 /decl/hierarchy/outfit/proc/equip(mob/living/carbon/human/H, var/rank, var/assignment)
 	equip_base(H)
 
-	rank = id_pda_assignment || rank
+	rank = rank || id_pda_assignment
 	assignment = id_pda_assignment || assignment || rank
 	var/obj/item/weapon/card/id/W = equip_id(H, rank, assignment)
 	if(W)


### PR DESCRIPTION
Earlyport of https://github.com/PolarisSS13/Polaris/pull/6627

Fixes alt-titles with custom outfits supposedly not having any access. Definitely fixes barista's.