### PR TITLE
Talon Bugfixes and QOL

### DIFF
--- a/maps/tether/submaps/offmap/talon1.dmm
+++ b/maps/tether/submaps/offmap/talon1.dmm
@@ -56,9 +56,7 @@
 	dir = 4;
 	icon_state = "map_connector-aux"
 	},
-/obj/machinery/portable_atmospherics/canister/air/airlock{
-	start_pressure = 4559.63
-	},
+/obj/machinery/portable_atmospherics/canister/air/airlock,
 /turf/simulated/floor/tiled/eris/steel/gray_perforated,
 /area/talon/deckone/port_eng)
 "ai" = (
@@ -202,9 +200,7 @@
 	dir = 8;
 	icon_state = "map_connector-aux"
 	},
-/obj/machinery/portable_atmospherics/canister/air/airlock{
-	start_pressure = 4559.63
-	},
+/obj/machinery/portable_atmospherics/canister/air/airlock,
 /turf/simulated/floor/tiled/eris/steel/gray_perforated,
 /area/talon/deckone/starboard_eng)
 "av" = (

--- a/maps/tether/submaps/offmap/talon1.dmm
+++ b/maps/tether/submaps/offmap/talon1.dmm
@@ -158,6 +158,9 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
+/obj/structure/closet/wardrobe/black{
+	starts_with = list(/obj/item/clothing/under/color/black = 4, /obj/item/clothing/shoes/black = 4, /obj/item/clothing/head/soft/black = 4, /obj/item/clothing/mask/bandana = 4, /obj/item/weapon/storage/backpack/messenger/black = 4, /obj/item/weapon/storage/backpack/dufflebag = 4)
+	},
 /turf/simulated/floor/tiled/eris/white/orangecorner,
 /area/talon/deckone/armory)
 "as" = (

--- a/maps/tether/submaps/offmap/talon1.dmm
+++ b/maps/tether/submaps/offmap/talon1.dmm
@@ -216,9 +216,76 @@
 /obj/machinery/chemical_dispenser/full,
 /turf/simulated/floor/tiled/eris/white/bluecorner,
 /area/talon/deckone/medical)
+"ax" = (
+/obj/machinery/camera/network/talon,
+/obj/structure/closet/wardrobe/black{
+	starts_with = list(/obj/item/clothing/head/helmet/combat = 4, /obj/item/clothing/mask/gas/commando = 4, /obj/item/clothing/mask/balaclava = 4, /obj/item/clothing/under/syndicate/combat = 4, /obj/item/clothing/accessory/storage/black_vest = 4, /obj/item/clothing/accessory/storage/black_drop_pouches = 4, /obj/item/clothing/gloves/combat = 4, /obj/item/clothing/suit/armor/combat = 4, /obj/item/clothing/shoes/boots/combat = 4)
+	},
+/turf/simulated/floor/tiled/eris/white/danger,
+/area/talon/deckone/armory)
+"ay" = (
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_y = 0
+	},
+/turf/simulated/floor/plating/eris/under,
+/area/talon/maintenance/deckone_port)
+"az" = (
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_x = 0
+	},
+/turf/simulated/floor/plating/eris/under,
+/area/talon/maintenance/deckone_starboard)
+"aA" = (
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/light/small,
+/turf/simulated/floor/plating/eris/under,
+/area/talon/maintenance/deckone_port)
+"aB" = (
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	icon_state = "1-8"
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/light/small,
+/turf/simulated/floor/plating/eris/under,
+/area/talon/maintenance/deckone_starboard)
 "aC" = (
 /turf/simulated/wall/rshull,
 /area/talon/maintenance/deckone_port)
+"aD" = (
+/obj/structure/closet/wardrobe/black{
+	starts_with = list(/obj/item/clothing/head/helmet/space/syndicate/black = 4, /obj/item/clothing/suit/space/syndicate/black = 4, /obj/item/clothing/shoes/magboots = 4)
+	},
+/turf/simulated/floor/tiled/eris/white/danger,
+/area/talon/deckone/armory)
 "aK" = (
 /turf/simulated/wall/rshull,
 /area/talon/maintenance/deckone_starboard)
@@ -1165,20 +1232,6 @@
 /obj/machinery/optable,
 /turf/simulated/floor/tiled/eris/white/bluecorner,
 /area/talon/deckone/medical)
-"iw" = (
-/obj/structure/catwalk,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating/eris/under,
-/area/talon/maintenance/deckone_port)
 "ix" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
@@ -4333,14 +4386,6 @@
 	},
 /turf/simulated/floor/tiled/eris/steel,
 /area/talon/deckone/central_hallway)
-"Lm" = (
-/obj/structure/table/rack/steel,
-/obj/item/clothing/suit/armor/combat,
-/obj/item/clothing/head/helmet/combat,
-/obj/item/clothing/under/syndicate/combat,
-/obj/machinery/camera/network/talon,
-/turf/simulated/floor/tiled/eris/white/danger,
-/area/talon/deckone/armory)
 "Lt" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction{
@@ -4549,18 +4594,6 @@
 	},
 /turf/simulated/floor/plating/eris/under,
 /area/talon/maintenance/deckone_port)
-"MJ" = (
-/obj/structure/catwalk,
-/obj/structure/cable/green{
-	icon_state = "1-8"
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating/eris/under,
-/area/talon/maintenance/deckone_starboard)
 "ML" = (
 /obj/structure/catwalk,
 /obj/structure/cable/green{
@@ -5225,13 +5258,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/eris/steel,
 /area/talon/deckone/central_hallway)
-"TN" = (
-/obj/structure/table/rack/steel,
-/obj/item/clothing/suit/space/syndicate/black,
-/obj/item/clothing/head/helmet/space/syndicate/black,
-/obj/item/clothing/shoes/magboots,
-/turf/simulated/floor/tiled/eris/white/danger,
-/area/talon/deckone/armory)
 "TO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/aux,
 /obj/machinery/alarm/talon{
@@ -14548,12 +14574,12 @@ am
 am
 am
 yC
-GH
+ay
 GH
 GH
 VY
 GH
-iw
+aA
 cl
 Se
 FQ
@@ -16533,9 +16559,9 @@ ab
 ab
 ab
 ac
-Lm
+ax
 Fl
-TN
+aD
 Fl
 xd
 aY
@@ -17104,12 +17130,12 @@ sI
 Of
 qA
 mN
-sL
+az
 sL
 sL
 BD
 sL
-MJ
+aB
 co
 yN
 kz

--- a/maps/tether/submaps/offmap/talon1.dmm
+++ b/maps/tether/submaps/offmap/talon1.dmm
@@ -313,26 +313,36 @@
 /area/talon/maintenance/deckone_starboard)
 "aG" = (
 /obj/structure/catwalk,
-/obj/structure/sign/warning/moving_parts{
-	pixel_x = 30
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction{
+	dir = 8;
+	icon_state = "intact"
 	},
-/turf/simulated/floor/plating/eris/under,
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction{
+	dir = 8;
+	icon_state = "intact"
+	},
+/obj/structure/handrail{
+	dir = 8
+	},
+/turf/space,
 /area/talon/maintenance/deckone_port_fore_wing)
 "aH" = (
 /obj/structure/catwalk,
-/obj/structure/sign/warning/moving_parts{
-	pixel_x = -30
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction{
+	dir = 4;
+	icon_state = "intact"
 	},
-/turf/simulated/floor/plating/eris/under,
+/obj/structure/handrail{
+	dir = 4
+	},
+/turf/space,
 /area/talon/maintenance/deckone_starboard_fore_wing)
 "aI" = (
 /obj/structure/catwalk,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/sign/warning/moving_parts{
+	pixel_x = 30
 	},
-/turf/simulated/floor/plating/eris/under,
+/turf/space,
 /area/talon/maintenance/deckone_port_fore_wing)
 "aJ" = (
 /obj/structure/table/rack/shelf/steel,
@@ -396,19 +406,27 @@
 /area/talon/deckone/secure_storage)
 "aS" = (
 /obj/structure/catwalk,
+/obj/structure/sign/warning/moving_parts{
+	pixel_x = -30
+	},
+/turf/space,
+/area/talon/maintenance/deckone_starboard_fore_wing)
+"aT" = (
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/space,
+/area/talon/maintenance/deckone_port_fore_wing)
+"aU" = (
+/obj/structure/catwalk,
 /obj/structure/cable/green{
 	dir = 1;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/plating/eris/under,
-/area/talon/maintenance/deckone_starboard_fore_wing)
-"aT" = (
-/obj/structure/catwalk,
-/turf/simulated/floor/plating/eris/under,
-/area/talon/maintenance/deckone_port_fore_wing)
-"aU" = (
-/obj/structure/catwalk,
-/turf/simulated/floor/plating/eris/under,
+/turf/space,
 /area/talon/maintenance/deckone_starboard_fore_wing)
 "aV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/aux,
@@ -441,12 +459,12 @@
 /area/talon/deckone/armory)
 "aZ" = (
 /obj/structure/catwalk,
-/turf/simulated/floor/plating/eris/under,
-/area/talon/maintenance/deckone_port_aft_wing)
+/turf/space,
+/area/talon/maintenance/deckone_port_fore_wing)
 "ba" = (
 /obj/structure/catwalk,
-/turf/simulated/floor/plating/eris/under,
-/area/talon/maintenance/deckone_starboard_aft_wing)
+/turf/space,
+/area/talon/maintenance/deckone_starboard_fore_wing)
 "bb" = (
 /obj/structure/closet/secure_closet/chemical{
 	req_access = list(301)
@@ -455,21 +473,17 @@
 /area/talon/deckone/medical)
 "bc" = (
 /obj/structure/catwalk,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/handrail{
+	dir = 8
 	},
-/turf/simulated/floor/plating/eris/under,
+/turf/space,
 /area/talon/maintenance/deckone_port_aft_wing)
 "bd" = (
 /obj/structure/catwalk,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/handrail{
+	dir = 4
 	},
-/turf/simulated/floor/plating/eris/under,
+/turf/space,
 /area/talon/maintenance/deckone_starboard_aft_wing)
 "be" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -505,13 +519,9 @@
 /turf/simulated/floor/tiled/eris/white/bluecorner,
 /area/talon/deckone/medical)
 "bi" = (
-/obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 0
-	},
 /obj/structure/catwalk,
-/turf/simulated/floor/plating/eris/under,
-/area/talon/maintenance/deckone_port)
+/turf/space,
+/area/talon/maintenance/deckone_port_aft_wing)
 "bj" = (
 /obj/structure/window/reinforced,
 /turf/simulated/floor/tiled/eris/steel,
@@ -524,56 +534,42 @@
 /turf/simulated/floor/plating/eris/under,
 /area/talon/maintenance/deckone_starboard)
 "bl" = (
+/obj/structure/catwalk,
+/turf/space,
+/area/talon/maintenance/deckone_starboard_aft_wing)
+"bm" = (
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/space,
+/area/talon/maintenance/deckone_port_aft_wing)
+"bn" = (
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/space,
+/area/talon/maintenance/deckone_starboard_aft_wing)
+"bo" = (
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_y = 0
+	},
+/obj/structure/catwalk,
+/turf/space,
+/area/talon/maintenance/deckone_port)
+"bp" = (
 /obj/machinery/light/small{
 	dir = 8;
 	pixel_y = 0
 	},
 /obj/structure/catwalk,
-/turf/simulated/floor/plating/eris/under,
-/area/talon/maintenance/deckone_starboard)
-"bm" = (
-/obj/machinery/airlock_sensor{
-	dir = 8;
-	pixel_x = 28;
-	pixel_y = 28;
-	req_one_access = list(301)
-	},
-/obj/effect/map_helper/airlock/sensor/ext_sensor,
-/obj/structure/catwalk,
-/turf/simulated/floor/plating/eris/under,
-/area/talon/maintenance/deckone_port)
-"bn" = (
-/obj/machinery/airlock_sensor{
-	dir = 4;
-	pixel_x = -28;
-	pixel_y = 28;
-	req_one_access = list(301)
-	},
-/obj/effect/map_helper/airlock/sensor/ext_sensor,
-/obj/structure/catwalk,
-/turf/simulated/floor/plating/eris/under,
-/area/talon/maintenance/deckone_starboard)
-"bo" = (
-/obj/structure/catwalk,
-/obj/structure/sign/warning/moving_parts{
-	pixel_x = 30
-	},
-/obj/machinery/camera/network/talon{
-	dir = 8;
-	icon_state = "camera"
-	},
-/turf/simulated/floor/plating/eris/under,
-/area/talon/maintenance/deckone_port)
-"bp" = (
-/obj/structure/catwalk,
-/obj/structure/sign/warning/moving_parts{
-	pixel_x = -30
-	},
-/obj/machinery/camera/network/talon{
-	dir = 4;
-	icon_state = "camera"
-	},
-/turf/simulated/floor/plating/eris/under,
+/turf/space,
 /area/talon/maintenance/deckone_starboard)
 "bq" = (
 /obj/machinery/airlock_sensor{
@@ -664,20 +660,16 @@
 /turf/simulated/floor/tiled/eris/dark/brown_perforated,
 /area/talon/deckone/port_eng)
 "bx" = (
+/obj/machinery/airlock_sensor{
+	dir = 8;
+	pixel_x = 28;
+	pixel_y = 28;
+	req_one_access = list(301)
+	},
+/obj/effect/map_helper/airlock/sensor/ext_sensor,
 /obj/structure/catwalk,
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction{
-	dir = 8;
-	icon_state = "intact"
-	},
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction{
-	dir = 8;
-	icon_state = "intact"
-	},
-/obj/structure/handrail{
-	dir = 8
-	},
-/turf/simulated/floor/plating/eris/under,
-/area/talon/maintenance/deckone_port_fore_wing)
+/turf/space,
+/area/talon/maintenance/deckone_port)
 "by" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4;
@@ -698,30 +690,38 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/talon/deckone/armory)
 "bz" = (
-/obj/structure/catwalk,
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction{
+/obj/machinery/airlock_sensor{
 	dir = 4;
-	icon_state = "intact"
+	pixel_x = -28;
+	pixel_y = 28;
+	req_one_access = list(301)
 	},
-/obj/structure/handrail{
-	dir = 4
-	},
-/turf/simulated/floor/plating/eris/under,
-/area/talon/maintenance/deckone_starboard_fore_wing)
+/obj/effect/map_helper/airlock/sensor/ext_sensor,
+/obj/structure/catwalk,
+/turf/space,
+/area/talon/maintenance/deckone_starboard)
 "bA" = (
 /obj/structure/catwalk,
-/obj/structure/handrail{
-	dir = 8
+/obj/structure/sign/warning/moving_parts{
+	pixel_x = 30
 	},
-/turf/simulated/floor/plating/eris/under,
-/area/talon/maintenance/deckone_port_aft_wing)
+/obj/machinery/camera/network/talon{
+	dir = 8;
+	icon_state = "camera"
+	},
+/turf/space,
+/area/talon/maintenance/deckone_port)
 "bB" = (
 /obj/structure/catwalk,
-/obj/structure/handrail{
-	dir = 4
+/obj/structure/sign/warning/moving_parts{
+	pixel_x = -30
 	},
-/turf/simulated/floor/plating/eris/under,
-/area/talon/maintenance/deckone_starboard_aft_wing)
+/obj/machinery/camera/network/talon{
+	dir = 4;
+	icon_state = "camera"
+	},
+/turf/space,
+/area/talon/maintenance/deckone_starboard)
 "bC" = (
 /obj/structure/table/rack,
 /obj/item/weapon/storage/box/bodybags,
@@ -13403,11 +13403,11 @@ vz
 qo
 sc
 Dh
-aZ
 bi
-bm
 bo
-aZ
+bx
+bA
+bi
 Dh
 Dh
 Dh
@@ -13545,11 +13545,11 @@ lD
 Sc
 Km
 Dh
-aZ
+bi
 aC
 TP
 aC
-aZ
+bi
 Dh
 Dh
 Dh
@@ -13682,22 +13682,22 @@ aa
 aa
 aa
 aa
-bA
-aZ
-aZ
 bc
-aZ
-aZ
+bi
+bi
+bm
+bi
+bi
 aC
 MH
 aC
-aZ
-aZ
-aZ
-aZ
-aZ
-aZ
-bA
+bi
+bi
+bi
+bi
+bi
+bi
+bc
 aa
 aa
 aa
@@ -14377,11 +14377,11 @@ aa
 aa
 aa
 aa
-bx
 aG
 aI
 aT
-bx
+aZ
+aG
 aa
 aC
 am
@@ -17501,11 +17501,11 @@ aa
 aa
 aa
 aa
-bz
 aH
 aS
 aU
-bz
+ba
+aH
 aa
 aK
 qA
@@ -18226,22 +18226,22 @@ aa
 aa
 aa
 aa
-bB
-ba
-ba
 bd
-ba
-ba
+bl
+bl
+bn
+bl
+bl
 aK
 xQ
 aK
-ba
-ba
-ba
-ba
-ba
-ba
-bB
+bl
+bl
+bl
+bl
+bl
+bl
+bd
 aa
 aa
 aa
@@ -18373,11 +18373,11 @@ Eo
 QX
 UI
 Ru
-ba
+bl
 aK
 oU
 aK
-ba
+bl
 Ru
 Ru
 Ru
@@ -18515,11 +18515,11 @@ Bs
 uo
 rL
 Ru
-ba
 bl
-bn
 bp
-ba
+bz
+bB
+bl
 Ru
 Ru
 Ru

--- a/maps/tether/submaps/offmap/talon1.dmm
+++ b/maps/tether/submaps/offmap/talon1.dmm
@@ -155,14 +155,15 @@
 /turf/simulated/floor/tiled/eris/dark/cyancorner,
 /area/talon/deckone/bridge)
 "ar" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
+/obj/machinery/door/blast/regular/open{
+	dir = 4;
+	icon_state = "pdoor1";
+	id = "talon_unused_hardpoint";
+	name = "Unused Hardpoint Blast Door"
 	},
-/obj/structure/closet/wardrobe/black{
-	starts_with = list(/obj/item/clothing/under/color/black = 4, /obj/item/clothing/shoes/black = 4, /obj/item/clothing/head/soft/black = 4, /obj/item/clothing/mask/bandana = 4, /obj/item/weapon/storage/backpack/messenger/black = 4, /obj/item/weapon/storage/backpack/dufflebag = 4)
-	},
-/turf/simulated/floor/tiled/eris/white/orangecorner,
-/area/talon/deckone/armory)
+/obj/structure/lattice,
+/turf/space,
+/area/talon/maintenance/deckone_starboard)
 "as" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -220,12 +221,13 @@
 /turf/simulated/floor/tiled/eris/white/bluecorner,
 /area/talon/deckone/medical)
 "ax" = (
-/obj/machinery/camera/network/talon,
-/obj/structure/closet/wardrobe/black{
-	starts_with = list(/obj/item/clothing/head/helmet/combat = 4, /obj/item/clothing/mask/gas/commando = 4, /obj/item/clothing/mask/balaclava = 4, /obj/item/clothing/under/syndicate/combat = 4, /obj/item/clothing/accessory/storage/black_vest = 4, /obj/item/clothing/accessory/storage/black_drop_pouches = 4, /obj/item/clothing/gloves/combat = 4, /obj/item/clothing/suit/armor/combat = 4, /obj/item/clothing/shoes/boots/combat = 4)
-	},
-/turf/simulated/floor/tiled/eris/white/danger,
-/area/talon/deckone/armory)
+/obj/structure/table/rack/shelf/steel,
+/obj/item/weapon/tank/oxygen,
+/obj/item/weapon/tank/oxygen,
+/obj/item/weapon/tank/oxygen,
+/obj/item/weapon/tank/oxygen,
+/turf/simulated/floor/tiled/eris/dark/danger,
+/area/talon/deckone/secure_storage)
 "ay" = (
 /obj/structure/catwalk,
 /obj/structure/cable/green{
@@ -284,11 +286,62 @@
 /turf/simulated/wall/rshull,
 /area/talon/maintenance/deckone_port)
 "aD" = (
-/obj/structure/closet/wardrobe/black{
-	starts_with = list(/obj/item/clothing/head/helmet/space/syndicate/black = 4, /obj/item/clothing/suit/space/syndicate/black = 4, /obj/item/clothing/shoes/magboots = 4)
-	},
+/obj/structure/table/rack/steel,
+/obj/machinery/camera/network/talon,
+/obj/item/device/suit_cooling_unit,
+/obj/item/device/suit_cooling_unit,
+/obj/item/device/suit_cooling_unit,
+/obj/item/device/suit_cooling_unit,
+/turf/simulated/floor/tiled/eris/dark/danger,
+/area/talon/deckone/secure_storage)
+"aE" = (
+/obj/machinery/camera/network/talon,
+/obj/structure/table/rack/steel,
+/obj/item/clothing/under/syndicate/combat,
+/obj/item/clothing/suit/armor/combat,
+/obj/item/clothing/head/helmet/combat,
 /turf/simulated/floor/tiled/eris/white/danger,
 /area/talon/deckone/armory)
+"aF" = (
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 9
+	},
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 6
+	},
+/turf/simulated/floor/greengrid/airless,
+/area/talon/maintenance/deckone_starboard)
+"aG" = (
+/obj/structure/catwalk,
+/obj/structure/sign/warning/moving_parts{
+	pixel_x = 30
+	},
+/turf/simulated/floor/plating/eris/under,
+/area/talon/maintenance/deckone_port_fore_wing)
+"aH" = (
+/obj/structure/catwalk,
+/obj/structure/sign/warning/moving_parts{
+	pixel_x = -30
+	},
+/turf/simulated/floor/plating/eris/under,
+/area/talon/maintenance/deckone_starboard_fore_wing)
+"aI" = (
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating/eris/under,
+/area/talon/maintenance/deckone_port_fore_wing)
+"aJ" = (
+/obj/structure/table/rack/shelf/steel,
+/obj/item/clothing/shoes/magboots,
+/obj/item/clothing/shoes/magboots,
+/obj/item/clothing/shoes/magboots,
+/obj/item/clothing/shoes/magboots,
+/turf/simulated/floor/tiled/eris/dark/danger,
+/area/talon/deckone/secure_storage)
 "aK" = (
 /turf/simulated/wall/rshull,
 /area/talon/maintenance/deckone_starboard)
@@ -311,9 +364,25 @@
 "aM" = (
 /turf/simulated/wall,
 /area/talon/maintenance/deckone_port)
+"aN" = (
+/obj/structure/table/rack/shelf/steel,
+/obj/item/weapon/tank/jetpack/carbondioxide,
+/obj/item/weapon/tank/jetpack/carbondioxide,
+/obj/item/weapon/tank/jetpack/carbondioxide,
+/obj/item/weapon/tank/jetpack/carbondioxide,
+/obj/item/weapon/tank/jetpack/carbondioxide,
+/turf/simulated/floor/tiled/eris/dark/danger,
+/area/talon/deckone/secure_storage)
 "aO" = (
 /turf/simulated/wall,
 /area/talon/maintenance/deckone_starboard)
+"aP" = (
+/obj/structure/table/rack/steel,
+/obj/item/clothing/shoes/magboots,
+/obj/item/clothing/suit/space/syndicate/black,
+/obj/item/clothing/head/helmet/space/syndicate/black,
+/turf/simulated/floor/tiled/eris/white/danger,
+/area/talon/deckone/armory)
 "aQ" = (
 /obj/machinery/computer/ship/engines{
 	dir = 8;
@@ -325,6 +394,22 @@
 "aR" = (
 /turf/simulated/wall,
 /area/talon/deckone/secure_storage)
+"aS" = (
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	dir = 1;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating/eris/under,
+/area/talon/maintenance/deckone_starboard_fore_wing)
+"aT" = (
+/obj/structure/catwalk,
+/turf/simulated/floor/plating/eris/under,
+/area/talon/maintenance/deckone_port_fore_wing)
+"aU" = (
+/obj/structure/catwalk,
+/turf/simulated/floor/plating/eris/under,
+/area/talon/maintenance/deckone_starboard_fore_wing)
 "aV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/aux,
 /obj/structure/catwalk,
@@ -334,9 +419,71 @@
 	},
 /turf/simulated/floor/plating/eris/under,
 /area/talon/maintenance/deckone_port)
+"aW" = (
+/obj/machinery/alarm/talon{
+	dir = 1;
+	pixel_y = -25
+	},
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/turf/simulated/floor/tiled/eris/dark/danger,
+/area/talon/deckone/secure_storage)
+"aX" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/structure/closet/wardrobe/black{
+	starts_with = list(/obj/item/clothing/under/color/black = 4, /obj/item/clothing/accessory/storage/black_vest = 4, /obj/item/clothing/accessory/storage/black_drop_pouches = 4, /obj/item/clothing/gloves/black = 4, /obj/item/clothing/head/soft/black = 4, /obj/item/clothing/mask/balaclava = 4, /obj/item/clothing/mask/bandana = 4, /obj/item/clothing/mask/gas/commando = 4, /obj/item/weapon/storage/backpack/messenger/black = 4, /obj/item/weapon/storage/backpack/dufflebag = 4, /obj/item/clothing/shoes/black = 4, /obj/item/clothing/shoes/boots/duty = 4)
+	},
+/turf/simulated/floor/tiled/eris/white/orangecorner,
+/area/talon/deckone/armory)
 "aY" = (
 /turf/simulated/wall,
 /area/talon/deckone/armory)
+"aZ" = (
+/obj/structure/catwalk,
+/turf/simulated/floor/plating/eris/under,
+/area/talon/maintenance/deckone_port_aft_wing)
+"ba" = (
+/obj/structure/catwalk,
+/turf/simulated/floor/plating/eris/under,
+/area/talon/maintenance/deckone_starboard_aft_wing)
+"bb" = (
+/obj/structure/closet/secure_closet/chemical{
+	req_access = list(301)
+	},
+/turf/simulated/floor/tiled/eris/white/bluecorner,
+/area/talon/deckone/medical)
+"bc" = (
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating/eris/under,
+/area/talon/maintenance/deckone_port_aft_wing)
+"bd" = (
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating/eris/under,
+/area/talon/maintenance/deckone_starboard_aft_wing)
+"be" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/table/standard,
+/obj/item/clothing/gloves/sterile/nitrile,
+/obj/item/clothing/mask/surgical,
+/obj/item/clothing/suit/surgicalapron,
+/turf/simulated/floor/tiled/eris/white/bluecorner,
+/area/talon/deckone/medical)
+"bf" = (
+/obj/structure/table/standard,
+/obj/machinery/chemical_dispenser/biochemistry/full,
+/turf/simulated/floor/tiled/eris/white/bluecorner,
+/area/talon/deckone/medical)
 "bg" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
@@ -350,6 +497,21 @@
 	},
 /turf/simulated/floor/tiled/eris/steel,
 /area/talon/deckone/brig)
+"bh" = (
+/obj/structure/table/standard,
+/obj/item/device/defib_kit/loaded,
+/obj/item/weapon/storage/belt/medical/emt,
+/obj/item/device/sleevemate,
+/turf/simulated/floor/tiled/eris/white/bluecorner,
+/area/talon/deckone/medical)
+"bi" = (
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_y = 0
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating/eris/under,
+/area/talon/maintenance/deckone_port)
 "bj" = (
 /obj/structure/window/reinforced,
 /turf/simulated/floor/tiled/eris/steel,
@@ -361,6 +523,76 @@
 	},
 /turf/simulated/floor/plating/eris/under,
 /area/talon/maintenance/deckone_starboard)
+"bl" = (
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_y = 0
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating/eris/under,
+/area/talon/maintenance/deckone_starboard)
+"bm" = (
+/obj/machinery/airlock_sensor{
+	dir = 8;
+	pixel_x = 28;
+	pixel_y = 28;
+	req_one_access = list(301)
+	},
+/obj/effect/map_helper/airlock/sensor/ext_sensor,
+/obj/structure/catwalk,
+/turf/simulated/floor/plating/eris/under,
+/area/talon/maintenance/deckone_port)
+"bn" = (
+/obj/machinery/airlock_sensor{
+	dir = 4;
+	pixel_x = -28;
+	pixel_y = 28;
+	req_one_access = list(301)
+	},
+/obj/effect/map_helper/airlock/sensor/ext_sensor,
+/obj/structure/catwalk,
+/turf/simulated/floor/plating/eris/under,
+/area/talon/maintenance/deckone_starboard)
+"bo" = (
+/obj/structure/catwalk,
+/obj/structure/sign/warning/moving_parts{
+	pixel_x = 30
+	},
+/obj/machinery/camera/network/talon{
+	dir = 8;
+	icon_state = "camera"
+	},
+/turf/simulated/floor/plating/eris/under,
+/area/talon/maintenance/deckone_port)
+"bp" = (
+/obj/structure/catwalk,
+/obj/structure/sign/warning/moving_parts{
+	pixel_x = -30
+	},
+/obj/machinery/camera/network/talon{
+	dir = 4;
+	icon_state = "camera"
+	},
+/turf/simulated/floor/plating/eris/under,
+/area/talon/maintenance/deckone_starboard)
+"bq" = (
+/obj/machinery/airlock_sensor{
+	dir = 4;
+	pixel_x = -28;
+	req_one_access = list(301)
+	},
+/obj/effect/map_helper/airlock/atmos/chamber_pump,
+/obj/effect/map_helper/airlock/sensor/chamber_sensor,
+/obj/machinery/light/small{
+	dir = 1;
+	icon_state = "bulb1"
+	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/aux{
+	dir = 4;
+	icon_state = "map_vent_aux"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/shuttle/talonboat)
 "br" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
@@ -375,6 +607,23 @@
 	},
 /turf/simulated/floor/plating,
 /area/talon/maintenance/deckone_port)
+"bs" = (
+/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
+	dir = 8;
+	id_tag = "talon_boat";
+	pixel_x = 28
+	},
+/obj/effect/map_helper/airlock/atmos/chamber_pump,
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/aux{
+	dir = 8;
+	icon_state = "map_vent_aux"
+	},
+/turf/simulated/floor/tiled/eris/dark/gray_perforated,
+/area/shuttle/talonboat)
+"bt" = (
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/turf/simulated/floor/tiled/eris/steel,
+/area/talon/deckone/central_hallway)
 "bu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4;
@@ -393,6 +642,20 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/talon/deckone/secure_storage)
+"bv" = (
+/obj/machinery/door/firedoor/glass/talon,
+/obj/machinery/door/blast/regular/open{
+	dir = 4;
+	id = "talon_windows"
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/simulated/floor/plating/eris/under,
+/area/talon/maintenance/deckone_starboard)
 "bw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4;
@@ -400,6 +663,21 @@
 	},
 /turf/simulated/floor/tiled/eris/dark/brown_perforated,
 /area/talon/deckone/port_eng)
+"bx" = (
+/obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction{
+	dir = 8;
+	icon_state = "intact"
+	},
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction{
+	dir = 8;
+	icon_state = "intact"
+	},
+/obj/structure/handrail{
+	dir = 8
+	},
+/turf/simulated/floor/plating/eris/under,
+/area/talon/maintenance/deckone_port_fore_wing)
 "by" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4;
@@ -419,6 +697,40 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/talon/deckone/armory)
+"bz" = (
+/obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction{
+	dir = 4;
+	icon_state = "intact"
+	},
+/obj/structure/handrail{
+	dir = 4
+	},
+/turf/simulated/floor/plating/eris/under,
+/area/talon/maintenance/deckone_starboard_fore_wing)
+"bA" = (
+/obj/structure/catwalk,
+/obj/structure/handrail{
+	dir = 8
+	},
+/turf/simulated/floor/plating/eris/under,
+/area/talon/maintenance/deckone_port_aft_wing)
+"bB" = (
+/obj/structure/catwalk,
+/obj/structure/handrail{
+	dir = 4
+	},
+/turf/simulated/floor/plating/eris/under,
+/area/talon/maintenance/deckone_starboard_aft_wing)
+"bC" = (
+/obj/structure/table/rack,
+/obj/item/weapon/storage/box/bodybags,
+/obj/item/roller,
+/obj/item/roller{
+	pixel_y = 8
+	},
+/turf/simulated/floor/tiled/eris/white/bluecorner,
+/area/talon/deckone/medical)
 "bP" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden,
 /turf/simulated/floor/tiled/eris/dark/brown_perforated,
@@ -914,39 +1226,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/aux,
 /turf/simulated/floor/tiled/eris/dark/gray_perforated,
 /area/shuttle/talonboat)
-"fo" = (
-/obj/structure/catwalk,
-/obj/structure/sign/warning/moving_parts{
-	pixel_x = 30
-	},
-/obj/machinery/camera/network/talon{
-	dir = 8;
-	icon_state = "camera"
-	},
-/turf/space,
-/area/talon/maintenance/deckone_port)
-"fy" = (
-/obj/structure/catwalk,
-/obj/structure/sign/warning/moving_parts{
-	pixel_x = -30
-	},
-/obj/machinery/camera/network/talon{
-	dir = 4;
-	icon_state = "camera"
-	},
-/turf/space,
-/area/talon/maintenance/deckone_starboard)
-"fz" = (
-/obj/machinery/airlock_sensor{
-	dir = 8;
-	pixel_x = 28;
-	pixel_y = 28;
-	req_one_access = list(301)
-	},
-/obj/effect/map_helper/airlock/sensor/ext_sensor,
-/obj/structure/catwalk,
-/turf/space,
-/area/talon/maintenance/deckone_port)
 "fH" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -969,17 +1248,6 @@
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating/eris/under,
 /area/talon/deckone/central_hallway)
-"fW" = (
-/obj/machinery/airlock_sensor{
-	dir = 4;
-	pixel_x = -28;
-	pixel_y = 28;
-	req_one_access = list(301)
-	},
-/obj/effect/map_helper/airlock/sensor/ext_sensor,
-/obj/structure/catwalk,
-/turf/space,
-/area/talon/maintenance/deckone_starboard)
 "ga" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
@@ -1461,22 +1729,6 @@
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/talon/deckone/starboard_eng)
-"kl" = (
-/obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 0
-	},
-/obj/structure/catwalk,
-/turf/space,
-/area/talon/maintenance/deckone_port)
-"km" = (
-/obj/machinery/light/small{
-	dir = 8;
-	pixel_y = 0
-	},
-/obj/structure/catwalk,
-/turf/space,
-/area/talon/maintenance/deckone_starboard)
 "kr" = (
 /obj/structure/barricade,
 /obj/structure/catwalk,
@@ -1802,15 +2054,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/eris/under,
 /area/talon/maintenance/deckone_starboard)
-"mM" = (
-/obj/structure/catwalk,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/space,
-/area/talon/maintenance/deckone_port_fore_wing)
 "mN" = (
 /obj/structure/catwalk,
 /obj/structure/cable/green{
@@ -1877,13 +2120,6 @@
 	},
 /turf/simulated/floor/hull/airless,
 /area/talon/maintenance/deckone_port_aft_wing)
-"nI" = (
-/obj/structure/catwalk,
-/obj/structure/sign/warning/moving_parts{
-	pixel_x = 30
-	},
-/turf/space,
-/area/talon/maintenance/deckone_port_fore_wing)
 "nN" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -1893,20 +2129,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/eris/under,
 /area/talon/maintenance/deckone_starboard)
-"nR" = (
-/obj/structure/catwalk,
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction{
-	dir = 4;
-	icon_state = "intact"
-	},
-/turf/space,
-/area/talon/maintenance/deckone_starboard_fore_wing)
-"nS" = (
-/obj/structure/table/rack/shelf/steel,
-/obj/item/weapon/tank/jetpack/carbondioxide,
-/obj/item/weapon/tank/jetpack/carbondioxide,
-/turf/simulated/floor/tiled/eris/dark/danger,
-/area/talon/deckone/secure_storage)
 "nT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -2277,11 +2499,6 @@
 	},
 /turf/simulated/floor/tiled/eris/steel,
 /area/talon/deckone/central_hallway)
-"sb" = (
-/obj/structure/table/rack/shelf/steel,
-/obj/item/clothing/shoes/magboots,
-/turf/simulated/floor/tiled/eris/dark/danger,
-/area/talon/deckone/secure_storage)
 "sc" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -2622,13 +2839,6 @@
 	},
 /turf/simulated/floor/tiled/eris/dark/orangecorner,
 /area/talon/deckone/brig)
-"vc" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/table/standard,
-/obj/item/clothing/mask/surgical,
-/obj/item/clothing/suit/surgicalapron,
-/turf/simulated/floor/tiled/eris/white/bluecorner,
-/area/talon/deckone/medical)
 "vf" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 5;
@@ -2723,12 +2933,6 @@
 	},
 /turf/simulated/floor/tiled/eris/white/golden,
 /area/talon/deckone/bridge)
-"wz" = (
-/obj/structure/table/rack/steel,
-/obj/machinery/camera/network/talon,
-/obj/item/device/suit_cooling_unit,
-/turf/simulated/floor/tiled/eris/dark/danger,
-/area/talon/deckone/secure_storage)
 "wD" = (
 /obj/machinery/power/terminal{
 	dir = 8;
@@ -2933,15 +3137,6 @@
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled/eris/steel,
 /area/talon/deckone/brig)
-"yn" = (
-/obj/structure/catwalk,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/space,
-/area/talon/maintenance/deckone_port_aft_wing)
 "yo" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -2965,15 +3160,6 @@
 	},
 /turf/simulated/floor/tiled/eris/white/gray_platform,
 /area/shuttle/talonboat)
-"yy" = (
-/obj/structure/catwalk,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/space,
-/area/talon/maintenance/deckone_starboard_aft_wing)
 "yA" = (
 /obj/effect/floor_decal/industrial/warning/dust{
 	dir = 1
@@ -3053,15 +3239,6 @@
 	},
 /turf/simulated/floor/tiled/eris/steel,
 /area/talon/deckone/central_hallway)
-"zt" = (
-/obj/machinery/alarm/talon{
-	dir = 1;
-	pixel_y = -25
-	},
-/obj/structure/table/rack/steel,
-/obj/item/weapon/tank/oxygen,
-/turf/simulated/floor/tiled/eris/dark/danger,
-/area/talon/deckone/secure_storage)
 "zx" = (
 /obj/structure/cable/green{
 	d2 = 2;
@@ -3423,11 +3600,6 @@
 	},
 /turf/simulated/floor/hull/airless,
 /area/talon/maintenance/deckone_port_fore_wing)
-"Dq" = (
-/obj/structure/table/standard,
-/obj/item/device/sleevemate,
-/turf/simulated/floor/tiled/eris/white/bluecorner,
-/area/talon/deckone/medical)
 "Dr" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 6;
@@ -3835,12 +4007,6 @@
 /obj/machinery/door/firedoor/glass/talon,
 /turf/simulated/floor/tiled/eris/techmaint_panels,
 /area/talon/deckone/medical)
-"GK" = (
-/obj/structure/table/standard,
-/obj/item/device/defib_kit/loaded,
-/obj/item/weapon/storage/belt/medical/emt,
-/turf/simulated/floor/tiled/eris/white/bluecorner,
-/area/talon/deckone/medical)
 "GL" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 1;
@@ -3868,10 +4034,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/hull/airless,
-/area/talon/maintenance/deckone_starboard_fore_wing)
-"Hb" = (
-/obj/structure/catwalk,
-/turf/space,
 /area/talon/maintenance/deckone_starboard_fore_wing)
 "Hh" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
@@ -4282,24 +4444,6 @@
 /obj/machinery/vending/medical_talon,
 /turf/simulated/floor/tiled/eris/white/bluecorner,
 /area/talon/deckone/medical)
-"Kx" = (
-/obj/machinery/airlock_sensor{
-	dir = 4;
-	pixel_x = -28;
-	req_one_access = list(301)
-	},
-/obj/machinery/atmospherics/unary/vent_pump/aux{
-	dir = 4;
-	icon_state = "map_vent_aux"
-	},
-/obj/effect/map_helper/airlock/atmos/chamber_pump,
-/obj/effect/map_helper/airlock/sensor/chamber_sensor,
-/obj/machinery/light/small{
-	dir = 1;
-	icon_state = "bulb1"
-	},
-/turf/simulated/floor/tiled/eris/dark/gray_perforated,
-/area/shuttle/talonboat)
 "KF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -4389,18 +4533,6 @@
 	},
 /turf/simulated/floor/tiled/eris/steel,
 /area/talon/deckone/central_hallway)
-"Lt" = (
-/obj/structure/catwalk,
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction{
-	dir = 8;
-	icon_state = "intact"
-	},
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction{
-	dir = 8;
-	icon_state = "intact"
-	},
-/turf/space,
-/area/talon/maintenance/deckone_port_fore_wing)
 "Ly" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/door/window/brigdoor/eastleft{
@@ -4766,11 +4898,6 @@
 	},
 /turf/simulated/floor/tiled/eris/dark/cyancorner,
 /area/talon/deckone/bridge)
-"Ou" = (
-/obj/structure/table/rack/shelf/steel,
-/obj/item/weapon/tank/oxygen,
-/turf/simulated/floor/tiled/eris/dark/danger,
-/area/talon/deckone/secure_storage)
 "Ow" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/aux,
 /obj/machinery/alarm/talon{
@@ -4826,10 +4953,6 @@
 /obj/structure/bedsheetbin,
 /turf/simulated/floor/tiled/eris/steel,
 /area/talon/deckone/brig)
-"Pi" = (
-/obj/structure/catwalk,
-/turf/space,
-/area/talon/maintenance/deckone_port_fore_wing)
 "Pu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -5294,21 +5417,6 @@
 /obj/item/clothing/accessory/holster/waist,
 /turf/simulated/floor/tiled/eris/white/danger,
 /area/talon/deckone/armory)
-"Ue" = (
-/obj/structure/catwalk,
-/obj/structure/sign/warning/moving_parts{
-	pixel_x = -30
-	},
-/turf/space,
-/area/talon/maintenance/deckone_starboard_fore_wing)
-"Ui" = (
-/obj/structure/catwalk,
-/obj/structure/cable/green{
-	dir = 1;
-	icon_state = "4-8"
-	},
-/turf/space,
-/area/talon/maintenance/deckone_starboard_fore_wing)
 "Uq" = (
 /obj/machinery/alarm/talon{
 	dir = 4;
@@ -5594,19 +5702,6 @@
 	},
 /turf/simulated/floor/plating/eris/under,
 /area/talon/maintenance/deckone_port)
-"VZ" = (
-/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	dir = 8;
-	id_tag = "talon_boat";
-	pixel_x = 28
-	},
-/obj/machinery/atmospherics/unary/vent_pump/aux{
-	dir = 8;
-	icon_state = "map_vent_aux"
-	},
-/obj/effect/map_helper/airlock/atmos/chamber_pump,
-/turf/simulated/floor/tiled/eris/dark/gray_perforated,
-/area/shuttle/talonboat)
 "Wo" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
@@ -5869,10 +5964,6 @@
 	},
 /turf/simulated/floor/tiled/eris/steel/techfloor_grid,
 /area/shuttle/talonboat)
-"YS" = (
-/obj/structure/catwalk,
-/turf/space,
-/area/talon/maintenance/deckone_port_aft_wing)
 "YT" = (
 /obj/machinery/alarm/talon{
 	dir = 1;
@@ -5884,10 +5975,6 @@
 	},
 /turf/simulated/floor/tiled/eris/dark/cyancorner,
 /area/talon/deckone/bridge)
-"Za" = (
-/obj/structure/catwalk,
-/turf/space,
-/area/talon/maintenance/deckone_starboard_aft_wing)
 "Zg" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -13316,11 +13403,11 @@ vz
 qo
 sc
 Dh
-YS
-kl
-fz
-fo
-YS
+aZ
+bi
+bm
+bo
+aZ
 Dh
 Dh
 Dh
@@ -13458,11 +13545,11 @@ lD
 Sc
 Km
 Dh
-YS
+aZ
 aC
 TP
 aC
-YS
+aZ
 Dh
 Dh
 Dh
@@ -13595,22 +13682,22 @@ aa
 aa
 aa
 aa
-YS
-YS
-YS
-yn
-YS
-YS
+bA
+aZ
+aZ
+bc
+aZ
+aZ
 aC
 MH
 aC
-YS
-YS
-YS
-YS
-YS
-YS
-YS
+aZ
+aZ
+aZ
+aZ
+aZ
+aZ
+bA
 aa
 aa
 aa
@@ -14290,11 +14377,11 @@ aa
 aa
 aa
 aa
-Lt
-nI
-mM
-Pi
-Lt
+bx
+aG
+aI
+aT
+bx
 aa
 aC
 am
@@ -14858,9 +14945,9 @@ aa
 aa
 ab
 ac
-Ou
+ax
 dQ
-sb
+aJ
 kN
 en
 aR
@@ -15002,7 +15089,7 @@ ab
 ac
 wj
 kN
-nS
+aN
 kN
 LO
 aR
@@ -15142,11 +15229,11 @@ ab
 ab
 ab
 ac
-wz
+aD
 kN
 sK
 kN
-zt
+aW
 aR
 aM
 aM
@@ -15750,7 +15837,7 @@ YO
 YO
 mT
 lb
-Kx
+bq
 lb
 nc
 ki
@@ -16034,7 +16121,7 @@ ht
 xu
 Kk
 lb
-VZ
+bs
 lb
 nc
 ki
@@ -16282,7 +16369,7 @@ ZH
 if
 mj
 VN
-ar
+aX
 bQ
 jp
 aO
@@ -16562,9 +16649,9 @@ ab
 ab
 ab
 ac
-ax
+aE
 Fl
-aD
+aP
 Fl
 xd
 aY
@@ -16602,7 +16689,7 @@ iN
 dL
 wk
 UN
-Bj
+bt
 Bj
 Bj
 ki
@@ -16984,8 +17071,8 @@ aa
 aa
 aa
 aa
-aa
-aa
+aK
+aK
 aK
 aO
 aY
@@ -17007,7 +17094,7 @@ dO
 xH
 aw
 Xd
-vc
+be
 eV
 dO
 uN
@@ -17126,9 +17213,9 @@ aa
 aa
 aa
 aa
-aa
-aa
-aK
+ar
+aF
+bv
 sI
 Of
 qA
@@ -17268,8 +17355,8 @@ aa
 aa
 aa
 aa
-aa
-aa
+aK
+aK
 aK
 aK
 aK
@@ -17289,10 +17376,10 @@ co
 qA
 dO
 NG
-Gb
+bb
 Gb
 qB
-Dq
+bf
 dO
 hD
 pz
@@ -17414,11 +17501,11 @@ aa
 aa
 aa
 aa
-nR
-Ue
-Ui
-Hb
-nR
+bz
+aH
+aS
+aU
+bz
 aa
 aK
 qA
@@ -17433,8 +17520,8 @@ dO
 dz
 Rk
 Gb
-Gb
-GK
+bC
+bh
 dO
 Gt
 SI
@@ -18139,22 +18226,22 @@ aa
 aa
 aa
 aa
-Za
-Za
-Za
-yy
-Za
-Za
+bB
+ba
+ba
+bd
+ba
+ba
 aK
 xQ
 aK
-Za
-Za
-Za
-Za
-Za
-Za
-Za
+ba
+ba
+ba
+ba
+ba
+ba
+bB
 aa
 aa
 aa
@@ -18286,11 +18373,11 @@ Eo
 QX
 UI
 Ru
-Za
+ba
 aK
 oU
 aK
-Za
+ba
 Ru
 Ru
 Ru
@@ -18428,11 +18515,11 @@ Bs
 uo
 rL
 Ru
-Za
-km
-fW
-fy
-Za
+ba
+bl
+bn
+bp
+ba
 Ru
 Ru
 Ru

--- a/maps/tether/submaps/offmap/talon2.dmm
+++ b/maps/tether/submaps/offmap/talon2.dmm
@@ -264,6 +264,39 @@
 "aM" = (
 /turf/simulated/floor/wood,
 /area/talon/decktwo/cap_room)
+"aN" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atm{
+	pixel_x = 32;
+	step_x = 0
+	},
+/turf/simulated/floor/tiled/eris/steel,
+/area/talon/decktwo/central_hallway)
+"aO" = (
+/obj/machinery/airlock_sensor{
+	dir = 4;
+	pixel_x = -28;
+	req_one_access = list(301)
+	},
+/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
+	dir = 8;
+	id_tag = "talon_aft_solar";
+	pixel_x = 28;
+	req_one_access = list(301)
+	},
+/obj/effect/map_helper/airlock/atmos/chamber_pump,
+/obj/effect/map_helper/airlock/sensor/chamber_sensor,
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/aux{
+	dir = 1
+	},
+/turf/simulated/floor/plating/eris/under,
+/area/talon/maintenance/decktwo_aft)
 "aP" = (
 /obj/machinery/alarm/talon{
 	dir = 4;
@@ -277,9 +310,35 @@
 "aQ" = (
 /turf/simulated/floor/wood,
 /area/talon/decktwo/bar)
-"aV" = (
+"aR" = (
+/obj/structure/handrail{
+	dir = 1
+	},
+/turf/simulated/floor/hull/airless,
+/area/talon/maintenance/decktwo_solars)
+"aS" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9;
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/vending/food{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/eris/steel/gray_perforated,
+/area/talon/decktwo/bar)
+"aT" = (
 /obj/machinery/vending/coffee{
 	dir = 1
+	},
+/turf/simulated/floor/tiled/eris/steel/gray_perforated,
+/area/talon/decktwo/bar)
+"aU" = (
+/obj/machinery/vending/dinnerware{
+	dir = 1;
+	icon_state = "dinnerware"
 	},
 /turf/simulated/floor/tiled/eris/steel/gray_perforated,
 /area/talon/decktwo/bar)
@@ -607,13 +666,6 @@
 	},
 /turf/simulated/open,
 /area/talon/decktwo/central_hallway)
-"cn" = (
-/obj/machinery/vending/dinnerware{
-	dir = 1;
-	icon_state = "dinnerware"
-	},
-/turf/simulated/floor/tiled/eris/steel/gray_perforated,
-/area/talon/decktwo/bar)
 "cp" = (
 /obj/structure/lattice,
 /obj/structure/cable/green{
@@ -2296,19 +2348,6 @@
 	},
 /turf/simulated/floor/plating/eris/under,
 /area/talon/maintenance/decktwo_aft)
-"rz" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/machinery/vending/food{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/eris/steel/gray_perforated,
-/area/talon/decktwo/bar)
 "rA" = (
 /obj/structure/cable/yellow{
 	d1 = 2;
@@ -2340,26 +2379,6 @@
 	},
 /turf/simulated/floor/tiled/eris/steel,
 /area/talon/decktwo/central_hallway)
-"rJ" = (
-/obj/machinery/airlock_sensor{
-	dir = 4;
-	pixel_x = -28;
-	req_one_access = list(301)
-	},
-/obj/machinery/atmospherics/unary/vent_pump/aux{
-	dir = 1;
-	icon_state = "map_vent_aux"
-	},
-/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	dir = 8;
-	id_tag = "talon_aft_solar";
-	pixel_x = 28;
-	req_one_access = list(301)
-	},
-/obj/effect/map_helper/airlock/atmos/chamber_pump,
-/obj/effect/map_helper/airlock/sensor/chamber_sensor,
-/turf/simulated/floor/plating/eris/under,
-/area/talon/maintenance/decktwo_aft)
 "rQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -13412,7 +13431,7 @@ aa
 aa
 aa
 pi
-pi
+aR
 ap
 ap
 ap
@@ -14552,7 +14571,7 @@ As
 dX
 ay
 Rm
-Gq
+aN
 Gq
 Af
 Gq
@@ -14588,7 +14607,7 @@ gC
 gT
 gS
 nj
-rJ
+aO
 pt
 DT
 pi
@@ -15127,7 +15146,7 @@ WS
 VZ
 bI
 Uf
-rz
+aS
 aw
 cl
 cz
@@ -15269,7 +15288,7 @@ Zn
 UY
 aQ
 vB
-aV
+aT
 aw
 cl
 cz
@@ -15411,7 +15430,7 @@ UY
 ZF
 bJ
 bP
-cn
+aU
 aw
 ck
 cy
@@ -15683,8 +15702,8 @@ aa
 aa
 aa
 aa
-aa
-aa
+pi
+aR
 ax
 ax
 ax
@@ -15825,8 +15844,8 @@ aa
 aa
 aa
 aa
-aa
-aa
+pi
+pi
 pi
 pi
 pi
@@ -15967,8 +15986,8 @@ aa
 aa
 aa
 aa
-aa
-aa
+pi
+pi
 pi
 pi
 pi

--- a/maps/tether/submaps/offmap/talon2.dmm
+++ b/maps/tether/submaps/offmap/talon2.dmm
@@ -119,6 +119,18 @@
 	},
 /turf/simulated/floor/plating/eris/under,
 /area/talon/maintenance/decktwo_aft)
+"ar" = (
+/obj/structure/closet/secure_closet/personal/cabinet{
+	locked = 0
+	},
+/turf/simulated/floor/wood,
+/area/talon/decktwo/eng_room)
+"as" = (
+/obj/structure/closet/secure_closet/personal/cabinet{
+	locked = 0
+	},
+/turf/simulated/floor/wood,
+/area/talon/decktwo/pilot_room)
 "at" = (
 /turf/simulated/floor/tiled/eris/steel,
 /area/talon/decktwo/central_hallway)
@@ -185,6 +197,18 @@
 "aC" = (
 /turf/simulated/wall,
 /area/talon/decktwo/cap_room)
+"aD" = (
+/obj/structure/closet/secure_closet/personal/cabinet{
+	locked = 0
+	},
+/turf/simulated/floor/wood,
+/area/talon/decktwo/med_room)
+"aE" = (
+/obj/structure/closet/secure_closet/personal/cabinet{
+	locked = 0
+	},
+/turf/simulated/floor/wood,
+/area/talon/decktwo/sec_room)
 "aF" = (
 /obj/structure/bed/chair/bay/chair,
 /turf/simulated/floor/wood,
@@ -203,6 +227,29 @@
 	},
 /turf/simulated/floor/tiled/eris/white,
 /area/talon/decktwo/central_hallway)
+"aI" = (
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_y = 0
+	},
+/turf/simulated/floor/plating/eris/under,
+/area/talon/maintenance/decktwo_port)
+"aJ" = (
+/obj/machinery/atmospherics/pipe/simple/visible/supply{
+	dir = 4
+	},
+/obj/structure/catwalk,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/plating/eris/under,
+/area/talon/maintenance/decktwo_aft)
 "aK" = (
 /turf/simulated/floor/carpet/blucarpet,
 /area/talon/decktwo/cap_room)
@@ -991,10 +1038,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/talon/decktwo/eng_room)
-"eE" = (
-/obj/structure/closet/secure_closet/personal/cabinet,
-/turf/simulated/floor/wood,
-/area/talon/decktwo/eng_room)
 "eF" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -1020,10 +1063,6 @@
 	dir = 1
 	},
 /obj/structure/closet/secure_closet/talon_pilot,
-/turf/simulated/floor/wood,
-/area/talon/decktwo/pilot_room)
-"eJ" = (
-/obj/structure/closet/secure_closet/personal/cabinet,
 /turf/simulated/floor/wood,
 /area/talon/decktwo/pilot_room)
 "eK" = (
@@ -1346,10 +1385,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/talon/decktwo/med_room)
-"ga" = (
-/obj/structure/closet/secure_closet/personal/cabinet,
-/turf/simulated/floor/wood,
-/area/talon/decktwo/med_room)
 "gb" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -1362,10 +1397,6 @@
 	dir = 1
 	},
 /obj/structure/closet/secure_closet/talon_guard,
-/turf/simulated/floor/wood,
-/area/talon/decktwo/sec_room)
-"gd" = (
-/obj/structure/closet/secure_closet/personal/cabinet,
 /turf/simulated/floor/wood,
 /area/talon/decktwo/sec_room)
 "ge" = (
@@ -12986,7 +13017,7 @@ Qt
 lx
 lx
 lx
-lx
+aI
 lx
 lx
 lx
@@ -13277,7 +13308,7 @@ cc
 gZ
 gZ
 hu
-WG
+aJ
 mm
 ht
 ao
@@ -13829,13 +13860,13 @@ dz
 dM
 ea
 eo
-eE
+ar
 dr
 eV
 fm
 fA
 fN
-ga
+aD
 eT
 gn
 gn
@@ -15249,13 +15280,13 @@ dH
 dU
 eh
 ew
-eJ
+as
 du
 fb
 fs
 fG
 fT
-gd
+aE
 eZ
 gn
 gn
@@ -16110,7 +16141,7 @@ Az
 QA
 QA
 QA
-QA
+AX
 QA
 QA
 QA

--- a/maps/tether/submaps/offmap/talon2.dmm
+++ b/maps/tether/submaps/offmap/talon2.dmm
@@ -114,9 +114,7 @@
 	dir = 1;
 	icon_state = "map_connector-aux"
 	},
-/obj/machinery/portable_atmospherics/canister/air/airlock{
-	start_pressure = 4559.63
-	},
+/obj/machinery/portable_atmospherics/canister/air/airlock,
 /turf/simulated/floor/plating/eris/under,
 /area/talon/maintenance/decktwo_aft)
 "ar" = (


### PR DESCRIPTION
Made various airlock pumps High Volume to reduce wait times.

Added a few more lights in maints in a few areas.

Added an unused hardpoint to the bow starboard to match the bow port sensor suite. [for ship symmetry]

Added underplating beneath catwalks outside. Catwalks being the only thing keeping the wings on? YIKES! [Also made slipping and gravity-related issues...] Added handrails at various external points in case someone forgets their magboots and does not want to faceplant.

Added an ATM outside the Talon at the bar.

Added nitrile gloves, a bioproduct dispenser, roller beds, a body bag box, and a chem locker to medical. Should they have a smartfridge?...

Addes more magboots to suit storage to prevent any further infighting among talon crew. Also stocked more 02 canisters and PSCU's, just in case; They are cheaper to produce than a new crew. Also added a closet with black civilian garb, enough for 4 peeps.

Like above, but with C02 jetpacks. Added C02 Canisters to storage and just outside the Talon boat for refueling them.