### PR TITLE
Update alienwhitelist.txt

### DIFF
--- a/config/alienwhitelist.txt
+++ b/config/alienwhitelist.txt
@@ -16,6 +16,7 @@ bricker98 - Protean
 camanis - Protean
 cgr - Protean
 chargae - Protean
+chemlight - Xenochimera
 chillyfang - Black-Eyed Shadekin
 crossexonar - Protean
 detectivegoogle - Protean


### PR DESCRIPTION
Simply put, adds Chemlight to the XenoChimera whitelist.

https://forum.vore-station.net/viewtopic.php?f=46&t=1955

(Take two, now with 445 less commits, ran into something on accident was all for the first time.)