### PR TITLE
Makes most neutral traits available to all species

### DIFF
--- a/code/_helpers/global_lists_vr.dm
+++ b/code/_helpers/global_lists_vr.dm
@@ -8,6 +8,7 @@ var/global/list/tail_styles_list = list()	// Stores /datum/sprite_accessory/tail
 var/global/list/wing_styles_list = list()	// Stores /datum/sprite_accessory/wing indexed by type
 var/global/list/negative_traits = list()	// Negative custom species traits, indexed by path
 var/global/list/neutral_traits = list()		// Neutral custom species traits, indexed by path
+var/global/list/everyone_traits = list()	// Neutral traits available to all species, indexed by path
 var/global/list/positive_traits = list()	// Positive custom species traits, indexed by path
 var/global/list/traits_costs = list()		// Just path = cost list, saves time in char setup
 var/global/list/all_traits = list()			// All of 'em at once (same instances)
@@ -457,7 +458,7 @@ var/global/list/remainless_species = list(SPECIES_PROMETHEAN,
 	for(var/path in paths)
 		var/datum/sprite_accessory/hair_accessory/instance = new path()
 		hair_accesories_list[path] = instance
-	
+
 	// Custom species traits
 	paths = typesof(/datum/trait) - /datum/trait
 	for(var/path in paths)
@@ -472,6 +473,8 @@ var/global/list/remainless_species = list(SPECIES_PROMETHEAN,
 				negative_traits[path] = instance
 			if(0)
 				neutral_traits[path] = instance
+				if(!(instance.custom_only))
+					everyone_traits[path] = instance
 			if(0.1 to INFINITY)
 				positive_traits[path] = instance
 

--- a/code/game/dna/dna2.dm
+++ b/code/game/dna/dna2.dm
@@ -202,23 +202,9 @@ var/global/list/datum/dna/gene/dna_genes[0]
 
 	// Technically custom_species is not part of the UI, but this place avoids merge problems.
 	src.custom_species = character.custom_species
-	if(istype(character.species,/datum/species/custom))
-		var/datum/species/custom/CS = character.species
-		src.species_traits = CS.traits.Copy()
-		src.base_species = CS.base_species
-		src.blood_color = CS.blood_color
-
-	if(istype(character.species,/datum/species/xenochimera))
-		var/datum/species/xenochimera/CS = character.species
-		//src.species_traits = CS.traits.Copy() //No traits
-		src.base_species = CS.base_species
-		src.blood_color = CS.blood_color
-
-	if(istype(character.species,/datum/species/alraune))
-		var/datum/species/alraune/CS = character.species
-		//src.species_traits = CS.traits.Copy() //No traits
-		src.base_species = CS.base_species
-		src.blood_color = CS.blood_color
+	src.base_species = character.species.base_species
+	src.blood_color = character.species.blood_color
+	src.species_traits = character.species.traits.Copy()
 
 	// +1 to account for the none-of-the-above possibility
 	SetUIValueRange(DNA_UI_EAR_STYLE,	ear_style + 1,     ear_styles_list.len  + 1,  1)

--- a/code/game/dna/dna2_helpers.dm
+++ b/code/game/dna/dna2_helpers.dm
@@ -237,20 +237,9 @@
 
 		// Technically custom_species is not part of the UI, but this place avoids merge problems.
 		H.custom_species = dna.custom_species
-		if(istype(H.species,/datum/species/custom))
-			var/datum/species/custom/CS = H.species
-			var/datum/species/custom/new_CS = CS.produceCopy(dna.base_species,dna.species_traits,src)
-			new_CS.blood_color = dna.blood_color
-
-		if(istype(H.species,/datum/species/xenochimera))
-			var/datum/species/xenochimera/CS = H.species
-			var/datum/species/xenochimera/new_CS = CS.produceCopy(dna.base_species,dna.species_traits,src)
-			new_CS.blood_color = dna.blood_color
-
-		if(istype(H.species,/datum/species/alraune))
-			var/datum/species/alraune/CS = H.species
-			var/datum/species/alraune/new_CS = CS.produceCopy(dna.base_species,dna.species_traits,src)
-			new_CS.blood_color = dna.blood_color
+		H.species.blood_color = dna.blood_color
+		var/datum/species/S = H.species
+		S.produceCopy(dna.base_species,dna.species_traits,src)
 		// VOREStation Edit End
 
 		H.force_update_organs() //VOREStation Add - Gotta do this too

--- a/code/modules/client/preference_setup/vore/07_traits.dm
+++ b/code/modules/client/preference_setup/vore/07_traits.dm
@@ -58,21 +58,21 @@
 
 	if(pref.species != SPECIES_CUSTOM)
 		pref.pos_traits.Cut()
-		pref.neu_traits.Cut()
 		pref.neg_traits.Cut()
-	else
-		// Clean up positive traits
-		for(var/path in pref.pos_traits)
-			if(!(path in positive_traits))
-				pref.pos_traits -= path
-		//Neutral traits
-		for(var/path in pref.neu_traits)
-			if(!(path in neutral_traits))
-				pref.neu_traits -= path
-		//Negative traits
-		for(var/path in pref.neg_traits)
-			if(!(path in negative_traits))
-				pref.neg_traits -= path
+	// Clean up positive traits
+	for(var/path in pref.pos_traits)
+		if(!(path in positive_traits))
+			pref.pos_traits -= path
+	//Neutral traits
+	for(var/path in pref.neu_traits)
+		if(!(path in neutral_traits))
+			pref.neu_traits -= path
+		if(!(pref.species == SPECIES_CUSTOM) && !(path in everyone_traits))
+			pref.neu_traits -= path
+	//Negative traits
+	for(var/path in pref.neg_traits)
+		if(!(path in negative_traits))
+			pref.neg_traits -= path
 
 	var/datum/species/selected_species = GLOB.all_species[pref.species]
 	if(selected_species.selects_bodytype)
@@ -82,23 +82,23 @@
 
 /datum/category_item/player_setup_item/vore/traits/copy_to_mob(var/mob/living/carbon/human/character)
 	character.custom_species	= pref.custom_species
-	var/datum/species/selected_species = GLOB.all_species[pref.species]
 
 	if(character.isSynthetic())	//Checking if we have a synth on our hands, boys.
 		pref.dirty_synth = 1
 
-	if(selected_species.selects_bodytype)
-		var/datum/species/custom/CS = character.species
-		var/S = pref.custom_base ? pref.custom_base : "Human"
-		var/datum/species/custom/new_CS = CS.produceCopy(S, pref.pos_traits + pref.neu_traits + pref.neg_traits, character)
+	var/datum/species/S = character.species
+	var/SB = pref.custom_base ? pref.custom_base : "Human"
+	var/datum/species/new_S = S.produceCopy(SB, pref.pos_traits + pref.neu_traits + pref.neg_traits, character)
 
-		//Any additional non-trait settings can be applied here
-		new_CS.blood_color = pref.blood_color
+	//Any additional non-trait settings can be applied here
+	new_S.blood_color = pref.blood_color
 
-		if(pref.species == SPECIES_CUSTOM)
-			//Statistics for this would be nice
-			var/english_traits = english_list(new_CS.traits, and_text = ";", comma_text = ";")
-			log_game("TRAITS [pref.client_ckey]/([character]) with: [english_traits]") //Terrible 'fake' key_name()... but they aren't in the same entity yet
+	if(pref.species == SPECIES_CUSTOM)
+		//Statistics for this would be nice
+		var/english_traits = english_list(new_S.traits, and_text = ";", comma_text = ";")
+		log_game("TRAITS [pref.client_ckey]/([character]) with: [english_traits]") //Terrible 'fake' key_name()... but they aren't in the same entity yet
+	else
+
 
 /datum/category_item/player_setup_item/vore/traits/content(var/mob/user)
 	. += "<b>Custom Species Name:</b> "
@@ -109,15 +109,16 @@
 		. += "<b>Icon Base: </b> "
 		. += "<a href='?src=\ref[src];custom_base=1'>[pref.custom_base ? pref.custom_base : "Human"]</a><br>"
 
+	var/traits_left = pref.max_traits
+	. += "<b>Traits Left:</b> [traits_left]<br>"
 	if(pref.species == SPECIES_CUSTOM)
 		var/points_left = pref.starting_trait_points
-		var/traits_left = pref.max_traits
+
 		for(var/T in pref.pos_traits + pref.neg_traits)
 			points_left -= traits_costs[T]
 			traits_left--
 
 		. += "<b>Points Left:</b> [points_left]<br>"
-		. += "<b>Traits Left:</b> [traits_left]<br>"
 		if(points_left < 0 || traits_left < 0 || !pref.custom_species)
 			. += "<span style='color:red;'><b>^ Fix things! ^</b></span><br>"
 
@@ -128,19 +129,18 @@
 			. += "<li>- <a href='?src=\ref[src];clicked_pos_trait=[T]'>[trait.name] ([trait.cost])</a></li>"
 		. += "</ul>"
 
-		. += "<a href='?src=\ref[src];add_trait=[NEUTRAL_MODE]'>Neutral Trait +</a><br>"
-		. += "<ul>"
-		for(var/T in pref.neu_traits)
-			var/datum/trait/trait = neutral_traits[T]
-			. += "<li>- <a href='?src=\ref[src];clicked_neu_trait=[T]'>[trait.name] ([trait.cost])</a></li>"
-		. += "</ul>"
-
 		. += "<a href='?src=\ref[src];add_trait=[NEGATIVE_MODE]'>Negative Trait +</a><br>"
 		. += "<ul>"
 		for(var/T in pref.neg_traits)
 			var/datum/trait/trait = negative_traits[T]
 			. += "<li>- <a href='?src=\ref[src];clicked_neg_trait=[T]'>[trait.name] ([trait.cost])</a></li>"
 		. += "</ul>"
+	. += "<a href='?src=\ref[src];add_trait=[NEUTRAL_MODE]'>Neutral Trait +</a><br>"
+	. += "<ul>"
+	for(var/T in pref.neu_traits)
+		var/datum/trait/trait = neutral_traits[T]
+		. += "<li>- <a href='?src=\ref[src];clicked_neu_trait=[T]'>[trait.name] ([trait.cost])</a></li>"
+	. += "</ul>"
 	. += "<b>Blood Color: </b>" //People that want to use a certain species to have that species traits (xenochimera/promethean/spider) should be able to set their own blood color.
 	. += "<a href='?src=\ref[src];blood_color=1'>Set Color</a>"
 	. += "<a href='?src=\ref[src];blood_reset=1'>R</a><br>"
@@ -213,8 +213,12 @@
 				picklist = positive_traits.Copy() - pref.pos_traits
 				mylist = pref.pos_traits
 			if(NEUTRAL_MODE)
-				picklist = neutral_traits.Copy() - pref.neu_traits
-				mylist = pref.neu_traits
+				if(pref.species == SPECIES_CUSTOM)
+					picklist = neutral_traits.Copy() - pref.neu_traits
+					mylist = pref.neu_traits
+				else
+					picklist = everyone_traits.Copy() - pref.neu_traits
+					mylist = pref.neu_traits
 			if(NEGATIVE_MODE)
 				picklist = negative_traits.Copy() - pref.neg_traits
 				mylist = pref.neg_traits

--- a/code/modules/mob/living/carbon/human/species/shadekin/shadekin.dm
+++ b/code/modules/mob/living/carbon/human/species/shadekin/shadekin.dm
@@ -54,8 +54,6 @@
 	base_color = "#f0f0f0"
 	color_mult = 1
 
-	inherent_verbs = list(/mob/living/proc/shred_limb)
-
 	has_glowing_eyes = TRUE
 
 	death_message = "phases to somewhere far away!"

--- a/code/modules/mob/living/carbon/human/species/species_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/species_vr.dm
@@ -21,6 +21,8 @@
 	var/icon_height = 32
 	var/agility = 20 //prob() to do agile things
 
+	var/list/traits = list()
+
 /datum/species/proc/update_attack_types()
 	unarmed_attacks = list()
 	for(var/u_type in unarmed_types)
@@ -44,3 +46,29 @@
 		nif.nifsofts = nifsofts
 	else
 		..()
+/datum/species/proc/produceCopy(var/datum/species/to_copy,var/list/traits,var/mob/living/carbon/human/H)
+	ASSERT(to_copy)
+	ASSERT(istype(H))
+
+	if(ispath(to_copy))
+		to_copy = "[initial(to_copy.name)]"
+	if(istext(to_copy))
+		to_copy = GLOB.all_species[to_copy]
+
+	var/datum/species/new_copy = new to_copy.type()
+
+	new_copy.traits = traits
+
+	//If you had traits, apply them
+	if(new_copy.traits)
+		for(var/trait in new_copy.traits)
+			var/datum/trait/T = all_traits[trait]
+			T.apply(new_copy,H)
+
+	//Set up a mob
+	H.species = new_copy
+
+	if(H.dna)
+		H.dna.ready_dna(H)
+
+	return new_copy

--- a/code/modules/mob/living/carbon/human/species/station/alraune.dm
+++ b/code/modules/mob/living/carbon/human/species/station/alraune.dm
@@ -46,10 +46,6 @@
 	appearance_flags = HAS_HAIR_COLOR | HAS_LIPS | HAS_UNDERWEAR | HAS_SKIN_COLOR | HAS_EYE_COLOR
 
 	inherent_verbs = list(
-		/mob/living/carbon/human/proc/succubus_drain,
-		/mob/living/carbon/human/proc/succubus_drain_finalize,
-		/mob/living/carbon/human/proc/succubus_drain_lethal,
-		/mob/living/carbon/human/proc/bloodsuck,
 		/mob/living/carbon/human/proc/alraune_fruit_select) //Give them the voremodes related to wrapping people in vines and sapping their fluids
 
 	color_mult = 1
@@ -58,7 +54,7 @@
 	flesh_color = "#9ee02c"
 	blood_color = "#edf4d0" //sap!
 	base_color = "#1a5600"
-	
+
 	reagent_tag = IS_ALRAUNE
 
 	blurb = "Alraunes are a rare sight in space. Their bodies are reminiscent of that of plants, and yet they share many\
@@ -449,7 +445,7 @@
 
 //End of fruit gland code.
 
-/datum/species/alraune/proc/produceCopy(var/datum/species/to_copy,var/list/traits,var/mob/living/carbon/human/H)
+/datum/species/alraune/produceCopy(var/datum/species/to_copy,var/list/traits,var/mob/living/carbon/human/H)
 	ASSERT(to_copy)
 	ASSERT(istype(H))
 
@@ -475,6 +471,13 @@
 	new_copy.blood_mask = to_copy.blood_mask
 	new_copy.damage_mask = to_copy.damage_mask
 	new_copy.damage_overlays = to_copy.damage_overlays
+	new_copy.traits = traits
+
+	//If you had traits, apply them
+	if(new_copy.traits)
+		for(var/trait in new_copy.traits)
+			var/datum/trait/T = all_traits[trait]
+			T.apply(new_copy,H)
 
 	//Set up a mob
 	H.species = new_copy

--- a/code/modules/mob/living/carbon/human/species/station/blank_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/blank_vr.dm
@@ -34,8 +34,6 @@
 	spawn_flags = SPECIES_CAN_JOIN
 	appearance_flags = HAS_HAIR_COLOR | HAS_SKIN_COLOR | HAS_LIPS | HAS_UNDERWEAR | HAS_EYE_COLOR
 
-	var/list/traits = list()
-
 	has_limbs = list(
 		BP_TORSO =  list("path" = /obj/item/organ/external/chest, "descriptor" = "torso"),
 		BP_GROIN =  list("path" = /obj/item/organ/external/groin, "descriptor" = "groin"),
@@ -57,7 +55,7 @@
 	var/datum/species/real = GLOB.all_species[base_species]
 	return real.race_key
 
-/datum/species/custom/proc/produceCopy(var/datum/species/to_copy,var/list/traits,var/mob/living/carbon/human/H)
+/datum/species/custom/produceCopy(var/datum/species/to_copy,var/list/traits,var/mob/living/carbon/human/H)
 	ASSERT(to_copy)
 	ASSERT(istype(H))
 

--- a/code/modules/mob/living/carbon/human/species/station/prometheans_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/prometheans_vr.dm
@@ -34,10 +34,5 @@
 		/mob/living/carbon/human/proc/shapeshifter_select_tail,
 		/mob/living/carbon/human/proc/shapeshifter_select_ears,
 		/mob/living/proc/set_size,
-		/mob/living/carbon/human/proc/succubus_drain,
-		/mob/living/carbon/human/proc/succubus_drain_finalize,
-		/mob/living/carbon/human/proc/succubus_drain_lethal,
-		/mob/living/carbon/human/proc/slime_feed,
-		/mob/living/proc/eat_trash,
 		/mob/living/carbon/human/proc/promethean_select_opaqueness,
 		)

--- a/code/modules/mob/living/carbon/human/species/station/protean_vr/protean_species.dm
+++ b/code/modules/mob/living/carbon/human/species/station/protean_vr/protean_species.dm
@@ -98,9 +98,7 @@
 		/mob/living/carbon/human/proc/shapeshifter_select_gender,
 		/mob/living/carbon/human/proc/shapeshifter_select_wings,
 		/mob/living/carbon/human/proc/shapeshifter_select_tail,
-		/mob/living/carbon/human/proc/shapeshifter_select_ears,
-		/mob/living/proc/eat_trash,
-		/mob/living/carbon/human/proc/slime_feed
+		/mob/living/carbon/human/proc/shapeshifter_select_ears
 		)
 
 	var/global/list/abilities = list()

--- a/code/modules/mob/living/carbon/human/species/station/station_special_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_special_vr.dm
@@ -25,12 +25,7 @@
 	inherent_verbs = list(
 		/mob/living/carbon/human/proc/reconstitute_form,
 		/mob/living/carbon/human/proc/sonar_ping,
-		/mob/living/carbon/human/proc/succubus_drain,
-		/mob/living/carbon/human/proc/succubus_drain_finalize,
-		/mob/living/carbon/human/proc/succubus_drain_lethal,
-		/mob/living/carbon/human/proc/bloodsuck,
 		/mob/living/carbon/human/proc/tie_hair,
-		/mob/living/proc/shred_limb,
 		/mob/living/proc/flying_toggle,
 		/mob/living/proc/start_wings_hovering) //Xenochimera get all the special verbs since they can't select traits.
 
@@ -297,7 +292,7 @@
 	update_xenochimera_hud(H, danger, feral_state)
 
 
-/datum/species/xenochimera/proc/produceCopy(var/datum/species/to_copy,var/list/traits,var/mob/living/carbon/human/H)
+/datum/species/xenochimera/produceCopy(var/datum/species/to_copy,var/list/traits,var/mob/living/carbon/human/H)
 	ASSERT(to_copy)
 	ASSERT(istype(H))
 
@@ -323,6 +318,13 @@
 	new_copy.blood_mask = to_copy.blood_mask
 	new_copy.damage_mask = to_copy.damage_mask
 	new_copy.damage_overlays = to_copy.damage_overlays
+	new_copy.traits = traits
+
+	//If you had traits, apply them
+	if(new_copy.traits)
+		for(var/trait in new_copy.traits)
+			var/datum/trait/T = all_traits[trait]
+			T.apply(new_copy,H)
 
 	//Set up a mob
 	H.species = new_copy
@@ -462,9 +464,6 @@
 
 	spawn_flags		 = SPECIES_CAN_JOIN | SPECIES_IS_WHITELISTED | SPECIES_WHITELIST_SELECTABLE
 	appearance_flags = HAS_HAIR_COLOR | HAS_SKIN_COLOR | HAS_EYE_COLOR
-	inherent_verbs = list(
-		/mob/living/proc/shred_limb,
-		/mob/living/proc/eat_trash)
 
 	flesh_color = "#AFA59E"
 	base_color = "#777777"

--- a/code/modules/mob/living/carbon/human/species/station/station_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_vr.dm
@@ -36,7 +36,6 @@
 
 	spawn_flags = SPECIES_CAN_JOIN
 	appearance_flags = HAS_HAIR_COLOR | HAS_LIPS | HAS_UNDERWEAR | HAS_SKIN_COLOR | HAS_EYE_COLOR
-	inherent_verbs = list(/mob/living/proc/shred_limb)
 
 	flesh_color = "#AFA59E"
 	base_color = "#777777"
@@ -80,7 +79,6 @@
 	secondary_langs = list(LANGUAGE_SKRELLIAN)
 	name_language = LANGUAGE_SKRELLIAN
 	color_mult = 1
-	inherent_verbs = list(/mob/living/proc/shred_limb)
 	assisted_langs = list(LANGUAGE_EAL, LANGUAGE_ROOTLOCAL, LANGUAGE_ROOTGLOBAL, LANGUAGE_VOX)
 
 	min_age = 18
@@ -129,7 +127,7 @@
 	secondary_langs = list(LANGUAGE_BIRDSONG)
 	name_language = LANGUAGE_BIRDSONG
 	color_mult = 1
-	inherent_verbs = list(/mob/living/proc/shred_limb,/mob/living/proc/flying_toggle,/mob/living/proc/start_wings_hovering)
+	inherent_verbs = list(/mob/living/proc/flying_toggle,/mob/living/proc/start_wings_hovering)
 
 	min_age = 18
 	max_age = 80
@@ -222,7 +220,7 @@
 //	gluttonous = 1
 	num_alternate_languages = 3
 	color_mult = 1
-	inherent_verbs = list(/mob/living/proc/shred_limb, /mob/living/carbon/human/proc/lick_wounds)
+	inherent_verbs = list(/mob/living/carbon/human/proc/lick_wounds)
 
 	blurb = "Vulpkanin are a species of sharp-witted canine-pideds residing on the planet Altam just barely within the \
 	dual-star Vazzend system. Their politically de-centralized society and independent natures have led them to become a species and \
@@ -256,7 +254,6 @@
 	color_mult = 1
 	min_age = 18
 	gluttonous = 0
-	inherent_verbs = list(/mob/living/proc/shred_limb)
 	genders = list(MALE, FEMALE, PLURAL, NEUTER, HERM)
 	descriptors = list()
 	wikilink="https://wiki.vore-station.net/Unathi"
@@ -269,7 +266,7 @@
 	color_mult = 1
 	min_age = 18
 	gluttonous = 0 //Moving this here so I don't have to fix this conflict every time polaris glances at station.dm
-	inherent_verbs = list(/mob/living/proc/shred_limb, /mob/living/carbon/human/proc/lick_wounds)
+	inherent_verbs = list(/mob/living/carbon/human/proc/lick_wounds)
 	heat_discomfort_level = 295 //Prevents heat discomfort spam at 20c
 	genders = list(MALE, FEMALE, PLURAL, NEUTER, HERM)
 	wikilink="https://wiki.vore-station.net/Tajaran"
@@ -327,7 +324,6 @@
 	inherent_verbs = list(
 		/mob/living/carbon/human/proc/sonar_ping,
 		/mob/living/proc/hide,
-		/mob/living/proc/shred_limb,
 		/mob/living/proc/toggle_pass_table
 		)
 
@@ -350,7 +346,6 @@
 	min_age = 18
 	icobase = 'icons/mob/human_races/r_vox_old.dmi'
 	deform = 'icons/mob/human_races/r_def_vox_old.dmi'
-	inherent_verbs = list(/mob/living/proc/shred_limb, /mob/living/proc/eat_trash)
 	descriptors = list(
 		/datum/mob_descriptor/vox_markings = 0
 		)
@@ -453,8 +448,6 @@ datum/species/harpy
 	blood_color = "#A10808"
 	base_color = "#f0f0f0"
 	color_mult = 1
-
-	inherent_verbs = list(/mob/living/proc/shred_limb)
 
 	has_glowing_eyes = TRUE
 
@@ -577,4 +570,3 @@ datum/species/harpy
 		"You feel uncomfortably warm.",
 		"Your chitin feels hot."
 		)
-	inherent_verbs = list(/mob/living/proc/shred_limb)

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
@@ -25,7 +25,7 @@
 	cost = 0
 	var_changes = list("cold_level_1" = 200,  "cold_level_2" = 150, "cold_level_3" = 90, "breath_cold_level_1" = 180, "breath_cold_level_2" = 100, "breath_cold_level_3" = 60, "cold_discomfort_level" = 210, "heat_level_1" = 305, "heat_level_2" = 360, "heat_level_3" = 700, "breath_heat_level_1" = 345, "breath_heat_level_2" = 380, "breath_heat_level_3" = 780, "heat_discomfort_level" = 295, "body_temperature" = 290)
 	excludes = list(/datum/trait/hotadapt)
-	
+
 /datum/trait/hotadapt
 	name = "Heat-Adapted"
 	desc = "You are able to withstand much hotter temperatures than other species, and can even be comfortable in extremely hot environments. You are also more vulnerable to cold environments, and have a higher body temperature as a consequence of these adaptations."
@@ -63,6 +63,7 @@
 	name = "Bloodsucker"
 	desc = "Makes you unable to gain nutrition from anything but blood. To compenstate, you get fangs that can be used to drain blood from prey."
 	cost = 0
+	custom_only = FALSE
 	var_changes = list("gets_food_nutrition" = 0) //The verb is given in human.dm
 
 /datum/trait/bloodsucker/apply(var/datum/species/S,var/mob/living/carbon/human/H)
@@ -73,6 +74,7 @@
 	name = "Succubus Drain"
 	desc = "Makes you able to gain nutrition from draining prey in your grasp."
 	cost = 0
+	custom_only = FALSE
 
 /datum/trait/succubus_drain/apply(var/datum/species/S,var/mob/living/carbon/human/H)
 	..(S,H)
@@ -84,6 +86,7 @@
 	name = "Feeder"
 	desc = "Allows you to feed your prey using your own body."
 	cost = 0
+	custom_only = FALSE
 
 /datum/trait/feeder/apply(var/datum/species/S,var/mob/living/carbon/human/H)
 	..(S,H)
@@ -92,7 +95,8 @@
 /datum/trait/hard_vore
 	name = "Brutal Predation"
 	desc = "Allows you to tear off limbs & tear out internal organs."
-	cost = 0 //I would make this cost a point, since it has some in game value, but there are easier, less damaging ways to perform the same functions.
+	cost = 0
+	custom_only = FALSE
 
 /datum/trait/hard_vore/apply(var/datum/species/S,var/mob/living/carbon/human/H)
 	..(S,H)
@@ -102,6 +106,7 @@
 	name = "Trash Can"
 	desc = "Allows you to dispose of some garbage on the go instead of having to look for a bin or littering like an animal."
 	cost = 0
+	custom_only = FALSE
 	var_changes = list("trashcan" = 1)
 
 /datum/trait/trashcan/apply(var/datum/species/S,var/mob/living/carbon/human/H)
@@ -112,6 +117,7 @@
 	name = "Expensive Taste"
 	desc = "You only gain nutrition from raw ore and refined minerals. There's nothing that sates the appetite better than precious gems, exotic or rare minerals and you have damn fine taste. Anything else is beneath you."
 	cost = 0
+	custom_only = FALSE
 	var_changes = list("gets_food_nutrition" = 0, "eat_minerals" = 1)
 
 /datum/trait/gem_eater/apply(var/datum/species/S,var/mob/living/carbon/human/H)
@@ -122,12 +128,15 @@
 	name = "Glowing Eyes"
 	desc = "Your eyes show up above darkness. SPOOKY! And kinda edgey too."
 	cost = 0
+	custom_only = FALSE
 	var_changes = list("has_glowing_eyes" = 1)
 
 /datum/trait/glowing_body
 	name = "Glowing Body"
 	desc = "Your body glows about as much as a PDA light! Settable color and toggle in Abilities tab ingame."
 	cost = 0
+	custom_only = FALSE
+
 /datum/trait/glowing_body/apply(var/datum/species/S,var/mob/living/carbon/human/H)
 	..(S,H)
 	H.verbs |= /mob/living/proc/glow_toggle
@@ -138,36 +147,42 @@
 	name = "Extreme Spice Intolerance"
 	desc = "Spicy (and chilly) peppers are three times as strong. (This does not affect pepperspray.)"
 	cost = 0
+	custom_only = FALSE
 	var_changes = list("spice_mod" = 3) // 300% as effective if spice_mod is set to 1. If it's not 1 in species.dm, update this!
-	
+
 /datum/trait/spice_intolerance_basic
 	name = "Heavy Spice Intolerance"
 	desc = "Spicy (and chilly) peppers are twice as strong. (This does not affect pepperspray.)"
 	cost = 0
+	custom_only = FALSE
 	var_changes = list("spice_mod" = 2) // 200% as effective if spice_mod is set to 1. If it's not 1 in species.dm, update this!
 
 /datum/trait/spice_intolerance_slight
 	name = "Slight Spice Intolerance"
 	desc = "You have a slight struggle with spicy foods. Spicy (and chilly) peppers are one and a half times stronger. (This does not affect pepperspray.)"
 	cost = 0
+	custom_only = FALSE
 	var_changes = list("spice_mod" = 1.5) // 150% as effective if spice_mod is set to 1. If it's not 1 in species.dm, update this!
 
 /datum/trait/spice_tolerance_basic
 	name = "Spice Tolerance"
 	desc = "Spicy (and chilly) peppers are only three-quarters as strong. (This does not affect pepperspray.)"
 	cost = 0
+	custom_only = FALSE
 	var_changes = list("spice_mod" = 0.75) // 75% as effective if spice_mod is set to 1. If it's not 1 in species.dm, update this!
-	
+
 /datum/trait/spice_tolerance_advanced
 	name = "Strong Spice Tolerance"
 	desc = "Spicy (and chilly) peppers are only half as strong. (This does not affect pepperspray.)"
 	cost = 0
+	custom_only = FALSE
 	var_changes = list("spice_mod" = 0.5) // 50% as effective if spice_mod is set to 1. If it's not 1 in species.dm, update this!
 
 /datum/trait/spice_immunity
 	name = "Extreme Spice Tolerance"
 	desc = "Spicy (and chilly) peppers are basically ineffective! (This does not affect pepperspray.)"
 	cost = 0
+	custom_only = FALSE
 	var_changes = list("spice_mod" = 0.25) // 25% as effective if spice_mod is set to 1. If it's not 1 in species.dm, update this!
 
 // Alcohol Traits Start Here, from negative to positive.
@@ -175,35 +190,41 @@
 	name = "Liver of Air"
 	desc = "The only way you can hold a drink is if it's in your own two hands, and even then you'd best not inhale too deeply near it. Drinks are three times as strong."
 	cost = 0
+	custom_only = FALSE
 	var_changes = list("alcohol_mod" = 3) // 300% as effective if alcohol_mod is set to 1. If it's not 1 in species.dm, update this!
 
 /datum/trait/alcohol_intolerance_basic
 	name = "Liver of Lilies"
 	desc = "You have a hard time with alcohol. Maybe you just never took to it, or maybe it doesn't agree with you... either way, drinks are twice as strong."
 	cost = 0
+	custom_only = FALSE
 	var_changes = list("alcohol_mod" = 2) // 200% as effective if alcohol_mod is set to 1. If it's not 1 in species.dm, update this!
 
 /datum/trait/alcohol_intolerance_slight
 	name = "Liver of Tulips"
 	desc = "You have a slight struggle with alcohol. Drinks are one and a half times stronger."
 	cost = 0
+	custom_only = FALSE
 	var_changes = list("alcohol_mod" = 1.5) // 150% as effective if alcohol_mod is set to 1. If it's not 1 in species.dm, update this!
 
 /datum/trait/alcohol_tolerance_basic
 	name = "Liver of Iron"
 	desc = "You can hold drinks much better than those lily-livered land-lubbers! Arr! Drinks are only three-quarters as strong."
 	cost = 0
+	custom_only = FALSE
 	var_changes = list("alcohol_mod" = 0.75) // 75% as effective if alcohol_mod is set to 1. If it's not 1 in species.dm, update this!
-	
+
 /datum/trait/alcohol_tolerance_advanced
 	name = "Liver of Steel"
 	desc = "Drinks tremble before your might! You can hold your alcohol twice as well as those blue-bellied barnacle boilers! Drinks are only half as strong."
 	cost = 0
+	custom_only = FALSE
 	var_changes = list("alcohol_mod" = 0.5) // 50% as effective if alcohol_mod is set to 1. If it's not 1 in species.dm, update this!
 
 /datum/trait/alcohol_immunity
 	name = "Liver of Durasteel"
 	desc = "You've drunk so much that most booze doesn't even faze you. It takes something like a Pan-Galactic or a pint of Deathbell for you to even get slightly buzzed."
 	cost = 0
+	custom_only = FALSE
 	var_changes = list("alcohol_mod" = 0.25) // 25% as effective if alcohol_mod is set to 1. If it's not 1 in species.dm, update this!
 // Alcohol Traits End Here.

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/trait.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/trait.dm
@@ -5,7 +5,8 @@
 	var/cost = 0			// 0 is neutral, negative cost means negative, positive cost means positive.
 	var/list/var_changes	// A list to apply to the custom species vars.
 	var/list/excludes		// Store a list of paths of traits to exclude, but done automatically if they change the same vars.
-	var/not_for_synths = 0	// Can freaking synths use those.
+	var/not_for_synths = FALSE	// Can freaking synths use those.
+	var/custom_only = TRUE		// Trait only available for custom species
 
 //Proc can be overridden lower to include special changes, make sure to call up though for the vars changes
 /datum/trait/proc/apply(var/datum/species/S,var/mob/living/carbon/human/H)


### PR DESCRIPTION
Title. All species can now select limited range of neutral traits. Not included: temperature-adaptation traits, metabolism traits and autohiss traits.

Other changes:
All the verbs provided by neutral traits removed from species' default roster. Now have to be manually added via neutral traits.
Fixed custom blood color only applying to Alraune, Xenochimera and Custom Species.


Probably breaks like entire game lol, but seemed to work fine in basic testing, if someone actually smart could look at it, would be nice.