### PR TITLE
Removes Self-Surgery Toggle

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -52,7 +52,7 @@
 		dna.real_name = real_name
 		sync_organ_dna()
 
-	verbs |= /mob/living/proc/toggle_selfsurgery
+	//verbs |= /mob/living/proc/toggle_selfsurgery //VOREStation Removal
 
 /mob/living/carbon/human/Destroy()
 	human_mob_list -= src

--- a/code/modules/mob/living/living_powers.dm
+++ b/code/modules/mob/living/living_powers.dm
@@ -21,7 +21,6 @@
 		plane = OBJ_PLANE
 		to_chat(src,"<span class='notice'>You are now hiding.</span>")
 
-/* VOREStation Removal
 /mob/living/proc/toggle_selfsurgery()
 	set name = "Allow Self Surgery"
 	set desc = "Toggles the 'safeties' on self-surgery, allowing you to do so."
@@ -31,4 +30,3 @@
 
 	to_chat(usr, "<span class='notice'>You will [allow_self_surgery ? "now" : "no longer"] attempt to operate upon yourself.</span>")
 	log_admin("DEBUG \[[world.timeofday]\]: [src.ckey ? "[src.name]:([src.ckey])" : "[src.name]"] has [allow_self_surgery ? "Enabled" : "Disabled"] self surgery.")
-*/

--- a/code/modules/mob/living/living_powers.dm
+++ b/code/modules/mob/living/living_powers.dm
@@ -21,6 +21,7 @@
 		plane = OBJ_PLANE
 		to_chat(src,"<span class='notice'>You are now hiding.</span>")
 
+/* VOREStation Removal
 /mob/living/proc/toggle_selfsurgery()
 	set name = "Allow Self Surgery"
 	set desc = "Toggles the 'safeties' on self-surgery, allowing you to do so."
@@ -30,3 +31,4 @@
 
 	to_chat(usr, "<span class='notice'>You will [allow_self_surgery ? "now" : "no longer"] attempt to operate upon yourself.</span>")
 	log_admin("DEBUG \[[world.timeofday]\]: [src.ckey ? "[src.name]:([src.ckey])" : "[src.name]"] has [allow_self_surgery ? "Enabled" : "Disabled"] self surgery.")
+*/

--- a/maps/expedition_vr/space/guttersite.dmm
+++ b/maps/expedition_vr/space/guttersite.dmm
@@ -3083,9 +3083,6 @@
 /obj/structure/bed/chair/office/dark{
 	dir = 4
 	},
-/mob/living/simple_mob/humanoid/merc/ranged/laser{
-	faction = "wolfgirl"
-	},
 /turf/simulated/floor/tiled/eris/dark/gray_perforated,
 /area/tether_away/guttersite/security)
 "hj" = (
@@ -3259,19 +3256,6 @@
 "hD" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 1
-	},
-/mob/living/simple_mob/humanoid/merc/ranged/smg/poi{
-	faction = "wolfgirl"
-	},
-/mob/living/simple_mob/vore/wolfgirl,
-/turf/simulated/floor/tiled/eris/dark/gray_perforated,
-/area/tether_away/guttersite/security)
-"hE" = (
-/obj/structure/bed/chair/office/dark{
-	dir = 1
-	},
-/mob/living/simple_mob/humanoid/merc/melee/poi{
-	faction = "wolfgirl"
 	},
 /mob/living/simple_mob/vore/wolfgirl,
 /turf/simulated/floor/tiled/eris/dark/gray_perforated,
@@ -3736,10 +3720,6 @@
 	},
 /turf/simulated/floor/tiled/eris/dark/gray_perforated,
 /area/tether_away/guttersite/vault)
-"iN" = (
-/obj/structure/table/rack/steel,
-/turf/simulated/floor/tiled/eris/dark/gray_perforated,
-/area/tether_away/guttersite/security)
 "iO" = (
 /obj/structure/grille,
 /obj/machinery/door/firedoor/glass,
@@ -3820,7 +3800,7 @@
 /area/tether_away/guttersite/bridge)
 "jd" = (
 /obj/structure/table/rack/steel,
-/obj/random/firstaid,
+/obj/random/tetheraid,
 /turf/simulated/floor/tiled/eris/dark/gray_perforated,
 /area/tether_away/guttersite/security)
 "jg" = (
@@ -12102,7 +12082,7 @@ fw
 fw
 fw
 fw
-iN
+jd
 fu
 ag
 ag
@@ -12244,7 +12224,7 @@ fw
 fw
 hg
 fw
-iN
+jd
 fu
 ag
 ag
@@ -12372,7 +12352,7 @@ fw
 fw
 fw
 kE
-hE
+hD
 fw
 gX
 fu


### PR DESCRIPTION
By staff request. It is largely agreed upon by staff that allowing players to enable self-surgery will just encourage more "i can avoid medbay" behavior which we are wanting to avoid.

It can still be enabled by var-edit but that is it.