### PR TITLE
Enable Excavation POI

### DIFF
--- a/maps/submaps/surface_submaps/mountains/mountains.dm
+++ b/maps/submaps/surface_submaps/mountains/mountains.dm
@@ -254,14 +254,12 @@
 	cost = 40
 	discard_prob = 50
 
-/*
 /datum/map_template/surface/mountains/normal/crashed_ufo_frigate //VOREStation Edit
 	name = "Crashed UFO Frigate"
 	desc = "A (formerly) flying saucer that is now embedded into the mountain, yet the combat protocols still seem to be running..."
 	mappath = 'maps/submaps/surface_submaps/mountains/crashed_ufo_frigate.dmm'
 	cost = 60
 	discard_prob = 50
-*/		//VOREStation Removal
 
 /datum/map_template/surface/mountains/normal/Scave1 //VOREStation Edit
 	name = "Spider Cave 1"


### PR DESCRIPTION
On @Novacat's request, disables UFO frigate due to bugged content present.

Also enables one of newer PoIs from Polaris that never got enabled, Excavation, because why not.

EDIT: UFO Frigate is no longer considered problematic. This PR now just enables Excavation POI.