### PR TITLE
Adjust ghosts hearing whispers/subtles

### DIFF
--- a/code/modules/client/preference_setup/global/setting_datums.dm
+++ b/code/modules/client/preference_setup/global/setting_datums.dm
@@ -104,6 +104,12 @@ var/list/_client_preferences_by_type
 	key = "EMOTE_NOISES"
 	enabled_description = "Noisy"
 	disabled_description = "Silent"
+/datum/client_preference/whisubtle_vis
+	description = "Whi/Subtles Ghost Visible" 
+	key = "WHISUBTLE_VIS"
+	enabled_description = "Visible"
+	disabled_description = "Hidden"
+	enabled_by_default = FALSE
 //VOREStation Add End
 /datum/client_preference/weather_sounds
 	description ="Weather sounds"

--- a/code/modules/client/preferences_vr.dm
+++ b/code/modules/client/preferences_vr.dm
@@ -1,5 +1,4 @@
-//TFF 5/8/19 - minor refactoring of this thing from 09_misc.dm to call this for preferences.
-datum/preferences
+/datum/preferences
 	var/show_in_directory = 1	//Show in Character Directory
 	var/sensorpref = 5			//Set character's suit sensor level
 
@@ -54,3 +53,18 @@ datum/preferences
 	SScharacter_setup.queue_preferences_save(prefs)
 
 	feedback_add_details("admin_verb","TEmoteNoise") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+
+/client/verb/toggle_ghost_quiets()
+	set name = "Whisper/Subtle Vis"
+	set category = "Preferences"
+	set desc = "Toggle ghosts viewing your subtles/whispers."
+
+	var/pref_path = /datum/client_preference/whisubtle_vis
+
+	toggle_preference(pref_path)
+
+	to_chat(src, "Ghosts will [ (is_preference_enabled(pref_path)) ? "now" : "no longer"] hear subtles/whispers made by you.")
+
+	SScharacter_setup.queue_preferences_save(prefs)
+
+	feedback_add_details("admin_verb","TWhisubtleVis") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -363,6 +363,12 @@ proc/get_radio_key_from_channel(var/channel)
 		spawn(0) //Using spawns to queue all the messages for AFTER this proc is done, and stop runtimes
 
 			if(M && src) //If we still exist, when the spawn processes
+				//VOREStation Add - Ghosts don't hear whispers
+				if(whispering && isobserver(M) && !M.client?.holder)
+					M.show_message("<span class='game say'><span class='name'>[src.name]</span> [w_not_heard].</span>", 2)
+					return
+				//VOREStation Add End
+
 				var/dst = get_dist(get_turf(M),get_turf(src))
 
 				if(dst <= message_range || (M.stat == DEAD && !forbid_seeing_deadchat)) //Inside normal message range, or dead with ears (handled in the view proc)

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -364,7 +364,7 @@ proc/get_radio_key_from_channel(var/channel)
 
 			if(M && src) //If we still exist, when the spawn processes
 				//VOREStation Add - Ghosts don't hear whispers
-				if(whispering && isobserver(M) && !M.client?.holder)
+				if(whispering && !is_preference_enabled(/datum/client_preference/whisubtle_vis) && isobserver(M) && !M.client?.holder)
 					M.show_message("<span class='game say'><span class='name'>[src.name]</span> [w_not_heard].</span>", 2)
 					return
 				//VOREStation Add End

--- a/code/modules/mob/say_vr.dm
+++ b/code/modules/mob/say_vr.dm
@@ -51,7 +51,7 @@
 
 		for(var/vismob in vis_mobs)
 			var/mob/M = vismob
-			if(isobserver(M) && !M.client?.holder)
+			if(isobserver(M) && !is_preference_enabled(/datum/client_preference/whisubtle_vis) && !M.client?.holder)
 				spawn(0)
 					M.show_message(undisplayed_message, 2)
 			else

--- a/code/modules/mob/say_vr.dm
+++ b/code/modules/mob/say_vr.dm
@@ -42,6 +42,7 @@
 		return
 
 	if (message)
+		var/undisplayed_message = "<span class='emote'><B>[src]</B> <I>does something too subtle for you to see.</I></span>"
 		message = encode_html_emphasis(message)
 
 		var/list/vis = get_mobs_and_objs_in_view_fast(get_turf(src),1,2) //Turf, Range, and type 2 is emote
@@ -50,8 +51,12 @@
 
 		for(var/vismob in vis_mobs)
 			var/mob/M = vismob
-			spawn(0)
-				M.show_message(message, 2)
+			if(isobserver(M) && !M.client?.holder)
+				spawn(0)
+					M.show_message(undisplayed_message, 2)
+			else
+				spawn(0)
+					M.show_message(message, 2)
 
 		for(var/visobj in vis_objs)
 			var/obj/O = visobj


### PR DESCRIPTION
Adds a preference to toggle whether or not ghosts can hear your whispers/subtles.

For whispering, this changes the 'nothing at all' that happens currently (a bug?) when someone whispers for ghosts into getting the same message someone would get if they were standing far away from a whisper ingame.

For subtles, this removes the ability of ghosts to read the contents of subtle messages.