### PR TITLE
Tweaks to Photocopier, Adjust NanoUI, and allow Butt Photocopying!

### DIFF
--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -295,13 +295,17 @@
 				temp_img = icon('icons/obj/butts_vr.dmi', "vulp") // Give Werewolves their own thicc'er than a boal of oatmeal ass sprite someday?
 			if(SPECIES_XENOHYBRID, SPECIES_XENO, SPECIES_XENO_DRONE, SPECIES_XENO_HUNTER, SPECIES_XENO_QUEEN, SPECIES_XENO_SENTINEL) // Xenos + Xenohybrids have their own asses, thanks to Pybro.
 				temp_img = icon('icons/obj/butts_vr.dmi', "xeno")
+			if(SPECIES_ZORREN_HIGH)
+				temp_img = icon('icons/obj/butts_vr.dmi', "vulp") // placeholder until we get zorren butts.
+			if(SPECIES_FENNEC)
+				temp_img = icon('icons/obj/butts_vr.dmi', "vulp") // placeholder until we get fennec butts.
+			if(SPECIES_AKULA)
+				temp_img = icon('icons/obj/butts_vr.dmi', "xeno") // placeholder until we get proper sharkbutt. AKULA BE THICC ASS SHARKS MMMMMMMMMMMMMMKAY?
 			/* // Commented out because no icons exist, BUT if someone wants to sprite some more ASSCHEEKS, then just uncomment these and you have asses for each species. - Rykka.
 			if(SPECIES_TESHARI)
 				temp_img = icon('icons/obj/butts_vr.dmi', "tesh")
 			if(SPECIES_SHADEKIN || SPECIES_SHADEKIN_CREW)
 				temp_img = icon('icons/obj/butts_vr.dmi', "shadekin") 
-			if(SPECIES_AKULA)
-				temp_img = icon('icons/obj/butts_vr.dmi', "akula")
 			if(SPECIES_ALRAUNE)
 				temp_img = icon('icons/obj/butts_vr.dmi', "alraune")
 			if(SPECIES_NEVREAN)
@@ -310,10 +314,6 @@
 				temp_img = icon('icons/obj/butts_vr.dmi', "rapala")
 			if(SPECIES_ZADDAT)
 				temp_img = icon('icons/obj/butts_vr.dmi', "zaddat")
-			if(SPECIES_ZORREN_HIGH)
-				temp_img = icon('icons/obj/butts_vr.dmi', "zorren")
-			if(SPECIES_FENNEC)
-				temp_img = icon('icons/obj/butts_vr.dmi', "fennec")
 			if(SPECIES_SERGAL)
 				temp_img = icon('icons/obj/butts_vr.dmi', "sergal")
 			*/

--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -11,10 +11,12 @@
 	active_power_usage = 200
 	power_channel = EQUIP
 	circuit = /obj/item/weapon/circuitboard/photocopier
+	can_buckle = TRUE
 	var/obj/item/copyitem = null	//what's in the copier!
 	var/copies = 1	//how many copies to print!
 	var/toner = 30 //how much toner is left! woooooo~
 	var/maxcopies = 10	//how many copies can be copied at once- idea shamelessly stolen from bs12's copier!
+	var/copying = FALSE // Is the printer busy with something? Sanity check variable.
 
 /obj/machinery/photocopier/Initialize()
 	. = ..()
@@ -43,6 +45,7 @@
 
 	var/list/data = list()
 	data["copyItem"] = copyitem
+	data["assPresent"] = has_buckled_mobs()
 	data["toner"] = toner
 	data["copies"] = copies
 	data["maxCopies"] = maxcopies
@@ -58,39 +61,64 @@
 		ui.open()
 		ui.set_auto_update(10)
 
+/obj/machinery/photocopier/proc/copy_operation(var/mob/user)
+	if(copying)
+		return FALSE
+	copying = TRUE
+	for(var/i = 0, i < copies, i++)
+		if(toner <= 0)
+			break
+
+		if (istype(copyitem, /obj/item/weapon/paper))
+			playsound(loc, "sound/machines/copier.ogg", 100, 1)
+			sleep(11)
+			copy(copyitem)
+			audible_message("<span class='notice'>You can hear [src] whirring as it finishes printing.</span>")
+			playsound(loc, "sound/machines/buzzbeep.ogg", 30)
+		else if (istype(copyitem, /obj/item/weapon/photo))
+			playsound(loc, "sound/machines/copier.ogg", 100, 1)
+			sleep(11)
+			photocopy(copyitem)
+			audible_message("<span class='notice'>You can hear [src] whirring as it finishes printing.</span>")
+			playsound(loc, "sound/machines/buzzbeep.ogg", 30)
+		else if (istype(copyitem, /obj/item/weapon/paper_bundle))
+			sleep(11)
+			playsound(loc, "sound/machines/copier.ogg", 100, 1)
+			var/obj/item/weapon/paper_bundle/B = bundlecopy(copyitem)
+			sleep(11*B.pages.len)
+			audible_message("<span class='notice'>You can hear [src] whirring as it finishes printing.</span>")
+			playsound(loc, "sound/machines/buzzbeep.ogg", 30)
+		else if (has_buckled_mobs()) // VOREStation EDIT: For ass-copying.
+			playsound(loc, "sound/machines/copier.ogg", 100, 1)
+			audible_message("<span class='notice'>You can hear [src] whirring as it attempts to scan.</span>")
+			sleep(rand(20,45)) // Sit with your bare ass on the copier for a random time, feel like a fool, get stared at.
+			copyass(user)
+			sleep(15)
+			audible_message("<span class='notice'>You can hear [src] whirring as it finishes printing.</span>")
+			playsound(loc, "sound/machines/buzzbeep.ogg", 30)
+		else
+			to_chat(user, "<span class='warning'>\The [copyitem] can't be copied by [src].</span>")
+			playsound(loc, "sound/machines/buzz-two.ogg", 100)
+			break
+
+		use_power(active_power_usage)
+	copying = FALSE
+
 /obj/machinery/photocopier/Topic(href, href_list)
 	if(href_list["copy"])
 		if(stat & (BROKEN|NOPOWER))
 			return
+		addtimer(CALLBACK(src, .proc/copy_operation, usr), 0)
 
-		for(var/i = 0, i < copies, i++)
-			if(toner <= 0)
-				break
-
-			if (istype(copyitem, /obj/item/weapon/paper))
-				playsound(loc, "sound/machines/copier.ogg", 100, 1)
-				sleep(11)
-				copy(copyitem)
-			else if (istype(copyitem, /obj/item/weapon/photo))
-				playsound(loc, "sound/machines/copier.ogg", 100, 1)
-				sleep(11)
-				photocopy(copyitem)
-			else if (istype(copyitem, /obj/item/weapon/paper_bundle))
-				sleep(11)
-				playsound(loc, "sound/machines/copier.ogg", 100, 1)
-				var/obj/item/weapon/paper_bundle/B = bundlecopy(copyitem)
-				sleep(11*B.pages.len)
-			else
-				to_chat(usr, "<span class='warning'>\The [copyitem] can't be copied by \the [src].</span>")
-				break
-
-			use_power(active_power_usage)
 	else if(href_list["remove"])
 		if(copyitem)
 			copyitem.loc = usr.loc
 			usr.put_in_hands(copyitem)
 			to_chat(usr, "<span class='notice'>You take \the [copyitem] out of \the [src].</span>")
 			copyitem = null
+		else if(has_buckled_mobs())
+			to_chat(buckled_mobs[1], "<span class='notice'>You feel a slight pressure on your ass.</span>") // It can't eject your asscheeks, but it'll try.
+			return TOPIC_REFRESH
 	else if(href_list["min"])
 		if(copies > 1)
 			copies--
@@ -145,7 +173,6 @@
 		playsound(loc, O.usesound, 50, 1)
 		anchored = !anchored
 		to_chat(user, "<span class='notice'>You [anchored ? "wrench" : "unwrench"] \the [src].</span>")
-
 	else if(default_deconstruction_screwdriver(user, O))
 		return
 	else if(default_deconstruction_crowbar(user, O))
@@ -205,6 +232,7 @@
 	if(need_toner)
 		toner--
 	if(toner == 0)
+		playsound(loc, "sound/machines/buzz-sigh.ogg", 100)
 		visible_message("<span class='notice'>A red light on \the [src] flashes, indicating that it is out of toner.</span>")
 	return c
 
@@ -227,9 +255,95 @@
 		toner -= 5	//photos use a lot of ink!
 	if(toner < 0)
 		toner = 0
+		playsound(loc, "sound/machines/buzz-sigh.ogg", 100)
 		visible_message("<span class='notice'>A red light on \the [src] flashes, indicating that it is out of toner.</span>")
 
 	return p
+
+// VOREStation Edit Start
+
+/obj/machinery/photocopier/proc/copyass(mob/user)
+	var/icon/temp_img
+	if(!has_buckled_mobs()) // Are there no mobs buckled to the photocopier?
+		return
+	var/mob/sitter = buckled_mobs[1] // You have to be sitting on the copier/buckled to it and either be a xeno or a human without clothes on that cover your ass.
+	if(ishuman(sitter)) // Suit checks are in can_buckle_mobs at the bottom of the file.
+		var/mob/living/carbon/human/H = sitter // All human subtypes.
+		var/species_to_check = H.get_species()
+		if(species_to_check == SPECIES_CUSTOM || species_to_check == SPECIES_XENOCHIMERA) // Are we a custom species, or Xenochimera? If so, what is the base icon sprite for our species?
+			species_to_check = H.species.base_species // Grab the base species and use that as the 'species' for the purpose of printing off your asscheeks.
+		switch(species_to_check)
+			if(SPECIES_HUMAN)
+				temp_img = icon('icons/obj/butts_vr.dmi', "human")
+			if(SPECIES_TAJ)
+				temp_img = icon('icons/obj/butts_vr.dmi', "tajaran")
+			if(SPECIES_UNATHI)
+				temp_img = icon('icons/obj/butts_vr.dmi', "unathi")
+			if(SPECIES_SKRELL)
+				temp_img = icon('icons/obj/butts_vr.dmi', "skrell")
+			if(SPECIES_VOX)
+				temp_img = icon('icons/obj/butts_vr.dmi', "vox")
+			if(SPECIES_DIONA)
+				temp_img = icon('icons/obj/butts_vr.dmi', "diona")
+			if(SPECIES_PROMETHEAN)
+				temp_img = icon('icons/obj/butts_vr.dmi', "slime")
+			if(SPECIES_VULPKANIN)
+				temp_img = icon('icons/obj/butts_vr.dmi', "vulp")
+			if(SPECIES_PROTEAN)
+				temp_img = icon('icons/obj/butts_vr.dmi', "machine")
+			if(SPECIES_WEREBEAST)
+				temp_img = icon('icons/obj/butts_vr.dmi', "vulp") // Give Werewolves their own thicc'er than a boal of oatmeal ass sprite someday?
+			if(SPECIES_XENOHYBRID, SPECIES_XENO, SPECIES_XENO_DRONE, SPECIES_XENO_HUNTER, SPECIES_XENO_QUEEN, SPECIES_XENO_SENTINEL) // Xenos + Xenohybrids have their own asses, thanks to Pybro.
+				temp_img = icon('icons/obj/butts_vr.dmi', "xeno")
+			/* // Commented out because no icons exist, BUT if someone wants to sprite some more ASSCHEEKS, then just uncomment these and you have asses for each species. - Rykka.
+			if(SPECIES_TESHARI)
+				temp_img = icon('icons/obj/butts_vr.dmi', "tesh")
+			if(SPECIES_SHADEKIN || SPECIES_SHADEKIN_CREW)
+				temp_img = icon('icons/obj/butts_vr.dmi', "shadekin") 
+			if(SPECIES_AKULA)
+				temp_img = icon('icons/obj/butts_vr.dmi', "akula")
+			if(SPECIES_ALRAUNE)
+				temp_img = icon('icons/obj/butts_vr.dmi', "alraune")
+			if(SPECIES_NEVREAN)
+				temp_img = icon('icons/obj/butts_vr.dmi', "nevrean")
+			if(SPECIES_RAPALA)
+				temp_img = icon('icons/obj/butts_vr.dmi', "rapala")
+			if(SPECIES_ZADDAT)
+				temp_img = icon('icons/obj/butts_vr.dmi', "zaddat")
+			if(SPECIES_ZORREN_HIGH)
+				temp_img = icon('icons/obj/butts_vr.dmi', "zorren")
+			if(SPECIES_FENNEC)
+				temp_img = icon('icons/obj/butts_vr.dmi', "fennec")
+			if(SPECIES_SERGAL)
+				temp_img = icon('icons/obj/butts_vr.dmi', "sergal")
+			*/
+			else // Sanity/Safety check - does their species not show up or not work, or did something fail, but they're DEFINITELY a /human/ subtype? Print the 'default' ass.
+				temp_img = icon('icons/obj/butts_vr.dmi', "human")
+	else if(istype(sitter,/mob/living/silicon/robot/drone)) // Are we a drone?
+		temp_img = icon('icons/obj/butts_vr.dmi', "drone")
+	else if(istype(sitter,/mob/living/carbon/alien/diona)) // Are we a nymph, instead of a full-grown Diona?
+		temp_img = icon('icons/obj/butts_vr.dmi', "nymph")
+	else 
+		return
+	var/obj/item/weapon/photo/p = new /obj/item/weapon/photo (loc)
+	p.desc = "You see [sitter]'s ass on the photo."
+	p.pixel_x = rand(-10, 10)
+	p.pixel_y = rand(-10, 10)
+	p.img = temp_img
+	p.drop_sound = 'sound/items/drop/paper.ogg'
+	var/icon/small_img = icon(temp_img) // Icon() is needed or else temp_img will be rescaled too >.>
+	var/icon/ic = icon('icons/obj/items.dmi',"photo")
+	small_img.Scale(8, 8)
+	ic.Blend(small_img,ICON_OVERLAY, 10, 13)
+	p.icon = ic
+	toner -= 10 // PHOTOCOPYING YOUR ASS IS EXPENSIVE (And so you can't just spam it a bunch).
+	if(toner < 0)
+		toner = 0
+		playsound(loc, "sound/machines/buzz-sigh.ogg", 100)
+		visible_message("<span class='notice'>A red light on \the [src] flashes, indicating that it is out of toner.</span>")
+	return p
+
+// VOREStation Edit Stop
 
 //If need_toner is 0, the copies will still be lightened when low on toner, however it will not be prevented from printing. TODO: Implement print queues for fax machines and get rid of need_toner
 /obj/machinery/photocopier/proc/bundlecopy(var/obj/item/weapon/paper_bundle/bundle, var/need_toner=1)
@@ -237,6 +351,7 @@
 	for(var/obj/item/weapon/W in bundle.pages)
 		if(toner <= 0 && need_toner)
 			toner = 0
+			playsound(loc, "sound/machines/buzz-sigh.ogg", 100)
 			visible_message("<span class='notice'>A red light on \the [src] flashes, indicating that it is out of toner.</span>")
 			break
 
@@ -254,6 +369,21 @@
 	p.pixel_y = rand(-8, 8)
 	p.pixel_x = rand(-9, 9)
 	return p
+
+// VOREStation Edit Start - Rykka
+
+/obj/machinery/photocopier/can_buckle_check(mob/living/M, forced = FALSE)
+	if(!..()) 
+		return FALSE
+	for(var/obj/item/clothing/C in M)
+		if(M.item_is_in_hands(C))
+			continue
+		if((C.body_parts_covered & LOWER_TORSO) && !istype(C,/obj/item/clothing/under/permit))
+			to_chat(usr, "<span class='warning'>One needs to not be wearing pants to photocopy one's ass...</span>")
+			return FALSE
+	return TRUE
+
+// VOREStation Edit Stop - Rykka
 
 /obj/item/device/toner
 	name = "toner cartridge"

--- a/nano/templates/photocopier.tmpl
+++ b/nano/templates/photocopier.tmpl
@@ -3,12 +3,11 @@
 	See: code/modules/paperwork/photocopier.dm
 -->
 
-{{if data.copyItem}}
+{{if data.copyItem || data.assPresent}}
 	<div class='item'>
 	{{:helper.link('Remove Item', 'eject', {'remove' : 1})}}
 	{{if data.toner}}
-		{{:helper.link('Copy', 'copy', {'copy' : 1})}}</div>
-		<hr>
+		{{:helper.link('Copy', 'copy', {'copy' : 1})}}
 		<div class='item'>
 			<div class='itemLabel'>
 				Printing: 
@@ -27,10 +26,9 @@
 			<div class='itemContentNarrow'><b>{{:data.toner}}</b>u</div>
 		</div>
 	{{else}}
-	<div class='item'>
 		<span class='average'>Please insert a new toner cartridge!</span>
-	</div>
 	{{/if}}
+	</div>
 {{else data.toner}}
 	<h3>Please insert something to copy.</h3>
 	{{if data.isSilicon}}


### PR DESCRIPTION
You can photocopy your ass!

It will use 10 toner per (original) photo, and will use your base species!

If you're a custom species and have icon set to Vulpkanin, for instance, it will use the vulp ass. Werewolves will use the vulp for now, pending a thicc'er sprite.

Xenos + Xenohybrid will use THICC XENOS ASS sprites.

Xenochimera will work the same as custom species, using the base species ass.

Zorren + Fennecs will use the Vulp ass. (Placeholder until we get special sprites for specifically them.)

Akula will use Xenos sprite because THICC SHARK ASS. (Placeholder until we get special sprites for specifically them.)

The rest of the species not currently implemented (that is, those without sprites) will print a generic human butt. If you'd like custom sprites, sprite an ass, and put it in butts_vr.dmi

Improvements to photocopiers will be pushed forward to Polaris.

You can also tell precisely who's ass it is on the photo by clicking on it. 
![https://i.imgur.com/UOPhfIt.gif](https://i.imgur.com/UOPhfIt.gif)

I'd still like to add the option to recolor the sprite based on your body color, but for now, it's a black/white ass. Sorry!

Also also, nudity permits and clothes that don't cover the LOWER_BODY allow you to copy your ass.