### PR TITLE
Port over AI Opening Doors from Paradise

### DIFF
--- a/code/game/machinery/camera/tracking.dm
+++ b/code/game/machinery/camera/tracking.dm
@@ -152,11 +152,11 @@
 	cameraFollow = null
 
 /mob/living/silicon/ai/proc/ai_actual_track(mob/living/target as mob)
-	if(!istype(target))	return
+	if(!istype(target))	return FALSE
 	var/mob/living/silicon/ai/U = usr
 
 	if(target == U.cameraFollow)
-		return
+		return TRUE
 
 	if(U.cameraFollow)
 		U.ai_cancel_tracking()
@@ -184,6 +184,8 @@
 				view_core()
 				return
 			sleep(10)
+
+	return TRUE
 
 /obj/machinery/camera/attack_ai(var/mob/living/silicon/ai/user as mob)
 	if (!istype(user))


### PR DESCRIPTION
This makes an [OPEN] link appear on all radio messages the AI hears (to the right of the follow link). When clicked, it allows the AI to open
the door nearest to the speaker (or, if it is a voice changer, the door
nearest to the poor sap who had his voice stolen).

AI, Open This Door!
