### PR TITLE
Revert "Bandaid for helper.dm runtime lag"

### DIFF
--- a/code/game/objects/items/devices/communicator/UI.dm
+++ b/code/game/objects/items/devices/communicator/UI.dm
@@ -121,7 +121,7 @@
 	data["flashlight"] = fon
 	data["manifest"] = PDA_Manifest
 	data["feeds"] = compile_news()
-	//data["latest_news"] = get_recent_news()	//VOREStation Edit, bandaid for catastrophic runtime lag in helper.dm
+	data["latest_news"] = get_recent_news()
 	if(cartridge) // If there's a cartridge, we need to grab the information from it
 		data["cart_devices"] = cartridge.get_device_status()
 		data["cart_templates"] = cartridge.ui_templates


### PR DESCRIPTION
Reverts VOREStation/VOREStation#5680

Root cause of this runtime was just fixed, so, can revert this.