### PR TITLE
Fix Hot/Cold Discomfort Message Strings

### DIFF
--- a/code/modules/mob/living/carbon/human/species/species_getters.dm
+++ b/code/modules/mob/living/carbon/human/species/species_getters.dm
@@ -79,9 +79,10 @@
 
 /datum/species/proc/get_environment_discomfort(var/mob/living/carbon/human/H, var/msg_type)
 
-	if(!prob(5))
+	if(!prob(10))
 		return
 
+	/* // Commented out because clothes should not prevent you from feeling cold if your body temperature has already dropped. You can absolutely feel cold through clothing, and feel too warm without clothing. ???
 	var/covered = 0 // Basic coverage can help.
 	for(var/obj/item/clothing/clothes in H)
 		if(H.item_is_in_hands(clothes))
@@ -89,14 +90,13 @@
 		if((clothes.body_parts_covered & UPPER_TORSO) && (clothes.body_parts_covered & LOWER_TORSO))
 			covered = 1
 			break
+	*/
 
 	switch(msg_type)
 		if("cold")
-			if(!covered)
-				to_chat(H, "<span class='danger'>[pick(cold_discomfort_strings)]</span>")
+			to_chat(H, "<span class='danger'>[pick(cold_discomfort_strings)]</span>")
 		if("heat")
-			if(covered)
-				to_chat(H, "<span class='danger'>[pick(heat_discomfort_strings)]</span>")
+			to_chat(H, "<span class='danger'>[pick(heat_discomfort_strings)]</span>")
 
 /datum/species/proc/get_random_name(var/gender)
 	if(!name_language)


### PR DESCRIPTION
Cold Discomfort would not display if your body was covered - every /under/ item by default did so.
Heat discomfort would not display if your body was UNcovered.

This is fixed now - once you're uncomfortable, irregardless of what you're wearing, you'll start feeling it.
This should help prevent random deaths to freezing or overheating as you'll have warnings the area is too warm/cold before you start going ouchie.
