### PR TITLE
Fix oversensitive instability test

### DIFF
--- a/code/game/machinery/bomb_tester_vr.dm
+++ b/code/game/machinery/bomb_tester_vr.dm
@@ -205,7 +205,7 @@
 		simulation_results = "Error"
 		simulation_finish()
 		return
-	if((tank1 && (tank1.return_pressure() > TANK_RUPTURE_PRESSURE)) || (tank2 && (tank2.return_pressure() > TANK_RUPTURE_PRESSURE)))
+	if((tank?.air_contents.return_pressure() > TANK_RUPTURE_PRESSURE)) || tank2?.air_contents.return_pressure() > TANK_RUPTURE_PRESSURE)))
 		simulation_results = "Unstable"
 		simulation_finish()
 		return

--- a/code/game/machinery/bomb_tester_vr.dm
+++ b/code/game/machinery/bomb_tester_vr.dm
@@ -205,7 +205,7 @@
 		simulation_results = "Error"
 		simulation_finish()
 		return
-	if((tank?.air_contents.return_pressure() > TANK_RUPTURE_PRESSURE)) || tank2?.air_contents.return_pressure() > TANK_RUPTURE_PRESSURE)))
+	if((tank1?.air_contents.return_pressure() > TANK_RUPTURE_PRESSURE) || (tank2?.air_contents.return_pressure() > TANK_RUPTURE_PRESSURE))
 		simulation_results = "Unstable"
 		simulation_finish()
 		return

--- a/code/game/machinery/bomb_tester_vr.dm
+++ b/code/game/machinery/bomb_tester_vr.dm
@@ -205,7 +205,7 @@
 		simulation_results = "Error"
 		simulation_finish()
 		return
-	if(tank1?.integrity < tank1?.maxintegrity || tank2?.integrity < tank2?.maxintegrity)
+	if((tank1 && (tank1.return_pressure() > TANK_RUPTURE_PRESSURE)) || (tank2 && (tank2.return_pressure() > TANK_RUPTURE_PRESSURE)))
 		simulation_results = "Unstable"
 		simulation_finish()
 		return


### PR DESCRIPTION
I was testing some bomb stuff on a copy of master and I noticed the bomb tester's tank instability warning introduced in https://github.com/VOREStation/VOREStation/pull/8814 gives some false positives.  This fixes that.  