### PR TITLE
Fixes scaling mode toggle verb not persisting

### DIFF
--- a/code/modules/vore/eating/living_vr.dm
+++ b/code/modules/vore/eating/living_vr.dm
@@ -821,6 +821,7 @@
 	set category = "Preferences"
 	set desc = "Switch sharp/fuzzy scaling for current mob."
 	appearance_flags ^= PIXEL_SCALE
+	fuzzy = !fuzzy
 
 /mob/living/examine(mob/user, infix, suffix)
 	. = ..()


### PR DESCRIPTION
Fixes "switch scaling mode" verb not updating the mob var that the icon update code now relies on and therefore reverts the ingame toggled setting back to saved pref setting whenever icon update happens.