### PR TITLE
Add a better nightshift control

### DIFF
--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -928,7 +928,7 @@
 		return 1
 
 	if(href_list["nightshift"])
-		if(last_nightshift_switch > world.time + 10 SECONDS) // don't spam...
+		if(last_nightshift_switch > world.time - 10 SECONDS) // don't spam...
 			to_chat(usr, "<span class='warning'>[src]'s night lighting circuit breaker is still cycling!</span>")
 			return 0
 		last_nightshift_switch = world.time

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -39,6 +39,10 @@
 #define POWERCHAN_ON       2	// Power channel is on until there is no power
 #define POWERCHAN_ON_AUTO  3	// Power channel is on until power drops below a threshold
 
+#define NIGHTSHIFT_AUTO 1
+#define NIGHTSHIFT_NEVER 2
+#define NIGHTSHIFT_ALWAYS 3
+
 //NOTE: STUFF STOLEN FROM AIRLOCK.DM thx
 
 /obj/machinery/power/apc/critical
@@ -121,6 +125,7 @@
 	var/alarms_hidden = FALSE //If power alarms from this APC are visible on consoles
 	
 	var/nightshift_lights = FALSE
+	var/nightshift_setting = NIGHTSHIFT_AUTO
 	var/last_nightshift_switch = 0
 
 /obj/machinery/power/apc/updateDialog()
@@ -802,6 +807,7 @@
 		"siliconUser" = issilicon(user) || isobserver(user), //I add observer here so admins can have more control, even if it makes 'siliconUser' seem inaccurate.
 		"emergencyLights" = !emergency_lights,
 		"nightshiftLights" = nightshift_lights,
+		"nightshiftSetting" = nightshift_setting,
 
 		"powerChannels" = list(
 			list(
@@ -926,7 +932,8 @@
 			to_chat(usr, "<span class='warning'>[src]'s night lighting circuit breaker is still cycling!</span>")
 			return 0
 		last_nightshift_switch = world.time
-		set_nightshift(!nightshift_lights)
+		nightshift_setting = text2num(href_list["nightshift"])
+		update_nightshift()
 		return 1
 
 	if(locked && !issilicon(usr) )
@@ -1383,8 +1390,19 @@ obj/machinery/power/apc/proc/autoset(var/cur_state, var/on)
 	if(automated && istype(area, /area/shuttle))
 		return
 	nightshift_lights = on
+	update_nightshift()
+
+/obj/machinery/power/apc/proc/update_nightshift()
+	var/new_state = nightshift_lights
+
+	switch(nightshift_setting)
+		if(NIGHTSHIFT_NEVER)
+			new_state = FALSE
+		if(NIGHTSHIFT_ALWAYS)
+			new_state = TRUE
+
 	for(var/obj/machinery/light/L in area)
-		L.nightshift_mode(on)
+		L.nightshift_mode(new_state)
 		CHECK_TICK
 
 #undef APC_UPDATE_ICON_COOLDOWN

--- a/nano/templates/apc.tmpl
+++ b/nano/templates/apc.tmpl
@@ -206,7 +206,9 @@
 			Night Lighting:
 		</div>
 		<div class="itemContent">
-			{{:helper.link(data.nightshiftLights ? 'Enabled' : 'Disabled', data.nightshiftLights ? 'power' : 'close', {'nightshift' : 1}, null)}}
+			{{:helper.link('Disabled', null, {'nightshift' : 2}, data.nightshiftSetting == 2 ? 'selected' : null)}}
+			{{:helper.link('Automatic', null, {'nightshift' : 1}, data.nightshiftSetting == 1 ? 'selected' : null)}}
+			{{:helper.link('Enabled', null, {'nightshift' : 3}, data.nightshiftSetting == 3 ? 'selected' : null)}}
 		</div>
 	</div>
 


### PR DESCRIPTION
Adds a control to APCs for disabling and enabling nightshift mode in a way that isn't changed by the nightshift system.
![image](https://user-images.githubusercontent.com/4680835/81234044-fe89e280-8fc5-11ea-9259-a070522ada00.png)

Also fixes the cooldown while I'm here.

I've _probably_ committed programming sins here, I'm not familiar with DM and this is my first non-map PR in a long time. Sorry in advance.