### PR TITLE
Hotfix for Ambience Freq Overwriting Ambience Chance on Save

### DIFF
--- a/code/modules/client/preference_setup/global/01_ui.dm
+++ b/code/modules/client/preference_setup/global/01_ui.dm
@@ -22,7 +22,7 @@
 	S["tooltipstyle"]	<< pref.tooltipstyle
 	S["client_fps"]		<< pref.client_fps
 	S["ambience_freq"]	<< pref.ambience_freq
-	S["ambience_chance"] << pref.ambience_freq
+	S["ambience_chance"] << pref.ambience_chance
 	S["tgui_fancy"]		<< pref.tgui_fancy
 	S["tgui_lock"]		<< pref.tgui_lock
 


### PR DESCRIPTION
I accidentally had ambience_freq being written to ambience_chance, oops.
