### PR TITLE
Makes pixel shifting work while resting

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -682,7 +682,7 @@
 
 // facing verbs
 /mob/proc/canface()
-	if(!canmove)						return 0
+//	if(!canmove)						return 0 //VOREStation Edit. Redundant check that only affects conscious proning, actual inability to turn and shift around handled by actual inabilities.
 	if(stat)							return 0
 	if(anchored)						return 0
 	if(transforming)						return 0


### PR DESCRIPTION
Every other method of incapacitation is handled by the other procs, leaving "canmove" to functionally only hinder conscious proning. Might send to polaris at some point, but they still lack the features this "fixes" and could probably use a proper de-spaghettification rework on the whole system