### PR TITLE
Don't even install gcc-multilib at all.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
         run: |
           sudo dpkg --add-architecture i386
           sudo apt update || true
-          sudo apt install libc6:i386 libgcc1:i386 libstdc++6:i386 libssl1.0.0:i386 g++-7 g++-7-multilib gcc-multilib zlib1g:i386
+          sudo apt install libc6:i386 libgcc1:i386 libstdc++6:i386 libssl1.0.0:i386 zlib1g:i386
           ldd librust_g.so
       - name: Unit Tests
         run: |


### PR DESCRIPTION
Problem: packages g++-7 g++-7-multilib gcc-multilib were failing to be installed in the CI environment.
Reason: Probably due to a recent update in the ubuntu-toolchain-r/test PPA,
Wait: Who said we needed these again? I don't think we need these packages installed at all.
Fix: Don't bother trying to install them.