### PR TITLE
Talon Polish, Round... 3?

### DIFF
--- a/maps/offmap_vr/talon/talon_v2.dm
+++ b/maps/offmap_vr/talon/talon_v2.dm
@@ -61,7 +61,7 @@ var/global/list/latejoin_talon = list()
 	req_one_access = list(access_talon)
 
 /obj/effect/overmap/visitable/ship/landable/talon_boat
-	name = "Talon's Shuttle"
+	name = "ITV Talon Shuttle"
 	desc = "A small shuttle from the ITV Talon."
 	vessel_mass = 1000
 	vessel_size = SHIP_SIZE_TINY

--- a/maps/offmap_vr/talon/talon_v2.dm
+++ b/maps/offmap_vr/talon/talon_v2.dm
@@ -47,7 +47,7 @@ var/global/list/latejoin_talon = list()
 	vessel_mass = 10000
 	vessel_size = SHIP_SIZE_LARGE
 	initial_generic_waypoints = list("talon_v2_near_fore_port", "talon_v2_near_fore_star", "talon_v2_near_aft_port", "talon_v2_near_aft_star", "talon_v2_wing_port", "talon_v2_wing_star")
-	initial_restricted_waypoints = list("Talon's boat" = list("offmap_spawn_talonboat"))
+	initial_restricted_waypoints = list("Talon's Shuttle" = list("offmap_spawn_talonboat"))
 
 	skybox_icon = 'talon.dmi' //Art by Gwyvern, distributed under Creative Commons license
 	skybox_icon_state = "skybox"
@@ -56,20 +56,20 @@ var/global/list/latejoin_talon = list()
 
 // The shuttle's 'shuttle' computer
 /obj/machinery/computer/shuttle_control/explore/talonboat
-	name = "boat control console"
-	shuttle_tag = "Talon's boat"
+	name = "shuttle control console"
+	shuttle_tag = "Talon's Shuttle"
 	req_one_access = list(access_talon)
 
 /obj/effect/overmap/visitable/ship/landable/talon_boat
-	name = "Talon's Boat"
+	name = "Talon's Shuttle"
 	desc = "A small shuttle from the ITV Talon."
 	vessel_mass = 1000
 	vessel_size = SHIP_SIZE_TINY
-	shuttle = "Talon's boat"
+	shuttle = "Talon's Shuttle"
 
 // A shuttle lateloader landmark
 /obj/effect/shuttle_landmark/shuttle_initializer/talonboat
-	name = "Talon's boat bay"
+	name = "Talon's shuttle bay"
 	base_area = /area/talon_v2/hangar
 	base_turf = /turf/simulated/floor/reinforced
 	landmark_tag = "offmap_spawn_talonboat"
@@ -78,7 +78,7 @@ var/global/list/latejoin_talon = list()
 
 // The talon's boat
 /datum/shuttle/autodock/overmap/talonboat
-	name = "Talon's boat"
+	name = "Talon's Shuttle"
 	current_location = "offmap_spawn_talonboat"
 	docking_controller_tag = "talonboat_docker"
 	shuttle_area = /area/shuttle/talonboat
@@ -86,7 +86,10 @@ var/global/list/latejoin_talon = list()
 	defer_initialisation = TRUE
 
 /area/shuttle/talonboat
-	name = "Talon's Boat"
+	name = "Talon's Shuttle"
+	requires_power = 1
+	icon = 'icons/turf/areas_vr_talon.dmi'
+	icon_state = "green"
 
 ///////////////////////////
 //// The Various Machines
@@ -113,18 +116,20 @@ good luck<br>\
 	info = {"to whoever's saddled with running this rustbucket this week,<br>\
 good news! you may have noticed the entire ship was replaced pretty much overnight.<br>\
 that or it changed shape or something? whatever, not important.<br>\
-what <b>is</b> important is that it no longer runs off solar arrays. now we have a pair of tritium generators.<br>\
-they're in the shielded compartment just across from the big white SMES bricks.<br>\
-jam the tritium pucks in the hoppers (not too rough and messy though) and fire them up!<br>\
-you shouldn't need to push power generation past 50kW per generator unless it's an emergency, so let it run slow and save the fuel.<br>\
-congrats, power is good to go!<br>\
+what <b>is</b> important is that it no longer runs off solar arrays. now we have a pair of radioisotope thermoelectric generators (or 'RTGs' as the kids call them) and a PTTO (or 'potato'... don't ask) mini reactor.<br>\
+they're all in the shielded compartment just across from the big white SMES bricks.<br>\
+the radioisotope buggers are basically reserves; they'll run themselves pretty much forever and provide just enough juice to run cryosupport plus allow you to kickstart power for the ship in an emergency, whilst the PTTO eats sheet uranium and puts out the big watts that keeps all the major stuff running.<br>\
+you shouldn't need to push power generation past 100kW unless it's an emergency or you've been drifting dark for a while, so let it run slow and save the fuel. initial draw will be a little high but once all the APCs are charged up it should settle down to about two-thirds 'peak'. <b>do not</b> push the PTTO past 200kW, or it'll start to overheat. too much heat and it'll explode. I don't need to tell you why that's bad.<br>\
+congrats, power is good to go! just keep in mind that the PTTO puts out hard rads whilst it's in use, so don't stand in the chamber too long whilst it's running. legal assures me it's fine but as far as I'm concerned any level of ionizing radiation is bad, y'know?<br>\
 <br>\
-just remember to actually go anywhere you'll also need to flip the output of each engine room's pumps up.<br>\
-if you somehow, <i>somehow</i>, start to run low on fuel, there are two reserve tanks and twelve(!) empty tanks.<br>\
-pray you can make it to the fuel depot on what gas you have left and fill up the tanks there.<br>\
+also! remember to actually go anywhere you'll also need to flip the output of each engine room's pumps up.<br>\
+if you somehow, <i>somehow</i>, start to run low on fuel, there are two reserve tanks in port engineering behind the atmos rig and twelve(!) empty tanks in the tail spars.<br>\
+the two reserve tanks are mostly for the shuttle, but if you're low then pray you can make it to the fuel depot on what gas you have left and fill up the tanks there.<br>\
 alternately maybe you can trade some off those nanotrasen corpos down on 3B. atmosphere's full of the stuff, I'm sure they won't miss a little.<br>\
 <br>\
-<i>Harry Townes</i>"}
+<i>Harry Townes</i><br>\
+<br>\
+p.s. speaking of shit that's bad for your health for the love of <i>fuck</i> do not smoke in the main engineering compartments, and <b>definitely</b> don't smoke in the engine rooms! if the ass-end of the ship ends up blown off because you went for a smoke break in a room full of crazy-flammable phoron they'll stick your reconstituted atoms so far in debt-prison you won't see daylight for a century."}
 
 /obj/item/weapon/paper/talon_doctor
 	name = "new medical bay"
@@ -171,8 +176,10 @@ what is important is that the shuttle has been replaced. it is now capable of fu
 but the rear airlock is a bit fussy. be sure to use the manual switches on each side of the airlock if you're matching another airlock and one side is exposed to vacuum or a hostile atmosphere!<br>\
 also be sure that it's locked down before you take off, the automatic switch is a bit stupid sometimes!<br>\
 <br>\
-finally, make sure you check the shuttle's APC power level before you head out! it can be fussy about (re)charging off the main ship grid sometimes. despite having someone in to look at the cables, we couldn't figure out why.<br>\
+finally, make sure you check the shuttle's APC power level before you head out! it used to be fussy, so we had a pro come in to double-check our setup and he yanked some weird gubbin I'd never seen before out of a wall panel, nodded to himself, and then walked off without saying anything else. weird but now it seems to behave.<br>\
 I recommend packing a spare battery (there should be a few in engineering you can borrow and charge up) to be safe. don't wanna get stranded!<br>\
+<br>\
+speaking of, if some dumbass does take it and fly off solo then get themselves killed, you can use the remote console in the little spot north of the hangar to initiate basic remote maneuvers. it can't do long-range flight, but the shuttle has some basic autopilot routines for stable orbit and docking that you can ping. this won't help if the shuttle's grounded <b>and</b> out of battery, but better than nothing, right?<br>\
 <br>\
 <i>Harry Townes</i>"}
 

--- a/maps/offmap_vr/talon/talon_v2.dmm
+++ b/maps/offmap_vr/talon/talon_v2.dmm
@@ -114,8 +114,10 @@
 /turf/simulated/floor/reinforced/airless,
 /area/talon_v2/engineering/port)
 "al" = (
-/obj/machinery/vending/nifsoft_shop,
-/turf/simulated/floor/tiled/techmaint,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
 /area/talon_v2/central_hallway)
 "am" = (
 /obj/machinery/alarm/talon{
@@ -154,15 +156,16 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 32
 	},
-/obj/machinery/camera/network/talon{
-	dir = 4
-	},
 /obj/fiftyspawner/uranium,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
 /turf/simulated/floor/plating,
 /area/talon_v2/engineering/generators)
 "aq" = (
-/obj/effect/catwalk_plated/dark,
 /obj/machinery/recharge_station,
+/obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/talon_v2/engineering/generators)
 "ar" = (
@@ -174,6 +177,9 @@
 	},
 /obj/machinery/alarm/talon{
 	pixel_y = 24
+	},
+/obj/machinery/camera/network/talon{
+	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/talon_v2/engineering/generators)
@@ -199,6 +205,11 @@
 	dir = 8
 	},
 /obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
 /area/talon_v2/engineering)
 "av" = (
@@ -248,18 +259,17 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
-/obj/structure/catwalk,
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /obj/structure/cable/yellow{
 	d2 = 4;
 	icon_state = "0-4"
 	},
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/structure/catwalk,
 /obj/machinery/power/apc/talon/hyper{
-	dir = 1;
+	dir = 8;
 	pixel_x = -24
 	},
 /turf/simulated/floor/plating,
@@ -268,17 +278,19 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/catwalk,
 /obj/structure/cable/yellow{
-	d1 = 2;
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/structure/cable/yellow{
 	d2 = 4;
-	icon_state = "2-4"
+	icon_state = "0-4"
 	},
 /obj/structure/cable/yellow{
-	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "0-8"
 	},
+/obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/talon_v2/engineering/generators)
 "aB" = (
@@ -325,17 +337,19 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/obj/structure/catwalk,
 /obj/structure/cable/yellow{
-	d1 = 2;
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/structure/cable/yellow{
 	d2 = 4;
-	icon_state = "2-4"
+	icon_state = "0-4"
 	},
 /obj/structure/cable/yellow{
-	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "0-8"
 	},
+/obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/talon_v2/engineering/generators)
 "aE" = (
@@ -380,22 +394,20 @@
 	dir = 4
 	},
 /obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
 /area/talon_v2/engineering)
 "aH" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/aux{
-	dir = 1
-	},
 /obj/effect/map_helper/airlock/atmos/chamber_pump,
-/obj/structure/handrail{
-	dir = 1
-	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
-/obj/structure/closet/autolok_wall{
-	dir = 1;
-	pixel_y = -32
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/aux{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/shuttle/talonboat)
@@ -423,16 +435,6 @@
 	},
 /turf/simulated/wall/rshull,
 /area/talon_v2/engineering/star_store)
-"aM" = (
-/obj/structure/cable/yellow,
-/obj/machinery/firealarm{
-	dir = 4;
-	layer = 3.3;
-	pixel_x = 26
-	},
-/obj/machinery/power/rtg/advanced,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/generators)
 "aN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -460,27 +462,29 @@
 	},
 /obj/effect/catwalk_plated/dark,
 /obj/structure/closet/walllocker_double/hydrant/west,
+/obj/structure/cable/green,
 /obj/structure/cable/green{
+	d1 = 1;
 	d2 = 4;
-	icon_state = "0-4"
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/plating,
 /area/talon_v2/engineering)
 "aQ" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/catwalk,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
-	d1 = 1;
+	d1 = 2;
 	d2 = 8;
-	icon_state = "1-8"
+	icon_state = "2-8"
 	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/talon_v2/engineering)
 "aR" = (
@@ -526,27 +530,23 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/talon_v2/central_hallway/fore)
 "aV" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /obj/machinery/light/small,
-/obj/structure/railing/grey{
-	dir = 1
-	},
 /obj/machinery/light_switch{
 	dir = 1;
 	pixel_x = 2;
 	pixel_y = -28
 	},
+/obj/structure/cable/yellow{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/terminal{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/talon_v2/engineering)
 "aW" = (
 /obj/effect/shuttle_landmark/shuttle_initializer/talonboat,
-/obj/machinery/atmospherics/pipe/manifold/hidden/aux{
-	dir = 1
-	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -556,13 +556,12 @@
 	dir = 4
 	},
 /obj/effect/overmap/visitable/ship/landable/talon_boat,
-/obj/machinery/button/remote/blast_door{
-	id = "talon_boat_west";
-	pixel_y = 28
-	},
 /obj/structure/handrail,
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/aux{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/shuttle/talonboat)
@@ -742,6 +741,19 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/talon_v2/engineering/starboard)
+"bK" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/maintenance/wing_starboard)
 "bM" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -800,7 +812,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/unused)
+/area/talon_v2/gen_store)
 "bX" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -1067,6 +1079,11 @@
 	dir = 4;
 	pixel_x = 26
 	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
 /area/talon_v2/maintenance/fore_port)
 "cT" = (
@@ -1308,13 +1325,13 @@
 /turf/simulated/floor/plating,
 /area/talon_v2/maintenance/aft_starboard)
 "dw" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/vending/wallmed1{
+	emagged = 1;
+	pixel_y = 32;
+	shut_up = 0
 	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway)
+/turf/simulated/floor/wood,
+/area/talon_v2/crew_quarters/bar)
 "dz" = (
 /obj/machinery/door/firedoor/glass/talon,
 /obj/structure/grille,
@@ -1373,6 +1390,11 @@
 /obj/structure/closet/emergsuit_wall{
 	dir = 1;
 	pixel_y = -32
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/talon_v2/central_hallway)
@@ -1966,7 +1988,7 @@
 	name = "Storage Room"
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/unused)
+/area/talon_v2/gen_store)
 "fq" = (
 /obj/effect/map_helper/airlock/sensor/chamber_sensor,
 /obj/machinery/atmospherics/pipe/simple/hidden/aux{
@@ -2061,15 +2083,7 @@
 /turf/simulated/floor/wood,
 /area/talon_v2/crew_quarters/cap_room)
 "fC" = (
-/obj/machinery/vending/wallmed1{
-	emagged = 1;
-	pixel_y = 32;
-	shut_up = 0
-	},
-/obj/machinery/alarm/talon{
-	dir = 4;
-	pixel_x = -22
-	},
+/obj/structure/reagent_dispensers/water_cooler/full,
 /turf/simulated/floor/wood,
 /area/talon_v2/crew_quarters/bar)
 "fF" = (
@@ -2114,6 +2128,18 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/talon_v2/central_hallway/star)
+"fQ" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering)
 "fR" = (
 /obj/effect/map_helper/airlock/sensor/ext_sensor,
 /obj/machinery/airlock_sensor{
@@ -2208,26 +2234,41 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/talon_v2/armory)
 "gj" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/structure/catwalk,
 /obj/structure/disposalpipe/segment{
 	dir = 4;
 	icon_state = "pipe-c"
+	},
+/obj/machinery/power/sensor{
+	name = "Talon Power Generation";
+	name_tag = "TLN-PWR-GEN"
+	},
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/cable/yellow,
+/obj/structure/cable/yellow{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/effect/catwalk_plated/dark,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering)
+"gl" = (
+/obj/structure/catwalk,
+/obj/machinery/light/small{
+	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/talon_v2/engineering)
@@ -2344,6 +2385,17 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/talon_v2/brig)
+"gD" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 8
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/space)
 "gE" = (
 /obj/structure/catwalk,
 /obj/machinery/firealarm{
@@ -2586,10 +2638,21 @@
 /turf/simulated/floor/wood,
 /area/talon_v2/crew_quarters/meditation)
 "hD" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 6
+/obj/structure/closet/autolok_wall{
+	dir = 1;
+	pixel_y = -32
 	},
-/turf/simulated/wall/rshull,
+/obj/structure/handrail{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/aux{
+	dir = 4
+	},
+/obj/effect/map_helper/airlock/atmos/chamber_pump,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/shuttle/talonboat)
 "hG" = (
 /obj/structure/cable/green{
@@ -2738,6 +2801,11 @@
 	pixel_y = 28
 	},
 /obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/plating,
 /area/talon_v2/maintenance/aft_starboard)
 "in" = (
@@ -2746,6 +2814,16 @@
 "iq" = (
 /turf/simulated/floor/wood,
 /area/talon_v2/crew_quarters/eng_room)
+"ir" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/random/multiple/corp_crate/talon_cargo,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/maintenance/wing_port)
 "iv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/aux{
 	dir = 6
@@ -2779,6 +2857,11 @@
 	dir = 8
 	},
 /obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
 /area/talon_v2/maintenance/aft_port)
 "iz" = (
@@ -2837,6 +2920,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/talon_v2/engineering/star_store)
+"iM" = (
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/fore_starboard)
 "iN" = (
 /obj/machinery/vending/engivend{
 	products = list(/obj/item/device/geiger = 4, /obj/item/clothing/glasses/meson = 2, /obj/item/device/multitool = 4, /obj/item/weapon/cell/high = 10, /obj/item/weapon/airlock_electronics = 10, /obj/item/weapon/module/power_control = 10, /obj/item/weapon/circuitboard/airalarm = 10, /obj/item/weapon/circuitboard/firealarm = 10, /obj/item/weapon/circuitboard/status_display = 2, /obj/item/weapon/circuitboard/ai_status_display = 2, /obj/item/weapon/circuitboard/newscaster = 2, /obj/item/weapon/circuitboard/holopad = 2, /obj/item/weapon/circuitboard/intercom = 4, /obj/item/weapon/circuitboard/security/telescreen/entertainment = 4, /obj/item/weapon/stock_parts/motor = 2, /obj/item/weapon/stock_parts/spring = 2, /obj/item/weapon/stock_parts/gear = 2, /obj/item/weapon/circuitboard/atm, /obj/item/weapon/circuitboard/guestpass, /obj/item/weapon/circuitboard/keycard_auth, /obj/item/weapon/circuitboard/photocopier, /obj/item/weapon/circuitboard/fax, /obj/item/weapon/circuitboard/request, /obj/item/weapon/circuitboard/microwave, /obj/item/weapon/circuitboard/washing, /obj/item/weapon/circuitboard/scanner_console, /obj/item/weapon/circuitboard/sleeper_console, /obj/item/weapon/circuitboard/body_scanner, /obj/item/weapon/circuitboard/sleeper, /obj/item/weapon/circuitboard/dna_analyzer, /obj/item/weapon/circuitboard/partslathe);
@@ -2883,6 +2975,17 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/talon_v2/bridge)
+"jb" = (
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/hangar)
 "jc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -3058,6 +3161,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/talon_v2/central_hallway)
 "jQ" = (
@@ -3070,7 +3178,7 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/unused)
+/area/talon_v2/gen_store)
 "jS" = (
 /obj/machinery/mineral/output,
 /obj/machinery/conveyor{
@@ -3120,14 +3228,7 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/talon_v2/maintenance/wing_port)
 "kg" = (
-/obj/machinery/computer/cryopod{
-	pixel_y = 32
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/floor_decal/emblem/talon,
-/turf/simulated/floor/tiled/techmaint,
+/turf/simulated/floor/tiled/techfloor,
 /area/talon_v2/central_hallway)
 "ki" = (
 /obj/machinery/atmospherics/unary/engine/bigger{
@@ -3308,25 +3409,33 @@
 /turf/simulated/floor/plating,
 /area/talon_v2/engineering/port_store)
 "kM" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 10
+/obj/structure/closet/autolok_wall{
+	dir = 1;
+	pixel_y = -32
 	},
-/turf/simulated/wall/rshull,
-/area/shuttle/talonboat)
-"kP" = (
-/obj/machinery/power/terminal{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/camera/network/talon{
+/obj/structure/handrail{
 	dir = 1
 	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/aux{
+	dir = 8
+	},
+/obj/effect/map_helper/airlock/atmos/chamber_pump,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/shuttle/talonboat)
+"kP" = (
 /obj/structure/extinguisher_cabinet{
 	dir = 1;
 	pixel_y = -32
+	},
+/obj/machinery/power/smes/buildable/offmap_spawn{
+	RCon_tag = "Talon Port SMES"
+	},
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area/talon_v2/engineering)
@@ -3628,7 +3737,7 @@
 	pixel_y = -26
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/unused)
+/area/talon_v2/gen_store)
 "lI" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -3695,6 +3804,16 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/talon_v2/refining)
+"lS" = (
+/obj/machinery/door/firedoor/glass/talon,
+/obj/machinery/door/airlock/maintenance/common,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/fore_port)
 "lT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -3718,6 +3837,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
 /area/talon_v2/maintenance/aft_port)
 "lW" = (
@@ -3815,6 +3939,15 @@
 /obj/random/multiple/corp_crate/talon_cargo,
 /turf/simulated/floor/tiled/techfloor,
 /area/talon_v2/maintenance/wing_starboard)
+"mm" = (
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/aft_starboard)
 "mo" = (
 /obj/effect/floor_decal/industrial/warning/dust/corner{
 	dir = 8
@@ -3979,18 +4112,11 @@
 /area/talon_v2/refining)
 "mT" = (
 /obj/effect/map_helper/airlock/atmos/chamber_pump,
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/aux{
-	dir = 1
-	},
-/obj/structure/handrail{
-	dir = 1
-	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
 	},
-/obj/structure/closet/autolok_wall{
-	dir = 1;
-	pixel_y = -32
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/aux{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/shuttle/talonboat)
@@ -4048,12 +4174,40 @@
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/space)
+"ng" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/camera/network/talon{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway)
 "nh" = (
 /obj/effect/floor_decal/industrial/warning/dust{
 	dir = 9
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/talon_v2/engineering/starboard)
+"nk" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/wall/rshull,
+/area/talon_v2/maintenance/wing_port)
 "nl" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -4117,6 +4271,9 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
+/obj/item/modular_computer/console/preset/talon{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/talon_v2/engineering)
 "nz" = (
@@ -4176,12 +4333,12 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/talon_v2/central_hallway/fore)
 "nI" = (
-/obj/machinery/power/terminal{
-	dir = 4
+/obj/machinery/power/smes/buildable/offmap_spawn{
+	RCon_tag = "Talon Port SMES"
 	},
-/obj/structure/cable/yellow{
-	d2 = 8;
-	icon_state = "0-8"
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area/talon_v2/engineering)
@@ -4276,7 +4433,8 @@
 /obj/machinery/airlock_sensor/airlock_exterior/shuttle{
 	dir = 4;
 	pixel_x = 11;
-	pixel_y = 24
+	pixel_y = 24;
+	req_one_access = list(301)
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/shuttle/talonboat)
@@ -4347,8 +4505,11 @@
 "ox" = (
 /obj/structure/cable/green{
 	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/light{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/talon_v2/central_hallway)
@@ -4362,7 +4523,10 @@
 /turf/simulated/floor/plating,
 /area/talon_v2/engineering/atmospherics)
 "oA" = (
-/obj/effect/floor_decal/industrial/warning/corner{
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -4511,6 +4675,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/talon_v2/maintenance/wing_starboard)
+"pk" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/fuel,
+/turf/simulated/wall/rshull,
+/area/shuttle/talonboat)
 "pl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -4518,10 +4686,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway)
-"pm" = (
-/obj/structure/closet/walllocker_double/hydrant/north,
 /turf/simulated/floor/tiled/techmaint,
 /area/talon_v2/central_hallway)
 "pn" = (
@@ -4551,6 +4715,7 @@
 	dir = 4;
 	icon_state = "pipe-j2"
 	},
+/obj/structure/closet/walllocker_double/hydrant/east,
 /turf/simulated/floor/tiled/techmaint,
 /area/talon_v2/central_hallway)
 "pr" = (
@@ -4565,14 +4730,15 @@
 /area/talon_v2/engineering/atmospherics)
 "pt" = (
 /obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+	d2 = 8;
+	icon_state = "0-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/catwalk,
-/obj/structure/disposalpipe/segment,
+/obj/machinery/power/terminal{
+	dir = 4
+	},
+/obj/structure/railing/grey{
+	dir = 1
+	},
 /turf/simulated/floor/plating,
 /area/talon_v2/engineering)
 "pv" = (
@@ -4624,10 +4790,16 @@
 /turf/simulated/floor/carpet/blucarpet,
 /area/talon_v2/crew_quarters/cap_room)
 "pA" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/junction/yjunction{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
 /obj/structure/catwalk,
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/talon_v2/engineering)
 "pB" = (
@@ -4695,11 +4867,6 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/talon_v2/central_hallway/fore)
 "pN" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/machinery/light,
 /turf/simulated/floor/carpet,
 /area/talon_v2/crew_quarters/pilot_room)
 "pQ" = (
@@ -4762,24 +4929,17 @@
 /turf/simulated/floor/carpet/blucarpet,
 /area/talon_v2/crew_quarters/cap_room)
 "qc" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
+/obj/structure/bed/chair/bay/chair,
+/obj/machinery/alarm/talon{
+	pixel_y = 24
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/hangar)
+/turf/simulated/floor/wood,
+/area/talon_v2/crew_quarters/bar)
 "qe" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/light_switch{
 	dir = 8;
 	pixel_x = 24
@@ -4841,6 +5001,17 @@
 "qp" = (
 /turf/simulated/wall/shull,
 /area/talon_v2/crew_quarters/bar)
+"qq" = (
+/obj/structure/closet/walllocker_double/south,
+/obj/structure/handrail{
+	dir = 1
+	},
+/obj/item/weapon/storage/toolbox/mechanical,
+/obj/machinery/atmospherics/pipe/simple/hidden/aux{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/shuttle/talonboat)
 "qr" = (
 /turf/simulated/wall/shull,
 /area/talon_v2/crew_quarters/med_room)
@@ -4857,6 +5028,17 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/talon_v2/central_hallway/port)
+"qt" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/hangar)
 "qu" = (
 /obj/structure/barricade,
 /turf/simulated/floor/plating,
@@ -4983,8 +5165,17 @@
 /turf/simulated/floor/plating,
 /area/talon_v2/central_hallway/star)
 "qL" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/fuel,
-/turf/simulated/wall/rshull,
+/obj/structure/closet/walllocker_double/south,
+/obj/machinery/light,
+/obj/item/weapon/extinguisher,
+/obj/item/stack/cable_coil/green,
+/obj/item/stack/cable_coil/green,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/aux{
+	dir = 8
+	},
+/obj/effect/map_helper/airlock/atmos/chamber_pump,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/shuttle/talonboat)
 "qN" = (
 /turf/simulated/wall/shull{
@@ -5061,6 +5252,17 @@
 /obj/effect/catwalk_plated/dark,
 /turf/simulated/floor/plating,
 /area/talon_v2/engineering/atmospherics)
+"qX" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 4
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/space)
 "rg" = (
 /obj/machinery/door/firedoor/glass/talon,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -5162,6 +5364,11 @@
 	icon_state = "0-2"
 	},
 /obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/plating,
 /area/talon_v2/maintenance/aft_port)
 "rx" = (
@@ -5504,9 +5711,16 @@
 	name = "south bump";
 	pixel_y = -24
 	},
-/obj/structure/cable/green,
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/talon_v2/central_hallway)
@@ -5560,6 +5774,15 @@
 /obj/random/multiple/corp_crate/talon_cargo,
 /turf/simulated/floor/tiled/techfloor,
 /area/talon_v2/maintenance/wing_port)
+"sV" = (
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/fore_starboard)
 "sZ" = (
 /obj/structure/catwalk,
 /obj/machinery/light/small{
@@ -5763,14 +5986,18 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/talon_v2/armory)
 "tB" = (
-/obj/machinery/power/smes/buildable/offmap_spawn{
-	RCon_tag = "Talon Port SMES"
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /obj/structure/cable/green{
+	d1 = 1;
 	d2 = 2;
-	icon_state = "0-2"
+	icon_state = "1-2"
 	},
-/obj/structure/cable/green,
+/obj/structure/closet/walllocker_double/east,
+/obj/item/weapon/storage/toolbox/electrical,
 /turf/simulated/floor/plating,
 /area/talon_v2/engineering)
 "tC" = (
@@ -5779,8 +6006,9 @@
 "tD" = (
 /obj/structure/table/rack/shelf/steel,
 /obj/random/maintenance/cargo,
+/obj/random/maintenance/cargo,
 /turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/unused)
+/area/talon_v2/gen_store)
 "tE" = (
 /obj/machinery/embedded_controller/radio/simple_docking_controller{
 	frequency = 1380;
@@ -5876,6 +6104,12 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/talon_v2/brig)
+"ub" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 10
+	},
+/turf/simulated/wall/rshull,
+/area/shuttle/talonboat)
 "uc" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -6122,10 +6356,13 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/talonboat)
 "uV" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/fuel{
+/obj/structure/closet/walllocker_double/south,
+/obj/structure/handrail{
 	dir = 1
 	},
-/turf/simulated/wall/rshull,
+/obj/item/weapon/storage/toolbox/emergency,
+/obj/machinery/atmospherics/pipe/manifold/hidden/aux,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/shuttle/talonboat)
 "uW" = (
 /obj/structure/table/rack/steel,
@@ -6155,39 +6392,32 @@
 /obj/structure/sign/department/eng{
 	pixel_y = -32
 	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/talon_v2/central_hallway)
 "vb" = (
 /obj/structure/cable/yellow{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/structure/cable/yellow{
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/structure/cable/yellow{
-	d2 = 2;
-	icon_state = "0-2"
+/obj/machinery/power/terminal{
+	dir = 4
 	},
-/obj/structure/cable/yellow,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/obj/machinery/power/sensor{
-	name = "Talon Power Generation";
-	name_tag = "TLN-PWR-GEN"
-	},
-/obj/effect/catwalk_plated/dark,
 /turf/simulated/floor/plating,
 /area/talon_v2/engineering)
+"vc" = (
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/aft_starboard)
 "vd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -6306,6 +6536,7 @@
 	dir = 8
 	},
 /obj/structure/table/steel,
+/obj/random/maintenance/engineering,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/talon_v2/engineering)
 "vA" = (
@@ -6342,6 +6573,11 @@
 	},
 /obj/structure/catwalk,
 /obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/plating,
 /area/talon_v2/maintenance/aft_port)
 "vE" = (
@@ -6589,10 +6825,6 @@
 /obj/structure/bed/chair/bay/chair{
 	dir = 1
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
 /turf/simulated/floor/carpet,
 /area/talon_v2/crew_quarters/eng_room)
 "wy" = (
@@ -6654,6 +6886,15 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/talon_v2/secure_storage)
+"wN" = (
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/fore_starboard)
 "wO" = (
 /obj/structure/bed/chair/bay/comfy/brown{
 	dir = 1
@@ -6705,15 +6946,9 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/talon_v2/engineering/atmospherics)
 "wX" = (
-/obj/structure/closet/walllocker_double/south,
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/aux{
-	dir = 1
+/obj/machinery/atmospherics/pipe/manifold/hidden/aux{
+	dir = 4
 	},
-/obj/effect/map_helper/airlock/atmos/chamber_pump,
-/obj/structure/handrail{
-	dir = 1
-	},
-/obj/item/weapon/storage/toolbox/emergency,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/shuttle/talonboat)
 "wZ" = (
@@ -6809,6 +7044,15 @@
 /obj/structure/table/marble,
 /turf/simulated/floor/tiled/white,
 /area/talon_v2/crew_quarters/bar)
+"xr" = (
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/aft_starboard)
 "xt" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -6868,17 +7112,18 @@
 /turf/simulated/floor/plating,
 /area/talon_v2/engineering/atmospherics)
 "xB" = (
+/obj/machinery/power/pointdefense{
+	id_tag = "talon_pd"
+	},
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 5
+	},
 /obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d2 = 2;
+	icon_state = "0-2"
 	},
-/obj/machinery/holoposter{
-	dir = 1;
-	pixel_y = 32
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway)
+/turf/simulated/floor/reinforced/airless,
+/area/space)
 "xE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -6914,6 +7159,11 @@
 	pixel_x = 22
 	},
 /obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
 /area/talon_v2/maintenance/fore_port)
 "xM" = (
@@ -7058,6 +7308,11 @@
 /obj/machinery/holoposter{
 	pixel_y = -32
 	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/talon_v2/central_hallway)
 "yj" = (
@@ -7108,6 +7363,13 @@
 /obj/random/maintenance/engineering,
 /obj/item/device/radio/off{
 	channels = list("Talon" = 1)
+	},
+/obj/item/clothing/suit/radiation,
+/obj/item/clothing/head/radiation,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating,
 /area/talon_v2/engineering)
@@ -7239,6 +7501,10 @@
 /obj/item/modular_computer/laptop/preset/custom_loadout/standard/talon/engineer,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
 	},
 /turf/simulated/floor/carpet,
 /area/talon_v2/crew_quarters/eng_room)
@@ -7392,23 +7658,18 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
+/obj/random/maintenance/cargo,
 /turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/unused)
+/area/talon_v2/gen_store)
 "zB" = (
 /obj/structure/table/rack/shelf/steel,
 /obj/item/clothing/head/helmet/space/void/refurb/talon,
 /turf/simulated/floor/tiled/techfloor,
 /area/talon_v2/secure_storage)
 "zC" = (
-/obj/structure/closet/walllocker_double/south,
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/aux{
-	dir = 1
+/obj/machinery/atmospherics/pipe/manifold/hidden/aux{
+	dir = 8
 	},
-/obj/effect/map_helper/airlock/atmos/chamber_pump,
-/obj/structure/handrail{
-	dir = 1
-	},
-/obj/item/weapon/storage/toolbox/mechanical,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/shuttle/talonboat)
 "zF" = (
@@ -7573,6 +7834,11 @@
 /obj/structure/sign/department/telecoms{
 	pixel_y = -31
 	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/talon_v2/central_hallway)
 "As" = (
@@ -7606,9 +7872,24 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/techmaint,
 /area/talon_v2/maintenance/wing_port)
+"Av" = (
+/obj/structure/catwalk,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/aft_starboard)
 "Aw" = (
-/obj/machinery/camera/network/talon,
-/turf/simulated/floor/tiled/techmaint,
+/obj/machinery/door/firedoor/glass/talon,
+/obj/machinery/door/airlock/glass{
+	name = "Flight Control"
+	},
+/turf/simulated/floor/tiled/techfloor,
 /area/talon_v2/central_hallway)
 "Ax" = (
 /obj/structure/cable/green{
@@ -7715,6 +7996,12 @@
 /obj/machinery/door/blast/regular/open{
 	id = "talon_boat_east"
 	},
+/obj/machinery/button/remote/blast_door{
+	dir = 1;
+	id = "talon_boat_east";
+	pixel_y = -28;
+	req_one_access = list(301)
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/shuttle/talonboat)
 "AO" = (
@@ -7762,6 +8049,31 @@
 	},
 /turf/simulated/floor/plating,
 /area/talon_v2/engineering/starboard)
+"AU" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/random/multiple/corp_crate/talon_cargo,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/maintenance/wing_starboard)
+"AV" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 1;
+	pixel_y = -32
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/hangar)
 "AW" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
@@ -7802,11 +8114,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/junction{
-	dir = 2;
-	icon_state = "pipe-j2"
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
@@ -7825,7 +8135,7 @@
 /turf/simulated/wall/shull{
 	can_open = 1
 	},
-/area/talon_v2/unused)
+/area/talon_v2/gen_store)
 "Bf" = (
 /obj/machinery/shipsensors{
 	dir = 1
@@ -7846,17 +8156,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/talon_v2/central_hallway/fore)
-"Bj" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/hangar)
 "Bk" = (
 /obj/machinery/atmospherics/binary/pump/high_power/on{
 	dir = 4
@@ -8012,9 +8311,6 @@
 /turf/simulated/floor/plating,
 /area/talon_v2/central_hallway)
 "BK" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/disposal/wall,
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -8238,6 +8534,11 @@
 /obj/structure/sign/department/shield{
 	pixel_y = -31
 	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/talon_v2/central_hallway)
 "Cy" = (
@@ -8306,6 +8607,10 @@
 	dir = 4
 	},
 /obj/item/weapon/paper/talon_pilot,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
 /turf/simulated/floor/carpet,
 /area/talon_v2/crew_quarters/pilot_room)
 "CI" = (
@@ -8396,7 +8701,7 @@
 /area/talon_v2/maintenance/wing_port)
 "Dc" = (
 /turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/unused)
+/area/talon_v2/gen_store)
 "Dd" = (
 /turf/simulated/wall/shull,
 /area/talon_v2/secure_storage)
@@ -8426,6 +8731,12 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/talon_v2/maintenance/wing_port)
+"Dj" = (
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/hangar)
 "Dm" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -8522,6 +8833,7 @@
 	dir = 4;
 	icon_state = "pipe-j2"
 	},
+/obj/structure/closet/walllocker_double/hydrant/west,
 /turf/simulated/floor/tiled/techmaint,
 /area/talon_v2/central_hallway)
 "DH" = (
@@ -8539,7 +8851,7 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/talon_v2/maintenance/wing_starboard)
 "DK" = (
-/obj/machinery/vending/coffee,
+/obj/machinery/vending/nifsoft_shop,
 /turf/simulated/floor/tiled/techfloor,
 /area/talon_v2/central_hallway/fore)
 "DM" = (
@@ -8599,6 +8911,22 @@
 /obj/random/multiple/corp_crate/talon_cargo,
 /turf/simulated/floor/tiled/techfloor,
 /area/talon_v2/maintenance/wing_port)
+"DX" = (
+/obj/machinery/power/pointdefense{
+	id_tag = "talon_pd"
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 6
+	},
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 5
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/space)
 "DY" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -8623,9 +8951,9 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/talon_v2/bridge)
 "Eb" = (
-/obj/structure/table/rack/shelf/steel,
+/obj/structure/reagent_dispensers/watertank/high,
 /turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/unused)
+/area/talon_v2/gen_store)
 "Ef" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/red{
 	dir = 1
@@ -8634,14 +8962,14 @@
 /turf/simulated/floor/plating,
 /area/talon_v2/engineering/atmospherics)
 "Ek" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
+/obj/machinery/door/firedoor/glass/talon,
+/obj/machinery/door/airlock{
+	id_tag = "talon_pilotdoor";
+	name = "Pilot's Cabin";
+	req_one_access = list(301)
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/hangar)
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/crew_quarters/pilot_room)
 "En" = (
 /obj/structure/table/standard,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -8777,11 +9105,24 @@
 /turf/simulated/floor/plating,
 /area/talon_v2/engineering/atmospherics)
 "EJ" = (
-/obj/machinery/atmospherics/unary/engine{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 6
 	},
-/turf/simulated/floor/reinforced,
+/turf/simulated/wall/rshull,
 /area/shuttle/talonboat)
+"EL" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/maintenance/wing_port)
 "EN" = (
 /obj/item/weapon/storage/firstaid/regular,
 /obj/item/weapon/storage/firstaid/o2,
@@ -8801,6 +9142,23 @@
 	},
 /turf/simulated/floor/plating,
 /area/talon_v2/engineering/port)
+"EP" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/catwalk,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/aft_starboard)
 "ES" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -8963,22 +9321,13 @@
 /turf/simulated/floor/plating,
 /area/talon_v2/engineering/atmospherics)
 "Fq" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
+/obj/effect/landmark/talon,
+/obj/structure/handrail,
+/obj/machinery/computer/cryopod{
+	pixel_y = 32
 	},
-/obj/machinery/power/apc/talon{
-	name = "south bump";
-	pixel_y = -24
-	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/camera/network/talon{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/hangar)
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/central_hallway)
 "Fv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -8986,9 +9335,6 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/talon_v2/bridge)
 "Fx" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
 /obj/structure/catwalk,
 /obj/structure/extinguisher_cabinet{
 	dir = 4;
@@ -9059,6 +9405,11 @@
 	},
 /obj/structure/sign/department/atmos{
 	pixel_y = -32
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/talon_v2/central_hallway)
@@ -9246,6 +9597,11 @@
 /obj/machinery/camera/network/talon{
 	dir = 1
 	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/talon_v2/central_hallway)
 "Gl" = (
@@ -9371,6 +9727,22 @@
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/talon_v2/engineering/starboard)
+"GC" = (
+/obj/machinery/power/pointdefense{
+	id_tag = "talon_pd"
+	},
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 10
+	},
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 9
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/space)
 "GE" = (
 /obj/machinery/door/firedoor/glass/talon,
 /obj/machinery/door/airlock/maintenance/engi{
@@ -9396,7 +9768,7 @@
 	pixel_y = 26
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/unused)
+/area/talon_v2/gen_store)
 "GH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -9800,6 +10172,11 @@
 /obj/structure/catwalk,
 /obj/machinery/door/firedoor/glass/talon,
 /obj/machinery/door/airlock/maintenance/common,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
 /area/talon_v2/maintenance/fore_port)
 "Ie" = (
@@ -9843,6 +10220,12 @@
 /obj/machinery/door/blast/regular/open{
 	id = "talon_boat_west"
 	},
+/obj/machinery/button/remote/blast_door{
+	dir = 1;
+	id = "talon_boat_west";
+	pixel_y = -28;
+	req_one_access = list(301)
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/shuttle/talonboat)
 "Ii" = (
@@ -9883,11 +10266,6 @@
 /area/talon_v2/engineering/starboard)
 "Im" = (
 /obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -9897,6 +10275,9 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/talon_v2/engineering)
@@ -10034,11 +10415,22 @@
 	dir = 8;
 	pixel_x = -24
 	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/plating,
 /area/talon_v2/maintenance/aft_starboard)
 "IK" = (
 /turf/simulated/wall/rshull,
 /area/talon_v2/engineering/generators)
+"IL" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/fuel{
+	dir = 1
+	},
+/turf/simulated/wall/rshull,
+/area/shuttle/talonboat)
 "IM" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -10066,6 +10458,11 @@
 /obj/item/weapon/cell/apc,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/talon_v2/engineering)
+"IP" = (
+/obj/structure/catwalk,
+/obj/structure/barricade,
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/aft_port)
 "IR" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/aux{
 	dir = 1
@@ -10179,7 +10576,8 @@
 /obj/machinery/airlock_sensor/airlock_exterior/shuttle{
 	dir = 8;
 	pixel_x = -11;
-	pixel_y = 24
+	pixel_y = 24;
+	req_one_access = list(301)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 4
@@ -10203,6 +10601,11 @@
 /obj/structure/catwalk,
 /obj/machinery/light/small{
 	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
 /area/talon_v2/maintenance/aft_port)
@@ -10258,6 +10661,23 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/talonboat)
+"JB" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/catwalk,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/aft_port)
 "JC" = (
 /obj/machinery/computer/ship/helm{
 	req_one_access = list(301)
@@ -10292,8 +10712,9 @@
 /obj/structure/closet/crate,
 /obj/random/maintenance/clean,
 /obj/random/maintenance/clean,
+/obj/random/maintenance/clean,
 /turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/unused)
+/area/talon_v2/gen_store)
 "JH" = (
 /obj/structure/extinguisher_cabinet{
 	dir = 1;
@@ -10516,8 +10937,9 @@
 /obj/structure/closet/crate,
 /obj/random/maintenance/clean,
 /obj/random/maintenance/clean,
+/obj/random/maintenance/clean,
 /turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/unused)
+/area/talon_v2/gen_store)
 "Ks" = (
 /obj/machinery/door/firedoor/glass/talon,
 /obj/structure/grille,
@@ -10598,6 +11020,11 @@
 /obj/structure/catwalk,
 /obj/machinery/light/small{
 	dir = 8
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/talon_v2/maintenance/fore_port)
@@ -10760,13 +11187,16 @@
 /turf/simulated/floor/plating,
 /area/talon_v2/engineering/starboard)
 "Lr" = (
-/obj/effect/floor_decal/industrial/warning/corner{
+/obj/effect/floor_decal/industrial/warning{
 	dir = 4
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
 	},
 /obj/structure/cable/green{
 	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/talon_v2/hangar)
@@ -10807,7 +11237,11 @@
 /area/space)
 "LA" = (
 /obj/structure/catwalk,
-/obj/structure/barricade,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
 /area/talon_v2/maintenance/aft_port)
 "LB" = (
@@ -10863,23 +11297,18 @@
 /turf/simulated/floor/plating,
 /area/talon_v2/engineering/starboard)
 "LL" = (
-/obj/structure/table/rack/shelf/steel,
 /obj/machinery/light/small{
 	dir = 8
 	},
+/obj/structure/reagent_dispensers/fueltank/high,
 /turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/unused)
+/area/talon_v2/gen_store)
 "LM" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/aux{
 	dir = 1
 	},
-/obj/structure/closet/walllocker_double/south,
 /obj/effect/map_helper/airlock/atmos/chamber_pump,
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
-/obj/machinery/light,
-/obj/item/stack/cable_coil/green,
-/obj/item/stack/cable_coil/green,
-/obj/item/weapon/extinguisher,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/shuttle/talonboat)
 "LN" = (
@@ -10888,9 +11317,34 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/talon_v2/engineering)
+"LO" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/aft_port)
 "LT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -10986,6 +11440,11 @@
 	dir = 8
 	},
 /obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
 /area/talon_v2/maintenance/aft_starboard)
 "Mo" = (
@@ -11020,6 +11479,11 @@
 	icon_state = "1-2"
 	},
 /obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/plating,
 /area/talon_v2/maintenance/fore_starboard)
 "MA" = (
@@ -11053,23 +11517,19 @@
 /turf/simulated/floor/plating,
 /area/talon_v2/engineering/starboard)
 "ME" = (
-/obj/machinery/button/remote/blast_door{
-	id = "talon_boat_east";
-	pixel_y = 28
-	},
 /obj/structure/handrail,
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/aux{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/aux{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -11180,16 +11640,18 @@
 /turf/simulated/floor/tiled/white,
 /area/talon_v2/medical)
 "Nc" = (
-/obj/machinery/power/smes/buildable/offmap_spawn{
-	RCon_tag = "Talon Port SMES"
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /obj/structure/cable/green{
+	d1 = 1;
 	d2 = 2;
-	icon_state = "0-2"
+	icon_state = "1-2"
 	},
-/obj/structure/cable/green,
-/obj/structure/railing/grey{
-	dir = 1
+/obj/machinery/camera/network/talon{
+	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/talon_v2/engineering)
@@ -11366,20 +11828,14 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/talon_v2/maintenance/wing_starboard)
 "NR" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
+/obj/structure/catwalk,
 /obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/structure/extinguisher_cabinet{
-	dir = 1;
-	pixel_y = -32
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/hangar)
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/fore_port)
 "NS" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/aux{
 	dir = 4
@@ -11399,15 +11855,10 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/light{
-	dir = 1
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/tiled/techmaint,
+/turf/simulated/wall/shull,
 /area/talon_v2/central_hallway)
 "NV" = (
 /turf/simulated/wall/rshull,
@@ -11640,15 +12091,15 @@
 /turf/simulated/floor/plating,
 /area/talon_v2/central_hallway/port)
 "OL" = (
-/obj/machinery/power/terminal{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	d2 = 8;
-	icon_state = "0-8"
-	},
 /obj/structure/railing/grey{
 	dir = 1
+	},
+/obj/machinery/power/smes/buildable/offmap_spawn{
+	RCon_tag = "Talon Port SMES"
+	},
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area/talon_v2/engineering)
@@ -11691,7 +12142,7 @@
 /area/talon_v2/engineering/atmospherics)
 "OQ" = (
 /turf/simulated/wall/shull,
-/area/talon_v2/unused)
+/area/talon_v2/gen_store)
 "OR" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -12047,10 +12498,8 @@
 	dir = 4
 	},
 /obj/structure/railing/grey,
-/obj/item/modular_computer/console/preset/talon{
-	dir = 1
-	},
 /obj/effect/floor_decal/industrial/warning,
+/obj/structure/table/steel,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/talon_v2/engineering)
 "Qb" = (
@@ -12096,6 +12545,11 @@
 /obj/effect/catwalk_plated,
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/talon_v2/central_hallway/port)
@@ -12153,6 +12607,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/plating,
 /area/talon_v2/maintenance/aft_port)
 "Qv" = (
@@ -12272,11 +12731,11 @@
 /turf/simulated/floor/plating,
 /area/talon_v2/engineering)
 "QM" = (
-/obj/effect/floor_decal/industrial/warning{
+/obj/machinery/atmospherics/unary/engine{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/hangar)
+/turf/simulated/floor/reinforced,
+/area/shuttle/talonboat)
 "QN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/carpet,
@@ -12325,18 +12784,20 @@
 /turf/simulated/floor/plating,
 /area/talon_v2/engineering/port)
 "Rd" = (
-/obj/machinery/power/smes/buildable/offmap_spawn{
-	RCon_tag = "Talon Port SMES"
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
-/obj/structure/cable/green,
 /turf/simulated/floor/plating,
 /area/talon_v2/engineering)
 "Re" = (
 /obj/structure/closet/crate,
 /obj/random/maintenance/clean,
 /obj/random/maintenance/clean,
+/obj/random/maintenance/clean,
 /turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/unused)
+/area/talon_v2/gen_store)
 "Rf" = (
 /turf/simulated/wall/shull{
 	can_open = 1
@@ -12685,19 +13146,18 @@
 /area/talon_v2/crew_quarters/cap_room)
 "St" = (
 /obj/structure/cable/green{
-	d1 = 2;
+	d1 = 4;
 	d2 = 8;
-	icon_state = "2-8"
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/techmaint,
+/obj/machinery/computer/shuttle_control/explore/talonboat{
+	dir = 4;
+	name = "boat remote control console"
+	},
+/turf/simulated/floor/tiled/techfloor,
 /area/talon_v2/central_hallway)
 "Su" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
@@ -12722,6 +13182,11 @@
 	dir = 4
 	},
 /obj/structure/closet/walllocker_double/hydrant/south,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/talon_v2/central_hallway)
 "Sx" = (
@@ -12749,6 +13214,7 @@
 /obj/machinery/cryopod/talon{
 	dir = 4
 	},
+/obj/machinery/camera/network/talon,
 /turf/simulated/floor/tiled/techfloor,
 /area/talon_v2/central_hallway)
 "SE" = (
@@ -13052,6 +13518,15 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/talon_v2/engineering/port_store)
+"TJ" = (
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/aft_starboard)
 "TL" = (
 /obj/machinery/alarm/talon{
 	dir = 8;
@@ -13062,6 +13537,7 @@
 /obj/machinery/computer/ship/navigation/telescreen{
 	pixel_y = -32
 	},
+/obj/machinery/light,
 /turf/simulated/floor/carpet,
 /area/talon_v2/crew_quarters/pilot_room)
 "TN" = (
@@ -13367,6 +13843,19 @@
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow,
 /turf/simulated/floor/plating,
 /area/talon_v2/engineering/starboard)
+"UR" = (
+/obj/machinery/power/pointdefense{
+	id_tag = "talon_pd"
+	},
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 10
+	},
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/space)
 "UW" = (
 /obj/machinery/power/pointdefense{
 	id_tag = "talon_pd"
@@ -13391,6 +13880,11 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/talon_v2/central_hallway/port)
@@ -13617,9 +14111,9 @@
 	dir = 1;
 	pixel_y = -25
 	},
-/obj/structure/table/rack/shelf/steel,
+/obj/structure/reagent_dispensers/foam,
 /turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/unused)
+/area/talon_v2/gen_store)
 "VY" = (
 /obj/structure/closet/walllocker/emerglocker/east,
 /obj/machinery/light{
@@ -13641,6 +14135,23 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/shuttle/talonboat)
+"Wc" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/machinery/power/apc/talon{
+	name = "south bump";
+	pixel_y = -24
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/camera/network/talon{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/hangar)
 "Wd" = (
 /obj/machinery/autolathe,
 /turf/simulated/floor/tiled/techfloor,
@@ -13675,7 +14186,7 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/unused)
+/area/talon_v2/gen_store)
 "Wm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -13723,15 +14234,17 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/talon_v2/bridge)
 "Wr" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/structure/extinguisher_cabinet{
-	dir = 1;
-	pixel_y = -32
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/hangar)
+/obj/structure/bed/chair/bay/chair,
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/central_hallway)
 "Ws" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -13762,6 +14275,11 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/plating,
 /area/talon_v2/central_hallway)
 "Wu" = (
@@ -13775,6 +14293,7 @@
 /area/talon_v2/medical)
 "Wy" = (
 /obj/machinery/cryopod/talon,
+/obj/machinery/camera/network/talon,
 /turf/simulated/floor/tiled/techfloor,
 /area/talon_v2/central_hallway)
 "Wz" = (
@@ -13877,10 +14396,32 @@
 "WZ" = (
 /turf/simulated/wall/shull,
 /area/talon_v2/maintenance/aft_port)
+"Xa" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/aft_port)
+"Xb" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/wall/rshull,
+/area/talon_v2/maintenance/wing_starboard)
 "Xf" = (
 /obj/machinery/telecomms/allinone/talon{
 	id = "talon_aio";
 	network = "Talon"
+	},
+/obj/machinery/light/small{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/talon_v2/engineering)
@@ -14118,14 +14659,17 @@
 /area/space)
 "XX" = (
 /obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/machinery/light{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/techmaint,
+/obj/machinery/computer/ship/sensors{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
 /area/talon_v2/central_hallway)
 "XY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -14428,13 +14972,13 @@
 /turf/simulated/floor/plating,
 /area/talon_v2/engineering)
 "YW" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/talon_v2/engineering/starboard)
@@ -14550,18 +15094,28 @@
 /turf/simulated/floor/plating,
 /area/talon_v2/engineering)
 "Zp" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
 /obj/machinery/light_switch{
 	dir = 4;
 	pixel_x = -24
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/hangar)
+"Zr" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 1;
+	pixel_y = -32
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/talon_v2/hangar)
@@ -14717,6 +15271,12 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/talon_v2/maintenance/fore_port)
+"ZO" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/hangar)
 "ZP" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
@@ -14758,6 +15318,15 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/talon_v2/brig)
+"ZY" = (
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/fore_starboard)
 "ZZ" = (
 /obj/machinery/atmospherics/binary/pump/on{
 	dir = 8;
@@ -19241,9 +19810,9 @@ Dp
 yw
 XP
 XP
-XP
-aa
-aa
+Mu
+uK
+bA
 aa
 aa
 aa
@@ -19383,10 +19952,10 @@ Qk
 TR
 XP
 XP
+ZJ
+RD
+Kl
 XP
-XP
-XP
-aa
 aa
 aa
 aa
@@ -19526,8 +20095,8 @@ TR
 TR
 TR
 TR
-XP
-XP
+gD
+QI
 XP
 XP
 aa
@@ -19668,7 +20237,7 @@ TA
 Wa
 Wa
 TR
-TR
+nk
 TR
 TR
 XP
@@ -19810,7 +20379,7 @@ TA
 Du
 Ph
 TA
-VD
+ir
 vR
 TR
 TR
@@ -19952,7 +20521,7 @@ rm
 NS
 Ye
 TA
-VD
+ir
 CY
 ty
 vR
@@ -20094,7 +20663,7 @@ TA
 TA
 TA
 TA
-VD
+ir
 CY
 Xi
 CE
@@ -20236,7 +20805,7 @@ kf
 le
 OB
 qV
-CE
+EL
 CE
 pa
 Bv
@@ -21945,7 +22514,7 @@ Sn
 tC
 tC
 tC
-XP
+UR
 XP
 XP
 aa
@@ -22061,21 +22630,21 @@ aa
 aa
 aa
 aa
-XP
-wi
-wi
-hS
-hS
+OH
+ML
+ML
+NR
+NR
 cS
 xL
-hS
-hS
+NR
+NR
 Id
-hS
+NR
 KI
-hS
-hS
-oU
+NR
+NR
+lS
 Qj
 Va
 Iv
@@ -22087,7 +22656,7 @@ yg
 qa
 TX
 tC
-tC
+aR
 tC
 tC
 XP
@@ -22230,7 +22799,7 @@ WZ
 NB
 TX
 LA
-Mi
+IP
 tC
 tC
 tC
@@ -22374,8 +22943,8 @@ go
 Qu
 lV
 iy
-gI
-TX
+Xa
+LO
 tC
 tC
 tC
@@ -22392,7 +22961,7 @@ XP
 XP
 XP
 XP
-XP
+GC
 tm
 tm
 tm
@@ -22518,8 +23087,8 @@ Zc
 Pl
 Zc
 Jr
-gI
-gI
+Xa
+Xa
 vC
 tC
 aR
@@ -22534,7 +23103,7 @@ tC
 tC
 tC
 tC
-tC
+aR
 tC
 tC
 tC
@@ -22676,7 +23245,7 @@ rW
 rW
 LX
 rW
-Qm
+JB
 rW
 rW
 rW
@@ -22958,7 +23527,7 @@ yY
 Er
 rB
 XH
-XH
+Cr
 XH
 qu
 XH
@@ -23785,7 +24354,7 @@ lB
 Iq
 Iq
 Iq
-XX
+Iq
 ox
 Gj
 Zc
@@ -23927,8 +24496,8 @@ Ia
 fV
 Ks
 Ks
+Ks
 fV
-xB
 FK
 Zc
 ZZ
@@ -24067,10 +24636,10 @@ Nf
 As
 Ns
 Zp
-qc
+Ns
 Lr
+jb
 rI
-dw
 jO
 Zc
 Uh
@@ -24210,9 +24779,9 @@ Jm
 Ih
 Tt
 Tt
-NR
+Tt
+AV
 fV
-dw
 jO
 Zc
 rk
@@ -24336,8 +24905,8 @@ lU
 lU
 lU
 Aw
-Hh
-yV
+NU
+fV
 sf
 Tt
 Tt
@@ -24352,9 +24921,9 @@ aW
 mT
 hD
 EJ
-Bj
+QM
+qt
 yV
-dw
 yh
 Zc
 hY
@@ -24477,8 +25046,8 @@ Ur
 CH
 Cd
 lU
-pm
-Hh
+al
+St
 yV
 sf
 Eo
@@ -24493,10 +25062,10 @@ Tt
 RP
 wX
 uV
-EJ
-Bj
+IL
+QM
+qt
 yV
-dw
 dF
 Zc
 Zc
@@ -24618,9 +25187,9 @@ on
 Jk
 SL
 pN
-lU
+Ek
 kg
-Hh
+Wr
 yV
 sf
 Eo
@@ -24635,16 +25204,16 @@ Fy
 kI
 LM
 qL
+pk
 Tt
-Fq
+Wc
 fV
-NU
 sJ
 LY
 gF
 Qx
 Fx
-mM
+gl
 Ck
 IK
 aq
@@ -24762,7 +25331,7 @@ jg
 TL
 lU
 al
-Hh
+XX
 yV
 sf
 Eo
@@ -24776,11 +25345,11 @@ hH
 Tt
 Ux
 zC
-uV
-EJ
+qq
+IL
 QM
+ZO
 yV
-dw
 Sv
 LY
 Xf
@@ -24791,7 +25360,7 @@ AZ
 IK
 ar
 aD
-aM
+aJ
 IK
 ep
 zm
@@ -24904,8 +25473,8 @@ lU
 lU
 lU
 Aw
-Hh
-yV
+NU
+fV
 sf
 Tt
 Tt
@@ -24919,10 +25488,10 @@ Tt
 ME
 aH
 kM
-EJ
+ub
 QM
+ZO
 yV
-dw
 jO
 LY
 wH
@@ -25062,9 +25631,9 @@ ol
 AN
 Tt
 Tt
-Wr
+Tt
+Zr
 fV
-dw
 Aq
 LY
 BK
@@ -25165,7 +25734,7 @@ VI
 JO
 cx
 JO
-By
+dw
 By
 Zf
 Ip
@@ -25203,10 +25772,10 @@ AW
 Zh
 by
 qe
-Ek
+by
 oA
+Dj
 rI
-dw
 Cx
 LY
 IN
@@ -25215,7 +25784,7 @@ Sr
 jc
 LN
 Im
-LN
+fQ
 gj
 aQ
 Gb
@@ -25345,10 +25914,10 @@ fV
 Yx
 Ia
 fV
+Ks
 jM
 jM
 fV
-xB
 va
 LY
 HU
@@ -25449,7 +26018,7 @@ aa
 XP
 XP
 JO
-OX
+qc
 qI
 oh
 DU
@@ -25470,7 +26039,7 @@ EH
 iQ
 AQ
 qr
-vF
+Fq
 pG
 Hh
 SY
@@ -25489,9 +26058,9 @@ pG
 pG
 pG
 pG
+pG
 SY
-dw
-Gj
+ng
 LY
 fx
 KA
@@ -25632,7 +26201,7 @@ tx
 LD
 CO
 vw
-St
+CO
 Wt
 FT
 pw
@@ -26652,7 +27221,7 @@ rL
 rL
 bM
 rL
-vL
+EP
 rL
 rL
 rL
@@ -26778,9 +27347,9 @@ fW
 dJ
 cg
 IJ
-LF
-hL
-hL
+Av
+vc
+mm
 Dq
 Lk
 Dq
@@ -26794,7 +27363,7 @@ Dq
 Dq
 Dq
 Dq
-Dq
+Lk
 Dq
 Dq
 Dq
@@ -26915,11 +27484,11 @@ Ig
 fW
 dJ
 hL
-hL
+xr
 Mm
-hL
-hL
-hL
+vc
+vc
+mm
 Dq
 Dq
 Dq
@@ -26936,7 +27505,7 @@ XP
 XP
 XP
 XP
-XP
+DX
 tm
 tm
 tm
@@ -27057,7 +27626,7 @@ fW
 fW
 hL
 hL
-hL
+TJ
 xP
 Dq
 Dq
@@ -27173,13 +27742,13 @@ aa
 aa
 aa
 aa
-XP
-EU
-EU
-rx
-rx
-rx
-rx
+xB
+ZQ
+ZQ
+iM
+iM
+iM
+ZY
 uz
 RQ
 RQ
@@ -27199,7 +27768,7 @@ bP
 sZ
 hL
 Dq
-Dq
+Lk
 Dq
 Dq
 XP
@@ -27321,7 +27890,7 @@ EU
 EU
 QY
 rx
-rx
+sV
 CL
 Bw
 dT
@@ -27341,7 +27910,7 @@ ch
 Dq
 Dq
 Dq
-XP
+up
 XP
 XP
 aa
@@ -27463,7 +28032,7 @@ XP
 EU
 EU
 rx
-rx
+sV
 QY
 Bw
 Wd
@@ -27605,8 +28174,8 @@ aa
 XP
 EU
 EU
-rx
-rx
+wN
+ZY
 Bw
 Bw
 ss
@@ -27748,8 +28317,8 @@ aa
 XP
 EU
 EU
-rx
-rx
+wN
+ZY
 qN
 Sg
 eV
@@ -27891,7 +28460,7 @@ aa
 XP
 EU
 EU
-rx
+sV
 Bw
 Bw
 JH
@@ -29040,7 +29609,7 @@ gU
 EX
 ST
 Uk
-Iz
+bK
 Iz
 mV
 SG
@@ -29182,7 +29751,7 @@ mw
 mw
 mw
 mw
-BF
+AU
 yC
 Qc
 Iz
@@ -29324,7 +29893,7 @@ dd
 Hb
 pi
 mw
-BF
+AU
 yC
 Pv
 Gv
@@ -29466,7 +30035,7 @@ mw
 UA
 JV
 mw
-BF
+AU
 Gv
 Up
 Up
@@ -29608,7 +30177,7 @@ mw
 XC
 XC
 Up
-Up
+Xb
 Up
 Up
 XP
@@ -29750,8 +30319,8 @@ Up
 Up
 Up
 Up
-XP
-XP
+qX
+bA
 XP
 XP
 aa
@@ -29891,10 +30460,10 @@ Dy
 Up
 XP
 XP
+ZJ
+UI
+Kl
 XP
-XP
-XP
-aa
 aa
 aa
 aa
@@ -30033,9 +30602,9 @@ ke
 Hj
 XP
 XP
-XP
-aa
-aa
+mo
+Fg
+QI
 aa
 aa
 aa

--- a/maps/offmap_vr/talon/talon_v2_areas.dm
+++ b/maps/offmap_vr/talon/talon_v2_areas.dm
@@ -80,8 +80,8 @@
 /area/talon_v2/anomaly_storage
 	name = "\improper Talon - Anomaly Storage"
 	icon_state = "gray"
-/area/talon_v2/unused
-	name = "\improper Talon - Unused Room"
+/area/talon_v2/gen_store
+	name = "\improper Talon - General Storage"
 	icon_state = "gray"
 
 /area/talon_v2/armory
@@ -95,19 +95,19 @@
 	icon_state = "blue"
 
 /area/talon_v2/crew_quarters/pilot_room
-	name = "\improper Talon - Pilot Cabin"
+	name = "\improper Talon - Pilot's Cabin"
 	icon_state = "gray"
 /area/talon_v2/crew_quarters/med_room
-	name = "\improper Talon - Doctor Cabin"
+	name = "\improper Talon - Doctor's Cabin"
 	icon_state = "green"
 /area/talon_v2/crew_quarters/eng_room
-	name = "\improper Talon - Engineer Cabin"
+	name = "\improper Talon - Engineer's Cabin"
 	icon_state = "yellow"
 /area/talon_v2/crew_quarters/sec_room
-	name = "\improper Talon - Guard Cabin"
+	name = "\improper Talon - Guard's Cabin"
 	icon_state = "red"
 /area/talon_v2/crew_quarters/cap_room
-	name = "\improper Talon - Captain Cabin"
+	name = "\improper Talon - Captain's Cabin"
 	icon_state = "blue"
 /area/talon_v2/crew_quarters/bar
 	name = "\improper Talon - Bar"


### PR DESCRIPTION
Further improvements to the Talon;
- Changed most instances of "boat" to "shuttle" for consistency and to make it clear the shuttle can fly around the overmap by itself
- Added a remote recall/control console that can be used to recover the shuttle so long as you're at the same overmap X/Y
- Added a radsuit+hood to the locker outside the generator room, just to be safe
- Updated the Engineer's documentation since that got missed
- Fixed the shuttle having infinite power (sorry guys!) and updated the Pilot's documentation accordingly
- Added a half-dozen more PD turrets to cover major blind spots that could cause major atmospherics-related problems if breached
- Enlarged the shuttle's airlock and moved the shutter-buttons so they can be accessed from the outside too
- Moved a few odds and ends around
- The 'unused room' is now officially 'general storage' and contains welder fuel + water + foam tanks