### PR TITLE
 Makes voremobs with fullness-specific eye overlays utilize them.

### DIFF
--- a/code/modules/mob/living/simple_mob/simple_mob_vr.dm
+++ b/code/modules/mob/living/simple_mob/simple_mob_vr.dm
@@ -76,6 +76,9 @@
 /mob/living/simple_mob/update_icon()
 	. = ..()
 	if(vore_active)
+		var/voremob_awake = FALSE
+		if(icon_state == icon_living)
+			voremob_awake = TRUE
 		update_fullness()
 		if(!vore_fullness)
 			return 0
@@ -85,7 +88,7 @@
 			icon_state = "[icon_dead]-[vore_fullness]"
 		else if(((stat == UNCONSCIOUS) || resting || incapacitated(INCAPACITATION_DISABLED) ) && icon_rest && (vore_icons & SA_ICON_REST))
 			icon_state = "[icon_rest]-[vore_fullness]"
-		if(vore_eyes) //Update eye layer if applicable.
+		if(vore_eyes && voremob_awake) //Update eye layer if applicable.
 			remove_eyes()
 			add_eyes()
 	update_transform()

--- a/code/modules/mob/living/simple_mob/simple_mob_vr.dm
+++ b/code/modules/mob/living/simple_mob/simple_mob_vr.dm
@@ -42,6 +42,7 @@
 
 	var/vore_fullness = 0				// How "full" the belly is (controls icons)
 	var/vore_icons = 0					// Bitfield for which fields we have vore icons for.
+	var/vore_eyes = FALSE				// For mobs with fullness specific eye overlays.
 	var/life_disabled = 0				// For performance reasons
 
 	var/mount_offset_x = 5				// Horizontal riding offset.
@@ -84,6 +85,9 @@
 			icon_state = "[icon_dead]-[vore_fullness]"
 		else if(((stat == UNCONSCIOUS) || resting || incapacitated(INCAPACITATION_DISABLED) ) && icon_rest && (vore_icons & SA_ICON_REST))
 			icon_state = "[icon_rest]-[vore_fullness]"
+		if(vore_eyes) //Update eye layer if applicable.
+			remove_eyes()
+			add_eyes()
 	update_transform()
 
 /mob/living/simple_mob/proc/will_eat(var/mob/living/M)

--- a/code/modules/mob/living/simple_mob/subtypes/vore/dragon.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/dragon.dm
@@ -96,6 +96,7 @@
 	mount_offset_y = 24
 	mount_offset_x = -9
 	has_eye_glow = TRUE
+	vore_eyes = TRUE
 
 /mob/living/simple_mob/vore/aggressive/dragon/Login()
 	. = ..()

--- a/code/modules/mob/living/simple_mob/subtypes/vore/sect_drone.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/sect_drone.dm
@@ -30,6 +30,7 @@
 	icon = 'icons/mob/vore64x64.dmi'
 	vis_height = 64
 	has_eye_glow = TRUE
+	vore_eyes = TRUE
 
 	faction = "insects"
 	maxHealth = 90

--- a/code/modules/mob/living/simple_mob/subtypes/vore/sect_queen.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/sect_queen.dm
@@ -33,6 +33,7 @@
 	icon = 'icons/mob/vore64x64.dmi'
 	vis_height = 64
 	has_eye_glow = TRUE
+	vore_eyes = TRUE
 
 	faction = "insects"
 	maxHealth = 200


### PR DESCRIPTION
Fixes voremobs with belly state specific eye/glow overlays not updating the overlays to match the fullness sprites.