### PR TITLE
VB + Typhon PD Wiring

### DIFF
--- a/maps/submaps/admin_use_vr/ert.dmm
+++ b/maps/submaps/admin_use_vr/ert.dmm
@@ -7,6 +7,10 @@
 /obj/machinery/power/pointdefense{
 	id_tag = "vonbraun_pd"
 	},
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/reinforced/airless,
 /area/ship/ert/barracks)
 "ac" = (
@@ -36,6 +40,10 @@
 "ag" = (
 /obj/machinery/power/pointdefense{
 	id_tag = "vonbraun_pd"
+	},
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/ship/ert/mech_bay)
@@ -85,6 +93,11 @@
 	},
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/structure/dispenser/oxygen,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/barracks)
 "ao" = (
@@ -157,6 +170,11 @@
 /area/ship/ert/commander)
 "av" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/gunnery)
 "ax" = (
@@ -168,6 +186,10 @@
 "aC" = (
 /obj/machinery/power/pointdefense{
 	id_tag = "vonbraun_pd"
+	},
+/obj/structure/cable/yellow{
+	d2 = 8;
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/ship/ert/med_surg)
@@ -232,6 +254,11 @@
 /obj/machinery/power/pointdefense{
 	id_tag = "vonbraun_pd"
 	},
+/obj/structure/cable/yellow{
+	d2 = 4;
+	dir = 4;
+	icon_state = "0-4"
+	},
 /turf/simulated/floor/reinforced/airless,
 /area/ship/ert/eng_storage)
 "bp" = (
@@ -295,6 +322,11 @@
 	},
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/structure/table/rack/steel,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/barracks)
 "bJ" = (
@@ -317,6 +349,25 @@
 /obj/machinery/light/no_nightshift,
 /turf/simulated/floor/reinforced/airless,
 /area/ship/ert/atmos)
+"bS" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/med)
 "bU" = (
 /obj/structure/hull_corner/long_horiz{
 	dir = 5
@@ -329,6 +380,20 @@
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/ship/ert/atmos)
+"ca" = (
+/obj/machinery/sleeper{
+	dir = 4
+	},
+/obj/machinery/light/no_nightshift{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/white,
+/area/ship/ert/med_surg)
 "ch" = (
 /obj/machinery/door/airlock/glass_external,
 /obj/effect/map_helper/airlock/door/int_door,
@@ -713,6 +778,11 @@
 	pixel_y = 26
 	},
 /obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/barracks)
 "eg" = (
@@ -792,6 +862,25 @@
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/teleporter)
+"eG" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/barracks)
 "eH" = (
 /obj/structure/sign/department/cargo{
 	name = "ENGINEERING SUPPLIES"
@@ -888,6 +977,38 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/dock_star)
+"fp" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/barracks)
+"fr" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/eng_storage)
 "fx" = (
 /obj/structure/table/steel_reinforced,
 /obj/machinery/light/no_nightshift{
@@ -910,6 +1031,11 @@
 	},
 /obj/item/rig_module/rescue_pharm{
 	pixel_y = -2
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/mech_bay)
@@ -1065,6 +1191,20 @@
 /obj/effect/floor_decal/industrial/outline/blue,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/eng_storage)
+"gl" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/barracks)
 "gn" = (
 /obj/machinery/light/no_nightshift,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1076,6 +1216,14 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/atmos)
+"go" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/wall/rshull,
+/area/ship/ert/eng_storage)
 "gx" = (
 /obj/structure/table/rack/steel,
 /obj/item/weapon/melee/baton{
@@ -1188,6 +1336,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/white,
 /area/ship/ert/med_surg)
 "ha" = (
@@ -1233,6 +1386,11 @@
 	},
 /obj/machinery/light/no_nightshift{
 	dir = 8
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/white,
 /area/ship/ert/med_surg)
@@ -1350,6 +1508,14 @@
 "ib" = (
 /turf/simulated/floor/reinforced/airless,
 /area/ship/ert/hangar)
+"if" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/wall/rshull,
+/area/ship/ert/gunnery)
 "ij" = (
 /turf/simulated/floor/tiled/white,
 /area/ship/ert/med_surg)
@@ -1365,6 +1531,17 @@
 "ip" = (
 /turf/simulated/floor/tiled/techmaint,
 /area/ship/ert/barracks)
+"iu" = (
+/obj/machinery/power/pointdefense{
+	id_tag = "vonbraun_pd"
+	},
+/obj/structure/cable/yellow{
+	d2 = 4;
+	dir = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/ship/ert/hallways_aft)
 "ix" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/airlock/glass{
@@ -1411,6 +1588,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/ship/ert/barracks)
 "iR" = (
@@ -1425,6 +1607,16 @@
 "iW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/white,
 /area/ship/ert/med_surg)
@@ -1532,6 +1724,14 @@
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/armoury_st)
+"kg" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/wall/rshull,
+/area/ship/ert/hallways_aft)
 "kh" = (
 /obj/machinery/light/no_nightshift{
 	dir = 8
@@ -1540,8 +1740,24 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/ship/ert/hallways_aft)
+"kl" = (
+/obj/effect/landmark{
+	name = "Commando"
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/barracks)
 "km" = (
 /obj/effect/floor_decal/corner/white{
 	dir = 4
@@ -1571,6 +1787,14 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/med)
+"ky" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/wall/shull,
+/area/ship/ert/med_surg)
 "kz" = (
 /obj/structure/closet/crate{
 	dir = 1
@@ -1834,6 +2058,11 @@
 /obj/effect/landmark{
 	name = "Commando"
 	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/barracks)
 "mq" = (
@@ -1843,10 +2072,20 @@
 /obj/effect/landmark{
 	name = "Commando"
 	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/barracks)
 "mr" = (
 /obj/structure/reagent_dispensers/water_cooler/full,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/barracks)
 "mt" = (
@@ -1881,6 +2120,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/ship/ert/barracks)
 "mF" = (
@@ -1942,6 +2186,22 @@
 "mN" = (
 /obj/machinery/sleep_console{
 	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/ship/ert/med_surg)
+"mO" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/med)
+"mP" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/white,
 /area/ship/ert/med_surg)
@@ -2094,14 +2354,13 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/ship/ert/mech_bay)
 "nq" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/ship/ert/med_surg)
+/turf/simulated/wall/rshull,
+/area/ship/ert/barracks)
 "nr" = (
 /obj/machinery/porta_turret/stationary/CIWS,
 /turf/simulated/floor/reinforced/airless,
@@ -2165,6 +2424,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/ship/ert/gunnery)
 "nC" = (
@@ -2189,6 +2453,11 @@
 /obj/structure/ship_munition/disperser_charge/emp,
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/reinforced,
 /area/ship/ert/hallways_aft)
@@ -2233,6 +2502,11 @@
 /obj/machinery/alarm/alarms_hidden{
 	pixel_y = 26
 	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/engine)
 "op" = (
@@ -2276,6 +2550,11 @@
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/ship/ert/eng_storage)
@@ -2759,6 +3038,14 @@
 /obj/item/weapon/tool/crowbar,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/mech_bay)
+"qa" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/wall/shull,
+/area/ship/ert/med_surg)
 "ql" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -2790,6 +3077,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/ship/ert/gunnery)
@@ -2882,12 +3174,28 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/ship/ert/gunnery)
 "qR" = (
 /obj/machinery/recharge_station,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/atmos)
+"rn" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/white,
+/area/ship/ert/med_surg)
 "rp" = (
 /obj/structure/disposaloutlet,
 /obj/structure/disposalpipe/trunk{
@@ -2937,9 +3245,25 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/engine)
+"rB" = (
+/obj/structure/ship_munition/disperser_charge/emp,
+/obj/effect/floor_decal/industrial/warning,
+/obj/structure/railing,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/reinforced,
+/area/ship/ert/gunnery)
 "rD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 10
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/engine)
@@ -2947,9 +3271,25 @@
 /obj/machinery/atmospherics/pipe/tank/air,
 /turf/simulated/floor/airless,
 /area/ship/ert/gunnery)
+"rN" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/gunnery)
 "rO" = (
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/gunnery)
+"rP" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/wall/rshull,
+/area/ship/ert/med_surg)
 "rR" = (
 /obj/machinery/atmospherics/pipe/tank/phoron{
 	dir = 8
@@ -3168,6 +3508,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/ship/ert/eng_storage)
 "sX" = (
@@ -3235,6 +3580,11 @@
 "tK" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/machinery/door/window/brigdoor/northleft,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/hallways_aft)
 "tL" = (
@@ -3287,6 +3637,15 @@
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/airless,
 /area/ship/ert/gunnery)
+"uf" = (
+/obj/structure/sign/nosmoking_1,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/wall/rshull,
+/area/ship/ert/engine)
 "ug" = (
 /obj/item/device/healthanalyzer/advanced{
 	pixel_x = 2;
@@ -3357,6 +3716,11 @@
 "ux" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/engine)
 "uE" = (
@@ -3404,6 +3768,11 @@
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/engine)
@@ -3480,6 +3849,14 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/ship/ert/hallways_aft)
+"vw" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/wall/shull,
+/area/ship/ert/barracks)
 "vK" = (
 /turf/simulated/wall/rshull,
 /area/ship/ert/gunnery)
@@ -3560,6 +3937,10 @@
 /obj/machinery/power/pointdefense{
 	id_tag = "vonbraun_pd"
 	},
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/reinforced/airless,
 /area/ship/ert/hallways_aft)
 "wt" = (
@@ -3582,6 +3963,14 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/med)
+"wC" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled/white,
+/area/ship/ert/med_surg)
 "wG" = (
 /obj/structure/hull_corner/long_horiz{
 	dir = 5
@@ -3615,6 +4004,23 @@
 /obj/machinery/oxygen_pump/anesthetic,
 /turf/simulated/wall/shull,
 /area/ship/ert/med_surg)
+"xc" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/landmark{
+	name = "Commando"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/barracks)
 "xe" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -3842,6 +4248,16 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/eng_storage)
+"xD" = (
+/obj/effect/landmark/late_antag/ert,
+/obj/structure/table/bench/steel,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/barracks)
 "xG" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/machinery/alarm/alarms_hidden{
@@ -3893,6 +4309,11 @@
 "ya" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/ship/ert/hallways_aft)
 "yf" = (
@@ -3947,6 +4368,11 @@
 "yl" = (
 /obj/structure/ship_munition/disperser_charge/emp,
 /obj/effect/floor_decal/industrial/warning,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/reinforced,
 /area/ship/ert/hallways_aft)
 "yo" = (
@@ -4036,6 +4462,11 @@
 /obj/machinery/chemical_dispenser/biochemistry/full,
 /obj/machinery/light/no_nightshift,
 /obj/item/weapon/reagent_containers/glass/beaker/large,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/med)
 "yR" = (
@@ -4088,6 +4519,11 @@
 /obj/machinery/firealarm/alarms_hidden{
 	pixel_y = 26
 	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/white,
 /area/ship/ert/med_surg)
 "zc" = (
@@ -4118,6 +4554,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/engine)
 "zo" = (
@@ -4297,6 +4738,19 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/ship/ert/armoury_dl)
+"Az" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/wall/rshull,
+/area/ship/ert/engine)
 "AI" = (
 /obj/machinery/power/thermoregulator,
 /obj/effect/floor_decal/industrial/outline,
@@ -4316,6 +4770,22 @@
 /obj/item/modular_computer/console/preset/medical,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/bridge)
+"AW" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/wall/rshull,
+/area/ship/ert/engine)
+"AX" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/barracks)
 "AZ" = (
 /obj/machinery/alarm/alarms_hidden{
 	pixel_y = 26
@@ -4599,6 +5069,11 @@
 "CN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/engine)
 "CP" = (
@@ -4627,6 +5102,11 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/engine)
 "Dd" = (
@@ -4809,6 +5289,11 @@
 /obj/structure/sign/warning/engineering_access{
 	pixel_x = -32
 	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/ship/ert/hallways_aft)
 "Ee" = (
@@ -4983,6 +5468,14 @@
 /obj/effect/shuttle_landmark/premade/ert_ship_port,
 /turf/space,
 /area/space)
+"FG" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/wall/shull,
+/area/ship/ert/med_surg)
 "FJ" = (
 /obj/machinery/door/airlock/glass_command{
 	req_one_access = list(103)
@@ -5003,6 +5496,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/techmaint,
 /area/ship/ert/hallways)
+"FL" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/wall/rshull,
+/area/ship/ert/gunnery)
 "FM" = (
 /obj/effect/floor_decal/corner/yellow{
 	dir = 10
@@ -5260,11 +5761,24 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/eng_storage)
+"Gu" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/wall/rshull,
+/area/ship/ert/med_surg)
 "Gv" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
 /obj/machinery/door/window/brigdoor/southleft,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/hallways_aft)
 "Gw" = (
@@ -5527,6 +6041,11 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/engine)
 "Ii" = (
@@ -5852,6 +6371,11 @@
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/engine)
 "JZ" = (
@@ -5884,6 +6408,16 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/ship/ert/teleporter)
+"Kj" = (
+/obj/machinery/power/pointdefense{
+	id_tag = "vonbraun_pd"
+	},
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/ship/ert/engine)
 "Kk" = (
 /obj/effect/landmark/late_antag/ert,
 /obj/structure/table/bench/steel,
@@ -6008,12 +6542,43 @@
 /obj/structure/table/steel_reinforced,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/bridge)
+"KK" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/wall/rshull,
+/area/ship/ert/engine)
 "KM" = (
 /obj/structure/bed/chair/bay/chair/padded/blue{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/ship/ert/bridge)
+"KN" = (
+/obj/structure/closet/wardrobe/ert,
+/obj/item/modular_computer/tablet/preset/custom_loadout/elite,
+/obj/item/weapon/storage/box/survival/comp{
+	starts_with = list(/obj/item/weapon/tool/prybar/red,/obj/item/clothing/glasses/goggles,/obj/item/weapon/reagent_containers/hypospray/autoinjector,/obj/item/stack/medical/bruise_pack,/obj/item/device/flashlight/glowstick,/obj/item/weapon/reagent_containers/food/snacks/candy/proteinbar,/obj/item/clothing/mask/breath,/obj/item/weapon/tank/emergency/oxygen/engi)
+	},
+/obj/machinery/light/no_nightshift{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/item/modular_computer/laptop/preset/custom_loadout/elite,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/barracks)
 "KO" = (
 /obj/machinery/vending/tool,
 /obj/machinery/light/no_nightshift{
@@ -6186,6 +6751,11 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/white,
 /area/ship/ert/med_surg)
 "LC" = (
@@ -6227,6 +6797,14 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/ship/ert/med_surg)
+"LM" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/wall/rshull,
+/area/ship/ert/med)
 "LR" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/map_helper/airlock/door/ext_door,
@@ -6261,6 +6839,11 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/white,
 /area/ship/ert/med_surg)
@@ -6481,11 +7064,20 @@
 /obj/machinery/light/no_nightshift{
 	dir = 4
 	},
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
+	},
 /turf/simulated/floor/reinforced/airless,
 /area/ship/ert/engine)
 "Np" = (
 /obj/machinery/light/no_nightshift{
 	dir = 8
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/engine)
@@ -6527,6 +7119,21 @@
 	dir = 8
 	},
 /obj/effect/catwalk_plated/dark,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
 /area/ship/ert/engine)
 "NI" = (
@@ -6549,6 +7156,11 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/binary/pump/fuel/on,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/engine)
 "NR" = (
@@ -6631,6 +7243,11 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/engine)
 "Og" = (
@@ -6649,6 +7266,11 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/ship/ert/hallways_aft)
 "Oh" = (
@@ -6698,6 +7320,10 @@
 /obj/machinery/power/pointdefense{
 	id_tag = "vonbraun_pd"
 	},
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/reinforced/airless,
 /area/ship/ert/gunnery)
 "On" = (
@@ -6710,6 +7336,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/ship/ert/hallways_aft)
@@ -6742,6 +7373,25 @@
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
 /area/ship/ert/bridge)
+"OA" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/med)
 "OE" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -7001,6 +7651,14 @@
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/ship/ert/atmos)
+"Px" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/wall/shull,
+/area/ship/ert/mech_bay)
 "Py" = (
 /obj/machinery/light/no_nightshift{
 	dir = 1
@@ -7290,6 +7948,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/engine)
 "RO" = (
@@ -7486,6 +8149,11 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/yellow{
+	d2 = 4;
+	dir = 4;
+	icon_state = "0-4"
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/ship/ert/hallways_aft)
 "SB" = (
@@ -7494,6 +8162,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/white,
 /area/ship/ert/med_surg)
@@ -7623,6 +8296,11 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/fuel{
 	dir = 4
 	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/engine)
 "TB" = (
@@ -7637,6 +8315,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/engineering)
+"TD" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/wall/rshull,
+/area/ship/ert/gunnery)
 "TF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -7669,6 +8355,11 @@
 "TM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/ship/ert/hallways_aft)
 "TR" = (
@@ -7695,6 +8386,14 @@
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled/techmaint,
 /area/ship/ert/teleporter)
+"Ue" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/mech_bay)
 "Ul" = (
 /obj/machinery/firealarm/alarms_hidden{
 	dir = 1;
@@ -7758,6 +8457,24 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/ship/ert/teleporter)
+"UK" = (
+/obj/machinery/power/pointdefense{
+	id_tag = "vonbraun_pd"
+	},
+/obj/structure/cable/yellow,
+/turf/simulated/floor/reinforced/airless,
+/area/ship/ert/engine)
+"UN" = (
+/obj/machinery/power/pointdefense{
+	id_tag = "vonbraun_pd"
+	},
+/obj/structure/cable/yellow{
+	d2 = 4;
+	dir = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/ship/ert/med_surg)
 "UT" = (
 /obj/machinery/door/airlock/glass_security{
 	req_one_access = list(103)
@@ -7823,6 +8540,17 @@
 "Vq" = (
 /turf/simulated/floor/tiled/techmaint,
 /area/ship/ert/gunnery)
+"Vx" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 9
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/engine)
 "VC" = (
 /obj/machinery/power/port_gen/pacman/super/potato,
 /obj/structure/cable/green,
@@ -7830,6 +8558,14 @@
 /obj/effect/decal/cleanable/greenglow,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/engineering)
+"VH" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/wall/rshull,
+/area/ship/ert/mech_bay)
 "VJ" = (
 /obj/machinery/door/firedoor/multi_tile{
 	dir = 1
@@ -7927,6 +8663,14 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/med)
+"Wo" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/barracks)
 "Wq" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -7981,6 +8725,11 @@
 /obj/machinery/power/pointdefense{
 	id_tag = "vonbraun_pd"
 	},
+/obj/structure/cable/yellow{
+	d2 = 4;
+	dir = 4;
+	icon_state = "0-4"
+	},
 /turf/simulated/floor/reinforced/airless,
 /area/ship/ert/med)
 "WH" = (
@@ -8011,6 +8760,11 @@
 "WO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/engine)
 "WR" = (
@@ -8049,6 +8803,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/ship/ert/barracks)
+"WZ" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/wall/rshull,
+/area/ship/ert/engine)
 "Xg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/bed/chair/bay/chair/padded/blue{
@@ -8092,6 +8854,16 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/teleporter)
+"Xz" = (
+/obj/machinery/shield_capacitor,
+/obj/effect/floor_decal/industrial/outline/blue,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/eng_storage)
 "XB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/yellow{
@@ -8109,6 +8881,11 @@
 	dir = 1;
 	pixel_y = -26
 	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/engine)
 "XM" = (
@@ -8119,6 +8896,14 @@
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/dock_star)
+"XN" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/med)
 "XS" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -8153,6 +8938,14 @@
 "Ye" = (
 /turf/simulated/floor/reinforced/airless,
 /area/ship/ert/barracks)
+"Yf" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/wall/shull,
+/area/ship/ert/eng_storage)
 "Yk" = (
 /obj/structure/cable/yellow{
 	d2 = 2;
@@ -8222,6 +9015,25 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/bridge)
+"YC" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled/white,
+/area/ship/ert/med_surg)
 "YN" = (
 /obj/structure/sign/warning/radioactive{
 	desc = "WARNING: VON BRAUN PTTOS EMIT RADIATION WHILST OPERATIONAL.";
@@ -8309,6 +9121,11 @@
 	},
 /obj/machinery/light/no_nightshift,
 /obj/effect/floor_decal/industrial/outline,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/med)
 "ZI" = (
@@ -8324,6 +9141,10 @@
 "ZL" = (
 /obj/machinery/power/pointdefense{
 	id_tag = "vonbraun_pd"
+	},
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/ship/ert/engine)
@@ -8349,6 +9170,11 @@
 	},
 /obj/machinery/power/port_gen/pacman/mrs,
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/eng_storage)
 "ZW" = (
@@ -13292,7 +14118,7 @@ Do
 yz
 yz
 yz
-Hf
+AW
 yz
 yz
 yz
@@ -13425,7 +14251,7 @@ yz
 yz
 yz
 lZ
-ZL
+Kj
 kL
 yz
 yz
@@ -13434,7 +14260,7 @@ Hf
 nX
 DN
 JW
-Hf
+AW
 nX
 DN
 JW
@@ -13443,7 +14269,7 @@ yz
 yz
 yz
 lZ
-ZL
+Kj
 lZ
 yz
 yz
@@ -13567,7 +14393,7 @@ yz
 yz
 yz
 lZ
-Hf
+AW
 Hf
 nX
 DN
@@ -13576,7 +14402,7 @@ Hf
 uh
 et
 tL
-Hf
+AW
 uh
 et
 tL
@@ -13585,7 +14411,7 @@ nX
 DN
 JW
 Hf
-Hf
+AW
 lZ
 yz
 yz
@@ -13709,7 +14535,7 @@ yz
 yz
 yz
 Do
-Hf
+AW
 Hf
 uh
 et
@@ -13718,7 +14544,7 @@ Hf
 GI
 rA
 GI
-MK
+uf
 GI
 rA
 GI
@@ -13727,7 +14553,7 @@ uh
 et
 tL
 Hf
-Hf
+AW
 Do
 yz
 yz
@@ -13851,7 +14677,7 @@ yz
 yz
 yz
 aj
-Hf
+AW
 Hf
 GI
 rA
@@ -13869,7 +14695,7 @@ GI
 rA
 GI
 Hf
-Hf
+AW
 Ia
 yz
 yz
@@ -13993,8 +14819,8 @@ yz
 yz
 yz
 ZL
-Hf
-Hf
+Az
+WZ
 ok
 rD
 ux
@@ -14008,11 +14834,11 @@ Tx
 WO
 CZ
 Of
-RO
+Vx
 XH
-Hf
-Hf
-ZL
+WZ
+KK
+UK
 yz
 yz
 yz
@@ -15411,7 +16237,7 @@ yz
 yz
 yz
 wr
-DS
+kg
 yl
 tK
 Oq
@@ -15433,8 +16259,8 @@ ya
 kh
 Gv
 nY
-DS
-wr
+kg
+iu
 yz
 yz
 yz
@@ -17256,8 +18082,8 @@ yz
 yz
 yz
 ab
-Zo
-Bo
+nq
+vw
 ef
 iO
 mj
@@ -17278,9 +18104,9 @@ sS
 Zv
 xC
 sW
-PS
-zc
-XG
+Xz
+Yf
+go
 aV
 yz
 yz
@@ -17544,7 +18370,7 @@ Zo
 Gw
 Kk
 OU
-pg
+kl
 Kk
 lv
 ZM
@@ -17686,7 +18512,7 @@ yY
 lv
 Kk
 OU
-pg
+kl
 Kk
 sz
 ZM
@@ -17828,7 +18654,7 @@ yY
 lv
 Kk
 OU
-pg
+kl
 Kk
 lv
 ZM
@@ -18250,11 +19076,11 @@ yz
 yz
 yz
 ab
-Zo
-Gw
-Kk
-OU
-mF
+nq
+KN
+xD
+xc
+fp
 ip
 ip
 BW
@@ -18271,10 +19097,10 @@ BW
 Br
 Br
 Br
-eI
-Zv
+fr
+SG
 ZU
-XG
+go
 aV
 yz
 yz
@@ -18817,12 +19643,12 @@ yz
 yz
 yz
 ab
-Zo
+nq
 an
-WH
-WH
-Jd
-mF
+Wo
+Wo
+gl
+fp
 so
 tH
 LC
@@ -18839,11 +19665,11 @@ nb
 ZT
 Jc
 QT
-sU
-Pq
-Pq
+bS
+mO
+mO
 ZF
-ZT
+LM
 WF
 yz
 yz
@@ -19527,12 +20353,12 @@ yz
 yz
 yz
 ab
-Zo
+nq
 bI
-WH
-WH
-ip
-mV
+Wo
+Wo
+AX
+eG
 pd
 tH
 xt
@@ -19548,12 +20374,12 @@ On
 JZ
 ZT
 Wl
-DJ
-QT
-Pq
-Pq
+OA
+XN
+mO
+mO
 yJ
-ZT
+LM
 WF
 yz
 yz
@@ -20664,11 +21490,11 @@ yz
 yz
 yz
 ag
-bM
-Cx
+VH
+Px
 fx
-jQ
-np
+Ue
+Is
 pM
 Cx
 yj
@@ -20684,12 +21510,12 @@ WC
 dk
 dq
 gf
-TF
-ij
+YC
+mP
 hv
-dq
-MZ
-aC
+qa
+rP
+UN
 yz
 yz
 yz
@@ -21252,7 +22078,7 @@ WC
 Zx
 nl
 pb
-nq
+TF
 ij
 MC
 dq
@@ -21536,7 +22362,7 @@ WC
 Zx
 nl
 aQ
-nq
+TF
 ij
 aQ
 dq
@@ -21678,7 +22504,7 @@ WC
 Zx
 nl
 cO
-nq
+TF
 ij
 Mb
 dq
@@ -21800,9 +22626,9 @@ yz
 yz
 yz
 PO
-vK
-Cf
-rO
+TD
+rB
+rN
 av
 nB
 FP
@@ -21820,7 +22646,7 @@ WC
 Zx
 nl
 NJ
-nq
+TF
 ij
 NJ
 dq
@@ -21942,7 +22768,7 @@ yz
 yz
 yz
 nr
-vK
+FL
 vK
 gF
 rO
@@ -22084,7 +22910,7 @@ yz
 yz
 yz
 PO
-vK
+FL
 vK
 gW
 TG
@@ -22104,7 +22930,7 @@ WC
 aK
 Sh
 ij
-nq
+TF
 ij
 ij
 dq
@@ -22226,7 +23052,7 @@ yz
 yz
 yz
 PO
-vK
+FL
 vK
 hj
 db
@@ -22368,7 +23194,7 @@ yz
 yz
 yz
 Om
-vK
+if
 rM
 hk
 eO
@@ -22389,11 +23215,11 @@ Ff
 dq
 vb
 iW
-LJ
-vb
-dq
-MZ
-aC
+rn
+ca
+qa
+rP
+UN
 yz
 yz
 yz
@@ -22529,8 +23355,8 @@ CH
 CH
 yX
 MZ
-dq
-ij
+ky
+wC
 ij
 dq
 MZ
@@ -22671,7 +23497,7 @@ za
 za
 ib
 MZ
-dq
+FG
 jv
 ij
 dq
@@ -22813,7 +23639,7 @@ yz
 yz
 yz
 MZ
-MZ
+Gu
 GY
 GY
 MZ
@@ -22955,7 +23781,7 @@ yz
 yz
 yz
 MZ
-MZ
+Gu
 MZ
 MZ
 MZ
@@ -23097,7 +23923,7 @@ yz
 yz
 yz
 Cr
-MZ
+Gu
 MZ
 MZ
 YO
@@ -23239,7 +24065,7 @@ yz
 yz
 yz
 CR
-MZ
+Gu
 MZ
 YO
 yz
@@ -23381,7 +24207,7 @@ yz
 yz
 yz
 ci
-MZ
+Gu
 YO
 yz
 yz

--- a/maps/submaps/admin_use_vr/kk_mercship.dmm
+++ b/maps/submaps/admin_use_vr/kk_mercship.dmm
@@ -599,6 +599,10 @@
 /obj/machinery/power/pointdefense{
 	id_tag = "mercenary_pd"
 	},
+/obj/structure/cable/orange{
+	d2 = 2;
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/reinforced/airless,
 /area/ship/manta/armoury_st)
 "bI" = (
@@ -862,6 +866,10 @@
 /obj/machinery/power/pointdefense{
 	id_tag = "mercenary_pd"
 	},
+/obj/structure/cable/orange{
+	d2 = 2;
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/reinforced/airless,
 /area/ship/manta/med)
 "cK" = (
@@ -881,6 +889,11 @@
 /obj/structure/bed,
 /obj/effect/floor_decal/rust,
 /obj/effect/floor_decal/techfloor,
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/manta/holding)
 "cP" = (
@@ -952,6 +965,17 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/manta/armoury_st)
+"cR" = (
+/obj/effect/floor_decal/techfloor/corner{
+	dir = 5
+	},
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/white,
+/area/ship/manta/med)
 "cS" = (
 /obj/structure/hull_corner/long_horiz{
 	dir = 6
@@ -977,6 +1001,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/techfloor/corner{
 	dir = 5
+	},
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/manta/recreation)
@@ -1086,6 +1115,14 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/manta/bridge)
+"dy" = (
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/wall/rshull,
+/area/ship/manta/hallways_port)
 "dC" = (
 /obj/structure/cable/orange{
 	d1 = 2;
@@ -1122,8 +1159,27 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/manta/recreation)
+"dK" = (
+/obj/structure/toilet{
+	dir = 1
+	},
+/obj/effect/floor_decal/techfloor{
+	dir = 6
+	},
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/ship/manta/holding)
 "dM" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 8
@@ -1165,6 +1221,11 @@
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/airlock/glass_external,
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/manta/gunnery)
 "dX" = (
@@ -1198,6 +1259,11 @@
 	},
 /obj/effect/floor_decal/techfloor/corner{
 	dir = 10
+	},
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/manta/holding)
@@ -1304,6 +1370,11 @@
 	dir = 5
 	},
 /obj/item/weapon/reagent_containers/glass/beaker/large,
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/white,
 /area/ship/manta/med)
 "eG" = (
@@ -1325,6 +1396,11 @@
 /obj/item/weapon/rig/merc/empty,
 /obj/effect/floor_decal/techfloor{
 	dir = 9
+	},
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/manta/armoury_st)
@@ -1500,6 +1576,13 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/manta/hangar)
+"fM" = (
+/obj/machinery/power/pointdefense{
+	id_tag = "mercenary_pd"
+	},
+/obj/structure/cable/orange,
+/turf/simulated/floor/reinforced/airless,
+/area/ship/manta/magazine)
 "fN" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 8
@@ -1652,6 +1735,11 @@
 /obj/structure/catwalk,
 /obj/structure/railing{
 	dir = 8
+	},
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/ship/manta/engine)
@@ -1862,6 +1950,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/manta/recreation)
 "hx" = (
@@ -1933,6 +2026,11 @@
 /obj/effect/floor_decal/techfloor/corner{
 	dir = 10
 	},
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/manta/holding)
 "hS" = (
@@ -1990,6 +2088,11 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/manta/holding)
 "ia" = (
@@ -2243,6 +2346,11 @@
 /obj/effect/floor_decal/techfloor/corner{
 	dir = 1
 	},
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/manta/armoury_st)
 "iS" = (
@@ -2297,6 +2405,28 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/manta/hangar)
+"ja" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/grille,
+/obj/structure/window/plastitanium/full,
+/obj/structure/window/plastitanium{
+	dir = 8
+	},
+/obj/structure/window/plastitanium{
+	dir = 4
+	},
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/ship/manta/gunnery)
 "jc" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
@@ -2375,6 +2505,14 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/manta/recreation)
+"jt" = (
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/wall/shull,
+/area/ship/manta/med)
 "jv" = (
 /obj/structure/cable/orange{
 	d1 = 1;
@@ -2534,6 +2672,11 @@
 /area/ship/manta/med)
 "ki" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/white,
 /area/ship/manta/med)
 "kl" = (
@@ -2713,6 +2856,14 @@
 /obj/effect/floor_decal/techfloor,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/manta/dock_port)
+"lh" = (
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/wall/rshull,
+/area/ship/manta/mech_bay)
 "li" = (
 /obj/structure/cable/orange{
 	d1 = 4;
@@ -2749,6 +2900,14 @@
 /obj/item/ammo_magazine/m10mm,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/manta/armoury_st)
+"lk" = (
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/manta/armoury_st)
 "lm" = (
 /turf/simulated/wall/rshull,
 /area/ship/manta/recreation)
@@ -2780,6 +2939,16 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/effect/catwalk_plated/dark,
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/plating,
 /area/ship/manta/engine)
 "lz" = (
@@ -3014,6 +3183,11 @@
 	dir = 9
 	},
 /obj/item/mecha_parts/mecha_equipment/cloak,
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/manta/mech_bay)
 "ms" = (
@@ -3066,6 +3240,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
+	},
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/white,
 /area/ship/manta/med)
@@ -3131,6 +3310,11 @@
 /area/ship/manta/med)
 "na" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/manta/mech_bay)
 "nf" = (
@@ -3234,6 +3418,11 @@
 /obj/effect/floor_decal/techfloor{
 	dir = 1
 	},
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/tiled/white,
 /area/ship/manta/med)
 "nz" = (
@@ -3258,6 +3447,14 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/manta/armoury_st)
+"nG" = (
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/wall/rshull,
+/area/ship/manta/med)
 "nH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /obj/effect/floor_decal/industrial/warning,
@@ -3266,6 +3463,10 @@
 "nJ" = (
 /obj/machinery/power/pointdefense{
 	id_tag = "mercenary_pd"
+	},
+/obj/structure/cable/orange{
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/ship/manta/gunnery)
@@ -3315,6 +3516,11 @@
 	},
 /obj/effect/floor_decal/techfloor/corner{
 	dir = 9
+	},
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/manta/holding)
@@ -3369,6 +3575,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/ship/manta/hallways_port)
+"oh" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 1
+	},
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/manta/armoury_st)
 "oi" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 1
@@ -3425,6 +3642,11 @@
 "ot" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
+	},
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/manta/mech_bay)
@@ -3575,6 +3797,11 @@
 /obj/machinery/mech_recharger,
 /obj/mecha/combat/gygax/dark{
 	desc = "A lightweight combat exosuit, based off the standard Gygax chassis but no doubt thoroughly customized and upgraded."
+	},
+/obj/structure/cable/orange{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/manta/mech_bay)
@@ -3833,6 +4060,11 @@
 /obj/effect/floor_decal/techfloor/corner{
 	dir = 6
 	},
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/white,
 /area/ship/manta/med)
 "qB" = (
@@ -3857,6 +4089,10 @@
 "qI" = (
 /obj/machinery/power/pointdefense{
 	id_tag = "mercenary_pd"
+	},
+/obj/structure/cable/orange{
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/ship/manta/dock_star)
@@ -3913,6 +4149,10 @@
 /obj/machinery/power/pointdefense{
 	id_tag = "mercenary_pd"
 	},
+/obj/structure/cable/orange{
+	d2 = 8;
+	icon_state = "0-8"
+	},
 /turf/simulated/floor/reinforced/airless,
 /area/ship/manta/magazine)
 "qR" = (
@@ -3954,6 +4194,11 @@
 /obj/effect/floor_decal/techfloor/corner{
 	dir = 6
 	},
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/white,
 /area/ship/manta/med)
 "rl" = (
@@ -3976,6 +4221,10 @@
 "rp" = (
 /obj/machinery/power/pointdefense{
 	id_tag = "mercenary_pd"
+	},
+/obj/structure/cable/orange{
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/ship/manta/mech_bay)
@@ -4142,6 +4391,14 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/manta/armoury_st)
+"sl" = (
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/ship/manta/magazine)
 "sn" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 8
@@ -4236,6 +4493,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/white,
 /area/ship/manta/med)
 "sM" = (
@@ -4253,6 +4515,14 @@
 "sN" = (
 /turf/simulated/wall/shull,
 /area/ship/manta/bridge)
+"sR" = (
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/wall/rshull,
+/area/ship/manta/holding)
 "sS" = (
 /obj/structure/cable/orange{
 	d1 = 4;
@@ -4316,6 +4586,11 @@
 	},
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 8
+	},
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/manta/gunnery)
@@ -4448,6 +4723,10 @@
 "tR" = (
 /obj/machinery/power/pointdefense{
 	id_tag = "mercenary_pd"
+	},
+/obj/structure/cable/orange{
+	d2 = 8;
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/ship/manta/dock_port)
@@ -4635,6 +4914,11 @@
 /obj/effect/floor_decal/techfloor/corner{
 	dir = 5
 	},
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/manta/hallways_star)
 "uN" = (
@@ -4710,6 +4994,11 @@
 /obj/effect/floor_decal/techfloor{
 	dir = 5
 	},
+/obj/structure/cable/orange{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/manta/hallways_star)
 "uY" = (
@@ -4744,6 +5033,21 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/manta/engineering)
+"vr" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/catwalk,
+/obj/structure/cable/orange{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/plating,
+/area/ship/manta/engine)
 "vt" = (
 /obj/effect/floor_decal/techfloor/corner{
 	dir = 6
@@ -4758,6 +5062,11 @@
 	dir = 1
 	},
 /obj/machinery/meter,
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/manta/gunnery)
 "vu" = (
@@ -4786,6 +5095,11 @@
 /obj/structure/cable/orange,
 /obj/machinery/light/small{
 	dir = 8
+	},
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating,
 /area/ship/manta/dock_port)
@@ -4892,6 +5206,19 @@
 	},
 /turf/simulated/floor/plating,
 /area/ship/manta/engine)
+"vT" = (
+/obj/machinery/door/window/brigdoor/northleft{
+	req_access = list(150);
+	req_one_access = list(150)
+	},
+/obj/machinery/door/firedoor/glass,
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/ship/manta/holding)
 "vU" = (
 /obj/structure/cable/orange{
 	d1 = 2;
@@ -4909,6 +5236,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
+	},
+/obj/structure/cable/orange{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/manta/hallways_port)
@@ -4993,6 +5325,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/manta/armoury_st)
@@ -5155,6 +5492,11 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
+	},
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/manta/armoury_st)
@@ -5461,6 +5803,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/manta/hallways_star)
 "xQ" = (
@@ -5588,6 +5935,11 @@
 /turf/simulated/floor/reinforced/airless,
 /area/ship/manta/dock_star)
 "yo" = (
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/reinforced/airless,
 /area/ship/manta/dock_port)
 "yp" = (
@@ -5673,6 +6025,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/manta/hallways_star)
 "yw" = (
@@ -5691,6 +6048,11 @@
 "yy" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
+	},
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/ship/manta/engine)
@@ -5772,6 +6134,11 @@
 /obj/effect/floor_decal/techfloor{
 	dir = 1
 	},
+/obj/structure/cable/orange{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/manta/holding)
 "yT" = (
@@ -5794,6 +6161,11 @@
 /obj/effect/floor_decal/rust,
 /obj/effect/floor_decal/techfloor{
 	dir = 5
+	},
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/manta/holding)
@@ -5907,6 +6279,11 @@
 /obj/effect/floor_decal/techfloor{
 	dir = 10
 	},
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/manta/mech_bay)
 "zv" = (
@@ -5931,6 +6308,10 @@
 "zw" = (
 /obj/machinery/power/pointdefense{
 	id_tag = "mercenary_pd"
+	},
+/obj/structure/cable/orange{
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/ship/manta/recreation)
@@ -6079,6 +6460,15 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/manta/bridge)
+"zV" = (
+/obj/machinery/flasher,
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/ship/manta/holding)
 "zX" = (
 /obj/structure/bed/chair/bay/shuttle{
 	dir = 8
@@ -6091,6 +6481,11 @@
 /obj/machinery/light_switch{
 	dir = 8;
 	pixel_x = 23
+	},
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/ship/manta/holding)
@@ -6223,6 +6618,21 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/manta_ship_boat)
+"AI" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/fuel{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/catwalk,
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/ship/manta/engine)
 "AJ" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 4
@@ -6285,6 +6695,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/cable/orange{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/manta/holding)
 "AX" = (
@@ -6297,12 +6712,25 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/manta/barracks)
+"AZ" = (
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/wall/rshull,
+/area/ship/manta/dock_star)
 "Bi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
+	},
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/manta/gunnery)
@@ -6354,6 +6782,14 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/manta/barracks)
+"Bz" = (
+/obj/structure/cable/orange{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/wall/rshull,
+/area/ship/manta/dock_star)
 "BJ" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 8
@@ -6430,6 +6866,11 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/plating,
 /area/ship/manta/dock_star)
 "Cp" = (
@@ -6499,6 +6940,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/manta/mech_bay)
@@ -6801,6 +7247,11 @@
 	dir = 9
 	},
 /obj/structure/catwalk,
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
 /area/ship/manta/magazine)
 "DR" = (
@@ -6856,6 +7307,14 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/manta_ship_boat)
+"Ed" = (
+/obj/structure/cable/orange{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/wall/rshull,
+/area/ship/manta/dock_port)
 "Eg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 6
@@ -6938,6 +7397,16 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
+	},
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/manta/hallways_port)
@@ -7046,6 +7515,15 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/manta/dock_star)
+"EU" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/manta/armoury_st)
 "EY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -7166,6 +7644,17 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/manta/armoury_as)
+"Fy" = (
+/obj/effect/floor_decal/techfloor/corner{
+	dir = 10
+	},
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/manta/recreation)
 "FB" = (
 /obj/structure/cable/orange{
 	d1 = 1;
@@ -7179,6 +7668,17 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/ship/manta/magazine)
+"FE" = (
+/obj/effect/floor_decal/techfloor/corner{
+	dir = 5
+	},
+/obj/structure/cable/orange{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled/white,
+/area/ship/manta/med)
 "FH" = (
 /obj/structure/cable/orange{
 	d1 = 1;
@@ -7243,6 +7743,7 @@
 /obj/machinery/power/pointdefense{
 	id_tag = "mercenary_pd"
 	},
+/obj/structure/cable/orange,
 /turf/simulated/floor/reinforced/airless,
 /area/ship/manta/engine)
 "Gd" = (
@@ -7380,6 +7881,11 @@
 	req_one_access = list(150)
 	},
 /obj/machinery/door/firedoor/glass,
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/manta/holding)
 "GS" = (
@@ -7862,6 +8368,11 @@
 /obj/effect/floor_decal/techfloor{
 	dir = 10
 	},
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/manta/recreation)
 "Js" = (
@@ -7992,6 +8503,11 @@
 	},
 /obj/effect/floor_decal/techfloor/corner{
 	dir = 6
+	},
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/manta/gunnery)
@@ -8129,6 +8645,17 @@
 /obj/item/clothing/accessory/storage/pouches/large/green,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/manta/barracks)
+"KC" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/ship/manta/magazine)
 "KE" = (
 /obj/machinery/door/window/brigdoor/eastright{
 	req_access = list();
@@ -8169,6 +8696,10 @@
 "KK" = (
 /obj/machinery/power/pointdefense{
 	id_tag = "mercenary_pd"
+	},
+/obj/structure/cable/orange{
+	d2 = 8;
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/ship/manta/holding)
@@ -8312,6 +8843,21 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/manta/holding)
+"Ls" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/catwalk,
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/ship/manta/engine)
 "Lt" = (
 /obj/machinery/computer/teleporter{
 	dir = 2
@@ -8347,6 +8893,11 @@
 "LI" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
+	},
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/ship/manta/engine)
@@ -8387,6 +8938,14 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/manta/hangar)
+"LR" = (
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/ship/manta/gunnery)
 "LS" = (
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 4
@@ -8420,6 +8979,11 @@
 	},
 /obj/effect/floor_decal/techfloor/corner{
 	dir = 10
+	},
+/obj/structure/cable/orange{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/manta/holding)
@@ -8455,6 +9019,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/ship/manta/hallways_star)
+"Me" = (
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/wall/rshull,
+/area/ship/manta/magazine)
 "Mf" = (
 /obj/structure/cable/orange{
 	d1 = 1;
@@ -8491,6 +9063,11 @@
 "Mk" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
+	},
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/manta/holding)
@@ -8571,6 +9148,11 @@
 /obj/effect/floor_decal/techfloor/corner{
 	dir = 9
 	},
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/manta/holding)
 "Mz" = (
@@ -8585,6 +9167,11 @@
 /obj/effect/floor_decal/techfloor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/manta/holding)
@@ -9062,6 +9649,14 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/manta/holding)
+"ON" = (
+/obj/structure/cable/orange{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/wall/rshull,
+/area/ship/manta/magazine)
 "OO" = (
 /obj/structure/sign/warning/radioactive,
 /turf/simulated/wall/rshull,
@@ -9209,6 +9804,14 @@
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/tiled/dark,
 /area/ship/manta/holding)
+"PI" = (
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/ship/manta/dock_star)
 "PJ" = (
 /obj/machinery/vending/fitness{
 	prices = list()
@@ -9241,6 +9844,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/manta/holding)
 "PP" = (
@@ -9271,6 +9879,11 @@
 	},
 /obj/effect/floor_decal/techfloor{
 	dir = 4
+	},
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/manta/mech_bay)
@@ -9371,6 +9984,11 @@
 	icon_state = "1-8"
 	},
 /obj/structure/catwalk,
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
 /area/ship/manta/engine)
 "Qx" = (
@@ -9492,6 +10110,11 @@
 	},
 /obj/effect/floor_decal/techfloor{
 	dir = 9
+	},
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/manta/gunnery)
@@ -9659,6 +10282,11 @@
 /obj/effect/floor_decal/techfloor{
 	dir = 1
 	},
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/manta/mech_bay)
 "RU" = (
@@ -9699,6 +10327,14 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/manta/armoury_st)
+"RV" = (
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/wall/rshull,
+/area/ship/manta/gunnery)
 "RY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -9795,6 +10431,16 @@
 	},
 /turf/simulated/floor/wood,
 /area/ship/manta/barracks)
+"Sr" = (
+/obj/machinery/power/pointdefense{
+	id_tag = "mercenary_pd"
+	},
+/obj/structure/cable/orange{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/ship/manta/gunnery)
 "Ss" = (
 /obj/machinery/door/airlock/multi_tile/glass{
 	req_one_access = list(150)
@@ -9818,6 +10464,14 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/manta/armoury_st)
+"SB" = (
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/wall/rshull,
+/area/ship/manta/magazine)
 "SF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/industrial/warning{
@@ -9858,6 +10512,14 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/manta/mech_bay)
+"SP" = (
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/wall/rshull,
+/area/ship/manta/holding)
 "SV" = (
 /obj/structure/cable/orange{
 	d1 = 2;
@@ -10016,6 +10678,11 @@
 	dir = 4
 	},
 /obj/structure/catwalk,
+/obj/structure/cable/orange{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/plating,
 /area/ship/manta/engine)
 "Tp" = (
@@ -10034,6 +10701,19 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/manta/hallways_port)
+"Tr" = (
+/obj/structure/cable/orange{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/wall/rshull,
+/area/ship/manta/magazine)
 "Tu" = (
 /obj/structure/hull_corner/long_vert{
 	dir = 9
@@ -10091,6 +10771,15 @@
 	},
 /turf/simulated/floor/wood,
 /area/ship/manta/barracks/bed_2)
+"TC" = (
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/manta/armoury_st)
 "TD" = (
 /obj/machinery/light/small,
 /obj/effect/floor_decal/industrial/outline,
@@ -10175,6 +10864,16 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
+/obj/structure/cable/orange{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/manta/mech_bay)
 "TY" = (
@@ -10195,6 +10894,11 @@
 	},
 /obj/effect/floor_decal/techfloor/corner{
 	dir = 9
+	},
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/manta/holding)
@@ -10312,6 +11016,11 @@
 /obj/effect/floor_decal/techfloor{
 	dir = 8
 	},
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/manta/gunnery)
 "UM" = (
@@ -10335,6 +11044,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/manta/holding)
 "UQ" = (
@@ -10616,6 +11330,14 @@
 /obj/structure/table/steel_reinforced,
 /turf/simulated/floor/tiled/dark,
 /area/ship/manta/holding)
+"VO" = (
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/wall/rshull,
+/area/ship/manta/engine)
 "VP" = (
 /obj/structure/cable/orange{
 	d1 = 4;
@@ -10848,6 +11570,14 @@
 	},
 /turf/simulated/floor/wood,
 /area/ship/manta/barracks/bed_1)
+"Xn" = (
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/wall/rshull,
+/area/ship/manta/armoury_st)
 "Xo" = (
 /obj/structure/cable/orange{
 	d1 = 4;
@@ -10993,8 +11723,25 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/manta/engineering)
+"XL" = (
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/wall/rshull,
+/area/ship/manta/gunnery)
 "XO" = (
 /turf/simulated/floor/reinforced/airless,
+/area/ship/manta/magazine)
+"XP" = (
+/obj/structure/catwalk,
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
 /area/ship/manta/magazine)
 "XQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -11059,6 +11806,10 @@
 /obj/machinery/power/pointdefense{
 	id_tag = "mercenary_pd"
 	},
+/obj/structure/cable/orange{
+	d2 = 2;
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/reinforced/airless,
 /area/ship/manta/hallways_port)
 "Yd" = (
@@ -11098,6 +11849,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
+	},
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/manta/recreation)
@@ -11167,6 +11923,14 @@
 /obj/structure/table/steel,
 /turf/simulated/floor/tiled/dark,
 /area/ship/manta/holding)
+"Ys" = (
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/wall/rshull,
+/area/ship/manta/dock_port)
 "YA" = (
 /obj/structure/bed/chair/bay/comfy/red,
 /obj/structure/cable/orange{
@@ -11327,8 +12091,26 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/orange{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/manta/holding)
+"Zk" = (
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/wall/rshull,
+/area/ship/manta/recreation)
 "Zn" = (
 /obj/structure/table/rack,
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack/grenade/frag,
@@ -11362,6 +12144,17 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/manta/holding)
+"Zw" = (
+/obj/effect/floor_decal/techfloor/corner{
+	dir = 10
+	},
+/obj/structure/cable/orange{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/manta/mech_bay)
 "Zy" = (
 /turf/simulated/wall/shull,
 /area/ship/manta/dock_port)
@@ -11378,6 +12171,11 @@
 	dir = 4
 	},
 /obj/structure/catwalk,
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
 /area/ship/manta/magazine)
 "ZB" = (
@@ -11388,6 +12186,11 @@
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
+	},
+/obj/structure/cable/orange{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/manta/holding)
@@ -17364,7 +18167,7 @@ yz
 yz
 yz
 Hr
-nJ
+Sr
 Hr
 Hr
 rT
@@ -17506,20 +18309,20 @@ yz
 yz
 rT
 CF
-CF
+RV
 CF
 CF
 CF
 CF
 KY
 Hr
-nJ
+Sr
 DS
 lm
 lm
 lm
 lm
-lm
+Zk
 lm
 fZ
 yz
@@ -17648,14 +18451,14 @@ yz
 Hr
 Hr
 Zb
-Hr
+LR
 yY
 qB
 Hg
 CF
 CF
 CF
-CF
+RV
 CF
 lm
 RF
@@ -17788,9 +18591,9 @@ yz
 yz
 yz
 nJ
-CF
-CF
-Ac
+XL
+XL
+ja
 Ac
 CF
 xM
@@ -17803,7 +18606,7 @@ lm
 KH
 gh
 gh
-gf
+Fy
 Db
 lm
 lm
@@ -18354,9 +19157,9 @@ yz
 yz
 yz
 Yc
-ht
-ht
-ht
+dy
+dy
+dy
 tj
 Ex
 vI
@@ -18946,7 +19749,7 @@ Rj
 jB
 oS
 lm
-PW
+lh
 PW
 rm
 Vk
@@ -19088,7 +19891,7 @@ iu
 jB
 kG
 lm
-PW
+lh
 PW
 PW
 PW
@@ -19204,12 +20007,12 @@ yz
 yz
 yz
 bG
-ZT
-ZT
-ZT
-ZT
-ZT
-ic
+Xn
+Xn
+Xn
+Xn
+Xn
+oh
 wc
 ZT
 ZT
@@ -19234,7 +20037,7 @@ mp
 ou
 rs
 PW
-PW
+lh
 PW
 Vk
 rm
@@ -19518,7 +20321,7 @@ oT
 na
 TT
 ot
-ZS
+Zw
 Oq
 Zn
 PW
@@ -19954,8 +20757,8 @@ Zy
 KI
 Xu
 nL
-WF
-WF
+Ed
+Ys
 yo
 yz
 yz
@@ -20196,14 +20999,14 @@ yz
 yz
 yz
 bG
-ZT
-ZT
+Xn
+Xn
 eJ
 iR
-bR
-bR
-sa
-tG
+lk
+lk
+TC
+EU
 wC
 zC
 zC
@@ -21232,16 +22035,16 @@ Ni
 LU
 Tn
 yy
-XE
-XE
-XE
-XE
-XE
-XE
-XE
-XE
-XE
-XE
+VO
+VO
+VO
+VO
+VO
+VO
+VO
+VO
+VO
+VO
 FZ
 yz
 yz
@@ -21372,7 +22175,7 @@ ZU
 ZU
 YB
 Hh
-lV
+AI
 vJ
 nH
 xT
@@ -21656,7 +22459,7 @@ sg
 NJ
 Ok
 fz
-lV
+AI
 RY
 nH
 xT
@@ -21798,7 +22601,7 @@ zR
 zR
 iv
 zf
-yu
+Ls
 xt
 Sl
 Sa
@@ -21940,18 +22743,18 @@ XH
 vD
 Hh
 zf
-yu
+vr
 LI
-XE
-XE
-XE
-XE
-XE
-XE
-XE
-XE
-XE
-XE
+VO
+VO
+VO
+VO
+VO
+VO
+VO
+VO
+VO
+VO
 FZ
 yz
 yz
@@ -22894,9 +23697,9 @@ yz
 yz
 yz
 cI
-dl
+nG
 eF
-fU
+cR
 ki
 mG
 qA
@@ -23220,9 +24023,9 @@ rJ
 YZ
 Ky
 XS
-PK
-PK
-Ly
+Bz
+AZ
+PI
 yz
 yz
 yz
@@ -23634,7 +24437,7 @@ VW
 EA
 xE
 XY
-XY
+XP
 hu
 rY
 rY
@@ -23750,7 +24553,7 @@ yz
 cr
 dl
 kF
-fU
+FE
 rb
 sY
 uS
@@ -23776,7 +24579,7 @@ VW
 EA
 bu
 bu
-bu
+KC
 QO
 QO
 QO
@@ -23890,8 +24693,8 @@ yz
 yz
 yz
 cI
-dl
-dl
+nG
+nG
 ny
 rl
 rM
@@ -23918,7 +24721,7 @@ VW
 EA
 nq
 dg
-nq
+sl
 QO
 QO
 QO
@@ -24058,11 +24861,11 @@ iW
 NQ
 VW
 EA
-QO
-QO
-QO
-QO
-qQ
+ON
+SB
+Tr
+SB
+fM
 XO
 yz
 yz
@@ -24200,7 +25003,7 @@ NQ
 NQ
 VW
 EA
-QO
+Me
 QO
 sV
 XO
@@ -24463,7 +25266,7 @@ dI
 dl
 rM
 rM
-ch
+SP
 ch
 ch
 ch
@@ -24605,7 +25408,7 @@ cr
 dl
 rM
 rM
-ch
+SP
 yx
 fN
 FL
@@ -24744,10 +25547,10 @@ yz
 yz
 yz
 cI
-dl
-dl
-rM
-ch
+nG
+nG
+jt
+sR
 yD
 BQ
 FR
@@ -25317,7 +26120,7 @@ rR
 ch
 ch
 yR
-BQ
+zV
 GN
 ME
 Pb
@@ -25327,8 +26130,8 @@ zX
 OK
 Pb
 AV
-Yo
-BQ
+vT
+zV
 cM
 ch
 ch
@@ -25465,13 +26268,13 @@ MY
 ch
 ch
 ch
-ch
+SP
 ch
 ch
 Yq
 GE
 BY
-OL
+dK
 ch
 ch
 pn
@@ -25600,7 +26403,7 @@ yz
 yz
 sZ
 ch
-ch
+SP
 ch
 ch
 ch
@@ -25613,7 +26416,7 @@ ch
 ch
 ch
 ch
-ch
+SP
 ch
 pn
 yz


### PR DESCRIPTION
Wires the Von Braun and Typhon's point defense turrets into the grid, as they should be.

The reactors need to be fuelled and putting out power or the turrets will brownout and fail to fire (but at least they shouldn't kill the Timer SS and MC by proxy).