### PR TITLE
Makes passive gate UI more accurate

### DIFF
--- a/tgui/packages/tgui/interfaces/PressureRegulator.js
+++ b/tgui/packages/tgui/interfaces/PressureRegulator.js
@@ -69,7 +69,7 @@ export const PressureRegulator = (props, context) => {
                 </Fragment>
               } />
             <LabeledList.Item
-              label="Desired Output Pressure"
+              label="Pressure Threshold"
               buttons={
                 <Fragment>
                   <Button


### PR DESCRIPTION
This value is only "output pressure" if regulation is set to output. 