### PR TITLE
Fixes some trait stats requiring set_species

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/blank_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/blank_vr.dm
@@ -93,6 +93,8 @@
 
 	//Set up a mob
 	H.species = new_copy
+	H.maxHealth = new_copy.total_health
+	H.hunger_rate = new_copy.hunger_factor
 
 	if(new_copy.holder_type)
 		H.holder_type = new_copy.holder_type


### PR DESCRIPTION
Moves a couple trait stats applied via set_species proc (not used for customspecies) to somewhere custom species can actually access them.
Mostly just affects motion based hunger factor, and would also affect health traits but those already have their own bandaid application.

Kind of "fixes"  #8502