### PR TITLE
Fixes Spacer language color

### DIFF
--- a/code/modules/vchat/css/ss13styles.css
+++ b/code/modules/vchat/css/ss13styles.css
@@ -172,7 +172,7 @@ h1.alert, h2.alert		{color: #000000;}
 .say_quote				{font-family: Georgia, Verdana, sans-serif;}
 .terminus				{font-family: "Times New Roman", Times, serif, sans-serif}
 .interface				{color: #330033;}
-.spacer					{color: #9c660b;}
+.spacer					{color: #9c660b;} /* VOREStation Add */
 
 .black					{color: #000000;}
 .darkgray				{color: #808080;}

--- a/code/modules/vchat/css/ss13styles.css
+++ b/code/modules/vchat/css/ss13styles.css
@@ -172,6 +172,7 @@ h1.alert, h2.alert		{color: #000000;}
 .say_quote				{font-family: Georgia, Verdana, sans-serif;}
 .terminus				{font-family: "Times New Roman", Times, serif, sans-serif}
 .interface				{color: #330033;}
+.spacer					{color: #9c660b;}
 
 .black					{color: #000000;}
 .darkgray				{color: #808080;}


### PR DESCRIPTION
There was an oversight in VOREStation/VOREStation#9125 where the style was forgotten in one of the files. This made Spacer appear in the same font and color as Galactic Common, and impossible to distinguish if you know both languages.