### PR TITLE
EARLYPORT: Fix Air Pump loop sound stacking multiple times per pump.

### DIFF
--- a/code/datums/looping_sounds/machinery_sounds.dm
+++ b/code/datums/looping_sounds/machinery_sounds.dm
@@ -51,7 +51,7 @@
 	start_sound = 'sound/machines/air_pump/airpumpstart.ogg'
 	start_length = 10
 	mid_sounds = list('sound/machines/air_pump/airpumpidle.ogg' = 1)
-	mid_length = 4
+	mid_length = 110
 	end_sound = 'sound/machines/air_pump/airpumpshutdown.ogg'
 	volume = 15
 	pref_check = /datum/client_preference/air_pump_noise


### PR DESCRIPTION
Turns out that the # was so, so, so far off. It was acting as if it was 0.4 seconds per loop, for an 11 SECOND SOUND FILE.

My bad.
Earlyport of https://github.com/PolarisSS13/Polaris/pull/6700
