### PR TITLE
Reduces cost of Sci and Eng AR programs.

### DIFF
--- a/code/modules/nifsoft/software/01_vision.dm
+++ b/code/modules/nifsoft/software/01_vision.dm
@@ -34,9 +34,9 @@
 
 /datum/nifsoft/ar_eng
 	name = "AR Overlay (Eng)"
-	desc = "Like the civilian model, but provides station alert notices."
+	desc = "Like the civilian model, but provides ... well, nothing. For now."
 	list_pos = NIF_ENGINE_AR
-	cost = 375
+	cost = 250
 	access = access_engine
 	a_drain = 0.01
 	planes_enabled = list(VIS_CH_ID,VIS_CH_HEALTH_VR,VIS_AUGMENTED)
@@ -47,7 +47,7 @@
 	name = "AR Overlay (Sci)"
 	desc = "Like the civilian model, but provides ... well, nothing. For now."
 	list_pos = NIF_SCIENCE_AR
-	cost = 375
+	cost = 250
 	access = access_research
 	a_drain = 0.01
 	planes_enabled = list(VIS_CH_ID,VIS_CH_HEALTH_VR,VIS_AUGMENTED)


### PR DESCRIPTION
Title. They are practically no different from Civilian AR bar the name. Shouldn't cost any more than that either then. Also adjusts otherwise misleading description of engineering AR, as it does NOT in fact provide the alerts (need separate program for that).