### PR TITLE
Change stack autocombine

### DIFF
--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -363,13 +363,21 @@
 	else
 		return ..()
 
-/obj/item/stack/Moved(atom/old_loc, direction, forced = FALSE)
+/obj/item/stack/proc/combine_in_loc()
+	for(var/obj/item/stack/S in loc)
+		if(S == src)
+			continue
+		S.transfer_to(src) // them to us, so if we're being pulled, we can keep being pulled
+
+/obj/item/stack/dropped(atom/old_loc)
 	. = ..()
 	if(isturf(loc))
-		for(var/obj/item/stack/S in loc)
-			if(S == src)
-				continue
-			S.transfer_to(src) // them to us, so if we're being pulled, we can keep being pulled
+		combine_in_loc()
+
+/obj/item/stack/Moved(atom/old_loc, direction, forced)
+	. = ..()
+	if(pulledby && isturf(loc))
+		combine_in_loc()
 
 /*
  * Recipe datum


### PR DESCRIPTION
Only happens when dropped or pulled by a mob, to avoid problems with stack-using machines and conveyors in mining