### PR TITLE
Expands Surfmed among other things take 2

### DIFF
--- a/maps/tether/tether-01-surface1.dmm
+++ b/maps/tether/tether-01-surface1.dmm
@@ -1964,7 +1964,7 @@
 /area/tether/surfacebase/lowernorthhall)
 "adt" = (
 /turf/simulated/wall,
-/area/maintenance/surfacebase/cargostoresubstation)
+/area/maintenance/cargostoresubstation)
 "adu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -3763,7 +3763,7 @@
 	RCon_tag = "CargoShop Substation Bypass"
 	},
 /turf/simulated/floor,
-/area/maintenance/surfacebase/cargostoresubstation)
+/area/maintenance/cargostoresubstation)
 "age" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -15555,7 +15555,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/surfacebase/lowmedbaymaint)
+/area/maintenance/lowmedbaymaint)
 "azc" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -15960,7 +15960,7 @@
 	sort_tag = "Void"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/surfacebase/lowmedbaymaint)
+/area/maintenance/lowmedbaymaint)
 "azH" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
@@ -16626,7 +16626,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/surfacebase/lowmedbaymaint)
+/area/maintenance/lowmedbaymaint)
 "aAA" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -16640,7 +16640,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/surfacebase/lowmedbaymaint)
+/area/maintenance/lowmedbaymaint)
 "aAB" = (
 /obj/machinery/power/apc{
 	dir = 4;
@@ -16677,7 +16677,7 @@
 /area/tether/surfacebase/medical/viro/viroward)
 "aAD" = (
 /turf/simulated/wall,
-/area/maintenance/surfacebase/lowmedbaymaint)
+/area/maintenance/lowmedbaymaint)
 "aAE" = (
 /turf/simulated/wall,
 /area/tether/surfacebase/medical/bathroom)
@@ -16698,7 +16698,7 @@
 /area/tether/surfacebase/medical/bathroom)
 "aAG" = (
 /turf/simulated/mineral,
-/area/maintenance/surfacebase/lowmedbaymaint)
+/area/maintenance/lowmedbaymaint)
 "aAH" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -16708,10 +16708,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
-/area/maintenance/surfacebase/lowmedbaymaint)
+/area/maintenance/lowmedbaymaint)
 "aAI" = (
 /turf/simulated/floor/plating,
-/area/maintenance/surfacebase/lowmedbaymaint)
+/area/maintenance/lowmedbaymaint)
 "aAJ" = (
 /obj/machinery/portable_atmospherics/powered/scrubber/huge/stationary/phoronlock{
 	frequency = 1379;
@@ -16838,7 +16838,7 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor,
-/area/maintenance/surfacebase/lowmedbaymaint)
+/area/maintenance/lowmedbaymaint)
 "aAX" = (
 /obj/structure/cable/green{
 	icon_state = "16-0"
@@ -16858,7 +16858,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/surfacebase/lowmedbaymaint)
+/area/maintenance/lowmedbaymaint)
 "aAY" = (
 /obj/machinery/power/apc{
 	cell_type = /obj/item/weapon/cell/super;
@@ -16973,13 +16973,13 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/surfacebase/lowmedbaymaint)
+/area/maintenance/lowmedbaymaint)
 "aBi" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/surfacebase/lowmedbaymaint)
+/area/maintenance/lowmedbaymaint)
 "aBj" = (
 /obj/machinery/recharge_station,
 /obj/machinery/light/small{
@@ -17061,13 +17061,13 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/surfacebase/lowmedbaymaint)
+/area/maintenance/lowmedbaymaint)
 "aBp" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/surfacebase/lowmedbaymaint)
+/area/maintenance/lowmedbaymaint)
 "aBq" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -17078,7 +17078,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/surfacebase/lowmedbaymaint)
+/area/maintenance/lowmedbaymaint)
 "aBr" = (
 /obj/machinery/button/remote/airlock{
 	desc = "A remote control switch for the medbay recovery room door.";
@@ -22153,6 +22153,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/cargostore)
@@ -31229,13 +31233,13 @@
 	dir = 1
 	},
 /turf/simulated/floor,
-/area/maintenance/surfacebase/cargostoresubstation)
+/area/maintenance/cargostoresubstation)
 "bbh" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
-/area/maintenance/surfacebase/cargostoresubstation)
+/area/maintenance/cargostoresubstation)
 "bbi" = (
 /obj/machinery/door/airlock/engineering{
 	name = "CargoShop Substation";
@@ -31246,10 +31250,10 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
-/area/maintenance/surfacebase/cargostoresubstation)
+/area/maintenance/cargostoresubstation)
 "bbj" = (
 /turf/simulated/wall,
-/area/maintenance/surfacebase/medbaysubstation)
+/area/maintenance/medbaysubstation)
 "bbk" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -31397,7 +31401,7 @@
 	req_one_access = list(11,24,5)
 	},
 /turf/simulated/floor,
-/area/maintenance/surfacebase/medbaysubstation)
+/area/maintenance/medbaysubstation)
 "bbs" = (
 /obj/structure/cable/green,
 /obj/structure/cable/green{
@@ -31409,7 +31413,7 @@
 	output_attempt = 0
 	},
 /turf/simulated/floor,
-/area/maintenance/surfacebase/cargostoresubstation)
+/area/maintenance/cargostoresubstation)
 "bbt" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 5
@@ -31441,7 +31445,7 @@
 	},
 /obj/structure/cable,
 /turf/simulated/floor,
-/area/maintenance/surfacebase/cargostoresubstation)
+/area/maintenance/cargostoresubstation)
 "bbv" = (
 /obj/machinery/power/apc{
 	dir = 4;
@@ -31453,7 +31457,7 @@
 	icon_state = "0-2"
 	},
 /turf/simulated/floor,
-/area/maintenance/surfacebase/cargostoresubstation)
+/area/maintenance/cargostoresubstation)
 "bbw" = (
 /obj/structure/table/rack,
 /obj/random/maintenance/cargo,
@@ -31466,7 +31470,7 @@
 	RCon_tag = "Medical2 Substation Bypass"
 	},
 /turf/simulated/floor,
-/area/maintenance/surfacebase/medbaysubstation)
+/area/maintenance/medbaysubstation)
 "bby" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
@@ -31483,7 +31487,7 @@
 	dir = 1
 	},
 /turf/simulated/floor,
-/area/maintenance/surfacebase/medbaysubstation)
+/area/maintenance/medbaysubstation)
 "bbz" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -31494,7 +31498,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor,
-/area/maintenance/surfacebase/medbaysubstation)
+/area/maintenance/medbaysubstation)
 "bbA" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -31505,7 +31509,7 @@
 	req_one_access = list(11,24,5)
 	},
 /turf/simulated/floor,
-/area/maintenance/surfacebase/medbaysubstation)
+/area/maintenance/medbaysubstation)
 "bbB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -31532,7 +31536,7 @@
 	name_tag = "CargoShop Subgrid"
 	},
 /turf/simulated/floor,
-/area/maintenance/surfacebase/cargostoresubstation)
+/area/maintenance/cargostoresubstation)
 "bbD" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 1
@@ -31546,7 +31550,7 @@
 	dir = 1
 	},
 /turf/simulated/floor,
-/area/maintenance/surfacebase/cargostoresubstation)
+/area/maintenance/cargostoresubstation)
 "bbE" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -31563,7 +31567,7 @@
 	pixel_y = -25
 	},
 /turf/simulated/floor,
-/area/maintenance/surfacebase/cargostoresubstation)
+/area/maintenance/cargostoresubstation)
 "bbF" = (
 /obj/machinery/door/firedoor/glass,
 /obj/structure/cable/green{
@@ -31576,7 +31580,7 @@
 	req_one_access = list(11,24,50)
 	},
 /turf/simulated/floor,
-/area/maintenance/surfacebase/cargostoresubstation)
+/area/maintenance/cargostoresubstation)
 "bbG" = (
 /obj/machinery/door/airlock/maintenance/common,
 /obj/structure/disposalpipe/segment,
@@ -31603,7 +31607,7 @@
 	icon_state = "warning"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/surfacebase/medbaysubstation)
+/area/maintenance/medbaysubstation)
 "bbJ" = (
 /obj/structure/cable/green,
 /obj/structure/cable/green{
@@ -31615,7 +31619,7 @@
 	output_attempt = 0
 	},
 /turf/simulated/floor,
-/area/maintenance/surfacebase/medbaysubstation)
+/area/maintenance/medbaysubstation)
 "bbK" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
@@ -31625,7 +31629,7 @@
 	},
 /obj/structure/cable,
 /turf/simulated/floor,
-/area/maintenance/surfacebase/medbaysubstation)
+/area/maintenance/medbaysubstation)
 "bbL" = (
 /obj/machinery/power/apc{
 	dir = 4;
@@ -31642,14 +31646,14 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor,
-/area/maintenance/surfacebase/medbaysubstation)
+/area/maintenance/medbaysubstation)
 "bbM" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 4;
 	icon_state = "warningcorner"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/surfacebase/medbaysubstation)
+/area/maintenance/medbaysubstation)
 "bbN" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -31767,7 +31771,7 @@
 	name_tag = "Medical2 Subgrid"
 	},
 /turf/simulated/floor,
-/area/maintenance/surfacebase/medbaysubstation)
+/area/maintenance/medbaysubstation)
 "bbW" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 1
@@ -31781,7 +31785,7 @@
 	dir = 1
 	},
 /turf/simulated/floor,
-/area/maintenance/surfacebase/medbaysubstation)
+/area/maintenance/medbaysubstation)
 "bbX" = (
 /obj/machinery/door/airlock/maintenance/common,
 /obj/structure/disposalpipe/segment,
@@ -31799,7 +31803,7 @@
 	pixel_y = -25
 	},
 /turf/simulated/floor,
-/area/maintenance/surfacebase/medbaysubstation)
+/area/maintenance/medbaysubstation)
 "bbZ" = (
 /obj/machinery/power/apc{
 	dir = 4;
@@ -31811,7 +31815,7 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/surfacebase/lowmedbaymaint)
+/area/maintenance/lowmedbaymaint)
 "bca" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/brown/border,
@@ -32755,7 +32759,7 @@
 	pixel_y = 0
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/surfacebase/lowmedbaymaint)
+/area/maintenance/lowmedbaymaint)
 "bMs" = (
 /obj/machinery/door/airlock/glass_external/public,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -33134,9 +33138,14 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_one_hall)
 "dYd" = (
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/tether/surfacebase/outside/outside1)
+/obj/machinery/firealarm{
+	dir = 2;
+	layer = 3.3;
+	pixel_x = 0;
+	pixel_y = 26
+	},
+/turf/simulated/floor/tiled/steel_dirty,
+/area/tether/surfacebase/cargostore/warehouse)
 "dZW" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
@@ -34660,7 +34669,7 @@
 	scrub_id = "atrium"
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/tether/surfacebase/outside/outside1)
+/area/maintenance/lower/vacant_site)
 "ofS" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/mauve/border,
@@ -34847,7 +34856,7 @@
 	pixel_y = 0
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/surfacebase/lowmedbaymaint)
+/area/maintenance/lowmedbaymaint)
 "poN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/catwalk,
@@ -35917,12 +35926,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/looking_glass/lg_1)
-"xSa" = (
-/obj/machinery/door/airlock/maintenance/common,
-/obj/machinery/door/firedoor/glass,
-/obj/structure/catwalk,
-/turf/simulated/floor/tiled/techfloor,
-/area/tether/surfacebase/outside/outside1)
 "xYn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 4
@@ -48390,7 +48393,7 @@ cPX
 afO
 aBB
 aCr
-aDt
+dYd
 aEh
 aDC
 aCr
@@ -49972,7 +49975,7 @@ apF
 ahc
 apF
 nKz
-adK
+apF
 ash
 ast
 asU
@@ -50113,8 +50116,8 @@ apG
 apF
 aqN
 apF
-xSa
-adK
+aqN
+apF
 ash
 ast
 asU
@@ -50255,8 +50258,8 @@ aaW
 aqi
 aqO
 mRY
-dYd
-dYd
+aql
+aql
 ash
 asu
 asU

--- a/maps/tether/tether-01-surface1.dmm
+++ b/maps/tether/tether-01-surface1.dmm
@@ -1340,7 +1340,7 @@
 	use_power = 1
 	},
 /turf/simulated/floor/virgo3b,
-/area/medical/virology)
+/area/tether/surfacebase/mining_main/external)
 "acl" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -1638,7 +1638,7 @@
 "acM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/black,
 /turf/simulated/floor/virgo3b,
-/area/medical/virology)
+/area/tether/surfacebase/mining_main/external)
 "acN" = (
 /obj/structure/cable/ender{
 	icon_state = "1-2";
@@ -33133,9 +33133,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_one_hall)
-"dXe" = (
-/turf/simulated/wall/r_wall,
-/area/medical/virologyisolation)
 "dYd" = (
 /obj/machinery/firealarm{
 	dir = 2;
@@ -35925,6 +35922,9 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/looking_glass/lg_1)
+"xUo" = (
+/turf/simulated/wall/r_wall,
+/area/medical/virologyisolation)
 "xYn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 4
@@ -52640,14 +52640,14 @@ aad
 aad
 aah
 aah
-dXe
+xUo
 ajb
 awu
 lMK
 ayx
 ayN
 azA
-dXe
+xUo
 aah
 aah
 aah
@@ -52782,14 +52782,14 @@ aad
 aad
 aah
 aah
-dXe
+xUo
 amc
 arB
 arB
 ayy
 ayO
 azB
-dXe
+xUo
 aah
 aah
 aah
@@ -52924,14 +52924,14 @@ aad
 aad
 aah
 aah
-dXe
+xUo
 amP
 awv
 awv
 ayz
 ayP
 azC
-dXe
+xUo
 aah
 aah
 aah
@@ -53066,14 +53066,14 @@ aad
 aad
 aad
 aah
-dXe
+xUo
 aAC
 avY
 axJ
 ayA
 ayX
 azD
-dXe
+xUo
 aah
 aah
 aah
@@ -53208,14 +53208,14 @@ aad
 aad
 aad
 aad
-dXe
-dXe
-dXe
-dXe
-dXe
-dXe
-dXe
-dXe
+xUo
+xUo
+xUo
+xUo
+xUo
+xUo
+xUo
+xUo
 aah
 aah
 aah

--- a/maps/tether/tether-01-surface1.dmm
+++ b/maps/tether/tether-01-surface1.dmm
@@ -16625,11 +16625,11 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/lowmedbaymaint)
@@ -16963,6 +16963,12 @@
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/lowmedbaymaint)
@@ -31493,6 +31499,12 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
 /turf/simulated/floor,
 /area/maintenance/substation/SurfMedsubstation)
 "bbA" = (
@@ -31503,6 +31515,12 @@
 /obj/machinery/door/airlock/engineering{
 	name = "Medbay Substation";
 	req_one_access = list(11,24,5)
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/maintenance/substation/SurfMedsubstation)
@@ -31542,8 +31560,8 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/camera/network/engineering{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
 	},
 /turf/simulated/floor,
 /area/maintenance/substation/cargostoresubstation)
@@ -31558,9 +31576,11 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -25
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/maintenance/substation/cargostoresubstation)
@@ -31574,6 +31594,12 @@
 /obj/machinery/door/airlock/engineering{
 	name = "CargoShop Substation";
 	req_one_access = list(11,24,50)
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/maintenance/substation/cargostoresubstation)
@@ -31602,6 +31628,9 @@
 	dir = 4;
 	icon_state = "warning"
 	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/SurfMedsubstation)
 "bbJ" = (
@@ -31614,6 +31643,9 @@
 	RCon_tag = "Substation - SurfMed";
 	output_attempt = 0
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor,
 /area/maintenance/substation/SurfMedsubstation)
 "bbK" = (
@@ -31624,6 +31656,9 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor,
 /area/maintenance/substation/SurfMedsubstation)
 "bbL" = (
@@ -31641,12 +31676,19 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
 /turf/simulated/floor,
 /area/maintenance/substation/SurfMedsubstation)
 "bbM" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 4;
 	icon_state = "warningcorner"
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/SurfMedsubstation)
@@ -31766,6 +31808,9 @@
 	name = "Powernet Sensor - SurfMed Subgrid";
 	name_tag = "SurfMed Subgrid"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor,
 /area/maintenance/substation/SurfMedsubstation)
 "bbW" = (
@@ -31779,6 +31824,9 @@
 	},
 /obj/machinery/camera/network/engineering{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/maintenance/substation/SurfMedsubstation)
@@ -31797,6 +31845,13 @@
 /obj/machinery/alarm{
 	dir = 1;
 	pixel_y = -25
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
 	},
 /turf/simulated/floor,
 /area/maintenance/substation/SurfMedsubstation)
@@ -33252,6 +33307,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/lower/research)
+"eQz" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/lowmedbaymaint)
 "eQT" = (
 /obj/effect/floor_decal/steeldecal/steel_decals6{
 	dir = 10
@@ -33385,6 +33449,12 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_one_hall)
+"gjF" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/lowmedbaymaint)
 "glc" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -33553,6 +33623,12 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_one_hall)
+"gYx" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/lowmedbaymaint)
 "gZN" = (
 /turf/simulated/floor/looking_glass{
 	dir = 9;
@@ -33687,6 +33763,13 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9;
+	pixel_y = 0
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/lower/mining_eva)
@@ -34162,12 +34245,6 @@
 /area/maintenance/lower/research)
 "lpK" = (
 /obj/structure/catwalk,
-/obj/machinery/atmospherics/pipe/simple/visible/scrubbers{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/supply{
-	dir = 5
-	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -34177,6 +34254,12 @@
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/lower/mining_eva)
@@ -34244,6 +34327,8 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/maintenance/lower/mining_eva)
 "lMf" = (
@@ -34460,6 +34545,13 @@
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/xenoflora)
+"mMs" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plating,
+/area/maintenance/lowmedbaymaint)
 "mOz" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
@@ -34537,8 +34629,8 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_one_hall)
 "naC" = (
-/turf/simulated/floor,
-/area/maintenance/lower/mining_eva)
+/turf/simulated/wall/r_wall,
+/area/medical/virologyisolation)
 "ndH" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -34615,6 +34707,15 @@
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/locker/laundry_arrival)
+"npp" = (
+/obj/machinery/camera/network/engineering{
+	dir = 1
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/maintenance/substation/cargostoresubstation)
 "nsp" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -34908,6 +35009,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_one_hall)
+"qDR" = (
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/turf/simulated/floor,
+/area/maintenance/substation/cargostoresubstation)
 "qKn" = (
 /obj/effect/floor_decal/steeldecal/steel_decals_central1{
 	dir = 8
@@ -34943,6 +35051,11 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/lowerhall)
+"qNr" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plating,
+/area/maintenance/lowmedbaymaint)
 "qOA" = (
 /obj/structure/table/standard{
 	name = "plastic table frame"
@@ -35207,6 +35320,12 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/public_garden_one)
+"skC" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/lowmedbaymaint)
 "svZ" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -35755,6 +35874,16 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/bathroom)
+"woJ" = (
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -25
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/maintenance/substation/cargostoresubstation)
 "wvn" = (
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 1
@@ -35806,6 +35935,21 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/lower/mining_eva)
+"wIo" = (
+/obj/structure/catwalk,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/lower/mining_eva)
@@ -35922,9 +36066,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/looking_glass/lg_1)
-"xUo" = (
-/turf/simulated/wall/r_wall,
-/area/medical/virologyisolation)
 "xYn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 4
@@ -46267,8 +46408,8 @@ adt
 agd
 bbs
 bbC
-adt
-blL
+qDR
+adK
 blL
 abT
 wzA
@@ -46409,8 +46550,8 @@ adt
 bbg
 bbu
 bbD
-adt
-blL
+npp
+adK
 blL
 abT
 tCV
@@ -46551,8 +46692,8 @@ adt
 bbh
 bbv
 bbE
-adt
-naC
+woJ
+abT
 blL
 abT
 tCV
@@ -46837,7 +46978,7 @@ lDW
 hPU
 cpD
 fBN
-fBN
+wIo
 cBf
 hQP
 anv
@@ -52083,10 +52224,10 @@ azH
 azW
 aAe
 aeE
-aAI
-aAI
-aAI
-aAI
+eQz
+mMs
+qNr
+qNr
 aBh
 aBi
 aBi
@@ -52225,9 +52366,9 @@ azJ
 azX
 aAg
 aeE
-aAI
-aAI
-aAI
+skC
+gjF
+gYx
 pdo
 aAI
 aAI
@@ -52640,14 +52781,14 @@ aad
 aad
 aah
 aah
-xUo
+naC
 ajb
 awu
 lMK
 ayx
 ayN
 azA
-xUo
+naC
 aah
 aah
 aah
@@ -52782,14 +52923,14 @@ aad
 aad
 aah
 aah
-xUo
+naC
 amc
 arB
 arB
 ayy
 ayO
 azB
-xUo
+naC
 aah
 aah
 aah
@@ -52924,14 +53065,14 @@ aad
 aad
 aah
 aah
-xUo
+naC
 amP
 awv
 awv
 ayz
 ayP
 azC
-xUo
+naC
 aah
 aah
 aah
@@ -53066,14 +53207,14 @@ aad
 aad
 aad
 aah
-xUo
+naC
 aAC
 avY
 axJ
 ayA
 ayX
 azD
-xUo
+naC
 aah
 aah
 aah
@@ -53208,14 +53349,14 @@ aad
 aad
 aad
 aad
-xUo
-xUo
-xUo
-xUo
-xUo
-xUo
-xUo
-xUo
+naC
+naC
+naC
+naC
+naC
+naC
+naC
+naC
 aah
 aah
 aah

--- a/maps/tether/tether-01-surface1.dmm
+++ b/maps/tether/tether-01-surface1.dmm
@@ -1340,7 +1340,7 @@
 	use_power = 1
 	},
 /turf/simulated/floor/virgo3b,
-/area/tether/surfacebase/medical/viro)
+/area/medical/virology)
 "acl" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -1638,7 +1638,7 @@
 "acM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/black,
 /turf/simulated/floor/virgo3b,
-/area/tether/surfacebase/medical/viro)
+/area/medical/virology)
 "acN" = (
 /obj/structure/cable/ender{
 	icon_state = "1-2";
@@ -2557,13 +2557,10 @@
 /obj/machinery/light,
 /turf/simulated/floor/carpet/blue,
 /area/tether/surfacebase/medical/mentalhealth)
-"aem" = (
-/turf/simulated/wall/r_wall,
-/area/tether/surfacebase/medical/viro)
 "aen" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/black,
 /turf/simulated/wall/r_wall,
-/area/tether/surfacebase/medical/viro)
+/area/medical/virology)
 "aeo" = (
 /turf/simulated/floor/virgo3b,
 /area/tether/surfacebase/outside/outside1)
@@ -2836,7 +2833,7 @@
 /area/tether/surfacebase/medical/recoveryward)
 "aeE" = (
 /turf/simulated/wall/r_wall,
-/area/tether/surfacebase/medical/viro/viroward)
+/area/medical/virology)
 "aeF" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -3209,7 +3206,7 @@
 /area/rnd/testingroom)
 "aff" = (
 /turf/simulated/wall,
-/area/tether/surfacebase/medical/viroairlock)
+/area/medical/virologyaccess)
 "afg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5;
@@ -3304,7 +3301,7 @@
 /area/tether/surfacebase/lowernorthhall)
 "afm" = (
 /turf/simulated/wall/r_wall,
-/area/tether/surfacebase/medical/viroairlock)
+/area/medical/virologyaccess)
 "afn" = (
 /obj/machinery/disease2/diseaseanalyser,
 /obj/item/device/radio/intercom{
@@ -3319,7 +3316,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/viro)
+/area/medical/virology)
 "afo" = (
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 9
@@ -3424,7 +3421,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/viro)
+/area/medical/virology)
 "afy" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -3476,7 +3473,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/viro)
+/area/medical/virology)
 "afC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/rack,
@@ -3502,7 +3499,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/viro)
+/area/medical/virology)
 "afE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -3599,7 +3596,7 @@
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/viro)
+/area/medical/virology)
 "afM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -3855,7 +3852,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/tether/surfacebase/medical/viro)
+/area/medical/virology)
 "agr" = (
 /obj/machinery/alarm{
 	dir = 8;
@@ -4867,7 +4864,7 @@
 	},
 /obj/machinery/smartfridge/secure/virology,
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/viro)
+/area/medical/virology)
 "aih" = (
 /obj/machinery/button/remote/blast_door{
 	id = "gogogo";
@@ -5385,7 +5382,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/viro/viroward)
+/area/medical/virologyisolation)
 "ajc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 4
@@ -7224,7 +7221,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/viro/viroward)
+/area/medical/virologyisolation)
 "amd" = (
 /obj/structure/sign/warning/nosmoking_2,
 /turf/simulated/wall/r_wall,
@@ -7623,7 +7620,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/viro/viroward)
+/area/medical/virologyisolation)
 "amQ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -10513,7 +10510,7 @@
 /area/tether/surfacebase/surface_one_hall)
 "arB" = (
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/viro/viroward)
+/area/medical/virologyisolation)
 "arC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/green{
@@ -12086,7 +12083,7 @@
 /obj/structure/closet/l3closet/virology,
 /obj/machinery/camera/network/medbay,
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/viroairlock)
+/area/medical/virologyaccess)
 "aup" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -12108,7 +12105,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/viroairlock)
+/area/medical/virologyaccess)
 "aur" = (
 /obj/structure/closet/l3closet/virology,
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
@@ -12116,7 +12113,7 @@
 	pixel_y = 22
 	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/viroairlock)
+/area/medical/virologyaccess)
 "aus" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -12398,7 +12395,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/viro)
+/area/medical/virology)
 "auM" = (
 /obj/structure/table/rack,
 /obj/random/junk,
@@ -12668,10 +12665,10 @@
 	dir = 10
 	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/viro)
+/area/medical/virology)
 "avl" = (
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/viro)
+/area/medical/virology)
 "avm" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -13192,7 +13189,7 @@
 	pixel_y = 62
 	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/viro)
+/area/medical/virology)
 "avR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow,
 /obj/effect/floor_decal/industrial/warning/corner{
@@ -13201,7 +13198,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/viro)
+/area/medical/virology)
 "avS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/red,
 /obj/effect/floor_decal/industrial/warning{
@@ -13209,7 +13206,7 @@
 	icon_state = "warning"
 	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/viro)
+/area/medical/virology)
 "avT" = (
 /turf/simulated/wall/r_wall,
 /area/maintenance/lower/xenoflora)
@@ -13285,7 +13282,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/viro/viroward)
+/area/medical/virologyisolation)
 "avZ" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/red/border,
@@ -13527,7 +13524,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/viro/viroward)
+/area/medical/virologyisolation)
 "awv" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -13535,7 +13532,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/viro/viroward)
+/area/medical/virologyisolation)
 "aww" = (
 /obj/effect/floor_decal/borderfloorwhite,
 /obj/effect/floor_decal/corner/paleblue/border,
@@ -14014,7 +14011,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/viroairlock)
+/area/medical/virologyaccess)
 "awY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -14042,7 +14039,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/viroairlock)
+/area/medical/virologyaccess)
 "awZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -14064,7 +14061,7 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/viroairlock)
+/area/medical/virologyaccess)
 "axa" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -14099,7 +14096,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/viroairlock)
+/area/medical/virologyaccess)
 "axb" = (
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/airlock/medical{
@@ -14129,7 +14126,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/viroairlock)
+/area/medical/virologyaccess)
 "axc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -14170,7 +14167,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/viro)
+/area/medical/virology)
 "axd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -14190,7 +14187,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/viro)
+/area/medical/virology)
 "axe" = (
 /obj/machinery/door/airlock/maintenance/engi{
 	name = "Elevator Maintenance"
@@ -14295,7 +14292,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/viro)
+/area/medical/virology)
 "axk" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/structure/cable{
@@ -14577,7 +14574,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/viro)
+/area/medical/virology)
 "axG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -14593,16 +14590,11 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/viro)
+/area/medical/virology)
 "axH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/universal,
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/viro)
-"axI" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/turf/simulated/floor/plating,
-/area/tether/surfacebase/medical/viro/viroward)
+/area/medical/virology)
 "axJ" = (
 /obj/structure/bed/padded,
 /obj/item/weapon/bedsheet/green,
@@ -14617,7 +14609,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/viro/viroward)
+/area/medical/virologyisolation)
 "axK" = (
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/airlock/glass_medical{
@@ -14897,7 +14889,7 @@
 	},
 /obj/structure/curtain/open/shower/medical,
 /turf/simulated/floor/tiled/steel,
-/area/tether/surfacebase/medical/viroairlock)
+/area/medical/virologyaccess)
 "aye" = (
 /obj/structure/table/standard,
 /obj/random/medical,
@@ -14908,7 +14900,7 @@
 	},
 /obj/structure/cable/green,
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/viroairlock)
+/area/medical/virologyaccess)
 "ayf" = (
 /obj/structure/sink{
 	dir = 4;
@@ -14924,7 +14916,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/viroairlock)
+/area/medical/virologyaccess)
 "ayg" = (
 /obj/machinery/embedded_controller/radio/airlock/access_controller{
 	dir = 4;
@@ -14957,7 +14949,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/viro)
+/area/medical/virology)
 "ayh" = (
 /turf/simulated/wall,
 /area/crew_quarters/locker/laundry_arrival)
@@ -14975,7 +14967,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/viro)
+/area/medical/virology)
 "ayk" = (
 /obj/structure/table/glass,
 /obj/item/device/radio{
@@ -15006,7 +14998,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/viro)
+/area/medical/virology)
 "ayl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 5
@@ -15016,7 +15008,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/viro)
+/area/medical/virology)
 "aym" = (
 /obj/machinery/door/firedoor/glass/hidden/steel{
 	dir = 2
@@ -15123,7 +15115,7 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/viro)
+/area/medical/virology)
 "ayu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -15148,7 +15140,7 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/viro)
+/area/medical/virology)
 "ayv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -15169,7 +15161,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/viro)
+/area/medical/virology)
 "ayw" = (
 /obj/machinery/door/airlock/glass_medical{
 	name = "Virology Laboratory";
@@ -15190,7 +15182,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/viro/viroward)
+/area/medical/virology)
 "ayx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -15213,7 +15205,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/viro/viroward)
+/area/medical/virologyisolation)
 "ayy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -15230,7 +15222,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/viro/viroward)
+/area/medical/virologyisolation)
 "ayz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 10
@@ -15245,7 +15237,7 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/viro/viroward)
+/area/medical/virologyisolation)
 "ayA" = (
 /obj/structure/bed/padded,
 /obj/item/weapon/bedsheet/green,
@@ -15261,7 +15253,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/viro/viroward)
+/area/medical/virologyisolation)
 "ayB" = (
 /obj/machinery/door/firedoor/glass/hidden/steel,
 /obj/effect/floor_decal/borderfloorwhite{
@@ -15306,7 +15298,7 @@
 	req_access = list(5)
 	},
 /turf/simulated/floor/plating,
-/area/tether/surfacebase/medical/viroairlock)
+/area/medical/virologyaccess)
 "ayE" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -15319,12 +15311,12 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/viro)
+/area/medical/virology)
 "ayF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/viro)
+/area/medical/virology)
 "ayG" = (
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_one_hall)
@@ -15345,7 +15337,7 @@
 	name = "lightsout"
 	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/viro)
+/area/medical/virology)
 "ayL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -15355,7 +15347,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/viro)
+/area/medical/virology)
 "ayM" = (
 /obj/structure/table/glass,
 /obj/item/weapon/storage/box/monkeycubes,
@@ -15377,7 +15369,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/viro)
+/area/medical/virology)
 "ayN" = (
 /obj/machinery/light_switch{
 	dir = 4;
@@ -15396,11 +15388,11 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/viro/viroward)
+/area/medical/virologyisolation)
 "ayO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/viro/viroward)
+/area/medical/virologyisolation)
 "ayP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow,
 /obj/structure/disposalpipe/segment{
@@ -15408,7 +15400,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/viro/viroward)
+/area/medical/virologyisolation)
 "ayQ" = (
 /obj/machinery/status_display{
 	pixel_y = 30
@@ -15525,7 +15517,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/viro/viroward)
+/area/medical/virologyisolation)
 "ayY" = (
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 8
@@ -15834,7 +15826,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/viro)
+/area/medical/virology)
 "azv" = (
 /obj/structure/table/glass,
 /obj/item/weapon/storage/fancy/vials,
@@ -15847,7 +15839,7 @@
 /obj/effect/floor_decal/borderfloorwhite/corner2,
 /obj/effect/floor_decal/corner/lime/bordercorner2,
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/viro)
+/area/medical/virology)
 "azw" = (
 /obj/structure/table/glass,
 /obj/item/weapon/storage/lockbox/vials,
@@ -15858,7 +15850,7 @@
 /obj/effect/floor_decal/borderfloorwhite,
 /obj/effect/floor_decal/corner/lime/border,
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/viro)
+/area/medical/virology)
 "azx" = (
 /obj/structure/table/glass,
 /obj/item/weapon/storage/box/beakers,
@@ -15875,14 +15867,14 @@
 	dir = 9
 	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/viro)
+/area/medical/virology)
 "azy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/yellow{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/viro)
+/area/medical/virology)
 "azz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow,
 /obj/structure/cable/green{
@@ -15894,7 +15886,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/viro)
+/area/medical/virology)
 "azA" = (
 /obj/machinery/vending/snack{
 	dir = 1
@@ -15906,7 +15898,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/viro/viroward)
+/area/medical/virologyisolation)
 "azB" = (
 /obj/structure/table/standard,
 /obj/item/weapon/soap/nanotrasen,
@@ -15921,7 +15913,7 @@
 	},
 /obj/effect/floor_decal/borderfloorwhite,
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/viro/viroward)
+/area/medical/virologyisolation)
 "azC" = (
 /obj/structure/reagent_dispensers/water_cooler/full{
 	dir = 4
@@ -15931,7 +15923,7 @@
 	},
 /obj/effect/floor_decal/borderfloorwhite,
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/viro/viroward)
+/area/medical/virologyisolation)
 "azD" = (
 /obj/machinery/disposal,
 /obj/effect/floor_decal/industrial/warning/full,
@@ -15939,7 +15931,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/viro/viroward)
+/area/medical/virologyisolation)
 "azE" = (
 /obj/structure/railing,
 /obj/machinery/camera/network/medbay{
@@ -15965,7 +15957,7 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
 /turf/simulated/floor/plating,
-/area/tether/surfacebase/medical/viro)
+/area/medical/virology)
 "azI" = (
 /obj/machinery/door/window/eastright{
 	dir = 1;
@@ -15981,7 +15973,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/viro)
+/area/medical/virology)
 "azJ" = (
 /obj/machinery/door/window/eastright{
 	dir = 1;
@@ -15997,7 +15989,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/viro)
+/area/medical/virology)
 "azK" = (
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 6
@@ -16138,7 +16130,7 @@
 /area/tether/surfacebase/medical/recoveryward/storage)
 "azV" = (
 /turf/simulated/wall,
-/area/tether/surfacebase/medical/viro)
+/area/medical/virology)
 "azW" = (
 /obj/structure/closet/secure_closet/personal/patient,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -16154,7 +16146,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/viro)
+/area/medical/virology)
 "azX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 9
@@ -16169,7 +16161,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/viro)
+/area/medical/virology)
 "azY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -16181,7 +16173,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/viro)
+/area/medical/virology)
 "azZ" = (
 /obj/machinery/alarm{
 	dir = 4;
@@ -16284,7 +16276,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/viro)
+/area/medical/virology)
 "aAf" = (
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/steeldecal/steel_decals_central1{
@@ -16303,7 +16295,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/viro)
+/area/medical/virology)
 "aAh" = (
 /obj/structure/table/standard,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -16320,7 +16312,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/viro)
+/area/medical/virology)
 "aAi" = (
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/airlock/glass_medical{
@@ -16674,7 +16666,7 @@
 	pixel_x = 24
 	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/viro/viroward)
+/area/medical/virologyisolation)
 "aAD" = (
 /turf/simulated/wall,
 /area/maintenance/lowmedbaymaint)
@@ -31901,7 +31893,7 @@
 /obj/effect/floor_decal/borderfloorwhite/corner2,
 /obj/effect/floor_decal/corner/lime/bordercorner2,
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/viro)
+/area/medical/virology)
 "bch" = (
 /obj/random/junk,
 /turf/simulated/floor/plating,
@@ -33141,6 +33133,9 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_one_hall)
+"dXe" = (
+/turf/simulated/wall/r_wall,
+/area/medical/virologyisolation)
 "dYd" = (
 /obj/machinery/firealarm{
 	dir = 2;
@@ -34301,7 +34296,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/viro/viroward)
+/area/medical/virologyisolation)
 "lNp" = (
 /turf/simulated/floor/looking_glass/optional{
 	dir = 4;
@@ -35890,7 +35885,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/viro)
+/area/medical/virology)
 "xzn" = (
 /obj/effect/floor_decal/steeldecal/steel_decals6{
 	dir = 9
@@ -51367,14 +51362,14 @@ aad
 aad
 aad
 aad
-aem
+aeE
 afm
 afm
 axb
 afm
 afm
-aem
-aem
+aeE
+aeE
 azV
 azV
 azV
@@ -51509,7 +51504,7 @@ aad
 aad
 aad
 aad
-aem
+aeE
 afn
 avk
 axc
@@ -51519,7 +51514,7 @@ azu
 azH
 azW
 aAe
-aem
+aeE
 aAz
 aAG
 aAG
@@ -51651,7 +51646,7 @@ aad
 aad
 aad
 aad
-aem
+aeE
 afx
 avl
 axd
@@ -51661,7 +51656,7 @@ azy
 azI
 azX
 aAg
-aem
+aeE
 aAz
 aAG
 aAG
@@ -51793,7 +51788,7 @@ aad
 aad
 aad
 aad
-aem
+aeE
 afB
 avQ
 axj
@@ -51803,7 +51798,7 @@ azv
 azH
 azY
 aAh
-aem
+aeE
 aAz
 aAG
 aAW
@@ -51935,17 +51930,17 @@ aad
 aad
 aad
 aad
-aem
+aeE
 afD
 avl
 axF
 ayl
 avl
 azw
-aem
-aem
-aem
-aem
+aeE
+aeE
+aeE
+aeE
 aAA
 aAH
 aAX
@@ -52077,7 +52072,7 @@ aad
 aad
 aad
 aah
-aem
+aeE
 afL
 avR
 axG
@@ -52087,7 +52082,7 @@ azx
 azH
 azW
 aAe
-aem
+aeE
 aAI
 aAI
 aAI
@@ -52219,7 +52214,7 @@ aad
 aad
 aad
 aah
-aem
+aeE
 agq
 avS
 axH
@@ -52229,7 +52224,7 @@ azz
 azJ
 azX
 aAg
-aem
+aeE
 aAI
 aAI
 aAI
@@ -52371,7 +52366,7 @@ bcf
 azH
 azY
 aAh
-aem
+aeE
 aAD
 aAD
 aAD
@@ -52506,14 +52501,14 @@ aah
 aeE
 aeE
 aeE
-axI
+azH
 ayw
 aeE
 aeE
 aeE
-aem
-aem
-aem
+aeE
+aeE
+aeE
 aah
 aah
 aah
@@ -52645,14 +52640,14 @@ aad
 aad
 aah
 aah
-aeE
+dXe
 ajb
 awu
 lMK
 ayx
 ayN
 azA
-aeE
+dXe
 aah
 aah
 aah
@@ -52787,14 +52782,14 @@ aad
 aad
 aah
 aah
-aeE
+dXe
 amc
 arB
 arB
 ayy
 ayO
 azB
-aeE
+dXe
 aah
 aah
 aah
@@ -52929,14 +52924,14 @@ aad
 aad
 aah
 aah
-aeE
+dXe
 amP
 awv
 awv
 ayz
 ayP
 azC
-aeE
+dXe
 aah
 aah
 aah
@@ -53071,14 +53066,14 @@ aad
 aad
 aad
 aah
-aeE
+dXe
 aAC
 avY
 axJ
 ayA
 ayX
 azD
-aeE
+dXe
 aah
 aah
 aah
@@ -53213,14 +53208,14 @@ aad
 aad
 aad
 aad
-aeE
-aeE
-aeE
-aeE
-aeE
-aeE
-aeE
-aeE
+dXe
+dXe
+dXe
+dXe
+dXe
+dXe
+dXe
+dXe
 aah
 aah
 aah

--- a/maps/tether/tether-01-surface1.dmm
+++ b/maps/tether/tether-01-surface1.dmm
@@ -859,9 +859,14 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/random/cigarettes,
 /obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_x = 0;
+	pixel_y = 28
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/lower/trash_pit)
@@ -872,9 +877,6 @@
 	dir = 1
 	},
 /obj/random/junk,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/lower/trash_pit)
 "abu" = (
@@ -882,11 +884,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/random/junk,
 /obj/random/maintenance/clean,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/lower/trash_pit)
 "abv" = (
@@ -1168,11 +1165,6 @@
 /obj/machinery/door/airlock/medical{
 	name = "EMT Bay"
 	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -1214,7 +1206,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
-/area/tether/surfacebase/lowernortheva)
+/area/tether/surfacebase/lowernorthhall)
 "aca" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -1238,7 +1230,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/tiled,
-/area/tether/surfacebase/lowernortheva)
+/area/tether/surfacebase/lowernorthhall)
 "acb" = (
 /turf/simulated/mineral,
 /area/rnd/testingroom)
@@ -1499,7 +1491,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/tiled,
-/area/tether/surfacebase/lowernortheva)
+/area/tether/surfacebase/lowernorthhall)
 "acz" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1;
@@ -1536,7 +1528,7 @@
 	pixel_x = 32
 	},
 /turf/simulated/floor/tiled,
-/area/tether/surfacebase/lowernortheva)
+/area/tether/surfacebase/lowernorthhall)
 "acC" = (
 /obj/structure/table/woodentable,
 /obj/item/device/flashlight/lamp/green{
@@ -20836,6 +20828,9 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
+/obj/machinery/door/window/westleft{
+	req_access = list(31)
+	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/cargostore)
 "aHG" = (
@@ -21731,6 +21726,9 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/door/window/westleft{
+	req_access = list(31)
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/cargostore)
@@ -31132,7 +31130,7 @@
 /area/tether/surfacebase/outside/outside1)
 "baX" = (
 /obj/machinery/door/airlock/multi_tile/glass{
-	name = "Surface Cargo"
+	name = "Cargo Shop"
 	},
 /obj/machinery/door/firedoor/multi_tile,
 /turf/simulated/floor/tiled,
@@ -31172,7 +31170,7 @@
 /area/tether/surfacebase/cargostore/office)
 "bbb" = (
 /obj/machinery/door/airlock/multi_tile/glass{
-	name = "Surface Cargo"
+	name = "Mental Health and North EVA"
 	},
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/steeldecal/steel_decals_central1{
@@ -32747,6 +32745,17 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_one_hall)
+"bHK" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24;
+	pixel_y = 0
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/surfacebase/lowmedbaymaint)
 "bMs" = (
 /obj/machinery/door/airlock/glass_external/public,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -33094,7 +33103,7 @@
 /obj/item/clothing/suit/storage/hooded/wintercoat,
 /obj/item/weapon/tank/emergency/oxygen/engi,
 /turf/simulated/floor/tiled/techfloor,
-/area/tether/surfacebase/lowernortheva)
+/area/tether/surfacebase/lowernorthhall)
 "dCc" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -33206,7 +33215,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor,
-/area/tether/surfacebase/lowernortheva)
+/area/tether/surfacebase/lowernorthhall)
 "evF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -34832,8 +34841,13 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_one_hall)
 "pdo" = (
-/turf/simulated/mineral,
-/area/tether/surfacebase/lowernortheva)
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 25;
+	pixel_y = 0
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/surfacebase/lowmedbaymaint)
 "poN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/catwalk,
@@ -46380,8 +46394,8 @@ aaq
 aaq
 aaq
 aaq
-pdo
-pdo
+aah
+aah
 aah
 aah
 abT
@@ -46522,8 +46536,8 @@ aaq
 aaz
 aaM
 aaq
-aaq
-aaq
+aef
+aef
 aef
 aef
 abT
@@ -47090,8 +47104,8 @@ aaq
 aAB
 aAJ
 aaq
-aaq
-aaq
+aef
+aef
 aef
 aef
 aeS
@@ -52074,7 +52088,7 @@ aAI
 aBh
 aBi
 aBi
-aBi
+bHK
 aBi
 aBi
 aBi
@@ -52212,7 +52226,7 @@ aem
 aAI
 aAI
 aAI
-aAI
+pdo
 aAI
 aAI
 aAI

--- a/maps/tether/tether-01-surface1.dmm
+++ b/maps/tether/tether-01-surface1.dmm
@@ -14,20 +14,20 @@
 	portal_id = "surfacemine"
 	},
 /turf/simulated/floor/tiled/steel_dirty/virgo3b,
-/area/tether/surfacebase/mining_main/external)
+/area/tether/surfacebase/lowernortheva/external)
 "aad" = (
 /turf/simulated/floor/outdoors/grass/sif/virgo3b,
 /area/tether/surfacebase/outside/outside1)
 "aae" = (
 /turf/simulated/floor/outdoors/grass/sif/virgo3b,
-/area/tether/surfacebase/mining_main/external)
+/area/tether/surfacebase/lowernortheva/external)
 "aaf" = (
 /turf/simulated/floor/tiled/steel_dirty/virgo3b,
-/area/tether/surfacebase/mining_main/external)
+/area/tether/surfacebase/lowernortheva/external)
 "aag" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/steel_dirty/virgo3b,
-/area/tether/surfacebase/mining_main/external)
+/area/tether/surfacebase/lowernortheva/external)
 "aah" = (
 /turf/simulated/mineral,
 /area/tether/surfacebase/outside/outside1)
@@ -37,7 +37,7 @@
 	icon_state = "camera"
 	},
 /turf/simulated/floor/tiled/steel_dirty/virgo3b,
-/area/tether/surfacebase/mining_main/external)
+/area/tether/surfacebase/lowernortheva/external)
 "aaj" = (
 /obj/structure/railing{
 	dir = 8
@@ -61,17 +61,17 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/tiled/steel_dirty/virgo3b,
-/area/tether/surfacebase/mining_main/external)
+/area/tether/surfacebase/lowernortheva/external)
 "aal" = (
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled/steel_dirty/virgo3b,
-/area/tether/surfacebase/mining_main/external)
+/area/tether/surfacebase/lowernortheva/external)
 "aam" = (
 /obj/machinery/light,
 /turf/simulated/floor/tiled/steel_dirty/virgo3b,
-/area/tether/surfacebase/mining_main/external)
+/area/tether/surfacebase/lowernortheva/external)
 "aan" = (
 /turf/simulated/wall,
 /area/tether/surfacebase/medical/mentalhealth)
@@ -1340,7 +1340,7 @@
 	use_power = 1
 	},
 /turf/simulated/floor/virgo3b,
-/area/tether/surfacebase/mining_main/external)
+/area/tether/surfacebase/lowernortheva/external)
 "acl" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -1638,7 +1638,7 @@
 "acM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/black,
 /turf/simulated/floor/virgo3b,
-/area/tether/surfacebase/mining_main/external)
+/area/tether/surfacebase/lowernortheva/external)
 "acN" = (
 /obj/structure/cable/ender{
 	icon_state = "1-2";
@@ -10147,7 +10147,7 @@
 	dir = 2
 	},
 /turf/simulated/floor/tiled/steel_dirty/virgo3b,
-/area/tether/surfacebase/mining_main/external)
+/area/tether/surfacebase/lowernortheva/external)
 "aqS" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -16625,11 +16625,11 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/lowmedbaymaint)
@@ -16963,12 +16963,6 @@
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/lowmedbaymaint)
@@ -31499,12 +31493,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
 /turf/simulated/floor,
 /area/maintenance/substation/SurfMedsubstation)
 "bbA" = (
@@ -31515,12 +31503,6 @@
 /obj/machinery/door/airlock/engineering{
 	name = "Medbay Substation";
 	req_one_access = list(11,24,5)
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
 	},
 /turf/simulated/floor,
 /area/maintenance/substation/SurfMedsubstation)
@@ -31560,8 +31542,8 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
+/obj/machinery/camera/network/engineering{
+	dir = 1
 	},
 /turf/simulated/floor,
 /area/maintenance/substation/cargostoresubstation)
@@ -31576,11 +31558,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -25
 	},
 /turf/simulated/floor,
 /area/maintenance/substation/cargostoresubstation)
@@ -31594,12 +31574,6 @@
 /obj/machinery/door/airlock/engineering{
 	name = "CargoShop Substation";
 	req_one_access = list(11,24,50)
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
 	},
 /turf/simulated/floor,
 /area/maintenance/substation/cargostoresubstation)
@@ -31628,9 +31602,6 @@
 	dir = 4;
 	icon_state = "warning"
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/SurfMedsubstation)
 "bbJ" = (
@@ -31643,9 +31614,6 @@
 	RCon_tag = "Substation - SurfMed";
 	output_attempt = 0
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /turf/simulated/floor,
 /area/maintenance/substation/SurfMedsubstation)
 "bbK" = (
@@ -31656,9 +31624,6 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /turf/simulated/floor,
 /area/maintenance/substation/SurfMedsubstation)
 "bbL" = (
@@ -31676,19 +31641,12 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
 /turf/simulated/floor,
 /area/maintenance/substation/SurfMedsubstation)
 "bbM" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 4;
 	icon_state = "warningcorner"
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/SurfMedsubstation)
@@ -31808,9 +31766,6 @@
 	name = "Powernet Sensor - SurfMed Subgrid";
 	name_tag = "SurfMed Subgrid"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /turf/simulated/floor,
 /area/maintenance/substation/SurfMedsubstation)
 "bbW" = (
@@ -31824,9 +31779,6 @@
 	},
 /obj/machinery/camera/network/engineering{
 	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
 	},
 /turf/simulated/floor,
 /area/maintenance/substation/SurfMedsubstation)
@@ -31845,9 +31797,6 @@
 /obj/machinery/alarm{
 	dir = 1;
 	pixel_y = -25
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
 	},
 /obj/machinery/firealarm{
 	dir = 4;
@@ -33308,14 +33257,8 @@
 /turf/simulated/floor/plating,
 /area/maintenance/lower/research)
 "eQz" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/lowmedbaymaint)
+/turf/simulated/floor,
+/area/maintenance/lower/mining_eva)
 "eQT" = (
 /obj/effect/floor_decal/steeldecal/steel_decals6{
 	dir = 10
@@ -33449,12 +33392,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_one_hall)
-"gjF" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/lowmedbaymaint)
 "glc" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -33763,13 +33700,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/lower/mining_eva)
@@ -34255,11 +34185,11 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/visible/supply{
+	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/visible/scrubbers{
+	dir = 5
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/lower/mining_eva)
@@ -34327,8 +34257,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/maintenance/lower/mining_eva)
 "lMf" = (
@@ -34545,13 +34473,6 @@
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/xenoflora)
-"mMs" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plating,
-/area/maintenance/lowmedbaymaint)
 "mOz" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
@@ -34707,15 +34628,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/locker/laundry_arrival)
-"npp" = (
-/obj/machinery/camera/network/engineering{
-	dir = 1
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/simulated/floor,
-/area/maintenance/substation/cargostoresubstation)
 "nsp" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -35014,7 +34926,7 @@
 	dir = 8;
 	pixel_x = -24
 	},
-/turf/simulated/floor,
+/turf/simulated/wall,
 /area/maintenance/substation/cargostoresubstation)
 "qKn" = (
 /obj/effect/floor_decal/steeldecal/steel_decals_central1{
@@ -35051,11 +34963,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/lowerhall)
-"qNr" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plating,
-/area/maintenance/lowmedbaymaint)
 "qOA" = (
 /obj/structure/table/standard{
 	name = "plastic table frame"
@@ -35320,12 +35227,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/public_garden_one)
-"skC" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/lowmedbaymaint)
 "svZ" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -35874,16 +35775,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/bathroom)
-"woJ" = (
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -25
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
-/turf/simulated/floor,
-/area/maintenance/substation/cargostoresubstation)
 "wvn" = (
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 1
@@ -46409,7 +46300,7 @@ agd
 bbs
 bbC
 qDR
-adK
+blL
 blL
 abT
 wzA
@@ -46550,8 +46441,8 @@ adt
 bbg
 bbu
 bbD
-npp
-adK
+adt
+blL
 blL
 abT
 tCV
@@ -46692,8 +46583,8 @@ adt
 bbh
 bbv
 bbE
-woJ
-abT
+adt
+eQz
 blL
 abT
 tCV
@@ -52224,10 +52115,10 @@ azH
 azW
 aAe
 aeE
-eQz
-mMs
-qNr
-qNr
+aAI
+aAI
+aAI
+aAI
 aBh
 aBi
 aBi
@@ -52366,8 +52257,8 @@ azJ
 azX
 aAg
 aeE
-skC
-gjF
+aAI
+aAI
 gYx
 pdo
 aAI

--- a/maps/tether/tether-01-surface1.dmm
+++ b/maps/tether/tether-01-surface1.dmm
@@ -1964,7 +1964,7 @@
 /area/tether/surfacebase/lowernorthhall)
 "adt" = (
 /turf/simulated/wall,
-/area/maintenance/cargostoresubstation)
+/area/maintenance/substation/cargostoresubstation)
 "adu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -3763,7 +3763,7 @@
 	RCon_tag = "CargoShop Substation Bypass"
 	},
 /turf/simulated/floor,
-/area/maintenance/cargostoresubstation)
+/area/maintenance/substation/cargostoresubstation)
 "age" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -20968,6 +20968,10 @@
 /obj/effect/floor_decal/corner/brown/border{
 	dir = 4
 	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/cargostore/office)
 "aHU" = (
@@ -31233,13 +31237,13 @@
 	dir = 1
 	},
 /turf/simulated/floor,
-/area/maintenance/cargostoresubstation)
+/area/maintenance/substation/cargostoresubstation)
 "bbh" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
-/area/maintenance/cargostoresubstation)
+/area/maintenance/substation/cargostoresubstation)
 "bbi" = (
 /obj/machinery/door/airlock/engineering{
 	name = "CargoShop Substation";
@@ -31250,10 +31254,10 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
-/area/maintenance/cargostoresubstation)
+/area/maintenance/substation/cargostoresubstation)
 "bbj" = (
 /turf/simulated/wall,
-/area/maintenance/medbaysubstation)
+/area/maintenance/substation/SurfMedsubstation)
 "bbk" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -31401,7 +31405,7 @@
 	req_one_access = list(11,24,5)
 	},
 /turf/simulated/floor,
-/area/maintenance/medbaysubstation)
+/area/maintenance/substation/SurfMedsubstation)
 "bbs" = (
 /obj/structure/cable/green,
 /obj/structure/cable/green{
@@ -31413,7 +31417,7 @@
 	output_attempt = 0
 	},
 /turf/simulated/floor,
-/area/maintenance/cargostoresubstation)
+/area/maintenance/substation/cargostoresubstation)
 "bbt" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 5
@@ -31445,7 +31449,7 @@
 	},
 /obj/structure/cable,
 /turf/simulated/floor,
-/area/maintenance/cargostoresubstation)
+/area/maintenance/substation/cargostoresubstation)
 "bbv" = (
 /obj/machinery/power/apc{
 	dir = 4;
@@ -31457,7 +31461,7 @@
 	icon_state = "0-2"
 	},
 /turf/simulated/floor,
-/area/maintenance/cargostoresubstation)
+/area/maintenance/substation/cargostoresubstation)
 "bbw" = (
 /obj/structure/table/rack,
 /obj/random/maintenance/cargo,
@@ -31467,10 +31471,10 @@
 /area/maintenance/lower/mining_eva)
 "bbx" = (
 /obj/machinery/power/breakerbox/activated{
-	RCon_tag = "Medical2 Substation Bypass"
+	RCon_tag = "SurfMed Substation Bypass"
 	},
 /turf/simulated/floor,
-/area/maintenance/medbaysubstation)
+/area/maintenance/substation/SurfMedsubstation)
 "bby" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
@@ -31487,7 +31491,7 @@
 	dir = 1
 	},
 /turf/simulated/floor,
-/area/maintenance/medbaysubstation)
+/area/maintenance/substation/SurfMedsubstation)
 "bbz" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -31498,7 +31502,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor,
-/area/maintenance/medbaysubstation)
+/area/maintenance/substation/SurfMedsubstation)
 "bbA" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -31509,7 +31513,7 @@
 	req_one_access = list(11,24,5)
 	},
 /turf/simulated/floor,
-/area/maintenance/medbaysubstation)
+/area/maintenance/substation/SurfMedsubstation)
 "bbB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -31536,7 +31540,7 @@
 	name_tag = "CargoShop Subgrid"
 	},
 /turf/simulated/floor,
-/area/maintenance/cargostoresubstation)
+/area/maintenance/substation/cargostoresubstation)
 "bbD" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 1
@@ -31550,7 +31554,7 @@
 	dir = 1
 	},
 /turf/simulated/floor,
-/area/maintenance/cargostoresubstation)
+/area/maintenance/substation/cargostoresubstation)
 "bbE" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -31567,7 +31571,7 @@
 	pixel_y = -25
 	},
 /turf/simulated/floor,
-/area/maintenance/cargostoresubstation)
+/area/maintenance/substation/cargostoresubstation)
 "bbF" = (
 /obj/machinery/door/firedoor/glass,
 /obj/structure/cable/green{
@@ -31580,7 +31584,7 @@
 	req_one_access = list(11,24,50)
 	},
 /turf/simulated/floor,
-/area/maintenance/cargostoresubstation)
+/area/maintenance/substation/cargostoresubstation)
 "bbG" = (
 /obj/machinery/door/airlock/maintenance/common,
 /obj/structure/disposalpipe/segment,
@@ -31607,7 +31611,7 @@
 	icon_state = "warning"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/medbaysubstation)
+/area/maintenance/substation/SurfMedsubstation)
 "bbJ" = (
 /obj/structure/cable/green,
 /obj/structure/cable/green{
@@ -31615,11 +31619,11 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/power/smes/buildable{
-	RCon_tag = "Substation - Medical2";
+	RCon_tag = "Substation - SurfMed";
 	output_attempt = 0
 	},
 /turf/simulated/floor,
-/area/maintenance/medbaysubstation)
+/area/maintenance/substation/SurfMedsubstation)
 "bbK" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
@@ -31629,7 +31633,7 @@
 	},
 /obj/structure/cable,
 /turf/simulated/floor,
-/area/maintenance/medbaysubstation)
+/area/maintenance/substation/SurfMedsubstation)
 "bbL" = (
 /obj/machinery/power/apc{
 	dir = 4;
@@ -31646,14 +31650,14 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor,
-/area/maintenance/medbaysubstation)
+/area/maintenance/substation/SurfMedsubstation)
 "bbM" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 4;
 	icon_state = "warningcorner"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/medbaysubstation)
+/area/maintenance/substation/SurfMedsubstation)
 "bbN" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -31767,11 +31771,11 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/sensor{
-	name = "Powernet Sensor - Medical2 Subgrid";
-	name_tag = "Medical2 Subgrid"
+	name = "Powernet Sensor - SurfMed Subgrid";
+	name_tag = "SurfMed Subgrid"
 	},
 /turf/simulated/floor,
-/area/maintenance/medbaysubstation)
+/area/maintenance/substation/SurfMedsubstation)
 "bbW" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 1
@@ -31785,7 +31789,7 @@
 	dir = 1
 	},
 /turf/simulated/floor,
-/area/maintenance/medbaysubstation)
+/area/maintenance/substation/SurfMedsubstation)
 "bbX" = (
 /obj/machinery/door/airlock/maintenance/common,
 /obj/structure/disposalpipe/segment,
@@ -31803,7 +31807,7 @@
 	pixel_y = -25
 	},
 /turf/simulated/floor,
-/area/maintenance/medbaysubstation)
+/area/maintenance/substation/SurfMedsubstation)
 "bbZ" = (
 /obj/machinery/power/apc{
 	dir = 4;

--- a/maps/tether/tether-01-surface1.dmm
+++ b/maps/tether/tether-01-surface1.dmm
@@ -74,59 +74,203 @@
 /area/tether/surfacebase/mining_main/external)
 "aan" = (
 /turf/simulated/wall,
-/area/tether/surfacebase/cargo/mining/airlock)
+/area/tether/surfacebase/medical/mentalhealth)
 "aao" = (
-/obj/machinery/door/airlock/glass_external{
-	frequency = 1379;
-	icon_state = "door_locked";
-	id_tag = "mining_airlock_outer";
-	locked = 1
+/turf/simulated/wall,
+/area/tether/surfacebase/medical/paramed)
+"aap" = (
+/obj/machinery/door/firedoor/glass,
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced{
+	dir = 1
 	},
+/obj/machinery/door/blast/shutters{
+	closed_layer = 10;
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id = "medbayquar";
+	layer = 1;
+	name = "Medbay Emergency Lockdown Shutters";
+	opacity = 0;
+	open_layer = 1
+	},
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/medical/paramed)
+"aaq" = (
+/turf/simulated/wall,
+/area/tether/surfacebase/lowernortheva)
+"aar" = (
+/obj/machinery/door/firedoor/glass,
+/obj/structure/window/reinforced/polarized/full{
+	id = "psych_office"
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/door/blast/shutters{
+	closed_layer = 10;
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id = "medbayquar";
+	layer = 1;
+	name = "Medbay Emergency Lockdown Shutters";
+	opacity = 0;
+	open_layer = 1
+	},
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/medical/mentalhealth)
+"aas" = (
 /obj/effect/map_helper/airlock/door/ext_door,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/tether/surfacebase/cargo/mining/airlock)
-"aap" = (
 /obj/machinery/door/airlock/glass_external{
 	frequency = 1379;
 	icon_state = "door_locked";
-	id_tag = "mining_airlock_outer";
+	id_tag = "northciv_airlock_outer";
 	locked = 1
 	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/tether/surfacebase/lowernortheva)
+"aat" = (
 /obj/machinery/access_button/airlock_exterior{
-	master_tag = "mining_airlock";
+	master_tag = "northciv_airlock";
 	pixel_x = 25;
 	pixel_y = 8
 	},
 /obj/effect/map_helper/airlock/door/ext_door,
+/obj/machinery/door/airlock/glass_external{
+	frequency = 1379;
+	icon_state = "door_locked";
+	id_tag = "northciv_airlock_outer";
+	locked = 1
+	},
 /turf/simulated/floor/tiled/steel_grid,
-/area/tether/surfacebase/cargo/mining/airlock)
-"aaq" = (
+/area/tether/surfacebase/lowernortheva)
+"aau" = (
+/obj/machinery/suit_cycler/medical,
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 9
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals9,
+/obj/effect/floor_decal/steeldecal/steel_decals9{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals9{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals9{
+	dir = 4
+	},
+/obj/machinery/camera/network/medbay{
+	dir = 9;
+	icon_state = "camera"
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/tether/surfacebase/medical/paramed)
+"aav" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/dark,
+/area/tether/surfacebase/medical/paramed)
+"aaw" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/tether/surfacebase/medical/paramed)
+"aax" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/tether/surfacebase/medical/paramed)
+"aay" = (
+/obj/structure/table/rack,
+/obj/item/device/gps/medical{
+	pixel_y = 3
+	},
+/obj/item/device/gps/medical{
+	pixel_x = -3
+	},
+/obj/item/device/radio{
+	pixel_x = 2
+	},
+/obj/item/device/radio{
+	pixel_x = -1;
+	pixel_y = -3
+	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 6
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals9{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals9{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals9{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals9,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/tether/surfacebase/medical/paramed)
+"aaz" = (
 /obj/machinery/portable_atmospherics/powered/scrubber/huge/stationary/phoronlock{
 	frequency = 1379;
-	scrub_id = "mining_airlock_scrubber"
+	scrub_id = "northciv_airlock_scrubber"
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/tether/surfacebase/cargo/mining/airlock)
-"aar" = (
-/turf/simulated/wall,
-/area/tether/surfacebase/cargo/mining)
-"aas" = (
+/area/tether/surfacebase/lowernortheva)
+"aaA" = (
 /obj/structure/grille,
 /obj/structure/railing{
 	dir = 4
 	},
+/obj/effect/map_helper/airlock/atmos/chamber_pump,
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 4;
 	frequency = 1379;
-	id_tag = "mining_airlock_pump"
+	id_tag = "northciv_airlock_pump"
 	},
-/obj/effect/map_helper/airlock/atmos/chamber_pump,
 /turf/simulated/floor/tiled/techmaint,
-/area/tether/surfacebase/cargo/mining/airlock)
-"aat" = (
+/area/tether/surfacebase/lowernortheva)
+"aaB" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
 	},
@@ -143,10 +287,6 @@
 	dir = 10;
 	icon_state = "intact"
 	},
-/obj/machinery/light_switch{
-	pixel_x = -25;
-	pixel_y = 25
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -154,8 +294,8 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled,
-/area/tether/surfacebase/cargo/mining/airlock)
-"aau" = (
+/area/tether/surfacebase/lowernortheva)
+"aaC" = (
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 9
 	},
@@ -171,76 +311,129 @@
 /obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 9
 	},
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 28
-	},
 /obj/structure/cable{
+	d1 = 4;
 	d2 = 8;
-	icon_state = "0-8"
+	icon_state = "4-8";
+	pixel_x = 0
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/tether/surfacebase/cargo/mining/airlock)
-"aav" = (
-/obj/machinery/portable_atmospherics/powered/scrubber/huge/stationary/phoronlock{
-	frequency = 1379;
-	scrub_id = "mining_airlock_scrubber"
+/area/tether/surfacebase/lowernortheva)
+"aaD" = (
+/obj/structure/closet/crate/bin,
+/obj/machinery/light{
+	dir = 1
 	},
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/medical/mentalhealth)
+"aaE" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/medical/mentalhealth)
+"aaF" = (
+/obj/structure/table/rack,
+/obj/item/clothing/shoes/magboots,
+/obj/item/clothing/suit/space/void/medical/emt,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/head/helmet/space/void/medical/emt,
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -24
+	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 9
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals9,
+/obj/effect/floor_decal/steeldecal/steel_decals9{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals9{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals9{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/tether/surfacebase/medical/paramed)
+"aaG" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/tether/surfacebase/medical/paramed)
+"aaH" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/dark,
+/area/tether/surfacebase/medical/paramed)
+"aaI" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/blue,
+/area/tether/surfacebase/medical/mentalhealth)
+"aaJ" = (
+/obj/structure/table/woodentable,
+/obj/item/weapon/folder/white,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/simulated/floor/carpet/blue,
+/area/tether/surfacebase/medical/mentalhealth)
+"aaK" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/tether/surfacebase/medical/paramed)
+"aaL" = (
+/obj/structure/table/rack,
+/obj/item/weapon/storage/toolbox/mechanical,
+/obj/item/device/multitool,
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 6
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals9{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals9{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals9{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals9,
+/turf/simulated/floor/tiled/dark,
+/area/tether/surfacebase/medical/paramed)
+"aaM" = (
 /obj/structure/sign/nosmoking_2{
 	pixel_x = -32
 	},
-/turf/simulated/floor/tiled/techmaint,
-/area/tether/surfacebase/cargo/mining/airlock)
-"aaw" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 6
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/cargo/mining/airlock)
-"aax" = (
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 6
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 10
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 5
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 9
-	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/cargo/mining/airlock)
-"aay" = (
 /obj/machinery/portable_atmospherics/powered/scrubber/huge/stationary/phoronlock{
 	frequency = 1379;
-	scrub_id = "mining_airlock_scrubber"
-	},
-/obj/structure/sign/fire{
-	pixel_x = -32
+	scrub_id = "northciv_airlock_scrubber"
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/tether/surfacebase/cargo/mining/airlock)
-"aaz" = (
+/area/tether/surfacebase/lowernortheva)
+"aaN" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 5
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 6
@@ -255,21 +448,14 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
-/area/tether/surfacebase/cargo/mining/airlock)
-"aaA" = (
-/obj/machinery/embedded_controller/radio/airlock/phoron{
-	dir = 8;
-	id_tag = "mining_airlock";
-	pixel_x = 25
+/area/tether/surfacebase/lowernortheva)
+"aaO" = (
+/obj/structure/filingcabinet/chestdrawer{
+	name = "Medical Forms"
 	},
-/obj/machinery/airlock_sensor/phoron{
-	id_tag = "mining_airlock_sensor";
-	pixel_x = 25;
-	pixel_y = 11
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 8
-	},
+/turf/simulated/floor/carpet/blue,
+/area/tether/surfacebase/medical/mentalhealth)
+"aaP" = (
 /obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 6
 	},
@@ -283,225 +469,21 @@
 	dir = 9
 	},
 /obj/effect/map_helper/airlock/sensor/chamber_sensor,
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/cargo/mining/airlock)
-"aaB" = (
-/obj/machinery/door/firedoor/glass,
-/obj/machinery/door/airlock/glass_external{
-	frequency = 1379;
-	icon_state = "door_locked";
-	id_tag = "mining_airlock_inner";
-	locked = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
-/obj/effect/map_helper/airlock/door/int_door,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/tether/surfacebase/cargo/mining/airlock)
-"aaC" = (
-/obj/machinery/door/firedoor/glass,
-/obj/machinery/door/airlock/glass_external{
-	frequency = 1379;
-	icon_state = "door_locked";
-	id_tag = "mining_airlock_inner";
-	locked = 1
-	},
-/obj/effect/map_helper/airlock/door/int_door,
-/turf/simulated/floor/tiled/steel_grid,
-/area/tether/surfacebase/cargo/mining/airlock)
-"aaD" = (
-/obj/effect/floor_decal/techfloor{
-	dir = 1
-	},
-/obj/effect/floor_decal/techfloor{
-	dir = 5
-	},
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/rust,
-/obj/structure/closet,
-/obj/random/maintenance/cargo,
-/obj/random/maintenance/cargo,
-/obj/random/maintenance/clean,
-/obj/random/tool,
-/turf/simulated/floor/plating,
-/area/maintenance/lower/trash_pit)
-"aaE" = (
-/turf/simulated/wall,
-/area/construction/vacant_mining_ops)
-"aaF" = (
-/obj/machinery/washing_machine,
-/turf/simulated/floor/tiled/techfloor,
-/area/tether/surfacebase/cargo/mining)
-"aaG" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/brown/border{
-	dir = 8
-	},
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/brown/bordercorner2{
-	dir = 8
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 4
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 5
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/cargo/mining)
-"aaH" = (
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
-	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/brown/border{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 6
-	},
-/obj/effect/floor_decal/corner/brown/bordercorner2{
-	dir = 6
-	},
-/obj/machinery/access_button/airlock_interior{
-	master_tag = "mining_airlock";
+/obj/machinery/embedded_controller/radio/airlock/phoron{
+	id_tag = "northciv_airlock";
 	pixel_x = 25;
-	pixel_y = -8
+	pixel_y = -25
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 9
+/obj/machinery/airlock_sensor/phoron{
+	id_tag = "northciv_airlock_sensor";
+	pixel_x = 59;
+	pixel_y = 11
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 9
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 10
-	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/cargo/mining)
-"aaI" = (
-/obj/machinery/door/airlock/maintenance/common{
-	name = "Trash Pit Access";
-	req_one_access = list(48)
-	},
-/obj/machinery/door/firedoor/glass,
-/turf/simulated/floor/tiled/steel_grid,
-/area/maintenance/lower/trash_pit)
-"aaJ" = (
-/obj/effect/floor_decal/techfloor{
+/obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/rust,
-/obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 0
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/lower/trash_pit)
-"aaK" = (
-/obj/structure/sign/nosmoking_2{
-	pixel_x = -32
-	},
-/obj/machinery/washing_machine,
-/turf/simulated/floor/tiled/techfloor,
-/area/tether/surfacebase/cargo/mining)
-"aaL" = (
-/turf/simulated/floor/plating,
-/area/construction/vacant_mining_ops)
-"aaM" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/brown/border{
-	dir = 8
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 5
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/tiled,
-/area/tether/surfacebase/cargo/mining)
-"aaN" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/brown/border{
-	dir = 4
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 9
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 10
-	},
-/obj/machinery/camera/network/cargo{
-	dir = 8;
-	icon_state = "camera"
-	},
-/obj/structure/closet/hydrant{
-	pixel_x = 32
-	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/cargo/mining)
-"aaO" = (
-/obj/effect/floor_decal/techfloor{
-	dir = 4
-	},
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/random/junk,
-/turf/simulated/floor/plating,
-/area/maintenance/lower/trash_pit)
-"aaP" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/brown/border{
-	dir = 8
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
-/obj/machinery/vending/wallmed_airlock{
-	pixel_x = -32
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/cargo/mining)
+/area/tether/surfacebase/lowernortheva)
 "aaQ" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/lightgrey/border,
@@ -523,36 +505,51 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/north_stairs_one)
 "aaR" = (
-/obj/effect/floor_decal/techfloor,
-/obj/structure/railing{
+/obj/structure/filingcabinet/medical{
+	desc = "A large cabinet with hard copy medical records.";
+	name = "Medical Records"
+	},
+/obj/item/device/radio/intercom{
+	dir = 4;
+	pixel_x = 24
+	},
+/obj/item/device/radio/intercom/department/medbay{
+	dir = 1;
+	pixel_y = 24
+	},
+/turf/simulated/floor/carpet/blue,
+/area/tether/surfacebase/medical/mentalhealth)
+"aaS" = (
+/obj/structure/table/rack,
+/obj/item/clothing/shoes/magboots,
+/obj/item/clothing/suit/space/void/medical/emt,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/head/helmet/space/void/medical/emt,
+/obj/item/device/radio/intercom{
+	dir = 8;
+	pixel_x = -24
+	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 9
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals9,
+/obj/effect/floor_decal/steeldecal/steel_decals9{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals9{
 	dir = 1
 	},
-/obj/structure/railing{
+/obj/effect/floor_decal/steeldecal/steel_decals9{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/power/apc{
-	dir = 2;
-	name = "south bump";
-	pixel_y = -24
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/lower/trash_pit)
-"aaS" = (
-/obj/effect/floor_decal/borderfloor/corner{
+/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/obj/effect/floor_decal/corner/brown/bordercorner{
-	dir = 4
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 10
-	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/cargo/mining)
+/turf/simulated/floor/tiled/dark,
+/area/tether/surfacebase/medical/paramed)
 "aaT" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -569,15 +566,15 @@
 /turf/simulated/wall,
 /area/maintenance/lower/trash_pit)
 "aaV" = (
-/obj/structure/catwalk,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/alarm{
+/obj/structure/table/woodentable,
+/obj/structure/plushie/ian{
 	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 24
+	icon_state = "ianplushie";
+	pixel_y = 6
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/lower/trash_pit)
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/medical/mentalhealth)
 "aaW" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -590,77 +587,60 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/vacant_site)
 "aaX" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 1
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
 	},
-/obj/effect/floor_decal/corner/brown/border{
-	dir = 1
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 8
 	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/cargo/mining)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/tether/surfacebase/medical/paramed)
 "aaY" = (
-/obj/item/device/radio/intercom{
-	dir = 8;
-	pixel_x = -24
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
+/obj/effect/landmark/start{
+	name = "Paramedic"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
+	dir = 10
 	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/cargo/mining)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/dark,
+/area/tether/surfacebase/medical/paramed)
 "aaZ" = (
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/brown/border,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/machinery/mech_recharger,
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 6
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals9{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/effect/floor_decal/steeldecal/steel_decals9{
+	dir = 1
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+/obj/effect/floor_decal/steeldecal/steel_decals9{
+	dir = 8
 	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/cargo/mining)
+/obj/effect/floor_decal/steeldecal/steel_decals9,
+/obj/machinery/light_switch{
+	dir = 8;
+	pixel_x = 28
+	},
+/turf/simulated/floor/tiled/dark,
+/area/tether/surfacebase/medical/paramed)
 "aba" = (
-/obj/effect/floor_decal/borderfloor/corner{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24;
+	pixel_y = 0
 	},
-/obj/effect/floor_decal/corner/brown/bordercorner{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/cargo/mining)
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/medical/mentalhealth)
 "abb" = (
 /obj/effect/floor_decal/steeldecal/steel_decals6{
 	dir = 6
@@ -692,48 +672,58 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_one_hall)
 "abd" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/effect/floor_decal/borderfloor{
-	dir = 1
+/obj/structure/table/rack,
+/obj/item/weapon/rig/medical/equipped,
+/obj/structure/fireaxecabinet{
+	pixel_x = -32
 	},
-/obj/effect/floor_decal/corner/brown/border{
-	dir = 1
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 6
 	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/cargo/mining)
-"abe" = (
-/obj/machinery/light{
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 9
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals9,
+/obj/effect/floor_decal/steeldecal/steel_decals9{
 	dir = 8
 	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 10
+/obj/effect/floor_decal/steeldecal/steel_decals9{
+	dir = 1
 	},
-/obj/effect/floor_decal/corner/brown/border{
-	dir = 10
+/obj/effect/floor_decal/steeldecal/steel_decals9{
+	dir = 4
 	},
-/obj/machinery/power/apc{
-	name = "south bump";
-	pixel_x = 0;
-	pixel_y = -32
+/turf/simulated/floor/tiled/dark,
+/area/tether/surfacebase/medical/paramed)
+"abe" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
 	},
-/obj/machinery/light_switch{
-	dir = 1;
-	pixel_x = -13;
-	pixel_y = -30
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 8
 	},
-/obj/structure/cable,
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/cargo/mining)
-"abf" = (
-/obj/structure/catwalk,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/lower/trash_pit)
+/turf/simulated/floor/tiled/dark,
+/area/tether/surfacebase/medical/paramed)
+"abf" = (
+/obj/structure/table/woodentable,
+/obj/item/toy/plushie/therapy/blue,
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_x = 0;
+	pixel_y = 24
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/medical/mentalhealth)
 "abg" = (
 /obj/machinery/light{
 	dir = 1
@@ -779,24 +769,29 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_one_hall)
 "abi" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 1
+/obj/machinery/hologram/holopad,
+/obj/effect/landmark/start{
+	name = "Paramedic"
 	},
-/obj/effect/floor_decal/corner/brown/border{
-	dir = 1
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/cargo/mining)
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/tether/surfacebase/medical/paramed)
 "abj" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 5
-	},
-/obj/effect/floor_decal/corner/brown/border{
-	dir = 5
-	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/cargo/mining)
+/obj/structure/table/woodentable,
+/obj/random/plushie,
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/medical/mentalhealth)
 "abk" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -827,49 +822,38 @@
 /turf/simulated/floor/tiled,
 /area/rnd/hardstorage)
 "abo" = (
-/obj/effect/floor_decal/borderfloor{
+/obj/effect/floor_decal/borderfloorblack{
 	dir = 4
 	},
-/obj/effect/floor_decal/corner/brown/border{
+/obj/effect/floor_decal/corner/paleblue/border{
 	dir = 4
 	},
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 5
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/corner/brown/bordercorner2{
-	dir = 5
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/cargo/mining)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/tether/surfacebase/medical/paramed)
 "abp" = (
-/obj/structure/catwalk,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/maintenance/common{
-	name = "Trash Pit Access";
-	req_one_access = list(48,12)
+/obj/item/weapon/storage/secure/safe{
+	pixel_y = 32
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/lower/trash_pit)
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/medical/mentalhealth)
 "abq" = (
-/obj/structure/catwalk,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/lower/trash_pit)
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/medical/mentalhealth)
 "abr" = (
-/obj/structure/catwalk,
-/obj/effect/decal/cleanable/dirt,
-/obj/random/maintenance/cargo,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/lower/trash_pit)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/medical/mentalhealth)
 "abs" = (
 /obj/structure/catwalk,
 /obj/effect/decal/cleanable/dirt,
@@ -1033,6 +1017,11 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/lower/trash_pit)
 "abH" = (
@@ -1064,14 +1053,8 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/tether/surfacebase/public_garden_one)
 "abL" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/plating,
-/area/construction/vacant_mining_ops)
+/turf/simulated/floor/carpet/blue,
+/area/tether/surfacebase/medical/mentalhealth)
 "abM" = (
 /obj/structure/catwalk,
 /obj/random/junk,
@@ -1084,31 +1067,38 @@
 /turf/simulated/wall/r_wall,
 /area/rnd/testingroom)
 "abO" = (
-/obj/machinery/door/airlock/maintenance/common{
-	name = "Trash Pit Access";
-	req_one_access = list(26,48,12)
-	},
 /obj/structure/catwalk,
 /obj/machinery/door/firedoor/glass,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/door/airlock/maintenance/common,
 /turf/simulated/floor/plating,
 /area/maintenance/lower/trash_pit)
 "abP" = (
-/obj/effect/floor_decal/steeldecal/steel_decals4{
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/paleblue{
 	dir = 9
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/steel_dirty,
-/area/tether/surfacebase/cargo/warehouse)
+/obj/effect/floor_decal/steeldecal/steel_decals4,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/dark,
+/area/tether/surfacebase/medical/paramed)
 "abQ" = (
 /obj/structure/catwalk,
 /obj/structure/cable{
@@ -1141,22 +1131,24 @@
 /turf/simulated/wall,
 /area/maintenance/lower/mining_eva)
 "abU" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/table/woodentable,
+/obj/item/weapon/paper_bin{
+	pixel_y = 4
 	},
-/turf/simulated/floor/plating,
-/area/construction/vacant_mining_ops)
+/obj/item/weapon/pen{
+	pixel_y = 4
+	},
+/turf/simulated/floor/carpet/blue,
+/area/tether/surfacebase/medical/mentalhealth)
 "abV" = (
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 5
+/obj/effect/landmark/start{
+	name = "Psychiatrist"
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
+/obj/structure/bed/chair/office/dark{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/cargo/mining)
+/turf/simulated/floor/carpet/blue,
+/area/tether/surfacebase/medical/mentalhealth)
 "abW" = (
 /obj/machinery/portable_atmospherics/powered/scrubber/huge/stationary{
 	name = "Research Testing Scrubber";
@@ -1165,87 +1157,153 @@
 /turf/simulated/floor/tiled,
 /area/rnd/testingroom)
 "abX" = (
-/obj/structure/catwalk,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/rust,
-/turf/simulated/floor/plating,
-/area/maintenance/lower/trash_pit)
-"abY" = (
-/obj/machinery/door/airlock/maintenance/cargo{
-	name = "Mining Maintenance Access";
-	req_one_access = list(48)
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/scrubbers,
 /obj/machinery/door/firedoor/glass,
+/obj/structure/grille,
+/obj/structure/window/reinforced/polarized/full{
+	id = "psych_birdcage"
+	},
 /turf/simulated/floor/plating,
-/area/tether/surfacebase/cargo/mining)
+/area/tether/surfacebase/medical/mentalhealth)
+"abY" = (
+/obj/machinery/door/airlock/medical{
+	name = "EMT Bay"
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/glass,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/paramed)
 "abZ" = (
-/obj/structure/closet/crate,
-/turf/simulated/floor/tiled/steel_dirty,
-/area/tether/surfacebase/cargo/warehouse)
-"aca" = (
-/obj/machinery/light{
-	dir = 1
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
 	},
-/turf/simulated/floor/tiled/steel_dirty,
-/area/tether/surfacebase/cargo/warehouse)
-"acb" = (
-/turf/simulated/mineral,
-/area/rnd/testingroom)
-"acc" = (
-/turf/simulated/wall,
-/area/tether/surfacebase/cargo/warehouse)
-"acd" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 8
 	},
-/turf/simulated/floor/tiled/steel_dirty,
-/area/tether/surfacebase/cargo/warehouse)
-"ace" = (
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 9
+/obj/effect/floor_decal/corner/lightgrey/bordercorner2{
+	dir = 8
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/steel_dirty,
-/area/tether/surfacebase/cargo/warehouse)
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/lowernortheva)
+"aca" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/lightgrey/bordercorner2{
+	dir = 6
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 10
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 9
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/lowernortheva)
+"acb" = (
+/turf/simulated/mineral,
+/area/rnd/testingroom)
+"acc" = (
+/obj/structure/flora/ausbushes/genericbush,
+/turf/simulated/floor/grass,
+/area/tether/surfacebase/medical/mentalhealth)
+"acd" = (
+/obj/structure/table/rack,
+/obj/item/device/suit_cooling_unit{
+	pixel_y = -5
+	},
+/obj/item/device/suit_cooling_unit{
+	pixel_y = -5
+	},
+/obj/item/device/radio/intercom/department/medbay{
+	dir = 8;
+	pixel_x = -24
+	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 9
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals9,
+/obj/effect/floor_decal/steeldecal/steel_decals9{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals9{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals9{
+	dir = 4
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/tether/surfacebase/medical/paramed)
+"ace" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/machinery/alarm{
+	pixel_y = 22
+	},
+/turf/simulated/floor/grass,
+/area/tether/surfacebase/medical/mentalhealth)
 "acf" = (
-/obj/machinery/light_switch{
-	pixel_x = 25
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
 	},
-/obj/machinery/camera/network/cargo,
-/obj/machinery/firealarm{
-	dir = 2;
-	layer = 3.3;
-	pixel_x = 0;
-	pixel_y = 26
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 8
 	},
-/obj/machinery/conveyor_switch/oneway{
-	convdir = 1;
-	id = "gloriouscargopipeline";
-	name = "Mining Ops conveyor switch";
-	pixel_x = 10;
-	pixel_y = 5;
-	req_access = list(48);
-	req_one_access = list(48)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4;
+	icon_state = "intact-scrubbers"
 	},
-/turf/simulated/floor/tiled/steel_dirty,
-/area/tether/surfacebase/cargo/warehouse)
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/tether/surfacebase/medical/paramed)
 "acg" = (
 /obj/random/maintenance/cargo,
 /obj/random/maintenance/cargo,
@@ -1253,14 +1311,16 @@
 /turf/simulated/floor/plating,
 /area/maintenance/lower/mining_eva)
 "ach" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/landmark/start{
+	name = "Paramedic"
 	},
-/turf/simulated/floor/tiled/steel_dirty,
-/area/tether/surfacebase/cargo/warehouse)
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4;
+	icon_state = "map-scrubbers"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/tether/surfacebase/medical/paramed)
 "aci" = (
 /turf/simulated/mineral,
 /area/storage/surface_eva/external)
@@ -1281,36 +1341,47 @@
 /turf/simulated/floor/plating,
 /area/maintenance/lower/mining_eva)
 "ack" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 28
+/obj/machinery/atmospherics/unary/vent_pump{
+	external_pressure_bound = 140;
+	external_pressure_bound_default = 140;
+	icon_state = "map_vent_out";
+	use_power = 1
 	},
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/tiled/steel_dirty,
-/area/tether/surfacebase/cargo/warehouse)
+/turf/simulated/floor/virgo3b,
+/area/tether/surfacebase/medical/viro)
 "acl" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor/glass,
-/obj/machinery/door/airlock/maintenance/common,
-/obj/structure/cable{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/plating,
-/area/tether/surfacebase/cargo)
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/medical/mentalhealth)
 "acm" = (
-/obj/structure/window/reinforced,
-/obj/structure/closet/crate,
-/turf/simulated/floor/tiled/steel_dirty,
-/area/tether/surfacebase/cargo/warehouse)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/medical/mentalhealth)
 "acn" = (
-/obj/structure/window/reinforced,
-/turf/simulated/floor/tiled/steel_dirty,
-/area/tether/surfacebase/cargo/warehouse)
+/obj/structure/table/rack,
+/obj/item/device/defib_kit/compact/loaded,
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 6
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals9{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals9{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals9{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals9,
+/turf/simulated/floor/tiled/dark,
+/area/tether/surfacebase/medical/paramed)
 "aco" = (
 /obj/structure/railing,
 /obj/structure/railing{
@@ -1333,15 +1404,9 @@
 /turf/simulated/floor/tiled,
 /area/rnd/testingroom)
 "acq" = (
-/obj/effect/floor_decal/techfloor{
-	dir = 4
-	},
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/maintenance/lower/trash_pit)
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/medical/mentalhealth)
 "acr" = (
 /obj/structure/table/marble,
 /obj/machinery/door/window{
@@ -1420,15 +1485,21 @@
 /turf/simulated/floor/tiled,
 /area/rnd/hardstorage)
 "acy" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+/obj/effect/floor_decal/borderfloor{
 	dir = 8
 	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/steel_dirty,
-/area/tether/surfacebase/cargo/warehouse)
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 6
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/lowernortheva)
 "acz" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1;
@@ -1443,125 +1514,115 @@
 /turf/simulated/floor/tiled,
 /area/crew_quarters/visitor_laundry)
 "acA" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/turf/simulated/floor/carpet/blue,
+/area/tether/surfacebase/medical/mentalhealth)
+"acB" = (
 /obj/effect/floor_decal/borderfloor{
-	dir = 1
+	dir = 4
 	},
-/obj/effect/floor_decal/corner/brown/border{
-	dir = 1
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 4
 	},
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 28
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 10
 	},
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 1
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 9
 	},
-/obj/effect/floor_decal/corner/brown/bordercorner2{
-	dir = 1
-	},
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
+/obj/machinery/vending/wallmed_airlock{
+	pixel_x = 32
 	},
 /turf/simulated/floor/tiled,
-/area/tether/surfacebase/cargo)
-"acB" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment{
+/area/tether/surfacebase/lowernortheva)
+"acC" = (
+/obj/structure/table/woodentable,
+/obj/item/device/flashlight/lamp/green{
 	dir = 2;
-	icon_state = "pipe-c"
+	pixel_x = -5;
+	pixel_y = 4
 	},
-/obj/structure/window/reinforced{
+/obj/machinery/button/windowtint{
+	id = "psych_office";
+	pixel_x = 6;
+	pixel_y = 10;
+	range = 12
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/button/windowtint{
+	id = "psych_office_inside";
+	pixel_x = 6;
+	range = 12
 	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/cargo)
-"acC" = (
-/obj/structure/table/rack,
-/obj/random/maintenance/cargo,
-/obj/random/maintenance/cargo,
-/obj/random/maintenance/clean,
-/turf/simulated/floor/tiled/techfloor,
-/area/maintenance/lower/mining_eva)
+/turf/simulated/floor/carpet/blue,
+/area/tether/surfacebase/medical/mentalhealth)
 "acD" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled,
 /area/rnd/hardstorage)
 "acE" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
+/obj/structure/dispenser{
+	phorontanks = 0
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 6
 	},
-/turf/simulated/floor/tiled/steel_dirty,
-/area/tether/surfacebase/cargo/warehouse)
-"acF" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
-	},
-/turf/simulated/floor/tiled/steel_dirty,
-/area/tether/surfacebase/cargo/warehouse)
-"acG" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
-	},
-/turf/simulated/floor/tiled/steel_dirty,
-/area/tether/surfacebase/cargo/warehouse)
-"acH" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
+/obj/effect/floor_decal/steeldecal/steel_decals9,
+/obj/effect/floor_decal/steeldecal/steel_decals9{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/steel_dirty,
-/area/tether/surfacebase/cargo/warehouse)
-"acI" = (
-/obj/machinery/door/firedoor/glass,
-/obj/machinery/door/blast/shutters{
+/obj/effect/floor_decal/steeldecal/steel_decals9{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals9{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/tether/surfacebase/medical/paramed)
+"acF" = (
+/obj/structure/table/woodentable,
+/obj/machinery/computer/med_data/laptop{
+	dir = 1
+	},
+/turf/simulated/floor/carpet/blue,
+/area/tether/surfacebase/medical/mentalhealth)
+"acG" = (
+/obj/machinery/door/window{
 	dir = 8;
-	id = "mine_warehouse";
-	name = "Warehouse Shutters"
+	name = "Birdcage";
+	req_one_access = list(64)
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/turf/simulated/floor/carpet/blue,
+/area/tether/surfacebase/medical/mentalhealth)
+"acH" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 8
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/cargo/warehouse)
+/turf/simulated/floor/tiled/dark,
+/area/tether/surfacebase/medical/paramed)
+"acI" = (
+/obj/structure/flora/ausbushes/lavendergrass,
+/turf/simulated/floor/grass,
+/area/tether/surfacebase/medical/mentalhealth)
 "acJ" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/lightgrey/border,
@@ -1571,55 +1632,21 @@
 /turf/simulated/floor/tiled,
 /area/hallway/lower/first_west)
 "acK" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 9
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/machinery/light/small{
+	dir = 4
 	},
-/obj/effect/floor_decal/corner/brown/border{
-	dir = 9
-	},
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 10
-	},
-/obj/effect/floor_decal/corner/brown/bordercorner2{
-	dir = 10
-	},
-/obj/machinery/status_display{
-	pixel_y = 30
-	},
-/obj/machinery/button/remote/blast_door{
-	id = "mine_warehouse";
-	name = "Warehouse Door Control";
-	pixel_x = -26;
-	pixel_y = 0;
-	req_access = list(31)
-	},
-/obj/structure/closet/firecloset,
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/cargo)
+/turf/simulated/floor/grass,
+/area/tether/surfacebase/medical/mentalhealth)
 "acL" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/brown/border{
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/cargo)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/dark,
+/area/tether/surfacebase/medical/paramed)
 "acM" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/cargo)
+/obj/machinery/atmospherics/pipe/simple/hidden/black,
+/turf/simulated/floor/virgo3b,
+/area/tether/surfacebase/medical/viro)
 "acN" = (
 /obj/structure/cable/ender{
 	icon_state = "1-2";
@@ -1634,37 +1661,35 @@
 /turf/simulated/floor/virgo3b,
 /area/tether/surfacebase/outside/outside1)
 "acO" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
 /obj/machinery/alarm{
-	alarm_id = "anomaly_testing";
-	breach_detection = 0;
-	dir = 8;
-	frequency = 1439;
-	pixel_x = 22;
-	pixel_y = 0;
-	report_danger_level = 0
-	},
-/turf/simulated/floor/tiled/steel_dirty,
-/area/tether/surfacebase/cargo/warehouse)
-"acP" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
 	dir = 4;
-	icon_state = "pipe-c"
+	pixel_x = -23;
+	pixel_y = 0
 	},
-/obj/structure/cable{
-	icon_state = "2-8"
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/medical/mentalhealth)
+"acP" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 5
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 5
 	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/cargo)
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/machinery/camera/network/medbay,
+/obj/effect/floor_decal/borderfloorwhite/corner2{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner2{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lowerhall)
 "acQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 10;
@@ -1674,25 +1699,19 @@
 /turf/simulated/floor/plating,
 /area/maintenance/lower/mining_eva)
 "acR" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/cargo)
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/medical/mentalhealth)
 "acS" = (
 /obj/machinery/atmospherics/pipe/tank/air{
 	dir = 4
@@ -1721,13 +1740,12 @@
 /turf/simulated/floor/tiled,
 /area/hallway/lower/first_west)
 "acU" = (
-/obj/structure/railing,
-/obj/machinery/conveyor{
-	dir = 8;
-	id = "surfacecargo"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
 	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/cargo)
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/medical/mentalhealth)
 "acV" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -1758,27 +1776,24 @@
 /turf/simulated/floor/plating,
 /area/maintenance/lower/mining_eva)
 "acY" = (
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/cargo)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/medical/mentalhealth)
 "acZ" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/brown/border{
-	dir = 1
-	},
-/obj/effect/floor_decal/borderfloor/corner2{
+/obj/structure/bed/chair{
 	dir = 4
 	},
-/obj/effect/floor_decal/corner/brown/bordercorner2{
-	dir = 4
+/obj/machinery/light/small{
+	dir = 8
 	},
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 2
-	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/cargo)
+/obj/machinery/camera/network/medbay,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lowerhall)
 "ada" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -1793,29 +1808,27 @@
 /turf/simulated/floor/tiled,
 /area/hallway/lower/first_west)
 "adb" = (
-/obj/structure/table/glass,
-/obj/effect/floor_decal/borderfloor{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
 	},
-/obj/effect/floor_decal/corner/brown/border{
-	dir = 1
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 4
 	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/cargo)
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lowerhall)
 "adc" = (
-/obj/structure/table/glass,
-/obj/effect/floor_decal/borderfloor{
-	dir = 1
+/obj/structure/bed/chair{
+	dir = 8
 	},
-/obj/effect/floor_decal/corner/brown/border{
-	dir = 1
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 22;
+	pixel_y = 0
 	},
-/obj/machinery/camera/network/cargo,
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/cargo)
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lowerhall)
 "add" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -1826,36 +1839,29 @@
 /turf/simulated/floor/tiled,
 /area/hallway/lower/first_west)
 "ade" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 5
-	},
-/obj/effect/floor_decal/corner/brown/border{
-	dir = 5
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 30
-	},
-/obj/structure/flora/pottedplant/stoutbush,
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/cargo)
-"adf" = (
-/turf/simulated/wall,
-/area/tether/surfacebase/cargo)
-"adg" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/structure/bed/chair{
 	dir = 4
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lowerhall)
+"adf" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/medical/mentalhealth)
+"adg" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/cargo)
+/turf/simulated/floor/carpet/blue,
+/area/tether/surfacebase/medical/mentalhealth)
 "adh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
@@ -1929,20 +1935,10 @@
 /turf/simulated/floor/plating,
 /area/maintenance/lower/mining_eva)
 "adm" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/cargo)
+/obj/structure/bed/chair/bay/chair/padded/red/bignest,
+/mob/living/simple_mob/animal/passive/bird/azure_tit/tweeter,
+/turf/simulated/floor/grass,
+/area/tether/surfacebase/medical/mentalhealth)
 "adn" = (
 /turf/simulated/wall/r_wall,
 /area/rnd/tankstorage)
@@ -1958,64 +1954,25 @@
 /turf/simulated/floor/plating,
 /area/maintenance/lower/mining_eva)
 "adq" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/cargo)
+/obj/structure/flora/ausbushes/brflowers,
+/turf/simulated/floor/grass,
+/area/tether/surfacebase/medical/mentalhealth)
 "adr" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/cargo)
+/turf/simulated/wall,
+/area/tether/surfacebase/medical/recoveryward)
 "ads" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/structure/disposalpipe/segment{
+/obj/structure/table/rack,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/suit/storage/hooded/wintercoat,
+/obj/item/weapon/tank/emergency/oxygen/engi,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/cargo)
-"adt" = (
-/obj/machinery/space_heater,
 /turf/simulated/floor/tiled/techfloor,
-/area/maintenance/lower/mining_eva)
+/area/tether/surfacebase/lowernorthhall)
+"adt" = (
+/turf/simulated/wall,
+/area/maintenance/surfacebase/cargostoresubstation)
 "adu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -2037,27 +1994,57 @@
 /turf/simulated/floor/tiled,
 /area/hallway/lower/first_west)
 "adv" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 5
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
 /turf/simulated/floor/tiled,
-/area/tether/surfacebase/cargo)
+/area/tether/surfacebase/lowernorthhall)
 "adw" = (
-/obj/machinery/atmospherics/pipe/cap/visible/scrubbers,
-/turf/simulated/floor/plating,
-/area/construction/vacant_mining_ops)
+/obj/structure/flora/pottedplant/fern,
+/obj/machinery/light,
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/medical/mentalhealth)
 "adx" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/cap/visible/supply,
-/turf/simulated/floor/plating,
-/area/construction/vacant_mining_ops)
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 9
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/lowernorthhall)
 "ady" = (
-/obj/machinery/portable_atmospherics/powered/pump/filled,
-/turf/simulated/floor/tiled/techfloor,
-/area/maintenance/lower/mining_eva)
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/medical/mentalhealth)
 "adz" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -2067,67 +2054,71 @@
 /turf/simulated/floor/tiled,
 /area/rnd/hardstorage)
 "adA" = (
-/obj/structure/disposaloutlet{
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_x = -8;
+	pixel_y = -26
+	},
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/medical/mentalhealth)
+"adB" = (
+/obj/structure/bookcase,
+/obj/item/weapon/book/manual/anomaly_spectroscopy,
+/obj/item/weapon/book/manual/anomaly_testing,
+/obj/item/weapon/book/manual/materials_chemistry_analysis,
+/obj/item/weapon/book/manual/resleeving,
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/medical/mentalhealth)
+"adC" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 9
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals9,
+/obj/effect/floor_decal/steeldecal/steel_decals9{
 	dir = 8
 	},
-/obj/structure/disposalpipe/trunk{
+/obj/effect/floor_decal/steeldecal/steel_decals9{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals9{
 	dir = 4
 	},
-/obj/structure/railing,
-/obj/structure/railing{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/cargo)
-"adB" = (
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/brown/border,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/cargo)
-"adC" = (
-/obj/machinery/door/airlock/glass_mining{
-	name = "Warehouse"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor/glass,
-/turf/simulated/floor/tiled/steel_grid,
-/area/tether/surfacebase/cargo/warehouse)
+/obj/machinery/light,
+/turf/simulated/floor/tiled/dark,
+/area/tether/surfacebase/medical/paramed)
 "adD" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
+/obj/machinery/power/apc{
+	dir = 2;
+	name = "south bump";
+	pixel_y = -28
 	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/cargo)
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 10
+	},
+/obj/effect/floor_decal/borderfloorblack/corner2{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner2{
+	dir = 9
+	},
+/obj/structure/cable/green,
+/turf/simulated/floor/tiled/dark,
+/area/tether/surfacebase/medical/paramed)
 "adE" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/window/northright{
-	dir = 2;
-	name = "Mailing Room";
-	req_access = list(50)
-	},
-/obj/structure/noticeboard{
-	pixel_x = 32
-	},
-/obj/machinery/door/blast/shutters{
-	dir = 2;
-	id = "surfcargooffice";
-	layer = 3.3;
-	name = "Cargo Office Shutters"
-	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/cargo/office)
+/obj/structure/bookcase,
+/obj/item/weapon/book/manual,
+/obj/item/weapon/book/manual/command_guide,
+/obj/item/weapon/book/manual/security_space_law,
+/obj/item/weapon/book/manual/standard_operating_procedure,
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/medical/mentalhealth)
 "adF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -2148,9 +2139,18 @@
 /turf/simulated/floor/tiled,
 /area/hallway/lower/first_west)
 "adG" = (
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/cargo)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/dark,
+/area/tether/surfacebase/medical/paramed)
 "adH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -2271,75 +2271,77 @@
 /turf/simulated/floor/tiled,
 /area/hallway/lower/first_west)
 "adP" = (
-/obj/structure/table/glass,
-/obj/effect/floor_decal/borderfloor{
+/obj/effect/floor_decal/borderfloorblack{
 	dir = 4
 	},
-/obj/effect/floor_decal/corner/brown/border{
+/obj/effect/floor_decal/corner/paleblue/border{
 	dir = 4
 	},
-/obj/machinery/computer/guestpass{
-	dir = 8;
-	pixel_x = 25
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/cargo)
+/turf/simulated/floor/tiled/dark,
+/area/tether/surfacebase/medical/paramed)
 "adQ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/closet/secure_closet/paramedic,
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 9
 	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/cargo/office)
-"adR" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -28
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 6
 	},
-/obj/structure/bed/chair/sofa/brown/left{
+/obj/effect/floor_decal/steeldecal/steel_decals9{
 	dir = 4
 	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 8;
-	icon_state = "borderfloor";
-	pixel_x = 0
+/obj/effect/floor_decal/steeldecal/steel_decals9{
+	dir = 1
 	},
-/obj/effect/floor_decal/corner/brown/border{
+/obj/effect/floor_decal/steeldecal/steel_decals9{
 	dir = 8
 	},
-/obj/effect/floor_decal/borderfloor/corner2{
+/obj/effect/floor_decal/steeldecal/steel_decals9,
+/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
-/obj/effect/floor_decal/corner/brown/bordercorner2{
+/obj/machinery/light,
+/turf/simulated/floor/tiled/dark,
+/area/tether/surfacebase/medical/paramed)
+"adR" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 8
 	},
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
 	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/cargo/office)
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lowerhall)
 "adS" = (
-/turf/simulated/floor/tiled/steel_dirty,
-/area/tether/surfacebase/cargo/warehouse)
+/obj/structure/bed/chair{
+	dir = 8
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lowerhall)
 "adT" = (
-/obj/machinery/door/firedoor/glass,
-/obj/machinery/door/blast/shutters{
-	dir = 8;
-	id = "mine_warehouse";
-	name = "Warehouse Shutters"
-	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/cargo/warehouse)
+/obj/structure/flora/pottedplant/fern,
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/medical/mentalhealth)
 "adU" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/glass_medical{
+	name = "Mental Health";
+	req_one_access = list()
 	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/cargo/office)
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lowerhall)
 "adV" = (
 /obj/structure/table/glass,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -2383,76 +2385,53 @@
 /turf/simulated/floor/tiled,
 /area/hallway/lower/first_west)
 "adX" = (
-/obj/structure/table/standard,
-/obj/item/weapon/stamp/cargo,
-/obj/item/weapon/stamp/denied{
-	pixel_x = 4;
-	pixel_y = -2
-	},
-/obj/item/weapon/clipboard,
-/obj/item/weapon/folder/yellow,
-/obj/effect/floor_decal/borderfloor/corner2{
+/obj/structure/bed/chair{
 	dir = 4
 	},
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/brown/bordercorner2{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/brown/bordercorner2{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/cargo/office)
-"adY" = (
-/obj/machinery/button/remote/blast_door{
-	id = "mine_warehouse";
-	name = "Warehouse Door Control";
-	pixel_x = -26;
-	pixel_y = 24;
-	req_access = list(31)
-	},
-/obj/machinery/button/remote/blast_door{
-	id = "surfcargooffice";
-	name = "Office Shutters";
-	pixel_x = -34;
-	pixel_y = 24;
-	req_access = list(31)
-	},
-/obj/effect/landmark/start{
-	name = "Cargo Technician"
-	},
-/obj/structure/bed/chair/office/dark{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/cargo/office)
-"adZ" = (
-/obj/effect/floor_decal/steeldecal/steel_decals6{
+/obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals6{
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/obj/structure/sign/poster{
+	pixel_y = 32
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/recoveryward)
+"adY" = (
+/obj/item/device/radio/intercom{
+	dir = 1;
+	name = "Station Intercom (General)";
+	pixel_y = 24
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/effect/floor_decal/borderfloorwhite{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/cargo)
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/recoveryward)
+"adZ" = (
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/recoveryward)
 "aea" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+/obj/structure/closet/secure_closet/chemical{
+	req_access = list(64);
+	req_one_access = list(5)
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/cargo/office)
+/turf/simulated/floor/carpet/blue,
+/area/tether/surfacebase/medical/mentalhealth)
 "aeb" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -2495,59 +2474,67 @@
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
 "aed" = (
-/obj/structure/disposalpipe/segment{
+/obj/structure/bed/padded,
+/obj/item/weapon/bedsheet/medical,
+/obj/structure/curtain/open/privacy,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/recoveryward)
+"aee" = (
+/obj/machinery/door/firedoor/glass,
+/obj/structure/window/reinforced/polarized/full{
+	id = "ward_tint"
+	},
+/obj/structure/grille,
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/medical/recoveryward)
+"aef" = (
+/turf/simulated/wall,
+/area/tether/surfacebase/lowernorthhall)
+"aeg" = (
+/obj/structure/sign/nosmoking_2{
+	pixel_x = -32
+	},
+/obj/machinery/washing_machine,
+/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/tether/surfacebase/lowernorthhall)
+"aeh" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 5
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
-/area/tether/surfacebase/cargo/office)
-"aee" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/cargo)
-"aef" = (
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/cargo)
-"aeg" = (
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/brown/border,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/cargo/office)
-"aeh" = (
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/brown/border,
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -25
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/cargo/office)
+/area/tether/surfacebase/lowernorthhall)
 "aei" = (
-/obj/effect/floor_decal/techfloor{
-	dir = 10
-	},
-/obj/structure/railing{
+/obj/structure/bed/chair/comfy/brown{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/rust,
-/obj/structure/table/rack,
-/obj/random/maintenance/cargo,
-/obj/random/maintenance/cargo,
-/obj/random/maintenance/clean,
-/turf/simulated/floor/plating,
-/area/maintenance/lower/trash_pit)
+/turf/simulated/floor/carpet/blue,
+/area/tether/surfacebase/medical/mentalhealth)
 "aej" = (
 /obj/machinery/door/airlock/maintenance/engi{
 	name = "Atmospherics";
@@ -2569,49 +2556,22 @@
 /turf/simulated/floor/plating,
 /area/engineering/atmos/processing)
 "aek" = (
-/obj/effect/floor_decal/techfloor,
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/rust,
-/turf/simulated/floor/plating,
-/area/maintenance/lower/trash_pit)
+/obj/structure/bed/psych,
+/turf/simulated/floor/carpet/blue,
+/area/tether/surfacebase/medical/mentalhealth)
 "ael" = (
-/obj/effect/floor_decal/techfloor,
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/random/trash_pile,
-/turf/simulated/floor/plating,
-/area/maintenance/lower/trash_pit)
+/obj/structure/table/woodentable,
+/obj/item/weapon/clipboard,
+/obj/machinery/light,
+/turf/simulated/floor/carpet/blue,
+/area/tether/surfacebase/medical/mentalhealth)
 "aem" = (
-/obj/effect/floor_decal/techfloor,
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small,
-/turf/simulated/floor/plating,
-/area/maintenance/lower/trash_pit)
+/turf/simulated/wall/r_wall,
+/area/tether/surfacebase/medical/viro)
 "aen" = (
-/obj/effect/floor_decal/techfloor{
-	dir = 4
-	},
-/obj/structure/railing,
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/alarm{
-	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 24
-	},
-/obj/random/trash_pile,
-/turf/simulated/floor/plating,
-/area/maintenance/lower/trash_pit)
+/obj/machinery/atmospherics/pipe/simple/hidden/black,
+/turf/simulated/wall/r_wall,
+/area/tether/surfacebase/medical/viro)
 "aeo" = (
 /turf/simulated/floor/virgo3b,
 /area/tether/surfacebase/outside/outside1)
@@ -2659,16 +2619,27 @@
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
 "aes" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 9
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 10
+	},
+/obj/machinery/camera/network/cargo{
+	dir = 8;
+	icon_state = "camera"
+	},
+/obj/structure/closet/hydrant{
+	pixel_x = 32
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/tether/surfacebase/cargo)
+/area/tether/surfacebase/lowernorthhall)
 "aet" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -2710,11 +2681,25 @@
 /turf/simulated/floor/plating,
 /area/engineering/atmos/processing)
 "aev" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/medical{
+	name = "EMT Bay"
 	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/cargo)
+/obj/machinery/door/blast/shutters{
+	closed_layer = 10;
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id = "medbayquar";
+	layer = 1;
+	name = "Medbay Emergency Lockdown Shutters";
+	opacity = 0;
+	open_layer = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/dark,
+/area/tether/surfacebase/medical/paramed)
 "aew" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -2812,46 +2797,66 @@
 /obj/random/maintenance/cargo,
 /obj/random/maintenance/clean,
 /obj/random/tool,
+/obj/effect/decal/cleanable/cobweb{
+	icon_state = "cobweb2"
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/mining_eva)
 "aeC" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
 	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/cargo)
-"aeD" = (
-/obj/structure/table/glass,
-/obj/effect/floor_decal/borderfloor{
+/obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 4
 	},
-/obj/effect/floor_decal/corner/brown/border{
-	dir = 4
-	},
-/obj/machinery/newscaster{
-	pixel_x = 30;
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/cargo)
-"aeE" = (
-/obj/structure/railing,
-/obj/machinery/conveyor{
-	dir = 8;
-	id = "surfacecargo"
-	},
-/obj/structure/plasticflaps,
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/cargo)
-"aeF" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/light_switch{
+	pixel_x = 24;
+	pixel_y = 30
 	},
 /turf/simulated/floor/tiled/steel_dirty,
-/area/tether/surfacebase/cargo/warehouse)
+/area/tether/surfacebase/cargostore/warehouse)
+"aeD" = (
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/obj/machinery/power/apc{
+	cell_type = /obj/item/weapon/cell/super;
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/recoveryward)
+"aeE" = (
+/turf/simulated/wall/r_wall,
+/area/tether/surfacebase/medical/viro/viroward)
+"aeF" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/recoveryward)
 "aeG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -2903,12 +2908,19 @@
 /turf/simulated/floor/wood,
 /area/vacant/vacant_bar)
 "aeJ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
+/obj/machinery/computer/security/telescreen/entertainment{
+	desc = "Looks like it's on MTV. Now you can't blame that demi-cowgirl for working her money maker. I wonder what else is on?";
+	icon_state = "frame";
+	pixel_x = 16;
+	pixel_y = 64
 	},
-/turf/simulated/floor/tiled/steel_dirty,
-/area/tether/surfacebase/cargo/warehouse)
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/recoveryward)
 "aeK" = (
 /obj/machinery/light/small,
 /obj/effect/floor_decal/industrial/warning/corner{
@@ -2952,13 +2964,27 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_one_hall)
 "aeN" = (
-/obj/machinery/conveyor{
-	dir = 8;
-	id = "gloriouscargopipeline"
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
 	},
-/obj/structure/plasticflaps,
-/turf/simulated/floor/tiled/steel_dirty,
-/area/tether/surfacebase/cargo/warehouse)
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube1"
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/lowernorthhall)
 "aeO" = (
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/airlock{
@@ -2995,36 +3021,33 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/north_stairs_one)
 "aeQ" = (
-/obj/machinery/door/airlock/multi_tile/glass{
-	name = "Surface Cargo"
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 4
 	},
-/obj/machinery/door/firedoor/glass,
-/obj/effect/floor_decal/steeldecal/steel_decals_central1{
-	dir = 8
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 10
 	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/monofloor{
-	dir = 8
+/obj/effect/floor_decal/corner/lightgrey/bordercorner{
+	dir = 4
 	},
-/area/tether/surfacebase/surface_one_hall)
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/lowernorthhall)
 "aeR" = (
 /turf/simulated/floor/reinforced,
 /area/rnd/testingroom)
 "aeS" = (
 /obj/effect/floor_decal/borderfloor{
-	dir = 10
+	dir = 1
 	},
-/obj/effect/floor_decal/corner/brown/border{
-	dir = 10
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 1
 	},
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/brown/bordercorner2{
-	dir = 8
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/tether/surfacebase/cargo)
+/area/tether/surfacebase/lowernorthhall)
 "aeT" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1;
@@ -3047,17 +3070,8 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/public_garden)
 "aeU" = (
-/obj/machinery/light,
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/brown/border,
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 9
-	},
-/obj/effect/floor_decal/corner/brown/bordercorner2{
-	dir = 9
-	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/cargo)
+/turf/simulated/wall,
+/area/tether/surfacebase/medical/lowerhall)
 "aeV" = (
 /obj/structure/stairs/north,
 /turf/simulated/floor/virgo3b,
@@ -3092,22 +3106,37 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/north_stairs_one)
 "aeY" = (
-/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/medical{
+	id_tag = "mentaldoor";
+	name = "Mental Health";
+	req_access = list(64)
+	},
+/obj/machinery/door/firedoor/glass,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/cargo)
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/mentalhealth)
 "aeZ" = (
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/brown/border,
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 9
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
 	},
-/obj/effect/floor_decal/corner/brown/bordercorner2{
-	dir = 9
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/glass/hidden/steel{
+	dir = 2
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/tether/surfacebase/cargo)
+/area/tether/surfacebase/lowernorthhall)
 "afa" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -3135,16 +3164,13 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/north_stairs_one)
 "afb" = (
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/brown/border,
-/obj/machinery/computer/supplycomp{
-	dir = 1;
-	icon_state = "computer"
+/obj/machinery/door/firedoor/glass,
+/obj/structure/window/reinforced/polarized/full{
+	id = "psych_office_inside"
 	},
-/obj/effect/floor_decal/borderfloor/corner2,
-/obj/effect/floor_decal/corner/brown/bordercorner2,
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/cargo)
+/obj/structure/grille,
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/medical/mentalhealth)
 "afc" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -3190,14 +3216,8 @@
 /turf/simulated/floor/reinforced,
 /area/rnd/testingroom)
 "aff" = (
-/obj/machinery/door/firedoor/glass,
-/obj/effect/floor_decal/steeldecal/steel_decals_central1{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/monofloor{
-	dir = 4
-	},
-/area/tether/surfacebase/cargo)
+/turf/simulated/wall,
+/area/tether/surfacebase/medical/viroairlock)
 "afg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5;
@@ -3233,101 +3253,90 @@
 /turf/simulated/floor/tiled/monofloor,
 /area/tether/surfacebase/surface_one_hall)
 "afi" = (
-/obj/structure/bed/chair{
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/effect/floor_decal/borderfloor{
 	dir = 1
 	},
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/brown/border,
-/obj/effect/floor_decal/borderfloor/corner2,
-/obj/effect/floor_decal/corner/brown/bordercorner2,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_x = 0;
-	pixel_y = -24
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/tether/surfacebase/cargo)
+/area/tether/surfacebase/lowernorthhall)
 "afj" = (
-/obj/structure/bed/chair{
+/obj/effect/floor_decal/borderfloor{
 	dir = 1
 	},
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/brown/border,
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -25
-	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/cargo)
-"afk" = (
-/obj/structure/reagent_dispensers/water_cooler/full,
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/brown/border,
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/cargo)
-"afl" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 6
-	},
-/obj/effect/floor_decal/corner/brown/border{
-	dir = 6
-	},
-/obj/structure/flora/pottedplant/stoutbush,
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/cargo)
-"afm" = (
-/obj/machinery/door/airlock/glass_mining{
-	name = "Warehouse"
-	},
-/obj/machinery/door/firedoor/glass,
-/turf/simulated/floor/tiled/steel_grid,
-/area/tether/surfacebase/cargo/warehouse)
-"afn" = (
-/obj/machinery/door/firedoor/glass,
-/obj/effect/floor_decal/steeldecal/steel_decals_central1{
-	dir = 8
-	},
-/obj/machinery/door/airlock/multi_tile/glass{
-	name = "Surface Cargo"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/monofloor{
-	dir = 8
-	},
-/area/tether/surfacebase/cargo)
-"afo" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/brown/border{
-	dir = 4
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 1
 	},
 /obj/effect/floor_decal/borderfloor/corner2{
-	dir = 6
+	dir = 1
 	},
-/obj/effect/floor_decal/corner/brown/bordercorner2{
-	dir = 6
+/obj/effect/floor_decal/corner/paleblue/bordercorner2{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/lowernorthhall)
+"afk" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 4
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 9
 	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/lowernorthhall)
+"afl" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 1
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/effect/floor_decal/steeldecal/steel_decals7,
 /obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 10
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 9
-	},
-/obj/machinery/camera/network/cargo{
-	dir = 8;
-	icon_state = "camera"
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/tether/surfacebase/cargo)
+/area/tether/surfacebase/lowernorthhall)
+"afm" = (
+/turf/simulated/wall/r_wall,
+/area/tether/surfacebase/medical/viroairlock)
+"afn" = (
+/obj/machinery/disease2/diseaseanalyser,
+/obj/item/device/radio/intercom{
+	dir = 1;
+	name = "Station Intercom (General)";
+	pixel_y = 24
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/lime/border{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/viro)
+"afo" = (
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/lowernorthhall)
 "afp" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -3361,33 +3370,25 @@
 /area/storage/primary)
 "afs" = (
 /obj/effect/floor_decal/borderfloor{
-	dir = 8
+	dir = 5
 	},
-/obj/effect/floor_decal/corner/brown/border{
-	dir = 8
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 5
 	},
 /obj/effect/floor_decal/borderfloor/corner2{
-	dir = 8
+	dir = 5
 	},
-/obj/effect/floor_decal/corner/brown/bordercorner2{
-	dir = 8
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
+/obj/effect/floor_decal/borderfloor/corner2{
 	dir = 4
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
+/obj/effect/floor_decal/corner/paleblue/bordercorner2{
 	dir = 5
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 6
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+/obj/effect/floor_decal/corner/paleblue/bordercorner2{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/tether/surfacebase/cargo)
+/area/tether/surfacebase/lowernorthhall)
 "aft" = (
 /obj/machinery/camera/network/civilian{
 	dir = 2
@@ -3420,41 +3421,37 @@
 /turf/simulated/floor/tiled,
 /area/storage/primary)
 "afx" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 8
+/obj/machinery/computer/diseasesplicer,
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/effect/floor_decal/corner/brown/border{
-	dir = 8
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 5
+/obj/effect/floor_decal/corner/lime/border{
+	dir = 1
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 6
-	},
-/obj/structure/sign/nosmoking_2{
-	pixel_x = -32
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/cargo)
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/viro)
 "afy" = (
-/obj/structure/table/standard,
-/obj/item/weapon/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 2
 	},
-/obj/item/weapon/pen/red{
-	pixel_x = 2;
-	pixel_y = 6
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 8
 	},
-/obj/structure/disposalpipe/junction/yjunction,
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/cargo/office)
+/obj/effect/floor_decal/borderfloorwhite/corner2{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner2{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/recoveryward)
 "afz" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -3479,95 +3476,54 @@
 /turf/simulated/floor/tiled,
 /area/rnd/hardstorage)
 "afB" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 8
+/obj/machinery/disease2/incubator,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
 	},
-/obj/effect/floor_decal/corner/brown/border{
-	dir = 8
+/obj/effect/floor_decal/corner/lime/border{
+	dir = 1
 	},
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 10
-	},
-/obj/effect/floor_decal/corner/brown/bordercorner2{
-	dir = 10
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 5
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 5
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 6
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5;
-	icon_state = "intact-scrubbers"
-	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/cargo)
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/viro)
 "afC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/rack,
 /obj/random/maintenance/cargo,
 /obj/random/maintenance/cargo,
 /obj/random/maintenance/clean,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/mining_eva)
 "afD" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/brown/border{
-	dir = 4
-	},
+/obj/machinery/computer/centrifuge,
 /obj/machinery/alarm{
-	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 24
+	pixel_y = 22
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 10
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 9
+/obj/effect/floor_decal/corner/lime/border{
+	dir = 1
 	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/cargo)
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/viro)
 "afE" = (
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/brown/border,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/cargo/office)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/recoveryward)
 "afF" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 4
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/effect/floor_decal/corner/brown/border{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 5
-	},
-/obj/effect/floor_decal/corner/brown/bordercorner2{
-	dir = 5
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 8
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 10
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 9
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/cargo)
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/recoveryward)
 "afG" = (
 /obj/structure/bed/chair,
 /obj/machinery/camera/network/civilian,
@@ -3583,32 +3539,52 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/tether/surfacebase/tram)
 "afI" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/blast/shutters{
-	dir = 2;
-	id = "surfcargooffice";
-	layer = 3.3;
-	name = "Cargo Office Shutters"
+/obj/item/device/radio/intercom{
+	dir = 8;
+	pixel_x = -24
 	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plating,
-/area/tether/surfacebase/cargo/office)
-"afJ" = (
-/obj/machinery/door/firedoor/glass,
-/obj/effect/floor_decal/steeldecal/steel_decals_central1{
-	dir = 4
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/monofloor{
-	dir = 4
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/area/tether/surfacebase/surface_one_hall)
-"afK" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /obj/effect/floor_decal/borderfloor{
-	dir = 1
+	dir = 8
 	},
 /obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/lowernorthhall)
+"afJ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/lowernorthhall)
+"afK" = (
+/obj/effect/floor_decal/borderfloor{
 	dir = 1
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals7{
@@ -3618,50 +3594,53 @@
 /obj/structure/disposalpipe/junction{
 	dir = 8
 	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 1
+	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_one_hall)
 "afL" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
+	dir = 6
 	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_x = 0;
-	pixel_y = -24
-	},
-/turf/simulated/floor/tiled/steel_dirty,
-/area/tether/surfacebase/cargo/warehouse)
+/obj/effect/floor_decal/industrial/warning/full,
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/viro)
 "afM" = (
-/obj/machinery/light,
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/extinguisher_cabinet{
-	dir = 1;
-	icon_state = "extinguisher_closed";
-	pixel_y = -32
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
-/turf/simulated/floor/tiled/steel_dirty,
-/area/tether/surfacebase/cargo/warehouse)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/lowernorthhall)
 "afN" = (
-/obj/machinery/conveyor{
-	dir = 8;
-	id = "gloriouscargopipeline"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/steel_dirty,
-/area/tether/surfacebase/cargo/warehouse)
-"afO" = (
-/obj/structure/railing{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/glass/hidden/steel{
 	dir = 8
 	},
-/obj/structure/sign/warning{
-	desc = "A warning sign. It has great big words saying 'Surface Cargo Deliveries. Stay behind the railings when active!' on it.";
-	name = "Surface Cargo Delivery";
-	pixel_y = 32
-	},
-/obj/effect/floor_decal/industrial/loading,
 /turf/simulated/floor/tiled,
-/area/tether/surfacebase/cargo)
+/area/tether/surfacebase/lowernorthhall)
+"afO" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/lowernorthhall)
 "afP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -3681,20 +3660,13 @@
 /turf/simulated/floor/tiled,
 /area/rnd/hardstorage)
 "afQ" = (
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
-	icon_state = "pipe-c"
+	icon_state = "map-scrubbers"
 	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/sign/warning/moving_parts{
-	desc = "A warning sign for moving parts. This one states 'Put your gathered ore here for processing!' on it.";
-	name = "To Mining Operations Processing";
-	pixel_x = -32
-	},
-/turf/simulated/floor/tiled/steel_dirty,
-/area/tether/surfacebase/cargo/warehouse)
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/lowernorthhall)
 "afR" = (
 /obj/effect/floor_decal/corner_steel_grid{
 	dir = 5
@@ -3703,32 +3675,15 @@
 /turf/simulated/floor/virgo3b,
 /area/tether/surfacebase/outside/outside1)
 "afS" = (
-/obj/effect/floor_decal/borderfloor/corner2{
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1;
+	icon_state = "map-scrubbers"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
-	},
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/brown/bordercorner2{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/brown/bordercorner2{
-	dir = 1
-	},
-/obj/machinery/light_switch{
-	dir = 2;
-	name = "light switch ";
-	pixel_x = 10;
-	pixel_y = 32
-	},
-/obj/machinery/conveyor_switch{
-	id = "surfacecargo";
-	name = "Surface Cargo Delivery conveyor switch";
-	pixel_x = 0;
-	pixel_y = 0
 	},
 /turf/simulated/floor/tiled,
-/area/tether/surfacebase/cargo/office)
+/area/tether/surfacebase/lowernorthhall)
 "afT" = (
 /turf/simulated/floor/tiled,
 /area/storage/primary)
@@ -3812,38 +3767,34 @@
 /turf/simulated/floor/holofloor/tiled/dark,
 /area/tether/elevator)
 "agd" = (
-/obj/random/trash_pile,
-/turf/simulated/floor/tiled/techfloor,
-/area/maintenance/lower/mining_eva)
+/obj/machinery/power/breakerbox/activated{
+	RCon_tag = "CargoShop Substation Bypass"
+	},
+/turf/simulated/floor,
+/area/maintenance/surfacebase/cargostoresubstation)
 "age" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/lower/mining_eva)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/lowernorthhall)
 "agf" = (
 /obj/effect/floor_decal/steeldecal/steel_decals6{
 	dir = 1
 	},
-/obj/structure/disposalpipe/sortjunction{
-	dir = 8;
-	name = "Surface Cargo";
-	sortType = "Surface Cargo"
+/obj/structure/disposalpipe/junction{
+	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_one_hall)
 "agg" = (
-/obj/machinery/disposal/deliveryChute{
-	dir = 4
-	},
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "gloriouscargopipeline"
-	},
-/obj/structure/disposalpipe/trunk,
-/turf/simulated/floor/plating,
-/area/tether/surfacebase/cargo/warehouse)
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/lowernorthhall)
 "agh" = (
 /obj/turbolift_map_holder/tether{
 	dir = 4
@@ -3857,15 +3808,12 @@
 	},
 /area/tether/elevator)
 "agj" = (
-/obj/machinery/button/remote/blast_door{
-	id = "mine_warehouse";
-	name = "Warehouse Door Control";
-	pixel_x = 0;
-	pixel_y = -22;
-	req_access = list(31)
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
 	},
-/turf/simulated/floor/tiled/steel_dirty,
-/area/tether/surfacebase/cargo/warehouse)
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/lowernorthhall)
 "agk" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/floor/tiled,
@@ -3911,15 +3859,11 @@
 /turf/simulated/floor/tiled,
 /area/rnd/xenoarch_storage)
 "agq" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/machinery/atmospherics/tvalve/bypass{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/cargo)
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/medical/viro)
 "agr" = (
 /obj/machinery/alarm{
 	dir = 8;
@@ -4867,50 +4811,38 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 1
-	},
 /obj/effect/floor_decal/steeldecal/steel_decals7,
 /obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 4
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/brown/bordercorner2{
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_one_hall)
 "aid" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 1
-	},
-/obj/machinery/status_display{
-	pixel_y = 30
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 1
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7,
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 4
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_one_hall)
 "aie" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
+/obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 4
 	},
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 1
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7,
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 4
+/obj/structure/disposalpipe/sortjunction{
+	dir = 8;
+	name = "Cargo Shop";
+	sortType = "Cargo Shop"
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_one_hall)
@@ -4922,31 +4854,28 @@
 	dir = 4
 	},
 /obj/machinery/camera/network/tether,
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 1
-	},
 /obj/effect/floor_decal/steeldecal/steel_decals7,
 /obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/brown/bordercorner2{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_one_hall)
 "aig" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 9
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/danger{
-	dir = 1
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7,
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/surface_one_hall)
+/obj/machinery/smartfridge/secure/virology,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/viro)
 "aih" = (
 /obj/machinery/button/remote/blast_door{
 	id = "gogogo";
@@ -4973,12 +4902,12 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
 	},
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 1
-	},
 /obj/effect/floor_decal/steeldecal/steel_decals7,
 /obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 4
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_one_hall)
@@ -5454,14 +5383,17 @@
 	},
 /area/tether/surfacebase/surface_one_hall)
 "ajb" = (
-/obj/machinery/door/airlock/maintenance/cargo{
-	name = "Mining Maintenance Access";
-	req_one_access = list(48)
+/obj/machinery/computer/arcade{
+	dir = 8
 	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor/glass,
-/turf/simulated/floor/plating,
-/area/tether/surfacebase/cargo/warehouse)
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/lime/border{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/viro/viroward)
 "ajc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 4
@@ -7290,8 +7222,17 @@
 /turf/simulated/floor/tiled,
 /area/rnd/tankstorage)
 "amc" = (
-/turf/simulated/wall,
-/area/tether/surfacebase/cargo/office)
+/obj/structure/sink{
+	pixel_y = 26
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lime/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/viro/viroward)
 "amd" = (
 /obj/structure/sign/warning/nosmoking_2,
 /turf/simulated/wall/r_wall,
@@ -7424,6 +7365,11 @@
 	icon_state = "1-2";
 	pixel_y = 0
 	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/mining_eva)
 "amr" = (
@@ -7489,9 +7435,17 @@
 /turf/simulated/floor/tiled/steel_dirty,
 /area/rnd/tankstorage)
 "amw" = (
-/obj/structure/sign/department/cargo,
-/turf/simulated/wall,
-/area/tether/surfacebase/cargo/office)
+/obj/effect/landmark{
+	name = "lightsout"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/lowernorthhall)
 "amx" = (
 /obj/effect/floor_decal/industrial/warning/dust,
 /obj/structure/cable/green{
@@ -7660,9 +7614,24 @@
 /turf/simulated/floor/tiled/steel_dirty,
 /area/rnd/tankstorage)
 "amP" = (
-/obj/machinery/camera/network/cargo,
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/cargo/office)
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_x = 0;
+	pixel_y = 28
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lime/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/viro/viroward)
 "amQ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -8195,13 +8164,16 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
-/obj/effect/floor_decal/corner/lightgrey/border{
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/brown/border{
 	dir = 9
 	},
 /obj/effect/floor_decal/borderfloor/corner2{
 	dir = 10
 	},
-/obj/effect/floor_decal/corner/lightgrey/bordercorner2{
+/obj/effect/floor_decal/corner/brown/bordercorner2{
 	dir = 10
 	},
 /turf/simulated/floor/tiled,
@@ -8210,21 +8182,18 @@
 /turf/simulated/wall/r_wall,
 /area/crew_quarters/sleep/Dorm_1)
 "anF" = (
-/obj/machinery/door/airlock/glass_mining{
-	id_tag = "cargodoor";
-	name = "Cargo Office";
-	req_access = list();
-	req_one_access = list(48,50)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
 	},
-/obj/machinery/door/firedoor/glass,
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/tiled,
-/area/tether/surfacebase/cargo/office)
+/area/tether/surfacebase/lowernorthhall)
 "anG" = (
 /obj/machinery/door/airlock/maintenance/rnd{
 	req_one_access = list(47,24)
@@ -10551,23 +10520,8 @@
 /turf/simulated/floor/grass,
 /area/tether/surfacebase/surface_one_hall)
 "arB" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 4
-	},
-/obj/machinery/camera/network/tether{
-	dir = 9
-	},
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 4
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 10
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 9
-	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/surface_one_hall)
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/viro/viroward)
 "arC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/green{
@@ -11375,13 +11329,15 @@
 /turf/simulated/floor/tiled/steel_dirty/virgo3b,
 /area/tether/surfacebase/outside/outside1)
 "asT" = (
-/obj/machinery/door/airlock/maintenance/cargo{
-	name = "Mining Maintenance Access";
-	req_one_access = list(48,50)
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/machinery/door/firedoor/glass,
-/turf/simulated/floor/plating,
-/area/tether/surfacebase/cargo/office)
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 10
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/lowernorthhall)
 "asU" = (
 /turf/simulated/floor/tiled,
 /area/crew_quarters/locker)
@@ -11449,15 +11405,21 @@
 /turf/simulated/floor/plating,
 /area/vacant/vacant_site)
 "atc" = (
-/obj/machinery/door/airlock/maintenance/common{
-	name = "Mining Maintenance Access"
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 9
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 9
 	},
-/obj/machinery/door/firedoor/glass,
-/turf/simulated/floor/plating,
-/area/maintenance/lower/mining_eva)
+/obj/effect/floor_decal/borderfloorwhite/corner2{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lowerhall)
 "atd" = (
 /obj/machinery/door/airlock{
 	id_tag = "lg_1";
@@ -11605,6 +11567,16 @@
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/locker)
+"atq" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 1
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lowerhall)
 "atr" = (
 /obj/structure/table/standard{
 	name = "plastic table frame"
@@ -11768,6 +11740,33 @@
 "atH" = (
 /turf/simulated/wall,
 /area/maintenance/substation/civ_west)
+"atI" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 1
+	},
+/obj/machinery/alarm{
+	pixel_y = 22
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lowerhall)
+"atJ" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloorwhite/corner2{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner2{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lowerhall)
 "atK" = (
 /obj/machinery/light/small{
 	dir = 4;
@@ -11799,6 +11798,65 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_one_hall)
+"atN" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lowerhall)
+"atO" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lowerhall)
+"atP" = (
+/obj/machinery/door/firedoor/glass/hidden/steel{
+	dir = 2
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lowerhall)
+"atQ" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 1
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_x = 0;
+	pixel_y = 24
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lowerhall)
 "atR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -12032,6 +12090,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/civ_west)
+"auo" = (
+/obj/structure/closet/l3closet/virology,
+/obj/machinery/camera/network/medbay,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/viroairlock)
 "aup" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -12046,6 +12109,22 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/lower/mining_eva)
+"auq" = (
+/obj/structure/closet/wardrobe/virology_white,
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/viroairlock)
+"aur" = (
+/obj/structure/closet/l3closet/virology,
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/machinery/alarm{
+	pixel_y = 22
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/viroairlock)
 "aus" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -12306,6 +12385,28 @@
 "auK" = (
 /turf/simulated/wall,
 /area/maintenance/lower/solars)
+"auL" = (
+/obj/structure/closet/crate/freezer,
+/obj/item/weapon/virusdish/random,
+/obj/item/weapon/virusdish/random,
+/obj/item/weapon/virusdish/random,
+/obj/item/weapon/virusdish/random,
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 1;
+	icon_state = "warningcorner"
+	},
+/obj/machinery/camera/network/medbay{
+	dir = 8;
+	icon_state = "camera"
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/lime/border{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/viro)
 "auM" = (
 /obj/structure/table/rack,
 /obj/random/junk,
@@ -12555,6 +12656,30 @@
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/plating,
 /area/maintenance/lower/xenoflora)
+"avk" = (
+/obj/structure/bed/chair/office/dark{
+	dir = 4
+	},
+/obj/effect/landmark/start{
+	name = "Medical Doctor"
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/lime/border{
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloorwhite/corner2{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/lime/bordercorner2{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/viro)
+"avl" = (
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/viro)
 "avm" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -13069,6 +13194,30 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/lower/solars)
+"avQ" = (
+/obj/structure/reagent_dispensers/virusfood{
+	density = 0;
+	pixel_y = 62
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/viro)
+"avR" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 4;
+	icon_state = "warningcorner"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/viro)
+"avS" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/red,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1;
+	icon_state = "warning"
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/viro)
 "avT" = (
 /turf/simulated/wall/r_wall,
 /area/maintenance/lower/xenoflora)
@@ -13130,6 +13279,21 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_one_hall)
+"avY" = (
+/obj/structure/bed/padded,
+/obj/item/weapon/bedsheet/green,
+/obj/machinery/camera/network/medbay{
+	dir = 8;
+	icon_state = "camera"
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/lime/border{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/viro/viroward)
 "avZ" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/red/border,
@@ -13362,6 +13526,162 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/lower/solars)
+"awu" = (
+/obj/item/weapon/stool/padded,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/lime/border{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/viro/viroward)
+"awv" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/viro/viroward)
+"aww" = (
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/paleblue/border,
+/obj/effect/floor_decal/borderfloorwhite/corner2,
+/obj/effect/floor_decal/corner/paleblue/bordercorner2,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/camera/network/medbay{
+	dir = 10;
+	icon_state = "camera"
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lowerhall)
+"awx" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lowerhall)
+"awy" = (
+/obj/structure/closet/secure_closet/paramedic,
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 6
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals9{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals9{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals9{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals9,
+/obj/machinery/camera/network/medbay{
+	dir = 8;
+	icon_state = "camera"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/tether/surfacebase/medical/paramed)
+"awz" = (
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/paleblue/border,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/light,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lowerhall)
+"awA" = (
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/paleblue/border,
+/obj/effect/floor_decal/borderfloorwhite/corner2{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner2{
+	dir = 9
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lowerhall)
+"awB" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lowerhall)
+"awC" = (
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/paleblue/border,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lowerhall)
 "awD" = (
 /obj/machinery/atmospherics/pipe/zpipe/up/scrubbers,
 /obj/machinery/atmospherics/pipe/zpipe/up/supply,
@@ -13380,6 +13700,57 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/plating,
 /area/maintenance/lower/xenoflora)
+"awE" = (
+/obj/machinery/door/firedoor/glass/hidden/steel{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/paleblue/border,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lowerhall)
+"awF" = (
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/paleblue/border,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lowerhall)
+"awG" = (
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/paleblue/border,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lowerhall)
 "awH" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -13556,6 +13927,278 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/lower/solars)
+"awV" = (
+/obj/effect/landmark{
+	name = "lightsout"
+	},
+/obj/effect/floor_decal/borderfloorwhite/corner{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lowerhall)
+"awW" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/access_button{
+	command = "cycle_exterior";
+	dir = 8;
+	frequency = 1379;
+	master_tag = "virology_airlock_control";
+	name = "Virology Access Button";
+	pixel_x = 24;
+	pixel_y = 25;
+	req_access = list(39)
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lowerhall)
+"awX" = (
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/medical{
+	autoclose = 0;
+	frequency = 1379;
+	icon_state = "door_locked";
+	id_tag = "virology_airlock_exterior";
+	locked = 1;
+	name = "Virology Exterior Airlock";
+	req_access = list(39)
+	},
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id = "virologyquar";
+	name = "Virology Emergency Quarantine Blast Doors";
+	opacity = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/viroairlock)
+"awY" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/access_button{
+	command = "cycle_exterior";
+	dir = 8;
+	frequency = 1379;
+	master_tag = "virology_airlock_control";
+	name = "Virology Access Button";
+	pixel_x = -24;
+	pixel_y = 25;
+	req_access = list(39)
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 6
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/viroairlock)
+"awZ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/viroairlock)
+"axa" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/access_button{
+	command = "cycle_interior";
+	dir = 8;
+	frequency = 1379;
+	master_tag = "virology_airlock_control";
+	name = "Virology Access Button";
+	pixel_x = 24;
+	pixel_y = 25;
+	req_access = list(39)
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/viroairlock)
+"axb" = (
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/medical{
+	autoclose = 0;
+	frequency = 1379;
+	icon_state = "door_locked";
+	id_tag = "virology_airlock_interior";
+	locked = 1;
+	name = "Virology Interior Airlock";
+	req_access = list(39)
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/viroairlock)
+"axc" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/access_button{
+	command = "cycle_interior";
+	dir = 8;
+	frequency = 1379;
+	master_tag = "virology_airlock_control";
+	name = "Virology Access Button";
+	pixel_x = -24;
+	pixel_y = 25;
+	req_access = list(39)
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/light_switch{
+	dir = 4;
+	pixel_x = -38;
+	pixel_y = -30
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 6
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/viro)
+"axd" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/yellow{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/viro)
 "axe" = (
 /obj/machinery/door/airlock/maintenance/engi{
 	name = "Elevator Maintenance"
@@ -13637,6 +14280,30 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_one_hall)
+"axj" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/landmark/start{
+	name = "Medical Doctor"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/viro)
 "axk" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/structure/cable{
@@ -13901,6 +14568,183 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/lower/solars)
+"axF" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/disease2/isolator,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/viro)
+"axG" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/viro)
+"axH" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/universal,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/viro)
+"axI" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/medical/viro/viroward)
+"axJ" = (
+/obj/structure/bed/padded,
+/obj/item/weapon/bedsheet/green,
+/obj/machinery/status_display{
+	pixel_x = 32;
+	pixel_y = 0
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/lime/border{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/viro/viroward)
+"axK" = (
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/glass_medical{
+	name = "Mental Health"
+	},
+/obj/machinery/door/blast/shutters{
+	closed_layer = 10;
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id = "medbayquar";
+	layer = 1;
+	name = "Medbay Emergency Lockdown Shutters";
+	opacity = 0;
+	open_layer = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lowerhall)
+"axL" = (
+/obj/structure/sign/nosmoking_1,
+/turf/simulated/wall,
+/area/tether/surfacebase/medical/lowerhall)
+"axM" = (
+/obj/machinery/vending/coffee{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 6
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lowerhall)
+"axN" = (
+/obj/machinery/vending/fitness{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lowerhall)
+"axO" = (
+/obj/machinery/vending/snack{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lowerhall)
+"axP" = (
+/obj/machinery/vending/medical{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 6
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lowerhall)
+"axQ" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 8
+	},
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -23;
+	pixel_y = 0
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lowerhall)
+"axR" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 4
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloorwhite/corner2{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner2{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lowerhall)
 "axS" = (
 /turf/simulated/floor/plating,
 /area/maintenance/lower/xenoflora)
@@ -14046,6 +14890,82 @@
 /obj/effect/floor_decal/steeldecal/steel_decals7,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_one_hall)
+"ayd" = (
+/obj/machinery/shower{
+	dir = 4;
+	icon_state = "shower";
+	pixel_x = 2;
+	pixel_y = 0
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 6
+	},
+/obj/structure/curtain/open/shower/medical,
+/turf/simulated/floor/tiled/steel,
+/area/tether/surfacebase/medical/viroairlock)
+"aye" = (
+/obj/structure/table/standard,
+/obj/random/medical,
+/obj/machinery/power/apc{
+	dir = 2;
+	name = "south bump";
+	pixel_y = -32
+	},
+/obj/structure/cable/green,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/viroairlock)
+"ayf" = (
+/obj/structure/sink{
+	dir = 4;
+	icon_state = "sink";
+	pixel_x = 11;
+	pixel_y = 0
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/viroairlock)
+"ayg" = (
+/obj/machinery/embedded_controller/radio/airlock/access_controller{
+	dir = 4;
+	id_tag = "virology_airlock_control";
+	name = "Virology Access Console";
+	pixel_x = -28;
+	pixel_y = -6;
+	tag_exterior_door = "virology_airlock_exterior";
+	tag_interior_door = "virology_airlock_interior"
+	},
+/obj/machinery/button/remote/blast_door{
+	desc = "A remote control-switch for shutters.";
+	dir = 4;
+	id = "virologyquar";
+	name = "Virology Emergency Lockdown Control";
+	pixel_x = -28;
+	pixel_y = 6;
+	req_access = list(5)
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/lime/border{
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloorwhite/corner2{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/lime/bordercorner2{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/viro)
 "ayh" = (
 /turf/simulated/wall,
 /area/crew_quarters/locker/laundry_arrival)
@@ -14055,6 +14975,56 @@
 	},
 /turf/simulated/wall,
 /area/crew_quarters/locker/laundry_arrival)
+"ayj" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/table/glass,
+/obj/machinery/computer/med_data/laptop{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/viro)
+"ayk" = (
+/obj/structure/table/glass,
+/obj/item/device/radio{
+	anchored = 1;
+	broadcasting = 0;
+	canhear_range = 7;
+	frequency = 1487;
+	icon = 'icons/obj/items.dmi';
+	icon_state = "red_phone";
+	listening = 1;
+	name = "Virology Emergency Phone";
+	pixel_x = -6;
+	pixel_y = 8
+	},
+/obj/item/weapon/paper_bin{
+	pixel_x = 1;
+	pixel_y = 8
+	},
+/obj/item/weapon/folder/white,
+/obj/item/weapon/pen,
+/obj/item/device/antibody_scanner,
+/obj/item/device/antibody_scanner{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/viro)
+"ayl" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
+	dir = 5
+	},
+/obj/machinery/hologram/holopad,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/viro)
 "aym" = (
 /obj/machinery/door/firedoor/glass/hidden/steel{
 	dir = 2
@@ -14143,6 +15113,226 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/rnd/hallway)
+"ayt" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5;
+	icon_state = "intact-scrubbers"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/yellow,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/viro)
+"ayu" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/yellow{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/viro)
+"ayv" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/viro)
+"ayw" = (
+/obj/machinery/door/airlock/glass_medical{
+	name = "Virology Laboratory";
+	req_access = list(39)
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/viro/viroward)
+"ayx" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 6
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/viro/viroward)
+"ayy" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/viro/viroward)
+"ayz" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
+	dir = 10
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/viro/viroward)
+"ayA" = (
+/obj/structure/bed/padded,
+/obj/item/weapon/bedsheet/green,
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1";
+	pixel_x = 0
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/lime/border{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/viro/viroward)
+"ayB" = (
+/obj/machinery/door/firedoor/glass/hidden/steel,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lowerhall)
+"ayC" = (
+/obj/machinery/door/firedoor/glass/hidden/steel{
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloorwhite/corner2{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner2{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lowerhall)
+"ayD" = (
+/obj/machinery/door/firedoor/glass,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/maintenance/medical{
+	locked = 1;
+	name = "Medical Maintenance Access";
+	req_access = list(5)
+	},
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/medical/viroairlock)
+"ayE" = (
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/lime/border{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/viro)
+"ayF" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/viro)
 "ayG" = (
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_one_hall)
@@ -14158,6 +15348,75 @@
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_one_hall)
+"ayK" = (
+/obj/effect/landmark{
+	name = "lightsout"
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/viro)
+"ayL" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/viro)
+"ayM" = (
+/obj/structure/table/glass,
+/obj/item/weapon/storage/box/monkeycubes,
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1";
+	pixel_x = 0
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/lime/border{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloorwhite/corner2{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/lime/bordercorner2{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/viro)
+"ayN" = (
+/obj/machinery/light_switch{
+	dir = 4;
+	pixel_x = -28
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/lime/border{
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloorwhite/corner2{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/lime/bordercorner2{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/viro/viroward)
+"ayO" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/viro/viroward)
+"ayP" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/viro/viroward)
 "ayQ" = (
 /obj/machinery/status_display{
 	pixel_y = 30
@@ -14257,6 +15516,54 @@
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/locker/laundry_arrival)
+"ayX" = (
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/obj/item/device/radio/intercom{
+	dir = 4;
+	name = "Station Intercom (General)";
+	pixel_x = 24
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/lime/border{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/viro/viroward)
+"ayY" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lowerhall)
+"ayZ" = (
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lowerhall)
+"aza" = (
+/obj/structure/stairs/east,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lowerhall)
+"azb" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/surfacebase/lowmedbaymaint)
 "azc" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -14503,6 +15810,225 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/hallway)
+"azu" = (
+/obj/item/device/radio{
+	pixel_x = -4
+	},
+/obj/item/weapon/reagent_containers/spray/cleaner{
+	desc = "Someone has crossed out the Space from Space Cleaner and written in Virology. 'Do not remove under punishment of death!!!' is scrawled on the back.";
+	name = "Virology Cleaner";
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/weapon/hand_labeler,
+/obj/structure/table/glass,
+/obj/machinery/camera/network/medbay{
+	dir = 4;
+	icon_state = "camera"
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/lime/border{
+	dir = 10
+	},
+/obj/effect/floor_decal/borderfloorwhite/corner2{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/lime/bordercorner2{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/viro)
+"azv" = (
+/obj/structure/table/glass,
+/obj/item/weapon/storage/fancy/vials,
+/obj/item/weapon/reagent_containers/syringe/antiviral,
+/obj/item/weapon/reagent_containers/syringe/antiviral,
+/obj/item/weapon/reagent_containers/syringe/antiviral,
+/obj/item/weapon/reagent_containers/syringe/antiviral,
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/lime/border,
+/obj/effect/floor_decal/borderfloorwhite/corner2,
+/obj/effect/floor_decal/corner/lime/bordercorner2,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/viro)
+"azw" = (
+/obj/structure/table/glass,
+/obj/item/weapon/storage/lockbox/vials,
+/obj/item/weapon/reagent_containers/dropper,
+/obj/item/weapon/storage/secure/safe{
+	pixel_y = -28
+	},
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/lime/border,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/viro)
+"azx" = (
+/obj/structure/table/glass,
+/obj/item/weapon/storage/box/beakers,
+/obj/item/weapon/storage/box/syringes{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/lime/border,
+/obj/effect/floor_decal/borderfloorwhite/corner2{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/lime/bordercorner2{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/viro)
+"azy" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/yellow{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/viro)
+"azz" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/viro)
+"azA" = (
+/obj/machinery/vending/snack{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/lime/border{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/viro/viroward)
+"azB" = (
+/obj/structure/table/standard,
+/obj/item/weapon/soap/nanotrasen,
+/obj/item/weapon/storage/box/cups,
+/obj/machinery/alarm{
+	dir = 1;
+	icon_state = "alarm0";
+	pixel_y = -22
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloorwhite,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/viro/viroward)
+"azC" = (
+/obj/structure/reagent_dispensers/water_cooler/full{
+	dir = 4
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloorwhite,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/viro/viroward)
+"azD" = (
+/obj/machinery/disposal,
+/obj/effect/floor_decal/industrial/warning/full,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/viro/viroward)
+"azE" = (
+/obj/structure/railing,
+/obj/machinery/camera/network/medbay{
+	dir = 10;
+	icon_state = "camera"
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lowerhall)
+"azF" = (
+/obj/structure/stairs/east,
+/obj/structure/railing,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lowerhall)
+"azG" = (
+/obj/structure/disposalpipe/tagger{
+	dir = 2;
+	name = "package tagger - Void";
+	sort_tag = "Void"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/surfacebase/lowmedbaymaint)
+"azH" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/medical/viro)
+"azI" = (
+/obj/machinery/door/window/eastright{
+	dir = 1;
+	name = "Virology Isolation Room One";
+	req_one_access = list(39)
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/floor_decal/corner/lime{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/lime{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/viro)
+"azJ" = (
+/obj/machinery/door/window/eastright{
+	dir = 1;
+	name = "Virology Isolation Room Two";
+	req_one_access = list(39)
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/floor_decal/corner/lime{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/lime{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/viro)
+"azK" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 6
+	},
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 22;
+	pixel_y = 0
+	},
+/obj/machinery/light,
+/obj/effect/floor_decal/borderfloorwhite/corner2,
+/obj/effect/floor_decal/borderfloorwhite/corner2{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner2{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner2,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lowerhall)
 "azL" = (
 /obj/machinery/door/firedoor/glass/hidden/steel{
 	dir = 1
@@ -14606,6 +16132,64 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_one_hall)
+"azT" = (
+/turf/simulated/wall,
+/area/tether/surfacebase/medical/recoveryward/storage)
+"azU" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/maintenance/medical{
+	name = "Medical Maintenance Access";
+	req_access = list(5)
+	},
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/medical/recoveryward/storage)
+"azV" = (
+/turf/simulated/wall,
+/area/tether/surfacebase/medical/viro)
+"azW" = (
+/obj/structure/closet/secure_closet/personal/patient,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/obj/machinery/camera/network/medbay{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/lime{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/lime{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/viro)
+"azX" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/lime{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/lime{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/viro)
+"azY" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/lime{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/lime{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/viro)
 "azZ" = (
 /obj/machinery/alarm{
 	dir = 4;
@@ -14621,6 +16205,94 @@
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/locker/laundry_arrival)
+"aAa" = (
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/medical{
+	id_tag = "MedicalRecovery";
+	name = "Recovery Room"
+	},
+/obj/machinery/door/blast/shutters{
+	closed_layer = 10;
+	density = 0;
+	dir = 8;
+	icon_state = "shutter0";
+	id = "medbayquar";
+	layer = 1;
+	name = "Medbay Emergency Lockdown Shutters";
+	opacity = 0;
+	open_layer = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/recoveryward)
+"aAb" = (
+/obj/machinery/vending/loadout/uniform,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 9
+	},
+/obj/effect/floor_decal/borderfloorwhite/corner2{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner2{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/recoveryward/storage)
+"aAc" = (
+/obj/structure/bed/chair/wheelchair{
+	dir = 8
+	},
+/obj/structure/sign/poster{
+	pixel_y = 32
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/recoveryward/storage)
+"aAd" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 5
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/recoveryward/storage)
+"aAe" = (
+/obj/structure/bed/padded,
+/obj/machinery/alarm{
+	dir = 1;
+	icon_state = "alarm0";
+	pixel_y = -22
+	},
+/obj/effect/floor_decal/corner/lime{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/lime{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/viro)
 "aAf" = (
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/steeldecal/steel_decals_central1{
@@ -14630,6 +16302,246 @@
 	dir = 1
 	},
 /area/crew_quarters/locker/laundry_arrival)
+"aAg" = (
+/obj/machinery/light,
+/obj/effect/floor_decal/corner/lime{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/lime{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/viro)
+"aAh" = (
+/obj/structure/table/standard,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/machinery/status_display{
+	layer = 4;
+	pixel_y = -32
+	},
+/obj/effect/floor_decal/corner/lime{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/lime{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/viro)
+"aAi" = (
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/glass_medical{
+	req_one_access = list()
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/recoveryward/storage)
+"aAj" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/light_switch{
+	pixel_y = 25
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 6
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/recoveryward/storage)
+"aAk" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/recoveryward/storage)
+"aAl" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/recoveryward/storage)
+"aAm" = (
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 22;
+	pixel_y = 0
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/recoveryward/storage)
+"aAn" = (
+/obj/structure/closet/secure_closet/personal/patient,
+/obj/machinery/power/apc{
+	cell_type = /obj/item/weapon/cell/super;
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/structure/cable/green,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 10
+	},
+/obj/effect/floor_decal/borderfloorwhite/corner2{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner2{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/recoveryward/storage)
+"aAo" = (
+/obj/structure/bed/padded,
+/obj/item/weapon/bedsheet/medical,
+/obj/structure/curtain/open/privacy,
+/obj/machinery/camera/network/medbay{
+	dir = 8;
+	icon_state = "camera"
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/recoveryward)
+"aAp" = (
+/obj/machinery/door/airlock/glass_medical,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/recoveryward)
+"aAq" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5;
+	icon_state = "intact-scrubbers"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 6
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/recoveryward/storage)
+"aAr" = (
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/maintenance/medical{
+	name = "Medical Maintenance Access";
+	req_access = list(5)
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/medical/recoveryward/storage)
 "aAs" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -14709,6 +16621,145 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/hallway)
+"aAz" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/surfacebase/lowmedbaymaint)
+"aAA" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/surfacebase/lowmedbaymaint)
+"aAB" = (
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 28
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/portable_atmospherics/powered/scrubber/huge/stationary/phoronlock{
+	frequency = 1379;
+	scrub_id = "northciv_airlock_scrubber"
+	},
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/tether/surfacebase/lowernortheva)
+"aAC" = (
+/obj/structure/bed/padded,
+/obj/item/weapon/bedsheet/green,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/lime/border{
+	dir = 5
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/viro/viroward)
+"aAD" = (
+/turf/simulated/wall,
+/area/maintenance/surfacebase/lowmedbaymaint)
+"aAE" = (
+/turf/simulated/wall,
+/area/tether/surfacebase/medical/bathroom)
+"aAF" = (
+/obj/machinery/door/airlock/medical{
+	name = "Rest Room";
+	req_one_access = list()
+	},
+/obj/machinery/door/firedoor/glass,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/bathroom)
+"aAG" = (
+/turf/simulated/mineral,
+/area/maintenance/surfacebase/lowmedbaymaint)
+"aAH" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plating,
+/area/maintenance/surfacebase/lowmedbaymaint)
+"aAI" = (
+/turf/simulated/floor/plating,
+/area/maintenance/surfacebase/lowmedbaymaint)
+"aAJ" = (
+/obj/machinery/portable_atmospherics/powered/scrubber/huge/stationary/phoronlock{
+	frequency = 1379;
+	scrub_id = "northciv_airlock_scrubber"
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/tether/surfacebase/lowernortheva)
+"aAK" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24;
+	pixel_y = 0
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/bathroom)
+"aAL" = (
+/obj/machinery/light_switch{
+	pixel_y = 25
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/bathroom)
 "aAM" = (
 /obj/structure/closet/crate,
 /obj/random/maintenance/engineering,
@@ -14769,6 +16820,310 @@
 /obj/random/contraband,
 /turf/simulated/floor/plating,
 /area/tether/surfacebase/surface_one_hall)
+"aAT" = (
+/obj/structure/sink{
+	pixel_y = 22
+	},
+/obj/structure/mirror{
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/bathroom)
+"aAU" = (
+/obj/machinery/washing_machine,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/bathroom)
+"aAV" = (
+/obj/structure/table/standard,
+/obj/random/soap,
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/bathroom)
+"aAW" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor,
+/area/maintenance/surfacebase/lowmedbaymaint)
+"aAX" = (
+/obj/structure/cable/green{
+	icon_state = "16-0"
+	},
+/obj/structure/cable/green{
+	icon_state = "0-8"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/zpipe/up/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/zpipe/up/scrubbers{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/surfacebase/lowmedbaymaint)
+"aAY" = (
+/obj/machinery/power/apc{
+	cell_type = /obj/item/weapon/cell/super;
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/light/small{
+	dir = 1;
+	icon_state = "bulb1"
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/bathroom)
+"aAZ" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5;
+	icon_state = "intact-scrubbers"
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/bathroom)
+"aBa" = (
+/obj/effect/landmark{
+	name = "morphspawn"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/bathroom)
+"aBb" = (
+/obj/effect/landmark{
+	name = "lightsout"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/bathroom)
+"aBc" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/bathroom)
+"aBd" = (
+/obj/machinery/light/small,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/bathroom)
+"aBe" = (
+/obj/structure/table/standard,
+/obj/random/soap,
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 22;
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/bathroom)
+"aBf" = (
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/bathroom)
+"aBg" = (
+/obj/machinery/door/airlock/medical{
+	name = "Rest Room";
+	req_one_access = list()
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/bathroom)
+"aBh" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/surfacebase/lowmedbaymaint)
+"aBi" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/surfacebase/lowmedbaymaint)
+"aBj" = (
+/obj/machinery/recharge_station,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/tether/surfacebase/medical/bathroom)
+"aBk" = (
+/obj/structure/toilet{
+	dir = 1
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/bathroom)
+"aBl" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/light,
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/obj/structure/mirror{
+	dir = 4;
+	pixel_x = -25
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/bathroom)
+"aBm" = (
+/obj/effect/floor_decal/steeldecal/steel_decals5,
+/obj/effect/floor_decal/steeldecal/steel_decals5{
+	dir = 1
+	},
+/obj/structure/curtain/open/shower/medical,
+/obj/machinery/shower{
+	dir = 8;
+	pixel_x = -2
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 9
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 10
+	},
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/bathroom)
+"aBn" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloorwhite/corner2{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner2{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lowerhall)
+"aBo" = (
+/obj/machinery/door/airlock/maintenance/common,
+/obj/machinery/door/firedoor/glass,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/surfacebase/lowmedbaymaint)
+"aBp" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/surfacebase/lowmedbaymaint)
+"aBq" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/surfacebase/lowmedbaymaint)
+"aBr" = (
+/obj/machinery/button/remote/airlock{
+	desc = "A remote control switch for the medbay recovery room door.";
+	dir = 4;
+	id = "MedicalRecovery";
+	name = "Exit Button";
+	pixel_x = -26;
+	pixel_y = 26
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 6
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/recoveryward)
+"aBs" = (
+/obj/machinery/hologram/holopad,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/recoveryward)
+"aBt" = (
+/obj/structure/closet/secure_closet/personal/patient,
+/obj/machinery/light,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/paleblue/border,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/recoveryward/storage)
 "aBu" = (
 /obj/structure/cable/heavyduty{
 	icon_state = "0-2"
@@ -14795,6 +17150,159 @@
 /obj/machinery/door/firedoor/glass/hidden/steel,
 /turf/simulated/floor/tiled,
 /area/rnd/hallway)
+"aBx" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/lowernorthhall)
+"aBy" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/lightgrey/border,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/lowernorthhall)
+"aBz" = (
+/obj/machinery/power/apc{
+	name = "south bump";
+	pixel_x = 0;
+	pixel_y = -32
+	},
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_x = -13;
+	pixel_y = -30
+	},
+/obj/structure/cable,
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/lightgrey/border,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/lowernorthhall)
+"aBA" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/brown/border,
+/obj/machinery/door/firedoor/glass/hidden/steel{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/lowernorthhall)
+"aBB" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/brown/border,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/lowernorthhall)
+"aBC" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/brown/border,
+/obj/structure/extinguisher_cabinet{
+	dir = 1;
+	icon_state = "extinguisher_closed";
+	pixel_y = -32
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/lowernorthhall)
+"aBD" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/lowernorthhall)
+"aBE" = (
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -25
+	},
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/brown/border,
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/brown/bordercorner2{
+	dir = 9
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/lowernorthhall)
+"aBF" = (
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/lowernorthhall)
+"aBG" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/brown/border,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/lowernorthhall)
 "aBH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/junk,
@@ -14916,6 +17424,21 @@
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/locker/laundry_arrival)
+"aBW" = (
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/brown/bordercorner{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/lowernorthhall)
+"aBX" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/lowernorthhall)
 "aBY" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
@@ -15015,6 +17538,136 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/hallway)
+"aCg" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner2{
+	dir = 6
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 9
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 10
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/lowernorthhall)
+"aCh" = (
+/obj/machinery/door/firedoor/glass,
+/obj/structure/window/reinforced/polarized/full{
+	id = "ward_tint"
+	},
+/obj/structure/grille,
+/obj/machinery/door/blast/shutters{
+	closed_layer = 10;
+	density = 0;
+	dir = 8;
+	icon_state = "shutter0";
+	id = "medbayquar";
+	layer = 1;
+	name = "Medbay Emergency Lockdown Shutters";
+	opacity = 0;
+	open_layer = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/medical/recoveryward)
+"aCi" = (
+/obj/structure/table/glass,
+/obj/item/weapon/folder/white,
+/obj/item/device/healthanalyzer,
+/obj/item/weapon/cane,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloorwhite/corner2{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner2{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/recoveryward)
+"aCj" = (
+/obj/machinery/button/windowtint{
+	id = "ward_tint";
+	pixel_x = -24;
+	pixel_y = 8;
+	range = 12
+	},
+/obj/effect/landmark{
+	name = "lightsout"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/recoveryward)
+"aCk" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/recoveryward)
+"aCl" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloorwhite/corner{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/recoveryward)
 "aCm" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 9
@@ -15057,6 +17710,58 @@
 /obj/effect/floor_decal/steeldecal/steel_decals7,
 /turf/simulated/floor/tiled,
 /area/rnd/hallway)
+"aCp" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
+/obj/machinery/light_switch{
+	pixel_x = -24;
+	pixel_y = 30
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/recoveryward)
+"aCq" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/scrubbers,
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/maintenance/common{
+	name = "Mining Maintenance Access"
+	},
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/lowernorthhall)
+"aCr" = (
+/turf/simulated/wall,
+/area/tether/surfacebase/cargostore/warehouse)
 "aCs" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 5
@@ -15290,14 +17995,35 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/vacant/vacant_site/east)
+"aCL" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/mining,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/steel_grid,
+/area/tether/surfacebase/cargostore/warehouse)
+"aCM" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 5
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 6
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/lowernorthhall)
 "aCN" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/effect/floor_decal/borderfloor{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/lightgrey/border{
 	dir = 1
 	},
 /obj/machinery/light{
@@ -15307,6 +18033,9 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 1
+	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_one_hall)
 "aCO" = (
@@ -15364,6 +18093,86 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/hallway)
+"aCW" = (
+/obj/structure/table/glass,
+/obj/item/weapon/paper_bin{
+	pixel_y = 4
+	},
+/obj/item/weapon/pen{
+	pixel_y = 4
+	},
+/obj/item/clothing/accessory/stethoscope,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/recoveryward)
+"aCX" = (
+/obj/structure/bed/chair/office/light{
+	dir = 8
+	},
+/obj/effect/landmark/start{
+	name = "Medical Doctor"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/recoveryward)
+"aCY" = (
+/obj/machinery/light,
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/paleblue/border,
+/obj/effect/floor_decal/borderfloorwhite/corner2{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner2{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/recoveryward)
+"aCZ" = (
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 22;
+	pixel_y = 0
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/recoveryward)
+"aDa" = (
+/obj/structure/plasticflaps,
+/obj/machinery/conveyor{
+	dir = 10;
+	id = "gloriouscargopipeline"
+	},
+/turf/simulated/floor/tiled/steel_dirty,
+/area/tether/surfacebase/cargostore/warehouse)
+"aDb" = (
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "gloriouscargopipeline"
+	},
+/turf/simulated/floor/tiled/steel_dirty,
+/area/tether/surfacebase/cargostore/warehouse)
 "aDc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -15502,6 +18311,22 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/hallway)
+"aDs" = (
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_x = 0;
+	pixel_y = 24
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/tiled/steel_dirty,
+/area/tether/surfacebase/cargostore/warehouse)
+"aDt" = (
+/turf/simulated/floor/tiled/steel_dirty,
+/area/tether/surfacebase/cargostore/warehouse)
 "aDu" = (
 /turf/simulated/floor/lino,
 /area/crew_quarters/visitor_dining)
@@ -15565,6 +18390,107 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/rnd/hallway)
+"aDA" = (
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/light_switch{
+	dir = 4;
+	pixel_x = -24;
+	pixel_y = -30
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/cargostore/office)
+"aDB" = (
+/obj/machinery/alarm{
+	pixel_y = 22
+	},
+/turf/simulated/floor/tiled/steel_dirty,
+/area/tether/surfacebase/cargostore/warehouse)
+"aDC" = (
+/obj/structure/closet/crate,
+/turf/simulated/floor/tiled/steel_dirty,
+/area/tether/surfacebase/cargostore/warehouse)
+"aDD" = (
+/obj/structure/table/rack,
+/turf/simulated/floor/tiled/steel_dirty,
+/area/tether/surfacebase/cargostore/warehouse)
+"aDE" = (
+/obj/structure/table/rack,
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/tiled/steel_dirty,
+/area/tether/surfacebase/cargostore/warehouse)
+"aDF" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/glass/hidden/steel,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 5
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 6
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/lowernorthhall)
+"aDG" = (
+/obj/machinery/door/firedoor/glass/hidden/steel{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/lowernorthhall)
+"aDH" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/glass/hidden/steel{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 10
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/lowernorthhall)
+"aDI" = (
+/obj/structure/table/glass,
+/obj/machinery/computer/med_data/laptop{
+	dir = 4
+	},
+/obj/item/device/radio/intercom/department/medbay{
+	dir = 8;
+	pixel_x = -24
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/recoveryward)
 "aDJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
@@ -15593,6 +18519,12 @@
 /obj/structure/stairs/north,
 /turf/simulated/floor/tiled,
 /area/rnd/hallway)
+"aDM" = (
+/obj/structure/undies_wardrobe,
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/paleblue/border,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/recoveryward)
 "aDN" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -15664,6 +18596,51 @@
 	dir = 1
 	},
 /area/tether/surfacebase/surface_one_hall)
+"aDU" = (
+/obj/machinery/disposal/deliveryChute{
+	dir = 1
+	},
+/obj/machinery/conveyor{
+	dir = 1;
+	id = "gloriouscargopipeline"
+	},
+/obj/structure/disposalpipe/trunk,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/steel_dirty,
+/area/tether/surfacebase/cargostore/warehouse)
+"aDV" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/conveyor_switch/oneway{
+	id = "gloriouscargopipeline";
+	name = "Mining Ops conveyor switch";
+	pixel_x = -5;
+	pixel_y = -3;
+	req_access = list(48);
+	req_one_access = list(48)
+	},
+/turf/simulated/floor/tiled/steel_dirty,
+/area/tether/surfacebase/cargostore/warehouse)
+"aDW" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/steel_dirty,
+/area/tether/surfacebase/cargostore/warehouse)
 "aDX" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
@@ -15724,6 +18701,15 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/tram)
+"aEd" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel_dirty,
+/area/tether/surfacebase/cargostore/warehouse)
 "aEe" = (
 /obj/machinery/light{
 	dir = 4;
@@ -15751,6 +18737,81 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/rnd/hallway)
+"aEf" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
+/turf/simulated/floor/tiled/steel_dirty,
+/area/tether/surfacebase/cargostore/warehouse)
+"aEg" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel_dirty,
+/area/tether/surfacebase/cargostore/warehouse)
+"aEh" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel_dirty,
+/area/tether/surfacebase/cargostore/warehouse)
+"aEi" = (
+/obj/structure/table/rack,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel_dirty,
+/area/tether/surfacebase/cargostore/warehouse)
+"aEj" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/sign/warning/moving_parts{
+	desc = "A warning sign for moving parts. This one states 'Put your gathered ore here for processing!' on it.";
+	name = "To Mining Operations Processing";
+	pixel_x = -32
+	},
+/obj/structure/closet/crate,
+/turf/simulated/floor/tiled/steel_dirty,
+/area/tether/surfacebase/cargostore/warehouse)
+"aEk" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel_dirty,
+/area/tether/surfacebase/cargostore/warehouse)
+"aEl" = (
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/steel_dirty,
+/area/tether/surfacebase/cargostore/warehouse)
 "aEm" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled,
@@ -15775,6 +18836,12 @@
 /obj/effect/floor_decal/steeldecal/steel_decals9,
 /turf/simulated/floor/tiled/monotile,
 /area/rnd/hallway)
+"aEo" = (
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/steel_dirty,
+/area/tether/surfacebase/cargostore/warehouse)
 "aEp" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -15926,6 +18993,13 @@
 	},
 /turf/simulated/floor/tiled/monofloor,
 /area/tether/surfacebase/surface_one_hall)
+"aEG" = (
+/obj/structure/table/rack,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/steel_dirty,
+/area/tether/surfacebase/cargostore/warehouse)
 "aEH" = (
 /obj/effect/floor_decal/steeldecal/steel_decals6{
 	dir = 10
@@ -16048,6 +19122,112 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/hallway)
+"aEU" = (
+/obj/structure/table/rack,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/machinery/light,
+/turf/simulated/floor/tiled/steel_dirty,
+/area/tether/surfacebase/cargostore/warehouse)
+"aEV" = (
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/steel_dirty,
+/area/tether/surfacebase/cargostore/warehouse)
+"aEW" = (
+/obj/structure/table/rack,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/steel_dirty,
+/area/tether/surfacebase/cargostore/warehouse)
+"aEX" = (
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/lightgrey/bordercorner{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 10
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/lowernorthhall)
+"aEY" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 2
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/lowernorthhall)
+"aEZ" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/bed/chair,
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/lowernorthhall)
+"aFa" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/machinery/camera/network/cargo,
+/obj/structure/bed/chair,
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/lowernorthhall)
+"aFb" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 5
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 30
+	},
+/obj/structure/flora/pottedplant/stoutbush,
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 5
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/lowernorthhall)
+"aFc" = (
+/obj/machinery/door/firedoor/multi_tile,
+/obj/machinery/door/airlock/multi_tile/metal{
+	name = "Shop Warehouse";
+	req_one_access = list(48)
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/tether/surfacebase/cargostore/warehouse)
+"aFd" = (
+/turf/simulated/floor/tiled/steel_grid,
+/area/tether/surfacebase/cargostore/warehouse)
 "aFe" = (
 /obj/effect/floor_decal/steeldecal/steel_decals5{
 	dir = 1
@@ -16228,6 +19408,33 @@
 	},
 /turf/simulated/floor/plating,
 /area/vacant/vacant_site/east)
+"aFt" = (
+/obj/machinery/door/airlock/glass_mining{
+	name = "Warehouse"
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/tiled/steel_grid,
+/area/tether/surfacebase/cargostore/warehouse)
+"aFu" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 2;
+	icon_state = "pipe-j2"
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/lowernorthhall)
+"aFv" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/lowernorthhall)
 "aFw" = (
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/steeldecal/steel_decals_central1,
@@ -16495,6 +19702,29 @@
 	},
 /turf/simulated/wall,
 /area/maintenance/lower/research)
+"aFO" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/lowernorthhall)
+"aFP" = (
+/obj/machinery/hologram/holopad,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/lowernorthhall)
+"aFQ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/lowernorthhall)
 "aFR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -16582,6 +19812,58 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/hallway)
+"aFZ" = (
+/obj/structure/table/glass,
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/machinery/computer/guestpass{
+	dir = 8;
+	pixel_x = 25
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/lowernorthhall)
+"aGa" = (
+/turf/simulated/wall,
+/area/tether/surfacebase/cargostore)
+"aGb" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 9
+	},
+/obj/structure/table/rack,
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/cargostore)
+"aGc" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 1
+	},
+/obj/structure/table/rack,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8;
+	pixel_x = -4
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/cargostore)
 "aGd" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 10
@@ -16591,6 +19873,131 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/hallway)
+"aGe" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/cargostore)
+"aGf" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/cargostore)
+"aGg" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 1
+	},
+/obj/structure/table/rack,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/cargostore)
+"aGh" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 5
+	},
+/obj/structure/table/rack,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8;
+	pixel_x = -4
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/cargostore)
+"aGi" = (
+/obj/effect/floor_decal/corner/brown{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/brown{
+	dir = 6
+	},
+/obj/machinery/alarm{
+	pixel_y = 22
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/cargostore)
+"aGj" = (
+/turf/simulated/wall,
+/area/tether/surfacebase/cargostore/office)
+"aGk" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 9
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 10;
+	icon_state = "borderfloorcorner2";
+	pixel_x = 0
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/brown/bordercorner2{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/brown/bordercorner2{
+	dir = 10
+	},
+/obj/machinery/power/apc{
+	cell_type = /obj/item/weapon/cell/super;
+	dir = 1;
+	name = "north bump";
+	pixel_y = 24
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/cargostore/office)
+"aGl" = (
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/cargostore/office)
 "aGm" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -16666,6 +20073,36 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/hallway)
+"aGr" = (
+/obj/structure/bed/chair/sofa/brown/right,
+/obj/effect/floor_decal/borderfloor{
+	dir = 1;
+	pixel_y = 0
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/brown/bordercorner2{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/cargostore/office)
+"aGs" = (
+/obj/structure/bed/chair/sofa/brown/corner,
+/obj/effect/landmark/start{
+	name = "Cargo Technician"
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 5
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/cargostore/office)
 "aGt" = (
 /turf/simulated/wall,
 /area/vacant/vacant_site/east)
@@ -16678,6 +20115,20 @@
 	},
 /turf/simulated/floor/plating,
 /area/vacant/vacant_site/east)
+"aGv" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/lowernorthhall)
+"aGw" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/lowernorthhall)
 "aGx" = (
 /obj/machinery/power/apc{
 	cell_type = /obj/item/weapon/cell/super;
@@ -16787,17 +20238,203 @@
 	},
 /turf/simulated/floor/virgo3b,
 /area/tether/surfacebase/outside/outside1)
-"aGV" = (
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/brown/border,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+"aGJ" = (
+/obj/structure/table/glass,
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/machinery/newscaster{
+	pixel_x = 30;
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/tether/surfacebase/cargo/mining)
+/area/tether/surfacebase/lowernorthhall)
+"aGK" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/power/apc{
+	cell_type = /obj/item/weapon/cell/super;
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/cargostore)
+"aGL" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/cargostore)
+"aGM" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/cargostore)
+"aGN" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/cargostore)
+"aGO" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/cargostore)
+"aGP" = (
+/obj/effect/floor_decal/corner/brown{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/brown{
+	dir = 6
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/cargostore)
+"aGQ" = (
+/obj/machinery/door/airlock/glass_mining{
+	id_tag = "cargodoor";
+	name = "Cargo Office";
+	req_access = list(31);
+	req_one_access = list()
+	},
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/tether/surfacebase/cargostore/office)
+"aGS" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/cargostore/office)
+"aGT" = (
+/obj/machinery/computer/security/telescreen/entertainment{
+	desc = "Looks like it's on MTV. Now you can't blame that demi-cowgirl for working her money maker. I wonder what else is on?";
+	icon_state = "frame";
+	pixel_x = 16;
+	pixel_y = 64
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/cargostore/office)
+"aGU" = (
+/obj/structure/bed/chair/sofa/brown/left{
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/cargostore/office)
+"aGV" = (
+/obj/effect/floor_decal/borderfloor/corner,
+/obj/effect/floor_decal/corner/lightgrey/bordercorner,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 9
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/lowernorthhall)
 "aGW" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/mauve/border,
@@ -16946,6 +20583,29 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/lower/research)
+"aHh" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = -24
+	},
+/obj/structure/reagent_dispensers/water_cooler/full,
+/obj/effect/floor_decal/corner/lightgrey/border,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/lowernorthhall)
+"aHi" = (
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloor,
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -25
+	},
+/obj/effect/floor_decal/corner/lightgrey/border,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/lowernorthhall)
 "aHj" = (
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 10
@@ -16954,6 +20614,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/vacant/vacant_site/east)
+"aHk" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey/border,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/lowernorthhall)
 "aHl" = (
 /obj/machinery/camera/network/civilian{
 	dir = 4
@@ -17006,6 +20674,46 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/hallway)
+"aHq" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 6
+	},
+/obj/structure/flora/pottedplant/stoutbush,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 6
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/lowernorthhall)
+"aHr" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 8
+	},
+/obj/structure/table/rack,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/cargostore)
+"aHs" = (
+/obj/structure/table/rack,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8;
+	pixel_x = -4
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/cargostore)
 "aHt" = (
 /obj/machinery/door/firedoor/glass,
 /obj/structure/cable/green{
@@ -17060,6 +20768,23 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/lower/research)
+"aHz" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/cargostore)
+"aHA" = (
+/obj/effect/landmark{
+	name = "lightsout"
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/cargostore)
 "aHB" = (
 /obj/machinery/atmospherics/pipe/simple/visible/scrubbers{
 	dir = 4
@@ -17103,6 +20828,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/lower/research)
+"aHF" = (
+/obj/structure/table/rack,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/cargostore)
 "aHG" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
@@ -17130,33 +20865,38 @@
 	},
 /turf/simulated/floor/plating,
 /area/crew_quarters/visitor_dining)
+"aHK" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/cargostore)
 "aHL" = (
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/tiled/steel_dirty/virgo3b,
 /area/tether/surfacebase/outside/outside1)
 "aHM" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_x = 0;
-	pixel_y = -25
+/obj/structure/disposalpipe/trunk,
+/obj/structure/disposaloutlet,
+/obj/machinery/conveyor{
+	id = "surfacecargo"
 	},
-/obj/structure/bed/chair/sofa/brown/corner{
-	dir = 4
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 10
-	},
-/obj/effect/floor_decal/corner/brown/border{
-	dir = 10
-	},
-/obj/effect/landmark/start{
-	name = "Cargo Technician"
-	},
-/obj/machinery/light/small{
+/obj/structure/window/reinforced{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/cargo/office)
+/obj/structure/sign/warning{
+	desc = "A warning sign. It has great big words saying 'Surface Cargo Deliveries. Stay behind the railings when active!' on it.";
+	name = "Surface Cargo Delivery";
+	pixel_x = 32
+	},
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/cargostore)
 "aHN" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -17191,6 +20931,80 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
+"aHQ" = (
+/obj/machinery/disposal,
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/brown/bordercorner2{
+	dir = 8
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/cargostore/office)
+"aHR" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/cargostore/office)
+"aHS" = (
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/cargostore/office)
+"aHT" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/cargostore/office)
+"aHU" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 9
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 10
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/lowernorthhall)
+"aHV" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/maintenance/common{
+	name = "Mining Maintenance Access"
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/cargostore)
 "aHW" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -17352,6 +21166,29 @@
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_one_hall)
+"aIq" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 6
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/cargostore)
 "aIr" = (
 /obj/structure/bed/chair/wood,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -17362,6 +21199,17 @@
 	},
 /turf/simulated/floor/lino,
 /area/crew_quarters/visitor_dining)
+"aIs" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/cargostore)
 "aIt" = (
 /obj/structure/bed/chair/wood,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -17429,13 +21277,19 @@
 /turf/simulated/floor/lino,
 /area/crew_quarters/visitor_dining)
 "aIA" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
 	dir = 8;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/lower/mining_eva)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/cargostore)
 "aIB" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -17857,6 +21711,45 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_one_hall)
+"aJj" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/cargostore)
+"aJk" = (
+/obj/structure/table/rack,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/cargostore)
+"aJl" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/loading{
+	dir = 8;
+	icon_state = "loadingarea"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/cargostore)
 "aJm" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/reagent_containers/food/condiment/small/sugar,
@@ -17946,6 +21839,18 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/rnd/hallway)
+"aJt" = (
+/obj/structure/railing,
+/obj/machinery/conveyor{
+	dir = 5;
+	id = "surfacecargo"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/cargostore)
 "aJu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/green{
@@ -18000,6 +21905,79 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
+"aJy" = (
+/obj/structure/table/standard,
+/obj/item/weapon/stamp/cargo,
+/obj/item/weapon/stamp/denied{
+	pixel_x = 4;
+	pixel_y = -2
+	},
+/obj/item/weapon/clipboard,
+/obj/item/weapon/folder/yellow,
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/cargostore/office)
+"aJz" = (
+/obj/structure/table/standard,
+/obj/item/weapon/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/weapon/pen/red{
+	pixel_x = 2;
+	pixel_y = 6
+	},
+/obj/item/device/retail_scanner/civilian,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/cargostore/office)
+"aJA" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/cargostore/office)
+"aJB" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 4
+	},
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 22;
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/cargostore/office)
+"aJC" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 8
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 5
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 6
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/lowernorthhall)
 "aJD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -18140,6 +22118,46 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_one_hall)
+"aJS" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/lowernorthhall)
+"aJT" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 4
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 9
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 10
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/lowernorthhall)
+"aJU" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/cargostore)
 "aJV" = (
 /obj/structure/bed/chair/wood{
 	dir = 1
@@ -18210,6 +22228,42 @@
 "aKa" = (
 /turf/simulated/wall,
 /area/maintenance/asmaint2)
+"aKb" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/cargostore)
+"aKc" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9;
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/cargostore)
+"aKd" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/cargostore)
+"aKe" = (
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/cargostore)
+"aKf" = (
+/obj/effect/floor_decal/corner/brown{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/brown{
+	dir = 6
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/cargostore)
 "aKg" = (
 /obj/machinery/alarm{
 	dir = 4;
@@ -18504,6 +22558,25 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_one_hall)
+"aKG" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/window/northright{
+	dir = 4;
+	name = "Mailing Room";
+	req_access = list(50)
+	},
+/obj/structure/noticeboard{
+	pixel_y = 28
+	},
+/obj/machinery/door/blast/shutters{
+	dir = 8;
+	id = "surfcargooffice";
+	layer = 3.3;
+	name = "Cargo Office Shutters"
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/cargostore/office)
 "aKH" = (
 /obj/effect/floor_decal/steeldecal/steel_decals6{
 	dir = 8
@@ -18517,6 +22590,28 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_one_hall)
+"aKI" = (
+/obj/effect/landmark/start{
+	name = "Cargo Technician"
+	},
+/obj/structure/bed/chair/office/dark{
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 10
+	},
+/obj/machinery/button/remote/blast_door{
+	id = "surfcargooffice";
+	name = "Office Shutters";
+	pixel_x = -7;
+	pixel_y = 24;
+	req_access = list(31)
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/cargostore/office)
 "aKJ" = (
 /obj/machinery/light,
 /turf/simulated/floor/lino,
@@ -18563,6 +22658,38 @@
 /obj/effect/map_helper/airlock/door/int_door,
 /turf/simulated/floor/tiled/steel_grid,
 /area/rnd/external)
+"aKO" = (
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/brown/bordercorner{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/cargostore/office)
+"aKP" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/cargostore/office)
+"aKQ" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/cargostore/office)
+"aKR" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/lowernorthhall)
 "aKS" = (
 /obj/random/junk,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -18834,6 +22961,42 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/rnd/external)
+"aLt" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 10
+	},
+/obj/structure/table/rack,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/cargostore)
+"aLu" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/brown/border,
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/brown/bordercorner2{
+	dir = 9
+	},
+/obj/structure/table/rack,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8;
+	pixel_x = -4
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/machinery/light,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/cargostore)
 "aLv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -19126,6 +23289,12 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/rnd/external)
+"aLZ" = (
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/cargostore)
 "aMa" = (
 /obj/effect/floor_decal/steeldecal/steel_decals10{
 	dir = 6
@@ -19191,6 +23360,13 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/rnd/external)
+"aMe" = (
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/cargostore)
 "aMf" = (
 /obj/effect/floor_decal/rust,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -19513,6 +23689,14 @@
 /obj/effect/map_helper/airlock/door/ext_door,
 /turf/simulated/floor/tiled/steel_grid,
 /area/rnd/external)
+"aML" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/brown/border,
+/obj/effect/floor_decal/borderfloor/corner2,
+/obj/effect/floor_decal/corner/brown/bordercorner2,
+/obj/machinery/light,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/cargostore)
 "aMM" = (
 /obj/effect/floor_decal/rust,
 /obj/structure/closet,
@@ -20660,6 +24844,15 @@
 "aOR" = (
 /turf/simulated/wall/r_wall,
 /area/engineering/atmos/processing)
+"aOS" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 6
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/cargostore)
 "aOT" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -21695,6 +25888,19 @@
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/atmos)
+"aQE" = (
+/obj/effect/floor_decal/corner/brown{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/brown{
+	dir = 6
+	},
+/obj/machinery/computer/supplycomp{
+	dir = 1;
+	icon_state = "computer"
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/cargostore)
 "aQF" = (
 /obj/machinery/light{
 	dir = 8
@@ -22374,6 +26580,15 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/atmos/processing)
+"aRR" = (
+/obj/machinery/computer/supplycomp/control{
+	dir = 1
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/cargostore/office)
 "aRS" = (
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/atmospherics/pipe/simple/visible/green{
@@ -23379,6 +27594,21 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/atmos)
+"aTT" = (
+/obj/machinery/conveyor_switch{
+	id = "surfacecargo";
+	name = "Surface Cargo Delivery conveyor switch";
+	pixel_x = -10;
+	pixel_y = 14
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 10
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/cargostore/office)
 "aTU" = (
 /obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 6
@@ -24558,6 +28788,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/engineering/atmos/processing)
+"aVY" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/brown/border,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/cargostore/office)
 "aVZ" = (
 /obj/machinery/vending/boozeomat,
 /turf/simulated/floor/wood,
@@ -25548,6 +29784,19 @@
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/tiled/steel_dirty,
 /area/maintenance/lower/atmos)
+"aXQ" = (
+/obj/structure/filingcabinet/chestdrawer,
+/obj/effect/floor_decal/borderfloor{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 6
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/cargostore/office)
 "aXR" = (
 /obj/structure/window/reinforced,
 /obj/structure/closet/masks,
@@ -26199,6 +30448,21 @@
 /obj/effect/decal/cleanable/blood/oil,
 /turf/simulated/floor/plating,
 /area/vacant/vacant_bar)
+"aZg" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 10
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/brown/bordercorner2{
+	dir = 9
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/lowernorthhall)
 "aZh" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -26866,6 +31130,25 @@
 	},
 /turf/unsimulated/wall/planetary/virgo3b,
 /area/tether/surfacebase/outside/outside1)
+"baX" = (
+/obj/machinery/door/airlock/multi_tile/glass{
+	name = "Surface Cargo"
+	},
+/obj/machinery/door/firedoor/multi_tile,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/cargostore)
+"baY" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/blast/shutters{
+	dir = 2;
+	id = "surfcargooffice";
+	layer = 3.3;
+	name = "Cargo Office Shutters"
+	},
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/cargostore/office)
 "baZ" = (
 /obj/machinery/alarm{
 	dir = 4;
@@ -26874,6 +31157,32 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/lower/mining_eva)
+"bba" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/blast/shutters{
+	dir = 2;
+	id = "surfcargooffice";
+	layer = 3.3;
+	name = "Cargo Office Shutters"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/cargostore/office)
+"bbb" = (
+/obj/machinery/door/airlock/multi_tile/glass{
+	name = "Surface Cargo"
+	},
+/obj/machinery/door/firedoor/glass,
+/obj/effect/floor_decal/steeldecal/steel_decals_central1{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/monofloor{
+	dir = 8
+	},
+/area/tether/surfacebase/lowernorthhall)
 "bbc" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -26898,33 +31207,57 @@
 /turf/simulated/floor/plating,
 /area/maintenance/lower/mining_eva)
 "bbf" = (
-/obj/machinery/computer/supplycomp/control{
-	dir = 8;
-	icon_state = "computer"
-	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 5
-	},
-/obj/effect/floor_decal/corner/brown/border{
-	dir = 5
-	},
-/obj/effect/floor_decal/borderfloor/corner2{
+/obj/machinery/door/firedoor/glass,
+/obj/effect/floor_decal/steeldecal/steel_decals_central1{
 	dir = 4
 	},
-/obj/effect/floor_decal/corner/brown/bordercorner2{
+/turf/simulated/floor/tiled/monofloor{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/cargo/office)
+/area/tether/surfacebase/lowernorthhall)
+"bbg" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/maintenance/surfacebase/cargostoresubstation)
+"bbh" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/maintenance/surfacebase/cargostoresubstation)
+"bbi" = (
+/obj/machinery/door/airlock/engineering{
+	name = "CargoShop Substation";
+	req_one_access = list(11,24,50)
+	},
+/obj/machinery/door/firedoor/glass,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/maintenance/surfacebase/cargostoresubstation)
+"bbj" = (
+/turf/simulated/wall,
+/area/maintenance/surfacebase/medbaysubstation)
 "bbk" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
-	},
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 1
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals7,
 /obj/effect/floor_decal/steeldecal/steel_decals7{
@@ -26935,6 +31268,9 @@
 	layer = 3.3;
 	pixel_x = 0;
 	pixel_y = 26
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_one_hall)
@@ -26953,7 +31289,7 @@
 /obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 4
 	},
-/obj/effect/floor_decal/corner/lightgrey/border{
+/obj/effect/floor_decal/corner/brown/border{
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
@@ -26969,7 +31305,7 @@
 /obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 4
 	},
-/obj/effect/floor_decal/corner/lightgrey/border{
+/obj/effect/floor_decal/corner/brown/border{
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
@@ -27023,7 +31359,7 @@
 	pixel_y = 24;
 	req_access = list()
 	},
-/obj/effect/floor_decal/corner/lightgrey/border{
+/obj/effect/floor_decal/corner/brown/border{
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
@@ -27052,17 +31388,30 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_one_hall)
 "bbr" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/blast/shutters{
-	dir = 8;
-	id = "surfcargooffice";
-	layer = 3.3;
-	name = "Cargo Office Shutters"
+/obj/machinery/door/firedoor/glass,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/plating,
-/area/tether/surfacebase/cargo/office)
+/obj/machinery/door/airlock/engineering{
+	name = "Medbay Substation";
+	req_one_access = list(11,24,5)
+	},
+/turf/simulated/floor,
+/area/maintenance/surfacebase/medbaysubstation)
+"bbs" = (
+/obj/structure/cable/green,
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/smes/buildable{
+	RCon_tag = "Substation - CargoShop";
+	output_attempt = 0
+	},
+/turf/simulated/floor,
+/area/maintenance/surfacebase/cargostoresubstation)
 "bbt" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 5
@@ -27071,20 +31420,42 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
-/obj/effect/floor_decal/corner/brown/border{
+/obj/machinery/status_display{
+	pixel_x = 32
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
 	dir = 5
 	},
 /obj/effect/floor_decal/borderfloor/corner2{
 	dir = 4
 	},
-/obj/effect/floor_decal/corner/brown/bordercorner2{
+/obj/effect/floor_decal/corner/lightgrey/bordercorner2{
 	dir = 4
-	},
-/obj/machinery/status_display{
-	pixel_x = 32
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_one_hall)
+"bbu" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/machinery/power/terminal{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/simulated/floor,
+/area/maintenance/surfacebase/cargostoresubstation)
+"bbv" = (
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 28
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor,
+/area/maintenance/surfacebase/cargostoresubstation)
 "bbw" = (
 /obj/structure/table/rack,
 /obj/random/maintenance/cargo,
@@ -27092,57 +31463,122 @@
 /obj/random/maintenance/medical,
 /turf/simulated/floor/plating,
 /area/maintenance/lower/mining_eva)
-"bbA" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
+"bbx" = (
+/obj/machinery/power/breakerbox/activated{
+	RCon_tag = "Medical2 Substation Bypass"
+	},
+/turf/simulated/floor,
+/area/maintenance/surfacebase/medbaysubstation)
+"bby" = (
+/obj/effect/floor_decal/industrial/warning{
 	dir = 8
 	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/corner/brown/border{
-	dir = 4
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 0
+	dir = 1
 	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/cargo/office)
+/turf/simulated/floor,
+/area/maintenance/surfacebase/medbaysubstation)
+"bbz" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/maintenance/surfacebase/medbaysubstation)
+"bbA" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/engineering{
+	name = "Medbay Substation";
+	req_one_access = list(11,24,5)
+	},
+/turf/simulated/floor,
+/area/maintenance/surfacebase/medbaysubstation)
 "bbB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
 	icon_state = "pipe-c"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/cobweb,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/lower/mining_eva)
 "bbC" = (
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/brown/border,
-/obj/structure/bed/chair/sofa/brown/right{
+/obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/cargo/office)
+/obj/structure/cable/green,
+/obj/structure/cable/green{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/sensor{
+	name = "Powernet Sensor - CargoShop Subgrid";
+	name_tag = "CargoShop Subgrid"
+	},
+/turf/simulated/floor,
+/area/maintenance/surfacebase/cargostoresubstation)
+"bbD" = (
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/camera/network/engineering{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/maintenance/surfacebase/cargostoresubstation)
 "bbE" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/maintenance/lower/mining_eva)
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -25
+	},
+/turf/simulated/floor,
+/area/maintenance/surfacebase/cargostoresubstation)
 "bbF" = (
-/obj/structure/filingcabinet/chestdrawer,
-/obj/effect/floor_decal/borderfloor{
-	dir = 6
+/obj/machinery/door/firedoor/glass,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/corner/brown/border{
-	dir = 6
+/obj/machinery/door/airlock/engineering{
+	name = "CargoShop Substation";
+	req_one_access = list(11,24,50)
 	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/cargo/office)
+/turf/simulated/floor,
+/area/maintenance/surfacebase/cargostoresubstation)
 "bbG" = (
 /obj/machinery/door/airlock/maintenance/common,
 /obj/structure/disposalpipe/segment,
@@ -27163,6 +31599,59 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/hallway/lower/first_west)
+"bbI" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4;
+	icon_state = "warning"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/surfacebase/medbaysubstation)
+"bbJ" = (
+/obj/structure/cable/green,
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/smes/buildable{
+	RCon_tag = "Substation - Medical2";
+	output_attempt = 0
+	},
+/turf/simulated/floor,
+/area/maintenance/surfacebase/medbaysubstation)
+"bbK" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/machinery/power/terminal{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/simulated/floor,
+/area/maintenance/surfacebase/medbaysubstation)
+"bbL" = (
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 28
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/maintenance/surfacebase/medbaysubstation)
+"bbM" = (
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 4;
+	icon_state = "warningcorner"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/surfacebase/medbaysubstation)
 "bbN" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -27267,24 +31756,107 @@
 /obj/random/maintenance/medical,
 /turf/simulated/floor/plating,
 /area/maintenance/lower/mining_eva)
-"bbW" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/blast/shutters{
-	dir = 2;
-	id = "surfcargooffice";
-	layer = 3.3;
-	name = "Cargo Office Shutters"
+"bbV" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
 	},
-/turf/simulated/floor/plating,
-/area/tether/surfacebase/cargo/office)
+/obj/structure/cable/green,
+/obj/structure/cable/green{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/sensor{
+	name = "Powernet Sensor - Medical2 Subgrid";
+	name_tag = "Medical2 Subgrid"
+	},
+/turf/simulated/floor,
+/area/maintenance/surfacebase/medbaysubstation)
+"bbW" = (
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/camera/network/engineering{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/maintenance/surfacebase/medbaysubstation)
 "bbX" = (
 /obj/machinery/door/airlock/maintenance/common,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/plating,
 /area/maintenance/lower/xenoflora)
+"bbY" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -25
+	},
+/turf/simulated/floor,
+/area/maintenance/surfacebase/medbaysubstation)
+"bbZ" = (
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/surfacebase/lowmedbaymaint)
+"bca" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/brown/border,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = -24
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/lowernorthhall)
+"bcb" = (
+/obj/structure/closet/secure_closet/personal/patient,
+/obj/machinery/camera/network/medbay{
+	dir = 10;
+	icon_state = "camera"
+	},
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/paleblue/border,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/recoveryward/storage)
+"bcc" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 1
+	},
+/obj/machinery/camera/network/medbay,
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/lowernorthhall)
 "bcd" = (
 /turf/simulated/mineral,
 /area/maintenance/lower/xenoflora)
@@ -27297,14 +31869,33 @@
 /turf/simulated/floor/plating,
 /area/maintenance/lower/mining_eva)
 "bcf" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/maintenance/lower/mining_eva)
-"bcg" = (
-/obj/structure/table/rack,
-/obj/random/maintenance/cargo,
-/turf/simulated/floor/plating,
-/area/maintenance/lower/mining_eva)
+/obj/structure/table/glass,
+/obj/item/weapon/storage/box/gloves{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/weapon/storage/box/masks,
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/obj/structure/cable/green{
+	icon_state = "0-8"
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/lime/border{
+	dir = 6
+	},
+/obj/effect/floor_decal/borderfloorwhite/corner2,
+/obj/effect/floor_decal/corner/lime/bordercorner2,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/viro)
 "bch" = (
 /obj/random/junk,
 /turf/simulated/floor/plating,
@@ -27628,19 +32219,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos/processing)
-"bcQ" = (
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 25;
-	pixel_y = 0
-	},
-/obj/effect/floor_decal/rust,
-/turf/simulated/floor/plating,
-/area/maintenance/lower/mining_eva)
-"bcR" = (
-/obj/effect/floor_decal/rust,
-/turf/simulated/floor/plating,
-/area/maintenance/lower/mining_eva)
 "bcS" = (
 /obj/structure/closet/crate,
 /obj/random/maintenance/cargo,
@@ -28114,28 +32692,9 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/public_garden_one)
-"beE" = (
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/brown/border,
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 9
-	},
-/obj/effect/floor_decal/corner/brown/bordercorner2{
-	dir = 9
-	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_x = 0;
-	pixel_y = -24
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
-	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/cargo/mining)
+"blL" = (
+/turf/simulated/floor,
+/area/tether/surfacebase/outside/outside1)
 "byn" = (
 /obj/effect/floor_decal/steeldecal/steel_decals6,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -28435,6 +32994,22 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/hallway)
+"cKC" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lowerhall)
 "cOq" = (
 /obj/random/cutout,
 /turf/simulated/floor/plating,
@@ -28458,6 +33033,25 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/looking_glass/lg_1)
+"cPX" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner2{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/lowernorthhall)
 "cWS" = (
 /obj/item/device/radio/beacon,
 /turf/simulated/floor/tiled,
@@ -28476,6 +33070,31 @@
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/locker/laundry_arrival)
+"doa" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 10
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 9
+	},
+/obj/machinery/camera/network/tether{
+	dir = 9
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/surface_one_hall)
+"dxY" = (
+/obj/structure/table/rack,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/suit/storage/hooded/wintercoat,
+/obj/item/weapon/tank/emergency/oxygen/engi,
+/turf/simulated/floor/tiled/techfloor,
+/area/tether/surfacebase/lowernortheva)
 "dCc" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -28505,13 +33124,10 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_one_hall)
-"dYe" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/cargo/mining)
+"dYd" = (
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/outside/outside1)
 "dZW" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
@@ -28536,18 +33152,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/tram)
-"ecq" = (
-/obj/structure/catwalk,
-/obj/machinery/atmospherics/pipe/simple/visible/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/visible/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/lower/mining_eva)
 "efV" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -28594,6 +33198,15 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_one_hall)
+"erc" = (
+/obj/structure/sign/nosmoking_2{
+	pixel_y = 30
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/tether/surfacebase/lowernortheva)
 "evF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -28611,18 +33224,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/locker)
-"eGO" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/cargo/mining)
 "eIL" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -28724,10 +33325,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/xenoflora)
-"fYi" = (
-/obj/random/cutout,
-/turf/simulated/floor/plating,
-/area/construction/vacant_mining_ops)
 "ghg" = (
 /obj/effect/floor_decal/steeldecal/steel_decals6{
 	dir = 5
@@ -28808,12 +33405,45 @@
 /obj/effect/floor_decal/corner/mauve/border,
 /turf/simulated/floor/tiled,
 /area/rnd/hallway)
+"goJ" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
+	},
+/obj/effect/landmark{
+	name = "lightsout"
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/surface_one_hall)
 "guV" = (
 /obj/structure/closet,
 /obj/random/drinkbottle,
 /obj/random/maintenance/cargo,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/vacant_site)
+"gvC" = (
+/obj/structure/catwalk,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -23;
+	pixel_y = 0
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/lower/trash_pit)
+"gwo" = (
+/obj/structure/catwalk,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/lower/trash_pit)
 "gxa" = (
 /obj/effect/floor_decal/borderfloor/corner{
 	dir = 1
@@ -28855,6 +33485,22 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/hallway)
+"gJK" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/lowernorthhall)
 "gOA" = (
 /obj/structure/railing{
 	dir = 1;
@@ -28904,6 +33550,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/lower/research)
+"hgx" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/junction{
+	dir = 2;
+	icon_state = "pipe-j2"
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/lowernorthhall)
 "hmx" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -28955,6 +33610,22 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/hallway)
+"hpB" = (
+/obj/machinery/door/firedoor/glass,
+/obj/effect/map_helper/airlock/door/int_door,
+/obj/machinery/door/airlock/glass_external{
+	frequency = 1379;
+	icon_state = "door_locked";
+	id_tag = "northciv_airlock_inner";
+	locked = 1
+	},
+/obj/machinery/access_button/airlock_interior{
+	master_tag = "northciv_airlock";
+	pixel_x = 25;
+	pixel_y = -8
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/tether/surfacebase/lowernortheva)
 "huE" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -28991,6 +33662,20 @@
 /obj/effect/landmark/looking_glass,
 /turf/simulated/floor/looking_glass/center,
 /area/looking_glass/lg_1)
+"hPU" = (
+/obj/structure/catwalk,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/lower/mining_eva)
 "hQP" = (
 /obj/structure/catwalk,
 /obj/structure/cable{
@@ -29034,6 +33719,21 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_one_hall)
+"hYh" = (
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/effect/map_helper/airlock/door/int_door,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/glass_external{
+	frequency = 1379;
+	icon_state = "door_locked";
+	id_tag = "northciv_airlock_inner";
+	locked = 1
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/tether/surfacebase/lowernortheva)
 "icB" = (
 /obj/effect/floor_decal/borderfloor/corner{
 	dir = 8
@@ -29056,6 +33756,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/rnd/hallway)
+"igw" = (
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/lowernorthhall)
 "imW" = (
 /obj/structure/railing{
 	dir = 4
@@ -29162,16 +33865,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_one_hall)
-"jKO" = (
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/brown/border,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/cargo/mining)
 "jPk" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/visible/scrubbers,
@@ -29183,6 +33876,26 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/lower/mining_eva)
+"jQL" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 1
+	},
+/obj/machinery/camera/network/medbay,
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner2{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/lowernorthhall)
 "jSU" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/mauve/border,
@@ -29230,15 +33943,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_one_hall)
-"kxe" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/cargo/mining)
 "kyE" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -29380,6 +34084,24 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_one_hall)
+"lbu" = (
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/paleblue/border,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloorwhite/corner2,
+/obj/effect/floor_decal/corner/paleblue/bordercorner2,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lowerhall)
 "ldI" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -29402,6 +34124,18 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_one_hall)
+"lew" = (
+/obj/structure/bed/padded,
+/obj/item/weapon/bedsheet/medical,
+/obj/structure/curtain/open/privacy,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/recoveryward)
 "loc" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/manifold/visible/scrubbers{
@@ -29424,6 +34158,11 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/lower/mining_eva)
@@ -29475,6 +34214,15 @@
 /obj/machinery/holoposter,
 /turf/simulated/wall,
 /area/hallway/lower/first_west)
+"lBd" = (
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/bathroom)
 "lDW" = (
 /obj/structure/catwalk,
 /obj/structure/cable{
@@ -29517,6 +34265,21 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/hallway)
+"lMK" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/lime/border{
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloorwhite/corner2{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/lime/bordercorner2{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/viro/viroward)
 "lNp" = (
 /turf/simulated/floor/looking_glass/optional{
 	dir = 4;
@@ -29550,6 +34313,25 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_one_hall)
+"lUk" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 5
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 6
+	},
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube1"
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/lowernorthhall)
 "lWT" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -29627,6 +34409,21 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_one_hall)
+"mGH" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 9
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 10
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/lowernorthhall)
 "mGP" = (
 /obj/effect/floor_decal/steeldecal/steel_decals6{
 	dir = 10
@@ -29676,6 +34473,12 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/tether/surfacebase/tram)
+"mRY" = (
+/obj/structure/catwalk,
+/obj/machinery/door/airlock/maintenance/common,
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/plating,
+/area/maintenance/lower/vacant_site)
 "mSz" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
@@ -29719,6 +34522,17 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_one_hall)
+"naC" = (
+/turf/simulated/floor,
+/area/maintenance/lower/mining_eva)
+"ndH" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/lower/mining_eva)
 "nis" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/mauve/border,
@@ -29832,6 +34646,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/lower/mining_eva)
+"nKz" = (
+/obj/machinery/portable_atmospherics/powered/scrubber/huge/stationary{
+	scrub_id = "atrium"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/tether/surfacebase/outside/outside1)
 "ofS" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/mauve/border,
@@ -30011,6 +34831,9 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_one_hall)
+"pdo" = (
+/turf/simulated/mineral,
+/area/tether/surfacebase/lowernortheva)
 "poN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/catwalk,
@@ -30079,6 +34902,28 @@
 	dir = 8
 	},
 /area/tether/surfacebase/surface_one_hall)
+"qKZ" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/borderfloorwhite/corner2{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner2{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lowerhall)
 "qOA" = (
 /obj/structure/table/standard{
 	name = "plastic table frame"
@@ -30131,6 +34976,25 @@
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/locker/laundry_arrival)
+"qWW" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube1"
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 5
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 6
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/lowernorthhall)
 "raS" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
@@ -30148,19 +35012,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/tram)
-"rtx" = (
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -25
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
-	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/cargo/mining)
 "rxq" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -30185,15 +35036,25 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_one_hall)
-"rMk" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+"rKh" = (
+/obj/machinery/door/firedoor/glass,
+/obj/structure/window/reinforced/polarized/full{
+	id = "ward_tint"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/structure/grille,
+/obj/machinery/door/blast/shutters{
+	closed_layer = 10;
+	density = 0;
+	dir = 8;
+	icon_state = "shutter0";
+	id = "medbayquar";
+	layer = 1;
+	name = "Medbay Emergency Lockdown Shutters";
+	opacity = 0;
+	open_layer = 1
 	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/cargo/mining)
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/medical/recoveryward)
 "rRC" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -30433,20 +35294,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/lower/mining_eva)
-"sNu" = (
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 5
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/cargo/mining)
 "sQB" = (
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/airlock/glass,
@@ -30480,6 +35327,21 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/rnd/hallway)
+"tCi" = (
+/obj/structure/bed/padded,
+/obj/item/weapon/bedsheet/medical,
+/obj/structure/curtain/open/privacy,
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 6
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/recoveryward)
 "tCV" = (
 /obj/structure/catwalk,
 /obj/structure/cable{
@@ -30492,6 +35354,15 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
+/area/maintenance/lower/mining_eva)
+"tEo" = (
+/obj/random/trash_pile,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/mining_eva)
 "tLx" = (
 /obj/effect/floor_decal/industrial/warning,
@@ -30546,6 +35417,27 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_one_hall)
+"tRA" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/lightgrey/bordercorner2{
+	dir = 5
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 9
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 10
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/lowernorthhall)
 "tRJ" = (
 /obj/effect/floor_decal/spline/plain{
 	dir = 10;
@@ -30655,6 +35547,18 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_one_hall)
+"uHS" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 1
+	},
+/obj/machinery/firealarm{
+	pixel_y = 25
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lowerhall)
 "uKS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -30741,6 +35645,25 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/hallway)
+"vry" = (
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/paleblue/border,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = -24
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/recoveryward)
+"vCb" = (
+/obj/machinery/portable_atmospherics/powered/pump/filled,
+/turf/simulated/floor/plating,
+/area/maintenance/lower/mining_eva)
+"vCD" = (
+/obj/effect/floor_decal/borderfloorwhite/corner,
+/obj/effect/floor_decal/corner/paleblue/bordercorner,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/recoveryward)
 "vDb" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -30787,6 +35710,41 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_one_hall)
+"vHW" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/lower/mining_eva)
+"vPZ" = (
+/obj/structure/catwalk,
+/obj/effect/decal/cleanable/dirt,
+/obj/random/junk,
+/obj/random/junk,
+/obj/random/maintenance/clean,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/lower/trash_pit)
+"wjs" = (
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/bathroom)
+"wvn" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/recoveryward)
 "wxa" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -30854,22 +35812,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_one_hall)
-"xbP" = (
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/brown/border,
-/obj/structure/extinguisher_cabinet{
-	dir = 1;
-	icon_state = "extinguisher_closed";
-	pixel_y = -32
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
-	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/cargo/mining)
 "xgQ" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -30907,6 +35849,21 @@
 /obj/machinery/holoposter,
 /turf/simulated/wall,
 /area/crew_quarters/visitor_laundry)
+"xpP" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/lime/border{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloorwhite/corner2{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/lime/bordercorner2{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/viro)
 "xzn" = (
 /obj/effect/floor_decal/steeldecal/steel_decals6{
 	dir = 9
@@ -30946,6 +35903,12 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/looking_glass/lg_1)
+"xSa" = (
+/obj/machinery/door/airlock/maintenance/common,
+/obj/machinery/door/firedoor/glass,
+/obj/structure/catwalk,
+/turf/simulated/floor/tiled/techfloor,
+/area/tether/surfacebase/outside/outside1)
 "xYn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 4
@@ -30956,6 +35919,19 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/lower/mining_eva)
+"yaU" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/lowernorthhall)
 "ygY" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -30983,6 +35959,35 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/hallway)
+"yhd" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloorwhite/corner2{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner2{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/recoveryward)
 
 (1,1,1) = {"
 aaa
@@ -41100,11 +46105,11 @@ abT
 abT
 abT
 abT
-abT
-abT
-abT
-abT
-abT
+adt
+adt
+adt
+adt
+adt
 abT
 abT
 abT
@@ -41238,17 +46243,17 @@ aah
 aah
 aah
 abT
-cGJ
+vCb
 acS
 acS
 adp
-abT
-aah
-aah
-aah
-aah
-aah
-aah
+adt
+agd
+bbs
+bbC
+adt
+blL
+blL
 abT
 wzA
 ahr
@@ -41371,12 +46376,12 @@ aad
 aad
 aad
 aad
-aan
-aan
-aan
-aan
-aan
-aan
+aaq
+aaq
+aaq
+aaq
+pdo
+pdo
 aah
 aah
 abT
@@ -41384,13 +46389,13 @@ acj
 acX
 acX
 adL
-abT
-aah
-aah
-aah
-aah
-aah
-aah
+adt
+bbg
+bbu
+bbD
+adt
+blL
+blL
 abT
 tCV
 ahq
@@ -41513,26 +46518,26 @@ aae
 aae
 aaf
 aai
-aan
 aaq
-aav
-aay
+aaz
+aaM
 aaq
-aan
-aar
-aar
+aaq
+aaq
+aef
+aef
 abT
 acQ
 adl
 ado
 xYn
-abT
-abT
-abT
-abT
-abT
-abT
-aah
+adt
+bbh
+bbv
+bbE
+adt
+naC
+blL
 abT
 tCV
 ahs
@@ -41655,24 +46660,24 @@ aae
 aae
 aaf
 aak
-aan
-aas
-aas
-aas
-aas
-aan
-aaF
-aaK
-aar
-aar
-aar
-abT
+aaq
+aaA
+aaA
+aaq
+erc
+dxY
+ads
+aeg
+aef
+aef
+aef
+aef
 ajc
-abT
-agd
-acC
 adt
-ady
+bbi
+adt
+bbF
+adt
 abT
 abT
 abT
@@ -41797,23 +46802,23 @@ aae
 aae
 aaf
 aal
-aao
-aat
-aaw
-aaw
-aaz
+aas
 aaB
-aaG
-aaM
-aaP
-aaY
-abY
-ecq
+aaN
+hYh
+abZ
+acy
+adv
+aeh
+aeN
+afI
+aBx
+aCq
 nDD
 jPk
 lpK
 lDW
-lDW
+hPU
 cpD
 fBN
 fBN
@@ -41939,28 +46944,28 @@ aae
 aae
 aaf
 aaf
-aap
-aau
-aax
-aax
-aaA
+aat
 aaC
-aaH
-aaN
-aaS
-aaZ
-aar
-abT
+aaP
+hpB
+aca
+acB
+adx
+aes
+aeQ
+afJ
+aBy
+aef
 abT
 abT
 aeA
 alX
 amq
 amM
-abT
-abT
-abT
-atc
+cGJ
+vHW
+vHW
+anp
 abT
 ahX
 aiY
@@ -42081,25 +47086,25 @@ aaf
 aaf
 aaf
 aam
-aan
-aan
-aan
-aan
-aan
-aan
-aar
-aar
-abi
-aba
-abe
-abT
+aaq
+aAB
+aAJ
+aaq
+aaq
+aaq
+aef
+aef
+aeS
+afM
+aBz
+aef
 acg
 abT
 aeB
 afd
 afC
-agd
-abT
+tEo
+ndH
 bbB
 bbe
 bce
@@ -42223,29 +47228,29 @@ aaf
 aaf
 aaf
 aaf
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aar
-aaX
-eGO
-jKO
-acc
-acc
-acc
-acc
-acc
-acc
-acc
-acc
-bbE
-abT
-abT
-agM
+aAD
+aAD
+aAD
+aAD
+aAI
+aAI
+aAI
+aef
+aeZ
+afN
+aBA
+aCr
+aCr
+aCr
+aCr
+aCr
+aGa
+aGa
+aGa
+aHV
+aGa
+aGa
+aGa
 agM
 aja
 afh
@@ -42365,29 +47370,29 @@ aaf
 aaf
 aaf
 aaf
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aar
-aaX
-rMk
-aGV
-acc
-abZ
-abZ
-abZ
-acm
-agg
-afQ
-acc
-age
-air
-bcg
-agM
+aAD
+aAI
+aAI
+aAI
+aAI
+aAI
+aAI
+aef
+aeS
+afO
+aBB
+aCr
+aDa
+aDU
+aEj
+aCr
+aGb
+aGK
+aHr
+aIq
+aJU
+aLt
+aGa
 anD
 anU
 afp
@@ -42507,29 +47512,29 @@ aaf
 aaf
 aaf
 aaf
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aar
-aaX
-rMk
-xbP
-acc
-adS
-adS
-adS
-acn
-aeN
-aeF
-acc
-age
-bcf
-bcg
-agM
+aAD
+aAI
+aAI
+aAI
+aAI
+aAI
+aAI
+aef
+aeS
+afO
+aBC
+aCr
+aDb
+aDV
+aEk
+aCr
+aGc
+aGL
+aHs
+aIs
+aKb
+aLu
+aGa
 aic
 anV
 aoh
@@ -42649,31 +47654,31 @@ aaf
 aag
 aaf
 aaf
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aar
-abd
-dYe
-beE
-acc
-aca
-adS
-adS
-acn
-afN
-aeF
-acc
-age
-bcf
-bcR
-agM
+aAD
+aAI
+aAI
+aAI
+aAI
+aAI
+aAI
+aef
+afi
+afQ
+bca
+aCr
+aDs
+aDW
+aEl
+aFc
+aGe
+aGM
+aHz
+aIA
+aKc
+aLZ
+baX
 aid
-anW
+goJ
 aoi
 aoj
 aoj
@@ -42790,30 +47795,30 @@ aae
 aaf
 aaf
 aaf
-aaf
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aar
-aaX
-rMk
-rtx
-acc
-adS
-adS
-adS
-adS
-afN
-afL
-acc
-age
-bcQ
-air
-agM
+aao
+aao
+aao
+aao
+aao
+aao
+aao
+aao
+aao
+gJK
+afO
+aBE
+aCr
+aDt
+aEd
+aEo
+aFd
+aGf
+aGN
+aHA
+aJj
+aKd
+aMe
+aKd
 aie
 anW
 aoj
@@ -42932,30 +47937,30 @@ aad
 aad
 aad
 aad
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aar
-aaX
-kxe
-sNu
-adC
-abP
+aao
+aau
+aaF
+aaS
+abd
 acd
-acy
 acE
-adS
-afM
-acc
-age
-agM
-agM
-agM
+adC
+aao
+bcc
+afS
+aBF
+aCL
+aeC
+aEf
+aEG
+aCr
+aGg
+aGN
+aHF
+aJk
+aKe
+aML
+aGa
 aif
 anW
 aoj
@@ -43073,32 +48078,32 @@ aad
 aad
 aad
 aad
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aar
-abj
-abo
-abV
-afm
-ace
-ach
+aad
+aap
+aav
+aaG
+aaX
+abe
+acf
 acH
-acF
-adS
-aeJ
-ajb
-aIA
-agM
-ahc
-ahu
-aig
+adD
+aao
+afj
+age
+aBB
+aCr
+aDt
+aEg
+aEU
+aCr
+aGh
+aGO
+aHK
+aJl
+aHK
+aOS
+aGa
+bbm
 anW
 aoj
 aoS
@@ -43215,31 +48220,31 @@ aad
 aad
 aad
 aad
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aaE
-aaE
-aar
-aar
-aar
-aar
-acc
-acf
-ack
-acO
-acG
-adS
-agj
-acc
-asT
-amc
-amc
-amc
+aad
+aap
+aaw
+aaH
+aaY
+abi
+ach
+acL
+adG
+aev
+afk
+agg
+aBB
+aCr
+aDB
+aEh
+aDC
+aCr
+aGi
+aGP
+aHM
+aJt
+aKf
+aQE
+aGa
 bbk
 anW
 aoj
@@ -43357,31 +48362,31 @@ aad
 aad
 aad
 aad
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aaE
-aaL
-aaL
-aaL
-aaL
-aaL
-acc
-acc
-acc
-acc
-acI
-adT
-acc
-amc
-amP
-adR
-aHM
-amc
+aad
+aap
+aax
+aaK
+aaK
+abo
+aaK
+aaK
+adP
+aao
+cPX
+afO
+aBB
+aCr
+aDt
+aEh
+aDC
+aCr
+aGj
+aGQ
+aGj
+aGj
+aKG
+aGj
+aGj
 aii
 anW
 aoj
@@ -43499,31 +48504,31 @@ aad
 aad
 aad
 aad
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aaE
+aad
+aao
+aay
 aaL
-aaL
-aaL
-aaL
-aaL
-aaL
-aaL
-adf
-acK
-acM
-adZ
-aeS
-amw
-afS
-adU
-bbC
-amc
+aaZ
+abP
+acn
+awy
+adQ
+aao
+yaU
+afO
+aBB
+aCr
+aDC
+aEh
+aDt
+aCr
+aGk
+aDA
+aHQ
+aJy
+aKI
+aRR
+aGj
 bbl
 anX
 aoj
@@ -43641,31 +48646,31 @@ aad
 aad
 aad
 aad
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aaE
-aaL
-aaL
-aaL
-aaL
-aaL
-aaL
-aaL
-adf
-acL
-acP
-adv
-adB
-anF
-adQ
-aea
-aeg
-bbW
+aad
+aao
+aao
+aao
+aao
+abY
+aao
+aao
+aao
+aao
+yaU
+afO
+aBB
+aCr
+aDC
+aEh
+aEV
+aFt
+aGl
+aGS
+aHR
+aJz
+aKO
+aTT
+baY
 bbm
 anW
 aoj
@@ -43786,28 +48791,28 @@ aad
 aah
 aah
 aah
-aah
-aah
-aah
-aah
-aaE
-aaL
-aaL
-aaL
-aaL
-aaL
-aaL
-aaL
-adf
-acA
-acR
-aee
-aeZ
-amc
-adX
-afy
-afE
-afI
+aeU
+atc
+awx
+aeU
+aAI
+aAI
+aef
+yaU
+afO
+aBB
+aCr
+aDD
+aEh
+aDD
+aCr
+aGr
+aGT
+aHS
+aJA
+aKP
+aVY
+bba
 afK
 anW
 aoj
@@ -43928,28 +48933,28 @@ aad
 aah
 aah
 aah
-aah
-aah
-aah
-aah
-aaE
-aaL
-aaE
-aaL
-aaL
-aaL
-aaL
-aaL
-adf
-afO
-adg
-acY
-acY
-adE
-adY
-aed
-aeh
-amc
+aeU
+atq
+aww
+aeU
+aAI
+aAI
+aef
+afl
+agj
+aBG
+aCr
+aDE
+aEi
+aEW
+aCr
+aGs
+aGU
+aHT
+aJB
+aKQ
+aXQ
+aGj
 aCN
 anW
 aoj
@@ -44065,33 +49070,33 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aah
-aah
-aah
-aah
-aah
-aah
-aaE
-aaL
-aaE
-aaE
-aaL
-aaL
-aaL
-aaL
-adf
-acU
-adm
-aef
-afb
-amc
-bbf
-bbA
-bbF
-amc
+aan
+aan
+aan
+aan
+aan
+aan
+atI
+awz
+aeU
+aeU
+aeU
+aeU
+aBD
+afO
+aBB
+aCr
+aCr
+aCr
+aCr
+aCr
+aGj
+aGj
+aGj
+aGj
+aGj
+aGj
+aGj
 bbp
 anW
 aoj
@@ -44207,33 +49212,33 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aah
-aah
-aah
-aah
-aah
-aah
-aaE
-aaL
-aaL
-aaL
-aaL
-aaL
-aaL
-aaL
-adf
-aeE
-adq
-acY
+aan
+aaV
+aba
+acO
+adw
+aan
+atJ
+awA
 aeU
-amc
-bbr
-amc
-bbr
-amc
+acZ
+ade
+aeU
+jQL
+amw
+aBW
+aCM
+aDF
+aCM
+lUk
+aCM
+aCM
+aCM
+aCM
+aJC
+qWW
+aZg
+aef
 bbq
 anW
 aoj
@@ -44349,33 +49354,33 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aah
-aah
-aah
-aah
-aah
-aah
-aaE
-aaL
-aaL
-aaL
-aaL
-aaL
-aaL
-aaL
-adf
-adA
-adr
-aes
+aan
+abf
+acl
+acR
+ady
 aeY
-afn
-afs
-afx
-afB
-aeQ
+atN
+awB
+axK
+adb
+adR
+adU
+afo
+anF
+hgx
+aBX
+aDG
+aBX
+aBX
+aFu
+aGv
+aBX
+aBX
+aJS
+aKR
+aKR
+bbb
 agf
 anW
 aoi
@@ -44491,33 +49496,33 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aah
-aah
-aah
-aah
-aah
-aah
-aaE
-aaL
-aaL
-aaL
-adw
-adx
-abL
-abU
-acl
-acB
-ads
-agq
-acY
-aff
-afo
-afD
-afF
-afJ
+aan
+abj
+acm
+acU
+adA
+aan
+aBn
+lbu
+axL
+adc
+adS
+aeU
+afs
+asT
+aCg
+mGH
+aDH
+mGH
+aEX
+aFv
+aGw
+aGV
+aHU
+aJT
+tRA
+igw
+bbf
 ago
 anY
 aok
@@ -44632,34 +49637,34 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aah
-aah
-aah
-aah
-aah
-aah
-aaE
-aaL
-aaL
-aaL
-aaL
-aaL
-aaL
-aaL
-adf
-acZ
-adD
-aev
-afi
-adf
-adf
-adf
-adf
-agM
+aan
+aan
+abp
+abq
+acY
+adB
+aan
+atP
+awE
+aeU
+adr
+adr
+adr
+adr
+aAa
+aCh
+rKh
+adr
+adr
+aEY
+aFO
+aGw
+aHh
+aef
+aef
+aef
+aef
+aef
 bbt
 anZ
 aol
@@ -44667,8 +49672,8 @@ aoT
 apE
 aqh
 aqL
-aqh
-arB
+doa
+aqL
 ajA
 asf
 ass
@@ -44774,30 +49779,30 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aad
-aah
-aah
-aah
-aah
-aah
-aaE
-aaL
-aaE
-aaE
-aaL
-aaL
-aaL
-aaE
-adf
-adb
-adG
-aeC
-afj
-adf
+aan
+aaD
+abq
+acq
+acY
+adE
+aan
+uHS
+awF
+axM
+adr
+adX
+aeD
+afy
+aBr
+aCi
+aCW
+aDI
+adr
+aEZ
+aFP
+aGw
+aHi
+aef
 aah
 aah
 aah
@@ -44810,7 +49815,7 @@ agM
 agM
 aqM
 agM
-agM
+aqM
 agM
 asg
 ash
@@ -44913,33 +49918,33 @@ aad
 aad
 aad
 aad
+adK
 aad
 aad
-aad
-aad
-aad
-aad
-aad
-aad
-aad
-aah
-aah
-aah
-aah
+aar
 aaE
-aaL
-aaE
-fYi
-aaL
-aaL
-aaL
-aaL
+abr
+abr
 adf
-adc
-acY
-acY
-afk
-adf
+adT
+afb
+atO
+awC
+axN
+adr
+adY
+aeF
+afE
+aBs
+aCj
+aCX
+aDM
+adr
+aFa
+aFQ
+aGw
+aHk
+aef
 aah
 aah
 aah
@@ -44952,8 +49957,8 @@ guV
 apF
 ahc
 apF
-aah
-aah
+nKz
+adK
 ash
 ast
 asU
@@ -45058,30 +50063,30 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aad
-aad
-aah
-aah
-aah
-aah
-aaE
-aaL
-aaE
-aaL
-aaL
-aaL
-aaL
-aaL
-adf
-ade
-adP
-aeD
-afl
-adf
+aar
+aaI
+abL
+acA
+adg
+aea
+afb
+atO
+awC
+axO
+adr
+wvn
+aeJ
+afF
+afF
+aCk
+adZ
+vry
+adr
+aFb
+aFZ
+aGJ
+aHq
+aef
 aah
 aah
 aah
@@ -45094,8 +50099,8 @@ apG
 apF
 aqN
 apF
-aah
-aah
+xSa
+adK
 ash
 ast
 asU
@@ -45200,30 +50205,30 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aad
-aad
-aah
-aah
-aah
-aaU
-aaU
-aaI
-aaU
-aaU
-aaU
-aaU
-aaU
-aaU
-adf
-adf
-adf
-adf
-adf
-adf
+aar
+aaJ
+abU
+acC
+abL
+aei
+afb
+atO
+awG
+axP
+adr
+aed
+lew
+lew
+aAo
+aCl
+vCD
+tCi
+adr
+aef
+aef
+aef
+aef
+aef
 aah
 aah
 aah
@@ -45235,9 +50240,9 @@ ahx
 aaW
 aqi
 aqO
-apF
-aah
-aah
+mRY
+dYd
+dYd
 ash
 asu
 asU
@@ -45342,30 +50347,30 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aad
-aad
-aah
-aah
-aah
-aaU
-abH
-abH
-abX
-abX
-abH
-abH
-abX
-aei
-aaU
-aah
-aah
-aah
-aah
-aah
+aar
+aaO
+abV
+acF
+abL
+aek
+afb
+atO
+awz
+aeU
+adr
+aee
+aee
+aee
+adr
+yhd
+aCY
+aAE
+aAE
+aAY
+lBd
+aBg
+aBj
+aAE
 aah
 aah
 aah
@@ -45484,30 +50489,30 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aad
-aah
-aah
-aah
-aah
-aaU
-abH
-abH
-abH
-abX
-abX
-abH
-abH
-aek
-aaU
-aah
-aah
-aah
-aah
-aah
+aan
+aaR
+abL
+abL
+abL
+ael
+aan
+atQ
+awV
+axQ
+ayB
+ayY
+qKZ
+cKC
+aAp
+aCp
+aCZ
+aAF
+aAK
+aAZ
+aBf
+aAE
+aAE
+aAE
 aah
 aah
 aah
@@ -45623,33 +50628,33 @@ aad
 aad
 aad
 aad
+adK
 aad
 aad
-aad
-aad
-aad
-aad
-aad
-aad
-aah
-aah
-aah
-aah
-aaU
-aaD
-aaJ
-aaO
-acq
-aen
-abH
-abH
-aek
-aaU
-aah
-aah
-aah
-aah
-aah
+aan
+aan
+abX
+acG
+abX
+aan
+aan
+acP
+awW
+axR
+ayC
+ayZ
+ayZ
+azK
+aeU
+aAi
+azT
+aAE
+aAL
+aBa
+lBd
+aBg
+aBk
+aAE
 aah
 aah
 aah
@@ -45769,29 +50774,29 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aah
-aah
-aah
-aah
-aaU
-aaU
-aaU
-aaU
-aaU
-aaU
-abH
-abH
-ael
-aaU
-aah
-aah
-aah
-aah
-aaU
+aan
+acc
+acI
+adm
+aan
+aff
+aff
+awX
+aff
+aff
+ayZ
+azE
+azT
+azT
+aAj
+aAn
+aAE
+aAT
+aBb
+aAE
+aAE
+aAE
+aAE
 aaU
 aaU
 aaU
@@ -45911,32 +50916,32 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aad
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aaU
-abH
-abH
-aem
-aaU
-aah
-aah
-aah
-aah
-aaU
+aan
+ace
+acK
+adq
+aan
+aff
+auq
+awY
+ayd
+aff
+aza
+azF
+azT
+aAb
+aAk
+bcb
+aAE
+aAT
+aBc
+aBg
+wjs
+aBl
+aAE
 abs
 aby
-abq
+gvC
 abC
 abE
 aaU
@@ -46053,29 +51058,29 @@ aad
 aad
 aad
 aad
-aad
-aad
-aad
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aaU
-abH
-abH
-aaR
-aaU
-aaU
-aaU
-aaU
-aaU
-aaU
+aan
+aan
+aan
+aan
+aan
+aff
+aur
+awZ
+aye
+aff
+aeU
+aeU
+azT
+aAc
+aAl
+aBt
+aAE
+aAU
+aBd
+aAE
+aBf
+aBm
+aAE
 abt
 agQ
 anq
@@ -46200,24 +51205,24 @@ aad
 aad
 aah
 aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aaU
-abH
-abH
-abf
-abp
-abq
-abq
-abr
-abq
-abq
+aff
+auo
+axa
+ayf
+ayD
+azb
+azG
+azU
+aAd
+aAm
+aAq
+aAE
+aAV
+aBe
+aAE
+aAE
+aAE
+aAE
 abu
 anf
 ahg
@@ -46341,30 +51346,30 @@ aad
 aad
 aad
 aad
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aaU
-aaU
-aaU
-aaU
-aaU
-aaU
-aaU
-aaU
-aaU
-aaU
+aem
+afm
+afm
+axb
+afm
+afm
+aem
+aem
+azV
+azV
+azV
+aAr
+aAE
+aAE
+aAE
+aAE
+bbI
+bbM
+bbj
 agH
 agS
 anr
 ahB
-abH
+gwo
 aaU
 aaU
 aaU
@@ -46483,30 +51488,30 @@ aad
 aad
 aad
 aad
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aaU
+aem
+afn
+avk
+axc
+ayg
+ayE
+azu
+azH
+azW
+aAe
+aem
+aAz
+aAG
+aAG
+bbj
+bbx
+bbJ
+bbV
+bbj
 abH
 agT
-aaV
+abH
 agT
-agT
+vPZ
 aaU
 aah
 aah
@@ -46625,30 +51630,30 @@ aad
 aad
 aad
 aad
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
+aem
+afx
+avl
+axd
+ayj
+ayF
+azy
+azI
+azX
+aAg
+aem
+aAz
+aAG
+aAG
+bbj
+bby
+bbK
+bbW
+bbj
 aaU
 aaU
 aaU
 aaU
-aaU
-aaU
+aBo
 aaU
 aah
 aah
@@ -46767,31 +51772,31 @@ aad
 aad
 aad
 aad
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
+aem
+afB
+avQ
+axj
+ayk
+ayK
+azv
+azH
+azY
+aAh
+aem
+aAz
+aAG
+aAW
+bbr
+bbz
+bbL
+bbY
+bbj
+aAG
+aAG
+aAG
+aAG
+aBp
+aAD
 aah
 aah
 apF
@@ -46909,31 +51914,31 @@ aad
 aad
 aad
 aad
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
+aem
+afD
+avl
+axF
+ayl
+avl
+azw
+aem
+aem
+aem
+aem
+aAA
+aAH
+aAX
+bbj
+bbA
+bbj
+bbj
+bbj
+aAG
+aAG
+aAG
+aAI
+aBp
+aAD
 aah
 aah
 apF
@@ -47051,31 +52056,31 @@ aad
 aad
 aad
 aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
+aem
+afL
+avR
+axG
+ayt
+avl
+azx
+azH
+azW
+aAe
+aem
+aAI
+aAI
+aAI
+aAI
+aBh
+aBi
+aBi
+aBi
+aBi
+aBi
+aBi
+aBi
+aBq
+aAD
 aah
 aah
 apF
@@ -47193,31 +52198,31 @@ aad
 aad
 aad
 aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
+aem
+agq
+avS
+axH
+ayu
+ayL
+azz
+azJ
+azX
+aAg
+aem
+aAI
+aAI
+aAI
+aAI
+aAI
+aAI
+aAI
+aAI
+aAI
+aAI
+aAI
+aAI
+bbZ
+aAD
 aah
 aah
 apF
@@ -47332,34 +52337,34 @@ aad
 aad
 aad
 aad
-aad
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
+ack
+acM
+acM
+aen
+aig
+auL
+xpP
+ayv
+ayM
+bcf
+azH
+azY
+aAh
+aem
+aAD
+aAD
+aAD
+aAD
+aAD
+aAD
+aAD
+aAD
+aAD
+aAD
+aAD
+aAD
+aAD
+aAD
 aah
 aah
 apF
@@ -47477,17 +52482,17 @@ aad
 aad
 aah
 aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
+aeE
+aeE
+aeE
+axI
+ayw
+aeE
+aeE
+aeE
+aem
+aem
+aem
 aah
 aah
 aah
@@ -47619,14 +52624,14 @@ aad
 aad
 aah
 aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
+aeE
+ajb
+awu
+lMK
+ayx
+ayN
+azA
+aeE
 aah
 aah
 aah
@@ -47761,14 +52766,14 @@ aad
 aad
 aah
 aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
+aeE
+amc
+arB
+arB
+ayy
+ayO
+azB
+aeE
 aah
 aah
 aah
@@ -47903,14 +52908,14 @@ aad
 aad
 aah
 aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
+aeE
+amP
+awv
+awv
+ayz
+ayP
+azC
+aeE
 aah
 aah
 aah
@@ -48045,14 +53050,14 @@ aad
 aad
 aad
 aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
+aeE
+aAC
+avY
+axJ
+ayA
+ayX
+azD
+aeE
 aah
 aah
 aah
@@ -48187,14 +53192,14 @@ aad
 aad
 aad
 aad
-aad
-aah
-aah
-aah
-aah
-aah
-aah
-aah
+aeE
+aeE
+aeE
+aeE
+aeE
+aeE
+aeE
+aeE
 aah
 aah
 aah

--- a/maps/tether/tether-02-surface2.dmm
+++ b/maps/tether/tether-02-surface2.dmm
@@ -1360,7 +1360,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
-/area/maintenance/surfacebase/lowmedbaymaint)
+/area/maintenance/lowmedbaymaint)
 "acD" = (
 /turf/simulated/wall,
 /area/tether/surfacebase/outside/outside2)
@@ -21506,7 +21506,7 @@
 	dir = 8
 	},
 /turf/simulated/open,
-/area/maintenance/surfacebase/lowmedbaymaint)
+/area/maintenance/lowmedbaymaint)
 "aNA" = (
 /obj/structure/catwalk,
 /obj/structure/table/steel,
@@ -28465,10 +28465,10 @@
 /area/tether/surfacebase/medical/stairwell)
 "aYC" = (
 /turf/simulated/wall,
-/area/maintenance/surfacebase/lowmedbaymaint)
+/area/maintenance/lowmedbaymaint)
 "aYD" = (
 /turf/simulated/floor/tiled/techfloor,
-/area/maintenance/surfacebase/lowmedbaymaint)
+/area/maintenance/lowmedbaymaint)
 "aYE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{

--- a/maps/tether/tether-02-surface2.dmm
+++ b/maps/tether/tether-02-surface2.dmm
@@ -19,13 +19,23 @@
 /area/tether/surfacebase/medical/lowerhall)
 "aag" = (
 /turf/simulated/wall,
-/area/tether/surfacebase/medical/surgery)
+/area/tether/surfacebase/medical/patient_a)
 "aah" = (
 /turf/simulated/wall,
 /area/tether/surfacebase/medical/resleeving)
 "aai" = (
-/turf/simulated/floor/tiled/techfloor,
-/area/maintenance/lower/mining)
+/obj/structure/table/standard,
+/obj/item/weapon/storage/firstaid/toxin{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/item/weapon/storage/firstaid/toxin{
+	pixel_x = 0;
+	pixel_y = 0
+	},
+/obj/effect/floor_decal/corner/green/full,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/storage)
 "aaj" = (
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 9
@@ -44,6 +54,10 @@
 	icon_state = "alarm0";
 	pixel_x = -22;
 	pixel_y = 0
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/machinery/firealarm{
+	pixel_y = 25
 	},
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/lowerhall)
@@ -97,10 +111,6 @@
 /obj/structure/stairs/east,
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/lowerhall)
-"aar" = (
-/obj/structure/closet/firecloset,
-/turf/simulated/floor/tiled/techfloor,
-/area/tether/surfacebase/medical/lowerhall)
 "aas" = (
 /obj/structure/closet/secure_closet/warden,
 /obj/item/weapon/gun/projectile/shotgun/pump/combat{
@@ -146,25 +156,25 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/bar)
 "aav" = (
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 9
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
 	},
-/obj/effect/floor_decal/corner/white/border{
-	dir = 9;
-	icon_state = "bordercolor"
+/obj/structure/disposalpipe/sortjunction{
+	dir = 4;
+	name = "Reading Rooms"
 	},
-/obj/structure/table/standard,
-/obj/item/weapon/reagent_containers/spray/cleaner{
-	desc = "Someone has crossed out the Space from Space Cleaner and written in Surgery. 'Do not remove under punishment of death!!!' is scrawled on the back.";
-	name = "Surgery Cleaner";
-	pixel_x = 2;
-	pixel_y = 2
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/machinery/light{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/surgery)
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/lower/south)
 "aaw" = (
 /obj/machinery/power/breakerbox/activated{
 	RCon_tag = "MedSec Substation Bypass"
@@ -189,31 +199,8 @@
 /turf/simulated/floor,
 /area/maintenance/substation/medsec)
 "aay" = (
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 9
-	},
-/obj/effect/floor_decal/corner/white/border{
-	dir = 9;
-	icon_state = "bordercolor"
-	},
-/obj/effect/floor_decal/borderfloorwhite/corner2{
-	dir = 10
-	},
-/obj/effect/floor_decal/corner/white/bordercorner2{
-	dir = 10
-	},
-/obj/structure/table/standard,
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/machinery/light_switch{
-	dir = 2;
-	name = "light switch ";
-	on = 0;
-	pixel_x = 0;
-	pixel_y = 26
-	},
-/obj/item/stack/nanopaste,
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/surgery)
+/turf/simulated/wall,
+/area/maintenance/readingrooms)
 "aaz" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -225,26 +212,8 @@
 /turf/simulated/floor,
 /area/maintenance/substation/medsec)
 "aaA" = (
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 5
-	},
-/obj/effect/floor_decal/corner/white/border{
-	dir = 5
-	},
-/obj/effect/floor_decal/borderfloorwhite/corner2{
-	dir = 5
-	},
-/obj/effect/floor_decal/corner/white/bordercorner2{
-	dir = 5;
-	icon_state = "bordercolorcorner2"
-	},
-/obj/structure/table/standard,
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 30
-	},
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/surgery)
+/turf/simulated/floor/plating,
+/area/maintenance/readingrooms)
 "aaB" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -256,97 +225,92 @@
 /turf/simulated/floor/plating,
 /area/maintenance/lower/north)
 "aaC" = (
-/obj/machinery/oxygen_pump/anesthetic,
-/turf/simulated/wall,
-/area/tether/surfacebase/medical/surgery)
+/obj/machinery/door/airlock/maintenance/common,
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/plating,
+/area/maintenance/readingrooms)
 "aaD" = (
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 5
-	},
-/obj/effect/floor_decal/corner/white/border{
-	dir = 5
-	},
-/obj/structure/table/standard,
-/obj/item/device/defib_kit/loaded,
-/obj/machinery/light{
+/obj/machinery/power/apc{
 	dir = 4;
-	icon_state = "tube1"
+	name = "east bump";
+	pixel_x = 28
 	},
-/obj/item/weapon/reagent_containers/spray/cleaner{
-	desc = "Someone has crossed out the Space from Space Cleaner and written in Surgery. 'Do not remove under punishment of death!!!' is scrawled on the back.";
-	name = "Surgery Cleaner";
-	pixel_x = 2;
-	pixel_y = 2
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
 	},
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/surgery)
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/maintenance/readingrooms)
 "aaE" = (
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 5
+/obj/machinery/door/firedoor/glass,
+/obj/structure/grille,
+/obj/structure/window/reinforced/polarized/full{
+	id = "patient_room_a"
 	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 5
+/obj/structure/window/reinforced/polarized{
+	dir = 1;
+	id = "patient_room_a"
 	},
-/obj/machinery/organ_printer/flesh,
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/resleeving)
+/obj/machinery/door/blast/shutters{
+	closed_layer = 10;
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id = "medbayquar";
+	layer = 1;
+	name = "Medbay Emergency Lockdown Shutters";
+	opacity = 0;
+	open_layer = 1
+	},
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/medical/patient_a)
 "aaF" = (
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 9
+/obj/machinery/door/firedoor/glass,
+/obj/structure/grille,
+/obj/structure/window/reinforced/polarized/full{
+	id = "patient_room_b"
 	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 9
+/obj/structure/window/reinforced/polarized{
+	dir = 1;
+	id = "patient_room_b"
 	},
-/obj/machinery/transhuman/resleever,
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/resleeving)
+/obj/machinery/door/blast/shutters{
+	closed_layer = 10;
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id = "medbayquar";
+	layer = 1;
+	name = "Medbay Emergency Lockdown Shutters";
+	opacity = 0;
+	open_layer = 1
+	},
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/medical/patient_b)
 "aaG" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/mining)
 "aaH" = (
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 1
-	},
-/obj/machinery/clonepod/transhuman,
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/resleeving)
+/turf/simulated/wall,
+/area/tether/surfacebase/medical/patient_b)
 "aaI" = (
+/turf/simulated/wall,
+/area/tether/surfacebase/medical/surgery1)
+"aaJ" = (
+/obj/machinery/clonepod/transhuman,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
 /obj/effect/floor_decal/borderfloorwhite{
-	dir = 1
+	dir = 5
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
-	dir = 1
-	},
-/obj/structure/table/glass,
-/obj/item/weapon/reagent_containers/glass/bottle/biomass{
-	pixel_x = 4;
-	pixel_y = 6
-	},
-/obj/item/weapon/reagent_containers/glass/bottle/biomass{
-	pixel_x = -4;
-	pixel_y = 8
-	},
-/obj/item/weapon/reagent_containers/glass/bottle/biomass{
-	pixel_x = -7;
-	pixel_y = 4
+	dir = 5
 	},
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/resleeving)
-"aaJ" = (
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 1
-	},
-/obj/machinery/vending/medical,
-/obj/machinery/camera/network/medbay,
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/storage)
 "aaK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -425,28 +389,8 @@
 /turf/simulated/floor/plating,
 /area/maintenance/lower/north)
 "aaQ" = (
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 1
-	},
-/obj/structure/table/glass,
-/obj/item/weapon/reagent_containers/glass/bottle/biomass{
-	pixel_x = 6;
-	pixel_y = 8
-	},
-/obj/machinery/alarm{
-	pixel_x = 0;
-	pixel_y = 28
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/item/device/flashlight/pen{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/resleeving)
+/turf/simulated/wall,
+/area/tether/surfacebase/medical/surgery2)
 "aaR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -501,21 +445,24 @@
 /turf/simulated/floor,
 /area/maintenance/substation/medsec)
 "aaW" = (
-/obj/effect/floor_decal/steeldecal/steel_decals10{
-	dir = 5
+/obj/structure/table/glass,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals10{
-	dir = 6
+/obj/item/weapon/paper_bin,
+/obj/item/weapon/pen,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 9
 	},
-/obj/structure/curtain/open/shower/medical,
-/obj/machinery/shower{
-	dir = 4;
-	icon_state = "shower";
-	pixel_x = 2;
-	pixel_y = 0
+/obj/effect/floor_decal/corner/pink/border{
+	dir = 9
 	},
-/turf/simulated/floor/tiled/dark,
-/area/tether/surfacebase/medical/resleeving)
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/patient_a)
 "aaX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -533,149 +480,182 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/lowerhallway)
 "aaY" = (
-/obj/effect/floor_decal/techfloor{
-	dir = 9
+/obj/effect/landmark/start{
+	name = "Medical Doctor"
 	},
-/obj/effect/floor_decal/rust,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/wardrobe/pjs,
-/obj/item/weapon/handcuffs/fuzzy,
-/obj/item/weapon/handcuffs/fuzzy,
-/obj/item/weapon/handcuffs/legcuffs/fuzzy,
-/obj/item/weapon/handcuffs/fuzzy,
-/obj/item/clothing/accessory/shiny/socks,
-/obj/item/clothing/under/shiny/catsuit,
-/obj/item/clothing/accessory/shiny/gloves,
-/obj/item/clothing/head/shiny_hood,
-/turf/simulated/floor/tiled/techfloor,
-/area/maintenance/lower/mining)
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/storage)
 "aaZ" = (
-/obj/effect/floor_decal/techfloor{
-	dir = 1
+/obj/structure/table/standard,
+/obj/item/weapon/storage/firstaid/o2{
+	pixel_x = 5;
+	pixel_y = 5
 	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/table/steel,
-/obj/item/weapon/storage/fancy/candle_box,
-/turf/simulated/floor/tiled/techfloor,
-/area/maintenance/lower/mining)
-"aba" = (
-/obj/effect/floor_decal/techfloor{
-	dir = 1
-	},
-/obj/machinery/vending/sovietsoda,
-/turf/simulated/floor/tiled/techfloor,
-/area/maintenance/lower/mining)
-"abb" = (
-/obj/effect/floor_decal/techfloor{
-	dir = 1
-	},
-/obj/machinery/vending/cigarette{
-	name = "Cigarette machine";
-	prices = list();
-	products = list(/obj/item/weapon/storage/fancy/cigarettes = 10, /obj/item/weapon/storage/box/matches = 10, /obj/item/weapon/flame/lighter/zippo = 4, /obj/item/clothing/mask/smokable/cigarette/cigar/havana = 2)
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/maintenance/lower/mining)
-"abc" = (
-/obj/effect/floor_decal/techfloor{
-	dir = 1
-	},
-/obj/machinery/status_display{
-	pixel_y = 30
-	},
-/obj/random/cutout,
-/turf/simulated/floor/tiled/techfloor,
-/area/maintenance/lower/mining)
-"abd" = (
-/obj/effect/floor_decal/techfloor{
-	dir = 1
-	},
-/obj/effect/floor_decal/techfloor/hole/right{
-	dir = 1
-	},
-/obj/structure/bed/padded,
-/obj/item/weapon/bedsheet/purple,
-/turf/simulated/floor/tiled/techfloor,
-/area/maintenance/lower/mining)
-"abe" = (
-/obj/effect/floor_decal/techfloor{
-	dir = 1
-	},
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/techfloor,
-/area/maintenance/lower/mining)
-"abf" = (
-/obj/effect/floor_decal/techfloor{
-	dir = 1
-	},
-/obj/structure/bed/padded,
-/obj/item/weapon/bedsheet/mime,
-/turf/simulated/floor/tiled/techfloor,
-/area/maintenance/lower/mining)
-"abg" = (
-/obj/effect/floor_decal/techfloor{
-	dir = 1
-	},
-/obj/machinery/light_switch{
-	dir = 2;
-	name = "light switch ";
+/obj/item/weapon/storage/firstaid/o2{
 	pixel_x = 0;
-	pixel_y = 26
+	pixel_y = 0
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/maintenance/lower/mining)
-"abh" = (
-/obj/effect/floor_decal/techfloor{
+/obj/effect/floor_decal/corner/blue/full{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/storage)
+"aba" = (
+/obj/structure/table/standard,
+/obj/item/weapon/storage/firstaid/adv{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/item/weapon/storage/firstaid/adv,
+/obj/effect/floor_decal/corner/red/full{
 	dir = 1
 	},
-/obj/structure/bed/padded,
-/obj/item/weapon/bedsheet/red,
-/obj/machinery/light/small{
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/storage)
+"abb" = (
+/obj/structure/bed/chair/office/light,
+/obj/effect/floor_decal/borderfloorwhite{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/maintenance/lower/mining)
-"abi" = (
-/obj/effect/floor_decal/techfloor{
+/obj/effect/floor_decal/corner/pink/border{
 	dir = 1
 	},
-/obj/effect/floor_decal/rust,
-/obj/machinery/alarm{
-	pixel_y = 22
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/maintenance/lower/mining)
-"abj" = (
-/obj/effect/floor_decal/techfloor{
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/patient_a)
+"abc" = (
+/obj/structure/bed/chair,
+/obj/item/device/radio/intercom{
+	dir = 4;
+	pixel_x = 24
+	},
+/obj/effect/floor_decal/borderfloorwhite{
 	dir = 5
 	},
-/obj/effect/floor_decal/techfloor/hole/right{
+/obj/effect/floor_decal/corner/pink/border{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/patient_a)
+"abd" = (
+/obj/machinery/door/airlock/multi_tile/glass{
+	dir = 2;
+	name = "Medbay Equipment";
+	req_access = list(5);
+	req_one_access = list(5)
+	},
+/obj/machinery/door/firedoor/multi_tile{
 	dir = 1
 	},
-/obj/structure/undies_wardrobe,
-/turf/simulated/floor/tiled/techfloor,
-/area/maintenance/lower/mining)
-"abk" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet,
-/turf/simulated/floor/plating,
-/area/maintenance/lower/mining)
-"abl" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/alarm{
-	pixel_y = 22
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/storage)
+"abe" = (
+/obj/structure/table/glass,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/lower/mining)
+/obj/item/weapon/paper_bin,
+/obj/item/weapon/pen,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/pink/border{
+	dir = 9
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/patient_b)
+"abf" = (
+/obj/structure/bed/chair/office/light,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/pink/border{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/patient_b)
+"abg" = (
+/obj/structure/bed/chair,
+/obj/item/device/radio/intercom{
+	dir = 4;
+	pixel_x = 24
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/pink/border{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/patient_b)
+"abh" = (
+/obj/structure/table/standard,
+/obj/item/weapon/reagent_containers/spray/cleaner{
+	desc = "Someone has crossed out the Space from Space Cleaner and written in Surgery. 'Do not remove under punishment of death!!!' is scrawled on the back.";
+	name = "Surgery Cleaner";
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/device/radio/intercom/department/medbay{
+	dir = 8;
+	pixel_x = -24
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/surgery1)
+"abi" = (
+/obj/structure/table/standard,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/surgery1)
+"abj" = (
+/obj/machinery/oxygen_pump/anesthetic,
+/turf/simulated/wall,
+/area/tether/surfacebase/medical/surgery1)
+"abk" = (
+/obj/structure/table/standard,
+/obj/item/stack/nanopaste,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/surgery1)
+"abl" = (
+/obj/structure/table/standard,
+/obj/item/device/defib_kit/loaded,
+/obj/item/weapon/reagent_containers/spray/cleaner{
+	desc = "Someone has crossed out the Space from Space Cleaner and written in Surgery. 'Do not remove under punishment of death!!!' is scrawled on the back.";
+	name = "Surgery Cleaner";
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/device/radio/intercom/department/medbay{
+	dir = 4;
+	pixel_x = 24
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/surgery1)
 "abm" = (
-/obj/random/trash_pile,
-/turf/simulated/floor/plating,
-/area/maintenance/lower/mining)
+/obj/structure/table/standard,
+/obj/item/weapon/reagent_containers/spray/cleaner{
+	desc = "Someone has crossed out the Space from Space Cleaner and written in Surgery. 'Do not remove under punishment of death!!!' is scrawled on the back.";
+	name = "Surgery Cleaner";
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/device/radio/intercom/department/medbay{
+	dir = 8;
+	pixel_x = -24
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/surgery2)
 "abn" = (
 /turf/simulated/wall,
 /area/maintenance/lower/public_garden_maintenence/upper)
@@ -728,49 +708,75 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/north)
 "abs" = (
-/obj/effect/floor_decal/techfloor{
-	dir = 8
+/obj/effect/landmark/start{
+	name = "Paramedic"
 	},
-/obj/effect/floor_decal/techfloor/hole/right{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/maintenance/lower/mining)
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/storage)
 "abt" = (
-/obj/effect/floor_decal/rust,
-/turf/simulated/floor/tiled/techfloor,
-/area/maintenance/lower/mining)
-"abu" = (
-/obj/effect/floor_decal/techfloor{
+/obj/structure/sign/nosmoking_1{
+	pixel_x = 32
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/borderfloorwhite{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/maintenance/lower/mining)
-"abv" = (
-/obj/structure/symbol/sa,
-/turf/simulated/wall{
-	can_open = 1
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 4
 	},
-/area/maintenance/lower/mining)
+/obj/effect/floor_decal/borderfloorwhite/corner2{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner2{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/storage)
+"abu" = (
+/obj/structure/table/standard,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/surgery2)
+"abv" = (
+/obj/machinery/oxygen_pump/anesthetic,
+/turf/simulated/wall,
+/area/tether/surfacebase/medical/surgery2)
 "abw" = (
-/obj/random/cigarettes,
-/obj/random/toy,
-/obj/random/tech_supply,
-/obj/random/junk,
-/obj/item/weapon/flame/lighter/zippo,
-/turf/simulated/floor/plating,
-/area/maintenance/lower/mining)
+/obj/structure/table/standard,
+/obj/item/stack/nanopaste,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/surgery2)
 "abx" = (
-/obj/effect/floor_decal/rust,
-/turf/simulated/floor/plating,
-/area/maintenance/lower/mining)
-"aby" = (
-/obj/machinery/light/small{
+/obj/structure/table/standard,
+/obj/item/device/defib_kit/loaded,
+/obj/item/weapon/reagent_containers/spray/cleaner{
+	desc = "Someone has crossed out the Space from Space Cleaner and written in Surgery. 'Do not remove under punishment of death!!!' is scrawled on the back.";
+	name = "Surgery Cleaner";
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/device/radio/intercom/department/medbay{
 	dir = 4;
+	pixel_x = 24
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/surgery2)
+"aby" = (
+/obj/structure/table/glass,
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -23;
 	pixel_y = 0
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/lower/mining)
+/obj/item/weapon/clipboard,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/pink/border{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/patient_a)
 "abz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/rust,
@@ -887,80 +893,129 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/north)
 "abL" = (
-/obj/effect/floor_decal/techfloor{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/patient_a)
+"abM" = (
+/obj/structure/bed/padded,
+/obj/item/weapon/bedsheet/medical,
+/obj/item/device/radio/intercom/department/medbay{
+	dir = 4;
+	pixel_x = 24
 	},
-/obj/structure/bed/chair/comfy/black{
+/obj/effect/floor_decal/borderfloorwhite{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/maintenance/lower/mining)
-"abM" = (
-/obj/effect/floor_decal/corner_techfloor_grid,
-/turf/simulated/floor/tiled/techfloor,
-/area/maintenance/lower/mining)
+/obj/effect/floor_decal/corner/pink/border{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/patient_a)
 "abN" = (
-/obj/effect/floor_decal/techfloor,
-/turf/simulated/floor/tiled/techfloor,
-/area/maintenance/lower/mining)
+/obj/structure/table/glass,
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -23;
+	pixel_y = 0
+	},
+/obj/item/weapon/clipboard,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/pink/border{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/patient_b)
 "abO" = (
-/obj/effect/floor_decal/techfloor,
-/obj/effect/floor_decal/techfloor/hole/right,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/techfloor,
-/area/maintenance/lower/mining)
+/obj/structure/table/rack,
+/obj/item/roller,
+/obj/item/roller{
+	pixel_y = 8
+	},
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 25;
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/storage)
 "abP" = (
-/obj/effect/floor_decal/techfloor,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/steel,
-/obj/random/drinkbottle,
-/turf/simulated/floor/tiled/techfloor,
-/area/maintenance/lower/mining)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/patient_b)
 "abQ" = (
-/obj/effect/floor_decal/techfloor,
-/obj/structure/table/steel,
-/obj/item/weapon/storage/toolbox/mechanical,
-/turf/simulated/floor/tiled/techfloor,
-/area/maintenance/lower/mining)
+/obj/structure/bed/padded,
+/obj/item/weapon/bedsheet/medical,
+/obj/item/device/radio/intercom/department/medbay{
+	dir = 4;
+	pixel_x = 24
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/pink/border{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/patient_b)
 "abR" = (
-/obj/effect/floor_decal/techfloor,
-/obj/structure/table/steel,
-/obj/item/weapon/tape_roll,
-/turf/simulated/floor/tiled/techfloor,
-/area/maintenance/lower/mining)
+/obj/structure/table/standard,
+/obj/item/weapon/storage/firstaid/surgery,
+/obj/item/device/radio/intercom{
+	dir = 8;
+	pixel_x = -24
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/surgery1)
 "abS" = (
-/obj/effect/floor_decal/techfloor,
-/obj/structure/table/steel,
-/obj/item/stack/cable_coil,
-/obj/item/stack/cable_coil,
-/obj/machinery/recharger,
-/turf/simulated/floor/tiled/techfloor,
-/area/maintenance/lower/mining)
+/obj/effect/floor_decal/industrial/loading{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/surgery1)
 "abT" = (
-/obj/effect/floor_decal/techfloor,
-/obj/structure/table/steel,
-/obj/random/medical/lite,
-/obj/machinery/vending/wallmed1/public{
-	pixel_y = -28
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/maintenance/lower/mining)
+/obj/machinery/optable,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/surgery1)
 "abU" = (
-/obj/effect/floor_decal/techfloor{
-	dir = 6
+/obj/effect/floor_decal/industrial/loading{
+	dir = 8
 	},
-/obj/random/junk,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/rust,
-/turf/simulated/floor/tiled/techfloor,
-/area/maintenance/lower/mining)
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/surgery1)
 "abV" = (
-/turf/simulated/floor/plating,
-/area/maintenance/lower/mining)
+/obj/structure/table/standard,
+/obj/item/weapon/storage/firstaid/surgery,
+/obj/item/device/radio/intercom{
+	dir = 4;
+	name = "Station Intercom (General)";
+	pixel_x = 24
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/surgery1)
 "abW" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/maintenance/lower/mining)
+/obj/structure/table/standard,
+/obj/item/weapon/storage/firstaid/surgery,
+/obj/item/device/radio/intercom{
+	dir = 8;
+	pixel_x = -24
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/surgery2)
 "abX" = (
 /obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
@@ -1107,17 +1162,21 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/north)
 "ack" = (
-/obj/effect/floor_decal/techfloor{
+/obj/machinery/vitals_monitor,
+/obj/effect/floor_decal/borderfloorwhite{
 	dir = 8
 	},
-/obj/effect/floor_decal/rust,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/techfloor,
-/area/maintenance/lower/mining)
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/storage)
 "acl" = (
-/obj/random/junk,
-/turf/simulated/floor/plating,
-/area/maintenance/lower/mining)
+/obj/effect/floor_decal/industrial/loading{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/surgery2)
 "acm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -1186,71 +1245,122 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/north)
 "acu" = (
-/obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 0
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/maintenance/lower/north)
+/obj/machinery/optable,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/surgery2)
 "acv" = (
-/obj/effect/floor_decal/techfloor{
+/obj/structure/closet/crate{
+	icon_state = "crate";
+	name = "Grenade Crate";
+	opened = 0
+	},
+/obj/item/weapon/grenade/chem_grenade,
+/obj/item/weapon/grenade/chem_grenade,
+/obj/item/weapon/grenade/chem_grenade,
+/obj/item/device/assembly/timer,
+/obj/item/device/assembly/timer,
+/obj/item/device/assembly/timer,
+/obj/item/device/assembly/igniter,
+/obj/item/device/assembly/igniter,
+/obj/item/device/assembly/igniter,
+/obj/item/weapon/tool/screwdriver,
+/obj/effect/floor_decal/borderfloorwhite{
 	dir = 10
 	},
-/obj/structure/closet,
-/obj/random/tool,
-/obj/random/toolbox,
-/obj/random/powercell,
-/obj/random/maintenance/cargo,
-/obj/random/maintenance/cargo,
-/obj/random/maintenance/clean,
-/obj/random/maintenance/clean,
-/obj/random/action_figure,
-/turf/simulated/floor/tiled/techfloor,
-/area/maintenance/lower/mining)
-"acw" = (
-/obj/effect/floor_decal/corner_techfloor_grid{
-	dir = 8
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 10
 	},
-/obj/effect/floor_decal/techfloor{
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/storage)
+"acw" = (
+/obj/structure/bed/chair/wheelchair{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/maintenance/lower/mining)
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/paleblue/border,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/storage)
 "acx" = (
-/obj/structure/catwalk,
-/obj/random/junk,
-/turf/simulated/floor/plating,
-/area/maintenance/lower/mining)
+/obj/structure/table/standard,
+/obj/structure/bedsheetbin,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/storage)
 "acy" = (
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/lower/mining)
 "acz" = (
-/obj/structure/catwalk,
-/obj/machinery/light/small,
-/turf/simulated/floor/plating,
-/area/maintenance/lower/mining)
+/obj/effect/floor_decal/industrial/loading{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/surgery2)
 "acA" = (
-/obj/machinery/door/airlock/maintenance/common,
-/obj/machinery/door/firedoor/glass,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/maintenance/lower/mining)
+/obj/structure/table/standard,
+/obj/item/weapon/storage/firstaid/surgery,
+/obj/item/device/radio/intercom{
+	dir = 4;
+	name = "Station Intercom (General)";
+	pixel_x = 24
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/surgery2)
 "acB" = (
-/obj/structure/closet/crate,
-/obj/random/medical/lite,
-/obj/random/maintenance/cargo,
-/obj/random/maintenance/clean,
-/obj/random/maintenance/clean,
-/turf/simulated/floor/plating,
-/area/maintenance/lower/mining)
+/obj/structure/table/glass,
+/obj/machinery/computer/med_data/laptop{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/pink/border{
+	dir = 10
+	},
+/obj/effect/floor_decal/borderfloorwhite/corner2{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/pink/bordercorner2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/machinery/power/apc{
+	cell_type = /obj/item/weapon/cell/super;
+	dir = 8;
+	name = "west bump";
+	pixel_x = -28
+	},
+/obj/structure/cable/green{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/patient_a)
 "acC" = (
-/obj/structure/reagent_dispensers/watertank,
-/turf/simulated/floor/plating,
-/area/maintenance/lower/mining)
+/obj/machinery/alarm{
+	pixel_y = 22
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/surfacebase/lowmedbaymaint)
 "acD" = (
 /turf/simulated/wall,
 /area/tether/surfacebase/outside/outside2)
@@ -1265,10 +1375,7 @@
 /area/rnd/rdoffice)
 "acG" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/railing{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/south)
 "acH" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1346,6 +1453,7 @@
 /area/maintenance/lower/mining)
 "acT" = (
 /obj/machinery/camera/network/medbay,
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/lowerhall)
 "acU" = (
@@ -1795,6 +1903,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/lower/mining)
 "adK" = (
@@ -1804,6 +1915,9 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/lower/mining)
@@ -1939,20 +2053,23 @@
 /turf/simulated/mineral/floor/virgo3b,
 /area/tether/surfacebase/outside/outside2)
 "aeb" = (
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/effect/floor_decal/corner/white/border{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/structure/table/standard,
-/obj/item/device/radio/intercom/department/medbay{
-	dir = 8;
-	pixel_x = -24
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/item/weapon/storage/firstaid/surgery,
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/surgery)
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/maintenance/readingrooms)
 "aec" = (
 /obj/structure/catwalk,
 /obj/structure/cable{
@@ -1971,11 +2088,11 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/supply{
-	dir = 10
+/obj/machinery/atmospherics/pipe/manifold/visible/supply{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/scrubbers{
-	dir = 10
+/obj/machinery/atmospherics/pipe/manifold/visible/scrubbers{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/lower/bar)
@@ -2055,20 +2172,33 @@
 /turf/simulated/floor/plating,
 /area/maintenance/lower/north)
 "aem" = (
-/obj/effect/floor_decal/borderfloorwhite{
+/obj/machinery/button/windowtint{
+	id = "patient_room_a";
+	pixel_x = 26;
+	pixel_y = -26
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 8
 	},
-/obj/effect/floor_decal/corner/white/border{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
 	},
-/obj/structure/table/standard,
-/obj/item/device/radio/intercom{
-	dir = 8;
-	pixel_x = -24
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_x = -24;
+	pixel_y = -30
 	},
-/obj/item/device/healthanalyzer,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/surgery)
+/area/tether/surfacebase/medical/patient_a)
 "aen" = (
 /obj/machinery/portable_atmospherics/powered/scrubber/huge/stationary{
 	scrub_id = "atrium"
@@ -2101,39 +2231,51 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/mining)
 "aer" = (
-/obj/structure/table/rack,
-/obj/machinery/light,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
+/obj/structure/closet/secure_closet/personal/patient,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/pink/border{
+	dir = 6
+	},
+/obj/effect/floor_decal/borderfloorwhite/corner2,
+/obj/effect/floor_decal/corner/pink/bordercorner2,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/patient_a)
+"aes" = (
+/obj/structure/table/glass,
+/obj/machinery/computer/med_data/laptop{
 	dir = 1
 	},
-/obj/item/clothing/suit/space/void/medical/emt,
-/obj/item/clothing/suit/space/void/medical/emt,
-/obj/item/clothing/head/helmet/space/void/medical/emt,
-/obj/item/clothing/head/helmet/space/void/medical/emt,
-/obj/item/clothing/shoes/magboots,
-/obj/item/clothing/shoes/magboots,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/paramed)
-"aes" = (
 /obj/effect/floor_decal/borderfloorwhite{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/pink/border{
+	dir = 10
+	},
+/obj/effect/floor_decal/borderfloorwhite/corner2{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/pink/bordercorner2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 4
+/obj/machinery/power/apc{
+	cell_type = /obj/item/weapon/cell/super;
+	dir = 8;
+	name = "west bump";
+	pixel_x = -28
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
+/obj/structure/cable/green{
+	icon_state = "0-4"
 	},
-/obj/structure/table/rack,
-/obj/item/weapon/storage/belt/medical,
-/obj/item/weapon/storage/belt/medical,
-/obj/item/weapon/storage/belt/medical,
-/obj/item/weapon/storage/belt/medical,
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/storage)
+/area/tether/surfacebase/medical/patient_b)
 "aet" = (
 /obj/structure/railing{
 	dir = 1
@@ -2144,17 +2286,33 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/mining)
 "aeu" = (
-/obj/effect/floor_decal/techfloor{
+/obj/machinery/button/windowtint{
+	id = "patient_room_b";
+	pixel_x = -26;
+	pixel_y = -26
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 5
 	},
-/obj/machinery/light/small{
-	dir = 1;
-	icon_state = "bulb1"
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
 	},
-/obj/structure/table/standard,
-/obj/random/soap,
-/turf/simulated/floor/tiled/dark,
-/area/tether/surfacebase/medical/resleeving)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_x = 24;
+	pixel_y = -30
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/patient_b)
 "aev" = (
 /obj/structure/railing{
 	dir = 1
@@ -2326,17 +2484,26 @@
 	dir = 1;
 	icon_state = "bulb1"
 	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/lower/bar)
 "aeM" = (
-/obj/effect/floor_decal/borderfloorwhite,
-/obj/effect/floor_decal/corner/paleblue/border,
-/obj/item/weapon/storage/toolbox/mechanical,
-/obj/item/device/multitool,
-/obj/item/device/multitool,
-/obj/structure/table/rack,
+/obj/structure/closet/secure_closet/personal/patient,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/pink/border{
+	dir = 6
+	},
+/obj/effect/floor_decal/borderfloorwhite/corner2,
+/obj/effect/floor_decal/corner/pink/bordercorner2,
+/obj/machinery/light/small{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/storage)
+/area/tether/surfacebase/medical/patient_b)
 "aeN" = (
 /obj/effect/floor_decal/rust,
 /obj/effect/decal/cleanable/dirt,
@@ -2451,48 +2618,21 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/tether/surfacebase/surface_two_hall)
 "afb" = (
-/obj/effect/floor_decal/borderfloorwhite,
-/obj/effect/floor_decal/corner/paleblue/border,
-/obj/machinery/power/apc{
-	dir = 2;
-	name = "south bump";
-	pixel_y = -28;
-	req_access = list(67)
-	},
-/obj/structure/cable/green,
-/obj/structure/table/rack,
-/obj/item/device/gps/medical{
-	pixel_y = 3
-	},
-/obj/item/device/gps/medical{
-	pixel_x = -3
-	},
-/obj/item/device/radio{
-	pixel_x = 2;
-	pixel_y = 0
-	},
-/obj/item/device/radio{
-	pixel_x = -1;
-	pixel_y = -3
+/obj/structure/table/standard,
+/obj/item/device/healthanalyzer,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/light{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/storage)
+/area/tether/surfacebase/medical/surgery1)
 "afc" = (
-/obj/machinery/door/firedoor/glass,
-/obj/machinery/door/airlock/medical{
-	id_tag = null;
-	name = "Resleeving Backroom";
-	req_access = list(0);
-	req_one_access = list(0)
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/effect/floor_decal/steeldecal/steel_decals6,
+/obj/effect/floor_decal/steeldecal/steel_decals6{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/resleeving)
+/area/tether/surfacebase/medical/surgery1)
 "afd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/green{
 	dir = 4;
@@ -3561,25 +3701,18 @@
 /turf/simulated/wall,
 /area/tether/surfacebase/surface_two_hall)
 "ahh" = (
-/obj/machinery/suit_cycler/medical,
-/obj/machinery/camera/network/medbay{
-	dir = 4;
-	icon_state = "camera"
-	},
+/obj/machinery/computer/operating,
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/paramed)
+/area/tether/surfacebase/medical/surgery1)
 "ahi" = (
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 4
-	},
-/obj/structure/bed/chair/wheelchair{
+/obj/effect/floor_decal/steeldecal/steel_decals6{
 	dir = 8
 	},
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/storage)
+/area/tether/surfacebase/medical/surgery1)
 "ahj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/red,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -3624,6 +3757,10 @@
 /obj/random/maintenance/clean,
 /obj/random/maintenance/clean,
 /obj/random/tool,
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_y = 0
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/lower/bar)
 "ahm" = (
@@ -3899,14 +4036,15 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/tether/surfacebase/surface_two_hall)
 "ahO" = (
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 4
+/obj/structure/table/standard,
+/obj/item/device/healthanalyzer,
+/obj/machinery/button/windowtint{
+	id = "surfsurgery1";
+	pixel_x = 26
 	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/lowerhall)
+/area/tether/surfacebase/medical/surgery1)
 "ahP" = (
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/bar)
@@ -4683,9 +4821,13 @@
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
 "ajt" = (
-/obj/machinery/space_heater,
-/turf/simulated/floor/tiled/techfloor,
-/area/maintenance/lower/bar)
+/obj/machinery/door/firedoor/glass,
+/obj/structure/grille,
+/obj/structure/window/reinforced/polarized/full{
+	id = "surfsurgery1"
+	},
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/medical/surgery1)
 "aju" = (
 /turf/simulated/floor/tiled/dark,
 /area/maintenance/lower/bar)
@@ -4818,6 +4960,12 @@
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/tether/surfacebase/surface_two_hall)
@@ -5709,22 +5857,13 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/tether/surfacebase/fish_farm)
 "alt" = (
-/obj/structure/table/bench/standard,
-/obj/effect/landmark/start{
-	name = "Medical Doctor"
+/obj/machinery/door/firedoor/glass,
+/obj/structure/grille,
+/obj/structure/window/reinforced/polarized/full{
+	id = "surfsurgery2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	icon_state = "intact-supply"
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 10
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/breakroom)
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/medical/surgery2)
 "alu" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
@@ -6485,6 +6624,12 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor/glass,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
 "amO" = (
@@ -6527,6 +6672,12 @@
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
@@ -6645,6 +6796,12 @@
 	dir = 2;
 	icon_state = "0-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
 "ane" = (
@@ -6654,6 +6811,9 @@
 	},
 /obj/machinery/light/small{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
 	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
@@ -6800,6 +6960,9 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
 	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
@@ -7348,12 +7511,6 @@
 /turf/simulated/floor/holofloor/tiled/dark,
 /area/tether/elevator)
 "aoy" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
 	d1 = 4;
@@ -7364,6 +7521,12 @@
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
@@ -8627,11 +8790,8 @@
 /area/rnd/rdoffice)
 "aqT" = (
 /obj/machinery/alarm{
-	alarm_id = "pen_nine";
-	breach_detection = 0;
 	dir = 1;
-	icon_state = "alarm0";
-	pixel_y = -22
+	pixel_y = -24
 	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
@@ -8808,7 +8968,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/commandmaint)
 "arq" = (
-/obj/structure/morgue/crematorium,
+/obj/structure/morgue/crematorium{
+	id = "crematorium"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel/chapel_morgue)
 "arr" = (
@@ -12871,21 +13033,15 @@
 /turf/simulated/floor/plating,
 /area/engineering/atmos/storage)
 "ayf" = (
-/obj/machinery/alarm{
-	pixel_x = 0;
-	pixel_y = 28
+/obj/structure/table/standard,
+/obj/item/device/healthanalyzer,
+/obj/machinery/button/windowtint{
+	id = "surfsurgery2";
+	pixel_x = -26
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/effect/landmark{
-	name = "morphspawn"
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/paramed)
+/area/tether/surfacebase/medical/surgery2)
 "ayg" = (
 /obj/effect/floor_decal/rust,
 /obj/effect/decal/cleanable/dirt,
@@ -13040,6 +13196,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/supply{
 	dir = 6
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/lower/south)
 "ayp" = (
@@ -13413,6 +13570,7 @@
 	icon_state = "4-8";
 	pixel_x = 0
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/lower/south)
 "ayY" = (
@@ -14180,6 +14338,7 @@
 	icon_state = "1-2";
 	pixel_y = 0
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/lower/south)
 "azR" = (
@@ -14675,14 +14834,15 @@
 /turf/simulated/floor/tiled,
 /area/janitor)
 "aAH" = (
-/obj/structure/railing{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 4
 	},
-/obj/effect/floor_decal/corner_techfloor_grid{
-	dir = 10
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/maintenance/lower/south)
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lowerhall)
 "aAI" = (
 /obj/effect/floor_decal/corner_techfloor_grid{
 	dir = 10
@@ -15012,6 +15172,7 @@
 	pixel_y = 0
 	},
 /obj/structure/catwalk,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/maintenance/lower/south)
 "aBp" = (
@@ -16453,6 +16614,7 @@
 	pixel_y = 0
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/lower/south)
 "aEh" = (
@@ -16865,6 +17027,10 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/lower/south)
 "aFk" = (
@@ -16879,6 +17045,10 @@
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/lower/south)
@@ -17216,12 +17386,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/lower/atmos)
 "aGe" = (
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/structure/railing{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/rack,
 /obj/random/maintenance/clean,
@@ -17230,18 +17394,27 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/south)
 "aGf" = (
-/obj/structure/railing{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/maintenance/lower/south)
-"aGg" = (
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/structure/railing{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/maintenance/readingrooms)
+"aGg" = (
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/south)
 "aGh" = (
@@ -17337,18 +17510,12 @@
 /area/maintenance/lower/atmos)
 "aGs" = (
 /obj/structure/catwalk,
-/obj/machinery/light/small{
-	dir = 8
-	},
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/lower/south)
 "aGt" = (
-/obj/structure/railing{
-	dir = 8
-	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -17366,23 +17533,14 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/south)
 "aGv" = (
-/obj/structure/railing{
+/obj/effect/floor_decal/steeldecal/steel_decals6,
+/obj/effect/floor_decal/steeldecal/steel_decals6{
 	dir = 4
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/techfloor,
-/area/maintenance/lower/south)
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/surgery2)
 "aGw" = (
 /obj/structure/catwalk,
-/obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 0
-	},
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
@@ -17633,6 +17791,9 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/railing{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/south)
 "aGP" = (
@@ -17648,6 +17809,9 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/random/trash_pile,
+/obj/structure/railing{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/south)
 "aGQ" = (
@@ -19429,12 +19593,25 @@
 "aKi" = (
 /obj/machinery/door/firedoor/glass,
 /obj/structure/grille,
-/obj/structure/window/reinforced/full,
+/obj/machinery/door/blast/shutters{
+	closed_layer = 10;
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id = "medbayquar";
+	layer = 1;
+	name = "Medbay Emergency Lockdown Shutters";
+	opacity = 0;
+	open_layer = 1
+	},
+/obj/structure/window/reinforced/polarized/full{
+	id = "surfresleeving"
+	},
 /obj/structure/window/reinforced{
 	dir = 1
 	},
 /turf/simulated/floor/plating,
-/area/tether/surfacebase/medical/storage)
+/area/tether/surfacebase/medical/resleeving)
 "aKj" = (
 /obj/random/slimecore,
 /turf/simulated/floor/reinforced,
@@ -19549,8 +19726,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/rnd/outpost/xenobiology/outpost_slimepens)
 "aKv" = (
-/turf/simulated/wall,
-/area/tether/surfacebase/medical/storage)
+/obj/machinery/computer/operating,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/surgery2)
 "aKw" = (
 /obj/structure/table/rack,
 /obj/item/device/flashlight,
@@ -20074,14 +20252,18 @@
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment{
 	dir = 1;
 	icon_state = "pipe-c"
 	},
 /obj/structure/cable{
 	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/tether/surfacebase/east_stairs_two)
@@ -20735,6 +20917,12 @@
 	icon_state = "4-8";
 	pixel_x = 0
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/tether/surfacebase/east_stairs_two)
 "aMB" = (
@@ -21029,14 +21217,24 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/tether/surfacebase/east_stairs_two)
 "aNd" = (
-/obj/machinery/telecomms/broadcaster/preset_right/tether,
-/turf/simulated/floor/bluegrid{
-	name = "Mainframe Base";
-	nitrogen = 100;
-	oxygen = 0;
-	temperature = 80
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 8
 	},
-/area/tcommsat/chamber)
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloorwhite/corner2{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lowerhall)
 "aNe" = (
 /obj/machinery/telecomms/hub/preset/tether,
 /turf/simulated/floor/bluegrid{
@@ -21047,14 +21245,23 @@
 	},
 /area/tcommsat/chamber)
 "aNf" = (
-/obj/machinery/telecomms/receiver/preset_right/tether,
-/turf/simulated/floor/bluegrid{
-	name = "Mainframe Base";
-	nitrogen = 100;
-	oxygen = 0;
-	temperature = 80
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 4
 	},
-/area/tcommsat/chamber)
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloorwhite/corner2{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner2{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lowerhall)
 "aNg" = (
 /obj/effect/floor_decal/corner_techfloor_grid{
 	dir = 9
@@ -21068,6 +21275,12 @@
 	d2 = 8;
 	icon_state = "4-8";
 	pixel_x = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/south)
@@ -21275,8 +21488,25 @@
 /turf/simulated/floor/tiled/dark,
 /area/rnd/outpost/xenobiology/outpost_slimepens)
 "aNz" = (
-/turf/simulated/wall,
-/area/tether/surfacebase/medical/paramed)
+/obj/structure/lattice,
+/obj/machinery/door/firedoor/glass,
+/obj/structure/railing{
+	dir = 1;
+	icon_state = "railing0"
+	},
+/obj/structure/cable/green{
+	d1 = 32;
+	d2 = 8;
+	icon_state = "32-8"
+	},
+/obj/machinery/atmospherics/pipe/zpipe/down/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/zpipe/down/scrubbers{
+	dir = 8
+	},
+/turf/simulated/open,
+/area/maintenance/surfacebase/lowmedbaymaint)
 "aNA" = (
 /obj/structure/catwalk,
 /obj/structure/table/steel,
@@ -21307,6 +21537,12 @@
 	d2 = 8;
 	icon_state = "4-8";
 	pixel_x = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/south)
@@ -21786,13 +22022,24 @@
 /turf/simulated/floor/plating,
 /area/maintenance/lower/atmos)
 "aOu" = (
-/obj/machinery/optable,
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/light{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
 	},
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/surgery)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/maintenance/readingrooms)
 "aOv" = (
 /obj/structure/table/rack,
 /obj/random/maintenance/research,
@@ -21807,6 +22054,12 @@
 	d2 = 8;
 	icon_state = "4-8";
 	pixel_x = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/south)
@@ -21827,6 +22080,13 @@
 /obj/effect/floor_decal/corner/paleblue/border{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/floor_decal/borderfloorwhite/corner2{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner2{
+	dir = 10
+	},
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/lowerhall)
 "aOy" = (
@@ -21843,12 +22103,16 @@
 	icon_state = "4-8";
 	pixel_x = 0
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/south)
 "aOz" = (
 /obj/structure/catwalk,
-/obj/machinery/atmospherics/pipe/simple/visible/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/visible/supply,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
 	d1 = 1;
@@ -21861,6 +22125,13 @@
 	},
 /obj/structure/cable{
 	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4;
+	icon_state = "map-scrubbers"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/lower/south)
@@ -22100,6 +22371,7 @@
 	dir = 8;
 	pixel_y = 0
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/lower/south)
 "aOU" = (
@@ -22161,19 +22433,14 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/drone_fabrication)
 "aPa" = (
-/obj/effect/floor_decal/borderfloorwhite,
-/obj/effect/floor_decal/corner/paleblue/border,
-/obj/machinery/camera/network/medbay{
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals6{
 	dir = 1
 	},
-/obj/item/weapon/storage/box/gloves,
-/obj/item/weapon/storage/box/masks{
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/obj/structure/table/standard,
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/storage)
+/area/tether/surfacebase/medical/surgery2)
 "aPb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -22359,119 +22626,80 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/solitary)
 "aPn" = (
-/obj/structure/bed/chair{
-	dir = 1
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 10
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 10
-	},
-/obj/structure/extinguisher_cabinet{
-	dir = 4;
-	icon_state = "extinguisher_closed";
-	pixel_x = -30
-	},
-/obj/machinery/camera/network/medbay{
-	dir = 10;
-	icon_state = "camera"
+/obj/structure/table/standard,
+/obj/item/device/healthanalyzer,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/light{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/resleeving)
+/area/tether/surfacebase/medical/surgery2)
 "aPo" = (
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 25;
+	pixel_y = 0
+	},
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 5
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
 	dir = 5
 	},
-/obj/effect/floor_decal/borderfloorwhite/corner2{
-	dir = 5
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
 	},
-/obj/effect/floor_decal/corner/paleblue/bordercorner2{
-	dir = 5
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 4
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/machinery/camera/network/medbay,
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/lowerhall)
 "aPp" = (
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 8
-	},
-/obj/machinery/camera/network/medbay{
-	dir = 4;
-	icon_state = "camera"
-	},
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/lowerhall)
-"aPq" = (
-/obj/effect/floor_decal/borderfloorwhite,
-/obj/effect/floor_decal/corner/paleblue/border,
-/obj/machinery/camera/network/medbay{
-	dir = 10;
-	icon_state = "camera"
-	},
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/lowerhall)
-"aPr" = (
-/obj/structure/table/bench/standard,
-/obj/effect/landmark/start{
-	name = "Medical Doctor"
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 9
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 9
-	},
-/obj/machinery/camera/network/medbay,
+/obj/machinery/vending/fitness,
+/obj/effect/floor_decal/corner/paleblue/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/breakroom)
-"aPs" = (
+"aPq" = (
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/medical{
+	name = "Patient Room A";
+	req_one_access = list()
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 10
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 10
-	},
-/obj/effect/floor_decal/borderfloorwhite/corner2{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/paleblue/bordercorner2{
-	dir = 8
-	},
-/obj/machinery/camera/network/medbay{
-	dir = 4;
-	icon_state = "camera"
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/lowerhall)
+/area/tether/surfacebase/medical/patient_a)
+"aPr" = (
+/obj/machinery/door/firedoor/glass,
+/obj/structure/grille,
+/obj/structure/window/reinforced/polarized/full{
+	id = "patient_room_a"
+	},
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/medical/patient_a)
+"aPs" = (
+/obj/machinery/door/firedoor/glass,
+/obj/structure/grille,
+/obj/structure/window/reinforced/polarized/full{
+	id = "patient_room_b"
+	},
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/medical/patient_b)
 "aPt" = (
-/obj/effect/floor_decal/borderfloorwhite,
-/obj/effect/floor_decal/corner/white/border,
-/obj/effect/floor_decal/borderfloorwhite/corner2{
-	dir = 9
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/machinery/door/firedoor,
+/obj/structure/window/reinforced{
+	dir = 4
 	},
-/obj/effect/floor_decal/corner/white/bordercorner2{
-	dir = 9;
-	icon_state = "bordercolorcorner2"
-	},
-/obj/structure/bed/chair{
-	dir = 1
-	},
-/obj/machinery/camera/network/medbay{
-	dir = 10;
-	icon_state = "camera"
-	},
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/surgery)
+/turf/simulated/floor/outdoors/grass/sif/virgo3b,
+/area/maintenance/readingrooms)
 "aPu" = (
 /obj/structure/table/bench/padded,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -22519,7 +22747,20 @@
 /turf/simulated/floor/reinforced,
 /area/rnd/outpost/xenobiology/outpost_slimepens)
 "aPz" = (
-/turf/simulated/floor/tiled/techfloor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloorwhite/corner2{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner2{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/lowerhall)
 "aPA" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -22534,171 +22775,257 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
-"aPC" = (
-/obj/machinery/light/small,
-/turf/simulated/floor/tiled/techfloor,
-/area/tether/surfacebase/medical/lowerhall)
 "aPD" = (
 /obj/machinery/alarm{
-	alarm_id = "pen_nine";
-	breach_detection = 0;
 	dir = 1;
-	icon_state = "alarm0";
-	pixel_y = -22
+	pixel_y = -24
 	},
 /turf/simulated/floor/lino,
 /area/chapel/office)
 "aPE" = (
-/obj/effect/floor_decal/industrial/loading{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/maintenance/readingrooms)
+"aPF" = (
+/turf/simulated/mineral,
+/area/maintenance/readingrooms)
+"aPG" = (
+/obj/structure/lattice,
+/turf/simulated/mineral/floor/cave,
+/area/maintenance/readingrooms)
+"aPH" = (
+/turf/simulated/wall,
+/area/tether/surfacebase/medical/storage)
+"aPI" = (
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/medical{
+	name = "Patient Room B";
+	req_one_access = list()
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/surgery)
-"aPG" = (
-/obj/effect/floor_decal/industrial/loading{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/surgery)
-"aPH" = (
-/obj/effect/floor_decal/borderfloorwhite{
+/area/tether/surfacebase/medical/patient_b)
+"aPJ" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/item/weapon/reagent_containers/blood/OMinus,
+/obj/structure/closet/crate/freezer,
+/obj/machinery/power/apc{
+	cell_type = /obj/item/weapon/cell/super;
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/obj/structure/cable/green{
+	icon_state = "0-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5;
+	icon_state = "intact-scrubbers"
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/surgery1)
+"aPK" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/floor_decal/corner/white/border{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/item/device/radio/intercom/department/medbay{
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/surgery1)
+"aPL" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 2
+	},
+/obj/machinery/light_switch{
+	dir = 8;
+	pixel_x = 30;
+	pixel_y = -24
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 10
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/surgery1)
+"aPM" = (
+/obj/machinery/door/airlock/medical{
+	name = "Operating Theatre 1";
+	req_access = list(45)
+	},
+/obj/machinery/door/firedoor/glass,
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/surgery1)
+"aPN" = (
+/obj/machinery/door/airlock/medical{
+	name = "Operating Theatre 2";
+	req_access = list(45)
+	},
+/obj/machinery/door/firedoor/glass,
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/surgery2)
+"aPO" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 2
+	},
+/obj/machinery/light_switch{
 	dir = 4;
-	pixel_x = 24
+	pixel_x = -30;
+	pixel_y = -24
 	},
-/obj/structure/table/standard,
-/obj/item/weapon/storage/firstaid/surgery,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 6
+	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/surgery)
-"aPI" = (
+/area/tether/surfacebase/medical/surgery2)
+"aPP" = (
+/obj/structure/table/glass,
+/obj/item/weapon/book/manual/resleeving,
+/obj/structure/sign/nosmoking_1{
+	pixel_x = -32
+	},
+/obj/item/device/sleevemate,
+/obj/machinery/alarm{
+	pixel_y = 28
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
 /obj/effect/floor_decal/borderfloorwhite{
-	dir = 8
+	dir = 9
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
-	dir = 8
+	dir = 9
 	},
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/resleeving)
-"aPJ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+"aPQ" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/resleeving)
-"aPK" = (
-/obj/effect/floor_decal/techfloor{
-	dir = 8
+/area/tether/surfacebase/medical/surgery2)
+"aPR" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/item/weapon/reagent_containers/blood/OMinus,
+/obj/structure/closet/crate/freezer,
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/surgery2)
+"aPS" = (
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24
-	},
-/turf/simulated/floor/tiled/dark,
-/area/tether/surfacebase/medical/resleeving)
-"aPL" = (
-/obj/effect/floor_decal/techfloor{
-	dir = 4
-	},
-/obj/structure/table/standard,
-/turf/simulated/floor/tiled/dark,
-/area/tether/surfacebase/medical/resleeving)
-"aPM" = (
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloorwhite/corner2{
-	dir = 5
-	},
-/obj/effect/floor_decal/corner/paleblue/bordercorner2{
-	dir = 5
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
+	pixel_x = -24;
+	pixel_y = 0
 	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/resleeving)
-"aPN" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/resleeving)
-"aPO" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/resleeving)
-"aPP" = (
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 9
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 9
-	},
-/obj/structure/bed/chair{
-	dir = 4
-	},
-/obj/effect/landmark/start{
-	name = "Medical Doctor"
-	},
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/storage)
-"aPQ" = (
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 1
-	},
-/obj/structure/table/standard,
-/obj/item/weapon/storage/box/nifsofts_medical,
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/storage)
-"aPR" = (
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 1
-	},
-/obj/structure/table/standard,
-/obj/item/weapon/storage/firstaid/regular,
-/obj/item/weapon/storage/firstaid/regular{
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/storage)
-"aPS" = (
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 1
-	},
-/obj/structure/bed/chair{
-	dir = 8
-	},
-/obj/effect/landmark/start{
-	name = "Medical Doctor"
-	},
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/storage)
+/area/tether/surfacebase/medical/patient)
+"aPT" = (
+/turf/simulated/mineral/floor/cave,
+/area/maintenance/readingrooms)
 "aPU" = (
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 1
@@ -22706,256 +23033,279 @@
 /obj/effect/floor_decal/corner/paleblue/border{
 	dir = 1
 	},
-/obj/structure/table/standard,
-/obj/item/weapon/cane,
-/obj/item/weapon/cane,
-/obj/structure/bedsheetbin,
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/storage)
-"aPV" = (
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 5
+/obj/effect/floor_decal/borderfloorwhite/corner2{
+	dir = 4
 	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 5
-	},
-/obj/structure/table/standard,
-/obj/item/device/radio,
-/obj/item/device/radio,
-/obj/item/device/radio,
-/obj/item/weapon/tool/screwdriver,
-/obj/item/weapon/tool/wrench,
-/obj/item/weapon/storage/briefcase/inflatable,
-/obj/item/weapon/storage/briefcase/inflatable,
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/storage)
-"aPW" = (
-/obj/machinery/firealarm{
-	dir = 2;
-	layer = 3.3;
-	pixel_x = 4;
-	pixel_y = 26
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
+/obj/effect/floor_decal/corner/paleblue/bordercorner2{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/paramed)
+/area/tether/surfacebase/medical/patient)
+"aPV" = (
+/obj/machinery/washing_machine,
+/obj/effect/floor_decal/techfloor{
+	dir = 9
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/tiled/dark,
+/area/tether/surfacebase/medical/resleeving)
+"aPW" = (
+/obj/machinery/vending/wallmed1{
+	pixel_y = 32
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/patient)
+"aPX" = (
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/maintenance/readingrooms)
 "aPY" = (
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/patient)
+"aPZ" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lowerhall)
+"aQa" = (
 /obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 24
+	dir = 4;
+	name = "east bump";
+	pixel_x = 28
 	},
 /obj/structure/cable/green{
 	d2 = 2;
 	icon_state = "0-2"
 	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 5
+	},
+/obj/effect/floor_decal/borderfloorwhite/corner2{
+	dir = 5
+	},
+/obj/effect/floor_decal/borderfloorwhite/corner2{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner2{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner2{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/patient)
+"aQb" = (
+/turf/simulated/wall,
+/area/tether/surfacebase/medical/patient)
+"aQc" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/machinery/light_switch{
-	dir = 8;
-	on = 0;
-	pixel_x = 28
-	},
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/paramed)
-"aPZ" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 8
-	},
-/obj/effect/floor_decal/borderfloorwhite/corner2{
-	dir = 10
-	},
-/obj/effect/floor_decal/corner/paleblue/bordercorner2{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/lowerhall)
-"aQa" = (
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 1
-	},
-/obj/effect/floor_decal/borderfloorwhite/corner2{
 	dir = 4
 	},
-/obj/effect/floor_decal/corner/paleblue/bordercorner2{
-	dir = 4
-	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/lowerhall)
-"aQb" = (
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/lowerhall)
-"aQc" = (
-/obj/machinery/alarm{
-	pixel_y = 22
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/lowerhall)
+/area/tether/surfacebase/medical/surgery1)
 "aQd" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 5
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 5
+/obj/machinery/vending/wallmed1{
+	dir = 1;
+	pixel_y = -30
 	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/lowerhall)
+/area/tether/surfacebase/medical/surgery1)
+"aQe" = (
+/obj/machinery/light/small,
+/turf/simulated/floor/plating,
+/area/maintenance/readingrooms)
 "aQf" = (
-/obj/effect/floor_decal/steeldecal/steel_decals6{
-	dir = 4
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -24
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals6,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/medical_stand,
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/surgery)
+/area/tether/surfacebase/medical/surgery1)
 "aQg" = (
-/obj/machinery/computer/operating,
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/surgery)
-"aQh" = (
-/obj/effect/floor_decal/steeldecal/steel_decals6{
-	dir = 8
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals6{
+/obj/structure/bed/chair{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = -24
+	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/surgery)
+/area/tether/surfacebase/medical/surgery1)
+"aQh" = (
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/surgery1)
 "aQi" = (
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 4
+/obj/structure/bed/chair{
+	dir = 1
 	},
-/obj/effect/floor_decal/corner/white/border{
-	dir = 4
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
 	},
-/obj/item/device/radio/intercom{
-	dir = 4;
-	pixel_x = 24
-	},
-/obj/structure/table/standard,
-/obj/item/device/healthanalyzer,
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/surgery)
+/area/tether/surfacebase/medical/surgery2)
 "aQj" = (
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = -24
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/surgery2)
+"aQk" = (
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/obj/structure/medical_stand,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/surgery2)
+"aQl" = (
+/turf/simulated/floor/tiled/techfloor,
+/area/tether/surfacebase/medical/lowerhall)
+"aQm" = (
+/turf/simulated/wall,
+/area/tether/surfacebase/reading_room)
+"aQn" = (
+/obj/machinery/vending/wallmed1{
+	dir = 1;
+	pixel_y = -30
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/surgery2)
+"aQo" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/surgery2)
+"aQp" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/structure/cable/green{
+	icon_state = "1-4"
+	},
+/obj/structure/sign/poster{
+	pixel_x = -32
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloorwhite/corner2{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner2{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/patient)
+"aQq" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/patient)
+"aQr" = (
 /obj/machinery/computer/transhuman/resleeving{
 	dir = 4
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 8
 	},
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/resleeving)
-"aQk" = (
-/obj/structure/bed/chair/office/light{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/resleeving)
-"aQl" = (
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 10
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/resleeving)
-"aQn" = (
-/obj/effect/floor_decal/techfloor{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/tether/surfacebase/medical/resleeving)
-"aQo" = (
-/obj/effect/floor_decal/techfloor{
-	dir = 4
-	},
-/obj/machinery/alarm{
-	alarm_id = "anomaly_testing";
-	breach_detection = 0;
-	dir = 8;
-	frequency = 1439;
-	pixel_x = 22;
-	pixel_y = 0;
-	report_danger_level = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/dark,
-/area/tether/surfacebase/medical/resleeving)
-"aQp" = (
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/glass/hidden/steel,
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/lowerhall)
-"aQq" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/glass/hidden/steel{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/lowerhall)
-"aQr" = (
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 8
 	},
@@ -22963,61 +23313,229 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/storage)
+/area/tether/surfacebase/medical/resleeving)
 "aQs" = (
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/storage)
+/area/tether/surfacebase/medical/resleeving)
 "aQt" = (
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 4
+/obj/effect/floor_decal/techfloor{
+	dir = 8
 	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 4
-	},
-/obj/structure/table/standard,
-/obj/item/device/glasses_kit,
-/obj/item/weapon/storage/box/rxglasses,
-/obj/item/weapon/storage/box/rxglasses,
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/storage)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/dark,
+/area/tether/surfacebase/medical/resleeving)
 "aQu" = (
 /obj/machinery/camera/network/civilian{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
-"aQw" = (
-/obj/structure/extinguisher_cabinet{
-	dir = 1;
-	icon_state = "extinguisher_closed";
-	pixel_y = -32
-	},
-/obj/structure/cable/green{
+"aQv" = (
+/obj/machinery/door/airlock/maintenance/common,
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
 	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/reading_room)
+"aQw" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	icon_state = "intact-supply"
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/patient)
+"aQx" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/patient)
+"aQy" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 10
+	},
+/obj/effect/floor_decal/borderfloorwhite/corner2{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner2{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lowerhall)
+"aQz" = (
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/paleblue/border,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = -24
+	},
+/obj/structure/cable/green{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lowerhall)
+"aQA" = (
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "1-4"
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/patient)
+"aQB" = (
+/obj/machinery/hologram/holopad,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/borderfloorwhite/corner{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lowerhall)
+"aQC" = (
+/obj/structure/cable/green{
+	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
+	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/light_switch{
+	dir = 8;
+	pixel_x = 24;
+	pixel_y = -24
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4,
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 10
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals4,
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/paramed)
-"aQx" = (
-/obj/machinery/door/airlock/medical{
-	name = "EMT Closet"
+/area/tether/surfacebase/medical/patient)
+"aQD" = (
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/glass_medical{
+	name = "Recovery Rooms";
+	req_one_access = list()
 	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/patient)
+"aQE" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/reading_room)
+"aQF" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/status_display{
+	pixel_y = 30
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/reading_room)
+"aQG" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	layer = 3.3;
+	pixel_y = 26
+	},
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/reading_room)
+"aQH" = (
+/obj/machinery/door/airlock{
+	id_tag = "ReadingRoom1";
+	name = "Room 1"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -23026,246 +23544,256 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor/glass,
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/paramed)
-"aQy" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/reading_room)
+"aQI" = (
+/obj/machinery/button/remote/airlock{
+	id = "ReadingRoom1";
+	name = "Room 1 Bolt";
+	pixel_y = 30;
+	specialfunctions = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 6
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/reading_room)
+"aQJ" = (
+/obj/structure/table/glass,
+/obj/item/device/paicard,
+/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/lowerhall)
-"aQz" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloorwhite,
-/obj/effect/floor_decal/corner/paleblue/border,
-/obj/effect/floor_decal/borderfloorwhite/corner2,
-/obj/effect/floor_decal/corner/paleblue/bordercorner2,
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/lowerhall)
-"aQA" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloorwhite,
-/obj/effect/floor_decal/corner/paleblue/border,
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/lowerhall)
-"aQB" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloorwhite/corner{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/paleblue/bordercorner{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/lowerhall)
-"aQC" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/effect/floor_decal/borderfloorwhite/corner{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/paleblue/bordercorner{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/lowerhall)
-"aQD" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
 /obj/effect/floor_decal/borderfloorwhite{
-	dir = 5
+	dir = 10
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
-	dir = 5
+	dir = 10
 	},
-/obj/machinery/recharge_station,
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/lowerhall)
-"aQE" = (
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/white/border{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/warning{
+/area/tether/surfacebase/medical/patient)
+"aQK" = (
+/obj/structure/table/glass,
+/obj/item/weapon/paper_bin,
+/obj/item/weapon/pen,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/obj/machinery/power/apc{
-	cell_type = /obj/item/weapon/cell/apc;
-	dir = 8;
-	name = "west bump";
-	pixel_x = -28
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/paleblue/border,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/patient)
+"aQL" = (
+/obj/structure/closet/secure_closet/medical2,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
 	},
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
+/obj/machinery/camera/network/medbay{
+	dir = 10;
+	icon_state = "camera"
 	},
-/obj/structure/sink{
-	dir = 8;
-	icon_state = "sink";
-	pixel_x = -12;
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/surgery1)
+"aQM" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/structure/table/glass,
+/obj/item/device/flashlight/lamp/green,
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/reading_room)
+"aQN" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/machinery/door/firedoor,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/outdoors/grass/sif/virgo3b,
+/area/tether/surfacebase/reading_room)
+"aQO" = (
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/reading_room)
+"aQP" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
 	pixel_y = 0
 	},
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/surgery)
-"aQF" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/reading_room)
+"aQQ" = (
+/obj/machinery/button/windowtint{
+	dir = 4;
+	id = "surfresleeving";
+	pixel_x = -28;
+	pixel_y = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+/obj/machinery/button/remote/airlock{
+	desc = "A remote control switch for the medbay recovery room door.";
+	dir = 4;
+	id = "SurfMedicalResleeving";
+	name = "Exit Button";
+	pixel_x = -28;
+	pixel_y = -4
 	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 8
 	},
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/surgery)
-"aQG" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/effect/floor_decal/borderfloorwhite/corner2{
 	dir = 10
 	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+/obj/effect/floor_decal/corner/paleblue/bordercorner2{
+	dir = 10
 	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/surgery)
-"aQH" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
+/area/tether/surfacebase/medical/resleeving)
+"aQR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/surgery)
-"aQI" = (
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/white/border{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
+	dir = 5
 	},
 /obj/machinery/alarm{
-	alarm_id = "anomaly_testing";
-	breach_detection = 0;
-	dir = 8;
-	frequency = 1439;
-	pixel_x = 22;
-	pixel_y = 0;
-	report_danger_level = 0
+	dir = 1;
+	pixel_x = 3;
+	pixel_y = -28
 	},
-/obj/structure/closet/crate/freezer,
-/obj/item/weapon/reagent_containers/blood/OMinus,
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/surgery)
-"aQJ" = (
-/obj/effect/floor_decal/borderfloorwhite{
+/obj/structure/bed/chair/comfy/brown{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/reading_room)
+"aQS" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
+	},
+/obj/structure/table/glass,
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/reading_room)
+"aQT" = (
+/obj/structure/table/glass,
+/obj/item/weapon/cane,
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/paleblue/border,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/patient)
+"aQU" = (
+/obj/structure/table/standard,
+/obj/random/tetheraid,
+/obj/random/tetheraid,
+/obj/item/weapon/storage/secure/briefcase/ml3m_pack_med,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
-	dir = 8
+	dir = 1
 	},
-/obj/machinery/light_switch{
-	dir = 4;
-	on = 0;
-	pixel_x = -28
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloorwhite/corner2{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner2{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/resleeving)
-"aQK" = (
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/resleeving)
-"aQL" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/area/tether/surfacebase/medical/storage)
+"aQV" = (
+/obj/structure/table/glass,
+/obj/item/weapon/paper_bin,
+/obj/item/weapon/pen,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/reading_room)
+"aQW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4;
+	icon_state = "map-scrubbers"
 	},
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/resleeving)
-"aQM" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
 	},
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/resleeving)
-"aQN" = (
-/obj/effect/floor_decal/borderfloorwhite{
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/reading_room)
+"aQX" = (
+/obj/machinery/light/small{
 	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/reading_room)
+"aQY" = (
+/obj/structure/table/glass,
+/obj/item/device/flashlight/lamp/green,
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/reading_room)
+"aQZ" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/reading_room)
+"aRa" = (
+/obj/structure/catwalk,
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_y = 0
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/lower/south)
+"aRb" = (
+/obj/structure/table/glass,
+/obj/item/device/universal_translator,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/machinery/light,
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/paleblue/border,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/patient)
+"aRc" = (
+/obj/structure/bed/chair/wheelchair{
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 6
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
-	dir = 4
+	dir = 6
 	},
 /obj/effect/floor_decal/borderfloorwhite/corner2{
 	dir = 6
@@ -23273,322 +23801,102 @@
 /obj/effect/floor_decal/corner/paleblue/bordercorner2{
 	dir = 6
 	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/patient)
+"aRd" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/reading_room)
+"aRe" = (
+/turf/simulated/wall,
+/area/tether/surfacebase/medical/stairwell)
+"aRf" = (
+/obj/machinery/door/airlock{
+	id_tag = "ReadingRoom2";
+	name = "Room 2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/reading_room)
+"aRg" = (
+/obj/machinery/button/remote/airlock{
+	id = "ReadingRoom2";
+	name = "Room 2 Bolt";
+	pixel_y = 30;
+	specialfunctions = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/reading_room)
+"aRh" = (
+/obj/machinery/door/airlock/multi_tile/glass{
+	name = "Medbay Airlock";
+	req_access = list(5);
+	req_one_access = list(5)
+	},
+/obj/machinery/door/firedoor/multi_tile,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/stairwell)
+"aRi" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/stairwell)
+"aRj" = (
+/turf/simulated/open,
+/area/tether/surfacebase/medical/stairwell)
+"aRk" = (
+/obj/machinery/organ_printer/flesh,
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "east bump";
 	pixel_x = 28
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
+	d2 = 8;
 	icon_state = "0-8"
 	},
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/resleeving)
-"aQO" = (
-/obj/machinery/washing_machine,
-/obj/effect/floor_decal/techfloor{
-	dir = 8
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/tether/surfacebase/medical/resleeving)
-"aQP" = (
-/obj/effect/floor_decal/techfloor{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/dark,
-/area/tether/surfacebase/medical/resleeving)
-"aQQ" = (
 /obj/effect/floor_decal/borderfloorwhite{
-	dir = 8
+	dir = 4
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
-	dir = 8
-	},
-/obj/structure/extinguisher_cabinet{
-	dir = 4;
-	icon_state = "extinguisher_closed";
-	pixel_x = -30
-	},
-/obj/machinery/vitals_monitor,
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/storage)
-"aQS" = (
-/obj/structure/table/glass,
-/obj/item/weapon/book/manual/resleeving,
-/obj/item/device/radio/intercom{
-	dir = 2;
-	pixel_y = -24
-	},
-/obj/structure/sign/nosmoking_1{
-	pixel_x = 32
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 6
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 6
-	},
-/obj/item/device/sleevemate,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/resleeving)
-"aQT" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor/glass/hidden/steel{
-	dir = 2
-	},
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/lowerhall)
-"aQU" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/glass/hidden/steel{
-	dir = 2
-	},
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/lowerhall)
-"aQV" = (
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 10
-	},
-/obj/effect/floor_decal/corner/white/border{
-	dir = 10
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
-/obj/structure/bed/chair{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/surgery)
-"aQX" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 5
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/surgery)
-"aQY" = (
-/obj/effect/floor_decal/borderfloorwhite,
-/obj/effect/floor_decal/corner/white/border,
-/obj/effect/floor_decal/borderfloorwhite/corner2,
-/obj/effect/floor_decal/corner/white/bordercorner2,
-/obj/machinery/button/windowtint{
-	id = "surfsurgery";
-	pixel_x = 0;
-	pixel_y = -26
-	},
-/obj/structure/medical_stand,
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/surgery)
-"aQZ" = (
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 6
-	},
-/obj/effect/floor_decal/corner/white/border{
-	dir = 6
-	},
-/obj/structure/closet/secure_closet/medical2,
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/surgery)
-"aRb" = (
-/obj/effect/floor_decal/borderfloorwhite,
-/obj/effect/floor_decal/corner/paleblue/border,
 /obj/effect/floor_decal/borderfloorwhite/corner2{
-	dir = 9
+	dir = 6
 	},
 /obj/effect/floor_decal/corner/paleblue/bordercorner2{
-	dir = 9
-	},
-/obj/structure/bed/chair{
-	dir = 1
-	},
-/obj/machinery/button/remote/airlock{
-	desc = "A remote control switch for the medbay recovery room door.";
-	dir = 1;
-	id = "SurfMedicalResleeving";
-	name = "Exit Button";
-	pixel_x = -4;
-	pixel_y = -28
-	},
-/obj/machinery/button/windowtint{
-	dir = 8;
-	id = "surfresleeving";
-	pixel_x = 8;
-	pixel_y = -28
+	dir = 6
 	},
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/resleeving)
-"aRc" = (
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 5
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
+"aRl" = (
+/obj/structure/window/reinforced,
+/obj/effect/floor_decal/techfloor{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/resleeving)
-"aRd" = (
-/obj/effect/floor_decal/borderfloorwhite,
-/obj/effect/floor_decal/corner/paleblue/border,
-/obj/effect/floor_decal/borderfloorwhite/corner2,
-/obj/effect/floor_decal/corner/paleblue/bordercorner2,
-/obj/machinery/vending/loadout/uniform,
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/resleeving)
-"aRe" = (
-/obj/effect/floor_decal/borderfloorwhite,
-/obj/effect/floor_decal/corner/paleblue/border,
-/obj/machinery/door/firedoor/glass/hidden/steel{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/lowerhall)
-"aRf" = (
-/obj/machinery/washing_machine,
 /obj/effect/floor_decal/techfloor{
 	dir = 10
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/medical/resleeving)
-"aRg" = (
-/obj/structure/sink{
-	dir = 4;
-	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
-	},
-/obj/effect/floor_decal/techfloor{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/machinery/light/small,
-/obj/structure/mirror{
-	dir = 4;
-	pixel_x = 25;
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled/dark,
-/area/tether/surfacebase/medical/resleeving)
-"aRh" = (
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 8
-	},
-/obj/structure/closet/secure_closet/medical3,
-/obj/item/weapon/soap/nanotrasen,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/storage)
-"aRi" = (
-/obj/structure/table/standard,
-/obj/item/weapon/storage/firstaid/o2{
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/obj/item/weapon/storage/firstaid/o2{
-	pixel_x = 0;
-	pixel_y = 0
-	},
-/obj/effect/floor_decal/corner/blue/full{
-	dir = 8
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/storage)
-"aRj" = (
-/obj/effect/landmark{
-	name = "lightsout"
-	},
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/storage)
-"aRk" = (
-/obj/structure/table/standard,
-/obj/item/weapon/storage/firstaid/adv{
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/obj/item/weapon/storage/firstaid/adv,
-/obj/effect/floor_decal/corner/red/full{
-	dir = 1
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/storage)
-"aRl" = (
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 4
-	},
-/obj/structure/table/rack,
-/obj/item/roller,
-/obj/item/roller{
-	pixel_y = 8
-	},
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
-	},
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/storage)
 "aRm" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -23600,197 +23908,201 @@
 /turf/simulated/floor/plating,
 /area/maintenance/lower/north)
 "aRn" = (
-/obj/structure/catwalk,
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
 	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/north)
 "aRo" = (
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/stairwell)
+"aRp" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lowerhall)
+"aRq" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/machinery/door/firedoor,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/reading_room)
+"aRr" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/stairwell)
+"aRs" = (
+/obj/machinery/door/airlock/medical{
+	name = "Morgue";
+	req_access = list(6)
+	},
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/techfloor,
+/area/tether/surfacebase/medical/morgue)
+"aRt" = (
+/obj/structure/railing,
+/turf/simulated/open,
+/area/tether/surfacebase/medical/stairwell)
+"aRu" = (
+/obj/structure/bookcase,
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/reading_room)
+"aRv" = (
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
 /obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d2 = 2;
+	icon_state = "0-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/borderfloorwhite{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/effect/floor_decal/corner/paleblue/border{
 	dir = 4
 	},
-/obj/effect/floor_decal/borderfloorwhite,
-/obj/effect/floor_decal/corner/paleblue/border,
+/obj/effect/floor_decal/borderfloorwhite/corner2{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner2{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/stairwell)
+"aRw" = (
+/obj/machinery/door/firedoor/glass/hidden/steel{
+	dir = 2
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lowerhall)
+"aRx" = (
+/turf/simulated/wall,
+/area/tether/surfacebase/medical/morgue)
+"aRy" = (
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 10
+	},
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_x = 0;
 	pixel_y = -24
 	},
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/lowerhall)
-"aRp" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/maintenance/lower/north)
-"aRq" = (
-/obj/machinery/light/small,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/maintenance/lower/north)
-"aRr" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/floor_decal/borderfloorwhite{
+/obj/effect/floor_decal/borderfloorwhite/corner2{
 	dir = 8
 	},
-/obj/effect/floor_decal/corner/paleblue/border{
+/obj/effect/floor_decal/corner/paleblue/bordercorner2{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/lowerhall)
-"aRs" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/lowerhall)
-"aRt" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/lowerhall)
-"aRu" = (
-/obj/machinery/door/firedoor/glass,
-/obj/structure/grille,
-/obj/structure/window/reinforced/polarized/full{
-	id = "surfsurgery"
-	},
-/turf/simulated/floor/plating,
-/area/tether/surfacebase/medical/surgery)
-"aRv" = (
-/obj/machinery/door/firedoor/glass,
-/obj/machinery/door/airlock/medical{
-	name = "Operating Theatre 2";
-	req_access = list(45)
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/surgery)
-"aRw" = (
-/obj/machinery/door/firedoor/glass,
-/obj/structure/grille,
-/obj/structure/window/reinforced/polarized/full{
-	id = "surfresleeving"
-	},
-/turf/simulated/floor/plating,
-/area/tether/surfacebase/medical/resleeving)
-"aRx" = (
-/obj/machinery/door/airlock/medical{
-	id_tag = "SurfMedicalResleeving";
-	name = "Resleeving Lab";
-	req_access = list(5)
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/resleeving)
-"aRy" = (
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 8
-	},
-/obj/structure/closet/secure_closet/medical3,
-/obj/item/weapon/soap/nanotrasen,
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/storage)
 "aRz" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/storage)
+/obj/structure/morgue,
+/turf/simulated/floor/tiled/techfloor,
+/area/tether/surfacebase/medical/morgue)
 "aRA" = (
-/obj/machinery/hologram/holopad,
+/obj/structure/table/glass,
+/obj/item/weapon/reagent_containers/glass/bottle/biomass{
+	pixel_x = 4;
+	pixel_y = 6
+	},
+/obj/item/weapon/reagent_containers/glass/bottle/biomass{
+	pixel_x = -4;
+	pixel_y = 8
+	},
+/obj/item/weapon/reagent_containers/glass/bottle/biomass{
+	pixel_x = -7;
+	pixel_y = 4
+	},
+/obj/item/weapon/reagent_containers/glass/bottle/biomass{
+	pixel_x = 6;
+	pixel_y = 8
+	},
+/obj/item/device/flashlight/pen{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/item/device/radio/intercom{
+	pixel_y = -28
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/paleblue/border,
+/obj/effect/floor_decal/borderfloorwhite/corner2,
+/obj/effect/floor_decal/corner/paleblue/bordercorner2,
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/storage)
+/area/tether/surfacebase/medical/resleeving)
 "aRB" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/storage)
-"aRC" = (
 /obj/effect/floor_decal/borderfloorwhite{
-	dir = 4
+	dir = 9
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
-	dir = 4
+	dir = 9
 	},
-/obj/structure/bed/chair/wheelchair{
+/obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/alarm{
-	alarm_id = "anomaly_testing";
-	breach_detection = 0;
-	dir = 8;
-	frequency = 1439;
-	pixel_x = 22;
-	pixel_y = 0;
-	report_danger_level = 0
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
 	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/storage)
+/area/tether/surfacebase/medical/lowerhall)
+"aRC" = (
+/obj/machinery/shower{
+	dir = 4;
+	icon_state = "shower";
+	pixel_x = 2;
+	pixel_y = 0
+	},
+/obj/structure/curtain/open/shower/medical,
+/obj/effect/floor_decal/steeldecal/steel_decals10,
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/medical/resleeving)
 "aRD" = (
 /obj/structure/railing{
 	dir = 8
-	},
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/north)
@@ -23801,249 +24113,150 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/tether/surfacebase/fish_farm)
 "aRF" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/effect/landmark{
-	name = "lightsout"
-	},
+/obj/machinery/vending/coffee,
+/obj/effect/floor_decal/corner/paleblue/diagonal,
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/lowerhall)
+/area/tether/surfacebase/medical/breakroom)
 "aRG" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	icon_state = "intact-supply"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/effect/floor_decal/borderfloorwhite/corner{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/paleblue/bordercorner{
-	dir = 4
-	},
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/structure/flora/pottedplant,
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/lowerhall)
+/area/tether/surfacebase/medical/breakroom)
 "aRH" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 1
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/lowerhall)
-"aRI" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/lowerhall)
-"aRJ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 1
-	},
-/obj/effect/floor_decal/borderfloorwhite/corner2{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/paleblue/bordercorner2{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/lowerhall)
-"aRK" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 4
-	},
+/obj/effect/floor_decal/corner/paleblue/diagonal,
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 9
 	},
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/lowerhall)
-"aRL" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 1
-	},
-/obj/effect/floor_decal/borderfloorwhite/corner2{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/breakroom)
+"aRI" = (
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 4
 	},
-/obj/effect/floor_decal/corner/paleblue/bordercorner2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
+/obj/machinery/light_switch{
+	dir = 8;
+	pixel_x = 24;
+	pixel_y = 6
 	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/lowerhall)
-"aRM" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 1
+/area/tether/surfacebase/medical/breakroom)
+"aRJ" = (
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_x = 0;
+	pixel_y = 24
 	},
 /obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/lowerhall)
-"aRN" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/lowerhall)
-"aRO" = (
-/obj/machinery/door/airlock/maintenance/medical{
-	name = "Medical Maintenance Access"
-	},
-/obj/machinery/door/firedoor/glass,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/tiled/techfloor,
-/area/maintenance/lower/north)
-"aRP" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+/area/tether/surfacebase/medical/morgue)
+"aRK" = (
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -26
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 4
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
+/obj/effect/floor_decal/borderfloorwhite{
 	dir = 9
 	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
+/obj/structure/table/standard,
+/obj/item/clothing/suit/straight_jacket,
+/obj/item/clothing/mask/muzzle,
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/machinery/firealarm{
+	pixel_y = 25
 	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/lowerhall)
-"aRQ" = (
+/area/tether/surfacebase/medical/storage)
+"aRL" = (
+/obj/structure/sink/kitchen{
+	name = "sink";
+	pixel_y = 28
+	},
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
 	dir = 1
 	},
-/obj/machinery/light{
+/obj/effect/floor_decal/borderfloorwhite/corner2{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner2{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/storage)
+"aRM" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/light_switch{
+	pixel_x = 24;
+	pixel_y = 26
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/tether/surfacebase/medical/morgue)
+"aRN" = (
+/obj/structure/table/standard,
+/obj/item/weapon/storage/box/syringes{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/weapon/storage/box/syringes,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 1
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_x = 0;
+	pixel_y = 28
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/storage)
+"aRO" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/lowerhall)
+"aRP" = (
+/obj/structure/morgue{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/tether/surfacebase/medical/morgue)
+"aRQ" = (
+/obj/structure/morgue{
+	dir = 8
+	},
+/obj/structure/morgue,
+/turf/simulated/floor/tiled/techfloor,
+/area/tether/surfacebase/medical/morgue)
 "aRR" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1;
@@ -24055,49 +24268,40 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/tether/surfacebase/east_stairs_two)
 "aRS" = (
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 8
+/obj/machinery/alarm{
+	pixel_y = 22
 	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 8
-	},
-/obj/machinery/light_switch{
-	dir = 4;
-	on = 0;
-	pixel_x = -28
-	},
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/storage)
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/tiled/techfloor,
+/area/tether/surfacebase/medical/morgue)
 "aRT" = (
-/obj/structure/table/standard,
-/obj/item/weapon/storage/firstaid/toxin{
-	pixel_x = 5;
-	pixel_y = 5
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/obj/item/weapon/storage/firstaid/toxin{
-	pixel_x = 0;
-	pixel_y = 0
+/obj/machinery/vending/snack,
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 6
 	},
-/obj/effect/floor_decal/corner/green/full,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 9
+	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/storage)
+/area/tether/surfacebase/medical/stairwell)
 "aRU" = (
-/obj/structure/table/standard,
-/obj/item/weapon/storage/firstaid/fire{
-	pixel_x = 5;
-	pixel_y = 5
+/obj/machinery/vending/cola/soft,
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 6
 	},
-/obj/item/weapon/storage/firstaid/fire{
-	pixel_x = 0;
-	pixel_y = 0
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 9
 	},
-/obj/effect/floor_decal/corner/yellow/full{
-	dir = 4
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/storage)
+/area/tether/surfacebase/medical/stairwell)
 "aRV" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -24114,106 +24318,86 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/lower/north)
 "aRX" = (
-/obj/structure/cable{
+/obj/machinery/vending/wallmed1{
+	pixel_x = 30
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/catwalk,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/lower/north)
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/stairwell)
 "aRY" = (
 /obj/structure/railing{
 	dir = 8
 	},
 /obj/random/tool,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/north)
 "aRZ" = (
-/turf/simulated/floor/plating,
-/area/tether/surfacebase/outside/outside2)
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/structure/sign/poster{
+	pixel_x = -32
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/breakroom)
 "aSa" = (
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 10
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/lowerhall)
+/turf/simulated/floor/tiled/techfloor,
+/area/tether/surfacebase/medical/morgue)
 "aSb" = (
-/obj/effect/floor_decal/borderfloorwhite,
-/obj/effect/floor_decal/corner/paleblue/border,
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/lowerhall)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/techfloor,
+/area/tether/surfacebase/medical/morgue)
 "aSc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/floor_decal/borderfloorwhite/corner{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/paleblue/bordercorner{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/lowerhall)
+/turf/simulated/floor/tiled/techfloor,
+/area/tether/surfacebase/medical/morgue)
 "aSd" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
+/obj/machinery/washing_machine,
+/obj/effect/floor_decal/techfloor{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/lowerhall)
-"aSe" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/light/small{
+	dir = 1;
+	icon_state = "bulb1"
 	},
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/lowerhall)
+/turf/simulated/floor/tiled/dark,
+/area/tether/surfacebase/medical/resleeving)
+"aSe" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 5
+	},
+/obj/machinery/vending/wallmed1{
+	pixel_x = 30
+	},
+/obj/machinery/alarm{
+	pixel_y = 22
+	},
+/turf/simulated/floor/tiled/dark,
+/area/tether/surfacebase/medical/resleeving)
 "aSf" = (
 /turf/simulated/floor/plating,
 /area/vacant/vacant_site/gateway/lower)
 "aSg" = (
 /obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	icon_state = "intact-supply"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/lowerhall)
-"aSh" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -24223,240 +24407,316 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/lowerhall)
-"aSi" = (
-/obj/effect/floor_decal/steeldecal/steel_decals4,
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 10
-	},
+/area/tether/surfacebase/medical/stairwell)
+"aSh" = (
 /obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/stairwell)
+"aSi" = (
+/obj/machinery/door/firedoor/glass/hidden/steel,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/lowerhall)
 "aSj" = (
-/obj/machinery/door/airlock/glass_medical{
-	name = "Medbay Equipment";
-	req_access = list(5)
+/obj/machinery/door/firedoor/glass/hidden/steel{
+	dir = 8
 	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/glass,
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/storage)
-"aSk" = (
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 1
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 6
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/storage)
-"aSl" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/storage)
-"aSm" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/storage)
-"aSn" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/storage)
-"aSo" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/storage)
-"aSp" = (
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 4
-	},
-/obj/structure/table/standard,
-/obj/item/weapon/storage/box/beakers,
-/obj/random/medical,
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/storage)
-"aSq" = (
-/obj/machinery/door/firedoor/glass,
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/tether/surfacebase/medical/storage)
-"aSr" = (
-/turf/simulated/wall,
-/area/tether/surfacebase/medical/breakroom)
-"aSs" = (
-/obj/machinery/door/firedoor/glass,
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/turf/simulated/floor/plating,
-/area/tether/surfacebase/medical/breakroom)
-"aSt" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lowerhall)
+"aSk" = (
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/hologram/holopad,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 2
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/stairwell)
+"aSl" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4;
+	icon_state = "map-scrubbers"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloorwhite/corner2{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner2{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/stairwell)
+"aSm" = (
+/obj/machinery/hologram/holopad,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/techfloor,
+/area/tether/surfacebase/medical/morgue)
+"aSn" = (
+/obj/effect/landmark/start{
+	name = "Medical Doctor"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/tether/surfacebase/medical/morgue)
+"aSo" = (
+/obj/structure/filingcabinet/chestdrawer{
+	desc = "A large drawer filled with autopsy reports.";
+	name = "Autopsy Reports"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/tether/surfacebase/medical/morgue)
+"aSp" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 2;
+	icon_state = "pipe-j2"
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/stairwell)
+"aSq" = (
+/obj/structure/bed/chair/office/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/resleeving)
+"aSr" = (
+/turf/simulated/wall,
+/area/tether/surfacebase/medical/breakroom)
+"aSs" = (
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/structure/bed/chair,
+/obj/effect/landmark/start{
+	name = "Medical Doctor"
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/breakroom)
+"aSt" = (
+/obj/machinery/door/airlock/medical{
+	name = "Morgue";
+	req_access = list(6)
+	},
+/obj/machinery/door/firedoor/glass,
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/tether/surfacebase/medical/morgue)
+"aSu" = (
+/obj/machinery/transhuman/resleever,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloorwhite/corner2{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner2{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/resleeving)
+"aSv" = (
+/obj/structure/table/rack,
+/obj/item/clothing/suit/radiation,
+/obj/item/clothing/head/radiation,
+/obj/item/bodybag/cryobag{
+	pixel_x = -2;
+	pixel_y = -2
+	},
+/obj/item/bodybag/cryobag{
+	pixel_x = 1;
+	pixel_y = 1
+	},
+/obj/item/weapon/storage/toolbox/emergency{
+	pixel_x = 2;
+	pixel_y = 1
+	},
+/obj/item/weapon/storage/toolbox/mechanical{
+	pixel_x = -2;
+	pixel_y = -2
+	},
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube1"
+	},
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/lowerhall)
-"aSu" = (
-/obj/effect/floor_decal/borderfloorwhite/corner,
-/obj/effect/floor_decal/corner/paleblue/bordercorner,
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/lowerhall)
-"aSv" = (
-/obj/effect/floor_decal/borderfloorwhite,
-/obj/effect/floor_decal/corner/paleblue/border,
-/obj/machinery/light,
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/lowerhall)
+/area/tether/surfacebase/medical/storage)
 "aSw" = (
-/obj/effect/floor_decal/borderfloorwhite,
-/obj/effect/floor_decal/corner/paleblue/border,
-/obj/machinery/power/apc{
-	dir = 2;
-	name = "south bump";
-	pixel_y = -28;
-	req_access = list(67)
-	},
-/obj/structure/cable/green,
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/lowerhall)
+/turf/simulated/floor/tiled/dark,
+/area/tether/surfacebase/medical/resleeving)
 "aSx" = (
 /turf/simulated/floor/wood,
 /area/bridge/meeting_room)
 "aSy" = (
-/obj/effect/floor_decal/borderfloorwhite{
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/light_switch{
+	dir = 4;
+	pixel_x = -30;
+	pixel_y = -24
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 6
 	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 6
-	},
-/obj/effect/floor_decal/borderfloorwhite/corner2{
-	dir = 6
-	},
-/obj/effect/floor_decal/corner/paleblue/bordercorner2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
+/obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/lowerhall)
+/turf/simulated/floor/tiled/techfloor,
+/area/tether/surfacebase/medical/morgue)
 "aSz" = (
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 10
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 10
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
 	},
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/storage)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/tether/surfacebase/medical/morgue)
 "aSA" = (
-/obj/effect/floor_decal/borderfloorwhite,
-/obj/effect/floor_decal/corner/paleblue/border,
-/obj/structure/dispenser{
-	phorontanks = 0
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 2
 	},
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/storage)
+/turf/simulated/floor/tiled/techfloor,
+/area/tether/surfacebase/medical/morgue)
+"aSB" = (
+/obj/machinery/camera/network/civilian{
+	dir = 9
+	},
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/reading_room)
+"aSC" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/reading_room)
 "aSD" = (
-/obj/effect/floor_decal/borderfloorwhite,
-/obj/effect/floor_decal/corner/paleblue/border,
-/obj/structure/table/standard,
-/obj/item/clothing/suit/straight_jacket,
-/obj/item/clothing/mask/muzzle,
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/storage)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/tether/surfacebase/medical/morgue)
 "aSE" = (
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 6
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
 	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 6
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
 	},
-/obj/structure/table/standard,
-/obj/item/weapon/storage/box/bodybags,
-/obj/item/weapon/backup_implanter,
-/obj/item/weapon/backup_implanter,
-/obj/item/weapon/backup_implanter,
-/obj/item/bodybag/cryobag,
-/obj/item/bodybag/cryobag,
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/storage)
+/turf/simulated/floor/tiled/techfloor,
+/area/tether/surfacebase/medical/morgue)
 "aSF" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 1
@@ -24465,210 +24725,149 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/bar)
 "aSG" = (
-/obj/structure/table/bench/standard,
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 24
-	},
-/obj/effect/landmark/start{
-	name = "Medical Doctor"
-	},
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 1
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/machinery/status_display{
+	density = 0;
+	layer = 4;
+	pixel_x = -32;
+	pixel_y = 0
 	},
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/breakroom)
+"aSH" = (
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 28
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/reading_room)
 "aSI" = (
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 1
-	},
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/structure/table/glass,
+/obj/item/weapon/deck/cards,
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/breakroom)
 "aSJ" = (
-/obj/machinery/vending/coffee,
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 5
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 5
-	},
-/obj/effect/floor_decal/borderfloorwhite/corner2{
-	dir = 5;
-	icon_state = "borderfloorcorner2_white";
-	pixel_x = 0;
-	pixel_y = 0
-	},
-/obj/effect/floor_decal/corner/paleblue/bordercorner2{
-	dir = 5
-	},
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/structure/table/glass,
+/obj/machinery/recharger,
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/breakroom)
 "aSK" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/window/reinforced,
+/obj/machinery/vending/nifsoft_shop{
+	pixel_x = -9;
+	pixel_y = -15
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/stairwell)
+"aSL" = (
+/obj/structure/closet/hydrant{
+	pixel_x = -32
+	},
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/reading_room)
+"aSM" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/tether/surfacebase/medical/resleeving)
+"aSN" = (
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/machinery/newscaster{
+	layer = 3.3;
+	pixel_x = -27;
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/breakroom)
+"aSO" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/borderfloorwhite{
-	dir = 8
+	dir = 4
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
-	dir = 8
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	layer = 3.3;
+	pixel_x = 26
 	},
 /obj/effect/floor_decal/borderfloorwhite/corner2{
-	dir = 10
+	dir = 6
 	},
 /obj/effect/floor_decal/corner/paleblue/bordercorner2{
-	dir = 10
+	dir = 6
 	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/lowerhall)
-"aSM" = (
-/obj/structure/table/standard,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/breakroom)
-"aSN" = (
-/obj/structure/table/standard,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/breakroom)
-"aSO" = (
-/obj/structure/table/standard,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/breakroom)
+/area/tether/surfacebase/medical/stairwell)
 "aSP" = (
-/obj/machinery/hologram/holopad,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/structure/table/glass,
+/obj/item/weapon/storage/box/cups,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/breakroom)
 "aSQ" = (
-/obj/machinery/light_switch{
-	dir = 8;
-	on = 0;
-	pixel_x = 28;
-	pixel_y = -20
-	},
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/structure/table/glass,
 /obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 10
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4,
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/breakroom)
 "aSR" = (
-/obj/machinery/door/airlock/glass_medical{
-	name = "Staff Room";
-	req_access = list(5)
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/structure/bed/chair{
+	dir = 8
 	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/effect/landmark/start{
+	name = "Medical Doctor"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/breakroom)
 "aSS" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/vending/loadout/uniform,
+/obj/machinery/camera/network/medbay{
+	dir = 10;
+	icon_state = "camera"
 	},
 /obj/effect/floor_decal/borderfloorwhite{
-	dir = 1
+	dir = 6
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
-	dir = 1
-	},
-/obj/effect/floor_decal/borderfloorwhite/corner2{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/paleblue/bordercorner2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+	dir = 6
 	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/lowerhall)
+/area/tether/surfacebase/medical/resleeving)
 "aST" = (
-/obj/structure/extinguisher_cabinet{
-	dir = 8;
-	icon_state = "extinguisher_closed";
-	pixel_x = 30
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
 	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/lowerhall)
+/turf/simulated/floor/tiled/techfloor,
+/area/tether/surfacebase/medical/morgue)
 "aSU" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -24679,62 +24878,84 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/tether/surfacebase/surface_two_hall)
 "aSV" = (
-/obj/structure/table/bench/standard,
-/obj/effect/landmark/start{
-	name = "Medical Doctor"
-	},
-/obj/item/device/radio/intercom{
-	pixel_x = 0;
-	pixel_y = -28
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/structure/reagent_dispensers/water_cooler/full{
 	dir = 4
 	},
-/obj/effect/floor_decal/borderfloorwhite,
-/obj/effect/floor_decal/corner/paleblue/border,
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/breakroom)
 "aSW" = (
-/obj/structure/table/bench/standard,
-/obj/effect/landmark/start{
-	name = "Medical Doctor"
-	},
-/obj/machinery/light,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloorwhite,
-/obj/effect/floor_decal/corner/paleblue/border,
+/obj/effect/floor_decal/corner/paleblue/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/breakroom)
 "aSX" = (
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -25
+/obj/structure/table/steel,
+/obj/item/weapon/storage/box/bodybags{
+	pixel_x = 4;
+	pixel_y = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/effect/floor_decal/borderfloorwhite,
-/obj/effect/floor_decal/corner/paleblue/border,
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/breakroom)
-"aSY" = (
-/obj/machinery/vending/fitness{
+/obj/item/weapon/storage/box/bodybags,
+/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = -24
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/tether/surfacebase/medical/morgue)
+"aSY" = (
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/obj/effect/landmark/start{
+	name = "Medical Doctor"
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/breakroom)
+"aSZ" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/reading_room)
+"aTa" = (
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/item/device/radio/intercom/department/medbay{
+	dir = 4;
+	pixel_x = 24
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/machinery/disposal,
+/obj/machinery/camera/network/medbay{
+	dir = 10;
+	icon_state = "camera"
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/breakroom)
+"aTb" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/borderfloorwhite{
-	dir = 6
+	dir = 4
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
-	dir = 6
+	dir = 4
 	},
 /obj/effect/floor_decal/borderfloorwhite/corner2{
 	dir = 6
@@ -24742,16 +24963,6 @@
 /obj/effect/floor_decal/corner/paleblue/bordercorner2{
 	dir = 6
 	},
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/breakroom)
-"aTa" = (
-/obj/machinery/light/small,
-/obj/effect/floor_decal/borderfloorwhite,
-/obj/effect/floor_decal/corner/paleblue/border,
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/lowerhall)
-"aTb" = (
-/obj/machinery/door/firedoor/glass/hidden/steel,
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/lowerhall)
 "aTc" = (
@@ -24762,7 +24973,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/techfloor,
-/area/tether/surfacebase/medical/lowerhall)
+/area/tether/surfacebase/medical/breakroom)
 "aTd" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/visible/supply,
@@ -24794,6 +25005,11 @@
 /obj/machinery/alarm{
 	pixel_y = 22
 	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/lower/mining)
 "aTh" = (
@@ -24816,67 +25032,50 @@
 /turf/simulated/floor/plating,
 /area/vacant/vacant_site/gateway/lower)
 "aTj" = (
-/obj/effect/floor_decal/borderfloorwhite,
-/obj/effect/floor_decal/corner/paleblue/border,
-/obj/machinery/alarm{
-	dir = 1;
-	icon_state = "alarm0";
-	pixel_y = -22
-	},
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/lowerhall)
-"aTk" = (
-/obj/effect/floor_decal/borderfloorwhite,
-/obj/effect/floor_decal/corner/paleblue/border,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_x = 0;
-	pixel_y = -24
-	},
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/lowerhall)
-"aTl" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 6
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
+/obj/machinery/light,
+/turf/simulated/floor/tiled/techfloor,
+/area/tether/surfacebase/medical/morgue)
+"aTk" = (
+/obj/machinery/door/firedoor/glass,
+/obj/structure/grille,
+/obj/structure/window/reinforced/polarized/full{
+	id = "surfresleeving"
+	},
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/medical/resleeving)
+"aTl" = (
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/lowerhall)
+/area/tether/surfacebase/medical/breakroom)
 "aTm" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
+/obj/item/device/radio/intercom{
+	dir = 4;
+	pixel_x = 24
+	},
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/structure/table/standard,
+/obj/item/weapon/storage/mre/random,
+/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/lowerhall)
+/area/tether/surfacebase/medical/breakroom)
 "aTn" = (
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 6
+/obj/machinery/hologram/holopad,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
 	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 6
-	},
-/obj/machinery/alarm{
-	dir = 1;
-	icon_state = "alarm0";
-	pixel_y = -22
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/lowerhall)
+/area/tether/surfacebase/medical/resleeving)
 "aTo" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -25119,6 +25318,15 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/lowerhallway)
+"aTI" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/reading_room)
 "aTJ" = (
 /obj/effect/floor_decal/borderfloor/shifted{
 	dir = 1;
@@ -25139,6 +25347,20 @@
 /obj/structure/bed/padded,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/solitary)
+"aTK" = (
+/obj/machinery/door/airlock{
+	id_tag = "ReadingRoom3";
+	name = "Room 3"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/reading_room)
 "aTL" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -25493,6 +25715,21 @@
 "aUk" = (
 /turf/simulated/wall/r_wall,
 /area/tether/surfacebase/security/evidence)
+"aUl" = (
+/obj/machinery/button/remote/airlock{
+	id = "ReadingRoom3";
+	name = "Room 3 Bolt";
+	pixel_y = 30;
+	specialfunctions = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/reading_room)
 "aUm" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 4
@@ -25669,6 +25906,16 @@
 	},
 /turf/simulated/floor,
 /area/tether/surfacebase/security/gasstorage)
+"aUD" = (
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/reading_room)
 "aUE" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -26015,6 +26262,15 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/lowerhallway)
+"aVb" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/reading_room)
 "aVc" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -26296,6 +26552,16 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/lowerhallway)
+"aVr" = (
+/obj/structure/table/glass,
+/obj/machinery/photocopier/faxmachine{
+	department = "Reading Room"
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/reading_room)
 "aVs" = (
 /obj/structure/railing{
 	dir = 4
@@ -26312,6 +26578,15 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/north)
+"aVt" = (
+/obj/machinery/door/airlock{
+	name = "Reading Room"
+	},
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/reading_room)
 "aVu" = (
 /obj/machinery/power/sensor{
 	name = "Powernet Sensor - Command Subgrid";
@@ -26388,6 +26663,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/brig)
+"aVA" = (
+/turf/simulated/wall,
+/area/tether/surfacebase/southhall)
+"aVB" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/reading_room)
 "aVC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
@@ -26415,6 +26699,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/lowerhallway)
+"aVE" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/southhall)
 "aVF" = (
 /obj/machinery/door/firedoor/glass,
 /obj/structure/grille,
@@ -26548,6 +26839,12 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/brig)
+"aVO" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/southhall)
 "aVP" = (
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/interrogation)
@@ -26634,6 +26931,10 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/brig)
+"aVV" = (
+/obj/structure/stairs/west,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/southhall)
 "aVW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -26650,6 +26951,13 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/brig)
+"aVX" = (
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/southhall)
+"aVY" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/southhall)
 "aVZ" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -26870,6 +27178,21 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/interrogation)
+"aWo" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/machinery/door/firedoor,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/southhall)
+"aWp" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/southhall)
 "aWq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -27210,6 +27533,16 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/rnd/outpost/xenobiology/outpost_slimepens)
+"aWN" = (
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 28
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/southhall)
 "aWO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/green{
 	dir = 9;
@@ -27408,6 +27741,13 @@
 	},
 /turf/simulated/floor/carpet/sblucarpet,
 /area/bridge/meeting_room)
+"aXi" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/machinery/door/firedoor,
+/obj/structure/window/reinforced,
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/southhall)
 "aXj" = (
 /obj/machinery/power/apc{
 	dir = 4;
@@ -27458,6 +27798,16 @@
 	dir = 1;
 	icon_state = "railing0"
 	},
+/obj/structure/cable/green,
+/obj/structure/cable/green{
+	icon_state = "16-0"
+	},
+/obj/machinery/atmospherics/pipe/zpipe/up/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/zpipe/up/scrubbers{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/mining)
 "aXp" = (
@@ -27471,6 +27821,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/command)
+"aXq" = (
+/obj/structure/table/steel,
+/obj/item/weapon/surgical/scalpel,
+/obj/item/weapon/autopsy_scanner,
+/obj/item/weapon/surgical/cautery,
+/obj/effect/floor_decal/techfloor,
+/turf/simulated/floor/tiled/techfloor,
+/area/tether/surfacebase/medical/morgue)
 "aXr" = (
 /turf/simulated/wall,
 /area/maintenance/substation/command)
@@ -27493,6 +27851,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/commandmaint)
+"aXu" = (
+/obj/machinery/optable,
+/turf/simulated/floor/tiled/techfloor,
+/area/tether/surfacebase/medical/morgue)
 "aXv" = (
 /obj/machinery/firealarm{
 	dir = 2;
@@ -27548,8 +27910,47 @@
 	icon_state = "1-2";
 	pixel_y = 0
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/tether/surfacebase/surface_two_hall)
+"aXB" = (
+/obj/structure/table/standard,
+/obj/item/clothing/gloves/sterile/nitrile,
+/obj/item/clothing/gloves/sterile/nitrile,
+/obj/item/device/defib_kit/loaded,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 5
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/machinery/camera/network/medbay{
+	dir = 8;
+	icon_state = "camera"
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/storage)
+"aXC" = (
+/obj/structure/table/steel,
+/obj/item/weapon/folder/white,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/tether/surfacebase/medical/morgue)
+"aXD" = (
+/obj/structure/stairs/west,
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/stairwell)
 "aXE" = (
 /obj/structure/cable,
 /obj/machinery/power/terminal{
@@ -27742,6 +28143,12 @@
 "aYd" = (
 /turf/simulated/wall,
 /area/chapel/main)
+"aYe" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/stairwell)
 "aYf" = (
 /obj/structure/table/woodentable,
 /obj/machinery/photocopier/faxmachine{
@@ -27769,6 +28176,78 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge_hallway)
+"aYj" = (
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 25;
+	pixel_y = 0
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/stairwell)
+"aYk" = (
+/obj/structure/stairs/west,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/stairwell)
+"aYl" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/stairwell)
+"aYm" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/stairwell)
 "aYn" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
@@ -27781,6 +28260,30 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge_hallway)
+"aYo" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 6
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/stairwell)
 "aYp" = (
 /turf/simulated/floor/tiled/dark,
 /area/chapel/chapel_morgue)
@@ -27829,6 +28332,88 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge_hallway)
+"aYt" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/maintenance/medical{
+	name = "Medical Maintenance Access"
+	},
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/tether/surfacebase/medical/stairwell)
+"aYu" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/holoplant,
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/stairwell)
+"aYv" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/stairwell)
+"aYw" = (
+/obj/machinery/light,
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/paleblue/border,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/stairwell)
+"aYx" = (
+/obj/structure/table/glass,
+/obj/random/mre,
+/obj/random/coin,
+/obj/random/maintenance/medical,
+/obj/random/medical,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/stairwell)
+"aYy" = (
+/obj/structure/table/glass,
+/obj/random/contraband,
+/obj/random/firstaid,
+/obj/random/maintenance/medical,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/stairwell)
 "aYz" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -27864,6 +28449,26 @@
 	},
 /turf/simulated/floor/wood,
 /area/bridge/meeting_room)
+"aYB" = (
+/obj/machinery/door/airlock/maintenance/medical{
+	name = "Medical Maintenance Access"
+	},
+/obj/machinery/door/firedoor/glass,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/stairwell)
+"aYC" = (
+/turf/simulated/wall,
+/area/maintenance/surfacebase/lowmedbaymaint)
+"aYD" = (
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/surfacebase/lowmedbaymaint)
 "aYE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -27882,6 +28487,54 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel/chapel_morgue)
+"aYG" = (
+/obj/machinery/door/airlock/medical{
+	id_tag = null;
+	name = "Resleeving Backroom";
+	req_access = list();
+	req_one_access = list()
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/tether/surfacebase/medical/resleeving)
+"aYH" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/light_switch{
+	dir = 2;
+	name = "light switch ";
+	pixel_x = 24;
+	pixel_y = 32
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/storage)
+"aYI" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/light_switch{
+	dir = 8;
+	on = 0;
+	pixel_x = 24;
+	pixel_y = -22
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/storage)
 "aYJ" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -27892,6 +28545,17 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge_hallway)
+"aYK" = (
+/obj/structure/closet/secure_closet/medical2,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/machinery/camera/network/medbay{
+	dir = 10;
+	icon_state = "camera"
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/surgery2)
 "aYL" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -27964,6 +28628,64 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel/chapel_morgue)
+"aYQ" = (
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/machinery/camera/network/medbay{
+	dir = 10;
+	icon_state = "camera"
+	},
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/paleblue/border,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/patient)
+"aYR" = (
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/camera/network/medbay{
+	dir = 10;
+	icon_state = "camera"
+	},
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/paleblue/border,
+/obj/effect/floor_decal/borderfloorwhite/corner2{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner2{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lowerhall)
+"aYS" = (
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/light,
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/paleblue/border,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lowerhall)
 "aYT" = (
 /obj/machinery/power/apc{
 	dir = 4;
@@ -27977,6 +28699,18 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge_hallway)
+"aYU" = (
+/obj/machinery/camera/network/medbay,
+/turf/simulated/open,
+/area/tether/surfacebase/medical/stairwell)
+"aYV" = (
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/machinery/camera/network/medbay{
+	dir = 10;
+	icon_state = "camera"
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/breakroom)
 "aYW" = (
 /obj/structure/closet/coffin,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -27997,6 +28731,23 @@
 	},
 /turf/simulated/floor/wood,
 /area/bridge/meeting_room)
+"aYY" = (
+/obj/structure/table/steel,
+/obj/item/device/sleevemate,
+/obj/item/device/camera{
+	name = "Autopsy Camera";
+	pixel_x = -2;
+	pixel_y = 7
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/camera/network/medbay{
+	dir = 10;
+	icon_state = "camera"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/tether/surfacebase/medical/morgue)
 "aYZ" = (
 /obj/structure/grille,
 /obj/machinery/door/firedoor/glass,
@@ -28008,6 +28759,54 @@
 	can_open = 0
 	},
 /area/maintenance/lower/bar)
+"aZb" = (
+/obj/machinery/camera/network/medbay{
+	dir = 4;
+	icon_state = "camera"
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/storage)
+"aZc" = (
+/obj/machinery/camera/network/medbay{
+	dir = 10;
+	icon_state = "camera"
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 10
+	},
+/obj/effect/floor_decal/borderfloorwhite/corner2{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner2{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/stairwell)
+"aZd" = (
+/obj/machinery/hologram/holopad,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloorwhite/corner2{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner2{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/patient)
 "aZe" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -28045,6 +28844,20 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/maintenance/commandmaint)
+"aZi" = (
+/obj/item/device/radio/intercom{
+	dir = 1;
+	pixel_y = 24;
+	req_access = list()
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lowerhall)
 "aZl" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 1
@@ -28132,6 +28945,9 @@
 	dir = 4
 	},
 /obj/random/trash_pile,
+/obj/structure/railing{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/south)
 "aZE" = (
@@ -28542,6 +29358,16 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/techmaint,
 /area/tether/surfacebase/surface_two_hall)
+"bju" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lowerhall)
 "bkW" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -28568,10 +29394,84 @@
 /obj/random/cutout,
 /turf/simulated/floor/plating,
 /area/maintenance/lower/atmos)
+"bqJ" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/lower/bar)
+"bvD" = (
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/storage)
 "bvS" = (
 /obj/machinery/door/firedoor/glass/hidden,
 /turf/simulated/floor/tiled/techmaint,
 /area/tether/surfacebase/surface_two_hall)
+"bDS" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 1
+	},
+/obj/machinery/vending/cigarette{
+	name = "Cigarette machine";
+	prices = list();
+	products = list(/obj/item/weapon/storage/fancy/cigarettes = 10, /obj/item/weapon/storage/box/matches = 10, /obj/item/weapon/flame/lighter/zippo = 4, /obj/item/clothing/mask/smokable/cigarette/cigar/havana = 2)
+	},
+/obj/effect/floor_decal/techfloor/hole{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/lower/bar)
+"bGA" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lowerhall)
+"bHt" = (
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/lower/north)
+"bSO" = (
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/breakroom)
+"bVB" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 9
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lowerhall)
 "ceC" = (
 /obj/structure/catwalk,
 /obj/machinery/light/small{
@@ -28589,6 +29489,52 @@
 /obj/random/cutout,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/north)
+"cqN" = (
+/obj/structure/bookcase/manuals/medical,
+/obj/item/weapon/book/manual/resleeving,
+/obj/item/weapon/book/manual/stasis,
+/obj/item/weapon/book/manual/medical_diagnostics_manual{
+	pixel_y = 7
+	},
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/breakroom)
+"cvH" = (
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/resleeving)
+"cvP" = (
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/breakroom)
+"czO" = (
+/obj/machinery/light/small{
+	dir = 1;
+	icon_state = "bulb1"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/lower/bar)
+"cFp" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 4
+	},
+/obj/structure/bed/padded,
+/obj/item/weapon/bedsheet/purple,
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/lower/bar)
 "cHg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 1
@@ -28602,6 +29548,29 @@
 /obj/effect/catwalk_plated/dark,
 /turf/simulated/open,
 /area/maintenance/lower/bar)
+"cHx" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 6
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/stairwell)
 "cIm" = (
 /obj/effect/floor_decal/borderfloor/corner{
 	dir = 8
@@ -28617,6 +29586,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/techmaint,
 /area/tether/surfacebase/surface_two_hall)
+"cOS" = (
+/obj/structure/table/steel,
+/obj/machinery/recharger,
+/obj/item/weapon/storage/toolbox/mechanical,
+/obj/random/drinkbottle,
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/lower/bar)
 "cZo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -28624,12 +29600,59 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
+/obj/effect/landmark{
+	name = "lightsout"
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/tether/surfacebase/surface_two_hall)
+"dbq" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/resleeving)
+"dep" = (
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lowerhall)
 "dgA" = (
 /obj/structure/bed/chair/comfy/brown,
 /turf/simulated/floor/wood,
 /area/rnd/breakroom)
+"dji" = (
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lowerhall)
+"doE" = (
+/obj/structure/catwalk,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/maintenance/lower/south)
 "drH" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -28649,6 +29672,41 @@
 /obj/structure/railing,
 /turf/simulated/floor/plating,
 /area/maintenance/lower/rnd)
+"dtm" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 9
+	},
+/obj/structure/table/glass,
+/obj/random/medical,
+/obj/random/medical,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lowerhall)
+"dvS" = (
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/lower/bar)
+"dBl" = (
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/resleeving)
+"dCn" = (
+/obj/effect/floor_decal/techfloor,
+/obj/effect/floor_decal/techfloor/hole/right,
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -25
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/lower/bar)
 "dEl" = (
 /obj/structure/bed/chair/comfy/brown{
 	dir = 8
@@ -28665,6 +29723,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/lower/bar)
+"dQh" = (
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 8;
+	icon_state = "warningcorner"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/lower/bar)
 "dQj" = (
 /obj/structure/catwalk,
 /obj/structure/cable{
@@ -28679,6 +29744,75 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/lower/mining)
+"dYs" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lowerhall)
+"dZb" = (
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/breakroom)
+"ehM" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lowerhall)
+"ekD" = (
+/obj/structure/sink{
+	dir = 4;
+	icon_state = "sink";
+	pixel_x = 11;
+	pixel_y = 0
+	},
+/obj/structure/mirror{
+	dir = 4;
+	pixel_x = 25;
+	pixel_y = 0
+	},
+/obj/effect/floor_decal/techfloor{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/tether/surfacebase/medical/resleeving)
+"ekX" = (
+/obj/effect/floor_decal/techfloor,
+/obj/machinery/vending/wallmed1/public{
+	pixel_y = -28
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/lower/bar)
+"elI" = (
+/obj/machinery/door/firedoor/glass,
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/lower/bar)
 "emJ" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -28699,6 +29833,33 @@
 /obj/machinery/door/firedoor/glass/hidden,
 /turf/simulated/floor/tiled/techmaint,
 /area/tether/surfacebase/surface_two_hall)
+"enU" = (
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable/green{
+	icon_state = "1-4"
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 4;
+	icon_state = "pipe-j1"
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lowerhall)
 "exx" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -28713,12 +29874,131 @@
 	},
 /turf/simulated/floor,
 /area/maintenance/lower/security)
+"eKf" = (
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/stairwell)
+"eKj" = (
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lowerhall)
+"ePA" = (
+/obj/random/cutout,
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/lower/bar)
 "eXR" = (
 /obj/machinery/door/firedoor/glass/hidden{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/tether/surfacebase/surface_two_hall)
+"ffd" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/dark,
+/area/tether/surfacebase/medical/resleeving)
+"fiR" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lowerhall)
+"fll" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/black,
+/obj/machinery/telecomms/receiver/preset_right/tether,
+/turf/simulated/floor/bluegrid{
+	name = "Mainframe Base";
+	nitrogen = 100;
+	oxygen = 0;
+	temperature = 80
+	},
+/area/tcommsat/chamber)
+"frL" = (
+/obj/effect/landmark{
+	name = "lightsout"
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/paleblue/border,
+/obj/effect/floor_decal/borderfloorwhite/corner2,
+/obj/effect/floor_decal/corner/paleblue/bordercorner2,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lowerhall)
+"fzr" = (
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4;
+	icon_state = "map-scrubbers"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/breakroom)
+"fFg" = (
+/obj/structure/table/standard,
+/obj/item/weapon/storage/box/syringegun,
+/obj/item/weapon/gun/launcher/syringe,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 10
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/storage)
 "fGk" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -28750,6 +30030,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/lower/north)
+"fXO" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/storage)
 "fYA" = (
 /obj/structure/catwalk,
 /obj/structure/cable{
@@ -28772,12 +30060,70 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/tether/surfacebase/surface_two_hall)
+"gnB" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 9
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/body_scanconsole{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lowerhall)
+"gyR" = (
+/obj/structure/symbol/sa,
+/turf/simulated/wall{
+	can_open = 1
+	},
+/area/maintenance/lower/bar)
 "gDW" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/tether/surfacebase/surface_two_hall)
+"gNE" = (
+/obj/machinery/alarm{
+	pixel_y = 22
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lowerhall)
+"gOq" = (
+/obj/structure/table/standard,
+/obj/item/weapon/storage/firstaid/fire{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/item/weapon/storage/firstaid/fire{
+	pixel_x = 0;
+	pixel_y = 0
+	},
+/obj/effect/floor_decal/corner/yellow/full{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/storage)
 "gPa" = (
 /obj/structure/catwalk,
 /obj/structure/disposalpipe/segment,
@@ -28785,11 +30131,58 @@
 /obj/machinery/atmospherics/pipe/simple/visible/supply,
 /turf/simulated/floor/plating,
 /area/maintenance/lower/mining)
+"hpJ" = (
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 10
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lowerhall)
 "hCD" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/tiled/techmaint,
 /area/tether/surfacebase/surface_two_hall)
+"hKn" = (
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/light_switch{
+	dir = 4;
+	pixel_x = -30;
+	pixel_y = -24
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 6
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/resleeving)
 "hNH" = (
 /obj/structure/catwalk,
 /obj/structure/cable{
@@ -28800,6 +30193,64 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/open,
 /area/maintenance/lower/bar)
+"hXR" = (
+/obj/structure/catwalk,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/lower/south)
+"idN" = (
+/obj/structure/closet/wardrobe/pjs,
+/obj/item/weapon/handcuffs/fuzzy,
+/obj/item/weapon/handcuffs/fuzzy,
+/obj/item/weapon/handcuffs/legcuffs/fuzzy,
+/obj/item/weapon/handcuffs/fuzzy,
+/obj/item/clothing/accessory/shiny/socks,
+/obj/item/clothing/under/shiny/catsuit,
+/obj/item/clothing/accessory/shiny/gloves,
+/obj/item/clothing/head/shiny_hood,
+/obj/effect/floor_decal/techfloor{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/lower/bar)
+"ioB" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lowerhall)
 "isi" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor/glass/hidden{
@@ -28832,6 +30283,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/lower/rnd)
+"iGg" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 5
+	},
+/obj/structure/table/steel,
+/obj/item/weapon/storage/fancy/candle_box,
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/lower/bar)
 "iGv" = (
 /obj/effect/floor_decal/borderfloor/corner{
 	dir = 1
@@ -28848,6 +30307,18 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/techmaint,
 /area/tether/surfacebase/surface_two_hall)
+"iJb" = (
+/obj/machinery/computer/security/telescreen/entertainment{
+	desc = "Looks like it's set to ree-Anur-ntertanment, I wonder what else is on?";
+	icon_state = "frame";
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/obj/structure/table/glass,
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/breakroom)
 "iJj" = (
 /obj/machinery/door/firedoor/glass,
 /obj/structure/disposalpipe/segment,
@@ -28858,12 +30329,44 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/tether/surfacebase/surface_two_hall)
+"iOZ" = (
+/obj/machinery/door/firedoor/glass/hidden/steel{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/paleblue/border,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lowerhall)
 "iRp" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/drone_fabrication)
+"iVf" = (
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/resleeving)
 "jfi" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -28873,6 +30376,22 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/tether/surfacebase/surface_two_hall)
+"jgw" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/storage)
+"jje" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/techfloor/hole{
+	dir = 4;
+	icon_state = "techfloor_hole_left"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/lower/bar)
 "jnL" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -28883,15 +30402,148 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/tether/surfacebase/surface_two_hall)
+"jpv" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/resleeving)
+"jrt" = (
+/obj/structure/bed/chair/wheelchair{
+	dir = 4
+	},
+/obj/machinery/light,
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/paleblue/border,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/storage)
+"jxF" = (
+/obj/effect/landmark/start{
+	name = "Paramedic"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/effect/floor_decal/borderfloorwhite/corner{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/storage)
+"jAv" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/storage)
+"jDa" = (
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/camera/network/medbay{
+	dir = 10;
+	icon_state = "camera"
+	},
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/paleblue/border,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lowerhall)
+"jGD" = (
+/obj/machinery/door/airlock/medical{
+	id_tag = "SurfMedicalResleeving";
+	name = "Resleeving Lab";
+	req_access = list(5)
+	},
+/obj/machinery/door/firedoor/glass,
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/resleeving)
+"jUn" = (
+/obj/effect/floor_decal/corner_techfloor_grid{
+	dir = 8
+	},
+/obj/effect/floor_decal/techfloor/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/dark,
+/area/tether/surfacebase/medical/resleeving)
 "kaa" = (
 /obj/random/cutout,
 /turf/simulated/floor,
 /area/maintenance/lower/south)
+"kfr" = (
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 1;
+	icon_state = "warningcorner"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/lower/bar)
+"kfs" = (
+/obj/structure/table/standard,
+/obj/item/device/glasses_kit,
+/obj/item/weapon/storage/box/rxglasses,
+/obj/item/weapon/storage/box/rxglasses,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/storage)
+"kim" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/lower/bar)
 "knh" = (
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/airlock/maintenance/common,
 /turf/simulated/floor/plating,
 /area/tether/surfacebase/north_staires_two)
+"knE" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/black,
+/obj/machinery/telecomms/broadcaster/preset_right/tether,
+/turf/simulated/floor/bluegrid{
+	name = "Mainframe Base";
+	nitrogen = 100;
+	oxygen = 0;
+	temperature = 80
+	},
+/area/tcommsat/chamber)
+"krY" = (
+/obj/structure/table/steel,
+/obj/random/medical/lite,
+/obj/item/stack/cable_coil,
+/obj/item/weapon/tape_roll,
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/lower/bar)
 "ksZ" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -28947,6 +30599,41 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/techmaint,
 /area/tether/surfacebase/surface_two_hall)
+"kLp" = (
+/obj/random/soap,
+/obj/structure/table/standard,
+/obj/effect/floor_decal/techfloor{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/tether/surfacebase/medical/resleeving)
+"kLV" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/borderfloorwhite/corner{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lowerhall)
+"kPO" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 4
+	},
+/obj/structure/bed/padded,
+/obj/item/weapon/bedsheet/red,
+/obj/effect/floor_decal/techfloor/hole/right{
+	dir = 4;
+	icon_state = "techfloor_hole_right"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/lower/bar)
 "kYW" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -28978,12 +30665,154 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/techmaint,
 /area/tether/surfacebase/surface_two_hall)
+"lgy" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 10
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/resleeving)
 "lkN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/tether/surfacebase/surface_two_hall)
+"ltw" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 9
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/machinery/alarm{
+	pixel_y = 28
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lowerhall)
+"lBF" = (
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/light,
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/paleblue/border,
+/obj/effect/floor_decal/borderfloorwhite/corner2{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner2{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lowerhall)
+"lFx" = (
+/obj/machinery/door/airlock/multi_tile/glass{
+	name = "Medbay Breakroom";
+	req_access = list(5);
+	req_one_access = list(5)
+	},
+/obj/machinery/door/firedoor/glass,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/breakroom)
+"lGa" = (
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lowerhall)
+"lHK" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 9
+	},
+/obj/machinery/camera/network/medbay,
+/obj/machinery/bodyscanner{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lowerhall)
+"lJe" = (
+/obj/structure/cable/green{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/storage)
+"lMc" = (
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/breakroom)
+"lNd" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lowerhall)
+"lTd" = (
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/visible/supply,
+/obj/structure/disposalpipe/junction{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/lower/bar)
 "lVd" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/visible/scrubbers{
@@ -28999,6 +30828,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/lower/bar)
+"lWi" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/storage)
 "maZ" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -29011,6 +30849,34 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/tether/surfacebase/surface_two_hall)
+"mgJ" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lowerhall)
+"miD" = (
+/obj/machinery/door/airlock/glass_medical{
+	name = "Medbay Equipment";
+	req_access = list(5)
+	},
+/obj/machinery/door/firedoor/glass,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/storage)
 "msI" = (
 /obj/machinery/door/airlock/maintenance/common,
 /obj/machinery/door/firedoor/glass,
@@ -29018,6 +30884,22 @@
 /obj/machinery/atmospherics/pipe/simple/visible/supply,
 /turf/simulated/floor,
 /area/maintenance/lower/north)
+"mtl" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8;
+	icon_state = "warning"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/lower/bar)
+"mzH" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/techfloor/hole{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/lower/bar)
 "mDI" = (
 /obj/structure/catwalk,
 /obj/structure/cable{
@@ -29045,6 +30927,19 @@
 /obj/machinery/atmospherics/pipe/simple/visible/scrubbers,
 /turf/simulated/floor/plating,
 /area/maintenance/lower/north)
+"mIX" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lowerhall)
 "mLQ" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -29058,6 +30953,40 @@
 /obj/machinery/door/firedoor/glass/hidden,
 /turf/simulated/floor/tiled/techmaint,
 /area/tether/surfacebase/surface_two_hall)
+"mRO" = (
+/obj/machinery/smartfridge/chemistry/chemvator/down,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/storage)
+"mYS" = (
+/obj/item/weapon/cane,
+/obj/item/weapon/cane,
+/obj/structure/table/standard,
+/obj/random/medical,
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/paleblue/border,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/storage)
+"nhq" = (
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/maintenance/common,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/lower/bar)
+"nsn" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 1
+	},
+/obj/machinery/vending/sovietsoda,
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/lower/bar)
 "nKP" = (
 /obj/machinery/alarm{
 	dir = 8;
@@ -29132,6 +31061,41 @@
 /obj/effect/floor_decal/corner/yellow/bordercorner2,
 /turf/simulated/floor/tiled/techmaint,
 /area/tether/surfacebase/surface_two_hall)
+"ocQ" = (
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/obj/machinery/computer/guestpass{
+	dir = 1;
+	icon_state = "guest";
+	pixel_y = -28
+	},
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/paleblue/border,
+/obj/effect/floor_decal/borderfloorwhite/corner2{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner2{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/resleeving)
+"ojT" = (
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/obj/effect/landmark/start{
+	name = "Medical Doctor"
+	},
+/obj/machinery/power/apc{
+	dir = 2;
+	name = "south bump";
+	pixel_y = -24
+	},
+/obj/structure/cable/green,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/breakroom)
 "okd" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -29166,6 +31130,33 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/lower/rnd)
+"omy" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/lower/bar)
+"oqi" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lowerhall)
+"ovt" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 4
+	},
+/obj/structure/bed/padded,
+/obj/item/weapon/bedsheet/mime,
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/lower/bar)
+"owI" = (
+/obj/effect/floor_decal/techfloor,
+/obj/effect/floor_decal/techfloor{
+	dir = 10
+	},
+/obj/machinery/light/small,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/dark,
+/area/tether/surfacebase/medical/resleeving)
 "oIf" = (
 /obj/structure/catwalk,
 /obj/structure/disposalpipe/segment{
@@ -29176,6 +31167,72 @@
 /obj/machinery/atmospherics/pipe/simple/visible/scrubbers,
 /turf/simulated/floor/plating,
 /area/maintenance/lower/north)
+"oKm" = (
+/obj/machinery/door/airlock/multi_tile/glass{
+	name = "Medbay Airlock";
+	req_access = list(5);
+	req_one_access = list(5)
+	},
+/obj/machinery/door/firedoor/multi_tile,
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lowerhall)
+"oNf" = (
+/obj/structure/table/standard,
+/obj/effect/floor_decal/techfloor{
+	dir = 6
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/tether/surfacebase/medical/resleeving)
+"oOs" = (
+/obj/machinery/door/airlock/maintenance/common,
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/lower/south)
+"oVi" = (
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 2
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/storage)
+"oVp" = (
+/obj/machinery/door/firedoor/glass,
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/medical/breakroom)
 "oWH" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -29239,6 +31296,45 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/north_staires_two)
+"pny" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/resleeving)
+"poM" = (
+/obj/machinery/button/crematorium{
+	pixel_x = -4;
+	pixel_y = 28;
+	req_access = list();
+	req_one_access = list(27,6)
+	},
+/turf/simulated/floor/tiled/dark,
+/area/chapel/chapel_morgue)
+"ppv" = (
+/obj/structure/cable/green{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lowerhall)
 "ppI" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -29268,6 +31364,24 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/techmaint,
 /area/tether/surfacebase/surface_two_hall)
+"psj" = (
+/obj/structure/catwalk,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/visible/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/visible/supply{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/lower/mining)
 "pvh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -29301,6 +31415,28 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/tether/surfacebase/surface_two_hall)
+"pBa" = (
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/breakroom)
+"pFq" = (
+/obj/structure/closet,
+/obj/random/tool,
+/obj/random/toolbox,
+/obj/random/powercell,
+/obj/random/maintenance/cargo,
+/obj/random/maintenance/cargo,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/clean,
+/obj/random/action_figure,
+/obj/effect/floor_decal/techfloor{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/lower/bar)
 "pGt" = (
 /obj/machinery/door/firedoor/glass,
 /obj/structure/cable{
@@ -29311,6 +31447,24 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/tether/surfacebase/surface_two_hall)
+"pTc" = (
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 2
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lowerhall)
 "pUx" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -29329,22 +31483,23 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/tether/surfacebase/surface_two_hall)
+"pZz" = (
+/obj/structure/sink{
+	dir = 4;
+	icon_state = "sink";
+	pixel_x = 11;
+	pixel_y = 0
+	},
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/breakroom)
 "qaW" = (
-/obj/structure/table/bench/standard,
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/structure/bed/chair{
+	dir = 4
+	},
 /obj/effect/landmark/start{
 	name = "Medical Doctor"
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 1
-	},
-/obj/machinery/computer/security/telescreen/entertainment{
-	desc = "Looks like it's set to ree-Anur-ntertanment, I wonder what else is on?";
-	icon_state = "frame";
-	pixel_x = 0;
-	pixel_y = 32
 	},
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/breakroom)
@@ -29364,6 +31519,24 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/lower/north)
+"qhu" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 8
+	},
+/obj/item/device/radio/intercom/department/medbay{
+	dir = 8;
+	pixel_x = -24
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/machinery/disposal,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/storage)
 "qrg" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -29374,6 +31547,45 @@
 /obj/machinery/door/firedoor/glass/hidden,
 /turf/simulated/floor/tiled/techmaint,
 /area/tether/surfacebase/surface_two_hall)
+"qGx" = (
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -25
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable/green{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/paleblue/border,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lowerhall)
+"qLK" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/techfloor/hole/right{
+	dir = 1
+	},
+/obj/machinery/status_display{
+	pixel_y = 30
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/lower/bar)
 "qNo" = (
 /obj/structure/cable{
 	icon_state = "16-0"
@@ -29386,6 +31598,57 @@
 /obj/structure/disposalpipe/up,
 /turf/simulated/floor/plating,
 /area/maintenance/lower/rnd)
+"qPL" = (
+/obj/structure/table/standard,
+/obj/item/weapon/storage/box/beakers,
+/obj/random/medical,
+/obj/machinery/status_display{
+	pixel_x = 32;
+	pixel_y = 0
+	},
+/obj/item/weapon/storage/firstaid/regular,
+/obj/item/weapon/storage/firstaid/regular{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/storage)
+"qQc" = (
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -28
+	},
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/reading_room)
+"qSw" = (
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/stairwell)
+"qUC" = (
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/structure/bed/chair{
+	dir = 8
+	},
+/obj/effect/landmark/start{
+	name = "Medical Doctor"
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/breakroom)
 "qXI" = (
 /obj/machinery/requests_console{
 	department = "Science";
@@ -29427,6 +31690,84 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/lower/north)
+"rkH" = (
+/obj/machinery/alarm{
+	pixel_y = 22
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 5
+	},
+/obj/effect/floor_decal/borderfloorwhite/corner2{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner2{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lowerhall)
+"rnG" = (
+/obj/structure/catwalk,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/lower/south)
+"rpV" = (
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/breakroom)
+"rqc" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lowerhall)
+"ryh" = (
+/obj/machinery/door/firedoor/glass/hidden/steel{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/paleblue/border,
+/obj/effect/floor_decal/borderfloorwhite/corner2{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner2{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lowerhall)
 "rGt" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -29436,6 +31777,103 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/tether/surfacebase/surface_two_hall)
+"rKK" = (
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/paleblue/border,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lowerhall)
+"rPF" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 9
+	},
+/obj/structure/table/glass,
+/obj/item/device/defib_kit/loaded,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = -24
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lowerhall)
+"sab" = (
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_x = 0;
+	pixel_y = 24
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lowerhall)
+"sfF" = (
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 2
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/paleblue/border,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lowerhall)
+"ska" = (
+/obj/random/cigarettes,
+/obj/random/toy,
+/obj/random/tech_supply,
+/obj/random/junk,
+/obj/item/weapon/flame/lighter/zippo,
+/turf/simulated/floor/plating,
+/area/maintenance/lower/bar)
+"smC" = (
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/paleblue/border,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = -24
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lowerhall)
 "svN" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -29449,11 +31887,18 @@
 	icon_state = "1-2";
 	pixel_y = 0
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/tether/surfacebase/surface_two_hall)
+"sMe" = (
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/storage)
+"sYH" = (
+/obj/machinery/space_heater,
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/lower/bar)
 "tgA" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -29469,6 +31914,15 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/engineering/drone_fabrication)
+"thm" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/storage)
+"tnD" = (
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/breakroom)
 "toV" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
@@ -29482,6 +31936,56 @@
 	},
 /turf/simulated/floor/plating,
 /area/engineering/drone_fabrication)
+"trq" = (
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/paleblue/border,
+/obj/effect/floor_decal/borderfloorwhite/corner2,
+/obj/effect/floor_decal/corner/paleblue/bordercorner2,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lowerhall)
+"tzo" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/resleeving)
+"tzH" = (
+/obj/structure/table/standard,
+/obj/machinery/microwave,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/breakroom)
+"tGL" = (
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/storage)
 "tIb" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -29508,12 +32012,36 @@
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/atmos)
+"tMi" = (
+/obj/effect/floor_decal/techfloor,
+/obj/effect/floor_decal/techfloor/hole,
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/lower/bar)
 "tRh" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/visible/supply,
 /obj/machinery/atmospherics/pipe/simple/visible/scrubbers,
 /turf/simulated/floor/plating,
 /area/maintenance/lower/north)
+"tTL" = (
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -23;
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/breakroom)
+"tVf" = (
+/obj/structure/catwalk,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/lower/bar)
 "tXA" = (
 /obj/machinery/door/firedoor/glass/hidden/steel{
 	dir = 1
@@ -29570,6 +32098,31 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/lower/north)
+"unp" = (
+/obj/structure/table/standard,
+/obj/item/device/sleevemate,
+/obj/item/device/radio/intercom{
+	dir = 4;
+	pixel_x = 24
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloorwhite/corner2{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner2{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/storage)
+"unv" = (
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/lower/north)
 "uoL" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -29585,6 +32138,47 @@
 /obj/machinery/atmospherics/pipe/simple/visible/supply,
 /turf/simulated/floor/plating,
 /area/maintenance/lower/north)
+"uMi" = (
+/obj/structure/table/standard,
+/obj/item/weapon/storage/box/donkpockets,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/breakroom)
+"uNf" = (
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/stairwell)
+"uNP" = (
+/obj/structure/lattice,
+/turf/simulated/open,
+/area/maintenance/lower/bar)
+"uQG" = (
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/paleblue/border,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lowerhall)
 "vgb" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1;
@@ -29606,6 +32200,18 @@
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/atmos)
+"vlq" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/dark,
+/area/tether/surfacebase/medical/resleeving)
 "vmO" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -29626,6 +32232,17 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/techmaint,
 /area/tether/surfacebase/surface_two_hall)
+"vnv" = (
+/obj/structure/cable/green{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/storage)
 "vvJ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -29641,6 +32258,120 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_two_hall)
+"vKe" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 8
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/lower/bar)
+"vRI" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/tether/surfacebase/surface_two_hall)
+"vXa" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloorwhite/corner2{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner2{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lowerhall)
+"wfh" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/techfloor/hole/right{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/lower/bar)
+"wfF" = (
+/obj/structure/table/standard,
+/obj/item/weapon/storage/box/lights/mixed,
+/obj/item/device/flashlight,
+/obj/item/device/radio{
+	pixel_x = -4
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/storage)
+"wrX" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/floor_decal/borderfloorwhite/corner{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lowerhall)
+"wxi" = (
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 4;
+	icon_state = "pipe-j1"
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lowerhall)
 "wBk" = (
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/airlock/multi_tile/metal/mait{
@@ -29678,6 +32409,13 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/drone_fabrication)
+"xey" = (
+/obj/effect/landmark/start{
+	name = "Medical Doctor"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/storage)
 "xiE" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -29691,8 +32429,8 @@
 	icon_state = "1-2";
 	pixel_y = 0
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/tether/surfacebase/surface_two_hall)
@@ -29705,6 +32443,54 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/tether/surfacebase/surface_two_hall)
+"xop" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/resleeving)
+"xpw" = (
+/turf/simulated/mineral,
+/area/maintenance/lower/mining)
+"xxj" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lowerhall)
+"xzM" = (
+/obj/machinery/hologram/holopad,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 2
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/storage)
+"xFz" = (
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/paleblue/border,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lowerhall)
 "xPU" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -29737,6 +32523,16 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/tether/surfacebase/surface_two_hall)
+"xVQ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/floor_decal/borderfloorwhite/corner{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lowerhall)
 
 (1,1,1) = {"
 aaa
@@ -40689,10 +43485,10 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
+aag
+aag
+aag
+aag
 aTt
 aPm
 acN
@@ -40831,15 +43627,15 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
+aaE
+aaW
+aby
+acB
 aTt
 aTt
 aTt
 aaS
-aUq
+acD
 aUq
 aUS
 exx
@@ -40973,14 +43769,14 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aac
-aac
-aac
-acD
+aaE
+abb
+abL
+aem
+aPq
+aPS
+aQp
+aQJ
 aan
 aan
 aan
@@ -41115,14 +43911,14 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aac
-aac
-aac
-aac
+aaE
+abc
+abM
+aer
+aPr
+aPU
+aQq
+aQK
 aan
 aaw
 aaL
@@ -41257,14 +44053,14 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aac
-aNz
-aNz
-aNz
+aag
+aag
+aag
+aag
+aag
+aPW
+aQw
+aYQ
 aan
 aax
 aaM
@@ -41399,14 +44195,14 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aac
-aNz
-aPW
-ahh
+aaF
+abe
+abN
+aes
+aPs
+aZd
+aQx
+aQT
 aan
 ahd
 aaN
@@ -41541,14 +44337,14 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aac
-aNz
-ayf
-aer
+aaF
+abf
+abP
+aeu
+aPI
+aPY
+aQA
+aRb
 aan
 aaz
 aan
@@ -41683,14 +44479,14 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aac
-aac
-aNz
-aPY
-aQw
+aaF
+abg
+abQ
+aeM
+aaH
+aQa
+aQC
+aRc
 aap
 aRm
 aaO
@@ -41825,22 +44621,22 @@ aab
 aab
 aab
 aab
-aab
-aab
-aac
+aaH
+aaH
+aaH
+aaH
+aaH
+aQb
+aQD
+aQb
 aaf
-aaf
-aNz
-aNz
-aQx
-aap
 aaB
 aaP
-aRX
+aaP
 aaP
 abK
 acj
-acu
+abK
 abK
 abK
 adc
@@ -41975,15 +44771,15 @@ aaj
 aOx
 aPZ
 aQy
-aap
+aaf
 aRn
 aRD
 aRY
 aap
-aap
-aap
-aap
-aap
+unv
+unv
+bHt
+unv
 acQ
 ach
 aac
@@ -42114,17 +44910,17 @@ aab
 aac
 aaf
 acT
-aao
-aao
+oqi
+xxj
 aQz
-aap
-aRp
-aap
-aap
+aaf
+aaf
 aSr
-aPr
-aSM
-alt
+aSr
+aSr
+aSr
+aSr
+aSr
 aSr
 acQ
 add
@@ -42257,13 +45053,13 @@ aac
 aaf
 aao
 aDX
-aQa
-aRo
-aap
-aRq
-aap
+vXa
+wrX
+ppv
+aaf
+cqN
 aRZ
-aSr
+tTL
 aSG
 aSN
 aSV
@@ -42399,16 +45195,16 @@ aac
 aaf
 aaq
 aOS
-aQb
-aQA
-aap
-aRO
-aap
-acD
-aSr
-qaW
-aSO
+ioB
+oqi
+xFz
+aaf
+iJb
+pBa
 aSW
+qaW
+qaW
+aYV
 aSr
 acQ
 ach
@@ -42541,16 +45337,16 @@ aac
 aaf
 aaf
 aaf
-aQc
+gNE
 aQB
-aQp
-aRr
+uQG
+oVp
 aPp
-aSa
+aTl
 aSs
 aSI
 aSP
-aSX
+aSY
 aSr
 acR
 ade
@@ -42681,18 +45477,18 @@ aab
 aab
 aac
 aaf
-aar
-aPz
-aQd
-aQC
-aQT
-aRs
+aQl
+aaf
+aaf
+aRp
+rKK
+oVp
 aRF
-aSb
+aTl
 aSs
 aSJ
 aSQ
-aSY
+ojT
 aSr
 acy
 adf
@@ -42819,22 +45615,22 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
+apq
+apq
+apq
 aaf
-aar
-aPC
+aQl
+aQl
 aaf
-aQD
-aQq
-aRt
+aRO
+aYR
+aSr
 aRG
-aSb
-aSr
-aSr
+aTl
+tnD
 aSR
-aSr
+qUC
+aSW
 aSr
 acy
 fYA
@@ -42961,22 +45757,22 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aag
-aag
-aag
-aag
-aag
-aag
-aag
+aaI
+aaI
+aaI
+aaI
+aaI
+aaI
+aaI
+sab
+enU
+lFx
 aRH
-aSc
-aSt
-aSK
-aTl
-aPs
+dZb
+cvP
+rpV
+fzr
+bSO
 aTc
 aTd
 aTf
@@ -43103,23 +45899,23 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aag
-aav
-aeb
-aem
-aQE
-aQV
-aRu
+aaI
+abh
+abR
+afb
+aPJ
+aQL
+aaI
+aRO
+eKj
+lMc
 aRI
-aao
-aao
-aao
+pZz
+tzH
+uMi
 aTm
 aTa
-aaf
+aSr
 aTe
 adg
 adt
@@ -43245,23 +46041,23 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aag
-aaA
-aPE
-aQf
-aQF
-aPt
-aRu
-aRJ
-aao
-aSu
-ahO
-aST
-aTn
+aaI
+abi
+abS
+afc
+aPK
+aQd
+aaI
+aRO
+frL
 aaf
+aSr
+aSr
+aSr
+aSr
+aSr
+aSr
+aSr
 acy
 adh
 acy
@@ -43386,27 +46182,27 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aag
-aaC
-aOu
-aQg
-aQG
-aQX
-aRv
+apq
+aaI
+abj
+abT
+ahh
+aQc
+aQf
+aaI
+aRw
+iOZ
+aPH
 aRK
-aao
+qhu
 aSv
-aad
-aad
-aad
-aad
-aad
-aad
-aad
+wfF
+mRO
+fFg
+aPH
+aPH
+aPH
+aPH
 acS
 adf
 acy
@@ -43467,7 +46263,7 @@ arZ
 arZ
 arZ
 aFQ
-aDN
+rnG
 aGs
 aGM
 arZ
@@ -43528,27 +46324,27 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aag
-aay
-aPG
-aQh
-aQH
-aQY
-aRu
+apq
+aaI
+abk
+abU
+ahi
+aPK
+aQg
+aaI
+aRO
+lBF
+aPH
 aRL
-aSd
-aPq
-aad
-aaY
-abs
-abL
+jgw
+sMe
+lWi
+xey
+jxF
+aZb
 ack
 acv
-aad
+aPH
 adH
 dQj
 gPa
@@ -43667,30 +46463,30 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aag
-aaD
-aPH
-aQi
-aQI
-aQZ
-aRu
-aRM
-aSe
-aSw
-aad
+aaf
+aaf
+aaf
+aaf
+aaI
+abl
+abV
+ahO
+aPL
+aQh
+aaI
+aZi
+wxi
+miD
+aYH
+vnv
+thm
+xzM
 aaZ
 aai
-aaG
-aai
-abN
-aad
+sMe
+sMe
+acw
+aPH
 adI
 adf
 aet
@@ -43713,7 +46509,7 @@ afG
 afG
 afG
 afF
-afG
+vRI
 afL
 afG
 afG
@@ -43751,7 +46547,7 @@ aFi
 aOm
 arZ
 aFR
-azS
+avW
 aGu
 aGO
 arZ
@@ -43809,32 +46605,32 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aah
-aah
-aah
-aah
-aah
-aah
-aah
+aaf
+ltw
+fiR
+rPF
+aaI
+aaI
+aaI
+ajt
+aPM
+ajt
+aaI
+bju
+trq
+aPH
 aQU
-aTb
-aRe
-aad
+bvD
+fXO
+lJe
 aba
-aai
-abM
-abu
-acw
-aad
+gOq
+sMe
+sMe
+jrt
+aPH
 aTg
-adf
+psj
 aXo
 adY
 afu
@@ -43893,7 +46689,7 @@ arZ
 arZ
 arZ
 aDN
-aGf
+aGg
 aGu
 aGO
 arZ
@@ -43909,7 +46705,7 @@ aLF
 aMd
 aMd
 aMd
-aLJ
+knE
 aMd
 aMd
 aNM
@@ -43951,30 +46747,30 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aah
-aaF
-aPI
-aQj
-aQJ
-aPn
-aah
+aaf
+gnB
+rqc
+mIX
+oKm
+aRB
+ehM
+aNd
+dep
+aPz
+aSi
+xVQ
+smC
+aPH
 aRN
-aao
-aSb
-aad
-abb
-aaG
-abN
-aad
-aad
-aad
+jAv
+sMe
+tGL
+abs
+aaY
+sMe
+sMe
+mYS
+aPH
 adK
 adf
 aad
@@ -44036,7 +46832,7 @@ aac
 arZ
 aDN
 aGg
-aGv
+aGu
 aGP
 arZ
 aac
@@ -44051,7 +46847,7 @@ aLG
 aLM
 aLM
 aLM
-aNd
+aLD
 aLM
 aLM
 aLM
@@ -44093,35 +46889,35 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aah
-aaH
-aQK
-aQk
-aQK
-aRb
-aRw
-aSS
-aao
-aSb
-aad
-abc
+aaf
+lHK
+dYs
+mgJ
+bGA
+aPo
+aAH
+aNf
+hpJ
+aTb
+aSj
+kLV
+qGx
+aPH
+aXB
+qPL
+unp
+oVi
+aYI
 abt
 abO
-aad
+kfs
 acx
-acy
+aPH
 adJ
 adf
 aad
 aTh
-aac
+xpw
 any
 any
 adY
@@ -44177,7 +46973,7 @@ aac
 aac
 arZ
 aDN
-aDN
+aRa
 aGw
 aGQ
 arZ
@@ -44235,30 +47031,30 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aah
-aaI
-aQK
+aaf
+bVB
+lNd
+dtm
+aaQ
+aaQ
+aaQ
+alt
 aPN
-aQL
-aRc
-aRx
-aRP
-aSg
-aSb
-aad
+alt
+aaQ
+dji
+sfF
+aPH
+aPH
+aPH
+aPH
+tGL
 abd
-aai
-abP
-aad
-acy
-aad
+aPH
+aPH
+aPH
+aPH
+aPH
 adJ
 adf
 aad
@@ -44320,7 +47116,7 @@ arZ
 arZ
 arZ
 arZ
-arZ
+aCH
 aGL
 arZ
 aac
@@ -44335,7 +47131,7 @@ aLI
 aLM
 aLM
 aLM
-aNf
+aLD
 aLM
 aLM
 aLM
@@ -44377,30 +47173,30 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aah
+aaf
+aaf
+aaf
+aaf
 aaQ
-aPJ
+abm
+abW
+ayf
 aPO
-aQM
-aRd
-aRw
-aQa
-aSh
-aSb
-aad
-abe
-aai
-abQ
-aad
-acy
-aad
+aQi
+aaQ
+aRO
+jDa
+aRe
+aRj
+aRj
+aRe
+eKf
+uNf
+aRe
+aXD
+aYk
+aYu
+aRe
 adJ
 adf
 aad
@@ -44461,8 +47257,8 @@ arZ
 arZ
 aFH
 aFS
-aEV
 aEr
+aCH
 aGL
 arZ
 aac
@@ -44477,7 +47273,7 @@ aLJ
 aMd
 aMd
 aMd
-aLJ
+fll
 aMd
 aMd
 aNO
@@ -44523,27 +47319,27 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aah
-aaE
-aPM
-aQl
-aQN
-aQS
-aah
-aQb
+aaQ
+abu
+acl
+aGv
+aPQ
+aQj
+aaQ
+aRO
+aYS
+aRe
+aRj
+aRt
+aRT
 aSh
-aTj
-aad
-abf
-aai
-abR
-aad
-acy
-adu
-adL
+aRo
+aSK
+aYe
+aRo
+aYv
+aRe
+tVf
 aec
 adu
 adu
@@ -44582,8 +47378,8 @@ aDM
 arZ
 avl
 avW
-aNC
-aDM
+aav
+doE
 ayo
 ayX
 aOT
@@ -44604,7 +47400,7 @@ arZ
 arZ
 arZ
 arZ
-arZ
+aCH
 aGL
 arZ
 aac
@@ -44665,27 +47461,27 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aah
-aah
-aah
-afc
-aah
-aah
-aah
-aQb
-aSh
-aTk
-aad
-abg
-aai
-abS
-aad
-acy
-adu
-adL
+aaQ
+abv
+acu
+aKv
+aQo
+aQk
+aaQ
+aRw
+ryh
+aRe
+aYU
+aRt
+aRU
+aSk
+aRo
+aRo
+aRo
+aRo
+aZc
+aRe
+tVf
 aec
 aev
 aeO
@@ -44746,7 +47542,7 @@ azQ
 azQ
 azQ
 azQ
-azQ
+hXR
 aGR
 arZ
 aac
@@ -44807,26 +47603,26 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aah
-aaW
-aPK
-aQn
-aQO
-aRf
-aah
-aRQ
-aSh
-aSv
-aad
-abh
-aaG
-abT
-aad
+aaQ
+abw
 acz
-adu
+aPa
+aPQ
+aQn
+aaQ
+dji
+pTc
+aRh
+qSw
+aRo
+aRo
+aSg
+aRo
+aRo
+aRo
+aRo
+aYw
+aRe
 aeL
 aec
 aew
@@ -44871,7 +47667,7 @@ axE
 ayp
 ayZ
 azR
-aAH
+bav
 arZ
 arZ
 arZ
@@ -44888,7 +47684,7 @@ arZ
 arZ
 arZ
 arZ
-arZ
+oOs
 arZ
 arZ
 aac
@@ -44949,27 +47745,27 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aah
-aeu
-aPL
-aQo
-aQP
-aRg
-aah
-aPo
-aSi
-aSy
-aad
-abi
-aai
-abN
-aad
-acy
-adu
-adL
+aaQ
+abx
+acA
+aPn
+aPR
+aYK
+aaQ
+rkH
+lGa
+aRi
+aRr
+aRv
+aRX
+aSl
+aSp
+aSO
+aYj
+aYl
+cHx
+aYB
+lTd
 aed
 aex
 aeQ
@@ -45021,23 +47817,23 @@ aac
 aac
 aac
 aac
+aay
+aay
+aay
+aaA
+aay
+aay
+aay
 aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
+aay
+aeb
+aaA
+aPF
+aPT
+aPF
+aPF
+aPF
+aPF
 aKh
 aKh
 aKh
@@ -45091,26 +47887,26 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
+aaQ
+aaQ
+aaQ
+aaQ
+aaQ
+aaQ
+aaQ
+aTk
+jGD
 aah
 aah
-aah
-aah
-aah
-aah
-aah
-aKv
-aSj
-aKv
-aad
-abj
-abu
-abU
-aad
-acy
-adu
+aRx
+aRx
+aRx
+aSt
+aRx
+aRx
+aYm
+aYx
+aRe
 adL
 aee
 aey
@@ -45162,24 +47958,24 @@ aac
 aac
 aac
 aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
+aay
+aay
+aaA
+aaA
+aaA
+aaA
+aaA
+aay
+aay
+aay
+aeb
+aaA
+aPG
+aPT
+aPT
+aPT
+aPF
+aPF
 aac
 aac
 aKh
@@ -45193,8 +47989,8 @@ aKh
 aKh
 aKh
 aKh
-aac
-aab
+aVA
+apq
 aab
 aab
 aab
@@ -45237,22 +48033,22 @@ aab
 aab
 aab
 aab
-aKi
+aah
 aPP
 aQr
 aQQ
-aRh
+hKn
 aRy
-aRS
-aSk
-aSz
-aad
-aad
-abv
-aad
-aad
-acA
-adu
+aah
+aRz
+aRz
+aRz
+aSy
+aST
+aRx
+aYo
+aYy
+aRe
 adM
 aee
 aez
@@ -45304,6 +48100,24 @@ aac
 aac
 aac
 aac
+aay
+aaA
+aaA
+aaA
+aaA
+aaA
+aaA
+aaA
+aaC
+aaD
+aGf
+aaA
+aPG
+aPG
+aPT
+aPT
+aPT
+aPF
 aac
 aac
 aac
@@ -45314,29 +48128,11 @@ aac
 aac
 aac
 aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aab
+aVA
+aVV
+aVV
+aVA
+apq
 aab
 aab
 aab
@@ -45380,21 +48176,21 @@ aab
 aab
 aab
 aKi
-aPQ
+tzo
+aSq
 aQs
-aQs
-aQs
-aQs
-aQs
-aSl
-aSA
-aad
-abk
-abw
-abV
-abV
-acB
-adu
+iVf
+ocQ
+aah
+aRJ
+aSa
+aSa
+aSz
+aSX
+aRx
+aYt
+aRe
+aRe
 adL
 aee
 aeA
@@ -45446,39 +48242,39 @@ aac
 aac
 aac
 aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aab
-aab
+aay
+aay
+aaA
+aaA
+aaA
+aaA
+aaA
+aay
+aay
+aay
+aeb
+aaA
+aaA
+aaA
+aaA
+aaA
+aQe
+aay
+aQm
+aQm
+aQm
+aQm
+aQm
+aQm
+aQm
+aQm
+aQm
+aQm
+aVA
+aVX
+aVX
+aVA
+apq
 aab
 aab
 aab
@@ -45522,21 +48318,21 @@ aab
 aab
 aab
 aKi
-aPR
-aQs
-aQs
-aRi
-aRz
-aRT
+pny
+jpv
+aTn
+dBl
+jpv
+aRs
+aRM
+aSb
 aSm
-aeM
-aad
-abl
-abx
-abV
-abW
-abV
-adu
+aSA
+aTj
+aRx
+acC
+aYD
+aYC
 adL
 aee
 aee
@@ -45589,37 +48385,37 @@ aac
 aac
 aac
 aac
+aay
+aay
+aay
+aaA
+aay
+aay
+aay
 aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aab
+aay
+aOu
+aPE
+aPE
+aPX
+aPE
+aPE
+aPE
+aPE
+aQv
+aQE
+qQc
+aQV
+aQY
+aRu
+aRu
+aSL
+aUD
+aQm
+aVB
+aVX
+aVX
+aXi
 aab
 aab
 aab
@@ -45664,21 +48460,21 @@ aab
 aab
 aab
 aKi
-aPS
+dbq
 aQs
-aQs
-aRj
+xop
+cvH
 aRA
-aQs
+aah
+aRP
+aRP
 aSn
-afb
-aad
-abm
-aby
-abW
-acl
-acC
-adu
+aSD
+aXq
+aRx
+aNz
+aYD
+aYC
 adN
 aef
 aef
@@ -45733,35 +48529,35 @@ aac
 aac
 aac
 aac
+aay
+aay
+aay
 aac
 aac
 aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aab
+aay
+aPt
+aPt
+aPt
+aay
+aPt
+aPt
+aPt
+aay
+aQm
+aQF
+aQP
+aQW
+aQZ
+aQP
+aSC
+aSZ
+aVb
+aVt
+aVE
+aVY
+aWp
+aXi
 aab
 aab
 aab
@@ -45805,27 +48601,27 @@ aab
 aab
 aab
 aac
-aKv
+aah
 aaJ
-aQs
-aQs
+aSu
+lgy
 aRk
-aRB
-aRU
+aSS
+aah
+aRQ
+aRQ
 aSo
-aPa
-aad
-aad
-aad
-aad
-aad
-aad
+aSD
+aXu
+aRx
+aYC
+aYC
+aYC
+adu
+gyR
 adu
 adu
-adu
-adu
-adu
-afJ
+nhq
 adu
 adu
 adu
@@ -45882,28 +48678,28 @@ aac
 aac
 aac
 aac
+apq
+apq
+apq
 aac
+apq
+apq
+apq
 aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aab
-aab
+aQm
+aQG
+aQO
+aQX
+aRd
+aSB
+aSH
+aTI
+aVr
+aQm
+aVO
+aVX
+aWN
+aXi
 aab
 aab
 aab
@@ -45947,31 +48743,31 @@ aab
 aab
 aab
 aac
-aKv
-aPU
-aQs
-aQs
-aQs
-aQs
-aQs
-aQs
-aSD
-aKv
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
+aah
+aah
+aah
+aYG
+aah
+aah
+aah
+aRS
+aSc
+aSc
+aSE
+aYY
+aRx
+pFq
+wfh
+cFp
+vKe
+mzH
+ska
 adu
 ahP
-ajt
-ajt
-adu
-aac
+dvS
+uNP
+bqJ
+omy
 adu
 ahP
 adu
@@ -46023,29 +48819,29 @@ aac
 aac
 aac
 aac
+apq
+apq
+apq
 aac
 aac
-aac
-aac
+apq
 aab
-aab
-aab
-aab
-aab
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aab
-aac
-aab
-aab
-aab
+apq
+apq
+aQm
+aQH
+aQm
+aQm
+aRf
+aQm
+aQm
+aTK
+aQm
+aQm
+aVA
+aWo
+aVA
+aVA
 aab
 aab
 aab
@@ -46089,31 +48885,31 @@ aab
 aab
 aac
 aac
-aKv
+aah
 aPV
 aQt
-aes
+vlq
 aRl
 aRC
-ahi
-aSp
-aSE
-aKv
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
+aah
+aRP
+aRP
+aRP
+aRP
+aXC
+aRx
+bDS
+ahP
+ahP
+ahP
+ahP
+dCn
 adu
 ahP
-ahP
-ahP
-adu
-aac
+dQh
+mtl
+kfr
+sYH
 adu
 ahP
 ajT
@@ -46172,21 +48968,21 @@ aab
 aab
 aab
 aab
-aab
-aab
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aab
-aab
-aab
-aab
+apq
+apq
+aQm
+aQI
+aQR
+aQm
+aRg
+aQR
+aQm
+aUl
+aQR
+aQm
+apq
+apq
+apq
 aab
 aab
 aab
@@ -46231,33 +49027,33 @@ aab
 aab
 aac
 aac
-aKv
-aKv
-aKv
-aKv
-aKv
-aKv
-aKv
-aSq
-aSq
-aKv
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
+aah
+aSd
+aSw
+ffd
+jUn
+owI
+aah
+aRx
+aRx
+aRx
+aRx
+aRx
+aRx
+nsn
+ahP
+krY
+cOS
+ahP
+ekX
 adu
 aio
 amQ
 aiM
+ePA
+sYH
 adu
-aac
-adu
-ahP
+czO
 amO
 aYp
 aYp
@@ -46315,19 +49111,19 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
+apq
+aQm
+aQM
+aQS
+aQm
+aQM
+aQS
+aQm
+aQM
+aQS
+aQm
+apq
+apq
 aab
 aab
 aab
@@ -46373,31 +49169,31 @@ aab
 aab
 aac
 aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
+aah
+aSe
+aSM
+ekD
+kLp
+oNf
+aah
 aea
 aea
 aac
 aac
 aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
+adu
+qLK
+ahP
+ahP
+ahP
+ahP
+tMi
 adu
 adu
 adu
 adu
 adu
-aac
+adu
 adu
 ahP
 ajT
@@ -46457,19 +49253,19 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
+apq
+aQm
+aQN
+aQN
+aQm
+aRq
+aRq
+aQm
+aRq
+aRq
+aQm
+apq
+apq
 aab
 aab
 aab
@@ -46515,26 +49311,26 @@ aab
 aab
 aac
 aac
-aac
-aac
-aac
-aac
-aac
-aac
+aah
+aah
+aah
+aah
+aah
+aah
+aah
 aea
 aea
 aea
-aea
 aac
 aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aab
+adu
+iGg
+jje
+ovt
+kim
+kPO
+idN
+adu
 aab
 aab
 aab
@@ -46543,7 +49339,7 @@ aab
 adu
 afK
 ajT
-aYp
+poM
 agy
 aYM
 aYZ
@@ -46599,18 +49395,18 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
+apq
+apq
+apq
+apq
+apq
+apq
+apq
+apq
+apq
+apq
+apq
+apq
 aab
 aab
 aab
@@ -46669,14 +49465,14 @@ aea
 aea
 aac
 aac
-aac
-aac
-aab
-aab
-aab
-aab
-aab
-aab
+adu
+adu
+elI
+elI
+elI
+elI
+adu
+adu
 aab
 aab
 aab
@@ -46745,10 +49541,10 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
+apq
+apq
+apq
+apq
 aab
 aab
 aab

--- a/maps/tether/tether-03-surface3.dmm
+++ b/maps/tether/tether-03-surface3.dmm
@@ -923,7 +923,7 @@
 	},
 /obj/machinery/door/airlock/multi_tile/metal{
 	dir = 1;
-	name = "Medical Airlock";
+	name = "Triage";
 	req_access = list(5);
 	req_one_access = list(5)
 	},
@@ -3426,7 +3426,6 @@
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/lobby)
 "agn" = (
-/obj/machinery/door/airlock/glass_medical,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -3435,6 +3434,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/glass_medical{
+	name = "Medical Outfitting"
+	},
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/outfitting)
 "ago" = (
@@ -26027,7 +26029,7 @@
 	},
 /obj/machinery/door/airlock/multi_tile/metal{
 	dir = 1;
-	name = "Medical Airlock";
+	name = "Triage";
 	req_access = list(5);
 	req_one_access = list(5)
 	},
@@ -35262,7 +35264,6 @@
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/outfitting)
 "bjD" = (
-/obj/machinery/door/airlock/medical,
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -35275,6 +35276,9 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/glass_medical{
+	name = "Medical Outfitting"
+	},
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/outfitting)
 "bjE" = (
@@ -36498,7 +36502,9 @@
 /turf/simulated/floor/tiled,
 /area/rnd/research/researchdivision)
 "ffg" = (
-/obj/machinery/door/airlock/medical,
+/obj/machinery/door/airlock/medical{
+	name = "Medical Admin Access"
+	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/admin)

--- a/maps/tether/tether-03-surface3.dmm
+++ b/maps/tether/tether-03-surface3.dmm
@@ -9,14 +9,8 @@
 /turf/simulated/floor/outdoors/grass/sif/virgo3b,
 /area/tether/surfacebase/outside/outside3)
 "aad" = (
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/triage)
+/turf/simulated/wall,
+/area/tether/surfacebase/medical/upperhall)
 "aae" = (
 /obj/structure/flora/pottedplant/stoutbush,
 /obj/machinery/light{
@@ -28,16 +22,27 @@
 /turf/simulated/wall/r_wall,
 /area/tether/surfacebase/security/upperhall)
 "aag" = (
-/turf/simulated/wall,
-/area/tether/surfacebase/medical/triage)
-"aah" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
 /obj/machinery/door/firedoor,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
+/obj/machinery/door/blast/shutters{
+	closed_layer = 10;
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id = "medbayquar";
+	layer = 1;
+	name = "Medbay Emergency Lockdown Shutters";
+	opacity = 0;
+	open_layer = 1
+	},
 /turf/simulated/floor/plating,
+/area/tether/surfacebase/medical/upperhall)
+"aah" = (
+/turf/simulated/wall,
 /area/tether/surfacebase/medical/triage)
 "aai" = (
 /obj/structure/grille,
@@ -97,57 +102,44 @@
 /turf/simulated/floor/plating,
 /area/tether/surfacebase/security/upperhall)
 "aao" = (
-/obj/machinery/alarm{
-	pixel_y = 22
-	},
-/turf/simulated/open,
-/area/tether/surfacebase/medical/triage)
+/turf/simulated/wall,
+/area/tether/surfacebase/medical/cmo)
 "aap" = (
-/obj/machinery/light{
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/machinery/door/firedoor,
+/obj/structure/window/reinforced{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/triage)
+/obj/machinery/door/blast/shutters{
+	closed_layer = 10;
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id = "medbayquar";
+	layer = 1;
+	name = "Medbay Emergency Lockdown Shutters";
+	opacity = 0;
+	open_layer = 1
+	},
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/medical/cmo)
 "aaq" = (
 /turf/simulated/floor/tiled/steel_dirty/virgo3b,
 /area/tether/surfacebase/outside/outside3)
 "aar" = (
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 5
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 5
-	},
-/obj/effect/floor_decal/borderfloorwhite/corner2{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/paleblue/bordercorner2{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/glass/hidden/steel{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/warning/corner,
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/triage)
-"aas" = (
-/obj/effect/floor_decal/borderfloorwhite/corner{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/paleblue/bordercorner{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/glass/hidden/steel{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/triage)
-"aat" = (
 /turf/simulated/open,
-/area/tether/surfacebase/medical/triage)
+/area/tether/surfacebase/medical/upperhall)
+"aas" = (
+/obj/machinery/alarm{
+	pixel_y = 22
+	},
+/turf/simulated/open,
+/area/tether/surfacebase/medical/upperhall)
+"aat" = (
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/upperhall)
 "aau" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
@@ -184,30 +176,65 @@
 /turf/simulated/floor/carpet/blue,
 /area/tether/surfacebase/security/breakroom)
 "aaz" = (
-/turf/simulated/wall,
-/area/tether/surfacebase/medical/patient_a)
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/upperhall)
 "aaA" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/paleblue{
 	dir = 6
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/triage)
 "aaB" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
+/obj/machinery/atmospherics/unary/cryo_cell,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/tether/surfacebase/medical/triage)
 "aaC" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
+/obj/machinery/atmospherics/unary/freezer{
+	dir = 4
+	},
+/obj/machinery/alarm{
+	pixel_y = 25
+	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 9
+	},
+/obj/effect/floor_decal/industrial/warning{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/triage)
 "aaD" = (
-/obj/machinery/atmospherics/unary/cryo_cell,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 10;
+	icon_state = "intact"
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/sink{
+	pixel_y = 22
+	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/triage)
 "aaE" = (
 /turf/simulated/wall,
@@ -235,61 +262,75 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/breakroom)
 "aaH" = (
-/obj/machinery/disposal,
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 8
+/obj/machinery/status_display{
+	density = 0;
+	layer = 4;
+	pixel_x = 0;
+	pixel_y = 32
 	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 8
+/obj/machinery/portable_atmospherics/canister/oxygen/prechilled,
+/obj/machinery/atmospherics/portables_connector,
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 9
 	},
-/obj/structure/disposalpipe/trunk,
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 6
+	},
+/obj/machinery/door/window/brigdoor/southright{
+	req_access = list();
+	req_one_access = list(5,24)
+	},
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/triage)
 "aaI" = (
-/obj/effect/floor_decal/steeldecal/steel_decals10,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/portable_atmospherics/canister/oxygen/prechilled,
+/obj/machinery/atmospherics/portables_connector,
+/obj/item/weapon/tool/wrench,
+/obj/machinery/door/window/brigdoor/southright{
+	req_access = list();
+	req_one_access = list(5)
+	},
+/obj/machinery/alarm{
+	pixel_y = 25
+	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 6
+	},
+/obj/machinery/door/window/brigdoor/southright{
+	req_access = list();
+	req_one_access = list(5,24)
+	},
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/triage)
 "aaJ" = (
-/obj/machinery/sleeper{
-	dir = 8
+/obj/structure/window/reinforced{
+	dir = 8;
+	health = 1e+006
 	},
-/obj/effect/floor_decal/corner_steel_grid{
-	dir = 10
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 9
 	},
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/triage)
 "aaK" = (
-/obj/machinery/sleep_console,
-/obj/effect/floor_decal/corner_steel_grid{
-	dir = 10
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/triage)
 "aaL" = (
-/obj/machinery/alarm{
-	pixel_y = 22
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 5
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 5
-	},
-/obj/effect/floor_decal/borderfloorwhite/corner2{
-	dir = 5
-	},
-/obj/effect/floor_decal/corner/paleblue/bordercorner2{
-	dir = 5
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/table/glass,
-/obj/item/weapon/reagent_containers/glass/beaker/cryoxadone,
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/triage)
 "aaM" = (
@@ -323,55 +364,67 @@
 /turf/simulated/floor/carpet/blue,
 /area/tether/surfacebase/security/breakroom)
 "aaQ" = (
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 1
+/obj/structure/table/glass,
+/obj/machinery/photocopier/faxmachine{
+	department = "CMO's Office"
 	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 1
+/obj/machinery/newscaster{
+	layer = 3.3;
+	pixel_x = -27;
+	pixel_y = 0
 	},
-/obj/structure/sink/kitchen{
-	name = "sink";
+/obj/machinery/status_display{
+	density = 0;
+	layer = 4;
+	pixel_x = 0;
 	pixel_y = 32
 	},
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/triage)
-"aaR" = (
-/obj/effect/floor_decal/borderfloorwhite/corner{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/paleblue/bordercorner{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/triage)
-"aaS" = (
-/obj/effect/floor_decal/steeldecal/steel_decals10{
+/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/triage)
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/medical/cmo)
+"aaR" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/medical/cmo)
+"aaS" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/medical/cmo)
 "aaT" = (
-/obj/effect/floor_decal/corner_steel_grid{
-	dir = 5
+/obj/machinery/keycard_auth{
+	pixel_x = 32;
+	pixel_y = 28
 	},
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/triage)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/medical/cmo)
 "aaU" = (
-/obj/structure/closet/secure_closet/paramedic,
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 9
+/obj/item/modular_computer/console/preset/command{
+	dir = 8
 	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 9
-	},
-/obj/machinery/alarm{
+/obj/item/device/radio/intercom{
 	dir = 4;
-	pixel_x = -22
+	pixel_x = 24
 	},
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/triage)
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/medical/cmo)
 "aaV" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 9
@@ -416,48 +469,72 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/upperhall)
 "aaZ" = (
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/triage)
+/obj/structure/railing,
+/turf/simulated/open,
+/area/tether/surfacebase/medical/upperhall)
 "aba" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/triage)
+/obj/machinery/camera/network/medbay{
+	dir = 10
+	},
+/obj/structure/railing,
+/turf/simulated/open,
+/area/tether/surfacebase/medical/upperhall)
 "abb" = (
-/obj/machinery/bodyscanner{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner_steel_grid{
-	dir = 10
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/triage)
+/area/tether/surfacebase/medical/upperhall)
 "abc" = (
-/obj/machinery/body_scanconsole,
-/obj/effect/floor_decal/corner_steel_grid{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 10
 	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/triage)
+/area/tether/surfacebase/medical/upperhall)
 "abd" = (
-/obj/structure/grille,
-/obj/machinery/door/firedoor/glass,
-/obj/structure/window/reinforced/polarized/full{
-	id = "surfmedint-a"
+/obj/effect/floor_decal/borderfloorwhite/corner{
+	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/tether/surfacebase/medical/patient_a)
-"abe" = (
-/turf/simulated/wall,
-/area/tether/surfacebase/reading_room)
-"abf" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/machinery/door/firedoor,
-/obj/structure/window/reinforced{
+/obj/effect/floor_decal/corner/paleblue/bordercorner{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 4;
+	icon_state = "warningcorner"
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 1
 	},
-/turf/simulated/floor/plating,
-/area/tether/surfacebase/reading_room)
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/triage)
+"abe" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 5;
+	icon_state = "intact"
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/triage)
+"abf" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/cyan,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/triage)
 "abg" = (
 /obj/machinery/door/blast/shutters{
 	id = "hangarsurface";
@@ -467,10 +544,20 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/tether/surfacebase/shuttle_pad)
 "abh" = (
-/obj/machinery/camera/network/medbay{
-	dir = 10
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
 	},
-/turf/simulated/open,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 1;
+	icon_state = "warningcorner"
+	},
+/turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/triage)
 "abi" = (
 /obj/effect/floor_decal/borderfloor{
@@ -520,6 +607,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
+/obj/effect/landmark{
+	name = "morphspawn"
+	},
 /turf/simulated/floor/wood,
 /area/maintenance/lower/medsec_maintenance)
 "abm" = (
@@ -540,163 +630,111 @@
 /turf/simulated/floor/wood,
 /area/maintenance/lower/medsec_maintenance)
 "abn" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/effect/floor_decal/techfloor{
-	dir = 6
-	},
-/obj/effect/landmark{
-	name = "morphspawn"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/tether/surfacebase/medical/triage)
-"abo" = (
-/obj/structure/bed/chair{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/maintenance/lower/medsec_maintenance)
-"abp" = (
-/obj/structure/bed/chair,
-/obj/machinery/alarm{
-	pixel_y = 22
-	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/cyan,
 /obj/effect/floor_decal/borderfloorwhite{
-	dir = 9
+	dir = 1
 	},
-/obj/effect/floor_decal/corner/pink/border{
-	dir = 9
-	},
-/obj/effect/floor_decal/borderfloorwhite/corner2{
-	dir = 10
-	},
-/obj/effect/floor_decal/corner/pink/bordercorner2{
-	dir = 10
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/patient_a)
+/area/tether/surfacebase/medical/triage)
+"abo" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 9;
+	icon_state = "intact"
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/triage)
+"abp" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/triage)
 "abq" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/hologram/holopad,
+/obj/structure/table/glass,
+/obj/machinery/recharger,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/triage)
 "abr" = (
-/obj/structure/bed/padded,
-/obj/item/weapon/bedsheet/medical,
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 1
+/obj/machinery/photocopier,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24;
+	pixel_y = 0
 	},
-/obj/effect/floor_decal/corner/pink/border{
-	dir = 1
-	},
-/obj/item/device/radio/intercom{
-	dir = 1;
-	pixel_y = 24
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/machinery/button/windowtint{
-	id = "surfmedint-a";
-	pixel_x = -12;
-	pixel_y = 28
-	},
-/obj/machinery/button/windowtint{
-	id = "surfmedext-a";
-	pixel_x = 12;
-	pixel_y = 28
-	},
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/patient_a)
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/medical/cmo)
 "abs" = (
-/obj/structure/table/glass,
-/obj/item/weapon/paper_bin,
-/obj/item/weapon/pen,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 5
-	},
-/obj/effect/floor_decal/corner/pink/border{
-	dir = 5
-	},
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_y = 28
-	},
-/obj/structure/cable/green{
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/patient_a)
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/medical/cmo)
 "abt" = (
 /obj/structure/table/glass,
-/obj/item/device/flashlight/lamp/green,
-/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/wood,
-/area/tether/surfacebase/reading_room)
+/area/tether/surfacebase/medical/cmo)
 "abu" = (
-/obj/structure/table/glass,
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/wood,
-/area/tether/surfacebase/reading_room)
-"abv" = (
-/obj/structure/table/glass,
-/obj/item/roller,
-/obj/item/roller{
-	pixel_y = 8
-	},
-/obj/item/roller{
-	pixel_y = 16
-	},
-/obj/effect/floor_decal/borderfloorwhite,
-/obj/effect/floor_decal/corner/paleblue/border,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/machinery/light,
+/obj/structure/bed/chair/office/light,
 /obj/machinery/button/remote/blast_door{
 	desc = "A remote control-switch for shutters.";
-	id = "surfmed";
-	name = "Medical Shutters";
-	pixel_y = -24;
+	id = "medbayquar";
+	name = "Medbay Emergency Lockdown Control";
+	pixel_x = -36;
+	pixel_y = 0;
 	req_access = list(5)
 	},
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/triage)
+/obj/machinery/button/remote/airlock{
+	desc = "A remote control switch for the CMO's office.";
+	id = "cmodoor";
+	name = "CMO Office Door Control";
+	pixel_x = -36;
+	pixel_y = -11
+	},
+/obj/machinery/button/remote/blast_door{
+	desc = "A remote control-switch for shutters.";
+	id = "virologyquar";
+	name = "Virology Emergency Lockdown Control";
+	pixel_x = -28;
+	pixel_y = 0;
+	req_access = list(5)
+	},
+/obj/machinery/button/windowtint{
+	id = "cmo_office";
+	pixel_x = -26;
+	pixel_y = -10
+	},
+/obj/effect/landmark/start{
+	name = "Chief Medical Officer"
+	},
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/medical/cmo)
+"abv" = (
+/obj/structure/filingcabinet,
+/obj/item/device/radio/intercom/department/medbay{
+	dir = 4;
+	pixel_x = 24
+	},
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/medical/cmo)
 "abw" = (
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 8
-	},
-/obj/machinery/camera/network/medbay{
-	dir = 4
-	},
-/obj/structure/table/glass,
-/obj/machinery/recharger,
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/triage)
+/turf/simulated/wall,
+/area/tether/surfacebase/medical/outfitting)
 "abx" = (
-/obj/structure/table,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 30
-	},
-/obj/random/action_figure,
-/obj/random/cigarettes,
-/turf/simulated/floor/plating,
-/area/maintenance/lower/medsec_maintenance)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/steeldecal/steel_decals4,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/upperhall)
 "aby" = (
 /obj/machinery/alarm{
 	pixel_y = 25
@@ -880,15 +918,17 @@
 /turf/simulated/floor/plating,
 /area/maintenance/lower/medsec_maintenance)
 "abT" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/rack,
-/obj/random/maintenance/medical,
-/obj/random/maintenance/clean,
-/obj/random/medical/lite,
-/obj/random/maintenance/medical,
-/obj/random/toy,
-/turf/simulated/floor/plating,
-/area/maintenance/lower/medsec_maintenance)
+/obj/machinery/door/firedoor/multi_tile{
+	dir = 1
+	},
+/obj/machinery/door/airlock/multi_tile/metal{
+	dir = 1;
+	name = "Medical Airlock";
+	req_access = list(5);
+	req_one_access = list(5)
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/triage)
 "abU" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -971,93 +1011,68 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/upperhall)
 "aca" = (
-/obj/structure/grille,
-/obj/machinery/door/firedoor/glass,
-/obj/structure/window/reinforced/polarized/full{
-	id = "surfmedext-a"
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 6
 	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/tether/surfacebase/medical/patient_a)
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/triage)
 "acb" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/steeldecal/steel_decals10,
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/triage)
 "acc" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/machinery/sleep_console{
 	dir = 4
+	},
+/obj/effect/floor_decal/corner_steel_grid{
+	dir = 10
 	},
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/triage)
 "acd" = (
-/obj/machinery/atmospherics/portables_connector,
-/obj/machinery/portable_atmospherics/canister/oxygen/prechilled,
-/obj/effect/floor_decal/techfloor{
-	dir = 1
+/obj/machinery/sleeper{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/corner_steel_grid{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/triage)
 "ace" = (
-/obj/machinery/atmospherics/unary/freezer,
-/obj/effect/floor_decal/techfloor{
-	dir = 1
+/obj/structure/table/glass,
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 8
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/machinery/recharger,
+/obj/random/medical,
+/turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/triage)
 "acf" = (
 /turf/simulated/wall/r_wall,
 /area/rnd/xenobiology/xenoflora)
 "acg" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/machinery/button/remote/airlock{
-	id = "ReadingRoom1";
-	name = "Room 1 Bolt";
-	pixel_x = -30;
-	specialfunctions = 4
-	},
-/turf/simulated/floor/wood,
-/area/tether/surfacebase/reading_room)
-"ach" = (
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/structure/bed/chair/comfy/black{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
-/turf/simulated/floor/wood,
-/area/tether/surfacebase/reading_room)
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/triage)
+"ach" = (
+/obj/structure/table/glass,
+/obj/item/weapon/reagent_containers/syringe/antiviral,
+/obj/item/weapon/storage/pill_bottle/antitox,
+/obj/item/weapon/storage/pill_bottle/tramadol,
+/obj/random/medical,
+/obj/structure/table/glass,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/triage)
 "aci" = (
-/obj/machinery/light/small{
-	dir = 1
+/obj/structure/grille,
+/obj/machinery/door/firedoor/glass,
+/obj/structure/window/reinforced/polarized/full{
+	id = "cmo_office"
 	},
-/turf/simulated/floor/wood,
-/area/tether/surfacebase/reading_room)
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/medical/cmo)
 "acj" = (
 /turf/simulated/wall,
 /area/rnd/outpost/xenobiology/outpost_hallway)
@@ -1429,98 +1444,127 @@
 /turf/simulated/floor/plating,
 /area/maintenance/lower/medsec_maintenance)
 "acN" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/triage)
+/obj/machinery/papershredder,
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/medical/cmo)
 "acO" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/triage)
+/obj/structure/table/glass,
+/obj/item/weapon/folder/white_cmo,
+/obj/item/weapon/stamp/cmo,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/medical/cmo)
 "acP" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/triage)
+/obj/structure/table/glass,
+/obj/item/weapon/paper_bin,
+/obj/item/weapon/pen,
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/medical/cmo)
 "acQ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
+/obj/structure/table/glass,
+/obj/machinery/computer/skills{
+	dir = 8;
+	icon_state = "laptop";
+	pixel_x = 4;
+	pixel_y = -3
 	},
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/triage)
+/obj/machinery/computer/med_data/laptop{
+	dir = 8;
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Chief Medical Officer's Desk";
+	departmentType = 5;
+	name = "Chief Medical Officer RC";
+	pixel_x = 30
+	},
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/medical/cmo)
 "acR" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
+/obj/structure/table/glass,
+/obj/item/weapon/storage/box/nifsofts_medical,
+/obj/item/device/flashlight/pen,
+/obj/item/device/flashlight/pen,
+/obj/item/device/flashlight/pen,
 /obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
+	dir = 2;
+	layer = 3.3;
+	pixel_x = 0;
+	pixel_y = 26
 	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/item/weapon/storage/firstaid/regular,
+/obj/item/weapon/storage/firstaid/regular{
+	pixel_x = 5;
+	pixel_y = 5
 	},
-/obj/machinery/light_switch{
-	dir = 1;
-	on = 0;
-	pixel_x = -10;
-	pixel_y = -24
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 9
 	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/patient_a)
+/area/tether/surfacebase/medical/outfitting)
 "acS" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
+/obj/item/weapon/storage/box/gloves{
+	pixel_x = 4;
+	pixel_y = 4
 	},
-/obj/machinery/button/remote/airlock{
-	id = "ReadingRoom2";
-	name = "Room 2 Bolt";
-	pixel_x = -30;
-	specialfunctions = 4
+/obj/item/weapon/storage/box/masks{
+	pixel_y = 0
 	},
-/turf/simulated/floor/wood,
-/area/tether/surfacebase/reading_room)
+/obj/structure/table/glass,
+/obj/item/device/radio/intercom/department/medbay{
+	dir = 1;
+	pixel_y = 24
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/outfitting)
 "acT" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
+/obj/structure/table/glass,
+/obj/item/device/radio/intercom{
+	dir = 1;
+	pixel_y = 24;
+	req_access = list()
 	},
-/obj/machinery/button/remote/airlock{
-	id = "ReadingRoom3";
-	name = "Room 3 Bolt";
-	pixel_x = -30;
-	specialfunctions = 4
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 5
 	},
-/turf/simulated/floor/wood,
-/area/tether/surfacebase/reading_room)
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 5
+	},
+/obj/item/clothing/glasses/hud/health,
+/obj/item/clothing/glasses/hud/health,
+/obj/item/clothing/accessory/stethoscope,
+/obj/item/clothing/accessory/stethoscope,
+/obj/item/clothing/accessory/stethoscope,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/outfitting)
 "acU" = (
-/obj/machinery/door/airlock{
-	id_tag = "ReadingRoom1";
-	name = "Room 1"
-	},
-/obj/machinery/door/firedoor/glass,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/wood,
-/area/tether/surfacebase/reading_room)
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/upperhall)
 "acV" = (
 /turf/simulated/floor/tiled,
 /area/rnd/xenobiology/xenoflora)
@@ -1569,17 +1613,21 @@
 /turf/simulated/floor/plating,
 /area/maintenance/lower/medsec_maintenance)
 "adc" = (
-/obj/machinery/vending/medical{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/borderfloorwhite{
 	dir = 4
 	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 9
-	},
 /obj/effect/floor_decal/corner/paleblue/border{
-	dir = 9
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloorwhite/corner2{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner2{
+	dir = 6
 	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/triage)
+/area/tether/surfacebase/medical/upperhall)
 "add" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -1785,51 +1833,35 @@
 /turf/simulated/floor/plating,
 /area/maintenance/lower/medsec_maintenance)
 "adu" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloorwhite,
-/obj/effect/floor_decal/corner/pink/border,
-/obj/effect/floor_decal/borderfloorwhite/corner2,
-/obj/effect/floor_decal/corner/pink/bordercorner2,
-/obj/machinery/light/small,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/patient_a)
-"adv" = (
-/obj/structure/closet/secure_closet/personal/patient,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
+/obj/machinery/vending/wallmed1{
+	pixel_x = -30
 	},
 /obj/effect/floor_decal/borderfloorwhite{
-	dir = 6
+	dir = 8
 	},
-/obj/effect/floor_decal/corner/pink/border{
-	dir = 6
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 8
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+/obj/effect/floor_decal/borderfloorwhite/corner2{
+	dir = 8
 	},
-/obj/machinery/vending/wallmed1{
-	pixel_y = -30
+/obj/effect/floor_decal/corner/paleblue/bordercorner2{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/patient_a)
-"adw" = (
-/obj/effect/floor_decal/borderfloorwhite/corner{
-	dir = 1
+/area/tether/surfacebase/medical/triage)
+"adv" = (
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 4
 	},
-/obj/effect/floor_decal/corner/paleblue/bordercorner{
-	dir = 1
+/obj/effect/landmark/start{
+	name = "Medical Doctor"
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/triage)
+"adw" = (
+/obj/effect/floor_decal/corner_steel_grid{
+	dir = 5
 	},
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/triage)
@@ -1845,96 +1877,115 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/processing)
 "ady" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/floor_decal/steeldecal/steel_decals6{
-	dir = 8
+/obj/effect/landmark/start{
+	name = "Medical Doctor"
 	},
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/triage)
 "adz" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/steeldecal/steel_decals6,
-/obj/machinery/button/remote/airlock{
-	desc = "A remote control switch for the medbay foyer.";
-	id = "SurfMedbayFoyer";
-	name = "Medbay Doors Control";
-	pixel_x = 20;
-	pixel_y = -26
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/triage)
 "adA" = (
-/obj/structure/table/glass,
-/obj/item/weapon/storage/firstaid/regular,
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 6
+/obj/structure/dogbed{
+	desc = "Runtime's bed. Some of her disappointment seems to have rubbed off on it.";
+	name = "cat bed"
 	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 6
-	},
-/obj/effect/floor_decal/borderfloorwhite/corner2,
-/obj/effect/floor_decal/corner/paleblue/bordercorner2,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
-/obj/random/tetheraid,
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/triage)
+/obj/item/toy/plushie/mouse/fluff,
+/mob/living/simple_mob/animal/passive/cat/runtime,
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/medical/cmo)
 "adB" = (
-/obj/machinery/firealarm{
-	layer = 3.3;
-	pixel_y = 26
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/wood,
-/area/tether/surfacebase/reading_room)
+/area/tether/surfacebase/medical/cmo)
 "adC" = (
-/obj/structure/table/glass,
-/obj/item/weapon/book/codex,
-/obj/machinery/recharger,
-/obj/machinery/newscaster{
-	pixel_y = -28
-	},
-/turf/simulated/floor/wood,
-/area/tether/surfacebase/reading_room)
-"adD" = (
-/obj/machinery/light_switch{
-	pixel_y = 25
-	},
-/turf/simulated/floor/wood,
-/area/tether/surfacebase/reading_room)
-"adE" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_y = 28
+/obj/structure/bed/chair{
+	dir = 1
 	},
 /obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/wood,
-/area/tether/surfacebase/reading_room)
-"adF" = (
+/area/tether/surfacebase/medical/cmo)
+"adD" = (
+/obj/item/weapon/storage/box{
+	pixel_x = 5;
+	pixel_y = -2
+	},
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/medical/cmo)
+"adE" = (
 /obj/structure/table/glass,
-/obj/machinery/photocopier/faxmachine{
-	department = "Reading Room"
+/obj/item/weapon/packageWrap,
+/obj/item/weapon/hand_labeler,
+/obj/item/weapon/backup_implanter{
+	pixel_y = -12
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/machinery/status_display{
-	pixel_y = 30
+/obj/item/weapon/backup_implanter{
+	pixel_y = -5
 	},
-/obj/machinery/camera/network/civilian{
-	dir = 9
+/obj/item/weapon/backup_implanter{
+	pixel_y = 2
 	},
-/turf/simulated/floor/wood,
-/area/tether/surfacebase/reading_room)
+/obj/item/weapon/backup_implanter{
+	pixel_y = 9
+	},
+/obj/machinery/power/apc{
+	cell_type = /obj/item/weapon/cell/super;
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/outfitting)
+"adF" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/outfitting)
 "adG" = (
 /obj/structure/catwalk,
 /turf/simulated/open/virgo3b,
@@ -1984,24 +2035,28 @@
 /turf/simulated/floor/plating,
 /area/maintenance/lower/medsec_maintenance)
 "adM" = (
-/obj/structure/table/glass,
-/obj/item/weapon/reagent_containers/spray/cleaner{
-	pixel_x = -1;
-	pixel_y = -2
+/obj/structure/table/rack,
+/obj/item/weapon/storage/belt/medical,
+/obj/item/weapon/storage/belt/medical,
+/obj/item/weapon/storage/belt/medical,
+/obj/item/weapon/storage/belt/medical,
+/obj/item/weapon/storage/belt/medical,
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 25;
+	pixel_y = 0
 	},
-/obj/item/weapon/reagent_containers/spray/cleaner,
-/obj/effect/floor_decal/borderfloorwhite{
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 4
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
-	dir = 8
+	dir = 4
 	},
-/obj/machinery/light_switch{
-	pixel_x = -25
-	},
-/obj/item/device/defib_kit/loaded,
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/triage)
+/area/tether/surfacebase/medical/outfitting)
 "adN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/dark,
@@ -2089,24 +2144,16 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/maintenance/lower/medsec_maintenance)
 "aea" = (
-/obj/structure/table/glass,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/door/firedoor/glass/hidden/steel,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
 	dir = 8
 	},
-/obj/item/device/radio/intercom/department/medbay{
-	dir = 8;
-	pixel_x = -24
-	},
-/obj/machinery/recharger,
-/obj/item/weapon/tool/screwdriver,
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/triage)
+/area/tether/surfacebase/medical/upperhall)
 "aeb" = (
 /obj/structure/table/reinforced,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -2116,59 +2163,51 @@
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/armory)
 "aec" = (
-/obj/structure/table/glass,
-/obj/item/weapon/storage/box/syringes,
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 10
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 10
-	},
-/obj/machinery/requests_console{
-	announcementConsole = 1;
-	department = "Medical Department";
-	departmentType = 3;
-	name = "Medical RC";
-	pixel_x = -30
-	},
-/obj/machinery/camera/network/medbay{
-	dir = 10
-	},
-/obj/item/bodybag/cryobag,
-/obj/item/bodybag/cryobag,
-/obj/item/device/sleevemate,
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/triage)
-"aed" = (
-/turf/simulated/wall,
-/area/tether/surfacebase/medical/patient_b)
-"aee" = (
-/obj/machinery/door/firedoor/glass,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/door/firedoor/glass/hidden/steel{
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/airlock/multi_tile/glass{
-	id_tag = "SurfMedbayFoyer";
-	name = "Infirmary";
-	req_access = list(5)
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 4
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central1{
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/upperhall)
+"aed" = (
+/obj/item/device/radio/intercom{
+	dir = 8;
+	pixel_x = -24
+	},
+/obj/structure/table/glass,
+/obj/machinery/recharger,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloorwhite{
 	dir = 8
 	},
-/obj/machinery/door/blast/shutters{
-	dir = 2;
-	id = "surfmed";
-	layer = 3.1;
-	name = "Medical Shutters"
-	},
-/turf/simulated/floor/tiled/monofloor{
+/obj/effect/floor_decal/corner/paleblue/border{
 	dir = 8
 	},
+/turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/triage)
+"aee" = (
+/obj/structure/sign/department/medbay{
+	pixel_x = -32
+	},
+/obj/machinery/door/airlock/multi_tile/glass{
+	id_tag = "MedbayFoyer";
+	name = "Medbay Airlock";
+	req_access = list(5);
+	req_one_access = list(5)
+	},
+/obj/machinery/door/firedoor/multi_tile,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lobby)
 "aef" = (
 /obj/machinery/papershredder,
 /obj/effect/floor_decal/borderfloor{
@@ -2180,62 +2219,43 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/frontdesk)
 "aeg" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/wood,
-/area/tether/surfacebase/reading_room)
-"aeh" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/wood,
-/area/tether/surfacebase/reading_room)
-"aei" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/wood,
-/area/tether/surfacebase/reading_room)
-"aej" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/turf/simulated/floor/wood,
-/area/tether/surfacebase/reading_room)
-"aek" = (
-/obj/structure/table/glass,
-/obj/item/weapon/pen,
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/triage)
+"aeh" = (
+/obj/effect/floor_decal/steeldecal/steel_decals10,
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/triage)
+"aei" = (
+/obj/machinery/body_scanconsole{
+	dir = 4
 	},
-/turf/simulated/floor/wood,
-/area/tether/surfacebase/reading_room)
+/obj/effect/floor_decal/corner_steel_grid{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/triage)
+"aej" = (
+/obj/machinery/bodyscanner{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner_steel_grid{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/triage)
+"aek" = (
+/obj/structure/table/glass,
+/obj/random/medical,
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 8
+	},
+/obj/item/weapon/tool/screwdriver,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/triage)
 "ael" = (
 /obj/effect/floor_decal/corner_oldtile/green{
 	dir = 9
@@ -2410,19 +2430,17 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/common)
 "aeA" = (
-/obj/structure/table/reinforced,
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 4
+/obj/structure/table/glass,
+/obj/item/weapon/reagent_containers/spray/cleaner{
+	pixel_x = 2;
+	pixel_y = 2
 	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 4
-	},
-/obj/machinery/reagentgrinder,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
+/obj/item/weapon/reagent_containers/spray/cleaner{
+	pixel_x = -2;
+	pixel_y = -2
 	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/chemistry)
+/area/tether/surfacebase/medical/triage)
 "aeB" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -2473,18 +2491,15 @@
 /turf/simulated/wall,
 /area/tether/surfacebase/medical/lobby)
 "aeH" = (
-/obj/structure/closet/secure_closet/medical3,
+/obj/item/device/radio/intercom/department/medbay{
+	dir = 4;
+	pixel_x = 24
+	},
 /obj/effect/floor_decal/borderfloorwhite{
-	dir = 8
+	dir = 4
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
-	dir = 8
-	},
-/obj/machinery/status_display{
-	pixel_x = -32
-	},
-/obj/machinery/light{
-	dir = 8
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/triage)
@@ -2537,11 +2552,6 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/frontdesk)
 "aeL" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment{
@@ -2553,19 +2563,18 @@
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/lobby)
 "aeM" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/structure/disposalpipe/junction,
 /obj/effect/floor_decal/steeldecal/steel_decals6{
 	dir = 4
 	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/lobby)
 "aeN" = (
-/obj/structure/flora/pottedplant/stoutbush,
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 5
 	},
@@ -2578,27 +2587,28 @@
 /obj/effect/floor_decal/corner/paleblue/bordercorner2{
 	dir = 4
 	},
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 28
-	},
-/obj/structure/cable/green{
-	icon_state = "0-8"
-	},
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
 	},
+/obj/structure/disposalpipe/trunk,
+/obj/machinery/disposal,
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/lobby)
 "aeO" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
+/obj/structure/bed/chair/comfy/brown{
 	dir = 4
 	},
 /turf/simulated/floor/wood,
-/area/tether/surfacebase/reading_room)
+/area/tether/surfacebase/medical/cmo)
 "aeP" = (
+/obj/item/weapon/storage/box{
+	pixel_x = 5;
+	pixel_y = -2
+	},
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/medical/cmo)
+"aeQ" = (
+/obj/machinery/hologram/holopad,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -2607,32 +2617,44 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment{
-	dir = 2;
+	dir = 4;
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/wood,
-/area/tether/surfacebase/reading_room)
-"aeQ" = (
-/obj/structure/closet/firecloset,
-/turf/simulated/floor/wood,
-/area/tether/surfacebase/reading_room)
+/area/tether/surfacebase/medical/cmo)
 "aeR" = (
-/obj/structure/bookcase,
-/turf/simulated/floor/wood,
-/area/tether/surfacebase/reading_room)
-"aeS" = (
-/obj/structure/bookcase,
-/obj/machinery/light/small,
-/turf/simulated/floor/wood,
-/area/tether/surfacebase/reading_room)
-"aeT" = (
-/obj/structure/table/glass,
-/obj/item/weapon/paper_bin,
-/obj/item/device/radio/intercom{
-	pixel_y = -24
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/wood,
-/area/tether/surfacebase/reading_room)
+/area/tether/surfacebase/medical/cmo)
+"aeS" = (
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/machinery/camera/network/medbay{
+	dir = 8;
+	icon_state = "camera"
+	},
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/medical/cmo)
+"aeT" = (
+/obj/structure/medical_stand,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 10
+	},
+/obj/effect/floor_decal/borderfloorwhite/corner2{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner2{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/outfitting)
 "aeU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -2643,13 +2665,26 @@
 /turf/simulated/floor/tiled,
 /area/rnd/xenobiology/xenoflora_storage)
 "aeV" = (
-/obj/structure/table/glass,
-/obj/item/device/flashlight/lamp/green,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/wood,
-/area/tether/surfacebase/reading_room)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_x = 24;
+	pixel_y = -30
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/outfitting)
 "aeW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
@@ -2687,49 +2722,31 @@
 /turf/simulated/floor/grass,
 /area/hydroponics)
 "afa" = (
-/obj/machinery/door/airlock/maintenance/medical{
-	name = "Medical Maintenance Access";
-	req_access = list(5)
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 6
 	},
-/obj/machinery/door/firedoor/glass,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/tether/surfacebase/medical/triage)
+/obj/effect/floor_decal/borderfloorwhite/corner2,
+/obj/effect/floor_decal/corner/paleblue/bordercorner2,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/outfitting)
 "afb" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/item/device/radio/intercom{
+	dir = 8;
+	pixel_x = -24
+	},
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
 	dir = 8
 	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/triage)
+/area/tether/surfacebase/medical/upperhall)
 "afc" = (
 /turf/simulated/wall/r_wall,
 /area/tether/surfacebase/security/processing)
@@ -2955,35 +2972,37 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/common)
 "afx" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/item/roller,
+/obj/item/roller{
+	pixel_y = 8
+	},
+/obj/item/roller{
+	pixel_y = 16
+	},
+/obj/structure/table/glass,
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube1";
+	pixel_y = 0
 	},
 /obj/effect/floor_decal/borderfloorwhite{
-	dir = 4
+	dir = 8
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloorwhite/corner2{
-	dir = 5
-	},
-/obj/effect/floor_decal/corner/paleblue/bordercorner2{
-	dir = 5
+	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/triage)
 "afy" = (
-/obj/structure/grille,
-/obj/machinery/door/firedoor/glass,
-/obj/structure/window/reinforced/polarized/full{
-	id = "surfmedint-b"
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
 	},
-/turf/simulated/floor/plating,
-/area/tether/surfacebase/medical/patient_b)
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/triage)
 "afz" = (
 /obj/structure/bed/chair/office/light,
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
@@ -2993,124 +3012,105 @@
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/lobby)
 "afA" = (
-/obj/structure/bed/chair,
-/obj/machinery/alarm{
-	pixel_y = 22
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 4
 	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 9
+/obj/effect/landmark/start{
+	name = "Medical Doctor"
 	},
-/obj/effect/floor_decal/corner/pink/border{
-	dir = 9
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/effect/floor_decal/borderfloorwhite/corner2{
-	dir = 10
-	},
-/obj/effect/floor_decal/corner/pink/bordercorner2{
-	dir = 10
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/patient_b)
+/area/tether/surfacebase/medical/triage)
 "afB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/lobby)
 "afC" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/lobby)
-"afD" = (
-/obj/structure/bed/padded,
-/obj/item/weapon/bedsheet/medical,
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/pink/border{
-	dir = 1
-	},
-/obj/item/device/radio/intercom{
-	dir = 1;
-	pixel_y = 24
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/machinery/button/windowtint{
-	id = "surfmedint-b";
-	pixel_x = -12;
-	pixel_y = 28
-	},
-/obj/machinery/button/windowtint{
-	id = "surfmedext-b";
-	pixel_x = 12;
-	pixel_y = 28
-	},
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/patient_b)
-"afE" = (
-/obj/structure/table/glass,
-/obj/item/weapon/paper_bin,
-/obj/item/weapon/pen,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 5
-	},
-/obj/effect/floor_decal/corner/pink/border{
-	dir = 5
-	},
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_y = 28
-	},
-/obj/structure/cable/green{
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/patient_b)
-"afF" = (
-/obj/machinery/disposal,
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 9
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 9
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/machinery/status_display{
-	pixel_y = 30
-	},
-/obj/machinery/camera/network/medbay{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/lobby)
-"afG" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/tether/surfacebase/reading_room)
-"afH" = (
-/obj/machinery/door/airlock{
-	name = "Reading Room"
-	},
-/obj/machinery/door/firedoor/glass,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/junction{
+	dir = 2;
+	icon_state = "pipe-j2"
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lobby)
+"afD" = (
+/obj/effect/floor_decal/corner_steel_grid{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/triage)
+"afE" = (
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 1
+	},
+/obj/effect/landmark/start{
+	name = "Medical Doctor"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/triage)
+"afF" = (
+/obj/machinery/status_display{
+	pixel_y = 30
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloorwhite/corner2{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner2{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lobby)
+"afG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/steel_grid,
-/area/tether/surfacebase/reading_room)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/triage)
+"afH" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/triage)
 "afI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -3127,8 +3127,18 @@
 /turf/simulated/floor/tiled,
 /area/rnd/xenobiology/xenoflora_storage)
 "afJ" = (
-/turf/simulated/wall/r_wall,
-/area/tether/surfacebase/reading_room)
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/triage)
 "afK" = (
 /turf/simulated/wall,
 /area/rnd/staircase/thirdfloor)
@@ -3247,15 +3257,11 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/maintenance/lower/medsec_maintenance)
 "afX" = (
-/obj/machinery/door/airlock{
-	id_tag = "ReadingRoom2";
-	name = "Room 2"
+/obj/structure/bed/psych{
+	name = "couch"
 	},
-/obj/machinery/door/firedoor/glass,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/wood,
-/area/tether/surfacebase/reading_room)
+/area/tether/surfacebase/medical/cmo)
 "afY" = (
 /obj/machinery/atmospherics/pipe/manifold/visible,
 /obj/machinery/meter,
@@ -3268,29 +3274,16 @@
 /turf/simulated/floor/tiled,
 /area/rnd/xenobiology/xenoflora_storage)
 "aga" = (
-/obj/structure/table/glass,
-/obj/item/weapon/backup_implanter{
-	pixel_y = 8
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/item/weapon/backup_implanter{
-	pixel_y = -8
-	},
-/obj/item/weapon/backup_implanter,
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 8
-	},
-/obj/machinery/power/apc{
-	cell_type = /obj/item/weapon/cell/super;
-	dir = 8;
-	name = "west bump";
-	pixel_x = -30
-	},
-/obj/structure/cable/green,
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/triage)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/medical/cmo)
 "agb" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/cell/device/weapon,
@@ -3365,38 +3358,34 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/common)
 "agi" = (
-/obj/structure/grille,
-/obj/machinery/door/firedoor/glass,
-/obj/structure/window/reinforced/polarized/full{
-	id = "surfmedext-b"
+/obj/structure/filingcabinet/chestdrawer,
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 25;
+	pixel_y = 0
 	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/tether/surfacebase/medical/patient_b)
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/medical/cmo)
 "agj" = (
 /obj/structure/table/glass,
+/obj/item/device/sleevemate,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+	dir = 4
 	},
-/obj/machinery/door/window/southleft{
-	req_access = list(5)
-	},
+/obj/structure/window/reinforced,
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/lobby)
 "agk" = (
 /obj/structure/table/glass,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/door/window/southright{
 	req_access = list(5)
 	},
-/obj/item/weapon/backup_implanter,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/lobby)
 "agl" = (
@@ -3411,57 +3400,33 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
+/obj/item/weapon/backup_implanter{
+	pixel_y = 9
+	},
+/obj/item/weapon/backup_implanter{
+	pixel_y = 2
+	},
+/obj/item/weapon/backup_implanter{
+	pixel_y = -5
+	},
+/obj/item/weapon/backup_implanter{
+	pixel_y = -12
+	},
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/lobby)
 "agm" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4;
+	icon_state = "map-scrubbers"
 	},
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/lobby)
 "agn" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/blast/shutters{
-	dir = 2;
-	id = "surfmed";
-	layer = 3.1;
-	name = "Medical Shutters"
-	},
-/turf/simulated/floor/plating,
-/area/tether/surfacebase/medical/triage)
-"ago" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/triage)
-"agp" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 9
-	},
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 9
-	},
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/lightgrey/bordercorner2{
-	dir = 1
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 6
-	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/surface_three_hall)
-"agq" = (
+/obj/machinery/door/airlock/glass_medical,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -3469,12 +3434,53 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/steeldecal/steel_decals4{
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/outfitting)
+"ago" = (
+/obj/structure/sign/department/medbay{
+	pixel_x = -32
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/upperhall)
+"agp" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 9
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 6
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/surface_three_hall)
+"agq" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 4
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 9
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey/bordercorner2{
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_three_hall)
@@ -3719,9 +3725,6 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/maintenance/lower/medsec_maintenance)
 "agL" = (
-/obj/structure/bed/chair{
-	dir = 4
-	},
 /obj/structure/cable/green{
 	d2 = 8;
 	icon_state = "0-8"
@@ -3730,35 +3733,35 @@
 	name = "south bump";
 	pixel_y = -28
 	},
+/obj/random/maintenance/medical,
+/obj/random/maintenance/medical,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/medical,
+/obj/structure/closet,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/maintenance/lower/medsec_maintenance)
 "agM" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 6
 	},
-/obj/effect/decal/cleanable/vomit,
-/obj/structure/table,
-/obj/random/tech_supply,
+/obj/random/maintenance/medical,
+/obj/random/maintenance/medical,
+/obj/random/maintenance/medical,
+/obj/structure/closet/firecloset,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/maintenance/lower/medsec_maintenance)
 "agN" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/structure/cable/green{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
 	},
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_three_hall)
 "agO" = (
@@ -3860,24 +3863,30 @@
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/lobby)
 "agY" = (
-/obj/structure/disposalpipe/junction{
-	dir = 2;
-	icon_state = "pipe-j2"
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 5
 	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/lobby)
+/area/tether/surfacebase/medical/triage)
 "agZ" = (
-/obj/structure/table/steel,
-/obj/item/weapon/tool/wrench,
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/effect/floor_decal/techfloor{
+/obj/structure/sign/department/medbay{
+	pixel_x = 32
+	},
+/obj/machinery/hologram/holopad,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/obj/machinery/alarm{
-	pixel_y = 22
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
-/area/tether/surfacebase/medical/triage)
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/upperhall)
 "aha" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -3901,7 +3910,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_three_hall)
 "ahc" = (
@@ -4150,15 +4158,18 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/frontdesk)
 "ahz" = (
-/obj/machinery/door/airlock{
-	id_tag = "ReadingRoom3";
-	name = "Room 3"
+/obj/structure/closet/secure_closet/medical1,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
 	},
-/obj/machinery/door/firedoor/glass,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/wood,
-/area/tether/surfacebase/reading_room)
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/triage)
 "ahA" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -4244,6 +4255,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/floor_decal/techfloor{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/maintenance/lower/medsec_maintenance)
 "ahF" = (
@@ -4328,6 +4342,9 @@
 	},
 /obj/effect/floor_decal/borderfloorwhite,
 /obj/effect/floor_decal/corner/paleblue/border,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/lobby)
 "ahL" = (
@@ -4348,61 +4365,56 @@
 /obj/effect/floor_decal/steeldecal/steel_decals6{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/lobby)
 "ahN" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/steeldecal/steel_decals6,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/lobby)
 "ahO" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+	dir = 10
 	},
-/obj/machinery/door/airlock/medical{
-	name = "Patient Room B";
-	req_one_access = list()
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor/glass,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/patient_b)
+/area/tether/surfacebase/medical/triage)
 "ahP" = (
-/obj/effect/floor_decal/borderfloor{
+/obj/structure/table/glass,
+/obj/effect/floor_decal/steeldecal/steel_decals10{
 	dir = 8
 	},
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 8
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 5
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 6
-	},
-/obj/machinery/station_map{
-	dir = 4;
-	pixel_x = -32
-	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/surface_three_hall)
+/obj/item/device/defib_kit/loaded,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/triage)
 "ahQ" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
 /obj/item/device/radio/beacon,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4;
+	icon_state = "map-scrubbers"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_three_hall)
 "ahR" = (
@@ -4455,18 +4467,14 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/frontdesk)
 "ahW" = (
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/item/device/radio/intercom{
-	dir = 1;
-	pixel_y = 24
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/lobby)
@@ -4492,10 +4500,17 @@
 /obj/effect/floor_decal/corner/paleblue/border{
 	dir = 1
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals6{
-	dir = 9
-	},
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/item/device/radio/intercom{
+	dir = 1;
+	pixel_y = 24
+	},
+/obj/effect/floor_decal/borderfloorwhite/corner2{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner2{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
@@ -4578,71 +4593,79 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
+/obj/effect/floor_decal/techfloor{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/maintenance/lower/medsec_maintenance)
 "aie" = (
-/obj/structure/closet,
-/obj/random/maintenance/medical,
-/obj/random/maintenance/clean,
-/obj/random/maintenance/medical,
-/obj/random/maintenance/medical,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/maintenance/lower/medsec_maintenance)
-"aif" = (
-/obj/effect/floor_decal/techfloor{
-	dir = 5
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
 	},
-/obj/structure/closet/firecloset,
-/obj/random/maintenance/medical,
-/obj/random/maintenance/medical,
-/obj/random/maintenance/medical,
-/turf/simulated/floor/tiled/techfloor/grid,
+/obj/effect/floor_decal/borderfloorwhite/corner{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/triage)
+"aif" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 9
+	},
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/machinery/alarm{
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled/white,
 /area/maintenance/lower/medsec_maintenance)
 "aig" = (
-/obj/structure/bed/chair/office/light,
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/effect/landmark/start{
-	name = "Medical Doctor"
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 4
 	},
-/obj/machinery/button/remote/blast_door{
-	desc = "A remote control-switch for shutters.";
-	id = "surfmed";
-	name = "Medical Shutters";
-	pixel_x = -16;
-	pixel_y = -24;
-	req_access = list(5)
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/lobby)
+/area/tether/surfacebase/medical/triage)
 "aih" = (
+/obj/effect/floor_decal/borderfloorwhite/corner,
+/obj/effect/floor_decal/corner/paleblue/bordercorner,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/light_switch{
-	dir = 1;
-	on = 0;
-	pixel_x = -10;
-	pixel_y = -24
+	dir = 5;
+	icon_state = "intact-scrubbers"
 	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/patient_b)
+/area/tether/surfacebase/medical/triage)
 "aii" = (
 /obj/machinery/door/firedoor/glass,
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/steeldecal/steel_decals_central1{
 	dir = 4
+	},
+/obj/machinery/door/blast/shutters{
+	closed_layer = 10;
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id = "medbayquar";
+	layer = 1;
+	name = "Medbay Emergency Lockdown Shutters";
+	opacity = 0;
+	open_layer = 1
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/monofloor{
 	dir = 4
@@ -4681,10 +4704,14 @@
 	dir = 8;
 	pixel_x = -24
 	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_three_hall)
 "aim" = (
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -4863,6 +4890,9 @@
 	},
 /obj/machinery/door/window/eastleft{
 	req_access = list(5)
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 9
 	},
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/lobby)
@@ -5116,18 +5146,20 @@
 /turf/simulated/floor/tiled,
 /area/rnd/xenobiology/xenoflora_storage)
 "aiY" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
 /obj/effect/floor_decal/techfloor{
 	dir = 8
 	},
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
+/obj/effect/floor_decal/techfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/techfloor/hole/right{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/maintenance/lower/medsec_maintenance)
 "aiZ" = (
@@ -5138,21 +5170,13 @@
 /turf/simulated/floor/tiled,
 /area/rnd/xenobiology/xenoflora_storage)
 "aja" = (
-/obj/machinery/computer/crew{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 8
-	},
-/obj/machinery/requests_console{
-	announcementConsole = 1;
-	department = "Medical Department";
-	departmentType = 3;
-	name = "Medical RC";
-	pixel_x = -30
+/obj/machinery/button/remote/airlock{
+	desc = "A remote control switch for the medbay foyer.";
+	dir = 1;
+	id = "MedbayFoyer";
+	name = "Medbay Doors Control";
+	pixel_x = -23;
+	pixel_y = -28
 	},
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/lobby)
@@ -5212,6 +5236,9 @@
 /obj/effect/floor_decal/steeldecal/steel_decals6{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_three_hall)
 "ajg" = (
@@ -5231,6 +5258,11 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_three_hall)
 "ajh" = (
@@ -5247,6 +5279,11 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_three_hall)
 "aji" = (
@@ -5262,6 +5299,11 @@
 /obj/effect/floor_decal/steeldecal/steel_decals7,
 /obj/effect/floor_decal/industrial/danger{
 	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_three_hall)
@@ -5292,6 +5334,11 @@
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 5
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_three_hall)
@@ -5749,31 +5796,25 @@
 /turf/simulated/floor/tiled,
 /area/rnd/xenobiology/xenoflora_storage)
 "aka" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/surface_three_hall)
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/paleblue/border,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/triage)
 "akb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/structure/filingcabinet/chestdrawer{
+	name = "Scan Records"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/light,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/glass,
-/obj/machinery/door/airlock/glass,
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/surface_three_hall)
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/paleblue/border,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/triage)
 "akc" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -5785,10 +5826,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_three_hall)
@@ -5822,6 +5859,12 @@
 	desc = "Is that, The worlds slowest spaceship chase?";
 	icon_state = "frame";
 	pixel_y = 32
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/lobby)
@@ -6046,13 +6089,12 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_three_hall)
 "aky" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/structure/table,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark{
-	name = "morphspawn"
-	},
+/obj/random/action_figure,
+/obj/random/cigarettes,
 /turf/simulated/floor/plating,
 /area/maintenance/lower/medsec_maintenance)
 "akz" = (
@@ -7477,6 +7519,12 @@
 	},
 /obj/machinery/door/firedoor/glass/hidden/steel{
 	dir = 2
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/mauve/bordercorner2{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_three_hall)
@@ -10635,21 +10683,15 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_three_hall)
 "asA" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4,
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 10
-	},
-/obj/effect/floor_decal/industrial/warning/corner{
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 4
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 6
 	},
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/triage)
@@ -11436,6 +11478,7 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals5,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/shuttle_pad)
 "auh" = (
@@ -14535,17 +14578,19 @@
 /turf/simulated/floor/wood,
 /area/tether/surfacebase/bar_backroom)
 "azu" = (
-/obj/effect/floor_decal/borderfloorwhite,
-/obj/effect/floor_decal/corner/paleblue/border,
-/obj/effect/floor_decal/borderfloorwhite/corner2{
-	dir = 9
+/obj/structure/closet/secure_closet/CMO,
+/obj/item/weapon/storage/belt/medical,
+/obj/item/device/flashlight/pen,
+/obj/item/clothing/accessory/stethoscope,
+/obj/item/clothing/glasses/hud/health,
+/obj/item/device/defib_kit/compact/combat/loaded,
+/obj/item/weapon/cmo_disk_holder,
+/obj/item/weapon/storage/secure/briefcase/ml3m_pack_cmo,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
 	},
-/obj/effect/floor_decal/corner/paleblue/bordercorner2{
-	dir = 9
-	},
-/obj/machinery/mech_recharger,
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/triage)
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/medical/cmo)
 "azv" = (
 /obj/structure/sign/double/barsign{
 	dir = 8
@@ -16991,23 +17036,10 @@
 /area/rnd/outpost/xenobiology/outpost_south_airlock)
 "aDp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/floor_decal/borderfloorwhite,
-/obj/effect/floor_decal/corner/pink/border,
-/obj/effect/floor_decal/borderfloorwhite/corner2,
-/obj/effect/floor_decal/corner/pink/bordercorner2,
-/obj/machinery/light/small,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/patient_b)
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/medical/cmo)
 "aDq" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
@@ -18322,18 +18354,26 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/botanystorage)
 "aFC" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_x = 24;
+	pixel_y = -30
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals5{
-	dir = 1
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4;
+	icon_state = "map-scrubbers"
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals5,
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/shuttle_pad)
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/medical/cmo)
 "aFD" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -18811,26 +18851,15 @@
 /turf/simulated/floor/tiled/dark,
 /area/rnd/research/testingrange)
 "aGm" = (
-/obj/structure/closet/secure_closet/personal/patient,
+/obj/structure/bookcase,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 6
+/obj/machinery/light{
+	dir = 4
 	},
-/obj/effect/floor_decal/corner/pink/border{
-	dir = 6
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/vending/wallmed1{
-	pixel_y = -30
-	},
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/patient_b)
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/medical/cmo)
 "aGn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -19943,6 +19972,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/hallway/lower/third_south)
 "aIc" = (
@@ -20271,6 +20301,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/hallway/lower/third_south)
 "aIE" = (
@@ -20379,21 +20410,28 @@
 /turf/simulated/floor/wood,
 /area/tether/surfacebase/bar_backroom)
 "aIR" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 8
+/obj/structure/closet/secure_closet/medical3,
+/obj/item/weapon/soap/nanotrasen,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
 	},
-/obj/machinery/disposal,
+/obj/machinery/light{
+	dir = 1
+	},
 /obj/effect/floor_decal/borderfloorwhite{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 4
-	},
-/obj/machinery/camera/network/medbay{
 	dir = 9
 	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 9
+	},
+/obj/effect/floor_decal/borderfloorwhite/corner2{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner2{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/chemistry)
+/area/tether/surfacebase/medical/outfitting)
 "aIS" = (
 /obj/machinery/vending/cigarette{
 	dir = 1
@@ -20618,16 +20656,9 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/assembly/robotics)
 "aJl" = (
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 4
-	},
-/obj/machinery/chemical_dispenser/full{
-	dir = 8
-	},
 /obj/structure/table/reinforced,
+/obj/item/weapon/storage/box/beakers,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/chemistry)
 "aJm" = (
@@ -20660,6 +20691,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/glass_external/public,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/hallway/lower/third_south)
 "aJq" = (
@@ -21122,6 +21154,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/shuttle_pad)
 "aKj" = (
@@ -21514,6 +21547,7 @@
 	dir = 8;
 	pixel_x = 24
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/shuttle_pad)
 "aKY" = (
@@ -21537,14 +21571,13 @@
 /turf/simulated/floor/tiled,
 /area/hallway/lower/third_south)
 "aLa" = (
-/obj/item/stack/material/plastic,
-/obj/structure/table/rack,
-/obj/item/stack/material/steel{
-	amount = 3
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
 	},
-/obj/random/maintenance/engineering,
-/obj/machinery/camera/network/civilian,
-/turf/simulated/floor/tiled/techfloor,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/techmaint,
 /area/tether/surfacebase/shuttle_pad)
 "aLb" = (
 /obj/structure/closet/crate,
@@ -21822,6 +21855,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/glass_external/public,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/shuttle_pad)
 "aLC" = (
@@ -21915,11 +21949,21 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/servicebackroom)
 "aLL" = (
-/obj/machinery/camera/network/civilian{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 8
 	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/shuttle_pad)
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloorwhite/corner2{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner2{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/upperhall)
 "aLM" = (
 /obj/machinery/light{
 	dir = 8
@@ -22085,14 +22129,19 @@
 /obj/structure/cable/green{
 	icon_state = "1-8"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/shuttle_pad)
 "aMd" = (
-/obj/machinery/alarm{
-	pixel_y = 22
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 4
 	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/shuttle_pad)
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/upperhall)
 "aMe" = (
 /obj/structure/cable/green{
 	icon_state = "0-2"
@@ -22305,9 +22354,13 @@
 /turf/simulated/floor/bluegrid,
 /area/assembly/chargebay)
 "aMA" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/monotile,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/structure/cable/green{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled,
 /area/tether/surfacebase/shuttle_pad)
 "aMB" = (
 /obj/structure/cable/green{
@@ -22315,6 +22368,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/monotile,
 /area/tether/surfacebase/shuttle_pad)
 "aMC" = (
@@ -22323,7 +22377,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/wall,
 /area/tether/surfacebase/shuttle_pad)
 "aMD" = (
 /obj/structure/cable/green{
@@ -22535,7 +22589,9 @@
 /turf/simulated/shuttle/floor/black,
 /area/shuttle/tether)
 "aNa" = (
-/obj/machinery/computer/shuttle_control/tether_backup,
+/obj/machinery/computer/shuttle_control/tether_backup{
+	req_one_access = list()
+	},
 /turf/simulated/shuttle/floor/black,
 /area/shuttle/tether)
 "aNb" = (
@@ -22623,7 +22679,7 @@
 /obj/structure/closet/hydrant{
 	pixel_y = 32
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/wall,
 /area/tether/surfacebase/shuttle_pad)
 "aNk" = (
 /obj/structure/bed/chair/shuttle{
@@ -22749,30 +22805,32 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/assembly/robotics)
 "aNx" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9;
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/structure/cable/green{
+	icon_state = "1-8"
+	},
+/obj/machinery/camera/network/civilian{
+	dir = 1
+	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/shuttle_pad)
 "aNy" = (
-/obj/structure/table/rack/shelf,
-/obj/item/weapon/storage/backpack/parachute{
-	pixel_x = -4;
-	pixel_y = -6
+/obj/structure/closet/secure_closet/medical3,
+/obj/item/weapon/soap/nanotrasen,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 4
 	},
-/obj/item/weapon/storage/backpack/parachute{
-	pixel_x = 4;
-	pixel_y = -6
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 4
 	},
-/obj/item/weapon/storage/backpack/parachute{
-	pixel_x = -4;
-	pixel_y = 4
-	},
-/obj/item/weapon/storage/backpack/parachute{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/shuttle_pad)
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/outfitting)
 "aNz" = (
 /obj/machinery/door/airlock/glass_external{
 	frequency = 1380;
@@ -22857,17 +22915,32 @@
 	},
 /area/tether/surfacebase/shuttle_pad)
 "aNH" = (
-/obj/structure/bed/chair{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/shuttle_pad)
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/admin)
 "aNI" = (
-/obj/machinery/computer/atmos_alert{
-	dir = 8
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
 	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/shuttle_pad)
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloorwhite/corner2{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner2{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/admin)
 "aNJ" = (
 /obj/structure/bed/chair/shuttle{
 	dir = 1
@@ -22901,11 +22974,20 @@
 /turf/simulated/floor/tiled/monofloor,
 /area/tether/surfacebase/shuttle_pad)
 "aNO" = (
-/obj/machinery/computer/shuttle_control/tether_backup{
-	dir = 8
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
 	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/shuttle_pad)
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloorwhite/corner2{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner2{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/admin)
 "aNP" = (
 /obj/structure/shuttle/engine/heater,
 /obj/structure/window/reinforced{
@@ -22963,7 +23045,7 @@
 /obj/structure/closet/hydrant{
 	pixel_y = -32
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/wall,
 /area/tether/surfacebase/shuttle_pad)
 "aNY" = (
 /obj/machinery/button/remote/blast_door{
@@ -23032,6 +23114,7 @@
 	dir = 8;
 	pixel_x = 30
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/shuttle_pad)
 "aOe" = (
@@ -23158,6 +23241,10 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
+/obj/structure/cable/green{
+	dir = 1;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/shuttle_pad)
 "aOv" = (
@@ -23167,6 +23254,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/shuttle_pad)
 "aOw" = (
@@ -23216,8 +23304,8 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/tether/surfacebase/shuttle_pad)
 "aOA" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -23347,6 +23435,11 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/tether/surfacebase/shuttle_pad)
 "aOO" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/techmaint,
+/area/tether/surfacebase/shuttle_pad)
+"aOP" = (
 /obj/machinery/alarm{
 	dir = 1;
 	pixel_y = -22
@@ -23355,11 +23448,6 @@
 /obj/random/maintenance/engineering,
 /obj/item/clothing/glasses/welding,
 /obj/item/weapon/weldingtool,
-/turf/simulated/floor/tiled/techmaint,
-/area/tether/surfacebase/shuttle_pad)
-"aOP" = (
-/obj/machinery/light/small,
-/obj/item/weapon/tank/phoron,
 /turf/simulated/floor/tiled/techmaint,
 /area/tether/surfacebase/shuttle_pad)
 "aOQ" = (
@@ -23479,11 +23567,11 @@
 /turf/simulated/floor/plating,
 /area/tether/surfacebase/shuttle_pad)
 "aPc" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/airlock/hatch,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/techfloor,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled,
 /area/tether/surfacebase/shuttle_pad)
 "aPd" = (
 /obj/structure/window/basic/full,
@@ -23620,45 +23708,67 @@
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
 "aPq" = (
-/obj/machinery/alarm{
-	pixel_y = 22
+/obj/effect/landmark/start{
+	name = "Paramedic"
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/tether/surfacebase/shuttle_pad)
-"aPr" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/tether/surfacebase/shuttle_pad)
-"aPs" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/tether/surfacebase/shuttle_pad)
-"aPt" = (
-/obj/structure/frame/computer,
-/obj/item/weapon/material/twohanded/baseballbat{
-	name = "Swatta"
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/tether/surfacebase/shuttle_pad)
-"aPu" = (
-/obj/machinery/door/firedoor,
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/structure/window/reinforced{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/outfitting)
+"aPr" = (
+/obj/structure/closet/secure_closet/medical3,
+/obj/item/weapon/soap/nanotrasen,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 5
+	},
+/obj/effect/floor_decal/borderfloorwhite/corner2{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner2{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/outfitting)
+"aPs" = (
+/turf/simulated/wall,
+/area/tether/surfacebase/southhall)
+"aPt" = (
+/obj/machinery/light/small,
+/obj/item/weapon/tank/phoron,
+/turf/simulated/floor/tiled/techmaint,
 /area/tether/surfacebase/shuttle_pad)
+"aPu" = (
+/obj/machinery/door/airlock/glass,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	dir = 1;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/southhall)
 "aPv" = (
 /obj/structure/window/basic/full,
 /obj/structure/window/basic{
@@ -23802,14 +23912,23 @@
 /turf/simulated/floor/plating,
 /area/rnd/outpost/xenobiology/outpost_breakroom)
 "aPL" = (
-/obj/structure/table/rack,
-/obj/random/maintenance/clean,
-/obj/random/maintenance/engineering,
-/turf/simulated/floor/tiled/techfloor,
-/area/tether/surfacebase/shuttle_pad)
+/obj/machinery/door/airlock/glass,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/southhall)
 "aPM" = (
-/turf/simulated/floor/tiled/techfloor,
-/area/tether/surfacebase/shuttle_pad)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/southhall)
 "aPN" = (
 /obj/machinery/photocopier,
 /turf/simulated/floor/wood,
@@ -23882,16 +24001,29 @@
 /turf/simulated/floor/tiled,
 /area/rnd/outpost/xenobiology/outpost_breakroom)
 "aPZ" = (
-/obj/structure/bed/chair,
-/obj/machinery/light/small{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/tether/surfacebase/shuttle_pad)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/southhall)
 "aQa" = (
-/obj/structure/bed/chair,
-/turf/simulated/floor/tiled/techfloor,
-/area/tether/surfacebase/shuttle_pad)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/southhall)
 "aQb" = (
 /obj/machinery/papershredder,
 /turf/simulated/floor/wood,
@@ -24171,13 +24303,21 @@
 /turf/simulated/floor/tiled,
 /area/rnd/outpost/xenobiology/outpost_breakroom)
 "aQF" = (
-/obj/effect/floor_decal/steeldecal/steel_decals10{
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -23;
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/borderfloorwhite{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/triage)
+/area/tether/surfacebase/medical/upperhall)
 "aQG" = (
 /obj/structure/bed/chair/wood{
 	dir = 8
@@ -24672,16 +24812,13 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/outpost/xenobiology/outpost_decon)
 "aRG" = (
-/obj/item/device/radio/intercom{
+/obj/machinery/power/apc{
 	dir = 4;
+	name = "east bump";
 	pixel_x = 24
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	icon_state = "0-2"
 	},
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 4
@@ -24690,13 +24827,13 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/borderfloorwhite/corner2{
-	dir = 6
+	dir = 5
 	},
 /obj/effect/floor_decal/corner/paleblue/bordercorner2{
-	dir = 6
+	dir = 5
 	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/triage)
+/area/tether/surfacebase/medical/upperhall)
 "aRH" = (
 /obj/structure/sink/kitchen{
 	name = "sink";
@@ -24717,20 +24854,29 @@
 /turf/simulated/floor/tiled/steel_dirty/virgo3b,
 /area/tether/surfacebase/outside/outside3)
 "aRK" = (
-/obj/machinery/door/airlock/medical{
-	name = "Cryogenics Maintenance"
+/obj/machinery/power/apc{
+	cell_type = /obj/item/weapon/cell/super;
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 4
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 8
 	},
-/obj/machinery/door/firedoor/glass,
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/borderfloorwhite/corner2{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner2{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/triage)
 "aRL" = (
 /obj/machinery/washing_machine,
@@ -24756,11 +24902,12 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/rnd/outpost/xenobiology/outpost_storage)
 "aRN" = (
-/obj/effect/floor_decal/steeldecal/steel_decals10{
-	dir = 1
+/obj/structure/cable/green{
+	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/triage)
 "aRO" = (
@@ -24866,10 +25013,7 @@
 /turf/simulated/floor/tiled,
 /area/rnd/outpost/xenobiology/outpost_main)
 "aSb" = (
-/obj/machinery/door/firedoor/glass/hidden/steel{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/warning/corner{
+/obj/effect/floor_decal/steeldecal/steel_decals10{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
@@ -24963,11 +25107,8 @@
 /turf/simulated/floor/plating,
 /area/rnd/outpost/xenobiology/outpost_main)
 "aSk" = (
-/obj/effect/floor_decal/industrial/warning{
+/obj/effect/floor_decal/steeldecal/steel_decals10{
 	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 5
 	},
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/triage)
@@ -24978,79 +25119,70 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/servicebackroom)
 "aSm" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 4
+/obj/machinery/vending/wallmed1{
+	pixel_x = 30
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/floor_decal/techfloor/corner{
-	dir = 1
-	},
-/obj/effect/floor_decal/techfloor/corner,
-/turf/simulated/floor/tiled/dark,
-/area/tether/surfacebase/medical/triage)
-"aSn" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/cyan,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/floor_decal/techfloor,
-/turf/simulated/floor/tiled/dark,
-/area/tether/surfacebase/medical/triage)
-"aSo" = (
-/obj/structure/table/steel,
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/random/maintenance/medical,
-/obj/random/maintenance/medical,
-/obj/effect/floor_decal/techfloor{
-	dir = 5
-	},
-/obj/machinery/firealarm{
-	layer = 3.3;
-	pixel_y = 26
-	},
-/turf/simulated/floor/tiled/dark,
-/area/tether/surfacebase/medical/triage)
-"aSp" = (
-/obj/effect/floor_decal/steeldecal/steel_decals10{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+/obj/machinery/camera/network/medbay{
+	dir = 8;
+	icon_state = "camera"
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/triage)
+"aSn" = (
+/turf/simulated/wall,
+/area/tether/surfacebase/medical/admin)
+"aSo" = (
+/obj/machinery/door/airlock/command{
+	id_tag = "cmodoor";
+	name = "Chief Medical Officer";
+	req_access = list(40);
+	req_one_access = list()
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/cmo)
+"aSp" = (
+/obj/structure/closet/secure_closet/medical3,
+/obj/item/weapon/soap/nanotrasen,
+/obj/structure/sign/poster{
+	pixel_x = -32
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/outfitting)
 "aSq" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4,
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 10
+/obj/effect/landmark/start{
+	name = "Paramedic"
 	},
 /obj/structure/cable/green{
 	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/triage)
+/area/tether/surfacebase/medical/outfitting)
 "aSr" = (
 /obj/structure/lattice,
 /obj/machinery/door/firedoor,
@@ -25212,22 +25344,21 @@
 /turf/simulated/floor/wood,
 /area/library)
 "aSG" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24;
+	pixel_y = 0
+	},
 /obj/effect/floor_decal/borderfloorwhite{
-	dir = 4
+	dir = 8
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloorwhite/corner2{
-	dir = 6
-	},
-/obj/effect/floor_decal/corner/paleblue/bordercorner2{
-	dir = 6
+	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/triage)
+/area/tether/surfacebase/medical/upperhall)
 "aSH" = (
 /obj/effect/floor_decal/steeldecal/steel_decals4,
 /obj/effect/floor_decal/steeldecal/steel_decals4{
@@ -25245,22 +25376,20 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/rnd/outpost/xenobiology/outpost_storage)
 "aSK" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 4
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 4
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
 	},
-/obj/effect/floor_decal/borderfloorwhite/corner2{
-	dir = 5
-	},
-/obj/effect/floor_decal/corner/paleblue/bordercorner2{
-	dir = 5
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 10
 	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/triage)
+/area/tether/surfacebase/medical/upperhall)
 "aSL" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 8
@@ -25273,76 +25402,66 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4;
+	icon_state = "intact-scrubbers"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/tether/surfacebase/security/lobby)
 "aSM" = (
-/obj/effect/floor_decal/corner_steel_grid{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/triage)
 "aSN" = (
-/obj/effect/floor_decal/corner_steel_grid{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/triage)
-"aSO" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 4
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals10{
-	dir = 1
-	},
-/obj/structure/closet/hydrant{
-	pixel_x = 32
-	},
-/obj/effect/floor_decal/borderfloorwhite/corner2{
-	dir = 5
-	},
-/obj/effect/floor_decal/corner/paleblue/bordercorner2{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/floor_decal/borderfloorwhite/corner2{
-	dir = 6
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 2
 	},
-/obj/effect/floor_decal/corner/paleblue/bordercorner2{
-	dir = 6
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/junction{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/triage)
+"aSO" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/triage)
 "aSP" = (
-/turf/simulated/wall/r_wall,
-/area/tether/surfacebase/medical/chemistry)
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 2
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloorwhite/corner{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/triage)
 "aSQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -25350,93 +25469,67 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/outpost/xenobiology/outpost_first_aid)
 "aSR" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/door/firedoor/glass/hidden/steel{
+	dir = 2
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/triage)
+/area/tether/surfacebase/medical/admin)
 "aSS" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
-/obj/effect/landmark{
-	name = "lightsout"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/triage)
+/area/tether/surfacebase/medical/admin)
 "aST" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/computer/guestpass{
+	pixel_y = 28
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/triage)
+/area/tether/surfacebase/medical/admin)
 "aSU" = (
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 10
+/obj/machinery/vending/medical,
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals4,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/triage)
+/area/tether/surfacebase/medical/admin)
 "aSV" = (
-/obj/machinery/door/airlock/glass_medical{
-	name = "Chemistry";
-	req_one_access = list(33)
+/obj/machinery/vending/blood,
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
 	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/chemistry)
+/area/tether/surfacebase/medical/admin)
 "aSW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -25462,28 +25555,11 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/rnd/outpost/xenobiology/outpost_storage)
 "aSZ" = (
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 6
+/obj/machinery/door/airlock/glass_medical{
+	name = "Chemistry";
+	req_one_access = list(33)
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 4
-	},
-/obj/machinery/light_switch{
-	name = "light switch ";
-	on = 0;
-	pixel_y = 36
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/chemistry)
 "aTa" = (
@@ -25498,45 +25574,8 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/outpost/xenobiology/outpost_first_aid)
 "aTb" = (
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 1
-	},
-/obj/effect/floor_decal/borderfloorwhite/corner2{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/paleblue/bordercorner2{
-	dir = 4
-	},
-/obj/item/device/radio/headset/headset_med,
-/obj/item/weapon/storage/box/syringes,
-/obj/item/weapon/storage/fancy/vials,
-/obj/item/weapon/storage/fancy/vials,
-/obj/item/weapon/storage/box/pillbottles,
-/obj/item/weapon/storage/box/pillbottles,
-/obj/structure/closet/wardrobe/chemistry_white,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/requests_console{
-	announcementConsole = 1;
-	department = "Medical Department";
-	departmentType = 3;
-	name = "Medical RC";
-	pixel_y = 30
-	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/chemistry)
+/area/tether/surfacebase/medical/admin)
 "aTc" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -25550,32 +25589,7 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/servicebackroom)
 "aTd" = (
-/obj/structure/table/reinforced,
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 5
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 5
-	},
-/obj/item/device/mass_spectrometer/adv,
-/obj/item/device/mass_spectrometer/adv,
-/obj/item/clothing/glasses/science,
-/obj/item/clothing/glasses/science,
-/obj/item/weapon/storage/box/beakers,
-/obj/item/weapon/hand_labeler,
-/obj/item/weapon/packageWrap,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/item/weapon/reagent_containers/spray/cleaner{
-	desc = "Someone has crossed out the 'Space' from Space Cleaner and written in Chemistry. Scrawled on the back is, 'Okay, whoever filled this with polytrinic acid, it was only funny the first time. It was hard enough replacing the CMO's first cat!'";
-	name = "Chemistry Cleaner"
-	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/wall,
 /area/tether/surfacebase/medical/chemistry)
 "aTe" = (
 /obj/machinery/door/firedoor/glass,
@@ -25593,8 +25607,22 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/outpost/xenobiology/outpost_first_aid)
 "aTg" = (
-/turf/simulated/wall,
-/area/maintenance/lower/mining)
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/admin)
 "aTh" = (
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 1
@@ -25615,35 +25643,46 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/rnd/outpost/xenobiology/outpost_storage)
 "aTj" = (
-/obj/effect/landmark/start{
-	name = "Medical Doctor"
+/obj/machinery/vitals_monitor,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 5
+	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/triage)
+/area/tether/surfacebase/medical/admin)
 "aTk" = (
 /turf/simulated/floor/tiled/techmaint,
 /area/rnd/outpost/xenobiology/outpost_storage)
 "aTl" = (
-/obj/effect/floor_decal/borderfloorwhite{
+/obj/machinery/door/airlock/glass_medical{
+	name = "Chemistry";
+	req_one_access = list(33)
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/floor_decal/corner/paleblue/border{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/floor_decal/borderfloorwhite/corner2{
-	dir = 6
-	},
-/obj/effect/floor_decal/corner/paleblue/bordercorner2{
-	dir = 6
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/triage)
+/area/tether/surfacebase/medical/chemistry)
 "aTm" = (
-/obj/machinery/smartfridge/chemistry/chemvator,
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/chemistry)
+/turf/simulated/wall/r_wall,
+/area/tether/surfacebase/medical/admin)
 "aTn" = (
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -23;
+	pixel_y = 0
+	},
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 8
 	},
@@ -25651,67 +25690,116 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/borderfloorwhite/corner2{
-	dir = 8
+	dir = 10
 	},
 /obj/effect/floor_decal/corner/paleblue/bordercorner2{
-	dir = 8
+	dir = 10
 	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/chemistry)
+/area/tether/surfacebase/medical/outfitting)
 "aTo" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/closet/hydrant{
+	pixel_y = 32
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloorwhite/corner2{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner2{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/chemistry)
 "aTp" = (
+/obj/machinery/hologram/holopad,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/chemistry)
+/area/tether/surfacebase/medical/outfitting)
 "aTq" = (
-/obj/structure/table/reinforced,
+/obj/machinery/vending/medical{
+	dir = 8
+	},
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
 	dir = 4
 	},
-/obj/item/stack/material/phoron,
-/obj/item/stack/material/phoron,
-/obj/item/stack/material/phoron,
-/obj/item/stack/material/phoron,
-/obj/item/stack/material/phoron,
-/obj/machinery/alarm{
-	alarm_id = "anomaly_testing";
-	breach_detection = 0;
-	dir = 8;
-	pixel_x = 22;
-	report_danger_level = 0
+/obj/effect/floor_decal/borderfloorwhite/corner2{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner2{
+	dir = 5
 	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/chemistry)
+/area/tether/surfacebase/medical/outfitting)
 "aTr" = (
 /obj/effect/floor_decal/techfloor/corner{
 	dir = 1
 	},
-/obj/effect/floor_decal/techfloor,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
 	},
+/obj/effect/floor_decal/techfloor{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9;
+	pixel_y = 0
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/maintenance/lower/medsec_maintenance)
 "aTs" = (
-/obj/random/maintenance/clean,
-/obj/random/maintenance/clean,
-/obj/random/contraband,
-/obj/structure/closet,
-/turf/simulated/floor/plating,
-/area/maintenance/lower/mining)
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloorwhite/corner2{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner2{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/upperhall)
 "aTt" = (
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/airlock/maintenance/command{
@@ -25903,17 +25991,13 @@
 /area/tether/surfacebase/servicebackroom)
 "aTK" = (
 /obj/structure/table/glass,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 8
-	},
 /obj/structure/window/reinforced,
-/obj/item/device/flashlight/lamp/green,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/computer/med_data/laptop{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/lobby)
 "aTL" = (
@@ -25922,32 +26006,61 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/turf/simulated/floor/wood,
-/area/tether/surfacebase/reading_room)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/steeldecal/steel_decals4,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/upperhall)
 "aTM" = (
+/obj/machinery/door/firedoor/multi_tile{
+	dir = 1
+	},
+/obj/machinery/door/airlock/multi_tile/metal{
+	dir = 1;
+	name = "Medical Airlock";
+	req_access = list(5);
+	req_one_access = list(5)
+	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/turf/simulated/floor/wood,
-/area/tether/surfacebase/reading_room)
-"aTN" = (
-/obj/structure/bed/chair/office/light{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/turf/simulated/floor/wood,
-/area/tether/surfacebase/reading_room)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/triage)
+"aTN" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/triage)
 "aTO" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/lightgrey/border,
@@ -26133,16 +26246,22 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/servicebackroom)
 "aUh" = (
-/obj/effect/floor_decal/steeldecal/steel_decals4,
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 10
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 2
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
 	},
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/triage)
@@ -26160,16 +26279,20 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/common)
 "aUj" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 9
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
+/obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/floor_decal/techfloor,
-/obj/effect/floor_decal/techfloor/hole,
-/obj/machinery/light/small,
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/paleblue/border,
+/obj/effect/floor_decal/borderfloorwhite/corner2,
+/obj/effect/floor_decal/corner/paleblue/bordercorner2,
+/turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/triage)
 "aUk" = (
 /obj/effect/floor_decal/borderfloor{
@@ -26247,43 +26370,60 @@
 /turf/simulated/floor/grass,
 /area/hydroponics)
 "aUs" = (
-/obj/effect/floor_decal/techfloor/corner{
-	dir = 8
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 10
 	},
-/obj/effect/floor_decal/techfloor/corner,
-/obj/effect/floor_decal/techfloor{
-	dir = 4
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/floor_decal/techfloor{
-	dir = 8
+/obj/machinery/computer/transhuman/designer{
+	dir = 1
 	},
-/turf/simulated/floor/tiled/techfloor/grid,
+/turf/simulated/floor/tiled/white,
 /area/maintenance/lower/medsec_maintenance)
 "aUt" = (
-/obj/machinery/door/airlock/maintenance/common,
-/obj/machinery/door/firedoor/glass,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/maintenance/lower/medsec_maintenance)
-"aUu" = (
-/obj/effect/landmark{
-	name = "morphspawn"
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = -24
+	},
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/paleblue/border,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/triage)
+"aUu" = (
+/obj/item/stack/material/plastic,
+/obj/structure/table/rack,
+/obj/item/stack/material/steel{
+	amount = 3
+	},
+/obj/random/maintenance/engineering,
+/obj/machinery/camera/network/civilian,
 /turf/simulated/floor/tiled/techfloor,
 /area/tether/surfacebase/shuttle_pad)
 "aUv" = (
-/obj/structure/table/reinforced,
-/obj/effect/floor_decal/borderfloorwhite{
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Medical Department";
+	departmentType = 3;
+	name = "Medical RC";
+	pixel_x = -30;
+	pixel_y = -30
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/floor_decal/borderfloorwhite/corner{
 	dir = 8
 	},
-/obj/effect/floor_decal/corner/paleblue/border{
+/obj/effect/floor_decal/corner/paleblue/bordercorner{
 	dir = 8
-	},
-/obj/machinery/chemical_dispenser/biochemistry/full{
-	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/chemistry)
@@ -26349,11 +26489,16 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/public_garden_three)
 "aUA" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /obj/effect/floor_decal/borderfloorwhite,
 /obj/effect/floor_decal/corner/paleblue/border,
-/obj/structure/filingcabinet/chestdrawer{
-	name = "Scan Records"
-	},
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/triage)
 "aUB" = (
@@ -26370,27 +26515,41 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/public_garden_three)
 "aUD" = (
-/obj/structure/table/reinforced,
-/obj/item/weapon/reagent_containers/glass/beaker/large,
-/obj/item/weapon/reagent_containers/dropper,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/chemistry)
-"aUE" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
+/obj/machinery/status_display{
+	layer = 4;
+	pixel_y = -32
 	},
 /obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/paleblue/border,
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/chemistry)
+/area/tether/surfacebase/medical/triage)
+"aUE" = (
+/obj/machinery/door/firedoor/glass/hidden/steel{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/paleblue/border,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/admin)
 "aUF" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/lime/border,
@@ -26401,63 +26560,87 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/public_garden_three)
 "aUG" = (
-/turf/simulated/floor/plating,
-/area/maintenance/lower/mining)
-"aUH" = (
-/obj/machinery/door/airlock/maintenance/common,
-/obj/machinery/door/firedoor/glass,
-/turf/simulated/floor/plating,
-/area/maintenance/lower/mining)
-"aUI" = (
-/obj/machinery/door/firedoor/glass,
-/obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/steeldecal/steel_decals_central1{
-	dir = 4
-	},
-/obj/machinery/door/blast/shutters{
-	dir = 2;
-	id = "surfmed";
-	layer = 3.1;
-	name = "Medical Shutters"
-	},
-/turf/simulated/floor/tiled/monofloor{
-	dir = 4
-	},
-/area/tether/surfacebase/medical/triage)
-"aUJ" = (
-/obj/effect/floor_decal/borderfloorwhite{
+/obj/structure/table/reinforced,
+/obj/item/weapon/storage/box/beakers,
+/obj/item/stack/material/phoron,
+/obj/item/stack/material/phoron,
+/obj/item/stack/material/phoron,
+/obj/item/stack/material/phoron,
+/obj/item/stack/material/phoron,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 4
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
-	dir = 8
-	},
-/obj/machinery/chem_master{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 8
-	},
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/chemistry)
-"aUK" = (
-/obj/structure/bed/chair/office/dark{
-	dir = 8
-	},
-/obj/effect/landmark/start{
-	name = "Chemist"
-	},
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/chemistry)
-"aUL" = (
-/obj/structure/disposalpipe/segment,
+"aUH" = (
 /obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/admin)
+"aUI" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/admin)
+"aUJ" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 2
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/admin)
+"aUK" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 2
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/admin)
+"aUL" = (
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/chemistry)
 "aUM" = (
@@ -26473,12 +26656,15 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/public_garden_three)
 "aUN" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -26
+/obj/structure/closet/secure_closet/medical1,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/lower/mining)
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/chemistry)
 "aUO" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 6
@@ -26486,44 +26672,44 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/tether/surfacebase/public_garden_three)
 "aUP" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -23;
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
 	dir = 8
 	},
-/obj/machinery/chemical_dispenser/full{
-	dir = 4
-	},
-/obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/chemistry)
 "aUQ" = (
+/obj/structure/table/reinforced,
+/obj/machinery/reagentgrinder,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/chemistry)
 "aUR" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/chemistry)
 "aUS" = (
-/obj/structure/table/reinforced,
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 4
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
 	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 4
-	},
-/obj/item/weapon/reagent_containers/glass/beaker/large,
-/obj/item/weapon/reagent_containers/dropper,
-/obj/structure/extinguisher_cabinet{
-	dir = 8;
-	pixel_x = 30
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/chemistry)
 "aUT" = (
@@ -26545,10 +26731,15 @@
 /obj/structure/window/reinforced/full,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/blast/shutters{
+	closed_layer = 10;
+	density = 0;
 	dir = 2;
-	id = "surfmed";
-	layer = 3.1;
-	name = "Medical Shutters"
+	icon_state = "shutter0";
+	id = "medbayquar";
+	layer = 1;
+	name = "Medbay Emergency Lockdown Shutters";
+	opacity = 0;
+	open_layer = 1
 	},
 /turf/simulated/floor/plating,
 /area/tether/surfacebase/medical/lobby)
@@ -26571,10 +26762,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/lobby)
 "aUX" = (
-/obj/structure/table/reinforced,
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/window/eastright{
 	dir = 8;
@@ -26585,20 +26776,38 @@
 	name = "Chemistry";
 	req_one_access = list(33)
 	},
-/obj/machinery/door/blast/shutters{
-	dir = 8;
-	id = "surfchemistry";
-	layer = 3.1;
-	name = "Chemistry Shutters"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/door/blast/shutters{
+	dir = 8;
+	id = "chemistry";
+	layer = 3.1;
+	name = "Chemistry Shutters"
+	},
+/obj/structure/table/glass,
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/chemistry)
 "aUY" = (
 /obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/button/remote/blast_door{
+	desc = "A remote control-switch for shutters.";
+	dir = 1;
+	id = "chemistry";
+	name = "Chemistry Shutters";
+	pixel_x = -6;
+	pixel_y = -57;
+	req_access = list(5)
+	},
+/obj/structure/bed/chair/office/dark{
+	dir = 8
+	},
+/obj/effect/landmark/start{
+	name = "Chemist"
 	},
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 8
@@ -26609,22 +26818,13 @@
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/chemistry)
 "aUZ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/hologram/holopad,
+/obj/structure/table/reinforced,
+/obj/item/weapon/reagent_containers/glass/beaker/large,
+/obj/item/weapon/reagent_containers/dropper,
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/chemistry)
 "aVa" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
+/obj/structure/bed/chair/office/dark,
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/chemistry)
 "aVb" = (
@@ -26634,12 +26834,26 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/public_garden_three)
 "aVc" = (
-/obj/machinery/alarm{
-	dir = 8;
+/obj/structure/table/reinforced,
+/obj/item/weapon/reagent_containers/glass/beaker/large,
+/obj/item/weapon/reagent_containers/dropper,
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
 	pixel_x = 24
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/lower/mining)
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/chemistry)
 "aVd" = (
 /obj/machinery/conveyor{
 	dir = 1;
@@ -26652,107 +26866,117 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/servicebackroom)
 "aVe" = (
-/obj/structure/table/glass,
-/obj/item/weapon/storage/box/cups,
-/obj/item/weapon/storage/box/cups,
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
 	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/lobby)
 "aVf" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/window/eastright{
+	dir = 8;
+	name = "Chemistry"
+	},
+/obj/machinery/door/window/westleft{
+	dir = 4;
+	name = "Chemistry";
+	req_one_access = list(33)
+	},
 /obj/machinery/door/blast/shutters{
 	dir = 8;
-	id = "surfchemistry";
+	id = "chemistry";
 	layer = 3.1;
 	name = "Chemistry Shutters"
 	},
-/turf/simulated/floor/plating,
+/obj/structure/table/glass,
+/turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/chemistry)
 "aVg" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/structure/table/reinforced,
+/obj/item/weapon/reagent_containers/spray/cleaner{
+	desc = "Someone has crossed out the 'Space' from Space Cleaner and written in Chemistry. Scrawled on the back is, 'Okay, whoever filled this with polytrinic acid, it was only funny the first time. It was hard enough replacing the CMO's first cat!'";
+	name = "Chemistry Cleaner"
+	},
+/obj/item/weapon/hand_labeler,
+/obj/item/weapon/packageWrap,
+/obj/item/device/mass_spectrometer/adv,
+/obj/item/device/mass_spectrometer/adv,
+/obj/item/clothing/glasses/science,
+/obj/item/clothing/glasses/science,
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 10
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
 	dir = 10
-	},
-/obj/machinery/button/remote/blast_door{
-	desc = "A remote control-switch for shutters.";
-	id = "surfchemistry";
-	name = "Chemistry Shutters";
-	pixel_x = -6;
-	pixel_y = -24;
-	req_access = list(5)
 	},
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/chemistry)
 "aVh" = (
+/obj/machinery/chemical_dispenser/full,
+/obj/structure/table/reinforced,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = -24
+	},
 /obj/effect/floor_decal/borderfloorwhite,
 /obj/effect/floor_decal/corner/paleblue/border,
-/obj/structure/extinguisher_cabinet{
-	dir = 1;
-	pixel_y = -32
-	},
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/chemistry)
 "aVi" = (
+/obj/machinery/chem_master,
 /obj/effect/floor_decal/borderfloorwhite,
 /obj/effect/floor_decal/corner/paleblue/border,
-/obj/structure/bed/chair/office/dark{
-	dir = 4
-	},
-/obj/effect/landmark/start{
-	name = "Chemist"
-	},
-/obj/machinery/power/apc{
-	name = "south bump";
-	pixel_y = -32
-	},
-/obj/structure/cable/green,
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/chemistry)
 "aVj" = (
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 6
+/obj/machinery/chemical_dispenser/full,
+/obj/structure/table/reinforced,
+/obj/item/device/radio/intercom/department/medbay{
+	pixel_y = -24
 	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 6
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
 	},
-/obj/machinery/chem_master{
-	dir = 8
-	},
-/obj/machinery/light,
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/paleblue/border,
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/chemistry)
 "aVk" = (
 /obj/machinery/hologram/holopad,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/lobby)
 "aVl" = (
-/obj/machinery/disposal,
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
 	dir = 4
 	},
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
 /obj/machinery/light{
 	dir = 4
+	},
+/obj/structure/reagent_dispensers/water_cooler/full{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/lobby)
 "aVm" = (
 /obj/structure/sign/nosmoking_1,
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall,
 /area/tether/surfacebase/medical/chemistry)
 "aVn" = (
 /obj/structure/bed/chair{
@@ -26775,12 +26999,16 @@
 	},
 /obj/effect/floor_decal/borderfloorwhite/corner2,
 /obj/effect/floor_decal/corner/paleblue/bordercorner2,
-/obj/machinery/newscaster{
-	pixel_x = 25
+/obj/structure/cable/green{
+	icon_state = "0-8"
 	},
-/obj/structure/reagent_dispensers/water_cooler/full{
-	dir = 8
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 28
 	},
+/obj/structure/table/glass,
+/obj/item/weapon/storage/box/cups,
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/lobby)
 "aVp" = (
@@ -26819,6 +27047,17 @@
 /area/tether/surfacebase/public_garden_three)
 "aVs" = (
 /obj/structure/lattice,
+/obj/structure/cable/green{
+	d1 = 32;
+	d2 = 4;
+	icon_state = "32-4"
+	},
+/obj/machinery/atmospherics/pipe/zpipe/down/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/zpipe/down/scrubbers{
+	dir = 4
+	},
 /turf/simulated/open,
 /area/maintenance/lower/mining)
 "aVt" = (
@@ -26829,6 +27068,20 @@
 /obj/effect/floor_decal/steeldecal/steel_decals_central1{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/blast/shutters{
+	closed_layer = 10;
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id = "medbayquar";
+	layer = 1;
+	name = "Medbay Emergency Lockdown Shutters";
+	opacity = 0;
+	open_layer = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/monofloor{
 	dir = 8
 	},
@@ -26844,27 +27097,18 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_three_hall)
 "aVv" = (
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 8
+/obj/structure/cable/green{
+	icon_state = "1-8"
 	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 8
-	},
-/obj/effect/floor_decal/borderfloorwhite/corner2{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/paleblue/bordercorner2{
-	dir = 8
-	},
-/obj/structure/extinguisher_cabinet{
-	dir = 4;
-	pixel_x = -30
-	},
-/obj/machinery/door/firedoor/glass/hidden/steel{
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 2
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 2
+	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/triage)
+/area/tether/surfacebase/medical/admin)
 "aVw" = (
 /obj/effect/floor_decal/spline/plain{
 	dir = 8
@@ -26941,6 +27185,12 @@
 /obj/structure/cable/green{
 	icon_state = "1-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/lobby)
 "aVE" = (
@@ -26956,18 +27206,25 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_three_hall)
 "aVF" = (
-/obj/effect/floor_decal/borderfloorwhite{
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloorwhite/corner{
 	dir = 8
 	},
-/obj/effect/floor_decal/corner/paleblue/border{
+/obj/effect/floor_decal/corner/paleblue/bordercorner{
 	dir = 8
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
 	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/lobby)
+/area/tether/surfacebase/medical/admin)
 "aVG" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -27156,16 +27413,7 @@
 /obj/structure/bed/chair{
 	dir = 1
 	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 10
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 10
-	},
-/obj/machinery/computer/guestpass{
-	dir = 4;
-	pixel_x = -28
-	},
+/obj/effect/floor_decal/borderfloorwhite,
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/lobby)
 "aVX" = (
@@ -27345,6 +27593,11 @@
 /obj/effect/floor_decal/steeldecal/steel_decals7,
 /obj/machinery/newscaster{
 	pixel_y = 30
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_three_hall)
@@ -27591,20 +27844,27 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_three_hall)
 "aWA" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/floor_decal/borderfloor{
-	dir = 1
+/obj/structure/closet/secure_closet/medical3,
+/obj/item/weapon/soap/nanotrasen,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24;
+	pixel_y = 0
 	},
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 1
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 8
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 4
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 8
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals7,
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/surface_three_hall)
+/obj/effect/floor_decal/borderfloorwhite/corner2{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner2{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/outfitting)
 "aWB" = (
 /obj/machinery/light{
 	dir = 1
@@ -27715,12 +27975,16 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_three_hall)
 "aWL" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
@@ -27855,6 +28119,12 @@
 "aWX" = (
 /obj/structure/cable/green{
 	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/tether/surfacebase/security/lobby)
@@ -31563,10 +31833,14 @@
 /turf/simulated/floor/lino,
 /area/tether/surfacebase/entertainment/backstage)
 "bde" = (
-/obj/structure/shuttle/engine/propulsion,
-/turf/simulated/floor/reinforced,
-/turf/simulated/shuttle/plating/carry,
-/area/shuttle/tether)
+/obj/machinery/alarm{
+	pixel_y = 22
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/tether/surfacebase/shuttle_pad)
 "bdf" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -31792,6 +32066,9 @@
 	},
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -32
+	},
+/obj/item/device/radio/intercom/entertainment{
+	pixel_y = -23
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_three_hall)
@@ -32427,12 +32704,14 @@
 /turf/simulated/floor/tiled,
 /area/hydroponics)
 "beN" = (
-/obj/machinery/atmospherics/unary/engine{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
 	},
-/turf/simulated/floor/reinforced,
-/turf/simulated/shuttle/plating/carry,
-/area/shuttle/tourbus/engines)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/tether/surfacebase/shuttle_pad)
 "beO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -32455,6 +32734,12 @@
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/freezer)
+"beQ" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/tether/surfacebase/shuttle_pad)
 "beR" = (
 /obj/effect/floor_decal/spline/plain{
 	dir = 4
@@ -32469,6 +32754,31 @@
 /obj/structure/bed/chair/wood,
 /turf/simulated/floor/wood,
 /area/tether/surfacebase/entertainment)
+"beT" = (
+/obj/structure/frame/computer,
+/obj/item/weapon/material/twohanded/baseballbat{
+	name = "Swatta"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/tether/surfacebase/shuttle_pad)
+"beU" = (
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/southhall)
+"beV" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	dir = 1;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/southhall)
+"beW" = (
+/obj/structure/table/rack,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/engineering,
+/turf/simulated/floor/tiled/techfloor,
+/area/tether/surfacebase/shuttle_pad)
 "beX" = (
 /obj/structure/table/woodentable,
 /turf/simulated/floor/wood,
@@ -32569,6 +32879,27 @@
 	},
 /turf/simulated/wall,
 /area/tether/surfacebase/entertainment)
+"bfh" = (
+/turf/simulated/floor/tiled/techfloor,
+/area/tether/surfacebase/shuttle_pad)
+"bfi" = (
+/obj/effect/landmark{
+	name = "morphspawn"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/tether/surfacebase/shuttle_pad)
+"bfj" = (
+/obj/machinery/power/apc{
+	cell_type = /obj/item/weapon/cell/super;
+	dir = 8;
+	name = "west bump";
+	pixel_x = -28
+	},
+/obj/structure/cable/green{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/southhall)
 "bfk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -32807,6 +33138,18 @@
 	},
 /turf/simulated/floor/lino,
 /area/tether/surfacebase/entertainment/backstage)
+"bfJ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	icon_state = "1-8"
+	},
+/obj/structure/cable/green{
+	dir = 1;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/southhall)
 "bfK" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/tiled/eris/steel/bar_dance,
@@ -33065,6 +33408,14 @@
 	},
 /turf/simulated/floor/tiled/eris/steel/bar_light,
 /area/tether/surfacebase/barbackmaintenance)
+"bgm" = (
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 28
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/southhall)
 "bgn" = (
 /obj/effect/floor_decal/corner/grey/diagonal,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -33140,6 +33491,13 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
+"bgu" = (
+/obj/structure/bed/chair,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/tether/surfacebase/shuttle_pad)
 "bgv" = (
 /obj/structure/bed/chair/wood{
 	dir = 8
@@ -33625,6 +33983,117 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/rnd/outpost/xenobiology/outpost_storage)
+"bhg" = (
+/obj/structure/bed/chair,
+/turf/simulated/floor/tiled/techfloor,
+/area/tether/surfacebase/shuttle_pad)
+"bhh" = (
+/obj/machinery/door/firedoor,
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/southhall)
+"bhi" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/southhall)
+"bhj" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	dir = 1;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/southhall)
+"bhk" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/southhall)
+"bhl" = (
+/obj/machinery/door/firedoor,
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/southhall)
+"bhm" = (
+/obj/machinery/door/firedoor/glass/hidden/steel{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/tether/surfacebase/southhall)
+"bhn" = (
+/obj/machinery/door/firedoor/glass/hidden/steel{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	dir = 1;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/tether/surfacebase/southhall)
+"bho" = (
+/obj/machinery/door/firedoor/glass/hidden/steel,
+/turf/simulated/floor/tiled/monotile,
+/area/tether/surfacebase/southhall)
+"bhp" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/southhall)
+"bhq" = (
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 28
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/southhall)
+"bhr" = (
+/obj/machinery/door/firedoor,
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/southhall)
+"bhs" = (
+/obj/machinery/door/firedoor/glass/hidden/steel{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/tether/surfacebase/southhall)
+"bht" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/southhall)
 "bhu" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/lightgrey/border,
@@ -33639,6 +34108,1662 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_three_hall)
+"bhv" = (
+/obj/machinery/alarm{
+	pixel_y = 28
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/southhall)
+"bhw" = (
+/obj/structure/cable/green{
+	dir = 1;
+	icon_state = "1-2"
+	},
+/obj/effect/landmark{
+	name = "lightsout"
+	},
+/obj/structure/cable/green{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/southhall)
+"bhx" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/southhall)
+"bhy" = (
+/obj/machinery/door/firedoor/glass/hidden/steel{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/tether/surfacebase/southhall)
+"bhz" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 2
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1;
+	icon_state = "map-scrubbers"
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/southhall)
+"bhA" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/southhall)
+"bhB" = (
+/obj/machinery/door/firedoor/glass/hidden/steel{
+	dir = 2
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/tether/surfacebase/southhall)
+"bhC" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/southhall)
+"bhD" = (
+/obj/machinery/light,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/southhall)
+"bhE" = (
+/turf/simulated/wall,
+/area/tether/surfacebase/topairlock)
+"bhF" = (
+/obj/structure/table/rack{
+	dir = 4
+	},
+/obj/random/maintenance/clean,
+/obj/item/clothing/mask/gas,
+/obj/random/maintenance/engineering,
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/topairlock)
+"bhG" = (
+/obj/machinery/atmospherics/pipe/tank/air,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/topairlock)
+"bhH" = (
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -28
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/southhall)
+"bhI" = (
+/turf/simulated/open,
+/area/tether/surfacebase/southhall)
+"bhJ" = (
+/obj/machinery/light/small,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/southhall)
+"bhK" = (
+/obj/machinery/door/firedoor,
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced,
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/southhall)
+"bhL" = (
+/obj/machinery/atmospherics/pipe/tank/air,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/topairlock)
+"bhM" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 6
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/topairlock)
+"bhN" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/cyan,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 10
+	},
+/obj/effect/landmark{
+	name = "morphspawn"
+	},
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/topairlock)
+"bhO" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/cyan,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 6
+	},
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/topairlock)
+"bhP" = (
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 10;
+	icon_state = "intact"
+	},
+/obj/machinery/alarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
+	},
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/topairlock)
+"bhQ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/topairlock)
+"bhR" = (
+/obj/machinery/atmospherics/pipe/simple/visible/universal{
+	dir = 4
+	},
+/obj/machinery/light/small,
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/topairlock)
+"bhS" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/industrial/outline/blue,
+/obj/machinery/atmospherics/binary/passive_gate/on{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/topairlock)
+"bhT" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 9;
+	icon_state = "intact"
+	},
+/obj/machinery/floodlight,
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/topairlock)
+"bhU" = (
+/obj/structure/sign/nosmoking_2{
+	pixel_y = 30
+	},
+/obj/machinery/portable_atmospherics/powered/scrubber/huge/stationary/phoronlock{
+	frequency = 1379;
+	scrub_id = "southciv_airlock_scrubber"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/tether/surfacebase/topairlock)
+"bhV" = (
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_x = 0;
+	pixel_y = 28
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/portable_atmospherics/powered/scrubber/huge/stationary/phoronlock{
+	frequency = 1379;
+	scrub_id = "southciv_airlock_scrubber"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/tether/surfacebase/topairlock)
+"bhW" = (
+/obj/machinery/door/airlock/maintenance/common,
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/topairlock)
+"bhX" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel_dirty/virgo3b,
+/area/tether/surfacebase/topairlock)
+"bhY" = (
+/obj/structure/railing,
+/obj/structure/grille,
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	frequency = 1379;
+	id_tag = "southciv_airlock_pump"
+	},
+/obj/effect/map_helper/airlock/atmos/chamber_pump,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/topairlock)
+"bhZ" = (
+/obj/structure/railing,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/grille,
+/obj/effect/map_helper/airlock/atmos/chamber_pump,
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	frequency = 1379;
+	id_tag = "southciv_airlock_pump"
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/topairlock)
+"bia" = (
+/obj/machinery/washing_machine,
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/machinery/camera/network/civilian,
+/obj/structure/sign/nosmoking_2{
+	pixel_y = 30
+	},
+/turf/simulated/floor/tiled/dark,
+/area/tether/surfacebase/topairlock)
+"bib" = (
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/vending/wallmed_airlock{
+	pixel_x = 32
+	},
+/turf/simulated/floor/tiled/dark,
+/area/tether/surfacebase/topairlock)
+"bic" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/machinery/firealarm{
+	dir = 2;
+	pixel_y = 24
+	},
+/turf/simulated/floor/tiled/dark,
+/area/tether/surfacebase/topairlock)
+"bid" = (
+/obj/structure/dispenser/oxygen,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 5;
+	pixel_y = 28
+	},
+/turf/simulated/floor/tiled/dark,
+/area/tether/surfacebase/topairlock)
+"bie" = (
+/obj/machinery/door/airlock/glass_external{
+	frequency = 1379;
+	icon_state = "door_locked";
+	id_tag = "southciv_airlock_outer";
+	locked = 1
+	},
+/obj/effect/map_helper/airlock/door/ext_door,
+/turf/simulated/floor/tiled/steel_grid,
+/area/tether/surfacebase/topairlock)
+"bif" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 5;
+	icon_state = "intact"
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/topairlock)
+"big" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/topairlock)
+"bih" = (
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/glass_external{
+	frequency = 1379;
+	icon_state = "door_locked";
+	id_tag = "southciv_airlock_inner";
+	locked = 1
+	},
+/obj/machinery/access_button/airlock_interior{
+	master_tag = "southciv_airlock";
+	pixel_x = 8;
+	pixel_y = 25
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/map_helper/airlock/door/int_door,
+/turf/simulated/floor/tiled/steel_grid,
+/area/tether/surfacebase/topairlock)
+"bii" = (
+/obj/effect/floor_decal/steeldecal/steel_decals5{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals5{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 6
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/topairlock)
+"bij" = (
+/obj/effect/floor_decal/steeldecal/steel_decals5{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals5{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 9;
+	icon_state = "intact"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/topairlock)
+"bik" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals_central1{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/monofloor{
+	dir = 1
+	},
+/area/tether/surfacebase/topairlock)
+"bil" = (
+/obj/effect/floor_decal/steeldecal/steel_decals5{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals5{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 6
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/topairlock)
+"bim" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals5{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals5{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/topairlock)
+"bin" = (
+/obj/machinery/door/firedoor/glass,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/topairlock)
+"bio" = (
+/obj/machinery/access_button/airlock_exterior{
+	master_tag = "southciv_airlock";
+	pixel_x = -8;
+	pixel_y = -25
+	},
+/obj/effect/map_helper/airlock/door/ext_door,
+/obj/machinery/door/airlock/glass_external{
+	frequency = 1379;
+	icon_state = "door_locked";
+	id_tag = "southciv_airlock_outer";
+	locked = 1
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/tether/surfacebase/topairlock)
+"bip" = (
+/obj/effect/floor_decal/industrial/warning,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/topairlock)
+"biq" = (
+/obj/machinery/embedded_controller/radio/airlock/phoron{
+	dir = 8;
+	id_tag = "southciv_airlock";
+	pixel_x = 25;
+	pixel_y = -30
+	},
+/obj/effect/floor_decal/industrial/warning,
+/obj/machinery/airlock_sensor/phoron{
+	id_tag = "southciv_airlock_sensor";
+	pixel_x = 25;
+	pixel_y = -40
+	},
+/obj/effect/map_helper/airlock/sensor/chamber_sensor,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/topairlock)
+"bir" = (
+/obj/machinery/door/firedoor/glass,
+/obj/effect/map_helper/airlock/door/int_door,
+/obj/machinery/door/airlock/glass_external{
+	frequency = 1379;
+	icon_state = "door_locked";
+	id_tag = "southciv_airlock_inner";
+	locked = 1
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/tether/surfacebase/topairlock)
+"bis" = (
+/obj/effect/floor_decal/steeldecal/steel_decals5{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals5{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/topairlock)
+"bit" = (
+/obj/effect/floor_decal/steeldecal/steel_decals5{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals5{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 10
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/topairlock)
+"biu" = (
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/multi_tile/glass{
+	dir = 1;
+	name = "Surface EVA"
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals_central1,
+/turf/simulated/floor/tiled/monofloor,
+/area/tether/surfacebase/topairlock)
+"biv" = (
+/obj/effect/floor_decal/steeldecal/steel_decals5{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals5{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/topairlock)
+"biw" = (
+/obj/effect/floor_decal/steeldecal/steel_decals5{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals5{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/topairlock)
+"bix" = (
+/obj/machinery/door/airlock/multi_tile/glass{
+	dir = 1;
+	name = "Surface EVA"
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/topairlock)
+"biy" = (
+/obj/machinery/camera/network/civilian{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/steel_dirty/virgo3b,
+/area/tether/surfacebase/topairlock)
+"biz" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/powered/scrubber/huge/stationary/phoronlock{
+	frequency = 1379;
+	scrub_id = "southciv_airlock_scrubber"
+	},
+/obj/structure/sign/fire{
+	pixel_y = -32
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/tether/surfacebase/topairlock)
+"biA" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/powered/scrubber/huge/stationary/phoronlock{
+	frequency = 1379;
+	scrub_id = "southciv_airlock_scrubber"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/tether/surfacebase/topairlock)
+"biB" = (
+/obj/structure/table/rack,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/suit/storage/hooded/wintercoat,
+/obj/item/weapon/tank/emergency/oxygen/engi,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/tether/surfacebase/topairlock)
+"biC" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 25;
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/dark,
+/area/tether/surfacebase/topairlock)
+"biD" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/dark,
+/area/tether/surfacebase/topairlock)
+"biE" = (
+/obj/structure/table/reinforced,
+/obj/effect/floor_decal/industrial/warning,
+/obj/item/stack/cable_coil{
+	pixel_x = 3;
+	pixel_y = -7
+	},
+/obj/item/weapon/cell/high{
+	charge = 100;
+	maxcharge = 15000
+	},
+/obj/item/stack/cable_coil{
+	pixel_x = 3;
+	pixel_y = -7
+	},
+/obj/item/weapon/cell/high{
+	charge = 100;
+	maxcharge = 15000
+	},
+/obj/item/weapon/storage/toolbox/mechanical{
+	pixel_x = -2;
+	pixel_y = -1
+	},
+/obj/machinery/power/apc{
+	dir = 2;
+	name = "south bump";
+	pixel_y = -24
+	},
+/obj/machinery/light_switch{
+	pixel_x = 12;
+	pixel_y = -24
+	},
+/obj/structure/cable/green,
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 28
+	},
+/turf/simulated/floor/tiled/dark,
+/area/tether/surfacebase/topairlock)
+"biF" = (
+/turf/simulated/wall,
+/area/tether/surfacebase/cafeteria)
+"biG" = (
+/obj/machinery/door/airlock/glass{
+	name = "Cafeteria"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	dir = 1;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/cafeteria)
+"biH" = (
+/obj/machinery/door/firedoor,
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/cafeteria)
+"biI" = (
+/obj/machinery/door/airlock/glass{
+	name = "Cafeteria"
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/cafeteria)
+"biJ" = (
+/obj/machinery/door/airlock{
+	name = "Decontamination"
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/tiled/dark,
+/area/tether/surfacebase/topairlock)
+"biK" = (
+/obj/machinery/door/airlock{
+	name = "Decontamination"
+	},
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/dark,
+/area/tether/surfacebase/topairlock)
+"biL" = (
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/cafeteria)
+"biM" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	dir = 1;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/cafeteria)
+"biN" = (
+/obj/machinery/light_switch{
+	pixel_y = 25
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/cafeteria)
+"biO" = (
+/obj/machinery/computer/security/telescreen/entertainment{
+	desc = "Looks like it's set to Free-Anur-Entertanment, I wonder what else is on?";
+	icon_state = "frame";
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/cafeteria)
+"biP" = (
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_x = 0;
+	pixel_y = 28
+	},
+/obj/structure/cable/green{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/cafeteria)
+"biQ" = (
+/obj/machinery/alarm{
+	pixel_y = 28
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/cafeteria)
+"biR" = (
+/turf/simulated/floor/tiled/dark,
+/area/tether/surfacebase/topairlock)
+"biS" = (
+/obj/structure/sink{
+	pixel_y = 22
+	},
+/turf/simulated/floor/tiled/dark,
+/area/tether/surfacebase/topairlock)
+"biT" = (
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 28
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/dark,
+/area/tether/surfacebase/topairlock)
+"biU" = (
+/obj/machinery/vending/snack{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/lightgrey{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/lightgrey{
+	dir = 10
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/cafeteria)
+"biV" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/cafeteria)
+"biW" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/cafeteria)
+"biX" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/cafeteria)
+"biY" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/cafeteria)
+"biZ" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/cafeteria)
+"bja" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/cafeteria)
+"bjb" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/cafeteria)
+"bjc" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/cafeteria)
+"bjd" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/cafeteria)
+"bje" = (
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_x = 0
+	},
+/turf/simulated/floor/tiled/dark,
+/area/tether/surfacebase/topairlock)
+"bjf" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/dark,
+/area/tether/surfacebase/topairlock)
+"bjg" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/dark,
+/area/tether/surfacebase/topairlock)
+"bjh" = (
+/obj/machinery/vending/fitness{
+	dir = 4;
+	icon_state = "fitness"
+	},
+/obj/effect/floor_decal/corner/lightgrey{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/lightgrey{
+	dir = 10
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/cafeteria)
+"bji" = (
+/obj/structure/table/bench/sifwooden/padded,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/cafeteria)
+"bjj" = (
+/obj/structure/table/bench/sifwooden/padded,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/cafeteria)
+"bjk" = (
+/obj/structure/table/bench/sifwooden/padded,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/cafeteria)
+"bjl" = (
+/obj/machinery/shower{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals9{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals9{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals9,
+/obj/effect/floor_decal/steeldecal/steel_decals9{
+	dir = 4
+	},
+/obj/structure/curtain/open/shower,
+/turf/simulated/floor/tiled/monotile,
+/area/tether/surfacebase/topairlock)
+"bjm" = (
+/obj/machinery/washing_machine,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/tether/surfacebase/topairlock)
+"bjn" = (
+/obj/machinery/washing_machine,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/tether/surfacebase/topairlock)
+"bjo" = (
+/obj/machinery/vending/coffee{
+	dir = 4;
+	icon_state = "coffee"
+	},
+/obj/effect/floor_decal/corner/lightgrey{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/lightgrey{
+	dir = 10
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/cafeteria)
+"bjp" = (
+/obj/structure/table/wooden_reinforced,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/cafeteria)
+"bjq" = (
+/obj/structure/table/wooden_reinforced,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/cafeteria)
+"bjr" = (
+/obj/structure/table/wooden_reinforced,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/cafeteria)
+"bjs" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/cafeteria)
+"bjt" = (
+/obj/structure/table/bench/sifwooden/padded,
+/obj/machinery/computer/security/telescreen/entertainment{
+	desc = "Looks like it's set to history channel, the show is talking about modern aliens.  I wonder what else is on?";
+	icon_state = "frame";
+	pixel_x = 0;
+	pixel_y = -32
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/cafeteria)
+"bju" = (
+/obj/item/device/radio/intercom/entertainment{
+	pixel_y = -23
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/cafeteria)
+"bjv" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/cafeteria)
+"bjw" = (
+/obj/machinery/door/firedoor,
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced,
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/cafeteria)
+"bjx" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/admin)
+"bjy" = (
+/obj/item/device/healthanalyzer,
+/obj/item/bodybag/cryobag,
+/obj/structure/table/glass,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/admin)
+"bjz" = (
+/obj/machinery/door/airlock/maintenance/medical{
+	name = "Medical Maintenance Access";
+	req_access = list(5)
+	},
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/tether/surfacebase/medical/outfitting)
+"bjA" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/outfitting)
+"bjB" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/outfitting)
+"bjC" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/light_switch{
+	dir = 8;
+	pixel_x = 24;
+	pixel_y = -24
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/outfitting)
+"bjD" = (
+/obj/machinery/door/airlock/medical,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/outfitting)
+"bjE" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4;
+	icon_state = "map-scrubbers"
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 6
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/upperhall)
+"bjF" = (
+/obj/effect/landmark{
+	name = "lightsout"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloorwhite/corner2{
+	dir = 5
+	},
+/obj/effect/floor_decal/borderfloorwhite/corner2{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner2{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner2{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/upperhall)
+"bjG" = (
+/obj/structure/disposalpipe/junction{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/admin)
+"bjH" = (
+/obj/machinery/hologram/holopad,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/admin)
+"bjI" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/admin)
+"bjJ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/admin)
+"bjK" = (
+/obj/structure/table/glass,
+/obj/item/device/radio{
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/obj/item/device/radio{
+	pixel_x = 4;
+	pixel_y = -4
+	},
+/obj/machinery/camera/network/medbay{
+	dir = 8;
+	icon_state = "camera"
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/admin)
+"bjL" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/admin)
+"bjM" = (
+/obj/effect/landmark/start{
+	name = "Paramedic"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/outfitting)
+"bjN" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/upperhall)
+"bjO" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/admin)
+"bjP" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/power/apc{
+	name = "south bump";
+	pixel_y = -28;
+	req_access = list(67)
+	},
+/obj/structure/cable/green,
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/paleblue/border,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/admin)
+"bjQ" = (
+/obj/structure/filingcabinet/medical{
+	desc = "A large cabinet with hard copy medical records.";
+	name = "Medical Records"
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/admin)
+"bjR" = (
+/obj/structure/window/reinforced,
+/obj/machinery/photocopier,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/admin)
+"bjS" = (
+/obj/structure/window/reinforced,
+/obj/structure/filingcabinet/chestdrawer{
+	name = "Medical Forms"
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/admin)
+"bjT" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5;
+	icon_state = "intact-supply"
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/admin)
+"bjU" = (
+/obj/structure/table/glass,
+/obj/item/weapon/paper{
+	desc = "";
+	info = "Bodies designed on the design console must be saved to a disk, provided on the front desk counter, then placed into the resleeving console for printing.";
+	name = "Body Designer Note"
+	},
+/obj/item/device/sleevemate,
+/obj/item/weapon/storage/box/body_record_disk,
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1";
+	pixel_x = 0
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/admin)
+"bjV" = (
+/obj/structure/closet/secure_closet/medical3,
+/obj/item/weapon/soap/nanotrasen,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/obj/machinery/camera/network/medbay{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 10
+	},
+/obj/effect/floor_decal/borderfloorwhite/corner2{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner2{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/outfitting)
+"bjW" = (
+/obj/effect/landmark/start{
+	name = "Paramedic"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/outfitting)
+"bjX" = (
+/obj/structure/closet/secure_closet/medical3,
+/obj/item/weapon/soap/nanotrasen,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/machinery/light,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 6
+	},
+/obj/effect/floor_decal/borderfloorwhite/corner2,
+/obj/effect/floor_decal/corner/paleblue/bordercorner2,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/outfitting)
+"bjY" = (
+/obj/machinery/button/remote/airlock{
+	desc = "A remote control switch for the medbay foyer.";
+	dir = 1;
+	id = "MedbayFoyer";
+	name = "Medbay Doors Control";
+	pixel_x = -25;
+	pixel_y = -5
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/upperhall)
+"bjZ" = (
+/obj/structure/sign/department/chem{
+	pixel_x = 32
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/steeldecal/steel_decals6,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/upperhall)
+"bka" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/simulated/open,
+/area/tether/surfacebase/medical/admin)
+"bkb" = (
+/turf/simulated/open,
+/area/tether/surfacebase/medical/admin)
+"bkc" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/admin)
+"bkd" = (
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/admin)
+"bke" = (
+/obj/machinery/computer/transhuman/designer{
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/admin)
+"bkf" = (
+/obj/machinery/door/airlock/medical,
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/outfitting)
+"bkg" = (
+/obj/item/weapon/reagent_containers/spray/cleaner{
+	desc = "Someone has crossed out the 'Space' from Space Cleaner and written in Chemistry. Scrawled on the back is, 'Okay, whoever filled this with polytrinic acid, it was only funny the first time. It was hard enough replacing the CMO's first cat!'";
+	name = "Chemistry Cleaner"
+	},
+/obj/structure/table/reinforced,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/chemistry)
+"bkh" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/paleblue/border,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/admin)
+"bki" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/paleblue/border,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/admin)
+"bkj" = (
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/admin)
+"bkk" = (
+/obj/machinery/camera/network/medbay{
+	dir = 1
+	},
+/obj/machinery/chem_master,
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/paleblue/border,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/chemistry)
+"bkl" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/camera/network/medbay{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloorwhite/corner2{
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloorwhite/corner2{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner2{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner2{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/upperhall)
+"bkm" = (
+/obj/item/device/radio/intercom{
+	dir = 8;
+	pixel_x = -24
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/admin)
+"bkn" = (
+/obj/machinery/chem_master,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/item/device/radio/intercom{
+	dir = 1;
+	pixel_y = 24;
+	req_access = list()
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/chemistry)
+"bko" = (
+/obj/structure/shuttle/engine/propulsion,
+/turf/simulated/floor/reinforced,
+/turf/simulated/shuttle/plating/carry,
+/area/shuttle/tether)
+"bkp" = (
+/obj/machinery/atmospherics/unary/engine{
+	dir = 1
+	},
+/turf/simulated/floor/reinforced,
+/turf/simulated/shuttle/plating/carry,
+/area/shuttle/tourbus/engines)
 "bkN" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
@@ -33666,15 +35791,40 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_three_hall)
+"brV" = (
+/obj/structure/railing{
+	dir = 1;
+	icon_state = "railing0"
+	},
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/simulated/open/virgo3b,
+/area/tether/surfacebase/outside/outside3)
+"bsr" = (
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/cafeteria)
 "bxH" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/structure/closet/secure_closet/medical3,
+/obj/item/weapon/soap/nanotrasen,
+/obj/effect/floor_decal/borderfloorwhite{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/effect/floor_decal/corner/paleblue/border{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/maintenance/lower/medsec_maintenance)
+/obj/effect/floor_decal/borderfloorwhite/corner2{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner2{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/outfitting)
 "bzK" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -33839,6 +35989,24 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/wood,
 /area/library)
+"cFe" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/surface_three_hall)
 "cFA" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -33869,6 +36037,13 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled,
 /area/rnd/research/researchdivision)
+"cHf" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/southhall)
 "cJL" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/mauve/border,
@@ -33931,6 +36106,23 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/outpost/xenobiology/outpost_hallway)
+"cWU" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/beige/border{
+	dir = 1
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 4;
+	icon_state = "pipe-j1"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/lower/third_south)
 "ddn" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
@@ -34012,6 +36204,19 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_three_hall)
+"dDQ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/disposalpipe/sortjunction{
+	dir = 8;
+	name = "Chemistry";
+	sortType = "Chemistry"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/surface_three_hall)
 "dGZ" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -34062,6 +36267,14 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/research/researchdivision)
+"dNi" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/chemistry)
 "dVE" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -34084,12 +36297,14 @@
 	},
 /turf/simulated/floor/tiled/eris/dark/golden,
 /area/shuttle/tourbus/general)
-"dYX" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+"dXv" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
+/obj/structure/bed/chair{
+	dir = 8
 	},
+/turf/simulated/floor/tiled/monotile,
+/area/tether/surfacebase/shuttle_pad)
+"dYX" = (
 /obj/machinery/light_switch{
 	pixel_y = 25
 	},
@@ -34109,11 +36324,6 @@
 	},
 /obj/effect/floor_decal/techfloor/hole/right{
 	dir = 1
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
@@ -34143,6 +36353,10 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/public_garden_three)
+"exM" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lobby)
 "eAM" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -34283,6 +36497,11 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/rnd/research/researchdivision)
+"ffg" = (
+/obj/machinery/door/airlock/medical,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/admin)
 "fgW" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -34415,25 +36634,15 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_three_hall)
-"fXv" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/door/airlock/medical{
-	name = "Patient Room A";
-	req_one_access = list()
-	},
+"fRO" = (
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor/glass,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/patient_a)
+/area/tether/surfacebase/medical/chemistry)
 "fYr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 4
@@ -34452,6 +36661,13 @@
 	},
 /turf/simulated/floor/tiled/eris/dark/golden,
 /area/shuttle/tourbus/engines)
+"gfg" = (
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube1"
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/tether/surfacebase/shuttle_pad)
 "ghf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -34475,6 +36691,18 @@
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/recreation_area)
+"gtn" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lobby)
 "gtp" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -34504,6 +36732,10 @@
 /obj/structure/cable/green{
 	icon_state = "1-8"
 	},
+/obj/structure/cable/green{
+	dir = 1;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/shuttle_pad)
 "gLg" = (
@@ -34514,6 +36746,24 @@
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/pool)
+"gPo" = (
+/obj/structure/bed/chair/office/dark{
+	dir = 4
+	},
+/obj/effect/landmark/start{
+	name = "Chemist"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/chemistry)
+"gRG" = (
+/obj/structure/closet/hydrant{
+	pixel_x = -32
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/southhall)
 "gRX" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/red/border,
@@ -34536,16 +36786,16 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/lobby)
 "gTN" = (
-/obj/structure/disposalpipe/junction{
-	dir = 8;
-	icon_state = "pipe-j2"
-	},
 /obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_three_hall)
@@ -34580,6 +36830,28 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/lower/third_south)
+"gXd" = (
+/obj/structure/closet/wardrobe/chemistry_white,
+/obj/item/weapon/storage/box/pillbottles,
+/obj/item/weapon/storage/box/pillbottles,
+/obj/item/weapon/storage/fancy/vials,
+/obj/item/weapon/storage/fancy/vials,
+/obj/item/weapon/storage/box/syringes,
+/obj/item/device/radio/headset/headset_med,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 10
+	},
+/obj/effect/floor_decal/borderfloorwhite/corner2{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner2{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/chemistry)
 "haS" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass{
@@ -34620,6 +36892,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/lower/third_south)
+"hth" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/tether/surfacebase/shuttle_pad)
 "hxc" = (
 /obj/effect/floor_decal/borderfloor/corner,
 /obj/effect/floor_decal/corner/lime/bordercorner,
@@ -34631,6 +36910,26 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/public_garden_three)
+"hBf" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/chemistry)
+"hCz" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/airlock/hatch,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled/techfloor,
+/area/tether/surfacebase/shuttle_pad)
 "hCB" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -34652,6 +36951,16 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/wood,
 /area/library)
+"hGJ" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/medical/chemistry)
+"hId" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/southhall)
 "hJt" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
@@ -34671,18 +36980,34 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/maintenance/lower/medsec_maintenance)
-"hYK" = (
-/obj/effect/floor_decal/techfloor{
-	dir = 4
+"hPb" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/effect/floor_decal/techfloor/corner{
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/chemistry)
+"hYK" = (
+/obj/effect/floor_decal/borderfloorwhite{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 1
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/techfloor/grid,
+/obj/structure/table/glass,
+/obj/item/roller,
+/obj/item/roller{
+	pixel_y = 8
+	},
+/obj/item/roller{
+	pixel_y = 16
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/turf/simulated/floor/tiled/white,
 /area/maintenance/lower/medsec_maintenance)
 "ieb" = (
 /obj/effect/floor_decal/borderfloorblack,
@@ -34694,6 +37019,41 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/shuttle_pad)
+"ieo" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 1
+	},
+/obj/machinery/camera/network/medbay{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	pixel_y = 25
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lobby)
+"ieE" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/shuttle_pad)
+"ifI" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
+/obj/machinery/computer/atmos_alert{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/tether/surfacebase/shuttle_pad)
+"igX" = (
+/obj/structure/cable/green{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/chemistry)
 "iiv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -34703,6 +37063,21 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/public_garden_three)
+"iiM" = (
+/obj/structure/table/reinforced,
+/obj/item/weapon/reagent_containers/glass/beaker/large,
+/obj/item/weapon/reagent_containers/dropper,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/chemistry)
 "ioG" = (
 /obj/effect/floor_decal/techfloor,
 /obj/structure/cable/green{
@@ -34723,6 +37098,26 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/panic_shelter)
+"ioL" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/chemistry)
 "iqb" = (
 /obj/structure/bed/chair/bay/chair{
 	dir = 8
@@ -34833,6 +37228,11 @@
 "jvK" = (
 /turf/simulated/wall/shull,
 /area/shuttle/tourbus/cockpit)
+"jwy" = (
+/obj/machinery/door/firedoor/glass/hidden/steel,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/monotile,
+/area/tether/surfacebase/southhall)
 "jAt" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -34991,6 +37391,25 @@
 	},
 /turf/simulated/floor/tiled/eris/white/orangecorner,
 /area/shuttle/tourbus/cockpit)
+"keg" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 5
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 6
+	},
+/obj/machinery/station_map{
+	dir = 4;
+	pixel_x = -32
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/surface_three_hall)
 "keX" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/lightgrey/border,
@@ -35113,6 +37532,17 @@
 /obj/effect/floor_decal/steeldecal/steel_decals7,
 /turf/simulated/floor/tiled,
 /area/rnd/research/researchdivision)
+"kyU" = (
+/obj/structure/railing{
+	dir = 1;
+	icon_state = "railing0"
+	},
+/obj/structure/railing{
+	dir = 4;
+	icon_state = "railing0"
+	},
+/turf/simulated/open/virgo3b,
+/area/tether/surfacebase/outside/outside3)
 "kBF" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 4
@@ -35124,6 +37554,18 @@
 	},
 /turf/simulated/floor/tiled/eris/dark/bluecorner,
 /area/shuttle/tourbus/engines)
+"kBY" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5;
+	icon_state = "intact-scrubbers"
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/chemistry)
 "kTn" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -35151,6 +37593,20 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/research/researchdivision)
+"laB" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/southhall)
 "lcS" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -35259,6 +37715,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/rnd/research/testingrange)
+"lXo" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lobby)
 "lXv" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -35336,11 +37796,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
@@ -35348,6 +37803,16 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
+/area/maintenance/lower/medsec_maintenance)
+"mAl" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/rack,
+/obj/random/maintenance/medical,
+/obj/random/maintenance/clean,
+/obj/random/medical/lite,
+/obj/random/maintenance/medical,
+/obj/random/toy,
+/turf/simulated/floor/plating,
 /area/maintenance/lower/medsec_maintenance)
 "mDf" = (
 /obj/structure/bed/chair/bay/chair{
@@ -35372,22 +37837,8 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_three_hall)
 "mHO" = (
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 1
-	},
-/obj/structure/closet/secure_closet/medical1,
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/item/weapon/reagent_containers/glass/beaker/vial/imidazoline,
+/obj/machinery/smartfridge/chemistry/chemvator,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/chemistry)
 "mRs" = (
@@ -35480,6 +37931,32 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_three_hall)
+"nKy" = (
+/obj/machinery/door/airlock/maintenance/common,
+/obj/machinery/door/firedoor/glass,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/surface_three_hall)
+"nLw" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	dir = 1;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/southhall)
 "nLX" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
@@ -35561,6 +38038,29 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_three_hall)
+"otR" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/light_switch{
+	pixel_y = 25
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/chemistry)
 "oAu" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -35591,11 +38091,11 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/lobby)
@@ -35688,6 +38188,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/rnd/research/researchdivision)
+"oWF" = (
+/obj/structure/railing{
+	dir = 1;
+	icon_state = "railing0"
+	},
+/turf/simulated/open/virgo3b,
+/area/tether/surfacebase/outside/outside3)
 "peS" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -35731,6 +38238,20 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_three_hall)
+"pmK" = (
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24;
+	pixel_y = 0
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/admin)
 "pwF" = (
 /obj/machinery/computer/ship/sensors,
 /turf/simulated/floor/tiled/eris/white/orangecorner,
@@ -35789,6 +38310,19 @@
 	},
 /turf/simulated/floor/tiled/eris/white/orangecorner,
 /area/shuttle/tourbus/cockpit)
+"pPe" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	dir = 1;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/southhall)
 "pPs" = (
 /obj/machinery/light{
 	dir = 1
@@ -35801,6 +38335,20 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/outpost/xenobiology/outpost_main)
+"qda" = (
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/obj/machinery/computer/guestpass{
+	dir = 1;
+	pixel_y = -28
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lobby)
 "qem" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
@@ -35855,6 +38403,16 @@
 "qwm" = (
 /turf/simulated/wall/shull,
 /area/shuttle/tourbus/engines)
+"qwA" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/surface_three_hall)
 "qIb" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -35868,6 +38426,12 @@
 /obj/effect/floor_decal/steeldecal/steel_decals7,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_three_hall)
+"qKO" = (
+/obj/structure/closet/hydrant{
+	pixel_x = 32
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/cafeteria)
 "qQZ" = (
 /obj/effect/floor_decal/techfloor,
 /obj/machinery/firealarm{
@@ -35922,6 +38486,26 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/recreation_area_restroom)
+"rBW" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/chemistry)
 "rEZ" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/reagent_containers/glass/bucket,
@@ -35952,6 +38536,10 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/lower/third_south)
+"rPD" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/monotile,
+/area/tether/surfacebase/shuttle_pad)
 "rXW" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 1
@@ -35972,6 +38560,26 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/panic_shelter)
+"rYU" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/glass,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/surface_three_hall)
 "saK" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/red/border,
@@ -36097,19 +38705,23 @@
 /turf/simulated/floor/tiled,
 /area/hallway/lower/third_south)
 "sWs" = (
-/obj/effect/floor_decal/techfloor{
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 8
+	},
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Medical Department";
+	departmentType = 3;
+	name = "Medical RC";
+	pixel_x = -30
+	},
+/obj/machinery/computer/crew{
 	dir = 4
 	},
-/obj/effect/floor_decal/techfloor/hole/right{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
+/turf/simulated/floor/tiled/white,
 /area/maintenance/lower/medsec_maintenance)
 "sXa" = (
 /obj/machinery/holoposter{
@@ -36147,15 +38759,18 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/public_garden_three)
 "trA" = (
-/obj/effect/floor_decal/techfloor{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/floor_decal/techfloor{
+/obj/effect/floor_decal/borderfloorwhite{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/techfloor/grid,
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 8
+	},
+/obj/structure/bed/chair,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/turf/simulated/floor/tiled/white,
 /area/maintenance/lower/medsec_maintenance)
 "ttH" = (
 /obj/structure/cable/green{
@@ -36292,6 +38907,35 @@
 	},
 /turf/simulated/floor/tiled/eris/dark/golden,
 /area/shuttle/tourbus/general)
+"uiJ" = (
+/obj/machinery/chemical_dispenser/full,
+/obj/structure/table/reinforced,
+/obj/structure/sign/poster{
+	pixel_x = 32
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/chemistry)
+"utY" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/chemistry)
+"uvd" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/admin)
 "uxT" = (
 /obj/effect/floor_decal/steeldecal/steel_decals_central5{
 	dir = 8
@@ -36302,6 +38946,15 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow,
 /turf/simulated/floor/tiled/monotile,
 /area/tether/surfacebase/shuttle_pad)
+"uAI" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lobby)
 "uFI" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -36363,6 +39016,20 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_three_hall)
+"vnS" = (
+/obj/machinery/chemical_dispenser/full,
+/obj/structure/table/reinforced,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/chemistry)
 "voF" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
@@ -36413,6 +39080,19 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_three_hall)
+"vuZ" = (
+/obj/structure/table/glass,
+/obj/machinery/door/window/southleft{
+	req_access = list(5)
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/item/device/flashlight/lamp/green{
+	pixel_x = -12
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lobby)
 "vvA" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/borderfloor{
@@ -36459,10 +39139,64 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_three_hall)
+"vLM" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/tether/surfacebase/shuttle_pad)
 "vQP" = (
-/obj/effect/floor_decal/techfloor,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/maintenance/lower/medsec_maintenance)
+/obj/structure/sign/poster{
+	pixel_x = -32
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/admin)
+"vTf" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/danger{
+	dir = 4
+	},
+/obj/structure/table/rack/shelf,
+/obj/item/weapon/storage/backpack/parachute{
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/obj/item/weapon/storage/backpack/parachute{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/weapon/storage/backpack/parachute{
+	pixel_x = -4;
+	pixel_y = -6
+	},
+/obj/item/weapon/storage/backpack/parachute{
+	pixel_x = 4;
+	pixel_y = -6
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/shuttle_pad)
+"way" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/danger{
+	dir = 4
+	},
+/obj/machinery/computer/shuttle_control/tether_backup{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/shuttle_pad)
 "weK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/hologram/holopad,
@@ -36483,6 +39217,23 @@
 /obj/machinery/photocopier,
 /turf/simulated/floor/wood,
 /area/library)
+"woZ" = (
+/obj/structure/table/woodentable,
+/obj/item/weapon/flame/candle,
+/obj/effect/floor_decal/corner/lightgrey{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/lightgrey{
+	dir = 9
+	},
+/obj/machinery/computer/security/telescreen/entertainment{
+	desc = "Look's like it's set to the info station... I wonder what else is on?";
+	icon_state = "frame";
+	pixel_x = 32;
+	pixel_y = -64
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/surface_three_hall)
 "wrA" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -36525,6 +39276,14 @@
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/plating/eris/under,
 /area/shuttle/tourbus/general)
+"wKZ" = (
+/obj/effect/landmark/start{
+	name = "Medical Doctor"
+	},
+/obj/structure/bed/chair/office/light,
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lobby)
 "wPD" = (
 /obj/effect/floor_decal/borderfloor/corner{
 	dir = 4
@@ -36586,6 +39345,15 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/research/researchdivision)
+"xku" = (
+/obj/machinery/door/firedoor,
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/shuttle_pad)
 "xkx" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -36627,6 +39395,18 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_three_hall)
+"xog" = (
+/obj/structure/bed/chair/office/dark,
+/obj/effect/landmark/start{
+	name = "Chemist"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/chemistry)
 "xpJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 1
@@ -36636,12 +39416,38 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_three_hall)
+"xud" = (
+/obj/structure/table/rack/shelf,
+/obj/item/weapon/storage/backpack/parachute{
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/obj/item/weapon/storage/backpack/parachute{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/weapon/storage/backpack/parachute{
+	pixel_x = -4;
+	pixel_y = -6
+	},
+/obj/item/weapon/storage/backpack/parachute{
+	pixel_x = 4;
+	pixel_y = -6
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/tether/surfacebase/shuttle_pad)
 "xvN" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/recreation_area_restroom)
+"xxB" = (
+/obj/structure/bed/chair{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/tether/surfacebase/shuttle_pad)
 "xyK" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -36655,6 +39461,12 @@
 	},
 /obj/structure/cable/green{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/lobby)
@@ -36750,22 +39562,54 @@
 /turf/simulated/floor/plating/eris/under,
 /area/shuttle/tourbus/cockpit)
 "xZw" = (
-/obj/structure/bed/chair{
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/admin)
+"ycf" = (
+/obj/effect/floor_decal/borderfloor{
 	dir = 8
 	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 5
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 6
+	},
 /obj/structure/cable/green{
-	d1 = 4;
+	d1 = 2;
 	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/tether/surfacebase/shuttle_pad)
+/area/tether/surfacebase/surface_three_hall)
 "yet" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/recreation_area)
+"yjx" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/paleblue/border,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/admin)
 
 (1,1,1) = {"
 aaa
@@ -47718,10 +50562,10 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
+aaq
+aaq
+aaq
+aaq
 aaq
 aac
 aac
@@ -47799,7 +50643,7 @@ jML
 jHw
 jpB
 qWU
-beN
+bkp
 aKU
 aOI
 aPb
@@ -47860,10 +50704,10 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
+aaq
+aaq
+aaq
+aaq
 aaq
 aac
 aac
@@ -47956,10 +50800,10 @@ aac
 aac
 aac
 aac
-aac
-aac
-aac
-aac
+bhX
+aaq
+aaq
+biy
 aac
 aac
 aab
@@ -48002,10 +50846,10 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
+aaq
+aaq
+aaq
+aaq
 aac
 aac
 aac
@@ -48096,13 +50940,13 @@ aac
 aac
 aac
 aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
+bhE
+bhE
+bhE
+bie
+bio
+bhE
+bhE
 aac
 aab
 aab
@@ -48144,10 +50988,10 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
+aaq
+aaq
+aaq
+aaq
 aac
 aac
 aac
@@ -48238,18 +51082,18 @@ aac
 aac
 aac
 aac
-aac
-aac
-aac
-aac
-aac
-aac
+bhE
+bhU
+bhY
+bif
+bip
+biz
+bhE
 aac
 aac
 aab
-aab
-aab
-aab
+aMG
+aMG
 aab
 aab
 aab
@@ -48286,10 +51130,10 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
+aaq
+aaq
+aaq
+aaq
 aac
 aac
 aac
@@ -48380,19 +51224,19 @@ aac
 aac
 aac
 aac
+bhE
+bhV
+bhZ
+big
+biq
+biA
+bhE
 aac
 aac
 aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aab
-aab
-aab
+adG
+adG
+oWF
 aab
 aab
 aab
@@ -48428,10 +51272,10 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
+aaq
+aaq
+aaq
+aaq
 aac
 aac
 aac
@@ -48522,19 +51366,19 @@ aac
 aac
 aac
 aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aab
-aab
+bhE
+bhE
+bhE
+bih
+bir
+bhE
+bhE
+bhE
+bhE
+bhE
+bhE
+adG
+oWF
 aab
 aab
 aab
@@ -48570,10 +51414,10 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
+aaq
+aaq
+aaq
+aaq
 aac
 aac
 aac
@@ -48588,9 +51432,9 @@ dYX
 orc
 agL
 aaE
-aie
-bxH
-vQP
+aaE
+aaE
+aaE
 aaE
 aaE
 aaE
@@ -48651,7 +51495,7 @@ caw
 jHw
 gHh
 qWU
-beN
+bkp
 aKU
 aOI
 aPb
@@ -48661,22 +51505,22 @@ aac
 aac
 aac
 aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aab
-aab
+bhE
+bhE
+bhE
+bhE
+bhE
+bia
+bii
+bis
+biB
+bhE
+biR
+bje
+bjl
+bhE
+adG
+oWF
 aab
 aab
 aab
@@ -48712,16 +51556,16 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
+aaq
+aaq
+aaq
 aac
 aac
 aac
 aac
 aaF
 aky
-abS
+mAl
 acy
 adb
 adV
@@ -48735,8 +51579,8 @@ sWs
 hYK
 trA
 aUs
-aUt
-aWA
+aaE
+aix
 aWL
 aNp
 alj
@@ -48803,22 +51647,22 @@ aac
 aac
 aac
 aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aab
-aab
+bhE
+bhF
+bhM
+bhQ
+bhW
+bib
+bij
+bit
+biC
+biJ
+biR
+biR
+biR
+bhE
+adG
+oWF
 aab
 aab
 aab
@@ -48854,29 +51698,29 @@ aab
 aab
 aab
 aab
-aab
-aab
+aaq
+aaq
 aac
 aac
 aac
 aac
-aac
-aaF
-abo
-abS
-aaE
-aag
-aag
-aag
-afa
-aag
-aag
-aag
-aeG
-aeG
-aeG
-aeG
-aeG
+abw
+abw
+abw
+abw
+abw
+abw
+abw
+abw
+bjz
+abw
+abw
+abw
+ieo
+wKZ
+vuZ
+lXo
+qda
 aWg
 aWB
 ajR
@@ -48945,22 +51789,22 @@ aac
 aac
 aac
 aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aab
-aab
+bhE
+bhG
+bhN
+bhR
+bhE
+bhE
+bik
+biu
+bhE
+bhE
+biS
+bjf
+bjm
+bhE
+adG
+oWF
 aab
 aab
 aab
@@ -48999,25 +51843,25 @@ aab
 aab
 aab
 aac
-aac
-aac
-aac
-aac
-aaE
-abx
-abT
-aaE
-adc
-adM
-aea
-afb
-aga
-aec
-aag
+aad
+aad
+aad
+abw
+acR
+adE
+aeT
+abw
+aIR
+aSp
+aTn
+bjA
+aWA
+bjV
+abw
 afF
 aja
 aTK
-aVF
+agX
 aVW
 aWh
 qIb
@@ -49087,22 +51931,22 @@ aac
 aac
 aac
 aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aab
-aab
-aab
-aab
+bhE
+bhL
+bhO
+bhS
+bhE
+bic
+bil
+biv
+biD
+biK
+biT
+bjg
+bjn
+bhE
+adG
+kyU
 aab
 aab
 aab
@@ -49141,23 +51985,23 @@ aab
 aab
 aab
 aac
-aag
-aag
-aag
-aag
-aag
-aag
-aag
-aag
-aaQ
-aaZ
-aaZ
-aSR
-aTj
-abv
-aag
+aad
+aar
+aar
+abw
+acS
+adF
+aeV
+agn
+aPq
+aSq
+aTp
+bjB
+bjM
+bjW
+bkf
 ahW
-aig
+agX
 agj
 agX
 aVn
@@ -49212,40 +52056,40 @@ bMK
 rxh
 jZe
 uxT
-jZe
-jZe
+ifI
+dXv
 ooM
 uYO
-aKe
-aKe
+xxB
+xud
 aMU
 aKe
 aKe
 aKe
 aKj
-aNi
-aNi
-aKj
 aac
 aac
 aac
 aac
 aac
 aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aab
-aab
-aab
-aab
-aab
+bhE
+bhE
+bhP
+bhT
+bhE
+bid
+bim
+biw
+biE
+bhE
+bhE
+bhE
+bhE
+bhE
+adG
+adG
+oWF
 aab
 aab
 aab
@@ -49283,25 +52127,25 @@ aab
 aab
 aab
 aac
-aag
-aat
-aat
-aag
-aaU
-aeH
+aad
+aar
+aaZ
 abw
-aaH
-aaR
-aba
-abq
-acb
-acN
-aUA
-agn
+acT
+adM
+afa
+abw
+aPr
+aNy
+aTq
+bjC
+bxH
+bjX
+abw
 ahY
 afz
 agk
-agX
+exM
 ahK
 aUU
 qIb
@@ -49351,43 +52195,43 @@ ats
 aKf
 aKf
 aKj
-aKg
-aKe
+aKf
 aKj
-aKe
+aKj
+aKj
+aKf
 aKg
-aNH
-xZw
-aKg
+xJy
+aKf
 aNX
 aKj
-aKe
-aKg
-aLL
 aKj
-aLa
-aPL
-aKj
-aKj
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aab
-aab
-aab
-aab
-aab
+aKf
+aKf
+aPs
+aPs
+aPs
+aPs
+bhh
+bhh
+aPs
+aPs
+aPs
+aPs
+aPs
+aPs
+aPs
+bin
+bix
+biF
+biF
+biU
+bjh
+bjo
+biF
+biF
+adG
+oWF
 aab
 aab
 aab
@@ -49425,21 +52269,21 @@ aab
 aab
 aab
 aac
-aag
-aao
-abh
-aag
 aad
-aaZ
-aaA
-aaI
-aaS
-aaI
-aaS
-acc
-acO
-azu
-agn
+aas
+aba
+abw
+abw
+abw
+abw
+abw
+abw
+abw
+abw
+bjD
+abw
+abw
+abw
 aiB
 aUV
 agl
@@ -49494,7 +52338,7 @@ aKg
 aKg
 aLA
 aKg
-aKe
+gfg
 aMV
 aKe
 aKg
@@ -49505,31 +52349,31 @@ aKe
 aOc
 aKe
 aKg
-aKg
-aKj
-aPq
+aMA
+aPu
 aPM
-aPZ
-aPb
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aab
-aab
-aab
-aab
+beU
+bfj
+bhi
+beU
+bhm
+beU
+beU
+bhp
+beU
+beU
+gRG
+laB
+beU
+biF
+bsr
+biL
+biL
+biL
+bjs
+biF
+adG
+oWF
 aab
 aab
 aab
@@ -49567,20 +52411,20 @@ aab
 aab
 aab
 aac
-aah
-aap
-aaZ
-aVv
-adw
-aaZ
-aaB
-aaJ
-aaT
+aag
+aat
 abb
-aSM
-aSS
-acP
-ady
+aLL
+acU
+aea
+afb
+ago
+aQF
+aSG
+aTs
+bjE
+bkl
+bjY
 aee
 aeL
 afB
@@ -49589,7 +52433,7 @@ aVk
 ahM
 aVt
 ajf
-avG
+dDQ
 akn
 alk
 aZt
@@ -49642,36 +52486,36 @@ sFW
 ghf
 ghf
 gLd
-aNx
-aMA
-aFC
-aMA
+ghf
+sFW
+aMW
+sFW
 aOu
 aNx
-aPc
-aPr
-aPM
-aQa
-aPb
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aab
-aab
-aab
-aab
-aab
+aPs
+aPZ
+beV
+bfJ
+bhj
+beV
+bhn
+beV
+beV
+bhj
+beV
+pPe
+nLw
+bhw
+nLw
+biG
+biM
+biV
+biL
+biL
+biL
+bjw
+adG
+oWF
 aab
 aab
 aab
@@ -49709,32 +52553,32 @@ aab
 aab
 aab
 aac
-aah
-aar
-aas
-aSb
-aaZ
-aaZ
-aaC
-aaK
-aaT
+aag
+aaz
 abc
-aSN
-aST
-acQ
-adz
-aUI
+abx
+adc
+aec
+aMd
+agZ
+aRG
+aSK
+aTL
+bjF
+bjN
+bjZ
+uAI
 aeM
-agY
+gtn
 afC
-agY
+uAI
 ahN
 aii
-aiV
+qwA
 jri
 akn
 bbq
-aZu
+woZ
 bbu
 ayx
 aZo
@@ -49770,7 +52614,7 @@ bgk
 bbk
 bfc
 bbg
-bds
+cWU
 aIb
 aID
 aJp
@@ -49780,40 +52624,40 @@ aLB
 aMc
 aMB
 aug
-aKe
-aKg
-aKg
-aKg
-aKg
-aKe
+rPD
+ieE
+ieE
+ieE
+ieE
+vLM
 aOd
-aKe
+hth
 aOv
-aKg
-aKj
-aPs
-aPM
+aPc
+aPL
 aQa
-aPb
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aab
-aab
-aab
-aab
-aab
+hId
+bgm
+bhk
+hId
+jwy
+hId
+hId
+bhq
+hId
+cHf
+beU
+bhx
+beU
+biF
+biN
+biW
+bji
+bjp
+bjj
+bjw
+adG
+oWF
 aab
 aab
 aab
@@ -49848,24 +52692,24 @@ aab
 aab
 aab
 aab
-aab
-aOm
-adG
-aag
-aag
-aaD
-aSk
-aaZ
-aaZ
-ago
-aQF
-aRN
-aSp
-aSO
-aSU
+aaq
+aaq
+aac
+aah
+aah
+aaL
+abT
+aah
+aah
+aah
+aah
+aah
+afH
+aTM
+aTd
 aTl
-adA
-aag
+aTd
+aTd
 aeN
 aUW
 aVe
@@ -49919,43 +52763,43 @@ ats
 aKj
 aKj
 aKj
-aMd
+aKf
 aMC
 aKj
 aNj
-aNy
-aNI
-aNO
-aNy
-aKe
-aKj
-aKe
-aOv
+aKf
 aKg
+aKg
+aKf
 aKj
-aPt
-aUu
 aKj
 aKj
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aab
-aab
-aab
+aKf
+aKf
+aPs
+aPs
+aPs
+aPs
+bhl
+bhl
+aPs
+aPs
+aPs
+aPs
+aPs
+aPs
+bhs
+bhy
+bhB
+biF
+biO
+biX
+bjj
+bjq
+bjj
+bjw
+adG
+oWF
 aab
 aab
 aab
@@ -49990,25 +52834,25 @@ aab
 aab
 aab
 aab
-aab
-aOm
-adG
+aaq
+aaq
 aac
-aag
-aaL
-asA
-aSG
-aSK
-aUh
-aRG
+aah
+aaA
+abd
+aca
+adu
+aed
 afx
-aSq
-aSP
-aSV
-aTm
-aSP
-aSP
-aSP
+ahz
+aRK
+aSM
+aTN
+aTd
+otR
+gXd
+aTd
+aTd
 aUX
 aVf
 aVm
@@ -50075,9 +52919,6 @@ aKe
 aOw
 aKe
 aKj
-aPu
-aPu
-aKj
 aac
 aac
 aac
@@ -50088,16 +52929,19 @@ aac
 aac
 aac
 aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aab
-aab
-aab
+aPs
+beU
+bhx
+beU
+biF
+biL
+biX
+bjj
+bjq
+bjt
+biF
+adG
+oWF
 aab
 aab
 aab
@@ -50132,28 +52976,28 @@ aab
 aab
 aab
 aab
-aab
-aab
-aNM
+aaq
+aaq
 aQW
-aag
-aag
-aRK
-aaz
-abd
-fXv
-aed
+aah
+aaB
+abe
+aaL
+aaL
+aeg
 afy
 ahO
-aSP
+aRN
+aSN
+aUh
 aSZ
-aTn
+rBW
 aUv
-aUJ
+hBf
 aUP
 aUY
 aVg
-aSP
+aTd
 ahd
 ahS
 aji
@@ -50206,9 +53050,9 @@ ats
 aMf
 aKT
 aKT
+way
 aKT
-aKT
-aKT
+vTf
 aKT
 aKT
 aKT
@@ -50227,19 +53071,19 @@ aac
 aac
 aac
 aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aab
-aab
-aab
+bhr
+beU
+bhx
+beU
+biF
+biP
+biY
+bjj
+bjq
+bjj
+bjw
+adG
+oWF
 aab
 aab
 aab
@@ -50274,28 +53118,28 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
+aaq
+aaq
 aac
-aag
-agZ
-aSm
-aaz
-abp
-acR
-aed
+aah
+aaB
+abf
+acb
+adv
+aeh
 afA
-aih
-aSP
-aTb
+acb
+aSb
+aSO
+aUj
+aTd
 aTo
-aUD
-aUK
+aUL
+aUL
 aUQ
 aUZ
 aVh
-aSP
+aTd
 agw
 agw
 aWi
@@ -50359,6 +53203,9 @@ aKj
 aOy
 aKj
 aKj
+aNi
+aNi
+aKj
 aac
 aac
 aac
@@ -50366,22 +53213,19 @@ aac
 aac
 aac
 aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aab
-aab
+bhr
+beU
+bhx
+beU
+biH
+biL
+biZ
+bjk
+bjr
+bjj
+bjw
+adG
+oWF
 aab
 aab
 aab
@@ -50416,31 +53260,31 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
+aaq
 aac
-aag
-acd
-aSn
-aaz
-abr
-adu
-aed
+aac
+aah
+aaC
+abh
+acc
+adw
+aei
 afD
-aDp
-aSP
+acc
+adw
+aSO
+aUA
 mHO
-aTp
-aUE
-aUL
+ioL
+kBY
+igX
 aUR
 aVa
-aVi
-aSP
+bkk
+aTd
 aVq
 aVu
-aix
+cFe
 avG
 akn
 alk
@@ -50501,29 +53345,29 @@ aOj
 aOz
 aOM
 aKj
+aUu
+beW
+aKj
+aKj
 aac
 aac
 aac
 aac
 aac
 aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aab
-aab
-aab
-aab
+aPs
+bht
+bhx
+beU
+biH
+biL
+bja
+biL
+biL
+biL
+bjw
+adG
+oWF
 aab
 aab
 aab
@@ -50558,31 +53402,31 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aaq
-aag
-ace
-aUj
-aaz
-abs
-adv
-aed
-afE
-aGm
-aSP
-aTd
-aTq
-aIR
-aeA
+aac
+aac
+aac
+aah
+aaD
+abn
+acd
+adw
+aej
+afD
+acd
+adw
+aSO
+aUA
+hGJ
+iiM
+utY
+fRO
 aUS
 aJl
 aVj
-aSP
+aTd
 auS
 aVu
-aix
+cFe
 avG
 akG
 aha
@@ -50636,36 +53480,36 @@ aNk
 uSA
 aNJ
 aNP
-bde
+bko
 aKU
 abg
 aOk
 aOA
 aON
 aKj
+bde
+bfh
+bgu
+aPb
 aac
 aac
 aac
 aac
 aac
 aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aab
-aab
-aab
-aab
+aPs
+bhv
+bhz
+bhC
+biH
+biL
+bja
+biL
+biL
+bju
+biF
+adG
+oWF
 aab
 aab
 aab
@@ -50696,35 +53540,35 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
 aaq
-aag
-aSo
+aaq
+aaq
+aac
+aac
+aac
+aac
+aah
+aaH
 abn
-aaz
-aca
-aca
-aed
-agi
-agi
-aSP
-aSP
-aSP
-aSP
-aSP
-aSP
-aSP
-aSP
-aSP
+ace
+ady
+aek
+afE
+ahP
+aSk
+aSO
+aUt
+aTd
+bkn
+gPo
+dNi
+hPb
+xog
+aVi
+aTd
 agw
 agw
-aix
+cFe
 gTN
 akL
 akH
@@ -50778,36 +53622,36 @@ aNl
 aNl
 aNK
 aNP
-bde
+bko
 aKU
 abg
 aOk
-aOB
+aLa
 aOO
-aKj
+hCz
+beN
+bfh
+bhg
+aPb
 aac
 aac
 aac
 aac
 aac
 aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aab
-aab
-aab
-aab
+aPs
+beU
+bhx
+beU
+biH
+biL
+bja
+biL
+biL
+biL
+bjw
+adG
+oWF
 aab
 aab
 aab
@@ -50838,36 +53682,36 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
 aaq
-aag
-aag
-aag
-aag
+aaq
+aaq
 aac
 aac
 aac
 aac
-aac
-aac
-aTg
-aTs
+aah
+aaI
+abo
+abp
+adz
+adz
+afG
+aih
+aSm
+aSP
+aUD
+aTd
+vnS
 aUG
 aUN
-aUG
+bkg
 aVc
-aUG
-aUG
+uiJ
+aTd
 aVs
 agw
-aix
-aka
+cFe
+ajM
 atc
 aMX
 ama
@@ -50920,36 +53764,36 @@ aNm
 aNl
 aNK
 aNP
-bde
+bko
 aKU
 abg
 aOk
 aOB
 aOP
 aKj
-aQf
+beQ
+bfh
+bhg
+aPb
 aac
 aac
 aac
 aac
 aac
 aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aab
-aab
+bhr
+beU
+bhx
+beU
+biH
+biL
+bjb
+bjk
+bjr
+bjj
+bjw
+adG
+oWF
 aab
 aab
 aab
@@ -50980,36 +53824,36 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
+aaq
 aaq
 aaq
 aac
 aac
 aac
 aac
-aac
-aac
-aac
-abe
-abe
-abe
-abe
-aUH
-abe
-abe
-abe
+aah
+aaJ
+aie
+acg
+aaL
+aaL
+afH
+aka
+aSn
+aSR
+aUE
+aTd
+aTd
+aTd
+aTd
+aTd
+aTd
+aTd
 agw
+nKy
 agw
-agw
-agw
-ajj
-akb
+rYU
+aWI
 avH
 alo
 amb
@@ -51069,29 +53913,29 @@ aOk
 aOC
 axB
 aKj
+beT
+bfi
+aKj
+aKj
 aac
 aac
 aac
 aac
 aac
 aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aab
-aab
+bhr
+beU
+bhx
+beU
+biF
+biQ
+bjc
+bjj
+bjq
+bjj
+bjw
+adG
+oWF
 aab
 aab
 aab
@@ -51122,36 +53966,36 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
+aaq
 aac
 aac
 aac
 aac
 aac
 aac
-aac
-aac
-aac
-abf
-abt
-acg
-acU
-aeg
-aej
-aeO
-afG
+aah
+aaK
+abq
+ach
+aaL
+aeA
+afH
+akb
+aSn
+aNH
+aVF
+bkm
+bjO
+pmK
+vQP
+uvd
+aSn
 agp
-aha
-ahP
+keg
+ycf
 ail
 ajk
-aka
+ajM
 awp
 alp
 amc
@@ -51209,7 +54053,10 @@ aKU
 aKj
 aOl
 oMK
-aOk
+aPt
+aKj
+xku
+xku
 aKj
 aac
 aac
@@ -51218,22 +54065,19 @@ aac
 aac
 aac
 aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aab
-aab
-aab
+aPs
+beU
+bhx
+beU
+biF
+biL
+bjc
+bjj
+bjq
+bjt
+biF
+adG
+oWF
 aab
 aab
 aab
@@ -51264,30 +54108,30 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
+aaq
 aac
 aac
 aac
 aac
 aac
 aac
-aac
-aac
-aac
-abf
-abu
-ach
-abe
-adB
-aTL
-aeP
-afH
+aah
+agY
+aig
+aig
+aig
+aeH
+afJ
+asA
+aSn
+aST
+aUI
+bjG
+bjL
+bjL
+bjL
+bjP
+aSn
 agq
 agN
 ahQ
@@ -51363,19 +54207,19 @@ aac
 aac
 aac
 aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aab
-aab
-aab
+aPs
+bhs
+bhy
+bhB
+biF
+biO
+bjc
+bjj
+bjq
+bjj
+bjw
+adG
+oWF
 aab
 aab
 aab
@@ -51406,31 +54250,31 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
+aaq
 aaq
 aac
 aac
 aac
 aac
 aac
-aac
-aac
-aac
-abe
-abe
-abe
-abe
+aao
+aao
+aao
 aci
-aeh
-aeQ
-afG
-apr
+aci
+aao
+aci
+aci
+aao
+aSU
+aUJ
+aSS
+bjQ
+bka
+bkb
+yjx
+ffg
+apS
 art
 asm
 akI
@@ -51505,19 +54349,19 @@ aac
 aac
 aac
 aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aab
-aab
-aab
-aab
+aPs
+bht
+bhx
+beU
+biF
+biN
+bjd
+bji
+bjp
+bjj
+bjw
+adG
+oWF
 aab
 aab
 aab
@@ -51550,28 +54394,28 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aaq
 aac
 aac
 aac
 aac
 aac
-aac
-aac
-aac
-abf
-abt
-acS
+aao
+aaQ
+abr
+acN
+adA
+aeO
 afX
-aeg
-aTM
-aeR
-abe
+azu
+aao
+aSV
+aUK
+aSS
+bjR
+bka
+bkb
+bkh
+aSn
 anm
 arH
 asn
@@ -51647,19 +54491,19 @@ aac
 aac
 aac
 aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aab
-aab
-aab
-aab
+bhr
+beU
+bhx
+beU
+biI
+biL
+biL
+biL
+biL
+biL
+bjw
+adG
+oWF
 aab
 aab
 aab
@@ -51693,27 +54537,27 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aaq
 aac
 aac
 aac
 aac
-aac
-aac
-aac
-aac
-abf
-abu
-ach
-abe
-adD
-aeh
-aeS
-abe
+aap
+aaR
+abs
+abs
+abs
+aeP
+abs
+aDp
+aci
+aNI
+aUH
+bjH
+bjS
+bkb
+bkb
+bki
+aSn
 aoj
 aXU
 asr
@@ -51789,19 +54633,19 @@ aac
 aac
 aac
 aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aab
-aab
-aab
-aab
+bhr
+beU
+bhx
+beU
+biF
+biL
+biL
+qKO
+biL
+bjv
+biF
+adG
+oWF
 aab
 aab
 aab
@@ -51836,26 +54680,26 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
+aaq
 aac
 aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-abe
-abe
-abe
-abe
-adE
-aei
-aeT
-abe
+aap
+aaS
+abt
+acO
+adB
+aeQ
+aga
+aFC
+aSo
+aTg
+aVv
+bjI
+aTb
+bkc
+bkc
+yjx
+aSn
 aoo
 aXU
 asv
@@ -51931,19 +54775,19 @@ aac
 aac
 aac
 aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aab
-aab
-aab
-aab
+aPs
+beU
+bhx
+beU
+biF
+biF
+biF
+biF
+biF
+biF
+biF
+adG
+oWF
 aab
 aab
 aab
@@ -51978,26 +54822,26 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
+aaq
 aac
 aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-abf
-abt
-acT
-ahz
-aeg
-aTN
+aap
+aaT
+abu
+acP
 adC
-abe
+aeR
+abs
+aaR
+aci
+aNO
+bjx
+bjJ
+bjT
+bkd
+aTb
+yjx
+aSn
 aoD
 aXU
 asr
@@ -52073,19 +54917,19 @@ aac
 aac
 aac
 aac
+aPs
+bhv
+bhA
+bhC
+bhm
+bhH
+beU
+aPs
 aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aab
-aab
-aab
-aab
+adG
+adG
+adG
+oWF
 aab
 aab
 aab
@@ -52120,26 +54964,26 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
 aaq
 aaq
 aac
-aac
-aac
-aac
-aac
-aac
-aac
-abf
-abu
-ach
-abe
-adF
-aek
-aeV
-abe
+aao
+aaU
+abv
+acQ
+adD
+aeS
+agi
+aGm
+aao
+aTj
+bjy
+bjK
+bjU
+bke
+xZw
+bkj
+aSn
 aoF
 arM
 asE
@@ -52215,18 +55059,18 @@ aac
 aac
 aac
 aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aab
-aab
-aab
-aab
+aPs
+beU
+beU
+beU
+bhs
+beU
+bhJ
+aPs
+adG
+adG
+aNB
+aNM
 aab
 aab
 aab
@@ -52263,25 +55107,25 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aaq
-aaq
-aac
-aac
-acf
-acf
-acf
-acf
-afJ
-afJ
-afJ
-afJ
-afJ
-afJ
-afJ
-afJ
+aOm
+ajG
+aao
+aao
+aao
+aao
+aao
+aao
+aao
+aao
+aao
+aTm
+aTm
+aTm
+aTm
+aTm
+aTm
+aTm
+aTm
 acf
 arx
 acf
@@ -52357,16 +55201,16 @@ aac
 aac
 aac
 aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aab
-aab
+bhr
+beU
+beU
+beU
+bho
+bhI
+bhI
+bhK
+adG
+brV
 aab
 aab
 aab
@@ -52405,11 +55249,11 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aaq
-aaq
+aOm
+ajG
+aac
+aac
+aac
 aac
 aac
 afS
@@ -52499,16 +55343,16 @@ aac
 aac
 aac
 aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aab
-aab
-aab
+bhr
+beU
+beU
+bhD
+aPs
+bhI
+bhI
+bhK
+adG
+oWF
 aab
 aab
 aab
@@ -52548,10 +55392,10 @@ aab
 aab
 aab
 aab
-aab
-aab
-aaq
-aaq
+aNM
+aac
+aac
+aac
 aac
 aac
 afS
@@ -52641,16 +55485,16 @@ aac
 aac
 aac
 aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aab
-aab
-aab
+aPs
+beU
+beU
+beU
+aPs
+bhI
+bhI
+aPs
+adG
+oWF
 aab
 aab
 aab
@@ -52783,16 +55627,16 @@ aac
 aac
 aac
 aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aab
-aab
-aab
+aPs
+aPs
+bhl
+aPs
+aPs
+aPs
+aPs
+aPs
+adG
+oWF
 aab
 aab
 aab
@@ -52931,10 +55775,10 @@ aac
 aac
 aac
 aac
-aab
-aab
-aab
-aab
+aac
+adG
+adG
+oWF
 aab
 aab
 aab
@@ -53058,24 +55902,24 @@ aac
 aac
 aab
 aab
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
 aab
-aab
-aab
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aab
-aac
-aab
-aab
-aab
-aab
+aNM
+aNM
 aab
 aab
 aab
@@ -53202,7 +56046,6 @@ aab
 aab
 aab
 aab
-aab
 aac
 aac
 aac
@@ -53212,8 +56055,9 @@ aac
 aac
 aac
 aac
-aab
-aab
+aac
+aac
+aac
 aab
 aab
 aab
@@ -53345,16 +56189,16 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
 aab
 aab
 aab
@@ -53488,15 +56332,15 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
+aac
+aac
+aac
+aac
+aac
+aac
+aaq
+aaq
+aaq
 aab
 aab
 aab

--- a/maps/tether/tether-06-station2.dmm
+++ b/maps/tether/tether-06-station2.dmm
@@ -3808,6 +3808,10 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/exploration/staircase)
+"fD" = (
+/obj/structure/firedoor_assembly,
+/turf/simulated/floor,
+/area/medical/morgue)
 "fE" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 8
@@ -14524,6 +14528,10 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/exploration/equipment)
+"yB" = (
+/obj/structure/barricade,
+/turf/simulated/floor,
+/area/medical/psych)
 "yH" = (
 /obj/structure/closet/secure_closet/pilot,
 /obj/effect/floor_decal/borderfloor,
@@ -14610,6 +14618,10 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery)
+"zc" = (
+/obj/structure/firedoor_assembly,
+/turf/simulated/floor,
+/area/medical/psych)
 "zd" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -18664,6 +18676,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel_dirty,
 /area/security/brig)
+"Jb" = (
+/obj/structure/barricade,
+/turf/simulated/floor/airless,
+/area/medical/patient_c)
 "Jc" = (
 /obj/machinery/seed_storage/brig{
 	dir = 8
@@ -18874,6 +18890,10 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/security_cell_hallway)
+"KS" = (
+/obj/structure/barricade,
+/turf/simulated/floor,
+/area/maintenance/station/medbay)
 "KT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -20288,6 +20308,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white,
 /area/maintenance/station/sec_lower)
+"Ta" = (
+/obj/structure/frame,
+/turf/simulated/floor,
+/area/medical/morgue)
 "Tb" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -20950,6 +20974,10 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/maintenance/station/sec_lower)
+"WH" = (
+/obj/structure/barricade,
+/turf/simulated/floor,
+/area/medical/morgue)
 "WJ" = (
 /obj/structure/catwalk,
 /obj/effect/decal/cleanable/dirt,
@@ -29738,9 +29766,9 @@ AH
 AX
 Bm
 BC
+Jb
 CD
-CD
-CD
+Jb
 CO
 aP
 ab
@@ -30567,8 +30595,8 @@ rW
 rk
 fM
 po
-wz
-wz
+zc
+zc
 wz
 wz
 wz
@@ -30851,7 +30879,7 @@ rW
 Dh
 Yy
 po
-wz
+zc
 wz
 wz
 wz
@@ -31139,12 +31167,12 @@ qL
 wb
 rD
 pp
+zc
 wz
 wz
 wz
-wz
-wz
-wz
+yB
+yB
 xb
 xv
 ye
@@ -31987,11 +32015,11 @@ ac
 ac
 uW
 KV
+Ta
 KV
 KV
-KV
-KV
-KV
+fD
+WH
 tu
 tU
 vd
@@ -32129,11 +32157,11 @@ ac
 ac
 uW
 KV
+Ta
 KV
 KV
 KV
-KV
-KV
+WH
 tu
 tV
 ve
@@ -32417,7 +32445,7 @@ KV
 KV
 KV
 KV
-KV
+fD
 tu
 tX
 vh
@@ -32559,7 +32587,7 @@ KV
 KV
 KV
 KV
-KV
+fD
 tu
 uq
 vw
@@ -32570,7 +32598,7 @@ zP
 zP
 xg
 zP
-zP
+KS
 xg
 pp
 pp
@@ -32839,7 +32867,7 @@ ac
 ac
 uW
 KV
-KV
+Ta
 KV
 KV
 KV
@@ -32981,7 +33009,7 @@ ac
 ac
 uW
 KV
-KV
+Ta
 KV
 KV
 KV

--- a/maps/tether/tether-06-station2.dmm
+++ b/maps/tether/tether-06-station2.dmm
@@ -3033,18 +3033,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/station/port)
-"ev" = (
-/obj/structure/table/standard,
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 6
-	},
-/obj/effect/floor_decal/corner/white/border{
-	dir = 6
-	},
-/obj/effect/floor_decal/borderfloorwhite/corner2,
-/obj/effect/floor_decal/corner/white/bordercorner2,
-/turf/simulated/floor/tiled/white,
-/area/medical/surgery2)
 "ew" = (
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -3820,22 +3808,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/exploration/staircase)
-"fD" = (
-/obj/structure/table/standard,
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 6
-	},
-/obj/effect/floor_decal/corner/white/border{
-	dir = 6
-	},
-/obj/item/weapon/reagent_containers/spray/cleaner{
-	desc = "Someone has crossed out the Space from Space Cleaner and written in Surgery. 'Do not remove under punishment of death!!!' is scrawled on the back.";
-	name = "Surgery Cleaner";
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/surgery2)
 "fE" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 8
@@ -4636,29 +4608,6 @@
 /obj/random/maintenance/research,
 /turf/simulated/floor,
 /area/maintenance/station/exploration)
-"gS" = (
-/obj/structure/table/standard,
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 5
-	},
-/obj/effect/floor_decal/corner/white/border{
-	dir = 5
-	},
-/obj/effect/floor_decal/borderfloorwhite/corner2{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/white/bordercorner2{
-	dir = 4;
-	icon_state = "bordercolorcorner2"
-	},
-/obj/machinery/status_display{
-	density = 0;
-	layer = 4;
-	pixel_x = 32;
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/surgery2)
 "gT" = (
 /obj/structure/shuttle/engine/propulsion{
 	dir = 8
@@ -9995,20 +9944,8 @@
 /turf/simulated/floor/tiled,
 /area/hallway/station/starboard)
 "pn" = (
-/obj/machinery/door/firedoor/glass,
-/obj/structure/window/reinforced/polarized/full{
-	id = "psych_office"
-	},
-/obj/structure/grille,
-/obj/machinery/door/blast/shutters{
-	density = 0;
-	dir = 2;
-	icon_state = "shutter0";
-	id = "medbayquar";
-	name = "Medbay Emergency Lockdown Shutters";
-	opacity = 0
-	},
-/turf/simulated/floor/plating,
+/obj/machinery/door/airlock/maintenance/common,
+/turf/simulated/floor,
 /area/medical/psych)
 "po" = (
 /turf/simulated/wall,
@@ -10031,8 +9968,13 @@
 /turf/simulated/floor/plating,
 /area/medical/surgery_hallway)
 "pr" = (
-/obj/structure/sign/department/medbay,
-/turf/simulated/wall,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/white,
 /area/medical/surgery_hallway)
 "ps" = (
 /obj/structure/disposalpipe/segment,
@@ -10418,42 +10360,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/station/starboard)
-"pV" = (
-/obj/structure/morgue,
-/turf/simulated/floor/tiled/techfloor,
-/area/medical/morgue)
-"pW" = (
-/obj/machinery/light/small{
-	dir = 1;
-	icon_state = "bulb1"
-	},
-/obj/effect/floor_decal/techfloor{
-	dir = 9
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/medical/morgue)
-"pX" = (
-/obj/effect/floor_decal/techfloor{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/medical/morgue)
-"pY" = (
-/obj/structure/morgue{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/medical/morgue)
-"pZ" = (
-/obj/effect/floor_decal/techfloor{
-	dir = 9
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/medical/morgue)
 "qa" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -10791,29 +10697,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/station/starboard)
-"qD" = (
-/obj/machinery/light/small{
-	dir = 1;
-	icon_state = "bulb1"
-	},
-/obj/effect/floor_decal/techfloor{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/medical/morgue)
-"qE" = (
-/obj/machinery/disposal,
-/obj/effect/floor_decal/techfloor{
-	dir = 5
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/medical/morgue)
 "qF" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -10874,22 +10757,7 @@
 /obj/item/stack/cable_coil,
 /turf/simulated/floor,
 /area/storage/tech)
-"qJ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/turf/simulated/floor/wood,
-/area/medical/psych)
-"qK" = (
-/obj/structure/flora/pottedplant/fern,
-/obj/machinery/camera/network/medbay{
-	dir = 9;
-	icon_state = "camera"
-	},
-/turf/simulated/floor/wood,
-/area/medical/psych)
 "qL" = (
-/obj/structure/bed/chair,
 /obj/structure/sign/nosmoking_1{
 	pixel_y = 32
 	},
@@ -10899,26 +10767,9 @@
 /obj/effect/floor_decal/corner/paleblue/border{
 	dir = 9
 	},
-/obj/effect/floor_decal/borderfloorwhite/corner2{
-	dir = 10
-	},
-/obj/effect/floor_decal/corner/paleblue/bordercorner2{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/surgery_hallway)
-"qM" = (
-/obj/structure/bed/chair,
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 1
-	},
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery_hallway)
 "qN" = (
-/obj/structure/bed/chair,
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 1
 	},
@@ -11207,12 +11058,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/station/port)
-"rn" = (
-/obj/effect/floor_decal/techfloor{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/medical/morgue)
 "ro" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -11250,46 +11095,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/tether/station/public_meeting_room)
-"rq" = (
-/obj/structure/table/woodentable,
-/obj/item/toy/plushie/therapy/blue,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
-	},
-/turf/simulated/floor/wood,
-/area/medical/psych)
-"rr" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/wood,
-/area/medical/psych)
-"rs" = (
-/turf/simulated/floor/wood,
-/area/medical/psych)
-"rt" = (
-/obj/machinery/door/firedoor/glass,
-/obj/machinery/door/airlock/medical{
-	id_tag = "mentaldoor";
-	name = "Mental Health";
-	req_access = list(64)
-	},
-/turf/simulated/floor/wood,
-/area/medical/psych)
-"ru" = (
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 6
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/surgery_hallway)
 "rv" = (
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery_hallway)
@@ -11317,55 +11122,12 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery_hallway)
-"rz" = (
-/obj/structure/table/steel,
-/obj/item/weapon/storage/box/bodybags,
-/obj/item/weapon/storage/box/bodybags{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/effect/floor_decal/techfloor{
-	dir = 4
-	},
-/obj/machinery/camera/network/medbay{
-	dir = 9;
-	icon_state = "camera"
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/medical/morgue)
-"rA" = (
-/obj/structure/table/woodentable,
-/obj/random/plushie,
-/turf/simulated/floor/wood,
-/area/medical/psych)
-"rB" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/wood,
-/area/medical/psych)
-"rC" = (
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 25;
-	pixel_y = 0
-	},
-/turf/simulated/floor/wood,
-/area/medical/psych)
 "rD" = (
-/obj/structure/bed/chair{
-	dir = 1
-	},
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 10
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
 	dir = 10
-	},
-/obj/effect/floor_decal/borderfloorwhite/corner2{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/paleblue/bordercorner2{
-	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery_hallway)
@@ -11649,9 +11411,6 @@
 /turf/simulated/floor/tiled,
 /area/ai_monitored/storage/eva)
 "sa" = (
-/obj/structure/bed/chair{
-	dir = 1
-	},
 /obj/machinery/light,
 /obj/effect/floor_decal/borderfloorwhite,
 /obj/effect/floor_decal/corner/paleblue/border,
@@ -11692,23 +11451,6 @@
 /obj/effect/floor_decal/corner/paleblue/bordercorner2,
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery_hallway)
-"se" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/medical/morgue)
-"sf" = (
-/obj/structure/table/steel,
-/obj/item/device/sleevemate,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/obj/effect/floor_decal/techfloor{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/medical/morgue)
 "sg" = (
 /obj/machinery/portable_atmospherics/powered/scrubber/huge/stationary{
 	scrub_id = "sec_riot_control"
@@ -11719,29 +11461,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/security/brig)
-"sh" = (
-/obj/structure/bookcase,
-/turf/simulated/floor/wood,
-/area/medical/psych)
-"si" = (
-/obj/item/weapon/storage/secure/safe{
-	pixel_x = 32
-	},
-/turf/simulated/floor/wood,
-/area/medical/psych)
 "sj" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	icon_state = "intact-scrubbers"
-	},
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 5
 	},
@@ -11761,89 +11481,8 @@
 	pixel_x = -4;
 	pixel_y = 26
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery_hallway)
-"sk" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -26
-	},
-/obj/effect/floor_decal/techfloor{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/medical/morgue)
-"sl" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/effect/floor_decal/techfloor/corner{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/medical/morgue)
-"sm" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	icon_state = "intact-scrubbers"
-	},
-/obj/effect/floor_decal/techfloor/corner{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/medical/morgue)
-"sn" = (
-/obj/machinery/hologram/holopad,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	icon_state = "intact-scrubbers"
-	},
-/obj/effect/floor_decal/techfloor{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/medical/morgue)
-"so" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	icon_state = "intact-scrubbers"
-	},
-/obj/effect/floor_decal/techfloor{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/medical/morgue)
 "sp" = (
 /obj/machinery/door/airlock/glass_engineering{
 	name = "Engineering Hardsuits";
@@ -11852,18 +11491,6 @@
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/tiled,
 /area/ai_monitored/storage/eva)
-"sq" = (
-/obj/structure/table/woodentable,
-/obj/structure/plushie/ian{
-	dir = 8;
-	icon_state = "ianplushie";
-	pixel_y = 6
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/medical/psych)
 "sr" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/grille,
@@ -11952,74 +11579,10 @@
 "sB" = (
 /turf/simulated/wall,
 /area/maintenance/station/micro)
-"sC" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	icon_state = "intact-scrubbers"
-	},
-/obj/effect/floor_decal/techfloor/corner{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/medical/morgue)
-"sD" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/structure/bed/chair/office/dark{
-	dir = 4
-	},
-/obj/effect/landmark/start{
-	name = "Medical Doctor"
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/medical/morgue)
-"sE" = (
-/obj/structure/table/steel,
-/obj/item/weapon/paper_bin{
-	pixel_y = 0
-	},
-/obj/item/weapon/pen/blue{
-	pixel_x = 3;
-	pixel_y = -1
-	},
-/obj/item/weapon/pen/red{
-	pixel_x = -1;
-	pixel_y = -3
-	},
-/obj/item/device/radio/intercom/department/medbay{
-	dir = 4;
-	pixel_x = 24
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/effect/floor_decal/techfloor{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/medical/morgue)
 "sF" = (
 /turf/simulated/wall/r_wall,
 /area/maintenance/evahallway)
-"sG" = (
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/wood,
-/area/medical/psych)
 "sH" = (
-/obj/structure/bed/chair{
-	dir = 1
-	},
 /obj/effect/floor_decal/borderfloorwhite,
 /obj/effect/floor_decal/corner/paleblue/border,
 /obj/machinery/camera/network/medbay{
@@ -12058,91 +11621,17 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery_hallway)
 "sK" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 9
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 4
 	},
-/obj/structure/disposalpipe/junction{
-	dir = 2;
-	icon_state = "pipe-j2"
-	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery_hallway)
-"sL" = (
-/obj/structure/filingcabinet/medical{
-	desc = "A large cabinet with hard copy medical records.";
-	name = "Medical Records"
-	},
-/obj/machinery/button/windowtint{
-	id = "psych_office";
-	pixel_x = 24;
-	range = 12
-	},
-/turf/simulated/floor/carpet/blue,
-/area/medical/psych)
-"sM" = (
-/obj/machinery/door/firedoor/glass,
-/obj/machinery/door/airlock/medical{
-	name = "Morgue";
-	req_access = list(6)
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	icon_state = "intact-scrubbers"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/morgue)
-"sN" = (
-/obj/structure/table/steel,
-/obj/effect/floor_decal/techfloor{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/medical/morgue)
-"sO" = (
-/obj/machinery/power/apc{
-	dir = 2;
-	name = "south bump";
-	pixel_y = -28
-	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/effect/floor_decal/techfloor,
-/turf/simulated/floor/tiled/techfloor,
-/area/medical/morgue)
 "sP" = (
 /obj/machinery/light{
 	dir = 8;
@@ -12304,63 +11793,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/station/stairs_two)
-"tg" = (
-/obj/structure/table/steel,
-/obj/item/weapon/surgical/scalpel,
-/obj/item/weapon/autopsy_scanner,
-/obj/item/weapon/surgical/cautery,
-/obj/effect/floor_decal/techfloor,
-/obj/machinery/light_switch{
-	dir = 1;
-	pixel_x = 0;
-	pixel_y = -26
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/medical/morgue)
-"th" = (
-/obj/machinery/optable,
-/obj/effect/floor_decal/techfloor,
-/turf/simulated/floor/tiled/techfloor,
-/area/medical/morgue)
-"ti" = (
-/obj/structure/filingcabinet/chestdrawer{
-	desc = "A large drawer filled with autopsy reports.";
-	name = "Autopsy Reports"
-	},
-/obj/machinery/light/small,
-/obj/effect/floor_decal/techfloor,
-/turf/simulated/floor/tiled/techfloor,
-/area/medical/morgue)
-"tj" = (
-/obj/effect/floor_decal/techfloor,
-/turf/simulated/floor/tiled/techfloor,
-/area/medical/morgue)
-"tk" = (
-/obj/structure/table/steel,
-/obj/item/weapon/folder/white,
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -25
-	},
-/obj/effect/floor_decal/techfloor,
-/turf/simulated/floor/tiled/techfloor,
-/area/medical/morgue)
-"tl" = (
-/obj/structure/table/steel,
-/obj/item/device/camera{
-	name = "Autopsy Camera";
-	pixel_x = -2;
-	pixel_y = 7
-	},
-/obj/item/device/radio/intercom{
-	dir = 4;
-	pixel_x = 24
-	},
-/obj/effect/floor_decal/techfloor{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/medical/morgue)
 "tm" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/lightgrey/border,
@@ -12395,26 +11827,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/tether/station/public_meeting_room)
-"tp" = (
-/obj/structure/flora/pottedplant/fern,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -26
-	},
-/turf/simulated/floor/wood,
-/area/medical/psych)
-"tq" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 28
-	},
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/wood,
-/area/medical/psych)
 "tr" = (
 /obj/machinery/alarm{
 	dir = 4;
@@ -12426,12 +11838,6 @@
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
 	dir = 8
-	},
-/obj/effect/floor_decal/borderfloorwhite/corner2{
-	dir = 10
-	},
-/obj/effect/floor_decal/corner/paleblue/bordercorner2{
-	dir = 10
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery_hallway)
@@ -12446,20 +11852,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery_hallway)
-"tt" = (
-/obj/structure/closet/crate/bin,
-/turf/simulated/floor/wood,
-/area/medical/psych)
 "tu" = (
 /turf/simulated/wall,
-/area/medical/resleeving)
-"tv" = (
-/obj/machinery/door/firedoor/glass,
-/obj/machinery/door/airlock/medical{
-	name = "Morgue";
-	req_access = list(6)
-	},
-/turf/simulated/floor/tiled/white,
 /area/medical/resleeving)
 "tw" = (
 /obj/structure/table/reinforced,
@@ -12638,76 +12032,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/station/stairs_two)
-"tK" = (
-/turf/simulated/floor/carpet/blue,
-/area/medical/psych)
-"tL" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5;
-	icon_state = "intact-scrubbers"
-	},
-/turf/simulated/floor/carpet/blue,
-/area/medical/psych)
-"tM" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	icon_state = "intact-scrubbers"
-	},
-/turf/simulated/floor/carpet/blue,
-/area/medical/psych)
-"tN" = (
-/obj/structure/bed/chair/comfy/brown,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	icon_state = "intact-scrubbers"
-	},
-/turf/simulated/floor/carpet/blue,
-/area/medical/psych)
-"tO" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	icon_state = "intact-scrubbers"
-	},
-/turf/simulated/floor/carpet/blue,
-/area/medical/psych)
-"tP" = (
-/obj/machinery/door/firedoor/glass,
-/obj/machinery/door/airlock/medical{
-	id_tag = "mentaldoor";
-	name = "Mental Health";
-	req_access = list(64)
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	icon_state = "intact-scrubbers"
-	},
-/turf/simulated/floor/wood,
-/area/medical/psych)
 "tQ" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -12726,27 +12050,6 @@
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/surgery_hallway)
-"tR" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4;
-	icon_state = "map-scrubbers"
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery_hallway)
@@ -12824,26 +12127,6 @@
 /obj/structure/table/glass,
 /turf/simulated/floor/tiled/white,
 /area/medical/resleeving)
-"tY" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	icon_state = "intact-scrubbers"
-	},
-/obj/effect/floor_decal/techfloor,
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/medical/morgue)
 "tZ" = (
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 1
@@ -13144,25 +12427,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/biostorage)
-"uB" = (
-/obj/structure/flora/ausbushes/genericbush,
-/turf/simulated/floor/grass,
-/area/medical/psych)
-"uC" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/machinery/alarm{
-	pixel_y = 22
-	},
-/turf/simulated/floor/grass,
-/area/medical/psych)
-"uD" = (
-/obj/machinery/door/firedoor/glass,
-/obj/structure/grille,
-/obj/structure/window/reinforced/polarized/full{
-	id = "psych_birdcage"
-	},
-/turf/simulated/floor/plating,
-/area/medical/psych)
 "uE" = (
 /obj/machinery/suit_cycler/engineering{
 	req_access = null
@@ -13327,24 +12591,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/station/stairs_two)
-"uU" = (
-/obj/structure/bed/chair/comfy/brown{
-	dir = 4
-	},
-/obj/effect/landmark/start{
-	name = "Psychiatrist"
-	},
-/turf/simulated/floor/carpet/blue,
-/area/medical/psych)
-"uV" = (
-/obj/structure/table/woodentable,
-/obj/item/device/flashlight/lamp/green{
-	dir = 2;
-	pixel_x = -5;
-	pixel_y = 4
-	},
-/turf/simulated/floor/carpet/blue,
-/area/medical/psych)
 "uW" = (
 /turf/simulated/wall,
 /area/medical/morgue)
@@ -13361,29 +12607,6 @@
 /obj/effect/floor_decal/steeldecal/steel_decals6,
 /turf/simulated/floor/tiled,
 /area/hallway/station/port)
-"uY" = (
-/obj/structure/table/woodentable,
-/obj/item/weapon/paper_bin{
-	pixel_y = 4
-	},
-/obj/item/weapon/pen{
-	pixel_y = 4
-	},
-/turf/simulated/floor/carpet/blue,
-/area/medical/psych)
-"uZ" = (
-/obj/structure/table/woodentable,
-/obj/item/weapon/folder/white,
-/turf/simulated/floor/carpet/blue,
-/area/medical/psych)
-"va" = (
-/obj/machinery/door/firedoor/glass,
-/obj/structure/window/reinforced/polarized/full{
-	id = "psych_office"
-	},
-/obj/structure/grille,
-/turf/simulated/floor/plating,
-/area/medical/psych)
 "vb" = (
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 8
@@ -13925,44 +13148,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/biostorage)
-"vV" = (
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/mob/living/simple_mob/animal/passive/bird/azure_tit/tweeter,
-/turf/simulated/floor/grass,
-/area/medical/psych)
-"vW" = (
-/obj/structure/flora/ausbushes/ywflowers,
-/turf/simulated/floor/grass,
-/area/medical/psych)
-"vX" = (
-/obj/structure/bed/psych,
-/turf/simulated/floor/carpet/blue,
-/area/medical/psych)
-"vY" = (
-/obj/structure/table/woodentable,
-/obj/machinery/computer/med_data/laptop{
-	dir = 4
-	},
-/turf/simulated/floor/carpet/blue,
-/area/medical/psych)
-"vZ" = (
-/obj/structure/bed/chair/office/dark{
-	dir = 1
-	},
-/obj/effect/landmark/start{
-	name = "Psychiatrist"
-	},
-/turf/simulated/floor/carpet/blue,
-/area/medical/psych)
-"wa" = (
-/obj/structure/filingcabinet/chestdrawer{
-	name = "Medical Forms"
-	},
-/turf/simulated/floor/carpet/blue,
-/area/medical/psych)
 "wb" = (
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 8
@@ -13973,11 +13158,6 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery_hallway)
 "wc" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/structure/cable/green{
 	d1 = 2;
 	d2 = 4;
@@ -14209,56 +13389,8 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/biostorage)
-"wt" = (
-/obj/structure/closet/secure_closet/chemical{
-	req_access = list(64);
-	req_one_access = list(5)
-	},
-/turf/simulated/floor/carpet/blue,
-/area/medical/psych)
-"wu" = (
-/obj/structure/flora/ausbushes/brflowers,
-/turf/simulated/floor/grass,
-/area/medical/psych)
-"wv" = (
-/obj/structure/table/woodentable,
-/obj/item/weapon/clipboard,
-/obj/machinery/camera/network/medbay{
-	dir = 10;
-	icon_state = "camera"
-	},
-/turf/simulated/floor/carpet/blue,
-/area/medical/psych)
-"ww" = (
-/obj/machinery/button/windowtint{
-	id = "psych_birdcage";
-	pixel_x = 6;
-	pixel_y = -26;
-	range = 12
-	},
-/obj/machinery/light_switch{
-	dir = 1;
-	pixel_x = -8;
-	pixel_y = -26
-	},
-/turf/simulated/floor/carpet/blue,
-/area/medical/psych)
-"wx" = (
-/obj/machinery/light,
-/turf/simulated/floor/carpet/blue,
-/area/medical/psych)
-"wy" = (
-/obj/item/device/radio/intercom{
-	dir = 2;
-	pixel_y = -24
-	},
-/turf/simulated/floor/carpet/blue,
-/area/medical/psych)
 "wz" = (
-/obj/item/device/radio/intercom/department/medbay{
-	pixel_y = -24
-	},
-/turf/simulated/floor/carpet/blue,
+/turf/simulated/floor,
 /area/medical/psych)
 "wA" = (
 /obj/structure/table/standard,
@@ -14277,12 +13409,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/biostorage)
-"wB" = (
-/obj/effect/floor_decal/techfloor{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/medical/morgue)
 "wC" = (
 /obj/machinery/vending/wallmed1{
 	pixel_x = -30
@@ -14684,9 +13810,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery_hallway)
-"xf" = (
-/turf/simulated/wall,
-/area/medical/surgery2)
 "xg" = (
 /turf/simulated/wall,
 /area/maintenance/station/medbay)
@@ -14892,11 +14015,9 @@
 "xx" = (
 /obj/machinery/door/firedoor/glass,
 /obj/structure/grille,
-/obj/structure/window/reinforced/polarized/full{
-	id = "surgery_2"
-	},
+/obj/structure/window/reinforced/full,
 /turf/simulated/floor/plating,
-/area/medical/surgery2)
+/area/maintenance/station/medbay)
 "xy" = (
 /obj/effect/decal/cleanable/blood,
 /obj/item/weapon/paper,
@@ -14913,79 +14034,6 @@
 /obj/item/weapon/paper,
 /turf/simulated/floor,
 /area/maintenance/station/sec_lower)
-"xB" = (
-/turf/simulated/floor/tiled/techfloor,
-/area/medical/morgue)
-"xC" = (
-/obj/structure/bed/chair,
-/obj/machinery/firealarm{
-	dir = 2;
-	layer = 3.3;
-	pixel_x = 0;
-	pixel_y = 26
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 9
-	},
-/obj/effect/floor_decal/corner/white/border{
-	dir = 9
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/surgery2)
-"xD" = (
-/obj/structure/bed/chair,
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 28
-	},
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/white/border{
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/surgery2)
-"xE" = (
-/obj/structure/table/standard,
-/obj/item/device/healthanalyzer,
-/obj/item/device/radio/intercom{
-	dir = 1;
-	pixel_y = 24;
-	req_access = list()
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/white/border{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/surgery2)
-"xF" = (
-/obj/structure/table/standard,
-/obj/item/weapon/storage/firstaid/surgery,
-/obj/item/device/radio/intercom/department/medbay{
-	dir = 1;
-	pixel_y = 24
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/white/border{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/surgery2)
 "xG" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -15298,27 +14346,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery_hallway)
-"yg" = (
-/obj/structure/sink{
-	dir = 8;
-	icon_state = "sink";
-	pixel_x = -12;
-	pixel_y = 8
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/white/border{
-	dir = 8
-	},
-/obj/effect/floor_decal/borderfloorwhite/corner2{
-	dir = 10
-	},
-/obj/effect/floor_decal/corner/white/bordercorner2{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/surgery2)
 "yh" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
@@ -15451,22 +14478,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/station/stairs_two)
-"ys" = (
-/obj/structure/table/standard,
-/obj/item/weapon/reagent_containers/spray/cleaner{
-	desc = "Someone has crossed out the Space from Space Cleaner and written in Surgery. 'Do not remove under punishment of death!!!' is scrawled on the back.";
-	name = "Surgery Cleaner";
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 5
-	},
-/obj/effect/floor_decal/corner/white/border{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/surgery2)
 "yt" = (
 /obj/machinery/light{
 	dir = 4;
@@ -15481,30 +14492,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ai_cyborg_station)
-"yu" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/surgery2)
-"yv" = (
-/obj/effect/floor_decal/steeldecal/steel_decals6{
-	dir = 5
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals6{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/surgery2)
-"yw" = (
-/obj/effect/floor_decal/industrial/loading,
-/turf/simulated/floor/tiled/white,
-/area/medical/surgery2)
 "yy" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -15702,10 +14689,6 @@
 /area/medical/surgery_hallway)
 "zh" = (
 /obj/machinery/door/firedoor/glass,
-/obj/machinery/door/airlock/medical{
-	name = "Operating Theatre 2";
-	req_access = list(45)
-	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -15718,63 +14701,17 @@
 	dir = 4;
 	icon_state = "intact-scrubbers"
 	},
+/obj/machinery/door/airlock/maintenance/medical,
 /turf/simulated/floor/tiled/white,
-/area/medical/surgery2)
-"zi" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 1
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/surgery2)
-"zj" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/effect/landmark/start{
-	name = "Medical Doctor"
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/surgery2)
+/area/maintenance/station/medbay)
 "zk" = (
-/obj/machinery/computer/operating{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/surgery2)
+/obj/structure/frame/computer,
+/turf/simulated/floor,
+/area/maintenance/station/medbay)
 "zl" = (
-/obj/machinery/optable,
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/tiled/white,
-/area/medical/surgery2)
-"zm" = (
-/obj/machinery/oxygen_pump/anesthetic,
-/turf/simulated/wall,
-/area/medical/surgery2)
+/obj/structure/frame,
+/turf/simulated/floor,
+/area/maintenance/station/medbay)
 "zn" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -15857,49 +14794,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery)
-"zu" = (
-/obj/structure/medical_stand,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/white/border{
-	dir = 8
-	},
-/obj/effect/floor_decal/borderfloorwhite/corner2{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/white/bordercorner2{
-	dir = 8
-	},
-/obj/machinery/camera/network/medbay{
-	dir = 4;
-	icon_state = "camera"
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/surgery2)
-"zv" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/surgery2)
-"zw" = (
-/obj/effect/floor_decal/steeldecal/steel_decals6{
-	dir = 9
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals6{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/surgery2)
-"zx" = (
-/obj/effect/floor_decal/industrial/loading{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/surgery2)
 "zy" = (
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 4
@@ -16060,62 +14954,9 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery)
-"zM" = (
-/obj/structure/closet/secure_closet/medical2,
-/obj/machinery/button/windowtint{
-	id = "surgery_2";
-	pixel_y = -26
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 10
-	},
-/obj/effect/floor_decal/corner/white/border{
-	dir = 10;
-	icon_state = "bordercolor"
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/surgery2)
-"zN" = (
-/obj/structure/closet/crate/freezer,
-/obj/item/weapon/reagent_containers/blood/OMinus,
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -25
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/effect/floor_decal/borderfloorwhite,
-/obj/effect/floor_decal/corner/white/border,
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/surgery2)
-"zO" = (
-/obj/structure/table/standard,
-/obj/item/device/healthanalyzer,
-/obj/item/device/radio/intercom{
-	dir = 2;
-	pixel_y = -24
-	},
-/obj/effect/floor_decal/borderfloorwhite,
-/obj/effect/floor_decal/corner/white/border,
-/turf/simulated/floor/tiled/white,
-/area/medical/surgery2)
 "zP" = (
-/obj/structure/table/standard,
-/obj/item/weapon/storage/firstaid/surgery,
-/obj/item/device/radio/intercom/department/medbay{
-	pixel_y = -24
-	},
-/obj/effect/floor_decal/borderfloorwhite,
-/obj/effect/floor_decal/corner/white/border,
-/turf/simulated/floor/tiled/white,
-/area/medical/surgery2)
+/turf/simulated/floor,
+/area/maintenance/station/medbay)
 "zR" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -16266,7 +15107,7 @@
 "Ac" = (
 /obj/structure/sign/department/operational,
 /turf/simulated/wall,
-/area/medical/surgery2)
+/area/maintenance/station/medbay)
 "Ad" = (
 /obj/structure/table/glass,
 /obj/item/weapon/paper_bin,
@@ -16554,7 +15395,6 @@
 /turf/simulated/floor/plating,
 /area/medical/patient_b)
 "AF" = (
-/obj/structure/closet/secure_closet/personal/patient,
 /obj/item/device/radio/intercom{
 	dir = 1;
 	pixel_y = 24;
@@ -16569,12 +15409,6 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_b)
 "AG" = (
-/obj/structure/bed/padded,
-/obj/item/weapon/bedsheet/medical,
-/obj/item/device/radio/intercom/department/medbay{
-	dir = 1;
-	pixel_y = 24
-	},
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 1
 	},
@@ -16584,7 +15418,6 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_b)
 "AH" = (
-/obj/structure/bed/chair,
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
@@ -16664,15 +15497,6 @@
 /obj/effect/floor_decal/steeldecal/steel_decals10,
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery_hallway)
-"AN" = (
-/obj/machinery/body_scanconsole{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_steel_grid{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/surgery_hallway)
 "AO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -16688,17 +15512,12 @@
 /turf/simulated/floor/plating,
 /area/vacant/vacant_restaurant_upper)
 "AP" = (
-/obj/machinery/bodyscanner{
-	dir = 4
-	},
 /obj/effect/floor_decal/corner_steel_grid{
 	dir = 10
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery_hallway)
 "AQ" = (
-/obj/structure/table/glass,
-/obj/random/medical,
 /obj/effect/floor_decal/steeldecal/steel_decals10{
 	dir = 8
 	},
@@ -16757,9 +15576,6 @@
 /turf/simulated/floor,
 /area/maintenance/station/medbay)
 "AV" = (
-/obj/structure/bed/chair/office/light{
-	dir = 4
-	},
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 8
 	},
@@ -16833,8 +15649,8 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery_hallway)
 "Ba" = (
@@ -17020,9 +15836,6 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery_hallway)
 "Bk" = (
-/obj/structure/table/glass,
-/obj/item/weapon/paper_bin,
-/obj/item/weapon/pen,
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -24
@@ -17036,8 +15849,6 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_b)
 "Bl" = (
-/obj/structure/table/glass,
-/obj/item/weapon/clipboard,
 /obj/machinery/alarm{
 	dir = 1;
 	pixel_y = -25
@@ -17050,12 +15861,6 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_b)
 "Bm" = (
-/obj/structure/table/glass,
-/obj/machinery/computer/med_data/laptop{
-	dir = 8;
-	pixel_x = 0;
-	pixel_y = 0
-	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
@@ -17075,12 +15880,6 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_b)
 "Bn" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery_hallway)
@@ -17232,14 +16031,8 @@
 /turf/simulated/wall,
 /area/medical/patient_b)
 "BD" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery_hallway)
@@ -17319,90 +16112,10 @@
 "BM" = (
 /turf/simulated/wall,
 /area/medical/recoveryrestroom)
-"BN" = (
-/obj/machinery/door/firedoor/glass,
-/obj/structure/grille,
-/obj/structure/window/reinforced/polarized/full{
-	id = "patient_room_c"
-	},
-/obj/structure/window/reinforced/polarized{
-	dir = 8;
-	id = "patient_room_c"
-	},
-/turf/simulated/floor/plating,
-/area/medical/patient_c)
-"BO" = (
-/obj/structure/closet/secure_closet/personal/patient,
-/obj/item/device/radio/intercom{
-	dir = 1;
-	pixel_y = 24;
-	req_access = list()
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 9
-	},
-/obj/effect/floor_decal/corner/pink/border{
-	dir = 9
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/patient_c)
-"BP" = (
-/obj/structure/bed/padded,
-/obj/item/weapon/bedsheet/medical,
-/obj/item/device/radio/intercom/department/medbay{
-	dir = 1;
-	pixel_y = 24
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/pink/border{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/patient_c)
-"BQ" = (
-/obj/structure/bed/chair,
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 28
-	},
-/obj/machinery/button/windowtint{
-	id = "patient_room_c";
-	pixel_x = 26;
-	pixel_y = 0
-	},
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 5
-	},
-/obj/effect/floor_decal/corner/pink/border{
-	dir = 5
-	},
-/obj/effect/floor_decal/borderfloorwhite/corner2{
-	dir = 5
-	},
-/obj/effect/floor_decal/corner/pink/bordercorner2{
-	dir = 5
-	},
-/obj/machinery/light_switch{
-	dir = 8;
-	pixel_x = 26;
-	pixel_y = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/patient_c)
 "BR" = (
 /obj/machinery/door/firedoor/glass,
 /obj/structure/grille,
-/obj/structure/window/reinforced/polarized/full{
-	id = "patient_room_c"
-	},
+/obj/structure/window/reinforced/full,
 /turf/simulated/floor/plating,
 /area/medical/patient_c)
 "BS" = (
@@ -17592,61 +16305,9 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/medical/recoveryrestroom)
-"Ch" = (
-/obj/structure/bed/chair/office/light{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/pink/border{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/patient_c)
-"Ci" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/patient_c)
-"Cj" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	icon_state = "intact-scrubbers"
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 10
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4,
-/turf/simulated/floor/tiled/white,
-/area/medical/patient_c)
 "Ck" = (
 /obj/machinery/door/firedoor/glass,
-/obj/machinery/door/airlock/medical{
-	name = "Patient Room C";
-	req_one_access = list()
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	icon_state = "intact-scrubbers"
-	},
+/obj/machinery/door/airlock/maintenance/medical,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_c)
 "Cm" = (
@@ -17692,21 +16353,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/exploration/pathfinder_office)
-"Co" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/surgery_hallway)
 "Cp" = (
 /obj/structure/bed/padded,
 /obj/effect/floor_decal/borderfloorwhite{
@@ -17834,60 +16480,8 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/medical/recoveryrestroom)
-"CB" = (
-/obj/structure/table/glass,
-/obj/item/weapon/paper_bin,
-/obj/item/weapon/pen,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 10
-	},
-/obj/effect/floor_decal/corner/pink/border{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/patient_c)
-"CC" = (
-/obj/structure/table/glass,
-/obj/item/weapon/clipboard,
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -25
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/obj/effect/floor_decal/borderfloorwhite,
-/obj/effect/floor_decal/corner/pink/border,
-/turf/simulated/floor/tiled/white,
-/area/medical/patient_c)
 "CD" = (
-/obj/structure/table/glass,
-/obj/machinery/computer/med_data/laptop{
-	dir = 8;
-	pixel_x = 0;
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/machinery/light,
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 6
-	},
-/obj/effect/floor_decal/corner/pink/border{
-	dir = 6
-	},
-/obj/effect/floor_decal/borderfloorwhite/corner2{
-	dir = 6
-	},
-/obj/effect/floor_decal/corner/pink/bordercorner2{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/airless,
 /area/medical/patient_c)
 "CF" = (
 /obj/effect/floor_decal/borderfloorwhite{
@@ -20049,10 +18643,7 @@
 /turf/simulated/floor/tiled,
 /area/hallway/station/starboard)
 "IO" = (
-/obj/structure/disposaloutlet{
-	dir = 1
-	},
-/obj/structure/disposalpipe/trunk,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/airless,
 /area/space)
 "IX" = (
@@ -20302,11 +18893,7 @@
 /turf/simulated/floor,
 /area/maintenance/station/sec_lower)
 "KV" = (
-/obj/effect/floor_decal/techfloor{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/techfloor,
+/turf/simulated/floor,
 /area/medical/morgue)
 "Ld" = (
 /obj/machinery/door/firedoor/glass,
@@ -21873,6 +20460,13 @@
 "TY" = (
 /turf/simulated/wall/r_wall,
 /area/security/riot_control)
+"Ue" = (
+/obj/structure/disposaloutlet{
+	dir = 1
+	},
+/obj/structure/disposalpipe/trunk,
+/turf/space,
+/area/space)
 "Uf" = (
 /obj/structure/railing{
 	dir = 8
@@ -30718,9 +29312,9 @@ AE
 AE
 AE
 BC
-BN
-BN
-BN
+BR
+BR
+BR
 CO
 aa
 aa
@@ -30860,9 +29454,9 @@ AF
 AV
 Bk
 BC
-BO
-Ch
-CB
+CD
+CD
+CD
 CO
 aa
 aa
@@ -31002,9 +29596,9 @@ AG
 AW
 Bl
 BC
-BP
-Ci
-CC
+CD
+CD
+CD
 CO
 aP
 ab
@@ -31144,8 +29738,8 @@ AH
 AX
 Bm
 BC
-BQ
-Cj
+CD
+CD
 CD
 CO
 aP
@@ -31211,9 +29805,9 @@ aa
 aa
 aa
 aa
-aa
-ab
-ab
+Ue
+IO
+IO
 IO
 Mq
 Ql
@@ -31412,10 +30006,10 @@ Pj
 SV
 tn
 po
-uB
-vV
-vW
-va
+wz
+wz
+wz
+po
 xl
 xU
 zp
@@ -31429,7 +30023,7 @@ xU
 vb
 wC
 yf
-xU
+pr
 CF
 CP
 aP
@@ -31554,10 +30148,10 @@ PR
 PS
 to
 po
-uC
-vW
-wu
-va
+wz
+wz
+wz
+po
 xm
 xV
 ts
@@ -31570,8 +30164,8 @@ ts
 AZ
 Bn
 BD
-Bn
-Co
+rv
+rv
 Bq
 CP
 aP
@@ -31696,9 +30290,9 @@ Ea
 LL
 po
 po
-uD
-uD
-uD
+wz
+wz
+wz
 po
 xn
 xY
@@ -31837,10 +30431,10 @@ KI
 KI
 KI
 po
-wt
-uU
-vX
-wv
+wz
+wz
+wz
+wz
 xb
 xb
 xb
@@ -31972,17 +30566,17 @@ kj
 rW
 rk
 fM
-pn
-sq
-rq
-rA
-sh
-sh
-tp
-tK
-tK
-tK
-ww
+po
+wz
+wz
+wz
+wz
+wz
+wz
+wz
+wz
+wz
+wz
 xb
 ya
 xZ
@@ -32115,16 +30709,16 @@ Fk
 ei
 fO
 pn
-qJ
-rr
-rB
-rB
-rB
-rB
-tL
-tK
-tK
-wx
+wz
+wz
+wz
+wz
+wz
+wz
+wz
+wz
+wz
+wz
 xb
 xp
 yb
@@ -32256,17 +30850,17 @@ pP
 rW
 Dh
 Yy
-pn
-qK
-rs
-rC
-si
-sG
-rs
-tM
-uV
-vY
-wy
+po
+wz
+wz
+wz
+wz
+wz
+wz
+wz
+wz
+wz
+wz
 xb
 xq
 yc
@@ -32400,14 +30994,14 @@ Qt
 uz
 po
 po
-rt
 po
 po
-rs
-rs
-tN
-uY
-vZ
+po
+wz
+wz
+wz
+wz
+wz
 wz
 xb
 xu
@@ -32542,15 +31136,15 @@ OQ
 Tp
 pp
 qL
-ru
+wb
 rD
 pp
-tt
-tq
-tO
-uZ
-wa
-sL
+wz
+wz
+wz
+wz
+wz
+wz
 xb
 xv
 ye
@@ -32683,15 +31277,15 @@ qy
 fp
 xi
 pq
-qM
+Am
 rv
 sH
 pp
 sI
 po
-tP
-va
-va
+po
+po
+po
 po
 xb
 xw
@@ -32824,15 +31418,15 @@ pT
 Fp
 fG
 gx
-pr
+pp
 qN
 rw
 sa
 pp
 sJ
 tr
-tQ
-vb
+wb
+wb
 wb
 wC
 xG
@@ -32972,9 +31566,9 @@ rx
 sb
 wX
 sK
-ts
-tR
-ts
+rx
+rx
+rx
 wc
 ts
 xd
@@ -33255,13 +31849,13 @@ uW
 uW
 uW
 uW
-sM
+uW
 tu
 tT
 tT
 we
 tT
-xf
+xg
 xx
 xx
 zh
@@ -33392,27 +31986,27 @@ ac
 ac
 ac
 uW
-pV
-pV
-pV
-pV
-sk
-tY
+KV
+KV
+KV
+KV
+KV
+KV
 tu
 tU
 vd
 wf
 wE
-xf
-xC
-yg
-zi
-zu
-zM
-xf
+xg
+zP
+zP
+zP
+zP
+zP
+xg
 Fh
 AB
-AN
+AP
 Bg
 By
 BL
@@ -33534,24 +32128,24 @@ ac
 ac
 ac
 uW
-pW
-rn
-rn
-rn
-sl
-sO
+KV
+KV
+KV
+KV
+KV
+KV
 tu
 tV
 ve
 wg
 wF
-xf
-xD
-yu
-zj
-zv
-zN
-xf
+xg
+zP
+zP
+zP
+zP
+zP
+xg
 Ao
 AC
 AP
@@ -33676,24 +32270,24 @@ ac
 ac
 ac
 uW
-pX
-wB
-wB
-wB
-sm
-tg
+KV
+KV
+KV
+KV
+KV
+KV
 tu
 tW
 vg
 wh
 wG
-xf
-xE
-yv
+xg
+zP
+zP
 zk
-zw
-zO
-xf
+zP
+zP
+xg
 Ap
 rv
 AQ
@@ -33818,24 +32412,24 @@ ac
 ac
 ac
 uW
-pY
-pY
-pY
-pY
-sn
-th
+KV
+KV
+KV
+KV
+KV
+KV
 tu
 tX
 vh
 wi
 wH
-xf
-xF
-yw
-zl
-zx
+xg
 zP
-xf
+zP
+zl
+zP
+zP
+xg
 Aq
 ry
 AR
@@ -33960,24 +32554,24 @@ ac
 ac
 ac
 uW
-pV
-pV
-pV
-pV
-so
-ti
+KV
+KV
+KV
+KV
+KV
+KV
 tu
 uq
 vw
 wi
 wI
-xf
-ys
-ev
-zm
-gS
-fD
-xf
+xg
+zP
+zP
+xg
+zP
+zP
+xg
 pp
 pp
 yp
@@ -34102,24 +32696,24 @@ ac
 ac
 ac
 uW
-pZ
 KV
 KV
 KV
-sC
-tj
-tv
+KV
+KV
+KV
+tu
 tZ
 vw
 wi
 wJ
-xf
-xf
-xf
-xf
-xf
-xf
-xf
+xg
+xg
+xg
+xg
+xg
+xg
+xg
 Ar
 AD
 AT
@@ -34244,12 +32838,12 @@ ac
 ac
 ac
 uW
-qD
-xB
-xB
-se
-sD
-tk
+KV
+KV
+KV
+KV
+KV
+KV
 tu
 ua
 vw
@@ -34386,12 +32980,12 @@ ac
 ac
 ac
 uW
-qE
-sN
-rz
-sf
-sE
-tl
+KV
+KV
+KV
+KV
+KV
+KV
 tu
 ub
 vx

--- a/maps/tether/tether-07-station3.dmm
+++ b/maps/tether/tether-07-station3.dmm
@@ -4118,6 +4118,9 @@
 /obj/machinery/door/firedoor/glass/hidden/steel{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/foyer)
 "ahu" = (
@@ -7844,11 +7847,6 @@
 /area/crew_quarters/heads/hos)
 "anE" = (
 /obj/structure/table/woodentable,
-/obj/item/weapon/paper{
-	desc = "";
-	info = "The Chief of Security at CentCom is debating a new policy. It's not official yet, and probably won't be since it's hard to enforce, but I suggest following it anyway. That policy is, if a security officer claims they need more than two extra magazines (or batteries) to go on routine patrols, fire them. If they cannot subdue a single suspect using all that ammo, they are not competent as Security.\[br]-Jeremiah Acacius";
-	name = "note to the Head of Security"
-	},
 /obj/item/clothing/accessory/permit/gun{
 	desc = "An example of a card indicating that the owner is allowed to carry a firearm. There's a note saying to fax CentCom if you want to order more blank permits.";
 	name = "sample weapon permit";
@@ -8523,6 +8521,7 @@
 	pixel_x = -3;
 	pixel_y = 3
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/quartermaster/storage)
 "aoL" = (
@@ -9614,7 +9613,7 @@
 /turf/simulated/floor/lino,
 /area/security/detectives_office)
 "aqI" = (
-/obj/structure/flora/pottedplant,
+/obj/structure/closet/wardrobe/detective,
 /turf/simulated/floor/lino,
 /area/security/detectives_office)
 "aqJ" = (
@@ -10793,8 +10792,10 @@
 /turf/simulated/floor/tiled,
 /area/quartermaster/delivery)
 "asy" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/disposalpipe/sortjunction/flipped{
+	dir = 8;
+	name = "Void";
+	sortType = "Void"
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/delivery)
@@ -11408,12 +11409,6 @@
 /obj/machinery/door/firedoor/glass/hidden/steel{
 	dir = 1
 	},
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 9
-	},
-/obj/effect/floor_decal/corner/paleblue/bordercorner2{
-	dir = 9
-	},
 /obj/machinery/camera/network/tether{
 	dir = 1
 	},
@@ -11445,6 +11440,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/quartermaster/delivery)
 "aty" = (
@@ -11932,6 +11928,7 @@
 /area/quartermaster/delivery)
 "auu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/quartermaster/delivery)
 "auv" = (
@@ -12398,6 +12395,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/quartermaster/delivery)
 "avi" = (
@@ -12893,6 +12891,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/brown/border,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/quartermaster/delivery)
 "avZ" = (
@@ -13479,6 +13478,7 @@
 /obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/quartermaster/foyer)
 "axn" = (
@@ -13866,6 +13866,10 @@
 "axZ" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/foyer)
 "aya" = (
@@ -13873,6 +13877,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
@@ -13883,6 +13890,9 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/foyer)
@@ -13901,6 +13911,9 @@
 /obj/effect/floor_decal/steeldecal/steel_decals4,
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 10
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/foyer)
@@ -13924,6 +13937,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/steel_grid,
@@ -13961,6 +13977,9 @@
 	dir = 9;
 	pixel_y = 0
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
 "ayg" = (
@@ -13968,6 +13987,10 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
@@ -14380,7 +14403,7 @@
 "ayN" = (
 /obj/structure/sign/department/medbay,
 /turf/simulated/wall,
-/area/medical/medbay_emt_bay)
+/area/maintenance/station/cargo)
 "ayP" = (
 /obj/machinery/alarm{
 	dir = 1;
@@ -14415,8 +14438,17 @@
 /turf/simulated/floor/tiled,
 /area/quartermaster/foyer)
 "ayT" = (
-/turf/simulated/wall,
-/area/medical/medbay_emt_bay)
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/sleeper)
 "ayU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -14740,24 +14772,6 @@
 	dir = 4
 	},
 /area/medical/reception)
-"azs" = (
-/obj/machinery/door/firedoor/glass,
-/obj/machinery/door/airlock/medical{
-	name = "EMT Bay"
-	},
-/obj/machinery/door/blast/shutters{
-	closed_layer = 10;
-	density = 0;
-	dir = 2;
-	icon_state = "shutter0";
-	id = "medbayquar";
-	layer = 1;
-	name = "Medbay Emergency Lockdown Shutters";
-	opacity = 0;
-	open_layer = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/medical/medbay_emt_bay)
 "azt" = (
 /turf/simulated/wall,
 /area/security/lobby)
@@ -15820,75 +15834,6 @@
 /obj/machinery/door/firedoor/glass/hidden/steel,
 /turf/simulated/floor/tiled,
 /area/hallway/station/upper)
-"aBu" = (
-/obj/structure/table/rack,
-/obj/item/device/gps/medical{
-	pixel_y = 3
-	},
-/obj/item/device/gps/medical{
-	pixel_x = -3
-	},
-/obj/item/device/radio{
-	pixel_x = 2
-	},
-/obj/item/device/radio{
-	pixel_x = -1;
-	pixel_y = -3
-	},
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 9
-	},
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 6
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals9{
-	dir = 4
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals9{
-	dir = 1
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals9{
-	dir = 8
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals9,
-/turf/simulated/floor/tiled/dark,
-/area/medical/medbay_emt_bay)
-"aBv" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 9
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 9
-	},
-/obj/effect/floor_decal/borderfloorblack/corner2{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/paleblue/bordercorner2{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/medical/medbay_emt_bay)
-"aBw" = (
-/turf/simulated/floor/tiled/dark,
-/area/medical/medbay_emt_bay)
-"aBx" = (
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 5
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 5
-	},
-/obj/effect/floor_decal/borderfloorblack/corner2{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/paleblue/bordercorner2{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/medical/medbay_emt_bay)
 "aBy" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
@@ -15931,30 +15876,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/station/upper)
-"aBB" = (
-/obj/machinery/suit_cycler/medical,
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 6
-	},
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 9
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals9,
-/obj/effect/floor_decal/steeldecal/steel_decals9{
-	dir = 8
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals9{
-	dir = 1
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals9{
-	dir = 4
-	},
-/obj/machinery/camera/network/medbay{
-	dir = 9;
-	icon_state = "camera"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/medical/medbay_emt_bay)
 "aBC" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/lightgrey/border,
@@ -16410,79 +16331,10 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/reception)
-"aCs" = (
-/obj/structure/table/rack,
-/obj/item/weapon/storage/toolbox/mechanical,
-/obj/item/device/multitool,
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 9
-	},
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 6
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals9{
-	dir = 4
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals9{
-	dir = 1
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals9{
-	dir = 8
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals9,
-/turf/simulated/floor/tiled/dark,
-/area/medical/medbay_emt_bay)
-"aCt" = (
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
-/area/medical/medbay_emt_bay)
 "aCu" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/dark,
 /area/lawoffice)
-"aCv" = (
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/medical/medbay_emt_bay)
-"aCw" = (
-/obj/structure/table/rack,
-/obj/item/clothing/shoes/magboots,
-/obj/item/clothing/suit/space/void/medical/emt,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/head/helmet/space/void/medical/emt,
-/obj/machinery/alarm{
-	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 24
-	},
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 6
-	},
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 9
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals9,
-/obj/effect/floor_decal/steeldecal/steel_decals9{
-	dir = 8
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals9{
-	dir = 1
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals9{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/medical/medbay_emt_bay)
 "aCx" = (
 /obj/effect/floor_decal/rust,
 /obj/structure/railing{
@@ -16671,6 +16523,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/quartermaster/storage)
 "aCN" = (
@@ -16938,27 +16791,6 @@
 "aDl" = (
 /turf/simulated/wall,
 /area/medical/reception)
-"aDm" = (
-/obj/structure/table/rack,
-/obj/item/device/defib_kit/compact/loaded,
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 9
-	},
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 6
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals9{
-	dir = 4
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals9{
-	dir = 1
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals9{
-	dir = 8
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals9,
-/turf/simulated/floor/tiled/dark,
-/area/medical/medbay_emt_bay)
 "aDn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4;
@@ -17266,31 +17098,6 @@
 /obj/structure/cable,
 /turf/simulated/floor/tiled,
 /area/tether/station/stairs_three)
-"aDM" = (
-/obj/machinery/mech_recharger,
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 9
-	},
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 6
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals9{
-	dir = 4
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals9{
-	dir = 1
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals9{
-	dir = 8
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals9,
-/obj/machinery/light_switch{
-	dir = 4;
-	pixel_x = -28;
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled/dark,
-/area/medical/medbay_emt_bay)
 "aDN" = (
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 1
@@ -17304,58 +17111,6 @@
 /obj/structure/table/steel,
 /turf/simulated/floor/tiled,
 /area/security/security_processing)
-"aDQ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/effect/landmark/start{
-	name = "Paramedic"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/medical/medbay_emt_bay)
-"aDR" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/medical/medbay_emt_bay)
-"aDS" = (
-/obj/structure/table/rack,
-/obj/item/clothing/shoes/magboots,
-/obj/item/clothing/suit/space/void/medical/emt,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/head/helmet/space/void/medical/emt,
-/obj/item/device/radio/intercom{
-	dir = 4;
-	pixel_x = 24
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 6
-	},
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 9
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals9,
-/obj/effect/floor_decal/steeldecal/steel_decals9{
-	dir = 8
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals9{
-	dir = 1
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals9{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/medical/medbay_emt_bay)
 "aDT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/rust,
@@ -17803,12 +17558,6 @@
 /obj/effect/floor_decal/corner/paleblue/border{
 	dir = 1
 	},
-/obj/effect/floor_decal/borderfloorwhite/corner2{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/paleblue/bordercorner2{
-	dir = 1
-	},
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
 "aEH" = (
@@ -17847,59 +17596,11 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/reception)
-"aEK" = (
-/obj/machinery/door/firedoor/glass,
-/obj/machinery/door/airlock/medical{
-	name = "EMT Bay"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/medical/medbay_emt_bay)
-"aEL" = (
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 6
-	},
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 9
-	},
-/turf/simulated/floor/tiled/dark,
-/area/medical/medbay_emt_bay)
-"aEM" = (
-/obj/machinery/hologram/holopad,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/landmark/start{
-	name = "Paramedic"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/medical/medbay_emt_bay)
 "aEN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
 /area/medical/reception)
-"aEO" = (
-/obj/structure/table/rack,
-/obj/item/weapon/rig/medical/equipped,
-/obj/structure/fireaxecabinet{
-	pixel_x = 32
-	},
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 6
-	},
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 9
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals9,
-/obj/effect/floor_decal/steeldecal/steel_decals9{
-	dir = 8
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals9{
-	dir = 1
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals9{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/medical/medbay_emt_bay)
 "aEP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/trash_pile,
@@ -18148,17 +17849,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/reception)
-"aFi" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/machinery/camera/network/medbay{
-	dir = 9;
-	icon_state = "camera"
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/heads/cmo)
 "aFj" = (
 /turf/simulated/wall,
 /area/quartermaster/warehouse)
@@ -18284,29 +17974,6 @@
 	},
 /turf/simulated/open,
 /area/tether/station/stairs_three)
-"aFv" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/effect/landmark/start{
-	name = "Paramedic"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/medical/medbay_emt_bay)
-"aFw" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	icon_state = "intact-scrubbers"
-	},
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/medical/medbay_emt_bay)
 "aFx" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -18318,42 +17985,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
-"aFy" = (
-/obj/structure/table/rack,
-/obj/item/device/suit_cooling_unit{
-	pixel_y = -5
-	},
-/obj/item/device/suit_cooling_unit{
-	pixel_y = -5
-	},
-/obj/item/device/radio/intercom/department/medbay{
-	dir = 4;
-	pixel_x = 24
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 6
-	},
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 9
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals9,
-/obj/effect/floor_decal/steeldecal/steel_decals9{
-	dir = 8
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals9{
-	dir = 1
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals9{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/medical/medbay_emt_bay)
-"aFz" = (
-/turf/simulated/wall/r_wall,
-/area/crew_quarters/heads/cmo)
 "aFA" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
@@ -18543,57 +18174,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/reception)
-"aFQ" = (
-/obj/structure/closet/secure_closet/paramedic,
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 9
-	},
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 6
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals9{
-	dir = 4
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals9{
-	dir = 1
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals9{
-	dir = 8
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals9,
-/turf/simulated/floor/tiled/dark,
-/area/medical/medbay_emt_bay)
-"aFR" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/dark,
-/area/medical/medbay_emt_bay)
-"aFS" = (
-/obj/structure/dispenser{
-	phorontanks = 0
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 6
-	},
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 9
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals9,
-/obj/effect/floor_decal/steeldecal/steel_decals9{
-	dir = 8
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals9{
-	dir = 1
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals9{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/medical/medbay_emt_bay)
 "aFT" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/paleblue/border,
@@ -18611,45 +18191,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/station/upper)
-"aFU" = (
-/obj/machinery/requests_console{
-	announcementConsole = 1;
-	department = "Chief Medical Officer's Desk";
-	departmentType = 5;
-	name = "Chief Medical Officer RC";
-	pixel_x = 0;
-	pixel_y = 30
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/heads/cmo)
-"aFV" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/light_switch{
-	dir = 2;
-	name = "light switch ";
-	pixel_x = 0;
-	pixel_y = 26
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/heads/cmo)
-"aFW" = (
-/obj/machinery/keycard_auth{
-	pixel_y = 28
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/heads/cmo)
-"aFX" = (
-/obj/item/modular_computer/console/preset/command{
-	dir = 8
-	},
-/obj/item/device/radio/intercom{
-	dir = 4;
-	pixel_x = 24
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/heads/cmo)
 "aFY" = (
 /obj/machinery/power/sensor{
 	name = "Powernet Sensor - Cargo Subgrid";
@@ -19005,119 +18546,9 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
-"aGy" = (
-/obj/machinery/power/apc{
-	dir = 2;
-	name = "south bump";
-	pixel_y = -28
-	},
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 10
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 10
-	},
-/obj/effect/floor_decal/borderfloorblack/corner2{
-	dir = 9
-	},
-/obj/effect/floor_decal/corner/paleblue/bordercorner2{
-	dir = 9
-	},
-/turf/simulated/floor/tiled/dark,
-/area/medical/medbay_emt_bay)
-"aGz" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/dark,
-/area/medical/medbay_emt_bay)
-"aGA" = (
-/obj/machinery/light,
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 6
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 6
-	},
-/obj/effect/floor_decal/borderfloorblack/corner2,
-/obj/effect/floor_decal/corner/paleblue/bordercorner2,
-/turf/simulated/floor/tiled/dark,
-/area/medical/medbay_emt_bay)
-"aGB" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 6
-	},
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 9
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals9,
-/obj/effect/floor_decal/steeldecal/steel_decals9{
-	dir = 8
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals9{
-	dir = 1
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals9{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/medical/medbay_emt_bay)
 "aGC" = (
 /turf/simulated/wall,
 /area/maintenance/substation/cargo)
-"aGD" = (
-/obj/machinery/photocopier,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24;
-	pixel_y = 0
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/heads/cmo)
-"aGE" = (
-/obj/structure/bed/chair/office/light,
-/obj/machinery/button/remote/blast_door{
-	desc = "A remote control-switch for shutters.";
-	id = "medbayquar";
-	name = "Medbay Emergency Lockdown Control";
-	pixel_x = -36;
-	pixel_y = 0;
-	req_access = list(5)
-	},
-/obj/machinery/button/remote/airlock{
-	desc = "A remote control switch for the CMO's office.";
-	id = "cmodoor";
-	name = "CMO Office Door Control";
-	pixel_x = -36;
-	pixel_y = -8
-	},
-/obj/machinery/button/remote/blast_door{
-	desc = "A remote control-switch for shutters.";
-	id = "virologyquar";
-	name = "Virology Emergency Lockdown Control";
-	pixel_x = -28;
-	pixel_y = 0;
-	req_access = list(5)
-	},
-/obj/machinery/button/windowtint{
-	id = "cmo_office";
-	pixel_x = -26;
-	pixel_y = -10
-	},
-/obj/effect/landmark/start{
-	name = "Chief Medical Officer"
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/heads/cmo)
 "aGF" = (
 /obj/structure/closet/crate,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -19159,6 +18590,9 @@
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
 "aGJ" = (
@@ -19236,32 +18670,6 @@
 	},
 /turf/simulated/floor,
 /area/quartermaster/storage)
-"aGS" = (
-/obj/structure/filingcabinet,
-/obj/item/device/radio/intercom/department/medbay{
-	dir = 4;
-	pixel_x = 24
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/heads/cmo)
-"aGT" = (
-/obj/structure/table/glass,
-/obj/machinery/photocopier/faxmachine{
-	department = "CMO's Office"
-	},
-/obj/machinery/newscaster{
-	layer = 3.3;
-	pixel_x = -27;
-	pixel_y = 0
-	},
-/obj/machinery/status_display{
-	density = 0;
-	layer = 4;
-	pixel_x = 0;
-	pixel_y = 32
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/heads/cmo)
 "aGU" = (
 /obj/structure/medical_stand,
 /obj/machinery/power/apc{
@@ -19349,47 +18757,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
-"aHa" = (
-/obj/machinery/door/firedoor/glass,
-/obj/machinery/door/airlock/medical{
-	name = "EMT Bay"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/dark,
-/area/medical/medbay_emt_bay)
-"aHb" = (
-/obj/structure/table/glass,
-/obj/item/weapon/folder/white_cmo,
-/obj/item/weapon/stamp/cmo,
-/turf/simulated/floor/wood,
-/area/crew_quarters/heads/cmo)
-"aHc" = (
-/obj/structure/table/glass,
-/obj/item/weapon/paper_bin,
-/obj/item/weapon/pen,
-/turf/simulated/floor/wood,
-/area/crew_quarters/heads/cmo)
-"aHd" = (
-/obj/structure/table/glass,
-/obj/machinery/computer/skills{
-	dir = 8;
-	icon_state = "laptop";
-	pixel_x = 4;
-	pixel_y = -3
-	},
-/obj/machinery/computer/med_data/laptop{
-	dir = 8;
-	pixel_x = -4;
-	pixel_y = 4
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/heads/cmo)
 "aHe" = (
 /obj/machinery/camera/network/cargo{
 	dir = 4
@@ -19654,9 +19021,6 @@
 /obj/effect/floor_decal/corner/paleblue/border{
 	dir = 1
 	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
 /obj/effect/floor_decal/borderfloorwhite/corner2{
 	dir = 1
 	},
@@ -19803,6 +19167,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/quartermaster/storage)
 "aHF" = (
@@ -19909,11 +19274,6 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
@@ -19933,22 +19293,8 @@
 /obj/effect/floor_decal/corner/paleblue/border{
 	dir = 5
 	},
-/obj/effect/floor_decal/borderfloorwhite/corner2{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/paleblue/bordercorner2{
-	dir = 4
-	},
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
-"aHN" = (
-/obj/structure/grille,
-/obj/machinery/door/firedoor/glass,
-/obj/structure/window/reinforced/polarized/full{
-	id = "cmo_office"
-	},
-/turf/simulated/floor/plating,
-/area/crew_quarters/heads/cmo)
 "aHO" = (
 /obj/machinery/light{
 	dir = 1
@@ -19967,40 +19313,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
-"aHP" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/item/weapon/storage/box,
-/obj/item/weapon/storage/box{
-	pixel_x = 5;
-	pixel_y = -2
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 5
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/heads/cmo)
-"aHQ" = (
-/obj/structure/bed/chair{
-	dir = 1
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/heads/cmo)
-"aHR" = (
-/obj/machinery/alarm{
-	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 24
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/heads/cmo)
 "aHS" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -20129,21 +19441,13 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
 "aIc" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
-	dir = 8;
-	icon_state = "map"
-	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
 "aId" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 9;
-	icon_state = "intact"
-	},
-/obj/effect/floor_decal/industrial/warning{
+/obj/effect/floor_decal/industrial/warning/corner{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
@@ -20154,10 +19458,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
-	},
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 1;
-	icon_state = "warningcorner"
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
@@ -20179,11 +19479,6 @@
 	},
 /obj/structure/cable/green{
 	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable/green{
-	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
 	},
@@ -20197,11 +19492,6 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
 "aIh" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -20214,11 +19504,6 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
 "aIi" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -20231,11 +19516,6 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
 "aIj" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -20252,13 +19532,13 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
 "aIk" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4;
+	icon_state = "intact-scrubbers"
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
 "aIl" = (
@@ -20377,56 +19657,9 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/storage)
-"aIw" = (
-/obj/structure/window/reinforced,
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/heads/cmo)
-"aIx" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/door/window/southright{
-	name = "Runtime";
-	req_one_access = list(40)
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 4
-	},
-/mob/living/simple_mob/animal/passive/cat/runtime,
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/heads/cmo)
 "aIy" = (
 /turf/simulated/wall,
 /area/medical/sleeper)
-"aIz" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/heads/cmo)
-"aIA" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 28
-	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/heads/cmo)
 "aIB" = (
 /obj/machinery/vending/medical{
 	dir = 4
@@ -20729,13 +19962,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/warehouse)
-"aIU" = (
-/obj/effect/floor_decal/borderfloorwhite,
-/obj/effect/floor_decal/corner/paleblue/border,
-/obj/effect/floor_decal/borderfloorwhite/corner2,
-/obj/effect/floor_decal/corner/paleblue/bordercorner2,
-/turf/simulated/floor/tiled/white,
-/area/medical/sleeper)
 "aIV" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 5;
@@ -20830,52 +20056,11 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
-"aJf" = (
-/obj/structure/flora/pottedplant/stoutbush,
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 8
-	},
-/obj/effect/floor_decal/borderfloorwhite/corner2{
-	dir = 10
-	},
-/obj/effect/floor_decal/corner/paleblue/bordercorner2{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/heads/cmo)
-"aJg" = (
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/heads/cmo)
-"aJh" = (
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/wood,
-/area/crew_quarters/heads/cmo)
 "aJi" = (
 /obj/machinery/atmospherics/unary/cryo_cell,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled,
 /area/medical/sleeper)
-"aJj" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/heads/cmo)
 "aJk" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -21106,52 +20291,19 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
 "aJF" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
 /obj/effect/floor_decal/steeldecal/steel_decals4,
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 10
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
 "aJG" = (
 /obj/machinery/door/firedoor/glass,
-/obj/machinery/door/airlock/command{
-	id_tag = "cmodoor";
-	name = "Chief Medical Officer";
-	req_access = list(40);
-	req_one_access = list()
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	icon_state = "intact-scrubbers"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/heads/cmo)
+/obj/machinery/door/airlock/maintenance/medical,
+/turf/simulated/floor/plating,
+/area/maintenance/station/cargo)
 "aJH" = (
 /obj/machinery/light/small{
 	dir = 8;
@@ -21167,30 +20319,6 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/steel,
 /area/quartermaster/warehouse)
-"aJJ" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	icon_state = "intact-scrubbers"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 6
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/heads/cmo)
 "aJK" = (
 /obj/structure/closet/crate/medical,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -21237,73 +20365,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/storage)
-"aJP" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	icon_state = "intact-scrubbers"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/heads/cmo)
-"aJQ" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	icon_state = "intact-scrubbers"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/heads/cmo)
-"aJR" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/heads/cmo)
-"aJS" = (
-/obj/structure/filingcabinet/chestdrawer,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/heads/cmo)
 "aJT" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -21367,20 +20428,6 @@
 	},
 /turf/simulated/floor,
 /area/maintenance/station/cargo)
-"aJZ" = (
-/obj/structure/table/standard,
-/obj/random/medical,
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -28
-	},
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/virologyaccess)
 "aKa" = (
 /obj/structure/closet/secure_closet/medical3,
 /obj/item/weapon/soap/nanotrasen,
@@ -21392,38 +20439,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay_primary_storage)
-"aKb" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
-	dir = 6
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/virologyaccess)
-"aKc" = (
-/obj/structure/closet/wardrobe/virology_white,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 9
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/virologyaccess)
 "aKd" = (
 /obj/structure/closet/secure_closet/medical3,
 /obj/item/weapon/soap/nanotrasen,
@@ -21583,14 +20598,8 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
 "aKt" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 4
 	},
@@ -21605,63 +20614,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
-"aKu" = (
-/obj/structure/flora/pottedplant/stoutbush,
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 10
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 10
-	},
-/obj/effect/floor_decal/borderfloorwhite/corner2{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/paleblue/bordercorner2{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/heads/cmo)
-"aKv" = (
-/obj/structure/closet/secure_closet/CMO,
-/obj/item/weapon/storage/belt/medical,
-/obj/item/device/flashlight/pen,
-/obj/item/clothing/accessory/stethoscope,
-/obj/item/clothing/glasses/hud/health,
-/obj/item/device/defib_kit/compact/combat/loaded,
-/obj/item/weapon/cmo_disk_holder,
-/obj/item/weapon/storage/secure/briefcase/ml3m_pack_cmo,
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 6
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/heads/cmo)
-"aKw" = (
-/obj/structure/bed/chair/comfy/brown{
-	dir = 1
-	},
-/obj/machinery/light,
-/turf/simulated/floor/wood,
-/area/crew_quarters/heads/cmo)
-"aKx" = (
-/obj/structure/bed/psych{
-	name = "couch"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5;
-	icon_state = "intact-scrubbers"
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/heads/cmo)
-"aKy" = (
-/obj/structure/table/glass,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/heads/cmo)
 "aKz" = (
 /obj/structure/railing{
 	dir = 8
@@ -21672,51 +20624,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/station/cargo)
-"aKA" = (
-/obj/structure/table/glass,
-/obj/item/weapon/storage/box/gloves{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/item/weapon/storage/box/masks,
-/obj/machinery/light_switch{
-	dir = 1;
-	pixel_x = 0;
-	pixel_y = -24
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/virology)
-"aKB" = (
-/obj/machinery/computer/arcade{
-	dir = 8
-	},
-/obj/structure/sign/nosmoking_1{
-	pixel_x = 32
-	},
-/obj/machinery/light_switch{
-	dir = 1;
-	pixel_x = 0;
-	pixel_y = -24
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/virologyisolation)
-"aKC" = (
-/obj/structure/dogbed{
-	desc = "Runtime's bed. Some of her disappointment seems to have rubbed off on it.";
-	name = "cat bed"
-	},
-/obj/item/toy/plushie/mouse/fluff,
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 9
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 9
-	},
-/obj/machinery/ai_status_display{
-	pixel_y = 32
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/heads/cmo)
 "aKD" = (
 /obj/machinery/door/firedoor/glass/hidden/steel{
 	dir = 2
@@ -21841,14 +20748,8 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
 "aKQ" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 4
 	},
@@ -21894,6 +20795,7 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/quartermaster/delivery)
 "aKU" = (
@@ -21997,13 +20899,6 @@
 /obj/machinery/disposal,
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
-"aLf" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/virology)
 "aLg" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
@@ -22096,22 +20991,15 @@
 /turf/simulated/floor/plating,
 /area/medical/medbay_primary_storage)
 "aLq" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/sortjunction/flipped{
-	dir = 4;
-	name = "CMO Office";
-	sortType = "CMO Office"
-	},
 /obj/effect/floor_decal/borderfloorwhite/corner{
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/paleblue/bordercorner{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
@@ -22275,7 +21163,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/steeldecal/steel_decals10,
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
 "aLJ" = (
@@ -22780,52 +21667,15 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4;
-	icon_state = "map-scrubbers"
-	},
 /obj/structure/disposalpipe/junction{
 	dir = 4;
 	icon_state = "pipe-j2"
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals10{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
 	},
-/turf/simulated/floor/tiled/white,
-/area/medical/sleeper)
-"aMt" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_steel_grid{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/sleeper)
-"aMu" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals10{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
@@ -22992,16 +21842,6 @@
 /obj/effect/floor_decal/corner/paleblue/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/medbreak)
-"aMJ" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/white,
-/area/medical/sleeper)
 "aMK" = (
 /turf/simulated/open,
 /area/medical/sleeper)
@@ -23217,51 +22057,10 @@
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5;
-	icon_state = "intact-scrubbers"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /obj/effect/floor_decal/borderfloorwhite,
 /obj/effect/floor_decal/corner/paleblue/border,
-/obj/effect/floor_decal/borderfloorwhite/corner2{
-	dir = 9
-	},
-/obj/effect/floor_decal/corner/paleblue/bordercorner2{
-	dir = 9
-	},
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
-"aNd" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/structure/cable/green{
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/sleeper)
-"aNe" = (
-/obj/structure/closet/crate/freezer,
-/obj/item/weapon/virusdish/random,
-/obj/item/weapon/virusdish/random,
-/obj/item/weapon/virusdish/random,
-/obj/item/weapon/virusdish/random,
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/virology)
 "aNg" = (
 /obj/structure/bed/chair{
 	dir = 1
@@ -23387,50 +22186,6 @@
 /obj/effect/floor_decal/corner/paleblue/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/medbreak)
-"aNr" = (
-/turf/simulated/wall/r_wall,
-/area/medical/virologyaccess)
-"aNs" = (
-/obj/machinery/door/firedoor/glass,
-/obj/machinery/door/airlock/medical{
-	autoclose = 0;
-	frequency = 1379;
-	icon_state = "door_locked";
-	id_tag = "virology_airlock_exterior";
-	locked = 1;
-	name = "Virology Exterior Airlock";
-	req_access = list(39)
-	},
-/obj/machinery/door/blast/regular{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id = "virologyquar";
-	name = "Virology Emergency Quarantine Blast Doors";
-	opacity = 0
-	},
-/obj/machinery/access_button{
-	command = "cycle_exterior";
-	frequency = 1379;
-	master_tag = "virology_airlock_control";
-	name = "Virology Access Button";
-	pixel_x = -24;
-	pixel_y = 0;
-	req_access = list(39)
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/white,
-/area/medical/virologyaccess)
-"aNt" = (
-/obj/structure/sign/department/virology,
-/turf/simulated/wall/r_wall,
-/area/medical/virologyaccess)
 "aNu" = (
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 8
@@ -23504,19 +22259,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/storage)
-"aNy" = (
-/obj/structure/table/standard,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/machinery/status_display{
-	density = 0;
-	layer = 4;
-	pixel_x = -32;
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/virology)
 "aNz" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal,
 /obj/structure/disposalpipe/segment,
@@ -23532,38 +22274,6 @@
 /obj/item/weapon/storage/mre/random,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/medbreak)
-"aNB" = (
-/obj/machinery/shower{
-	dir = 4;
-	icon_state = "shower";
-	pixel_x = 2;
-	pixel_y = 0
-	},
-/obj/structure/window/reinforced,
-/obj/effect/floor_decal/industrial/warning{
-	dir = 6
-	},
-/obj/structure/curtain/open/shower/medical,
-/turf/simulated/floor/tiled/steel,
-/area/medical/virologyaccess)
-"aNC" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 9
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/virologyaccess)
 "aND" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -23639,60 +22349,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/hallwayaux)
-"aNJ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/universal{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/virology)
-"aNK" = (
-/obj/structure/closet/l3closet/virology,
-/obj/machinery/alarm{
-	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 24
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/virologyaccess)
 "aNL" = (
 /turf/simulated/wall/rshull,
 /area/shuttle/medivac/engines)
-"aNN" = (
-/obj/structure/sink{
-	dir = 8;
-	icon_state = "sink";
-	pixel_x = -12;
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/virologyaccess)
 "aNO" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/bluegrid,
 /area/ai_core_foyer)
-"aNP" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 5
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/virologyaccess)
 "aNQ" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -23717,15 +22380,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/foyer)
-"aNR" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/red{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/virology)
 "aNU" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -23743,30 +22397,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/quartermaster/storage)
-"aNW" = (
-/turf/simulated/wall/r_wall,
-/area/medical/virology)
-"aNX" = (
-/obj/machinery/door/firedoor/glass,
-/obj/machinery/door/airlock/medical{
-	autoclose = 0;
-	frequency = 1379;
-	icon_state = "door_locked";
-	id_tag = "virology_airlock_interior";
-	locked = 1;
-	name = "Virology Interior Airlock";
-	req_access = list(39)
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
-/turf/simulated/floor/tiled/white,
-/area/medical/virologyaccess)
 "aNY" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1;
@@ -23850,115 +22480,11 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/quartermaster/belterdock)
-"aOj" = (
-/obj/structure/bed/padded,
-/obj/machinery/alarm{
-	pixel_y = 22
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/virology)
-"aOk" = (
-/obj/structure/closet/secure_closet/personal/patient,
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/tiled/white,
-/area/medical/virology)
 "aOl" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
 /turf/simulated/floor/plating,
-/area/medical/virology)
-"aOm" = (
-/obj/structure/table/glass,
-/obj/item/weapon/hand_labeler,
-/obj/item/device/radio{
-	pixel_x = -4
-	},
-/obj/item/weapon/reagent_containers/spray/cleaner{
-	desc = "Someone has crossed out the Space from Space Cleaner and written in Virology. 'Do not remove under punishment of death!!!' is scrawled on the back.";
-	name = "Virology Cleaner";
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/machinery/embedded_controller/radio/airlock/access_controller{
-	id_tag = "virology_airlock_control";
-	name = "Virology Access Console";
-	pixel_x = 8;
-	pixel_y = 24;
-	tag_exterior_door = "virology_airlock_exterior";
-	tag_interior_door = "virology_airlock_interior"
-	},
-/obj/machinery/button/remote/blast_door{
-	desc = "A remote control-switch for shutters.";
-	id = "virologyquar";
-	name = "Virology Emergency Lockdown Control";
-	pixel_x = -2;
-	pixel_y = 28;
-	req_access = list(5)
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/virology)
-"aOn" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 4
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 9
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/virology)
-"aOo" = (
-/obj/structure/sink{
-	pixel_y = 26
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/virology)
-"aOp" = (
-/obj/machinery/disease2/incubator,
-/obj/item/device/radio/intercom{
-	dir = 1;
-	pixel_y = 24;
-	req_access = list()
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/virology)
-"aOq" = (
-/obj/machinery/computer/diseasesplicer,
-/obj/item/device/radio/intercom/department/medbay{
-	dir = 1;
-	pixel_y = 24
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/virology)
-"aOr" = (
-/obj/structure/closet/l3closet/virology,
-/obj/machinery/access_button{
-	command = "cycle_interior";
-	frequency = 1379;
-	master_tag = "virology_airlock_control";
-	name = "Virology Access Button";
-	pixel_x = -8;
-	pixel_y = -28;
-	req_access = list(39)
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 10
-	},
-/obj/machinery/camera/network/medbay{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/virologyaccess)
+/area/maintenance/station/cargo)
 "aOu" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -23991,13 +22517,6 @@
 "aOx" = (
 /turf/simulated/open,
 /area/tether/exploration)
-"aOy" = (
-/obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/virology)
 "aOz" = (
 /obj/structure/table/rack/shelf,
 /obj/item/weapon/storage/backpack/parachute{
@@ -24018,81 +22537,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/tether/exploration)
-"aOA" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/virology)
-"aOB" = (
-/obj/machinery/door/window/eastright{
-	name = "Virology Isolation Room One";
-	req_one_access = list(39)
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/virology)
-"aOC" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/virology)
-"aOD" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/yellow{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/virology)
-"aOE" = (
-/turf/simulated/floor/tiled/white,
-/area/medical/virology)
-"aOF" = (
-/obj/structure/bed/chair/office/dark{
-	dir = 1
-	},
-/obj/effect/landmark/start{
-	name = "Medical Doctor"
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/virology)
-"aOG" = (
-/obj/structure/table/glass,
-/obj/machinery/computer/med_data/laptop{
-	dir = 8;
-	pixel_x = 0;
-	pixel_y = 0
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/requests_console{
-	department = "Virology";
-	name = "Virology Requests Console";
-	pixel_x = 32
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/virology)
 "aOL" = (
 /turf/simulated/floor/tiled,
 /area/quartermaster/belterdock)
@@ -24133,64 +22577,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/security/breakroom)
-"aOR" = (
-/obj/structure/table/glass,
-/obj/item/weapon/storage/fancy/vials,
-/obj/item/weapon/reagent_containers/syringe/antiviral,
-/obj/item/weapon/reagent_containers/syringe/antiviral,
-/obj/item/weapon/reagent_containers/syringe/antiviral,
-/obj/item/weapon/reagent_containers/syringe/antiviral,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/virology)
-"aOS" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
-/turf/simulated/floor/tiled/white,
-/area/medical/virology)
-"aOT" = (
-/obj/machinery/disease2/isolator,
-/turf/simulated/floor/tiled/white,
-/area/medical/virology)
-"aOU" = (
-/obj/machinery/computer/centrifuge,
-/turf/simulated/floor/tiled/white,
-/area/medical/virology)
-"aOV" = (
-/obj/structure/table/glass,
-/obj/item/weapon/paper_bin{
-	pixel_x = 1;
-	pixel_y = 8
-	},
-/obj/item/device/radio{
-	anchored = 1;
-	broadcasting = 0;
-	canhear_range = 7;
-	frequency = 1487;
-	icon = 'icons/obj/items.dmi';
-	icon_state = "red_phone";
-	listening = 1;
-	name = "Virology Emergency Phone";
-	pixel_x = -6;
-	pixel_y = 8
-	},
-/obj/item/weapon/folder/white,
-/obj/item/weapon/pen,
-/obj/structure/reagent_dispensers/virusfood{
-	pixel_x = 30
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/virology)
 "aOW" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/red/border,
@@ -24217,22 +22603,6 @@
 	},
 /turf/simulated/floor/bluegrid,
 /area/ai_core_foyer)
-"aPa" = (
-/obj/item/weapon/stool/padded,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
-/turf/simulated/floor/tiled/white,
-/area/medical/virology)
-"aPb" = (
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/tiled/white,
-/area/medical/virology)
 "aPc" = (
 /obj/machinery/ai_slipper{
 	icon_state = "motion0"
@@ -24242,19 +22612,6 @@
 	},
 /turf/simulated/floor/bluegrid,
 /area/ai_core_foyer)
-"aPd" = (
-/obj/structure/table/glass,
-/obj/item/device/antibody_scanner{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/item/device/antibody_scanner,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/virology)
 "aPe" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -24269,29 +22626,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ai_core_foyer)
-"aPf" = (
-/obj/structure/table/glass,
-/obj/item/weapon/storage/box/syringes{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/item/weapon/storage/box/beakers,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/virology)
-"aPg" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/yellow,
-/turf/simulated/floor/tiled/white,
-/area/medical/virology)
 "aPh" = (
 /obj/machinery/ai_slipper{
 	icon_state = "motion0"
@@ -24301,25 +22635,6 @@
 	},
 /turf/simulated/floor/bluegrid,
 /area/ai_core_foyer)
-"aPi" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/yellow{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/virology)
-"aPj" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/virology)
 "aPk" = (
 /obj/structure/catwalk,
 /obj/effect/decal/cleanable/dirt,
@@ -24336,83 +22651,6 @@
 	},
 /turf/simulated/floor,
 /area/maintenance/station/ai)
-"aPl" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/warning/corner,
-/turf/simulated/floor/tiled/white,
-/area/medical/virology)
-"aPm" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
-	dir = 10
-	},
-/obj/effect/floor_decal/industrial/warning/full,
-/obj/structure/sign/deathsposal{
-	pixel_x = 32
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/virology)
-"aPn" = (
-/obj/machinery/door/window/eastright{
-	name = "Virology Isolation Room Two";
-	req_one_access = list(39)
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/virology)
-"aPo" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5;
-	icon_state = "intact-scrubbers"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/turf/simulated/floor/tiled/white,
-/area/medical/virology)
-"aPp" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	icon_state = "intact-scrubbers"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/yellow{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/virology)
 "aPq" = (
 /obj/machinery/camera/network/security{
 	dir = 10;
@@ -24428,16 +22666,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ai_core_foyer)
-"aPs" = (
-/obj/machinery/atmospherics/tvalve/bypass,
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/sign/nosmoking_1{
-	pixel_x = 32
-	},
-/turf/simulated/floor/plating,
-/area/medical/virology)
 "aPt" = (
 /obj/structure/bed/chair{
 	dir = 1
@@ -24450,44 +22678,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
-"aPu" = (
-/obj/structure/table/glass,
-/obj/item/weapon/storage/box/monkeycubes,
-/obj/machinery/power/apc{
-	dir = 2;
-	name = "south bump";
-	pixel_y = -28
-	},
-/obj/structure/cable/green,
-/turf/simulated/floor/tiled/white,
-/area/medical/virology)
-"aPv" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 8
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/virology)
-"aPw" = (
-/obj/machinery/disease2/diseaseanalyser,
-/obj/machinery/alarm{
-	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 24
-	},
-/obj/machinery/camera/network/medbay,
-/turf/simulated/floor/tiled/white,
-/area/medical/virology)
 "aPx" = (
 /obj/machinery/camera/network/exploration{
 	dir = 5;
@@ -24495,24 +22685,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/tether/exploration)
-"aPy" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/black{
-	dir = 4
-	},
-/turf/simulated/wall/r_wall,
-/area/medical/virology)
-"aPz" = (
-/obj/machinery/atmospherics/unary/vent_pump{
-	dir = 8;
-	external_pressure_bound = 140;
-	external_pressure_bound_default = 140;
-	icon_state = "map_vent_out";
-	pressure_checks = 1;
-	pressure_checks_default = 1;
-	use_power = 1
-	},
-/turf/simulated/floor/airless,
-/area/medical/virology)
 "aPA" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/closet/secure_closet/freezer/money,
@@ -24524,9 +22696,6 @@
 /obj/item/weapon/storage/mrebag/pill/sleevingcure,
 /turf/simulated/floor/tiled/dark,
 /area/security/nuke_storage)
-"aPB" = (
-/turf/simulated/wall/r_wall,
-/area/medical/virologyisolation)
 "aPC" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -24534,39 +22703,6 @@
 	},
 /turf/simulated/floor/bluegrid,
 /area/ai_core_foyer)
-"aPD" = (
-/obj/machinery/smartfridge/secure/virology,
-/obj/machinery/atmospherics/pipe/simple/hidden/black{
-	dir = 5
-	},
-/obj/machinery/camera/network/medbay{
-	dir = 9;
-	icon_state = "camera"
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/virology)
-"aPE" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
-	},
-/obj/structure/disposalpipe/junction/yjunction{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 4
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 9
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/virologyisolation)
 "aPF" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 4
@@ -24578,80 +22714,9 @@
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/bluegrid,
 /area/ai_core_foyer)
-"aPG" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/virologyisolation)
-"aPH" = (
-/obj/structure/sink{
-	pixel_y = 26
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/virologyisolation)
-"aPI" = (
-/obj/structure/reagent_dispensers/water_cooler/full{
-	dir = 4
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/machinery/camera/network/medbay{
-	dir = 4;
-	icon_state = "camera"
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/virologyisolation)
-"aPJ" = (
-/obj/structure/bed/padded,
-/obj/item/weapon/bedsheet/green,
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 28
-	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/virologyisolation)
 "aPK" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/wall/r_wall,
-/area/medical/virologyisolation)
-"aPL" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/structure/disposaloutlet{
-	dir = 4
-	},
-/turf/simulated/floor/airless,
-/area/medical/virologyisolation)
+/area/maintenance/station/cargo)
 "aPM" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
@@ -24659,24 +22724,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/medical/virologyisolation)
-"aPN" = (
-/obj/structure/table/standard,
-/obj/item/weapon/soap/nanotrasen,
-/obj/item/weapon/storage/box/cups,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/virologyisolation)
-"aPO" = (
-/obj/item/weapon/stool/padded,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
-	dir = 9
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/virologyisolation)
+/area/maintenance/station/cargo)
 "aPP" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -24687,72 +22735,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor,
 /area/tether/exploration)
-"aPQ" = (
-/turf/simulated/floor/tiled/white,
-/area/medical/virologyisolation)
-"aPR" = (
-/obj/structure/bed/padded,
-/obj/item/weapon/bedsheet/green,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/virologyisolation)
-"aPS" = (
-/obj/machinery/vending/snack{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/virologyisolation)
-"aPT" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/white,
-/area/medical/virologyisolation)
-"aPU" = (
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/tiled/white,
-/area/medical/virologyisolation)
-"aPV" = (
-/obj/structure/bed/padded,
-/obj/item/weapon/bedsheet/green,
-/obj/item/device/radio/intercom{
-	dir = 4;
-	pixel_x = 24
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/virologyisolation)
-"aPW" = (
-/obj/machinery/disposal,
-/obj/machinery/alarm{
-	dir = 1;
-	icon_state = "alarm0";
-	pixel_y = -22
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
-	},
-/obj/effect/floor_decal/industrial/warning/full,
-/obj/structure/sign/deathsposal{
-	pixel_x = -32
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/virologyisolation)
-"aPX" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/virologyisolation)
-"aPY" = (
-/obj/item/weapon/stool/padded,
-/turf/simulated/floor/tiled/white,
-/area/medical/virologyisolation)
 "aPZ" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -24772,7 +22754,7 @@
 /obj/structure/window/reinforced/full,
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
-/area/medical/virologyisolation)
+/area/maintenance/station/cargo)
 "aQb" = (
 /obj/machinery/camera/network/exploration{
 	dir = 9;
@@ -24797,6 +22779,7 @@
 	dir = 1;
 	name = "security camera"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
 "aQd" = (
@@ -24914,19 +22897,6 @@
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/heads/hos)
-"aQo" = (
-/obj/item/weapon/storage/secure/safe{
-	pixel_x = -28
-	},
-/obj/structure/table/glass,
-/obj/item/weapon/storage/lockbox/vials,
-/obj/item/weapon/reagent_containers/dropper,
-/obj/machinery/camera/network/medbay{
-	dir = 4;
-	icon_state = "camera"
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/virology)
 "aQp" = (
 /obj/effect/landmark{
 	name = "morphspawn"
@@ -24956,21 +22926,9 @@
 /turf/simulated/floor/tiled,
 /area/quartermaster/belterdock/refinery)
 "aQs" = (
-/obj/machinery/door/firedoor/glass,
-/obj/machinery/door/airlock/glass_medical{
-	name = "Virology Laboratory";
-	req_access = list(39)
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/white,
-/area/medical/virology)
+/obj/structure/foamedmetal,
+/turf/simulated/floor/plating,
+/area/maintenance/station/cargo)
 "aQt" = (
 /turf/simulated/wall,
 /area/tether/exploration)
@@ -25035,6 +22993,7 @@
 /area/maintenance/station/cargo)
 "aQC" = (
 /obj/machinery/door/airlock/maintenance/common,
+/obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/plating,
 /area/maintenance/station/cargo)
 "aQD" = (
@@ -26702,10 +24661,6 @@
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/heads/hos)
-"aUj" = (
-/obj/machinery/papershredder,
-/turf/simulated/floor/wood,
-/area/crew_quarters/heads/cmo)
 "aUk" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -27397,9 +25352,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/medical_restroom)
-"aWw" = (
-/turf/simulated/wall,
-/area/crew_quarters/heads/cmo)
 "aWz" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1;
@@ -27778,10 +25730,6 @@
 /obj/structure/sign/nosmoking_1,
 /turf/simulated/wall/rshull,
 /area/shuttle/medivac/general)
-"aXM" = (
-/obj/structure/table/glass,
-/turf/simulated/floor/wood,
-/area/crew_quarters/heads/cmo)
 "aXO" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -27862,9 +25810,6 @@
 "aYa" = (
 /turf/simulated/wall/rshull,
 /area/shuttle/medivac/general)
-"aYb" = (
-/turf/simulated/floor/wood,
-/area/crew_quarters/heads/cmo)
 "aYc" = (
 /obj/structure/sign/redcross,
 /turf/simulated/wall/rshull,
@@ -28145,10 +26090,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/quartermaster/belterdock/refinery)
-"aZs" = (
-/obj/structure/bookcase,
-/turf/simulated/floor/wood,
-/area/crew_quarters/heads/cmo)
 "aZu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -28670,6 +26611,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/station/upper)
+"btZ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/mineral/vacuum,
+/area/mine/explored/upper_level)
 "bxz" = (
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/airlock/security/armory{
@@ -28696,6 +26644,13 @@
 /obj/machinery/sleep_console,
 /turf/simulated/floor/tiled/eris/dark/techfloor_grid,
 /area/shuttle/excursion/general)
+"bFB" = (
+/obj/structure/lattice,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/space,
+/area/space)
 "bFX" = (
 /obj/machinery/power/port_gen/pacman/mrs,
 /obj/structure/cable/yellow{
@@ -28838,10 +26793,12 @@
 /turf/simulated/floor/tiled/eris/steel/cyancorner,
 /area/shuttle/medivac/cockpit)
 "cay" = (
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 5
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/paleblue/border,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 1
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
+/obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
@@ -29134,6 +27091,10 @@
 	},
 /turf/simulated/floor/tiled/eris/dark/techfloor_grid,
 /area/shuttle/excursion/general)
+"dLI" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/wall,
+/area/quartermaster/storage)
 "dRj" = (
 /obj/structure/table/standard,
 /obj/random/medical,
@@ -30104,6 +28065,15 @@
 /obj/effect/floor_decal/corner/blue,
 /turf/simulated/floor/tiled/eris/white,
 /area/shuttle/medivac/general)
+"ioI" = (
+/obj/structure/disposaloutlet{
+	dir = 4
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/turf/space,
+/area/space)
 "irY" = (
 /obj/structure/bed/padded,
 /obj/structure/window/reinforced{
@@ -30186,6 +28156,14 @@
 /obj/structure/table/steel,
 /turf/simulated/floor/tiled/eris/white/bluecorner,
 /area/shuttle/excursion/cockpit)
+"iJs" = (
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "QMLoad"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor,
+/area/quartermaster/storage)
 "iJT" = (
 /obj/structure/shuttle/engine/heater,
 /obj/structure/window/reinforced{
@@ -31806,6 +29784,11 @@
 	},
 /turf/simulated/floor/tiled/eris/dark/techfloor_grid,
 /area/shuttle/excursion/general)
+"rju" = (
+/obj/structure/foamedmetal,
+/obj/effect/decal/cleanable/blood/gibs,
+/turf/simulated/floor/plating,
+/area/maintenance/station/cargo)
 "rlz" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -32224,11 +30207,19 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/station/upper)
+"twW" = (
+/obj/effect/floor_decal/industrial/warning,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled,
+/area/quartermaster/storage)
 "tyn" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/foyer)
 "tzx" = (
@@ -32271,6 +30262,12 @@
 	},
 /turf/simulated/floor/tiled/eris/white,
 /area/shuttle/medivac/general)
+"tVq" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/mineral/vacuum,
+/area/mine/explored/upper_level)
 "ufq" = (
 /obj/structure/barricade/cutout/ntsec,
 /turf/simulated/floor/tiled/dark,
@@ -33040,6 +31037,10 @@
 	},
 /turf/simulated/floor/tiled/eris/steel/gray_perforated,
 /area/shuttle/securiship/general)
+"xZK" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/wall,
+/area/quartermaster/office)
 "ydg" = (
 /obj/machinery/conveyor_switch/oneway{
 	id = "shuttle_inbound"
@@ -33060,6 +31061,14 @@
 /obj/effect/map_helper/airlock/sensor/int_sensor,
 /turf/simulated/floor/tiled/eris/dark/gray_perforated,
 /area/shuttle/excursion/cargo)
+"ydR" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/foyer)
 "yeP" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 9
@@ -41047,15 +39056,15 @@ aKW
 aKW
 aKW
 aKW
-aNW
-aNW
-aNW
-aNW
-aNW
-aNW
-aNW
-aNW
-aNW
+aPK
+aPK
+aPK
+aPK
+aPK
+aPK
+aPK
+aPK
+aPK
 aaa
 aaa
 aaa
@@ -41189,15 +39198,15 @@ aIy
 aab
 aab
 aab
-aNW
-aOj
-aOy
-aNy
-aNW
-aOj
-aOy
-aNy
-aNW
+aPK
+aQs
+aQs
+aQs
+aPK
+aQs
+aQs
+aQs
+aPK
 aaa
 aaa
 aaa
@@ -41331,15 +39340,15 @@ aIy
 aab
 aab
 aab
-aNW
-aOk
-aOA
-aLf
-aNW
-aOk
-aOA
-aLf
-aNW
+aPK
+aQs
+aQs
+aQs
+aPK
+aQs
+aQs
+aQs
+aPK
 aaa
 aaa
 aaa
@@ -41469,19 +39478,19 @@ aLH
 aMr
 aLh
 aNb
-aNr
-aNr
-aNr
-aNr
-aNW
+aPK
+aPK
+aPK
+aPK
+aPK
 aOl
-aOB
+aQs
 aOl
-aNW
+aPK
 aOl
-aPn
+aQs
 aOl
-aNW
+aPK
 aaa
 aaa
 aaa
@@ -41609,26 +39618,26 @@ aKJ
 aLj
 aLI
 aMs
-aMJ
+aLh
 aNc
-aNr
-aNB
-aJZ
-aNN
-aNr
-aOm
-aOC
-aOR
-aQo
-aPf
-aOC
-aKA
-aNW
-aPB
+aPK
+aQs
+aQs
+aQs
+aPK
+aQs
+aQs
+aQs
+aQs
+aQs
+aQs
+aQs
+aPK
+aPK
 aPM
 aPM
-aPB
-aPB
+aPK
+aPK
 aaa
 aaa
 aaa
@@ -41749,28 +39758,28 @@ aJy
 aKm
 aKK
 aLN
-aJy
-aMt
 aLh
-aNd
-aNs
-aNC
-aKb
-aNP
-aNX
-aOn
-aOD
-aOS
-aPa
-aPg
-aPo
-aPu
-aNW
-aPI
-aPN
-aPS
-aPW
-aPB
+aMX
+aLh
+aNb
+aAH
+aQs
+aQs
+aQs
+aQs
+aQs
+aQs
+aQs
+aQs
+aQs
+aQs
+aQs
+aPK
+aQs
+aQs
+aQs
+aQs
+aPK
 aaa
 aaa
 aaa
@@ -41891,27 +39900,27 @@ aJz
 aKm
 aKL
 aLN
-aJz
-aMt
 aLh
-aIU
-aNt
-aKc
-aNK
-aOr
-aNr
-aOo
-aOE
-aOE
-aPb
-aPi
-aPp
-aPv
+aMX
+aLh
+aNb
+aPK
 aQs
-aPE
-aPO
-aPT
-aPX
+aQs
+aQs
+aPK
+aQs
+aQs
+aQs
+rju
+aQs
+aQs
+aQs
+aQs
+aQs
+aQs
+aQs
+aQs
 aQa
 aaa
 aaa
@@ -42026,34 +40035,34 @@ aFg
 aFO
 aGu
 aIy
-aJi
+ayT
 aId
 aLh
 aJA
 aKn
 aKM
 aLO
-aJA
-aMu
+aLh
+aMX
 aLh
 aPt
-aNr
-aNr
-aNr
-aNr
-aNr
-aOp
-aOE
-aOT
-aOE
-aPj
-aNJ
-aOE
+aPK
+aPK
+aPK
+aPK
+aPK
+aQs
+aQs
+aQs
+aQs
+aQs
+aQs
+aQs
 aOl
-aPG
-aPQ
-aPU
-aPQ
+aQs
+aQs
+aQs
+aQs
 aQa
 aaa
 aaa
@@ -42183,19 +40192,19 @@ aIy
 aab
 aab
 aab
-aNW
-aOq
-aOF
-aOU
-aOE
-aPl
-aNR
-aNe
-aNW
-aPH
-aPQ
-aPQ
-aPY
+aPK
+aQs
+aQs
+aQs
+aQs
+aQs
+aQs
+aQs
+aPK
+aQs
+aQs
+aQs
+aQs
 aQa
 aaa
 aaa
@@ -42325,20 +40334,20 @@ aIy
 aab
 aab
 aab
-aNW
-aPw
-aOG
-aOV
-aPd
-aPm
-aPs
-aPD
-aNW
-aPJ
-aPR
-aPV
-aKB
-aPB
+aPK
+aQs
+aQs
+aQs
+aQs
+aQs
+aQs
+aQs
+aPK
+aQs
+aQs
+aQs
+aQs
+aPK
 aaa
 aaa
 aaa
@@ -42467,20 +40476,20 @@ aIy
 aab
 aab
 aab
-aNW
-aNW
-aNW
-aNW
-aNW
-aNW
-aNW
-aPy
-aNW
 aPK
-aPB
-aPB
-aPB
-aPB
+aPK
+aPK
+aPK
+aPK
+aPK
+aPK
+aPK
+aPK
+aPK
+aPK
+aPK
+aPK
+aPK
 aaa
 aaa
 aaa
@@ -42586,14 +40595,14 @@ aXT
 aRn
 aCk
 ayN
-ayT
-ayT
-ayT
-aEK
-ayT
-ayT
-ayT
-ayT
+aAH
+aAH
+aAH
+aAH
+aAH
+aAH
+aAH
+aAH
 aHJ
 aIh
 aJb
@@ -42616,9 +40625,9 @@ avs
 avs
 avs
 aYk
-aPz
+avs
 aaa
-aPL
+aaa
 aaa
 aaa
 aaa
@@ -42727,15 +40736,15 @@ azz
 aAt
 aBz
 atc
-ayT
-aBu
-aCs
-aDM
-aEL
-aDm
-aFQ
-aFQ
-ayT
+aAH
+aSo
+aSo
+aSo
+aSo
+aSo
+aSo
+aSo
+aAH
 aHO
 aIi
 aJc
@@ -42869,15 +40878,15 @@ asq
 aAu
 aBA
 att
-ayT
-aBv
-aCt
-aCt
-aCt
-aCt
-aCt
-aGy
-ayT
+aAH
+aSo
+aSo
+aSo
+aSo
+aSo
+aSo
+aSo
+aAH
 aEG
 aIj
 aJd
@@ -43011,16 +41020,16 @@ fox
 xBW
 nrc
 cay
-azs
-aBw
-aBw
-aDQ
-aEM
-aFv
-aFR
-aGz
-aHa
-aHv
+aAH
+aSo
+aSo
+aSo
+aSo
+aSo
+aSo
+aSo
+aAH
+aEG
 aIk
 aLh
 aLh
@@ -43152,16 +41161,16 @@ gfw
 bWl
 mqv
 tzx
-arC
-ayT
-aBx
-aCv
-aDR
-aCv
-aFw
-aCv
-aGA
-ayT
+aCk
+aAH
+aSo
+aSo
+aSo
+aSo
+aSo
+aSo
+aSo
+aAH
 aHM
 aIl
 aJe
@@ -43295,21 +41304,21 @@ afS
 dFr
 aoh
 auN
-ayT
-aBB
-aCw
-aDS
-aEO
-aFy
-aFS
-aGB
-aWw
-aHN
-aHN
-aHN
+aAH
+aSo
+aSo
+aSo
+aSo
+aSo
+aSo
+aSo
+aAH
+aAH
+aAH
+aAH
 aJG
-aHN
-aFz
+aAH
+aPK
 aKD
 aLU
 aLu
@@ -43437,21 +41446,21 @@ aAH
 aAH
 aoq
 aAH
-ayT
-ayT
-ayT
-ayT
-ayT
-aFz
-aFz
-aFz
-aFz
-aKC
-aIw
-aJf
-aJJ
-aKu
-aHN
+aAH
+aAH
+aAH
+aAH
+aAH
+aAH
+aQC
+aAH
+aAH
+aSo
+aSo
+aSo
+aSo
+aSo
+aAH
 aLs
 aLV
 aMx
@@ -43584,16 +41593,16 @@ aAH
 aCx
 aDT
 aEP
-aFz
-aGT
-aGD
-aUj
-aHP
-aIx
-aJg
-aJP
-aKv
-aHN
+aAH
+aSo
+aSo
+aSo
+aSo
+aSo
+aSo
+aSo
+aSo
+aAH
 aLt
 aLW
 aMy
@@ -43726,16 +41735,16 @@ aoq
 azD
 aou
 aEQ
-aFz
-aFU
-aYb
-aYb
-aYb
-aYb
-aYb
-aJQ
-aZs
-aFz
+aAH
+aSo
+aSo
+aSo
+aSo
+aSo
+aSo
+aSo
+aSo
+aAH
 aLu
 aLX
 aLu
@@ -43868,16 +41877,16 @@ aBD
 aBD
 aBD
 aBD
-aFz
-aFV
-aXM
-aHb
-aYb
-aYb
-aJh
-aJQ
-aKw
-aFz
+aAH
+aSo
+aSo
+aSo
+aSo
+aSo
+aSo
+aSo
+aSo
+aAH
 aLv
 aLY
 aAH
@@ -44010,16 +42019,16 @@ aBD
 aCy
 aDU
 aES
-aFz
-aFW
-aGE
-aHc
-aHQ
-aIz
-aJj
-aJR
-aKx
-aFz
+aAH
+aSo
+aSo
+aSo
+aSo
+aSo
+aSo
+aSo
+aSo
+aAH
 aLw
 aLY
 aAH
@@ -44152,16 +42161,16 @@ aBD
 aCz
 aDW
 aET
-aFz
-aFX
-aGS
-aHd
-aHR
-aIA
-aFi
-aJS
-aKy
-aFz
+aAH
+aSo
+aSo
+aSo
+aSo
+aSo
+aSo
+aSo
+aSo
+aAH
 aLx
 aLY
 aAH
@@ -44294,16 +42303,16 @@ aBD
 aCB
 aBD
 aEU
-aFz
-aFz
-aFz
-aFz
-aFz
-aFz
-aFz
-aFz
-aFz
-aFz
+aAH
+aAH
+aAH
+aAH
+aAH
+aQC
+aAH
+aAH
+aAH
+aAH
 aLy
 aLZ
 aAH
@@ -45987,7 +43996,7 @@ avl
 avl
 awH
 avl
-axZ
+ydR
 aAO
 azN
 aAN
@@ -46841,20 +44850,20 @@ asJ
 axs
 ayg
 aQc
-aqu
+xZK
 aoK
-aBU
+aBT
 aCM
-aBU
-aBU
-aBU
-aBU
-aBU
+aBT
+aBT
+aBT
+aBT
+aBT
 aHE
-aIu
-aGR
-azO
-aab
+twW
+iJs
+dLI
+btZ
 aab
 aMN
 aTg
@@ -46996,7 +45005,7 @@ aBU
 aIu
 aIX
 azO
-aab
+tVq
 aab
 aMN
 aTg
@@ -47138,7 +45147,7 @@ aGO
 aIv
 aGR
 azO
-aab
+tVq
 aab
 aMN
 aWZ
@@ -47280,7 +45289,7 @@ aHF
 aQe
 aIY
 azO
-aab
+tVq
 aab
 aMN
 aTj
@@ -47422,7 +45431,7 @@ aCP
 aAX
 aAX
 azO
-aab
+tVq
 aab
 aMN
 aTv
@@ -47564,7 +45573,7 @@ aHG
 aaa
 aaa
 aae
-aae
+bFB
 aaa
 aMN
 ahc
@@ -47706,7 +45715,7 @@ aHH
 aae
 aae
 aae
-aae
+bFB
 aaa
 aMN
 aTv
@@ -47848,7 +45857,7 @@ agg
 agg
 agg
 aae
-aae
+bFB
 baS
 aMD
 aMD
@@ -47990,7 +45999,7 @@ agg
 agg
 agg
 agg
-aae
+bFB
 baS
 aNn
 aTB
@@ -48132,7 +46141,7 @@ agg
 agg
 agg
 agg
-aae
+bFB
 baS
 aQh
 aUN
@@ -48274,7 +46283,7 @@ agg
 agg
 agg
 aCS
-aae
+bFB
 baS
 aQr
 aTR
@@ -48416,7 +46425,7 @@ agg
 agg
 agg
 agg
-aae
+bFB
 baS
 aQA
 aUe
@@ -48558,7 +46567,7 @@ agg
 agg
 agg
 agg
-aae
+bFB
 baS
 aRL
 aUe
@@ -48700,7 +46709,7 @@ agg
 agg
 agg
 aae
-aae
+bFB
 baS
 aSR
 aMD
@@ -48842,7 +46851,7 @@ aae
 aae
 aae
 aae
-aae
+bFB
 baS
 aSS
 aUe
@@ -48984,7 +46993,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+ioI
 baS
 aTH
 aWO

--- a/maps/tether/tether-07-station3.dmm
+++ b/maps/tether/tether-07-station3.dmm
@@ -30263,6 +30263,10 @@
 /obj/structure/barricade/cutout/ntsec,
 /turf/simulated/floor/tiled/dark,
 /area/security/nuke_storage)
+"ufG" = (
+/obj/structure/barricade,
+/turf/simulated/floor/airless,
+/area/maintenance/station/cargo)
 "uiP" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -39629,8 +39633,8 @@ aQs
 aQs
 aPK
 aPK
-aQa
-aQa
+ufG
+ufG
 aPK
 aPK
 aaa
@@ -39916,7 +39920,7 @@ aQs
 aQs
 aQs
 aQs
-aQa
+ufG
 aaa
 aaa
 aaa
@@ -40058,7 +40062,7 @@ aQs
 aQs
 aQs
 aQs
-aQa
+ufG
 aaa
 aaa
 aaa
@@ -40200,7 +40204,7 @@ aQs
 aQs
 aQs
 aQs
-aQa
+ufG
 aaa
 aaa
 aaa

--- a/maps/tether/tether-07-station3.dmm
+++ b/maps/tether/tether-07-station3.dmm
@@ -19444,6 +19444,7 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
 "aId" = (
@@ -22482,7 +22483,7 @@
 /area/quartermaster/belterdock)
 "aOl" = (
 /obj/structure/grille,
-/obj/structure/window/reinforced/full,
+/obj/structure/foamedmetal,
 /turf/simulated/floor/plating,
 /area/maintenance/station/cargo)
 "aOu" = (
@@ -22717,14 +22718,6 @@
 "aPK" = (
 /turf/simulated/wall/r_wall,
 /area/maintenance/station/cargo)
-"aPM" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/station/cargo)
 "aPP" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -22750,9 +22743,7 @@
 /turf/simulated/floor/tiled/monotile,
 /area/tether/exploration)
 "aQa" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/structure/window/reinforced,
+/obj/structure/barricade,
 /turf/simulated/floor/plating,
 /area/maintenance/station/cargo)
 "aQb" = (
@@ -30306,6 +30297,10 @@
 	},
 /turf/simulated/floor/tiled/eris/dark/techfloor_grid,
 /area/shuttle/securiship/cockpit)
+"ukV" = (
+/obj/structure/firedoor_assembly,
+/turf/simulated/floor/plating,
+/area/maintenance/station/cargo)
 "upC" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -39634,8 +39629,8 @@ aQs
 aQs
 aPK
 aPK
-aPM
-aPM
+aQa
+aQa
 aPK
 aPK
 aaa
@@ -41163,13 +41158,13 @@ mqv
 tzx
 aCk
 aAH
+aQa
 aSo
 aSo
 aSo
 aSo
 aSo
-aSo
-aSo
+ukV
 aAH
 aHM
 aIl
@@ -41305,13 +41300,13 @@ dFr
 aoh
 auN
 aAH
+aQa
 aSo
 aSo
 aSo
 aSo
 aSo
-aSo
-aSo
+aQa
 aAH
 aAH
 aAH
@@ -41455,11 +41450,11 @@ aAH
 aQC
 aAH
 aAH
+aQa
+ukV
+ukV
 aSo
-aSo
-aSo
-aSo
-aSo
+aQa
 aAH
 aLs
 aLV
@@ -41596,8 +41591,8 @@ aEP
 aAH
 aSo
 aSo
-aSo
-aSo
+aQa
+aQa
 aSo
 aSo
 aSo

--- a/maps/tether/tether_areas.dm
+++ b/maps/tether/tether_areas.dm
@@ -345,39 +345,113 @@
 /area/maintenance/commandmaint
 	name = "\improper Command Maintenance"
 
+/area/maintenance/surfacebase/lowmedbaymaint
+	name = "\improper Lower Medbay Maintenance"
+	icon_state = "green"
+/area/maintenance/surfacebase/medbaysubstation
+	name = "\improper Medbay Substation"
+	icon_state = "green"
+/area/maintenance/surfacebase/cargostoresubstation
+	name = "\improper Cargo Store Substation"
+	icon_state = "green"
+
+/area/tether/surfacebase/lowernorthhall
+	name = "\improper Lower North Hallway"
+	icon_state = "green"
+/area/tether/surfacebase/lowernortheva
+	name = "\improper Lower North EVA"
+	icon_state = "green"
+
+/area/tether/surfacebase/cargostore
+	name = "\improper Cargo Store"
+	icon_state = "yellow"
+/area/tether/surfacebase/cargostore/office
+	name = "\improper Cargo Store Office"
+	icon_state = "yellow"
+	lightswitch = 0
+/area/tether/surfacebase/cargostore/warehouse
+	name = "\improper Cargo Store Warehouse"
+	icon_state = "yellow"
+	lightswitch = 0
+
 /area/tether/surfacebase/medical
 	icon_state = "medical"
 /area/tether/surfacebase/medical/lobby
-	name = "\improper Surface Medical Lobby"
+	name = "\improper Medical Lobby"
 /area/tether/surfacebase/medical/triage
-	name = "\improper Surface Triage"
+	name = "\improper Triage"
+/area/tether/surfacebase/medical/admin
+	name = "\improper Medical Admin"
 /area/tether/surfacebase/medical/first_aid_west
 	name = "\improper First Aid West"
 /area/tether/surfacebase/medical/chemistry
-	name = "\improper Surface Chemistry"
+	name = "\improper Chemistry"
 	lightswitch = 0
 /area/tether/surfacebase/medical/resleeving
-	name = "\improper Surface Resleeving"
+	name = "\improper Resleeving"
 	lightswitch = 0
-/area/tether/surfacebase/medical/surgery
-	name = "\improper Surface Surgery"
+/area/tether/surfacebase/medical/surgery1
+	name = "\improper Surgery OR 1"
+	lightswitch = 0
+/area/tether/surfacebase/medical/surgery2
+	name = "\improper Surgery OR 2"
+	lightswitch = 0
+/area/tether/surfacebase/medical/patient
+	name = "\improper Surface Patient Recovery Rooms"
 	lightswitch = 0
 /area/tether/surfacebase/medical/patient_a
-	name = "\improper Surface Patient Room A"
+	name = "\improper Patient Room A"
 	lightswitch = 0
 /area/tether/surfacebase/medical/patient_b
-	name = "\improper Surface Patient Room B"
+	name = "\improper Patient Room B"
 	lightswitch = 0
+/area/tether/surfacebase/medical/recoveryward
+	name = "\improper Medbay Recovery Ward"
+	lightswitch = 0
+/area/tether/surfacebase/medical/recoveryward/storage
+	name = "\improper Medbay Recovery Storage"
+	lightswitch = 0
+/area/tether/surfacebase/medical/bathroom
+	name = "\improper Medbay Bathroom"
+	lightswitch = 0
+/area/tether/surfacebase/medical/mentalhealth
+	name = "\improper Mental Health"
+	lightswitch = 0
+/area/tether/surfacebase/medical/mentalhealthwaiting
+	name = "\improper Mental Health Waiting Room"
+/area/tether/surfacebase/medical/cmo
+	name = "\improper Chief Medical Officer's Office"
+	lightswitch = 0
+/area/tether/surfacebase/medical/morgue
+	name = "\improper Morgue"
+	lightswitch = 0
+/area/tether/surfacebase/medical/viro
+	name = "\improper Virology"
+	lightswitch = 0
+/area/tether/surfacebase/medical/viroairlock
+	name = "\improper Virology Airlock"
+/area/tether/surfacebase/medical/viro/viroward
+	name = "\improper Virology Ward"
+	lightswitch = 0
+/area/tether/surfacebase/medical/upperhall
+	name = "\improper Medical Upper Hall"
+/area/tether/surfacebase/medical/centralhall
+	name = "\improper Medical Central Hall"
 /area/tether/surfacebase/medical/lowerhall
-	name = "\improper Surface Medical Lower Hall"
+	name = "\improper Medical Lower Hall"
+/area/tether/surfacebase/medical/stairwell
+	name = "\improper Medical Stairwell"
 /area/tether/surfacebase/medical/storage
-	name = "\improper Surface Medical Storage"
+	name = "\improper Medical Storage"
+	lightswitch = 0
+/area/tether/surfacebase/medical/outfitting
+	name = "\improper Medical Outfitting"
 	lightswitch = 0
 /area/tether/surfacebase/medical/paramed
-	name = "\improper Surface Paramedic Closet"
+	name = "\improper Emergency Medical Bay"
 	lightswitch = 0
 /area/tether/surfacebase/medical/breakroom
-	name = "\improper Surface Medical Break Room"
+	name = "\improper Medical Break Room"
 	lightswitch = 0
 /area/tether/surfacebase/medical/maints
 	name = "\improper Mining Upper Maintenance"
@@ -455,6 +529,26 @@
 	name = "\improper Surface Security Upper Hallway"
 /area/maintenance/lower/security
 	name = "\improper Surface Security Maintenance"
+
+/area/maintenance/readingrooms
+	name = "\improper Southeast Maintenance"
+	icon = 'icons/turf/areas_vr.dmi'
+	icon_state = "green"
+	sound_env = SMALL_SOFTFLOOR
+
+/area/tether/surfacebase/cafeteria
+	name = "\improper Surface Cafeteria"
+	icon_state = "blueold"
+	lightswitch = 0
+/area/tether/surfacebase/southhall
+	name = "\improper Surface South Central Hallway"
+	icon_state = "blueold"
+/area/tether/surfacebase/southhall/readingroomaccess
+	name = "\improper Reading Room Access"
+	icon_state = "blueold"
+/area/tether/surfacebase/topairlock
+	name = "\improper Surface Upper Airlock"
+	icon_state = "blueold"
 
 /area/engineering/atmos/processing
 	name = "Atmospherics Processing"
@@ -721,6 +815,10 @@
 	name = "\improper Tether Shuttle Pad"
 /area/tether/surfacebase/reading_room
 	name = "\improper Reading Room"
+	icon = 'icons/turf/areas_vr.dmi'
+	icon_state = "green"
+	flags = RAD_SHIELDED
+	lightswitch = 0
 /area/tether/surfacebase/vacant_site
 	name = "\improper Vacant Site"
 	flags = null

--- a/maps/tether/tether_areas.dm
+++ b/maps/tether/tether_areas.dm
@@ -288,7 +288,7 @@
 	icon_state = "outpost_mine_main"
 /area/tether/surfacebase/mining_main/eva
 	name = "\improper Mining EVA"
-/area/tether/surfacebase/mining_main/external	//TODO: repath for medical move
+/area/tether/surfacebase/lowernortheva/external
 	name = "\improper Mining External"
 /area/tether/surfacebase/mining_main/break_room
 	name = "\improper Mining Crew Area"

--- a/maps/tether/tether_areas.dm
+++ b/maps/tether/tether_areas.dm
@@ -344,14 +344,13 @@
 	name = "\improper Tether Midpoint Maint"
 /area/maintenance/commandmaint
 	name = "\improper Command Maintenance"
-
 /area/maintenance/lowmedbaymaint
 	name = "\improper Lower Medbay Maintenance"
 	icon_state = "green"
-/area/maintenance/medbaysubstation
-	name = "\improper Medbay Substation"
+/area/maintenance/substation/SurfMedsubstation
+	name = "\improper SurfMed Substation"
 	icon_state = "green"
-/area/maintenance/cargostoresubstation
+/area/maintenance/substation/cargostoresubstation
 	name = "\improper Cargo Store Substation"
 	icon_state = "green"
 

--- a/maps/tether/tether_areas.dm
+++ b/maps/tether/tether_areas.dm
@@ -345,13 +345,13 @@
 /area/maintenance/commandmaint
 	name = "\improper Command Maintenance"
 
-/area/maintenance/surfacebase/lowmedbaymaint
+/area/maintenance/lowmedbaymaint
 	name = "\improper Lower Medbay Maintenance"
 	icon_state = "green"
-/area/maintenance/surfacebase/medbaysubstation
+/area/maintenance/medbaysubstation
 	name = "\improper Medbay Substation"
 	icon_state = "green"
-/area/maintenance/surfacebase/cargostoresubstation
+/area/maintenance/cargostoresubstation
 	name = "\improper Cargo Store Substation"
 	icon_state = "green"
 

--- a/maps/tether/tether_defines.dm
+++ b/maps/tether/tether_defines.dm
@@ -155,6 +155,12 @@
 		/area/tether/surfacebase/emergency_storage/rnd,
 		/area/tether/surfacebase/emergency_storage/atrium)
 
+//Medical Move
+	unit_test_exempt_from_atmos = list(
+		/area/tether/surfacebase/lowernortheva, // it airlock
+		/area/tether/surfacebase/lowernortheva/external //it outside
+		)
+
 	lateload_z_levels = list(
 		list("Tether - Misc","Tether - Underdark","Tether - Plains"), //Stock Tether lateload maps
 		list("Offmap Ship - Talon Z1","Offmap Ship - Talon Z2"),

--- a/maps/tether/tether_defines.dm
+++ b/maps/tether/tether_defines.dm
@@ -151,13 +151,10 @@
 		/area/engineering/atmos_intake, // Outside,
 		/area/rnd/external, //  Outside,
 		/area/tether/surfacebase/emergency_storage/rnd,
-		/area/tether/surfacebase/emergency_storage/atrium)
-
-//Medical Move
-	unit_test_exempt_from_atmos = list(
+		/area/tether/surfacebase/emergency_storage/atrium,
 		/area/tether/surfacebase/lowernortheva, // it airlock
-		/area/tether/surfacebase/lowernortheva/external //it outside
-		)
+		/area/tether/surfacebase/lowernortheva/external) //it outside
+
 
 	lateload_z_levels = list(
 		list("Tether - Misc","Tether - Underdark","Tether - Plains"), //Stock Tether lateload maps

--- a/maps/tether/tether_defines.dm
+++ b/maps/tether/tether_defines.dm
@@ -150,8 +150,6 @@
 	unit_test_exempt_from_atmos = list(
 		/area/engineering/atmos_intake, // Outside,
 		/area/rnd/external, //  Outside,
-		/area/tether/surfacebase/mining_main/external, // Outside,
-		/area/tether/surfacebase/cargo/mining/airlock, //  It's an airlock,	TODO: repath for later Med EVA on Surface
 		/area/tether/surfacebase/emergency_storage/rnd,
 		/area/tether/surfacebase/emergency_storage/atrium)
 


### PR DESCRIPTION
Expands Surface Medical to make it into primary medical, nerfs Space Medical, making it look a bit like things are being 'moved out' in continuing with the plan

![z3](https://user-images.githubusercontent.com/24854483/99341304-a32f8b80-2857-11eb-9cbd-b5e338b07855.png)
![z2](https://user-images.githubusercontent.com/24854483/99341310-a4f94f00-2857-11eb-81f2-53bd09fc2492.png)
![z1](https://user-images.githubusercontent.com/24854483/99341315-a75ba900-2857-11eb-8eba-fca863ce6daa.png)


Also adds an ignition button to the crematorium
Also fixxes some pipe things I missed after the chapel rework
Also converts the surface cargo area into a Cargo Shop
Also adds Detective Wardrobe to detective's office
Also makes the tiny shuttle public access
Moves the reading rooms to Z2, and adds a new section to connect the area, including a new cafeteria, and a new airlock