### PR TITLE
Allows Custom Species to select any of 5 physical genders.

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/blank_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/blank_vr.dm
@@ -29,6 +29,8 @@
 	num_alternate_languages = 3
 	assisted_langs = list(LANGUAGE_EAL, LANGUAGE_ROOTLOCAL, LANGUAGE_ROOTGLOBAL, LANGUAGE_VOX)
 
+	genders = list(MALE, FEMALE, PLURAL, NEUTER, HERM)
+
 	spawn_flags = SPECIES_CAN_JOIN
 	appearance_flags = HAS_HAIR_COLOR | HAS_SKIN_COLOR | HAS_LIPS | HAS_UNDERWEAR | HAS_EYE_COLOR
 


### PR DESCRIPTION
Title. While potentially desirable and makes sense for other species to be restricted to only what their lore allows, Custom Species should totally allow full selection.