### PR TITLE
Refactor Character Setup to use MAP

### DIFF
--- a/code/modules/client/preference_setup/general/03_body.dm
+++ b/code/modules/client/preference_setup/general/03_body.dm
@@ -37,7 +37,6 @@ var/global/list/valid_bloodtypes = list("A+", "A-", "B+", "B-", "AB+", "AB-", "O
 	S["synth_green"]		>> pref.g_synth
 	S["synth_blue"]			>> pref.b_synth
 	S["synth_markings"]		>> pref.synth_markings
-	pref.preview_icon = null
 	S["bgstate"]			>> pref.bgstate
 	S["body_descriptors"]	>> pref.body_descriptors
 
@@ -188,9 +187,6 @@ var/global/list/valid_bloodtypes = list("A+", "A-", "B+", "B-", "AB+", "AB-", "O
 
 /datum/category_item/player_setup_item/general/body/content(var/mob/user)
 	. = list()
-	if(!pref.preview_icon)
-		pref.update_preview_icon()
- 	user << browse_rsc(pref.preview_icon, "previewicon.png")
 
 	var/datum/species/mob_species = GLOB.all_species[pref.species]
 	. += "<table><tr style='vertical-align:top'><td><b>Body</b> "
@@ -313,7 +309,6 @@ var/global/list/valid_bloodtypes = list("A+", "A-", "B+", "B-", "AB+", "AB-", "O
 		. += "</table><br>"
 
 	. += "</td><td><b>Preview</b><br>"
-	. += "<div class='statusDisplay'><center><img src=previewicon.png width=[pref.preview_icon.Width()] height=[pref.preview_icon.Height()]></center></div>"
 	. += "<br><a href='?src=\ref[src];cycle_bg=1'>Cycle background</a>"
 	. += "<br><a href='?src=\ref[src];toggle_preview_value=[EQUIP_PREVIEW_LOADOUT]'>[pref.equip_preview_mob & EQUIP_PREVIEW_LOADOUT ? "Hide loadout" : "Show loadout"]</a>"
 	. += "<br><a href='?src=\ref[src];toggle_preview_value=[EQUIP_PREVIEW_JOB]'>[pref.equip_preview_mob & EQUIP_PREVIEW_JOB ? "Hide job gear" : "Show job gear"]</a>"

--- a/code/modules/client/preference_setup/preference_setup.dm
+++ b/code/modules/client/preference_setup/preference_setup.dm
@@ -232,7 +232,7 @@
 
 	. = OnTopic(href, href_list, usr)
 	if(. & TOPIC_UPDATE_PREVIEW)
-		pref_mob.client.prefs.preview_icon = null
+		pref_mob.client.prefs.update_preview_icon()
 	if(. & TOPIC_REFRESH)
 		pref_mob.client.prefs.ShowChoices(usr)
 

--- a/code/modules/client/preference_setup/vore/01_ears.dm
+++ b/code/modules/client/preference_setup/vore/01_ears.dm
@@ -27,7 +27,6 @@
 	var/r_wing2 = 30	// Wing extra color
 	var/g_wing2 = 30	// Wing extra color
 	var/b_wing2 = 30	// Wing extra color
-	var/dress_mob = TRUE
 
 // Definition of the stuff for Ears
 /datum/category_item/player_setup_item/vore/ears
@@ -142,14 +141,6 @@
 
 /datum/category_item/player_setup_item/vore/ears/content(var/mob/user)
 	. += "<h2>VORE Station Settings</h2>"
-
-	if(!pref.preview_icon)
-		pref.update_preview_icon()
- 	user << browse_rsc(pref.preview_icon, "previewicon.png")
-
-	. += "<b>Preview</b><br>"
-	. += "<div class='statusDisplay'><center><img src=previewicon.png width=[pref.preview_icon.Width()] height=[pref.preview_icon.Height()]></center></div>"
-	. += "<br><a href='?src=\ref[src];toggle_clothing=1'>[pref.dress_mob ? "Hide equipment" : "Show equipment"]</a><br>"
 
 	var/ear_display = "Normal"
 	if(pref.ear_style && (pref.ear_style in ear_styles_list))
@@ -301,9 +292,5 @@
 			pref.g_wing2 = hex2num(copytext(new_wingc2, 4, 6))
 			pref.b_wing2 = hex2num(copytext(new_wingc2, 6, 8))
 			return TOPIC_REFRESH_UPDATE_PREVIEW
-
-	else if(href_list["toggle_clothing"])
-		pref.dress_mob = !pref.dress_mob
-		return TOPIC_REFRESH_UPDATE_PREVIEW
 
 	return ..()

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -71,7 +71,14 @@ datum/preferences
 	var/antag_vis = "Hidden"			//How visible antag association is to others.
 
 		//Mob preview
-	var/icon/preview_icon = null
+	var/list/char_render_holders		//Should only be a key-value list of north/south/east/west = obj/screen.
+	var/static/list/preview_screen_locs = list(
+		"1" = "character_preview_map:1,5:-12",
+		"2" = "character_preview_map:1,3:15",
+		"4"  = "character_preview_map:1:7,2:10",
+		"8"  = "character_preview_map:1:-7,1:5",
+		"BG" = "character_preview_map:1,1 to 1,5"
+	)
 
 		//Jobs, uses bitflags
 	var/job_civilian_high = 0
@@ -154,6 +161,10 @@ datum/preferences
 				if(load_character())
 					return
 
+/datum/preferences/Destroy()
+	. = ..()
+	QDEL_LIST_ASSOC_VAL(char_render_holders)
+
 /datum/preferences/proc/ZeroSkills(var/forced = 0)
 	for(var/V in SKILLS) for(var/datum/skill/S in SKILLS[V])
 		if(!skills.Find(S.ID) || forced)
@@ -213,6 +224,10 @@ datum/preferences
 		to_chat(user, "<span class='danger'>No mob exists for the given client!</span>")
 		close_load_dialog(user)
 		return
+	
+	if(!char_render_holders)
+		update_preview_icon()
+	show_character_previews()
 
 	var/dat = "<html><body><center>"
 
@@ -234,9 +249,48 @@ datum/preferences
 
 	dat += "</html></body>"
 	//user << browse(dat, "window=preferences;size=635x736")
-	var/datum/browser/popup = new(user, "Character Setup","Character Setup", 800, 800, src)
+	winshow(user, "preferences_window", TRUE)
+	var/datum/browser/popup = new(user, "preferences_browser", "Character Setup", 800, 800)
 	popup.set_content(dat)
-	popup.open()
+	popup.open(FALSE) // Skip registring onclose on the browser pane
+	onclose(user, "preferences_window", src) // We want to register on the window itself
+
+/datum/preferences/proc/update_character_previews(mutable_appearance/MA)
+	if(!client)
+		return
+
+	var/obj/screen/BG= LAZYACCESS(char_render_holders, "BG")
+	if(!BG)
+		BG = new
+		BG.plane = TURF_PLANE
+		BG.icon = 'icons/effects/128x48.dmi'
+		LAZYSET(char_render_holders, "BG", BG)
+		client.screen |= BG
+	BG.icon_state = bgstate
+	BG.screen_loc = preview_screen_locs["BG"]
+	
+	for(var/D in global.cardinal)
+		var/obj/screen/O = LAZYACCESS(char_render_holders, "[D]")
+		if(!O)
+			O = new
+			LAZYSET(char_render_holders, "[D]", O)
+			client.screen |= O
+		O.appearance = MA
+		O.dir = D
+		O.screen_loc = preview_screen_locs["[D]"]
+
+/datum/preferences/proc/show_character_previews()
+	if(!client || !char_render_holders)
+		return
+	for(var/render_holder in char_render_holders)
+		client.screen |= char_render_holders[render_holder]
+
+/datum/preferences/proc/clear_character_previews()
+	for(var/index in char_render_holders)
+		var/obj/screen/S = char_render_holders[index]
+		client?.screen -= S
+		qdel(S)
+	char_render_holders = null
 
 /datum/preferences/proc/process_link(mob/user, list/href_list)
 	if(!user)	return
@@ -286,6 +340,10 @@ datum/preferences
 		overwrite_character(text2num(href_list["overwrite"]))
 		sanitize_preferences()
 		close_load_dialog(usr)
+	else if(href_list["close"])
+		// User closed preferences window, cleanup anything we need to.
+		clear_character_previews()
+		return 1
 	else
 		return 0
 

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -85,6 +85,7 @@
 		sanitize_preferences()
 
 	player_setup.load_character(S)
+	clear_character_previews() // Recalculate them on next show
 	return 1
 
 /datum/preferences/proc/save_character()

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -578,7 +578,7 @@
 /mob/new_player/proc/close_spawn_windows()
 
 	src << browse(null, "window=latechoices") //closes late choices window
-	//src << browse(null, "window=playersetup") //closes the player setup window
+	src << browse(null, "window=preferences_window") //closes the player setup window
 	panel.close()
 
 /mob/new_player/proc/has_admin_rights()

--- a/code/modules/mob/new_player/preferences_setup.dm
+++ b/code/modules/mob/new_player/preferences_setup.dm
@@ -255,19 +255,7 @@
 	dress_preview_mob(mannequin)
 	COMPILE_OVERLAYS(mannequin)
 
-	preview_icon = icon('icons/effects/128x48.dmi', bgstate)
-	preview_icon.Scale(48+32, 16+32)
-
-	var/icon/stamp = getFlatIcon(mannequin, defdir=NORTH)
-	preview_icon.Blend(stamp, ICON_OVERLAY, 25, 17)
-
-	stamp = getFlatIcon(mannequin, defdir=WEST)
-	preview_icon.Blend(stamp, ICON_OVERLAY, 1, 9)
-
-	stamp = getFlatIcon(mannequin, defdir=SOUTH)
-	preview_icon.Blend(stamp, ICON_OVERLAY, 49, 1)
-
-	preview_icon.Scale(preview_icon.Width() * 2, preview_icon.Height() * 2) // Scaling here to prevent blurring in the browser.
+	update_character_previews(new /mutable_appearance(mannequin))
 
 /datum/preferences/proc/get_highest_job()
 	var/datum/job/highJob

--- a/code/modules/mob/new_player/preferences_setup_vr.dm
+++ b/code/modules/mob/new_player/preferences_setup_vr.dm
@@ -4,27 +4,11 @@
 		mannequin.dna = new /datum/dna(null)
 	mannequin.delete_inventory(TRUE)
 	dress_preview_mob(mannequin)
+	mannequin.toggle_tail_vr(setting = TRUE)
+	mannequin.toggle_wing_vr(setting = TRUE)
 	COMPILE_OVERLAYS(mannequin)
 
-	preview_icon = icon('icons/effects/128x72_vr.dmi', bgstate)
-	preview_icon.Scale(128, 72)
-
-	mannequin.dir = NORTH
-	var/icon/stamp = getFlatIcon(mannequin)
-	stamp.Scale(stamp.Width()*size_multiplier,stamp.Height()*size_multiplier)
-	preview_icon.Blend(stamp, ICON_OVERLAY, 64-stamp.Width()/2, 5)
-
-	mannequin.dir = WEST
-	stamp = getFlatIcon(mannequin)
-	stamp.Scale(stamp.Width()*size_multiplier,stamp.Height()*size_multiplier)
-	preview_icon.Blend(stamp, ICON_OVERLAY, 16-stamp.Width()/2, 5)
-
-	mannequin.dir = SOUTH
-	stamp = getFlatIcon(mannequin)
-	stamp.Scale(stamp.Width()*size_multiplier,stamp.Height()*size_multiplier)
-	preview_icon.Blend(stamp, ICON_OVERLAY, 112-stamp.Width()/2, 5)
-
-	preview_icon.Scale(preview_icon.Width() * 2, preview_icon.Height() * 2) // Scaling here to prevent blurring in the browser.
+	update_character_previews(new /mutable_appearance(mannequin))
 
 //TFF 5/8/19 - add randomised sensor setting for random button clicking
 /datum/preferences/randomize_appearance_and_body_for(var/mob/living/carbon/human/H)

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -1399,6 +1399,31 @@ window "browserwindow"
 		on-show = ".winset\"rpane.infob.is-visible=true?rpane.infob.pos=130,0;rpane.textb.is-visible=true;rpane.browseb.is-visible=true;rpane.browseb.is-checked=true;rpane.rpanewindow.pos=0,30;rpane.rpanewindow.size=0x0;rpane.rpanewindow.left=browserwindow\""
 		on-hide = ".winset\"rpane.infob.is-visible=true?rpane.infob.is-checked=true rpane.infob.pos=65,0 rpane.rpanewindow.left=infowindow:rpane.rpanewindow.left=textwindow rpane.textb.is-visible=true rpane.rpanewindow.pos=0,30 rpane.rpanewindow.size=0x0\""
 
+window "preferences_window"
+	elem "preferences_window"
+		type = MAIN
+		pos = 281,0
+		size = 1000x800
+		anchor1 = none
+		anchor2 = none
+		is-visible = false
+		saved-params = "pos;size;is-minimized;is-maximized"
+		statusbar = false
+	elem "preferences_browser"
+		type = BROWSER
+		pos = 0,0
+		size = 800x800
+		anchor1 = 0,0
+		anchor2 = 80,100
+		saved-params = ""
+	elem "character_preview_map"
+		type = MAP
+		pos = 800,0
+		size = 200x800
+		anchor1 = 80,0
+		anchor2 = 100,100
+		right-click = false
+
 window "infowindow"
 	elem "infowindow"
 		type = MAIN


### PR DESCRIPTION
- Instead of using expensive getFlatIcon() calls, character previews are now shown using screen objects in a second map window.
- Edited skin to add a named window for preferences setup that contains a browser plus a new map window to show the previews.
- Mannequins are still generated the same way, but now a MA is applied to four screen objects which are shown in the second map window.
- The screen objects are deleted on close of the preferences window.  So we do make sure to close it when spawning.

- This improves performance, but also has some other advantages:  The preview icons are now animated.


![WWc0ZKJvEB](https://user-images.githubusercontent.com/14110581/82613994-c1f8e200-9b94-11ea-9d56-a8041647446b.gif)


Somewhat based on tgstation/tgstation#41978