### PR TITLE
Small eggmode fix

### DIFF
--- a/code/modules/vore/eating/bellymodes_datum_vr.dm
+++ b/code/modules/vore/eating/bellymodes_datum_vr.dm
@@ -172,7 +172,7 @@ GLOBAL_LIST_INIT(digest_modes, list())
 				B.ownegg.update_transform()
 				egg_contents -= I
 				B.ownegg = null
-				return
+				return list("to_update" = TRUE)
 			if(isliving(C))
 				var/mob/living/M = C
 				var/mob_holder_type = M.holder_type || /obj/item/weapon/holder
@@ -186,7 +186,7 @@ GLOBAL_LIST_INIT(digest_modes, list())
 				if(B.ownegg.w_class > 4)
 					B.ownegg.slowdown = B.ownegg.w_class - 4
 				B.ownegg = null
-				return
+				return list("to_update" = TRUE)
 			C.forceMove(B.ownegg)
 			if(isitem(C))
 				var/obj/item/I = C
@@ -200,4 +200,5 @@ GLOBAL_LIST_INIT(digest_modes, list())
 		if(B.ownegg.w_class > 4)
 			B.ownegg.slowdown = B.ownegg.w_class - 4
 		B.ownegg = null
+		return list("to_update" = TRUE)
 	return


### PR DESCRIPTION
Fixes active item digestion mode combined with egg mode letting the belly process carry out the rest of its plans to digest the items after they've already been touched and egged by the egg mode, causing the egg contents to un-exist and leave behind empty shells.