### PR TITLE
Freezers are chilly!

### DIFF
--- a/code/game/machinery/air_alarm.dm
+++ b/code/game/machinery/air_alarm.dm
@@ -788,3 +788,14 @@
 	..()
 	spawn(rand(0,15))
 		update_icon()
+
+// VOREStation Edit Start
+/obj/machinery/alarm/freezer
+	target_temperature = T0C - 13.15 // Chilly freezer room
+
+/obj/machinery/alarm/freezer/first_run()
+	. = ..()
+
+	TLV["temperature"] =	list(T0C - 40, T0C - 20, T0C + 40, T0C + 66) // K, Lower Temperature for Freezer Air Alarms (This is because TLV is hardcoded to be generated on first_run, and therefore the only way to modify this without changing TLV generation)
+
+// VOREStation Edit End

--- a/code/game/turfs/flooring/flooring_premade.dm
+++ b/code/game/turfs/flooring/flooring_premade.dm
@@ -317,6 +317,7 @@
 	name = "tiles"
 	icon_state = "freezer"
 	initial_flooring = /decl/flooring/tiling/freezer
+	temperature = T0C - 5 // VOREStation Edit: Chillier Freezer Tiles on-start
 
 /turf/simulated/floor/lino
 	name = "lino"

--- a/maps/tether/tether-03-surface3.dmm
+++ b/maps/tether/tether-03-surface3.dmm
@@ -16289,10 +16289,14 @@
 /turf/simulated/floor/tiled,
 /area/rnd/research/testingrange)
 "aBJ" = (
-/obj/structure/shuttle/engine/propulsion,
-/turf/simulated/floor/reinforced,
-/turf/simulated/shuttle/plating/carry,
-/area/shuttle/tether)
+/obj/structure/kitchenspike,
+/obj/machinery/alarm/freezer{
+	dir = 1;
+	icon_state = "alarm0";
+	pixel_y = -25
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/crew_quarters/freezer)
 "aBK" = (
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/borderfloorblack,
@@ -16333,12 +16337,10 @@
 /turf/simulated/floor/tiled,
 /area/rnd/research/researchdivision)
 "aBM" = (
-/obj/machinery/atmospherics/unary/engine{
-	dir = 1
-	},
+/obj/structure/shuttle/engine/propulsion,
 /turf/simulated/floor/reinforced,
 /turf/simulated/shuttle/plating/carry,
-/area/shuttle/tourbus/engines)
+/area/shuttle/tether)
 "aBN" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -32858,14 +32860,12 @@
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
 "bet" = (
-/obj/structure/kitchenspike,
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -25;
-	target_temperature = 270
+/obj/machinery/atmospherics/unary/engine{
+	dir = 1
 	},
-/turf/simulated/floor/tiled/freezer,
-/area/crew_quarters/freezer)
+/turf/simulated/floor/reinforced,
+/turf/simulated/shuttle/plating/carry,
+/area/shuttle/tourbus/engines)
 "beu" = (
 /obj/effect/floor_decal/corner/grey/diagonal,
 /obj/structure/cable/green{
@@ -48769,7 +48769,7 @@ jML
 jHw
 jpB
 qWU
-aBM
+bet
 aKU
 aOI
 aPb
@@ -49621,7 +49621,7 @@ caw
 jHw
 gHh
 qWU
-aBM
+bet
 aKU
 aOI
 aPb
@@ -51606,7 +51606,7 @@ aNk
 uSA
 aNJ
 aNP
-aBJ
+aBM
 aKU
 abg
 aOk
@@ -51748,7 +51748,7 @@ aNl
 aNl
 aNK
 aNP
-aBJ
+aBM
 aKU
 abg
 aOk
@@ -51890,7 +51890,7 @@ aNm
 aNl
 aNK
 aNP
-aBJ
+aBM
 aKU
 abg
 aOk
@@ -54702,7 +54702,7 @@ bdI
 aoJ
 beP
 bdR
-bet
+aBJ
 aoJ
 bbr
 bcB


### PR DESCRIPTION
Freezers will start at T0C - 5 (Which is effectively 268.15), and a new Freezer air alarm subtype has been added that bypasses the TLV hardcoded default to allow for larger cooling thresholds (and allow lower target temps).

TL;DR: Freezer tiles and the kitchen freezer will start cold and actually stay cold, prompting "you feel chilly" in the freezer. Other areas that use /freezer/ tiles may be affected by the initial temp, but this should quickly resolve itself thanks to heat balancing.
