### PR TITLE
[LOADOUT] Alt. Paramedic Jacket + Paramedic Vest

### DIFF
--- a/code/modules/client/preference_setup/loadout/loadout_suit_vr.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_suit_vr.dm
@@ -61,3 +61,9 @@
 /datum/gear/suit/roles/medical/ems_jacket/alt
 	display_name = "first responder jacket, alt."
 	path = /obj/item/clothing/suit/storage/toggle/fr_jacket/ems
+	
+//paramedic vest
+/datum/gear/suit/roles/medical/paramedic_vest
+	display_name = "paramedic vest"
+	path = /obj/item/clothing/suit/storage/toggle/paramedic
+	allowed_roles = list("Chief Medical Officer","Paramedic","Medical Doctor")

--- a/code/modules/client/preference_setup/loadout/loadout_suit_vr.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_suit_vr.dm
@@ -50,3 +50,14 @@
 	display_name = "sleek modern coat (long), detective"
 	path = /obj/item/clothing/suit/storage/det_trench/alt2
 	allowed_roles = list("Head of Security", "Detective")
+
+//Emergency Responder jackets for Parameds & EMTs, but also general Medical Staff
+/datum/gear/suit/roles/medical/ems_jacket
+	display_name = "first responder jacket"
+	path = /obj/item/clothing/suit/storage/toggle/fr_jacket
+	allowed_roles = list("Chief Medical Officer","Paramedic","Medical Doctor")
+
+//imo-superior 'martian' style jacket with the star-of-life design
+/datum/gear/suit/roles/medical/ems_jacket/alt
+	display_name = "first responder jacket, alt."
+	path = /obj/item/clothing/suit/storage/toggle/fr_jacket/ems


### PR DESCRIPTION
Port of [YW726](https://github.com/Yawn-Wider/YWPolarisVore/pull/726) that adds an alternate jacket for Parameds/EMTs and a couple other Medical roles, since I saw people grumbling about the awful highvis jacket. Has the same dark blue theme as the EMT labcoat, but comes with orange/white highvis markings and a blue 'star of life' design on the back. Also adds the actual paramedic vest since that was inaccessible for some reason.

Modelled in character setup;
EMT Jacket (left) & Paramedic Vest (right)
![image](https://user-images.githubusercontent.com/49700375/84703025-6fba9f00-af4f-11ea-9d2b-8f2ff1386e31.png)![image](https://user-images.githubusercontent.com/49700375/84703976-fd4abe80-af50-11ea-8ee6-53157fa734c4.png)


Polaris has had this for forever and I have no idea why it's unused. I thought the vest was exclusive to YW but apparently isn't.