### PR TITLE
Makes it so that only freezer's freezer tiles are cold.

### DIFF
--- a/code/game/turfs/flooring/flooring_premade.dm
+++ b/code/game/turfs/flooring/flooring_premade.dm
@@ -317,7 +317,6 @@
 	name = "tiles"
 	icon_state = "freezer"
 	initial_flooring = /decl/flooring/tiling/freezer
-	temperature = T0C - 5 // VOREStation Edit: Chillier Freezer Tiles on-start
 
 /turf/simulated/floor/lino
 	name = "lino"

--- a/code/game/turfs/flooring/flooring_vr.dm
+++ b/code/game/turfs/flooring/flooring_vr.dm
@@ -24,3 +24,6 @@
 /decl/flooring/grass/outdoors/forest
 	icon = 'icons/turf/outdoors.dmi'
 	icon_base = "grass-dark"
+
+/turf/simulated/floor/tiled/freezer/cold
+	temperature = T0C - 5

--- a/maps/tether/tether-03-surface3.dmm
+++ b/maps/tether/tether-03-surface3.dmm
@@ -14781,10 +14781,10 @@
 /turf/simulated/wall/r_wall,
 /area/tether/surfacebase/botanystorage)
 "ayh" = (
-/obj/structure/shuttle/engine/propulsion,
-/turf/simulated/floor/reinforced,
-/turf/simulated/shuttle/plating/carry,
-/area/shuttle/tether)
+/obj/structure/closet/secure_closet/freezer/meat,
+/obj/machinery/camera/network/civilian,
+/turf/simulated/floor/tiled/freezer/cold,
+/area/crew_quarters/freezer)
 "ayi" = (
 /obj/structure/disposalpipe/sortjunction{
 	name = "Research";
@@ -17103,12 +17103,8 @@
 /turf/simulated/floor/tiled,
 /area/rnd/research/testingrange)
 "aBJ" = (
-/obj/structure/kitchenspike,
-/obj/machinery/alarm/freezer{
-	dir = 1;
-	pixel_y = -25
-	},
-/turf/simulated/floor/tiled/freezer,
+/obj/machinery/icecream_vat,
+/turf/simulated/floor/tiled/freezer/cold,
 /area/crew_quarters/freezer)
 "aBK" = (
 /obj/machinery/door/firedoor/glass,
@@ -20151,12 +20147,12 @@
 /turf/simulated/floor/plating,
 /area/rnd/outpost/xenobiology/outpost_north_airlock)
 "aGO" = (
-/obj/machinery/atmospherics/unary/engine{
-	dir = 1
+/obj/machinery/firealarm{
+	layer = 3.3;
+	pixel_y = 26
 	},
-/turf/simulated/floor/reinforced,
-/turf/simulated/shuttle/plating/carry,
-/area/shuttle/tourbus/engines)
+/turf/simulated/floor/tiled/freezer/cold,
+/area/crew_quarters/freezer)
 "aGP" = (
 /obj/structure/sign/nanotrasen,
 /turf/simulated/wall,
@@ -20402,6 +20398,18 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/lower/third_south)
+"aHi" = (
+/obj/machinery/power/apc{
+	cell_type = /obj/item/weapon/cell/super;
+	dir = 1;
+	name = "north bump";
+	pixel_y = 24
+	},
+/obj/structure/cable/green{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/tiled/freezer/cold,
+/area/crew_quarters/freezer)
 "aHj" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/borderfloor{
@@ -20842,6 +20850,13 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/outpost/xenobiology/outpost_south_airlock)
+"aHV" = (
+/obj/machinery/gibber,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/freezer/cold,
+/area/crew_quarters/freezer)
 "aHW" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -23317,6 +23332,20 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/tether/surfacebase/shuttle_pad)
+"aMC" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/freezer/cold,
+/area/crew_quarters/freezer)
 "aMD" = (
 /obj/structure/cable/orange{
 	d1 = 1;
@@ -25396,6 +25425,17 @@
 /obj/machinery/media/jukebox,
 /turf/simulated/floor/tiled,
 /area/rnd/outpost/xenobiology/outpost_breakroom)
+"aQZ" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/freezer/cold,
+/area/crew_quarters/freezer)
 "aRa" = (
 /turf/simulated/wall,
 /area/rnd/outpost/xenobiology/outpost_autopsy)
@@ -26483,6 +26523,20 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
 /area/rnd/outpost/xenobiology/outpost_first_aid)
+"aTg" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/freezer/cold,
+/area/crew_quarters/freezer)
 "aTh" = (
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 1
@@ -26521,9 +26575,31 @@
 "aTk" = (
 /turf/simulated/floor/tiled/techmaint,
 /area/rnd/outpost/xenobiology/outpost_storage)
+"aTl" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/mob/living/simple_mob/animal/goat{
+	name = "Spike"
+	},
+/turf/simulated/floor/tiled/freezer/cold,
+/area/crew_quarters/freezer)
 "aTm" = (
 /turf/simulated/wall/r_wall,
 /area/tether/surfacebase/medical/admin)
+"aTn" = (
+/obj/structure/kitchenspike,
+/turf/simulated/floor/tiled/freezer/cold,
+/area/crew_quarters/freezer)
+"aTo" = (
+/obj/structure/closet/crate/freezer,
+/turf/simulated/floor/tiled/freezer/cold,
+/area/crew_quarters/freezer)
 "aTp" = (
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 5
@@ -26890,6 +26966,10 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/storage)
+"aTW" = (
+/obj/machinery/light,
+/turf/simulated/floor/tiled/freezer/cold,
+/area/crew_quarters/freezer)
 "aTX" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -26928,6 +27008,25 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/iaa/officecommon)
+"aTZ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/freezer/cold,
+/area/crew_quarters/freezer)
+"aUa" = (
+/obj/machinery/button/remote/blast_door{
+	id = "freezer";
+	name = "Freezer Shutter Control";
+	pixel_y = -24
+	},
+/turf/simulated/floor/tiled/freezer/cold,
+/area/crew_quarters/freezer)
 "aUb" = (
 /obj/structure/bed/chair,
 /obj/machinery/alarm{
@@ -26980,6 +27079,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/servicebackroom)
+"aUh" = (
+/obj/structure/kitchenspike,
+/obj/machinery/alarm/freezer{
+	dir = 1;
+	pixel_y = -25
+	},
+/turf/simulated/floor/tiled/freezer/cold,
+/area/crew_quarters/freezer)
 "aUi" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/storage/box/donut,
@@ -27085,10 +27192,10 @@
 	},
 /area/hallway/lower/third_south)
 "aUq" = (
-/obj/structure/closet/secure_closet/freezer/meat,
-/obj/machinery/camera/network/civilian,
-/turf/simulated/floor/tiled/freezer,
-/area/crew_quarters/freezer)
+/obj/structure/shuttle/engine/propulsion,
+/turf/simulated/floor/reinforced,
+/turf/simulated/shuttle/plating/carry,
+/area/shuttle/tether)
 "aUr" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -27136,6 +27243,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/public_garden_three)
+"aUx" = (
+/obj/machinery/atmospherics/unary/engine{
+	dir = 1
+	},
+/turf/simulated/floor/reinforced,
+/turf/simulated/shuttle/plating/carry,
+/area/shuttle/tourbus/engines)
 "aUy" = (
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/airlock/glass_command{
@@ -30607,10 +30721,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_three_hall)
-"baI" = (
-/obj/machinery/icecream_vat,
-/turf/simulated/floor/tiled/freezer,
-/area/crew_quarters/freezer)
 "baJ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -31178,13 +31288,6 @@
 	},
 /turf/simulated/floor/tiled/eris/cafe,
 /area/hydroponics)
-"bbJ" = (
-/obj/machinery/firealarm{
-	layer = 3.3;
-	pixel_y = 26
-	},
-/turf/simulated/floor/tiled/freezer,
-/area/crew_quarters/freezer)
 "bbK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/wood,
@@ -31653,18 +31756,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
-"bcv" = (
-/obj/machinery/power/apc{
-	cell_type = /obj/item/weapon/cell/super;
-	dir = 1;
-	name = "north bump";
-	pixel_y = 24
-	},
-/obj/structure/cable/green{
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/tiled/freezer,
-/area/crew_quarters/freezer)
 "bcw" = (
 /obj/machinery/light,
 /obj/structure/bed/chair/comfy{
@@ -32053,20 +32144,6 @@
 	},
 /turf/simulated/floor/lino,
 /area/tether/surfacebase/entertainment)
-"bdc" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 1
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/freezer,
-/area/crew_quarters/freezer)
 "bdd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -32429,10 +32506,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
-"bdR" = (
-/obj/structure/kitchenspike,
-/turf/simulated/floor/tiled/freezer,
-/area/crew_quarters/freezer)
 "bdS" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -32446,17 +32519,6 @@
 /obj/structure/fans/tiny,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/white,
-/area/crew_quarters/freezer)
-"bdT" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 5
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/freezer)
 "bdV" = (
 /obj/structure/cable/green{
@@ -32923,13 +32985,6 @@
 	},
 /turf/simulated/floor/grass,
 /area/hydroponics)
-"beP" = (
-/obj/machinery/gibber,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/freezer,
-/area/crew_quarters/freezer)
 "beQ" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -33002,17 +33057,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/servicebackroom)
-"bfa" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/freezer,
-/area/crew_quarters/freezer)
 "bfb" = (
 /obj/machinery/door/airlock/freezer{
 	name = "Service";
@@ -33176,34 +33220,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/servicebackroom)
-"bfr" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/freezer,
-/area/crew_quarters/freezer)
-"bfs" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/mob/living/simple_mob/animal/goat{
-	name = "Spike"
-	},
-/turf/simulated/floor/tiled/freezer,
-/area/crew_quarters/freezer)
 "bft" = (
 /obj/machinery/light,
 /obj/structure/cable/green{
@@ -33238,14 +33254,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/servicebackroom)
-"bfw" = (
-/obj/structure/closet/crate/freezer,
-/turf/simulated/floor/tiled/freezer,
-/area/crew_quarters/freezer)
-"bfx" = (
-/obj/machinery/light,
-/turf/simulated/floor/tiled/freezer,
-/area/crew_quarters/freezer)
 "bfy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -33512,14 +33520,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/eris/cafe,
 /area/hydroponics)
-"bgb" = (
-/obj/machinery/button/remote/blast_door{
-	id = "freezer";
-	name = "Freezer Shutter Control";
-	pixel_y = -24
-	},
-/turf/simulated/floor/tiled/freezer,
-/area/crew_quarters/freezer)
 "bgc" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
@@ -54385,7 +54385,7 @@ jML
 jHw
 jpB
 qWU
-aGO
+aUx
 aKU
 aOI
 aPb
@@ -55237,7 +55237,7 @@ caw
 jHw
 gHh
 qWU
-aGO
+aUx
 aKU
 aOI
 aKj
@@ -57222,7 +57222,7 @@ aNk
 uSA
 aNJ
 aNP
-ayh
+aUq
 aKU
 abg
 aOk
@@ -57364,7 +57364,7 @@ aNl
 aNl
 aNK
 aNP
-ayh
+aUq
 aKU
 abg
 aOk
@@ -57506,7 +57506,7 @@ aNm
 aNl
 aNK
 aNP
-ayh
+aUq
 aKU
 abg
 aOk
@@ -59748,9 +59748,9 @@ ati
 aFz
 asu
 aoJ
-aUq
-bdc
-bfw
+ayh
+aMC
+aTo
 aoJ
 beD
 bfV
@@ -59890,9 +59890,9 @@ aty
 aGt
 aKw
 aoJ
-baI
-bfa
-bfx
+aBJ
+aQZ
+aTW
 aoJ
 bfk
 bgi
@@ -60032,9 +60032,9 @@ aum
 aJw
 asu
 aoJ
-bbJ
-bfr
-bdT
+aGO
+aTg
+aTZ
 beq
 bes
 bcB
@@ -60174,9 +60174,9 @@ awq
 aJw
 asu
 aoJ
-bcv
-bfs
-bgb
+aHi
+aTl
+aUa
 aoJ
 beZ
 bfq
@@ -60316,9 +60316,9 @@ axv
 bcF
 bdI
 aoJ
-beP
-bdR
-aBJ
+aHV
+aTn
+aUh
 aoJ
 bbr
 bcB


### PR DESCRIPTION
Not all freezer tiles have to be cold. Its just a name and it does NOT mean the tile is used exclusively in the freezer.

Fixes the pool starting off colder than intended and triggering air alarm heating clicks the moment people start entering it.