### PR TITLE
Talon Shuttle Tweaks

### DIFF
--- a/maps/offmap_vr/talon/talon_v2.dmm
+++ b/maps/offmap_vr/talon/talon_v2.dmm
@@ -3353,6 +3353,15 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/talon_v2/maintenance/wing_starboard)
+"kv" = (
+/obj/effect/map_helper/airlock/atmos/pump_out_external,
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning/cee,
+/obj/structure/handrail,
+/turf/simulated/floor/reinforced,
+/area/shuttle/talonboat)
 "kx" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -4748,6 +4757,7 @@
 /area/talon_v2/maintenance/wing_starboard)
 "pk" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/fuel,
+/obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/wall/rshull,
 /area/shuttle/talonboat)
 "pl" = (
@@ -5258,10 +5268,8 @@
 /obj/item/stack/cable_coil/green,
 /obj/item/stack/cable_coil/green,
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/aux{
-	dir = 8
-	},
-/obj/effect/map_helper/airlock/atmos/chamber_pump,
+/obj/effect/map_helper/airlock/atmos/pump_out_internal,
+/obj/machinery/atmospherics/unary/vent_pump/high_volume,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/shuttle/talonboat)
 "qN" = (
@@ -6474,7 +6482,9 @@
 	dir = 1
 	},
 /obj/item/weapon/storage/toolbox/emergency,
-/obj/machinery/atmospherics/pipe/manifold/hidden/aux,
+/obj/machinery/atmospherics/pipe/simple/hidden/aux{
+	dir = 9
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/shuttle/talonboat)
 "uW" = (
@@ -25441,7 +25451,7 @@ kI
 LM
 qL
 pk
-Tt
+kv
 Wc
 fV
 sJ

--- a/maps/offmap_vr/talon/talon_v2.dmm
+++ b/maps/offmap_vr/talon/talon_v2.dmm
@@ -2617,9 +2617,6 @@
 /turf/simulated/floor/carpet,
 /area/talon_v2/crew_quarters/eng_room)
 "ho" = (
-/obj/structure/bed/chair/bay/shuttle{
-	dir = 1
-	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
@@ -6637,10 +6634,10 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
-/obj/structure/handrail,
 /obj/structure/closet/autolok_wall{
 	pixel_y = 32
 	},
+/obj/structure/bed/chair/bay/shuttle,
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/talonboat)
 "vz" = (
@@ -6659,13 +6656,13 @@
 /obj/structure/bed/chair/bay/chair{
 	dir = 1
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
 /obj/machinery/light,
 /obj/machinery/alarm/talon{
 	dir = 1;
 	pixel_y = -25
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/talonboat)
@@ -7246,14 +7243,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/handrail,
 /obj/machinery/firealarm{
 	layer = 3.3;
 	pixel_y = 26
 	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
+/obj/structure/bed/chair/bay/shuttle,
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/talonboat)
 "xH" = (
@@ -8618,9 +8612,6 @@
 /obj/structure/bed/chair/bay/chair{
 	dir = 1
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
 /obj/machinery/light,
 /obj/machinery/light_switch{
 	dir = 1;
@@ -8631,6 +8622,9 @@
 	dir = 1;
 	pixel_x = -6;
 	pixel_y = -24
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/talonboat)
@@ -10984,6 +10978,9 @@
 	dir = 1;
 	pixel_y = -32
 	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/talonboat)
 "Kd" = (
@@ -11183,16 +11180,10 @@
 /turf/simulated/wall/rshull,
 /area/talon_v2/engineering/port_store)
 "KN" = (
-/obj/structure/bed/chair/bay/shuttle{
-	dir = 1
-	},
 /obj/structure/closet/walllocker/medical/east,
 /obj/item/weapon/storage/firstaid/regular,
 /obj/item/weapon/storage/firstaid/o2,
 /obj/item/weapon/extinguisher/mini,
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 4
-	},
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/talonboat)
 "KO" = (
@@ -12432,17 +12423,15 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/talon_v2/armory)
 "Po" = (
-/obj/effect/map_helper/airlock/door/simple,
-/obj/machinery/door/airlock/glass_external{
-	req_one_access = list(301)
+/obj/structure/table/steel,
+/obj/structure/closet/autolok_wall{
+	dir = 1;
+	pixel_y = -32
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
+/turf/simulated/floor/tiled/techfloor,
 /area/shuttle/talonboat)
 "Pr" = (
 /obj/machinery/shower,
@@ -25019,7 +25008,7 @@ cK
 cK
 Tt
 cK
-cK
+Tt
 cK
 Tt
 Jm
@@ -25726,7 +25715,7 @@ sf
 Tt
 Tt
 vY
-Kc
+Po
 Tt
 xE
 KN
@@ -25870,7 +25859,7 @@ Tt
 DC
 DC
 Tt
-Po
+DC
 Tt
 DC
 Tt


### PR DESCRIPTION
Based on some comments in the offmap channel, it sounds like the Talon Shuttle's side-door doesn't function like I wanted and is actually quite unsafe.

As such I've quickly remapped it to remove the side door, and reorganized the center bay a little as a result. Two less handrails, but you've already got six passenger seats and ten handrails so it's not like there's a shortage of seating. ~~And even if there was I'm sure people would find creative ways to secure additional passengers.~~

I've also adjusted the airlock to add a dump system so it can pump out hazardous atmospheres (e.g. V2's) if need be. It'll probably be pretty slow though.

:cl:
fix - made talon shuttle safer, added dump vent
/:cl: