### PR TITLE
Persistence Patch

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -236,7 +236,8 @@ var/list/gamemode_cache = list()
 	var/static/dooc_allowed = 1
 	var/static/dsay_allowed = 1
 
-	var/persistence_enabled = 1
+	var/persistence_disabled = FALSE
+	var/persistence_ignore_mapload = FALSE
 
 	var/allow_byond_links = 0
 	var/allow_discord_links = 0
@@ -579,8 +580,11 @@ var/list/gamemode_cache = list()
 				if("protect_roles_from_antagonist")
 					config.protect_roles_from_antagonist = 1
 
-				if ("persistence_enabled")
-					config.persistence_enabled = 1
+				if("persistence_disabled")
+					config.persistence_disabled = TRUE // Previously this forcibly set persistence enabled in the saves.
+					
+				if("persistence_ignore_mapload")
+					config.persistence_ignore_mapload = TRUE
 
 				if ("probability")
 					var/prob_pos = findtext(value, " ")

--- a/code/controllers/subsystems/persistence.dm
+++ b/code/controllers/subsystems/persistence.dm
@@ -19,7 +19,7 @@ SUBSYSTEM_DEF(persistence)
 
 /datum/controller/subsystem/persistence/proc/track_value(var/atom/value, var/track_type)
 
-	if(config.persistence_enabled == 0) //if the config is not set to persistent nothing will save or load.
+	if(config.persistence_disabled) //if the config is set to persistence disabled, nothing will save or load.
 		return
 
 	var/turf/T = get_turf(value)

--- a/code/game/objects/effects/decals/cleanable.dm
+++ b/code/game/objects/effects/decals/cleanable.dm
@@ -12,12 +12,13 @@ generic_filth = TRUE means when the decal is saved, it will be switched out for 
 	var/age = 0
 	var/list/random_icon_states = list()
 
-/obj/effect/decal/cleanable/Initialize(var/ml, var/_age)
+/obj/effect/decal/cleanable/Initialize(var/mapload, var/_age)
 	if(!isnull(_age))
 		age = _age
 	if(random_icon_states && length(src.random_icon_states) > 0)
 		src.icon_state = pick(src.random_icon_states)
-	SSpersistence.track_value(src, /datum/persistent/filth)
+	if(!mapload || !config.persistence_ignore_mapload)
+		SSpersistence.track_value(src, /datum/persistent/filth)
 	. = ..()
 
 /obj/effect/decal/cleanable/Destroy()

--- a/code/game/objects/items/trash.dm
+++ b/code/game/objects/items/trash.dm
@@ -14,7 +14,7 @@
 	if(!isnull(_age))
 		age = _age
 
-/obj/item/trash/Initialize()
+/obj/item/trash/Initialize(mapload)
 	if(!mapload || !config.persistence_ignore_mapload)
 		SSpersistence.track_value(src, /datum/persistent/filth/trash)
 	. = ..()

--- a/code/game/objects/items/trash.dm
+++ b/code/game/objects/items/trash.dm
@@ -15,7 +15,8 @@
 		age = _age
 
 /obj/item/trash/Initialize()
-	SSpersistence.track_value(src, /datum/persistent/filth/trash)
+	if(!mapload || !config.persistence_ignore_mapload)
+		SSpersistence.track_value(src, /datum/persistent/filth/trash)
 	. = ..()
 
 /obj/item/trash/Destroy()

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -108,7 +108,7 @@ var/world_topic_spam_protect_time = world.timeofday
 		s["version"] = game_version
 		s["mode"] = master_mode
 		s["respawn"] = config.abandon_allowed
-		s["persistance"] = config.persistence_enabled
+		s["persistance"] = config.persistence_disabled
 		s["enter"] = config.enter_allowed
 		s["vote"] = config.allow_vote_mode
 		s["ai"] = config.allow_ai
@@ -529,7 +529,9 @@ var/world_topic_spam_protect_time = world.timeofday
 
 	features += config.abandon_allowed ? "respawn" : "no respawn"
 
-	features += config.persistence_enabled ? "persistence enabled" : "persistence disabled"
+	features += config.persistence_disabled ? "persistence disabled" : "persistence enabled"
+	
+	features += config.persistence_ignore_mapload ? "persistence mapload disabled" : "persistence mapload enabled"
 
 	if (config && config.allow_vote_mode)
 		features += "vote"

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -937,15 +937,29 @@ var/datum/announcement/minor/admin_min_announcer = new
 	set category = "Server"
 	set desc="Whether persistent data will be saved from now on."
 	set name="Toggle Persistent Data"
-	config.persistence_enabled = !(config.persistence_enabled)
-	if(config.persistence_enabled)
+	config.persistence_disabled = !(config.persistence_disabled)
+	if(!config.persistence_disabled)
 		to_world("<B>Persistence is now enabled..</B>")
 	else
 		to_world("<B>Persistence is no longer enabled.</B>")
-	message_admins("<font color='blue'>[key_name_admin(usr)] toggled persistence to [config.persistence_enabled ? "On" : "Off"].</font>", 1)
-	log_admin("[key_name(usr)] toggled persistence to [config.persistence_enabled ? "On" : "Off"].")
+	message_admins("<font color='blue'>[key_name_admin(usr)] toggled persistence to [config.persistence_disabled ? "Off" : "On"].</font>", 1)
+	log_admin("[key_name(usr)] toggled persistence to [config.persistence_disabled ? "Off" : "On"].")
 	world.update_status()
 	feedback_add_details("admin_verb","TPD") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+	
+/datum/admins/proc/togglemaploadpersistence()
+	set category = "Server"
+	set desc="Whether mapload persistent data will be saved from now on."
+	set name="Toggle Mapload Persistent Data"
+	config.persistence_ignore_mapload = !(config.persistence_ignore_mapload)
+	if(!config.persistence_ignore_mapload)
+		to_world("<B>Persistence is now enabled..</B>")
+	else
+		to_world("<B>Persistence is no longer enabled.</B>")
+	message_admins("<font color='blue'>[key_name_admin(usr)] toggled persistence to [config.persistence_ignore_mapload ? "Off" : "On"].</font>", 1)
+	log_admin("[key_name(usr)] toggled persistence to [config.persistence_ignore_mapload ? "Off" : "On"].")
+	world.update_status()
+	feedback_add_details("admin_verb","TMPD") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /datum/admins/proc/toggle_aliens()
 	set category = "Server"

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -34,6 +34,8 @@
 	var/spam_flag = 0
 	var/age = 0
 	var/last_modified_ckey
+	
+	var/was_maploaded = FALSE // This tracks if the paper was created on mapload.
 
 	var/const/deffont = "Verdana"
 	var/const/signfont = "Times New Roman"
@@ -102,6 +104,12 @@
 	return
 
 //lipstick wiping is in code/game/objects/items/weapons/cosmetics.dm!
+
+/obj/item/weapon/paper/Initialize(mapload)
+	. = ..()
+	
+	if(mapload) // Jank, but we do this to prevent maploaded papers from somehow stacking across rounds if re-added to the board by a player.
+		was_maploaded = TRUE
 
 /obj/item/weapon/paper/New(var/newloc, var/text, var/title)
 	..()
@@ -463,6 +471,7 @@
 		//t = html_encode(t)
 		t = replacetext(t, "\n", "<BR>")
 		t = parsepencode(t, i, usr, iscrayon) // Encode everything from pencode to html
+		was_maploaded = FALSE // Set this to FALSE because a user has written on us. This is for persistence purposes.
 
 
 		if(fields > 50)//large amount of fields creates a heavy load on the server, see updateinfolinks() and addtofield()

--- a/code/modules/persistence/datum/datum_filth.dm
+++ b/code/modules/persistence/datum/datum_filth.dm
@@ -1,7 +1,7 @@
 /datum/persistent/filth
 	name = "filth"
 	tokens_per_line = 5
-	entries_expire_at = 5
+	entries_expire_at = 4 // 4 rounds, 24 hours.
 
 /datum/persistent/filth/LabelTokens(var/list/tokens)
 	var/list/labelled_tokens = ..()

--- a/code/modules/persistence/datum/datum_graffiti.dm
+++ b/code/modules/persistence/datum/datum_graffiti.dm
@@ -1,7 +1,7 @@
 /datum/persistent/graffiti
 	name = "graffiti"
 	tokens_per_line = 6
-	entries_expire_at = 50
+	entries_expire_at = 4 // This previously was at 50 rounds??? Over 10 days.
 	has_admin_data = TRUE
 
 /datum/persistent/graffiti/LabelTokens(var/list/tokens)

--- a/code/modules/persistence/datum/datum_paper.dm
+++ b/code/modules/persistence/datum/datum_paper.dm
@@ -25,7 +25,7 @@
 		return
 	var/obj/item/weapon/paper/paper = new paper_type(creating)
 	paper.info = tokens["message"]
-	paper.title = tokens["title"])
+	paper.title = tokens["title"]
 	paper.last_modified_ckey = tokens["author"]
 	if(requires_noticeboard)
 		board.add_paper(paper)

--- a/code/modules/persistence/datum/datum_paper.dm
+++ b/code/modules/persistence/datum/datum_paper.dm
@@ -25,7 +25,7 @@
 		return
 	var/obj/item/weapon/paper/paper = new paper_type(creating)
 	paper.info = tokens["message"]
-	paper.title = tokens["title"]
+	paper.name = tokens["title"]
 	paper.last_modified_ckey = tokens["author"]
 	if(requires_noticeboard)
 		board.add_paper(paper)

--- a/code/modules/persistence/datum/datum_paper.dm
+++ b/code/modules/persistence/datum/datum_paper.dm
@@ -24,11 +24,13 @@
 	if(requires_noticeboard && LAZYLEN(board.notices) >= board.max_notices)
 		return
 	var/obj/item/weapon/paper/paper = new paper_type(creating)
-	paper.set_content(tokens["message"], tokens["title"])
+	paper.info = tokens["message"]
+	paper.title = tokens["title"])
 	paper.last_modified_ckey = tokens["author"]
 	if(requires_noticeboard)
 		board.add_paper(paper)
-	SSpersistence.track_value(paper, type)
+	if(!paper.was_maploaded) // If we were created/loaded when the map was made, skip us!
+		SSpersistence.track_value(paper, type)
 	return paper
 
 /datum/persistent/paper/GetEntryAge(var/atom/entry)

--- a/code/modules/persistence/datum/persistence_datum.dm
+++ b/code/modules/persistence/datum/persistence_datum.dm
@@ -6,8 +6,8 @@
 	var/name
 	var/filename
 	var/tokens_per_line
-	var/entries_expire_at
-	var/entries_decay_at
+	var/entries_expire_at						// Set in rounds, this controls when the item is finally removed permanently regardless if cleaned or not.
+	var/entries_decay_at						// Set in rounds. This controls when item messages start getting scrambled.
 	var/entry_decay_weight = 0.5
 	var/file_entry_split_character = "\t"
 	var/file_entry_substitute_character = " "

--- a/code/modules/persistence/graffiti.dm
+++ b/code/modules/persistence/graffiti.dm
@@ -21,7 +21,7 @@
 	if(!isnull(author))
 		author = _author
 
-/obj/effect/decal/writing/Initialize()
+/obj/effect/decal/writing/Initialize(mapload)
 	var/list/random_icon_states = icon_states(icon)
 	for(var/obj/effect/decal/writing/W in loc)
 		random_icon_states.Remove(W.icon_state)

--- a/code/modules/persistence/graffiti.dm
+++ b/code/modules/persistence/graffiti.dm
@@ -27,7 +27,8 @@
 		random_icon_states.Remove(W.icon_state)
 	if(random_icon_states.len)
 		icon_state = pick(random_icon_states)
-	SSpersistence.track_value(src, /datum/persistent/graffiti)
+	if(!mapload || !config.persistence_ignore_mapload)
+		SSpersistence.track_value(src, /datum/persistent/graffiti)
 	. = ..()
 
 /obj/effect/decal/writing/Destroy()

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -151,6 +151,12 @@ TRAITOR_SCALING
 ## If security is prohibited from being most antagonists
 #PROTECT_ROLES_FROM_ANTAGONIST
 
+## Uncomment this to DISABLE persistence
+#PERSISTENCE_DISABLED
+
+## Uncomment this to DISABLE maploaded trash/paper/etc from being saved by the persistence system.
+#PERSISTENCE_IGNORE_MAPLOAD
+
 ## Comment this out to stop admins being able to choose their personal ooccolor
 ALLOW_ADMIN_OOCCOLOR
 


### PR DESCRIPTION
- Fixes Paper and font tags stacking across rounds, as shown in: ![](https://cdn.discordapp.com/attachments/187013248309002240/741937939382141000/164fdd3a37fb22f18dfa9b5c431ffc04.png)

- Fixes Graffiti being persistent for over 50 rounds (10+ days)
- Sets Trash to be persistent for 4 rounds instead of 5
- Fixes Persistence being always-on because of if("persistence_enabled") config.persistence_enabled = 1. As explained: 
> it's on by default, which means config.txt will be read and if it's not there it stays at 1. If it is there,it gets set to 1. There is no way to disable it

- Adds config options to enable/disable **Persistence for Maploaded objects**, as well as a verb to toggle such.
- Adds Persistence to config.

Currently IGNORE_MAPLOAD for Persistance is **Disabled.**
Maploaded objects/dirt/etc will be saved by persistence, preserving current behavior.

You will need to update config.txt with the following lines:
\## Uncomment this to DISABLE persistence 
\#PERSISTENCE_DISABLED 
 
\## Uncomment this to DISABLE maploaded trash/paper/etc from being saved by the persistence system. 
\#PERSISTENCE_IGNORE_MAPLOAD 