### PR TITLE
Overmap Ship Pixel Movement

### DIFF
--- a/code/modules/overmap/sectors.dm
+++ b/code/modules/overmap/sectors.dm
@@ -153,7 +153,7 @@
 	var/area/overmap/A = new
 	for (var/square in block(locate(1,1,global.using_map.overmap_z), locate(global.using_map.overmap_size,global.using_map.overmap_size,global.using_map.overmap_z)))
 		var/turf/T = square
-		if(T.x == global.using_map.overmap_size || T.y == global.using_map.overmap_size)
+		if(T.x == 1 || T.y == 1 || T.x == global.using_map.overmap_size || T.y == global.using_map.overmap_size)
 			T = T.ChangeTurf(/turf/unsimulated/map/edge)
 		else
 			T = T.ChangeTurf(/turf/unsimulated/map)

--- a/code/modules/overmap/ships/ship.dm
+++ b/code/modules/overmap/ships/ship.dm
@@ -13,7 +13,9 @@
 	name = "spacecraft"
 	desc = "This marker represents a spaceship. Scan it for more information."
 	scanner_desc = "Unknown spacefaring vessel."
+	dir = NORTH
 	icon_state = "ship"
+	appearance_flags = TILE_BOUND|KEEP_TOGETHER //VOREStation Edit
 	var/moving_state = "ship_moving"
 
 	var/vessel_mass = 10000             //tonnes, arbitrary number, affects acceleration provided by engines
@@ -163,10 +165,14 @@
 /obj/effect/overmap/visitable/ship/update_icon()
 	if(!is_still())
 		icon_state = moving_state
-		dir = get_heading()
+		transform = matrix().Turn(get_heading_degrees())
 	else
 		icon_state = initial(icon_state)
+		transform = null
 	..()
+
+/obj/effect/overmap/visitable/ship/set_dir(new_dir)
+	return ..(NORTH) // NO! We always face north.
 
 /obj/effect/overmap/visitable/ship/proc/burn()
 	for(var/datum/ship_engine/E in engines)

--- a/code/modules/overmap/turfs.dm
+++ b/code/modules/overmap/turfs.dm
@@ -19,7 +19,10 @@ var/global/list/map_sectors = list()
 	var/turf/unsimulated/map/edge/wrap_buddy
 
 /turf/unsimulated/map/edge/Initialize()
-	. = ..()
+	..()
+	return INITIALIZE_HINT_LATELOAD
+
+/turf/unsimulated/map/edge/LateInitialize()
 	//This could be done by using the using_map.overmap_size much faster, HOWEVER, doing it programatically to 'find'
 	//  the edges this way allows for 'sub overmaps' elsewhere and whatnot.
 	for(var/side in alldirs) //The order of this list is relevant: It should definitely break on finding a cardinal FIRST.


### PR DESCRIPTION
- Fixed build_overmap() to actually work.
- Transform overmap ship icons to exact angle of heading.
- Moved ships to be in in SSprocessing so they get 1 second resolution.
- Add/remove ships from processing only when they are moving.
- Simulate pixel movement in code using pixel_x and pixel_y
