### PR TITLE
Improved Trait Exclusion Logic v2

### DIFF
--- a/code/modules/client/preference_setup/vore/07_traits.dm
+++ b/code/modules/client/preference_setup/vore/07_traits.dm
@@ -286,6 +286,9 @@
 				pref.gross_meatbag = 0	//Just to be sure
 				return TOPIC_REFRESH
 
+			if(pref.species in instance.banned_species)
+				alert("The trait you've selected cannot be taken by the species you've chosen!","Error")
+				return TOPIC_REFRESH
 
 			if(trait_choice in pref.pos_traits + pref.neu_traits + pref.neg_traits)
 				conflict = instance.name

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
@@ -145,6 +145,36 @@
 	H.verbs |= /mob/living/proc/glow_toggle
 	H.verbs |= /mob/living/proc/glow_color
 
+/*
+//Allergen traits! Not available to any species with a base allergens var.
+/datum/trait/allergy_gluten
+	name = "Allergy: Gluten"
+	desc = "You're highly allergic to gluten proteins, which are found in most common grains. This trait cannot be taken by skrell or tajara."
+	cost = 0
+	custom_only = FALSE
+	banned_species = list(SPECIES_SKRELL,SPECIES_TAJ)
+	var_changes = list("allergens" = 16)
+	excludes = list(/datum/trait/allergy_nuts,/datum/trait/allergy_soy)
+
+/datum/trait/allergy_nuts
+	name = "Allergy: Nuts"
+	desc = "You're highly allergic to hard-shell seeds, such as peanuts. This trait cannot be taken by skrell or tajara."
+	cost = 0
+	custom_only = FALSE
+	banned_species = list(SPECIES_SKRELL,SPECIES_TAJ)
+	var_changes = list("allergens" = 64)
+	excludes = list(/datum/trait/allergy_gluten,/datum/trait/allergy_soy)
+
+/datum/trait/allergy_soy
+	name = "Allergy: Soy"
+	desc = "You're highly allergic to soybeans, and some other kinds of bean. This trait cannot be taken by skrell or tajara."
+	cost = 0
+	custom_only = FALSE
+	banned_species = list(SPECIES_SKRELL,SPECIES_TAJ)
+	var_changes = list("allergens" = 32)
+	excludes = list(/datum/trait/allergy_gluten,/datum/trait/allergy_nuts)
+*/
+
 // Spicy Food Traits, from negative to positive.
 /datum/trait/spice_intolerance_extreme
 	name = "Extreme Spice Intolerance"

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/trait.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/trait.dm
@@ -6,9 +6,10 @@
 	var/desc = "Contact a developer if you see this trait."
 
 	var/cost = 0			// 0 is neutral, negative cost means negative, positive cost means positive.
-	var/list/var_changes	// A list to apply to the custom species vars.
+	var/list/var_changes		// A list to apply to the custom species vars.
 	var/list/excludes		// Store a list of paths of traits to exclude, but done automatically if they change the same vars.
 	var/can_take = ORGANICS|SYNTHETICS	// Can freaking synths use those.
+	var/list/banned_species		// A list of species that can't take this trait
 	var/custom_only = TRUE		// Trait only available for custom species
 
 //Proc can be overridden lower to include special changes, make sure to call up though for the vars changes


### PR DESCRIPTION
Adds a listvar to traits which can be used to exclude the trait from specific core species.

Includes three commented-out allergy traits that won't work until/unless #9751 is merged.