### PR TITLE
Makes fish meat non-toxic for Virgo

### DIFF
--- a/code/modules/food/food/snacks_vr.dm
+++ b/code/modules/food/food/snacks_vr.dm
@@ -750,3 +750,14 @@
 	)
 	can_hold = list(/obj/item/weapon/reagent_containers/food/snacks/cube/protein,
 					/obj/item/weapon/reagent_containers/food/snacks/cube/nutriment)
+
+/obj/item/weapon/reagent_containers/food/snacks/carpmeat/sif //Making fish meat non-toxic!  As advised by Ascian!
+    toxin_type = null
+    toxin_amount = null
+
+/obj/item/weapon/reagent_containers/food/snacks/carpmeat/sif/murkfish
+    toxin_type = null
+
+/obj/item/weapon/reagent_containers/food/snacks/carpmeat/fish
+	toxin_type = null
+    toxin_amount = null


### PR DESCRIPTION
As advised by Ascian, this PR makes it so that fish meat isn't toxic!  Doesn't affect base carp meat, though, carpotoxin is still a thing.  But now you can have your non-carp fish fillets without being poisoned!