### PR TITLE
Fix will_eat returning true if !devourable

### DIFF
--- a/code/modules/mob/living/simple_mob/simple_mob_vr.dm
+++ b/code/modules/mob/living/simple_mob/simple_mob_vr.dm
@@ -106,7 +106,7 @@
 	if(vore_ignores_undigestable && !M.digestable) //Don't eat people with nogurgle prefs
 		//ai_log("vr/wont eat [M] because I am picky", 3) //VORESTATION AI TEMPORARY REMOVAL
 		return 0
-	if(!M.allowmobvore) // Don't eat people who don't want to be ate by mobs
+	if(!M.allowmobvore || !M.devourable) // Don't eat people who don't want to be ate by mobs
 		//ai_log("vr/wont eat [M] because they don't allow mob vore", 3) //VORESTATION AI TEMPORARY REMOVAL
 		return 0
 	if(M in prey_excludes) // They're excluded


### PR DESCRIPTION
AI wastes time trying to eat people set `!devourable`. It's stopped in `perform_the_nom()`, but it logs a message to admins saying the simple mob was trying to prefbreak which is dumb, and it will consume the AI's action for that SSai tick so that seems unhelpful.

It checked allowmobvore in `will_nom()` so it seems to be an oversight that it didn't also check devourable.

[2021-06-02T12:24:16] ADMIN: EVENT INVALID/(juvenile solargrub) attempted to devour INVALID/(Runtime) against their prefs

lol