### PR TITLE
Brings back character age restrictions for certain roles

### DIFF
--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -166,11 +166,12 @@
 ///Assigns minimum age by race & brain type. Code says Positronic = mechanical and Drone = digital because nothing can be simple.
 ///Will first check based on brain type, then based on species.
 /datum/job/proc/get_min_age(species_name, brain_type)
-	return 18 // VOREStation Edit - Minimum character age by rules anyway, might as well return 18 instead of 0 or 1 or whatever.
-    //return (brain_type && LAZYACCESS(min_age_by_species, brain_type)) || LAZYACCESS(min_age_by_species, species_name) || minimum_character_age //VOREStation Edit
+	return minimum_character_age // VOREStation Edit - Minimum character age by rules is 18, return default which is standard for all species
+    //return (brain_type && LAZYACCESS(min_age_by_species, brain_type)) || LAZYACCESS(min_age_by_species, species_name) || minimum_character_age //VOREStation Removal
 
 /datum/job/proc/get_ideal_age(species_name, brain_type)
-	return (brain_type && LAZYACCESS(ideal_age_by_species, brain_type)) || LAZYACCESS(ideal_age_by_species, brain_type) || ideal_character_age
+	return ideal_character_age // VOREStation Edit - Minimum character age by rules is 18, return default which is standard for all species
+	//return (brain_type && LAZYACCESS(ideal_age_by_species, brain_type)) || LAZYACCESS(ideal_age_by_species, brain_type) || ideal_character_age //VOREStation Removal
 
 /datum/job/proc/is_species_banned(species_name, brain_type)
 	return FALSE // VOREStation Edit - Any species can be any job.


### PR DESCRIPTION
#11603 initially introduced some... uh... questionable age restrictions for certain species in context of our ERP 18+ server, and it's fixed version removed all age restrictions for jobs entirely. This should fix it so that behaviour is overall unchanged from way it was before #11603.