### PR TITLE
A couple vorepanel update fixes

### DIFF
--- a/code/modules/vore/eating/belly_obj_vr.dm
+++ b/code/modules/vore/eating/belly_obj_vr.dm
@@ -215,6 +215,7 @@
 	//Messages if it's a mob
 	if(isliving(thing))
 		var/mob/living/M = thing
+		M.updateVRPanel()
 		if(desc)
 			to_chat(M, "<span class='notice'><B>[desc]</B></span>")
 		var/taste

--- a/code/modules/vore/eating/bellymodes_datum_vr.dm
+++ b/code/modules/vore/eating/bellymodes_datum_vr.dm
@@ -22,6 +22,7 @@ GLOBAL_LIST_INIT(digest_modes, list())
 	noise_chance = 50
 
 /datum/digest_mode/digest/process_mob(obj/belly/B, mob/living/L)
+	var/oldstat = L.stat
 	//Pref protection!
 	if(!L.digestable || L.absorbed)
 		return null
@@ -59,6 +60,8 @@ GLOBAL_LIST_INIT(digest_modes, list())
 		B.owner.adjust_nutrition(offset*(4.5 * (damage_gain) / difference)) //4.5 nutrition points per health point. Normal same size 100+100 health prey with average weight would give 900 points if the digestion was instant. With all the size/weight offset taxes plus over time oxyloss+hunger taxes deducted with non-instant digestion, this should be enough to not leave the pred starved.
 	else
 		B.owner.adjust_nutrition(4.5 * (damage_gain) / difference)
+	if(L.stat != oldstat)
+		return list("to_update" = TRUE)
 
 /datum/digest_mode/absorb
 	id = DM_ABSORB

--- a/code/modules/vore/eating/bellymodes_datum_vr.dm
+++ b/code/modules/vore/eating/bellymodes_datum_vr.dm
@@ -123,6 +123,7 @@ GLOBAL_LIST_INIT(digest_modes, list())
 	noise_chance = 50 //Wet heals! The secret is you can leave this on for gurgle noises for fun.
 
 /datum/digest_mode/heal/process_mob(obj/belly/B, mob/living/L)
+	var/oldstat = L.stat
 	if(L.stat == DEAD)
 		return null // Can't heal the dead with healbelly
 	if(B.owner.nutrition > 90 && (L.health < L.maxHealth))
@@ -137,6 +138,8 @@ GLOBAL_LIST_INIT(digest_modes, list())
 	else if(B.owner.nutrition > 90 && (L.nutrition <= 400))
 		B.owner.adjust_nutrition(-1)
 		L.adjust_nutrition(1)
+	if(L.stat != oldstat)
+		return list("to_update" = TRUE)
 
 // E G G
 /datum/digest_mode/egg

--- a/code/modules/vore/eating/bellymodes_vr.dm
+++ b/code/modules/vore/eating/bellymodes_vr.dm
@@ -63,10 +63,9 @@
 				SEND_SOUND(M, prey_digest)
 		play_sound = pred_digest
 
-	if(to_update)
-		updateVRPanels()
-
 	if(!LAZYLEN(touchable_mobs))
+		if(to_update)
+			updateVRPanels()
 		if(play_sound)
 			for(var/mob/M in hearers(VORE_SOUND_RANGE, get_turf(owner))) //so we don't fill the whole room with the sound effect
 				if(!M.is_preference_enabled(/datum/client_preference/digestion_noises))
@@ -124,6 +123,9 @@
 				formatted_message = replacetext(formatted_message, "%countprey", living_count)
 				formatted_message = replacetext(formatted_message, "%count", contents.len)
 				to_chat(M, "<span class='notice'>[formatted_message]</span>")
+	
+	if(to_update)
+		updateVRPanels()
 
 
 /obj/belly/proc/handle_touchable_atoms(list/touchable_atoms)

--- a/code/modules/vore/eating/vorepanel_vr.dm
+++ b/code/modules/vore/eating/vorepanel_vr.dm
@@ -638,6 +638,7 @@
 				return FALSE
 
 			host.vore_selected.digest_mode = new_mode
+			host.vore_selected.updateVRPanels()
 			. = TRUE
 		if("b_addons")
 			var/list/menu_list = host.vore_selected.mode_flag_list.Copy()


### PR DESCRIPTION
With the perpetual autoupdate being disabled, a couple missing mechanics-triggered updates turned up.
Fixes vorepanel not updating in cases such as:
-Prey getting moved from belly to another (from prey's perspective)
-Prey's stat (conscious/unconscious/dead) changing during digest or heal modes.
-Belly digest mode being changed (from prey's perspective)