### PR TITLE
Reduce tgui logging

### DIFF
--- a/code/_helpers/logging.dm
+++ b/code/_helpers/logging.dm
@@ -172,6 +172,9 @@
 #endif
 
 /proc/log_tgui(user_or_client, text)
+	if(!text)
+		stack_trace("Pointless log_tgui message")
+		return
 	var/entry = ""
 	if(!user_or_client)
 		entry += "no user"

--- a/code/modules/tgui/external.dm
+++ b/code/modules/tgui/external.dm
@@ -224,7 +224,9 @@
 	if(window_id)
 		window = usr.client.tgui_windows[window_id]
 		if(!window)
+			// #ifdef TGUI_DEBUGGING // Always going to log these
 			log_tgui(usr, "Error: Couldn't find the window datum, force closing.")
+			// #endif
 			SStgui.force_close_window(usr, window_id)
 			return FALSE
 	// Decode payload

--- a/code/modules/tgui/tgui.dm
+++ b/code/modules/tgui/tgui.dm
@@ -257,12 +257,14 @@
 		return
 	// Validate ping
 	if(!initialized && world.time - opened_at > TGUI_PING_TIMEOUT)
+		// #ifdef TGUI_DEBUGGING // Always log zombie windows
 		log_tgui(user, \
 			"Error: Zombie window detected, killing it with fire.\n" \
 			+ "window_id: [window.id]\n" \
 			+ "opened_at: [opened_at]\n" \
 			+ "world.time: [world.time]")
 		close(can_be_suspended = FALSE)
+		// #endif
 		return
 	// Update through a normal call to ui_interact
 	if(status != STATUS_DISABLED && (autoupdate || force))
@@ -288,9 +290,6 @@
 		status = min(status, parent_ui.status)
 	return prev_status != status
 
-/datum/tgui/proc/log_message(message)
-	log_tgui("[user] ([user.ckey]) using \"[title]\":\n[message]")
-
 /datum/tgui/proc/set_map_z_level(nz)
 	map_z_level = nz
 
@@ -305,7 +304,9 @@
 	// Pass act type messages to tgui_act
 	if(type && copytext(type, 1, 5) == "act/")
 		var/act_type = copytext(type, 5)
+		#ifdef TGUI_DEBUGGING
 		log_tgui(user, "Action: [act_type] [href_list["payload"]], Window: [window.id], Source: [src_object]")
+		#endif
 		process_status()
 		if(src_object.tgui_act(act_type, payload, src, state))
 			SStgui.update_uis(src_object)

--- a/code/modules/tgui/tgui_window.dm
+++ b/code/modules/tgui/tgui_window.dm
@@ -53,7 +53,9 @@
 		inline_assets = list(),
 		inline_html = "",
 		fancy = FALSE)
+	#ifdef TGUI_DEBUGGING
 	log_tgui(client, "[id]/initiailize ([src])")
+	#endif
 	if(!client)
 		return
 	src.inline_assets = inline_assets
@@ -177,7 +179,9 @@
 	if(!client)
 		return
 	if(can_be_suspended && can_be_suspended())
+		#ifdef TGUI_DEBUGGING
 		log_tgui(client, "[id]/close: suspending")
+		#endif
 		status = TGUI_WINDOW_READY
 		send_message("suspend")
 		// You would think that BYOND would null out client or make it stop passing istypes or, y'know, ANYTHING during
@@ -187,7 +191,9 @@
 		if(!logout && client)
 			winset(client, null, "mapwindow.map.focus=true")
 		return
+	#ifdef TGUI_DEBUGGING
 	log_tgui(client, "[id]/close")
+	#endif
 	release_lock()
 	status = TGUI_WINDOW_CLOSED
 	message_queue = null


### PR DESCRIPTION
Getting TONS of tgui log messages makes rummaging in logs more annoying. No need for these, hide them behind a define. Some of them are just blank, also.