### PR TITLE
Added three utilities for admins & developers

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -264,6 +264,10 @@ var/list/gamemode_cache = list()
 	var/sqlite_feedback_cooldown = 0 // How long one must wait, in days, to submit another feedback form. Used to help prevent spam, especially with privacy active. 0 = No limit.
 	var/sqlite_feedback_min_age = 0 // Used to block new people from giving feedback. This metric is very bad but it can help slow down spammers.
 
+	// disables the annoying "You have already logged in this round, disconnect or be banned" popup for multikeying, because it annoys the shit out of me when testing.
+	var/disable_cid_warn_popup = FALSE
+
+
 /datum/configuration/New()
 	var/list/L = typesof(/datum/game_mode) - /datum/game_mode
 	for (var/T in L)
@@ -873,7 +877,8 @@ var/list/gamemode_cache = list()
 				if("sqlite_feedback_cooldown")
 					config.sqlite_feedback_cooldown = text2num(value)
 
-
+				if("disable_cid_warn_popup")
+					config.disable_cid_warn_popup = TRUE
 
 				else
 					log_misc("Unknown setting in configuration: '[name]'")

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -75,6 +75,7 @@ proc/admin_notice(var/message, var/rights)
 
 	if(M.client)
 		body += "| <A HREF='?src=\ref[src];sendtoprison=\ref[M]'>Prison</A> | "
+		body += "\ <A HREF='?src=\ref[src];sendbacktolobby=\ref[M]'>Send back to Lobby</A> | "
 		var/muted = M.client.prefs.muted
 		body += {"<br><b>Mute: </b>
 			\[<A href='?src=\ref[src];mute=\ref[M];mute_type=[MUTE_IC]'><font color='[(muted & MUTE_IC)?"red":"blue"]'>IC</font></a> |
@@ -127,6 +128,8 @@ proc/admin_notice(var/message, var/rights)
 				body += "<A href='?src=\ref[src];makeanimal=\ref[M]'>Re-Animalize</A> | "
 			else
 				body += "<A href='?src=\ref[src];makeanimal=\ref[M]'>Animalize</A> | "
+
+			body += "<A href='?src=\ref[src];respawn=\ref[M.client]'>Respawn</A> | "
 
 			// DNA2 - Admin Hax
 			if(M.dna && iscarbon(M))

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1065,6 +1065,29 @@
 		log_admin("[key_name(usr)] sent [key_name(M)] to the prison station.")
 		message_admins("<font color='blue'>[key_name_admin(usr)] sent [key_name_admin(M)] to the prison station.</font>", 1)
 
+	else if(href_list["sendbacktolobby"])
+		if(!check_rights(R_ADMIN))
+			return
+
+		var/mob/M = locate(href_list["sendbacktolobby"])
+		if(!isobserver(M))
+			to_chat(usr, "<span class='notice'>You can only send ghost players back to the Lobby.</span>")
+			return
+
+		if(!M.client)
+			to_chat(usr, "<span class='warning'>[M] doesn't seem to have an active client.</span>")
+			return
+
+		if(alert(usr, "Send [key_name(M)] back to Lobby?", "Message", "Yes", "No") != "Yes")
+			return
+
+		log_admin("[key_name(usr)] has sent [key_name(M)] back to the Lobby.")
+		message_admins("[key_name(usr)] has sent [key_name(M)] back to the Lobby.")
+
+		var/mob/new_player/NP = new()
+		NP.ckey = M.ckey
+		qdel(M)
+
 	else if(href_list["tdome1"])
 		if(!check_rights(R_FUN))	return
 
@@ -1222,6 +1245,15 @@
 			return
 
 		usr.client.cmd_admin_animalize(M)
+
+	else if(href_list["respawn"])
+		if(!check_rights(R_SPAWN))
+			return
+
+		var/client/C = locate(href_list["respawn"])
+		if(!istype(C))
+			return
+		usr.client.respawn_character_proper(C)
 
 	else if(href_list["togmutate"])
 		if(!check_rights(R_SPAWN))	return

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -369,12 +369,18 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	if(!holder)
 		return
 
-	//I frontload all the questions so we don't have a half-done process while you're reading.
 	var/client/picked_client = input(src, "Please specify which client's character to spawn.", "Client", "") as null|anything in GLOB.clients
 	if(!picked_client)
 		return
 
-	var/location = alert(src,"Please specify where to spawn them.", "Location", "Right Here", "Arrivals", "Cancel")
+	respawn_character_proper(picked_client)
+
+/client/proc/respawn_character_proper(client/picked_client)
+	if(!istype(picked_client))
+		return
+
+	//I frontload all the questions so we don't have a half-done process while you're reading.
+	var/location = alert(src, "Please specify where to spawn them.", "Location", "Right Here", "Arrivals", "Cancel")
 	if(location == "Cancel" || !location)
 		return
 

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -14,7 +14,8 @@
 				if( (client.connection != "web") && (M.computer_id == client.computer_id) )
 					if(matches)	matches += " and "
 					matches += "ID ([client.computer_id])"
-					spawn() alert("You have logged in already with another key this round, please log out of this one NOW or risk being banned!")
+					if(!config.disable_cid_warn_popup)
+						spawn() alert("You have logged in already with another key this round, please log out of this one NOW or risk being banned!")
 				if(matches)
 					if(M.client)
 						message_admins("<font color='red'><B>Notice: </B></font><font color='blue'>[key_name_admin(src)] has the same [matches] as [key_name_admin(M)].</font>", 1)

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -526,3 +526,6 @@ SQLITE_FEEDBACK_COOLDOWN 0
 ## Set this to how many days you want someone to have to wait when they first join.
 ## Setting to zero will disable this restriction.
 SQLITE_FEEDBACK_MIN_AGE 7
+
+## Uncomment this if you want to disable the popup alert for people on the same CID (Don't do this on a live server if you ban multikeying)
+#DISABLE_CID_WARN_POPUP


### PR DESCRIPTION
 - There is a new option in the player panel labeled "Send back to
   Lobby", which will send a given player back to the lobby.
 - The player panel also has a shortcut to the "Spawn Character" verb.
 - Finally, there's a new config option that disables the warning
   message about multikeying if two mobs with the same CID are found;
   this option should NOT be enabled if multikeying is prohibited by the
   server rules. It is simply a developer tool, as multikeying is
   sometimes necessary to test new features that require two clients
   interacting.

This should be sent to Polaris eventually, no real reason for them -not- to have these.

![Screenshot of the player panel now](https://i.tigercat2000.net/2020/03/dreamseeker_ABcLukVeCD.png)