### PR TITLE
Finishes purge of Industrial Expansion

### DIFF
--- a/code/game/objects/random/mapping.dm
+++ b/code/game/objects/random/mapping.dm
@@ -464,7 +464,7 @@
 
 /obj/random/multiple/ore_pile/item_to_spawn()
 	return pick(
-			prob(10);list(
+			/*prob(10);list(
 				/obj/item/weapon/ore/bauxite,
 				/obj/item/weapon/ore/bauxite,
 				/obj/item/weapon/ore/bauxite,
@@ -475,7 +475,7 @@
 				/obj/item/weapon/ore/bauxite,
 				/obj/item/weapon/ore/bauxite,
 				/obj/item/weapon/ore/bauxite
-			),
+			),*/
 			prob(10);list(
 				/obj/item/weapon/ore/coal,
 				/obj/item/weapon/ore/coal,
@@ -488,7 +488,7 @@
 				/obj/item/weapon/ore/coal,
 				/obj/item/weapon/ore/coal
 			),
-			prob(10);list(
+			/*prob(10);list(
 				/obj/item/weapon/ore/copper,
 				/obj/item/weapon/ore/copper,
 				/obj/item/weapon/ore/copper,
@@ -499,7 +499,7 @@
 				/obj/item/weapon/ore/copper,
 				/obj/item/weapon/ore/copper,
 				/obj/item/weapon/ore/copper
-			),
+			),*/
 			prob(3);list(
 				/obj/item/weapon/ore/diamond,
 				/obj/item/weapon/ore/diamond,
@@ -598,11 +598,11 @@
 			prob(2);list(
 				/obj/item/weapon/ore/verdantium,
 				/obj/item/weapon/ore/verdantium
-			),
+			),/*
 			prob(2);list(
 				/obj/item/weapon/ore/void_opal,
 				/obj/item/weapon/ore/void_opal
-			),
+			),*/
 		)
 
 /obj/random/multiple/corp_crate

--- a/code/modules/mining/alloys.dm
+++ b/code/modules/mining/alloys.dm
@@ -44,7 +44,7 @@
 		"sand" = 2
 		)
 	product = /obj/item/stack/material/glass/phoronglass
-
+/*
 /datum/alloy/bronze
 	metaltag = "bronze"
 	requires = list(
@@ -52,3 +52,4 @@
 		"tin" = 1
 		)
 	product = /obj/item/stack/material/bronze
+*/

--- a/code/modules/mining/drilling/drill.dm
+++ b/code/modules/mining/drilling/drill.dm
@@ -28,9 +28,9 @@
 		"hydrogen" = /obj/item/weapon/ore/hydrogen,
 		"silicates" = /obj/item/weapon/ore/glass,
 		"carbon" = /obj/item/weapon/ore/coal,
-		"copper" = /obj/item/weapon/ore/copper,
+	//	"copper" = /obj/item/weapon/ore/copper,
 	//	"tin" = /obj/item/weapon/ore/tin,
-		"bauxite" = /obj/item/weapon/ore/bauxite,
+	//	"bauxite" = /obj/item/weapon/ore/bauxite,
 		"rutile" = /obj/item/weapon/ore/rutile
 		)
 
@@ -44,14 +44,14 @@
 	// Found with an advanced laser. exotic_drilling >= 1
 	var/list/ore_types_uncommon = list(
 		MAT_MARBLE = /obj/item/weapon/ore/marble,
-		"painite" = /obj/item/weapon/ore/painite,
-		"quartz" = /obj/item/weapon/ore/quartz,
+		//"painite" = /obj/item/weapon/ore/painite,
+		//"quartz" = /obj/item/weapon/ore/quartz,
 		MAT_LEAD = /obj/item/weapon/ore/lead
 		)
 
 	// Found with an ultra laser. exotic_drilling >= 2
 	var/list/ore_types_rare = list(
-		"void opal" = /obj/item/weapon/ore/void_opal,
+		//"void opal" = /obj/item/weapon/ore/void_opal,
 		MAT_VERDANTIUM = /obj/item/weapon/ore/verdantium
 		)
 

--- a/code/modules/mining/drilling/scanner.dm
+++ b/code/modules/mining/drilling/scanner.dm
@@ -41,13 +41,13 @@
 			var/ore_type
 
 			switch(metal)
-				if("silicates", "carbon", "marble", "quartz")	ore_type = "surface minerals"
-				if("hematite", "tin", "copper", "bauxite", "lead")	ore_type = "industrial metals"
+				if("silicates", "carbon", "marble", /*"quartz"*/)	ore_type = "surface minerals"
+				if("hematite", /*"tin", "copper", "bauxite",*/ "lead")	ore_type = "industrial metals"
 				if("gold", "silver", "rutile")					ore_type = "precious metals"
-				if("diamond", "painite")	ore_type = "precious gems"
+				if("diamond", /*"painite"*/)	ore_type = "precious gems"
 				if("uranium")									ore_type = "nuclear fuel"
 				if("phoron", "osmium", "hydrogen")				ore_type = "exotic matter"
-				if("verdantium", "void opal")				ore_type = "anomalous matter"
+				if("verdantium", /*"void opal"*/)				ore_type = "anomalous matter"
 
 			if(ore_type) metals[ore_type] += T.resources[metal]
 

--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -54,9 +54,9 @@ var/list/mining_overlay_cache = list()
 		"verdantium" = /obj/item/weapon/ore/verdantium,
 		"marble" = /obj/item/weapon/ore/marble,
 		"lead" = /obj/item/weapon/ore/lead,
-		"copper" = /obj/item/weapon/ore/copper,
+//		"copper" = /obj/item/weapon/ore/copper,
 //		"tin" = /obj/item/weapon/ore/tin,
-		"bauxite" = /obj/item/weapon/ore/bauxite,
+//		"bauxite" = /obj/item/weapon/ore/bauxite,
 //		"void opal" = /obj/item/weapon/ore/void_opal,
 //		"painite" = /obj/item/weapon/ore/painite,
 //		"quartz" = /obj/item/weapon/ore/quartz,
@@ -680,10 +680,10 @@ var/list/mining_overlay_cache = list()
 
 	var/mineral_name
 	if(rare_ore)
-		mineral_name = pickweight(list("marble" = 5,/* "quartz" = 15,*/ "copper" = 10, /*"tin" = 5,*/ "bauxite" = 5, "uranium" = 15, "platinum" = 20, "hematite" = 15, "rutile" = 20, "carbon" = 15, "diamond" = 3, "gold" = 15, "silver" = 15, "phoron" = 25, "lead" = 5,/* "void opal" = 1,*/ "verdantium" = 2/*, "painite" = 1*/))
+		mineral_name = pickweight(list("marble" = 5,/* "quartz" = 15, "copper" = 10, "tin" = 5, "bauxite" = 5*/, "uranium" = 15, "platinum" = 20, "hematite" = 15, "rutile" = 20, "carbon" = 15, "diamond" = 3, "gold" = 15, "silver" = 15, "phoron" = 25, "lead" = 5,/* "void opal" = 1,*/ "verdantium" = 2/*, "painite" = 1*/))
 
 	else
-		mineral_name = pickweight(list("marble" = 3,/* "quartz" = 10,*/ "copper" = 20, /*"tin" = 15,*/ "bauxite" = 15, "uranium" = 10, "platinum" = 10, "hematite" = 70, "rutile" = 15, "carbon" = 70, "diamond" = 2, "gold" = 10, "silver" = 10, "phoron" = 20, "lead" = 3,/* "void opal" = 1,*/ "verdantium" = 1/*, "painite" = 1*/))
+		mineral_name = pickweight(list("marble" = 3,/* "quartz" = 10, "copper" = 20, "tin" = 15, "bauxite" = 15*/, "uranium" = 10, "platinum" = 10, "hematite" = 70, "rutile" = 15, "carbon" = 70, "diamond" = 2, "gold" = 10, "silver" = 10, "phoron" = 20, "lead" = 3,/* "void opal" = 1,*/ "verdantium" = 1/*, "painite" = 1*/))
 
 	if(mineral_name && (mineral_name in GLOB.ore_data))
 		mineral = GLOB.ore_data[mineral_name]

--- a/code/modules/mining/ore.dm
+++ b/code/modules/mining/ore.dm
@@ -106,7 +106,7 @@
 	icon_state = "ore_lead"
 	material = MAT_LEAD
 	origin_tech = list(TECH_MATERIAL = 3)
-
+/*
 /obj/item/weapon/ore/copper
 	name = "raw copper"
 	icon_state = "ore_copper"
@@ -121,12 +121,12 @@
 	name = "raw bauxite"
 	icon_state = "ore_bauxite"
 	material = "bauxite"
-
+*/
 /obj/item/weapon/ore/rutile
 	name = "raw rutile"
 	icon_state = "ore_rutile"
 	material = "rutile"
-
+/*
 /obj/item/weapon/ore/void_opal
 	name = "raw void opal"
 	icon_state = "ore_void_opal"
@@ -141,7 +141,7 @@
 	name = "raw quartz"
 	icon_state = "ore_quartz"
 	material = "quartz"
-
+*/
 /obj/item/weapon/ore/slag
 	name = "Slag"
 	desc = "Someone screwed up..."

--- a/code/modules/mining/ore_datum.dm
+++ b/code/modules/mining/ore_datum.dm
@@ -175,7 +175,7 @@
 	ore = /obj/item/weapon/ore/lead
 	scan_icon = "mineral_rare"
 	reagent = "lead"
-
+/*
 /ore/copper
 	name = "copper"
 	display_name = "copper"
@@ -215,7 +215,7 @@
 	ore = /obj/item/weapon/ore/bauxite
 	scan_icon = "mineral_common"
 	reagent = "aluminum"
-
+*/
 /ore/rutile
 	name = "rutile"
 	display_name = "rutile"
@@ -225,7 +225,7 @@
 	alloy = 1
 	ore = /obj/item/weapon/ore/rutile
 	scan_icon = "mineral_uncommon"
-
+/*
 /ore/painite
 	name = "painite"
 	display_name = "rough painite"
@@ -243,3 +243,4 @@
 	spread_chance = 1
 	ore = /obj/item/weapon/ore/void_opal
 	scan_icon = "mineral_rare"
+*/

--- a/code/modules/random_map/noise/ore.dm
+++ b/code/modules/random_map/noise/ore.dm
@@ -64,13 +64,13 @@
 				T.resources["hydrogen"] = 0
 				T.resources["verdantium"] = 0
 				T.resources["lead"]     = 0
-				T.resources["copper"] =   rand(RESOURCE_MID_MIN, RESOURCE_HIGH_MAX)
-				T.resources["tin"] =      rand(RESOURCE_LOW_MIN, RESOURCE_MID_MAX)
-				T.resources["bauxite"] =  rand(RESOURCE_LOW_MIN, RESOURCE_LOW_MAX)
+				//T.resources["copper"] =   rand(RESOURCE_MID_MIN, RESOURCE_HIGH_MAX)
+				//T.resources["tin"] =      rand(RESOURCE_LOW_MIN, RESOURCE_MID_MAX)
+				//T.resources["bauxite"] =  rand(RESOURCE_LOW_MIN, RESOURCE_LOW_MAX)
 				T.resources["rutile"] =   0
-				T.resources["void opal"] = 0
-				T.resources["quartz"] = 0
-				T.resources["painite"] = 0
+				//T.resources["void opal"] = 0
+				//T.resources["quartz"] = 0
+				//T.resources["painite"] = 0
 			else if(current_cell < deep_val) // Rare metals.
 				T.resources["gold"] =     rand(RESOURCE_MID_MIN,  RESOURCE_MID_MAX)
 				T.resources["silver"] =   rand(RESOURCE_MID_MIN,  RESOURCE_MID_MAX)
@@ -83,13 +83,13 @@
 				T.resources["diamond"] =  0
 				T.resources["hematite"] = 0
 				T.resources["marble"] =   0
-				T.resources["copper"] =   0
-				T.resources["tin"] =      rand(RESOURCE_MID_MIN, RESOURCE_MID_MAX)
-				T.resources["bauxite"] =  0
+				//T.resources["copper"] =   0
+				//T.resources["tin"] =      rand(RESOURCE_MID_MIN, RESOURCE_MID_MAX)
+				//T.resources["bauxite"] =  0
 				T.resources["rutile"] =   rand(RESOURCE_LOW_MIN, RESOURCE_MID_MAX)
-				T.resources["void opal"] = 0
-				T.resources["quartz"] = 0
-				T.resources["painite"] = 0
+				//T.resources["void opal"] = 0
+				//T.resources["quartz"] = 0
+				//T.resources["painite"] = 0
 			else                             // Deep metals.
 				T.resources["uranium"] =  rand(RESOURCE_LOW_MIN,  RESOURCE_LOW_MAX)
 				T.resources["diamond"] =  rand(RESOURCE_LOW_MIN,  RESOURCE_LOW_MAX)
@@ -102,13 +102,13 @@
 				T.resources["hematite"] = 0
 				T.resources["gold"] =     0
 				T.resources["silver"] =   0
-				T.resources["copper"] =   0
-				T.resources["tin"] =      0
-				T.resources["bauxite"] =  0
+				//T.resources["copper"] =   0
+				//T.resources["tin"] =      0
+				//T.resources["bauxite"] =  0
 				T.resources["rutile"] =   rand(RESOURCE_MID_MIN, RESOURCE_HIGH_MAX)
-				T.resources["void opal"] = 0
-				T.resources["quartz"] = 0
-				T.resources["painite"] = 0
+				//T.resources["void opal"] = 0
+				//T.resources["quartz"] = 0
+				//T.resources["painite"] = 0
 	return
 
 /datum/random_map/noise/ore/get_map_char(var/value)

--- a/maps/expedition_vr/aerostat/_aerostat.dm
+++ b/maps/expedition_vr/aerostat/_aerostat.dm
@@ -135,7 +135,7 @@ VIRGO2_TURF_CREATE(/turf/simulated/mineral)
 	if(mineral)
 		return
 
-	var/mineral_name = pickweight(list("marble" = 5, "uranium" = 5, "platinum" = 5, "hematite" = 5, "carbon" = 5, "diamond" = 5, "gold" = 5, "silver" = 5, "lead" = 5, "verdantium" = 5, "rutile" = 10, "copper" = 5, "tin" = 5, "bauxite" = 5))
+	var/mineral_name = pickweight(list("marble" = 5, "uranium" = 5, "platinum" = 5, "hematite" = 5, "carbon" = 5, "diamond" = 5, "gold" = 5, "silver" = 5, "lead" = 5, "verdantium" = 5, "rutile" = 20))
 
 	if(mineral_name && (mineral_name in GLOB.ore_data))
 		mineral = GLOB.ore_data[mineral_name]
@@ -213,4 +213,3 @@ VIRGO2_TURF_CREATE(/turf/simulated/floor/hull)
 	name = "V4 Outpost - Power Room"
 /area/tether_away/aerostat/surface/outpost/guardpost
 	name = "V4 Outpost - Guard Post"
-	

--- a/maps/tether/tether_turfs.dm
+++ b/maps/tether/tether_turfs.dm
@@ -69,10 +69,6 @@ VIRGO3B_TURF_CREATE(/turf/simulated/mineral/floor)
 			"uranium" = 10,
 			"platinum" = 10,
 			"hematite" = 20,
-			"copper" = 8,
-//			"tin" = 4,
-			"bauxite" = 4,
-			"rutile" = 4,
 			"carbon" = 20,
 			"diamond" = 1,
 			"gold" = 8,
@@ -86,10 +82,6 @@ VIRGO3B_TURF_CREATE(/turf/simulated/mineral/floor)
 			"uranium" = 5,
 			"platinum" = 5,
 			"hematite" = 35,
-			"copper" = 15,
-//			"tin" = 10,
-			"bauxite" = 10,
-			"rutile" = 10,
 			"carbon" = 35,
 			"gold" = 3,
 			"silver" = 3,
@@ -272,7 +264,7 @@ VIRGO3B_TURF_CREATE(/turf/simulated/mineral/floor)
 				new_junction |= (1<<5)
 
 	icon_state = "[base_icon_state]-[new_junction]"
-	
+
 	add_vis_overlay('icons/effects/effects.dmi', "white", plane = SPACE_PLANE, add_vis_flags = VIS_INHERIT_ID|VIS_UNDERLAY)
 
 /turf/space/v3b_midpoint/Initialize()
@@ -283,4 +275,3 @@ VIRGO3B_TURF_CREATE(/turf/simulated/mineral/floor)
 	. = ..()
 	for(var/obj/effect/step_trigger/teleporter/planetary_fall/virgo3b/F in src)
 		qdel(F)
-		


### PR DESCRIPTION
Removes all remnants of ores added in industrial expansion. Materials originally produced from ores still exist and are still spawnable, only the ores themselves are gone.

Supposedly, despite uselessness, ores were kept to 'make people come up with use for them that is actually original', but that is doubtfully happening at this point.

Also Rutile is back to being an expedition area exclusive, as it was meant to be prior to that update.