### PR TITLE
Wreck & Debris Field Updates

### DIFF
--- a/code/game/objects/structures/props/blackbox.dm
+++ b/code/game/objects/structures/props/blackbox.dm
@@ -130,3 +130,120 @@
 		<B>A repeating ping, before silence.</B><BR>
 		<B>End of second log.</B>
 	"}
+
+//VOREStation additions below this line - Killian's wrecks
+/obj/structure/prop/blackbox/mackerel_wreck
+	catalogue_data = list(/datum/category_item/catalogue/information/blackbox/mackerel_wreck)
+
+/datum/category_item/catalogue/information/blackbox/mackerel_wreck
+	name = "Black Box Data - ITV Phish Phood"
+	desc = {"
+		<BR>
+		<B>BEGIN LOG</B><BR>
+		<B>(blaring alarms)</B><BR>
+		<B>Shipboard Computer:</B> Collision warning. Collision warning.<BR>
+		<B>Shipboard Computer:</B> High speed impact detected.<BR>
+		<B>Shipboard Computer:</B> Extensive damage detected.<BR>
+		<B>Shipboard Computer:</B> Starboard nacelle offline.<BR>
+		<B>Shipboard Computer:</B> Port nacelle damaged.<BR>
+		<B>Shipboard Computer:</B> Fore starboard impact buffer shattered.<BR>
+		<B>Shipboard Computer:</B> Fore port impact buffer critically damaged.<BR>
+		<B>Shipboard Computer:</B> Warning. Canopy breached. Warning. Canopy breached.<BR>
+		<B>Shipboard Computer:</B> Danger. Canopy depressurized.<BR>
+		<B>Shipboard Computer:</B> Warning. Sensors indicate crawlspaces exposed to vacuum.<BR>
+		<B>Unknown Voice 1:</B> Wow, that thing really did a number on this ship for a fifty year old piece of shit warhead huh?<BR>
+		<B>Unknown Voice 2:</B> No kidding!<BR>
+		<B>Shipboard Computer:</B> Danger. Lethal trauma to operator detected.<BR>
+		<B>Unknown Voice 1:</B> Fucking hell, will you shut that thing up?<BR>
+		<B>(several loud metallic impacts)</B><BR>
+		<B>Shipboard Computer:</B> Warning. Intruders detec--*kzzzht*<BR>
+		<B>(alarms cease)</B><BR>
+		<B>Unknown Voice 2:</B> There. Fuck. Finally. Sorry.<BR>
+		<B>Unknown Voice 2:</B> I hope whatever this idiot was hauling is here. Why were they in such a hurry anyway?<BR>
+		<B>Unknown Voice 1:</B> Beats me- and hand me that crowbar already.<BR>
+		<B>Unknown Voice 2:</B> Here, catch.<BR>
+		<B>Unknown Voice 1:</B> 'cha, nice. Let's see...<BR>
+		<B>(sound of metal creaking, then a loud snapping sound)</B><BR>
+		<B>Unknown Voice 1:</B> And here she is.<BR>
+		<B>Unknown Voice 2:</B> (whistling) What a beauty. How much you think it'll go for?<BR>
+		<B>Unknown Voice 1:</B> Enough we'll never have to worry about doing another job all the way out here ever again.<BR>
+		<B>Unknown Voice 2:</B> Shiny. Now let's bounce before the ess-defs show up.<BR>
+		<B>Unknown Voice 1:</B> I hear that, <U>brat</U>.<BR>
+		<B>END LOG</B><BR>
+		<BR>
+		<B>CATALOGUER VOICE RECOGNITION RESULTS:</B><BR>
+		No match found for either speaker, but contextual clues and use of Old Earth russian (\'brat\', approximately \'brother\' or \'pal\') suggests out-of-sector criminal elements.
+	"}
+
+/obj/structure/prop/blackbox/gecko_wreck
+	catalogue_data = list(/datum/category_item/catalogue/information/blackbox/gecko_wreck)
+
+/datum/category_item/catalogue/information/blackbox/gecko_wreck
+	name = "Black Box Data - ITV Sticky Situation"
+	desc = {"
+		<BR>
+		<B>BEGIN LOG</B><BR>
+		<B>(blaring alarms)</B><BR>
+		<B>Shipboard Computer:</B> Alert. Multiple impacts detected along starboard side.<BR>
+		<B>Shipboard Computer:</B> Multiple hull breaches detected. Starboard cargo hatches have been breaches.<BR>
+		<B>Shipboard Computer:</B> Warning. Nacelle engines offline. Thrust reduced by thirty-five-point-three percent.<BR>
+		<B>Unknown Voice 1:</B> Agh! Shit! How'd they know-<BR>
+		<B>(loud explosion, sound of rushing air)</B><BR>
+		<B>Shipboard Computer:</B> Danger. Canopy breached. Automatic lockdown successfully engaged.<BR>
+		<B>Unknown Voice 1:</B> (wheezing) Mother<U>fucker!</U> Jackson, Phelps, stand by to repel boarders!<BR>
+		<B>Unknown Voice 2:</B> Roger!<BR>
+		<B>Unknown Voice 3:</B> Already there.<BR>
+		<B>Shipboard Computer:</B> Warning. Minor breach in Engineering. Local depressurization in five minutes.<BR>
+		<B>Unknown Voice 1:</B> Shit, shit, shit.<BR>
+		<B>Unknown Voice 3:</B> Jackson\'s down!<BR>
+		<B>Unknown Voice 1:</B> Motherf-<BR>
+		<B>Unknown Voice 4:</B> <U>Captain</U>. Enough. You know why we\'re here, and we have your engineer. Tell us where you hid the goods and maybe we\'ll let you live.<BR>
+		<B>Unknown Voice 5:</B> Let me go you son of a-<BR>
+		<B>(gunshot, ballistic)</B><BR>
+		<B>Unknown Voice 4:</B> You fucking idiot!<BR>
+		<B>Unknown Voice 6:</B> Don\'t you start, you said-<BR>
+		<B>Unknown Voice 4:</B> I don\'t care what I fucking said, shit-for-brains!<BR>
+		<B>Unknown Voice 7:</B> Boss, I <U>hate</U> to rain on your little parade but SDF just popped up on my scopes, \'bout... fifty klicks out, closing fast.<BR>
+		<B>Unknown Voice 4:</B> Fuck! You, dumbass! Link up with the others and grab as many crates as you can! Pray for your sake that we get the right one!<BR>
+		<B>END LOG</B><BR>
+		<BR>
+		<B>CATALOGUER DATA ANALYSIS RESULTS:</B><BR>
+		No matches found for any of the voices involved. Ship manifest suggests a crew of at least six, but under the circumstances three of the recorded voices are clearly not from the crew.<BR>
+		<BR>
+		Audio resynthesis of firearm discharge matches common high-caliber ballistic sidearm cartridges, best match 10mm Watson Special. An uncommon cartridge, one not manufactured locally.
+	"}
+
+/obj/structure/prop/blackbox/salamander_wreck
+	catalogue_data = list(/datum/category_item/catalogue/information/blackbox/salamander_wreck)
+
+/datum/category_item/catalogue/information/blackbox/salamander_wreck
+	name = "Black Box Data - ITV Unity"
+	desc = {"
+		<BR>
+		<B>BEGIN LOG</B><BR>
+		<B>Unknown Speaker 1:</B> Hey cap, you seeing this?<BR>
+		<B>Unknown Speaker 2 ("Cap"):</B> Yea-- what the fuck?<BR>
+		<B>Unknown Speaker 1:</B> Yeah that was my reaction.<BR>
+		<B>Unknown Speaker 3:</B> What are you tw-- holy shit, what <U>is</U> that?<BR>
+		<B>Unknown Speakers 1 & 2:</B> We don't know!<BR>
+		<B>Unknown Speaker 4:</B> What's all the yel-- fuck me sideways, what the hell?<BR>
+		<B>Unknown Speaker 2 ("Cap"):</B> Stars above and fucking below, they never said anything like this was in the cans... shouldn't the port bioscanners have picked this up?<BR>
+		<B>Unknown Speaker 3:</B> I <I>told</I> you that guy was one shady motherfucker, and whaddaya know.<BR>
+		<B>Unknown Speaker 1:</B> No kidding. Christ. What's the play, cap?<BR>
+		<B>Unknown Speaker 4:</B> I say we shoot this crap into the nearest star. Or gas giant maybe.<BR>
+		<B>Unknown Speaker 2 ("Cap"):</B> Pretty much. Get in one of the voidsuits and rig the can up with some spare O2 canisters -- plot it a course that'll sling it right into V3's atmosphere.<BR>
+		<B>Unknown Speaker 1:</B> Yeah, sure. That shouldn't take long. Then what?<BR>
+		<B>Unknown Speaker 2 ("Cap"):</B> Let's see... ah, perfect. There's another ship passing close by, and I know the captain. We'll take our suits out and have her pick us up. Max, you still got those old cutting charges I told you to get rid of?<BR>
+		<B>Unknown Speaker 4 ("Max"):</B> No. (pause) ...but also yes.<BR>
+		<B>Unknown Speaker 2 ("Cap"):</B> Your propensity for ignoring my orders has once again paid off. Fuck. I'm gonna miss the Unity, but... better this way. I want holes in both sides of the engine bay and one in the portside crawlspace. Lock all the doors open and depressurize the main cabins. Drain as much fuel as you can, break up the main power block, and scatter the parts.<BR>
+		<B>Unknown Speaker 1:</B> You want us to scuttle her, chief?<BR>
+		<B>Unknown Speaker 2 ("Cap"):</B> Nail on the head, my friend.<BR>
+		<B>Unknown Speaker 3:</B> Let's get rid of that fucking can first, I think it just blinked at me.<BR>
+		<B>END LOG</B><BR>
+		<BR>
+		<B>CATALOGUER VOBCE RECOGNBTBON RESULTS:</B><BR>
+		<B>SPEAKER ONE:</B> No match.<BR>
+		<B>SPEAKER TWO, "CAP":</B> Predicted to be Jeremiah Wells, human, last registered owner of the ITV Unity and small-time smuggler of fake alien artefacts. Wanted for smuggling and sale of said (fake) alien artefacts. 87% confidence.<BR>
+		<B>SPEAKER THREE:</B> Predicted to be Allie Wells, human, niece of Captain Wells. 90% confidence.<BR>
+		<B>SPEAKER FOUR, "MAX":</B> Predicted to be Maxwell Ulysses Sarevic, zorren, known smuggler, and wanted in the Elysian Colonies for liberation of slaves and, quote, \'harshing my vibe, and being a, like, <U>total lamer</U>, dude\', unquote. 99% confidence.
+	"}

--- a/code/game/objects/structures/props/blackbox.dm
+++ b/code/game/objects/structures/props/blackbox.dm
@@ -162,12 +162,12 @@
 		<B>Unknown Voice 2:</B> I hope whatever this idiot was hauling is here. Why were they in such a hurry anyway?<BR>
 		<B>Unknown Voice 1:</B> Beats me- and hand me that crowbar already.<BR>
 		<B>Unknown Voice 2:</B> Here, catch.<BR>
-		<B>Unknown Voice 1:</B> 'cha, nice. Let's see...<BR>
+		<B>Unknown Voice 1:</B> \'cha, nice. Let's see...<BR>
 		<B>(sound of metal creaking, then a loud snapping sound)</B><BR>
 		<B>Unknown Voice 1:</B> And here she is.<BR>
-		<B>Unknown Voice 2:</B> (whistling) What a beauty. How much you think it'll go for?<BR>
-		<B>Unknown Voice 1:</B> Enough we'll never have to worry about doing another job all the way out here ever again.<BR>
-		<B>Unknown Voice 2:</B> Shiny. Now let's bounce before the ess-defs show up.<BR>
+		<B>Unknown Voice 2:</B> (whistling) What a beauty. How much you think it\'ll go for?<BR>
+		<B>Unknown Voice 1:</B> Enough we\'ll never have to worry about doing another job all the way out here ever again.<BR>
+		<B>Unknown Voice 2:</B> Shiny. Now let\'s bounce before the ess-defs show up.<BR>
 		<B>Unknown Voice 1:</B> I hear that, <U>brat</U>.<BR>
 		<B>END LOG</B><BR>
 		<BR>
@@ -185,11 +185,13 @@
 		<B>BEGIN LOG</B><BR>
 		<B>(blaring alarms)</B><BR>
 		<B>Shipboard Computer:</B> Alert. Multiple impacts detected along starboard side.<BR>
-		<B>Shipboard Computer:</B> Multiple hull breaches detected. Starboard cargo hatches have been breaches.<BR>
+		<B>Shipboard Computer:</B> Multiple hull breaches detected. Starboard cargo hatches have been breached.<BR>
 		<B>Shipboard Computer:</B> Warning. Nacelle engines offline. Thrust reduced by thirty-five-point-three percent.<BR>
 		<B>Unknown Voice 1:</B> Agh! Shit! How'd they know-<BR>
 		<B>(loud explosion, sound of rushing air)</B><BR>
-		<B>Shipboard Computer:</B> Danger. Canopy breached. Automatic lockdown successfully engaged.<BR>
+		<B>Shipboard Computer:</B> Danger. Canopy breached.<BR>
+		<B>(mechanical whine, followed by a deep hiss)</B><BR>
+		<B>Shipboard Computer:</B> Automatic lockdown successfully engaged.<BR>
 		<B>Unknown Voice 1:</B> (wheezing) Mother<U>fucker!</U> Jackson, Phelps, stand by to repel boarders!<BR>
 		<B>Unknown Voice 2:</B> Roger!<BR>
 		<B>Unknown Voice 3:</B> Already there.<BR>
@@ -203,7 +205,7 @@
 		<B>Unknown Voice 4:</B> You fucking idiot!<BR>
 		<B>Unknown Voice 6:</B> Don\'t you start, you said-<BR>
 		<B>Unknown Voice 4:</B> I don\'t care what I fucking said, shit-for-brains!<BR>
-		<B>Unknown Voice 7:</B> Boss, I <U>hate</U> to rain on your little parade but SDF just popped up on my scopes, \'bout... fifty klicks out, closing fast.<BR>
+		<B>Unknown Voice 7:</B> Boss, I <U>hate</U> to rain on your little parade but SDF just popped up on my scopes, \'bout... fifty klicks out, closing fast. Be on top of us in a few minutes tops.<BR>
 		<B>Unknown Voice 4:</B> Fuck! You, dumbass! Link up with the others and grab as many crates as you can! Pray for your sake that we get the right one!<BR>
 		<B>END LOG</B><BR>
 		<BR>
@@ -222,28 +224,28 @@
 		<BR>
 		<B>BEGIN LOG</B><BR>
 		<B>Unknown Speaker 1:</B> Hey cap, you seeing this?<BR>
-		<B>Unknown Speaker 2 ("Cap"):</B> Yea-- what the fuck?<BR>
+		<B>Unknown Speaker 2 (\"Cap\"):</B> Yea-- what the fuck?<BR>
 		<B>Unknown Speaker 1:</B> Yeah that was my reaction.<BR>
 		<B>Unknown Speaker 3:</B> What are you tw-- holy shit, what <U>is</U> that?<BR>
 		<B>Unknown Speakers 1 & 2:</B> We don't know!<BR>
-		<B>Unknown Speaker 4:</B> What's all the yel-- fuck me sideways, what the hell?<BR>
-		<B>Unknown Speaker 2 ("Cap"):</B> Stars above and fucking below, they never said anything like this was in the cans... shouldn't the port bioscanners have picked this up?<BR>
-		<B>Unknown Speaker 3:</B> I <I>told</I> you that guy was one shady motherfucker, and whaddaya know.<BR>
-		<B>Unknown Speaker 1:</B> No kidding. Christ. What's the play, cap?<BR>
+		<B>Unknown Speaker 4:</B> What\'s all the yel-- fuck me sideways, what the hell?<BR>
+		<B>Unknown Speaker 2 (\"Cap\"):</B> Stars above and fucking below, they never said anything like this was in the cans... shouldn't the port bioscanners have picked this up?<BR>
+		<B>Unknown Speaker 3:</B> I <U>told</U> you that guy was one shady motherfucker, and whaddaya know.<BR>
+		<B>Unknown Speaker 1:</B> No kidding. Christ. What\'s the play, cap?<BR>
 		<B>Unknown Speaker 4:</B> I say we shoot this crap into the nearest star. Or gas giant maybe.<BR>
-		<B>Unknown Speaker 2 ("Cap"):</B> Pretty much. Get in one of the voidsuits and rig the can up with some spare O2 canisters -- plot it a course that'll sling it right into V3's atmosphere.<BR>
-		<B>Unknown Speaker 1:</B> Yeah, sure. That shouldn't take long. Then what?<BR>
-		<B>Unknown Speaker 2 ("Cap"):</B> Let's see... ah, perfect. There's another ship passing close by, and I know the captain. We'll take our suits out and have her pick us up. Max, you still got those old cutting charges I told you to get rid of?<BR>
-		<B>Unknown Speaker 4 ("Max"):</B> No. (pause) ...but also yes.<BR>
-		<B>Unknown Speaker 2 ("Cap"):</B> Your propensity for ignoring my orders has once again paid off. Fuck. I'm gonna miss the Unity, but... better this way. I want holes in both sides of the engine bay and one in the portside crawlspace. Lock all the doors open and depressurize the main cabins. Drain as much fuel as you can, break up the main power block, and scatter the parts.<BR>
+		<B>Unknown Speaker 2 (\"Cap\"):</B> Pretty much. Get in one of the voidsuits and rig the can up with some spare O2 canisters -- plot it a course that\'ll sling it right into V3\'s atmosphere.<BR>
+		<B>Unknown Speaker 1:</B> Yeah, sure. That shouldn\'t take long. Then what?<BR>
+		<B>Unknown Speaker 2 (\"Cap\"):</B> Let\'s see... ah, perfect. There's another ship passing close by, and I know the captain. We'll take our suits out and have her pick us up. Max, you still got those old cutting charges I told you to get rid of?<BR>
+		<B>Unknown Speaker 4 (\"Max\"):</B> No. (pause) ...but also yes.<BR>
+		<B>Unknown Speaker 2 (\"Cap\"):</B> Your propensity for ignoring my orders has once again paid off... man, I\'m gonna miss the Unity, but... better this way. I want holes in both sides of the engine bay and one in the portside crawlspace. Lock all the doors open and depressurize the main cabins. Drain as much fuel as you can, break up the main power block, and scatter the parts.<BR>
 		<B>Unknown Speaker 1:</B> You want us to scuttle her, chief?<BR>
-		<B>Unknown Speaker 2 ("Cap"):</B> Nail on the head, my friend.<BR>
-		<B>Unknown Speaker 3:</B> Let's get rid of that fucking can first, I think it just blinked at me.<BR>
+		<B>Unknown Speaker 2 (\"Cap\"):</B> Nail on the head, my friend.<BR>
+		<B>Unknown Speaker 3:</B> Let\'s get rid of that fucking can first, I think it just blinked at me.<BR>
 		<B>END LOG</B><BR>
 		<BR>
-		<B>CATALOGUER VOBCE RECOGNBTBON RESULTS:</B><BR>
+		<B>CATALOGUER VOICE RECOGNITION RESULTS:</B><BR>
 		<B>SPEAKER ONE:</B> No match.<BR>
-		<B>SPEAKER TWO, "CAP":</B> Predicted to be Jeremiah Wells, human, last registered owner of the ITV Unity and small-time smuggler of fake alien artefacts. Wanted for smuggling and sale of said (fake) alien artefacts. 87% confidence.<BR>
+		<B>SPEAKER TWO, \"CAP\":</B> Predicted to be Jeremiah Wells, human, last registered owner of the ITV Unity and small-time smuggler of fake alien artefacts. Wanted for smuggling and sale of said (fake) alien artefacts. 87% confidence.<BR>
 		<B>SPEAKER THREE:</B> Predicted to be Allie Wells, human, niece of Captain Wells. 90% confidence.<BR>
-		<B>SPEAKER FOUR, "MAX":</B> Predicted to be Maxwell Ulysses Sarevic, zorren, known smuggler, and wanted in the Elysian Colonies for liberation of slaves and, quote, \'harshing my vibe, and being a, like, <U>total lamer</U>, dude\', unquote. 99% confidence.
+		<B>SPEAKER FOUR, \"MAX\":</B> Predicted to be Maxwell Ulysses Sarevic, zorren, known smuggler, and wanted in the Elysian Colonies for liberation of slaves and, quote, \'harshing my vibe, and being a, like, <U>total lamer</U>, dude\', unquote. 99% confidence.
 	"}

--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -203,6 +203,19 @@
 	corpsesuit = /obj/item/clothing/suit/space/void/mining
 	corpsemask = /obj/item/clothing/mask/breath
 	corpsehelmet = /obj/item/clothing/head/helmet/space/void/mining
+	
+//VORESTATION ADD START
+/obj/effect/landmark/corpse/vintage/pilot
+	name = "Pilot"
+	corpseuniform = /obj/item/clothing/under/rank/engineer
+	corpsesuit = /obj/item/clothing/suit/space/void/refurb/pilot
+	corpsemask = /obj/item/clothing/mask/breath
+	corpsehelmet = /obj/item/clothing/head/helmet/space/void/refurb/pilot
+	corpseshoes = /obj/item/clothing/shoes/orange
+	corpseid = 1
+	corpseidjob = "Pilot"
+	corpseidaccess = "Pilot"
+//VORESTATION ADD END
 
 
 /////////////////Officers//////////////////////

--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -207,14 +207,11 @@
 //VORESTATION ADD START
 /obj/effect/landmark/corpse/vintage/pilot
 	name = "Pilot"
-	corpseuniform = /obj/item/clothing/under/rank/engineer
+	corpseuniform = /obj/item/clothing/under/color/grey
 	corpsesuit = /obj/item/clothing/suit/space/void/refurb/pilot
-	corpsemask = /obj/item/clothing/mask/breath
 	corpsehelmet = /obj/item/clothing/head/helmet/space/void/refurb/pilot
-	corpseshoes = /obj/item/clothing/shoes/orange
-	corpseid = 1
-	corpseidjob = "Pilot"
-	corpseidaccess = "Pilot"
+	corpseshoes = /obj/item/clothing/shoes/black
+	corpseback = /obj/item/weapon/tank/oxygen
 //VORESTATION ADD END
 
 

--- a/maps/offmap_vr/om_ships/gecko_cr_wreck.dmm
+++ b/maps/offmap_vr/om_ships/gecko_cr_wreck.dmm
@@ -219,7 +219,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/structure/closet/crate,
+/obj/structure/prop/blackbox/gecko_wreck,
 /turf/simulated/floor/plating,
 /area/shuttle/gecko_cr_cockpit_wreck)
 "fL" = (
@@ -235,10 +235,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
-/obj/effect/decal/remains/human,
-/obj/item/weapon/tank/air,
-/obj/item/clothing/suit/space/void/refurb/marine,
-/obj/item/clothing/head/helmet/space/void/refurb/marine,
 /turf/simulated/floor/tiled/techmaint,
 /area/shuttle/gecko_cr_cockpit_wreck)
 "fR" = (
@@ -1098,6 +1094,7 @@
 	dir = 1;
 	pixel_y = 42
 	},
+/obj/random/multiple/voidsuit/vintage,
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/gecko_cr_cockpit_wreck)
 "vI" = (
@@ -1597,6 +1594,7 @@
 	},
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/light/flicker,
+/obj/random/multiple/voidsuit/vintage,
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/gecko_cr_cockpit_wreck)
 "FA" = (
@@ -1962,10 +1960,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
-/obj/effect/decal/remains,
-/obj/item/weapon/tank/oxygen/yellow,
-/obj/item/clothing/suit/space/void/refurb/engineering,
-/obj/item/clothing/head/helmet/space/void/refurb/engineering,
 /turf/simulated/floor/tiled/techmaint/airless,
 /area/shuttle/gecko_cr_engineering_wreck)
 "LW" = (

--- a/maps/offmap_vr/om_ships/mackerel_lc_wreck.dmm
+++ b/maps/offmap_vr/om_ships/mackerel_lc_wreck.dmm
@@ -74,8 +74,6 @@
 /area/shuttle/mackerel_lc_wreck)
 "cD" = (
 /obj/effect/floor_decal/industrial/warning,
-/obj/item/weapon/bone/skull,
-/obj/item/clothing/head/helmet/space/void/refurb/pilot,
 /obj/item/weapon/material/shard/shrapnel,
 /obj/item/weapon/material/shard/shrapnel,
 /turf/simulated/floor/tiled/techmaint/airless,
@@ -616,6 +614,10 @@
 /obj/machinery/door/airlock/hatch,
 /turf/simulated/floor/tiled/techmaint,
 /area/shuttle/mackerel_lc_wreck)
+"Iu" = (
+/obj/structure/prop/blackbox/mackerel_wreck,
+/turf/simulated/floor/airless,
+/area/shuttle/mackerel_lc_wreck)
 "Jq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -890,9 +892,8 @@
 /turf/simulated/floor/airless,
 /area/shuttle/mackerel_lc_wreck)
 "Zp" = (
-/obj/item/weapon/bone/ribs,
-/obj/item/clothing/suit/space/void/refurb/pilot,
 /obj/effect/decal/cleanable/blood,
+/obj/effect/landmark/corpse/vintage/pilot,
 /turf/simulated/floor/tiled/techmaint/airless,
 /area/shuttle/mackerel_lc_wreck)
 "ZJ" = (
@@ -1061,7 +1062,7 @@ ka
 ka
 tV
 ka
-WP
+ka
 WP
 WP
 "}
@@ -1085,8 +1086,8 @@ fL
 JG
 kU
 dG
+Iu
 ka
-WP
 WP
 WP
 "}
@@ -1235,8 +1236,8 @@ zo
 KZ
 rQ
 dG
+oq
 ka
-WP
 WP
 WP
 "}
@@ -1261,7 +1262,7 @@ ka
 ka
 tV
 ka
-WP
+ka
 BB
 WP
 "}

--- a/maps/offmap_vr/om_ships/salamander_wreck.dmm
+++ b/maps/offmap_vr/om_ships/salamander_wreck.dmm
@@ -448,6 +448,10 @@
 	},
 /turf/simulated/floor/tiled/techmaint/airless,
 /area/shuttle/salamander_wreck_cockpit)
+"gx" = (
+/obj/structure/prop/blackbox/salamander_wreck,
+/turf/simulated/floor/plating,
+/area/shuttle/salamander_wreck)
 "gC" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled/techfloor{
@@ -2322,7 +2326,7 @@ ON
 mO
 VT
 Vs
-qQ
+gx
 VT
 WP
 "}

--- a/maps/submaps/pois_vr/debris_field/_templates.dm
+++ b/maps/submaps/pois_vr/debris_field/_templates.dm
@@ -231,6 +231,34 @@
 	allow_duplicates = FALSE
 	discard_prob = 50
 
+/datum/map_template/debrisfield/new_escape_pod
+	name = "Escape Pod"
+	mappath = 'new_escapepod.dmm'
+	cost = 10
+	allow_duplicates = FALSE
+	discard_prob = 10
+	
+/datum/map_template/debrisfield/new_escape_pod_infested_xeno
+	name = "Xeno-Infested Escape Pod"
+	mappath = 'new_escapepod_xeno.dmm'
+	cost = 20
+	allow_duplicates = FALSE
+	discard_prob = 25
+	
+/datum/map_template/debrisfield/new_escape_pod_infested_carp
+	name = "Carp-Infested Escape Pod"
+	mappath = 'new_escapepod_carp.dmm'
+	cost = 20
+	allow_duplicates = FALSE
+	discard_prob = 25
+
+/datum/map_template/debrisfield/new_escape_pod_infested_robo
+	name = "Robo-Infested Escape Pod"
+	mappath = 'new_escapepod_robo.dmm'
+	cost = 20
+	allow_duplicates = FALSE
+	discard_prob = 25
+
 /datum/map_template/debrisfield/gutted_mackerel
 	name = "Gutted Mackerel LC"
 	mappath = 'maps/offmap_vr/om_ships/mackerel_lc_wreck.dmm'

--- a/maps/submaps/pois_vr/debris_field/debrisfield_things.dm
+++ b/maps/submaps/pois_vr/debris_field/debrisfield_things.dm
@@ -83,3 +83,23 @@
 				prob(2);/obj/item/slime_extract/light_pink,
 				prob(1);/obj/item/slime_extract/grey,
 				prob(1);/obj/item/slime_extract/rainbow)
+
+/obj/item/weapon/paper/robo_escape_pod
+	name = "faded note"
+	info = {"<i>This paper is old and the shaky writing has faded, rendering it difficult to read.</i><br>\
+whichever poor bastard finds this pod<br>\
+<br>\
+im sorry<br>\
+we tried to do everything we could for her<br>\
+but in the end the virus was too much<br>\
+rnd wanted to take her apart and document what happened<br>\
+but after watching her tear through three of my men like they were nothing<br>\
+i just. i couldnt. they might fire me, but fuck the suits. the safety of the other staff here matter more.<br>\
+her fucking dignity matters more.<br>\
+<br>\
+we managed to bait her into one of the escape pods. fired her out into the black.<br>\
+<br>\
+hope nobody ever has to read this. has to find her.<br>\
+if you do, im sorry.<br>\
+i just hope whatever happens, she finds the mercy we werent equipped to give her.<br>\
+<i>The author's signature is smudged beyond recognition.</i>"}

--- a/maps/submaps/pois_vr/debris_field/new_escapepod.dmm
+++ b/maps/submaps/pois_vr/debris_field/new_escapepod.dmm
@@ -1,0 +1,91 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/turf/simulated/wall/rshull,
+/area/submap/debrisfield/misc_debris)
+"n" = (
+/turf/simulated/floor/reinforced/airless,
+/area/submap/debrisfield/misc_debris)
+"z" = (
+/obj/structure/closet/walllocker/emerglocker/south,
+/obj/structure/bed/chair/bay/shuttle{
+	dir = 1
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/submap/debrisfield/misc_debris)
+"D" = (
+/obj/structure/bed/chair/bay/shuttle,
+/obj/structure/closet/walllocker/emerglocker/north,
+/turf/simulated/floor/reinforced/airless,
+/area/submap/debrisfield/misc_debris)
+"O" = (
+/obj/structure/bed/chair/bay/shuttle{
+	dir = 1
+	},
+/obj/structure/closet/walllocker/emerglocker/south,
+/turf/simulated/floor/reinforced/airless,
+/area/submap/debrisfield/misc_debris)
+"P" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/submap/debrisfield/misc_debris)
+"R" = (
+/obj/structure/closet/walllocker/emerglocker/north,
+/obj/structure/bed/chair/bay/shuttle,
+/turf/simulated/floor/reinforced/airless,
+/area/submap/debrisfield/misc_debris)
+"Y" = (
+/obj/machinery/door/airlock/external{
+	name = "Escape Pod Door"
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/submap/debrisfield/misc_debris)
+
+(1,1,1) = {"
+a
+P
+P
+P
+a
+"}
+(2,1,1) = {"
+a
+D
+n
+O
+a
+"}
+(3,1,1) = {"
+a
+D
+n
+O
+a
+"}
+(4,1,1) = {"
+a
+R
+n
+z
+a
+"}
+(5,1,1) = {"
+a
+D
+n
+O
+a
+"}
+(6,1,1) = {"
+a
+a
+Y
+a
+a
+"}

--- a/maps/submaps/pois_vr/debris_field/new_escapepod_carp.dmm
+++ b/maps/submaps/pois_vr/debris_field/new_escapepod_carp.dmm
@@ -1,0 +1,87 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/turf/simulated/wall/rshull,
+/area/submap/debrisfield/misc_debris)
+"F" = (
+/turf/simulated/floor/airless,
+/area/submap/debrisfield/misc_debris)
+"K" = (
+/mob/living/simple_mob/animal/space/carp/large,
+/turf/simulated/floor/airless,
+/area/submap/debrisfield/misc_debris)
+"N" = (
+/obj/structure/grille/broken,
+/turf/simulated/floor/airless,
+/area/submap/debrisfield/misc_debris)
+"R" = (
+/obj/structure/grille/broken,
+/mob/living/simple_mob/animal/space/carp,
+/turf/simulated/floor/airless,
+/area/submap/debrisfield/misc_debris)
+"S" = (
+/obj/machinery/door/airlock/external{
+	density = 0;
+	icon_state = "door_open";
+	name = "Escape Pod Door";
+	opacity = 0
+	},
+/turf/simulated/floor/airless,
+/area/submap/debrisfield/misc_debris)
+"U" = (
+/obj/structure/grille/broken,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/airless,
+/area/submap/debrisfield/misc_debris)
+"W" = (
+/mob/living/simple_mob/animal/space/carp,
+/turf/simulated/floor/airless,
+/area/submap/debrisfield/misc_debris)
+"Z" = (
+/obj/effect/gibspawner/human,
+/turf/simulated/floor/airless,
+/area/submap/debrisfield/misc_debris)
+
+(1,1,1) = {"
+a
+U
+N
+R
+a
+"}
+(2,1,1) = {"
+a
+W
+Z
+F
+a
+"}
+(3,1,1) = {"
+a
+F
+K
+F
+a
+"}
+(4,1,1) = {"
+a
+F
+Z
+W
+a
+"}
+(5,1,1) = {"
+a
+W
+F
+F
+a
+"}
+(6,1,1) = {"
+a
+a
+S
+a
+a
+"}

--- a/maps/submaps/pois_vr/debris_field/new_escapepod_robo.dmm
+++ b/maps/submaps/pois_vr/debris_field/new_escapepod_robo.dmm
@@ -1,0 +1,115 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/turf/simulated/wall/rshull,
+/area/submap/debrisfield/misc_debris)
+"g" = (
+/obj/structure/bed/chair/bay/shuttle{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/blood/oil,
+/turf/simulated/floor/reinforced/airless,
+/area/submap/debrisfield/misc_debris)
+"i" = (
+/mob/living/simple_mob/vore/aggressive/corrupthound/space,
+/turf/simulated/floor/reinforced/airless,
+/area/submap/debrisfield/misc_debris)
+"m" = (
+/obj/structure/bed/chair/bay/shuttle,
+/obj/effect/decal/cleanable/blood/oil,
+/obj/effect/gibspawner/robot,
+/turf/simulated/floor/reinforced/airless,
+/area/submap/debrisfield/misc_debris)
+"q" = (
+/turf/simulated/floor/reinforced/airless,
+/area/submap/debrisfield/misc_debris)
+"r" = (
+/obj/effect/gibspawner/robot,
+/turf/simulated/floor/reinforced/airless,
+/area/submap/debrisfield/misc_debris)
+"v" = (
+/obj/structure/bed/chair/bay/shuttle{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/blood/oil,
+/obj/effect/gibspawner/robot,
+/turf/simulated/floor/reinforced/airless,
+/area/submap/debrisfield/misc_debris)
+"y" = (
+/obj/effect/decal/cleanable/blood/oil,
+/turf/simulated/wall/rshull,
+/area/submap/debrisfield/misc_debris)
+"B" = (
+/obj/effect/decal/cleanable/blood/oil,
+/obj/item/weapon/paper/robo_escape_pod,
+/turf/simulated/floor/reinforced/airless,
+/area/submap/debrisfield/misc_debris)
+"D" = (
+/obj/machinery/door/airlock/external{
+	name = "Escape Pod Door"
+	},
+/obj/effect/decal/cleanable/blood/oil,
+/turf/simulated/floor/reinforced/airless,
+/area/submap/debrisfield/misc_debris)
+"E" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/submap/debrisfield/misc_debris)
+"Q" = (
+/obj/structure/bed/chair/bay/shuttle,
+/obj/effect/decal/cleanable/blood/oil,
+/turf/simulated/floor/reinforced/airless,
+/area/submap/debrisfield/misc_debris)
+"S" = (
+/obj/effect/decal/cleanable/blood/oil,
+/turf/simulated/floor/reinforced/airless,
+/area/submap/debrisfield/misc_debris)
+
+(1,1,1) = {"
+a
+E
+E
+E
+y
+"}
+(2,1,1) = {"
+y
+S
+S
+v
+a
+"}
+(3,1,1) = {"
+a
+m
+i
+S
+a
+"}
+(4,1,1) = {"
+a
+Q
+S
+q
+a
+"}
+(5,1,1) = {"
+a
+B
+r
+g
+a
+"}
+(6,1,1) = {"
+y
+a
+D
+a
+y
+"}

--- a/maps/submaps/pois_vr/debris_field/new_escapepod_xeno.dmm
+++ b/maps/submaps/pois_vr/debris_field/new_escapepod_xeno.dmm
@@ -1,0 +1,119 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/turf/simulated/wall/rshull,
+/area/submap/debrisfield/misc_debris)
+"f" = (
+/obj/structure/grille/broken,
+/obj/effect/alien/weeds,
+/obj/effect/alien/resin/membrane,
+/turf/simulated/floor/airless,
+/area/submap/debrisfield/misc_debris)
+"h" = (
+/obj/effect/alien/resin/wall,
+/obj/effect/alien/weeds,
+/turf/space,
+/area/submap/debrisfield/misc_debris)
+"k" = (
+/obj/effect/alien/weeds,
+/mob/living/simple_mob/animal/space/alien,
+/turf/simulated/floor/airless,
+/area/submap/debrisfield/misc_debris)
+"r" = (
+/obj/structure/grille/broken,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/effect/alien/weeds,
+/obj/effect/alien/resin/membrane,
+/turf/simulated/floor/airless,
+/area/submap/debrisfield/misc_debris)
+"t" = (
+/obj/effect/alien/weeds,
+/mob/living/simple_mob/animal/space/alien/sentinel,
+/turf/simulated/floor/airless,
+/area/submap/debrisfield/misc_debris)
+"v" = (
+/obj/machinery/door/airlock/external{
+	density = 0;
+	icon_state = "door_open";
+	name = "Escape Pod Door";
+	opacity = 0
+	},
+/obj/effect/alien/weeds,
+/turf/simulated/floor/airless,
+/area/submap/debrisfield/misc_debris)
+"A" = (
+/obj/effect/alien/weeds/node,
+/turf/simulated/floor/airless,
+/area/submap/debrisfield/misc_debris)
+"D" = (
+/obj/effect/alien/weeds,
+/obj/effect/alien/resin/wall,
+/turf/simulated/wall/rshull,
+/area/submap/debrisfield/misc_debris)
+"T" = (
+/obj/structure/grille/broken,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/effect/alien/weeds,
+/obj/effect/alien/resin/membrane,
+/turf/simulated/floor/airless,
+/area/submap/debrisfield/misc_debris)
+"U" = (
+/obj/effect/alien/weeds,
+/turf/simulated/floor/airless,
+/area/submap/debrisfield/misc_debris)
+"W" = (
+/obj/effect/alien/weeds,
+/obj/effect/alien/egg,
+/turf/simulated/floor/airless,
+/area/submap/debrisfield/misc_debris)
+"X" = (
+/obj/effect/alien/weeds,
+/mob/living/simple_mob/animal/space/alien/drone,
+/turf/simulated/floor/airless,
+/area/submap/debrisfield/misc_debris)
+
+(1,1,1) = {"
+a
+T
+f
+r
+a
+"}
+(2,1,1) = {"
+h
+X
+U
+W
+D
+"}
+(3,1,1) = {"
+a
+k
+A
+t
+D
+"}
+(4,1,1) = {"
+a
+U
+U
+U
+a
+"}
+(5,1,1) = {"
+h
+W
+U
+X
+a
+"}
+(6,1,1) = {"
+a
+a
+v
+a
+a
+"}


### PR DESCRIPTION
Some minor updates to the wrecked ships and debris field;
- Adds a new escape pod model with four variants (one normal but empty, three infested)
- Replaced the body in the Mackerel wreck with a corpse spawner
- Added black boxes to the Mackerel, Salamander, and Gecko wrecks for cataloguer points and Deep Lore
- Removed the dead bodies from the Gecko (to match the new blackbox recording) and added a pair of random refurb suit spawners instead