### PR TITLE
Fixes explorer shield light runtime spam

### DIFF
--- a/code/game/objects/items/weapons/shields_vr.dm
+++ b/code/game/objects/items/weapons/shields_vr.dm
@@ -65,7 +65,6 @@
 		light_applied = 0
 	update_icon(user)
 	user.update_action_buttons()
-	light = !light
 	playsound(src, 'sound/weapons/empty.ogg', 15, 1, -3)
 
 /obj/item/weapon/shield/riot/explorer/update_icon()


### PR DESCRIPTION
Hnngh.

LIGHT VAR IS THE LIGHT SOURCE DATUM REFERENCE, NOT A TOGGLE. Also the proper toggle already existed in the proc calling this one lmao