### PR TITLE
Makes belly overlays not apply on clientless mobs

### DIFF
--- a/code/modules/vore/eating/belly_obj_vr.dm
+++ b/code/modules/vore/eating/belly_obj_vr.dm
@@ -244,6 +244,8 @@
 /obj/belly/proc/vore_fx(mob/living/L)
 	if(!istype(L))
 		return
+	if(!L.client)
+		return
 	if(!L.show_vore_fx)
 		L.clear_fullscreen("belly")
 		return


### PR DESCRIPTION
This happening with each process cycle on every npc simplemob someone might be holding probably isn't all too healthy for performance.