### PR TITLE
AlFalah fluff item fix part 2

### DIFF
--- a/code/modules/vore/fluffstuff/custom_items_vr.dm
+++ b/code/modules/vore/fluffstuff/custom_items_vr.dm
@@ -1371,4 +1371,5 @@
 	can_hold = list(/obj/item/clothing/mask/smokable/cigarette, /obj/item/weapon/flame/lighter, /obj/item/trash/cigbutt)
 	icon_type = "charlotte"
 	//brand = "\improper Professional 120"
+	w_class = ITEMSIZE_TINY
 	starts_with = list(/obj/item/clothing/mask/smokable/cigarette = 7)


### PR DESCRIPTION
I did it bad _again._ The cigarette case went from being a subtype of cigarette cases to being a subtype of donut boxes and as such went from ITEMSIZE_TINY to ITEMSIZE_NORMAL and that doesn't make sense and is stupid so I fixed it.

If this messes up in some unforeseen way again I'll be especially cross.