### PR TITLE
Exploration/Gateway Balance Update

### DIFF
--- a/code/datums/outfits/jobs/special_vr.dm
+++ b/code/datums/outfits/jobs/special_vr.dm
@@ -9,6 +9,18 @@
 	id_type = /obj/item/weapon/card/id/centcom
 	pda_type = /obj/item/device/pda/centcom
 
+/decl/hierarchy/outfit/job/emergency_responder
+	name = OUTFIT_JOB_NAME("Emergency Responder")
+	uniform = /obj/item/clothing/under/ert
+	shoes = /obj/item/clothing/shoes/boots/swat
+	gloves = /obj/item/clothing/gloves/swat
+	l_ear = /obj/item/device/radio/headset/ert
+	belt = /obj/item/weapon/gun/energy/gun
+	glasses = /obj/item/clothing/glasses/sunglasses
+	back = /obj/item/weapon/storage/backpack/satchel
+	id_type = /obj/item/weapon/card/id/centcom/ERT
+	pda_type = /obj/item/device/pda/centcom
+
 /decl/hierarchy/outfit/job/clown
 	name = OUTFIT_JOB_NAME("Clown")
 	uniform = /obj/item/clothing/under/rank/clown

--- a/code/datums/supplypacks/munitions_vr.dm
+++ b/code/datums/supplypacks/munitions_vr.dm
@@ -2,7 +2,7 @@
 	name = "Frontier phaser (station-locked) crate"
 	contains = list(
 			/obj/item/weapon/gun/energy/locked/frontier = 2,
-			/obj/item/weapon/gun/energy/locked/frontier/holdout = 1,
+			/obj/item/weapon/gun/energy/locked/frontier/holdout = 2,
 			)
 	cost = 35
 	containertype = /obj/structure/closet/crate/secure

--- a/code/game/jobs/job/special_vr.dm
+++ b/code/game/jobs/job/special_vr.dm
@@ -39,7 +39,7 @@
 	economic_modifier = 20
 	whitelist_only = 1
 	latejoin_only = 1
-	outfit_type = /decl/hierarchy/outfit/job/centcom_officer
+	outfit_type = /decl/hierarchy/outfit/job/emergency_responder
 	job_description = "Emergency Responders are usually called in to deal with on-station emergencies that the crew require assistance to deal with."
 
 	minimum_character_age = 18

--- a/code/game/jobs/job/special_vr.dm
+++ b/code/game/jobs/job/special_vr.dm
@@ -24,47 +24,31 @@
 	get_access()
 		return get_all_accesses().Copy()
 
-/*/datum/job/centcom_visitor //For Pleasure // You mean for admin abuse... -Ace
-	title = "CentCom Visitor"
-	department = "Civilian"
-	head_position = 1
+/datum/job/emergency_responder //For staff managing/leading ERTs
+	title = "Emergency Responder"
+	departments = list("Central Command")
+	department_accounts = list(DEPARTMENT_COMMAND, DEPARTMENT_ENGINEERING, DEPARTMENT_MEDICAL, DEPARTMENT_RESEARCH, DEPARTMENT_SECURITY, DEPARTMENT_CARGO, DEPARTMENT_PLANET, DEPARTMENT_CIVILIAN)
 	faction = "Station"
 	total_positions = 2
 	spawn_positions = 1
 	supervisors = "company officials and Corporate Regulations"
 	selection_color = "#1D1D4F"
-	idtype = /obj/item/weapon/card/id/centcom
 	access = list()
 	minimal_access = list()
 	minimal_player_age = 14
 	economic_modifier = 20
 	whitelist_only = 1
 	latejoin_only = 1
+	outfit_type = /decl/hierarchy/outfit/job/centcom_officer
+	job_description = "Emergency Responders are usually called in to deal with on-station emergencies that the crew require assistance to deal with."
 
-	minimum_character_age = 25
-	ideal_character_age = 40
+	minimum_character_age = 18
+	ideal_character_age = 30
 
-	equip(var/mob/living/carbon/human/H)
-		if(!H)	return 0
-		H.equip_to_slot_or_del(new /obj/item/device/radio/headset/centcom(H), slot_l_ear)
-		switch(H.backbag)
-			if(2) H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack(H), slot_back)
-			if(3) H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/satchel(H), slot_back)
-			if(4) H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/satchel(H), slot_back)
-		H.equip_to_slot_or_del(new /obj/item/clothing/under/rank/centcom, slot_w_uniform)
-		H.equip_to_slot_or_del(new /obj/item/device/pda/centcom(H), slot_belt)
-		H.equip_to_slot_or_del(new /obj/item/clothing/shoes/laceup(H), slot_shoes)
-		H.equip_to_slot_or_del(new /obj/item/clothing/gloves/white(H), slot_gloves)
-		H.equip_to_slot_or_del(new /obj/item/clothing/head/beret/centcom/officer(H), slot_head)
-		H.equip_to_slot_or_del(new /obj/item/clothing/glasses/omnihud(H), slot_l_store)
-
-		H.implant_loyalty()
-
-		return 1
+	pto_type = PTO_CIVILIAN
 
 	get_access()
-		var/access = get_all_accesses()
-		return access*/
+		return get_all_accesses().Copy()
 
 /datum/job/clown
 	title = "Clown"

--- a/code/game/objects/effects/landmarks_vr.dm
+++ b/code/game/objects/effects/landmarks_vr.dm
@@ -1,3 +1,6 @@
+/obj/effect/landmark
+	var/abductor = 0
+
 /obj/effect/landmark/late_antag
 	name = "Antag Latespawn"
 	var/antag_id

--- a/code/global_vr.dm
+++ b/code/global_vr.dm
@@ -12,7 +12,9 @@ var/list/shell_module_types = list(
 	"Standard", "Service", "Clerical", "Service-Hound"
 )
 
+var/list/awayabductors = list() // List of scatter landmarks for Abductors in Gateways
 var/list/eventdestinations = list() // List of scatter landmarks for VOREStation event portals
+var/list/eventabductors = list() // List of scatter landmarks for VOREStation abductor portals
 
 var/global/list/acceptable_fruit_types= list(
 											"ambrosia",

--- a/code/modules/awaymissions/gateway.dm
+++ b/code/modules/awaymissions/gateway.dm
@@ -172,7 +172,7 @@ obj/machinery/gateway/centerstation/process()
 							for(var/obj/item/II in MI)
 								if(istype(II,/obj/item/weapon/implant) || istype(II,/obj/item/device/nif))
 									continue
-								MI.drop_from_inventory(II, loc)
+								MI.drop_from_inventory(II, dest.loc)
 						var/obj/effect/landmark/finaldest = pick(awayabductors)
 						MI.forceMove(finaldest.loc)
 						sleep(1)

--- a/code/modules/awaymissions/gateway.dm
+++ b/code/modules/awaymissions/gateway.dm
@@ -145,11 +145,11 @@ obj/machinery/gateway/centerstation/process()
 		if(dest)
 			M.forceMove(dest.loc)
 			M.set_dir(SOUTH)
+			sleep(100)
 			//VOREStation Addition Start: Abduction!
 			if(istype(M, /mob/living) && dest.abductor)
 				var/mob/living/L = M
 				L.Paralyse(10)
-				sleep(5)
 				//Situations to get the mob out of
 				if(L.buckled)
 					L.buckled.unbuckle_mob()

--- a/code/modules/awaymissions/gateway.dm
+++ b/code/modules/awaymissions/gateway.dm
@@ -145,7 +145,6 @@ obj/machinery/gateway/centerstation/process()
 		if(dest)
 			M.forceMove(dest.loc)
 			M.set_dir(SOUTH)
-			sleep(100)
 			//VOREStation Addition Start: Abduction!
 			if(istype(M, /mob/living) && dest.abductor)
 				var/mob/living/L = M
@@ -181,7 +180,7 @@ obj/machinery/gateway/centerstation/process()
 							MI.forceMove(finaldest.loc)
 							MI << 'sound/effects/bamf.ogg'
 							to_chat(MI,"<span class='warning'>You're starting to come to. You feel like you've been out for a few minutes, at least...</span>")
-						L.drop_from_inventory(I, loc)
+						L.drop_from_inventory(I, dest.loc)
 				var/obj/effect/landmark/finaldest = pick(awayabductors)
 				L.forceMove(finaldest.loc)
 				L << 'sound/effects/bamf.ogg'

--- a/code/modules/awaymissions/gateway.dm
+++ b/code/modules/awaymissions/gateway.dm
@@ -148,6 +148,8 @@ obj/machinery/gateway/centerstation/process()
 			//VOREStation Addition Start: Abduction!
 			if(istype(M, /mob/living) && dest.abductor)
 				var/mob/living/L = M
+				L.Paralyse(10)
+				sleep(5)
 				//Situations to get the mob out of
 				if(L.buckled)
 					L.buckled.unbuckle_mob()
@@ -180,7 +182,6 @@ obj/machinery/gateway/centerstation/process()
 							MI << 'sound/effects/bamf.ogg'
 							to_chat(MI,"<span class='warning'>You're starting to come to. You feel like you've been out for a few minutes, at least...</span>")
 						L.drop_from_inventory(I, loc)
-				L.Paralyse(10)
 				var/obj/effect/landmark/finaldest = pick(awayabductors)
 				L.forceMove(finaldest.loc)
 				L << 'sound/effects/bamf.ogg'

--- a/code/modules/awaymissions/gateway.dm
+++ b/code/modules/awaymissions/gateway.dm
@@ -145,6 +145,46 @@ obj/machinery/gateway/centerstation/process()
 		if(dest)
 			M.forceMove(dest.loc)
 			M.set_dir(SOUTH)
+			//VOREStation Addition Start: Abduction!
+			if(istype(M, /mob/living) && dest.abductor)
+				var/mob/living/L = M
+				//Situations to get the mob out of
+				if(L.buckled)
+					L.buckled.unbuckle_mob()
+				if(istype(L.loc,/obj/mecha))
+					var/obj/mecha/ME = L.loc
+					ME.go_out()
+				else if(istype(L.loc,/obj/machinery/sleeper))
+					var/obj/machinery/sleeper/SL = L.loc
+					SL.go_out()
+				else if(istype(L.loc,/obj/machinery/recharge_station))
+					var/obj/machinery/recharge_station/RS = L.loc
+					RS.go_out()
+
+				if(!issilicon(L)) //Don't drop borg modules...
+					for(var/obj/item/I in L)
+						if(istype(I,/obj/item/weapon/implant) || istype(I,/obj/item/device/nif))
+							continue
+						if(istype(I,/obj/item/weapon/holder))
+							var/obj/item/weapon/holder/H = I
+							var/mob/living/MI = H.held_mob
+							MI.forceMove(get_turf(H))
+							for(var/obj/item/II in MI)
+								if(istype(II,/obj/item/weapon/implant) || istype(II,/obj/item/device/nif))
+									continue
+								MI.drop_from_inventory(II, loc)
+								MI.Paralyse(10)
+								var/obj/effect/landmark/finaldest = pick(awayabductors)
+								MI.forceMove(finaldest)
+								MI << 'sound/effects/bamf.ogg'
+								to_chat(MI,"<span class='warning'>You're starting to come to. You feel like you've been out for a few minutes, at least...</span>")
+						L.drop_from_inventory(I, loc)
+				L.Paralyse(10)
+				var/obj/effect/landmark/finaldest = pick(awayabductors)
+				L.forceMove(finaldest)
+				L << 'sound/effects/bamf.ogg'
+				to_chat(L,"<span class='warning'>You're starting to come to. You feel like you've been out for a few minutes, at least...</span>")
+			//VOREStation Addition End
 		return
 
 /obj/machinery/gateway/centerstation/attackby(obj/item/device/W as obj, mob/user as mob)

--- a/code/modules/awaymissions/gateway.dm
+++ b/code/modules/awaymissions/gateway.dm
@@ -160,26 +160,28 @@ obj/machinery/gateway/centerstation/process()
 				else if(istype(L.loc,/obj/machinery/recharge_station))
 					var/obj/machinery/recharge_station/RS = L.loc
 					RS.go_out()
-
 				if(!issilicon(L)) //Don't drop borg modules...
+					var/list/mob_contents = list() //Things which are actually drained as a result of the above not being null.
+					mob_contents |= L // The recursive check below does not add the object being checked to its list.
+					mob_contents |= recursive_content_check(L, mob_contents, recursion_limit = 3, client_check = 0, sight_check = 0, include_mobs = 1, include_objects = 1, ignore_show_messages = 1)
+					for(var/obj/item/weapon/holder/I in mob_contents)
+						var/obj/item/weapon/holder/H = I
+						var/mob/living/MI = H.held_mob
+						MI.forceMove(get_turf(H))
+						if(!issilicon(MI)) //Don't drop borg modules...
+							for(var/obj/item/II in MI)
+								if(istype(II,/obj/item/weapon/implant) || istype(II,/obj/item/device/nif))
+									continue
+								MI.drop_from_inventory(II, loc)
+						var/obj/effect/landmark/finaldest = pick(awayabductors)
+						MI.forceMove(finaldest.loc)
+						sleep(1)
+						MI.Paralyse(10)
+						MI << 'sound/effects/bamf.ogg'
+						to_chat(MI,"<span class='warning'>You're starting to come to. You feel like you've been out for a few minutes, at least...</span>")
 					for(var/obj/item/I in L)
 						if(istype(I,/obj/item/weapon/implant) || istype(I,/obj/item/device/nif))
 							continue
-						if(istype(I,/obj/item/weapon/holder))
-							var/obj/item/weapon/holder/H = I
-							var/mob/living/MI = H.held_mob
-							MI.forceMove(get_turf(H))
-							if(!issilicon(MI)) //Don't drop borg modules...
-								for(var/obj/item/II in MI)
-									if(istype(II,/obj/item/weapon/implant) || istype(II,/obj/item/device/nif))
-										continue
-									MI.drop_from_inventory(II, loc)
-							var/obj/effect/landmark/finaldest = pick(awayabductors)
-							MI.forceMove(finaldest.loc)
-							sleep(1)
-							MI.Paralyse(10)
-							MI << 'sound/effects/bamf.ogg'
-							to_chat(MI,"<span class='warning'>You're starting to come to. You feel like you've been out for a few minutes, at least...</span>")
 						L.drop_from_inventory(I, dest.loc)
 				var/obj/effect/landmark/finaldest = pick(awayabductors)
 				L.forceMove(finaldest.loc)

--- a/code/modules/awaymissions/gateway.dm
+++ b/code/modules/awaymissions/gateway.dm
@@ -148,7 +148,6 @@ obj/machinery/gateway/centerstation/process()
 			//VOREStation Addition Start: Abduction!
 			if(istype(M, /mob/living) && dest.abductor)
 				var/mob/living/L = M
-				L.Paralyse(10)
 				//Situations to get the mob out of
 				if(L.buckled)
 					L.buckled.unbuckle_mob()
@@ -176,13 +175,16 @@ obj/machinery/gateway/centerstation/process()
 										continue
 									MI.drop_from_inventory(II, loc)
 							var/obj/effect/landmark/finaldest = pick(awayabductors)
-							MI.Paralyse(10)
 							MI.forceMove(finaldest.loc)
+							sleep(1)
+							MI.Paralyse(10)
 							MI << 'sound/effects/bamf.ogg'
 							to_chat(MI,"<span class='warning'>You're starting to come to. You feel like you've been out for a few minutes, at least...</span>")
 						L.drop_from_inventory(I, dest.loc)
 				var/obj/effect/landmark/finaldest = pick(awayabductors)
 				L.forceMove(finaldest.loc)
+				sleep(1)
+				L.Paralyse(10)
 				L << 'sound/effects/bamf.ogg'
 				to_chat(L,"<span class='warning'>You're starting to come to. You feel like you've been out for a few minutes, at least...</span>")
 			//VOREStation Addition End

--- a/code/modules/awaymissions/gateway.dm
+++ b/code/modules/awaymissions/gateway.dm
@@ -176,13 +176,13 @@ obj/machinery/gateway/centerstation/process()
 									MI.drop_from_inventory(II, loc)
 							var/obj/effect/landmark/finaldest = pick(awayabductors)
 							MI.Paralyse(10)
-							MI.forceMove(finaldest)
+							MI.forceMove(finaldest.loc)
 							MI << 'sound/effects/bamf.ogg'
 							to_chat(MI,"<span class='warning'>You're starting to come to. You feel like you've been out for a few minutes, at least...</span>")
 						L.drop_from_inventory(I, loc)
 				L.Paralyse(10)
 				var/obj/effect/landmark/finaldest = pick(awayabductors)
-				L.forceMove(finaldest)
+				L.forceMove(finaldest.loc)
 				L << 'sound/effects/bamf.ogg'
 				to_chat(L,"<span class='warning'>You're starting to come to. You feel like you've been out for a few minutes, at least...</span>")
 			//VOREStation Addition End

--- a/code/modules/awaymissions/gateway.dm
+++ b/code/modules/awaymissions/gateway.dm
@@ -169,15 +169,16 @@ obj/machinery/gateway/centerstation/process()
 							var/obj/item/weapon/holder/H = I
 							var/mob/living/MI = H.held_mob
 							MI.forceMove(get_turf(H))
-							for(var/obj/item/II in MI)
-								if(istype(II,/obj/item/weapon/implant) || istype(II,/obj/item/device/nif))
-									continue
-								MI.drop_from_inventory(II, loc)
-								MI.Paralyse(10)
-								var/obj/effect/landmark/finaldest = pick(awayabductors)
-								MI.forceMove(finaldest)
-								MI << 'sound/effects/bamf.ogg'
-								to_chat(MI,"<span class='warning'>You're starting to come to. You feel like you've been out for a few minutes, at least...</span>")
+							if(!issilicon(MI)) //Don't drop borg modules...
+								for(var/obj/item/II in MI)
+									if(istype(II,/obj/item/weapon/implant) || istype(II,/obj/item/device/nif))
+										continue
+									MI.drop_from_inventory(II, loc)
+							var/obj/effect/landmark/finaldest = pick(awayabductors)
+							MI.Paralyse(10)
+							MI.forceMove(finaldest)
+							MI << 'sound/effects/bamf.ogg'
+							to_chat(MI,"<span class='warning'>You're starting to come to. You feel like you've been out for a few minutes, at least...</span>")
 						L.drop_from_inventory(I, loc)
 				L.Paralyse(10)
 				var/obj/effect/landmark/finaldest = pick(awayabductors)

--- a/code/modules/awaymissions/zlevel.dm
+++ b/code/modules/awaymissions/zlevel.dm
@@ -63,9 +63,29 @@ proc/createRandomZlevel()
 	. = ..()
 	awaydestinations += src
 
+/obj/effect/landmark/gateway_scatter/abduct
+	name = "uncalibrated gateway abductor"
+	abductor = 1
+
 /obj/effect/landmark/event_scatter
-	name = "uncalibrated gateway destination"
+	name = "uncalibrated event destination"
 /obj/effect/landmark/event_scatter/Initialize()
 	. = ..()
 	eventdestinations += src
+
+/obj/effect/landmark/event_scatter/abduct
+	name = "uncalibrated event abductor"
+	abductor = 1
+
+/obj/effect/landmark/gateway_abduct_dest
+	name = "abductor gateway destination"
+/obj/effect/landmark/gateway_abduct_dest/Initialize()
+	. = ..()
+	awayabductors += src
+
+/obj/effect/landmark/event_abduct_dest
+	name = "abductor event destination"
+/obj/effect/landmark/event_abduct_dest/Initialize()
+	. = ..()
+	eventabductors += src
 //VOREStation Add End

--- a/code/modules/mob/living/simple_mob/simple_mob_vr.dm
+++ b/code/modules/mob/living/simple_mob/simple_mob_vr.dm
@@ -4,7 +4,7 @@
 #define SA_ICON_REST	0x04
 
 /mob/living/simple_mob
-	base_attack_cooldown = 15
+	base_attack_cooldown = 10
 
 	var/temperature_range = 40			// How close will they get to environmental temperature before their body stops changing its heat
 

--- a/code/modules/multiz/structures_vr.dm
+++ b/code/modules/multiz/structures_vr.dm
@@ -90,25 +90,28 @@
 			else if(istype(L.loc,/obj/machinery/recharge_station))
 				var/obj/machinery/recharge_station/RS = L.loc
 				RS.go_out()
-				if(!issilicon(L)) //Don't drop borg modules...
+			if(!issilicon(L)) //Don't drop borg modules...
+				var/list/mob_contents = list() //Things which are actually drained as a result of the above not being null.
+				mob_contents |= L // The recursive check below does not add the object being checked to its list.
+				mob_contents |= recursive_content_check(L, mob_contents, recursion_limit = 3, client_check = 0, sight_check = 0, include_mobs = 1, include_objects = 1, ignore_show_messages = 1)
+				for(var/obj/item/weapon/holder/I in mob_contents)
+					var/obj/item/weapon/holder/H = I
+					var/mob/living/MI = H.held_mob
+					MI.forceMove(get_turf(H))
+					if(!issilicon(MI)) //Don't drop borg modules...
+						for(var/obj/item/II in MI)
+							if(istype(II,/obj/item/weapon/implant) || istype(II,/obj/item/device/nif))
+								continue
+							MI.drop_from_inventory(II, loc)
+					var/obj/effect/landmark/finaldest = pick(awayabductors)
+					MI.forceMove(finaldest.loc)
+					sleep(1)
+					MI.Paralyse(10)
+					MI << 'sound/effects/bamf.ogg'
+					to_chat(MI,"<span class='warning'>You're starting to come to. You feel like you've been out for a few minutes, at least...</span>")
 				for(var/obj/item/I in L)
 					if(istype(I,/obj/item/weapon/implant) || istype(I,/obj/item/device/nif))
 						continue
-					if(istype(I,/obj/item/weapon/holder))
-						var/obj/item/weapon/holder/H = I
-						var/mob/living/MI = H.held_mob
-						MI.forceMove(get_turf(H))
-						if(!issilicon(MI)) //Don't drop borg modules...
-							for(var/obj/item/II in MI)
-								if(istype(II,/obj/item/weapon/implant) || istype(II,/obj/item/device/nif))
-									continue
-								MI.drop_from_inventory(II, loc)
-						var/obj/effect/landmark/finaldest = pick(awayabductors)
-						MI.forceMove(finaldest.loc)
-						sleep(1)
-						MI.Paralyse(10)
-						MI << 'sound/effects/bamf.ogg'
-						to_chat(MI,"<span class='warning'>You're starting to come to. You feel like you've been out for a few minutes, at least...</span>")
 					L.drop_from_inventory(I, dest.loc)
 			var/obj/effect/landmark/finaldest = pick(awayabductors)
 			L.forceMove(finaldest.loc)

--- a/code/modules/multiz/structures_vr.dm
+++ b/code/modules/multiz/structures_vr.dm
@@ -102,7 +102,7 @@
 						for(var/obj/item/II in MI)
 							if(istype(II,/obj/item/weapon/implant) || istype(II,/obj/item/device/nif))
 								continue
-							MI.drop_from_inventory(II, loc)
+							MI.drop_from_inventory(II, dest.loc)
 					var/obj/effect/landmark/finaldest = pick(awayabductors)
 					MI.forceMove(finaldest.loc)
 					sleep(1)

--- a/code/modules/multiz/structures_vr.dm
+++ b/code/modules/multiz/structures_vr.dm
@@ -76,4 +76,44 @@
 		M << 'sound/effects/phasein.ogg'
 		playsound(src, 'sound/effects/phasein.ogg', 100, 1)
 		M.forceMove(dest.loc)
+		if(istype(M, /mob/living) && dest.abductor)
+			var/mob/living/L = M
+			//Situations to get the mob out of
+			if(L.buckled)
+				L.buckled.unbuckle_mob()
+			if(istype(L.loc,/obj/mecha))
+				var/obj/mecha/ME = L.loc
+				ME.go_out()
+			else if(istype(L.loc,/obj/machinery/sleeper))
+				var/obj/machinery/sleeper/SL = L.loc
+				SL.go_out()
+			else if(istype(L.loc,/obj/machinery/recharge_station))
+				var/obj/machinery/recharge_station/RS = L.loc
+				RS.go_out()
+				if(!issilicon(L)) //Don't drop borg modules...
+				for(var/obj/item/I in L)
+					if(istype(I,/obj/item/weapon/implant) || istype(I,/obj/item/device/nif))
+						continue
+					if(istype(I,/obj/item/weapon/holder))
+						var/obj/item/weapon/holder/H = I
+						var/mob/living/MI = H.held_mob
+						MI.forceMove(get_turf(H))
+						if(!issilicon(MI)) //Don't drop borg modules...
+							for(var/obj/item/II in MI)
+								if(istype(II,/obj/item/weapon/implant) || istype(II,/obj/item/device/nif))
+									continue
+								MI.drop_from_inventory(II, loc)
+						var/obj/effect/landmark/finaldest = pick(awayabductors)
+						MI.forceMove(finaldest.loc)
+						sleep(1)
+						MI.Paralyse(10)
+						MI << 'sound/effects/bamf.ogg'
+						to_chat(MI,"<span class='warning'>You're starting to come to. You feel like you've been out for a few minutes, at least...</span>")
+					L.drop_from_inventory(I, dest.loc)
+			var/obj/effect/landmark/finaldest = pick(awayabductors)
+			L.forceMove(finaldest.loc)
+			sleep(1)
+			L.Paralyse(10)
+			L << 'sound/effects/bamf.ogg'
+			to_chat(L,"<span class='warning'>You're starting to come to. You feel like you've been out for a few minutes, at least...</span>")
 	return

--- a/code/modules/projectiles/guns/energy/laser_vr.dm
+++ b/code/modules/projectiles/guns/energy/laser_vr.dm
@@ -199,7 +199,7 @@
 	item_icons = list(slot_l_hand_str = 'icons/mob/items/lefthand_guns_vr.dmi', slot_r_hand_str = 'icons/mob/items/righthand_guns_vr.dmi', "slot_belt" = 'icons/mob/belt_vr.dmi')
 	fire_sound = 'sound/weapons/laser2.ogg'
 	origin_tech = list(TECH_COMBAT = 4, TECH_MAGNET = 2, TECH_POWER = 4)
-	charge_cost = 300
+	charge_cost = 400
 
 	battery_lock = 1
 	unacidable = 1
@@ -287,7 +287,7 @@
 	phase_power = 100
 
 	w_class = ITEMSIZE_SMALL
-	charge_cost = 600
+	charge_cost = 800
 	modifystate = "holdoutkill"
 	firemodes = list(
 		list(mode_name="lethal", fire_delay=12, projectile_type=/obj/item/projectile/beam, modifystate="holdoutkill", charge_cost = 600),

--- a/code/modules/projectiles/guns/energy/laser_vr.dm
+++ b/code/modules/projectiles/guns/energy/laser_vr.dm
@@ -199,7 +199,7 @@
 	item_icons = list(slot_l_hand_str = 'icons/mob/items/lefthand_guns_vr.dmi', slot_r_hand_str = 'icons/mob/items/righthand_guns_vr.dmi', "slot_belt" = 'icons/mob/belt_vr.dmi')
 	fire_sound = 'sound/weapons/laser2.ogg'
 	origin_tech = list(TECH_COMBAT = 4, TECH_MAGNET = 2, TECH_POWER = 4)
-	charge_cost = 400
+	charge_cost = 300
 
 	battery_lock = 1
 	unacidable = 1
@@ -209,8 +209,8 @@
 
 	projectile_type = /obj/item/projectile/beam
 	firemodes = list(
-		list(mode_name="lethal", fire_delay=12, projectile_type=/obj/item/projectile/beam, charge_cost = 300),
-		list(mode_name="low-power", fire_delay=8, projectile_type=/obj/item/projectile/beam/weaklaser, charge_cost = 60),
+		list(mode_name="lethal", fire_delay=12, projectile_type=/obj/item/projectile/beam/blue, charge_cost = 300),
+		list(mode_name="low-power", fire_delay=8, projectile_type=/obj/item/projectile/beam/weaklaser/blue, charge_cost = 80),
 	)
 
 /obj/item/weapon/gun/energy/locked/frontier/unload_ammo(var/mob/user)
@@ -260,8 +260,8 @@
 
 	modifystate = "carbinekill"
 	firemodes = list(
-		list(mode_name="lethal", fire_delay=12, projectile_type=/obj/item/projectile/beam, modifystate="carbinekill", charge_cost = 300),
-		list(mode_name="low-power", fire_delay=8, projectile_type=/obj/item/projectile/beam/weaklaser, modifystate="carbinestun", charge_cost = 60),
+		list(mode_name="lethal", fire_delay=12, projectile_type=/obj/item/projectile/beam/blue, modifystate="carbinekill", charge_cost = 300),
+		list(mode_name="low-power", fire_delay=8, projectile_type=/obj/item/projectile/beam/weaklaser/blue, modifystate="carbinestun", charge_cost = 80),
 	)
 
 /obj/item/weapon/gun/energy/locked/frontier/carbine/update_icon()
@@ -287,11 +287,11 @@
 	phase_power = 100
 
 	w_class = ITEMSIZE_SMALL
-	charge_cost = 800
+	charge_cost = 600
 	modifystate = "holdoutkill"
 	firemodes = list(
-		list(mode_name="lethal", fire_delay=12, projectile_type=/obj/item/projectile/beam, modifystate="holdoutkill", charge_cost = 600),
-		list(mode_name="low-power", fire_delay=8, projectile_type=/obj/item/projectile/beam/weaklaser, modifystate="holdoutstun", charge_cost = 120),
+		list(mode_name="lethal", fire_delay=12, projectile_type=/obj/item/projectile/beam/blue, modifystate="holdoutkill", charge_cost = 600),
+		list(mode_name="low-power", fire_delay=8, projectile_type=/obj/item/projectile/beam/weaklaser/blue, modifystate="holdoutstun", charge_cost = 160),
 		list(mode_name="stun", fire_delay=12, projectile_type=/obj/item/projectile/beam/stun/med, modifystate="holdoutshock", charge_cost = 300),
 	)
 

--- a/code/modules/projectiles/projectile/beams_vr.dm
+++ b/code/modules/projectiles/projectile/beams_vr.dm
@@ -42,6 +42,11 @@
 	tracer_type = /obj/effect/projectile/tracer/laser_blue
 	impact_type = /obj/effect/projectile/impact/laser_blue
 
+/obj/item/projectile/beam/weaklaser/blue
+	muzzle_type = /obj/effect/projectile/muzzle/laser_blue
+	tracer_type = /obj/effect/projectile/tracer/laser_blue
+	impact_type = /obj/effect/projectile/impact/laser_blue
+
 /obj/item/projectile/beam/medigun
 	name = "healing beam"
 	icon_state = "healbeam"

--- a/maps/submaps/admin_use_vr/ert.dmm
+++ b/maps/submaps/admin_use_vr/ert.dmm
@@ -5270,25 +5270,13 @@
 /area/ship/ert/atmos)
 "Lq" = (
 /obj/structure/table/rack/steel,
-/obj/item/weapon/gun/energy/gun/martin{
-	battery_lock = 0
-	},
-/obj/item/weapon/gun/energy/gun/martin{
-	battery_lock = 0
-	},
-/obj/item/weapon/gun/energy/gun/martin{
-	battery_lock = 0
-	},
-/obj/item/weapon/gun/energy/gun/martin{
-	battery_lock = 0
-	},
-/obj/item/weapon/gun/energy/gun/martin{
-	battery_lock = 0
-	},
-/obj/item/weapon/gun/energy/gun/martin{
-	battery_lock = 0
-	},
 /obj/effect/floor_decal/industrial/outline/grey,
+/obj/item/weapon/gun/energy/locked/frontier/holdout/unlocked,
+/obj/item/weapon/gun/energy/locked/frontier/holdout/unlocked,
+/obj/item/weapon/gun/energy/locked/frontier/holdout/unlocked,
+/obj/item/weapon/gun/energy/locked/frontier/holdout/unlocked,
+/obj/item/weapon/gun/energy/locked/frontier/holdout/unlocked,
+/obj/item/weapon/gun/energy/locked/frontier/holdout/unlocked,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/armoury_st)
 "LA" = (
@@ -5601,6 +5589,7 @@
 "NI" = (
 /obj/structure/table/rack,
 /obj/item/weapon/storage/secure/briefcase/nsfw_pack_hybrid,
+/obj/item/weapon/storage/belt/explorer/pathfinder,
 /turf/simulated/floor/wood,
 /area/ship/ert/commander)
 "NJ" = (
@@ -6757,7 +6746,7 @@
 /turf/simulated/floor/wood,
 /area/ship/ert/commander)
 "Wd" = (
-/obj/machinery/telecomms/relay/preset/centcom/tether,
+/obj/machinery/telecomms/relay,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/atmos)
 "Wj" = (

--- a/maps/submaps/pois_vr/aerostat/Rockybase.dmm
+++ b/maps/submaps/pois_vr/aerostat/Rockybase.dmm
@@ -659,12 +659,6 @@
 /obj/item/mecha_parts/chassis/gygax,
 /turf/simulated/floor/tiled/techfloor/virgo2,
 /area/submap/virgo2/Rockybase)
-"co" = (
-/mob/living/simple_mob/mechanical/mecha/combat/gygax/dark/advanced{
-	faction = "syndicate"
-	},
-/turf/simulated/floor/tiled/techfloor/virgo2,
-/area/submap/virgo2/Rockybase)
 "cp" = (
 /obj/machinery/vending/robotics,
 /obj/machinery/light{
@@ -1302,7 +1296,7 @@ al
 bA
 ao
 ao
-co
+ao
 bq
 ao
 al

--- a/maps/submaps/surface_submaps/plains/Thiefc_vr.dmm
+++ b/maps/submaps/surface_submaps/plains/Thiefc_vr.dmm
@@ -75,7 +75,6 @@
 /obj/random/firstaid,
 /obj/random/firstaid,
 /obj/random/firstaid,
-/obj/random/firstaid,
 /turf/simulated/floor/outdoors/dirt{
 	outdoors = 0
 	},
@@ -103,7 +102,6 @@
 /obj/vehicle/train/trolley,
 /obj/random/multiple/voidsuit,
 /obj/random/multiple/voidsuit,
-/obj/random/multiple/voidsuit,
 /turf/simulated/floor/outdoors/dirt{
 	outdoors = 0
 	},
@@ -121,15 +119,13 @@
 /area/submap/Thiefc)
 "p" = (
 /obj/structure/closet/crate,
-/obj/item/weapon/storage/box/shotgunammo,
 /obj/item/weapon/storage/box/practiceshells,
-/obj/item/weapon/grenade/spawnergrenade/manhacks/station,
 /turf/simulated/floor/outdoors/dirt{
 	outdoors = 0
 	},
 /area/submap/Thiefc)
-"u" = (
-/mob/living/simple_mob/humanoid/merc/ranged/virgo,
+"B" = (
+/mob/living/simple_mob/animal/giant_spider/phorogenic,
 /turf/simulated/floor/outdoors/dirt{
 	outdoors = 0
 	},
@@ -322,7 +318,7 @@ a
 c
 c
 c
-u
+h
 h
 h
 h
@@ -346,7 +342,7 @@ c
 f
 h
 h
-h
+B
 h
 h
 c
@@ -387,12 +383,12 @@ a
 a
 c
 e
-h
-u
-h
+B
 h
 h
 h
+h
+B
 h
 h
 c
@@ -414,7 +410,7 @@ i
 h
 h
 h
-u
+h
 c
 c
 c

--- a/maps/tether/tether_things.dm
+++ b/maps/tether/tether_things.dm
@@ -366,7 +366,7 @@ var/global/list/latejoin_tram   = list()
 
 /obj/structure/closet/secure_closet/guncabinet/excursion/New()
 	..()
-	for(var/i = 1 to 3)
+	for(var/i = 1 to 2)
 		new /obj/item/weapon/gun/energy/locked/frontier(src)
 
 // Used at centcomm for the elevator


### PR DESCRIPTION
- Adds a new Scatter type of gateway, abductor, which strips the person's gear and deposits them somewhere else
- Nerfs Expedition Phasers and Holdout Phasers
- Reduces the number of full size phasers in Exploration from 4 to 3
- Slightly buffs melee mobs
- Removes humanoid mobs from Virgo 3B Wilderness
- Removes ADG from one of the POIs from V2