### PR TITLE
Fixes Science being renamed to Research breaking PTO

### DIFF
--- a/code/controllers/subsystems/persist_vr.dm
+++ b/code/controllers/subsystems/persist_vr.dm
@@ -93,3 +93,7 @@ SUBSYSTEM_DEF(persist)
 	if(C.department_hours[DEPARTMENT_COMMAND])
 		C.department_hours[DEPARTMENT_COMMAND] = null
 		C.department_hours.Remove(DEPARTMENT_COMMAND)
+	if(C.department_hours["Science"])
+		C.department_hours[DEPARTMENT_RESEARCH] = C.department_hours["Science"]
+		C.department_hours["Science"] = null
+		C.department_hours.Remove("Science")


### PR DESCRIPTION
New addition to PTO sanitization proc, now transfers all old "Science" PTO to new "Research" PTO.