### PR TITLE
Remove override of dinnerware vendor

### DIFF
--- a/code/game/machinery/vending_vr.dm
+++ b/code/game/machinery/vending_vr.dm
@@ -22,35 +22,6 @@
 					/obj/item/clothing/glasses/omnihud/med = 4, /obj/item/device/glasses_kit = 1,  /obj/item/weapon/storage/quickdraw/syringe_case = 4)
 	..()
 
-//Custom vendors
-/obj/machinery/vending/dinnerware
-	name = "Dinnerware"
-	desc = "A kitchen and restaurant equipment vendor."
-	product_ads = "Mm, food stuffs!;Food and food accessories.;Get your plates!;You like forks?;I like forks.;Woo, utensils.;You don't really need these..."
-	icon_state = "dinnerware"
-	products = list(
-	/obj/item/weapon/tray = 8,
-	/obj/item/weapon/material/kitchen/utensil/fork = 6,
-	/obj/item/weapon/material/knife/plastic = 6,
-	/obj/item/weapon/material/kitchen/utensil/spoon = 6,
-	/obj/item/weapon/material/knife = 3,
-	/obj/item/weapon/material/kitchen/rollingpin = 2,
-	/obj/item/weapon/reagent_containers/food/drinks/glass2/square = 8,
-	/obj/item/weapon/reagent_containers/food/drinks/glass2/shake = 8,
-	/obj/item/weapon/glass_extra/stick = 15,
-	/obj/item/weapon/glass_extra/straw = 15,
-	/obj/item/clothing/suit/chef/classic = 2,
-	/obj/item/weapon/storage/toolbox/lunchbox = 3,
-	/obj/item/weapon/storage/toolbox/lunchbox/heart = 3,
-	/obj/item/weapon/storage/toolbox/lunchbox/cat = 3,
-	/obj/item/weapon/storage/toolbox/lunchbox/nt = 3,
-	/obj/item/weapon/storage/toolbox/lunchbox/mars = 3,
-	/obj/item/weapon/storage/toolbox/lunchbox/cti = 3,
-	/obj/item/weapon/storage/toolbox/lunchbox/nymph = 3,
-	/obj/item/weapon/storage/toolbox/lunchbox/syndicate = 3,
-	/obj/item/trash/bowl = 30)
-	contraband = list(/obj/item/weapon/material/knife/butch = 2)
-
 //I want this not just as part of the zoo. ;v
 /obj/machinery/vending/food
 	name = "Food-O-Mat"


### PR DESCRIPTION
I have no idea why this is overridden like this.
This is where you get yeast normally on Polaris (and food bags and corn oil)