### PR TITLE
Quick migration hot-fix

### DIFF
--- a/code/modules/events/infestation.dm
+++ b/code/modules/events/infestation.dm
@@ -23,7 +23,7 @@
 
 /datum/event/infestation/start()
 
-	location = rand(0,10)
+	location = rand(0,9)
 	var/list/turf/simulated/floor/turfs = list()
 	var/spawn_area_type
 	switch(location)


### PR DESCRIPTION
Funny location was set to 10 and not 9 from earlier removal of broken location. 