### PR TITLE
Port SSnightshift from Paradise

### DIFF
--- a/code/__defines/lighting.dm
+++ b/code/__defines/lighting.dm
@@ -82,6 +82,7 @@
 #define LIGHT_COLOR_INCANDESCENT_TUBE "#FFFEB8"
 #define LIGHT_COLOR_INCANDESCENT_BULB "#FFDDBB"
 #define LIGHT_COLOR_INCANDESCENT_FLASHLIGHT "#FFCC66"
+#define LIGHT_COLOR_NIGHTSHIFT "#EFCC86"
 
 //Fake ambient occlusion filter
 #define AMBIENT_OCCLUSION filter(type="drop_shadow", x=0, y=-1, size=2, offset=2, color="#04080F55") //VOREStation Edit for prettier visuals.

--- a/code/__defines/subsystems.dm
+++ b/code/__defines/subsystems.dm
@@ -68,8 +68,9 @@ var/global/list/runlevel_flags = list(RUNLEVEL_LOBBY, RUNLEVEL_SETUP, RUNLEVEL_G
 #define INIT_ORDER_ASSETS		-3
 #define INIT_ORDER_PLANETS		-4
 #define INIT_ORDER_HOLOMAPS		-5
-#define INIT_ORDER_OVERLAY		-6
-#define INIT_ORDER_ALARM		-7
+#define INIT_ORDER_NIGHTSHIFT	-6
+#define INIT_ORDER_OVERLAY		-7
+#define INIT_ORDER_ALARM		-8
 #define INIT_ORDER_OPENSPACE	-10
 #define INIT_ORDER_XENOARCH		-20
 #define INIT_ORDER_CIRCUIT		-21
@@ -84,6 +85,7 @@ var/global/list/runlevel_flags = list(RUNLEVEL_LOBBY, RUNLEVEL_SETUP, RUNLEVEL_G
 // If the subsystem isn't listed here it's either DEFAULT or PROCESS (if it's a processing subsystem child)
 #define FIRE_PRIORITY_SHUTTLES		5
 #define FIRE_PRIORITY_SUPPLY		5
+#define FIRE_PRIORITY_NIGHTSHIFT	5
 #define FIRE_PRIORITY_ORBIT			8
 #define FIRE_PRIORITY_VOTE			9
 #define FIRE_PRIORITY_AI			10

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -270,6 +270,9 @@ var/list/gamemode_cache = list()
 	// disables the annoying "You have already logged in this round, disconnect or be banned" popup for multikeying, because it annoys the shit out of me when testing.
 	var/static/disable_cid_warn_popup = FALSE
 
+	// whether or not to use the nightshift subsystem to perform lighting changes
+	var/static/enable_night_shifts = FALSE
+
 /datum/configuration/New()
 	var/list/L = typesof(/datum/game_mode) - /datum/game_mode
 	for (var/T in L)
@@ -887,6 +890,9 @@ var/list/gamemode_cache = list()
 
 				if("disable_cid_warn_popup")
 					config.disable_cid_warn_popup = TRUE
+
+				if("enable_night_shifts")
+					config.enable_night_shifts = TRUE
 
 				else
 					log_misc("Unknown setting in configuration: '[name]'")

--- a/code/controllers/subsystems/nightshift.dm
+++ b/code/controllers/subsystems/nightshift.dm
@@ -1,0 +1,62 @@
+SUBSYSTEM_DEF(nightshift)
+	name = "Night Shift"
+	init_order = INIT_ORDER_NIGHTSHIFT
+	priority = FIRE_PRIORITY_NIGHTSHIFT
+	wait = 60 SECONDS
+	flags = SS_NO_TICK_CHECK
+
+	var/nightshift_active = FALSE
+	var/nightshift_first_check = 30 SECONDS
+
+	var/high_security_mode = FALSE
+
+/datum/controller/subsystem/nightshift/Initialize()
+	if(!config.enable_night_shifts)
+		can_fire = FALSE
+	/*
+	if(config.randomize_shift_time)
+		GLOB.gametime_offset = rand(0, 23) HOURS
+	*/
+	return ..()
+
+/datum/controller/subsystem/nightshift/fire(resumed = FALSE)
+	if(round_duration_in_ticks < nightshift_first_check)
+		return
+	check_nightshift()
+
+/datum/controller/subsystem/nightshift/proc/announce(message)
+	var/announce_z
+	if(using_map.station_levels.len)
+		announce_z = pick(using_map.station_levels)
+	priority_announcement.Announce(message, new_title = "Automated Lighting System Announcement", new_sound = 'sound/misc/notice2.ogg', zlevel = announce_z)
+
+/datum/controller/subsystem/nightshift/proc/check_nightshift(check_canfire=FALSE) //This is called from elsewhere, like setting the alert levels
+	if(check_canfire && !can_fire)
+		return
+	var/emergency = security_level > SEC_LEVEL_GREEN
+	var/announcing = TRUE
+	var/night_time = using_map.get_nightshift()
+	if(high_security_mode != emergency)
+		high_security_mode = emergency
+		if(night_time)
+			announcing = FALSE
+			if(!emergency)
+				announce("Restoring night lighting configuration to normal operation.")
+			else
+				announce("Disabling night lighting: Station is in a state of emergency.")
+	if(emergency)
+		night_time = FALSE
+	if(nightshift_active != night_time)
+		update_nightshift(night_time, announcing)
+
+/datum/controller/subsystem/nightshift/proc/update_nightshift(active, announce = TRUE)
+	nightshift_active = active
+	if(announce)
+		if(active)
+			announce("Good evening, crew. To reduce power consumption and stimulate the circadian rhythms of some species, all of the lights aboard the station have been dimmed for the night.")
+		else
+			announce("Good morning, crew. As it is now day time, all of the lights aboard the station have been restored to their former brightness.")
+	for(var/obj/machinery/power/apc/apc in machines)
+		if(apc.z in using_map.station_levels)
+			apc.set_nightshift(active, TRUE)
+			CHECK_TICK

--- a/code/controllers/subsystems/planets.dm
+++ b/code/controllers/subsystems/planets.dm
@@ -6,16 +6,16 @@ SUBSYSTEM_DEF(planets)
 	flags = SS_BACKGROUND
 	runlevels = RUNLEVEL_GAME | RUNLEVEL_POSTGAME
 
-	var/list/new_outdoor_turfs = list()
-	var/list/new_outdoor_walls = list()
+	var/static/list/new_outdoor_turfs = list()
+	var/static/list/new_outdoor_walls = list()
 
-	var/list/planets = list()
-	var/list/z_to_planet = list()
+	var/static/list/planets = list()
+	var/static/list/z_to_planet = list()
 
-	var/list/currentrun = list()
+	var/static/list/currentrun = list()
 
-	var/list/needs_sun_update = list()
-	var/list/needs_temp_update = list()
+	var/static/list/needs_sun_update = list()
+	var/static/list/needs_temp_update = list()
 
 /datum/controller/subsystem/planets/Initialize(timeofday)
 	admin_notice("<span class='danger'>Initializing planetary weather.</span>", R_DEBUG)

--- a/code/defines/procs/announce.dm
+++ b/code/defines/procs/announce.dm
@@ -86,13 +86,13 @@ datum/announcement/priority/command/Message(message as text, message_title as te
 			to_chat(M, command)
 
 datum/announcement/priority/Message(var/message as text, var/message_title as text, var/list/zlevels)
-	global_announcer.autosay("<span class='alert'>[message_title]:</span> [message]", announcer ? announcer : ANNOUNCER_NAME, zlevels)
+	global_announcer.autosay("<span class='alert'>[message_title]:</span> [message]", announcer ? announcer : ANNOUNCER_NAME, channel = "Common", zlevels = zlevels)
 
 datum/announcement/priority/command/Message(var/message as text, var/message_title as text, var/list/zlevels)
-	global_announcer.autosay("<span class='alert'>[command_name()] - [message_title]:</span> [message]", ANNOUNCER_NAME, zlevels)
+	global_announcer.autosay("<span class='alert'>[command_name()] - [message_title]:</span> [message]", ANNOUNCER_NAME, channel = "Common", zlevels = zlevels)
 
 datum/announcement/priority/security/Message(var/message as text, var/message_title as text, var/list/zlevels)
-	global_announcer.autosay("<span class='alert'>[message_title]:</span> [message]", ANNOUNCER_NAME, zlevels)
+	global_announcer.autosay("<span class='alert'>[message_title]:</span> [message]", ANNOUNCER_NAME, channel = "Common", zlevels = zlevels)
 
 datum/announcement/proc/NewsCast(var/message as text, var/message_title as text)
 	if(!newscast)

--- a/code/modules/planet/time.dm
+++ b/code/modules/planet/time.dm
@@ -11,27 +11,29 @@
 
 /datum/time/New(new_time)
 	if(new_time)
+		if(new_time >= seconds_in_day)
+			new_time = rollover(new_time)
 		seconds_stored = new_time
 	..()
 
 /datum/time/proc/add_seconds(amount)
 	var/answer = seconds_stored + amount * 10
 	if(answer >= seconds_in_day)
-		rollover(answer)
+		answer = rollover(answer)
 	return new type(answer)
 
 /datum/time/proc/add_minutes(amount)
 	var/real_amount = amount * seconds_in_minute
 	var/answer = real_amount + seconds_stored
 	if(answer >= seconds_in_day)
-		rollover(answer)
+		answer = rollover(answer)
 	return new type(answer)
 
 /datum/time/proc/add_hours(amount)
 	var/real_amount = amount * seconds_in_hour
 	var/answer = real_amount + seconds_stored
 	if(answer >= seconds_in_day)
-		rollover(answer)
+		answer = rollover(answer)
 	return new type(answer)
 
 /datum/time/proc/rollover(time)

--- a/code/modules/security levels/security levels.dm
+++ b/code/modules/security levels/security levels.dm
@@ -64,10 +64,6 @@
 				else
 					security_announcement_down.Announce("[config.alert_desc_red_downto]", "Attention! Code red!")
 				security_level = SEC_LEVEL_RED
-				/*	- At the time of commit, setting status displays didn't work properly
-				var/obj/machinery/computer/communications/CC = locate(/obj/machinery/computer/communications,world)
-				if(CC)
-					CC.post_status("alert", "redalert")*/
 			if(SEC_LEVEL_DELTA)
 				security_announcement_up.Announce("[config.alert_desc_delta]", "Attention! Delta alert level reached!", new_sound = 'sound/effects/siren.ogg')
 				security_level = SEC_LEVEL_DELTA
@@ -84,6 +80,10 @@
 			atc.reroute_traffic(yes = 1) // Tell them fuck off we're busy.
 		else
 			atc.reroute_traffic(yes = 0)
+
+		spawn()
+			SSnightshift.check_nightshift()
+
 		admin_chat_message(message = "Security level is now: [uppertext(get_security_level())]", color = "#CC2222") //VOREStation Add
 
 /proc/get_security_level()

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -529,3 +529,6 @@ SQLITE_FEEDBACK_MIN_AGE 7
 
 ## Uncomment this if you want to disable the popup alert for people on the same CID (Don't do this on a live server if you ban multikeying)
 #DISABLE_CID_WARN_POPUP
+
+## Comment this out if you don't want to use the 'nightshift lighting' subsystem to adjust lights based on ingame time
+ENABLE_NIGHT_SHIFTS

--- a/nano/templates/apc.tmpl
+++ b/nano/templates/apc.tmpl
@@ -201,6 +201,15 @@
 		</div>
 	</div>
 
+	<div class="item">
+		<div class="itemLabel">
+			Night Lighting:
+		</div>
+		<div class="itemContent">
+			{{:helper.link(data.nightshiftLights ? 'Enabled' : 'Disabled', data.nightshiftLights ? 'power' : 'close', {'nightshift' : 1}, null)}}
+		</div>
+	</div>
+
 	{{if data.siliconUser}}
 		<h3>System Overrides</h3>
 

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -244,6 +244,7 @@
 #include "code\controllers\subsystems\mapping_vr.dm"
 #include "code\controllers\subsystems\mobs.dm"
 #include "code\controllers\subsystems\nanoui.dm"
+#include "code\controllers\subsystems\nightshift.dm"
 #include "code\controllers\subsystems\open_space.dm"
 #include "code\controllers\subsystems\orbits.dm"
 #include "code\controllers\subsystems\overlays.dm"


### PR DESCRIPTION
Dims station lights when it's night, brightens when day. Can be manually toggled on APC panels, and there's a light subtype that ignores nightshift mode if you want to map those in. Only affects station levels, and ignores shuttles (presumably they have their own power management system or something).

Night is considered 25% of the day after midnight or 25% of the day before midnight (so 50% of the day). On Virgo 3, that's 2:15 to 0:45 (I'm terrible at math but I think that's right).

When you set an alert level other than green, it disables nightshift mode.
![dreamseeker_2020-05-03_17-46-15](https://user-images.githubusercontent.com/15028025/80926720-f718ce00-8d66-11ea-8888-b1c70d948d94.png)

![dreamseeker_2020-05-03_17-46-08](https://user-images.githubusercontent.com/15028025/80926719-f5e7a100-8d66-11ea-8330-4a61cb5652f2.png)

![dreamseeker_2020-05-03_17-41-54](https://user-images.githubusercontent.com/15028025/80926690-c6d12f80-8d66-11ea-861a-cdcf6cfa5968.png)
![dreamseeker_2020-05-03_17-43-13](https://user-images.githubusercontent.com/15028025/80926695-cdf83d80-8d66-11ea-94e6-5be3d8510b71.png)
![dreamseeker_2020-05-03_17-46-01](https://user-images.githubusercontent.com/15028025/80926697-d0f32e00-8d66-11ea-99d7-32a97220f21d.png)
![dreamseeker_2020-05-03_17-45-39](https://user-images.githubusercontent.com/15028025/80926699-d2245b00-8d66-11ea-80a8-dab3082e5a31.png)
