### PR TITLE
Makes Unathi's mob_size MOB_MEDIUM to match all other (non event) species

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/station_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_vr.dm
@@ -238,6 +238,7 @@
 	max_age = 80
 
 /datum/species/unathi
+	mob_size = MOB_MEDIUM //To allow normal mob swapping
 	spawn_flags = SPECIES_CAN_JOIN //Species_can_join is the only spawn flag all the races get, so that none of them will be whitelist only if whitelist is enabled.
 	icobase = 'icons/mob/human_races/r_lizard_vr.dmi'
 	deform = 'icons/mob/human_races/r_def_lizard_vr.dmi'
@@ -293,7 +294,7 @@
 	wikilink="https://wiki.vore-station.net/Diona"
 
 /datum/species/teshari
-	mob_size = MOB_MEDIUM
+	mob_size = MOB_MEDIUM //To allow normal mob swapping
 	spawn_flags = SPECIES_CAN_JOIN
 	icobase = 'icons/mob/human_races/r_seromi_vr.dmi'
 	deform = 'icons/mob/human_races/r_seromi_vr.dmi'


### PR DESCRIPTION
Same reason prommies and teshari had it modified up, IMO, its only fair for the scalies to be sized down for equality of mobswap interactions.

Does not touch Werebeasts' mob_size because event species.