### PR TITLE
Decreases notification timing for transcore, allows delaying

### DIFF
--- a/code/controllers/subsystems/transcore_vr.dm
+++ b/code/controllers/subsystems/transcore_vr.dm
@@ -15,7 +15,7 @@ SUBSYSTEM_DEF(transcore)
 	init_order = INIT_ORDER_TRANSCORE
 
 	// THINGS
-	var/overdue_time = 5 MINUTES
+	var/overdue_time = 6 MINUTES			// Has to be a multiple of wait var, or else will just round up anyway.
 
 	var/current_step = SSTRANSCORE_IMPLANTS
 
@@ -116,8 +116,6 @@ SUBSYSTEM_DEF(transcore)
 				if(curr_MR.do_notify)
 					db.notify(curr_MR.mindname)
 					curr_MR.last_notification = world.time
-				else
-					curr_MR.last_notification = world.time - 5 MINUTES
 			curr_MR.dead_state = MR_DEAD
 
 		if(MC_TICK_CHECK)

--- a/code/controllers/subsystems/transcore_vr.dm
+++ b/code/controllers/subsystems/transcore_vr.dm
@@ -15,7 +15,7 @@ SUBSYSTEM_DEF(transcore)
 	init_order = INIT_ORDER_TRANSCORE
 
 	// THINGS
-	var/overdue_time = 15 MINUTES
+	var/overdue_time = 5 MINUTES
 
 	var/current_step = SSTRANSCORE_IMPLANTS
 
@@ -113,8 +113,11 @@ SUBSYSTEM_DEF(transcore)
 			curr_MR.dead_state = MR_NORMAL
 		else
 			if(curr_MR.dead_state != MR_DEAD) //First time switching to dead
-				db.notify(curr_MR.mindname)
-				curr_MR.last_notification = world.time
+				if(curr_MR.do_notify)
+					db.notify(curr_MR.mindname)
+					curr_MR.last_notification = world.time
+				else
+					curr_MR.last_notification = world.time - 5 MINUTES
 			curr_MR.dead_state = MR_DEAD
 
 		if(MC_TICK_CHECK)
@@ -250,12 +253,9 @@ SUBSYSTEM_DEF(transcore)
 	return 1
 
 // Send a past-due notification to the medical radio channel.
-/datum/transcore_db/proc/notify(var/name, var/repeated = FALSE)
+/datum/transcore_db/proc/notify(var/name)
 	ASSERT(name)
-	if(repeated)
-		global_announcer.autosay("This is a repeat notification that [name] is past-due for a mind backup.", "TransCore Oversight", "Medical")
-	else
-		global_announcer.autosay("[name] is past-due for a mind backup.", "TransCore Oversight", "Medical")
+	global_announcer.autosay("[name] is past-due for a mind backup.", "TransCore Oversight", "Medical")
 
 // Called from mind_record to add itself to the transcore.
 /datum/transcore_db/proc/add_backup(var/datum/transhuman/mind_record/MR)

--- a/code/modules/mob/dead/observer/observer_vr.dm
+++ b/code/modules/mob/dead/observer/observer_vr.dm
@@ -81,7 +81,7 @@
 
 /mob/observer/dead/verb/backup_delay()
 	set category = "Ghost"
-	set name = "Delay Transcore Notification"
+	set name = "Cancel Transcore Notification"
 	set desc = "You can use this to avoid automatic backup notification happening. Manual notification can still be used."
 
 	if(!mind)

--- a/code/modules/mob/dead/observer/observer_vr.dm
+++ b/code/modules/mob/dead/observer/observer_vr.dm
@@ -70,12 +70,31 @@
 		var/datum/transhuman/mind_record/record = db.backed_up[src.mind.name]
 		if(!(record.dead_state == MR_DEAD))
 			to_chat(src, "<span class='warning'>Your backup is not past-due yet.</span>")
-		else if((world.time - record.last_notification) < 10 MINUTES)
+		else if((world.time - record.last_notification) < 5 MINUTES)
 			to_chat(src, "<span class='warning'>Too little time has passed since your last notification.</span>")
 		else
-			db.notify(record.mindname, TRUE)
+			db.notify(record.mindname)
 			record.last_notification = world.time
 			to_chat(src, "<span class='notice'>New notification has been sent.</span>")
+	else
+		to_chat(src,"<span class='warning'>No backup record could be found, sorry.</span>")
+
+/mob/observer/dead/verb/backup_delay()
+	set category = "Ghost"
+	set name = "Delay Transcore Notification"
+	set desc = "You can use this to avoid automatic backup notification happening. Manual notification can still be used."
+
+	if(!mind)
+		to_chat(src,"<span class='warning'>Your ghost is missing game values that allow this functionality, sorry.</span>")
+		return
+	var/datum/transcore_db/db = SStranscore.db_by_mind_name(mind.name)
+	if(db)
+		var/datum/transhuman/mind_record/record = db.backed_up[src.mind.name]
+		if(record.dead_state == MR_DEAD || !(record.do_notify))
+			to_chat(src, "<span class='warning'>The notification has already happened or been delayed.</span>")
+		else
+			record.do_notify = FALSE
+			to_chat(src, "<span class='notice'>Overdue mind backup notification delayed successfully.</span>")
 	else
 		to_chat(src,"<span class='warning'>No backup record could be found, sorry.</span>")
 

--- a/code/modules/resleeving/infocore_records.dm
+++ b/code/modules/resleeving/infocore_records.dm
@@ -15,6 +15,7 @@
 	var/dead_state = 0
 	var/last_update = 0
 	var/last_notification
+	var/do_notify = TRUE
 
 	//Backend
 	var/ckey = ""


### PR DESCRIPTION
Decreases initial notification timer to 6 minutes, down from 15

Decreases cooldown on repeat notification to 5 minutes, down from 10

Changes repeat notification message to be same as regular

Added a verb for ghosts that 'cancels' transcore message without removing the record or backup. Good if you want your pred to be one resleeving you or stick around for longer before doctors get to you. Notify Transcore can be used manually to send it later.


Mostly all of it is a proposal, since there's not much reason for the backup timer to be that high now that defib timer is an hour.