### PR TITLE
Adds a second confirmation to the reset character slot option

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -339,6 +339,7 @@ datum/preferences
 	else if(href_list["resetslot"])
 		if("No" == alert("This will reset the current slot. Continue?", "Reset current slot?", "No", "Yes"))
 			return 0
+		if("No" == alert("Are you absolutely sure you want to reset this slot?", "Reset current slot?", "No", "Yes")) return 0 //VOREStation Edit
 		load_character(SAVE_RESET)
 		sanitize_preferences()
 	else if(href_list["copy"])


### PR DESCRIPTION
I've seen accidental slot resets happen like twice in the last week, if they continue beyond this it's a user issue.