### PR TITLE
Fix vchat loading history without errors

### DIFF
--- a/code/controllers/subsystems/chat.dm
+++ b/code/controllers/subsystems/chat.dm
@@ -54,17 +54,12 @@ SUBSYSTEM_DEF(chat)
 			var/client/C = CLIENT_FROM_VAR(I) //Grab us a client if possible
 
 			if(!C)
-				return
-
-			if(!C?.chatOutput || C.chatOutput.broken) //A player who hasn't updated his skin file.
-				//Send it to the old style output window.
+				continue // No client? No care.
+			else if(C.chatOutput.broken)
 				DIRECT_OUTPUT(C, original_message)
 				continue
-
-			// // Client still loading, put their messages in a queue - Actually don't, logged already in database.
-			// if(!C.chatOutput.loaded && C.chatOutput.message_queue && islist(C.chatOutput.message_queue))
-			// 	C.chatOutput.message_queue[++C.chatOutput.message_queue.len] = messageStruct
-			// 	continue
+			else if(!C.chatOutput.loaded)
+				continue // If not loaded yet, do nothing and history-sending on load will get it.
 
 			LAZYINITLIST(msg_queue[C])
 			msg_queue[C][++msg_queue[C].len] = messageStruct
@@ -72,16 +67,12 @@ SUBSYSTEM_DEF(chat)
 		var/client/C = CLIENT_FROM_VAR(target) //Grab us a client if possible
 
 		if(!C)
-			return
-
-		if(!C?.chatOutput || C.chatOutput.broken) //A player who hasn't updated his skin file.
+			return // No client? No care.
+		else if(C.chatOutput.broken)
 			DIRECT_OUTPUT(C, original_message)
 			return
-
-		// // Client still loading, put their messages in a queue - Actually don't, logged already in database.
-		// if(!C.chatOutput.loaded && C.chatOutput.message_queue && islist(C.chatOutput.message_queue))
-		// 	C.chatOutput.message_queue[++C.chatOutput.message_queue.len] = messageStruct
-		// 	return
+		else if(!C.chatOutput.loaded)
+			return // If not loaded yet, do nothing and history-sending on load will get it.
 
 		LAZYINITLIST(msg_queue[C])
 		msg_queue[C][++msg_queue[C].len] = messageStruct

--- a/code/modules/vchat/vchat_client.dm
+++ b/code/modules/vchat/vchat_client.dm
@@ -367,15 +367,13 @@ var/to_chat_src
 			time = world.time
 
 		var/client/C = CLIENT_FROM_VAR(target)
-		if(C && C.chatOutput)
-			if(C.chatOutput.broken)
-				DIRECT_OUTPUT(C, original_message)
-				return
-
-			// // Client still loading, put their messages in a queue - Actually don't, logged already in database.
-			// if(!C.chatOutput.loaded && C.chatOutput.message_queue && islist(C.chatOutput.message_queue))
-			// 	C.chatOutput.message_queue[++C.chatOutput.message_queue.len] = list("time" = time, "message" = message)
-			// 	return
+		if(!C)
+			return // No client? No care.
+		else if(C.chatOutput.broken)
+			DIRECT_OUTPUT(C, original_message)
+			return
+		else if(!C.chatOutput.loaded)
+			return // If not loaded yet, do nothing and history-sending on load will get it.
 
 		var/list/tojson = list("time" = time, "message" = message);
 		target << output(jsEncode(tojson), "htmloutput:putmessage")

--- a/code/modules/vchat/vchat_client.dm
+++ b/code/modules/vchat/vchat_client.dm
@@ -138,8 +138,9 @@ GLOBAL_DATUM_INIT(iconCache, /savefile, new("data/iconCache.sav")) //Cache of ic
 //Perform DB shenanigans
 /datum/chatOutput/proc/load_database()
 	set waitfor = FALSE
-	var/list/results = vchat_get_messages(owner.ckey) //If there's bad performance on reconnects, look no further
-	for(var/i in max(1, results.len - message_buffer)) // Only send them the number of buffered messages, instead of the ENTIRE log
+	// Only send them the number of buffered messages, instead of the ENTIRE log
+	var/list/results = vchat_get_messages(owner.ckey, message_buffer) //If there's bad performance on reconnects, look no further
+	for(var/i in results.len to 1 step -1)
 		var/list/message = results[i]
 		var/count = 10
 		to_chat_immediate(owner, message["time"], message["message"])

--- a/code/modules/vchat/vchat_db.dm
+++ b/code/modules/vchat/vchat_db.dm
@@ -108,12 +108,16 @@ GLOBAL_DATUM(vchatdb, /database)
 
 	return vchat_exec_update(messagedef)
 
-//Get a player's message history
-/proc/vchat_get_messages(var/ckey, var/oldest = 0)
+//Get a player's message history.  If limit is supplied, messages will be in reverse order.
+/proc/vchat_get_messages(var/ckey, var/limit)
 	if(!ckey)
 		return
 
-	var/list/getdef = list("SELECT * FROM messages WHERE ckey = ? AND worldtime >= ?", ckey, oldest)
+	var/list/getdef
+	if (limit)
+		getdef = list("SELECT * FROM messages WHERE ckey = ? ORDER BY id DESC LIMIT [text2num(limit)]", ckey)
+	else
+		getdef = list("SELECT * FROM messages WHERE ckey = ?", ckey)
 
 	return vchat_exec_query(getdef)
 


### PR DESCRIPTION
- Check vchat loaded flag before attempting to call putmessage
- Fix loading of history on connect. New method calculates correctly and also doesn't spend time loading from database if we're going to throw it away.