### PR TITLE
Adds Jams Sensors belly mode addon

### DIFF
--- a/code/__defines/belly_modes_vr.dm
+++ b/code/__defines/belly_modes_vr.dm
@@ -20,6 +20,7 @@
 #define DM_FLAG_LEAVEREMAINS	0x4
 #define DM_FLAG_THICKBELLY		0x8
 #define DM_FLAG_AFFECTWORN		0x10
+#define DM_FLAG_JAMSENSORS		0x20
 
 //Item related modes
 #define IM_HOLD									"Hold"

--- a/code/datums/repositories/crew.dm
+++ b/code/datums/repositories/crew.dm
@@ -25,7 +25,7 @@ var/global/datum/repository/crew/crew_repository = new()
 	for(var/obj/item/clothing/under/C in tracked)
 		var/turf/pos = get_turf(C)
 		var/area/B = pos?.loc //VOREStation Add: No sensor in Dorm
-		if((C.has_sensor) && (pos?.z == zLevel) && (C.sensor_mode != SUIT_SENSOR_OFF) && !(B.block_suit_sensors) && !(is_jammed(C))) //VOREStation Edit
+		if((C.has_sensor) && (pos?.z == zLevel) && (C.sensor_mode != SUIT_SENSOR_OFF) && !(B.block_suit_sensors) && !(is_jammed(C)) && !(is_vore_jammed(C))) //VOREStation Edit
 			if(istype(C.loc, /mob/living/carbon/human))
 				var/mob/living/carbon/human/H = C.loc
 				if(H.w_uniform != C)

--- a/code/game/objects/items/devices/radio/jammer.dm
+++ b/code/game/objects/items/devices/radio/jammer.dm
@@ -13,11 +13,6 @@ var/global/list/active_radio_jammers = list()
 			if(dist <= J.jam_range)
 				return list("jammer" = J, "distance" = dist)
 
-	//VOREStation Addition Start
-	if(is_vore_jammed(radio))
-		return TRUE
-	//VOREStation Addition End
-
 /obj/item/device/radio_jammer
 	name = "subspace jammer"
 	desc = "Primarily for blocking subspace communications, preventing the use of headsets, PDAs, and communicators. Also masks suit sensors."	// Added suit sensor jamming

--- a/code/game/objects/items/devices/radio/jammer.dm
+++ b/code/game/objects/items/devices/radio/jammer.dm
@@ -13,6 +13,11 @@ var/global/list/active_radio_jammers = list()
 			if(dist <= J.jam_range)
 				return list("jammer" = J, "distance" = dist)
 
+	//VOREStation Addition Start
+	if(is_vore_jammed(radio))
+		return TRUE
+	//VOREStation Addition End
+
 /obj/item/device/radio_jammer
 	name = "subspace jammer"
 	desc = "Primarily for blocking subspace communications, preventing the use of headsets, PDAs, and communicators. Also masks suit sensors."	// Added suit sensor jamming

--- a/code/game/objects/items/devices/radio/jammer_vr.dm
+++ b/code/game/objects/items/devices/radio/jammer_vr.dm
@@ -2,3 +2,14 @@
 /obj/item/device/radio_jammer/admin
 	jam_range = 255
 	tick_cost = 0
+
+/proc/is_vore_jammed(var/obj/radio)
+	var/atom/current = radio
+	while(current.loc)
+		if(isbelly(current.loc))
+			var/obj/belly/B = current.loc
+			if((istype(current, /obj/item/clothing/under)) && (B.mode_flags & DM_FLAG_JAMSENSORS))
+				return TRUE
+		current = current.loc
+
+ 	return FALSE

--- a/code/game/objects/items/devices/radio/jammer_vr.dm
+++ b/code/game/objects/items/devices/radio/jammer_vr.dm
@@ -8,7 +8,7 @@
 	while(current.loc)
 		if(isbelly(current.loc))
 			var/obj/belly/B = current.loc
-			if((istype(current, /obj/item/clothing/under)) && (B.mode_flags & DM_FLAG_JAMSENSORS))
+			if(B.mode_flags & DM_FLAG_JAMSENSORS)
 				return TRUE
 		current = current.loc
 

--- a/code/modules/vore/eating/belly_obj_vr.dm
+++ b/code/modules/vore/eating/belly_obj_vr.dm
@@ -50,7 +50,7 @@
 	//Actual full digest modes
 	var/tmp/static/list/digest_modes = list(DM_HOLD,DM_DIGEST,DM_ABSORB,DM_DRAIN,DM_UNABSORB,DM_HEAL,DM_SHRINK,DM_GROW,DM_SIZE_STEAL,DM_EGG)
 	//Digest mode addon flags
-	var/tmp/static/list/mode_flag_list = list("Numbing" = DM_FLAG_NUMBING, "Stripping" = DM_FLAG_STRIPPING, "Leave Remains" = DM_FLAG_LEAVEREMAINS, "Muffles" = DM_FLAG_THICKBELLY, "Affect Worn Items" = DM_FLAG_AFFECTWORN)
+	var/tmp/static/list/mode_flag_list = list("Numbing" = DM_FLAG_NUMBING, "Stripping" = DM_FLAG_STRIPPING, "Leave Remains" = DM_FLAG_LEAVEREMAINS, "Muffles" = DM_FLAG_THICKBELLY, "Affect Worn Items" = DM_FLAG_AFFECTWORN, "Jams Sensors" = DM_FLAG_JAMSENSORS)
 	//Item related modes
 	var/tmp/static/list/item_digest_modes = list(IM_HOLD,IM_DIGEST_FOOD,IM_DIGEST)
 


### PR DESCRIPTION
Off by default, mostly due to how belly mode addons work.

Jams the sensors of prey, preventing them from appearing on sensors monitoring consoles. Also, jams prey's prey's sensors, and prey's prey's prey's sensors... Basically, if pred has jamming tummy, everyone inside, no matter how many layers deep, will also be jammed.