### PR TITLE
Remove different sound for doors that have same mechanical base.

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -39,9 +39,9 @@
 	var/secured_wires = 0
 	var/datum/wires/airlock/wires = null
 
-	var/open_sound_powered = 'sound/machines/door/hall1o.ogg'
+	var/open_sound_powered = 'sound/machines/door/hall1o.ogg' //VOREStation Edit
 	var/open_sound_unpowered = 'sound/machines/airlockforced.ogg'
-	var/close_sound_powered = 'sound/machines/door/hall1c.ogg'
+	var/close_sound_powered = 'sound/machines/door/hall1c.ogg' //VOREStation Edit
 	var/denied_sound = 'sound/machines/deniedbeep.ogg'
 	var/bolt_up_sound = 'sound/machines/boltsup.ogg'
 	var/bolt_down_sound = 'sound/machines/boltsdown.ogg'

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -39,9 +39,9 @@
 	var/secured_wires = 0
 	var/datum/wires/airlock/wires = null
 
-	var/open_sound_powered = 'sound/machines/door/airlock.ogg'
+	var/open_sound_powered = 'sound/machines/airlock.ogg'
 	var/open_sound_unpowered = 'sound/machines/airlockforced.ogg'
-	var/close_sound_powered = 'sound/machines/door/airlockclose.ogg'
+	var/close_sound_powered = 'sound/machines/airlockclose.ogg'
 	var/denied_sound = 'sound/machines/deniedbeep.ogg'
 	var/bolt_up_sound = 'sound/machines/boltsup.ogg'
 	var/bolt_down_sound = 'sound/machines/boltsdown.ogg'

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -39,9 +39,9 @@
 	var/secured_wires = 0
 	var/datum/wires/airlock/wires = null
 
-	var/open_sound_powered = 'sound/machines/door/covert1o.ogg'
+	var/open_sound_powered = 'sound/machines/door/airlock.ogg'
 	var/open_sound_unpowered = 'sound/machines/airlockforced.ogg'
-	var/close_sound_powered = 'sound/machines/door/covert1c.ogg'
+	var/close_sound_powered = 'sound/machines/door/airlockclose.ogg'
 	var/denied_sound = 'sound/machines/deniedbeep.ogg'
 	var/bolt_up_sound = 'sound/machines/boltsup.ogg'
 	var/bolt_down_sound = 'sound/machines/boltsdown.ogg'
@@ -112,54 +112,54 @@
 	icon = 'icons/obj/doors/Doorcom.dmi'
 	req_one_access = list(access_heads)
 	assembly_type = /obj/structure/door_assembly/door_assembly_com
-	open_sound_powered = 'sound/machines/door/cmd3o.ogg'
-	close_sound_powered = 'sound/machines/door/cmd3c.ogg'
+	//open_sound_powered = 'sound/machines/door/cmd3o.ogg'	//VOREStation Removal: Material/Mechanic-based door sounds
+	//close_sound_powered = 'sound/machines/door/cmd3c.ogg'	//VOREStation Removal: Material/Mechanic-based door sounds
 
 /obj/machinery/door/airlock/security
 	name = "Security Airlock"
 	icon = 'icons/obj/doors/Doorsec.dmi'
 	req_one_access = list(access_security)
 	assembly_type = /obj/structure/door_assembly/door_assembly_sec
-	open_sound_powered = 'sound/machines/door/sec1o.ogg'
-	close_sound_powered = 'sound/machines/door/sec1c.ogg'
+	//open_sound_powered = 'sound/machines/door/sec1o.ogg'	//VOREStation Removal: Material/Mechanic-based door sounds
+	//close_sound_powered = 'sound/machines/door/sec1c.ogg'	//VOREStation Removal: Material/Mechanic-based door sounds
 
 /obj/machinery/door/airlock/engineering
 	name = "Engineering Airlock"
 	icon = 'icons/obj/doors/Dooreng.dmi'
 	req_one_access = list(access_engine)
 	assembly_type = /obj/structure/door_assembly/door_assembly_eng
-	open_sound_powered = 'sound/machines/door/eng1o.ogg'
-	close_sound_powered = 'sound/machines/door/eng1c.ogg'
+	//open_sound_powered = 'sound/machines/door/eng1o.ogg'	//VOREStation Removal: Material/Mechanic-based door sounds
+	//close_sound_powered = 'sound/machines/door/eng1c.ogg'	//VOREStation Removal: Material/Mechanic-based door sounds
 
 /obj/machinery/door/airlock/engineeringatmos
 	name = "Atmospherics Airlock"
 	icon = 'icons/obj/doors/Doorengatmos.dmi'
 	req_one_access = list(access_atmospherics)
 	assembly_type = /obj/structure/door_assembly/door_assembly_eat
-	open_sound_powered = 'sound/machines/door/eng1o.ogg'
-	close_sound_powered = 'sound/machines/door/eng1c.ogg'
+	//open_sound_powered = 'sound/machines/door/eng1o.ogg'	//VOREStation Removal: Material/Mechanic-based door sounds
+	//close_sound_powered = 'sound/machines/door/eng1c.ogg'	//VOREStation Removal: Material/Mechanic-based door sounds
 
 /obj/machinery/door/airlock/medical
 	name = "Medical Airlock"
 	icon = 'icons/obj/doors/Doormed.dmi'
 	req_one_access = list(access_medical)
 	assembly_type = /obj/structure/door_assembly/door_assembly_med
-	open_sound_powered = 'sound/machines/door/med1o.ogg'
-	close_sound_powered = 'sound/machines/door/med1c.ogg'
+	//open_sound_powered = 'sound/machines/door/med1o.ogg'	//VOREStation Removal: Material/Mechanic-based door sounds
+	//close_sound_powered = 'sound/machines/door/med1c.ogg'	//VOREStation Removal: Material/Mechanic-based door sounds
 
 /obj/machinery/door/airlock/maintenance
 	name = "Maintenance Access"
 	icon = 'icons/obj/doors/Doormaint.dmi'
 	//req_one_access = list(access_maint_tunnels) //VOREStation Edit - Maintenance is open access
 	assembly_type = /obj/structure/door_assembly/door_assembly_mai
-	open_sound_powered = 'sound/machines/door/door2o.ogg'
-	close_sound_powered = 'sound/machines/door/door2c.ogg'
+	//open_sound_powered = 'sound/machines/door/door2o.ogg'		//VOREStation Removal: Material/Mechanic-based door sounds
+	//close_sound_powered = 'sound/machines/door/door2c.ogg'	//VOREStation Removal: Material/Mechanic-based door sounds
 
 /obj/machinery/door/airlock/maintenance/cargo
 	icon = 'icons/obj/doors/Doormaint_cargo.dmi'
 	req_one_access = list(access_cargo)
-	open_sound_powered = 'sound/machines/door/door2o.ogg'
-	close_sound_powered = 'sound/machines/door/door2c.ogg'
+	//open_sound_powered = 'sound/machines/door/door2o.ogg'		//VOREStation Removal: Material/Mechanic-based door sounds
+	//close_sound_powered = 'sound/machines/door/door2c.ogg'	//VOREStation Removal: Material/Mechanic-based door sounds
 
 /obj/machinery/door/airlock/maintenance/command
 	icon = 'icons/obj/doors/Doormaint_command.dmi'
@@ -167,8 +167,8 @@
 
 /obj/machinery/door/airlock/maintenance/common
 	icon = 'icons/obj/doors/Doormaint_common.dmi'
-	open_sound_powered = 'sound/machines/door/hall3o.ogg'
-	close_sound_powered = 'sound/machines/door/hall3c.ogg'
+	//open_sound_powered = 'sound/machines/door/hall3o.ogg'		//VOREStation Removal: Material/Mechanic-based door sounds
+	//close_sound_powered = 'sound/machines/door/hall3c.ogg'	//VOREStation Removal: Material/Mechanic-based door sounds
 
 /obj/machinery/door/airlock/maintenance/engi
 	icon = 'icons/obj/doors/Doormaint_engi.dmi'
@@ -193,8 +193,8 @@
 	name = "External Airlock"
 	icon = 'icons/obj/doors/Doorext.dmi'
 	assembly_type = /obj/structure/door_assembly/door_assembly_ext
-	open_sound_powered = 'sound/machines/door/space1o.ogg'
-	close_sound_powered = 'sound/machines/door/space1c.ogg'
+	//open_sound_powered = 'sound/machines/door/space1o.ogg'	//VOREStation Removal: Material/Mechanic-based door sounds
+	//close_sound_powered = 'sound/machines/door/space1c.ogg'	//VOREStation Removal: Material/Mechanic-based door sounds
 
 /obj/machinery/door/airlock/external/glass/bolted
 	icon_state = "door_locked" // So it looks visibly bolted in map editor
@@ -211,8 +211,8 @@
 	opacity = 0
 	glass = 1
 	req_one_access = list(access_external_airlocks)
-	open_sound_powered = 'sound/machines/door/space1o.ogg'
-	close_sound_powered = 'sound/machines/door/space1c.ogg'
+	//open_sound_powered = 'sound/machines/door/space1o.ogg'	//VOREStation Removal: Material/Mechanic-based door sounds
+	//close_sound_powered = 'sound/machines/door/space1c.ogg'	//VOREStation Removal: Material/Mechanic-based door sounds
 
 /obj/machinery/door/airlock/glass
 	name = "Glass Airlock"
@@ -230,16 +230,16 @@
 	icon = 'icons/obj/doors/Doorele.dmi'
 	req_one_access = list(access_cent_general)
 	opacity = 1
-	open_sound_powered = 'sound/machines/door/cmd3o.ogg'
-	close_sound_powered = 'sound/machines/door/cmd3c.ogg'
+	//open_sound_powered = 'sound/machines/door/cmd3o.ogg'	//VOREStation Removal: Material/Mechanic-based door sounds
+	//close_sound_powered = 'sound/machines/door/cmd3c.ogg'	//VOREStation Removal: Material/Mechanic-based door sounds
 
 /obj/machinery/door/airlock/glass_centcom
 	name = "Airlock"
 	icon = 'icons/obj/doors/Dooreleglass.dmi'
 	opacity = 0
 	glass = 1
-	open_sound_powered = 'sound/machines/door/cmd3o.ogg'
-	close_sound_powered = 'sound/machines/door/cmd3c.ogg'
+	//open_sound_powered = 'sound/machines/door/cmd3o.ogg'	//VOREStation Removal: Material/Mechanic-based door sounds
+	//close_sound_powered = 'sound/machines/door/cmd3c.ogg'	//VOREStation Removal: Material/Mechanic-based door sounds
 
 /obj/machinery/door/airlock/vault
 	name = "Vault"
@@ -294,8 +294,8 @@
 	assembly_type = /obj/structure/door_assembly/door_assembly_com
 	glass = 1
 	req_one_access = list(access_heads)
-	open_sound_powered = 'sound/machines/door/cmd1o.ogg'
-	close_sound_powered = 'sound/machines/door/cmd1c.ogg'
+	//open_sound_powered = 'sound/machines/door/cmd1o.ogg'	//VOREStation Removal: Material/Mechanic-based door sounds
+	//close_sound_powered = 'sound/machines/door/cmd1c.ogg'	//VOREStation Removal: Material/Mechanic-based door sounds
 
 /obj/machinery/door/airlock/glass_engineering
 	name = "Engineering Airlock"
@@ -307,8 +307,8 @@
 	assembly_type = /obj/structure/door_assembly/door_assembly_eng
 	glass = 1
 	req_one_access = list(access_engine)
-	open_sound_powered = 'sound/machines/door/eng1o.ogg'
-	close_sound_powered = 'sound/machines/door/eng1c.ogg'
+	//open_sound_powered = 'sound/machines/door/eng1o.ogg'	//VOREStation Removal: Material/Mechanic-based door sounds
+	//close_sound_powered = 'sound/machines/door/eng1c.ogg'	//VOREStation Removal: Material/Mechanic-based door sounds
 
 /obj/machinery/door/airlock/glass_engineeringatmos
 	name = "Atmospherics Airlock"
@@ -320,8 +320,8 @@
 	assembly_type = /obj/structure/door_assembly/door_assembly_eat
 	glass = 1
 	req_one_access = list(access_atmospherics)
-	open_sound_powered = 'sound/machines/door/eng1o.ogg'
-	close_sound_powered = 'sound/machines/door/eng1c.ogg'
+	//open_sound_powered = 'sound/machines/door/eng1o.ogg'	//VOREStation Removal: Material/Mechanic-based door sounds
+	//close_sound_powered = 'sound/machines/door/eng1c.ogg'	//VOREStation Removal: Material/Mechanic-based door sounds
 
 /obj/machinery/door/airlock/glass_security
 	name = "Security Airlock"
@@ -333,8 +333,8 @@
 	assembly_type = /obj/structure/door_assembly/door_assembly_sec
 	glass = 1
 	req_one_access = list(access_security)
-	open_sound_powered = 'sound/machines/door/sec1o.ogg'
-	close_sound_powered = 'sound/machines/door/sec1c.ogg'
+	//open_sound_powered = 'sound/machines/door/sec1o.ogg'	//VOREStation Removal: Material/Mechanic-based door sounds
+	//close_sound_powered = 'sound/machines/door/sec1c.ogg'	//VOREStation Removal: Material/Mechanic-based door sounds
 
 /obj/machinery/door/airlock/glass_medical
 	name = "Medical Airlock"
@@ -346,31 +346,31 @@
 	assembly_type = /obj/structure/door_assembly/door_assembly_med
 	glass = 1
 	req_one_access = list(access_medical)
-	open_sound_powered = 'sound/machines/door/med1o.ogg'
-	close_sound_powered = 'sound/machines/door/med1c.ogg'
+	//open_sound_powered = 'sound/machines/door/med1o.ogg'	//VOREStation Removal: Material/Mechanic-based door sounds
+	//close_sound_powered = 'sound/machines/door/med1c.ogg'	//VOREStation Removal: Material/Mechanic-based door sounds
 
 /obj/machinery/door/airlock/mining
 	name = "Mining Airlock"
 	icon = 'icons/obj/doors/Doormining.dmi'
 	assembly_type = /obj/structure/door_assembly/door_assembly_min
 	req_one_access = list(access_mining)
-	open_sound_powered = 'sound/machines/door/cgo1o.ogg'
-	close_sound_powered = 'sound/machines/door/cgo1c.ogg'
+	//open_sound_powered = 'sound/machines/door/cgo1o.ogg'	//VOREStation Removal: Material/Mechanic-based door sounds
+	//close_sound_powered = 'sound/machines/door/cgo1c.ogg'	//VOREStation Removal: Material/Mechanic-based door sounds
 
 /obj/machinery/door/airlock/atmos
 	name = "Atmospherics Airlock"
 	icon = 'icons/obj/doors/Dooratmo.dmi'
 	assembly_type = /obj/structure/door_assembly/door_assembly_atmo
 	req_one_access = list(access_atmospherics)
-	open_sound_powered = 'sound/machines/door/eng1o.ogg'
-	close_sound_powered = 'sound/machines/door/eng1c.ogg'
+	//open_sound_powered = 'sound/machines/door/eng1o.ogg'	//VOREStation Removal: Material/Mechanic-based door sounds
+	//close_sound_powered = 'sound/machines/door/eng1c.ogg'	//VOREStation Removal: Material/Mechanic-based door sounds
 
 /obj/machinery/door/airlock/research
 	name = "Research Airlock"
 	icon = 'icons/obj/doors/Doorresearch.dmi'
 	assembly_type = /obj/structure/door_assembly/door_assembly_research
-	open_sound_powered = 'sound/machines/door/sci1o.ogg'
-	close_sound_powered = 'sound/machines/door/sci1c.ogg'
+	//open_sound_powered = 'sound/machines/door/sci1o.ogg'	//VOREStation Removal: Material/Mechanic-based door sounds
+	//close_sound_powered = 'sound/machines/door/sci1c.ogg'	//VOREStation Removal: Material/Mechanic-based door sounds
 
 /obj/machinery/door/airlock/glass_research
 	name = "Research Airlock"
@@ -382,8 +382,8 @@
 	assembly_type = /obj/structure/door_assembly/door_assembly_research
 	glass = 1
 	req_one_access = list(access_research)
-	open_sound_powered = 'sound/machines/door/sci1o.ogg'
-	close_sound_powered = 'sound/machines/door/sci1c.ogg'
+	//open_sound_powered = 'sound/machines/door/sci1o.ogg'	//VOREStation Removal: Material/Mechanic-based door sounds
+	//close_sound_powered = 'sound/machines/door/sci1c.ogg'	//VOREStation Removal: Material/Mechanic-based door sounds
 
 /obj/machinery/door/airlock/glass_mining
 	name = "Mining Airlock"
@@ -395,8 +395,8 @@
 	assembly_type = /obj/structure/door_assembly/door_assembly_min
 	glass = 1
 	req_one_access = list(access_mining)
-	open_sound_powered = 'sound/machines/door/cgo1o.ogg'
-	close_sound_powered = 'sound/machines/door/cgo1c.ogg'
+	//open_sound_powered = 'sound/machines/door/cgo1o.ogg'	//VOREStation Removal: Material/Mechanic-based door sounds
+	//close_sound_powered = 'sound/machines/door/cgo1c.ogg'	//VOREStation Removal: Material/Mechanic-based door sounds
 
 /obj/machinery/door/airlock/glass_atmos
 	name = "Atmospherics Airlock"
@@ -408,8 +408,8 @@
 	assembly_type = /obj/structure/door_assembly/door_assembly_atmo
 	glass = 1
 	req_one_access = list(access_atmospherics)
-	open_sound_powered = 'sound/machines/door/eng1o.ogg'
-	close_sound_powered = 'sound/machines/door/eng1c.ogg'
+	//open_sound_powered = 'sound/machines/door/eng1o.ogg'	//VOREStation Removal: Material/Mechanic-based door sounds
+	//close_sound_powered = 'sound/machines/door/eng1c.ogg'	//VOREStation Removal: Material/Mechanic-based door sounds
 
 /obj/machinery/door/airlock/gold
 	name = "Gold Airlock"
@@ -490,8 +490,8 @@
 	icon = 'icons/obj/doors/Doorsci.dmi'
 	assembly_type = /obj/structure/door_assembly/door_assembly_science
 	req_one_access = list(access_research)
-	open_sound_powered = 'sound/machines/door/sci1o.ogg'
-	close_sound_powered = 'sound/machines/door/sci1c.ogg'
+	//open_sound_powered = 'sound/machines/door/sci1o.ogg'	//VOREStation Removal: Material/Mechanic-based door sounds
+	//close_sound_powered = 'sound/machines/door/sci1c.ogg'	//VOREStation Removal: Material/Mechanic-based door sounds
 
 /obj/machinery/door/airlock/glass_science
 	name = "Glass Airlocks"
@@ -500,8 +500,8 @@
 	assembly_type = /obj/structure/door_assembly/door_assembly_science
 	glass = 1
 	req_one_access = list(access_research)
-	open_sound_powered = 'sound/machines/door/sci1o.ogg'
-	close_sound_powered = 'sound/machines/door/sci1c.ogg'
+	//open_sound_powered = 'sound/machines/door/sci1o.ogg'	//VOREStation Removal: Material/Mechanic-based door sounds
+	//close_sound_powered = 'sound/machines/door/sci1c.ogg'	//VOREStation Removal: Material/Mechanic-based door sounds
 
 /obj/machinery/door/airlock/highsecurity
 	name = "Secure Airlock"

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -39,9 +39,9 @@
 	var/secured_wires = 0
 	var/datum/wires/airlock/wires = null
 
-	var/open_sound_powered = 'sound/machines/door/covert1o.ogg'
+	var/open_sound_powered = 'sound/machines/door/hall1o.ogg'
 	var/open_sound_unpowered = 'sound/machines/airlockforced.ogg'
-	var/close_sound_powered = 'sound/machines/door/covert1c.ogg'
+	var/close_sound_powered = 'sound/machines/door/hall1c.ogg'
 	var/denied_sound = 'sound/machines/deniedbeep.ogg'
 	var/bolt_up_sound = 'sound/machines/boltsup.ogg'
 	var/bolt_down_sound = 'sound/machines/boltsdown.ogg'

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -39,9 +39,9 @@
 	var/secured_wires = 0
 	var/datum/wires/airlock/wires = null
 
-	var/open_sound_powered = 'sound/machines/airlock.ogg'
+	var/open_sound_powered = 'sound/machines/door/covert1o.ogg'
 	var/open_sound_unpowered = 'sound/machines/airlockforced.ogg'
-	var/close_sound_powered = 'sound/machines/airlockclose.ogg'
+	var/close_sound_powered = 'sound/machines/door/covert1c.ogg'
 	var/denied_sound = 'sound/machines/deniedbeep.ogg'
 	var/bolt_up_sound = 'sound/machines/boltsup.ogg'
 	var/bolt_down_sound = 'sound/machines/boltsdown.ogg'


### PR DESCRIPTION
Partial VOREStation-only revert of https://github.com/VOREStation/VOREStation/pull/8658.

 Different paint job or different access restrictions don't make a door sound differently. This makes all doors with same mechanical basis sound the same, approprietly, not based on "what mapped in color they use". So all standard doors now again have same base sounds for opening and closing, as they all share base appearance.

Doesn't affect doors with actually unique appearances, such as pure glass, vault, voidcraft, hatches, highsecurity, doubles, etc. Would also have ignored doors made out of unique materials but those didn't have any sound given to them in the first place, so.