### PR TITLE
Adds a bunch more boards to technical storage and AI law storage, makes appliance boards makeable in autolathe

### DIFF
--- a/code/datums/autolathe/engineering_vr.dm
+++ b/code/datums/autolathe/engineering_vr.dm
@@ -5,3 +5,23 @@
 /datum/category_item/autolathe/engineering/id_restorer
 	name = "ID restoration console electronics"
 	path =/obj/item/weapon/circuitboard/id_restorer
+
+/datum/category_item/autolathe/engineering/oven
+	name = "oven electronics"
+	path =/obj/item/weapon/circuitboard/oven
+
+/datum/category_item/autolathe/engineering/fryer
+	name = "fryer electronics"
+	path =/obj/item/weapon/circuitboard/fryer
+
+/datum/category_item/autolathe/engineering/grill
+	name = "grill electronics"
+	path =/obj/item/weapon/circuitboard/grill
+
+/datum/category_item/autolathe/engineering/cerealmaker
+	name = "cereal maker electronics"
+	path =/obj/item/weapon/circuitboard/cerealmaker
+
+/datum/category_item/autolathe/engineering/candymachine
+	name = "candy machine electronics"
+	path =/obj/item/weapon/circuitboard/candymachine

--- a/maps/tether/tether-06-station2.dmm
+++ b/maps/tether/tether-06-station2.dmm
@@ -470,18 +470,16 @@
 /turf/simulated/floor/tiled,
 /area/security/brig/visitation)
 "aW" = (
-/obj/structure/table/rack{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/item/weapon/stock_parts/matter_bin,
-/obj/item/weapon/stock_parts/matter_bin,
-/obj/item/weapon/stock_parts/manipulator,
-/obj/item/weapon/stock_parts/manipulator,
-/obj/item/weapon/stock_parts/console_screen,
-/obj/item/weapon/circuitboard/autolathe,
-/obj/item/weapon/circuitboard/partslathe,
-/turf/simulated/floor,
+/obj/structure/table/rack/steel,
+/obj/random/tech_supply/component/nofail,
+/obj/random/tech_supply/component/nofail,
+/obj/random/tech_supply/component/nofail,
+/obj/random/tech_supply/component/nofail,
+/obj/random/tech_supply/component/nofail,
+/obj/random/tech_supply/component/nofail,
+/obj/random/tech_supply/component/nofail,
+/obj/random/tech_supply/component/nofail,
+/turf/simulated/floor/plating,
 /area/storage/tech)
 "aX" = (
 /obj/effect/floor_decal/borderfloor{
@@ -5265,13 +5263,18 @@
 /turf/simulated/floor/tiled,
 /area/tether/exploration/staircase)
 "hU" = (
-/obj/structure/shuttle/engine/propulsion{
-	dir = 8;
-	icon_state = "propulsion_l"
-	},
-/turf/space,
-/turf/simulated/shuttle/plating/airless/carry,
-/area/shuttle/large_escape_pod1)
+/obj/structure/table/rack/steel,
+/obj/item/weapon/stock_parts/manipulator,
+/obj/item/weapon/stock_parts/manipulator,
+/obj/item/weapon/stock_parts/matter_bin,
+/obj/item/weapon/stock_parts/micro_laser,
+/obj/item/weapon/stock_parts/capacitor,
+/obj/item/weapon/stock_parts/capacitor,
+/obj/item/weapon/stock_parts/scanning_module,
+/obj/item/weapon/stock_parts/scanning_module,
+/obj/item/weapon/stock_parts/console_screen,
+/turf/simulated/floor,
+/area/storage/tech)
 "hV" = (
 /turf/simulated/floor/tiled,
 /area/security/security_cell_hallway)
@@ -5911,6 +5914,12 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/structure/table/standard,
+/obj/item/weapon/aiModule/consuming_eradicator,
+/obj/item/weapon/aiModule/guard_dog,
+/obj/item/weapon/aiModule/pleasurebot,
+/obj/item/weapon/aiModule/protective_shell,
+/obj/item/weapon/aiModule/scientific_pursuer,
 /turf/simulated/floor/bluegrid,
 /area/ai_upload)
 "iQ" = (
@@ -7251,20 +7260,16 @@
 "kL" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
-/obj/machinery/light/small{
-	dir = 1
-	},
 /turf/simulated/floor,
 /area/storage/tech)
 "kM" = (
-/obj/structure/table/rack{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/item/device/analyzer/plant_analyzer,
-/obj/item/device/healthanalyzer,
-/obj/item/device/analyzer,
-/obj/item/device/analyzer,
+/obj/machinery/camera/network/engineering,
+/obj/structure/table/rack/steel,
+/obj/item/weapon/stock_parts/matter_bin,
+/obj/item/weapon/stock_parts/matter_bin,
+/obj/item/weapon/stock_parts/matter_bin,
+/obj/item/weapon/stock_parts/manipulator,
+/obj/item/weapon/circuitboard/partslathe,
 /turf/simulated/floor/plating,
 /area/storage/tech)
 "kN" = (
@@ -7277,32 +7282,21 @@
 /turf/simulated/floor/airless,
 /area/maintenance/station/sec_lower)
 "kO" = (
-/obj/structure/table/rack{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/item/weapon/circuitboard/unary_atmos/heater,
-/obj/item/weapon/circuitboard/unary_atmos/cooler{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/machinery/camera/network/engineering,
-/turf/simulated/floor/plating,
-/area/storage/tech)
-"kP" = (
-/obj/structure/table/rack{
-	dir = 8;
-	layer = 2.9
-	},
 /obj/item/weapon/stock_parts/manipulator,
 /obj/item/weapon/stock_parts/matter_bin,
 /obj/item/weapon/stock_parts/matter_bin,
-/obj/item/weapon/stock_parts/capacitor,
-/obj/item/weapon/stock_parts/capacitor,
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/item/weapon/stock_parts/manipulator,
+/obj/structure/table/rack/steel,
+/obj/item/weapon/circuitboard/autolathe,
 /turf/simulated/floor/plating,
+/area/storage/tech)
+"kP" = (
+/obj/structure/table/steel,
+/obj/item/device/integrated_circuit_printer,
+/turf/simulated/floor,
 /area/storage/tech)
 "kQ" = (
 /obj/machinery/vending/assist,
@@ -7785,58 +7779,57 @@
 /turf/simulated/wall/r_wall,
 /area/storage/tech)
 "lx" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/table/rack/steel,
+/obj/item/weapon/computer_hardware/battery_module,
+/obj/item/weapon/computer_hardware/battery_module,
+/obj/item/weapon/computer_hardware/battery_module/nano,
+/obj/item/weapon/computer_hardware/hard_drive,
+/obj/item/weapon/computer_hardware/hard_drive,
+/obj/item/weapon/computer_hardware/hard_drive/micro,
+/obj/item/weapon/computer_hardware/network_card,
+/obj/item/weapon/computer_hardware/network_card,
+/obj/item/weapon/computer_hardware/network_card/wired,
+/obj/item/weapon/computer_hardware/processor_unit,
+/obj/item/weapon/computer_hardware/processor_unit,
+/obj/item/weapon/computer_hardware/processor_unit/small,
+/obj/item/weapon/computer_hardware/tesla_link,
+/obj/item/weapon/computer_hardware/nano_printer,
+/obj/item/weapon/computer_hardware/hard_drive/portable,
+/obj/item/weapon/computer_hardware/hard_drive/portable,
+/turf/simulated/floor,
+/area/storage/tech)
+"ly" = (
 /obj/machinery/status_display{
 	layer = 4;
 	pixel_x = -32;
 	pixel_y = 0
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor,
-/area/storage/tech)
-"ly" = (
-/obj/structure/table/rack{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/item/weapon/circuitboard/transhuman_synthprinter{
-	pixel_x = -3;
-	pixel_y = 4
-	},
-/obj/item/weapon/circuitboard/rdconsole{
-	pixel_x = 0;
-	pixel_y = 2
-	},
-/obj/item/weapon/circuitboard/destructive_analyzer,
-/obj/item/weapon/circuitboard/protolathe{
-	pixel_x = 3;
-	pixel_y = -2
-	},
-/obj/item/weapon/circuitboard/rdserver{
-	pixel_x = 6;
-	pixel_y = -4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plating,
 /area/storage/tech)
 "lz" = (
+/obj/item/weapon/stool,
+/turf/simulated/floor,
+/area/storage/tech)
+"lA" = (
 /obj/structure/table/rack{
 	dir = 8;
 	layer = 2.9
 	},
-/obj/item/weapon/circuitboard/security/mining{
-	pixel_x = 1;
+/obj/machinery/camera/network/engineering,
+/obj/item/weapon/circuitboard/robotics{
+	pixel_x = -3;
 	pixel_y = 3
 	},
-/obj/item/weapon/circuitboard/autolathe,
-/obj/item/weapon/circuitboard/scan_consolenew{
-	pixel_x = 6;
+/obj/item/weapon/circuitboard/mecha_control,
+/obj/item/weapon/circuitboard/aifixer{
+	pixel_x = 3;
 	pixel_y = -3
 	},
-/turf/simulated/floor/plating,
-/area/storage/tech)
-"lA" = (
-/obj/structure/table/steel,
-/obj/item/weapon/storage/bag/circuits/basic,
-/turf/simulated/floor,
+/turf/simulated/floor/tiled/dark,
 /area/storage/tech)
 "lB" = (
 /obj/effect/floor_decal/steeldecal/steel_decals7{
@@ -8274,20 +8267,17 @@
 /turf/simulated/floor,
 /area/storage/tech)
 "me" = (
-/obj/structure/table/rack{
-	dir = 8;
-	layer = 2.9
+/obj/structure/table/rack/steel,
+/obj/item/weapon/circuitboard/algae_farm{
+	pixel_x = -3;
+	pixel_y = 3
 	},
-/obj/item/weapon/circuitboard/robotics{
-	pixel_x = -2;
-	pixel_y = 2
+/obj/item/weapon/circuitboard/unary_atmos/heater,
+/obj/item/weapon/circuitboard/unary_atmos/cooler{
+	pixel_x = 3;
+	pixel_y = -3
 	},
-/obj/item/weapon/circuitboard/mecha_control{
-	pixel_x = 1;
-	pixel_y = -1
-	},
-/obj/machinery/camera/network/engineering,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/plating,
 /area/storage/tech)
 "mf" = (
 /obj/structure/railing,
@@ -8305,10 +8295,36 @@
 	name = "west bump";
 	pixel_x = -28
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor,
 /area/storage/tech)
 "mh" = (
-/obj/structure/disposalpipe/segment,
+/obj/structure/table/rack/steel,
+/obj/item/weapon/circuitboard/rdserver{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/weapon/circuitboard/protolathe{
+	pixel_x = -2;
+	pixel_y = 2
+	},
+/obj/item/weapon/circuitboard/destructive_analyzer{
+	pixel_x = -1;
+	pixel_y = 1
+	},
+/obj/item/weapon/circuitboard/rdconsole,
+/obj/item/weapon/circuitboard/autolathe{
+	pixel_x = 1;
+	pixel_y = -1
+	},
+/obj/item/weapon/circuitboard/mechfab{
+	pixel_x = 2;
+	pixel_y = -2
+	},
+/obj/item/weapon/circuitboard/prosthetics{
+	pixel_x = 3;
+	pixel_y = -3
+	},
 /turf/simulated/floor,
 /area/storage/tech)
 "mi" = (
@@ -8320,44 +8336,65 @@
 /turf/simulated/floor/plating,
 /area/maintenance/station/eng_upper)
 "mj" = (
-/obj/structure/table/rack{
-	dir = 8;
-	layer = 2.9
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/table/rack/steel,
+/obj/item/weapon/circuitboard/skills{
+	pixel_x = -3;
+	pixel_y = 3
 	},
-/obj/item/weapon/circuitboard/secure_data{
+/obj/item/weapon/circuitboard/med_data{
 	pixel_x = -2;
 	pixel_y = 2
 	},
-/obj/item/weapon/circuitboard/security{
+/obj/item/weapon/circuitboard/secure_data{
+	pixel_x = -1;
+	pixel_y = 1
+	},
+/obj/item/weapon/circuitboard/security,
+/obj/item/weapon/circuitboard/security/engineering{
 	pixel_x = 1;
 	pixel_y = -1
 	},
-/obj/item/weapon/circuitboard/skills{
-	pixel_x = 4;
+/obj/item/weapon/circuitboard/security/mining{
+	pixel_x = 2;
+	pixel_y = -2
+	},
+/obj/item/weapon/circuitboard/stationalert_security{
+	pixel_x = 3;
 	pixel_y = -3
 	},
 /turf/simulated/floor/plating,
 /area/storage/tech)
 "mk" = (
-/obj/structure/table/rack{
-	dir = 8;
-	layer = 2.9
+/obj/structure/table/rack/steel,
+/obj/item/weapon/circuitboard/grinder{
+	pixel_x = -4;
+	pixel_y = 4
 	},
-/obj/item/weapon/circuitboard/arcade/orion_trail{
+/obj/item/weapon/circuitboard/grill{
 	pixel_x = -3;
 	pixel_y = 3
 	},
-/obj/item/weapon/circuitboard/jukebox{
-	pixel_x = 0;
-	pixel_y = 0
+/obj/item/weapon/circuitboard/fryer{
+	pixel_x = -2;
+	pixel_y = 2
 	},
-/obj/item/weapon/circuitboard/message_monitor{
+/obj/item/weapon/circuitboard/oven{
+	pixel_x = -1;
+	pixel_y = 1
+	},
+/obj/item/weapon/circuitboard/microwave,
+/obj/item/weapon/circuitboard/cerealmaker{
+	pixel_x = 1;
+	pixel_y = -1
+	},
+/obj/item/weapon/circuitboard/candymachine{
+	pixel_x = 2;
+	pixel_y = -2
+	},
+/obj/item/weapon/circuitboard/biogenerator{
 	pixel_x = 3;
 	pixel_y = -3
-	},
-/obj/item/weapon/circuitboard/arcade/battle{
-	pixel_x = 6;
-	pixel_y = -5
 	},
 /turf/simulated/floor/plating,
 /area/storage/tech)
@@ -8418,23 +8455,24 @@
 	dir = 8;
 	layer = 2.9
 	},
-/obj/item/weapon/circuitboard/powermonitor{
-	pixel_x = 0;
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/item/weapon/circuitboard/crew{
+	pixel_x = -3;
 	pixel_y = 3
 	},
-/obj/item/weapon/circuitboard/stationalert_engineering{
-	pixel_x = 2;
-	pixel_y = 1
-	},
-/obj/item/weapon/circuitboard/security/engineering{
-	pixel_x = 5;
-	pixel_y = -1
-	},
-/obj/item/weapon/circuitboard/atmos_alert{
-	pixel_x = 6;
+/obj/item/weapon/circuitboard/card,
+/obj/item/weapon/circuitboard/communications{
+	pixel_x = 3;
 	pixel_y = -3
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/dark,
 /area/storage/tech)
 "mr" = (
 /obj/structure/railing{
@@ -8571,31 +8609,24 @@
 /turf/simulated/floor,
 /area/storage/tech)
 "mD" = (
-/obj/structure/table/rack{
-	dir = 8;
-	layer = 2.9
+/obj/structure/table/rack/steel,
+/obj/item/weapon/circuitboard/body_designer{
+	pixel_x = -3;
+	pixel_y = 3
 	},
-/obj/item/weapon/circuitboard/crew{
+/obj/item/weapon/circuitboard/resleeving_control{
 	pixel_x = -1;
 	pixel_y = 1
 	},
-/obj/item/weapon/circuitboard/card{
-	pixel_x = 2;
-	pixel_y = -2
+/obj/item/weapon/circuitboard/transhuman_clonepod{
+	pixel_x = 1;
+	pixel_y = -1
 	},
-/obj/item/weapon/circuitboard/communications{
-	pixel_x = 5;
-	pixel_y = -5
+/obj/item/weapon/circuitboard/transhuman_synthprinter{
+	pixel_x = 3;
+	pixel_y = -3
 	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor,
 /area/storage/tech)
 "mE" = (
 /obj/machinery/hologram/holopad,
@@ -8641,13 +8672,13 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/simulated/floor,
-/area/storage/tech)
-"mH" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
 	icon_state = "pipe-c"
 	},
+/turf/simulated/floor,
+/area/storage/tech)
+"mH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -8658,6 +8689,9 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/storage/tech)
@@ -9091,12 +9125,28 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/ai_upload_foyer)
 "nk" = (
-/obj/structure/shuttle/engine/propulsion{
-	dir = 8
+/obj/structure/table/rack{
+	dir = 8;
+	layer = 2.9
 	},
-/turf/space,
-/turf/simulated/shuttle/plating/airless/carry,
-/area/shuttle/large_escape_pod1)
+/obj/item/weapon/circuitboard/transhuman_resleever{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/weapon/circuitboard/circuit_imprinter{
+	pixel_x = -1;
+	pixel_y = 1
+	},
+/obj/item/weapon/circuitboard/aiupload{
+	pixel_x = 1;
+	pixel_y = -1
+	},
+/obj/item/weapon/circuitboard/borgupload{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/turf/simulated/floor/tiled/dark,
+/area/storage/tech)
 "nl" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -9183,23 +9233,30 @@
 /turf/simulated/floor,
 /area/maintenance/station/exploration)
 "nt" = (
-/obj/structure/table/rack{
-	dir = 8;
-	layer = 2.9
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/table/rack/steel,
+/obj/item/weapon/circuitboard/powermonitor{
+	pixel_x = -3;
+	pixel_y = 3
 	},
-/obj/item/weapon/circuitboard/borgupload{
+/obj/item/weapon/circuitboard/stationalert_engineering{
+	pixel_x = -2;
+	pixel_y = 2
+	},
+/obj/item/weapon/circuitboard/atmos_alert{
 	pixel_x = -1;
 	pixel_y = 1
 	},
-/obj/item/weapon/circuitboard/aiupload{
+/obj/item/weapon/circuitboard/rcon_console,
+/obj/item/weapon/circuitboard/atmoscontrol{
+	pixel_x = 1;
+	pixel_y = -1
+	},
+/obj/item/weapon/circuitboard/drone_control{
 	pixel_x = 2;
 	pixel_y = -2
 	},
-/obj/item/weapon/circuitboard/transhuman_resleever{
-	pixel_x = 5;
-	pixel_y = -5
-	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/plating,
 /area/storage/tech)
 "nu" = (
 /obj/machinery/light,
@@ -9213,37 +9270,49 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/ai_cyborg_station)
 "nw" = (
-/obj/structure/table/rack{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/item/weapon/circuitboard/transhuman_clonepod{
-	pixel_x = -2;
+/obj/structure/table/rack/steel,
+/obj/item/weapon/circuitboard/sleeper{
+	pixel_x = -3;
 	pixel_y = 3
 	},
-/obj/item/weapon/circuitboard/resleeving_control{
-	pixel_x = 0;
+/obj/item/weapon/circuitboard/sleeper_console{
+	pixel_x = -2;
+	pixel_y = 2
+	},
+/obj/item/weapon/circuitboard/body_scanner{
+	pixel_x = -1;
 	pixel_y = 1
 	},
-/obj/item/weapon/circuitboard/body_designer{
+/obj/item/weapon/circuitboard/scanner_console,
+/obj/item/weapon/circuitboard/grinder{
 	pixel_x = 1;
 	pixel_y = -1
 	},
-/obj/item/weapon/circuitboard/med_data{
-	pixel_x = 5;
+/obj/item/weapon/circuitboard/bioprinter{
+	pixel_x = 2;
+	pixel_y = -2
+	},
+/obj/item/weapon/circuitboard/chem_master{
+	pixel_x = 3;
 	pixel_y = -3
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/storage/tech)
 "nx" = (
-/obj/structure/shuttle/engine/propulsion{
-	dir = 8;
-	icon_state = "propulsion_r"
+/obj/structure/table/steel,
+/obj/item/weapon/cell/high{
+	charge = 100;
+	maxcharge = 15000
 	},
-/turf/space,
-/turf/simulated/shuttle/plating/airless/carry,
-/area/shuttle/large_escape_pod1)
+/obj/item/stack/cable_coil,
+/obj/machinery/cell_charger{
+	pixel_y = 5
+	},
+/obj/item/device/multitool,
+/obj/random/powercell,
+/obj/random/powercell,
+/turf/simulated/floor,
+/area/storage/tech)
 "ny" = (
 /obj/structure/stairs/spawner/north,
 /turf/simulated/floor/tiled,
@@ -9355,6 +9424,25 @@
 /obj/structure/stairs/spawner/west,
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery_hallway)
+"nL" = (
+/obj/item/weapon/storage/toolbox/electrical{
+	pixel_x = 1;
+	pixel_y = -1
+	},
+/obj/item/device/multitool,
+/obj/item/clothing/glasses/meson,
+/obj/machinery/light/small,
+/obj/structure/table/rack/steel,
+/obj/item/weapon/storage/toolbox/electrical{
+	pixel_x = 1;
+	pixel_y = -1
+	},
+/obj/item/clothing/gloves/yellow,
+/obj/item/device/t_scanner,
+/obj/item/clothing/glasses/meson,
+/obj/item/device/multitool,
+/turf/simulated/floor/plating,
+/area/storage/tech)
 "nM" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
@@ -9462,6 +9550,23 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/station/stairs_two)
+"nU" = (
+/obj/machinery/ai_status_display{
+	pixel_x = 0;
+	pixel_y = -32
+	},
+/obj/structure/table/rack/steel,
+/obj/item/device/slime_scanner,
+/obj/item/device/sleevemate,
+/obj/item/device/robotanalyzer,
+/obj/item/device/reagent_scanner,
+/obj/item/device/healthanalyzer,
+/obj/item/device/geiger,
+/obj/item/device/analyzer/plant_analyzer,
+/obj/item/device/analyzer,
+/obj/item/device/t_scanner,
+/turf/simulated/floor/plating,
+/area/storage/tech)
 "nV" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -9536,6 +9641,25 @@
 	dir = 1
 	},
 /turf/simulated/floor,
+/area/storage/tech)
+"oc" = (
+/obj/item/device/flashlight{
+	pixel_x = 1;
+	pixel_y = 5
+	},
+/obj/item/device/flashlight{
+	pixel_x = 1;
+	pixel_y = 5
+	},
+/obj/item/device/flash,
+/obj/item/device/flash,
+/obj/structure/table/steel,
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -25
+	},
+/obj/item/device/flashlight/maglight,
+/turf/simulated/floor/plating,
 /area/storage/tech)
 "od" = (
 /obj/effect/floor_decal/borderfloor{
@@ -9641,6 +9765,18 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor,
 /area/maintenance/station/exploration)
+"on" = (
+/obj/structure/table/steel,
+/obj/machinery/camera/network/engineering{
+	dir = 1
+	},
+/obj/random/toolbox,
+/obj/random/tank,
+/obj/random/tank,
+/obj/random/tool,
+/obj/random/tool,
+/turf/simulated/floor,
+/area/storage/tech)
 "oo" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -9706,6 +9842,21 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor,
 /area/maintenance/station/exploration)
+"ot" = (
+/obj/structure/table/steel,
+/obj/item/weapon/module/power_control,
+/obj/machinery/light/small,
+/obj/item/weapon/airlock_electronics,
+/obj/item/weapon/module/power_control,
+/obj/item/weapon/airlock_electronics,
+/turf/simulated/floor,
+/area/storage/tech)
+"ou" = (
+/obj/structure/table/steel,
+/obj/item/device/aicard,
+/obj/item/weapon/aiModule/reset,
+/turf/simulated/floor,
+/area/storage/tech)
 "ov" = (
 /obj/machinery/door/firedoor/glass,
 /obj/structure/lattice,
@@ -9714,6 +9865,39 @@
 	},
 /turf/simulated/open,
 /area/maintenance/station/eng_upper)
+"ow" = (
+/obj/structure/table/rack/steel,
+/obj/item/weapon/circuitboard/mech_recharger{
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/obj/item/weapon/circuitboard/cell_charger{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/weapon/circuitboard/recharger{
+	pixel_x = -2;
+	pixel_y = 2
+	},
+/obj/item/weapon/circuitboard/recharge_station{
+	pixel_x = -1;
+	pixel_y = 1
+	},
+/obj/item/weapon/circuitboard/arcade/battle,
+/obj/item/weapon/circuitboard/arcade/clawmachine{
+	pixel_x = 1;
+	pixel_y = -1
+	},
+/obj/item/weapon/circuitboard/arcade/orion_trail{
+	pixel_x = 2;
+	pixel_y = -2
+	},
+/obj/item/weapon/circuitboard/jukebox{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/turf/simulated/floor/plating,
+/area/storage/tech)
 "ox" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -9811,6 +9995,21 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/station/starboard)
+"oD" = (
+/obj/structure/shuttle/engine/propulsion{
+	dir = 8;
+	icon_state = "propulsion_l"
+	},
+/turf/space,
+/turf/simulated/shuttle/plating/airless/carry,
+/area/shuttle/large_escape_pod1)
+"oE" = (
+/obj/structure/shuttle/engine/propulsion{
+	dir = 8
+	},
+/turf/space,
+/turf/simulated/shuttle/plating/airless/carry,
+/area/shuttle/large_escape_pod1)
 "oF" = (
 /obj/structure/table/bench/wooden,
 /obj/effect/landmark/start{
@@ -9819,80 +10018,13 @@
 /turf/simulated/floor/tiled,
 /area/tether/exploration/equipment)
 "oG" = (
-/obj/structure/table/rack{
+/obj/structure/shuttle/engine/propulsion{
 	dir = 8;
-	layer = 2.9
+	icon_state = "propulsion_r"
 	},
-/obj/item/weapon/storage/toolbox/electrical{
-	pixel_x = 1;
-	pixel_y = -1
-	},
-/obj/item/device/multitool,
-/obj/item/clothing/glasses/meson,
-/obj/machinery/light/small,
-/turf/simulated/floor/plating,
-/area/storage/tech)
-"oH" = (
-/obj/structure/table/rack{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/item/weapon/storage/toolbox/electrical{
-	pixel_x = 1;
-	pixel_y = -1
-	},
-/obj/item/clothing/gloves/yellow,
-/obj/item/device/t_scanner,
-/obj/item/clothing/glasses/meson,
-/obj/item/device/multitool,
-/obj/machinery/ai_status_display{
-	pixel_x = 0;
-	pixel_y = -32
-	},
-/turf/simulated/floor/plating,
-/area/storage/tech)
-"oI" = (
-/obj/item/device/flashlight{
-	pixel_x = 1;
-	pixel_y = 5
-	},
-/obj/item/device/flashlight{
-	pixel_x = 1;
-	pixel_y = 5
-	},
-/obj/item/device/flash,
-/obj/item/device/flash,
-/obj/structure/table/steel,
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -25
-	},
-/turf/simulated/floor/plating,
-/area/storage/tech)
-"oJ" = (
-/obj/structure/table/steel,
-/obj/item/device/aicard,
-/obj/item/weapon/aiModule/reset,
-/obj/machinery/camera/network/engineering{
-	dir = 1
-	},
-/turf/simulated/floor,
-/area/storage/tech)
-"oK" = (
-/obj/structure/table/steel,
-/obj/item/weapon/module/power_control,
-/obj/item/weapon/airlock_electronics,
-/obj/machinery/light/small,
-/turf/simulated/floor,
-/area/storage/tech)
-"oL" = (
-/obj/structure/table/steel,
-/obj/machinery/cell_charger{
-	pixel_y = 5
-	},
-/obj/item/device/multitool,
-/turf/simulated/floor,
-/area/storage/tech)
+/turf/space,
+/turf/simulated/shuttle/plating/airless/carry,
+/area/shuttle/large_escape_pod1)
 "oM" = (
 /turf/simulated/open,
 /area/engineering/foyer_mezzenine)
@@ -10873,15 +11005,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/tether/station/public_meeting_room)
-"qI" = (
-/obj/structure/table/steel,
-/obj/item/weapon/cell/high{
-	charge = 100;
-	maxcharge = 15000
-	},
-/obj/item/stack/cable_coil,
-/turf/simulated/floor,
-/area/storage/tech)
 "qL" = (
 /obj/structure/sign/nosmoking_1{
 	pixel_y = 32
@@ -26419,9 +26542,9 @@ at
 aP
 aP
 lu
-me
-mD
-nt
+lA
+mq
+nk
 nX
 aP
 pd
@@ -26843,8 +26966,8 @@ Nf
 Tb
 jA
 fX
-kK
-lx
+kL
+ly
 mg
 mG
 pN
@@ -26985,13 +27108,13 @@ QM
 GD
 jB
 fX
-kL
-mh
+lx
+kK
 mh
 mH
-kK
+mD
 oa
-oG
+nL
 kJ
 pG
 pG
@@ -27127,13 +27250,13 @@ Vr
 WM
 jC
 fX
-kM
+aW
 jR
-ly
+mj
 mI
-nw
+nt
 ob
-oH
+nU
 kJ
 pG
 pG
@@ -27269,13 +27392,13 @@ is
 jb
 jC
 fX
-aW
+hU
 kK
-lz
+me
 mK
-mj
+nw
 kK
-oI
+oc
 kJ
 pG
 qm
@@ -27411,13 +27534,13 @@ it
 jb
 jD
 fX
-kO
+kM
 kK
 mk
 mK
-mq
+ow
 kK
-oJ
+on
 kJ
 pH
 qm
@@ -27553,13 +27676,13 @@ it
 jb
 jE
 fX
-kP
-kK
+kO
+lz
 kK
 mK
 kK
 kK
-oK
+ot
 kJ
 pI
 pG
@@ -27696,12 +27819,12 @@ jb
 jF
 fX
 kQ
-lA
+kP
 ml
 mK
 nz
-qI
-oL
+nx
+ou
 kJ
 pJ
 pG
@@ -35795,11 +35918,11 @@ hl
 DI
 RX
 DL
-hU
-nk
-nk
-nk
-nx
+oD
+oE
+oE
+oE
+oG
 oY
 sW
 ef


### PR DESCRIPTION
This is a bit all over the place, but map changes touch same z-level and are similar in nature.

Generally updates the technical storage to store more, well, tech:

Replaces outdated recursive box horror of integrated circuits with proper IC printer
Replaces parts on northern racks with exact sets needed for parts lathe and autolathe
Adds a randomized part spawner rack, with small chance of higher-tier parts spawning
Adds a rack with modular computer parts
Increases amount of various tech scanners on the scanner rack, now including: t-ray, atmospheric, plant, geiger, health, reagent, cyborg, slime, sleevemate.
Adds a bunch of boards to both storages and organizes them a bit more, more comprehensive list:
Secure storage:
Rack 1 - AI integrety, exosuit control, robotics control
Rack 2 - C&C, crew monitoring, ID console
Rack 3 - cyborg upload, ai upload, resleeving pod, circuit printer
Regular storage:
Rack 1 - R&D server, protolathe, autolathe, destructive analyzer, R&D console, exosuit fabricator, prosthetics fabricator
Rack 2 - employment, medical, security records, security, engineering, mining cameras, security alarms
Rack 3 - algae farm, gas cooler, gas heater
Rack 4 - grinder, biogenerator, all kitchen appliances
Rack 5 - body designer, grower pod, resleeving console, synthfab
Rack 6 - power monitoring, engineering alarms, atmos alarm, rcon, global atmos, drone control
Rack 7 - sleeper and console, body scanner and console, grinder, bioprinter, chemmaster
Rack 8 - mech charger, borg charger, regular charger, cell charger, all arcade machines, jukebox
Added some random air tank, toolbox and tool spawners

Makes all kitchen appliance boards makeable in autolathe, in-line with microwave

Also adds vorestation-exclusive lawsets in board form into 'dangerous lawset' AI storage.