### PR TITLE
Stops literally everything in the world from being recyclable

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -4,7 +4,7 @@
 	w_class = ITEMSIZE_NORMAL
 	blocks_emissive = EMISSIVE_BLOCK_GENERIC
 
-	matter = list(MAT_STEEL = 1)
+	//matter = list(MAT_STEEL = 1)
 
 	var/image/blood_overlay = null //this saves our blood splatter overlay, which will be processed not to go over the edges of the sprite
 	var/randpixel = 6
@@ -249,7 +249,7 @@
 		var/obj/item/weapon/storage/S = src.loc
 		if(!S.remove_from_storage(src))
 			return
-	
+
 	src.pickup(user)
 	src.throwing = 0
 	if (src.loc == user)
@@ -258,7 +258,7 @@
 	else
 		if(isliving(src.loc))
 			return
-			
+
 	if(user.put_in_active_hand(src))
 		if(isturf(old_loc))
 			var/obj/effect/temporary_effect/item_pickup_ghost/ghost = new(old_loc)
@@ -832,7 +832,7 @@ modules/mob/living/carbon/human/life.dm if you die, you will be zoomed out.
 	if(!inhands)
 		apply_blood(standing)			//Some items show blood when bloodied
 		apply_accessories(standing)		//Some items sport accessories like webbing
-	
+
 	//Apply overlays to our...overlay
 	apply_overlays(standing)
 


### PR DESCRIPTION
Not that its bad, but there have to be exceptions and this was just a terrible way to do it. Being able to delete any item in the game by just putting it in autolathe so easily is dumb regardless.