### PR TITLE
Rotates some unrotated vendomats and coolers

### DIFF
--- a/maps/tether/tether-02-surface2.dmm
+++ b/maps/tether/tether-02-surface2.dmm
@@ -12490,7 +12490,9 @@
 /obj/effect/floor_decal/steeldecal/steel_decals9{
 	dir = 8
 	},
-/obj/machinery/vending/cigarette,
+/obj/machinery/vending/cigarette{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/rnd/breakroom)
 "axO" = (
@@ -12523,7 +12525,9 @@
 /obj/effect/floor_decal/steeldecal/steel_decals9{
 	dir = 8
 	},
-/obj/machinery/vending/snack,
+/obj/machinery/vending/coffee{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/rnd/breakroom)
 "axQ" = (
@@ -15094,7 +15098,9 @@
 /obj/effect/floor_decal/steeldecal/steel_decals9{
 	dir = 8
 	},
-/obj/machinery/vending/coffee,
+/obj/machinery/vending/snack{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/rnd/breakroom)
 "aBG" = (
@@ -38578,7 +38584,7 @@ aut
 aut
 aut
 atJ
-aBF
+axP
 auv
 azl
 aCY
@@ -38720,7 +38726,7 @@ auZ
 auu
 auu
 axb
-axP
+aBF
 auv
 azm
 aAf

--- a/maps/tether/tether-03-surface3.dmm
+++ b/maps/tether/tether-03-surface3.dmm
@@ -6019,7 +6019,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/vending/security,
+/obj/machinery/vending/security{
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/common)
 "ajQ" = (
@@ -8629,18 +8631,17 @@
 /turf/simulated/floor/tiled,
 /area/crew_quarters/pool)
 "aou" = (
-/obj/structure/reagent_dispensers/water_cooler/full,
-/obj/item/device/radio/intercom{
-	dir = 2;
-	pixel_y = -24
+/obj/effect/floor_decal/corner/lightgrey{
+	dir = 9
 	},
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1";
-	pixel_x = 0
+/obj/effect/floor_decal/corner/lightgrey{
+	dir = 6
 	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/recreation_area)
+/obj/machinery/vending/snack{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/surface_three_hall)
 "aov" = (
 /obj/machinery/scale,
 /obj/structure/disposalpipe/segment{
@@ -15964,7 +15965,9 @@
 /obj/effect/floor_decal/corner/lightgrey{
 	dir = 6
 	},
-/obj/machinery/vending/cola,
+/obj/machinery/vending/cola{
+	dir = 1
+	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_three_hall)
 "aAo" = (
@@ -28849,10 +28852,20 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/lobby)
 "aVS" = (
-/obj/structure/shuttle/engine/propulsion,
-/turf/simulated/floor/reinforced,
-/turf/simulated/shuttle/plating/carry,
-/area/shuttle/tether)
+/obj/item/device/radio/intercom{
+	dir = 2;
+	pixel_y = -24
+	},
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1";
+	pixel_x = 0
+	},
+/obj/structure/reagent_dispensers/water_cooler/full{
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/recreation_area)
 "aVT" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/steeldecal/steel_decals6,
@@ -28862,12 +28875,10 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/lobby)
 "aVV" = (
-/obj/machinery/atmospherics/unary/engine{
-	dir = 1
-	},
+/obj/structure/shuttle/engine/propulsion,
 /turf/simulated/floor/reinforced,
 /turf/simulated/shuttle/plating/carry,
-/area/shuttle/tourbus/engines)
+/area/shuttle/tether)
 "aVW" = (
 /obj/structure/bed/chair{
 	dir = 1
@@ -29021,6 +29032,13 @@
 /obj/structure/sign/directions/evac,
 /turf/simulated/wall/r_wall,
 /area/tether/surfacebase/security/lobby)
+"aWf" = (
+/obj/machinery/atmospherics/unary/engine{
+	dir = 1
+	},
+/turf/simulated/floor/reinforced,
+/turf/simulated/shuttle/plating/carry,
+/area/shuttle/tourbus/engines)
 "aWg" = (
 /obj/structure/sign/directions/evac{
 	dir = 8
@@ -31746,16 +31764,6 @@
 /obj/structure/bed/chair/wood{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/surface_three_hall)
-"bbv" = (
-/obj/effect/floor_decal/corner/lightgrey{
-	dir = 9
-	},
-/obj/effect/floor_decal/corner/lightgrey{
-	dir = 6
-	},
-/obj/machinery/vending/snack,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_three_hall)
 "bbw" = (
@@ -41892,7 +41900,7 @@ amx
 ana
 anF
 aiI
-aou
+aVS
 akY
 aix
 apQ
@@ -43786,7 +43794,7 @@ mfi
 jHw
 jpB
 qWU
-aVV
+aWf
 aKU
 aOI
 aPb
@@ -44638,7 +44646,7 @@ isR
 jHw
 gHh
 qWU
-aVV
+aWf
 aKU
 aOI
 aPb
@@ -46291,7 +46299,7 @@ akn
 bbq
 aZu
 bbu
-bbv
+aou
 ayx
 aZE
 aZR
@@ -46623,7 +46631,7 @@ aNk
 uSA
 aNJ
 aNP
-aVS
+aVV
 aKU
 abg
 aOk
@@ -46765,7 +46773,7 @@ aNl
 aNl
 aNK
 aNP
-aVS
+aVV
 aKU
 abg
 aOk
@@ -46907,7 +46915,7 @@ aNm
 aNl
 aNK
 aNP
-aVS
+aVV
 aKU
 abg
 aOk
@@ -49437,8 +49445,8 @@ aac
 aac
 aac
 aab
-aab
-aab
+aac
+aac
 aac
 aac
 aac

--- a/maps/tether/tether-05-station1.dmm
+++ b/maps/tether/tether-05-station1.dmm
@@ -12042,19 +12042,17 @@
 /turf/simulated/floor/tiled,
 /area/bridge/secondary/hallway)
 "auO" = (
-/obj/machinery/vending/fitness,
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 10
-	},
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 10
-	},
-/turf/simulated/floor/tiled,
-/area/tether/station/visitorhallway/office)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/maintenance/common,
+/turf/simulated/floor,
+/area/crew_quarters/sleep/cryo)
 "auP" = (
 /obj/machinery/alarm{
 	dir = 8;
@@ -13380,6 +13378,23 @@
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/break_room)
+"awU" = (
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 10
+	},
+/obj/machinery/vending/fitness{
+	icon_state = "fitness";
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/visitorhallway/office)
 "awV" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /turf/simulated/floor/tiled/dark,
@@ -14428,7 +14443,9 @@
 /turf/simulated/floor/tiled,
 /area/tether/station/visitorhallway)
 "ayN" = (
-/obj/structure/reagent_dispensers/water_cooler/full,
+/obj/structure/reagent_dispensers/water_cooler/full{
+	dir = 8
+	},
 /turf/simulated/floor/wood,
 /area/bridge/meeting_room)
 "ayO" = (
@@ -18033,18 +18050,6 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled,
 /area/tether/station/dock_two)
-"aEP" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor/glass,
-/obj/structure/door_assembly,
-/turf/simulated/floor,
-/area/maintenance/station/abandonedholodeck)
 "aER" = (
 /obj/effect/floor_decal/steeldecal/steel_decals5{
 	dir = 1
@@ -32378,7 +32383,7 @@ aCk
 ahU
 ahU
 atw
-auO
+awU
 afI
 avK
 awq
@@ -37337,7 +37342,7 @@ alo
 aCu
 aEG
 aEJ
-aEP
+auO
 baT
 bcO
 baT
@@ -37479,7 +37484,7 @@ alo
 aCy
 aEH
 aEK
-amK
+aus
 aur
 bcK
 bfk
@@ -37621,7 +37626,7 @@ alo
 aCu
 aEI
 aEL
-amK
+aus
 aus
 aus
 aus

--- a/maps/tether/tether-06-station2.dmm
+++ b/maps/tether/tether-06-station2.dmm
@@ -9901,6 +9901,21 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor,
 /area/maintenance/station/exploration)
+"ot" = (
+/obj/structure/shuttle/engine/propulsion{
+	dir = 8;
+	icon_state = "propulsion_l"
+	},
+/turf/space,
+/turf/simulated/shuttle/plating/airless/carry,
+/area/shuttle/large_escape_pod1)
+"ou" = (
+/obj/structure/shuttle/engine/propulsion{
+	dir = 8
+	},
+/turf/space,
+/turf/simulated/shuttle/plating/airless/carry,
+/area/shuttle/large_escape_pod1)
 "ov" = (
 /obj/machinery/door/firedoor/glass,
 /obj/structure/lattice,
@@ -10791,7 +10806,7 @@
 "pS" = (
 /obj/structure/shuttle/engine/propulsion{
 	dir = 8;
-	icon_state = "propulsion_l"
+	icon_state = "propulsion_r"
 	},
 /turf/space,
 /turf/simulated/shuttle/plating/airless/carry,
@@ -16143,6 +16158,18 @@
 /obj/structure/cable/green,
 /turf/simulated/floor,
 /area/maintenance/station/micro)
+"yo" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 5
+	},
+/obj/machinery/vending/medical{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/ward)
 "ys" = (
 /obj/structure/table/standard,
 /obj/item/weapon/reagent_containers/spray/cleaner{
@@ -18345,16 +18372,6 @@
 	},
 /obj/effect/floor_decal/corner/paleblue/bordercorner2{
 	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/ward)
-"Cc" = (
-/obj/machinery/vending/medical,
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 5
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 5
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/ward)
@@ -21842,14 +21859,6 @@
 	},
 /turf/simulated/floor,
 /area/maintenance/station/sec_lower)
-"Rv" = (
-/obj/structure/shuttle/engine/propulsion{
-	dir = 8;
-	icon_state = "propulsion_r"
-	},
-/turf/space,
-/turf/simulated/shuttle/plating/airless/carry,
-/area/shuttle/large_escape_pod1)
 "RB" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
@@ -22420,13 +22429,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/tether/station/public_meeting_room)
-"VO" = (
-/obj/structure/shuttle/engine/propulsion{
-	dir = 8
-	},
-/turf/space,
-/turf/simulated/shuttle/plating/airless/carry,
-/area/shuttle/large_escape_pod1)
 "VU" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
@@ -33248,7 +33250,7 @@ AM
 Bf
 Bq
 BI
-Cc
+yo
 Cw
 Fi
 CW
@@ -37478,11 +37480,11 @@ hl
 DI
 RX
 DL
+ot
+ou
+ou
+ou
 pS
-VO
-VO
-VO
-Rv
 oY
 sW
 ef

--- a/maps/tether/tether-07-station3.dmm
+++ b/maps/tether/tether-07-station3.dmm
@@ -4359,6 +4359,13 @@
 /obj/machinery/portable_atmospherics/canister/air/airlock,
 /turf/simulated/floor/tiled,
 /area/security/eva)
+"hc" = (
+/obj/machinery/atmospherics/unary/engine{
+	dir = 1
+	},
+/turf/simulated/floor/reinforced,
+/turf/simulated/shuttle/plating/airless/carry,
+/area/shuttle/excursion/cargo)
 "hd" = (
 /obj/structure/table/woodentable,
 /obj/machinery/photocopier/faxmachine{
@@ -15808,7 +15815,9 @@
 /obj/effect/floor_decal/corner/red/bordercorner2{
 	dir = 9
 	},
-/obj/structure/reagent_dispensers/water_cooler/full,
+/obj/structure/reagent_dispensers/water_cooler/full{
+	dir = 1
+	},
 /turf/simulated/floor/tiled,
 /area/security/lobby)
 "yw" = (
@@ -16586,7 +16595,6 @@
 /turf/simulated/floor/tiled,
 /area/hallway/station/upper)
 "zG" = (
-/obj/machinery/vending/snack,
 /obj/effect/floor_decal/corner/lightgrey{
 	dir = 9
 	},
@@ -16602,11 +16610,13 @@
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals9{
 	dir = 8
+	},
+/obj/machinery/vending/snack{
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/station/upper)
 "zH" = (
-/obj/machinery/vending/cola,
 /obj/effect/floor_decal/corner/lightgrey{
 	dir = 9
 	},
@@ -16622,11 +16632,13 @@
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals9{
 	dir = 8
+	},
+/obj/machinery/vending/cola{
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/station/upper)
 "zI" = (
-/obj/machinery/vending/cigarette,
 /obj/effect/floor_decal/corner/lightgrey{
 	dir = 9
 	},
@@ -16642,6 +16654,9 @@
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals9{
 	dir = 8
+	},
+/obj/machinery/vending/cigarette{
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/station/upper)
@@ -25864,6 +25879,14 @@
 /obj/effect/map_helper/airlock/atmos/chamber_pump,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/shuttle/medivac/general)
+"NU" = (
+/obj/structure/shuttle/engine/propulsion{
+	dir = 8;
+	icon_state = "propulsion_l"
+	},
+/turf/simulated/floor/tiled/asteroid_steel/airless,
+/turf/simulated/shuttle/plating/airless/carry,
+/area/shuttle/belter)
 "NV" = (
 /obj/machinery/sleeper{
 	dir = 4
@@ -25950,6 +25973,13 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/shuttle/medivac/engines)
+"Oc" = (
+/obj/structure/shuttle/engine/propulsion{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/asteroid_steel/airless,
+/turf/simulated/shuttle/plating/airless/carry,
+/area/shuttle/belter)
 "Od" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/structure/cable/green{
@@ -25967,6 +25997,14 @@
 /obj/effect/map_helper/airlock/door/int_door,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/shuttle/medivac/general)
+"Of" = (
+/obj/structure/shuttle/engine/propulsion{
+	dir = 8;
+	icon_state = "propulsion_r"
+	},
+/turf/simulated/floor/tiled/asteroid_steel/airless,
+/turf/simulated/shuttle/plating/airless/carry,
+/area/shuttle/belter)
 "Og" = (
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 8
@@ -29679,21 +29717,6 @@
 /obj/machinery/light,
 /turf/simulated/shuttle/floor/yellow/airless,
 /area/shuttle/belter)
-"Vy" = (
-/obj/structure/shuttle/engine/propulsion{
-	dir = 8;
-	icon_state = "propulsion_l"
-	},
-/turf/simulated/floor/tiled/asteroid_steel/airless,
-/turf/simulated/shuttle/plating/airless/carry,
-/area/shuttle/belter)
-"Vz" = (
-/obj/structure/shuttle/engine/propulsion{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/asteroid_steel/airless,
-/turf/simulated/shuttle/plating/airless/carry,
-/area/shuttle/belter)
 "VA" = (
 /obj/effect/landmark/start{
 	name = "Medical Doctor"
@@ -29799,14 +29822,6 @@
 "VM" = (
 /turf/simulated/open,
 /area/ai_core_foyer)
-"VN" = (
-/obj/structure/shuttle/engine/propulsion{
-	dir = 8;
-	icon_state = "propulsion_r"
-	},
-/turf/simulated/floor/tiled/asteroid_steel/airless,
-/turf/simulated/shuttle/plating/airless/carry,
-/area/shuttle/belter)
 "VP" = (
 /obj/machinery/atmospherics/unary/engine{
 	icon_state = "nozzle";
@@ -30392,13 +30407,6 @@
 "Xy" = (
 /turf/simulated/wall/rshull,
 /area/shuttle/medivac/cockpit)
-"Xz" = (
-/obj/machinery/atmospherics/unary/engine{
-	dir = 1
-	},
-/turf/simulated/floor/reinforced,
-/turf/simulated/shuttle/plating/airless/carry,
-/area/shuttle/excursion/cargo)
 "XB" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -42256,7 +42264,7 @@ UJ
 Xb
 Wp
 WV
-Xz
+hc
 ms
 Xq
 be
@@ -42398,7 +42406,7 @@ Wt
 WS
 Wp
 XN
-Xz
+hc
 ms
 Xq
 be
@@ -43534,7 +43542,7 @@ kQ
 TG
 Wp
 XN
-Xz
+hc
 ms
 mq
 be
@@ -43676,7 +43684,7 @@ kR
 Vd
 Wp
 XD
-Xz
+hc
 ms
 QL
 be
@@ -45000,11 +45008,11 @@ Ty
 TL
 QG
 Ue
-Vy
-Vz
-Vz
-Vz
-VN
+NU
+Oc
+Oc
+Oc
+Of
 VH
 vt
 vt

--- a/maps/tether/tether-08-mining.dmm
+++ b/maps/tether/tether-08-mining.dmm
@@ -637,6 +637,24 @@
 	},
 /turf/simulated/floor/plating,
 /area/outpost/mining_main/maintenance)
+"bt" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 10
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/brown/bordercorner2{
+	dir = 8
+	},
+/obj/machinery/vending/cola{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/outpost/mining_main/break_room)
 "bu" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -818,6 +836,32 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/mining_main/break_room)
+"bM" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/brown/border,
+/obj/machinery/vending/coffee{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/outpost/mining_main/break_room)
+"bN" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 6
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/brown/bordercorner2{
+	dir = 6
+	},
+/obj/machinery/vending/snack{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/outpost/mining_main/break_room)
 "bW" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/brown/border,
@@ -933,22 +977,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/turf/simulated/floor/tiled,
-/area/outpost/mining_main/break_room)
-"kB" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 10
-	},
-/obj/effect/floor_decal/corner/brown/border{
-	dir = 10
-	},
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/brown/bordercorner2{
-	dir = 8
-	},
-/obj/machinery/vending/cola,
 /turf/simulated/floor/tiled,
 /area/outpost/mining_main/break_room)
 "qx" = (
@@ -1087,12 +1115,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/mining_main/maintenance)
-"DV" = (
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/brown/border,
-/obj/machinery/vending/coffee,
-/turf/simulated/floor/tiled,
-/area/outpost/mining_main/break_room)
 "DX" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -1302,22 +1324,6 @@
 /obj/structure/table/woodentable,
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/machinery/recharger,
-/turf/simulated/floor/tiled,
-/area/outpost/mining_main/break_room)
-"US" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 6
-	},
-/obj/effect/floor_decal/corner/brown/border{
-	dir = 6
-	},
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 6
-	},
-/obj/effect/floor_decal/corner/brown/bordercorner2{
-	dir = 6
-	},
-/obj/machinery/vending/snack,
 /turf/simulated/floor/tiled,
 /area/outpost/mining_main/break_room)
 "VG" = (
@@ -4950,7 +4956,7 @@ bv
 ZV
 ty
 Fn
-kB
+bt
 az
 ab
 aF
@@ -5092,7 +5098,7 @@ bg
 Uk
 Uk
 by
-DV
+bM
 az
 ab
 aF
@@ -5234,7 +5240,7 @@ hW
 bK
 bL
 by
-US
+bN
 az
 ab
 aF

--- a/maps/tether/tether-09-solars.dmm
+++ b/maps/tether/tether-09-solars.dmm
@@ -1428,6 +1428,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/rnd/outpost/eva)
+"cZ" = (
+/obj/machinery/vending/phoronresearch{
+	dir = 8;
+	name = "Toximate 2556";
+	products = list(/obj/item/device/transfer_valve = 3, /obj/item/device/assembly/timer = 6, /obj/item/device/assembly/signaler = 6, /obj/item/device/assembly/prox_sensor = 6, /obj/item/device/assembly/igniter = 12)
+	},
+/turf/simulated/floor/tiled,
+/area/rnd/outpost/testing)
 "da" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 2;
@@ -1630,6 +1638,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/outpost/eva)
+"dA" = (
+/obj/machinery/vending/coffee{
+	icon_state = "coffee";
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/rnd/outpost/breakroom)
 "dB" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 4;
@@ -1655,6 +1670,12 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/outpost/airlock)
+"dD" = (
+/obj/machinery/vending/snack{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/rnd/outpost/breakroom)
 "dE" = (
 /turf/simulated/wall,
 /area/maintenance/substation/outpost)
@@ -1793,12 +1814,12 @@
 /turf/simulated/floor/tiled,
 /area/rnd/outpost/testing)
 "dV" = (
-/obj/machinery/vending/phoronresearch{
-	name = "Toximate 2556";
-	products = list(/obj/item/device/transfer_valve = 3, /obj/item/device/assembly/timer = 6, /obj/item/device/assembly/signaler = 6, /obj/item/device/assembly/prox_sensor = 6, /obj/item/device/assembly/igniter = 12)
+/obj/machinery/vending/cola{
+	icon_state = "Soda_Machine";
+	dir = 8
 	},
 /turf/simulated/floor/tiled,
-/area/rnd/outpost/testing)
+/area/rnd/outpost/breakroom)
 "dW" = (
 /obj/machinery/requests_console/preset/research{
 	pixel_y = -30
@@ -7953,23 +7974,16 @@
 /turf/simulated/floor/tiled,
 /area/rnd/outpost/breakroom)
 "oC" = (
-/obj/machinery/vending/coffee,
+/obj/machinery/vending/fitness{
+	dir = 8;
+	icon_state = "fitness"
+	},
 /turf/simulated/floor/tiled,
 /area/rnd/outpost/breakroom)
 "oD" = (
-/obj/machinery/vending/snack,
-/turf/simulated/floor/tiled,
-/area/rnd/outpost/breakroom)
-"oE" = (
-/obj/machinery/vending/cola,
-/turf/simulated/floor/tiled,
-/area/rnd/outpost/breakroom)
-"oF" = (
-/obj/machinery/vending/fitness,
-/turf/simulated/floor/tiled,
-/area/rnd/outpost/breakroom)
-"oG" = (
-/obj/machinery/vending/cigarette,
+/obj/machinery/vending/cigarette{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/rnd/outpost/breakroom)
 "oH" = (
@@ -23349,7 +23363,7 @@ cf
 cx
 cU
 dv
-dV
+cZ
 cf
 eU
 ft
@@ -24649,7 +24663,7 @@ oI
 mm
 nf
 ni
-oG
+oD
 oP
 oX
 eE
@@ -25071,10 +25085,10 @@ kB
 lh
 lx
 ks
+dA
+dD
+dV
 oC
-oD
-oE
-oF
 oM
 pb
 pc


### PR DESCRIPTION
With directional vendors most were rotated to make sense. Not all though. Fixes that and rotates ones unrotated. Also watercoolers.

Two minor changes unrelated to vendomat/cooler rotations:

- Adds two grass turfs outside bar on Asteroid 3 to cover ugly sticking out wall and window from floor below.

- Replaces broken door in cryo maintenance with functioning one... This one is primarily for consistency with how construction area appear. They all have functional entrance, but nothing inside is functional.

Full list of changed vendomats/coolers:

- R&D breakroom, from facing south to north.

- Surface Security, sec vendomat from south to west

- Atrium floor 3, seating area in the northeast, vendomats from south to north

- Watercooler in the gym, from south to west

- Sweatmax in meeting room on asteroid 1, from south to east

- Asteroid Bridge meeting room, cooler from south to west

- Recovery ward, medvendor from south to west

- Security lobby, cooler from south to north

- Vendomats in hallway to cargo, from south to north

- Vendomats in mining outpost, from south to north

- Vendomats in science outpost breakroom, all to west except one on western wall which to east

- Toxin vendomat in testing room of outpost, from south to west.