### PR TITLE
Emote Delay Strikes Back

### DIFF
--- a/code/modules/emotes/definitions/visible_animated.dm
+++ b/code/modules/emotes/definitions/visible_animated.dm
@@ -12,7 +12,7 @@
 	key = "sidestep"
 	check_restraints = TRUE
 	emote_message_3p = "steps rhythmically and moves side to side."
-	emote_delay = 1.2 SECONDS
+	//emote_delay = 1.2 SECONDS //VOREStation Edit - Delay moved to parent
 
 /decl/emote/visible/sidestep/do_extra(mob/user)
 	if(istype(user))
@@ -26,7 +26,7 @@
 	emote_message_1p = "You do a flip!"
 	emote_message_3p = "does a flip!"
 	emote_sound = 'sound/effects/bodyfall4.ogg'
-	emote_delay = 1.2 SECONDS
+	//emote_delay = 1.2 SECONDS //VOREStation Edit - Delay moved to parent
 
 /decl/emote/visible/flip/do_extra(mob/user)
 	. = ..()
@@ -42,7 +42,7 @@
 	key = "floorspin"
 	emote_message_1p = "You spin around on the floor!"
 	emote_message_3p = "spins around on the floor!"
-	emote_delay = 1.2 SECONDS
+	//emote_delay = 1.2 SECONDS //VOREStation Edit - Delay moved to parent
 	var/static/list/spin_dirs = list(
 		NORTH,
 		SOUTH,

--- a/code/modules/emotes/emote_define.dm
+++ b/code/modules/emotes/emote_define.dm
@@ -35,7 +35,7 @@ var/global/list/emotes_by_key
 	var/list/emote_sound_synthetic                      // As above, but used when check_synthetic() is true.
 	var/emote_volume = 50                               // Volume of sound to play.
 	var/emote_volume_synthetic = 50                     // As above, but used when check_synthetic() is true.
-	var/emote_delay = 0                                 // Time in ds that this emote will block further emote use (spam prevention).
+	var/emote_delay = 1.2 SECONDS                       // Time in ds that this emote will block further emote use (spam prevention). // VOREStation Edit
 
 	var/message_type = VISIBLE_MESSAGE                  // Audible/visual flag
 	var/check_restraints                                // Can this emote be used while restrained?


### PR DESCRIPTION
Readds the 1.2 SECOND emote delay across the board. Definitely not related to nightmare textwalls in runechat or anything.