### PR TITLE
Fixes shoe stuffing/Handles mob when shoes are destroyed/digested

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -473,7 +473,7 @@
 
 /obj/item/clothing/head/proc/update_flashlight(var/mob/user = null)
 	set_light_on(!light_on)
-	
+
 	if(light_system == STATIC_LIGHT)
 		update_light()
 
@@ -766,7 +766,7 @@
 	// means that if a taur puts on an already taurized suit without a taur sprite
 	// for their taur type, but the previous taur type had a sprite, it stays
 	// taurized and they end up with that taur style which is funny
-	else 
+	else
 		taurized = FALSE
 
 	if(!taurized)
@@ -1048,3 +1048,10 @@
 /obj/item/clothing/under/rank/New()
 	sensor_mode = pick(0,1,2,3)
 	..()
+
+//Vorestation edit - eject mobs from clothing before deletion
+/obj/item/clothing/Destroy()
+	for(var/mob/living/M in contents)
+		M.forceMove(get_turf(src))
+	return ..()
+//Vorestation edit end

--- a/code/modules/clothing/clothing_vr.dm
+++ b/code/modules/clothing/clothing_vr.dm
@@ -41,9 +41,11 @@
 		else
 			var/obj/item/weapon/holder/micro/holder = I
 			if(holder.held_mob && (holder.held_mob in holder))
-				to_chat(holder.held_mob, "<span class='warning'>[user] stuffs you into \the [src]!</span>")
-				holder.held_mob.forceMove(src)
-				to_chat(user, "<span class='notice'>You stuff \the [holder.held_mob] into \the [src]!</span>")
+				var/mob/living/M = holder.held_mob
+				holder.dump_mob()
+				to_chat(M, "<span class='warning'>[user] stuffs you into \the [src]!</span>")
+				M.forceMove(src)
+				to_chat(user, "<span class='notice'>You stuff \the [M] into \the [src]!</span>")
 	else
 		..()
 

--- a/code/modules/vore/eating/digest_act_vr.dm
+++ b/code/modules/vore/eating/digest_act_vr.dm
@@ -9,6 +9,8 @@
 			var/obj/item/device/pda/P = src
 			if(P.id)
 				P.id = null
+		for(var/mob/living/M in contents)//Drop mobs from objects(shoes) before deletion
+			M.forceMove(item_storage)
 		for(var/obj/item/O in contents)
 			if(istype(O, /obj/item/weapon/storage/internal)) //Dump contents from dummy pockets.
 				for(var/obj/item/SO in O)
@@ -37,6 +39,8 @@
 			var/obj/item/device/pda/P = src
 			if(P.id)
 				P.id = null
+		for(var/mob/living/M in contents)//Drop mobs from objects(shoes) before deletion
+			M.forceMove(item_storage)
 		for(var/obj/item/O in contents)
 			if(istype(O,/obj/item/weapon/storage/internal)) //Dump contents from dummy pockets.
 				for(var/obj/item/SO in O)


### PR DESCRIPTION
Fixes being able to put handheld people into shoes, and properly handles moving them to the stomach if the shoe is digested or drops the mob on the tile if the shoe is outright deleted. (Technically it's setup to handle more than just the shoes so we can stick micros in other clothing with most of the functionality in place!)

Fixes #11172