### PR TITLE
Swap default response for resleeving prompt

### DIFF
--- a/code/modules/resleeving/computers.dm
+++ b/code/modules/resleeving/computers.dm
@@ -356,7 +356,7 @@
 
 				//Body to sleeve into, but mind is in another living body.
 				if(active_mr.mind_ref.current && active_mr.mind_ref.current.stat < DEAD) //Mind is in a body already that's alive
-					var/answer = alert(active_mr.mind_ref.current,"Someone is attempting to restore a backup of your mind. Do you want to abandon this body, and move there? You MAY suffer memory loss! (Same rules as CMD apply)","Resleeving","Yes","No")
+					var/answer = alert(active_mr.mind_ref.current,"Someone is attempting to restore a backup of your mind. Do you want to abandon this body, and move there? You MAY suffer memory loss! (Same rules as CMD apply)","Resleeving","No","Yes")
 
 					//They declined to be moved.
 					if(answer == "No")


### PR DESCRIPTION
Applies when you're already in a body, so typing won't hit yes. If you're mashing keys you'll hit no instead.