### PR TITLE
Changes Print vore belly settings to X-print vore belly settings.

### DIFF
--- a/code/modules/vore/eating/living_vr.dm
+++ b/code/modules/vore/eating/living_vr.dm
@@ -869,7 +869,7 @@
 	icon_state = ""
 
 /mob/living/proc/vorebelly_printout() //Spew the vorepanel belly messages into chat window for copypasting.
-	set name = "Print Vorebelly Settings"
+	set name = "X-Print Vorebelly Settings"
 	set category = "Preferences"
 	set desc = "Print out your vorebelly messages into chat for copypasting."
 


### PR DESCRIPTION
The reason for this change is that it this verb is really cool, but it also messes with speed typing 'Vore panel'
Given you use the 'Print' verb maybe once per two weeks, i added the X to make it show last.
