### PR TITLE
Adds the ability to ban people from ghost roles

### DIFF
--- a/code/datums/ghost_query.dm
+++ b/code/datums/ghost_query.dm
@@ -52,6 +52,11 @@
 
 /// Send async alerts and ask for responses. Expects you to have tested D for client and type already
 /datum/ghost_query/proc/ask_question(var/mob/observer/dead/D)
+	//VOREStation Add Start		Check the ban status before we ask
+	if(jobban_isbanned(D, "GhostRoles"))
+		return
+	//VOREStation Add End
+
 	var/client/C = D.client
 	window_flash(C)
 	
@@ -67,7 +72,7 @@
 		return
 	
 	// Unhandled are "No" and "Nevermind" responses, which should just do nothing
-
+	
 	// This response is always fine, doesn't warrant retesting
 	switch(response)
 		if("Never for this round")

--- a/code/game/objects/items/devices/denecrotizer_vr.dm
+++ b/code/game/objects/items/devices/denecrotizer_vr.dm
@@ -43,7 +43,9 @@
 /mob/living/simple_mob/attack_ghost(mob/observer/dead/user as mob)
 	if(!ghostjoin)
 		return ..()
-
+	if(jobban_isbanned(user, "GhostRoles"))
+		to_chat(user, "<font color='red'><B>You cannot inhabit this creature because you are banned from playing ghost roles.</B></font>")
+		return
 	if(!evaluate_ghost_join(user))
 		return ..()
 

--- a/code/game/objects/items/devices/denecrotizer_vr.dm
+++ b/code/game/objects/items/devices/denecrotizer_vr.dm
@@ -44,7 +44,7 @@
 	if(!ghostjoin)
 		return ..()
 	if(jobban_isbanned(user, "GhostRoles"))
-		to_chat(user, "<font color='red'><B>You cannot inhabit this creature because you are banned from playing ghost roles.</B></font>")
+		to_chat(user, "<span class='warning'>You cannot inhabit this creature because you are banned from playing ghost roles.</span>")
 		return
 	if(!evaluate_ghost_join(user))
 		return ..()

--- a/code/game/objects/structures/ghost_pods/event_vr.dm
+++ b/code/game/objects/structures/ghost_pods/event_vr.dm
@@ -51,6 +51,9 @@
 	var/finalized = "No"
 
 	while(finalized == "No" && M.client)
+		if(jobban_isbanned(M, "GhostRoles"))
+			to_chat(M, "<font color='red'><B>You cannot inhabit this creature because you are banned from playing ghost roles.</B></font>")
+			return
 		choice = tgui_input_list(M, "What type of predator do you want to play as?", "Maintpred Choice", possible_mobs)
 		if(!choice)
 			randomize = TRUE

--- a/code/game/objects/structures/ghost_pods/event_vr.dm
+++ b/code/game/objects/structures/ghost_pods/event_vr.dm
@@ -52,7 +52,7 @@
 
 	while(finalized == "No" && M.client)
 		if(jobban_isbanned(M, "GhostRoles"))
-			to_chat(M, "<font color='red'><B>You cannot inhabit this creature because you are banned from playing ghost roles.</B></font>")
+			to_chat(M, "<span class='warning'>You cannot inhabit this creature because you are banned from playing ghost roles.</span>")
 			return
 		choice = tgui_input_list(M, "What type of predator do you want to play as?", "Maintpred Choice", possible_mobs)
 		if(!choice)

--- a/code/game/objects/structures/ghost_pods/ghost_pods.dm
+++ b/code/game/objects/structures/ghost_pods/ghost_pods.dm
@@ -84,6 +84,11 @@
 	description_info = "A ghost can click on this to return to the round as whatever is contained inside this object."
 
 /obj/structure/ghost_pod/ghost_activated/attack_ghost(var/mob/observer/dead/user)
+	//VOREStation Add Start
+	if(jobban_isbanned(user, "GhostRoles"))
+		to_chat(user, "<font color='red'><B>You cannot inhabit this creature because you are banned from playing ghost roles.</B></font>")
+		return
+	//VOREStation Add End
 	if(used)
 		to_chat(user, "<span class='warning'>Another spirit appears to have gotten to \the [src] before you.  Sorry.</span>")
 		return

--- a/code/game/objects/structures/ghost_pods/ghost_pods.dm
+++ b/code/game/objects/structures/ghost_pods/ghost_pods.dm
@@ -86,7 +86,7 @@
 /obj/structure/ghost_pod/ghost_activated/attack_ghost(var/mob/observer/dead/user)
 	//VOREStation Add Start
 	if(jobban_isbanned(user, "GhostRoles"))
-		to_chat(user, "<font color='red'><B>You cannot inhabit this creature because you are banned from playing ghost roles.</B></font>")
+		to_chat(user, "<span class='warning'>You cannot inhabit this creature because you are banned from playing ghost roles.</span>")
 		return
 	//VOREStation Add End
 	if(used)

--- a/code/game/objects/structures/ghost_pods/ghost_pods_vr.dm
+++ b/code/game/objects/structures/ghost_pods/ghost_pods_vr.dm
@@ -11,6 +11,10 @@
 	var/activated = FALSE
 
 /obj/structure/ghost_pod/manual/attack_ghost(var/mob/observer/dead/user)
+	if(jobban_isbanned(user, "GhostRoles"))
+		to_chat(user, "<font color='red'><B>You cannot inhabit this creature because you are banned from playing ghost roles.</B></font>")
+		return
+
 	if(!remains_active || busy)
 		return
 

--- a/code/game/objects/structures/ghost_pods/ghost_pods_vr.dm
+++ b/code/game/objects/structures/ghost_pods/ghost_pods_vr.dm
@@ -12,7 +12,7 @@
 
 /obj/structure/ghost_pod/manual/attack_ghost(var/mob/observer/dead/user)
 	if(jobban_isbanned(user, "GhostRoles"))
-		to_chat(user, "<font color='red'><B>You cannot inhabit this creature because you are banned from playing ghost roles.</B></font>")
+		to_chat(user, "<span class='warning'>You cannot inhabit this creature because you are banned from playing ghost roles.</span>")
 		return
 
 	if(!remains_active || busy)

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -591,6 +591,12 @@
 			jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=pAI;jobban4=\ref[M]'><font color=red>pAI</font></a></td>"
 		else
 			jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=pAI;jobban4=\ref[M]'>pAI</a></td>"
+		//VOREStation Add Start
+		if(jobban_isbanned(M, "GhostRoles"))
+			jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=GhostRoles;jobban4=\ref[M]'><font color=red>GhostRoles</font></a></td>"
+		else
+			jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=GhostRoles;jobban4=\ref[M]'>GhostRoles</a></td>"
+		//VOREStation Add End
 		if(jobban_isbanned(M, "AntagHUD"))
 			jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=AntagHUD;jobban4=\ref[M]'><font color=red>AntagHUD</font></a></td>"
 		else

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -638,6 +638,12 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		to_chat(src, "<span class='warning'>Spawning as a mouse is currently disabled.</span>")
 		return
 
+	//VOREStation Add Start
+	if(jobban_isbanned(src, "GhostRoles"))
+		to_chat(src, "<font color='red'><B>You cannot become a mouse because you are banned from playing ghost roles.</B></font>")
+		return
+	//VOREStation Add End
+
 	if(!MayRespawn(1))
 		return
 

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -640,7 +640,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 
 	//VOREStation Add Start
 	if(jobban_isbanned(src, "GhostRoles"))
-		to_chat(src, "<font color='red'><B>You cannot become a mouse because you are banned from playing ghost roles.</B></font>")
+		to_chat(src, "<span class='warning'>You cannot become a mouse because you are banned from playing ghost roles.</span>")
 		return
 	//VOREStation Add End
 


### PR DESCRIPTION
There are some mobs you can play as now that are PRETTY ABUSABLE, and there's some players who play fine normally, but get into trouble and take things too far when you put them in special roles, SO! Rather than just flat banning those people from the server, it would be cool if we could just, ban them from playing those roles. 

This should help with that.