### PR TITLE
Fixes hound belly expansion upgrade having wrong name in prosfab, tweaks tech reqs, makes name less wordy

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades_vr.dm
+++ b/code/game/objects/items/robot/robot_upgrades_vr.dm
@@ -31,8 +31,8 @@
 	return 1
 
 /obj/item/borg/upgrade/bellysizeupgrade
-	name = "robotic Hound process capacity upgrade Module"
-	desc = "Used to upgrade a hound belly capacity. This only affects total volume and such, you won't be able to support more than one patient. Usable once."
+	name = "robohound capacity expansion module"
+	desc = "Used to double a robohound's belly capacity. This only affects total volume, and won't allow support of more than one patient in case of sleeper bellies. Can only be applied once."
 	icon_state = "cyborg_upgrade2"
 	item_state = "cyborg_upgrade"
 	require_module = 1

--- a/code/modules/research/prosfab_designs_vr.dm
+++ b/code/modules/research/prosfab_designs_vr.dm
@@ -8,8 +8,8 @@
 	build_path = /obj/item/borg/upgrade/sizeshift
 
 /datum/design/item/prosfab/robot_upgrade/bellysizeupgrade
-	name = "Size Alteration Module"
+	name = "Robohound Capacity Expansion Module"
 	id = "borg_hound_capacity_module"
-	req_tech = list(TECH_BLUESPACE = 3, TECH_MATERIAL = 3, TECH_POWER = 2)
+	req_tech = list(TECH_MATERIAL = 3, TECH_ENGINEERING = 2)
 	materials = list(DEFAULT_WALL_MATERIAL = 4000, "glass" = 4000)
 	build_path = /obj/item/borg/upgrade/bellysizeupgrade


### PR DESCRIPTION
Tweaks hound belly expansion upgrade tech requirements to no longer require Bluespace at all, and replaces Power 2 requirement with Engineering 2 (as original requirements were just complete copy-paste of Size Alteration requirements it seems)

Changes the name from wordy "robotic Hound process capacity upgrade Module" to somewhat less wordy "robohound capacity expansion module"

Fixes the recipe in the prosthetics fabricator having same name as Size Alteration Module.