### PR TITLE
Admin ghosts can now examine other ghosts to pull up admin tools!

### DIFF
--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -160,6 +160,12 @@
 		I = getFlatIcon(src, defdir = SOUTH, no_anim = TRUE)
 		set_cached_examine_icon(src, I, 200 SECONDS)
 	return I
+	
+/mob/observer/dead/examine(mob/user)
+	. = ..()
+	
+	if(is_admin(user))
+		. += "\t><span class='admin'>[ADMIN_FULLMONTY(src)]</span>"
 
 /*
 Transfer_mind is there to check if mob is being deleted/not going to have a body.


### PR DESCRIPTION
Admin ghosts can now examine another ghost to pull up a full monty of their information, as below. It's just one line, so it's hardly obstructive. <3

Admin View Here:
![](https://i.imgur.com/gOTi7u0.png)

Player View Here:
![](https://i.imgur.com/1NX1jtE.png)

Port of a /tg/ feature that I figured admins might like.