### PR TITLE
Tables behave better for flipping purposes

### DIFF
--- a/code/ZAS/Atom.dm
+++ b/code/ZAS/Atom.dm
@@ -30,12 +30,6 @@
 		else
 			CRASH("Invalid can_atmos_pass = [can_atmos_pass] on [src] ([type])")
 
-/turf/CanPass(atom/movable/mover, turf/target)
-	if(!target) return FALSE
-
-	if(istype(mover)) // turf/Enter(...) will perform more advanced checks
-		return !density
-
 /turf/CanZASPass(turf/T, is_zone)
 	if(T.blocks_air || src.blocks_air)
 		return FALSE

--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -89,7 +89,9 @@
 /obj/structure/proc/turf_is_crowded()
 	var/turf/T = get_turf(src)
 	if(!T || !istype(T))
-		return 0
+		return "empty void"
+	if(T.density)
+		return T
 	for(var/obj/O in T.contents)
 		if(istype(O,/obj/structure))
 			var/obj/structure/S = O
@@ -113,11 +115,14 @@
 		LAZYREMOVE(climbers, user)
 		return
 
-	usr.forceMove(get_turf(src))
+	usr.forceMove(climb_to(user))
 
 	if (get_turf(user) == get_turf(src))
 		usr.visible_message("<span class='warning'>[user] climbs onto \the [src]!</span>")
 	LAZYREMOVE(climbers, user)
+
+/obj/structure/proc/climb_to(var/mob/living/user)
+	return get_turf(src)
 
 /obj/structure/proc/structure_shaken()
 	for(var/mob/living/M in climbers)

--- a/code/modules/tables/flipping.dm
+++ b/code/modules/tables/flipping.dm
@@ -86,7 +86,7 @@
 	if(dir != NORTH)
 		plane = MOB_PLANE
 		layer = ABOVE_MOB_LAYER
-	climbable = FALSE //flipping tables allows them to be used as makeshift barriers
+	//climbable = FALSE //flipping tables allows them to be used as makeshift barriers
 	flipped = 1
 	flags |= ON_BORDER
 	for(var/D in list(turn(direction, 90), turn(direction, -90)))
@@ -105,7 +105,7 @@
 
 	reset_plane_and_layer()
 	flipped = 0
-	climbable = initial(climbable)
+	//climbable = initial(climbable)
 	flags &= ~ON_BORDER
 	for(var/D in list(turn(dir, 90), turn(dir, -90)))
 		var/obj/structure/table/T = locate() in get_step(src.loc,D)

--- a/code/modules/tables/interactions.dm
+++ b/code/modules/tables/interactions.dm
@@ -1,11 +1,15 @@
 /obj/structure/table/CanPass(atom/movable/mover, turf/target)
 	if(istype(mover,/obj/item/projectile))
 		return (check_cover(mover,target))
-	if (flipped == 1)
-		if (get_dir(loc, target) == dir)
+	if (flipped)
+		var/move_dir = get_dir(mover, target)
+		// Moving from back to front, gotta climb
+		if(move_dir == dir && target != loc)
 			return !density
-		else
-			return TRUE
+		// Moving from front to back, gotta climb
+		if(move_dir == reverse_dir[dir])
+			return !density
+		return TRUE
 	if(istype(mover) && mover.checkpass(PASSTABLE))
 		return TRUE
 	if(locate(/obj/structure/table/bench) in get_turf(mover))
@@ -14,6 +18,14 @@
 	if(table && !table.flipped)
 		return TRUE
 	return FALSE
+
+/obj/structure/table/climb_to(mob/living/mover)
+	if(flipped && mover.loc == loc)
+		var/turf/T = get_step(src, dir)
+		if(T.Enter(mover))
+			return T
+
+	return ..()
 
 //checks if projectile 'P' from turf 'from' can hit whatever is behind the table. Returns 1 if it can, 0 if bullet stops.
 /obj/structure/table/proc/check_cover(obj/item/projectile/P, turf/from)


### PR DESCRIPTION
Because someone @ResidentCody keeps nagging @ResidentCody about it!

Can't cross tables to/from the flipped surface side, but you can climb over with the normal timer.