### PR TITLE
Fixes #11129

### DIFF
--- a/code/modules/power/batteryrack.dm
+++ b/code/modules/power/batteryrack.dm
@@ -36,10 +36,10 @@
 /obj/machinery/power/smes/batteryrack/proc/add_parts()
 	component_parts = list()
 	component_parts += new /obj/item/weapon/circuitboard/batteryrack
-	component_parts += new /obj/item/weapon/stock_parts/capacitor/				// Capacitors: Maximal I/O
-	component_parts += new /obj/item/weapon/stock_parts/capacitor/
-	component_parts += new /obj/item/weapon/stock_parts/capacitor/
-	component_parts += new /obj/item/weapon/stock_parts/matter_bin/				// Matter Bin: Max. amount of cells.
+	component_parts += new /obj/item/weapon/stock_parts/capacitor				// Capacitors: Maximal I/O
+	component_parts += new /obj/item/weapon/stock_parts/capacitor
+	component_parts += new /obj/item/weapon/stock_parts/capacitor
+	component_parts += new /obj/item/weapon/stock_parts/matter_bin				// Matter Bin: Max. amount of cells.
 
 /obj/machinery/power/smes/batteryrack/RefreshParts()
 	var/capacitor_efficiency = 0
@@ -60,6 +60,9 @@
 		qdel(C)
 	internal_cells = null
 	return ..()
+
+/obj/machinery/power/smes/batteryrack/check_terminals()
+	return TRUE // we don't necessarily need terminals
 
 /obj/machinery/power/smes/batteryrack/update_icon()
 	cut_overlays()

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -68,14 +68,8 @@ GLOBAL_LIST_EMPTY(smeses)
 /obj/machinery/power/smes/Initialize()
 	. = ..()
 	GLOB.smeses += src
-	for(var/d in GLOB.cardinal)
-		var/turf/T = get_step(src, d)
-		for(var/obj/machinery/power/terminal/term in T)
-			if(term && term.dir == turn(d, 180) && !term.master)
-				terminals |= term
-				term.master = src
-				term.connect_to_network()
-	if(!terminals.len)
+	add_nearby_terminals()
+	if(!check_terminals())
 		stat |= BROKEN
 		return
 	update_icon()
@@ -90,6 +84,20 @@ GLOBAL_LIST_EMPTY(smeses)
 	terminals = null
 	GLOB.smeses -= src
 	return ..()
+
+/obj/machinery/power/smes/proc/add_nearby_terminals()
+	for(var/d in GLOB.cardinal)
+		var/turf/T = get_step(src, d)
+		for(var/obj/machinery/power/terminal/term in T)
+			if(term && term.dir == turn(d, 180) && !term.master)
+				terminals |= term
+				term.master = src
+				term.connect_to_network()
+
+/obj/machinery/power/smes/proc/check_terminals()
+	if(!terminals.len)
+		return FALSE
+	return TRUE
 
 /obj/machinery/power/smes/add_avail(var/amount)
 	if(..(amount))


### PR DESCRIPTION
If you build a battery rack without a terminal you can't open tgui, which might make sense for a SMES because a SMES without a terminal is totally pointless, as there's no way to put power into it (though it'd be cool if it gave a hint, anyway). But a battery rack has another way to put power into it, so setting BROKEN on battery racks is less sensible for lack of terminal.