### PR TITLE
Fix hook "failing" when no file

### DIFF
--- a/code/modules/media/media_tracks.dm
+++ b/code/modules/media/media_tracks.dm
@@ -38,7 +38,7 @@ var/global/list/all_lobby_tracks = list()
 	var/jukebox_track_file = "config/jukebox.json"
 	if(!fexists(jukebox_track_file))
 		warning("File not found: [jukebox_track_file]")
-		return
+		return 1
 	var/list/jsonData = json_decode(file2text(jukebox_track_file))
 	if(!istype(jsonData))
 		warning("Failed to read tracks from [jukebox_track_file], json_decode failed.")


### PR DESCRIPTION
It hasn't failed, really. And it prints another warning anyway.