### PR TITLE
Minor Talon Update

### DIFF
--- a/maps/offmap_vr/talon/talon_v2.dmm
+++ b/maps/offmap_vr/talon/talon_v2.dmm
@@ -2562,7 +2562,7 @@
 /obj/machinery/camera/network/talon{
 	dir = 1
 	},
-/obj/random/multiple/corp_crate/talon_cargo,
+/obj/structure/vehiclecage/quadbike,
 /turf/simulated/floor/tiled/techfloor,
 /area/talon_v2/maintenance/wing_starboard)
 "hc" = (
@@ -9564,7 +9564,7 @@
 /obj/machinery/camera/network/talon{
 	dir = 1
 	},
-/obj/random/multiple/corp_crate/talon_cargo,
+/obj/structure/vehiclecage/quadbike,
 /turf/simulated/floor/tiled/techfloor,
 /area/talon_v2/maintenance/wing_port)
 "FO" = (


### PR DESCRIPTION
Something reminded me that the Talon used to have a pair of vehicle cages, so I've readded them; one ATV in each cargo bay. No trailers included.

:cl:
tweak - restored vehicle cages that got lost in the update
/:cl: