### PR TITLE
Silence, cleanbots

### DIFF
--- a/code/modules/mob/living/bot/cleanbot.dm
+++ b/code/modules/mob/living/bot/cleanbot.dm
@@ -28,7 +28,7 @@
 /mob/living/bot/cleanbot/handleIdle()
 	if(!wet_floors && !spray_blood && prob(2))
 		custom_emote(2, "makes an excited booping sound!")
-		playsound(src, 'sound/machines/synth_yes.ogg', 50, 0)
+		//playsound(src, 'sound/machines/synth_yes.ogg', 50, 0) // VOREStation removal
 
 	if(wet_floors && prob(5)) // Make a mess
 		if(istype(loc, /turf/simulated))


### PR DESCRIPTION
Silences cleanbots by just commenting out the line that makes them play the sound, removing the behavior entirely.
The cartridges that janitors get for their PDAs can be used to locate cleanbots, if I remember correctly. So this beeping isn't needed for locating cleanbots.

Why not instead add a toggle to them, like the ones medibots have? Because if one or more of them are beeping and annoying me, I'll have to hunt them down to shut them up. Also I'm too lazy to figure out how to make the needed changes to their UI

Why not instead add a preference? Because I'm too lazy to figure out how to add more preference settings.

My decision to create and submit this PR may be motivated in part by the headache I am currently suffering from.