### PR TITLE
Add a belly size upgrade for hounds and fix an important typo.

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades_vr.dm
+++ b/code/game/objects/items/robot/robot_upgrades_vr.dm
@@ -29,3 +29,39 @@
 
 	R.verbs += /mob/living/proc/set_size
 	return 1
+
+/obj/item/borg/upgrade/bellysizeupgrade
+	name = "robotic Hound process capacity upgrade Module"
+	desc = "Used to upgrade a hound belly capacity. This only affects total volume and such, you won't be able to support more than one patient. Usable once."
+	icon_state = "cyborg_upgrade2"
+	item_state = "cyborg_upgrade"
+	require_module = 1
+
+/obj/item/borg/upgrade/bellysizeupgrade/action(var/mob/living/silicon/robot/R)
+	if(..()) return 0
+
+	if(!R.module || R.dogborg == FALSE)//can work
+		to_chat(R, "Upgrade mounting error!  No suitable hardpoint detected!")
+		to_chat(usr, "There's no mounting point for the module! Try upgrading another model.")
+		return 0
+
+	var/obj/item/device/dogborg/sleeper/T = locate() in R.module
+	if(!T)
+		T = locate() in R.module.contents
+	if(!T)
+		T = locate() in R.module.modules
+	if(!T)
+		to_chat(usr, "<span class='warning'>This robot has had its processor removed!</span>")
+		return 0
+
+	if(T.upgraded_capacity)// == TRUE
+		to_chat(R, "Maximum capacity achieved for this hardpoint!")
+		to_chat(usr, "There's no room for another capacity upgrade!")
+		return 0
+	else
+		var/X = T.max_item_count*2
+		T.max_item_count = X	//I couldn't do T = maxitem*2 for some reason.
+		to_chat(R, "Internal capacity doubled.")
+		to_chat(usr, "Internal capacity doubled.")
+		T.upgraded_capacity = TRUE
+	return 1

--- a/code/modules/mob/living/silicon/robot/dogborg/dog_sleeper_vr.dm
+++ b/code/modules/mob/living/silicon/robot/dogborg/dog_sleeper_vr.dm
@@ -30,6 +30,7 @@
 	var/synced = FALSE
 	var/startdrain = 500
 	var/max_item_count = 1
+	var/upgraded_capacity = FALSE
 	var/gulpsound = 'sound/vore/gulp.ogg'
 	var/datum/matter_synth/metal = null
 	var/datum/matter_synth/glass = null

--- a/code/modules/research/prosfab_designs_vr.dm
+++ b/code/modules/research/prosfab_designs_vr.dm
@@ -6,3 +6,10 @@
 	req_tech = list(TECH_BLUESPACE = 3, TECH_MATERIAL = 3, TECH_POWER = 2)
 	materials = list(DEFAULT_WALL_MATERIAL = 4000, "glass" = 4000)
 	build_path = /obj/item/borg/upgrade/sizeshift
+
+/datum/design/item/prosfab/robot_upgrade/bellysizeupgrade
+	name = "Size Alteration Module"
+	id = "borg_hound_capacity_module"
+	req_tech = list(TECH_BLUESPACE = 3, TECH_MATERIAL = 3, TECH_POWER = 2)
+	materials = list(DEFAULT_WALL_MATERIAL = 4000, "glass" = 4000)
+	build_path = /obj/item/borg/upgrade/bellysizeupgrade

--- a/code/modules/vore/resizing/resize_vr.dm
+++ b/code/modules/vore/resizing/resize_vr.dm
@@ -251,7 +251,7 @@ var/const/RESIZE_A_SMALLTINY = (RESIZE_SMALL + RESIZE_TINY) / 2
 	now_pushing = 0
 	forceMove(tmob.loc)
 	if(a_intent == I_GRAB || a_intent == I_DISARM)
-		if(tmob.a_intent = I_HELP)
+		if(tmob.a_intent == I_HELP)
 			tmob.resting = 1
 		else
 			tmob.Weaken(1)


### PR DESCRIPTION
Researchable upgrade. 
- It fits only hounds. 
- It doubles the capacity of their sleeper for items. 
- Usable only once. 
- This does not affect number of patients that can be held.

Might allow it to be used twice.

Also an important typo.