### PR TITLE
Disables autoupdate on vorepanel tgui

### DIFF
--- a/code/modules/vore/eating/vorepanel_vr.dm
+++ b/code/modules/vore/eating/vorepanel_vr.dm
@@ -51,6 +51,7 @@
 	if(!ui)
 		ui = new(user, src, "VorePanel", "Vore Panel")
 		ui.open()
+		ui.set_autoupdate(FALSE)
 
 // This looks weird, but all tgui_host is used for is state checking
 // So this allows us to use the self_state just fine.


### PR DESCRIPTION
The vorepanel/bellies/bellymodes/etc already handle the updates whenever needed, and with how bloated the vorepanel is with content, it's no wonder it's laggy when kept open while the autoupdate refreshes it on every tick regardless of whether anything's changed or not.