### PR TITLE
Lazy ship/landable Overmap Levels

### DIFF
--- a/code/modules/overmap/overmap_shuttle.dm
+++ b/code/modules/overmap/overmap_shuttle.dm
@@ -42,7 +42,7 @@
 	if(moving_status == SHUTTLE_INTRANSIT)
 		return FALSE //already going somewhere, current_location may be an intransit location instead of in a sector
 	var/our_sector = waypoint_sector(current_location)
-	if(!our_sector && myship?.landmark && next_location == myship.landmark)
+	if(myship?.landmark && next_location == myship.landmark)
 		return TRUE //We're not on the overmap yet (admin spawned probably), and we're trying to hook up with our openspace sector
 	return get_dist(our_sector, waypoint_sector(next_location)) <= range
 

--- a/code/modules/overmap/spacetravel.dm
+++ b/code/modules/overmap/spacetravel.dm
@@ -29,14 +29,16 @@ var/list/cached_space = list()
 	return 1
 
 proc/get_deepspace(x,y)
-	var/obj/effect/overmap/visitable/sector/temporary/res = locate(x,y,global.using_map.overmap_z)
+	var/turf/unsimulated/map/overmap_turf = locate(x,y,global.using_map.overmap_z)
+	if(!istype(overmap_turf))
+		CRASH("Attempt to get deepspace at ([x],[y]) which is not on overmap: [overmap_turf]")
+	var/obj/effect/overmap/visitable/sector/temporary/res = locate() in overmap_turf
 	if(istype(res))
 		return res
 	else if(cached_space.len)
 		res = cached_space[cached_space.len]
 		cached_space -= res
-		res.x = x
-		res.y = y
+		res.forceMove(overmap_turf)
 		return res
 	else
 		return new /obj/effect/overmap/visitable/sector/temporary(x, y, global.using_map.get_empty_zlevel())
@@ -110,5 +112,5 @@ proc/overmap_spacetravel(var/turf/space/T, var/atom/movable/A)
 		var/obj/effect/overmap/visitable/sector/temporary/source = M
 		if (source.can_die())
 			testing("Caching [M] for future use")
-			source.loc = null
+			source.moveToNullspace()
 			cached_space += source

--- a/code/modules/shuttles/landmarks.dm
+++ b/code/modules/shuttles/landmarks.dm
@@ -123,14 +123,16 @@
 	name = "Navpoint"
 	landmark_tag = "navpoint"
 	flags = SLANDMARK_FLAG_AUTOSET
+	var/original_name = null // Save our mapped-in name so we can rebuild our name when moving sectors.
 
 /obj/effect/shuttle_landmark/automatic/Initialize()
+	original_name = name
 	landmark_tag += "-[x]-[y]-[z]-[random_id("landmarks",1,9999)]"
 	return ..()
 
 /obj/effect/shuttle_landmark/automatic/sector_set(var/obj/effect/overmap/visitable/O)
 	..()
-	name = ("[O.name] - [initial(name)] ([x],[y])")
+	name = ("[O.name] - [original_name] ([x],[y])")
 
 //Subtype that calls explosion on init to clear space for shuttles
 /obj/effect/shuttle_landmark/automatic/clearing

--- a/code/modules/shuttles/landmarks.dm
+++ b/code/modules/shuttles/landmarks.dm
@@ -44,7 +44,6 @@
 	else
 		base_area = locate(base_area || world.area)
 
-	name = (name + " ([x],[y])")
 	SSshuttles.register_landmark(landmark_tag, src)
 
 /obj/effect/shuttle_landmark/LateInitialize()

--- a/code/modules/shuttles/shuttle.dm
+++ b/code/modules/shuttles/shuttle.dm
@@ -249,16 +249,16 @@
 		log_shuttle("Shuttle [src] aborting attempt_move() because current_location=[current_location] refuses.")
 		return FALSE
 
+	// Observer pattern pre-move
+	var/old_location = current_location
+	GLOB.shuttle_pre_move_event.raise_event(src, old_location, destination)
+	current_location.shuttle_departed(src)
+
 	log_shuttle("[src] moving to [destination]. Areas are [english_list(shuttle_area)]")
 	var/list/translation = list()
 	for(var/area/A in shuttle_area)
 		log_shuttle("Translating [A]")
 		translation += get_turf_translation(get_turf(current_location), get_turf(destination), A.contents)
-	var/old_location = current_location
-
- 	// Observer pattern pre-move
-	GLOB.shuttle_pre_move_event.raise_event(src, old_location, destination)
-	current_location.shuttle_departed(src)
 
 	// Actually do it! (This never fails)
 	perform_shuttle_move(destination, translation)

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -2906,6 +2906,7 @@
 #include "code\modules\organs\subtypes\vox_vr.dm"
 #include "code\modules\organs\subtypes\xenos.dm"
 #include "code\modules\overmap\bluespace_rift_vr.dm"
+#include "code\modules\overmap\champagne.dm"
 #include "code\modules\overmap\helpers.dm"
 #include "code\modules\overmap\overmap_object.dm"
 #include "code\modules\overmap\overmap_shuttle.dm"


### PR DESCRIPTION
### Lazily create landable ship's overmap z-level on first use.
- Create the landmark as normal, but instead of allocating a z-level and placing it, register a pre_move listener on the shuttle and setup the z-level only when the shuttle is about to move to its overmap landmark.
- Previously all mapped in overmap ship shuttles used an entire z-level even if they were never used!  Now at least they'll allocate that z-level only if someone actually uses them to travel on the overmap.
- Change when shuttles fire the shuttle_pre_move_event to before calculating translation list to give us a chance to allocate the z-level.

### Bugfixes
- Fix overmap spacemove not actually re-using deepspace sectors.
- Fix: Forgot to include champagne.dm in dme

### Tweaks
- Mapped in shuttle landmarks won't append their own coordinates to their name.
  - Couldbe meta-info in some circumstances, and redundant in most well-named landmarks. Automatics still do it.
- If a mapper puts an automatic landmark and overrides the name var, that is now respected instead of overwritten.