### PR TITLE
Adds a new vorepanel mode addon.

### DIFF
--- a/code/__defines/belly_modes_vr.dm
+++ b/code/__defines/belly_modes_vr.dm
@@ -19,6 +19,7 @@
 #define DM_FLAG_STRIPPING		0x2
 #define DM_FLAG_LEAVEREMAINS	0x4
 #define DM_FLAG_THICKBELLY		0x8
+#define DM_FLAG_AFFECTWORN		0x10
 
 //Item related modes
 #define IM_HOLD									"Hold"

--- a/code/modules/vore/eating/belly_obj_vr.dm
+++ b/code/modules/vore/eating/belly_obj_vr.dm
@@ -43,7 +43,7 @@
 	//Actual full digest modes
 	var/tmp/static/list/digest_modes = list(DM_HOLD,DM_DIGEST,DM_ABSORB,DM_DRAIN,DM_UNABSORB,DM_HEAL,DM_SHRINK,DM_GROW,DM_SIZE_STEAL,DM_EGG)
 	//Digest mode addon flags
-	var/tmp/static/list/mode_flag_list = list("Numbing" = DM_FLAG_NUMBING, "Stripping" = DM_FLAG_STRIPPING, "Leave Remains" = DM_FLAG_LEAVEREMAINS, "Muffles" = DM_FLAG_THICKBELLY)
+	var/tmp/static/list/mode_flag_list = list("Numbing" = DM_FLAG_NUMBING, "Stripping" = DM_FLAG_STRIPPING, "Leave Remains" = DM_FLAG_LEAVEREMAINS, "Muffles" = DM_FLAG_THICKBELLY, "Affect Worn Items" = DM_FLAG_AFFECTWORN)
 	//Item related modes
 	var/tmp/static/list/item_digest_modes = list(IM_HOLD,IM_DIGEST_FOOD,IM_DIGEST)
 

--- a/code/modules/vore/eating/bellymodes_vr.dm
+++ b/code/modules/vore/eating/bellymodes_vr.dm
@@ -141,10 +141,11 @@
 				if(mode_flags & DM_FLAG_AFFECTWORN)
 					for(var/slot in slots)
 						var/obj/item/I = H.get_equipped_item(slot = slot)
-						if(I && handle_digesting_item(I))
-							digestion_noise_chance = 25
-							to_update = TRUE
-							break
+						if(I && I.canremove)
+							if(handle_digesting_item(I))
+								digestion_noise_chance = 25
+								to_update = TRUE
+								break
 
 				//Stripping flag
 				if(mode_flags & DM_FLAG_STRIPPING)

--- a/code/modules/vore/eating/bellymodes_vr.dm
+++ b/code/modules/vore/eating/bellymodes_vr.dm
@@ -137,6 +137,15 @@
 				if((mode_flags & DM_FLAG_THICKBELLY) && !H.muffled)
 					H.muffled = TRUE
 
+				//Worn items flag
+				if(mode_flags & DM_FLAG_AFFECTWORN)
+					for(var/slot in slots)
+						var/obj/item/I = H.get_equipped_item(slot = slot)
+						if(I && handle_digesting_item(I))
+							digestion_noise_chance = 25
+							to_update = TRUE
+							break
+
 				//Stripping flag
 				if(mode_flags & DM_FLAG_STRIPPING)
 					for(var/slot in slots)


### PR DESCRIPTION
Adds a new vorepanel mode addon "Affect Worn Items", which, depending on the belly settings, will either contaminate or digest worn gear right off the prey without stripping. Item friendly modes will affect the prey's entire outfit at once, but the item digest mode will only affect one item at a time using the same digestion rates the belly would have on loose items.