### PR TITLE
Prevent multiple simultaneous stack usage

### DIFF
--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -74,6 +74,17 @@
 
 	return .
 
+/obj/item/stack/medical/proc/do_apply(var/mob/user, var/mob/target, var/time)
+	if(currently_using && !simultaneous_use)
+		to_chat(user, "<span class='warning'>You're already in the middle of applying [src]!</span>")
+		return FALSE
+	currently_using = TRUE
+	var/result = do_mob(user, target, time)
+	currently_using = FALSE
+	if(!result)
+		to_chat(user, "<span class='warning'>You must stand still and keep [src] in your hand to apply it.</span>")
+	return result
+
 /obj/item/stack/medical/crude_pack
 	name = "crude bandage"
 	singular_name = "crude bandage length"
@@ -111,8 +122,7 @@
 					continue
 				if(used == amount)
 					break
-				if(!do_mob(user, M, W.damage/3))
-					to_chat(user, "<span class='notice'>You must stand still to bandage wounds.</span>")
+				if(!do_apply(user, M, W.damage/3))
 					break
 
 				if(affecting.is_bandaged()) // We do a second check after the delay, in case it was bandaged after the first check.
@@ -174,8 +184,7 @@
 					continue
 				if(used == amount)
 					break
-				if(!do_mob(user, M, W.damage/5))
-					to_chat(user, "<span class='notice'>You must stand still to bandage wounds.</span>")
+				if(!do_apply(user, M, W.damage/5))
 					break
 
 				if(affecting.is_bandaged()) // We do a second check after the delay, in case it was bandaged after the first check.
@@ -234,8 +243,7 @@
 		else
 			user.visible_message("<span class='notice'>\The [user] starts salving wounds on [M]'s [affecting.name].</span>", \
 					             "<span class='notice'>You start salving the wounds on [M]'s [affecting.name].</span>" )
-			if(!do_mob(user, M, 10))
-				to_chat(user, "<span class='notice'>You must stand still to salve wounds.</span>")
+			if(!do_apply(user, M, 10))
 				return 1
 			if(affecting.is_salved()) // We do a second check after the delay, in case it was bandaged after the first check.
 				to_chat(user, "<span class='warning'>The wounds on [M]'s [affecting.name] have already been salved.</span>")
@@ -281,8 +289,7 @@
 					continue
 				//if(used == amount) //VOREStation Edit
 				//	break //VOREStation Edit
-				if(!do_mob(user, M, W.damage/5))
-					to_chat(user, "<span class='notice'>You must stand still to bandage wounds.</span>")
+				if(!do_apply(user, M, W.damage/5))
 					break
 				if(affecting.is_bandaged() && affecting.is_disinfected()) // We do a second check after the delay, in case it was bandaged after the first check.
 					to_chat(user, "<span class='warning'>The wounds on [M]'s [affecting.name] have already been bandaged.</span>")
@@ -336,8 +343,7 @@
 		else
 			user.visible_message("<span class='notice'>\The [user] starts salving wounds on [M]'s [affecting.name].</span>", \
 					             "<span class='notice'>You start salving the wounds on [M]'s [affecting.name].</span>" )
-			if(!do_mob(user, M, 10))
-				to_chat(user, "<span class='notice'>You must stand still to salve wounds.</span>")
+			if(!do_apply(user, M, 10))
 				return 1
 			if(affecting.is_salved()) // We do a second check after the delay, in case it was bandaged after the first check.
 				to_chat(user, "<span class='warning'>The wounds on [M]'s [affecting.name] have already been salved.</span>")
@@ -383,7 +389,7 @@
 				to_chat(user, "<span class='danger'>You can't apply a splint to the arm you're using!</span>")
 				return
 			user.visible_message("<span class='danger'>[user] starts to apply \the [src] to their [limb].</span>", "<span class='danger'>You start to apply \the [src] to your [limb].</span>", "<span class='danger'>You hear something being wrapped.</span>")
-		if(do_after(user, 50, M))
+		if(do_apply(user, M, 5 SECONDS))
 			if(affecting.splinted)
 				to_chat(user, "<span class='danger'>[M]'s [limb] is already splinted!</span>")
 				return

--- a/code/game/objects/items/stacks/nanopaste.dm
+++ b/code/game/objects/items/stacks/nanopaste.dm
@@ -13,16 +13,22 @@
 /obj/item/stack/nanopaste/attack(mob/living/M as mob, mob/user as mob)
 	if (!istype(M) || !istype(user))
 		return 0
+	if(currently_using && !simultaneous_use)
+		to_chat(user, "<span class='warning'>No body part there to work on!</span>")
+		return 1
 	if (istype(M,/mob/living/silicon/robot))	//Repairing cyborgs
 		var/mob/living/silicon/robot/R = M
 		if (R.getBruteLoss() || R.getFireLoss())
+			currently_using = TRUE
 			if(do_after(user,7 * toolspeed))
 				R.adjustBruteLoss(-15)
 				R.adjustFireLoss(-15)
 				R.updatehealth()
 				use(1)
+				currently_using = FALSE
 				user.visible_message("<span class='notice'>\The [user] applied some [src] on [R]'s damaged areas.</span>",\
 				"<span class='notice'>You apply some [src] at [R]'s damaged areas.</span>")
+			currently_using = FALSE
 		else
 			to_chat(user, "<span class='notice'>All [R]'s systems are nominal.</span>")
 
@@ -51,10 +57,12 @@
 			else if(can_use(1))
 				user.setClickCooldown(user.get_attack_speed(src))
 				if(S.open >= 2)
+					currently_using = TRUE
 					if(do_after(user,5 * toolspeed))
 						S.heal_damage(restoration_internal, restoration_internal, robo_repair = 1)
 				else if(do_after(user,5 * toolspeed))
 					S.heal_damage(restoration_external,restoration_external, robo_repair =1)
+				currently_using = FALSE
 				H.updatehealth()
 				use(1)
 				user.visible_message("<span class='notice'>\The [user] applies some nanite paste on [user != M ? "[M]'s [S.name]" : "[S]"] with [src].</span>",\

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -28,6 +28,8 @@
 
 	var/pass_color = FALSE // Will the item pass its own color var to the created item? Dyed cloth, wood, etc.
 	var/strict_color_stacking = FALSE // Will the stack merge with other stacks that are different colors? (Dyed cloth, wood, etc)
+	var/simultaneous_use = FALSE
+	var/currently_using = FALSE
 
 /obj/item/stack/New(var/loc, var/amount=null)
 	..()
@@ -128,6 +130,10 @@
 	var/required = quantity*recipe.req_amount
 	var/produced = min(quantity*recipe.res_amount, recipe.max_res_amount)
 
+	if (currently_using && !simultaneous_use)
+		to_chat(user, "<span class='warning'>You're already building something with [src]!</span>")
+		return
+	
 	if (!can_use(required))
 		if (produced>1)
 			to_chat(user, "<span class='warning'>You haven't got enough [src] to build \the [produced] [recipe.title]\s!</span>")
@@ -145,8 +151,11 @@
 
 	if (recipe.time)
 		to_chat(user, "<span class='notice'>Building [recipe.title] ...</span>")
+		currently_using = TRUE
 		if (!do_after(user, recipe.time))
+			currently_using = FALSE
 			return
+		currently_using = FALSE
 
 	if (use(required))
 		var/atom/O


### PR DESCRIPTION
So you can't simultaneously build 5 chairs with the same stack of metal, or simultaneously heal an entire person with the same stack of kits.