### PR TITLE
Fixes R&D machines missing sprites

### DIFF
--- a/code/modules/research/rdmachines.dm
+++ b/code/modules/research/rdmachines.dm
@@ -4,7 +4,7 @@
 
 /obj/machinery/r_n_d
 	name = "R&D Device"
-	icon = 'icons/obj/machines/research_vr.dmi' //VOREStation Edit - Replaced with Eris sprites
+	icon = 'icons/obj/machines/research.dmi'
 	density = 1
 	anchored = 1
 	use_power = USE_POWER_IDLE


### PR DESCRIPTION
Removes a vorestation edit made redundant by upstream updates. The _vr file had incorrect iconstates, causing at least protolathe to turn invisible when in use.