### PR TITLE
Disables sif mob spawning on outdoors grass turfs

### DIFF
--- a/code/game/turfs/simulated/outdoors/grass.dm
+++ b/code/game/turfs/simulated/outdoors/grass.dm
@@ -39,7 +39,7 @@ var/list/grass_types = list(
 	grass_chance = 5
 	var/tree_chance = 2
 
-	animal_chance = 0.5
+	animal_chance = 0 //VOREStation Edit
 
 	animal_types = list(
 		/mob/living/simple_mob/animal/sif/diyaab = 10,


### PR DESCRIPTION
No more 500 suffocated automatically spawned non-phoron mobs clogging the moblists around tether.