### PR TITLE
Fix for Resetting Character Slot to Default

### DIFF
--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -81,6 +81,8 @@
 	else
 		player_setup.load_character(S)
 		S.cd = "/character[default_slot]"
+		player_setup.save_character(S)
+		sanitize_preferences()
 
 	player_setup.load_character(S)
 	return 1


### PR DESCRIPTION
Resets the character slot to default.
Fixes https://github.com/VOREStation/VOREStation/issues/7693

Credit goes to @ShadowLarkens  for helping me figure it out and implementing the solution.
