### PR TITLE
Add a large shotgun slugs box to the Red armory.

### DIFF
--- a/maps/tether/tether-07-station3.dmm
+++ b/maps/tether/tether-07-station3.dmm
@@ -857,7 +857,11 @@
 /obj/structure/table/steel,
 /obj/item/weapon/storage/box/shotgunshells{
 	pixel_x = 6;
-	pixel_y = -1
+	pixel_y = -3
+	},
+/obj/item/weapon/storage/box/shotgunammo/large{
+	pixel_x = 0;
+	pixel_y = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9


### PR DESCRIPTION
The station lacked any of this ammo type, save in autolathes, which security generally shouldn't be messing with.