### PR TITLE
Possibly fixes simplemob bad del runtime spam

### DIFF
--- a/code/modules/mob/living/simple_mob/simple_mob_vr.dm
+++ b/code/modules/mob/living/simple_mob/simple_mob_vr.dm
@@ -54,7 +54,7 @@
 /mob/living/simple_mob/Destroy()
 	release_vore_contents()
 	prey_excludes.Cut()
-	. = ..()
+	return ..()
 
 //For all those ID-having mobs
 /mob/living/simple_mob/GetIdCard()


### PR DESCRIPTION
Pretty sure the destroy proc expects a returned confirmation, which was like this on pretty much everything else.