### PR TITLE
Adds a different version of bloodsucker trait

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
@@ -65,13 +65,25 @@
 	excludes = list(/datum/trait/neutral/autohiss_unathi)
 
 /datum/trait/neutral/bloodsucker
-	name = "Bloodsucker"
+	name = "Bloodsucker (Obligate)"
 	desc = "Makes you unable to gain nutrition from anything but blood. To compenstate, you get fangs that can be used to drain blood from prey."
 	cost = 0
 	custom_only = FALSE
-	var_changes = list("organic_food_coeff" = 0) //The verb is given in human.dm
+	var_changes = list("organic_food_coeff" = 0)
+	excludes = list(/datum/trait/neutral/bloodsucker_freeform)
 
 /datum/trait/neutral/bloodsucker/apply(var/datum/species/S,var/mob/living/carbon/human/H)
+	..(S,H)
+	H.verbs |= /mob/living/carbon/human/proc/bloodsuck
+
+/datum/trait/neutral/bloodsucker_freeform
+	name = "Bloodsucker"
+	desc = "You get fangs that can be used to drain blood from prey."
+	cost = 0
+	custom_only = FALSE
+	excludes = list(/datum/trait/neutral/bloodsucker)
+
+/datum/trait/neutral/bloodsucker_freeform/apply(var/datum/species/S,var/mob/living/carbon/human/H)
 	..(S,H)
 	H.verbs |= /mob/living/carbon/human/proc/bloodsuck
 


### PR DESCRIPTION
Renames existing Bloodsucker into Bloodsucker (Obligate)

Adds a different version just called Bloodsucker which still gives suck blood verb, but does not make other sources of nutrition useless.

Because while it's cool for people who want to play full vampire, for those who want a more mixed diet, its way too restrictive. So, options!