### PR TITLE
Little tweaks

### DIFF
--- a/maps/tether/tether-03-surface3.dmm
+++ b/maps/tether/tether-03-surface3.dmm
@@ -31268,15 +31268,15 @@
 "bcf" = (
 /obj/effect/floor_decal/corner/grey/diagonal,
 /obj/structure/table/standard,
-/obj/item/frame/noticeboard{
-	pixel_x = 32
-	},
 /obj/item/weapon/paper{
 	desc = "";
 	info = "Yes hello, the goat in the freezer is named 'Spike'. Please do not fuck with Spike. He doesn't have the best temper.";
 	name = "Important notice from Rancher Jim"
 	},
 /obj/item/weapon/book/manual/chef_recipes,
+/obj/structure/noticeboard{
+	pixel_x = 32
+	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
 "bcg" = (
@@ -33396,8 +33396,8 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/servicebackroom)
 "bgf" = (
-/obj/item/frame/noticeboard{
-	pixel_y = 26
+/obj/structure/noticeboard{
+	pixel_y = 29
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
@@ -38722,7 +38722,9 @@
 "hCz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/airlock/hatch,
+/obj/machinery/door/airlock/hatch{
+	req_one_access = list()
+	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/techfloor,
 /area/tether/surfacebase/shuttle_pad)

--- a/maps/tether/tether-07-station3.dmm
+++ b/maps/tether/tether-07-station3.dmm
@@ -15572,7 +15572,7 @@
 	dir = 4;
 	id = "QMLoad"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/tiled,
 /area/quartermaster/storage)
 "aIY" = (
 /obj/machinery/conveyor{
@@ -22662,6 +22662,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/station/upper)
+"hai" = (
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "QMLoad"
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/storage)
 "hid" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -22923,7 +22930,7 @@
 	id = "QMLoad"
 	},
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor,
+/turf/simulated/floor/tiled,
 /area/quartermaster/storage)
 "iJT" = (
 /obj/structure/shuttle/engine/heater,
@@ -39445,7 +39452,7 @@ aCN
 aGO
 aGO
 aIv
-aGR
+hai
 azO
 tVq
 aab


### PR DESCRIPTION
Replaces notice board frames with notice boards in the kitchen, makes the little bubble room south of the surface 3 shuttle public access since there's no real reason for it to be restricted. And adds floor tiles under a section of conveyor belt in cargo to hide a disposal pipe.

should fix #9354