### PR TITLE
Prevent Refitting AutoLok Suits

### DIFF
--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -778,6 +778,13 @@
 			to_chat(user, "You cannot refit a customised voidsuit.")
 			return
 
+		//VR ADDITION BEGINS
+		//Make it so autolok suits can't be refitted in a cycler
+		if(istype(I,/obj/item/clothing/suit/space/void/autolok))
+			to_chat(user, "You cannot refit an autolok suit.")
+			return
+		//VR ADDITION ENDS
+		
 		to_chat(user, "You fit \the [I] into the suit cycler.")
 		user.drop_item()
 		I.loc = src

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -778,12 +778,12 @@
 			to_chat(user, "You cannot refit a customised voidsuit.")
 			return
 
-		//VR ADDITION BEGINS
+		//VOREStation Edit BEGINS
 		//Make it so autolok suits can't be refitted in a cycler
 		if(istype(I,/obj/item/clothing/suit/space/void/autolok))
 			to_chat(user, "You cannot refit an autolok suit.")
 			return
-		//VR ADDITION ENDS
+		//VOREStation Edit ENDS
 		
 		to_chat(user, "You fit \the [I] into the suit cycler.")
 		user.drop_item()


### PR DESCRIPTION
Realized it was technically possible to refit them as they're a subtype of the /void/ type. This would be a bad idea anyway as they'd almost certainly turn invisible, so hey, not allowed any more.