### PR TITLE
Minor Talon Edits

### DIFF
--- a/maps/tether/submaps/offmap/talon1.dmm
+++ b/maps/tether/submaps/offmap/talon1.dmm
@@ -158,6 +158,9 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
+/obj/structure/closet/wardrobe/black{
+	starts_with = list(/obj/item/clothing/under/color/black = 4, /obj/item/clothing/shoes/black = 4, /obj/item/clothing/head/soft/black = 4, /obj/item/clothing/mask/bandana = 4, /obj/item/weapon/storage/backpack/messenger/black = 4, /obj/item/weapon/storage/backpack/dufflebag = 4)
+	},
 /turf/simulated/floor/tiled/eris/white/orangecorner,
 /area/talon/deckone/armory)
 "as" = (

--- a/maps/tether/submaps/offmap/talon1.dmm
+++ b/maps/tether/submaps/offmap/talon1.dmm
@@ -216,9 +216,76 @@
 /obj/machinery/chemical_dispenser/full,
 /turf/simulated/floor/tiled/eris/white/bluecorner,
 /area/talon/deckone/medical)
+"ax" = (
+/obj/machinery/camera/network/talon,
+/obj/structure/closet/wardrobe/black{
+	starts_with = list(/obj/item/clothing/head/helmet/combat = 4, /obj/item/clothing/mask/gas/commando = 4, /obj/item/clothing/mask/balaclava = 4, /obj/item/clothing/under/syndicate/combat = 4, /obj/item/clothing/accessory/storage/black_vest = 4, /obj/item/clothing/accessory/storage/black_drop_pouches = 4, /obj/item/clothing/gloves/combat = 4, /obj/item/clothing/suit/armor/combat = 4, /obj/item/clothing/shoes/boots/combat = 4)
+	},
+/turf/simulated/floor/tiled/eris/white/danger,
+/area/talon/deckone/armory)
+"ay" = (
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_y = 0
+	},
+/turf/simulated/floor/plating/eris/under,
+/area/talon/maintenance/deckone_port)
+"az" = (
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_x = 0
+	},
+/turf/simulated/floor/plating/eris/under,
+/area/talon/maintenance/deckone_starboard)
+"aA" = (
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/light/small,
+/turf/simulated/floor/plating/eris/under,
+/area/talon/maintenance/deckone_port)
+"aB" = (
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	icon_state = "1-8"
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/light/small,
+/turf/simulated/floor/plating/eris/under,
+/area/talon/maintenance/deckone_starboard)
 "aC" = (
 /turf/simulated/wall/rshull,
 /area/talon/maintenance/deckone_port)
+"aD" = (
+/obj/structure/closet/wardrobe/black{
+	starts_with = list(/obj/item/clothing/head/helmet/space/syndicate/black = 4, /obj/item/clothing/suit/space/syndicate/black = 4, /obj/item/clothing/shoes/magboots = 4)
+	},
+/turf/simulated/floor/tiled/eris/white/danger,
+/area/talon/deckone/armory)
 "aK" = (
 /turf/simulated/wall/rshull,
 /area/talon/maintenance/deckone_starboard)
@@ -1165,20 +1232,6 @@
 /obj/machinery/optable,
 /turf/simulated/floor/tiled/eris/white/bluecorner,
 /area/talon/deckone/medical)
-"iw" = (
-/obj/structure/catwalk,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating/eris/under,
-/area/talon/maintenance/deckone_port)
 "ix" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
@@ -4333,14 +4386,6 @@
 	},
 /turf/simulated/floor/tiled/eris/steel,
 /area/talon/deckone/central_hallway)
-"Lm" = (
-/obj/structure/table/rack/steel,
-/obj/item/clothing/suit/armor/combat,
-/obj/item/clothing/head/helmet/combat,
-/obj/item/clothing/under/syndicate/combat,
-/obj/machinery/camera/network/talon,
-/turf/simulated/floor/tiled/eris/white/danger,
-/area/talon/deckone/armory)
 "Lt" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction{
@@ -4549,18 +4594,6 @@
 	},
 /turf/simulated/floor/plating/eris/under,
 /area/talon/maintenance/deckone_port)
-"MJ" = (
-/obj/structure/catwalk,
-/obj/structure/cable/green{
-	icon_state = "1-8"
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating/eris/under,
-/area/talon/maintenance/deckone_starboard)
 "ML" = (
 /obj/structure/catwalk,
 /obj/structure/cable/green{
@@ -5225,13 +5258,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/eris/steel,
 /area/talon/deckone/central_hallway)
-"TN" = (
-/obj/structure/table/rack/steel,
-/obj/item/clothing/suit/space/syndicate/black,
-/obj/item/clothing/head/helmet/space/syndicate/black,
-/obj/item/clothing/shoes/magboots,
-/turf/simulated/floor/tiled/eris/white/danger,
-/area/talon/deckone/armory)
 "TO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/aux,
 /obj/machinery/alarm/talon{
@@ -14548,12 +14574,12 @@ am
 am
 am
 yC
-GH
+ay
 GH
 GH
 VY
 GH
-iw
+aA
 cl
 Se
 FQ
@@ -16533,9 +16559,9 @@ ab
 ab
 ab
 ac
-Lm
+ax
 Fl
-TN
+aD
 Fl
 xd
 aY
@@ -17104,12 +17130,12 @@ sI
 Of
 qA
 mN
-sL
+az
 sL
 sL
 BD
 sL
-MJ
+aB
 co
 yN
 kz

--- a/maps/tether/submaps/offmap/talon2.dmm
+++ b/maps/tether/submaps/offmap/talon2.dmm
@@ -119,6 +119,18 @@
 	},
 /turf/simulated/floor/plating/eris/under,
 /area/talon/maintenance/decktwo_aft)
+"ar" = (
+/obj/structure/closet/secure_closet/personal/cabinet{
+	locked = 0
+	},
+/turf/simulated/floor/wood,
+/area/talon/decktwo/eng_room)
+"as" = (
+/obj/structure/closet/secure_closet/personal/cabinet{
+	locked = 0
+	},
+/turf/simulated/floor/wood,
+/area/talon/decktwo/pilot_room)
 "at" = (
 /turf/simulated/floor/tiled/eris/steel,
 /area/talon/decktwo/central_hallway)
@@ -185,6 +197,18 @@
 "aC" = (
 /turf/simulated/wall,
 /area/talon/decktwo/cap_room)
+"aD" = (
+/obj/structure/closet/secure_closet/personal/cabinet{
+	locked = 0
+	},
+/turf/simulated/floor/wood,
+/area/talon/decktwo/med_room)
+"aE" = (
+/obj/structure/closet/secure_closet/personal/cabinet{
+	locked = 0
+	},
+/turf/simulated/floor/wood,
+/area/talon/decktwo/sec_room)
 "aF" = (
 /obj/structure/bed/chair/bay/chair,
 /turf/simulated/floor/wood,
@@ -203,6 +227,29 @@
 	},
 /turf/simulated/floor/tiled/eris/white,
 /area/talon/decktwo/central_hallway)
+"aI" = (
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_y = 0
+	},
+/turf/simulated/floor/plating/eris/under,
+/area/talon/maintenance/decktwo_port)
+"aJ" = (
+/obj/machinery/atmospherics/pipe/simple/visible/supply{
+	dir = 4
+	},
+/obj/structure/catwalk,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/plating/eris/under,
+/area/talon/maintenance/decktwo_aft)
 "aK" = (
 /turf/simulated/floor/carpet/blucarpet,
 /area/talon/decktwo/cap_room)
@@ -991,10 +1038,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/talon/decktwo/eng_room)
-"eE" = (
-/obj/structure/closet/secure_closet/personal/cabinet,
-/turf/simulated/floor/wood,
-/area/talon/decktwo/eng_room)
 "eF" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -1020,10 +1063,6 @@
 	dir = 1
 	},
 /obj/structure/closet/secure_closet/talon_pilot,
-/turf/simulated/floor/wood,
-/area/talon/decktwo/pilot_room)
-"eJ" = (
-/obj/structure/closet/secure_closet/personal/cabinet,
 /turf/simulated/floor/wood,
 /area/talon/decktwo/pilot_room)
 "eK" = (
@@ -1346,10 +1385,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/talon/decktwo/med_room)
-"ga" = (
-/obj/structure/closet/secure_closet/personal/cabinet,
-/turf/simulated/floor/wood,
-/area/talon/decktwo/med_room)
 "gb" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -1362,10 +1397,6 @@
 	dir = 1
 	},
 /obj/structure/closet/secure_closet/talon_guard,
-/turf/simulated/floor/wood,
-/area/talon/decktwo/sec_room)
-"gd" = (
-/obj/structure/closet/secure_closet/personal/cabinet,
 /turf/simulated/floor/wood,
 /area/talon/decktwo/sec_room)
 "ge" = (
@@ -12986,7 +13017,7 @@ Qt
 lx
 lx
 lx
-lx
+aI
 lx
 lx
 lx
@@ -13277,7 +13308,7 @@ cc
 gZ
 gZ
 hu
-WG
+aJ
 mm
 ht
 ao
@@ -13829,13 +13860,13 @@ dz
 dM
 ea
 eo
-eE
+ar
 dr
 eV
 fm
 fA
 fN
-ga
+aD
 eT
 gn
 gn
@@ -15249,13 +15280,13 @@ dH
 dU
 eh
 ew
-eJ
+as
 du
 fb
 fs
 fG
 fT
-gd
+aE
 eZ
 gn
 gn
@@ -16110,7 +16141,7 @@ Az
 QA
 QA
 QA
-QA
+AX
 QA
 QA
 QA


### PR DESCRIPTION
Made the armory a bit more friendly with actual lockers instead of just racks, and clothing enough for four crew instead of just one. Also includes an extra locker with black civillian garb and bags... In the armory, because I have no idea where else to put it on the tiny Talon.

Added a few more lights in maints in a few areas.

Unlocked personal lockers roundstart so that they could, you know, actually be used by the Talon crew.

