### PR TITLE
using rutile in alloys no longer makes slag

### DIFF
--- a/code/modules/mining/ore_datum.dm
+++ b/code/modules/mining/ore_datum.dm
@@ -224,6 +224,7 @@ var/global/list/ore_data = list()
 	smelts_to = "titanium"
 	result_amount = 5
 	spread_chance = 12
+	alloy = 1
 	ore = /obj/item/weapon/ore/rutile
 	scan_icon = "mineral_uncommon"
 


### PR DESCRIPTION
fun fact: if you don't set alloy = 1 in ore, and you use it in alloying, it uses extra bits of it to make

drumroll please

slag

this sucks and i hate it so here's a fix, probably
(fun fact: in ore_datum_vr.dm, alloy = 1 was set, but i guess someone on polaris forgot it?)