### PR TITLE
Improve Ship Scanners

### DIFF
--- a/code/modules/overmap/overmap_object.dm
+++ b/code/modules/overmap/overmap_object.dm
@@ -5,6 +5,8 @@
 
 	var/known = 1		//shows up on nav computers automatically
 	var/scannable       //if set to TRUE will show up on ship sensors for detailed scans
+	var/scanner_name	//name for scans, replaces name once scanned
+	var/scanner_desc	//description for scans
 
 	var/skybox_icon 		//Icon file to use for skybox
 	var/skybox_icon_state	//Icon state to use for skybox
@@ -40,7 +42,12 @@
 		SSskybox.rebuild_skyboxes(O.map_z)
 
 /obj/effect/overmap/proc/get_scan_data(mob/user)
-	return desc
+	if(scanner_name && (name != scanner_name)) //A silly check, but 'name' is part of appearance, so more expensive than you might think
+		name = scanner_name
+
+	var/dat = {"\[b\]Scan conducted at\[/b\]: [stationtime2text()] [stationdate2text()]\n\[b\]Grid coordinates\[/b\]: [x],[y]\n\n[scanner_desc]"}
+
+	return dat
 
 /obj/effect/overmap/Initialize()
 	. = ..()

--- a/code/modules/overmap/sectors.dm
+++ b/code/modules/overmap/sectors.dm
@@ -4,6 +4,7 @@
 /obj/effect/overmap/visitable
 	name = "map object"
 	scannable = TRUE
+	scanner_desc = "!! No Data Available !!"
 
 	var/list/map_z = list()
 	var/list/extra_z_levels //if you need to manually insist that these z-levels are part of this sector, for things like edge-of-map step trigger transitions rather than multi-z complexes

--- a/code/modules/overmap/ships/ship.dm
+++ b/code/modules/overmap/ships/ship.dm
@@ -10,8 +10,9 @@
 // Uses Lorentzian dynamics to avoid going too fast.
 
 /obj/effect/overmap/visitable/ship
-	name = "generic ship"
-	desc = "Space faring vessel."
+	name = "spacecraft"
+	desc = "This marker represents a spaceship. Scan it for more information."
+	scanner_desc = "Unknown spacefaring vessel."
 	icon_state = "ship"
 	var/moving_state = "ship_moving"
 
@@ -54,8 +55,19 @@
 
 /obj/effect/overmap/visitable/ship/get_scan_data(mob/user)
 	. = ..()
+	
 	if(!is_still())
-		. += "<br>Heading: [get_heading_degrees()], speed [get_speed() * 1000]"
+		. += {"\n\[i\]Heading\[/i\]: [get_heading_degrees()]\n\[i\]Velocity\[/i\]: [get_speed() * 1000]"}
+	else
+		. += {"\n\[i\]Vessel was stationary at time of scan.\[/i\]\n"}
+	
+	var/life = 0
+	
+	for(var/mob/living/L in living_mob_list)
+		if(L.z in map_z) //Things inside things we'll consider shielded, otherwise we'd want to use get_z(L)
+			life++
+	
+	. += {"\[i\]Life Signs\[/i\]: [life ? life : "None"]"}
 
 //Projected acceleration based on information from engines
 /obj/effect/overmap/visitable/ship/proc/get_acceleration()

--- a/maps/tether/submaps/_tether_submaps.dm
+++ b/maps/tether/submaps/_tether_submaps.dm
@@ -263,14 +263,6 @@
 	desc = "Approach and perform a scan to obtain further information."
 	icon_state = "object" //or "globe" for planetary stuff
 	known = FALSE
-	//initial_generic_waypoints = list("don't forget waypoints!")
-	var/true_name = "The scanned name goes here"
-	var/true_desc = "The scanned desc goes here"
-
-/obj/effect/overmap/visitable/sector/tether_gateway/get_scan_data(mob/user)
-	name = true_name
-	desc = true_desc
-	return ..()
 
 /datum/map_template/tether_lateload/gateway
 	name = "Gateway Submap"

--- a/maps/tether/submaps/aerostat/_aerostat.dm
+++ b/maps/tether/submaps/aerostat/_aerostat.dm
@@ -3,6 +3,10 @@
 /obj/effect/overmap/visitable/sector/virgo2
 	name = "Virgo 2"
 	desc = "Includes the Remmi Aerostat and associated ground mining complexes."
+	scanner_desc = @{"[i]Stellar Body[/i]: Virgo 2
+[i]Class[/i]: R-Class Planet
+[i]Habitability[/i]: Low (High Temperature, Toxic Atmosphere)
+[b]Notice[/b]: Planetary environment not suitable for life. Landing may be hazardous."}
 	icon_state = "globe"
 	color = "#dfff3f" //Bright yellow
 	initial_generic_waypoints = list("aerostat_west","aerostat_east","aerostat_south","aerostat_northwest","aerostat_northeast")

--- a/maps/tether/submaps/beach/_beach.dm
+++ b/maps/tether/submaps/beach/_beach.dm
@@ -3,6 +3,10 @@
 /obj/effect/overmap/visitable/sector/virgo4
 	name = "Virgo 4"
 	desc = "Home to sand, and things with big fluffy ears."
+	scanner_desc = @{"[i]Stellar Body[/i]: Virgo 4
+[i]Class[/i]: M-Class Planet
+[i]Habitability[/i]: Moderate (High Temperature)
+[b]Notice[/b]: Request authorization from planetary authorities before attempting to construct settlements"}
 	icon_state = "globe"
 	color = "#ffd300" //Sandy
 	initial_generic_waypoints = list("beach_e", "beach_c", "beach_nw")

--- a/maps/tether/submaps/gateway/carpfarm.dm
+++ b/maps/tether/submaps/gateway/carpfarm.dm
@@ -1,7 +1,10 @@
 /obj/effect/overmap/visitable/sector/tether_gateway/carpfarm
 	initial_generic_waypoints = list("tether_excursion_carpfarm")
-	true_name = "Carp-Infested Outpost"
-	true_desc = "Scans indicate this outpost has many instances of 'space carp' moving around, along with an assortment of equipment that appears human in origin."
+	scanner_name = "Carp-Infested Outpost"
+	scanner_desc = @{"[i]Registration[/i]: UNKNOWN
+[i]Class[/i]: Installation
+[i]Transponder[/i]: None Detected
+[b]Notice[/b]: Many spaceborne lifesigns detected"}
 
 /area/awaymission/carpfarm
 	icon_state = "blank"

--- a/maps/tether/submaps/gateway/listeningpost.dm
+++ b/maps/tether/submaps/gateway/listeningpost.dm
@@ -1,7 +1,10 @@
 /obj/effect/overmap/visitable/sector/tether_gateway/listeningpost
 	initial_generic_waypoints = list("tether_excursion_listeningpost")
-	true_name = "Strange Asteroid"
-	true_desc = "Scans indicate this asteroid is emitting large amounts of radio-frequency energy, and has indications of life being present."
+	scanner_name = "Strange Asteroid"
+	scanner_desc = @{"[i]Registration[/i]: UNKNOWN
+[i]Class[/i]: Installation
+[i]Transponder[/i]: None Detected
+[b]Notice[/b]: Emitting encrypted radio-frequency traffic"}
 
 /obj/item/weapon/paper/listneningpost/mission
 	name = "\improper Operation: Watchtower"

--- a/maps/tether/submaps/gateway/snow_outpost.dm
+++ b/maps/tether/submaps/gateway/snow_outpost.dm
@@ -1,7 +1,10 @@
 /obj/effect/overmap/visitable/sector/tether_gateway/snowoutpost
 	initial_generic_waypoints = list("tether_excursion_snow_outpost")
-	true_name = "Snowy Outpost"
-	true_desc = "Scans indicate this planetoid has a very cold atmosphere and almost perpetual snow. There are signs of habitation on the surface."
+	scanner_name = "Snowy Outpost"
+	scanner_desc = @{"[i]Stellar Body[/i]>: UNKNOWN
+[i]Class[/i]>: M-Class Planetoid
+[i]Habitability[/i]>: Moderate (Low Temperature)
+[b]Notice[/b]>: Various small outposts and extensive cave network detected on surface"}
 
 // -- Areas -- //
 

--- a/maps/tether/submaps/gateway/snowfield.dm
+++ b/maps/tether/submaps/gateway/snowfield.dm
@@ -1,8 +1,10 @@
 /obj/effect/overmap/visitable/sector/tether_gateway/snowfield
 	initial_generic_waypoints = list("tether_excursion_snowfield")
-	true_name = "Snowy Field"
-	true_desc = "Scans indicate this planetoid has a very cold atmosphere and almost perpetual snow."
-
+	scanner_name = "Snowy Field"
+	scanner_desc = @{"[i]Stellar Body[/i]: UNKNOWN
+[i]Class[/i]: M-Class Planetoid
+[i]Habitability[/i]: Moderate (Low Temperature)
+[b]Notice[/b]: Very cold atmosphere, minimal life signs detected"}
 
 // -- Areas -- //
 

--- a/maps/tether/submaps/offmap/talon.dm
+++ b/maps/tether/submaps/offmap/talon.dm
@@ -39,6 +39,7 @@ var/global/list/latejoin_talon = list()
 [i]Class[/i]: Frigate
 [i]Transponder[/i]: Transmitting (CIV)
 [b]Notice[/b]: Independent trader vessel"}
+	color = "#aacccc"
 	vessel_mass = 10000
 	vessel_size = SHIP_SIZE_LARGE
 	initial_generic_waypoints = list("talon_fore", "talon_aft", "talon_port", "talon_starboard")

--- a/maps/tether/submaps/offmap/talon.dm
+++ b/maps/tether/submaps/offmap/talon.dm
@@ -34,8 +34,11 @@ var/global/list/latejoin_talon = list()
 ///////////////////////////
 //// The Talon
 /obj/effect/overmap/visitable/ship/talon
-	name = "ITV Talon"
-	desc = "A semi-modern make of ship from Haephestus, registered as the ITV Talon."
+	scanner_name = "ITV Talon"
+	scanner_desc = @{"[i]Registration[/i]: ITV Talon
+[i]Class[/i]: Frigate
+[i]Transponder[/i]: Transmitting (CIV)
+[b]Notice[/b]: Independent trader vessel"}
 	vessel_mass = 10000
 	vessel_size = SHIP_SIZE_LARGE
 	initial_generic_waypoints = list("talon_fore", "talon_aft", "talon_port", "talon_starboard")

--- a/maps/tether/submaps/om_ships/aro2.dm
+++ b/maps/tether/submaps/om_ships/aro2.dm
@@ -54,8 +54,13 @@
 
 // The 'ship'
 /obj/effect/overmap/visitable/ship/aro2
-	name = "Aronai Sieyes"
-	desc = "It's Aronai. Did you know he's actually a spaceship? Yeah it's weird."
+	name = "spacecraft"
+	desc = "Spacefaring vessel. Friendly IFF detected."
+	scanner_name = "Aronai Sieyes"
+	scanner_desc = @{"[i]Registration[/i]: Aronai Sieyes
+[i]Class[/i]: Small Frigate (Low Displacement)
+[i]Transponder[/i]: Transmitting (CIV), non-hostile
+[b]Notice[/b]: Automated vessel"}
 	color = "#00aaff" //Bluey
 	vessel_mass = 8000
 	vessel_size = SHIP_SIZE_SMALL

--- a/maps/tether/submaps/om_ships/cruiser.dm
+++ b/maps/tether/submaps/om_ships/cruiser.dm
@@ -125,9 +125,14 @@
 	mappath = 'cruiser.dmm'
 
 /obj/effect/overmap/visitable/ship/cruiser
-	name = "NDV Tabiranth"
-	desc = "A large military cruiser pinging NT IFF. An automated message warns unauthorized vessels from getting close."
-	color = "#00aaff" //Bluey
+	name = "spacecraft"
+	desc = "Spacefaring vessel. NanoTrasen IFF detected."
+	scanner_name = "NDV Tabiranth"
+	scanner_desc = @{"[i]Registration[/i]: NDV Tabiranth
+[i]Class[/i]: Cruiser
+[i]Transponder[/i]: Transmitting (MIL), NanoTrasen IFF
+[b]Notice[/b]: Military vessel, do not approach"}
+	color = "#0033ff" //Bluey
 	vessel_mass = 15000
 	vessel_size = SHIP_SIZE_LARGE
 	initial_generic_waypoints = list("cruiser_fore", "cruiser_aft", "cruiser_port", "cruiser_starboard", "ws_port_dock_1", "ws_port_dock_2", "ws_starboard_dock_1", "ws_starboard_dock_2")

--- a/maps/tether/submaps/om_ships/generic_shuttle.dm
+++ b/maps/tether/submaps/om_ships/generic_shuttle.dm
@@ -45,8 +45,11 @@
 
 // The 'ship'
 /obj/effect/overmap/visitable/ship/landable/generic_shuttle
-	name = "Private Vessel"
-	desc = "A small privately-owned vessel."
+	scanner_name = "Private Vessel"
+	scanner_desc = @{"[i]Registration[/i]: PRIVATE
+[i]Class[/i]: Small Shuttle
+[i]Transponder[/i]: Transmitting (CIV), non-hostile
+[b]Notice[/b]: Small private vessel"}
 	vessel_mass = 1000
 	vessel_size = SHIP_SIZE_TINY
 	shuttle = "Private Vessel"

--- a/maps/tether/submaps/om_ships/hybridshuttle.dm
+++ b/maps/tether/submaps/om_ships/hybridshuttle.dm
@@ -41,8 +41,11 @@
 
 // The 'ship'
 /obj/effect/overmap/visitable/ship/landable/hybridshuttle
-	name = "XN-29 Prototype Shuttle"
-	desc = "A hybrid excursion shuttle, sporting different features. Less space for equipment, but no fuel or power requirements."
+	scanner_name = "XN-29 Prototype Shuttle"
+	scanner_desc = @{"[i]Registration[/i]: UNKNOWN
+[i]Class[/i]: Shuttle
+[i]Transponder[/i]: Transmitting (MIL), NanoTrasen
+[b]Notice[/b]: Experimental vessel"}
 	color = "#00aaff" //Bluey
 	vessel_mass = 3000
 	vessel_size = SHIP_SIZE_SMALL

--- a/maps/tether/submaps/om_ships/mercship.dm
+++ b/maps/tether/submaps/om_ships/mercship.dm
@@ -64,7 +64,11 @@
 // The 'ship'
 /obj/effect/overmap/visitable/ship/mercship
 	name = "Unknown Vessel"
-	desc = "An unknown vessel, of unknown design."
+	desc = "Spacefaring vessel. No IFF detected."
+	scanner_desc = @{"[i]Registration[/i]: UNKNOWN
+[i]Class[/i]: UNKNOWN
+[i]Transponder[/i]: None Detected
+[b]Notice[/b]: Unregistered vessel"}
 	color = "#f23000" //Red
 	vessel_mass = 8000
 	vessel_size = SHIP_SIZE_SMALL

--- a/maps/tether/submaps/om_ships/vespa.dm
+++ b/maps/tether/submaps/om_ships/vespa.dm
@@ -116,8 +116,12 @@
 
 // The 'ship'
 /obj/effect/overmap/visitable/ship/vespa
-	name = "HPV Vespa"
-	desc = "A Hephaestus Industries vessel."
+	desc = "A spacefaring vessel, of Hephaestus design."
+	scanner_name = "HPV Vespa"
+	scanner_desc = @{"[i]Registration[/i]: HPV Vespa
+[i]Class[/i]: Cruiser
+[i]Transponder[/i]: Transmitting (CIV), Hephaestus Industries
+[b]Notice[/b]: Corporate vessel"}
 	color = "#4cad73" //Green
 	vessel_mass = 10000
 	vessel_size = SHIP_SIZE_LARGE

--- a/maps/tether/submaps/space/_debrisfield.dm
+++ b/maps/tether/submaps/space/_debrisfield.dm
@@ -3,6 +3,8 @@
 /obj/effect/overmap/visitable/sector/debrisfield
 	name = "Debris Field"
 	desc = "Space junk galore."
+scanner_desc = @{"[i]Transponder[/i]: Various faint signals
+[b]Notice[/b]: Warning! Significant field of space debris detected. May be salvagable."}
 	icon_state = "dust1"
 	known = FALSE
 	color = "#ee3333" //Redish, so it stands out against the other debris-like icons

--- a/maps/tether/submaps/space/_debrisfield.dm
+++ b/maps/tether/submaps/space/_debrisfield.dm
@@ -3,7 +3,7 @@
 /obj/effect/overmap/visitable/sector/debrisfield
 	name = "Debris Field"
 	desc = "Space junk galore."
-scanner_desc = @{"[i]Transponder[/i]: Various faint signals
+	scanner_desc = @{"[i]Transponder[/i]: Various faint signals
 [b]Notice[/b]: Warning! Significant field of space debris detected. May be salvagable."}
 	icon_state = "dust1"
 	known = FALSE

--- a/maps/tether/submaps/space/_fueldepot.dm
+++ b/maps/tether/submaps/space/_fueldepot.dm
@@ -1,6 +1,10 @@
 /obj/effect/overmap/visitable/sector/fueldepot
 	name = "Fuel Depot"
 	desc = "Self-service refueling depot."
+	scanner_desc = @{"[i]Registration[/i]: Virgo-Erigonne System Authority
+[i]Class[/i]: Installation (Space)
+[i]Transponder[/i]: Transmitting (CIV), V-E.S.A.
+[b]Notice[/b]: This facility classified for public use for the purpose of refueling and recharging starships"}
 	icon = 'icons/obj/overmap_vr.dmi'
 	icon_state = "fueldepot"
 	color = "#33FF33"

--- a/maps/tether/tether_defines.dm
+++ b/maps/tether/tether_defines.dm
@@ -209,6 +209,10 @@
 /obj/effect/overmap/visitable/sector/virgo3b
 	name = "Virgo 3B"
 	desc = "Full of phoron, and home to the NSB Adephagia, where you can dock and refuel your craft."
+	scanner_desc = @{"[i]Registration[/i]: NSB Adephagia
+[i]Class[/i]: Installation
+[i]Transponder[/i]: Transmitting (CIV), NanoTrasen IFF
+[b]Notice[/b]: NanoTrasen Base, authorized personnel only"}
 	base = 1
 	icon_state = "globe"
 	color = "#d35b5b"


### PR DESCRIPTION
They now give you way more than one lame description I lazily typed in. Replaced every scannable object with a nicer description.

![dreamseeker_2020-04-17_13-09-37](https://user-images.githubusercontent.com/15028025/79595498-f87ea100-80ac-11ea-945e-ad7dc1caff7b.png)

Ships on the overmap are all just named "spacecraft" until you scan them, but they are always colored, so a savvy sensor-operator can identify them by their color before scanning if they've scanned them in the past and remember. Consider this like identifying a ship by a faint signature and getting better at operating sensors.

Note that the 'Life Signs' reading can be fooled by people being inside of other things (or other people). A ship with people hiding in lockers (or in mechs...) will report no life signs.