### PR TITLE
VV Jump/Move To Coordinate

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -587,3 +587,5 @@
 		<a href='?_src_=vars;rotatedatum=\ref[src];rotatedir=right'>>></a>
 		</font>
 		"}
+	var/turf/T = get_turf(src)
+	. += "<br><font size='1'>[ADMIN_COORDJMP(T)]</font>"

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -48,6 +48,17 @@
 		pulledby = null
 	QDEL_NULL(riding_datum) //VOREStation Add
 
+
+/atom/movable/vv_get_dropdown()
+	. = ..()
+	VV_DROPDOWN_OPTION("move_atom", "Move To Coordinate")
+
+/atom/vv_do_topic(list/href_list)
+	. = ..()
+	IF_VV_OPTION("move_atom")
+		usr.client.cmd_admin_move_atom(src)
+		href_list["datumrefresh"] = "\ref[src]"
+
 /atom/movable/vv_edit_var(var_name, var_value)
 	if(var_name in GLOB.VVpixelmovement)			//Pixel movement is not yet implemented, changing this will break everything irreversibly.
 		return FALSE

--- a/code/modules/admin/verbs/adminjump.dm
+++ b/code/modules/admin/verbs/adminjump.dm
@@ -170,3 +170,33 @@
 			admin_ticket_log(M, msg)
 		else
 			alert("Admin jumping disabled")
+
+/client/proc/cmd_admin_move_atom(var/atom/movable/AM, tx as num, ty as num, tz as num)
+	set category = "Admin"
+	set name = "Move Atom to Coordinate"
+
+	if(!check_rights(R_ADMIN|R_DEBUG|R_EVENT))
+		return
+
+	if(config.allow_admin_jump)
+		if(isnull(tx))
+			tx = input("Select X coordinate", "Move Atom", null, null) as null|num
+			if(!tx) return
+		if(isnull(ty))
+			ty = input("Select Y coordinate", "Move Atom", null, null) as null|num
+			if(!ty) return
+		if(isnull(tz))
+			tz = input("Select Z coordinate", "Move Atom", null, null) as null|num
+			if(!tz) return
+		var/turf/T = locate(tx, ty, tz)
+		if(!T)
+			to_chat(usr, "<span class='warning'>Those coordinates are outside the boundaries of the map.</span>")
+			return
+		if(ismob(AM))
+			var/mob/M = AM
+			M.on_mob_jump()
+		AM.forceMove(T)
+		feedback_add_details("admin_verb", "MA") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+		message_admins("[key_name_admin(usr)] jumped [AM] to coordinates [tx], [ty], [tz]")
+	else
+		alert("Admin jumping disabled")


### PR DESCRIPTION
Add current coordinates and link to admin jump to VV screen for atoms.
![vv with jump](https://user-images.githubusercontent.com/14110581/80002898-43722d00-848e-11ea-8034-3c5f509c81a1.PNG)

Adds "Move" command to atom/movable's VV dropdown that lets you jump it to a coordinate.
![vv move to coordinate](https://user-images.githubusercontent.com/14110581/80002930-4d942b80-848e-11ea-91a5-33d18abbd340.png)
