### PR TITLE
[FEATURE] Size Related Content Updates

### DIFF
--- a/code/modules/clothing/under/miscellaneous_vr.dm
+++ b/code/modules/clothing/under/miscellaneous_vr.dm
@@ -73,7 +73,7 @@
 		to_chat(H,"<span class='warning'>You must be WEARING the uniform to change your size.</span>")
 		return
 
-	var/new_size = input("Put the desired size (25-200%)", "Set Size", 200) as num|null
+	var/new_size = input("Put the desired size (25-200%), or (1-600%) in dormitory areas.", "Set Size", 200) as num|null
 
 	//Check AGAIN because we accepted user input which is blocking.
 	if (src != H.w_uniform)
@@ -89,7 +89,7 @@
 		H.update_icons() //Just want the matrix transform
 		return
 
-	if (!ISINRANGE(new_size,25,200))
+	if (!H.size_range_check(new_size))
 		to_chat(H,"<span class='notice'>The safety features of the uniform prevent you from choosing this size.</span>")
 		return
 

--- a/code/modules/mob/living/carbon/human/emote_vr.dm
+++ b/code/modules/mob/living/carbon/human/emote_vr.dm
@@ -181,6 +181,14 @@
 
 	return FALSE
 
+/mob/living/carbon/human/verb/toggle_resizing_immunity()
+	set name = "Toggle Resizing Immunity"
+	set desc = "Toggles your ability to resist resizing attempts"
+	set category = "IC"
+
+	resizable = !resizable
+	to_chat(src, "<span class='notice'>You are now [resizable ? "susceptible" : "immune"] to being resized.</span>")
+
 
 /mob/living/carbon/human/proc/handle_flip_vr()
 	var/original_density = density

--- a/code/modules/mob/living/carbon/human/human_defines_vr.dm
+++ b/code/modules/mob/living/carbon/human/human_defines_vr.dm
@@ -9,6 +9,7 @@
 	var/impersonate_bodytype //For impersonating a bodytype
 	var/ability_flags = 0	//Shadekin abilities/potentially other species-based?
 	var/sensorpref = 5		//Suit sensor loadout pref
+	var/unnaturally_resized = FALSE 		//If one became larger than 200%, or smaller than 25%. This flag is needed for the case when admins want someone to be very big or very small outside of dorms.
 	var/wings_hidden = FALSE
 
 /mob/living/carbon/human/proc/shadekin_get_energy()

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -62,6 +62,8 @@
 
 	//No need to update all of these procs if the guy is dead.
 	fall() //VORESTATION EDIT. Prevents people from floating
+	if(unnaturally_resized)	//VORESTATION EDIT.
+		handle_unnatural_size()
 	if(stat != DEAD && !stasis)
 		//Updates the number of stored chemicals for powers
 		handle_changeling()

--- a/code/modules/mob/living/carbon/human/life_vr.dm
+++ b/code/modules/mob/living/carbon/human/life_vr.dm
@@ -78,3 +78,10 @@
 	// Moving around increases germ_level faster
 	if(germ_level < GERM_LEVEL_MOVE_CAP && prob(8))
 		germ_level++
+
+/mob/living/carbon/human/proc/handle_unnatural_size()
+	if(!in_dorms())
+		if(src.size_multiplier > 2)
+			src.resize(2)
+		else if (src.size_multiplier < 0.25)
+			src.resize(0.25)

--- a/code/modules/mob/living/carbon/human/species/station/protean_vr/protean_powers.dm
+++ b/code/modules/mob/living/carbon/human/species/station/protean_vr/protean_powers.dm
@@ -282,9 +282,9 @@
 		to_chat(user,"<span class='warning'>You don't have a working refactory module!</span>")
 		return
 
-	var/nagmessage = "Adjust your mass to be a size between 25 to 200%. Up-sizing consumes metal, downsizing returns metal."
+	var/nagmessage = "Adjust your mass to be a size between 25 to 200% (or between 1 to 600% in dorms area). Up-sizing consumes metal, downsizing returns metal."
 	var/new_size = input(user, nagmessage, "Pick a Size", user.size_multiplier*100) as num|null
-	if(!new_size || !ISINRANGE(new_size,25,200))
+	if(!new_size || !size_range_check(new_size))
 		return
 
 	var/size_factor = new_size/100

--- a/code/modules/mob/living/living_defines_vr.dm
+++ b/code/modules/mob/living/living_defines_vr.dm
@@ -5,6 +5,7 @@
 	var/ooc_notes = null
 	appearance_flags = TILE_BOUND|PIXEL_SCALE|KEEP_TOGETHER
 	var/hunger_rate = DEFAULT_HUNGER_FACTOR
+	var/resizable = TRUE
 
 //custom say verbs
 	var/custom_say = null

--- a/code/modules/nifsoft/software/15_misc.dm
+++ b/code/modules/nifsoft/software/15_misc.dm
@@ -127,17 +127,15 @@
 
 /datum/nifsoft/sizechange/activate()
 	if((. = ..()))
-		var/new_size = input("Put the desired size (25-200%)", "Set Size", 200) as num|null
+		var/new_size = input("Put the desired size (25-200%), or (1-600%) in dormitory areas.", "Set Size", 200) as num|null
 
-		if (!ISINRANGE(new_size,25,200))
+		if (!nif.human.size_range_check(new_size))
 			to_chat(nif.human,"<span class='notice'>The safety features of the NIF Program prevent you from choosing this size.</span>")
 			return
 		else
-			nif.human.resize(new_size/100)
-			to_chat(nif.human,"<span class='notice'>You set the size to [new_size]%</span>")
-
-		nif.human.visible_message("<span class='warning'>Swirling grey mist envelops [nif.human] as they change size!</span>","<span class='notice'>Swirling streams of nanites wrap around you as you change size!</span>")
-
+			if(nif.human.resize(new_size/100))
+				to_chat(nif.human,"<span class='notice'>You set the size to [new_size]%</span>")
+				nif.human.visible_message("<span class='warning'>Swirling grey mist envelops [nif.human] as they change size!</span>","<span class='notice'>Swirling streams of nanites wrap around you as you change size!</span>")
 		spawn(0)
 			deactivate()
 

--- a/code/modules/vore/resizing/sizegun_vr.dm
+++ b/code/modules/vore/resizing/sizegun_vr.dm
@@ -41,8 +41,8 @@
 	set category = "Object"
 	set src in view(1)
 
-	var/size_select = input("Put the desired size (25-200%)", "Set Size", size_set_to * 100) as num
-	if(size_select > 200 || size_select < 25)
+	var/size_select = input("Put the desired size (25-200%), (1-600%) in dormitory areas.", "Set Size", size_set_to * 100) as num
+	if(!size_range_check(size_select))
 		to_chat(usr, "<span class='notice'>Invalid size.</span>")
 		return
 	size_set_to = (size_select/100)
@@ -51,6 +51,21 @@
 /obj/item/weapon/gun/energy/sizegun/examine(mob/user)
 	. = ..()
 	. += "<span class='info'>It is currently set at [size_set_to*100]%</span>"
+
+/obj/item/weapon/gun/energy/sizegun/admin
+	name = "modified size gun"
+	desc = "Sizegun, without limits on minimum/maximum size, and with unlimited charge. Time to show 'em that size does matter."
+	charge_cost = 0
+	projectile_type = /obj/item/projectile/beam/sizelaser/admin
+
+/obj/item/weapon/gun/energy/sizegun/admin/select_size()
+	set name = "Select Size"
+	set category = "Object"
+	set src in view(1)
+
+	var/size_select = input("Put the desired size", "Set Size", size_set_to * 100) as num
+	size_set_to = max(1,size_select/100)		//No negative numbers
+	to_chat(usr, "<span class='notice'>You set the size to [size_set_to]%</span>")
 
 //
 // Beams for size gun
@@ -71,8 +86,21 @@
 /obj/item/projectile/beam/sizelaser/on_hit(var/atom/target)
 	var/mob/living/M = target
 	if(istype(M))
-		M.resize(set_size)
-		to_chat(M, "<font color='blue'> The beam fires into your body, changing your size!</font>")
+		if(!M.in_dorms() || !istype(M, /mob/living/carbon/human))
+			if(!M.resize(clamp(set_size,0.25,2)))
+				to_chat(M, "<font color='blue'>The beam fires into your body, changing your size!</font>")
+		else
+			if(!M.resize(clamp(set_size,0.01,6)))
+				to_chat(M, "<font color='blue'>The beam fires into your body, changing your size!</font>")
+		M.updateicon()
+		return
+	return 1
+
+/obj/item/projectile/beam/sizelaser/admin/on_hit(var/atom/target)
+	var/mob/living/M = target
+	if(istype(M))
+		M.resize(set_size, TRUE, FALSE)
+		to_chat(M, "<font color='blue'>The beam fires into your body, changing your size!</font>")
 		M.updateicon()
 		return
 	return 1


### PR DESCRIPTION
This pull request adds new traits: Toggleable Resizing Immunity, and Sizeshifting. Resizing immunity is neutral, while Sizeshifting costs 2 points.
Also, now when you are in dormidory areas, available size range from nearly all resizing sources (including NIFs, size guns and ability) is increased from 25%-200% to 1%-600%. Size will be reverted to 25% or 200% respectively once you leave dorm area.

Toggleable Resizing Immunity makes your immune to all kinds of size changing, untill you turn it off.
Sizeshifting allows you to change your own size, or size of someone you holding in at least passive grab. It also allows you to enter customizable message when doing so.

Video of resizing to maximum size via NIF, and size reverting to 200% once leaving dorm room.

https://user-images.githubusercontent.com/7351585/103492706-4c116480-4e5f-11eb-97ac-c0a7d9cb7630.mp4

