### PR TITLE
Lifts nutrition cap even further.

### DIFF
--- a/code/__defines/mobs.dm
+++ b/code/__defines/mobs.dm
@@ -438,6 +438,6 @@
 #define EXAMINE_SKIPLEGS			0x0080
 #define EXAMINE_SKIPFEET			0x0100
 
-#define MAX_NUTRITION	5000 //VOREStation Edit
+#define MAX_NUTRITION	50000 //VOREStation Edit
 
 #define FAKE_INVIS_ALPHA_THRESHOLD 127 // If something's alpha var is at or below this number, certain things will pretend it is invisible.


### PR DESCRIPTION
The upstream cap of 500 was just straight up moronic, considering 450 is the "full", and this is VOREStation after all. Even 5000 is far too easy to cap here with only a few preythings. This cap never had any mechanical benefit in the first place.