### PR TITLE
Adds PAI spawn points.

### DIFF
--- a/maps/tether/tether-01-surface1.dmm
+++ b/maps/tether/tether-01-surface1.dmm
@@ -7487,6 +7487,9 @@
 	dir = 1
 	},
 /obj/structure/closet/crate,
+/obj/item/device/paicard{
+	pixel_x = 4
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/tether/surfacebase/public_garden_one)
 "amC" = (
@@ -34023,6 +34026,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
+/obj/item/device/paicard{
+	pixel_x = 4
+	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/visitor_laundry)
 "jCv" = (
@@ -35417,6 +35423,20 @@
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/plating,
 /area/maintenance/substation/SurfMedsubstation)
+"ncj" = (
+/obj/structure/table/standard{
+	name = "plastic table frame"
+	},
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/item/device/paicard{
+	pixel_x = 4
+	},
+/turf/simulated/floor/tiled,
+/area/crew_quarters/locker)
 "ndH" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -52837,7 +52857,7 @@ apF
 ash
 ast
 asU
-atp
+ncj
 hoH
 ast
 auR

--- a/maps/tether/tether-02-surface2.dmm
+++ b/maps/tether/tether-02-surface2.dmm
@@ -16241,6 +16241,9 @@
 	dir = 8;
 	pixel_x = 24
 	},
+/obj/item/device/paicard{
+	pixel_x = 4
+	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/fish_farm)
 "aBG" = (
@@ -19173,6 +19176,9 @@
 "aHj" = (
 /obj/structure/table/woodentable,
 /obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/item/device/paicard{
+	pixel_x = 4
+	},
 /turf/simulated/floor/carpet,
 /area/chapel/main)
 "aHk" = (
@@ -33877,6 +33883,13 @@
 /obj/item/weapon/grenade/anti_photon,
 /turf/simulated/floor/plating,
 /area/tether/surfacebase/funny/hideyhole)
+"owg" = (
+/obj/structure/table/marble,
+/obj/item/device/paicard{
+	pixel_x = 4
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/public_garden_two)
 "oXH" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -40244,7 +40257,7 @@ apq
 aqw
 aib
 ast
-atG
+owg
 ass
 avi
 akX

--- a/maps/tether/tether-03-surface3.dmm
+++ b/maps/tether/tether-03-surface3.dmm
@@ -18590,6 +18590,9 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
+/obj/item/device/paicard{
+	pixel_x = 4
+	},
 /turf/simulated/floor/carpet,
 /area/library)
 "aEv" = (
@@ -41987,6 +41990,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/carpet,
 /area/tether/surfacebase/security/hos)
+"rpN" = (
+/obj/structure/table/woodentable,
+/obj/item/device/paicard{
+	pixel_x = 4
+	},
+/turf/simulated/floor/wood,
+/area/tether/surfacebase/entertainment)
 "rrG" = (
 /obj/structure/table/steel,
 /obj/item/weapon/folder/red{
@@ -57386,7 +57396,7 @@ aGA
 aEd
 bbl
 beX
-beX
+rpN
 bcY
 bdq
 bbk


### PR DESCRIPTION
Just Added some PAI spawn locations by request of a PAI player. The current only spawn point not directly carried by a player is in the RD's office which it does not have access to escape from.

![image](https://user-images.githubusercontent.com/34927367/125020605-c73a1a00-e03e-11eb-87c3-4f71a77367b2.png)

![image](https://user-images.githubusercontent.com/34927367/125020613-cacda100-e03e-11eb-9f92-21cc39fabc7b.png)

![image](https://user-images.githubusercontent.com/34927367/125020631-d3be7280-e03e-11eb-9abf-3760a09ecd9e.png)


![image](https://user-images.githubusercontent.com/34927367/125020640-d7ea9000-e03e-11eb-8d2d-626186cfa550.png)


![image](https://user-images.githubusercontent.com/34927367/125020654-dcaf4400-e03e-11eb-8a36-6ab820347e78.png)


![image](https://user-images.githubusercontent.com/34927367/125020663-e173f800-e03e-11eb-8147-daf528bd6c3c.png)
