### PR TITLE
Makes Pint Metaglasses Printable

### DIFF
--- a/code/datums/autolathe/general_vr.dm
+++ b/code/datums/autolathe/general_vr.dm
@@ -30,6 +30,11 @@
 	name = "metamorphic glass"
 	path =/obj/item/weapon/reagent_containers/food/drinks/metaglass
 	is_stack = TRUE
+	
+/datum/category_item/autolathe/general/metaglass_pint
+	name = "metamorphic pint glass"
+	path =/obj/item/weapon/reagent_containers/food/drinks/metaglass/metapint
+	is_stack = TRUE
 
 /datum/category_item/autolathe/general/drinkingglass_carafe
 	name = "glass carafe"


### PR DESCRIPTION
TL;DR Only Virgo and downstreams can print metaglasses, but we never added printing for the pint version.
