### PR TITLE
Clean up air tank processing and initialize

### DIFF
--- a/code/game/objects/items/weapons/tanks/jetpack.dm
+++ b/code/game/objects/items/weapons/tanks/jetpack.dm
@@ -84,9 +84,8 @@
 	item_state_slots = list(slot_r_hand_str = "jetpack-void", slot_l_hand_str = "jetpack-void")
 
 /obj/item/weapon/tank/jetpack/void/Initialize()
-	..()
+	. = ..()
 	air_contents.adjust_gas("oxygen", (6*ONE_ATMOSPHERE)*volume/(R_IDEAL_GAS_EQUATION*T20C))
-	return
 
 /obj/item/weapon/tank/jetpack/oxygen
 	name = "jetpack (oxygen)"
@@ -95,9 +94,8 @@
 	item_state_slots = list(slot_r_hand_str = "jetpack", slot_l_hand_str = "jetpack")
 
 /obj/item/weapon/tank/jetpack/oxygen/Initialize()
-	..()
+	. = ..()
 	air_contents.adjust_gas("oxygen", (6*ONE_ATMOSPHERE)*volume/(R_IDEAL_GAS_EQUATION*T20C))
-	return
 
 /obj/item/weapon/tank/jetpack/carbondioxide
 	name = "jetpack (carbon dioxide)"
@@ -107,9 +105,8 @@
 	item_state_slots = list(slot_r_hand_str = "jetpack-black", slot_l_hand_str = "jetpack-black")
 
 /obj/item/weapon/tank/jetpack/carbondioxide/Initialize()
-	..()
+	. = ..()
 	air_contents.adjust_gas("carbon_dioxide", (6*ONE_ATMOSPHERE)*volume/(R_IDEAL_GAS_EQUATION*T20C))
-	return
 
 /obj/item/weapon/tank/jetpack/rig
 	name = "jetpack"

--- a/code/game/objects/items/weapons/tanks/tank_types.dm
+++ b/code/game/objects/items/weapons/tanks/tank_types.dm
@@ -17,9 +17,8 @@
 	distribute_pressure = ONE_ATMOSPHERE*O2STANDARD
 
 /obj/item/weapon/tank/oxygen/Initialize()
-	..()
+	. = ..()
 	air_contents.adjust_gas("oxygen", (6*ONE_ATMOSPHERE)*volume/(R_IDEAL_GAS_EQUATION*T20C))
-	return
 
 /obj/item/weapon/tank/oxygen/examine(mob/user)
 	. = ..()
@@ -43,13 +42,11 @@
 	icon_state = "anesthetic"
 
 /obj/item/weapon/tank/anesthetic/Initialize()
-	..()
+	. = ..()
 
 	air_contents.gas["oxygen"] = (3*ONE_ATMOSPHERE)*70/(R_IDEAL_GAS_EQUATION*T20C) * O2STANDARD
 	air_contents.gas["sleeping_agent"] = (3*ONE_ATMOSPHERE)*70/(R_IDEAL_GAS_EQUATION*T20C) * N2STANDARD
 	air_contents.update_values()
-
-	return
 
 /*
  * Air
@@ -66,11 +63,8 @@
 		user << sound('sound/effects/alert.ogg')
 
 /obj/item/weapon/tank/air/Initialize()
-	..()
-
+	. = ..()
 	src.air_contents.adjust_multi("oxygen", (6*ONE_ATMOSPHERE)*volume/(R_IDEAL_GAS_EQUATION*T20C) * O2STANDARD, "nitrogen", (6*ONE_ATMOSPHERE)*volume/(R_IDEAL_GAS_EQUATION*T20C) * N2STANDARD)
-
-	return
 
 /*
  * Phoron
@@ -83,10 +77,8 @@
 	slot_flags = null	//they have no straps!
 
 /obj/item/weapon/tank/phoron/Initialize()
-	..()
-
+	. = ..()
 	src.air_contents.adjust_gas("phoron", (3*ONE_ATMOSPHERE)*70/(R_IDEAL_GAS_EQUATION*T20C))
-	return
 
 /obj/item/weapon/tank/phoron/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	..()
@@ -109,10 +101,8 @@
 	slot_flags = SLOT_BACK	//these ones have straps!
 
 /obj/item/weapon/tank/vox/Initialize()
-	..()
-
+	. = ..()
 	air_contents.adjust_gas("phoron", (6*ONE_ATMOSPHERE)*volume/(R_IDEAL_GAS_EQUATION*T20C))
-	return
 
 /obj/item/weapon/tank/phoron/pressurized
 	name = "fuel can"
@@ -120,12 +110,9 @@
 	w_class = ITEMSIZE_NORMAL
 
 /obj/item/weapon/tank/phoron/pressurized/Initialize()
-	..()
-
+	. = ..()
 	adjust_scale(0.8)
-
 	air_contents.adjust_gas("phoron", (7*ONE_ATMOSPHERE)*volume/(R_IDEAL_GAS_EQUATION*T20C))
-	return
 
 /*
  * Emergency Oxygen
@@ -149,9 +136,8 @@
 	gauge_icon = "indicator_emergency"
 
 /obj/item/weapon/tank/emergency/oxygen/Initialize()
-	..()
+	. = ..()
 	src.air_contents.adjust_gas("oxygen", (10*ONE_ATMOSPHERE)*volume/(R_IDEAL_GAS_EQUATION*T20C))
-	return
 
 /obj/item/weapon/tank/emergency/oxygen/examine(mob/user)
 	. = ..()
@@ -178,9 +164,8 @@
 	volume = 10
 
 /obj/item/weapon/tank/stasis/oxygen/Initialize()
-	..()
+	. = ..()
 	src.air_contents.adjust_gas("oxygen", (3*ONE_ATMOSPHERE)*volume/(R_IDEAL_GAS_EQUATION*T20C))
-	return
 
 /obj/item/weapon/tank/emergency/nitrogen
 	name = "emergency nitrogen tank"
@@ -205,7 +190,7 @@
 	gauge_icon = "indicator_emergency"
 
 /obj/item/weapon/tank/emergency/phoron/Initialize()
-	..()
+	. = ..()
 	src.air_contents.adjust_gas("phoron", (10*ONE_ATMOSPHERE)*volume/(R_IDEAL_GAS_EQUATION*T20C))
 
 /obj/item/weapon/tank/emergency/phoron/double
@@ -224,10 +209,8 @@
 	distribute_pressure = ONE_ATMOSPHERE*O2STANDARD
 
 /obj/item/weapon/tank/nitrogen/Initialize()
-	..()
-
+	. = ..()
 	src.air_contents.adjust_gas("nitrogen", (3*ONE_ATMOSPHERE)*70/(R_IDEAL_GAS_EQUATION*T20C))
-	return
 
 /obj/item/weapon/tank/nitrogen/examine(mob/user)
 	. = ..()
@@ -243,6 +226,5 @@
 	volume = 10
 
 /obj/item/weapon/tank/stasis/nitro_cryo/Initialize()
-	..()
+	. = ..()
 	src.air_contents.adjust_gas_temp("nitrogen", (3*ONE_ATMOSPHERE)*volume/(R_IDEAL_GAS_EQUATION*TN60C), TN60C)
-	return

--- a/code/game/objects/items/weapons/tanks/tanks.dm
+++ b/code/game/objects/items/weapons/tanks/tanks.dm
@@ -59,15 +59,13 @@ var/list/global/tank_gauge_cache = list()
 
 
 /obj/item/weapon/tank/Initialize()
-	..()
+	. = ..()
 
 	src.init_proxy()
 	src.air_contents = new /datum/gas_mixture()
 	src.air_contents.volume = volume //liters
 	src.air_contents.temperature = T20C
-	START_PROCESSING(SSobj, src)
 	update_gauge()
-	return
 
 /obj/item/weapon/tank/Destroy()
 	QDEL_NULL(air_contents)
@@ -80,6 +78,13 @@ var/list/global/tank_gauge_cache = list()
 		TTV.remove_tank(src)
 
 	. = ..()
+
+/obj/item/weapon/tank/equipped() // Note that even grabbing into a hand calls this, so it should be fine as a 'has a player touched this'
+	. = ..()
+	// An attempt at optimization. There are MANY tanks during rounds that will never get touched.
+	// Don't see why any of those would explode spontaneously. So only tanks that players touch get processed.
+	// This could be optimized more, but it's a start!
+	START_PROCESSING(SSobj, src) // This has a built in safety to avoid multi-processing
 
 /obj/item/weapon/tank/examine(mob/user)
 	. = ..()


### PR DESCRIPTION
Air tanks only start processing if a player picks them up for the first time. Air tanks in closets, racks, etc won't process needlessly. They are pretty unlikely to explode, after all.