### PR TITLE
Eng/Med Belts

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
@@ -82,6 +82,7 @@
 		/obj/item/clothing/suit/storage/hooded/wintercoat/engineering,
 		/obj/item/clothing/shoes/boots/winter/engineering,
 		/obj/item/weapon/tank/emergency/oxygen/engi,
+		/obj/item/weapon/storage/belt/utility,	//VOREStation Add
 		/obj/item/weapon/reagent_containers/spray/windowsealant) //VOREStation Add
 
 /obj/structure/closet/secure_closet/engineering_personal/Initialize()
@@ -114,7 +115,8 @@
 		/obj/item/taperoll/atmos,
 		/obj/item/clothing/suit/storage/hooded/wintercoat/engineering/atmos,
 		/obj/item/clothing/shoes/boots/winter/atmos,
-		/obj/item/weapon/tank/emergency/oxygen/engi)
+		/obj/item/weapon/tank/emergency/oxygen/engi,
+		/obj/item/weapon/storage/belt/utility) //VOREStation Add
 
 /obj/structure/closet/secure_closet/atmos_personal/Initialize()
 	if(prob(50))

--- a/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
@@ -44,7 +44,8 @@
 		/obj/item/clothing/shoes/boots/winter/medical,
 		/obj/item/clothing/under/rank/nursesuit,
 		/obj/item/clothing/head/nursehat,
-		/obj/item/weapon/storage/box/freezer = 3)
+		/obj/item/weapon/storage/box/freezer = 3,
+		/obj/item/weapon/storage/belt/medical) //VOREStation Add
 
 /obj/structure/closet/secure_closet/medical3/Initialize()
 	if(prob(50))
@@ -147,7 +148,8 @@
 		/obj/item/clothing/suit/bio_suit/cmo,
 		/obj/item/clothing/head/bio_hood/cmo,
 		/obj/item/clothing/shoes/white,
-		/obj/item/weapon/reagent_containers/glass/beaker/vial) //VOREStation Add
+		/obj/item/weapon/reagent_containers/glass/beaker/vial, //VOREStation Add
+		/obj/item/weapon/storage/belt/medical) //VOREStation Add
 
 /obj/structure/closet/secure_closet/CMO/Initialize()
 	if(prob(50))


### PR DESCRIPTION
Adds empty engineering and medical belts to appropriate equipment lockers;
- Toolbelts for engineers
- Medical belts for MDs and CMOs

Initially suggested for Engineering belts by @Screemonster, but then I threw in medical as well since ~~redshirts~~ security officers get belts in their lockers, so why not be consistent about it? Makes it easier to gear up if you come in from off-duty or something happens to your starting gear.

I'm aware there's already empty toolbelts in the engineering workshop, but they're hidden under a pile of other stuff and putting them in the lockers is a way more intuitive location for them.