### PR TITLE
Adds *dwoop to all synths. 

### DIFF
--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -6,6 +6,7 @@ var/list/_human_default_emotes = list(
 	/decl/emote/audible/synth/confirm,
 	/decl/emote/audible/synth/deny,
 	/decl/emote/audible/synth/scary,
+	/decl/emote/audible/synth/dwoop,
 	/decl/emote/visible/nod,
 	/decl/emote/visible/shake,
 	/decl/emote/visible/shiver,


### PR DESCRIPTION
Rejoice, all synthetics who were envious of station bounds getting to chirp happily. Now all silicons can partake in *dwoop. Just one line was missing from the human/emote.dm to make this work.