### PR TITLE
Removes _vr only sofa definitions

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest/chairs_vr.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs_vr.dm
@@ -1,24 +1,3 @@
-/obj/structure/bed/chair/sofa
-	name = "sofa"
-	desc = "A padded, comfy sofa. Great for lazing on."
-	base_icon = "sofamiddle"
-
-/obj/structure/bed/chair/sofa/left
-	base_icon = "sofaend_left"
-
-/obj/structure/bed/chair/sofa/right
-	base_icon = "sofaend_right"
-
-/obj/structure/bed/chair/sofa/corner
-	base_icon = "sofacorner"
-
-/obj/structure/bed/chair/sofa/corner/update_layer()
-	if(src.dir == NORTH || src.dir == WEST)
-		plane = MOB_PLANE
-		layer = MOB_LAYER + 0.1
-	else
-		reset_plane_and_layer()
-
 /obj/structure/bed/chair/modern_chair
 	name = "modern chair"
 	desc = "It's like sitting in an egg."


### PR DESCRIPTION
I am pretty sure it was already done but somehow got reverted. We don't need _vr only sofas, they exist upstream now.