### PR TITLE
Do speedboost text with zany regex

### DIFF
--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -130,10 +130,13 @@
 			. = 1
 
 	if(CE_SPEEDBOOST in chem_effects || is_jittery) // motor mouth
+		// Despite trying to url/html decode these, byond is just being bad and I dunno.
+		var/static/regex/speedboost_initial = new (@"&[a-z]{2,5};|&#\d{2};","g")
+		// Not herestring because bad vs code syntax highlight panics at apostrophe
+		var/static/regex/speedboost_main = new ("\[ ',!?.;\]","g")
 		for(var/datum/multilingual_say_piece/S in message_data[1])
-			S.message = replacetext(S.message," ","")
-			S.message = replacetext(S.message,",","")
-			S.message = replacetext(S.message,";","")
+			S.message = speedboost_initial.Replace(S.message, "")
+			S.message = speedboost_main.Replace(S.message, "")
 	else
 		. = ..(message_data)
 


### PR DESCRIPTION
ARG. This is annoying. But resolves the issue of broken html/url encoded fragments in runechat