### PR TITLE
Drink update patch

### DIFF
--- a/code/modules/food/drinkingglass/metaglass_vr.dm
+++ b/code/modules/food/drinkingglass/metaglass_vr.dm
@@ -53,7 +53,7 @@
 	glass_center_of_mass = list("x"=16, "y"=8)
 	glass_icon_file = 'icons/obj/drinks_vr.dmi'
 
-/datum/reagent/drink/shroomjuice
+/datum/reagent/ethanol/shroomjuice
 	glass_icon_state = "shroomjuiceglass"
 	glass_center_of_mass = list("x"=16, "y"=8)
 	glass_icon_file = 'icons/obj/drinks_vr.dmi'
@@ -108,7 +108,7 @@
 	glass_center_of_mass = list("x"=16, "y"=8)
 	glass_icon_file = 'icons/obj/drinks_vr.dmi'
 
-/datum/reagent/drink/unsweettea
+/datum/reagent/ethanol/unsweettea
 	glass_icon_state = "unsweetteaglass"
 	glass_center_of_mass = list("x"=16, "y"=8)
 	glass_icon_file = 'icons/obj/drinks_vr.dmi'

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -3608,6 +3608,12 @@
 #include "maps\submaps\surface_submaps\plains\plains_areas.dm"
 #include "maps\submaps\surface_submaps\wilderness\wilderness.dm"
 #include "maps\submaps\surface_submaps\wilderness\wilderness_areas.dm"
-#include "maps\tether\tether.dm"
+#include "maps\virgo_minitest\virgo_minitest.dm"
+#include "maps\virgo_minitest\virgo_minitest_defines.dm"
+#include "maps\virgo_minitest\virgo_minitest_sectors.dm"
+#include "maps\virgo_minitest\virgo_minitest_shuttles.dm"
+#include "maps\virgo_minitest\virgo_minitest-1.dmm"
+#include "maps\virgo_minitest\virgo_minitest-sector-2.dmm"
+#include "maps\virgo_minitest\virgo_minitest-sector-3.dmm"
 #include "maps\~map_system\maps.dm"
 // END_INCLUDE


### PR DESCRIPTION
Two drinks, the "Unsweetened Tea" and "Dumb Shroom Juice" weren't properly mapped as /ethanol.
This should be the last update needed for the Drink Update.