### PR TITLE
Scale Skybox by client view size

### DIFF
--- a/code/__defines/misc.dm
+++ b/code/__defines/misc.dm
@@ -268,6 +268,7 @@
 
 #define WORLD_ICON_SIZE 32 //Needed for the R-UST port
 #define PIXEL_MULTIPLIER WORLD_ICON_SIZE/32 //Needed for the R-UST port
+#define MAX_CLIENT_VIEW	34  // Maximum effective value of client.view (According to DM references)
 
 // Maploader bounds indices
 #define MAP_MINX 1

--- a/code/_onclick/hud/skybox.dm
+++ b/code/_onclick/hud/skybox.dm
@@ -1,12 +1,26 @@
+#define SKYBOX_PADDING	4	// How much larger we want the skybox image to be than client's screen (in turfs)
+#define SKYBOX_PIXELS	736	// Size of skybox image in pixels
+#define SKYBOX_TURFS	(SKYBOX_PIXELS/WORLD_ICON_SIZE)
+
 // Skybox screen object.
 /obj/skybox
 	name = "skybox"
 	mouse_opacity = 0
 	anchored = TRUE
 	simulated = FALSE
-	screen_loc = "CENTER:-352,CENTER:-352" // (736/2 - 32/2)
+	screen_loc = "CENTER,CENTER"
 	plane = SKYBOX_PLANE
 	blend_mode = BLEND_MULTIPLY // You actually need to do it this way or you see it in occlusion.
+
+// Adjust transform property to scale for client's view var. We assume the skybox is 736x736 px
+/obj/skybox/proc/scale_to_view(var/view)
+	var/matrix/M = matrix()
+	// Translate to center the icon over us!
+	M.Translate(-(SKYBOX_PIXELS - WORLD_ICON_SIZE) / 2)
+	// Scale appropriately based on view size.  (7 results in scale of 1)
+	view = text2num(view) || 7 // Sanitize
+	M.Scale(((min(MAX_CLIENT_VIEW, view) + SKYBOX_PADDING) * 2 + 1) / SKYBOX_TURFS)
+	src.transform = M
 
 /client
 	var/obj/skybox/skybox
@@ -14,6 +28,7 @@
 /client/proc/update_skybox(rebuild)
 	if(!skybox)
 		skybox = new()
+		skybox.scale_to_view(src.view)
 		screen += skybox
 		rebuild = 1
 
@@ -23,7 +38,7 @@
 			skybox.cut_overlays()
 			skybox.add_overlay(SSskybox.get_skybox(T.z))
 			screen |= skybox
-		skybox.screen_loc = "CENTER:[-352 + (world.maxx>>1) - T.x],CENTER:[-352 + (world.maxy>>1) - T.y]"
+		skybox.screen_loc = "CENTER:[(world.maxx>>1) - T.x],CENTER:[(world.maxy>>1) - T.y]"
 
 /mob/Login()
 	. = ..()
@@ -40,3 +55,13 @@
 	. = ..()
 	if(. && client)
 		client.update_skybox(old_z != get_z(src))
+
+/mob/set_viewsize()
+	. = ..()
+	if (. && client)
+		client.update_skybox()
+		client.skybox?.scale_to_view(client.view)
+
+#undef SKYBOX_BORDER
+#undef SKYBOX_PIXELS
+#undef SKYBOX_TURFS

--- a/code/game/mecha/combat/gorilla.dm
+++ b/code/game/mecha/combat/gorilla.dm
@@ -178,10 +178,10 @@
 		src.log_message("Toggled zoom mode.")
 		src.occupant_message("<font color='[src.zoom?"blue":"red"]'>Zoom mode [zoom?"en":"dis"]abled.</font>")
 		if(zoom)
-			src.occupant.client.view = 12
+			src.occupant.set_viewsize(12)
 			playsound(src.occupant, 'sound/mecha/imag_enh.ogg',50)
 		else
-			src.occupant.client.view = world.view//world.view - default mob view size
+			src.occupant.set_viewsize() // Reset to default
 	return
 
 

--- a/code/game/mecha/combat/marauder.dm
+++ b/code/game/mecha/combat/marauder.dm
@@ -180,10 +180,10 @@
 		src.log_message("Toggled zoom mode.")
 		src.occupant_message("<font color='[src.zoom?"blue":"red"]'>Zoom mode [zoom?"en":"dis"]abled.</font>")
 		if(zoom)
-			src.occupant.client.view = 12
+			src.occupant.set_viewsize(12)
 			src.occupant << sound('sound/mecha/imag_enh.ogg',volume=50)
 		else
-			src.occupant.client.view = world.view//world.view - default mob view size
+			src.occupant.set_viewsize() // Reset to default
 	return
 
 

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -654,7 +654,7 @@ modules/mob/living/carbon/human/life.dm if you die, you will be zoomed out.
 	if(!zoom && !cannotzoom)
 		if(H.hud_used.hud_shown)
 			H.toggle_zoom_hud()	// If the user has already limited their HUD this avoids them having a HUD when they zoom in
-		H.client.view = viewsize
+		H.set_viewsize(viewsize)
 		zoom = 1
 
 		var/tilesize = 32
@@ -679,7 +679,7 @@ modules/mob/living/carbon/human/life.dm if you die, you will be zoomed out.
 		H.handle_vision()
 
 	else
-		H.client.view = world.view
+		H.set_viewsize() // Reset to default
 		if(!H.hud_used.hud_shown)
 			H.toggle_zoom_hud()
 		zoom = 0

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -837,10 +837,12 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	if(!holder)
 		return
 
+	var/view = src.view
 	if(view == world.view)
 		view = input("Select view range:", "FUCK YE", 7) in list(1,2,3,4,5,6,7,8,9,10,11,12,13,14,128)
 	else
 		view = world.view
+	mob.set_viewsize(view)
 
 	log_admin("[key_name(usr)] changed their view range to [view].")
 	//message_admins("<font color='blue'>[key_name_admin(usr)] changed their view range to [view].</font>", 1)	//why? removed by order of XSI

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1063,6 +1063,13 @@ mob/proc/yank_out_object()
 /mob/proc/setEarDamage()
 	return
 
+// Set client view distance (size of client's screen). Returns TRUE if anything changed.
+/mob/proc/set_viewsize(var/new_view = world.view)
+	if (client && new_view != client.view)
+		client.view = new_view
+		return TRUE
+	return FALSE
+
 //Throwing stuff
 
 /mob/proc/toggle_throw_mode()

--- a/code/modules/overmap/ships/computers/ship.dm
+++ b/code/modules/overmap/ships/computers/ship.dm
@@ -56,16 +56,14 @@ somewhere on that shuttle. Subtypes of these can be then used to perform ship ov
 /obj/machinery/computer/ship/proc/look(var/mob/user)
 	if(linked)
 		user.reset_view(linked)
-	if(user.client)
-		user.client.view = world.view + extra_view
+	user.set_viewsize(world.view + extra_view)
 	GLOB.moved_event.register(user, src, /obj/machinery/computer/ship/proc/unlook)
 	// TODO GLOB.stat_set_event.register(user, src, /obj/machinery/computer/ship/proc/unlook)
 	LAZYDISTINCTADD(viewers, weakref(user))
 
 /obj/machinery/computer/ship/proc/unlook(var/mob/user)
 	user.reset_view()
-	if(user.client)
-		user.client.view = world.view
+	user.set_viewsize() // reset to default
 	GLOB.moved_event.unregister(user, src, /obj/machinery/computer/ship/proc/unlook)
 	// TODO GLOB.stat_set_event.unregister(user, src, /obj/machinery/computer/ship/proc/unlook)
 	LAZYREMOVE(viewers, weakref(user))


### PR DESCRIPTION
Add proc `set_viewsize()` to allow hooking actions when `client.view` is changed.
  - Proc is on mob to simplify the standard use case; maybe someday actually save it there too if desired.
Simplify skybox parallax code and add support for scaling for larger client.view sizes.
  - Hooked up skybox to recalculate it's scaling when the view changes.
  - Added constant defines to clarify where the magic numbers are coming from.
