### PR TITLE
tg(?) style stack autocombining

### DIFF
--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -363,6 +363,14 @@
 	else
 		return ..()
 
+/obj/item/stack/Moved(atom/old_loc, direction, forced = FALSE)
+	. = ..()
+	if(isturf(loc))
+		for(var/obj/item/stack/S in loc)
+			if(S == src)
+				continue
+			S.transfer_to(src) // them to us, so if we're being pulled, we can keep being pulled
+
 /*
  * Recipe datum
  */


### PR DESCRIPTION
A stack moving into a turf, be that because it was dropped, dragged, opened from a locker, ejected from an autolathe, etc, will try to combine with any other stacks on the same turf.

This will let you drop stacks onto each other to combine them, drag a stack of floor tiles over other floor tiles to combine them, etc.

Works for 'not-very-obvious' stacks too but probably not really important to be able to combine things like advanced burn kits this way.