### PR TITLE
Slightly raises nutrition cap to fix a vr feature

### DIFF
--- a/code/__defines/mobs.dm
+++ b/code/__defines/mobs.dm
@@ -437,7 +437,7 @@
 #define EXAMINE_SKIPLEGS			0x0080
 #define EXAMINE_SKIPFEET			0x0100
 
-#define MAX_NUTRITION	5000 //VOREStation Edit
+#define MAX_NUTRITION	6000 //VOREStation Edit
 
 #define FAKE_INVIS_ALPHA_THRESHOLD 127 // If something's alpha var is at or below this number, certain things will pretend it is invisible.
 


### PR DESCRIPTION
Raises nutrition cap just enough to make the vorestation feeding fullness system work properly again.
https://github.com/VOREStation/VOREStation/blob/master/code/modules/food/food/snacks.dm#L79

Fixes food giving infinite amount of empty 0-reagent bites instead of hitting the cap and stopping the empty bites before they happen.