### PR TITLE
IP reputation checking

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -104,6 +104,13 @@ var/list/gamemode_cache = list()
 	var/panic_bunker = 0
 	var/paranoia_logging = 0
 
+	var/ip_reputation = FALSE		//Should we query IPs to get scores? Generates HTTP traffic to an API service.
+	var/ipr_email					//Left null because you MUST specify one otherwise you're making the internet worse.
+	var/ipr_block_bad_ips = FALSE	//Should we block anyone who meets the minimum score below? Otherwise we just log it (If paranoia logging is on, visibly in chat).
+	var/ipr_bad_score = 1			//The API returns a value between 0 and 1 (inclusive), with 1 being 'definitely VPN/Tor/Proxy'. Values equal/above this var are considered bad.
+	var/ipr_allow_existing = FALSE 	//Should we allow known players to use VPNs/Proxies? If the player is already banned then obviously they still can't connect.
+	var/ipr_minimum_age = 5			//How many days before a player is considered 'fine' for the purposes of allowing them to use VPNs.
+
 	var/serverurl
 	var/server
 	var/banappeals
@@ -805,6 +812,24 @@ var/list/gamemode_cache = list()
 
 				if ("paranoia_logging")
 					config.paranoia_logging = 1
+
+				if("ip_reputation")
+					config.ip_reputation = 1
+
+				if("ipr_email")
+					config.ipr_email = value
+
+				if("ipr_block_bad_ips")
+					config.ipr_block_bad_ips = 1
+
+				if("ipr_bad_score")
+					config.ipr_bad_score = text2num(value)
+
+				if("ipr_allow_existing")
+					config.ipr_allow_existing = 1
+
+				if("ipr_minimum_age")
+					config.ipr_minimum_age = text2num(value)
 
 				if("random_submap_orientation")
 					config.random_submap_orientation = 1

--- a/code/modules/client/client defines.dm
+++ b/code/modules/client/client defines.dm
@@ -41,6 +41,7 @@
 	var/received_irc_pm = -99999
 	var/irc_admin			//IRC admin that spoke with them last.
 	var/mute_irc = 0
+	var/ip_reputation = 0 //Do we think they're using a proxy/vpn? Only if IP Reputation checking is enabled in config.
 
 
 		////////////////////////////////////

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -307,7 +307,7 @@
 		else
 			log_admin("Couldn't perform IP check on [key] with [address]")
 
-	// VOREStation Edit Start - Department Hoursn
+	// VOREStation Edit Start - Department Hours
 	if(config.time_off)
 		var/DBQuery/query_hours = dbcon.NewQuery("SELECT department, hours FROM vr_player_hours WHERE ckey = '[sql_ckey]'")
 		query_hours.Execute()

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -460,8 +460,26 @@ RADIATION_RESISTANCE_MULTIPLIER 2.1
 ## Divisor for material weights when computing radiation resistance of a material object (walls)
 RADIATION_MATERIAL_RESISTANCE_DIVISOR 16
 
-
 ## Mode of computing radiation resistance into effective radiation on a turf
 ## One and only one of the following options must be uncommented
 RADIATION_RESISTANCE_CALC_DIVIDE
 # RADIATION_RESISTANCE_CALC_SUBTRACT
+
+## IP Reputation Checking
+# Enable/disable IP reputation checking (present/nonpresent)
+#IP_REPUTATION
+
+# Set the e-mail address problems can go to for IPR checks (e-mail address)
+IPR_EMAIL whatever@whatever.com
+
+# Above this value, reputation scores are considered 'bad' (number)
+IPR_BAD_SCORE 1
+
+# If you want the people disconnected. Otherwise it just logs. (present/nonpresent)
+IPR_BLOCK_BAD_IPS
+
+# If players of a certain length of playtime are allowed anyway (REQUIRES DATABASE) (present/nonpresent)
+IPR_ALLOW_EXISTING
+
+# And what that age is (number)
+IPR_MINIMUM_AGE 5


### PR DESCRIPTION
Adds IP reputation checking to detect Tor, proxy, and VPN usage and block it if so configured.

It's disabled by default, but if enabled the default settings are to block all VPN/Proxy/Tor to connect unless the player has been a player for 5 days on a 'normal' connection so that people who legitimately sometimes use a VPN for *reasons* can continue to do so. You can also have it check reputations and just log bad ones, without disconnecting the users.

Whether or not it allows 'existing' players, the length of time they must have played, what's considered a 'bad' IP score, etc, are configurable. You **must** put an e-mail address if you use this, otherwise the service will likely ban you. This is the e-mail address they will send e-mails to if you're performing too many checks or they need to speak to you. 

Adds config options, here's a paste from the example config:
```
## IP Reputation Checking
# Enable/disable IP reputation checking (present/nonpresent)
#IP_REPUTATION

# Set the e-mail address problems can go to for IPR checks (e-mail address)
IPR_EMAIL whatever@whatever.com

# Above this value, reputation scores are considered 'bad' (number)
IPR_BAD_SCORE 1

# If you want the people disconnected. Otherwise it just logs. (present/nonpresent)
IPR_BLOCK_BAD_IPS

# If players of a certain length of playtime are allowed anyway (REQUIRES DATABASE) (present/nonpresent)
IPR_ALLOW_EXISTING

# And what that age is (number)
IPR_MINIMUM_AGE 5
```

As you can see, it's off by default, so if you're a downstream this won't change anything for you unless you decide to turn it on. If you want the features, just copypaste the new config lines out of the example and uncomment IP_REPUTATION.

Downstreams can replace the /client/proc/update_ip_reputation() proc with your own, if you'd like to substitute your own service! Just set the client's ip_reputation var at the end of your proc.