### PR TITLE
Alien whitelist update

### DIFF
--- a/config/alienwhitelist.txt
+++ b/config/alienwhitelist.txt
@@ -48,3 +48,9 @@ xioen - Diona
 xioen - Xenochimera
 zalvine - Shadekin Empathy
 zammyman215 - Vox
+Bricker98 - Protean
+CGR - Protean
+Storesund97 - Protean
+Vitoras - Protean
+Nerdass - Protean
+

--- a/config/alienwhitelist.txt
+++ b/config/alienwhitelist.txt
@@ -48,9 +48,8 @@ xioen - Diona
 xioen - Xenochimera
 zalvine - Shadekin Empathy
 zammyman215 - Vox
-Bricker98 - Protean
-CGR - Protean
-Storesund97 - Protean
-Vitoras - Protean
-Nerdass - Protean
-
+bricker98 - Protean
+cgr - Protean
+storesund97 - Protean
+vitoras - Protean
+nerdass - Protean


### PR DESCRIPTION
updates the alien whitelist to include Bicker98, CRG, Cyrstal, Vioras and Nerdass. Can be found on the virgo forms.