### PR TITLE
Fix Mulebot Crossed() Code, allows simplemobs to be crushed if laying

### DIFF
--- a/code/modules/mob/living/bot/mulebot.dm
+++ b/code/modules/mob/living/bot/mulebot.dm
@@ -218,6 +218,12 @@
 /mob/living/bot/mulebot/confirmTarget()
 	return 1
 
+/mob/living/bot/mulebot/handle_micro_bump_helping() // VOREStation EDIT: Can't drive over micros or macros regardless of intent.
+	return 0
+
+/mob/living/bot/mulebot/handle_micro_bump_other() // VOREStation EDIT: Can't drive over micros or macros regardless of intent.
+	return 0
+
 /mob/living/bot/mulebot/calcTargetPath()
 	..()
 	if(!target_path.len && target != home) // I presume that target is not null
@@ -241,20 +247,34 @@
 		M.Weaken(5)
 	..()
 
-/mob/living/bot/mulebot/proc/runOver(var/mob/living/carbon/human/H)
-	if(istype(H)) // No safety checks - WILL run over lying humans. Stop ERPing in the maint!
-		visible_message("<span class='warning'>[src] drives over [H]!</span>")
+/mob/living/bot/mulebot/proc/runOver(var/mob/living/M)
+	if(istype(M) && M.lying) // Screw the original implementation, of "runs over everything, no checks". We're going to check if you're lying down.
+		visible_message("<span class='warning'>[src] drives over [M]!</span>")
 		playsound(src, 'sound/effects/splat.ogg', 50, 1)
 
 		var/damage = rand(5, 7)
-		H.apply_damage(2 * damage, BRUTE, BP_HEAD)
-		H.apply_damage(2 * damage, BRUTE, BP_TORSO)
-		H.apply_damage(0.5 * damage, BRUTE, BP_L_LEG)
-		H.apply_damage(0.5 * damage, BRUTE, BP_R_LEG)
-		H.apply_damage(0.5 * damage, BRUTE, BP_L_ARM)
-		H.apply_damage(0.5 * damage, BRUTE, BP_R_ARM)
+		M.apply_damage(2 * damage, BRUTE, BP_HEAD)
+		M.apply_damage(2 * damage, BRUTE, BP_TORSO)
+		M.apply_damage(0.5 * damage, BRUTE, BP_L_LEG)
+		M.apply_damage(0.5 * damage, BRUTE, BP_R_LEG)
+		M.apply_damage(0.5 * damage, BRUTE, BP_L_ARM)
+		M.apply_damage(0.5 * damage, BRUTE, BP_R_ARM)
 
-		blood_splatter(src, H, 1)
+		blood_splatter(src, M, 1)
+
+	else if(istype(M) && !safety) // Are safeties disabled? Gonna FUCK you up.
+		visible_message("<span class='warning'>[src] drives over [M]!</span>")
+		playsound(src, 'sound/effects/splat.ogg', 50, 1)
+
+		var/damage = rand(10, 25) // Really fuck you up, this thing is big as fucc.
+		M.apply_damage(2 * damage, BRUTE, BP_HEAD)
+		M.apply_damage(2 * damage, BRUTE, BP_TORSO)
+		M.apply_damage(0.5 * damage, BRUTE, BP_L_LEG)
+		M.apply_damage(0.5 * damage, BRUTE, BP_R_LEG)
+		M.apply_damage(0.5 * damage, BRUTE, BP_L_ARM)
+		M.apply_damage(0.5 * damage, BRUTE, BP_R_ARM)
+
+		blood_splatter(src, M, 1)
 	..()
 
 /mob/living/bot/mulebot/relaymove(var/mob/user, var/direction)

--- a/code/modules/mob/living/bot/mulebot.dm
+++ b/code/modules/mob/living/bot/mulebot.dm
@@ -218,12 +218,6 @@
 /mob/living/bot/mulebot/confirmTarget()
 	return 1
 
-/mob/living/bot/mulebot/handle_micro_bump_helping() // VOREStation EDIT: Can't drive over micros or macros regardless of intent.
-	return 0
-
-/mob/living/bot/mulebot/handle_micro_bump_other() // VOREStation EDIT: Can't drive over micros or macros regardless of intent.
-	return 0
-
 /mob/living/bot/mulebot/calcTargetPath()
 	..()
 	if(!target_path.len && target != home) // I presume that target is not null
@@ -248,25 +242,11 @@
 	..()
 
 /mob/living/bot/mulebot/proc/runOver(var/mob/living/M)
-	if(istype(M) && M.lying) // Screw the original implementation, of "runs over everything, no checks". We're going to check if you're lying down.
+	if(istype(M)) // At this point, MULEBot has somehow crossed over onto your tile with you still on it. CRRRNCH.
 		visible_message("<span class='warning'>[src] drives over [M]!</span>")
 		playsound(src, 'sound/effects/splat.ogg', 50, 1)
 
 		var/damage = rand(5, 7)
-		M.apply_damage(2 * damage, BRUTE, BP_HEAD)
-		M.apply_damage(2 * damage, BRUTE, BP_TORSO)
-		M.apply_damage(0.5 * damage, BRUTE, BP_L_LEG)
-		M.apply_damage(0.5 * damage, BRUTE, BP_R_LEG)
-		M.apply_damage(0.5 * damage, BRUTE, BP_L_ARM)
-		M.apply_damage(0.5 * damage, BRUTE, BP_R_ARM)
-
-		blood_splatter(src, M, 1)
-
-	else if(istype(M) && !safety) // Are safeties disabled? Gonna FUCK you up.
-		visible_message("<span class='warning'>[src] drives over [M]!</span>")
-		playsound(src, 'sound/effects/splat.ogg', 50, 1)
-
-		var/damage = rand(10, 25) // Really fuck you up, this thing is big as fucc.
 		M.apply_damage(2 * damage, BRUTE, BP_HEAD)
 		M.apply_damage(2 * damage, BRUTE, BP_TORSO)
 		M.apply_damage(0.5 * damage, BRUTE, BP_L_LEG)

--- a/code/modules/mob/living/bot/mulebot_vr.dm
+++ b/code/modules/mob/living/bot/mulebot_vr.dm
@@ -1,0 +1,5 @@
+/mob/living/bot/mulebot/handle_micro_bump_helping() // Can't drive over micros or macros regardless of intent.
+	return 0
+
+/mob/living/bot/mulebot/handle_micro_bump_other() // Can't drive over micros or macros regardless of intent.
+	return 0

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -259,6 +259,8 @@
 		return
 
 	spread_fire(AM)
+	
+	..() // call parent because we moved behavior to parent
 
 // Get rank from ID, ID inside PDA, PDA, ID in wallet, etc.
 /mob/living/carbon/human/proc/get_authentification_rank(var/if_no_id = "No id", var/if_no_job = "No job")

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -253,18 +253,10 @@
 	return
 
 // called when something steps onto a human
-// this handles mulebots and vehicles
-// and now mobs on fire
+// this handles mobs on fire - mulebot and vehicle code has been relocated to /mob/living/Crossed()
 /mob/living/carbon/human/Crossed(var/atom/movable/AM)
 	if(AM.is_incorporeal())
 		return
-	if(istype(AM, /mob/living/bot/mulebot))
-		var/mob/living/bot/mulebot/MB = AM
-		MB.runOver(src)
-
-	if(istype(AM, /obj/vehicle))
-		var/obj/vehicle/V = AM
-		V.RunOver(src)
 
 	spread_fire(AM)
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -244,6 +244,19 @@ default behaviour is:
 		return TRUE
 	return ..()
 
+// Called when something steps onto us. This allows for mulebots and vehicles to run things over. <3
+/mob/living/Crossed(var/atom/movable/AM) // Transplanting this from /mob/living/carbon/human/Crossed()
+	if(AM.is_incorporeal())
+		return
+	
+	if(istype(AM, /mob/living/bot/mulebot))
+		var/mob/living/bot/mulebot/MB = AM
+		MB.runOver(src)
+
+	if(istype(AM, /obj/vehicle))
+		var/obj/vehicle/V = AM
+		V.RunOver(src)
+
 /mob/living/verb/succumb()
 	set hidden = 1
 	if ((src.health < 0 && src.health > (5-src.getMaxHealth()))) // Health below Zero but above 5-away-from-death, as before, but variable

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -246,7 +246,7 @@ default behaviour is:
 
 // Called when something steps onto us. This allows for mulebots and vehicles to run things over. <3
 /mob/living/Crossed(var/atom/movable/AM) // Transplanting this from /mob/living/carbon/human/Crossed()
-	if(AM.is_incorporeal())
+	if(AM == src || AM.is_incorporeal()) // We're not going to run over ourselves or ghosts
 		return
 	
 	if(istype(AM, /mob/living/bot/mulebot))

--- a/code/modules/organs/blood.dm
+++ b/code/modules/organs/blood.dm
@@ -360,7 +360,7 @@ proc/blood_splatter(var/target,var/datum/reagent/blood/source,var/large)
 		drop.drips |= drips
 
 	// If there's no data to copy, call it quits here.
-	if(!source)
+	if(!istype(source))
 		return B
 
 	// Update appearance.

--- a/code/modules/vehicles/Securitrain_vr.dm
+++ b/code/modules/vehicles/Securitrain_vr.dm
@@ -166,28 +166,28 @@
 	else
 		verbs += /obj/vehicle/train/security/engine/verb/stop_engine
 
-/obj/vehicle/train/security/RunOver(var/mob/living/carbon/human/H)
+/obj/vehicle/train/security/RunOver(var/mob/living/M)
 	var/list/parts = list(BP_HEAD, BP_TORSO, BP_L_LEG, BP_R_LEG, BP_L_ARM, BP_R_ARM)
 
-	H.apply_effects(5, 5)
+	M.apply_effects(5, 5)
 	for(var/i = 0, i < rand(1,3), i++)
-		H.apply_damage(rand(1,5), BRUTE, pick(parts))
+		M.apply_damage(rand(1,5), BRUTE, pick(parts))
 
-/obj/vehicle/train/security/trolley/RunOver(var/mob/living/carbon/human/H)
+/obj/vehicle/train/security/trolley/RunOver(var/mob/living/M)
 	..()
-	attack_log += text("\[[time_stamp()]\] <font color='red'>ran over [H.name] ([H.ckey])</font>")
+	attack_log += text("\[[time_stamp()]\] <font color='red'>ran over [M.name] ([M.ckey])</font>")
 
-/obj/vehicle/train/security/engine/RunOver(var/mob/living/carbon/human/H)
+/obj/vehicle/train/security/engine/RunOver(var/mob/living/M)
 	..()
 
 	if(is_train_head() && istype(load, /mob/living/carbon/human))
 		var/mob/living/carbon/human/D = load
-		to_chat(D, "<span class='danger'>You ran over \the [H]!</span>"
-		visible_message("<span class='danger'>\The [src] ran over \the [H]!</span>")
-		add_attack_logs(D,H,"Ran over with [src.name]")
-		attack_log += text("\[[time_stamp()]\] <font color='red'>ran over [H.name] ([H.ckey]), driven by [D.name] ([D.ckey])</font>")
+		to_chat(D, "<span class='danger'>You ran over \the [M]!</span>"
+		visible_message("<span class='danger'>\The [src] ran over \the [M]!</span>")
+		add_attack_logs(D,M,"Ran over with [src.name]")
+		attack_log += text("\[[time_stamp()]\] <font color='red'>ran over [M.name] ([M.ckey]), driven by [D.name] ([D.ckey])</font>")
 	else
-		attack_log += text("\[[time_stamp()]\] <font color='red'>ran over [H.name] ([H.ckey])</font>")
+		attack_log += text("\[[time_stamp()]\] <font color='red'>ran over [M.name] ([M.ckey])</font>")
 
 
 //-------------------------------------------

--- a/code/modules/vehicles/cargo_train.dm
+++ b/code/modules/vehicles/cargo_train.dm
@@ -152,28 +152,28 @@
 	else
 		verbs += /obj/vehicle/train/engine/verb/stop_engine
 
-/obj/vehicle/train/RunOver(var/mob/living/carbon/human/H)
+/obj/vehicle/train/RunOver(var/mob/living/M)
 	var/list/parts = list(BP_HEAD, BP_TORSO, BP_L_LEG, BP_R_LEG, BP_L_ARM, BP_R_ARM)
 
-	H.apply_effects(5, 5)
+	M.apply_effects(5, 5)
 	for(var/i = 0, i < rand(1,3), i++)
-		H.apply_damage(rand(1,5), BRUTE, pick(parts))
+		M.apply_damage(rand(1,5), BRUTE, pick(parts))
 
-/obj/vehicle/train/trolley/RunOver(var/mob/living/carbon/human/H)
+/obj/vehicle/train/trolley/RunOver(var/mob/living/M)
 	..()
-	attack_log += text("\[[time_stamp()]\] <font color='red'>ran over [H.name] ([H.ckey])</font>")
+	attack_log += text("\[[time_stamp()]\] <font color='red'>ran over [M.name] ([M.ckey])</font>")
 
-/obj/vehicle/train/engine/RunOver(var/mob/living/carbon/human/H)
+/obj/vehicle/train/engine/RunOver(var/mob/living/M)
 	..()
 
 	if(is_train_head() && istype(load, /mob/living/carbon/human))
 		var/mob/living/carbon/human/D = load
-		to_chat(D, "<font color='red'><B>You ran over [H]!</B></font>")
-		visible_message("<B><font color='red'>\The [src] ran over [H]!</B></font>")
-		add_attack_logs(D,H,"Ran over with [src.name]")
-		attack_log += text("\[[time_stamp()]\] <font color='red'>ran over [H.name] ([H.ckey]), driven by [D.name] ([D.ckey])</font>")
+		to_chat(D, "<font color='red'><B>You ran over [M]!</B></font>")
+		visible_message("<B><font color='red'>\The [src] ran over [M]!</B></font>")
+		add_attack_logs(D,M,"Ran over with [src.name]")
+		attack_log += text("\[[time_stamp()]\] <font color='red'>ran over [M.name] ([M.ckey]), driven by [D.name] ([D.ckey])</font>")
 	else
-		attack_log += text("\[[time_stamp()]\] <font color='red'>ran over [H.name] ([H.ckey])</font>")
+		attack_log += text("\[[time_stamp()]\] <font color='red'>ran over [M.name] ([M.ckey])</font>")
 
 
 //-------------------------------------------

--- a/code/modules/vehicles/quad.dm
+++ b/code/modules/vehicles/quad.dm
@@ -142,15 +142,15 @@
 			add_attack_logs(D,M,"Ran over with [src.name]")
 
 
-/obj/vehicle/train/engine/quadbike/RunOver(var/mob/living/carbon/human/H)
+/obj/vehicle/train/engine/quadbike/RunOver(var/mob/living/M)
 	..()
 	var/list/throw_dirs = list(1, 2, 4, 8, 5, 6, 9, 10)
 	if(!emagged)
 		throw_dirs -= dir
 		if(tow)
-			throw_dirs -= get_dir(H, tow) //Don't throw it at the trailer either.
-	var/turf/T = get_step(H, pick(throw_dirs))
-	H.throw_at(T, 1, 1, src)
+			throw_dirs -= get_dir(M, tow) //Don't throw it at the trailer either.
+	var/turf/T = get_step(M, pick(throw_dirs))
+	M.throw_at(T, 1, 1, src)
 
 /*
  * Trailer bits and bobs.

--- a/code/modules/vehicles/rover_vr.dm
+++ b/code/modules/vehicles/rover_vr.dm
@@ -164,28 +164,28 @@
 	else
 		verbs += /obj/vehicle/train/rover/engine/verb/stop_engine
 
-/obj/vehicle/train/rover/RunOver(var/mob/living/carbon/human/H)
+/obj/vehicle/train/rover/RunOver(var/mob/living/M)
 	var/list/parts = list(BP_HEAD, BP_TORSO, BP_L_LEG, BP_R_LEG, BP_L_ARM, BP_R_ARM)
 
-	H.apply_effects(5, 5)
+	M.apply_effects(5, 5)
 	for(var/i = 0, i < rand(1,3), i++)
-		H.apply_damage(rand(1,5), BRUTE, pick(parts))
+		M.apply_damage(rand(1,5), BRUTE, pick(parts))
 
-/obj/vehicle/train/rover/trolley/RunOver(var/mob/living/carbon/human/H)
+/obj/vehicle/train/rover/trolley/RunOver(var/mob/living/M)
 	..()
-	attack_log += text("\[[time_stamp()]\] <font color='red'>ran over [H.name] ([H.ckey])</font>")
+	attack_log += text("\[[time_stamp()]\] <font color='red'>ran over [M.name] ([M.ckey])</font>")
 
-/obj/vehicle/train/rover/engine/RunOver(var/mob/living/carbon/human/H)
+/obj/vehicle/train/rover/engine/RunOver(var/mob/living/M)
 	..()
 
 	if(is_train_head() && istype(load, /mob/living/carbon/human))
 		var/mob/living/carbon/human/D = load
-		to_chat(D, "<span class='danger'>You ran over \the [H]!</span>")
-		visible_message("<span class='danger'>\The [src] ran over \the [H]!</span>")
-		add_attack_logs(D,H,"Ran over with [src.name]")
-		attack_log += text("\[[time_stamp()]\] <font color='red'>ran over [H.name] ([H.ckey]), driven by [D.name] ([D.ckey])</font>")
+		to_chat(D, "<span class='danger'>You ran over \the [M]!</span>")
+		visible_message("<span class='danger'>\The [src] ran over \the [M]!</span>")
+		add_attack_logs(D,M,"Ran over with [src.name]")
+		attack_log += text("\[[time_stamp()]\] <font color='red'>ran over [M.name] ([M.ckey]), driven by [D.name] ([D.ckey])</font>")
 	else
-		attack_log += text("\[[time_stamp()]\] <font color='red'>ran over [H.name] ([H.ckey])</font>")
+		attack_log += text("\[[time_stamp()]\] <font color='red'>ran over [M.name] ([M.ckey])</font>")
 
 
 //-------------------------------------------

--- a/code/modules/vehicles/vehicle.dm
+++ b/code/modules/vehicles/vehicle.dm
@@ -292,7 +292,7 @@
 	cell = null
 	powercheck()
 
-/obj/vehicle/proc/RunOver(var/mob/living/carbon/human/H)
+/obj/vehicle/proc/RunOver(var/mob/living/M)
 	return		//write specifics for different vehicles
 
 //-------------------------------------------

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -2428,6 +2428,7 @@
 #include "code\modules\mob\living\bot\floorbot.dm"
 #include "code\modules\mob\living\bot\medbot.dm"
 #include "code\modules\mob\living\bot\mulebot.dm"
+#include "code\modules\mob\living\bot\mulebot_vr.dm"
 #include "code\modules\mob\living\bot\secbot.dm"
 #include "code\modules\mob\living\bot\SLed209bot.dm"
 #include "code\modules\mob\living\carbon\breathe.dm"


### PR DESCRIPTION
Fixes Mulebots (and really any vehicles) ruthlessly murdering macros/micros without care, will actually run over mobs properly now. 

Pathing fixes will be in a second PR.
