### PR TITLE
RIP older versions of byond

### DIFF
--- a/code/__defines/__outdated_compatibility.dm
+++ b/code/__defines/__outdated_compatibility.dm
@@ -1,0 +1,8 @@
+//Update this whenever you need to take advantage of more recent byond features
+#define MIN_COMPILER_VERSION 514
+#define MIN_COMPILER_BUILD 1556
+#if (DM_VERSION < MIN_COMPILER_VERSION || DM_BUILD < MIN_COMPILER_BUILD) && !defined(SPACEMAN_DMM)
+//Don't forget to update this part
+#error Your version of BYOND is too out-of-date to compile this project. Go to https://secure.byond.com/download and update.
+#error You need version 514.1556 or higher
+#endif

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -24,6 +24,7 @@
 #include "code\world.dm"
 #include "code\__datastructures\globals.dm"
 #include "code\__defines\__513_compatibility.dm"
+#include "code\__defines\__outdated_compatibility.dm"
 #include "code\__defines\_compile_options.dm"
 #include "code\__defines\_lists.dm"
 #include "code\__defines\_planes+layers.dm"


### PR DESCRIPTION
Error out and print messages indicating you need to update if you compile with byond earlier than 514.1556.