### PR TITLE
Conversion Kit Overhaul

### DIFF
--- a/code/modules/vore/fluffstuff/custom_items_vr.dm
+++ b/code/modules/vore/fluffstuff/custom_items_vr.dm
@@ -143,7 +143,7 @@
 /obj/item/device/modkit_conversion/fluff/debug_gunkit
 	name = "Gun Transformation Kit"
 	desc = "A kit containing all the needed tools and fabric to modify one sidearm to another."
-	skip_contents = FALSE
+	skip_content_check = FALSE
 	transfer_contents = FALSE
 
 	icon = 'icons/vore/custom_items_vr.dmi'

--- a/code/modules/vore/fluffstuff/custom_items_vr.dm
+++ b/code/modules/vore/fluffstuff/custom_items_vr.dm
@@ -45,7 +45,7 @@
 	
 	var/owner_ckey = null		//ckey of the kit owner as a string
 	var/skip_contents = FALSE	//can we skip the contents check? we generally shouldn't, but this is necessary for rigs/coats with hoods/etc.
-	var/transfer_contents = FALSE	//should we transfer the contents across before deleting? we generally shouldn't, esp. in the case of rigs/coats with hoods/etc.
+	var/transfer_contents = FALSE	//should we transfer the contents across before deleting? we generally shouldn't, esp. in the case of rigs/coats with hoods/etc. note this does nothing if skip is FALSE.
 	var/can_repair = FALSE		//can we be used to repair damaged voidsuits when converting them?
 	var/can_revert = TRUE		//can we revert items, or is it a one-way trip?
 	var/delete_on_empty = FALSE	//do we self-delete when emptied?
@@ -56,7 +56,8 @@
 	var/to_type
 	var/keycheck
 	if(istype(O,/obj/item/clothing/suit/space/void/) && !can_repair) //check if we're a voidsuit and if we're allowed to repair
-		if(O:breaches.len)	//this has to be underneath the istype or it'll spit a runtime if used on non-voidsuits
+		var/obj/item/clothing/suit/space/void/SS = O
+		if(LAZYLEN(SS.breaches))
 			to_chat(user, "<span class='warning'>You should probably repair that before you start tinkering with it.</span>")
 			return
 	if(isturf(O)) //silently fail if you click on a turf. shouldn't work anyway because turfs aren't objects but if I don't do this it spits runtimes. 
@@ -114,23 +115,43 @@
 	if(skip_contents && transfer_contents)
 		N.contents = O.contents
 		if(istype(N,/obj/item/weapon/gun/projectile/))
-			N:magazine_type = O:magazine_type
-			N:ammo_magazine = O:ammo_magazine
+			var/obj/item/weapon/gun/projectile/NN = N
+			var/obj/item/weapon/gun/projectile/OO = O
+			NN.magazine_type = OO.magazine_type
+			NN.ammo_magazine = OO.ammo_magazine
 		if(istype(N,/obj/item/weapon/gun/energy/))
-			N:cell_type = O:cell_type
+			var/obj/item/weapon/gun/energy/NE = N
+			var/obj/item/weapon/gun/energy/OE = O
+			NE.cell_type = OE.cell_type
 	else	//nuke any ammo it'd normally spawn with, if it's a gun, to prevent ammo duplication. we have to do this just for guns, not immediately under the else, or it breaks default attachments like hoods and suit storage
 		if(istype(N,/obj/item/weapon/gun/projectile/))
-			N:contents = list()
-			N:magazine_type = null
-			N:ammo_magazine = null
+			var/obj/item/weapon/gun/projectile/NM = N
+			NM.contents = list()
+			NM.magazine_type = null
+			NM.ammo_magazine = null
 		if(istype(N,/obj/item/weapon/gun/energy/))
-			N:contents = list()
-			N:cell_type = null
+			var/obj/item/weapon/gun/energy/NO = N
+			NO.contents = list()
+			NO.cell_type = null
 	
 	qdel(O)
 	parts -= cost
 	if(!parts && delete_on_empty)
 		qdel(src)
+
+//DEBUG ITEM
+/obj/item/device/modkit_conversion/fluff/debug_gunkit
+	name = "Gun Transformation Kit"
+	desc = "A kit containing all the needed tools and fabric to modify one sidearm to another."
+	skip_contents = FALSE
+	transfer_contents = FALSE
+
+	icon = 'icons/vore/custom_items_vr.dmi'
+	icon_state = "harmony_kit"
+
+	from_helmet = /obj/item/weapon/gun/energy/laser
+	to_helmet = /obj/item/weapon/gun/energy/retro
+//DEBUG ITEM ENDS
 
 //JoanRisu:Joan Risu
 /obj/item/weapon/flame/lighter/zippo/fluff/joan

--- a/code/modules/vore/fluffstuff/custom_items_vr.dm
+++ b/code/modules/vore/fluffstuff/custom_items_vr.dm
@@ -36,34 +36,100 @@
 	var/from_suit = /obj/item/clothing/suit/space/void
 	var/to_helmet = /obj/item/clothing/head/cardborg
 	var/to_suit = /obj/item/clothing/suit/cardborg
-
+	
+	//conversion costs. refunds all parts by default, but can be tweaked per-kit
+	var/from_helmet_cost = 1
+	var/from_suit_cost = 2
+	var/to_helmet_cost = -1
+	var/to_suit_cost = -2
+	
+	var/owner_ckey = null		//ckey of the kit owner as a string
+	var/skip_contents = FALSE	//can we skip the contents check? we generally shouldn't, but this is necessary for rigs/coats with hoods/etc.
+	var/transfer_contents = FALSE	//should we transfer the contents across before deleting? we generally shouldn't, esp. in the case of rigs/coats with hoods/etc.
+	var/can_repair = FALSE		//can we be used to repair damaged voidsuits when converting them?
+	var/can_revert = TRUE		//can we revert items, or is it a one-way trip?
+	var/delete_on_empty = FALSE	//do we self-delete when emptied?
+	
 	//Conversion proc
 /obj/item/device/modkit_conversion/afterattack(obj/O, mob/user as mob)
-	var/flag
+	var/cost
 	var/to_type
-	if(istype(O,from_helmet))
-		flag = 1
+	var/keycheck
+	if(istype(O,/obj/item/clothing/suit/space/void/) && !can_repair) //check if we're a voidsuit and if we're allowed to repair
+		if(O:breaches.len)	//this has to be underneath the istype or it'll spit a runtime if used on non-voidsuits
+			to_chat(user, "<span class='warning'>You should probably repair that before you start tinkering with it.</span>")
+			return
+	if(isturf(O)) //silently fail if you click on a turf. shouldn't work anyway because turfs aren't objects but if I don't do this it spits runtimes. 
+		return
+	if(O.blood_DNA || O.contaminated) //check if we're bloody or gooey or whatever, so modkits can't be used to hide crimes easily.
+		to_chat(user, "<span class='warning'>You should probably clean that up before you start tinkering with it.</span>")
+		return
+	//we have to check that it's not the original type first, because otherwise it might convert wrong based on pathing; the subtype can still count as the basetype
+	if(istype(O,to_helmet) && can_revert)
+		cost = to_helmet_cost
+		to_type = from_helmet
+	else if(istype(O,to_suit) && can_revert)
+		cost = to_suit_cost
+		to_type = from_suit
+	else if(!can_revert && (istype(O,to_helmet) || istype (O,to_suit)))
+		to_chat(user, "<span class='warning'>This kit doesn't seem to have the tools necessary to revert changes to modified items.</span>")
+		return
+	else if(istype(O,from_helmet))
+		cost = from_helmet_cost
 		to_type = to_helmet
+		keycheck = TRUE
 	else if(istype(O,from_suit))
-		flag = 2
+		cost = from_suit_cost
 		to_type = to_suit
+		keycheck = TRUE
 	else
 		return
-	if(!(parts & flag))
-		to_chat(user, "<span class='warning'>This kit has no parts for this modification left.</span>")
-		return
-	if(istype(O,to_type))
-		to_chat(user, "<span class='notice'>[O] is already modified.</span>")
-		return
 	if(!isturf(O.loc))
-		to_chat(user, "<span class='warning'>[O] must be safely placed on the ground for modification.</span>")
+		to_chat(user, "<span class='warning'>You need to put \the [O] on the ground, a table, or other worksurface before modifying it.</span>")
 		return
+	if(!skip_contents && O.contents.len) //check if we're loaded/modified, in the event of gun/suit kits, to avoid purging stuff like ammo, badges, armbands, or suit helmets
+		to_chat(user, "<span class='warning'>You should probably remove any attached items or loaded ammunition before trying to modify that!</span>")
+		return
+	if(cost > parts)
+		to_chat(user, "<span class='warning'>The kit doesn't have enough parts left to modify that.</span>")
+		if(can_revert && ((to_helmet_cost || to_suit_cost) < 0))
+			to_chat(user, "<span class='notice'> You can recover parts by using the kit on an already-modified item.</span>")
+		return
+	if(keycheck && owner_ckey) //check if we're supposed to care
+		if(user.ckey != owner_ckey) //ERROR: UNAUTHORIZED USER
+			to_chat(user, "<span class='warning'>You probably shouldn't mess with all these strange tools and parts...</span>") //give them a slightly fluffy explanation as to why it didn't work
+			return
 	playsound(user.loc, 'sound/items/Screwdriver.ogg', 100, 1)
-	var/N = new to_type(O.loc)
-	user.visible_message("<span class='warning'>[user] opens \the [src] and modifies \the [O] into \the [N].</span>","<span class='warning'>You open \the [src] and modify \the [O] into \the [N].</span>")
+	var/obj/N = new to_type(O.loc)
+	user.visible_message("<span class='notice'>[user] opens \the [src] and modifies \the [O] into \the [N].</span>","<span class='notice'>You open \the [src] and modify \the [O] into \the [N].</span>")
+	
+	//crude, but transfer prints and fibers to avoid forensics abuse, same as the bloody/gooey check above
+	N.fingerprints = O.fingerprints
+	N.fingerprintshidden = O.fingerprintshidden
+	N.fingerprintslast = O.fingerprintslast
+	N.suit_fibers = O.suit_fibers
+	
+	//I don't like using the lookdown checks here but fuck it, it works. the istypes are essential though, or else it runtimes and won't get to the qdel for the source item, allowing item duping
+	//transfer logic could technically be made more thorough and handle stuff like helmet/boots/tank vars for suits, but in those cases you should be removing the items first anyway
+	if(skip_contents && transfer_contents)
+		N.contents = O.contents
+		if(istype(N,/obj/item/weapon/gun/projectile/))
+			N:magazine_type = O:magazine_type
+			N:ammo_magazine = O:ammo_magazine
+		if(istype(N,/obj/item/weapon/gun/energy/))
+			N:cell_type = O:cell_type
+	else	//nuke any ammo it'd normally spawn with, if it's a gun, to prevent ammo duplication. we have to do this just for guns, not immediately under the else, or it breaks default attachments like hoods and suit storage
+		if(istype(N,/obj/item/weapon/gun/projectile/))
+			N:contents = list()
+			N:magazine_type = null
+			N:ammo_magazine = null
+		if(istype(N,/obj/item/weapon/gun/energy/))
+			N:contents = list()
+			N:cell_type = null
+	
 	qdel(O)
-	parts &= ~flag
-	if(!parts)
+	parts -= cost
+	if(!parts && delete_on_empty)
 		qdel(src)
 
 //JoanRisu:Joan Risu


### PR DESCRIPTION
This is basically a port of [this PR](https://github.com/Yawn-Wider/YWPolarisVore/pull/683), which massively reworks fluff conversion kits so they can be safely used for a wider range of items.

To summarize for those who don't want to click through;
- Kits can be used to revert items back into their original format
- Various forensic evidence persists through item conversion
- Items can't be converted if they're bloody, contaminated, or breached (breach check can be overridden to permit repairs via kits)
- Items that have stuff loaded or attached can't be converted unless an override is enabled on the kit (see below), to avoid deleting things (e.g. ammo, suit helmets, sec badges)
- Ammunition/cells are deleted from guns spawned by conversion, ties into the above to avoid ammo duplication (gun can't be converted when loaded: empty gun, convert, load new gun with old mag)
- Kits have a bunch of flags that do things like prevent non-owners from using them, disable reverting items to their original type, allow contents to be transferred when converting, what conversion costs, whether kits self-delete when empty, and so on

I've given this a fair bit of testing but I'm sure I've missed a couple of edge-cases, overlooked some stuff, and done things messily. Constructive feedback would be appreciated.