### PR TITLE
Allow emptying contents from nearby bags

### DIFF
--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -662,9 +662,20 @@
 /obj/item/weapon/storage/verb/quick_empty()
 	set name = "Empty Contents"
 	set category = "Object"
+	set src in view(1)
 
-	if(((!(ishuman(usr) || isrobot(usr))) && (src.loc != usr)) || usr.stat || usr.restrained())
+	// Only humans and robots can dump contents
+	if(!(ishuman(usr) || isrobot(usr)))
 		return
+
+	// Hard to do when you're KO'd
+	if(usr.incapacitated())
+		return
+
+	// Has to be at least adjacent (just for safety, src in view should handle this already)
+	if(!Adjacent(usr))
+		return
+
 	drop_contents()
 
 /obj/item/weapon/storage/proc/drop_contents() // why is this a proc? literally just for RPEDs


### PR DESCRIPTION
You can empty bags you're adjacent to if they allow emptying. Previously would only allow emptying onto the floor from wherever you were standing (or you could, I guess, stand on the table).