### PR TITLE
Add Rapid Pipe Dispenser to R&D

### DIFF
--- a/code/game/objects/items/weapons/RPD_vr.dm
+++ b/code/game/objects/items/weapons/RPD_vr.dm
@@ -24,6 +24,7 @@
 	throw_range = 5
 	w_class = ITEMSIZE_NORMAL
 	matter = list(MAT_STEEL = 50000, MAT_GLASS = 25000)
+	origin_tech = list(TECH_ENGINEERING = 4, TECH_MATERIAL = 2)
 	var/datum/effect/effect/system/spark_spread/spark_system
 	var/p_dir = NORTH 			// Next pipe will be built with this dir
 	var/p_flipped = FALSE		// If the next pipe should be built flipped

--- a/code/modules/research/designs/engineering.dm
+++ b/code/modules/research/designs/engineering.dm
@@ -31,6 +31,15 @@
 	build_path = /obj/item/weapon/tool/crowbar/power
 	sort_string = "NAAAC"
 
+/datum/design/item/tool/rpd
+	name = "Rapid Pipe Dispenser"
+	desc = "A counterpart to the rapid construction device that allows creating and placing atmospheric and disposal pipes."
+	id = "rapidpipedispenser"
+	req_tech = list(TECH_ENGINEERING = 4, TECH_MATERIAL = 2)
+	materials = list(DEFAULT_WALL_MATERIAL = 4000, MAT_GLASS = 2000)
+	build_path = /obj/item/weapon/pipe_dispenser
+	sort_string = "NAAAD"
+
 // Other devices
 
 /datum/design/item/engineering/AssembleDesignName()


### PR DESCRIPTION
Origin tech, req tech, and materials are all up for debate, I just copied the RCD for tech and went with values that seemed vaguely close to the surrounding tools for materials. I just want this thing to be obtainable outside of a *single* instance placed on Talon (who have no use for it) lol.