### PR TITLE
Update vore space prot test

### DIFF
--- a/code/unit_tests/vore_tests_vr.dm
+++ b/code/unit_tests/vore_tests_vr.dm
@@ -91,9 +91,20 @@
 			fail("[pred.vore_selected].nom_mob([prey]) did not put prey inside [pred]")
 			return 1
 		else
-			var/turf/T = locate(/turf/space)
+			// Get an empty space level instead of just picking a random space turf
+			var/empty_z = using_map.get_empty_zlevel()
+			if(!empty_z)
+				fail("Unable to get empty z-level for vore space protection test!")
+				return 1
+
+			// Away from map edges so they don't transit while we're testing
+			var/mid_w = round(world.maxx*0.5)
+			var/mid_h = round(world.maxy*0.5)
+
+			var/turf/T = locate(mid_w, mid_h, empty_z)
+
 			if(!T)
-				fail("could not find a space turf for testing")
+				fail("Unable to get turf for vore space protection test!")
 				return 1
 			else
 				pred.forceMove(T)


### PR DESCRIPTION
This is like the suffocation test, but will never trigger that bug because it spawns the pred elsewhere, then moves them to a space turf. The problem with the other one was new'ing the human on the turf with the fall trigger, which meant they would fall before having a species (because they were still in the middle of their own New). In this one, that won't ever happen.

BUT, for the sake of consistency, let's just update this one too for fun.