### PR TITLE
Increase the round restart timer from 3 to 4

### DIFF
--- a/code/controllers/subsystems/ticker.dm
+++ b/code/controllers/subsystems/ticker.dm
@@ -9,7 +9,7 @@ SUBSYSTEM_DEF(ticker)
 	flags = SS_NO_TICK_CHECK | SS_KEEP_TIMING
 	runlevels = RUNLEVEL_LOBBY | RUNLEVEL_SETUP | RUNLEVEL_GAME | RUNLEVEL_POSTGAME // Every runlevel!
 
-	var/const/restart_timeout = 3 MINUTES	// Default time to wait before rebooting in desiseconds.
+	var/const/restart_timeout = 4 MINUTES	// Default time to wait before rebooting in desiseconds.
 	var/current_state = GAME_STATE_INIT	// We aren't even at pregame yet // TODO replace with CURRENT_GAME_STATE
 
 	/* Relies upon the following globals (TODO move those in here) */


### PR DESCRIPTION
## About this pull request 
This simply adds another extra minute to the restart timer, like on polaris.

## Why is this good for the game
I often feel like the end of the shift can be a rushed affair. A little extra minute would be nice to exchange a few words before DC'ing, and so on. It also gives you a bit more time to take a pause if you'd like to queue for the next roundstart. It isn't a dramatic increase in time either for people who just want to get on with it either.