### PR TITLE
Restore TLV clamping (+ sound update for canister dispenser)

### DIFF
--- a/code/game/machinery/air_alarm.dm
+++ b/code/game/machinery/air_alarm.dm
@@ -691,6 +691,7 @@
 					TLV[env][name] = -1
 				else
 					TLV[env][name] = round(value, 0.01)
+				clamp_tlv_values(env, name)
 				// investigate_log(" treshold value for [env]:[name] was set to [value] by [key_name(usr)]",INVESTIGATE_ATMOS)
 				. = TRUE
 		if("mode")
@@ -706,6 +707,43 @@
 			atmos_reset()
 			. = TRUE
 	update_icon()
+
+// This big ol' mess just ensures that TLV always makes sense. If you set the max value below the min value,
+// it'll automatically update all the other values to keep it sane.
+/obj/machinery/alarm/proc/clamp_tlv_values(env, changed_threshold)
+	var/list/selected = TLV[env]
+	switch(changed_threshold)
+		if(1)
+			if(selected[1] > selected[2])
+				selected[2] = selected[1]
+			if(selected[1] > selected[3])
+				selected[3] = selected[1]
+			if(selected[1] > selected[4])
+				selected[4] = selected[1]
+		if(2)
+			if(selected[1] > selected[2])
+				selected[1] = selected[2]
+			if(selected[2] > selected[3])
+				selected[3] = selected[2]
+			if(selected[2] > selected[4])
+				selected[4] = selected[2]
+		if(3)
+			if(selected[1] > selected[3])
+				selected[1] = selected[3]
+			if(selected[2] > selected[3])
+				selected[2] = selected[3]
+			if(selected[3] > selected[4])
+				selected[4] = selected[3]
+		if(4)
+			if(selected[1] > selected[4])
+				selected[1] = selected[4]
+			if(selected[2] > selected[4])
+				selected[2] = selected[4]
+			if(selected[3] > selected[4])
+				selected[3] = selected[4]
+
+
+
 
 /obj/machinery/alarm/proc/atmos_reset()
 	if(alarm_area.atmosalert(0, src))

--- a/code/game/objects/structures/tank_dispenser.dm
+++ b/code/game/objects/structures/tank_dispenser.dm
@@ -107,7 +107,7 @@
 				usr.put_in_hands(tank)
 				phorontanks--
 			. = TRUE
-			playsound(src, 'sound/machines/vending/vending_drop.ogg', 100, 1, 1)
+			playsound(src, 'sound/items/drop/gascan.ogg', 100, 1, 1)
 		if("oxygen")
 			var/obj/item/weapon/tank/tank = null
 			for(var/obj/item/weapon/tank/T in src)
@@ -118,5 +118,5 @@
 				usr.put_in_hands(tank)
 				oxygentanks--
 			. = TRUE
-			playsound(src, 'sound/machines/vending/vending_drop.ogg', 100, 1, 1)
+			playsound(src, 'sound/items/drop/gascan.ogg', 100, 1, 1)
 	update_icon()


### PR DESCRIPTION
By request from Bluehaus. Air alarms clamp the TLV values to make sure minimum is always below maximum, and that danger-max is never below warning-max.
![https://i.tigercat2000.net/2020/08/qeDUe6X18d.webm](https://i.tigercat2000.net/2020/08/qeDUe6X18d.webm)