### PR TITLE
Improves *flip, adds Traceur trait

### DIFF
--- a/code/modules/mob/living/carbon/human/emote_vr.dm
+++ b/code/modules/mob/living/carbon/human/emote_vr.dm
@@ -72,7 +72,8 @@
 				to_chat(src, "<span class='warning'>You can't *flip in your current state!</span>")
 				return 1
 			else
-				src.SpinAnimation(7,1)
+				nextemote += 12 //Double delay
+				handle_flip_vr()
 				message = "does a flip!"
 				m_type = 1
 		if ("vhelp") //Help for Virgo-specific emotes.
@@ -83,6 +84,32 @@
 		return 1
 
 	return 0
+
+
+/mob/living/carbon/human/proc/handle_flip_vr()
+	var/original_density = density
+	var/original_passflags = pass_flags
+	
+	//Briefly un-dense to dodge projectiles
+	density = FALSE
+	
+	//Parkour!
+	var/parkour_chance = 20 //Default
+	if(species)
+		parkour_chance = species.agility
+	if(prob(parkour_chance))
+		pass_flags |= PASSTABLE
+	else
+		Confuse(1) //Thud
+
+	if(dir & WEST)
+		SpinAnimation(7,1,0)
+	else
+		SpinAnimation(7,1,1)
+
+	spawn(7)
+		density = original_density
+		pass_flags = original_passflags
 
 /mob/living/carbon/human/proc/toggle_tail_vr(var/setting,var/message = 0)
 	if(!tail_style || !tail_style.ani_state)

--- a/code/modules/mob/living/carbon/human/species/species_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/species_vr.dm
@@ -19,6 +19,7 @@
 	var/icobase_wing
 	var/wikilink = null //link to wiki page for species
 	var/icon_height = 32
+	var/agility = 20 //prob() to do agile things
 
 /datum/species/proc/update_attack_types()
 	unarmed_attacks = list()

--- a/code/modules/mob/living/carbon/human/species/station/station_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_vr.dm
@@ -260,7 +260,7 @@
 	inherent_verbs = list(/mob/living/proc/shred_limb, /mob/living/carbon/human/proc/lick_wounds)
 	heat_discomfort_level = 295 //Prevents heat discomfort spam at 20c
 	wikilink="https://wiki.vore-station.net/Tajaran"
-	agility = 80
+	agility = 90
 
 /datum/species/skrell
 	spawn_flags = SPECIES_CAN_JOIN
@@ -305,7 +305,7 @@
 	gluttonous = 0
 	descriptors = list()
 	wikilink="https://wiki.vore-station.net/Teshari"
-	agility = 80
+	agility = 90
 
 	inherent_verbs = list(
 		/mob/living/carbon/human/proc/sonar_ping,

--- a/code/modules/mob/living/carbon/human/species/station/station_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_vr.dm
@@ -260,6 +260,7 @@
 	inherent_verbs = list(/mob/living/proc/shred_limb, /mob/living/carbon/human/proc/lick_wounds)
 	heat_discomfort_level = 295 //Prevents heat discomfort spam at 20c
 	wikilink="https://wiki.vore-station.net/Tajaran"
+	agility = 80
 
 /datum/species/skrell
 	spawn_flags = SPECIES_CAN_JOIN
@@ -304,6 +305,7 @@
 	gluttonous = 0
 	descriptors = list()
 	wikilink="https://wiki.vore-station.net/Teshari"
+	agility = 80
 
 	inherent_verbs = list(
 		/mob/living/carbon/human/proc/sonar_ping,

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/positive.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/positive.dm
@@ -118,3 +118,9 @@
 /datum/trait/antiseptic_saliva/apply(var/datum/species/S,var/mob/living/carbon/human/H)
 	..()
 	H.verbs |= /mob/living/carbon/human/proc/lick_wounds 
+
+/datum/trait/traceur
+	name = "Traceur"
+	desc = "You're capable of parkour and can *flip over low objects."
+	cost = 2
+	var_changes = list("agility" = 100)

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/positive.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/positive.dm
@@ -121,6 +121,6 @@
 
 /datum/trait/traceur
 	name = "Traceur"
-	desc = "You're capable of parkour and can *flip over low objects."
+	desc = "You're capable of parkour and can *flip over low objects (most of the time)."
 	cost = 2
-	var_changes = list("agility" = 100)
+	var_changes = list("agility" = 90)


### PR DESCRIPTION
- Adds 'agility' species var. Default 20, Tajara and Teshari have 90.
- Traceur trait raises agility to 90.
- *flip lets you dodge projectiles and thrown items for the duration of the animation.
- *flip has 2x the emote cooldown.
- *flip will give you either the ability to jump tables/railings/etc or 1 point of Confusion depending on your species agility as a %.
- Makes *flip rotate counter-clockwise if you're facing west.