### PR TITLE
Fixes pixel shifting breaking offsets

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -943,8 +943,8 @@ default behaviour is:
 	// Begin VOREstation edit
 	if(is_shifted)
 		is_shifted = FALSE
-		pixel_x = 0
-		pixel_y = 0
+		pixel_x = default_pixel_x
+		pixel_y = default_pixel_y
 	// End VOREstation edit
 
 	if(pulling) // we were pulling a thing and didn't lose it during our move.


### PR DESCRIPTION
Fixes pixel shifting breaking offsets for wide mobs by resetting into hard 0 rather than the mob's defined default offset.