### PR TITLE
Fixes a rogue area

### DIFF
--- a/maps/tether/tether-03-surface3.dmm
+++ b/maps/tether/tether-03-surface3.dmm
@@ -14150,12 +14150,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/tether/surfacebase/bar_backroom)
-"axq" = (
-/obj/machinery/camera/network/civilian{
-	dir = 4
-	},
-/turf/simulated/floor/grass,
-/area/maintenance/lower/xenoflora)
 "axr" = (
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 5
@@ -38627,6 +38621,12 @@
 /obj/machinery/computer/operating,
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/surgery1)
+"hfN" = (
+/obj/machinery/camera/network/civilian{
+	dir = 4
+	},
+/turf/simulated/floor/grass,
+/area/hydroponics)
 "hgf" = (
 /obj/machinery/door/firedoor/glass/hidden{
 	dir = 2
@@ -59514,7 +59514,7 @@ acV
 acV
 axr
 ayK
-axq
+hfN
 atg
 aSy
 aop


### PR DESCRIPTION
Fixes a rogue area tile in Hydroponics. The original area belonged to Xenobotany Maint, but was infront a door in Botany. Probably a missclick from another mapper that got missed! All fixed now!

Before
![image](https://user-images.githubusercontent.com/39163353/103635472-8f7ada00-4f16-11eb-9efe-6a9ad8368aa4.png)

After
![image](https://user-images.githubusercontent.com/39163353/103635495-986bab80-4f16-11eb-8125-9a5677dbaab1.png)

