### PR TITLE
No More Vines That Shrink Thee

### DIFF
--- a/code/modules/hydroponics/seed.dm
+++ b/code/modules/hydroponics/seed.dm
@@ -452,11 +452,15 @@
 	var/additional_chems = rand(0,5)
 
 	if(additional_chems)
-
+		//VOREStation Edit Start TFF 24/1/20 - More chems too the blacklist for prefs reasoning.
 		var/list/banned_chems = list(
 			"adminordrazine",
-			"nutriment"
+			"nutriment",
+			"macrocillin",
+			"microcillin",
+			"normalcillin"
 			)
+		//VOREStation Edit End
 
 		for(var/x=1;x<=additional_chems;x++)
 


### PR DESCRIPTION
Changelog Notes: 

- Blacklist Macro/micro/normal cillins from list of spawnable chems in vines that can get injected into your body. This is purely for pref reasons if you don't actually like having your size changed.