### PR TITLE
Remove weird helmet thing from Forensic Technician outfit

### DIFF
--- a/code/datums/outfits/jobs/security.dm
+++ b/code/datums/outfits/jobs/security.dm
@@ -40,6 +40,7 @@
 //VOREStation Edit - More cyberpunky
 /decl/hierarchy/outfit/job/security/detective/forensic
 	name = OUTFIT_JOB_NAME("Forensic technician")
+	head = null
 	suit = /datum/gear/uniform/detective_alt2
 	uniform = /obj/item/clothing/under/det
 //VOREStation Edit End

--- a/code/datums/outfits/jobs/security.dm
+++ b/code/datums/outfits/jobs/security.dm
@@ -40,7 +40,6 @@
 //VOREStation Edit - More cyberpunky
 /decl/hierarchy/outfit/job/security/detective/forensic
 	name = OUTFIT_JOB_NAME("Forensic technician")
-	head = /obj/item/clothing/head/helmet/detective_alt
 	suit = /datum/gear/uniform/detective_alt2
 	uniform = /obj/item/clothing/under/det
 //VOREStation Edit End


### PR DESCRIPTION
It's weird and unfashionable and seems... out of place (I'm surprised to find that it's a Virgo thing)? As far as I am aware it doesn't serve any function. No one I've asked (read: one person I've asked IC) knows why it exists. And I am mildly inconvenienced by having to remove it from my head every time I join as Forensic Technician.

Git blame seems to say that @Arokha added this last Feburary, and I do wonder: Why, foxxo?