### PR TITLE
Fix clamp case breaking BYOND versions below 513.1490

### DIFF
--- a/code/datums/progressbar.dm
+++ b/code/datums/progressbar.dm
@@ -39,7 +39,7 @@
 		if(user.client)
 			user.client.images += bar
 
-	progress = clamp(progress, 0, goal)
+	progress = CLAMP(progress, 0, goal)
 	bar.icon_state = "prog_bar_[round(((progress / goal) * 100), 5)]"
 	if(!shown && user.is_preference_enabled(/datum/client_preference/show_progress_bar))
 		user.client.images += bar

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -154,7 +154,7 @@
 
 	//inputting
 	if(input_attempt && (!input_pulsed && !input_cut) && !grid_check)
-		target_load = clamp((capacity-charge)/SMESRATE, 0, input_level)	// Amount we will request from the powernet.
+		target_load = CLAMP((capacity-charge)/SMESRATE, 0, input_level)	// Amount we will request from the powernet.
 		var/input_available = FALSE
 		for(var/obj/machinery/power/terminal/term in terminals)
 			if(!term.powernet)


### PR DESCRIPTION
513.1490 added `clamp` as a native proc, but using this breaks the current BYOND stable 512 version
