### PR TITLE
Fixes proteans losing languages when un-blobbing

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/protean_vr/protean_blob.dm
+++ b/code/modules/mob/living/carbon/human/species/station/protean_vr/protean_blob.dm
@@ -382,7 +382,7 @@ var/global/list/disallowed_protean_accessories = list(
 		B.owner = blob
 	
 	//We can still speak our languages!
-	blob.languages = languages
+	blob.languages = languages.Copy()
 
 	//Flip them to the protean panel
 	if(panel_was_up)


### PR DESCRIPTION
Blobform now copies the language list so it doesn't just get deleted with the blob.

Fixes #9384