### PR TITLE
Fixes #11102

### DIFF
--- a/code/modules/reagents/reagents/food_drinks.dm
+++ b/code/modules/reagents/reagents/food_drinks.dm
@@ -648,7 +648,7 @@
 /datum/reagent/frostoil/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	if(alien == IS_DIONA)
 		return
-	M.bodytemperature = max(M.bodytemperature - 10 * TEMPERATURE_DAMAGE_COEFFICIENT, 215)
+	M.bodytemperature = min(M.bodytemperature, max(M.bodytemperature - 10 * TEMPERATURE_DAMAGE_COEFFICIENT, 215))
 	if(prob(1))
 		M.emote("shiver")
 	holder.remove_reagent("capsaicin", 5)


### PR DESCRIPTION
B = bodytemp
Y = the value for bodytemp that frostoil wants (in reality it's B-10*1.5)
C = 215

`min(B, max(Y, C))` should allow bodytemp to be lower than what frostoil wants without letting frostoil do it

example Bs

300
min(300, max(300-15, 215))
min(300, 285) = 285

285
min(285, max(285-15, 215)) = 270
min(285, 270) = 270

210
min(210, max(210-15, 215))
min(210, 215) = 210

75
min(75, max(75-15, 215))
min(75, 215) = 75