### PR TITLE
Add github actions

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,7 @@
+# Map changes
+"Type: Map":
+  - maps/**/*
+
+# Icon Changes
+"Type: Icon":
+  - icons/**/*

--- a/.github/workflows/label.yaml
+++ b/.github/workflows/label.yaml
@@ -1,0 +1,13 @@
+
+name: Label PRs based on files changed
+on: [pull_request]
+
+jobs:
+  label:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/labeler@v2 # See: https://github.com/actions/labeler
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -1,0 +1,19 @@
+name: Mark and close stale issues
+
+on:
+  schedule:
+  - cron: "0 0 * * *"
+
+jobs:
+  stale:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/stale@v1 # See: https://github.com/actions/stale
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-message: "This issue has been open for over a year with no activity. If it receives no updates within 30 days, it will be closed."
+        stale-issue-label: "Status: No Response"
+        days-before-stale: 365
+        days-before-close: 30


### PR DESCRIPTION
Labeler: Autolabels PRs with "Type: Map" or "Type: Icon" if files in the maps or icons folder are changed, respectively.

Stale: Warns on issues older than 365 days that they will be closed unless updated within 30 days. If nobody has fixed after 365 days, it's probably either not an issue anymore, or nobody cares so there's no point in leaving it.