### PR TITLE
Fix oversensitive instability test

### DIFF
--- a/code/game/machinery/bomb_tester_vr.dm
+++ b/code/game/machinery/bomb_tester_vr.dm
@@ -205,7 +205,7 @@
 		simulation_results = "Error"
 		simulation_finish()
 		return
-	if(tank1?.integrity < tank1?.maxintegrity || tank2?.integrity < tank2?.maxintegrity)
+	if((tank1?.air_contents.return_pressure() > TANK_RUPTURE_PRESSURE) || (tank2?.air_contents.return_pressure() > TANK_RUPTURE_PRESSURE))
 		simulation_results = "Unstable"
 		simulation_finish()
 		return


### PR DESCRIPTION
I was testing some bomb stuff on a copy of master and I noticed the bomb tester's tank instability warning introduced in #8814 gives some false positives. This fixes that.  This version tested and working.  Pull request recreated due to double travis bug.