### PR TITLE
Prevents resleeving sickness from affecting hardvore victims

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/station_special_abilities_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_special_abilities_vr.dm
@@ -745,6 +745,8 @@
 			to_chat(src,"<span class='warning'>Looks like you lost your chance...</span>")
 			return
 
+		T.add_modifier(/datum/modifier/gory_devourment, 10 SECONDS)
+
 		//Removing an internal organ
 		if(T_int && T_int.damage >= 25) //Internal organ and it's been severely damaged
 			T.apply_damage(15, BRUTE, T_ext) //Damage the external organ they're going through.

--- a/code/modules/resleeving/resleeving_sickness.dm
+++ b/code/modules/resleeving/resleeving_sickness.dm
@@ -22,3 +22,27 @@
 
 	on_created_text = "<span class='warning'>You feel slightly weak and unfocused.</span>"
 	on_expired_text = "<span class='notice'>You feel your strength and focus return to you.</span>"
+
+/datum/modifier/gory_devourment
+	name = "gory devourment"
+	desc = "You are being devoured! Dying right now would definitely be same as dying as food."
+	stacks = MODIFIER_STACK_EXTEND
+	hidden = TRUE
+	var/datum/mind/cached_mind = null
+
+/datum/modifier/gory_devourment/can_apply(var/mob/living/L)
+	if(L.stat == DEAD)
+		return FALSE
+	else
+		return TRUE
+
+/datum/modifier/gory_devourment/on_applied()
+	if(holder.ckey)
+		if(holder.mind)
+			cached_mind = holder.mind
+	return
+
+/datum/modifier/gory_devourment/on_expire()
+	if(holder.stat == DEAD)
+		cached_mind.vore_death = TRUE
+	return


### PR DESCRIPTION
Title. Applies a very short buff when living creature is hardvored. If when buff expires its dead, its death is marked as vore death.

Resolves #6569 