### PR TITLE
Emergency Talon Fixs

### DIFF
--- a/maps/offmap_vr/talon/talon1.dmm
+++ b/maps/offmap_vr/talon/talon1.dmm
@@ -516,6 +516,14 @@
 	},
 /obj/structure/table/standard,
 /obj/item/weapon/storage/firstaid/surgery,
+/obj/item/stack/nanopaste{
+	pixel_x = -7;
+	pixel_y = -4
+	},
+/obj/item/stack/nanopaste{
+	pixel_x = 9;
+	pixel_y = -4
+	},
 /obj/item/device/robotanalyzer{
 	pixel_y = -8
 	},

--- a/maps/offmap_vr/talon/talon1.dmm
+++ b/maps/offmap_vr/talon/talon1.dmm
@@ -511,10 +511,14 @@
 /turf/simulated/floor/tiled/eris/steel,
 /area/talon/deckone/brig)
 "bh" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
 /obj/structure/table/standard,
-/obj/item/device/defib_kit/loaded,
-/obj/item/weapon/storage/belt/medical/emt,
-/obj/item/device/sleevemate,
+/obj/item/weapon/storage/firstaid/surgery,
+/obj/item/device/robotanalyzer{
+	pixel_y = -8
+	},
 /turf/simulated/floor/tiled/eris/white/bluecorner,
 /area/talon/deckone/medical)
 "bi" = (
@@ -1178,6 +1182,14 @@
 	},
 /turf/simulated/floor/tiled/eris/dark/brown_platform,
 /area/talon/deckone/port_eng_store)
+"ct" = (
+/obj/structure/table/standard,
+/obj/item/device/defib_kit/jumper_kit/loaded,
+/obj/item/device/defib_kit/loaded,
+/obj/item/weapon/storage/belt/medical/emt,
+/obj/item/device/sleevemate,
+/turf/simulated/floor/tiled/eris/white/bluecorner,
+/area/talon/deckone/medical)
 "cv" = (
 /obj/machinery/vending/coffee,
 /turf/simulated/floor/tiled/steel_ridged,
@@ -1527,14 +1539,6 @@
 	},
 /turf/simulated/floor/tiled/eris/techmaint_panels,
 /area/talon/deckone/brig)
-"eV" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/structure/table/standard,
-/obj/item/weapon/storage/firstaid/surgery,
-/turf/simulated/floor/tiled/eris/white/bluecorner,
-/area/talon/deckone/medical)
 "fi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4;
@@ -17183,7 +17187,7 @@ xH
 aw
 Xd
 be
-eV
+bh
 dO
 uN
 SI
@@ -17609,7 +17613,7 @@ dz
 Rk
 Gb
 bC
-bh
+ct
 dO
 Gt
 SI

--- a/maps/offmap_vr/talon/talon1.dmm
+++ b/maps/offmap_vr/talon/talon1.dmm
@@ -742,7 +742,8 @@
 "bE" = (
 /obj/machinery/vending/engineering{
 	products = list(/obj/item/clothing/under/rank/chief_engineer = 4, /obj/item/clothing/under/rank/engineer = 4, /obj/item/clothing/shoes/orange = 4, /obj/item/clothing/head/hardhat = 4, /obj/item/weapon/storage/belt/utility = 4, /obj/item/clothing/glasses/meson = 4, /obj/item/clothing/gloves/yellow = 4, /obj/item/weapon/tool/screwdriver = 12, /obj/item/weapon/tool/crowbar = 12, /obj/item/weapon/tool/wirecutters = 12, /obj/item/device/multitool = 12, /obj/item/weapon/tool/wrench = 12, /obj/item/device/t_scanner = 12, /obj/item/stack/cable_coil/heavyduty = 8, /obj/item/weapon/cell = 8, /obj/item/weapon/weldingtool = 8, /obj/item/clothing/head/welding = 8, /obj/item/weapon/light/tube = 10, /obj/item/clothing/head/hardhat/red = 4, /obj/item/clothing/suit/fire = 4, /obj/item/weapon/stock_parts/scanning_module = 5, /obj/item/weapon/stock_parts/micro_laser = 5, /obj/item/weapon/stock_parts/matter_bin = 5, /obj/item/weapon/stock_parts/manipulator = 5, /obj/item/weapon/stock_parts/console_screen = 5);
-	req_log_access = 301;
+	req_access = list(301);
+	req_log_access = list(301);
 	req_one_access = list(301)
 	},
 /turf/simulated/floor/tiled/eris/dark/brown_platform,
@@ -752,8 +753,8 @@
 /obj/item/weapon/storage/toolbox/electrical,
 /obj/item/stack/marker_beacon/thirty,
 /obj/item/weapon/pipe_dispenser,
-/obj/structure/closet/hydrant{
-	pixel_y = 32
+/obj/machinery/alarm/talon{
+	pixel_y = 28
 	},
 /turf/simulated/floor/tiled/eris/dark/brown_platform,
 /area/talon/deckone/port_eng_store)
@@ -1170,6 +1171,13 @@
 /obj/structure/vehiclecage/spacebike,
 /turf/simulated/floor/tiled/eris/steel,
 /area/talon/deckone/central_hallway)
+"cs" = (
+/obj/structure/closet/hydrant{
+	pixel_x = -32;
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/eris/dark/brown_platform,
+/area/talon/deckone/port_eng_store)
 "cv" = (
 /obj/machinery/vending/coffee,
 /turf/simulated/floor/tiled/steel_ridged,
@@ -4947,15 +4955,6 @@
 /obj/item/weapon/pen,
 /turf/simulated/floor/tiled/eris/steel/cargo,
 /area/talon/deckone/workroom)
-"Nt" = (
-/obj/machinery/alarm/talon{
-	dir = 4;
-	icon_state = "alarm0";
-	pixel_x = -22;
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled/eris/dark/brown_platform,
-/area/talon/deckone/port_eng_store)
 "Nu" = (
 /obj/structure/table/standard,
 /obj/fiftyspawner/glass,
@@ -14496,7 +14495,7 @@ dH
 am
 gU
 dR
-Nt
+cs
 gU
 NP
 ho

--- a/maps/offmap_vr/talon/talon2.dmm
+++ b/maps/offmap_vr/talon/talon2.dmm
@@ -379,7 +379,6 @@
 	pixel_y = 0
 	},
 /obj/structure/table/standard,
-/obj/item/weapon/paper/talon_shields,
 /obj/structure/closet/hydrant{
 	pixel_x = 0;
 	pixel_y = 32;
@@ -667,6 +666,20 @@
 	},
 /turf/simulated/floor/wood,
 /area/talon/decktwo/sec_room)
+"bA" = (
+/obj/machinery/power/apc/talon{
+	cell_type = /obj/item/weapon/cell/apc;
+	dir = 8;
+	name = "west bump";
+	pixel_x = -28
+	},
+/obj/structure/cable/green{
+	icon_state = "0-4"
+	},
+/obj/structure/table/standard,
+/obj/item/weapon/paper/talon_shields,
+/turf/simulated/floor/tiled/eris/dark/violetcorener,
+/area/talon/decktwo/tech)
 "bB" = (
 /obj/machinery/alarm/talon{
 	dir = 4;
@@ -2253,19 +2266,6 @@
 "pi" = (
 /turf/simulated/floor/hull/airless,
 /area/talon/maintenance/decktwo_solars)
-"pp" = (
-/obj/machinery/power/apc/talon{
-	cell_type = /obj/item/weapon/cell/apc;
-	dir = 8;
-	name = "west bump";
-	pixel_x = -28
-	},
-/obj/structure/cable/green{
-	icon_state = "0-4"
-	},
-/obj/structure/table/standard,
-/turf/simulated/floor/tiled/eris/dark/violetcorener,
-/area/talon/decktwo/tech)
 "pt" = (
 /obj/effect/map_helper/airlock/door/ext_door,
 /obj/machinery/door/airlock/glass_external{
@@ -14326,7 +14326,7 @@ NT
 bF
 ds
 aZ
-pp
+bA
 Db
 iV
 ds


### PR DESCRIPTION
Fixed the Robco machine from locking out Talon crew, preventing them from accessing critical supplies.

Moved a few fire lockers around to prevent certain items initializing within them.

Added Jumpkit, Robotanalyser, and some nanopaste to medbay for the non-organics.