### PR TITLE
Space level unsealing

### DIFF
--- a/maps/expedition_vr/aerostat/_aerostat.dm
+++ b/maps/expedition_vr/aerostat/_aerostat.dm
@@ -12,7 +12,7 @@
 	in_space = 0
 	initial_generic_waypoints = list("aerostat_west","aerostat_east","aerostat_south","aerostat_northwest","aerostat_northeast")
 	extra_z_levels = list(Z_LEVEL_AEROSTAT_SURFACE)
-	
+
 // -- Datums -- //
 
 /datum/shuttle/autodock/ferry/aerostat

--- a/maps/expedition_vr/aerostat/_aerostat.dm
+++ b/maps/expedition_vr/aerostat/_aerostat.dm
@@ -9,6 +9,7 @@
 [b]Notice[/b]: Planetary environment not suitable for life. Landing may be hazardous."}
 	icon_state = "globe"
 	color = "#dfff3f" //Bright yellow
+	in_space = 0
 	initial_generic_waypoints = list("aerostat_west","aerostat_east","aerostat_south","aerostat_northwest","aerostat_northeast")
 	extra_z_levels = list(Z_LEVEL_AEROSTAT_SURFACE)
 	

--- a/maps/expedition_vr/beach/_beach.dm
+++ b/maps/expedition_vr/beach/_beach.dm
@@ -9,6 +9,7 @@
 [b]Notice[/b]: Request authorization from planetary authorities before attempting to construct settlements"}
 	icon_state = "globe"
 	color = "#ffd300" //Sandy
+	in_space = 0
 	initial_generic_waypoints = list("beach_e", "beach_c", "beach_nw")
 	extra_z_levels = list(Z_LEVEL_BEACH_CAVE)
 

--- a/maps/gateway_vr/snow_outpost.dm
+++ b/maps/gateway_vr/snow_outpost.dm
@@ -1,5 +1,6 @@
 /obj/effect/overmap/visitable/sector/tether_gateway/snowoutpost
 	initial_generic_waypoints = list("tether_excursion_snow_outpost")
+	in_space = 0
 	scanner_name = "Snowy Outpost"
 	scanner_desc = @{"[i]Stellar Body[/i]>: UNKNOWN
 [i]Class[/i]>: M-Class Planetoid

--- a/maps/gateway_vr/snowfield.dm
+++ b/maps/gateway_vr/snowfield.dm
@@ -1,5 +1,6 @@
 /obj/effect/overmap/visitable/sector/tether_gateway/snowfield
 	initial_generic_waypoints = list("tether_excursion_snowfield")
+	in_space = 0
 	scanner_name = "Snowy Field"
 	scanner_desc = @{"[i]Stellar Body[/i]: UNKNOWN
 [i]Class[/i]: M-Class Planetoid

--- a/maps/tether/submaps/_tether_submaps.dm
+++ b/maps/tether/submaps/_tether_submaps.dm
@@ -25,7 +25,7 @@
 
 /datum/map_z_level/tether_lateload/underdark
 	name = "Underdark"
-	flags = MAP_LEVEL_CONTACT|MAP_LEVEL_PLAYER
+	flags = MAP_LEVEL_CONTACT|MAP_LEVEL_PLAYER|MAP_LEVEL_SEALED
 	base_turf = /turf/simulated/mineral/floor/virgo3b
 	z = Z_LEVEL_UNDERDARK
 
@@ -44,7 +44,7 @@
 
 /datum/map_z_level/tether_lateload/tether_plains
 	name = "Away Mission - Plains"
-	flags = MAP_LEVEL_CONTACT|MAP_LEVEL_PLAYER
+	flags = MAP_LEVEL_CONTACT|MAP_LEVEL_PLAYER|MAP_LEVEL_SEALED
 	base_turf = /turf/simulated/mineral/floor/virgo3b
 	z = Z_LEVEL_PLAINS
 
@@ -358,7 +358,6 @@
 
 /datum/map_z_level/tether_lateload
 	z = 0
-	flags = MAP_LEVEL_SEALED
 
 /datum/map_z_level/tether_lateload/New(var/datum/map/map, mapZ)
 	if(mapZ && !z)


### PR DESCRIPTION
The space away areas were considered sealed zlevels which was causing runtimes when beams were fired off of them and probably other weirdness