### PR TITLE
CONVEYORS

### DIFF
--- a/code/modules/recycling/conveyor2.dm
+++ b/code/modules/recycling/conveyor2.dm
@@ -67,8 +67,8 @@
 
 /obj/machinery/conveyor/proc/update_dir()
 	if(!(dir in cardinal)) // Diagonal. Forwards is *away* from dir, curving to the right.
-		forwards = turn(dir, 135)
-		backwards = turn(dir, 45)
+		forwards = turn(dir, 45)
+		backwards = turn(dir, 135)
 	else
 		forwards = dir
 		backwards = turn(dir, 180)


### PR DESCRIPTION
AAAA

Ok they now move clockwise towards the nearest orthagonal if they are a diagonal conveyor, which makes more sense than 'they move 135 degrees away from where they're pointing as forwards'.

Requires map fixes