### PR TITLE
Implements negative trait "Neural hypersensitivity"

### DIFF
--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -102,6 +102,7 @@
 	var/alcohol_mod =		1						// Multiplier to alcohol strength; 0.5 = half, 0 = no effect at all, 2 = double, etc.
 	var/pain_mod =			1						// Multiplier to pain effects; 0.5 = half, 0 = no effect (equal to NO_PAIN, really), 2 = double, etc.
 	var/spice_mod =			1						// Multiplier to spice/capsaicin/frostoil effects; 0.5 = half, 0 = no effect (immunity), 2 = double, etc.
+	var/trauma_mod = 		1						// Affects traumatic shock (how fast pain crit happens). 0 = no effect (immunity to pain crit), 2 = double etc.Overriden by "can_feel_pain" var	
 	// set below is EMP interactivity for nonsynth carbons
 	var/emp_sensitivity =		0			// bitflag. valid flags are: EMP_PAIN, EMP_BLIND, EMP_DEAFEN, EMP_CONFUSE, EMP_STUN, and EMP_(BRUTE/BURN/TOX/OXY)_DMG
 	var/emp_dmg_mod =		1			// Multiplier to all EMP damage sustained by the mob, if it's EMP-sensitive

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/negative.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/negative.dm
@@ -141,3 +141,9 @@
 	..(S,H)
 	H.add_modifier(/datum/modifier/trait/colorblind_taj)
 	
+/datum/trait/neural_hypersensitivity
+	name = "Neural Hypersensitivity"
+	desc = "Your nerves are particularly sensitive to physical changes, leading to experiencing twice the intensity of pain and pleasure alike. Doubles traumatic shock."
+	cost = -1
+	var_changes = list("traumatic_mod" = 2)
+	

--- a/code/modules/mob/living/carbon/shock.dm
+++ b/code/modules/mob/living/carbon/shock.dm
@@ -13,8 +13,7 @@
 	1.2	* src.getShockFireLoss() + 		\
 	1.2	* src.getShockBruteLoss() + 		\
 	1.7	* src.getCloneLoss() + 		\
-	2	* src.halloss + 			\
-	-1	* src.chem_effects[CE_PAINKILLER]
+	2	* src.halloss
 
 	if(src.slurring)
 		src.traumatic_shock -= 20
@@ -27,6 +26,13 @@
 				src.traumatic_shock += 30
 			else if(organ.is_dislocated())
 				src.traumatic_shock += 15
+	
+	// Some individuals/species are more or less supectible to pain. Default trauma_mod = 1. Does not affect painkillers
+	if(istype(src, /mob/living/carbon/human))
+		var/mob/living/carbon/human/H = src
+		H.traumatic_shock *= H.species.trauma_mod
+		
+	src.traumatic_shock += -1 *  src.chem_effects[CE_PAINKILLER]
 
 	if(src.traumatic_shock < 0)
 		src.traumatic_shock = 0


### PR DESCRIPTION
Earlyports part of https://github.com/PolarisSS13/Polaris/pull/7771 , expands on it to add a negative trait.

In essence, I've changed how "traumatic_shock", that is the variable used to determine when a human mob starts to stutter in pain, have their eyes go blurry and enter pain crit, is calculated by multiplying traumatic_shock acquired from dislocated limbs, oxy/tox/brute/burn/clone damage with the new variable. 

I've also decided to keep the traumatic_shock reduction from slurred speech (which is acquired from overdosing on alcohol and drinking deathbell), which I did because I thought brain damage also causes slurring (turns out nope). I ended up keeping it to avoid conflicts from an earlyport, and considering the effects of alcohol on combat (makes it impossible if you're at the point that you're slurring), it shouldn't have balance issues. If necessary, I can change the calculation to exclude slurring as it excludes painkillers.

At the moment the simplified calculation is ((Sum of damage derived pain) - (slurred speech))*trauma_mod-(pain_killer)=final value

The default value of the new variable "trauma_mod" is 1, i.e.: the calculation is unchanged.

Taking the trait changes this to 2, making the person taking it rack up traumatic_shock twice as fast, and thus go into pain crit at e.g.:
50 oxy over default 100
41.2 brute/born over 83
71 tox over 142
25 halloss over 50

While needing twice as much/powerful pain killer for the same effect.

I am uncertain as to what cost is appropriate for this, I think 1 might be fair considering pain killers can still counter it.