### PR TITLE
[LOADOUT] Dept. AR Glasses

### DIFF
--- a/code/modules/client/preference_setup/loadout/loadout_eyes_vr.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_eyes_vr.dm
@@ -13,6 +13,27 @@
 	display_name = "AR glasses, prescription"
 	path = /obj/item/clothing/glasses/omnihud/prescription
 
+/datum/gear/eyes/arglasses/sec
+	display_name = "AR-S glasses (Sec)"
+	path = /obj/item/clothing/glasses/omnihud/sec
+	allowed_roles = list("Security Officer","Head of Security","Warden","Detective")
+
+/datum/gear/eyes/arglasses/eng
+	display_name = "AR-E glasses (Eng)"
+	path = /obj/item/clothing/glasses/omnihud/eng
+	allowed_roles = list("Station Engineer","Chief Engineer","Atmospheric Technician")
+
+/datum/gear/eyes/arglasses/med
+	display_name = "AR-M glasses (Medical)"
+	path = /obj/item/clothing/glasses/omnihud/med
+	allowed_roles = list("Medical Doctor","Chief Medical Officer","Chemist","Paramedic","Geneticist", "Psychiatrist", "Field Medic")
+
+/datum/gear/eyes/arglasses/all
+	display_name = "AR-B glasses (CD, HoP)"
+	path = /obj/item/clothing/glasses/omnihud/all
+	cost = 2
+	allowed_roles = list("Colony Director","Head of Personnel")
+
 /datum/gear/eyes/spiffygogs
 	display_name = "slick orange goggles"
 	path = /obj/item/clothing/glasses/fluff/spiffygogs


### PR DESCRIPTION
Basically just a downstream port (if you can call something so simple a port) of [this PR](https://github.com/Yawn-Wider/YWPolarisVore/pull/582) to add the departmental AR glasses to loadout with the same logic; they're readily available in departments and you can already get a bunch of other department eyewear in loadouts, so why not these?