### PR TITLE
Makes pixel shifting work with custom offsets

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1026,7 +1026,7 @@ mob/proc/yank_out_object()
 	set hidden = TRUE
 	if(!canface())
 		return FALSE
-	if(pixel_y <= 16)
+	if(pixel_y <= (default_pixel_y + 16))
 		pixel_y++
 		is_shifted = TRUE
 
@@ -1034,7 +1034,7 @@ mob/proc/yank_out_object()
 	set hidden = TRUE
 	if(!canface())
 		return FALSE
-	if(pixel_y >= -16)
+	if(pixel_y >= (default_pixel_y - 16))
 		pixel_y--
 		is_shifted = TRUE
 
@@ -1042,7 +1042,7 @@ mob/proc/yank_out_object()
 	set hidden = TRUE
 	if(!canface())
 		return FALSE
-	if(pixel_x >= -16)
+	if(pixel_x >= (default_pixel_x - 16))
 		pixel_x--
 		is_shifted = TRUE
 
@@ -1050,7 +1050,7 @@ mob/verb/shifteast()
 	set hidden = TRUE
 	if(!canface())
 		return FALSE
-	if(pixel_x <= 16)
+	if(pixel_x <= (default_pixel_x + 16))
 		pixel_x++
 		is_shifted = TRUE
 // End VOREstation edit


### PR DESCRIPTION
Pixel shifting now allows mobs with custom offsets to shift themselves 16 pixels from their default offsets instead of point zero. This means that a wide mob can now shift towards left without getting stopped due to being already at -16 at default offset.