### PR TITLE
Move some things NT wouldn't sell to hacked purchasable

### DIFF
--- a/code/datums/supplypacks/recreation_vr.dm
+++ b/code/datums/supplypacks/recreation_vr.dm
@@ -25,6 +25,7 @@
 			)
 	containertype = /obj/structure/closet/crate
 	containername = "Restraints crate"
+	contraband = 1
 	cost = 30
 
 /datum/supply_pack/recreation/wolfgirl_cosplay_crate
@@ -38,6 +39,7 @@
 			)
 	cost = 50
 	containertype = /obj/structure/closet/crate
+	contraband = 1
 	containername = "wolfgirl cosplay crate"
 
 /datum/supply_pack/randomised/recreation/figures
@@ -48,6 +50,7 @@
 			)
 	cost = 200
 	containertype = /obj/structure/closet/crate
+	contraband = 1
 	containername = "Action figures crate"
 
 /datum/supply_pack/recreation/collars
@@ -63,4 +66,5 @@
 			)
 	cost = 25
 	containertype = /obj/structure/closet/crate
+	contraband = 1
 	containername = "collar crate"


### PR DESCRIPTION
Pending a better solution, like charging money instead of cargo points for them to represent buying them from some independent supplier.

Edit to explain: I'm not changing their legal status, I'm making it so you need to hack the console to order them, because presumably they're ordered from not-centcomm (which is where everything else comes from), pending a better system with like separate vendors that can come/go/etc.