### PR TITLE
Disable bicon() icon object cache, and create text tag cache

### DIFF
--- a/code/_helpers/text.dm
+++ b/code/_helpers/text.dm
@@ -301,12 +301,15 @@ proc/TextPreview(var/string,var/len=40)
 //For generating neat chat tag-images
 //The icon var could be local in the proc, but it's a waste of resources
 //	to always create it and then throw it out.
-/var/icon/text_tag_icons = new('./icons/chattags.dmi')
+/var/icon/text_tag_icons = 'icons/chattags.dmi'
+/var/list/text_tag_cache = list()
 /proc/create_text_tag(var/tagname, var/tagdesc = tagname, var/client/C = null)
 	if(!(C && C.is_preference_enabled(/datum/client_preference/chat_tags)))
 		return tagdesc
-	var/icon/tag = icon(text_tag_icons.icon, tagname)
-	return bicon(tag,TRUE,"text_tag") //"<IMG src='\ref[text_tag_icons.icon]' class='text_tag' iconstate='[tagname]'" + (tagdesc ? " alt='[tagdesc]'" : "") + ">"
+	if(!text_tag_cache[tagname])
+		var/icon/tag = icon(text_tag_icons, tagname)
+		text_tag_cache[tagname] = bicon(tag, TRUE, "text_tag")
+	return text_tag_cache[tagname]
 
 /proc/contains_az09(var/input)
 	for(var/i=1, i<=length(input), i++)

--- a/code/modules/vchat/vchat_client.dm
+++ b/code/modules/vchat/vchat_client.dm
@@ -244,10 +244,11 @@ GLOBAL_DATUM_INIT(iconCache, /savefile, new("data/iconCache.sav")) //Cache of ic
 
 	var/static/list/bicon_cache = list()
 	if (isicon(obj))
-		if (!bicon_cache["\ref[obj]"]) // Doesn't exist yet, make it.
-			bicon_cache["\ref[obj]"] = icon2base64(obj)
+		//Icon refs get reused all the time especially on temporarily made ones like chat tags, too difficult to cache.
+		//if (!bicon_cache["\ref[obj]"]) // Doesn't exist yet, make it.
+			//bicon_cache["\ref[obj]"] = icon2base64(obj)
 
-		return "<img [class] src='data:image/png;base64,[bicon_cache["\ref[obj]"]]'>"
+		return "<img [class] src='data:image/png;base64,[icon2base64(obj)]'>"
 
 	// Either an atom or somebody fucked up and is gonna get a runtime, which I'm fine with.
 	var/atom/A = obj


### PR DESCRIPTION
Probably fixes 'wrong' chat tags showing up