### PR TITLE
Increases number of things that survive overmap ztransit

### DIFF
--- a/code/modules/overmap/spacetravel.dm
+++ b/code/modules/overmap/spacetravel.dm
@@ -49,13 +49,10 @@ proc/get_deepspace(x,y)
 			return FALSE
 	if(has_buckled_mobs())
 		for(var/mob/M in buckled_mobs)
-			if(!M.lost_in_space)
+			if(!M.lost_in_space())
 				return FALSE
 
 	return TRUE
-
-/obj/item/weapon/disk/nuclear/lost_in_space()
-	return FALSE
 
 /obj/item/device/uav/lost_in_space()
 	if(state == 1)

--- a/code/modules/overmap/spacetravel.dm
+++ b/code/modules/overmap/spacetravel.dm
@@ -47,7 +47,31 @@ proc/get_deepspace(x,y)
 	for(var/atom/movable/AM in contents)
 		if(!AM.lost_in_space())
 			return FALSE
+	if(has_buckled_mobs())
+		for(var/mob/M in buckled_mobs)
+			if(!M.lost_in_space)
+				return FALSE
+
 	return TRUE
+
+/obj/item/weapon/disk/nuclear/lost_in_space()
+	return FALSE
+
+/obj/item/device/uav/lost_in_space()
+	if(state == 1)
+		return FALSE
+	return ..()
+
+/obj/machinery/power/supermatter/lost_in_space()
+	return FALSE
+
+/obj/singularity/lost_in_space()
+	return FALSE
+
+/obj/vehicle/lost_in_space()
+	if(load && !load.lost_in_space())
+		return FALSE
+	return ..()
 
 /mob/lost_in_space()
 	return isnull(client)


### PR DESCRIPTION
Keeps the following from being deleted when exiting a space zlevel with overmap enabled:
Active UAVs
Supermatter
Singularities and Teslas
Vehicles carrying things that also survive.
Anything with something important buckled.

There are probably many things I missed, but you get the idea