### PR TITLE
Makes modifying ID cards not change the department if rank wasn't changed

### DIFF
--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -301,7 +301,7 @@ var/global/list/PDA_Manifest = list()
 			manifest_inject(H)
 		return
 
-/datum/datacore/proc/manifest_modify(var/name, var/assignment)
+/datum/datacore/proc/manifest_modify(var/name, var/assignment, var/rank)
 	ResetPDAManifest()
 	var/datum/data/record/foundrecord
 	var/real_title = assignment
@@ -315,11 +315,18 @@ var/global/list/PDA_Manifest = list()
 	var/list/all_jobs = get_job_datums()
 
 	for(var/datum/job/J in all_jobs)
-		var/list/alttitles = get_alternate_titles(J.title)
-		if(!J)	continue
-		if(assignment in alttitles)
-			real_title = J.title
+		if(J.title == rank)					//If we have a rank, just default to using that.
+			real_title = rank
 			break
+		else if(J.title == assignment)
+			real_title = assignment
+			break
+		else
+			var/list/alttitles = get_alternate_titles(J.title)
+			if(!J)	continue
+			if(assignment in alttitles)
+				real_title = J.title
+				break
 
 	if(foundrecord)
 		foundrecord.fields["rank"] = assignment
@@ -332,7 +339,7 @@ var/global/list/PDA_Manifest = list()
 		var/datum/job/J = SSjob.get_job(H.mind.assigned_role)
 		hidden = J?.offmap_spawn
 
-		/* Note: Due to cached_character_icon, a number of emergent properties occur due to the initialization 
+		/* Note: Due to cached_character_icon, a number of emergent properties occur due to the initialization
 		* order of readied-up vs latejoiners. Namely, latejoiners will get a uniform in their datacore picture, but readied-up will
 		* not. This is due to the fact that SSticker calls data_core.manifest_inject() inside of ticker/proc/create_characters(),
 		* but does not equip them until ticker/proc/equip_characters(), which is called later. So, this proc is literally called before

--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -323,7 +323,6 @@ var/global/list/PDA_Manifest = list()
 			break
 		else
 			var/list/alttitles = get_alternate_titles(J.title)
-			if(!J)	continue
 			if(assignment in alttitles)
 				real_title = J.title
 				break

--- a/code/game/machinery/computer/card.dm
+++ b/code/game/machinery/computer/card.dm
@@ -157,7 +157,7 @@
 	switch(action)
 		if("modify")
 			if(modify)
-				data_core.manifest_modify(modify.registered_name, modify.assignment)
+				data_core.manifest_modify(modify.registered_name, modify.assignment, modify.rank)
 				modify.name = "[modify.registered_name]'s ID Card ([modify.assignment])"
 				if(ishuman(usr))
 					modify.forceMove(get_turf(src))

--- a/code/game/machinery/computer/timeclock_vr.dm
+++ b/code/game/machinery/computer/timeclock_vr.dm
@@ -177,7 +177,7 @@
 		card.rank = newjob.title
 		card.assignment = newassignment
 		card.name = text("[card.registered_name]'s ID Card ([card.assignment])")
-		data_core.manifest_modify(card.registered_name, card.assignment)
+		data_core.manifest_modify(card.registered_name, card.assignment, card.rank)
 		card.last_job_switch = world.time
 		callHook("reassign_employee", list(card))
 		newjob.current_positions++
@@ -203,7 +203,7 @@
 		card.rank = ptojob.title
 		card.assignment = ptojob.title
 		card.name = text("[card.registered_name]'s ID Card ([card.assignment])")
-		data_core.manifest_modify(card.registered_name, card.assignment)
+		data_core.manifest_modify(card.registered_name, card.assignment, card.rank)
 		card.last_job_switch = world.time
 		callHook("reassign_employee", list(card))
 		var/mob/living/carbon/human/H = usr

--- a/code/game/machinery/computer3/computers/card.dm
+++ b/code/game/machinery/computer3/computers/card.dm
@@ -312,14 +312,14 @@
 
 			writer.assignment = t1
 			writer.name = text("[writer.registered_name]'s ID Card ([writer.assignment])")
-			data_core.manifest_modify(writer.registered_name, writer.assignment)
+			data_core.manifest_modify(writer.registered_name, writer.assignment, writer.rank)
 			callHook("reassign_employee", list(writer))
 
 	if("reg" in href_list)
 		if(auth)
 			writer.registered_name = href_list["reg"]
 			writer.name = text("[writer.registered_name]'s ID Card ([writer.assignment])")
-			data_core.manifest_modify(writer.registered_name, writer.assignment)
+			data_core.manifest_modify(writer.registered_name, writer.assignment, writer.rank)
 			callHook("reassign_employee", list(writer))
 
 	computer.updateUsrDialog()

--- a/code/modules/tgui/modules/ntos-only/cardmod.dm
+++ b/code/modules/tgui/modules/ntos-only/cardmod.dm
@@ -167,7 +167,7 @@
 		if("modify")
 			if(computer && computer.card_slot)
 				if(id_card)
-					data_core.manifest_modify(id_card.registered_name, id_card.assignment)
+					data_core.manifest_modify(id_card.registered_name, id_card.assignment, id_card.rank)
 				computer.proc_eject_id(usr)
 			. = TRUE
 		if("terminate")


### PR DESCRIPTION
Title. Means HoP-modified IDs won't be defaulted to Miscellaneous.

Polaris version: https://github.com/PolarisSS13/Polaris/pull/8018