### PR TITLE
Removes freebie namechange in loadout + adjustments to make vr-only ones work properly

### DIFF
--- a/code/modules/client/preference_setup/loadout/loadout.dm
+++ b/code/modules/client/preference_setup/loadout/loadout.dm
@@ -261,7 +261,7 @@ var/list/gear_datums = list()
 	if(!description)
 		var/obj/O = path
 		description = initial(O.desc)
-	gear_tweaks = list(gear_tweak_free_name, gear_tweak_free_desc)
+	//gear_tweaks = list(gear_tweak_free_name, gear_tweak_free_desc)		//VOREStation Removal
 
 /datum/gear_data
 	var/path

--- a/code/modules/client/preference_setup/loadout/loadout_accessories_vr.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_accessories_vr.dm
@@ -8,7 +8,7 @@
 
 /datum/gear/choker/New()
 	..()
-	gear_tweaks = list(gear_tweak_free_color_choice)
+	gear_tweaks += gear_tweak_free_color_choice
 
 /datum/gear/collar
 	display_name = "collar, silver"
@@ -18,7 +18,7 @@
 
 /datum/gear/collar/New()
 	..()
-	gear_tweaks = list(gear_tweak_collar_tag)
+	gear_tweaks += gear_tweak_collar_tag
 
 /datum/gear/collar/golden
 	display_name = "collar, golden"
@@ -93,6 +93,12 @@
 	description = "A shiny steel chain with a vague metallic object dangling off it."
 	path = /obj/item/clothing/accessory/tronket
 
+/datum/gear/accessory/tronket/New()
+	..()
+	gear_tweaks += gear_tweak_free_name
+	gear_tweaks += gear_tweak_free_desc
+
+
 /datum/gear/accessory/pilotpin
 	display_name = "pilot qualification pin"
 	description = "An iron pin denoting the qualification to fly SCG spacecraft."
@@ -106,4 +112,4 @@
 
 /datum/gear/accessory/flops/New()
 	..()
-	gear_tweaks = list(gear_tweak_free_color_choice)
+	gear_tweaks += gear_tweak_free_color_choice

--- a/code/modules/client/preference_setup/loadout/loadout_fluffitems_vr.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_fluffitems_vr.dm
@@ -25,7 +25,7 @@
 
 /datum/gear/fluff/collar/New()
 	..()
-	gear_tweaks = list(gear_tweak_collar_tag)
+	gear_tweaks += gear_tweak_collar_tag
 
 //  0-9 CKEYS
 /datum/gear/fluff/malady_crop

--- a/code/modules/client/preference_setup/loadout/loadout_general_vr.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_general_vr.dm
@@ -10,3 +10,8 @@
 		var/obj/item/toy/tennis/ball_type = ball
 		balls[initial(ball_type.name)] = ball_type
 	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(balls))
+
+/datum/gear/plushie/New()
+	..()
+	gear_tweaks += gear_tweak_free_name
+	gear_tweaks += gear_tweak_free_desc

--- a/code/modules/client/preference_setup/loadout/loadout_gloves_vr.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_gloves_vr.dm
@@ -12,7 +12,7 @@
 
 /datum/gear/gloves/colored/New()
 	..()
-	gear_tweaks = list(gear_tweak_free_color_choice)
+	gear_tweaks += gear_tweak_free_color_choice
 
 
 /datum/gear/gloves/latex/colorable
@@ -21,7 +21,7 @@
 
 /datum/gear/gloves/latex/colorable/New()
 	..()
-	gear_tweaks = list(gear_tweak_free_color_choice)
+	gear_tweaks += gear_tweak_free_color_choice
 
 /datum/gear/gloves/siren
 	display_name = "gloves, Siren"

--- a/code/modules/client/preference_setup/loadout/loadout_head_vr.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_head_vr.dm
@@ -12,7 +12,7 @@
 
 /datum/gear/head/headbando/New()
 	..()
-	gear_tweaks = list(gear_tweak_free_color_choice)
+	gear_tweaks += gear_tweak_free_color_choice
 
 //Detective alternative
 /datum/gear/head/detective_alt

--- a/code/modules/client/preference_setup/loadout/loadout_suit_vr.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_suit_vr.dm
@@ -16,7 +16,7 @@
 
 /datum/gear/suit/labcoat_colorable/New()
 	..()
-	gear_tweaks = list(gear_tweak_free_color_choice)
+	gear_tweaks += gear_tweak_free_color_choice
 
 /datum/gear/suit/jacket_modular
 	display_name = "jacket, modular"


### PR DESCRIPTION
Removes free name/desc change as gear tweak from being a thing for literally every single item available. For now remains available only on plushie selection and locket accessory. Mostly to prevent devaluation of fluff items and potential abuse with being able to have a wide selection of items that have names completely changed.

Also changes way gear tweaks are initialized on _vr only items to match the non-vr ones post-this-change.