### PR TITLE
Fixes https://github.com/VOREStation/VOREStation/issues/9975

### DIFF
--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -329,7 +329,7 @@ var/global/list/PDA_Manifest = list()
 	if(H.mind && !player_is_antag(H.mind, only_offstation_roles = 1))
 		var/assignment = GetAssignment(H)
 		var/hidden
-		var/datum/job/J = SSjob.get_job(assignment)
+		var/datum/job/J = SSjob.get_job(H.mind.assigned_role)
 		hidden = J?.offmap_spawn
 
 		/* Note: Due to cached_character_icon, a number of emergent properties occur due to the initialization 


### PR DESCRIPTION
🆑
bugfix - Talon alt-titles no longer show up under miscellaneous on the manifest
/🆑
fixes https://github.com/VOREStation/VOREStation/issues/9975