### PR TITLE
Fixes Mercs threaten timers, and threaten sounds

### DIFF
--- a/code/modules/ai/say_list.dm
+++ b/code/modules/ai/say_list.dm
@@ -71,6 +71,9 @@
 	say_threaten = list("Get out of here!", "Hey! Private Property!")
 	say_stand_down = list("Good.")
 	say_escalate = list("Your funeral!", "Bring it!")
+	
+	threaten_sound = 'sound/weapons/TargetOn.ogg'
+	stand_down_sound = 'sound/weapons/TargetOff.ogg'
 
 /datum/say_list/malf_drone
 	speak = list("ALERT.","Hostile-ile-ile entities dee-twhoooo-wected.","Threat parameterszzzz- szzet.","Bring sub-sub-sub-systems uuuup to combat alert alpha-a-a.")

--- a/code/modules/mob/living/simple_mob/subtypes/humanoid/mercs/mercs.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/humanoid/mercs/mercs.dm
@@ -83,6 +83,8 @@
 	threaten = TRUE
 	returns_home = TRUE		// Stay close to the base...
 	wander = TRUE			// ... but "patrol" a little.
+	intelligence_level = AI_SMART // Also knows not to walk while confused if it risks death.
+	threaten_delay = 30 SECONDS // Mercs will give you 30 seconds to leave or get shot.
 
 /datum/ai_holder/simple_mob/merc/ranged
 	pointblank = TRUE		// They get close? Just shoot 'em!

--- a/code/modules/mob/living/simple_mob/subtypes/humanoid/mercs/mercs_vr.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/humanoid/mercs/mercs_vr.dm
@@ -23,6 +23,3 @@
 	min_n2 = 0
 	max_n2 = 0
 	minbodytemp = 0
-
-/datum/ai_holder/simple_mob/merc
-	intelligence_level = AI_SMART // Also knows not to walk while confused if it risks death.


### PR DESCRIPTION
The default "threaten" timer was 3 seconds, meaning that as soon as world.time advanced beyond that, the merc would shoot you. If there's TIDI/lag or other issues, you'd immediately end up getting shot.

30 seconds is more reasonable, allows you time to back away from the merc without being shot at, and it keeps the mercs from being cheesed easily.

This also fixes the merc aggression sounds. Actual voicelines incoming once I get help from a contributor!
