### PR TITLE
Changes persistent smartfridge loss to a flat rate.

### DIFF
--- a/code/modules/persistence/storage/smartfridge.dm
+++ b/code/modules/persistence/storage/smartfridge.dm
@@ -51,8 +51,8 @@
 
 		// Delete some stacks if we want
 		if(stacks_go_missing)
-			var/fuzzy = rand(75,85)
-			count = round(count*0.01*fuzzy) // loss of 15-25% with rounding down
+			var/fuzzy = rand(55,65)
+			count = round(count*0.01*fuzzy) // loss of 35-45% with rounding down
 			if(count <= 0)
 				continue
 		

--- a/code/modules/persistence/storage/smartfridge.dm
+++ b/code/modules/persistence/storage/smartfridge.dm
@@ -51,14 +51,7 @@
 
 		// Delete some stacks if we want
 		if(stacks_go_missing)
-			var/fuzzy = rand(-5,5)
-			switch(count / max_amount)
-				if(0 to 1)
-					count -= 10+fuzzy // 1 stack or less, lose 10
-				if(1 to 10)
-					count -= max_amount+fuzzy // 1 to 10 stacks, lose a stack
-				if(10 to INFINITY)
-					count -= max_amount*3+fuzzy // 10+ stacks, lose 3 stacks
+			count -= count*0.2 // flat loss of 20%
 			if(count <= 0)
 				continue
 		

--- a/code/modules/persistence/storage/smartfridge.dm
+++ b/code/modules/persistence/storage/smartfridge.dm
@@ -51,8 +51,8 @@
 
 		// Delete some stacks if we want
 		if(stacks_go_missing)
-			var/fuzzy = rand(-5,5)*.01
-			count -= floor(count*(0.8+fuzzy)) // loss of 15-25% with rounding down
+			var/fuzzy = rand(75,85)
+			count -= round(count*0.01*fuzzy) // loss of 15-25% with rounding down
 			if(count <= 0)
 				continue
 		

--- a/code/modules/persistence/storage/smartfridge.dm
+++ b/code/modules/persistence/storage/smartfridge.dm
@@ -52,7 +52,7 @@
 		// Delete some stacks if we want
 		if(stacks_go_missing)
 			var/fuzzy = rand(75,85)
-			count -= round(count*0.01*fuzzy) // loss of 15-25% with rounding down
+			count = round(count*0.01*fuzzy) // loss of 15-25% with rounding down
 			if(count <= 0)
 				continue
 		

--- a/code/modules/persistence/storage/smartfridge.dm
+++ b/code/modules/persistence/storage/smartfridge.dm
@@ -51,7 +51,8 @@
 
 		// Delete some stacks if we want
 		if(stacks_go_missing)
-			count -= count*0.2 // flat loss of 20%
+			var/fuzzy = rand(-5,5)*.01
+			count -= floor(count*(0.8+fuzzy)) // loss of 15-25% with rounding down
 			if(count <= 0)
 				continue
 		


### PR DESCRIPTION
The current issue with lossy sheet storage is that the jump from .99 stacks to 1-10 stacks is way too punishing.
It makes it so the best option is to put in less then one unless you have a ton of it, because you are likely to loose more overall.
This PR makes it so you don't have to follow weird meta-logic, but making it a flat 20% loss at all levels.
Still following the standard overall cap of of to 250 sheets per material.
I just picked the first number that seemed good to me, but I am open to hear other ones for sure.
I also did this at like 5:00am under a request, so if the way I coded it is dumb let me know.
It passed the does it compile test at the very least.