### PR TITLE
Standartizes gear_tweaks on _vr only items

### DIFF
--- a/code/modules/client/preference_setup/loadout/loadout_accessories_vr.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_accessories_vr.dm
@@ -8,7 +8,7 @@
 
 /datum/gear/choker/New()
 	..()
-	gear_tweaks = list(gear_tweak_free_color_choice)
+	gear_tweaks = += gear_tweak_free_color_choice
 
 /datum/gear/collar
 	display_name = "collar, silver"
@@ -18,7 +18,7 @@
 
 /datum/gear/collar/New()
 	..()
-	gear_tweaks = list(gear_tweak_collar_tag)
+	gear_tweaks += gear_tweak_collar_tag
 
 /datum/gear/collar/golden
 	display_name = "collar, golden"
@@ -106,4 +106,4 @@
 
 /datum/gear/accessory/flops/New()
 	..()
-	gear_tweaks = list(gear_tweak_free_color_choice)
+	gear_tweaks += gear_tweak_free_color_choice

--- a/code/modules/client/preference_setup/loadout/loadout_accessories_vr.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_accessories_vr.dm
@@ -8,7 +8,7 @@
 
 /datum/gear/choker/New()
 	..()
-	gear_tweaks = += gear_tweak_free_color_choice
+	gear_tweaks += gear_tweak_free_color_choice
 
 /datum/gear/collar
 	display_name = "collar, silver"

--- a/code/modules/client/preference_setup/loadout/loadout_fluffitems_vr.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_fluffitems_vr.dm
@@ -25,7 +25,7 @@
 
 /datum/gear/fluff/collar/New()
 	..()
-	gear_tweaks = list(gear_tweak_collar_tag)
+	gear_tweaks += gear_tweak_collar_tag
 
 //  0-9 CKEYS
 /datum/gear/fluff/malady_crop

--- a/code/modules/client/preference_setup/loadout/loadout_gloves_vr.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_gloves_vr.dm
@@ -12,7 +12,7 @@
 
 /datum/gear/gloves/colored/New()
 	..()
-	gear_tweaks = list(gear_tweak_free_color_choice)
+	gear_tweaks += gear_tweak_free_color_choice
 
 
 /datum/gear/gloves/latex/colorable
@@ -21,7 +21,7 @@
 
 /datum/gear/gloves/latex/colorable/New()
 	..()
-	gear_tweaks = list(gear_tweak_free_color_choice)
+	gear_tweaks += gear_tweak_free_color_choice
 
 /datum/gear/gloves/siren
 	display_name = "gloves, Siren"

--- a/code/modules/client/preference_setup/loadout/loadout_head_vr.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_head_vr.dm
@@ -12,7 +12,7 @@
 
 /datum/gear/head/headbando/New()
 	..()
-	gear_tweaks = list(gear_tweak_free_color_choice)
+	gear_tweaks += gear_tweak_free_color_choice
 
 //Detective alternative
 /datum/gear/head/detective_alt

--- a/code/modules/client/preference_setup/loadout/loadout_suit_vr.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_suit_vr.dm
@@ -16,7 +16,7 @@
 
 /datum/gear/suit/labcoat_colorable/New()
 	..()
-	gear_tweaks = list(gear_tweak_free_color_choice)
+	gear_tweaks += gear_tweak_free_color_choice
 
 /datum/gear/suit/jacket_modular
 	display_name = "jacket, modular"


### PR DESCRIPTION
The nonoffensive part of #9170. Actually makes several _vr items have said name/desc changes working properly, as well as standartizing them with Polaris' new way of adding tweaks to prevent any potential issues down the line.