### PR TITLE
Fix inventory oversights

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -60,6 +60,7 @@
 	for(var/organ in organs)
 		qdel(organ)
 	QDEL_NULL(nif)	//VOREStation Add
+	worn_clothing.Cut()
 	return ..()
 
 /mob/living/carbon/human/Stat()

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -193,6 +193,7 @@ This saves us from having to call add_fingerprint() any time something is put in
 		s_store = null
 		update_inv_s_store()
 	else if (W == back)
+		worn_clothing -= back
 		back = null
 		update_inv_back()
 	else if (W == handcuffed)
@@ -304,6 +305,7 @@ This saves us from having to call add_fingerprint() any time something is put in
 		if(slot_gloves)
 			src.gloves = W
 			W.equipped(src, slot)
+			worn_clothing += gloves
 			update_inv_gloves()
 		if(slot_head)
 			src.head = W


### PR DESCRIPTION
Backpacks don't GC because they're held in a list, due to lacking symmetry in the handling of this list with regards specifically to back (and I noticed gloves was asymmetric the other way as well).