### PR TITLE
Sundry Bugfixes - Feburary

### DIFF
--- a/code/modules/mob/living/simple_mob/subtypes/animal/passive/fish_vr.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/passive/fish_vr.dm
@@ -69,6 +69,7 @@
 	icon_dead = "measelshark-dead"
 	meat_amount = 6 //Big fish, tons of meat. Great for feasts.
 	meat_type = /obj/item/weapon/reagent_containers/food/snacks/sliceable/sharkchunk
+	vore_active = 1
 	vore_bump_chance = 100
 	vore_default_mode = DM_HOLD //docile shark
 	vore_capacity = 5

--- a/code/modules/mob/new_player/preferences_setup_vr.dm
+++ b/code/modules/mob/new_player/preferences_setup_vr.dm
@@ -1,5 +1,7 @@
 /datum/preferences/update_preview_icon() // Lines up and un-overlaps character edit previews. Also un-splits taurs.
 	var/mob/living/carbon/human/dummy/mannequin/mannequin = get_mannequin(client_ckey)
+	if(!mannequin.dna) // Special handling for preview icons before SSAtoms has initailized.
+		mannequin.dna = new /datum/dna(null)
 	mannequin.delete_inventory(TRUE)
 	dress_preview_mob(mannequin)
 	COMPILE_OVERLAYS(mannequin)

--- a/code/modules/vore/eating/living_vr.dm
+++ b/code/modules/vore/eating/living_vr.dm
@@ -425,7 +425,7 @@
 /mob/living/proc/perform_the_nom(var/mob/living/user, var/mob/living/prey, var/mob/living/pred, var/obj/belly/belly, var/delay)
 	//Sanity
 	if(!user || !prey || !pred || !istype(belly) || !(belly in pred.vore_organs))
-		log_debug("[user] attempted to feed [prey] to [pred], via [lowertext(belly.name)] but it went wrong.")
+		log_debug("[user] attempted to feed [prey] to [pred], via [belly ? lowertext(belly.name) : "*null*"] but it went wrong.")
 		return
 
 	// The belly selected at the time of noms

--- a/maps/RandomZLevels/labyrinth.dm
+++ b/maps/RandomZLevels/labyrinth.dm
@@ -10,7 +10,7 @@
 
 /area/awaymission/labyrinth/temple
 	icon_state = "away"
-	ambience = null // Todo: Add better ambience.
+	ambience = list() // Todo: Add better ambience.
 
 /area/awaymission/labyrinth/temple/entry
 	icon_state = "chapel"

--- a/maps/RandomZLevels/snowfield.dm
+++ b/maps/RandomZLevels/snowfield.dm
@@ -40,7 +40,7 @@
 
 /area/awaymission/snowfield/base
 	icon_state = "away"
-	ambience = null // Todo: Add better ambience.
+	ambience = list() // Todo: Add better ambience.
 
 // -- Mobs -- //
 

--- a/maps/tether/submaps/gateway/snowfield.dm
+++ b/maps/tether/submaps/gateway/snowfield.dm
@@ -40,7 +40,7 @@
 
 /area/awaymission/snowfield/base
 	icon_state = "away"
-	ambience = null // Todo: Add better ambience.
+	ambience = list() // Todo: Add better ambience.
 
 // -- Mobs -- //
 


### PR DESCRIPTION
####  Fix Runtime in areas.dm,307: Cannot read null.len 
area.ambience is never expected to be null.
#### Fixes Runtime in living_vr.dm,428: Cannot read null.name
- This was happening when null is passed for belly. Now it will print *null*
- Also fixed root cause (at least one of them). Animals can't have vore attributes enabled when vore_active = 0 because then they don't get a belly.
#### Fix character setup preview icons rendering prior to SSAtoms initialization
- Rendering the characters involved creating mannequin mobs, prior to SSAtoms init these would not be initialized and thus have no DNA.  This prints many warning messages, causes runtimes, and ultimately the icon does not render correctly.
- Its fixed here since it seems that needing to use mobs prior to initialization is a pretty unique edge case.  Comment added to explain to future us.

