### PR TITLE
Two fixes for messages I noticed in logs

### DIFF
--- a/code/game/objects/items/weapons/canes.dm
+++ b/code/game/objects/items/weapons/canes.dm
@@ -22,11 +22,12 @@
 /obj/item/weapon/cane/concealed
 	var/concealed_blade
 
-/obj/item/weapon/cane/concealed/New()
-	..()
+/obj/item/weapon/cane/concealed/Initialize()
+	. = ..()
 	var/obj/item/weapon/material/butterfly/switchblade/temp_blade = new(src)
 	concealed_blade = temp_blade
-	temp_blade.attack_self()
+	temp_blade.active = TRUE
+	temp_blade.update_force()
 
 /obj/item/weapon/cane/concealed/attack_self(var/mob/user)
 	var/datum/gender/T = gender_datums[user.get_visible_gender()]

--- a/code/game/objects/items/weapons/material/knives.dm
+++ b/code/game/objects/items/weapons/material/knives.dm
@@ -45,13 +45,15 @@
 
 /obj/item/weapon/material/butterfly/attack_self(mob/user)
 	active = !active
-	if(active)
-		to_chat(user, "<span class='notice'>You flip out \the [src].</span>")
-		playsound(src, 'sound/weapons/flipblade.ogg', 15, 1)
-	else
-		to_chat(user, "<span class='notice'>\The [src] can now be concealed.</span>")
 	update_force()
-	add_fingerprint(user)
+
+	if(user)
+		if(active)
+			to_chat(user, "<span class='notice'>You flip out \the [src].</span>")
+			playsound(src, 'sound/weapons/flipblade.ogg', 15, 1)
+		else
+			to_chat(user, "<span class='notice'>\The [src] can now be concealed.</span>")
+		add_fingerprint(user)
 
 /*
  * Kitchen knives

--- a/code/modules/admin/admin_investigate.dm
+++ b/code/modules/admin/admin_investigate.dm
@@ -23,7 +23,7 @@
 	if(!message)	return
 	var/F = investigate_subject2file(subject)
 	if(!F)	return
-	to_chat(F, "<span class='filter_adminlog'><small>[time2text(world.timeofday,"hh:mm")] \ref[src] ([x],[y],[z])</small> || [src] [message]<br></span>")
+	to_file(F, "<span class='filter_adminlog'><small>[time2text(world.timeofday,"hh:mm")] \ref[src] ([x],[y],[z])</small> || [src] [message]<br></span>")
 
 //ADMINVERBS
 /client/proc/investigate_show( subject in list("hrefs","notes","singulo","telesci") )


### PR DESCRIPTION
admin_investigate: A `<<` was incorrectly changed to `to_chat` when it should have been `to_file` (or someone could make it rust_g at some point hint hint)

knives.dm: Switchblades expect a user because they print a to_chat message and play some sounds and add fingerprints on flippy. (You would think the latter would be some parent thing, but hm!) canes.dm calls it with no user because whatever.