### PR TITLE
New belt items

### DIFF
--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -71,6 +71,8 @@
 		/obj/item/weapon/tape_roll,
 		/obj/item/device/integrated_electronics/wirer,
 		/obj/item/device/integrated_electronics/debugger, //Vorestation edit adding debugger to toolbelt can hold list
+		/obj/item/weapon/shovel/spade, //VOREStation edit. If it can hold minihoes and hatchers, why not the gardening spade?
+		/obj/item/stack/nanopaste //VOREStation edit. Think of it as a tube of superglue. Belts hold that all the time.
 		)
 
 /obj/item/weapon/storage/belt/utility/full
@@ -349,7 +351,8 @@
 		/obj/item/device/megaphone,
 		/obj/item/taperoll,
 		/obj/item/weapon/reagent_containers/spray,
-		/obj/item/weapon/soap
+		/obj/item/weapon/soap,
+		/obj/item/device/lightreplacer //VOREStation edit
 		)
 
 /obj/item/weapon/storage/belt/archaeology


### PR DESCRIPTION
Toolbelts can now hold nanopaste (+ advanced) and gardening spades

- Nanopaste is the size of a tube of superglue and I never leave the house without at least one tube of superglue on my toolbelt
- Hatchets and mini-hoes can be put on the belt so why not spades

Janitor belts can now hold the light replacer

- I see no downside to this except for the possibility of disrupting the incredibly intricate janitor end-game balance loop
