### PR TITLE
Adds Virgo-Erigone, Virgo 3b and Virgo 4 as home/citizenship options

### DIFF
--- a/code/modules/client/preferences_factions.dm
+++ b/code/modules/client/preferences_factions.dm
@@ -13,6 +13,7 @@ var/global/list/seen_religions = list()
 		seen_religions    |= M.client.prefs.religion*/
 	return
 
+// VOREStation Edits Start
 var/global/list/citizenship_choices = list(
 	"Earth",
 	"Mars",
@@ -20,10 +21,13 @@ var/global/list/citizenship_choices = list(
 	"Binma",
 	"Moghes",
 	"Meralar",
-	"Qerr'balak"
+	"Qerr'balak",
+	"Virgo 3b Colony",
+	"Virgo 4 NT Compound"
 	)
 
 var/global/list/home_system_choices = list(
+	"Virgo-Erigone",
 	"Sol",
 	"Vir",
 	"Nyx",
@@ -32,6 +36,7 @@ var/global/list/home_system_choices = list(
 	"Epsilon Ursae Minoris",
 	"Rarkajar"
 	)
+// VOREStation Edits Stop
 
 var/global/list/faction_choices = list(
 	"Sol Central",

--- a/code/modules/client/preferences_factions.dm
+++ b/code/modules/client/preferences_factions.dm
@@ -23,12 +23,17 @@ var/global/list/citizenship_choices = list(
 	"Meralar",
 	"Qerr'balak",
 	"Virgo 3b Colony",
-	"Virgo 4 NT Compound"
+	"Virgo 4 NT Compound",
+	"Venus",
+	"Tiamat",
+	"An-Tahk-Et"
 	)
 
 var/global/list/home_system_choices = list(
 	"Virgo-Erigone",
 	"Sol",
+	"Proxima Centauri",
+	"Procyon",
 	"Vir",
 	"Nyx",
 	"Tau Ceti",
@@ -36,10 +41,13 @@ var/global/list/home_system_choices = list(
 	"Epsilon Ursae Minoris",
 	"Rarkajar"
 	)
-// VOREStation Edits Stop
+
 
 var/global/list/faction_choices = list(
-	"Sol Central",
+	"Commonwealth of Sol-Procyon",
+	"United Fyrds",
+	"Elysian Colonies",
+	"Ares Confederation",
 	"Vey Med",
 	"Einstein Engines",
 	"Free Trade Union",
@@ -53,6 +61,7 @@ var/global/list/faction_choices = list(
 	"Morpheus Cyberkinetics",
 	"Xion Manufacturing Group"
 	)
+// VOREStation Edits Stop
 
 var/global/list/antag_faction_choices = list()	//Should be populated after brainstorming. Leaving as blank in case brainstorming does not occur.
 
@@ -80,5 +89,7 @@ var/global/list/religion_choices = list(
 	"Xilar Qall",
 	"Tajr-kii Rarkajar",
 	"Agnosticism",
-	"Deism"
+	"Deism",
+	"Neo-Moreauism",
+	"Orthodox Moreauism"
 	)


### PR DESCRIPTION
None of the citizenship/etc stuff had stuff that was specific to our setting in it, all of them stating home systems like "Sol" which are by definition a good distance away to travel for work. They're left in so you can choose 'em, but I added Virgo as a home system option for those of us that decide we live in-system where we work.