### PR TITLE
Guttersite patch 2

### DIFF
--- a/maps/tether/submaps/space/guttersite.dmm
+++ b/maps/tether/submaps/space/guttersite.dmm
@@ -1,769 +1,24974 @@
-"aa" = (/turf/space,/area/tether_away/guttersite/unexplored)
-"ab" = (/turf/simulated/mineral/floor/vacuum,/area/space)
-"ac" = (/turf/simulated/mineral/cave,/area/space)
-"ad" = (/turf/simulated/mineral/floor/vacuum,/area/tether_away/guttersite/unexplored)
-"ae" = (/turf/simulated/mineral/floor/vacuum,/area/tether_away/guttersite/teleporter)
-"af" = (/obj/structure/lattice,/turf/simulated/mineral/floor/vacuum,/area/tether_away/guttersite/unexplored)
-"ag" = (/turf/simulated/mineral/cave,/area/tether_away/guttersite/unexplored)
-"ah" = (/turf/simulated/wall/r_wall,/area/tether_away/guttersite/teleporter)
-"ai" = (/obj/structure/lattice,/turf/simulated/mineral/floor/vacuum,/area/tether_away/guttersite/teleporter)
-"aj" = (/turf/simulated/mineral/cave,/area/tether_away/guttersite/teleporter)
-"ak" = (/obj/structure/lattice,/turf/space,/area/tether_away/guttersite/unexplored)
-"al" = (/obj/structure/frame/computer{dir = 4},/obj/structure/cable{d2 = 2; icon_state = "0-2"},/turf/simulated/floor/airless,/area/tether_away/guttersite/teleporter)
-"am" = (/obj/machinery/teleport/station,/obj/structure/cable{d2 = 2; icon_state = "0-2"},/turf/simulated/floor/airless,/area/tether_away/guttersite/teleporter)
-"an" = (/obj/machinery/teleport/hub,/turf/simulated/floor/airless,/area/tether_away/guttersite/teleporter)
-"ao" = (/obj/item/weapon/material/shard{icon_state = "medium"},/turf/simulated/floor/airless,/area/tether_away/guttersite/teleporter)
-"ap" = (/turf/simulated/floor/airless,/area/tether_away/guttersite/teleporter)
-"aq" = (/obj/structure/cable,/turf/simulated/floor/airless,/area/tether_away/guttersite/teleporter)
-"ar" = (/obj/structure/table/rack,/obj/item/clothing/gloves/yellow,/obj/item/weapon/storage/toolbox/mechanical,/turf/simulated/floor/airless,/area/tether_away/guttersite/teleporter)
-"as" = (/obj/structure/girder,/turf/simulated/floor/airless,/area/tether_away/guttersite/teleporter)
-"at" = (/obj/item/weapon/cell,/turf/simulated/floor/airless,/area/tether_away/guttersite/teleporter)
-"au" = (/obj/structure/grille/broken,/turf/simulated/floor/airless,/area/tether_away/guttersite/teleporter)
-"av" = (/obj/structure/table,/turf/simulated/floor/airless,/area/tether_away/guttersite/teleporter)
-"aw" = (/obj/structure/closet,/turf/simulated/floor/airless,/area/tether_away/guttersite/teleporter)
-"ax" = (/turf/simulated/wall/r_wall,/area/tether_away/guttersite/storage)
-"ay" = (/obj/structure/boulder,/turf/simulated/mineral/floor/vacuum,/area/tether_away/guttersite/unexplored)
-"az" = (/obj/structure/inflatable/door,/turf/simulated/mineral/floor/vacuum,/area/tether_away/guttersite/unexplored)
-"aA" = (/obj/structure/bonfire/sifwood,/turf/simulated/mineral/floor/vacuum,/area/tether_away/guttersite/unexplored)
-"aB" = (/turf/simulated/wall/r_wall,/area/tether_away/guttersite/maint)
-"aC" = (/obj/machinery/light{dir = 1; icon_state = "tube1"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/storage)
-"aD" = (/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/storage)
-"aE" = (/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/maint)
-"aF" = (/turf/simulated/wall/r_wall,/area/tether_away/guttersite/engines)
-"aG" = (/turf/simulated/wall,/area/tether_away/guttersite/engines)
-"aH" = (/obj/machinery/door/airlock/multi_tile/glass,/turf/simulated/floor/tiled/eris/techmaint_panels,/area/tether_away/guttersite/engines)
-"aI" = (/turf/simulated/floor/tiled/eris/techmaint_panels,/area/tether_away/guttersite/engines)
-"aJ" = (/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/engines)
-"aK" = (/obj/machinery/light_switch{on = 0; pixel_y = 26},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/engines)
-"aL" = (/obj/structure/loot_pile/surface/bones,/turf/simulated/mineral/floor/vacuum,/area/tether_away/guttersite/unexplored)
-"aM" = (/obj/structure/table/steel,/obj/item/weapon/storage/toolbox/electrical,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/engines)
-"aN" = (/obj/structure/sign/poster{dir = 1; icon_state = ""},/turf/simulated/wall,/area/tether_away/guttersite/maint)
-"aO" = (/obj/machinery/computer/ship/navigation/telescreen{pixel_y = 23},/obj/structure/table/steel,/obj/fiftyspawner/glass,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/engines)
-"aP" = (/turf/simulated/wall,/area/tether_away/guttersite/maint)
-"aQ" = (/turf/simulated/wall,/area/tether_away/guttersite/atmos)
-"aR" = (/obj/machinery/door/airlock/multi_tile/glass,/turf/simulated/floor/tiled/eris/techmaint_panels,/area/tether_away/guttersite/atmos)
-"aS" = (/turf/simulated/floor/tiled/eris/techmaint_panels,/area/tether_away/guttersite/atmos)
-"aT" = (/turf/simulated/wall/r_wall,/area/tether_away/guttersite/atmos)
-"aU" = (/obj/structure/table/steel,/obj/machinery/atmospherics/unary/vent_pump/on,/obj/fiftyspawner/steel,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/engines)
-"aV" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 8},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4; icon_state = "intact-supply"},/obj/structure/cable/cyan{d1 = 2; d2 = 4; icon_state = "2-4"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/maint)
-"aW" = (/obj/structure/cable/cyan{d1 = 2; d2 = 8; icon_state = "2-8"},/turf/simulated/floor/plating/eris/under,/area/tether_away/guttersite/engines)
-"aX" = (/turf/simulated/floor/plating/eris/under,/area/tether_away/guttersite/engines)
-"aY" = (/obj/machinery/light{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/supply,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/engines)
-"aZ" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 1},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 1},/turf/simulated/floor/tiled/eris/dark,/area/tether_away/guttersite/maint)
-"ba" = (/obj/item/weapon/circuitboard/teleporter,/turf/simulated/floor/airless,/area/tether_away/guttersite/teleporter)
-"bb" = (/obj/structure/barricade,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/unexplored)
-"bc" = (/obj/structure/cable/cyan{icon_state = "0-4"},/obj/machinery/power/rtg/fake_gen,/turf/simulated/floor/plating/eris/under,/area/tether_away/guttersite/engines)
-"bd" = (/obj/machinery/power/terminal{dir = 4},/obj/structure/cable/cyan{d2 = 8; icon_state = "0-8"},/obj/structure/cable/cyan,/turf/simulated/floor/plating/eris/under,/area/tether_away/guttersite/engines)
-"be" = (/obj/structure/table/steel,/obj/machinery/atmospherics/unary/vent_pump/on,/obj/fiftyspawner/rods,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/atmos)
-"bf" = (/obj/machinery/computer/ship/navigation/telescreen{pixel_y = 23},/obj/structure/table/steel,/obj/item/weapon/storage/toolbox/mechanical,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/atmos)
-"bg" = (/obj/structure/table/steel,/obj/fiftyspawner/wood,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/atmos)
-"bh" = (/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/atmos)
-"bi" = (/obj/machinery/light_switch{on = 0; pixel_y = 26},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/atmos)
-"bj" = (/obj/structure/cable/cyan{d1 = 2; d2 = 4; icon_state = "2-4"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/storage)
-"bk" = (/obj/structure/cable/cyan{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/plating/eris/under,/area/tether_away/guttersite/engines)
-"bl" = (/obj/structure/cable/cyan{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/structure/cable/cyan{d1 = 1; d2 = 4; dir = 4; icon_state = "2-8"},/turf/simulated/floor/plating/eris/under,/area/tether_away/guttersite/engines)
-"bm" = (/obj/structure/cable/cyan{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/structure/cable/cyan{d1 = 2; d2 = 8; icon_state = "2-8"},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 5},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 6},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/engines)
-"bn" = (/obj/structure/cable/cyan{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 8},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 8},/turf/simulated/floor/tiled/eris/techmaint_panels,/area/tether_away/guttersite/engines)
-"bo" = (/turf/simulated/floor/tiled/eris/dark,/area/tether_away/guttersite/maint)
-"bp" = (/obj/machinery/light{dir = 8},/obj/machinery/atmospherics/pipe/simple/hidden/supply,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/atmos)
-"bq" = (/turf/simulated/floor/plating/eris/under,/area/tether_away/guttersite/atmos)
-"br" = (/obj/machinery/atmospherics/pipe/simple/visible/blue{dir = 6},/obj/machinery/meter,/turf/simulated/floor/plating/eris/under,/area/tether_away/guttersite/atmos)
-"bs" = (/obj/machinery/atmospherics/portables_connector{dir = 8},/obj/effect/floor_decal/industrial/outline/red,/obj/machinery/portable_atmospherics/canister/air,/turf/simulated/floor/plating/eris/under,/area/tether_away/guttersite/atmos)
-"bt" = (/obj/machinery/atmospherics/unary/vent_scrubber/on,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/storage)
-"bu" = (/obj/structure/cable/cyan{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 8},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 8},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/maint)
-"bv" = (/obj/structure/cable/cyan{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/machinery/atmospherics/pipe/manifold/hidden/supply,/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,/turf/simulated/floor/tiled/eris/dark,/area/tether_away/guttersite/maint)
-"bw" = (/obj/structure/cable/cyan{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 8},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 8},/obj/structure/cable/cyan{d1 = 2; d2 = 8; icon_state = "2-8"},/obj/structure/cable/cyan{icon_state = "1-8"},/turf/simulated/floor/tiled/eris/dark,/area/tether_away/guttersite/maint)
-"bx" = (/obj/structure/cable/cyan{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 8},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 8},/turf/simulated/floor/tiled/eris/techmaint_panels,/area/tether_away/guttersite/maint)
-"by" = (/obj/structure/cable/cyan{d1 = 2; d2 = 8; icon_state = "2-8"},/obj/machinery/atmospherics/pipe/manifold/hidden/supply,/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{dir = 1},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/atmos)
-"bz" = (/obj/machinery/power/terminal{dir = 4},/obj/structure/cable/cyan{d2 = 8; icon_state = "0-8"},/obj/structure/cable/cyan{d2 = 2; icon_state = "0-2"},/turf/simulated/floor/plating/eris/under,/area/tether_away/guttersite/engines)
-"bA" = (/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,/obj/machinery/atmospherics/pipe/manifold/hidden/supply{dir = 1; icon_state = "map-supply"},/obj/structure/table/darkglass,/obj/structure/cable/cyan{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/commons)
-"bB" = (/obj/structure/cable/cyan{d1 = 1; d2 = 4; dir = 1; icon_state = "1-2"},/obj/structure/cable/cyan{d1 = 1; d2 = 4; dir = 4; icon_state = "1-4"},/turf/simulated/floor/plating/eris/under,/area/tether_away/guttersite/engines)
-"bC" = (/obj/structure/cable/cyan{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/engines)
-"bD" = (/obj/machinery/door/airlock/multi_tile/glass{dir = 2},/turf/simulated/floor/tiled/eris/techmaint_panels,/area/tether_away/guttersite/engines)
-"bE" = (/obj/structure/cable/cyan{d1 = 1; d2 = 2; icon_state = "1-2"},/turf/simulated/floor/tiled/eris/dark,/area/tether_away/guttersite/maint)
-"bF" = (/obj/structure/cable/cyan{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/atmos)
-"bG" = (/obj/structure/cable/cyan{d1 = 1; d2 = 8; icon_state = "1-8"},/turf/simulated/floor/plating/eris/under,/area/tether_away/guttersite/engines)
-"bH" = (/obj/structure/cable/cyan{d1 = 1; d2 = 2; icon_state = "1-2"},/turf/simulated/floor/plating/eris/under,/area/tether_away/guttersite/engines)
-"bI" = (/obj/machinery/atmospherics/pipe/simple/visible/supply{dir = 8},/obj/machinery/atmospherics/pipe/simple/visible/scrubbers{dir = 10},/turf/simulated/floor/plating/eris/under,/area/tether_away/guttersite/atmos)
-"bJ" = (/obj/machinery/atmospherics/pipe/simple/visible/universal{dir = 8},/turf/simulated/floor/plating/eris/under,/area/tether_away/guttersite/atmos)
-"bK" = (/obj/machinery/atmospherics/pipe/simple/visible/blue{dir = 8},/obj/machinery/meter,/turf/simulated/floor/plating/eris/under,/area/tether_away/guttersite/atmos)
-"bL" = (/obj/machinery/atmospherics/binary/pump/on{dir = 8},/turf/simulated/floor/plating/eris/under,/area/tether_away/guttersite/atmos)
-"bM" = (/obj/machinery/atmospherics/pipe/manifold/visible/blue,/turf/simulated/floor/plating/eris/under,/area/tether_away/guttersite/atmos)
-"bN" = (/obj/machinery/atmospherics/portables_connector{dir = 8},/obj/effect/floor_decal/industrial/outline,/obj/machinery/portable_atmospherics/canister/air,/turf/simulated/floor/plating/eris/under,/area/tether_away/guttersite/atmos)
-"bO" = (/obj/structure/table/steel,/obj/structure/cable/cyan,/obj/machinery/power/apc{dir = 4; name = "east bump"; pixel_x = 24},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/engines)
-"bP" = (/obj/structure/table/steel,/obj/structure/cable/cyan,/obj/machinery/power/apc{cell_type = /obj/item/weapon/cell/super; dir = 8; name = "west bump"; pixel_x = -24},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/atmos)
-"bQ" = (/obj/structure/cable/cyan{d1 = 1; d2 = 4; dir = 4; icon_state = "1-4"},/turf/simulated/floor/plating/eris/under,/area/tether_away/guttersite/engines)
-"bR" = (/obj/structure/cable/cyan{d1 = 1; d2 = 4; icon_state = "1-4"},/turf/simulated/floor/tiled/eris/dark,/area/tether_away/guttersite/maint)
-"bS" = (/obj/machinery/light{dir = 4},/obj/structure/cable/cyan{d1 = 2; d2 = 8; icon_state = "2-8"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/maint)
-"bT" = (/obj/machinery/light,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/engines)
-"bU" = (/obj/machinery/alarm{alarm_id = null; breach_detection = 0; dir = 1; icon_state = "alarm0"; pixel_y = -22},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/engines)
-"bV" = (/obj/machinery/firealarm{dir = 1; pixel_x = 0; pixel_y = -25},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/engines)
-"bW" = (/obj/structure/table/steel,/obj/fiftyspawner/plasteel,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/engines)
-"bX" = (/obj/structure/table/steel,/obj/machinery/atmospherics/unary/vent_scrubber/on{dir = 1},/obj/fiftyspawner/plasteel/hull,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/engines)
-"bY" = (/obj/machinery/power/apc{dir = 4; name = "east bump"; pixel_x = 24},/obj/structure/cable/cyan,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/maint)
-"bZ" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 8},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 8},/obj/structure/bed/chair/bay/comfy/black,/obj/structure/cable/cyan{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/commons)
-"ca" = (/obj/machinery/door/airlock/multi_tile/glass{dir = 2},/turf/simulated/floor/tiled/eris/techmaint_panels,/area/tether_away/guttersite/maint)
-"cb" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 6},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 6; icon_state = "intact-supply"},/obj/structure/bed/chair/bay/comfy/black{dir = 1; icon_state = "bay_comfychair_preview"},/obj/structure/cable/cyan{d1 = 2; d2 = 4; icon_state = "2-4"},/turf/simulated/floor/tiled/eris/steel/bar_dance,/area/tether_away/guttersite/commons)
-"cc" = (/obj/machinery/atmospherics/pipe/simple/visible/scrubbers{dir = 5},/turf/simulated/floor/plating/eris/under,/area/tether_away/guttersite/atmos)
-"cd" = (/obj/machinery/atmospherics/pipe/simple/visible/red{dir = 8},/obj/machinery/meter,/turf/simulated/floor/plating/eris/under,/area/tether_away/guttersite/atmos)
-"ce" = (/obj/machinery/atmospherics/binary/pump/on{dir = 4},/turf/simulated/floor/plating/eris/under,/area/tether_away/guttersite/atmos)
-"cf" = (/obj/machinery/atmospherics/pipe/manifold/visible/red{dir = 1},/turf/simulated/floor/plating/eris/under,/area/tether_away/guttersite/atmos)
-"cg" = (/obj/machinery/atmospherics/portables_connector{dir = 8},/obj/effect/floor_decal/industrial/outline/blue,/obj/machinery/portable_atmospherics/canister/empty,/turf/simulated/floor/plating/eris/under,/area/tether_away/guttersite/atmos)
-"ch" = (/obj/machinery/atmospherics/unary/vent_pump/on{dir = 1; icon_state = "map_vent_out"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/storage)
-"ci" = (/obj/structure/cable/cyan{d1 = 2; d2 = 4; icon_state = "2-4"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/office)
-"cj" = (/obj/machinery/light,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/storage)
-"ck" = (/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{dir = 1},/obj/machinery/atmospherics/pipe/manifold/hidden/supply{dir = 1; icon_state = "map-supply"},/obj/machinery/atmospherics/pipe/simple/hidden,/obj/structure/window/basic,/obj/structure/window/basic{dir = 4; icon_state = "window"},/obj/structure/table/darkglass,/obj/structure/cable/cyan{d1 = 2; d2 = 8; icon_state = "2-8"},/obj/structure/cable/cyan{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/tiled/eris/white/monofloor,/area/tether_away/guttersite/office)
-"cl" = (/obj/item/weapon/hand_tele,/turf/simulated/mineral/floor/vacuum,/area/tether_away/guttersite/unexplored)
-"cm" = (/obj/machinery/atmospherics/pipe/simple/visible/red{dir = 5},/obj/machinery/meter,/turf/simulated/floor/plating/eris/under,/area/tether_away/guttersite/atmos)
-"cn" = (/obj/machinery/atmospherics/portables_connector{dir = 8},/obj/effect/floor_decal/industrial/outline/yellow,/obj/machinery/portable_atmospherics/canister/empty,/turf/simulated/floor/plating/eris/under,/area/tether_away/guttersite/atmos)
-"co" = (/obj/structure/loot_pile/surface/bones,/obj/random/gun/random,/turf/simulated/mineral/floor/vacuum,/area/tether_away/guttersite/unexplored)
-"cp" = (/obj/structure/window/basic{dir = 8; icon_state = "window"},/turf/simulated/floor/tiled/eris/white/monofloor,/area/tether_away/guttersite/office)
-"cq" = (/obj/item/device/bluespaceradio/tether_prelinked,/turf/simulated/mineral/floor/vacuum,/area/tether_away/guttersite/unexplored)
-"cr" = (/obj/structure/table/darkglass,/obj/item/key,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/storage)
-"cs" = (/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/unexplored)
-"ct" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 6},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 6; icon_state = "intact-supply"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/maint)
-"cu" = (/obj/structure/table/steel,/obj/machinery/atmospherics/unary/vent_scrubber/on{dir = 1},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/atmos)
-"cv" = (/obj/structure/table/steel,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/atmos)
-"cw" = (/obj/machinery/firealarm{dir = 1; pixel_x = 0; pixel_y = -25},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/atmos)
-"cx" = (/obj/machinery/alarm{alarm_id = null; breach_detection = 0; dir = 1; icon_state = "alarm0"; pixel_y = -22},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/atmos)
-"cy" = (/obj/machinery/light,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/atmos)
-"cz" = (/obj/machinery/light{dir = 8},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/maint)
-"cA" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 8},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4; icon_state = "intact-supply"},/obj/structure/cable/cyan{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/maint)
-"cB" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 10; icon_state = "intact-scrubbers"},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 10; icon_state = "intact-supply"},/obj/structure/cable/cyan{d1 = 2; d2 = 8; icon_state = "2-8"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/maint)
-"cC" = (/obj/machinery/door/airlock/multi_tile/glass,/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 1},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 1},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/maint)
-"cD" = (/obj/machinery/alarm{dir = 4; icon_state = "alarm0"; pixel_x = -22; pixel_y = 0},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/maint)
-"cE" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 1},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 1},/obj/structure/cable/cyan{d1 = 1; d2 = 2; icon_state = "1-2"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/maint)
-"cF" = (/turf/simulated/wall/r_wall,/area/tether_away/guttersite/commons)
-"cG" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 1},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 1},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/maint)
-"cH" = (/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/commons)
-"cI" = (/obj/machinery/light{dir = 1; icon_state = "tube1"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/commons)
-"cJ" = (/obj/fiftyspawner/glass,/obj/fiftyspawner/steel,/turf/simulated/floor/airless,/area/tether_away/guttersite/teleporter)
-"cK" = (/obj/structure/cable/cyan{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/storage)
-"cL" = (/obj/machinery/atmospherics/unary/vent_scrubber/on,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/commons)
-"cM" = (/obj/effect/landmark/corpse/clown,/turf/simulated/mineral/floor/vacuum,/area/tether_away/guttersite/unexplored)
-"cN" = (/obj/machinery/power/apc{dir = 4; name = "east bump"; pixel_x = 24},/obj/structure/cable/cyan{d2 = 8; icon_state = "0-8"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/storage)
-"cO" = (/obj/structure/bed/chair/bay/comfy/black,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/commons)
-"cP" = (/obj/machinery/vending/loadout/uniform,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/commons)
-"cQ" = (/obj/structure/cable/cyan{d2 = 4; icon_state = "0-4"},/obj/machinery/power/smes/buildable/point_of_interest,/turf/simulated/floor/plating/eris/under,/area/tether_away/guttersite/engines)
-"cR" = (/obj/machinery/light{dir = 4},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/commons)
-"cS" = (/obj/machinery/atmospherics/unary/vent_pump/on{dir = 1; icon_state = "map_vent_out"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/commons)
-"cT" = (/obj/structure/inflatable/door,/turf/simulated/floor/plating/eris,/area/tether_away/guttersite/unexplored)
-"cU" = (/obj/machinery/vending/boozeomat,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/commons)
-"cV" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 5; icon_state = "intact-scrubbers"},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 5},/obj/structure/cable/cyan{d1 = 1; d2 = 4; icon_state = "1-4"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/maint)
-"cW" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 8},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4; icon_state = "intact-supply"},/obj/machinery/light,/obj/structure/cable/cyan{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/maint)
-"cX" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 8},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4; icon_state = "intact-supply"},/obj/machinery/door/firedoor,/obj/machinery/door/airlock/maintenance_hatch{req_access = list(0); req_one_access = list(10)},/obj/structure/cable/cyan{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/storage)
-"cY" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 8},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4; icon_state = "intact-supply"},/obj/structure/cable/cyan{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/storage)
-"cZ" = (/turf/simulated/floor/tiled/eris/steel/bar_light,/area/tether_away/guttersite/commons)
-"da" = (/obj/structure/window/basic{dir = 1},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/commons)
-"db" = (/obj/machinery/vending/food,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/commons)
-"dc" = (/obj/machinery/light{dir = 1; icon_state = "tube1"},/obj/structure/table/darkglass,/obj/machinery/chemical_dispenser/bar_alc/full,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/commons)
-"dd" = (/obj/machinery/light,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/commons)
-"de" = (/turf/simulated/wall/r_wall,/area/tether_away/guttersite/medbay)
-"df" = (/obj/structure/grille,/obj/structure/window/reinforced/full,/obj/machinery/door/firedoor/glass,/turf/simulated/floor/plating,/area/tether_away/guttersite/commons)
-"dg" = (/obj/machinery/atmospherics/pipe/manifold/hidden/supply{dir = 1; icon_state = "map-supply"},/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,/obj/structure/cable/cyan{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/storage)
-"dh" = (/obj/structure/table/darkglass,/turf/simulated/floor/tiled/eris/steel/bar_dance,/area/tether_away/guttersite/commons)
-"di" = (/obj/structure/table/darkglass,/obj/item/weapon/storage/box/glasses/meta,/turf/simulated/floor/tiled/eris/steel/bar_dance,/area/tether_away/guttersite/commons)
-"dj" = (/obj/structure/table/darkglass,/obj/item/weapon/reagent_containers/food/drinks/shaker,/turf/simulated/floor/tiled/eris/steel/bar_dance,/area/tether_away/guttersite/commons)
-"dk" = (/turf/simulated/mineral/cave,/area/tether_away/guttersite/commons)
-"dl" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 10; icon_state = "intact-scrubbers"},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 10; icon_state = "intact-supply"},/obj/structure/cable/cyan{d1 = 2; d2 = 8; icon_state = "2-8"},/obj/structure/cable/cyan{icon_state = "1-8"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/storage)
-"dm" = (/obj/machinery/door/firedoor,/obj/machinery/door/airlock/maintenance_hatch{req_one_access = list()},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/commons)
-"dn" = (/turf/simulated/wall/r_wall,/area/tether_away/guttersite/walkway)
-"do" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 1},/obj/structure/cable/cyan{d1 = 1; d2 = 2; icon_state = "1-2"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/storage)
-"dp" = (/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/medbay)
-"dq" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 1},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 1},/obj/structure/cable/cyan{d1 = 1; d2 = 2; icon_state = "1-2"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/storage)
-"dr" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 1},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 1},/obj/machinery/door/firedoor,/obj/machinery/door/airlock/maintenance_hatch{req_access = list(0); req_one_access = list(10)},/obj/structure/cable/cyan{d1 = 1; d2 = 2; icon_state = "1-2"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/storage)
-"ds" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 1},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 1},/obj/machinery/door/firedoor,/obj/machinery/door/airlock/maintenance_hatch{req_access = list(0); req_one_access = list(10)},/obj/structure/cable/cyan{d1 = 1; d2 = 2; icon_state = "1-2"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/commons)
-"dt" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 1},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 1},/obj/structure/cable/cyan{d1 = 1; d2 = 2; icon_state = "1-2"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/commons)
-"du" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 1},/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/structure/cable/cyan{d1 = 1; d2 = 2; icon_state = "1-2"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/commons)
-"dv" = (/turf/simulated/wall/skipjack,/area/tether_away/guttersite/office)
-"dw" = (/obj/machinery/door/airlock/hatch{frequency = 1331; icon_state = "door_closed"; id_tag = "vox_northeast_lock"; locked = 0; req_access = list(150)},/turf/simulated/shuttle/plating,/area/tether_away/guttersite/office)
-"dx" = (/obj/machinery/access_button{command = "cycle_exterior"; frequency = 1331; master_tag = "vox_east_control"; req_access = list(150)},/turf/simulated/wall/skipjack,/area/tether_away/guttersite/office)
-"dy" = (/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{dir = 8; icon_state = "map-scrubbers"},/obj/machinery/atmospherics/pipe/manifold/hidden/supply{dir = 8},/obj/structure/cable/cyan{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/structure/cable/cyan{d1 = 1; d2 = 4; icon_state = "1-4"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/commons)
-"dz" = (/obj/structure/closet/medical_wall,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/medbay)
-"dA" = (/obj/machinery/airlock_sensor{frequency = 1331; id_tag = "vox_east_sensor"; pixel_x = -25},/turf/simulated/shuttle/plating,/area/tether_away/guttersite/office)
-"dB" = (/obj/machinery/atmospherics/unary/vent_pump/high_volume{frequency = 1331; id_tag = "vox_east_vent"},/turf/simulated/shuttle/plating,/area/tether_away/guttersite/office)
-"dC" = (/obj/machinery/atmospherics/unary/vent_pump/on{dir = 4; icon_state = "map_vent_out"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/medbay)
-"dD" = (/obj/structure/medical_stand,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/medbay)
-"dE" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 10; icon_state = "intact-supply"},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 10; icon_state = "intact-scrubbers"},/obj/structure/cable/cyan{d1 = 2; d2 = 8; icon_state = "2-8"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/commons)
-"dF" = (/obj/structure/dogbed,/mob/living/simple_mob/vore/redpanda/fae{name = "Rhythm"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/office)
-"dG" = (/obj/structure/bed/padded,/obj/item/weapon/bedsheet/medical,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/medbay)
-"dH" = (/obj/machinery/embedded_controller/radio/airlock/airlock_controller{frequency = 1331; id_tag = ""; pixel_x = -24; req_access = list(150); tag_airpump = "vox_east_vent"; tag_chamber_sensor = "vox_east_sensor"; tag_exterior_door = "vox_northeast_lock"; tag_interior_door = "vox_southeast_lock"},/obj/machinery/atmospherics/unary/vent_pump/high_volume{dir = 4; frequency = 1331; id_tag = "vox_east_vent"},/obj/machinery/light/small,/turf/simulated/shuttle/plating,/area/tether_away/guttersite/office)
-"dI" = (/obj/machinery/meter,/obj/machinery/atmospherics/pipe/manifold/hidden{dir = 4; icon_state = "map"},/turf/simulated/shuttle/plating,/area/tether_away/guttersite/office)
-"dJ" = (/obj/machinery/alarm{dir = 4; icon_state = "alarm0"; pixel_x = -22; pixel_y = 0},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/medbay)
-"dK" = (/obj/machinery/door/airlock/hatch{frequency = 1331; icon_state = "door_closed"; id_tag = "vox_southeast_lock"; locked = 0; req_access = list(150)},/obj/machinery/atmospherics/pipe/simple/hidden,/turf/simulated/shuttle/plating,/area/tether_away/guttersite/office)
-"dL" = (/obj/structure/window/basic{dir = 8},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/medbay)
-"dM" = (/obj/machinery/firealarm{dir = 1; pixel_x = 0; pixel_y = -25},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/medbay)
-"dN" = (/turf/simulated/wall/r_wall,/area/tether_away/guttersite/office)
-"dO" = (/obj/structure/grille,/obj/structure/window/reinforced/full,/obj/machinery/door/firedoor/glass,/turf/simulated/floor/plating,/area/tether_away/guttersite/office)
-"dP" = (/obj/structure/table/rack,/obj/item/weapon/tank/oxygen,/obj/random/multiple/voidsuit,/turf/simulated/shuttle/plating,/area/tether_away/guttersite/office)
-"dQ" = (/obj/machinery/access_button{command = "cycle_interior"; frequency = 1331; master_tag = "vox_east_control"; pixel_x = 22; req_access = list(150)},/obj/machinery/atmospherics/pipe/simple/hidden,/turf/simulated/shuttle/plating,/area/tether_away/guttersite/office)
-"dR" = (/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/office)
-"dS" = (/obj/machinery/light{dir = 1; icon_state = "tube1"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/office)
-"dT" = (/obj/machinery/atmospherics/pipe/simple/hidden,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/office)
-"dU" = (/obj/machinery/light{dir = 4},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/office)
-"dV" = (/obj/machinery/light{dir = 8},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/office)
-"dW" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 8},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4; icon_state = "intact-supply"},/obj/structure/bed/chair/bay/comfy/black{dir = 1; icon_state = "bay_comfychair_preview"},/obj/structure/cable/cyan{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/tiled/eris/steel/bar_dance,/area/tether_away/guttersite/commons)
-"dX" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 8},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4; icon_state = "intact-supply"},/obj/structure/cable/cyan{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/tiled/eris/steel/bar_dance,/area/tether_away/guttersite/commons)
-"dY" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 8},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4; icon_state = "intact-supply"},/obj/structure/cable/cyan{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/wall/r_wall,/area/tether_away/guttersite/commons)
-"dZ" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 8},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4; icon_state = "intact-supply"},/obj/structure/closet/cabinet,/obj/structure/cable/cyan{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/commons)
-"ea" = (/obj/machinery/atmospherics/pipe/manifold/hidden/supply{dir = 1; icon_state = "map-supply"},/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,/obj/structure/cable/cyan{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/commons)
-"eb" = (/turf/simulated/wall/r_wall,/area/tether_away/guttersite/bridge)
-"ec" = (/obj/structure/window/basic,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/office)
-"ed" = (/turf/simulated/wall/r_wall,/area/tether_away/guttersite/vault)
-"ee" = (/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/walkway)
-"ef" = (/obj/machinery/light{dir = 1; icon_state = "tube1"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/walkway)
-"eg" = (/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/bridge)
-"eh" = (/obj/machinery/light{dir = 1; icon_state = "tube1"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/bridge)
-"ei" = (/obj/machinery/door/window/southleft,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/office)
-"ej" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 8},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4; icon_state = "intact-supply"},/obj/machinery/washing_machine,/obj/structure/cable/cyan{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/commons)
-"ek" = (/obj/structure/window/basic{dir = 8; icon_state = "window"},/obj/structure/filingcabinet/filingcabinet,/turf/simulated/floor/tiled/eris/white/monofloor,/area/tether_away/guttersite/office)
-"el" = (/obj/machinery/alarm{dir = 4; icon_state = "alarm0"; pixel_x = -22; pixel_y = 0},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/vault)
-"em" = (/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/vault)
-"en" = (/obj/machinery/alarm{dir = 4; icon_state = "alarm0"; pixel_x = -22; pixel_y = 0},/obj/machinery/light{dir = 1; icon_state = "tube1"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/walkway)
-"eo" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 8},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4; icon_state = "intact-supply"},/obj/structure/cable/cyan{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/commons)
-"ep" = (/obj/machinery/atmospherics/unary/vent_scrubber/on,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/walkway)
-"eq" = (/obj/machinery/atmospherics/unary/vent_scrubber/on,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/bridge)
-"er" = (/obj/machinery/alarm{dir = 4; icon_state = "alarm0"; pixel_x = -22; pixel_y = 0},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/office)
-"es" = (/turf/simulated/floor/tiled/eris/white/monofloor,/area/tether_away/guttersite/office)
-"et" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 8},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4; icon_state = "intact-supply"},/obj/structure/curtain/open/shower,/obj/machinery/shower,/obj/structure/cable/cyan{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/tiled/eris/dark/techfloor_grid,/area/tether_away/guttersite/commons)
-"eu" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 8},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4; icon_state = "intact-supply"},/obj/structure/cable/cyan{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/tiled/eris/dark/techfloor_grid,/area/tether_away/guttersite/commons)
-"ev" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 8},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4; icon_state = "intact-supply"},/obj/structure/table/darkglass,/obj/structure/cable/cyan{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/commons)
-"ew" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 8},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4; icon_state = "intact-supply"},/obj/structure/bed/chair/bay/comfy/black{dir = 8; icon_state = "bay_comfychair_preview"},/obj/structure/cable/cyan{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/commons)
-"ex" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 9; icon_state = "intact-scrubbers"},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 9; icon_state = "intact-supply"},/obj/structure/cable/cyan{icon_state = "1-8"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/commons)
-"ey" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 1},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 1},/obj/structure/cable/cyan{d1 = 1; d2 = 2; icon_state = "1-2"},/turf/simulated/floor/tiled/eris/steel/bar_dance,/area/tether_away/guttersite/commons)
-"ez" = (/obj/machinery/power/apc{cell_type = /obj/item/weapon/cell/super; dir = 8; name = "west bump"; pixel_x = -24},/obj/structure/cable/cyan{d2 = 4; icon_state = "0-4"},/turf/simulated/floor/tiled/eris/steel/bar_dance,/area/tether_away/guttersite/commons)
-"eA" = (/obj/structure/bed/chair/bay/comfy/black{dir = 4; icon_state = "bay_comfychair_preview"},/obj/structure/cable/cyan{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/tiled/eris/steel/bar_dance,/area/tether_away/guttersite/commons)
-"eB" = (/obj/structure/table/darkglass,/obj/structure/cable/cyan{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/tiled/eris/steel/bar_dance,/area/tether_away/guttersite/commons)
-"eC" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 1},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 1},/obj/structure/bed/chair/bay/comfy/black{dir = 8; icon_state = "bay_comfychair_preview"},/obj/structure/cable/cyan{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/structure/cable/cyan{icon_state = "1-8"},/turf/simulated/floor/tiled/eris/steel/bar_dance,/area/tether_away/guttersite/commons)
-"eD" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 1},/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/machinery/door/firedoor,/obj/machinery/door/airlock/maintenance_hatch{req_one_access = list()},/obj/structure/cable/cyan{d1 = 1; d2 = 2; icon_state = "1-2"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/medbay)
-"eE" = (/turf/space,/area/space)
-"eF" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 1},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 1},/obj/structure/bed/chair/bay/comfy/black{dir = 8; icon_state = "bay_comfychair_preview"},/obj/structure/cable/cyan{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/structure/cable/cyan{d1 = 1; d2 = 2; icon_state = "1-2"},/turf/simulated/floor/tiled/eris/steel/bar_dance,/area/tether_away/guttersite/commons)
-"eG" = (/obj/structure/bedsheetbin,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/commons)
-"eH" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 1},/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/structure/cable/cyan{d1 = 1; d2 = 2; icon_state = "1-2"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/medbay)
-"eI" = (/obj/machinery/atmospherics/unary/vent_pump/on{dir = 1; icon_state = "map_vent_out"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/walkway)
-"eJ" = (/obj/machinery/firealarm{dir = 1; pixel_x = 0; pixel_y = -25},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/walkway)
-"eK" = (/obj/machinery/atmospherics/pipe/manifold/hidden/supply{dir = 8},/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{dir = 4},/obj/structure/cable/cyan{d1 = 1; d2 = 2; icon_state = "1-2"},/turf/simulated/floor/tiled/eris/steel/bar_dance,/area/tether_away/guttersite/commons)
-"eL" = (/obj/machinery/atmospherics/unary/vent_pump/on{dir = 1; icon_state = "map_vent_out"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/bridge)
-"eM" = (/obj/machinery/atmospherics/unary/vent_pump/on{dir = 4; icon_state = "map_vent_out"},/turf/simulated/floor/tiled/eris/white/monofloor,/area/tether_away/guttersite/office)
-"eN" = (/obj/machinery/atmospherics/pipe/simple/hidden{dir = 9; icon_state = "intact"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/office)
-"eO" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 1},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 1},/obj/structure/cable/cyan{d1 = 1; d2 = 2; icon_state = "1-2"},/turf/simulated/floor/tiled/eris/steel/bar_dance,/area/tether_away/guttersite/commons)
-"eP" = (/obj/structure/table/rack/shelf/steel,/obj/random/curseditem,/obj/random/slimecore,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/vault)
-"eQ" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 1},/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/machinery/light{dir = 4},/obj/structure/cable/cyan{d1 = 1; d2 = 2; icon_state = "1-2"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/medbay)
-"eR" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 1},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 1},/obj/machinery/door/firedoor,/obj/machinery/door/airlock/maintenance_hatch{req_one_access = list()},/obj/structure/cable/cyan{d1 = 1; d2 = 2; icon_state = "1-2"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/commons)
-"eS" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 1},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 1},/obj/structure/cable/cyan{d1 = 1; d2 = 2; icon_state = "1-2"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/walkway)
-"eT" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 1},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 1},/obj/machinery/light{dir = 4},/obj/structure/cable/cyan{d1 = 1; d2 = 2; icon_state = "1-2"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/walkway)
-"eU" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 1},/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/structure/bed/padded,/obj/item/weapon/bedsheet/medical,/obj/structure/cable/cyan{d1 = 1; d2 = 2; icon_state = "1-2"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/medbay)
-"eV" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 5; icon_state = "intact-scrubbers"},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 9; icon_state = "intact-supply"},/obj/structure/window/basic{dir = 1},/obj/structure/cable/cyan{d1 = 1; d2 = 4; icon_state = "1-4"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/medbay)
-"eW" = (/obj/machinery/atmospherics/unary/vent_scrubber/on{dir = 8; icon_state = "map_scrubber_on"},/obj/structure/cable/cyan{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/medbay)
-"eX" = (/obj/structure/cable/cyan{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/medbay)
-"eY" = (/obj/machinery/power/apc{dir = 4; name = "east bump"; pixel_x = 24},/obj/structure/bed/chair/bay/comfy/black{dir = 8; icon_state = "bay_comfychair_preview"},/obj/structure/cable/cyan{d2 = 8; icon_state = "0-8"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/medbay)
-"eZ" = (/obj/item/weapon/cell/super,/turf/simulated/floor/airless,/area/tether_away/guttersite/teleporter)
-"fa" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 6},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 10; icon_state = "intact-supply"},/obj/structure/filingcabinet/filingcabinet,/turf/simulated/floor/tiled/eris/white/monofloor,/area/tether_away/guttersite/office)
-"fb" = (/obj/machinery/atmospherics/unary/vent_scrubber/on{dir = 8; icon_state = "map_scrubber_on"},/turf/simulated/floor/tiled/eris/white/monofloor,/area/tether_away/guttersite/office)
-"fc" = (/obj/machinery/power/apc{dir = 4; name = "east bump"; pixel_x = 24},/obj/structure/cable/cyan{d2 = 8; icon_state = "0-8"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/office)
-"fd" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 1},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 1},/obj/machinery/door/firedoor,/obj/machinery/door/airlock/maintenance_hatch{req_one_access = list()},/obj/structure/cable/cyan{d1 = 1; d2 = 2; icon_state = "1-2"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/walkway)
-"fe" = (/obj/structure/table/rack,/obj/random/energy,/obj/random/multiple/voidsuit,/obj/item/weapon/tank/oxygen,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/vault)
-"ff" = (/obj/machinery/atmospherics/unary/vent_pump/on{dir = 1; icon_state = "map_vent_out"},/obj/structure/table/rack,/obj/random/firstaid,/obj/random/firstaid,/obj/random/medical/lite,/obj/random/medical/lite,/obj/random/medical/pillbottle,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/vault)
-"fg" = (/obj/structure/cable/cyan{d1 = 1; d2 = 2; icon_state = "1-2"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/office)
-"fh" = (/obj/structure/bed/chair/bay/comfy/black{dir = 8; icon_state = "bay_comfychair_preview"},/obj/structure/cable/cyan{d1 = 1; d2 = 2; icon_state = "1-2"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/office)
-"fi" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 1},/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/structure/cable/cyan{d1 = 1; d2 = 2; icon_state = "1-2"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/walkway)
-"fj" = (/obj/machinery/power/apc{cell_type = /obj/item/weapon/cell/super; dir = 8; name = "west bump"; pixel_x = -24},/obj/structure/cable/cyan{d2 = 4; icon_state = "0-4"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/walkway)
-"fk" = (/obj/random/humanoidremains,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/vault)
-"fl" = (/obj/machinery/light,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/bridge)
-"fm" = (/obj/machinery/firealarm{dir = 1; pixel_x = 0; pixel_y = -25},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/bridge)
-"fn" = (/obj/machinery/firealarm{dir = 1; pixel_x = 0; pixel_y = -25},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/vault)
-"fo" = (/obj/machinery/door/firedoor,/obj/machinery/door/airlock/maintenance_hatch{req_one_access = list()},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/office)
-"fp" = (/obj/structure/cable/cyan{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/walkway)
-"fq" = (/turf/simulated/wall/r_wall,/area/tether_away/guttersite/docking)
-"fr" = (/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/docking)
-"fs" = (/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{dir = 8; icon_state = "map-scrubbers"},/obj/machinery/atmospherics/pipe/manifold/hidden/supply{dir = 8},/obj/structure/cable/cyan{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/structure/cable/cyan{d1 = 1; d2 = 4; icon_state = "1-4"},/obj/structure/cable/cyan{icon_state = "1-8"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/walkway)
-"ft" = (/obj/machinery/light{dir = 4},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/docking)
-"fu" = (/turf/simulated/wall/r_wall,/area/tether_away/guttersite/security)
-"fv" = (/obj/machinery/atmospherics/pipe/manifold/hidden/supply{dir = 1; icon_state = "map-supply"},/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,/obj/structure/cable/cyan{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/walkway)
-"fw" = (/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/security)
-"fx" = (/obj/machinery/light{dir = 1; icon_state = "tube1"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/security)
-"fy" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4; icon_state = "intact-supply"},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 8},/obj/structure/cable/cyan{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/walkway)
-"fz" = (/turf/simulated/floor/plating/eris/under,/area/tether_away/guttersite/security)
-"fA" = (/obj/machinery/atmospherics/pipe/simple/visible/blue{dir = 6},/obj/machinery/meter,/turf/simulated/floor/plating/eris/under,/area/tether_away/guttersite/security)
-"fB" = (/obj/machinery/atmospherics/portables_connector{dir = 8},/obj/effect/floor_decal/industrial/outline/red,/obj/machinery/portable_atmospherics/canister/air,/turf/simulated/floor/plating/eris/under,/area/tether_away/guttersite/security)
-"fC" = (/obj/machinery/atmospherics/pipe/simple/hidden{dir = 6; icon_state = "intact"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/security)
-"fD" = (/obj/machinery/atmospherics/pipe/simple/visible/universal{dir = 8},/turf/simulated/floor/plating/eris/under,/area/tether_away/guttersite/security)
-"fE" = (/obj/machinery/meter,/obj/machinery/atmospherics/pipe/simple/hidden{dir = 4},/turf/simulated/floor/plating/eris/under,/area/tether_away/guttersite/security)
-"fF" = (/obj/machinery/atmospherics/binary/pump/on{dir = 8},/turf/simulated/floor/plating/eris/under,/area/tether_away/guttersite/security)
-"fG" = (/obj/machinery/atmospherics/pipe/manifold/visible/blue,/turf/simulated/floor/plating/eris/under,/area/tether_away/guttersite/security)
-"fH" = (/obj/machinery/atmospherics/portables_connector{dir = 8},/obj/effect/floor_decal/industrial/outline,/obj/machinery/portable_atmospherics/canister/air,/turf/simulated/floor/plating/eris/under,/area/tether_away/guttersite/security)
-"fI" = (/obj/machinery/atmospherics/unary/vent_scrubber/on,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/security)
-"fJ" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4; icon_state = "intact-supply"},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 8},/obj/machinery/door/firedoor,/obj/machinery/door/airlock/maintenance_hatch{req_one_access = list()},/obj/structure/cable/cyan{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/walkway)
-"fK" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4; icon_state = "intact-supply"},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 8},/obj/structure/cable/cyan{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/bridge)
-"fL" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4; icon_state = "intact-supply"},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 8},/obj/machinery/door/firedoor,/obj/machinery/door/airlock/maintenance_hatch{req_one_access = list()},/obj/structure/cable/cyan{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/bridge)
-"fM" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4; icon_state = "intact-supply"},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 8},/obj/structure/cable/cyan{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/structure/cable/cyan{d1 = 2; d2 = 8; icon_state = "2-8"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/bridge)
-"fN" = (/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{dir = 1},/obj/machinery/atmospherics/pipe/manifold/hidden/supply{dir = 1; icon_state = "map-supply"},/obj/structure/cable/cyan{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/bridge)
-"fO" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 10; icon_state = "intact-supply"},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 9; icon_state = "intact-scrubbers"},/obj/structure/cable/cyan{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/bridge)
-"fP" = (/obj/structure/cable/cyan{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/bridge)
-"fQ" = (/obj/machinery/power/apc{dir = 4; name = "east bump"; pixel_x = 24},/obj/structure/cable/cyan{d2 = 8; icon_state = "0-8"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/bridge)
-"fR" = (/obj/structure/cable/cyan{d1 = 1; d2 = 2; icon_state = "1-2"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/bridge)
-"fS" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 6; icon_state = "intact-supply"},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 6},/obj/structure/cable/cyan{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/office)
-"fT" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4; icon_state = "intact-supply"},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 8},/obj/machinery/door/firedoor,/obj/machinery/door/airlock/vault/bolted,/obj/structure/cable/cyan{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/office)
-"fU" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/machinery/atmospherics/pipe/simple/hidden,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/security)
-"fV" = (/obj/machinery/atmospherics/unary/vent_pump/on{dir = 1; icon_state = "map_vent_out"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/security)
-"fW" = (/obj/item/weapon/storage/toolbox/lunchbox/heart/filled,/turf/simulated/mineral/floor/vacuum,/area/tether_away/guttersite/unexplored)
-"fX" = (/obj/structure/grille,/obj/structure/window/reinforced/full,/obj/structure/sign/securearea{desc = "A warning sign which reads 'EXTERNAL AIRLOCK'"; icon_state = "space"; layer = 4; name = "EXTERNAL AIRLOCK"; pixel_x = 0},/obj/structure/window/reinforced{dir = 1},/obj/structure/window/reinforced{dir = 8},/obj/machinery/door/firedoor/glass,/turf/simulated/floor/plating,/area/tether_away/guttersite/security)
-"fY" = (/obj/structure/grille,/obj/structure/window/reinforced/full,/obj/structure/window/reinforced{dir = 1},/obj/machinery/door/firedoor/glass,/turf/simulated/floor/plating,/area/tether_away/guttersite/security)
-"fZ" = (/obj/structure/bed/chair/office/dark{dir = 1; icon_state = "officechair_dark"},/mob/living/simple_mob/humanoid/merc/ranged/smg/poi{faction = "wolfgirl"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/security)
-"ga" = (/obj/effect/floor_decal/industrial/warning/corner{dir = 8},/obj/machinery/atmospherics/unary/vent_scrubber/on{dir = 4},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/security)
-"gb" = (/obj/machinery/atmospherics/pipe/manifold/hidden/supply{dir = 8},/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/security)
-"gc" = (/obj/machinery/atmospherics/unary/vent_pump/on{dir = 8},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/security)
-"gd" = (/obj/structure/table/steel,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/security)
-"ge" = (/obj/structure/bed/chair/office/dark{dir = 8; icon_state = "officechair_dark"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/security)
-"gf" = (/obj/machinery/door/firedoor,/obj/machinery/door/airlock/maintenance_hatch{req_one_access = list(38)},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/security)
-"gg" = (/obj/structure/fence,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/security)
-"gh" = (/obj/machinery/door/airlock/glass_external,/obj/machinery/access_button{command = "cycle_exterior"; frequency = 1380; master_tag = "dock_d2a2"; name = "exterior access button"; pixel_x = -5; pixel_y = -26; req_one_access = list(13)},/obj/effect/map_helper/airlock/door/ext_door,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/security)
-"gi" = (/obj/machinery/atmospherics/unary/vent_pump/high_volume{dir = 4; frequency = 1380; id_tag = "dock_d2a2_pump"},/obj/machinery/light/small,/obj/machinery/embedded_controller/radio/airlock/docking_port{frequency = 1380; id_tag = ""; pixel_y = 28},/obj/machinery/airlock_sensor{frequency = 1380; id_tag = "dock_d2a2_sensor"; pixel_x = 0; pixel_y = -25},/obj/effect/map_helper/airlock/atmos/chamber_pump,/obj/effect/map_helper/airlock/sensor/chamber_sensor,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/security)
-"gj" = (/obj/machinery/door/airlock/glass_external,/obj/machinery/atmospherics/pipe/simple/hidden{dir = 4},/obj/effect/map_helper/airlock/door/int_door,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/security)
-"gk" = (/obj/effect/floor_decal/industrial/warning{dir = 8},/obj/machinery/access_button{command = "cycle_interior"; frequency = 1380; master_tag = "dock_d2a2"; name = "interior access button"; pixel_x = -28; pixel_y = 26; req_one_access = list(13)},/obj/machinery/atmospherics/pipe/simple/hidden{dir = 4},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/security)
-"gl" = (/obj/effect/floor_decal/sign/dock/two,/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 1},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/machinery/atmospherics/pipe/manifold/hidden{dir = 4; icon_state = "map"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/security)
-"gm" = (/obj/structure/bed/chair/office/dark{dir = 4; icon_state = "officechair_dark"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/security)
-"gn" = (/obj/structure/closet,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/security)
-"go" = (/obj/structure/grille,/obj/structure/window/reinforced/full,/obj/structure/window/reinforced,/obj/structure/window/reinforced{dir = 8},/obj/machinery/door/firedoor/glass,/turf/simulated/floor/plating,/area/tether_away/guttersite/security)
-"gp" = (/obj/structure/grille,/obj/structure/window/reinforced/full,/obj/structure/window/reinforced,/obj/machinery/door/firedoor/glass,/turf/simulated/floor/plating,/area/tether_away/guttersite/security)
-"gq" = (/obj/effect/floor_decal/industrial/warning/corner{dir = 1},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/security)
-"gr" = (/obj/structure/fence/door/locked{dir = 8; icon_state = "door_closed"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/security)
-"gs" = (/obj/structure/grille,/obj/structure/window/reinforced/full,/obj/structure/sign/securearea{desc = "A warning sign which reads 'EXTERNAL AIRLOCK'"; icon_state = "space"; layer = 4; name = "EXTERNAL AIRLOCK"; pixel_x = 0},/obj/structure/window/reinforced{dir = 1},/obj/structure/window/reinforced{dir = 8},/obj/machinery/door/firedoor/glass,/turf/simulated/floor/plating,/area/tether_away/guttersite/docking)
-"gt" = (/obj/structure/grille,/obj/structure/window/reinforced/full,/obj/structure/window/reinforced{dir = 1},/obj/machinery/door/firedoor/glass,/turf/simulated/floor/plating,/area/tether_away/guttersite/docking)
-"gu" = (/obj/structure/grille,/obj/structure/window/reinforced/full,/obj/machinery/door/firedoor/glass,/turf/simulated/floor/plating,/area/tether_away/guttersite/docking)
-"gv" = (/obj/effect/floor_decal/industrial/warning/corner{dir = 8},/obj/machinery/atmospherics/unary/vent_scrubber/on{dir = 4},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/docking)
-"gw" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4; icon_state = "intact-supply"},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 8},/obj/structure/cable/cyan{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/vault)
-"gx" = (/obj/machinery/atmospherics/unary/vent_pump/on{dir = 8},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/docking)
-"gy" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 5; icon_state = "intact-scrubbers"},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 5},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/security)
-"gz" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4; icon_state = "intact-scrubbers"},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4; icon_state = "intact-supply"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/security)
-"gA" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4; icon_state = "intact-scrubbers"},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4; icon_state = "intact-supply"},/obj/machinery/door/airlock/maintenance_hatch{req_one_access = list(38)},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/security)
-"gB" = (/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{dir = 1},/obj/machinery/atmospherics/pipe/manifold/hidden/supply{dir = 1; icon_state = "map-supply"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/security)
-"gC" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4; icon_state = "intact-scrubbers"},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4; icon_state = "intact-supply"},/turf/simulated/wall/r_wall,/area/tether_away/guttersite/security)
-"gD" = (/obj/structure/bed/chair/office/dark{dir = 1; icon_state = "officechair_dark"},/mob/living/simple_mob/humanoid/merc/melee/poi{faction = "wolfgirl"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/security)
-"gE" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 10; icon_state = "intact-scrubbers"},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 10; icon_state = "intact-supply"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/security)
-"gF" = (/obj/structure/table/rack/shelf/steel,/obj/random/mre,/obj/random/mre,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/vault)
-"gG" = (/obj/machinery/atmospherics/unary/vent_pump/high_volume{dir = 4; frequency = 1380; id_tag = "dock_d2a2_pump"},/obj/machinery/light/small,/obj/machinery/embedded_controller/radio/airlock/docking_port{frequency = 1380; id_tag = "guttersite_sshuttle"; pixel_y = 28},/obj/machinery/airlock_sensor{frequency = 1380; id_tag = "dock_d2a2_sensor"; pixel_x = 0; pixel_y = -25},/obj/effect/map_helper/airlock/atmos/chamber_pump,/obj/effect/map_helper/airlock/sensor/chamber_sensor,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/docking)
-"gH" = (/obj/machinery/door/airlock/glass_external,/obj/machinery/atmospherics/pipe/simple/hidden{dir = 4},/obj/effect/map_helper/airlock/door/int_door,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/docking)
-"gI" = (/obj/structure/closet{name = "mechanical equipment"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/medbay)
-"gJ" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4; icon_state = "intact-supply"},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 8},/obj/machinery/door/firedoor,/obj/machinery/door/airlock/vault/bolted,/obj/structure/cable/cyan{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/vault)
-"gK" = (/obj/machinery/alarm{dir = 4; icon_state = "alarm0"; pixel_x = -22; pixel_y = 0},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/security)
-"gL" = (/obj/machinery/firealarm{dir = 1; pixel_x = 0; pixel_y = -25},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/security)
-"gM" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 1},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 1},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/security)
-"gN" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/machinery/atmospherics/pipe/simple/hidden/supply,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/security)
-"gO" = (/obj/structure/fence/end{dir = 4; icon_state = "end"},/obj/structure/fence,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/security)
-"gP" = (/obj/structure/fence{dir = 8; icon_state = "straight"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/security)
-"gQ" = (/obj/structure/grille,/obj/structure/window/reinforced/full,/obj/structure/window/reinforced,/obj/structure/window/reinforced{dir = 8},/obj/machinery/door/firedoor/glass,/turf/simulated/floor/plating,/area/tether_away/guttersite/docking)
-"gR" = (/obj/structure/grille,/obj/structure/window/reinforced/full,/obj/structure/window/reinforced,/obj/machinery/door/firedoor/glass,/turf/simulated/floor/plating,/area/tether_away/guttersite/docking)
-"gS" = (/obj/effect/floor_decal/industrial/warning/corner{dir = 1},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/docking)
-"gT" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4; icon_state = "intact-supply"},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 8},/obj/structure/cable/cyan{d1 = 2; d2 = 8; icon_state = "2-8"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/vault)
-"gU" = (/obj/structure/barricade,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/security)
-"gV" = (/obj/machinery/alarm{dir = 4; icon_state = "alarm0"; pixel_x = -22; pixel_y = 0},/obj/structure/cable/cyan{d1 = 1; d2 = 4; icon_state = "1-4"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/bridge)
-"gW" = (/obj/structure/fence/door/opened{dir = 8; icon_state = "door_opened"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/security)
-"gX" = (/obj/machinery/light,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/security)
-"gY" = (/obj/machinery/atmospherics/unary/vent_pump/on{dir = 4; icon_state = "map_vent_out"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/security)
-"gZ" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 5; icon_state = "intact-scrubbers"},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 9; icon_state = "intact-supply"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/security)
-"ha" = (/obj/machinery/atmospherics/unary/vent_scrubber/on{dir = 8; icon_state = "map_scrubber_on"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/security)
-"hb" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 5; icon_state = "intact-scrubbers"},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 5},/obj/structure/cable/cyan{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/bridge)
-"hc" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4; icon_state = "intact-supply"},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 8},/obj/machinery/light{dir = 1; icon_state = "tube1"},/obj/structure/cable/cyan{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/bridge)
-"hd" = (/obj/machinery/fitness/punching_bag/clown,/turf/simulated/mineral/floor/vacuum,/area/tether_away/guttersite/unexplored)
-"he" = (/obj/machinery/atmospherics/unary/vent_scrubber/on{dir = 4},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/security)
-"hf" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 5},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 9; icon_state = "intact-scrubbers"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/security)
-"hg" = (/obj/machinery/light{dir = 4},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/security)
-"hh" = (/obj/machinery/atmospherics/pipe/simple/hidden,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/machinery/atmospherics/pipe/simple/hidden/supply,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/docking)
-"hi" = (/turf/simulated/wall/skipjack,/area/tether_away/guttersite/docking)
-"hj" = (/obj/machinery/door/airlock/hatch{frequency = 1331; icon_state = "door_closed"; id_tag = "vox_northeast_lock"; locked = 0; req_access = list(150)},/turf/simulated/shuttle/plating,/area/tether_away/guttersite/docking)
-"hk" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4; icon_state = "intact-supply"},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 8},/obj/machinery/door/firedoor,/obj/machinery/door/airlock/maintenance_hatch{req_one_access = list()},/obj/structure/cable/cyan{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/office)
-"hl" = (/obj/structure/fence/door/locked,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/security)
-"hm" = (/obj/structure/fence/end{dir = 8; icon_state = "end"},/obj/structure/fence/end{dir = 4; icon_state = "end"},/obj/structure/fence,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/security)
-"hn" = (/obj/structure/fence/end{dir = 8; icon_state = "end"},/obj/structure/fence,/obj/structure/fence/end{dir = 1; icon_state = "end"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/security)
-"ho" = (/obj/machinery/airlock_sensor{frequency = 1331; id_tag = "vox_east_sensor"; pixel_x = -25},/turf/simulated/shuttle/plating,/area/tether_away/guttersite/docking)
-"hp" = (/obj/machinery/atmospherics/unary/vent_pump/high_volume{frequency = 1331; id_tag = "vox_east_vent"},/turf/simulated/shuttle/plating,/area/tether_away/guttersite/docking)
-"hq" = (/obj/machinery/alarm{dir = 4; icon_state = "alarm0"; pixel_x = -22; pixel_y = 0},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/docking)
-"hr" = (/obj/structure/table/rack/shelf/steel,/obj/random/cash,/obj/random/cash,/obj/random/cigarettes,/obj/random/drinkbottle,/obj/random/pizzabox,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/vault)
-"hs" = (/obj/machinery/meter,/obj/machinery/atmospherics/pipe/manifold/hidden{dir = 4; icon_state = "map"},/turf/simulated/shuttle/plating,/area/tether_away/guttersite/docking)
-"ht" = (/obj/machinery/atmospherics/pipe/simple/visible/blue{dir = 6},/obj/machinery/meter,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/docking)
-"hu" = (/obj/machinery/atmospherics/portables_connector{dir = 8},/obj/effect/floor_decal/industrial/outline/red,/obj/machinery/portable_atmospherics/canister/air,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/docking)
-"hv" = (/obj/machinery/door/airlock/hatch{frequency = 1331; icon_state = "door_closed"; id_tag = "vox_southeast_lock"; locked = 0; req_access = list(150)},/obj/machinery/atmospherics/pipe/simple/hidden,/turf/simulated/shuttle/plating,/area/tether_away/guttersite/docking)
-"hw" = (/obj/structure/table/rack/steel,/obj/random/mre,/obj/random/multiple/gun/projectile/handgun,/obj/random/powercell,/obj/random/multiple/voidsuit,/obj/item/weapon/tank/oxygen,/obj/random/tool,/obj/random/drinkbottle,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/unexplored)
-"hx" = (/obj/machinery/atmospherics/pipe/simple/hidden{dir = 6; icon_state = "intact"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/docking)
-"hy" = (/obj/machinery/atmospherics/pipe/simple/visible/universal{dir = 8},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/docking)
-"hz" = (/obj/machinery/meter,/obj/machinery/atmospherics/pipe/simple/hidden{dir = 4},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/docking)
-"hA" = (/obj/machinery/atmospherics/binary/pump/on{dir = 8},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/docking)
-"hB" = (/obj/machinery/atmospherics/pipe/manifold/visible/blue,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/docking)
-"hC" = (/obj/machinery/atmospherics/portables_connector{dir = 8},/obj/effect/floor_decal/industrial/outline,/obj/machinery/portable_atmospherics/canister/air,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/docking)
-"hD" = (/obj/machinery/light{dir = 4},/obj/structure/table/rack,/obj/random/coin,/obj/random/contraband,/obj/random/energy,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/vault)
-"hE" = (/obj/structure/table/rack/shelf/steel,/obj/random/powercell,/obj/random/powercell,/obj/random/powercell,/obj/random/powercell,/obj/random/toolbox,/obj/random/tool/alien,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/vault)
-"hF" = (/obj/machinery/atmospherics/pipe/simple/hidden{dir = 5; icon_state = "intact"},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/machinery/atmospherics/pipe/simple/hidden/supply,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/docking)
-"hG" = (/obj/machinery/atmospherics/pipe/simple/hidden{dir = 4},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/docking)
-"hH" = (/obj/machinery/atmospherics/pipe/simple/hidden{dir = 4},/obj/machinery/light{dir = 1; icon_state = "tube1"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/docking)
-"hI" = (/obj/machinery/atmospherics/pipe/manifold/hidden,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/docking)
-"hJ" = (/obj/machinery/atmospherics/pipe/simple/hidden{dir = 8; icon_state = "intact"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/docking)
-"hK" = (/obj/machinery/atmospherics/pipe/simple/hidden{dir = 8; icon_state = "intact"},/obj/machinery/light{dir = 1; icon_state = "tube1"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/docking)
-"hL" = (/obj/machinery/atmospherics/pipe/simple/hidden{dir = 8; icon_state = "intact"},/obj/machinery/atmospherics/unary/vent_pump/on,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/docking)
-"hM" = (/obj/machinery/atmospherics/pipe/simple/hidden{dir = 9; icon_state = "intact"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/docking)
-"hN" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 5; icon_state = "intact-scrubbers"},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 5},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/docking)
-"hO" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4; icon_state = "intact-scrubbers"},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 8},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/docking)
-"hP" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 10; icon_state = "intact-scrubbers"},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 9; icon_state = "intact-supply"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/docking)
-"hQ" = (/obj/machinery/firealarm{dir = 1; pixel_x = 0; pixel_y = -25},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/docking)
-"hR" = (/obj/machinery/atmospherics/unary/vent_scrubber/on{dir = 1},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/docking)
-"hS" = (/obj/effect/shuttle_landmark/premade/guttersite/sshuttle,/turf/space,/area/space)
-"hT" = (/obj/effect/shuttle_landmark/premade/guttersite/lshuttle,/turf/space,/area/space)
-"hU" = (/obj/structure/bed/chair/office/dark{dir = 8; icon_state = "officechair_dark"},/mob/living/simple_mob/humanoid/merc/melee/poi{faction = "wolfgirl"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/security)
-"hV" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4; icon_state = "intact-supply"},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 8},/obj/structure/cable/cyan{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/office)
-"hW" = (/obj/machinery/firealarm{dir = 1; pixel_x = 0; pixel_y = -25},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4; icon_state = "intact-supply"},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 8},/obj/structure/cable/cyan{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/office)
-"hX" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4; icon_state = "intact-supply"},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 8},/obj/structure/window/basic{dir = 8; icon_state = "window"},/obj/structure/window/basic,/obj/structure/table/darkglass,/obj/structure/cable/cyan{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/tiled/eris/white/monofloor,/area/tether_away/guttersite/office)
-"hY" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4; icon_state = "intact-supply"},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 8},/obj/structure/table/darkglass,/obj/structure/cable/cyan{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/tiled/eris/white/monofloor,/area/tether_away/guttersite/office)
-"hZ" = (/obj/structure/grille,/obj/structure/window/reinforced/full,/obj/machinery/door/firedoor/glass,/turf/simulated/floor/plating,/area/tether_away/guttersite/bridge)
-"ia" = (/obj/structure/grille,/obj/structure/window/reinforced/full,/obj/machinery/door/firedoor/glass,/turf/simulated/floor/plating,/area/tether_away/guttersite/walkway)
-"ib" = (/obj/machinery/vending/cola/soft,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/walkway)
-"ic" = (/obj/structure/grille,/obj/structure/window/reinforced/full,/obj/machinery/door/firedoor/glass,/turf/simulated/floor/plating,/area/tether_away/guttersite/medbay)
-"id" = (/obj/machinery/door/airlock/glass_external,/obj/machinery/access_button{command = "cycle_exterior"; frequency = 1380; master_tag = "dock_d2a2"; name = "exterior access button"; pixel_x = -5; pixel_y = -26; req_one_access = list()},/obj/effect/map_helper/airlock/door/ext_door,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/docking)
-"ie" = (/obj/effect/floor_decal/industrial/warning{dir = 8},/obj/machinery/access_button{command = "cycle_interior"; frequency = 1380; master_tag = "dock_d2a2"; name = "interior access button"; pixel_x = -28; pixel_y = 26; req_one_access = list()},/obj/machinery/atmospherics/pipe/simple/hidden{dir = 4},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/docking)
-"if" = (/obj/random/mob/mouse,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/security)
-"ig" = (/mob/living/simple_mob/vore/aggressive/rat/phoron,/turf/simulated/mineral/floor/vacuum,/area/tether_away/guttersite/unexplored)
-"ih" = (/obj/machinery/computer/arcade/battle,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/bridge)
-"ii" = (/obj/effect/overmap/visitable/sector/guttersite,/turf/space,/area/tether_away/guttersite/unexplored)
-"ij" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4; icon_state = "intact-supply"},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 8},/obj/structure/table/darkglass,/obj/item/weapon/pen/blue,/obj/structure/cable/cyan{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/tiled/eris/white/monofloor,/area/tether_away/guttersite/office)
-"ik" = (/turf/simulated/floor/tiled/eris/white/techfloor_grid,/area/tether_away/guttersite/office)
-"il" = (/turf/simulated/floor/tiled/eris/white/panels,/area/tether_away/guttersite/office)
-"im" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 1},/turf/simulated/floor/tiled/eris/white/panels,/area/tether_away/guttersite/office)
-"in" = (/obj/machinery/atmospherics/pipe/manifold/hidden/supply,/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,/obj/structure/table/darkglass,/obj/item/weapon/paper_bin,/obj/structure/cable/cyan{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/tiled/eris/white/monofloor,/area/tether_away/guttersite/office)
-"io" = (/obj/machinery/door/window/westleft,/turf/simulated/floor/tiled/eris/white/monofloor,/area/tether_away/guttersite/office)
-"ip" = (/obj/machinery/vending/nifsoft_shop,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/office)
-"iq" = (/obj/structure/bed/chair/bay/comfy/black,/turf/simulated/floor/tiled/eris/white/panels,/area/tether_away/guttersite/office)
-"ir" = (/obj/item/weapon/card/id/assistant,/turf/simulated/mineral/floor/vacuum,/area/tether_away/guttersite/unexplored)
-"is" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4; icon_state = "intact-supply"},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 8},/obj/structure/cable/cyan{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/structure/cable/cyan{icon_state = "1-8"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/office)
-"it" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4; icon_state = "intact-supply"},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 8},/obj/structure/cable/cyan{icon_state = "1-8"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/office)
-"iu" = (/obj/machinery/door/window/westright,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/office)
-"iv" = (/obj/structure/window/basic{dir = 8; icon_state = "window"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/office)
-"iw" = (/obj/structure/cable/cyan{d1 = 1; d2 = 2; icon_state = "1-2"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/vault)
-"ix" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 1},/obj/machinery/atmospherics/pipe/simple/hidden,/obj/structure/cable/cyan{d1 = 1; d2 = 2; icon_state = "1-2"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/office)
-"iy" = (/obj/structure/window/basic{dir = 8; icon_state = "window"},/obj/machinery/papershredder,/turf/simulated/floor/tiled/eris/white/monofloor,/area/tether_away/guttersite/office)
-"iz" = (/obj/structure/cable/cyan{d1 = 1; d2 = 4; icon_state = "1-4"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/vault)
-"iA" = (/mob/living/simple_mob/humanoid/merc/melee/sword/space,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/vault)
-"iB" = (/obj/structure/cable/cyan{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/vault)
-"iC" = (/obj/machinery/vending/sovietsoda,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/office)
-"iD" = (/obj/machinery/vending/snack,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/office)
-"iE" = (/obj/machinery/vending/cigarette,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/office)
-"iF" = (/obj/structure/bed/chair/bay/comfy/black{dir = 4; icon_state = "bay_comfychair_preview"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/office)
-"iG" = (/obj/structure/table/darkglass,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/office)
-"iH" = (/obj/structure/bed/chair/bay/comfy/black{dir = 8; icon_state = "bay_comfychair_preview"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/office)
-"iI" = (/obj/structure/bed/chair/bay/comfy/black{dir = 4; icon_state = "bay_comfychair_preview"},/mob/living/simple_mob/vore/catgirl,/turf/simulated/floor/tiled/eris/white/techfloor_grid,/area/tether_away/guttersite/office)
-"iJ" = (/mob/living/simple_mob/vore/aggressive/mimic,/turf/simulated/mineral/floor/vacuum,/area/tether_away/guttersite/unexplored)
-"iK" = (/obj/structure/cable/cyan{d1 = 4; d2 = 8; icon_state = "4-8"},/mob/living/simple_mob/humanoid/merc/ranged/rifle/mag/poi,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/vault)
-"iL" = (/obj/structure/table/rack,/obj/item/weapon/tank/oxygen,/obj/random/multiple/voidsuit,/turf/simulated/shuttle/plating,/area/tether_away/guttersite/docking)
-"iM" = (/obj/machinery/power/apc{dir = 4; name = "east bump"; pixel_x = 24},/obj/random/cutout,/obj/structure/cable/cyan{d2 = 8; icon_state = "0-8"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/vault)
-"iN" = (/obj/structure/table/rack/shelf/steel,/obj/random/plushie,/obj/random/plushielarge,/obj/random/toy,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/vault)
-"iO" = (/obj/machinery/access_button{command = "cycle_exterior"; frequency = 1331; master_tag = "vox_east_control"; req_access = list()},/turf/simulated/wall/skipjack,/area/tether_away/guttersite/docking)
-"iP" = (/obj/machinery/embedded_controller/radio/airlock/airlock_controller{frequency = 1331; id_tag = "guttersite_lshuttle"; pixel_x = -24; req_access = list(); tag_airpump = "vox_east_vent"; tag_chamber_sensor = "vox_east_sensor"; tag_exterior_door = "vox_northeast_lock"; tag_interior_door = "vox_southeast_lock"},/obj/machinery/atmospherics/unary/vent_pump/high_volume{dir = 4; frequency = 1331; id_tag = "vox_east_vent"},/obj/machinery/light/small,/turf/simulated/shuttle/plating,/area/tether_away/guttersite/docking)
-"iQ" = (/obj/machinery/access_button{command = "cycle_interior"; frequency = 1331; master_tag = "vox_east_control"; pixel_x = 22; req_access = list()},/obj/machinery/atmospherics/pipe/simple/hidden,/turf/simulated/shuttle/plating,/area/tether_away/guttersite/docking)
-"iR" = (/mob/living/simple_mob/mechanical/hivebot/ranged_damage/basic,/turf/simulated/mineral/floor/vacuum,/area/tether_away/guttersite/unexplored)
-"iS" = (/mob/living/simple_mob/mechanical/hivebot/tank/meatshield,/turf/simulated/mineral/floor/vacuum,/area/tether_away/guttersite/unexplored)
-"iT" = (/obj/structure/bed/chair/office/dark{dir = 4; icon_state = "officechair_dark"},/obj/effect/landmark/corpse/clown,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/security)
-"iU" = (/obj/machinery/light{dir = 8; icon_state = "tube1"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/vault)
-"iV" = (/obj/item/clothing/under/assistantformal,/turf/simulated/mineral/floor/vacuum,/area/tether_away/guttersite/unexplored)
-"iW" = (/obj/item/weapon/reagent_containers/food/snacks/clownburger,/turf/simulated/mineral/floor/vacuum,/area/tether_away/guttersite/unexplored)
-"iX" = (/obj/machinery/computer/arcade/orion_trail,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/bridge)
-"iY" = (/obj/machinery/vending/snack,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/bridge)
-"iZ" = (/obj/machinery/light,/obj/machinery/vending/fitness,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/walkway)
-"ja" = (/obj/structure/bed/chair/bay/comfy/black{dir = 4; icon_state = "bay_comfychair_preview"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/bridge)
-"jb" = (/obj/structure/table/darkglass,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/bridge)
-"jc" = (/obj/structure/bed/chair/bay/comfy/black{dir = 8; icon_state = "bay_comfychair_preview"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/bridge)
-"jd" = (/obj/structure/table/rack/steel,/obj/random/firstaid,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/security)
-"je" = (/obj/structure/table/rack/steel,/obj/random/handgun/sec,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/security)
-"jf" = (/obj/structure/table/rack/steel,/obj/random/energy/sec,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/security)
-"jg" = (/mob/living/simple_mob/humanoid/merc/melee/poi{desc = "A lone space clown, taking on the world."; icon = 'icons/mob/clowns_vr.dmi'; icon_dead = "cluwne_dead"; icon_gib = "clown_gib"; icon_living = "cluwne"; icon_state = "cluwne"; name = "Green Clown"},/turf/simulated/mineral/floor/vacuum,/area/tether_away/guttersite/unexplored)
-"jh" = (/obj/structure/bed/chair/office/dark{dir = 8; icon_state = "officechair_dark"},/mob/living/simple_mob/humanoid/merc/ranged/rifle/mag/poi{faction = "wolfgirl"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/security)
-"ji" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4; icon_state = "intact-scrubbers"},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4; icon_state = "intact-supply"},/obj/structure/bed/chair/office/dark{dir = 4; icon_state = "officechair_dark"},/mob/living/simple_mob/humanoid/merc/ranged/technician/poi{faction = "wolfgirl"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/security)
-"jj" = (/obj/random/curseditem,/turf/simulated/mineral/floor/vacuum,/area/tether_away/guttersite/unexplored)
-"jk" = (/obj/item/weapon/reagent_containers/food/snacks/clownstears,/turf/simulated/mineral/floor/vacuum,/area/tether_away/guttersite/unexplored)
-"jl" = (/obj/structure/loot_pile/surface/bones,/obj/item/weapon/reagent_containers/food/drinks/bottle/bottleofnothing,/turf/simulated/mineral/floor/vacuum,/area/tether_away/guttersite/unexplored)
-"jm" = (/obj/item/weapon/storage/backpack/clown,/turf/simulated/mineral/floor/vacuum,/area/tether_away/guttersite/unexplored)
-"jn" = (/obj/item/weapon/stamp/clown,/turf/simulated/mineral/floor/vacuum,/area/tether_away/guttersite/unexplored)
-"jo" = (/obj/structure/table/rack/shelf/steel,/obj/item/weapon/reagent_containers/food/snacks/donut/cherryjelly,/obj/item/weapon/reagent_containers/food/snacks/donut/jelly,/obj/item/weapon/reagent_containers/food/snacks/donut/normal,/obj/item/weapon/reagent_containers/food/snacks/donut/poisonberry,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/security)
-"jp" = (/obj/structure/table/rack/shelf/steel,/obj/item/weapon/reagent_containers/food/snacks/donut/cherryjelly,/obj/item/weapon/reagent_containers/food/snacks/donut/jelly,/obj/item/weapon/reagent_containers/food/snacks/donut/normal,/obj/item/weapon/reagent_containers/food/snacks/donut/slimejelly,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/security)
-"jq" = (/obj/structure/table/rack/shelf/steel,/obj/item/weapon/reagent_containers/food/snacks/donut/chaos,/obj/item/weapon/reagent_containers/food/snacks/donut/cherryjelly,/obj/item/weapon/reagent_containers/food/snacks/donut/cherryjelly,/obj/item/weapon/reagent_containers/food/snacks/donut/jelly,/obj/item/weapon/reagent_containers/food/snacks/donut/normal,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/security)
-"jr" = (/obj/structure/table/rack/shelf/steel,/obj/item/weapon/grenade/chem_grenade/metalfoam,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/security)
-"js" = (/obj/structure/table/rack/shelf/steel,/obj/item/weapon/grenade/flashbang,/obj/item/weapon/grenade/flashbang,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/security)
-"jt" = (/obj/structure/table/rack/shelf/steel,/obj/item/weapon/melee/chainofcommand,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/security)
-"ju" = (/obj/structure/table/rack/steel,/obj/item/weapon/handcuffs,/obj/item/weapon/melee/baton,/obj/item/weapon/implant/sizecontrol,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/security)
-"jv" = (/obj/structure/table/darkglass,/obj/machinery/chemical_dispenser/biochemistry/full,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/commons)
-"jw" = (/obj/item/weapon/reagent_containers/spray/waterflower,/turf/simulated/mineral/floor/vacuum,/area/tether_away/guttersite/unexplored)
-"jx" = (/mob/living/simple_mob/vore/wolfgirl,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/security)
-"jy" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 1},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 1},/obj/machinery/door/firedoor,/obj/machinery/door/airlock/maintenance_hatch{req_one_access = list(38)},/obj/structure/cable/cyan{d1 = 1; d2 = 2; icon_state = "1-2"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/security)
-"jz" = (/mob/living/simple_mob/vore/wolfgirl{name = "Tricky Dixie"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/unexplored)
-"jA" = (/obj/structure/closet/cabinet,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/commons)
-"jB" = (/obj/machinery/washing_machine,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/commons)
-"jC" = (/obj/machinery/door/airlock/maintenance_hatch{req_one_access = list()},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/commons)
-"jD" = (/turf/simulated/floor/tiled/eris/steel/bar_dance,/area/tether_away/guttersite/commons)
-"jE" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 1},/obj/machinery/door/firedoor,/obj/machinery/door/airlock/maintenance_hatch{req_one_access = list()},/obj/machinery/atmospherics/pipe/simple/hidden,/obj/structure/cable/cyan{d1 = 1; d2 = 2; icon_state = "1-2"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/office)
-"jF" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 1},/obj/machinery/atmospherics/pipe/simple/hidden,/obj/structure/cable/cyan{d1 = 1; d2 = 2; icon_state = "1-2"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/docking)
-"jH" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 1},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 1},/obj/structure/cable/cyan{d1 = 1; d2 = 2; icon_state = "1-2"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/security)
-"jI" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 1},/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/structure/cable/cyan{d1 = 1; d2 = 2; icon_state = "1-2"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/security)
-"jJ" = (/obj/machinery/power/apc{cell_type = /obj/item/weapon/cell/super; dir = 8; name = "west bump"; pixel_x = -24},/obj/structure/cable/cyan{d2 = 4; icon_state = "0-4"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/security)
-"jK" = (/obj/machinery/atmospherics/pipe/simple/hidden,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 6},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 6; icon_state = "intact-supply"},/obj/structure/cable/cyan{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/security)
-"jL" = (/obj/structure/bed/padded,/obj/item/weapon/bedsheet/ian,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/commons)
-"jM" = (/obj/structure/bed/padded,/obj/item/weapon/bedsheet/captain,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/commons)
-"jN" = (/obj/structure/bed/padded,/obj/item/weapon/bedsheet/mime,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/commons)
-"jO" = (/obj/structure/bed/padded,/obj/item/weapon/bedsheet/hop,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/commons)
-"jP" = (/obj/structure/bed/padded,/obj/item/weapon/bedsheet/cosmos,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/commons)
-"jQ" = (/obj/structure/bed/padded,/obj/item/weapon/bedsheet/hos,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/commons)
-"jR" = (/obj/structure/bed/padded,/obj/item/weapon/bedsheet/pirate,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/commons)
-"jS" = (/obj/structure/bed/padded,/obj/item/weapon/bedsheet/ce,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/commons)
-"jT" = (/obj/structure/window/basic,/obj/structure/bed/padded,/obj/item/weapon/bedsheet/clown,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/commons)
-"jU" = (/obj/structure/window/basic,/obj/structure/bed/padded,/obj/item/weapon/bedsheet/medical,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/commons)
-"jV" = (/obj/structure/window/basic,/obj/structure/bed/padded,/obj/item/weapon/bedsheet/rd,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/commons)
-"jW" = (/obj/structure/window/basic,/obj/structure/bed/padded,/obj/item/weapon/bedsheet/rainbow,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/commons)
-"jX" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 8},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4; icon_state = "intact-supply"},/obj/structure/cable/cyan{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/security)
-"jY" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 8},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4; icon_state = "intact-supply"},/obj/structure/cable/cyan{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/wall/r_wall,/area/tether_away/guttersite/security)
-"ka" = (/obj/structure/bed/chair/bay/comfy/black{dir = 4; icon_state = "bay_comfychair_preview"},/turf/simulated/floor/tiled/eris/steel/bar_dance,/area/tether_away/guttersite/commons)
-"kb" = (/obj/structure/bed/chair/bay/comfy/black{dir = 8; icon_state = "bay_comfychair_preview"},/turf/simulated/floor/tiled/eris/steel/bar_dance,/area/tether_away/guttersite/commons)
-"kc" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 8},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4; icon_state = "intact-supply"},/obj/structure/table/steel,/obj/structure/cable/cyan{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/security)
-"kd" = (/obj/machinery/light,/turf/simulated/floor/tiled/eris/steel/bar_dance,/area/tether_away/guttersite/commons)
-"ke" = (/obj/machinery/atmospherics/unary/vent_scrubber/on{dir = 4},/turf/simulated/floor/tiled/eris/steel/bar_dance,/area/tether_away/guttersite/commons)
-"kf" = (/obj/item/device/flashlight/lamp/green,/turf/simulated/mineral/floor/vacuum,/area/tether_away/guttersite/unexplored)
-"kg" = (/obj/machinery/atmospherics/unary/vent_pump/on{dir = 8},/turf/simulated/floor/tiled/eris/steel/bar_dance,/area/tether_away/guttersite/commons)
-"kh" = (/obj/item/weapon/book{author = "Urist McHopefulsoul"; desc = "It contains fourty blank pages followed by the entire screenplay of a movie called 'Requiem for a Dream'"; name = "A Comprehensive Guide to Assisting"},/turf/simulated/mineral/floor/vacuum,/area/tether_away/guttersite/unexplored)
-"ki" = (/obj/structure/reagent_dispensers/water_cooler/full{icon_state = "water_cooler-vend"},/turf/simulated/floor/tiled/eris/steel/bar_dance,/area/tether_away/guttersite/commons)
-"kj" = (/obj/machinery/firealarm{dir = 1; pixel_x = 0; pixel_y = -25},/obj/structure/table/darkglass,/obj/machinery/microwave,/turf/simulated/floor/tiled/eris/steel/bar_dance,/area/tether_away/guttersite/commons)
-"kk" = (/obj/structure/table/darkglass,/obj/item/weapon/storage/box/cups,/turf/simulated/floor/tiled/eris/steel/bar_dance,/area/tether_away/guttersite/commons)
-"kl" = (/obj/machinery/light,/obj/structure/table/darkglass,/obj/item/weapon/storage/box/condimentbottles,/turf/simulated/floor/tiled/eris/steel/bar_dance,/area/tether_away/guttersite/commons)
-"km" = (/obj/structure/table/darkglass,/obj/item/weapon/storage/box/donkpockets,/turf/simulated/floor/tiled/eris/steel/bar_dance,/area/tether_away/guttersite/commons)
-"kn" = (/obj/machinery/atmospherics/pipe/manifold/hidden/supply{dir = 1; icon_state = "map-supply"},/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,/obj/structure/table/steel,/obj/structure/cable/cyan{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/security)
-"ko" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 8},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4; icon_state = "intact-supply"},/obj/structure/table/steel,/obj/item/device/flashlight/lamp,/obj/structure/cable/cyan{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/security)
-"kp" = (/turf/simulated/floor/tiled/eris/dark/techfloor_grid,/area/tether_away/guttersite/commons)
-"kq" = (/obj/structure/sink{dir = 8; icon_state = "sink"; pixel_x = -12; pixel_y = 8},/turf/simulated/floor/tiled/eris/dark/techfloor_grid,/area/tether_away/guttersite/commons)
-"kr" = (/obj/structure/toilet{dir = 8},/turf/simulated/floor/tiled/eris/dark/techfloor_grid,/area/tether_away/guttersite/commons)
-"ks" = (/obj/machinery/holoplant,/obj/machinery/holoplant{icon_state = "plant-09"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/commons)
-"kt" = (/obj/machinery/holoplant,/obj/machinery/holoplant{icon_state = "plant-10"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/commons)
-"ku" = (/obj/machinery/holoplant,/obj/machinery/holoplant{icon_state = "plant-15"},/turf/simulated/floor/tiled/eris/steel/bar_dance,/area/tether_away/guttersite/commons)
-"kv" = (/obj/structure/window/basic,/obj/machinery/holoplant,/obj/machinery/holoplant{icon_state = "plant-1"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/office)
-"kw" = (/obj/machinery/holoplant,/obj/machinery/holoplant{icon_state = "plant-13"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/bridge)
-"kx" = (/obj/machinery/holoplant,/obj/machinery/holoplant{icon_state = "plant-15"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/office)
-"ky" = (/obj/machinery/vending/loadout/overwear,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/commons)
-"kz" = (/obj/machinery/vending/loadout/clothing,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/commons)
-"kA" = (/obj/structure/table/darkglass,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/commons)
-"kB" = (/obj/structure/bed/chair/bay/comfy/black{dir = 4; icon_state = "bay_comfychair_preview"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/commons)
-"kC" = (/obj/structure/window/basic{dir = 8},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/commons)
-"kD" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 8},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4; icon_state = "intact-supply"},/obj/structure/table/steel,/obj/item/weapon/pen/fountain,/obj/structure/cable/cyan{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/security)
-"kE" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 8},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4; icon_state = "intact-supply"},/obj/structure/table/steel,/obj/item/weapon/paper_bin,/obj/structure/cable/cyan{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/security)
-"kF" = (/obj/machinery/atmospherics/unary/vent_scrubber/on,/obj/structure/table/darkglass,/obj/structure/window/basic{dir = 8},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/commons)
-"kG" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 9; icon_state = "intact-scrubbers"},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 9; icon_state = "intact-supply"},/obj/structure/table/steel,/obj/structure/cable/cyan{icon_state = "1-8"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/security)
-"kH" = (/obj/machinery/atmospherics/pipe/manifold/hidden/supply{dir = 8},/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden,/obj/structure/cable/cyan{d1 = 1; d2 = 2; icon_state = "1-2"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/docking)
-"kI" = (/obj/machinery/vending/medical,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/medbay)
-"kJ" = (/obj/effect/floor_decal/sign/dock/two,/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 1},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/machinery/atmospherics/pipe/manifold/hidden{dir = 4; icon_state = "map"},/obj/machinery/atmospherics/pipe/manifold/hidden{dir = 4; icon_state = "map"},/obj/structure/cable/cyan{d1 = 1; d2 = 2; icon_state = "1-2"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/docking)
-"kK" = (/obj/structure/cable{d2 = 4; icon_state = "0-4"},/obj/machinery/power/apc{cell_type = /obj/item/weapon/cell/super; dir = 8; name = "west bump"; pixel_x = -24},/turf/simulated/floor/airless,/area/tether_away/guttersite/teleporter)
-"kL" = (/obj/machinery/atmospherics/unary/vent_pump/on{dir = 1; icon_state = "map_vent_out"},/obj/structure/table/darkglass,/obj/structure/window/basic,/obj/structure/window/basic{dir = 8},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/commons)
-"kM" = (/obj/structure/table/darkglass,/obj/structure/window/basic,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/commons)
-"kN" = (/obj/structure/table/darkglass,/obj/structure/window/basic{dir = 1},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/commons)
-"kO" = (/obj/structure/window/basic{dir = 1},/obj/structure/window/basic{dir = 4},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/commons)
-"kP" = (/obj/structure/window/basic{dir = 1},/obj/structure/medical_stand,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/commons)
-"kQ" = (/obj/structure/medical_stand,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/commons)
-"kR" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/machinery/atmospherics/pipe/simple/hidden,/obj/structure/cable/cyan{d1 = 1; d2 = 2; icon_state = "1-2"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/docking)
-"kS" = (/obj/machinery/light{dir = 4},/obj/structure/closet/crate/medical/blood,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/medbay)
-"kT" = (/obj/structure/window/basic{dir = 1},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/medbay)
-"kU" = (/obj/machinery/atmospherics/pipe/simple/hidden,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/structure/cable/cyan{d1 = 1; d2 = 2; icon_state = "1-2"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/docking)
-"kV" = (/obj/machinery/atmospherics/pipe/simple/hidden,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/structure/cable/cyan{d1 = 1; d2 = 4; icon_state = "1-4"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/docking)
-"kW" = (/obj/machinery/light,/obj/structure/window/basic{dir = 1},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/medbay)
-"kX" = (/obj/structure/sign/nosmoking_1,/turf/simulated/wall/r_wall,/area/tether_away/guttersite/medbay)
-"kY" = (/obj/structure/table/darkglass,/obj/item/weapon/storage/box/masks,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/medbay)
-"kZ" = (/obj/structure/table/darkglass,/obj/item/weapon/surgical/surgicaldrill,/obj/item/weapon/surgical/scalpel,/obj/item/weapon/surgical/circular_saw,/obj/item/weapon/surgical/cautery,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/medbay)
-"la" = (/obj/structure/sink{dir = 8; icon_state = "sink"; pixel_x = -12; pixel_y = 8},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/medbay)
-"lb" = (/obj/machinery/light{dir = 1; icon_state = "tube1"},/obj/machinery/vending/engivend,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/storage)
-"lc" = (/obj/machinery/vending/engineering,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/storage)
-"ld" = (/obj/machinery/vending/tool,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/storage)
-"le" = (/obj/structure/closet/toolcloset,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/storage)
-"lf" = (/obj/structure/window/basic{dir = 4},/obj/structure/closet/toolcloset,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/storage)
-"lg" = (/obj/structure/window/basic{dir = 8},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/storage)
-"lh" = (/obj/structure/window/basic{dir = 4},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/storage)
-"li" = (/obj/item/toy/figure/assistant,/turf/simulated/mineral/floor/vacuum,/area/tether_away/guttersite/unexplored)
-"lj" = (/obj/structure/closet/walllocker/emerglocker/east,/obj/structure/closet/firecloset/full,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/storage)
-"lk" = (/obj/structure/closet/crate/engineering/electrical,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/storage)
-"ll" = (/obj/structure/window/basic,/obj/structure/closet/crate/engineering/electrical,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/storage)
-"lm" = (/obj/structure/window/basic,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/storage)
-"ln" = (/obj/structure/table/darkglass,/obj/item/weapon/storage/toolbox/electrical,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/storage)
-"lo" = (/obj/machinery/light,/obj/structure/window/basic{dir = 8},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/storage)
-"lp" = (/obj/structure/closet/crate/engineering,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/storage)
-"lq" = (/mob/living/bot/mulebot,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/storage)
-"lr" = (/obj/structure/closet/crate/solar,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/storage)
-"ls" = (/obj/structure/closet/crate/science,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/storage)
-"lt" = (/obj/structure/closet/crate/rcd,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/storage)
-"lu" = (/obj/structure/closet/firecloset/full,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/commons)
-"lv" = (/obj/structure/closet/firecloset/full,/turf/simulated/floor/tiled/eris/steel/bar_dance,/area/tether_away/guttersite/commons)
-"lw" = (/obj/structure/closet/firecloset/full,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/bridge)
-"lx" = (/obj/machinery/light{dir = 4},/obj/structure/closet/firecloset/full,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/office)
-"ly" = (/obj/structure/closet/firecloset/full,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/security)
-"lz" = (/obj/structure/closet/firecloset/full,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/docking)
-"lA" = (/obj/structure/window/basic{dir = 4},/obj/structure/window/basic,/obj/structure/bed/chair/bay/comfy/black{dir = 8; icon_state = "bay_comfychair_preview"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/storage)
-"lB" = (/obj/structure/table/darkglass,/obj/item/weapon/storage/toolbox/mechanical,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/storage)
-"lC" = (/obj/structure/table/rack/shelf/steel,/obj/random/projectile/random,/obj/random/weapon/guarenteed,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/vault)
-"lD" = (/obj/machinery/atmospherics/unary/vent_scrubber/on,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/vault)
-"lF" = (/obj/machinery/light,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/office)
-"lG" = (/obj/machinery/light{dir = 1; icon_state = "tube1"},/turf/simulated/floor/plating/eris/under,/area/tether_away/guttersite/security)
-"lH" = (/obj/machinery/light{dir = 8; icon_state = "tube1"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/security)
-"lJ" = (/obj/item/weapon/storage/toolbox/electrical{pixel_x = 1; pixel_y = -1},/turf/simulated/floor/airless,/area/tether_away/guttersite/teleporter)
-"lK" = (/obj/machinery/power/apc{dir = 4; name = "east bump"; pixel_x = 24},/obj/structure/cable/cyan{d2 = 8; icon_state = "0-8"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/docking)
-"lL" = (/obj/structure/loot_pile/surface/bones,/obj/random/weapon/guarenteed,/turf/simulated/mineral/floor/vacuum,/area/tether_away/guttersite/unexplored)
-"lM" = (/obj/item/toy/plushie/carp,/turf/simulated/mineral/floor/vacuum,/area/tether_away/guttersite/unexplored)
-"lN" = (/obj/structure/loot_pile/surface/bones,/turf/simulated/mineral/floor/vacuum,/area/space)
-"lO" = (/obj/structure/bonfire,/turf/simulated/mineral/floor/vacuum,/area/space)
-"lP" = (/obj/item/weapon/card/emag,/turf/simulated/mineral/floor/vacuum,/area/space)
-"lQ" = (/obj/item/weapon/card/emag_broken,/turf/simulated/mineral/floor/vacuum,/area/tether_away/guttersite/unexplored)
-"lR" = (/obj/item/toy/plushie/carp,/turf/simulated/mineral/floor/vacuum,/area/space)
-"lS" = (/obj/structure/inflatable/door,/turf/simulated/mineral/floor/vacuum,/area/space)
-"lT" = (/obj/item/pizzavoucher,/turf/simulated/mineral/floor/vacuum,/area/space)
-"lU" = (/mob/living/simple_mob/animal/space/carp/large/huge,/turf/simulated/mineral/floor/vacuum,/area/space)
-"lV" = (/obj/item/clothing/suit/storage/hooded/carp_costume,/turf/simulated/mineral/floor/vacuum,/area/space)
-"lW" = (/obj/item/clothing/suit/storage/hooded/techpriest,/turf/simulated/mineral/floor/vacuum,/area/tether_away/guttersite/unexplored)
-"mu" = (/obj/structure/window/basic{dir = 4; icon_state = "window"},/obj/structure/table/darkglass,/turf/simulated/floor/tiled/eris/white/monofloor,/area/tether_away/guttersite/office)
-"mw" = (/obj/structure/table/darkglass,/obj/item/device/flashlight/lamp/green,/turf/simulated/floor/tiled/eris/white/monofloor,/area/tether_away/guttersite/office)
-"mM" = (/obj/structure/table/darkglass,/obj/item/weapon/pen/blue,/turf/simulated/floor/tiled/eris/white/monofloor,/area/tether_away/guttersite/office)
-"mN" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 1},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/bridge)
-"mO" = (/obj/machinery/atmospherics/pipe/simple/hidden{dir = 6; icon_state = "intact"},/obj/structure/table/darkglass,/obj/item/weapon/paper_bin,/turf/simulated/floor/tiled/eris/white/monofloor,/area/tether_away/guttersite/office)
-"mT" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 10; icon_state = "intact-supply"},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 9; icon_state = "intact-scrubbers"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/vault)
-"ne" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 9; icon_state = "intact-supply"},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 9; icon_state = "intact-scrubbers"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/office)
-"nf" = (/obj/structure/table/rack,/obj/random/janusmodule,/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/vault)
-"Ob" = (/obj/structure/cable/cyan{d1 = 1; d2 = 2; icon_state = "1-2"},/turf/simulated/floor/tiled/eris/dark/gray_perforated,/area/tether_away/guttersite/maint)
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"aa" = (
+/turf/space,
+/area/tether_away/guttersite/unexplored)
+"ab" = (
+/turf/simulated/mineral/floor/vacuum,
+/area/space)
+"ac" = (
+/turf/simulated/mineral/cave,
+/area/space)
+"ad" = (
+/turf/simulated/mineral/floor/vacuum,
+/area/tether_away/guttersite/unexplored)
+"ae" = (
+/turf/simulated/mineral/floor/vacuum,
+/area/tether_away/guttersite/teleporter)
+"af" = (
+/obj/structure/lattice,
+/turf/simulated/mineral/floor/vacuum,
+/area/tether_away/guttersite/unexplored)
+"ag" = (
+/turf/simulated/mineral/cave,
+/area/tether_away/guttersite/unexplored)
+"ah" = (
+/turf/simulated/wall/r_wall,
+/area/tether_away/guttersite/teleporter)
+"ai" = (
+/obj/structure/lattice,
+/turf/simulated/mineral/floor/vacuum,
+/area/tether_away/guttersite/teleporter)
+"aj" = (
+/turf/simulated/mineral/cave,
+/area/tether_away/guttersite/teleporter)
+"ak" = (
+/obj/structure/lattice,
+/turf/space,
+/area/tether_away/guttersite/unexplored)
+"al" = (
+/obj/structure/frame/computer{
+	dir = 4
+	},
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/airless,
+/area/tether_away/guttersite/teleporter)
+"am" = (
+/obj/machinery/teleport/station,
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/airless,
+/area/tether_away/guttersite/teleporter)
+"an" = (
+/obj/machinery/teleport/hub,
+/turf/simulated/floor/airless,
+/area/tether_away/guttersite/teleporter)
+"ao" = (
+/obj/item/weapon/material/shard{
+	icon_state = "medium"
+	},
+/turf/simulated/floor/airless,
+/area/tether_away/guttersite/teleporter)
+"ap" = (
+/turf/simulated/floor/airless,
+/area/tether_away/guttersite/teleporter)
+"aq" = (
+/obj/structure/cable,
+/turf/simulated/floor/airless,
+/area/tether_away/guttersite/teleporter)
+"ar" = (
+/obj/structure/table/rack,
+/obj/item/clothing/gloves/yellow,
+/obj/item/weapon/storage/toolbox/mechanical,
+/turf/simulated/floor/airless,
+/area/tether_away/guttersite/teleporter)
+"as" = (
+/obj/structure/girder,
+/turf/simulated/floor/airless,
+/area/tether_away/guttersite/teleporter)
+"at" = (
+/obj/item/weapon/cell,
+/turf/simulated/floor/airless,
+/area/tether_away/guttersite/teleporter)
+"au" = (
+/obj/structure/grille/broken,
+/turf/simulated/floor/airless,
+/area/tether_away/guttersite/teleporter)
+"av" = (
+/obj/structure/table,
+/turf/simulated/floor/airless,
+/area/tether_away/guttersite/teleporter)
+"aw" = (
+/obj/structure/closet,
+/turf/simulated/floor/airless,
+/area/tether_away/guttersite/teleporter)
+"ax" = (
+/turf/simulated/wall/r_wall,
+/area/tether_away/guttersite/storage)
+"ay" = (
+/obj/structure/boulder,
+/turf/simulated/mineral/floor/vacuum,
+/area/tether_away/guttersite/unexplored)
+"az" = (
+/obj/structure/inflatable/door,
+/turf/simulated/mineral/floor/vacuum,
+/area/tether_away/guttersite/unexplored)
+"aA" = (
+/obj/structure/bonfire/sifwood,
+/turf/simulated/mineral/floor/vacuum,
+/area/tether_away/guttersite/unexplored)
+"aB" = (
+/turf/simulated/wall/r_wall,
+/area/tether_away/guttersite/maint)
+"aC" = (
+/obj/machinery/light{
+	dir = 1;
+	icon_state = "tube1"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/storage)
+"aD" = (
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/storage)
+"aE" = (
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/maint)
+"aF" = (
+/turf/simulated/wall/r_wall,
+/area/tether_away/guttersite/engines)
+"aG" = (
+/turf/simulated/wall,
+/area/tether_away/guttersite/engines)
+"aH" = (
+/obj/machinery/door/airlock/multi_tile/glass,
+/turf/simulated/floor/tiled/eris/techmaint_panels,
+/area/tether_away/guttersite/engines)
+"aI" = (
+/turf/simulated/floor/tiled/eris/techmaint_panels,
+/area/tether_away/guttersite/engines)
+"aJ" = (
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/engines)
+"aK" = (
+/obj/machinery/light_switch{
+	on = 0;
+	pixel_y = 26
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/engines)
+"aL" = (
+/obj/structure/loot_pile/surface/bones,
+/turf/simulated/mineral/floor/vacuum,
+/area/tether_away/guttersite/unexplored)
+"aM" = (
+/obj/structure/table/steel,
+/obj/item/weapon/storage/toolbox/electrical,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/engines)
+"aN" = (
+/obj/structure/sign/poster{
+	dir = 1;
+	icon_state = ""
+	},
+/turf/simulated/wall,
+/area/tether_away/guttersite/maint)
+"aO" = (
+/obj/machinery/computer/ship/navigation/telescreen{
+	pixel_y = 23
+	},
+/obj/structure/table/steel,
+/obj/fiftyspawner/glass,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/engines)
+"aP" = (
+/turf/simulated/wall,
+/area/tether_away/guttersite/maint)
+"aQ" = (
+/turf/simulated/wall,
+/area/tether_away/guttersite/atmos)
+"aR" = (
+/obj/machinery/door/airlock/multi_tile/glass,
+/turf/simulated/floor/tiled/eris/techmaint_panels,
+/area/tether_away/guttersite/atmos)
+"aS" = (
+/turf/simulated/floor/tiled/eris/techmaint_panels,
+/area/tether_away/guttersite/atmos)
+"aT" = (
+/turf/simulated/wall/r_wall,
+/area/tether_away/guttersite/atmos)
+"aU" = (
+/obj/structure/table/steel,
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/fiftyspawner/steel,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/engines)
+"aV" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4;
+	icon_state = "intact-supply"
+	},
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/maint)
+"aW" = (
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/plating/eris/under,
+/area/tether_away/guttersite/engines)
+"aX" = (
+/turf/simulated/floor/plating/eris/under,
+/area/tether_away/guttersite/engines)
+"aY" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/engines)
+"aZ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/eris/dark,
+/area/tether_away/guttersite/maint)
+"ba" = (
+/obj/item/weapon/circuitboard/teleporter,
+/turf/simulated/floor/airless,
+/area/tether_away/guttersite/teleporter)
+"bb" = (
+/obj/structure/barricade,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/unexplored)
+"bc" = (
+/obj/structure/cable/cyan{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/rtg/fake_gen,
+/turf/simulated/floor/plating/eris/under,
+/area/tether_away/guttersite/engines)
+"bd" = (
+/obj/machinery/power/terminal{
+	dir = 4
+	},
+/obj/structure/cable/cyan{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/cable/cyan,
+/turf/simulated/floor/plating/eris/under,
+/area/tether_away/guttersite/engines)
+"be" = (
+/obj/structure/table/steel,
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/fiftyspawner/rods,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/atmos)
+"bf" = (
+/obj/machinery/computer/ship/navigation/telescreen{
+	pixel_y = 23
+	},
+/obj/structure/table/steel,
+/obj/item/weapon/storage/toolbox/mechanical,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/atmos)
+"bg" = (
+/obj/structure/table/steel,
+/obj/fiftyspawner/wood,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/atmos)
+"bh" = (
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/atmos)
+"bi" = (
+/obj/machinery/light_switch{
+	on = 0;
+	pixel_y = 26
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/atmos)
+"bj" = (
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/storage)
+"bk" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating/eris/under,
+/area/tether_away/guttersite/engines)
+"bl" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 4;
+	dir = 4;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/plating/eris/under,
+/area/tether_away/guttersite/engines)
+"bm" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/engines)
+"bn" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/eris/techmaint_panels,
+/area/tether_away/guttersite/engines)
+"bo" = (
+/turf/simulated/floor/tiled/eris/dark,
+/area/tether_away/guttersite/maint)
+"bp" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/atmos)
+"bq" = (
+/turf/simulated/floor/plating/eris/under,
+/area/tether_away/guttersite/atmos)
+"br" = (
+/obj/machinery/atmospherics/pipe/simple/visible/blue{
+	dir = 6
+	},
+/obj/machinery/meter,
+/turf/simulated/floor/plating/eris/under,
+/area/tether_away/guttersite/atmos)
+"bs" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/outline/red,
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/simulated/floor/plating/eris/under,
+/area/tether_away/guttersite/atmos)
+"bt" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/storage)
+"bu" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/maint)
+"bv" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/turf/simulated/floor/tiled/eris/dark,
+/area/tether_away/guttersite/maint)
+"bw" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled/eris/dark,
+/area/tether_away/guttersite/maint)
+"bx" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/eris/techmaint_panels,
+/area/tether_away/guttersite/maint)
+"by" = (
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/atmos)
+"bz" = (
+/obj/machinery/power/terminal{
+	dir = 4
+	},
+/obj/structure/cable/cyan{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/cable/cyan{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating/eris/under,
+/area/tether_away/guttersite/engines)
+"bA" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1;
+	icon_state = "map-supply"
+	},
+/obj/structure/table/darkglass,
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/commons)
+"bB" = (
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 4;
+	dir = 1;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 4;
+	dir = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating/eris/under,
+/area/tether_away/guttersite/engines)
+"bC" = (
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/engines)
+"bD" = (
+/obj/machinery/door/airlock/multi_tile/glass{
+	dir = 2
+	},
+/turf/simulated/floor/tiled/eris/techmaint_panels,
+/area/tether_away/guttersite/engines)
+"bE" = (
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/eris/dark,
+/area/tether_away/guttersite/maint)
+"bF" = (
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/atmos)
+"bG" = (
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plating/eris/under,
+/area/tether_away/guttersite/engines)
+"bH" = (
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating/eris/under,
+/area/tether_away/guttersite/engines)
+"bI" = (
+/obj/machinery/atmospherics/pipe/simple/visible/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/scrubbers{
+	dir = 10
+	},
+/turf/simulated/floor/plating/eris/under,
+/area/tether_away/guttersite/atmos)
+"bJ" = (
+/obj/machinery/atmospherics/pipe/simple/visible/universal{
+	dir = 8
+	},
+/turf/simulated/floor/plating/eris/under,
+/area/tether_away/guttersite/atmos)
+"bK" = (
+/obj/machinery/atmospherics/pipe/simple/visible/blue{
+	dir = 8
+	},
+/obj/machinery/meter,
+/turf/simulated/floor/plating/eris/under,
+/area/tether_away/guttersite/atmos)
+"bL" = (
+/obj/machinery/atmospherics/binary/pump/on{
+	dir = 8
+	},
+/turf/simulated/floor/plating/eris/under,
+/area/tether_away/guttersite/atmos)
+"bM" = (
+/obj/machinery/atmospherics/pipe/manifold/visible/blue,
+/turf/simulated/floor/plating/eris/under,
+/area/tether_away/guttersite/atmos)
+"bN" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/outline,
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/simulated/floor/plating/eris/under,
+/area/tether_away/guttersite/atmos)
+"bO" = (
+/obj/structure/table/steel,
+/obj/structure/cable/cyan,
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/engines)
+"bP" = (
+/obj/structure/table/steel,
+/obj/structure/cable/cyan,
+/obj/machinery/power/apc{
+	cell_type = /obj/item/weapon/cell/super;
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/atmos)
+"bQ" = (
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 4;
+	dir = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating/eris/under,
+/area/tether_away/guttersite/engines)
+"bR" = (
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled/eris/dark,
+/area/tether_away/guttersite/maint)
+"bS" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/maint)
+"bT" = (
+/obj/machinery/light,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/engines)
+"bU" = (
+/obj/machinery/alarm{
+	alarm_id = null;
+	breach_detection = 0;
+	dir = 1;
+	icon_state = "alarm0";
+	pixel_y = -22
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/engines)
+"bV" = (
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = -25
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/engines)
+"bW" = (
+/obj/structure/table/steel,
+/obj/fiftyspawner/plasteel,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/engines)
+"bX" = (
+/obj/structure/table/steel,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/fiftyspawner/plasteel/hull,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/engines)
+"bY" = (
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/obj/structure/cable/cyan,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/maint)
+"bZ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/structure/bed/chair/bay/comfy/black,
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/commons)
+"ca" = (
+/obj/machinery/door/airlock/multi_tile/glass{
+	dir = 2
+	},
+/turf/simulated/floor/tiled/eris/techmaint_panels,
+/area/tether_away/guttersite/maint)
+"cb" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6;
+	icon_state = "intact-supply"
+	},
+/obj/structure/bed/chair/bay/comfy/black{
+	dir = 1;
+	icon_state = "bay_comfychair_preview"
+	},
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled/eris/steel/bar_dance,
+/area/tether_away/guttersite/commons)
+"cc" = (
+/obj/machinery/atmospherics/pipe/simple/visible/scrubbers{
+	dir = 5
+	},
+/turf/simulated/floor/plating/eris/under,
+/area/tether_away/guttersite/atmos)
+"cd" = (
+/obj/machinery/atmospherics/pipe/simple/visible/red{
+	dir = 8
+	},
+/obj/machinery/meter,
+/turf/simulated/floor/plating/eris/under,
+/area/tether_away/guttersite/atmos)
+"ce" = (
+/obj/machinery/atmospherics/binary/pump/on{
+	dir = 4
+	},
+/turf/simulated/floor/plating/eris/under,
+/area/tether_away/guttersite/atmos)
+"cf" = (
+/obj/machinery/atmospherics/pipe/manifold/visible/red{
+	dir = 1
+	},
+/turf/simulated/floor/plating/eris/under,
+/area/tether_away/guttersite/atmos)
+"cg" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/outline/blue,
+/obj/machinery/portable_atmospherics/canister/empty,
+/turf/simulated/floor/plating/eris/under,
+/area/tether_away/guttersite/atmos)
+"ch" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1;
+	icon_state = "map_vent_out"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/storage)
+"ci" = (
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/office)
+"cj" = (
+/obj/machinery/light,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/storage)
+"ck" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1;
+	icon_state = "map-supply"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/structure/window/basic,
+/obj/structure/window/basic{
+	dir = 4;
+	icon_state = "window"
+	},
+/obj/structure/table/darkglass,
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/eris/white/monofloor,
+/area/tether_away/guttersite/office)
+"cl" = (
+/obj/item/weapon/hand_tele,
+/turf/simulated/mineral/floor/vacuum,
+/area/tether_away/guttersite/unexplored)
+"cm" = (
+/obj/machinery/atmospherics/pipe/simple/visible/red{
+	dir = 5
+	},
+/obj/machinery/meter,
+/turf/simulated/floor/plating/eris/under,
+/area/tether_away/guttersite/atmos)
+"cn" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/portable_atmospherics/canister/empty,
+/turf/simulated/floor/plating/eris/under,
+/area/tether_away/guttersite/atmos)
+"co" = (
+/obj/structure/loot_pile/surface/bones,
+/obj/random/gun/random,
+/turf/simulated/mineral/floor/vacuum,
+/area/tether_away/guttersite/unexplored)
+"cp" = (
+/obj/structure/window/basic{
+	dir = 8;
+	icon_state = "window"
+	},
+/turf/simulated/floor/tiled/eris/white/monofloor,
+/area/tether_away/guttersite/office)
+"cq" = (
+/obj/item/device/bluespaceradio/tether_prelinked,
+/turf/simulated/mineral/floor/vacuum,
+/area/tether_away/guttersite/unexplored)
+"cr" = (
+/obj/structure/table/darkglass,
+/obj/item/key,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/storage)
+"cs" = (
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/unexplored)
+"ct" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6;
+	icon_state = "intact-supply"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/maint)
+"cu" = (
+/obj/structure/table/steel,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/atmos)
+"cv" = (
+/obj/structure/table/steel,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/atmos)
+"cw" = (
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = -25
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/atmos)
+"cx" = (
+/obj/machinery/alarm{
+	alarm_id = null;
+	breach_detection = 0;
+	dir = 1;
+	icon_state = "alarm0";
+	pixel_y = -22
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/atmos)
+"cy" = (
+/obj/machinery/light,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/atmos)
+"cz" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/maint)
+"cA" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4;
+	icon_state = "intact-supply"
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/maint)
+"cB" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10;
+	icon_state = "intact-scrubbers"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10;
+	icon_state = "intact-supply"
+	},
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/maint)
+"cC" = (
+/obj/machinery/door/airlock/multi_tile/glass,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/maint)
+"cD" = (
+/obj/machinery/alarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -22;
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/maint)
+"cE" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 1
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/maint)
+"cF" = (
+/turf/simulated/wall/r_wall,
+/area/tether_away/guttersite/commons)
+"cG" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/maint)
+"cH" = (
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/commons)
+"cI" = (
+/obj/machinery/light{
+	dir = 1;
+	icon_state = "tube1"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/commons)
+"cJ" = (
+/obj/fiftyspawner/glass,
+/obj/fiftyspawner/steel,
+/turf/simulated/floor/airless,
+/area/tether_away/guttersite/teleporter)
+"cK" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/storage)
+"cL" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/commons)
+"cM" = (
+/obj/effect/landmark/corpse/clown,
+/turf/simulated/mineral/floor/vacuum,
+/area/tether_away/guttersite/unexplored)
+"cN" = (
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/obj/structure/cable/cyan{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/storage)
+"cO" = (
+/obj/structure/bed/chair/bay/comfy/black,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/commons)
+"cP" = (
+/obj/machinery/vending/loadout/uniform,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/commons)
+"cQ" = (
+/obj/structure/cable/cyan{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/power/smes/buildable/point_of_interest,
+/turf/simulated/floor/plating/eris/under,
+/area/tether_away/guttersite/engines)
+"cR" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/commons)
+"cS" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1;
+	icon_state = "map_vent_out"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/commons)
+"cT" = (
+/obj/structure/inflatable/door,
+/turf/simulated/floor/plating/eris,
+/area/tether_away/guttersite/unexplored)
+"cU" = (
+/obj/machinery/vending/boozeomat,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/commons)
+"cV" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5;
+	icon_state = "intact-scrubbers"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/maint)
+"cW" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4;
+	icon_state = "intact-supply"
+	},
+/obj/machinery/light,
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/maint)
+"cX" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4;
+	icon_state = "intact-supply"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/maintenance_hatch{
+	req_access = list(0);
+	req_one_access = list(10)
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/storage)
+"cY" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4;
+	icon_state = "intact-supply"
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/storage)
+"cZ" = (
+/turf/simulated/floor/tiled/eris/steel/bar_light,
+/area/tether_away/guttersite/commons)
+"da" = (
+/obj/structure/window/basic{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/commons)
+"db" = (
+/obj/machinery/vending/food,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/commons)
+"dc" = (
+/obj/machinery/light{
+	dir = 1;
+	icon_state = "tube1"
+	},
+/obj/structure/table/darkglass,
+/obj/machinery/chemical_dispenser/bar_alc/full,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/commons)
+"dd" = (
+/obj/machinery/light,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/commons)
+"de" = (
+/turf/simulated/wall/r_wall,
+/area/tether_away/guttersite/medbay)
+"df" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/plating,
+/area/tether_away/guttersite/commons)
+"dg" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1;
+	icon_state = "map-supply"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/storage)
+"dh" = (
+/obj/structure/table/darkglass,
+/turf/simulated/floor/tiled/eris/steel/bar_dance,
+/area/tether_away/guttersite/commons)
+"di" = (
+/obj/structure/table/darkglass,
+/obj/item/weapon/storage/box/glasses/meta,
+/turf/simulated/floor/tiled/eris/steel/bar_dance,
+/area/tether_away/guttersite/commons)
+"dj" = (
+/obj/structure/table/darkglass,
+/obj/item/weapon/reagent_containers/food/drinks/shaker,
+/turf/simulated/floor/tiled/eris/steel/bar_dance,
+/area/tether_away/guttersite/commons)
+"dk" = (
+/turf/simulated/mineral/cave,
+/area/tether_away/guttersite/commons)
+"dl" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10;
+	icon_state = "intact-scrubbers"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10;
+	icon_state = "intact-supply"
+	},
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/storage)
+"dm" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/maintenance_hatch{
+	req_one_access = list()
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/commons)
+"dn" = (
+/turf/simulated/wall/r_wall,
+/area/tether_away/guttersite/walkway)
+"do" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 1
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/storage)
+"dp" = (
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/medbay)
+"dq" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 1
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/storage)
+"dr" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/maintenance_hatch{
+	req_access = list(0);
+	req_one_access = list(10)
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/storage)
+"ds" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/maintenance_hatch{
+	req_access = list(0);
+	req_one_access = list(10)
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/commons)
+"dt" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 1
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/commons)
+"du" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/commons)
+"dv" = (
+/turf/simulated/wall/skipjack,
+/area/tether_away/guttersite/office)
+"dw" = (
+/obj/machinery/door/airlock/hatch{
+	frequency = 1331;
+	icon_state = "door_closed";
+	id_tag = "vox_northeast_lock";
+	locked = 0;
+	req_access = list(150)
+	},
+/turf/simulated/shuttle/plating,
+/area/tether_away/guttersite/office)
+"dx" = (
+/obj/machinery/access_button{
+	command = "cycle_exterior";
+	frequency = 1331;
+	master_tag = "vox_east_control";
+	req_access = list(150)
+	},
+/turf/simulated/wall/skipjack,
+/area/tether_away/guttersite/office)
+"dy" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8;
+	icon_state = "map-scrubbers"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/commons)
+"dz" = (
+/obj/structure/closet/medical_wall,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/medbay)
+"dA" = (
+/obj/machinery/airlock_sensor{
+	frequency = 1331;
+	id_tag = "vox_east_sensor";
+	pixel_x = -25
+	},
+/turf/simulated/shuttle/plating,
+/area/tether_away/guttersite/office)
+"dB" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	frequency = 1331;
+	id_tag = "vox_east_vent"
+	},
+/turf/simulated/shuttle/plating,
+/area/tether_away/guttersite/office)
+"dC" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4;
+	icon_state = "map_vent_out"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/medbay)
+"dD" = (
+/obj/structure/medical_stand,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/medbay)
+"dE" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10;
+	icon_state = "intact-supply"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10;
+	icon_state = "intact-scrubbers"
+	},
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/commons)
+"dF" = (
+/obj/structure/dogbed,
+/mob/living/simple_mob/vore/redpanda/fae{
+	name = "Rhythm"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/office)
+"dG" = (
+/obj/structure/bed/padded,
+/obj/item/weapon/bedsheet/medical,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/medbay)
+"dH" = (
+/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
+	frequency = 1331;
+	id_tag = "";
+	pixel_x = -24;
+	req_access = list(150);
+	tag_airpump = "vox_east_vent";
+	tag_chamber_sensor = "vox_east_sensor";
+	tag_exterior_door = "vox_northeast_lock";
+	tag_interior_door = "vox_southeast_lock"
+	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 4;
+	frequency = 1331;
+	id_tag = "vox_east_vent"
+	},
+/obj/machinery/light/small,
+/turf/simulated/shuttle/plating,
+/area/tether_away/guttersite/office)
+"dI" = (
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 4;
+	icon_state = "map"
+	},
+/turf/simulated/shuttle/plating,
+/area/tether_away/guttersite/office)
+"dJ" = (
+/obj/machinery/alarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -22;
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/medbay)
+"dK" = (
+/obj/machinery/door/airlock/hatch{
+	frequency = 1331;
+	icon_state = "door_closed";
+	id_tag = "vox_southeast_lock";
+	locked = 0;
+	req_access = list(150)
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/turf/simulated/shuttle/plating,
+/area/tether_away/guttersite/office)
+"dL" = (
+/obj/structure/window/basic{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/medbay)
+"dM" = (
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = -25
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/medbay)
+"dN" = (
+/turf/simulated/wall/r_wall,
+/area/tether_away/guttersite/office)
+"dO" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/plating,
+/area/tether_away/guttersite/office)
+"dP" = (
+/obj/structure/table/rack,
+/obj/item/weapon/tank/oxygen,
+/obj/random/multiple/voidsuit,
+/turf/simulated/shuttle/plating,
+/area/tether_away/guttersite/office)
+"dQ" = (
+/obj/machinery/access_button{
+	command = "cycle_interior";
+	frequency = 1331;
+	master_tag = "vox_east_control";
+	pixel_x = 22;
+	req_access = list(150)
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/turf/simulated/shuttle/plating,
+/area/tether_away/guttersite/office)
+"dR" = (
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/office)
+"dS" = (
+/obj/machinery/light{
+	dir = 1;
+	icon_state = "tube1"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/office)
+"dT" = (
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/office)
+"dU" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/office)
+"dV" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/office)
+"dW" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4;
+	icon_state = "intact-supply"
+	},
+/obj/structure/bed/chair/bay/comfy/black{
+	dir = 1;
+	icon_state = "bay_comfychair_preview"
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/eris/steel/bar_dance,
+/area/tether_away/guttersite/commons)
+"dX" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4;
+	icon_state = "intact-supply"
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/eris/steel/bar_dance,
+/area/tether_away/guttersite/commons)
+"dY" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4;
+	icon_state = "intact-supply"
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/wall/r_wall,
+/area/tether_away/guttersite/commons)
+"dZ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4;
+	icon_state = "intact-supply"
+	},
+/obj/structure/closet/cabinet,
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/commons)
+"ea" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1;
+	icon_state = "map-supply"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/commons)
+"eb" = (
+/turf/simulated/wall/r_wall,
+/area/tether_away/guttersite/bridge)
+"ec" = (
+/obj/structure/window/basic,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/office)
+"ed" = (
+/turf/simulated/wall/r_wall,
+/area/tether_away/guttersite/vault)
+"ee" = (
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/walkway)
+"ef" = (
+/obj/machinery/light{
+	dir = 1;
+	icon_state = "tube1"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/walkway)
+"eg" = (
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/bridge)
+"eh" = (
+/obj/machinery/light{
+	dir = 1;
+	icon_state = "tube1"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/bridge)
+"ei" = (
+/obj/machinery/door/window/southleft,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/office)
+"ej" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4;
+	icon_state = "intact-supply"
+	},
+/obj/machinery/washing_machine,
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/commons)
+"ek" = (
+/obj/structure/window/basic{
+	dir = 8;
+	icon_state = "window"
+	},
+/obj/structure/filingcabinet/filingcabinet,
+/turf/simulated/floor/tiled/eris/white/monofloor,
+/area/tether_away/guttersite/office)
+"el" = (
+/obj/machinery/alarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -22;
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/vault)
+"em" = (
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/vault)
+"en" = (
+/obj/machinery/alarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -22;
+	pixel_y = 0
+	},
+/obj/machinery/light{
+	dir = 1;
+	icon_state = "tube1"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/walkway)
+"eo" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4;
+	icon_state = "intact-supply"
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/commons)
+"ep" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/walkway)
+"eq" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/bridge)
+"er" = (
+/obj/machinery/alarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -22;
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/office)
+"es" = (
+/turf/simulated/floor/tiled/eris/white/monofloor,
+/area/tether_away/guttersite/office)
+"et" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4;
+	icon_state = "intact-supply"
+	},
+/obj/structure/curtain/open/shower,
+/obj/machinery/shower,
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/eris/dark/techfloor_grid,
+/area/tether_away/guttersite/commons)
+"eu" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4;
+	icon_state = "intact-supply"
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/eris/dark/techfloor_grid,
+/area/tether_away/guttersite/commons)
+"ev" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4;
+	icon_state = "intact-supply"
+	},
+/obj/structure/table/darkglass,
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/commons)
+"ew" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4;
+	icon_state = "intact-supply"
+	},
+/obj/structure/bed/chair/bay/comfy/black{
+	dir = 8;
+	icon_state = "bay_comfychair_preview"
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/commons)
+"ex" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9;
+	icon_state = "intact-scrubbers"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9;
+	icon_state = "intact-supply"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/commons)
+"ey" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 1
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/eris/steel/bar_dance,
+/area/tether_away/guttersite/commons)
+"ez" = (
+/obj/machinery/power/apc{
+	cell_type = /obj/item/weapon/cell/super;
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/obj/structure/cable/cyan{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/tiled/eris/steel/bar_dance,
+/area/tether_away/guttersite/commons)
+"eA" = (
+/obj/structure/bed/chair/bay/comfy/black{
+	dir = 4;
+	icon_state = "bay_comfychair_preview"
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/eris/steel/bar_dance,
+/area/tether_away/guttersite/commons)
+"eB" = (
+/obj/structure/table/darkglass,
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/eris/steel/bar_dance,
+/area/tether_away/guttersite/commons)
+"eC" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 1
+	},
+/obj/structure/bed/chair/bay/comfy/black{
+	dir = 8;
+	icon_state = "bay_comfychair_preview"
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled/eris/steel/bar_dance,
+/area/tether_away/guttersite/commons)
+"eD" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/maintenance_hatch{
+	req_one_access = list()
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/medbay)
+"eE" = (
+/turf/space,
+/area/space)
+"eF" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 1
+	},
+/obj/structure/bed/chair/bay/comfy/black{
+	dir = 8;
+	icon_state = "bay_comfychair_preview"
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/eris/steel/bar_dance,
+/area/tether_away/guttersite/commons)
+"eG" = (
+/obj/structure/bedsheetbin,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/commons)
+"eH" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/medbay)
+"eI" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1;
+	icon_state = "map_vent_out"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/walkway)
+"eJ" = (
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = -25
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/walkway)
+"eK" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/eris/steel/bar_dance,
+/area/tether_away/guttersite/commons)
+"eL" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1;
+	icon_state = "map_vent_out"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/bridge)
+"eM" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4;
+	icon_state = "map_vent_out"
+	},
+/turf/simulated/floor/tiled/eris/white/monofloor,
+/area/tether_away/guttersite/office)
+"eN" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 9;
+	icon_state = "intact"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/office)
+"eO" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 1
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/eris/steel/bar_dance,
+/area/tether_away/guttersite/commons)
+"eP" = (
+/obj/structure/table/rack/shelf/steel,
+/obj/random/curseditem,
+/obj/random/slimecore,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/vault)
+"eQ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/medbay)
+"eR" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/maintenance_hatch{
+	req_one_access = list()
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/commons)
+"eS" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 1
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/walkway)
+"eT" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/walkway)
+"eU" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/bed/padded,
+/obj/item/weapon/bedsheet/medical,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/medbay)
+"eV" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5;
+	icon_state = "intact-scrubbers"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9;
+	icon_state = "intact-supply"
+	},
+/obj/structure/window/basic{
+	dir = 1
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/medbay)
+"eW" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8;
+	icon_state = "map_scrubber_on"
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/medbay)
+"eX" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/medbay)
+"eY" = (
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/obj/structure/bed/chair/bay/comfy/black{
+	dir = 8;
+	icon_state = "bay_comfychair_preview"
+	},
+/obj/structure/cable/cyan{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/medbay)
+"eZ" = (
+/obj/item/weapon/cell/super,
+/turf/simulated/floor/airless,
+/area/tether_away/guttersite/teleporter)
+"fa" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10;
+	icon_state = "intact-supply"
+	},
+/obj/structure/filingcabinet/filingcabinet,
+/turf/simulated/floor/tiled/eris/white/monofloor,
+/area/tether_away/guttersite/office)
+"fb" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8;
+	icon_state = "map_scrubber_on"
+	},
+/turf/simulated/floor/tiled/eris/white/monofloor,
+/area/tether_away/guttersite/office)
+"fc" = (
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/obj/structure/cable/cyan{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/office)
+"fd" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/maintenance_hatch{
+	req_one_access = list()
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/walkway)
+"fe" = (
+/obj/structure/table/rack,
+/obj/random/energy,
+/obj/random/multiple/voidsuit,
+/obj/item/weapon/tank/oxygen,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/vault)
+"ff" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1;
+	icon_state = "map_vent_out"
+	},
+/obj/structure/table/rack,
+/obj/random/firstaid,
+/obj/random/firstaid,
+/obj/random/medical/lite,
+/obj/random/medical/lite,
+/obj/random/medical/pillbottle,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/vault)
+"fg" = (
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/office)
+"fh" = (
+/obj/structure/bed/chair/bay/comfy/black{
+	dir = 8;
+	icon_state = "bay_comfychair_preview"
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/office)
+"fi" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/walkway)
+"fj" = (
+/obj/machinery/power/apc{
+	cell_type = /obj/item/weapon/cell/super;
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/obj/structure/cable/cyan{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/walkway)
+"fk" = (
+/obj/random/humanoidremains,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/vault)
+"fl" = (
+/obj/machinery/light,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/bridge)
+"fm" = (
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = -25
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/bridge)
+"fn" = (
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = -25
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/vault)
+"fo" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/maintenance_hatch{
+	req_one_access = list()
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/office)
+"fp" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/walkway)
+"fq" = (
+/turf/simulated/wall/r_wall,
+/area/tether_away/guttersite/docking)
+"fr" = (
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/docking)
+"fs" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8;
+	icon_state = "map-scrubbers"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/walkway)
+"ft" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/docking)
+"fu" = (
+/turf/simulated/wall/r_wall,
+/area/tether_away/guttersite/security)
+"fv" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1;
+	icon_state = "map-supply"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/walkway)
+"fw" = (
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/security)
+"fx" = (
+/obj/machinery/light{
+	dir = 1;
+	icon_state = "tube1"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/security)
+"fy" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4;
+	icon_state = "intact-supply"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/walkway)
+"fz" = (
+/turf/simulated/floor/plating/eris/under,
+/area/tether_away/guttersite/security)
+"fA" = (
+/obj/machinery/atmospherics/pipe/simple/visible/blue{
+	dir = 6
+	},
+/obj/machinery/meter,
+/turf/simulated/floor/plating/eris/under,
+/area/tether_away/guttersite/security)
+"fB" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/outline/red,
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/simulated/floor/plating/eris/under,
+/area/tether_away/guttersite/security)
+"fC" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 6;
+	icon_state = "intact"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/security)
+"fD" = (
+/obj/machinery/atmospherics/pipe/simple/visible/universal{
+	dir = 8
+	},
+/turf/simulated/floor/plating/eris/under,
+/area/tether_away/guttersite/security)
+"fE" = (
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/turf/simulated/floor/plating/eris/under,
+/area/tether_away/guttersite/security)
+"fF" = (
+/obj/machinery/atmospherics/binary/pump/on{
+	dir = 8
+	},
+/turf/simulated/floor/plating/eris/under,
+/area/tether_away/guttersite/security)
+"fG" = (
+/obj/machinery/atmospherics/pipe/manifold/visible/blue,
+/turf/simulated/floor/plating/eris/under,
+/area/tether_away/guttersite/security)
+"fH" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/outline,
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/simulated/floor/plating/eris/under,
+/area/tether_away/guttersite/security)
+"fI" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/security)
+"fJ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4;
+	icon_state = "intact-supply"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/maintenance_hatch{
+	req_one_access = list()
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/walkway)
+"fK" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4;
+	icon_state = "intact-supply"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/bridge)
+"fL" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4;
+	icon_state = "intact-supply"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/maintenance_hatch{
+	req_one_access = list()
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/bridge)
+"fM" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4;
+	icon_state = "intact-supply"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/bridge)
+"fN" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1;
+	icon_state = "map-supply"
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/bridge)
+"fO" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10;
+	icon_state = "intact-supply"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9;
+	icon_state = "intact-scrubbers"
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/bridge)
+"fP" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/bridge)
+"fQ" = (
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/obj/structure/cable/cyan{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/bridge)
+"fR" = (
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/bridge)
+"fS" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6;
+	icon_state = "intact-supply"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/office)
+"fT" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4;
+	icon_state = "intact-supply"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/vault/bolted,
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/office)
+"fU" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/security)
+"fV" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1;
+	icon_state = "map_vent_out"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/security)
+"fW" = (
+/obj/item/weapon/storage/toolbox/lunchbox/heart/filled,
+/turf/simulated/mineral/floor/vacuum,
+/area/tether_away/guttersite/unexplored)
+"fX" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
+	icon_state = "space";
+	layer = 4;
+	name = "EXTERNAL AIRLOCK";
+	pixel_x = 0
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/plating,
+/area/tether_away/guttersite/security)
+"fY" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/plating,
+/area/tether_away/guttersite/security)
+"fZ" = (
+/obj/structure/bed/chair/office/dark{
+	dir = 1;
+	icon_state = "officechair_dark"
+	},
+/mob/living/simple_mob/humanoid/merc/ranged/smg/poi{
+	faction = "wolfgirl"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/security)
+"ga" = (
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/security)
+"gb" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/security)
+"gc" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/security)
+"gd" = (
+/obj/structure/table/steel,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/security)
+"ge" = (
+/obj/structure/bed/chair/office/dark{
+	dir = 8;
+	icon_state = "officechair_dark"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/security)
+"gf" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/maintenance_hatch{
+	req_one_access = list(38)
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/security)
+"gg" = (
+/obj/structure/fence,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/security)
+"gh" = (
+/obj/machinery/door/airlock/glass_external,
+/obj/machinery/access_button{
+	command = "cycle_exterior";
+	frequency = 1380;
+	master_tag = "dock_d2a2";
+	name = "exterior access button";
+	pixel_x = -5;
+	pixel_y = -26;
+	req_one_access = list(13)
+	},
+/obj/effect/map_helper/airlock/door/ext_door,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/security)
+"gi" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 4;
+	frequency = 1380;
+	id_tag = "dock_d2a2_pump"
+	},
+/obj/machinery/light/small,
+/obj/machinery/embedded_controller/radio/airlock/docking_port{
+	frequency = 1380;
+	id_tag = "";
+	pixel_y = 28
+	},
+/obj/machinery/airlock_sensor{
+	frequency = 1380;
+	id_tag = "dock_d2a2_sensor";
+	pixel_x = 0;
+	pixel_y = -25
+	},
+/obj/effect/map_helper/airlock/atmos/chamber_pump,
+/obj/effect/map_helper/airlock/sensor/chamber_sensor,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/security)
+"gj" = (
+/obj/machinery/door/airlock/glass_external,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/effect/map_helper/airlock/door/int_door,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/security)
+"gk" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/machinery/access_button{
+	command = "cycle_interior";
+	frequency = 1380;
+	master_tag = "dock_d2a2";
+	name = "interior access button";
+	pixel_x = -28;
+	pixel_y = 26;
+	req_one_access = list(13)
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/security)
+"gl" = (
+/obj/effect/floor_decal/sign/dock/two,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 4;
+	icon_state = "map"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/security)
+"gm" = (
+/obj/structure/bed/chair/office/dark{
+	dir = 4;
+	icon_state = "officechair_dark"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/security)
+"gn" = (
+/obj/structure/closet,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/security)
+"go" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/plating,
+/area/tether_away/guttersite/security)
+"gp" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced,
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/plating,
+/area/tether_away/guttersite/security)
+"gq" = (
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/security)
+"gr" = (
+/obj/structure/fence/door/locked{
+	dir = 8;
+	icon_state = "door_closed"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/security)
+"gs" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
+	icon_state = "space";
+	layer = 4;
+	name = "EXTERNAL AIRLOCK";
+	pixel_x = 0
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/plating,
+/area/tether_away/guttersite/docking)
+"gt" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/plating,
+/area/tether_away/guttersite/docking)
+"gu" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/plating,
+/area/tether_away/guttersite/docking)
+"gv" = (
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/docking)
+"gw" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4;
+	icon_state = "intact-supply"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/vault)
+"gx" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/docking)
+"gy" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5;
+	icon_state = "intact-scrubbers"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/security)
+"gz" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4;
+	icon_state = "intact-scrubbers"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4;
+	icon_state = "intact-supply"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/security)
+"gA" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4;
+	icon_state = "intact-scrubbers"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4;
+	icon_state = "intact-supply"
+	},
+/obj/machinery/door/airlock/maintenance_hatch{
+	req_one_access = list(38)
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/security)
+"gB" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1;
+	icon_state = "map-supply"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/security)
+"gC" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4;
+	icon_state = "intact-scrubbers"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4;
+	icon_state = "intact-supply"
+	},
+/turf/simulated/wall/r_wall,
+/area/tether_away/guttersite/security)
+"gD" = (
+/obj/structure/bed/chair/office/dark{
+	dir = 1;
+	icon_state = "officechair_dark"
+	},
+/mob/living/simple_mob/humanoid/merc/melee/poi{
+	faction = "wolfgirl"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/security)
+"gE" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10;
+	icon_state = "intact-scrubbers"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10;
+	icon_state = "intact-supply"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/security)
+"gF" = (
+/obj/structure/table/rack/shelf/steel,
+/obj/random/mre,
+/obj/random/mre,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/vault)
+"gG" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 4;
+	frequency = 1380;
+	id_tag = "dock_d2a2_pump"
+	},
+/obj/machinery/light/small,
+/obj/machinery/embedded_controller/radio/airlock/docking_port{
+	frequency = 1380;
+	id_tag = "guttersite_sshuttle";
+	pixel_y = 28
+	},
+/obj/machinery/airlock_sensor{
+	frequency = 1380;
+	id_tag = "dock_d2a2_sensor";
+	pixel_x = 0;
+	pixel_y = -25
+	},
+/obj/effect/map_helper/airlock/atmos/chamber_pump,
+/obj/effect/map_helper/airlock/sensor/chamber_sensor,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/docking)
+"gH" = (
+/obj/machinery/door/airlock/glass_external,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/effect/map_helper/airlock/door/int_door,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/docking)
+"gI" = (
+/obj/structure/closet{
+	name = "mechanical equipment"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/medbay)
+"gJ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4;
+	icon_state = "intact-supply"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/vault/bolted,
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/vault)
+"gK" = (
+/obj/machinery/alarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -22;
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/security)
+"gL" = (
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = -25
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/security)
+"gM" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/security)
+"gN" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/security)
+"gO" = (
+/obj/structure/fence/end{
+	dir = 4;
+	icon_state = "end"
+	},
+/obj/structure/fence,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/security)
+"gP" = (
+/obj/structure/fence{
+	dir = 8;
+	icon_state = "straight"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/security)
+"gQ" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/plating,
+/area/tether_away/guttersite/docking)
+"gR" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced,
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/plating,
+/area/tether_away/guttersite/docking)
+"gS" = (
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/docking)
+"gT" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4;
+	icon_state = "intact-supply"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/vault)
+"gU" = (
+/obj/structure/barricade,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/security)
+"gV" = (
+/obj/machinery/alarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -22;
+	pixel_y = 0
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/bridge)
+"gW" = (
+/obj/structure/fence/door/opened{
+	dir = 8;
+	icon_state = "door_opened"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/security)
+"gX" = (
+/obj/machinery/light,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/security)
+"gY" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4;
+	icon_state = "map_vent_out"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/security)
+"gZ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5;
+	icon_state = "intact-scrubbers"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9;
+	icon_state = "intact-supply"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/security)
+"ha" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8;
+	icon_state = "map_scrubber_on"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/security)
+"hb" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5;
+	icon_state = "intact-scrubbers"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/bridge)
+"hc" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4;
+	icon_state = "intact-supply"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 1;
+	icon_state = "tube1"
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/bridge)
+"hd" = (
+/obj/machinery/fitness/punching_bag/clown,
+/turf/simulated/mineral/floor/vacuum,
+/area/tether_away/guttersite/unexplored)
+"he" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/security)
+"hf" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9;
+	icon_state = "intact-scrubbers"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/security)
+"hg" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/security)
+"hh" = (
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/docking)
+"hi" = (
+/turf/simulated/wall/skipjack,
+/area/tether_away/guttersite/docking)
+"hj" = (
+/obj/machinery/door/airlock/hatch{
+	frequency = 1331;
+	icon_state = "door_closed";
+	id_tag = "vox_northeast_lock";
+	locked = 0;
+	req_access = list(150)
+	},
+/turf/simulated/shuttle/plating,
+/area/tether_away/guttersite/docking)
+"hk" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4;
+	icon_state = "intact-supply"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/maintenance_hatch{
+	req_one_access = list()
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/office)
+"hl" = (
+/obj/structure/fence/door/locked,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/security)
+"hm" = (
+/obj/structure/fence/end{
+	dir = 8;
+	icon_state = "end"
+	},
+/obj/structure/fence/end{
+	dir = 4;
+	icon_state = "end"
+	},
+/obj/structure/fence,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/security)
+"hn" = (
+/obj/structure/fence/end{
+	dir = 8;
+	icon_state = "end"
+	},
+/obj/structure/fence,
+/obj/structure/fence/end{
+	dir = 1;
+	icon_state = "end"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/security)
+"ho" = (
+/obj/machinery/airlock_sensor{
+	frequency = 1331;
+	id_tag = "vox_east_sensor";
+	pixel_x = -25
+	},
+/turf/simulated/shuttle/plating,
+/area/tether_away/guttersite/docking)
+"hp" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	frequency = 1331;
+	id_tag = "vox_east_vent"
+	},
+/turf/simulated/shuttle/plating,
+/area/tether_away/guttersite/docking)
+"hq" = (
+/obj/machinery/alarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -22;
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/docking)
+"hr" = (
+/obj/structure/table/rack/shelf/steel,
+/obj/random/cash,
+/obj/random/cash,
+/obj/random/cigarettes,
+/obj/random/drinkbottle,
+/obj/random/pizzabox,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/vault)
+"hs" = (
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 4;
+	icon_state = "map"
+	},
+/turf/simulated/shuttle/plating,
+/area/tether_away/guttersite/docking)
+"ht" = (
+/obj/machinery/atmospherics/pipe/simple/visible/blue{
+	dir = 6
+	},
+/obj/machinery/meter,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/docking)
+"hu" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/outline/red,
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/docking)
+"hv" = (
+/obj/machinery/door/airlock/hatch{
+	frequency = 1331;
+	icon_state = "door_closed";
+	id_tag = "vox_southeast_lock";
+	locked = 0;
+	req_access = list(150)
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/turf/simulated/shuttle/plating,
+/area/tether_away/guttersite/docking)
+"hw" = (
+/obj/structure/table/rack/steel,
+/obj/random/mre,
+/obj/random/multiple/gun/projectile/handgun,
+/obj/random/powercell,
+/obj/random/multiple/voidsuit,
+/obj/item/weapon/tank/oxygen,
+/obj/random/tool,
+/obj/random/drinkbottle,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/unexplored)
+"hx" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 6;
+	icon_state = "intact"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/docking)
+"hy" = (
+/obj/machinery/atmospherics/pipe/simple/visible/universal{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/docking)
+"hz" = (
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/docking)
+"hA" = (
+/obj/machinery/atmospherics/binary/pump/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/docking)
+"hB" = (
+/obj/machinery/atmospherics/pipe/manifold/visible/blue,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/docking)
+"hC" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/outline,
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/docking)
+"hD" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/table/rack,
+/obj/random/coin,
+/obj/random/contraband,
+/obj/random/energy,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/vault)
+"hE" = (
+/obj/structure/table/rack/shelf/steel,
+/obj/random/powercell,
+/obj/random/powercell,
+/obj/random/powercell,
+/obj/random/powercell,
+/obj/random/toolbox,
+/obj/random/tool/alien,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/vault)
+"hF" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 5;
+	icon_state = "intact"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/docking)
+"hG" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/docking)
+"hH" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1;
+	icon_state = "tube1"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/docking)
+"hI" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/docking)
+"hJ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 8;
+	icon_state = "intact"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/docking)
+"hK" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 8;
+	icon_state = "intact"
+	},
+/obj/machinery/light{
+	dir = 1;
+	icon_state = "tube1"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/docking)
+"hL" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 8;
+	icon_state = "intact"
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/docking)
+"hM" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 9;
+	icon_state = "intact"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/docking)
+"hN" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5;
+	icon_state = "intact-scrubbers"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/docking)
+"hO" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4;
+	icon_state = "intact-scrubbers"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/docking)
+"hP" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10;
+	icon_state = "intact-scrubbers"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9;
+	icon_state = "intact-supply"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/docking)
+"hQ" = (
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = -25
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/docking)
+"hR" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/docking)
+"hS" = (
+/obj/effect/shuttle_landmark/premade/guttersite/sshuttle,
+/turf/space,
+/area/space)
+"hT" = (
+/obj/effect/shuttle_landmark/premade/guttersite/lshuttle,
+/turf/space,
+/area/space)
+"hU" = (
+/obj/structure/bed/chair/office/dark{
+	dir = 8;
+	icon_state = "officechair_dark"
+	},
+/mob/living/simple_mob/humanoid/merc/melee/poi{
+	faction = "wolfgirl"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/security)
+"hV" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4;
+	icon_state = "intact-supply"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/office)
+"hW" = (
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = -25
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4;
+	icon_state = "intact-supply"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/office)
+"hX" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4;
+	icon_state = "intact-supply"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/structure/window/basic{
+	dir = 8;
+	icon_state = "window"
+	},
+/obj/structure/window/basic,
+/obj/structure/table/darkglass,
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/eris/white/monofloor,
+/area/tether_away/guttersite/office)
+"hY" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4;
+	icon_state = "intact-supply"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/structure/table/darkglass,
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/eris/white/monofloor,
+/area/tether_away/guttersite/office)
+"hZ" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/plating,
+/area/tether_away/guttersite/bridge)
+"ia" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/plating,
+/area/tether_away/guttersite/walkway)
+"ib" = (
+/obj/machinery/vending/cola/soft,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/walkway)
+"ic" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/plating,
+/area/tether_away/guttersite/medbay)
+"id" = (
+/obj/machinery/door/airlock/glass_external,
+/obj/machinery/access_button{
+	command = "cycle_exterior";
+	frequency = 1380;
+	master_tag = "dock_d2a2";
+	name = "exterior access button";
+	pixel_x = -5;
+	pixel_y = -26;
+	req_one_access = list()
+	},
+/obj/effect/map_helper/airlock/door/ext_door,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/docking)
+"ie" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/machinery/access_button{
+	command = "cycle_interior";
+	frequency = 1380;
+	master_tag = "dock_d2a2";
+	name = "interior access button";
+	pixel_x = -28;
+	pixel_y = 26;
+	req_one_access = list()
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/docking)
+"if" = (
+/obj/random/mob/mouse,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/security)
+"ig" = (
+/mob/living/simple_mob/vore/aggressive/rat/phoron,
+/turf/simulated/mineral/floor/vacuum,
+/area/tether_away/guttersite/unexplored)
+"ih" = (
+/obj/machinery/computer/arcade/battle,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/bridge)
+"ii" = (
+/obj/effect/overmap/visitable/sector/guttersite,
+/turf/space,
+/area/tether_away/guttersite/unexplored)
+"ij" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4;
+	icon_state = "intact-supply"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/structure/table/darkglass,
+/obj/item/weapon/pen/blue,
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/eris/white/monofloor,
+/area/tether_away/guttersite/office)
+"ik" = (
+/turf/simulated/floor/tiled/eris/white/techfloor_grid,
+/area/tether_away/guttersite/office)
+"il" = (
+/turf/simulated/floor/tiled/eris/white/panels,
+/area/tether_away/guttersite/office)
+"im" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/eris/white/panels,
+/area/tether_away/guttersite/office)
+"in" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/table/darkglass,
+/obj/item/weapon/paper_bin,
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/eris/white/monofloor,
+/area/tether_away/guttersite/office)
+"io" = (
+/obj/machinery/door/window/westleft,
+/turf/simulated/floor/tiled/eris/white/monofloor,
+/area/tether_away/guttersite/office)
+"ip" = (
+/obj/machinery/vending/nifsoft_shop,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/office)
+"iq" = (
+/obj/structure/bed/chair/bay/comfy/black,
+/turf/simulated/floor/tiled/eris/white/panels,
+/area/tether_away/guttersite/office)
+"ir" = (
+/obj/item/weapon/card/id/assistant,
+/turf/simulated/mineral/floor/vacuum,
+/area/tether_away/guttersite/unexplored)
+"is" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4;
+	icon_state = "intact-supply"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/office)
+"it" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4;
+	icon_state = "intact-supply"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/structure/cable/cyan{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/office)
+"iu" = (
+/obj/machinery/door/window/westright,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/office)
+"iv" = (
+/obj/structure/window/basic{
+	dir = 8;
+	icon_state = "window"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/office)
+"iw" = (
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/vault)
+"ix" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/office)
+"iy" = (
+/obj/structure/window/basic{
+	dir = 8;
+	icon_state = "window"
+	},
+/obj/machinery/papershredder,
+/turf/simulated/floor/tiled/eris/white/monofloor,
+/area/tether_away/guttersite/office)
+"iz" = (
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/vault)
+"iA" = (
+/mob/living/simple_mob/humanoid/merc/melee/sword/space,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/vault)
+"iB" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/vault)
+"iC" = (
+/obj/machinery/vending/sovietsoda,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/office)
+"iD" = (
+/obj/machinery/vending/snack,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/office)
+"iE" = (
+/obj/machinery/vending/cigarette,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/office)
+"iF" = (
+/obj/structure/bed/chair/bay/comfy/black{
+	dir = 4;
+	icon_state = "bay_comfychair_preview"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/office)
+"iG" = (
+/obj/structure/table/darkglass,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/office)
+"iH" = (
+/obj/structure/bed/chair/bay/comfy/black{
+	dir = 8;
+	icon_state = "bay_comfychair_preview"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/office)
+"iI" = (
+/obj/structure/bed/chair/bay/comfy/black{
+	dir = 4;
+	icon_state = "bay_comfychair_preview"
+	},
+/mob/living/simple_mob/vore/catgirl,
+/turf/simulated/floor/tiled/eris/white/techfloor_grid,
+/area/tether_away/guttersite/office)
+"iJ" = (
+/mob/living/simple_mob/vore/aggressive/mimic,
+/turf/simulated/mineral/floor/vacuum,
+/area/tether_away/guttersite/unexplored)
+"iK" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/mob/living/simple_mob/humanoid/merc/ranged/rifle/mag/poi,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/vault)
+"iL" = (
+/obj/structure/table/rack,
+/obj/item/weapon/tank/oxygen,
+/obj/random/multiple/voidsuit,
+/turf/simulated/shuttle/plating,
+/area/tether_away/guttersite/docking)
+"iM" = (
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/obj/random/cutout,
+/obj/structure/cable/cyan{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/vault)
+"iN" = (
+/obj/structure/table/rack/shelf/steel,
+/obj/random/plushie,
+/obj/random/plushielarge,
+/obj/random/toy,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/vault)
+"iO" = (
+/obj/machinery/access_button{
+	command = "cycle_exterior";
+	frequency = 1331;
+	master_tag = "vox_east_control";
+	req_access = list()
+	},
+/turf/simulated/wall/skipjack,
+/area/tether_away/guttersite/docking)
+"iP" = (
+/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
+	frequency = 1331;
+	id_tag = "guttersite_lshuttle";
+	pixel_x = -24;
+	req_access = list();
+	tag_airpump = "vox_east_vent";
+	tag_chamber_sensor = "vox_east_sensor";
+	tag_exterior_door = "vox_northeast_lock";
+	tag_interior_door = "vox_southeast_lock"
+	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 4;
+	frequency = 1331;
+	id_tag = "vox_east_vent"
+	},
+/obj/machinery/light/small,
+/turf/simulated/shuttle/plating,
+/area/tether_away/guttersite/docking)
+"iQ" = (
+/obj/machinery/access_button{
+	command = "cycle_interior";
+	frequency = 1331;
+	master_tag = "vox_east_control";
+	pixel_x = 22;
+	req_access = list()
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/turf/simulated/shuttle/plating,
+/area/tether_away/guttersite/docking)
+"iR" = (
+/mob/living/simple_mob/mechanical/hivebot/ranged_damage/basic,
+/turf/simulated/mineral/floor/vacuum,
+/area/tether_away/guttersite/unexplored)
+"iS" = (
+/mob/living/simple_mob/mechanical/hivebot/tank/meatshield,
+/turf/simulated/mineral/floor/vacuum,
+/area/tether_away/guttersite/unexplored)
+"iT" = (
+/obj/structure/bed/chair/office/dark{
+	dir = 4;
+	icon_state = "officechair_dark"
+	},
+/obj/effect/landmark/corpse/clown,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/security)
+"iU" = (
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube1"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/vault)
+"iV" = (
+/obj/item/clothing/under/assistantformal,
+/turf/simulated/mineral/floor/vacuum,
+/area/tether_away/guttersite/unexplored)
+"iW" = (
+/obj/item/weapon/reagent_containers/food/snacks/clownburger,
+/turf/simulated/mineral/floor/vacuum,
+/area/tether_away/guttersite/unexplored)
+"iX" = (
+/obj/machinery/computer/arcade/orion_trail,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/bridge)
+"iY" = (
+/obj/machinery/vending/snack,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/bridge)
+"iZ" = (
+/obj/machinery/light,
+/obj/machinery/vending/fitness,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/walkway)
+"ja" = (
+/obj/structure/bed/chair/bay/comfy/black{
+	dir = 4;
+	icon_state = "bay_comfychair_preview"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/bridge)
+"jb" = (
+/obj/structure/table/darkglass,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/bridge)
+"jc" = (
+/obj/structure/bed/chair/bay/comfy/black{
+	dir = 8;
+	icon_state = "bay_comfychair_preview"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/bridge)
+"jd" = (
+/obj/structure/table/rack/steel,
+/obj/random/firstaid,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/security)
+"je" = (
+/obj/structure/table/rack/steel,
+/obj/random/handgun/sec,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/security)
+"jf" = (
+/obj/structure/table/rack/steel,
+/obj/random/energy/sec,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/security)
+"jg" = (
+/mob/living/simple_mob/humanoid/merc/melee/poi{
+	desc = "A lone space clown, taking on the world.";
+	icon = 'icons/mob/clowns_vr.dmi';
+	icon_dead = "cluwne_dead";
+	icon_gib = "clown_gib";
+	icon_living = "cluwne";
+	icon_state = "cluwne";
+	name = "Green Clown"
+	},
+/turf/simulated/mineral/floor/vacuum,
+/area/tether_away/guttersite/unexplored)
+"jh" = (
+/obj/structure/bed/chair/office/dark{
+	dir = 8;
+	icon_state = "officechair_dark"
+	},
+/mob/living/simple_mob/humanoid/merc/ranged/rifle/mag/poi{
+	faction = "wolfgirl"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/security)
+"ji" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4;
+	icon_state = "intact-scrubbers"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4;
+	icon_state = "intact-supply"
+	},
+/obj/structure/bed/chair/office/dark{
+	dir = 4;
+	icon_state = "officechair_dark"
+	},
+/mob/living/simple_mob/humanoid/merc/ranged/technician/poi{
+	faction = "wolfgirl"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/security)
+"jj" = (
+/obj/random/curseditem,
+/turf/simulated/mineral/floor/vacuum,
+/area/tether_away/guttersite/unexplored)
+"jk" = (
+/obj/item/weapon/reagent_containers/food/snacks/clownstears,
+/turf/simulated/mineral/floor/vacuum,
+/area/tether_away/guttersite/unexplored)
+"jl" = (
+/obj/structure/loot_pile/surface/bones,
+/obj/item/weapon/reagent_containers/food/drinks/bottle/bottleofnothing,
+/turf/simulated/mineral/floor/vacuum,
+/area/tether_away/guttersite/unexplored)
+"jm" = (
+/obj/item/weapon/storage/backpack/clown,
+/turf/simulated/mineral/floor/vacuum,
+/area/tether_away/guttersite/unexplored)
+"jn" = (
+/obj/item/weapon/stamp/clown,
+/turf/simulated/mineral/floor/vacuum,
+/area/tether_away/guttersite/unexplored)
+"jo" = (
+/obj/structure/table/rack/shelf/steel,
+/obj/item/weapon/reagent_containers/food/snacks/donut/cherryjelly,
+/obj/item/weapon/reagent_containers/food/snacks/donut/jelly,
+/obj/item/weapon/reagent_containers/food/snacks/donut/normal,
+/obj/item/weapon/reagent_containers/food/snacks/donut/poisonberry,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/security)
+"jp" = (
+/obj/structure/table/rack/shelf/steel,
+/obj/item/weapon/reagent_containers/food/snacks/donut/cherryjelly,
+/obj/item/weapon/reagent_containers/food/snacks/donut/jelly,
+/obj/item/weapon/reagent_containers/food/snacks/donut/normal,
+/obj/item/weapon/reagent_containers/food/snacks/donut/slimejelly,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/security)
+"jq" = (
+/obj/structure/table/rack/shelf/steel,
+/obj/item/weapon/reagent_containers/food/snacks/donut/chaos,
+/obj/item/weapon/reagent_containers/food/snacks/donut/cherryjelly,
+/obj/item/weapon/reagent_containers/food/snacks/donut/cherryjelly,
+/obj/item/weapon/reagent_containers/food/snacks/donut/jelly,
+/obj/item/weapon/reagent_containers/food/snacks/donut/normal,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/security)
+"jr" = (
+/obj/structure/table/rack/shelf/steel,
+/obj/item/weapon/grenade/chem_grenade/metalfoam,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/security)
+"js" = (
+/obj/structure/table/rack/shelf/steel,
+/obj/item/weapon/grenade/flashbang,
+/obj/item/weapon/grenade/flashbang,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/security)
+"jt" = (
+/obj/structure/table/rack/shelf/steel,
+/obj/item/weapon/melee/chainofcommand,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/security)
+"ju" = (
+/obj/structure/table/rack/steel,
+/obj/item/weapon/handcuffs,
+/obj/item/weapon/melee/baton,
+/obj/item/weapon/implant/sizecontrol,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/security)
+"jv" = (
+/obj/structure/table/darkglass,
+/obj/machinery/chemical_dispenser/biochemistry/full,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/commons)
+"jw" = (
+/obj/item/weapon/reagent_containers/spray/waterflower,
+/turf/simulated/mineral/floor/vacuum,
+/area/tether_away/guttersite/unexplored)
+"jx" = (
+/mob/living/simple_mob/vore/wolfgirl,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/security)
+"jy" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/maintenance_hatch{
+	req_one_access = list(38)
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/security)
+"jz" = (
+/mob/living/simple_mob/vore/wolfgirl{
+	name = "Tricky Dixie"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/unexplored)
+"jA" = (
+/obj/structure/closet/cabinet,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/commons)
+"jB" = (
+/obj/machinery/washing_machine,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/commons)
+"jC" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	req_one_access = list()
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/commons)
+"jD" = (
+/turf/simulated/floor/tiled/eris/steel/bar_dance,
+/area/tether_away/guttersite/commons)
+"jE" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/maintenance_hatch{
+	req_one_access = list()
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/office)
+"jF" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/docking)
+"jH" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 1
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/security)
+"jI" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/security)
+"jJ" = (
+/obj/machinery/power/apc{
+	cell_type = /obj/item/weapon/cell/super;
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/obj/structure/cable/cyan{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/security)
+"jK" = (
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6;
+	icon_state = "intact-supply"
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/security)
+"jL" = (
+/obj/structure/bed/padded,
+/obj/item/weapon/bedsheet/ian,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/commons)
+"jM" = (
+/obj/structure/bed/padded,
+/obj/item/weapon/bedsheet/captain,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/commons)
+"jN" = (
+/obj/structure/bed/padded,
+/obj/item/weapon/bedsheet/mime,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/commons)
+"jO" = (
+/obj/structure/bed/padded,
+/obj/item/weapon/bedsheet/hop,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/commons)
+"jP" = (
+/obj/structure/bed/padded,
+/obj/item/weapon/bedsheet/cosmos,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/commons)
+"jQ" = (
+/obj/structure/bed/padded,
+/obj/item/weapon/bedsheet/hos,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/commons)
+"jR" = (
+/obj/structure/bed/padded,
+/obj/item/weapon/bedsheet/pirate,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/commons)
+"jS" = (
+/obj/structure/bed/padded,
+/obj/item/weapon/bedsheet/ce,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/commons)
+"jT" = (
+/obj/structure/window/basic,
+/obj/structure/bed/padded,
+/obj/item/weapon/bedsheet/clown,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/commons)
+"jU" = (
+/obj/structure/window/basic,
+/obj/structure/bed/padded,
+/obj/item/weapon/bedsheet/medical,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/commons)
+"jV" = (
+/obj/structure/window/basic,
+/obj/structure/bed/padded,
+/obj/item/weapon/bedsheet/rd,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/commons)
+"jW" = (
+/obj/structure/window/basic,
+/obj/structure/bed/padded,
+/obj/item/weapon/bedsheet/rainbow,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/commons)
+"jX" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4;
+	icon_state = "intact-supply"
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/security)
+"jY" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4;
+	icon_state = "intact-supply"
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/wall/r_wall,
+/area/tether_away/guttersite/security)
+"ka" = (
+/obj/structure/bed/chair/bay/comfy/black{
+	dir = 4;
+	icon_state = "bay_comfychair_preview"
+	},
+/turf/simulated/floor/tiled/eris/steel/bar_dance,
+/area/tether_away/guttersite/commons)
+"kb" = (
+/obj/structure/bed/chair/bay/comfy/black{
+	dir = 8;
+	icon_state = "bay_comfychair_preview"
+	},
+/turf/simulated/floor/tiled/eris/steel/bar_dance,
+/area/tether_away/guttersite/commons)
+"kc" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4;
+	icon_state = "intact-supply"
+	},
+/obj/structure/table/steel,
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/security)
+"kd" = (
+/obj/machinery/light,
+/turf/simulated/floor/tiled/eris/steel/bar_dance,
+/area/tether_away/guttersite/commons)
+"ke" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/eris/steel/bar_dance,
+/area/tether_away/guttersite/commons)
+"kf" = (
+/obj/item/device/flashlight/lamp/green,
+/turf/simulated/mineral/floor/vacuum,
+/area/tether_away/guttersite/unexplored)
+"kg" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/eris/steel/bar_dance,
+/area/tether_away/guttersite/commons)
+"kh" = (
+/obj/item/weapon/book{
+	author = "Urist McHopefulsoul";
+	desc = "It contains fourty blank pages followed by the entire screenplay of a movie called 'Requiem for a Dream'";
+	name = "A Comprehensive Guide to Assisting"
+	},
+/turf/simulated/mineral/floor/vacuum,
+/area/tether_away/guttersite/unexplored)
+"ki" = (
+/obj/structure/reagent_dispensers/water_cooler/full{
+	icon_state = "water_cooler-vend"
+	},
+/turf/simulated/floor/tiled/eris/steel/bar_dance,
+/area/tether_away/guttersite/commons)
+"kj" = (
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = -25
+	},
+/obj/structure/table/darkglass,
+/obj/machinery/microwave,
+/turf/simulated/floor/tiled/eris/steel/bar_dance,
+/area/tether_away/guttersite/commons)
+"kk" = (
+/obj/structure/table/darkglass,
+/obj/item/weapon/storage/box/cups,
+/turf/simulated/floor/tiled/eris/steel/bar_dance,
+/area/tether_away/guttersite/commons)
+"kl" = (
+/obj/machinery/light,
+/obj/structure/table/darkglass,
+/obj/item/weapon/storage/box/condimentbottles,
+/turf/simulated/floor/tiled/eris/steel/bar_dance,
+/area/tether_away/guttersite/commons)
+"km" = (
+/obj/structure/table/darkglass,
+/obj/item/weapon/storage/box/donkpockets,
+/turf/simulated/floor/tiled/eris/steel/bar_dance,
+/area/tether_away/guttersite/commons)
+"kn" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1;
+	icon_state = "map-supply"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/table/steel,
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/security)
+"ko" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4;
+	icon_state = "intact-supply"
+	},
+/obj/structure/table/steel,
+/obj/item/device/flashlight/lamp,
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/security)
+"kp" = (
+/turf/simulated/floor/tiled/eris/dark/techfloor_grid,
+/area/tether_away/guttersite/commons)
+"kq" = (
+/obj/structure/sink{
+	dir = 8;
+	icon_state = "sink";
+	pixel_x = -12;
+	pixel_y = 8
+	},
+/turf/simulated/floor/tiled/eris/dark/techfloor_grid,
+/area/tether_away/guttersite/commons)
+"kr" = (
+/obj/structure/toilet{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/eris/dark/techfloor_grid,
+/area/tether_away/guttersite/commons)
+"ks" = (
+/obj/machinery/holoplant,
+/obj/machinery/holoplant{
+	icon_state = "plant-09"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/commons)
+"kt" = (
+/obj/machinery/holoplant,
+/obj/machinery/holoplant{
+	icon_state = "plant-10"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/commons)
+"ku" = (
+/obj/machinery/holoplant,
+/obj/machinery/holoplant{
+	icon_state = "plant-15"
+	},
+/turf/simulated/floor/tiled/eris/steel/bar_dance,
+/area/tether_away/guttersite/commons)
+"kv" = (
+/obj/structure/window/basic,
+/obj/machinery/holoplant,
+/obj/machinery/holoplant{
+	icon_state = "plant-1"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/office)
+"kw" = (
+/obj/machinery/holoplant,
+/obj/machinery/holoplant{
+	icon_state = "plant-13"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/bridge)
+"kx" = (
+/obj/machinery/holoplant,
+/obj/machinery/holoplant{
+	icon_state = "plant-15"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/office)
+"ky" = (
+/obj/machinery/vending/loadout/overwear,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/commons)
+"kz" = (
+/obj/machinery/vending/loadout/clothing,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/commons)
+"kA" = (
+/obj/structure/table/darkglass,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/commons)
+"kB" = (
+/obj/structure/bed/chair/bay/comfy/black{
+	dir = 4;
+	icon_state = "bay_comfychair_preview"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/commons)
+"kC" = (
+/obj/structure/window/basic{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/commons)
+"kD" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4;
+	icon_state = "intact-supply"
+	},
+/obj/structure/table/steel,
+/obj/item/weapon/pen/fountain,
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/security)
+"kE" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4;
+	icon_state = "intact-supply"
+	},
+/obj/structure/table/steel,
+/obj/item/weapon/paper_bin,
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/security)
+"kF" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/structure/table/darkglass,
+/obj/structure/window/basic{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/commons)
+"kG" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9;
+	icon_state = "intact-scrubbers"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9;
+	icon_state = "intact-supply"
+	},
+/obj/structure/table/steel,
+/obj/structure/cable/cyan{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/security)
+"kH" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/docking)
+"kI" = (
+/obj/machinery/vending/medical,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/medbay)
+"kJ" = (
+/obj/effect/floor_decal/sign/dock/two,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 4;
+	icon_state = "map"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 4;
+	icon_state = "map"
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/docking)
+"kK" = (
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc{
+	cell_type = /obj/item/weapon/cell/super;
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/turf/simulated/floor/airless,
+/area/tether_away/guttersite/teleporter)
+"kL" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1;
+	icon_state = "map_vent_out"
+	},
+/obj/structure/table/darkglass,
+/obj/structure/window/basic,
+/obj/structure/window/basic{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/commons)
+"kM" = (
+/obj/structure/table/darkglass,
+/obj/structure/window/basic,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/commons)
+"kN" = (
+/obj/structure/table/darkglass,
+/obj/structure/window/basic{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/commons)
+"kO" = (
+/obj/structure/window/basic{
+	dir = 1
+	},
+/obj/structure/window/basic{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/commons)
+"kP" = (
+/obj/structure/window/basic{
+	dir = 1
+	},
+/obj/structure/medical_stand,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/commons)
+"kQ" = (
+/obj/structure/medical_stand,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/commons)
+"kR" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/docking)
+"kS" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/closet/crate/medical/blood,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/medbay)
+"kT" = (
+/obj/structure/window/basic{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/medbay)
+"kU" = (
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/docking)
+"kV" = (
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/docking)
+"kW" = (
+/obj/machinery/light,
+/obj/structure/window/basic{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/medbay)
+"kX" = (
+/obj/structure/sign/nosmoking_1,
+/turf/simulated/wall/r_wall,
+/area/tether_away/guttersite/medbay)
+"kY" = (
+/obj/structure/table/darkglass,
+/obj/item/weapon/storage/box/masks,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/medbay)
+"kZ" = (
+/obj/structure/table/darkglass,
+/obj/item/weapon/surgical/surgicaldrill,
+/obj/item/weapon/surgical/scalpel,
+/obj/item/weapon/surgical/circular_saw,
+/obj/item/weapon/surgical/cautery,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/medbay)
+"la" = (
+/obj/structure/sink{
+	dir = 8;
+	icon_state = "sink";
+	pixel_x = -12;
+	pixel_y = 8
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/medbay)
+"lb" = (
+/obj/machinery/light{
+	dir = 1;
+	icon_state = "tube1"
+	},
+/obj/machinery/vending/engivend,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/storage)
+"lc" = (
+/obj/machinery/vending/engineering,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/storage)
+"ld" = (
+/obj/machinery/vending/tool,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/storage)
+"le" = (
+/obj/structure/closet/toolcloset,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/storage)
+"lf" = (
+/obj/structure/window/basic{
+	dir = 4
+	},
+/obj/structure/closet/toolcloset,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/storage)
+"lg" = (
+/obj/structure/window/basic{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/storage)
+"lh" = (
+/obj/structure/window/basic{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/storage)
+"li" = (
+/obj/item/toy/figure/assistant,
+/turf/simulated/mineral/floor/vacuum,
+/area/tether_away/guttersite/unexplored)
+"lj" = (
+/obj/structure/closet/walllocker/emerglocker/east,
+/obj/structure/closet/firecloset/full,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/storage)
+"lk" = (
+/obj/structure/closet/crate/engineering/electrical,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/storage)
+"ll" = (
+/obj/structure/window/basic,
+/obj/structure/closet/crate/engineering/electrical,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/storage)
+"lm" = (
+/obj/structure/window/basic,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/storage)
+"ln" = (
+/obj/structure/table/darkglass,
+/obj/item/weapon/storage/toolbox/electrical,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/storage)
+"lo" = (
+/obj/machinery/light,
+/obj/structure/window/basic{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/storage)
+"lp" = (
+/obj/structure/closet/crate/engineering,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/storage)
+"lq" = (
+/mob/living/bot/mulebot,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/storage)
+"lr" = (
+/obj/structure/closet/crate/solar,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/storage)
+"ls" = (
+/obj/structure/closet/crate/science,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/storage)
+"lt" = (
+/obj/structure/closet/crate/rcd,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/storage)
+"lu" = (
+/obj/structure/closet/firecloset/full,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/commons)
+"lv" = (
+/obj/structure/closet/firecloset/full,
+/turf/simulated/floor/tiled/eris/steel/bar_dance,
+/area/tether_away/guttersite/commons)
+"lw" = (
+/obj/structure/closet/firecloset/full,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/bridge)
+"lx" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/closet/firecloset/full,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/office)
+"ly" = (
+/obj/structure/closet/firecloset/full,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/security)
+"lz" = (
+/obj/structure/closet/firecloset/full,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/docking)
+"lA" = (
+/obj/structure/window/basic{
+	dir = 4
+	},
+/obj/structure/window/basic,
+/obj/structure/bed/chair/bay/comfy/black{
+	dir = 8;
+	icon_state = "bay_comfychair_preview"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/storage)
+"lB" = (
+/obj/structure/table/darkglass,
+/obj/item/weapon/storage/toolbox/mechanical,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/storage)
+"lC" = (
+/obj/structure/table/rack/shelf/steel,
+/obj/random/projectile/random,
+/obj/random/weapon/guarenteed,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/vault)
+"lD" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/vault)
+"lF" = (
+/obj/machinery/light,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/office)
+"lG" = (
+/obj/machinery/light{
+	dir = 1;
+	icon_state = "tube1"
+	},
+/turf/simulated/floor/plating/eris/under,
+/area/tether_away/guttersite/security)
+"lH" = (
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube1"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/security)
+"lJ" = (
+/obj/item/weapon/storage/toolbox/electrical{
+	pixel_x = 1;
+	pixel_y = -1
+	},
+/turf/simulated/floor/airless,
+/area/tether_away/guttersite/teleporter)
+"lK" = (
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/obj/structure/cable/cyan{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/docking)
+"lL" = (
+/obj/structure/loot_pile/surface/bones,
+/obj/random/weapon/guarenteed,
+/turf/simulated/mineral/floor/vacuum,
+/area/tether_away/guttersite/unexplored)
+"lM" = (
+/obj/item/toy/plushie/carp,
+/turf/simulated/mineral/floor/vacuum,
+/area/tether_away/guttersite/unexplored)
+"lN" = (
+/obj/structure/loot_pile/surface/bones,
+/turf/simulated/mineral/floor/vacuum,
+/area/space)
+"lO" = (
+/obj/structure/bonfire,
+/turf/simulated/mineral/floor/vacuum,
+/area/space)
+"lP" = (
+/obj/item/weapon/card/emag,
+/turf/simulated/mineral/floor/vacuum,
+/area/space)
+"lQ" = (
+/obj/item/weapon/card/emag_broken,
+/turf/simulated/mineral/floor/vacuum,
+/area/tether_away/guttersite/unexplored)
+"lR" = (
+/obj/item/toy/plushie/carp,
+/turf/simulated/mineral/floor/vacuum,
+/area/space)
+"lS" = (
+/obj/structure/inflatable/door,
+/turf/simulated/mineral/floor/vacuum,
+/area/space)
+"lT" = (
+/obj/item/pizzavoucher,
+/turf/simulated/mineral/floor/vacuum,
+/area/space)
+"lU" = (
+/mob/living/simple_mob/animal/space/carp/large/huge,
+/turf/simulated/mineral/floor/vacuum,
+/area/space)
+"lV" = (
+/obj/item/clothing/suit/storage/hooded/carp_costume,
+/turf/simulated/mineral/floor/vacuum,
+/area/space)
+"lW" = (
+/obj/item/clothing/suit/storage/hooded/techpriest,
+/turf/simulated/mineral/floor/vacuum,
+/area/tether_away/guttersite/unexplored)
+"mu" = (
+/obj/structure/window/basic{
+	dir = 4;
+	icon_state = "window"
+	},
+/obj/structure/table/darkglass,
+/turf/simulated/floor/tiled/eris/white/monofloor,
+/area/tether_away/guttersite/office)
+"mw" = (
+/obj/structure/table/darkglass,
+/obj/item/device/flashlight/lamp/green,
+/turf/simulated/floor/tiled/eris/white/monofloor,
+/area/tether_away/guttersite/office)
+"mM" = (
+/obj/structure/table/darkglass,
+/obj/item/weapon/pen/blue,
+/turf/simulated/floor/tiled/eris/white/monofloor,
+/area/tether_away/guttersite/office)
+"mN" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/bridge)
+"mO" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 6;
+	icon_state = "intact"
+	},
+/obj/structure/table/darkglass,
+/obj/item/weapon/paper_bin,
+/turf/simulated/floor/tiled/eris/white/monofloor,
+/area/tether_away/guttersite/office)
+"mT" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10;
+	icon_state = "intact-supply"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9;
+	icon_state = "intact-scrubbers"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/vault)
+"ne" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9;
+	icon_state = "intact-supply"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9;
+	icon_state = "intact-scrubbers"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/office)
+"nf" = (
+/obj/structure/table/rack,
+/obj/random/janusmodule,
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/vault)
+"Ob" = (
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/tether_away/guttersite/maint)
 
 (1,1,1) = {"
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaagagagaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaadadadadaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaagagadagagaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaadadadadaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaagclcqadagaaaaaaaaaaaaaaaaadagaaaaaaaaaaaaadlMadaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaagadaLadagagaaaaaaaaaaaaaaagagagaaaaaaaaaaadadadaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaagadadadadagaaaaaaaaaaaaaaagagagagaaaaaaaaaaadaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaagagagadaaaaaaaaaaaaaaaaaaagagagagaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaagagaaaaaaaaagadaaaaaaaaaaagagagadaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaglMadaaaaaaadagagagadaaaaaaaaaaaaaaaaaaagadaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaagagaaaaaaaaadadaglMadaaaaaaaaaaaaaaaaaaagagadaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaadadadadaaaaaaaaaaaaaaaaaaaaagadadaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaagagagadaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaagagagagadadaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaagagagadadadadaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaagagadadagagaaaaaaaaaaaaaaaaaaaaaaaaadaglMadadaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaagadagagagaaaaaaaaaaaaaaaaaaaaaaaaaaagagagagaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaagagagaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaagagagagaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaagaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaadaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaadadadadadaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeaeaeaeaeaeaeaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaadadadadadaaaaaaaaaaaaaaagagadadadaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaacacacacacacacacacacacabadadadadagagadadadadadadadaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeaeahahahahahaiajajaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaadagagadadaaaaaaaaaaaaaaagagadadadaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaababababacacacacacacacacacacacacacacababadagagagagagagagagagagagaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaiaiahahalamanahahajajajaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaagagagadaaaaaaaaaaaaagagiriVadadadadaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabacacacacacacacacacacacacacababababacacacacacacacacacagagagagagagagagagagadadaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaakafaiahahaoapaqaparahahajajaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaagagadaaaaaaaaaaaaaaagagkfkhliagagagagaaaaaaaaaaaaaaaaaaaaaaaaaaaaacabacacacacacacacacacacacacablRababababacacacacacacacacacacacacagagagagagagagagagadaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeaeasatbaapapeZapavahajajaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaagagagagagagagagagaaaaaaaaaaaaaaaaaaaaacacacacacablSlSabababababababablSlSabababablRababababablSlSabababababababadadadagagagagagadaaaaaaaaaaaaaaaaaaagaaaaaaaaaaaaaaaaaaaaaeauapapapapaiapcJahajajaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaagagagagagagagaaaaaaaaaaaaaaaaaaaaacacacacacacacacacacacacacacacacacacacablTablUablVablNlOabacacacacacacacacacacacabagagagagagagagaaaaaaaaaaaaaaagagaaaaaaaaaaaaaaaaaaaeaeahapaiapapaiaeawahajajaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaagagaaaaaaaaaaaaaaaaaaacacacacacacacacacacacacacacacacacacacacacabababababababacacacacacacaxaxaxaxaxaxacacababacacacagagagaaaaaaaaaaaaagagagagaaaaaaaaaaaaaaakaiaiahahkKapapailJahahajajaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaBaBaBaBaBaBaBaBaBaBaBaBaBaBaBaBaBaBaBaBaBaBaBaBacababablPablRabacacacaxaxaxaxlblcldlcaxaxacacababacacacacacagaaaaaaaaaaagagagadaaaaaaaaaaaaaaaaaaaiaiahahapaiapahahajajajaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaBaEaEaEaEaEaEaEctaVcAcAcAcAcAcAcAcAcAcAcAcBaEaBacablRabababababacacaxaxlelelfaDaDaDaDlgaxaxacacababacacacacacaaaaaaaaaaaaaaadadaaaaaaaaaaaaaaaaaaaeaeaeahahauahahaiajajajaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaFaGaGaGaHaIaGaGaGaGaNcCObaPaPaQaQaQaRaSaQaQaQaTcEaEaBacacabababababacacaxaxaCaDaDlhcraDaDaDlgljaxacacacabababacacacagaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeaeaiaeaiaeaiaeaeajaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaFaJaJaKaJaJaMaOaUaGaEcGObaEaPbebfbgbhbhbibhbhaTcEaEaBacacacacacacacacacaxlkaDaDaDlhlnaDaDaDlglraxacacacacacabacacacagaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeaeaiaiaiaeaeaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaFaJbcaWaXaXaXaXaYaGaEaZbEaEaPbpbqbqbqbqbrbsbhaTcEaEaBaBaBaBaBaBaBaBaBaBaxlllmaDbtlAlBbjcKcKcKcNaxacacacacacabacacacagaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaakaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaFaJbcbdcQbkblbkbmbnbubvbwbubxbybIbJbKbLbMbNbhaTcVcAcAcWcAcAcAcAcAcAcAcWcXcYcYcYdgcYcYdlaDaDlglsaxacacacacaclSacacacagaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaFaJbcbzcQbkbBaXbCbDaEbobEaEcabFccbJcdcecfcgbhaTaPaPaBaBaBaBaBaBaBaBaBaBaxaDaDaDchaDaDdoaDaDloltaxacacacacaclSacacacaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaFaJbcbGaXaXbHaXbOaFaEbobEaEaBbPbqbqbqbqcmcnbhaTagagagagagagagagagagagagaxaDaDaDaDaDaDdqaDlpaxaxaxacacacacacababacacaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaFaJbcbzcQbkbQaXaJaFaEbobEaEaBcucvcwbhcxcybhbhaTagagagagagagagagagagagagaxaxaxlqlqcjaDdqaDlpaxacacacacacacacacababadaaaaaaaaaaagagaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaFaJbcbGaXaXaXaXaJaFczbobRbSaBaTaTaTaTaTaTaTaTaTagagagagagagagagagagagagagagaxaxaxaxaxdraxaxaxacacacacacacacacacacacaaaaaaaaaaagagadaaaaaaaaaaaaagagagagaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaFaJaJbTbUaJbVbWbXaBcDaEaEbYaBagagagagagagagagagagagagagagagagagagagagagagagagagagagaxdqaxacacacacacacacacacacacacacaaaaaaaaaaaglQadaaaaaaaaaaagagagagagaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaFaFaFaFaFaFaFaFaFaBaBaBaBaBaBagagagagagagagagagagagagagagagagagagagagagagagagagagagaxdqaxacacacacacacacacacacacacaaaaaaaaaaaaaaaaaaaaaaadaaaaagagagfWadaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaagagagagagagagagagagagagagagagagagagagagagagagagagagagagagagagagagagagagagagagagaxdqaxacacacacacacacacacacacaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaagagagagayayhdhdhdadadadadadagagagagagagagagagagagcFcFcFcFcFcFdkcFcFcFcFcFcFcFcFdscFcFcFcFcFcFcFacacacacacaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaagagagayadadiWadjkadadcMadadazadadagagagagagagcFcFcFcFjLcIjMcFdkcFjNcIjOcFkscOcOdtkCcPkykzcIkAcFacacacacaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaagagjwjjadadadjgadadadadadagagadagagagagagcFcFcUdbcFjPcHjQcFdkcFjRcHjScFkBcHcHdtkCcHcHcHkBkAcFacacacaaaaaaaaaaaaaaaaaaaaaaaaaaaaadaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaagjwadcMadjmaAaLadjkadadagagadagagagagcFcFcZcZcZcFjTcHjUcFcFcFjVcHjWcFkBcHcHdukFcHcHcHcHkAcFacacaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaagagadadadadadadadadadadagagadagagcFcFcFdcjvcZcZdmdacHdacHcHcHdacHdadmcHcHcHdybAbZdEcHcHcRcFacaaaaaaaaaaagagaaaaaaaaaaaaaaaaadadaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaagagadadadiWadjnadcMadagagadadagcFcFcZcZcZcZcZcZcFktcHcHcHcHcHcHcHcHcFcHcHcHdukLkMducHcHcHdfaaaaaaaaaaaaagagagaaaaaaaaaaaaaaaglWaaaaaaaaaaaaaaaaaaadadaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaagagagagaLaLadadadayayagagadagcFcFdhcZdidhdhdhdjcFcFjAcLjBcHcFcFcFjCcFkNkOcHducHcHducHcHdfdfaaaaaaaaaaadadagagaaaaaaaaaaaaaaagagaaaaaaaaaaaaaaaaaaagagagaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaagagagagagadadayagagagagadagcFdhdhjDcbdWdWdWdWdXdYdZeaejeodYeteueudYeveweoexcHcHdukPdfdfaaaaaaaaaaaaadadagaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaagagaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaagagagagagagagagagagagazagcFjDjDjDeyjDjDjDjDjDcFeGcSjBcHcFkpkpkpcFkAcHcHcHcHcHdukQdfaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaagagagagagagagagadadagcFezeAeBeCjDkadhkbjDcFcFcHcHcHcFkqkpkrcFlucHcHddcHcHdudfdfaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaadagagagagagadadagagcFjDjDjDeyjDjDjDjDjDjDcFcFcFdmcFcFcFcFcFdfdfdfcFdfdeeDdeaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaadagagagadadagagagcFjDkadheFjDkadhkbjDjDjDjDjDjDjDjDlvcFcFaaaaaaaaaaiceHicaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaadagaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaadazadadagagagagcFkdjDkeeKkgjDjDjDjDjDjDjDjDjDjDcFcFcFaaaaaaaaaaaaiceHicaaaaaaaaaaaaaaaaaaadagaaaaaaaaaaaaaaaaaaaaaaagagaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaadagagagagagagagcFcFcFjDeyjDjDjDjDjDjDjDjDkdkucFcFaaaaaaaaaaaaaaaaiceHicaaaaaaaaaaaaaaaaaaagagagaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaagagagagagagagagagcFjDeOjDjDkikjkkklkmcFcFcFcFaaaaaaaaaaaaaaaaaaiceQicaaaaaaaaaaaaaaaaaaadagagaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaadagagagagagagagagcFcFeRcFcFcFcFcFcFcFcFabaaaaaaaaaaaaaaaaaaaaaaiceHicaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaadadagagagagagagagagdneSdnacacacacacacabaaaaaaaaaaaaaaaaaaaaaaaaiceHicaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaababababacacaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaadagagagagagagagagdneSdnacababababaaaaaaaaaaaaaaaaaaaaaaaaaaaaiceHicaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaababababababacacacacacaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaadagagagagagagagdneSiaabaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaiceHicaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaababababababababacacacacacacaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaagagagagagagagdneSiaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaadedekXdeeDdededeaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaababababababababacacacacacacacacaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaagagagagagagdneSiaaaaaaaaaaaaaaaaaaaaaaaaaaaaadededekYkZdpeHdpdpdedeaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaababababababababababacacacacacacacacacaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaiaeSiaaaaaaaaaaaaaaaaaaaaaaaaaaaaadeladpdpdpdpeHdpdpdzdeaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaababababdvdwdxdvabababacacacacacacacacacacaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaiaeTdnaaaaaaaaaaaaaaaaaaaaaaaaaaaadedpdDdGdLdDeUdLdpkSdeaaaaaaaaaaaaaaaaaaaaaaaaaaaaababababababdvdAdBdvabababacacacacacacacacacacaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaiaeSiaaaaaaaaaaaaaaaaaaaaaaaaaaaaadedpdpkTdpdCeVeWeXeYdeaaaaaaaaaaaaaaabababababababababababababdvdHdIdvabababacacacacacacacacacacaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaiaeSiaaaaaaaaaaaaaaaaaaaaaaaaaaaaadedJdDdGdLdDdGdLdpkIdeaaaaaaaaaaaaababababababababababababababdvdvdKdvabababacacacacacacacacacacaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaiaeSiaaaaaaaaaaaaaaaaaaaaaaaaaaaaadededpkWdpdpkTdMgIdedeaaaaaaaaaaaaabababababababdNdOdOdOdOdOdOdvdPdQdvdOdOdOdNdNacacacacacacacacaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaiaeSiaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaadededededededededeaaaaaaaaaaaaababababababababdOdRdRdRdRdRdRdSdRdTdRipiCiDiEdNacacacacacacacacacaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaiaeSiaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabababababababababdOiFiGiHdRiFiGiHdRdTdRdRdRdRdUdNacacacacacacacacacaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaiaeSiaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabababababababababdNdNdVdRdRdRdRdRdRdRdTdRdRdRcifcdNdNacacacacacacacacacaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaadndnfddndnaaaaaaaaaaebhZhZhZebhZebaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabababababababababdOkveceieceiececececdTdRdRdRfgdRdRdNacacededededededacacaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaadndnibeSefdndnaaaaaaebebihiXlwehiYebebaaaaaaaaaaaaaaaaaaaaaaaaaaaaabababababababababdOdRdRdRekeseMfafbmudTdRiFiGfhdRdRdNacacedelePgFlCedacacaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaadneneefiepeednhZhZhZebehegegegeqegegebaaaaaaaaaaaaaaaaaaaaaaaaaaaaabababababababababdNerdRdRcpikilimikmwdTdRdRdRfgdRdUdNacacediUememiAedacacacaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaadnfjfpfsfvfyfJfKfKfKfLfMfKfNfKfOfPfQebaaaaaaaaaaaaaaaaaaaaaaaaaaaaababacacacacabababdOdRdRdRioikilimiImMdTdRiFiGfhdRdRdNedededemlDemfeedacacacaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaadniZeefieIeJdnhZhZhZebfRegmNegeLegegebhZhZhZhZhZhZhZhZhZhZebhZhZhZhZhZebebebebhZhZhZdNdRdRdRiyikiqimikmOeNdRdRdRfgcifSfTgwgwgJgTmTemfkedacacacaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaadndneeeSeedndnaaaaaaebgVfPhbfKfKfKfKfLfKfKfKfKfKfKfKfKfKfKhcfKfKfKfKfKfKfKfKhcfKfKfKhkhVhWhVhXhYijinhYckhVhVhVhVisitnedNededediwffnfhDedacacacaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaadndnfddndnaaaaaaaaebjajbjcegjajbjcebhZhZhZhZhZhZhZhZhZhZhZhZhZhZhZebebebebebebebebdNdNdNdRiudRdRdRdRixdRdRdRdRdRdRlxdNacacediziBiKiMedacacacaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaiaeSiaaaaaaaaaaaebebflfmkwegegebebaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaacacacacacacacacacacdNkxivdRlFdRdRixdRdRdRdFdNdNdNdNacacedfnhrhEiNedacacaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaiaeSiaaaaaaaaaaaaaebebebhZhZhZebaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaacacacacacacacacacacdNdNdNdNdNdNfojEfodNdNdNdNacacacacacededededededacacaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaiaeSiaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaacacacacacacacacacacacacacfqfrjFfrfqacacacacacacacacacacacacacacacaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaiaeSiaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaacacacacacacacacacacacacfqfrjFfrfqacacacacacacacacacacacacacacaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaiaeSiaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaacacacacacacacacacacfqfrjFftfqacacacacacacacacacacacaceEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeE
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaadadadadadadadadadaaaaaaaaaaaaaaiaeSiaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaacacacacacacacacacfqfrjFfrfqacacacacacacacacaceEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeE
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaagagagagagagagadadadadadadadadadadadaaaaaaaaiaeSiaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEgufrjFfrfqacacacacaceEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeE
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaagagagjliJadagagadadadadadadadadadadadadaaaaaadneTdnaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEgufrjFfrgueEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeE
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaagagagagadadadagagadadadadadadadadadadadadadaaaadneSdnaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEgufrjFfrgueEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeE
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaagagagagagadadadadagagadadadadadadadadadadadadadaadneSdnaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEgufrjFfrgueEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeE
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaagagagagagagagagadadagagadadadadadadadadadadadadaadneSdnaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEgufrjFfrgueEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeE
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaagagagagagagagagagadadagagadadadadadadadadadadadaadneSdnaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEgufrjFfrgueEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeE
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaagagagagagagagagagagazagagadadadadadfufufufufufufufujyfuaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEgufrjFftfqeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeE
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaagagagagagagagagagagadagfufufufufufufulyfxfwfwfwfwfwjHfufuaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEgufrjFfrgueEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeE
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaagagagagagagagagagadadfufufzfzlGfAfBfufwfwfwfwfwfwfwjHfwfufuaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEgufrjFfrgueEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeE
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaagagagagagagagagagadfufufCfDfEfFfGfHfulHfwfIfwfwfwfwjIfwfwfuaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEgufrjFfrgueEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeE
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaagagagagagagagagadfujJjKjXjXjXjXjXjYjXkcknkokDkEkckGfufufufuaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEgufrjFfrgueEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeE
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaagagagadadadaLadadfufwfUfwfwfwfwfwfufwfwfVfwfZgDfwfwfufwfxfufufuaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEgufrjFfrgueEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeE
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaagagadadadadadfXfYfugagbgcgdgdhUfwgffwfwfwfwfwfwfwfwgffwfwggfwfufufuaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEgufrjFfrgueEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeE
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaadadadaLadadghgigjgkgliTgdgdgefwfufwfwfwfwfwfwgngnfulHfwggfwfwfwfuaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEgufrjFfrgueEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeE
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaadadadadadadgogpfugqfUfwgdgdjhfwfufufufufufufufufufufwfwgrjxfwfwfufuaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeEeEeEeEeEeEeEeEeEeEeEeEeEgsgtgugvkHgxgueEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeE
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaadadadadadadaLagfufwgygzgzgzgzgzgAgzgBgzgzgzgCjigEfwfwfwggfwfwjxfwfuagagagagaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeEeEeEeEeEeEeEeEeEeEeEhSeEidgGgHiekJfrgueEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeE
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaadadaLadadadagagfugKgLfwfwfwfwfwfufwgMfwfwhgfufwgNfwfwfwgOgPgPgPgPfuagagagagagagaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeEeEeEeEeEeEeEeEeEeEeEeEeEgQgRgugSkRfrgueEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeE
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaadadadadagagagfufufufufufufufufufwgMfwfwfwfugmgNfwfwfwggfwfwfwgUfuagagagagagagagaaaaaaaaaaaaaaaaaaaaaaaaaaaaeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEgufrkUftgueEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEhTeEeEeEeEeEeEeEeEeEeEeEeE
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaadadadadagagagagagagfufwfwfwfxfwfwgMfwfwfwfufwgNfwfwfwgWfwfwfwgUgUbbcscscscsagagagagagaaaaaaaaaaaaaaaaaaaaaaeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEgufrkUfrgueEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeE
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaadadadadagagagagagfufugXfwiffwfwgMfwfwfwfugYgZhafwfwggfwiffwgUfuagagagagcsagagagagagagaaaaaaaaaaaaaaaaaaaaeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEgufrkUfrgueEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeE
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaadaLadadadagagagagfufufwfwfwfwgMfwfwfwfufwfwfwfwfwgOgPgPgPgPfuagagagagcsjzcscscTcTcTaaaaaaaaaaaaaaaaaaaaeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEgufrkVlKfqeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeE
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaagadadadadadagagagagfujojpjqhehfgcfwfwgffwfwfwfwfwgrjxfwfwhgfuagagagagagagagcsagagagagaaaaaaaaaaaaaaaaaaeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEgufrhhfrgueEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEhihjiOhieEeEeEeEeEeEeEeEeEeEeEeEeEeEeE
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaagagagagadadadadagagagfufufwfwfwfwfwfwfwfugPhlhmhlgPhnfwfwfwfufuagagagagagagaghwagagagagagaaaaaaaaaaaaaaaaeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEgufrhhfrgueEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEhihohphieEeEeEeEeEeEeEeEeEeEeEeEeEeEeE
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaagagagagagadadadagagagagfufujrjsjtfwfwhgfufwfwggjxfwggfwfufufuagagagagagagagagagagagagagagagaaaaaaaaaaaaaaeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEfqhqhhfrgueEeEeEeEeEeEeEeEgugugugugugugugueEeEeEeEeEhiiPhshieEeEeEeEeEeEeEeEeEeEeEeEeEeEeE
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaagagagagagagadaLagagagagagfufufwfwfwfwfwfufwjxggfwjxfufufuagagagagagagagagagagadagadadadagagaaaaaaaaaaaaaaeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEgufrhhfrgueEeEeEeEeEeEeEeEgulzfrfrfrhthugueEeEeEeEeEhihihvhieEeEeEeEeEeEeEeEeEeEeEeEeEeEeE
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaagagagagagagadadagagagagagagfufujujdjejffujxgXggfufufuagagagadadadadadadigagagadagaLadadadagagaaaaaaaaaaaaeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEgufrhhfrgugugugugufqguguguguhxhyhzhAhBhCgugufqguguguhiiLiQhifqeEeEeEeEeEeEeEeEeEeEeEeEeEeE
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaagagagagagagadadadagagagagagagfufufufufufufufufufuagagagagadadadagagagagagagagadagagagadadadagaaaaaaaaaaaaeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEgufrhFhGhGhGhGhGhGhHhGhGhGhGhIhJhJhJhJhJhJhJhKhJhLhJhJhJhMfrgueEeEeEeEeEeEeEeEeEeEeEeEeEeE
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaagagagagagadadadagagagagagagagagagagagagagagagagagadadadadagagagagagagagagadadadadadadadagaaaaaaaaaaaaeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEgufrhNhOhOhOhOhOhOhOhOhOhOhOhOhOhOhOhOhOhOhOhOhOhPfrfrfrfrfrgueEeEeEeEeEeEeEeEeEeEeEeEeEeE
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaagagagagagadadadadagagagagagagagagagagadadadadadadadadagagagcoiRadagagagadagagagadadagagaaaaaaaaaaaaeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEguhQfrfrfrfrfrfrfrfrfrfrfrfrfrfrfrfrfrfrfrfrfrfrhRfrfrfrfrfrgueEeEeEeEeEeEeEeEeEeEeEeEeEeE
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaagagagagagadadadadagagagagagagagagadadadadadadadadagagagagagagadadagagadagagagadadagagaaaaaaaaaaaaeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEfqfqgugugugugugugugugugugugugugugugugugugugugugugugugugugugugueEeEeEeEeEeEeEeEeEeEeEeEeEeE
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaagagagagagadadadadadagagagagagadadadadagagagagagagadadadagagagadadadadagagagadadagaaaaaaaaaaaaaaeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeE
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaagagagagagagadadadadadadadadadadagagagagadadadadadagadadadadadagagagagagadadagagaaaaaaaaaaaaaaeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeE
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaagagagagagagagadadadadadadaLadagagadadadagagadagagagagagagagagagagagagadadagagaaaaaaaaaaaaaaeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeE
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaagagagagagagagagagagagadadadadagagagagagagadadadadadadiSlLagagagadadadadagaaaaaaaaaaaaaaaaeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeE
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaagagagagagagagagagagadadadadadagagadadadagagagagagagagagagadadadadagagaaaaaaaaaaaaaaaaeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeE
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaagagagagagagagagagadadadadadagagagagagagagagagagagadadadadagagagaaaaaaaaaaaaaaaaaaeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeE
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaagagagagagagagagagagadadadadadadadadadadadadadadadadagagagaaaaaaaaaaaaaaaaaaaaeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeE
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaagagagagagagagagagagadadadadadadadadadadadagagagagagaaaaaaaaaaaaaaaaaaaaaaeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeE
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaagagagagagagagagagagagagagagagagaaaaaaaaaaaaaaaaaaaaaaaaaaeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeE
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaagagagagagagagagagagaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeE
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaagagagagagagaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeE
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeE
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeE
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeE
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeE
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeE
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeE
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeE
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeE
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeE
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeE
-iiaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeE
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ii
+"}
+(2,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(3,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(4,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(5,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(6,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ag
+ag
+ag
+ag
+ag
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ad
+ad
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(7,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+ag
+ag
+cl
+ad
+ad
+ag
+ag
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ad
+ag
+ag
+ag
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(8,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+ag
+ad
+cq
+aL
+ad
+ag
+ag
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ad
+ag
+ag
+ag
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(9,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+ag
+ag
+ad
+ad
+ad
+ad
+aa
+aa
+aa
+aa
+aa
+ag
+ag
+ag
+ag
+aa
+aa
+aa
+aa
+aa
+ad
+ad
+ag
+ad
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(10,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ag
+ag
+ag
+ad
+aa
+aa
+aa
+aa
+aa
+aa
+ag
+ag
+ag
+ag
+ag
+ag
+aa
+aa
+aa
+ad
+ad
+ad
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(11,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ag
+ag
+aa
+aa
+aa
+aa
+aa
+aa
+ag
+ag
+ag
+ad
+ad
+ag
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(12,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ad
+ag
+ad
+ad
+ag
+ag
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(13,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ag
+ag
+ag
+aa
+aa
+aa
+ad
+ad
+ag
+ag
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(14,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ad
+lM
+ag
+aa
+aa
+aa
+ad
+ad
+ag
+ag
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(15,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ad
+aa
+aa
+aa
+aa
+aa
+ad
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(16,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(17,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ag
+ag
+ag
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(18,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ag
+ag
+ag
+ag
+ag
+ag
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(19,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ad
+ag
+ag
+ag
+aa
+ad
+ad
+ad
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ad
+ag
+ag
+ir
+kf
+ag
+ag
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(20,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ag
+ag
+ag
+ag
+ag
+ag
+ad
+ad
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ad
+ad
+iV
+kh
+ag
+ag
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(21,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ag
+ag
+ag
+ag
+ag
+ag
+ad
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ad
+ad
+ad
+li
+ag
+ag
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(22,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ag
+ag
+ag
+ag
+lM
+ad
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ad
+ad
+ad
+ag
+ag
+ag
+ag
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(23,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ad
+ad
+ad
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ad
+ag
+ag
+ag
+ag
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(24,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ad
+ag
+ag
+ag
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(25,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ag
+ag
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(26,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+ad
+ad
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aF
+aF
+aF
+aF
+aF
+aF
+aF
+aF
+aF
+aF
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ad
+ad
+ad
+ad
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(27,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+ad
+ad
+ad
+ad
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ad
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aG
+aJ
+aJ
+aJ
+aJ
+aJ
+aJ
+aJ
+aJ
+aF
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(28,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+ad
+ad
+lM
+ad
+ad
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ag
+ag
+ag
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aG
+aJ
+bc
+bc
+bc
+bc
+bc
+bc
+aJ
+aF
+ag
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ad
+ad
+ad
+ad
+ad
+aL
+ad
+ad
+ad
+aa
+aa
+ag
+ag
+ag
+ag
+ag
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(29,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+ad
+ad
+ad
+ad
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+lM
+ag
+ag
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aB
+aB
+aG
+aK
+aW
+bd
+bz
+bG
+bz
+bG
+bT
+aF
+ag
+ag
+ag
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ag
+jl
+ad
+ad
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ad
+ad
+aL
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ag
+ag
+ag
+ag
+ag
+ag
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(30,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ad
+ag
+ag
+ag
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aB
+aE
+aH
+aJ
+aX
+cQ
+cQ
+aX
+cQ
+aX
+bU
+aF
+ag
+ag
+ag
+ag
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ag
+iJ
+ad
+ad
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+aL
+ad
+ag
+ag
+ag
+ag
+ag
+ag
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(31,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ad
+ag
+ag
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aB
+aE
+aI
+aJ
+aX
+bk
+bk
+aX
+bk
+aX
+aJ
+aF
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ag
+ad
+ad
+ad
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+aL
+ad
+ad
+ad
+ad
+ad
+ag
+ag
+ad
+ad
+ad
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(32,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aB
+aE
+aG
+aM
+aX
+bl
+bB
+bH
+bQ
+aX
+bV
+aF
+ag
+ag
+ay
+jw
+jw
+ag
+ag
+ag
+ag
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ag
+ag
+ag
+ad
+ad
+ag
+ag
+ag
+ag
+ag
+ag
+ad
+fX
+gh
+go
+aL
+ag
+ag
+ag
+ag
+ad
+ad
+ad
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(33,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ag
+ag
+ag
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ac
+aB
+aE
+aG
+aO
+aX
+bk
+aX
+aX
+aX
+aX
+bW
+aF
+ag
+ay
+ad
+jj
+ad
+ad
+ad
+ag
+ag
+ag
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ad
+ag
+ag
+ag
+ag
+ad
+ad
+ag
+ag
+ad
+ad
+ad
+ad
+fY
+gi
+gp
+ag
+ag
+ag
+ag
+ag
+ad
+ad
+ad
+ad
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(34,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ad
+ag
+ad
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ac
+aB
+aE
+aG
+aU
+aY
+bm
+bC
+bO
+aJ
+aJ
+bX
+aF
+ag
+ay
+ad
+ad
+cM
+ad
+ad
+ag
+ag
+ag
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ad
+ad
+ad
+ad
+ag
+ag
+ad
+az
+ad
+ad
+fu
+fu
+fu
+fu
+gj
+fu
+fu
+fu
+fu
+ag
+ag
+ag
+ad
+ad
+ad
+ad
+ad
+ad
+ag
+ag
+ag
+ag
+ag
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(35,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ad
+ad
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ac
+ac
+aB
+aE
+aG
+aG
+aG
+bn
+bD
+aF
+aF
+aF
+aB
+aB
+ag
+hd
+iW
+ad
+ad
+ad
+ad
+aL
+ag
+ag
+ag
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ad
+ad
+ad
+ad
+ad
+ag
+ag
+ag
+ag
+fu
+fu
+jJ
+fw
+ga
+gk
+gq
+fw
+gK
+fu
+ag
+ag
+ag
+ag
+ad
+ad
+aL
+ad
+ad
+ad
+ag
+ag
+ag
+ag
+ag
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(36,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ac
+ac
+ac
+aB
+aE
+aN
+aE
+aE
+bu
+aE
+aE
+aE
+cz
+cD
+aB
+ag
+hd
+ad
+ad
+jm
+ad
+iW
+aL
+ag
+ag
+ag
+ad
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ad
+ad
+ad
+ad
+ad
+ad
+ag
+ag
+fu
+fu
+fC
+jK
+fU
+gb
+gl
+fU
+gy
+gL
+fu
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ad
+ad
+ad
+ag
+ag
+ag
+ag
+ag
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(37,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ac
+ac
+ac
+aB
+ct
+cC
+cG
+aZ
+bv
+bo
+bo
+bo
+bo
+aE
+aB
+ag
+hd
+jk
+jg
+aA
+ad
+ad
+ad
+ad
+ag
+ag
+ag
+ad
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+fu
+fz
+fD
+jX
+fw
+gc
+iT
+fw
+gz
+fw
+fu
+fu
+fu
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ad
+ad
+ad
+ag
+ag
+ag
+ag
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(38,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ac
+ac
+ac
+aB
+aV
+Ob
+Ob
+bE
+bw
+bE
+bE
+bE
+bR
+aE
+aB
+ag
+ad
+ad
+ad
+aL
+ad
+jn
+ad
+ad
+ag
+ag
+ag
+ag
+ad
+ad
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+fu
+fz
+fE
+jX
+fw
+gd
+gd
+gd
+gz
+fw
+fu
+fw
+fu
+fu
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ad
+ad
+ad
+ag
+ag
+ag
+ag
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(39,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ac
+ac
+ac
+aB
+cA
+aP
+aE
+aE
+bu
+aE
+aE
+aE
+bS
+bY
+aB
+ag
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ay
+ag
+ag
+ag
+ag
+az
+ag
+ag
+ad
+ad
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+fu
+lG
+fF
+jX
+fw
+gd
+gd
+gd
+gz
+fw
+fu
+fw
+gX
+fu
+fu
+fu
+ag
+ag
+ag
+ag
+ag
+ad
+ad
+ad
+ag
+ag
+ag
+ag
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(40,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ac
+ac
+ac
+ac
+aB
+cA
+aP
+aP
+aP
+bx
+ca
+aB
+aB
+aB
+aB
+aB
+ag
+ad
+cM
+ad
+jk
+ad
+cM
+ay
+ag
+ag
+ag
+ag
+ag
+ad
+ag
+ag
+ag
+ad
+ad
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+fu
+fA
+fG
+jX
+fw
+hU
+ge
+jh
+gz
+fw
+fu
+fw
+fw
+fw
+jo
+fu
+fu
+ag
+ag
+ag
+ag
+ag
+ad
+ad
+ad
+ag
+ag
+ag
+ag
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(41,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ab
+ab
+ab
+ac
+ac
+aB
+cA
+aQ
+be
+bp
+by
+bF
+bP
+cu
+aT
+ag
+ag
+ag
+ad
+ad
+ad
+ad
+ad
+ad
+ay
+ag
+ag
+ag
+ag
+ad
+ad
+ag
+ag
+ag
+ag
+ag
+ad
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+fu
+fB
+fH
+jX
+fw
+fw
+fw
+fw
+gz
+fw
+fu
+fx
+if
+fw
+jp
+fw
+fu
+fu
+ag
+ag
+ag
+ag
+ag
+ad
+ad
+ag
+ag
+ag
+ag
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(42,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ac
+ac
+lS
+ac
+ac
+aB
+cA
+aQ
+bf
+bq
+bI
+cc
+bq
+cv
+aT
+ag
+ag
+ag
+ad
+ad
+ad
+ad
+ad
+ag
+ag
+ag
+ag
+ag
+ad
+ad
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ad
+ad
+ad
+ad
+ad
+ad
+fu
+fu
+fu
+fu
+jY
+fu
+gf
+fu
+fu
+gA
+fu
+fu
+fw
+fw
+fw
+jq
+fw
+jr
+fu
+fu
+ag
+ag
+ag
+ag
+ad
+ad
+ad
+ag
+ag
+ag
+ag
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(43,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ac
+ac
+lS
+ac
+ac
+aB
+cA
+aQ
+bg
+bq
+bJ
+bJ
+bq
+cw
+aT
+ag
+ag
+ag
+ag
+az
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ad
+ad
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ad
+ad
+ad
+ad
+ad
+ad
+fu
+ly
+fw
+lH
+jX
+fw
+fw
+fw
+fu
+gz
+fw
+fw
+fw
+fw
+fw
+he
+fw
+js
+fw
+fu
+fu
+ag
+ag
+ag
+ag
+ad
+ad
+ag
+ag
+ag
+ag
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(44,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ab
+ac
+ac
+ab
+ac
+ac
+aB
+cA
+aR
+bh
+bq
+bK
+cd
+bq
+bh
+aT
+ag
+ag
+ag
+ag
+ad
+ag
+ag
+ag
+ad
+ad
+ad
+az
+ad
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ad
+ad
+ad
+ad
+ad
+ad
+fu
+fx
+fw
+fw
+kc
+fw
+fw
+fw
+fu
+gB
+gM
+gM
+gM
+gM
+gM
+hf
+fw
+jt
+fw
+ju
+fu
+ag
+ag
+ag
+ag
+ad
+ad
+ag
+ag
+ag
+ag
+ag
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(45,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ab
+ac
+ac
+ab
+ac
+ac
+aB
+cA
+aS
+bh
+bq
+bL
+ce
+bq
+cx
+aT
+ag
+ag
+ag
+ag
+ad
+ad
+ad
+ad
+ad
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ad
+ad
+ad
+ad
+ad
+fu
+fw
+fw
+fI
+kn
+fV
+fw
+fw
+fu
+gz
+fw
+fw
+fw
+fw
+fw
+gc
+fw
+fw
+fw
+jd
+fu
+ag
+ag
+ag
+ag
+ad
+ad
+ag
+ag
+ag
+ag
+ag
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(46,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ab
+ac
+ac
+ab
+ac
+ac
+aB
+cA
+aQ
+bi
+br
+bM
+cf
+cm
+cy
+aT
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+cF
+cF
+cF
+cF
+cF
+cF
+cF
+cF
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ad
+ad
+ad
+ad
+fu
+fw
+fw
+fw
+ko
+fw
+fw
+fw
+fu
+gz
+fw
+fw
+fw
+fw
+fw
+fw
+fw
+fw
+fw
+je
+fu
+ag
+ag
+ag
+ag
+ad
+ad
+ag
+ag
+ag
+ag
+ag
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(47,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ab
+ac
+ac
+ab
+ac
+ac
+aB
+cA
+aQ
+bh
+bs
+bN
+cg
+cn
+bh
+aT
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+cF
+cF
+dh
+jD
+ez
+jD
+jD
+kd
+cF
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+dn
+dn
+dn
+dn
+dn
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ad
+ad
+ad
+fu
+fw
+fw
+fw
+kD
+fZ
+fw
+fw
+fu
+gz
+hg
+fw
+fw
+fw
+fw
+fw
+fw
+hg
+fw
+jf
+fu
+ag
+ag
+ag
+ag
+ad
+ad
+ad
+ag
+ag
+ag
+ag
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(48,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ac
+ac
+ac
+ab
+ac
+ac
+aB
+cA
+aQ
+bh
+bh
+bh
+bh
+bh
+bh
+aT
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+cF
+cF
+dh
+dh
+jD
+eA
+jD
+ka
+jD
+cF
+cF
+cF
+ag
+ag
+ag
+ag
+ag
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+dn
+dn
+en
+fj
+iZ
+dn
+dn
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+fu
+fw
+fw
+fw
+kE
+gD
+fw
+fw
+fu
+gC
+fu
+fu
+fu
+fu
+fu
+gf
+fu
+fu
+fu
+fu
+fu
+ag
+ag
+ag
+ad
+ad
+aL
+ad
+ad
+ag
+ag
+ag
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(49,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ac
+ac
+ac
+ac
+ab
+ac
+ac
+aB
+cA
+aT
+aT
+aT
+aT
+aT
+aT
+aT
+aT
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+cF
+cZ
+cZ
+jD
+jD
+eB
+jD
+dh
+ke
+jD
+jD
+cF
+dn
+dn
+dn
+dn
+dn
+ia
+ia
+ia
+ia
+ia
+ia
+ia
+ia
+dn
+ib
+ee
+fp
+ee
+ee
+dn
+ia
+ia
+ia
+ia
+ia
+ia
+ia
+dn
+dn
+dn
+dn
+dn
+fu
+fw
+fw
+fw
+kc
+fw
+fw
+gn
+fu
+ji
+fw
+gm
+fw
+gY
+fw
+fw
+gP
+fw
+fw
+jx
+fu
+ag
+ag
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ag
+ag
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(50,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ac
+ac
+ac
+ac
+ab
+ac
+ac
+aB
+cB
+cE
+cE
+cE
+cV
+aP
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+cF
+cF
+cZ
+di
+cb
+ey
+eC
+ey
+eF
+eK
+ey
+eO
+eR
+eS
+eS
+eS
+eS
+eS
+eS
+eT
+eS
+eS
+eS
+eS
+eS
+eS
+fd
+eS
+fi
+fs
+fi
+eS
+fd
+eS
+eS
+eS
+eS
+eS
+eS
+eS
+eT
+eS
+eS
+eS
+eS
+jy
+jH
+jH
+jI
+kG
+fw
+fw
+gn
+fu
+gE
+gN
+gN
+gN
+gZ
+fw
+fw
+hl
+fw
+jx
+gX
+fu
+ag
+ad
+ad
+ad
+ag
+ag
+ad
+ad
+ad
+ag
+ag
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(51,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ac
+ac
+ac
+ac
+ab
+ac
+ac
+aB
+aE
+aE
+aE
+aE
+cA
+aP
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+cF
+cF
+dc
+cZ
+dh
+dW
+jD
+jD
+jD
+jD
+kg
+jD
+jD
+cF
+dn
+dn
+ia
+ia
+ia
+ia
+dn
+ia
+ia
+ia
+ia
+ia
+ia
+dn
+ef
+ep
+fv
+eI
+ee
+dn
+ia
+ia
+ia
+ia
+ia
+ia
+ia
+dn
+dn
+dn
+dn
+dn
+fu
+fu
+fw
+fw
+fu
+fu
+gf
+fu
+fu
+fw
+fw
+fw
+fw
+ha
+fw
+fw
+hm
+gg
+gg
+gg
+fu
+ag
+ad
+ad
+ad
+ag
+ag
+ag
+ad
+ad
+ag
+ag
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(52,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ac
+ac
+ac
+ac
+lS
+ac
+ac
+aB
+aB
+aB
+aB
+aB
+cA
+aB
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+cF
+cF
+cZ
+jv
+cZ
+dh
+dW
+jD
+ka
+jD
+ka
+jD
+jD
+jD
+cF
+ac
+ac
+ab
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+dn
+dn
+ee
+fy
+eJ
+dn
+dn
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+fu
+fu
+fw
+fu
+fw
+fw
+lH
+fw
+fw
+fw
+fw
+fw
+fw
+fw
+fw
+hl
+jx
+fw
+fu
+fu
+ag
+ad
+ad
+ag
+ag
+ad
+ag
+ad
+ad
+ad
+ag
+ag
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(53,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ac
+ac
+ac
+ac
+lS
+ac
+ac
+ac
+ac
+ac
+ac
+aB
+cW
+aB
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+cF
+cU
+cZ
+cZ
+cZ
+dh
+dW
+jD
+dh
+jD
+dh
+jD
+jD
+ki
+cF
+ac
+ab
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+dn
+dn
+fJ
+dn
+dn
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+fu
+fu
+fu
+fx
+fw
+fw
+fw
+fw
+fw
+fw
+fw
+fw
+fw
+fw
+gP
+fw
+jx
+fu
+ag
+ag
+ad
+ad
+ag
+ag
+ad
+ag
+ag
+ad
+ad
+ag
+ag
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(54,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ac
+ac
+ac
+ab
+ab
+ab
+ab
+ab
+ab
+ac
+ac
+aB
+cA
+aB
+ag
+ag
+ag
+ag
+ag
+ag
+cF
+cF
+db
+cZ
+cZ
+cZ
+dj
+dW
+jD
+kb
+jD
+kb
+jD
+jD
+kj
+cF
+ac
+ab
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+hZ
+fK
+hZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+fu
+fu
+gg
+gg
+gr
+gg
+gO
+gg
+gW
+gg
+gO
+gr
+hn
+gg
+fu
+fu
+ag
+ag
+ad
+ad
+ag
+ad
+ad
+ag
+ag
+ag
+ad
+ad
+ag
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(55,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ac
+ac
+ab
+lR
+ab
+lT
+ab
+ab
+lR
+ab
+ac
+aB
+cA
+aB
+ag
+ag
+ag
+ag
+ag
+ag
+cF
+cF
+cF
+cF
+dm
+cF
+cF
+dX
+jD
+jD
+jD
+jD
+jD
+jD
+kk
+cF
+ac
+ab
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+hZ
+fK
+hZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+fu
+fw
+fw
+jx
+fw
+gP
+fw
+fw
+fw
+gP
+jx
+fw
+fw
+fu
+ag
+ag
+ad
+ad
+ad
+ag
+ad
+ag
+ag
+ad
+ag
+ad
+ad
+ag
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(56,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ac
+ac
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ac
+aB
+cA
+aB
+ag
+ag
+ag
+ag
+ag
+ag
+cF
+jL
+jP
+jT
+da
+kt
+cF
+dY
+cF
+cF
+jD
+jD
+jD
+jD
+kl
+cF
+ac
+ab
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+hZ
+fK
+hZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+fu
+fu
+fw
+fw
+fw
+gP
+fw
+fw
+if
+gP
+fw
+fw
+fu
+fu
+ag
+ag
+ad
+ad
+ad
+ag
+ad
+ag
+ag
+ad
+ag
+ad
+ad
+ag
+ag
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(57,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ac
+ac
+ab
+ab
+ab
+lU
+ab
+lP
+ab
+ab
+ac
+aB
+cA
+aB
+ag
+ag
+ag
+ag
+ag
+ag
+cF
+cI
+cH
+cH
+cH
+cH
+jA
+dZ
+eG
+cF
+cF
+jD
+jD
+jD
+km
+cF
+ac
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+eb
+eb
+fL
+eb
+eb
+eb
+eb
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+fu
+fw
+fw
+jx
+gP
+fw
+fw
+fw
+gP
+fw
+fw
+fu
+ag
+ag
+ad
+ad
+ad
+ag
+ag
+ad
+ad
+ad
+ad
+ag
+ad
+ad
+ag
+ag
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(58,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ac
+ac
+ab
+ab
+lR
+ab
+ab
+ab
+ab
+ab
+ac
+aB
+cA
+aB
+ag
+ag
+ag
+ag
+ag
+ag
+cF
+jM
+jQ
+jU
+da
+cH
+cL
+ea
+cS
+cH
+cF
+jD
+jD
+jD
+cF
+cF
+ab
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+eb
+eb
+eh
+fM
+fR
+gV
+ja
+eb
+eb
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+fu
+fu
+fu
+fw
+gP
+gU
+gU
+gU
+gP
+hg
+fu
+fu
+ag
+ad
+ad
+ad
+ag
+ag
+ad
+ad
+ag
+ad
+ag
+ag
+ad
+ad
+ag
+ag
+ag
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(59,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ad
+ac
+ac
+ac
+ab
+ab
+lV
+ab
+lR
+ab
+ab
+ac
+aB
+cA
+aB
+ag
+ag
+ag
+ag
+ag
+ag
+cF
+cF
+cF
+cF
+cH
+cH
+jB
+ej
+jB
+cH
+cF
+jD
+jD
+kd
+cF
+ab
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+hZ
+ih
+eg
+fK
+eg
+fP
+jb
+fl
+eb
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+fu
+fu
+fu
+fu
+gU
+fu
+fu
+fu
+fu
+ag
+ag
+ad
+ad
+ag
+ag
+ag
+ad
+ag
+ag
+ad
+ag
+ag
+ad
+ad
+ag
+ag
+ag
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(60,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ad
+ab
+ac
+ac
+ac
+ab
+ab
+ab
+ab
+ab
+ac
+ac
+aB
+cA
+aB
+ag
+ag
+ag
+ag
+ag
+ag
+dk
+dk
+dk
+cF
+cH
+cH
+cH
+eo
+cH
+cH
+dm
+jD
+jD
+ku
+cF
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+hZ
+iX
+eg
+fN
+mN
+hb
+jc
+fm
+eb
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ag
+ag
+ag
+bb
+ag
+ag
+ag
+ag
+ag
+ag
+ad
+ag
+ag
+ag
+ag
+ad
+ad
+ag
+ad
+ag
+ag
+ad
+ad
+ag
+ag
+ag
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(61,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ad
+ad
+ac
+ac
+ac
+ab
+lN
+ac
+ac
+ac
+ac
+ac
+aB
+cW
+aB
+ag
+ag
+ag
+ag
+ag
+ag
+cF
+cF
+cF
+cF
+cH
+cH
+cF
+dY
+cF
+cF
+cF
+jD
+jD
+cF
+cF
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+hZ
+lw
+eg
+fK
+eg
+fK
+eg
+kw
+hZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ag
+ag
+ag
+cs
+ag
+ag
+ag
+ag
+ag
+ag
+ad
+ag
+ag
+co
+ag
+ag
+ad
+ag
+ad
+ag
+ag
+ad
+ad
+ag
+ag
+ag
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(62,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ad
+ad
+ab
+ac
+ac
+ab
+lO
+ac
+ac
+ac
+ax
+ax
+ax
+cX
+ax
+ax
+ax
+ag
+ag
+ag
+ag
+cF
+jN
+jR
+jV
+da
+cH
+cF
+et
+kp
+kq
+cF
+jD
+cF
+cF
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+eb
+eh
+eq
+fO
+eL
+fK
+ja
+eg
+hZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ag
+ag
+ag
+cs
+ag
+ag
+ag
+ag
+ag
+ag
+ad
+ag
+ag
+iR
+ag
+ag
+ad
+ag
+ad
+ag
+ag
+ad
+ad
+ag
+ag
+ag
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(63,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ad
+ad
+ab
+ac
+ac
+ab
+ab
+ac
+ac
+ax
+ax
+lk
+ll
+cY
+aD
+aD
+ax
+ag
+ag
+ag
+ag
+cF
+cI
+cH
+cH
+cH
+cH
+cF
+eu
+kp
+kp
+cF
+lv
+cF
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+hZ
+iY
+eg
+fP
+eg
+fK
+jb
+eg
+hZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ag
+ag
+ag
+cs
+ag
+ag
+ag
+ag
+ag
+ag
+ad
+ag
+ag
+ad
+ad
+ag
+ad
+ag
+iS
+ag
+ag
+ad
+ad
+ag
+ag
+ag
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(64,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ad
+ad
+ac
+ac
+lS
+ac
+ac
+ax
+ax
+aC
+aD
+lm
+cY
+aD
+aD
+ax
+ax
+ag
+ag
+ag
+cF
+jO
+jS
+jW
+da
+cH
+jC
+eu
+kp
+kr
+cF
+cF
+cF
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+eb
+eb
+eg
+fQ
+eg
+fK
+jc
+eb
+eb
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ag
+ag
+cs
+cs
+cs
+ag
+ag
+ag
+ag
+ig
+ag
+ag
+ag
+ad
+ad
+ad
+ag
+lL
+ag
+ag
+ad
+ad
+ag
+ag
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(65,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ag
+ag
+ac
+ac
+lS
+ac
+ac
+ax
+le
+aD
+aD
+aD
+cY
+aD
+aD
+lq
+ax
+ag
+ag
+ag
+cF
+cF
+cF
+cF
+dm
+cF
+cF
+dY
+cF
+cF
+cF
+cF
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+eb
+eb
+eb
+eb
+fL
+eb
+eb
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ag
+ag
+ag
+ag
+jz
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ad
+ag
+ag
+ag
+ag
+ad
+ad
+ag
+ag
+ag
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(66,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ag
+ag
+ac
+ac
+ab
+ac
+ac
+ax
+le
+aD
+aD
+bt
+dg
+ch
+aD
+lq
+ax
+ag
+ag
+ag
+cF
+ks
+kB
+kB
+cH
+cH
+kN
+ev
+kA
+lu
+df
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+de
+de
+de
+de
+de
+de
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+hZ
+fK
+hZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ag
+ag
+ag
+cs
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ad
+ag
+ag
+ag
+ag
+ad
+ad
+ag
+ag
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(67,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ad
+ag
+ac
+ac
+ab
+ac
+ax
+ax
+lf
+lh
+lh
+lA
+cY
+aD
+aD
+cj
+ax
+ag
+ag
+ag
+cF
+cO
+cH
+cH
+cH
+cH
+kO
+ew
+cH
+cH
+df
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+de
+la
+dp
+dp
+dJ
+de
+de
+aa
+aa
+aa
+aa
+aa
+aa
+hZ
+fK
+hZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ag
+ag
+cs
+cs
+hw
+ag
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ag
+ag
+ag
+ad
+ad
+ad
+ag
+ag
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(68,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ad
+ag
+ag
+ac
+ab
+ac
+ax
+lb
+aD
+cr
+ln
+lB
+cY
+aD
+aD
+aD
+ax
+ax
+ax
+ax
+cF
+cO
+cH
+cH
+cH
+cH
+cH
+eo
+cH
+cH
+df
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+de
+de
+dp
+dD
+dp
+dD
+dp
+de
+aa
+aa
+aa
+aa
+aa
+aa
+hZ
+fK
+hZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ag
+ag
+cT
+ag
+ag
+ag
+ag
+ag
+ag
+ad
+ag
+ag
+ag
+ag
+ag
+ad
+ad
+ad
+ag
+ag
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(69,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ad
+ag
+ag
+ac
+ab
+ac
+ax
+lc
+aD
+aD
+aD
+bj
+dl
+do
+dq
+dq
+dr
+dq
+dq
+dq
+ds
+dt
+dt
+du
+dy
+du
+du
+ex
+cH
+dd
+cF
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+de
+kY
+dp
+dG
+kT
+dG
+kW
+de
+aa
+aa
+aa
+aa
+aa
+aa
+hZ
+fK
+hZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ag
+ag
+cT
+ag
+ag
+ag
+ad
+aL
+ag
+ad
+ag
+ag
+ag
+ag
+ag
+ad
+ad
+ag
+ag
+ag
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(70,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ad
+ag
+ag
+ac
+ab
+ac
+ax
+ld
+aD
+aD
+aD
+cK
+aD
+aD
+aD
+aD
+ax
+ax
+ax
+ax
+cF
+kC
+kC
+kF
+bA
+kL
+cH
+cH
+cH
+cH
+df
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+kX
+kZ
+dp
+dL
+dp
+dL
+dp
+de
+aa
+aa
+aa
+aa
+aa
+aa
+hZ
+fK
+hZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ag
+cT
+ag
+ag
+ag
+ad
+ad
+ag
+ad
+ag
+ag
+ag
+ad
+ad
+ad
+ad
+ag
+ag
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(71,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ad
+ag
+ag
+ac
+ab
+ac
+ax
+lc
+aD
+aD
+aD
+cK
+aD
+aD
+lp
+lp
+ax
+ac
+ac
+ac
+cF
+cP
+cH
+cH
+bZ
+kM
+cH
+cH
+cH
+cH
+de
+ic
+ic
+ic
+ic
+ic
+ic
+ic
+ic
+de
+dp
+dp
+dD
+dC
+dD
+dp
+de
+aa
+aa
+aa
+aa
+aa
+aa
+hZ
+fK
+hZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ag
+ag
+ag
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ag
+ag
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(72,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ad
+ag
+ag
+ag
+ab
+ac
+ax
+ax
+lg
+lg
+lg
+cK
+lg
+lo
+ax
+ax
+ax
+ac
+ac
+ac
+cF
+ky
+cH
+cH
+dE
+du
+du
+du
+du
+du
+eD
+eH
+eH
+eH
+eQ
+eH
+eH
+eH
+eH
+eD
+eH
+eH
+eU
+eV
+dG
+kT
+de
+aa
+aa
+aa
+aa
+aa
+aa
+hZ
+fK
+hZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ag
+ag
+ag
+ad
+ad
+ad
+ad
+ad
+ad
+ag
+ag
+ag
+ag
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(73,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ad
+ag
+ag
+ag
+ad
+ac
+ac
+ax
+ax
+lj
+lr
+cN
+ls
+lt
+ax
+ac
+ac
+ac
+ac
+ac
+cF
+kz
+cH
+cH
+cH
+cH
+cH
+kP
+kQ
+df
+de
+ic
+ic
+ic
+ic
+ic
+ic
+ic
+ic
+de
+dp
+dp
+dL
+eW
+dL
+dM
+de
+aa
+aa
+aa
+aa
+aa
+aa
+hZ
+fK
+hZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ag
+ag
+ag
+ad
+ad
+ag
+ag
+ag
+ag
+ag
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(74,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ag
+ag
+ag
+ad
+ac
+ac
+ac
+ax
+ax
+ax
+ax
+ax
+ax
+ax
+ac
+ac
+ac
+ac
+ac
+cF
+cI
+kB
+cH
+cH
+cH
+cH
+df
+df
+df
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+de
+dp
+dp
+dp
+eX
+dp
+gI
+de
+aa
+aa
+aa
+aa
+aa
+aa
+hZ
+fK
+hZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ag
+ag
+ag
+ag
+ag
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(75,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ag
+ag
+ag
+ad
+ab
+ab
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+cF
+kA
+kA
+kA
+cR
+cH
+df
+df
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+de
+de
+dz
+kS
+eY
+kI
+de
+de
+aa
+aa
+aa
+aa
+aa
+aa
+hZ
+fK
+hZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(76,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ag
+ag
+ag
+ag
+ab
+ab
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+cF
+cF
+cF
+cF
+cF
+df
+df
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+de
+de
+de
+de
+de
+de
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+eb
+hc
+hZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(77,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ag
+ag
+ag
+ag
+ac
+ab
+ab
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+hZ
+fK
+hZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(78,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ad
+ag
+ag
+ag
+ac
+ac
+ab
+ab
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+hZ
+fK
+hZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(79,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ad
+ag
+ag
+ag
+ac
+ac
+ac
+ab
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+hZ
+fK
+hZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(80,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ag
+ag
+ag
+ag
+ac
+ac
+ab
+ab
+ab
+lS
+lS
+ab
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+hZ
+fK
+hZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(81,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ad
+ad
+ag
+ag
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ab
+ab
+ac
+ac
+ac
+ac
+ac
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+hZ
+fK
+eb
+ac
+ac
+aa
+aa
+aa
+aa
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+"}
+(82,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ag
+ag
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ab
+ac
+ac
+ac
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ad
+ad
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ac
+eb
+fK
+eb
+ac
+ac
+aa
+aa
+aa
+aa
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+"}
+(83,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ag
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ad
+ac
+ac
+aa
+aa
+aa
+aa
+aa
+aa
+ag
+ag
+ad
+ad
+aa
+aa
+aa
+aa
+ad
+ag
+ad
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ac
+eb
+fK
+eb
+ac
+ac
+ac
+aa
+aa
+aa
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+"}
+(84,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ag
+ag
+ag
+ag
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ag
+ag
+ag
+ag
+aa
+aa
+aa
+aa
+ag
+ag
+ag
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ac
+eb
+fK
+eb
+ac
+ac
+ac
+ac
+aa
+aa
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+"}
+(85,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ag
+ag
+aa
+aa
+aa
+aa
+aa
+aa
+ag
+ag
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ac
+eb
+hc
+eb
+ac
+ac
+ac
+ac
+aa
+aa
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+"}
+(86,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+hZ
+fK
+eb
+ac
+ac
+ac
+ac
+ac
+aa
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+"}
+(87,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+hZ
+fK
+eb
+ac
+ac
+ac
+ac
+ac
+ac
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+"}
+(88,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+hZ
+fK
+eb
+ac
+ac
+ac
+ac
+ac
+ac
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+"}
+(89,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ag
+ag
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ag
+ag
+ag
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+dN
+dO
+dO
+dN
+dO
+dN
+hk
+dN
+ac
+ac
+ac
+ac
+ac
+ac
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+"}
+(90,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ag
+ag
+ag
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ag
+ag
+lQ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ab
+ab
+dN
+dO
+dO
+dN
+kv
+dR
+er
+dR
+dR
+hV
+dN
+ac
+ac
+ac
+ac
+ac
+ac
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+"}
+(91,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ag
+ag
+ag
+ag
+ad
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ad
+ad
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ab
+ab
+ab
+dO
+dR
+iF
+dV
+ec
+dR
+dR
+dR
+dR
+hW
+dN
+dN
+dN
+ac
+ac
+ac
+ac
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+"}
+(92,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ag
+ad
+ad
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ab
+ab
+ab
+dO
+dR
+iG
+dR
+ei
+dR
+dR
+dR
+dR
+hV
+dR
+kx
+dN
+ac
+ac
+ac
+ac
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+hS
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+"}
+(93,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ad
+ag
+ag
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ab
+ab
+ab
+ab
+dO
+dR
+iH
+dR
+ec
+ek
+cp
+io
+iy
+hX
+iu
+iv
+dN
+ac
+ac
+ac
+ac
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+"}
+(94,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ad
+aa
+aa
+aa
+ad
+aa
+ad
+lW
+ag
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+dO
+dR
+dR
+dR
+ei
+es
+ik
+ik
+ik
+hY
+dR
+dR
+dN
+ac
+ac
+ac
+ac
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+gs
+id
+gQ
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+"}
+(95,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+dO
+dR
+iF
+dR
+ec
+eM
+il
+il
+iq
+ij
+dR
+lF
+dN
+ac
+ac
+ac
+ac
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+gt
+gG
+gR
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+"}
+(96,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ad
+ag
+aa
+aa
+aa
+aa
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+dO
+dR
+iG
+dR
+ec
+fa
+im
+im
+im
+in
+dR
+dR
+dN
+fq
+fq
+fq
+fq
+gu
+gu
+gu
+gu
+gu
+gu
+gu
+gu
+gu
+gu
+gu
+gu
+gu
+gu
+gu
+gH
+gu
+gu
+gu
+gu
+gu
+gu
+gu
+fq
+gu
+gu
+gu
+gu
+gu
+fq
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+"}
+(97,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ag
+ag
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ag
+ag
+aa
+aa
+aa
+aa
+aa
+ab
+ab
+ab
+dv
+dv
+dv
+dv
+dv
+dS
+iH
+dR
+ec
+fb
+ik
+iI
+ik
+hY
+dR
+dR
+fo
+fr
+fr
+fr
+fr
+fr
+fr
+fr
+fr
+fr
+fr
+fr
+fr
+fr
+fr
+fr
+fr
+fr
+fr
+gv
+ie
+gS
+fr
+fr
+fr
+fr
+fr
+fr
+hq
+fr
+fr
+fr
+fr
+hQ
+fq
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+"}
+(98,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ag
+ag
+ag
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ab
+ab
+ab
+dw
+dA
+dH
+dv
+dP
+dR
+dR
+dR
+ec
+mu
+mw
+mM
+mO
+ck
+ix
+ix
+jE
+jF
+jF
+jF
+jF
+jF
+jF
+jF
+jF
+jF
+jF
+jF
+jF
+jF
+jF
+jF
+jF
+jF
+jF
+kH
+kJ
+kR
+kU
+kU
+kU
+kV
+hh
+hh
+hh
+hh
+hh
+hF
+hN
+fr
+gu
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+"}
+(99,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ag
+ag
+ag
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ab
+ab
+ab
+ab
+dx
+dB
+dI
+dK
+dQ
+dT
+dT
+dT
+dT
+dT
+dT
+dT
+eN
+hV
+dR
+dR
+fo
+fr
+fr
+ft
+fr
+fr
+fr
+fr
+fr
+fr
+fr
+ft
+fr
+fr
+fr
+fr
+fr
+fr
+fr
+gx
+fr
+fr
+ft
+fr
+fr
+lK
+fr
+fr
+fr
+fr
+fr
+hG
+hO
+fr
+gu
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+"}
+(100,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ak
+aa
+aa
+aa
+ak
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ag
+ag
+fW
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ab
+ab
+ab
+ab
+dv
+dv
+dv
+dv
+dv
+dR
+dR
+dR
+dR
+dR
+dR
+dR
+dR
+hV
+dR
+dR
+dN
+fq
+fq
+fq
+fq
+fq
+gu
+gu
+gu
+gu
+gu
+fq
+gu
+gu
+gu
+gu
+gu
+gu
+gu
+gu
+gu
+gu
+gu
+gu
+gu
+fq
+gu
+gu
+gu
+gu
+gu
+hG
+hO
+fr
+gu
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+"}
+(101,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+af
+ae
+aa
+ae
+ai
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ag
+ag
+ad
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+dO
+ip
+dR
+dR
+dR
+iF
+dR
+iF
+dR
+hV
+dR
+dR
+dN
+ac
+ac
+ac
+ac
+ac
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+gu
+hG
+hO
+fr
+gu
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+"}
+(102,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ai
+ai
+ae
+ae
+ae
+ai
+ai
+ae
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+dO
+iC
+dR
+dR
+dR
+iG
+dR
+iG
+dR
+hV
+dR
+dF
+dN
+ac
+ac
+ac
+ac
+ac
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+gu
+hG
+hO
+fr
+gu
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+"}
+(103,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ae
+ai
+ah
+as
+au
+ah
+ah
+ai
+ae
+ae
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+dO
+iD
+dR
+ci
+fg
+fh
+fg
+fh
+fg
+is
+dR
+dN
+dN
+ac
+ac
+ac
+ac
+ac
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+gu
+hG
+hO
+fr
+gu
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+"}
+(104,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ae
+ae
+ah
+ah
+at
+ap
+ap
+ah
+ah
+ae
+ae
+ae
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ad
+ag
+ag
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ab
+ab
+ab
+ac
+ac
+ac
+ac
+ac
+ac
+dN
+iE
+dU
+fc
+dR
+dR
+dR
+dR
+ci
+it
+dR
+dN
+ac
+ac
+ac
+ac
+ac
+ac
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+gu
+hG
+hO
+fr
+gu
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+"}
+(105,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ae
+ah
+ah
+ao
+ba
+ap
+ai
+kK
+ah
+ah
+ai
+ae
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ad
+ag
+ag
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ab
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+dN
+dN
+dN
+dN
+dR
+dR
+dU
+dR
+fS
+ne
+lx
+dN
+ac
+ac
+ac
+ac
+ac
+ac
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+fq
+hH
+hO
+fr
+gu
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+"}
+(106,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ae
+ah
+al
+ap
+ap
+ap
+ap
+ap
+ap
+ah
+ae
+ai
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ag
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+dN
+dN
+dN
+dN
+dN
+fT
+dN
+dN
+dN
+ac
+ac
+ac
+ac
+ac
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+gu
+hG
+hO
+fr
+gu
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+"}
+(107,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ae
+ah
+am
+aq
+ap
+ap
+ap
+ap
+ai
+au
+ai
+ai
+ak
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ed
+gw
+ed
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+gu
+hG
+hO
+fr
+gu
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+"}
+(108,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ae
+ah
+an
+ap
+eZ
+ai
+ai
+ai
+ap
+ah
+ae
+ai
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ed
+gw
+ed
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+gu
+hG
+hO
+fr
+gu
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+"}
+(109,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ae
+ah
+ah
+ar
+ap
+ap
+ae
+lJ
+ah
+ah
+ai
+ae
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ed
+ed
+ed
+ed
+gJ
+ed
+ed
+ed
+ed
+ac
+ac
+ac
+ac
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+gu
+gu
+gu
+hG
+hO
+fr
+gu
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+"}
+(110,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ae
+ai
+ah
+ah
+av
+cJ
+aw
+ah
+ah
+ai
+ae
+ae
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ed
+el
+iU
+em
+gT
+iw
+iz
+fn
+ed
+ac
+ac
+ac
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+gu
+lz
+hx
+hI
+hO
+fr
+gu
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+"}
+(111,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aj
+aj
+ah
+ah
+ah
+ah
+ah
+aj
+aj
+ae
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ed
+eP
+em
+lD
+mT
+ff
+iB
+hr
+ed
+ac
+ac
+ac
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+gu
+fr
+hy
+hJ
+hO
+fr
+gu
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+"}
+(112,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aj
+aj
+aj
+aj
+aj
+aj
+aj
+aj
+aj
+aj
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ed
+gF
+em
+em
+em
+nf
+iK
+hE
+ed
+ac
+ac
+ac
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+gu
+fr
+hz
+hJ
+hO
+fr
+gu
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+"}
+(113,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aj
+aj
+aj
+aj
+aj
+aj
+aj
+aj
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ed
+lC
+iA
+fe
+fk
+hD
+iM
+iN
+ed
+ac
+ac
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+gu
+fr
+hA
+hJ
+hO
+fr
+gu
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+"}
+(114,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ac
+ac
+ac
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ed
+ac
+ac
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+gu
+ht
+hB
+hJ
+hO
+fr
+gu
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+"}
+(115,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+aa
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+gu
+hu
+hC
+hJ
+hO
+fr
+gu
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+"}
+(116,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+aa
+aa
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+gu
+gu
+gu
+hJ
+hO
+fr
+gu
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+"}
+(117,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ac
+ac
+ac
+ac
+ac
+aa
+aa
+aa
+aa
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+gu
+hJ
+hO
+fr
+gu
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+"}
+(118,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+fq
+hK
+hO
+fr
+gu
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+"}
+(119,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+gu
+hJ
+hO
+fr
+gu
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+"}
+(120,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+gu
+hL
+hP
+hR
+gu
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+"}
+(121,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+gu
+hJ
+fr
+fr
+gu
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+"}
+(122,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+hi
+hi
+hi
+hi
+hi
+hJ
+fr
+fr
+gu
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+"}
+(123,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+hj
+ho
+iP
+hi
+iL
+hJ
+fr
+fr
+gu
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+"}
+(124,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+iO
+hp
+hs
+hv
+iQ
+hM
+fr
+fr
+gu
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+"}
+(125,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+hi
+hi
+hi
+hi
+hi
+fr
+fr
+fr
+gu
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+"}
+(126,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+fq
+gu
+gu
+gu
+gu
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+"}
+(127,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+"}
+(128,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+hT
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+"}
+(129,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+"}
+(130,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+"}
+(131,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+"}
+(132,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+"}
+(133,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+"}
+(134,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+"}
+(135,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+"}
+(136,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+"}
+(137,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+"}
+(138,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+"}
+(139,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+"}
+(140,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
+eE
 "}


### PR DESCRIPTION
Removes broken objects.
Balancing changes to mercs.
Security Mercs don't murder the wolfgirls anymore.
Replaced glass windows with metal walls in areas with mercs.
Tweaked teleporter setup so it's completeable. Teleporter still needs more tweaking.
Fixes airlock permissions in different areas.