### PR TITLE
Small item digestion fix/tweak

### DIFF
--- a/code/modules/vore/eating/digest_act_vr.dm
+++ b/code/modules/vore/eating/digest_act_vr.dm
@@ -28,7 +28,7 @@
 		if(g_damage > digest_stage)
 			g_damage = digest_stage
 		digest_stage -= g_damage
-	else
+	if(digest_stage <= 0)
 		for(var/obj/item/O in contents)
 			if(istype(O,/obj/item/weapon/storage/internal)) //Dump contents from dummy pockets.
 				for(var/obj/item/SO in O)
@@ -38,6 +38,8 @@
 			else if(item_storage)
 				O.forceMove(item_storage)
 		qdel(src)
+	if(g_damage > w_class)
+		return w_class
 	return g_damage
 
 /////////////


### PR DESCRIPTION
Fixes gurgle damages higher than the item's w_class value giving excess nutrition (like 6+6 damages would give 3 w_class worth of nutrition per cycle, totaling to be worth w_class 6 when taking 2 cycles) and also lets the digestion handle the entire item with one cycle if the damage is sufficient enough. A ciggy butt will no longer be worth 1,5 mining drills on max damage.