### PR TITLE
Fixes free clothing dispenser only handing shoes for money

### DIFF
--- a/code/game/machinery/vending_vr.dm
+++ b/code/game/machinery/vending_vr.dm
@@ -300,6 +300,7 @@
 					/obj/item/clothing/under/color/yellow = 5,
 					/obj/item/clothing/shoes/black = 20,
 					/obj/item/clothing/shoes/white = 20)
+	prices = list()
 
 /obj/machinery/vending/loadout/accessory
 	name = "Looty Inc."


### PR DESCRIPTION
The Basics sold shoes when eveything in it was supposed to be free. This is why inheiritance is an unstable road.