### PR TITLE
Fix unintended inbelly item interactions caused by copypaste

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -111,12 +111,11 @@
 		trigger_aiming(TARGET_CAN_CLICK)
 		return 1
 
-	// VOREStation Addition Start: inbelly item interaction
+	// VOREStation Addition Start: inbelly interaction
 	if(isbelly(loc) && (loc == A.loc))
 		if(W)
-			var/resolved = W.resolve_attackby(A,src)
-			if(!resolved && A && W)
-				W.afterattack(A, src, 1, params) // 1: clicking something Adjacent
+			to_chat(src, "The firm confines prevent that kind of dexterity!")	//Only hand-based interactions in bellies
+			return
 		else
 			if(ismob(A)) // No instant mob attacking
 				setClickCooldown(get_attack_speed())


### PR DESCRIPTION
Originally it was just a copypaste of different section of code, but looking at it in retrospect, the only part supposed to be happening is part with empty hands, supported even by the wording in vore panel. Fixes that but adds message when trying to do stuff with items in your hands, so that its not silent unexplained denial as it was before the interaction fix went through.