### PR TITLE
Arokha/synthtweak

### DIFF
--- a/code/modules/emotes/definitions/exertion.dm
+++ b/code/modules/emotes/definitions/exertion.dm
@@ -5,7 +5,7 @@
 	emote_message_3p = "is sweating heavily."
 
 /decl/emote/exertion/biological/check_user(mob/living/user)
-	if(istype(user) && !user.isSynthetic(skip_emote_update = TRUE))
+	if(istype(user) && !user.isSynthetic())
 		return ..()
 	return FALSE
 
@@ -30,7 +30,7 @@
 	emote_message_3p = "USER's actuators whine with strain."
 
 /decl/emote/exertion/synthetic/check_user(mob/living/user)
-	if(istype(user) && user.isSynthetic(skip_emote_update = TRUE))
+	if(istype(user) && user.isSynthetic())
 		return ..()
 	return FALSE
 

--- a/code/modules/emotes/definitions/human.dm
+++ b/code/modules/emotes/definitions/human.dm
@@ -1,5 +1,11 @@
+/decl/emote/human
+	key = "vomit"
+
 /decl/emote/human/check_user(var/mob/living/carbon/human/user)
-	return istype(user)
+	return (istype(user))//VOREStation Edit - What does a mouth have to do with wagging?? && user.check_has_mouth() && !user.isSynthetic())
+
+/decl/emote/human/do_emote(var/mob/living/carbon/human/user)
+	user.vomit()
 
 /decl/emote/human/deathgasp
 	key = "deathgasp"

--- a/code/modules/emotes/definitions/synthetics.dm
+++ b/code/modules/emotes/definitions/synthetics.dm
@@ -4,7 +4,7 @@
 	emote_sound = 'sound/machines/twobeep.ogg'
 
 /decl/emote/audible/synth/check_user(var/mob/living/user)
-	if(istype(user) && user.isSynthetic(skip_emote_update = TRUE))
+	if(istype(user) && user.isSynthetic())
 		return ..()
 	return FALSE
 

--- a/code/modules/emotes/definitions/visible_vomit.dm
+++ b/code/modules/emotes/definitions/visible_vomit.dm
@@ -4,7 +4,7 @@
 /decl/emote/visible/vomit/do_emote(var/atom/user, var/extra_params)
 	if(isliving(user))
 		var/mob/living/M = user
-		if(!M.isSynthetic(skip_emote_update = TRUE))
+		if(!M.isSynthetic())
 			M.vomit()
 			return
 	to_chat(src, SPAN_WARNING("You are unable to vomit."))	

--- a/code/modules/emotes/emote_define.dm
+++ b/code/modules/emotes/emote_define.dm
@@ -172,7 +172,7 @@
 	return key
 
 /decl/emote/proc/check_synthetic(var/mob/living/user)
-	. = istype(user) && user.isSynthetic(skip_emote_update = TRUE)
+	. = istype(user) && user.isSynthetic()
 	if(!. && ishuman(user) && message_type == AUDIBLE_MESSAGE)
 		var/mob/living/carbon/human/H = user
 		if(H.should_have_organ(O_LUNGS))

--- a/code/modules/mob/living/bot/bot.dm
+++ b/code/modules/mob/living/bot/bot.dm
@@ -441,5 +441,5 @@
 	return 0
 
 
-/mob/living/bot/isSynthetic(var/skip_emote_update) //Robots are synthetic, no?
+/mob/living/bot/isSynthetic() //Robots are synthetic, no?
 	return 1

--- a/code/modules/mob/living/carbon/brain/brain.dm
+++ b/code/modules/mob/living/carbon/brain/brain.dm
@@ -42,7 +42,7 @@
 		canmove = 0
 	return canmove
 
-/mob/living/carbon/brain/isSynthetic(var/skip_emote_update)
+/mob/living/carbon/brain/isSynthetic()
 	return istype(loc, /obj/item/device/mmi)
 
 /mob/living/carbon/brain/set_typing_indicator(var/state)

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -33,6 +33,7 @@ var/list/_human_default_emotes = list(
 	/decl/emote/audible/grunt,
 	/decl/emote/audible/slap,
 	/decl/emote/audible/crack,
+	/decl/emote/human,
 	/decl/emote/human/deathgasp,
 	/decl/emote/audible/giggle,
 	/decl/emote/audible/scream,

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -98,18 +98,7 @@
 // This is the 'mechanical' check for synthetic-ness, not appearance
 // Returns the company that made the synthetic
 /mob/living/carbon/human/isSynthetic()
-	if(synthetic) 
-		return synthetic //Your synthetic-ness is not going away
-	var/obj/item/organ/external/T = organs_by_name[BP_TORSO]
-	if(T && T.robotic >= ORGAN_ROBOT)
-		src.verbs += /mob/living/carbon/human/proc/self_diagnostics
-		src.verbs += /mob/living/carbon/human/proc/reagent_purge //VOREStation Add
-		src.verbs += /mob/living/carbon/human/proc/setmonitor_state
-		var/datum/robolimb/R = all_robolimbs[T.model]
-		synthetic = R
-		update_emotes()
-		return synthetic
-	return FALSE
+	return synthetic
 
 // Would an onlooker know this person is synthetic?
 // Based on sort of logical reasoning, 'Look at head, look at torso'

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -97,7 +97,7 @@
 
 // This is the 'mechanical' check for synthetic-ness, not appearance
 // Returns the company that made the synthetic
-/mob/living/carbon/human/isSynthetic(var/skip_emote_update)
+/mob/living/carbon/human/isSynthetic()
 	if(synthetic) 
 		return synthetic //Your synthetic-ness is not going away
 	var/obj/item/organ/external/T = organs_by_name[BP_TORSO]
@@ -107,8 +107,7 @@
 		src.verbs += /mob/living/carbon/human/proc/setmonitor_state
 		var/datum/robolimb/R = all_robolimbs[T.model]
 		synthetic = R
-		if(!skip_emote_update)
-			update_emotes()
+		update_emotes()
 		return synthetic
 	return FALSE
 

--- a/code/modules/mob/living/carbon/human/human_powers.dm
+++ b/code/modules/mob/living/carbon/human/human_powers.dm
@@ -217,8 +217,7 @@
 
 		if(isSynthetic())
 			output += "Current Battery Charge: [nutrition]\n"
-
-		if(isSynthetic())
+			
 			var/toxDam = getToxLoss()
 			if(toxDam)
 				output += "System Instability: <span class='warning'>[toxDam > 25 ? "Severe" : "Moderate"]</span>. Seek charging station for cleanup.\n"

--- a/code/modules/mob/living/simple_mob/subtypes/mechanical/mechanical.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/mechanical/mechanical.dm
@@ -18,7 +18,7 @@
 	poison_resist = 1.0
 	shock_resist = -0.5
 
-/mob/living/simple_mob/mechanical/isSynthetic(var/skip_emote_update)
+/mob/living/simple_mob/mechanical/isSynthetic()
 	return TRUE
 
 /mob/living/simple_mob/mechanical/speech_bubble_appearance()

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1072,7 +1072,7 @@ mob/verb/shifteast()
 	if(src.throw_icon)
 		src.throw_icon.icon_state = "act_throw_on"
 
-/mob/proc/isSynthetic(var/skip_emote_update)
+/mob/proc/isSynthetic()
 	return 0
 
 /mob/proc/is_muzzled()

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -33,7 +33,7 @@
 		return L.mob_size <= MOB_MINISCULE
 	return 0
 
-/mob/living/silicon/isSynthetic(var/skip_emote_update)
+/mob/living/silicon/isSynthetic()
 	return 1
 
 /mob/proc/isMonkey()

--- a/code/modules/organs/internal/stomach.dm
+++ b/code/modules/organs/internal/stomach.dm
@@ -58,6 +58,8 @@
 
 	acidtype = "sacid"
 
+	organ_verbs = list(/mob/living/carbon/human/proc/reagent_purge) //VOREStation Add
+
 /obj/item/organ/internal/stomach/machine/handle_organ_proc_special()
 	..()
 	if(owner && owner.stat != DEAD)

--- a/code/modules/organs/subtypes/nano.dm
+++ b/code/modules/organs/subtypes/nano.dm
@@ -89,6 +89,10 @@
 	organ_tag = O_ORCH
 	parent_organ = BP_TORSO
 	vital = TRUE
+	organ_verbs = list(
+		/mob/living/carbon/human/proc/self_diagnostics,
+		/mob/living/carbon/human/proc/reagent_purge
+	)
 
 /obj/item/organ/internal/nano/refactory
 	name = "refactory module"

--- a/code/modules/organs/subtypes/standard.dm
+++ b/code/modules/organs/subtypes/standard.dm
@@ -24,14 +24,23 @@
 	base_miss_chance = 10
 
 /obj/item/organ/external/chest/robotize()
-	if(..() && robotic != ORGAN_NANOFORM) //VOREStation Edit
-		// Give them fancy new organs.
-		owner.internal_organs_by_name[O_CELL] = new /obj/item/organ/internal/cell(owner,1)
-		owner.internal_organs_by_name[O_VOICE] = new /obj/item/organ/internal/voicebox/robot(owner, 1)
-		owner.internal_organs_by_name[O_PUMP] = new /obj/item/organ/internal/heart/machine(owner,1)
-		owner.internal_organs_by_name[O_CYCLER] = new /obj/item/organ/internal/stomach/machine(owner,1)
-		owner.internal_organs_by_name[O_HEATSINK] = new /obj/item/organ/internal/robotic/heatsink(owner,1)
-		owner.internal_organs_by_name[O_DIAGNOSTIC] = new /obj/item/organ/internal/robotic/diagnostic(owner,1)
+	if(..() && owner)
+		if(robotic != ORGAN_NANOFORM) //VOREStation Edit
+			// Give them fancy new organs.
+			owner.internal_organs_by_name[O_CELL] = new /obj/item/organ/internal/cell(owner,1)
+			owner.internal_organs_by_name[O_VOICE] = new /obj/item/organ/internal/voicebox/robot(owner, 1)
+			owner.internal_organs_by_name[O_PUMP] = new /obj/item/organ/internal/heart/machine(owner,1)
+			owner.internal_organs_by_name[O_CYCLER] = new /obj/item/organ/internal/stomach/machine(owner,1)
+			owner.internal_organs_by_name[O_HEATSINK] = new /obj/item/organ/internal/robotic/heatsink(owner,1)
+			owner.internal_organs_by_name[O_DIAGNOSTIC] = new /obj/item/organ/internal/robotic/diagnostic(owner,1)
+
+		var/datum/robolimb/R = all_robolimbs[model] // company should be set in parent by now
+		if(!R)
+			log_error("A torso was robotize() but has no model that can be found: [model]. May affect FBPs.")
+		owner.synthetic = R
+		owner.update_emotes()
+	return FALSE
+
 
 /obj/item/organ/external/chest/handle_germ_effects()
 	. = ..() //Should return an infection level
@@ -279,7 +288,14 @@
 	return ..()
 
 /obj/item/organ/external/head/robotize(var/company, var/skip_prosthetics, var/keep_organs)
-	return ..(company, skip_prosthetics, 1)
+	. = ..(company, skip_prosthetics, 1)
+	if(model)
+		var/datum/robolimb/robohead = all_robolimbs[model]
+		if(robohead?.monitor_styles && robohead?.monitor_icon)
+			LAZYDISTINCTADD(organ_verbs, /mob/living/carbon/human/proc/setmonitor_state)
+		else
+			LAZYREMOVE(organ_verbs, /mob/living/carbon/human/proc/setmonitor_state)
+		handle_organ_mod_special()
 
 /obj/item/organ/external/head/removed()
 	if(owner)


### PR DESCRIPTION
isSynthetic() on humans was severely overloaded with performing work when it's just an accessor function, so I moved the work to the appropriate places (and also reverted the lynx quick fix):

- Mechanical stomach provides the reagent purge verb (orchestrator on proteans)
- Diagnostic organ provides the self-diagnostics verb (orchestrator on proteans)
- Head organ provides monitor set verb if robotizing to a head that supports it, otherwise removes it
- Torso sets the `synthetic` var on owner to robolimb singleton (previous isSynthetic was handled by checking torso, so all cases of a human being isSynthetic() true should be the same: ones where torso is robotized)