### PR TITLE
Fixes Teshari

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/station_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_vr.dm
@@ -307,31 +307,6 @@
 	genders = list(MALE, FEMALE, PLURAL, NEUTER)
 	wikilink="https://wiki.vore-station.net/Diona"
 
-/datum/species/teshari
-	mob_size = MOB_MEDIUM //To allow normal mob swapping
-	spawn_flags = SPECIES_CAN_JOIN
-	icobase = 'icons/mob/human_races/r_teshari_vr.dmi'
-	deform = 'icons/mob/human_races/r_teshari_vr.dmi'
-	icobase_tail = 1
-	color_mult = 1
-	min_age = 18
-	push_flags = ~HEAVY //Allows them to use micro step code.
-	swap_flags = ~HEAVY
-	gluttonous = 0
-	genders = list(MALE, FEMALE, PLURAL, NEUTER)
-	descriptors = list()
-	wikilink="https://wiki.vore-station.net/Teshari"
-	agility = 90
-
-	male_sneeze_sound = list('sound/effects/mob_effects/tesharisneeze.ogg','sound/effects/mob_effects/tesharisneezeb.ogg')
-	female_sneeze_sound = list('sound/effects/mob_effects/tesharisneeze.ogg','sound/effects/mob_effects/tesharisneezeb.ogg')
-
-	inherent_verbs = list(
-		/mob/living/carbon/human/proc/sonar_ping,
-		/mob/living/proc/hide,
-		/mob/living/proc/toggle_pass_table
-		)
-
 /datum/species/human
 	color_mult = 1
 	icobase = 'icons/mob/human_races/r_human_vr.dmi'

--- a/code/modules/mob/living/carbon/human/species/station/teshari_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/teshari_vr.dm
@@ -1,0 +1,24 @@
+/datum/species/teshari
+	mob_size = MOB_MEDIUM //To allow normal mob swapping
+	spawn_flags = SPECIES_CAN_JOIN
+	icobase = 'icons/mob/human_races/r_teshari_vr.dmi'
+	deform = 'icons/mob/human_races/r_teshari_vr.dmi'
+	icobase_tail = 1
+	color_mult = 1
+	min_age = 18
+	push_flags = ~HEAVY //Allows them to use micro step code.
+	swap_flags = ~HEAVY
+	gluttonous = 0
+	genders = list(MALE, FEMALE, PLURAL, NEUTER)
+	descriptors = list()
+	wikilink="https://wiki.vore-station.net/Teshari"
+	agility = 90
+
+	male_sneeze_sound = list('sound/effects/mob_effects/tesharisneeze.ogg','sound/effects/mob_effects/tesharisneezeb.ogg')
+	female_sneeze_sound = list('sound/effects/mob_effects/tesharisneeze.ogg','sound/effects/mob_effects/tesharisneezeb.ogg')
+
+	inherent_verbs = list(
+		/mob/living/carbon/human/proc/sonar_ping,
+		/mob/living/proc/hide,
+		/mob/living/proc/toggle_pass_table
+		)

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -2663,6 +2663,7 @@
 #include "code\modules\mob\living\carbon\human\species\station\station_special_vr.dm"
 #include "code\modules\mob\living\carbon\human\species\station\station_vr.dm"
 #include "code\modules\mob\living\carbon\human\species\station\teshari.dm"
+#include "code\modules\mob\living\carbon\human\species\station\teshari_vr.dm"
 #include "code\modules\mob\living\carbon\human\species\station\xenochimera_hud_vr.dm"
 #include "code\modules\mob\living\carbon\human\species\station\xenochimera_trait_vr.dm"
 #include "code\modules\mob\living\carbon\human\species\station\protean_vr\protean_blob.dm"


### PR DESCRIPTION
The rename put it below station_vr, which meant that Polaris's teshari was overriding Vore's override.