### PR TITLE
Fixes bomb simulator maths.

### DIFF
--- a/code/game/machinery/bomb_tester_vr.dm
+++ b/code/game/machinery/bomb_tester_vr.dm
@@ -237,7 +237,7 @@
 			pressure = faketank.return_pressure()
 
 			var/strength = (pressure-TANK_FRAGMENT_PRESSURE)/TANK_FRAGMENT_SCALE
-			var/mult = ((faketank.volume/140)**(1/2)) * (faketank.total_moles**2/3)/((29*0.64) **2/3) //Don't ask me what this is, see tanks.dm
+			var/mult = ((faketank.volume/140)**(1/2)) * (faketank.total_moles**(2/3))/((29*0.64) **(2/3)) //Don't ask me what this is, see tanks.dm
 
 			var/dev = round((mult*strength)*0.15)
 			var/heavy = round((mult*strength)*0.35)

--- a/code/game/machinery/bomb_tester_vr.dm
+++ b/code/game/machinery/bomb_tester_vr.dm
@@ -242,7 +242,7 @@
 			var/dev = round((mult*strength)*0.15)
 			var/heavy = round((mult*strength)*0.35)
 			var/light = round((mult*strength)*0.80)
-			simulation_results += "<hr>Final Result: Explosive tank rupture. [dev?"Extreme damage within [2.5*dev] meters. ":""][heavy?"Heavy damage within [2.5*heavy] meters. ":""][light?"Light damage within [2.5*light] meters. ":""]Hazardous shrapnel produced."
+			simulation_results += "<hr>Final Result: Explosive tank rupture. [dev?"Extreme damage within [2*dev] meters. ":""][heavy?"Heavy damage within [2*heavy] meters. ":""][light?"Light damage within [2*light] meters. ":""]Hazardous shrapnel produced."
 			return 1
 		else
 			faketank_integrity -= 7


### PR DESCRIPTION
The TTV explosion math had a fuckup causing it to calculate the explosions up to 1000 times the intended size.

Fix for the actual bomb math PR'd upstream.

Also changes the "meter conversion" on the report. It was counting tiles as being 2,5m wide, which is kinda silly. According to the cell volume, it implies the tiles being 1x1m with 2,5m height, but I chose to keep that as 2 since it makes more sense in the horizontal spaceman scale.