### PR TITLE
Fixes flavor double post on vore

### DIFF
--- a/code/modules/vore/eating/living_vr.dm
+++ b/code/modules/vore/eating/living_vr.dm
@@ -519,10 +519,6 @@
 	if(!ishuman(user))
 		user.update_icons()
 
-	// Flavor handling
-	if(belly.can_taste && prey.get_taste_message(FALSE))
-		to_chat(belly.owner, "<span class='notice'>[prey] tastes of [prey.get_taste_message(FALSE)].</span>")
-
 	// Inform Admins
 	if(pred == user)
 		add_attack_logs(pred, prey, "Eaten via [belly.name]")


### PR DESCRIPTION
The flavor message is already handled by the belly obj Entered proc, so having it in the ingestion proc as well is kinda redundant.