### PR TITLE
Fix for Camera interaction for Borgs/Drones.

### DIFF
--- a/code/game/machinery/computer/camera.dm
+++ b/code/game/machinery/computer/camera.dm
@@ -37,8 +37,10 @@
 	tgui_interact(user)
 
 /obj/machinery/computer/security/attack_ai(mob/user)
-	to_chat(user, "<span class='notice'>You realise its kind of stupid to access a camera console when you have the entire camera network at your metaphorical fingertips.</span>")
-	return
+	if(isAI(user))
+		to_chat(user, "<span class='notice'>You realise its kind of stupid to access a camera console when you have the entire camera network at your metaphorical fingertips</span>")
+		return
+	attack_hand(user)
 
 /obj/machinery/computer/security/proc/set_network(list/new_network)
 	network = new_network


### PR DESCRIPTION
To note - the original change was intentional change on Paradise's part.

"You might not have been able to actually view the cameras, but you should have been able to open the interface." - this restores the attack_hand(user) functionality for borgs/drones.
