### PR TITLE
Re-fixes scaling offsets for tall sprites

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1194,7 +1194,7 @@ default behaviour is:
 	// Now for the regular stuff.
 	var/matrix/M = matrix()
 	M.Scale(desired_scale_x, desired_scale_y)
-	M.Translate(0, 16*(desired_scale_y-1))
+	M.Translate(0, (vis_height/2)*(desired_scale_y-1)) //VOREStation edit
 	src.transform = M //VOREStation edit
 
 // This handles setting the client's color variable, which makes everything look a specific color.

--- a/code/modules/vore/resizing/resize_vr.dm
+++ b/code/modules/vore/resizing/resize_vr.dm
@@ -42,7 +42,7 @@ var/const/RESIZE_A_SMALLTINY = (RESIZE_SMALL + RESIZE_TINY) / 2
 	ASSERT(!ishuman(src))
 	var/matrix/M = matrix()
 	M.Scale(size_multiplier)
-	M.Translate(0, 16*(size_multiplier-1))
+	M.Translate(0, (vis_height/2)*(size_multiplier-1))
 	transform = M
 
 /**


### PR DESCRIPTION
Turns out fixing the busted update_transform proc revealed it lacked the thing that the previous scaling offset fix gave to the other size procs that did function back then.