### PR TITLE
Fix getting stuck in deep space because of bad creation of temporary sectors

### DIFF
--- a/code/modules/overmap/spacetravel.dm
+++ b/code/modules/overmap/spacetravel.dm
@@ -5,15 +5,16 @@
 	known = FALSE
 	in_space = TRUE
 
-/obj/effect/overmap/visitable/sector/temporary/Initialize(var/nx, var/ny)
+/obj/effect/overmap/visitable/sector/temporary/Initialize()
+	if(!istype(loc, /turf/unsimulated/map))
+		CRASH("Attempt to create deepspace which is not on overmap: [log_info_line(loc)]")
+	// Tell sector initializer where are is where we want to be.
+	start_x = loc.x
+	start_y = loc.y
+	// But pick an empty z level to use
+	map_z += global.using_map.get_empty_zlevel()
 	. = ..()
-	loc = locate(nx, ny, global.using_map.overmap_z)
-	x = nx
-	y = ny
-	var/emptyz = global.using_map.get_empty_zlevel()
-	map_z += emptyz
-	map_sectors["[emptyz]"] = src
-	testing("Temporary sector at [x],[y] was created, corresponding zlevel is [emptyz].")
+	testing("Temporary sector at [x],[y],[z] was created, corresponding zlevel is [english_list(map_z)].")
 
 /obj/effect/overmap/visitable/sector/temporary/Destroy()
 	for(var/zlevel in map_z)
@@ -43,7 +44,7 @@
 	var/obj/effect/overmap/visitable/sector/temporary/res = locate() in overmap_turf
 	if(istype(res))
 		return res
-	return new /obj/effect/overmap/visitable/sector/temporary(x, y)
+	return new /obj/effect/overmap/visitable/sector/temporary(overmap_turf)
 
 /atom/movable/proc/lost_in_space()
 	for(var/atom/movable/AM in contents)
@@ -132,6 +133,8 @@
 	if(!TM)
 		TM = get_deepspace(M.x,M.y)
 	nz = pick(TM.get_space_zlevels())
+
+	testing("spacetravel chose [nz],[ny],[nz] in sector [TM] @ ([TM.x],[TM.y],[TM.z])")
 
 	var/turf/dest = locate(nx,ny,nz)
 	if(istype(dest))


### PR DESCRIPTION
Deep Space temporary sectors were being created on Z1 instead of the overmap, and with a bad map_z list.
- Initialize was taking the wrong parameters, resulting in the sector being always located at 1,?,1 instead of on the overmap
  Fix by passing the first parameter to new() as the location you want the object, as is proper for BYOND.
- Also fixed map_z containing a zero, it was put there by the sector Initialize().
  Fix by setting the appropriate values *before* calling parent.

This hopefully should also fix (or at least mitigate) the creation of infinite "temporary" empty z levels because:
A) Someone lost in a overmap tile with no real sectors will get recycled back into the same Z without making a new one.
B) Attempts to cleanup will no longer *always* think players are present because it is counting all players in nullspace.