### PR TITLE
Fix language keys not working after multilingualism

### DIFF
--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -153,7 +153,7 @@
 	var/list/prefixes = list() // [["Common", start, end], ["Gutter", start, end]]
 	for(var/i in 1 to length(message))
 		// This grabs trimmed 3 character substrings, to allow for up to 1 prefix and 1 letter language keys
-		var/selection = trim_right(lowertext(copytext(message, i, i + 2)))
+		var/selection = trim_right(copytext(message, i, i + 2)) // VOREStation Edit: We use uppercase keys to avoid Polaris key duplication, but this had lowertext() in it
 		// The first character in the selection will always be the prefix (if this is a valid language invocation)
 		var/prefix = copytext(selection, 1, 2)
 		var/language_key = copytext(selection, 2, 3)


### PR DESCRIPTION
Sort of a "fix", sort of a tweak; the system deliberately never checked for anything but the lowercase version of a language key to make it easier to use, but a lot of the VOREStation languages use uppercase invocation keys. Easy enough to fix by just making it check for the literal version of the key instead of the lowertext version.

Could probably send this to Polaris if they don't care about having their uppercase keys reduced to lowercase, but I tagged it as a VOREStation edit for now.