### PR TITLE
Shuttle Console ID Stuff

### DIFF
--- a/code/game/machinery/computer/guestpass.dm
+++ b/code/game/machinery/computer/guestpass.dm
@@ -168,9 +168,9 @@
 			if(reas)
 				reason = reas
 		if("duration")
-			var/dur = input("Duration (in minutes) during which pass is valid (up to 120 minutes).", "Duration") as num|null
+			var/dur = input("Duration (in minutes) during which pass is valid (up to 360 minutes).", "Duration") as num|null //VOREStation Edit
 			if(dur)
-				if(dur > 0 && dur <= 120)
+				if(dur > 0 && dur <= 360) //VOREStation Edit
 					duration = dur
 				else
 					to_chat(usr, "<span class='warning'>Invalid duration.</span>")

--- a/code/modules/overmap/ships/computers/ship_vr.dm
+++ b/code/modules/overmap/ships/computers/ship_vr.dm
@@ -1,0 +1,13 @@
+/*
+Ships can now be hijacked!
+*/
+/obj/machinery/computer/ship
+	var/hacked = 0   // Has been emagged, no access restrictions.
+
+/obj/machinery/computer/ship/emag_act(var/remaining_charges, var/mob/user)
+	if (!hacked)
+		req_access = list()
+		req_one_access = list()
+		hacked = 1
+		to_chat(user, "You short out the console's ID checking system. It's now available to everyone!")
+		return 1

--- a/maps/tether/tether_shuttles.dm
+++ b/maps/tether/tether_shuttles.dm
@@ -259,7 +259,6 @@
 /obj/machinery/computer/shuttle_control/explore/medivac
 	name = "short jump console"
 	shuttle_tag = "Medivac Shuttle"
-	req_one_access = list(access_cmo, access_pilot)
 
 ////////////////////////////////////////
 ////////      Securiship   /////////////
@@ -285,4 +284,3 @@
 /obj/machinery/computer/shuttle_control/explore/securiship
 	name = "short jump console"
 	shuttle_tag = "Securiship Shuttle"
-	req_one_access = list(access_pilot, access_hos)

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -3105,6 +3105,7 @@
 #include "code\modules\overmap\ships\computers\helm.dm"
 #include "code\modules\overmap\ships\computers\sensors.dm"
 #include "code\modules\overmap\ships\computers\ship.dm"
+#include "code\modules\overmap\ships\computers\ship_vr.dm"
 #include "code\modules\overmap\ships\computers\shuttle.dm"
 #include "code\modules\overmap\ships\engines\engine.dm"
 #include "code\modules\overmap\ships\engines\gas_thruster.dm"


### PR DESCRIPTION
- Removes CMO and HoS Access from their respective shuttle consoles
- Adds emag_act to all shuttle consoles to gain access to them
- Guest Passes can now be set for 6 hours max