### PR TITLE
2 catwalk fixes, climbing and decon

### DIFF
--- a/code/game/objects/structures/catwalk.dm
+++ b/code/game/objects/structures/catwalk.dm
@@ -85,6 +85,11 @@
 	qdel(src)
 
 /obj/structure/catwalk/attackby(obj/item/C as obj, mob/user as mob)
+	if(istype(C, /obj/item/weapon/weldingtool))
+		var/obj/item/weapon/weldingtool/WT = C
+		if(WT.isOn() && WT.remove_fuel(0, user))
+			deconstruct(user)
+			return
 	if(C.is_crowbar() && plated_tile)
 		hatch_open = !hatch_open
 		if(hatch_open)

--- a/code/modules/multiz/movement.dm
+++ b/code/modules/multiz/movement.dm
@@ -61,6 +61,11 @@
 		else if(catwalk?.hatch_open)
 			var/pull_up_time = max(5 SECONDS + (src.movement_delay() * 10), 1)
 			to_chat(src, "<span class='notice'>You grab the edge of \the [catwalk] and start pulling yourself upward...</span>")
+			var/old_dest = destination
+			destination = get_step(destination, dir) // mob's dir
+			if(!destination?.Enter(src, old_dest))
+				to_chat(src, "<span class='notice'>There's something in the way up above in that direction, try another.</span>")
+				return 0
 			destination.audible_message("<span class='notice'>You hear something climbing up \the [catwalk].</span>")
 			if(do_after(src, pull_up_time))
 				to_chat(src, "<span class='notice'>You pull yourself up.</span>")


### PR DESCRIPTION
- Deconning catwalks with welder works again
- Climbing up through open plated catwalks moves you 1 turf in the direction you're facing so you don't fall back down, or warns you and aborts climbing if you wouldn't be able to move to that turf. Try other directions if you get the 'try other directions' message.