### PR TITLE
Adds a sanity check for speech sound logic

### DIFF
--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -184,7 +184,7 @@
 
 /mob/living/carbon/human/handle_speech_sound()
 	var/list/returns[2]
-	if(species.speech_sounds && prob(species.speech_chance))
+	if(species.speech_sounds && species.speech_sounds.len && prob(species.speech_chance))		//VOREStation Edit: Sanity Check
 		returns[1] = sound(pick(species.speech_sounds))
 		returns[2] = 50
 	return returns


### PR DESCRIPTION
Lists _may_ just be empty sometimes. The proc did not account for that.

Fixes two runtimes at once, and potentially fixes a bug where vox messages disappear sometimes.