### PR TITLE
Disables container quick-empty when in a belly

### DIFF
--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -679,6 +679,10 @@
 	if(!Adjacent(usr))
 		return
 
+	//VOREStation Add: No turf dumping if user is in a belly
+	if(isbelly(usr.loc))
+		return
+
 	drop_contents()
 
 /obj/item/weapon/storage/proc/drop_contents() // why is this a proc? literally just for RPEDs


### PR DESCRIPTION
The proc is coded to dump the contents exclusively on the turf, so a prey hitting that button on a storage item inside a gut would just tp it all onto the ground outside.