### PR TITLE
Don't sleep SSticker

### DIFF
--- a/code/defines/procs/statistics.dm
+++ b/code/defines/procs/statistics.dm
@@ -94,6 +94,7 @@ proc/sql_report_cyborg_death(var/mob/living/silicon/robot/H)
 
 
 proc/statistic_cycle()
+	set waitfor = 0
 	if(!sqllogging)
 		return
 	while(1)


### PR DESCRIPTION
Not even if db statistics are enabled.