### PR TITLE
Allow wings with a secondary color

### DIFF
--- a/code/game/dna/dna2.dm
+++ b/code/game/dna/dna2.dm
@@ -51,10 +51,13 @@
 #define DNA_UI_WING_STYLE  32
 #define DNA_UI_WING_R      33
 #define DNA_UI_WING_G      34
-#define DNA_UI_WING_B      35 // VOREStation snippet end.
-#define DNA_UI_LENGTH      35 // VOREStation Edit to 35
+#define DNA_UI_WING_B      35
+#define DNA_UI_WING2_R     36
+#define DNA_UI_WING2_G     37
+#define DNA_UI_WING2_B     38 // VOREStation snippet end.
+#define DNA_UI_LENGTH      38 // VOREStation Edit - Needs to match the highest number above.
 
-#define DNA_SE_LENGTH 46 // VOREStation Edit (original was UI+11)
+#define DNA_SE_LENGTH 49 // VOREStation Edit (original was UI+11)
 // For later:
 //#define DNA_SE_LENGTH 50 // Was STRUCDNASIZE, size 27. 15 new blocks added = 42, plus room to grow.
 
@@ -224,6 +227,10 @@ var/global/list/datum/dna/gene/dna_genes[0]
 	SetUIValueRange(DNA_UI_WING_R,    character.r_wing,    255,    1)
 	SetUIValueRange(DNA_UI_WING_G,    character.g_wing,    255,    1)
 	SetUIValueRange(DNA_UI_WING_B,    character.b_wing,    255,    1)
+
+	SetUIValueRange(DNA_UI_WING2_R,    character.r_wing2,  255,    1)
+	SetUIValueRange(DNA_UI_WING2_G,    character.g_wing2,  255,    1)
+	SetUIValueRange(DNA_UI_WING2_B,    character.b_wing2,  255,    1)
 
 	SetUIValueRange(DNA_UI_EARS_R,    character.r_ears,    255,    1)
 	SetUIValueRange(DNA_UI_EARS_G,    character.g_ears,    255,    1)

--- a/code/modules/client/preference_setup/vore/01_ears.dm
+++ b/code/modules/client/preference_setup/vore/01_ears.dm
@@ -24,6 +24,9 @@
 	var/r_wing = 30		// Wing color
 	var/g_wing = 30		// Wing color
 	var/b_wing = 30		// Wing color
+	var/r_wing2 = 30	// Wing extra color
+	var/g_wing2 = 30	// Wing extra color
+	var/b_wing2 = 30	// Wing extra color
 	var/dress_mob = TRUE
 
 // Definition of the stuff for Ears
@@ -50,6 +53,9 @@
 	S["r_wing"]			>> pref.r_wing
 	S["g_wing"]			>> pref.g_wing
 	S["b_wing"]			>> pref.b_wing
+	S["r_wing2"]		>> pref.r_wing2
+	S["g_wing2"]		>> pref.g_wing2
+	S["b_wing2"]		>> pref.b_wing2
 
 /datum/category_item/player_setup_item/vore/ears/save_character(var/savefile/S)
 	S["ear_style"]		<< pref.ear_style
@@ -70,6 +76,9 @@
 	S["r_wing"]			<< pref.r_wing
 	S["g_wing"]			<< pref.g_wing
 	S["b_wing"]			<< pref.b_wing
+	S["r_wing2"]		<< pref.r_wing2
+	S["g_wing2"]		<< pref.g_wing2
+	S["b_wing2"]		<< pref.b_wing2
 
 /datum/category_item/player_setup_item/vore/ears/sanitize_character()
 	pref.r_ears		= sanitize_integer(pref.r_ears, 0, 255, initial(pref.r_ears))
@@ -87,6 +96,9 @@
 	pref.r_wing		= sanitize_integer(pref.r_wing, 0, 255, initial(pref.r_wing))
 	pref.g_wing		= sanitize_integer(pref.g_wing, 0, 255, initial(pref.g_wing))
 	pref.b_wing		= sanitize_integer(pref.b_wing, 0, 255, initial(pref.b_wing))
+	pref.r_wing2	= sanitize_integer(pref.r_wing2, 0, 255, initial(pref.r_wing2))
+	pref.g_wing2	= sanitize_integer(pref.g_wing2, 0, 255, initial(pref.g_wing2))
+	pref.b_wing2	= sanitize_integer(pref.b_wing2, 0, 255, initial(pref.b_wing2))
 	if(pref.ear_style)
 		pref.ear_style	= sanitize_inlist(pref.ear_style, ear_styles_list, initial(pref.ear_style))
 		var/datum/sprite_accessory/temp_ear_style = ear_styles_list[pref.ear_style]
@@ -122,6 +134,9 @@
 	character.r_wing			= pref.r_wing
 	character.b_wing			= pref.b_wing
 	character.g_wing			= pref.g_wing
+	character.r_wing2			= pref.r_wing2
+	character.b_wing2			= pref.b_wing2
+	character.g_wing2			= pref.g_wing2
 
 
 
@@ -178,9 +193,11 @@
 	. += " Style: <a href='?src=\ref[src];wing_style=1'>[wing_display]</a><br>"
 
 	if(wing_styles_list[pref.wing_style])
-		var/datum/sprite_accessory/wing/T = wing_styles_list[pref.wing_style]
-		if (T.do_colouration)
+		var/datum/sprite_accessory/wing/W = wing_styles_list[pref.wing_style]
+		if (W.do_colouration)
 			. += "<a href='?src=\ref[src];wing_color=1'>Change Color</a> <font face='fixedsys' size='3' color='#[num2hex(pref.r_wing, 2)][num2hex(pref.g_wing, 2)][num2hex(pref.b_wing, 2)]'><table style='display:inline;' bgcolor='#[num2hex(pref.r_wing, 2)][num2hex(pref.g_wing, 2)][num2hex(pref.b_wing, 2)]'><tr><td>__</td></tr></table> </font><br>"
+		if (W.extra_overlay)
+			. += "<a href='?src=\ref[src];wing_color2=1'>Change Secondary Color</a> <font face='fixedsys' size='3' color='#[num2hex(pref.r_wing2, 2)][num2hex(pref.g_wing2, 2)][num2hex(pref.b_wing2, 2)]'><table style='display:inline;' bgcolor='#[num2hex(pref.r_wing2, 2)][num2hex(pref.g_wing2, 2)][num2hex(pref.b_wing2, 2)]'><tr><td>__</td></tr></table> </font><br>"
 
 /datum/category_item/player_setup_item/vore/ears/OnTopic(var/href,var/list/href_list, var/mob/user)
 	if(!CanUseTopic(user))
@@ -274,6 +291,15 @@
 			pref.r_wing = hex2num(copytext(new_wingc, 2, 4))
 			pref.g_wing = hex2num(copytext(new_wingc, 4, 6))
 			pref.b_wing = hex2num(copytext(new_wingc, 6, 8))
+			return TOPIC_REFRESH_UPDATE_PREVIEW
+
+	else if(href_list["wing_color2"])
+		var/new_wingc2 = input(user, "Choose your character's secondary wing colour:", "Character Preference",
+			rgb(pref.r_wing2, pref.g_wing2, pref.b_wing2)) as color|null
+		if(new_wingc2)
+			pref.r_wing2 = hex2num(copytext(new_wingc2, 2, 4))
+			pref.g_wing2 = hex2num(copytext(new_wingc2, 4, 6))
+			pref.b_wing2 = hex2num(copytext(new_wingc2, 6, 8))
 			return TOPIC_REFRESH_UPDATE_PREVIEW
 
 	else if(href_list["toggle_clothing"])

--- a/code/modules/mob/living/carbon/human/species/species_shapeshift_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/species_shapeshift_vr.dm
@@ -121,4 +121,14 @@
 		g_wing = new_color_rgb_list[2]
 		b_wing = new_color_rgb_list[3]
 
+		//Indented inside positive primary color choice, don't bother if they clicked cancel
+		var/current_sec_color = rgb(r_wing2,g_wing2,b_wing2)
+	
+		var/new_sec_color = input("Pick secondary wing color (only applies to some wings):","Wing Color (sec)", current_sec_color) as null|color
+		if(new_sec_color)
+			new_color_rgb_list = hex2rgb(new_sec_color)
+			r_wing2 = new_color_rgb_list[1]
+			g_wing2 = new_color_rgb_list[2]
+			b_wing2 = new_color_rgb_list[3]
+
 	update_wing_showing()

--- a/code/modules/mob/living/carbon/human/update_icons_vr.dm
+++ b/code/modules/mob/living/carbon/human/update_icons_vr.dm
@@ -60,6 +60,11 @@
 		var/icon/wing_s = new/icon("icon" = wing_style.icon, "icon_state" = flapping && wing_style.ani_state ? wing_style.ani_state : wing_style.icon_state)
 		if(wing_style.do_colouration)
 			wing_s.Blend(rgb(src.r_wing, src.g_wing, src.b_wing), wing_style.color_blend_mode)
+		if(wing_style.extra_overlay)
+			var/icon/overlay = new/icon("icon" = wing_style.icon, "icon_state" = wing_style.extra_overlay)
+			overlay.Blend(rgb(src.r_wing2, src.g_wing2, src.b_wing2), wing_style.color_blend_mode)
+			wing_s.Blend(overlay, ICON_OVERLAY)
+			qdel(overlay)
 		return image(wing_s)
 
 // TODO - Move this to where it should go ~Leshana

--- a/code/modules/vore/appearance/preferences_vr.dm
+++ b/code/modules/vore/appearance/preferences_vr.dm
@@ -28,6 +28,9 @@
 	var/r_wing = 30
 	var/g_wing = 30
 	var/b_wing = 30
+	var/r_wing2 = 30
+	var/g_wing2 = 30
+	var/b_wing2 = 30
 
 	// Custom Species Name
 	var/custom_species


### PR DESCRIPTION
Adds code to support wings with extra_overlay having a secondary color, like tails do. Currently extra_overlay is just ignored on wings.