### PR TITLE
Add art possibility to Virgo 2 surface outpost

### DIFF
--- a/code/game/objects/structures/artstuff.dm
+++ b/code/game/objects/structures/artstuff.dm
@@ -375,6 +375,12 @@
 	persistence_id = "library_private"
 	req_one_access = list(access_library)
 
+/obj/structure/sign/painting/away_areas // for very hard-to-get-to areas
+	name = "\improper Remote Painting Exhibit mounting"
+	desc = "For art pieces made in the depths of space."
+	desc_with_canvas = "A painting hung where only the determined can reach it."
+	persistence_id = "away_area"
+
 /obj/structure/sign/painting/Initialize(mapload, dir, building)
 	. = ..()
 	if(persistence_id)

--- a/maps/expedition_vr/aerostat/surface.dmm
+++ b/maps/expedition_vr/aerostat/surface.dmm
@@ -421,6 +421,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/eris/dark,
 /area/tether_away/aerostat/surface/outpost/cafe)
+"nx" = (
+/obj/structure/sign/painting/away_areas{
+	pixel_x = -32
+	},
+/turf/simulated/floor/tiled/eris/bcircuit,
+/area/tether_away/aerostat/surface/outpost/hallway)
 "nI" = (
 /obj/structure/cable/cyan{
 	icon_state = "1-2"
@@ -550,6 +556,13 @@
 	},
 /turf/simulated/floor/plating/eris/under,
 /area/tether_away/aerostat/surface/outpost/powerroom)
+"ru" = (
+/obj/structure/table/woodentable,
+/obj/structure/sign/painting/away_areas{
+	pixel_x = 32
+	},
+/turf/simulated/floor/tiled/eris/dark,
+/area/tether_away/aerostat/surface/outpost/cafe)
 "rA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -1116,6 +1129,13 @@
 /obj/structure/medical_stand/anesthetic,
 /turf/simulated/floor/tiled/eris/bcircuit,
 /area/tether_away/aerostat/surface/outpost/backroom)
+"GH" = (
+/obj/structure/table/woodentable,
+/obj/structure/sign/painting/away_areas{
+	pixel_x = 32
+	},
+/turf/simulated/floor/wood,
+/area/tether_away/aerostat/surface/outpost/barracks)
 "Ha" = (
 /obj/structure/cable/cyan{
 	icon_state = "1-2"
@@ -1402,6 +1422,8 @@
 "ON" = (
 /obj/structure/table/rack/shelf/steel,
 /obj/item/weapon/storage/box/glasses,
+/obj/item/paint_brush,
+/obj/item/paint_palette,
 /turf/simulated/floor/tiled/eris/dark/monofloor,
 /area/tether_away/aerostat/surface/outpost/cafe)
 "OT" = (
@@ -1550,6 +1572,8 @@
 "Ur" = (
 /obj/structure/table/rack/shelf/steel,
 /obj/item/weapon/storage/box/glasses/pint,
+/obj/item/canvas/twentyfour_twentyfour,
+/obj/item/canvas/nineteen_nineteen,
 /turf/simulated/floor/tiled/eris/dark/monofloor,
 /area/tether_away/aerostat/surface/outpost/cafe)
 "UC" = (
@@ -2602,9 +2626,9 @@ Ge
 QJ
 Zb
 br
-zN
-zN
-zN
+nx
+nx
+nx
 br
 zN
 dE
@@ -5308,9 +5332,9 @@ gq
 dE
 zr
 WC
+ru
 Ra
-Ra
-Ra
+ru
 iu
 WF
 Oi
@@ -6301,7 +6325,7 @@ Rw
 Bs
 sA
 nK
-nK
+GH
 tG
 gx
 gx


### PR DESCRIPTION
Adds painting frames there with a persistence pool that only shows up in hard-to-reach areas. There's some canvases and paint in the closet in the dining area.