### PR TITLE
Fixes #11027

### DIFF
--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -491,6 +491,19 @@
 	for(var/datum/data/record/G in data_core.general)
 		if((G.fields["name"] == to_despawn.real_name))
 			qdel(G)
+	
+	// Also check the hidden version of each datacore, if they're an offmap role.
+	var/datum/job/J = SSjob.get_job(job)
+	if(J?.offmap_spawn)
+		for(var/datum/data/record/R in data_core.hidden_general)
+			if((R.fields["name"] == to_despawn.real_name))
+				qdel(R)
+		for(var/datum/data/record/T in data_core.hidden_security)
+			if((T.fields["name"] == to_despawn.real_name))
+				qdel(T)
+		for(var/datum/data/record/G in data_core.hidden_medical)
+			if((G.fields["name"] == to_despawn.real_name))
+				qdel(G)
 
 	icon_state = base_icon_state
 


### PR DESCRIPTION
I believe that it did actually free the slot, but left the (OOC) manifest. This properly removes offmap spawn jobs from the hidden datacore.

(Also, this was partially made with Github Copilot!)