### PR TITLE
Fixes #10463

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/protean_vr/protean_blob.dm
+++ b/code/modules/mob/living/carbon/human/species/station/protean_vr/protean_blob.dm
@@ -305,7 +305,11 @@ var/global/list/disallowed_protean_accessories = list(
 	)
 
 // Helpers - Unsafe, WILL perform change.
-/mob/living/carbon/human/proc/nano_intoblob()
+/mob/living/carbon/human/proc/nano_intoblob(force)
+	if(!force && !isturf(loc))
+		to_chat(src,"<span class='warning'>You can't change forms while inside something.</span>")
+		return
+		
 	var/panel_was_up = FALSE
 	if(client?.statpanel == "Protean")
 		panel_was_up = TRUE
@@ -398,7 +402,11 @@ var/global/list/disallowed_protean_accessories = list(
 		if(istype(I, /obj/item/weapon/holder))
 			root.remove_from_mob(I)
 
-/mob/living/carbon/human/proc/nano_outofblob(var/mob/living/simple_mob/protean_blob/blob)
+/mob/living/carbon/human/proc/nano_outofblob(var/mob/living/simple_mob/protean_blob/blob, force)
+	if(!force && !isturf(loc))
+		to_chat(src,"<span class='warning'>You can't change forms while inside something.</span>")
+		return
+	
 	if(!istype(blob))
 		return
 

--- a/code/modules/mob/living/carbon/human/species/station/protean_vr/protean_powers.dm
+++ b/code/modules/mob/living/carbon/human/species/station/protean_vr/protean_powers.dm
@@ -12,13 +12,16 @@
 		to_chat(src,"<span class='warning'>You must be awake and standing to perform this action!</span>")
 		return
 
+	if(!isturf(loc))
+		to_chat(src,"<span class='warning'>You need more space to perform this action!</span>")
+		return
+
 	var/obj/item/organ/internal/nano/refactory/refactory = nano_get_refactory()
 	//Missing the organ that does this
 	if(!istype(refactory))
 		to_chat(src,"<span class='warning'>You don't have a working refactory module!</span>")
 		return
-
-
+		
 	var/choice = input(src,"Pick the bodypart to change:", "Refactor - One Bodypart") as null|anything in species.has_limbs
 	if(!choice)
 		return
@@ -89,6 +92,10 @@
 
 	if(stat)
 		to_chat(src,"<span class='warning'>You must be awake and standing to perform this action!</span>")
+		return
+
+	if(!isturf(loc))
+		to_chat(src,"<span class='warning'>You need more space to perform this action!</span>")
 		return
 
 	var/obj/item/organ/internal/nano/refactory/refactory = nano_get_refactory()
@@ -232,6 +239,10 @@
 	set category = "Abilities"
 	set hidden = TRUE
 
+	if(!isturf(loc))
+		to_chat(src,"<span class='warning'>You need more space to perform this action!</span>")
+		return
+	
 	//Blob form
 	if(temporary_form)
 		if(health < maxHealth*0.5)

--- a/code/modules/mob/living/carbon/human/species/station/protean_vr/protean_species.dm
+++ b/code/modules/mob/living/carbon/human/species/station/protean_vr/protean_species.dm
@@ -183,7 +183,6 @@
 
 /datum/species/protean/handle_environment_special(var/mob/living/carbon/human/H)
 	if((H.getActualBruteLoss() + H.getActualFireLoss()) > H.maxHealth*0.5 && isturf(H.loc)) //So, only if we're not a blob (we're in nullspace) or in someone (or a locker, really, but whatever)
-		H.nano_intoblob()
 		return ..() //Any instakill shot runtimes since there are no organs after this. No point to not skip these checks, going to nullspace anyway.
 
 	var/obj/item/organ/internal/nano/refactory/refactory = locate() in H.internal_organs


### PR DESCRIPTION
More than just that issue, since this can be an issue in mechs, suit cyclers, sleepers, med scanners, basically anything that tracks occupant. I'm not planning on rewriting every object to accommodate proteans. If we end up with more cases in which those things need to be 'very' robust about tracking where the occupant is, then we can rewrite those. Also not planning on making a giant list of things that proteans are allowed to swap inside. The blob-due-to-injury already had an isturf() check in it, even.