### PR TITLE
Fixes secret maint lab prosfab access lock

### DIFF
--- a/maps/tether/tether-02-surface2.dmm
+++ b/maps/tether/tether-02-surface2.dmm
@@ -18127,6 +18127,7 @@
 	name = "Legitimate Prosthetics Fabricator";
 	res_max_amount = 150000;
 	speed = 0.2
+	req_access = list()
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/lower/atmos)


### PR DESCRIPTION
The machine is no longer restricted to roboticist access and can now be operated by legitimate quacks.