### PR TITLE
Fixes Azura's collar

### DIFF
--- a/code/modules/client/preference_setup/loadout/loadout_fluffitems_vr.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_fluffitems_vr.dm
@@ -81,7 +81,7 @@
 	path = /obj/item/clothing/accessory/collar/azura
 	display_name = "collar, Azura"
 	description = "For the kobold's pet."
-	ckeywhitelist = list("azura chitin")
+	ckeywhitelist = list("azurachitin")
 	character_name = list("Azura Chitin")
 
 //  B CKEYS

--- a/code/modules/client/preference_setup/loadout/loadout_fluffitems_vr.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_fluffitems_vr.dm
@@ -1,3 +1,7 @@
+// Note for newly added fluff items: Ckeys should not contain any spaces, underscores or capitalizations,
+// or else the item will not be usable.
+// Example: Someone whose username is "Master Pred_Man" should be written as "masterpredman" instead
+
 /datum/gear/fluff
 	path = /obj/item
 	sort_category = "Fluff Items"


### PR DESCRIPTION
No spaces, capitalizations or underscores in ckeys.

Also adds the comment in the beginning of the file as hopefully a preventative measure