### PR TITLE
Fixes holodeck carp icons

### DIFF
--- a/code/modules/mob/living/simple_mob/subtypes/vore/zz_vore_overrides.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/zz_vore_overrides.dm
@@ -124,7 +124,7 @@
 	vore_icons = 0
 /mob/living/simple_mob/animal/space/carp/large/huge
 	vore_icons = 0
-/mob/living/simple_mob/animal/space/carp/holographic
+/mob/living/simple_mob/animal/space/carp/holodeck
 	vore_icons = 0
 
 /* //VOREStation AI Temporary removal


### PR DESCRIPTION
Fixes #11592

Why are there /mob/living/simple_mob/animal/space/carp/holodeck and /mob/living/simple_mob/animal/space/carp/holographic? Are /mob/living/simple_mob/animal/space/carp/holographic actually used anywhere? Beats me, but that's outside the scope of this PR.