### PR TITLE
Makes it possible to cancel out of Mass Alteration

### DIFF
--- a/code/modules/nifsoft/software/15_misc.dm
+++ b/code/modules/nifsoft/software/15_misc.dm
@@ -127,7 +127,7 @@
 
 /datum/nifsoft/sizechange/activate()
 	if((. = ..()))
-		var/new_size = input("Put the desired size (25-200%)", "Set Size", 200) as num
+		var/new_size = input("Put the desired size (25-200%)", "Set Size", 200) as num|null
 
 		if (!ISINRANGE(new_size,25,200))
 			to_chat(nif.human,"<span class='notice'>The safety features of the NIF Program prevent you from choosing this size.</span>")


### PR DESCRIPTION
While one could use a number outside of 25-200 to avoid changing their size by accident, this is not clearly communicated to the player.

Adding a cancel button elicits the same effect as putting something out of range. I'd thought to add a different message when pressing the cancel button, but I think it's sufficient to just have it talk about safety features for both out of range and null values.