### PR TITLE
Fix+change to surface sec

### DIFF
--- a/maps/tether/tether-02-surface2.dmm
+++ b/maps/tether/tether-02-surface2.dmm
@@ -25999,11 +25999,12 @@
 	dir = 10
 	},
 /obj/machinery/button/remote/blast_door{
-	id = "surfbriglockdown";
-	name = "Brig Lockdown";
+	dir = 0;
+	id = "armoryaccess";
+	name = "Armory Access";
 	pixel_x = 7;
 	pixel_y = 27;
-	req_access = list(2)
+	req_access = list(3)
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/middlehall)
@@ -26468,12 +26469,11 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/middlehall)
 "aVl" = (
-/obj/machinery/door/airlock/security{
-	name = "Evidence Storage";
-	req_access = list(3);
-	req_one_access = list()
-	},
 /obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass_security{
+	name = "Warden's Office";
+	req_access = list(3)
+	},
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/warden)
 "aVm" = (

--- a/maps/tether/tether-02-surface2.dmm
+++ b/maps/tether/tether-02-surface2.dmm
@@ -25999,7 +25999,6 @@
 	dir = 10
 	},
 /obj/machinery/button/remote/blast_door{
-	dir = 0;
 	id = "armoryaccess";
 	name = "Armory Access";
 	pixel_x = 7;
@@ -26349,11 +26348,11 @@
 	pixel_y = 37
 	},
 /obj/machinery/button/remote/blast_door{
-	id = "surfbriglockdown";
-	name = "Brig Lockdown";
+	id = "armoryaccess";
+	name = "Armory Access";
 	pixel_x = -9;
 	pixel_y = 27;
-	req_access = list(2)
+	req_access = list(3)
 	},
 /turf/simulated/floor,
 /area/tether/surfacebase/security/armory)


### PR DESCRIPTION
Button near the armory entrance now toggles the armory entrance's blast doors instead of toggling surface brig lockdown

Renames the door from the Warden's Office to EVA from 'Evidence Storage' to 'Warden's Office'