### PR TITLE
Add default zorren tail to character setup menu

### DIFF
--- a/code/modules/mob/new_player/sprite_accessories_tail.dm
+++ b/code/modules/mob/new_player/sprite_accessories_tail.dm
@@ -558,6 +558,14 @@
 	do_colouration = 1
 	color_blend_mode = ICON_MULTIPLY
 
+/datum/sprite_accessory/tail/special/foxdefault
+	name = "default zorren tail, colorable"
+	desc = ""
+	icon = "icons/mob/human_races/r_fox_vr.dmi"
+	icon_state = "tail_s"
+	do_colouration = 1
+	color_blend_mode = ICON_MULTIPLY
+
 /datum/sprite_accessory/tail/special/foxhc
 	name = "highlander zorren tail, colorable"
 	desc = ""

--- a/code/modules/mob/new_player/sprite_accessories_tail_vr.dm
+++ b/code/modules/mob/new_player/sprite_accessories_tail_vr.dm
@@ -635,6 +635,14 @@
 	do_colouration = 1
 	color_blend_mode = ICON_MULTIPLY
 
+/datum/sprite_accessory/tail/special/foxdefault
+	name = "default zorren tail, colorable"
+	desc = ""
+	icon = "icons/mob/human_races/r_fox_vr.dmi"
+	icon_state = "tail_s"
+	do_colouration = 1
+	color_blend_mode = ICON_MULTIPLY
+
 /datum/sprite_accessory/tail/special/foxhc
 	name = "highlander zorren tail, colorable"
 	desc = ""


### PR DESCRIPTION
The "default" Zorren tail is not available for selection in the character setup menu, despite its potential use for various characters that may not like the other vulpine/canine tails available. This seems to fix that!