### PR TITLE
Reduce maximum audible range of sounds [DNM]

### DIFF
--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -10,7 +10,7 @@
 
  	// Looping through the player list has the added bonus of working for mobs inside containers
 	var/sound/S = sound(get_sfx(soundin))
-	var/maxdistance = (world.view + extrarange) * 2
+	var/maxdistance = (world.view + extrarange) * 2  //VOREStation Edit - 3 to 2
 	var/list/listeners = player_list
 	if(!ignore_walls) //these sounds don't carry through walls
 		listeners = listeners & hearers(maxdistance,turf_source)

--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -10,7 +10,7 @@
 
  	// Looping through the player list has the added bonus of working for mobs inside containers
 	var/sound/S = sound(get_sfx(soundin))
-	var/maxdistance = (world.view + extrarange) * 3
+	var/maxdistance = (world.view + extrarange) * 2
 	var/list/listeners = player_list
 	if(!ignore_walls) //these sounds don't carry through walls
 		listeners = listeners & hearers(maxdistance,turf_source)


### PR DESCRIPTION
This is a global change - this reduces sounds to being audible at a MAXIMUM of 14 tiles from their source, unless the var is changed later. (I think).

Discuss if this is needed or not, please, and give all feedback, marking DNM until staff can weigh in.
