### PR TITLE
Can now give custom species names during vorebelly transformations

### DIFF
--- a/code/modules/tgui/modules/appearance_changer.dm
+++ b/code/modules/tgui/modules/appearance_changer.dm
@@ -92,7 +92,8 @@
 			if(can_change(APPEARANCE_RACE) && (params["race"] in valid_species))
 				if(target.change_species(params["race"]))
 					if(params["race"] == "Custom Species")
-						target.custom_species = input(usr,"Custom Species name:","Species Name")
+						target.custom_species = sanitize(input(usr, "Input custom species name:",
+							"Custom Species Name") as null|text, MAX_NAME_LEN)
 					cut_data()
 					generate_data(usr)
 					changed_hook(APPEARANCECHANGER_CHANGED_RACE)

--- a/code/modules/tgui/modules/appearance_changer.dm
+++ b/code/modules/tgui/modules/appearance_changer.dm
@@ -91,6 +91,8 @@
 		if("race")
 			if(can_change(APPEARANCE_RACE) && (params["race"] in valid_species))
 				if(target.change_species(params["race"]))
+					if(params["race"] == "Custom Species")
+						target.custom_species = (usr,"Custom Species name:","Species Name")
 					cut_data()
 					generate_data(usr)
 					changed_hook(APPEARANCECHANGER_CHANGED_RACE)

--- a/code/modules/tgui/modules/appearance_changer.dm
+++ b/code/modules/tgui/modules/appearance_changer.dm
@@ -92,7 +92,7 @@
 			if(can_change(APPEARANCE_RACE) && (params["race"] in valid_species))
 				if(target.change_species(params["race"]))
 					if(params["race"] == "Custom Species")
-						target.custom_species = (usr,"Custom Species name:","Species Name")
+						target.custom_species = input(usr,"Custom Species name:","Species Name")
 					cut_data()
 					generate_data(usr)
 					changed_hook(APPEARANCECHANGER_CHANGED_RACE)


### PR DESCRIPTION
Prompts you for a custom race name when transforming people in a vorebelly.
Fixes #11406
![CustomRaceFix](https://user-images.githubusercontent.com/89228541/130300208-0d4e26e9-12c1-4e89-b287-86eebc2a5be3.gif)