### PR TITLE
Minor buffs for flying

### DIFF
--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -83,7 +83,7 @@
 
 	if (istype(A,/mob/living))
 		var/mob/living/M = A
-		if(M.lying)
+		if(M.lying || M.flying) //VOREStation Edit
 			return ..()
 
 		if(M.dirties_floor())


### PR DESCRIPTION
People flying will now no longer slip on wet floors, leave bloody footprints, or create dirt.
The immunity to slipping while flying is the only major benefit here, but like, you can still just shove a flier into a wall and ground them easily.