### PR TITLE
Prevent synths from taking temp traits

### DIFF
--- a/code/modules/client/preference_setup/vore/07_traits.dm
+++ b/code/modules/client/preference_setup/vore/07_traits.dm
@@ -79,20 +79,33 @@
 		pref.pos_traits.Cut()
 		pref.neg_traits.Cut()
 	// Clean up positive traits
-	for(var/path in pref.pos_traits)
+	for(var/datum/trait/path as anything in pref.pos_traits)
 		if(!(path in positive_traits))
 			pref.pos_traits -= path
+			continue
+		var/take_flags = initial(path.can_take)
+		if((pref.dirty_synth && !(take_flags & SYNTHETICS)) || (pref.gross_meatbag && !(take_flags & ORGANICS)))
+			pref.pos_traits -= path
 	//Neutral traits
-	for(var/path in pref.neu_traits)
+	for(var/datum/trait/path as anything in pref.neu_traits)
 		if(!(path in neutral_traits))
 			pref.neu_traits -= path
+			continue
 		if(!(pref.species == SPECIES_CUSTOM) && !(path in everyone_traits))
 			pref.neu_traits -= path
+			continue
+		var/take_flags = initial(path.can_take)
+		if((pref.dirty_synth && !(take_flags & SYNTHETICS)) || (pref.gross_meatbag && !(take_flags & ORGANICS)))
+			pref.neu_traits -= path
 	//Negative traits
-	for(var/path in pref.neg_traits)
+	for(var/datum/trait/path as anything in pref.neg_traits)
 		if(!(path in negative_traits))
 			pref.neg_traits -= path
-
+			continue
+		var/take_flags = initial(path.can_take)
+		if((pref.dirty_synth && !(take_flags & SYNTHETICS)) || (pref.gross_meatbag && !(take_flags & ORGANICS)))
+			pref.neg_traits -= path
+	
 	var/datum/species/selected_species = GLOB.all_species[pref.species]
 	if(selected_species.selects_bodytype)
 		// Allowed!

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
@@ -26,6 +26,7 @@
 	desc = "You are able to withstand much colder temperatures than other species, and can even be comfortable in extremely cold environments. You are also more vulnerable to hot environments, and have a lower body temperature as a consequence of these adaptations."
 	cost = 0
 	var_changes = list("cold_level_1" = 200,  "cold_level_2" = 150, "cold_level_3" = 90, "breath_cold_level_1" = 180, "breath_cold_level_2" = 100, "breath_cold_level_3" = 60, "cold_discomfort_level" = 210, "heat_level_1" = 330, "heat_level_2" = 380, "heat_level_3" = 700, "breath_heat_level_1" = 360, "breath_heat_level_2" = 400, "breath_heat_level_3" = 850, "heat_discomfort_level" = 295, "body_temperature" = 290)
+	can_take = ORGANICS
 	excludes = list(/datum/trait/neutral/hotadapt)
 
 /datum/trait/neutral/hotadapt
@@ -33,6 +34,7 @@
 	desc = "You are able to withstand much hotter temperatures than other species, and can even be comfortable in extremely hot environments. You are also more vulnerable to cold environments, and have a higher body temperature as a consequence of these adaptations."
 	cost = 0
 	var_changes = list("heat_level_1" = 420, "heat_level_2" = 460, "heat_level_3" = 1100, "breath_heat_level_1" = 440, "breath_heat_level_2" = 510, "breath_heat_level_3" = 1500, "heat_discomfort_level" = 390, "cold_level_1" = 280, "cold_level_2" = 220, "cold_level_3" = 140, "breath_cold_level_1" = 260, "breath_cold_level_2" = 240, "breath_cold_level_3" = 120, "cold_discomfort_level" = 280, "body_temperature" = 330)
+	can_take = ORGANICS // negates the need for suit coolers entirely for synths, so no
 	excludes = list(/datum/trait/neutral/coldadapt)
 
 /datum/trait/neutral/autohiss_unathi

--- a/code/modules/mob/new_player/new_player_vr.dm
+++ b/code/modules/mob/new_player/new_player_vr.dm
@@ -43,7 +43,9 @@
 		var/list/megalist = client.prefs.pos_traits + client.prefs.neu_traits + client.prefs.neg_traits
 		var/points_left = client.prefs.starting_trait_points
 		var/traits_left = client.prefs.max_traits
-		for(var/T in megalist)
+		var/pref_synth = client.prefs.dirty_synth
+		var/pref_meat = client.prefs.gross_meatbag
+		for(var/datum/trait/T as anything in megalist)
 			var/cost = traits_costs[T]
 
 			if(cost)
@@ -56,6 +58,11 @@
 				break
 			else
 				points_left -= traits_costs[T]
+
+			var/take_flags = initial(T.can_take)
+			if((pref_synth && !(take_flags & SYNTHETICS)) || (pref_meat && !(take_flags & ORGANICS)))
+				pass = FALSE
+				to_chat(src, "<span class='warning'>Some of your traits are not usable by your character type (synthetic traits on organic, or vice versa).</span>")
 
 		//Went into negatives
 		if(points_left < 0 || traits_left < 0)


### PR DESCRIPTION
Hot adaptation functions as an ad hoc 'I'm immune to space hooray' trait for synths which is not ideal. Ideally it'd be neat to have these specifically not affect that aspect of synths but that requires more work than I'm willing to try and figure out.