### PR TITLE
Map tweaks

### DIFF
--- a/code/modules/multiz/admin_upload.dm
+++ b/code/modules/multiz/admin_upload.dm
@@ -1,0 +1,23 @@
+/obj/effect/landmark/map_data/admin_upload
+	name = "Unknown"
+	desc = "An unknown location."
+
+/obj/effect/landmark/map_data/admin_upload/two
+	desc = "An unknown location. It's two levels tall."
+	height = 2
+
+/obj/effect/landmark/map_data/admin_upload/three
+	desc = "An unknown location. It's three levels tall."
+	height = 3
+
+/obj/effect/landmark/map_data/admin_upload/four
+	desc = "An unknown location. It's four levels tall."
+	height = 4
+
+/obj/effect/landmark/map_data/admin_upload/five
+	desc = "An unknown location. It's five levels tall."
+	height = 5
+
+/obj/effect/landmark/map_data/admin_upload/six
+	desc = "An unknown location. It's six levels tall."
+	height = 6

--- a/maps/offmap_vr/om_ships/itglight.dmm
+++ b/maps/offmap_vr/om_ships/itglight.dmm
@@ -3101,6 +3101,33 @@
 	},
 /turf/simulated/floor/tiled/eris/steel/brown_platform,
 /area/itglight/shuttlebay)
+"vR" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/structure/cable/pink{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/pink{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable/pink{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/newscaster{
+	pixel_y = 28
+	},
+/turf/simulated/floor/tiled/eris/steel/brown_platform,
+/area/itglight/afthall)
 "vX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -7344,6 +7371,13 @@
 	},
 /turf/simulated/floor,
 /area/itglight/starboardengi)
+"Vz" = (
+/obj/machinery/newscaster{
+	pixel_x = -12;
+	pixel_y = -26
+	},
+/turf/simulated/floor/tiled/eris/steel/brown_platform,
+/area/itglight/common)
 "VB" = (
 /obj/machinery/light{
 	dir = 1
@@ -17920,7 +17954,7 @@ Nn
 Sh
 UF
 UF
-Ji
+Vz
 Xu
 Ud
 YT
@@ -18495,7 +18529,7 @@ Zf
 UL
 YM
 Qi
-uf
+vR
 Ga
 Nc
 Gc

--- a/maps/offmap_vr/om_ships/itglight.dmm
+++ b/maps/offmap_vr/om_ships/itglight.dmm
@@ -3102,32 +3102,11 @@
 /turf/simulated/floor/tiled/eris/steel/brown_platform,
 /area/itglight/shuttlebay)
 "vR" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/structure/cable/pink{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/pink{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable/pink{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /obj/machinery/newscaster{
 	pixel_y = 28
 	},
 /turf/simulated/floor/tiled/eris/steel/brown_platform,
-/area/itglight/afthall)
+/area/itglight/metingroom)
 "vX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -18529,7 +18508,7 @@ Zf
 UL
 YM
 Qi
-vR
+uf
 Ga
 Nc
 Gc
@@ -18633,7 +18612,7 @@ VU
 iJ
 VU
 VU
-vf
+vR
 oz
 qN
 qN

--- a/maps/submaps/admin_use_vr/fun.dm
+++ b/maps/submaps/admin_use_vr/fun.dm
@@ -152,8 +152,43 @@
 	power_environ = FALSE
 	power_light = FALSE
 
+/area/submap/admin_upload/lo
+	name = "\improper Unknown Area AA"
+	requires_power = 1
+	dynamic_lighting = 1
+	lightswitch = 0
+	power_equip = FALSE
+	power_environ = FALSE
+	power_light = FALSE
+
+/area/submap/admin_upload/lo/one
+	name = "\improper Unknown Area AB"
+
+/area/submap/admin_upload/lo/two
+	name = "\improper Unknown Area AC"
 
 
+/area/submap/admin_upload/lo/three
+	name = "\improper Unknown Area AD"
+
+/area/submap/admin_upload/lo/four
+	name = "\improper Unknown Area AE"
+
+/area/submap/admin_upload/lo/pow
+	name = "\improper Unknown Area AF"
+	requires_power = 0
+
+/area/submap/admin_upload/lo/pow/one
+	name = "\improper Unknown Area AG"
+
+/area/submap/admin_upload/lo/pow/two
+	name = "\improper Unknown Area AH"
+
+/area/submap/admin_upload/lo/pow/three
+	name = "\improper Unknown Area AI"
+
+/area/submap/admin_upload/lo/pow/four
+	name = "\improper Unknown Area AJ"
 
 
 // Adminbuse things for overmap sectors

--- a/maps/tether/tether-01-surface1.dmm
+++ b/maps/tether/tether-01-surface1.dmm
@@ -28722,7 +28722,7 @@
 	icon_state = "bordercolorcorner2"
 	},
 /obj/machinery/vending/nifsoft_shop{
-	pixel_y = -20
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/visitor_laundry)
@@ -39905,7 +39905,7 @@ aad
 aad
 aad
 aad
-aad
+bcV
 aad
 aad
 aad
@@ -40336,7 +40336,7 @@ aad
 aad
 aad
 aad
-bcV
+aad
 aad
 aad
 aad
@@ -53395,7 +53395,7 @@ aad
 aad
 aad
 aad
-bcV
+aad
 aad
 aad
 aad
@@ -56374,7 +56374,7 @@ aad
 aad
 aad
 aad
-aad
+bcV
 aad
 aad
 aad

--- a/maps/tether/tether-01-surface1.dmm
+++ b/maps/tether/tether-01-surface1.dmm
@@ -1941,14 +1941,12 @@
 /turf/simulated/floor/grass,
 /area/tether/surfacebase/medical/mentalhealth)
 "adr" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor/glass,
-/obj/machinery/door/airlock/maintenance/medical{
-	name = "Medical Maintenance Access";
-	req_access = list(5)
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
+/obj/structure/catwalk,
 /turf/simulated/floor/plating,
-/area/maintenance/lowmedbaymaint)
+/area/maintenance/lower/xenoflora)
 "ads" = (
 /obj/structure/table/rack,
 /obj/item/clothing/mask/gas,
@@ -2052,6 +2050,9 @@
 	},
 /obj/machinery/door/firedoor/glass/hidden/steel{
 	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virologyaccess)
@@ -2158,10 +2159,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
 /obj/machinery/access_button{
 	command = "cycle_interior";
 	dir = 8;
@@ -2182,6 +2179,9 @@
 	dir = 10
 	},
 /obj/machinery/door/firedoor/glass/hidden/steel,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virologyaccess)
 "adH" = (
@@ -2482,6 +2482,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/lowerhall)
 "aea" = (
@@ -2907,6 +2908,9 @@
 /area/medical/virology)
 "aeF" = (
 /obj/random/junk,
+/obj/machinery/light/small{
+	dir = 8
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/lowmedbaymaint)
 "aeG" = (
@@ -3481,7 +3485,6 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
 "afy" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = 24
@@ -3549,21 +3552,7 @@
 /area/medical/virology)
 "afE" = (
 /obj/machinery/door/firedoor/glass,
-/obj/machinery/door/blast/shutters{
-	closed_layer = 10;
-	density = 0;
-	dir = 8;
-	icon_state = "shutter0";
-	id = "medbayquar";
-	layer = 1;
-	name = "Medbay Emergency Lockdown Shutters";
-	opacity = 0;
-	open_layer = 1
-	},
-/obj/machinery/door/airlock/maintenance/medical{
-	name = "Medical Maintenance Access";
-	req_access = list(5)
-	},
+/obj/machinery/door/airlock/maintenance/common,
 /turf/simulated/floor/plating,
 /area/tether/surfacebase/lowernorthhall)
 "afF" = (
@@ -5346,8 +5335,16 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/north_stairs_one)
 "aiW" = (
-/turf/simulated/mineral,
-/area/engineering/engine_room)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -25
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/maintenance/lower/xenoflora)
 "aiX" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/structure/disposalpipe/segment{
@@ -11423,16 +11420,6 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 9
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 4
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5;
 	icon_state = "intact-supply"
@@ -11440,6 +11427,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5;
 	icon_state = "intact-scrubbers"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/lowmedbaymaint)
@@ -13751,22 +13742,17 @@
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/lowerhall)
 "awB" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/button/remote/airlock{
+	id = "elevescaper";
+	name = "elevator escape button";
+	pixel_y = 32
+	},
+/obj/structure/catwalk,
 /turf/simulated/floor/plating,
-/area/maintenance/lowmedbaymaint)
+/area/maintenance/lower/xenoflora)
 "awC" = (
 /obj/effect/floor_decal/borderfloorwhite,
 /obj/effect/floor_decal/corner/paleblue/border,
@@ -14062,6 +14048,10 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/lowerhall)
 "awW" = (
@@ -14089,6 +14079,9 @@
 /obj/effect/floor_decal/steeldecal/steel_decals4,
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 10
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/lowerhall)
@@ -14120,6 +14113,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
@@ -14157,6 +14153,9 @@
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virologyaccess)
@@ -14674,23 +14673,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/universal,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"axI" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/lowmedbaymaint)
 "axJ" = (
 /obj/structure/bed/padded,
 /obj/item/weapon/bedsheet/green,
@@ -14716,9 +14698,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
@@ -14790,6 +14769,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/lowerhall)
 "axR" = (
@@ -14989,7 +14969,6 @@
 	pixel_x = 11;
 	pixel_y = 0
 	},
-/obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 5
 	},
@@ -15349,21 +15328,28 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/tagger{
+	dir = 2;
+	name = "package tagger - Void";
+	sort_tag = "Void"
+	},
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/centralstairwell)
 "ayC" = (
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/centralstairwell)
 "ayD" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/machinery/door/firedoor/glass,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/maintenance/medical{
-	locked = 1;
-	name = "Medical Maintenance Access";
-	req_access = list(5)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/maintenance/engi{
+	id_tag = "elevescaper";
+	name = "Elevator Maintenance"
 	},
 /turf/simulated/floor/plating,
-/area/medical/virologyaccess)
+/area/maintenance/lower/xenoflora)
 "ayE" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -15603,6 +15589,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/centralstairwell)
 "aza" = (
@@ -15612,12 +15599,12 @@
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/centralstairwell)
 "azb" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/light/small{
-	dir = 4
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/lowmedbaymaint)
+/area/maintenance/lower/xenoflora)
 "azc" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -16016,13 +16003,18 @@
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/centralstairwell)
 "azG" = (
-/obj/structure/disposalpipe/tagger{
-	dir = 2;
-	name = "package tagger - Void";
-	sort_tag = "Void"
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'CRUSH WARNING'.";
+	name = "\improper CRUSH WARNING";
+	pixel_y = -32
+	},
+/obj/effect/floor_decal/industrial/warning,
+/obj/structure/railing{
+	dir = 4;
+	icon_state = "railing0"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/lowmedbaymaint)
+/area/maintenance/lower/xenoflora)
 "azH" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
@@ -16061,22 +16053,9 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
 "azK" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/lowmedbaymaint)
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/lower/xenoflora)
 "azL" = (
 /obj/machinery/door/firedoor/glass/hidden/steel{
 	dir = 1
@@ -16197,31 +16176,20 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/lowmedbaymaint)
 "azU" = (
-/obj/machinery/door/firedoor/glass,
-/obj/structure/window/reinforced/polarized/full{
-	id = "ward_tint"
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'CRUSH WARNING'.";
+	name = "\improper CRUSH WARNING";
+	pixel_y = -32
 	},
-/obj/structure/grille,
-/obj/machinery/door/blast/shutters{
-	closed_layer = 10;
-	density = 0;
-	dir = 8;
-	icon_state = "shutter0";
-	id = "medbayquar";
-	layer = 1;
-	name = "Medbay Emergency Lockdown Shutters";
-	opacity = 0;
-	open_layer = 1
+/obj/effect/floor_decal/industrial/warning,
+/obj/structure/railing{
+	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/tether/surfacebase/lowernorthhall)
+/area/maintenance/lower/xenoflora)
 "azV" = (
 /turf/simulated/wall,
 /area/medical/virology)
@@ -16304,10 +16272,6 @@
 /area/maintenance/lowmedbaymaint)
 "aAb" = (
 /obj/machinery/door/firedoor/glass,
-/obj/machinery/door/airlock/maintenance/medical{
-	name = "Medical Maintenance Access";
-	req_access = list(5)
-	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -16319,6 +16283,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/machinery/door/airlock/maintenance/common,
 /turf/simulated/floor/plating,
 /area/maintenance/lowmedbaymaint)
 "aAc" = (
@@ -16351,6 +16316,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/centralstairwell)
 "aAd" = (
@@ -16446,6 +16412,18 @@
 	name = "Medical Maintenance Access";
 	req_access = list(5)
 	},
+/obj/machinery/door/blast/shutters{
+	closed_layer = 10;
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id = "medbayquar";
+	layer = 1;
+	name = "Medbay Emergency Lockdown Shutters";
+	opacity = 0;
+	open_layer = 1
+	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/centralstairwell)
 "aAs" = (
@@ -27272,10 +27250,9 @@
 	dir = 10;
 	icon_state = "bordercolorcorner2"
 	},
-/obj/structure/extinguisher_cabinet{
+/obj/machinery/light_switch{
 	dir = 4;
-	icon_state = "extinguisher_closed";
-	pixel_x = -30
+	pixel_x = -24
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/visitor_laundry)
@@ -27326,6 +27303,12 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
+/obj/effect/floor_decal/corner/grey{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/grey{
+	dir = 10
+	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/visitor_laundry)
 "aUt" = (
@@ -27353,6 +27336,12 @@
 /obj/machinery/washing_machine,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/corner/grey{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/grey{
+	dir = 10
+	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/visitor_laundry)
 "aUv" = (
@@ -27535,9 +27524,10 @@
 	dir = 4;
 	icon_state = "bordercolor"
 	},
-/obj/machinery/light_switch{
+/obj/structure/extinguisher_cabinet{
 	dir = 8;
-	pixel_x = 24
+	icon_state = "extinguisher_closed";
+	pixel_x = 30
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/visitor_laundry)
@@ -27677,14 +27667,34 @@
 /area/crew_quarters/visitor_laundry)
 "aVe" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/grey/border{
+	dir = 4;
+	icon_state = "bordercolor"
+	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/visitor_laundry)
 "aVf" = (
 /obj/machinery/washing_machine,
+/obj/effect/floor_decal/corner/grey{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/grey{
+	dir = 10
+	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/visitor_laundry)
 "aVg" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/grey/border{
+	dir = 8;
+	icon_state = "bordercolor"
+	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/visitor_laundry)
 "aVh" = (
@@ -27944,6 +27954,13 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/grey/border{
+	dir = 4;
+	icon_state = "bordercolor"
+	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/visitor_laundry)
 "aVB" = (
@@ -27958,6 +27975,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/effect/floor_decal/corner/grey{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/grey{
+	dir = 10
+	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/visitor_laundry)
 "aVC" = (
@@ -27971,6 +27994,13 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/grey/border{
+	dir = 8;
+	icon_state = "bordercolor"
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/visitor_laundry)
@@ -28144,6 +28174,13 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/grey/border{
+	dir = 4;
+	icon_state = "bordercolor"
+	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/visitor_laundry)
 "aVR" = (
@@ -28154,6 +28191,13 @@
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/grey/border{
+	dir = 8;
+	icon_state = "bordercolor"
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/visitor_laundry)
@@ -28676,6 +28720,9 @@
 /obj/effect/floor_decal/corner/grey/bordercorner2{
 	dir = 9;
 	icon_state = "bordercolorcorner2"
+	},
+/obj/machinery/vending/nifsoft_shop{
+	pixel_y = -20
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/visitor_laundry)
@@ -31119,8 +31166,9 @@
 /turf/simulated/floor/tiled,
 /area/hallway/lower/first_west)
 "bbQ" = (
-/turf/simulated/mineral,
-/area/tether/surfacebase/surface_one_hall)
+/obj/machinery/door/airlock/maintenance/common,
+/turf/simulated/floor/plating,
+/area/tether/elevator)
 "bbR" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -31353,9 +31401,14 @@
 /turf/simulated/floor/plating,
 /area/maintenance/lower/xenoflora)
 "bcm" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/techfloor,
-/area/maintenance/lower/xenoflora)
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/grey/bordercorner{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/crew_quarters/visitor_laundry)
 "bcn" = (
 /obj/structure/closet/crate,
 /obj/random/tool,
@@ -31377,34 +31430,42 @@
 /obj/machinery/alarm{
 	pixel_y = 22
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/xenoflora)
 "bcq" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/door/airlock/maintenance/common,
 /obj/machinery/door/firedoor/glass,
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/maintenance/engi{
+	id_tag = "elevescapel";
+	name = "Elevator Maintenance"
+	},
+/obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/lower/xenoflora)
 "bcr" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/button/remote/airlock{
+	id = "elevescapel";
+	name = "elevator escape button";
+	pixel_y = 32
+	},
+/obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/lower/xenoflora)
 "bcs" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -25
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'CRUSH WARNING'.";
+	name = "\improper CRUSH WARNING";
+	pixel_y = 32
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/lower/xenoflora)
 "bct" = (
@@ -31425,7 +31486,6 @@
 /obj/structure/disposalpipe/up{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/lower/xenoflora)
 "bcw" = (
@@ -31458,9 +31518,6 @@
 	icon_state = "alarm0";
 	pixel_x = -22
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/random/trash,
-/obj/effect/decal/cleanable/cobweb,
 /turf/simulated/floor/plating,
 /area/maintenance/lower/xenoflora)
 "bcA" = (
@@ -31471,19 +31528,17 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/random/trash,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/lower/xenoflora)
 "bcC" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate,
 /obj/random/unidentified_medicine,
 /obj/random/firstaid,
 /obj/random/drinkbottle,
-/obj/effect/decal/cleanable/cobweb{
-	icon_state = "cobweb2"
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/lower/xenoflora)
 "bcD" = (
@@ -32272,6 +32327,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/lowmedbaymaint)
+"bHR" = (
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/grey/bordercorner{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/crew_quarters/visitor_laundry)
 "bJz" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -32497,6 +32561,15 @@
 /obj/effect/floor_decal/corner/red/border,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/lowerhall)
+"cwS" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/grey/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/crew_quarters/visitor_laundry)
 "cAR" = (
 /turf/simulated/floor/looking_glass/center,
 /area/looking_glass/lg_1)
@@ -33987,6 +34060,17 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/rnd/hallway)
+"iee" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/grey/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/crew_quarters/visitor_laundry)
 "igw" = (
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/lowernorthhall)
@@ -34667,6 +34751,20 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/brig)
+"laR" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/grey/bordercorner{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/crew_quarters/visitor_laundry)
 "lbu" = (
 /obj/effect/floor_decal/borderfloorwhite,
 /obj/effect/floor_decal/corner/paleblue/border,
@@ -42148,7 +42246,7 @@ aah
 aah
 aah
 aah
-aiW
+aah
 aah
 aah
 aah
@@ -46957,7 +47055,7 @@ ate
 apu
 apu
 apu
-bcr
+adr
 avT
 agb
 agb
@@ -47099,8 +47197,8 @@ ate
 apu
 bcd
 apu
-bcr
-avT
+bcs
+azG
 agb
 agc
 agc
@@ -47242,8 +47340,8 @@ apu
 bcd
 apu
 bcB
-avT
-agb
+azK
+bbQ
 agc
 agc
 agc
@@ -47384,7 +47482,7 @@ apu
 bcd
 apu
 bcs
-avT
+azU
 agb
 agc
 agc
@@ -47525,7 +47623,7 @@ arL
 apu
 bcd
 apu
-bcr
+aiW
 avT
 agb
 agc
@@ -47667,8 +47765,8 @@ arL
 apu
 bcd
 apu
-bcr
-avU
+adr
+avT
 agb
 agb
 agc
@@ -47809,8 +47907,8 @@ atf
 apu
 bcd
 apu
-bcr
-agM
+adr
+apu
 agM
 axg
 axT
@@ -47951,8 +48049,8 @@ atg
 apu
 bcd
 apu
-bcr
-bbQ
+awB
+bcd
 agM
 axh
 axU
@@ -48093,7 +48191,7 @@ apu
 apu
 apu
 apu
-bcq
+ayD
 apu
 agM
 agM
@@ -48235,9 +48333,9 @@ ath
 axS
 apu
 bcz
-bct
+azb
 bcv
-bco
+axS
 agM
 axW
 ayI
@@ -48377,7 +48475,7 @@ apu
 axS
 apu
 bcA
-bco
+axS
 apu
 apu
 agM
@@ -48519,7 +48617,7 @@ apu
 axS
 apu
 bcC
-bco
+axS
 apu
 bcd
 agM
@@ -48801,9 +48899,9 @@ apu
 asL
 atj
 atL
-bcm
-bcm
-bcm
+atL
+atL
+atL
 agM
 ahc
 ahu
@@ -48944,8 +49042,8 @@ asL
 apu
 agM
 agM
-bcm
-bcm
+atL
+atL
 agM
 agM
 agM
@@ -49087,8 +49185,8 @@ apu
 ahc
 agM
 bcp
-bcm
-bcm
+atL
+atL
 atL
 atj
 ayc
@@ -51614,7 +51712,7 @@ aeU
 aef
 aef
 afE
-azU
+aef
 aef
 aef
 aEY
@@ -51756,7 +51854,7 @@ aah
 aah
 aah
 akA
-aah
+aAG
 aah
 aef
 aEZ
@@ -51898,7 +51996,7 @@ aah
 aah
 aah
 akA
-aah
+aAG
 aah
 aef
 aFa
@@ -52040,7 +52138,7 @@ aah
 aah
 aah
 anF
-aah
+aAG
 aah
 aef
 aFb
@@ -52182,7 +52280,7 @@ aah
 aah
 aah
 akA
-aah
+aAG
 aah
 aef
 aef
@@ -52324,7 +52422,7 @@ axP
 axP
 axP
 akA
-aah
+aAI
 aah
 aah
 aah
@@ -52466,8 +52564,8 @@ ayZ
 aAc
 aAi
 asT
-aah
-aah
+aAI
+adK
 aah
 aah
 aah
@@ -52607,9 +52705,9 @@ ayC
 aza
 aAd
 axP
-awB
-aah
-aah
+aAz
+aAI
+adK
 aah
 aah
 aah
@@ -52749,9 +52847,9 @@ ayC
 azE
 axP
 axP
-axI
-aah
-aah
+axK
+aAI
+adK
 aah
 aah
 aah
@@ -52892,8 +52990,8 @@ azF
 axP
 aeF
 axK
-aah
-aah
+aAI
+adK
 aah
 aah
 aah
@@ -52961,11 +53059,11 @@ aSW
 aTD
 aSo
 acw
-aUP
+aVS
 aVe
 aVA
 aVQ
-aUP
+bHR
 aUP
 bcT
 aVn
@@ -53033,9 +53131,9 @@ axP
 axP
 axP
 aeJ
-azK
-aah
-aah
+aAz
+aAI
+adK
 aah
 aah
 aah
@@ -53103,11 +53201,11 @@ aSX
 aTE
 aSo
 acz
-aUP
+bcT
 aVf
 aVB
 aVf
-aUP
+cwS
 aUP
 aWX
 aUm
@@ -53170,14 +53268,14 @@ aff
 auo
 adG
 ayf
-ayD
-azb
-azG
-adr
+aff
+aAI
+aAI
+aAD
 afy
 azT
 aAa
-aah
+adK
 aah
 aah
 bbj
@@ -53245,11 +53343,11 @@ aSY
 aTF
 aSo
 afZ
-aUP
+bcT
 aVf
 aVB
 aVf
-aUP
+cwS
 aUP
 aWY
 aUm
@@ -53319,7 +53417,7 @@ azV
 azV
 azV
 aAb
-aah
+adK
 aah
 bbj
 bbj
@@ -53387,11 +53485,11 @@ aSX
 aTG
 aSo
 arm
-aUP
+bcT
 aVf
 aUs
 aUu
-aVP
+iee
 aVP
 aWZ
 bcj
@@ -53461,7 +53559,7 @@ azW
 aAe
 aeE
 aAz
-aah
+adK
 aah
 bbj
 bbx
@@ -53529,11 +53627,11 @@ aSZ
 aSo
 aSo
 arD
-aUP
+bcT
 aVf
 aVB
 aVf
-aUP
+cwS
 aUP
 aXa
 aUm
@@ -53603,7 +53701,7 @@ azX
 aAg
 aeE
 aAz
-aah
+adK
 aah
 bbj
 bby
@@ -53671,11 +53769,11 @@ aTa
 aTH
 aSo
 aTB
-aUP
+bcm
 aVg
 aVC
 aVR
-aWp
+laR
 aWp
 aXb
 aUm
@@ -53745,7 +53843,7 @@ azY
 aAh
 aeE
 aAz
-aah
+adK
 aAW
 bbr
 bbz

--- a/maps/tether/tether-02-surface2.dmm
+++ b/maps/tether/tether-02-surface2.dmm
@@ -11133,6 +11133,9 @@
 /obj/effect/floor_decal/corner/red/border{
 	dir = 6
 	},
+/obj/machinery/newscaster/security_unit{
+	pixel_x = 32
+	},
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/warden)
 "asJ" = (

--- a/maps/tether/tether-02-surface2.dmm
+++ b/maps/tether/tether-02-surface2.dmm
@@ -2065,6 +2065,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/sign/poster{
+	pixel_y = 32
+	},
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/evidence)
 "acW" = (
@@ -7104,8 +7107,17 @@
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/uppersouthstairwell)
 "akR" = (
-/turf/simulated/wall/r_wall,
-/area/tether/surfacebase/medical/uppersouthstairwell)
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 8
+	},
+/obj/structure/sign/poster{
+	pixel_x = -32
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/security/middlehall)
 "akS" = (
 /obj/structure/window/reinforced,
 /obj/machinery/vending/fitness{
@@ -8564,7 +8576,9 @@
 "ano" = (
 /obj/machinery/door/firedoor/glass,
 /obj/structure/grille,
-/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced/polarized/full{
+	id = "wardenwindows"
+	},
 /turf/simulated/floor,
 /area/tether/surfacebase/security/warden)
 "anp" = (
@@ -8592,11 +8606,12 @@
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/warden)
 "anq" = (
-/obj/machinery/door/airlock/glass_security{
-	name = "Warden's Office";
-	req_access = list(3)
-	},
 /obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/security{
+	name = "Warden's Office";
+	req_access = list(3);
+	req_one_access = list()
+	},
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/warden)
 "anr" = (
@@ -9072,6 +9087,11 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/button/windowtint/multitint{
+	id = "wardenwindows";
+	pixel_x = -55;
+	pixel_y = 26
+	},
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/warden)
 "aow" = (
@@ -9382,8 +9402,8 @@
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/recoveryward)
 "aoZ" = (
-/turf/simulated/wall/r_wall,
-/area/tether/surfacebase/medical/recoveryward)
+/turf/simulated/floor/tiled/techfloor,
+/area/chapel/main)
 "apc" = (
 /obj/structure/cable/green,
 /obj/structure/cable/green{
@@ -10179,9 +10199,11 @@
 "aqJ" = (
 /obj/machinery/door/firedoor/glass,
 /obj/structure/grille,
-/obj/structure/window/reinforced/full,
 /obj/structure/cable/green{
 	icon_state = "0-4"
+	},
+/obj/structure/window/reinforced/polarized/full{
+	id = "wardenwindows"
 	},
 /turf/simulated/floor,
 /area/tether/surfacebase/security/warden)
@@ -10587,12 +10609,14 @@
 "arE" = (
 /obj/machinery/door/firedoor/glass,
 /obj/structure/grille,
-/obj/structure/window/reinforced/full,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/structure/cable/green{
 	icon_state = "0-4"
+	},
+/obj/structure/window/reinforced/polarized/full{
+	id = "wardenwindows"
 	},
 /turf/simulated/floor,
 /area/tether/surfacebase/security/warden)
@@ -11090,6 +11114,7 @@
 /obj/effect/landmark/start{
 	name = "Warden"
 	},
+/obj/structure/curtain/open/bed,
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/warden)
 "asH" = (
@@ -15379,7 +15404,7 @@
 	},
 /obj/structure/railing,
 /turf/simulated/floor/tiled/techfloor,
-/area/maintenance/lower/bar)
+/area/chapel/main)
 "aCa" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 1
@@ -15390,7 +15415,7 @@
 	},
 /obj/structure/railing,
 /turf/simulated/floor/tiled/techfloor,
-/area/maintenance/lower/bar)
+/area/chapel/main)
 "aCb" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -15399,14 +15424,14 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor,
-/area/maintenance/lower/bar)
+/area/chapel/main)
 "aCc" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 1
 	},
 /obj/machinery/camera/network/tether,
 /turf/simulated/floor/tiled/techfloor,
-/area/maintenance/lower/bar)
+/area/chapel/main)
 "aCd" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 5
@@ -15419,7 +15444,7 @@
 	pixel_x = 24
 	},
 /turf/simulated/floor/tiled/techfloor,
-/area/maintenance/lower/bar)
+/area/chapel/main)
 "aCe" = (
 /obj/structure/catwalk,
 /obj/structure/cable{
@@ -15914,31 +15939,23 @@
 "aCU" = (
 /obj/structure/stairs/west,
 /turf/simulated/floor/tiled/techfloor,
-/area/maintenance/lower/bar)
+/area/chapel/main)
 "aCV" = (
-/turf/simulated/floor/tiled/dark,
-/area/maintenance/lower/bar)
+/obj/effect/floor_decal/techfloor{
+	dir = 8;
+	icon_state = "techfloororange_edges"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/chapel/main)
 "aCW" = (
 /obj/effect/floor_decal/techfloor/corner{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
-/area/maintenance/lower/bar)
+/area/chapel/main)
 "aCX" = (
-/obj/machinery/door/firedoor/glass,
-/turf/simulated/floor/tiled/dark,
-/area/maintenance/lower/bar)
-"aCY" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/dark,
-/area/maintenance/lower/bar)
-"aCZ" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/dark,
+/obj/structure/sign/nanotrasen,
+/turf/simulated/wall,
 /area/maintenance/lower/bar)
 "aDa" = (
 /obj/machinery/alarm{
@@ -15949,7 +15966,7 @@
 	icon_state = "techfloororange_edges"
 	},
 /turf/simulated/floor/tiled/techfloor,
-/area/maintenance/lower/bar)
+/area/chapel/main)
 "aDb" = (
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/airlock/maintenance/common,
@@ -15958,6 +15975,9 @@
 "aDc" = (
 /obj/machinery/alarm{
 	pixel_y = 22
+	},
+/obj/effect/floor_decal/techfloor{
+	dir = 9
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/bar)
@@ -16347,7 +16367,7 @@
 "aDL" = (
 /obj/effect/floor_decal/techfloor/corner,
 /turf/simulated/floor/tiled/dark,
-/area/maintenance/lower/bar)
+/area/chapel/main)
 "aDM" = (
 /obj/machinery/door/airlock/multi_tile/glass{
 	dir = 1;
@@ -16355,42 +16375,25 @@
 	},
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/tiled/dark,
-/area/maintenance/lower/bar)
+/area/chapel/main)
 "aDN" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /turf/simulated/floor/tiled/dark,
-/area/maintenance/lower/bar)
+/area/chapel/main)
 "aDO" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/dark,
-/area/maintenance/lower/bar)
+/area/chapel/main)
 "aDP" = (
 /turf/simulated/wall,
 /area/chapel/main)
 "aDQ" = (
-/obj/structure/grille,
-/obj/machinery/door/firedoor/glass,
-/obj/structure/window/reinforced/polarized/full{
-	id = "chaplainpet"
-	},
-/turf/simulated/floor/tiled/dark,
+/obj/machinery/recharge_station,
+/turf/simulated/floor/tiled/techfloor,
 /area/chapel/main)
 "aDR" = (
 /obj/machinery/light_switch{
@@ -16638,7 +16641,7 @@
 	icon_state = "railing0"
 	},
 /turf/simulated/floor/tiled/techfloor,
-/area/maintenance/lower/bar)
+/area/chapel/main)
 "aEn" = (
 /obj/structure/cable/green{
 	d1 = 32;
@@ -16652,7 +16655,7 @@
 	icon_state = "railing0"
 	},
 /turf/simulated/open,
-/area/maintenance/lower/bar)
+/area/chapel/main)
 "aEo" = (
 /obj/effect/floor_decal/techfloor/corner{
 	dir = 8
@@ -16683,7 +16686,7 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled/techfloor,
-/area/maintenance/lower/bar)
+/area/chapel/main)
 "aEp" = (
 /obj/structure/cable/green{
 	d1 = 16;
@@ -16712,7 +16715,7 @@
 	icon_state = "up-scrubbers"
 	},
 /turf/simulated/floor/tiled/techfloor,
-/area/maintenance/lower/bar)
+/area/chapel/main)
 "aEq" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 6
@@ -16722,7 +16725,7 @@
 	icon_state = "railing0"
 	},
 /turf/simulated/floor/tiled/techfloor,
-/area/maintenance/lower/bar)
+/area/chapel/main)
 "aEr" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -16732,24 +16735,48 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/dark,
-/area/maintenance/lower/bar)
-"aEs" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/grass,
-/area/chapel/main)
-"aEt" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/machinery/camera/network/civilian,
-/turf/simulated/floor/grass,
-/area/chapel/main)
-"aEu" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/machinery/alarm{
-	pixel_y = 22
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/turf/simulated/floor/grass,
+/turf/simulated/floor/tiled/dark,
 /area/chapel/main)
+"aEs" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/lower/bar)
+"aEt" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/lower/bar)
+"aEu" = (
+/obj/item/clothing/mask/gas,
+/obj/random/mre,
+/obj/random/mre,
+/obj/random/mre,
+/obj/random/mre,
+/obj/random/mre,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/structure/closet/walllocker_double{
+	dir = 8;
+	pixel_x = -28
+	},
+/obj/effect/floor_decal/techfloor{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/lower/bar)
 "aEv" = (
 /obj/machinery/door/airlock{
 	name = "Chapel Morgue";
@@ -17058,22 +17085,43 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/dark,
-/area/maintenance/lower/bar)
+/area/chapel/main)
 "aEX" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/simulated/floor/grass,
-/area/chapel/main)
+/obj/machinery/portable_atmospherics/powered/scrubber,
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_x = 0
+	},
+/obj/effect/floor_decal/techfloor{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/lower/bar)
 "aEY" = (
-/turf/simulated/floor/grass,
-/area/chapel/main)
+/obj/effect/floor_decal/techfloor{
+	dir = 1
+	},
+/mob/living/simple_mob/animal/passive/mouse/brown/Tom,
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/lower/bar)
 "aEZ" = (
-/mob/living/simple_mob/animal/passive/snake/noodle,
-/turf/simulated/floor/grass,
-/area/chapel/main)
+/obj/effect/floor_decal/corner_techfloor_grid{
+	dir = 1
+	},
+/obj/effect/floor_decal/techfloor/corner{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/lower/bar)
 "aFa" = (
-/obj/structure/flora/ausbushes/brflowers,
-/turf/simulated/floor/grass,
-/area/chapel/main)
+/obj/effect/floor_decal/techfloor{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/lower/bar)
 "aFb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5;
@@ -17412,31 +17460,40 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
-/area/maintenance/lower/bar)
+/area/chapel/main)
 "aFF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/tiled/dark,
-/area/maintenance/lower/bar)
+/area/chapel/main)
 "aFG" = (
 /obj/structure/sign/department/chapel,
 /turf/simulated/wall,
 /area/chapel/main)
 "aFH" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/machinery/light/small{
-	dir = 8
+/obj/machinery/portable_atmospherics/powered/pump/filled,
+/obj/effect/floor_decal/techfloor{
+	dir = 10
 	},
-/mob/living/simple_mob/animal/passive/mouse/white/apple,
-/turf/simulated/floor/grass,
-/area/chapel/main)
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/lower/bar)
 "aFI" = (
-/obj/structure/table/woodentable,
-/obj/item/weapon/storage/box/snakesnackbox,
-/turf/simulated/floor/grass,
-/area/chapel/main)
+/obj/machinery/shower{
+	dir = 8;
+	pixel_x = -2
+	},
+/obj/effect/floor_decal/techfloor{
+	dir = 6
+	},
+/obj/effect/floor_decal/techfloor/hole/right{
+	dir = 4
+	},
+/obj/effect/floor_decal/techfloor/hole,
+/obj/effect/floor_decal/industrial/outline/blue,
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/lower/bar)
 "aFJ" = (
 /obj/machinery/light/small{
 	dir = 8;
@@ -17750,20 +17807,40 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/structure/extinguisher_cabinet{
+	dir = 8;
+	icon_state = "extinguisher_closed";
+	pixel_x = 30
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/tether/surfacebase/surface_two_hall)
 "aGn" = (
-/obj/structure/girder/displaced,
-/turf/simulated/floor/plating,
+/obj/machinery/washing_machine,
+/obj/effect/floor_decal/techfloor{
+	dir = 4
+	},
+/obj/structure/sign/nosmoking_2{
+	pixel_x = 32
+	},
+/turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/bar)
 "aGo" = (
-/obj/structure/firedoor_assembly,
+/obj/structure/grille,
+/obj/machinery/door/firedoor/glass,
+/obj/structure/window/reinforced/polarized/full{
+	id = "chaplainpet"
+	},
 /turf/simulated/floor,
-/area/maintenance/lower/bar)
+/area/chapel/main)
 "aGp" = (
-/obj/structure/girder/displaced,
-/turf/simulated/floor,
-/area/maintenance/lower/bar)
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/structure/closet/hydrant{
+	pixel_x = 32
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/tether/surfacebase/surface_two_hall)
 "aGq" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -17785,12 +17862,16 @@
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
 "aGs" = (
-/obj/machinery/door/airlock{
-	name = "Noodle Office";
-	req_access = list(27)
+/obj/structure/disposalpipe/segment,
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
 	},
-/obj/machinery/door/firedoor/glass,
-/turf/simulated/floor/lino,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/tiled/dark,
 /area/chapel/main)
 "aGt" = (
 /obj/machinery/door/blast/shutters{
@@ -17934,23 +18015,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/techmaint,
 /area/tether/surfacebase/surface_two_hall)
-"aGO" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/closet/hydrant{
-	pixel_x = 32
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/tether/surfacebase/surface_two_hall)
 "aGP" = (
-/turf/simulated/floor/plating,
-/area/maintenance/lower/bar)
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/grass,
+/area/chapel/main)
 "aGQ" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -17982,13 +18053,6 @@
 	},
 /obj/effect/landmark/start{
 	name = "Chaplain"
-	},
-/obj/machinery/button/windowtint{
-	dir = 1;
-	id = "chaplainpet";
-	name = "interior window tint";
-	pixel_x = -10;
-	pixel_y = 30
 	},
 /obj/machinery/button/windowtint{
 	dir = 1;
@@ -18119,11 +18183,6 @@
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
 	},
-/obj/structure/extinguisher_cabinet{
-	dir = 8;
-	icon_state = "extinguisher_closed";
-	pixel_x = 30
-	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -18136,8 +18195,8 @@
 	dir = 1;
 	pixel_y = -25
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/lower/bar)
+/turf/simulated/floor/grass,
+/area/chapel/main)
 "aHj" = (
 /obj/structure/table/woodentable,
 /obj/machinery/atmospherics/unary/vent_pump/on,
@@ -18449,22 +18508,16 @@
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
 "aHT" = (
-/obj/machinery/power/apc{
-	cell_type = /obj/item/weapon/cell/super;
-	dir = 1;
-	name = "north bump";
-	pixel_y = 24
-	},
-/obj/structure/cable/green{
-	d2 = 8;
-	dir = 2;
-	icon_state = "0-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
@@ -18479,11 +18532,21 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
 "aHV" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
@@ -21679,18 +21742,17 @@
 /obj/effect/floor_decal/corner_techfloor_grid{
 	dir = 5
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/portable_atmospherics/hydroponics,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/south)
 "aNZ" = (
-/obj/effect/floor_decal/rust,
 /obj/structure/railing{
 	dir = 4
 	},
 /obj/effect/floor_decal/corner_techfloor_grid{
 	dir = 5
 	},
+/obj/effect/floor_decal/techfloor/hole,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/south)
 "aOa" = (
@@ -22212,8 +22274,12 @@
 /obj/effect/floor_decal/corner_techfloor_grid{
 	dir = 9
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/portable_atmospherics/hydroponics,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/floor_decal/techfloor/hole/right{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/south)
 "aOM" = (
@@ -22224,13 +22290,24 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/south)
 "aON" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /obj/structure/catwalk,
-/obj/random/junk,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/south)
 "aOO" = (
 /obj/machinery/door/airlock/maintenance/common,
 /obj/machinery/door/firedoor/glass,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor,
 /area/maintenance/lower/south)
 "aOP" = (
@@ -22617,6 +22694,10 @@
 /obj/effect/floor_decal/corner_techfloor_grid{
 	dir = 9
 	},
+/obj/effect/floor_decal/techfloor/hole/right{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/hydroponics,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/south)
 "aPx" = (
@@ -22625,13 +22706,23 @@
 /turf/simulated/floor/plating,
 /area/maintenance/lower/south)
 "aPy" = (
-/obj/effect/floor_decal/rust,
-/obj/structure/catwalk,
 /obj/structure/closet/crate,
 /obj/random/maintenance/clean,
 /obj/random/maintenance/clean,
 /obj/random/maintenance/cargo,
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/corner_techfloor_grid{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner_techfloor_grid{
+	dir = 4
+	},
+/obj/item/weapon/material/minihoe,
+/obj/item/weapon/reagent_containers/glass/bucket,
+/obj/item/seeds/random,
+/obj/item/seeds/random,
+/obj/item/seeds/random,
+/obj/item/seeds/random,
+/turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/south)
 "aPz" = (
 /obj/structure/dogbed,
@@ -22983,7 +23074,6 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/tether/surfacebase/east_stairs_two)
 "aQl" = (
-/obj/effect/floor_decal/rust,
 /obj/effect/floor_decal/corner_techfloor_grid{
 	dir = 9
 	},
@@ -23002,6 +23092,9 @@
 	},
 /obj/effect/floor_decal/corner_techfloor_grid{
 	dir = 10
+	},
+/obj/effect/floor_decal/techfloor/hole/right{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/south)
@@ -23723,6 +23816,9 @@
 	d2 = 8;
 	icon_state = "4-8";
 	pixel_x = 0
+	},
+/obj/effect/floor_decal/corner_techfloor_grid{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/south)
@@ -35560,8 +35656,9 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/substation/medsec)
 "boD" = (
-/turf/simulated/wall/r_wall,
-/area/tether/surfacebase/medical/bathroom)
+/obj/structure/sign/department/chapel,
+/turf/simulated/wall,
+/area/maintenance/lower/bar)
 "boF" = (
 /obj/structure/table/glass,
 /obj/machinery/computer/med_data/laptop{
@@ -35969,18 +36066,55 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/breakroom)
+"czm" = (
+/mob/living/simple_mob/animal/passive/snake/noodle,
+/obj/structure/flora/ausbushes/brflowers,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/grass,
+/area/chapel/main)
 "cJE" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/breakroom)
+"djo" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/machinery/camera/network/civilian,
+/turf/simulated/floor/grass,
+/area/chapel/main)
 "djt" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal,
 /obj/structure/flora/pottedplant,
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/breakroom)
+"dSO" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 1
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/lower/south)
+"dXv" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/power/apc{
+	cell_type = /obj/item/weapon/cell/super;
+	dir = 1;
+	name = "north bump";
+	pixel_y = 24
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	dir = 2;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/chapel/main)
 "ebp" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal,
 /obj/machinery/vending/snack,
@@ -36005,6 +36139,11 @@
 /obj/structure/table/glass,
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/breakroom)
+"kCs" = (
+/mob/living/simple_mob/animal/passive/mouse/white/apple,
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/simulated/floor/grass,
+/area/chapel/main)
 "kPb" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -36037,6 +36176,14 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/tiled/techfloor,
 /area/tether/surfacebase/outside/outside2)
+"llG" = (
+/obj/machinery/space_heater,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/effect/floor_decal/techfloor,
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/lower/bar)
 "lsC" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -36044,6 +36191,10 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/breakroom)
+"lOO" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/grass,
+/area/chapel/main)
 "mnt" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -36065,6 +36216,18 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/tether/surfacebase/surface_two_hall)
+"mUP" = (
+/obj/structure/bed/padded,
+/obj/effect/floor_decal/techfloor,
+/obj/machinery/firealarm{
+	pixel_y = -26
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/lower/bar)
+"mWq" = (
+/obj/structure/catwalk,
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/lower/south)
 "nFT" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -36086,6 +36249,33 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/north)
+"pah" = (
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock{
+	name = "Noodle Office";
+	req_access = list(27)
+	},
+/turf/simulated/floor/tiled/dark,
+/area/chapel/main)
+"pLH" = (
+/obj/effect/floor_decal/corner_techfloor_grid{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner_techfloor_grid{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/lower/south)
+"qpA" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/lower/south)
 "rJc" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal,
 /obj/effect/landmark/start{
@@ -36096,6 +36286,24 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/breakroom)
+"sVf" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/button/windowtint{
+	dir = 1;
+	id = "chaplainpet";
+	name = "interior window tint";
+	pixel_x = -4;
+	pixel_y = 30
+	},
+/turf/simulated/floor/tiled/dark,
+/area/chapel/main)
 "sZp" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -36112,6 +36320,24 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/north)
+"tuO" = (
+/obj/effect/floor_decal/corner_techfloor_grid,
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/lower/south)
+"tED" = (
+/obj/effect/floor_decal/corner_techfloor_grid{
+	dir = 10
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = -25
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/lower/south)
 "tHa" = (
 /obj/structure/railing{
 	dir = 4;
@@ -36120,6 +36346,9 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/mining)
+"tPB" = (
+/turf/simulated/floor/grass,
+/area/chapel/main)
 "unM" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -36161,6 +36390,38 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white,
 /area/maintenance/lower/north)
+"voE" = (
+/obj/effect/floor_decal/corner_techfloor_grid,
+/obj/effect/floor_decal/corner_techfloor_grid{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/lower/south)
+"vTb" = (
+/obj/structure/catwalk,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4;
+	icon_state = "map-scrubbers"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/lower/south)
+"wqU" = (
+/obj/machinery/alarm{
+	pixel_y = 22
+	},
+/obj/effect/floor_decal/corner_techfloor_grid{
+	dir = 5
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/lower/south)
 "xbt" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal,
 /obj/structure/sign/poster{
@@ -44317,7 +44578,7 @@ aeP
 afD
 agv
 ahl
-ahY
+akR
 ajg
 ake
 ali
@@ -46722,8 +46983,8 @@ aab
 aab
 aab
 aab
-aab
-aab
+aac
+aac
 aab
 aab
 ael
@@ -49862,7 +50123,7 @@ any
 akq
 akq
 akq
-boD
+akq
 akq
 akq
 akq
@@ -50004,7 +50265,7 @@ abd
 aoK
 aqd
 asP
-boD
+akq
 boZ
 bpi
 bpI
@@ -50308,11 +50569,11 @@ aBv
 ayl
 aCT
 aDK
-ayl
+aGp
 aET
 aFy
 aGm
-aGO
+aHh
 aHh
 aHy
 aHQ
@@ -50453,9 +50714,9 @@ avD
 avD
 aEU
 aFz
-avD
-avD
-avD
+aDP
+aGo
+aGo
 aDP
 aHR
 aFG
@@ -50595,9 +50856,9 @@ aCU
 aEm
 ard
 aFA
-aGn
+aDP
 aGP
-aGP
+kCs
 aDP
 aHS
 aIx
@@ -50714,10 +50975,10 @@ aar
 aiK
 aiK
 akH
-akR
-akR
-akR
-akR
+aiK
+aiK
+aiK
+aiK
 aiK
 auX
 asV
@@ -50732,15 +50993,15 @@ ard
 aAS
 ard
 aCa
-ato
-ato
+aoZ
+aoZ
 aEn
 ard
 aFA
 aGo
-aGP
-aGP
-aDP
+lOO
+tPB
+aGo
 aHT
 aIy
 aIZ
@@ -50752,8 +51013,8 @@ aLT
 aMK
 aJv
 aNZ
-aOM
-aOM
+mWq
+mWq
 aQm
 aLY
 aRB
@@ -50874,13 +51135,13 @@ ard
 aAT
 ard
 aCb
-aCV
-aCV
+aGR
+aGR
 aEo
 aEV
 aFB
-aGp
-aGP
+aDP
+djo
 aHi
 aDP
 aHU
@@ -50893,10 +51154,10 @@ aLn
 aJU
 aJU
 aJv
-aOa
-aLX
-aPx
-aPx
+wqU
+qpA
+dSO
+tED
 aLY
 aRC
 aPB
@@ -51016,15 +51277,15 @@ ard
 aAU
 ard
 aCc
-aCV
-aCV
+aGR
+aGR
 aEp
 ard
 aFC
 aGo
-aGP
-aGP
-aDP
+tPB
+tPB
+pah
 aHV
 aIA
 aGR
@@ -51035,10 +51296,10 @@ aKF
 aLU
 aML
 aJv
-aLX
+aRC
 aON
-aLX
-aPx
+tuO
+pLH
 aLY
 aRD
 aPB
@@ -51163,11 +51424,11 @@ aDL
 aEq
 ard
 aFC
-aGn
-aGP
-aGP
 aDP
-aHV
+czm
+lOO
+aDP
+sVf
 aIA
 aGR
 aJw
@@ -51177,8 +51438,8 @@ aLo
 aLV
 aMM
 aJv
-aLX
-aLX
+voE
+aON
 aPy
 aLY
 aLY
@@ -51300,16 +51561,16 @@ ard
 aAV
 ard
 ard
-aCX
+aGr
 aDM
 ard
 ard
 aFD
 aDP
+aGo
+aGo
 aDP
-aDP
-aDP
-aHV
+dXv
 aIA
 aGR
 aJv
@@ -51442,7 +51703,7 @@ azV
 aAW
 aBw
 aCe
-aCY
+aDN
 aDN
 aEr
 aEW
@@ -51462,7 +51723,7 @@ aLW
 aMN
 aMN
 aMN
-aMN
+vTb
 aMN
 aQn
 aRa
@@ -51584,10 +51845,10 @@ avL
 aAX
 aBx
 aCf
-aCZ
 aDO
-aCZ
-aCZ
+aDO
+aGs
+aDO
 aFF
 aGr
 aGR
@@ -51727,10 +51988,10 @@ avL
 avb
 ard
 aDa
-aDP
-aDQ
-aDQ
-aFG
+aCV
+ard
+ard
+boD
 aDP
 aGR
 aGR
@@ -51868,9 +52129,9 @@ aAv
 avL
 avb
 ard
-ato
+aoZ
 aDQ
-aEs
+ard
 aEX
 aFH
 aDP
@@ -52011,11 +52272,11 @@ avL
 avb
 ard
 aDb
+aCX
+ard
+aEY
+mUP
 aDP
-aEt
-aEY
-aEY
-aGs
 aGT
 aHj
 aHA
@@ -52153,10 +52414,10 @@ avM
 aBy
 ard
 aDc
-aDP
+aEt
 aEu
 aEZ
-aEs
+llG
 aDP
 aGU
 aHk
@@ -52295,11 +52556,11 @@ aAY
 ard
 ard
 aDd
-aDP
+aGn
 aEs
 aFa
 aFI
-aDQ
+aDP
 aGT
 aHl
 aHB
@@ -52415,7 +52676,7 @@ adi
 ahN
 ajC
 ahN
-aoZ
+ahN
 ahN
 ahN
 ahN
@@ -52437,10 +52698,10 @@ ato
 ard
 ard
 ard
-aDP
-aDP
-aDQ
-aDP
+ard
+ard
+ard
+ard
 aDP
 aGS
 aGT
@@ -52557,7 +52818,7 @@ ajA
 akL
 abb
 anT
-aoZ
+ahN
 arc
 ath
 boL
@@ -52845,7 +53106,7 @@ ahN
 abh
 auL
 ahN
-ard
+ahN
 asi
 ato
 ato
@@ -52987,7 +53248,7 @@ ahN
 abh
 auL
 boL
-ard
+ahN
 asj
 atp
 auf
@@ -53129,7 +53390,7 @@ ahN
 asb
 auM
 boP
-ard
+ahN
 ard
 atq
 atq
@@ -53267,11 +53528,11 @@ ahN
 ahN
 ahN
 ahN
-aoZ
-aoZ
-aoZ
-aoZ
-aac
+ahN
+ahN
+ahN
+ahN
+ahN
 aab
 aab
 aab

--- a/maps/tether/tether-03-surface3.dmm
+++ b/maps/tether/tether-03-surface3.dmm
@@ -3206,9 +3206,6 @@
 /area/tether/surfacebase/surface_three_hall)
 "aeI" = (
 /obj/structure/table/bench/steel,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 5
 	},

--- a/maps/tether/tether-03-surface3.dmm
+++ b/maps/tether/tether-03-surface3.dmm
@@ -9576,6 +9576,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/machinery/light_switch{
+	dir = 4;
+	pixel_x = -28;
+	pixel_y = 26
+	},
 /turf/simulated/floor/wood,
 /area/tether/surfacebase/bar_backroom)
 "api" = (
@@ -13548,6 +13553,13 @@
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/captain)
 "awm" = (
+/obj/machinery/button/remote/airlock{
+	id = "barbackdoor";
+	name = "Back Door Locks";
+	pixel_x = -29;
+	pixel_y = 30;
+	specialfunctions = 4
+	},
 /turf/simulated/floor/wood,
 /area/tether/surfacebase/bar_backroom)
 "awn" = (
@@ -14219,6 +14231,10 @@
 	name = "Bartender"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
 /turf/simulated/floor/wood,
 /area/tether/surfacebase/bar_backroom)
 "axp" = (
@@ -14228,9 +14244,6 @@
 /obj/item/weapon/paper{
 	info = "This permit signifies that the Bartender is permitted to posess this firearm in the bar, and ONLY the bar. Failure to adhere to this permit will result in confiscation of the weapon and possibly arrest.";
 	name = "Shotgun permit"
-	},
-/obj/machinery/light_switch{
-	pixel_x = 25
 	},
 /turf/simulated/floor/wood,
 /area/tether/surfacebase/bar_backroom)
@@ -18577,6 +18590,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
 	},
+/obj/machinery/light_switch{
+	dir = 4;
+	pixel_x = -28
+	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "aEm" = (
@@ -18926,6 +18943,9 @@
 /obj/machinery/chemical_dispenser/bar_soft/full{
 	dir = 8
 	},
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/simulated/floor/lino,
 /area/crew_quarters/bar)
 "aEX" = (
@@ -19005,9 +19025,19 @@
 /turf/simulated/floor/wood,
 /area/library)
 "aFf" = (
-/obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/outdoors/grass/sif/virgo3b,
-/area/tether/surfacebase/outside/outside3)
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/machinery/vending/nifsoft_shop,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/surface_three_hall)
 "aFg" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -19022,11 +19052,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/botanystorage)
-"aFh" = (
-/obj/effect/decal/cleanable/blood,
-/obj/effect/decal/remains/deer,
-/turf/simulated/floor/outdoors/grass/sif/virgo3b,
-/area/tether/surfacebase/outside/outside3)
 "aFi" = (
 /obj/structure/table/glass,
 /obj/machinery/cell_charger,
@@ -31355,6 +31380,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
+/obj/machinery/light_switch{
+	dir = 4;
+	pixel_x = -28;
+	pixel_y = -25
+	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/barrestroom)
 "bbY" = (
@@ -33404,7 +33434,6 @@
 /area/tether/surfacebase/southhall)
 "bfK" = (
 /obj/structure/table/gamblingtable,
-/obj/structure/table/gamblingtable,
 /obj/item/weapon/deck/cards,
 /turf/simulated/floor/tiled/eris/steel/bar_dance,
 /area/tether/surfacebase/barbackmaintenance)
@@ -33518,9 +33547,6 @@
 /obj/structure/table/marble,
 /obj/machinery/chemical_dispenser/bar_alc/full{
 	dir = 8
-	},
-/obj/machinery/light{
-	dir = 4
 	},
 /obj/machinery/light{
 	dir = 1
@@ -33892,6 +33918,7 @@
 /area/tether/surfacebase/servicebackroom)
 "bgJ" = (
 /obj/machinery/door/airlock{
+	id_tag = "barbackdoor";
 	name = "Service";
 	req_access = list(25)
 	},
@@ -33949,10 +33976,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/camera/network/civilian{
 	dir = 4
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
 	},
 /turf/simulated/floor/wood,
 /area/tether/surfacebase/bar_backroom)
@@ -42218,20 +42241,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/lobby)
-"uBR" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 1
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 4
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7,
-/obj/machinery/vending/nifsoft_shop,
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/surface_three_hall)
 "uFI" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -47168,7 +47177,7 @@ aac
 aac
 aac
 aac
-aFf
+aac
 aac
 aac
 aac
@@ -47309,9 +47318,9 @@ aac
 aac
 aac
 aac
-aFf
-aFh
-aFf
+aac
+aac
+aac
 aac
 aac
 aac
@@ -47452,7 +47461,7 @@ aac
 aac
 aac
 aac
-aFf
+aac
 aac
 aac
 aac
@@ -55229,7 +55238,7 @@ agk
 trA
 aUs
 aeG
-uBR
+aFf
 aWL
 aNp
 alj

--- a/maps/tether/tether-03-surface3.dmm
+++ b/maps/tether/tether-03-surface3.dmm
@@ -41041,8 +41041,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/camera/network/security{
-	dir = 10
+/obj/machinery/newscaster/security_unit{
+	pixel_y = -32
 	},
 /turf/simulated/floor/wood,
 /area/tether/surfacebase/security/hos)
@@ -41663,6 +41663,10 @@
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
 	dir = 8
+	},
+/obj/machinery/camera/network/security{
+	dir = 8;
+	icon_state = "camera"
 	},
 /turf/simulated/floor/wood,
 /area/tether/surfacebase/security/hos)

--- a/maps/tether/tether-03-surface3.dmm
+++ b/maps/tether/tether-03-surface3.dmm
@@ -2274,9 +2274,6 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/upperhall)
 "adp" = (
-/obj/machinery/alarm{
-	pixel_y = 22
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -2987,9 +2984,6 @@
 	},
 /obj/structure/cable/green{
 	icon_state = "0-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -3732,9 +3726,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
@@ -3742,6 +3733,9 @@
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/lobby)
@@ -4714,6 +4708,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
+/obj/item/weapon/storage/box/donut,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/lobby)
 "agU" = (
@@ -4735,8 +4730,10 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/hologram/holopad,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/lobby)
 "agW" = (
@@ -5005,6 +5002,9 @@
 	dir = 5
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/lobby)
 "ahv" = (
@@ -42218,6 +42218,20 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/lobby)
+"uBR" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/machinery/vending/nifsoft_shop,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/surface_three_hall)
 "uFI" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -55215,7 +55229,7 @@ agk
 trA
 aUs
 aeG
-aix
+uBR
 aWL
 aNp
 alj

--- a/maps/tether/tether-03-surface3.dmm
+++ b/maps/tether/tether-03-surface3.dmm
@@ -206,8 +206,8 @@
 "aas" = (
 /obj/structure/railing,
 /obj/structure/railing{
-	icon_state = "railing0";
-	dir = 4
+	dir = 4;
+	icon_state = "railing0"
 	},
 /turf/simulated/open/virgo3b,
 /area/tether/surfacebase/outside/outside3)
@@ -716,8 +716,8 @@
 "abd" = (
 /obj/structure/railing,
 /obj/structure/railing{
-	icon_state = "railing0";
-	dir = 4
+	dir = 4;
+	icon_state = "railing0"
 	},
 /turf/simulated/floor/tiled/steel_dirty/virgo3b,
 /area/tether/surfacebase/outside/outside3)
@@ -791,6 +791,9 @@
 	},
 /obj/effect/floor_decal/corner/red/bordercorner2{
 	dir = 4
+	},
+/obj/structure/sign/poster{
+	pixel_x = 32
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/upperhall)
@@ -2049,6 +2052,15 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/red/bordercorner{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/upperhall)
 "ade" = (
@@ -2126,11 +2138,21 @@
 /area/tether/surfacebase/security/iaa/officecommon)
 "adi" = (
 /obj/machinery/door/airlock/glass_security{
-	name = "Front Desk";
-	req_access = list(63);
-	req_one_access = list(63)
+	id_tag = "BrigFoyer";
+	layer = 2.8;
+	name = "Security";
+	req_one_access = list(38,63)
 	},
 /obj/machinery/door/firedoor/glass,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 1
+	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/lobby)
 "adj" = (
@@ -2255,19 +2277,14 @@
 /obj/machinery/alarm{
 	pixel_y = 22
 	},
-/obj/effect/floor_decal/corner/red{
-	dir = 6;
-	icon_state = "corner_white"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/effect/floor_decal/corner/red{
-	dir = 9;
-	icon_state = "corner_white"
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
+/obj/effect/floor_decal/borderfloor{
 	dir = 1
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 6
+/obj/effect/floor_decal/corner/red/border{
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/lobby)
@@ -2645,23 +2662,15 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/upperhall)
 "adT" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/machinery/camera/network/security{
+	dir = 8;
+	icon_state = "camera"
+	},
+/obj/effect/floor_decal/borderfloor{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/effect/floor_decal/corner/red/border{
 	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloor/corner{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/red/bordercorner{
-	dir = 4
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 10
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/upperhall)
@@ -2719,18 +2728,15 @@
 /turf/simulated/wall,
 /area/tether/surfacebase/security/processing)
 "adX" = (
-/obj/structure/bed/chair/office/dark,
-/obj/effect/landmark/start{
-	name = "Security Officer"
-	},
 /obj/machinery/camera/network/security,
-/obj/effect/floor_decal/corner/red{
-	dir = 6;
-	icon_state = "corner_white"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/effect/floor_decal/corner/red{
-	dir = 9;
-	icon_state = "corner_white"
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/lobby)
@@ -2801,22 +2807,17 @@
 	name = "\improper North Medical Stairwell"
 	})
 "aef" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/computer/security{
-	dir = 8
-	},
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/floor_decal/corner/red{
-	dir = 6;
-	icon_state = "corner_white"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/effect/floor_decal/corner/red{
-	dir = 9;
-	icon_state = "corner_white"
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/lobby)
@@ -2933,11 +2934,14 @@
 /obj/machinery/firealarm{
 	pixel_y = 26
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/effect/floor_decal/borderfloor{
-	dir = 9
+	dir = 1
 	},
 /obj/effect/floor_decal/corner/red/border{
-	dir = 9
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/lobby)
@@ -2993,6 +2997,9 @@
 /obj/effect/floor_decal/corner/red/border{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/lobby)
 "aet" = (
@@ -3006,6 +3013,9 @@
 /obj/effect/floor_decal/corner/red/border{
 	dir = 5
 	},
+/obj/structure/sign/poster{
+	pixel_x = 32
+	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/iaa/officecommon)
 "aeu" = (
@@ -3013,6 +3023,7 @@
 	dir = 4;
 	icon_state = "railing0"
 	},
+/obj/structure/railing,
 /turf/simulated/open/virgo3b,
 /area/tether/surfacebase/outside/outside3)
 "aev" = (
@@ -3112,8 +3123,8 @@
 	req_one_access = list(5)
 	},
 /obj/machinery/door/firedoor/multi_tile{
-	icon_state = "door_open";
-	dir = 2
+	dir = 2;
+	icon_state = "door_open"
 	},
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/admin)
@@ -3210,25 +3221,14 @@
 /obj/effect/floor_decal/corner/red/border{
 	dir = 5
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/lobby)
 "aeJ" = (
 /turf/simulated/wall,
-/area/tether/surfacebase/security/lobby)
-"aeK" = (
-/obj/machinery/door/window/brigdoor/eastleft{
-	dir = 2;
-	req_access = list(63)
-	},
-/obj/effect/floor_decal/corner/red{
-	dir = 6;
-	icon_state = "corner_white"
-	},
-/obj/effect/floor_decal/corner/red{
-	dir = 9;
-	icon_state = "corner_white"
-	},
-/turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/lobby)
 "aeL" = (
 /obj/effect/floor_decal/borderfloorwhite,
@@ -3586,24 +3586,19 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/briefingroom)
 "afm" = (
-/obj/structure/table/reinforced,
-/obj/structure/window/reinforced,
-/obj/machinery/button/remote/airlock{
-	id = "BrigFoyer";
-	name = "Brig Foyer";
-	pixel_x = -6;
-	pixel_y = 0;
-	req_access = list(1)
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/effect/floor_decal/corner/red{
-	dir = 6;
-	icon_state = "corner_white"
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
 	},
-/obj/effect/floor_decal/corner/red{
-	dir = 9;
-	icon_state = "corner_white"
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
 	},
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/red/border,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/lobby)
 "afn" = (
@@ -3671,28 +3666,39 @@
 /turf/simulated/floor/tiled,
 /area/rnd/xenobiology/xenoflora_storage)
 "afs" = (
-/obj/structure/table/reinforced,
-/obj/structure/window/reinforced,
-/obj/machinery/door/window/brigdoor/eastleft{
-	req_access = list(63)
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/effect/floor_decal/corner/red{
-	dir = 6;
-	icon_state = "corner_white"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/effect/floor_decal/corner/red{
-	dir = 9;
-	icon_state = "corner_white"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/red/border,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/lobby)
 "aft" = (
-/obj/effect/floor_decal/borderfloor{
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloor/corner{
 	dir = 8
 	},
-/obj/effect/floor_decal/corner/red/border{
-	dir = 8
+/obj/effect/floor_decal/corner/red/bordercorner{
+	dir = 8;
+	icon_state = "bordercolorcorner"
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/lobby)
@@ -3726,24 +3732,32 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/lobby)
 "afw" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
+/obj/effect/floor_decal/borderfloor{
 	dir = 4
 	},
-/obj/effect/floor_decal/borderfloor/corner,
-/obj/effect/floor_decal/corner/red/bordercorner,
-/obj/effect/floor_decal/steeldecal/steel_decals4,
+/obj/effect/floor_decal/corner/red/border{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/red/bordercorner2{
+	dir = 5
+	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/upperhall)
 "afx" = (
@@ -4024,6 +4038,7 @@
 /obj/effect/floor_decal/corner/red/border{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/lobby)
 "afS" = (
@@ -4052,30 +4067,12 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/processing)
 "afV" = (
-/obj/machinery/door/airlock/glass_security{
-	id_tag = "BrigFoyer";
-	layer = 2.8;
-	name = "Security";
-	req_one_access = list(38,63)
+/obj/structure/railing{
+	dir = 4;
+	icon_state = "railing0"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/red/border{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/glass,
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/security/lobby)
+/turf/simulated/open/virgo3b,
+/area/tether/surfacebase/outside/outside3)
 "afW" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 8
@@ -4527,23 +4524,19 @@
 /turf/simulated/floor/tiled,
 /area/rnd/xenobiology/xenoflora_storage)
 "agG" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloor{
+/obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/effect/floor_decal/corner/red/border{
-	dir = 1
+/obj/effect/floor_decal/corner/red{
+	dir = 6;
+	icon_state = "corner_white"
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 1
+/obj/effect/floor_decal/corner/red{
+	dir = 9;
+	icon_state = "corner_white"
+	},
+/obj/machinery/computer/secure_data{
+	pixel_y = -4
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/lobby)
@@ -4655,19 +4648,22 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/iaa/officecommon)
 "agP" = (
+/obj/structure/table/reinforced,
+/obj/effect/floor_decal/corner/red{
+	dir = 6;
+	icon_state = "corner_white"
+	},
+/obj/effect/floor_decal/corner/red{
+	dir = 9;
+	icon_state = "corner_white"
+	},
+/obj/machinery/door/window/brigdoor/eastright{
+	dir = 1
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/red/border{
-	dir = 1
-	},
+/obj/machinery/recharger,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/lobby)
 "agQ" = (
@@ -4700,18 +4696,23 @@
 /turf/simulated/floor/carpet/blue,
 /area/tether/surfacebase/security/breakroom)
 "agT" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/structure/table/reinforced,
+/obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloor{
+/obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/effect/floor_decal/corner/red/border{
-	dir = 1
+/obj/effect/floor_decal/corner/red{
+	dir = 6;
+	icon_state = "corner_white"
+	},
+/obj/effect/floor_decal/corner/red{
+	dir = 9;
+	icon_state = "corner_white"
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/lobby)
@@ -4719,21 +4720,11 @@
 /obj/effect/landmark{
 	name = "lightsout"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/hologram/holopad,
-/obj/effect/floor_decal/borderfloor/corner{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/red/bordercorner{
-	dir = 1
+/obj/effect/floor_decal/corner/red/border{
+	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/lobby)
@@ -4743,15 +4734,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/machinery/hologram/holopad,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/lobby)
 "agW" = (
@@ -4759,12 +4744,15 @@
 	dir = 8;
 	pixel_x = -26
 	},
-/obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/red/border{
 	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/upperhall)
@@ -5004,10 +4992,6 @@
 /area/crew_quarters/panic_shelter)
 "ahu" = (
 /obj/structure/table/bench/steel,
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
 	},
@@ -5020,6 +5004,7 @@
 /obj/effect/floor_decal/corner/red/bordercorner2{
 	dir = 5
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/lobby)
 "ahv" = (
@@ -5053,47 +5038,52 @@
 	name = "Security";
 	req_one_access = list(38,63)
 	},
+/obj/machinery/door/firedoor/glass,
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/red/border,
-/obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/lobby)
 "ahx" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/effect/floor_decal/corner/red{
+	dir = 6;
+	icon_state = "corner_white"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/effect/floor_decal/corner/red{
+	dir = 9;
+	icon_state = "corner_white"
 	},
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/red/border,
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 6
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -22;
+	pixel_y = 0
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/lobby)
 "ahy" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/bed/chair/office/dark,
+/obj/effect/floor_decal/corner/red{
+	dir = 6;
+	icon_state = "corner_white"
 	},
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/red/border,
+/obj/effect/floor_decal/corner/red{
+	dir = 9;
+	icon_state = "corner_white"
+	},
+/obj/effect/landmark/start{
+	name = "Security Officer"
+	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/lobby)
 "ahz" = (
@@ -5102,17 +5092,20 @@
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/admin)
 "ahA" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/computer/security{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment{
+/obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/red/border,
+/obj/effect/floor_decal/corner/red{
+	dir = 6;
+	icon_state = "corner_white"
+	},
+/obj/effect/floor_decal/corner/red{
+	dir = 9;
+	icon_state = "corner_white"
+	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/lobby)
 "ahB" = (
@@ -5138,21 +5131,12 @@
 /area/tether/surfacebase/surface_three_hall)
 "ahC" = (
 /obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/lobby)
 "ahD" = (
@@ -5236,15 +5220,6 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/tether/surfacebase/security/lobby)
 "ahI" = (
-/obj/machinery/door/window/brigdoor/eastleft{
-	dir = 1;
-	req_access = list(63)
-	},
-/obj/machinery/alarm{
-	dir = 4;
-	pixel_x = -22;
-	pixel_y = 0
-	},
 /obj/effect/floor_decal/corner/red{
 	dir = 6;
 	icon_state = "corner_white"
@@ -5252,6 +5227,15 @@
 /obj/effect/floor_decal/corner/red{
 	dir = 9;
 	icon_state = "corner_white"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 6
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/lobby)
@@ -5261,12 +5245,24 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
 /obj/structure/disposalpipe/junction,
 /obj/machinery/hologram/holopad,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/upperhall)
 "ahK" = (
@@ -5387,9 +5383,6 @@
 /area/rnd/workshop)
 "ahV" = (
 /obj/structure/table/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
 /obj/machinery/button/remote/airlock{
 	id = "BrigFoyer";
 	name = "Brig Foyer";
@@ -5408,6 +5401,17 @@
 	dir = 9;
 	icon_state = "corner_white"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/item/weapon/paper_bin{
+	pixel_x = 4;
+	pixel_y = 7
+	},
+/obj/item/weapon/pen/blue{
+	pixel_x = 5;
+	pixel_y = 5
+	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/lobby)
 "ahW" = (
@@ -5424,15 +5428,6 @@
 /area/tether/surfacebase/medical/lobby)
 "ahX" = (
 /obj/structure/table/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/machinery/door/window/brigdoor/eastleft{
-	req_access = list(63)
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
 /obj/effect/floor_decal/corner/red{
 	dir = 6;
 	icon_state = "corner_white"
@@ -5440,6 +5435,19 @@
 /obj/effect/floor_decal/corner/red{
 	dir = 9;
 	icon_state = "corner_white"
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/obj/machinery/door/window/brigdoor/eastright{
+	dir = 8
+	},
+/obj/machinery/door/window/westleft{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/lobby)
@@ -5466,7 +5474,10 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/lobby)
 "aia" = (
@@ -5986,22 +5997,18 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/upperhall)
 "aiP" = (
+/obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
 	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable/green{
-	d1 = 2;
 	d2 = 8;
-	icon_state = "2-8"
+	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/upperhall)
 "aiQ" = (
@@ -6065,6 +6072,8 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
+/obj/item/weapon/book/manual/security_space_law,
+/obj/item/weapon/book/manual/security_space_law,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/tether/surfacebase/security/lobby)
 "aiV" = (
@@ -6610,6 +6619,9 @@
 /obj/effect/floor_decal/corner/red/border{
 	dir = 8
 	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/upperhall)
 "ajO" = (
@@ -6630,17 +6642,9 @@
 	},
 /area/tether/surfacebase/security/lobby)
 "ajP" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/upperhall)
 "ajQ" = (
@@ -6806,8 +6810,8 @@
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/corner/paleblue/full{
-	icon_state = "corner_white_full";
-	dir = 1
+	dir = 1;
+	icon_state = "corner_white_full"
 	},
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/triage)
@@ -7011,8 +7015,8 @@
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/corner/paleblue/full{
-	icon_state = "corner_white_full";
-	dir = 8
+	dir = 8;
+	icon_state = "corner_white_full"
 	},
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/triage)
@@ -7213,6 +7217,11 @@
 /obj/machinery/door/window/southleft{
 	name = "Library Desk Door";
 	req_access = list(37)
+	},
+/obj/machinery/light_switch{
+	dir = 4;
+	on = 0;
+	pixel_x = -24
 	},
 /turf/simulated/floor/carpet,
 /area/library)
@@ -11868,9 +11877,6 @@
 /turf/simulated/floor/grass,
 /area/hydroponics/cafegarden)
 "asZ" = (
-/obj/effect/floor_decal/spline/plain{
-	dir = 8
-	},
 /obj/machinery/light{
 	dir = 1
 	},
@@ -13448,9 +13454,6 @@
 /area/crew_quarters/kitchen)
 "awd" = (
 /obj/machinery/librarycomp,
-/obj/machinery/light/small{
-	dir = 8
-	},
 /obj/structure/table/woodentable,
 /turf/simulated/floor/carpet,
 /area/library)
@@ -13829,20 +13832,13 @@
 /turf/simulated/floor/tiled,
 /area/hallway/lower/third_south)
 "awI" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 10
 	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/red/border{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 5
-	},
-/obj/effect/floor_decal/corner/red/bordercorner2{
-	dir = 5
+/obj/effect/floor_decal/steeldecal/steel_decals4,
+/obj/structure/disposalpipe/junction{
+	dir = 4;
+	icon_state = "pipe-j1"
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/upperhall)
@@ -14206,14 +14202,17 @@
 /turf/simulated/floor/plating,
 /area/rnd/xenobiology/xenoflora)
 "axn" = (
-/obj/effect/floor_decal/spline/plain{
-	dir = 1
+/obj/machinery/door/airlock/glass_security{
+	name = "Front Desk";
+	req_access = list(63);
+	req_one_access = list(63)
 	},
+/obj/machinery/door/firedoor/glass,
 /obj/structure/disposalpipe/segment{
-	dir = 8
+	dir = 4
 	},
-/turf/simulated/floor/tiled/eris/cafe,
-/area/hydroponics)
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/security/lobby)
 "axo" = (
 /obj/structure/bed/chair/comfy,
 /obj/effect/landmark/start{
@@ -14701,27 +14700,38 @@
 /turf/simulated/floor/lino,
 /area/crew_quarters/bar)
 "aya" = (
-/obj/machinery/alarm{
-	dir = 4;
-	pixel_x = -22
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/barrestroom)
+/obj/machinery/space_heater,
+/turf/simulated/floor/tiled/techmaint,
+/area/tether/surfacebase/barbackmaintenance)
 "ayb" = (
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/barrestroom)
+/obj/structure/bed/chair/comfy/beige,
+/turf/simulated/floor/tiled/eris/steel/bar_dance,
+/area/tether/surfacebase/barbackmaintenance)
 "ayc" = (
-/obj/machinery/vending/wallmed1/public{
-	pixel_y = 28
+/obj/structure/cable/green{
+	icon_state = "2-4"
 	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/barrestroom)
+/obj/machinery/button/windowtint{
+	id = "secreet";
+	name = "Window Tint Control";
+	pixel_x = -25;
+	range = 15
+	},
+/turf/simulated/floor/tiled/eris/steel/bar_dance,
+/area/tether/surfacebase/barbackmaintenance)
 "ayd" = (
-/obj/machinery/light/small{
-	dir = 1
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_x = 0;
+	pixel_y = 24
 	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/barrestroom)
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/tiled/eris/steel/bar_dance,
+/area/tether/surfacebase/barbackmaintenance)
 "aye" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -14748,11 +14758,17 @@
 /turf/simulated/wall/r_wall,
 /area/tether/surfacebase/botanystorage)
 "ayh" = (
-/obj/machinery/door/airlock{
-	name = "Unit 3"
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -28
 	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/barrestroom)
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/tether/surfacebase/barbackmaintenance)
 "ayi" = (
 /obj/structure/disposalpipe/sortjunction{
 	name = "Research";
@@ -14973,42 +14989,52 @@
 /turf/simulated/floor/tiled,
 /area/rnd/staircase/thirdfloor)
 "ayC" = (
-/obj/machinery/door/airlock{
-	name = "Unit 2"
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/barrestroom)
-"ayD" = (
-/obj/machinery/door/airlock{
-	name = "Unit 1"
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/barrestroom)
-"ayE" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/recharge_station,
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/barrestroom)
-"ayF" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/structure/toilet{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/barrestroom)
-"ayG" = (
-/obj/effect/floor_decal/spline/plain{
+/obj/effect/floor_decal/borderfloor{
 	dir = 8
 	},
-/obj/effect/floor_decal/spline/plain{
-	dir = 1
+/obj/effect/floor_decal/corner/red/border{
+	dir = 8
 	},
-/turf/simulated/floor/grass,
-/area/hydroponics)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/security/lobby)
+"ayD" = (
+/obj/structure/bed/chair/comfy/beige{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/eris/steel/bar_dance,
+/area/tether/surfacebase/barbackmaintenance)
+"ayE" = (
+/obj/structure/closet/firecloset,
+/turf/simulated/floor/tiled/techmaint,
+/area/tether/surfacebase/barbackmaintenance)
+"ayF" = (
+/obj/machinery/door/airlock/maintenance/common,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/tether/surfacebase/barbackmaintenance)
+"ayG" = (
+/obj/structure/bed/chair/comfy/black{
+	dir = 4
+	},
+/turf/simulated/floor/carpet,
+/area/library)
 "ayH" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/borderfloor{
@@ -15035,17 +15061,28 @@
 /turf/simulated/floor/tiled,
 /area/rnd/research/researchdivision)
 "ayI" = (
-/obj/effect/floor_decal/spline/plain{
-	dir = 1
+/obj/structure/bed/chair/comfy/black{
+	dir = 8
 	},
-/turf/simulated/floor/grass,
-/area/hydroponics)
+/obj/effect/landmark/start{
+	name = "Librarian"
+	},
+/turf/simulated/floor/carpet,
+/area/library)
 "ayJ" = (
-/obj/machinery/light/small{
-	dir = 1
+/obj/structure/sink{
+	pixel_y = 20
 	},
-/turf/simulated/floor/tiled/techmaint,
-/area/tether/surfacebase/barbackmaintenance)
+/obj/structure/mirror{
+	dir = 4;
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/barrestroom)
 "ayK" = (
 /obj/machinery/door/airlock/glass_research{
 	name = "Xenoflora Research";
@@ -15380,9 +15417,6 @@
 	dir = 8
 	},
 /obj/machinery/disposal,
-/obj/machinery/light/small{
-	dir = 4
-	},
 /turf/simulated/floor/wood,
 /area/library)
 "azi" = (
@@ -16051,16 +16085,19 @@
 /turf/simulated/floor/tiled,
 /area/hallway/lower/third_south)
 "aAe" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/techmaint,
-/area/tether/surfacebase/barbackmaintenance)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/barrestroom)
 "aAf" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -16115,36 +16152,23 @@
 /turf/simulated/floor/plating,
 /area/rnd/xenobiology/xenoflora)
 "aAi" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/structure/cable/green{
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/tether/surfacebase/barbackmaintenance)
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/wood,
+/area/library)
 "aAj" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
+/obj/machinery/vending/wallmed1/public{
+	pixel_x = -28
 	},
 /obj/structure/cable/green{
 	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/techmaint,
-/area/tether/surfacebase/barbackmaintenance)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/barrestroom)
 "aAk" = (
 /obj/structure/flora/pottedplant/unusual,
 /obj/machinery/firealarm{
@@ -16304,12 +16328,6 @@
 /obj/item/device/tape,
 /turf/simulated/floor/carpet,
 /area/tether/surfacebase/library/study)
-"aAx" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/tether/surfacebase/barbackmaintenance)
 "aAy" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/paper_bin{
@@ -16321,6 +16339,9 @@
 /turf/simulated/floor/carpet,
 /area/tether/surfacebase/library/study)
 "aAz" = (
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/simulated/floor/carpet,
 /area/library)
 "aAA" = (
@@ -16361,9 +16382,14 @@
 /turf/simulated/floor/plating,
 /area/tether/surfacebase/botanystorage)
 "aAE" = (
-/obj/structure/closet/firecloset,
-/turf/simulated/floor/tiled/techmaint,
-/area/tether/surfacebase/barbackmaintenance)
+/obj/structure/table/woodentable,
+/obj/item/weapon/paper_bin{
+	pixel_x = 1;
+	pixel_y = 9
+	},
+/obj/item/weapon/pen,
+/turf/simulated/floor/carpet,
+/area/library)
 "aAF" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -16850,11 +16876,13 @@
 /turf/simulated/floor/wood,
 /area/library)
 "aBt" = (
-/obj/structure/bed/chair/office/dark,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
+/obj/structure/bed/chair/comfy/black{
+	dir = 4
 	},
-/turf/simulated/floor/wood,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/carpet,
 /area/library)
 "aBu" = (
 /obj/machinery/holoplant,
@@ -16867,8 +16895,12 @@
 /turf/simulated/floor/tiled,
 /area/rnd/outpost/xenobiology/outpost_hallway)
 "aBv" = (
-/obj/structure/bed/chair/office/dark,
-/turf/simulated/floor/wood,
+/obj/structure/table/woodentable,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/item/weapon/paper,
+/turf/simulated/floor/carpet,
 /area/library)
 "aBw" = (
 /obj/machinery/door/firedoor/glass,
@@ -16974,9 +17006,6 @@
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
 "aBE" = (
-/obj/effect/floor_decal/spline/plain{
-	dir = 1
-	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -17422,8 +17451,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/rnd/outpost/xenobiology/outpost_hallway)
 "aCn" = (
-/obj/machinery/portable_atmospherics/powered/pump/filled,
-/turf/simulated/floor/tiled/techmaint,
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_x = 0
+	},
+/turf/simulated/floor/tiled/eris/steel/bar_dance,
 /area/tether/surfacebase/barbackmaintenance)
 "aCo" = (
 /obj/structure/grille,
@@ -17627,21 +17659,25 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_three_hall)
 "aCF" = (
-/obj/machinery/light/small{
+/obj/structure/bed/chair/comfy/black{
+	dir = 8
+	},
+/obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/carpet,
 /area/library)
 "aCG" = (
 /obj/machinery/bookbinder,
-/obj/machinery/light/small{
-	dir = 8
-	},
 /turf/simulated/floor/wood,
 /area/library)
 "aCH" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
+	},
+/obj/structure/table/woodentable,
+/obj/machinery/photocopier/faxmachine{
+	department = "Library Conference Room"
 	},
 /turf/simulated/floor/wood,
 /area/library)
@@ -18621,14 +18657,9 @@
 "aEu" = (
 /obj/structure/table/woodentable,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
+	dir = 4
 	},
-/obj/item/weapon/tape_roll,
-/obj/item/device/flashlight/lamp/green{
-	pixel_x = 1;
-	pixel_y = 5
-	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/carpet,
 /area/library)
 "aEv" = (
 /obj/structure/disposalpipe/segment{
@@ -18696,13 +18727,13 @@
 /turf/simulated/floor/tiled/dark,
 /area/rnd/outpost/xenobiology/outpost_hallway)
 "aEz" = (
-/obj/structure/table/woodentable,
-/obj/item/weapon/packageWrap,
-/obj/item/weapon/paper_bin{
-	pixel_x = 1;
-	pixel_y = 9
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/turf/simulated/floor/wood,
+/obj/structure/bed/chair/office/dark{
+	dir = 8
+	},
+/turf/simulated/floor/carpet,
 /area/library)
 "aEA" = (
 /obj/structure/railing{
@@ -18718,23 +18749,31 @@
 /turf/simulated/floor/grass,
 /area/hydroponics)
 "aEC" = (
-/obj/structure/bed/chair/office/dark{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/bookcase{
+	name = "bookcase (Adult)"
 	},
 /turf/simulated/floor/wood,
 /area/library)
 "aED" = (
-/obj/structure/table/woodentable,
-/obj/machinery/photocopier/faxmachine{
-	department = "Library Conference Room"
+/obj/structure/bookcase{
+	name = "bookcase (Fiction)"
 	},
+/obj/item/weapon/book/custom_library/fiction/blacksmithandkinglybloke,
+/obj/item/weapon/book/custom_library/fiction/irishairmanforseesdeath,
+/obj/item/weapon/book/custom_library/fiction/myrock,
+/obj/item/weapon/book/custom_library/fiction/starsandsometimesfallingones,
+/obj/item/weapon/book/custom_library/fiction/truelovehathmyheart,
 /turf/simulated/floor/wood,
 /area/library)
 "aEE" = (
-/obj/structure/table/woodentable,
-/obj/item/device/flashlight/lamp/green{
-	pixel_x = 1;
-	pixel_y = 5
+/obj/structure/bookcase{
+	name = "bookcase (Adult)"
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
 	},
 /turf/simulated/floor/wood,
 /area/library)
@@ -18743,42 +18782,33 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/botanystorage)
 "aEG" = (
-/obj/structure/bed/chair/comfy/black{
-	dir = 4
-	},
+/obj/structure/bed/chair/office/dark,
 /turf/simulated/floor/carpet,
 /area/library)
 "aEH" = (
-/obj/structure/table/woodentable,
-/obj/item/weapon/paper,
-/obj/item/weapon/pen,
-/obj/item/weapon/book/codex,
-/turf/simulated/floor/carpet,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/bookcase/bookcart,
+/turf/simulated/floor/wood,
 /area/library)
 "aEI" = (
-/obj/structure/bed/chair/comfy/black{
-	dir = 8
+/obj/structure/bookcase{
+	name = "bookcase (Non-Fiction)"
 	},
-/turf/simulated/floor/carpet,
+/obj/item/weapon/book/codex/lore/robutt,
+/obj/item/weapon/book/codex,
+/obj/item/weapon/book/custom_library/nonfiction/freesirisailightbulbs,
+/turf/simulated/floor/wood,
 /area/library)
 "aEJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/hologram/holopad,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
-	},
-/turf/simulated/floor/wood,
-/area/library)
-"aEK" = (
-/obj/structure/table/woodentable,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
 	},
 /turf/simulated/floor/wood,
 /area/library)
@@ -18832,28 +18862,13 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/botanystorage)
-"aEO" = (
-/obj/item/weapon/dice/d20,
-/obj/item/weapon/dice,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/table/woodentable,
-/turf/simulated/floor/wood,
-/area/library)
 "aEP" = (
-/obj/structure/bed/chair/comfy/black{
-	dir = 4
-	},
-/obj/effect/landmark/start{
-	name = "Librarian"
+/obj/structure/bed/chair/office/dark{
+	dir = 8
 	},
 /turf/simulated/floor/carpet,
 /area/library)
 "aEQ" = (
-/obj/structure/table/woodentable,
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "east bump";
@@ -18862,27 +18877,16 @@
 /obj/structure/cable/green{
 	icon_state = "0-8"
 	},
-/obj/machinery/recharger,
 /turf/simulated/floor/wood,
 /area/library)
 "aER" = (
-/obj/structure/bookcase{
-	name = "bookcase (Reference)"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/item/weapon/book/manual/anomaly_spectroscopy,
-/obj/item/weapon/book/manual/anomaly_testing,
-/obj/item/weapon/book/manual/atmospipes,
-/obj/item/weapon/book/manual/barman_recipes,
-/obj/item/weapon/book/manual/chef_recipes,
-/obj/item/weapon/book/manual/command_guide,
-/obj/item/weapon/book/manual/detective,
-/obj/item/weapon/book/manual/engineering_construction,
-/obj/item/weapon/book/manual/engineering_guide,
-/obj/item/weapon/book/manual/engineering_particle_accelerator,
-/obj/item/weapon/book/manual/engineering_singularity_safety,
-/obj/item/weapon/book/manual/evaguide,
-/obj/item/weapon/book/manual/excavation,
-/turf/simulated/floor/wood,
+/obj/structure/bed/chair/office/dark{
+	dir = 1
+	},
+/turf/simulated/floor/carpet,
 /area/library)
 "aES" = (
 /obj/structure/table/standard,
@@ -18903,30 +18907,16 @@
 /turf/simulated/floor/lino,
 /area/crew_quarters/bar)
 "aEU" = (
-/obj/structure/bookcase{
-	name = "bookcase (Reference)"
-	},
-/obj/item/weapon/book/manual/hydroponics_pod_people,
-/obj/item/weapon/book/manual/mass_spectrometry,
-/obj/item/weapon/book/manual/materials_chemistry_analysis,
-/obj/item/weapon/book/manual/medical_cloning,
-/obj/item/weapon/book/manual/medical_diagnostics_manual,
-/obj/item/weapon/book/manual/research_and_development,
-/obj/item/weapon/book/manual/resleeving,
-/obj/item/weapon/book/manual/ripley_build_and_repair,
-/obj/item/weapon/book/manual/robotics_cyborgs,
-/obj/item/weapon/book/manual/rust_engine,
-/obj/item/weapon/book/manual/security_space_law,
-/obj/item/weapon/book/manual/standard_operating_procedure,
-/obj/item/weapon/book/manual/stasis,
-/obj/item/weapon/book/manual/supermatter_engine,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/carpet,
 /area/library)
 "aEV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
-/turf/simulated/floor/wood,
+/obj/structure/bed/chair/office/dark{
+	dir = 1
+	},
+/turf/simulated/floor/carpet,
 /area/library)
 "aEW" = (
 /obj/effect/floor_decal/spline/plain{
@@ -18948,9 +18938,6 @@
 /turf/simulated/floor/grass,
 /area/hydroponics)
 "aEY" = (
-/obj/effect/floor_decal/spline/plain{
-	dir = 8
-	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -18988,9 +18975,6 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/botanystorage)
 "aFc" = (
-/obj/structure/bed/chair/office/dark{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -19002,17 +18986,22 @@
 /turf/simulated/floor/wood,
 /area/library)
 "aFd" = (
-/obj/structure/table/woodentable,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/item/weapon/folder/yellow,
-/obj/item/weapon/pen,
+/obj/structure/bookcase{
+	name = "bookcase (Religious)"
+	},
+/obj/item/weapon/book/custom_library/religious/feastofkubera,
+/obj/item/weapon/book/custom_library/religious/storyoflordganesha,
+/obj/item/weapon/book/custom_library/religious/sungoddessofkorea,
+/obj/item/weapon/book/custom_library/religious/wayofbleedingswan,
 /turf/simulated/floor/wood,
 /area/library)
 "aFe" = (
-/obj/structure/table/woodentable,
-/obj/item/weapon/deck/cards,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/wood,
 /area/library)
 "aFf" = (
@@ -19123,12 +19112,8 @@
 /turf/simulated/floor/tiled,
 /area/rnd/research/researchdivision)
 "aFn" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
-/obj/machinery/alarm{
-	dir = 4;
-	pixel_x = -22
+/obj/machinery/light{
+	dir = 8
 	},
 /turf/simulated/floor/wood,
 /area/library)
@@ -19178,16 +19163,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/outpost/xenobiology/outpost_north_airlock)
-"aFq" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/tether/surfacebase/barbackmaintenance)
 "aFr" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -19197,36 +19172,27 @@
 /turf/simulated/floor/wood,
 /area/library)
 "aFs" = (
-/obj/structure/bed/chair/office/dark{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/carpet,
 /area/library)
 "aFt" = (
-/obj/structure/bookcase{
-	name = "bookcase (Fiction)"
-	},
-/obj/machinery/light/small{
-	dir = 8
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -22
 	},
 /turf/simulated/floor/wood,
 /area/library)
 "aFu" = (
-/obj/structure/bookcase{
-	name = "bookcase (Fiction)"
-	},
-/turf/simulated/floor/wood,
-/area/library)
-"aFv" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/structure/bed/chair/office/dark{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/techmaint,
-/area/tether/surfacebase/barbackmaintenance)
+/obj/effect/landmark/start{
+	name = "Librarian"
+	},
+/turf/simulated/floor/carpet,
+/area/library)
 "aFw" = (
 /obj/structure/closet/crate,
 /obj/item/target,
@@ -19255,20 +19221,10 @@
 	name = "\improper Surface Civilian Substation"
 	})
 "aFy" = (
-/obj/machinery/light/small{
+/obj/structure/bed/chair/comfy/beige{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/tiled/techmaint,
+/turf/simulated/floor/tiled/eris/steel/bar_dance,
 /area/tether/surfacebase/barbackmaintenance)
 "aFz" = (
 /obj/structure/cable/green{
@@ -19280,19 +19236,10 @@
 /turf/simulated/floor/grass,
 /area/hydroponics/cafegarden)
 "aFA" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 8
+/obj/structure/bed/chair/comfy/beige{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/techmaint,
+/turf/simulated/floor/tiled/eris/steel/bar_light,
 /area/tether/surfacebase/barbackmaintenance)
 "aFB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -19561,10 +19508,8 @@
 /turf/simulated/floor/tiled,
 /area/rnd/research/researchdivision)
 "aFU" = (
-/obj/structure/bookcase{
-	name = "bookcase (Religious)"
-	},
-/turf/simulated/floor/wood,
+/obj/structure/table/woodentable,
+/turf/simulated/floor/carpet,
 /area/library)
 "aFV" = (
 /obj/structure/cable/green,
@@ -19934,22 +19879,35 @@
 /area/tether/surfacebase/surface_three_hall)
 "aGw" = (
 /obj/structure/bookcase{
-	name = "bookcase (Non-Fiction)"
+	name = "bookcase (Reference)"
 	},
-/obj/item/weapon/book/codex/lore/robutt,
+/obj/item/weapon/book/manual/hydroponics_pod_people,
+/obj/item/weapon/book/manual/mass_spectrometry,
+/obj/item/weapon/book/manual/materials_chemistry_analysis,
+/obj/item/weapon/book/manual/medical_cloning,
+/obj/item/weapon/book/manual/medical_diagnostics_manual,
+/obj/item/weapon/book/manual/research_and_development,
+/obj/item/weapon/book/manual/resleeving,
+/obj/item/weapon/book/manual/ripley_build_and_repair,
+/obj/item/weapon/book/manual/robotics_cyborgs,
+/obj/item/weapon/book/manual/rust_engine,
+/obj/item/weapon/book/manual/security_space_law,
+/obj/item/weapon/book/manual/standard_operating_procedure,
+/obj/item/weapon/book/manual/stasis,
+/obj/item/weapon/book/manual/supermatter_engine,
 /turf/simulated/floor/wood,
 /area/library)
 "aGx" = (
-/obj/structure/bed/chair/office/dark{
-	dir = 4
+/obj/structure/sink{
+	pixel_y = 20
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/mirror{
+	dir = 4;
+	pixel_x = 0;
+	pixel_y = 32
 	},
-/turf/simulated/floor/wood,
-/area/library)
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/barrestroom)
 "aGy" = (
 /obj/structure/railing,
 /obj/structure/grille,
@@ -20216,8 +20174,15 @@
 /turf/simulated/floor/tiled,
 /area/hallway/lower/third_south)
 "aGY" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
+/obj/item/weapon/tape_roll,
+/obj/item/weapon/packageWrap,
+/obj/item/weapon/dice,
+/obj/item/weapon/dice/d20,
+/obj/item/weapon/deck/cards,
+/obj/item/weapon/folder/yellow,
+/obj/structure/closet/walllocker_double{
+	dir = 8;
+	pixel_x = -28
 	},
 /turf/simulated/floor/wood,
 /area/library)
@@ -20280,16 +20245,21 @@
 /turf/simulated/floor/tiled,
 /area/hallway/lower/third_south)
 "aHc" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/structure/bed/chair/office/dark{
 	dir = 4
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/carpet,
 /area/library)
 "aHd" = (
 /obj/machinery/newscaster{
 	pixel_y = 28
 	},
-/turf/simulated/floor/wood,
+/obj/structure/table/woodentable,
+/obj/item/device/flashlight/lamp/green{
+	pixel_x = 1;
+	pixel_y = 5
+	},
+/turf/simulated/floor/carpet,
 /area/library)
 "aHe" = (
 /obj/structure/table/woodentable,
@@ -20313,8 +20283,22 @@
 /area/hallway/lower/third_south)
 "aHg" = (
 /obj/structure/bookcase{
-	name = "bookcase (Non-Fiction)"
+	name = "bookcase (Reference)"
 	},
+/obj/item/weapon/book/manual/anomaly_spectroscopy,
+/obj/item/weapon/book/manual/anomaly_testing,
+/obj/item/weapon/book/manual/atmospipes,
+/obj/item/weapon/book/manual/barman_recipes,
+/obj/item/weapon/book/manual/chef_recipes,
+/obj/item/weapon/book/manual/command_guide,
+/obj/item/weapon/book/manual/detective,
+/obj/item/weapon/book/manual/engineering_construction,
+/obj/item/weapon/book/manual/engineering_guide,
+/obj/item/weapon/book/manual/engineering_particle_accelerator,
+/obj/item/weapon/book/manual/engineering_singularity_safety,
+/obj/item/weapon/book/manual/evaguide,
+/obj/item/weapon/book/manual/excavation,
+/obj/item/weapon/book/custom_library/reference/fistfulofd6splayersguide,
 /turf/simulated/floor/wood,
 /area/library)
 "aHh" = (
@@ -20555,31 +20539,11 @@
 /turf/simulated/floor/carpet/turcarpet,
 /area/crew_quarters/bar)
 "aHC" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/spiderling_remains,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/machinery/light/small{
 	dir = 4
 	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/techmaint,
+/turf/simulated/floor/tiled/eris/steel/bar_dance,
 /area/tether/surfacebase/barbackmaintenance)
-"aHD" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 11
-	},
-/obj/structure/mirror{
-	pixel_x = 27
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/barrestroom)
 "aHE" = (
 /obj/structure/window/basic/full,
 /obj/structure/grille,
@@ -20643,12 +20607,6 @@
 	},
 /obj/effect/floor_decal/corner/red/border{
 	dir = 4
-	},
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 5
-	},
-/obj/effect/floor_decal/corner/red/bordercorner2{
-	dir = 5
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/upperhall)
@@ -20971,19 +20929,16 @@
 /area/hallway/lower/third_south)
 "aId" = (
 /obj/effect/floor_decal/industrial/warning,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/generic,
+/obj/structure/railing{
+	dir = 1;
+	icon_state = "railing0"
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/tether/surfacebase/barbackmaintenance)
 "aIe" = (
-/obj/structure/railing{
-	dir = 4
-	},
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/generic,
 /turf/simulated/floor/tiled/techmaint,
 /area/tether/surfacebase/barbackmaintenance)
 "aIf" = (
@@ -21268,9 +21223,7 @@
 /turf/simulated/floor/tiled,
 /area/hallway/lower/third_south)
 "aIE" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/photocopier,
 /turf/simulated/floor/wood,
 /area/library)
 "aIF" = (
@@ -22939,7 +22892,11 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/rnd/outpost/xenobiology/outpost_storage)
 "aLP" = (
-/obj/machinery/camera/network/civilian,
+/obj/structure/table/woodentable,
+/obj/item/device/flashlight/lamp/green{
+	pixel_x = 1;
+	pixel_y = 5
+	},
 /turf/simulated/floor/wood,
 /area/library)
 "aLQ" = (
@@ -24976,11 +24933,19 @@
 /turf/simulated/floor/tiled/dark,
 /area/rnd/outpost/xenobiology/outpost_main)
 "aQf" = (
-/obj/machinery/camera/network/outside{
-	dir = 6
+/obj/structure/sink{
+	pixel_y = 20
 	},
-/turf/simulated/floor/outdoors/grass/sif/virgo3b,
-/area/tether/surfacebase/outside/outside3)
+/obj/structure/mirror{
+	dir = 4;
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/barrestroom)
 "aQg" = (
 /obj/machinery/vending/cola{
 	dir = 4
@@ -26233,11 +26198,6 @@
 	dir = 4;
 	pixel_x = 26
 	},
-/obj/machinery/light_switch{
-	dir = 1;
-	pixel_x = 2;
-	pixel_y = -28
-	},
 /obj/machinery/librarypubliccomp,
 /obj/structure/table/woodentable,
 /turf/simulated/floor/wood,
@@ -26692,15 +26652,8 @@
 /turf/simulated/floor/tiled/dark,
 /area/rnd/outpost/xenobiology/outpost_south_airlock)
 "aTE" = (
-/obj/structure/table/woodentable,
-/obj/effect/floor_decal/spline/plain{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
-/turf/simulated/floor/grass,
-/area/hydroponics)
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/barrestroom)
 "aTF" = (
 /obj/structure/closet/crate/plastic,
 /obj/structure/disposalpipe/segment{
@@ -26756,8 +26709,8 @@
 	},
 /obj/item/weapon/pen,
 /obj/item/device/flashlight/lamp/green{
-	pixel_y = 14;
-	pixel_x = 10
+	pixel_x = 10;
+	pixel_y = 14
 	},
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/lobby)
@@ -26978,6 +26931,11 @@
 /obj/effect/floor_decal/corner/red/border{
 	dir = 8
 	},
+/obj/item/weapon/paper_bin{
+	pixel_x = 4;
+	pixel_y = 7
+	},
+/obj/item/weapon/pen,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/upperhall)
 "aUj" = (
@@ -27117,7 +27075,13 @@
 	dir = 9;
 	pixel_y = 0
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/upperhall)
 "aUy" = (
@@ -27688,14 +27652,11 @@
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/surgery2)
 "aVw" = (
-/obj/effect/floor_decal/spline/plain{
+/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
-/turf/simulated/floor/grass,
-/area/hydroponics)
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/barrestroom)
 "aVx" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -27737,17 +27698,20 @@
 /turf/simulated/floor/grass,
 /area/hydroponics)
 "aVC" = (
-/obj/structure/bed/chair/wood{
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -22
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 1
 	},
-/obj/effect/floor_decal/spline/plain{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
-/turf/simulated/floor/grass,
-/area/hydroponics)
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/barrestroom)
 "aVD" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
@@ -27831,6 +27795,10 @@
 	},
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/red/border,
+/obj/structure/sign/poster{
+	pixel_x = 0;
+	pixel_y = -32
+	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/upperhall)
 "aVN" = (
@@ -28590,8 +28558,8 @@
 /turf/simulated/floor/tiled,
 /area/hallway/lower/third_south)
 "aXf" = (
-/obj/structure/bookcase{
-	name = "bookcase (Adult)"
+/obj/machinery/camera/network/civilian{
+	dir = 1
 	},
 /turf/simulated/floor/wood,
 /area/library)
@@ -28676,9 +28644,6 @@
 /turf/simulated/floor/tiled,
 /area/hallway/lower/third_south)
 "aXo" = (
-/obj/structure/bed/chair/office/dark{
-	dir = 4
-	},
 /obj/structure/cable/green{
 	icon_state = "2-4"
 	},
@@ -28798,7 +28763,6 @@
 /obj/structure/closet/hydrant{
 	pixel_x = 32
 	},
-/obj/structure/bookcase/bookcart,
 /turf/simulated/floor/wood,
 /area/library)
 "aXx" = (
@@ -28883,16 +28847,10 @@
 /turf/simulated/floor/plating,
 /area/bridge)
 "aXC" = (
-/obj/structure/bed/chair/office/dark{
-	dir = 8
-	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
-	},
-/obj/effect/landmark/start{
-	name = "Librarian"
 	},
 /turf/simulated/floor/wood,
 /area/library)
@@ -29724,9 +29682,6 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/outpost/xenobiology/outpost_first_aid)
 "aZg" = (
-/obj/effect/floor_decal/spline/plain{
-	dir = 8
-	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -30084,9 +30039,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
 "aZJ" = (
-/obj/effect/floor_decal/spline/plain{
-	dir = 8
-	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 8;
@@ -30821,9 +30773,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_three_hall)
-"baR" = (
-/turf/simulated/floor/tiled/techmaint,
-/area/tether/surfacebase/barbackmaintenance)
 "baS" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/window/reinforced/full,
@@ -31395,26 +31344,19 @@
 /turf/simulated/floor/lino,
 /area/crew_quarters/bar)
 "bbW" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/green{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
-/turf/simulated/floor/tiled/techmaint,
-/area/tether/surfacebase/barbackmaintenance)
-"bbX" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/techmaint,
-/area/tether/surfacebase/barbackmaintenance)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/barrestroom)
 "bbY" = (
 /obj/effect/floor_decal/spline/plain,
 /obj/item/weapon/stool/padded,
@@ -31477,16 +31419,8 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bcd" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -28
-	},
-/obj/structure/cable/green{
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/barrestroom)
+/turf/simulated/floor/tiled/techmaint,
+/area/tether/surfacebase/barbackmaintenance)
 "bce" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -32374,14 +32308,6 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/wood,
 /area/tether/surfacebase/entertainment)
-"bdz" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/tether/surfacebase/barbackmaintenance)
 "bdA" = (
 /obj/structure/lattice,
 /turf/simulated/open,
@@ -32473,19 +32399,17 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bdK" = (
-/obj/structure/railing{
-	dir = 4
-	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/tether/surfacebase/barbackmaintenance)
 "bdL" = (
-/obj/machinery/floodlight,
-/turf/simulated/floor/tiled/techmaint,
-/area/tether/surfacebase/barbackmaintenance)
+/obj/machinery/door/airlock{
+	name = "Unit 1"
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/barrestroom)
 "bdM" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -32496,10 +32420,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
-"bdN" = (
-/obj/machinery/portable_atmospherics/powered/scrubber,
-/turf/simulated/floor/tiled/techmaint,
-/area/tether/surfacebase/barbackmaintenance)
 "bdO" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/packageWrap,
@@ -32576,87 +32496,45 @@
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/freezer)
-"bdU" = (
-/obj/machinery/firealarm{
-	layer = 3.3;
-	pixel_y = 26
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/barrestroom)
 "bdV" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/barrestroom)
-"bdW" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/techmaint,
+/turf/simulated/floor/tiled/eris/steel/bar_dance,
 /area/tether/surfacebase/barbackmaintenance)
-"bdX" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
+"bdZ" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/techmaint,
-/area/tether/surfacebase/barbackmaintenance)
-"bdY" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/barrestroom)
-"bdZ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/barrestroom)
-"bea" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/barrestroom)
-"beb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/barrestroom)
-"bec" = (
 /obj/machinery/light/small{
-	dir = 1
+	dir = 8;
+	pixel_x = 0
 	},
-/obj/machinery/space_heater,
-/turf/simulated/floor/tiled/techmaint,
+/turf/simulated/floor/tiled/eris/steel/bar_dance,
+/area/tether/surfacebase/barbackmaintenance)
+"bea" = (
+/turf/simulated/floor/tiled/eris/steel/bar_dance,
+/area/tether/surfacebase/barbackmaintenance)
+"beb" = (
+/obj/structure/bed/chair/comfy/beige,
+/turf/simulated/floor/tiled/eris/steel/bar_light,
+/area/tether/surfacebase/barbackmaintenance)
+"bec" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/polarized/full{
+	id = "secreet";
+	name = "Tintable Window"
+	},
+/obj/structure/window/reinforced/polarized{
+	id = "secreet";
+	name = "Tintable Window"
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/plating,
 /area/tether/surfacebase/barbackmaintenance)
 "bed" = (
 /obj/structure/disposalpipe/segment,
@@ -32680,21 +32558,21 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bef" = (
+/obj/structure/toilet{
+	dir = 8
+	},
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/eris/steel/bar_dance,
-/area/tether/surfacebase/barbackmaintenance)
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/barrestroom)
 "beg" = (
-/obj/structure/bed/chair/comfy/beige,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_y = 0
 	},
-/turf/simulated/floor/tiled/eris/steel/bar_dance,
-/area/tether/surfacebase/barbackmaintenance)
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/barrestroom)
 "beh" = (
 /obj/machinery/newscaster{
 	pixel_y = -28
@@ -32712,17 +32590,17 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bei" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -28
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/cable/green,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 1
 	},
-/turf/simulated/floor/tiled/eris/steel/bar_dance,
-/area/tether/surfacebase/barbackmaintenance)
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/barrestroom)
 "bej" = (
 /obj/effect/floor_decal/corner/grey/diagonal,
 /obj/structure/disposalpipe/segment{
@@ -32749,36 +32627,50 @@
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
 "bel" = (
-/obj/structure/bed/chair/comfy/beige{
-	dir = 4
+/obj/machinery/door/airlock{
+	name = "Unit 2"
 	},
-/turf/simulated/floor/tiled/eris/steel/bar_light,
-/area/tether/surfacebase/barbackmaintenance)
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/barrestroom)
 "bem" = (
-/obj/structure/table/gamblingtable,
-/turf/simulated/floor/tiled/eris/steel/bar_dance,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techmaint,
 /area/tether/surfacebase/barbackmaintenance)
 "ben" = (
-/obj/structure/table/gamblingtable,
-/obj/item/weapon/storage/pill_bottle/dice,
-/turf/simulated/floor/tiled/eris/steel/bar_dance,
-/area/tether/surfacebase/barbackmaintenance)
-"beo" = (
-/obj/structure/bed/chair/comfy/beige{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/eris/steel/bar_light,
-/area/tether/surfacebase/barbackmaintenance)
-"bep" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	icon_state = "2-4"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
 	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/turf/simulated/floor/tiled/eris/steel/bar_dance,
+/area/tether/surfacebase/barbackmaintenance)
+"beo" = (
+/obj/structure/table/gamblingtable,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/eris/steel/bar_dance,
+/area/tether/surfacebase/barbackmaintenance)
+"bep" = (
+/obj/structure/table/gamblingtable,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/item/weapon/storage/pill_bottle/dice,
 /turf/simulated/floor/tiled/eris/steel/bar_dance,
 /area/tether/surfacebase/barbackmaintenance)
 "beq" = (
@@ -33301,9 +33193,7 @@
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
 "bfo" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
+/obj/structure/table/gamblingtable,
 /turf/simulated/floor/tiled/eris/steel/bar_dance,
 /area/tether/surfacebase/barbackmaintenance)
 "bfp" = (
@@ -33414,46 +33304,63 @@
 /area/hallway/lower/third_south)
 "bfz" = (
 /obj/structure/bed/chair/comfy/beige{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/eris/steel/bar_dance,
-/area/tether/surfacebase/barbackmaintenance)
-"bfA" = (
-/obj/structure/table/gamblingtable,
-/obj/item/weapon/storage/pill_bottle/dice_nerd,
-/turf/simulated/floor/tiled/eris/steel/bar_dance,
-/area/tether/surfacebase/barbackmaintenance)
-"bfB" = (
-/obj/structure/bed/chair/wood,
-/turf/simulated/floor/tiled/eris/steel/bar_dance,
-/area/tether/surfacebase/barbackmaintenance)
-"bfC" = (
-/obj/structure/table/gamblingtable,
-/obj/item/weapon/deck/cards,
-/turf/simulated/floor/tiled/eris/steel/bar_dance,
-/area/tether/surfacebase/barbackmaintenance)
-"bfD" = (
-/obj/structure/bed/chair/comfy/beige{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/eris/steel/bar_dance,
 /area/tether/surfacebase/barbackmaintenance)
-"bfE" = (
-/obj/machinery/light/small,
+"bfA" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/barrestroom)
-"bfF" = (
-/turf/simulated/floor/tiled/eris/steel/bar_dance,
-/area/tether/surfacebase/barbackmaintenance)
-"bfG" = (
+"bfB" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/barrestroom)
+"bfC" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
 	},
 /obj/structure/cable/green{
 	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d2 = 4;
+	icon_state = "1-4"
 	},
+/turf/simulated/floor/tiled/techmaint,
+/area/tether/surfacebase/barbackmaintenance)
+"bfD" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled/eris/steel/bar_dance,
+/area/tether/surfacebase/barbackmaintenance)
+"bfE" = (
+/obj/structure/bed/chair/wood,
+/turf/simulated/floor/tiled/eris/steel/bar_dance,
+/area/tether/surfacebase/barbackmaintenance)
+"bfF" = (
+/obj/structure/bed/chair/comfy/beige{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/eris/steel/bar_dance,
+/area/tether/surfacebase/barbackmaintenance)
+"bfG" = (
+/obj/structure/table/gamblingtable,
+/obj/item/weapon/storage/pill_bottle/dice_nerd,
 /turf/simulated/floor/tiled/eris/steel/bar_dance,
 /area/tether/surfacebase/barbackmaintenance)
 "bfH" = (
@@ -33496,7 +33403,9 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/southhall)
 "bfK" = (
-/obj/machinery/light/small,
+/obj/structure/table/gamblingtable,
+/obj/structure/table/gamblingtable,
+/obj/item/weapon/deck/cards,
 /turf/simulated/floor/tiled/eris/steel/bar_dance,
 /area/tether/surfacebase/barbackmaintenance)
 "bfL" = (
@@ -33510,23 +33419,18 @@
 /turf/simulated/floor/plating,
 /area/tether/surfacebase/servicebackroom)
 "bfM" = (
-/obj/structure/bed/chair/comfy/beige{
+/obj/machinery/door/airlock{
+	name = "Unit 3"
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/barrestroom)
+"bfN" = (
+/obj/machinery/recharge_station,
+/obj/machinery/light/small{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/eris/steel/bar_dance,
-/area/tether/surfacebase/barbackmaintenance)
-"bfN" = (
-/obj/machinery/power/apc{
-	cell_type = /obj/item/weapon/cell/super;
-	dir = 8;
-	name = "west bump";
-	pixel_x = -30
-	},
-/obj/structure/cable/green{
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/tiled/eris/steel/bar_dance,
-/area/tether/surfacebase/barbackmaintenance)
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/barrestroom)
 "bfO" = (
 /obj/effect/floor_decal/spline/plain{
 	dir = 9
@@ -33539,22 +33443,17 @@
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
 "bfP" = (
-/obj/structure/bed/chair/comfy/beige{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/eris/steel/bar_light,
+/obj/machinery/portable_atmospherics/powered/pump/filled,
+/turf/simulated/floor/tiled/techmaint,
 /area/tether/surfacebase/barbackmaintenance)
 "bfQ" = (
-/obj/structure/table/gamblingtable,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -23;
+	pixel_y = 0
 	},
 /turf/simulated/floor/tiled/eris/steel/bar_dance,
 /area/tether/surfacebase/barbackmaintenance)
@@ -33563,10 +33462,11 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bfS" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+/obj/structure/bed/chair/comfy/beige{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/eris/steel/bar_dance,
 /area/tether/surfacebase/barbackmaintenance)
@@ -33743,15 +33643,11 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/entertainment/stage)
 "bgl" = (
-/obj/structure/bed/chair/comfy/beige{
-	dir = 8
+/obj/structure/table/gamblingtable,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/eris/steel/bar_light,
+/turf/simulated/floor/tiled/eris/steel/bar_dance,
 /area/tether/surfacebase/barbackmaintenance)
 "bgm" = (
 /obj/machinery/alarm{
@@ -33871,21 +33767,15 @@
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
 "bgy" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 4
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 9
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/barrestroom)
+/turf/simulated/floor/tiled/techmaint,
+/area/tether/surfacebase/barbackmaintenance)
 "bgz" = (
 /obj/effect/floor_decal/spline/plain{
 	dir = 4
@@ -33970,24 +33860,25 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bgG" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/machinery/button/windowtint{
-	id = "secreet";
-	name = "Window Tint Control";
-	pixel_x = -25;
-	range = 15
+/obj/structure/table/gamblingtable,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/eris/steel/bar_dance,
 /area/tether/surfacebase/barbackmaintenance)
 "bgH" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/item/device/radio/intercom{
-	dir = 8;
-	pixel_x = -24
+/obj/structure/grille,
+/obj/structure/window/reinforced/polarized/full{
+	id = "secreet";
+	name = "Tintable Window"
 	},
-/turf/simulated/floor/tiled/eris/steel/bar_dance,
+/obj/structure/window/reinforced/polarized{
+	dir = 4;
+	id = "secreet";
+	name = "Tintable Window"
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/plating,
 /area/tether/surfacebase/barbackmaintenance)
 "bgI" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -34107,7 +33998,6 @@
 /turf/simulated/floor/lino,
 /area/tether/surfacebase/bar_backroom)
 "bgR" = (
-/obj/machinery/door/airlock/maintenance/common,
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -34120,87 +34010,57 @@
 	dir = 8
 	},
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/techmaint,
-/area/crew_quarters/bar)
-"bgS" = (
 /obj/machinery/door/airlock{
 	name = "Unisex Restrooms"
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/techmaint,
 /area/crew_quarters/barrestroom)
-"bgT" = (
-/obj/machinery/door/airlock/maintenance/common,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+"bgS" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/maintenance/common,
 /turf/simulated/floor/tiled/techmaint,
 /area/tether/surfacebase/barbackmaintenance)
+"bgT" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/polarized/full{
+	id = "secreet";
+	name = "Tintable Window"
+	},
+/obj/structure/window/reinforced/polarized{
+	id = "secreet";
+	name = "Tintable Window"
+	},
+/obj/structure/window/reinforced/polarized{
+	dir = 4;
+	id = "secreet";
+	name = "Tintable Window"
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/barbackmaintenance)
 "bgU" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/firealarm{
-	layer = 3.3;
-	pixel_y = 26
-	},
-/turf/simulated/floor/tiled/eris/steel/bar_dance,
-/area/tether/surfacebase/barbackmaintenance)
+/obj/machinery/vending/nifsoft_shop,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/southhall)
 "bgV" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/polarized/full{
-	id = "secreet";
-	name = "Tintable Window"
+/obj/machinery/vending/sovietsoda{
+	dir = 8
 	},
-/obj/structure/window/reinforced/polarized{
-	dir = 4;
-	id = "secreet";
-	name = "Tintable Window"
-	},
-/obj/structure/cable/green{
-	icon_state = "0-2"
-	},
-/obj/machinery/door/firedoor/glass,
-/turf/simulated/floor/plating,
-/area/tether/surfacebase/barbackmaintenance)
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/southhall)
 "bgW" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/polarized/full{
-	id = "secreet";
-	name = "Tintable Window"
+/obj/machinery/vending/cigarette{
+	dir = 8
 	},
-/obj/structure/window/reinforced/polarized{
-	dir = 4;
-	id = "secreet";
-	name = "Tintable Window"
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/cable/green{
-	icon_state = "0-2"
-	},
-/obj/structure/cable/green,
-/obj/machinery/door/firedoor/glass,
-/turf/simulated/floor/plating,
-/area/tether/surfacebase/barbackmaintenance)
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/southhall)
 "bgX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -34208,31 +34068,6 @@
 /obj/machinery/camera/network/research/xenobio,
 /turf/simulated/floor/tiled/white,
 /area/rnd/outpost/xenobiology/outpost_autopsy)
-"bgY" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/polarized/full{
-	id = "secreet";
-	name = "Tintable Window"
-	},
-/obj/structure/window/reinforced/polarized{
-	dir = 4;
-	id = "secreet";
-	name = "Tintable Window"
-	},
-/obj/structure/cable/green{
-	icon_state = "0-2"
-	},
-/obj/structure/cable/green,
-/obj/machinery/door/firedoor/glass,
-/turf/simulated/floor/plating,
-/area/tether/surfacebase/barbackmaintenance)
-"bgZ" = (
-/obj/machinery/alarm{
-	dir = 4;
-	pixel_x = -22
-	},
-/turf/simulated/floor/tiled/eris/steel/bar_dance,
-/area/tether/surfacebase/barbackmaintenance)
 "bha" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -34254,63 +34089,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/outpost/xenobiology/outpost_main)
-"bhb" = (
-/obj/structure/grille,
-/obj/structure/cable/green{
-	icon_state = "0-4"
-	},
-/obj/structure/window/reinforced/polarized/full{
-	id = "secreet";
-	name = "Tintable Window"
-	},
-/obj/structure/window/reinforced/polarized{
-	id = "secreet";
-	name = "Tintable Window"
-	},
-/obj/machinery/door/firedoor/glass,
-/turf/simulated/floor/plating,
-/area/tether/surfacebase/barbackmaintenance)
-"bhc" = (
-/obj/structure/grille,
-/obj/structure/cable/green{
-	icon_state = "0-4"
-	},
-/obj/structure/window/reinforced/polarized/full{
-	id = "secreet";
-	name = "Tintable Window"
-	},
-/obj/structure/window/reinforced/polarized{
-	id = "secreet";
-	name = "Tintable Window"
-	},
-/obj/structure/cable/green{
-	icon_state = "0-8"
-	},
-/obj/machinery/door/firedoor/glass,
-/turf/simulated/floor/plating,
-/area/tether/surfacebase/barbackmaintenance)
-"bhd" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/polarized/full{
-	id = "secreet";
-	name = "Tintable Window"
-	},
-/obj/structure/window/reinforced/polarized{
-	id = "secreet";
-	name = "Tintable Window"
-	},
-/obj/structure/window/reinforced/polarized{
-	dir = 4;
-	id = "secreet";
-	name = "Tintable Window"
-	},
-/obj/structure/cable/green{
-	icon_state = "0-8"
-	},
-/obj/structure/cable/green,
-/obj/machinery/door/firedoor/glass,
-/turf/simulated/floor/plating,
-/area/tether/surfacebase/barbackmaintenance)
 "bhe" = (
 /obj/machinery/hologram/holopad,
 /obj/machinery/camera/network/research/xenobio{
@@ -37881,7 +37659,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/light/small,
+/obj/machinery/light,
 /turf/simulated/floor/wood,
 /area/library)
 "cEx" = (
@@ -38522,15 +38300,15 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/effect/floor_decal/borderfloor/corner{
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/red/bordercorner{
 	dir = 8;
 	icon_state = "bordercolorcorner"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/upperhall)
@@ -38888,7 +38666,6 @@
 /obj/effect/landmark{
 	name = "lightsout"
 	},
-/obj/structure/disposalpipe/segment,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -39232,10 +39009,22 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/shuttle_pad)
 "ieN" = (
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 10
+/obj/effect/floor_decal/borderfloor{
+	dir = 6
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals4,
+/obj/effect/floor_decal/corner/red/border{
+	dir = 6
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/red/bordercorner2{
+	dir = 6
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/machinery/disposal,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/upperhall)
 "ifI" = (
@@ -39672,6 +39461,9 @@
 /obj/effect/floor_decal/corner/red/border{
 	dir = 4
 	},
+/obj/structure/sign/poster{
+	pixel_x = 32
+	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/breakroom)
 "jSV" = (
@@ -39978,18 +39770,10 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/briefingroom)
 "kRa" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloor/corner{
+/obj/effect/floor_decal/borderfloor{
 	dir = 8
 	},
-/obj/effect/floor_decal/corner/red/bordercorner{
+/obj/effect/floor_decal/corner/red/border{
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
@@ -40154,10 +39938,9 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/briefingroom)
 "lxa" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/turf/simulated/floor/wood,
+/obj/structure/table/woodentable,
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/carpet,
 /area/library)
 "lzq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -40646,25 +40429,19 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/upperhall)
 "nEn" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/machinery/camera/network/security{
-	dir = 8;
-	icon_state = "camera"
-	},
-/obj/effect/floor_decal/borderfloor{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/floor_decal/corner/red/border{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 6
-	},
-/obj/effect/floor_decal/corner/red/bordercorner2{
-	dir = 6
-	},
+/obj/effect/floor_decal/borderfloor/corner,
+/obj/effect/floor_decal/corner/red/bordercorner,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/upperhall)
 "nJe" = (
@@ -41471,6 +41248,9 @@
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 9
 	},
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/upperhall)
 "qzU" = (
@@ -41481,12 +41261,6 @@
 /obj/effect/floor_decal/corner/red{
 	dir = 9;
 	icon_state = "corner_white"
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 1
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 6
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/lobby)
@@ -41730,10 +41504,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/upperhall)
@@ -42527,11 +42297,8 @@
 /obj/machinery/papershredder,
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/red/border,
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 9
-	},
-/obj/effect/floor_decal/corner/red/bordercorner2{
-	dir = 9
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/upperhall)
@@ -42886,13 +42653,6 @@
 /obj/structure/window/reinforced/full,
 /turf/simulated/floor,
 /area/tether/surfacebase/security/briefingroom)
-"wiX" = (
-/obj/machinery/camera/network/civilian{
-	dir = 9
-	},
-/obj/machinery/photocopier,
-/turf/simulated/floor/wood,
-/area/library)
 "wlf" = (
 /obj/structure/table/glass,
 /obj/machinery/atmospherics/unary/vent_pump/on,
@@ -48688,7 +48448,7 @@ aac
 aac
 aac
 aac
-aac
+aaq
 adG
 adG
 adG
@@ -51251,7 +51011,7 @@ aLS
 azL
 azL
 azL
-aac
+aaq
 aab
 aab
 aab
@@ -51596,7 +51356,7 @@ aab
 aab
 aab
 aab
-aab
+afV
 aac
 aac
 aac
@@ -51738,9 +51498,9 @@ aab
 aab
 aab
 aeu
-aeu
-aac
-aac
+adG
+aaq
+aaq
 aac
 aac
 aac
@@ -51881,8 +51641,8 @@ aab
 aOm
 adG
 adG
-aac
-aac
+aaq
+aaq
 aac
 aac
 aac
@@ -53744,7 +53504,7 @@ whW
 whW
 iLF
 adO
-ieN
+qAt
 nEn
 adT
 afw
@@ -53887,11 +53647,11 @@ rnn
 agb
 adO
 adi
-aeJ
-afV
 ahw
 aeJ
-adi
+aeJ
+axn
+aeJ
 aeJ
 aWn
 ajM
@@ -54029,7 +53789,7 @@ afl
 eCP
 adO
 adp
-aeK
+afs
 agG
 ahx
 ahI
@@ -54068,8 +53828,8 @@ azi
 aAw
 azP
 aCG
-aEE
-aER
+azT
+azT
 aFn
 aFt
 aGY
@@ -54212,10 +53972,10 @@ azP
 aLP
 azT
 aEU
-aBs
+aHc
 aFu
 aHc
-aXf
+aEU
 axg
 aGZ
 aHR
@@ -54353,9 +54113,9 @@ aCM
 azP
 aCH
 azT
-azT
-aBs
-azT
+aEG
+aAE
+aFU
 lxa
 aEV
 axg
@@ -54458,7 +54218,7 @@ aep
 aft
 agU
 kRa
-aft
+ayC
 aiR
 aiW
 rJT
@@ -54494,12 +54254,12 @@ aTT
 azP
 azP
 aIE
-aEP
+azT
 aEG
-aBs
+aEu
+aAA
 aFU
-aFU
-aHc
+aER
 axg
 aHb
 aHR
@@ -54635,13 +54395,13 @@ awd
 azQ
 aAz
 akM
+aAi
 azT
-aEH
-aAA
-aBs
-azT
-azT
-aHc
+aEU
+aEz
+aEP
+aEP
+aFs
 axi
 aGX
 aHR
@@ -54778,7 +54538,7 @@ azR
 aAA
 azV
 azT
-aEI
+azT
 aEI
 aBs
 aGw
@@ -55061,7 +54821,7 @@ ayA
 azW
 aFr
 aEJ
-aGx
+aFr
 aXo
 aFc
 aFr
@@ -55108,7 +54868,7 @@ biA
 bhE
 aac
 aac
-aac
+aaq
 adG
 adG
 oWF
@@ -55200,13 +54960,13 @@ ajM
 aoI
 axk
 azh
-wiX
-azT
+aMk
+ayG
 aBt
-aEu
-aEK
+azT
+aXC
 aFd
-aFs
+azT
 azT
 aMk
 aXw
@@ -55345,10 +55105,10 @@ axg
 axg
 aHd
 aBv
-aEz
-aEO
+azT
+aXC
 aFe
-aFs
+azT
 aBq
 axg
 axg
@@ -55438,7 +55198,7 @@ aac
 aac
 aac
 aac
-aaF
+aaE
 aky
 mAl
 abR
@@ -55485,12 +55245,12 @@ ape
 aEA
 ahd
 axg
-azT
+ayI
 aCF
-aEC
+azT
 aXC
 aEC
-aCF
+aEH
 aSF
 axg
 atH
@@ -57885,10 +57645,10 @@ aqh
 agw
 apc
 asZ
-aVw
-axn
+aVy
+aVO
 ate
-ayG
+aop
 aZg
 bda
 baM
@@ -58028,9 +57788,9 @@ apc
 apc
 avg
 aVy
-axn
+aVO
 ate
-ayI
+aop
 baB
 aru
 asw
@@ -58054,10 +57814,10 @@ bcc
 bdM
 bdQ
 arJ
-aGK
-aGK
-aGK
-aGK
+arJ
+arJ
+arJ
+arJ
 aKj
 aKj
 aKj
@@ -58195,22 +57955,22 @@ aKq
 bck
 aKr
 beh
-aGK
+ayM
 aya
 bcd
 ayh
 ayE
-aGK
+bfP
 aAl
 aId
 bdA
 ayM
-bgG
-bgH
-bfo
-bfN
-bgZ
-bhb
+aac
+aac
+aac
+aac
+aac
+aac
 aac
 aac
 aac
@@ -58312,7 +58072,7 @@ apg
 apc
 aGH
 aVB
-axn
+aVO
 aZQ
 bga
 bgc
@@ -58339,20 +58099,20 @@ aAF
 bcb
 bgS
 bgy
-bdY
-aGK
-aGK
-aGK
-aAx
+bgy
+bem
+bfC
+bcd
+bcd
 aIe
 bdK
 ayM
-bef
-bel
-bfz
-bfP
-bfK
-bhc
+aac
+aac
+aac
+aac
+aac
+aac
 aac
 aac
 aac
@@ -58452,9 +58212,9 @@ awP
 awP
 awP
 awP
-aTE
-aVC
-axn
+aGH
+aVB
+aVO
 bdB
 ayL
 baP
@@ -58479,22 +58239,22 @@ bbP
 bcm
 aAG
 bgF
-aGK
-ayd
-bdZ
-ayC
-ayF
-aGK
-aAE
-baR
-bdL
 ayM
-beg
-bem
-bfA
-bfQ
-bfM
-bhc
+ayM
+ayM
+ayM
+ayF
+ayM
+ayM
+ayM
+ayM
+ayM
+aac
+aac
+aac
+aac
+aac
+aac
 aac
 aac
 aac
@@ -58621,22 +58381,22 @@ bbT
 bcm
 aAG
 bfR
-aGK
+ayM
 ayc
 bdZ
-aGK
-aGK
-aGK
-aCn
-baR
-bdN
-ayM
-beg
 ben
-bfB
+bfD
 bfQ
-bfM
-bhc
+aCn
+bea
+bec
+aac
+aac
+aac
+aac
+aac
+aac
+aac
 aac
 aac
 aac
@@ -58763,22 +58523,22 @@ bbU
 bdJ
 aAG
 aIS
-aGK
-bdU
+ayM
+bdV
 bea
 ayD
-ayF
-aGK
-aFq
-bbX
-bdW
-ayM
-beg
-bem
-bfC
-bfQ
-bfM
-bhc
+bfF
+bfS
+bea
+bea
+bec
+aac
+aac
+aac
+aac
+aac
+aac
+aac
 aac
 aac
 aac
@@ -58800,7 +58560,7 @@ bhm
 bhH
 beU
 aPs
-aac
+aaq
 adG
 adG
 adG
@@ -58905,22 +58665,22 @@ bbV
 aAc
 aEl
 baC
-aGK
+ayM
 bdV
 beb
-aGK
-aGK
-aGK
-aFv
-baR
-aFv
-ayM
-bgU
 beo
-bfD
+bfG
 bgl
-bfK
-bhc
+aFA
+bea
+bec
+aac
+aac
+aac
+aac
+aac
+aac
+aac
 aac
 aac
 aac
@@ -59047,22 +58807,22 @@ bfY
 bbY
 aIf
 aIU
-aGK
+ayM
 ayd
 ayb
-ayb
-bfE
-aGK
-aFy
-bdz
-bdX
-bgT
-bei
 bep
-bfG
-bfS
-bfF
-bhc
+bfE
+bgG
+aFy
+bea
+bec
+aac
+aac
+aac
+aac
+aac
+aac
+aac
 aac
 aac
 aac
@@ -59189,23 +58949,23 @@ bbS
 bbZ
 aIf
 baT
-aGK
-aHD
-aHD
-aHD
-aHD
-aGK
+ayM
+bea
+beb
+bfo
+bfK
+bfo
 aFA
-ayM
+bea
 bec
-ayM
-bgV
-bgW
-bgY
-bgY
-bgY
-bhd
-aQf
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
 aac
 aac
 aac
@@ -59331,16 +59091,16 @@ bgC
 bgE
 aIf
 baW
-aGK
-aGK
-aGK
-aGK
-aGK
-aGK
+ayM
+bea
 aHC
-ayM
-ayM
-ayM
+bfz
+bfz
+bfz
+aHC
+bea
+bec
+aac
 aac
 aac
 aac
@@ -59361,9 +59121,9 @@ aac
 aac
 aac
 aPs
-beU
-beU
-beU
+bgU
+bgV
+bgW
 aPs
 bhI
 bhI
@@ -59470,18 +59230,18 @@ ato
 bcp
 atN
 arJ
-arJ
-bgR
-arJ
 aGK
-aAi
-aAe
-aAe
-aAe
-aAe
-aAj
-ayM
-aac
+bgR
+aGK
+aGK
+aGK
+aGK
+aGK
+aGK
+aGK
+bgH
+bgH
+bgT
 aac
 aac
 aac
@@ -59615,14 +59375,12 @@ aJt
 ayJ
 bbW
 aAe
-aAe
+aVC
 aAj
-ayM
-ayM
-ayM
-ayM
-ayM
-ayM
+bei
+bfA
+aTE
+aGK
 aac
 aac
 aac
@@ -59651,7 +59409,9 @@ aac
 aac
 aac
 aac
-adG
+aac
+aac
+aaq
 adG
 oWF
 aab
@@ -59754,34 +59514,17 @@ aIQ
 aph
 azt
 aJt
-ayM
-ayM
-ayM
-ayM
-ayM
-ayM
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aab
-aab
-aac
-aac
-aac
-aac
-aac
+aGx
+aTE
+aVw
+aTE
+beg
+aTE
+bfB
+aTE
+aGK
+aaq
+aaq
 aac
 aac
 aac
@@ -59793,7 +59536,24 @@ aac
 aac
 aac
 aab
-aNM
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
+aac
 aNM
 aab
 aab
@@ -59896,21 +59656,23 @@ axy
 aHv
 bdO
 aJt
+aGx
+aTE
+aGK
+bdL
+aGK
+bel
+aGK
+bfM
+aGK
+aaq
+aaq
 aac
 aac
 aac
 aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
+aab
+aab
 aab
 aab
 aab
@@ -59918,9 +59680,6 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
 aac
 aac
 aac
@@ -59933,8 +59692,9 @@ aac
 aac
 aac
 aac
-aab
-aab
+aac
+aac
+aac
 aab
 aab
 aab
@@ -60038,6 +59798,18 @@ bdn
 aKs
 axu
 aJt
+aQf
+aTE
+aGK
+bef
+aGK
+bef
+aGK
+bfN
+aGK
+adG
+aOi
+aab
 aac
 aac
 aac
@@ -60050,20 +59822,8 @@ aab
 aab
 aab
 aab
+aab
 aac
-aac
-aac
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
 aac
 aac
 aac
@@ -60180,33 +59940,33 @@ axp
 bbQ
 axx
 aJt
+aGK
+aGK
+aGK
+aGK
+aGK
+aGK
+aGK
+aGK
+aGK
+adG
+aOi
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
+aab
 aac
-aac
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
 aac
 aac
 aac
@@ -60323,16 +60083,16 @@ aJt
 aJt
 aJt
 adG
+adG
+adG
+adG
+adG
+adG
+adG
+adG
+adG
+adG
 aOi
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
 aab
 aab
 aab
@@ -60465,15 +60225,15 @@ adG
 adG
 adG
 adG
-aOi
-aab
-aab
-aab
-aab
-aab
-aab
-aab
-aab
+adG
+aNB
+aNM
+aNM
+aNM
+aNM
+aNM
+aNM
+aNM
 aab
 aab
 aab
@@ -60607,7 +60367,7 @@ aNM
 aNM
 aNM
 aNM
-aab
+aNM
 aab
 aab
 aab

--- a/maps/tether/tether-05-station1.dmm
+++ b/maps/tether/tether-05-station1.dmm
@@ -2781,6 +2781,9 @@
 /area/hallway/station/atrium)
 "afA" = (
 /obj/machinery/hologram/holopad,
+/obj/machinery/camera/network/tether{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/station/atrium)
 "afB" = (
@@ -13381,6 +13384,10 @@
 /obj/effect/floor_decal/corner/lightgrey/bordercorner{
 	dir = 4
 	},
+/obj/machinery/vending/nifsoft_shop{
+	pixel_x = 12;
+	pixel_y = 2
+	},
 /turf/simulated/floor/tiled,
 /area/tether/station/visitorhallway)
 "ayQ" = (
@@ -22324,6 +22331,20 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/station/dock_one)
+"kqv" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/obj/machinery/vending/nifsoft_shop,
+/turf/simulated/floor/tiled,
+/area/hallway/station/atrium)
 "kth" = (
 /obj/effect/floor_decal/borderfloor/corner{
 	dir = 4
@@ -34630,7 +34651,7 @@ alT
 aFe
 alT
 alT
-asY
+kqv
 acm
 acm
 acm

--- a/maps/tether/tether-05-station1.dmm
+++ b/maps/tether/tether-05-station1.dmm
@@ -20983,6 +20983,20 @@
 	},
 /turf/simulated/floor/plating,
 /area/tether/station/dock_two)
+"crl" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/obj/machinery/vending/nifsoft_shop,
+/turf/simulated/floor/tiled,
+/area/hallway/station/atrium)
 "cto" = (
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -22331,20 +22345,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/station/dock_one)
-"kqv" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 1
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7,
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 4
-	},
-/obj/machinery/vending/nifsoft_shop,
-/turf/simulated/floor/tiled,
-/area/hallway/station/atrium)
 "kth" = (
 /obj/effect/floor_decal/borderfloor/corner{
 	dir = 4
@@ -34651,7 +34651,7 @@ alT
 aFe
 alT
 alT
-kqv
+crl
 acm
 acm
 acm

--- a/maps/tether/tether-07-station3.dmm
+++ b/maps/tether/tether-07-station3.dmm
@@ -2531,6 +2531,11 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/machinery/power/apc{
+	dir = 2;
+	name = "south bump";
+	pixel_y = -28
+	},
 /turf/simulated/floor/tiled,
 /area/security/eva)
 "agZ" = (

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -3003,6 +3003,7 @@
 #include "code\modules\modular_computers\NTNet\NTNRC\conversation.dm"
 #include "code\modules\multi-tile\multi-tile.dm"
 #include "code\modules\multiz\_stubs.dm"
+#include "code\modules\multiz\admin_upload.dm"
 #include "code\modules\multiz\basic.dm"
 #include "code\modules\multiz\hoist.dm"
 #include "code\modules\multiz\ladder_assembly_vr.dm"


### PR DESCRIPTION
moves the chaplain pets, makes the tiny hidden garden slightly more cool, combines the surfsec desks, adds a door to the elevator on Z1 so it won't eat people so much, adds a missing APC on Z7, adds tintable windows to the warden office, rearranges the bar's bathroom and gambling room area and stuff, and adds a few more nifsoft vendors, also some other stuff I probably forgot. 

Also adds some admin upload fun stuff.