### PR TITLE
Fixes #11223

### DIFF
--- a/code/modules/overmap/sectors.dm
+++ b/code/modules/overmap/sectors.dm
@@ -35,6 +35,7 @@
 
 	var/has_distress_beacon
 	var/list/levels_for_distress
+	var/list/unowned_areas // areas we don't own despite them being present on our z
 
 /obj/effect/overmap/visitable/Initialize()
 	. = ..()
@@ -137,7 +138,12 @@
 
 //Helper for init.
 /obj/effect/overmap/visitable/proc/check_ownership(obj/object)
-	if((get_z(object) in map_z) && !(get_area(object) in SSshuttles.shuttle_areas))
+	var/area/A = get_area(object)
+	if(A in SSshuttles.shuttle_areas)
+		return 0
+	if(is_type_in_list(A, unowned_areas))
+		return 0	
+	if(get_z(object) in map_z)
 		return 1
 
 //If shuttle_name is false, will add to generic waypoints; otherwise will add to restricted. Does not do checks.

--- a/maps/offmap_vr/om_ships/mercship.dm
+++ b/maps/offmap_vr/om_ships/mercship.dm
@@ -75,6 +75,7 @@
 	initial_generic_waypoints = list("carrier_fore", "carrier_aft", "carrier_port", "carrier_starboard", "base_dock")
 	initial_restricted_waypoints = list("Carrier's Ship's Boat" = list("omship_spawn_mercboat"))
 
+	unowned_areas = list(/area/shuttle/mercboat)
 
 //The boat's area
 /area/shuttle/mercboat

--- a/maps/offmap_vr/talon/talon_v2.dm
+++ b/maps/offmap_vr/talon/talon_v2.dm
@@ -55,6 +55,7 @@ var/global/list/latejoin_talon = list()
 	skybox_pixel_y = 60
 
 	levels_for_distress = list(1, Z_LEVEL_BEACH, Z_LEVEL_AEROSTAT, Z_LEVEL_DEBRISFIELD, Z_LEVEL_FUELDEPOT)
+	unowned_areas = list(/area/shuttle/talonboat)
 
 // The shuttle's 'shuttle' computer
 /obj/machinery/computer/shuttle_control/explore/talonboat


### PR DESCRIPTION
Allows you to specify `list/unowned_areas` on sectors, for areas that they shouldn't consider themselves as owning for the purpose of claiming consoles, engines, etc.