### PR TITLE
Re-adds cyborg charger to Curashuttle

### DIFF
--- a/maps/tether/submaps/om_ships/curashuttle.dmm
+++ b/maps/tether/submaps/om_ships/curashuttle.dmm
@@ -1076,7 +1076,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/universal{
 	dir = 4
 	},
-/obj/machinery/autolathe,
+/obj/machinery/recharge_station,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/shuttle/curabitur/curashuttle/eng)
 "bV" = (
@@ -1275,6 +1275,7 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/shuttle/curabitur/curashuttle/eng)
 "cq" = (
+/obj/machinery/portable_atmospherics/canister/phoron,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/shuttle/curabitur/curashuttle/eng)
 "cr" = (
@@ -1323,7 +1324,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 9
 	},
-/obj/machinery/portable_atmospherics/canister/phoron,
+/obj/machinery/autolathe,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/shuttle/curabitur/curashuttle/eng)
 "cx" = (


### PR DESCRIPTION
Remodeling is a heck when you forget to put things back.
Basically just readds the cyborg charger and moves around some stuff.