### PR TITLE
Make a borer subtype for adminbuse

### DIFF
--- a/code/modules/mob/living/simple_mob/subtypes/animal/borer/borer.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/borer/borer.dm
@@ -26,24 +26,30 @@
 	holder_type = /obj/item/weapon/holder/borer
 	ai_holder_type = null // This is player-controlled, always.
 
+	var/mob/living/carbon/human/host = null		// The humanoid host for the brain worm.
+	var/mob/living/captive_brain/host_brain		// Used for swapping control of the body back and forth.
+	
+	var/roundstart = FALSE						// If true, spawning won't try to pull a ghost.
+	var/antag = TRUE							// If false, will avoid setting up objectives and events
+
 	var/chemicals = 10							// A resource used for reproduction and powers.
 	var/max_chemicals = 250						// Max of said resource.
-	var/mob/living/carbon/human/host = null		// The humanoid host for the brain worm.
 	var/true_name = null						// String used when speaking among other worms.
-	var/mob/living/captive_brain/host_brain		// Used for swapping control of the body back and forth.
 	var/controlling = FALSE						// Used in human death ceck.
 	var/docile = FALSE							// Sugar can stop borers from acting.
+	
 	var/has_reproduced = FALSE
-	var/roundstart = FALSE						// If true, spawning won't try to pull a ghost.
 	var/used_dominate							// world.time when the dominate power was last used.
-
 
 /mob/living/simple_mob/animal/borer/roundstart
 	roundstart = TRUE
 
+/mob/living/simple_mob/animal/borer/non_antag
+	antag = FALSE
+
 /mob/living/simple_mob/animal/borer/Login()
 	..()
-	if(mind)
+	if(antag && mind)
 		borers.add_antagonist(mind)
 
 /mob/living/simple_mob/animal/borer/Initialize()
@@ -54,7 +60,7 @@
 
 	true_name = "[pick("Primary","Secondary","Tertiary","Quaternary")] [rand(1000,9999)]"
 
-	if(!roundstart)
+	if(!roundstart && antag)
 		request_player()
 
 	return ..()

--- a/code/modules/mob/living/simple_mob/subtypes/animal/borer/borer_powers.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/borer/borer_powers.dm
@@ -169,7 +169,8 @@
 
 	H.verbs |= /mob/living/carbon/human/proc/psychic_whisper
 	H.verbs |= /mob/living/carbon/human/proc/tackle
-	H.verbs |= /mob/living/carbon/proc/spawn_larvae
+	if(antag)
+		H.verbs |= /mob/living/carbon/proc/spawn_larvae
 
 	if(H.client)
 		H.ghostize(0)
@@ -332,7 +333,8 @@
 
 			host.verbs += /mob/living/carbon/proc/release_control
 			host.verbs += /mob/living/carbon/proc/punish_host
-			host.verbs += /mob/living/carbon/proc/spawn_larvae
+			if(antag)
+				host.verbs += /mob/living/carbon/proc/spawn_larvae
 
 			return
 


### PR DESCRIPTION
The /non_antag version doesn't let you spawn more borers, doesn't ask for a ghost volunteer, and doesn't do antag role stuff.