### PR TITLE
Von Braun Tweaks

### DIFF
--- a/maps/submaps/admin_use_vr/ert.dmm
+++ b/maps/submaps/admin_use_vr/ert.dmm
@@ -149,6 +149,18 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/ship/ert/med)
+"aK" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/white{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/hangar)
 "aQ" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/weapon/storage/firstaid/surgery,
@@ -721,6 +733,14 @@
 	},
 /obj/mecha/combat/gygax/serenity,
 /obj/effect/floor_decal/industrial/outline,
+/obj/machinery/button/remote/blast_door{
+	description_fluff = "\(OOC) DO NOT TOUCH THIS BUTTON WITHOUT THE EXPLICIT PERMISSION OF AN ADMINISTRATOR.";
+	dir = 4;
+	id = "NRV_MECHS";
+	name = "MECH BAY CONTROL";
+	pixel_x = -25;
+	req_one_access = list(108)
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/mech_bay)
 "gk" = (
@@ -778,8 +798,12 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/armoury_st)
 "gy" = (
-/obj/machinery/mech_recharger,
-/obj/mecha/combat/gygax,
+/obj/structure/table/rack/steel,
+/obj/machinery/light/no_nightshift{
+	dir = 1
+	},
+/obj/item/mecha_parts/mecha_equipment/weapon/energy/pulse,
+/obj/item/mecha_parts/mecha_equipment/weapon/energy/pulse,
 /obj/effect/floor_decal/industrial/outline/red,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/mech_bay)
@@ -787,20 +811,9 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/atmos)
 "gF" = (
-/obj/structure/table/rack/steel,
-/obj/item/mecha_parts/mecha_equipment/shocker,
-/obj/item/mecha_parts/mecha_equipment/shocker,
-/obj/machinery/power/apc/hyper{
-	alarms_hidden = 1;
-	dir = 1;
-	name = "VB APC - North";
-	pixel_y = 24
-	},
-/obj/structure/cable/yellow{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/effect/floor_decal/industrial/outline/blue,
+/obj/machinery/mech_recharger,
+/obj/mecha/combat/gygax,
+/obj/effect/floor_decal/industrial/outline/red,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/mech_bay)
 "gN" = (
@@ -832,12 +845,17 @@
 /area/ship/ert/engine)
 "gW" = (
 /obj/structure/table/rack/steel,
-/obj/item/mecha_parts/mecha_equipment/anticcw_armor_booster,
-/obj/item/mecha_parts/mecha_equipment/anticcw_armor_booster,
-/obj/item/mecha_parts/mecha_equipment/antiproj_armor_booster,
-/obj/item/mecha_parts/mecha_equipment/antiproj_armor_booster,
-/obj/machinery/firealarm/alarms_hidden{
-	pixel_y = 26
+/obj/item/mecha_parts/mecha_equipment/shocker,
+/obj/item/mecha_parts/mecha_equipment/shocker,
+/obj/machinery/power/apc/hyper{
+	alarms_hidden = 1;
+	dir = 1;
+	name = "VB APC - North";
+	pixel_y = 24
+	},
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/effect/floor_decal/industrial/outline/blue,
 /turf/simulated/floor/tiled/techfloor,
@@ -868,6 +886,18 @@
 /area/ship/ert/bridge)
 "hj" = (
 /obj/structure/table/rack/steel,
+/obj/item/mecha_parts/mecha_equipment/anticcw_armor_booster,
+/obj/item/mecha_parts/mecha_equipment/anticcw_armor_booster,
+/obj/item/mecha_parts/mecha_equipment/antiproj_armor_booster,
+/obj/item/mecha_parts/mecha_equipment/antiproj_armor_booster,
+/obj/machinery/firealarm/alarms_hidden{
+	pixel_y = 26
+	},
+/obj/effect/floor_decal/industrial/outline/blue,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/mech_bay)
+"hk" = (
+/obj/structure/table/rack/steel,
 /obj/item/mecha_parts/mecha_equipment/combat_shield,
 /obj/item/mecha_parts/mecha_equipment/combat_shield,
 /obj/item/mecha_parts/mecha_equipment/omni_shield,
@@ -876,16 +906,6 @@
 /obj/item/mecha_parts/mecha_equipment/repair_droid,
 /obj/item/mecha_parts/mecha_equipment/repair_droid,
 /obj/effect/floor_decal/industrial/outline/blue,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/mech_bay)
-"hk" = (
-/obj/structure/table/rack/steel,
-/obj/machinery/light/no_nightshift{
-	dir = 1
-	},
-/obj/item/mecha_parts/mecha_equipment/weapon/energy/pulse,
-/obj/item/mecha_parts/mecha_equipment/weapon/energy/pulse,
-/obj/effect/floor_decal/industrial/outline/red,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/mech_bay)
 "hs" = (
@@ -1057,9 +1077,13 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/bridge)
 "iA" = (
-/obj/structure/window/reinforced,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/teleporter)
+/obj/machinery/door/blast/regular{
+	closed_layer = 4;
+	id = "NRV_DELTA";
+	layer = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/mech_bay)
 "iB" = (
 /turf/simulated/wall/shull,
 /area/ship/ert/dock_port)
@@ -1184,7 +1208,7 @@
 "ki" = (
 /obj/machinery/door/blast/regular{
 	closed_layer = 4;
-	id = "NRV_DELTA";
+	id = "NRV_MECHS";
 	layer = 4
 	},
 /turf/simulated/floor/tiled/techmaint,
@@ -1771,11 +1795,6 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/ship/ert/atmos)
 "nz" = (
-/obj/machinery/door/blast/regular{
-	closed_layer = 4;
-	id = "NRV_DELTA";
-	layer = 4
-	},
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
@@ -1790,19 +1809,32 @@
 /obj/machinery/door/firedoor/multi_tile{
 	dir = 1
 	},
+/obj/machinery/door/blast/regular{
+	closed_layer = 4;
+	id = "NRV_MECHS";
+	layer = 4
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/ship/ert/mech_bay)
 "nB" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/multi_tile{
+	dir = 1
+	},
+/obj/machinery/door/blast/regular{
+	closed_layer = 4;
+	id = "NRV_DELTA";
+	layer = 4
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/ship/ert/mech_bay)
@@ -1816,19 +1848,24 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/engineering)
 "nP" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/ship/ert/mech_bay)
 "nR" = (
-/obj/structure/table/rack/steel,
-/obj/item/mecha_parts/mecha_equipment/weapon/energy/taser,
-/obj/item/mecha_parts/mecha_equipment/weapon/energy/taser,
-/obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack/grenade/clusterbang,
-/obj/effect/floor_decal/industrial/outline/red,
-/obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack/grenade/clusterbang,
-/turf/simulated/floor/tiled/techfloor,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/techmaint,
 /area/ship/ert/mech_bay)
 "nX" = (
 /obj/machinery/light/no_nightshift{
@@ -1853,6 +1890,7 @@
 /obj/item/device/binoculars,
 /obj/item/device/survivalcapsule,
 /obj/item/device/survivalcapsule,
+/mob/living/simple_mob/animal/passive/mimepet,
 /turf/simulated/floor/wood,
 /area/ship/ert/commander)
 "og" = (
@@ -2345,13 +2383,12 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/mech_bay)
 "qE" = (
-/obj/machinery/mech_recharger,
-/obj/machinery/alarm/alarms_hidden{
-	dir = 1;
-	pixel_y = -26
-	},
-/obj/mecha/combat/durand,
+/obj/structure/table/rack/steel,
+/obj/item/mecha_parts/mecha_equipment/weapon/energy/taser,
+/obj/item/mecha_parts/mecha_equipment/weapon/energy/taser,
+/obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack/grenade/clusterbang,
 /obj/effect/floor_decal/industrial/outline/red,
+/obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack/grenade/clusterbang,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/mech_bay)
 "qF" = (
@@ -2361,10 +2398,13 @@
 /turf/simulated/floor/reinforced/airless,
 /area/ship/ert/eng_storage)
 "qQ" = (
-/obj/structure/table/rack/steel,
-/obj/item/mecha_parts/mecha_equipment/gravcatapult,
-/obj/item/mecha_parts/mecha_equipment/wormhole_generator,
-/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/mech_recharger,
+/obj/machinery/alarm/alarms_hidden{
+	dir = 1;
+	pixel_y = -26
+	},
+/obj/mecha/combat/durand,
+/obj/effect/floor_decal/industrial/outline/red,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/mech_bay)
 "qR" = (
@@ -2373,6 +2413,13 @@
 /area/ship/ert/atmos)
 "qS" = (
 /obj/structure/table/rack/steel,
+/obj/item/mecha_parts/mecha_equipment/gravcatapult,
+/obj/item/mecha_parts/mecha_equipment/wormhole_generator,
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/mech_bay)
+"qT" = (
+/obj/structure/table/rack/steel,
 /obj/item/mecha_parts/mecha_equipment/tool/jetpack,
 /obj/item/mecha_parts/mecha_equipment/tool/jetpack,
 /obj/item/mecha_parts/mecha_equipment/tool/jetpack,
@@ -2380,14 +2427,14 @@
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/mech_bay)
-"qT" = (
+"rp" = (
 /obj/structure/table/rack/steel,
 /obj/item/mecha_parts/mecha_equipment/weapon/energy/ion,
 /obj/item/mecha_parts/mecha_equipment/weapon/energy/ion,
 /obj/effect/floor_decal/industrial/outline/red,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/mech_bay)
-"rp" = (
+"rr" = (
 /obj/structure/table/rack/steel,
 /obj/item/mecha_parts/mecha_equipment/weapon/energy/laser/heavy,
 /obj/item/mecha_parts/mecha_equipment/weapon/energy/laser/heavy,
@@ -2396,13 +2443,6 @@
 /obj/item/mecha_parts/mecha_equipment/weapon/energy/laser/xray,
 /obj/item/mecha_parts/mecha_equipment/weapon/energy/laser/xray,
 /obj/machinery/light/no_nightshift,
-/obj/effect/floor_decal/industrial/outline/red,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/mech_bay)
-"rr" = (
-/obj/structure/table/rack/steel,
-/obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack/grenade/frag,
-/obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack/grenade/frag,
 /obj/effect/floor_decal/industrial/outline/red,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/mech_bay)
@@ -3496,6 +3536,9 @@
 	dir = 1;
 	pixel_y = -26
 	},
+/obj/effect/floor_decal/corner/white{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/ship/ert/hangar)
 "zs" = (
@@ -3744,6 +3787,13 @@
 /obj/effect/floor_decal/industrial/outline/blue,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/eng_storage)
+"Bl" = (
+/obj/structure/table/rack/steel,
+/obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack/grenade/frag,
+/obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack/grenade/frag,
+/obj/effect/floor_decal/industrial/outline/red,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/mech_bay)
 "Bo" = (
 /turf/simulated/wall/shull,
 /area/ship/ert/barracks)
@@ -5352,7 +5402,7 @@
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/machinery/button/remote/blast_door{
-	desc = "\[OOC] DO NOT TOUCH THIS BUTTON WITHOUT THE EXPLICIT PERMISSION OF AN ADMINISTRATOR.";
+	description_fluff = "\(OOC) DO NOT TOUCH THIS BUTTON WITHOUT THE EXPLICIT PERMISSION OF AN ADMINISTRATOR.";
 	dir = 1;
 	id = "NRV_DELTA";
 	name = "DELTA ACCESS CONTROL";
@@ -5422,6 +5472,16 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/ship/ert/teleporter)
+"Mx" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/white,
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/hangar)
 "My" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -5589,7 +5649,9 @@
 "NI" = (
 /obj/structure/table/rack,
 /obj/item/weapon/storage/secure/briefcase/nsfw_pack_hybrid,
-/obj/item/weapon/storage/belt/explorer/pathfinder,
+/obj/item/weapon/storage/belt/explorer/pathfinder{
+	name = "ERT Commander's belt"
+	},
 /turf/simulated/floor/wood,
 /area/ship/ert/commander)
 "NJ" = (
@@ -6157,9 +6219,7 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/shuttle/ert_ship_boat)
 "QR" = (
-/obj/structure/bed/chair/bay/shuttle{
-	dir = 4
-	},
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/techmaint,
 /area/shuttle/ert_ship_boat)
 "QS" = (
@@ -6325,6 +6385,14 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/engineering)
+"Sh" = (
+/obj/machinery/door/airlock/glass_medical{
+	name = "Medical Bay";
+	req_access = list(103)
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/med_surg)
 "Sj" = (
 /obj/machinery/light_switch{
 	dir = 4;
@@ -7002,7 +7070,6 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/teleporter)
 "Yr" = (
-/obj/structure/window/reinforced,
 /obj/machinery/light/no_nightshift{
 	dir = 4
 	},
@@ -14523,7 +14590,7 @@ Mm
 jA
 Wj
 UU
-iA
+jA
 jA
 DS
 lu
@@ -20188,7 +20255,7 @@ yz
 ah
 bM
 bM
-qy
+bM
 ki
 nz
 qy
@@ -20614,10 +20681,10 @@ yz
 ah
 bM
 bM
-gy
-jQ
-np
-qE
+bM
+iA
+nB
+bM
 bM
 xO
 WC
@@ -20757,8 +20824,8 @@ ai
 bM
 bM
 gF
-kl
-nB
+jQ
+np
 qQ
 bM
 xO
@@ -20771,7 +20838,7 @@ WC
 HO
 WC
 WC
-Zx
+Mx
 dq
 wZ
 gZ
@@ -20899,7 +20966,7 @@ ah
 bM
 bM
 gW
-jY
+kl
 nP
 qS
 bM
@@ -20913,8 +20980,8 @@ WC
 HO
 WC
 WC
-Zx
-dq
+aK
+Sh
 ij
 nq
 ij
@@ -21041,8 +21108,8 @@ ah
 bM
 bM
 hj
-jQ
-jQ
+jY
+nR
 qT
 bM
 yB
@@ -21324,9 +21391,9 @@ yz
 af
 bM
 bM
-bM
-kn
-nR
+gy
+jQ
+jQ
 rr
 bM
 yX
@@ -21467,9 +21534,9 @@ yz
 ai
 bM
 bM
-bM
-bM
-bM
+kn
+qE
+Bl
 bM
 ib
 za
@@ -21612,7 +21679,7 @@ bM
 bM
 bM
 bM
-ai
+bM
 yz
 yz
 yz
@@ -21624,7 +21691,7 @@ yz
 yz
 yz
 yz
-Cr
+MZ
 MZ
 MZ
 MZ
@@ -21754,7 +21821,7 @@ ag
 bM
 bM
 bM
-ah
+ai
 yz
 yz
 yz
@@ -21766,7 +21833,7 @@ yz
 yz
 yz
 yz
-ci
+Cr
 MZ
 MZ
 MZ


### PR DESCRIPTION
A couple of things I missed in #9709 or thought of just now;
- Split the mech bay up into two seperate spaces, so the Ripley and Serenity are accessible without also opening the Delta Armory or granting access to the Gygax and Durand. The mech bay as a whole still requires an admin to access.
- Added a shortcut from the hangar into the front of Medical, so people can go out the front of the boat and straight to stasis if need be.
- Replaced the seat behind the boat pilot with an outlined spot for a mech.
- Gave the ERT Commander's belt a custom name.