### PR TITLE
Adds a few more alt-titles to some jobs

### DIFF
--- a/code/game/jobs/job/captain_vr.dm
+++ b/code/game/jobs/job/captain_vr.dm
@@ -47,17 +47,20 @@
 /datum/job/secretary
 	disallow_jobhop = TRUE
 	pto_type = PTO_CIVILIAN
-	alt_titles = list("Command Liaison" = /datum/alt_title/command_liaison, "Bridge Secretary" = /datum/alt_title/bridge_secretary,
-						"Command Assistant" = /datum/alt_title/command_assistant, "Command Intern" = /datum/alt_title/command_intern)
+	alt_titles = list("Command Liaison" = /datum/alt_title/command_liaison, "Command Assistant" = /datum/alt_title/command_assistant, "Command Intern" = /datum/alt_title/command_intern,
+						"Bridge Secretary" = /datum/alt_title/bridge_secretary, "Bridge Assistant" = /datum/alt_title/bridge_assistant)
 
 /datum/alt_title/command_liaison
 	title = "Command Liaison"
-
-/datum/alt_title/bridge_secretary
-	title = "Bridge Secretary"
 
 /datum/alt_title/command_assistant
 	title = "Command Assistant"
 
 /datum/alt_title/command_intern
 	title = "Command Intern"
+
+/datum/alt_title/bridge_secretary
+	title = "Bridge Secretary"
+
+/datum/alt_title/bridge_assistant
+	title = "Bridge Assistant"

--- a/code/game/jobs/job/civilian_vr.dm
+++ b/code/game/jobs/job/civilian_vr.dm
@@ -49,10 +49,13 @@
 /datum/job/qm
 	pto_type = PTO_CARGO
 	dept_time_required = 20
-	alt_titles = list("Supply Chief" = /datum/alt_title/supply_chief, "Logistics Manager" = /datum/alt_title/logistics_manager)
+	alt_titles = list("Supply Chief" = /datum/alt_title/supply_chief, "Logistics Manager" = /datum/alt_title/logistics_manager, "Cargo Supervisor" = /datum/alt_title/cargo_supervisor)
 
 /datum/alt_title/logistics_manager
 	title = "Logistics Manager"
+
+/datum/alt_title/cargo_supervisor
+	title = "Cargo Supervisor"
 
 
 /datum/job/cargo_tech
@@ -83,7 +86,8 @@
 	total_positions = 4
 	spawn_positions = 4
 	pto_type = PTO_CARGO
-	alt_titles = list("Deep Space Miner" = /datum/alt_title/deep_space_miner, "Drill Technician" = /datum/alt_title/drill_tech, "Prospector" = /datum/alt_title/prospector)
+	alt_titles = list("Deep Space Miner" = /datum/alt_title/deep_space_miner, "Drill Technician" = /datum/alt_title/drill_tech, "Prospector" = /datum/alt_title/prospector,
+						"Excavator" = /datum/alt_title/excavator)
 
 /datum/alt_title/deep_space_miner
 	title = "Deep Space Miner"
@@ -91,6 +95,9 @@
 
 /datum/alt_title/prospector
 	title = "Prospector"
+
+/datum/alt_title/excavator
+	title = "Excavator"
 
 
 /datum/job/janitor //Lots of janitor substations on station.
@@ -162,7 +169,9 @@
 
 /datum/job/chaplain
 	pto_type = PTO_CIVILIAN
-	alt_titles = list("Missionary" = /datum/alt_title/missionary, "Preacher" = /datum/alt_title/preacher, "Counselor" = /datum/alt_title/counselor, "Guru" = /datum/alt_title/guru)
+	alt_titles = list("Missionary" = /datum/alt_title/missionary, "Preacher" = /datum/alt_title/preacher, "Priest" = /datum/alt_title/priest,
+						"Nun" = /datum/alt_title/nun, "Monk" = /datum/alt_title/monk, "Counselor" = /datum/alt_title/counselor,
+						"Guru" = /datum/alt_title/guru)
 
 /datum/alt_title/guru
 	title = "Guru"
@@ -173,6 +182,15 @@
 
 /datum/alt_title/preacher
 	title = "Preacher"
+
+/datum/alt_title/priest
+	title = "Priest"
+
+/datum/alt_title/nun
+	title = "Nun"
+
+/datum/alt_title/monk
+	title = "Monk"
 
 
 

--- a/code/game/jobs/job/engineering_vr.dm
+++ b/code/game/jobs/job/engineering_vr.dm
@@ -39,10 +39,13 @@
 /datum/job/atmos
 	spawn_positions = 3
 	pto_type = PTO_ENGINEERING
-	alt_titles = list("Atmospherics Maintainer" = /datum/alt_title/atmos_maint, "Disposals Technician" = /datum/alt_title/disposals_tech)
+	alt_titles = list("Atmospheric Engineer" = /datum/alt_title/atmos_engi, "Atmospheric Maintainer" = /datum/alt_title/atmos_maint, "Disposals Technician" = /datum/alt_title/disposals_tech)
 
 /datum/alt_title/atmos_maint
-	title = "Atmospherics Maintainer"
+	title = "Atmospheric Maintainer"
+
+/datum/alt_title/atmos_engi
+	title = "Atmospheric Engineer"
 
 /datum/alt_title/disposals_tech
 	title = "Disposals Technician"

--- a/code/game/jobs/job/exploration_vr.dm
+++ b/code/game/jobs/job/exploration_vr.dm
@@ -73,7 +73,7 @@
 	minimal_access = list(access_pilot)
 	outfit_type = /decl/hierarchy/outfit/job/pilot
 	job_description = "A Pilot flies the various shuttles in the Virgo-Erigone System."
-	alt_titles = list("Co-Pilot" = /datum/alt_title/co_pilot, "Navigator" = /datum/alt_title/navigator)
+	alt_titles = list("Co-Pilot" = /datum/alt_title/co_pilot, "Navigator" = /datum/alt_title/navigator, "Helmsman" = /datum/alt_title/helmsman)
 
 /datum/alt_title/co_pilot
 	title = "Co-Pilot"
@@ -81,6 +81,9 @@
 
 /datum/alt_title/navigator
 	title = "Navigator"
+
+/datum/alt_title/helmsman
+	title = "Helmsman"
 
 
 /datum/job/explorer
@@ -125,7 +128,10 @@
 	minimal_access = list(access_medical, access_medical_equip, access_morgue, access_pilot)
 	outfit_type = /decl/hierarchy/outfit/job/medical/sar
 	job_description = "A Field medic works as the field doctor of expedition teams."
-	alt_titles = list("Expedition Medic" = /datum/alt_title/expedition_medic)
+	alt_titles = list("Expedition Medic" = /datum/alt_title/expedition_medic, "Offsite Medic" = /datum/alt_title/offsite_medic)
 
 /datum/alt_title/expedition_medic
 	title = "Expedition Medic"
+
+/datum/alt_title/offsite_medic
+	title = "Offsite Medic"

--- a/code/game/jobs/job/science_vr.dm
+++ b/code/game/jobs/job/science_vr.dm
@@ -27,13 +27,16 @@
 /datum/job/scientist
 	spawn_positions = 5
 	pto_type = PTO_SCIENCE
-	alt_titles = list("Lab Assistant" = /datum/alt_title/lab_assistant, "Xenoarchaeologist" = /datum/alt_title/xenoarch, "Xenopaleontologist" = /datum/alt_title/xenopaleontologist, \
-						"Anomalist" = /datum/alt_title/anomalist, "Phoron Researcher" = /datum/alt_title/phoron_research, "Gas Physicist" = /datum/alt_title/gas_physicist, \
-						"Circuit Designer" = /datum/alt_title/circuit_designer, "Circuit Programmer" = /datum/alt_title/circuit_programmer)
+	alt_titles = list("Researcher" = /datum/alt_title/researcher, "Lab Assistant" = /datum/alt_title/lab_assistant, "Xenoarchaeologist" = /datum/alt_title/xenoarch,
+						"Xenopaleontologist" = /datum/alt_title/xenopaleontologist, "Anomalist" = /datum/alt_title/anomalist, "Phoron Researcher" = /datum/alt_title/phoron_research,
+						"Gas Physicist" = /datum/alt_title/gas_physicist, "Circuit Designer" = /datum/alt_title/circuit_designer, "Circuit Programmer" = /datum/alt_title/circuit_programmer)
 
 
 	access = list(access_robotics, access_tox, access_tox_storage, access_research, access_xenobiology, access_xenoarch, access_xenobotany)
 	minimal_access = list(access_tox, access_tox_storage, access_research, access_xenoarch)					// Unchanged (for now?), mostly here for reference
+
+/datum/alt_title/researcher
+	title = "Researcher"
 
 /datum/alt_title/lab_assistant
 	title = "Lab Assistant"
@@ -106,7 +109,10 @@
 	outfit_type = /decl/hierarchy/outfit/job/science/xenobiologist
 	job_description = "A Xenobotanist grows and cares for a variety of abnormal, custom made, and frequently dangerous plant life. When the products of these plants \
 					are both safe and beneficial to the station, they may choose to introduce it to the rest of the crew."
-	alt_titles = list("Xenoflorist" = /datum/alt_title/xenoflorist)
+	alt_titles = list("Xenohydroponicist" = /datum/alt_title/xenohydroponicist, "Xenoflorist" = /datum/alt_title/xenoflorist)
 
 /datum/alt_title/xenoflorist
 	title = "Xenoflorist"
+
+/datum/alt_title/xenohydroponicist
+	title = "Xenohydroponicist"


### PR DESCRIPTION
More purely fluff alt-titles for the god of purely fluff alt-titles.

Command Secretary - Added Bridge Assistant
Quartermaster - Added Cargo Supervisor
Shaft Miner - Added Excavator
Chaplain - Added Priest, Nun, Monk
Atmospheric Technician - Added Atmospheric Engineer, Renamed Atmospherics Maintainer to Atmospheric Maintainer.
Pilot - Added Helmsman
Field Medic - Added Offsite Medic
Scientist - Added Researcher
Xenobotanist - Added Xenohydroponicist