### PR TITLE
Beginning of adding a Cyborg job slot to Talon

### DIFF
--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -457,7 +457,7 @@ var/global/datum/controller/occupations/job_master
 			alt_title = H.mind.role_alt_title
 
 			switch(rank)
-				if("Cyborg")
+				if("Cyborg", "Talon Cyborg")
 					return H.Robotize()
 				if("AI")
 					return H

--- a/code/game/jobs/jobs.dm
+++ b/code/game/jobs/jobs.dm
@@ -53,6 +53,7 @@ var/const/TALPIL			=(1<<1)
 var/const/TALDOC			=(1<<2)
 var/const/TALSEC			=(1<<3)
 var/const/TALENG			=(1<<4)
+var/const/TALBORG			=(1<<5)
 //VOREStation Add End
 
 /proc/guest_jobbans(var/job)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -262,7 +262,8 @@
 	//VOREStatation Edit Start: shell restrictions
 	if(shell)
 		modules.Add(shell_module_types)
-	if(istype(get_area(src),/area/talon))
+	var/area/A = get_area(src)
+	if(findtext(A.type, "/area/talon"))
 		modules+="Talon K9 Medical Module"
 		modules+="Talon K9 Engineering Module"
 		modules+="Talon K9 Multipurpose Module"

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -262,6 +262,14 @@
 	//VOREStatation Edit Start: shell restrictions
 	if(shell)
 		modules.Add(shell_module_types)
+	if(istype(get_area(src),/area/talon))
+		modules+="Talon K9 Medical Module"
+		modules+="Talon K9 Engineering Module"
+		modules+="Talon K9 Multipurpose Module"
+		modules+="Talon Engineering Module"
+		modules+="Talon Medical Module"
+		idcard_type = /obj/item/weapon/card/id/synthetic/talon
+		to_chat(src, "<font color= 'purple'>Talon modules available.</font>")
 	else
 		modules.Add(robot_module_types)
 		if(crisis || security_level == SEC_LEVEL_RED || crisis_override)

--- a/code/modules/mob/living/silicon/robot/robot_modules/station_vr.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules/station_vr.dm
@@ -622,6 +622,35 @@
 	R.verbs |= /mob/living/silicon/robot/proc/rest_style
 	..()
 
+// Rykka adds Talon modules
+
+/obj/item/weapon/robot_module/robot/talondogmed
+	name = "Talon K9 Medical Module"
+	channels = list("Talon" = 1)
+	networks = list(NETWORK_TALON_HELMETS, NETWORK_TALON_SHIP)
+
+/obj/item/weapon/robot_module/robot/talonengdog
+	name = "Talon K9 Engineering Module"
+	channels = list("Talon" = 1)
+	networks = list(NETWORK_TALON_HELMETS, NETWORK_TALON_SHIP)
+
+/obj/item/weapon/robot_module/robot/talonengborg
+	name = "Talon Engineering Module"
+	channels = list("Talon" = 1)
+	networks = list(NETWORK_TALON_HELMETS, NETWORK_TALON_SHIP)
+
+/obj/item/weapon/robot_module/robot/talonmedborg
+	name = "Talon Medical Module"
+	channels = list("Talon" = 1)
+	networks = list(NETWORK_TALON_HELMETS, NETWORK_TALON_SHIP)
+
+/obj/item/weapon/robot_module/robot/talonmultidog
+	name = "Talon K9 Multipurpose Module"
+	channels = list("Talon" = 1)
+	networks = list(NETWORK_TALON_HELMETS, NETWORK_TALON_SHIP)
+
+// Rykka edits stop here.
+
 // Uses modified K9 sprites.
 /obj/item/weapon/robot_module/robot/clerical/brodog
 	name = "service-hound module"

--- a/maps/tether/submaps/offmap/talon.dm
+++ b/maps/tether/submaps/offmap/talon.dm
@@ -47,6 +47,12 @@ var/global/list/latejoin_talon_cyborg = list()
 	on_store_visible_message_1 = "hums and hisses as it moves"
 	on_store_visible_message_2 = "into cryogenic storage."
 
+/obj/machinery/cryopod/robot/talon
+	announce_channel = "Talon"
+	on_store_message = "has entered robotic storage."
+	on_store_name = "ITV Talon Robotic Control"
+	on_enter_occupant_message = "The storage unit broadcasts a sleep signal to you. Your systems start to shut down, and you enter low-power mode."
+
 /obj/effect/landmark/map_data/talon
     height = 2
 

--- a/maps/tether/submaps/offmap/talon.dm
+++ b/maps/tether/submaps/offmap/talon.dm
@@ -1,12 +1,21 @@
 ///////////////////////////
 //// Spawning and despawning
 var/global/list/latejoin_talon = list()
+var/global/list/latejoin_talon_cyborg = list()
 /obj/effect/landmark/talon
 	name = "JoinLateTalon"
 	delete_me = 1
 
 /obj/effect/landmark/talon/New()
 	latejoin_talon += loc // Register this turf as tram latejoin.
+	..()
+
+/obj/effect/landmark/talon/cyborg
+	name = "JoinLateTalonCyborg"
+	delete_me = 1
+
+/obj/effect/landmark/talon/cyborg/New()
+	latejoin_talon_cyborg += loc // Register this turf as tram latejoin
 	..()
 
 /datum/spawnpoint/talon
@@ -18,6 +27,16 @@ var/global/list/latejoin_talon = list()
 /datum/spawnpoint/talon/New()
 	..()
 	turfs = latejoin_talon
+
+/datum/spawnpoint/taloncyborg
+	display_name = "ITV Talon Robot Storage"
+	restrict_job = list("Talon Cyborg")
+	msg = "has exited robot storage"
+	announce_channel = "Talon"
+
+/datum/spawnpoint/taloncyborg/New()
+	..()
+	turfs = latejoin_talon_cyborg
 
 /obj/machinery/cryopod/talon
 	announce_channel = "Talon"

--- a/maps/tether/submaps/offmap/talon1.dmm
+++ b/maps/tether/submaps/offmap/talon1.dmm
@@ -225,12 +225,6 @@
 "az" = (
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/talon/deckone/bridge)
-"aA" = (
-/obj/effect/landmark/start{
-	name = "Talon Cyborg"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon/deckone/workroom)
 "aB" = (
 /obj/effect/floor_decal/techfloor{
 	icon_state = "techfloororange_edges";
@@ -1203,9 +1197,7 @@
 /turf/simulated/floor/plating,
 /area/talon/deckone/starboard_solar)
 "cq" = (
-/obj/machinery/cryopod/robot{
-	announce_channel = "Talon"
-	},
+/obj/machinery/cryopod/robot/talon,
 /turf/simulated/floor/tiled/techmaint,
 /area/talon/deckone/workroom)
 "cr" = (
@@ -6738,6 +6730,15 @@
 	},
 /turf/space,
 /area/talon/maintenance/deckone_starboard_aft_wing)
+"yA" = (
+/obj/effect/landmark/start{
+	name = "Talon Cyborg"
+	},
+/obj/machinery/computer/cryopod/robot{
+	pixel_x = 32
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon/deckone/workroom)
 "yN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -19034,7 +19035,7 @@ fn
 dO
 OF
 fP
-aA
+yA
 cq
 fJ
 aP

--- a/maps/tether/submaps/offmap/talon1.dmm
+++ b/maps/tether/submaps/offmap/talon1.dmm
@@ -225,6 +225,12 @@
 "az" = (
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/talon/deckone/bridge)
+"aA" = (
+/obj/effect/landmark/start{
+	name = "Talon Cyborg"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon/deckone/workroom)
 "aB" = (
 /obj/effect/floor_decal/techfloor{
 	icon_state = "techfloororange_edges";
@@ -372,6 +378,15 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/talon/maintenance/deckone_starboard)
+"aQ" = (
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = -25
+	},
+/obj/machinery/recharge_station,
+/turf/simulated/floor/tiled/techmaint,
+/area/talon/deckone/workroom)
 "aR" = (
 /turf/simulated/wall,
 /area/talon/deckone/secure_storage)
@@ -1187,6 +1202,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/talon/deckone/starboard_solar)
+"cq" = (
+/obj/machinery/cryopod/robot{
+	announce_channel = "Talon"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon/deckone/workroom)
 "cr" = (
 /obj/structure/cable/yellow{
 	icon_state = "16-0"
@@ -2230,6 +2251,10 @@
 /obj/item/clothing/accessory/holster/waist,
 /turf/simulated/floor/tiled/dark,
 /area/talon/deckone/armory)
+"ej" = (
+/obj/effect/landmark/talon/cyborg,
+/turf/simulated/floor/tiled/techmaint,
+/area/talon/deckone/workroom)
 "ek" = (
 /obj/structure/closet/crate/medical{
 	name = "first-aid kits"
@@ -5724,10 +5749,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/talon/deckone/workroom)
-"kq" = (
-/obj/machinery/fitness/punching_bag,
-/turf/simulated/floor/tiled/techmaint,
-/area/talon/deckone/workroom)
 "kr" = (
 /obj/machinery/light/small{
 	dir = 4;
@@ -7292,14 +7313,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/steel,
 /area/talon/deckone/central_hallway)
-"PY" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_x = 0;
-	pixel_y = -25
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon/deckone/workroom)
 "Qi" = (
 /obj/machinery/door/blast/regular/open{
 	dir = 4;
@@ -18879,8 +18892,8 @@ fm
 dO
 fQ
 kp
-fP
-PY
+ej
+aQ
 fJ
 aP
 gY
@@ -19021,8 +19034,8 @@ fn
 dO
 OF
 fP
-fP
-kq
+aA
+cq
 fJ
 aP
 gY

--- a/maps/tether/tether_jobs.dm
+++ b/maps/tether/tether_jobs.dm
@@ -109,6 +109,27 @@
 	access = list(access_talon)
 	minimal_access = list(access_talon)
 
+/datum/job/talon_cyborg
+	title = "Talon Cyborg"
+	flag = TALBORG
+	department_flag = TALON
+	job_description = "A Cyborg is a mobile synthetic, piloted by a cybernetically preserved brain. It is considered a person, but is still required \
+						to follow its Laws."
+	supervisors = "your Laws and the ITV Talon's Captain"	// Might add an AI to the Talon later :3
+	outfit_type = /decl/hierarchy/outfit/job/silicon/cyborg
+
+	offmap_spawn = TRUE
+	faction = "Station" //Required for SSjob to allow people to join as it
+	departments = list(DEPARTMENT_TALON)
+	total_positions = 1
+	spawn_positions = 1
+	selection_color = "#aaaaaa"
+	account_allowed = 0
+	economic_modifier = 0
+	minimal_player_age = 14
+	has_headset = FALSE
+	assignable = FALSE
+
 /decl/hierarchy/outfit/job/talon_captain
 	name = OUTFIT_JOB_NAME("Talon Captain")
 
@@ -193,3 +214,12 @@
 	messenger_bag = /obj/item/weapon/storage/backpack/messenger/engi
 	uniform = /obj/item/clothing/under/rank/atmospheric_technician
 	belt = /obj/item/weapon/storage/belt/utility/atmostech
+
+/datum/job/talon_cyborg/equip(var/mob/living/carbon/human/H)
+	if(!H)	return 0
+	return 1
+
+/datum/job/talon_cyborg/equip_preview(mob/living/carbon/human/H)
+	H.equip_to_slot_or_del(new /obj/item/clothing/suit/cardborg(H), slot_wear_suit)
+	H.equip_to_slot_or_del(new /obj/item/clothing/head/cardborg(H), slot_head)
+	return 1


### PR DESCRIPTION
Adds a Cyborg job slot to Talon crew, same 14 day limit as the rest of the crew, and adds a spawn/leave storage spot as well as a recharger next to it.

Modules are Tether default, access is Tether default, I'll have to figure out how to change that, because a lot of the Cyborg/AI stuff is hardcoded to assume there's only ever one main "station", it seems like?

I'm very new to this, so I'm probably doing it wrong.
