### PR TITLE
Adjusts Hacking of NIFSoft Vendor, Resolves #1761

### DIFF
--- a/code/modules/nifsoft/nif_softshop.dm
+++ b/code/modules/nifsoft/nif_softshop.dm
@@ -139,7 +139,7 @@
 			if(initial(path.access))
 				var/list/soft_access = list(initial(path.access))
 				var/list/usr_access = usr.GetAccess()
-				if(!has_access(soft_access, list(), usr_access) && !emagged)
+				if(scan_id && !has_access(soft_access, list(), usr_access) && !emagged)
 					to_chat(usr, "<span class='warning'>You aren't authorized to buy [initial(path.name)].</span>")
 					flick("[icon_state]-deny",entopic.my_image)
 					return

--- a/code/modules/nifsoft/nif_softshop.dm
+++ b/code/modules/nifsoft/nif_softshop.dm
@@ -234,7 +234,7 @@
 		return
 
 /obj/machinery/vending/nifsoft_shop/emag_act(remaining_charges, mob/user) //Yeees, YEEES! Give me that black market tech.
-	if(!emagged)
+	if(!emagged || !(categories & CAT_HIDDEN))
 		emagged = 1
 		categories |= CAT_HIDDEN
 		to_chat(user, "You short out [src]'s access lock & stock restrictions.")

--- a/code/modules/nifsoft/nif_softshop.dm
+++ b/code/modules/nifsoft/nif_softshop.dm
@@ -19,6 +19,10 @@
 
 /obj/machinery/vending/nifsoft_shop/Initialize()
 	. = ..()
+
+	if(wires)
+		qdel(wires)
+	wires = new /datum/wires/vending/no_contraband(src) //These wires can't be hacked for contraband.
 	entopic = new(aholder = src, aicon = icon, aicon_state = "beacon")
 
 /obj/machinery/vending/nifsoft_shop/Destroy()
@@ -70,9 +74,9 @@
 		list(premium, CAT_COIN))
 
 	for(var/current_list in all_products)
-		var/category = current_list[2]
+		var/category = current_list[CAT_HIDDEN]
 
-		for(var/entry in current_list[1])
+		for(var/entry in current_list[CAT_NORMAL])
 			var/datum/nifsoft/NS = entry
 			var/applies_to = initial(NS.applies_to)
 			var/context = ""
@@ -220,3 +224,18 @@
 /obj/machinery/vending/nifsoft_shop/throw_item()
 	//TODO: Make it throw disks at people with random software? That might be fun. EVEN THE ILLEGAL ONES? ;o
 	return 0
+
+/datum/wires/vending/no_contraband
+
+/datum/wires/vending/no_contraband/UpdatePulsed(index) //Can't hack for contraband, need emag.
+	if(index != VENDING_WIRE_CONTRABAND)
+		..(index)
+	else
+		return
+
+/obj/machinery/vending/nifsoft_shop/emag_act(remaining_charges, mob/user) //Yeees, YEEES! Give me that black market tech.
+	if(!emagged)
+		emagged = 1
+		categories |= CAT_HIDDEN
+		to_chat(user, "You short out [src]'s access lock & stock restrictions.")
+		return 1


### PR DESCRIPTION
Hacking the NIFSoft vendor by pulsing the ID scan wire now behaves like other vendors, allowing you to unlock ID restriction on the various NIFSofts.

You can not enable contraband on the nifsoft shop by hacking, though it can be accessed with an emag.

You can restore the ID lock and hide contraband again by cutting & mending the appropriate wires.
If someone restores either the ID lock & contraband restriction by working with the wires, you can re-emag the machine.

Issue & solution documented by @Dankman in #1761 and confirmed to still be an issue by @Zeldazackman
This issue was acted on as it was marked as a moderately severe bug:
![it's a bug man](https://user-images.githubusercontent.com/12377767/79392916-b85fd700-7f63-11ea-9f50-25db95a3e410.PNG)

Changed on review by @Novacat 