### PR TITLE
Allows players to name their mobs.

### DIFF
--- a/code/modules/mob/living/simple_mob/subtypes/vore/vore.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/vore.dm
@@ -1,6 +1,35 @@
 /mob/living/simple_mob/vore
 	mob_class = MOB_CLASS_ANIMAL
 	mob_bump_flag = 0
+	var/nameset
+
+/mob/living/simple_mob/vore/Login()
+	. = ..()
+	verbs |= /mob/living/simple_mob/vore/proc/set_name
+	verbs |= /mob/living/simple_mob/vore/proc/set_desc
+
+/mob/living/simple_mob/vore/proc/set_name()
+	set name = "Set Name"
+	set desc = "Sets your mobs name. You only get to do this once."
+	set category = "Abilities"
+	if(nameset)
+		to_chat(src, "<span class='userdanger'>You've already set your name. Ask an admin to toggle \"nameset\" to 0 if you really must.</span>")
+		return
+	var/newname
+	newname = sanitizeSafe(input(src,"Set your name. You only get to do this once. Max 52 chars.", "Name set","") as text, MAX_NAME_LEN)
+	if (newname)
+		name = newname
+		voice_name = newname
+		nameset = 1
+
+/mob/living/simple_mob/vore/proc/set_desc()
+	set name = "Set Description"
+	set desc = "Set your description."
+	set category = "Abilities"
+	var/newdesc
+	newdesc = sanitizeSafe(input(src,"Set your description. Max 4096 chars.", "Description set","") as text, MAX_MESSAGE_LEN)
+	if(newdesc)
+		desc = newdesc
 
 /mob/living/simple_mob/vore/aggressive
 	mob_bump_flag = HEAVY

--- a/code/modules/mob/living/simple_mob/subtypes/vore/weretiger.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/weretiger.dm
@@ -12,6 +12,7 @@
 	faction = "panther"
 	maxHealth = 150
 	health = 150
+	movement_cooldown = 2
 
 	response_help = "pats"
 	response_disarm = "gently pushes aside"
@@ -24,6 +25,10 @@
 
 	say_list_type = /datum/say_list/weretiger
 	ai_holder_type = /datum/ai_holder/simple_mob/retaliate
+
+	pixel_x = -16
+
+	has_hands = 1
 
 // Nomnomn
 /mob/living/simple_mob/vore/weretiger


### PR DESCRIPTION
Quick chompstation port.

- You can now name a vore mob you control, and change the description.
- Only works once, need admin support if you mess it up.
- Also includes some tweaks for the weretiger I forgot to add, such as hands to pick stuff up, and not being super-duper slow.