### PR TITLE
[Fluff] Vakashi's Permit Expiration

### DIFF
--- a/code/modules/client/preference_setup/loadout/loadout_fluffitems_vr.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_fluffitems_vr.dm
@@ -349,30 +349,6 @@
 	ckeywhitelist = list("jemli")
 	character_name = list("Jemli")
 
-//TFF 28/11/19 - Expired permit removal
-/*
-/datum/gear/fluff/jeremiah_permit
-	path = /obj/item/clothing/accessory/permit/gun/fluff/ace
-	display_name = "Ace's Gun Permit"
-	ckeywhitelist = list("jertheace")
-	character_name = list("Jeremiah Acacius")
-	allowed_roles = list("Colony Director", "Warden", "Head of Security")
-
-/datum/gear/fluff/jeremiah_gun
-	path = /obj/item/weapon/gun/projectile/p92x/large/preban/hp
-	display_name = "Ace's Gun"
-	ckeywhitelist = list("jertheace")
-	character_name = list("Jeremiah Acacius")
-	allowed_roles = list("Colony Director", "Warden", "Head of Security")
-
-/datum/gear/fluff/jeremiah_ammo
-	path = /obj/item/ammo_magazine/m9mm/large/preban/hp //Spare ammo
-	display_name = "Ace's Spare Ammo"
-	ckeywhitelist = list("jertheace")
-	character_name = list("Jeremiah Acacius")
-	allowed_roles = list("Colony Director", "Warden", "Head of Security")
-*/
-
 /datum/gear/fluff/jeremiah_holster
 	path = /obj/item/clothing/accessory/holster/armpit
 	display_name = "Ace's Holster"
@@ -822,18 +798,6 @@
 //  U CKEYS
 
 //  V CKEYS
-/datum/gear/fluff/vakashi_permit
-	path = /obj/item/clothing/accessory/permit/gun/fluff/Vakashi
-	display_name = "Vakashi's Pepperspray Permit"
-	ckeywhitelist = list("vailthewolf")
-	character_name = list("Vakashi")
-
-/datum/gear/fluff/vakashi_pepperspray
-	path = /obj/item/weapon/reagent_containers/spray/pepper
-	display_name = "Vakashi's Pepperspray"
-	ckeywhitelist = list("vailthewolf")
-	character_name = list("Vakashi")
-
 /datum/gear/fluff/cameron_glasses
 	path = /obj/item/clothing/glasses/fluff/science_proper
 	display_name = "Cameron's Science Glasses"

--- a/code/modules/vore/fluffstuff/custom_permits_vr.dm
+++ b/code/modules/vore/fluffstuff/custom_permits_vr.dm
@@ -6,19 +6,6 @@
 	to_chat(user, "You cannot reset the naming locks on [src]. It's issued by CentCom and totally tamper-proof!")
 	return
 
-//TFF 28/11/19 - Remove expired permit
-/*
-// jertheace:Jeremiah 'Ace' Acacius
-/obj/item/clothing/accessory/permit/gun/fluff/ace
-	name = "Jeremiah Acacius's Sidearm Permit"
-	desc = "A card indicating that the owner is allowed to carry a sidearm. It is issued by CentCom, so it is valid until it expires on November 10th, 2563."
-*/
-
-// ValiTheWolf: Vakashi
-/obj/item/clothing/accessory/permit/gun/fluff/Vakashi
-	name = "Vakashi's Sidearm Permit"
-	desc = "A card indicating that the owner is allowed to carry a sidearm that uses less-than-lethal munitions. It is issued by CentCom, so it is valid until it expires on March 1st, 2564."
-
 /* Legacy Permits
 // BEGIN - PROTOTYPE
 /obj/item/clothing/accessory/permit/gun/fluff


### PR DESCRIPTION
Expired permit removal, code cleanup.

Changlog Notes:

- Removes Vakashi's Permit and allowed item.

- Also removes code for Ace's long expired permit and the same for the commented out items.