### PR TITLE
Fixes the character creator by: Revert "Fixes #10321"

### DIFF
--- a/code/modules/client/preference_setup/general/03_body.dm
+++ b/code/modules/client/preference_setup/general/03_body.dm
@@ -975,8 +975,6 @@ var/global/list/valid_bloodtypes = list("A+", "A-", "B+", "B-", "AB+", "AB-", "O
 					if(tmp_species in M.species_cannot_use)
 						continue
 					//VOREStation Add - Cyberlimb whitelisting.
-					if(M.unavailable_to_build)
-						continue
 					if(M.whitelisted_to && !(user.ckey in M.whitelisted_to))
 						continue
 					//VOREStation Add End


### PR DESCRIPTION
Reverts VOREStation/VOREStation#10537

Breaks creating characters with prosthetic limbs because almost every limb has unavailable_to_build set to 1. Find a proper solution and PR that instead.

For example: 
![image](https://user-images.githubusercontent.com/48196179/120913154-6cd22600-c65a-11eb-9dd4-2c10c5decbf0.png)
