### PR TITLE
Add protean shakes

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -819,7 +819,8 @@
 					/obj/item/weapon/towel/random = 20)
 	//VOREStation Edit End
 
-	contraband = list(/obj/item/weapon/reagent_containers/syringe/steroid = 4)
+	contraband = list(/obj/item/weapon/reagent_containers/syringe/steroid = 4, /obj/item/weapon/reagent_containers/food/drinks/glass2/fitnessflask/proteanshake = 2) // VOREStation Add - Slurpable blobs.
+	
 
 /obj/machinery/vending/cart
 	name = "PTech"

--- a/code/modules/food/drinkingglass/shaker_vr.dm
+++ b/code/modules/food/drinkingglass/shaker_vr.dm
@@ -1,0 +1,13 @@
+/obj/item/weapon/reagent_containers/food/drinks/glass2/fitnessflask/proteanshake
+	name = "protean shake"
+
+/obj/item/weapon/reagent_containers/food/drinks/glass2/fitnessflask/proteanshake/Initialize()
+	. = ..()
+	reagents.add_reagent("liquid_protean", 50)
+	reagents.add_reagent("nutriment", 50)
+
+/obj/item/weapon/reagent_containers/food/drinks/glass2/fitnessflask/proteanshake/update_icon()
+	..()
+	// And now set half the stuff back because our name shouldn't change
+	name = initial(name)
+	desc = initial(desc)

--- a/code/modules/reagents/Chemistry-Reagents_vr.dm
+++ b/code/modules/reagents/Chemistry-Reagents_vr.dm
@@ -98,3 +98,30 @@
 
 	M.adjust_fire_stacks(-reac_volume)
 	M.ExtinguishMob()
+
+/datum/reagent/liquid_protean
+	name = "Liquid protean"
+	id = "liquid_protean"
+	description = "This seems to be a small portion of a Protean creature, still slightly wiggling."
+	taste_description = "wiggly peanutbutter"
+	reagent_state = LIQUID
+	color = "#1d1d1d"
+	scannable = 0
+	metabolism = REM * 0.5
+
+/datum/reagent/liquid_protean/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
+	if(alien != IS_DIONA)
+		var/chem_effective = 1
+		if(alien == IS_SLIME)
+			chem_effective = 0.5
+		M.adjustOxyLoss(-1 * removed * chem_effective)
+		M.heal_organ_damage(0.5 * removed, 0.5 * removed * chem_effective)
+		M.adjustToxLoss(-0.5 * removed * chem_effective)
+
+	if(ishuman(M))
+		var/mob/living/carbon/human/H = M
+		if(H.nif)
+			var/obj/item/device/nif/nif = H.nif //L o c a l
+			if(nif.stat == NIF_TEMPFAIL)
+				nif.stat = NIF_INSTALLING
+			nif.durability = min(nif.durability + removed*0.1, initial(nif.durability))

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -2051,6 +2051,7 @@
 #include "code\modules\food\drinkingglass\metaglass.dm"
 #include "code\modules\food\drinkingglass\serving_glasses.dm"
 #include "code\modules\food\drinkingglass\shaker.dm"
+#include "code\modules\food\drinkingglass\shaker_vr.dm"
 #include "code\modules\food\food\cans.dm"
 #include "code\modules\food\food\condiment.dm"
 #include "code\modules\food\food\drinks.dm"


### PR DESCRIPTION
Adds protean shakes to fitness vendors (as contraband), with minor mechanical effect.

Liquid protean is weak NIF repair juice (10% as effective), and weak tricord (30% as effective). Metabolizes at half the speed though, so you probably shouldn't try to replace either with it.