### PR TITLE
Improved Trait Exclusion Logic

### DIFF
--- a/code/modules/client/preference_setup/vore/07_traits.dm
+++ b/code/modules/client/preference_setup/vore/07_traits.dm
@@ -2,6 +2,9 @@
 #define NEUTRAL_MODE 2
 #define NEGATIVE_MODE 3
 
+#define ORGANICS	1
+#define SYNTHETICS	2
+
 /datum/preferences
 	var/custom_species	// Custom species name, can't be changed due to it having been used in savefiles already.
 	var/custom_base		// What to base the custom species on
@@ -15,6 +18,7 @@
 	var/starting_trait_points = STARTING_SPECIES_POINTS
 	var/max_traits = MAX_SPECIES_TRAITS
 	var/dirty_synth = 0		//Are you a synth
+	var/gross_meatbag = 0		//Where'd I leave my Voight-Kampff test kit?
 
 // Definition of the stuff for Ears
 /datum/category_item/player_setup_item/vore/traits
@@ -85,6 +89,10 @@
 
 	if(character.isSynthetic())	//Checking if we have a synth on our hands, boys.
 		pref.dirty_synth = 1
+		pref.gross_meatbag = 0
+	else
+		pref.gross_meatbag = 1
+		pref.dirty_synth = 0
 
 	var/datum/species/S = character.species
 	var/SB
@@ -268,11 +276,14 @@
 
 			var/conflict = FALSE
 
-			user.isSynthetic()	//Recheck just to be sure
-			if(pref.dirty_synth && instance.not_for_synths)//if you are a synth you can't take this trait.
-				alert("You cannot take this trait as a SYNTH.\
-				Please remove that trait, or pick another trait to add.","Error")
+			if(pref.dirty_synth && !(instance.can_take & SYNTHETICS))
+				alert("The trait you've selected can only be taken by organic characters!","Error")
 				pref.dirty_synth = 0	//Just to be sure
+				return TOPIC_REFRESH
+
+			if(pref.gross_meatbag && !(instance.can_take & ORGANICS))
+				alert("The trait you've selected can only be taken by synthetic characters!","Error")
+				pref.gross_meatbag = 0	//Just to be sure
 				return TOPIC_REFRESH
 
 

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/negative.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/negative.dm
@@ -1,3 +1,6 @@
+#define ORGANICS	1
+#define SYNTHETICS	2
+
 /datum/trait/speed_slow
 	name = "Slowdown"
 	desc = "Allows you to move slower on average than baseline."
@@ -92,10 +95,10 @@
 
 /datum/trait/haemophilia
 	name = "Haemophilia - Organics only"
-	desc = "When you bleed, you bleed a LOT. This trait is only for organics, buggy with synths!"
+	desc = "When you bleed, you bleed a LOT."
 	cost = -2
 	var_changes = list("bloodloss_rate" = 2)
-	not_for_synths = 1
+	can_take = ORGANICS
 
 /datum/trait/hollow
 	name = "Hollow Bones/Aluminum Alloy"

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
@@ -1,3 +1,6 @@
+#define ORGANICS	1
+#define SYNTHETICS	2
+
 /datum/trait/metabolism_up
 	name = "Fast Metabolism"
 	desc = "You process ingested and injected reagents faster, but get hungry faster (Teshari speed)."

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/positive.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/positive.dm
@@ -1,3 +1,6 @@
+#define ORGANICS	1
+#define SYNTHETICS	2
+
 /datum/trait/speed_fast
 	name = "Haste"
 	desc = "Allows you to move faster on average than baseline."

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/trait.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/trait.dm
@@ -1,3 +1,6 @@
+#define ORGANICS	1
+#define SYNTHETICS	2
+
 /datum/trait
 	var/name
 	var/desc = "Contact a developer if you see this trait."
@@ -5,7 +8,7 @@
 	var/cost = 0			// 0 is neutral, negative cost means negative, positive cost means positive.
 	var/list/var_changes	// A list to apply to the custom species vars.
 	var/list/excludes		// Store a list of paths of traits to exclude, but done automatically if they change the same vars.
-	var/not_for_synths = FALSE	// Can freaking synths use those.
+	var/can_take = ORGANICS|SYNTHETICS	// Can freaking synths use those.
 	var/custom_only = TRUE		// Trait only available for custom species
 
 //Proc can be overridden lower to include special changes, make sure to call up though for the vars changes


### PR DESCRIPTION
👐 BITFLAGS 👐

okay fine, full version; I expanded the logic behind trait exclusion for organics/synthetics to let it go both ways. Now you can have organic-exclusive traits *and* synthetic-exclusive traits. a little messy, but tested and working okay so far as I can see.

:cl:
tweak - improved logic for trait exclusivity using bitflags
/:cl: