### PR TITLE
Go [Verb] Yourself!

### DIFF
--- a/code/game/dna/dna2.dm
+++ b/code/game/dna/dna2.dm
@@ -118,6 +118,10 @@ var/global/list/datum/dna/gene/dna_genes[0]
 	var/base_species = "Human"
 	var/list/species_traits = list()
 	var/blood_color = "#A10808"
+	var/custom_say
+	var/custom_ask
+	var/custom_whisper
+	var/custom_exclaim
 	// VOREStation
 
 	// New stuff
@@ -139,6 +143,10 @@ var/global/list/datum/dna/gene/dna_genes[0]
 	new_dna.custom_species=custom_species //VOREStaton Edit
 	new_dna.species_traits=species_traits.Copy() //VOREStation Edit
 	new_dna.blood_color=blood_color //VOREStation Edit
+	new_dna.custom_say=custom_say //VOREStaton Edit
+	new_dna.custom_ask=custom_ask //VOREStaton Edit
+	new_dna.custom_whisper=custom_whisper //VOREStaton Edit
+	new_dna.custom_exclaim=custom_exclaim //VOREStaton Edit
 	for(var/b=1;b<=DNA_SE_LENGTH;b++)
 		new_dna.SE[b]=SE[b]
 		if(b<=DNA_UI_LENGTH)
@@ -205,6 +213,10 @@ var/global/list/datum/dna/gene/dna_genes[0]
 	src.base_species = character.species.base_species
 	src.blood_color = character.species.blood_color
 	src.species_traits = character.species.traits.Copy()
+	src.custom_say = character.custom_say
+	src.custom_ask = character.custom_ask
+	src.custom_whisper = character.custom_whisper
+	src.custom_exclaim = character.custom_exclaim
 
 	// +1 to account for the none-of-the-above possibility
 	SetUIValueRange(DNA_UI_EAR_STYLE,	ear_style + 1,     ear_styles_list.len  + 1,  1)

--- a/code/game/dna/dna2_helpers.dm
+++ b/code/game/dna/dna2_helpers.dm
@@ -237,6 +237,10 @@
 
 		// Technically custom_species is not part of the UI, but this place avoids merge problems.
 		H.custom_species = dna.custom_species
+		H.custom_say = dna.custom_say
+		H.custom_ask = dna.custom_ask
+		H.custom_whisper = dna.custom_whisper
+		H.custom_exclaim = dna.custom_exclaim
 		H.species.blood_color = dna.blood_color
 		var/datum/species/S = H.species
 		S.produceCopy(dna.base_species,dna.species_traits,src)

--- a/code/modules/client/preference_setup/vore/07_traits.dm
+++ b/code/modules/client/preference_setup/vore/07_traits.dm
@@ -10,6 +10,11 @@
 	var/custom_base		// What to base the custom species on
 	var/blood_color = "#A10808"
 
+	var/custom_say = null
+	var/custom_whisper = null
+	var/custom_ask = null
+	var/custom_exclaim = null
+
 	var/list/pos_traits	= list()	// What traits they've selected for their custom species
 	var/list/neu_traits = list()
 	var/list/neg_traits = list()
@@ -33,9 +38,14 @@
 	S["neg_traits"]		>> pref.neg_traits
 	S["blood_color"]	>> pref.blood_color
 
-	S["traits_cheating"]>> pref.traits_cheating
+	S["traits_cheating"]	>> pref.traits_cheating
 	S["max_traits"]		>> pref.max_traits
 	S["trait_points"]	>> pref.starting_trait_points
+	
+	S["custom_say"]		>> pref.custom_say
+	S["custom_whisper"]	>> pref.custom_whisper
+	S["custom_ask"]		>> pref.custom_ask
+	S["custom_exclaim"]	>> pref.custom_exclaim
 
 /datum/category_item/player_setup_item/vore/traits/save_character(var/savefile/S)
 	S["custom_species"]	<< pref.custom_species
@@ -45,9 +55,14 @@
 	S["neg_traits"]		<< pref.neg_traits
 	S["blood_color"]	<< pref.blood_color
 
-	S["traits_cheating"]<< pref.traits_cheating
+	S["traits_cheating"]	<< pref.traits_cheating
 	S["max_traits"]		<< pref.max_traits
 	S["trait_points"]	<< pref.starting_trait_points
+	
+	S["custom_say"]		<< pref.custom_say
+	S["custom_whisper"]	<< pref.custom_whisper
+	S["custom_ask"]		<< pref.custom_ask
+	S["custom_exclaim"]	<< pref.custom_exclaim
 
 /datum/category_item/player_setup_item/vore/traits/sanitize_character()
 	if(!pref.pos_traits) pref.pos_traits = list()
@@ -86,6 +101,10 @@
 
 /datum/category_item/player_setup_item/vore/traits/copy_to_mob(var/mob/living/carbon/human/character)
 	character.custom_species	= pref.custom_species
+	character.custom_say		= pref.custom_say
+	character.custom_ask		= pref.custom_ask
+	character.custom_whisper	= pref.custom_whisper
+	character.custom_exclaim	= pref.custom_exclaim
 
 	if(character.isSynthetic())	//Checking if we have a synth on our hands, boys.
 		pref.dirty_synth = 1
@@ -156,6 +175,16 @@
 	. += "<b>Blood Color: </b>" //People that want to use a certain species to have that species traits (xenochimera/promethean/spider) should be able to set their own blood color.
 	. += "<a href='?src=\ref[src];blood_color=1'>Set Color</a>"
 	. += "<a href='?src=\ref[src];blood_reset=1'>R</a><br>"
+	. += "<br>"
+	
+	. += "<b>Custom Say: </b>"
+	. += "<a href='?src=\ref[src];custom_say=1'>Set Say Verb</a><br>"
+	. += "<b>Custom Whisper: </b>"
+	. += "<a href='?src=\ref[src];custom_whisper=1'>Set Whisper Verb</a><br>"
+	. += "<b>Custom Ask: </b>"
+	. += "<a href='?src=\ref[src];custom_ask=1'>Set Ask Verb</a><br>"
+	. += "<b>Custom Exclaim: </b>"
+	. += "<a href='?src=\ref[src];custom_exclaim=1'>Set Exclaim Verb</a><br>"
 
 /datum/category_item/player_setup_item/vore/traits/OnTopic(var/href,var/list/href_list, var/mob/user)
 	if(!CanUseTopic(user))
@@ -214,6 +243,30 @@
 		var/choice = alert("Remove [initial(trait.name)] and lose [initial(trait.cost)] points?","Remove Trait","Remove","Cancel")
 		if(choice == "Remove")
 			pref.neg_traits -= trait
+		return TOPIC_REFRESH
+
+	else if(href_list["custom_say"])
+		var/say_choice = sanitize(input(usr, "This word or phrase will appear instead of 'says': [pref.real_name] says, \"Hi.\"", "Custom Say", pref.custom_say) as null|text, 12)
+		if(say_choice)
+			pref.custom_say = say_choice
+		return TOPIC_REFRESH
+
+	else if(href_list["custom_whisper"])
+		var/whisper_choice = sanitize(input(usr, "This word or phrase will appear instead of 'whispers': [pref.real_name] whispers, \"Hi...\"", "Custom Whisper", pref.custom_whisper) as null|text, 12)
+		if(whisper_choice)
+			pref.custom_whisper = whisper_choice
+		return TOPIC_REFRESH
+
+	else if(href_list["custom_ask"])
+		var/ask_choice = sanitize(input(usr, "This word or phrase will appear instead of 'asks': [pref.real_name] asks, \"Hi?\"", "Custom Ask", pref.custom_ask) as null|text, 12)
+		if(ask_choice)
+			pref.custom_ask = ask_choice
+		return TOPIC_REFRESH
+
+	else if(href_list["custom_exclaim"])
+		var/exclaim_choice = sanitize(input(usr, "This word or phrase will appear instead of 'exclaims', 'shouts' or 'yells': [pref.real_name] exclaims, \"Hi!\"", "Custom Exclaim", pref.custom_exclaim) as null|text, 12)
+		if(exclaim_choice)
+			pref.custom_exclaim = exclaim_choice
 		return TOPIC_REFRESH
 
 	else if(href_list["add_trait"])


### PR DESCRIPTION
One of the lesser-known features of this fork is the ability to set your own speech verbs using a command buried in the IC tab. Unfortunately this has never been a *persistent* feature, requiring that you manually set them *every round* whilst navigating through the 90s-era inputs, which puts a bit of a damper on the idea.

***No more, I say!***

This PR adds the ability to *set and save* custom say, ask, whisper, and exclaim verbs, per character. These verbs persist through cloning (so if you TF-impersonate someone, TF them into a clone of yourself somehow, or just get resleeved, you/they should keep the same verbs!) as well. There is a fairly short maximum limit on the input, to avoid memes/abuse; it can easily be increased if desired.

You'll find the settings just under traits and blood color, on the VORE tab;
![image](https://user-images.githubusercontent.com/49700375/107909378-f6e16c00-6f4f-11eb-9676-f10919fc5901.png)

Using the IC tab command will not set your persistent/pref-level verbs, for now, as I'm not sure how to neatly handle that. As a whole it's a bit hacky but it seems to work well enough.

:cl:
tweak - Added the ability to set custom say/whisper/shout/ask 'verbs' on a persistent, per-character basis.
/:cl: