### PR TITLE
No ERP -> Unset

### DIFF
--- a/code/modules/client/preferences_vr.dm
+++ b/code/modules/client/preferences_vr.dm
@@ -1,7 +1,7 @@
 /datum/preferences
 	var/show_in_directory = 1	//Show in Character Directory
 	var/directory_tag = "Unset" //Sorting tag to use in character directory
-	var/directory_erptag = "No ERP"	//ditto, but for non-vore scenes
+	var/directory_erptag = "Unset"	//ditto, but for non-vore scenes
 	var/directory_ad = ""		//Advertisement stuff to show in character directory.
 	var/sensorpref = 5			//Set character's suit sensor level
 


### PR DESCRIPTION
Just feels like this would be better since having No ERP as default might turn potential partners away if the player is unaware they can switch this to what they want. 

🆑 
tweak - Change default setting for ERP prefs to unset to encourage asking if unsure.
/🆑