### PR TITLE
Fixes eggless spider versions still laying eggs if 'nest' was someone's body

### DIFF
--- a/code/modules/mob/living/simple_mob/subtypes/animal/giant_spider/giant_spider_vr.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/giant_spider/giant_spider_vr.dm
@@ -52,8 +52,11 @@
 	old_x = -16
 	old_y = 0
 
-/mob/living/simple_mob/animal/giant_spider/nurse/eggless/lay_eggs(turf/T)
-	return FALSE
+/mob/living/simple_mob/animal/giant_spider/nurse
+	var/can_lay_eggs = TRUE
 
-/mob/living/simple_mob/animal/giant_spider/nurse/queen/eggless/lay_eggs(turf/T)
-	return FALSE
+/mob/living/simple_mob/animal/giant_spider/nurse/eggless
+	can_lay_eggs = FALSE
+
+/mob/living/simple_mob/animal/giant_spider/nurse/queen/eggless
+	can_lay_eggs = FALSE

--- a/code/modules/mob/living/simple_mob/subtypes/animal/giant_spider/nurse.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/giant_spider/nurse.dm
@@ -57,7 +57,7 @@
 
 /mob/living/simple_mob/animal/giant_spider/nurse/inject_poison(mob/living/L, target_zone)
 	..() // Inject the stoxin here.
-	if(ishuman(L) && prob(egg_inject_chance))
+	if(ishuman(L) && prob(egg_inject_chance) && can_lay_eggs)			//VOREStation Edit
 		var/mob/living/carbon/human/H = L
 		var/obj/item/organ/external/O = H.get_organ(target_zone)
 		if(O)
@@ -147,7 +147,7 @@
 /mob/living/simple_mob/animal/giant_spider/nurse/handle_special()
 	set waitfor = FALSE
 	if(get_AI_stance() == STANCE_IDLE && !is_AI_busy() && isturf(loc))
-		if(fed)
+		if(fed && can_lay_eggs)			//VOREStation Edit
 			lay_eggs(loc)
 		else
 			web_tile(loc)


### PR DESCRIPTION
Hoped to avoid //VOREStation Edit situation with original implementation, but clearly it wasn't enough.