### PR TITLE
Extends Tempest's hypo and glasses whitelists to Off-duty Medic

### DIFF
--- a/code/modules/client/preference_setup/loadout/loadout_fluffitems_vr.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_fluffitems_vr.dm
@@ -918,7 +918,7 @@
 	display_name = "Tempest's Medical Hud"
 	ckeywhitelist = list("wickedtemp")
 	character_name = list("Chakat Tempest Venosare")
-	allowed_roles = list("Chief Medical Officer","Medical Doctor","Chemist","Psychiatrist","Paramedic", "Field Medic")
+	allowed_roles = list("Chief Medical Officer","Medical Doctor","Chemist","Psychiatrist","Paramedic", "Field Medic", "Off-duty Medic")
 	slot = slot_glasses
 
 /datum/gear/fluff/tempest_hypospray
@@ -926,7 +926,7 @@
 	display_name = "Tempest's Hypospray"
 	ckeywhitelist = list("wickedtemp")
 	character_name = list("Chakat Tempest Venosare")
-	allowed_roles = list("Chief Medical Officer","Medical Doctor","Chemist","Psychiatrist","Paramedic", "Field Medic")
+	allowed_roles = list("Chief Medical Officer","Medical Doctor","Chemist","Psychiatrist","Paramedic", "Field Medic", "Off-duty Medic")
 	slot = slot_belt
 
 /datum/gear/fluff/tempest_backpack


### PR DESCRIPTION
As long as I typed it correctly, I just copied how its spelled from the manifest. I couldn't really test this on a private server because of a lack of PTO I think, because even as a Host ranking in the config, while I could join as CC Officer and Mimes, I couldn't join as anything off-duty, so... If it works, it works, and if it doesn't, I'll just try another spelling or something.