### PR TITLE
Orderable Replacement Job Gear

### DIFF
--- a/code/datums/supplypacks/joblockers.dm
+++ b/code/datums/supplypacks/joblockers.dm
@@ -1,0 +1,202 @@
+/*
+*	Here is where any supply packs related
+*	to replacing a job's gear live.
+*/
+
+
+/datum/supply_pack/jobgear
+	group = "Replacement Equipment"
+
+
+/*
+TEMPLATE
+we don't actually need to 'contain' anything, using the proper containertype means it comes with all the stuff anyway!
+/datum/supply_pack/jobgear/
+	name = " Locker"
+	contains = null
+	cost = 30
+	containertype = 
+	containername = " Locker"
+
+/datum/supply_pack/jobgear/
+	name = " Locker"
+	contains = null
+	cost = 30
+	containertype = /obj/structure/closet/secure_closet/
+	containername = " Locker"
+*/
+
+/datum/supply_pack/jobgear/barservice
+	name = "Bartending & Service"
+	contains = null
+	cost = 30
+	containertype = /obj/structure/closet/gmcloset
+	containername = "Bartending & Service"
+
+/datum/supply_pack/jobgear/chef
+	name = "Chef's Supplies"
+	contains = null
+	cost = 30
+	containertype = /obj/structure/closet/chefcloset
+	containername = "Chef's Supplies"
+
+/datum/supply_pack/jobgear/jcloset
+	name = "Custodial Supplies"
+	contains = null
+	cost = 30
+	containertype = /obj/structure/closet/jcloset
+	containername = "Custodial Supplies"
+
+/datum/supply_pack/jobgear/legal
+	name = "IAA & Courtroom Apparel"
+	contains = null
+	cost = 30
+	containertype = /obj/structure/closet/lawcloset
+	containername = "IAA & Courtroom Apparel"
+
+/datum/supply_pack/jobgear/cargotech
+	name = "Cargo Technician's Locker"
+	contains = null
+	cost = 30
+	containertype = /obj/structure/closet/secure_closet/cargotech
+	containername = "Cargo Technician's Locker"
+
+/datum/supply_pack/jobgear/quartermaster
+	name = "Quartermaster's Locker"
+	contains = null
+	cost = 30
+	containertype = /obj/structure/closet/secure_closet/quartermaster
+	containername = "Quartermaster's Locker"
+
+/datum/supply_pack/jobgear/miner
+	name = "Miner's Locker"
+	contains = null
+	cost = 30
+	containertype = /obj/structure/closet/secure_closet/miner
+	containername = "Miner's Equipment Locker"
+
+/datum/supply_pack/jobgear/engineer_chief
+	name = "Chief Engineer's Locker"
+	contains = null
+	cost = 30
+	containertype = /obj/structure/closet/secure_closet/engineering_chief
+	containername = "Chief Engineer's Locker"
+
+/datum/supply_pack/jobgear/engineer_personal
+	name = "Engineer's Locker"
+	contains = null
+	cost = 30
+	containertype = /obj/structure/closet/secure_closet/engineering_personal
+	containername = "Engineer's Locker"
+
+/datum/supply_pack/jobgear/atmos_personal
+	name = "Atmos Tech's Locker"
+	contains = null
+	cost = 30
+	containertype = /obj/structure/closet/secure_closet/atmos_personal
+	containername = "Atmos Tech's Locker"
+
+/datum/supply_pack/jobgear/gen_medical
+	name = "Medical Doctor's Locker"
+	contains = null
+	cost = 30
+	containertype = /obj/structure/closet/secure_closet/medical3
+	containername = "Medical Doctor's Locker"
+
+/datum/supply_pack/jobgear/paramedic
+	name = "Paramedic's Locker"
+	contains = null
+	cost = 30
+	containertype = /obj/structure/closet/secure_closet/paramedic
+	containername = "Paramedic's Locker"
+
+/datum/supply_pack/jobgear/chief_medical
+	name = "Chief Medical Officer's Locker"
+	contains = null
+	cost = 30
+	containertype = /obj/structure/closet/secure_closet/CMO
+	containername = "Chief Medical Officer's Locker"
+
+/datum/supply_pack/jobgear/psych_medical
+	name = "Psychiatrist's Locker"
+	contains = null
+	cost = 30
+	containertype = /obj/structure/closet/secure_closet/psych
+	containername = "Psychiatrist's Locker"
+
+/datum/supply_pack/jobgear/sci_general
+	name = "Scientist's Locker"
+	contains = null
+	cost = 30
+	containertype = /obj/structure/closet/secure_closet/scientist
+	containername = "Scientist's Locker"
+
+/datum/supply_pack/jobgear/sci_director
+	name = "Research Director's Locker"
+	contains = null
+	cost = 30
+	containertype = /obj/structure/closet/secure_closet/RD
+	containername = "Research Director's Locker"
+
+/datum/supply_pack/jobgear/sci_xenoarch
+	name = "Xenoarchaeologist's Locker"
+	contains = null
+	cost = 30
+	containertype = /obj/structure/closet/secure_closet/xenoarchaeologist
+	containername = "Xenoarchaeologist's Locker"
+
+/datum/supply_pack/jobgear/botanist
+	name = "Botanist's Locker"
+	contains = null
+	cost = 30
+	containertype = /obj/structure/closet/secure_closet/hydroponics
+	containername = "Botanist's Locker"
+
+/datum/supply_pack/jobgear/botanist_sci
+	name = "Xenobotanist's Locker"
+	contains = null
+	cost = 30
+	containertype = /obj/structure/closet/secure_closet/hydroponics/sci
+	containername = "Xenobotanist's Locker"
+
+/datum/supply_pack/jobgear/site_manager
+	name = "Site Manager's Locker"
+	contains = null
+	cost = 30
+	containertype = /obj/structure/closet/secure_closet/captains
+	containername = "Site Manager's Locker"
+
+/datum/supply_pack/jobgear/head_personnel
+	name = "Head of Personnel's Locker"
+	contains = null
+	cost = 30
+	containertype = /obj/structure/closet/secure_closet/hop
+	containername = "Head of Personnel's Locker"
+
+/datum/supply_pack/jobgear/head_security
+	name = "Head of Security's Locker"
+	contains = null
+	cost = 30
+	containertype = /obj/structure/closet/secure_closet/hos
+	containername = "Head of Security's Locker"
+
+/datum/supply_pack/jobgear/warden
+	name = "Warden's Locker"
+	contains = null
+	cost = 30
+	containertype = /obj/structure/closet/secure_closet/warden
+	containername = "Warden's Locker"
+
+/datum/supply_pack/jobgear/security
+	name = "Security Officer's Locker"
+	contains = null
+	cost = 30
+	containertype = /obj/structure/closet/secure_closet/security
+	containername = "Security Officer's Locker"
+
+/datum/supply_pack/jobgear/detective
+	name = "Detective's Locker"
+	contains = null
+	cost = 30
+	containertype = /obj/structure/closet/secure_closet/detective
+	containername = "Detective's Locker"

--- a/code/datums/supplypacks/supplypacks.dm
+++ b/code/datums/supplypacks/supplypacks.dm
@@ -19,6 +19,7 @@ var/list/all_supply_groups = list("Atmospherics",
 								  "Reagents",
 								  "Reagent Cartridges",
 								  "Recreation",
+								  "Replacement Equipment",	//VOREStation Addition
 								  "Robotics",
 								  "Science",
 								  "Security",

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -440,6 +440,7 @@
 #include "code\datums\supplypacks\hospitality_vr.dm"
 #include "code\datums\supplypacks\hydroponics.dm"
 #include "code\datums\supplypacks\hydroponics_vr.dm"
+#include "code\datums\supplypacks\joblockers.dm"
 #include "code\datums\supplypacks\materials.dm"
 #include "code\datums\supplypacks\medical.dm"
 #include "code\datums\supplypacks\medical_vr.dm"


### PR DESCRIPTION
WIP/Proof of Concept for ordering lockers of replacement job gear via cargo, as suggested by @Novacat in #10409.

![image](https://user-images.githubusercontent.com/49700375/119788658-3d891f80-beca-11eb-87fa-163e8a05b008.png)

Currently uses the *actual* job lockers. Pros;
- Easy to maintain, access restriction(s) and contents always match whatever the server's local settings are.

Cons;
- Doesn't show contents when viewed at the cargo console.
- Can include items that may be better put in their own crates or simply not be available.

Wanted to PR this up on Polaris but their cargo console wasn't cooperating when I tried to test it, something about missing templates.

Prices are placeholders. Contents and lockers may need to be totally overhauled (see cons, above).