### PR TITLE
Alleviate shapeshifter color issues

### DIFF
--- a/code/_helpers/icons.dm
+++ b/code/_helpers/icons.dm
@@ -367,6 +367,13 @@ proc/ReadRGB(rgb)
 	. = list(r, g, b)
 	if(usealpha) . += alpha
 
+proc/RGBdec2hex(var/list/values)
+	var/string = ""
+	while(values.len)
+		string = "[num2text(values[values.len], 2, 16)][string]"
+		values.len--
+	return "#[string]"
+
 proc/ReadHSV(hsv)
 	if(!hsv) return
 

--- a/code/modules/mob/living/carbon/human/species/species_shapeshift.dm
+++ b/code/modules/mob/living/carbon/human/species/species_shapeshift.dm
@@ -173,7 +173,8 @@ var/list/wrapped_species_by_ref = list()
 
 	last_special = world.time + 50
 
-	var/new_skin = input("Please select a new body color.", "Shapeshifter Colour") as color
+	var/current = RGBdec2hex(list(r_skin, g_skin, b_skin))
+	var/new_skin = input("Please select a new body color.", "Shapeshifter Colour", current) as null|color
 	if(!new_skin)
 		return
 	shapeshifter_set_colour(new_skin)

--- a/code/modules/mob/living/carbon/human/species/station/protean_vr/protean_powers.dm
+++ b/code/modules/mob/living/carbon/human/species/station/protean_vr/protean_powers.dm
@@ -46,6 +46,7 @@
 			var/obj/item/organ/external/new_eo = new limbpath(src)
 			organs_by_name[choice] = new_eo
 			new_eo.robotize(synthetic ? synthetic.company : null) //Use the base we started with
+			new_eo.sync_colour_to_human(src)
 			regenerate_icons()
 		active_regen = FALSE
 		nano_outofblob(blob)


### PR DESCRIPTION
I'm not 100% sure that this fixes 100% of https://github.com/VOREStation/VOREStation/issues/7930 but it does enough that I think it can close it.

Shapeshifters selecting body color can cancel the dialog, and also the dialog defaults to the current body color, so opening it and clicking OK will just reset your limbs to that color. Also added a thing that will hopefully autocolor protean single limb refactors.

Closes https://github.com/VOREStation/VOREStation/issues/7930