### PR TITLE
Boom, Lift Button/Panel Immortality

### DIFF
--- a/code/modules/turbolift/turbolift_console_vr.dm
+++ b/code/modules/turbolift/turbolift_console_vr.dm
@@ -1,0 +1,3 @@
+// TFF 6/10/20 - Just a little thing to prevent the button from being destroyed by explosions.
+/obj/structure/lift/button/ex_act()
+  return

--- a/code/modules/turbolift/turbolift_console_vr.dm
+++ b/code/modules/turbolift/turbolift_console_vr.dm
@@ -1,3 +1,7 @@
-// TFF 6/10/20 - Just a little thing to prevent the button from being destroyed by explosions.
+// TFF 6/10/20 - Just a little thing to prevent the button
+				// and console from being destroyed by explosions.
 /obj/structure/lift/button/ex_act()
-  return
+	return
+
+/obj/structure/lift/panel/ex_act()
+	return

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -3603,6 +3603,7 @@
 #include "code\modules\turbolift\turbolift.dm"
 #include "code\modules\turbolift\turbolift_areas.dm"
 #include "code\modules\turbolift\turbolift_console.dm"
+#include "code\modules\turbolift\turbolift_console_vr.dm"
 #include "code\modules\turbolift\turbolift_door.dm"
 #include "code\modules\turbolift\turbolift_door_vr.dm"
 #include "code\modules\turbolift\turbolift_floor.dm"


### PR DESCRIPTION
Makes the lift button and panel immune to being destroyed by mech drills and other stuff. This is just precautionary so you can't get cucked over if lots of buttons or the lift panel get destroyed if this isn't in place. Also a slight perk, since it means admins won't have to spawn any replacement buttons or panels for said lift.

Changelog Notes: 
- Prevent lift button and lift panel destruction by ex_act.