### PR TITLE
Expands do_after/do_mob exclusive var to affect target

### DIFF
--- a/code/__defines/flags.dm
+++ b/code/__defines/flags.dm
@@ -34,6 +34,7 @@ GLOBAL_LIST_INIT(bitflags, list(1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 204
 #define PHORONGUARD				(1<<5)	// Does not get contaminated by phoron.
 #define	NOREACT					(1<<6)	// Reagents don't react inside this container.
 #define OVERLAY_QUEUED			(1<<7)// Atom queued to SSoverlay for COMPILE_OVERLAYS
+#define IS_BUSY					(1<<8)	// Atom has a TASK_TARGET_EXCLUSIVE do_after with it as the target.
 
 //Flags for items (equipment) - Used in /obj/item/var/item_flags
 #define THICKMATERIAL			(1<<0)	// Prevents syringes, parapens and hyposprays if equipped to slot_suit or slot_head.
@@ -49,3 +50,8 @@ GLOBAL_LIST_INIT(bitflags, list(1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 204
 #define PASSGRILLE				(1<<2)
 #define PASSBLOB				(1<<3)
 #define PASSMOB					(1<<4)
+
+// Flags for do_after/do_mob exclusivity.
+#define TASK_TARGET_EXCLUSIVE	(1<<1)
+#define TASK_USER_EXCLUSIVE		(1<<2)
+#define TASK_ALL_EXCLUSIVE		TASK_TARGET_EXCLUSIVE | TASK_USER_EXCLUSIVE

--- a/code/_helpers/mobs.dm
+++ b/code/_helpers/mobs.dm
@@ -144,12 +144,15 @@ Proc for attack log creation, because really why not
 
 /proc/do_mob(mob/user , mob/target, time = 30, target_zone = 0, uninterruptible = FALSE, progress = TRUE, ignore_movement = FALSE, exclusive = FALSE)
 	if(!user || !target)
-		return 0
+		return FALSE
 	if(!time)
-		return 1 //Done!
+		return TRUE //Done!
 	if(user.status_flags & DOING_TASK)
 		to_chat(user, "<span class='warning'>You're in the middle of doing something else already.</span>")
-		return 0 //Performing an exclusive do_after or do_mob already
+		return FALSE //Performing an exclusive do_after or do_mob already
+	if(target?.flags & IS_BUSY)
+		to_chat(user, "<span class='warning'>Someone is already doing something with \the [target].</span>")
+		return FALSE
 	var/user_loc = user.loc
 	var/target_loc = target.loc
 
@@ -161,8 +164,10 @@ Proc for attack log creation, because really why not
 	var/endtime = world.time+time
 	var/starttime = world.time
 
-	if(exclusive)
+	if(exclusive & TASK_USER_EXCLUSIVE)
 		user.status_flags |= DOING_TASK
+	if(target && exclusive & TASK_TARGET_EXCLUSIVE)
+		target.flags |= IS_BUSY
 
 	. = TRUE
 	while (world.time < endtime)
@@ -195,20 +200,26 @@ Proc for attack log creation, because really why not
 			. = FALSE
 			break
 
-	if(exclusive)
+	if(exclusive & TASK_USER_EXCLUSIVE)
 		user.status_flags &= ~DOING_TASK
+	if(exclusive & TASK_TARGET_EXCLUSIVE)
+		target?.status_flags &= ~IS_BUSY
 
 	if (progbar)
 		qdel(progbar)
 
 /proc/do_after(mob/user, delay, atom/target = null, needhand = TRUE, progress = TRUE, incapacitation_flags = INCAPACITATION_DEFAULT, ignore_movement = FALSE, max_distance = null, exclusive = FALSE)
 	if(!user)
-		return 0
+		return FALSE
 	if(!delay)
-		return 1 //Okay. Done.
+		return TRUE //Okay. Done.
 	if(user.status_flags & DOING_TASK)
 		to_chat(user, "<span class='warning'>You're in the middle of doing something else already.</span>")
-		return 0 //Performing an exclusive do_after or do_mob already
+		return FALSE //Performing an exclusive do_after or do_mob already
+	if(target?.flags & IS_BUSY)
+		to_chat(user, "<span class='warning'>Someone is already doing something with \the [target].</span>")
+		return FALSE
+		
 	var/atom/target_loc = null
 	if(target)
 		target_loc = target.loc
@@ -230,10 +241,13 @@ Proc for attack log creation, because really why not
 	var/endtime = world.time + delay
 	var/starttime = world.time
 
-	if(exclusive)
+	if(exclusive & TASK_USER_EXCLUSIVE)
 		user.status_flags |= DOING_TASK
+	
+	if(target && exclusive & TASK_TARGET_EXCLUSIVE)
+		target.flags |= IS_BUSY
 
-	. = 1
+	. = TRUE
 	while (world.time < endtime)
 		stoplag(1)
 		if(progress)
@@ -269,8 +283,10 @@ Proc for attack log creation, because really why not
 			. = FALSE
 			break
 
-	if(exclusive)
+	if(exclusive & TASK_USER_EXCLUSIVE)
 		user.status_flags &= ~DOING_TASK
+	if(target & exclusive & TASK_TARGET_EXCLUSIVE)
+		target.flags &= ~IS_BUSY
 
 	if(progbar)
 		qdel(progbar)

--- a/code/game/objects/items/devices/denecrotizer_vr.dm
+++ b/code/game/objects/items/devices/denecrotizer_vr.dm
@@ -145,7 +145,7 @@
 			return FALSE
 		if(!target.mind) 
 			user.visible_message("[user] gently presses [src] to [target]...", runemessage = "presses [src] to [target]")
-			if(do_after(user, revive_time, exclusive = 1, target = target))
+			if(do_after(user, revive_time, exclusive = TASK_USER_EXCLUSIVE, target = target))
 				target.faction = user.faction
 				target.revivedby = user.name
 				target.ghostjoin = 1
@@ -166,7 +166,7 @@
 
 /obj/item/device/denecrotizer/proc/ghostjoin_rez(mob/living/simple_mob/target, mob/living/user)
 	user.visible_message("[user] gently presses [src] to [target]...", runemessage = "presses [src] to [target]")
-	if(do_after(user, revive_time, exclusive = 1, target = target))
+	if(do_after(user, revive_time, exclusive = TASK_ALL_EXCLUSIVE, target = target))
 		target.faction = user.faction
 		target.revivedby = user.name
 		target.ai_holder.returns_home = FALSE
@@ -190,7 +190,7 @@
 		
 /obj/item/device/denecrotizer/proc/basic_rez(mob/living/simple_mob/target, mob/living/user) //so medical can have a way to bring back people's pets or whatever, does not change any settings about the mob or offer it to ghosts.
 	user.visible_message("[user] presses [src] to [target]...", runemessage = "presses [src] to [target]")
-	if(do_after(user, revive_time, exclusive = 1, target = target))
+	if(do_after(user, revive_time, exclusive = TASK_ALL_EXCLUSIVE, target = target))
 		target.revive()
 		target.sight = initial(target.sight)
 		target.see_in_dark = initial(target.see_in_dark)

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -408,7 +408,7 @@
 				to_chat(user, "<span class='danger'>You can't apply a splint to the arm you're using!</span>")
 				return
 			user.visible_message("<span class='danger'>[user] starts to apply \the [src] to their [limb].</span>", "<span class='danger'>You start to apply \the [src] to your [limb].</span>", "<span class='danger'>You hear something being wrapped.</span>")
-		if(do_after(user, 50, M, exclusive = TRUE))
+		if(do_after(user, 50, M, exclusive = TASK_USER_EXCLUSIVE))
 			if(affecting.splinted)
 				to_chat(user, "<span class='danger'>[M]'s [limb] is already splinted!</span>")
 				return

--- a/code/game/objects/items/stacks/nanopaste.dm
+++ b/code/game/objects/items/stacks/nanopaste.dm
@@ -16,7 +16,7 @@
 	if (istype(M,/mob/living/silicon/robot))	//Repairing cyborgs
 		var/mob/living/silicon/robot/R = M
 		if (R.getBruteLoss() || R.getFireLoss())
-			if(do_after(user, 7 * toolspeed, exclusive = TRUE))
+			if(do_after(user, 7 * toolspeed, R, exclusive = TASK_ALL_EXCLUSIVE))
 				R.adjustBruteLoss(-15)
 				R.adjustFireLoss(-15)
 				R.updatehealth()
@@ -51,9 +51,9 @@
 			else if(can_use(1))
 				user.setClickCooldown(user.get_attack_speed(src))
 				if(S.open >= 2)
-					if(do_after(user, 5 * toolspeed, exclusive = TRUE))
+					if(do_after(user, 5 * toolspeed, S, exclusive = TASK_ALL_EXCLUSIVE))
 						S.heal_damage(restoration_internal, restoration_internal, robo_repair = 1)
-				else if(do_after(user, 5 * toolspeed, exclusive = TRUE))
+				else if(do_after(user, 5 * toolspeed, S, exclusive = TASK_ALL_EXCLUSIVE))
 					S.heal_damage(restoration_external,restoration_external, robo_repair =1)
 				H.updatehealth()
 				use(1)

--- a/code/game/objects/items/weapons/storage/pouches.dm
+++ b/code/game/objects/items/weapons/storage/pouches.dm
@@ -23,7 +23,7 @@
 	if(user.get_active_hand() == src || user.get_inactive_hand() == src)
 		return TRUE // Skip delay
 
-	if(insert_delay && !do_after(user, 2 SECONDS, src, needhand = TRUE, exclusive = TRUE))
+	if(insert_delay && !do_after(user, 2 SECONDS, src, needhand = TRUE, exclusive = TASK_USER_EXCLUSIVE))
 		return FALSE // Moved or whatever
 
 	if(W in src)
@@ -36,7 +36,7 @@
 	if(user.get_active_hand() == src || user.get_inactive_hand() == src)
 		return TRUE // Skip delay
 	
-	if(remove_delay && !do_after(user, 2 SECONDS, src, needhand = TRUE, exclusive = TRUE))
+	if(remove_delay && !do_after(user, 2 SECONDS, src, needhand = TRUE, exclusive = TASK_USER_EXCLUSIVE))
 		return FALSE // Moved or whatever
 
 	if(W in src)

--- a/code/game/objects/structures/door_assembly.dm
+++ b/code/game/objects/structures/door_assembly.dm
@@ -176,7 +176,7 @@
 			playsound(src, WT.usesound, 50, 1)
 			if(istext(glass))
 				user.visible_message("[user] welds the [glass] plating off the airlock assembly.", "You start to weld the [glass] plating off the airlock assembly.")
-				if(do_after(user, 40 * WT.toolspeed))
+				if(do_after(user, 4 SECONDS * WT.toolspeed, src, exclusive = TASK_ALL_EXCLUSIVE))
 					if(!src || !WT.isOn()) return
 					to_chat(user, "<span class='notice'>You welded the [glass] plating off!</span>")
 					var/M = text2path("/obj/item/stack/material/[glass]")
@@ -184,14 +184,14 @@
 					glass = 0
 			else if(glass == 1)
 				user.visible_message("[user] welds the glass panel out of the airlock assembly.", "You start to weld the glass panel out of the airlock assembly.")
-				if(do_after(user, 40 * WT.toolspeed))
+				if(do_after(user, 4 SECONDS * WT.toolspeed, src, exclusive = TASK_ALL_EXCLUSIVE))
 					if(!src || !WT.isOn()) return
 					to_chat(user, "<span class='notice'>You welded the glass panel out!</span>")
 					new /obj/item/stack/material/glass/reinforced(src.loc)
 					glass = 0
 			else if(!anchored)
 				user.visible_message("[user] dissassembles the airlock assembly.", "You start to dissassemble the airlock assembly.")
-				if(do_after(user, 40 * WT.toolspeed))
+				if(do_after(user, 4 SECONDS * WT.toolspeed, src, exclusive = TASK_ALL_EXCLUSIVE))
 					if(!src || !WT.isOn()) return
 					to_chat(user, "<span class='notice'>You dissasembled the airlock assembly!</span>")
 					new /obj/item/stack/material/steel(src.loc, 4)
@@ -207,7 +207,7 @@
 		else
 			user.visible_message("[user] begins securing the airlock assembly to the floor.", "You starts securing the airlock assembly to the floor.")
 
-		if(do_after(user, 40 * W.toolspeed))
+		if(do_after(user, 4 SECONDS * W.toolspeed, src, exclusive = TASK_ALL_EXCLUSIVE))
 			if(!src) return
 			to_chat(user, "<span class='notice'>You [anchored? "un" : ""]secured the airlock assembly!</span>")
 			anchored = !anchored
@@ -218,7 +218,7 @@
 			to_chat(user, "<span class='warning'>You need one length of coil to wire the airlock assembly.</span>")
 			return
 		user.visible_message("[user] wires the airlock assembly.", "You start to wire the airlock assembly.")
-		if(do_after(user, 40) && state == 0 && anchored)
+		if(do_after(user, 4 SECONDS, src, exclusive = TASK_ALL_EXCLUSIVE) && state == 0 && anchored)
 			if (C.use(1))
 				src.state = 1
 				to_chat(user, "<span class='notice'>You wire the airlock.</span>")
@@ -227,7 +227,7 @@
 		playsound(src, W.usesound, 100, 1)
 		user.visible_message("[user] cuts the wires from the airlock assembly.", "You start to cut the wires from airlock assembly.")
 
-		if(do_after(user, 40 * W.toolspeed))
+		if(do_after(user, 4 SECONDS * W.toolspeed, src, exclusive = TASK_ALL_EXCLUSIVE))
 			if(!src) return
 			to_chat(user, "<span class='notice'>You cut the airlock wires.!</span>")
 			new/obj/item/stack/cable_coil(src.loc, 1)
@@ -237,7 +237,7 @@
 		playsound(src, W.usesound, 100, 1)
 		user.visible_message("[user] installs the electronics into the airlock assembly.", "You start to install electronics into the airlock assembly.")
 
-		if(do_after(user, 40))
+		if(do_after(user, 4 SECONDS, src, exclusive = TASK_ALL_EXCLUSIVE))
 			if(!src) return
 			user.drop_item()
 			W.loc = src
@@ -255,7 +255,7 @@
 		playsound(src, W.usesound, 100, 1)
 		user.visible_message("\The [user] starts removing the electronics from the airlock assembly.", "You start removing the electronics from the airlock assembly.")
 
-		if(do_after(user, 40 * W.toolspeed))
+		if(do_after(user, 4 SECONDS * W.toolspeed, src, exclusive = TASK_ALL_EXCLUSIVE))
 			if(!src) return
 			to_chat(user, "<span class='notice'>You removed the airlock electronics!</span>")
 			src.state = 1
@@ -270,7 +270,7 @@
 				if(material_name == "rglass")
 					playsound(src, 'sound/items/Crowbar.ogg', 100, 1)
 					user.visible_message("[user] adds [S.name] to the airlock assembly.", "You start to install [S.name] into the airlock assembly.")
-					if(do_after(user, 40) && !glass)
+					if(do_after(user, 4 SECONDS, src, exclusive = TASK_ALL_EXCLUSIVE) && !glass)
 						if (S.use(1))
 							to_chat(user, "<span class='notice'>You installed reinforced glass windows into the airlock assembly.</span>")
 							glass = 1
@@ -282,7 +282,7 @@
 					if(S.get_amount() >= 2)
 						playsound(src, 'sound/items/Crowbar.ogg', 100, 1)
 						user.visible_message("[user] adds [S.name] to the airlock assembly.", "You start to install [S.name] into the airlock assembly.")
-						if(do_after(user, 40) && !glass)
+						if(do_after(user, 4 SECONDS, src, exclusive = TASK_ALL_EXCLUSIVE) && !glass)
 							if (S.use(2))
 								to_chat(user, "<span class='notice'>You installed [material_display_name(material_name)] plating into the airlock assembly.</span>")
 								glass = material_name
@@ -291,7 +291,7 @@
 		playsound(src, W.usesound, 100, 1)
 		to_chat(user, "<span class='notice'>Now finishing the airlock.</span>")
 
-		if(do_after(user, 40 * W.toolspeed))
+		if(do_after(user, 4 SECONDS * W.toolspeed, src, exclusive = TASK_ALL_EXCLUSIVE))
 			if(!src) return
 			to_chat(user, "<span class='notice'>You finish the airlock!</span>")
 			var/path

--- a/code/modules/mob/living/carbon/human/species/station/station_special_abilities_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_special_abilities_vr.dm
@@ -910,7 +910,7 @@
 		to_chat(src, "<span class='warning'>You can't weave here!</span>")
 		return
 
-	if(do_after(src, desired_result.time, exclusive = TRUE))
+	if(do_after(src, desired_result.time, exclusive = TASK_USER_EXCLUSIVE))
 		if(desired_result.cost > species.silk_reserve)
 			to_chat(src, "<span class='warning'>You don't have enough silk to weave that!</span>")
 			return
@@ -969,7 +969,7 @@
 		to_chat(src, "<span class='warning'>You can't weave here!</span>")
 		return
 
-	if(do_after(src, desired_result.time, exclusive = TRUE))
+	if(do_after(src, desired_result.time, exclusive = TASK_USER_EXCLUSIVE))
 		if(desired_result.cost > species.silk_reserve)
 			to_chat(src, "<span class='warning'>You don't have enough silk to weave that!</span>")
 			return

--- a/code/modules/mob/living/simple_mob/subtypes/vore/softdog.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/softdog.dm
@@ -252,7 +252,7 @@
 		return ..()
 	if(M.a_intent == I_HELP)
 		M.visible_message("[M] pets [src].", runemessage = "pets [src]")
-		if(do_after(M, 30 SECONDS, exclusive = 1, target = src))
+		if(do_after(M, 30 SECONDS, exclusive = TASK_USER_EXCLUSIVE, target = src))
 			faction = M.faction
 			revive()
 			sight = initial(sight)

--- a/code/modules/vore/eating/living_vr.dm
+++ b/code/modules/vore/eating/living_vr.dm
@@ -521,7 +521,7 @@
 	prey.ai_holder?.react_to_attack(user)
 	
 	//Timer and progress bar
-	if(!do_after(user, swallow_time, prey, exclusive = TRUE))
+	if(!do_after(user, swallow_time, prey, exclusive = TASK_USER_EXCLUSIVE))
 		return FALSE // Prey escpaed (or user disabled) before timer expired.
 
 	// If we got this far, nom successful! Announce it!
@@ -798,7 +798,7 @@
 		playsound(src, 'sound/items/eatfood.ogg', rand(10,50), 1)
 		var/T = (istype(M) ? M.hardness/40 : 1) SECONDS //1.5 seconds to eat a sheet of metal. 2.5 for durasteel and diamond & 1 by default (applies to some ores like raw carbon, slag, etc.
 		to_chat(src, "<span class='notice'>You start crunching on [I] with your powerful jaws, attempting to tear it apart...</span>")
-		if(do_after(feeder, T, ignore_movement = TRUE, exclusive = TRUE)) //Eat on the move, but not multiple things at once.
+		if(do_after(feeder, T, ignore_movement = TRUE, exclusive = TASK_ALL_EXCLUSIVE)) //Eat on the move, but not multiple things at once.
 			if(feeder != src)
 				to_chat(feeder, "<span class='notice'>You feed [I] to [src].</span>")
 				log_admin("VORE: [feeder] fed [src] [I].")


### PR DESCRIPTION
- The `exclusive` var on `do_after`/`do_target` is now a bitflag, with `TASK_USER_EXCLUSIVE`, `TASK_TARGET_EXCLUSIVE`, and `TASK_ALL_EXCLUSIVE` (a shorthand for the combination of the first two).
- `TASK_USER_EXCLUSIVE` functions as the old system did, where the user is restricted to just one interaction.
- `TASK_TARGET_EXCLUSIVE` restricts the *target* to one interaction, so you can't have multiple people doing the same thing (or two different things) to it at once.
- `TASK_ALL_EXCLUSIVE` just combines the above two.
- A number of `exclusive = 1`/`exclusive = TRUE` `do_after`s have been changed to `TASK_ALL_EXCLUSIVE`, on a case-by-case basis.