### PR TITLE
A followup fix to borg whitelisting PR

### DIFF
--- a/code/game/jobs/whitelist.dm
+++ b/code/game/jobs/whitelist.dm
@@ -98,6 +98,10 @@ var/list/whitelist = list()
 	if(!M || !module)
 		return 0
 
+	//Module is not even whitelisted
+	if(!(module in whitelisted_module_types))
+		return 1
+
 	//If we have a loaded file, search it
 	if(alien_whitelist)
 		for (var/s in alien_whitelist)


### PR DESCRIPTION
Kind of an alternative fix to #11703. Instead of removing additional whitelist check after selecting module, makes sure whitelists have proper bypass for non-whitelisted entries.