### PR TITLE
Allows Cyborgs and AI to earn PTO and departmental playtime

### DIFF
--- a/code/__defines/misc_vr.dm
+++ b/code/__defines/misc_vr.dm
@@ -57,6 +57,8 @@
 #define PTO_EXPLORATION 	"Exploration"
 #define PTO_CARGO			"Cargo"
 #define PTO_CIVILIAN		"Civilian"
+#define PTO_CYBORG			"Cyborg"
+#define PTO_AI				"AI"
 
 #define DEPARTMENT_TALON	"ITV Talon"
 

--- a/code/__defines/misc_vr.dm
+++ b/code/__defines/misc_vr.dm
@@ -58,7 +58,6 @@
 #define PTO_CARGO			"Cargo"
 #define PTO_CIVILIAN		"Civilian"
 #define PTO_CYBORG			"Cyborg"
-#define PTO_AI				"AI"
 
 #define DEPARTMENT_TALON	"ITV Talon"
 

--- a/code/controllers/subsystems/persist_vr.dm
+++ b/code/controllers/subsystems/persist_vr.dm
@@ -45,6 +45,19 @@ SUBSYSTEM_DEF(persist)
 		var/department_earning = J.pto_type
 		clear_unused_pto(M)
 
+		// Determine special PTO types and convert properly
+		if(department_earning == PTO_AI)
+			department_earning = PTO_CIVILIAN
+		if(department_earning == PTO_CYBORG)
+			if(istype(M, /mob/living/silicon/robot))
+				var/mob/living/silicon/robot/C = M
+				if(C.module && C.module.pto_type)
+					department_earning = C.module.pto_type
+			if(department_earning == PTO_CYBORG)
+				if (MC_TICK_CHECK)
+					return
+				continue
+
 		// Update client whatever
 		var/client/C = M.client
 		var/wait_in_hours = wait / (1 HOUR)

--- a/code/controllers/subsystems/persist_vr.dm
+++ b/code/controllers/subsystems/persist_vr.dm
@@ -46,8 +46,6 @@ SUBSYSTEM_DEF(persist)
 		clear_unused_pto(M)
 
 		// Determine special PTO types and convert properly
-		if(department_earning == PTO_AI)
-			department_earning = PTO_CIVILIAN
 		if(department_earning == PTO_CYBORG)
 			if(isrobot(M))
 				var/mob/living/silicon/robot/C = M

--- a/code/controllers/subsystems/persist_vr.dm
+++ b/code/controllers/subsystems/persist_vr.dm
@@ -49,9 +49,9 @@ SUBSYSTEM_DEF(persist)
 		if(department_earning == PTO_AI)
 			department_earning = PTO_CIVILIAN
 		if(department_earning == PTO_CYBORG)
-			if(istype(M, /mob/living/silicon/robot))
+			if(isrobot(M))
 				var/mob/living/silicon/robot/C = M
-				if(C.module && C.module.pto_type)
+				if(C?.module?.pto_type)
 					department_earning = C.module.pto_type
 			if(department_earning == PTO_CYBORG)
 				if (MC_TICK_CHECK)

--- a/code/game/jobs/job/silicon_vr.dm
+++ b/code/game/jobs/job/silicon_vr.dm
@@ -1,5 +1,5 @@
 /datum/job/ai
-	pto_type = PTO_AI
+	pto_type = PTO_CIVILIAN
 
 /datum/job/cyborg
 	pto_type = PTO_CYBORG

--- a/code/game/jobs/job/silicon_vr.dm
+++ b/code/game/jobs/job/silicon_vr.dm
@@ -1,4 +1,8 @@
+/datum/job/ai
+	pto_type = PTO_AI
+
 /datum/job/cyborg
+	pto_type = PTO_CYBORG
 	minimal_player_age = 3		//1 day is a little too little time
 	total_positions = 4 		//Along with one able to spawn later in the round.
 	spawn_positions = 3 		//Let's have 3 able to spawn in roundstart

--- a/code/modules/mob/living/silicon/robot/robot_modules/station_vr.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules/station_vr.dm
@@ -15,6 +15,7 @@
 					LANGUAGE_ENOCHIAN	= 0
 					)
 	var/vr_sprites = list()
+	var/pto_type = null
 
 /obj/item/weapon/robot_module/robot/clerical
 	languages = list(
@@ -63,14 +64,16 @@
 	src.modules += new /obj/item/device/sleevemate(src) //Lets them scan people.
 	. = ..() //Any Global vore modules will come from here
 
-/obj/item/weapon/robot_module/robot/medical/surgeon //VOREStation sprites
+/obj/item/weapon/robot_module/robot/medical/surgeon
+	pto_type = PTO_MEDICAL
 	vr_sprites = list(
 						"Acheron" = "mechoid-Medical",
 						"Shellguard Noble" = "Noble-MED",
 						"ZOOM-BA" = "zoomba-medical"
 					 )
 
-/obj/item/weapon/robot_module/robot/medical/crisis //VOREStation sprites
+/obj/item/weapon/robot_module/robot/medical/crisis
+	pto_type = PTO_MEDICAL
 	vr_sprites = list(
 						"Handy" = "handy-med",
 						"Acheron" = "mechoid-Medical",
@@ -78,7 +81,8 @@
 						"ZOOM-BA" = "zoomba-crisis"
 					 )
 
-/obj/item/weapon/robot_module/robot/clerical/butler //VOREStation sprites
+/obj/item/weapon/robot_module/robot/clerical/butler
+	pto_type = PTO_CIVILIAN
 	vr_sprites = list(
 						"Handy - Service" = "handy-service",
 						"Handy - Hydro" = "handy-hydro",
@@ -87,7 +91,8 @@
 						"ZOOM-BA" = "zoomba-service"
 					 )
 
-/obj/item/weapon/robot_module/robot/clerical/general //VOREStation sprites
+/obj/item/weapon/robot_module/robot/clerical/general
+	pto_type = PTO_CIVILIAN
 	vr_sprites = list(
 						"Handy" = "handy-clerk",
 						"Acheron" = "mechoid-Service",
@@ -95,7 +100,8 @@
 						"ZOOM-BA" = "zoomba-clerical"
 					 )
 
-/obj/item/weapon/robot_module/robot/janitor //VOREStation sprites
+/obj/item/weapon/robot_module/robot/janitor
+	pto_type = PTO_CIVILIAN
 	vr_sprites = list(
 						"Handy" = "handy-janitor",
 						"Acheron" = "mechoid-Janitor",
@@ -103,7 +109,8 @@
 						"ZOOM-BA" = "zoomba-janitor"
 					 )
 
-/obj/item/weapon/robot_module/robot/security/general //VOREStation sprites
+/obj/item/weapon/robot_module/robot/security/general
+	pto_type = PTO_SECURITY
 	vr_sprites = list(
 						"Handy" = "handy-sec",
 						"Acheron" = "mechoid-Security",
@@ -111,7 +118,8 @@
 						"ZOOM-BA" = "zoomba-security"
 					 )
 
-/obj/item/weapon/robot_module/robot/miner //VOREStation sprites
+/obj/item/weapon/robot_module/robot/miner
+	pto_type = PTO_CARGO
 	vr_sprites = list(
 						"Handy" = "handy-miner",
 						"Acheron" = "mechoid-Miner",
@@ -119,28 +127,31 @@
 						"ZOOM-BA" = "zoomba-miner"
 					 )
 
-/obj/item/weapon/robot_module/robot/standard //VOREStation sprites
+/obj/item/weapon/robot_module/robot/standard
+	pto_type = PTO_CIVILIAN
 	vr_sprites = list(
 						"Handy" = "handy-standard",
 						"Acheron" = "mechoid-Standard",
 						"Shellguard Noble" = "Noble-STD",
 						"ZOOM-BA" = "zoomba-standard"
 					 )
-
-/obj/item/weapon/robot_module/robot/engineering/general //VOREStation sprites
+/obj/item/weapon/robot_module/robot/engineering/general
+	pto_type = PTO_ENGINEERING
 	vr_sprites = list(
 						"Acheron" = "mechoid-Engineering",
 						"Shellguard Noble" = "Noble-ENG",
 						"ZOOM-BA" = "zoomba-engineering"
 					 )
 
-/obj/item/weapon/robot_module/robot/research //VOREStation sprites
+/obj/item/weapon/robot_module/robot/research
+	pto_type = PTO_SCIENCE
 	vr_sprites = list(
 						"Acheron" = "mechoid-Science",
 						"ZOOM-BA" = "zoomba-research"
 					 )
 
-/obj/item/weapon/robot_module/robot/security/combat //VOREStation sprites
+/obj/item/weapon/robot_module/robot/security/combat
+	pto_type = PTO_SECURITY
 	vr_sprites = list(
 						"Acheron" = "mechoid-Combat",
 						"ZOOM-BA" = "zoomba-combat"
@@ -156,6 +167,7 @@
 					)
 	channels = list("Security" = 1)
 	networks = list(NETWORK_SECURITY)
+	pto_type = PTO_SECURITY
 	can_be_pushed = 0
 
 /obj/item/weapon/robot_module/robot/knine/New(var/mob/living/silicon/robot/R)
@@ -221,6 +233,7 @@
 	channels = list("Medical" = 1)
 	networks = list(NETWORK_MEDICAL)
 	subsystems = list(/mob/living/silicon/proc/subsystem_crew_monitor)
+	pto_type = PTO_MEDICAL
 	can_be_pushed = 0
 	sprites = list(
 					"Medical Hound" = "medihound",
@@ -276,6 +289,7 @@
 	name = "Emergency Responce module"
 	channels = list("Security" = 1)
 	networks = list(NETWORK_SECURITY)
+	pto_type = PTO_SECURITY
 	can_be_pushed = 0
 	sprites = list(
 					"Standard" = "ert",
@@ -327,6 +341,7 @@
 					"Borgi" = "borgi-jani"
 					)
 	channels = list("Service" = 1)
+	pto_type = PTO_CIVILIAN
 	can_be_pushed = 0
 
 /obj/item/weapon/robot_module/robot/scrubpup/New(var/mob/living/silicon/robot/R)
@@ -411,6 +426,7 @@
 					"SciHoundDark" = "scihounddark"
 					)
 	channels = list("Science" = 1)
+	pto_type = PTO_SCIENCE
 	can_be_pushed = 0
 
 /obj/item/weapon/robot_module/robot/science/New(var/mob/living/silicon/robot/R)
@@ -486,6 +502,7 @@
 					)
 	channels = list("Engineering" = 1)
 	networks = list(NETWORK_ENGINEERING)
+	pto_type = PTO_ENGINEERING
 	subsystems = list(/mob/living/silicon/proc/subsystem_power_monitor)
 	can_be_pushed = 0
 
@@ -632,6 +649,7 @@
 					"ServicehoundV2 Darkmode" = "servedark",
 					)
 	channels = list("Service" = 1)
+	pto_type = PTO_CIVILIAN
 	can_be_pushed = 0
 
 
@@ -703,6 +721,7 @@
 					"CargoHoundDark" = "cargohounddark"
 					)
 	channels = list("Supply" = 1)
+	pto_type = PTO_CARGO
 	can_be_pushed = 0
 
 /obj/item/weapon/robot_module/robot/kmine/New(var/mob/living/silicon/robot/R)


### PR DESCRIPTION
Title. Since PTO is half-OOC thing anyway (being account-wide rather than character-specific) I don't see any reason to not reward synthetic players, since they are just as much of contributors as any humanmob department member.

AI earns Civilian PTO
Borgs earn PTO based on module:
Standard, Clerical, Service, Janitor, Janihound, Brodog - Civilian PTO
Surgeon, Crisis, Medihound - Medical PTO
Engineering, Pupdozer - Engineering PTO
Security, Combat, K9, ERT - Security PTO
Research, Sci-borg - Science PTO
Mining, KMine - Cargo PTO