### PR TITLE
Grant brig access to the detective as a .vr tweak

### DIFF
--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -77,7 +77,7 @@
 	spawn_positions = 2
 	supervisors = "the Head of Security"
 	selection_color = "#601C1C"
-	access = list(access_security, access_sec_doors, access_forensics_lockers, access_morgue, access_maint_tunnels, access_eva, access_external_airlocks)
+	access = list(access_security, access_sec_doors, access_forensics_lockers, access_morgue, access_maint_tunnels, access_eva, access_external_airlocks, access_brig) //Vorestation edit - access_brig
 	minimal_access = list(access_security, access_sec_doors, access_forensics_lockers, access_morgue, access_maint_tunnels, access_eva, access_external_airlocks)
 	economic_modifier = 5
 	minimal_player_age = 3


### PR DESCRIPTION
Less headaches of low access rights and honestly, they should just be able to walk wherever a junior officer can, given they are sort of higher on the hierarchy.