### PR TITLE
Repurposes Explorer Corp Uniforms

### DIFF
--- a/code/modules/client/preference_setup/loadout/loadout_fluffitems_vr.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_fluffitems_vr.dm
@@ -92,7 +92,7 @@
 /datum/gear/fluff/aurora
 	path = /obj/item/clothing/accessory/solgov/department/security/aurora
 	display_name = "Aurora's keepsake"
-	description = "An old solgov sec insignia given to Aurora"
+	description = "An old solcom sec insignia given to Aurora"
 	ckeywhitelist = list("storesund97")
 	character_name = list("Aurora")
 
@@ -147,27 +147,6 @@
 /datum/gear/fluff/tasald_box
 	path = /obj/item/weapon/storage/box/fluff/tasald
 	display_name = "Tasald's Box"
-	ckeywhitelist = list("bwoincognito")
-	character_name = list("Tasald Corlethian")
-
-/datum/gear/fluff/tasald_cartographer_jumpsuit
-	path = /obj/item/clothing/under/solgov/utility/sifguard/officer/exploration
-	display_name = "Tasald's Cartographer's uniform - jumpsuit"
-	slot = slot_w_uniform
-	ckeywhitelist = list("bwoincognito")
-	character_name = list("Tasald Corlethian")
-
-/datum/gear/fluff/tasald_cartographer_jacket
-	path = /obj/item/clothing/suit/storage/service/sifguard/command
-	display_name = "Tasald's Cartographer's uniform - jacket"
-	slot = slot_wear_suit
-	ckeywhitelist = list("bwoincognito")
-	character_name = list("Tasald Corlethian")
-
-/datum/gear/fluff/tasald_cartographer_beret
-	path = /obj/item/clothing/head/beret/sol/expedition/command
-	display_name = "Tasald's Cartographer's uniform - beret"
-	slot = slot_head
 	ckeywhitelist = list("bwoincognito")
 	character_name = list("Tasald Corlethian")
 

--- a/code/modules/clothing/head/solgov_vr.dm
+++ b/code/modules/clothing/head/solgov_vr.dm
@@ -70,11 +70,11 @@
 //Dress
 
 /obj/item/clothing/head/dress/expedition
-	name = "\improper Nanotrasen dress cap"
+	name = "\improper NDF dress cap"
 	desc = "A peaked grey dress uniform cap belonging to the Nanotrasen Defense Force."
 
 /obj/item/clothing/head/dress/expedition/command
-	name = "\improper Nanotrasen command dress cap"
+	name = "\improper NDF command dress cap"
 	desc = "A peaked grey dress uniform cap belonging to the Nanotrasen Defense Force. This one is trimmed in gold."
 
 /obj/item/clothing/head/dress/fleet

--- a/code/modules/clothing/head/solgov_vr.dm
+++ b/code/modules/clothing/head/solgov_vr.dm
@@ -6,8 +6,8 @@
 	desc = "It's a blue ballcap in Terran Commonwealth Government colors."
 
 /obj/item/clothing/head/soft/sol/expedition
-	name = "\improper Explorer corps cap"
-	desc = "It's a black ballcap bearing a Terran Commonwealth Explorer Corps crest."
+	name = "\improper NDF cap"
+	desc = "It's a black ballcap bearing a Nanotrasen Defense Force crest."
 
 /obj/item/clothing/head/soft/sol/fleet
 	name = "fleet cap"
@@ -70,12 +70,12 @@
 //Dress
 
 /obj/item/clothing/head/dress/expedition
-	name = "explorer's dress cap"
-	desc = "A peaked grey dress uniform cap belonging to the Terran Commonwealth Explorer Corps."
+	name = "\improper Nanotrasen dress cap"
+	desc = "A peaked grey dress uniform cap belonging to the Nanotrasen Defense Force."
 
 /obj/item/clothing/head/dress/expedition/command
-	name = "explorer's command dress cap"
-	desc = "A peaked grey dress uniform cap belonging to the Terran Commonwealth Explorer Corps. This one is trimmed in gold."
+	name = "\improper Nanotrasen command dress cap"
+	desc = "A peaked grey dress uniform cap belonging to the Nanotrasen Defense Force. This one is trimmed in gold."
 
 /obj/item/clothing/head/dress/fleet
 	name = "fleet dress wheel cover"
@@ -124,28 +124,28 @@
 	desc = "A white beret denoting service in the Interstellar Health Service. For medics that are more inclined towards style than safety."
 
 /obj/item/clothing/head/beret/sol/expedition
-	name = "explorer's beret"
-	desc = "A black beret belonging to the Terran Commonwealth explorer corps. For personnel that are more inclined towards style than safety."
+	name = "\improper NDF beret"
+	desc = "A black beret belonging to the Nanotrasen Defense Force. For personnel that are more inclined towards style than safety."
 
 /obj/item/clothing/head/beret/sol/expedition/security
-	name = "explorer's security beret"
-	desc = "A Terran Commonwealth Explorer Corps beret with a security crest. For personnel that are more inclined towards style than safety."
+	name = "\improper NDF security beret"
+	desc = "A Nanotrasen Defense Force beret with a security crest. For personnel that are more inclined towards style than safety."
 
 /obj/item/clothing/head/beret/sol/expedition/medical
-	name = "explorer's medical beret"
-	desc = "A Terran Commonwealth Explorer Corps beret with a medical crest. For personnel that are more inclined towards style than safety."
+	name = "\improper NDF medical beret"
+	desc = "A Nanotrasen Defense Force beret with a medical crest. For personnel that are more inclined towards style than safety."
 
 /obj/item/clothing/head/beret/sol/expedition/engineering
-	name = "explorer's engineering beret"
-	desc = "A Terran Commonwealth Explorer Corps beret with an engineering crest. For personnel that are more inclined towards style than safety."
+	name = "\improper NDF engineering beret"
+	desc = "A Nanotrasen Defense Force beret with an engineering crest. For personnel that are more inclined towards style than safety."
 
 /obj/item/clothing/head/beret/sol/expedition/supply
-	name = "explorer's supply beret"
-	desc = "A Terran Commonwealth Explorer Corps beret with a supply crest. For personnel that are more inclined towards style than safety."
+	name = "\improper NDF supply beret"
+	desc = "A Nanotrasen Defense Force beret with a supply crest. For personnel that are more inclined towards style than safety."
 
 /obj/item/clothing/head/beret/sol/expedition/command
-	name = "explorer's command beret"
-	desc = "A Terran Commonwealth Explorer Corps beret with a command crest. For personnel that are more inclined towards style than safety."
+	name = "\improper NDF command beret"
+	desc = "A Nanotrasen Defense Force beret with a command crest. For personnel that are more inclined towards style than safety."
 
 /obj/item/clothing/head/beret/sol/fleet
 	name = "fleet beret"

--- a/code/modules/clothing/suits/solgov_vr.dm
+++ b/code/modules/clothing/suits/solgov_vr.dm
@@ -2,40 +2,40 @@
 
 //Service
 /obj/item/clothing/suit/storage/service/sifguard
-	name = "\improper SolCom jacket"
-	desc = "A uniform service jacket belonging to the Terran Commonwealth Explorer Corps. It has silver buttons."
+	name = "\improper NDF jacket"
+	desc = "A uniform service jacket belonging to the Nanotrasen Defense Force. It has silver buttons."
 
 /obj/item/clothing/suit/storage/service/sifguard/medical
-	name = "\improper SolCom medical jacket"
-	desc = "A uniform service jacket belonging to the Terran Commonwealth Explorer Corps. It has silver buttons and blue trim."
+	name = "\improper NDF medical jacket"
+	desc = "A uniform service jacket belonging to the Nanotrasen Defense Force. It has silver buttons and blue trim."
 
 /obj/item/clothing/suit/storage/service/sifguard/medical/command
-	name = "\improper SolCom medical command jacket"
-	desc = "A uniform service jacket belonging to the Terran Commonwealth Explorer Corps. It has gold buttons and blue trim."
+	name = "\improper NDF medical command jacket"
+	desc = "A uniform service jacket belonging to the Nanotrasen Defense Force. It has gold buttons and blue trim."
 
 /obj/item/clothing/suit/storage/service/sifguard/engineering
-	name = "\improper SolCom engineering jacket"
-	desc = "A uniform service jacket belonging to the Terran Commonwealth Explorer Corps. It has silver buttons and orange trim."
+	name = "\improper NDF engineering jacket"
+	desc = "A uniform service jacket belonging to the Nanotrasen Defense Force. It has silver buttons and orange trim."
 
 /obj/item/clothing/suit/storage/service/sifguard/engineering/command
-	name = "\improper SolCom engineering command jacket"
-	desc = "A uniform service jacket belonging to the Terran Commonwealth Explorer Corps. It has gold buttons and orange trim."
+	name = "\improper NDF engineering command jacket"
+	desc = "A uniform service jacket belonging to the Nanotrasen Defense Force. It has gold buttons and orange trim."
 
 /obj/item/clothing/suit/storage/service/sifguard/supply
-	name = "\improper SolCom supply jacket"
-	desc = "A uniform service jacket belonging to the Terran Commonwealth Explorer Corps. It has silver buttons and brown trim."
+	name = "\improper NDF supply jacket"
+	desc = "A uniform service jacket belonging to the Nanotrasen Defense Force. It has silver buttons and brown trim."
 
 /obj/item/clothing/suit/storage/service/sifguard/security
-	name = "\improper SolCom security jacket"
-	desc = "A uniform service jacket belonging to the Terran Commonwealth Explorer Corps. It has silver buttons and red trim."
+	name = "\improper NDF security jacket"
+	desc = "A uniform service jacket belonging to the Nanotrasen Defense Force. It has silver buttons and red trim."
 
 /obj/item/clothing/suit/storage/service/sifguard/security/command
-	name = "\improper SolCom security command jacket"
-	desc = "A uniform service jacket belonging to the Terran Commonwealth Explorer Corps. It has gold buttons and red trim."
+	name = "\improper NDF security command jacket"
+	desc = "A uniform service jacket belonging to the Nanotrasen Defense Force. It has gold buttons and red trim."
 
 /obj/item/clothing/suit/storage/service/sifguard/command
-	name = "\improper SolCom command jacket"
-	desc = "A uniform service jacket belonging to the Terran Commonwealth Explorer Corps. It has gold buttons and gold trim."
+	name = "\improper NDF command jacket"
+	desc = "A uniform service jacket belonging to the Nanotrasen Defense Force. It has gold buttons and gold trim."
 
 /obj/item/clothing/suit/storage/service/marine
 	name = "marine coat"
@@ -76,12 +76,12 @@
 //Dress
 
 /obj/item/clothing/suit/dress/expedition
-	name = "SolCom dress jacket"
-	desc = "A silver and grey dress jacket belonging to the Terran Commonwealth Explorer Corps. Fashionable, for the 24th century at least."
+	name = "\improper NDF dress jacket"
+	desc = "A silver and grey dress jacket belonging to the Nanotrasen Defense Force. Fashionable, for the 24th century at least."
 
 /obj/item/clothing/suit/dress/expedition/command
-	name = "explorer's command dress jacket"
-	desc = "A gold and grey dress jacket belonging to the Terran Commonwealth Explorer Corps. The height of fashion."
+	name = "\improper NDF command dress jacket"
+	desc = "A gold and grey dress jacket belonging to the Nanotrasen Defense Force. The height of fashion."
 
 /obj/item/clothing/suit/storage/toggle/dress/fleet
 	name = "fleet dress jacket"

--- a/code/modules/clothing/under/accessories/torch_vr.dm
+++ b/code/modules/clothing/under/accessories/torch_vr.dm
@@ -192,3 +192,22 @@ armour attachments
 /obj/item/clothing/accessory/armor/helmcover/blue/sol
 	name = "peacekeeper helmet cover"
 	desc = "A fabric cover for armored helmets. This one is in TCG peacekeeper colors."
+
+/*********
+ranks - ndf
+*********/
+/obj/item/clothing/accessory/solgov/rank/ec/enlisted
+	name = "ranks (E-1 seaman recruit)"
+	desc = "Insignia denoting the rank of Seaman Recruit."
+
+/obj/item/clothing/accessory/solgov/rank/ec/enlisted/e3
+	name = "ranks (E-3 seaman)"
+	desc = "Insignia denoting the rank of Seaman."
+
+/obj/item/clothing/accessory/solgov/rank/ec/enlisted/e5
+	name = "ranks (E-5 petty officer)"
+	desc = "Insignia denoting the rank of Petty Officer."
+
+/obj/item/clothing/accessory/solgov/rank/ec/enlisted/e7
+	name = "ranks (E-7 chief petty officer)"
+	desc = "Insignia denoting the rank of Chief Petty Officer."

--- a/code/modules/clothing/under/solgov_vr.dm
+++ b/code/modules/clothing/under/solgov_vr.dm
@@ -2,8 +2,8 @@
 
 //PT
 /obj/item/clothing/under/solgov/pt/sifguard
-	name = "\improper SolCom pt uniform"
-	desc = "A baggy shirt bearing the seal of the Terran Commonwealth Explorer Corps and some dorky looking blue shorts."
+	name = "\improper NDF pt uniform"
+	desc = "A baggy shirt bearing the seal of the Nanotrasen Defense Force and some dorky looking blue shorts."
 
 /obj/item/clothing/under/solgov/pt/fleet
 	name = "fleet pt uniform"
@@ -21,12 +21,12 @@
 	desc = "A comfortable turtleneck and black utility trousers."
 
 /obj/item/clothing/under/solgov/utility/sifguard
-	name = "\improper SolCom uniform"
-	desc = "The utility uniform of the Terran Commonwealth Explorer Corps, made from biohazard resistant material. This one has silver trim."
+	name = "\improper NDF uniform"
+	desc = "The utility uniform of the Nanotrasen Defense Force, made from biohazard resistant material. This one has silver trim."
 
 /obj/item/clothing/under/solgov/utility/sifguard/officer
-	name = "\improper SolCom officer uniform"
-	desc = "The utility uniform of the Terran Commonwealth Explorer Corps, made from biohazard resistant material. This one has gold trim."
+	name = "\improper NDF officer uniform"
+	desc = "The utility uniform of the Nanotrasen Defense Force, made from biohazard resistant material. This one has gold trim."
 
 
 /obj/item/clothing/under/solgov/utility/fleet
@@ -77,12 +77,12 @@
 	desc = "The service uniform of the TCG Marine Corps. Slimming and stylish."
 
 /obj/item/clothing/under/solgov/mildress/expeditionary
-	name = "\improper SolCom dress uniform"
-	desc = "The dress uniform of the Terran Commonwealth Explorer Corps in silver trim."
+	name = "\improper NDF dress uniform"
+	desc = "The dress uniform of the Nanotrasen Defense Force in silver trim."
 
 /obj/item/clothing/under/solgov/mildress/expeditionary/command
-	name = "\improper SolCom command dress uniform"
-	desc = "The dress uniform of the Terran Commonwealth Explorer Corps in gold trim."
+	name = "\improper NDF command dress uniform"
+	desc = "The dress uniform of the Nanotrasen Defense Force in gold trim."
 
 /obj/item/clothing/under/solgov/mildress/marine
 	name = "marine dress uniform"


### PR DESCRIPTION
Repurposes the SEV Torch Explorer Corp uniforms into uniforms for the Nanotrasen Defense Force.

Also purges some remaining Universal Cartographer related stuff, mostly fluff items