### PR TITLE
Bigger Bellies

### DIFF
--- a/code/modules/vore/eating/vorepanel_vr.dm
+++ b/code/modules/vore/eating/vorepanel_vr.dm
@@ -4,8 +4,8 @@
 
 #define BELLIES_MAX 40
 #define BELLIES_NAME_MIN 2
-#define BELLIES_NAME_MAX 20
-#define BELLIES_DESC_MAX 2048
+#define BELLIES_NAME_MAX 40
+#define BELLIES_DESC_MAX 4096
 #define FLAVOR_MAX 40
 
 /mob/living


### PR DESCRIPTION
Increases bellies_name_max from 20 to 40
Increases bellies_desc_max from 2048 to 4096

Incase some people want to be incredibly verbose with their bellies.  This, additionally, brings  bellies_desc_max in line with the maximum amount of characters  allowed for normal emotes, thus making it more universal and consistant.  