### PR TITLE
Quick fix to stop mobs in nullspace runtiming the mobs and ai subsystems.

### DIFF
--- a/code/controllers/subsystems/ai.dm
+++ b/code/controllers/subsystems/ai.dm
@@ -32,7 +32,7 @@ SUBSYSTEM_DEF(ai)
 	while(currentrun.len)
 		var/datum/ai_holder/A = currentrun[currentrun.len]
 		--currentrun.len
-		if(!A || QDELETED(A) || A.busy) // Doesn't exist or won't exist soon or not doing it this tick
+		if(!A || QDELETED(A) || !A.holder?.loc || A.busy) // Doesn't exist or won't exist soon or not doing it this tick
 			continue
 		
 		if(process_z[get_z(A.holder)])

--- a/code/controllers/subsystems/mobs.dm
+++ b/code/controllers/subsystems/mobs.dm
@@ -43,7 +43,7 @@ SUBSYSTEM_DEF(mobs)
 		if(!M || QDELETED(M))
 			mob_list -= M
 			continue
-		else if(M.low_priority && !(process_z[get_z(M)]))
+		else if(M.low_priority && !(M.loc && process_z[get_z(M)]))
 			slept_mobs++
 			continue
 		


### PR DESCRIPTION
For _Runtime in ai.dm,38: list index out of bounds_ and _Runtime in mobs.dm,46: list index out of bounds_

