### PR TITLE
Fix missing resize pref copy, move resize define

### DIFF
--- a/code/modules/mob/living/living_defines_vr.dm
+++ b/code/modules/mob/living/living_defines_vr.dm
@@ -5,7 +5,6 @@
 	var/ooc_notes = null
 	appearance_flags = TILE_BOUND|PIXEL_SCALE|KEEP_TOGETHER
 	var/hunger_rate = DEFAULT_HUNGER_FACTOR
-	var/resizable = TRUE
 //custom say verbs
 	var/custom_say = null
 	var/custom_ask = null

--- a/code/modules/vore/eating/living_vr.dm
+++ b/code/modules/vore/eating/living_vr.dm
@@ -3,7 +3,8 @@
 	var/digestable = TRUE				// Can the mob be digested inside a belly?
 	var/devourable = TRUE				// Can the mob be devoured at all?
 	var/feeding = TRUE					// Can the mob be vorishly force fed or fed to others?
-	var/absorbable = TRUE				// Are you allowed to absorb this person? TFF addition 14/12/19
+	var/absorbable = TRUE				// Are you allowed to absorb this person?
+	var/resizable = TRUE				// Can other people resize you? (Usually ignored for self-resizes)
 	var/digest_leave_remains = FALSE	// Will this mob leave bones/skull/etc after the melty demise?
 	var/allowmobvore = TRUE				// Will simplemobs attempt to eat the mob?
 	var/showvoreprefs = TRUE			// Determines if the mechanical vore preferences button will be displayed on the mob or not.
@@ -225,7 +226,8 @@
 	P.digestable = src.digestable
 	P.devourable = src.devourable
 	P.feeding = src.feeding
-	P.absorbable = src.absorbable	//TFF 14/12/19 - choose whether allowing absorbing
+	P.absorbable = src.absorbable
+	P.resizable = src.resizable
 	P.digest_leave_remains = src.digest_leave_remains
 	P.allowmobvore = src.allowmobvore
 	P.vore_taste = src.vore_taste
@@ -259,7 +261,8 @@
 	digestable = P.digestable
 	devourable = P.devourable
 	feeding = P.feeding
-	absorbable = P.absorbable	//TFF 14/12/19 - choose whether allowing absorbing
+	absorbable = P.absorbable
+	resizable = P.resizable
 	digest_leave_remains = P.digest_leave_remains
 	allowmobvore = P.allowmobvore
 	vore_taste = P.vore_taste

--- a/code/modules/vore/eating/vore_vr.dm
+++ b/code/modules/vore/eating/vore_vr.dm
@@ -45,20 +45,22 @@ V::::::V           V::::::VO:::::::OOO:::::::ORR:::::R     R:::::REE::::::EEEEEE
 	//Actual preferences
 	var/digestable = TRUE
 	var/devourable = TRUE
-	var/resizable = TRUE
+	var/absorbable = TRUE
 	var/feeding = TRUE
-	var/absorbable = TRUE	//TFF 14/12/19 - choose whether allowing absorbing
+	var/can_be_drop_prey = FALSE
+	var/can_be_drop_pred = FALSE
 	var/digest_leave_remains = FALSE
 	var/allowmobvore = TRUE
+	var/permit_healbelly = TRUE
+
+	var/resizable = TRUE
+	var/show_vore_fx = TRUE
+	var/step_mechanics_pref = FALSE
+	var/pickup_pref = TRUE
+
 	var/list/belly_prefs = list()
 	var/vore_taste = "nothing in particular"
 	var/vore_smell = "nothing in particular"
-	var/permit_healbelly = TRUE
-	var/show_vore_fx = TRUE
-	var/can_be_drop_prey = FALSE
-	var/can_be_drop_pred = FALSE
-	var/step_mechanics_pref = FALSE
-	var/pickup_pref = TRUE
 
 	//Mechanically required
 	var/path
@@ -125,7 +127,7 @@ V::::::V           V::::::VO:::::::OOO:::::::ORR:::::R     R:::::REE::::::EEEEEE
 	devourable = json_from_file["devourable"]
 	resizable = json_from_file["resizable"]
 	feeding = json_from_file["feeding"]
-	absorbable = json_from_file["absorbable"]	//TFF 14/12/19 - choose whether allowing absorbing
+	absorbable = json_from_file["absorbable"]
 	digest_leave_remains = json_from_file["digest_leave_remains"]
 	allowmobvore = json_from_file["allowmobvore"]
 	vore_taste = json_from_file["vore_taste"]


### PR DESCRIPTION
Couple lines were missing that copy resizing pref from/to the mob from vore prefs.
Rearranged the lines in vore_preferences because pedantry
Move where resizable is defined to be with the other like-vars