### PR TITLE
Update tether_plains.dmm

### DIFF
--- a/maps/tether/submaps/tether_plains.dmm
+++ b/maps/tether/submaps/tether_plains.dmm
@@ -37,7 +37,6 @@
 	dir = 1;
 	id = "wilderness";
 	name = "Anti-Fauna shutters";
-	pixel_x = 0;
 	pixel_y = -25
 	},
 /turf/simulated/floor/tiled/steel_dirty/virgo3b,
@@ -45,8 +44,7 @@
 "aj" = (
 /obj/effect/floor_decal/rust,
 /obj/machinery/light/small{
-	dir = 8;
-	pixel_x = 0
+	dir = 8
 	},
 /turf/simulated/floor/tiled/steel_dirty/virgo3b,
 /area/tether/outpost/exploration_shed)
@@ -99,7 +97,6 @@
 /area/tether/outpost/exploration_shed)
 "aq" = (
 /obj/machinery/button/remote/blast_door{
-	dir = 2;
 	id = "wilderness";
 	name = "Anti-Fauna shutters";
 	pixel_x = -1;
@@ -123,6 +120,9 @@
 "bF" = (
 /turf/simulated/mineral/virgo3b,
 /area/mine/unexplored)
+"Al" = (
+/turf/simulated/mineral/virgo3b,
+/area/mine/explored)
 "BE" = (
 /mob/living/simple_mob/animal/space/goose/virgo3b,
 /turf/simulated/floor/outdoors/grass/sif/virgo3b,
@@ -131,6 +131,9 @@
 /mob/living/simple_mob/animal/passive/gaslamp,
 /turf/simulated/floor/outdoors/grass/sif/virgo3b,
 /area/tether/outpost/exploration_plains)
+"ID" = (
+/turf/simulated/mineral/virgo3b,
+/area/tether/outpost/exploration_shed)
 
 (1,1,1) = {"
 as
@@ -418,7 +421,7 @@ ac
 "}
 (3,1,1) = {"
 as
-bF
+Al
 bF
 bF
 bF
@@ -560,7 +563,7 @@ ac
 "}
 (4,1,1) = {"
 as
-bF
+Al
 bF
 bF
 bF
@@ -702,7 +705,7 @@ ac
 "}
 (5,1,1) = {"
 as
-bF
+Al
 bF
 bF
 bF
@@ -844,7 +847,7 @@ ac
 "}
 (6,1,1) = {"
 as
-bF
+Al
 bF
 bF
 bF
@@ -986,7 +989,7 @@ ac
 "}
 (7,1,1) = {"
 as
-bF
+Al
 ad
 ad
 bF
@@ -1128,7 +1131,7 @@ ac
 "}
 (8,1,1) = {"
 as
-ad
+Al
 ad
 ad
 ad
@@ -1270,7 +1273,7 @@ ac
 "}
 (9,1,1) = {"
 as
-ad
+Al
 ad
 ad
 ad
@@ -1412,7 +1415,7 @@ ac
 "}
 (10,1,1) = {"
 as
-ab
+Al
 ad
 ad
 ab
@@ -1554,8 +1557,8 @@ ac
 "}
 (11,1,1) = {"
 as
-ab
-ab
+Al
+ad
 ab
 ab
 ab
@@ -1696,8 +1699,8 @@ ac
 "}
 (12,1,1) = {"
 as
-ab
-ab
+Al
+ad
 ab
 ab
 ab
@@ -1838,8 +1841,8 @@ ac
 "}
 (13,1,1) = {"
 as
-ab
-ab
+Al
+ad
 ab
 ab
 ab
@@ -1980,8 +1983,8 @@ ac
 "}
 (14,1,1) = {"
 as
-ab
-ab
+Al
+ad
 ab
 ab
 ab
@@ -2122,8 +2125,8 @@ ac
 "}
 (15,1,1) = {"
 as
-ab
-ab
+Al
+ad
 ab
 ab
 ab
@@ -2264,8 +2267,8 @@ ac
 "}
 (16,1,1) = {"
 as
-ab
-ab
+Al
+ad
 ab
 ab
 ab
@@ -2406,8 +2409,8 @@ ac
 "}
 (17,1,1) = {"
 as
-ab
-ab
+Al
+ad
 ab
 ab
 ab
@@ -2548,8 +2551,8 @@ ac
 "}
 (18,1,1) = {"
 as
-ab
-ab
+Al
+ad
 ab
 ab
 ab
@@ -2690,8 +2693,8 @@ ac
 "}
 (19,1,1) = {"
 as
-ab
-ab
+Al
+ad
 ab
 ab
 ab
@@ -2832,8 +2835,8 @@ ac
 "}
 (20,1,1) = {"
 as
-ab
-ab
+Al
+ad
 ab
 ab
 ab
@@ -2974,8 +2977,8 @@ ac
 "}
 (21,1,1) = {"
 as
-ab
-ab
+Al
+ad
 ab
 ab
 ab
@@ -3116,8 +3119,8 @@ ac
 "}
 (22,1,1) = {"
 as
-ab
-ab
+Al
+ad
 ab
 ab
 ab
@@ -3258,8 +3261,8 @@ ac
 "}
 (23,1,1) = {"
 as
-ab
-ab
+Al
+ad
 ab
 ab
 ab
@@ -3400,8 +3403,8 @@ ac
 "}
 (24,1,1) = {"
 as
-ab
-ab
+Al
+ad
 ab
 ab
 ab
@@ -3542,8 +3545,8 @@ ac
 "}
 (25,1,1) = {"
 as
-ab
-ab
+Al
+ad
 ab
 ab
 ab
@@ -3684,8 +3687,8 @@ ac
 "}
 (26,1,1) = {"
 as
-ab
-ab
+Al
+ad
 ab
 ab
 ab
@@ -3826,8 +3829,8 @@ ac
 "}
 (27,1,1) = {"
 as
-ab
-ab
+Al
+ad
 ab
 ab
 ab
@@ -3968,8 +3971,8 @@ ac
 "}
 (28,1,1) = {"
 as
-ab
-ab
+Al
+ad
 ab
 ab
 ab
@@ -4110,8 +4113,8 @@ ac
 "}
 (29,1,1) = {"
 as
-ab
-ab
+Al
+ad
 ab
 ab
 ab
@@ -4252,8 +4255,8 @@ ac
 "}
 (30,1,1) = {"
 as
-ab
-ab
+Al
+ad
 ab
 ab
 ab
@@ -4394,8 +4397,8 @@ ac
 "}
 (31,1,1) = {"
 as
-ab
-ab
+Al
+ad
 ab
 ab
 ab
@@ -4536,8 +4539,8 @@ ac
 "}
 (32,1,1) = {"
 as
-ab
-ab
+Al
+ad
 ab
 ab
 ab
@@ -4678,8 +4681,8 @@ ac
 "}
 (33,1,1) = {"
 as
-ab
-ab
+Al
+ad
 ab
 ab
 ab
@@ -4820,8 +4823,8 @@ ac
 "}
 (34,1,1) = {"
 as
-ab
-ab
+Al
+ad
 ab
 ab
 ab
@@ -4962,8 +4965,8 @@ ac
 "}
 (35,1,1) = {"
 as
-ab
-ab
+Al
+ad
 ab
 ab
 ab
@@ -5104,8 +5107,8 @@ ac
 "}
 (36,1,1) = {"
 as
-ab
-ab
+Al
+ad
 ab
 ab
 ab
@@ -5246,8 +5249,8 @@ ac
 "}
 (37,1,1) = {"
 as
-ab
-ab
+Al
+ad
 ab
 ab
 Em
@@ -5388,8 +5391,8 @@ ac
 "}
 (38,1,1) = {"
 as
-ab
-ab
+Al
+ad
 ab
 ab
 ab
@@ -5530,8 +5533,8 @@ ac
 "}
 (39,1,1) = {"
 as
-ab
-ab
+Al
+ad
 ab
 ab
 ab
@@ -5672,8 +5675,8 @@ ac
 "}
 (40,1,1) = {"
 as
-ab
-ab
+Al
+ad
 ab
 ab
 ab
@@ -5814,8 +5817,8 @@ ac
 "}
 (41,1,1) = {"
 as
-ab
-ab
+Al
+ad
 ab
 ab
 ab
@@ -5956,8 +5959,8 @@ ac
 "}
 (42,1,1) = {"
 as
-ab
-ab
+Al
+ad
 ab
 ab
 ab
@@ -6098,8 +6101,8 @@ ac
 "}
 (43,1,1) = {"
 as
-ab
-ab
+Al
+ad
 ab
 ab
 ab
@@ -6240,8 +6243,8 @@ ac
 "}
 (44,1,1) = {"
 as
-ab
-ab
+Al
+ad
 ab
 ab
 ab
@@ -6382,8 +6385,8 @@ ac
 "}
 (45,1,1) = {"
 as
-ab
-ab
+Al
+ad
 ab
 ab
 ab
@@ -6524,8 +6527,8 @@ ac
 "}
 (46,1,1) = {"
 as
-ab
-ab
+Al
+ad
 ab
 ab
 ab
@@ -6666,8 +6669,8 @@ ac
 "}
 (47,1,1) = {"
 as
-ab
-ab
+Al
+ad
 ab
 ab
 ab
@@ -6808,8 +6811,8 @@ ac
 "}
 (48,1,1) = {"
 as
-ab
-ab
+Al
+ad
 ab
 ab
 ab
@@ -6950,8 +6953,8 @@ ac
 "}
 (49,1,1) = {"
 as
-ab
-ab
+Al
+ad
 ab
 ab
 ab
@@ -7092,8 +7095,8 @@ ac
 "}
 (50,1,1) = {"
 as
-ab
-ab
+Al
+ad
 ab
 ab
 ab
@@ -7234,8 +7237,8 @@ ac
 "}
 (51,1,1) = {"
 as
-ab
-ab
+Al
+ad
 ab
 ab
 ab
@@ -7376,8 +7379,8 @@ ac
 "}
 (52,1,1) = {"
 as
-ab
-ab
+Al
+ad
 ab
 ab
 ab
@@ -7518,8 +7521,8 @@ ac
 "}
 (53,1,1) = {"
 as
-ab
-ab
+Al
+ad
 ab
 ab
 ab
@@ -7660,8 +7663,8 @@ ac
 "}
 (54,1,1) = {"
 as
-ab
-ab
+Al
+ad
 ab
 ab
 ab
@@ -7802,8 +7805,8 @@ ac
 "}
 (55,1,1) = {"
 as
-ab
-ab
+Al
+ad
 ab
 ab
 ab
@@ -7944,8 +7947,8 @@ ac
 "}
 (56,1,1) = {"
 as
-ab
-ab
+Al
+ad
 ab
 ab
 ab
@@ -8086,8 +8089,8 @@ ac
 "}
 (57,1,1) = {"
 as
-ab
-ab
+Al
+ad
 ab
 ab
 ab
@@ -8228,8 +8231,8 @@ ac
 "}
 (58,1,1) = {"
 as
-ab
-ab
+Al
+ad
 ab
 ab
 ab
@@ -8370,8 +8373,8 @@ ac
 "}
 (59,1,1) = {"
 as
-ab
-ab
+Al
+ad
 ab
 ab
 ab
@@ -8512,8 +8515,8 @@ ac
 "}
 (60,1,1) = {"
 as
-ab
-ab
+Al
+ad
 ab
 ab
 ab
@@ -8654,8 +8657,8 @@ ac
 "}
 (61,1,1) = {"
 as
-ab
-ab
+Al
+ad
 ab
 ab
 ab
@@ -8796,8 +8799,8 @@ ac
 "}
 (62,1,1) = {"
 as
-ab
-ab
+Al
+ad
 ab
 ab
 ab
@@ -8938,7 +8941,7 @@ ac
 "}
 (63,1,1) = {"
 as
-ab
+Al
 ad
 ad
 ab
@@ -9080,7 +9083,7 @@ ac
 "}
 (64,1,1) = {"
 at
-an
+ID
 an
 an
 an
@@ -10784,7 +10787,7 @@ ac
 "}
 (76,1,1) = {"
 at
-an
+ID
 an
 an
 an
@@ -10926,7 +10929,7 @@ ac
 "}
 (77,1,1) = {"
 as
-ad
+Al
 ad
 ad
 ab
@@ -11068,8 +11071,8 @@ ac
 "}
 (78,1,1) = {"
 as
-ab
-ab
+Al
+ad
 ab
 ab
 ab
@@ -11210,8 +11213,8 @@ ac
 "}
 (79,1,1) = {"
 as
-ab
-ab
+Al
+ad
 ab
 ab
 ab
@@ -11352,8 +11355,8 @@ ac
 "}
 (80,1,1) = {"
 as
-ab
-ab
+Al
+ad
 ab
 ab
 ab
@@ -11494,8 +11497,8 @@ ac
 "}
 (81,1,1) = {"
 as
-ab
-ab
+Al
+ad
 ab
 ab
 ab
@@ -11636,8 +11639,8 @@ ac
 "}
 (82,1,1) = {"
 as
-ab
-ab
+Al
+ad
 ab
 ab
 ab
@@ -11778,8 +11781,8 @@ ac
 "}
 (83,1,1) = {"
 as
-ab
-ab
+Al
+ad
 ab
 ab
 ab
@@ -11920,8 +11923,8 @@ ac
 "}
 (84,1,1) = {"
 as
-ab
-ab
+Al
+ad
 ab
 ab
 ab
@@ -12062,8 +12065,8 @@ ac
 "}
 (85,1,1) = {"
 as
-ab
-ab
+Al
+ad
 ab
 ab
 ab
@@ -12204,8 +12207,8 @@ ac
 "}
 (86,1,1) = {"
 as
-ab
-ab
+Al
+ad
 ab
 ab
 ab
@@ -12346,8 +12349,8 @@ ac
 "}
 (87,1,1) = {"
 as
-ab
-ab
+Al
+ad
 ab
 ab
 ab
@@ -12488,8 +12491,8 @@ ac
 "}
 (88,1,1) = {"
 as
-ab
-ab
+Al
+ad
 ab
 ab
 ab
@@ -12630,8 +12633,8 @@ ac
 "}
 (89,1,1) = {"
 as
-ab
-ab
+Al
+ad
 ab
 ab
 ab
@@ -12772,8 +12775,8 @@ ac
 "}
 (90,1,1) = {"
 as
-ab
-ab
+Al
+ad
 ab
 ab
 ab
@@ -12914,8 +12917,8 @@ ac
 "}
 (91,1,1) = {"
 as
-ab
-ab
+Al
+ad
 ab
 ab
 ab
@@ -13056,8 +13059,8 @@ ac
 "}
 (92,1,1) = {"
 as
-ab
-ab
+Al
+ad
 ab
 ab
 ab
@@ -13198,8 +13201,8 @@ ac
 "}
 (93,1,1) = {"
 as
-ab
-ab
+Al
+ad
 ab
 ab
 ab
@@ -13340,8 +13343,8 @@ ac
 "}
 (94,1,1) = {"
 as
-ab
-ab
+Al
+ad
 ab
 ab
 ab
@@ -13482,8 +13485,8 @@ ac
 "}
 (95,1,1) = {"
 as
-ab
-ab
+Al
+ad
 ab
 ab
 ab
@@ -13624,8 +13627,8 @@ ac
 "}
 (96,1,1) = {"
 as
-ab
-ab
+Al
+ad
 ab
 ab
 ab
@@ -13766,8 +13769,8 @@ ac
 "}
 (97,1,1) = {"
 as
-ab
-ab
+Al
+ad
 ab
 ab
 ab
@@ -13908,8 +13911,8 @@ ac
 "}
 (98,1,1) = {"
 as
-ab
-ab
+Al
+ad
 ab
 ab
 ab
@@ -14050,8 +14053,8 @@ ac
 "}
 (99,1,1) = {"
 as
-ab
-ab
+Al
+ad
 ab
 ab
 ab
@@ -14192,8 +14195,8 @@ ac
 "}
 (100,1,1) = {"
 as
-ab
-ab
+Al
+ad
 ab
 ab
 ab
@@ -14334,8 +14337,8 @@ ac
 "}
 (101,1,1) = {"
 as
-ab
-ab
+Al
+ad
 ab
 ab
 ab
@@ -14476,8 +14479,8 @@ ac
 "}
 (102,1,1) = {"
 as
-ab
-ab
+Al
+ad
 ab
 ab
 ab
@@ -14618,8 +14621,8 @@ ac
 "}
 (103,1,1) = {"
 as
-ab
-ab
+Al
+ad
 ab
 ab
 ab
@@ -14760,8 +14763,8 @@ ac
 "}
 (104,1,1) = {"
 as
-ab
-ab
+Al
+ad
 ab
 ab
 ab
@@ -14902,8 +14905,8 @@ ac
 "}
 (105,1,1) = {"
 as
-ab
-ab
+Al
+ad
 ab
 ab
 ab
@@ -15044,8 +15047,8 @@ ac
 "}
 (106,1,1) = {"
 as
-ab
-ab
+Al
+ad
 ab
 ab
 ab
@@ -15186,8 +15189,8 @@ ac
 "}
 (107,1,1) = {"
 as
-ab
-ab
+Al
+ad
 ab
 ab
 ab
@@ -15328,8 +15331,8 @@ ac
 "}
 (108,1,1) = {"
 as
-ab
-ab
+Al
+ad
 ab
 ab
 ab
@@ -15470,8 +15473,8 @@ ac
 "}
 (109,1,1) = {"
 as
-ab
-ab
+Al
+ad
 ab
 ab
 ab
@@ -15612,8 +15615,8 @@ ac
 "}
 (110,1,1) = {"
 as
-ab
-ab
+Al
+ad
 ab
 ab
 ab
@@ -15754,8 +15757,8 @@ ac
 "}
 (111,1,1) = {"
 as
-ab
-ab
+Al
+ad
 ab
 ab
 ab
@@ -15896,8 +15899,8 @@ ac
 "}
 (112,1,1) = {"
 as
-ab
-ab
+Al
+ad
 BE
 ab
 ab
@@ -16038,8 +16041,8 @@ ac
 "}
 (113,1,1) = {"
 as
-ab
-ab
+Al
+ad
 ab
 ab
 ab
@@ -16180,8 +16183,8 @@ ac
 "}
 (114,1,1) = {"
 as
-ab
-ab
+Al
+ad
 ab
 ab
 ab
@@ -16322,8 +16325,8 @@ ac
 "}
 (115,1,1) = {"
 as
-ab
-ab
+Al
+ad
 ab
 ab
 ab
@@ -16464,8 +16467,8 @@ ac
 "}
 (116,1,1) = {"
 as
-ab
-ab
+Al
+ad
 ab
 ab
 ab
@@ -16606,8 +16609,8 @@ ac
 "}
 (117,1,1) = {"
 as
-ab
-ab
+Al
+ad
 ab
 ab
 ab
@@ -16748,8 +16751,8 @@ ac
 "}
 (118,1,1) = {"
 as
-ab
-ab
+Al
+ad
 ab
 ab
 ab
@@ -16890,8 +16893,8 @@ ac
 "}
 (119,1,1) = {"
 as
-ab
-ab
+Al
+ad
 ab
 ab
 ab
@@ -17032,8 +17035,8 @@ ac
 "}
 (120,1,1) = {"
 as
-ab
-ab
+Al
+ad
 ab
 ab
 ab
@@ -17174,8 +17177,8 @@ ac
 "}
 (121,1,1) = {"
 as
-ab
-ab
+Al
+ad
 ab
 ab
 ab
@@ -17316,8 +17319,8 @@ ac
 "}
 (122,1,1) = {"
 as
-ab
-ab
+Al
+ad
 ab
 ab
 ab
@@ -17458,8 +17461,8 @@ ac
 "}
 (123,1,1) = {"
 as
-ab
-ab
+Al
+ad
 ab
 ab
 ab
@@ -17600,8 +17603,8 @@ ac
 "}
 (124,1,1) = {"
 as
-ab
-ab
+Al
+ad
 ab
 Em
 ab
@@ -17742,8 +17745,8 @@ ac
 "}
 (125,1,1) = {"
 as
-ab
-ab
+Al
+ad
 ab
 ab
 ab
@@ -17884,8 +17887,8 @@ ac
 "}
 (126,1,1) = {"
 as
-ab
-ab
+Al
+ad
 ab
 ab
 ab
@@ -18026,8 +18029,8 @@ ac
 "}
 (127,1,1) = {"
 as
-ab
-ab
+Al
+ad
 ab
 ab
 ab
@@ -18168,8 +18171,8 @@ ac
 "}
 (128,1,1) = {"
 as
-ab
-ab
+Al
+ad
 ab
 ab
 ab
@@ -18310,8 +18313,8 @@ ac
 "}
 (129,1,1) = {"
 as
-ab
-ab
+Al
+ad
 ab
 ab
 ab
@@ -18452,8 +18455,8 @@ ac
 "}
 (130,1,1) = {"
 as
-ab
-ab
+Al
+ad
 ab
 ab
 ab
@@ -18594,9 +18597,9 @@ ac
 "}
 (131,1,1) = {"
 as
-ab
-ab
-ab
+Al
+ad
+ad
 ab
 ab
 ab
@@ -18736,9 +18739,9 @@ ac
 "}
 (132,1,1) = {"
 as
-ab
-ab
-ab
+Al
+ad
+ad
 ad
 ab
 ab
@@ -18878,8 +18881,8 @@ ac
 "}
 (133,1,1) = {"
 as
+Al
 ad
-ab
 ad
 ad
 ad
@@ -19020,7 +19023,7 @@ ac
 "}
 (134,1,1) = {"
 as
-ad
+Al
 ad
 ad
 ad
@@ -19162,7 +19165,7 @@ ac
 "}
 (135,1,1) = {"
 as
-bF
+Al
 bF
 bF
 bF
@@ -19304,7 +19307,7 @@ ac
 "}
 (136,1,1) = {"
 as
-bF
+Al
 bF
 bF
 bF
@@ -19446,7 +19449,7 @@ ac
 "}
 (137,1,1) = {"
 as
-bF
+Al
 bF
 bF
 bF
@@ -19588,7 +19591,7 @@ ac
 "}
 (138,1,1) = {"
 as
-bF
+Al
 bF
 bF
 bF


### PR DESCRIPTION
Attempts to resolve some of the wilderness plains active edge issues by buffering the north wall with a thin layer of rock, as the other walls, the NW/NE corners, and the transit shed *aren't* triggering active edge warnings.

Basically just a bandaid fix that has been promising in the limited local unit tests I've run (which is actually really easy to do). Doesn't help with active edge warnings popping up from the debris field but it might help with everything else.

Obviously the actual POIs themselves need fixing and cleaning up too, but that's a much bigger project.

Knowing travis it'll still fire active edge warnings on the north wall with this to spite me, but hey, worth a shot?