### PR TITLE
Fix gas thrusters turning off when trying to burn.

### DIFF
--- a/code/modules/overmap/ships/engines/gas_thruster.dm
+++ b/code/modules/overmap/ships/engines/gas_thruster.dm
@@ -150,7 +150,7 @@
 /obj/machinery/atmospherics/unary/engine/proc/burn()
 	if(!is_on())
 		return 0
-	if(!check_fuel() || (0 < use_power_oneoff(charge_per_burn)) || check_blockage())
+	if(!check_fuel() || (use_power_oneoff(charge_per_burn) < charge_per_burn) || check_blockage())
 		audible_message(src,"<span class='warning'>[src] coughs once and goes silent!</span>")
 		update_use_power(USE_POWER_OFF)
 		return 0


### PR DESCRIPTION
They expected use_power_oneoff to return the amount of power that *couldn't* be used, but they return the amount of power that *could*