### PR TITLE
Converts visible_message notice spans to look more like emotes

### DIFF
--- a/code/ATMOSPHERICS/components/binary_devices/passive_gate.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/passive_gate.dm
@@ -296,7 +296,7 @@
 	to_chat(user, "<span class='notice'>You begin to unfasten \the [src]...</span>")
 	if (do_after(user, 40 * W.toolspeed))
 		user.visible_message( \
-			"<span class='notice'>\The [user] unfastens \the [src].</span>", \
+			"<b>\The [user]</b> unfastens \the [src].", \
 			"<span class='notice'>You have unfastened \the [src].</span>", \
 			"You hear ratchet.")
 		deconstruct()

--- a/code/ATMOSPHERICS/components/binary_devices/pump.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/pump.dm
@@ -256,7 +256,7 @@ Thus, the two variables affect pump operation are set in New():
 	to_chat(user, "<span class='notice'>You begin to unfasten \the [src]...</span>")
 	if (do_after(user, 40 * W.toolspeed))
 		user.visible_message( \
-			"<span class='notice'>\The [user] unfastens \the [src].</span>", \
+			"<b>\The [user]</b> unfastens \the [src].", \
 			"<span class='notice'>You have unfastened \the [src].</span>", \
 			"You hear ratchet.")
 		deconstruct()

--- a/code/ATMOSPHERICS/components/omni_devices/omni_base.dm
+++ b/code/ATMOSPHERICS/components/omni_devices/omni_base.dm
@@ -91,7 +91,7 @@
 	playsound(src, W.usesound, 50, 1)
 	if(do_after(user, 40 * W.toolspeed))
 		user.visible_message( \
-			"<span class='notice'>\The [user] unfastens \the [src].</span>", \
+			"<b>\The [user]</b> unfastens \the [src].", \
 			"<span class='notice'>You have unfastened \the [src].</span>", \
 			"You hear a ratchet.")
 		deconstruct()

--- a/code/ATMOSPHERICS/components/portables_connector.dm
+++ b/code/ATMOSPHERICS/components/portables_connector.dm
@@ -162,7 +162,7 @@
 	to_chat(user, "<span class='notice'>You begin to unfasten \the [src]...</span>")
 	if (do_after(user, 40 * W.toolspeed))
 		user.visible_message( \
-			"<span class='notice'>\The [user] unfastens \the [src].</span>", \
+			"<b>\The [user]</b> unfastens \the [src].", \
 			"<span class='notice'>You have unfastened \the [src].</span>", \
 			"You hear a ratchet.")
 		deconstruct()

--- a/code/ATMOSPHERICS/components/trinary_devices/trinary_base.dm
+++ b/code/ATMOSPHERICS/components/trinary_devices/trinary_base.dm
@@ -62,7 +62,7 @@
 	to_chat(user, "<span class='notice'>You begin to unfasten \the [src]...</span>")
 	if (do_after(user, 40 * W.toolspeed))
 		user.visible_message( \
-			"<span class='notice'>\The [user] unfastens \the [src].</span>", \
+			"<b>\The [user]</b> unfastens \the [src].", \
 			"<span class='notice'>You have unfastened \the [src].</span>", \
 			"You hear a ratchet.")
 		deconstruct()

--- a/code/ATMOSPHERICS/components/tvalve.dm
+++ b/code/ATMOSPHERICS/components/tvalve.dm
@@ -340,7 +340,7 @@
 	to_chat(user, "<span class='notice'>You begin to unfasten \the [src]...</span>")
 	if (do_after(user, 40 * W.toolspeed))
 		user.visible_message( \
-			"<span class='notice'>\The [user] unfastens \the [src].</span>", \
+			"<b>\The [user]</b> unfastens \the [src].", \
 			"<span class='notice'>You have unfastened \the [src].</span>", \
 			"You hear a ratchet.")
 		deconstruct()

--- a/code/ATMOSPHERICS/components/unary/heat_exchanger.dm
+++ b/code/ATMOSPHERICS/components/unary/heat_exchanger.dm
@@ -81,7 +81,7 @@
 	to_chat(user, "<span class='notice'>You begin to unfasten \the [src]...</span>")
 	if (do_after(user, 40 * W.toolspeed))
 		user.visible_message( \
-			"<span class='notice'>\The [user] unfastens \the [src].</span>", \
+			"<b>\The [user]</b> unfastens \the [src].", \
 			"<span class='notice'>You have unfastened \the [src].</span>", \
 			"You hear a ratchet.")
 		deconstruct()

--- a/code/ATMOSPHERICS/components/unary/outlet_injector.dm
+++ b/code/ATMOSPHERICS/components/unary/outlet_injector.dm
@@ -171,7 +171,7 @@
 	to_chat(user, "<span class='notice'>You begin to unfasten \the [src]...</span>")
 	if (do_after(user, 40 * W.toolspeed))
 		user.visible_message( \
-			"<span class='notice'>\The [user] unfastens \the [src].</span>", \
+			"<b>\The [user]</b> unfastens \the [src].", \
 			"<span class='notice'>You have unfastened \the [src].</span>", \
 			"You hear a ratchet.")
 		deconstruct()

--- a/code/ATMOSPHERICS/components/unary/vent_pump.dm
+++ b/code/ATMOSPHERICS/components/unary/vent_pump.dm
@@ -405,7 +405,7 @@
 				if(!src || !WT.isOn()) return
 				playsound(src, WT.usesound, 50, 1)
 				if(!welded)
-					user.visible_message("<span class='notice'>\The [user] welds the vent shut.</span>", "<span class='notice'>You weld the vent shut.</span>", "You hear welding.")
+					user.visible_message("<b>\The [user]</b> welds the vent shut.", "<span class='notice'>You weld the vent shut.</span>", "You hear welding.")
 					welded = 1
 					update_icon()
 				else
@@ -453,7 +453,7 @@
 	to_chat(user, "<span class='notice'>You begin to unfasten \the [src]...</span>")
 	if (do_after(user, 40 * W.toolspeed))
 		user.visible_message( \
-			"<span class='notice'>\The [user] unfastens \the [src].</span>", \
+			"<b>\The [user]</b> unfastens \the [src].", \
 			"<span class='notice'>You have unfastened \the [src].</span>", \
 			"You hear a ratchet.")
 		deconstruct()

--- a/code/ATMOSPHERICS/components/unary/vent_scrubber.dm
+++ b/code/ATMOSPHERICS/components/unary/vent_scrubber.dm
@@ -281,7 +281,7 @@
 	to_chat(user, "<span class='notice'>You begin to unfasten \the [src]...</span>")
 	if (do_after(user, 40 * W.toolspeed))
 		user.visible_message( \
-			"<span class='notice'>\The [user] unfastens \the [src].</span>", \
+			"<b>\The [user]</b> unfastens \the [src].", \
 			"<span class='notice'>You have unfastened \the [src].</span>", \
 			"You hear a ratchet.")
 		deconstruct()

--- a/code/ATMOSPHERICS/components/valve.dm
+++ b/code/ATMOSPHERICS/components/valve.dm
@@ -301,7 +301,7 @@
 	to_chat(user, "<span class='notice'>You begin to unfasten \the [src]...</span>")
 	if (do_after(user, 40 * W.toolspeed))
 		user.visible_message( \
-			"<span class='notice'>\The [user] unfastens \the [src].</span>", \
+			"<b>\The [user]</b> unfastens \the [src].", \
 			"<span class='notice'>You have unfastened \the [src].</span>", \
 			"You hear a ratchet.")
 		deconstruct()

--- a/code/ATMOSPHERICS/pipes/pipe_base.dm
+++ b/code/ATMOSPHERICS/pipes/pipe_base.dm
@@ -130,7 +130,7 @@
 	to_chat(user, "<span class='notice'>You begin to unfasten \the [src]...</span>")
 	if (do_after(user, 10 * W.toolspeed))
 		user.visible_message( \
-			"<span class='notice'>\The [user] unfastens \the [src].</span>", \
+			"<b>\The [user]</b> unfastens \the [src].", \
 			"<span class='notice'>You have unfastened \the [src].</span>", \
 			"You hear a ratchet.")
 		deconstruct()

--- a/code/game/gamemodes/cult/construct_spells.dm
+++ b/code/game/gamemodes/cult/construct_spells.dm
@@ -671,6 +671,6 @@
 			W.visible_message("<span class='danger'>\The [user] [attack_message] \the [W], obliterating it!</span>")
 			W.dismantle_wall(1)
 		else
-			user.visible_message("<span class='notice'>\The [user] lowers its fist.</span>")
+			user.visible_message("<b>\The [user]</b> lowers its fist.")
 			return
 	qdel(src)

--- a/code/game/gamemodes/technomancer/core_obj.dm
+++ b/code/game/gamemodes/technomancer/core_obj.dm
@@ -121,7 +121,7 @@
 			if(L.stat == DEAD)
 				summoned_mobs -= L
 				spawn(1)
-					L.visible_message("<span class='notice'>\The [L] begins to fade away...</span>")
+					L.visible_message("<b>\The [L]</b> begins to fade away...")
 					animate(L, alpha = 255, alpha = 0, time = 30) // Makes them fade into nothingness.
 					sleep(30)
 					qdel(L)

--- a/code/game/gamemodes/technomancer/spells/abjuration.dm
+++ b/code/game/gamemodes/technomancer/spells/abjuration.dm
@@ -27,7 +27,7 @@
 				to_chat(L, "<span class='warning'>\The [user] tried to teleport you far away, but failed.</span>")
 				return 0
 			else
-				visible_message("<span class='notice'>\The [L] vanishes!</span>")
+				visible_message("<b>\The [L]</b> vanishes!")
 				qdel(L)
 		else if(istype(L, /mob/living/simple_mob/construct))
 			var/mob/living/simple_mob/construct/evil = L

--- a/code/game/gamemodes/technomancer/spells/blink.dm
+++ b/code/game/gamemodes/technomancer/spells/blink.dm
@@ -47,7 +47,7 @@
 			if(L.buckled)
 				L.buckled.unbuckle_mob()
 		AM.forceMove(destination)
-		AM.visible_message("<span class='notice'>\The [AM] vanishes!</span>")
+		AM.visible_message("<b>\The [AM]</b> vanishes!")
 		to_chat(AM, "<span class='notice'>You suddenly appear somewhere else!</span>")
 		new /obj/effect/effect/sparks(destination)
 		new /obj/effect/effect/sparks(starting)

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -382,7 +382,7 @@
 			beaker = I
 			user.drop_item()
 			I.loc = src
-			user.visible_message("<span class='notice'>\The [user] adds \a [I] to \the [src].</span>", "<span class='notice'>You add \a [I] to \the [src].</span>")
+			user.visible_message("<b>\The [user]</b> adds \a [I] to \the [src].", "<span class='notice'>You add \a [I] to \the [src].</span>")
 		else
 			to_chat(user, "<span class='warning'>\The [src] has a beaker already.</span>")
 		return

--- a/code/game/machinery/airconditioner_vr.dm
+++ b/code/game/machinery/airconditioner_vr.dm
@@ -76,7 +76,7 @@
 		return
 
 	if(draw_power(idle_power_usage) < idle_power_usage)
-		visible_message("<span class='notice'>\The [src] shuts down.</span>")
+		visible_message("<b>\The [src]</b> shuts down.")
 		turn_off()
 		return
 

--- a/code/game/machinery/atmoalter/meter.dm
+++ b/code/game/machinery/atmoalter/meter.dm
@@ -110,7 +110,7 @@
 		to_chat(user, "<span class='notice'>You begin to unfasten \the [src]...</span>")
 		if(do_after(user, 40 * W.toolspeed))
 			user.visible_message( \
-				"<span class='notice'>\The [user] unfastens \the [src].</span>", \
+				"<b>\The [user]</b> unfastens \the [src].", \
 				"<span class='notice'>You have unfastened \the [src].</span>", \
 				"You hear ratchet.")
 			new /obj/item/pipe_meter(get_turf(src))

--- a/code/game/machinery/bioprinter.dm
+++ b/code/game/machinery/bioprinter.dm
@@ -163,7 +163,7 @@
 	printing = 1
 	update_icon()
 
-	visible_message("<span class='notice'>\The [src] begins churning.</span>")
+	visible_message("<b>\The [src]</b> begins churning.")
 
 	sleep(print_delay)
 
@@ -211,7 +211,7 @@
 /obj/machinery/organ_printer/proc/can_print(var/choice, var/masscount = 0)
 	var/biomass = get_biomass_volume()
 	if(biomass < masscount)
-		visible_message("<span class='notice'>\The [src] displays a warning: 'Not enough biomass. [biomass] stored and [masscount] needed.'</span>")
+		visible_message("<b>\The [src]</b> displays a warning: 'Not enough biomass. [biomass] stored and [masscount] needed.'")
 		return 0
 
 	if(!loaded_dna || !loaded_dna["donor"])

--- a/code/game/machinery/computer/ai_core.dm
+++ b/code/game/machinery/computer/ai_core.dm
@@ -234,21 +234,21 @@ GLOBAL_LIST_BOILERPLATE(all_deactivated_AI_cores, /obj/structure/AIcore/deactiva
 		return
 	else if(W.is_wrench())
 		if(anchored)
-			user.visible_message("<span class='notice'>\The [user] starts to unbolt \the [src] from the plating...</span>")
+			user.visible_message("<b>\The [user]</b> starts to unbolt \the [src] from the plating...")
 			playsound(src, W.usesound, 50, 1)
 			if(!do_after(user,40 * W.toolspeed))
-				user.visible_message("<span class='notice'>\The [user] decides not to unbolt \the [src].</span>")
+				user.visible_message("<b>\The [user]</b> decides not to unbolt \the [src].")
 				return
-			user.visible_message("<span class='notice'>\The [user] finishes unfastening \the [src]!</span>")
+			user.visible_message("<b>\The [user]</b> finishes unfastening \the [src]!")
 			anchored = 0
 			return
 		else
-			user.visible_message("<span class='notice'>\The [user] starts to bolt \the [src] to the plating...</span>")
+			user.visible_message("<b>\The [user]</b> starts to bolt \the [src] to the plating...")
 			playsound(src, W.usesound, 50, 1)
 			if(!do_after(user,40 * W.toolspeed))
-				user.visible_message("<span class='notice'>\The [user] decides not to bolt \the [src].</span>")
+				user.visible_message("<b>\The [user]</b> decides not to bolt \the [src].")
 				return
-			user.visible_message("<span class='notice'>\The [user] finishes fastening down \the [src]!</span>")
+			user.visible_message("<b>\The [user]</b> finishes fastening down \the [src]!")
 			anchored = 1
 			return
 	else

--- a/code/game/machinery/computer/guestpass.dm
+++ b/code/game/machinery/computer/guestpass.dm
@@ -48,7 +48,7 @@
 		var/confirm = tgui_alert(usr, "Do you really want to deactivate this guest pass? (you can't reactivate it)", "Confirm Deactivation", list("Yes", "No"))
 		if(confirm == "Yes")
 			//rip guest pass </3
-			user.visible_message("<span class='notice'>\The [user] deactivates \the [src].</span>")
+			user.visible_message("<b>\The [user]</b> deactivates \the [src].")
 			icon_state = "guest-invalid"
 			update_icon()
 			expiration_time = world.time

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -47,7 +47,7 @@
 			playsound(src, S.attack_sound, 75, 1)
 			take_damage(damage)
 		else
-			visible_message("<span class='notice'>\The [user] bonks \the [src] harmlessly.</span>")
+			visible_message("<b>\The [user]</b> bonks \the [src] harmlessly.")
 	user.do_attack_animation(src)
 
 /obj/machinery/door/New()

--- a/code/game/machinery/jukebox.dm
+++ b/code/game/machinery/jukebox.dm
@@ -253,7 +253,7 @@
 
 /obj/machinery/media/jukebox/proc/explode()
 	walk_to(src,0)
-	src.visible_message("<span class='danger'>\the [src] blows apart!</span>", 1)
+	src.visible_message("<span class='danger'>\The [src] blows apart!</span>", 1)
 
 	explosion(src.loc, 0, 0, 1, rand(1,2), 1)
 

--- a/code/game/machinery/oxygen_pump.dm
+++ b/code/game/machinery/oxygen_pump.dm
@@ -55,7 +55,7 @@
 
 /obj/machinery/oxygen_pump/attack_hand(mob/user as mob)
 	if((stat & MAINT) && tank)
-		user.visible_message("<span class='notice'>\The [user] removes \the [tank] from \the [src].</span>", "<span class='notice'>You remove \the [tank] from \the [src].</span>")
+		user.visible_message("<b>\The [user]</b> removes \the [tank] from \the [src].", "<span class='notice'>You remove \the [tank] from \the [src].</span>")
 		user.put_in_hands(tank)
 		src.add_fingerprint(user)
 		tank.add_fingerprint(user)
@@ -69,7 +69,7 @@
 			tank.forceMove(src)
 		breather.remove_from_mob(contained)
 		contained.forceMove(src)
-		src.visible_message("<span class='notice'>\The [user] makes \the [contained] rapidly retract back into \the [src]!</span>")
+		src.visible_message("<b>\The [user]</b> makes \the [contained] rapidly retract back into \the [src]!")
 		if(breather.internals)
 			breather.internals.icon_state = "internal0"
 		breather = null
@@ -140,7 +140,7 @@
 			user.drop_item()
 			W.forceMove(src)
 			tank = W
-			user.visible_message("<span class='notice'>\The [user] installs \the [tank] into \the [src].</span>", "<span class='notice'>You install \the [tank] into \the [src].</span>")
+			user.visible_message("<b>\The [user]</b> installs \the [tank] into \the [src].", "<span class='notice'>You install \the [tank] into \the [src].</span>")
 			src.add_fingerprint(user)
 	if(istype(W, /obj/item/weapon/tank) && !stat)
 		to_chat(user, "<span class='warning'>Please open the maintenance hatch first.</span>")

--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -567,7 +567,7 @@
 			take_damage(incoming_damage)
 			S.do_attack_animation(src)
 			return 1
-		visible_message("<span class='notice'>\The [L] bonks \the [src]'s casing!</span>")
+		visible_message("<b>\The [L]</b> bonks \the [src]'s casing!")
 	return ..()
 
 /obj/machinery/porta_turret/emag_act(var/remaining_charges, var/mob/user)
@@ -1007,7 +1007,7 @@
 					return
 				var/obj/item/weapon/gun/energy/E = I //typecasts the item to an energy gun
 				if(!user.unEquip(I))
-					to_chat(user, "<span class='notice'>\the [I] is stuck to your hand, you cannot put it in \the [src]</span>")
+					to_chat(user, "<span class='notice'>\The [I] is stuck to your hand, you cannot put it in \the [src]</span>")
 					return
 				installation = I.type //installation becomes I.type
 				gun_charge = E.power_supply.charge //the gun's charge is stored in gun_charge
@@ -1028,7 +1028,7 @@
 			if(isprox(I))
 				build_step = 5
 				if(!user.unEquip(I))
-					to_chat(user, "<span class='notice'>\the [I] is stuck to your hand, you cannot put it in \the [src]</span>")
+					to_chat(user, "<span class='notice'>\The [I] is stuck to your hand, you cannot put it in \the [src]</span>")
 					return
 				to_chat(user, "<span class='notice'>You add the prox sensor to the turret.</span>")
 				qdel(I)

--- a/code/game/machinery/reagents/pump.dm
+++ b/code/game/machinery/reagents/pump.dm
@@ -107,7 +107,7 @@
 	if(Output.get_pairing())
 		reagents.trans_to_holder(Output.reagents, Output.reagents.maximum_volume)
 		if(prob(5))
-			visible_message("<span class='notice'>\The [src] gurgles as it exports fluid.</span>")
+			visible_message("<b>\The [src]</b> gurgles as it exports fluid.")
 
 	if(!on)
 		return
@@ -148,7 +148,7 @@
 	on = 1
 	update_icon()
 	if(loud)
-		visible_message("<span class='notice'>\The [src] turns on.</span>")
+		visible_message("<b>\The [src]</b> turns on.")
 	return 1
 
 /obj/machinery/pump/proc/turn_off(var/loud = 0)
@@ -156,7 +156,7 @@
 	set_light(0, 0)
 	update_icon()
 	if(loud)
-		visible_message("<span class='notice'>\The [src] shuts down.</span>")
+		visible_message("<b>\The [src]</b> shuts down.")
 
 	if(!on)
 		return TRUE

--- a/code/game/machinery/supplybeacon.dm
+++ b/code/game/machinery/supplybeacon.dm
@@ -12,11 +12,11 @@
 	deploy_path = /obj/machinery/power/supply_beacon/supermatter
 
 /obj/item/supply_beacon/attack_self(var/mob/user)
-	user.visible_message("<span class='notice'>\The [user] begins setting up \the [src].</span>")
+	user.visible_message("<b>\The [user]</b> begins setting up \the [src].")
 	if(!do_after(user, deploy_time))
 		return
 	var/obj/S = new deploy_path(get_turf(user))
-	user.visible_message("<span class='notice'>\The [user] deploys \the [S].</span>")
+	user.visible_message("<b>\The [user]</b> deploys \the [S].")
 	user.unEquip(src)
 	qdel(src)
 

--- a/code/game/machinery/virtual_reality/ar_console.dm
+++ b/code/game/machinery/virtual_reality/ar_console.dm
@@ -25,7 +25,7 @@
 	if(stat & (BROKEN))
 		if(occupant)
 			go_out()
-			visible_message("<span class='notice'>\The [src] emits a low droning sound, before the pod door clicks open.</span>")
+			visible_message("<b>\The [src]</b> emits a low droning sound, before the pod door clicks open.")
 		return
 	else if(eject_dead && occupant && occupant.stat == DEAD)
 		visible_message("<span class='warning'>\The [src] sounds an alarm, swinging its hatch open.</span>")

--- a/code/game/machinery/virtual_reality/vr_console.dm
+++ b/code/game/machinery/virtual_reality/vr_console.dm
@@ -40,7 +40,7 @@
 	if(stat & (NOPOWER|BROKEN))
 		if(occupant)
 			go_out()
-			visible_message("<span class='notice'>\The [src] emits a low droning sound, before the pod door clicks open.</span>")
+			visible_message("<b>\The [src]</b> emits a low droning sound, before the pod door clicks open.")
 		return
 	else if(eject_dead && occupant && occupant.stat == DEAD) // If someone dies somehow while inside, spit them out.
 		visible_message("<span class='warning'>\The [src] sounds an alarm, swinging its hatch open.</span>")

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -1964,7 +1964,7 @@
 		if(ishuman(occupant))
 			GrantActions(occupant, 1)
 	else
-		visible_message("<span class='notice'>\The [usr] starts to climb into [src.name]</span>")
+		visible_message("<b>\The [usr]</b> starts to climb into [src.name]")
 		if(enter_after(40,usr))
 			if(!src.occupant)
 				moved_inside(usr)
@@ -2604,11 +2604,11 @@
 		var/obj/item/mecha_parts/mecha_equipment/tool/passenger/P = passengers[pname]
 		var/mob/occupant = P.occupant
 
-		user.visible_message("<span class='notice'>\The [user] begins opening the hatch on \the [P]...</span>", "<span class='notice'>You begin opening the hatch on \the [P]...</span>")
+		user.visible_message("<b>\The [user]</b> begins opening the hatch on \the [P]...", "<span class='notice'>You begin opening the hatch on \the [P]...</span>")
 		if (!do_after(user, 40))
 			return
 
-		user.visible_message("<span class='notice'>\The [user] opens the hatch on \the [P] and removes [occupant]!</span>", "<span class='notice'>You open the hatch on \the [P] and remove [occupant]!</span>")
+		user.visible_message("<b>\The [user]</b> opens the hatch on \the [P] and removes [occupant]!", "<span class='notice'>You open the hatch on \the [P] and remove [occupant]!</span>")
 		P.go_out()
 		P.log_message("[occupant] was removed.")
 		return
@@ -2795,7 +2795,7 @@
 	if(prob(temp_deflect_chance))//Deflected
 		src.log_append_to_last("Armor saved.")
 		src.occupant_message("<span class='notice'>\The [user]'s attack is stopped by the armor.</span>")
-		visible_message("<span class='notice'>\The [user] rebounds off [src.name]'s armor!</span>")
+		visible_message("<b>\The [user]</b> rebounds off [src.name]'s armor!")
 		user.attack_log += text("\[[time_stamp()]\] <font color='red'>attacked [src.name]</font>")
 		playsound(src, 'sound/weapons/slash.ogg', 50, 1, -1)
 

--- a/code/game/objects/effects/spiders.dm
+++ b/code/game/objects/effects/spiders.dm
@@ -236,7 +236,7 @@
 				last_itch = world.time
 				to_chat(O.owner, "<span class='notice'>Your [O.name] itches...</span>")
 	else if(prob(1))
-		src.visible_message("<span class='notice'>\The [src] skitters.</span>")
+		src.visible_message("<b>\The [src]</b> skitters.")
 
 	if(amount_grown >= 0)
 		amount_grown += rand(0,2)

--- a/code/game/objects/items/devices/defib.dm
+++ b/code/game/objects/items/devices/defib.dm
@@ -86,7 +86,7 @@
 		reattach_paddles(user)
 	else if(istype(W, /obj/item/weapon/cell))
 		if(bcell)
-			to_chat(user, "<span class='notice'>\the [src] already has a cell.</span>")
+			to_chat(user, "<span class='notice'>\The [src] already has a cell.</span>")
 		else
 			if(!user.unEquip(W))
 				return
@@ -392,7 +392,7 @@
 	user.visible_message("<span class='warning'>\The [user] begins to place [src] on [H]'s chest.</span>", "<span class='warning'>You begin to place [src] on [H]'s chest...</span>")
 	if(!do_after(user, 30, H))
 		return
-	user.visible_message("<span class='notice'>\The [user] places [src] on [H]'s chest.</span>", "<span class='warning'>You place [src] on [H]'s chest.</span>")
+	user.visible_message("<b>\The [user]</b> places [src] on [H]'s chest.", "<span class='warning'>You place [src] on [H]'s chest.</span>")
 	playsound(src, 'sound/machines/defib_charge.ogg', 50, 0)
 
 	var/error = can_defib(H)

--- a/code/game/objects/items/devices/flash.dm
+++ b/code/game/objects/items/devices/flash.dm
@@ -41,7 +41,7 @@
 		if(repairing)
 			to_chat(user, "<span class='notice'>\The [src] is already being repaired!</span>")
 			return
-		user.visible_message("<span class='notice'>\The [user] starts trying to repair \the [src]'s bulb.</span>")
+		user.visible_message("<b>\The [user]</b> starts trying to repair \the [src]'s bulb.")
 		repairing = TRUE
 		if(do_after(user, (40 SECONDS + rand(0, 20 SECONDS)) * W.toolspeed) && can_repair)
 			if(prob(30))
@@ -50,7 +50,7 @@
 				update_icon()
 			playsound(src, W.usesound, 50, 1)
 		else
-			user.visible_message("<span class='notice'>\The [user] fails to repair \the [src].</span>")
+			user.visible_message("<b>\The [user]</b> fails to repair \the [src].")
 		repairing = FALSE
 	else
 		..()

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -115,7 +115,7 @@
 			if(!vision)
 				to_chat(user, "<span class='warning'>You can't find any [H.species.vision_organ ? H.species.vision_organ : "eyes"] on [H]!</span>")
 
-			user.visible_message("<span class='notice'>\The [user] directs [src] to [M]'s eyes.</span>", \
+			user.visible_message("<b>\The [user]</b> directs [src] to [M]'s eyes.", \
 							 	 "<span class='notice'>You direct [src] to [M]'s eyes.</span>")
 			if(H != user)	//can't look into your own eyes buster
 				if(M.stat == DEAD || M.blinded)	//mob is dead or fully blind

--- a/code/game/objects/items/devices/modkit.dm
+++ b/code/game/objects/items/devices/modkit.dm
@@ -49,7 +49,7 @@
 
 	playsound(src, O.usesound, 100, 1)
 
-	user.visible_message("<span class='notice'>\The [user] opens \the [src] and modifies \the [O].</span>","<span class='notice'>You open \the [src] and modify \the [O].</span>")
+	user.visible_message("<b>\The [user]</b> opens \the [src] and modifies \the [O].","<span class='notice'>You open \the [src] and modify \the [O].</span>")
 
 	I.refit_for_species(target_species)
 

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -108,7 +108,7 @@
 			return 1
 		else
 			var/available = get_amount()
-			user.visible_message("<span class='notice'>\The [user] starts bandaging [M]'s [affecting.name].</span>", \
+			user.visible_message("<b>\The [user]</b> starts bandaging [M]'s [affecting.name].", \
 					             "<span class='notice'>You start bandaging [M]'s [affecting.name].</span>" )
 			var/used = 0
 			for (var/datum/wound/W in affecting.wounds)
@@ -131,10 +131,10 @@
 					break
 				
 				if (W.current_stage <= W.max_bleeding_stage)
-					user.visible_message("<span class='notice'>\The [user] bandages \a [W.desc] on [M]'s [affecting.name].</span>", \
+					user.visible_message("<b>\The [user]</b> bandages \a [W.desc] on [M]'s [affecting.name].", \
 					                              "<span class='notice'>You bandage \a [W.desc] on [M]'s [affecting.name].</span>" )
 				else
-					user.visible_message("<span class='notice'>\The [user] places a bandage over \a [W.desc] on [M]'s [affecting.name].</span>", \
+					user.visible_message("<b>\The [user]</b> places a bandage over \a [W.desc] on [M]'s [affecting.name].", \
 					                              "<span class='notice'>You place a bandage over \a [W.desc] on [M]'s [affecting.name].</span>" )
 				W.bandage()
 				playsound(src, pick(apply_sounds), 25)
@@ -177,7 +177,7 @@
 			return 1
 		else
 			var/available = get_amount()
-			user.visible_message("<span class='notice'>\The [user] starts treating [M]'s [affecting.name].</span>", \
+			user.visible_message("<b>\The [user]</b> starts treating [M]'s [affecting.name].", \
 					             "<span class='notice'>You start treating [M]'s [affecting.name].</span>" )
 			var/used = 0
 			for (var/datum/wound/W in affecting.wounds)
@@ -200,14 +200,14 @@
 					break
 
 				if (W.current_stage <= W.max_bleeding_stage)
-					user.visible_message("<span class='notice'>\The [user] bandages \a [W.desc] on [M]'s [affecting.name].</span>", \
+					user.visible_message("<b>\The [user]</b> bandages \a [W.desc] on [M]'s [affecting.name].", \
 					                              "<span class='notice'>You bandage \a [W.desc] on [M]'s [affecting.name].</span>" )
 					//H.add_side_effect("Itch")
 				else if (W.damage_type == BRUISE)
-					user.visible_message("<span class='notice'>\The [user] places a bruise patch over \a [W.desc] on [M]'s [affecting.name].</span>", \
+					user.visible_message("<b>\The [user]</b> places a bruise patch over \a [W.desc] on [M]'s [affecting.name].", \
 					                              "<span class='notice'>You place a bruise patch over \a [W.desc] on [M]'s [affecting.name].</span>" )
 				else
-					user.visible_message("<span class='notice'>\The [user] places a bandaid over \a [W.desc] on [M]'s [affecting.name].</span>", \
+					user.visible_message("<b>\The [user]</b> places a bandaid over \a [W.desc] on [M]'s [affecting.name].", \
 					                              "<span class='notice'>You place a bandaid over \a [W.desc] on [M]'s [affecting.name].</span>" )
 				W.bandage()
 				// W.disinfect() // VOREStation - Tech1 should not disinfect
@@ -250,7 +250,7 @@
 			to_chat(user, "<span class='warning'>The wounds on [M]'s [affecting.name] have already been salved.</span>")
 			return 1
 		else
-			user.visible_message("<span class='notice'>\The [user] starts salving wounds on [M]'s [affecting.name].</span>", \
+			user.visible_message("<b>\The [user]</b> starts salving wounds on [M]'s [affecting.name].", \
 					             "<span class='notice'>You start salving the wounds on [M]'s [affecting.name].</span>" )
 			if(!do_mob(user, M, 10, exclusive = TRUE))
 				to_chat(user, "<span class='notice'>You must stand still to salve wounds.</span>")
@@ -290,7 +290,7 @@
 			return 1
 		else
 			var/available = get_amount()
-			user.visible_message("<span class='notice'>\The [user] starts treating [M]'s [affecting.name].</span>", \
+			user.visible_message("<b>\The [user]</b> starts treating [M]'s [affecting.name].", \
 					             "<span class='notice'>You start treating [M]'s [affecting.name].</span>" )
 			var/used = 0
 			for (var/datum/wound/W in affecting.wounds)
@@ -312,13 +312,13 @@
 					break
 
 				if (W.current_stage <= W.max_bleeding_stage)
-					user.visible_message("<span class='notice'>\The [user] cleans \a [W.desc] on [M]'s [affecting.name] and seals the edges with bioglue.</span>", \
+					user.visible_message("<b>\The [user]</b> cleans \a [W.desc] on [M]'s [affecting.name] and seals the edges with bioglue.", \
 					                     "<span class='notice'>You clean and seal \a [W.desc] on [M]'s [affecting.name].</span>" )
 				else if (W.damage_type == BRUISE)
-					user.visible_message("<span class='notice'>\The [user] places a medical patch over \a [W.desc] on [M]'s [affecting.name].</span>", \
+					user.visible_message("<b>\The [user]</b> places a medical patch over \a [W.desc] on [M]'s [affecting.name].", \
 					                              "<span class='notice'>You place a medical patch over \a [W.desc] on [M]'s [affecting.name].</span>" )
 				else
-					user.visible_message("<span class='notice'>\The [user] smears some bioglue over \a [W.desc] on [M]'s [affecting.name].</span>", \
+					user.visible_message("<b>\The [user]</b> smears some bioglue over \a [W.desc] on [M]'s [affecting.name].", \
 					                              "<span class='notice'>You smear some bioglue over \a [W.desc] on [M]'s [affecting.name].</span>" )
 				W.bandage()
 				W.disinfect()
@@ -358,7 +358,7 @@
 			to_chat(user, "<span class='warning'>The wounds on [M]'s [affecting.name] have already been salved.</span>")
 			return 1
 		else
-			user.visible_message("<span class='notice'>\The [user] starts salving wounds on [M]'s [affecting.name].</span>", \
+			user.visible_message("<b>\The [user]</b> starts salving wounds on [M]'s [affecting.name].", \
 					             "<span class='notice'>You start salving the wounds on [M]'s [affecting.name].</span>" )
 			if(!do_mob(user, M, 10, exclusive = TRUE))
 				to_chat(user, "<span class='notice'>You must stand still to salve wounds.</span>")

--- a/code/game/objects/items/weapons/autopsy.dm
+++ b/code/game/objects/items/weapons/autopsy.dm
@@ -177,7 +177,7 @@
 	if(!S.open)
 		to_chat(user, "<span class='warning'>You have to cut [S] open first!</span>")
 		return
-	M.visible_message("<span class='notice'>\The [user] scans the wounds on [M]'s [S.name] with [src]</span>")
+	M.visible_message("<b>\The [user]</b> scans the wounds on [M]'s [S.name] with [src]")
 
 	src.add_data(S)
 

--- a/code/game/objects/items/weapons/canes.dm
+++ b/code/game/objects/items/weapons/canes.dm
@@ -97,7 +97,7 @@
 /obj/item/weapon/cane/white/collapsible/attack_self(mob/user as mob)
 	on = !on
 	if(on)
-		user.visible_message("<span class='notice'>\The [user] extends the white cane.</span>",\
+		user.visible_message("<b>\The [user]</b> extends the white cane.",\
 				"<span class='warning'>You extend the white cane.</span>",\
 				"You hear an ominous click.")
 		icon_state = "whitecane1out"
@@ -106,7 +106,7 @@
 		force = 5
 		attack_verb = list("smacked", "struck", "cracked", "beaten")
 	else
-		user.visible_message("<span class='notice'>\The [user] collapses the white cane.</span>",\
+		user.visible_message("<b>\The [user]</b> collapses the white cane.",\
 		"<span class='notice'>You collapse the white cane.</span>",\
 		"You hear a click.")
 		icon_state = "whitecane1in"

--- a/code/game/objects/items/weapons/circuitboards/computer/research.dm
+++ b/code/game/objects/items/weapons/circuitboards/computer/research.dm
@@ -9,7 +9,7 @@
 /obj/item/weapon/circuitboard/rdconsole/attackby(obj/item/I as obj, mob/user as mob)
 	if(I.is_screwdriver())
 		playsound(src, I.usesound, 50, 1)
-		user.visible_message("<span class='notice'>\The [user] adjusts the jumper on \the [src]'s access protocol pins.</span>", "<span class='notice'>You adjust the jumper on the access protocol pins.</span>")
+		user.visible_message("<b>\The [user]</b> adjusts the jumper on \the [src]'s access protocol pins.", "<span class='notice'>You adjust the jumper on the access protocol pins.</span>")
 		if(build_path == /obj/machinery/computer/rdconsole/core)
 			name = T_BOARD("RD Console - Robotics")
 			build_path = /obj/machinery/computer/rdconsole/robotics

--- a/code/game/objects/items/weapons/circuitboards/machinery/research.dm
+++ b/code/game/objects/items/weapons/circuitboards/machinery/research.dm
@@ -14,7 +14,7 @@
 /obj/item/weapon/circuitboard/rdserver/attackby(obj/item/I as obj, mob/user as mob)
 	if(I.is_screwdriver())
 		playsound(src, I.usesound, 50, 1)
-		user.visible_message("<span class='notice'>\The [user] adjusts the jumper on \the [src]'s access protocol pins.</span>", "<span class='notice'>You adjust the jumper on the access protocol pins.</span>")
+		user.visible_message("<b>\The [user]</b> adjusts the jumper on \the [src]'s access protocol pins.", "<span class='notice'>You adjust the jumper on the access protocol pins.</span>")
 		if(build_path == /obj/machinery/r_n_d/server/core)
 			name = T_BOARD("RD Console - Robotics")
 			build_path = /obj/machinery/r_n_d/server/robotics

--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -301,7 +301,7 @@ var/last_chew = 0
 		return 1
 
 /obj/item/weapon/handcuffs/legcuffs/bola/dropped()
-	visible_message("<span class='notice'>\The [src] falls apart!</span>")
+	visible_message("<b>\The [src]</b> falls apart!")
 	qdel(src)
 
 /obj/item/weapon/handcuffs/legcuffs/bola/place_legcuffs(var/mob/living/carbon/target, var/mob/user)
@@ -313,7 +313,7 @@ var/last_chew = 0
 		return 0
 
 	if(!H.has_organ_for_slot(slot_legcuffed))
-		H.visible_message("<span class='notice'>\The [src] slams into [H], but slides off!</span>")
+		H.visible_message("<b>\The [src]</b> slams into [H], but slides off!")
 		src.dropped()
 		return 0
 

--- a/code/game/objects/items/weapons/policetape.dm
+++ b/code/game/objects/items/weapons/policetape.dm
@@ -333,7 +333,7 @@ var/list/tape_roll_applications = list()
 
 /obj/item/tape/attack_hand(mob/user as mob)
 	if (user.a_intent == I_HELP && src.allowed(user))
-		user.show_viewers("<span class='notice'>\The [user] lifts \the [src], allowing passage.</span>")
+		user.show_viewers("<b>\The [user]</b> lifts \the [src], allowing passage.")
 		for(var/obj/item/tape/T in gettapeline())
 			T.lift(100) //~10 seconds
 	else
@@ -377,7 +377,7 @@ var/list/tape_roll_applications = list()
 	if(user.a_intent == I_HELP)
 		to_chat(user, "<span class='warning'>You refrain from breaking \the [src].</span>")
 		return
-	user.visible_message("<span class='notice'>\The [user] breaks \the [src]!</span>","<span class='notice'>You break \the [src].</span>")
+	user.visible_message("<b>\The [user]</b> breaks \the [src]!","<span class='notice'>You break \the [src].</span>")
 
 	for (var/obj/item/tape/T in gettapeline())
 		if(T == src)

--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -465,29 +465,29 @@
 		return
 
 	if(!parachute)	//This packs the parachute
-		H.visible_message("<span class='notice'>\The [H] starts to pack \the [src]!</span>", \
+		H.visible_message("<b>\The [H]</b> starts to pack \the [src]!", \
 					"<span class='notice'>You start to pack \the [src]!</span>", \
 					"You hear the shuffling of cloth.")
 		if(do_after(H, 50))
-			H.visible_message("<span class='notice'>\The [H] finishes packing \the [src]!</span>", \
+			H.visible_message("<b>\The [H]</b> finishes packing \the [src]!", \
 					"<span class='notice'>You finish packing \the [src]!</span>", \
 					"You hear the shuffling of cloth.")
 			parachute = TRUE
 		else
-			H.visible_message("<span class='notice'>\The [src] gives up on packing \the [src]!</span>", \
+			H.visible_message("<b>\The [src]</b> gives up on packing \the [src]!", \
 					"<span class='notice'>You give up on packing \the [src]!</span>")
 			return
 	else			//This unpacks the parachute
-		H.visible_message("<span class='notice'>\The [src] starts to unpack \the [src]!</span>", \
+		H.visible_message("<b>\The [src]</b> starts to unpack \the [src]!", \
 					"<span class='notice'>You start to unpack \the [src]!</span>", \
 					"You hear the shuffling of cloth.")
 		if(do_after(H, 25))
-			H.visible_message("<span class='notice'>\The [src] finishes unpacking \the [src]!</span>", \
+			H.visible_message("<b>\The [src]</b> finishes unpacking \the [src]!", \
 					"<span class='notice'>You finish unpacking \the [src]!</span>", \
 					"You hear the shuffling of cloth.")
 			parachute = FALSE
 		else
-			H.visible_message("<span class='notice'>\The [src] decides not to unpack \the [src]!</span>", \
+			H.visible_message("<b>\The [src]</b> decides not to unpack \the [src]!", \
 					"<span class='notice'>You decide not to unpack \the [src]!</span>")
 	return
 

--- a/code/game/objects/items/weapons/swords_axes_etc.dm
+++ b/code/game/objects/items/weapons/swords_axes_etc.dm
@@ -67,7 +67,7 @@
 		force = 15//quite robust
 		attack_verb = list("smacked", "struck", "slapped")
 	else
-		user.visible_message("<span class='notice'>\The [user] collapses their telescopic baton.</span>",\
+		user.visible_message("<b>\The [user]</b> collapses their telescopic baton.",\
 		"<span class='notice'>You collapse the baton.</span>",\
 		"You hear a click.")
 		icon_state = "telebaton0"

--- a/code/game/objects/items/weapons/tools/weldingtool.dm
+++ b/code/game/objects/items/weapons/tools/weldingtool.dm
@@ -508,7 +508,7 @@
 
 	if(mounted_pack.loc != src.loc && src.loc != mounted_pack)
 		mounted_pack.return_nozzle()
-		visible_message("<span class='notice'>\The [src] retracts to its fueltank.</span>")
+		visible_message("<b>\The [src]</b> retracts to its fueltank.")
 
 	if(get_fuel() <= get_max_fuel())
 		mounted_pack.reagents.trans_to_obj(src, 1)

--- a/code/game/objects/structures/bedsheet_bin.dm
+++ b/code/game/objects/structures/bedsheet_bin.dm
@@ -30,7 +30,7 @@ LINEN BINS
 
 /obj/item/weapon/bedsheet/attackby(obj/item/I, mob/user)
 	if(is_sharp(I))
-		user.visible_message("<span class='notice'>\The [user] begins cutting up [src] with [I].</span>", "<span class='notice'>You begin cutting up [src] with [I].</span>")
+		user.visible_message("<b>\The [user]</b> begins cutting up [src] with [I].", "<span class='notice'>You begin cutting up [src] with [I].</span>")
 		if(do_after(user, 50))
 			to_chat(user, "<span class='notice'>You cut [src] into pieces!</span>")
 			for(var/i in 1 to rand(2,5))

--- a/code/game/objects/structures/bonfire.dm
+++ b/code/game/objects/structures/bonfire.dm
@@ -160,7 +160,7 @@
 		burning = FALSE
 		update_icon()
 		STOP_PROCESSING(SSobj, src)
-		visible_message("<span class='notice'>\The [src] stops burning.</span>")
+		visible_message("<b>\The [src]</b> stops burning.")
 
 /obj/structure/bonfire/proc/ignite()
 	if(!burning && get_fuel_amount())
@@ -353,7 +353,7 @@
 		burning = FALSE
 		update_icon()
 		STOP_PROCESSING(SSobj, src)
-		visible_message("<span class='notice'>\The [src] stops burning.</span>")
+		visible_message("<b>\The [src]</b> stops burning.")
 
 /obj/structure/fireplace/proc/ignite()
 	if(!burning && get_fuel_amount())

--- a/code/game/objects/structures/flora/trees.dm
+++ b/code/game/objects/structures/flora/trees.dm
@@ -47,7 +47,7 @@
 	if(is_stump)
 		if(istype(W,/obj/item/weapon/shovel))
 			if(do_after(user, 5 SECONDS))
-				visible_message("<span class='notice'>\The [user] digs up \the [src] stump with \the [W].</span>")
+				visible_message("<b>\The [user]</b> digs up \the [src] stump with \the [W].")
 				qdel(src)
 		return
 

--- a/code/game/objects/structures/ghost_pods/ghost_pods_vr.dm
+++ b/code/game/objects/structures/ghost_pods/ghost_pods_vr.dm
@@ -15,7 +15,7 @@
 		return
 
 	if(!activated)
-		to_chat(user, "<span class='warning'>\the [src] has not yet been activated.  Sorry.</span>")
+		to_chat(user, "<span class='warning'>\The [src] has not yet been activated.  Sorry.</span>")
 		return
 
 	if(used)

--- a/code/game/objects/structures/medical_stand_vr.dm
+++ b/code/game/objects/structures/medical_stand_vr.dm
@@ -129,10 +129,10 @@
 						qdel(contained)
 						contained = new mask_type(src)
 					breather = null
-					src.visible_message("<span class='notice'>\The [contained] slips to \the [src]!</span>")
+					src.visible_message("<b>\The [contained]</b> slips to \the [src]!")
 					update_icon()
 					return
-				usr.visible_message("<span class='notice'>\The [usr] begins carefully placing the mask onto [target].</span>",
+				usr.visible_message("<b>\The [usr]</b> begins carefully placing the mask onto [target].",
 							"<span class='notice'>You begin carefully placing the mask onto [target].</span>")
 				if(!do_mob(usr, target, 100) || !can_apply_to_target(target, usr))
 					return
@@ -151,14 +151,14 @@
 					visible_message("\The [attached] is taken off \the [src]")
 					attached = null
 				else if(ishuman(target))
-					usr.visible_message("<span class='notice'>\The [usr] begins inserting needle into [target]'s vein.</span>",
+					usr.visible_message("<b>\The [usr]</b> begins inserting needle into [target]'s vein.",
 									"<span class='notice'>You begin inserting needle into [target]'s vein.</span>")
 					if(!do_mob(usr, target, 50))
 						usr.visible_message("<span class='notice'>\The [usr]'s hand slips and pricks \the [target].</span>",
 									"<span class='notice'>Your hand slips and pricks \the [target].</span>")
 						target.apply_damage(3, BRUTE, pick(BP_R_ARM, BP_L_ARM))
 						return
-					usr.visible_message("<span class='notice'>\The [usr] hooks \the [target] up to \the [src].</span>",
+					usr.visible_message("<b>\The [usr]</b> hooks \the [target] up to \the [src].",
 									"<span class='notice'>You hook \the [target] up to \the [src].</span>")
 					attached = target
 					START_PROCESSING(SSobj,src)
@@ -184,13 +184,13 @@
 				to_chat(user, "<span class='warning'>There is no tank in \the [src]!</span>")
 				return
 			else if (tank && is_loosen)
-				user.visible_message("<span class='notice'>\The [user] removes \the [tank] from \the [src].</span>", "<span class='warning'>You remove \the [tank] from \the [src].</span</span>>")
+				user.visible_message("<b>\The [user]</b> removes \the [tank] from \the [src].", "<span class='warning'>You remove \the [tank] from \the [src].</span</span>>")
 				user.put_in_hands(tank)
 				tank = null
 				update_icon()
 				return
 			else if (!is_loosen)
-				user.visible_message("<span class='notice'>\The [user] tries to removes \the [tank] from \the [src] but it won't budge.</span>", "<span class='warning'>You try to removes \the [tank] from \the [src] but it won't budge.</span</span>>")
+				user.visible_message("<b>\The [user]</b> tries to removes \the [tank] from \the [src] but it won't budge.", "<span class='warning'>You try to removes \the [tank] from \the [src] but it won't budge.</span</span>>")
 				return
 		if ("Toggle valve")
 			if (!tank)
@@ -198,7 +198,7 @@
 				return
 			else
 				if (valve_opened)
-					src.visible_message("<span class='notice'>\The [user] closes valve on \the [src]!</span>",
+					src.visible_message("<b>\The [user]</b> closes valve on \the [src]!",
 						"<span class='notice'>You close valve on \the [src].</span>")
 					if(breather)
 						breather.internals?.icon_state = "internal0"
@@ -206,7 +206,7 @@
 					valve_opened = FALSE
 					update_icon()
 				else
-					src.visible_message("<span class='notice'>\The [user] opens valve on \the [src]!</span>",
+					src.visible_message("<b>\The [user]</b> opens valve on \the [src]!",
 										"<span class='notice'>You open valve on \the [src].</span>")
 					if(breather)
 						breather.internal = tank
@@ -319,7 +319,7 @@
 			user.drop_item()
 			W.forceMove(src)
 			tank = W
-			user.visible_message("<span class='notice'>\The [user] attaches \the [tank] to \the [src].</span>", "<span class='notice'>You attach \the [tank] to \the [src].</span>")
+			user.visible_message("<b>\The [user]</b> attaches \the [tank] to \the [src].", "<span class='notice'>You attach \the [tank] to \the [src].</span>")
 			src.add_fingerprint(user)
 			update_icon()
 
@@ -373,7 +373,7 @@
 			else
 				qdel(contained)
 				contained = new mask_type (src)
-			src.visible_message("<span class='notice'>\The [contained] slips to \the [src]!</span>")
+			src.visible_message("<b>\The [contained]</b> slips to \the [src]!")
 			breather = null
 			update_icon()
 			return

--- a/code/game/objects/structures/props/beam_prism.dm
+++ b/code/game/objects/structures/props/beam_prism.dm
@@ -90,11 +90,11 @@
 
 /obj/structure/prop/prism/proc/rotate_auto(var/new_bearing)
 	if(rotation_lock)
-		visible_message("<span class='notice'>\The [src] shudders.</span>")
+		visible_message("<b>\The [src]</b> shudders.")
 		playsound(src, 'sound/effects/clang.ogg', 50, 1)
 		return
 
-	visible_message("<span class='notice'>\The [src] rotates to a bearing of [new_bearing].</span>")
+	visible_message("<b>\The [src]</b> rotates to a bearing of [new_bearing].")
 
 	var/rotate_degrees = new_bearing - degrees_from_north
 

--- a/code/game/objects/structures/railing.dm
+++ b/code/game/objects/structures/railing.dm
@@ -205,7 +205,7 @@
 	if(W.is_wrench() && !anchored)
 		playsound(src, W.usesound, 50, 1)
 		if(do_after(user, 20, src))
-			user.visible_message("<span class='notice'>\The [user] dismantles \the [src].</span>", "<span class='notice'>You dismantle \the [src].</span>")
+			user.visible_message("<b>\The [user]</b> dismantles \the [src].", "<span class='notice'>You dismantle \the [src].</span>")
 			new /obj/item/stack/material/steel(get_turf(usr), 2)
 			qdel(src)
 			return
@@ -216,13 +216,13 @@
 		if(F.welding)
 			playsound(src, F.usesound, 50, 1)
 			if(do_after(user, 20, src))
-				user.visible_message("<span class='notice'>\The [user] repairs some damage to \the [src].</span>", "<span class='notice'>You repair some damage to \the [src].</span>")
+				user.visible_message("<b>\The [user]</b> repairs some damage to \the [src].", "<span class='notice'>You repair some damage to \the [src].</span>")
 				health = min(health+(maxhealth/5), maxhealth) // 20% repair per application
 				return
 
 	// Install
 	if(W.is_screwdriver())
-		user.visible_message(anchored ? "<span class='notice'>\The [user] begins unscrewing \the [src].</span>" : "<span class='notice'>\The [user] begins fasten \the [src].</span>" )
+		user.visible_message(anchored ? "<b>\The [user]</b> begins unscrewing \the [src]." : "<b>\The [user]</b> begins fasten \the [src]." )
 		playsound(src, W.usesound, 75, 1)
 		if(do_after(user, 10, src))
 			to_chat(user, (anchored ? "<span class='notice'>You have unfastened \the [src] from the floor.</span>" : "<span class='notice'>You have fastened \the [src] to the floor.</span>"))

--- a/code/game/objects/structures/salvageable.dm
+++ b/code/game/objects/structures/salvageable.dm
@@ -18,7 +18,7 @@
 		playsound(src, I.usesound, 50, 1)
 		var/actual_time = I.toolspeed * 170
 		user.visible_message( \
-			"<span class='notice'>\The [user] begins salvaging from \the [src].</span>", \
+			"<b>\The [user]</b> begins salvaging from \the [src].", \
 			"<span class='notice'>You start salvaging from \the [src].</span>")
 		if(do_after(user, actual_time, target = src))
 			user.visible_message( \

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -324,7 +324,7 @@
 		to_chat(usr, "<span class='warning'>\The [thing] is empty.</span>")
 		return
 	// Clear the vessel.
-	visible_message("<span class='notice'>\The [usr] tips the contents of \the [thing] into \the [src].</span>")
+	visible_message("<b>\The [usr]</b> tips the contents of \the [thing] into \the [src].")
 	thing.reagents.clear_reagents()
 	thing.update_icon()
 

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -215,7 +215,7 @@
 			damage = damage / 2
 		take_damage(damage)
 	else
-		visible_message("<span class='notice'>\The [user] bonks \the [src] harmlessly.</span>")
+		visible_message("<b>\The [user]</b> bonks \the [src] harmlessly.")
 	user.do_attack_animation(src)
 	return 1
 
@@ -302,7 +302,7 @@
 		if (C.use(1))
 			playsound(src, 'sound/effects/sparks1.ogg', 75, 1)
 			user.visible_message( \
-				"<span class='notice'>\The [user] begins to wire \the [src] for electrochromic tinting.</span>", \
+				"<b>\The [user]</b> begins to wire \the [src] for electrochromic tinting.", \
 				"<span class='notice'>You begin to wire \the [src] for electrochromic tinting.</span>", \
 				"You hear sparks.")
 			if(do_after(user, 20 * C.toolspeed, src) && state == 0)

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -677,7 +677,7 @@
 		user.unEquip(I)
 		I.forceMove(src)
 		holding = I
-		user.visible_message("<span class='notice'>\The [user] shoves \the [I] into \the [src].</span>")
+		user.visible_message("<b>\The [user]</b> shoves \the [I] into \the [src].")
 		verbs |= /obj/item/clothing/shoes/proc/draw_knife
 		update_icon()
 	else

--- a/code/modules/clothing/gloves/miscellaneous.dm
+++ b/code/modules/clothing/gloves/miscellaneous.dm
@@ -62,7 +62,7 @@
 
 //TODO: Make inflating gloves a thing
 /*/obj/item/clothing/gloves/sterile/proc/Inflate(/mob/living/carbon/human/user)
-	user.visible_message("<span class='notice'>\The [src] expands!</span>")
+	user.visible_message("<b>\The [src]</b> expands!")
 	qdel(src)*/
 
 /obj/item/clothing/gloves/sterile/latex

--- a/code/modules/detectivework/tools/rag.dm
+++ b/code/modules/detectivework/tools/rag.dm
@@ -152,7 +152,7 @@
 			return
 
 		if(A.reagents && A.reagents.trans_to_obj(src, reagents.maximum_volume))
-			user.visible_message("<span class='notice'>\The [user] soaks [src] using [A].</span>", "<span class='notice'>You soak [src] using [A].</span>")
+			user.visible_message("<b>\The [user]</b> soaks [src] using [A].", "<span class='notice'>You soak [src] using [A].</span>")
 			update_name()
 		return
 

--- a/code/modules/economy/vending.dm
+++ b/code/modules/economy/vending.dm
@@ -580,7 +580,7 @@ GLOBAL_LIST_EMPTY(vending_products)
 	if(prob(1))
 		sleep(3)
 		if(R.get_product(get_turf(src)))
-			visible_message("<span class='notice'>\The [src] clunks as it vends an additional item.</span>")
+			visible_message("<b>\The [src]</b> clunks as it vends an additional item.")
 	playsound(src, "sound/[vending_sound]", 100, 1, 1)
 
 	GLOB.items_sold_shift_roundstat++

--- a/code/modules/food/food/snacks.dm
+++ b/code/modules/food/food/snacks.dm
@@ -235,7 +235,7 @@
 				user.visible_message("<span class='notice'>\The [user] crudely slices \the [src] with [W]!</span>", "<span class='notice'>You crudely slice \the [src] with your [W]!</span>")
 				slices_lost = rand(1,min(1,round(slices_num/2)))
 			else
-				user.visible_message("<span class='notice'>\The [user] slices \the [src]!</span>", "<span class='notice'>You slice \the [src]!</span>")
+				user.visible_message("<b>\The [user]</b> slices \the [src]!", "<span class='notice'>You slice \the [src]!</span>")
 
 			var/reagents_per_slice = reagents.total_volume/slices_num
 			for(var/i=1 to (slices_num-slices_lost))
@@ -1833,7 +1833,7 @@
 		Unwrap(user)
 
 /obj/item/weapon/reagent_containers/food/snacks/monkeycube/proc/Expand()
-	src.visible_message("<span class='notice'>\The [src] expands!</span>")
+	src.visible_message("<b>\The [src]</b> expands!")
 	var/mob/living/carbon/human/H = new(get_turf(src))
 	H.set_species(monkey_type)
 	H.real_name = H.species.get_random_name()

--- a/code/modules/food/food/snacks_vr.dm
+++ b/code/modules/food/food/snacks_vr.dm
@@ -476,7 +476,7 @@
 	. = ..()
 
 /obj/item/weapon/reagent_containers/food/snacks/cube/proc/Expand()
-	src.visible_message("<span class='notice'>\The [src] expands!</span>")
+	src.visible_message("<b>\The [src]</b> expands!")
 	new food_type(get_turf(src))
 	qdel(src)
 

--- a/code/modules/food/kitchen/cooking_machines/_appliance.dm
+++ b/code/modules/food/kitchen/cooking_machines/_appliance.dm
@@ -319,7 +319,7 @@
 		CI = new /datum/cooking_item/(CC)
 		I.forceMove(src)
 		cooking_objs.Add(CI)
-		user.visible_message("<span class='notice'>\The [user] puts \the [I] into \the [src].</span>")
+		user.visible_message("<b>\The [user]</b> puts \the [I] into \the [src].")
 		if (CC.check_contents() == 0)//If we're just putting an empty container in, then dont start any processing.
 			return TRUE
 	else
@@ -333,7 +333,7 @@
 		CI.combine_target = selected_option
 
 	// We can actually start cooking now.
-	user.visible_message("<span class='notice'>\The [user] puts \the [I] into \the [src].</span>")
+	user.visible_message("<b>\The [user]</b> puts \the [I] into \the [src].")
 
 	get_cooking_work(CI)
 	cooking = TRUE
@@ -433,7 +433,7 @@
 
 /obj/machinery/appliance/proc/finish_cooking(var/datum/cooking_item/CI)
 
-	src.visible_message("<span class='notice'>\The [src] pings!</span>")
+	src.visible_message("<b>\The [src]</b> pings!")
 	if(cooked_sound)
 		playsound(get_turf(src), cooked_sound, 50, 1)
 	//Check recipes first, a valid recipe overrides other options

--- a/code/modules/food/kitchen/cooking_machines/oven.dm
+++ b/code/modules/food/kitchen/cooking_machines/oven.dm
@@ -148,7 +148,7 @@
 /obj/machinery/appliance/cooker/oven/finish_cooking(var/datum/cooking_item/CI)
 	if(CI.combine_target)
 		CI.result_type = 3//Combination type. We're making something out of our ingredients
-		visible_message("<span class='notice'>\The [src] pings!</span>")
+		visible_message("<b>\The [src]</b> pings!")
 		combination_cook(CI)
 		return
 	else

--- a/code/modules/food/kitchen/microwave.dm
+++ b/code/modules/food/kitchen/microwave.dm
@@ -77,24 +77,24 @@
 	if(src.broken > 0)
 		if(src.broken == 2 && O.is_screwdriver()) // If it's broken and they're using a screwdriver
 			user.visible_message( \
-				"<span class='notice'>\The [user] starts to fix part of the microwave.</span>", \
+				"<b>\The [user]</b> starts to fix part of the microwave.", \
 				"<span class='notice'>You start to fix part of the microwave.</span>" \
 			)
 			playsound(src, O.usesound, 50, 1)
 			if (do_after(user,20 * O.toolspeed))
 				user.visible_message( \
-					"<span class='notice'>\The [user] fixes part of the microwave.</span>", \
+					"<b>\The [user]</b> fixes part of the microwave.", \
 					"<span class='notice'>You have fixed part of the microwave.</span>" \
 				)
 				src.broken = 1 // Fix it a bit
 		else if(src.broken == 1 && O.is_wrench()) // If it's broken and they're doing the wrench
 			user.visible_message( \
-				"<span class='notice'>\The [user] starts to fix part of the microwave.</span>", \
+				"<b>\The [user]</b> starts to fix part of the microwave.", \
 				"<span class='notice'>You start to fix part of the microwave.</span>" \
 			)
 			if (do_after(user,20 * O.toolspeed))
 				user.visible_message( \
-					"<span class='notice'>\The [user] fixes the microwave.</span>", \
+					"<b>\The [user]</b> fixes the microwave.", \
 					"<span class='notice'>You have fixed the microwave.</span>" \
 				)
 				src.icon_state = "mw"
@@ -108,7 +108,7 @@
 	else if(src.dirty==100) // The microwave is all dirty so can't be used!
 		if(istype(O, /obj/item/weapon/reagent_containers/spray/cleaner) || istype(O, /obj/item/weapon/soap)) // If they're trying to clean it then let them
 			user.visible_message( \
-				"<span class='notice'>\The [user] starts to clean the microwave.</span>", \
+				"<b>\The [user]</b> starts to clean the microwave.", \
 				"<span class='notice'>You start to clean the microwave.</span>" \
 			)
 			if (do_after(user,20))

--- a/code/modules/games/cards.dm
+++ b/code/modules/games/cards.dm
@@ -111,7 +111,7 @@
 	cards -= P
 	H.parentdeck = src
 	H.update_icon()
-	user.visible_message("<span class='notice'>\The [user] draws a card.</span>")
+	user.visible_message("<b>\The [user]</b> draws a card.")
 	to_chat(user,"<span class='notice'>It's the [P].</span>")
 
 /obj/item/weapon/deck/verb/deal_card()

--- a/code/modules/ghosttrap/trap.dm
+++ b/code/modules/ghosttrap/trap.dm
@@ -83,7 +83,7 @@ var/list/ghost_traps
 	to_chat(target, "<b>Remember, the purpose of your existence is to serve the crew and the station. Above all else, do no harm.</b>")
 	to_chat(target, "<b>Use say #b to speak to other artificial intelligences.</b>")
 	var/turf/T = get_turf(target)
-	T.visible_message("<span class='notice'>\The [src] chimes quietly.</span>")
+	T.visible_message("<b>\The [src]</b> chimes quietly.")
 	var/obj/item/device/mmi/digital/posibrain/P = target.loc
 	if(!istype(P)) //wat
 		return

--- a/code/modules/holodeck/HolodeckObjects.dm
+++ b/code/modules/holodeck/HolodeckObjects.dm
@@ -513,5 +513,5 @@
 	derez()
 
 /mob/living/simple_mob/animal/space/carp/holodeck/proc/derez()
-	visible_message("<span class='notice'>\The [src] fades away!</span>")
+	visible_message("<b>\The [src]</b> fades away!")
 	qdel(src)

--- a/code/modules/hydroponics/seed.dm
+++ b/code/modules/hydroponics/seed.dm
@@ -571,7 +571,7 @@
 
 	if(!degree || get_trait(TRAIT_IMMUTABLE) > 0) return
 
-	source_turf.visible_message("<span class='notice'>\The [display_name] quivers!</span>")
+	source_turf.visible_message("<b>\The [display_name]</b> quivers!")
 
 	//This looks like shit, but it's a lot easier to read/change this way.
 	var/total_mutations = rand(1,1+degree)
@@ -608,7 +608,7 @@
 				if(prob(degree*5))
 					set_trait(TRAIT_CARNIVOROUS,     get_trait(TRAIT_CARNIVOROUS)+rand(-degree,degree),2, 0)
 					if(get_trait(TRAIT_CARNIVOROUS))
-						source_turf.visible_message("<span class='notice'>\The [display_name] shudders hungrily.</span>")
+						source_turf.visible_message("<b>\The [display_name]</b> shudders hungrily.")
 			if(6)
 				set_trait(TRAIT_WEED_TOLERANCE,      get_trait(TRAIT_WEED_TOLERANCE)+(rand(-2,2)*degree),10, 0)
 				if(prob(degree*5))
@@ -629,7 +629,7 @@
 				set_trait(TRAIT_POTENCY,             get_trait(TRAIT_POTENCY)+(rand(-20,20)*degree),200, 0)
 				if(prob(degree*5))
 					set_trait(TRAIT_SPREAD,          get_trait(TRAIT_SPREAD)+rand(-1,1),2, 0)
-					source_turf.visible_message("<span class='notice'>\The [display_name] spasms visibly, shifting in the tray.</span>")
+					source_turf.visible_message("<b>\The [display_name]</b> spasms visibly, shifting in the tray.")
 				if(prob(degree*3))
 					set_trait(TRAIT_SPORING,        !get_trait(TRAIT_SPORING))
 			if(9)
@@ -647,7 +647,7 @@
 				if(prob(degree*2))
 					set_trait(TRAIT_BIOLUM,         !get_trait(TRAIT_BIOLUM))
 					if(get_trait(TRAIT_BIOLUM))
-						source_turf.visible_message("<span class='notice'>\The [display_name] begins to glow!</span>")
+						source_turf.visible_message("<b>\The [display_name]</b> begins to glow!")
 						if(prob(degree*2))
 							set_trait(TRAIT_BIOLUM_COLOUR,"#[get_random_colour(0,75,190)]")
 							source_turf.visible_message("<span class='notice'>\The [display_name]'s glow </span><font color='[get_trait(TRAIT_BIOLUM_COLOUR)]'>changes colour</font>!")

--- a/code/modules/hydroponics/seed_gene_mut.dm
+++ b/code/modules/hydroponics/seed_gene_mut.dm
@@ -4,7 +4,7 @@
 		return src
 
 	var/datum/seed/S = diverge()	//Let's not modify all of the seeds.
-	T.visible_message("<span class='notice'>\The [S.display_name] quivers!</span>")	//Mimicks the normal mutation.
+	T.visible_message("<b>\The [S.display_name]</b> quivers!")	//Mimicks the normal mutation.
 	G.mutate(S, T)
 
 	return S
@@ -94,7 +94,7 @@
 	if(prob(50))
 		S.set_trait(TRAIT_BIOLUM,         !S.get_trait(TRAIT_BIOLUM))
 		if(S.get_trait(TRAIT_BIOLUM))
-			T.visible_message("<span class='notice'>\The [S.display_name] begins to glow!</span>")
+			T.visible_message("<b>\The [S.display_name]</b> begins to glow!")
 			if(prob(50))
 				S.set_trait(TRAIT_BIOLUM_COLOUR,get_random_colour(0,75,190))
 				T.visible_message("<span class='notice'>\The [S.display_name]'s glow </span><font color='[S.get_trait(TRAIT_BIOLUM_COLOUR)]'>changes colour</font>!")
@@ -118,7 +118,7 @@
 		S.set_trait(TRAIT_MATURATION, S.get_trait(TRAIT_MATURATION)+rand(-1,1),30,0)
 	if(prob(55))
 		S.set_trait(TRAIT_SPREAD, S.get_trait(TRAIT_SPREAD)+rand(-1,1),2,0)
-		T.visible_message("<span class='notice'>\The [S.display_name] spasms visibly, shifting in the tray.</span>")
+		T.visible_message("<b>\The [S.display_name]</b> spasms visibly, shifting in the tray.")
 
 /decl/plantgene/fruit/mutate(var/datum/seed/S)
 	if(prob(65))

--- a/code/modules/hydroponics/spreading/spreading_response.dm
+++ b/code/modules/hydroponics/spreading/spreading_response.dm
@@ -68,12 +68,12 @@
 				var/mob/living/L = A
 				if(!(user in buckled_mobs))
 					L.visible_message(\
-					"<span class='notice'>\The [user] frees \the [L] from \the [src].</span>",\
-					"<span class='notice'>\The [user] frees you from \the [src].</span>",\
+					"<b>\The [user]</b> frees \the [L] from \the [src].",\
+					"<b>\The [user]</b> frees you from \the [src].",\
 					"<span class='warning'>You hear shredding and ripping.</span>")
 				else
 					L.visible_message(\
-					"<span class='notice'>\The [L] struggles free of \the [src].</span>",\
+					"<b>\The [L]</b> struggles free of \the [src].",\
 					"<span class='notice'>You untangle \the [src] from around yourself.</span>",\
 					"<span class='warning'>You hear shredding and ripping.</span>")
 				unbuckle()

--- a/code/modules/integrated_electronics/core/assemblies.dm
+++ b/code/modules/integrated_electronics/core/assemblies.dm
@@ -268,7 +268,7 @@
 			if(S.scan(target))
 				scanned = TRUE
 		if(scanned)
-			visible_message("<span class='notice'>\The [user] waves \the [src] around [target].</span>")
+			visible_message("<b>\The [user]</b> waves \the [src] around [target].")
 
 /obj/item/device/electronic_assembly/attackby(var/obj/item/I, var/mob/user)
 	if(can_anchor && I.is_wrench())

--- a/code/modules/library/lib_machines.dm
+++ b/code/modules/library/lib_machines.dm
@@ -187,7 +187,7 @@
 				new /obj/item/weapon/book/tome(src.loc)
 				var/datum/gender/T = gender_datums[user.get_visible_gender()]
 				to_chat(user, "<span class='warning'>Your sanity barely endures the seconds spent in the vault's browsing window. The only thing to remind you of this when you stop browsing is a dusty old tome sitting on the desk. You don't really remember printing it.</span>")
-				user.visible_message("<span class='notice'>\The [user] stares at the blank screen for a few moments, [T.his] expression frozen in fear. When [T.he] finally awakens from it, [T.he] looks a lot older.</span>", 2)
+				user.visible_message("<b>\The [user]</b> stares at the blank screen for a few moments, [T.his] expression frozen in fear. When [T.he] finally awakens from it, [T.he] looks a lot older.", 2)
 				src.arcanecheckout = 0
 		if(1)
 			// Inventory

--- a/code/modules/materials/sheets/metals/rods.dm
+++ b/code/modules/materials/sheets/metals/rods.dm
@@ -67,7 +67,7 @@ var/global/list/datum/stack_recipe/rods_recipes = list( \
 		var/obj/item/stack/medical/splint/ghetto/new_splint = new(get_turf(user))
 		new_splint.add_fingerprint(user)
 
-		user.visible_message("<span class='notice'>\The [user] constructs \a [new_splint] out of a [singular_name].</span>", \
+		user.visible_message("<b>\The [user]</b> constructs \a [new_splint] out of a [singular_name].", \
 				"<span class='notice'>You use make \a [new_splint] out of a [singular_name].</span>")
 		src.use(1)
 		return

--- a/code/modules/materials/sheets/organic/tanning/hide.dm
+++ b/code/modules/materials/sheets/organic/tanning/hide.dm
@@ -18,7 +18,7 @@
 /obj/item/stack/animalhide/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	if(has_edge(W) || is_sharp(W))
 		//visible message on mobs is defined as visible_message(var/message, var/self_message, var/blind_message)
-		user.visible_message("<span class='notice'>\The [user] starts cutting hair off \the [src]</span>", "<span class='notice'>You start cutting the hair off \the [src]</span>", "You hear the sound of a knife rubbing against flesh")
+		user.visible_message("<b>\The [user]</b> starts cutting hair off \the [src]", "<span class='notice'>You start cutting the hair off \the [src]</span>", "You hear the sound of a knife rubbing against flesh")
 		var/scraped = 0
 		while(amount > 0 && do_after(user, 2.5 SECONDS)) // 2.5s per hide
 			//Try locating an exisitng stack on the tile and add to there if possible

--- a/code/modules/mining/drilling/drill.dm
+++ b/code/modules/mining/drilling/drill.dm
@@ -209,10 +209,10 @@
 		if(use_cell_power())
 			active = !active
 			if(active)
-				visible_message("<span class='notice'>\The [src] lurches downwards, grinding noisily.</span>")
+				visible_message("<b>\The [src]</b> lurches downwards, grinding noisily.")
 				need_update_field = 1
 			else
-				visible_message("<span class='notice'>\The [src] shudders to a grinding halt.</span>")
+				visible_message("<b>\The [src]</b> shudders to a grinding halt.")
 		else
 			to_chat(user, "<span class='notice'>The drill is unpowered.</span>")
 	else
@@ -273,7 +273,7 @@
 /obj/machinery/mining/drill/proc/system_error(var/error)
 
 	if(error)
-		src.visible_message("<span class='notice'>\The [src] flashes a '[error]' warning.</span>")
+		src.visible_message("<b>\The [src]</b> flashes a '[error]' warning.")
 		faultreporter.autosay(error, src.name, "Supply")
 	need_player_check = 1
 	active = 0

--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -398,7 +398,7 @@ var/list/mining_overlay_cache = list()
 
 		if (istype(W, /obj/item/device/measuring_tape))
 			var/obj/item/device/measuring_tape/P = W
-			user.visible_message("<span class='notice'>\The [user] extends \a [P] towards \the [src].</span>","<span class='notice'>You extend \the [P] towards \the [src].</span>")
+			user.visible_message("<b>\The [user]</b> extends \a [P] towards \the [src].","<span class='notice'>You extend \the [P] towards \the [src].</span>")
 			if(do_after(user, 15))
 				to_chat(user, "<span class='notice'>\The [src] has been excavated to a depth of [excavation_level]cm.</span>")
 			return
@@ -408,7 +408,7 @@ var/list/mining_overlay_cache = list()
 			if(C.mode) //Mode means scanning
 				C.depth_scanner.scan_atom(user, src)
 			else
-				user.visible_message("<span class='notice'>\The [user] extends \the [C] over \the [src], a flurry of red beams scanning \the [src]'s surface!</span>", "<span class='notice'>You extend \the [C] over \the [src], a flurry of red beams scanning \the [src]'s surface!</span>")
+				user.visible_message("<b>\The [user]</b> extends \the [C] over \the [src], a flurry of red beams scanning \the [src]'s surface!", "<span class='notice'>You extend \the [C] over \the [src], a flurry of red beams scanning \the [src]'s surface!</span>")
 				if(do_after(user, 15))
 					to_chat(user, "<span class='notice'>\The [src] has been excavated to a depth of [excavation_level]cm.</span>")
 			return

--- a/code/modules/mob/living/bot/edCLNbot.dm
+++ b/code/modules/mob/living/bot/edCLNbot.dm
@@ -37,7 +37,7 @@
 	if(!red_switch && blue_switch && !green_switch && prob(50) || src.emagged)
 		if(istype(loc, /turf/simulated))
 			var/turf/simulated/T = loc
-			visible_message("<span class='notice'>\The [src] squirts a puddle of water on the floor!</span>")
+			visible_message("<b>\The [src]</b> squirts a puddle of water on the floor!")
 			T.wet_floor()
 
 	if(!red_switch && !blue_switch && green_switch && prob(10) || src.emagged)

--- a/code/modules/mob/living/bot/floorbot.dm
+++ b/code/modules/mob/living/bot/floorbot.dm
@@ -228,7 +228,7 @@
 			return
 		busy = 1
 		update_icons()
-		visible_message("<span class='notice'>\The [src] begins to repair the hole.</span>")
+		visible_message("<b>\The [src]</b> begins to repair the hole.")
 		if(do_after(src, 50))
 			if(A && (locate(/obj/structure/lattice, A) && building == 1 || !locate(/obj/structure/lattice, A) && building == 2)) // Make sure that it still needs repairs
 				var/obj/item/I
@@ -245,7 +245,7 @@
 		if(F.broken || F.burnt)
 			busy = 1
 			update_icons()
-			visible_message("<span class='notice'>\The [src] begins to remove the broken floor.</span>")
+			visible_message("<b>\The [src]</b> begins to remove the broken floor.")
 			if(do_after(src, 50, F))
 				if(F.broken || F.burnt)
 					F.make_plating()
@@ -255,7 +255,7 @@
 		else if(!F.flooring && amount)
 			busy = 1
 			update_icons()
-			visible_message("<span class='notice'>\The [src] begins to improve the floor.</span>")
+			visible_message("<b>\The [src]</b> begins to improve the floor.")
 			if(do_after(src, 50))
 				if(!F.flooring)
 					F.set_flooring(get_flooring_data(floor_build_type))
@@ -265,7 +265,7 @@
 			update_icons()
 	else if(istype(A, /obj/item/stack/tile/floor) && amount < maxAmount)
 		var/obj/item/stack/tile/floor/T = A
-		visible_message("<span class='notice'>\The [src] begins to collect tiles.</span>")
+		visible_message("<b>\The [src]</b> begins to collect tiles.")
 		busy = 1
 		update_icons()
 		if(do_after(src, 20))
@@ -279,7 +279,7 @@
 	else if(istype(A, /obj/item/stack/material) && amount + 4 <= maxAmount)
 		var/obj/item/stack/material/M = A
 		if(M.get_material_name() == DEFAULT_WALL_MATERIAL)
-			visible_message("<span class='notice'>\The [src] begins to make tiles.</span>")
+			visible_message("<b>\The [src]</b> begins to make tiles.")
 			busy = 1
 			update_icons()
 			if(do_after(50))

--- a/code/modules/mob/living/carbon/alien/diona/diona_attacks.dm
+++ b/code/modules/mob/living/carbon/alien/diona/diona_attacks.dm
@@ -18,6 +18,6 @@
 			return
 		user.unEquip(W)
 		wear_hat(W)
-		user.visible_message("<span class='notice'>\The [user] puts \the [W] on \the [src].</span>")
+		user.visible_message("<b>\The [user]</b> puts \the [W] on \the [src].")
 		return
 	return ..()

--- a/code/modules/mob/living/carbon/brain/MMI.dm
+++ b/code/modules/mob/living/carbon/brain/MMI.dm
@@ -58,7 +58,7 @@
 				to_chat(user, "<span class='warning'>\The [src] appears to reject this brain.  It is incompatable.</span>")
 				return
 
-		user.visible_message("<span class='notice'>\The [user] sticks \a [O] into \the [src].</span>")
+		user.visible_message("<b>\The [user]</b> sticks \a [O] into \the [src].")
 		B.preserved = TRUE
 
 		brainmob = B.brainmob

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -421,7 +421,7 @@ emp_act
 				return
 
 		if(!zone)
-			visible_message("<span class='notice'>\The [O] misses [src] narrowly!</span>")
+			visible_message("<b>\The [O]</b> misses [src] narrowly!")
 			return
 
 		O.throwing = 0		//it hit, so stop moving

--- a/code/modules/mob/living/carbon/human/species/species_shapeshift.dm
+++ b/code/modules/mob/living/carbon/human/species/species_shapeshift.dm
@@ -164,7 +164,7 @@ var/list/wrapped_species_by_ref = list()
 		return
 
 	wrapped_species_by_ref["\ref[src]"] = new_species
-	visible_message("<span class='notice'>\The [src] shifts and contorts, taking the form of \a [new_species]!</span>")
+	visible_message("<b>\The [src]</b> shifts and contorts, taking the form of \a [new_species]!")
 	regenerate_icons()
 
 /mob/living/carbon/human/proc/shapeshifter_select_colour()

--- a/code/modules/mob/living/carbon/human/species/station/prometheans.dm
+++ b/code/modules/mob/living/carbon/human/species/station/prometheans.dm
@@ -167,7 +167,7 @@ var/datum/species/shapeshifter/promethean/prometheans
 			if(FEMALE)
 				t_him = "her"
 
-	H.visible_message("<span class='notice'>\The [H] glomps [target] to make [t_him] feel better!</span>", \
+	H.visible_message("<b>\The [H]</b> glomps [target] to make [t_him] feel better!", \
 					"<span class='notice'>You glomp [target] to make [t_him] feel better!</span>")
 	H.apply_stored_shock_to(target)
 

--- a/code/modules/mob/living/carbon/human/species/station/teshari.dm
+++ b/code/modules/mob/living/carbon/human/species/station/teshari.dm
@@ -207,7 +207,7 @@
 	// Handled!
 	if(!silent)
 		to_chat(H, SPAN_NOTICE("You catch the air in your wings and greatly slow your fall."))
-		landing.visible_message(SPAN_NOTICE("\The [H] glides down from above, landing safely."))
+		landing.visible_message("<b>\The [H]</b> glides down from above, landing safely.")
 		H.Stun(1)
 		playsound(H, "rustle", 25, 1)
 	return TRUE

--- a/code/modules/mob/living/carbon/lick_wounds.dm
+++ b/code/modules/mob/living/carbon/lick_wounds.dm
@@ -51,7 +51,7 @@
 			return
            
 		else
-			visible_message("<span class='notice'>\The [src] starts licking the wounds on [M]'s [affecting.name] clean.</span>", \
+			visible_message("<b>\The [src]</b> starts licking the wounds on [M]'s [affecting.name] clean.", \
 					             "<span class='notice'>You start licking the wounds on [M]'s [affecting.name] clean.</span>" )
 
 			for (var/datum/wound/W in affecting.wounds)

--- a/code/modules/mob/living/silicon/robot/dogborg/dog_modules_vr.dm
+++ b/code/modules/mob/living/silicon/robot/dogborg/dog_modules_vr.dm
@@ -269,7 +269,7 @@
 			playsound(src, 'sound/weapons/Egloves.ogg', 50, 1, -1)
 			R.cell.charge -= 666
 		else
-			user.visible_message("<span class='notice'>\the [user] affectionately licks all over \the [target]'s face!</span>", "<span class='notice'>You affectionately lick all over \the [target]'s face!</span>")
+			user.visible_message("<span class='notice'>\The [user] affectionately licks all over \the [target]'s face!</span>", "<span class='notice'>You affectionately lick all over \the [target]'s face!</span>")
 			playsound(src, 'sound/effects/attackblob.ogg', 50, 1)
 			water.use_charge(5)
 			var/mob/living/carbon/human/H = target

--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -173,7 +173,7 @@ var/list/mob_hat_cache = list()
 			return
 		user.unEquip(W)
 		wear_hat(W)
-		user.visible_message("<span class='notice'>\The [user] puts \the [W] on \the [src].</span>")
+		user.visible_message("<b>\The [user]</b> puts \the [W] on \the [src].")
 		return
 	else if(istype(W, /obj/item/borg/upgrade/))
 		to_chat(user, "<span class='danger'>\The [src] is not compatible with \the [W].</span>")

--- a/code/modules/mob/living/silicon/robot/subtypes/thinktank/_thinktank.dm
+++ b/code/modules/mob/living/silicon/robot/subtypes/thinktank/_thinktank.dm
@@ -165,4 +165,4 @@
 
 			if(!recharge_complete && recharging_atom.percent() >= 100)
 				recharge_complete = TRUE
-				visible_message(SPAN_NOTICE("\The [src] beeps and flashes a green light above \his recharging port."))
+				visible_message("<b>\The [src]</b> beeps and flashes a green light above \his recharging port.")

--- a/code/modules/mob/living/silicon/robot/subtypes/thinktank/thinktank_interactions.dm
+++ b/code/modules/mob/living/silicon/robot/subtypes/thinktank/thinktank_interactions.dm
@@ -6,7 +6,7 @@
 			if(istype(recharging_atom) && !QDELETED(recharging_atom) && recharging_atom.loc == src)
 				recharging_atom.dropInto(loc)
 				user.put_in_hands(recharging_atom)
-				user.visible_message(SPAN_NOTICE("\The [user] pops \the [recharging_atom] out of \the [src]'s recharging port."))
+				user.visible_message("<b>\The [user]</b> pops \the [recharging_atom] out of \the [src]'s recharging port.")
 			recharging = null
 			return TRUE
 
@@ -24,7 +24,7 @@
 			W.forceMove(src)
 			recharging = weakref(W)
 			recharge_complete = FALSE
-			user.visible_message(SPAN_NOTICE("\The [user] slots \the [W] into \the [src]'s recharging port."))
+			user.visible_message("<b>\The [user]</b> slots \the [W] into \the [src]'s recharging port.")
 		return TRUE
 
 	if(istype(W, /obj/item/device/floor_painter))

--- a/code/modules/mob/living/silicon/robot/subtypes/thinktank/thinktank_storage.dm
+++ b/code/modules/mob/living/silicon/robot/subtypes/thinktank/thinktank_storage.dm
@@ -82,9 +82,9 @@
 	if(istype(ejecting) && !QDELETED(ejecting) && ejecting.loc == src)
 		ejecting.dropInto(loc)
 		if(user == src)
-			visible_message(SPAN_NOTICE("\The [src] ejects \the [ejecting] from its cargo compartment."))
+			visible_message("<b>\The [src]</b> ejects \the [ejecting] from its cargo compartment.")
 		else
-			user.visible_message(SPAN_NOTICE("\The [user] pulls \the [ejecting] from \the [src]'s cargo compartment."))
+			user.visible_message("<b>\The [user]</b> pulls \the [ejecting] from \the [src]'s cargo compartment.")
 
 /mob/living/silicon/robot/platform/attack_ai(mob/user)
 	if(isrobot(user) && user.Adjacent(src))
@@ -99,7 +99,7 @@
 	if(!istype(removing) || QDELETED(removing) || removing.loc != src)
 		LAZYREMOVE(stored_atoms, remove_ref)
 	else
-		user.visible_message(SPAN_NOTICE("\The [user] begins unloading \the [removing] from \the [src]'s cargo compartment."))
+		user.visible_message("<b>\The [user]</b> begins unloading \the [removing] from \the [src]'s cargo compartment.")
 		if(do_after(user, 3 SECONDS, src) && !QDELETED(removing) && removing.loc == src)
 			drop_stored_atom(removing, user)
 	return TRUE
@@ -124,9 +124,9 @@
 	if(!can_mouse_drop(dropping, user) || !can_store_atom(dropping, user))
 		return FALSE
 	if(user == src)
-		visible_message(SPAN_NOTICE("\The [src] begins loading \the [dropping] into its cargo compartment."))
+		visible_message("<b>\The [src]</b> begins loading \the [dropping] into its cargo compartment.")
 	else
-		user.visible_message(SPAN_NOTICE("\The [user] begins loading \the [dropping] into \the [src]'s cargo compartment."))
+		user.visible_message("<b>\The [user]</b> begins loading \the [dropping] into \the [src]'s cargo compartment.")
 	if(do_after(user, 3 SECONDS, src) && can_mouse_drop(dropping, user) && can_store_atom(dropping, user))
 		store_atom(dropping, user)
 	return FALSE

--- a/code/modules/mob/living/simple_mob/defense.dm
+++ b/code/modules/mob/living/simple_mob/defense.dm
@@ -64,7 +64,7 @@
 					MED.amount -= 1
 					if(MED.amount <= 0)
 						qdel(MED)
-					visible_message("<span class='notice'>\The [user] applies the [MED] on [src].</span>")
+					visible_message("<b>\The [user]</b> applies the [MED] on [src].")
 		else
 			var/datum/gender/T = gender_datums[src.get_visible_gender()]
 			to_chat(user, "<span class='notice'>\The [src] is dead, medical items won't bring [T.him] back to life.</span>") // the gender lookup is somewhat overkill, but it functions identically to the obsolete gender macros and future-proofs this code

--- a/code/modules/mob/living/simple_mob/simple_mob_vr.dm
+++ b/code/modules/mob/living/simple_mob/simple_mob_vr.dm
@@ -161,9 +161,9 @@
 	vore_pounce_cooldown = world.time + 20 SECONDS // don't attempt another pounce for a while
 	if(prob(successrate)) // pounce success!
 		M.Weaken(5)
-		M.visible_message("<span class='danger'>\the [src] pounces on \the [M]!</span>!")
+		M.visible_message("<span class='danger'>\The [src] pounces on \the [M]!</span>!")
 	else // pounce misses!
-		M.visible_message("<span class='danger'>\the [src] attempts to pounce \the [M] but misses!</span>!")
+		M.visible_message("<span class='danger'>\The [src] attempts to pounce \the [M] but misses!</span>!")
 		playsound(src, 'sound/weapons/punchmiss.ogg', 25, 1, -1)
 
 	if(will_eat(M) && (!M.canmove || vore_standing_too)) //if they're edible then eat them too
@@ -263,7 +263,7 @@
 	if(istype(tmob) && will_eat(tmob) && !istype(tmob, type) && prob(vore_bump_chance) && !ckey) //check if they decide to eat. Includes sanity check to prevent cannibalism.
 		if(tmob.canmove && prob(vore_pounce_chance)) //if they'd pounce for other noms, pounce for these too, otherwise still try and eat them if they hold still
 			tmob.Weaken(5)
-		tmob.visible_message("<span class='danger'>\the [src] [vore_bump_emote] \the [tmob]!</span>!")
+		tmob.visible_message("<span class='danger'>\The [src] [vore_bump_emote] \the [tmob]!</span>!")
 		set_AI_busy(TRUE)
 		spawn()
 			animal_nom(tmob)

--- a/code/modules/mob/living/simple_mob/subtypes/animal/passive/mouse_vr.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/passive/mouse_vr.dm
@@ -38,7 +38,7 @@
 		var/obj/item/weapon/storage/S = O
 		var/obj/item/weapon/holder/H = new holder_type(get_turf(src),src) //this works weird, but it creates an empty holder, to see if that holder can fit
 		if(S.can_be_inserted(H) && (src.size_multiplier <= 0.75))
-			visible_message("<span class='notice'>\the [src] squeezes into \the [S].</span>")
+			visible_message("<b>\The [src]</b> squeezes into \the [S].")
 			H.forceMove(S)
 			return 1
 		else

--- a/code/modules/mob/living/simple_mob/subtypes/animal/pets/cat.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/pets/cat.dm
@@ -185,7 +185,7 @@ var/list/_cat_default_emotes = list(
 /mob/living/simple_mob/animal/passive/cat/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	if(istype(W, /obj/item/weapon/pen) || istype(W, /obj/item/device/flashlight/pen))
 		if(named)
-			to_chat(user, "<span class='notice'>\the [name] already has a name!</span>")
+			to_chat(user, "<span class='notice'>\The [name] already has a name!</span>")
 		else
 			var/tmp_name = sanitizeSafe(input(user, "Give \the [name] a name", "Name"), MAX_NAME_LEN)
 			if(length(tmp_name) > 50)

--- a/code/modules/mob/living/simple_mob/subtypes/animal/sif/hooligan_crab.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/sif/hooligan_crab.dm
@@ -116,5 +116,5 @@
 		if(prob(10))
 			for(var/mob/living/L in hearers(holder))
 				if(!istype(L, holder)) // Don't follow other hooligan crabs.
-					holder.visible_message("<span class='notice'>\The [holder] starts to follow \the [L].</span>")
+					holder.visible_message("<b>\The [holder]</b> starts to follow \the [L].")
 					set_follow(L, rand(20 SECONDS, 40 SECONDS))

--- a/code/modules/mob/living/simple_mob/subtypes/animal/sif/racoon.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/sif/racoon.dm
@@ -181,7 +181,7 @@
 	if(holder.get_active_hand() && istype(holder.get_active_hand(), /obj/item/clothing/head) && !S.hat)
 		var/obj/item/I = holder.get_active_hand()
 		S.take_hat(S)
-		holder.visible_message("<span class='notice'>\The [holder] wears \the [I]</span>")
+		holder.visible_message("<b>\The [holder]</b> wears \the [I]")
 
 /mob/living/simple_mob/animal/sif/sakimm/intelligent
 	desc = "What appears to be an oversized rodent with hands. This one has a curious look in its eyes."
@@ -327,7 +327,7 @@
 		if(istype(holder) && istype(holder.get_active_hand(), /obj/item/clothing/head) && !S.hat)
 			var/obj/item/I = holder.get_active_hand()
 			S.take_hat(S)
-			holder.visible_message("<span class='notice'>\The [holder] wears \the [I]</span>")
+			holder.visible_message("<b>\The [holder]</b> wears \the [I]")
 		carrying_item = TRUE
 
 	if(istype(holder) && S.hat)		// Do we have a hat? Hats are loot.

--- a/code/modules/mob/living/simple_mob/subtypes/animal/space/bats.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/space/bats.dm
@@ -41,7 +41,7 @@
 		var/mob/living/L = A
 		if(prob(scare_chance))
 			L.Stun(1)
-			L.visible_message("<span class='danger'>\the [src] scares \the [L]!</span>")
+			L.visible_message("<span class='danger'>\The [src] scares \the [L]!</span>")
 
 // Spookiest of bats
 /mob/living/simple_mob/animal/space/bats/cult

--- a/code/modules/mob/living/simple_mob/subtypes/mechanical/drones/mining_drone.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/mechanical/drones/mining_drone.dm
@@ -116,7 +116,7 @@
 				my_storage.rangedload(T, src)
 
 		if(my_storage.contents.len >= my_storage.max_storage_space)
-			visible_message("<span class='notice'>\The [src] emits a shrill beep, indicating its storage is full.</span>")
+			visible_message("<b>\The [src]</b> emits a shrill beep, indicating its storage is full.")
 
 		var/obj/structure/ore_box/OB = locate() in view(2, src)
 

--- a/code/modules/mob/living/simple_mob/subtypes/occult/constructs/_construct.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/occult/constructs/_construct.dm
@@ -126,7 +126,7 @@
 			var/repair_upper_bound = A.melee_damage_upper * -1
 			adjustBruteLoss(rand(repair_lower_bound, repair_upper_bound))
 			adjustFireLoss(rand(repair_lower_bound, repair_upper_bound))
-			user.visible_message("<span class='notice'>\The [user] mends some of \the [src]'s wounds.</span>")
+			user.visible_message("<b>\The [user]</b> mends some of \the [src]'s wounds.")
 		else
 			to_chat(user, "<span class='notice'>\The [src] is undamaged.</span>")
 		return

--- a/code/modules/mob/living/simple_mob/subtypes/occult/faithless.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/occult/faithless.dm
@@ -48,7 +48,7 @@
 		var/mob/living/L = A
 		if(prob(12))
 			L.Weaken(3)
-			L.visible_message("<span class='danger'>\the [src] knocks down \the [L]!</span>")
+			L.visible_message("<span class='danger'>\The [src] knocks down \the [L]!</span>")
 
 // Strong Variant
 /mob/living/simple_mob/faithless/strong

--- a/code/modules/mob/living/simple_mob/subtypes/vore/rat.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/rat.dm
@@ -160,7 +160,7 @@
 				hunger += 5
 		else
 			food.Weaken(5)
-			food.visible_message("<span class='danger'>\the [src] pounces on \the [food]!</span>!")
+			food.visible_message("<span class='danger'>\The [src] pounces on \the [food]!</span>!")
 			target_mob = food
 			EatTarget()
 			hunger = 0

--- a/code/modules/mob/living/simple_mob/subtypes/vore/solargrub.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/solargrub.dm
@@ -69,7 +69,7 @@ List of things solar grubs should be able to do:
 		if(attached)
 			set_AI_busy(TRUE)
 			if(prob(2))
-				src.visible_message("<span class='notice'>\The [src] begins to sink power from the net.</span>")
+				src.visible_message("<b>\The [src]</b> begins to sink power from the net.")
 			if(prob(5))
 				var/datum/effect/effect/system/spark_spread/sparks = new /datum/effect/effect/system/spark_spread()
 				sparks.set_up(5, 0, get_turf(src))

--- a/code/modules/modular_computers/file_system/programs/generic/game.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/game.dm
@@ -166,7 +166,7 @@
 				to_chat(usr, "<span class='notice'>Hardware error: Printer is out of paper.</span>")
 				return
 			else
-				computer.visible_message("<span class='notice'>\The [computer] prints out paper.</span>")
+				computer.visible_message("<b>\The [computer]</b> prints out paper.")
 				if(ticket_count >= 1)
 					new /obj/item/stack/arcadeticket((get_turf(computer)), 1)
 					to_chat(usr, "<span class='notice'>[src] dispenses a ticket!</span>")

--- a/code/modules/multiz/ladders.dm
+++ b/code/modules/multiz/ladders.dm
@@ -94,7 +94,7 @@
 
 /obj/structure/ladder/proc/climbLadder(var/mob/M, var/obj/target_ladder)
 	var/direction = (target_ladder == target_up ? "up" : "down")
-	M.visible_message("<span class='notice'>\The [M] begins climbing [direction] \the [src]!</span>",
+	M.visible_message("<b>\The [M]</b> begins climbing [direction] \the [src]!",
 		"You begin climbing [direction] \the [src]!",
 		"You hear the grunting and clanging of a metal ladder being used.")
 

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -461,9 +461,9 @@
 	if(damage_desc)
 		if(user == src.owner)
 			var/datum/gender/T = gender_datums[user.get_visible_gender()]
-			user.visible_message("<span class='notice'>\The [user] patches [damage_desc] on [T.his] [src.name] with [tool].</span>")
+			user.visible_message("<b>\The [user]</b> patches [damage_desc] on [T.his] [src.name] with [tool].")
 		else
-			user.visible_message("<span class='notice'>\The [user] patches [damage_desc] on [owner]'s [src.name] with [tool].</span>")
+			user.visible_message("<b>\The [user]</b> patches [damage_desc] on [owner]'s [src.name] with [tool].")
 
 	return 1
 

--- a/code/modules/organs/subtypes/slime.dm
+++ b/code/modules/organs/subtypes/slime.dm
@@ -71,7 +71,7 @@
 /obj/item/organ/internal/heart/grey/colormatch/slime/process()
 	..()
 	if(!(QDELETED(src)) && src.loc != owner)
-		visible_message("<span class='notice'>\The [src] splatters!</span>")
+		visible_message("<b>\The [src]</b> splatters!")
 		var/turf/T = get_turf(src)
 		var/obj/effect/decal/cleanable/blood/B = new (T)
 
@@ -120,7 +120,7 @@
 	..()
 
 	if(!(QDELETED(src)) && src.loc != owner)
-		visible_message("<span class='notice'>\The [src] splatters!</span>")
+		visible_message("<b>\The [src]</b> splatters!")
 		var/turf/T = get_turf(src)
 		var/obj/effect/decal/cleanable/blood/B = new (T)
 

--- a/code/modules/overmap/disperser/disperser.dm
+++ b/code/modules/overmap/disperser/disperser.dm
@@ -24,7 +24,7 @@
 /obj/machinery/disperser/attackby(obj/item/I, mob/user)
 	if(I && I.is_wrench())
 		if(panel_open)
-			user.visible_message("<span class='notice'>\The [user] rotates \the [src] with \the [I].</span>",
+			user.visible_message("<b>\The [user]</b> rotates \the [src] with \the [I].",
 				"<span class='notice'>You rotate \the [src] with \the [I].</span>")
 			set_dir(turn(dir, 90))
 			playsound(src, 'sound/items/jaws_pry.ogg', 50, 1)

--- a/code/modules/paperwork/paper_sticky.dm
+++ b/code/modules/paperwork/paper_sticky.dm
@@ -37,7 +37,7 @@
 		var/text = sanitizeSafe(input(usr, "What would you like to write?") as text, writing_space)
 		if(!text || thing.loc != user || (!Adjacent(user) && loc != user) || user.incapacitated())
 			return
-		user.visible_message(SPAN_NOTICE("\The [user] jots a note down on \the [src]."))
+		user.visible_message("<b>\The [user]</b> jots a note down on \the [src].")
 		written_by = user.ckey
 		if(written_text)
 			written_text = "[written_text] [text]"

--- a/code/modules/persistence/graffiti.dm
+++ b/code/modules/persistence/graffiti.dm
@@ -47,7 +47,7 @@
 		var/obj/item/weapon/weldingtool/welder = thing
 		if(welder.isOn() && welder.remove_fuel(0,user) && do_after(user, 5, src) && !QDELETED(src))
 			playsound(src.loc, welder.usesound, 50, 1)
-			user.visible_message("<span class='notice'>\The [user] clears away some graffiti.</span>")
+			user.visible_message("<b>\The [user]</b> clears away some graffiti.")
 			qdel(src)
 	else if(thing.sharp)
 

--- a/code/modules/power/fusion/core/_core.dm
+++ b/code/modules/power/fusion/core/_core.dm
@@ -67,7 +67,7 @@ GLOBAL_LIST_EMPTY(fusion_cores)
 	if(Output.get_pairing())
 		reagents.trans_to_holder(Output.reagents, Output.reagents.maximum_volume)
 		if(prob(5))
-			visible_message("<span class='notice'>\The [src] gurgles as it exports fluid.</span>")
+			visible_message("<b>\The [src]</b> gurgles as it exports fluid.")
 
 	if(owned_field)
 
@@ -131,7 +131,7 @@ GLOBAL_LIST_EMPTY(fusion_cores)
 /obj/machinery/power/fusion_core/attack_hand(var/mob/user)
 	if(!Adjacent(user)) // As funny as it was for the AI to hug-kill the tokamak field from a distance...
 		return
-	visible_message("<span class='notice'>\The [user] hugs \the [src] to make it feel better!</span>")
+	visible_message("<b>\The [user]</b> hugs \the [src] to make it feel better!")
 	if(owned_field)
 		Shutdown()
 

--- a/code/modules/power/fusion/fuel_assembly/fuel_compressor.dm
+++ b/code/modules/power/fusion/fuel_assembly/fuel_compressor.dm
@@ -26,14 +26,14 @@
 			to_chat(user, "<span class='warning'>You need at least three hundred units of material to form a fuel rod.</span>")
 			return 1
 		var/datum/reagent/R = thing.reagents.reagent_list[1]
-		visible_message("<span class='notice'>\The [src] compresses the contents of \the [thing] into a new fuel assembly.</span>")
+		visible_message("<b>\The [src]</b> compresses the contents of \the [thing] into a new fuel assembly.")
 		var/obj/item/weapon/fuel_assembly/F = new(get_turf(src), R.id, R.color)
 		thing.reagents.remove_reagent(R.id, R.volume)
 		user.put_in_hands(F)
 
 	else if(istype(thing, /obj/machinery/power/supermatter))
 		var/obj/item/weapon/fuel_assembly/F = new(get_turf(src), "supermatter")
-		visible_message("<span class='notice'>\The [src] compresses \the [thing] into a new fuel assembly.</span>")
+		visible_message("<b>\The [src]</b> compresses \the [thing] into a new fuel assembly.")
 		qdel(thing)
 		user.put_in_hands(F)
 		return 1
@@ -58,7 +58,7 @@
 			to_chat(user, "<span class='warning'>You need at least 25 [mat.sheet_plural_name] to make a fuel rod.</span>")
 			return
 		var/obj/item/weapon/fuel_assembly/F = new(get_turf(src), mat.name)
-		visible_message("<span class='notice'>\The [src] compresses the [mat.use_name] into a new fuel assembly.</span>")
+		visible_message("<b>\The [src]</b> compresses the [mat.use_name] into a new fuel assembly.")
 		M.use(FUSION_ROD_SHEET_AMT)
 		user.put_in_hands(F)
 

--- a/code/modules/power/fusion/fuel_assembly/fuel_injector.dm
+++ b/code/modules/power/fusion/fuel_assembly/fuel_injector.dm
@@ -56,9 +56,9 @@ GLOBAL_LIST_EMPTY(fuel_injectors)
 
 		if(cur_assembly)
 			cur_assembly.forceMove(get_turf(src))
-			visible_message("<span class='notice'>\The [user] swaps \the [src]'s [cur_assembly] for \a [W].</span>")
+			visible_message("<b>\The [user]</b> swaps \the [src]'s [cur_assembly] for \a [W].")
 		else
-			visible_message("<span class='notice'>\The [user] inserts \a [W] into \the [src].</span>")
+			visible_message("<b>\The [user]</b> inserts \a [W] into \the [src].")
 
 		user.drop_from_inventory(W)
 		W.forceMove(src)
@@ -92,7 +92,7 @@ GLOBAL_LIST_EMPTY(fuel_injectors)
 	if(cur_assembly)
 		cur_assembly.forceMove(get_turf(src))
 		user.put_in_hands(cur_assembly)
-		visible_message("<span class='notice'>\The [user] removes \the [cur_assembly] from \the [src].</span>")
+		visible_message("<b>\The [user]</b> removes \the [cur_assembly] from \the [src].")
 		cur_assembly = null
 		return
 	else

--- a/code/modules/power/singularity/generator.dm
+++ b/code/modules/power/singularity/generator.dm
@@ -32,7 +32,7 @@
 	if(W.is_screwdriver())
 		panel_open = !panel_open
 		playsound(src, W.usesound, 50, 1)
-		visible_message("<span class='notice'>\The [user] adjusts \the [src]'s mechanisms.</span>")
+		visible_message("<b>\The [user]</b> adjusts \the [src]'s mechanisms.")
 		if(panel_open && do_after(user, 30))
 			to_chat(user, "<span class='notice'>\The [src] looks like it could be modified.</span>")
 			if(panel_open && do_after(user, 80 * W.toolspeed))	// We don't have skills, so a delayed hint for engineers will have to do for now. (Panel open check for sanity)
@@ -41,10 +41,10 @@
 		else
 			to_chat(user, "<span class='notice'>\The [src]'s mechanisms look secure.</span>")
 	if(istype(W, /obj/item/weapon/smes_coil/super_io) && panel_open)
-		visible_message("<span class='notice'>\The [user] begins to modify \the [src] with \the [W].</span>")
+		visible_message("<b>\The [user]</b> begins to modify \the [src] with \the [W].")
 		if(do_after(user, 300))
 			user.drop_from_inventory(W)
-			visible_message("<span class='notice'>\The [user] installs \the [W] onto \the [src].</span>")
+			visible_message("<b>\The [user]</b> installs \the [W] onto \the [src].")
 			qdel(W)
 			var/turf/T = get_turf(src)
 			var/new_machine = /obj/machinery/particle_smasher

--- a/code/modules/power/singularity/particle_accelerator/particle_smasher.dm
+++ b/code/modules/power/singularity/particle_accelerator/particle_smasher.dm
@@ -174,7 +174,7 @@
 		recipes = typesof(/datum/particle_smasher_recipe)
 
 	if(!target)	// You are just blasting an empty machine.
-		visible_message("<span class='notice'>\The [src] shudders.</span>")
+		visible_message("<b>\The [src]</b> shudders.")
 		update_icon()
 		return
 

--- a/code/modules/projectiles/guns/magnetic/bore.dm
+++ b/code/modules/projectiles/guns/magnetic/bore.dm
@@ -63,7 +63,7 @@
 
 		if(removing)
 			user.put_in_hands(removing)
-			user.visible_message("<span class='notice'>\The [user] removes \the [removing] from \the [src].</span>")
+			user.visible_message("<b>\The [user]</b> removes \the [removing] from \the [src].")
 			playsound(src, 'sound/machines/click.ogg', 10, 1)
 			update_icon()
 			return
@@ -91,7 +91,7 @@
 				to_chat(user, "<span class='warning'>\The [src] has no manipulator installed.</span>")
 				return
 			user.put_in_hands(manipulator)
-			user.visible_message("<span class='notice'>\The [user] levers \the [manipulator] from \the [src].</span>")
+			user.visible_message("<b>\The [user]</b> levers \the [manipulator] from \the [src].")
 			playsound(src, thing.usesound, 50, 1)
 			mat_cost = initial(mat_cost)
 			manipulator = null
@@ -107,7 +107,7 @@
 			user.drop_from_inventory(manipulator, src)
 			playsound(src, 'sound/machines/click.ogg', 10,1)
 			mat_cost = initial(mat_cost) / (2*manipulator.rating)
-			user.visible_message("<span class='notice'>\The [user] slots \the [manipulator] into \the [src].</span>")
+			user.visible_message("<b>\The [user]</b> slots \the [manipulator] into \the [src].")
 			update_icon()
 			update_rating_mod()
 			return
@@ -143,7 +143,7 @@
 			mat_storage += (SHEET_MATERIAL_AMOUNT/2*0.8) //two plasma ores needed per sheet, some inefficiency for not using refined product
 			success = TRUE
 		if(success)
-			user.visible_message("<span class='notice'>\The [user] loads \the [src] with \the [M].</span>")
+			user.visible_message("<b>\The [user]</b> loads \the [src] with \the [M].")
 			playsound(src, 'sound/weapons/flipblade.ogg', 50, 1)
 		update_icon()
 		return

--- a/code/modules/projectiles/guns/magnetic/magnetic.dm
+++ b/code/modules/projectiles/guns/magnetic/magnetic.dm
@@ -151,7 +151,7 @@
 			cell = thing
 			user.drop_from_inventory(cell, src)
 			playsound(src, 'sound/machines/click.ogg', 10, 1)
-			user.visible_message("<span class='notice'>\The [user] slots \the [cell] into \the [src].</span>")
+			user.visible_message("<b>\The [user]</b> slots \the [cell] into \the [src].")
 			update_icon()
 			return
 
@@ -160,7 +160,7 @@
 				to_chat(user, "<span class='warning'>\The [src] has no capacitor installed.</span>")
 				return
 			user.put_in_hands(capacitor)
-			user.visible_message("<span class='notice'>\The [user] unscrews \the [capacitor] from \the [src].</span>")
+			user.visible_message("<b>\The [user]</b> unscrews \the [capacitor] from \the [src].")
 			playsound(src, thing.usesound, 50, 1)
 			capacitor = null
 			update_icon()
@@ -174,7 +174,7 @@
 			user.drop_from_inventory(capacitor, src)
 			playsound(src, 'sound/machines/click.ogg', 10, 1)
 			power_per_tick = (power_cost*0.15) * capacitor.rating
-			user.visible_message("<span class='notice'>\The [user] slots \the [capacitor] into \the [src].</span>")
+			user.visible_message("<b>\The [user]</b> slots \the [capacitor] into \the [src].")
 			update_icon()
 			return
 
@@ -195,7 +195,7 @@
 			loaded = new load_type(src, 1)
 			ammo.use(1)
 
-		user.visible_message("<span class='notice'>\The [user] loads \the [src] with \the [loaded].</span>")
+		user.visible_message("<b>\The [user]</b> loads \the [src] with \the [loaded].")
 		playsound(src, 'sound/weapons/flipblade.ogg', 50, 1)
 		update_icon()
 		return
@@ -215,7 +215,7 @@
 		if(removing)
 			removing.forceMove(get_turf(src))
 			user.put_in_hands(removing)
-			user.visible_message("<span class='notice'>\The [user] removes \the [removing] from \the [src].</span>")
+			user.visible_message("<b>\The [user]</b> removes \the [removing] from \the [src].")
 			playsound(src, 'sound/machines/click.ogg', 10, 1)
 			update_icon()
 			return

--- a/code/modules/projectiles/guns/magnetic/magnetic_construction.dm
+++ b/code/modules/projectiles/guns/magnetic/magnetic_construction.dm
@@ -17,19 +17,19 @@
 				to_chat(user, "<span class='warning'>You need at least 5 [reinforcing.singular_name]\s for this task.</span>")
 				return
 			reinforcing.use(5)
-			user.visible_message("<span class='notice'>\The [user] shapes some steel sheets around \the [src] to form a body.</span>")
+			user.visible_message("<b>\The [user]</b> shapes some steel sheets around \the [src] to form a body.")
 			increment_construction_stage()
 			return
 
 	if(istype(thing, /obj/item/weapon/tape_roll) && construction_stage == 2)
-		user.visible_message("<span class='notice'>\The [user] secures \the [src] together with \the [thing].</span>")
+		user.visible_message("<b>\The [user]</b> secures \the [src] together with \the [thing].")
 		increment_construction_stage()
 		return
 
 	if(istype(thing, /obj/item/pipe) && construction_stage == 3)
 		user.drop_from_inventory(thing)
 		qdel(thing)
-		user.visible_message("<span class='notice'>\The [user] jams \the [thing] into \the [src].</span>")
+		user.visible_message("<b>\The [user]</b> jams \the [thing] into \the [src].")
 		increment_construction_stage()
 		return
 
@@ -44,7 +44,7 @@
 			to_chat(user, "<span class='warning'>You need more fuel!</span>")
 			return
 
-		user.visible_message("<span class='notice'>\The [user] welds the barrel of \the [src] into place.</span>")
+		user.visible_message("<b>\The [user]</b> welds the barrel of \the [src] into place.")
 		playsound(src, 'sound/items/Welder2.ogg', 100, 1)
 		increment_construction_stage()
 		return
@@ -55,19 +55,19 @@
 			to_chat(user, "<span class='warning'>You need at least 5 lengths of cable for this task.</span>")
 			return
 		cable.use(5)
-		user.visible_message("<span class='notice'>\The [user] wires \the [src].</span>")
+		user.visible_message("<b>\The [user]</b> wires \the [src].")
 		increment_construction_stage()
 		return
 
 	if(istype(thing, /obj/item/weapon/smes_coil) && construction_stage >= 6 && construction_stage <= 8)
-		user.visible_message("<span class='notice'>\The [user] installs \a [thing] into \the [src].</span>")
+		user.visible_message("<b>\The [user]</b> installs \a [thing] into \the [src].")
 		user.drop_from_inventory(thing)
 		qdel(thing)
 		increment_construction_stage()
 		return
 
 	if(thing.is_screwdriver() && construction_stage >= 9)
-		user.visible_message("<span class='notice'>\The [user] secures \the [src] and finishes it off.</span>")
+		user.visible_message("<b>\The [user]</b> secures \the [src] and finishes it off.")
 		playsound(src, 'sound/items/Screwdriver.ogg', 50, 1)
 		var/obj/item/weapon/gun/magnetic/coilgun = new(loc)
 		var/put_in_hands

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -667,7 +667,7 @@
 
 	if(result == PROJECTILE_FORCE_MISS)
 		if(!silenced)
-			target_mob.visible_message("<span class='notice'>\The [src] misses \the [target_mob] narrowly!</span>")
+			target_mob.visible_message("<b>\The [src]</b> misses \the [target_mob] narrowly!")
 			playsound(target_mob, "bullet_miss", 75, 1)
 		return FALSE
 

--- a/code/modules/projectiles/targeting/targeting_overlay.dm
+++ b/code/modules/projectiles/targeting/targeting_overlay.dm
@@ -217,7 +217,7 @@
 	if(istype(aiming_with, /obj/item/weapon/gun))
 		playsound(owner, 'sound/weapons/TargetOff.ogg', 50,1)
 	if(!no_message)
-		owner.visible_message("<span class='notice'>\The [owner] lowers \the [aiming_with].</span>")
+		owner.visible_message("<b>\The [owner]</b> lowers \the [aiming_with].")
 
 	aiming_with = null
 	aiming_at.aimed -= src

--- a/code/modules/reagents/machinery/distillery.dm
+++ b/code/modules/reagents/machinery/distillery.dm
@@ -146,7 +146,7 @@
 
 	to_chat(user, "<span class='notice'>You press \the [src]'s chamber agitator button.</span>")
 	if(on)
-		visible_message("<span class='notice'>\The [src] rattles to life.</span>")
+		visible_message("<b>\The [src]</b> rattles to life.")
 		reagents.handle_reactions()
 	else
 		spawn(1 SECOND)
@@ -316,7 +316,7 @@
 				if(target_temp == round(current_temp, 1.0))
 					current_temp = target_temp // Hard set it so we don't need to worry about exact decimals any more, after we've been keeping track of it all this time
 					playsound(src, 'sound/machines/ping.ogg', 50, 0)
-					src.visible_message("<span class='notice'>\The [src] pings as it reaches the target temperature.</span>")
+					src.visible_message("<b>\The [src]</b> pings as it reaches the target temperature.")
 
 		else if(connected_port && avg_pressure > 1000)
 			current_temp = round((current_temp + avg_temp) / 2)

--- a/code/modules/reagents/reagents/medicine.dm
+++ b/code/modules/reagents/reagents/medicine.dm
@@ -347,7 +347,7 @@
 		var/obj/item/stack/medical/M = C.upgrade_stack(to_produce)
 
 		if(M && M.amount)
-			holder.my_atom.visible_message("<span class='notice'>\The [packname] bubbles.</span>")
+			holder.my_atom.visible_message("<b>\The [packname]</b> bubbles.")
 			remove_self(to_produce * 5)
 
 /datum/reagent/cryoxadone
@@ -1256,7 +1256,7 @@
 		var/obj/item/stack/medical/M = C.upgrade_stack(to_produce)
 
 		if(M && M.amount)
-			holder.my_atom.visible_message("<span class='notice'>\The [packname] bubbles.</span>")
+			holder.my_atom.visible_message("<b>\The [packname]</b> bubbles.")
 			remove_self(to_produce)
 
 /datum/reagent/sterilizine

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -110,7 +110,7 @@
 	if(istype(I, /obj/item/weapon/material/ashtray))
 		var/obj/item/weapon/material/ashtray/A = I
 		if(A.contents.len > 0)
-			user.visible_message("<span class='notice'>\The [user] empties \the [A.name] into [src].</span>")
+			user.visible_message("<b>\The [user]</b> empties \the [A] into [src].")
 			for(var/obj/item/O in A.contents)
 				O.forceMove(src)
 			A.update_icon()

--- a/code/modules/resleeving/machines.dm
+++ b/code/modules/resleeving/machines.dm
@@ -383,7 +383,7 @@
 
 	var/obj/item/stack/material/S = W
 	if(!(S.material.name in stored_material))
-		to_chat(user, "<span class='warning'>\the [src] doesn't accept [S.material]!</span>")
+		to_chat(user, "<span class='warning'>\The [src] doesn't accept [S.material]!</span>")
 		return
 
 	var/amnt = S.perunit

--- a/code/modules/shieldgen/emergency_shield.dm
+++ b/code/modules/shieldgen/emergency_shield.dm
@@ -24,7 +24,7 @@
 
 /obj/machinery/shield/proc/check_failure()
 	if (src.health <= 0)
-		visible_message("<span class='notice'>\The [src] dissipates!</span>")
+		visible_message("<b>\The [src]</b> dissipates!")
 		qdel(src)
 		return
 

--- a/code/modules/tables/tables.dm
+++ b/code/modules/tables/tables.dm
@@ -110,7 +110,7 @@ var/list/table_icon_cache = list()
 		return 1
 
 	if(carpeted && W.is_crowbar())
-		user.visible_message("<span class='notice'>\The [user] removes the carpet from \the [src].</span>",
+		user.visible_message("<b>\The [user]</b> removes the carpet from \the [src].",
 		                              "<span class='notice'>You remove the carpet from \the [src].</span>")
 		new carpeted_type(loc)
 		carpeted = 0
@@ -120,7 +120,7 @@ var/list/table_icon_cache = list()
 	if(!carpeted && material && istype(W, /obj/item/stack/tile/carpet))
 		var/obj/item/stack/tile/carpet/C = W
 		if(C.use(1))
-			user.visible_message("<span class='notice'>\The [user] adds \the [C] to \the [src].</span>",
+			user.visible_message("<b>\The [user]</b> adds \the [C] to \the [src].",
 			                              "<span class='notice'>You add \the [C] to \the [src].</span>")
 			carpeted = 1
 			carpeted_type = W.type
@@ -151,7 +151,7 @@ var/list/table_icon_cache = list()
 			playsound(src, F.usesound, 50, 1)
 			if(!do_after(user, 20 * F.toolspeed) || !F.remove_fuel(1, user))
 				return
-			user.visible_message("<span class='notice'>\The [user] repairs some damage to \the [src].</span>",
+			user.visible_message("<b>\The [user]</b> repairs some damage to \the [src].",
 			                              "<span class='notice'>You repair some damage to \the [src].</span>")
 			health = max(health+(maxhealth/5), maxhealth) // 20% repair per application
 			return 1
@@ -191,7 +191,7 @@ var/list/table_icon_cache = list()
 			src.break_to_parts()
 			user.do_attack_animation(src)
 			return 1
-	visible_message("<span class='notice'>\The [user] scratches at \the [src]!</span>")
+	visible_message("<b>\The [user]</b> scratches at \the [src]!")
 	return ..()
 
 /obj/structure/table/MouseDrop_T(obj/item/stack/material/what)
@@ -260,14 +260,14 @@ var/list/table_icon_cache = list()
 
 	if(manipulating) return M
 	manipulating = 1
-	user.visible_message("<span class='notice'>\The [user] begins removing the [type_holding] holding \the [src]'s [M.display_name] [what] in place.</span>",
+	user.visible_message("<b>\The [user]</b> begins removing the [type_holding] holding \the [src]'s [M.display_name] [what] in place.",
 	                              "<span class='notice'>You begin removing the [type_holding] holding \the [src]'s [M.display_name] [what] in place.</span>")
 	if(sound)
 		playsound(src, sound, 50, 1)
 	if(!do_after(user, delay))
 		manipulating = 0
 		return M
-	user.visible_message("<span class='notice'>\The [user] removes the [M.display_name] [what] from \the [src].</span>",
+	user.visible_message("<b>\The [user]</b> removes the [M.display_name] [what] from \the [src].",
 	                              "<span class='notice'>You remove the [M.display_name] [what] from \the [src].</span>")
 	new M.stack_type(src.loc)
 	manipulating = 0
@@ -282,13 +282,13 @@ var/list/table_icon_cache = list()
 /obj/structure/table/proc/dismantle(obj/item/W, mob/user)
 	if(manipulating) return
 	manipulating = 1
-	user.visible_message("<span class='notice'>\The [user] begins dismantling \the [src].</span>",
+	user.visible_message("<b>\The [user]</b> begins dismantling \the [src].",
 	                              "<span class='notice'>You begin dismantling \the [src].</span>")
 	playsound(src, W.usesound, 50, 1)
 	if(!do_after(user, 20 * W.toolspeed))
 		manipulating = 0
 		return
-	user.visible_message("<span class='notice'>\The [user] dismantles \the [src].</span>",
+	user.visible_message("<b>\The [user]</b> dismantles \the [src].",
 	                              "<span class='notice'>You dismantle \the [src].</span>")
 	new /obj/item/stack/material/steel(src.loc)
 	qdel(src)

--- a/code/modules/tgui/modules/ntos-only/cardmod.dm
+++ b/code/modules/tgui/modules/ntos-only/cardmod.dm
@@ -152,7 +152,7 @@
 							to_chat(usr, "<span class='notice'>Hardware error: Printer was unable to print the file. It may be out of paper.</span>")
 							return
 						else
-							computer.visible_message("<span class='notice'>\The [computer] prints out paper.</span>")
+							computer.visible_message("<b>\The [computer]</b> prints out paper.")
 				else
 					var/contents = {"<h4>Crew Manifest</h4>
 									<br>
@@ -162,7 +162,7 @@
 						to_chat(usr, "<span class='notice'>Hardware error: Printer was unable to print the file. It may be out of paper.</span>")
 						return
 					else
-						computer.visible_message("<span class='notice'>\The [computer] prints out paper.</span>")
+						computer.visible_message("<b>\The [computer]</b> prints out paper.")
 			. = TRUE
 		if("modify")
 			if(computer && computer.card_slot)

--- a/code/modules/turbolift/turbolift_console.dm
+++ b/code/modules/turbolift/turbolift_console.dm
@@ -26,7 +26,7 @@
 		if(user.a_intent == I_HURT)
 			user.visible_message("<span class='danger'>\The [user] hammers on the lift button!</span>")
 		else
-			user.visible_message("<span class='notice'>\The [user] presses the lift button.</span>")
+			user.visible_message("<b>\The [user]</b> presses the lift button.")
 
 
 /obj/structure/lift/New(var/newloc, var/datum/turbolift/_lift)

--- a/code/modules/vore/fluffstuff/custom_clothes_vr.dm
+++ b/code/modules/vore/fluffstuff/custom_clothes_vr.dm
@@ -2121,7 +2121,7 @@ Departamental Swimsuits, for general use
 		user.visible_message("<span class='notice'>[user] harmlessly bops [target] with \the [src].</span>", \
 		"<span class='notice'>\The [src] harmlessly bops [target]. The hat seems... unwilling?</span>")
 	else
-		user.visible_message("<span class='notice'>\The [src] flops over [user]'s' head for a moment, but they seem alright.</span>", \
+		user.visible_message("<b>\The [src]</b> flops over [user]'s' head for a moment, but they seem alright.", \
 		"<span class='notice'>\The [src] flops over your head for a moment, but you correct it without issue. There we go!</span>")
 
 /obj/item/clothing/head/fluff/nikki/proc/hat_warp_checks(var/mob/living/target, mob/user, proximity_flag)

--- a/code/modules/xenoarcheaology/artifacts/gigadrill.dm
+++ b/code/modules/xenoarcheaology/artifacts/gigadrill.dm
@@ -24,7 +24,7 @@
 		if(istype(A,/turf/simulated/mineral))
 			var/turf/simulated/mineral/M = A
 			drilling_turf = get_turf(src)
-			src.visible_message("<span class='notice'>\The [src] begins to drill into \the [M].</span>")
+			src.visible_message("<b>\The [src]</b> begins to drill into \the [M].")
 			anchored = 1
 			spawn(drill_time)
 				if(get_turf(src) == drilling_turf && active)

--- a/code/modules/xenoarcheaology/artifacts/replicator.dm
+++ b/code/modules/xenoarcheaology/artifacts/replicator.dm
@@ -178,4 +178,4 @@
 	user.drop_item()
 	W.loc = src
 	stored_materials.Add(W)
-	src.visible_message("<span class='notice'>\The [user] inserts \the [W] into \the [src].</span>")
+	src.visible_message("<b>\The [user]</b> inserts \the [W] into \the [src].")

--- a/code/modules/xenoarcheaology/boulder.dm
+++ b/code/modules/xenoarcheaology/boulder.dm
@@ -35,14 +35,14 @@
 			C.depth_scanner.scan_atom(user, src)
 			return
 		else
-			user.visible_message("<span class='notice'>\The [user] extends \the [C] over \the [src], a flurry of red beams scanning \the [src]'s surface!</span>", "<span class='notice'>You extend \the [C] over \the [src], a flurry of red beams scanning \the [src]'s surface!</span>")
+			user.visible_message("<b>\The [user]</b> extends \the [C] over \the [src], a flurry of red beams scanning \the [src]'s surface!", "<span class='notice'>You extend \the [C] over \the [src], a flurry of red beams scanning \the [src]'s surface!</span>")
 			if(do_after(user, 15))
 				to_chat(user, "<span class='notice'>\The [src] has been excavated to a depth of [2 * src.excavation_level]cm.</span>")
 			return
 
 	if(istype(I, /obj/item/device/measuring_tape))
 		var/obj/item/device/measuring_tape/P = I
-		user.visible_message("<span class='notice'>\The [user] extends \the [P] towards \the [src].</span>", "<span class='notice'>You extend \the [P] towards \the [src].</span>")
+		user.visible_message("<b>\The [user]</b> extends \the [P] towards \the [src].", "<span class='notice'>You extend \the [P] towards \the [src].</span>")
 		if(do_after(user, 15))
 			to_chat(user, "<span class='notice'>\The [src] has been excavated to a depth of [2 * src.excavation_level]cm.</span>")
 		return

--- a/code/modules/xenoarcheaology/tools/tools.dm
+++ b/code/modules/xenoarcheaology/tools/tools.dm
@@ -111,7 +111,7 @@
 	var/material = "unknown"
 
 /obj/item/device/depth_scanner/proc/scan_atom(var/mob/user, var/atom/A)
-	user.visible_message("<span class='notice'>\The [user] scans \the [A], the air around them humming gently.</span>")
+	user.visible_message("<b>\The [user]</b> scans \the [A], the air around them humming gently.")
 
 	if(istype(A, /turf/simulated/mineral))
 		var/turf/simulated/mineral/M = A

--- a/code/modules/xenobio/items/extracts.dm
+++ b/code/modules/xenobio/items/extracts.dm
@@ -53,7 +53,7 @@
 	var/obj/item/slime_extract/T = holder.my_atom
 	T.uses--
 	if(T.uses <= 0)
-		T.visible_message("[bicon(T)]<span class='notice'>\The [T] goes inert.</span>")
+		T.visible_message("[bicon(T)]<b>\The [T]</b> goes inert.")
 		T.name = "inert [initial(T.name)]"
 
 

--- a/code/modules/xenobio/machinery/processor.dm
+++ b/code/modules/xenobio/machinery/processor.dm
@@ -58,7 +58,7 @@
 		return
 	to_be_processed.Add(AM)
 	AM.forceMove(src)
-	visible_message("<span class='notice'>\the [user] places [AM] inside \the [src].</span>")
+	visible_message("<b>\The [user]</b> places [AM] inside \the [src].")
 
 /obj/machinery/processor/proc/begin_processing()
 	if(processing)


### PR DESCRIPTION
* Changes a lot of blue-text third-person `visible_message`s to look more like emotes.
* Also fixes a few issues with `\the` after an html tag instead of `\The`. Technically they're autoinserted properly if you just use `[atom]`, but still.