### PR TITLE
Holowarrants can now only be authorized by an ID with HoS access

### DIFF
--- a/code/game/objects/items/devices/holowarrant.dm
+++ b/code/game/objects/items/devices/holowarrant.dm
@@ -39,13 +39,15 @@
 /obj/item/device/holowarrant/attackby(obj/item/weapon/W, mob/user)
 	if(active)
 		var/obj/item/weapon/card/id/I = W.GetIdCard()
-		if(I)
+		if(access_hos in I.access) // VOREStation edit
 			var/choice = alert(user, "Would you like to authorize this warrant?","Warrant authorization","Yes","No")
 			if(choice == "Yes")
 				active.fields["auth"] = "[I.registered_name] - [I.assignment ? I.assignment : "(Unknown)"]"
 			user.visible_message("<span class='notice'>You swipe \the [I] through the [src].</span>", \
 					"<span class='notice'>[user] swipes \the [I] through the [src].</span>")
 			return 1
+		to_chat(user, "<span class='warning'>You don't have the access to do this!</span>") // VOREStation edit
+		return 1
 	..()
 
 //hit other people with it
@@ -108,3 +110,12 @@
 		</BODY></HTML>
 		"}
 		show_browser(user, output, "window=Search warrant for [active.fields["namewarrant"]]")
+
+/obj/item/weapon/storage/box/holowarrants // VOREStation addition starts
+	name = "holowarrant devices"
+	desc = "A box of holowarrant diplays for security use."
+
+/obj/item/weapon/storage/box/holowarrants/New() 
+	..()
+	for(var/i = 0 to 3)
+		new /obj/item/device/holowarrant(src) // VOREStation addition ends

--- a/code/modules/modular_computers/file_system/programs/security/digitalwarrant.dm
+++ b/code/modules/modular_computers/file_system/programs/security/digitalwarrant.dm
@@ -90,7 +90,7 @@ var/warrant_uid = 0
 				W.fields["auth"] = "Unauthorized"
 				W.fields["arrestsearch"] = "arrest"
 			if(temp == "search")
-				W.fields["namewarrant"] = "No location given"
+				W.fields["namewarrant"] = "No suspect/location given" // VOREStation edit
 				W.fields["charges"] = "No reason given"
 				W.fields["auth"] = "Unauthorized"
 				W.fields["arrestsearch"] = "search"
@@ -135,7 +135,9 @@ var/warrant_uid = 0
 
 	if(href_list["editwarrantauth"])
 		. = 1
-
+		if(!(access_hos in I.access)) // VOREStation edit begin
+			to_chat(user, "<span class='warning'>You don't have the access to do this!</span>")
+			return // VOREStation edit end
 		activewarrant.fields["auth"] = "[I.registered_name] - [I.assignment ? I.assignment : "(Unknown)"]"
 
 	if(href_list["back"])

--- a/maps/tether/tether-07-station3.dmm
+++ b/maps/tether/tether-07-station3.dmm
@@ -4617,6 +4617,7 @@
 	icon_state = "camera";
 	dir = 5
 	},
+/obj/item/weapon/storage/box/holowarrants,
 /turf/simulated/floor/tiled/dark,
 /area/security/security_equiptment_storage)
 "hD" = (


### PR DESCRIPTION
Denied up at Polaris, so it's brought down here.

As it stands, the 'authorize' button on holowarrants can be pressed by anyone with access to the Warrant Assistant program. This changes it to be in line with SOP, and only have HoS access. See [SOP 5.1 - Green Alert](https://wiki.vore-station.net/Standard_Operating_Procedure#Code_Green_-_All_Clear). Also maps in a box of spare holowarrants in equipment storage.