### PR TITLE
Remove vorestation edit for APC sprite

### DIFF
--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -62,7 +62,7 @@
 /obj/machinery/power/apc
 	name = "area power controller"
 	desc = "A control terminal for the area electrical systems."
-	icon = 'icons/obj/power_vr.dmi' //VOREStation Edit - New Icon
+	icon = 'icons/obj/power.dmi'
 	icon_state = "apc0"
 	plane = TURF_PLANE
 	layer = ABOVE_TURF_LAYER


### PR DESCRIPTION
It looks better and the lack of directions on ours is really bothering me.

******
## Current
![dreamseeker_2020-03-19_18-39-03](https://user-images.githubusercontent.com/15028025/77121533-ca586380-6a11-11ea-84ac-40cb02c42672.png)
![dreamseeker_2020-03-19_18-38-58](https://user-images.githubusercontent.com/15028025/77121542-cc222700-6a11-11ea-92a9-34b704c135a4.png)

******
## Changes to
![dreamseeker_2020-03-19_18-43-31](https://user-images.githubusercontent.com/15028025/77121550-d2180800-6a11-11ea-910d-5d1595dfc2e3.png)
![dreamseeker_2020-03-19_18-43-22](https://user-images.githubusercontent.com/15028025/77121556-d3e1cb80-6a11-11ea-9098-2806188f3412.png)
