### PR TITLE
Makes non-decal effects not use obj plane

### DIFF
--- a/code/__defines/_planes+layers.dm
+++ b/code/__defines/_planes+layers.dm
@@ -90,6 +90,8 @@ What is the naming convention for planes or layers?
 	#define ON_WINDOW_LAYER			3.3 // Ontop of a window
 	#define ABOVE_WINDOW_LAYER 		3.4 //Above full tile windows so wall items are clickable
 
+#define ABOVE_OBJ_PLANE				-30
+
 // Mob planes
 #define MOB_PLANE				-25
 	#define BELOW_MOB_LAYER			3.9 // Should be converted to plane swaps

--- a/code/game/objects/effects/effect_system.dm
+++ b/code/game/objects/effects/effect_system.dm
@@ -6,7 +6,7 @@ would spawn and follow the beaker, even if it is carried or thrown.
 */
 /obj/effect
 	light_on = TRUE
-	plane = ABOVE_MOB_PLANE
+	plane = ABOVE_OBJ_PLANE
 
 /obj/effect/decal
 	plane = OBJ_PLANE

--- a/code/game/objects/effects/effect_system.dm
+++ b/code/game/objects/effects/effect_system.dm
@@ -6,6 +6,10 @@ would spawn and follow the beaker, even if it is carried or thrown.
 */
 /obj/effect
 	light_on = TRUE
+	plane = ABOVE_MOB_PLANE
+
+/obj/effect/decal
+	plane = OBJ_PLANE
 
 /obj/effect/effect
 	name = "effect"

--- a/code/game/objects/effects/mines.dm
+++ b/code/game/objects/effects/mines.dm
@@ -5,6 +5,7 @@
 	anchored = 1
 	icon = 'icons/obj/weapons.dmi'
 	icon_state = "uglymine"
+	plane = OBJ_PLANE
 	var/triggered = 0
 	var/smoke_strength = 3
 	var/obj/item/weapon/mine/mineitemtype = /obj/item/weapon/mine

--- a/code/game/objects/effects/misc.dm
+++ b/code/game/objects/effects/misc.dm
@@ -6,6 +6,7 @@
 	icon_state = "strangepresent"
 	density = 1
 	anchored = 0
+	plane = OBJ_PLANE
 
 /obj/effect/temporary_effect
 	name = "self deleting effect"
@@ -25,7 +26,7 @@
 	desc = "Something swinging really wide."
 	icon = 'icons/effects/96x96.dmi'
 	icon_state = "cleave"
-	plane = MOB_PLANE
+	plane = ABOVE_MOB_PLANE
 	layer = ABOVE_MOB_LAYER
 	time_to_die = 6
 	alpha = 140
@@ -73,6 +74,7 @@
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	light_on = TRUE
 	blocks_emissive = FALSE
+	plane = OBJ_PLANE
 
 /obj/effect/dummy/lighting_obj/Initialize(mapload, _range, _power, _color, _duration)
 	. = ..()

--- a/code/game/objects/effects/overlays.dm
+++ b/code/game/objects/effects/overlays.dm
@@ -1,12 +1,14 @@
 /obj/effect/overlay
 	name = "overlay"
 	unacidable = 1
+	plane = OBJ_PLANE
 	var/i_attached//Added for possible image attachments to objects. For hallucinations and the like.
 
 /obj/effect/overlay/beam//Not actually a projectile, just an effect.
 	name="beam"
 	icon='icons/effects/beam.dmi'
 	icon_state="b_beam"
+	plane = ABOVE_OBJ_PLANE
 	var/tmp/atom/BeamSource
 
 /obj/effect/overlay/beam/New()

--- a/code/game/objects/effects/spiders.dm
+++ b/code/game/objects/effects/spiders.dm
@@ -5,6 +5,7 @@
 	icon = 'icons/effects/effects.dmi'
 	anchored = 1
 	density = 0
+	plane = OBJ_PLANE
 	var/health = 15
 
 //similar to weeds, but only barfed out by nurses manually

--- a/code/modules/mob/living/carbon/human/species/station/protean_vr/protean_blob.dm
+++ b/code/modules/mob/living/carbon/human/species/station/protean_vr/protean_blob.dm
@@ -248,10 +248,12 @@
 	if(resting)
 		animate(src,alpha = 40,time = 1 SECOND)
 		mouse_opacity = 0
+		plane = ABOVE_OBJ_PLANE
 	else
 		mouse_opacity = 1
 		icon_state = "wake"
 		animate(src,alpha = 255,time = 1 SECOND)
+		plane = MOB_PLANE
 		sleep(7)
 		update_icon()
 		//Potential glob noms


### PR DESCRIPTION
This makes effects such as projectiles, sparks, and flashlight projections not cast shadows when fake ao is enabled.