### PR TITLE
Fix a couple cases of missing emotes

### DIFF
--- a/code/modules/emotes/emote_mob.dm
+++ b/code/modules/emotes/emote_mob.dm
@@ -168,6 +168,8 @@
 	var/runemessage
 	if(input)
 		formatted = format_emote(src, message)
+		if(!islist(formatted))
+			return
 		message = formatted["pretext"] + formatted["nametext"] + formatted["subtext"]
 		runemessage = formatted["subtext"]
 		// This is just personal preference (but I'm objectively right) that custom emotes shouldn't have periods at the end in runechat


### PR DESCRIPTION
Pointed out by @KillianKirilenko 

There are two cases in which format_emote() can return null instead of a list, so bailing would be nice.