### PR TITLE
Makes time/tram use REALTIMEOFDAY rather than world.time

### DIFF
--- a/code/_helpers/time.dm
+++ b/code/_helpers/time.dm
@@ -119,7 +119,8 @@ GLOBAL_VAR_INIT(round_start_time, 0)
 /var/rollovercheck_last_timeofday = 0
 /proc/update_midnight_rollover()
 	if (world.timeofday < rollovercheck_last_timeofday) //TIME IS GOING BACKWARDS!
-		return midnight_rollovers++
+		midnight_rollovers += 1
+	rollovercheck_last_timeofday = world.timeofday
 	return midnight_rollovers
 
 //Increases delay as the server gets more overloaded,

--- a/code/_helpers/time.dm
+++ b/code/_helpers/time.dm
@@ -44,7 +44,7 @@ var/next_station_date_change = 1 DAY
 
 #define duration2stationtime(time) time2text(station_time_in_ds + time, "hh:mm")
 #define worldtime2stationtime(time) time2text(GLOB.roundstart_hour HOURS + time, "hh:mm")
-#define round_duration_in_ds (GLOB.round_start_time ? world.time - GLOB.round_start_time : 0)
+#define round_duration_in_ds (GLOB.round_start_time ? REALTIMEOFDAY - GLOB.round_start_time : 0)
 #define station_time_in_ds (GLOB.roundstart_hour HOURS + round_duration_in_ds)
 
 /proc/stationtime2text()
@@ -56,9 +56,7 @@ var/next_station_date_change = 1 DAY
 		next_station_date_change += 1 DAY
 		update_time = TRUE
 	if(!station_date || update_time)
-		var/extra_days = round(station_time_in_ds / (1 DAY)) DAYS
-		var/timeofday = world.timeofday + extra_days
-		station_date = num2text((text2num(time2text(timeofday, "YYYY"))+300)) + "-" + time2text(timeofday, "MM-DD") //VOREStation Edit
+		station_date = num2text((text2num(time2text(REALTIMEOFDAY, "YYYY"))+300)) + "-" + time2text(REALTIMEOFDAY, "MM-DD") //VOREStation Edit
 	return station_date
 
 //ISO 8601
@@ -96,7 +94,7 @@ var/last_round_duration = 0
 GLOBAL_VAR_INIT(round_start_time, 0)
 
 /hook/roundstart/proc/start_timer()
-	GLOB.round_start_time = world.time
+	GLOB.round_start_time = REALTIMEOFDAY
 	return 1
 
 /proc/roundduration2text()


### PR DESCRIPTION
REALTIMEOFDAY means that at 11:59:59 -> 12:00:00, the time will go from 864000 to 864001 (Or 863999 to 864000?) and continue. Basically, it takes into account midnight rollover and is strictly monotonic.
Needs testing. I can't really just... AFK on a local server for 6 hours, so like... Iunno.