### PR TITLE
Fixes dropnoms

### DIFF
--- a/code/modules/multiz/movement.dm
+++ b/code/modules/multiz/movement.dm
@@ -319,6 +319,8 @@
 			return FALSE
 	// See if something in turf below prevents us from falling into it.
 	for(var/atom/A in landing)
+		if(ismob(A))
+			continue
 		if(!A.CanPass(src, src.loc, 1, 0))
 			return FALSE
 	return TRUE


### PR DESCRIPTION
CanPass checks for density var, which is enabled for nearly all mobs by default.