### PR TITLE
Ambiance and Sound Updates Attempt 3

### DIFF
--- a/code/game/machinery/computer/aifixer.dm
+++ b/code/game/machinery/computer/aifixer.dm
@@ -85,7 +85,10 @@
 		return
 	if(!occupier)
 		restoring = FALSE
-
+	
+	if(action)
+		playsound(src, "terminal_type", 50, 1)
+	
 	switch(action)
 		if("PRG_beginReconstruction")
 			if(occupier?.health < 100)

--- a/code/modules/tgui/modules/camera.dm
+++ b/code/modules/tgui/modules/camera.dm
@@ -161,7 +161,10 @@
 /datum/tgui_module/camera/tgui_act(action, params)
 	if(..())
 		return
-
+	
+	if(action && !issilicon(usr))
+		playsound(tgui_host(), "terminal_type", 50, 1)
+	
 	if(action == "switch_camera")
 		var/c_tag = params["name"]
 		var/list/cameras = get_available_cameras(usr)

--- a/code/modules/tgui/modules/crew_monitor.dm
+++ b/code/modules/tgui/modules/crew_monitor.dm
@@ -5,6 +5,9 @@
 /datum/tgui_module/crew_monitor/tgui_act(action, params, datum/tgui/ui)
 	if(..())
 		return TRUE
+		
+	if(action && !issilicon(usr))
+		playsound(tgui_host(), "terminal_type", 50, 1)
 
 	var/turf/T = get_turf(usr)
 	if(!T || !(T.z in using_map.player_levels))


### PR DESCRIPTION
All living mobs will now have a check run every 30 seconds or so to replay the current ambience of the area they're in, if they've not had it played in the last minute. Said check is a 35% chance of playing the ambience. Good for if you're standing around in one area.

Computers + turrets got new sounds, turrets have a deploy, retract, and rotate sound. Arcade machines now play sound effects depending on what step you're on and what you're doing.

Replaced maintenance ambience with different ambience from Paradise/Aurora, and moved our maintenance to foreboding, and moved old foreboding to it's own folder.
