### PR TITLE
Improves *flip

### DIFF
--- a/code/modules/mob/living/carbon/human/emote_vr.dm
+++ b/code/modules/mob/living/carbon/human/emote_vr.dm
@@ -72,7 +72,15 @@
 				to_chat(src, "<span class='warning'>You can't *flip in your current state!</span>")
 				return 1
 			else
-				src.SpinAnimation(7,1)
+				var/original_density = density
+				var/original_passflags = pass_flags
+				density = FALSE
+				if(prob(20))
+					pass_flags |= PASSTABLE
+				SpinAnimation(7,1)
+				spawn(7)
+					density = original_density
+					pass_flags = original_passflags
 				message = "does a flip!"
 				m_type = 1
 		if ("vhelp") //Help for Virgo-specific emotes.

--- a/code/modules/mob/living/carbon/human/emote_vr.dm
+++ b/code/modules/mob/living/carbon/human/emote_vr.dm
@@ -77,7 +77,10 @@
 				density = FALSE
 				if(prob(20))
 					pass_flags |= PASSTABLE
-				SpinAnimation(7,1)
+				if(dir & WEST)
+					SpinAnimation(7,1,0)
+				else
+					SpinAnimation(7,1,1)
 				spawn(7)
 					density = original_density
 					pass_flags = original_passflags


### PR DESCRIPTION
This is a terrible idea.

*flip now sets your density to false for the 0.7 seconds it's playing the animation. So, in theory, you can dodge projectiles and thrown items. There's also a 20% chance it gives you PASSTABLE so you can jump tables.

![2020-03-31_23-48-27](https://user-images.githubusercontent.com/15028025/78097452-4f486300-73aa-11ea-8a88-4ecb534d37f7.gif)