### PR TITLE
Enables Novel Posting

### DIFF
--- a/code/__defines/misc.dm
+++ b/code/__defines/misc.dm
@@ -77,7 +77,7 @@
 #define DO_AUTOPILOT 5
 
 // Setting this much higher than 1024 could allow spammers to DOS the server easily.
-#define MAX_MESSAGE_LEN       2048 //VOREStation Edit - I'm not sure about "easily". It can be a little longer.
+#define MAX_MESSAGE_LEN       4096 //VOREStation Edit - I'm not sure about "easily". It can be a little longer.
 #define MAX_PAPER_MESSAGE_LEN 6144
 #define MAX_BOOK_MESSAGE_LEN  24576
 #define MAX_RECORD_LENGTH	  24576


### PR DESCRIPTION
Doubles Max_message_len from 2048 to 4096

Because I hate having to break up posts and this would at least mitigate it somewhat , additionally making it easier for folks to get their posts out without worrying AS MUCH about the 2048 character limit should? be decent.  