### PR TITLE
Adds the ability to hide, or reveal one's own wings with a verb

### DIFF
--- a/code/modules/mob/living/carbon/human/emote_vr.dm
+++ b/code/modules/mob/living/carbon/human/emote_vr.dm
@@ -247,3 +247,10 @@
 	set desc = "Switch tail layer on top."
 	tail_alt = !tail_alt
 	update_tail_showing()
+	
+/mob/living/carbon/human/verb/hide_wings_vr()
+	set name = "Show/Hide wings"
+	set category = "IC"
+	set desc = "Hide your wings, or show them if you already hid them."
+	wings_hidden = !wings_hidden
+	update_wing_showing()

--- a/code/modules/mob/living/carbon/human/emote_vr.dm
+++ b/code/modules/mob/living/carbon/human/emote_vr.dm
@@ -254,3 +254,10 @@
 	set desc = "Hide your wings, or show them if you already hid them."
 	wings_hidden = !wings_hidden
 	update_wing_showing()
+	var/message = ""
+	if(!wings_hidden)
+		message = "reveals their wings!"
+	else
+		message = "hides their wings."
+	visible_message("[src] [message]")
+	

--- a/code/modules/mob/living/carbon/human/human_defines_vr.dm
+++ b/code/modules/mob/living/carbon/human/human_defines_vr.dm
@@ -9,6 +9,7 @@
 	var/impersonate_bodytype //For impersonating a bodytype
 	var/ability_flags = 0	//Shadekin abilities/potentially other species-based?
 	var/sensorpref = 5		//Suit sensor loadout pref
+	var/wings_hidden = FALSE
 
 /mob/living/carbon/human/proc/shadekin_get_energy()
 	var/datum/species/shadekin/SK = species

--- a/code/modules/mob/living/carbon/human/update_icons_vr.dm
+++ b/code/modules/mob/living/carbon/human/update_icons_vr.dm
@@ -3,13 +3,13 @@
 		return
 
 	//If you are FBP with wing style and didn't set a custom one
-	if(synthetic && synthetic.includes_wing && !wing_style)
+	if((synthetic && synthetic.includes_wing && !wing_style) && !wings_hidden)
 		var/icon/wing_s = new/icon("icon" = synthetic.icon, "icon_state" = "wing") //I dunno. If synths have some custom wing?
 		wing_s.Blend(rgb(src.r_skin, src.g_skin, src.b_skin), species.color_mult ? ICON_MULTIPLY : ICON_ADD)
 		return image(wing_s)
 
 	//If you have custom wings selected
-	if(wing_style && !(wear_suit && wear_suit.flags_inv & HIDETAIL))
+	if((wing_style && !(wear_suit && wear_suit.flags_inv & HIDETAIL)) && wings_hidden)
 		var/icon/wing_s = new/icon("icon" = wing_style.icon, "icon_state" = flapping && wing_style.ani_state ? wing_style.ani_state : wing_style.icon_state)
 		if(wing_style.do_colouration)
 			wing_s.Blend(rgb(src.r_wing, src.g_wing, src.b_wing), wing_style.color_blend_mode)

--- a/code/modules/mob/living/carbon/human/update_icons_vr.dm
+++ b/code/modules/mob/living/carbon/human/update_icons_vr.dm
@@ -9,7 +9,7 @@
 		return image(wing_s)
 
 	//If you have custom wings selected
-	if((wing_style && !(wear_suit && wear_suit.flags_inv & HIDETAIL)) && wings_hidden)
+	if((wing_style && !(wear_suit && wear_suit.flags_inv & HIDETAIL)) && !wings_hidden)
 		var/icon/wing_s = new/icon("icon" = wing_style.icon, "icon_state" = flapping && wing_style.ani_state ? wing_style.ani_state : wing_style.icon_state)
 		if(wing_style.do_colouration)
 			wing_s.Blend(rgb(src.r_wing, src.g_wing, src.b_wing), wing_style.color_blend_mode)


### PR DESCRIPTION
Adds a verb under "IC" tab allowing players to show off or hide their wings. Idea is that some wings can be folded up and hidden under clothes, be they a jumpsuit or a labcoat or something. 

For simplicity's sake, and for player customization (but mostly simplicity), I just made it a verb any player can use regardless of what clothing they wear. Could even do it naked, if so desired.

I cannot really see a way this could be abused beyond flying without visible wings, but that seems like such a niche thing, I don't see much of a need to fear it'd get abused like that.

Does not persist through rounds, nor going tramming out and returning. Defaults to visible wings.