### PR TITLE
Fixes runtime with tesh custom species

### DIFF
--- a/code/modules/mob/living/carbon/human/species/species_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/species_vr.dm
@@ -81,6 +81,8 @@
 	var/list/blacklist = list("type", "loc", "client", "ckey")
 	//Makes thorough copy of species datum.
 	for(var/i in vars)
+		if(!(i in S.vars)) //Don't copy incompatible vars.
+			continue
 		if(S.vars[i] != vars[i] && !islist(vars[i])) //If vars are same, no point in copying.
 			if(i in blacklist)
 				continue


### PR DESCRIPTION
Fixes custom species copy var runtimes caused by some species having vars that don't exist on other species.