### PR TITLE
un-earrapifies instruments (upstream early access)

### DIFF
--- a/code/game/objects/structures/musician.dm
+++ b/code/game/objects/structures/musician.dm
@@ -75,7 +75,7 @@
 	var/sound/music_played = sound(soundfile)
 	for(var/i in hearing_mobs)
 		var/mob/M = i
-		M.playsound_local(source, null, 100, falloff = 5, S = music_played)
+		M.playsound_local(source, null, 100, falloff = 0.5, S = music_played)
 
 /datum/song/proc/updateDialog(mob/user)
 	instrumentObj.updateDialog()		// assumes it's an object in world, override if otherwise


### PR DESCRIPTION
The default falloff value for sounds is 0.5 (lower means quieter).
There was only 3 things ingame with a sound falloff of a whole whopping 5 (10x)
These things were explosions, telepads, and instruments.
One had a volume of 25%, another one had a volume based on distance threshold, and you can probably guess which one of the bunch had a hardcoded 100% volume.