### PR TITLE
Add/Restore Rain Ambience

### DIFF
--- a/code/modules/planet/virgo3b_vr.dm
+++ b/code/modules/planet/virgo3b_vr.dm
@@ -265,6 +265,8 @@ var/datum/planet/virgo3b/planet_virgo3b = null
 	transition_messages = list(
 		"The sky is dark, and rain falls down upon you."
 	)
+	outdoor_sounds_type = /datum/looping_sound/weather/rain
+	indoor_sounds_type = /datum/looping_sound/weather/rain/indoors
 
 /datum/weather/virgo3b/rain/process_effects()
 	..()
@@ -310,6 +312,8 @@ var/datum/planet/virgo3b/planet_virgo3b = null
 		"Loud thunder is heard in the distance.",
 		"A bright flash heralds the approach of a storm."
 	)
+	outdoor_sounds_type = /datum/looping_sound/weather/rain
+	indoor_sounds_type = /datum/looping_sound/weather/rain/indoors
 
 
 	transition_chances = list(


### PR DESCRIPTION
For some reason the rain ambience datum was never hooked up to the v3b rain weather datum, so rain has been silent this whole time (except for thunder during storms).

That said, there's a very distinct sort of 'heartbeat' sound every seven-eight seconds or so in the single rain loop that exists. If this is going to be merged I strongly recommend someone find some good, suitably-licensed rain SFX that can be used to replace the existing files.