### PR TITLE
Make unnatural resizing even better and more efficient with the power of DCS:tm:

### DIFF
--- a/code/__defines/dcs/signals.dm
+++ b/code/__defines/dcs/signals.dm
@@ -80,6 +80,8 @@
 #define COMSIG_ATOM_UPDATED_ICON "atom_updated_icon"
 ///from base of atom/Entered(): (atom/movable/entering, /atom)
 #define COMSIG_ATOM_ENTERED "atom_entered"
+/// Sent from the atom that just Entered src. From base of atom/Entered(): (/atom/entered_atom, /atom/oldLoc)
+#define COMSIG_ATOM_ENTERING "atom_entering"
 ///from base of atom/Exit(): (/atom/movable/exiting, /atom/newloc)
 #define COMSIG_ATOM_EXIT "atom_exit"
 	#define COMPONENT_ATOM_BLOCK_EXIT (1<<0)

--- a/code/datums/components/resize_guard.dm
+++ b/code/datums/components/resize_guard.dm
@@ -1,0 +1,19 @@
+/datum/component/resize_guard
+
+/datum/component/resize_guard/Initialize()
+	if(!isliving(parent))
+		return COMPONENT_INCOMPATIBLE
+
+/datum/component/resize_guard/RegisterWithParent()
+	// When our parent mob enters any atom, we check resize
+	RegisterSignal(parent, COMSIG_ATOM_ENTERING, .proc/check_resize)
+
+/datum/component/resize_guard/UnregisterFromParent()
+	UnregisterSignal(parent, COMSIG_ATOM_ENTERING)
+
+/datum/component/resize_guard/proc/check_resize()
+	var/area/A = get_area(parent)
+	if(A?.limit_mob_size)
+		var/mob/living/L = parent
+		L.resize(L.size_multiplier)
+		qdel(src)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -638,6 +638,7 @@
 	. = ..()
 	GLOB.moved_event.raise_event(AM, old_loc, AM.loc)
 	SEND_SIGNAL(src, COMSIG_ATOM_ENTERED, AM, old_loc)
+	SEND_SIGNAL(AM, COMSIG_ATOM_ENTERING, src, old_loc)
 
 /atom/Exit(atom/movable/AM, atom/new_loc)
 	. = ..()

--- a/code/modules/admin/verbs/resize.dm
+++ b/code/modules/admin/verbs/resize.dm
@@ -17,10 +17,6 @@
         to_chat(src,"<span class='warning'>[L] will lose this size upon moving into an area where this size is not allowed.</span>")
     else if(very_big) // made an extreme size in an area that doesn't allow it, assume adminbuse
         to_chat(src,"<span class='warning'>[L] will retain this normally unallowed size outside this area.</span>")
-        L.size_uncapped = TRUE
-    else if(L.size_uncapped) // made a normal size after having been an extreme adminbuse size
-        to_chat(src,"<span class='warning'>[L] now returned to normal area-based size limitations.</span>")
-        L.size_uncapped = FALSE
 
     L.resize(size_multiplier, animate = TRUE, uncapped = TRUE, ignore_prefs = TRUE)
 

--- a/code/modules/mob/living/living_defines_vr.dm
+++ b/code/modules/mob/living/living_defines_vr.dm
@@ -6,8 +6,6 @@
 	appearance_flags = TILE_BOUND|PIXEL_SCALE|KEEP_TOGETHER
 	var/hunger_rate = DEFAULT_HUNGER_FACTOR
 	var/resizable = TRUE
-	var/size_uncapped = FALSE //Determines if a mob's size obedies the resize cap, used for adminbus resize.
-
 //custom say verbs
 	var/custom_say = null
 	var/custom_ask = null

--- a/code/modules/nifsoft/software/15_misc.dm
+++ b/code/modules/nifsoft/software/15_misc.dm
@@ -134,7 +134,7 @@
 				to_chat(nif.human,"<span class='notice'>The safety features of the NIF Program prevent you from choosing this size.</span>")
 			return
 		else
-			if(nif.human.resize(new_size/100, ignore_prefs = TRUE))
+			if(nif.human.resize(new_size/100, uncapped=nif.human.has_large_resize_bounds(), ignore_prefs = TRUE))
 				to_chat(nif.human,"<span class='notice'>You set the size to [new_size]%</span>")
 				nif.human.visible_message("<span class='warning'>Swirling grey mist envelops [nif.human] as they change size!</span>","<span class='notice'>Swirling streams of nanites wrap around you as you change size!</span>")
 		spawn(0)

--- a/code/modules/vore/resizing/resize_vr.dm
+++ b/code/modules/vore/resizing/resize_vr.dm
@@ -1,6 +1,3 @@
-GLOBAL_LIST_EMPTY(size_uncapped_mobs)
-GLOBAL_VAR(size_uncapped_mobs_timer)
-
 // Adding needed defines to /mob/living
 // Note: Polaris had this on /mob/living/carbon/human We need it higher up for animals and stuff.
 /mob/living
@@ -62,41 +59,6 @@ GLOBAL_VAR(size_uncapped_mobs_timer)
 /proc/is_extreme_size(size)
 	return (size < RESIZE_MINIMUM || size > RESIZE_MAXIMUM)
 
-/proc/add_to_uncapped_list(var/mob/living/L)
-	if(L.size_uncapped)
-		return
-	if(!GLOB.size_uncapped_mobs.len)
-		//Could be a subsystem but arguably a giant waste of time to make into a subsystem. A subsystem that is paused on and off all the time? Eh.
-		//If you're that worried, make metrics for how often this even runs and then decide.
-		GLOB.size_uncapped_mobs_timer = addtimer(CALLBACK(GLOBAL_PROC, .check_uncapped_list), 2 SECONDS, TIMER_LOOP | TIMER_UNIQUE | TIMER_STOPPABLE)
-	GLOB.size_uncapped_mobs |= weakref(L)
-
-/proc/remove_from_uncapped_list(var/mob/living/L)
-	if(!GLOB.size_uncapped_mobs.len)
-		return
-
-	GLOB.size_uncapped_mobs -= weakref(L)
-
-	if(!GLOB.size_uncapped_mobs.len)
-		deltimer(GLOB.size_uncapped_mobs_timer)
-		GLOB.size_uncapped_mobs_timer = null
-
-/proc/check_uncapped_list()
-	for(var/weakref/wr in GLOB.size_uncapped_mobs)
-		var/mob/living/L = wr.resolve()
-		if(!istype(L) || L.size_uncapped)
-			GLOB.size_uncapped_mobs -= wr
-			continue
-		
-		// If we get here, you're a mob, and you don't have admin exclusion (size_uncapped) to being big, and you're very likely big.
-		// If you're not abnormally big, the below will do nothing, so it's fine to run anyway.
-		if(!L.has_large_resize_bounds())
-			L.resize(L.size_multiplier, ignore_prefs = TRUE) //Calling this will have resize() clamp it
-			GLOB.size_uncapped_mobs -= wr
-
-	if(!GLOB.size_uncapped_mobs.len)
-		deltimer(GLOB.size_uncapped_mobs_timer)
-		GLOB.size_uncapped_mobs_timer = null
 
 /**
  * Resizes the mob immediately to the desired mod, animating it growing/shrinking.
@@ -107,9 +69,16 @@ GLOBAL_VAR(size_uncapped_mobs_timer)
 /mob/living/proc/resize(var/new_size, var/animate = TRUE, var/uncapped = FALSE, var/ignore_prefs = FALSE)
 	if(!uncapped)
 		new_size = clamp(new_size, RESIZE_MINIMUM, RESIZE_MAXIMUM)
-		remove_from_uncapped_list(src)
-	else if(is_extreme_size(new_size))
-		add_to_uncapped_list(src)
+		var/datum/component/resize_guard/guard = GetComponent(/datum/component/resize_guard)
+		if(guard)
+			qdel(guard)
+	else if(has_large_resize_bounds())
+		if(is_extreme_size(new_size))
+			AddComponent(/datum/component/resize_guard)
+		else
+			var/datum/component/resize_guard/guard = GetComponent(/datum/component/resize_guard)
+			if(guard)
+				qdel(guard)
 	
 	if(size_multiplier == new_size)
 		return 1

--- a/code/modules/vore/resizing/sizegun_vr.dm
+++ b/code/modules/vore/resizing/sizegun_vr.dm
@@ -114,12 +114,8 @@
 			to_chat(firer, "<span class='warning'>[M] will lose this size upon moving into an area where this size is not allowed.</span>")
 		else if(very_big) // made an extreme size in an area that doesn't allow it, assume adminbuse
 			to_chat(firer, "<span class='warning'>[M] will retain this normally unallowed size outside this area.</span>")
-			M.size_uncapped = TRUE
-		else if(M.size_uncapped) // made a normal size after having been an extreme adminbuse size
-			to_chat(firer, "<span class='warning'>[M] now returned to normal area-based size limitations.</span>")
-			M.size_uncapped = FALSE
 		
-		M.resize(set_size, uncapped = TRUE, ignoring_prefs = TRUE) // Always ignores prefs, caution is advisable
+		M.resize(set_size, uncapped = TRUE, ignore_prefs = TRUE) // Always ignores prefs, caution is advisable
 
 		to_chat(M, "<font color='blue'>The beam fires into your body, changing your size!</font>")
 		M.updateicon()

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -336,6 +336,7 @@
 #include "code\datums\autolathe\tools.dm"
 #include "code\datums\autolathe\tools_vr.dm"
 #include "code\datums\components\_component.dm"
+#include "code\datums\components\resize_guard.dm"
 #include "code\datums\elements\_element.dm"
 #include "code\datums\game_masters\_common.dm"
 #include "code\datums\helper_datums\construction_datum.dm"


### PR DESCRIPTION
Title. Makes #10090 and #9545 better while retaining the fixes required by #9950.
This is almost a revert of #10090 because I removed most of what it did in favor of this approach.

Basically, the way this works is that whenever resize() is called, the following will happen:

 - If uncapped = TRUE and your area permits this:
   - If you are scaling to an unnatural size, it will add a one shot component to return you to capped sizes when you move outside of this area
   - If you are scaling to a size within bounds, the component will be deleted if present.
 - If uncapped = TRUE and your area does not permit this, it will assume adminbus and permanently set your size to that value.
 - If uncapped = FALSE, the component will be deleted if present and your size will be capped.

The component in question is referred to as `one-shot` because it will delete itself as soon as it detects that you're resized out of bounds when you're not supposed to after resizing you down. The way it does this is by listening to `COMSIG_ATOM_ENTERING`, which is called from the base of atom/Entered() *on* the atom that just moved into a new place. This covers basically every possible way to leave an area, as any time you enter a new turf or area, you'll have your area checked for size limitations and the component will fire and reset your size before deleting itself.

This doesn't seem to have much performance impact at all.
> /datum/component/resize_guard/proc/check_resize   0.000   0.000   0.000  0.000  70
