### PR TITLE
Update librust_g.so with an Ubuntu 16.04 compatible version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
-language: generic
-os: linux
-dist: bionic
+#pretending we're C because otherwise ruby will initialize, even with "language: dm".
+language: c
 
 env:
   global:
@@ -13,13 +12,10 @@ cache:
 addons:
   apt:
     packages:
-      - libc6:i386
+      - libc6-i386
       - libgcc1:i386
       - libstdc++6:i386
-      - libssl1.1:i386
-      - g++-7
-      - g++-7-multilib
-      - gcc-multilib
+      - libssl-dev:i386
       - zlib1g:i386
 
 before_install:


### PR DESCRIPTION
The VOREStation production server uses Ubuntu 16.04, therefore:

- The librust_g.so binary must be compiled against dependency versions available on Ubuntu 16, in order for it to be usable in production.
- We mustn't change Travis CI to use Ubuntu 18.04 (bionic), or it won't realistically test production.
- Travis CI must install the same dependencies as we expect to be available on the real server.

This PR reverts the travis config back to how it was before it was upgraded to bionic (VOREStation/VOREStation#9246), and replaces the librust_g.so binary with a version compatible with the production server (Note: It was actually compiled *on* the production server)

This should fix the issue of the production server being basically unplayable by virtue of lacking a working rust_g binary.

