### PR TITLE
Fixes BL-3 Mecha Item Sprite

### DIFF
--- a/code/game/mecha/equipment/tools/medigun_vr.dm
+++ b/code/game/mecha/equipment/tools/medigun_vr.dm
@@ -2,7 +2,8 @@
 	equip_cooldown = 6
 	name = "\improper BL-3 \"Phoenix\" directed restoration system"
 	desc = "The BL-3 'Phoenix' is a portable medical system used to treat external injuries from afar."
-	icon_state = "mecha_medbeam"
+	icon_state = "medbeam"
+	icon = 'icons/mecha/mecha_equipment_vr.dmi'
 	energy_drain = 1000
 	projectile = /obj/item/projectile/beam/medigun
 	fire_sound = 'sound/weapons/eluger.ogg'


### PR DESCRIPTION
Such that it appears as a sprite (medbeam sprite), and not a debug invisible sprite.

Not sure if this fixes any issues stated, but I noticed this myself while adding to the wiki.