### PR TITLE
Fixes #11648

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1049,6 +1049,7 @@
 				do_give(H)
 			return TRUE
 		make_item_drop_sound(I)
+		drop_from_inventory(item)
 		I.forceMove(get_turf(target))
 		return TRUE
 


### PR DESCRIPTION
for whatever reason forcemove to your tile or an adjacent tile does not make you drop the item