### PR TITLE
Enables the construction of battery rack circuits from APC circuits

### DIFF
--- a/code/modules/power/batteryrack_vr.dm
+++ b/code/modules/power/batteryrack_vr.dm
@@ -1,0 +1,9 @@
+/obj/item/weapon/module/power_control/attackby(var/obj/item/I, var/mob/user)
+	if(I.is_multitool())
+		to_chat(user, SPAN_NOTICE("You begin tweaking the power control circuits to support a power cell rack."))
+		if(do_after(user, 50 * I.toolspeed))
+			var/obj/item/newcircuit = new/obj/item/weapon/circuitboard/batteryrack(get_turf(user))
+			qdel(src)
+			user.put_in_hands(newcircuit)
+			return
+	return ..()

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -3078,6 +3078,7 @@
 #include "code\modules\power\apc.dm"
 #include "code\modules\power\apc_vr.dm"
 #include "code\modules\power\batteryrack.dm"
+#include "code\modules\power\batteryrack_vr.dm"
 #include "code\modules\power\breaker_box.dm"
 #include "code\modules\power\cable.dm"
 #include "code\modules\power\cable_ender.dm"


### PR DESCRIPTION
For all your field powering needs, the battery rack is now (mostly) freed from science's clutches. It still needs the three capacitors and a matter bin, but those can be scavenged or built from a partslathe.