### PR TITLE
Allows feeding synths with the lewd trait

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/station_special_abilities_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_special_abilities_vr.dm
@@ -566,7 +566,7 @@
 		return
 
 	var/mob/living/carbon/human/T = G.affecting // I must say, this is a quite ingenious way of doing it. Props to the original coders.
-	if(!istype(T) || T.isSynthetic())
+	if(!istype(T))
 		to_chat(src, "<span class='warning'>\The [T] is not able to be fed.</span>")
 		return
 


### PR DESCRIPTION
A completely unnecessary no-fun-allowed check for a lewd scene ability. Crew synths use the nutrition var just like the rest of the crew do so there's no mechanical reason for this to not work on them.