### PR TITLE
Remove the throwing-people-to-the-floor effect of meteor strikes

### DIFF
--- a/code/modules/events/meteor_strike_vr.dm
+++ b/code/modules/events/meteor_strike_vr.dm
@@ -61,10 +61,6 @@
 			var/turf/mob_turf = get_turf(L)
 			if(!mob_turf || !(mob_turf.z in impacted.expected_z_levels))
 				continue
-			if(!L.buckled && !issilicon(L))
-				if(!L.Check_Shoegrip())
-					L.throw_at(get_step_rand(L),1,5)
-				L.Weaken(5)
 			if(L.client)
 				to_chat(L, "<span class='danger'>The ground lurches beneath you!</span>")
 				shake_camera(L, 6, 1)


### PR DESCRIPTION
Personally, I think this is kinda bad for RP. By that, I mean I dislike being randomly interrupted in the middle of my roleplaying just to be thrown to the floor for a few seconds, prompting one to either A) Ignore the event entirely and proceed as if it hasn't happened or B) stop what I was doing to give the predictable and unmeaningful responses of saying something along the lines of "That sounded bad" and/or asking others if they're okay (which they always are)

I dunno, it's not really a big deal and the above paragraph is probably an overreaction. But this thing bothered me enough to go through the (minor) effort of submitting a PR and that's why.