### PR TITLE
Revert "Fix unintended inbelly item interactions caused by copypaste"

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -114,11 +114,12 @@
 		trigger_aiming(TARGET_CAN_CLICK)
 		return 1
 
-	// VOREStation Addition Start: inbelly interaction
+	// VOREStation Addition Start: inbelly item interaction
 	if(isbelly(loc) && (loc == A.loc))
 		if(W)
-			to_chat(src, "The firm confines prevent that kind of dexterity!")	//Only hand-based interactions in bellies
-			return
+			var/resolved = W.resolve_attackby(A,src)
+			if(!resolved && A && W)
+				W.afterattack(A, src, 1, params) // 1: clicking something Adjacent
 		else
 			if(ismob(A)) // No instant mob attacking
 				setClickCooldown(get_attack_speed())


### PR DESCRIPTION
This is mostly made to attempt to revert a previous change Merged previously which disallowed the interaction of items under certain conditions. Some discussion is being made to, rather than limit it to the messy method it is to interact with a person, to expand on it and making it something anyone can really use.

However, an assumption comes that the code would need to be reverted anyways in case it may hinge on the previous change.

It is a simple change of could so it doubtfully will cause any issues.

**Edit:** Cleaned up my own rambling and tossed it off into comments somewhat.