### PR TITLE
Emergency Anti-Lag fix

### DIFF
--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -350,7 +350,7 @@
 	var/obj/item/projectile/P = initial(E.projectile_type)
 	//var/obj/item/ammo_casing/shottype = E.projectile_type
 
-	GLOB.moved_event.register_global(src, /obj/machinery/porta_turret/proc/point_defense)
+	//GLOB.moved_event.register_global(src, /obj/machinery/porta_turret/proc/point_defense) //VOREStation Removal
 
 	projectile = P
 	lethal_projectile = projectile


### PR DESCRIPTION
This might be a factor in why the server has been melting down as of late. Temporarily disabling Polaris' point defense functions until further notice.