### PR TITLE
Make Talon's sensors part of its bridge instead of its captain's office

### DIFF
--- a/maps/offmap_vr/talon/talon_v2.dmm
+++ b/maps/offmap_vr/talon/talon_v2.dmm
@@ -8192,7 +8192,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/reinforced/airless,
-/area/talon_v2/crew_quarters/cap_room)
+/area/talon_v2/bridge)
 "Bi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -10849,7 +10849,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/reinforced/airless,
-/area/talon_v2/crew_quarters/cap_room)
+/area/talon_v2/bridge)
 "JQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10


### PR DESCRIPTION
So that the sensors pull power from the bridge APC instead of the captain's quarters. Having them draw power from the captain's bedroom is a little weird, isn't it? Certainly seemed weird to me when I first saw how much power the captain's quarters were drawing