### PR TITLE
Reverse MC testing code

### DIFF
--- a/code/__defines/_tick.dm
+++ b/code/__defines/_tick.dm
@@ -1,5 +1,5 @@
 
-#define TICK_LIMIT_RUNNING 85 //VOREStation Emergency Edit
+#define TICK_LIMIT_RUNNING 80
 #define TICK_LIMIT_TO_RUN 70
 #define TICK_LIMIT_MC 70
 #define TICK_LIMIT_MC_INIT_DEFAULT 98

--- a/code/controllers/master.dm
+++ b/code/controllers/master.dm
@@ -50,8 +50,6 @@ GLOBAL_REAL(Master, /datum/controller/master) = new
 
 	var/current_runlevel	//for scheduling different subsystems for different stages of the round
 
-	var/dbg_is_running_subsystem = FALSE  // TEMPORARY DEBUGGING - true only while we are actually waiting on a subsystem
-
 	var/static/restart_clear = 0
 	var/static/restart_timeout = 0
 	var/static/restart_count = 0
@@ -476,11 +474,9 @@ GLOBAL_REAL(Master, /datum/controller/master) = new
 
 			queue_node.state = SS_RUNNING
 
-			dbg_is_running_subsystem = TRUE // TEMPORARY DEBUGGING
 			tick_usage = TICK_USAGE
 			var/state = queue_node.ignite(queue_node_paused)
 			tick_usage = TICK_USAGE - tick_usage
-			dbg_is_running_subsystem = FALSE // TEMPORARY DEBUGGING
 
 			if (state == SS_RUNNING)
 				state = SS_IDLE


### PR DESCRIPTION
Remove some debugging code that is no longer needed now that SStimer is working.
Also change TICK_LIMIT_RUNNING back to 80 to ease time dilation a bit.