### PR TITLE
Map Polish

### DIFF
--- a/code/game/machinery/atmoalter/pump_vr.dm
+++ b/code/game/machinery/atmoalter/pump_vr.dm
@@ -21,10 +21,10 @@
 	gid++
 
 	name = "[name] (ID [id])"
-
-/obj/machinery/portable_atmospherics/powered/pump/huge/attack_hand(var/mob/user)
-	to_chat(user, "<span class='notice'>You can't directly interact with this machine. Use the pump control console.</span>")
-
+// Commenting this out because the area_atmos computers will NOT connect to huge air pumps. Getting rid of this is the only way to interact with the Huge Air Pumps right now.
+///obj/machinery/portable_atmospherics/powered/pump/huge/attack_hand(var/mob/user)
+//	to_chat(user, "<span class='notice'>You can't directly interact with this machine. Use the pump control console.</span>")
+//
 /obj/machinery/portable_atmospherics/powered/pump/huge/update_icon()
 	overlays.Cut()
 

--- a/code/game/objects/items/weapons/storage/secure_vr.dm
+++ b/code/game/objects/items/weapons/storage/secure_vr.dm
@@ -2,4 +2,4 @@
 	name = "toxins football"
 	desc = "A large briefcase with a digital locking system and sleek, sciency design. This one has a hazard symbol that warns of explosive contents. It feels extremely heavy."
 	force = 14 // DON'T FUCK WITH THE SCIENCE TEAM!
-	slowdown = 0.25
+	slowdown = 0.5

--- a/code/game/objects/items/weapons/storage/secure_vr.dm
+++ b/code/game/objects/items/weapons/storage/secure_vr.dm
@@ -1,0 +1,4 @@
+/obj/item/weapon/storage/secure/briefcase/toxinsfootball
+	name = "toxins football"
+	desc = "A large briefcase with a digital locking system and sleek, sciency design. This one has a hazard symbol that warns of explosive contents. It feels extremely heavy."
+	force = 14 // DON'T FUCK WITH THE SCIENCE TEAM!

--- a/code/game/objects/items/weapons/storage/secure_vr.dm
+++ b/code/game/objects/items/weapons/storage/secure_vr.dm
@@ -2,3 +2,4 @@
 	name = "toxins football"
 	desc = "A large briefcase with a digital locking system and sleek, sciency design. This one has a hazard symbol that warns of explosive contents. It feels extremely heavy."
 	force = 14 // DON'T FUCK WITH THE SCIENCE TEAM!
+	slowdown = 0.25

--- a/maps/submaps/engine_submaps_vr/tether/engine_sme.dmm
+++ b/maps/submaps/engine_submaps_vr/tether/engine_sme.dmm
@@ -139,6 +139,7 @@
 	icon_state = "map";
 	dir = 1
 	},
+/obj/machinery/camera/network/engine,
 /turf/simulated/floor,
 /area/engineering/engine_room)
 "az" = (

--- a/maps/submaps/engine_submaps_vr/tether/engine_sme.dmm
+++ b/maps/submaps/engine_submaps_vr/tether/engine_sme.dmm
@@ -220,6 +220,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "east bump";
+	nightshift_setting = 2;
 	pixel_x = 28
 	},
 /turf/simulated/floor,
@@ -1578,6 +1579,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "east bump";
+	nightshift_setting = 2;
 	pixel_x = 28
 	},
 /obj/structure/closet/radiation,

--- a/maps/tether/tether-01-surface1.dmm
+++ b/maps/tether/tether-01-surface1.dmm
@@ -1859,9 +1859,6 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/camera/network/medbay{
-	dir = 4
-	},
 /obj/structure/closet/secure_closet/chemical{
 	req_access = list(64);
 	req_one_access = list(5)
@@ -2395,9 +2392,6 @@
 /area/tether/surfacebase/medical/lowerhall)
 "aea" = (
 /obj/structure/flora/ausbushes/brflowers,
-/obj/machinery/camera/network/medbay{
-	dir = 8
-	},
 /turf/simulated/floor/grass,
 /area/tether/surfacebase/medical/mentalhealth)
 "aeb" = (
@@ -11865,11 +11859,11 @@
 /turf/simulated/floor/plating,
 /area/tether/surfacebase/tram)
 "auc" = (
-/obj/effect/floor_decal/techfloor/orange{
-	dir = 8
-	},
-/obj/structure/railing{
-	dir = 8
+/obj/structure/grille,
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 4;
+	frequency = 1300;
+	id_tag = null
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/tether/surfacebase/tram)
@@ -12874,14 +12868,16 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/tram)
 "avD" = (
+/obj/effect/floor_decal/techfloor/orange{
+	dir = 8
+	},
+/obj/structure/railing{
+	dir = 8
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/tether/surfacebase/tram)
 "avE" = (
 /obj/structure/cable/green{
@@ -18619,18 +18615,16 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/tram)
 "aEP" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+/obj/effect/floor_decal/techfloor/orange{
+	dir = 8
 	},
-/obj/structure/cable/orange{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/railing{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/tether/surfacebase/tram)
 "aEQ" = (
 /obj/structure/sign/electricshock,
@@ -19355,7 +19349,10 @@
 /obj/structure/railing{
 	dir = 8
 	},
-/obj/structure/railing,
+/obj/machinery/camera/network/civilian{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/tether/surfacebase/tram)
 "aFV" = (
@@ -29341,7 +29338,13 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/tether/surfacebase/tram)
 "aXU" = (
-/obj/structure/grille,
+/obj/effect/floor_decal/techfloor/orange{
+	dir = 8
+	},
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/tether/surfacebase/tram)
 "aXV" = (
@@ -29358,9 +29361,8 @@
 /obj/structure/railing{
 	dir = 8
 	},
-/obj/machinery/camera/network/civilian{
-	dir = 4
-	},
+/obj/structure/railing,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/tether/surfacebase/tram)
 "aXX" = (
@@ -29748,6 +29750,16 @@
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/plating,
 /area/maintenance/lower/atmos)
+"aYH" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/tram)
 "aYI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -29763,6 +29775,18 @@
 	},
 /turf/simulated/floor/plating,
 /area/vacant/vacant_bar)
+"aYJ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/tram)
+"aYK" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/tether/surfacebase/tram)
 "aYL" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
@@ -29772,6 +29796,15 @@
 	},
 /turf/simulated/floor/wood,
 /area/vacant/vacant_bar)
+"aYM" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/tether/surfacebase/tram)
 "aYN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -29791,6 +29824,52 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/vacant/vacant_bar)
+"aYP" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/tram)
+"aYQ" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/tether/surfacebase/tram)
+"aYR" = (
+/obj/effect/floor_decal/techfloor/orange{
+	dir = 8
+	},
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/tether/surfacebase/tram)
+"aYS" = (
+/obj/effect/floor_decal/techfloor/orange{
+	dir = 8
+	},
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/tether/surfacebase/tram)
 "aYT" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -35041,18 +35120,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_one_hall)
-"mtl" = (
-/obj/effect/floor_decal/techfloor/orange{
-	dir = 8
-	},
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/structure/railing{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/tether/surfacebase/tram)
 "mvM" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -54742,7 +54809,7 @@ atx
 atZ
 auC
 auC
-avD
+aYH
 awj
 awj
 awj
@@ -54754,7 +54821,7 @@ aCb
 aCU
 aCU
 aCU
-aEP
+aYP
 aFH
 aFX
 aGB
@@ -54884,6 +54951,7 @@ atx
 auB
 auB
 auU
+aYJ
 auB
 auB
 auB
@@ -54895,8 +54963,7 @@ auB
 auB
 auB
 auB
-auB
-auB
+aYJ
 auU
 auB
 atW
@@ -55026,6 +55093,7 @@ atx
 auB
 auB
 auB
+aYJ
 auB
 auB
 auB
@@ -55037,8 +55105,7 @@ auB
 auB
 auB
 auB
-auB
-auB
+aYJ
 auB
 auB
 auB
@@ -55160,15 +55227,15 @@ aah
 aah
 aah
 aty
-aXU
-aXU
-aXU
-aXU
+auc
+auc
+auc
+auc
 aty
 atB
 oeA
 oeA
-oeA
+aYK
 auB
 auB
 auB
@@ -55180,14 +55247,14 @@ auB
 auB
 auB
 auB
-oeA
+aYK
 oeA
 oeA
 aGC
 aty
-aXU
-aXU
-aXU
+auc
+auc
+auc
 aty
 aad
 aad
@@ -55302,15 +55369,15 @@ aah
 aah
 aah
 auD
-auc
-auc
-auc
-auc
-aXW
-auc
-auc
+avD
+aEP
+aEP
+aEP
 aFU
-atA
+aXU
+aXU
+aXW
+aYM
 atA
 atA
 atA
@@ -55322,14 +55389,14 @@ atA
 atA
 atA
 atA
-atA
-mtl
-auc
-auc
-aXW
-auc
-auc
-auc
+aYQ
+aYR
+aXU
+aXU
+aFU
+aEP
+aEP
+aYS
 auD
 aad
 aad

--- a/maps/tether/tether-01-surface1.dmm
+++ b/maps/tether/tether-01-surface1.dmm
@@ -315,12 +315,8 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/lowernortheva)
 "aaD" = (
-/obj/structure/closet/crate/bin,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/wood,
-/area/tether/surfacebase/medical/mentalhealth)
+/turf/simulated/wall/r_wall,
+/area/tether/surfacebase/lowernortheva/external)
 "aaE" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/wood,
@@ -1860,8 +1856,17 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/mining_eva)
 "adq" = (
-/obj/structure/flora/ausbushes/brflowers,
-/turf/simulated/floor/grass,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/camera/network/medbay{
+	dir = 4
+	},
+/obj/structure/closet/secure_closet/chemical{
+	req_access = list(64);
+	req_one_access = list(5)
+	},
+/turf/simulated/floor/wood,
 /area/tether/surfacebase/medical/mentalhealth)
 "adr" = (
 /obj/structure/disposalpipe/segment{
@@ -2389,11 +2394,11 @@
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/lowerhall)
 "aea" = (
-/obj/structure/closet/secure_closet/chemical{
-	req_access = list(64);
-	req_one_access = list(5)
+/obj/structure/flora/ausbushes/brflowers,
+/obj/machinery/camera/network/medbay{
+	dir = 8
 	},
-/turf/simulated/floor/carpet/blue,
+/turf/simulated/floor/grass,
 /area/tether/surfacebase/medical/mentalhealth)
 "aeb" = (
 /obj/structure/cable{
@@ -3160,8 +3165,9 @@
 /turf/simulated/floor/reinforced,
 /area/rnd/testingroom)
 "aff" = (
-/turf/simulated/wall,
-/area/medical/virologyaccess)
+/obj/structure/closet/crate/bin,
+/turf/simulated/floor/carpet/blue,
+/area/tether/surfacebase/medical/mentalhealth)
 "afg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -6280,8 +6286,14 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/public_garden_maintenence)
 "akK" = (
-/turf/simulated/wall,
-/area/tether/surfacebase/lowernortheva/external)
+/obj/structure/table/rack,
+/obj/fiftyspawner/wood,
+/obj/fiftyspawner/cardboard,
+/obj/fiftyspawner/plastic,
+/obj/fiftyspawner/steel,
+/obj/fiftyspawner/glass,
+/turf/simulated/floor/plating,
+/area/maintenance/lower/trash_pit)
 "akL" = (
 /turf/simulated/floor/reinforced{
 	name = "Holodeck Projector Floor"
@@ -10651,7 +10663,9 @@
 "arR" = (
 /obj/structure/table/glass,
 /obj/random/medical/lite,
-/obj/item/device/radio/intercom/department/medbay,
+/obj/item/device/radio/intercom/department/medbay{
+	pixel_y = -24
+	},
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/first_aid_west)
 "arS" = (
@@ -11565,11 +11579,11 @@
 /turf/simulated/wall,
 /area/tether/surfacebase/tram)
 "atz" = (
-/obj/effect/floor_decal/techfloor/orange{
-	dir = 8
+/obj/item/device/radio/intercom{
+	pixel_y = -24
 	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/tether/surfacebase/tram)
+/turf/simulated/floor/carpet/gaycarpet,
+/area/tether/surfacebase/funny/clownoffice)
 "atA" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
@@ -23098,28 +23112,29 @@
 	},
 /area/crew_quarters/sleep/Dorm_7/holo)
 "aMy" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/floor_decal/spline/plain{
-	dir = 8
+/obj/structure/cable/orange{
+	d2 = 2;
+	icon_state = "0-2"
 	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/sleep/Dorm_7)
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_y = 28
+	},
+/turf/simulated/floor/reinforced{
+	name = "Holodeck Projector Floor"
+	},
+/area/crew_quarters/sleep/Dorm_7/holo)
 "aMz" = (
-/obj/machinery/button/remote/airlock{
-	id = "dorm7";
-	name = "Room 7 Lock";
-	pixel_x = 26;
-	pixel_y = -4;
-	specialfunctions = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/orange{
 	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/sleep/Dorm_7)
+/turf/simulated/floor/reinforced{
+	name = "Holodeck Projector Floor"
+	},
+/area/crew_quarters/sleep/Dorm_7/holo)
 "aMA" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -24254,12 +24269,17 @@
 /obj/effect/floor_decal/spline/plain{
 	dir = 8
 	},
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/wood,
-/area/crew_quarters/sleep/Dorm_5)
+/area/crew_quarters/sleep/Dorm_7)
 "aOH" = (
 /obj/machinery/button/remote/airlock{
-	id = "dorm5";
-	name = "Room 5 Lock";
+	id = "dorm7";
+	name = "Room 7 Lock";
 	pixel_x = 26;
 	pixel_y = -4;
 	specialfunctions = 4
@@ -24270,8 +24290,13 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/structure/cable/orange{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/wood,
-/area/crew_quarters/sleep/Dorm_5)
+/area/crew_quarters/sleep/Dorm_7)
 "aOI" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -25441,28 +25466,29 @@
 	},
 /area/crew_quarters/sleep/Dorm_3/holo)
 "aQG" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/floor_decal/spline/plain{
-	dir = 8
+/obj/structure/cable/orange{
+	d2 = 2;
+	icon_state = "0-2"
 	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/sleep/Dorm_3)
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_y = 28
+	},
+/turf/simulated/floor/reinforced{
+	name = "Holodeck Projector Floor"
+	},
+/area/crew_quarters/sleep/Dorm_5/holo)
 "aQH" = (
-/obj/machinery/button/remote/airlock{
-	id = "dorm3";
-	name = "Room 3 Lock";
-	pixel_x = 26;
-	pixel_y = -4;
-	specialfunctions = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/orange{
 	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/sleep/Dorm_3)
+/turf/simulated/floor/reinforced{
+	name = "Holodeck Projector Floor"
+	},
+/area/crew_quarters/sleep/Dorm_5/holo)
 "aQI" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -26560,12 +26586,17 @@
 /obj/effect/floor_decal/spline/plain{
 	dir = 8
 	},
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/wood,
-/area/crew_quarters/sleep/Dorm_1)
+/area/crew_quarters/sleep/Dorm_5)
 "aSU" = (
 /obj/machinery/button/remote/airlock{
-	id = "dorm1";
-	name = "Room 1 Lock";
+	id = "dorm5";
+	name = "Room 5 Lock";
 	pixel_x = 26;
 	pixel_y = -4;
 	specialfunctions = 4
@@ -26576,8 +26607,13 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/structure/cable/orange{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/wood,
-/area/crew_quarters/sleep/Dorm_1)
+/area/crew_quarters/sleep/Dorm_5)
 "aSV" = (
 /obj/machinery/button/remote/airlock{
 	id = "dorm2";
@@ -29254,6 +29290,14 @@
 	},
 /turf/simulated/floor/tiled/steel_dirty,
 /area/maintenance/lower/atmos)
+"aXN" = (
+/obj/structure/bed/chair/bar_stool,
+/obj/item/device/radio/intercom{
+	dir = 1;
+	pixel_y = 24
+	},
+/turf/simulated/floor/carpet/bcarpet,
+/area/tether/surfacebase/funny/mimeoffice)
 "aXO" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -29292,6 +29336,33 @@
 /obj/effect/decal/cleanable/vomit,
 /turf/simulated/floor/plating,
 /area/maintenance/lower/atmos)
+"aXT" = (
+/obj/machinery/portable_atmospherics/powered/scrubber/huge/stationary/tram,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/tether/surfacebase/tram)
+"aXU" = (
+/obj/structure/grille,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/tether/surfacebase/tram)
+"aXV" = (
+/obj/machinery/portable_atmospherics/powered/scrubber/huge/stationary/tram,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/tether/surfacebase/tram)
+"aXW" = (
+/obj/effect/floor_decal/techfloor/orange{
+	dir = 8
+	},
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/machinery/camera/network/civilian{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/tether/surfacebase/tram)
 "aXX" = (
 /obj/machinery/alarm{
 	dir = 4;
@@ -29310,6 +29381,38 @@
 	},
 /turf/simulated/floor/wood,
 /area/vacant/vacant_bar)
+"aXZ" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/lightgrey/bordercorner2{
+	dir = 6
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 9
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 10
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/camera/network/civilian{
+	dir = 9
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/surface_one_hall)
 "aYa" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -29401,12 +29504,36 @@
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/plating,
 /area/maintenance/lower/atmos)
+"aYl" = (
+/obj/structure/cable/orange{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_y = 28
+	},
+/turf/simulated/floor/reinforced{
+	name = "Holodeck Projector Floor"
+	},
+/area/crew_quarters/sleep/Dorm_3/holo)
 "aYm" = (
 /obj/machinery/light/small{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/lower/atmos)
+"aYn" = (
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/reinforced{
+	name = "Holodeck Projector Floor"
+	},
+/area/crew_quarters/sleep/Dorm_3/holo)
 "aYo" = (
 /obj/machinery/light_construct{
 	dir = 8
@@ -29447,6 +29574,18 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/vacant/vacant_bar)
+"aYt" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/spline/plain{
+	dir = 8
+	},
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/sleep/Dorm_3)
 "aYu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -29483,6 +29622,27 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/sleep/maintDorm3)
+"aYw" = (
+/obj/machinery/button/remote/airlock{
+	id = "dorm3";
+	name = "Room 3 Lock";
+	pixel_x = 26;
+	pixel_y = -4;
+	specialfunctions = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/orange{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/sleep/Dorm_3)
 "aYx" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 4
@@ -29490,6 +29650,20 @@
 /obj/machinery/disposal,
 /turf/simulated/floor/plating,
 /area/crew_quarters/sleep/maintDorm2)
+"aYy" = (
+/obj/structure/cable/orange{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_y = 28
+	},
+/turf/simulated/floor/reinforced{
+	name = "Holodeck Projector Floor"
+	},
+/area/crew_quarters/sleep/Dorm_1/holo)
 "aYz" = (
 /obj/structure/sink{
 	pixel_y = 22
@@ -29500,6 +29674,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/crew_quarters/sleep/maintDorm2)
+"aYA" = (
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/reinforced{
+	name = "Holodeck Projector Floor"
+	},
+/area/crew_quarters/sleep/Dorm_1/holo)
 "aYB" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 4
@@ -29507,6 +29691,39 @@
 /obj/machinery/disposal,
 /turf/simulated/floor/plating,
 /area/crew_quarters/sleep/maintDorm1)
+"aYC" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/spline/plain{
+	dir = 8
+	},
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/sleep/Dorm_1)
+"aYD" = (
+/obj/machinery/button/remote/airlock{
+	id = "dorm1";
+	name = "Room 1 Lock";
+	pixel_x = 26;
+	pixel_y = -4;
+	specialfunctions = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/orange{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/sleep/Dorm_1)
 "aYE" = (
 /obj/structure/toilet{
 	pixel_y = 10
@@ -33648,10 +33865,6 @@
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/tether/surfacebase/security/brig/bathroom)
-"iWa" = (
-/obj/structure/bed/chair/bar_stool,
-/turf/simulated/floor/carpet/bcarpet,
-/area/tether/surfacebase/funny/mimeoffice)
 "iWx" = (
 /obj/effect/floor_decal/corner/lightorange{
 	dir = 5
@@ -36866,9 +37079,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/lower/vacant_site)
-"trV" = (
-/turf/simulated/wall/r_wall,
-/area/tether/surfacebase/security/brig/storage)
 "tvk" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -37699,35 +37909,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/brig)
-"wxa" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 6
-	},
-/obj/effect/floor_decal/corner/lightgrey/bordercorner2{
-	dir = 6
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 9
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 10
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/orange{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/surface_one_hall)
 "wzA" = (
 /obj/structure/catwalk,
 /obj/machinery/alarm{
@@ -37817,11 +37998,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/brig)
-"wWK" = (
-/obj/structure/table/rack,
-/obj/fiftyspawner/wood,
-/turf/simulated/floor/plating,
-/area/maintenance/lower/trash_pit)
 "wXW" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
@@ -45723,7 +45899,7 @@ aah
 bqI
 bqI
 uFS
-trV
+bqI
 bqI
 bqI
 paY
@@ -46854,7 +47030,7 @@ aad
 aad
 aad
 aad
-adK
+ano
 aad
 aad
 aad
@@ -48557,8 +48733,8 @@ aad
 aad
 aad
 aad
-adK
-adK
+ano
+ano
 aad
 aad
 aad
@@ -48699,8 +48875,8 @@ aae
 aae
 aae
 aae
-akK
-akK
+aaD
+aaD
 aae
 aaf
 aai
@@ -50686,8 +50862,8 @@ aad
 aad
 aad
 aad
-adK
-adK
+ano
+ano
 aad
 aad
 aad
@@ -50828,8 +51004,8 @@ aad
 aad
 aad
 aad
-adK
-adK
+ano
+ano
 aad
 aad
 aad
@@ -51966,7 +52142,7 @@ aad
 aad
 aad
 aan
-aaD
+adq
 abq
 acq
 acY
@@ -52033,20 +52209,20 @@ aJf
 aJQ
 aKE
 aLg
-aLM
-aLM
+aMy
+aMz
 aLM
 aLg
-aOk
-aOk
+aQG
+aQH
 aOk
 aOj
-aQc
-aQc
+aYl
+aYn
 aQc
 aQb
-aSj
-aSj
+aYy
+aYA
 aSj
 aSi
 aUh
@@ -52104,7 +52280,7 @@ aad
 aad
 aad
 aad
-adK
+ano
 aad
 aad
 aar
@@ -52176,19 +52352,19 @@ aJQ
 aKF
 aLg
 aLN
-aMy
+aOG
 aNi
 aLg
 aOl
-aOG
+aST
 aOY
 aOj
 aQd
-aQG
+aYt
 aRi
 aQb
 aSk
-aST
+aYC
 aTx
 aSi
 aUi
@@ -52254,7 +52430,7 @@ abL
 abL
 abL
 abL
-aea
+aff
 afb
 atO
 awC
@@ -52275,7 +52451,7 @@ aHq
 aef
 nUG
 mnN
-wWK
+akK
 ahx
 ait
 aoc
@@ -52318,19 +52494,19 @@ agM
 agM
 aLg
 aLO
-aMz
+aOH
 aNj
 aLg
 aOm
-aOH
+aSU
 aOZ
 aOj
 aQe
-aQH
+aYw
 aRj
 aQb
 aSl
-aSU
+aYD
 aTy
 aSi
 aUj
@@ -52697,7 +52873,7 @@ oKn
 fFb
 meS
 meS
-meS
+atz
 aaU
 aaU
 qJl
@@ -52734,7 +52910,7 @@ eow
 kAG
 rZZ
 ghg
-wxa
+aXZ
 glc
 glc
 glc
@@ -52814,7 +52990,7 @@ aad
 aad
 aad
 aad
-adK
+ano
 aad
 aad
 aan
@@ -52965,11 +53141,11 @@ acc
 acI
 adm
 aan
-aff
-aff
+afm
+afm
 awX
-aff
-aff
+afm
+afm
 ayC
 azE
 axP
@@ -53105,13 +53281,13 @@ aad
 aan
 ace
 acK
-adq
+aea
 aan
-aff
+afm
 auq
 ady
 ayd
-aff
+afm
 aaI
 acA
 axP
@@ -53249,11 +53425,11 @@ aan
 aan
 aan
 aan
-aff
+afm
 aur
 awZ
 aye
-aff
+afm
 axP
 axP
 axP
@@ -53391,11 +53567,11 @@ aad
 aad
 aah
 aah
-aff
+afm
 auo
 adG
 ayf
-aff
+afm
 oto
 aAI
 jOI
@@ -54583,9 +54759,9 @@ aFH
 aFX
 aGB
 aCO
-aHJ
-aHJ
-aHJ
+aCO
+aCO
+aCO
 aCO
 aHJ
 aHJ
@@ -54693,17 +54869,17 @@ vHE
 lry
 lry
 lry
-iWa
+aXN
 fkx
 rse
 lry
 aah
 aah
-aah
-aah
-aah
-aah
-aah
+atx
+atx
+atx
+atx
+atx
 atx
 auB
 auB
@@ -54723,11 +54899,11 @@ auB
 auB
 auU
 auB
-auB
-auB
-auB
-auB
 atW
+atx
+atx
+atx
+atx
 atx
 aad
 aad
@@ -54841,11 +55017,11 @@ lry
 lry
 aah
 aah
-aah
-aah
-aah
-aah
-aah
+atx
+aXT
+aXT
+aXV
+aXT
 atx
 auB
 auB
@@ -54866,10 +55042,10 @@ auB
 auB
 auB
 auB
-auB
-auB
-auB
-auB
+atx
+aXT
+aXV
+aXT
 atx
 aad
 aad
@@ -54984,10 +55160,10 @@ aah
 aah
 aah
 aty
-atx
-atx
-atx
-atx
+aXU
+aXU
+aXU
+aXU
 aty
 atB
 oeA
@@ -55007,11 +55183,11 @@ auB
 oeA
 oeA
 oeA
-oeA
-oeA
-oeA
-oeA
 aGC
+aty
+aXU
+aXU
+aXU
 aty
 aad
 aad
@@ -55126,11 +55302,11 @@ aah
 aah
 aah
 auD
-atz
-atz
-atz
-atz
-atz
+auc
+auc
+auc
+auc
+aXW
 auc
 auc
 aFU
@@ -55150,7 +55326,7 @@ atA
 mtl
 auc
 auc
-auc
+aXW
 auc
 auc
 auc

--- a/maps/tether/tether-01-surface1.dmm
+++ b/maps/tether/tether-01-surface1.dmm
@@ -4918,8 +4918,21 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/chemistry_lab)
 "aio" = (
+/obj/machinery/door/firedoor,
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id = "gogogo";
+	opacity = 0
+	},
 /obj/machinery/camera/network/research{
-	dir = 5
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/testingroom)
@@ -6259,9 +6272,6 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/public_garden_maintenence)
 "akH" = (
-/obj/machinery/camera/network/outside{
-	dir = 9
-	},
 /turf/simulated/floor/outdoors/grass/sif/virgo3b,
 /area/holodeck_control)
 "akI" = (
@@ -11035,6 +11045,7 @@
 /obj/effect/floor_decal/corner/lightgrey/bordercorner2{
 	dir = 4
 	},
+/obj/machinery/camera/network/civilian,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/locker)
 "asz" = (
@@ -18267,6 +18278,9 @@
 /obj/machinery/alarm{
 	pixel_y = 22
 	},
+/obj/machinery/camera/network/civilian{
+	dir = 9
+	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/visitor_dining)
 "aEb" = (
@@ -18355,19 +18369,8 @@
 /turf/simulated/floor/tiled/steel_dirty,
 /area/tether/surfacebase/cargostore/warehouse)
 "aEj" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/sign/warning/moving_parts{
-	desc = "A warning sign for moving parts. This one states 'Put your gathered ore here for processing!' on it.";
-	name = "To Mining Operations Processing";
-	pixel_x = -32
-	},
 /obj/structure/closet/crate,
+/obj/machinery/camera/network/cargo,
 /turf/simulated/floor/tiled/steel_dirty,
 /area/tether/surfacebase/cargostore/warehouse)
 "aEk" = (
@@ -19521,17 +19524,24 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/cargostore)
 "aGi" = (
-/obj/effect/floor_decal/corner/brown{
-	dir = 9
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
 	},
-/obj/effect/floor_decal/corner/brown{
-	dir = 6
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/obj/machinery/alarm{
-	pixel_y = 22
+/obj/structure/sign/warning/moving_parts{
+	desc = "A warning sign for moving parts. This one states 'Put your gathered ore here for processing!' on it.";
+	name = "To Mining Operations Processing";
+	pixel_x = -32
 	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/cargostore)
+/obj/structure/closet/crate,
+/obj/machinery/camera/network/cargo{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel_dirty,
+/area/tether/surfacebase/cargostore/warehouse)
 "aGj" = (
 /turf/simulated/wall,
 /area/tether/surfacebase/cargostore/office)
@@ -22265,17 +22275,20 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/cargostore/office)
 "aKQ" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 4
+/obj/effect/floor_decal/corner/brown{
+	dir = 9
 	},
-/obj/effect/floor_decal/corner/brown/border{
-	dir = 4
+/obj/effect/floor_decal/corner/brown{
+	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
+/obj/machinery/alarm{
+	pixel_y = 22
+	},
+/obj/machinery/camera/network/cargo{
+	dir = 8
 	},
 /turf/simulated/floor/tiled,
-/area/tether/surfacebase/cargostore/office)
+/area/tether/surfacebase/cargostore)
 "aKR" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
@@ -22560,17 +22573,19 @@
 /area/rnd/external)
 "aLt" = (
 /obj/effect/floor_decal/borderfloor{
-	dir = 10
+	dir = 4
 	},
 /obj/effect/floor_decal/corner/brown/border{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
-/obj/structure/table/rack,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
+/obj/machinery/camera/network/cargo{
+	dir = 8
 	},
 /turf/simulated/floor/tiled,
-/area/tether/surfacebase/cargostore)
+/area/tether/surfacebase/cargostore/office)
 "aLu" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/brown/border,
@@ -28470,6 +28485,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/camera/network/tether{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/visitor_lodging)
 "aWm" = (
@@ -30565,6 +30583,74 @@
 /obj/structure/table/woodentable,
 /turf/simulated/floor/wood,
 /area/vacant/vacant_bar)
+"bav" = (
+/obj/machinery/camera/network/civilian{
+	dir = 9
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/tram)
+"baw" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 10
+	},
+/obj/structure/table/rack,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/machinery/camera/network/cargo{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/cargostore)
+"bax" = (
+/obj/machinery/camera/network/engineering{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/atmos)
+"bay" = (
+/obj/machinery/door/firedoor,
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id = "gogogo";
+	opacity = 0
+	},
+/obj/machinery/camera/network/research{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/rnd/testingroom)
+"baz" = (
+/obj/structure/grille,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 8;
+	icon_state = "shutter0";
+	id = "holodeck";
+	name = "Holodeck Privacy Shutters";
+	opacity = 0
+	},
+/obj/structure/window/reinforced/polarized/full{
+	id = "holodeck"
+	},
+/obj/structure/window/reinforced/polarized{
+	dir = 8;
+	id = "holodeck"
+	},
+/obj/machinery/camera/network/civilian,
+/turf/simulated/floor/plating,
+/area/holodeck_control)
 "baA" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -30590,6 +30676,29 @@
 /obj/item/weapon/bedsheet/mimedouble,
 /turf/simulated/floor/plating,
 /area/crew_quarters/sleep/maintDorm1)
+"baF" = (
+/obj/structure/grille,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 8;
+	icon_state = "shutter0";
+	id = "holodeck";
+	name = "Holodeck Privacy Shutters";
+	opacity = 0
+	},
+/obj/structure/window/reinforced/polarized/full{
+	id = "holodeck"
+	},
+/obj/structure/window/reinforced/polarized{
+	dir = 8;
+	id = "holodeck"
+	},
+/obj/machinery/camera/network/civilian{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/holodeck_control)
 "baK" = (
 /obj/structure/bed/chair/comfy/black{
 	dir = 8
@@ -41668,14 +41777,14 @@ aad
 aad
 ajO
 ajO
+baz
 ajV
 ajV
 ajV
 ajV
 ajV
 ajV
-ajV
-ajV
+baF
 ajO
 ajO
 aad
@@ -44272,10 +44381,10 @@ aeR
 aeR
 aji
 agF
-agP
+aio
 aiQ
 agD
-aio
+aiB
 abN
 xgQ
 ofS
@@ -45692,7 +45801,7 @@ aeR
 aeR
 ane
 agF
-agP
+bay
 ail
 aiG
 alL
@@ -48270,7 +48379,7 @@ aOx
 aJI
 aPt
 aJI
-aJI
+bax
 aQy
 aRD
 aRW
@@ -50200,14 +50309,14 @@ aBB
 aCr
 aDa
 aDU
-aEj
+aGi
 aCr
 aGb
 aGK
 aHr
 aIq
 aJU
-aLt
+baw
 aGa
 anD
 anU
@@ -51054,7 +51163,7 @@ aDB
 aEh
 aDC
 aCr
-aGi
+aKQ
 aGP
 aHM
 aJt
@@ -51334,7 +51443,7 @@ yaU
 afO
 aBB
 aCr
-aDC
+aEj
 aEh
 aDt
 aCr
@@ -51768,7 +51877,7 @@ aGs
 aGU
 aHT
 aJB
-aKQ
+aLt
 aXQ
 aGj
 aCN
@@ -54649,7 +54758,7 @@ aDu
 aIx
 aDu
 aCR
-aKK
+aDu
 aLj
 aLX
 aMI
@@ -54791,7 +54900,7 @@ aHH
 aIu
 aDu
 aDu
-aDu
+aKK
 aLj
 aLj
 aLj
@@ -55628,7 +55737,7 @@ auB
 auB
 auB
 auB
-auB
+bav
 auB
 auB
 auB
@@ -57461,7 +57570,7 @@ aad
 aad
 auD
 atC
-atC
+aue
 atC
 atC
 aua
@@ -57486,7 +57595,7 @@ atC
 aua
 atC
 atC
-atC
+aue
 atC
 auD
 aad

--- a/maps/tether/tether-01-surface1.dmm
+++ b/maps/tether/tether-01-surface1.dmm
@@ -11860,10 +11860,8 @@
 /area/tether/surfacebase/tram)
 "auc" = (
 /obj/structure/grille,
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 4;
-	frequency = 1300;
-	id_tag = null
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/tether/surfacebase/tram)
@@ -29334,9 +29332,11 @@
 /turf/simulated/floor/plating,
 /area/maintenance/lower/atmos)
 "aXT" = (
-/obj/machinery/portable_atmospherics/powered/scrubber/huge/stationary/tram,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/tether/surfacebase/tram)
+/obj/machinery/atmospherics/pipe/vent/high_volume{
+	volume = 1e+038
+	},
+/turf/simulated/floor/outdoors/grass/sif/virgo3b,
+/area/tether/surfacebase/outside/outside1)
 "aXU" = (
 /obj/effect/floor_decal/techfloor/orange{
 	dir = 8
@@ -29348,11 +29348,8 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/tether/surfacebase/tram)
 "aXV" = (
-/obj/machinery/portable_atmospherics/powered/scrubber/huge/stationary/tram,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/turf/simulated/wall,
 /area/tether/surfacebase/tram)
 "aXW" = (
 /obj/effect/floor_decal/techfloor/orange{
@@ -29751,15 +29748,10 @@
 /turf/simulated/floor/plating,
 /area/maintenance/lower/atmos)
 "aYH" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
+/turf/simulated/wall{
+	can_open = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/tram)
+/area/maintenance/lower/vacant_site)
 "aYI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -29825,16 +29817,11 @@
 /turf/simulated/floor/tiled/white,
 /area/vacant/vacant_bar)
 "aYP" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
 	},
-/obj/structure/cable/orange{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/turf/simulated/floor/tiled,
+/obj/structure/grille,
+/turf/simulated/floor/plating,
 /area/tether/surfacebase/tram)
 "aYQ" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -29880,6 +29867,48 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/sleep/maintDorm3)
+"aYU" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/structure/grille,
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/tram)
+"aYV" = (
+/obj/machinery/portable_atmospherics/powered/scrubber/huge/stationary/tram{
+	maxrate = 9119.25;
+	volume = 1e+038;
+	volume_rate = 1e+038
+	},
+/obj/machinery/atmospherics/portables_connector{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/tether/surfacebase/tram)
+"aYW" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 8
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/structure/grille,
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/tram)
+"aYX" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/powered/scrubber/huge/stationary/tram{
+	maxrate = 9119.25;
+	volume = 1e+038;
+	volume_rate = 1e+038
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/tether/surfacebase/tram)
 "aYY" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -29890,6 +29919,28 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/sleep/maintDorm2)
+"aYZ" = (
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
+/obj/structure/grille,
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/tram)
+"aZa" = (
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/tram)
+"aZb" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/grille,
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/tram)
 "aZc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -29899,6 +29950,21 @@
 	},
 /turf/simulated/floor/plating,
 /area/crew_quarters/sleep/maintDorm1)
+"aZd" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/wall{
+	can_open = 1
+	},
+/area/tether/surfacebase/tram)
+"aZe" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/tram)
+"aZf" = (
+/obj/machinery/hologram/holopad,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/tram)
 "aZg" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 10
@@ -29914,6 +29980,16 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/lowernorthhall)
+"aZh" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/tram)
 "aZi" = (
 /obj/machinery/shower{
 	dir = 1
@@ -29942,6 +30018,19 @@
 	},
 /turf/simulated/floor/plating,
 /area/crew_quarters/sleep/maintDorm3)
+"aZk" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/tram)
+"aZl" = (
+/obj/structure/symbol/maint,
+/turf/simulated/wall,
+/area/tether/surfacebase/tram)
 "aZm" = (
 /obj/machinery/shower{
 	dir = 1
@@ -29957,6 +30046,16 @@
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/sleep/maintDorm3)
+"aZn" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/structure/grille,
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/tram)
 "aZo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -29991,6 +30090,32 @@
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/sleep/maintDorm2)
+"aZr" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 8
+	},
+/obj/machinery/light,
+/obj/machinery/portable_atmospherics/powered/scrubber/huge/stationary/tram{
+	maxrate = 9119.25;
+	volume = 1e+038;
+	volume_rate = 1e+038
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/tether/surfacebase/tram)
+"aZs" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/powered/scrubber/huge/stationary/tram{
+	maxrate = 9119.25;
+	volume = 1e+038;
+	volume_rate = 1e+038
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/tether/surfacebase/tram)
 "aZu" = (
 /obj/machinery/shower{
 	dir = 1
@@ -29998,10 +30123,25 @@
 /obj/structure/curtain/open/shower,
 /turf/simulated/floor/plating,
 /area/crew_quarters/sleep/maintDorm1)
+"aZv" = (
+/obj/machinery/atmospherics/pipe/vent/high_volume{
+	dir = 1;
+	volume = 1e+038
+	},
+/turf/simulated/floor/outdoors/grass/sif/virgo3b,
+/area/tether/surfacebase/outside/outside1)
 "aZw" = (
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/plating,
 /area/vacant/vacant_bar)
+"aZx" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 6;
+	icon_state = "intact"
+	},
+/obj/structure/grille,
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/tram)
 "aZz" = (
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/maintDorm3)
@@ -30010,6 +30150,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/crew_quarters/sleep/maintDorm3)
+"aZB" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 8
+	},
+/obj/structure/grille,
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/tram)
 "aZC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -30018,6 +30165,11 @@
 "aZD" = (
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/maintDorm1)
+"aZE" = (
+/turf/simulated/wall{
+	can_open = 1
+	},
+/area/tether/surfacebase/tram)
 "aZI" = (
 /obj/machinery/light_construct{
 	dir = 1
@@ -54517,10 +54669,10 @@ lry
 aqj
 cZF
 apF
-aah
-aah
-aah
-aah
+atx
+atx
+atx
+atx
 atx
 atX
 auB
@@ -54658,11 +54810,11 @@ biK
 lry
 aql
 sJX
-apF
-aah
-aah
-aah
-aah
+aYH
+aYP
+aYP
+aYP
+aYP
 atx
 atY
 auB
@@ -54801,15 +54953,15 @@ lry
 apF
 apF
 apF
-aah
-aah
-aah
-aah
+aYU
+aYZ
+aYZ
+aZb
 atx
 atZ
 auC
 auC
-aYH
+aZh
 awj
 awj
 awj
@@ -54821,7 +54973,7 @@ aCb
 aCU
 aCU
 aCU
-aYP
+aZa
 aFH
 aFX
 aGB
@@ -54941,17 +55093,17 @@ fkx
 rse
 lry
 aah
-aah
-atx
-atx
-atx
-atx
-atx
-atx
-auB
-auB
-auU
-aYJ
+aXT
+aXV
+aYW
+aYW
+aYW
+aZn
+aZd
+aZe
+aZe
+aZf
+aZk
 auB
 auB
 auB
@@ -54967,12 +55119,12 @@ aYJ
 auU
 auB
 atW
-atx
-atx
-atx
-atx
-atx
-aad
+aZE
+aZx
+aZB
+aZB
+aXV
+aZv
 aad
 aad
 aad
@@ -55085,11 +55237,11 @@ lry
 aah
 aah
 atx
-aXT
-aXT
-aXV
-aXT
-atx
+aYV
+aYX
+aYX
+aZr
+aZl
 auB
 auB
 auB
@@ -55109,10 +55261,10 @@ aYJ
 auB
 auB
 auB
-atx
-aXT
-aXV
-aXT
+aZl
+aZs
+aYX
+aZr
 atx
 aad
 aad

--- a/maps/tether/tether-01-surface1.dmm
+++ b/maps/tether/tether-01-surface1.dmm
@@ -19764,6 +19764,11 @@
 	pixel_y = -28
 	},
 /obj/machinery/light,
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/tram)
 "aGC" = (
@@ -29868,46 +29873,57 @@
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/sleep/maintDorm3)
 "aYU" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
+/obj/machinery/atmospherics/portables_connector{
+	dir = 4
 	},
-/obj/structure/grille,
-/turf/simulated/floor/plating,
-/area/tether/surfacebase/tram)
-"aYV" = (
 /obj/machinery/portable_atmospherics/powered/scrubber/huge/stationary/tram{
-	maxrate = 9119.25;
+	icon_state = "scrubber:0";
+	maxrate = 9113.25;
+	on = 0;
+	scrub_id = "tram";
 	volume = 1e+038;
 	volume_rate = 1e+038
 	},
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/tram)
+"aYV" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 8
 	},
-/obj/machinery/light{
-	dir = 1
+/obj/machinery/portable_atmospherics/powered/scrubber/huge/stationary/tram{
+	icon_state = "scrubber:0";
+	maxrate = 9113.25;
+	on = 0;
+	scrub_id = "tram";
+	volume = 1e+038;
+	volume_rate = 1e+038
 	},
-/turf/simulated/floor/tiled/techfloor/grid,
+/turf/simulated/floor/plating,
 /area/tether/surfacebase/tram)
 "aYW" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden{
-	dir = 8
-	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
 /obj/structure/grille,
+/obj/machinery/atmospherics/pipe/manifold4w/hidden,
 /turf/simulated/floor/plating,
 /area/tether/surfacebase/tram)
 "aYX" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
 /obj/machinery/atmospherics/portables_connector{
-	dir = 8
+	dir = 4
 	},
 /obj/machinery/portable_atmospherics/powered/scrubber/huge/stationary/tram{
-	maxrate = 9119.25;
+	icon_state = "scrubber:0";
+	maxrate = 9113.25;
+	on = 0;
+	scrub_id = "tram";
 	volume = 1e+038;
 	volume_rate = 1e+038
 	},
-/turf/simulated/floor/tiled/techfloor/grid,
+/turf/simulated/floor/plating,
 /area/tether/surfacebase/tram)
 "aYY" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -29920,9 +29936,21 @@
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/sleep/maintDorm2)
 "aYZ" = (
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
-/obj/structure/grille,
-/turf/simulated/floor/plating,
+/obj/machinery/atmospherics/portables_connector{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/powered/scrubber/huge/stationary/tram{
+	icon_state = "scrubber:0";
+	maxrate = 9113.25;
+	on = 0;
+	scrub_id = "tram";
+	volume = 1e+038;
+	volume_rate = 1e+038
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/tether/surfacebase/tram)
 "aZa" = (
 /obj/structure/cable/orange{
@@ -29937,8 +29965,18 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/tram)
 "aZb" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/structure/grille,
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
+/obj/machinery/atmospherics/portables_connector{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/powered/scrubber/huge/stationary/tram{
+	icon_state = "scrubber:0";
+	maxrate = 9113.25;
+	on = 0;
+	scrub_id = "tram";
+	volume = 1e+038;
+	volume_rate = 1e+038
+	},
 /turf/simulated/floor/plating,
 /area/tether/surfacebase/tram)
 "aZc" = (
@@ -30048,10 +30086,8 @@
 /area/crew_quarters/sleep/maintDorm3)
 "aZn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
+	dir = 10;
+	icon_state = "intact"
 	},
 /obj/structure/grille,
 /turf/simulated/floor/plating,
@@ -30094,9 +30130,11 @@
 /obj/machinery/atmospherics/portables_connector{
 	dir = 8
 	},
-/obj/machinery/light,
 /obj/machinery/portable_atmospherics/powered/scrubber/huge/stationary/tram{
-	maxrate = 9119.25;
+	icon_state = "scrubber:0";
+	maxrate = 9113.25;
+	on = 0;
+	scrub_id = "tram";
 	volume = 1e+038;
 	volume_rate = 1e+038
 	},
@@ -30106,15 +30144,23 @@
 /obj/machinery/atmospherics/portables_connector{
 	dir = 8
 	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light,
 /obj/machinery/portable_atmospherics/powered/scrubber/huge/stationary/tram{
-	maxrate = 9119.25;
+	icon_state = "scrubber:0";
+	maxrate = 9113.25;
+	on = 0;
+	scrub_id = "tram";
 	volume = 1e+038;
 	volume_rate = 1e+038
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
+/area/tether/surfacebase/tram)
+"aZt" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 1
+	},
+/obj/structure/grille,
+/turf/simulated/floor/plating,
 /area/tether/surfacebase/tram)
 "aZu" = (
 /obj/machinery/shower{
@@ -30124,23 +30170,23 @@
 /turf/simulated/floor/plating,
 /area/crew_quarters/sleep/maintDorm1)
 "aZv" = (
-/obj/machinery/atmospherics/pipe/vent/high_volume{
-	dir = 1;
-	volume = 1e+038
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
 	},
-/turf/simulated/floor/outdoors/grass/sif/virgo3b,
-/area/tether/surfacebase/outside/outside1)
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/tram)
 "aZw" = (
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/plating,
 /area/vacant/vacant_bar)
 "aZx" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 6;
-	icon_state = "intact"
-	},
-/obj/structure/grille,
-/turf/simulated/floor/plating,
+/obj/machinery/hologram/holopad,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/tram)
+"aZy" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled,
 /area/tether/surfacebase/tram)
 "aZz" = (
 /turf/simulated/floor/wood,
@@ -30151,11 +30197,13 @@
 /turf/simulated/floor/plating,
 /area/crew_quarters/sleep/maintDorm3)
 "aZB" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/orange{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/obj/structure/grille,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled,
 /area/tether/surfacebase/tram)
 "aZC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -30166,9 +30214,34 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/maintDorm1)
 "aZE" = (
-/turf/simulated/wall{
-	can_open = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/airlock/atmos{
+	name = "Tram Atmospherics Control Room"
 	},
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/tether/surfacebase/tram)
+"aZF" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 4;
+	icon_state = "map"
+	},
+/obj/structure/grille,
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/tram)
+"aZG" = (
+/obj/machinery/atmospherics/pipe/manifold4w/hidden,
+/obj/structure/grille,
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/tram)
+"aZH" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden,
+/obj/structure/grille,
+/turf/simulated/floor/plating,
 /area/tether/surfacebase/tram)
 "aZI" = (
 /obj/machinery/light_construct{
@@ -30176,6 +30249,13 @@
 	},
 /turf/simulated/floor/wood,
 /area/vacant/vacant_bar)
+"aZJ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/structure/grille,
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/tram)
 "aZK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -30189,6 +30269,16 @@
 /obj/structure/table,
 /turf/simulated/floor/plating,
 /area/crew_quarters/sleep/maintDorm3)
+"aZM" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/structure/grille,
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/tram)
 "aZN" = (
 /obj/structure/table,
 /obj/item/stack/material/wood{
@@ -30224,11 +30314,36 @@
 /obj/random/junk,
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/maintDorm1)
+"aZT" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/structure/grille,
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/tram)
 "aZU" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/storage/fancy/markers,
 /turf/simulated/floor/plating,
 /area/crew_quarters/sleep/maintDorm1)
+"aZV" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden,
+/obj/structure/grille,
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/tram)
+"aZW" = (
+/obj/machinery/atmospherics/pipe/simple/visible/universal,
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/tram)
 "aZX" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -30272,12 +30387,68 @@
 /obj/structure/table/bench/padded,
 /turf/simulated/floor/wood,
 /area/vacant/vacant_bar)
+"bac" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/computer/area_atmos/tag{
+	dir = 8;
+	name = "Tram Heavy Scrubber Control";
+	req_one_access = list(24);
+	scrub_id = "tram";
+	use_power = 0
+	},
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/tram)
 "bad" = (
 /turf/simulated/floor/plating,
 /area/crew_quarters/sleep/maintDorm3)
+"bae" = (
+/obj/machinery/atmospherics/valve/digital/open,
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -24
+	},
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/tram)
+"baf" = (
+/obj/machinery/power/thermoregulator{
+	anchored = 1
+	},
+/obj/structure/cable/orange{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/tram)
+"bag" = (
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	dir = 5
+	},
+/obj/machinery/meter,
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/tram)
 "bah" = (
 /turf/simulated/floor/plating,
 /area/crew_quarters/sleep/maintDorm2)
+"bai" = (
+/obj/machinery/light,
+/obj/machinery/atmospherics/portables_connector{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/powered/pump/huge/stationary{
+	active_power_usage = 0;
+	direction_out = 1;
+	idle_power_usage = 0;
+	name = "Tram Stationary Air Pump"
+	},
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/tram)
 "baj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -30287,6 +30458,23 @@
 	},
 /turf/simulated/floor/plating,
 /area/crew_quarters/sleep/maintDorm2)
+"bak" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/powered/scrubber/huge/stationary/tram{
+	icon_state = "scrubber:0";
+	maxrate = 9113.25;
+	on = 0;
+	scrub_id = "tram";
+	volume = 1e+038;
+	volume_rate = 1e+038
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/tram)
 "bal" = (
 /obj/machinery/alarm{
 	dir = 8;
@@ -30295,6 +30483,38 @@
 /obj/structure/table/woodentable,
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/maintDorm2)
+"bam" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/powered/scrubber/huge/stationary/tram{
+	icon_state = "scrubber:0";
+	maxrate = 9113.25;
+	on = 0;
+	scrub_id = "tram";
+	volume = 1e+038;
+	volume_rate = 1e+038
+	},
+/obj/machinery/camera/network/civilian,
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/tram)
+"ban" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/powered/scrubber/huge/stationary/tram{
+	icon_state = "scrubber:0";
+	maxrate = 9113.25;
+	on = 0;
+	scrub_id = "tram";
+	volume = 1e+038;
+	volume_rate = 1e+038
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/tram)
 "bao" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -30304,6 +30524,21 @@
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/maintDorm1)
+"bap" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/powered/scrubber/huge/stationary/tram{
+	icon_state = "scrubber:0";
+	maxrate = 9113.25;
+	on = 0;
+	scrub_id = "tram";
+	volume = 1e+038;
+	volume_rate = 1e+038
+	},
+/obj/machinery/light,
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/tram)
 "baq" = (
 /obj/structure/sign/warning,
 /turf/simulated/wall,
@@ -53959,7 +54194,7 @@ lry
 aql
 arl
 apF
-aah
+atx
 ash
 ash
 ash
@@ -54101,11 +54336,11 @@ lry
 aql
 arl
 apF
-aah
-aah
-aah
-aah
-aah
+bak
+aYU
+aYU
+bap
+atx
 aah
 aah
 aah
@@ -54243,10 +54478,10 @@ lry
 aql
 arl
 apF
-aah
-aah
-aah
-aah
+aZn
+aZF
+aZF
+aZH
 atx
 atx
 atx
@@ -54385,10 +54620,10 @@ lry
 aql
 nlo
 apF
-aah
-aah
-aah
-aah
+bam
+aYU
+aYU
+aZJ
 atx
 atW
 auA
@@ -54527,10 +54762,10 @@ lry
 aql
 aql
 apF
-aah
-aah
-aah
-aah
+aZt
+aZG
+aZG
+aZH
 atx
 afG
 auB
@@ -54669,10 +54904,10 @@ lry
 aqj
 cZF
 apF
-atx
-atx
-atx
-atx
+ban
+aYV
+aYV
+aZJ
 atx
 atX
 auB
@@ -54814,7 +55049,7 @@ aYH
 aYP
 aYP
 aYP
-aYP
+aZM
 atx
 atY
 auB
@@ -54953,10 +55188,10 @@ lry
 apF
 apF
 apF
-aYU
-aYZ
-aYZ
+aYX
 aZb
+aZb
+aZT
 atx
 atZ
 auC
@@ -55098,7 +55333,7 @@ aXV
 aYW
 aYW
 aYW
-aZn
+aZV
 aZd
 aZe
 aZe
@@ -55115,16 +55350,16 @@ auB
 auB
 auB
 auB
-aYJ
-auU
-auB
-atW
-aZE
-aZx
-aZB
-aZB
-aXV
 aZv
+aZx
+aZy
+aZB
+aZE
+aZW
+bae
+bag
+atx
+aad
 aad
 aad
 aad
@@ -55237,34 +55472,34 @@ lry
 aah
 aah
 atx
-aYV
-aYX
-aYX
+aYZ
 aZr
-aZl
-auB
-auB
-auB
-aYJ
-auB
-auB
-auB
-auB
-auB
-auB
-auB
-auB
-auB
-auB
-auB
-aYJ
-auB
-auB
-auB
-aZl
+aZr
 aZs
-aYX
-aZr
+aZl
+auB
+auB
+auB
+aYJ
+auB
+auB
+auB
+auB
+auB
+auB
+auB
+auB
+auB
+auB
+auB
+aYJ
+auB
+auB
+atW
+atx
+bac
+baf
+bai
 atx
 aad
 aad

--- a/maps/tether/tether-02-surface2.dmm
+++ b/maps/tether/tether-02-surface2.dmm
@@ -7422,6 +7422,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/machinery/camera/network/security{
+	dir = 10
+	},
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/armory)
 "alB" = (
@@ -13895,14 +13898,14 @@
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/interrogation)
 "awy" = (
-/obj/structure/bed/chair{
-	dir = 4
+/obj/machinery/door/firedoor/glass,
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/machinery/camera/network/security{
+	dir = 10
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
-/area/tether/surfacebase/security/interrogation)
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/security/middlehall)
 "awz" = (
 /obj/structure/grille,
 /obj/machinery/door/firedoor/glass,
@@ -16941,6 +16944,9 @@
 	dir = 8;
 	icon_state = "techfloororange_edges"
 	},
+/obj/machinery/camera/network/tether{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/chapel/main)
 "aCW" = (
@@ -17001,10 +17007,13 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/bar)
 "aDe" = (
+/obj/structure/grille,
+/obj/machinery/door/firedoor/glass,
+/obj/structure/window/reinforced/full,
 /obj/machinery/camera/network/civilian{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor,
 /area/chapel/chapel_morgue)
 "aDf" = (
 /obj/structure/morgue,
@@ -25250,6 +25259,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/engineering/pumpstation)
+"aSZ" = (
+/obj/machinery/camera/network/civilian,
+/turf/simulated/floor/water/indoors,
+/area/tether/surfacebase/fish_farm)
 "aTa" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -25400,6 +25413,29 @@
 /obj/machinery/door/airlock/maintenance/common,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/maintenance/lower/south)
+"aTi" = (
+/obj/machinery/camera/network/civilian{
+	dir = 1
+	},
+/turf/simulated/floor/beach/sand/desert,
+/area/tether/surfacebase/fish_farm)
+"aTj" = (
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/machinery/camera/network/security,
+/turf/simulated/floor/tiled/dark,
+/area/tether/surfacebase/security/interrogation)
+"aTk" = (
+/obj/structure/catwalk,
+/obj/machinery/camera/network/engineering{
+	dir = 8
+	},
+/turf/simulated/open,
+/area/engineering/atmos)
 "aTl" = (
 /obj/structure/table/rack,
 /obj/random/maintenance/research,
@@ -42079,8 +42115,8 @@ avT
 avT
 avT
 avT
-awY
-ayw
+azs
+aSZ
 azq
 azq
 ayw
@@ -42091,8 +42127,8 @@ azq
 ayw
 axR
 aFP
-awY
-awY
+azs
+azs
 aGw
 aEc
 aEc
@@ -42232,8 +42268,8 @@ ayw
 azq
 ayw
 axR
-axR
-axR
+aTi
+azs
 awY
 awY
 aEc
@@ -42354,12 +42390,12 @@ aoq
 apA
 ahn
 arA
-arA
+awy
 ahn
 aur
 avn
 avT
-awy
+aTj
 axa
 axT
 avT
@@ -42647,7 +42683,7 @@ awA
 axb
 axU
 avT
-awY
+azs
 azr
 azq
 azq
@@ -42802,7 +42838,7 @@ azq
 ayw
 axR
 aFP
-awY
+azs
 aGw
 aGw
 aqZ
@@ -47098,7 +47134,7 @@ aXB
 aXB
 aXB
 bbB
-bbJ
+aTk
 bbJ
 aVP
 adt
@@ -51173,7 +51209,7 @@ ard
 ato
 aBz
 aCg
-aDe
+aCh
 aDR
 aEv
 aFb
@@ -51459,7 +51495,7 @@ aBz
 aCi
 aDf
 aDS
-aEw
+aDe
 aFd
 aFL
 aBz

--- a/maps/tether/tether-02-surface2.dmm
+++ b/maps/tether/tether-02-surface2.dmm
@@ -3280,8 +3280,9 @@
 "afg" = (
 /obj/machinery/door/airlock/medical{
 	id_tag = "SurfMedicalResleeving";
-	name = "Resleeving Lab";
-	req_access = list(5)
+	name = "Resleeving Washroom";
+	req_access = null;
+	req_one_access = null
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
@@ -45170,8 +45171,8 @@ aab
 aab
 aab
 aab
-aac
-aac
+ael
+ael
 aab
 aab
 ael
@@ -45312,8 +45313,8 @@ aab
 aab
 aab
 aab
-aac
-aac
+ael
+ael
 aab
 aab
 ael
@@ -52038,8 +52039,8 @@ abn
 abn
 abn
 abn
-aac
-aac
+ael
+ael
 abn
 abn
 abn
@@ -52173,15 +52174,15 @@ abn
 abn
 abn
 abn
-aac
-aac
+ael
+ael
 abn
 abn
 abn
 abn
 abn
-aac
-aac
+ael
+ael
 abn
 abn
 abn
@@ -52315,8 +52316,8 @@ abn
 abn
 abn
 abn
-aac
-aac
+ael
+ael
 abn
 abn
 abn
@@ -52879,8 +52880,8 @@ aeG
 aeG
 aeG
 aeG
-aac
-aac
+ael
+ael
 abn
 abn
 abn
@@ -53021,8 +53022,8 @@ aeG
 aeG
 aeG
 aeG
-aac
-aac
+ael
+ael
 abn
 abn
 abn

--- a/maps/tether/tether-02-surface2.dmm
+++ b/maps/tether/tether-02-surface2.dmm
@@ -12069,6 +12069,9 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/effect/landmark{
+	name = "morphspawn"
+	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos/storage)
 "atu" = (
@@ -13697,8 +13700,9 @@
 /area/tether/surfacebase/surface_two_hall)
 "awe" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/effect/landmark{
-	name = "morphspawn"
+/obj/machinery/portable_atmospherics/powered/pump/huge{
+	description_info = "No no no, we need The Big One for this job.";
+	name = "The Big One"
 	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos/storage)

--- a/maps/tether/tether-02-surface2.dmm
+++ b/maps/tether/tether-02-surface2.dmm
@@ -23345,7 +23345,7 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor/glass,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/tiled/dark,
 /area/engineering/lower/breakroom)
 "aPo" = (
 /obj/structure/cable/cyan{

--- a/maps/tether/tether-02-surface2.dmm
+++ b/maps/tether/tether-02-surface2.dmm
@@ -582,22 +582,24 @@
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/centralhall)
 "aaR" = (
+/obj/machinery/vending/loadout/uniform,
+/obj/machinery/camera/network/medbay{
+	dir = 10
+	},
 /obj/effect/floor_decal/borderfloorwhite{
-	dir = 1
+	dir = 6
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
-	dir = 1
+	dir = 6
 	},
 /obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_y = 24
+	name = "south bump";
+	nightshift_setting = 2;
+	pixel_y = -28
 	},
-/obj/structure/cable/green{
-	icon_state = "0-8"
-	},
+/obj/structure/cable/green,
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/centralhall)
+/area/tether/surfacebase/medical/resleeving)
 "aaS" = (
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 1
@@ -2786,23 +2788,23 @@
 /turf/simulated/wall,
 /area/tether/surfacebase/medical/patient_a)
 "aen" = (
-/obj/machinery/vending/loadout/uniform,
-/obj/machinery/camera/network/medbay{
-	dir = 10
-	},
 /obj/effect/floor_decal/borderfloorwhite{
-	dir = 6
+	dir = 1
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
-	dir = 6
+	dir = 1
 	},
 /obj/machinery/power/apc{
-	name = "south bump";
-	pixel_y = -28
+	dir = 1;
+	name = "north bump";
+	nightshift_setting = 2;
+	pixel_y = 24
 	},
-/obj/structure/cable/green,
+/obj/structure/cable/green{
+	icon_state = "0-8"
+	},
 /turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/resleeving)
+/area/tether/surfacebase/medical/centralhall)
 "aeo" = (
 /obj/structure/bed/psych{
 	name = "couch"
@@ -5328,6 +5330,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "east bump";
+	nightshift_setting = 2;
 	pixel_x = 28
 	},
 /obj/effect/floor_decal/borderfloorwhite{
@@ -6773,39 +6776,23 @@
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/uppersouthstairwell)
 "akG" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "east bump";
-	pixel_x = 24
+	nightshift_setting = 2;
+	pixel_x = 28
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
 	},
 /obj/structure/cable/green{
-	icon_state = "1-2"
+	icon_state = "0-8"
 	},
-/obj/effect/floor_decal/borderfloorwhite/corner2{
-	dir = 6
-	},
-/obj/effect/floor_decal/corner/paleblue/bordercorner2{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/uppersouthstairwell)
+/turf/simulated/floor/tiled/dark,
+/area/tether/surfacebase/security/armory)
 "akH" = (
 /obj/structure/toilet{
 	dir = 8
@@ -8134,19 +8121,15 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "east bump";
+	nightshift_setting = 2;
 	pixel_x = 28
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
 /obj/structure/cable/green{
-	icon_state = "0-8"
+	d2 = 2;
+	icon_state = "0-2"
 	},
-/turf/simulated/floor/tiled/dark,
-/area/tether/surfacebase/security/armory)
+/turf/simulated/floor,
+/area/maintenance/substation/medsec)
 "amD" = (
 /turf/simulated/wall/r_wall,
 /area/maintenance/lower/north)
@@ -10187,17 +10170,40 @@
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/breakroom)
 "aqb" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 28
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 4
 	},
 /obj/structure/cable/green{
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/turf/simulated/floor,
-/area/maintenance/substation/medsec)
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	nightshift_setting = 2;
+	pixel_x = 24
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/borderfloorwhite/corner2{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner2{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/uppersouthstairwell)
 "aqc" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal,
 /obj/item/device/radio/intercom/department/medbay{
@@ -11866,6 +11872,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "east bump";
+	nightshift_setting = 2;
 	pixel_x = 28
 	},
 /obj/structure/cable{
@@ -14837,22 +14844,18 @@
 /turf/simulated/floor/water/indoors,
 /area/tether/surfacebase/fish_farm)
 "ayx" = (
-/obj/effect/floor_decal/techfloor{
-	dir = 4
-	},
-/obj/structure/railing{
-	dir = 8
-	},
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "east bump";
+	nightshift_setting = 2;
 	pixel_x = 28
 	},
 /obj/structure/cable/green{
+	d2 = 8;
 	icon_state = "0-8"
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/maintenance/asmaint2)
+/turf/simulated/floor/tiled/dark,
+/area/bridge_hallway)
 "ayy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -17303,17 +17306,19 @@
 /turf/simulated/floor/tiled/dark,
 /area/bridge_hallway)
 "aDF" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "east bump";
+	nightshift_setting = 2;
 	pixel_x = 28
 	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/bridge_hallway)
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/fish_farm)
 "aDG" = (
 /obj/structure/cable/green{
 	icon_state = "0-2"
@@ -17809,18 +17814,15 @@
 /turf/simulated/floor/beach/sand/desert,
 /area/tether/surfacebase/fish_farm)
 "aEC" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "east bump";
+	nightshift_setting = 2;
 	pixel_x = 28
 	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/fish_farm)
+/obj/structure/cable/green,
+/turf/simulated/floor/wood,
+/area/bridge/meeting_room)
 "aED" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -19079,11 +19081,15 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "east bump";
+	nightshift_setting = 2;
 	pixel_x = 28
 	},
-/obj/structure/cable/green,
-/turf/simulated/floor/wood,
-/area/bridge/meeting_room)
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor,
+/area/maintenance/substation/research)
 "aHf" = (
 /obj/structure/lattice,
 /obj/machinery/alarm{
@@ -20930,17 +20936,27 @@
 /turf/simulated/floor,
 /area/maintenance/substation/research)
 "aKW" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/mauve/border{
+	dir = 4
+	},
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "east bump";
+	nightshift_setting = 2;
 	pixel_x = 28
 	},
 /obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
+	d2 = 8;
+	icon_state = "0-8"
 	},
-/turf/simulated/floor,
-/area/maintenance/substation/research)
+/obj/structure/bed/chair/office/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/rnd/rdoffice)
 "aKX" = (
 /turf/simulated/wall/r_wall,
 /area/ai_cyborg_station)
@@ -21595,23 +21611,18 @@
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
 	},
-/obj/effect/floor_decal/corner/mauve/border{
-	dir = 4
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
 	},
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "east bump";
+	nightshift_setting = 2;
 	pixel_x = 28
 	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/structure/bed/chair/office/light{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/rnd/rdoffice)
+/turf/simulated/floor/tiled/techmaint,
+/area/tether/surfacebase/east_stairs_two)
 "aMo" = (
 /turf/simulated/wall,
 /area/rnd/lockers)
@@ -24162,20 +24173,23 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/tether/surfacebase/east_stairs_two)
 "aQY" = (
-/obj/effect/floor_decal/borderfloor{
+/obj/effect/floor_decal/techfloor{
 	dir = 4
 	},
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
+/obj/structure/railing{
+	dir = 8
 	},
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "east bump";
+	nightshift_setting = 2;
 	pixel_x = 28
 	},
-/turf/simulated/floor/tiled/techmaint,
-/area/tether/surfacebase/east_stairs_two)
+/obj/structure/cable/green{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/asmaint2)
 "aQZ" = (
 /obj/structure/railing{
 	dir = 4
@@ -25458,6 +25472,42 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/south)
+"aTm" = (
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	nightshift_setting = 2;
+	pixel_x = 28
+	},
+/obj/structure/cable/cyan{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 5
+	},
+/obj/machinery/computer/rcon,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/atmos/monitoring)
+"aTn" = (
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	nightshift_setting = 2;
+	pixel_x = 28
+	},
+/turf/simulated/floor/tiled/steel_dirty,
+/area/maintenance/asmaint2)
 "aTo" = (
 /obj/structure/catwalk,
 /obj/effect/floor_decal/rust,
@@ -25475,6 +25525,51 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/south)
+"aTq" = (
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	nightshift_setting = 2;
+	pixel_x = 28
+	},
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/maintenance/lower/south)
+"aTr" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	nightshift_setting = 2;
+	pixel_x = 28
+	},
+/obj/structure/cable,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/maintenance/readingrooms)
+"aTs" = (
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	nightshift_setting = 2;
+	pixel_x = 28
+	},
+/obj/structure/cable/orange{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/reading_room)
 "aTw" = (
 /obj/structure/flora/pottedplant/stoutbush,
 /obj/machinery/camera/network/research{
@@ -28041,28 +28136,6 @@
 /obj/machinery/computer/power_monitor,
 /turf/simulated/floor/tiled,
 /area/engineering/atmos/monitoring)
-"aYp" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 28
-	},
-/obj/structure/cable/cyan{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 5
-	},
-/obj/effect/floor_decal/corner/yellow/border{
-	dir = 5
-	},
-/obj/machinery/computer/rcon,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/engineering/atmos/monitoring)
 "aYq" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/zpipe/down{
@@ -29039,18 +29112,6 @@
 	},
 /turf/simulated/floor/tiled/steel_dirty,
 /area/maintenance/asmaint2)
-"bbw" = (
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 28
-	},
-/turf/simulated/floor/tiled/steel_dirty,
-/area/maintenance/asmaint2)
 "bbz" = (
 /obj/structure/railing,
 /obj/machinery/light{
@@ -29348,19 +29409,6 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/lower/south)
-"bcO" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 28
-	},
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/lower/south)
 "bcP" = (
@@ -31356,18 +31404,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/tether/surfacebase/reading_room)
-"bjT" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 28
-	},
-/obj/structure/cable/orange{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/wood,
-/area/tether/surfacebase/reading_room)
 "bjU" = (
 /obj/machinery/door/blast/regular{
 	id = "xenobiodiv5";
@@ -33307,23 +33343,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/tether/surfacebase/reading_room)
-"jWK" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 28
-	},
-/obj/structure/cable,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/maintenance/readingrooms)
 "jZC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -42295,7 +42314,7 @@ avC
 axf
 axf
 ayb
-ayx
+aQY
 ayK
 ayK
 ayK
@@ -42564,7 +42583,7 @@ aJI
 aKg
 aKT
 aLA
-aMn
+aKW
 aMX
 aNv
 aOk
@@ -43130,7 +43149,7 @@ aEc
 aEc
 aJJ
 aBb
-aKW
+aHe
 aLD
 aMo
 aMZ
@@ -43157,7 +43176,7 @@ aHm
 aHE
 baT
 aEH
-bbw
+aTn
 bbH
 bbW
 aHE
@@ -43544,7 +43563,7 @@ aBD
 aCs
 aDn
 aDW
-aEC
+aDF
 aFf
 awY
 awY
@@ -45366,7 +45385,7 @@ aim
 ajt
 akl
 alz
-amC
+akG
 anw
 aoF
 apS
@@ -46272,7 +46291,7 @@ aSd
 aWd
 aWX
 aXF
-aYp
+aTm
 aYQ
 aZp
 aZP
@@ -46503,7 +46522,7 @@ ajO
 alL
 akM
 amG
-aqb
+amC
 ase
 auN
 boQ
@@ -46777,7 +46796,7 @@ acf
 acu
 acX
 adH
-aen
+aaR
 akM
 afV
 ago
@@ -47382,7 +47401,7 @@ aEN
 aFp
 aGg
 aGK
-aHe
+aEC
 aHv
 aGF
 aIu
@@ -47802,7 +47821,7 @@ aAM
 aBp
 aBX
 aCO
-aDF
+ayx
 aAJ
 aEP
 aAk
@@ -47916,7 +47935,7 @@ adI
 aeo
 afc
 abz
-aaR
+aen
 aam
 aiy
 ajF
@@ -48392,7 +48411,7 @@ aNV
 aNV
 aNV
 aNV
-aQY
+aMn
 aRA
 aSm
 aTb
@@ -49841,7 +49860,7 @@ bde
 bdE
 csF
 cMd
-jWK
+aTr
 cMd
 gus
 jxi
@@ -50195,7 +50214,7 @@ abE
 adV
 aiG
 akt
-akG
+aqb
 akQ
 akU
 alG
@@ -50404,7 +50423,7 @@ aZr
 aZr
 aZr
 bcA
-bcO
+aTq
 bdh
 aZr
 bdR
@@ -50987,7 +51006,7 @@ bij
 biL
 bjg
 bjF
-bjT
+aTs
 bkq
 bkG
 bgU

--- a/maps/tether/tether-03-surface3.dmm
+++ b/maps/tether/tether-03-surface3.dmm
@@ -6389,6 +6389,14 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/public_garden_three)
+"aju" = (
+/obj/structure/railing,
+/obj/structure/lattice,
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/simulated/open,
+/area/rnd/staircase/thirdfloor)
 "ajv" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /obj/effect/floor_decal/industrial/warning{
@@ -8440,11 +8448,10 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/crew_quarters/panic_shelter)
 "anl" = (
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/obj/effect/floor_decal/industrial/warning{
-	dir = 5
+/obj/machinery/camera/network/research{
+	dir = 8
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled,
 /area/rnd/xenobiology/xenoflora_storage)
 "anm" = (
 /obj/effect/floor_decal/borderfloor{
@@ -9336,6 +9343,9 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
+/obj/machinery/camera/network/research{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/eris/steel/techfloor_grid,
 /area/rnd/xenobiology/xenoflora_storage)
 "aoQ" = (
@@ -9876,15 +9886,14 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_three_hall)
 "apF" = (
-/obj/machinery/atmospherics/portables_connector{
-	dir = 1
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 5
 	},
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/mauve/border,
 /obj/machinery/camera/network/research{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenoflora_storage)
 "apG" = (
 /obj/structure/table/glass,
@@ -17915,6 +17924,12 @@
 /obj/structure/flora/ausbushes/brflowers,
 /turf/simulated/floor/grass,
 /area/tether/surfacebase/public_garden_three)
+"aDa" = (
+/mob/living/simple_mob/animal/goat{
+	name = "Spike"
+	},
+/turf/simulated/floor/grass,
+/area/hydroponics/cafegarden)
 "aDb" = (
 /obj/structure/flora/ausbushes/fernybush,
 /turf/simulated/floor/grass,
@@ -17942,6 +17957,17 @@
 "aDg" = (
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/public_garden_three)
+"aDh" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled/freezer/cold,
+/area/crew_quarters/freezer)
 "aDi" = (
 /obj/structure/window/reinforced,
 /obj/effect/floor_decal/steeldecal/steel_decals6{
@@ -19579,7 +19605,6 @@
 	name = "Robotics Operating Table"
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/effect/decal/cleanable/blood/oil,
 /turf/simulated/floor/tiled/dark,
 /area/rnd/robotics/surgeryroom2)
 "aFX" = (
@@ -22102,7 +22127,6 @@
 	name = "Robotics Operating Table"
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/effect/decal/cleanable/blood/oil,
 /turf/simulated/floor/tiled/dark,
 /area/rnd/robotics/surgeryroom1)
 "aKl" = (
@@ -23459,13 +23483,10 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/shuttle_pad)
 "aMU" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central5{
+/obj/machinery/door/firedoor/glass/hidden/steel{
 	dir = 8
 	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/tiled,
 /area/tether/surfacebase/shuttle_pad)
 "aMV" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -24172,17 +24193,12 @@
 /turf/simulated/open/virgo3b,
 /area/tether/surfacebase/outside/outside3)
 "aOu" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
 /obj/structure/cable/orange{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
+/obj/machinery/door/firedoor/glass/hidden/steel,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/shuttle_pad)
 "aOv" = (
@@ -24196,27 +24212,18 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/shuttle_pad)
 "aOw" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/door/firedoor/glass/hidden/steel{
+	dir = 8
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/tiled,
 /area/tether/surfacebase/shuttle_pad)
 "aOx" = (
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/grey/border{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
+/obj/machinery/door/firedoor/glass/hidden/steel,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/shuttle_pad)
 "aOy" = (
@@ -26548,19 +26555,10 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/rnd/outpost/xenobiology/outpost_storage)
 "aTl" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/mob/living/simple_mob/animal/goat{
-	name = "Spike"
-	},
-/turf/simulated/floor/tiled/freezer/cold,
-/area/crew_quarters/freezer)
+/obj/structure/shuttle/engine/propulsion,
+/turf/simulated/floor/reinforced,
+/turf/simulated/shuttle/plating/carry,
+/area/shuttle/tether)
 "aTm" = (
 /turf/simulated/wall/r_wall,
 /area/tether/surfacebase/medical/admin)
@@ -31533,10 +31531,26 @@
 /turf/simulated/floor/tiled/eris/cafe,
 /area/hydroponics)
 "bbJ" = (
-/obj/structure/shuttle/engine/propulsion,
-/turf/simulated/floor/reinforced,
-/turf/simulated/shuttle/plating/carry,
-/area/shuttle/tether)
+/obj/structure/table/rack/shelf,
+/obj/item/weapon/storage/backpack/parachute{
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/obj/item/weapon/storage/backpack/parachute{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/weapon/storage/backpack/parachute{
+	pixel_x = -4;
+	pixel_y = -6
+	},
+/obj/item/weapon/storage/backpack/parachute{
+	pixel_x = 4;
+	pixel_y = -6
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/tiled/monotile,
+/area/tether/surfacebase/shuttle_pad)
 "bbK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/wood,
@@ -31679,12 +31693,15 @@
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/barrestroom)
 "bbX" = (
-/obj/machinery/atmospherics/unary/engine{
-	dir = 1
+/obj/effect/floor_decal/steeldecal/steel_decals_central5{
+	dir = 8
 	},
-/turf/simulated/floor/reinforced,
-/turf/simulated/shuttle/plating/carry,
-/area/shuttle/tourbus/general)
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/monotile,
+/area/tether/surfacebase/shuttle_pad)
 "bbY" = (
 /obj/effect/floor_decal/spline/plain,
 /obj/item/weapon/stool/padded,
@@ -34590,6 +34607,13 @@
 /obj/structure/bed/chair,
 /turf/simulated/floor/tiled/techfloor,
 /area/tether/surfacebase/shuttle_pad)
+"bhh" = (
+/obj/machinery/atmospherics/unary/engine{
+	dir = 1
+	},
+/turf/simulated/floor/reinforced,
+/turf/simulated/shuttle/plating/carry,
+/area/shuttle/tourbus/general)
 "bhi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -34663,6 +34687,10 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/surgery2)
+"bho" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/monotile,
+/area/tether/surfacebase/shuttle_pad)
 "bhp" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -34817,6 +34845,14 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/southhall)
+"bhD" = (
+/obj/machinery/alarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -22
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/tether/surfacebase/shuttle_pad)
 "bhE" = (
 /turf/simulated/wall,
 /area/tether/surfacebase/topairlock)
@@ -34857,6 +34893,27 @@
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
 /area/tether/surfacebase/southhall)
+"bhL" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/tether/surfacebase/shuttle_pad)
+"bhM" = (
+/obj/machinery/door/firedoor,
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/shuttle_pad)
 "bhN" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/cyan,
 /obj/effect/floor_decal/industrial/warning{
@@ -34901,6 +34958,15 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/plating,
 /area/tether/surfacebase/topairlock)
+"bhS" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/shuttle_pad)
 "bhT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 9
@@ -35807,6 +35873,25 @@
 /obj/structure/table/glass,
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/admin)
+"bjz" = (
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/shuttle_pad)
+"bjA" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/tether/surfacebase/shuttle_pad)
 "bjB" = (
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 8
@@ -35833,6 +35918,73 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/storage)
+"bjC" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/grey/border{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/shuttle_pad)
+"bjD" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/structure/table/rack/shelf,
+/obj/item/weapon/storage/backpack/parachute{
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/obj/item/weapon/storage/backpack/parachute{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/weapon/storage/backpack/parachute{
+	pixel_x = -4;
+	pixel_y = -6
+	},
+/obj/item/weapon/storage/backpack/parachute{
+	pixel_x = 4;
+	pixel_y = -6
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/tether/surfacebase/shuttle_pad)
+"bjE" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/grey/border{
+	dir = 4
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/structure/table/rack/shelf,
+/obj/item/weapon/storage/backpack/parachute{
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/obj/item/weapon/storage/backpack/parachute{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/weapon/storage/backpack/parachute{
+	pixel_x = -4;
+	pixel_y = -6
+	},
+/obj/item/weapon/storage/backpack/parachute{
+	pixel_x = 4;
+	pixel_y = -6
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/shuttle_pad)
 "bjH" = (
 /obj/machinery/light{
 	dir = 1
@@ -43396,26 +43548,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/upperhall)
-"xud" = (
-/obj/structure/table/rack/shelf,
-/obj/item/weapon/storage/backpack/parachute{
-	pixel_x = -4;
-	pixel_y = 4
-	},
-/obj/item/weapon/storage/backpack/parachute{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/item/weapon/storage/backpack/parachute{
-	pixel_x = -4;
-	pixel_y = -6
-	},
-/obj/item/weapon/storage/backpack/parachute{
-	pixel_x = 4;
-	pixel_y = -6
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/tether/surfacebase/shuttle_pad)
 "xvN" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -51111,7 +51243,7 @@ akt
 ahh
 auu
 auu
-axO
+aju
 ayB
 aBh
 aBj
@@ -54685,7 +54817,7 @@ jML
 jHw
 jpB
 aVJ
-bbX
+bhh
 aKU
 aOI
 aPb
@@ -55537,7 +55669,7 @@ caw
 jHw
 gHh
 aVJ
-bbX
+bhh
 aKU
 aOI
 bgW
@@ -56103,11 +56235,11 @@ dXv
 ooM
 uYO
 xxB
-xud
-aMU
-aKe
-aKe
-aKe
+bbJ
+bbX
+bho
+bhL
+bjD
 bgW
 bdW
 bdW
@@ -56242,13 +56374,13 @@ aKj
 aKj
 aKj
 aKf
-aKg
-cdv
+aMU
+aOw
 aKf
 aNX
 aKj
 aKj
-aKf
+bhM
 aKf
 bgZ
 bdz
@@ -56390,7 +56522,7 @@ aKg
 aKe
 aOc
 aKe
-aKg
+bhS
 aMA
 aPu
 aPM
@@ -56532,7 +56664,7 @@ ghf
 sFW
 aMW
 sFW
-aOu
+bjz
 aNx
 aPs
 aPZ
@@ -56810,8 +56942,8 @@ aKj
 aKj
 aNj
 aKf
-cdv
-aKg
+aOu
+aOx
 aKf
 aKj
 aKj
@@ -56957,9 +57089,9 @@ aNN
 aKe
 aKe
 aMY
-aKe
-aOw
-aKe
+bhD
+bjA
+bjD
 aKj
 aac
 aac
@@ -57100,8 +57232,8 @@ aKT
 aKT
 aOe
 aOe
-aOx
-aOe
+bjC
+bjE
 aKj
 aac
 aac
@@ -57522,7 +57654,7 @@ aNk
 uSA
 aNJ
 aNP
-bbJ
+aTl
 aKU
 abg
 aOk
@@ -57664,7 +57796,7 @@ aNl
 aNl
 aNK
 aNP
-bbJ
+aTl
 aKU
 abg
 aOk
@@ -57806,7 +57938,7 @@ aNm
 aNl
 aNK
 aNP
-bbJ
+aTl
 aKU
 abg
 aOk
@@ -60302,7 +60434,7 @@ afZ
 aiX
 ajC
 akW
-anl
+apF
 afS
 aqX
 arP
@@ -60330,7 +60462,7 @@ bfb
 asI
 aum
 aJw
-asu
+aDa
 aoJ
 aGO
 aTg
@@ -60475,7 +60607,7 @@ aJw
 asu
 aoJ
 aHi
-aTl
+aDh
 aUa
 aoJ
 beZ
@@ -60720,7 +60852,7 @@ abn
 ajG
 afS
 afp
-afq
+anl
 bfW
 afS
 ajd
@@ -60728,7 +60860,7 @@ ajx
 alr
 anD
 akX
-apF
+apl
 acf
 aro
 arT

--- a/maps/tether/tether-03-surface3.dmm
+++ b/maps/tether/tether-03-surface3.dmm
@@ -19600,6 +19600,7 @@
 	name = "Robotics Operating Table"
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/decal/cleanable/blood/oil,
 /turf/simulated/floor/tiled/dark,
 /area/rnd/robotics/surgeryroom2)
 "aFX" = (
@@ -22126,6 +22127,7 @@
 	name = "Robotics Operating Table"
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/decal/cleanable/blood/oil,
 /turf/simulated/floor/tiled/dark,
 /area/rnd/robotics/surgeryroom1)
 "aKl" = (

--- a/maps/tether/tether-03-surface3.dmm
+++ b/maps/tether/tether-03-surface3.dmm
@@ -122,15 +122,10 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/breakroom)
 "aal" = (
-/obj/machinery/vending/cola{
-	dir = 1
-	},
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/red/border,
 /obj/machinery/camera/network/security{
-	dir = 10
+	dir = 5
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/carpet/blue,
 /area/tether/surfacebase/security/breakroom)
 "aam" = (
 /obj/machinery/vending/coffee{
@@ -22107,18 +22102,22 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/shuttle_pad)
 "aKi" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/orange{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/corner/beige/border{
+	dir = 1
+	},
+/obj/machinery/camera/network/tether,
 /turf/simulated/floor/tiled,
-/area/tether/surfacebase/shuttle_pad)
+/area/hallway/lower/third_south)
 "aKj" = (
 /turf/simulated/wall,
 /area/tether/surfacebase/shuttle_pad)
@@ -26555,10 +26554,18 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/rnd/outpost/xenobiology/outpost_storage)
 "aTl" = (
-/obj/structure/shuttle/engine/propulsion,
-/turf/simulated/floor/reinforced,
-/turf/simulated/shuttle/plating/carry,
-/area/shuttle/tether)
+/obj/effect/floor_decal/corner/grey/diagonal,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/camera/network/civilian{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/kitchen)
 "aTm" = (
 /turf/simulated/wall/r_wall,
 /area/tether/surfacebase/medical/admin)
@@ -32587,24 +32594,22 @@
 /turf/simulated/floor/wood,
 /area/tether/surfacebase/entertainment)
 "bdr" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
 /obj/structure/extinguisher_cabinet{
-	pixel_y = 30
-	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 1
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7,
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/beige/border{
-	dir = 1
+	dir = 8;
+	pixel_x = 30
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/lower/third_south)
+/area/tether/surfacebase/shuttle_pad)
 "bds" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -33158,12 +33163,12 @@
 /area/crew_quarters/kitchen)
 "bew" = (
 /obj/effect/floor_decal/corner/grey/diagonal,
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
 "bex" = (
@@ -33597,18 +33602,20 @@
 /turf/simulated/floor/tiled/eris/steel/bar_dance,
 /area/tether/surfacebase/barbackmaintenance)
 "bfp" = (
-/obj/effect/floor_decal/corner/grey/diagonal,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/machinery/door/firedoor,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
 	},
 /obj/machinery/camera/network/civilian{
-	dir = 9
+	dir = 1
 	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/kitchen)
+/turf/simulated/floor/plating,
+/area/tether/surfacebase/botanystorage)
 "bfq" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -34608,12 +34615,11 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/tether/surfacebase/shuttle_pad)
 "bhh" = (
-/obj/machinery/atmospherics/unary/engine{
+/obj/machinery/camera/network/civilian{
 	dir = 1
 	},
 /turf/simulated/floor/reinforced,
-/turf/simulated/shuttle/plating/carry,
-/area/shuttle/tourbus/general)
+/area/tether/surfacebase/shuttle_pad)
 "bhi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -34667,9 +34673,26 @@
 /turf/simulated/floor/plating,
 /area/tether/surfacebase/southhall)
 "bhm" = (
-/obj/machinery/door/firedoor/glass/hidden/steel,
-/turf/simulated/floor/tiled/monotile,
-/area/tether/surfacebase/southhall)
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/table/rack,
+/obj/item/clothing/shoes/magboots,
+/obj/item/device/suit_cooling_unit,
+/obj/item/weapon/tank/oxygen,
+/obj/machinery/door/window/brigdoor/eastleft{
+	name = "Protosuit Storage";
+	req_access = list(58)
+	},
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/suit/space/void/security/prototype,
+/obj/item/clothing/head/helmet/space/void/security/prototype,
+/obj/machinery/camera/network/security{
+	dir = 5
+	},
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/security/hos)
 "bhn" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
@@ -35812,11 +35835,12 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/cafeteria)
 "bjs" = (
-/obj/machinery/light{
-	dir = 8
+/obj/machinery/door/firedoor/glass/hidden/steel,
+/obj/machinery/camera/network/tether{
+	dir = 4
 	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/cafeteria)
+/turf/simulated/floor/tiled/monotile,
+/area/tether/surfacebase/southhall)
 "bjt" = (
 /obj/structure/table/bench/sifwooden/padded,
 /obj/machinery/computer/security/telescreen/entertainment{
@@ -35833,11 +35857,11 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/cafeteria)
 "bjv" = (
-/obj/machinery/light{
-	dir = 4
+/obj/machinery/camera/network/tether{
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
-/area/tether/surfacebase/cafeteria)
+/area/tether/surfacebase/southhall)
 "bjw" = (
 /obj/machinery/door/firedoor,
 /obj/structure/grille,
@@ -35985,6 +36009,24 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/shuttle_pad)
+"bjF" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/camera/network/tether{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/cafeteria)
+"bjG" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/camera/network/tether{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/cafeteria)
 "bjH" = (
 /obj/machinery/light{
 	dir = 1
@@ -36021,6 +36063,53 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/admin)
+"bjK" = (
+/obj/structure/table/reinforced,
+/obj/item/weapon/book/manual/security_space_law,
+/obj/item/weapon/book/codex,
+/obj/item/weapon/book/manual/security_space_law,
+/obj/effect/floor_decal/borderfloor{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 9
+	},
+/obj/machinery/camera/network/security{
+	dir = 5
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/security/briefingroom)
+"bjL" = (
+/obj/machinery/vending/cola{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/red/border,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/security/breakroom)
+"bjM" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 1
+	},
+/obj/machinery/camera/network/security,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/security/upperhall)
+"bjN" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
+/obj/machinery/computer/atmos_alert{
+	dir = 8
+	},
+/obj/machinery/camera/network/civilian{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/tether/surfacebase/shuttle_pad)
 "bjO" = (
 /obj/machinery/status_display{
 	layer = 4;
@@ -36040,6 +36129,18 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/triage)
+"bjP" = (
+/obj/structure/shuttle/engine/propulsion,
+/turf/simulated/floor/reinforced,
+/turf/simulated/shuttle/plating/carry,
+/area/shuttle/tether)
+"bjQ" = (
+/obj/machinery/atmospherics/unary/engine{
+	dir = 1
+	},
+/turf/simulated/floor/reinforced,
+/turf/simulated/shuttle/plating/carry,
+/area/shuttle/tourbus/general)
 "bjT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -39510,13 +39611,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/shuttle_pad)
-"ifI" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
-/obj/machinery/computer/atmos_alert{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/tether/surfacebase/shuttle_pad)
 "iiv" = (
 /obj/structure/table/woodentable,
 /obj/machinery/atmospherics/unary/vent_pump/on,
@@ -40554,24 +40648,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/lower/third_south)
-"lMj" = (
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/table/rack,
-/obj/item/clothing/shoes/magboots,
-/obj/item/device/suit_cooling_unit,
-/obj/item/weapon/tank/oxygen,
-/obj/machinery/door/window/brigdoor/eastleft{
-	name = "Protosuit Storage";
-	req_access = list(58)
-	},
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/suit/space/void/security/prototype,
-/obj/item/clothing/head/helmet/space/void/security/prototype,
-/turf/simulated/floor/wood,
-/area/tether/surfacebase/security/hos)
 "lSv" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -42543,19 +42619,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/iaa/officeb)
-"tPE" = (
-/obj/structure/table/reinforced,
-/obj/item/weapon/book/manual/security_space_law,
-/obj/item/weapon/book/codex,
-/obj/item/weapon/book/manual/security_space_law,
-/obj/effect/floor_decal/borderfloor{
-	dir = 9
-	},
-/obj/effect/floor_decal/corner/red/border{
-	dir = 9
-	},
-/turf/simulated/floor/tiled,
-/area/tether/surfacebase/security/briefingroom)
 "tRg" = (
 /obj/machinery/light,
 /obj/effect/floor_decal/borderfloor,
@@ -52467,7 +52530,7 @@ abX
 agR
 pJL
 gae
-aUe
+aal
 upV
 dMk
 aak
@@ -52612,7 +52675,7 @@ oIJ
 iLR
 aRJ
 cnO
-aal
+bjL
 adq
 aaO
 abE
@@ -53317,7 +53380,7 @@ aOm
 adG
 agQ
 aWs
-lMj
+bhm
 oPG
 acF
 tkB
@@ -53334,7 +53397,7 @@ aew
 bzK
 agg
 adW
-qAt
+bjM
 snE
 ajJ
 aTX
@@ -54176,7 +54239,7 @@ lmq
 aWv
 syw
 ueB
-tPE
+bjK
 acW
 acs
 adm
@@ -54817,7 +54880,7 @@ jML
 jHw
 jpB
 aVJ
-bhh
+bjQ
 aKU
 aOI
 aPb
@@ -55669,7 +55732,7 @@ caw
 jHw
 gHh
 aVJ
-bhh
+bjQ
 aKU
 aOI
 bgW
@@ -56230,7 +56293,7 @@ bMK
 rxh
 jZe
 uxT
-ifI
+bjN
 dXv
 ooM
 uYO
@@ -56531,7 +56594,7 @@ bfj
 beU
 qbo
 bhi
-bhm
+bjs
 beU
 bhp
 beU
@@ -56544,7 +56607,7 @@ bsr
 biL
 biL
 biL
-bjs
+bjF
 biF
 adG
 aOi
@@ -56646,7 +56709,7 @@ bgk
 bbk
 bgB
 aYC
-bdr
+aKi
 aIa
 lIe
 aJn
@@ -56792,7 +56855,7 @@ cWU
 aIb
 aID
 aJp
-aKi
+bdr
 aKX
 aLB
 aMc
@@ -57248,7 +57311,7 @@ aac
 bhr
 beU
 bhx
-beU
+bjv
 biF
 biP
 biY
@@ -57371,7 +57434,7 @@ aKU
 aKU
 aKU
 aKU
-aKU
+bhh
 aKj
 aKj
 aOy
@@ -57654,7 +57717,7 @@ aNk
 uSA
 aNJ
 aNP
-aTl
+bjP
 aKU
 abg
 aOk
@@ -57796,7 +57859,7 @@ aNl
 aNl
 aNK
 aNP
-aTl
+bjP
 aKU
 abg
 aOk
@@ -57938,7 +58001,7 @@ aNm
 aNl
 aNK
 aNP
-aTl
+bjP
 aKU
 abg
 aOk
@@ -58100,7 +58163,7 @@ aac
 bhr
 beU
 bhx
-beU
+bjv
 biF
 biQ
 bjc
@@ -58816,7 +58879,7 @@ gYa
 lWN
 qKO
 ikh
-bjv
+bjG
 biF
 adG
 aOi
@@ -59615,8 +59678,8 @@ aBD
 anj
 bgx
 rBz
+aTl
 bew
-bfp
 bfl
 baX
 amY
@@ -62152,7 +62215,7 @@ adG
 aAC
 aAR
 aAR
-aAR
+bfp
 ayg
 aEk
 aEL

--- a/maps/tether/tether-03-surface3.dmm
+++ b/maps/tether/tether-03-surface3.dmm
@@ -1677,6 +1677,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "east bump";
+	nightshift_setting = 2;
 	pixel_x = 28
 	},
 /obj/structure/cable/green{
@@ -8720,6 +8721,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "east bump";
+	nightshift_setting = 2;
 	pixel_x = 28
 	},
 /obj/structure/cable/green{
@@ -9289,17 +9291,18 @@
 /turf/simulated/floor/tiled,
 /area/rnd/research/testingrange)
 "aoM" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 6
+	},
+/obj/structure/cable/green,
 /obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_y = 24
+	dir = 4;
+	name = "east bump";
+	nightshift_setting = 2;
+	pixel_x = 28
 	},
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/grass,
-/area/hydroponics)
+/turf/simulated/floor/tiled/techmaint,
+/area/tether/surfacebase/public_garden_three)
 "aoN" = (
 /obj/structure/bed/chair/wood{
 	dir = 8
@@ -10266,27 +10269,31 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/vacant/vacant_shop)
 "aqk" = (
-/obj/effect/floor_decal/techfloor{
-	dir = 4
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 6
+	},
+/obj/effect/floor_decal/borderfloorwhite/corner2,
+/obj/effect/floor_decal/corner/paleblue/bordercorner2,
+/obj/structure/cable/green{
+	icon_state = "0-8"
 	},
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "east bump";
+	nightshift_setting = 2;
 	pixel_x = 28
 	},
-/obj/structure/cable/green{
-	icon_state = "0-8"
+/obj/structure/table/glass,
+/obj/item/weapon/storage/box/cups{
+	pixel_x = 7;
+	pixel_y = 13
 	},
-/obj/random/junk,
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/vacant/vacant_shop)
+/obj/machinery/recharger,
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/lobby)
 "aql" = (
 /obj/structure/closet/l3closet/scientist,
 /obj/machinery/light{
@@ -10475,16 +10482,17 @@
 /area/rnd/outpost/xenobiology/outpost_north_airlock)
 "aqD" = (
 /obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 28
+	dir = 1;
+	name = "north bump";
+	nightshift_setting = 2;
+	pixel_y = 24
 	},
 /obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
+	d2 = 2;
+	icon_state = "0-2"
 	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/recreation_area_restroom)
+/turf/simulated/floor/grass,
+/area/hydroponics)
 "aqE" = (
 /obj/machinery/alarm{
 	dir = 1;
@@ -10901,6 +10909,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
+	nightshift_setting = 2;
 	pixel_y = 24
 	},
 /obj/structure/cable/green{
@@ -13189,16 +13198,29 @@
 /turf/simulated/wall,
 /area/crew_quarters/kitchen)
 "avz" = (
-/obj/item/weapon/stool/padded,
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/kitchen)
-"avA" = (
-/obj/item/weapon/stool/padded,
 /obj/effect/floor_decal/corner/beige{
-	dir = 6
+	dir = 9
+	},
+/obj/effect/floor_decal/spline/plain{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
+	},
+/obj/machinery/camera/network/civilian{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
-/area/crew_quarters/kitchen)
+/area/crew_quarters/bar)
+"avA" = (
+/obj/structure/noticeboard{
+	pixel_y = 29
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/bar)
 "avB" = (
 /obj/structure/table/glass,
 /obj/machinery/reagentgrinder,
@@ -13303,12 +13325,9 @@
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/kitchen)
 "avM" = (
-/obj/effect/floor_decal/corner/beige{
-	dir = 10
-	},
-/obj/effect/floor_decal/spline/plain,
+/obj/item/weapon/stool/padded,
 /turf/simulated/floor/tiled/white,
-/area/crew_quarters/kitchen)
+/area/crew_quarters/bar)
 "avN" = (
 /obj/machinery/light{
 	dir = 1
@@ -15888,28 +15907,28 @@
 /turf/simulated/floor/tiled,
 /area/rnd/research/researchdivision)
 "azK" = (
-/obj/structure/cable/green{
-	icon_state = "0-8"
+/obj/effect/floor_decal/techfloor{
+	dir = 4
 	},
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "east bump";
+	nightshift_setting = 2;
 	pixel_x = 28
 	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 4
+/obj/structure/cable/green{
+	icon_state = "0-8"
 	},
-/obj/effect/floor_decal/corner/mauve/border{
-	dir = 4
+/obj/random/junk,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 9
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 10
-	},
-/turf/simulated/floor/tiled,
-/area/rnd/research/researchdivision)
+/turf/simulated/floor/tiled/techfloor,
+/area/vacant/vacant_shop)
 "azL" = (
 /turf/simulated/wall/r_wall,
 /area/rnd/research/testingrange)
@@ -17450,20 +17469,12 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/servicebackroom)
 "aCi" = (
+/obj/item/weapon/stool/padded,
 /obj/effect/floor_decal/corner/beige{
-	dir = 10
-	},
-/obj/effect/floor_decal/corner/beige{
-	dir = 4
-	},
-/obj/effect/floor_decal/spline/plain{
 	dir = 6
 	},
-/obj/machinery/light{
-	dir = 4
-	},
 /turf/simulated/floor/tiled/white,
-/area/crew_quarters/kitchen)
+/area/crew_quarters/bar)
 "aCj" = (
 /obj/effect/floor_decal/borderfloor/corner{
 	dir = 8
@@ -20571,7 +20582,7 @@
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
 /turf/simulated/floor/tiled/white,
-/area/crew_quarters/kitchen)
+/area/crew_quarters/bar)
 "aHz" = (
 /obj/effect/floor_decal/spline/plain{
 	dir = 1
@@ -22981,16 +22992,18 @@
 /turf/simulated/floor/bluegrid,
 /area/rnd/robotics/mechbay)
 "aLV" = (
-/obj/structure/cable/green{
-	icon_state = "0-8"
-	},
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "east bump";
+	nightshift_setting = 2;
 	pixel_x = 28
 	},
-/turf/simulated/floor/bluegrid,
-/area/rnd/robotics/mechbay)
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/recreation_area_restroom)
 "aLW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 6
@@ -23805,20 +23818,27 @@
 /turf/simulated/shuttle/floor/black,
 /area/shuttle/tether)
 "aNA" = (
+/obj/structure/table/rack/steel,
+/obj/item/pizzavoucher,
+/obj/item/weapon/moneybag,
+/obj/item/weapon/inflatable_duck,
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "east bump";
+	nightshift_setting = 2;
 	pixel_x = 28
 	},
+/obj/item/weapon/gun/projectile/revolver/capgun,
+/obj/item/weapon/gun/projectile/revolver/capgun,
+/obj/item/toy/cultsword,
+/obj/item/toy/cultsword,
+/obj/item/weapon/bikehorn/rubberducky,
+/obj/item/weapon/reagent_containers/spray/cleaner,
 /obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
+	icon_state = "0-2"
 	},
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/rnd/outpost/xenobiology/outpost_hallway)
+/turf/simulated/floor/lino,
+/area/tether/surfacebase/entertainment/backstage)
 "aNB" = (
 /obj/structure/railing{
 	dir = 8
@@ -24416,17 +24436,22 @@
 /turf/simulated/wall,
 /area/rnd/outpost/xenobiology/outpost_office)
 "aOS" = (
+/obj/structure/table/woodentable,
+/obj/item/weapon/reagent_containers/food/drinks/metaglass,
+/obj/item/weapon/reagent_containers/food/drinks/metaglass,
+/obj/item/weapon/reagent_containers/food/drinks/metaglass,
+/obj/item/weapon/reagent_containers/food/drinks/metaglass,
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "east bump";
+	nightshift_setting = 2;
 	pixel_x = 28
 	},
 /obj/structure/cable/green{
 	icon_state = "0-8"
 	},
-/obj/structure/closet/radiation,
-/turf/simulated/floor/tiled/white,
-/area/rnd/outpost/xenobiology/outpost_decon)
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/bar_backroom)
 "aOT" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -27403,17 +27428,29 @@
 /turf/simulated/floor/tiled/eris/white/orangecorner,
 /area/shuttle/tourbus/cockpit)
 "aUO" = (
-/obj/effect/floor_decal/techfloor{
-	dir = 6
+/obj/structure/cable/green{
+	icon_state = "0-8"
 	},
-/obj/structure/cable/green,
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "east bump";
+	nightshift_setting = 2;
 	pixel_x = 28
 	},
-/turf/simulated/floor/tiled/techmaint,
-/area/tether/surfacebase/public_garden_three)
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/mauve/border{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 9
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 10
+	},
+/turf/simulated/floor/tiled,
+/area/rnd/research/researchdivision)
 "aUP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -27731,30 +27768,24 @@
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/lobby)
 "aVo" = (
-/obj/effect/floor_decal/borderfloorwhite{
+/obj/effect/floor_decal/spline/plain{
 	dir = 6
 	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 6
-	},
-/obj/effect/floor_decal/borderfloorwhite/corner2,
-/obj/effect/floor_decal/corner/paleblue/bordercorner2,
-/obj/structure/cable/green{
-	icon_state = "0-8"
-	},
+/obj/item/weapon/stool/padded,
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "east bump";
+	nightshift_setting = 2;
 	pixel_x = 28
 	},
-/obj/structure/table/glass,
-/obj/item/weapon/storage/box/cups{
-	pixel_x = 7;
-	pixel_y = 13
+/obj/structure/cable/green{
+	icon_state = "0-8"
 	},
-/obj/machinery/recharger,
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/lobby)
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/lino,
+/area/crew_quarters/bar)
 "aVp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -29059,21 +29090,17 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/rnd/outpost/xenobiology/outpost_storage)
 "aXz" = (
+/obj/structure/cable/green{
+	icon_state = "0-8"
+	},
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "east bump";
+	nightshift_setting = 2;
 	pixel_x = 28
 	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/cable/green,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/obj/machinery/disposal,
-/turf/simulated/floor/wood,
-/area/rnd/outpost/xenobiology/outpost_office)
+/turf/simulated/floor/bluegrid,
+/area/rnd/robotics/mechbay)
 "aXA" = (
 /obj/machinery/light{
 	dir = 4
@@ -31615,21 +31642,21 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bbQ" = (
-/obj/structure/table/woodentable,
-/obj/item/weapon/reagent_containers/food/drinks/metaglass,
-/obj/item/weapon/reagent_containers/food/drinks/metaglass,
-/obj/item/weapon/reagent_containers/food/drinks/metaglass,
-/obj/item/weapon/reagent_containers/food/drinks/metaglass,
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "east bump";
+	nightshift_setting = 2;
 	pixel_x = 28
 	},
 /obj/structure/cable/green{
+	d2 = 8;
 	icon_state = "0-8"
 	},
-/turf/simulated/floor/wood,
-/area/tether/surfacebase/bar_backroom)
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/rnd/outpost/xenobiology/outpost_hallway)
 "bbR" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -32263,26 +32290,34 @@
 /turf/simulated/floor/tiled,
 /area/hallway/lower/third_south)
 "bcP" = (
-/obj/structure/table/rack/steel,
-/obj/item/pizzavoucher,
-/obj/item/weapon/moneybag,
-/obj/item/weapon/inflatable_duck,
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 28
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 8
 	},
-/obj/item/weapon/gun/projectile/revolver/capgun,
-/obj/item/weapon/gun/projectile/revolver/capgun,
-/obj/item/toy/cultsword,
-/obj/item/toy/cultsword,
-/obj/item/weapon/bikehorn/rubberducky,
-/obj/item/weapon/reagent_containers/spray/cleaner,
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 8
+	},
+/obj/structure/bed/chair/wheelchair{
+	dir = 4
+	},
+/obj/structure/bed/chair/wheelchair{
+	dir = 4
+	},
+/obj/structure/bed/chair/wheelchair{
+	dir = 4
+	},
+/obj/machinery/power/apc{
+	cell_type = /obj/item/weapon/cell/super;
+	dir = 8;
+	name = "west bump";
+	nightshift_setting = 2;
+	pixel_x = -30
+	},
 /obj/structure/cable/green{
+	d2 = 2;
 	icon_state = "0-2"
 	},
-/turf/simulated/floor/lino,
-/area/tether/surfacebase/entertainment/backstage)
+/turf/simulated/floor/tiled/white,
+/area/tether/surfacebase/medical/storage)
 "bcQ" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -33954,22 +33989,11 @@
 /area/crew_quarters/bar)
 "bfZ" = (
 /obj/effect/floor_decal/corner/beige{
-	dir = 9
+	dir = 10
 	},
-/obj/effect/floor_decal/spline/plain{
-	dir = 8
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 4
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 9
-	},
-/obj/machinery/camera/network/civilian{
-	dir = 4
-	},
+/obj/effect/floor_decal/spline/plain,
 /turf/simulated/floor/tiled/white,
-/area/crew_quarters/kitchen)
+/area/crew_quarters/bar)
 "bga" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -34008,11 +34032,20 @@
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/servicebackroom)
 "bgf" = (
-/obj/structure/noticeboard{
-	pixel_y = 29
+/obj/effect/floor_decal/corner/beige{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/beige{
+	dir = 4
+	},
+/obj/effect/floor_decal/spline/plain{
+	dir = 6
+	},
+/obj/machinery/light{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
-/area/crew_quarters/kitchen)
+/area/crew_quarters/bar)
 "bgg" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -34283,23 +34316,10 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bgE" = (
-/obj/effect/floor_decal/spline/plain{
-	dir = 6
-	},
-/obj/item/weapon/stool/padded,
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 28
-	},
-/obj/structure/cable/green{
-	icon_state = "0-8"
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/lino,
-/area/crew_quarters/bar)
+/obj/structure/shuttle/engine/propulsion,
+/turf/simulated/floor/reinforced,
+/turf/simulated/shuttle/plating/carry,
+/area/shuttle/tether)
 "bgF" = (
 /obj/structure/flora/pottedplant,
 /obj/machinery/camera/network/civilian{
@@ -36132,11 +36152,36 @@
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/triage)
 "bjP" = (
-/obj/structure/shuttle/engine/propulsion,
-/turf/simulated/floor/reinforced,
-/turf/simulated/shuttle/plating/carry,
-/area/shuttle/tether)
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	nightshift_setting = 2;
+	pixel_x = 28
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/cable/green,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/machinery/disposal,
+/turf/simulated/floor/wood,
+/area/rnd/outpost/xenobiology/outpost_office)
 "bjQ" = (
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	nightshift_setting = 2;
+	pixel_x = 28
+	},
+/obj/structure/cable/green{
+	icon_state = "0-8"
+	},
+/obj/structure/closet/radiation,
+/turf/simulated/floor/tiled/white,
+/area/rnd/outpost/xenobiology/outpost_decon)
+"bjR" = (
 /obj/machinery/atmospherics/unary/engine{
 	dir = 1
 	},
@@ -37052,34 +37097,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/triage)
-"bmg" = (
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 8
-	},
-/obj/structure/bed/chair/wheelchair{
-	dir = 4
-	},
-/obj/structure/bed/chair/wheelchair{
-	dir = 4
-	},
-/obj/structure/bed/chair/wheelchair{
-	dir = 4
-	},
-/obj/machinery/power/apc{
-	cell_type = /obj/item/weapon/cell/super;
-	dir = 8;
-	name = "west bump";
-	pixel_x = -30
-	},
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/tiled/white,
-/area/tether/surfacebase/medical/storage)
 "bmm" = (
 /obj/item/device/radio/intercom{
 	dir = 8;
@@ -49070,7 +49087,7 @@ aPO
 aQc
 aQo
 aQL
-aXz
+bjP
 aAk
 aRa
 aMM
@@ -49625,7 +49642,7 @@ aNn
 aMH
 aNc
 aNn
-aNA
+bbQ
 aOr
 aEt
 aGs
@@ -50133,7 +50150,7 @@ arW
 aDy
 aDF
 aDH
-aUO
+aoM
 arW
 eCg
 agw
@@ -50495,7 +50512,7 @@ aQY
 aRe
 aRs
 aOG
-aOS
+bjQ
 aRV
 pPs
 lcS
@@ -52450,7 +52467,7 @@ ayQ
 aAM
 ayS
 azf
-azK
+aUO
 aAp
 apK
 aCe
@@ -52710,7 +52727,7 @@ apr
 apQ
 aiG
 afj
-aqD
+aLV
 awo
 awM
 aXI
@@ -54161,7 +54178,7 @@ aAs
 dbk
 aJU
 aKQ
-aLV
+aXz
 aKQ
 aNw
 aIw
@@ -54882,7 +54899,7 @@ jML
 jHw
 jpB
 aVJ
-bjQ
+bjR
 aKU
 aOI
 aPb
@@ -55734,7 +55751,7 @@ caw
 jHw
 gHh
 aVJ
-bjQ
+bjR
 aKU
 aOI
 bgW
@@ -56418,7 +56435,7 @@ aWC
 bbe
 bcj
 bcH
-bcP
+aNA
 bcU
 bdd
 aFY
@@ -56953,7 +56970,7 @@ aeN
 aUW
 aVe
 aVl
-aVo
+aqk
 aij
 aeH
 avG
@@ -57719,7 +57736,7 @@ aNk
 uSA
 aNJ
 aNP
-bjP
+bgE
 aKU
 abg
 aOk
@@ -57861,7 +57878,7 @@ aNl
 aNl
 aNK
 aNP
-bjP
+bgE
 aKU
 abg
 aOk
@@ -58003,7 +58020,7 @@ aNm
 aNl
 aNK
 aNP
-bjP
+bgE
 aKU
 abg
 aOk
@@ -58263,7 +58280,7 @@ atP
 avD
 bej
 bfO
-bfZ
+avz
 aHy
 bee
 aCT
@@ -58405,8 +58422,8 @@ soG
 anj
 bfe
 avy
-bgf
-avM
+avA
+bfZ
 aJS
 asX
 aIl
@@ -58502,7 +58519,7 @@ aWe
 bjB
 aaS
 abc
-bmg
+bcP
 ada
 aVD
 adu
@@ -58547,8 +58564,8 @@ oII
 anj
 aLc
 wBv
-avz
 avM
+bfZ
 asX
 asX
 aIn
@@ -58671,7 +58688,7 @@ aol
 aYa
 aYe
 aYl
-aqk
+azK
 apg
 apc
 aGH
@@ -58689,8 +58706,8 @@ atQ
 bfd
 anj
 avm
-avz
 avM
+bfZ
 asX
 asX
 asX
@@ -58831,8 +58848,8 @@ bgn
 aKu
 anj
 avo
-avz
 avM
+bfZ
 asX
 aLd
 aHe
@@ -58973,8 +58990,8 @@ aBx
 baq
 anj
 avo
-avz
 avM
+bfZ
 asX
 aLd
 aHl
@@ -59115,8 +59132,8 @@ bgp
 baE
 aLc
 axt
-avA
 aCi
+bgf
 asX
 asX
 asX
@@ -59692,7 +59709,7 @@ aIP
 azx
 aIm
 bgC
-bgE
+aVo
 aIf
 baW
 ayM
@@ -59804,7 +59821,7 @@ amK
 anu
 anX
 aok
-aoM
+aqD
 aEX
 atR
 aEX
@@ -60541,7 +60558,7 @@ awt
 bgM
 awV
 axp
-bbQ
+aOS
 axx
 aJt
 aGK

--- a/maps/tether/tether-05-station1.dmm
+++ b/maps/tether/tether-05-station1.dmm
@@ -1285,15 +1285,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
 	dir = 5
 	},
-/obj/machinery/access_button{
-	command = "cycle_interior";
-	frequency = 1381;
-	master_tag = "ai_sat_airlock_inner";
-	name = "interior access button";
-	pixel_x = 28;
-	pixel_y = -26;
-	req_one_access = list(61)
-	},
 /turf/simulated/floor/tiled/dark{
 	nitrogen = 100;
 	oxygen = 0;
@@ -1361,7 +1352,6 @@
 	name = "Telecoms Server Access";
 	req_access = list(61)
 	},
-/obj/effect/map_helper/airlock/door/int_door,
 /turf/simulated/floor/tiled/techfloor,
 /area/tcommsat/chamber)
 "acB" = (
@@ -1377,41 +1367,33 @@
 /turf/simulated/floor/tiled/monotile,
 /area/tether/exploration)
 "acC" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 4
+	},
+/obj/machinery/airlock_sensor/airlock_interior{
+	frequency = 1381;
+	id_tag = "server_access_in_sensor";
+	name = "interior sensor";
+	pixel_y = -25
+	},
+/turf/simulated/floor/tiled/dark{
+	nitrogen = 100;
+	oxygen = 0;
+	temperature = 80
+	},
+/area/tcommsat/chamber)
+"acD" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 4;
 	frequency = 1381;
 	id_tag = "server_access_pump"
 	},
-/obj/effect/map_helper/airlock/atmos/chamber_pump,
-/turf/simulated/floor/tiled/techfloor,
-/area/tcommsat/chamber)
-"acD" = (
-/obj/machinery/embedded_controller/radio/airlock/advanced_airlock_controller{
-	frequency = 1381;
-	id_tag = "server_access_airlock";
-	name = "Server Access Airlock";
-	pixel_y = 25;
-	tag_airpump = "server_access_pump";
-	tag_chamber_sensor = "server_access_sensor";
-	tag_exterior_door = "server_access_outer";
-	tag_exterior_sensor = "server_access_ex_sensor";
-	tag_interior_door = "server_access_inner";
-	tag_interior_sensor = "server_access_in_sensor";
-	tag_secure = 1
-	},
-/obj/machinery/airlock_sensor{
-	frequency = 1381;
-	id_tag = "server_access_sensor";
-	pixel_x = 12;
-	pixel_y = 25
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden{
-	dir = 1
-	},
-/obj/effect/map_helper/airlock/sensor/chamber_sensor,
 /turf/simulated/floor/tiled/techfloor,
 /area/tcommsat/chamber)
 "acE" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
 /obj/machinery/door/airlock/maintenance_hatch{
 	frequency = 1381;
 	icon_state = "door_locked";
@@ -1420,10 +1402,6 @@
 	name = "Telecoms Server Access";
 	req_access = list(61)
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
-/obj/effect/map_helper/airlock/door/ext_door,
 /turf/simulated/floor/tiled/techfloor,
 /area/tcommsat/chamber)
 "acF" = (
@@ -1436,14 +1414,12 @@
 	dir = 10;
 	icon_state = "intact"
 	},
-/obj/machinery/access_button{
-	command = "cycle_exterior";
+/obj/machinery/airlock_sensor/airlock_exterior{
 	frequency = 1381;
-	master_tag = "ai_sat_airlock_inner";
-	name = "exterior access button";
-	pixel_x = -26;
-	pixel_y = -26;
-	req_one_access = list(61)
+	id_tag = "server_access_ex_sensor";
+	master_tag = "server_access_airlock";
+	pixel_x = -24;
+	pixel_y = -24
 	},
 /turf/simulated/floor/tiled,
 /area/tcommsat/computer)
@@ -1455,6 +1431,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
+/obj/item/device/multitool,
 /turf/simulated/floor/tiled,
 /area/tcommsat/computer)
 "acH" = (
@@ -2200,6 +2177,12 @@
 	},
 /turf/simulated/floor,
 /area/maintenance/substation/engineering)
+"adJ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 5
+	},
+/turf/simulated/floor/tiled,
+/area/tcommsat/computer)
 "adK" = (
 /obj/effect/landmark{
 	name = "morphspawn"
@@ -2226,6 +2209,31 @@
 /obj/structure/catwalk,
 /turf/simulated/floor,
 /area/maintenance/station/eng_lower)
+"adM" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 1
+	},
+/obj/machinery/embedded_controller/radio/airlock/advanced_airlock_controller{
+	frequency = 1381;
+	id_tag = "server_access_airlock";
+	name = "Server Access Airlock";
+	pixel_y = 25;
+	tag_airpump = "server_access_pump";
+	tag_chamber_sensor = "server_access_sensor";
+	tag_exterior_door = "server_access_outer";
+	tag_exterior_sensor = "server_access_ex_sensor";
+	tag_interior_door = "server_access_inner";
+	tag_interior_sensor = "server_access_in_sensor";
+	tag_secure = 1
+	},
+/obj/machinery/airlock_sensor{
+	frequency = 1381;
+	id_tag = "server_access_sensor";
+	pixel_x = 12;
+	pixel_y = 25
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/tcommsat/chamber)
 "adQ" = (
 /obj/machinery/computer/power_monitor{
 	dir = 4;
@@ -17295,12 +17303,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/excursion/general)
-"dJJ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 5
-	},
-/turf/simulated/floor/tiled,
-/area/tcommsat/computer)
 "dJL" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -50235,7 +50237,7 @@ avO
 bYg
 acu
 acA
-acC
+acD
 acV
 otm
 pMe
@@ -50375,9 +50377,9 @@ rLI
 rLI
 rLI
 thI
-rLO
+acC
 xTB
-acD
+adM
 huZ
 otm
 cik
@@ -50662,7 +50664,7 @@ thI
 rLO
 xSF
 acF
-dJJ
+adJ
 xEG
 awQ
 hea

--- a/maps/tether/tether-05-station1.dmm
+++ b/maps/tether/tether-05-station1.dmm
@@ -1281,6 +1281,25 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor,
 /area/teleporter/departing)
+"acu" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 5
+	},
+/obj/machinery/access_button{
+	command = "cycle_interior";
+	frequency = 1381;
+	master_tag = "ai_sat_airlock_inner";
+	name = "interior access button";
+	pixel_x = 28;
+	pixel_y = -26;
+	req_one_access = list(61)
+	},
+/turf/simulated/floor/tiled/dark{
+	nitrogen = 100;
+	oxygen = 0;
+	temperature = 80
+	},
+/area/tcommsat/chamber)
 "acv" = (
 /obj/structure/table/rack{
 	dir = 8;
@@ -1333,6 +1352,18 @@
 "acz" = (
 /turf/simulated/wall/r_wall,
 /area/engineering/hallway)
+"acA" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	frequency = 1381;
+	icon_state = "door_locked";
+	id_tag = "server_access_inner";
+	locked = 1;
+	name = "Telecoms Server Access";
+	req_access = list(61)
+	},
+/obj/effect/map_helper/airlock/door/int_door,
+/turf/simulated/floor/tiled/techfloor,
+/area/tcommsat/chamber)
 "acB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -1345,6 +1376,87 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/tether/exploration)
+"acC" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 4;
+	frequency = 1381;
+	id_tag = "server_access_pump"
+	},
+/obj/effect/map_helper/airlock/atmos/chamber_pump,
+/turf/simulated/floor/tiled/techfloor,
+/area/tcommsat/chamber)
+"acD" = (
+/obj/machinery/embedded_controller/radio/airlock/advanced_airlock_controller{
+	frequency = 1381;
+	id_tag = "server_access_airlock";
+	name = "Server Access Airlock";
+	pixel_y = 25;
+	tag_airpump = "server_access_pump";
+	tag_chamber_sensor = "server_access_sensor";
+	tag_exterior_door = "server_access_outer";
+	tag_exterior_sensor = "server_access_ex_sensor";
+	tag_interior_door = "server_access_inner";
+	tag_interior_sensor = "server_access_in_sensor";
+	tag_secure = 1
+	},
+/obj/machinery/airlock_sensor{
+	frequency = 1381;
+	id_tag = "server_access_sensor";
+	pixel_x = 12;
+	pixel_y = 25
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 1
+	},
+/obj/effect/map_helper/airlock/sensor/chamber_sensor,
+/turf/simulated/floor/tiled/techfloor,
+/area/tcommsat/chamber)
+"acE" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	frequency = 1381;
+	icon_state = "door_locked";
+	id_tag = "server_access_outer";
+	locked = 1;
+	name = "Telecoms Server Access";
+	req_access = list(61)
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/effect/map_helper/airlock/door/ext_door,
+/turf/simulated/floor/tiled/techfloor,
+/area/tcommsat/chamber)
+"acF" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 10;
+	icon_state = "intact"
+	},
+/obj/machinery/access_button{
+	command = "cycle_exterior";
+	frequency = 1381;
+	master_tag = "ai_sat_airlock_inner";
+	name = "exterior access button";
+	pixel_x = -26;
+	pixel_y = -26;
+	req_one_access = list(61)
+	},
+/turf/simulated/floor/tiled,
+/area/tcommsat/computer)
+"acG" = (
+/obj/item/device/multitool,
+/obj/structure/table/standard,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled,
+/area/tcommsat/computer)
 "acH" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 5
@@ -1363,6 +1475,21 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/exploration/hallway)
+"acI" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/machinery/atmospherics/portables_connector{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/canister/air/airlock{
+	start_pressure = 4559.63
+	},
+/turf/simulated/floor/tiled/dark,
+/area/tcommsat/entrance{
+	name = "\improper Telecomms Entrance"
+	})
 "acJ" = (
 /turf/simulated/floor,
 /area/engineering/engine_room)
@@ -1434,9 +1561,48 @@
 /obj/machinery/camera/network/engineering,
 /turf/simulated/floor,
 /area/maintenance/substation/engineering)
+"acP" = (
+/obj/structure/cable/yellow{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/solar_control{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/tcommsat/entrance{
+	name = "\improper Telecomms Entrance"
+	})
+"acQ" = (
+/obj/structure/cable/yellow{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/airless,
+/area/tether/outpost/solars_outside{
+	name = "\improper Telecomms Solar Field"
+	})
+"acR" = (
+/obj/item/stack/cable_coil/yellow{
+	amount = 4
+	},
+/turf/simulated/floor/airless,
+/area/tether/outpost/solars_outside{
+	name = "\improper Telecomms Solar Field"
+	})
 "acS" = (
 /turf/simulated/wall/r_wall,
 /area/engineering/workshop)
+"acT" = (
+/obj/machinery/camera/network/telecom,
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/airless,
+/area/tether/outpost/solars_outside{
+	name = "\improper Telecomms Solar Field"
+	})
 "acU" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -1452,6 +1618,25 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/exploration/hallway)
+"acV" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/machinery/camera/network/telecom{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/tcommsat/chamber)
+"acW" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	frequency = 1379;
+	id_tag = "gravity_pump"
+	},
+/obj/machinery/camera/network/engineering{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/engineering/gravity_lobby)
 "acX" = (
 /obj/structure/table/reinforced,
 /obj/effect/floor_decal/borderfloor{
@@ -1465,12 +1650,55 @@
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/engine_monitoring)
+"acY" = (
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 9
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 10
+	},
+/obj/machinery/camera/network/engineering{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/hallway)
+"acZ" = (
+/obj/machinery/atmospherics/binary/passive_gate/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/engine_airlock)
 "ada" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/gravity_lobby)
+"adb" = (
+/obj/machinery/camera/network/engineering,
+/obj/structure/table/rack/steel,
+/obj/item/weapon/stock_parts/matter_bin,
+/obj/item/weapon/stock_parts/matter_bin,
+/obj/item/weapon/stock_parts/matter_bin,
+/obj/item/weapon/stock_parts/manipulator,
+/obj/item/weapon/stock_parts/console_screen,
+/obj/item/weapon/circuitboard/autolathe,
+/turf/simulated/floor/plating,
+/area/storage/tech)
 "adc" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 9
@@ -1487,6 +1715,19 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/exploration/pilot_office)
+"add" = (
+/obj/item/weapon/stock_parts/manipulator,
+/obj/item/weapon/stock_parts/matter_bin,
+/obj/item/weapon/stock_parts/matter_bin,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/item/weapon/stock_parts/manipulator,
+/obj/structure/table/rack/steel,
+/obj/item/weapon/stock_parts/console_screen,
+/obj/item/weapon/circuitboard/partslathe,
+/turf/simulated/floor/plating,
+/area/storage/tech)
 "ade" = (
 /obj/machinery/atmospherics/portables_connector,
 /turf/simulated/floor/tiled,
@@ -1510,6 +1751,20 @@
 	},
 /turf/simulated/floor,
 /area/engineering/engine_monitoring)
+"adg" = (
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "englockdown";
+	name = "Engineering Lockdown";
+	opacity = 0
+	},
+/obj/machinery/door/airlock/maintenance/engi{
+	name = "Secure Storage Access"
+	},
+/turf/simulated/floor,
+/area/maintenance/station/eng_lower)
 "adh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -1561,6 +1816,62 @@
 	},
 /turf/simulated/floor,
 /area/storage/emergency_storage/emergency4)
+"adk" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "englockdown";
+	name = "Engineering Lockdown";
+	opacity = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/door/airlock/maintenance/engi{
+	name = "Engineering Maintenance Access"
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/engineering/hallway)
+"adl" = (
+/obj/machinery/atmospherics/binary/passive_gate/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/gravity_lobby)
+"adm" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/hallway)
 "adn" = (
 /obj/structure/table/rack{
 	dir = 8;
@@ -1625,6 +1936,37 @@
 	},
 /turf/simulated/floor,
 /area/storage/emergency_storage/emergency4)
+"adr" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	layer = 3.3;
+	pixel_y = 26
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/hallway)
 "ads" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -1704,6 +2046,52 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/tether/exploration)
+"adx" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/glass/hidden/steel{
+	dir = 2
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/hallway)
+"ady" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/machinery/atmospherics/binary/passive_gate/on{
+	dir = 2
+	},
+/turf/simulated/floor,
+/area/maintenance/cargo)
+"adz" = (
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 9;
+	icon_state = "intact"
+	},
+/turf/simulated/floor,
+/area/maintenance/cargo)
 "adA" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -1763,6 +2151,10 @@
 	},
 /turf/simulated/floor,
 /area/maintenance/substation/engineering)
+"adE" = (
+/obj/structure/reagent_dispensers/fueltank,
+/turf/simulated/floor,
+/area/maintenance/cargo)
 "adF" = (
 /obj/machinery/power/terminal{
 	dir = 1
@@ -2495,30 +2887,6 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor,
 /area/engineering/storage)
-"aft" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/yellow/border{
-	dir = 1
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7,
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/engineering/hallway)
 "afu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
 	dir = 4
@@ -3325,29 +3693,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/station/docks)
-"ahc" = (
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 9
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/yellow/border{
-	dir = 4
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 10
-	},
-/turf/simulated/floor/tiled,
-/area/engineering/hallway)
 "ahd" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -4292,17 +4637,6 @@
 	temperature = 80
 	},
 /area/tcommsat/chamber)
-"ajV" = (
-/obj/machinery/camera/network/engineering,
-/obj/structure/table/rack/steel,
-/obj/item/weapon/stock_parts/matter_bin,
-/obj/item/weapon/stock_parts/matter_bin,
-/obj/item/weapon/stock_parts/matter_bin,
-/obj/item/weapon/stock_parts/manipulator,
-/obj/item/weapon/stock_parts/console_screen,
-/obj/item/weapon/circuitboard/partslathe,
-/turf/simulated/floor/plating,
-/area/storage/tech)
 "ajX" = (
 /obj/machinery/telecomms/server/presets/engineering,
 /turf/simulated/floor/tiled/dark{
@@ -4314,19 +4648,6 @@
 "ajY" = (
 /turf/simulated/wall,
 /area/tether/exploration/equipment)
-"ajZ" = (
-/obj/item/weapon/stock_parts/manipulator,
-/obj/item/weapon/stock_parts/matter_bin,
-/obj/item/weapon/stock_parts/matter_bin,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/item/weapon/stock_parts/manipulator,
-/obj/structure/table/rack/steel,
-/obj/item/weapon/stock_parts/console_screen,
-/obj/item/weapon/circuitboard/autolathe,
-/turf/simulated/floor/plating,
-/area/storage/tech)
 "aka" = (
 /obj/structure/table/steel,
 /turf/simulated/floor,
@@ -4648,12 +4969,6 @@
 /obj/item/weapon/stool,
 /turf/simulated/floor,
 /area/storage/tech)
-"alb" = (
-/obj/machinery/atmospherics/binary/passive_gate{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/engineering/engine_airlock)
 "alc" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -4968,29 +5283,6 @@
 	},
 /obj/machinery/camera/network/engineering{
 	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/engineering/hallway)
-"alM" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/yellow/border{
-	dir = 1
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor/glass/hidden/steel{
-	dir = 2
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/hallway)
@@ -5703,29 +5995,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor,
 /area/maintenance/station/eng_lower)
-"anF" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/glass,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	icon_state = "pdoor0";
-	id = "englockdown";
-	name = "Engineering Lockdown";
-	opacity = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/door/airlock/maintenance/engi{
-	name = "Engineering Substation"
-	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/engineering/hallway)
 "anH" = (
 /turf/simulated/floor/greengrid/nitrogen,
 /area/engineering/engine_room)
@@ -6457,34 +6726,6 @@
 	dir = 9
 	},
 /obj/machinery/camera/network/engineering,
-/turf/simulated/floor/tiled,
-/area/engineering/hallway)
-"apx" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/yellow/border{
-	dir = 1
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7,
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 4
-	},
-/obj/machinery/firealarm{
-	layer = 3.3;
-	pixel_y = 26
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/tiled,
 /area/engineering/hallway)
 "apy" = (
@@ -13877,37 +14118,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/heads/chief)
-"bhH" = (
-/obj/machinery/embedded_controller/radio/airlock/advanced_airlock_controller{
-	frequency = 1381;
-	id_tag = "server_access_airlock";
-	name = "Server Access Airlock";
-	pixel_y = 25;
-	tag_airpump = "server_access_pump";
-	tag_chamber_sensor = "server_access_sensor";
-	tag_exterior_door = "server_access_outer";
-	tag_exterior_sensor = "server_access_ex_sensor";
-	tag_interior_door = "server_access_inner";
-	tag_interior_sensor = "server_access_in_sensor";
-	tag_secure = 1
-	},
-/obj/machinery/airlock_sensor{
-	frequency = 1381;
-	id_tag = "server_access_sensor";
-	pixel_x = 12;
-	pixel_y = 25
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/tcommsat/chamber)
-"bhJ" = (
-/obj/machinery/atmospherics/binary/passive_gate{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/engineering/gravity_lobby)
 "bhK" = (
 /obj/machinery/button/remote/blast_door{
 	dir = 4;
@@ -14092,20 +14302,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/gateway/prep_room)
-"bpd" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	frequency = 1381;
-	icon_state = "door_locked";
-	id_tag = "server_access_outer";
-	locked = 1;
-	name = "Telecoms Server Access";
-	req_access = list(61)
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/tcommsat/chamber)
 "bpi" = (
 /obj/machinery/camera/network/command,
 /turf/simulated/floor/tiled,
@@ -14369,13 +14565,6 @@
 /area/tether/station/dock_one)
 "byy" = (
 /turf/simulated/wall/r_wall,
-/area/engineering/gravity_lobby)
-"byA" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	frequency = 1379;
-	id_tag = "gravity_pump"
-	},
-/turf/simulated/floor/tiled/techmaint,
 /area/engineering/gravity_lobby)
 "bzn" = (
 /obj/structure/cable/green{
@@ -14704,18 +14893,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
-"bLM" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 10;
-	icon_state = "intact"
-	},
-/turf/simulated/floor/tiled,
-/area/tcommsat/computer)
 "bLO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -14875,36 +15052,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/tether/exploration)
-"bPV" = (
-/obj/item/device/multitool,
-/obj/structure/table/standard,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/turretid/lethal{
-	ailock = 1;
-	check_synth = 1;
-	control_area = /area/tcommsat/chamber;
-	desc = "A firewall prevents AIs from interacting with this device.";
-	name = "Telecoms lethal turret control";
-	pixel_x = 29;
-	req_access = list(61);
-	req_one_access = list(12)
-	},
-/turf/simulated/floor/tiled,
-/area/tcommsat/computer)
-"bPX" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/black{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/dark{
-	nitrogen = 100;
-	oxygen = 0;
-	temperature = 80
-	},
-/area/tcommsat/chamber)
 "bQj" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 1
@@ -15073,17 +15220,6 @@
 /obj/machinery/door/airlock/maintenance/common,
 /turf/simulated/floor,
 /area/maintenance/station/exploration)
-"bXn" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	frequency = 1381;
-	icon_state = "door_locked";
-	id_tag = "server_access_inner";
-	locked = 1;
-	name = "Telecoms Server Access";
-	req_access = list(61)
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/tcommsat/chamber)
 "bXv" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -15819,14 +15955,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/station/cargo)
-"cyf" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 4;
-	frequency = 1381;
-	id_tag = "server_access_pump"
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/tcommsat/chamber)
 "cys" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/power/apc{
@@ -17672,20 +17800,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/tether/exploration)
-"eoh" = (
-/obj/machinery/door/firedoor/glass,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	icon_state = "pdoor0";
-	id = "englockdown";
-	name = "Engineering Lockdown";
-	opacity = 0
-	},
-/obj/machinery/door/airlock/maintenance/common{
-	name = "Secure Storage Access"
-	},
-/turf/simulated/floor,
-/area/maintenance/station/eng_lower)
 "eom" = (
 /obj/machinery/suit_cycler/security{
 	req_access = null
@@ -18385,12 +18499,6 @@
 	},
 /turf/simulated/floor,
 /area/maintenance/substation/exploration)
-"fck" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/tcommsat/chamber)
 "fdw" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -20802,18 +20910,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/engineering/hallway)
-"hAw" = (
-/obj/structure/cable/yellow{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/power/solar_control{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
-/area/tcommsat/entrance{
-	name = "\improper Telecomms Entrance"
-	})
 "hBS" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -24786,13 +24882,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/hallway)
-"lqr" = (
-/obj/machinery/atmospherics/binary/passive_gate,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/simulated/floor,
-/area/maintenance/cargo)
 "lsa" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -26718,18 +26807,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor,
 /area/maintenance/cargo)
-"nab" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/tank/air/full{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/tcommsat/entrance{
-	name = "\improper Telecomms Entrance"
-	})
 "nac" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/steeldecal/steel_decals7{
@@ -27440,14 +27517,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/belterdock/gear)
-"nJb" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/turf/simulated/floor,
-/area/maintenance/cargo)
 "nJw" = (
 /obj/effect/floor_decal/industrial/warning/corner,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -27496,12 +27565,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/engineering_airlock)
-"nNV" = (
-/obj/machinery/atmospherics/pipe/tank/air/full{
-	dir = 8
-	},
-/turf/simulated/floor,
-/area/maintenance/cargo)
 "nOg" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/asteroid_steel/airless,
@@ -41669,7 +41732,7 @@ aac
 aac
 aac
 acz
-aft
+adm
 afu
 acS
 aru
@@ -41811,7 +41874,7 @@ aac
 aac
 aac
 acz
-apx
+adr
 afB
 aqN
 art
@@ -41953,7 +42016,7 @@ isj
 isj
 isj
 aoy
-alM
+adx
 amf
 aqN
 arx
@@ -42636,7 +42699,7 @@ aqV
 aqV
 aqV
 bkU
-brX
+bvs
 ank
 aac
 aam
@@ -42655,7 +42718,7 @@ aiP
 ajy
 afS
 akO
-alb
+acZ
 aml
 aiM
 aac
@@ -43064,7 +43127,7 @@ bdi
 ahf
 btt
 ank
-byA
+acW
 bAM
 bHt
 bJl
@@ -43238,7 +43301,7 @@ atF
 avx
 awO
 ayb
-ahc
+acY
 aBA
 aCV
 aEA
@@ -43401,7 +43464,7 @@ bdF
 tUh
 axz
 kLN
-lqr
+ady
 mqL
 mPj
 mPj
@@ -43493,7 +43556,7 @@ ank
 byy
 byy
 byy
-bhJ
+adl
 adH
 acz
 iuB
@@ -43546,7 +43609,7 @@ pGr
 pGr
 eTo
 ohn
-nJb
+adz
 tal
 gnV
 xpA
@@ -43688,7 +43751,7 @@ hqA
 qiw
 aHq
 rVd
-nNV
+adE
 tal
 gLW
 qQx
@@ -44350,7 +44413,7 @@ mdh
 aiw
 asT
 dPS
-eoh
+adg
 vrR
 adG
 lEB
@@ -44507,7 +44570,7 @@ amR
 ang
 aik
 acz
-anF
+adk
 aij
 aij
 aij
@@ -44623,7 +44686,7 @@ acc
 adn
 adR
 aaN
-ajV
+adb
 akY
 amK
 anb
@@ -44765,7 +44828,7 @@ aaN
 aaN
 aaN
 aaN
-ajZ
+add
 ala
 amK
 amK
@@ -50170,10 +50233,10 @@ xTB
 aie
 avO
 bYg
-bPX
-bXn
-cyf
-fck
+acu
+acA
+acC
+acV
 otm
 pMe
 nAA
@@ -50314,7 +50377,7 @@ rLI
 thI
 rLO
 xTB
-bhH
+acD
 huZ
 otm
 cik
@@ -50456,7 +50519,7 @@ avZ
 thI
 rLO
 xTB
-bpd
+acE
 xTB
 otm
 vow
@@ -50598,7 +50661,7 @@ apU
 thI
 rLO
 xSF
-bLM
+acF
 dJJ
 xEG
 awQ
@@ -50612,7 +50675,7 @@ dkG
 cEE
 kcM
 exs
-nab
+acI
 kff
 kff
 kff
@@ -51180,7 +51243,7 @@ dls
 dTU
 nwy
 dyt
-hAw
+acP
 kff
 kff
 kff
@@ -51592,7 +51655,7 @@ axf
 uyX
 bTu
 xSF
-bPV
+acG
 pyE
 ged
 ayg
@@ -51608,7 +51671,7 @@ dLP
 gDA
 dTU
 gfX
-fpk
+acQ
 aaa
 aaa
 aaa
@@ -51750,7 +51813,7 @@ dTU
 dTU
 dTU
 gfX
-fpk
+acR
 aaa
 aaa
 aaa
@@ -51892,7 +51955,7 @@ gfX
 gfX
 gfX
 gfX
-rhn
+acT
 aaa
 aaa
 aaa

--- a/maps/tether/tether-05-station1.dmm
+++ b/maps/tether/tether-05-station1.dmm
@@ -928,22 +928,27 @@
 /turf/simulated/floor/tiled,
 /area/hallway/station/atrium)
 "abM" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/power/apc{
-	name = "south bump";
-	pixel_y = -32
+/obj/machinery/airlock_sensor{
+	command = "cycle_interior";
+	id_tag = "gravity_isensor";
+	master_tag = "gravity_airlock";
+	pixel_y = 28;
+	req_access = list(11)
 	},
 /obj/structure/cable/green{
-	d2 = 4;
 	icon_state = "0-4"
 	},
-/turf/simulated/floor/tiled/techmaint,
-/area/engineering/engine_smes)
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "west bump";
+	nightshift_setting = 2;
+	pixel_x = -28
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/gravity_lobby)
 "abN" = (
 /obj/machinery/alarm{
 	dir = 1;
@@ -2623,6 +2628,32 @@
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/engine_monitoring)
+"aeu" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 4
+	},
+/obj/machinery/porta_turret{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/dark{
+	nitrogen = 100;
+	oxygen = 0;
+	temperature = 80
+	},
+/area/tcommsat/chamber)
+"aev" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 9
+	},
+/obj/machinery/porta_turret{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/dark{
+	nitrogen = 100;
+	oxygen = 0;
+	temperature = 80
+	},
+/area/tcommsat/chamber)
 "aew" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
@@ -2648,6 +2679,28 @@
 	},
 /turf/simulated/floor,
 /area/engineering/engine_monitoring)
+"aex" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/tcomsat{
+	name = "\improper Telecomms Lobby"
+	})
+"aey" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/machinery/porta_turret{
+	dir = 6
+	},
+/turf/simulated/floor/tiled,
+/area/tcomsat{
+	name = "\improper Telecomms Lobby"
+	})
 "aez" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -2734,6 +2787,83 @@
 /obj/structure/catwalk,
 /turf/simulated/floor,
 /area/maintenance/station/eng_lower)
+"aeF" = (
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	nightshift_setting = 2;
+	pixel_x = 28
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/machinery/porta_turret{
+	dir = 6
+	},
+/turf/simulated/floor/tiled,
+/area/tcomsat{
+	name = "\improper Telecomms Lobby"
+	})
+"aeG" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/tcomsat{
+	name = "\improper Telecomms Lobby"
+	})
+"aeH" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/light/small,
+/turf/simulated/floor/tiled,
+/area/tcomsat{
+	name = "\improper Telecomms Lobby"
+	})
+"aeI" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/wall/r_wall,
+/area/tcomsat{
+	name = "\improper Telecomms Lobby"
+	})
+"aeJ" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/highsecurity{
+	name = "Telecomms Access";
+	req_one_access = list(10,12,16,17,61)
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/tiled/techfloor,
+/area/tcomsat{
+	name = "\improper Telecomms Lobby"
+	})
 "aeK" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -2798,6 +2928,16 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor,
 /area/storage/tech)
+"aeN" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/wall/r_wall,
+/area/tcomsat{
+	name = "\improper Telecomms Lobby"
+	})
 "aeO" = (
 /turf/simulated/shuttle/wall/voidcraft/green{
 	hard_corner = 1
@@ -2821,6 +2961,31 @@
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/engine_monitoring)
+"aeR" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/camera/network/telecom,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/tcommsat/entrance{
+	name = "\improper Telecomms Entrance"
+	})
 "aeS" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -2846,6 +3011,23 @@
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/engine_monitoring)
+"aeT" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
+/turf/simulated/floor/tiled/dark,
+/area/tcommsat/entrance{
+	name = "\improper Telecomms Entrance"
+	})
 "aeU" = (
 /obj/machinery/door/firedoor/glass/hidden/steel,
 /turf/simulated/floor/tiled,
@@ -2866,6 +3048,37 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/storage)
+"aeY" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/turretid/stun{
+	ailock = 1;
+	check_synth = 1;
+	control_area = /area/tcomsat;
+	desc = "A firewall prevents AIs from interacting with this device.";
+	name = "Telecoms Foyer turret control";
+	pixel_y = 29;
+	req_access = list();
+	req_one_access = list(10,12,16,17,61)
+	},
+/turf/simulated/floor/tiled/dark,
+/area/tcommsat/entrance{
+	name = "\improper Telecomms Entrance"
+	})
 "aeZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -2887,6 +3100,53 @@
 	},
 /turf/simulated/floor,
 /area/maintenance/station/eng_lower)
+"afa" = (
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/tcommsat/entrance{
+	name = "\improper Telecomms Entrance"
+	})
+"afb" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/dark,
+/area/tcommsat/entrance{
+	name = "\improper Telecomms Entrance"
+	})
+"afc" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/tcommsat/entrance{
+	name = "\improper Telecomms Entrance"
+	})
+"afd" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 6
+	},
+/obj/machinery/power/apc{
+	cell_type = /obj/item/weapon/cell/super;
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/obj/structure/cable/green{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/tcommsat/entrance{
+	name = "\improper Telecomms Entrance"
+	})
 "afe" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden,
 /turf/simulated/floor/tiled,
@@ -2902,6 +3162,37 @@
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/engine_monitoring)
+"afg" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/dark,
+/area/tcommsat/entrance{
+	name = "\improper Telecomms Entrance"
+	})
+"afh" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/tcomsat{
+	name = "\improper Telecomms Lobby"
+	})
 "afi" = (
 /obj/machinery/camera/network/engine{
 	dir = 1
@@ -2931,23 +3222,40 @@
 /turf/simulated/floor/tiled,
 /area/engineering/engine_monitoring)
 "afk" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /obj/machinery/power/apc{
 	name = "south bump";
+	nightshift_setting = 2;
 	pixel_y = -32
 	},
-/obj/structure/cable/green,
-/obj/structure/table/reinforced,
-/obj/machinery/microwave,
-/obj/effect/floor_decal/borderfloor{
-	dir = 6
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
 	},
-/obj/effect/floor_decal/corner/yellow/border{
-	dir = 6
+/turf/simulated/floor/tiled/techmaint,
+/area/engineering/engine_smes)
+"afl" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/effect/floor_decal/borderfloor/corner2,
-/obj/effect/floor_decal/corner/yellow/bordercorner2,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -25
+	},
 /turf/simulated/floor/tiled,
-/area/engineering/engine_monitoring)
+/area/tcomsat{
+	name = "\improper Telecomms Lobby"
+	})
 "afm" = (
 /obj/structure/closet,
 /obj/random/maintenance/clean,
@@ -3027,6 +3335,21 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor,
 /area/engineering/storage)
+"aft" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	layer = 3.3;
+	pixel_x = 26
+	},
+/obj/structure/cable/green,
+/obj/machinery/power/apc{
+	name = "south bump";
+	pixel_y = -28
+	},
+/turf/simulated/floor/tiled/dark,
+/area/tcomsat{
+	name = "\improper Telecomms Lobby"
+	})
 "afu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
 	dir = 4
@@ -3046,6 +3369,33 @@
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/hallway)
+"afv" = (
+/obj/machinery/atmospherics/binary/passive_gate/on{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/tcommsat/entrance{
+	name = "\improper Telecomms Entrance"
+	})
+"afw" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/structure/closet/crate/solar,
+/turf/simulated/floor/tiled/dark,
+/area/tcommsat/entrance{
+	name = "\improper Telecomms Entrance"
+	})
+"afx" = (
+/obj/structure/grille,
+/turf/space,
+/area/space)
 "afy" = (
 /turf/simulated/floor/holofloor/tiled/dark,
 /area/tether/elevator)
@@ -3140,6 +3490,46 @@
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/hallway)
+"afH" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 9
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 10
+	},
+/obj/machinery/computer/guestpass{
+	dir = 8;
+	pixel_x = 25
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/atrium)
+"afI" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 10
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 9
+	},
+/obj/machinery/computer/id_restorer{
+	dir = 8;
+	pixel_x = 32
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/atrium)
 "afJ" = (
 /obj/machinery/vending/snack,
 /obj/machinery/light{
@@ -3317,6 +3707,23 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/station/docks)
+"afX" = (
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "west bump";
+	nightshift_setting = 2;
+	pixel_x = -28
+	},
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/table/reinforced,
+/obj/item/weapon/tool/crowbar,
+/obj/item/clothing/gloves/black,
+/obj/item/weapon/storage/box/lights/mixed,
+/turf/simulated/floor/tiled,
+/area/engineering/workshop)
 "afY" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/structure/disposalpipe/segment{
@@ -3341,6 +3748,30 @@
 	},
 /turf/simulated/floor,
 /area/maintenance/station/eng_lower)
+"aga" = (
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	nightshift_setting = 2;
+	pixel_y = 24
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/structure/table/reinforced,
+/obj/item/weapon/storage/briefcase/inflatable{
+	pixel_x = 3;
+	pixel_y = 6
+	},
+/obj/item/weapon/storage/briefcase/inflatable{
+	pixel_y = 3
+	},
+/obj/item/weapon/storage/briefcase/inflatable{
+	pixel_x = -3
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/engine_eva)
 "agb" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -3455,6 +3886,80 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/station/atrium)
+"agk" = (
+/obj/structure/cable/green{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	nightshift_setting = 2;
+	pixel_x = 28
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green,
+/turf/simulated/floor/tiled/monotile,
+/area/tether/exploration)
+"agl" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/canister/air/airlock,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 4
+	},
+/obj/machinery/power/apc{
+	name = "south bump";
+	nightshift_setting = 2;
+	pixel_y = -32
+	},
+/obj/structure/cable/green,
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 25
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/engineering_airlock)
+"agm" = (
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "west bump";
+	nightshift_setting = 2;
+	pixel_x = -28
+	},
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/computer/security/engineering{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/engineering_monitoring)
+"agn" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/effect/floor_decal/industrial/warning/corner,
+/obj/machinery/power/apc{
+	alarms_hidden = 1;
+	name = "south bump";
+	nightshift_setting = 2;
+	pixel_y = -28;
+	req_access = list();
+	req_one_access = list(11,67)
+	},
+/obj/structure/cable/green,
+/turf/simulated/floor/tiled,
+/area/crew_quarters/heads/chief)
 "ago" = (
 /obj/structure/disposalpipe/junction{
 	dir = 8
@@ -3470,12 +3975,107 @@
 /obj/effect/floor_decal/steeldecal/steel_decals4,
 /turf/simulated/floor/tiled,
 /area/hallway/station/docks)
+"agp" = (
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	nightshift_setting = 2;
+	pixel_x = 28
+	},
+/obj/structure/cable/green,
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -22
+	},
+/obj/structure/closet/radiation,
+/obj/item/clothing/glasses/meson,
+/obj/item/clothing/glasses/meson,
+/turf/simulated/floor/tiled,
+/area/engineering/engine_airlock)
+"agq" = (
+/obj/machinery/atmospherics/pipe/simple/visible/red{
+	dir = 4
+	},
+/obj/machinery/power/apc{
+	name = "south bump";
+	nightshift_setting = 2;
+	pixel_y = -32
+	},
+/obj/structure/cable/green,
+/turf/simulated/floor/tiled,
+/area/engineering/atmos/backup)
+"agr" = (
+/obj/machinery/power/apc{
+	name = "south bump";
+	nightshift_setting = 2;
+	pixel_y = -32
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor,
+/area/engineering/storage)
+"ags" = (
+/obj/machinery/power/apc{
+	name = "south bump";
+	nightshift_setting = 2;
+	pixel_y = -32
+	},
+/obj/structure/cable/green,
+/obj/structure/table/reinforced,
+/obj/machinery/microwave,
+/obj/effect/floor_decal/borderfloor{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 6
+	},
+/obj/effect/floor_decal/borderfloor/corner2,
+/obj/effect/floor_decal/corner/yellow/bordercorner2,
+/turf/simulated/floor/tiled,
+/area/engineering/engine_monitoring)
+"agt" = (
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	nightshift_setting = 2;
+	pixel_x = 28
+	},
+/turf/simulated/floor/tiled/white,
+/area/tether/exploration/equipment)
 "agu" = (
 /obj/structure/sign/deck1,
 /turf/simulated/shuttle/wall/voidcraft/green{
 	hard_corner = 1
 	},
 /area/tether/elevator)
+"agv" = (
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "west bump";
+	nightshift_setting = 2;
+	pixel_x = -28
+	},
+/obj/structure/cable/green{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor,
+/area/storage/tech)
 "agw" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -3520,6 +4120,78 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
+"agy" = (
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	nightshift_setting = 2;
+	pixel_x = 28
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/vending/cigarette{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/white/diagonal,
+/turf/simulated/floor/tiled,
+/area/engineering/break_room)
+"agz" = (
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 9
+	},
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	nightshift_setting = 2;
+	pixel_x = 28
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 10
+	},
+/obj/structure/cable/green,
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/hallway)
+"agA" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/machinery/camera/network/tether{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 9
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 10
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	nightshift_setting = 2;
+	pixel_x = 28
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/tiled,
+/area/tether/station/dock_one)
 "agB" = (
 /obj/structure/grille,
 /obj/structure/lattice,
@@ -3535,6 +4207,20 @@
 /area/tether/outpost/solars_outside{
 	name = "\improper Telecomms Solar Field"
 	})
+"agD" = (
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	nightshift_setting = 2;
+	pixel_x = 28
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/table/woodentable,
+/turf/simulated/floor/carpet,
+/area/engineering/foyer)
 "agE" = (
 /obj/structure/table/standard,
 /obj/item/weapon/clipboard,
@@ -3562,6 +4248,20 @@
 	},
 /turf/simulated/floor/plating,
 /area/engineering/engine_airlock)
+"agG" = (
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	nightshift_setting = 2;
+	pixel_x = 28
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals6,
+/turf/simulated/floor/tiled,
+/area/tether/station/dock_two)
 "agH" = (
 /obj/structure/table/reinforced,
 /obj/effect/floor_decal/corner/white/diagonal,
@@ -3833,6 +4533,67 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/station/docks)
+"ahc" = (
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	nightshift_setting = 2;
+	pixel_x = 28
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/outdoors/grass/forest,
+/area/quartermaster/qm)
+"ahd" = (
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	nightshift_setting = 2;
+	pixel_x = 28
+	},
+/obj/structure/table/standard,
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/brown/bordercorner2{
+	dir = 5
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/office)
+"ahe" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	nightshift_setting = 2;
+	pixel_x = 28
+	},
+/obj/random/junk,
+/turf/simulated/floor,
+/area/maintenance/cargo)
 "ahf" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -3856,6 +4617,18 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
+"ahh" = (
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	nightshift_setting = 2;
+	pixel_x = 28
+	},
+/obj/structure/cable/green{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/warehouse)
 "ahi" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -3883,6 +4656,36 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/shuttle/excursion/general)
+"ahl" = (
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 8
+	},
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	nightshift_setting = 2;
+	pixel_x = 28
+	},
+/obj/structure/cable/green,
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor,
+/area/maintenance/substation/cargo)
+"ahm" = (
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	nightshift_setting = 2;
+	pixel_x = 28
+	},
+/obj/structure/cable/green,
+/obj/structure/catwalk,
+/obj/random/junk,
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor,
+/area/maintenance/station/cargo)
 "ahn" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -3934,6 +4737,32 @@
 	},
 /turf/simulated/floor/plating,
 /area/engineering/engine_airlock)
+"aht" = (
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	nightshift_setting = 2;
+	pixel_x = 28
+	},
+/obj/structure/ore_box,
+/obj/effect/floor_decal/borderfloor{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 5
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/brown/bordercorner2{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/belterdock)
 "ahy" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
@@ -4312,22 +5141,6 @@
 	id_tag = "engine_airlock_pump"
 	},
 /turf/simulated/floor/plating,
-/area/engineering/engine_airlock)
-"aiF" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 28
-	},
-/obj/structure/cable/green,
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -22
-	},
-/obj/structure/closet/radiation,
-/obj/item/clothing/glasses/meson,
-/obj/item/clothing/glasses/meson,
-/turf/simulated/floor/tiled,
 /area/engineering/engine_airlock)
 "aiG" = (
 /obj/structure/table/rack/steel,
@@ -4841,17 +5654,6 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor,
 /area/engineering/storage)
-"akk" = (
-/obj/machinery/power/apc{
-	name = "south bump";
-	pixel_y = -32
-	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor,
-/area/engineering/storage)
 "akl" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -5151,17 +5953,6 @@
 "alm" = (
 /turf/simulated/floor/tiled,
 /area/engineering/gravity_lobby)
-"aln" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -28
-	},
-/obj/structure/cable/green{
-	icon_state = "0-4"
-	},
-/turf/simulated/floor,
-/area/storage/tech)
 "alp" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 8
@@ -7135,17 +7926,6 @@
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/floor,
 /area/engineering/atmos/backup)
-"aqj" = (
-/obj/machinery/atmospherics/pipe/simple/visible/red{
-	dir = 4
-	},
-/obj/machinery/power/apc{
-	name = "south bump";
-	pixel_y = -32
-	},
-/obj/structure/cable/green,
-/turf/simulated/floor/tiled,
-/area/engineering/atmos/backup)
 "aql" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
 	dir = 4
@@ -7902,22 +8682,6 @@
 /obj/structure/table/woodentable,
 /turf/simulated/floor/carpet,
 /area/engineering/break_room)
-"ass" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 28
-	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/vending/cigarette{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/white/diagonal,
-/turf/simulated/floor/tiled,
-/area/engineering/break_room)
 "asv" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -8640,22 +9404,6 @@
 /area/tether/outpost/solars_outside{
 	name = "\improper Telecomms Solar Field"
 	})
-"avd" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -28
-	},
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/structure/table/reinforced,
-/obj/item/weapon/tool/crowbar,
-/obj/item/clothing/gloves/black,
-/obj/item/weapon/storage/box/lights/mixed,
-/turf/simulated/floor/tiled,
-/area/engineering/workshop)
 "avf" = (
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/airless,
@@ -8981,21 +9729,6 @@
 /obj/machinery/light,
 /obj/structure/dogbed,
 /mob/living/simple_mob/animal/sif/fluffy/silky,
-/turf/simulated/floor/outdoors/grass/forest,
-/area/quartermaster/qm)
-"awh" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 28
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
 /turf/simulated/floor/outdoors/grass/forest,
 /area/quartermaster/qm)
 "awj" = (
@@ -9741,19 +10474,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/storage)
-"ayI" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/tcomsat{
-	name = "\improper Telecomms Lobby"
-	})
 "ayK" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -9796,24 +10516,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/storage)
-"ayT" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 28
-	},
-/obj/random/junk,
-/turf/simulated/floor,
-/area/maintenance/cargo)
 "ayY" = (
 /obj/structure/grille,
 /obj/machinery/door/firedoor/glass,
@@ -9943,22 +10645,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/engineering_airlock)
-"azu" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/tcomsat{
-	name = "\improper Telecomms Lobby"
-	})
 "azv" = (
 /obj/machinery/door/airlock/multi_tile/metal/mait,
 /obj/machinery/door/firedoor/glass,
@@ -10426,19 +11112,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
-"aBk" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/tcomsat{
-	name = "\improper Telecomms Lobby"
-	})
 "aBl" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -10468,29 +11141,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
-"aBp" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_y = 24
-	},
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/structure/table/reinforced,
-/obj/item/weapon/storage/briefcase/inflatable{
-	pixel_x = 3;
-	pixel_y = 6
-	},
-/obj/item/weapon/storage/briefcase/inflatable{
-	pixel_y = 3
-	},
-/obj/item/weapon/storage/briefcase/inflatable{
-	pixel_x = -3
-	},
-/turf/simulated/floor/tiled,
-/area/engineering/engine_eva)
 "aBq" = (
 /obj/machinery/camera/network/engineering{
 	dir = 8
@@ -10545,31 +11195,6 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/engineering/workshop)
-"aBA" = (
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 9
-	},
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 28
-	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/yellow/border{
-	dir = 4
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 10
-	},
-/obj/structure/cable/green,
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/tiled,
-/area/engineering/hallway)
 "aBB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 9
@@ -10704,17 +11329,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/engineering_airlock)
-"aBP" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 28
-	},
-/obj/structure/cable/green{
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/tiled,
-/area/quartermaster/warehouse)
 "aBQ" = (
 /obj/effect/floor_decal/techfloor/orange{
 	dir = 9
@@ -11418,15 +12032,6 @@
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/plating,
 /area/quartermaster/storage)
-"aEF" = (
-/obj/machinery/camera/network/telecom,
-/obj/machinery/atmospherics/binary/passive_gate/on{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
-/area/tcommsat/entrance{
-	name = "\improper Telecomms Entrance"
-	})
 "aEI" = (
 /obj/machinery/power/solar,
 /obj/structure/cable/yellow{
@@ -12620,26 +13225,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/engineering/workshop)
-"aNd" = (
-/obj/machinery/atmospherics/portables_connector{
-	dir = 1
-	},
-/obj/machinery/portable_atmospherics/canister/air/airlock,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 4
-	},
-/obj/machinery/power/apc{
-	name = "south bump";
-	pixel_y = -32
-	},
-/obj/structure/cable/green,
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 25
-	},
-/turf/simulated/floor/tiled,
-/area/engineering/engineering_airlock)
 "aNe" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 1
@@ -12880,24 +13465,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled,
-/area/engineering/engineering_monitoring)
-"aQs" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -28
-	},
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/machinery/computer/security/engineering{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/engineering_monitoring)
@@ -13367,22 +13934,6 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 6
 	},
-/turf/simulated/floor/tiled,
-/area/crew_quarters/heads/chief)
-"aVH" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/obj/effect/floor_decal/industrial/warning/corner,
-/obj/machinery/power/apc{
-	alarms_hidden = 1;
-	name = "south bump";
-	pixel_y = -28;
-	req_access = list();
-	req_one_access = list(11,67)
-	},
-/obj/structure/cable/green,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/heads/chief)
 "aVK" = (
@@ -14912,27 +15463,6 @@
 	temperature = 80
 	},
 /area/tcommsat/chamber)
-"bJl" = (
-/obj/machinery/airlock_sensor{
-	command = "cycle_interior";
-	id_tag = "gravity_isensor";
-	master_tag = "gravity_airlock";
-	pixel_y = 28;
-	req_access = list(11)
-	},
-/obj/structure/cable/green{
-	icon_state = "0-4"
-	},
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -28
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/engineering/gravity_lobby)
 "bJm" = (
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled,
@@ -15180,28 +15710,6 @@
 "bQF" = (
 /turf/simulated/floor,
 /area/maintenance/station/cargo)
-"bQG" = (
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 5
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 28
-	},
-/turf/simulated/floor/tiled/white,
-/area/tether/exploration/equipment)
 "bQS" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
@@ -15243,30 +15751,10 @@
 	temperature = 80
 	},
 /area/tcommsat/chamber)
-"bTu" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/black{
-	dir = 9
-	},
-/turf/simulated/floor/tiled/dark{
-	nitrogen = 100;
-	oxygen = 0;
-	temperature = 80
-	},
-/area/tcommsat/chamber)
 "bTZ" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/dark,
 /area/gateway/prep_room)
-"bUj" = (
-/obj/machinery/door/airlock/highsecurity{
-	name = "Messaging Server";
-	req_one_access = list(12,16,17,61)
-	},
-/obj/machinery/door/firedoor/glass,
-/turf/simulated/floor/tiled/dark,
-/area/tcommsat/entrance{
-	name = "\improper Telecomms Entrance"
-	})
 "bUz" = (
 /obj/machinery/camera/network/telecom{
 	dir = 1
@@ -15812,14 +16300,6 @@
 /obj/effect/floor_decal/corner/paleblue/border,
 /turf/simulated/floor/tiled,
 /area/tether/station/dock_two)
-"cjr" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/tcomsat{
-	name = "\improper Telecomms Lobby"
-	})
 "cjQ" = (
 /obj/effect/floor_decal/industrial/loading{
 	dir = 8
@@ -15983,19 +16463,6 @@
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor,
 /area/storage/tech)
-"cuN" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/tcomsat{
-	name = "\improper Telecomms Lobby"
-	})
 "cvx" = (
 /obj/machinery/shipsensors{
 	dir = 1
@@ -16912,32 +17379,6 @@
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/tiled/dark,
 /area/bridge/secondary/teleporter)
-"dkR" = (
-/obj/machinery/power/apc{
-	name = "south bump";
-	pixel_y = -28
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable/green,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/tcommsat/entrance{
-	name = "\improper Telecomms Entrance"
-	})
 "dkV" = (
 /obj/structure/bed/chair/shuttle{
 	dir = 4
@@ -18797,20 +19238,6 @@
 /obj/effect/floor_decal/corner/green/border,
 /turf/simulated/floor/tiled,
 /area/tether/exploration/pilot_office)
-"fqw" = (
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -25
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	layer = 3.3;
-	pixel_x = 26
-	},
-/turf/simulated/floor/tiled/dark,
-/area/tcomsat{
-	name = "\improper Telecomms Lobby"
-	})
 "fqP" = (
 /obj/machinery/power/apc{
 	dir = 8;
@@ -20310,22 +20737,6 @@
 /obj/structure/handrail,
 /turf/simulated/floor/plating,
 /area/shuttle/excursion/general)
-"hbc" = (
-/obj/structure/cable/green{
-	icon_state = "0-2"
-	},
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 28
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/green,
-/turf/simulated/floor/tiled/monotile,
-/area/tether/exploration)
 "hbv" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -20401,23 +20812,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/belterdock/gear)
-"heQ" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 28
-	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/tcomsat{
-	name = "\improper Telecomms Lobby"
-	})
 "hfo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 5
@@ -20660,28 +21054,6 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/tcomfoyer{
 	name = "\improper Telecomms Storage"
-	})
-"hqq" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 8
-	},
-/obj/machinery/light/small,
-/turf/simulated/floor/tiled,
-/area/tcommsat/entrance{
-	name = "\improper Telecomms Entrance"
 	})
 "hqA" = (
 /obj/machinery/portable_atmospherics/powered/pump/filled,
@@ -21240,31 +21612,6 @@
 /obj/machinery/door/airlock/multi_tile/glass,
 /turf/simulated/floor/tiled/steel_grid,
 /area/tether/exploration)
-"hLW" = (
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 28
-	},
-/obj/structure/table/standard,
-/obj/effect/floor_decal/borderfloor{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/brown/border{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 5
-	},
-/obj/effect/floor_decal/corner/brown/bordercorner2{
-	dir = 5
-	},
-/turf/simulated/floor/tiled,
-/area/quartermaster/office)
 "hNr" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -22087,16 +22434,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/station/docks)
-"iAx" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/wall/r_wall,
-/area/tcommsat/entrance{
-	name = "\improper Telecomms Entrance"
-	})
 "iAG" = (
 /obj/machinery/door/airlock/glass_external,
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -22508,18 +22845,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/gateway/prep_room)
-"iXg" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 28
-	},
-/obj/structure/cable/green,
-/obj/structure/catwalk,
-/obj/random/junk,
-/obj/effect/floor_decal/rust,
-/turf/simulated/floor,
-/area/maintenance/station/cargo)
 "iYB" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -22656,23 +22981,6 @@
 /obj/structure/sign/department/eng,
 /turf/simulated/wall/r_wall,
 /area/hallway/station/docks)
-"jmn" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/highsecurity{
-	name = "Telecomms Access";
-	req_one_access = list(10,12,16,17,61)
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/firedoor/glass,
-/turf/simulated/floor/tiled/techfloor,
-/area/tcommsat/entrance{
-	name = "\improper Telecomms Entrance"
-	})
 "jms" = (
 /obj/structure/table/rack,
 /obj/item/clothing/suit/space/void/mining,
@@ -22864,16 +23172,6 @@
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating,
 /area/maintenance/station/cargo)
-"jxP" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/tcomsat{
-	name = "\improper Telecomms Lobby"
-	})
 "jyc" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/grille,
@@ -23445,15 +23743,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/tcomms)
-"kcM" = (
-/obj/structure/closet/crate/solar,
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/dark,
-/area/tcommsat/entrance{
-	name = "\improper Telecomms Entrance"
-	})
 "kcV" = (
 /obj/structure/closet/emcloset,
 /obj/effect/floor_decal/industrial/outline/blue,
@@ -26019,32 +26308,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/station/atrium)
-"moi" = (
-/obj/machinery/turretid/stun{
-	ailock = 1;
-	check_synth = 1;
-	control_area = /area/tcomsat;
-	desc = "A firewall prevents AIs from interacting with this device.";
-	name = "Telecoms Foyer turret control";
-	pixel_y = 29;
-	req_access = list();
-	req_one_access = list(10,12,16,17,61)
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/dark,
-/area/tcommsat/entrance{
-	name = "\improper Telecomms Entrance"
-	})
 "mou" = (
 /obj/machinery/door/airlock/glass_external,
 /obj/structure/cable/green{
@@ -27288,17 +27551,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/quartermaster/qm)
-"nwy" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
-/area/tcommsat/entrance{
-	name = "\improper Telecomms Entrance"
-	})
 "nwK" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -27469,19 +27721,6 @@
 /obj/machinery/mineral/processing_unit,
 /turf/simulated/floor/plating,
 /area/quartermaster/belterdock/refinery)
-"nEB" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 28
-	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals6,
-/turf/simulated/floor/tiled,
-/area/tether/station/dock_two)
 "nFA" = (
 /obj/machinery/mineral/output,
 /obj/machinery/conveyor{
@@ -27505,31 +27744,6 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/hallway/station/atrium)
-"nGm" = (
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 28
-	},
-/obj/structure/ore_box,
-/obj/effect/floor_decal/borderfloor{
-	dir = 5
-	},
-/obj/effect/floor_decal/corner/brown/border{
-	dir = 5
-	},
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/brown/bordercorner2{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/quartermaster/belterdock)
 "nHH" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -27759,23 +27973,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/quartermaster/qm)
-"nWq" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
-/turf/simulated/floor/tiled,
-/area/tcommsat/entrance{
-	name = "\improper Telecomms Entrance"
-	})
 "nXm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/aux{
 	dir = 8;
@@ -28741,34 +28938,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/exploration/crew)
-"pmC" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 4
-	},
-/obj/machinery/camera/network/tether{
-	dir = 9
-	},
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 4
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 9
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 10
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 28
-	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/tiled,
-/area/tether/station/dock_one)
 "pmE" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
@@ -30360,26 +30529,6 @@
 	},
 /turf/simulated/floor,
 /area/maintenance/cargo)
-"rjV" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/computer/id_restorer{
-	dir = 8;
-	pixel_x = 32
-	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 4
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 9
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 10
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/station/atrium)
 "rlr" = (
 /obj/structure/table/standard,
 /obj/item/weapon/tape_roll,
@@ -31333,22 +31482,6 @@
 	},
 /turf/simulated/floor/tiled/eris/dark/techfloor,
 /area/shuttle/medivac/engines)
-"svZ" = (
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 8
-	},
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 28
-	},
-/obj/structure/cable/green,
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/turf/simulated/floor,
-/area/maintenance/substation/cargo)
 "swH" = (
 /obj/machinery/power/smes/buildable/point_of_interest,
 /obj/structure/cable{
@@ -33462,19 +33595,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/tiled,
 /area/tether/station/dock_two)
-"uVV" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 28
-	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/structure/table/woodentable,
-/turf/simulated/floor/carpet,
-/area/engineering/foyer)
 "uWa" = (
 /obj/machinery/access_button{
 	command = "cycle_interior";
@@ -34227,20 +34347,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/belterdock/gear)
-"vXw" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 8
-	},
-/obj/machinery/porta_turret{
-	dir = 6
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/tcomsat{
-	name = "\improper Telecomms Lobby"
-	})
 "vYj" = (
 /obj/structure/table/rack{
 	dir = 8;
@@ -34459,19 +34565,6 @@
 "wnV" = (
 /turf/simulated/floor/tiled,
 /area/quartermaster/foyer)
-"woq" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/tcomsat{
-	name = "\improper Telecomms Lobby"
-	})
 "wou" = (
 /obj/structure/closet/emcloset,
 /obj/machinery/firealarm{
@@ -35216,16 +35309,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/station/dock_one)
-"xlb" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled,
-/area/tcomsat{
-	name = "\improper Telecomms Lobby"
-	})
 "xmh" = (
 /obj/machinery/gateway{
 	dir = 9
@@ -39520,7 +39603,7 @@ lEZ
 mKN
 bxo
 mPT
-pmC
+agA
 hNr
 dnU
 bqU
@@ -40226,7 +40309,7 @@ aFJ
 aHQ
 amp
 aqm
-aNd
+agl
 ppG
 utr
 xbm
@@ -41206,14 +41289,14 @@ aac
 abZ
 arO
 apu
-aqj
+agq
 aqM
 aqM
 aqM
 aqM
 aqM
 aqM
-aBp
+aga
 aCE
 aEf
 aFX
@@ -41225,7 +41308,7 @@ aOS
 aQk
 bcw
 bfT
-aVH
+agn
 aRb
 oYN
 bVP
@@ -41351,7 +41434,7 @@ aps
 aqi
 aqM
 ath
-avd
+afX
 asA
 aoP
 aqM
@@ -41790,7 +41873,7 @@ anu
 aqu
 alt
 aOY
-aQs
+agm
 and
 aTX
 aVN
@@ -42892,17 +42975,17 @@ acL
 aaL
 abg
 abw
-abM
+afk
 alF
 agP
 ahZ
 aeC
 aeS
-afk
+ags
 alF
 adN
 ahK
-aiF
+agp
 aiM
 aac
 acz
@@ -43171,7 +43254,7 @@ ank
 acW
 bAM
 bHt
-bJl
+abM
 acy
 xeG
 adv
@@ -43224,7 +43307,7 @@ wHG
 loz
 trQ
 mOz
-nEB
+agG
 nZC
 aAV
 iDc
@@ -43343,7 +43426,7 @@ avx
 awO
 ayb
 acY
-aBA
+agz
 aCV
 aEA
 aGs
@@ -43781,7 +43864,7 @@ aCa
 aRc
 aSL
 qqY
-uVV
+agD
 aoJ
 agW
 bVP
@@ -44162,7 +44245,7 @@ aaN
 aiG
 doH
 alf
-aln
+agv
 hmm
 apC
 cue
@@ -44182,7 +44265,7 @@ akT
 alE
 amq
 amO
-akk
+agr
 aJs
 anZ
 any
@@ -44473,7 +44556,7 @@ anB
 apg
 apX
 aqH
-ass
+agy
 aCh
 avL
 awT
@@ -44807,7 +44890,7 @@ aAh
 ePp
 vVA
 vVA
-iXg
+ahm
 uYu
 bQF
 mtR
@@ -45322,7 +45405,7 @@ ack
 ach
 ajY
 kxm
-bQG
+agt
 mQR
 pyy
 lIs
@@ -45368,10 +45451,10 @@ sgS
 sgS
 oKz
 tUh
-ayT
+ahe
 kWQ
 azx
-svZ
+ahl
 qHe
 aAb
 mvv
@@ -46216,13 +46299,13 @@ gVf
 vZr
 bKM
 vuu
-hLW
+ahd
 sBs
 nob
 azc
 aah
 azV
-aBP
+ahh
 pmX
 aDS
 xsP
@@ -46334,10 +46417,10 @@ tRn
 vYJ
 vYJ
 dPx
-rjV
+afH
 kts
 vYJ
-vYJ
+afI
 aba
 abm
 abO
@@ -46519,7 +46602,7 @@ meW
 bOA
 nyL
 bmW
-nGm
+aht
 lxK
 seR
 sII
@@ -47491,7 +47574,7 @@ avQ
 agS
 ekh
 auK
-awh
+ahc
 ayY
 axd
 aDz
@@ -47869,7 +47952,7 @@ afD
 iaf
 vLG
 gVQ
-hbc
+agk
 htA
 qer
 scu
@@ -50558,7 +50641,7 @@ rLI
 amJ
 avZ
 thI
-rLO
+aeu
 xTB
 acE
 xTB
@@ -50714,7 +50797,7 @@ izZ
 otm
 dkG
 cEE
-kcM
+afd
 exs
 acI
 kff
@@ -50847,16 +50930,16 @@ kyd
 bLZ
 gtY
 xEG
-vXw
-cjr
+aex
+aey
 vxd
 lsa
 cso
-cuN
-ayI
-dkR
-kff
-aEF
+afl
+aeI
+aeR
+afa
+afv
 gvM
 uWa
 gbt
@@ -50995,9 +51078,9 @@ hkR
 lGY
 nJx
 iEU
-azu
-nWq
-jmn
+aeJ
+aeT
+afb
 gdZ
 mpB
 gWD
@@ -51132,15 +51215,15 @@ xjt
 awC
 xEG
 jsK
-heQ
+aeF
 vxd
 qOh
 yaH
-xlb
-aBk
-hqq
-iAx
-moi
+aeH
+aeN
+aeY
+afc
+afg
 sRH
 jSj
 kff
@@ -51276,13 +51359,13 @@ xEG
 kJl
 xEG
 xEG
-woq
-jxP
-fqw
+aeG
+afh
+aft
 xEG
 dls
 dTU
-nwy
+afw
 dyt
 acP
 kff
@@ -51308,7 +51391,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+ahW
 fLT
 fLT
 fLT
@@ -51424,7 +51507,7 @@ xEG
 xEG
 xdJ
 dTU
-bUj
+kff
 kff
 kff
 kff
@@ -51450,7 +51533,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+ahW
 fvg
 aaa
 aaa
@@ -51572,6 +51655,7 @@ dTU
 gfX
 asM
 hOw
+ahW
 aaa
 aaa
 aaa
@@ -51591,8 +51675,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+ahW
 aaa
 aaa
 aaa
@@ -51694,7 +51777,7 @@ xTB
 aie
 axf
 uyX
-bTu
+aev
 xSF
 acG
 pyE
@@ -51713,28 +51796,28 @@ gDA
 dTU
 gfX
 acQ
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+ahW
+ahW
+afx
+afx
+afx
+afx
+afx
+afx
+afx
+afx
+afx
+afx
+afx
+afx
+afx
+afx
+afx
+afx
+afx
+afx
+afx
+afx
 aaa
 aaa
 aaa
@@ -51856,7 +51939,7 @@ dTU
 gfX
 acR
 aaa
-aaa
+ahW
 aaa
 aaa
 aaa
@@ -51998,7 +52081,7 @@ gfX
 gfX
 acT
 aaa
-aaa
+afx
 aaa
 aaa
 aaa
@@ -52140,7 +52223,7 @@ gPx
 gPx
 hOw
 aaa
-aaa
+afx
 aaa
 aaa
 aaa
@@ -52277,12 +52360,12 @@ aaa
 aaa
 aaa
 ahW
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+afx
+afx
+afx
+afx
+afx
+afx
 aaa
 aaa
 aaa

--- a/maps/tether/tether-05-station1.dmm
+++ b/maps/tether/tether-05-station1.dmm
@@ -2207,6 +2207,7 @@
 	icon_state = "2-8"
 	},
 /obj/structure/catwalk,
+/obj/machinery/camera/network/engineering,
 /turf/simulated/floor,
 /area/maintenance/station/eng_lower)
 "adM" = (
@@ -2234,6 +2235,55 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/tcommsat/chamber)
+"adN" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/item/device/radio/intercom{
+	dir = 4;
+	pixel_x = 24
+	},
+/obj/machinery/camera/network/engine,
+/turf/simulated/floor/tiled,
+/area/engineering/engine_airlock)
+"adO" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 10
+	},
+/obj/machinery/embedded_controller/radio/airlock/advanced_airlock_controller{
+	id_tag = "engine_room_airlock";
+	name = "Engine Room Airlock";
+	pixel_x = -24;
+	tag_airpump = "engine_airlock_pump";
+	tag_chamber_sensor = "eng_al_c_snsr";
+	tag_exterior_door = "engine_airlock_exterior";
+	tag_exterior_sensor = "eng_al_ext_snsr";
+	tag_interior_door = "engine_airlock_interior";
+	tag_interior_sensor = "eng_al_int_snsr"
+	},
+/obj/machinery/camera/network/engine{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/engineering/engine_airlock)
+"adP" = (
+/obj/machinery/airlock_sensor/airlock_exterior{
+	id_tag = "eng_al_ext_snsr";
+	layer = 3.3;
+	master_tag = "engine_room_airlock";
+	pixel_x = -22;
+	req_access = list(10)
+	},
+/obj/effect/floor_decal/corner_steel_grid{
+	dir = 9
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/atmospherics/portables_connector{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/canister/air/airlock,
+/turf/simulated/floor/tiled,
+/area/engineering/engine_airlock)
 "adQ" = (
 /obj/machinery/computer/power_monitor{
 	dir = 4;
@@ -2262,6 +2312,16 @@
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/atmos/backup)
+"adT" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 5
+	},
+/obj/structure/reagent_dispensers/watertank,
+/obj/machinery/camera/network/tether{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/maintenance/cargo)
 "adU" = (
 /obj/machinery/light/small,
 /obj/machinery/floodlight,
@@ -2320,6 +2380,38 @@
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/engine_smes)
+"aec" = (
+/obj/structure/table/rack,
+/obj/item/device/suit_cooling_unit,
+/obj/item/device/suit_cooling_unit,
+/obj/item/device/suit_cooling_unit,
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/belterdock)
+"aed" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/brown/bordercorner2{
+	dir = 5
+	},
+/obj/machinery/camera/network/mining{
+	c_tag = "OPM - Mining Production Room";
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/belterdock)
 "aee" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/universal,
 /obj/structure/railing{
@@ -2346,6 +2438,19 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/tether/exploration)
+"aeg" = (
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/camera/network/mining{
+	c_tag = "OPM - Mining Production Room";
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/belterdock/surface_mining_outpost_shuttle_hangar)
 "aeh" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -2428,6 +2533,33 @@
 "aen" = (
 /turf/simulated/floor/tiled,
 /area/engineering/workshop)
+"aeo" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/camera/network/mining{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/belterdock/surface_mining_outpost_shuttle_hangar)
+"aep" = (
+/turf/simulated/wall,
+/area/space)
+"aeq" = (
+/obj/structure/catwalk,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/camera/network/telecom{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/space)
 "aer" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
 	dir = 4
@@ -3701,16 +3833,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/station/docks)
-"ahd" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/obj/item/device/radio/intercom{
-	dir = 4;
-	pixel_x = 24
-	},
-/turf/simulated/floor/tiled,
-/area/engineering/engine_airlock)
 "ahf" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -4172,23 +4294,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor,
 /area/storage/tech)
-"aiy" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 10
-	},
-/obj/machinery/embedded_controller/radio/airlock/advanced_airlock_controller{
-	id_tag = "engine_room_airlock";
-	name = "Engine Room Airlock";
-	pixel_x = -24;
-	tag_airpump = "engine_airlock_pump";
-	tag_chamber_sensor = "eng_al_c_snsr";
-	tag_exterior_door = "engine_airlock_exterior";
-	tag_exterior_sensor = "eng_al_ext_snsr";
-	tag_interior_door = "engine_airlock_interior";
-	tag_interior_sensor = "eng_al_int_snsr"
-	},
-/turf/simulated/floor/plating,
-/area/engineering/engine_airlock)
 "aiA" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -4207,27 +4312,6 @@
 	id_tag = "engine_airlock_pump"
 	},
 /turf/simulated/floor/plating,
-/area/engineering/engine_airlock)
-"aiD" = (
-/obj/machinery/airlock_sensor/airlock_exterior{
-	id_tag = "eng_al_ext_snsr";
-	layer = 3.3;
-	master_tag = "engine_room_airlock";
-	pixel_x = -22;
-	req_access = list(10)
-	},
-/obj/effect/floor_decal/corner_steel_grid{
-	dir = 9
-	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/atmospherics/portables_connector{
-	dir = 1
-	},
-/obj/machinery/camera/network/engine{
-	dir = 1
-	},
-/obj/machinery/portable_atmospherics/canister/air/airlock,
-/turf/simulated/floor/tiled,
 /area/engineering/engine_airlock)
 "aiF" = (
 /obj/machinery/power/apc{
@@ -22893,20 +22977,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/gateway)
-"jEs" = (
-/obj/structure/table/rack,
-/obj/item/device/suit_cooling_unit,
-/obj/item/device/suit_cooling_unit,
-/obj/item/device/suit_cooling_unit,
-/obj/effect/floor_decal/borderfloor{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/brown/border{
-	dir = 1
-	},
-/obj/machinery/camera/network/mining,
-/turf/simulated/floor/tiled,
-/area/quartermaster/belterdock)
 "jFv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
@@ -25997,13 +26067,6 @@
 /area/tcommsat/entrance{
 	name = "\improper Telecomms Entrance"
 	})
-"mqL" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 5
-	},
-/obj/structure/reagent_dispensers/watertank,
-/turf/simulated/floor,
-/area/maintenance/cargo)
 "mqR" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -28810,21 +28873,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor,
 /area/maintenance/station/eng_lower)
-"pwU" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/brown/border{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 5
-	},
-/obj/effect/floor_decal/corner/brown/bordercorner2{
-	dir = 5
-	},
-/turf/simulated/floor/tiled,
-/area/quartermaster/belterdock)
 "pyy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -35709,15 +35757,6 @@
 	},
 /turf/simulated/shuttle/floor/yellow/airless,
 /area/shuttle/belter)
-"xZB" = (
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/turf/simulated/floor/tiled,
-/area/quartermaster/belterdock/surface_mining_outpost_shuttle_hangar)
 "xZW" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -42153,7 +42192,7 @@ aff
 alF
 agF
 ahs
-aiy
+adO
 aiM
 aac
 acz
@@ -42579,7 +42618,7 @@ afj
 alF
 agL
 ahB
-aiD
+adP
 aiM
 aac
 acz
@@ -42861,7 +42900,7 @@ aeC
 aeS
 afk
 alF
-ahd
+adN
 ahK
 aiF
 aiM
@@ -43467,7 +43506,7 @@ tUh
 axz
 kLN
 ady
-mqL
+adT
 mPj
 mPj
 tal
@@ -45912,7 +45951,7 @@ bYr
 cqk
 bYr
 bYr
-jEs
+aec
 tNG
 tNG
 tts
@@ -46056,7 +46095,7 @@ rxK
 bmW
 sCo
 oTk
-pwU
+aed
 hTx
 mLa
 seR
@@ -46770,7 +46809,7 @@ yiu
 nJw
 huL
 huL
-huL
+aeo
 huL
 huL
 mWy
@@ -48329,7 +48368,7 @@ cWq
 sKB
 yiu
 ohT
-xZB
+aeg
 unR
 unR
 unR
@@ -50833,7 +50872,7 @@ aaa
 aaa
 aaa
 ahW
-ahW
+aep
 ahW
 aaa
 aaa
@@ -50975,7 +51014,7 @@ dxY
 dxY
 dxY
 dxY
-dxY
+aeq
 dxY
 dxY
 dxY

--- a/maps/tether/tether-08-mining.dmm
+++ b/maps/tether/tether-08-mining.dmm
@@ -1225,6 +1225,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/tiled/steel_grid,
 /area/outpost/mining_main/hangar)
 "cC" = (
@@ -1322,6 +1323,16 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/outpost/mining_main/break_room)
+"cG" = (
+/obj/machinery/door/airlock/glass_mining,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/tiled/steel_grid,
+/area/outpost/mining_main/secondary_gear_storage)
 "cH" = (
 /obj/machinery/mech_recharger,
 /turf/simulated/floor/tiled/steel_dirty/virgo3b,
@@ -1339,6 +1350,32 @@
 	},
 /turf/simulated/floor/tiled,
 /area/outpost/mining_main/secondary_gear_storage)
+"cJ" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/access_button{
+	command = "cycle_interior";
+	frequency = 1379;
+	master_tag = "mining_outpost_airlock";
+	name = "Mining Outpost Access Button";
+	pixel_x = 0;
+	pixel_y = 24;
+	req_access = list(10,24,48,54)
+	},
+/obj/machinery/door/airlock/glass_external{
+	frequency = 1379;
+	icon_state = "door_locked";
+	id_tag = "mining_outpost_airlock_inner";
+	locked = 1
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/outpost/mining_main/airlock)
 "cK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -1554,14 +1591,24 @@
 /turf/simulated/floor/tiled,
 /area/outpost/mining_main/secondary_gear_storage)
 "db" = (
-/obj/machinery/door/airlock/glass_mining,
-/obj/structure/cable/green{
-	icon_state = "1-2"
+/obj/machinery/access_button{
+	command = "cycle_exterior";
+	dir = 2;
+	frequency = 1379;
+	master_tag = "mining_outpost_airlock";
+	name = "Mining Outpost Access Button";
+	pixel_x = 0;
+	pixel_y = 24;
+	req_access = list(10,24,48,54)
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/airlock/glass_external/public{
+	frequency = 1379;
+	icon_state = "door_locked";
+	id_tag = "mining_outpost_airlock_outer";
+	locked = 1
+	},
 /turf/simulated/floor/tiled/steel_grid,
-/area/outpost/mining_main/secondary_gear_storage)
+/area/outpost/mining_main/airlock)
 "dc" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -1583,26 +1630,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/tiled/steel_grid,
 /area/outpost/mining_main/break_room)
-"di" = (
-/obj/machinery/access_button{
-	command = "cycle_exterior";
-	dir = 2;
-	frequency = 1379;
-	master_tag = "mining_outpost_airlock";
-	name = "Mining Outpost Access Button";
-	pixel_x = 0;
-	pixel_y = 24;
-	req_access = list(48,54)
-	},
-/obj/machinery/door/airlock/glass_external/public{
-	frequency = 1379;
-	icon_state = "door_locked";
-	id_tag = "mining_outpost_airlock_outer";
-	locked = 1
-	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/outpost/mining_main/airlock)
-"ef" = (
+"de" = (
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -1611,23 +1639,16 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/access_button{
-	command = "cycle_interior";
-	frequency = 1379;
-	master_tag = "mining_outpost_airlock";
-	name = "Mining Outpost Access Button";
-	pixel_x = 0;
-	pixel_y = 24;
-	req_access = list(48,54)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/machinery/door/airlock/glass_external{
-	frequency = 1379;
-	icon_state = "door_locked";
-	id_tag = "mining_outpost_airlock_inner";
-	locked = 1
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/maintenance/cargo{
+	name = "Utiltiy Room";
+	req_one_access = list(10,24,48,54)
 	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/outpost/mining_main/airlock)
+/turf/simulated/floor/tiled,
+/area/outpost/mining_main/maintenance)
 "hw" = (
 /obj/effect/floor_decal/rust,
 /obj/effect/floor_decal/industrial/warning/dust{
@@ -1753,24 +1774,6 @@
 	color = "#AAAAAA"
 	},
 /area/mine/explored)
-"Cy" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/glass,
-/obj/machinery/door/airlock/mining{
-	name = "Utility Room"
-	},
-/turf/simulated/floor/tiled,
-/area/outpost/mining_main/maintenance)
 "DX" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -4190,7 +4193,7 @@ cj
 cv
 bG
 ay
-Cy
+de
 ay
 ay
 ay
@@ -4614,7 +4617,7 @@ bX
 ce
 co
 da
-db
+cG
 dc
 dd
 bW
@@ -5187,7 +5190,7 @@ tk
 cM
 Px
 Px
-ef
+cJ
 Px
 Px
 ab
@@ -6039,7 +6042,7 @@ ab
 ab
 Px
 Px
-di
+db
 GU
 Px
 ab

--- a/maps/tether/tether-09-solars.dmm
+++ b/maps/tether/tether-09-solars.dmm
@@ -1105,8 +1105,20 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/rnd/outpost/testing)
 "cx" = (
-/obj/structure/filingcabinet/filingcabinet,
-/turf/simulated/floor/tiled/steel_grid,
+/obj/machinery/alarm{
+	pixel_y = 22
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/structure/table/reinforced,
+/obj/item/weapon/storage/box/beakers,
+/obj/item/device/reagent_scanner,
+/obj/item/weapon/reagent_containers/spray/cleaner{
+	desc = "Someone has crossed out the 'Space' from Space Cleaner and written in Toxins. Scrawled on the back is, 'Don't go making any messes that this stuff can't clean up.'";
+	name = "Toxins Cleaner"
+	},
+/obj/item/weapon/storage/box/syringes,
+/obj/item/weapon/storage/fancy/vials,
+/turf/simulated/floor/tiled,
 /area/rnd/outpost/testing)
 "cy" = (
 /obj/effect/floor_decal/industrial/warning/cee{
@@ -1305,27 +1317,39 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/rnd/outpost/testing)
 "cT" = (
-/obj/machinery/alarm{
-	pixel_y = 22
+/obj/structure/filingcabinet/filingcabinet,
+/obj/machinery/camera/network/research_outpost{
+	dir = 8
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/structure/table/reinforced,
-/obj/item/weapon/storage/box/beakers,
-/obj/item/device/reagent_scanner,
-/obj/item/weapon/reagent_containers/spray/cleaner{
-	desc = "Someone has crossed out the 'Space' from Space Cleaner and written in Toxins. Scrawled on the back is, 'Don't go making any messes that this stuff can't clean up.'";
-	name = "Toxins Cleaner"
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/steel_grid,
 /area/rnd/outpost/testing)
 "cU" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/button/remote/blast_door{
+	dir = 4;
+	id = "toxins_ww";
+	name = "Blast Door Control";
+	pixel_x = -24;
+	pixel_y = 4
+	},
 /obj/structure/table/reinforced,
-/obj/item/weapon/storage/box/syringes,
-/obj/item/weapon/storage/fancy/vials,
+/obj/machinery/reagentgrinder,
+/obj/machinery/button/remote/airlock{
+	dir = 4;
+	id = "toxins_ww_door";
+	name = "Door Bolt Control";
+	pixel_x = -24;
+	pixel_y = -4;
+	specialfunctions = 4
+	},
+/obj/machinery/button/windowtint/doortint{
+	id = "toxins_ww_door";
+	name = "Toxins tint control";
+	pixel_x = -32;
+	range = 12
+	},
 /turf/simulated/floor/tiled,
 /area/rnd/outpost/testing)
 "cV" = (
@@ -1539,24 +1563,14 @@
 /turf/simulated/floor/tiled/monotile,
 /area/rnd/outpost/testing)
 "du" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
 	},
-/obj/machinery/button/remote/blast_door{
-	dir = 4;
-	id = "toxins_ww";
-	name = "Blast Door Control";
-	pixel_x = -24;
-	pixel_y = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/table/reinforced,
-/obj/machinery/reagentgrinder,
-/obj/machinery/button/remote/blast_door{
-	dir = 4;
-	id = "toxins_ww_door";
-	name = "Door Bolt Control";
-	pixel_x = -24;
-	pixel_y = -4
+/obj/item/device/radio/phone{
+	name = "Toxins red phone";
+	pixel_x = 2
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/outpost/testing)
@@ -1815,7 +1829,14 @@
 "dW" = (
 /obj/machinery/light_switch{
 	dir = 1;
-	pixel_x = 4;
+	pixel_x = 8;
+	pixel_y = -24
+	},
+/obj/machinery/button/remote/blast_door{
+	dir = 1;
+	id = "toxins_ww";
+	name = "Toxins Workroom";
+	pixel_x = -8;
 	pixel_y = -24
 	},
 /turf/simulated/floor/tiled,
@@ -7220,6 +7241,10 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/item/device/radio/phone{
+	name = "Research Outpost red phone";
+	pixel_x = 2
+	},
 /turf/simulated/floor/tiled,
 /area/rnd/outpost/breakroom)
 "nj" = (
@@ -8235,7 +8260,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/firedoor/glass,
-/obj/machinery/door/airlock/multi_tile/metal{
+/obj/machinery/door/airlock/multi_tile/glass/polarized{
 	id_tag = "toxins_ww_door";
 	name = "Toxins Workroom";
 	req_one_access = list(7)
@@ -22715,7 +22740,7 @@ ad
 ad
 dr
 cQ
-du
+cU
 dS
 pf
 ob
@@ -22998,8 +23023,8 @@ ad
 ad
 ad
 dr
-cT
-cU
+cx
+du
 es
 pg
 dR
@@ -23424,7 +23449,7 @@ ad
 ad
 ad
 dr
-cx
+cT
 dv
 pe
 ph

--- a/maps/tether/tether-09-solars.dmm
+++ b/maps/tether/tether-09-solars.dmm
@@ -955,8 +955,24 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/outpost/mixing)
 "cf" = (
-/turf/simulated/wall,
-/area/rnd/outpost/testing)
+/obj/effect/floor_decal/steeldecal/steel_decals5,
+/obj/effect/floor_decal/steeldecal/steel_decals5{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/structure/table/standard,
+/obj/item/weapon/storage/toolbox/emergency,
+/obj/item/device/radio/intercom{
+	dir = 4;
+	pixel_x = 24
+	},
+/turf/simulated/floor/tiled,
+/area/rnd/outpost/eva)
 "cg" = (
 /turf/simulated/wall,
 /area/rnd/outpost/eva)
@@ -1114,24 +1130,8 @@
 /turf/simulated/floor/tiled,
 /area/rnd/outpost/eva)
 "cA" = (
-/obj/effect/floor_decal/steeldecal/steel_decals5,
-/obj/effect/floor_decal/steeldecal/steel_decals5{
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/obj/structure/table/standard,
-/obj/item/weapon/storage/toolbox/emergency,
-/obj/item/device/radio/intercom{
-	dir = 8;
-	pixel_x = 24
-	},
-/turf/simulated/floor/tiled,
-/area/rnd/outpost/eva)
+/turf/simulated/wall/r_wall,
+/area/rnd/outpost/mixing)
 "cB" = (
 /obj/machinery/alarm{
 	pixel_y = 22
@@ -1272,30 +1272,28 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/outpost/mixing)
 "cQ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/newscaster{
+	pixel_x = -32;
+	pixel_y = 0
 	},
+/obj/machinery/requests_console/preset/research{
+	pixel_x = 0;
+	pixel_y = 30
+	},
+/obj/structure/table/reinforced,
+/obj/machinery/chemical_dispenser/full,
+/turf/simulated/floor/tiled,
+/area/rnd/outpost/testing)
+"cR" = (
 /obj/item/device/radio/intercom{
 	dir = 1;
 	pixel_y = 24;
 	req_access = list()
 	},
-/obj/structure/table/standard,
-/obj/item/weapon/folder/white,
-/obj/item/weapon/pen/fountain,
-/turf/simulated/floor/tiled,
-/area/rnd/outpost/testing)
-"cR" = (
-/obj/structure/table/standard,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
-/obj/item/stack/cable_coil,
-/obj/item/stack/cable_coil,
-/obj/item/weapon/tool/wirecutters,
+/obj/structure/table/reinforced,
+/obj/item/weapon/reagent_containers/glass/beaker/large,
+/obj/item/weapon/reagent_containers/dropper,
+/obj/item/clothing/glasses/science,
 /turf/simulated/floor/tiled,
 /area/rnd/outpost/testing)
 "cS" = (
@@ -1310,22 +1308,25 @@
 /obj/machinery/alarm{
 	pixel_y = 22
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/structure/table/reinforced,
+/obj/item/weapon/storage/box/beakers,
+/obj/item/device/reagent_scanner,
+/obj/item/weapon/reagent_containers/spray/cleaner{
+	desc = "Someone has crossed out the 'Space' from Space Cleaner and written in Toxins. Scrawled on the back is, 'Don't go making any messes that this stuff can't clean up.'";
+	name = "Toxins Cleaner"
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/outpost/testing)
 "cU" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
 	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/tiled/steel_grid,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/table/reinforced,
+/obj/item/weapon/storage/box/syringes,
+/obj/item/weapon/storage/fancy/vials,
+/turf/simulated/floor/tiled,
 /area/rnd/outpost/testing)
 "cV" = (
 /obj/structure/cable/green{
@@ -1517,14 +1518,15 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/outpost/mixing)
 "dr" = (
-/obj/structure/bed/chair/office/light{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/wall/r_wall,
 /area/rnd/outpost/testing)
 "ds" = (
-/obj/structure/table/standard,
-/obj/item/weapon/tank/phoron,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/bed/chair/office/light{
+	dir = 1
+	},
 /turf/simulated/floor/tiled,
 /area/rnd/outpost/testing)
 "dt" = (
@@ -1537,16 +1539,53 @@
 /turf/simulated/floor/tiled/monotile,
 /area/rnd/outpost/testing)
 "du" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/obj/machinery/button/remote/blast_door{
+	dir = 4;
+	id = "toxins_ww";
+	name = "Blast Door Control";
+	pixel_x = -24;
+	pixel_y = 4
+	},
+/obj/structure/table/reinforced,
+/obj/machinery/reagentgrinder,
+/obj/machinery/button/remote/blast_door{
+	dir = 4;
+	id = "toxins_ww_door";
+	name = "Door Bolt Control";
+	pixel_x = -24;
+	pixel_y = -4
+	},
 /turf/simulated/floor/tiled,
 /area/rnd/outpost/testing)
 "dv" = (
-/obj/structure/dispenser,
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
 	},
-/turf/simulated/floor/tiled,
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/closet/crate/science,
+/obj/item/weapon/grenade/chem_grenade,
+/obj/item/weapon/grenade/chem_grenade,
+/obj/item/weapon/grenade/chem_grenade,
+/obj/item/device/assembly/timer,
+/obj/item/device/assembly/timer,
+/obj/item/device/assembly/timer,
+/obj/item/device/assembly/igniter,
+/obj/item/device/assembly/igniter,
+/obj/item/device/assembly/igniter,
+/obj/fiftyspawner/glass,
+/obj/fiftyspawner/steel,
+/obj/item/stack/material/phoron{
+	amount = 5
+	},
+/turf/simulated/floor/tiled/steel_grid,
 /area/rnd/outpost/testing)
 "dw" = (
 /turf/simulated/floor/tiled,
@@ -1715,33 +1754,24 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/outpost/mixing)
 "dR" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_x = 0;
-	pixel_y = -26
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/table/standard,
-/obj/item/weapon/weldingtool,
-/obj/item/clothing/glasses/welding,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/rnd/outpost/testing)
 "dS" = (
-/obj/structure/table/standard,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
+/obj/structure/table/reinforced,
+/obj/item/weapon/folder/red{
+	pixel_x = 2;
+	pixel_y = -3
 	},
-/obj/item/weapon/tool/screwdriver,
-/obj/item/device/assembly_holder/timer_igniter,
-/obj/machinery/camera/network/research_outpost{
-	dir = 4
+/obj/item/weapon/folder/white,
+/obj/item/weapon/folder/blue{
+	pixel_x = -2;
+	pixel_y = 3
 	},
-/obj/machinery/light_switch{
-	dir = 1;
+/obj/item/weapon/pen/fountain{
 	pixel_x = 4;
-	pixel_y = -24
+	pixel_y = 4
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/outpost/testing)
@@ -1754,10 +1784,25 @@
 /turf/simulated/floor/tiled,
 /area/rnd/outpost/testing)
 "dU" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
+/obj/structure/table/rack/shelf/steel,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = -26
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/clothing/shoes/boots/tactical,
+/obj/item/clothing/under/tactical{
+	sensor_mode = 3;
+	sensorpref = 1
+	},
+/obj/item/clothing/gloves/tactical,
+/obj/item/clothing/suit/bomb_suit,
+/obj/item/clothing/head/bomb_hood,
+/obj/item/device/gps/science,
+/obj/item/weapon/implant/death_alarm,
+/obj/item/weapon/implanter,
+/obj/item/clothing/mask/gas/explorer,
+/obj/item/weapon/tank/emergency/oxygen/double,
 /turf/simulated/floor/tiled,
 /area/rnd/outpost/testing)
 "dV" = (
@@ -1768,8 +1813,10 @@
 /turf/simulated/floor/tiled,
 /area/rnd/outpost/breakroom)
 "dW" = (
-/obj/machinery/requests_console/preset/research{
-	pixel_y = -30
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_x = 4;
+	pixel_y = -24
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/outpost/testing)
@@ -1974,21 +2021,12 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/outpost/mixing)
 "er" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor/glass,
-/turf/simulated/floor/tiled,
-/area/rnd/outpost/testing)
+/turf/simulated/wall/r_wall,
+/area/rnd/outpost/eva)
 "es" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/airlock/multi_tile/glass{
-	name = "Toxins Workroom"
-	},
-/obj/machinery/door/firedoor/glass,
+/obj/machinery/chem_master,
 /turf/simulated/floor/tiled,
 /area/rnd/outpost/testing)
 "et" = (
@@ -2357,34 +2395,7 @@
 /turf/simulated/floor/tiled,
 /area/rnd/outpost)
 "eV" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/purple/border{
-	dir = 1
-	},
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/purple/bordercorner2{
-	dir = 4
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7{
-	dir = 4
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals7,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/wall/r_wall,
 /area/rnd/outpost)
 "eW" = (
 /obj/structure/cable/green{
@@ -4068,7 +4079,7 @@
 	},
 /obj/machinery/door/airlock/maintenance/rnd{
 	name = "Science Outpost Atmospherics";
-	req_one_access = list(10,47)
+	req_one_access = list(10,24,47)
 	},
 /obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor,
@@ -4233,7 +4244,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/airlock/science{
-	name = "Research Outpost"
+	name = "Research Outpost";
+	req_one_access = list(10,24,47)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/tiled,
@@ -7661,6 +7673,26 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/outpost/anomaly_lab)
+"ob" = (
+/obj/machinery/camera/network/research_outpost{
+	dir = 4
+	},
+/obj/structure/table/rack/shelf/steel,
+/obj/item/clothing/shoes/boots/tactical,
+/obj/item/clothing/under/tactical{
+	sensor_mode = 3;
+	sensorpref = 1
+	},
+/obj/item/clothing/gloves/tactical,
+/obj/item/clothing/suit/bomb_suit,
+/obj/item/clothing/head/bomb_hood,
+/obj/item/device/gps/science,
+/obj/item/weapon/implant/death_alarm,
+/obj/item/weapon/implanter,
+/obj/item/clothing/mask/gas/explorer,
+/obj/item/weapon/tank/emergency/oxygen/double,
+/turf/simulated/floor/tiled,
+/area/rnd/outpost/testing)
 "oc" = (
 /obj/item/device/radio/intercom{
 	dir = 4;
@@ -7915,6 +7947,61 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/outpost/breakroom)
+"oE" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/blast/regular{
+	dir = 8;
+	id = "toxins_ww";
+	name = "Toxins Workroom Lockdown"
+	},
+/turf/simulated/floor/tiled,
+/area/rnd/outpost/testing)
+"oF" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/purple/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/purple/bordercorner2{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/button/remote/blast_door{
+	id = "toxins_ww";
+	name = "Toxins Workroom";
+	pixel_y = 24
+	},
+/turf/simulated/floor/tiled,
+/area/rnd/outpost)
+"oG" = (
+/obj/structure/sign/warning/bomb_range{
+	name = "\improper DANGER - EXPLOSIVES WORKROOM"
+	},
+/turf/simulated/wall/r_wall,
+/area/rnd/outpost/testing)
 "oH" = (
 /obj/structure/table/standard,
 /obj/machinery/light,
@@ -8111,6 +8198,55 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/outpost/breakroom)
+"pe" = (
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 4
+	},
+/obj/machinery/autolathe{
+	hacked = 1
+	},
+/turf/simulated/floor/tiled,
+/area/rnd/outpost/testing)
+"pf" = (
+/obj/structure/table/reinforced,
+/obj/item/weapon/storage/toolbox/syndicate{
+	pixel_y = 8
+	},
+/obj/item/clothing/glasses/welding{
+	pixel_y = 14
+	},
+/obj/item/stack/cable_coil,
+/obj/item/weapon/storage/secure/briefcase/toxinsfootball{
+	pixel_y = -8
+	},
+/turf/simulated/floor/tiled,
+/area/rnd/outpost/testing)
+"pg" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled,
+/area/rnd/outpost/testing)
+"ph" = (
+/obj/structure/dispenser,
+/turf/simulated/floor/tiled,
+/area/rnd/outpost/testing)
+"pi" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/multi_tile/metal{
+	id_tag = "toxins_ww_door";
+	name = "Toxins Workroom";
+	req_one_access = list(7)
+	},
+/obj/machinery/door/blast/regular{
+	dir = 8;
+	id = "toxins_ww";
+	name = "Toxins Workroom Lockdown"
+	},
+/turf/simulated/floor/tiled,
+/area/rnd/outpost/testing)
 "zg" = (
 /obj/effect/shuttle_landmark{
 	base_area = /area/mine/explored;
@@ -22435,13 +22571,13 @@ ad
 ad
 ad
 ad
-bW
-bW
-bW
-bW
-bW
-bW
-bW
+cA
+cA
+cA
+cA
+cA
+cA
+cA
 bW
 fp
 bW
@@ -22577,13 +22713,13 @@ ad
 ad
 ad
 ad
-ad
-ad
-cf
-cR
-ds
+dr
+cQ
+du
 dS
-cf
+pf
+ob
+dr
 eR
 fs
 fL
@@ -22719,13 +22855,13 @@ ad
 ad
 ad
 ad
-ad
-ad
-cf
-cQ
 dr
-dR
-cf
+cR
+ds
+dw
+dw
+dU
+oG
 eQ
 fr
 fK
@@ -22861,13 +22997,13 @@ ad
 ad
 ad
 ad
-ad
-cf
-cf
+dr
 cT
-du
-dU
+cU
 es
+pg
+dR
+pi
 eT
 ft
 fK
@@ -23003,13 +23139,13 @@ ad
 ad
 ad
 ad
-ad
-cf
+dr
 cw
 cS
 dt
 dT
-er
+dT
+oE
 eS
 ft
 fK
@@ -23145,14 +23281,14 @@ ad
 ad
 ad
 ad
-ad
-cf
+dr
 cy
 cV
 dw
+dw
 dW
-cf
-eV
+dr
+oF
 fu
 fK
 fW
@@ -23287,13 +23423,13 @@ ad
 ad
 ad
 ad
-ad
-cf
+dr
 cx
-cU
 dv
+pe
+ph
 cZ
-cf
+dr
 eU
 ft
 fM
@@ -23429,13 +23565,13 @@ ad
 ad
 jU
 cg
-cg
-cg
-cg
-cg
-eu
-eu
-eu
+er
+er
+er
+er
+eV
+eV
+eV
 eX
 fw
 fO
@@ -23855,7 +23991,7 @@ ad
 ad
 jW
 cg
-cA
+cf
 cX
 dy
 dX

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -1392,6 +1392,7 @@
 #include "code\game\objects\items\weapons\storage\mre.dm"
 #include "code\game\objects\items\weapons\storage\quickdraw.dm"
 #include "code\game\objects\items\weapons\storage\secure.dm"
+#include "code\game\objects\items\weapons\storage\secure_vr.dm"
 #include "code\game\objects\items\weapons\storage\storage.dm"
 #include "code\game\objects\items\weapons\storage\toolbox.dm"
 #include "code\game\objects\items\weapons\storage\toolbox_vr.dm"


### PR DESCRIPTION
SURFACE 1
Fixed a floating Medbay Intercom in First-Aid

Made structural pillars r-wall instead of regular wall in case Kenzie Houser ventures to the supported area.

Added R-wall to the Virology airlock. That lockdown blast door isn't gonna stop anyone if they can just go around it with ease.

Gave the clown a bit more love [and materials in their little storage room]

Switched the locations of the trash bin and chemical closet in Mental Health.

Added more scrubbers to Tram Station for faster atmos fixes. SUB 10 MINUTE FIXES LET'S GOOOOO!!!!

Removed an odd section of r-wall from brig storage.

Fixed holodeck lighting issue by adding APC's.

SURFACE 2
Continued pillar r-wall from S1

Removed access requirements on Resleeving Washroom.

Added "The Big One" to atmos hard storage.

SURFACE 3
Sectioned off the Tether Shuttle pads with emergency airlocks, scrubbers, and vents. Added more parachutes to accommodate a full Tour Bus and crew plus hide new scrubbers a bit.

ASTEROID
Fixed Tcommsat inner airlock, removed redundant turret control switch. Fixed primary airlock.

MINING
Added missing emergency shutters. Gave Engineering and atmospherics access to the outer airlock and utility room.

SOLARS
Adjusted door access for atmos room and the room with heavy scrubber control console. Fixed a wonky intercom. Added EOD stuff. Rearranged the Toxins workroom and gave it chem-nade capabilities.

FILES
Added the Toxins football, a unique and robust secure briefcase for Toxins!

Commented out some defunct code, if this merges I'll put in an Issue PR to adress the problem it produces. [The problem being non-atmospheric techs having access to a VERY robust atmos item. Unfortunately coding a new atmos computer is beyond me, so this change to allow the pumps to be used like the normal PAP's is the workaround.]