### PR TITLE
Adds K't's fishing rod whitelist

### DIFF
--- a/code/modules/client/preference_setup/loadout/loadout_fluffitems_vr.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_fluffitems_vr.dm
@@ -670,6 +670,12 @@
 	ckeywhitelist = list("nickcrazy")
 	character_name = list("Damon Bones Xrim")
 
+/datum/gear/fluff/kt_fishing_rod
+	path = /obj/item/weapon/material/fishing_rod/modern/strong
+	display_name = "K't's fishing rod"
+	ckeywhitelist = list("nerdass")
+	character_name = list("K't")
+
 //  O CKEYS
 /datum/gear/fluff/richard_chain
 	path = /obj/item/weapon/melee/fluff/holochain


### PR DESCRIPTION
Adds a fishing rod for Nerdass' character K't to use in the fluff loadout.

https://forum.vore-station.net/viewtopic.php?f=26&t=1726