### PR TITLE
IAA Office stuff

### DIFF
--- a/maps/tether/tether-03-surface3.dmm
+++ b/maps/tether/tether-03-surface3.dmm
@@ -20652,13 +20652,6 @@
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 8
 	},
-/obj/machinery/button/remote/blast_door{
-	id = "mechbay-inner";
-	name = "Mech Bay";
-	pixel_y = -26;
-	req_access = list(29,47);
-	req_one_access = list(47)
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/lower/third_south)
 "aHK" = (
@@ -21925,17 +21918,12 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/rnd/robotics/mechbay)
 "aJS" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
+/obj/machinery/computer/security/telescreen/entertainment{
+	icon_state = "frame";
+	pixel_x = -64
 	},
-/obj/machinery/button/remote/blast_door{
-	id = "mechbay";
-	name = "Mech Bay Access";
-	pixel_x = -30;
-	pixel_y = 30
-	},
-/turf/simulated/floor/bluegrid,
-/area/rnd/robotics/mechbay)
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
 "aJT" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
@@ -37649,6 +37637,31 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_three_hall)
+"dbk" = (
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/blast/regular{
+	dir = 4;
+	id = "mechbay";
+	name = "Mech Bay"
+	},
+/obj/machinery/button/remote/blast_door{
+	id = "mechbay-inner";
+	name = "Mech Bay";
+	pixel_x = 27;
+	pixel_y = -5;
+	req_access = list(29,47);
+	req_one_access = list(47)
+	},
+/obj/machinery/button/remote/blast_door{
+	id = "mechbay";
+	name = "Mech Bay";
+	pixel_x = 27;
+	pixel_y = 6;
+	req_access = list(29,47);
+	req_one_access = list(47)
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/rnd/robotics/mechbay)
 "ddl" = (
 /obj/effect/floor_decal/corner_steel_grid{
 	dir = 5
@@ -41618,13 +41631,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/breakroom)
-"taN" = (
-/obj/machinery/computer/security/telescreen/entertainment{
-	icon_state = "frame";
-	pixel_x = -64
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/bar)
 "tcW" = (
 /obj/effect/shuttle_landmark{
 	base_area = /area/tether/surfacebase/shuttle_pad;
@@ -53054,7 +53060,7 @@ aXd
 aHQ
 aIx
 aJg
-aJS
+aJT
 aKO
 aLU
 aKO
@@ -53337,7 +53343,7 @@ fgW
 aGW
 aHR
 aAs
-aJg
+dbk
 aJU
 aKQ
 aLV
@@ -57586,7 +57592,7 @@ bfe
 avy
 bgf
 avM
-taN
+aJS
 asX
 aIl
 aHB

--- a/maps/tether/tether-03-surface3.dmm
+++ b/maps/tether/tether-03-surface3.dmm
@@ -3008,9 +3008,15 @@
 /obj/effect/floor_decal/corner/red/border{
 	dir = 5
 	},
-/obj/structure/sign/poster{
-	pixel_x = 32
+/obj/structure/closet/walllocker_double{
+	dir = 4;
+	pixel_x = 28
 	},
+/obj/item/device/flash,
+/obj/item/device/flash,
+/obj/random/drinkbottle,
+/obj/item/device/camera_film,
+/obj/item/device/tape/random,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/iaa/officecommon)
 "aeu" = (
@@ -30675,10 +30681,6 @@
 	dir = 1;
 	pixel_y = -25
 	},
-/obj/machinery/computer/security/telescreen/entertainment{
-	icon_state = "frame";
-	pixel_x = 32
-	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "baX" = (
@@ -37136,7 +37138,7 @@
 	},
 /obj/structure/window/reinforced/polarized{
 	dir = 8;
-	id = "cmo_office"
+	id = "iaar"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/iaa/officeb)
@@ -37151,7 +37153,7 @@
 	},
 /obj/structure/window/reinforced/polarized{
 	dir = 8;
-	id = "cmo_office"
+	id = "iaar"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/iaa/officeb)
@@ -37161,7 +37163,7 @@
 	},
 /obj/structure/window/reinforced/polarized{
 	dir = 8;
-	id = "cmo_office"
+	id = "iaar"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/iaa/officeb)
@@ -37171,7 +37173,7 @@
 	},
 /obj/structure/window/reinforced/polarized{
 	dir = 8;
-	id = "cmo_office"
+	id = "iaar"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/iaa/officeb)
@@ -37364,10 +37366,16 @@
 /obj/effect/floor_decal/spline/plain{
 	dir = 8
 	},
-/obj/machinery/alarm{
-	dir = 4;
-	pixel_x = -22
+/obj/structure/closet/walllocker_double{
+	dir = 8;
+	pixel_x = -28
 	},
+/obj/item/device/camera,
+/obj/item/device/camera_film,
+/obj/item/device/taperecorder,
+/obj/item/device/tape/random,
+/obj/item/device/tape/random,
+/obj/item/weapon/storage/secure/briefcase,
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/iaa/officea)
 "ceN" = (
@@ -39959,6 +39967,9 @@
 /obj/effect/floor_decal/spline/plain{
 	dir = 5
 	},
+/obj/machinery/alarm{
+	pixel_y = 22
+	},
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/iaa/officeb)
 "mDf" = (
@@ -41216,6 +41227,9 @@
 /obj/effect/floor_decal/spline/plain{
 	dir = 9
 	},
+/obj/machinery/alarm{
+	pixel_y = 22
+	},
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/iaa/officea)
 "rEZ" = (
@@ -41604,6 +41618,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/breakroom)
+"taN" = (
+/obj/machinery/computer/security/telescreen/entertainment{
+	icon_state = "frame";
+	pixel_x = -64
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
 "tcW" = (
 /obj/effect/shuttle_landmark{
 	base_area = /area/tether/surfacebase/shuttle_pad;
@@ -42122,6 +42143,16 @@
 /obj/effect/floor_decal/spline/plain,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
+	},
+/obj/item/weapon/paper_bin,
+/obj/item/weapon/pen,
+/obj/item/weapon/pen/blue{
+	pixel_x = 2;
+	pixel_y = 3
+	},
+/obj/item/weapon/pen/blade/red{
+	pixel_x = -2;
+	pixel_y = -2
 	},
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/iaa/officea)
@@ -42805,10 +42836,16 @@
 /obj/effect/floor_decal/spline/plain{
 	dir = 4
 	},
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 22
+/obj/structure/closet/walllocker_double{
+	dir = 4;
+	pixel_x = 28
 	},
+/obj/item/device/camera,
+/obj/item/device/camera_film,
+/obj/item/device/taperecorder,
+/obj/item/device/tape/random,
+/obj/item/device/tape/random,
+/obj/item/weapon/storage/secure/briefcase,
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/iaa/officeb)
 "xHg" = (
@@ -42959,6 +42996,16 @@
 /obj/effect/floor_decal/spline/plain,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
+	},
+/obj/item/weapon/paper_bin,
+/obj/item/weapon/pen,
+/obj/item/weapon/pen/blade/red{
+	pixel_x = -2;
+	pixel_y = -2
+	},
+/obj/item/weapon/pen/blue{
+	pixel_x = 2;
+	pixel_y = 3
 	},
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/iaa/officeb)
@@ -57539,7 +57586,7 @@ bfe
 avy
 bgf
 avM
-asX
+taN
 asX
 aIl
 aHB


### PR DESCRIPTION
Fixxes the right offices electrochromic windows, adds paper, pens, recorders, cameras, secure briefcases, and flashes to their setup.

Also fixes #9484 puts both interior and exterior controls where you can reach them on either side of the exterior door, both buttons being access restricted. That way whatever way you want to configure the doors, you can from inside or out. 