### PR TITLE
Fixes proteans being a bit too liberal with reformation

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/protean_vr/protean_blob.dm
+++ b/code/modules/mob/living/carbon/human/species/station/protean_vr/protean_blob.dm
@@ -187,7 +187,7 @@
 		return humanform.adjustOxyLoss(amount)
 	else
 		return ..()
-	
+
 /mob/living/simple_mob/protean_blob/adjustHalLoss(amount)
 	if(humanform)
 		return humanform.adjustHalLoss(amount)
@@ -230,7 +230,7 @@
 	else
 		animate(src, alpha = 0, time = 2 SECONDS)
 		sleep(2 SECONDS)
-	
+
 	if(!QDELETED(src)) // Human's handle death should have taken us, but maybe we were adminspawned or something without a human counterpart
 		qdel(src)
 
@@ -380,7 +380,7 @@ var/global/list/disallowed_protean_accessories = list(
 		var/obj/belly/B = belly
 		B.forceMove(blob)
 		B.owner = blob
-	
+
 	//We can still speak our languages!
 	blob.languages = languages.Copy()
 
@@ -402,10 +402,14 @@ var/global/list/disallowed_protean_accessories = list(
 	if(!istype(blob))
 		return
 
+	if(istype(blob.loc, /obj/machinery/atmospherics))
+		to_chat(src, "You cannot reform in these confines!")
+		return
+
 	var/panel_was_up = FALSE
 	if(client?.statpanel == "Protean")
 		panel_was_up = TRUE
-	
+
 	if(buckled)
 		buckled.unbuckle_mob()
 	if(LAZYLEN(buckled_mobs))


### PR DESCRIPTION
Why is there no sanity check on "can we reform in there at all?" for proteans? Sounds like an oversight.

Can no longer reform onto the floor directly out of pipes. There's probably more circumstances where lack of sanity checks allows them to pull unrealistic even-by-protean-standards escapes, but I don't really feel like digging around looking for them, so just have the pipes for now.