### PR TITLE
Buffs Adranol Healing

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine_vr.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine_vr.dm
@@ -13,9 +13,9 @@
 	if(M.confused)
 		M.Confuse(-8*removed)
 	if(M.eye_blurry)
-		M.eye_blurry = max(M.eye_blurry - 8*removed, 0)
+		M.eye_blurry = max(M.eye_blurry - 25*removed, 0)
 	if(M.jitteriness)
-		M.make_jittery(max(M.jitteriness - 8*removed,0))
+		M.make_jittery(max(M.jitteriness - 25*removed,0))
 
 /datum/reagent/numbing_enzyme
 	name = "Numbing Enzyme"


### PR DESCRIPTION
🆑 
tweak - Buff Adranol healing.
/🆑 

Suggested by Tempest, and upon examination of related code, having it at eights makes reduction of peridaxon-caused eye blurriness or jitteriness reductions take long than one might like since ya can't even see how much Adranol you'd need. This'll just make it more evened out and a bit quicker.