### PR TITLE
Medibot Interaction Hotfix

### DIFF
--- a/code/modules/mob/living/bot/medbot.dm
+++ b/code/modules/mob/living/bot/medbot.dm
@@ -209,7 +209,7 @@
 		if(do_after(H, 3 SECONDS, target=src))
 			set_right(H)
 	else
-		interact()
+		interact(H)
 	
 /mob/living/bot/medbot/proc/interact(mob/user)
 	var/dat


### PR DESCRIPTION
Always check that you're passing the arguments a proc needs.

In this case, I was calling interact(), but not giving it a mob to interact with. Whoops.
