### PR TITLE
More machinery power update_var() proc usage

### DIFF
--- a/code/ATMOSPHERICS/components/trinary_devices/filter.dm
+++ b/code/ATMOSPHERICS/components/trinary_devices/filter.dm
@@ -185,7 +185,7 @@
 		var/new_flow_rate = input(usr,"Enter new flow rate (0-[air1.volume]L/s)","Flow Rate Control",src.set_flow_rate) as num
 		src.set_flow_rate = max(0, min(air1.volume, new_flow_rate))
 	if(href_list["power"])
-		use_power=!use_power
+		update_use_power(!use_power)
 	src.update_icon()
 	src.updateUsrDialog()
 /*

--- a/code/game/gamemodes/malfunction/malf_hardware.dm
+++ b/code/game/gamemodes/malfunction/malf_hardware.dm
@@ -64,4 +64,4 @@
 		T.maxhealth = round(initial(T.maxhealth) * 1.4)
 		T.shot_delay = round(initial(T.shot_delay) / 2)
 		T.auto_repair = 1
-		T.active_power_usage = round(initial(T.active_power_usage) * 5)
+		T.update_active_power_usage(round(initial(T.active_power_usage) * 5))

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -207,8 +207,6 @@
 
 	available_chemicals.Cut()
 	available_chemicals = base_chemicals.Copy()
-	idle_power_usage = initial(idle_power_usage)
-	active_power_usage = initial(active_power_usage)
 
 	for(var/obj/item/weapon/stock_parts/P in component_parts)
 		if(istype(P, /obj/item/weapon/stock_parts/capacitor))
@@ -216,8 +214,8 @@
 
 	cap_rating = max(1, round(cap_rating / 2))
 
-	idle_power_usage /= cap_rating
-	active_power_usage /= cap_rating
+	update_idle_power_usage(initial(idle_power_usage) / cap_rating)
+	update_active_power_usage(initial(active_power_usage) / cap_rating)
 
 	if(!limited)
 		for(var/obj/item/weapon/stock_parts/P in component_parts)

--- a/code/game/machinery/bioprinter.dm
+++ b/code/game/machinery/bioprinter.dm
@@ -161,7 +161,7 @@
 
 	container.reagents.remove_reagent("biomass", possible_list[choice][2])
 
-	use_power = USE_POWER_ACTIVE
+	update_use_power(USE_POWER_ACTIVE)
 	printing = 1
 	update_icon()
 
@@ -169,7 +169,7 @@
 
 	sleep(print_delay)
 
-	use_power = USE_POWER_IDLE
+	update_use_power(USE_POWER_IDLE)
 	printing = 0
 	update_icon()
 

--- a/code/game/machinery/camera/presets.dm
+++ b/code/game/machinery/camera/presets.dm
@@ -223,4 +223,4 @@ var/global/list/engineering_networks = list(
 		mult++
 	if (isMotion())
 		mult++
-	active_power_usage = mult*initial(active_power_usage)
+	update_active_power_usage(mult * initial(active_power_usage))

--- a/code/game/machinery/computer/camera.dm
+++ b/code/game/machinery/computer/camera.dm
@@ -182,7 +182,7 @@
 		if(istype(L))
 			L.tracking_cancelled()
 	current_camera = null
-	use_power = USE_POWER_IDLE
+	update_use_power(USE_POWER_IDLE)
 
 //Camera control: mouse.
 /atom/DblClick()

--- a/code/game/machinery/exonet_node.dm
+++ b/code/game/machinery/exonet_node.dm
@@ -60,13 +60,13 @@
 	if(toggle)
 		if(stat & (BROKEN|NOPOWER|EMPED))
 			on = 0
-			idle_power_usage = 0
+			update_idle_power_usage(0)
 		else
 			on = 1
-			idle_power_usage = 2500
+			update_idle_power_usage(2500)
 	else
 		on = 0
-		idle_power_usage = 0
+		update_idle_power_usage(0)
 	update_icon()
 
 // Proc: emp_act()

--- a/code/game/machinery/floor_light.dm
+++ b/code/game/machinery/floor_light.dm
@@ -99,7 +99,7 @@ var/list/floor_light_cache = list()
 		if(light_range || light_power)
 			set_light(0)
 
-	active_power_usage = ((light_range + light_power) * 10)
+	update_active_power_usage((light_range + light_power) * 10)
 	update_icon()
 
 /obj/machinery/floor_light/update_icon()

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -196,6 +196,18 @@ Class Procs:
 /obj/machinery/proc/update_use_power(var/new_use_power)
 	use_power = new_use_power
 
+// Sets the power_channel var
+/obj/machinery/proc/update_power_channel(var/new_channel)
+	power_channel = new_channel
+
+// Sets the idle_power_usage var
+/obj/machinery/proc/update_idle_power_usage(var/new_power_usage)
+	idle_power_usage = new_power_usage
+
+// Sets the active_power_usage var
+/obj/machinery/proc/update_active_power_usage(var/new_power_usage)
+	active_power_usage = new_power_usage
+
 /obj/machinery/proc/auto_use_power()
 	if(!powered(power_channel))
 		return 0

--- a/code/game/machinery/magnet.dm
+++ b/code/game/machinery/magnet.dm
@@ -143,7 +143,7 @@
 	// Update power usage:
 	if(on)
 		update_use_power(USE_POWER_ACTIVE)
-		active_power_usage = electricity_level*15
+		update_active_power_usage(electricity_level * 15)
 	else
 		update_use_power(USE_POWER_OFF)
 

--- a/code/game/machinery/pda_multicaster.dm
+++ b/code/game/machinery/pda_multicaster.dm
@@ -77,15 +77,15 @@
 		if(stat & (BROKEN|NOPOWER|EMPED))
 			on = 0
 			update_PDAs(1) // 1 being to turn off.
-			idle_power_usage = 0
+			update_idle_power_usage(0)
 		else
 			on = 1
 			update_PDAs(0)
-			idle_power_usage = 750
+			update_idle_power_usage(750)
 	else
 		on = 0
 		update_PDAs(1)
-		idle_power_usage = 0
+		update_idle_power_usage(0)
 	update_icon()
 
 /obj/machinery/pda_multicaster/process()

--- a/code/game/machinery/supplybeacon.dm
+++ b/code/game/machinery/supplybeacon.dm
@@ -80,7 +80,7 @@
 		return
 	set_light(3, 3, "#00CCAA")
 	icon_state = "beacon_active"
-	use_power = USE_POWER_IDLE
+	update_use_power(USE_POWER_IDLE)
 	if(user) to_chat(user, "<span class='notice'>You activate the beacon. The supply drop will be dispatched soon.</span>")
 
 /obj/machinery/power/supply_beacon/proc/deactivate(var/mob/user, var/permanent)
@@ -90,7 +90,7 @@
 	else
 		icon_state = "beacon"
 	set_light(0)
-	use_power = USE_POWER_OFF
+	update_use_power(USE_POWER_OFF)
 	target_drop_time = null
 	if(user) to_chat(user, "<span class='notice'>You deactivate the beacon.</span>")
 

--- a/code/game/machinery/telecomms/machine_interactions.dm
+++ b/code/game/machinery/telecomms/machine_interactions.dm
@@ -229,11 +229,11 @@
 	if(href_list["range_down"])
 		if(overmap_range > overmap_range_min)
 			overmap_range--
-			idle_power_usage = initial(idle_power_usage)**(overmap_range+1)
+			update_idle_power_usage(initial(idle_power_usage)**(overmap_range+1))
 	if(href_list["range_up"])
 		if(overmap_range < overmap_range_max)
 			overmap_range++
-			idle_power_usage = initial(idle_power_usage)**(overmap_range+1)
+			update_idle_power_usage(initial(idle_power_usage)**(overmap_range+1))
 
 // RECEIVER
 /obj/machinery/telecomms/receiver/Options_Menu()
@@ -245,11 +245,11 @@
 	if(href_list["range_down"])
 		if(overmap_range > overmap_range_min)
 			overmap_range--
-			idle_power_usage = initial(idle_power_usage)**(overmap_range+1)
+			update_idle_power_usage(initial(idle_power_usage)**(overmap_range+1))
 	if(href_list["range_up"])
 		if(overmap_range < overmap_range_max)
 			overmap_range++
-			idle_power_usage = initial(idle_power_usage)**(overmap_range+1)
+			update_idle_power_usage(initial(idle_power_usage)**(overmap_range+1))
 
 /obj/machinery/telecomms/Topic(href, href_list)
 

--- a/code/game/objects/structures/holoplant.dm
+++ b/code/game/objects/structures/holoplant.dm
@@ -48,13 +48,13 @@
 	plant = prepare_icon(emagged ? "emagged" : null)
 	overlays += plant
 	set_light(2)
-	use_power = USE_POWER_ACTIVE
+	update_use_power(USE_POWER_ACTIVE)
 
 /obj/machinery/holoplant/proc/deactivate()
 	overlays -= plant
 	QDEL_NULL(plant)
 	set_light(0)
-	use_power = USE_POWER_OFF
+	update_use_power(USE_POWER_OFF)
 
 /obj/machinery/holoplant/power_change()
 	..()

--- a/code/modules/holodeck/HolodeckControl.dm
+++ b/code/modules/holodeck/HolodeckControl.dm
@@ -301,7 +301,7 @@
 
 	last_change = world.time
 	active = 1
-	use_power = USE_POWER_ACTIVE
+	update_use_power(USE_POWER_ACTIVE)
 
 	for(var/item in holographic_objs)
 		derez(item)
@@ -362,7 +362,7 @@
 
 	last_gravity_change = world.time
 	active = 1
-	use_power = USE_POWER_IDLE
+	update_use_power(USE_POWER_IDLE)
 
 	if(A.has_gravity)
 		A.gravitychange(0)
@@ -377,4 +377,4 @@
 		linkedholodeck.gravitychange(1)
 
 	active = 0
-	use_power = USE_POWER_IDLE
+	update_use_power(USE_POWER_IDLE)

--- a/code/modules/overmap/disperser/disperser_console.dm
+++ b/code/modules/overmap/disperser/disperser_console.dm
@@ -178,13 +178,13 @@ obj/machinery/computer/ship/disperser/proc/is_valid_setup()
 		var/input = input("1-5", "disperser strength", 1) as num|null
 		if(input && CanInteract(user, state))
 			strength = sanitize_integer(input, 1, 5, 1)
-			middle.idle_power_usage = strength * range * 100
+			middle.update_idle_power_usage(strength * range * 100)
 
 	if(href_list["range"])
 		var/input = input("1-5", "disperser radius", 1) as num|null
 		if(input && CanInteract(user, state))
 			range = sanitize_integer(input, 1, 5, 1)
-			middle.idle_power_usage = strength * range * 100
+			middle.update_idle_power_usage(strength * range * 100)
 
 	if(href_list["fire"])
 		fire(user)

--- a/code/modules/overmap/ships/computers/computer_shims.dm
+++ b/code/modules/overmap/ships/computers/computer_shims.dm
@@ -20,9 +20,9 @@
 /obj/machinery/proc/change_power_consumption(new_power_consumption, use_power_mode = USE_POWER_IDLE)
 	switch(use_power_mode)
 		if(USE_POWER_IDLE)
-			idle_power_usage = new_power_consumption
+			update_idle_power_usage(new_power_consumption)
 		if(USE_POWER_ACTIVE)
-			active_power_usage = new_power_consumption
+			update_active_power_usage(new_power_consumption)
 	// No need to do anything else in our power scheme.
 
 // Defining directly here to avoid conflicts with existing set_broken procs in our codebase that behave differently.

--- a/code/modules/power/fusion/core/_core.dm
+++ b/code/modules/power/fusion/core/_core.dm
@@ -60,7 +60,7 @@ var/list/fusion_cores = list()
 	if(href_list["str"])
 		var/dif = text2num(href_list["str"])
 		field_strength = min(max(field_strength + dif, MIN_FIELD_STR), MAX_FIELD_STR)
-		active_power_usage = 500 * field_strength
+		update_active_power_usage(500 * field_strength)
 		if(owned_field)
 			owned_field.ChangeFieldStrength(field_strength)
 
@@ -96,7 +96,7 @@ var/list/fusion_cores = list()
 /obj/machinery/power/fusion_core/proc/set_strength(var/value)
 	value = CLAMP(value, MIN_FIELD_STR, MAX_FIELD_STR)
 	field_strength = value
-	active_power_usage = 5 * value
+	update_active_power_usage(5 * value)
 	if(owned_field)
 		owned_field.ChangeFieldStrength(value)
 

--- a/code/modules/power/fusion/gyrotron/gyrotron.dm
+++ b/code/modules/power/fusion/gyrotron/gyrotron.dm
@@ -22,7 +22,7 @@ var/list/gyrotrons = list()
 
 /obj/machinery/power/emitter/gyrotron/Initialize()
 	gyrotrons += src
-	active_power_usage = mega_energy * 50000
+	update_active_power_usage(mega_energy * 50000)
 	default_apply_parts()
 	. = ..()
 
@@ -31,7 +31,7 @@ var/list/gyrotrons = list()
 	return ..()
 
 /obj/machinery/power/emitter/gyrotron/process()
-	active_power_usage = mega_energy * 50000
+	update_active_power_usage(mega_energy * 50000)
 	. = ..()
 
 /obj/machinery/power/emitter/gyrotron/get_rand_burst_delay()

--- a/code/modules/power/fusion/gyrotron/gyrotron_control.dm
+++ b/code/modules/power/fusion/gyrotron/gyrotron_control.dm
@@ -75,7 +75,7 @@
 			to_chat(usr, "<span class='warning'>That's not a valid number.</span>")
 			return 1
 		G.mega_energy = CLAMP(new_val, 1, 50)
-		G.active_power_usage = G.mega_energy * 1500
+		G.update_active_power_usage(G.mega_energy * 1500)
 		updateUsrDialog()
 		return 1
 

--- a/code/modules/power/gravitygenerator_vr.dm
+++ b/code/modules/power/gravitygenerator_vr.dm
@@ -94,7 +94,7 @@ GLOBAL_LIST_EMPTY(gravity_generators)
 	setup_parts()
 	middle.add_overlay("activated")
 	current_overlay = "activated"
-	use_power = USE_POWER_ACTIVE
+	update_use_power(USE_POWER_ACTIVE)
 
 //
 // Generator an admin can spawn
@@ -298,7 +298,7 @@ GLOBAL_LIST_EMPTY(gravity_generators)
 /obj/machinery/gravity_generator/main/proc/set_state(new_state)
 	charging_state = POWER_IDLE
 	on = new_state
-	use_power = on ? USE_POWER_ACTIVE : USE_POWER_IDLE
+	update_use_power(on ? USE_POWER_ACTIVE : USE_POWER_IDLE)
 	// Sound the alert if gravity was just enabled or disabled.
 	var/alert = FALSE
 	if(SSticker.IsRoundInProgress())

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -438,7 +438,7 @@ var/global/list/light_type_cache = list()
 				update_use_power(USE_POWER_ACTIVE)
 				set_light(brightness_range, brightness_power, brightness_color)
 	else if(has_emergency_power(LIGHT_EMERGENCY_POWER_USE) && !turned_off())
-		use_power = 1
+		update_use_power(USE_POWER_IDLE)
 		emergency_mode = TRUE
 		START_PROCESSING(SSobj, src)
 	else

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -445,7 +445,7 @@ var/global/list/light_type_cache = list()
 		update_use_power(USE_POWER_IDLE)
 		set_light(0)
 
-	active_power_usage = ((light_range * light_power) * LIGHTING_POWER_FACTOR)
+	update_active_power_usage((light_range * light_power) * LIGHTING_POWER_FACTOR)
 
 
 /obj/machinery/light/attack_generic(var/mob/user, var/damage)

--- a/code/modules/power/singularity/particle_accelerator/particle_control.dm
+++ b/code/modules/power/singularity/particle_accelerator/particle_control.dm
@@ -24,7 +24,7 @@
 /obj/machinery/particle_accelerator/control_box/New()
 	wires = new(src)
 	connected_parts = list()
-	active_power_usage = initial(active_power_usage) * (strength + 1)
+	update_active_power_usage(initial(active_power_usage) * (strength + 1))
 	..()
 
 /obj/machinery/particle_accelerator/control_box/Destroy()

--- a/code/modules/research/server.dm
+++ b/code/modules/research/server.dm
@@ -31,7 +31,7 @@
 	var/tot_rating = 0
 	for(var/obj/item/weapon/stock_parts/SP in src)
 		tot_rating += SP.rating
-	idle_power_usage /= max(1, tot_rating)
+	update_idle_power_usage(initial(idle_power_usage) / max(1, tot_rating))
 
 /obj/machinery/r_n_d/server/Initialize()
 	. = ..()

--- a/code/modules/shieldgen/emergency_shield.dm
+++ b/code/modules/shieldgen/emergency_shield.dm
@@ -153,9 +153,10 @@
 
 	create_shields()
 
-	idle_power_usage = 0
+	var/new_power_usage = 0
 	for(var/obj/machinery/shield/shield_tile in deployed_shields)
-		idle_power_usage += shield_tile.shield_idle_power
+		new_power_usage += shield_tile.shield_idle_power
+	update_idle_power_usage(new_power_usage)
 	update_use_power(USE_POWER_IDLE)
 
 /obj/machinery/shieldgen/proc/shields_down()
@@ -205,7 +206,7 @@
 				new_power_usage += shield_tile.shield_idle_power
 
 			if (new_power_usage != idle_power_usage)
-				idle_power_usage = new_power_usage
+				update_idle_power_usage(new_power_usage)
 				use_power(0)
 
 			check_delay = 60


### PR DESCRIPTION
- Adds the update_idle_power_usage() and update_active_power_usage() procs for the respective vars.
- Switches all places modifying those vars directly to call the procs instead.
- This will let us react to the change appropriately, paving the way towards static area power.
- Adds update_power_channel proc for the sake of completeness, but no machines actually modify it so far.
- Also fixes some spots needing to call update_use_power() that were either missed or added since the last PR.

Doing this PR first reduces diff on the static power proc and gives me another day to test it.