### PR TITLE
Allow video calls with NIF commlinks

### DIFF
--- a/code/modules/nifsoft/software/14_commlink.dm
+++ b/code/modules/nifsoft/software/14_commlink.dm
@@ -43,7 +43,6 @@
 	..()
 	nif = newloc
 	nifsoft = soft
-	QDEL_NULL(camera) //Not supported on internal one.
 
 /obj/item/device/communicator/commlink/Destroy()
 	if(nif)


### PR DESCRIPTION
Putting this up for staff/players to discuss mostly. Once #9085 is in, I can tweak this so that NIFs only support "selfie" mode, if that seems like a reasonable alternative.

Reasoning for wanting this: Lewd vore things, mostly. Livestreams from guts comes to mind as one suggestion that's been made. From a practical standpoint, I think it'd be neat for commlinks to allow video calls while you're otherwise unequipped.

If this just throws everything super out of balance and can't be accepted, then so be it, but I wanna spark the conversation at least =p