### PR TITLE
Adds a verb for printing out vorebelly settings into chat for copypasting

### DIFF
--- a/code/modules/vore/eating/living_vr.dm
+++ b/code/modules/vore/eating/living_vr.dm
@@ -41,6 +41,7 @@
 	M.verbs += /mob/living/proc/lick
 	M.verbs += /mob/living/proc/smell
 	M.verbs += /mob/living/proc/switch_scaling
+	M.verbs += /mob/living/proc/vorebelly_printout
 	if(M.no_vore) //If the mob isn't supposed to have a stomach, let's not give it an insidepanel so it can make one for itself, or a stomach.
 		return TRUE
 	M.vorePanel = new(M)
@@ -864,3 +865,35 @@
 /obj/screen/fullscreen/belly
 	icon = 'icons/mob/screen_full_vore.dmi'
 	icon_state = ""
+
+/mob/living/proc/vorebelly_printout() //Spew the vorepanel belly messages into chat window for copypasting.
+	set name = "Print Vorebelly Settings"
+	set category = "Preferences"
+	set desc = "Print out your vorebelly messages into chat for copypasting."
+
+	for(var/belly in vore_organs)
+		if(isbelly(belly))
+			var/obj/belly/B = belly
+			to_chat(src, "<span class='notice'><b>Belly name:</b> [B.name]</span>")
+			to_chat(src, "<span class='notice'><b>Belly desc:</b> [B.desc]</span>")
+			to_chat(src, "<span class='notice'><b>Vore verb:</b> [B.vore_verb]</span>")
+			to_chat(src, "<span class='notice'><b>Struggle messages (outside):</b></span>")
+			for(var/msg in B.struggle_messages_outside)
+				to_chat(src, "<span class='notice'>[msg]</span>")
+			to_chat(src, "<span class='notice'><b>Struggle messages (inside):</b></span>")
+			for(var/msg in B.struggle_messages_inside)
+				to_chat(src, "<span class='notice'>[msg]</span>")
+			to_chat(src, "<span class='notice'><b>Digest messages (owner):</b></span>")
+			for(var/msg in B.digest_messages_owner)
+				to_chat(src, "<span class='notice'>[msg]</span>")
+			to_chat(src, "<span class='notice'><b>Digest messages (prey):</b></span>")
+			for(var/msg in B.digest_messages_prey)
+				to_chat(src, "<span class='notice'>[msg]</span>")
+			to_chat(src, "<span class='notice'><b>Examine messages:</b></span>")
+			for(var/msg in B.examine_messages)
+				to_chat(src, "<span class='notice'>[msg]</span>")
+			to_chat(src, "<span class='notice'><b>Emote lists:</b></span>")
+			for(var/EL in B.emote_lists)
+				to_chat(src, "<span class='notice'><b>[EL]:</b></span>")
+				for(var/msg in B.emote_lists[EL])
+					to_chat(src, "<span class='notice'>[msg]</span>")


### PR DESCRIPTION
This thing spews out all the belly messages (just the messages tho, no mode/number/addon/etc settings) into the chat window for convenient copypasting for players to backup/archive/transfer their belly setups.