### PR TITLE
Increases the character limit on character smell and taste.

### DIFF
--- a/code/modules/vore/eating/vorepanel_vr.dm
+++ b/code/modules/vore/eating/vorepanel_vr.dm
@@ -6,7 +6,7 @@
 #define BELLIES_NAME_MIN 2
 #define BELLIES_NAME_MAX 40
 #define BELLIES_DESC_MAX 4096
-#define FLAVOR_MAX 40
+#define FLAVOR_MAX 400
 
 /mob/living
 	var/datum/vore_look/vorePanel
@@ -321,7 +321,7 @@
 				unsaved_changes = FALSE
 			return TRUE
 		if("setflavor")
-			var/new_flavor = html_encode(input(usr,"What your character tastes like (40ch limit). This text will be printed to the pred after 'X tastes of...' so just put something like 'strawberries and cream':","Character Flavor",host.vore_taste) as text|null)
+			var/new_flavor = html_encode(input(usr,"What your character tastes like (400ch limit). This text will be printed to the pred after 'X tastes of...' so just put something like 'strawberries and cream':","Character Flavor",host.vore_taste) as text|null)
 			if(!new_flavor)
 				return FALSE
 
@@ -333,7 +333,7 @@
 			unsaved_changes = TRUE
 			return TRUE
 		if("setsmell")
-			var/new_smell = html_encode(input(usr,"What your character smells like (40ch limit). This text will be printed to the pred after 'X smells of...' so just put something like 'strawberries and cream':","Character Smell",host.vore_smell) as text|null)
+			var/new_smell = html_encode(input(usr,"What your character smells like (400ch limit). This text will be printed to the pred after 'X smells of...' so just put something like 'strawberries and cream':","Character Smell",host.vore_smell) as text|null)
 			if(!new_smell)
 				return FALSE
 


### PR DESCRIPTION
I had a couple of cases where I wanted to add more detail to my characters smell/taste, and found that the 40ch limit made it really impossible to do that. This PR currently raises it from 40 to 400 because I had to pick some larger number and decided to add a zero, it was really pretty arbitrary. The max limit on text for a belly is 4096 to help give some comparison. I suppose that it was smaller because its easier to lick/smell people, but I really don't see anyway this could be abused. 

Hopefully this PR let me let me know if anyone had a reason that it shouldn't be raised that I hadn't thought about, or if they want to see it changed to something other then the random number I came up with first. I mean, I already doubt I would ever use all of that space, but I don't see an issue with it being larger if people want to take advantage of it.