### PR TITLE
Fixes big belly overlay dmi breaking the menu

### DIFF
--- a/code/modules/vore/eating/vorepanel_vr.dm
+++ b/code/modules/vore/eating/vorepanel_vr.dm
@@ -164,7 +164,6 @@
 			"emote_time" = selected.emote_time,
 			"emote_active" = selected.emote_active,
 			"belly_fullscreen" = selected.belly_fullscreen,
-			"possible_fullscreens" = icon_states('icons/mob/screen_full_vore.dmi'),
 		)
 
 		var/list/addons = list()
@@ -192,6 +191,7 @@
 			selected_list["interacts"]["digestchance"] = selected.digestchance
 
 		selected_list["disable_hud"] = selected.disable_hud
+		selected_list["possible_fullscreens"] = icon_states('icons/mob/screen_full_vore.dmi')
 
 		var/list/selected_contents = list()
 		for(var/O in selected)


### PR DESCRIPTION
Apparently a big enough dmi file here can delay its loading enough to fuck up its proper presence on a pre-defined list here where the rest of the list items are all just singular vars. Moved the part into this more robust looking spot down here to be loaded at a more appropriate time fixed a downstream bug that would completely prevent the overlay options showing up on vorepanel menu at all.