### PR TITLE
Stack Examine Improvements, Log Examine Fix

### DIFF
--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -56,14 +56,17 @@
 			icon_state = "[initial(icon_state)]_3"
 		item_state = initial(icon_state)
 
+/obj/item/stack/proc/get_examine_string()
+	if(!uses_charge)
+		return "There [src.amount == 1 ? "is" : "are"] [src.amount] [src.singular_name]\s in the stack."
+	else
+		return "There is enough charge for [get_amount()]."
+
 /obj/item/stack/examine(mob/user)
 	. = ..()
 
 	if(Adjacent(user))
-		if(!uses_charge)
-			. += "There are [src.amount] [src.singular_name]\s in the stack."
-		else
-			. += "There is enough charge for [get_amount()]."
+		. += get_examine_string()
 
 /obj/item/stack/attack_self(mob/user)
 	tgui_interact(user)

--- a/code/modules/materials/materials/_materials.dm
+++ b/code/modules/materials/materials/_materials.dm
@@ -165,6 +165,7 @@ var/list/name_to_material
 	var/flags = 0                         // Various status modifiers.
 	var/sheet_singular_name = "sheet"
 	var/sheet_plural_name = "sheets"
+	var/sheet_collective_name = "stack"
 	var/is_fusion_fuel
 
 	// Shards/tables/structures

--- a/code/modules/materials/materials/organic/wood.dm
+++ b/code/modules/materials/materials/organic/wood.dm
@@ -67,10 +67,12 @@
 
 /datum/material/wood/log
 	name = MAT_LOG
+	display_name = "wood" // will lead to "wood log"
 	icon_base = "log"
 	stack_type = /obj/item/stack/material/log
-	sheet_singular_name = null
-	sheet_plural_name = "pile"
+	sheet_singular_name = "log"
+	sheet_plural_name = "logs"
+	sheet_collective_name = "pile"
 	pass_stack_colors = TRUE
 	supply_conversion_value = 1
 
@@ -81,6 +83,7 @@
 
 /datum/material/wood/log/sif
 	name = MAT_SIFLOG
+	display_name = "alien wood"
 	icon_colour = "#0099cc" // Cyan-ish
 	stack_origin_tech = list(TECH_MATERIAL = 2, TECH_BIO = 2)
 	stack_type = /obj/item/stack/material/log/sif

--- a/code/modules/materials/sheets/_sheets.dm
+++ b/code/modules/materials/sheets/_sheets.dm
@@ -54,12 +54,17 @@
 
 	if(amount>1)
 		name = "[material.use_name] [material.sheet_plural_name]"
-		desc = "A stack of [material.use_name] [material.sheet_plural_name]."
+		desc = "A [material.sheet_collective_name] of [material.use_name] [material.sheet_plural_name]."
 		gender = PLURAL
 	else
 		name = "[material.use_name] [material.sheet_singular_name]"
 		desc = "A [material.sheet_singular_name] of [material.use_name]."
 		gender = NEUTER
+
+/obj/item/stack/material/get_examine_string()
+	if(!uses_charge)
+		return "There [amount == 1 ? "is" : "are"] [amount] [material.sheet_singular_name]\s in the [material.sheet_collective_name]."
+	return ..()
 
 /obj/item/stack/material/use(var/used)
 	. = ..()

--- a/code/unit_tests/material_tests.dm
+++ b/code/unit_tests/material_tests.dm
@@ -1,0 +1,19 @@
+/datum/unit_test/materials_shall_have_names
+	name = "MATERIALS: Materials Shall Have All Names"
+
+/datum/unit_test/materials_shall_have_names/start_test()
+	var/list/failures = list()
+	populate_material_list()
+	for(var/name in global.name_to_material)
+		var/datum/material/mat = global.name_to_material[name]
+		if(!mat)
+			continue // how did we get here?
+		if(!mat.display_name || !mat.use_name || !mat.sheet_singular_name || !mat.sheet_plural_name || !mat.sheet_collective_name)
+			failures[name] = mat.type
+
+	if(length(failures))
+		fail("[length(failures)] material\s had missing name strings: [english_list(failures)].")
+	else
+		pass("All materials had all their name strings.")
+
+	return TRUE

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -3995,6 +3995,7 @@
 #include "code\unit_tests\language_tests.dm"
 #include "code\unit_tests\loadout_tests.dm"
 #include "code\unit_tests\map_tests.dm"
+#include "code\unit_tests\material_tests.dm"
 #include "code\unit_tests\mob_tests.dm"
 #include "code\unit_tests\recipe_tests.dm"
 #include "code\unit_tests\research_tests.dm"


### PR DESCRIPTION
You can now customise the `sheet_collective_name` for a material, so that you can have a `pile` of `alien wood` `logs`, etc.
Examining a stack will now use is and are properly.
Redoes log material strings, to fix this issue:
![`A  of log. There are 1 s in the stack.`](https://i.imgur.com/KwX7Crv.png)
It now looks like this (sheet shown to confirm it hasn't broken anything else):
![Fixed image](https://i.imgur.com/JK4cZva.png)
Adds a unit test to ensure that all the name strings on materials are defined, to prevent this from happening in the future.