### PR TITLE
Allows some protean ventcrawl accessories

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/protean_vr/protean_blob.dm
+++ b/code/modules/mob/living/carbon/human/species/station/protean_vr/protean_blob.dm
@@ -298,6 +298,12 @@
 		return
 	..()
 
+var/global/list/disallowed_protean_accessories = list(
+	/obj/item/clothing/accessory/holster,
+	/obj/item/clothing/accessory/storage,
+	/obj/item/clothing/accessory/armor
+	)
+
 // Helpers - Unsafe, WILL perform change.
 /mob/living/carbon/human/proc/nano_intoblob()
 	var/panel_was_up = FALSE
@@ -343,7 +349,8 @@
 		var/obj/item/clothing/uniform = w_uniform
 		if(LAZYLEN(uniform.accessories))
 			for(var/obj/item/clothing/accessory/A in uniform.accessories)
-				uniform.remove_accessory(null,A) //First param is user, but adds fingerprints and messages
+				if(is_type_in_list(A, disallowed_protean_accessories))
+					uniform.remove_accessory(null,A) //First param is user, but adds fingerprints and messages
 
 	//Size update
 	blob.transform = matrix()*size_multiplier


### PR DESCRIPTION
Allows proteans to enter blob form with decorative uniform accessories, instead of detaching all of them.
Notably, this allows them to stick their nanobot permit to their uniform to keep it with them.