### PR TITLE
Converts Morph Spawn and Maint Pred events to use ghostpods

### DIFF
--- a/code/_helpers/global_lists_vr.dm
+++ b/code/_helpers/global_lists_vr.dm
@@ -12,6 +12,7 @@ var/global/list/everyone_traits = list()	// Neutral traits available to all spec
 var/global/list/positive_traits = list()	// Positive custom species traits, indexed by path
 var/global/list/traits_costs = list()		// Just path = cost list, saves time in char setup
 var/global/list/all_traits = list()			// All of 'em at once (same instances)
+var/global/list/active_ghost_pods = list()
 
 var/global/list/sensorpreflist = list("Off", "Binary", "Vitals", "Tracking", "No Preference")	//TFF 5/8/19 - Suit Sensors global list
 

--- a/code/game/objects/structures/ghost_pods/event_vr.dm
+++ b/code/game/objects/structures/ghost_pods/event_vr.dm
@@ -1,0 +1,101 @@
+/obj/structure/ghost_pod/ghost_activated/maintpred
+	name = "maintenance hole"
+	desc = "Looks like some creature dug its way into station's maintenance..."
+	icon = 'icons/effects/effects.dmi'
+	icon_state = "tunnel_hole"
+	icon_state_opened = "tunnel_hole"
+	density = FALSE
+	ghost_query_type = /datum/ghost_query/maints_pred
+	anchored = TRUE
+	invisibility = INVISIBILITY_OBSERVER
+	spawn_active = TRUE
+	var/announce_prob = 35
+	var/list/possible_mobs = list("Space Bumblebee" = /mob/living/simple_mob/vore/bee,
+								  "Voracious Lizard" = /mob/living/simple_mob/vore/aggressive/dino,
+								  "Giant Frog" = /mob/living/simple_mob/vore/aggressive/frog,
+								  "Giant Rat" = /mob/living/simple_mob/vore/aggressive/rat,
+								  "Juvenile Solargrub" = /mob/living/simple_mob/vore/solargrub,
+								  "Red Panda" = /mob/living/simple_mob/vore/redpanda,
+								  "Fennec" = /mob/living/simple_mob/vore/fennec,
+								  "Fennix" = /mob/living/simple_mob/vore/fennix,
+								  "Jelly Blob" = /mob/living/simple_mob/animal/space/jelly,
+								  "Wolf" = /mob/living/simple_mob/animal/wolf,
+								  "Sect Queen" = /mob/living/simple_mob/vore/sect_queen,
+								  "Defanged Xenomorph" = /mob/living/simple_mob/vore/xeno_defanged,
+								  )
+
+/obj/structure/ghost_pod/ghost_activated/maintpred/create_occupant(var/mob/M)
+	..()
+	var/choice
+	var/randomize
+	var/finalized = "No"
+
+	while(finalized == "No" && M.client)
+		choice = input(M,"What type of predator do you want to play as?") as null|anything in possible_mobs
+		if(!choice)
+			randomize = TRUE
+			break
+
+		if(choice)
+			finalized = alert(M, "Are you sure you want to play as [choice]?","Confirmation","No","Yes")
+
+	if(randomize)
+		choice = pick(possible_mobs)
+
+	var/mobtype = possible_mobs[choice]
+	var/mob/living/simple_mob/newPred = new mobtype(get_turf(src))
+	qdel(newPred.ai_holder)
+	newPred.ai_holder = null
+	//newPred.movement_cooldown = 0			// The "needless artificial speed cap" exists for a reason
+	if(M.mind)
+		M.mind.transfer_to(newPred)
+	to_chat(M, "<span class='notice'>You are <b>[newPred]</b>, somehow having gotten aboard the station in search of food. \
+	You are wary of environment around you, but you do feel rather peckish. Stick around dark, secluded places to avoid danger or, \
+	if you are cute enough, try to make friends with this place's inhabitants.</span>")
+	newPred.ckey = M.ckey
+	newPred.visible_message("<span class='warning'>[newPred] emerges from somewhere!</span>")
+
+	if(prob(announce_prob))
+		spawn(2 MINUTES)
+			command_announcement.Announce("Unexpected biosignature detected in the maintenance tunnels of [station_name()].", "Lifesign Alert")
+
+	qdel(src)
+
+/obj/structure/ghost_pod/ghost_activated/maintpred/no_announce
+	announce_prob = 0
+
+/obj/structure/ghost_pod/ghost_activated/morphspawn
+	name = "weird goo"
+	desc = "A pile of weird gunk... Wait, is it actually moving?"
+	icon = 'icons/mob/animal_vr.dmi'
+	icon_state = "morph"
+	icon_state_opened = "morph_dead"
+	density = FALSE
+	ghost_query_type = /datum/ghost_query/morph
+	anchored = TRUE
+	invisibility = INVISIBILITY_OBSERVER
+	spawn_active = TRUE
+	var/announce_prob = 50
+
+/obj/structure/ghost_pod/ghost_activated/morphspawn/create_occupant(var/mob/M)
+	..()
+	var/mob/living/simple_mob/vore/hostile/morph/newMorph = new /mob/living/simple_mob/vore/hostile/morph(get_turf(src))
+	if(M.mind)
+		M.mind.transfer_to(newMorph)
+	to_chat(M, "<span class='notice'>You are a <b>Morph</b>, somehow having gotten aboard the station in your wandering. \
+	You are wary of environment around you, but your primal hunger still calls for you to find prey. Seek a convincing disguise, \
+	using your amorphous form to traverse vents to find and consume weak prey.</span>")
+	to_chat(M, "<span class='notice'>You can use shift + click on objects to disguise yourself as them, but your strikes are nearly useless when you are disguised. \
+	You can undisguise yourself by shift + clicking yourself, but disguise being switched, or turned on and off has a short cooldown. You can also ventcrawl, \
+	by using alt + click on the vent or scrubber.</span>")
+	newMorph.ckey = M.ckey
+	newMorph.visible_message("<span class='warning'>A morph appears to crawl out of somewhere.</span>")
+
+	if(prob(announce_prob))
+		spawn(2 MINUTES)
+			command_announcement.Announce("Unexpected biosignature detected in the maintenance tunnels of [station_name()].", "Lifesign Alert")
+
+	qdel(src)
+
+/obj/structure/ghost_pod/ghost_activated/morphspawn/no_announce
+	announce_prob = 0

--- a/code/game/objects/structures/ghost_pods/ghost_pods.dm
+++ b/code/game/objects/structures/ghost_pods/ghost_pods.dm
@@ -36,6 +36,10 @@
 // Override this to create whatever mob you need. Be sure to call ..() if you don't want it to make infinite mobs.
 /obj/structure/ghost_pod/proc/create_occupant(var/mob/M)
 	used = TRUE
+	//VOREStation Addition Start
+	if(src in active_ghost_pods)
+		active_ghost_pods -= src
+	//VOREStation Addition End
 	return TRUE
 
 
@@ -52,6 +56,7 @@
 		// VOREStation Addition Start
 		if(!used)
 			activated = TRUE
+			ghostpod_startup(FALSE)
 		// VOREStation Addition End
 
 /obj/structure/ghost_pod/manual/attack_ai(var/mob/living/silicon/user)

--- a/code/game/objects/structures/ghost_pods/ghost_pods_vr.dm
+++ b/code/game/objects/structures/ghost_pods/ghost_pods_vr.dm
@@ -1,3 +1,11 @@
+/obj/structure/ghost_pod/Destroy()
+	if(src in active_ghost_pods)
+		active_ghost_pods -= src
+	..()
+
+/obj/structure/ghost_pod
+	var/spawn_active = FALSE
+
 /obj/structure/ghost_pod/manual
 	var/remains_active = FALSE
 	var/activated = FALSE
@@ -29,3 +37,13 @@
 	busy = FALSE
 
 	create_occupant(user)
+
+/obj/structure/ghost_pod/proc/ghostpod_startup(var/notify = FALSE)
+	if(!(src in active_ghost_pods))
+		active_ghost_pods += src
+	if(notify)
+		trigger()
+
+/obj/structure/ghost_pod/ghost_activated/Initialize()
+	..()
+	ghostpod_startup(spawn_active)

--- a/code/modules/events/maintenance_predator_vr.dm
+++ b/code/modules/events/maintenance_predator_vr.dm
@@ -1,21 +1,6 @@
 /datum/event/maintenance_predator
 	startWhen = 1
-	announceWhen = 50
-	endWhen = 100
-	var/announceProb = 35
-	var/list/possible_mobs = list("Space Bumblebee" = /mob/living/simple_mob/vore/bee,
-								  "Voracious Lizard" = /mob/living/simple_mob/vore/aggressive/dino,
-								  "Giant Frog" = /mob/living/simple_mob/vore/aggressive/frog,
-								  "Giant Rat" = /mob/living/simple_mob/vore/aggressive/rat,
-								  "Juvenile Solargrub" = /mob/living/simple_mob/vore/solargrub,
-								  "Red Panda" = /mob/living/simple_mob/vore/redpanda,
-								  "Fennec" = /mob/living/simple_mob/vore/fennec,
-								  "Fennix" = /mob/living/simple_mob/vore/fennix,
-								  "Jelly Blob" = /mob/living/simple_mob/animal/space/jelly,
-								  "Wolf" = /mob/living/simple_mob/animal/wolf,
-								  "Sect Queen" = /mob/living/simple_mob/vore/sect_queen,
-								  "Defanged Xenomorph" = /mob/living/simple_mob/vore/xeno_defanged,
-								  )
+	endWhen = 30
 
 /datum/event/maintenance_predator/start()
 
@@ -34,44 +19,4 @@
 		kill()		// To prevent fake announcements
 		return
 
-	var/datum/ghost_query/Q = new /datum/ghost_query/maints_pred()
-	var/list/winner = Q.query()
-
-	if(winner.len)
-		var/mob/observer/dead/D = winner[1]
-		var/choice
-		var/randomize
-		var/finalized = "No"
-
-		while(finalized == "No" && D.client)
-			choice = input(D,"What type of predator do you want to play as?") as null|anything in possible_mobs
-			if(!choice)
-				randomize = TRUE
-				break
-
-			if(choice)
-				finalized = alert(D, "Are you sure you want to play as [choice]?","Confirmation","No","Yes")
-
-		if(randomize)
-			choice = pick(possible_mobs)
-
-		var/mobtype = possible_mobs[choice]
-		var/mob/living/simple_mob/newPred = new mobtype(get_turf(spawnspot))
-		qdel(newPred.ai_holder)
-		newPred.ai_holder = null
-		//newPred.movement_cooldown = 0			// The "needless artificial speed cap" exists for a reason
-		if(D.mind)
-			D.mind.transfer_to(newPred)
-		to_chat(D, "<span class='notice'>You are <b>[newPred]</b>, somehow having gotten aboard the station in search of food. \
-		You are wary of environment around you, but you do feel rather peckish. Stick around dark, secluded places to avoid danger or, \
-		if you are cute enough, try to make friends with this place's inhabitants.</span>")
-		newPred.ckey = D.ckey
-		newPred.visible_message("<span class='warning'>[newPred] emerges from somewhere!</span>")
-	else
-		kill()		// To prevent fake announcements
-		return
-
-
-/datum/event/maintenance_predator/announce()
-	if(prob(announceProb))
-		command_announcement.Announce("Unexpected biosignature detected in the maintenance tunnels of [station_name()].", "Lifesign Alert")
+	new /obj/structure/ghost_pod/ghost_activated/maintpred(get_turf(spawnspot))

--- a/code/modules/events/morph_spawn_vr.dm
+++ b/code/modules/events/morph_spawn_vr.dm
@@ -1,8 +1,6 @@
 /datum/event/morph_spawn
 	startWhen = 1
-	announceWhen = 20
 	endWhen = 30
-	var/announceProb = 50
 
 /datum/event/morph_spawn/start()
 
@@ -21,27 +19,4 @@
 		kill()		// To prevent fake announcements
 		return
 
-	var/datum/ghost_query/Q = new /datum/ghost_query/morph()
-	var/list/winner = Q.query()
-
-	if(winner.len)
-		var/mob/living/simple_mob/vore/hostile/morph/newMorph = new /mob/living/simple_mob/vore/hostile/morph(get_turf(spawnspot))
-		var/mob/observer/dead/D = winner[1]
-		if(D.mind)
-			D.mind.transfer_to(newMorph)
-		to_chat(D, "<span class='notice'>You are a <b>Morph</b>, somehow having gotten aboard the station in your wandering. \
-		You are wary of environment around you, but your primal hunger still calls for you to find prey. Seek a convincing disguise, \
-		using your amorphous form to traverse vents to find and consume weak prey.</span>")
-		to_chat(D, "<span class='notice'>You can use shift + click on objects to disguise yourself as them, but your strikes are nearly useless when you are disguised. \
-		You can undisguise yourself by shift + clicking yourself, but disguise being switched, or turned on and off has a short cooldown. You can also ventcrawl, \
-		by using alt + click on the vent or scrubber.</span>")
-		newMorph.ckey = D.ckey
-		newMorph.visible_message("<span class='warning'>A morph appears to crawl out of somewhere.</span>")
-	else
-		kill()		// To prevent fake announcements
-		return
-
-
-/datum/event/morph_spawn/announce()
-	if(prob(announceProb))
-		command_announcement.Announce("Unknown entitity detected boarding [station_name()]. Exercise extra caution.", "Lifesign Alert", new_sound = 'sound/AI/aliens.ogg')
+	new /obj/structure/ghost_pod/ghost_activated/morphspawn(get_turf(spawnspot))

--- a/code/modules/mob/dead/observer/observer_vr.dm
+++ b/code/modules/mob/dead/observer/observer_vr.dm
@@ -74,3 +74,30 @@
 			to_chat(src, "<span class='notice'>New notification has been sent.</span>")
 	else
 		to_chat(src, "<span class='warning'>No mind record found!</span>")
+
+/mob/observer/dead/verb/findghostpod() //Moves the ghost instead of just changing the ghosts's eye -Nodrak
+	set category = "Ghost"
+	set name = "Find Ghost Pod"
+	set desc = "Find an active ghost pod"
+	set popup_menu = FALSE
+
+	if(!istype(usr, /mob/observer/dead)) //Make sure they're an observer!
+		return
+
+	var/input = input(usr, "Select a ghost pod:", "Ghost Jump") as null|anything in observe_list_format(active_ghost_pods)
+	if(!input)
+		to_chat(src, "No active ghost pods detected.")
+		return
+
+	var/target = observe_list_format(active_ghost_pods)[input]
+	if (!target)//Make sure we actually have a target
+		return
+	else
+		var/obj/O = target //Destination mob
+		var/turf/T = get_turf(O) //Turf of the destination mob
+
+		if(T && isturf(T))	//Make sure the turf exists, then move the source to that destination.
+			forceMove(T)
+			stop_following()
+		else
+			to_chat(src, "This ghost pod is not located in the game world.")

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -1487,6 +1487,7 @@
 #include "code\game\objects\structures\flora\flora_vr.dm"
 #include "code\game\objects\structures\flora\grass.dm"
 #include "code\game\objects\structures\flora\trees.dm"
+#include "code\game\objects\structures\ghost_pods\event_vr.dm"
 #include "code\game\objects\structures\ghost_pods\ghost_pods.dm"
 #include "code\game\objects\structures\ghost_pods\ghost_pods_vr.dm"
 #include "code\game\objects\structures\ghost_pods\human.dm"


### PR DESCRIPTION
Basically, instead of doing a one-time Query for ghosts, the event now spawns a ghost pod that is only visible to ghosts and can be used at any point after the event.

Also adds a new verb to help with finding those: Find Ghost Pod. Gives you a list of all 'active' ghost pods. Right now only Maintenance Holes, Weird Gunks and those drone pods that have already been attemptedly activated are considered 'active'.

Practically, should basically mean that if maint pred/morph spawn event happened and nobody took initial opportunity, anyone later on can just use the verb to see if there are opportunities still open and take them later.
Also makes it easier for admins to spawn those things.

Probably needs more testing, but I'm sleepy as I'm posting this and just want to get it up before going to bed and finishing up tomorrow.