### PR TITLE
Make allergen traits make proper use of bitflags and add the rest of the allergens as traits

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
@@ -155,30 +155,30 @@
 
 
 //Allergen traits! Not available to any species with a base allergens var.
-/datum/trait/allergy_gluten
+/datum/trait/allergy
 	name = "Allergy: Gluten"
 	desc = "You're highly allergic to gluten proteins, which are found in most common grains."
 	cost = 0
 	custom_only = FALSE
-	var_changes = list("allergens" = 16)
-	excludes = list(/datum/trait/allergy_nuts,/datum/trait/allergy_soy)
+	var/allergen = 16
 
-/datum/trait/allergy_nuts
+/datum/trait/allergy/apply(var/datum/species/S,var/mob/living/carbon/human/H)
+	S.allergens |= allergen
+	..(S,H)
+
+/datum/trait/allergy/nuts
 	name = "Allergy: Nuts"
 	desc = "You're highly allergic to hard-shell seeds, such as peanuts."
 	cost = 0
 	custom_only = FALSE
-	var_changes = list("allergens" = 64)
-	excludes = list(/datum/trait/allergy_gluten,/datum/trait/allergy_soy)
+	allergen = 64
 
-/datum/trait/allergy_soy
+/datum/trait/allergy/soy
 	name = "Allergy: Soy"
 	desc = "You're highly allergic to soybeans, and some other kinds of bean."
 	cost = 0
 	custom_only = FALSE
-	var_changes = list("allergens" = 32)
-	excludes = list(/datum/trait/allergy_gluten,/datum/trait/allergy_nuts)
-
+	allergen = 32
 
 // Spicy Food Traits, from negative to positive.
 /datum/trait/spice_intolerance_extreme

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
@@ -160,25 +160,74 @@
 	desc = "You're highly allergic to gluten proteins, which are found in most common grains."
 	cost = 0
 	custom_only = FALSE
-	var/allergen = 16
+	var/allergen = GRAINS
 
 /datum/trait/allergy/apply(var/datum/species/S,var/mob/living/carbon/human/H)
 	S.allergens |= allergen
 	..(S,H)
+
+/datum/trait/allergy/meat
+	name = "Allergy: Meat"
+	desc = "You're highly allergic to just about any form of meat. You're probably better off just sticking to vegetables."
+	cost = 0
+	custom_only = FALSE
+	allergen = MEAT
+
+/datum/trait/allergy/fish
+	name = "Allergy: Fish"
+	desc = "You're highly allergic to fish. It's probably best to avoid seafood in general..."
+	cost = 0
+	custom_only = FALSE
+	allergen = FISH
+
+/datum/trait/allergy/fruit
+	name = "Allergy: Fruit"
+	desc = "You're highly allergic to fruit. Vegetables are fine, but you should probably read up on how to tell the difference."
+	cost = 0
+	custom_only = FALSE
+	allergen = FRUIT
+
+/datum/trait/allergy/vegetable
+	name = "Allergy: Vegetable"
+	desc = "You're highly allergic to vegetables. Fruit are fine, but you should probably read up on how to tell the difference."
+	cost = 0
+	custom_only = FALSE
+	allergen = VEGETABLE
 
 /datum/trait/allergy/nuts
 	name = "Allergy: Nuts"
 	desc = "You're highly allergic to hard-shell seeds, such as peanuts."
 	cost = 0
 	custom_only = FALSE
-	allergen = 64
+	allergen = SEEDS
 
 /datum/trait/allergy/soy
 	name = "Allergy: Soy"
 	desc = "You're highly allergic to soybeans, and some other kinds of bean."
 	cost = 0
 	custom_only = FALSE
-	allergen = 32
+	allergen = BEANS
+
+/datum/trait/allergy/dairy
+	name = "Allergy: Lactose"
+	desc = "You're highly allergic to lactose, and consequently, just about all forms of dairy."
+	cost = 0
+	custom_only = FALSE
+	allergen = DAIRY
+
+/datum/trait/allergy/fungi
+	name = "Allergy: Fungi"
+	desc = "You're highly allergic to Fungi such as mushrooms."
+	cost = 0
+	custom_only = FALSE
+	allergen = FUNGI
+
+/datum/trait/allergy/coffee
+	name = "Allergy: Coffee"
+	desc = "You're highly allergic to coffee in specific."
+	cost = 0
+	custom_only = FALSE
+	allergen = COFFEE
 
 // Spicy Food Traits, from negative to positive.
 /datum/trait/spice_intolerance_extreme


### PR DESCRIPTION
So, with a few lines and some pathing, allergen traits should add that allergen's bitflag instead of setting the variable equal to the allergen itself, this is much better for many reasons. Added the rest of the allergens as well. I might go and try to update a bunch of stuff polaris-side to make the allergen stuff more accurate as well, especially since like none of the foods that should trigger allergies right now actually do.