### PR TITLE
Better fix for the missing accessories on taurs

### DIFF
--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -777,14 +777,14 @@ var/global/list/damage_icon_parts = list() //see UpdateDamageIcon()
 		suit_sprite = "[INV_SUIT_DEF_ICON].dmi"
 
 	//VOREStation Edit start.
-	if(istype(wear_suit))
-		var/icon/c_mask = null
-		var/tail_is_rendered = (overlays_standing[TAIL_LAYER] || overlays_standing[TAIL_LAYER_ALT])
-		var/valid_clip_mask = (tail_style && tail_style.clip_mask_icon && tail_style.clip_mask_state)
+	var/icon/c_mask = null
+	var/tail_is_rendered = (overlays_standing[TAIL_LAYER] || overlays_standing[TAIL_LAYER_ALT])
+	var/valid_clip_mask = (tail_style && tail_style.clip_mask_icon && tail_style.clip_mask_state)
 
-		if(tail_is_rendered && valid_clip_mask && !(suit && suit.taurized)) //Clip the lower half of the suit off using the tail's clip mask for taurs since taur bodies aren't hidden.
-			c_mask = new /icon(tail_style.clip_mask_icon, tail_style.clip_mask_state)
-		overlays_standing[SUIT_LAYER] = wear_suit.make_worn_icon(body_type = species.get_bodytype(src), slot_name = slot_wear_suit_str, default_icon = suit_sprite, default_layer = SUIT_LAYER, clip_mask = c_mask)
+	if(!(istype(suit)) || (tail_is_rendered && valid_clip_mask && !(suit && suit.taurized))) //Clip the lower half of the suit off using the tail's clip mask for taurs since taur bodies aren't hidden.
+		c_mask = new /icon(tail_style.clip_mask_icon, tail_style.clip_mask_state)
+	overlays_standing[SUIT_LAYER] = wear_suit.make_worn_icon(body_type = species.get_bodytype(src), slot_name = slot_wear_suit_str, default_icon = suit_sprite, default_layer = SUIT_LAYER, clip_mask = c_mask)
+
 	//VOREStation Edit end.
 
 	apply_layer(SUIT_LAYER)


### PR DESCRIPTION
Previous one did fix the runtime... But aparently cloak sprites were still missing. Here is actual solution. Whoops.