### PR TITLE
Makes off-duty have an economic_modifier equal to lowest in department

### DIFF
--- a/code/game/jobs/job/exploration_vr.dm
+++ b/code/game/jobs/job/exploration_vr.dm
@@ -130,6 +130,7 @@ var/const/SAR 				=(1<<14)
 	outfit_type = /decl/hierarchy/outfit/job/assistant/explorer
 	job_description = "Off-duty crew has no responsibilities or authority and is just there to spend their well-deserved time off."
 	pto_type = PTO_EXPLORATION
+	economic_modifier = 6
 
 /datum/alt_title/offduty_exp
 	title = "Off-duty Explorer"

--- a/code/game/jobs/job/exploration_vr.dm
+++ b/code/game/jobs/job/exploration_vr.dm
@@ -130,7 +130,7 @@ var/const/SAR 				=(1<<14)
 	outfit_type = /decl/hierarchy/outfit/job/assistant/explorer
 	job_description = "Off-duty crew has no responsibilities or authority and is just there to spend their well-deserved time off."
 	pto_type = PTO_EXPLORATION
-	economic_modifier = 6
+	economic_modifier = 5
 
 /datum/alt_title/offduty_exp
 	title = "Off-duty Explorer"

--- a/code/game/jobs/job/offduty_vr.dm
+++ b/code/game/jobs/job/offduty_vr.dm
@@ -16,6 +16,7 @@
 	outfit_type = /decl/hierarchy/outfit/job/assistant/worker
 	job_description = "Off-duty crew has no responsibilities or authority and is just there to spend their well-deserved time off."
 	pto_type = PTO_CIVILIAN
+	economic_modifier = 2
 
 /datum/alt_title/offduty_civ
 	title = "Off-duty Worker"
@@ -34,6 +35,7 @@
 	outfit_type = /decl/hierarchy/outfit/job/assistant/cargo
 	job_description = "Off-duty crew has no responsibilities or authority and is just there to spend their well-deserved time off."
 	pto_type = PTO_CARGO
+	economic_modifier = 2
 
 /datum/alt_title/offduty_crg
 	title = "Off-duty Cargo"
@@ -52,6 +54,7 @@
 	outfit_type = /decl/hierarchy/outfit/job/assistant/engineer
 	job_description = "Off-duty crew has no responsibilities or authority and is just there to spend their well-deserved time off."
 	pto_type = PTO_ENGINEERING
+	economic_modifier = 5
 
 /datum/alt_title/offduty_eng
 	title = "Off-duty Engineer"
@@ -70,6 +73,7 @@
 	outfit_type = /decl/hierarchy/outfit/job/assistant/medic
 	job_description = "Off-duty crew has no responsibilities or authority and is just there to spend their well-deserved time off."
 	pto_type = PTO_MEDICAL
+	economic_modifier = 5
 
 /datum/alt_title/offduty_med
 	title = "Off-duty Medic"
@@ -88,6 +92,7 @@
 	outfit_type = /decl/hierarchy/outfit/job/assistant/scientist
 	job_description = "Off-duty crew has no responsibilities or authority and is just there to spend their well-deserved time off."
 	pto_type = PTO_SCIENCE
+	economic_modifier = 5 
 
 /datum/alt_title/offduty_sci
 	title = "Off-duty Scientist"
@@ -106,6 +111,7 @@
 	outfit_type = /decl/hierarchy/outfit/job/assistant/officer
 	job_description = "Off-duty crew has no responsibilities or authority and is just there to spend their well-deserved time off."
 	pto_type = PTO_SECURITY
+	economic_modifier = 4
 
 /datum/alt_title/offduty_sec
 	title = "Off-duty Officer"


### PR DESCRIPTION
Presently, joining off-duty gives you the default economic_modifier. This, at lower "economic status" levels can cause people be unable to afford NIF software for scenes, or other purchased items. This doesn't make sense, and can be easily averted by joining as on-duty and instantly going off-duty.

This PR eliminates the need to join as on-duty and then instantly go off-duty.

Since there's no way to check what role a given character usually fulfils in a given department, and wanting to avoid causing a lower paid dept member to make more money while off-duty than on-duty, I picked the lowest paying job and used its economic modifier for the off-duty role.

