### PR TITLE
Fixes mob update_transform proc and mouse sizing

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1195,7 +1195,7 @@ default behaviour is:
 	var/matrix/M = matrix()
 	M.Scale(desired_scale_x, desired_scale_y)
 	M.Translate(0, 16*(desired_scale_y-1))
-	//animate(src, transform = M, time = 10) //VOREStation edit
+	src.transform = M //VOREStation edit
 
 // This handles setting the client's color variable, which makes everything look a specific color.
 // This proc is here so it can be called without needing to check if the client exists, or if the client relogs.

--- a/code/modules/mob/living/simple_mob/subtypes/animal/passive/mouse_vr.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/passive/mouse_vr.dm
@@ -9,7 +9,6 @@
 
 	desc = "A small rodent, often seen hiding in maintenance areas and making a nuisance of itself. And stealing cheese, or annoying the chef. SQUEAK! <3"
 
-	size_multiplier = 0.25
 	movement_cooldown = 1.5 //roughly half the speed of a person
 	universal_understand = 1
 
@@ -51,8 +50,3 @@
 			return 0
 	else
 		..()
-
-/mob/living/simple_mob/animal/passive/mouse/resize(var/new_size, var/animate = TRUE)
-	size_multiplier = max(size_multiplier + 0.75, 1) //keeps sprite sizes consistent, keeps multiplier values low
-	..()
-	size_multiplier = max(size_multiplier - 0.75, 0.25) //the limits here ensure no negative values or infinite shrinkage

--- a/code/modules/vore/resizing/resize_vr.dm
+++ b/code/modules/vore/resizing/resize_vr.dm
@@ -141,7 +141,7 @@ var/const/RESIZE_A_SMALLTINY = (RESIZE_SMALL + RESIZE_TINY) / 2
 	if(buckled)
 		to_chat(usr,"<span class='notice'>You have to unbuckle \the [M] before you pick them up.</span>")
 		return 0
-	if(size_diff >= 0.50)
+	if(size_diff >= 0.50 || mob_size < MOB_SMALL)
 		holder_type = /obj/item/weapon/holder/micro
 		var/obj/item/weapon/holder/m_holder = get_scooped(M, G)
 		holder_type = holder_default


### PR DESCRIPTION
-Fixes update_transform proc for mobs. Meaning that the proc now actually does something and that mobs with pre-set size multipliers now spawn in the correct size.
-Removes some textbook spaghetti code that was making mice spawn in double (triple?) feigned size multipliers in order to be scoopable. Instead makes miniscule (mob_size var) mobs (such as mice) scoopable by default.
-This also fixes morphs in mouse form becoming tiny.