### PR TITLE
Buffs ERT Backpack

### DIFF
--- a/code/game/objects/items/weapons/storage/backpack_vr.dm
+++ b/code/game/objects/items/weapons/storage/backpack_vr.dm
@@ -134,3 +134,6 @@
 	sprite_sheets = list(
 		SPECIES_TESHARI = 'icons/mob/species/seromi/back.dmi',
 		SPECIES_WEREBEAST = 'icons/mob/species/werebeast/back.dmi')
+
+/obj/item/weapon/storage/backpack/ert
+	max_storage_space = INVENTORY_DUFFLEBAG_SPACE


### PR DESCRIPTION
I always thought it strange that the ERT had both their own backpacks, and access to the unquestionably superior Syndicate dufflebags.

This buffs the ERT Backpack to be on par with the syndicate dufflebag. Long term plan is to remove the Syndicate dufflebags from the ERT Armory, but that cannot be done yet due to the mapping freeze.