### PR TITLE
spider emotes weren't added to the list yet

### DIFF
--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -124,6 +124,8 @@ var/list/_human_default_emotes = list(
 	/decl/emote/audible/gao,
 	/decl/emote/audible/cackle,
 	/decl/emote/audible/squish,
+	/decl/emote/audible/spiderchitter,
+	/decl/emote/audible/spiderpurr,
 	
 	/decl/emote/visible/mlem,
 	/decl/emote/visible/blep,


### PR DESCRIPTION
Looks like I forgot to do this when adding spider stuff. The emotes are in, and the sounds, but we still can't use them without this, can we?