### PR TITLE
Extra hot species fix or how not to forget things

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/blank_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/blank_vr.dm
@@ -47,7 +47,7 @@
 	return real.race_key
 
 /datum/species/custom/produceCopy(var/list/traits,var/mob/living/carbon/human/H,var/custom_base)
-	. = ..()
+	. = ..(traits, H)
 	if(selects_bodytype && custom_base)
 		var/datum/species/S = GLOB.all_species[custom_base]
 		S.copy_variables(., copy_vars)


### PR DESCRIPTION
This little sleep deprived dunce forgot that parent proc calls need to have arguments pass down to them.
So sadly now this tiniest fix possible is needed to make sure custom species properly inherit their traits!