### PR TITLE
Fixes telecomms teleporter access

### DIFF
--- a/maps/tether/tether-05-station1.dmm
+++ b/maps/tether/tether-05-station1.dmm
@@ -16879,7 +16879,7 @@
 "dkG" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "Satellite Teleporter";
-	req_one_access = list(12,16,17,61)
+	req_one_access = list(17)
 	},
 /obj/structure/cable/green{
 	d1 = 4;


### PR DESCRIPTION
Before it was one of the following required: Maint Tunnel, AI Upload, Tcomms, Teleporter
Now its gonna properly be just Teleporter requirement without any extras or alternate options.