### PR TITLE
Phoron Bore - Adds Hefty Recoil When Firing

### DIFF
--- a/code/modules/projectiles/guns/magnetic/bore.dm
+++ b/code/modules/projectiles/guns/magnetic/bore.dm
@@ -82,7 +82,7 @@
 		return "<span class='notice'>It has [mat_storage] out of [max_mat_storage] units of [ammo_material] loaded.</span>"
 	else
 		return "<span class='warning'>It\'s out of [ammo_material]!</span>"
-	
+
 
 /obj/item/weapon/gun/magnetic/matfed/attackby(var/obj/item/thing, var/mob/user)
 	if(removable_components)
@@ -165,6 +165,7 @@
 	item_state = "bore"
 	wielded_item_state = "bore-wielded"
 	one_handed_penalty = 5
+	fire_delay = 20
 
 	projectile_type = /obj/item/projectile/bullet/magnetic/bore
 


### PR DESCRIPTION
Okay no it doesn't actually add physical recoil, but the phoron bore is now well-known to be a basically necessary Exploration support tool these days. Bringing at least one phoron bore for the purposes of clearing rock and stunlocking _multiple_ dangerous enemies at once is too good to pass up.

Consequently, propose adding a refire delay of two seconds to the phoron bore with no additional changes. The stun, damage, costs, all the same, but now you cannot _clickclickclickclickclickclickclickclickclick_ to hard stunlock a single enemy as oppressively, and the ability to juggle stunning multiple targets is severely hindered.

As a side effect this does somewhat nerf its ability to be used as a tool by actual Miners doing their jobs, however the two-second delay is much less of an issue in this environment and since the process looks something like "[Fire] - [Move] - [Fire] - [Move]" the majority of the delay is spent in the [Move] step. Long story short, sorry miners but the tool you can use with T4 parts to annihilate an entire mountain in record time is slightly slower at doing so.