### PR TITLE
fixes and tweaks for proto-kinetic melees

### DIFF
--- a/code/modules/mining/kinetic_crusher.dm
+++ b/code/modules/mining/kinetic_crusher.dm
@@ -237,6 +237,7 @@
 
 
 /obj/item/weapon/kinetic_crusher/machete
+	// general purpose. cleaves though
 	name = "proto-kinetic machete"
 	desc = "A scaled down version of a proto-kinetic crusher, used by people who don't want to lug around an axe-hammer."
 	icon_state = "glaive-machete"
@@ -247,14 +248,13 @@
 	item_state = "c-machete"
 	w_class = ITEMSIZE_SMALL
 	attack_verb = list("cleaved", "chopped", "pulped", "stabbed", "skewered")
-	force = 24
 	can_cleave = TRUE
 	requires_wield = FALSE
 	// yeah yeah buff but polaris mobs are meatwalls.
-	backstab_bonus = 40
-	detonation_damage = 26
-	// meme option
-	thrown_bonus = 20
+	force = 24
+	detonation_damage = 36 // 60
+	backstab_bonus = 40 // 100
+	thrown_bonus = 20 // 120
 	update_item_state = FALSE
 
 
@@ -269,11 +269,11 @@
 	attack_verb = list("bashed", "kicked", "punched", "struck", "axe kicked", "uppercut", "cross-punched", "jabbed", "hammerfisted", "roundhouse kicked")
 	integ_light_icon = FALSE
 	w_class = ITEMSIZE_HUGE
-	force = 30
 	can_cleave = FALSE
 	requires_wield = TRUE
-	backstab_bonus = 55
-	detonation_damage = 35
+	force = 28
+	detonation_damage = 37 // 75
+	backstab_bonus = 55 // 130
 	var/obj/item/offhand/crushergauntlets/offhand
 
 /obj/item/weapon/kinetic_crusher/machete/gauntlets/equipped()
@@ -302,21 +302,29 @@
 	var/mob/living/M = loc
 	if(istype(M) && forced == 0)
 		if(M.can_wield_item(src) && src.is_held_twohanded(M))
-			name = initial(name)
-			wielded = TRUE
-			to_chat(M, "<span class ='notice'>You ready [src].</span>")
-			var/obj/item/offhand/crushergauntlets/O = new(M)
-			O.name = "[name] - readied"
-			O.desc = "As much as you'd like to punch things with one hand, [src] is far too unwieldy for that."
-			O.linked = src
-			M.put_in_inactive_hand(O)
-			offhand = O
+			wield(M)
+		else
+			unwield(M)
 	else
-		name = "[initial(name)] (unreadied)"
-		wielded = FALSE
-		to_chat(M, "<span class ='notice'>You unready [src].</span>")
-		if(offhand)
-			QDEL_NULL(offhand)
+		unwield(M)
+
+/obj/item/weapon/kinetic_crusher/machete/gauntlets/proc/wield(var/mob/living/M)
+	name = initial(name)
+	wielded = TRUE
+	to_chat(M, "<span class ='notice'>You ready [src].</span>")
+	var/obj/item/offhand/crushergauntlets/O = new(M)
+	O.name = "[name] - readied"
+	O.desc = "As much as you'd like to punch things with one hand, [src] is far too unwieldy for that."
+	O.linked = src
+	M.put_in_inactive_hand(O)
+	offhand = O
+
+/obj/item/weapon/kinetic_crusher/machete/gauntlets/proc/unwield(var/mob/living/M)
+	to_chat(M, "<span class ='notice'>You unready [src].</span>")
+	name = "[initial(name)] (unreadied)"
+	wielded = FALSE
+	if(offhand)
+		QDEL_NULL(offhand)
 
 /obj/item/offhand
 	icon = 'icons/obj/weapons.dmi'
@@ -324,6 +332,7 @@
 	name = "offhand that shouldn't exist doo dee doo"
 	w_class = ITEMSIZE_NO_CONTAINER
 	// var/linked - redefine this wherever
+	// man i really should try porting the twohand component this is hacky and Sucks
 
 /obj/item/offhand/crushergauntlets
 	var/obj/item/weapon/kinetic_crusher/machete/gauntlets/linked
@@ -333,7 +342,7 @@
 		linked.ready_toggle(TRUE)
 
 /obj/item/weapon/kinetic_crusher/machete/gauntlets/rig
-	name = "mounted proto-kinetic gear"
+	name = "\improper mounted proto-kinetic gear"
 	var/obj/item/rig_module/gauntlets/storing_module
 
 /obj/item/weapon/kinetic_crusher/machete/gauntlets/rig/dropped(mob/user)
@@ -351,6 +360,7 @@
 	else
 		QDEL_NULL(src)
 
+// gimmicky backup for throwing
 /obj/item/weapon/kinetic_crusher/machete/dagger
 	name = "proto-kinetic dagger"
 	desc = "A scaled down version of a proto-kinetic machete, usually used in a last ditch scenario."
@@ -361,13 +371,14 @@
 			)
 	item_state = "c-knife"
 	w_class = ITEMSIZE_SMALL
-	force = 15
 	requires_wield = FALSE
 	charge_overlay = FALSE
-	backstab_bonus = 35
-	detonation_damage = 25
-	// woohoo
-	thrown_bonus = 35
+	charge_time = 10 // lowered charge in return for lowered damage
+	force = 18
+	detonation_damage = 27 // 45
+	backstab_bonus = 40 // 85
+	// gimmick mode
+	thrown_bonus = 50 // 135 but you drop your knife because you threw it
 
 
 //destablizing force
@@ -387,15 +398,18 @@
 	hammer_synced = null
 	return ..()
 
+/obj/item/projectile/destabilizer/on_impact(var/atom/A)
+	if(ismineralturf(A))
+		var/turf/simulated/mineral/M = A
+		new /obj/effect/temp_visual/kinetic_blast(M)
+		M.GetDrilled(firer)
+	. = ..()
+
 /obj/item/projectile/destabilizer/on_hit(atom/target, blocked = FALSE)
 	if(isliving(target))
 		var/mob/living/L = target
-		L.add_modifier(/datum/modifier/crusher_mark, 30 SECONDS, firer, TRUE)
-	var/target_turf = get_turf(target)
-	if(ismineralturf(target_turf))
-		var/turf/simulated/mineral/M = target_turf
-		new /obj/effect/temp_visual/kinetic_blast(M)
-		M.GetDrilled(firer)
+		if(hammer_synced.can_mark(L))
+			L.add_modifier(/datum/modifier/crusher_mark, 30 SECONDS, firer, TRUE)
 	..()
 
 /*
@@ -404,5 +418,6 @@
 there would be any if we had some
 but alas
 - hatterhat
+
 */
 

--- a/code/modules/mob/_modifiers/crusher_mark.dm
+++ b/code/modules/mob/_modifiers/crusher_mark.dm
@@ -2,34 +2,29 @@
     name = "destabilized"
     desc = "You've been struck by a destabilizing bolt. By all accounts, this is probably a bad thing."
     stacks = MODIFIER_STACK_EXTEND
-    on_created_text = "You feel destabilized."
-    on_expired_text = "You feel stable again."
+    on_created_text = "<span class='warning'>You feel physically unstable.</span>"
+    on_expired_text = "<span class='notice'>You feel physically stable again.</span>"
     var/mutable_appearance/marked_underlay
     var/obj/item/weapon/kinetic_crusher/hammer_synced
-
-/*
-/datum/modifier/New(var/new_holder, var/new_origin)
-	holder = new_holder
-	if(new_origin)
-		origin = weakref(new_origin)
-	else // We assume the holder caused the modifier if not told otherwise.
-		origin = weakref(holder)
-	..()
-/mob/living/proc/add_modifier(var/modifier_type, var/expire_at = null, var/mob/living/origin = null, var/suppress_failure = FALSE)
-*/
 
 /datum/modifier/crusher_mark/New(var/new_holder, var/new_origin)
     . = ..()
     if(isliving(new_origin))
         var/mob/living/origin = new_origin
-        var/obj/item/weapon/kinetic_crusher/to_sync = locate(/obj/item/weapon/kinetic_crusher) in origin
-        if(to_sync)
-            hammer_synced = to_sync
+        var/obj/item/weapon/kinetic_crusher/to_sync
+        if(istype(origin.get_active_hand(), /obj/item/weapon/kinetic_crusher))
+            to_sync = origin.get_active_hand()
+        else if (istype(origin.get_inactive_hand(), /obj/item/weapon/kinetic_crusher))
+            to_sync = origin.get_inactive_hand()
+        if(to_sync) // did we find it?
+            hammer_synced = to_sync // go ahead
         if(hammer_synced? hammer_synced.can_mark(holder) : TRUE)
             marked_underlay = mutable_appearance('icons/effects/effects.dmi', "shield2")
             marked_underlay.pixel_x = -holder.pixel_x
             marked_underlay.pixel_y = -holder.pixel_y
             holder.underlays += marked_underlay
+        else
+            Destroy()
 
 /datum/modifier/crusher_mark/Destroy()
 	hammer_synced = null


### PR DESCRIPTION
i'm just gonna start calling them kinetic melees now, or KMs, to match KAs,

FIXES/FEATURES:
- destabilizer bolts now break rocks, as they were intended to
- using the gauntlets inhand now toggles readiness/wielding

damage and intended roles:
machete: general purpose. nice middle of the road option.
base force 24 (comparable to plasteel machete)
detonation 60 (+36) damage
backstab 100 (+36+40) damage
thrown +20 damage

gauntlets: single target damage if you can keep hitting marks and detonating them
base force 28 (down from 30)
detonation 75 (+37. up from 35 to keep damage parity, unchanged otherwise)
backstab 130 (+37+55, unchanged)

daggers:
**reduced charge time from 1.5 to 1 second** (backup option)
force 18 (up from 15)
detonation 45 (+27)
backstab 85 (+40)
thrown +50 damage