### PR TITLE
Makes soulcatcher a pre-installed software

### DIFF
--- a/code/modules/nifsoft/nif.dm
+++ b/code/modules/nifsoft/nif.dm
@@ -88,8 +88,9 @@ You can also set the stat of a NIF to NIF_TEMPFAIL without any issues to disable
 				qdel(src)
 			return FALSE
 		else
-			//Free commlink for return customers
+			//Free commlink and soulcatcher for return customers
 			new /datum/nifsoft/commlink(src)
+			new /datum/nifsoft/soulcatcher(src)
 
 	//Free civilian AR included
 	new /datum/nifsoft/ar_civ(src)

--- a/code/modules/nifsoft/software/13_soulcatcher.dm
+++ b/code/modules/nifsoft/software/13_soulcatcher.dm
@@ -14,10 +14,10 @@
 	desc = "A mind storage and processing system capable of capturing and supporting human-level minds in a small VR space."
 	list_pos = NIF_SOULCATCHER
 	cost = 100 //If I wanna trap people's minds and lood them, then by god I'll do so.
-	wear = 1
+	wear = 0
 	p_drain = 0.01
 
-	var/setting_flags = (NIF_SC_CATCHING_OTHERS|NIF_SC_ALLOW_EARS|NIF_SC_ALLOW_EYES|NIF_SC_BACKUPS|NIF_SC_PROJECTING)
+	var/setting_flags = (NIF_SC_ALLOW_EARS|NIF_SC_ALLOW_EYES|NIF_SC_BACKUPS|NIF_SC_PROJECTING)
 	var/list/brainmobs = list()
 	var/inside_flavor = "A small completely white room with a couch, and a window to what seems to be the outside world. A small sign in the corner says 'Configure Me'."
 


### PR DESCRIPTION
Title. NIFs loaded from savefiles will have soulcatchers included same way as commlink. Newly installed ones still won't, also same way as commlink.

Also makes soulcatchers NOT catch prey by default to counteract accidents that could be brought upon with this change. Now both catching self AND catching prey needs to be turned on if you want to do that. Other settings have same defaults.