### PR TITLE
Allows Serdy's modkit to be selected.

### DIFF
--- a/code/modules/client/preference_setup/loadout/loadout_fluffitems_vr.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_fluffitems_vr.dm
@@ -810,6 +810,13 @@
 	character_name = list("NT-HASD #556")
 	allowed_roles = list("Colony Director", "Head of Personnel", "Security Officer", "Warden", "Head of Security","Detective")
 
+/datum/gear/fluff/serdykov_modkit //Also converts a Security suit's sprite
+	path = /obj/item/device/modkit_conversion/fluff/serdykit
+	display_name = "Serdykov Antoz's Modkit"
+	ckeywhitelist = list("silencedmp5a5")
+	character_name = list("Serdykov Antoz")
+	allowed_roles = list("Colony Director", "Head of Personnel", "Security Officer", "Warden", "Head of Security","Detective")
+
 /datum/gear/fluff/tasy_clownuniform
 	path = /obj/item/clothing/under/sexyclown
 	display_name = "Tasy's Clown Uniform"


### PR DESCRIPTION
After my previous PR, I was informed that Silencedmp5a5 was unable to select his other modkit (the one who's armor was updated), as it appears that his modkit was never made selectable in loadout_fluffitems_vr file as far as I can see.

This fixes that and allows it to be selected.