### PR TITLE
Fix Sundry Runtime Errors XII

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -538,7 +538,8 @@
 	cloak_animation(animation_time)
 
 	//Needs to be last so people can actually see the effect before we become invisible
-	plane = CLOAKED_PLANE
+	if(cloaked) // Ensure we are still cloaked after the animation delay
+		plane = CLOAKED_PLANE
 
 /atom/movable/proc/uncloak()
 	if(!cloaked)
@@ -573,7 +574,7 @@
 	sleep(length+5)
 
 	//Remove those
-	filters -= filters[our_filter]
+	filters -= filter(type="wave", x = 0, y = 16, size = 8, offset = 1, flags = WAVE_SIDEWAYS)
 
 	//Back to original alpha
 	alpha = initial_alpha
@@ -597,7 +598,7 @@
 	sleep(length+5)
 
 	//Remove those
-	filters -= filters[our_filter]
+	filters -= filter(type="wave", x=0, y = 16, size = 0, offset = 0, flags = WAVE_SIDEWAYS)
 
 
 // So cloaked things can see themselves, if necessary

--- a/code/game/turfs/simulated/floor_attackby.dm
+++ b/code/game/turfs/simulated/floor_attackby.dm
@@ -152,10 +152,10 @@
 	if(T.type == flooring.build_type)
 		return
 	var/obj/item/weapon/W = user.is_holding_item_of_type(/obj/item/weapon)
+	if(!istype(W))
+		return
 	if(!try_deconstruct_tile(W, user))
 		return
 	if(flooring)
-		return
-	if(!istype(W))
 		return
 	attackby(T, user)

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -19,6 +19,7 @@
 
 /mob/new_player/New()
 	mob_list += src
+	initialized = TRUE // Explicitly don't use Initialize().  New players join super early and use New()
 
 /mob/new_player/verb/new_player_panel()
 	set src = usr

--- a/code/modules/mob/new_player/preferences_setup.dm
+++ b/code/modules/mob/new_player/preferences_setup.dm
@@ -194,6 +194,8 @@
 	b_skin = blue
 
 /datum/preferences/proc/dress_preview_mob(var/mob/living/carbon/human/mannequin)
+	if(!mannequin.dna) // Special handling for preview icons before SSAtoms has initailized.
+		mannequin.dna = new /datum/dna(null)
 	copy_to(mannequin, TRUE)
 
 	if(!equip_preview_mob)

--- a/code/modules/vore/eating/vorepanel_vr.dm
+++ b/code/modules/vore/eating/vorepanel_vr.dm
@@ -46,7 +46,7 @@
 	. = ..()
 
 /datum/vore_look/Topic(href,href_list[])
-	if(vp_interact(href, href_list))
+	if(vp_interact(href, href_list) && popup)
 		popup.set_content(gen_ui(usr))
 		usr << output(popup.get_content(), "insidePanel.browser")
 


### PR DESCRIPTION
- Another fix for Runtime in update_icons.dm,254: Cannot execute null.GetUIState().
  - This time lets just ensure dna is instantiated no matter who is calling dress_preview_mob().
- Fix Runtime in vorepanel_vr.dm,50: Cannot execute null.set content().
- Fix null values being present in mob_list due to new_players existing before SSatoms init.
- Fix Runtime in floor_attackby.dm,118: Cannot execute 0.is crowbar().
- Fix Runtime in atoms_movable.dm,597: list index out of bounds
