### PR TITLE
Fixes some more submap issues

### DIFF
--- a/maps/tether/submaps/om_ships/cruiser.dmm
+++ b/maps/tether/submaps/om_ships/cruiser.dmm
@@ -3733,20 +3733,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/steel_ridged,
 /area/mothership/sechallway)
-"hB" = (
-/turf/simulated/shuttle/wall/voidcraft/blue{
-	hard_corner = 1;
-	icon_state = "void-hc";
-	name = "small craft wall hc";
-	stripe_color = "#45b3d8"
-	},
-/area/mothership/processing)
-"hC" = (
-/turf/simulated/shuttle/wall/voidcraft/blue{
-	name = "small craft wall";
-	stripe_color = "#45b3d8"
-	},
-/area/mothership/processing)
 "hD" = (
 /obj/machinery/door/airlock/security,
 /obj/machinery/door/firedoor/glass,
@@ -22219,7 +22205,7 @@ fl
 gE
 fl
 hm
-hB
+TE
 hV
 in
 iD
@@ -22361,7 +22347,7 @@ go
 gF
 fY
 hn
-hC
+TE
 hW
 ip
 iE

--- a/maps/tether/submaps/om_ships/generic_shuttle.dmm
+++ b/maps/tether/submaps/om_ships/generic_shuttle.dmm
@@ -686,12 +686,12 @@
 /area/shuttle/generic_shuttle/eng)
 "bt" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/voidcraft,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/door/airlock,
 /turf/simulated/floor/tiled{
 	icon_state = "monotile"
 	},

--- a/maps/tether/submaps/om_ships/generic_shuttle.dmm
+++ b/maps/tether/submaps/om_ships/generic_shuttle.dmm
@@ -825,6 +825,7 @@
 	},
 /area/shuttle/generic_shuttle/eng)
 "bJ" = (
+/obj/machinery/portable_atmospherics/canister/phoron,
 /turf/simulated/floor/plating,
 /area/shuttle/generic_shuttle/eng)
 "bK" = (
@@ -923,6 +924,10 @@
 	},
 /turf/space,
 /turf/simulated/shuttle/plating/airless/carry,
+/area/shuttle/generic_shuttle/eng)
+"dV" = (
+/obj/structure/fuel_port,
+/turf/simulated/wall/shull,
 /area/shuttle/generic_shuttle/eng)
 "gZ" = (
 /obj/machinery/door/blast/regular{
@@ -1103,7 +1108,7 @@ bi
 bn
 bs
 by
-bs
+dV
 bs
 bM
 bV

--- a/maps/tether/submaps/om_ships/generic_shuttle.dmm
+++ b/maps/tether/submaps/om_ships/generic_shuttle.dmm
@@ -5,18 +5,6 @@
 "ab" = (
 /turf/simulated/wall/shull,
 /area/shuttle/generic_shuttle/gen)
-"ac" = (
-/obj/machinery/shipsensors{
-	dir = 1
-	},
-/obj/effect/floor_decal/techfloor/orange{
-	dir = 4
-	},
-/obj/effect/floor_decal/techfloor/orange{
-	dir = 8
-	},
-/turf/simulated/shuttle/plating/airless,
-/area/shuttle/generic_shuttle/gen)
 "ad" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
@@ -26,18 +14,27 @@
 /turf/simulated/floor/plating,
 /area/shuttle/generic_shuttle/gen)
 "ae" = (
-/obj/structure/fitness/weightlifter,
+/obj/structure/closet/walllocker/emerglocker/west,
 /turf/simulated/floor/wood,
 /area/shuttle/generic_shuttle/gen)
 "af" = (
 /obj/structure/bed/padded,
 /obj/item/weapon/bedsheet,
-/obj/structure/closet/walllocker/emerglocker/east,
+/obj/machinery/button/remote/blast_door{
+	id = "generic_dorm1_blast";
+	name = "Blast Doors Controls";
+	pixel_x = 24;
+	pixel_y = -28
+	},
 /turf/simulated/floor/wood,
 /area/shuttle/generic_shuttle/gen)
 "ag" = (
-/obj/structure/flora/pottedplant{
-	icon_state = "plant-21"
+/obj/structure/closet/walllocker/emerglocker/west,
+/obj/machinery/button/remote/blast_door{
+	id = "generic_dorm2_blast";
+	name = "Blast Doors Controls";
+	pixel_x = -24;
+	pixel_y = -28
 	},
 /turf/simulated/floor/wood,
 /area/shuttle/generic_shuttle/gen)
@@ -67,6 +64,13 @@
 	icon_state = "map_vent_out";
 	dir = 8
 	},
+/obj/machinery/button/remote/airlock{
+	id = "generic-dorm1-door";
+	name = "Room 1 Lock";
+	pixel_x = -6;
+	pixel_y = -26;
+	specialfunctions = 4
+	},
 /turf/simulated/floor/wood,
 /area/shuttle/generic_shuttle/gen)
 "ak" = (
@@ -77,6 +81,13 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	icon_state = "map_vent_out";
 	dir = 4
+	},
+/obj/machinery/button/remote/airlock{
+	id = "generic-dorm2-door";
+	name = "Room 2 Lock";
+	pixel_x = 6;
+	pixel_y = -26;
+	specialfunctions = 4
 	},
 /turf/simulated/floor/wood,
 /area/shuttle/generic_shuttle/gen)
@@ -101,18 +112,22 @@
 /area/shuttle/generic_shuttle/gen)
 "an" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/voidcraft,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/airlock{
+	id_tag = "generic-dorm1-door"
+	},
 /turf/simulated/floor/tiled{
 	icon_state = "monotile"
 	},
 /area/shuttle/generic_shuttle/gen)
 "ao" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/voidcraft,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/airlock{
+	id_tag = "generic-dorm2-door"
+	},
 /turf/simulated/floor/tiled{
 	icon_state = "monotile"
 	},
@@ -121,6 +136,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
+/obj/structure/closet/emcloset,
 /turf/simulated/floor/tiled{
 	icon_state = "techmaint"
 	},
@@ -197,6 +213,7 @@
 	icon_state = "map_vent_out";
 	dir = 8
 	},
+/obj/structure/closet/emcloset,
 /turf/simulated/floor/tiled{
 	icon_state = "techmaint"
 	},
@@ -259,7 +276,6 @@
 	icon_state = "tube1";
 	dir = 4
 	},
-/obj/structure/fitness/punchingbag,
 /turf/simulated/floor/tiled{
 	icon_state = "techmaint"
 	},
@@ -575,15 +591,6 @@
 	},
 /turf/simulated/wall/shull,
 /area/shuttle/generic_shuttle/gen)
-"bl" = (
-/obj/machinery/smartfridge{
-	density = 0;
-	pixel_y = -32
-	},
-/turf/simulated/floor/tiled{
-	icon_state = "techmaint"
-	},
-/area/shuttle/generic_shuttle/gen)
 "bm" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -601,6 +608,15 @@
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
+	},
+/obj/machinery/access_button{
+	command = "cycle_interior";
+	frequency = 1380;
+	master_tag = "generic_shuttle_docker";
+	name = "interior access button";
+	pixel_x = 28;
+	pixel_y = 26;
+	req_one_access = list(101)
 	},
 /turf/simulated/floor/tiled{
 	icon_state = "techmaint"
@@ -654,6 +670,15 @@
 	pixel_x = 0
 	},
 /obj/effect/map_helper/airlock/door/ext_door,
+/obj/machinery/access_button{
+	command = "cycle_exterior";
+	frequency = 1380;
+	master_tag = "generic_shuttle_docker";
+	name = "exterior access button";
+	pixel_x = 5;
+	pixel_y = -26;
+	req_one_access = list(101)
+	},
 /turf/simulated/floor/plating,
 /area/shuttle/generic_shuttle/gen)
 "bs" = (
@@ -690,6 +715,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/universal{
 	dir = 4
 	},
+/obj/structure/closet/emcloset,
 /turf/simulated/floor/plating,
 /area/shuttle/generic_shuttle/eng)
 "bx" = (
@@ -898,6 +924,47 @@
 /turf/space,
 /turf/simulated/shuttle/plating/airless/carry,
 /area/shuttle/generic_shuttle/eng)
+"gZ" = (
+/obj/machinery/door/blast/regular{
+	density = 0;
+	destroy_hits = 10;
+	dir = 4;
+	icon_state = "pdoor0";
+	id = "generic_dorm2_blast";
+	name = "Shuttle Blast Doors";
+	opacity = 0
+	},
+/turf/template_noop,
+/area/shuttle/generic_shuttle/gen)
+"jV" = (
+/obj/machinery/shipsensors{
+	dir = 2
+	},
+/obj/effect/floor_decal/techfloor/orange{
+	dir = 4
+	},
+/obj/effect/floor_decal/techfloor/orange{
+	dir = 8
+	},
+/turf/simulated/shuttle/plating/airless,
+/area/shuttle/generic_shuttle/gen)
+"tg" = (
+/obj/structure/bed/padded,
+/obj/item/weapon/bedsheet,
+/turf/simulated/floor/wood,
+/area/shuttle/generic_shuttle/gen)
+"Ue" = (
+/obj/machinery/door/blast/regular{
+	density = 0;
+	destroy_hits = 10;
+	dir = 4;
+	icon_state = "pdoor0";
+	id = "generic_dorm1_blast";
+	name = "Shuttle Blast Doors";
+	opacity = 0
+	},
+/turf/template_noop,
+/area/shuttle/generic_shuttle/gen)
 
 (1,1,1) = {"
 aa
@@ -961,7 +1028,7 @@ aL
 aT
 aJ
 bf
-bl
+aJ
 bs
 bv
 bC
@@ -973,7 +1040,7 @@ aa
 "}
 (4,1,1) = {"
 aa
-aa
+Ue
 ad
 ae
 ai
@@ -997,7 +1064,7 @@ aa
 "}
 (5,1,1) = {"
 aa
-aa
+Ue
 ad
 af
 aj
@@ -1021,7 +1088,7 @@ aa
 "}
 (6,1,1) = {"
 aa
-ac
+ab
 ab
 ab
 ab
@@ -1040,12 +1107,12 @@ bs
 bs
 bM
 bV
-aa
+jV
 aa
 "}
 (7,1,1) = {"
 aa
-aa
+gZ
 ad
 ag
 ak
@@ -1069,9 +1136,9 @@ aa
 "}
 (8,1,1) = {"
 aa
-aa
+gZ
 ad
-af
+tg
 al
 ao
 au


### PR DESCRIPTION
- Makes the airlock in the generic shuttle functional.
- Fixes some wall issues on the Daedalus
- Adds blast doors to the generic shuttle's fore
- Moves the generic shuttle's sensor to the rear
- Adds some emergency lockers to the generic shuttle
- Replaces voidcraft airlocks with normal airlocks
- Adds a fuel port and a spare phoron canister
- Removes smartfridge and exercise equipment