### PR TITLE
Add phoron and nitrogen breather traits, and water breather trait

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/blank_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/blank_vr.dm
@@ -80,6 +80,3 @@
 			H.internal = H.r_hand
 			if(istype(H.internal,/obj/item/weapon/tank) && H.internals)
 				H.internals.icon_state = "internal1"
-
-	for(var/datum/trait/T in traits)
-		T.equip_survival_gear(H)

--- a/code/modules/mob/living/carbon/human/species/station/blank_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/blank_vr.dm
@@ -56,7 +56,8 @@
 //Called when face-down in the water or otherwise over their head.
 // Return: TRUE for able to breathe fine in water.
 /datum/species/custom/can_breathe_water()
-	return ..()
+	return /datum/trait/positive/water_breather in traits
+
 
 //Called during handle_environment in Life() ticks.
 // Return: Not used.
@@ -64,22 +65,21 @@
 	return ..()
 
 //Called when spawning to equip them with special things.
-/datum/species/custom/equip_survival_gear(var/mob/living/carbon/human/H)
-	/* Example, from Vox:
-	H.equip_to_slot_or_del(new /obj/item/clothing/mask/breath(H), slot_wear_mask)
-	if(H.backbag == 1)
-		H.equip_to_slot_or_del(new /obj/item/weapon/tank/vox(H), slot_back)
-		H.equip_to_slot_or_del(new /obj/item/weapon/storage/box/vox(H), slot_r_hand)
-		H.internal = H.back
-	else
-		H.equip_to_slot_or_del(new /obj/item/weapon/tank/vox(H), slot_r_hand)
-		H.equip_to_slot_or_del(new /obj/item/weapon/storage/box/vox(H.back), slot_in_backpack)
-		H.internal = H.r_hand
-	H.internal = locate(/obj/item/weapon/tank) in H.contents
-	if(istype(H.internal,/obj/item/weapon/tank) && H.internals)
-		H.internals.icon_state = "internal1"
-	*/
-	return ..()
+/datum/species/custom/equip_survival_gear(var/mob/living/carbon/human/H, var/extendedtank = 0, var/comprehensive = 0)
+	. = ..()
+	if(breath_type != "oxygen")
+		H.equip_to_slot_or_del(new /obj/item/clothing/mask/breath(H), slot_wear_mask)
+		var/obj/item/weapon/tank/tankpath
+		if(breath_type == "phoron")
+			tankpath = /obj/item/weapon/tank/vox
+		else
+			tankpath = text2path("/obj/item/weapon/tank/" + breath_type)
 
-/datum/species/custom/can_breathe_water()
-	return /datum/trait/positive/water_breather in traits
+		if(tankpath)
+			H.equip_to_slot_or_del(new tankpath(H), slot_r_hand)
+			H.internal = H.r_hand
+			if(istype(H.internal,/obj/item/weapon/tank) && H.internals)
+				H.internals.icon_state = "internal1"
+
+	for(var/datum/trait/T in traits)
+		T.equip_survival_gear(H)

--- a/code/modules/mob/living/carbon/human/species/station/blank_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/blank_vr.dm
@@ -80,3 +80,6 @@
 		H.internals.icon_state = "internal1"
 	*/
 	return ..()
+
+/datum/species/custom/can_breathe_water()
+	return /datum/trait/positive/water_breather in traits

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/negative.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/negative.dm
@@ -119,10 +119,40 @@
 	desc = "Your light weight and poor balance make you very susceptible to unhelpful bumping. Think of it like a bowling ball versus a pin."
 	cost = -2
 	var_changes = list("lightweight" = 1)
-	
+
 /datum/trait/negative/neural_hypersensitivity
 	name = "Neural Hypersensitivity"
 	desc = "Your nerves are particularly sensitive to physical changes, leading to experiencing twice the intensity of pain and pleasure alike. Doubles traumatic shock."
 	cost = -1
 	var_changes = list("trauma_mod" = 2)
 	can_take = ORGANICS
+
+/datum/trait/negative/breathes
+	var/tank = /obj/item/weapon/tank/air
+
+/datum/trait/negative/breathes/apply(var/datum/species/S,var/mob/living/carbon/human/H)
+	. = ..()
+	H.equip_to_slot_or_del(new /obj/item/clothing/mask/breath(H), slot_wear_mask)
+	if(H.backbag == 1)
+		H.equip_to_slot_or_del(new tank(H), slot_back)
+		H.internal = H.back
+	else
+		H.equip_to_slot_or_del(new tank(H), slot_r_hand)
+		H.internal = H.r_hand
+	H.internal = locate(/obj/item/weapon/tank) in H.contents
+	if(istype(H.internal,/obj/item/weapon/tank) && H.internals)
+		H.internals.icon_state = "internal1"
+
+/datum/trait/negative/breathes/phoron
+	name = "Phoron Breather"
+	desc = "You breathe phoron instead of oxygen (which is poisonous to you), much like a Vox."
+	cost = -2
+	var_changes = list("breath_type" = "phoron", "poison_type" = "oxygen")
+	tank = /obj/item/weapon/tank/vox
+
+/datum/trait/negative/breathes/nitrogen
+	name = "Nitrogen Breather"
+	desc = "You breathe nitrogen instead of oxygen (which is poisonous to you). Incidentally, phoron isn't poisonous to breathe to you."
+	cost = -2
+	var_changes = list("breath_type" = "nitrogen", "poison_type" = "oxygen")
+	tank = /obj/item/weapon/tank/nitrogen

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/negative.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/negative.dm
@@ -128,31 +128,15 @@
 	can_take = ORGANICS
 
 /datum/trait/negative/breathes
-	var/tank = /obj/item/weapon/tank/air
-
-/datum/trait/negative/breathes/apply(var/datum/species/S,var/mob/living/carbon/human/H)
-	. = ..()
-	H.equip_to_slot_or_del(new /obj/item/clothing/mask/breath(H), slot_wear_mask)
-	if(H.backbag == 1)
-		H.equip_to_slot_or_del(new tank(H), slot_back)
-		H.internal = H.back
-	else
-		H.equip_to_slot_or_del(new tank(H), slot_r_hand)
-		H.internal = H.r_hand
-	H.internal = locate(/obj/item/weapon/tank) in H.contents
-	if(istype(H.internal,/obj/item/weapon/tank) && H.internals)
-		H.internals.icon_state = "internal1"
+	cost = -2
+	can_take = ORGANICS
 
 /datum/trait/negative/breathes/phoron
 	name = "Phoron Breather"
 	desc = "You breathe phoron instead of oxygen (which is poisonous to you), much like a Vox."
-	cost = -2
 	var_changes = list("breath_type" = "phoron", "poison_type" = "oxygen")
-	tank = /obj/item/weapon/tank/vox
 
 /datum/trait/negative/breathes/nitrogen
 	name = "Nitrogen Breather"
 	desc = "You breathe nitrogen instead of oxygen (which is poisonous to you). Incidentally, phoron isn't poisonous to breathe to you."
-	cost = -2
 	var_changes = list("breath_type" = "nitrogen", "poison_type" = "oxygen")
-	tank = /obj/item/weapon/tank/nitrogen

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/positive.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/positive.dm
@@ -156,3 +156,8 @@
 	H.verbs |= /mob/living/carbon/human/proc/weave_structure
 	H.verbs |= /mob/living/carbon/human/proc/weave_item
 	H.verbs |= /mob/living/carbon/human/proc/set_silk_color
+
+/datum/trait/positive/water_breather
+	name = "Water Breather"
+	desc = "You can breathe underwater."
+	cost = 1

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/positive.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/positive.dm
@@ -159,5 +159,5 @@
 
 /datum/trait/positive/water_breather
 	name = "Water Breather"
-	desc = "You can breathe underwater."
+	desc = "You can breathe under water."
 	cost = 1

--- a/code/modules/resleeving/infocore_records.dm
+++ b/code/modules/resleeving/infocore_records.dm
@@ -84,6 +84,7 @@
 	var/sizemult
 	var/weight
 	var/aflags
+	var/breath_type = "oxygen"
 
 /datum/transhuman/body_record/New(var/copyfrom, var/add_to_db = 0, var/ckeylock = 0)
 	..()
@@ -120,6 +121,7 @@
 	sizemult = M.size_multiplier
 	weight = M.weight
 	aflags = M.appearance_flags
+	breath_type = M.species.breath_type
 
 	//Probably should
 	M.dna.check_integrity()

--- a/code/modules/resleeving/machines.dm
+++ b/code/modules/resleeving/machines.dm
@@ -69,6 +69,21 @@
 		else if(status == 3) //Digital organ
 			I.digitize()
 
+	//Give breathing equipment if needed
+	if(current_project.breath_type != "oxygen")
+		H.equip_to_slot_or_del(new /obj/item/clothing/mask/breath(H), slot_wear_mask)
+		var/obj/item/weapon/tank/tankpath
+		if(current_project.breath_type == "phoron")
+			tankpath = /obj/item/weapon/tank/vox
+		else
+			tankpath = text2path("/obj/item/weapon/tank/" + current_project.breath_type)
+
+		if(tankpath)
+			H.equip_to_slot_or_del(new tankpath(H), slot_back)
+			H.internal = H.back
+			if(istype(H.internal,/obj/item/weapon/tank) && H.internals)
+				H.internals.icon_state = "internal1"
+
 	occupant = H
 
 	//Set the name or generate one


### PR DESCRIPTION
Adds the phoron and nitrogen breather traits, which both make one breathe phoron/nitrogen and make oxygen be toxic to them (instead of phoron). Of course, if one has these traits, they spawn with a breath mask and a full-size tank of the gas they need to breathe.

Also adds the water breather trait. Which just makes it so you can lay down in water without suffocating. Not nearly as interesting, maybe not even worth a point, only included in this PR because I decided to make some new traits and this is all I came up with.