### PR TITLE
Fixes synth brain transplant forcing bad real_name

### DIFF
--- a/code/modules/surgery/robotics.dm
+++ b/code/modules/surgery/robotics.dm
@@ -467,7 +467,7 @@
 		target.languages = M.brainmob.languages
 
 	spawn(0) //Name yourself on your own damn time
-		var/new_name = target.name
+		var/new_name = target.real_name
 		while(target.client)
 			if(!target) return
 			var/try_name = input(target,"Pick a name for your new form!", "New Name", target.name)

--- a/code/modules/surgery/robotics.dm
+++ b/code/modules/surgery/robotics.dm
@@ -468,7 +468,7 @@
 
 	spawn(0) //Name yourself on your own damn time
 		var/new_name = target.name
-		while(!new_name && target.client)
+		while(target.client)
 			if(!target) return
 			var/try_name = input(target,"Pick a name for your new form!", "New Name", target.name)
 			var/clean_name = sanitizeName(try_name, allow_numbers = TRUE)
@@ -477,6 +477,7 @@
 				if(okay == "Ok")
 					new_name = clean_name
 
+		new_name = sanitizeName(new_name, allow_numbers = TRUE)
 		target.name = new_name
 		target.real_name = target.name
 


### PR DESCRIPTION
-Fixes the synth brain transplant rename prompt being a) broken, and b) having the capability to force a contaminated and unsanitized real_name var for the body, which in turn has the capability to kill regex and cause big issues.

In other words: an unnamed synth body wearing a person's ID gets their display name shown as "Unknown (as name)". The problematic part is that the brain transplant procedure here forces the new body to rename itself by the copied display name, AND also forces the real_name var into that without sanitizing. This causes the chat mention system to divide the unsanitized name into 3 names "Unknown", "(as", and "name)" and to shove these into regex to look for, and the rogue () in the names makes regex commit die and likely also break map loading and stuff.

Fixes #8652