### PR TITLE
Fix colorblind characters not seeing OL lights

### DIFF
--- a/code/modules/mob/mob_planes.dm
+++ b/code/modules/mob/mob_planes.dm
@@ -215,6 +215,7 @@
 	render_target = O_LIGHTING_VISUAL_RENDER_TARGET
 	blend_mode = BLEND_MULTIPLY
 	alpha = 255
+	appearance_flags = PLANE_MASTER|NO_CLIENT_COLOR // NO_CLIENT_COLOR because it has some naughty interactions with colorblindness that I can't figure out. Byond bug?
 
 /obj/screen/plane_master/emissive
 	plane = PLANE_EMISSIVE


### PR DESCRIPTION
Some sort of naughty interaction with plane masters and client color.

Lighting is BLEND_MULTIPLY, works fine with client color.
Emissives and OL planes are used as filters on lighting PM. Emissives works fine, but is not multiply. OL is multiply, and doesn't work with client color applied to it. So maybe "plane masters used as filters with blend_multiply" and maybe render targets "don't work with client color". Byond bug? It just makes them disappear entirely if you apply client color.

Fixes #11079 