### PR TITLE
Fix assignment in conditional warning/error

### DIFF
--- a/code/modules/vore/resizing/resize_vr.dm
+++ b/code/modules/vore/resizing/resize_vr.dm
@@ -251,7 +251,7 @@ var/const/RESIZE_A_SMALLTINY = (RESIZE_SMALL + RESIZE_TINY) / 2
 	now_pushing = 0
 	forceMove(tmob.loc)
 	if(a_intent == I_GRAB || a_intent == I_DISARM)
-		if(tmob.a_intent = I_HELP)
+		if(tmob.a_intent == I_HELP)
 			tmob.resting = 1
 		else
 			tmob.Weaken(1)


### PR DESCRIPTION
This is a followup to #8583 as it accidentally had = instead of == meaning that inside the if() it'd set the mob's intent, instead of COMPARING the mobs intent.