### PR TITLE
Enable encoding chat emphasis in runechat

### DIFF
--- a/code/datums/chat_message.dm
+++ b/code/datums/chat_message.dm
@@ -156,6 +156,8 @@ var/list/runechat_image_cache = list()
 
 	text = "[prefixes?.Join("&nbsp;")][text]"
 
+	text = encode_html_emphasis(text)
+
 	// We dim italicized text to make it more distinguishable from regular text
 	var/tgt_color = extra_classes.Find("italics") ? target.chat_color_darkened : target.chat_color
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/15028025/120215742-13a26680-c204-11eb-91d2-a1388f08d880.png)
