### PR TITLE
Attempt to further fix missing languages

### DIFF
--- a/code/controllers/subsystems/character_setup.dm
+++ b/code/controllers/subsystems/character_setup.dm
@@ -28,7 +28,10 @@ SUBSYSTEM_DEF(character_setup)
 		var/datum/preferences/prefs = save_queue[save_queue.len]
 		save_queue.len--
 
-		if(!QDELETED(prefs))
+		// Can't save prefs without client, because the sanitize functions will be
+		// unable to validate their whitelist status due to being unable to check
+		// 'holder' admin status, etc. Will result in Bad Times.
+		if(!QDELETED(prefs) && prefs.client)
 			prefs.save_preferences()
 
 		if(MC_TICK_CHECK)


### PR DESCRIPTION
If you connect, and then click the view updates/server news button then close the client within 1 second (or longer, if it's during init or very very laggy), or toggle certain other things and then quickly close the client/crash/lag out (including most 'ghost' verbs like 'ghost ears' toggle), your client prefs will be queued for saving but your client will be gone by the time the saving happens because the subsystem waits 1 second between each run, and then the whitelist/sani checks will fail because it will have nothing to check, passing a null client into whitelist checks and failing them for languages.