### PR TITLE
Adds Repeating Ambience and Ambience Chance Preferences!

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -395,8 +395,9 @@ var/list/mob/living/forced_ambiance_list = new
 			L << chosen_ambiance
 		else
 			L << sound(null, channel = CHANNEL_AMBIENCE_FORCED)
-	else if(src.ambience.len && prob(35))
-		if((world.time >= L.client.time_last_ambience_played + 1 MINUTE))
+	else if(src.ambience.len)
+		var/ambience_odds = L?.client.prefs.ambience_chance
+		if(prob(ambience_odds) && (world.time >= L.client.time_last_ambience_played + 1 MINUTE))
 			var/sound = pick(ambience)
 			L << sound(sound, repeat = 0, wait = 0, volume = 50, channel = CHANNEL_AMBIENCE)
 			L.client.time_last_ambience_played = world.time

--- a/code/modules/client/preference_setup/global/01_ui.dm
+++ b/code/modules/client/preference_setup/global/01_ui.dm
@@ -9,6 +9,8 @@
 	S["ooccolor"]		>> pref.ooccolor
 	S["tooltipstyle"]	>> pref.tooltipstyle
 	S["client_fps"]		>> pref.client_fps
+	S["ambience_freq"]	>> pref.ambience_freq
+	S["ambience_chance"] >> pref.ambience_chance
 	S["tgui_fancy"]		>> pref.tgui_fancy
 	S["tgui_lock"]		>> pref.tgui_lock
 
@@ -19,18 +21,22 @@
 	S["ooccolor"]		<< pref.ooccolor
 	S["tooltipstyle"]	<< pref.tooltipstyle
 	S["client_fps"]		<< pref.client_fps
+	S["ambience_freq"]	<< pref.ambience_freq
+	S["ambience_chance"] << pref.ambience_freq
 	S["tgui_fancy"]		<< pref.tgui_fancy
 	S["tgui_lock"]		<< pref.tgui_lock
 
 /datum/category_item/player_setup_item/player_global/ui/sanitize_preferences()
-	pref.UI_style		= sanitize_inlist(pref.UI_style, all_ui_styles, initial(pref.UI_style))
-	pref.UI_style_color	= sanitize_hexcolor(pref.UI_style_color, initial(pref.UI_style_color))
-	pref.UI_style_alpha	= sanitize_integer(pref.UI_style_alpha, 0, 255, initial(pref.UI_style_alpha))
-	pref.ooccolor		= sanitize_hexcolor(pref.ooccolor, initial(pref.ooccolor))
-	pref.tooltipstyle	= sanitize_inlist(pref.tooltipstyle, all_tooltip_styles, initial(pref.tooltipstyle))
-	pref.client_fps		= sanitize_integer(pref.client_fps, 0, MAX_CLIENT_FPS, initial(pref.client_fps))
-	pref.tgui_fancy		= sanitize_integer(pref.tgui_fancy, 0, 1, initial(pref.tgui_fancy))
-	pref.tgui_lock		= sanitize_integer(pref.tgui_lock, 0, 1, initial(pref.tgui_lock))
+	pref.UI_style			= sanitize_inlist(pref.UI_style, all_ui_styles, initial(pref.UI_style))
+	pref.UI_style_color		= sanitize_hexcolor(pref.UI_style_color, initial(pref.UI_style_color))
+	pref.UI_style_alpha		= sanitize_integer(pref.UI_style_alpha, 0, 255, initial(pref.UI_style_alpha))
+	pref.ooccolor			= sanitize_hexcolor(pref.ooccolor, initial(pref.ooccolor))
+	pref.tooltipstyle		= sanitize_inlist(pref.tooltipstyle, all_tooltip_styles, initial(pref.tooltipstyle))
+	pref.client_fps			= sanitize_integer(pref.client_fps, 0, MAX_CLIENT_FPS, initial(pref.client_fps))
+	pref.ambience_freq		= sanitize_integer(pref.ambience_freq, 0, 60, initial(pref.ambience_freq)) // No more than once per hour.
+	pref.ambience_chance 	= sanitize_integer(pref.ambience_chance, 0, 100, initial(pref.ambience_chance)) // 0-100 range.
+	pref.tgui_fancy			= sanitize_integer(pref.tgui_fancy, 0, 1, initial(pref.tgui_fancy))
+	pref.tgui_lock			= sanitize_integer(pref.tgui_lock, 0, 1, initial(pref.tgui_lock))
 
 /datum/category_item/player_setup_item/player_global/ui/content(var/mob/user)
 	. = "<b>UI Style:</b> <a href='?src=\ref[src];select_style=1'><b>[pref.UI_style]</b></a><br>"
@@ -39,6 +45,8 @@
 	. += "-Alpha(transparency): <a href='?src=\ref[src];select_alpha=1'><b>[pref.UI_style_alpha]</b></a>�<a href='?src=\ref[src];reset=alpha'>reset</a><br>"
 	. += "<b>Tooltip Style:</b> <a href='?src=\ref[src];select_tooltip_style=1'><b>[pref.tooltipstyle]</b></a><br>"
 	. += "<b>Client FPS:</b> <a href='?src=\ref[src];select_client_fps=1'><b>[pref.client_fps]</b></a><br>"
+	. += "<b>Random Ambience Frequency:</b> <a href='?src=\ref[src];select_ambience_freq=1'><b>[pref.ambience_freq]</b></a><br>"
+	. += "<b>Ambience Chance:</b> <a href='?src=\ref[src];select_ambience_chance=1'><b>[pref.ambience_chance]</b></a><br>"
 	. += "<b>tgui Window Mode:</b> <a href='?src=\ref[src];tgui_fancy=1'><b>[(pref.tgui_fancy) ? "Fancy (default)" : "Compatible (slower)"]</b></a><br>"
 	. += "<b>tgui Window Placement:</b> <a href='?src=\ref[src];tgui_lock=1'><b>[(pref.tgui_lock) ? "Primary Monitor" : "Free (default)"]</b></a><br>"
 	if(can_select_ooc_color(user))
@@ -86,6 +94,20 @@
 		pref.client_fps = fps_new
 		if(pref.client)
 			pref.client.fps = fps_new
+		return TOPIC_REFRESH
+		
+	else if(href_list["select_ambience_freq"])
+		var/ambience_new = input(user, "Input how often you wish to hear ambience repeated! (1-60 MINUTES, 0 for disabled)", "Global Preference", pref.ambience_freq) as null|num
+		if(isnull(ambience_new) || !CanUseTopic(user)) return TOPIC_NOACTION
+		if(ambience_new < 0 || ambience_new > 60) return TOPIC_NOACTION
+		pref.ambience_freq = ambience_new
+		return TOPIC_REFRESH
+		
+	else if(href_list["select_ambience_chance"])
+		var/ambience_chance_new = input(user, "Input the chance you'd like to hear ambience played to you (On area change, or by random ambience). 35 means a 35% chance to play ambience. This is a range from 0-100. 0 disables ambience playing entirely. This is also affected by Ambience Frequency.", "Global Preference", pref.ambience_freq) as null|num
+		if(isnull(ambience_chance_new) || !CanUseTopic(user)) return TOPIC_NOACTION
+		if(ambience_chance_new < 0 || ambience_chance_new > 100) return TOPIC_NOACTION
+		pref.ambience_chance = ambience_chance_new
 		return TOPIC_REFRESH
 
 	else if(href_list["tgui_fancy"])

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -23,6 +23,8 @@ datum/preferences
 	var/UI_style_alpha = 255
 	var/tooltipstyle = "Midnight"		//Style for popup tooltips
 	var/client_fps = 0
+	var/ambience_freq = 5				// How often we're playing repeating ambience to a client.
+	var/ambience_chance = 35			// What's the % chance we'll play ambience (in conjunction with the above frequency)
 
 	var/tgui_fancy = TRUE
 	var/tgui_lock = FALSE

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -46,7 +46,7 @@
 	//Check if we're on fire
 	handle_fire()
 	
-	if(client)	// Handle re-running ambience to mobs if they've remained in an area, AND have an active client assigned to them.
+	if(client && !(client.prefs.ambience_freq == 0))	// Handle re-running ambience to mobs if they've remained in an area, AND have an active client assigned to them, and do not have repeating ambience disabled.
 		handle_ambience()
 	
 	//stuff in the stomach
@@ -92,10 +92,11 @@
 /mob/living/proc/handle_stomach()
 	return
 
-/mob/living/proc/handle_ambience() // If you're in an ambient area and have not moved out of it for x time, we're going to play ambience again to you, to help break up the silence.
-	if(world.time >= (lastareachange + 30 SECONDS)) // Every 30 seconds, we're going to run a 35% chance to play ambience.
+/mob/living/proc/handle_ambience() // If you're in an ambient area and have not moved out of it for x time as configured per-client, and do not have it disabled, we're going to play ambience again to you, to help break up the silence.
+	if(world.time >= (lastareachange + client.prefs.ambience_freq MINUTES)) // Every 5 minutes (by default, set per-client), we're going to run a 35% chance (by default, also set per-client) to play ambience.
 		var/area/A = get_area(src)
 		if(A)
+			lastareachange = world.time // This will refresh the last area change to prevent this call happening LITERALLY every life tick.
 			A.play_ambience(src, initial = FALSE)
 
 /mob/living/proc/update_pulling()


### PR DESCRIPTION
Adds a Random Ambience Frequency and Ambience Chance Setting under Global, underneath Client FPS. Images here:

![](https://i.imgur.com/381HPGH.png)
![](https://i.imgur.com/tWuff1W.png)
![](https://i.imgur.com/smEtoQ9.png)

Self-explanatory. Random-Ambience-Frequency controls how long before it checks if it can play ambience to you again. Setting it to 0 disables the random re-play of ambience.

Ambience Chance affects the % chance to play ambience to your client. It defaults to 35%, but can be set from 0 to 100 to disable it or always play every time you move into an area or have the Random Ambience check called.
