### PR TITLE
Change span macros

### DIFF
--- a/code/__defines/misc.dm
+++ b/code/__defines/misc.dm
@@ -398,23 +398,23 @@ var/global/list/##LIST_NAME = list();\
 
 #define send_link(target, url) target << link(url)
 
-#define SPAN_NOTICE(X) "<span class='notice'>[X]</span>"
+#define SPAN_NOTICE(X) "<span class='notice'>"+ X + "</span>"
 
-#define SPAN_WARNING(X) "<span class='warning'>[X]</span>"
+#define SPAN_WARNING(X) "<span class='warning'>"+ X + "</span>"
 
-#define SPAN_DANGER(X) "<span class='danger'>[X]</span>"
+#define SPAN_DANGER(X) "<span class='danger'>"+ X + "</span>"
 
-#define SPAN_OCCULT(X) "<span class='cult'>[X]</span>"
+#define SPAN_OCCULT(X) "<span class='cult'>"+ X + "</span>"
 
-#define FONT_SMALL(X) "<font size='1'>[X]</font>"
+#define FONT_SMALL(X) "<font size='1'>"+ X + "</font>"
 
-#define FONT_NORMAL(X) "<font size='2'>[X]</font>"
+#define FONT_NORMAL(X) "<font size='2'>"+ X + "</font>"
 
-#define FONT_LARGE(X) "<font size='3'>[X]</font>"
+#define FONT_LARGE(X) "<font size='3'>"+ X + "</font>"
 
-#define FONT_HUGE(X) "<font size='4'>[X]</font>"
+#define FONT_HUGE(X) "<font size='4'>"+ X + "</font>"
 
-#define FONT_GIANT(X) "<font size='5'>[X]</font>"
+#define FONT_GIANT(X) "<font size='5'>"+ X + "</font>"
 
 // Volume Channel Defines
 


### PR DESCRIPTION
Never one to be outdone, byond has decided that this is a more betterer way to write these macros.
Normal text strings written to world are 3 ops.
This concat style macro is the same 3 ops.
The 'text replacement', despite the thing it's doing being a macro, compiles to something that takes 4 ops.