### PR TITLE
Minor Update to ERT Gear

### DIFF
--- a/maps/submaps/admin_use_vr/ert.dmm
+++ b/maps/submaps/admin_use_vr/ert.dmm
@@ -1980,13 +1980,16 @@
 /area/ship/ert/barracks)
 "oX" = (
 /obj/structure/table/rack/steel,
-/obj/item/weapon/storage/backpack/ert/engineer,
-/obj/item/weapon/storage/backpack/ert/engineer,
-/obj/item/weapon/storage/backpack/ert/engineer,
-/obj/item/clothing/suit/space/void/responseteam/engineer,
-/obj/item/clothing/suit/space/void/responseteam/engineer,
-/obj/item/clothing/suit/space/void/responseteam/engineer,
 /obj/effect/floor_decal/industrial/outline/grey,
+/obj/item/clothing/gloves/yellow,
+/obj/item/clothing/gloves/yellow,
+/obj/item/clothing/gloves/yellow,
+/obj/item/weapon/storage/backpack/ert/engineer,
+/obj/item/weapon/storage/backpack/ert/engineer,
+/obj/item/weapon/storage/backpack/ert/engineer,
+/obj/item/clothing/suit/space/void/responseteam/engineer,
+/obj/item/clothing/suit/space/void/responseteam/engineer,
+/obj/item/clothing/suit/space/void/responseteam/engineer,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/barracks)
 "pa" = (


### PR DESCRIPTION
Corrects a terrible oversight in the equipment for the ERT ship in that I somehow *completely* forgot to issue the engineers with any insulated gloves as part of their 'basic' kit. You were fine if you used the hardsuit, but not if you use the mark 7 voidsuits. Oops.

Fixed by issuing six pairs to go with the six voidsuits. There were technically four pairs in the Tool Maker already, but those are easy to miss.

Not sure anyone's actually had time to notice since I don't think the ERT's been called yet, but better to fix it ahead of time.