### PR TITLE
Ghost instrument fix

### DIFF
--- a/code/modules/instruments/songs/_song.dm
+++ b/code/modules/instruments/songs/_song.dm
@@ -161,7 +161,7 @@
 	var/list/old = hearing_mobs.Copy()
 	hearing_mobs.len = 0
 	var/turf/source = get_turf(parent)
-	var/list/in_range = get_mobs_and_objs_in_view_fast(source, instrument_range)
+	var/list/in_range = get_mobs_and_objs_in_view_fast(source, instrument_range, remote_ghosts = FALSE)
 	for(var/mob/M in in_range["mobs"])
 		hearing_mobs[M] = get_dist(M, source)
 	var/list/exited = old - hearing_mobs

--- a/code/modules/instruments/songs/play_synthesized.dm
+++ b/code/modules/instruments/songs/play_synthesized.dm
@@ -60,6 +60,7 @@
 	var/channel_text = num2text(channel)
 	channels_playing[channel_text] = 100
 	last_channel_played = channel_text
+	var/turf/source = get_turf(parent)
 	for(var/i in hearing_mobs)
 		var/mob/M = i
 		/* Maybe someday
@@ -69,7 +70,7 @@
 		*/
 		// Jeez
 		M.playsound_local(
-			turf_source = get_turf(parent),
+			turf_source = source,
 			soundin = null,
 			vol = volume,
 			vary = FALSE,


### PR DESCRIPTION
Ghosts can hear instruments across z-levels due to a difference in procs used to calculate who's in hearing range.

Also small optimization to iteration on sound playing.