### PR TITLE
Fix to_chat typo

### DIFF
--- a/code/modules/admin/newbanjob.dm
+++ b/code/modules/admin/newbanjob.dm
@@ -141,7 +141,7 @@ var/savefile/Banlistjob
 
 	Banlistjob.cd = "/base"
 	if ( Banlistjob.dir.Find("[ckey][computerid][rank]") )
-		to_char(usr,"<font color='red'>Banjob already exists.</font>")
+		to_chat(usr,"<font color='red'>Banjob already exists.</font>")
 		return 0
 	else
 		Banlistjob.dir.Add("[ckey][computerid][rank]")


### PR DESCRIPTION
This file is unchecked so it's not being used, but I'd still rather not leave this.

(cherry picked from commit 00b61d9bcb36e08aca10d72dcf0e2d00655a9527)