### PR TITLE
Reverts the forced sharp scaling on map window.

### DIFF
--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -1194,7 +1194,6 @@ window "mapwindow"
 		text-color = none
 		is-default = true
 		saved-params = "icon-size"
-		zoom-mode = "distort"
 		on-show = ".winset\"mainwindow.mainvsplit.left=mapwindow\""
 		on-hide = ".winset\"mainwindow.mainvsplit.left=\""
 


### PR DESCRIPTION
A bandaid fix that'll hopefully be replaced with an actual preference toggle button rather than the upstream fetish of hardcoding and forcing client preferences without access buttons to them.
Basically fixes map window having turned to sharp scaling, meaning that using the "stretch to fit" mode will mangle the entire screen if someone needs a little bit of a tweak. Most screens aren't big enough to blur the map window noticeably and if you're on a 4k screen, set your icon mode to 96 or 128 for fuck's sake.