### PR TITLE
Fix shadekin mouse opacity

### DIFF
--- a/code/modules/mob/living/simple_mob/subtypes/vore/shadekin/ability_procs.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/shadekin/ability_procs.dm
@@ -19,7 +19,7 @@
 	//Shifting in
 	if(ability_flags & AB_PHASE_SHIFTED)
 		ability_flags &= ~AB_PHASE_SHIFTED
-		mouse_opacity = 2
+		mouse_opacity = 1
 		name = real_name
 		for(var/belly in vore_organs)
 			var/obj/belly/B = belly


### PR DESCRIPTION
2 is 'even transparent parts of the sprite are clickable' which is probably not intentional. By probably I mean 'definitely' since I coded this.