### PR TITLE
Fix custom species synthetics' hunger alert icons

### DIFF
--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -1225,16 +1225,16 @@
 		var/hungry_alert = /obj/screen/alert/hungry
 		var/starving_alert = /obj/screen/alert/starving
 
-		if(get_species() == SPECIES_CUSTOM)
+		if(isSynthetic())
+			fat_alert = /obj/screen/alert/fat/synth
+			hungry_alert = /obj/screen/alert/hungry/synth
+			starving_alert = /obj/screen/alert/starving/synth
+		else if(get_species() == SPECIES_CUSTOM)
 			var/datum/species/custom/C = species
 			if(/datum/trait/bloodsucker in C.traits)
 				fat_alert = /obj/screen/alert/fat/vampire
 				hungry_alert = /obj/screen/alert/hungry/vampire
 				starving_alert = /obj/screen/alert/starving/vampire
-		else if(isSynthetic())
-			fat_alert = /obj/screen/alert/fat/synth
-			hungry_alert = /obj/screen/alert/hungry/synth
-			starving_alert = /obj/screen/alert/starving/synth
 
 		switch(nutrition)
 			if(450 to INFINITY)


### PR DESCRIPTION
Custom species characters with full body prosthetics will now properly get the battery icon for their hunger alerts instead of the hamburger icon or bloodsucker icon.

As a consequence of this change, bloodsucker synthetics will now get the battery icon instead of the blood icon. I don't know if that's a problem or not.