### PR TITLE
Fixes _vr only job things

### DIFF
--- a/code/game/jobs/job/assistant_vr.dm
+++ b/code/game/jobs/job/assistant_vr.dm
@@ -1,3 +1,7 @@
+//////////////////////////////////
+//		Intern
+//////////////////////////////////
+
 /datum/job/intern
 	title = "Intern"
 	flag = INTERN
@@ -12,8 +16,66 @@
 	access = list()			//See /datum/job/intern/get_access()
 	minimal_access = list()	//See /datum/job/intern/get_access()
 	outfit_type = /decl/hierarchy/outfit/job/assistant/intern
-	alt_titles = list("Apprentice Engineer","Medical Intern","Lab Assistant","Security Cadet","Jr. Cargo Tech", "Jr. Explorer", "Server" = /decl/hierarchy/outfit/job/service/server)
+	alt_titles = list("Intern" = /datum/alt_title/intern,
+					  "Apprentice Engineer" = /datum/alt_title/intern_eng,
+					  "Medical Intern" = /datum/alt_title/intern_med,
+					  "Lab Assistant" = /datum/alt_title/intern_sci,
+					  "Security Cadet" = /datum/alt_title/intern_sec,
+					  "Jr. Cargo Tech" = /datum/alt_title/intern_crg,
+					  "Jr. Explorer" = /datum/alt_title/intern_exp,
+					  "Server" = /datum/alt_title/server)
+	job_description = "An Intern does whatever is requested of them, often doing so in process of learning \
+						another job. Though they are part of the crew, they have no real authority."
 	timeoff_factor = 0 // Interns, noh
+
+/datum/alt_title/intern
+	title = "Intern"
+
+/datum/alt_title/intern_eng
+	title = "Apprentice Engineer"
+	title_blurb = "An Apprentice Engineer attempts to provide whatever the Engineering department needs. They are not proper Engineers, and are \
+					often in training to become an Engineer. A Technical Assistant has no real authority."
+	title_outfit = /decl/hierarchy/outfit/job/assistant/engineer
+
+/datum/alt_title/intern_med
+	title = "Medical Intern"
+	title_blurb = "A Medical Intern attempts to provide whatever the Medical department needs. They are not proper Doctors, and are \
+					often in training to become a Doctor. A Medical Intern has no real authority."
+	title_outfit = /decl/hierarchy/outfit/job/assistant/medic
+
+/datum/alt_title/intern_sci
+	title = "Lab Assistant"
+	title_blurb = "A Lab Assistant attempts to provide whatever the Research department needs. They are not proper Scientists, and are \
+					often in training to become a Scientist. A Lab Assistant has no real authority."
+	title_outfit = /decl/hierarchy/outfit/job/assistant/scientist
+
+/datum/alt_title/intern_sec
+	title = "Security Cadet"
+	title_blurb = "A Security Cadet attempts to provide whatever the Security department needs. They are not proper Officers, and are \
+					often in training to become an Officer. A Security Cadet has no real authority."
+	title_outfit = /decl/hierarchy/outfit/job/assistant/officer
+
+/datum/alt_title/intern_crg
+	title = "Jr. Cargo Tech"
+	title_blurb = "A Jr. Cargo Tech attempts to provide whatever the Cargo department needs. They are not proper Cargo Technicians, and are \
+					often in training to become a Cargo Technician. A Jr. Cargo Tech has no real authority."
+	title_outfit = /decl/hierarchy/outfit/job/assistant/cargo
+
+/datum/alt_title/intern_exp
+	title = "Jr. Explorer"
+	title_blurb = "A Jr. Explorer attempts to provide whatever the Exploration department needs. They are not proper Explorers, and are \
+					often in training to become an Explorer. A Jr. Explorer has no real authority."
+	title_outfit = /decl/hierarchy/outfit/job/assistant/explorer
+
+/datum/alt_title/server
+	title = "Server"
+	title_blurb = "A Server helps out kitchen and diner staff with various tasks, primarily food delivery. A Server has no real authority."
+	title_outfit = /decl/hierarchy/outfit/job/service/server
+
+
+//////////////////////////////////
+//		Visitor
+//////////////////////////////////
 
 /datum/job/intern/New()
 	..()
@@ -30,6 +92,7 @@
 /datum/job/assistant		// Visitor
 	title = USELESS_JOB
 	supervisors = "nobody! You don't work here"
+	job_description = "A Visitor is just there to visit the place. They have no real authority or responsibility."
 	timeoff_factor = 0
 
 /datum/job/assistant/New()

--- a/code/game/jobs/job/captain_vr.dm
+++ b/code/game/jobs/job/captain_vr.dm
@@ -4,7 +4,9 @@
 /datum/job/hop
 
 	disallow_jobhop = TRUE
-	alt_titles = list("Deputy Director", "Crew Resources Officer")
+	alt_titles = list("Head of Personnel" = /datum/alt_title/hop,
+					  "Crew Resources Officer" = /datum/alt_title/cro,
+					  "Deputy Director" = /datum/alt_title/deputy_director)
 
 	access = list(access_security, access_sec_doors, access_brig, access_forensics_lockers,
 			            access_medical, access_engine, access_change_ids, access_ai_upload, access_eva, access_heads,
@@ -18,6 +20,9 @@
 			            access_crematorium, access_kitchen, access_cargo, access_cargo_bot, access_mailsorting, access_qm, access_hydroponics, access_lawyer,
 			            access_chapel_office, access_library, access_research, access_mining, access_heads_vault, access_mining_station,
 			            access_hop, access_RC_announce, access_keycard_auth)
+
+/datum/alt_title/deputy_director
+	title = "Deputy Director"
 
 /datum/job/secretary
 	disallow_jobhop = TRUE

--- a/code/game/jobs/job/civilian_vr.dm
+++ b/code/game/jobs/job/civilian_vr.dm
@@ -16,13 +16,26 @@
 /datum/job/janitor //Lots of janitor substations on station.
 	total_positions = 3
 	spawn_positions = 3
-	alt_titles = list("Custodian", "Sanitation Technician", "Maid")
+	alt_titles = list("Janitor" = /datum/alt_title/janitor,
+					  "Custodian" = /datum/alt_title/custodian,
+					  "Sanitation Technician" = /datum/alt_title/sanitation_tech,
+					  "Maid" = /datum/alt_title/maid)
+
+/datum/alt_title/sanitation_tech
+	title = "Sanitation Technician"
+
+/datum/alt_title/maid
+	title = "Maid"
 
 //TFF 5/9/19 - restore librarian job slot to 2
 /datum/job/librarian
 	total_positions = 2
 	spawn_positions = 2
-	alt_titles = list("Journalist", "Historian", "Writer")
+	alt_titles = list("Librarian" = /datum/alt_title/librarian, "Journalist" = /datum/alt_title/journalist, "Writer" = /datum/alt_title/writer, "Historian" = /datum/alt_title/historian)
+
+/datum/alt_title/historian
+	title = "Historian"
+	title_blurb = "The Historian uses the Library as a base of operation to record any important events occuring on station."
 
 /datum/job/lawyer
 	disallow_jobhop = TRUE

--- a/code/game/jobs/job/offduty_vr.dm
+++ b/code/game/jobs/job/offduty_vr.dm
@@ -14,6 +14,10 @@
 	access = list(access_maint_tunnels)
 	minimal_access = list(access_maint_tunnels)
 	outfit_type = /decl/hierarchy/outfit/job/assistant/worker
+	job_description = "Off-duty crew has no responsibilities or authority and is just there to spend their well-deserved time off."
+
+/datum/alt_title/offduty_civ
+	title = "Off-duty Worker"
 
 /datum/job/offduty_cargo
 	title = "Off-duty Cargo"
@@ -27,6 +31,10 @@
 	access = list(access_maint_tunnels)
 	minimal_access = list(access_maint_tunnels)
 	outfit_type = /decl/hierarchy/outfit/job/assistant/cargo
+	job_description = "Off-duty crew has no responsibilities or authority and is just there to spend their well-deserved time off."
+
+/datum/alt_title/offduty_crg
+	title = "Off-duty Cargo"
 
 /datum/job/offduty_engineering
 	title = "Off-duty Engineer"
@@ -40,6 +48,10 @@
 	access = list(access_maint_tunnels, access_external_airlocks, access_construction)
 	minimal_access = list(access_maint_tunnels, access_external_airlocks)
 	outfit_type = /decl/hierarchy/outfit/job/assistant/engineer
+	job_description = "Off-duty crew has no responsibilities or authority and is just there to spend their well-deserved time off."
+
+/datum/alt_title/offduty_eng
+	title = "Off-duty Engineer"
 
 /datum/job/offduty_medical
 	title = "Off-duty Medic"
@@ -53,6 +65,10 @@
 	access = list(access_maint_tunnels, access_external_airlocks)
 	minimal_access = list(access_maint_tunnels, access_external_airlocks)
 	outfit_type = /decl/hierarchy/outfit/job/assistant/medic
+	job_description = "Off-duty crew has no responsibilities or authority and is just there to spend their well-deserved time off."
+
+/datum/alt_title/offduty_med
+	title = "Off-duty Medic"
 
 /datum/job/offduty_science
 	title = "Off-duty Scientist"
@@ -66,6 +82,10 @@
 	access = list(access_maint_tunnels)
 	minimal_access = list(access_maint_tunnels)
 	outfit_type = /decl/hierarchy/outfit/job/assistant/scientist
+	job_description = "Off-duty crew has no responsibilities or authority and is just there to spend their well-deserved time off."
+
+/datum/alt_title/offduty_sci
+	title = "Off-duty Scientist"
 
 /datum/job/offduty_security
 	title = "Off-duty Officer"
@@ -79,3 +99,7 @@
 	access = list(access_maint_tunnels)
 	minimal_access = list(access_maint_tunnels)
 	outfit_type = /decl/hierarchy/outfit/job/assistant/officer
+	job_description = "Off-duty crew has no responsibilities or authority and is just there to spend their well-deserved time off."
+
+/datum/alt_title/offduty_sec
+	title = "Off-duty Officer"

--- a/code/game/jobs/job/science_vr.dm
+++ b/code/game/jobs/job/science_vr.dm
@@ -12,7 +12,13 @@
 
 /datum/job/scientist
 	spawn_positions = 5
-	alt_titles = list("Xenoarcheologist", "Anomalist", "Phoron Researcher", "Circuit Designer")
+	alt_titles = list("Scientist" = /datum/alt_title/scientist, "Xenoarchaeologist" = /datum/alt_title/xenoarch, "Anomalist" = /datum/alt_title/anomalist, \
+						"Phoron Researcher" = /datum/alt_title/phoron_research, "Circuit Designer" = /datum/alt_title/circuit_designer)
+
+/datum/alt_title/circuit_designer
+	title = "Circuit Designer"
+	title_blurb = "A Circuit Designer is a Scientist whose expertise is working with integrated circuits. They are familar with the workings and programming of those devices. \
+				   They work to create various useful devices using the capabilities of integrated circuitry."
 
 /datum/job/xenobiologist
 	spawn_positions = 3

--- a/code/game/jobs/job/special_vr.dm
+++ b/code/game/jobs/job/special_vr.dm
@@ -14,6 +14,7 @@
 	whitelist_only = 1
 	latejoin_only = 1
 	outfit_type = /decl/hierarchy/outfit/job/centcom_officer
+	job_description = "A Central Command Officer is there on official business. Most of time. Whatever it is, they're a VIP."
 
 	minimum_character_age = 25
 	ideal_character_age = 40

--- a/code/game/jobs/job/special_vr.dm
+++ b/code/game/jobs/job/special_vr.dm
@@ -76,10 +76,20 @@
 	economic_modifier = 1
 	access = list()
 	minimal_access = list()
-	alt_titles = list("Comedian","Jester")
+	job_description = "A Clown is there to entertain the crew and keep high morale using various harmless pranks and ridiculous jokes!"
+	alt_titles = list("Clown" = /datum/alt_title/clown, "Comedian" = /datum/alt_title/comedian, "Jester" = /datum/alt_title/jester)
 	whitelist_only = 1
 	latejoin_only = 1
 	outfit_type = /decl/hierarchy/outfit/job/clown
+
+/datum/alt_title/clown
+	title = "Clown"
+
+/datum/alt_title/comedian
+	title = "Comedian"
+
+/datum/alt_title/jester
+	title = "Jester"
 
 /datum/job/clown/get_access()
 	if(config.assistant_maint)
@@ -100,10 +110,20 @@
 	economic_modifier = 1
 	access = list()
 	minimal_access = list()
-	alt_titles = list("Performer","Interpretive Dancer")
+	job_description = "A Mime is there to entertain the crew and keep high morale using unbelievable performances and acting skills!"
+	alt_titles = list("Mime" = /datum/alt_title/mime, "Performer" = /datum/alt_title/performer, "Interpretive Dancer" = /datum/alt_title/interpretive_dancer)
 	whitelist_only = 1
 	latejoin_only = 1
 	outfit_type = /decl/hierarchy/outfit/job/mime
+
+/datum/alt_title/mime
+	title = "Mime"
+
+/datum/alt_title/performer
+	title = "Performer"
+
+/datum/alt_title/interpretive_dancer
+	title = "Interpretive Dancer"
 
 /datum/job/mime/get_access()
 	if(config.assistant_maint)

--- a/maps/southern_cross/southern_cross_jobs_vr.dm
+++ b/maps/southern_cross/southern_cross_jobs_vr.dm
@@ -49,6 +49,9 @@ var/const/SAR 				=(1<<14)
 	outfit_type = /decl/hierarchy/outfit/job/pathfinder
 	job_description = "	The Pathfinder's job is to lead and manage expeditions, and is the primary authority on all off-station expeditions."
 
+/datum/alt_title/pathfinder
+	title = "Pathfinder"
+
 /datum/job/pilot
 	title = "Pilot"
 	flag = PILOT
@@ -66,6 +69,9 @@ var/const/SAR 				=(1<<14)
 	outfit_type = /decl/hierarchy/outfit/job/pilot
 	job_description = "A Pilot flies the various shuttles in the Virgo-Erigone System."
 
+/datum/alt_title/pilot
+	title = "Pilot"
+
 /datum/job/explorer
 	title = "Explorer"
 	flag = EXPLORER
@@ -82,6 +88,9 @@ var/const/SAR 				=(1<<14)
 	outfit_type = /decl/hierarchy/outfit/job/explorer2
 	job_description = "An Explorer searches for interesting things, and returns them to the station."
 
+/datum/alt_title/explorer
+	title = "Explorer"
+
 /datum/job/sar
 	title = "Field Medic"
 	flag = SAR
@@ -97,7 +106,10 @@ var/const/SAR 				=(1<<14)
 	access = list(access_medical, access_medical_equip, access_morgue, access_surgery, access_chemistry, access_eva, access_maint_tunnels, access_external_airlocks, access_pilot)
 	minimal_access = list(access_medical, access_medical_equip, access_morgue, access_pilot)
 	outfit_type = /decl/hierarchy/outfit/job/medical/sar
-	job_description = "A Field medic works as the field doctor of expedition teams." 
+	job_description = "A Field medic works as the field doctor of expedition teams."
+
+/datum/alt_title/field_medic
+	title = "Field Medic"
 
 /datum/job/offduty_exploration
 	title = "Off-duty Explorer"
@@ -111,3 +123,7 @@ var/const/SAR 				=(1<<14)
 	access = list(access_maint_tunnels, access_external_airlocks)
 	minimal_access = list(access_maint_tunnels, access_external_airlocks)
 	outfit_type = /decl/hierarchy/outfit/job/assistant/explorer
+	job_description = "Off-duty crew has no responsibilities or authority and is just there to spend their well-deserved time off."
+
+/datum/alt_title/offduty_exp
+	title = "Off-duty Explorer"


### PR DESCRIPTION
Fixes alt-titles not functioning for: Interns, Scientists, Janitors, Librarians, HoPs, Clowns and Mimes

Added descriptions for: Circuit Designer, Historian and all Intern alt-titles

Fixed without adding description: Maid, Sanitation Technician, Deputy Director, Clown and Mime alt-titles

Added general job descriptions for: Clowns, Mimes, Visitors, Off-duty jobs, CCO (last one mostly jokey)

Also makes use of 'departmental assistant' outfits for Intern alt-titles