### PR TITLE
More painting tweaks

### DIFF
--- a/code/controllers/subsystems/persistence.dm
+++ b/code/controllers/subsystems/persistence.dm
@@ -7,7 +7,8 @@ SUBSYSTEM_DEF(persistence)
 	
 	/// Places our subsystem can spawn paintings (helps with art spawning differently across maps)
 	var/list/obj/structure/sign/painting/painting_frames = list()
-	var/list/paintings = list()
+	var/list/all_paintings = list()
+	var/list/unpicked_paintings = list()
 
 /datum/controller/subsystem/persistence/Initialize()
 	. = ..()

--- a/code/game/objects/structures/artstuff.dm
+++ b/code/game/objects/structures/artstuff.dm
@@ -516,7 +516,7 @@
 	var/md5 = md5(lowertext(data))
 	LAZYINITLIST(SSpersistence.paintings)
 	for(var/list/entry in SSpersistence.paintings)
-		if(entry["md5"] == md5)
+		if(entry["md5"] == md5 && entry["persistence_id"] == persistence_id)
 			return
 	var/png_directory = "data/persistent/paintings/[persistence_id]/"
 	var/png_path = png_directory + "[md5].png"

--- a/code/modules/persistence/paintings.dm
+++ b/code/modules/persistence/paintings.dm
@@ -8,16 +8,17 @@
 /datum/persistent/paintings/Initialize()
 	. = ..()
 	if(fexists(filename))
-		SSpersistence.paintings = json_decode(file2text(filename))
-		var/list/tokens = SSpersistence.paintings
+		SSpersistence.all_paintings = json_decode(file2text(filename))
+		var/list/tokens = SSpersistence.all_paintings
 		for(var/list/token in tokens)
 			token["age"]++ // Increment age!
 			if(!CheckTokenSanity(token))
 				tokens -= token
-
+	
+	SSpersistence.unpicked_paintings = SSpersistence.all_paintings.Copy()
+	
 	for(var/obj/structure/sign/painting/P in SSpersistence.painting_frames)
 		P.load_persistent()
-	return
 
 /datum/persistent/paintings/CheckTokenSanity(var/list/token)
 	var/png_filename = "data/paintings/[token["persistence_id"]]/[token["md5"]].png"
@@ -33,4 +34,4 @@
 
 	if(fexists(filename))
 		fdel(filename)
-	to_file(file(filename), json_encode(SSpersistence.paintings))
+	to_file(file(filename), json_encode(SSpersistence.all_paintings))


### PR DESCRIPTION
- Allows cross-id saving, so you can unframe a painting from a public frame and slap it in a librarian frame and it will get saved into both pools.
- Prevents paintings from loading more than once. We have a lot of nice paintings now, let's show 'em all off rather than having chances to get duplicates around the station. And I'd rather have the frames empty if there's not enough, so we can get people to draw even more!

Holy heck people are doing a lot of art and it's all awesome.