### PR TITLE
Probably fixes the language reset bug

### DIFF
--- a/code/modules/client/preference_setup/general/02_language.dm
+++ b/code/modules/client/preference_setup/general/02_language.dm
@@ -30,7 +30,7 @@
 		// Sanitize illegal languages
 		for(var/language in pref.alternate_languages)
 			var/datum/language/L = GLOB.all_languages[language]
-			if(!istype(L) || (L.flags & RESTRICTED) || (!(language in S.secondary_langs) && !is_lang_whitelisted(pref.client, L)))
+			if(!istype(L) || (L.flags & RESTRICTED) || (!(language in S.secondary_langs) && pref.client && !is_lang_whitelisted(pref.client, L)))
 				testing("LANGSANI: Removed [L?.name || "lang not found"] from [pref.client]'s character [pref.real_name || "-name not yet loaded-"] because it failed allowed checks")
 				pref.alternate_languages -= language
 


### PR DESCRIPTION
Looks like the despawn persistence settings have a tendency to hit that save_character button after the victim has already disconnected, which would lead into complications right here because the language whitelist check will automatically fail when fed a null in the client's place.