### PR TITLE
Fixes vorepanel accessibility requirements

### DIFF
--- a/code/modules/vore/eating/vorepanel_vr.dm
+++ b/code/modules/vore/eating/vorepanel_vr.dm
@@ -58,8 +58,19 @@
 
 // Note, in order to allow others to look at others vore panels, this state would need
 // to be changed to tgui_always_state, and a custom tgui_status() implemented for true "rights" management.
+// Currently there is no way for others to look at others vore panels so the above concern can wait.
 /datum/vore_look/tgui_state(mob/user)
-	return GLOB.tgui_self_state
+	return GLOB.tgui_always_state
+
+/datum/vore_look/tgui_status(mob/user, datum/tgui_state/state)
+	. = STATUS_CLOSE
+	if(!state)
+		return
+	if(user.client)
+		if(user.stat)
+			. = max(., STATUS_UPDATE)
+		else
+			. = max(., STATUS_INTERACTIVE)
 
 /datum/vore_look/var/static/list/nom_icons
 /datum/vore_look/proc/cached_nom_icon(atom/target)


### PR DESCRIPTION
Vorepanel functionality is no longer restricted to require free hands and whatever else might affect operating default machinery UIs. Being unconscious does still gray it out for now, but can be changed if needed, but now even the unconscious vorepanel still updates rather than just locking into a snapshot from before you passed out.