### PR TITLE
Corrects rabbit typo

### DIFF
--- a/code/modules/mob/living/simple_mob/subtypes/vore/rabbit.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/rabbit.dm
@@ -91,7 +91,7 @@
 /datum/say_list/rabbit
 	speak = list("chrrrs.")
 	emote_hear = list("screms.")
-	emote_see = list("earflicks","wiggles it's tail", "wiggles its nose")
+	emote_see = list("earflicks","wiggles its tail", "wiggles its nose")
 
 /mob/living/simple_mob/vore/rabbit/black
 	icon_state = "rabbit_black"


### PR DESCRIPTION
Remember kids: "it's" means "it is"