### PR TITLE
Von Braun & Typhon tweaks

### DIFF
--- a/maps/submaps/admin_use_vr/ert.dm
+++ b/maps/submaps/admin_use_vr/ert.dm
@@ -154,7 +154,7 @@
 /obj/effect/shuttle_landmark/shuttle_initializer/ert_ship_boat
 	name = "NRV Von Braun's Bay"
 	base_area = /area/ship/ert/hangar
-	base_turf = /turf/simulated/floor/plating
+	base_turf = /turf/simulated/floor/reinforced
 	landmark_tag = "omship_spawn_ert_lander"
 	docking_controller = "ert_boarding_shuttle_dock"
 	shuttle_type = /datum/shuttle/autodock/overmap/ert_ship_boat

--- a/maps/submaps/admin_use_vr/kk_mercship.dmm
+++ b/maps/submaps/admin_use_vr/kk_mercship.dmm
@@ -657,6 +657,15 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/ship/manta/med)
+"cJ" = (
+/obj/machinery/sleeper{
+	desc = "A stasis pod with built-in injectors, a dialysis machine, and a limited health scanner. This one is preconfigured to stasis levels, for keeping captives (or teammates) alive as long as possible.";
+	dir = 1;
+	name = "stasis cell";
+	stasis_level = 10
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/manta_ship_boat)
 "cK" = (
 /obj/structure/cable/orange{
 	d1 = 1;
@@ -1129,7 +1138,9 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/manta/teleporter)
 "fp" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/fuel,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 8
+	},
 /turf/simulated/wall/rshull,
 /area/shuttle/manta_ship_boat)
 "fr" = (
@@ -2048,20 +2059,19 @@
 /turf/simulated/floor/reinforced,
 /area/ship/manta/recreation)
 "jl" = (
-/obj/structure/grille,
-/obj/structure/window/titanium/full,
-/obj/structure/window/titanium{
+/obj/structure/bed/chair/bay/shuttle{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
-/obj/machinery/door/blast/regular{
-	closed_layer = 4;
-	dir = 4;
+/obj/machinery/button/remote/blast_door{
+	dir = 8;
 	id = "Merc_Shuttle_Fore";
-	layer = 4
+	name = "Boarding Shuttle Fore Ramp";
+	pixel_x = -24;
+	req_access = list(150)
 	},
-/obj/machinery/shield_diffuser,
-/obj/machinery/door/firedoor/border_only,
-/obj/structure/window/titanium,
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/manta_ship_boat)
 "jo" = (
@@ -2145,17 +2155,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/manta/recreation)
 "jE" = (
-/obj/machinery/door/blast/regular{
-	closed_layer = 4;
-	dir = 4;
-	id = "Merc_Shuttle_Fore";
-	layer = 4
-	},
-/obj/machinery/shield_diffuser,
-/obj/machinery/door/firedoor/border_only,
+/obj/effect/shuttle_landmark/shuttle_initializer/manta_ship_boat,
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
+/obj/effect/overmap/visitable/ship/landable/manta_ship_boat,
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/manta_ship_boat)
 "jF" = (
@@ -2363,7 +2367,7 @@
 /turf/simulated/floor/plating,
 /area/ship/manta/hallways_port)
 "kT" = (
-/obj/structure/closet/crate,
+/obj/machinery/portable_atmospherics/canister/phoron/engine_setup,
 /turf/simulated/floor/plating,
 /area/ship/manta/hallways_port)
 "kW" = (
@@ -2609,15 +2613,12 @@
 /obj/structure/bed/chair/bay/shuttle{
 	dir = 4
 	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
+/obj/machinery/light/no_nightshift{
+	dir = 8
 	},
-/obj/machinery/button/remote/blast_door{
-	dir = 8;
-	id = "Merc_Shuttle_Fore";
-	name = "Boarding Shuttle Fore Ramp";
-	pixel_x = -24;
-	req_access = list(150)
+/obj/machinery/alarm/alarms_hidden{
+	dir = 4;
+	pixel_x = -26
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/manta_ship_boat)
@@ -2632,11 +2633,19 @@
 /turf/simulated/floor/wood,
 /area/ship/manta/barracks)
 "lZ" = (
-/obj/effect/shuttle_landmark/shuttle_initializer/manta_ship_boat,
-/obj/effect/floor_decal/industrial/warning{
+/obj/structure/grille,
+/obj/structure/window/titanium/full,
+/obj/structure/window/titanium{
 	dir = 1
 	},
-/obj/effect/overmap/visitable/ship/landable/manta_ship_boat,
+/obj/machinery/shield_diffuser,
+/obj/structure/window/titanium,
+/obj/machinery/door/blast/regular{
+	closed_layer = 4;
+	dir = 4;
+	id = "Merc_Shuttle_Fore";
+	layer = 4
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/manta_ship_boat)
 "mb" = (
@@ -2646,8 +2655,15 @@
 /turf/space,
 /area/ship/manta/radiator_port)
 "me" = (
+/obj/machinery/shield_diffuser,
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
+	},
+/obj/machinery/door/blast/regular{
+	closed_layer = 4;
+	dir = 4;
+	id = "Merc_Shuttle_Fore";
+	layer = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/manta_ship_boat)
@@ -2679,15 +2695,12 @@
 /obj/structure/bed/chair/bay/shuttle{
 	dir = 8
 	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
+/obj/machinery/light/no_nightshift{
+	dir = 4
 	},
-/obj/machinery/button/remote/blast_door{
+/obj/machinery/firealarm/alarms_hidden{
 	dir = 4;
-	id = "Merc_Shuttle_Fore";
-	name = "Boarding Shuttle Fore Ramp";
-	pixel_x = 24;
-	req_access = list(150)
+	pixel_x = 26
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/manta_ship_boat)
@@ -2743,9 +2756,14 @@
 /turf/simulated/floor/plating,
 /area/ship/manta/engine)
 "mN" = (
-/obj/machinery/computer/ship/engines{
-	dir = 1
+/obj/machinery/firealarm/alarms_hidden{
+	dir = 8;
+	pixel_x = -26
 	},
+/obj/structure/bed/chair/bay/shuttle{
+	dir = 4
+	},
+/obj/machinery/light/no_nightshift,
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/manta_ship_boat)
 "mO" = (
@@ -3339,13 +3357,6 @@
 /obj/structure/bed/chair/bay/shuttle{
 	dir = 4
 	},
-/obj/machinery/light/no_nightshift{
-	dir = 8
-	},
-/obj/machinery/alarm/alarms_hidden{
-	dir = 4;
-	pixel_x = -26
-	},
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/manta_ship_boat)
 "pB" = (
@@ -3403,13 +3414,6 @@
 "pS" = (
 /obj/structure/bed/chair/bay/shuttle{
 	dir = 8
-	},
-/obj/machinery/light/no_nightshift{
-	dir = 4
-	},
-/obj/machinery/firealarm/alarms_hidden{
-	dir = 4;
-	pixel_x = 26
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/manta_ship_boat)
@@ -3650,6 +3654,12 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/ship/manta/med)
+"rd" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/fuel{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/manta_ship_boat)
 "rl" = (
 /obj/machinery/power/apc/hyper{
 	alarms_hidden = 1;
@@ -3795,6 +3805,7 @@
 /area/ship/manta/mech_bay)
 "rU" = (
 /obj/machinery/door/airlock/engineering{
+	name = "Lander Fuel Storage";
 	req_one_access = list(150)
 	},
 /obj/structure/cable/orange{
@@ -3851,11 +3862,11 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/manta/armoury_st)
 "sn" = (
-/obj/structure/bed/chair/bay/shuttle{
-	dir = 4
-	},
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 8
+	},
+/obj/structure/bed/chair/bay/shuttle{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/manta_ship_boat)
@@ -3906,10 +3917,10 @@
 /turf/simulated/floor/wood,
 /area/ship/manta/barracks)
 "sx" = (
+/obj/effect/floor_decal/industrial/warning/corner,
 /obj/structure/bed/chair/bay/shuttle{
 	dir = 8
 	},
-/obj/effect/floor_decal/industrial/warning/corner,
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/manta_ship_boat)
 "sy" = (
@@ -4186,14 +4197,14 @@
 	id = "Merc_Shuttle_Boarding";
 	opacity = 0
 	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
 /obj/machinery/button/remote/blast_door{
 	id = "Merc_Shuttle_Boarding";
 	name = "Boarding Shuttle Access";
 	pixel_y = 24;
 	req_access = list(150)
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/manta_ship_boat)
@@ -4239,14 +4250,14 @@
 	id = "Merc_Shuttle_Boarding";
 	opacity = 0
 	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
 /obj/machinery/button/remote/blast_door{
-	id = "ERT_Shuttle_Rear";
+	id = "Merc_Shuttle_Boarding";
 	name = "Boarding Shuttle Access";
 	pixel_y = 24;
 	req_access = list(150)
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/manta_ship_boat)
@@ -4948,12 +4959,6 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/manta/hangar)
 "xf" = (
-/obj/machinery/door/blast/regular{
-	density = 0;
-	icon_state = "pdoor0";
-	id = "Merc_Shuttle_Boarding";
-	opacity = 0
-	},
 /obj/machinery/button/remote/blast_door{
 	dir = 1;
 	id = "Merc_Shuttle_Boarding";
@@ -4961,11 +4966,14 @@
 	pixel_y = -24;
 	req_access = list(150)
 	},
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "Merc_Shuttle_Boarding";
+	opacity = 0
+	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
-	},
-/obj/machinery/door/firedoor/multi_tile{
-	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/manta_ship_boat)
@@ -4981,12 +4989,6 @@
 /turf/simulated/floor/plating,
 /area/ship/manta/engine)
 "xo" = (
-/obj/machinery/door/blast/regular{
-	density = 0;
-	icon_state = "pdoor0";
-	id = "Merc_Shuttle_Boarding";
-	opacity = 0
-	},
 /obj/machinery/button/remote/blast_door{
 	dir = 1;
 	id = "Merc_Shuttle_Boarding";
@@ -4994,11 +4996,14 @@
 	pixel_y = -24;
 	req_access = list(150)
 	},
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "Merc_Shuttle_Boarding";
+	opacity = 0
+	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
-	},
-/obj/machinery/door/firedoor/multi_tile{
-	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/manta_ship_boat)
@@ -5024,6 +5029,19 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/manta/hangar)
+"xs" = (
+/obj/machinery/portable_atmospherics/canister/phoron/engine_setup,
+/obj/machinery/atmospherics/portables_connector/fuel{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/outline/red,
+/obj/machinery/door/window/brigdoor/northright{
+	dir = 8;
+	req_access = list(150);
+	req_one_access = list(150)
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/manta_ship_boat)
 "xt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -5781,9 +5799,11 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/manta/hangar)
 "Au" = (
-/obj/machinery/door/window/brigdoor/northleft{
-	req_access = list(150);
+/obj/machinery/computer/ship/helm{
 	req_one_access = list(150)
+	},
+/obj/structure/window/titanium{
+	dir = 1
 	},
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 1
@@ -5829,34 +5849,28 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/manta/hallways_aft)
 "AD" = (
-/obj/machinery/computer/shuttle_control/explore/manta_ship_boat,
-/obj/structure/window/titanium{
-	dir = 1
-	},
-/obj/structure/window/titanium{
-	dir = 8
+/obj/machinery/door/window/brigdoor/northleft{
+	req_access = list(150);
+	req_one_access = list(150)
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/manta_ship_boat)
 "AE" = (
-/obj/structure/window/titanium{
-	dir = 1
-	},
-/obj/structure/window/titanium{
-	dir = 4
-	},
-/obj/machinery/computer/ship/helm{
+/obj/machinery/door/window/brigdoor/northright{
+	req_access = list(150);
 	req_one_access = list(150)
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/manta_ship_boat)
 "AJ" = (
-/obj/machinery/door/window/brigdoor/northright{
-	req_access = list(150);
-	req_one_access = list(150)
-	},
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/bed/chair/bay/shuttle{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/manta_ship_boat)
@@ -6524,12 +6538,22 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/manta/armoury_st)
 "Ec" = (
-/obj/machinery/light/no_nightshift{
-	dir = 8
+/obj/structure/bed/chair/bay/shuttle{
+	dir = 1
 	},
-/obj/machinery/alarm/alarms_hidden{
-	dir = 4;
-	pixel_x = -26
+/obj/machinery/button/remote/blast_door{
+	id = "Merc_Shuttle_Fore";
+	name = "Boarding Shuttle Fore Ramp";
+	pixel_x = -24;
+	pixel_y = 25;
+	req_access = list(150)
+	},
+/obj/machinery/button/remote/blast_door{
+	id = "Merc_Shuttle_Boarding";
+	name = "Boarding Shuttle Side Hatches";
+	pixel_x = -41;
+	pixel_y = 25;
+	req_access = list(150)
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/manta_ship_boat)
@@ -6569,31 +6593,30 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/manta/hangar)
 "En" = (
-/obj/structure/bed/chair/bay/shuttle{
+/obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/manta_ship_boat)
 "Et" = (
 /obj/structure/bed/chair/bay/shuttle{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
 /obj/machinery/button/remote/blast_door{
+	dir = 4;
 	id = "Merc_Shuttle_Fore";
 	name = "Boarding Shuttle Fore Ramp";
-	pixel_x = -17;
-	pixel_y = 42;
+	pixel_x = 24;
 	req_access = list(150)
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/manta_ship_boat)
 "Eu" = (
-/obj/machinery/light/no_nightshift{
-	dir = 4
-	},
-/obj/machinery/firealarm/alarms_hidden{
-	dir = 4;
-	pixel_x = 26
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 6
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/manta_ship_boat)
@@ -6653,12 +6676,18 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/manta/hallways_aft)
 "EJ" = (
-/obj/structure/bed/chair/bay/shuttle{
-	dir = 1
-	},
 /obj/structure/fuel_port{
 	pixel_y = -29
 	},
+/obj/machinery/alarm/alarms_hidden{
+	dir = 8;
+	pixel_x = 26
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
+/obj/structure/bed/chair/bay/shuttle{
+	dir = 8
+	},
+/obj/machinery/light/no_nightshift,
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/manta_ship_boat)
 "EN" = (
@@ -6749,6 +6778,10 @@
 /obj/machinery/light_switch{
 	dir = 1;
 	pixel_y = -23
+	},
+/obj/machinery/vending/fitness{
+	dir = 1;
+	prices = list()
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/manta/hangar)
@@ -7615,10 +7648,9 @@
 /turf/simulated/floor/wood,
 /area/ship/manta/commander)
 "Ki" = (
-/obj/machinery/sleeper{
+/obj/machinery/computer/ship/engines{
 	dir = 4;
-	name = "Stasis Cell";
-	stasis_level = 10
+	req_one_access = list(150)
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/manta_ship_boat)
@@ -7684,10 +7716,15 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/manta/engineering)
 "Kv" = (
-/obj/machinery/sleeper{
+/obj/machinery/portable_atmospherics/canister/phoron/engine_setup,
+/obj/machinery/atmospherics/portables_connector/fuel{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/outline/red,
+/obj/machinery/door/window/brigdoor/northleft{
 	dir = 8;
-	name = "Stasis Cell";
-	stasis_level = 10
+	req_access = list(150);
+	req_one_access = list(150)
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/manta_ship_boat)
@@ -8129,6 +8166,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/ship/manta/hallways_star)
+"MO" = (
+/obj/machinery/sleep_console{
+	dir = 2;
+	name = "stasis cell console"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/manta_ship_boat)
 "MQ" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -9238,15 +9282,12 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/manta/armoury_st)
 "SF" = (
-/obj/machinery/door/window/brigdoor/northleft{
-	req_access = list(150);
-	req_one_access = list(150)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
 	},
-/obj/machinery/atmospherics/portables_connector/fuel,
-/obj/machinery/portable_atmospherics/canister/phoron/engine_setup,
-/obj/effect/floor_decal/industrial/outline/red,
 /turf/simulated/floor/tiled/techfloor,
-/area/shuttle/manta_ship_boat)
+/area/ship/manta/hangar)
 "SG" = (
 /obj/machinery/atmospherics/pipe/manifold/visible,
 /turf/simulated/floor/plating,
@@ -9258,13 +9299,9 @@
 /turf/simulated/floor/plating,
 /area/ship/manta/atmos)
 "SJ" = (
-/obj/machinery/door/window/brigdoor/northright{
-	req_access = list(150);
-	req_one_access = list(150)
+/obj/machinery/computer/shuttle_control/explore/manta_ship_boat{
+	dir = 4
 	},
-/obj/machinery/atmospherics/portables_connector/fuel,
-/obj/machinery/portable_atmospherics/canister/phoron/engine_setup,
-/obj/effect/floor_decal/industrial/outline/red,
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/manta_ship_boat)
 "SO" = (
@@ -20248,7 +20285,7 @@ fy
 jc
 lR
 jc
-jc
+SF
 tV
 wZ
 Al
@@ -20393,7 +20430,7 @@ je
 ag
 tW
 xe
-ag
+je
 je
 je
 je
@@ -20528,7 +20565,7 @@ yz
 ce
 dk
 ec
-ag
+je
 je
 je
 je
@@ -20536,7 +20573,7 @@ je
 ud
 xf
 je
-je
+SJ
 Ki
 je
 Eg
@@ -20670,7 +20707,7 @@ yz
 ce
 dk
 ec
-ag
+lZ
 jl
 lX
 pA
@@ -20812,18 +20849,18 @@ yz
 ce
 dk
 ec
-ag
+me
 jE
-lZ
+pH
 pH
 pH
 pH
 pH
 AD
-En
 pH
-pH
-SF
+cJ
+MO
+je
 fp
 ag
 aJ
@@ -20954,18 +20991,18 @@ yz
 ce
 dk
 ec
-ag
-jE
 me
+En
+pH
 pH
 pH
 pH
 pH
 AE
-Et
 pH
-pH
-SJ
+cJ
+MO
+je
 fp
 ag
 aJ
@@ -21096,8 +21133,8 @@ yz
 ce
 dk
 ec
-ag
-jl
+lZ
+Et
 ms
 pS
 sx
@@ -21105,9 +21142,9 @@ ur
 ur
 AJ
 Eu
-pH
+rd
 EJ
-Eg
+ed
 qa
 qg
 aJ
@@ -21238,7 +21275,7 @@ yz
 ce
 dk
 ec
-ag
+je
 je
 je
 je
@@ -21246,7 +21283,7 @@ je
 uu
 xo
 je
-je
+xs
 Kv
 je
 UY
@@ -21387,7 +21424,7 @@ je
 ag
 uy
 xq
-ag
+je
 je
 je
 je

--- a/maps/submaps/admin_use_vr/kk_mercship.dmm
+++ b/maps/submaps/admin_use_vr/kk_mercship.dmm
@@ -657,15 +657,6 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/ship/manta/med)
-"cJ" = (
-/obj/machinery/sleeper{
-	desc = "A stasis pod with built-in injectors, a dialysis machine, and a limited health scanner. This one is preconfigured to stasis levels, for keeping captives (or teammates) alive as long as possible.";
-	dir = 1;
-	name = "stasis cell";
-	stasis_level = 10
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/shuttle/manta_ship_boat)
 "cK" = (
 /obj/structure/cable/orange{
 	d1 = 1;
@@ -2192,6 +2183,13 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/manta/bridge)
+"jK" = (
+/obj/machinery/sleep_console{
+	dir = 2;
+	name = "stasis cell console"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/manta_ship_boat)
 "jP" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
@@ -2764,6 +2762,7 @@
 	dir = 4
 	},
 /obj/machinery/light/no_nightshift,
+/obj/structure/closet/walllocker/emerglocker/south,
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/manta_ship_boat)
 "mO" = (
@@ -3357,6 +3356,7 @@
 /obj/structure/bed/chair/bay/shuttle{
 	dir = 4
 	},
+/obj/structure/closet/walllocker/emerglocker/west,
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/manta_ship_boat)
 "pB" = (
@@ -3415,6 +3415,7 @@
 /obj/structure/bed/chair/bay/shuttle{
 	dir = 8
 	},
+/obj/structure/closet/walllocker/emerglocker/east,
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/manta_ship_boat)
 "pV" = (
@@ -3654,12 +3655,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/ship/manta/med)
-"rd" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/fuel{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/shuttle/manta_ship_boat)
 "rl" = (
 /obj/machinery/power/apc/hyper{
 	alarms_hidden = 1;
@@ -3868,6 +3863,7 @@
 /obj/structure/bed/chair/bay/shuttle{
 	dir = 4
 	},
+/obj/structure/closet/walllocker/emerglocker/west,
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/manta_ship_boat)
 "sq" = (
@@ -3916,11 +3912,25 @@
 	},
 /turf/simulated/floor/wood,
 /area/ship/manta/barracks)
+"sw" = (
+/obj/machinery/portable_atmospherics/canister/phoron/engine_setup,
+/obj/machinery/atmospherics/portables_connector/fuel{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/outline/red,
+/obj/machinery/door/window/brigdoor/northright{
+	dir = 8;
+	req_access = list(150);
+	req_one_access = list(150)
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/manta_ship_boat)
 "sx" = (
 /obj/effect/floor_decal/industrial/warning/corner,
 /obj/structure/bed/chair/bay/shuttle{
 	dir = 8
 	},
+/obj/structure/closet/walllocker/emerglocker/east,
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/manta_ship_boat)
 "sy" = (
@@ -5029,19 +5039,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/manta/hangar)
-"xs" = (
-/obj/machinery/portable_atmospherics/canister/phoron/engine_setup,
-/obj/machinery/atmospherics/portables_connector/fuel{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/outline/red,
-/obj/machinery/door/window/brigdoor/northright{
-	dir = 8;
-	req_access = list(150);
-	req_one_access = list(150)
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/shuttle/manta_ship_boat)
 "xt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -5872,6 +5869,7 @@
 /obj/structure/bed/chair/bay/shuttle{
 	dir = 8
 	},
+/obj/structure/closet/walllocker/emerglocker/east,
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/manta_ship_boat)
 "AO" = (
@@ -8110,6 +8108,15 @@
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging,
 /turf/simulated/floor/plating,
 /area/ship/manta/radiator_star)
+"Ms" = (
+/obj/machinery/sleeper{
+	desc = "A stasis pod with built-in injectors, a dialysis machine, and a limited health scanner. This one is preconfigured to stasis levels, for keeping captives (or teammates) alive as long as possible.";
+	dir = 1;
+	name = "stasis cell";
+	stasis_level = 10
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/manta_ship_boat)
 "Mt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 1
@@ -8166,13 +8173,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/ship/manta/hallways_star)
-"MO" = (
-/obj/machinery/sleep_console{
-	dir = 2;
-	name = "stasis cell console"
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/shuttle/manta_ship_boat)
 "MQ" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -9235,6 +9235,12 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/wood,
 /area/ship/manta/barracks)
+"Sh" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/fuel{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/manta_ship_boat)
 "Sl" = (
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/plating,
@@ -20858,8 +20864,8 @@ pH
 pH
 AD
 pH
-cJ
-MO
+Ms
+jK
 je
 fp
 ag
@@ -21000,8 +21006,8 @@ pH
 pH
 AE
 pH
-cJ
-MO
+Ms
+jK
 je
 fp
 ag
@@ -21142,7 +21148,7 @@ ur
 ur
 AJ
 Eu
-rd
+Sh
 EJ
 ed
 qa
@@ -21283,7 +21289,7 @@ je
 uu
 xo
 je
-xs
+sw
 Kv
 je
 UY

--- a/maps/submaps/admin_use_vr/mercship.dm
+++ b/maps/submaps/admin_use_vr/mercship.dm
@@ -173,7 +173,7 @@
 /obj/effect/shuttle_landmark/shuttle_initializer/manta_ship_boat
 	name = "Mercenary Cruiser's Bay"
 	base_area = /area/ship/manta/hangar
-	base_turf = /turf/simulated/floor/plating
+	base_turf = /turf/simulated/floor/reinforced
 	landmark_tag = "omship_spawn_manta_lander"
 	docking_controller = "manta_boarding_shuttle_dock"
 	shuttle_type = /datum/shuttle/autodock/overmap/manta_ship_boat
@@ -243,7 +243,9 @@ Finally, over in the port wing you'll find the recreation area and kitchen along
 <br>\
 You don't want to know how long it's going to take to pay off.<br>\
 <br>\
-<i>Capt. Thorne</i>"}
+<i>Capt. Thorne</i><br>\
+<br>
+P.S. If you need to refuel the lander for some reason, there's a pair of spare fuel canisters in that closet space in the port fore wing edge, opposite the assault armory."}
 
 /obj/item/weapon/paper/manta_approach_tactics
 	name = "Installation Approach"


### PR DESCRIPTION
Some minor tweaks for the Von Braun (ERT ship) and Typhon (merc ship) based on some odds and ends I noticed during the merc event round;
- Reworked the lander slightly to add stasis cell consoles, a couple of extra seats, rework the helm/control, remove the emergency shutters (they seem to cause more headaches than they're worth, especially since the tiny shuttle depressurizes pretty much instantly), add some softsuit wall-lockers, and a couple other minor tweaks.
- Added a couple of spare fuel tanks to port fore storage on the Typhon itself, either for the Lander or the ship (if you somehow manage to use all four pressure tanks).
- Fixed the landers for both having the wrong base_turf and leaving ugly plating patches on their smooth reinforced hangar floors.