### PR TITLE
Fixes prefless carbonmobs defaulting to fuzzy mode

### DIFF
--- a/code/modules/vore/eating/living_vr.dm
+++ b/code/modules/vore/eating/living_vr.dm
@@ -23,7 +23,7 @@
 	var/noisy = FALSE					// Toggle audible hunger.
 	var/absorbing_prey = 0 				// Determines if the person is using the succubus drain or not. See station_special_abilities_vr.
 	var/drain_finalized = 0				// Determines if the succubus drain will be KO'd/absorbed. Can be toggled on at any time.
-	var/fuzzy = 1						// Preference toggle for sharp/fuzzy icon.
+	var/fuzzy = 0						// Preference toggle for sharp/fuzzy icon.
 	var/permit_healbelly = TRUE
 	var/can_be_drop_prey = FALSE
 	var/can_be_drop_pred = TRUE			// Mobs are pred by default.


### PR DESCRIPTION
This fuzzy var is basically just reserved for character pref use and a semirecent fix on another thing moved the part of the code using this var from character spawn loading code to icon update code and therefore made it non-irrelevant for non pref-loaded humanmobs (such as monkeys)

Partially fixes #9950