### PR TITLE
Fix Salamanders and Wall-lockers

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/walllocker.dm
+++ b/code/game/objects/structures/crates_lockers/closets/walllocker.dm
@@ -60,7 +60,7 @@
 //VOREStation Add Start
 /obj/structure/closet/walllocker/medical
 	name = "first-aid closet"
-	desc = "It's wall-mounted storage unit for first aid supplies."
+	desc = "It's a wall-mounted storage unit for first aid supplies."
 	closet_appearance = /decl/closet_appearance/wall/medical
 
 /obj/structure/closet/walllocker/medical/north
@@ -92,6 +92,7 @@
 	wall_mounted = 1
 	plane = TURF_PLANE
 	layer = ABOVE_TURF_LAYER
+	door_anim_time = 0 //Unsupported
 
 /obj/structure/closet/walllocker_double/north
 	pixel_y = 32

--- a/maps/offmap_vr/om_ships/salamander.dm
+++ b/maps/offmap_vr/om_ships/salamander.dm
@@ -49,7 +49,7 @@
 /area/shuttle/salamander_q2	
 	name = "\improper Salamander Quarters 2"
 	icon = 'icons/turf/areas_vr_talon.dmi'
-	icon_state = "gray-p"
+	icon_state = "gray-s"
 	requires_power = 1
 	has_gravity = 0
 
@@ -98,7 +98,7 @@
 /area/shuttle/salamander_wreck_q2	
 	name = "\improper Wrecked Salamander Quarters 2"
 	icon = 'icons/turf/areas_vr_talon.dmi'
-	icon_state = "gray-p"
+	icon_state = "gray-s"
 	requires_power = 1
 	has_gravity = 0
 

--- a/maps/offmap_vr/om_ships/salamander.dmm
+++ b/maps/offmap_vr/om_ships/salamander.dmm
@@ -194,7 +194,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor,
-/area/shuttle/salamander_q2)
+/area/shuttle/salamander_q1)
 "dj" = (
 /turf/simulated/floor/plating,
 /area/shuttle/salamander_engineering)
@@ -270,7 +270,7 @@
 "eG" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled/techfloor,
-/area/shuttle/salamander_q2)
+/area/shuttle/salamander_q1)
 "eJ" = (
 /obj/effect/map_helper/airlock/sensor/int_sensor,
 /obj/machinery/airlock_sensor{
@@ -319,6 +319,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/salamander_engineering)
+"fu" = (
+/obj/structure/bed/pod,
+/obj/item/weapon/bedsheet/blue,
+/obj/machinery/light_switch{
+	dir = 4;
+	pixel_x = 22
+	},
+/obj/effect/landmark/late_antag/trader,
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/salamander_q1)
 "fB" = (
 /obj/machinery/light,
 /turf/simulated/floor/plating,
@@ -402,7 +412,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/tiled/techfloor,
-/area/shuttle/salamander_q2)
+/area/shuttle/salamander_q1)
 "gv" = (
 /obj/machinery/power/apc{
 	dir = 8;
@@ -1323,6 +1333,9 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/shuttle/salamander)
+"xj" = (
+/turf/simulated/wall/shull,
+/area/shuttle/salamander_q1)
 "xL" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -1407,7 +1420,7 @@
 	pixel_x = -32
 	},
 /turf/simulated/floor/tiled/techfloor,
-/area/shuttle/salamander_q2)
+/area/shuttle/salamander_q1)
 "Bf" = (
 /obj/machinery/light{
 	dir = 1
@@ -1503,6 +1516,12 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/shuttle/salamander)
+"FV" = (
+/obj/machinery/power/pointdefense{
+	id_tag = "salamander_pd"
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/salamander_q1)
 "Gj" = (
 /obj/machinery/door/firedoor/glass,
 /obj/structure/grille,
@@ -1624,6 +1643,22 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/salamander)
+"Lb" = (
+/obj/machinery/door/firedoor/glass,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/airlock/voidcraft{
+	req_one_access = list(160)
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/shuttle/salamander_q1)
 "Lf" = (
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled/techfloor,
@@ -1753,6 +1788,26 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/salamander)
+"Rj" = (
+/obj/machinery/door/firedoor/glass,
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/salamander_q1)
+"Rm" = (
+/obj/structure/bed/pod,
+/obj/item/weapon/bedsheet/blue,
+/obj/machinery/alarm/alarms_hidden{
+	dir = 8;
+	pixel_x = 26
+	},
+/obj/effect/landmark/late_antag/trader,
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/salamander_q1)
 "RO" = (
 /obj/structure/bed/pod,
 /obj/item/weapon/bedsheet/blue,
@@ -2495,11 +2550,11 @@ WP
 (26,1,1) = {"
 WP
 WP
-bk
-Vz
+FV
+xj
 cY
 AN
-Vz
+xj
 hn
 yv
 Vz
@@ -2514,10 +2569,10 @@ WP
 WP
 WP
 WP
-ci
+Rj
 eG
 gl
-ld
+Lb
 hp
 jT
 ld
@@ -2532,10 +2587,10 @@ WP
 WP
 WP
 WP
-Vz
-oF
-RO
-Vz
+xj
+fu
+Rm
+xj
 fh
 xL
 Vz
@@ -2550,10 +2605,10 @@ WP
 WP
 WP
 WP
-Vz
-Vz
-Vz
-Vz
+xj
+xj
+xj
+xj
 DB
 jV
 Vz

--- a/maps/submaps/admin_use_vr/salamander_trader.dm
+++ b/maps/submaps/admin_use_vr/salamander_trader.dm
@@ -1,0 +1,90 @@
+// Compile in the map for CI testing if we're testing compileability of all the maps
+#if MAP_TEST
+#include "salamander_trader.dmm"
+#endif
+
+// The shuttle's area(s)
+/area/shuttle/salamander_trader
+	name = "\improper Salamander Trader Cabin"
+	icon = 'icons/turf/areas_vr_talon.dmi'
+	icon_state = "gray"
+	requires_power = 1
+	has_gravity = 0
+
+/area/shuttle/salamander_trader_engineering
+	name = "\improper Salamander Trader Engineering"
+	icon = 'icons/turf/areas_vr_talon.dmi'
+	icon_state = "yellow"
+	requires_power = 1
+	has_gravity = 0
+
+/area/shuttle/salamander_trader_cockpit
+	name = "\improper Salamander Trader Cockpit"
+	icon = 'icons/turf/areas_vr_talon.dmi'
+	icon_state = "blue"
+	requires_power = 1
+	has_gravity = 0
+
+/area/shuttle/salamander_trader_q1	
+	name = "\improper Salamander Trader Quarters 1"
+	icon = 'icons/turf/areas_vr_talon.dmi'
+	icon_state = "gray-p"
+	requires_power = 1
+	has_gravity = 0
+
+/area/shuttle/salamander_trader_q2	
+	name = "\improper Salamander Trader Quarters 2"
+	icon = 'icons/turf/areas_vr_talon.dmi'
+	icon_state = "gray-s"
+	requires_power = 1
+	has_gravity = 0
+
+/area/shuttle/salamander_trader_galley	
+	name = "\improper Salamander Trader Galley"
+	icon = 'icons/turf/areas_vr_talon.dmi'
+	icon_state = "dark-s"
+	requires_power = 1
+	has_gravity = 0
+
+/area/shuttle/salamander_trader_head	
+	name = "\improper Salamander Trader Head"
+	icon = 'icons/turf/areas_vr_talon.dmi'
+	icon_state = "dark-p"
+	requires_power = 1
+	has_gravity = 0
+
+// The shuttle's 'shuttle' computer
+/obj/machinery/computer/shuttle_control/explore/salamander_trader
+	name = "short jump console"
+	shuttle_tag = "Salamander Trader"
+	req_one_access = list()
+
+// The 'shuttle'
+/datum/shuttle/autodock/overmap/salamander_trader
+	name = "Salamander Trader"
+	current_location = "omship_spawn_salamander_trader"
+	docking_controller_tag = "salamander_trader_docking"
+	shuttle_area = list(/area/shuttle/salamander_trader,/area/shuttle/salamander_trader_cockpit,/area/shuttle/salamander_trader_engineering,/area/shuttle/salamander_trader_q1,/area/shuttle/salamander_trader_q2,/area/shuttle/salamander_trader_galley,/area/shuttle/salamander_trader_head)
+	defer_initialisation = TRUE //We're not loaded until an admin does it
+	fuel_consumption = 5
+	ceiling_type = /turf/simulated/floor/reinforced/airless
+
+// A shuttle lateloader landmark
+/obj/effect/shuttle_landmark/shuttle_initializer/salamander_trader
+	name = "ITV Freedom"
+	base_area = /area/space
+	base_turf = /turf/space
+	landmark_tag = "omship_spawn_salamander_trader"
+	shuttle_type = /datum/shuttle/autodock/overmap/salamander_trader
+
+// The 'ship'
+/obj/effect/overmap/visitable/ship/landable/salamander_trader
+	name = "Salamander-class Corvette"
+	scanner_desc = @{"[i]Registration[/i]: ITV Freedom
+[i]Class[/i]: Corvette
+[i]Transponder[/i]: Transmitting (CIV), non-hostile
+[b]Notice[/b]: Multirole independent vessel"}
+	vessel_mass = 4500
+	vessel_size = SHIP_SIZE_LARGE
+	fore_dir = EAST
+	shuttle = "Salamander Trader"

--- a/maps/submaps/admin_use_vr/salamander_trader.dmm
+++ b/maps/submaps/admin_use_vr/salamander_trader.dmm
@@ -4,7 +4,7 @@
 /obj/effect/map_helper/airlock/door/ext_door,
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /turf/simulated/floor/tiled/techmaint,
-/area/shuttle/salamander_wreck)
+/area/shuttle/salamander_trader)
 "aK" = (
 /obj/machinery/door/airlock/glass_external/public,
 /obj/effect/map_helper/airlock/door/ext_door,
@@ -15,59 +15,74 @@
 	pixel_y = 11
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/shuttle/salamander_wreck)
+/area/shuttle/salamander_trader)
 "aL" = (
-/obj/effect/shuttle_landmark/shuttle_initializer/salamander_wreck,
-/obj/effect/overmap/visitable/ship/landable/salamander_wreck,
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 6
 	},
 /obj/machinery/embedded_controller/radio/airlock/docking_port_multi{
 	dir = 4;
-	id_tag = "salamander_wreck_docking_port";
+	id_tag = "salamander_trader_docking_port";
 	name = "Port Airlock Control";
-	pixel_x = -22
+	pixel_x = -22;
+	req_one_access = list(160)
 	},
 /obj/machinery/light{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
+/obj/effect/shuttle_landmark/shuttle_initializer/salamander_trader,
+/obj/effect/overmap/visitable/ship/landable/salamander_trader,
 /turf/simulated/floor/tiled/techmaint,
-/area/shuttle/salamander_wreck)
+/area/shuttle/salamander_trader)
+"aO" = (
+/obj/machinery/power/pointdefense{
+	id_tag = "salamander_pd"
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/salamander_trader_q2)
 "bk" = (
 /obj/machinery/power/pointdefense{
-	id_tag = "salamander_wreck_pd"
+	id_tag = "salamander_pd"
 	},
-/turf/simulated/floor/airless,
-/area/shuttle/salamander_wreck_q2)
-"bq" = (
-/obj/structure/hull_corner{
-	dir = 4
-	},
-/turf/template_noop,
-/area/shuttle/salamander_wreck)
+/turf/simulated/floor/plating,
+/area/shuttle/salamander_trader_q1)
 "br" = (
 /obj/structure/window/reinforced/tinted,
 /obj/structure/toilet{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/techfloor{
-	nitrogen = 0;
-	oxygen = 0
-	},
-/area/shuttle/salamander_wreck_head)
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/salamander_trader_head)
 "bu" = (
 /obj/effect/map_helper/airlock/sensor/chamber_sensor,
 /obj/machinery/atmospherics/pipe/manifold/hidden,
 /obj/machinery/airlock_sensor{
 	dir = 4;
-	pixel_x = -21
+	pixel_x = -21;
+	req_one_access = list(160)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /turf/simulated/floor/tiled/techmaint,
-/area/shuttle/salamander_wreck)
+/area/shuttle/salamander_trader)
+"bA" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/salamander_trader_engineering)
+"bH" = (
+/obj/structure/closet/crate,
+/turf/simulated/floor/plating,
+/area/shuttle/salamander_trader_engineering)
 "bI" = (
+/obj/structure/bed/chair/bay/chair,
 /obj/structure/handrail,
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_y = 24
+	},
 /obj/structure/cable{
 	d2 = 4;
 	icon_state = "0-4"
@@ -79,46 +94,31 @@
 	dir = 8;
 	pixel_x = -32
 	},
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_y = 24;
-	start_charge = 0
-	},
-/obj/structure/bed/chair/bay/chair{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor{
-	nitrogen = 0;
-	oxygen = 0
-	},
-/area/shuttle/salamander_wreck_galley)
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/salamander_trader_galley)
 "bK" = (
 /obj/machinery/atmospherics/portables_connector,
 /obj/effect/floor_decal/industrial/outline/blue,
 /obj/machinery/portable_atmospherics/canister/air,
-/turf/simulated/floor/airless,
-/area/shuttle/salamander_wreck_engineering)
+/turf/simulated/floor/plating,
+/area/shuttle/salamander_trader_engineering)
 "bL" = (
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/airlock/hatch{
-	req_one_access = list()
+	req_one_access = list(160)
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/shuttle/salamander_wreck)
+/area/shuttle/salamander_trader)
 "bN" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/machinery/alarm/alarms_hidden{
 	pixel_y = 26
 	},
-/obj/machinery/light/flicker{
+/obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/techfloor{
-	nitrogen = 0;
-	oxygen = 0
-	},
-/area/shuttle/salamander_wreck_head)
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/salamander_trader_head)
 "bP" = (
 /obj/structure/sink{
 	dir = 4;
@@ -131,11 +131,8 @@
 /obj/machinery/light_switch{
 	pixel_y = 23
 	},
-/turf/simulated/floor/tiled/techfloor{
-	nitrogen = 0;
-	oxygen = 0
-	},
-/area/shuttle/salamander_wreck_head)
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/salamander_trader_head)
 "bY" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -148,8 +145,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/techmaint/airless,
-/area/shuttle/salamander_wreck_engineering)
+/turf/simulated/floor/tiled/techmaint,
+/area/shuttle/salamander_trader_engineering)
 "ci" = (
 /obj/machinery/door/firedoor/glass,
 /obj/structure/grille,
@@ -159,10 +156,14 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating,
-/area/shuttle/salamander_wreck_q2)
+/area/shuttle/salamander_trader_q1)
 "cq" = (
 /obj/structure/handrail{
 	dir = 1
+	},
+/obj/machinery/power/apc{
+	name = "south bump";
+	pixel_y = -24
 	},
 /obj/structure/cable{
 	d2 = 4;
@@ -175,16 +176,8 @@
 	dir = 8;
 	pixel_x = -32
 	},
-/obj/machinery/power/apc{
-	name = "south bump";
-	pixel_y = -24;
-	start_charge = 0
-	},
-/turf/simulated/floor/tiled/techfloor{
-	nitrogen = 0;
-	oxygen = 0
-	},
-/area/shuttle/salamander_wreck_head)
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/salamander_trader_head)
 "cC" = (
 /obj/machinery/shower{
 	dir = 1
@@ -193,33 +186,33 @@
 /obj/structure/window/reinforced/tinted{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/techfloor{
-	nitrogen = 0;
-	oxygen = 0
-	},
-/area/shuttle/salamander_wreck_head)
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/salamander_trader_head)
 "cX" = (
 /obj/machinery/door/airlock/glass_external/public,
 /obj/effect/map_helper/airlock/door/int_door,
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /turf/simulated/floor/tiled/techmaint,
-/area/shuttle/salamander_wreck)
+/area/shuttle/salamander_trader)
 "cY" = (
 /obj/structure/fitness/weightlifter,
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/techfloor{
-	nitrogen = 0;
-	oxygen = 0
-	},
-/area/shuttle/salamander_wreck_q1)
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/salamander_trader_q1)
+"de" = (
+/turf/simulated/wall/shull,
+/area/shuttle/salamander_trader_q2)
+"dj" = (
+/turf/simulated/floor/plating,
+/area/shuttle/salamander_trader_engineering)
 "dm" = (
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/airless,
-/area/shuttle/salamander_wreck_engineering)
+/turf/simulated/floor/plating,
+/area/shuttle/salamander_trader_engineering)
 "dn" = (
 /obj/machinery/door/firedoor/glass,
 /obj/structure/grille,
@@ -233,8 +226,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 4
 	},
-/turf/simulated/floor/airless,
-/area/shuttle/salamander_wreck_engineering)
+/turf/simulated/floor/plating,
+/area/shuttle/salamander_trader_engineering)
 "dO" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -247,66 +240,58 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
-/turf/simulated/floor/tiled/techfloor{
-	nitrogen = 0;
-	oxygen = 0
-	},
-/area/shuttle/salamander_wreck_head)
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/salamander_trader_head)
 "dT" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/fuel{
 	dir = 1
 	},
-/turf/simulated/floor/airless,
-/area/shuttle/salamander_wreck_engineering)
+/turf/simulated/floor/plating,
+/area/shuttle/salamander_trader_engineering)
 "ee" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 10
 	},
-/turf/simulated/floor/airless,
-/area/shuttle/salamander_wreck_engineering)
+/turf/simulated/floor/plating,
+/area/shuttle/salamander_trader_engineering)
 "eg" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 5
 	},
-/turf/simulated/floor/airless,
-/area/shuttle/salamander_wreck_engineering)
-"el" = (
-/turf/simulated/wall/shull,
-/area/shuttle/salamander_wreck_q1)
+/turf/simulated/floor/plating,
+/area/shuttle/salamander_trader_engineering)
 "ey" = (
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 4
 	},
-/turf/simulated/floor/airless,
-/area/shuttle/salamander_wreck_engineering)
+/turf/simulated/floor/plating,
+/area/shuttle/salamander_trader_engineering)
 "eB" = (
 /obj/machinery/alarm/alarms_hidden{
 	dir = 4;
 	pixel_x = -26
 	},
-/obj/machinery/light/flicker{
+/obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/techmaint/airless,
-/area/shuttle/salamander_wreck)
+/turf/simulated/floor/tiled/techmaint,
+/area/shuttle/salamander_trader)
 "eG" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/tiled/techfloor{
-	nitrogen = 0;
-	oxygen = 0
-	},
-/area/shuttle/salamander_wreck_q1)
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/salamander_trader_q1)
 "eJ" = (
 /obj/effect/map_helper/airlock/sensor/int_sensor,
 /obj/machinery/airlock_sensor{
 	dir = 8;
-	pixel_x = 21
+	pixel_x = 21;
+	req_one_access = list(160)
 	},
 /obj/structure/handrail{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/techmaint/airless,
-/area/shuttle/salamander_wreck)
+/turf/simulated/floor/tiled/techmaint,
+/area/shuttle/salamander_trader)
 "eP" = (
 /obj/machinery/door/firedoor/glass,
 /obj/structure/cable{
@@ -319,37 +304,46 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/airlock/voidcraft{
-	density = 0;
-	icon_state = "door_open"
+	req_one_access = list(160)
 	},
-/turf/simulated/floor/tiled/techmaint/airless,
-/area/shuttle/salamander_wreck_head)
+/turf/simulated/floor/tiled/techmaint,
+/area/shuttle/salamander_trader_head)
 "fh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
 	},
-/obj/item/stack/cable_coil,
+/obj/item/clothing/shoes/boots/workboots,
+/obj/item/clothing/gloves/duty,
+/obj/item/clothing/under/utility,
+/obj/item/clothing/ears/earmuffs,
+/obj/item/clothing/head/soft/black,
 /obj/structure/closet/walllocker_double/north{
 	name = "Uniform Locker"
 	},
-/turf/simulated/floor/tiled/techmaint/airless,
-/area/shuttle/salamander_wreck)
+/turf/simulated/floor/tiled/techmaint,
+/area/shuttle/salamander_trader)
 "fn" = (
 /obj/machinery/atmospherics/unary/engine/bigger{
 	dir = 4
 	},
-/turf/simulated/floor/airless,
-/area/shuttle/salamander_wreck_engineering)
+/turf/simulated/floor/plating,
+/area/shuttle/salamander_trader_engineering)
 "fB" = (
 /obj/machinery/light,
-/turf/simulated/floor/airless,
-/area/shuttle/salamander_wreck_engineering)
+/turf/simulated/floor/plating,
+/area/shuttle/salamander_trader_engineering)
+"fC" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 9
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/salamander_trader_engineering)
 "fD" = (
 /obj/machinery/atmospherics/binary/pump/fuel{
 	dir = 1
 	},
-/turf/simulated/floor/airless,
-/area/shuttle/salamander_wreck_engineering)
+/turf/simulated/floor/plating,
+/area/shuttle/salamander_trader_engineering)
 "fE" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -359,11 +353,8 @@
 /obj/structure/railing/grey{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/techfloor{
-	nitrogen = 0;
-	oxygen = 0
-	},
-/area/shuttle/salamander_wreck_engineering)
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/salamander_trader_engineering)
 "fG" = (
 /obj/structure/handrail{
 	dir = 4
@@ -372,20 +363,16 @@
 	dir = 8;
 	pixel_x = -32
 	},
-/turf/simulated/floor/tiled/techmaint/airless,
-/area/shuttle/salamander_wreck)
+/turf/simulated/floor/tiled/techmaint,
+/area/shuttle/salamander_trader)
 "fP" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 10
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/structure/railing/grey,
-/obj/random/empty_or_lootable_crate,
-/turf/simulated/floor/tiled/techfloor{
-	nitrogen = 0;
-	oxygen = 0
-	},
-/area/shuttle/salamander_wreck)
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/salamander_trader)
 "fR" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 6
@@ -393,27 +380,24 @@
 /obj/structure/railing/grey{
 	dir = 4
 	},
-/obj/random/empty_or_lootable_crate,
-/turf/simulated/floor/tiled/techfloor{
-	nitrogen = 0;
-	oxygen = 0
-	},
-/area/shuttle/salamander_wreck)
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/salamander_trader)
 "fX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
-/turf/simulated/floor/tiled/techmaint/airless,
-/area/shuttle/salamander_wreck)
+/turf/simulated/floor/tiled/techmaint,
+/area/shuttle/salamander_trader)
 "fZ" = (
+/obj/item/device/suit_cooling_unit,
+/obj/item/weapon/tank/air,
+/obj/item/clothing/suit/space/void/refurb,
+/obj/item/clothing/head/helmet/space/void/refurb,
 /obj/structure/handrail,
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/structure/closet/walllocker_double/north{
 	name = "Voidsuit Locker"
 	},
-/turf/simulated/floor/tiled/techfloor{
-	nitrogen = 0;
-	oxygen = 0
-	},
-/area/shuttle/salamander_wreck)
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/salamander_trader)
 "gl" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -426,12 +410,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
-/turf/simulated/floor/tiled/techfloor{
-	nitrogen = 0;
-	oxygen = 0
-	},
-/area/shuttle/salamander_wreck_q1)
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/salamander_trader_q1)
 "gv" = (
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -28
+	},
 /obj/structure/cable{
 	d2 = 2;
 	icon_state = "0-2"
@@ -449,25 +435,12 @@
 /obj/structure/bed/chair/bay/comfy{
 	dir = 4
 	},
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -28;
-	start_charge = 0
-	},
-/turf/simulated/floor/tiled/techmaint/airless,
-/area/shuttle/salamander_wreck_cockpit)
-"gx" = (
-/obj/structure/prop/blackbox/salamander_wreck,
-/turf/simulated/floor/plating,
-/area/shuttle/salamander_wreck)
+/turf/simulated/floor/tiled/techmaint,
+/area/shuttle/salamander_trader_cockpit)
 "gC" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/tiled/techfloor{
-	nitrogen = 0;
-	oxygen = 0
-	},
-/area/shuttle/salamander_wreck_cockpit)
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/salamander_trader_cockpit)
 "gD" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/railing/grey{
@@ -476,16 +449,19 @@
 /obj/machinery/atmospherics/portables_connector/fuel{
 	dir = 4
 	},
-/turf/simulated/floor/airless,
-/area/shuttle/salamander_wreck_engineering)
+/obj/machinery/portable_atmospherics/canister/phoron{
+	start_pressure = 8000.25
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/salamander_trader_engineering)
 "gL" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 4
 	},
-/turf/simulated/floor/airless,
-/area/shuttle/salamander_wreck_engineering)
+/turf/simulated/floor/plating,
+/area/shuttle/salamander_trader_engineering)
 "gM" = (
 /obj/machinery/door/firedoor/glass,
 /obj/structure/grille,
@@ -497,7 +473,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/shuttle/salamander_wreck_cockpit)
+/area/shuttle/salamander_trader_cockpit)
 "hh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
@@ -505,8 +481,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 9
 	},
-/turf/simulated/floor/tiled/techmaint/airless,
-/area/shuttle/salamander_wreck)
+/turf/simulated/floor/tiled/techmaint,
+/area/shuttle/salamander_trader)
 "hn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
@@ -514,12 +490,16 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/item/weapon/circuitboard/smes,
+/obj/item/clothing/shoes/boots/workboots,
+/obj/item/clothing/gloves/duty,
+/obj/item/clothing/under/utility,
+/obj/item/clothing/ears/earmuffs,
+/obj/item/clothing/head/soft/black,
 /obj/structure/closet/walllocker_double/north{
 	name = "Uniform Locker"
 	},
-/turf/simulated/floor/tiled/techmaint/airless,
-/area/shuttle/salamander_wreck)
+/turf/simulated/floor/tiled/techmaint,
+/area/shuttle/salamander_trader)
 "hp" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -528,27 +508,22 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/techmaint/airless,
-/area/shuttle/salamander_wreck)
+/turf/simulated/floor/tiled/techmaint,
+/area/shuttle/salamander_trader)
 "hr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
-/turf/simulated/floor/tiled/techmaint/airless,
-/area/shuttle/salamander_wreck_cockpit)
+/turf/simulated/floor/tiled/techmaint,
+/area/shuttle/salamander_trader_cockpit)
 "hC" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/railing/grey,
 /obj/machinery/atmospherics/pipe/tank/phoron{
-	dir = 4;
-	start_pressure = 0
+	dir = 4
 	},
-/turf/simulated/floor/airless,
-/area/shuttle/salamander_wreck_engineering)
-"hK" = (
-/obj/structure/bed/chair/bay/chair,
-/turf/simulated/floor/tiled/techmaint/airless,
-/area/shuttle/salamander_wreck_cockpit)
+/turf/simulated/floor/plating,
+/area/shuttle/salamander_trader_engineering)
 "hO" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -559,12 +534,11 @@
 	dir = 4
 	},
 /obj/machinery/door/window/brigdoor/westleft{
-	density = 0;
-	icon_state = "leftsecureopen";
-	req_access = list()
+	req_access = list();
+	req_one_access = list(160)
 	},
-/turf/simulated/floor/tiled/techmaint/airless,
-/area/shuttle/salamander_wreck)
+/turf/simulated/floor/tiled/techmaint,
+/area/shuttle/salamander_trader)
 "if" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -572,17 +546,18 @@
 /obj/structure/catwalk,
 /obj/structure/railing/grey,
 /obj/machinery/computer/ship/engines{
-	dir = 4
+	dir = 4;
+	req_one_access = list(160)
 	},
-/turf/simulated/floor/airless,
-/area/shuttle/salamander_wreck_engineering)
+/turf/simulated/floor/plating,
+/area/shuttle/salamander_trader_engineering)
 "ii" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
 /obj/structure/catwalk,
-/turf/simulated/floor/airless,
-/area/shuttle/salamander_wreck_engineering)
+/turf/simulated/floor/plating,
+/area/shuttle/salamander_trader_engineering)
 "im" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -592,11 +567,24 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/techfloor{
-	nitrogen = 0;
-	oxygen = 0
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/salamander_trader_engineering)
+"iq" = (
+/obj/machinery/door/firedoor/glass,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/area/shuttle/salamander_wreck_engineering)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/airlock/voidcraft{
+	req_one_access = list(160)
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/shuttle/salamander_trader_q2)
 "is" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -611,8 +599,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/techmaint/airless,
-/area/shuttle/salamander_wreck_engineering)
+/turf/simulated/floor/tiled/techmaint,
+/area/shuttle/salamander_trader_engineering)
 "iC" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -622,8 +610,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/techmaint/airless,
-/area/shuttle/salamander_wreck)
+/turf/simulated/floor/tiled/techmaint,
+/area/shuttle/salamander_trader)
 "iJ" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -636,17 +624,16 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/techmaint/airless,
-/area/shuttle/salamander_wreck)
+/turf/simulated/floor/tiled/techmaint,
+/area/shuttle/salamander_trader)
 "iK" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/tiled/techmaint/airless,
-/area/shuttle/salamander_wreck)
+/turf/simulated/floor/tiled/techmaint,
+/area/shuttle/salamander_trader)
 "iL" = (
 /obj/machinery/door/window/brigdoor/eastleft{
-	density = 0;
-	icon_state = "leftsecureopen";
-	req_access = list()
+	req_access = list();
+	req_one_access = list(160)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
@@ -654,8 +641,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/techmaint/airless,
-/area/shuttle/salamander_wreck)
+/turf/simulated/floor/tiled/techmaint,
+/area/shuttle/salamander_trader)
 "iS" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -666,8 +653,8 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/techmaint/airless,
-/area/shuttle/salamander_wreck)
+/turf/simulated/floor/tiled/techmaint,
+/area/shuttle/salamander_trader)
 "iW" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -677,8 +664,8 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/techmaint/airless,
-/area/shuttle/salamander_wreck)
+/turf/simulated/floor/tiled/techmaint,
+/area/shuttle/salamander_trader)
 "jl" = (
 /obj/machinery/door/firedoor/glass,
 /obj/structure/grille,
@@ -687,7 +674,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating,
-/area/shuttle/salamander_wreck_cockpit)
+/area/shuttle/salamander_trader_cockpit)
 "jq" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
@@ -695,15 +682,24 @@
 /obj/structure/handrail{
 	dir = 1
 	},
-/obj/random/empty_or_lootable_crate,
+/obj/random/contraband/nofail,
+/obj/random/contraband/nofail,
+/obj/random/contraband/nofail,
+/obj/random/contraband/nofail,
+/obj/random/contraband/nofail,
+/obj/random/contraband/nofail,
+/obj/random/contraband/nofail,
+/obj/random/contraband/nofail,
+/obj/random/contraband/nofail,
+/obj/random/cigarettes,
+/obj/random/drinkbottle,
+/obj/random/drinkbottle,
+/obj/random/snack,
 /obj/structure/closet/walllocker_double/south{
 	name = "Storage Locker"
 	},
-/turf/simulated/floor/tiled/techfloor{
-	nitrogen = 0;
-	oxygen = 0
-	},
-/area/shuttle/salamander_wreck)
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/salamander_trader)
 "jT" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -725,13 +721,12 @@
 	dir = 1
 	},
 /obj/effect/catwalk_plated,
-/turf/simulated/floor/airless,
-/area/shuttle/salamander_wreck)
+/turf/simulated/floor/plating,
+/area/shuttle/salamander_trader)
 "jV" = (
 /obj/machinery/door/airlock/multi_tile/glass{
-	density = 0;
 	dir = 2;
-	icon_state = "door_open"
+	req_one_access = list(160)
 	},
 /obj/machinery/door/firedoor/multi_tile{
 	dir = 1
@@ -744,21 +739,21 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/techmaint/airless,
-/area/shuttle/salamander_wreck_cockpit)
+/turf/simulated/floor/tiled/techmaint,
+/area/shuttle/salamander_trader_cockpit)
 "ks" = (
-/turf/simulated/floor/tiled/techmaint/airless,
-/area/shuttle/salamander_wreck_cockpit)
+/turf/simulated/floor/tiled/techmaint,
+/area/shuttle/salamander_trader_cockpit)
 "kx" = (
 /obj/machinery/atmospherics/binary/pump/fuel,
-/turf/simulated/floor/airless,
-/area/shuttle/salamander_wreck_engineering)
+/turf/simulated/floor/plating,
+/area/shuttle/salamander_trader_engineering)
 "kK" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/simulated/floor/airless,
-/area/shuttle/salamander_wreck_engineering)
+/turf/simulated/floor/plating,
+/area/shuttle/salamander_trader_engineering)
 "kL" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -772,11 +767,12 @@
 	dir = 4;
 	pixel_x = 32
 	},
-/turf/simulated/floor/tiled/techfloor{
-	nitrogen = 0;
-	oxygen = 0
+/obj/structure/panic_button{
+	pixel_x = 32;
+	pixel_y = -32
 	},
-/area/shuttle/salamander_wreck_engineering)
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/salamander_trader_engineering)
 "kU" = (
 /obj/machinery/suit_cycler/vintage/omni,
 /obj/machinery/light{
@@ -785,11 +781,8 @@
 /obj/structure/railing/grey{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/techfloor{
-	nitrogen = 0;
-	oxygen = 0
-	},
-/area/shuttle/salamander_wreck)
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/salamander_trader)
 "kZ" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 9
@@ -800,12 +793,8 @@
 /obj/structure/railing/grey{
 	dir = 1
 	},
-/obj/random/empty_or_lootable_crate,
-/turf/simulated/floor/tiled/techfloor{
-	nitrogen = 0;
-	oxygen = 0
-	},
-/area/shuttle/salamander_wreck)
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/salamander_trader)
 "lc" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 5
@@ -813,12 +802,8 @@
 /obj/structure/railing/grey{
 	dir = 4
 	},
-/obj/random/empty_or_lootable_crate,
-/turf/simulated/floor/tiled/techfloor{
-	nitrogen = 0;
-	oxygen = 0
-	},
-/area/shuttle/salamander_wreck)
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/salamander_trader)
 "ld" = (
 /obj/machinery/door/firedoor/glass,
 /obj/structure/cable{
@@ -831,11 +816,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/airlock/voidcraft{
-	density = 0;
-	icon_state = "door_open"
+	req_one_access = list(160)
 	},
-/turf/simulated/floor/tiled/techmaint/airless,
-/area/shuttle/salamander_wreck_q2)
+/turf/simulated/floor/tiled/techmaint,
+/area/shuttle/salamander_trader_q1)
 "ll" = (
 /obj/structure/handrail{
 	dir = 1
@@ -847,6 +831,9 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
+/obj/machinery/light{
+	dir = 8
+	},
 /obj/structure/closet/autolok_wall{
 	dir = 1;
 	pixel_y = -32
@@ -857,20 +844,15 @@
 /obj/structure/bed/chair/bay/comfy{
 	dir = 4
 	},
-/obj/machinery/light/flicker{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/techmaint/airless,
-/area/shuttle/salamander_wreck_cockpit)
+/turf/simulated/floor/tiled/techmaint,
+/area/shuttle/salamander_trader_cockpit)
 "lo" = (
 /obj/machinery/computer/ship/engines{
-	dir = 1
+	dir = 1;
+	req_one_access = list(160)
 	},
-/turf/simulated/floor/tiled/techfloor{
-	nitrogen = 0;
-	oxygen = 0
-	},
-/area/shuttle/salamander_wreck_cockpit)
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/salamander_trader_cockpit)
 "lt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 4
@@ -884,19 +866,24 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/turf/simulated/floor/airless,
-/area/shuttle/salamander_wreck_engineering)
+/turf/simulated/floor/plating,
+/area/shuttle/salamander_trader_engineering)
 "lw" = (
 /obj/machinery/atmospherics/portables_connector,
+/obj/machinery/portable_atmospherics/canister/air/airlock,
 /obj/effect/floor_decal/industrial/outline,
-/turf/simulated/floor/airless,
-/area/shuttle/salamander_wreck)
+/turf/simulated/floor/plating,
+/area/shuttle/salamander_trader)
+"lC" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/fuel,
+/turf/simulated/floor/plating,
+/area/shuttle/salamander_trader_engineering)
 "lK" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 6
 	},
-/turf/simulated/floor/airless,
-/area/shuttle/salamander_wreck_engineering)
+/turf/simulated/floor/plating,
+/area/shuttle/salamander_trader_engineering)
 "lV" = (
 /obj/machinery/power/terminal{
 	dir = 4
@@ -905,45 +892,41 @@
 /obj/structure/railing/grey{
 	dir = 8
 	},
+/obj/item/weapon/tank/phoron/pressurized,
+/obj/item/weapon/tank/phoron/pressurized,
 /obj/structure/closet/walllocker{
 	dir = 1;
 	name = "Spare Fuel";
 	pixel_y = -32
 	},
 /obj/item/weapon/tool/crowbar/red,
-/obj/machinery/light,
-/turf/simulated/floor/tiled/techfloor{
-	nitrogen = 0;
-	oxygen = 0
+/obj/item/stack/material/tritium{
+	amount = 25
 	},
-/area/shuttle/salamander_wreck_engineering)
+/obj/machinery/light,
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/salamander_trader_engineering)
 "ma" = (
 /obj/structure/cable,
-/obj/structure/frame,
-/turf/simulated/floor/tiled/techfloor{
-	nitrogen = 0;
-	oxygen = 0
-	},
-/area/shuttle/salamander_wreck_engineering)
+/obj/machinery/power/smes/buildable/point_of_interest,
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/salamander_trader_engineering)
 "mg" = (
+/obj/machinery/door/airlock/glass_external/public,
 /obj/effect/map_helper/airlock/door/ext_door,
 /obj/effect/map_helper/airlock/sensor/ext_sensor,
 /obj/machinery/airlock_sensor/airlock_exterior/shuttle{
 	pixel_x = 24;
 	pixel_y = -11
 	},
-/obj/machinery/door/airlock/glass_external/public{
-	density = 0;
-	icon_state = "door_open"
-	},
-/turf/simulated/floor/tiled/techmaint/airless,
-/area/shuttle/salamander_wreck)
+/turf/simulated/floor/tiled/techmaint,
+/area/shuttle/salamander_trader)
 "mm" = (
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/techmaint/airless,
-/area/shuttle/salamander_wreck)
+/turf/simulated/floor/tiled/techmaint,
+/area/shuttle/salamander_trader)
 "mE" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
@@ -951,50 +934,69 @@
 /obj/structure/handrail{
 	dir = 1
 	},
-/obj/random/empty_or_lootable_crate,
+/obj/random/medical,
+/obj/random/medical,
+/obj/random/medical,
+/obj/random/medical,
+/obj/random/medical,
+/obj/random/contraband/nofail,
+/obj/random/contraband/nofail,
+/obj/random/cigarettes,
+/obj/random/drinkbottle,
+/obj/random/drinkbottle,
+/obj/random/snack,
 /obj/structure/closet/walllocker_double/south{
 	name = "Storage Locker"
 	},
-/turf/simulated/floor/tiled/techfloor{
-	nitrogen = 0;
-	oxygen = 0
-	},
-/area/shuttle/salamander_wreck)
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/salamander_trader)
 "mJ" = (
 /obj/structure/handrail{
 	dir = 1
 	},
-/obj/random/empty_or_lootable_crate,
-/obj/item/weapon/smes_coil,
+/obj/random/medical,
+/obj/random/medical,
+/obj/random/medical,
+/obj/random/medical,
+/obj/random/medical,
+/obj/random/contraband/nofail,
+/obj/random/contraband/nofail,
+/obj/random/cigarettes,
+/obj/random/drinkbottle,
+/obj/random/drinkbottle,
+/obj/random/snack,
 /obj/structure/closet/walllocker_double/south{
 	name = "Storage Locker"
 	},
-/turf/simulated/floor/tiled/techfloor{
-	nitrogen = 0;
-	oxygen = 0
-	},
-/area/shuttle/salamander_wreck)
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/salamander_trader)
 "mO" = (
-/obj/random/empty_or_lootable_crate,
-/obj/machinery/light/flicker,
+/obj/machinery/light,
+/obj/random/firstaid,
+/obj/random/firstaid,
+/obj/random/firstaid,
+/obj/random/firstaid,
+/obj/random/firstaid,
+/obj/random/contraband/nofail,
+/obj/random/contraband/nofail,
+/obj/random/cigarettes,
+/obj/random/drinkbottle,
+/obj/random/drinkbottle,
+/obj/random/snack,
 /obj/structure/closet/walllocker_double/south{
 	name = "Storage Locker"
 	},
-/turf/simulated/floor/tiled/techfloor{
-	nitrogen = 0;
-	oxygen = 0
-	},
-/area/shuttle/salamander_wreck)
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/salamander_trader)
 "mR" = (
 /turf/simulated/wall/shull,
-/area/shuttle/salamander_wreck_galley)
+/area/shuttle/salamander_trader_galley)
 "mY" = (
-/obj/machinery/computer/ship/sensors,
-/turf/simulated/floor/tiled/techfloor{
-	nitrogen = 0;
-	oxygen = 0
+/obj/machinery/computer/ship/sensors{
+	req_one_access = list(160)
 	},
-/area/shuttle/salamander_wreck_cockpit)
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/salamander_trader_cockpit)
 "nB" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -1007,45 +1009,45 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/turf/simulated/floor/tiled/techfloor{
-	nitrogen = 0;
-	oxygen = 0
-	},
-/area/shuttle/salamander_wreck_q2)
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/salamander_trader_q2)
 "nE" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/airless,
-/area/shuttle/salamander_wreck_engineering)
+/turf/simulated/floor/plating,
+/area/shuttle/salamander_trader_engineering)
 "nH" = (
 /turf/simulated/wall/shull,
-/area/shuttle/salamander_wreck_cockpit)
+/area/shuttle/salamander_trader_cockpit)
 "nP" = (
-/turf/simulated/floor/airless,
-/area/shuttle/salamander_wreck_engineering)
+/obj/machinery/light/small,
+/turf/simulated/floor/plating,
+/area/shuttle/salamander_trader_engineering)
 "nX" = (
-/obj/random/empty_or_lootable_crate,
-/turf/simulated/floor/airless,
-/area/shuttle/salamander_wreck_engineering)
+/obj/structure/closet/crate{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/salamander_trader_engineering)
 "oa" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/outline/red,
 /obj/machinery/portable_atmospherics/canister/empty,
-/turf/simulated/floor/airless,
-/area/shuttle/salamander_wreck_engineering)
+/turf/simulated/floor/plating,
+/area/shuttle/salamander_trader_engineering)
 "oc" = (
 /obj/machinery/door/airlock/hatch{
-	req_one_access = list()
+	req_one_access = list(160)
 	},
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/tiled/techmaint,
-/area/shuttle/salamander_wreck)
+/area/shuttle/salamander_trader)
 "oe" = (
 /obj/machinery/door/airlock/glass_external/public,
 /obj/effect/map_helper/airlock/door/int_door,
 /turf/simulated/floor/tiled/techmaint,
-/area/shuttle/salamander_wreck)
+/area/shuttle/salamander_trader)
 "oi" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
 /obj/item/weapon/storage/box/donkpockets,
@@ -1055,27 +1057,24 @@
 /obj/random/snack,
 /obj/random/snack,
 /obj/random/snack,
-/turf/simulated/floor/tiled/techfloor{
-	nitrogen = 0;
-	oxygen = 0
-	},
-/area/shuttle/salamander_wreck_galley)
+/obj/random/snack,
+/obj/random/snack,
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/salamander_trader_galley)
 "ot" = (
 /obj/machinery/door/firedoor/glass,
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
 /turf/simulated/floor/plating,
-/area/shuttle/salamander_wreck_cockpit)
+/area/shuttle/salamander_trader_cockpit)
 "oC" = (
 /obj/machinery/pointdefense_control{
-	id_tag = "salamander_wreck_pd";
-	name = "salamander defense control"
+	id_tag = "salamander_pd";
+	name = "salamander defense control";
+	req_one_access = list(160)
 	},
-/turf/simulated/floor/tiled/techfloor{
-	nitrogen = 0;
-	oxygen = 0
-	},
-/area/shuttle/salamander_wreck_cockpit)
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/salamander_trader_cockpit)
 "oF" = (
 /obj/structure/bed/pod,
 /obj/item/weapon/bedsheet/blue,
@@ -1083,21 +1082,19 @@
 	dir = 4;
 	pixel_x = 22
 	},
-/turf/simulated/floor/tiled/techfloor{
-	nitrogen = 0;
-	oxygen = 0
-	},
-/area/shuttle/salamander_wreck_q2)
+/obj/effect/landmark/late_antag/trader,
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/salamander_trader_q1)
 "oI" = (
 /obj/structure/closet/autolok_wall{
 	pixel_y = 32
 	},
 /turf/simulated/floor/plating,
-/area/shuttle/salamander_wreck)
+/area/shuttle/salamander_trader)
 "oL" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/turf/simulated/floor/tiled/techmaint/airless,
-/area/shuttle/salamander_wreck)
+/turf/simulated/floor/tiled/techmaint,
+/area/shuttle/salamander_trader)
 "pf" = (
 /obj/structure/handrail,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1106,8 +1103,8 @@
 /obj/machinery/light_switch{
 	pixel_y = 23
 	},
-/turf/simulated/floor/tiled/techmaint/airless,
-/area/shuttle/salamander_wreck)
+/turf/simulated/floor/tiled/techmaint,
+/area/shuttle/salamander_trader)
 "px" = (
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 1
@@ -1117,7 +1114,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating,
-/area/shuttle/salamander_wreck)
+/area/shuttle/salamander_trader)
 "pG" = (
 /obj/machinery/door/blast/shutters{
 	density = 0;
@@ -1131,10 +1128,11 @@
 /obj/machinery/door/window/brigdoor/eastleft{
 	layer = 2.9;
 	open_layer = 2.9;
-	req_access = list()
+	req_access = list();
+	req_one_access = list(160)
 	},
-/turf/simulated/floor/tiled/techmaint/airless,
-/area/shuttle/salamander_wreck)
+/turf/simulated/floor/tiled/techmaint,
+/area/shuttle/salamander_trader)
 "pH" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8
@@ -1142,7 +1140,7 @@
 /obj/effect/map_helper/airlock/atmos/chamber_pump,
 /obj/structure/closet/walllocker/emerglocker/east,
 /turf/simulated/floor/tiled/techmaint,
-/area/shuttle/salamander_wreck)
+/area/shuttle/salamander_trader)
 "qg" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -1157,19 +1155,22 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/techmaint/airless,
-/area/shuttle/salamander_wreck)
+/turf/simulated/floor/tiled/techmaint,
+/area/shuttle/salamander_trader)
 "qh" = (
-/obj/machinery/computer/shuttle_control/explore/salamander_wreck{
+/obj/machinery/computer/shuttle_control/explore/salamander_trader{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/techfloor{
-	nitrogen = 0;
-	oxygen = 0
-	},
-/area/shuttle/salamander_wreck_cockpit)
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/salamander_trader_cockpit)
 "qn" = (
+/obj/structure/bed/chair/bay/chair,
 /obj/structure/handrail,
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_y = 24
+	},
 /obj/structure/cable{
 	d2 = 4;
 	icon_state = "0-4"
@@ -1181,54 +1182,53 @@
 	dir = 8;
 	pixel_x = -32
 	},
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_y = 24;
-	start_charge = 0
-	},
-/obj/structure/bed/chair/bay/chair{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor{
-	nitrogen = 0;
-	oxygen = 0
-	},
-/area/shuttle/salamander_wreck_q2)
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/salamander_trader_q2)
 "qu" = (
 /obj/structure/table/steel,
 /obj/machinery/light_switch{
 	dir = 8;
 	pixel_x = -22
 	},
+/obj/random/pizzabox,
 /obj/structure/closet/walllocker_double/kitchen/south,
-/turf/simulated/floor/tiled/techfloor{
-	nitrogen = 0;
-	oxygen = 0
-	},
-/area/shuttle/salamander_wreck_galley)
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/salamander_trader_galley)
 "qx" = (
-/obj/machinery/light/small/flicker,
+/obj/machinery/light/small,
 /turf/simulated/floor/plating,
-/area/shuttle/salamander_wreck)
+/area/shuttle/salamander_trader)
 "qE" = (
 /obj/structure/handrail{
 	dir = 1
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
-/area/shuttle/salamander_wreck)
-"qQ" = (
-/obj/random/empty_or_lootable_crate,
+/area/shuttle/salamander_trader)
+"qM" = (
+/obj/structure/closet/crate{
+	dir = 8
+	},
+/obj/random/multiple/voidsuit/vintage,
 /turf/simulated/floor/plating,
-/area/shuttle/salamander_wreck)
+/area/shuttle/salamander_trader)
+"qQ" = (
+/obj/structure/closet/crate{
+	dir = 8
+	},
+/obj/random/material/refined,
+/obj/random/material/refined,
+/obj/random/toolbox,
+/turf/simulated/floor/plating,
+/area/shuttle/salamander_trader)
 "ri" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 1
 	},
+/obj/machinery/portable_atmospherics/canister/air/airlock,
 /obj/effect/floor_decal/industrial/outline,
 /turf/simulated/floor/plating,
-/area/shuttle/salamander_wreck)
+/area/shuttle/salamander_trader)
 "rj" = (
 /obj/machinery/door/firedoor/glass,
 /obj/structure/grille,
@@ -1237,18 +1237,19 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/shuttle/salamander_wreck_cockpit)
+/area/shuttle/salamander_trader_cockpit)
 "rt" = (
+/obj/structure/bed/chair/bay/chair{
+	dir = 4
+	},
 /obj/machinery/button/remote/blast_door{
 	id = "trade";
 	name = "Shop Shutters";
-	pixel_y = -26
+	pixel_y = -26;
+	req_access = list(160)
 	},
-/obj/structure/bed/chair/bay/chair{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techmaint/airless,
-/area/shuttle/salamander_wreck)
+/turf/simulated/floor/tiled/techmaint,
+/area/shuttle/salamander_trader)
 "rw" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -1256,13 +1257,12 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
-/turf/simulated/floor/tiled/techmaint/airless,
-/area/shuttle/salamander_wreck)
+/turf/simulated/floor/tiled/techmaint,
+/area/shuttle/salamander_trader)
 "ry" = (
 /obj/machinery/door/window/brigdoor/eastright{
-	density = 0;
-	icon_state = "rightsecureopen";
-	req_access = list()
+	req_access = list();
+	req_one_access = list(160)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -1272,8 +1272,14 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/techmaint/airless,
-/area/shuttle/salamander_wreck)
+/turf/simulated/floor/tiled/techmaint,
+/area/shuttle/salamander_trader)
+"rP" = (
+/obj/structure/hull_corner{
+	dir = 8
+	},
+/turf/template_noop,
+/area/shuttle/salamander_trader_head)
 "sb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
@@ -1281,18 +1287,34 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/techmaint/airless,
-/area/shuttle/salamander_wreck_engineering)
+/turf/simulated/floor/tiled/techmaint,
+/area/shuttle/salamander_trader_engineering)
+"tn" = (
+/obj/machinery/door/firedoor/glass,
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/salamander_trader_q2)
+"ts" = (
+/obj/structure/hull_corner,
+/turf/template_noop,
+/area/shuttle/salamander_trader)
 "tA" = (
 /obj/machinery/power/pointdefense{
-	id_tag = "salamander_wreck_pd"
+	id_tag = "salamander_pd"
 	},
-/turf/simulated/floor/airless,
-/area/shuttle/salamander_wreck_engineering)
-"tL" = (
-/obj/structure/girder,
-/turf/simulated/floor/airless,
-/area/shuttle/salamander_wreck_engineering)
+/turf/simulated/floor/plating,
+/area/shuttle/salamander_trader_engineering)
+"uf" = (
+/obj/structure/hull_corner{
+	dir = 1
+	},
+/turf/template_noop,
+/area/shuttle/salamander_trader_galley)
 "ur" = (
 /obj/machinery/door/firedoor/glass,
 /obj/structure/grille,
@@ -1302,7 +1324,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/shuttle/salamander_wreck_cockpit)
+/area/shuttle/salamander_trader_cockpit)
 "vi" = (
 /obj/structure/table/steel,
 /obj/machinery/microwave/advanced,
@@ -1311,23 +1333,8 @@
 	pixel_x = 26
 	},
 /obj/machinery/light,
-/turf/simulated/floor/tiled/techfloor{
-	nitrogen = 0;
-	oxygen = 0
-	},
-/area/shuttle/salamander_wreck_galley)
-"vt" = (
-/obj/structure/bed/pod,
-/obj/item/weapon/bedsheet/blue,
-/obj/machinery/alarm/alarms_hidden{
-	dir = 8;
-	pixel_x = 26
-	},
-/turf/simulated/floor/tiled/techfloor{
-	nitrogen = 0;
-	oxygen = 0
-	},
-/area/shuttle/salamander_wreck_q1)
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/salamander_trader_galley)
 "vI" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -1337,15 +1344,19 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/techmaint/airless,
-/area/shuttle/salamander_wreck_cockpit)
+/turf/simulated/floor/tiled/techmaint,
+/area/shuttle/salamander_trader_cockpit)
+"wq" = (
+/obj/structure/hull_corner,
+/turf/template_noop,
+/area/shuttle/salamander_trader_engineering)
 "wF" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 6
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
-/area/shuttle/salamander_wreck)
+/area/shuttle/salamander_trader)
 "xL" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -1355,12 +1366,16 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/item/weapon/tank/phoron/pressurized,
+/obj/item/clothing/shoes/boots/workboots,
+/obj/item/clothing/gloves/duty,
+/obj/item/clothing/under/utility,
+/obj/item/clothing/ears/earmuffs,
+/obj/item/clothing/head/soft/black,
 /obj/structure/closet/walllocker_double/south{
 	name = "Uniform Locker"
 	},
-/turf/simulated/floor/tiled/techmaint/airless,
-/area/shuttle/salamander_wreck)
+/turf/simulated/floor/tiled/techmaint,
+/area/shuttle/salamander_trader)
 "yv" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -1370,18 +1385,17 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/light/flicker,
+/obj/machinery/light,
+/obj/item/clothing/shoes/boots/workboots,
+/obj/item/clothing/gloves/duty,
+/obj/item/clothing/under/utility,
+/obj/item/clothing/ears/earmuffs,
+/obj/item/clothing/head/soft/black,
 /obj/structure/closet/walllocker_double/south{
 	name = "Uniform Locker"
 	},
-/turf/simulated/floor/tiled/techmaint/airless,
-/area/shuttle/salamander_wreck)
-"zx" = (
-/obj/structure/hull_corner{
-	dir = 8
-	},
-/turf/template_noop,
-/area/shuttle/salamander_wreck_head)
+/turf/simulated/floor/tiled/techmaint,
+/area/shuttle/salamander_trader)
 "zO" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -1394,40 +1408,26 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/techfloor{
-	nitrogen = 0;
-	oxygen = 0
-	},
-/area/shuttle/salamander_wreck_engineering)
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/salamander_trader_engineering)
 "zQ" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/techfloor{
-	nitrogen = 0;
-	oxygen = 0
-	},
-/area/shuttle/salamander_wreck_q2)
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/salamander_trader_q2)
 "AD" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/fuel,
 /obj/structure/catwalk,
-/turf/simulated/floor/airless,
-/area/shuttle/salamander_wreck_engineering)
-"AK" = (
-/obj/structure/bed/pod,
-/obj/item/weapon/bedsheet/blue,
-/obj/machinery/light_switch{
-	dir = 4;
-	pixel_x = 22
-	},
-/turf/simulated/floor/tiled/techfloor{
-	nitrogen = 0;
-	oxygen = 0
-	},
-/area/shuttle/salamander_wreck_q1)
+/turf/simulated/floor/plating,
+/area/shuttle/salamander_trader_engineering)
 "AN" = (
 /obj/structure/handrail{
 	dir = 1
+	},
+/obj/machinery/power/apc{
+	name = "south bump";
+	pixel_y = -24
 	},
 /obj/structure/cable{
 	d2 = 4;
@@ -1440,68 +1440,61 @@
 	dir = 8;
 	pixel_x = -32
 	},
-/obj/machinery/power/apc{
-	name = "south bump";
-	pixel_y = -24;
-	start_charge = 0
-	},
-/turf/simulated/floor/tiled/techfloor{
-	nitrogen = 0;
-	oxygen = 0
-	},
-/area/shuttle/salamander_wreck_q1)
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/salamander_trader_q1)
 "Bf" = (
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/random/empty_or_lootable_crate,
+/obj/random/tech_supply/component/nofail,
+/obj/random/tech_supply/component/nofail,
+/obj/random/tech_supply/component/nofail,
+/obj/random/tech_supply/component/nofail,
+/obj/random/tech_supply/component/nofail,
+/obj/random/contraband/nofail,
+/obj/random/contraband/nofail,
+/obj/random/powercell,
+/obj/random/powercell,
+/obj/random/drinksoft,
+/obj/random/drinksoft,
+/obj/random/snack,
 /obj/structure/closet/walllocker_double/north{
 	name = "Storage Locker"
 	},
-/turf/simulated/floor/tiled/techfloor{
-	nitrogen = 0;
-	oxygen = 0
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/salamander_trader)
+"Bu" = (
+/obj/structure/hull_corner{
+	dir = 4
 	},
-/area/shuttle/salamander_wreck)
-"BE" = (
-/obj/effect/map_helper/airlock/door/int_door,
-/obj/machinery/door/airlock/glass_external/public{
-	density = 0;
-	icon_state = "door_open"
-	},
-/turf/simulated/floor/tiled/techmaint/airless,
-/area/shuttle/salamander_wreck)
-"BG" = (
-/obj/structure/lattice,
-/obj/structure/grille/broken,
 /turf/template_noop,
-/area/shuttle/salamander_wreck)
+/area/shuttle/salamander_trader_engineering)
 "BW" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/techmaint/airless,
-/area/shuttle/salamander_wreck)
+/turf/simulated/floor/tiled/techmaint,
+/area/shuttle/salamander_trader)
 "Df" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/fuel{
 	dir = 4
 	},
 /obj/structure/catwalk,
-/turf/simulated/floor/airless,
-/area/shuttle/salamander_wreck_engineering)
+/turf/simulated/floor/plating,
+/area/shuttle/salamander_trader_engineering)
 "DB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/techmaint/airless,
-/area/shuttle/salamander_wreck_cockpit)
+/turf/simulated/floor/tiled/techmaint,
+/area/shuttle/salamander_trader_cockpit)
 "DK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
 /turf/simulated/wall/shull,
-/area/shuttle/salamander_wreck)
+/area/shuttle/salamander_trader)
 "DM" = (
 /obj/machinery/door/firedoor/glass,
 /obj/structure/grille,
@@ -1511,28 +1504,30 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating,
-/area/shuttle/salamander_wreck_galley)
-"EE" = (
-/obj/structure/hull_corner{
-	dir = 4
-	},
-/turf/template_noop,
-/area/shuttle/salamander_wreck_engineering)
+/area/shuttle/salamander_trader_galley)
+"ES" = (
+/obj/structure/closet/crate,
+/obj/random/material/refined,
+/obj/random/material/refined,
+/obj/random/toolbox,
+/turf/simulated/floor/plating,
+/area/shuttle/salamander_trader)
 "Fu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 5
 	},
 /obj/machinery/embedded_controller/radio/airlock/docking_port_multi{
 	dir = 4;
-	id_tag = "salamander_wreck_docking_star";
+	id_tag = "salamander_trader_docking_star";
 	name = "Starboard Airlock Control";
-	pixel_x = -22
+	pixel_x = -22;
+	req_one_access = list(160)
 	},
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/techmaint/airless,
-/area/shuttle/salamander_wreck)
+/turf/simulated/floor/tiled/techmaint,
+/area/shuttle/salamander_trader)
 "FL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
@@ -1540,32 +1535,15 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/techmaint/airless,
-/area/shuttle/salamander_wreck)
+/turf/simulated/floor/tiled/techmaint,
+/area/shuttle/salamander_trader)
 "Gj" = (
 /obj/machinery/door/firedoor/glass,
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
-/area/shuttle/salamander_wreck_cockpit)
-"Gr" = (
-/obj/machinery/door/firedoor/glass,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/airlock/voidcraft{
-	density = 0;
-	icon_state = "door_open"
-	},
-/turf/simulated/floor/tiled/techmaint/airless,
-/area/shuttle/salamander_wreck_q1)
+/area/shuttle/salamander_trader_cockpit)
 "HG" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -1578,12 +1556,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/techmaint/airless,
-/area/shuttle/salamander_wreck)
-"HQ" = (
-/obj/structure/catwalk,
-/turf/simulated/floor/airless,
-/area/shuttle/salamander_wreck)
+/turf/simulated/floor/tiled/techmaint,
+/area/shuttle/salamander_trader)
 "HR" = (
 /obj/machinery/shipsensors{
 	dir = 4
@@ -1591,15 +1565,13 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/airless,
-/area/shuttle/salamander_wreck_cockpit)
-"Il" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 9
-	},
-/turf/simulated/floor/airless,
-/area/shuttle/salamander_wreck_engineering)
+/turf/simulated/floor/plating,
+/area/shuttle/salamander_trader_cockpit)
 "IL" = (
+/obj/item/device/suit_cooling_unit,
+/obj/item/weapon/tank/air,
+/obj/item/clothing/suit/space/void/refurb,
+/obj/item/clothing/head/helmet/space/void/refurb,
 /obj/structure/handrail{
 	dir = 1
 	},
@@ -1609,11 +1581,8 @@
 /obj/structure/closet/walllocker_double/south{
 	name = "Voidsuit Locker"
 	},
-/turf/simulated/floor/tiled/techfloor{
-	nitrogen = 0;
-	oxygen = 0
-	},
-/area/shuttle/salamander_wreck)
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/salamander_trader)
 "IQ" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -1623,24 +1592,21 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
-/turf/simulated/floor/tiled/techmaint/airless,
-/area/shuttle/salamander_wreck_cockpit)
+/turf/simulated/floor/tiled/techmaint,
+/area/shuttle/salamander_trader_cockpit)
 "IR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/techmaint/airless,
-/area/shuttle/salamander_wreck)
+/turf/simulated/floor/tiled/techmaint,
+/area/shuttle/salamander_trader)
 "Jq" = (
 /obj/machinery/computer/ship/helm{
 	dir = 8;
-	req_one_access = list()
+	req_one_access = list(160)
 	},
-/turf/simulated/floor/tiled/techfloor{
-	nitrogen = 0;
-	oxygen = 0
-	},
-/area/shuttle/salamander_wreck_cockpit)
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/salamander_trader_cockpit)
 "Kn" = (
 /obj/structure/table/steel_reinforced,
 /obj/machinery/door/blast/shutters{
@@ -1656,10 +1622,11 @@
 /obj/machinery/door/window/brigdoor/eastright{
 	layer = 2.9;
 	open_layer = 2.9;
-	req_access = list()
+	req_access = list();
+	req_one_access = list(160)
 	},
-/turf/simulated/floor/tiled/techmaint/airless,
-/area/shuttle/salamander_wreck)
+/turf/simulated/floor/tiled/techmaint,
+/area/shuttle/salamander_trader)
 "Kw" = (
 /obj/effect/map_helper/airlock/sensor/chamber_sensor,
 /obj/machinery/atmospherics/pipe/manifold/hidden{
@@ -1667,37 +1634,39 @@
 	},
 /obj/machinery/airlock_sensor{
 	dir = 4;
-	pixel_x = -21
+	pixel_x = -21;
+	req_one_access = list(160)
 	},
-/turf/simulated/floor/tiled/techmaint/airless,
-/area/shuttle/salamander_wreck)
-"KB" = (
-/obj/structure/hull_corner,
-/turf/template_noop,
-/area/shuttle/salamander_wreck_engineering)
+/turf/simulated/floor/tiled/techmaint,
+/area/shuttle/salamander_trader)
 "KX" = (
 /obj/structure/handrail,
-/obj/random/empty_or_lootable_crate,
+/obj/random/tech_supply/nofail,
+/obj/random/tech_supply/nofail,
+/obj/random/tech_supply/nofail,
+/obj/random/tech_supply/nofail,
+/obj/random/tech_supply/nofail,
+/obj/random/contraband/nofail,
+/obj/random/contraband/nofail,
+/obj/random/powercell,
+/obj/random/powercell,
+/obj/random/drinksoft,
+/obj/random/drinksoft,
+/obj/random/snack,
 /obj/structure/closet/walllocker_double/north{
 	name = "Storage Locker"
 	},
-/turf/simulated/floor/tiled/techfloor{
-	nitrogen = 0;
-	oxygen = 0
-	},
-/area/shuttle/salamander_wreck)
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/salamander_trader)
 "Lf" = (
 /obj/effect/floor_decal/industrial/warning,
-/obj/random/empty_or_lootable_crate,
-/turf/simulated/floor/tiled/techfloor{
-	nitrogen = 0;
-	oxygen = 0
-	},
-/area/shuttle/salamander_wreck)
-"LJ" = (
-/obj/structure/lattice,
-/turf/template_noop,
-/area/shuttle/salamander_wreck_engineering)
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/salamander_trader)
+"LU" = (
+/obj/structure/closet/crate,
+/obj/random/multiple/voidsuit/vintage,
+/turf/simulated/floor/plating,
+/area/shuttle/salamander_trader)
 "No" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -1710,21 +1679,31 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/turf/simulated/floor/tiled/techfloor{
-	nitrogen = 0;
-	oxygen = 0
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/salamander_trader_galley)
+"Ns" = (
+/obj/structure/bed/pod,
+/obj/item/weapon/bedsheet/blue,
+/obj/machinery/light_switch{
+	dir = 4;
+	pixel_x = 22
 	},
-/area/shuttle/salamander_wreck_galley)
+/obj/effect/landmark/late_antag/trader,
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/salamander_trader_q2)
 "NR" = (
+/obj/structure/bed/chair/bay/chair{
+	dir = 4
+	},
 /obj/machinery/button/remote/blast_door{
 	dir = 1;
 	id = "trade";
 	name = "Shop Shutters";
-	pixel_y = 26
+	pixel_y = 26;
+	req_access = list(160)
 	},
-/obj/structure/bed/chair/bay/chair,
-/turf/simulated/floor/tiled/techmaint/airless,
-/area/shuttle/salamander_wreck)
+/turf/simulated/floor/tiled/techmaint,
+/area/shuttle/salamander_trader)
 "OI" = (
 /obj/machinery/door/blast/shutters{
 	density = 0;
@@ -1738,54 +1717,35 @@
 /obj/machinery/door/window/brigdoor/eastright{
 	layer = 2.9;
 	open_layer = 2.9;
-	req_access = list()
+	req_access = list();
+	req_one_access = list(160)
 	},
-/turf/simulated/floor/tiled/techmaint/airless,
-/area/shuttle/salamander_wreck)
+/turf/simulated/floor/tiled/techmaint,
+/area/shuttle/salamander_trader)
 "ON" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
-/obj/random/empty_or_lootable_crate,
-/turf/simulated/floor/tiled/techfloor{
-	nitrogen = 0;
-	oxygen = 0
-	},
-/area/shuttle/salamander_wreck)
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/salamander_trader)
 "OU" = (
 /obj/structure/bed/chair/bay/comfy{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/techmaint/airless,
-/area/shuttle/salamander_wreck_cockpit)
+/turf/simulated/floor/tiled/techmaint,
+/area/shuttle/salamander_trader_cockpit)
 "Pc" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/simulated/floor/airless,
-/area/shuttle/salamander_wreck)
+/turf/simulated/floor/plating,
+/area/shuttle/salamander_trader)
 "Pk" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/techmaint/airless,
-/area/shuttle/salamander_wreck)
-"Pr" = (
-/obj/machinery/power/pointdefense{
-	id_tag = "salamander_wreck_pd"
-	},
-/turf/simulated/floor/airless,
-/area/shuttle/salamander_wreck_q1)
-"Ps" = (
-/obj/structure/girder,
-/turf/simulated/floor/airless,
-/area/shuttle/salamander_wreck)
-"PF" = (
-/obj/structure/hull_corner{
-	dir = 1
-	},
-/turf/template_noop,
-/area/shuttle/salamander_wreck_galley)
+/turf/simulated/floor/tiled/techmaint,
+/area/shuttle/salamander_trader)
 "PN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
@@ -1794,11 +1754,11 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/techmaint/airless,
-/area/shuttle/salamander_wreck)
+/turf/simulated/floor/tiled/techmaint,
+/area/shuttle/salamander_trader)
 "Qn" = (
-/turf/simulated/floor/tiled/techmaint/airless,
-/area/shuttle/salamander_wreck)
+/turf/simulated/floor/tiled/techmaint,
+/area/shuttle/salamander_trader)
 "Qq" = (
 /obj/machinery/door/firedoor/glass,
 /obj/structure/cable{
@@ -1811,34 +1771,32 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/airlock/voidcraft{
-	density = 0;
-	icon_state = "door_open"
+	req_one_access = list(160)
 	},
-/turf/simulated/floor/tiled/techmaint/airless,
-/area/shuttle/salamander_wreck_galley)
-"Rb" = (
-/obj/machinery/atmospherics/unary/vent_pump{
-	dir = 8
-	},
-/obj/effect/map_helper/airlock/atmos/chamber_pump,
-/obj/structure/closet/walllocker/emerglocker/east,
-/turf/simulated/floor/tiled/techmaint/airless,
-/area/shuttle/salamander_wreck)
+/turf/simulated/floor/tiled/techmaint,
+/area/shuttle/salamander_trader_galley)
 "Rd" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
 /obj/structure/handrail,
-/obj/random/empty_or_lootable_crate,
-/obj/item/weapon/smes_coil,
+/obj/random/tech_supply/component/nofail,
+/obj/random/tech_supply/component/nofail,
+/obj/random/tech_supply/component/nofail,
+/obj/random/tech_supply/component/nofail,
+/obj/random/tech_supply/component/nofail,
+/obj/random/contraband/nofail,
+/obj/random/contraband/nofail,
+/obj/random/powercell,
+/obj/random/powercell,
+/obj/random/drinksoft,
+/obj/random/drinksoft,
+/obj/random/snack,
 /obj/structure/closet/walllocker_double/north{
 	name = "Storage Locker"
 	},
-/turf/simulated/floor/tiled/techfloor{
-	nitrogen = 0;
-	oxygen = 0
-	},
-/area/shuttle/salamander_wreck)
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/salamander_trader)
 "RO" = (
 /obj/structure/bed/pod,
 /obj/item/weapon/bedsheet/blue,
@@ -1846,20 +1804,15 @@
 	dir = 8;
 	pixel_x = 26
 	},
-/turf/simulated/floor/tiled/techfloor{
-	nitrogen = 0;
-	oxygen = 0
-	},
-/area/shuttle/salamander_wreck_q2)
+/obj/effect/landmark/late_antag/trader,
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/salamander_trader_q1)
 "RU" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/techfloor{
-	nitrogen = 0;
-	oxygen = 0
-	},
-/area/shuttle/salamander_wreck_galley)
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/salamander_trader_galley)
 "Sb" = (
 /obj/structure/table/steel_reinforced,
 /obj/machinery/door/blast/shutters{
@@ -1879,19 +1832,16 @@
 /obj/machinery/door/window/brigdoor/eastleft{
 	layer = 2.9;
 	open_layer = 2.9;
-	req_access = list()
+	req_access = list();
+	req_one_access = list(160)
 	},
-/turf/simulated/floor/tiled/techmaint/airless,
-/area/shuttle/salamander_wreck)
+/turf/simulated/floor/tiled/techmaint,
+/area/shuttle/salamander_trader)
 "Sp" = (
 /obj/structure/table/steel,
 /obj/machinery/light,
-/obj/item/weapon/paper/unity_notice,
-/turf/simulated/floor/tiled/techfloor{
-	nitrogen = 0;
-	oxygen = 0
-	},
-/area/shuttle/salamander_wreck_q2)
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/salamander_trader_q2)
 "Td" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -1901,23 +1851,23 @@
 /obj/structure/railing/grey{
 	dir = 8
 	},
-/obj/structure/table/steel,
-/obj/structure/fuel_port/empty{
+/obj/structure/fuel_port/heavy{
 	pixel_y = 28
 	},
-/obj/machinery/light/flicker{
+/obj/structure/table/steel,
+/obj/machinery/light{
 	dir = 1
 	},
-/obj/item/weapon/smes_coil,
-/turf/simulated/floor/tiled/techfloor{
-	nitrogen = 0;
-	oxygen = 0
-	},
-/area/shuttle/salamander_wreck_engineering)
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/salamander_trader_engineering)
 "Tg" = (
 /turf/simulated/wall/shull,
-/area/shuttle/salamander_wreck_head)
+/area/shuttle/salamander_trader_head)
 "Tl" = (
+/obj/item/device/suit_cooling_unit,
+/obj/item/weapon/tank/air,
+/obj/item/clothing/suit/space/void/refurb,
+/obj/item/clothing/head/helmet/space/void/refurb,
 /obj/structure/railing/grey{
 	dir = 8
 	},
@@ -1933,66 +1883,45 @@
 /obj/structure/closet/walllocker_double/south{
 	name = "Voidsuit Locker"
 	},
-/turf/simulated/floor/tiled/techfloor{
-	nitrogen = 0;
-	oxygen = 0
-	},
-/area/shuttle/salamander_wreck)
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/salamander_trader)
 "TG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
 	},
 /obj/machinery/door/window/brigdoor/westright{
-	density = 0;
-	icon_state = "rightsecureopen";
-	req_access = list()
+	req_access = list();
+	req_one_access = list(160)
 	},
-/turf/simulated/floor/tiled/techmaint/airless,
-/area/shuttle/salamander_wreck)
-"UB" = (
-/obj/machinery/door/firedoor/glass,
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/shuttle/salamander_wreck_q1)
+/turf/simulated/floor/tiled/techmaint,
+/area/shuttle/salamander_trader)
 "UT" = (
-/obj/machinery/door/airlock/glass_external/public{
-	density = 0;
-	icon_state = "door_open"
-	},
+/obj/machinery/door/airlock/glass_external/public,
 /obj/effect/map_helper/airlock/door/ext_door,
-/turf/simulated/floor/tiled/techmaint/airless,
-/area/shuttle/salamander_wreck)
+/turf/simulated/floor/tiled/techmaint,
+/area/shuttle/salamander_trader)
 "Vh" = (
 /obj/structure/cable{
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/structure/handrail{
-	dir = 8
-	},
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "east bump";
-	pixel_x = 24;
-	start_charge = 0
+	pixel_x = 24
 	},
-/turf/simulated/floor/tiled/techfloor{
-	nitrogen = 0;
-	oxygen = 0
+/obj/structure/handrail{
+	dir = 8
 	},
-/area/shuttle/salamander_wreck_engineering)
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/salamander_trader_engineering)
 "Vs" = (
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
-/area/shuttle/salamander_wreck)
+/area/shuttle/salamander_trader)
 "Vz" = (
 /turf/simulated/wall/shull,
-/area/shuttle/salamander_wreck_q2)
+/area/shuttle/salamander_trader_q1)
 "VK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -2004,25 +1933,31 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 4
 	},
-/turf/simulated/floor/airless,
-/area/shuttle/salamander_wreck_engineering)
+/turf/simulated/floor/plating,
+/area/shuttle/salamander_trader_engineering)
 "VT" = (
 /turf/simulated/wall/shull,
-/area/shuttle/salamander_wreck)
+/area/shuttle/salamander_trader)
 "VW" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 5
 	},
 /obj/structure/catwalk,
-/turf/simulated/floor/airless,
-/area/shuttle/salamander_wreck)
+/turf/simulated/floor/plating,
+/area/shuttle/salamander_trader)
 "Wj" = (
 /turf/simulated/wall/shull,
-/area/shuttle/salamander_wreck_engineering)
+/area/shuttle/salamander_trader_engineering)
 "Wv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/universal,
-/turf/simulated/floor/airless,
-/area/shuttle/salamander_wreck_engineering)
+/turf/simulated/floor/plating,
+/area/shuttle/salamander_trader_engineering)
+"WI" = (
+/obj/structure/hull_corner{
+	dir = 4
+	},
+/turf/template_noop,
+/area/shuttle/salamander_trader)
 "WN" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -2030,11 +1965,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/multi_tile/metal{
-	density = 0;
 	dir = 2;
-	icon_state = "door_open";
 	name = "Salamander Engineering Bay";
-	opacity = 0
+	req_one_access = list(160)
 	},
 /obj/machinery/door/firedoor/multi_tile{
 	dir = 1
@@ -2042,16 +1975,23 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/techmaint/airless,
-/area/shuttle/salamander_wreck_engineering)
+/turf/simulated/floor/tiled/techmaint,
+/area/shuttle/salamander_trader_engineering)
 "WP" = (
 /turf/template_noop,
 /area/template_noop)
 "WW" = (
-/obj/random/empty_or_lootable_crate,
-/turf/simulated/floor/airless,
-/area/shuttle/salamander_wreck)
+/obj/structure/closet/crate{
+	dir = 1
+	},
+/obj/random/multiple/voidsuit/vintage,
+/turf/simulated/floor/plating,
+/area/shuttle/salamander_trader)
 "Xc" = (
+/obj/item/device/suit_cooling_unit,
+/obj/item/weapon/tank/air,
+/obj/item/clothing/suit/space/void/refurb,
+/obj/item/clothing/head/helmet/space/void/refurb,
 /obj/structure/railing/grey{
 	dir = 8
 	},
@@ -2065,35 +2005,36 @@
 /obj/structure/closet/walllocker_double/north{
 	name = "Voidsuit Locker"
 	},
-/turf/simulated/floor/tiled/techfloor{
-	nitrogen = 0;
-	oxygen = 0
-	},
-/area/shuttle/salamander_wreck)
-"Xj" = (
-/obj/structure/hull_corner,
-/turf/template_noop,
-/area/shuttle/salamander_wreck)
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/salamander_trader)
 "Xn" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
 	},
 /obj/structure/handrail,
-/obj/random/empty_or_lootable_crate,
+/obj/random/tech_supply/nofail,
+/obj/random/tech_supply/nofail,
+/obj/random/tech_supply/nofail,
+/obj/random/tech_supply/nofail,
+/obj/random/tech_supply/nofail,
+/obj/random/contraband/nofail,
+/obj/random/contraband/nofail,
+/obj/random/powercell,
+/obj/random/powercell,
+/obj/random/drinksoft,
+/obj/random/drinksoft,
+/obj/random/snack,
 /obj/structure/closet/walllocker_double/north{
 	name = "Storage Locker"
 	},
-/turf/simulated/floor/tiled/techfloor{
-	nitrogen = 0;
-	oxygen = 0
-	},
-/area/shuttle/salamander_wreck)
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/salamander_trader)
 "Xr" = (
 /obj/machinery/atmospherics/pipe/manifold/visible,
 /obj/structure/catwalk,
-/obj/machinery/light/small/flicker,
-/turf/simulated/floor/airless,
-/area/shuttle/salamander_wreck)
+/obj/machinery/light/small,
+/turf/simulated/floor/plating,
+/area/shuttle/salamander_trader)
 "Xs" = (
 /obj/machinery/power/port_gen/pacman/mrs{
 	anchored = 1
@@ -2109,48 +2050,51 @@
 	dir = 4;
 	pixel_x = 22
 	},
-/turf/simulated/floor/tiled/techfloor{
-	nitrogen = 0;
-	oxygen = 0
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/salamander_trader_engineering)
+"Xu" = (
+/obj/structure/bed/pod,
+/obj/item/weapon/bedsheet/blue,
+/obj/machinery/alarm/alarms_hidden{
+	dir = 8;
+	pixel_x = 26
 	},
-/area/shuttle/salamander_wreck_engineering)
+/obj/effect/landmark/late_antag/trader,
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/salamander_trader_q2)
 "XJ" = (
 /obj/structure/handrail,
 /obj/structure/catwalk,
-/turf/simulated/floor/airless,
-/area/shuttle/salamander_wreck)
+/turf/simulated/floor/plating,
+/area/shuttle/salamander_trader)
 "ZK" = (
 /obj/structure/closet/autolok_wall{
 	dir = 1;
 	pixel_y = -32
 	},
-/turf/simulated/floor/airless,
-/area/shuttle/salamander_wreck)
+/turf/simulated/floor/plating,
+/area/shuttle/salamander_trader)
 "ZU" = (
 /obj/machinery/embedded_controller/radio/docking_port_multi{
 	child_names_txt = "Port Airlock Control;Starboard Airlock Control";
-	child_tags_txt = "salamander_wreck_docking_port;salamander_wreck_docking_star";
+	child_tags_txt = "salamander_trader_docking_port;salamander_trader_docking_star";
 	dir = 1;
-	id_tag = "salamander_docking";
-	name = "Salamander Master Docking Controller";
+	id_tag = "salamander_trader_docking";
+	name = "Salamander Trader Master Docking Controller";
 	pixel_y = -22
+	},
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
 	},
 /obj/structure/cable,
 /obj/machinery/light,
 /obj/structure/railing/grey{
 	dir = 8
 	},
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24;
-	start_charge = 0
-	},
-/turf/simulated/floor/tiled/techfloor{
-	nitrogen = 0;
-	oxygen = 0
-	},
-/area/shuttle/salamander_wreck)
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/salamander_trader)
 
 (1,1,1) = {"
 WP
@@ -2174,16 +2118,16 @@ WP
 WP
 WP
 WP
-KB
+wq
 Wj
-nP
+dj
 fn
 Wj
 Wj
-nP
+dj
 fn
 Wj
-EE
+Bu
 WP
 WP
 WP
@@ -2210,7 +2154,7 @@ WP
 WP
 WP
 WP
-tL
+Wj
 Wj
 dn
 dn
@@ -2219,7 +2163,7 @@ Wj
 dn
 lt
 Wj
-LJ
+Wj
 WP
 WP
 WP
@@ -2228,16 +2172,16 @@ WP
 WP
 WP
 WP
-nP
-nP
+Wj
+bA
 dT
-nP
+fC
 gD
 hC
 ee
+lC
 nP
-nP
-LJ
+Wj
 WP
 WP
 WP
@@ -2246,16 +2190,16 @@ WP
 WP
 WP
 WP
-tL
-nX
+Wj
+bH
 ee
 fD
 AD
 Df
 kx
-Il
+fC
 nX
-LJ
+Wj
 WP
 WP
 WP
@@ -2298,7 +2242,7 @@ WP
 "}
 (9,1,1) = {"
 WP
-Xj
+ts
 VT
 VT
 Wj
@@ -2311,7 +2255,7 @@ lV
 Wj
 VT
 VT
-bq
+WI
 WP
 "}
 (10,1,1) = {"
@@ -2327,7 +2271,7 @@ is
 kL
 ma
 Wj
-qQ
+WW
 VT
 VT
 WP
@@ -2354,7 +2298,7 @@ WP
 WP
 VT
 XJ
-HQ
+Vs
 bL
 eB
 fG
@@ -2370,9 +2314,9 @@ WP
 "}
 (13,1,1) = {"
 WP
-BG
-WW
-HQ
+VT
+LU
+Vs
 VT
 Xn
 fP
@@ -2382,15 +2326,15 @@ kZ
 mE
 VT
 Vs
-qQ
+qM
 VT
 WP
 "}
 (14,1,1) = {"
 WP
-BG
-WW
-HQ
+VT
+ES
+Vs
 VT
 KX
 Lf
@@ -2406,9 +2350,9 @@ WP
 "}
 (15,1,1) = {"
 WP
-BG
-WW
-HQ
+VT
+ES
+Vs
 VT
 Bf
 Lf
@@ -2418,13 +2362,13 @@ ON
 mO
 VT
 Vs
-gx
+qQ
 VT
 WP
 "}
 (16,1,1) = {"
 WP
-Ps
+VT
 lw
 VW
 VT
@@ -2488,7 +2432,7 @@ hh
 iC
 Qn
 Qn
-BE
+oe
 Kw
 Fu
 UT
@@ -2506,9 +2450,9 @@ IR
 iC
 Qn
 eJ
-BE
-Rb
-Rb
+oe
+pH
+pH
 mg
 WP
 "}
@@ -2532,7 +2476,7 @@ WP
 "}
 (22,1,1) = {"
 WP
-zx
+rP
 Tg
 br
 cq
@@ -2545,7 +2489,7 @@ mR
 bI
 qu
 mR
-PF
+uf
 WP
 "}
 (23,1,1) = {"
@@ -2605,18 +2549,18 @@ WP
 (26,1,1) = {"
 WP
 WP
-Pr
-el
+bk
+Vz
 cY
 AN
-el
+Vz
 hn
 yv
-Vz
+de
 qn
 Sp
-Vz
-bk
+de
+aO
 WP
 WP
 "}
@@ -2624,16 +2568,16 @@ WP
 WP
 WP
 WP
-UB
+ci
 eG
 gl
-Gr
+ld
 hp
 jT
-ld
+iq
 nB
 zQ
-ci
+tn
 WP
 WP
 WP
@@ -2642,16 +2586,16 @@ WP
 WP
 WP
 WP
-el
-AK
-vt
-el
+Vz
+oF
+RO
+Vz
 fh
 xL
-Vz
-RO
-oF
-Vz
+de
+Xu
+Ns
+de
 WP
 WP
 WP
@@ -2660,16 +2604,16 @@ WP
 WP
 WP
 WP
-el
-el
-el
-el
+Vz
+Vz
+Vz
+Vz
 DB
 jV
-Vz
-Vz
-Vz
-Vz
+de
+de
+de
+de
 WP
 WP
 WP
@@ -2719,7 +2663,7 @@ WP
 jl
 mY
 OU
-hK
+OU
 lo
 Gj
 WP

--- a/maps/tether/submaps/_tether_submaps.dm
+++ b/maps/tether/submaps/_tether_submaps.dm
@@ -57,6 +57,7 @@
 
 #include "../../submaps/admin_use_vr/ert.dm"
 #include "../../submaps/admin_use_vr/mercship.dm"
+#include "../../submaps/admin_use_vr/salamander_trader.dm"
 
 /datum/map_template/admin_use/ert
 	name = "Special Area - ERT"
@@ -71,7 +72,7 @@
 /datum/map_template/admin_use/salamander_trader
 	name = "Special Area - Salamander Trader"
 	desc = "Modest trader ship."
-	mappath = 'maps/offmap_vr/om_ships/salamander.dmm'
+	mappath = 'maps/submaps/admin_use_vr/salamander_trader.dmm'
 
 /datum/map_template/admin_use/mercenary
 	name = "Special Area - Merc Ship"


### PR DESCRIPTION
Boy, it's been a while since I made a PR hasn't it? Not dead, just distracted by RL stuff.

Anyway, simple PR, three purposes;
1. Fixes #11394, by seperating out the special Trader Salamander into its own submap under the admin_use section, assigning it its own areas, docking tags, and so on. Lightly tested, seems to be OK.
2. Fixes the Crew Quarters for all three Salamanders being wrong (both sets of quarters were assigned to the same area, when they should've been seperate areas, oops).
3. Fixes cabinet-style wall lockers getting bamboozled by animated doors from #11368.