### PR TITLE
Fixes Shadekin carbon opacity issue

### DIFF
--- a/code/modules/mob/living/carbon/human/species/shadekin/shadekin_abilities.dm
+++ b/code/modules/mob/living/carbon/human/species/shadekin/shadekin_abilities.dm
@@ -67,7 +67,7 @@
 	//Shifting in
 	if(ability_flags & AB_PHASE_SHIFTED)
 		ability_flags &= ~AB_PHASE_SHIFTED
-		mouse_opacity = 2
+		mouse_opacity = 1
 		name = real_name
 		for(var/belly in vore_organs)
 			var/obj/belly/B = belly


### PR DESCRIPTION
When shifting in, code caused a rectangle to form around the shadekin, meaning everything within that rectangle was, for the game, the shadekin. This changes the option from 2 to 1 so that only the sprite itself is the shadekin. If that makes any sense?