### PR TITLE
Changes the dates of bank account creation to be more reasonable

### DIFF
--- a/code/modules/economy/Accounts.dm
+++ b/code/modules/economy/Accounts.dm
@@ -35,7 +35,7 @@
 	T.amount = starting_funds
 	if(!source_db)
 		//set a random date, time and location some time over the past few decades
-		T.date = "[num2text(rand(1,31))] [pick("January","February","March","April","May","June","July","August","September","October","November","December")], 25[rand(10,56)]"
+		T.date = "[num2text(rand(1,28))] [pick("January","February","March","April","May","June","July","August","September","October","November","December")], 23[rand(12,19)]"		// VOREStation Edit: lore-compliant dates
 		T.time = "[rand(0,24)]:[rand(11,59)]"
 		T.source_terminal = "NTGalaxyNet Terminal #[rand(111,1111)]"
 


### PR DESCRIPTION
Ideally, the entire thing should be reworked to base it off current year instead of hardcoded one, but works for now. Also reduces possible days to 28 to avoid February 31st situation. Ideally should also be done differently.