### PR TITLE
Removes geese from immedeate Tether surroundings

### DIFF
--- a/maps/tether/tether_things.dm
+++ b/maps/tether/tether_things.dm
@@ -473,6 +473,5 @@ var/global/list/latejoin_tram   = list()
 	prob_fall = 50
 	mobs_to_pick_from = list(
 		/mob/living/simple_mob/animal/passive/gaslamp = 300,
-		/mob/living/simple_mob/animal/space/goose/virgo3b = 100,
-		/mob/living/simple_mob/vore/alienanimals/teppi = 5
+		/mob/living/simple_mob/vore/alienanimals/teppi = 4
 		)


### PR DESCRIPTION
They may not be dangerous to people going outside too much, but they are still hostile simplemobs that will break into station through the windows should they spot something inside, forcing people out of areas that are supposed to be perfectly safe.