### PR TITLE
QoL to supplypacks related to Belt Mining

### DIFF
--- a/code/datums/supplypacks/misc_vr.dm
+++ b/code/datums/supplypacks/misc_vr.dm
@@ -6,12 +6,16 @@
 			/obj/item/weapon/cell/device/weapon = 2,
 			/obj/item/weapon/storage/firstaid/regular = 1,
 			/obj/item/device/gps = 2,
-			/obj/item/weapon/storage/box/traumainjectors = 1
+			/obj/item/weapon/storage/box/traumainjectors = 1,
+			/obj/item/weapon/tank/jetpack = 1,
+			/obj/item/device/binoculars = 1
 			)
-	cost = 50
+	cost = 80
 	containertype = /obj/structure/closet/crate/secure/gear
 	containername = "Belt-miner gear crate"
-	access = access_mining
+	access = list(access_mining,
+				  access_xenoarch)
+	one_access = TRUE
 
 /datum/supply_pack/misc/eva_rig
 	name = "eva hardsuit (empty)"

--- a/code/datums/supplypacks/misc_vr.dm
+++ b/code/datums/supplypacks/misc_vr.dm
@@ -7,10 +7,9 @@
 			/obj/item/weapon/storage/firstaid/regular = 1,
 			/obj/item/device/gps = 2,
 			/obj/item/weapon/storage/box/traumainjectors = 1,
-			/obj/item/weapon/tank/jetpack = 1,
 			/obj/item/device/binoculars = 1
 			)
-	cost = 80
+	cost = 60
 	containertype = /obj/structure/closet/crate/secure/gear
 	containername = "Belt-miner gear crate"
 	access = list(access_mining,
@@ -82,3 +81,18 @@
 	containertype = /obj/structure/closet/crate/secure/gear
 	containername = "advanced voidsuit crate"
 	access = access_ce
+
+/datum/supply_pack/misc/jetpack
+	name = "jetpack (empty)"
+	contains = list(
+			/obj/item/weapon/tank/jetpack = 1
+			)
+	cost = 75
+	containertype = /obj/structure/closet/crate/secure/gear
+	containername = "jetpack crate"
+	access = list(access_mining,
+				  access_xenoarch,
+				  access_eva,
+				  access_explorer,
+				  access_pilot)
+	one_access = TRUE


### PR DESCRIPTION
Basically extra followup to #6492.

Feel like this might need its own discussion if any.

Increases price of belt mining crate by 10, adds a pair of binoculars into it, allows xenoarch access to open it.

Adds jetpack crate, contains one empty jetpack. Can be opened by mining, EVA, xenoarch or explorer access.