### PR TITLE
Allow remote control of disposal bins for silicons

### DIFF
--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -262,7 +262,7 @@
 	if(..())
 		return TRUE
 	
-	if(usr.loc == src)
+	if(usr.loc == src && !issilicon(usr))
 		to_chat(usr, "<span class='warning'>You cannot reach the controls from inside.</span>")
 		return TRUE
 
@@ -286,16 +286,15 @@
 			mode = 0
 			update()
 
-		if(!issilicon(usr))
-			if(action == "engageHandle")
-				flush = 1
-				update()
-			if(action == "disengageHandle")
-				flush = 0
-				update()
+		if(action == "engageHandle")
+			flush = 1
+			update()
+		if(action == "disengageHandle")
+			flush = 0
+			update()
 
-			if(action == "eject")
-				eject()
+		if(action == "eject")
+			eject()
 	
 	return TRUE
 	


### PR DESCRIPTION
Closes #9457

I'm pretty neutral on whether this should be merged or not, but it was apparently this way in the past.
/tg/ matches the current behavior (no one inside a disposal bin can control it, silicons can not pull the handle)
The new behavior is carbons inside a disposal bin cannot control it, silicons can pull the handle remotely