### PR TITLE
Fix an overcharged smes from breaking charging on other smes.

### DIFF
--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -154,7 +154,7 @@
 
 	//inputting
 	if(input_attempt && (!input_pulsed && !input_cut) && !grid_check)
-		target_load = min((capacity-charge)/SMESRATE, input_level)	// Amount we will request from the powernet.
+		target_load = clamp((capacity-charge)/SMESRATE, 0, input_level)	// Amount we will request from the powernet.
 		var/input_available = FALSE
 		for(var/obj/machinery/power/terminal/term in terminals)
 			if(!term.powernet)


### PR DESCRIPTION
An overcharged SMES could demand negative power from the grid, swamping other SMES and resulting in zero power being distributed.