### PR TITLE
Adds Ore/Gem Eater Trait

### DIFF
--- a/code/modules/mining/ore.dm
+++ b/code/modules/mining/ore.dm
@@ -122,3 +122,11 @@
 		C.sample_item(src, user)
 	else
 		return ..()
+
+/obj/item/weapon/ore/attack(mob/living/M as mob, mob/living/user as mob)
+	if(ishuman(M))
+		var/mob/living/carbon/human/H = M
+		if(H.species.eat_ore == 1)
+			H.eat_ore(src)
+			return
+	..()

--- a/code/modules/mob/living/carbon/human/species/station/blank_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/blank_vr.dm
@@ -5,6 +5,7 @@
 	var/metabolism = 0.0015
 	var/lightweight = FALSE //Oof! Nonhelpful bump stumbles.
 	var/trashcan = FALSE //It's always sunny in the wrestling ring.
+	var/eat_ore = FALSE //HEAVY METAL DIET
 	var/base_species = null // Unused outside of a few species
 	var/selects_bodytype = FALSE // Allows the species to choose from body types intead of being forced to be just one.
 

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
@@ -99,6 +99,16 @@
 	..(S,H)
 	H.verbs |= /mob/living/proc/eat_trash
 
+/datum/trait/gem_eater
+	name = "Expensive Taste"
+	desc = "There's nothing that sates the appetite better than precious gems, exotic or rare minerals and you have damn fine taste. Anything else is beneath you."
+	cost = 0
+	var_changes = list("gets_food_nutrition" = 0, "eat_ore" = 1) //The verb is given in human.dm
+
+/datum/trait/gem_eater/apply(var/datum/species/S,var/mob/living/carbon/human/H)
+	..(S,H)
+	H.verbs |= /mob/living/proc/eat_ore
+
 /datum/trait/glowing_eyes
 	name = "Glowing Eyes"
 	desc = "Your eyes show up above darkness. SPOOKY! And kinda edgey too."

--- a/code/modules/vore/eating/living_vr.dm
+++ b/code/modules/vore/eating/living_vr.dm
@@ -695,7 +695,7 @@
 	set desc = "Consume held ore and gems. Snack time!"
 
 	if(!vore_selected)
-		to_chat(src,"<span class='warning'>You either don't have a belly selected, or don't have a belly!</span>")
+		to_chat(src, "<span class='warning'>You either don't have a belly selected, or don't have a belly!</span>")
 		return
 
 	var/obj/item/I = (snack ? snack : get_active_hand())
@@ -725,8 +725,8 @@
 			"gold"			= list("nutrition" = 40, "remark" = "You taste supreme richness that exceeds expectations and satisfies your hunger."),
 			"diamond"		= list("nutrition" = 50, "remark" = "The heavenly taste of [O] almost brings a tear to your eye. Its glimmering gloriousness is even better on the tongue than you imagined, so you savour it fondly."),
 			"platinum"		= list("nutrition" = 40, "remark" = "A bit tangy but elegantly balanced with a long faintly sour finish. Delectible."),
-			"mhydrogen"		= list("nutrition" = 30, "remark" = "Quite sweet on the tongue, you savour the light easy to chew [O] and finish it quickly."),
-			MAT_VERDANTIUM	= list("nutrition" = 50, "remark" = "You taste the scientific mystery and a rare delicacy. Your tastebuds tingle pleasantly as you eat [O] and the feeling warmly blossoms in your chest for a moment."),
+			"mhydrogen"		= list("nutrition" = 30, "remark" = "Quite sweet on the tongue, you savour the light and easy to chew [O], finishing it quickly."),
+			MAT_VERDANTIUM	= list("nutrition" = 50, "remark" = "You taste scientific mystery and a rare delicacy. Your tastebuds tingle pleasantly as you eat [O] and the feeling warmly blossoms in your chest for a moment."),
 			MAT_LEAD		= list("nutrition" = 40, "remark" = "It takes some work to break down [O] but you manage it, unlocking lasting tangy goodness in the process. Yum."),
 		)
 		if(O.material in rock_munch)


### PR DESCRIPTION
Loosely inspired by some jazz about kobolds eating gems and loosely balanced around the rarity & quality of the ore.
Taking the ore eater trait, you only gain nutrition from ore.

5 raw diamonds or verdantite crystals will feed you well, while it'll take a handful of hematite or carbon to do the job.
Better stick to the good stuff - it's in your best interest and it tastes better anyway!

Nutritional value subject to change on review. I figured these were solid numbers to go with