### PR TITLE
Make some NIF items apply wear only when used, and not when purchased.

### DIFF
--- a/code/modules/nifsoft/software/05_health.dm
+++ b/code/modules/nifsoft/software/05_health.dm
@@ -5,7 +5,6 @@
 	cost = 1250
 	p_drain = 0.05
 	a_drain = 0.1 //This is messed with manually below.
-	wear = 2
 	activates = FALSE //It is automatic in emergencies, not manually controllable.
 	tick_flags = NIF_ALWAYSTICK
 	applies_to = NIF_ORGANIC
@@ -16,6 +15,7 @@
 /datum/nifsoft/medichines_org/activate()
 	if((. = ..()))
 		mode = 1
+		nif.wear(1)
 
 /datum/nifsoft/medichines_org/deactivate(var/force = FALSE)
 	if((. = ..()))
@@ -47,6 +47,7 @@
 				var/turf/T = get_turf(H)
 				var/obj/item/device/radio/headset/a = new /obj/item/device/radio/headset/heads/captain(null)
 				a.autosay("[H.real_name] has been put in emergency stasis, located at ([T.x],[T.y],[T.z])!", "[H.real_name]'s NIF", "Medical")
+				nif.wear(2)
 				qdel(a)
 
 		//Handle the actions in each mode
@@ -78,7 +79,6 @@
 	cost = 1250
 	p_drain = 0.05
 	a_drain = 0.00 //This is manually drained below.
-	wear = 2
 	activates = FALSE //It is automatic in emergencies, not manually controllable.
 	tick_flags = NIF_ALWAYSTICK
 	applies_to = NIF_SYNTHETIC
@@ -89,6 +89,7 @@
 /datum/nifsoft/medichines_syn/activate()
 	if((. = ..()))
 		mode = 1
+		nif.wear(1)
 
 /datum/nifsoft/medichines_syn/deactivate(var/force = FALSE)
 	if((. = ..()))
@@ -129,13 +130,13 @@
 	cost = 325
 	p_drain = 0.05
 	a_drain = 0.1
-	wear = 2
 	tick_flags = NIF_ALWAYSTICK
 	applies_to = NIF_ORGANIC
 	var/filled = 100 //Tracks the internal tank 'refilling', which still uses power
 	health_flags = (NIF_H_SPAREBREATH)
 
 /datum/nifsoft/spare_breath/activate()
+	nif.wear(1)
 	if(!(filled > 50))
 		nif.notify("Respirocytes not saturated!",TRUE)
 		return FALSE

--- a/code/modules/nifsoft/software/05_health.dm
+++ b/code/modules/nifsoft/software/05_health.dm
@@ -47,7 +47,7 @@
 				var/turf/T = get_turf(H)
 				var/obj/item/device/radio/headset/a = new /obj/item/device/radio/headset/heads/captain(null)
 				a.autosay("[H.real_name] has been put in emergency stasis, located at ([T.x],[T.y],[T.z])!", "[H.real_name]'s NIF", "Medical")
-				nif.wear(2)
+				nif.wear(1)
 				qdel(a)
 
 		//Handle the actions in each mode

--- a/code/modules/nifsoft/software/15_misc.dm
+++ b/code/modules/nifsoft/software/15_misc.dm
@@ -3,7 +3,6 @@
 	desc = "A small attachment that allows synthmorphs to recharge themselves from APCs."
 	list_pos = NIF_APCCHARGE
 	cost = 625
-	wear = 2
 	applies_to = NIF_SYNTHETIC
 	tick_flags = NIF_ACTIVETICK
 	var/obj/machinery/power/apc/apc
@@ -22,6 +21,7 @@
 			return FALSE
 
 		H.visible_message("<span class='warning'>Thin snakelike tendrils grow from [H] and connect to \the [apc].</span>","<span class='notice'>Thin snakelike tendrils grow from you and connect to \the [apc].</span>")
+		nif.wear(1)
 
 /datum/nifsoft/apc_recharge/deactivate(var/force = FALSE)
 	if((. = ..()))
@@ -120,10 +120,9 @@
 
 /datum/nifsoft/sizechange
 	name = "Mass Alteration"
-	desc = "A system that allows one to change their size, through drastic mass rearrangement. Causes significant wear when installed."
+	desc = "A system that allows one to change their size, through drastic mass rearrangement. Causes significant wear when used."
 	list_pos = NIF_SIZECHANGE
 	cost = 375
-	wear = 6
 
 /datum/nifsoft/sizechange/activate()
 	if((. = ..()))
@@ -137,6 +136,7 @@
 			if(nif.human.resize(new_size/100, uncapped=nif.human.has_large_resize_bounds(), ignore_prefs = TRUE))
 				to_chat(nif.human,"<span class='notice'>You set the size to [new_size]%</span>")
 				nif.human.visible_message("<span class='warning'>Swirling grey mist envelops [nif.human] as they change size!</span>","<span class='notice'>Swirling streams of nanites wrap around you as you change size!</span>")
+				nif.wear(2)
 		spawn(0)
 			deactivate()
 

--- a/code/modules/nifsoft/software/15_misc.dm
+++ b/code/modules/nifsoft/software/15_misc.dm
@@ -136,7 +136,7 @@
 			if(nif.human.resize(new_size/100, uncapped=nif.human.has_large_resize_bounds(), ignore_prefs = TRUE))
 				to_chat(nif.human,"<span class='notice'>You set the size to [new_size]%</span>")
 				nif.human.visible_message("<span class='warning'>Swirling grey mist envelops [nif.human] as they change size!</span>","<span class='notice'>Swirling streams of nanites wrap around you as you change size!</span>")
-				nif.wear(2)
+				nif.wear(1)
 		spawn(0)
 			deactivate()
 


### PR DESCRIPTION
## About this pull request
As the title says, really. I do note that the strongest modules (illegal ones) still have wear from installation.

## Why is this good for the game
It makes more sense to have your wear and tear come from usage rather than just downloading a program. That's it.