### PR TITLE
Implements a 'system' to allow whitelisted job alt-titles.

### DIFF
--- a/code/game/jobs/job/_alt_title_vr.dm
+++ b/code/game/jobs/job/_alt_title_vr.dm
@@ -1,0 +1,2 @@
+/datum/alt_title
+	var/whitelisted_ckey = null

--- a/code/modules/client/preference_setup/occupation/occupation.dm
+++ b/code/modules/client/preference_setup/occupation/occupation.dm
@@ -222,7 +222,7 @@
 	. += "</tt>"
 	. = jointext(.,null)
 
-/datum/category_item/player_setup_item/occupation/OnTopic(href, href_list, user)
+/datum/category_item/player_setup_item/occupation/OnTopic(href, href_list, mob/user)
 	if(href_list["reset_jobs"])
 		ResetJobs()
 		return TOPIC_REFRESH
@@ -237,7 +237,13 @@
 	else if(href_list["select_alt_title"])
 		var/datum/job/job = locate(href_list["select_alt_title"])
 		if (job)
-			var/choices = list(job.title) + job.alt_titles
+			var/choices = list(job.title)
+			for(var/I in job.alt_titles)
+				var/datum/alt_title/AT = job.alt_titles[I]
+				if(!initial(AT.whitelisted_ckey))
+					choices += I
+				else if(initial(AT.whitelisted_ckey) && user.ckey == initial(AT.whitelisted_ckey))
+					choices += I
 			var/choice = input("Choose a title for [job.title].", "Choose Title", pref.GetPlayerAltTitle(job)) as anything in choices|null
 			if(choice && CanUseTopic(user))
 				SetPlayerAltTitle(job, choice)

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -752,6 +752,7 @@
 #include "code\game\jobs\whitelist.dm"
 #include "code\game\jobs\whitelist_vr.dm"
 #include "code\game\jobs\job\_alt_title.dm"
+#include "code\game\jobs\job\_alt_title_vr.dm"
 #include "code\game\jobs\job\assistant.dm"
 #include "code\game\jobs\job\assistant_vr.dm"
 #include "code\game\jobs\job\captain.dm"


### PR DESCRIPTION
An alt-title can now have a ckey attached to it, and only that person will be able to select the alt-title. Currently no whitelisted alt-titles of course, but who knows if some will end up being put up/approved.