### PR TITLE
Fixes morph TF overwriting its verbs

### DIFF
--- a/code/modules/mob/living/simple_mob/subtypes/vore/morph/morph.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/morph/morph.dm
@@ -94,6 +94,7 @@
 
 	visible_message("<span class='warning'>[src] suddenly twists and changes shape, becoming a copy of [target]!</span>")
 	var/mutable_appearance/ma = new(target)
+	ma.verbs = verbs
 	ma.alpha = max(ma.alpha, 150) //fucking chameleons
 	ma.transform = initial(target.transform) //will this ever be non-null?
 


### PR DESCRIPTION
It's hard to do stuff like ventcrawling or eating or whatever when the transformation has irreversibly overwritten your mob abilities with the abilities of some whatever inanimate object.

Fixes #7334
Fixes #7148