### PR TITLE
Gas visuals use vis_contents not overlays

### DIFF
--- a/code/ZAS/Turf.dm
+++ b/code/ZAS/Turf.dm
@@ -6,9 +6,9 @@
 
 /turf/simulated/proc/update_graphic(list/graphic_add = null, list/graphic_remove = null)
 	if(LAZYLEN(graphic_add))
-		add_overlay(graphic_add, priority = TRUE)
+		vis_contents |= graphic_add
 	if(LAZYLEN(graphic_remove))
-		cut_overlay(graphic_remove, priority = TRUE)
+		vis_contents -= graphic_remove
 
 /turf/proc/update_air_properties()
 	var/block = c_airblock(src)

--- a/code/modules/admin/verbs/grief_fixers.dm
+++ b/code/modules/admin/verbs/grief_fixers.dm
@@ -40,7 +40,7 @@
 
 	for(var/turf/simulated/T in world)
 		T.air = null
-		T.overlays.Remove(unsorted_overlays)
+		T.vis_contents.Remove(unsorted_overlays)
 		T.zone = null
 
 	to_chat(usr, "\[4/5\] - All turfs reset to roundstart values.")

--- a/code/modules/xgm/xgm_gas_data.dm
+++ b/code/modules/xgm/xgm_gas_data.dm
@@ -39,8 +39,18 @@
 		gas_data.name[gas.id] = gas.name
 		gas_data.specific_heat[gas.id] = gas.specific_heat
 		gas_data.molar_mass[gas.id] = gas.molar_mass
-		if(gas.tile_overlay) gas_data.tile_overlay[gas.id] = image('icons/effects/tile_effects.dmi', gas.tile_overlay, FLY_LAYER)
-		if(gas.overlay_limit) gas_data.overlay_limit[gas.id] = gas.overlay_limit
+		if(gas.tile_overlay)
+			gas_data.tile_overlay[gas.id] = new /atom/movable/gas_visuals(null, gas.tile_overlay)
+		if(gas.overlay_limit)	
+			gas_data.overlay_limit[gas.id] = gas.overlay_limit
 		gas_data.flags[gas.id] = gas.flags
 
 	return 1
+
+/atom/movable/gas_visuals
+	icon = 'icons/effects/tile_effects.dmi'
+	mouse_opacity = 0
+	plane = ABOVE_MOB_PLANE
+/atom/movable/gas_visuals/New(newloc, ico)
+	..()
+	icon_state = ico


### PR DESCRIPTION
Also properly puts them above everything instead of under floor equipment like they are currently.