### PR TITLE
Fix refueling into fuelports

### DIFF
--- a/code/modules/overmap/overmap_shuttle.dm
+++ b/code/modules/overmap/overmap_shuttle.dm
@@ -172,6 +172,7 @@
 			return
 		if(contents.len == 0)
 			user.unEquip(W, src)
+			W.forceMove(src)
 	update_icon()
 
 // Walls hide stuff inside them, but we want to be visible.


### PR DESCRIPTION
They still work from roundstart cus they have fuel in them. Just can't refuel without asking an admin to move a fuel tank into contents.