### PR TITLE
Fixes #10896

### DIFF
--- a/code/_helpers/unsorted.dm
+++ b/code/_helpers/unsorted.dm
@@ -686,12 +686,12 @@ Turf and target are seperate in case you want to teleport some distance from a t
 /proc/return_areas()
 	var/list/area/areas = list()
 	for(var/area/A in world)
-		areas += A
+		areas[A.name] = A
 	return areas
 
 //Returns: all the areas in the world, sorted.
 /proc/return_sorted_areas()
-	return sortAtom(return_areas())
+	return sortTim(return_areas(), /proc/cmp_text_asc)
 
 //Takes: Area type as text string or as typepath OR an instance of the area.
 //Returns: A list of all areas of that type in the world.

--- a/code/modules/admin/secrets/admin_secrets/jump_shuttle.dm
+++ b/code/modules/admin/secrets/admin_secrets/jump_shuttle.dm
@@ -13,24 +13,25 @@
 	if (!shuttle_tag) return
 
 	var/datum/shuttle/S = SSshuttles.shuttles[shuttle_tag]
-
-	var/origin_area = tgui_input_list(user, "Which area is the shuttle at now? (MAKE SURE THIS IS CORRECT OR THINGS WILL BREAK)", "Area Choice", return_areas())
+	
+	var/list/area_choices = return_areas()
+	var/origin_area = tgui_input_list(user, "Which area is the shuttle at now? (MAKE SURE THIS IS CORRECT OR THINGS WILL BREAK)", "Area Choice", area_choices)
 	if (!origin_area) return
 
-	var/destination_area = tgui_input_list(user, "Which area is the shuttle at now? (MAKE SURE THIS IS CORRECT OR THINGS WILL BREAK)", "Area Choice", return_areas())
+	var/destination_area = tgui_input_list(user, "Which area is the shuttle at now? (MAKE SURE THIS IS CORRECT OR THINGS WILL BREAK)", "Area Choice", area_choices)
 	if (!destination_area) return
 
 	var/long_jump = tgui_alert(user, "Is there a transition area for this jump?","Transition?", list("Yes","No"))
 	if (long_jump == "Yes")
-		var/transition_area = tgui_input_list(user, "Which area is the transition area? (MAKE SURE THIS IS CORRECT OR THINGS WILL BREAK)", "Area Choice", return_areas())
+		var/transition_area = tgui_input_list(user, "Which area is the transition area? (MAKE SURE THIS IS CORRECT OR THINGS WILL BREAK)", "Area Choice", area_choices)
 		if (!transition_area) return
 
 		var/move_duration = input(user, "How many seconds will this jump take?") as num
 
-		S.long_jump(origin_area, destination_area, transition_area, move_duration)
+		S.long_jump(area_choices[origin_area], area_choices[destination_area], area_choices[transition_area], move_duration)
 		message_admins("<span class='notice'>[key_name_admin(user)] has initiated a jump from [origin_area] to [destination_area] lasting [move_duration] seconds for the [shuttle_tag] shuttle</span>", 1)
 		log_admin("[key_name_admin(user)] has initiated a jump from [origin_area] to [destination_area] lasting [move_duration] seconds for the [shuttle_tag] shuttle")
 	else
-		S.short_jump(origin_area, destination_area)
+		S.short_jump(area_choices[origin_area], area_choices[destination_area])
 		message_admins("<span class='notice'>[key_name_admin(user)] has initiated a jump from [origin_area] to [destination_area] for the [shuttle_tag] shuttle</span>", 1)
 		log_admin("[key_name_admin(user)] has initiated a jump from [origin_area] to [destination_area] for the [shuttle_tag] shuttle")

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -334,16 +334,15 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	to_chat(src, "<font color='blue'><B>AntagHUD [antagHUD ? "Enabled" : "Disabled"]</B></font>")
 
 /mob/observer/dead/proc/jumpable_areas()
-	var/list/areas = sortAtom(return_areas())
+	var/list/areas = return_sorted_areas()
 	if(client?.holder)
 		return areas
 	
-	var/list/area_map = list()
-	for(var/area/A as anything in areas)
+	for(var/key in areas)
+		var/area/A = areas[key]
 		if(A.z in using_map?.secret_levels)
-			continue
-		area_map[A.name] = A
-	return area_map
+			areas -= key
+	return areas
 
 /mob/observer/dead/proc/jumpable_mobs()
 	var/list/mobs = getmobs()

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -334,14 +334,16 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	to_chat(src, "<font color='blue'><B>AntagHUD [antagHUD ? "Enabled" : "Disabled"]</B></font>")
 
 /mob/observer/dead/proc/jumpable_areas()
-	var/list/areas = return_areas()
+	var/list/areas = sortAtom(return_areas())
 	if(client?.holder)
 		return areas
 	
+	var/list/area_map = list()
 	for(var/area/A as anything in areas)
 		if(A.z in using_map?.secret_levels)
-			areas -= A
-	return areas				
+			continue
+		area_map[A.name] = A
+	return area_map
 
 /mob/observer/dead/proc/jumpable_mobs()
 	var/list/mobs = getmobs()
@@ -363,11 +365,13 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		to_chat(usr, "Not when you're not dead!")
 		return
 
-	
-	var/area/A = tgui_input_list(usr, "Select an area:", "Ghost Teleport", jumpable_areas())
-	if(!A)
+	var/list/areas = jumpable_areas()
+	var/input = tgui_input_list(usr, "Select an area:", "Ghost Teleport", areas)
+	if(!input)
 		return
 	
+	var/area/A = areas[input]
+	if(!A) return
 	usr.forceMove(pick(get_area_turfs(A)))
 	usr.on_mob_jump()
 

--- a/code/modules/mob/living/silicon/ai/multicam.dm
+++ b/code/modules/mob/living/silicon/ai/multicam.dm
@@ -153,7 +153,7 @@ Whatever you did that made the last camera window disappear-- don't do that agai
 	. = ..()
 
 /area/ai_multicam_room
-	name = "ai_multicam_room"
+	name = "AI Multicam Room"
 	icon_state = "ai_camera_room"
 	dynamic_lighting = FALSE
 	ambience = list()


### PR DESCRIPTION
~~Sorts the areas in the ghost jump list. Most still say 'The', which is from all the area names having \improper at the start. Despite the fact that I thought the list input strips that, it remains there.~~

Fixed