### PR TITLE
Gurgled PDA ID floor drop fix, borgo belly edition

### DIFF
--- a/code/modules/vore/eating/digest_act_vr.dm
+++ b/code/modules/vore/eating/digest_act_vr.dm
@@ -5,6 +5,10 @@
 // Ye default implementation.
 /obj/item/proc/digest_act(atom/movable/item_storage = null)
 	if(istype(item_storage, /obj/item/device/dogborg/sleeper))
+		if(istype(src, /obj/item/device/pda))
+			var/obj/item/device/pda/P = src
+			if(P.id)
+				P.id = null
 		for(var/obj/item/O in contents)
 			if(istype(O, /obj/item/weapon/storage/internal)) //Dump contents from dummy pockets.
 				for(var/obj/item/SO in O)


### PR DESCRIPTION
Fixes PDAs digested in sleeperbellies dropping their IDs on the floor.