### PR TITLE
Fixes prone turning for tall species

### DIFF
--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -151,7 +151,10 @@ var/global/list/damage_icon_parts = list() //see UpdateDamageIcon()
 	if(lying && !species.prone_icon) //Only rotate them if we're not drawing a specific icon for being prone.
 		M.Turn(90)
 		M.Scale(desired_scale_x, desired_scale_y)
-		M.Translate(1,-6)
+		if(species.icon_height == 64)//VOREStation Edit
+			M.Translate(13,-22)
+		else
+			M.Translate(1,-6)
 		layer = MOB_LAYER -0.01 // Fix for a byond bug where turf entry order no longer matters
 	else
 		M.Scale(desired_scale_x, desired_scale_y)


### PR DESCRIPTION
Aligns the prone icon flip to properly compensate the offsets for 64p tall species