### PR TITLE
Update mob spawners/spawns

### DIFF
--- a/code/game/objects/effects/semirandom_mobs_vr.dm
+++ b/code/game/objects/effects/semirandom_mobs_vr.dm
@@ -291,7 +291,8 @@ var/global/list/semirandom_mob_spawner_decisions = list()
 			/mob/living/simple_mob/vore/sect_queen = 1
 			),
 		list(/mob/living/simple_mob/vore/solargrub),
-		list(/mob/living/simple_mob/vore/woof)
+		list(/mob/living/simple_mob/vore/woof),
+		list(/mob/living/simple_mob/vore/alienanimals/teppi)
 		)
 
 /obj/random/mob/semirandom_mob_spawner/item_to_spawn()
@@ -405,8 +406,8 @@ var/global/list/semirandom_mob_spawner_decisions = list()
 			/mob/living/simple_mob/animal/sif/shantak/leader = 1
 			) = 5,
 		list(/mob/living/simple_mob/animal/sif/siffet) = 5,
-		list(/mob/living/simple_mob/animal/sif/tymisian) = 5
-
+		list(/mob/living/simple_mob/animal/sif/tymisian) = 5,
+		list(/mob/living/simple_mob/vore/alienanimals/teppi) = 10
 	)
 
 /obj/random/mob/semirandom_mob_spawner/monster
@@ -499,7 +500,8 @@ var/global/list/semirandom_mob_spawner_decisions = list()
 		list(
 			/mob/living/simple_mob/vore/oregrub = 5,
 			/mob/living/simple_mob/vore/oregrub/lava = 1
-			) = 15
+			) = 15,
+		list(/mob/living/simple_mob/vore/alienanimals/teppi) = 15
 		)
 
 /obj/random/mob/semirandom_mob_spawner/humanoid
@@ -738,7 +740,8 @@ var/global/list/semirandom_mob_spawner_decisions = list()
 			/mob/living/simple_mob/vore/sect_queen = 1
 			) = 50,
 		list(/mob/living/simple_mob/vore/solargrub) = 100,
-		list(/mob/living/simple_mob/vore/woof) = 1
+		list(/mob/living/simple_mob/vore/woof) = 1,
+		list(/mob/living/simple_mob/vore/alienanimals/teppi) = 25
 		)
 
 /obj/random/mob/semirandom_mob_spawner/sus

--- a/maps/tether/submaps/tether_plains.dmm
+++ b/maps/tether/submaps/tether_plains.dmm
@@ -113,6 +113,10 @@
 "at" = (
 /turf/unsimulated/wall/planetary/virgo3b,
 /area/tether/outpost/exploration_shed)
+"au" = (
+/obj/tether_away_spawner/tether_outside,
+/turf/simulated/floor/outdoors/grass/sif/virgo3b,
+/area/tether/outpost/exploration_plains)
 "bj" = (
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/tiled/steel_dirty/virgo3b,
@@ -126,14 +130,6 @@
 "Al" = (
 /turf/simulated/mineral/virgo3b,
 /area/mine/explored)
-"BE" = (
-/mob/living/simple_mob/animal/space/goose/virgo3b,
-/turf/simulated/floor/outdoors/grass/sif/virgo3b,
-/area/tether/outpost/exploration_plains)
-"Em" = (
-/mob/living/simple_mob/animal/passive/gaslamp,
-/turf/simulated/floor/outdoors/grass/sif/virgo3b,
-/area/tether/outpost/exploration_plains)
 "ID" = (
 /turf/simulated/mineral/virgo3b,
 /area/tether/outpost/exploration_shed)
@@ -1827,7 +1823,7 @@ ab
 ab
 ab
 ab
-BE
+au
 ab
 ab
 ab
@@ -2672,7 +2668,7 @@ ab
 ab
 ab
 ab
-Em
+au
 ab
 ab
 ab
@@ -2770,7 +2766,7 @@ ab
 ab
 ab
 ab
-BE
+au
 ab
 ab
 ab
@@ -3009,7 +3005,7 @@ ab
 ab
 ab
 ab
-BE
+au
 ab
 ab
 ab
@@ -3031,7 +3027,7 @@ ab
 ab
 ab
 ab
-Em
+au
 ab
 ab
 ab
@@ -3269,7 +3265,7 @@ uw
 ab
 ab
 ab
-BE
+au
 ab
 ab
 ab
@@ -3353,7 +3349,7 @@ ab
 ab
 ab
 ab
-BE
+au
 ab
 ab
 ab
@@ -5256,7 +5252,7 @@ Al
 uw
 ab
 ab
-Em
+au
 ab
 ab
 ab
@@ -7356,7 +7352,7 @@ ab
 ab
 ab
 ab
-BE
+au
 ab
 ab
 ab
@@ -7389,7 +7385,7 @@ ab
 ab
 ab
 ab
-BE
+au
 ab
 ab
 ab
@@ -8438,7 +8434,7 @@ ab
 ab
 ab
 ab
-BE
+au
 ab
 ab
 ab
@@ -9245,7 +9241,7 @@ ab
 ab
 ab
 ab
-BE
+au
 ab
 ab
 ab
@@ -9416,7 +9412,7 @@ ab
 ab
 ab
 ab
-BE
+au
 ab
 ab
 ab
@@ -10802,7 +10798,7 @@ ab
 ab
 ab
 ab
-Em
+au
 ab
 ab
 ab
@@ -11725,7 +11721,7 @@ ab
 ab
 ab
 ab
-Em
+au
 ab
 ab
 ab
@@ -14132,7 +14128,7 @@ ab
 ab
 ab
 ab
-BE
+au
 ab
 ab
 ab
@@ -14647,7 +14643,7 @@ ab
 ab
 ab
 ab
-BE
+au
 ab
 ab
 ab
@@ -14875,7 +14871,7 @@ ab
 ab
 ab
 ab
-BE
+au
 ab
 ab
 ab
@@ -15904,7 +15900,7 @@ ac
 as
 Al
 uw
-BE
+au
 ab
 ab
 ab
@@ -15927,7 +15923,7 @@ ab
 ab
 ab
 ab
-Em
+au
 ab
 ab
 ab
@@ -16251,7 +16247,7 @@ ab
 ab
 ab
 ab
-BE
+au
 ab
 ab
 ab
@@ -17590,7 +17586,7 @@ ab
 ab
 ab
 ab
-Em
+au
 ab
 ab
 ab
@@ -17609,7 +17605,7 @@ as
 uw
 uw
 ab
-Em
+au
 ab
 ab
 ab

--- a/maps/tether/tether-01-surface1.dmm
+++ b/maps/tether/tether-01-surface1.dmm
@@ -5771,7 +5771,7 @@
 /turf/simulated/floor/tiled,
 /area/rnd/hallway)
 "ajK" = (
-/mob/living/simple_mob/animal/passive/gaslamp,
+/obj/tether_away_spawner/tether_outside,
 /turf/simulated/floor/outdoors/grass/sif/virgo3b,
 /area/tether/surfacebase/outside/outside1)
 "ajL" = (

--- a/maps/tether/tether-03-surface3.dmm
+++ b/maps/tether/tether-03-surface3.dmm
@@ -14139,6 +14139,10 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/research)
+"axb" = (
+/obj/tether_away_spawner/tether_outside,
+/turf/simulated/floor/outdoors/grass/sif/virgo3b,
+/area/tether/surfacebase/outside/outside3)
 "axc" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/borderfloor{
@@ -46647,7 +46651,7 @@ aac
 aac
 aac
 aac
-aac
+axb
 aac
 aac
 aac
@@ -48763,7 +48767,7 @@ aac
 aac
 aac
 aac
-aac
+axb
 aac
 aac
 aac
@@ -49919,7 +49923,7 @@ aac
 aac
 aac
 aac
-aac
+axb
 aac
 aac
 aac
@@ -51430,7 +51434,7 @@ aac
 aac
 aac
 aac
-aac
+axb
 aac
 aac
 aac
@@ -59606,7 +59610,7 @@ aac
 aac
 aac
 aac
-aac
+axb
 aac
 aac
 aac

--- a/maps/tether/tether-06-mining.dmm
+++ b/maps/tether/tether-06-mining.dmm
@@ -1120,7 +1120,7 @@
 /turf/simulated/floor/tiled/steel_dirty/virgo3b,
 /area/outpost/mining_main/drill_equipment)
 "cu" = (
-/mob/living/simple_mob/animal/passive/gaslamp,
+/obj/tether_away_spawner/tether_outside,
 /turf/simulated/floor/outdoors/grass/sif/virgo3b,
 /area/mine/explored)
 "cv" = (

--- a/maps/tether/tether-07-solars.dmm
+++ b/maps/tether/tether-07-solars.dmm
@@ -216,7 +216,7 @@
 /turf/simulated/floor/virgo3b_indoors,
 /area/tether/outpost/solars_shed)
 "aw" = (
-/mob/living/simple_mob/animal/passive/gaslamp,
+/obj/tether_away_spawner/tether_outside,
 /turf/simulated/floor/outdoors/grass/sif/virgo3b,
 /area/mine/explored)
 "ax" = (
@@ -624,7 +624,7 @@
 /turf/simulated/floor/tiled/steel_dirty/virgo3b,
 /area/mine/explored)
 "br" = (
-/mob/living/simple_mob/animal/passive/gaslamp,
+/obj/tether_away_spawner/tether_outside,
 /turf/simulated/floor/tiled/steel_dirty/virgo3b,
 /area/tether/outpost/solars_outside)
 "bs" = (
@@ -798,7 +798,7 @@
 /turf/simulated/floor/virgo3b,
 /area/mine/explored)
 "bJ" = (
-/mob/living/simple_mob/animal/passive/gaslamp,
+/obj/tether_away_spawner/tether_outside,
 /turf/simulated/floor/outdoors/dirt/virgo3b,
 /area/mine/explored)
 "bK" = (

--- a/maps/tether/tether_things.dm
+++ b/maps/tether/tether_things.dm
@@ -466,3 +466,13 @@ var/global/list/latejoin_tram   = list()
 	layer = ABOVE_WINDOW_LAYER
 /obj/structure/noticeboard
 	layer = ABOVE_WINDOW_LAYER
+
+/obj/tether_away_spawner/tether_outside
+	name = "Tether Outside Spawner"
+	prob_spawn = 75
+	prob_fall = 50
+	mobs_to_pick_from = list(
+		/mob/living/simple_mob/animal/passive/gaslamp = 300,
+		/mob/living/simple_mob/animal/space/goose/virgo3b = 100,
+		/mob/living/simple_mob/vore/alienanimals/teppi = 5
+		)


### PR DESCRIPTION
Teppi can rarely spawn on Virgo 3b now after an incident where they were released and able to survive. 

This also makes it so that gaslamps, geese, and teppi are all in the same spawn pools and such, with gaslamps being 3 times as likely as geese, and teppi being very rare, this will result in the odd goose outside of the wilderness, but, geese are easy to beat up and slow, so, that's probably fine, especially considering how few spawns there are outside of the wilderness.