### PR TITLE
Fixes dirs on previously dirless consoles

### DIFF
--- a/maps/submaps/engine_submaps/engine_sme.dmm
+++ b/maps/submaps/engine_submaps/engine_sme.dmm
@@ -728,7 +728,7 @@
 /area/template_noop)
 "bB" = (
 /obj/machinery/computer/general_air_control/supermatter_core{
-	dir = 1;
+	dir = 2;
 	frequency = 1438;
 	input_tag = "cooling_in";
 	name = "Engine Cooling Control";

--- a/maps/tether/tether-02-surface2.dmm
+++ b/maps/tether/tether-02-surface2.dmm
@@ -17584,6 +17584,7 @@
 	dir = 1
 	},
 /obj/machinery/computer/general_air_control/large_tank_control{
+	dir = 4;
 	frequency = 1441;
 	input_tag = "atmos_out";
 	name = "Atmos Intake Control";

--- a/maps/tether/tether-03-surface3.dmm
+++ b/maps/tether/tether-03-surface3.dmm
@@ -28876,10 +28876,11 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/lobby)
 "aVV" = (
-/obj/structure/shuttle/engine/propulsion,
-/turf/simulated/floor/reinforced,
-/turf/simulated/shuttle/plating/carry,
-/area/shuttle/tether)
+/obj/machinery/account_database{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/crew_quarters/heads/hop)
 "aVW" = (
 /obj/structure/bed/chair{
 	dir = 1
@@ -29034,12 +29035,10 @@
 /turf/simulated/wall/r_wall,
 /area/tether/surfacebase/security/lobby)
 "aWf" = (
-/obj/machinery/atmospherics/unary/engine{
-	dir = 1
-	},
+/obj/structure/shuttle/engine/propulsion,
 /turf/simulated/floor/reinforced,
 /turf/simulated/shuttle/plating/carry,
-/area/shuttle/tourbus/engines)
+/area/shuttle/tether)
 "aWg" = (
 /obj/structure/sign/directions/evac{
 	dir = 8
@@ -29082,6 +29081,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_three_hall)
+"aWj" = (
+/obj/machinery/atmospherics/unary/engine{
+	dir = 1
+	},
+/turf/simulated/floor/reinforced,
+/turf/simulated/shuttle/plating/carry,
+/area/shuttle/tourbus/engines)
 "aWl" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -31416,10 +31422,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/bridge)
-"bax" = (
-/obj/machinery/account_database,
-/turf/simulated/floor/tiled,
-/area/crew_quarters/heads/hop)
 "bay" = (
 /obj/structure/grille,
 /obj/machinery/door/firedoor/glass,
@@ -43795,7 +43797,7 @@ mfi
 jHw
 jpB
 qWU
-aWf
+aWj
 aKU
 aOI
 aPb
@@ -44647,7 +44649,7 @@ isR
 jHw
 gHh
 qWU
-aWf
+aWj
 aKU
 aOI
 aPb
@@ -46022,7 +46024,7 @@ aZC
 aZC
 aZC
 aZC
-bax
+aVV
 baV
 bao
 bap
@@ -46632,7 +46634,7 @@ aNk
 uSA
 aNJ
 aNP
-aVV
+aWf
 aKU
 abg
 aOk
@@ -46774,7 +46776,7 @@ aNl
 aNl
 aNK
 aNP
-aVV
+aWf
 aKU
 abg
 aOk
@@ -46916,7 +46918,7 @@ aNm
 aNl
 aNK
 aNP
-aVV
+aWf
 aKU
 abg
 aOk

--- a/maps/tether/tether-09-solars.dmm
+++ b/maps/tether/tether-09-solars.dmm
@@ -431,12 +431,14 @@
 /area/rnd/outpost)
 "aR" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/power/solar_control,
 /obj/structure/cable/yellow{
 	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/cable/yellow,
+/obj/machinery/power/solar_control{
+	dir = 1
+	},
 /turf/simulated/floor/virgo3b_indoors,
 /area/tether/outpost/solars_shed)
 "aS" = (


### PR DESCRIPTION
Might be more of those but those 3 are only ones I remember off the top of my head.

Fixes wrong dirs on Account console in HoP's office, engine gas console on Supermatter submap and gas sensor console in Atmos.

Edit: I knew I was forgetting one. Solars control console too.