### PR TITLE
Add Cyborg jobslot to the Talon Offmap Spawn [WIP]

### DIFF
--- a/code/game/jobs/jobs.dm
+++ b/code/game/jobs/jobs.dm
@@ -53,6 +53,7 @@ var/const/TALPIL			=(1<<1)
 var/const/TALDOC			=(1<<2)
 var/const/TALSEC			=(1<<3)
 var/const/TALENG			=(1<<4)
+var/const/TALBORG			=(1<<5)
 //VOREStation Add End
 
 /proc/guest_jobbans(var/job)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -261,12 +261,22 @@
 	//VOREStatation Edit Start: shell restrictions
 	if(shell)
 		modules.Add(shell_module_types)
+	var/area/A = get_area(src)
+	if(istype(A, /area/talon))
+		modules+="Talon K9 Medical Module"
+		modules+="Talon K9 Engineering Module"
+		modules+="Talon K9 Multipurpose Module"
+		modules+="Talon Engineering Module"
+		modules+="Talon Medical Module"
+		idcard_type = /obj/item/weapon/card/id/synthetic/talon
+		to_chat(src, "<font color= 'purple'>Talon modules available.</font>")
 	else
 		modules.Add(robot_module_types)
 		if(crisis || security_level == SEC_LEVEL_RED || crisis_override)
 			to_chat(src, "<font color='red'>Crisis mode active. Combat module available.</font>")
 			modules+="Combat"
 			modules+="ERT"
+		to_chat(src, "<font color= 'blue'>Tether modules available.</font>")
 	//VOREStatation Edit End: shell restrictions
 	modtype = input("Please, select a module!", "Robot module", null, null) as null|anything in modules
 

--- a/code/modules/mob/living/silicon/robot/robot_modules/station_vr.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules/station_vr.dm
@@ -648,6 +648,35 @@
 	R.verbs |= /mob/living/silicon/robot/proc/rest_style
 	..()
 
+// Rykka adds Talon modules
+
+/obj/item/weapon/robot_module/robot/talondogmed
+	name = "Talon K9 Medical Module"
+	channels = list("Talon" = 1)
+	networks = list(NETWORK_TALON_HELMETS, NETWORK_TALON_SHIP)
+
+/obj/item/weapon/robot_module/robot/talonengdog
+	name = "Talon K9 Engineering Module"
+	channels = list("Talon" = 1)
+	networks = list(NETWORK_TALON_HELMETS, NETWORK_TALON_SHIP)
+
+/obj/item/weapon/robot_module/robot/talonengborg
+	name = "Talon Engineering Module"
+	channels = list("Talon" = 1)
+	networks = list(NETWORK_TALON_HELMETS, NETWORK_TALON_SHIP)
+
+/obj/item/weapon/robot_module/robot/talonmedborg
+	name = "Talon Medical Module"
+	channels = list("Talon" = 1)
+	networks = list(NETWORK_TALON_HELMETS, NETWORK_TALON_SHIP)
+
+/obj/item/weapon/robot_module/robot/talonmultidog
+	name = "Talon K9 Multipurpose Module"
+	channels = list("Talon" = 1)
+	networks = list(NETWORK_TALON_HELMETS, NETWORK_TALON_SHIP)
+
+// Rykka edits stop here.
+
 // Uses modified K9 sprites.
 /obj/item/weapon/robot_module/robot/clerical/brodog
 	name = "service-hound module"

--- a/maps/tether/submaps/offmap/talon.dm
+++ b/maps/tether/submaps/offmap/talon.dm
@@ -1,12 +1,21 @@
 ///////////////////////////
 //// Spawning and despawning
 var/global/list/latejoin_talon = list()
+var/global/list/latejoin_talon_cyborg = list()
 /obj/effect/landmark/talon
 	name = "JoinLateTalon"
 	delete_me = 1
 
 /obj/effect/landmark/talon/New()
 	latejoin_talon += loc // Register this turf as tram latejoin.
+	..()
+
+/obj/effect/landmark/talon/cyborg
+	name = "JoinLateTalonCyborg"
+	delete_me = 1
+
+/obj/effect/landmark/talon/cyborg/New()
+	latejoin_talon_cyborg += loc // Register this turf as tram latejoin
 	..()
 
 /datum/spawnpoint/talon
@@ -19,6 +28,16 @@ var/global/list/latejoin_talon = list()
 	..()
 	turfs = latejoin_talon
 
+/datum/spawnpoint/taloncyborg
+	display_name = "ITV Talon Robot Storage"
+	restrict_job = list("Talon Cyborg")
+	msg = "has exited robot storage"
+	announce_channel = "Talon"
+
+/datum/spawnpoint/taloncyborg/New()
+	..()
+	turfs = latejoin_talon_cyborg
+
 /obj/machinery/cryopod/talon
 	announce_channel = "Talon"
 	on_store_message = "has entered cryogenic storage."
@@ -27,6 +46,13 @@ var/global/list/latejoin_talon = list()
 	on_enter_occupant_message = "You feel cool air surround you. You go numb as your senses turn inward."
 	on_store_visible_message_1 = "hums and hisses as it moves"
 	on_store_visible_message_2 = "into cryogenic storage."
+
+/obj/machinery/cryopod/robot/talon
+	announce_channel = "Talon"
+	on_store_message = "has entered robotic storage."
+	on_store_name = "ITV Talon Robotic Control"
+	on_enter_visible_message = "enters the"
+	on_enter_occupant_message = "The storage unit broadcasts a sleep signal to you. Your systems start to shut down, and you enter low-power mode."
 
 /obj/effect/landmark/map_data/talon
     height = 2

--- a/maps/tether/tether_defines.dm
+++ b/maps/tether/tether_defines.dm
@@ -121,7 +121,7 @@
 
 	bot_patrolling = FALSE
 
-	allowed_spawns = list("Tram Station","Gateway","Cryogenic Storage","Cyborg Storage","ITV Talon Cryo")
+	allowed_spawns = list("Tram Station","Gateway","Cryogenic Storage","Cyborg Storage","ITV Talon Cryo","ITV Talon Robotic Storage")
 	spawnpoint_died = /datum/spawnpoint/tram
 	spawnpoint_left = /datum/spawnpoint/tram
 	spawnpoint_stayed = /datum/spawnpoint/cryo

--- a/maps/tether/tether_jobs.dm
+++ b/maps/tether/tether_jobs.dm
@@ -109,6 +109,28 @@
 	access = list(access_talon)
 	minimal_access = list(access_talon)
 
+/datum/job/talon_cyborg
+	title = "Talon Cyborg"
+	flag = TALBORG
+	department_flag = TALON
+	job_description = "A Cyborg is a mobile synthetic, piloted by a cybernetically preserved brain. It is considered a person, but is still required \
+						to follow its Laws."
+	supervisors = "your Laws and the ITV Talon's Captain"	// Might add an AI to the Talon later :3
+	outfit_type = /decl/hierarchy/outfit/job/silicon/cyborg
+
+	offmap_spawn = TRUE
+	faction = "Station" //Required for SSjob to allow people to join as it
+	departments = list(DEPARTMENT_TALON)
+	total_positions = 1
+	spawn_positions = 1
+	selection_color = "#aaaaaa"
+	account_allowed = 0
+	economic_modifier = 0
+	minimal_player_age = 14
+	has_headset = FALSE
+	assignable = FALSE
+	mob_type = JOB_SILICON_ROBOT
+
 /decl/hierarchy/outfit/job/talon_captain
 	name = OUTFIT_JOB_NAME("Talon Captain")
 
@@ -193,3 +215,12 @@
 	messenger_bag = /obj/item/weapon/storage/backpack/messenger/engi
 	uniform = /obj/item/clothing/under/rank/atmospheric_technician
 	belt = /obj/item/weapon/storage/belt/utility/atmostech
+
+/datum/job/talon_cyborg/equip(var/mob/living/carbon/human/H)
+	if(!H)	return 0
+	return 1
+
+/datum/job/talon_cyborg/equip_preview(mob/living/carbon/human/H)
+	H.equip_to_slot_or_del(new /obj/item/clothing/suit/cardborg(H), slot_wear_suit)
+	H.equip_to_slot_or_del(new /obj/item/clothing/head/cardborg(H), slot_head)
+	return 1


### PR DESCRIPTION
Adds a Talon Cyborg jobslot, same 14 day wait.
Talon Modules and Tether Modules available depending on where you are. (If I could restrict it to spawn-in or a special IDcard or something I would). Check chat for a notification stating "x modules available."
Adds a borg recharger + cryo unit for cyborgs to Talon.
Lays groundwork for 3-4 dogborg modules with non-dogborg versions available.

...No it's not functional yet.
You can spawn, but the idcard still is the default robot one.
It still tries to autoconnect to the available AI.
AI/Cyborg code is a fucking snowflakey mess and I might try rewriting it provided I don't burnout from frustration by then.