### PR TITLE
Pilots get their harness even with loadout uniform

### DIFF
--- a/code/datums/outfits/outfit_vr.dm
+++ b/code/datums/outfits/outfit_vr.dm
@@ -123,11 +123,12 @@ Keep outfits simple. Spawn with basic uniforms and minimal gear. Gear instead go
 /decl/hierarchy/outfit/job/pilot
 	name = OUTFIT_JOB_NAME("Pilot")
 	shoes = /obj/item/clothing/shoes/black
-	uniform = /obj/item/clothing/under/rank/pilot1
+	uniform = /obj/item/clothing/under/rank/pilot1/no_webbing
 	suit = /obj/item/clothing/suit/storage/toggle/bomber/pilot
 	gloves = /obj/item/clothing/gloves/fingerless
 	glasses = /obj/item/clothing/glasses/fakesunglasses/aviator
 	l_ear = /obj/item/device/radio/headset/pilot/alt
+	uniform_accessories = list(/obj/item/clothing/accessory/storage/webbing/pilot1 = 1)
 	id_slot = slot_wear_id
 	pda_slot = slot_belt
 	pda_type = /obj/item/device/pda

--- a/maps/tether/tether_jobs.dm
+++ b/maps/tether/tether_jobs.dm
@@ -157,10 +157,11 @@
 
 	l_ear = /obj/item/device/radio/headset/talon
 	shoes = /obj/item/clothing/shoes/black
-	uniform = /obj/item/clothing/under/rank/pilot1
+	uniform = /obj/item/clothing/under/rank/pilot1/no_webbing
 	suit = /obj/item/clothing/suit/storage/toggle/bomber/pilot
 	gloves = /obj/item/clothing/gloves/fingerless
 	glasses = /obj/item/clothing/glasses/fakesunglasses/aviator
+	uniform_accessories = list(/obj/item/clothing/accessory/storage/webbing/pilot1 = 1)
 
 /decl/hierarchy/outfit/job/talon_doctor
 	name = OUTFIT_JOB_NAME("Talon Doctor")


### PR DESCRIPTION
🆑
bugfix - Pilots (inc. Talon Pilots) can now take a loadout uniform without losing their pilot harness
/🆑
The fix from https://github.com/VOREStation/VOREStation/pull/9965 applied to tether and talon pilots instead of just southern cross ones.