### PR TITLE
Prevents some teleporting abuses with taur riding

### DIFF
--- a/code/datums/helper_datums/teleport.dm
+++ b/code/datums/helper_datums/teleport.dm
@@ -158,6 +158,13 @@
 		precision = rand(1,100)
 
 	var/list/bagholding = teleatom.search_contents_for(/obj/item/weapon/storage/backpack/holding)
+	//VOREStation Addition Start: Prevent taurriding abuse
+	if(istype(teleatom, /mob/living))
+		var/mob/living/L = teleatom
+		if(LAZYLEN(L.buckled_mobs))
+			for(var/mob/rider in L.buckled_mobs)
+				bagholding += rider.search_contents_for(/obj/item/weapon/storage/backpack/holding)
+	//VOREStation Addition End: Prevent taurriding abuse
 	if(bagholding.len)
 		precision = max(rand(1,100)*bagholding.len,100)
 		if(istype(teleatom, /mob/living))

--- a/code/game/machinery/teleporter.dm
+++ b/code/game/machinery/teleporter.dm
@@ -209,6 +209,14 @@
 			O.show_message("<span class='warning'>Failure: Cannot authenticate locked on coordinates. Please reinstate coordinate matrix.</span>")
 		return
 	if(istype(M, /atom/movable))
+		//VOREStation Addition Start: Prevent taurriding abuse
+		if(istype(M, /mob/living))
+			var/mob/living/L = M
+			if(LAZYLEN(L.buckled_mobs))
+				var/datum/riding/R = L.riding_datum
+				for(var/rider in L.buckled_mobs)
+					R.force_dismount(rider)
+		//VOREStation Addition End: Prevent taurriding abuse
 		if(prob(5) && !accurate) //oh dear a problem, put em in deep space
 			do_teleport(M, locate(rand((2*TRANSITIONEDGE), world.maxx - (2*TRANSITIONEDGE)), rand((2*TRANSITIONEDGE), world.maxy - (2*TRANSITIONEDGE)), 3), 2)
 		else

--- a/code/game/objects/effects/portals.dm
+++ b/code/game/objects/effects/portals.dm
@@ -60,6 +60,14 @@ GLOBAL_LIST_BOILERPLATE(all_portals, /obj/effect/portal)
 		qdel(src)
 		return
 	if (istype(M, /atom/movable))
+		//VOREStation Addition Start: Prevent taurriding abuse
+		if(istype(M, /mob/living))
+			var/mob/living/L = M
+			if(LAZYLEN(L.buckled_mobs))
+				var/datum/riding/R = L.riding_datum
+				for(var/rider in L.buckled_mobs)
+					R.force_dismount(rider)
+		//VOREStation Addition End: Prevent taurriding abuse
 		if(prob(failchance)) //oh dear a problem, put em in deep space
 			src.icon_state = "portal1"
 			do_teleport(M, locate(rand(5, world.maxx - 5), rand(5, world.maxy -5), 3), 0)

--- a/code/modules/awaymissions/gateway.dm
+++ b/code/modules/awaymissions/gateway.dm
@@ -133,6 +133,14 @@ obj/machinery/gateway/centerstation/process()
 		M.set_dir(SOUTH)
 		return
 	else
+		//VOREStation Addition Start: Prevent taurriding abuse
+		if(istype(M, /mob/living))
+			var/mob/living/L = M
+			if(LAZYLEN(L.buckled_mobs))
+				var/datum/riding/R = L.riding_datum
+				for(var/rider in L.buckled_mobs)
+					R.force_dismount(rider)
+		//VOREStation Addition End: Prevent taurriding abuse
 		var/obj/effect/landmark/dest = pick(awaydestinations)
 		if(dest)
 			M.forceMove(dest.loc)

--- a/code/modules/vore/fluffstuff/guns/bsharpoon.dm
+++ b/code/modules/vore/fluffstuff/guns/bsharpoon.dm
@@ -62,22 +62,30 @@
 	var/turf/FromTurf = mode ? get_turf(user) : get_turf(A)
 	var/turf/ToTurf = mode ? get_turf(A) : get_turf(user)
 
+	var/recievefailchance = 5
+	var/sendfailchance = 5
+	if(istype(user, /mob/living))
+		var/mob/living/L = user
+		if(LAZYLEN(L.buckled_mobs))
+			for(var/rider in L.buckled_mobs)
+				sendfailchance += 15
+
 	if(mode)
 		if(user in FromTurf)
-			if(prob(5))
+			if(prob(sendfailchance))
 				user.forceMove(pick(trange(24,user)))
 			else
 				user.forceMove(ToTurf)
 	else
 		for(var/obj/O in FromTurf)
 			if(O.anchored) continue
-			if(prob(5))
+			if(prob(recievefailchance))
 				O.forceMove(pick(trange(24,user)))
 			else
 				O.forceMove(ToTurf)
 
 		for(var/mob/living/M in FromTurf)
-			if(prob(5))
+			if(prob(recievefailchance))
 				M.forceMove(pick(trange(24,user)))
 			else
 				M.forceMove(ToTurf)


### PR DESCRIPTION
When using _uncalibrated_ gateway, hand tele portals or command teleporter as a taur, all your riders are dismounted automatically and left behind.

All teleportation now takes into account the bluespace backpacks of the taur's riders for failing chances.

Bluespace harpoon's "send" mode now has increased chance of failure if you have riders.