### PR TITLE
Removes second vocal annoucement from grub event

### DIFF
--- a/code/modules/events/grubinfestation_vr.dm
+++ b/code/modules/events/grubinfestation_vr.dm
@@ -42,4 +42,4 @@
 		area_names |= grub_area.name
 	if(area_names.len)
 		var/english_list = english_list(area_names)
-		command_announcement.Announce("Sensors have narrowed down remaining active solargrubs to the followng areas: [english_list]", "Lifesign Alert", new_sound = 'sound/AI/aliens.ogg')
+		command_announcement.Announce("Sensors have narrowed down remaining active solargrubs to the followng areas: [english_list]", "Lifesign Alert")


### PR DESCRIPTION
This stops the delayed "this is where the grubs are" announcement from replaying the entire "XENOS HERE, WELD THE VENTS" vocal message.