### PR TITLE
Revert items.dm change

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -248,7 +248,7 @@
 
 	src.throwing = 0
 	if (src.loc == user)
-		if(!user.unEquip(src, null, src))
+		if(!user.unEquip(src))
 			return
 	else
 		if(isliving(src.loc))


### PR DESCRIPTION
This apparently causes some odd behavior when laying and a couple other places. It was done to fix a regression in micro holders, so this may cause weirdness when moving micro holders between slots (like dropping them), but better that than inventory items disappearing.

Fixes #10883