### PR TITLE
New Message, No Votes Anymore

### DIFF
--- a/code/controllers/autotransfer.dm
+++ b/code/controllers/autotransfer.dm
@@ -19,7 +19,7 @@ datum/controller/transfer_controller/process()
 	//VOREStation Edit START
 	if (round_duration_in_ticks >= shift_last_vote - 2 MINUTES) 
 		shift_last_vote = 999999999999 //Setting to a stupidly high number since it'll be not used again.
-		to_world("<b>Warning: This upcoming round-extend vote will be your ONLY extend vote. Wrap up your scenes in the next 60 minutes if the round is extended.</b>") //VOREStation Edit
+		to_world("<b>Warning: You have one hour left of the shift. Wrap up your scenes in the next 60 minutes before the transfer is called.</b>") //VOREStation Edit
 	if (round_duration_in_ticks >= shift_hard_end - 1 MINUTE)
 		init_shift_change(null, 1)
 		shift_hard_end = timerbuffer + config.vote_autotransfer_interval //If shuttle somehow gets recalled, let's force it to call again next time a vote would occur.


### PR DESCRIPTION
Title.

Changelog Notes: 

- Changes the roundvote message into a warning that one hour is left in the shift.