### PR TITLE
Fixes whitelist requirement for every borg module

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -282,8 +282,6 @@
 		return
 	if(!(modtype in robot_modules))
 		return
-	if(!is_borg_whitelisted(src, modtype))
-		return
 
 	var/module_type = robot_modules[modtype]
 	transform_with_anim()	//VOREStation edit: sprite animation


### PR DESCRIPTION
Already handled on line 275-277. At this position the line just makes _any and every_ borg module _require_ whitelisting.