### PR TITLE
Fix frontier phaser lock locations

### DIFF
--- a/code/modules/projectiles/guns/energy/laser_vr.dm
+++ b/code/modules/projectiles/guns/energy/laser_vr.dm
@@ -184,7 +184,7 @@
 /obj/item/weapon/gun/energy/locked/special_check(mob/user)
 	if(locked)
 		var/turf/T = get_turf(src)
-		if(T.z in using_map.map_levels)
+		if(T.z in using_map.station_levels)
 			to_chat(user, "<span class='warning'>The safety device prevents the gun from firing this close to the facility.</span>")
 			return 0
 	return ..()


### PR DESCRIPTION
FYI don't use map_levels, that's supposed to contain like every zlevel that's not administrative.
station_levels is the main player map zlevels
player_levels are all player-accessible levels
contact_levels are all levels where you should (probably) receive announcements
admin_levels are levels that are only for technical purposes (like centcomm transit areas)
sealed_levels are levels you can't get to by spacemove
