### PR TITLE
AI PiP Fixes

### DIFF
--- a/code/_onclick/hud/_defines.dm
+++ b/code/_onclick/hud/_defines.dm
@@ -75,8 +75,8 @@
 #define ui_ai_pda_log "SOUTH:6,WEST+11:16"
 #define ui_ai_take_picture "SOUTH:6,WEST+12:16"
 #define ui_ai_view_images "SOUTH:6,WEST+13:16"
-#define ui_ai_multicam "SOUTH+1:6,WEST+13"
-#define ui_ai_add_multicam "SOUTH+1:6,WEST+14"
+#define ui_ai_multicam "SOUTH+1:6,WEST+12:16"
+#define ui_ai_add_multicam "SOUTH+1:6,WEST+13:16"
 
 //Gun buttons
 #define ui_gun1 "EAST-2:26,SOUTH+2:7"

--- a/code/_onclick/hud/picture_in_picture.dm
+++ b/code/_onclick/hud/picture_in_picture.dm
@@ -2,6 +2,7 @@
 	name = "Picture-in-picture"
 	screen_loc = "CENTER"
 	plane = PLANE_WORLD
+	icon = null
 	var/atom/center
 	var/width = 0
 	var/height = 0

--- a/code/modules/mob/freelook/ai/eye.dm
+++ b/code/modules/mob/freelook/ai/eye.dm
@@ -86,7 +86,12 @@
 /atom/proc/move_camera_by_click()
 	if(istype(usr, /mob/living/silicon/ai))
 		var/mob/living/silicon/ai/AI = usr
-		if(AI.eyeobj && (AI.multicam_on || (AI.client.eye == AI.eyeobj)))
+		if(AI.eyeobj)
++            if(!AI.multicam_on || AI.client.eye != AI.eyeobj)
++                return
++            var/area/A = get_area(AI.eyeobj)
++            if(istype(A, /area/ai_multicam_room))
++                return
 			var/turf/T = get_turf(src)
 			if(T)
 				AI.eyeobj.setLoc(T)

--- a/code/modules/mob/freelook/ai/eye.dm
+++ b/code/modules/mob/freelook/ai/eye.dm
@@ -87,11 +87,11 @@
 	if(istype(usr, /mob/living/silicon/ai))
 		var/mob/living/silicon/ai/AI = usr
 		if(AI.eyeobj)
-+            if(!AI.multicam_on || AI.client.eye != AI.eyeobj)
-+                return
-+            var/area/A = get_area(AI.eyeobj)
-+            if(istype(A, /area/ai_multicam_room))
-+                return
+			if(!AI.multicam_on || AI.client.eye != AI.eyeobj)
+				return
+			var/area/A = get_area(AI.eyeobj)
+			if(istype(A, /area/ai_multicam_room))
+				return
 			var/turf/T = get_turf(src)
 			if(T)
 				AI.eyeobj.setLoc(T)


### PR DESCRIPTION
Fixes the undefined icon resulting in this:
![https://i.tigercat2000.net/2020/05/firefox_4x2cbYTrT1.png](https://i.tigercat2000.net/2020/05/firefox_4x2cbYTrT1.png)
Fixes the two buttons being misaligned with the UI.
Fixes double-clicking inside the AI PiP room teleporting the AI Eye out to the room and completely breaking the view. Do note that double-clicking no longer works at all inside the multi-cam room, as a tradeoff for completely preventing UI breaks.
