### PR TITLE
Fix some bugs

### DIFF
--- a/code/game/machinery/telecomms/machine_interactions.dm
+++ b/code/game/machinery/telecomms/machine_interactions.dm
@@ -83,12 +83,11 @@
 		data["linked"] = linked
 		
 		var/list/filter = list()
-		if(LAZYLEN(freq_listening))
-			for(var/x in freq_listening)
-				filter.Add(list(list(
-					"name" = "[format_frequency(x)]",
-					"freq" = x,
-				)))
+		for(var/x in freq_listening)
+			filter.Add(list(list(
+				"name" = "[format_frequency(x)]",
+				"freq" = x,
+			)))
 		data["filter"] = filter
 
 	return data

--- a/code/game/objects/items/devices/translocator_vr.dm
+++ b/code/game/objects/items/devices/translocator_vr.dm
@@ -390,7 +390,7 @@ or don't wish to potentially have a random person teleported into you, it's sugg
 not carry this around."}, "OOC Warning", list("Take It","Leave It"))
 		if(choice == "Leave It")
 			return
-		..()
+	return ..()
 
 /obj/item/device/perfect_tele_beacon/stationary
 	name = "stationary translocator beacon"

--- a/code/game/objects/items/weapons/implants/neuralbasic.dm
+++ b/code/game/objects/items/weapons/implants/neuralbasic.dm
@@ -16,7 +16,7 @@
 				my_brain.implant_assist(target_state)
 		if(H.isSynthetic() && H.get_FBP_type() != FBP_CYBORG)		//If this on an FBP, it's just an extra inefficient attachment to whatever their brain is.
 			robotic_brain = TRUE
-	if(my_brain && my_brain.can_assist())
+	if(istype(my_brain) && my_brain.can_assist())
 		START_PROCESSING(SSobj, src)
 
 /obj/item/weapon/implant/neural/Destroy()

--- a/code/modules/mob/living/carbon/human/species/station/protean_vr/protean_blob.dm
+++ b/code/modules/mob/living/carbon/human/species/station/protean_vr/protean_blob.dm
@@ -85,6 +85,9 @@
 /mob/living/simple_mob/protean_blob/speech_bubble_appearance()
 	return "synthetic"
 
+/mob/living/simple_mob/protean_blob/get_available_emotes()
+	return global._robot_default_emotes
+	
 /mob/living/simple_mob/protean_blob/init_vore()
 	return //Don't make a random belly, don't waste your time
 

--- a/code/modules/telesci/quantum_pad.dm
+++ b/code/modules/telesci/quantum_pad.dm
@@ -53,13 +53,13 @@
 	if(istype(I, /obj/item/device/multitool))
 		if(panel_open)
 			var/obj/item/device/multitool/M = I
-			M.buffer = src
+			M.connectable = src
 			to_chat(user, "<span class='notice'>You save the data in [I]'s buffer.</span>")
 			return 1
 		else
 			var/obj/item/device/multitool/M = I
-			if(istype(M.buffer, /obj/machinery/power/quantumpad))
-				linked_pad = M.buffer
+			if(istype(M.connectable, /obj/machinery/power/quantumpad))
+				linked_pad = M.connectable
 				to_chat(user, "<span class='notice'>You link [src] to the one in [I]'s buffer.</span>")
 				return 1
 

--- a/code/modules/vore/resizing/resize_vr.dm
+++ b/code/modules/vore/resizing/resize_vr.dm
@@ -47,7 +47,7 @@
 
 /atom/movable/proc/size_range_check(size_select)		//both objects and mobs needs to have that
 	var/area/A = get_area(src) //Get the atom's area to check for size limit.
-	if((A.limit_mob_size && (size_select > 200 || size_select < 25)) || (size_select > 600 || size_select <1))
+	if((A?.limit_mob_size && (size_select > 200 || size_select < 25)) || (size_select > 600 || size_select <1))
 		return FALSE
 	return TRUE
 


### PR DESCRIPTION
- Quantum pad linking then using the same multitool to look at tcomms machinery breaks the tgui interface of the tcomms machinery. It's the quantumpad's fault, though. Fixes #11011
- Giving people neural implants and them having an MMI is pointless and had a runtime, but it also doesn't do anything (it never has)
- Resizing people while in nullspace caused runtimes.
- Grabbing translocator beacons. Fixes #10939
- Proteans get synth emotes. Fixes #11004