### PR TITLE
Removes access loss on ID contamination/digestion.

### DIFF
--- a/code/game/machinery/computer/card.dm
+++ b/code/game/machinery/computer/card.dm
@@ -200,7 +200,6 @@
 					modify.access -= access_type
 					if(!access_allowed)
 						modify.access += access_type
-				modify.lost_access = list()	//VOREStation addition: reset the lost access upon any modifications
 			. = TRUE
 
 		if("assign")
@@ -225,7 +224,6 @@
 					modify.access = access
 					modify.assignment = t1
 					modify.rank = t1
-					modify.lost_access = list()	//VOREStation addition: reset the lost access upon any modifications
 
 				callHook("reassign_employee", list(modify))
 			. = TRUE
@@ -283,7 +281,6 @@
 			if(is_authenticated())
 				modify.assignment = "Dismissed"	//VOREStation Edit: setting adjustment
 				modify.access = list()
-				modify.lost_access = list()	//VOREStation addition: reset the lost access upon any modifications
 
 				callHook("terminate_employee", list(modify))
 

--- a/code/game/machinery/computer/id_restorer_vr.dm
+++ b/code/game/machinery/computer/id_restorer_vr.dm
@@ -17,6 +17,7 @@
 	var/obj/item/weapon/card/id/inserted
 
 /obj/machinery/computer/id_restorer/attackby(obj/I, mob/user)
+	/*
 	if(istype(I, /obj/item/weapon/card/id) && !(istype(I,/obj/item/weapon/card/id/guest)))
 		if(!inserted && user.unEquip(I))
 			I.forceMove(src)
@@ -24,12 +25,14 @@
 		else if(inserted)
 			to_chat(user, "<span class='warning'>There is already ID card inside.</span>")
 		return
+	*/
 	..()
 
 /obj/machinery/computer/id_restorer/attack_hand(mob/user)
 	if(..()) return
 	if(stat & (NOPOWER|BROKEN)) return
 
+	/*
 	if(!inserted) // No point in giving you an option what to do if there's no ID to do things with.
 		to_chat(user, "<span class='notice'>No ID is inserted.</span>")
 		return
@@ -78,6 +81,7 @@
 			return
 		if("Cancel")
 			return
+	*/
 
 
 //Frame

--- a/code/modules/vore/eating/contaminate_vr.dm
+++ b/code/modules/vore/eating/contaminate_vr.dm
@@ -96,7 +96,7 @@ var/list/gurgled_overlays = list(
 // Special handling of gurgle_contaminate
 //////////////
 /obj/item/weapon/card/id/gurgle_contaminate(var/atom/movable/item_storage = null)
-	digest_act(item_storage) //Digesting these anyway
+	digest_act(item_storage) //Contamination and digestion does same thing to these
 	return TRUE
 
 /obj/item/device/pda/gurgle_contaminate(var/atom/movable/item_storage = null)

--- a/code/modules/vore/eating/digest_act_vr.dm
+++ b/code/modules/vore/eating/digest_act_vr.dm
@@ -55,8 +55,6 @@
 /////////////
 /obj/item/weapon/hand_tele/digest_act(var/atom/movable/item_storage = null)
 	return FALSE
-/obj/item/weapon/card/id/gold/captain/spare/digest_act(var/atom/movable/item_storage = null)
-	return FALSE
 /obj/item/device/aicard/digest_act(var/atom/movable/item_storage = null)
 	return FALSE
 /obj/item/device/paicard/digest_act(var/atom/movable/item_storage = null)
@@ -78,20 +76,14 @@
 // Some special treatment
 /////////////
 
-/obj/item/weapon/card/id
-	var/lost_access = list()
-
 /obj/item/weapon/card/id/digest_act(atom/movable/item_storage = null)
-	desc = "A partially digested card that has seen better days. The damage appears to be only cosmetic, but the access codes need to be reprogrammed at the HoP office or ID restoration terminal."
+	desc = "A partially digested card that has seen better days. The damage appears to be only cosmetic."
 	if(!sprite_stack || !istype(sprite_stack) || !(sprite_stack.len))
 		icon = 'icons/obj/card_vr.dmi'
 		icon_state = "[initial(icon_state)]_digested"
 	else
 		sprite_stack += "digested"
 	update_icon()
-	if(!(LAZYLEN(lost_access)) && LAZYLEN(access))
-		lost_access = access	//Do not forget what access we lose
-	access = list()			// Then lose it
 	return FALSE
 
 /obj/item/weapon/reagent_containers/food/digest_act(atom/movable/item_storage = null)


### PR DESCRIPTION
More proposal than anything. Does what it says, IDs no longer lose their access on digest_act or contaminate_act. They still change appearance to scuffed and half-digested. Honestly, I still don't know why it was a good idea in the first place. Especially with how many workarounds had to be added around that anyway, to the point where it's very rare to see it even get contaminated in the first place, but is very annoying when it does.

ID restoration consoles are NOT removed with this to avoid conflicting with existing mapping PRs, but are reduced to basically decor pieces. If this PR is accepted, then once map stuff is resolved, ID restorers will be removed as separate action.