### PR TITLE
Warn before overwriting vore prefs as simple mobs

### DIFF
--- a/code/modules/vore/eating/vorepanel_vr.dm
+++ b/code/modules/vore/eating/vorepanel_vr.dm
@@ -302,6 +302,10 @@
 			return set_attr(usr, params)
 
 		if("saveprefs")
+			if(!ishuman(host) && !issilicon(host))
+				var/choice = tgui_alert(usr, "Warning: Saving your vore panel while playing what is very-likely not your normal character will overwrite whatever character you have loaded in character setup. Maybe this is your 'playing a simple mob' slot, though. Are you SURE you want to overwrite your current slot with these vore bellies?", "WARNING!", list("No, abort!", "Yes, save."))
+				if(choice != "Yes, save.")
+					return TRUE
 			if(!host.save_vore_prefs())
 				tgui_alert_async(usr, "ERROR: Virgo-specific preferences failed to save!","Error")
 			else


### PR DESCRIPTION
If you attempt to save your vore prefs while playing anything other than a human or a silicon, you get this message:

![7wlbZI80cS](https://user-images.githubusercontent.com/15028025/127757823-21550056-12d0-429f-8285-8031c1ef9598.png)

Should hopefully help prevent people wiping their bellies while playing a morph or something with another character slot loaded.