### PR TITLE
[Map] Remove Docking Controller

### DIFF
--- a/maps/tether/tether-07-station3.dmm
+++ b/maps/tether/tether-07-station3.dmm
@@ -29445,11 +29445,12 @@
 /turf/simulated/shuttle/floor/yellow/airless,
 /area/shuttle/belter/station)
 "Vb" = (
-/obj/machinery/embedded_controller/radio/airlock/docking_port{
-	id_tag = "belter_docking";
-	pixel_y = 26
+/obj/structure/shuttle/engine/propulsion{
+	dir = 8;
+	icon_state = "propulsion_l"
 	},
-/turf/simulated/shuttle/floor/yellow/airless,
+/turf/simulated/floor/tiled/asteroid_steel/airless,
+/turf/simulated/shuttle/plating/airless/carry,
 /area/shuttle/belter/station)
 "Vc" = (
 /turf/simulated/shuttle/floor/yellow/airless,
@@ -29645,15 +29646,15 @@
 /area/shuttle/belter/station)
 "Vy" = (
 /obj/structure/shuttle/engine/propulsion{
-	dir = 8;
-	icon_state = "propulsion_l"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/asteroid_steel/airless,
 /turf/simulated/shuttle/plating/airless/carry,
 /area/shuttle/belter/station)
 "Vz" = (
 /obj/structure/shuttle/engine/propulsion{
-	dir = 8
+	dir = 8;
+	icon_state = "propulsion_r"
 	},
 /turf/simulated/floor/tiled/asteroid_steel/airless,
 /turf/simulated/shuttle/plating/airless/carry,
@@ -29767,22 +29768,22 @@
 "VN" = (
 /obj/structure/shuttle/engine/propulsion{
 	dir = 8;
-	icon_state = "propulsion_r"
+	icon_state = "propulsion_l"
 	},
-/turf/simulated/floor/tiled/asteroid_steel/airless,
+/turf/space,
 /turf/simulated/shuttle/plating/airless/carry,
-/area/shuttle/belter/station)
+/area/shuttle/large_escape_pod1/station)
 "VO" = (
 /obj/structure/shuttle/engine/propulsion{
-	dir = 8;
-	icon_state = "propulsion_l"
+	dir = 8
 	},
 /turf/space,
 /turf/simulated/shuttle/plating/airless/carry,
 /area/shuttle/large_escape_pod1/station)
 "VP" = (
 /obj/structure/shuttle/engine/propulsion{
-	dir = 8
+	dir = 8;
+	icon_state = "propulsion_r"
 	},
 /turf/space,
 /turf/simulated/shuttle/plating/airless/carry,
@@ -29800,14 +29801,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/shuttle/excursion/tether)
-"VS" = (
-/obj/structure/shuttle/engine/propulsion{
-	dir = 8;
-	icon_state = "propulsion_r"
-	},
-/turf/space,
-/turf/simulated/shuttle/plating/airless/carry,
-/area/shuttle/large_escape_pod1/station)
 "VU" = (
 /obj/machinery/firealarm{
 	dir = 2;
@@ -40195,11 +40188,11 @@ MK
 Iy
 ab
 NL
+VN
+VO
+VO
 VO
 VP
-VP
-VP
-VS
 NL
 vt
 vt
@@ -44308,11 +44301,11 @@ Ty
 TL
 QG
 Ue
+Vb
+Vy
+Vy
 Vy
 Vz
-Vz
-Vz
-VN
 VH
 vt
 vt
@@ -44735,7 +44728,7 @@ TB
 TB
 Ue
 UF
-Vb
+Vc
 Vc
 Vc
 UF


### PR DESCRIPTION
Title. It's in a vacuum, anyway. And will always be in a vacuum so the lack of sensors mapped in made it display an errorneous air reading.

Changelog Notes:

- Removes the docking controller for the belt miner shuttle.