### PR TITLE
Adds audible belching preference toggle, makes belch emote respect it

### DIFF
--- a/code/modules/client/preference_setup/global/02_settings.dm
+++ b/code/modules/client/preference_setup/global/02_settings.dm
@@ -83,9 +83,17 @@
 
 	return ..()
 
+/**
+ * This can take either a single preference datum or a list of preferences, and will return true if *all* preferences in the arguments are enabled.
+ */
 /client/proc/is_preference_enabled(var/preference)
-	var/datum/client_preference/cp = get_client_preference(preference)
-	return cp && (cp.key in prefs.preferences_enabled)
+	if(!islist(preference))
+		preference = list(preference)
+	for(var/p in preference)
+		var/datum/client_preference/cp = get_client_preference(p)
+		if(!cp || !(cp.key in prefs.preferences_enabled))
+			return FALSE
+	return TRUE
 
 /client/proc/set_preference(var/preference, var/set_preference)
 	var/datum/client_preference/cp = get_client_preference(preference)

--- a/code/modules/client/preference_setup/global/setting_datums.dm
+++ b/code/modules/client/preference_setup/global/setting_datums.dm
@@ -101,7 +101,6 @@ var/list/_client_preferences_by_type
 	key = "BELCH_NOISES"
 	enabled_description = "Noisy"
 	disabled_description = "Silent"
-	enabled_by_default = FALSE
 
 /datum/client_preference/emote_noises
 	description = "Emote Noises" //MERP

--- a/code/modules/client/preference_setup/global/setting_datums.dm
+++ b/code/modules/client/preference_setup/global/setting_datums.dm
@@ -95,6 +95,13 @@ var/list/_client_preferences_by_type
 	key = "DIGEST_NOISES"
 	enabled_description = "Noisy"
 	disabled_description = "Silent"
+	
+/datum/client_preference/belch_noises // Belching noises - pref toggle for 'em
+	description = "Burping"
+	key = "BELCH_NOISES"
+	enabled_description = "Noisy"
+	disabled_description = "Silent"
+	enabled_by_default = FALSE
 
 /datum/client_preference/emote_noises
 	description = "Emote Noises" //MERP

--- a/code/modules/client/preferences_vr.dm
+++ b/code/modules/client/preferences_vr.dm
@@ -40,7 +40,21 @@
 	SScharacter_setup.queue_preferences_save(prefs)
 
 	feedback_add_details("admin_verb","TDigestNoise") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+	
+/client/verb/toggle_belch_noises()
+	set name = "Audible belching"
+	set category = "Preferences"
+	set desc = "Toggles audible belches."
 
+	var/pref_path = /datum/client_preference/belch_noises
+
+	toggle_preference(pref_path)
+
+	to_chat(src, "You will [ (is_preference_enabled(pref_path)) ? "now" : "no longer"] hear belching.")
+
+	SScharacter_setup.queue_preferences_save(prefs)
+
+	feedback_add_details("admin_verb","TBelchNoise")
 
 /client/verb/toggle_emote_noises()
 	set name = "Emote Noises"

--- a/code/modules/emotes/definitions/audible_belch.dm
+++ b/code/modules/emotes/definitions/audible_belch.dm
@@ -2,6 +2,7 @@
 	key = "belch"
 	emote_message_3p = "belches."
 	message_type = AUDIBLE_MESSAGE
+	sound_preferences = list(/datum/client_preference/emote_noises,/datum/client_preference/belch_noises)
 
 /decl/emote/audible/belch/get_emote_sound(var/atom/user)
 	return list(

--- a/code/modules/emotes/emote_define.dm
+++ b/code/modules/emotes/emote_define.dm
@@ -42,6 +42,8 @@ var/global/list/emotes_by_key
 	var/check_range                                     // falsy, or a range outside which the emote will not work
 	var/conscious = TRUE                                // Do we need to be awake to emote this?
 	var/emote_range = 0                                 // If >0, restricts emote visibility to viewers within range.
+	
+	var/sound_preferences = list(/datum/client_preference/emote_noises) // Default emote sound_preferences is just emote_noises. Belch emote overrides this list for pref-checks.
 
 /decl/emote/Initialize()
 	. = ..()
@@ -176,7 +178,7 @@ var/global/list/emotes_by_key
 		if(islist(sound_to_play) && length(sound_to_play))
 			sound_to_play = pick(sound_to_play)
 	if(sound_to_play)
-		playsound(user.loc, sound_to_play, use_sound["vol"], 0, preference = /datum/client_preference/emote_noises) //VOREStation Add - Preference
+		playsound(user.loc, sound_to_play, use_sound["vol"], 0, preference = sound_preferences) //VOREStation Add - Preference
 
 /decl/emote/proc/mob_can_use(var/mob/user)
 	return istype(user) && user.stat != DEAD && (type in user.get_available_emotes())


### PR DESCRIPTION
Preferences can now handle a list being passed to them, and will require all items in the list to be true. Singular datums work to preserve legacy behavior.

Audible belching will REQUIRE "Emote Noises" and "Audible Belching" preferences to be enabled.

Figured there'd be a potential shitstorm, and honestly adding the preference was easier than I thought.

This will work if for w/e reason you decide to add farting noises - a simple pref toggle, and bingo.

Etc etc.

<3
