### PR TITLE
Re-enables Slime Vore reaction, adjusts blocked lists for slimespawn reactions

### DIFF
--- a/code/modules/reagents/Chemistry-Recipes_vr.dm
+++ b/code/modules/reagents/Chemistry-Recipes_vr.dm
@@ -207,12 +207,18 @@
 
 		var/blocked = list(
 							/obj/item/stack/material,					//Technical stacks
-							/obj/item/stack/material/animalhide,
+							/obj/item/stack/material/hairlesshide,		//Useless leather production steps
+							/obj/item/stack/material/wetleather,
+							/obj/item/stack/material/algae/ten)			//Why is this one even a separate thing
+		blocked += typesof(/obj/item/stack/material/cyborg)				//Borg matter synths, should only exist in borgs
+		blocked += typesof(/obj/item/stack/material/animalhide)			//Hides which are only used for leather production anyway
+
+		var/rare_types = list(
 							/obj/item/stack/material/morphium,			//Complex materials requiring Particle Smasher to create
 							/obj/item/stack/material/morphium/hull,
 							/obj/item/stack/material/valhollide,
 							/obj/item/stack/material/supermatter)
-		blocked += typesof(/obj/item/stack/material/cyborg)				//Borg matter synths, should only exist in borgs
+
 		var/list/material = typesof(/obj/item/stack/material) - blocked
 
 		playsound(get_turf(holder.my_atom), 'sound/effects/phasein.ogg', 100, 1)
@@ -223,6 +229,8 @@
 */
 		var/spawn_amount = rand(1,50)
 		var/chosen = pick(material)
+		if(chosen in rare_types)
+			spawn_amount = rand(1,15)
 		var/obj/item/stack/material/C = new chosen
 		C.amount = spawn_amount
 		C.loc = get_turf(holder.my_atom)

--- a/code/modules/reagents/Chemistry-Recipes_vr.dm
+++ b/code/modules/reagents/Chemistry-Recipes_vr.dm
@@ -205,7 +205,14 @@
 				O.show_message(text("<span class='warning'>The slime core fizzles disappointingly.</span>"), 1)
 			return
 
-		var/blocked = list(/obj/item/stack/material, /obj/item/stack/material/cyborg, /obj/item/stack/material/cyborg/plastic, /obj/item/stack/material/cyborg/plasteel, /obj/item/stack/material/cyborg/glass/reinforced, /obj/item/stack/material/cyborg/wood, /obj/item/stack/material/animalhide/human, /obj/item/stack/material/animalhide/corgi, /obj/item/stack/material/animalhide/cat, /obj/item/stack/material/animalhide/monkey, /obj/item/stack/material/animalhide/lizard , /obj/item/stack/material/animalhide/xeno, /obj/item/stack/material/cyborg, /obj/item/stack/material/cyborg/glass/reinforced)
+		var/blocked = list(
+							/obj/item/stack/material,					//Technical stacks
+							/obj/item/stack/material/animalhide,
+							/obj/item/stack/material/morphium,			//Complex materials requiring Particle Smasher to create
+							/obj/item/stack/material/morphium/hull,
+							/obj/item/stack/material/valhollide,
+							/obj/item/stack/material/supermatter)
+		blocked += typesof(/obj/item/stack/material/cyborg)				//Borg matter synths, should only exist in borgs
 		var/list/material = typesof(/obj/item/stack/material) - blocked
 
 		playsound(get_turf(holder.my_atom), 'sound/effects/phasein.ogg', 100, 1)
@@ -323,10 +330,6 @@
 	required_reagents = list("phoron" = 20, "sugar" = 50, "lithium" = 50) //In case a xenobiologist is impatient and is willing to drain their dispenser resources, along with plasma!
 	result_amount = 5
 
-
-
-
-/* //VORESTATION AI TEMPORARY REMOVAL
 /datum/chemical_reaction/slimevore
 	name = "Slime Vore" // Hostile vore mobs only
 	id = "m_tele"
@@ -335,12 +338,44 @@
 	result_amount = 1
 	on_reaction(var/datum/reagents/holder)
 		var/mob_path = /mob/living/simple_mob
-		var/blocked = list(
-			/mob/living/simple_mob/hostile/mimic,
-			/mob/living/simple_mob/animal/space/alien/queen,
-			/mob/living/simple_mob/shadekin
+		var/blocked = list(														//List of things we do NOT want to spawn
+			/mob/living/simple_mob,												//Technical parent mobs
+			/mob/living/simple_mob/animal,
+			/mob/living/simple_mob/animal/passive,
+			/mob/living/simple_mob/animal/space,
+			/mob/living/simple_mob/blob,
+			/mob/living/simple_mob/mechanical,
+			/mob/living/simple_mob/mechanical/mecha,
+			/mob/living/simple_mob/slime,
+			/mob/living/simple_mob/vore,
+			/mob/living/simple_mob/vore/aggressive,
+			/mob/living/simple_mob/illusion,									//Other technical mobs
+			/mob/living/simple_mob/animal/passive/crab/Coffee,					//Unique pets/named mobs
+			/mob/living/simple_mob/animal/passive/cat/runtime,
+			/mob/living/simple_mob/animal/passive/cat/bones,
+			/mob/living/simple_mob/animal/passive/cat/tabiranth,
+			/mob/living/simple_mob/animal/passive/dog/corgi/puppy/Bockscar,
+			/mob/living/simple_mob/animal/passive/dog/corgi/Ian,
+			/mob/living/simple_mob/animal/passive/dog/corgi/Lisa,
+			/mob/living/simple_mob/animal/passive/dog/tamaskan/Spice,
+			/mob/living/simple_mob/animal/passive/fox/renault,
+			/mob/living/simple_mob/animal/passive/bird/azure_tit/tweeter,
+			/mob/living/simple_mob/animal/passive/bird/parrot/poly,
+			/mob/living/simple_mob/animal/sif/fluffy,
+			/mob/living/simple_mob/animal/sif/fluffy/silky,
+			/mob/living/simple_mob/animal/passive/snake/noodle,
+			/mob/living/simple_mob/slime/xenobio/rainbow/kendrick,
+			/mob/living/simple_mob/animal/space/space_worm,						//Space Worm parts that aren't proper heads
+			/mob/living/simple_mob/animal/space/space_worm/head/severed,
+			/mob/living/simple_mob/animal/borer,								//Event/player-control-only mobs
+			/mob/living/simple_mob/vore/hostile/morph
 			)//exclusion list for things you don't want the reaction to create.
-		var/list/voremobs = typesof(mob_path) - mob_path - blocked // list of possible hostile mobs
+		blocked += typesof(/mob/living/simple_mob/mechanical/ward)				//Wards that should be created with ward items, are mobs mostly on technicalities
+		blocked += typesof(/mob/living/simple_mob/construct)					//Should only exist
+		blocked += typesof(/mob/living/simple_mob/vore/demon)					//as player-controlled
+		blocked += typesof(/mob/living/simple_mob/shadekin)						//and/or event things
+		blocked += typesof(/mob/living/simple_mob/horror)
+		var/list/voremobs = typesof(mob_path) - blocked // list of possible hostile mobs
 
 		playsound(get_turf(holder.my_atom), 'sound/effects/phasein.ogg', 100, 1)
 /* Removed at some point, unsure what to replace with
@@ -351,13 +386,13 @@
 		var/spawn_count = rand(1,3)
 		for(var/i = 1, i <= spawn_count, i++)
 			var/chosen = pick(voremobs)
-			var/mob/living/simple_mob/hostile/C = new chosen
+			var/mob/living/simple_mob/C = new chosen
 			C.faction = "slimesummon"
 			C.loc = get_turf(holder.my_atom)
 			if(prob(50))
 				for(var/j = 1, j <= rand(1, 3), j++)
 					step(C, pick(NORTH,SOUTH,EAST,WEST))
-*/
+
 
 /datum/chemical_reaction/food/syntiflesh
 	required_reagents = list("blood" = 5, "clonexadone" = 1)


### PR DESCRIPTION
Re-enables slime vore reaction, which spawns a bunch of random simplemobs.

Heavily readjusts the blocked mobs list though. Now the mobs that cannot be spawned are:

- Technical mobs that only exist to pass on traits to subtypes
- Technical mobs that are things coded as mobs but don't really function as such
- Unique mobs, primarily named pets
- Mobs exclusive to events and/or lacking any sort of AI and designed to be player-controlled (such as shadekin, cult constructs, etc)
Also, the mimic and alien queen can now be spawned by it. Mimic was forbidden because in the old  mob system mob itself was technical, but not anymore, and alien queen... well, no idea there. Its not like it spawned eggs or anything, and animal Empress and Princess COULD spawn, which are just different looking queens anyway.


Also adjusts the Slime Resources reaction and makes its spawn list more readable, with some adjustments:

- Can no longer spawn Particle Smasher-exclusive sheets
- Can spawn animal hides (why were they forbidden from it in the first place?)
- Rather than mentioning every /cyborg sheet subtype, entire subtype is blanket-forbidden