### PR TITLE
Gives NIFs soulcatchers by default

### DIFF
--- a/code/modules/nifsoft/nif.dm
+++ b/code/modules/nifsoft/nif.dm
@@ -87,14 +87,12 @@ You can also set the stat of a NIF to NIF_TEMPFAIL without any issues to disable
 				qdel(src)
 			return FALSE
 		else
-			//Free commlink for return customers
+			//Free commlink and soulcatcher for return customers
 			new /datum/nifsoft/commlink(src)
+			new /datum/nifsoft/soulcatcher(src)
 
 	//Free civilian AR included
 	new /datum/nifsoft/ar_civ(src)
-	
-	//Free soulcatcher because why not
-	new /datum/nifsoft/soulcatcher(src)
 
 	//If given wear (like when spawned) then done
 	if(wear)

--- a/code/modules/nifsoft/nif.dm
+++ b/code/modules/nifsoft/nif.dm
@@ -92,6 +92,9 @@ You can also set the stat of a NIF to NIF_TEMPFAIL without any issues to disable
 
 	//Free civilian AR included
 	new /datum/nifsoft/ar_civ(src)
+	
+	//Free soulcatcher because why not
+	new /datum/nifsoft/soulcatcher(src)
 
 	//If given wear (like when spawned) then done
 	if(wear)


### PR DESCRIPTION
hm, there's usually some wacky PR text here

anyway, this adds soulcatchers to everyone's NIFs by default, much like commlinks. 

done on request, enjoy.

