### PR TITLE
 Fix: going on duty not giving correct access

### DIFF
--- a/code/game/machinery/computer/timeclock_vr.dm
+++ b/code/game/machinery/computer/timeclock_vr.dm
@@ -150,22 +150,23 @@
 							available_jobs += alt_job
 	return available_jobs
 
-/obj/machinery/computer/timeclock/proc/makeOnDuty(var/newjob)
-	var/datum/job/foundjob = job_master.GetJob(card.rank)
-	if(!newjob in getOpenOnDutyJobs(usr, foundjob.pto_type))
+/obj/machinery/computer/timeclock/proc/makeOnDuty(var/newassignment)
+	var/datum/job/oldjob = job_master.GetJob(card.rank)
+	var/datum/job/newjob = job_master.GetJob(newassignment)
+	if(!newassignment in getOpenOnDutyJobs(usr, oldjob.pto_type))
 		return
-	if(foundjob && card)
-		card.access = foundjob.get_access()
-		card.rank = foundjob.title
-		card.assignment = newjob
+	if(newjob && card)
+		card.access = newjob.get_access()
+		card.rank = newjob.title
+		card.assignment = newassignment
 		card.name = text("[card.registered_name]'s ID Card ([card.assignment])")
 		data_core.manifest_modify(card.registered_name, card.assignment)
 		card.last_job_switch = world.time
 		callHook("reassign_employee", list(card))
-		foundjob.current_positions++
+		newjob.current_positions++
 		var/mob/living/carbon/human/H = usr
-		H.mind.assigned_role = foundjob.title
-		H.mind.role_alt_title = newjob
+		H.mind.assigned_role = card.rank
+		H.mind.role_alt_title = card.assignment
 		announce.autosay("[card.registered_name] has moved On-Duty as [card.assignment].", "Employee Oversight")
 	return
 

--- a/code/game/machinery/computer/timeclock_vr.dm
+++ b/code/game/machinery/computer/timeclock_vr.dm
@@ -119,21 +119,19 @@
 		update_icon()
 		return 1
 	if(href_list["switch-to-onduty-rank"])
-		if(card)
-			if(checkFace())
-				if(checkCardCooldown())
-					makeOnDuty(href_list["switch-to-onduty-rank"], href_list["switch-to-onduty-assignment"])
-					usr.put_in_hands(card)
-					card = null
+		if(checkFace())
+			if(checkCardCooldown())
+				makeOnDuty(href_list["switch-to-onduty-rank"], href_list["switch-to-onduty-assignment"])
+				usr.put_in_hands(card)
+				card = null
 		update_icon()
 		return 1
 	if(href_list["switch-to-offduty"])
-		if(card)
-			if(checkFace())
-				if(checkCardCooldown())
-					makeOffDuty()
-					usr.put_in_hands(card)
-					card = null
+		if(checkFace())
+			if(checkCardCooldown())
+				makeOffDuty()
+				usr.put_in_hands(card)
+				card = null
 		update_icon()
 		return 1
 	return 1 // Return 1 to update UI
@@ -155,7 +153,7 @@
 	var/datum/job/newjob = job_master.GetJob(newrank)
 	if(!newassignment in getOpenOnDutyJobs(usr, oldjob.pto_type))
 		return
-	if(newjob && card)
+	if(newjob)
 		card.access = newjob.get_access()
 		card.rank = newjob.title
 		card.assignment = newassignment
@@ -180,7 +178,7 @@
 		if(job.pto_type == new_dept && job.timeoff_factor < 0)
 			ptojob = job
 			break
-	if(ptojob && card)
+	if(ptojob)
 		var/oldtitle = card.assignment
 		card.access = ptojob.get_access()
 		card.rank = ptojob.title

--- a/code/game/machinery/computer/timeclock_vr.dm
+++ b/code/game/machinery/computer/timeclock_vr.dm
@@ -118,11 +118,11 @@
 				card = I
 		update_icon()
 		return 1
-	if(href_list["switch-to-onduty"])
+	if(href_list["switch-to-onduty-rank"])
 		if(card)
 			if(checkFace())
 				if(checkCardCooldown())
-					makeOnDuty(href_list["switch-to-onduty"])
+					makeOnDuty(href_list["switch-to-onduty-rank"], href_list["switch-to-onduty-assignment"])
 					usr.put_in_hands(card)
 					card = null
 		update_icon()
@@ -143,16 +143,16 @@
 	for(var/datum/job/job in job_master.occupations)
 		if(job && job.is_position_available() && !job.whitelist_only && !jobban_isbanned(user,job.title) && job.player_old_enough(user.client))
 			if(job.pto_type == department && !job.disallow_jobhop && job.timeoff_factor > 0)
-				available_jobs += job.title
+				available_jobs[job.title] = list(job.title)
 				if(job.alt_titles)
 					for(var/alt_job in job.alt_titles)
 						if(alt_job != job.title)
-							available_jobs += alt_job
+							available_jobs[job.title] += alt_job
 	return available_jobs
 
-/obj/machinery/computer/timeclock/proc/makeOnDuty(var/newassignment)
+/obj/machinery/computer/timeclock/proc/makeOnDuty(var/newrank, var/newassignment)
 	var/datum/job/oldjob = job_master.GetJob(card.rank)
-	var/datum/job/newjob = job_master.GetJob(newassignment)
+	var/datum/job/newjob = job_master.GetJob(newrank)
 	if(!newassignment in getOpenOnDutyJobs(usr, oldjob.pto_type))
 		return
 	if(newjob && card)

--- a/nano/templates/timeclock_vr.tmpl
+++ b/nano/templates/timeclock_vr.tmpl
@@ -69,12 +69,14 @@
 				<span class='bad'>Insufficent Time Off Accrued</span>
 			{{/if}}
 		{{else (data.job_datum.timeoff_factor < 0) }}
-			{{props data.job_choices }}
-				<div class='itemLabelWide'>{{:value}}</div>
-				<div class='itemContentMedium'>{{:helper.link("Go On-Duty", 'suitcase', {'switch-to-onduty' : value})}}</div>
+			{{props data.job_choices :alt_titles:job }}
+				{{props alt_titles :alt_title:alt_title_index }}
+					<div class='itemLabelWide'>{{:alt_title}}</div>
+					<div class='itemContentMedium'>{{:helper.link("Go On-Duty", 'suitcase', {'switch-to-onduty-rank' : job,'switch-to-onduty-assignment' : alt_title})}}</div>
+				{{/props}}
 			{{empty}}
 				<div class='notice'>No Open Positions - See Head of Personnel</div>
-			{{/for}}
+			{{/props}}
 		{{/if}}
 	</div>
 </div>


### PR DESCRIPTION
Currently going on duty gives you the access of the off duty job you already have, instead of looking up the job you're switching to and giving you access for that.  This fixes that.  Also some small refactors of timeclock code.