### PR TITLE
Fix Asset Cache Verification - BYOND js Bugfix

### DIFF
--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -1145,6 +1145,7 @@ window "mainwindow"
 		anchor1 = none
 		anchor2 = none
 		is-visible = false
+		auto-format = false
 		saved-params = ""
 	elem "hotkey_toggle"
 		type = BUTTON


### PR DESCRIPTION
BYOND is injecting html to load js shims into json files returned by xhr. this will get fixed in a later byond release, but this disables the functionality for the asset cache skin control today.

Fix to be removed once the HTML injection is removed from asset cache (pending a BYOND change).

/tg/ PR Here: https://github.com/tgstation/tgstation/pull/51202

Bug Report about how this is "intended" http://www.byond.com/forum/post/2602776