### PR TITLE
Fixes custom species body setup jank

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1078,7 +1078,7 @@
 
 	if(species)
 
-		if(species.name && species.name == new_species)
+		if(species.name && species.name == new_species && species.name != "Custom Species") //VOREStation Edit
 			return
 		if(species.language)
 			remove_language(species.language)


### PR DESCRIPTION
Fixes loading custom species characters in setup not updating the body if the earlier slot was also custom species. This was making a real mess with synth bodies getting slapped onto non-synth character previews and so on.