### PR TITLE
Tracks random c_tags on areas to prevent duplicates.

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -51,6 +51,7 @@
 	var/forbid_events = FALSE // If true, random events will not start inside this area.
 	var/no_spoilers = FALSE // If true, makes it much more difficult to see what is inside an area with things like mesons.
 	var/soundproofed = FALSE // If true, blocks sounds from other areas and prevents hearers on other areas from hearing the sounds within.
+	var/used_ctags = list()
 
 /area/Initialize()
 	. = ..()

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -65,6 +65,12 @@
 	if(!c_tag)
 		var/area/A = get_area(src)
 		c_tag = "[A ? A.name : "Unknown"] #[rand(111,999)]"
+		if(length(used_ctags) >= 888) // The max number of unique ids from 111 to 999 inclusive
+			error("[get_area(src)] has over the maximum number of tagless cameras, and has run out of IDs!")
+		else	
+			while(c_tag in A.used_ctags))
+				c_tag = "[A ? A.name : "Unknown"] #[rand(111,999)]"
+			A.used_ctags += c_tag
 	..()
 	// VOREStation Edit End
 


### PR DESCRIPTION
Should fix the last error in #11023.