### PR TITLE
Remove AI subsystems TICKER flag

### DIFF
--- a/code/controllers/subsystems/ai.dm
+++ b/code/controllers/subsystems/ai.dm
@@ -3,7 +3,7 @@ SUBSYSTEM_DEF(ai)
 	init_order = INIT_ORDER_AI
 	priority = FIRE_PRIORITY_AI
 	wait = 2 SECONDS
-	flags = SS_NO_INIT|SS_TICKER
+	flags = SS_NO_INIT
 	runlevels = RUNLEVEL_GAME | RUNLEVEL_POSTGAME
 
 	var/list/processing = list()

--- a/code/controllers/subsystems/aifast.dm
+++ b/code/controllers/subsystems/aifast.dm
@@ -2,8 +2,8 @@ SUBSYSTEM_DEF(aifast)
 	name = "AI (Fast)"
 	init_order = INIT_ORDER_AI_FAST
 	priority = FIRE_PRIORITY_AI
-	wait = 5 // This gets run twice a second, but shouldn't do much unless mobs are in combat
-	flags = SS_NO_INIT|SS_TICKER
+	wait = 0.25 SECONDS // Every quarter second
+	flags = SS_NO_INIT
 	runlevels = RUNLEVEL_GAME | RUNLEVEL_POSTGAME
 
 	var/list/processing = list()


### PR DESCRIPTION
These subsystems are incorrectly flagged as ticker subsystems, which is unnecessary.