### PR TITLE
Cortical Borers - +100 points to Steath Attributes

### DIFF
--- a/code/game/antagonist/alien/borer.dm
+++ b/code/game/antagonist/alien/borer.dm
@@ -20,10 +20,10 @@ var/datum/antagonist/borer/borers
 	initial_spawn_req = 3
 	initial_spawn_target = 5
 
-	spawn_announcement = "Unidentified lifesigns detected coming aboard the station. Secure any exterior access, including ducting and ventilation."
-	spawn_announcement_title = "Lifesign Alert"
-	spawn_announcement_sound = 'sound/AI/aliens.ogg'
-	spawn_announcement_delay = 5000
+	//spawn_announcement = "Unidentified lifesigns detected coming aboard the station. Secure any exterior access, including ducting and ventilation."
+	//spawn_announcement_title = "Lifesign Alert"
+	//spawn_announcement_sound = 'sound/AI/aliens.ogg'
+	//spawn_announcement_delay = 5000
 
 /datum/antagonist/borer/New()
 	..(1)


### PR DESCRIPTION
In the exceedingly rare instance somebody wants to play a brain sluggo, they are afforded five minutes before their presence is rudely announced with a very loud and public:

`"Unidentified lifesigns detected coming aboard the station. Secure any exterior access, including ducting and ventilation."`

This announcement is also what sounds out when there are giant spiders, and when no said spiders are found the meta-knowledge kicks in and everyone starts shouting about how people should watch out for cortical borers immediately.

This is understandably a huge mood killer and makes it super awkward to even be around. So! This PR comments out the four lines pertaining to "spawn_announcement" and consequently makes it so that the entire universe is not informed when a single borer is spawned for a single scene.