### PR TITLE
Add Booze Traits!

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
@@ -123,3 +123,41 @@
 	..(S,H)
 	H.verbs |= /mob/living/proc/glow_toggle
 	H.verbs |= /mob/living/proc/glow_color
+	
+// Alcohol Traits Start Here, from negative to positive.
+/datum/trait/alcohol_intolerance_advanced
+	name = "Liver of Air"
+	desc = "The only way you can hold a drink is if it's in your own two hands, and even then you'd best not inhale too deeply near it. Drinks are three times as strong."
+	cost = 0
+	var_changes = list("alcohol_mod" = 3) // 300% as effective if alcohol_mod is set to 1. If it's not 1 in species.dm, update this!
+
+/datum/trait/alcohol_intolerance_basic
+	name = "Liver of Lilies"
+	desc = "You have a hard time with alcohol. Maybe you just never took to it, or maybe it doesn't agree with you... either way, drinks are twice as strong."
+	cost = 0
+	var_changes = list("alcohol_mod" = 2) // 200% as effective if alcohol_mod is set to 1. If it's not 1 in species.dm, update this!
+
+/datum/trait/alcohol_intolerance_slight
+	name = "Liver of Tulips"
+	desc = "You have a slight struggle with alcohol. Drinks are one and a half times stronger."
+	cost = 0
+	var_changes = list("alcohol_mod" = 1.5) // 150% as effective if alcohol_mod is set to 1. If it's not 1 in species.dm, update this!
+
+/datum/trait/alcohol_tolerance_basic
+	name = "Liver of Iron"
+	desc = "You can hold drinks much better than those lily-livered land-lubbers! Arr! Drinks are only three-quarters as strong."
+	cost = 0
+	var_changes = list("alcohol_mod" = 0.75) // 75% as effective if alcohol_mod is set to 1. If it's not 1 in species.dm, update this!
+	
+/datum/trait/alcohol_tolerance_advanced
+	name = "Liver of Steel"
+	desc = "Drinks tremble before your might! You can hold your alcohol twice as well as those blue-bellied barnacle boilers! Drinks are only half as strong."
+	cost = 0
+	var_changes = list("alcohol_mod" = 0.5) // 50% as effective if alcohol_mod is set to 1. If it's not 1 in species.dm, update this!
+
+/datum/trait/alcohol_immunity
+	name = "Liver of Durasteel"
+	desc = "You've drunk so much that most booze doesn't even faze you. It takes something like a Pan-Galactic or a pint of Deathbell for you to even get slightly buzzed."
+	cost = 0
+	var_changes = list("alcohol_mod" = 0.25) // 25% as effective if alcohol_mod is set to 1. If it's not 1 in species.dm, update this!
+// Alcohol Traits End Here.


### PR DESCRIPTION
Upstream port of https://github.com/Yawn-Wider/YWPolarisVore/pull/619

Credit goes to @KillianKirilenko for this, I just ported this upstream and put all the traits in neutral.dm as per admin request!

**Description:**
This uses the universal alcohol_mod to allow for increasing/reducing the effects of ethanol based on the trait you've taken. Basically? You can get drunk more or less quickly. This does not change how fast you die when you start taking liver damage/tox, this only affects how fast alcohol makes you drunk.
