### PR TITLE
Optimize some machines for static power

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1142,7 +1142,7 @@ About the new airlock wires panel:
 					if(!has_beeped)
 						playsound(src.loc, 'sound/machines/buzz-two.ogg', 50, 0)
 						has_beeped = 1
-					close_door_at = world.time + 6
+					autoclose_in(6)
 					return
 
 	for(var/turf/turf in locs)
@@ -1160,8 +1160,7 @@ About the new airlock wires panel:
 		var/obj/structure/window/killthis = (locate(/obj/structure/window) in turf)
 		if(killthis)
 			killthis.ex_act(2)//Smashin windows
-	..()
-	return
+	return ..()
 
 /obj/machinery/door/airlock/proc/lock(var/forced=0)
 	if(locked)

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -390,7 +390,8 @@
 	else if(electrified_until > 0 && world.time >= electrified_until)
 		electrify(0)
 
-	..()
+	if (..() == PROCESS_KILL && !(main_power_lost_until > 0 || backup_power_lost_until > 0 || electrified_until > 0))
+		. = PROCESS_KILL
 
 /obj/machinery/door/airlock/uranium/process()
 	if(world.time > last_event+20)
@@ -580,6 +581,9 @@ About the new airlock wires panel:
 	if(backup_power_lost_until == -1 && !backupPowerCablesCut())
 		backup_power_lost_until = world.time + SecondsToTicks(10)
 
+	if(main_power_lost_until > 0 || backup_power_lost_until > 0)
+		START_MACHINE_PROCESSING(src)
+
 	// Disable electricity if required
 	if(electrified_until && isAllPowerLoss())
 		electrify(0)
@@ -588,6 +592,9 @@ About the new airlock wires panel:
 
 /obj/machinery/door/airlock/proc/loseBackupPower()
 	backup_power_lost_until = backupPowerCablesCut() ? -1 : world.time + SecondsToTicks(60)
+
+	if(backup_power_lost_until > 0)
+		START_MACHINE_PROCESSING(src)
 
 	// Disable electricity if required
 	if(electrified_until && isAllPowerLoss())
@@ -630,6 +637,9 @@ About the new airlock wires panel:
 			shockedby += text("\[[time_stamp()]\] - EMP)")
 		message = "The door is now electrified [duration == -1 ? "permanently" : "for [duration] second\s"]."
 		src.electrified_until = duration == -1 ? -1 : world.time + SecondsToTicks(duration)
+
+	if(electrified_until > 0)
+		START_MACHINE_PROCESSING(src)
 
 	if(feedback && message)
 		to_chat(usr,message)

--- a/code/game/machinery/doors/airlock_control.dm
+++ b/code/game/machinery/doors/airlock_control.dm
@@ -9,7 +9,8 @@ obj/machinery/door/airlock
 	var/cur_command = null	//the command the door is currently attempting to complete
 
 obj/machinery/door/airlock/process()
-	..()
+	if (..() == PROCESS_KILL && !cur_command)
+		. = PROCESS_KILL
 	if (arePowerSystemsOn())
 		execute_current_command()
 
@@ -22,6 +23,9 @@ obj/machinery/door/airlock/receive_signal(datum/signal/signal)
 
 	cur_command = signal.data["command"]
 	execute_current_command()
+	if(cur_command)
+		START_MACHINE_PROCESSING(src)
+
 
 obj/machinery/door/airlock/proc/execute_current_command()
 	if(operating)

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -82,11 +82,17 @@
 /obj/machinery/door/process()
 	if(close_door_at && world.time >= close_door_at)
 		if(autoclose)
-			close_door_at = next_close_time()
+			close_door_at = world.time + next_close_wait()
 			spawn(0)
 				close()
 		else
 			close_door_at = 0
+	if (..() == PROCESS_KILL && !close_door_at)
+		return PROCESS_KILL
+
+/obj/machinery/door/proc/autoclose_in(wait)
+	close_door_at = world.time + wait
+	START_MACHINE_PROCESSING(src)
 
 /obj/machinery/door/proc/can_open()
 	if(!density || operating || !ticker)
@@ -427,12 +433,12 @@
 	operating = 0
 
 	if(autoclose)
-		close_door_at = next_close_time()
+		autoclose_in(next_close_wait())
 
 	return 1
 
-/obj/machinery/door/proc/next_close_time()
-	return world.time + (normalspeed ? 150 : 5)
+/obj/machinery/door/proc/next_close_wait()
+	return (normalspeed ? 150 : 5)
 
 /obj/machinery/door/proc/close(var/forced = 0)
 	if(!can_close(forced))

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -350,7 +350,9 @@
 /obj/machinery/door/firedoor/process()
 	..()
 
-	if(density && next_process_time <= world.time)
+	if(!density)
+		return PROCESS_KILL
+	if(next_process_time <= world.time)
 		next_process_time = world.time + 100		// 10 second delays between process updates
 		var/changed = 0
 		lockdown=0
@@ -406,7 +408,10 @@
 
 /obj/machinery/door/firedoor/close()
 	latetoggle()
-	return ..()
+	. = ..()
+	// Queue us for processing when we are closed!
+	if(density)
+		START_MACHINE_PROCESSING(src)
 
 /obj/machinery/door/firedoor/open(var/forced = 0)
 	if(hatch_open)

--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -127,6 +127,8 @@ For the other part of the code, check silicon say.dm. Particularly robot talk.*/
 	set_light(2)			//pad lighting
 	icon_state = "holopad1"
 	A.holo = src
+	if(LAZYLEN(masters))
+		START_MACHINE_PROCESSING(src)
 	return 1
 
 /obj/machinery/hologram/holopad/proc/clear_holo(mob/living/silicon/ai/user)
@@ -147,7 +149,8 @@ For the other part of the code, check silicon say.dm. Particularly robot talk.*/
 			continue
 
 		use_power(power_per_hologram)
-	return 1
+	if(..() == PROCESS_KILL && !LAZYLEN(masters))
+		return PROCESS_KILL
 
 /obj/machinery/hologram/holopad/proc/move_hologram(mob/living/silicon/ai/user)
 	if(masters[user])

--- a/code/modules/power/terminal.dm
+++ b/code/modules/power/terminal.dm
@@ -33,11 +33,6 @@
 /obj/machinery/power/terminal/hides_under_flooring()
 	return 1
 
-// Needed so terminals are not removed from machines list.
-// Powernet rebuilds need this to work properly.
-/obj/machinery/power/terminal/process()
-	return 1
-
 /obj/machinery/power/terminal/overload(var/obj/machinery/power/source)
 	if(master)
 		master.overload(source)


### PR DESCRIPTION
Now that we have static machinery power, machines don't need to process just to use idle power.   And yet some still do so all the time despite doing nothing!  Here we take a few of the most noticeable cases and make them process only when they have something to actually do.

- Firedoors should only process when they are closed (and need to update their lights)
- Doors only need to process when they are attempting to autoclose.
- Airlocks only need to process when they are obeying a command or counting down a timer.
- Terminals do not need to process! global.machines is a separate list from processing_machines
- Holopads only need to process when someone is using them.

By rough counting, this reduces the number of processing machines on Tether by about 5000


