### PR TITLE
Removes NonHelpIntent Hypo/Injector Delay

### DIFF
--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -55,13 +55,14 @@
 			if(!do_after(user, 30, H))
 				return
 		//VOREstation Add End
-		else if(!H.stat && !prototype) //VOREStation Edit
+	/*	else if(!H.stat && !prototype) //VOREStation Edit
 			if(H != user)
 				if(H.a_intent != I_HELP)
 					to_chat(user, "<span class='notice'>[H] is resisting your attempt to inject them with \the [src].</span>")
 					to_chat(H, "<span class='danger'> [user] is trying to inject you with \the [src]!</span>")
 					if(!do_after(user, 30, H))
 						return
+	*/ //VOREStation Edit: We don't have antags, and we don't use hyposprays or injectors as weapons, so we've no need for a delay.
 
 	do_injection(H, user)
 	return


### PR DESCRIPTION
The NonHelpIntent Resist is a mechanic that means an autoinjector and hypospray does not have its instant-inject when the patient is on Grab, Disarm, or Harm intent. It was added in early 2018, on Polaris, in an attempt to reduce chloral injectors and instant-death poisons from being used in injectors. It wasn't particularly successful in this, because antag Chemist/CMO's just switched methods to equally deadly tools like hydorophoron and acids.

It did, and still does, however, cause annoyance to Medical crew who are just trying to use injectors and hyposprays to help patients, and the patients don't know to be on help intent. They may be pulling someone else who is hurt along and be on grab, for example, or there may had been a recent fight with spiders and folks are still on harm.

Given we do not have antags outside of events, and the fact that I'm fairly sure if a doctor or chemist ran up to an event antag and chloral'd them, that'd mean a ban, I'd like to think we can scrap this change.

Soooo it's voided with a handy lil Vorestation edit note. I tested it and it seems fine. If something ends up not being fine, I can fix.