### PR TITLE
When looking at machines, don't allow mesons/material/etc

### DIFF
--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -454,6 +454,7 @@ Class Procs:
 	return 1
 
 /datum/proc/apply_visual(mob/M)
+	M.sight = 0 //Just reset their mesons and stuff so they can't use them, by default.
 	return
 
 /datum/proc/remove_visual(mob/M)

--- a/code/modules/overmap/ships/computers/ship.dm
+++ b/code/modules/overmap/ships/computers/ship.dm
@@ -58,6 +58,7 @@ somewhere on that shuttle. Subtypes of these can be then used to perform ship ov
 
 /obj/machinery/computer/ship/proc/look(var/mob/user)
 	if(linked)
+		apply_visual(user)
 		user.reset_view(linked)
 	user.set_viewsize(world.view + extra_view)
 	GLOB.moved_event.register(user, src, /obj/machinery/computer/ship/proc/unlook)


### PR DESCRIPTION
No using mesons on the overmap or through cameras, etc