### PR TITLE
Expanding the Public Garden significantly, or: Introducing the Public Leisure Minidome. 

### DIFF
--- a/maps/tether/tether-03-surface3.dmm
+++ b/maps/tether/tether-03-surface3.dmm
@@ -5691,9 +5691,16 @@
 /turf/simulated/floor/tiled/monotile,
 /area/tether/surfacebase/surface_three_hall)
 "aiq" = (
-/obj/machinery/portable_atmospherics/hydroponics/soil,
-/obj/machinery/camera/network/civilian,
-/turf/simulated/floor/grass,
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/machinery/door/firedoor,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
 /area/tether/surfacebase/public_garden_three)
 "air" = (
 /obj/effect/floor_decal/borderfloor{
@@ -5844,12 +5851,13 @@
 /turf/simulated/wall,
 /area/rnd/outpost/xenobiology/outpost_north_airlock)
 "aiF" = (
-/obj/machinery/portable_atmospherics/hydroponics/soil,
-/obj/item/device/radio/intercom{
-	dir = 8;
-	pixel_x = -24
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/machinery/door/firedoor,
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/turf/simulated/floor/grass,
+/turf/simulated/floor/plating,
 /area/tether/surfacebase/public_garden_three)
 "aiG" = (
 /obj/machinery/light,
@@ -17900,42 +17908,18 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/botanystorage)
-"aCY" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/machinery/door/firedoor,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/tether/surfacebase/public_garden_three)
 "aCZ" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/machinery/door/firedoor,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/tether/surfacebase/public_garden_three)
-"aDa" = (
-/obj/machinery/portable_atmospherics/hydroponics/soil,
+/obj/structure/flora/ausbushes/brflowers,
 /turf/simulated/floor/grass,
 /area/tether/surfacebase/public_garden_three)
+"aDa" = (
+/turf/simulated/mineral/floor/cave{
+	name = "dirt"
+	},
+/area/tether/surfacebase/public_garden_three)
 "aDb" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/machinery/door/firedoor,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
+/obj/structure/flora/tree/jungle_small,
+/turf/simulated/floor/grass,
 /area/tether/surfacebase/public_garden_three)
 "aDc" = (
 /obj/structure/grille,
@@ -17947,14 +17931,15 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/structure/table/bench/wooden,
 /turf/simulated/floor/grass,
 /area/tether/surfacebase/public_garden_three)
 "aDe" = (
 /turf/simulated/floor/grass,
 /area/tether/surfacebase/public_garden_three)
 "aDf" = (
-/obj/structure/table/bench/wooden,
+/obj/machinery/light/flamp/noshade{
+	pixel_y = 5
+	},
 /turf/simulated/floor/grass,
 /area/tether/surfacebase/public_garden_three)
 "aDg" = (
@@ -17977,6 +17962,10 @@
 /obj/effect/floor_decal/steeldecal/steel_decals6{
 	dir = 5
 	},
+/obj/machinery/camera/network/civilian{
+	dir = 1;
+	pixel_y = 6
+	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/public_garden_three)
 "aDj" = (
@@ -17995,6 +17984,9 @@
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals6{
 	dir = 6
+	},
+/obj/machinery/light{
+	pixel_y = 6
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/public_garden_three)
@@ -18048,13 +18040,8 @@
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/triage)
 "aDq" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/machinery/door/firedoor,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
+/obj/structure/table/bench/wooden,
+/turf/simulated/floor/grass,
 /area/tether/surfacebase/public_garden_three)
 "aDr" = (
 /obj/effect/floor_decal/borderfloor{
@@ -18099,21 +18086,13 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/public_garden_three)
 "aDw" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_y = 28
-	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/lime/border{
 	dir = 1
 	},
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
+/obj/machinery/vending/hydronutrients,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/public_garden_three)
 "aDx" = (
@@ -18129,11 +18108,8 @@
 /obj/effect/floor_decal/corner/lime/border{
 	dir = 5
 	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
+/obj/machinery/camera/network/tether,
+/obj/machinery/seed_storage/garden,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/public_garden_three)
 "aDy" = (
@@ -18154,21 +18130,13 @@
 /obj/effect/floor_decal/techfloor/hole/right{
 	dir = 8
 	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /turf/simulated/floor/tiled/techmaint,
 /area/tether/surfacebase/public_garden_three)
 "aDz" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/machinery/door/firedoor,
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/structure/bed/chair/wood{
+	dir = 1
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/grass,
 /area/tether/surfacebase/public_garden_three)
 "aDA" = (
 /obj/effect/floor_decal/borderfloor{
@@ -18248,13 +18216,12 @@
 /obj/effect/floor_decal/techfloor{
 	dir = 4
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 28
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/tether/surfacebase/public_garden_three)
 "aDG" = (
@@ -18279,7 +18246,15 @@
 	},
 /obj/structure/cable/green{
 	d1 = 32;
-	icon_state = "32-1"
+	d2 = 2;
+	icon_state = "32-2"
+	},
+/obj/structure/railing,
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/structure/railing{
+	dir = 8
 	},
 /turf/simulated/open,
 /area/tether/surfacebase/public_garden_three)
@@ -18312,8 +18287,7 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/public_garden_three)
 "aDL" = (
-/obj/machinery/portable_atmospherics/hydroponics/soil,
-/obj/machinery/light,
+/obj/machinery/camera/network/civilian,
 /turf/simulated/floor/grass,
 /area/tether/surfacebase/public_garden_three)
 "aDM" = (
@@ -18332,35 +18306,33 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/public_garden_three)
 "aDO" = (
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 25
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/machinery/door/firedoor,
+/obj/structure/window/reinforced{
+	dir = 4
 	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/public_garden_three)
+"aDP" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 6
 	},
 /obj/effect/floor_decal/corner/lime/border{
 	dir = 6
 	},
-/obj/machinery/camera/network/civilian{
-	dir = 1
+/obj/machinery/light{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/tether/surfacebase/public_garden_three)
-"aDP" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/machinery/door/firedoor,
-/obj/structure/window/reinforced,
-/turf/simulated/floor/plating,
 /area/tether/surfacebase/public_garden_three)
 "aDQ" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
 /obj/machinery/door/firedoor,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
 /area/tether/surfacebase/public_garden_three)
@@ -18374,18 +18346,11 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/public_garden_three)
 "aDS" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/machinery/door/firedoor,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced,
-/turf/simulated/floor/plating,
+/obj/structure/bed/chair/wood,
+/turf/simulated/floor/grass,
 /area/tether/surfacebase/public_garden_three)
 "aDT" = (
 /obj/machinery/light,
-/obj/structure/table/bench/wooden,
 /turf/simulated/floor/grass,
 /area/tether/surfacebase/public_garden_three)
 "aDU" = (
@@ -27314,9 +27279,8 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/servicebackroom)
 "aUC" = (
-/obj/effect/floor_decal/borderfloor/corner,
-/obj/effect/floor_decal/corner/lime/bordercorner,
-/turf/simulated/floor/tiled,
+/obj/structure/flora/ausbushes/fernybush,
+/turf/simulated/floor/grass,
 /area/tether/surfacebase/public_garden_three)
 "aUD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -27337,13 +27301,7 @@
 /turf/simulated/floor/tiled/eris/dark/golden,
 /area/shuttle/tourbus/general)
 "aUF" = (
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/lime/border,
-/obj/machinery/seed_storage/garden{
-	dir = 1
-	},
-/obj/machinery/light,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/wood,
 /area/tether/surfacebase/public_garden_three)
 "aUG" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -27400,13 +27358,10 @@
 /area/tether/surfacebase/medical/chemistry)
 "aUM" = (
 /obj/effect/floor_decal/borderfloor{
-	dir = 6
+	dir = 4
 	},
 /obj/effect/floor_decal/corner/lime/border{
-	dir = 6
-	},
-/obj/machinery/vending/hydronutrients{
-	dir = 1
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/public_garden_three)
@@ -27429,6 +27384,12 @@
 "aUO" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 6
+	},
+/obj/structure/cable/green,
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 28
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/tether/surfacebase/public_garden_three)
@@ -27790,19 +27751,8 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_three_hall)
 "aVr" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 10
-	},
-/obj/effect/floor_decal/corner/lime/border{
-	dir = 10
-	},
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 9
-	},
-/obj/effect/floor_decal/corner/lime/bordercorner2{
-	dir = 9
-	},
-/turf/simulated/floor/tiled,
+/obj/structure/table/bench/wooden,
+/turf/simulated/floor/wood,
 /area/tether/surfacebase/public_garden_three)
 "aVs" = (
 /obj/structure/lattice,
@@ -27869,11 +27819,17 @@
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/barrestroom)
 "aVx" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/lime/border{
+	dir = 8
+	},
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = -24
 	},
-/turf/simulated/floor/grass,
+/turf/simulated/floor/tiled,
 /area/tether/surfacebase/public_garden_three)
 "aVy" = (
 /obj/structure/disposalpipe/segment{
@@ -38351,20 +38307,22 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/southhall)
+"eon" = (
+/obj/structure/table/woodentable,
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/public_garden_three)
 "erS" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 6
-	},
-/obj/effect/floor_decal/corner/lime/border{
-	dir = 6
-	},
-/obj/effect/floor_decal/borderfloor/corner2,
-/obj/effect/floor_decal/corner/lime/bordercorner2,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/lime/border{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/public_garden_three)
@@ -38647,12 +38605,22 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_three_hall)
+"fSM" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/grass,
+/area/tether/surfacebase/public_garden_three)
 "gae" = (
 /obj/structure/bed/chair{
 	dir = 4
 	},
 /turf/simulated/floor/carpet/blue,
 /area/tether/surfacebase/security/breakroom)
+"gbE" = (
+/obj/machinery/portable_atmospherics/hydroponics/soil,
+/turf/simulated/floor/grass,
+/area/tether/surfacebase/public_garden_three)
 "geQ" = (
 /obj/machinery/holoposter{
 	pixel_y = -30
@@ -38745,6 +38713,12 @@
 	},
 /turf/simulated/floor/wood,
 /area/tether/surfacebase/security/hos)
+"gxH" = (
+/obj/structure/bed/chair/wood{
+	dir = 4
+	},
+/turf/simulated/floor/grass,
+/area/tether/surfacebase/public_garden_three)
 "gym" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -38954,6 +38928,10 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/lower/third_south)
+"hoR" = (
+/obj/structure/table/woodentable,
+/turf/simulated/floor/grass,
+/area/tether/surfacebase/public_garden_three)
 "hqs" = (
 /obj/effect/floor_decal/techfloor/orange{
 	dir = 1
@@ -39268,6 +39246,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/carpet/blue,
 /area/tether/surfacebase/security/breakroom)
+"iNR" = (
+/obj/structure/flora/rocks1,
+/turf/simulated/floor/grass,
+/area/tether/surfacebase/public_garden_three)
 "iOL" = (
 /obj/machinery/alarm{
 	dir = 1;
@@ -39916,6 +39898,12 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/teleporter/departing)
+"kVD" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/grass,
+/area/tether/surfacebase/public_garden_three)
 "kXo" = (
 /obj/structure/noticeboard{
 	pixel_y = -26
@@ -40186,6 +40174,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/rnd/research/testingrange)
+"lWy" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/simulated/floor/grass,
+/area/tether/surfacebase/public_garden_three)
 "lWE" = (
 /obj/structure/grille,
 /obj/machinery/door/blast/regular{
@@ -40263,6 +40255,18 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/rnd/research/researchdivision)
+"mfv" = (
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 10
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/lime/border{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden_three)
 "mjs" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -40390,6 +40394,15 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/upperhall)
+"mQP" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/machinery/door/firedoor,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/public_garden_three)
 "mUE" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -40463,6 +40476,10 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_three_hall)
+"nfF" = (
+/obj/structure/flora/rocks2,
+/turf/simulated/floor/grass,
+/area/tether/surfacebase/public_garden_three)
 "ngL" = (
 /obj/structure/table/steel,
 /obj/item/weapon/folder/red,
@@ -40494,6 +40511,16 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_three_hall)
+"nlX" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/machinery/door/firedoor,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/public_garden_three)
 "nnY" = (
 /obj/item/device/radio/intercom{
 	dir = 4;
@@ -40897,6 +40924,13 @@
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/recreation_area)
+"oUc" = (
+/obj/structure/flora/ausbushes/ppflowers{
+	pixel_x = 5;
+	pixel_y = -7
+	},
+/turf/simulated/floor/grass,
+/area/tether/surfacebase/public_garden_three)
 "oUI" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -41208,6 +41242,12 @@
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/southhall)
+"pUJ" = (
+/obj/machinery/camera/network/civilian{
+	dir = 9
+	},
+/turf/simulated/floor/outdoors/grass/sif/virgo3b,
+/area/tether/surfacebase/outside/outside3)
 "qbo" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -41250,6 +41290,15 @@
 /obj/structure/lattice,
 /turf/simulated/open,
 /area/tether/surfacebase/surface_three_hall)
+"qhB" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/machinery/door/firedoor,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/public_garden_three)
 "qkf" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -41467,6 +41516,13 @@
 	},
 /turf/simulated/floor/tiled/eris/dark/golden,
 /area/shuttle/tourbus/general)
+"rhH" = (
+/obj/structure/flora/ausbushes/ywflowers{
+	pixel_x = -5;
+	pixel_y = -10
+	},
+/turf/simulated/floor/grass,
+/area/tether/surfacebase/public_garden_three)
 "rnn" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -41619,6 +41675,10 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/briefingroom)
+"rTN" = (
+/obj/machinery/light/flamp/noshade,
+/turf/simulated/floor/grass,
+/area/tether/surfacebase/public_garden_three)
 "rWd" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/orange{
@@ -41733,6 +41793,10 @@
 /obj/structure/foodcart,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
+"suP" = (
+/obj/structure/flora/tree/jungle,
+/turf/simulated/floor/grass,
+/area/tether/surfacebase/public_garden_three)
 "suT" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -41932,10 +41996,7 @@
 /turf/simulated/floor/carpet/blue,
 /area/tether/surfacebase/security/breakroom)
 "sXa" = (
-/obj/machinery/holoposter{
-	pixel_x = -30;
-	pixel_y = 30
-	},
+/obj/structure/flora/bboulder2,
 /turf/simulated/floor/grass,
 /area/tether/surfacebase/public_garden_three)
 "sXR" = (
@@ -42038,6 +42099,10 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/research/researchdivision)
+"twe" = (
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/simulated/floor/grass,
+/area/tether/surfacebase/public_garden_three)
 "txo" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -42226,6 +42291,12 @@
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/pool)
+"ufz" = (
+/obj/structure/bed/chair/wood{
+	dir = 8
+	},
+/turf/simulated/floor/grass,
+/area/tether/surfacebase/public_garden_three)
 "uhm" = (
 /obj/structure/bed/chair/bay/chair{
 	dir = 8
@@ -42311,6 +42382,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/lobby)
+"uCd" = (
+/obj/machinery/camera/network/civilian{
+	dir = 1
+	},
+/turf/simulated/floor/grass,
+/area/tether/surfacebase/public_garden_three)
 "uFI" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -46674,8 +46751,8 @@ aab
 aab
 aab
 aab
-aab
-aab
+aMG
+aMG
 aac
 aac
 aac
@@ -46814,10 +46891,10 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
+aMG
+aNU
+adG
+adG
 aac
 aac
 aac
@@ -46955,9 +47032,9 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
+aNU
+adG
+adG
 aac
 aac
 aac
@@ -47096,8 +47173,8 @@ aab
 aab
 aab
 aab
-aab
-aab
+aNU
+adG
 aac
 aac
 aac
@@ -47112,7 +47189,7 @@ aac
 aac
 aac
 aac
-aac
+pUJ
 aac
 aac
 aac
@@ -47237,25 +47314,25 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
+aNU
+adG
 aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
+aiq
+qhB
+arW
+qhB
+qhB
+qhB
+qhB
+qhB
+arW
+qhB
+qhB
+qhB
+qhB
+qhB
+arW
+nlX
 aac
 aac
 aac
@@ -47378,27 +47455,27 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
+aNU
+adG
 aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
+aiq
+aDc
+uCd
+arW
+aDe
+aDe
+aDe
+aDe
+uCd
+arW
+aDe
+aDe
+aDe
+aDe
+uCd
+arW
+aDc
+nlX
 aac
 aac
 aac
@@ -47519,29 +47596,29 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
+aNU
+adG
 aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
+aiq
+aDc
+aDe
+lWy
+kVD
+aDe
+gbE
+gbE
+gbE
+aDe
+kVD
+aDe
+gbE
+gbE
+gbE
+aDe
+kVD
+lWy
+aDc
+nlX
 aac
 aac
 aac
@@ -47660,31 +47737,31 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aab
+aOm
+adG
 aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
+aiq
+aDc
+aDe
+aDe
+aDe
+aDe
+aDe
+aDe
+aDe
+aDe
+gbE
+gbE
+gbE
+aDe
+aDe
+aDe
+aDe
+aDe
+aDe
+aDe
+aDc
+nlX
 aac
 aac
 aac
@@ -47802,31 +47879,31 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
+aOm
+adG
 aac
 arW
-aDq
-aDq
-aDq
-aDq
 arW
-aac
-aac
-aac
+aUC
+aDe
+aDe
+aDe
+aDe
+twe
+aDe
+aDe
+aDe
+aDe
+aDe
+aDe
+aDe
+aDq
+aDq
+aDe
+aDe
+aDe
+aDe
+aDQ
 aac
 aac
 aac
@@ -47944,31 +48021,31 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
+aOm
+adG
 aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aCZ
-arW
-aDa
-aDa
-aDa
-aDL
-arW
+aiF
+aDe
+aDe
+aDe
+aDe
+aDe
+aDe
+aDe
+aDe
+aDq
+aDe
+aDe
+aDe
+aDe
+aDe
+aDe
+suP
+aDe
+aDe
+aDe
+aDe
 aDQ
-aac
-aac
 aac
 aac
 aac
@@ -48086,31 +48163,31 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
+aOm
+adG
 aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aCZ
-aDc
-aiq
-sXa
-aDe
-aDe
-aDe
 aiF
-aDc
+aCZ
+aUF
+sXa
+aVr
+aDe
+aDe
+aDe
+aDe
+aDq
+aDe
+aDe
+aDe
+aDe
+aDe
+aDe
+lWy
+aDe
+aDe
+aDe
+aDe
 aDQ
-aac
 aac
 aac
 aac
@@ -48228,30 +48305,30 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
+aOm
+adG
 aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
+aiF
+aDd
+aVr
+eon
+aVr
+aDe
+aDe
+aDb
+aDe
+aDq
+aDe
 aCZ
-aDc
-aDf
+aDe
 aDe
 aDj
 aDr
 aDr
 aDA
 aDe
-aDf
-aDc
+aDe
+aDe
 aDQ
 aac
 aac
@@ -48370,21 +48447,21 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
+aOm
+adG
 aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-arW
-arW
-aDd
+aiF
+aDe
+aVr
+eon
+aVr
+rTN
+aDe
+iNR
+rTN
+aDe
+aUC
+aDe
 aDf
 aDj
 ajt
@@ -48392,7 +48469,7 @@ aDu
 aDu
 aDR
 aDA
-aDf
+aDe
 aDT
 arW
 arW
@@ -48512,21 +48589,21 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
+aOm
+adG
 aac
-aac
-aac
-aac
-aac
-aac
-aac
-aCY
-aDa
+aiF
 aDe
+aVr
+eon
+aVr
+aDa
+aDa
+aDa
+aDa
+aDa
+aDa
+aDa
 aDj
 ajt
 aDg
@@ -48534,8 +48611,8 @@ aDB
 aDG
 aDg
 aDR
-aVr
-aDe
+aDr
+aDr
 aVx
 aDc
 aip
@@ -48654,21 +48731,21 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
+aOm
+adG
 aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aCY
-aDe
-aDe
+aiF
+aDL
+aVr
+aUF
+aUF
+aDa
+aDa
+aDa
+aDa
+aDa
+aDa
+aDa
 aDn
 aju
 aDi
@@ -48796,21 +48873,21 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
+aOm
+adG
 aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aCY
-aDa
+aiF
 aDe
+aVr
+eon
+aVr
+aDa
+aDa
+aDa
+aDa
+aDa
+aDa
+aDa
 aDh
 akm
 aDk
@@ -48819,8 +48896,8 @@ aDs
 aUz
 hxc
 erS
-aDe
-aDe
+mfv
+mfv
 aDc
 aVA
 sDG
@@ -48938,21 +49015,21 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
+aOm
+adG
 aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-arW
-arW
-aDd
+aiF
+aDe
+aVr
+eon
+aVr
+rTN
+aCZ
+aDe
+rTN
+aDe
+nfF
+aDe
 aDf
 aDm
 aDl
@@ -48960,9 +49037,9 @@ aDt
 rEZ
 dgA
 cwI
-aDf
+oUc
+gxH
 aDT
-arW
 arW
 aVE
 aWF
@@ -49080,30 +49157,30 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
-aab
+aOm
+adG
 aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
+aiF
+aDd
+aVr
+eon
+aVr
+aDe
+aDe
+aDq
+aDe
+aDe
 aDb
-aDc
-aDf
+aDe
+aDe
 aDn
 aDg
 aDu
 aDD
 aDg
 aDN
-aDf
-aDc
+aDS
+hoR
 aDz
 agw
 air
@@ -49222,31 +49299,31 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
+aOm
+adG
 aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aDb
-aDc
+aiF
+aDe
+aUF
+aDe
+aVr
+aDe
+aDe
+aDq
+aDe
+aDe
+aDe
+aDe
+aDe
 acm
 aDv
 aDg
 aDJ
-aUC
-aDO
-aDc
+aDg
+aDN
 aDS
-aac
+hoR
+aDz
 agw
 air
 aWF
@@ -49364,31 +49441,31 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
-aab
+aOm
+adG
 aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aDb
+aiF
+aDe
+aDe
+aDe
+suP
+aDe
+aDe
+aDq
+lWy
+aDe
+aDe
+twe
+aDe
 arW
 aDw
 aDg
 aDJ
-aUF
-arW
+aDg
+aDN
 aDS
-aac
-aac
+hoR
+aDz
 agw
 air
 aWF
@@ -49506,31 +49583,31 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
+aOm
+adG
 aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aCY
+arW
+arW
+aDe
+aCZ
+aDe
+aDe
+aDe
+aDe
+aDe
+aDe
+aDe
+aDe
+aDe
+arW
 aDx
 aDE
 aDK
 aUM
 aDP
-aac
-aac
-aac
+rhH
+ufz
+aDe
 agw
 aVG
 aWF
@@ -49648,29 +49725,29 @@ aab
 aab
 aab
 aab
-aab
-aab
-aab
+aOm
+adG
 aac
 aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aCY
+aDO
+aDc
+fSM
+aDe
+gbE
+gbE
+aDe
+fSM
+aDe
+gbE
+gbE
+aDe
+arW
 aDy
 aDF
 aDH
 aUO
-aDP
-aac
+arW
+mQP
 agw
 agw
 agw
@@ -49790,27 +49867,27 @@ aab
 aab
 aab
 aab
-aab
-aab
+aOm
+adG
 aac
 aac
 aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
+aDO
 arW
-aDz
-aDz
-aDz
-aDz
+aDL
+aDe
+aDe
+aUC
+arW
+aDL
+aDe
+aDe
+aDe
+arW
+arW
+arW
+arW
+arW
 arW
 aac
 agw
@@ -49933,22 +50010,22 @@ aab
 aab
 aab
 aab
-aab
+aNM
 aac
 aac
 aac
 aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
-aac
+arW
+mQP
+mQP
+mQP
+mQP
+arW
+mQP
+mQP
+mQP
+mQP
+arW
 aac
 aac
 aac


### PR DESCRIPTION
### **Disappointed by how depressingly enclosed the Public Garden is and _still_ seeing people reminisce about the April Fool's map with its wide open spaces, grass, trees, et cetera, I decided to take it upon myself to do something about it.**

Thus, the Expanded Public Garden. At roughly four times the area of the original, it includes revolutionary concepts such as:
- Grass you can actually lie down on without breaking into Hydroponics or rolling in farming soil.
- A number of benches, tables, and chairs for relaxing at or perhaps bringing some food for a picnic.
- An assortment of colorful flowers, bushes, and healthy green foliage in general to provide a relaxing environment instead of only ever seeing the sadness that is Virgo 3b's flora.
- +5 soil patches (13 total), rearranged to better follow the structure changes. One main line along the left and two pairs on the right.
- Exterior surface tiles reworked and catwalks/railings added to maintain the ability to navigate outside safely.
- All z-level transitions unaffected. Stairs and the gas/power lattice on the right remain untouched to preserve compatibility with the Surface 2 z-level.

**Current Public Garden**
![](https://cdn.discordapp.com/attachments/187013248309002240/836481629945462815/unknown.png)

**Expanded Public Garden**
![](https://cdn.discordapp.com/attachments/187013248309002240/836481378773762069/unknown.png)
