### PR TITLE
Reenable Air Pump Soundloop

### DIFF
--- a/code/ATMOSPHERICS/components/unary/vent_pump.dm
+++ b/code/ATMOSPHERICS/components/unary/vent_pump.dm
@@ -47,7 +47,7 @@
 	var/radio_filter_out
 	var/radio_filter_in
 
-	//var/datum/looping_sound/air_pump/soundloop //VOREStation Removal
+	var/datum/looping_sound/air_pump/soundloop
 
 /obj/machinery/atmospherics/unary/vent_pump/on
 	use_power = USE_POWER_IDLE
@@ -77,7 +77,7 @@
 
 /obj/machinery/atmospherics/unary/vent_pump/Initialize()
 	. = ..()
-	//soundloop = new(list(src), FALSE) //VOREStation Removal
+	soundloop = new(list(src), FALSE)
 
 /obj/machinery/atmospherics/unary/vent_pump/New()
 	..()
@@ -95,7 +95,7 @@
 	if(initial_loc)
 		initial_loc.air_vent_info -= id_tag
 		initial_loc.air_vent_names -= id_tag
-	//QDEL_NULL(soundloop) //VOREStation Removal
+	QDEL_NULL(soundloop)
 	return ..()
 
 /obj/machinery/atmospherics/unary/vent_pump/high_volume
@@ -181,15 +181,15 @@
 
 /obj/machinery/atmospherics/unary/vent_pump/proc/can_pump()
 	if(stat & (NOPOWER|BROKEN))
-		//soundloop.stop() //VOREStation Removal
+		soundloop.stop()
 		return 0
 	if(!use_power)
-		//soundloop.stop() //VOREStation Removal
+		soundloop.stop() 
 		return 0
 	if(welded)
-		//soundloop.stop() //VOREStation Removal
+		soundloop.stop()
 		return 0
-	//soundloop.start() //VOREStation Removal
+	soundloop.start()
 	return 1
 
 /obj/machinery/atmospherics/unary/vent_pump/process()


### PR DESCRIPTION
After extensive testing, there's no way to simply confine the airpump to a single sound channel without extreme wonkiness/inaudible audio, and the suggestion of a global audio channel resulted in no audio playing at all.

Attempting to make a static loop caused horrible feedback, so that was a no-go, and attempting to set up a check to find out if there are mobs near a vent (basically a proximity check) does the same thing/uses the same amount of resources that simply doing playsound() does - but in reverse.

Tested with @ShadowLarkens's help
