### PR TITLE
Prevent cyclic neighbor references in spreading plants

### DIFF
--- a/code/modules/hydroponics/spreading/spreading.dm
+++ b/code/modules/hydroponics/spreading/spreading.dm
@@ -72,6 +72,7 @@
 	var/obj/machinery/portable_atmospherics/hydroponics/soil/invisible/plant
 
 /obj/effect/plant/Destroy()
+	neighbors.Cut()
 	if(seed.get_trait(TRAIT_SPREAD)==2)
 		unsense_proximity(callback = .HasProximity, center = get_turf(src))
 	SSplants.remove_plant(src)


### PR DESCRIPTION
These are kind of a nightmare to GC regardless, but this should at least help prevent hard del hell