### PR TITLE
Adds possibility of borg module whitelisting

### DIFF
--- a/code/game/jobs/whitelist.dm
+++ b/code/game/jobs/whitelist.dm
@@ -72,6 +72,23 @@ var/list/whitelist = list()
 			if(findtext(s,"[M.ckey] - All"))
 				return 1
 
+/proc/is_borg_whitelisted(mob/M, var/module)
+	//They are admin or the whitelist isn't in use
+	if(whitelist_overrides(M))
+		return 1
+
+	//You did something wrong
+	if(!M || !module)
+		return 0
+
+	//If we have a loaded file, search it
+	if(alien_whitelist)
+		for (var/s in alien_whitelist)
+			if(findtext(s,"[M.ckey] - [module]"))
+				return 1
+			if(findtext(s,"[M.ckey] - All"))
+				return 1
+
 /proc/whitelist_overrides(mob/M)
 	if(!config.usealienwhitelist)
 		return 1

--- a/code/global.dm
+++ b/code/global.dm
@@ -134,11 +134,24 @@ var/DBConnection/dbcon_old = new() // /tg/station database (Old database) -- see
 var/global/list/alphabet_uppercase = list("A","B","C","D","E","F","G","H","I","J","K","L","M","N","O","P","Q","R","S","T","U","V","W","X","Y","Z")
 
 
-// Used by robots and robot preferences.
+// Used by robots and robot preferences for regular modules.
 var/list/robot_module_types = list(
 	"Standard", "Engineering", "Surgeon",  "Crisis",
 	"Miner",    "Janitor",     "Service",      "Clerical", "Security",
-	"Research"
+	"Research", "Medihound", "K9", "Janihound", "Sci-borg", "Pupdozer",
+	"Service-Hound", "BoozeHound", "KMine"
+)
+// List of modules added during code red
+var/list/emergency_module_types = list(
+	"Combat", "ERT"
+)
+// List of modules available to AI shells
+var/list/shell_module_types = list(
+	"Standard", "Service", "Clerical", "Service-Hound", "BoozeHound"
+)
+// List of whitelisted modules
+var/list/whitelisted_module_types = list(
+	"Lost", "Stray"
 )
 
 // Some scary sounds.

--- a/code/global_vr.dm
+++ b/code/global_vr.dm
@@ -1,18 +1,3 @@
-/hook/startup/proc/modules_vr()
-	robot_module_types += "Medihound"
-	robot_module_types += "K9"
-	robot_module_types += "Janihound"
-	robot_module_types += "Sci-borg"
-	robot_module_types += "Pupdozer"
-	robot_module_types += "Service-Hound"
-	robot_module_types += "BoozeHound"
-	robot_module_types += "KMine"
-	return 1
-
-var/list/shell_module_types = list(
-	"Standard", "Service", "Clerical", "Service-Hound"
-)
-
 var/list/awayabductors = list() // List of scatter landmarks for Abductors in Gateways
 var/list/eventdestinations = list() // List of scatter landmarks for VOREStation event portals
 var/list/eventabductors = list() // List of scatter landmarks for VOREStation abductor portals

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -271,14 +271,18 @@
 		modules.Add(robot_module_types)
 		if(crisis || security_level == SEC_LEVEL_RED || crisis_override)
 			to_chat(src, "<font color='red'>Crisis mode active. Combat module available.</font>")
-			modules+="Combat"
-			modules+="ERT"
+			modules += emergency_module_types
+		for(var/module_name in whitelisted_module_types)
+			if(is_borg_whitelisted(src, module_name))
+				modules += module_name
 	//VOREStatation Edit End: shell restrictions
 	modtype = tgui_input_list(usr, "Please, select a module!", "Robot module", modules)
 
 	if(module)
 		return
 	if(!(modtype in robot_modules))
+		return
+	if(!is_borg_whitelisted(src, modtype))
 		return
 
 	var/module_type = robot_modules[modtype]

--- a/code/modules/mob/living/silicon/robot/robot_modules/station.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules/station.dm
@@ -9,7 +9,12 @@ var/global/list/robot_modules = list(
 	"Security" 		= /obj/item/weapon/robot_module/robot/security/general,
 	"Combat" 		= /obj/item/weapon/robot_module/robot/security/combat,
 	"Engineering"	= /obj/item/weapon/robot_module/robot/engineering/general,
-	"Janitor" 		= /obj/item/weapon/robot_module/robot/janitor
+	"Janitor" 		= /obj/item/weapon/robot_module/robot/janitor,
+	"Gravekeeper"	= /obj/item/weapon/robot_module/robot/gravekeeper,
+	"Lost"			= /obj/item/weapon/robot_module/robot/lost,
+	"Protector" 	= /obj/item/weapon/robot_module/robot/syndicate/protector,
+	"Mechanist" 	= /obj/item/weapon/robot_module/robot/syndicate/mechanist,
+	"Combat Medic"	= /obj/item/weapon/robot_module/robot/syndicate/combat_medic
 	)
 
 /obj/item/weapon/robot_module

--- a/code/modules/mob/living/silicon/robot/robot_modules/station_vr.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules/station_vr.dm
@@ -49,6 +49,7 @@
 	robot_modules["Service-Hound"] = /obj/item/weapon/robot_module/robot/clerical/brodog
 	robot_modules["BoozeHound"] = /obj/item/weapon/robot_module/robot/booze
 	robot_modules["KMine"] = /obj/item/weapon/robot_module/robot/kmine
+	robot_modules["Stray"] = /obj/item/weapon/robot_module/robot/stray
 	return 1
 
 //Just add a new proc with the robot_module type if you wish to run some other vore code


### PR DESCRIPTION
A bit of overhaul to how borg module list building works and allows possibility of borg module whitelisting in future. More detailed + less related changes.

Reunites total list of borg modules available to station into single one
Makes the emergency modules into global list instead of two hardcoded ones
Adds whitelisted modules list. Currently only contains Lost and Stray modules (mostly for example's sake). To access them, you need to be in alienwhitelists file with module name whitelisted for you.
Adds BoozeHound to AI shell options just because.

Also adds Gravekeeper and three syndie borgs to list of 'named module entries', although they aren't even whitelist-accessible thing.