### PR TITLE
Changes formatting for RESPAWN_MESSAGE configuration to be more visible

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -496,7 +496,7 @@ var/list/gamemode_cache = list()
 					config.respawn_time = raw_minutes MINUTES
 
 				if ("respawn_message")
-					config.respawn_message = value
+					config.respawn_message = "<span class='notice'><B>[value]</B></span>"
 
 				if ("servername")
 					config.server_name = value


### PR DESCRIPTION
For some reason, the mirror pull bot decided to take the entire polaris configuration.dm and send it over to us, not just the part my PR changed.

This PR fixes the mirror bot's mistake.
PR in question:
https://github.com/VOREStation/VOREStation/pull/9499