### PR TITLE
Implement planetary solar behavior

### DIFF
--- a/code/modules/planet/planet.dm
+++ b/code/modules/planet/planet.dm
@@ -67,3 +67,7 @@
 	sun["color"] = new_color
 	needs_work |= PLANET_PROCESS_SUN
 
+/datum/planet/proc/get_sun_angle()
+	var/relatime = current_time.hours_until_noon()
+	var/pm = (relatime <= 0)
+	return (180 + sun_position * (pm ? 180 : -180))

--- a/code/modules/planet/time.dm
+++ b/code/modules/planet/time.dm
@@ -42,6 +42,27 @@
 /datum/time/proc/make_random_time()
 	return new type(rand(0, seconds_in_day - 1))
 
+// 'day' as in not hours since the epoch
+/datum/time/proc/get_day_hour()
+	var/day_seconds = seconds_stored % seconds_in_day
+	return FLOOR(day_seconds / seconds_in_hour, 1)
+
+/datum/time/proc/get_day_minute()
+	var/day_seconds = seconds_stored % seconds_in_day
+	return day_seconds % seconds_in_hour
+
+/datum/time/proc/get_day_second()
+	var/day_seconds = seconds_stored % seconds_in_day
+	return day_seconds % seconds_in_minute
+
+// negative return values mean noon is behind you
+/datum/time/proc/hours_until_noon()
+	var/day_seconds = seconds_stored % seconds_in_day
+	var/day_hour = day_seconds / seconds_in_hour
+	var/midday = (seconds_in_day / seconds_in_hour) / 2
+
+	return (midday - day_hour)
+
 // This works almost exactly like time2text.
 // The advantage of this is that it can handle time systems beyond 24h.
 // The downside is a lack of date capability.

--- a/code/modules/power/tracker.dm
+++ b/code/modules/power/tracker.dm
@@ -49,6 +49,12 @@
 	if(powernet && (powernet == control.powernet)) //update if we're still in the same powernet
 		control.cdir = angle
 
+/obj/machinery/power/tracker/proc/set_angle_to_sun()
+	var/sun_angle = get_sun_angle()
+	if(isnull(sun_angle))
+		log_error("Solar tracker can't find sun angle")
+	set_angle(sun_angle)
+
 /obj/machinery/power/tracker/attackby(var/obj/item/weapon/W, var/mob/user)
 
 	if(W.is_crowbar())
@@ -65,6 +71,17 @@
 			qdel(src)
 		return
 	..()
+
+/obj/machinery/power/tracker/proc/get_sun_angle()
+	var/datum/planet/P = SSplanets.z_to_planet[z]
+	if(P)
+		return P.get_sun_angle()
+	else if(SSsun?.sun)
+		return SSsun.sun.angle
+
+	return null
+
+
 
 // Tracker Electronic
 


### PR DESCRIPTION
Adds logic for solar panels on planets to behave differently (not using SSsun).

They base their power on the angle to the sun. I can't make the panels aim 'up' and tilt in a cool manner (assuming you're always on the equator and the sun passes overhead), so instead 'north' is where the sun is at noon, and all the 'south' angles (from 90 to 270, assuming 0 is north) are where it is on the other side of the planet. So day is from 270 to 90 basically, with noon being 0/360.

Sun brightness affects power output, so this means on v3b you get slightly sub-optimal power output since it's a bit darker than somewhere like v4, which will produce more power with solars. Bonus points if you figure out a way to build an array on v4 and mail the power back to the station.

Weather also affects solar output, so when overcast and whatnot it's decreased. I don't know if there's weather that makes the sun BRIGHTER but that would also work.

The goal would be to have the power output of the v3b solars produce the same amount of power on average after this PR as they do before, so it will require some tweaking to numbers and testing, and probably mapping in some extra panels since I suspect there will be too few to keep the same power output.