### PR TITLE
Fixes Nanotrasen Uniforms to account for Solgov Path Changes

### DIFF
--- a/code/modules/clothing/under/nanotrasen_vr.dm
+++ b/code/modules/clothing/under/nanotrasen_vr.dm
@@ -3,29 +3,32 @@
 /obj/item/clothing/under/nanotrasen
 	name = "NanoTrasen uniform"
 	desc = "A comfortable turtleneck and black trousers sporting nanotrasen symbols."
-	icon_state = "navyutility"
-	worn_state = "navyutility"
+	icon = 'icons/obj/clothing/uniforms_solgov.dmi'
+	icon_override = 'icons/mob/uniform_solgov.dmi'
+	item_icons = list(slot_w_uniform_str = 'icons/mob/uniform_solgov.dmi', slot_r_hand_str = "black", slot_l_hand_str = "black")
+	icon_state = "blackutility"
+	worn_state = "blackutility"
 	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 0, rad = 0)
 	siemens_coefficient = 0.9
 
 /obj/item/clothing/under/nanotrasen/security
 	name = "NanoTrasen security uniform"
 	desc = "The security uniform of NanoTrasen's security. It looks sturdy and well padded"
-	icon_state = "navyutility_sec"
-	worn_state = "navyutility_sec"
+	icon_state = "blackutility_crew"
+	worn_state = "blackutility_crew"
 	armor = list(melee = 10, bullet = 5, laser = 5, energy = 5, bomb = 5, bio = 0, rad = 0)
 
 /obj/item/clothing/under/nanotrasen/security/warden
 	name = "NanoTrasen warden uniform"
 	desc = "The uniform of the NanoTrasen's prison wardens. It looks sturdy and well padded. This one has gold cuffs."
-	icon_state = "navyutility_com"
-	worn_state = "navyutility_com"
+	icon_state = "blackutility_com"
+	worn_state = "blackutility_com"
 
 /obj/item/clothing/under/nanotrasen/security/commander
 	name = "NanoTrasen security command uniform"
 	desc = "The uniform of the NanoTrasen's security commanding officers. It looks sturdy and well padded. This one has gold trim and red blazes."
-	icon_state = "blackutility_seccom"
-	worn_state = "blackutility_seccom"
+	icon_state = "blackutility_com"
+	worn_state = "blackutility_com"
 
 //Head Gear
 
@@ -42,7 +45,7 @@
 /obj/item/clothing/head/beret/nanotrasen
 	name = "NanoTrasen security beret"
 	desc = "A NT blue beret belonging to the NanoTrasen security forces. For personnel that are more inclined towards style than safety."
-	icon_state = "beret_navy"
+	icon_state = "beret_navy_security"
 
 //Armor
 


### PR DESCRIPTION
This was introduced thanks to a PR in mid-2019, and NT Sec/etc uniforms had been broken since then.

Screenshot of broken uniforms:
![](https://i.imgur.com/AVii80Z.png)

As of now, the in-hand sprite is the only one that's 'broken', display JSUIT on your sprite, but the actual UI in-hand works, the on-ground works, the on-mob works, so frankly, after two+ hours, I'm calling it good here.

This fixes all derivative NT uniforms too.
