### PR TITLE
Help beam_components qdel properly

### DIFF
--- a/code/game/objects/effects/temporary_visuals/projectiles/tracer.dm
+++ b/code/game/objects/effects/temporary_visuals/projectiles/tracer.dm
@@ -2,8 +2,7 @@
 	var/list/beam_components = list()
 
 /datum/beam_components_cache/Destroy()
-	for(var/component in beam_components)
-		qdel(component)
+	QDEL_LIST_NULL(beam_components)
 	return ..()
 
 /proc/generate_tracer_between_points(datum/point/starting, datum/point/ending, datum/beam_components_cache/beam_components, beam_type, color, qdel_in = 5, light_range = 2, light_color_override, light_intensity = 1, instance_key)		//Do not pass z-crossing points as that will not be properly (and likely will never be properly until it's absolutely needed) supported!


### PR DESCRIPTION
Lynx shows this has a big problem doing lotsa hard dels:
```
/obj/effect/projectile_lighting
Failures: 5620
qdel() Count: 8789
Destroy() Cost: 2301.18ms
Total Hard Deletes 360
Time Spent Hard Deleting: 16109.4ms
```

I think it's due to this not removing the refs from this list.