### PR TITLE
Fix offline vent pumps and scrubbers on loaded maps.

### DIFF
--- a/code/controllers/subsystem.dm
+++ b/code/controllers/subsystem.dm
@@ -168,11 +168,12 @@
 		statclick = new/obj/effect/statclick/debug(null, "Initializing...", src)
 
 
-
-	if(can_fire && !(SS_NO_FIRE & flags))
-		msg = "[round(cost,1)]ms|[round(tick_usage,1)]%([round(tick_overrun,1)]%)|[round(ticks,0.1)]\t[msg]"
-	else
+	if(SS_NO_FIRE & flags)
+		msg = "NO FIRE\t[msg]"
+	else if(can_fire <= 0)
 		msg = "OFFLINE\t[msg]"
+	else
+		msg = "[round(cost,1)]ms|[round(tick_usage,1)]%([round(tick_overrun,1)]%)|[round(ticks,0.1)]\t[msg]"
 
 	var/title = name
 	if (can_fire)

--- a/code/controllers/subsystem.dm
+++ b/code/controllers/subsystem.dm
@@ -203,3 +203,15 @@
 //usually called via datum/controller/subsystem/New() when replacing a subsystem (i.e. due to a recurring crash)
 //should attempt to salvage what it can from the old instance of subsystem
 /datum/controller/subsystem/Recover()
+
+// Suspends this subsystem from being queued for running.  If already in the queue, sleeps until idle. Returns FALSE if the subsystem was already suspended.
+/datum/controller/subsystem/proc/suspend()
+	. = (can_fire > 0) // Return true if we were previously runnable, false if previously suspended.
+	can_fire = FALSE
+	// Safely sleep in a loop until the subsystem is idle, (or its been un-suspended somehow)
+	while(can_fire <= 0 && state != SS_IDLE)
+		stoplag() // Safely sleep in a loop until 
+
+// Wakes a suspended subsystem.
+/datum/controller/subsystem/proc/wake()
+	can_fire = TRUE

--- a/code/modules/maps/tg/map_template.dm
+++ b/code/modules/maps/tg/map_template.dm
@@ -41,6 +41,7 @@
 
 	var/prev_shuttle_queue_state = SSshuttles.block_init_queue
 	SSshuttles.block_init_queue = TRUE
+	var/machinery_was_awake = SSmachines.suspend() // Suspend machinery (if it was not already suspended)
 
 	var/list/atom/atoms = list()
 	var/list/area/areas = list()
@@ -74,6 +75,8 @@
 		var/area/A = I
 		A.power_change()
 
+	if(machinery_was_awake)
+		SSmachines.wake() // Wake only if it was awake before we tried to suspended it. 
 	SSshuttles.block_init_queue = prev_shuttle_queue_state
 	SSshuttles.process_init_queues() // We will flush the queue unless there were other blockers, in which case they will do it.
 


### PR DESCRIPTION
### Description
**Issue**:  Large maps loaded after game start sometimes had their vent pumps and scrubbers (possibly other atmos machines) be offline.
**Cause**: SSmachines was running these machines's process() proc in between the time when the map template's atoms were initialized and their atmos_init proc's were called.
**Solution**;  Suspend SSmachine processing while we are initializing map template bounds.

### Changes
- Adds the capability to "suspend" a subsystem while we're loading something.
- Suspend SSmachines subsystem while we are initializing map templates.
- MC Statpanel now distinguishes between NO_FIRE subsystems and OFFLINE (can_fire <= 0) subsystems

