### PR TITLE
Abstract Eating of Ore to Fix Unintentional Prompt

### DIFF
--- a/code/modules/mining/ore.dm
+++ b/code/modules/mining/ore.dm
@@ -128,7 +128,7 @@
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
 		if(H.species.eat_ore == 1)
-			H.eat_ore(src)
+			H.handle_eat_ore(src)
 			return
 	..()
 //VOREStation Add End

--- a/code/modules/vore/eating/living_vr.dm
+++ b/code/modules/vore/eating/living_vr.dm
@@ -689,11 +689,14 @@
 	to_chat(src, "<span class='notice'>This item is not appropriate for ethical consumption.</span>")
 	return
 
-/mob/living/proc/eat_ore(var/obj/item/snack)
+/mob/living/proc/eat_ore() //Actual eating abstracted so the user isn't given a prompt due to an argument in this verb.
 	set name = "Eat Ore"
 	set category = "Abilities"
 	set desc = "Consume held ore and gems. Snack time!"
 
+	handle_eat_ore()
+
+/mob/living/proc/handle_eat_ore(obj/item/snack)
 	if(!vore_selected)
 		to_chat(src, "<span class='warning'>You either don't have a belly selected, or don't have a belly!</span>")
 		return


### PR DESCRIPTION
Using the verb with nothing in your hand brings up a prompt to select an object due to the argument in the verb.

This resolves the issue, instead just showing the "nothing in your hand" message as intended.

Caused this myself in #7085

The issue:
![virgo ss13 eat-ore bug when nothing in hands 20200403](https://user-images.githubusercontent.com/12377767/78417543-a6586d00-7622-11ea-94fc-6ef5a33c11ee.PNG)
