### PR TITLE
Fixes Accessories on Taurized Suits & Clipping

### DIFF
--- a/code/modules/clothing/clothing_vr.dm
+++ b/code/modules/clothing/clothing_vr.dm
@@ -187,6 +187,8 @@
 			var/image/I = new(A.get_mob_overlay())
 			I.pixel_x = 16 //Opposite of the pixel_x on the suit (-16) from taurization to cancel it out and puts the accessory in the correct place on the body.
 			standing.add_overlay(I)
+	else
+		return ..()
 
 //TFF 5/8/19 - sets Vorestation /obj/item/clothing/under sensor setting default?
 /obj/item/clothing/under

--- a/code/modules/clothing/clothing_vr.dm
+++ b/code/modules/clothing/clothing_vr.dm
@@ -182,11 +182,11 @@
 	return standing
 
 /obj/item/clothing/suit/apply_accessories(var/image/standing)
-	if(LAZYLEN(accessories))
+	if(LAZYLEN(accessories) && taurized)
 		for(var/obj/item/clothing/accessory/A in accessories)
-			var/mutable_appearance/M = new(A.get_mob_overlay())
-			M.pixel_x = 16 //Opposite of the pixel_x on the suit (-16) from taurization to cancel it out and puts the accessory in the correct place on the body.
-			standing.add_overlay(M)
+			var/image/I = new(A.get_mob_overlay())
+			I.pixel_x = 16 //Opposite of the pixel_x on the suit (-16) from taurization to cancel it out and puts the accessory in the correct place on the body.
+			standing.add_overlay(I)
 
 //TFF 5/8/19 - sets Vorestation /obj/item/clothing/under sensor setting default?
 /obj/item/clothing/under

--- a/code/modules/clothing/clothing_vr.dm
+++ b/code/modules/clothing/clothing_vr.dm
@@ -63,7 +63,7 @@
 			to_chat(micro, "<span class='notice'>You climb out of [src]!</span>")
 			micro.forceMove(loc)
 		return
-	
+
 	var/escape_message_micro = "You start to climb out of [src]!"
 	var/escape_message_macro = "Something is trying to climb out of your [src]!"
 	var/escape_time = 60
@@ -71,14 +71,14 @@
 	if(macro.shoes == src)
 		escape_message_micro = "You start to climb around the larger creature's feet and ankles!"
 		escape_time = 100
-	
+
 	to_chat(micro, "<span class='notice'>[escape_message_micro]</span>")
 	to_chat(macro, "<span class='danger'>[escape_message_macro]</span>")
 	if(!do_after(micro, escape_time, macro))
 		to_chat(micro, "<span class='danger'>You're pinned underfoot!</span>")
 		to_chat(macro, "<span class='danger'>You pin the escapee underfoot!</span>")
 		return
-	
+
 	to_chat(micro, "<span class='notice'>You manage to escape [src]!</span>")
 	to_chat(macro, "<span class='danger'>Someone has climbed out of your [src]!</span>")
 	micro.forceMove(macro.loc)
@@ -180,6 +180,13 @@
 		standing.pixel_x = -16
 		standing.layer = BODY_LAYER + 15 // 15 is above tail layer, so will not be covered by taurbody.
 	return standing
+
+/obj/item/clothing/suit/apply_accessories(var/image/standing)
+	if(LAZYLEN(accessories))
+		for(var/obj/item/clothing/accessory/A in accessories)
+			var/mutable_appearance/M = new(A.get_mob_overlay())
+			M.pixel_x = 16 //Opposite of the pixel_x on the suit (-16) from taurization to cancel it out and puts the accessory in the correct place on the body.
+			standing.add_overlay(M)
 
 //TFF 5/8/19 - sets Vorestation /obj/item/clothing/under sensor setting default?
 /obj/item/clothing/under

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -594,7 +594,7 @@ var/global/list/damage_icon_parts = list() //see UpdateDamageIcon()
 	var/icon/c_mask = tail_style?.clip_mask
 	if(c_mask)
 		var/obj/item/clothing/suit/S = wear_suit
-		if(!istype(S) || (wear_suit.flags_inv & HIDETAIL) || S.taurized) // Reasons to not mask
+		if((wear_suit?.flags_inv & HIDETAIL) || (istype(S) && S.taurized)) // Reasons to not mask: 1. If you're wearing a suit that hides the tail or if you're wearing a taurized suit.
 			c_mask = null
 	overlays_standing[UNIFORM_LAYER] = w_uniform.make_worn_icon(body_type = species.get_bodytype(src), slot_name = slot_w_uniform_str, default_icon = uniform_sprite, default_layer = UNIFORM_LAYER, clip_mask = c_mask)
 	//VOREStation Edit end.
@@ -781,7 +781,7 @@ var/global/list/damage_icon_parts = list() //see UpdateDamageIcon()
 	var/tail_is_rendered = (overlays_standing[TAIL_LAYER] || overlays_standing[TAIL_LAYER_ALT])
 	var/valid_clip_mask = tail_style?.clip_mask
 
-	if(tail_is_rendered && valid_clip_mask && !(suit && istype(suit) && suit.taurized)) //Clip the lower half of the suit off using the tail's clip mask for taurs since taur bodies aren't hidden.
+	if(tail_is_rendered && valid_clip_mask && !(istype(suit) && suit.taurized)) //Clip the lower half of the suit off using the tail's clip mask for taurs since taur bodies aren't hidden.
 		c_mask = valid_clip_mask
 	overlays_standing[SUIT_LAYER] = wear_suit.make_worn_icon(body_type = species.get_bodytype(src), slot_name = slot_wear_suit_str, default_icon = suit_sprite, default_layer = SUIT_LAYER, clip_mask = c_mask)
 


### PR DESCRIPTION
Clipping logic got out of wack in #7591, that's all.
https://github.com/VOREStation/VOREStation/commit/48563200cee4aad945aa5bb235a52e3369fa72da#diff-ac3b89e91ad083b3cb3fdb669006158cR779

Fixes long-standing issue causing accessories on taursuits to render 16 pixels left on the x axis. I'm surprised I figured this out but not surprised I totally bungled up the first commit.
![virgo ss13 fixed accessory overlays on taurized suits 20200524](https://user-images.githubusercontent.com/12377767/82748145-2e3f3580-9d8f-11ea-9946-714bd05ae017.png)
