### PR TITLE
Reduce the default escape time for bellies from 60 to 20s.

### DIFF
--- a/code/modules/vore/eating/belly_obj_vr.dm
+++ b/code/modules/vore/eating/belly_obj_vr.dm
@@ -24,7 +24,7 @@
 	var/digest_burn = 0.5					// Burn damage per tick in digestion mode
 	var/immutable = FALSE					// Prevents this belly from being deleted
 	var/escapable = FALSE					// Belly can be resisted out of at any time
-	var/escapetime = 60 SECONDS				// Deciseconds, how long to escape this belly
+	var/escapetime = 20 SECONDS				// Deciseconds, how long to escape this belly
 	var/digestchance = 0					// % Chance of stomach beginning to digest if prey struggles
 	var/absorbchance = 0					// % Chance of stomach beginning to absorb if prey struggles
 	var/escapechance = 0 					// % Chance of prey beginning to escape if prey struggles.


### PR DESCRIPTION
It should make it easier for people to escape mobs not completely burnt despite having rolled a success. You can always change it for players.