### PR TITLE
Reduce job switch time

### DIFF
--- a/code/game/machinery/computer/timeclock_vr.dm
+++ b/code/game/machinery/computer/timeclock_vr.dm
@@ -210,9 +210,9 @@
 /obj/machinery/computer/timeclock/proc/checkCardCooldown()
 	if(!card)
 		return FALSE
-	var/time_left = 10 MINUTES - (world.time - card.last_job_switch)
+	var/time_left = 5 MINUTES - (world.time - card.last_job_switch)
 	if(time_left > 0)
-		to_chat(usr, "You need to wait another [round((time_left/10)/60, 1)] minute\s before you can switch.")
+		to_chat(usr, "You need to wait another [round((time_left/5)/60, 1)] minute\s before you can switch.")
 		return FALSE
 	return TRUE
 


### PR DESCRIPTION
Ten minutes ends up denying people and seems to last much longer than real life time, given we have been subject to horrible time dilatation those past weeks, at regular pop.

Maybe a better system would be for our entire game to have a sort of external clock against which we could run our time based things, but until then, this is a decent way.