### PR TITLE
clarified combat gloves description

### DIFF
--- a/code/modules/clothing/gloves/miscellaneous.dm
+++ b/code/modules/clothing/gloves/miscellaneous.dm
@@ -36,8 +36,8 @@
 	max_heat_protection_temperature = GLOVES_MAX_HEAT_PROTECTION_TEMPERATURE
 
 /obj/item/clothing/gloves/combat //Combined effect of SWAT gloves and insulated gloves
-	desc = "These tactical gloves are somewhat fire and impact resistant."
-	name = "combat gloves"
+	desc = "These tactical gloves are somewhat fire and impact resistant in addition to being shock absorbant." //Clarified its description compared to swat gloves
+	name = "Combat gloves"
 	icon_state = "swat"
 	item_state = "swat"
 	siemens_coefficient = 0


### PR DESCRIPTION
Clarified the description of the combat gloves item to differentiate it from SWAT gloves

I'm admittedlynot sure what  happened with line 169 , since I've not even so much as TOUCHED line 169 with the intents of this PR.    Either way, I feel like this PR helps clarify some of the differences between Combat gloves and SWAT Gloves since the fact they both use the same sprite with the only discernable difference being a hyphenated description is a bit misleading.  If the intent with the items sharing the smae sprite but different name is to just be a lucky thing to find , then so be it, but this adding some clarification to the differences between the item is handy, I feel.  