### PR TITLE
Adds Numbing Fangs trait

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/positive.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/positive.dm
@@ -66,7 +66,7 @@
 	name = "Numbing Fangs"
 	desc = "Provides fangs that makes the person bit unable to feel their body or pain."
 	cost = 1
-	var_changes = list("unarmed_types" = list(/datum/unarmed_attack/stomp, /datum/unarmed_attack/kick, /datum/unarmed_attack/claws, /datum/unarmed_attack/bite/sharp/numbing))
+	var_changes = list("unarmed_types" = list(/datum/unarmed_attack/stomp, /datum/unarmed_attack/kick, /datum/unarmed_attack/punch, /datum/unarmed_attack/bite/sharp/numbing))
 
 /datum/trait/minor_brute_resist
 	name = "Minor Brute Resist"

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/positive.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/positive.dm
@@ -62,6 +62,12 @@
 	cost = 2
 	var_changes = list("unarmed_types" = list(/datum/unarmed_attack/stomp, /datum/unarmed_attack/kick, /datum/unarmed_attack/claws, /datum/unarmed_attack/bite/sharp, /datum/unarmed_attack/bite/sharp/numbing))
 
+/datum/trait/fangs
+	name = "Numbing Fangs"
+	desc = "Provides fangs that makes the person bit unable to feel their body or pain."
+	cost = 1
+	var_changes = list("unarmed_types" = list(/datum/unarmed_attack/stomp, /datum/unarmed_attack/kick, /datum/unarmed_attack/claws, /datum/unarmed_attack/bite/sharp/numbing))
+
 /datum/trait/minor_brute_resist
 	name = "Minor Brute Resist"
 	desc = "Adds 15% resistance to brute damage sources."


### PR DESCRIPTION
Adds the numbing fangs from "Sharp Melee & Numbing Fangs" as a separate trait.  Cannot be taken with "Sharp Melee" or "Sharp Melee & Numbing Fangs", but you can still take the latter if you want both.  Positive trait, costs 1 point.  (Didn't need to explicitly add them as excluded traits of each other, as there's code to automatically detect that they modify the same variable.  Tested to confirm.)