### PR TITLE
Adds Xenochimera variants of some positive and negative traits

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/xenochimera_trait_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/xenochimera_trait_vr.dm
@@ -26,10 +26,10 @@
 	cost = 0
 	custom_only = FALSE
 
-/datum/trait/fangs/xenochimera
+/datum/trait/melee_attack_fangs/xenochimera
 	allowed_species = list(SPECIES_XENOCHIMERA)
-	name = "Xenochimera: Numbing Fangs"
-	desc = "You have grown fangs that makes the person bit unable to feel their body or pain."
+	name = "Xenochimera: Sharp Melee & Numbing Fangs"
+	desc = "Your hunting instincts manifest in earnest! You have grown numbing fangs alongside your naturally grown hunting weapons."
 	cost = 0
 	custom_only = FALSE
 

--- a/code/modules/mob/living/carbon/human/species/station/xenochimera_trait_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/xenochimera_trait_vr.dm
@@ -26,20 +26,6 @@
 	cost = 0
 	custom_only = FALSE
 
-/datum/trait/melee_attack/xenochimera
-	allowed_species = list(SPECIES_XENOCHIMERA)
-	name = "Xenochimera: Sharp Melee"
-	desc = "Your hunting instincts manifest. Melee attacks are sharper and more dangerous."
-	cost = 0
-	custom_only = FALSE
-
-/datum/trait/melee_attack_fangs/xenochimera
-	allowed_species = list(SPECIES_XENOCHIMERA)
-	name = "Xenochimera: Sharp Melee & Numbing Fangs"
-	desc = "Your hunting instincts manifest in earnest!"
-	cost = 0
-	custom_only = FALSE
-
 /datum/trait/fangs/xenochimera
 	allowed_species = list(SPECIES_XENOCHIMERA)
 	name = "Xenochimera: Numbing Fangs"

--- a/code/modules/mob/living/carbon/human/species/station/xenochimera_trait_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/xenochimera_trait_vr.dm
@@ -1,0 +1,55 @@
+/* 
+**	For now, these are just neutral traits for Xenochimera only to take.
+**	These are only traits that they should reasonably be able to evolve to acquire themselves.
+**	I won't add the resistances though because those are kinda lame for a 'chimera to take!
+*/
+/datum/trait/weaver/xenochimera
+	allowed_species = list(SPECIES_XENOCHIMERA)
+	name = "Xenochimera: Weaver"
+	desc = "You've evolved your body to produce silk that you can fashion into articles of clothing and other objects."
+	cost = 0
+	custom_only = FALSE
+
+/datum/trait/hardfeet/xenochimera
+	allowed_species = list(SPECIES_XENOCHIMERA)
+	name = "Xenochimera: Hard Feet"
+	desc = "Your body has adapted to make your feet immune to glass shards, whether by developing hooves, chitin, or just horrible callous."
+	cost = 0
+	custom_only = FALSE
+
+// Why put this on Xenochimera of all species? I have no idea, but someone may be enough of a lunatic to take it.
+/datum/trait/neural_hypersensitivity/xenochimera
+	allowed_species = list(SPECIES_XENOCHIMERA)
+	name = "Xenochimera: Neural Hypersensitivity"
+	desc = "Despite your evolutionary efforts, you are unusually sensitive to pain. \
+	Given your species' typical reactions to pain, this can only end well for you!"
+	cost = 0
+	custom_only = FALSE
+
+/datum/trait/melee_attack/xenochimera
+	allowed_species = list(SPECIES_XENOCHIMERA)
+	name = "Xenochimera: Sharp Melee"
+	desc = "Your hunting instincts manifest. Melee attacks are sharper and more dangerous."
+	cost = 0
+	custom_only = FALSE
+
+/datum/trait/melee_attack_fangs/xenochimera
+	allowed_species = list(SPECIES_XENOCHIMERA)
+	name = "Xenochimera: Sharp Melee & Numbing Fangs"
+	desc = "Your hunting instincts manifest in earnest!"
+	cost = 0
+	custom_only = FALSE
+
+/datum/trait/fangs/xenochimera
+	allowed_species = list(SPECIES_XENOCHIMERA)
+	name = "Xenochimera: Numbing Fangs"
+	desc = "You have grown fangs that makes the person bit unable to feel their body or pain."
+	cost = 0
+	custom_only = FALSE
+
+/datum/trait/snowwalker/xenochimera
+	allowed_species = list(SPECIES_XENOCHIMERA)
+	name = "Xenochimera: Snow Walker"
+	desc = "You've adapted to traversing snowy terrain. Snow does not slow you down!"
+	cost = 0
+	custom_only = FALSE

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -2658,6 +2658,7 @@
 #include "code\modules\mob\living\carbon\human\species\station\station_special_vr.dm"
 #include "code\modules\mob\living\carbon\human\species\station\station_vr.dm"
 #include "code\modules\mob\living\carbon\human\species\station\xenochimera_hud_vr.dm"
+#include "code\modules\mob\living\carbon\human\species\station\xenochimera_trait_vr.dm"
 #include "code\modules\mob\living\carbon\human\species\station\protean_vr\protean_blob.dm"
 #include "code\modules\mob\living\carbon\human\species\station\protean_vr\protean_powers.dm"
 #include "code\modules\mob\living\carbon\human\species\station\protean_vr\protean_species.dm"


### PR DESCRIPTION
This creates neutral versions of some positive/negative traits that Xenochimera can take, so that they can enjoy some of their benefits as well:

- Weaver
- Hard Feet
- Sharp Melee + Numbing Fangs
- Snow Walker
- Neural Hypersensitivity

I was given the OK by Scree to add Weaver. However, I added the other ones as I think they fall under the same justification as for Weaver: Xenochimera are more then capable of developing these adaptations on their own.

Oh, and Neural Hypersensitivity is a horrible, horrible idea to take on 'chimera, but I added it anyway in the name of !FUN!