### PR TITLE
Properly adjust vorepanel to remove restrictions

### DIFF
--- a/code/modules/tgui/states/vorepanel_vr.dm
+++ b/code/modules/tgui/states/vorepanel_vr.dm
@@ -1,0 +1,18 @@
+ /**
+  * tgui state: vorepanel_state
+  *
+  * Only checks that the user and src_object are the same.
+ **/
+
+GLOBAL_DATUM_INIT(tgui_vorepanel_state, /datum/tgui_state/vorepanel_state, new)
+
+/datum/tgui_state/vorepanel_state/can_use_topic(src_object, mob/user)
+	if(src_object != user)
+		// Note, in order to allow others to look at others vore panels, change this to
+		// STATUS_UPDATE
+		return STATUS_CLOSE
+	if(!user.client)
+		return STATUS_CLOSE
+	if(user.stat == DEAD)
+		return STATUS_DISABLED
+	return STATUS_INTERACTIVE

--- a/code/modules/vore/eating/vorepanel_vr.dm
+++ b/code/modules/vore/eating/vorepanel_vr.dm
@@ -57,20 +57,9 @@
 	return host
 
 // Note, in order to allow others to look at others vore panels, this state would need
-// to be changed to tgui_always_state, and a custom tgui_status() implemented for true "rights" management.
-// Currently there is no way for others to look at others vore panels so the above concern can wait.
+// to be modified.
 /datum/vore_look/tgui_state(mob/user)
-	return GLOB.tgui_always_state
-
-/datum/vore_look/tgui_status(mob/user, datum/tgui_state/state)
-	. = STATUS_CLOSE
-	if(!state)
-		return
-	if(user.client)
-		if(user.stat)
-			. = max(., STATUS_UPDATE)
-		else
-			. = max(., STATUS_INTERACTIVE)
+	return GLOB.tgui_vorepanel_state
 
 /datum/vore_look/var/static/list/nom_icons
 /datum/vore_look/proc/cached_nom_icon(atom/target)

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -3649,6 +3649,7 @@
 #include "code\modules\tgui\states\observer.dm"
 #include "code\modules\tgui\states\physical.dm"
 #include "code\modules\tgui\states\self.dm"
+#include "code\modules\tgui\states\vorepanel_vr.dm"
 #include "code\modules\tgui\states\zlevel.dm"
 #include "code\modules\tooltip\tooltip.dm"
 #include "code\modules\turbolift\_turbolift.dm"


### PR DESCRIPTION
#9853 left some inaccurate comments in the code and implemented a rather shoddy adjustment to 'fix' a not-broken state. This PR properly adjusts the behavior of the vorepanel to reflect the desired behavior.

This PR implements a new TGUI state for the vore panel which behaves as such:
 - If dead, clientless, or not the owner of the vorepanel, close.
 - Otherwise, interactive.
Being unconscious doesn't prevent you from messing with your belly settings, but being dead does. Restraints and other such things don't affect it at all.

The previous behavior of only working when not incapacitated was **not**
 - unintended
 - a bug
 - a "temporary solution left in place"