### PR TITLE
Expedition Medic Cargo Crate

### DIFF
--- a/code/datums/supplypacks/voidsuits_vr.dm
+++ b/code/datums/supplypacks/voidsuits_vr.dm
@@ -83,6 +83,20 @@
 	containername = "Exploration voidsuit crate"
 	access = access_explorer
 
+/datum/supply_pack/voidsuits/explorer_medic
+	name = "Expedition Medic voidsuits"
+	contains = list(
+			/obj/item/clothing/suit/space/void/exploration = 2,
+			/obj/item/clothing/head/helmet/space/void/exploration = 2,
+			/obj/item/clothing/mask/breath = 2,
+			/obj/item/clothing/shoes/magboots = 2,
+			/obj/item/weapon/tank/oxygen = 2
+			)
+	cost = 35
+	containertype = /obj/structure/closet/crate/secure
+	containername = "Expedition Medic voidsuit crate"
+	access = access_explorer
+
 /datum/supply_pack/voidsuits/pilot
 	name = "Pilot voidsuits"
 	contains = list(


### PR DESCRIPTION
Adds an orderable crate to cargo that contains two exploration medical voidsuits. 'nuff said.