### PR TITLE
Switches "Yes" and "no" for Request spice per #7133

### DIFF
--- a/code/modules/admin/verbs/adminhelp_vr.dm
+++ b/code/modules/admin/verbs/adminhelp_vr.dm
@@ -25,7 +25,7 @@
 		to_chat(usr, "<span class='danger'>Error: You cannot request spice (muted from adminhelps).</span>")
 		return
 
-	if(alert(usr, "Are you sure you want to request the admins spice things up for you? You accept the consequences if you do.",,"No","Yes") != "No")
+	if(alert(usr, "Are you sure you want to request the admins spice things up for you? You accept the consequences if you do.",,"Yes","No") != "No")
 		message_admins("[ADMIN_FULLMONTY(usr)] has requested the round be spiced up a little.")
 		to_chat(usr, "<span class='notice'>You have requested some more spice in your round.</span>")
 	else


### PR DESCRIPTION


Issue #7133 states that it's very easy to accidentally press yes using the current layout. 

Fixes #7133