### PR TITLE
fix stealthmins on staffwho

### DIFF
--- a/code/modules/client/verbs/who.dm
+++ b/code/modules/client/verbs/who.dm
@@ -69,7 +69,7 @@
 		var/temp = ""
 		var/category = R_ADMIN
 		// VOREStation Edit - Apply stealthmin protection to all levels
-		if(C.holder.fakekey && check_rights(R_ADMIN|R_MOD, FALSE, src))	// Only admins and mods can see stealthmins
+		if(C.holder.fakekey && !check_rights(R_ADMIN|R_MOD, FALSE, src))	// Only admins and mods can see stealthmins
 			continue
 		// VOREStation Edit End
 		if(check_rights(R_BAN, FALSE, C)) // admins //VOREStation Edit


### PR DESCRIPTION
fixes the bug part of #10768

dsay still uses your real rank which could potentially be revealing for uncommon admin ranks (such as dogmin, host, etc.), tbh i would just not use dsay if you're trying to stealth

Resolves #10768