### PR TITLE
Hardwood Material Port

### DIFF
--- a/code/__defines/materials.dm
+++ b/code/__defines/materials.dm
@@ -18,6 +18,8 @@
 #define MAT_LOG				"log"
 #define MAT_SIFWOOD			"alien wood"
 #define MAT_SIFLOG			"alien log"
+#define MAT_HARDWOOD			"hardwood"
+#define MAT_HARDLOG			"hardwood log"
 #define MAT_STEELHULL		"steel hull"
 #define MAT_PLASTEEL		"plasteel"
 #define MAT_PLASTEELHULL	"plasteel hull"

--- a/code/datums/supplypacks/materials.dm
+++ b/code/datums/supplypacks/materials.dm
@@ -28,6 +28,13 @@
 	containertype = /obj/structure/closet/crate/grayson
 	containername = "Wooden planks crate"
 
+/datum/supply_pack/materials/hardwood50
+	name = "50 hardwood planks"
+	contains = list(/obj/fiftyspawner/hardwood)
+	cost = 50
+	containertype = /obj/structure/closet/crate/gilthari
+	containername = "Hardwood planks crate"
+
 /datum/supply_pack/materials/plastic50
 	name = "50 plastic sheets"
 	contains = list(/obj/fiftyspawner/plastic)

--- a/code/game/objects/structures/simple_doors.dm
+++ b/code/game/objects/structures/simple_doors.dm
@@ -156,7 +156,7 @@
 		visible_message("<span class='danger'>[user] hits [src] with [W]!</span>")
 		if(material == get_material_by_name("resin"))
 			playsound(src, 'sound/effects/attackblob.ogg', 100, 1)
-		else if(material == (get_material_by_name(MAT_WOOD) || get_material_by_name(MAT_SIFWOOD)))
+		else if(material == (get_material_by_name(MAT_WOOD) || get_material_by_name(MAT_SIFWOOD) || get_material_by_name(MAT_HARDWOOD)))
 			playsound(src, 'sound/effects/woodcutting.ogg', 100, 1)
 		else
 			playsound(src, 'sound/weapons/smash.ogg', 50, 1)
@@ -181,7 +181,7 @@
 	visible_message("<span class='danger'>[user] [attack_verb] the [src]!</span>")
 	if(material == get_material_by_name("resin"))
 		playsound(src, 'sound/effects/attackblob.ogg', 100, 1)
-	else if(material == (get_material_by_name(MAT_WOOD) || get_material_by_name(MAT_SIFWOOD)))
+	else if(material == (get_material_by_name(MAT_WOOD) || get_material_by_name(MAT_SIFWOOD) || get_material_by_name(MAT_HARDWOOD)))
 		playsound(src, 'sound/effects/woodcutting.ogg', 100, 1)
 	else
 		playsound(src, 'sound/weapons/smash.ogg', 50, 1)
@@ -242,6 +242,9 @@
 /obj/structure/simple_door/wood/Initialize(mapload,var/material_name)
 	..(mapload, material_name || MAT_WOOD)
 	knock_sound = 'sound/machines/door/knock_wood.wav'
+
+/obj/structure/simple_door/hardwood/Initialize(mapload,var/material_name)
+	..(mapload, material_name || MAT_HARDWOOD)
 
 /obj/structure/simple_door/sifwood/Initialize(mapload,var/material_name)
 	..(mapload, material_name || MAT_SIFWOOD)

--- a/code/game/turfs/simulated/wall_types.dm
+++ b/code/game/turfs/simulated/wall_types.dm
@@ -92,6 +92,9 @@
 /turf/simulated/wall/wood/Initialize(mapload)
 	. = ..(mapload,  MAT_WOOD)
 
+/turf/simulated/wall/hardwood/Initialize(mapload)
+	. = ..(mapload,  MAT_HARDWOOD)
+
 /turf/simulated/wall/sifwood/Initialize(mapload)
 	. = ..(mapload,  MAT_SIFWOOD)
 

--- a/code/modules/materials/fifty_spawner_mats.dm
+++ b/code/modules/materials/fifty_spawner_mats.dm
@@ -92,6 +92,10 @@
 	name = "stack of alien wood"
 	type_to_spawn = /obj/item/stack/material/wood/sif
 
+/obj/fiftyspawner/hardwood
+	name = "stack of hardwood"
+	type_to_spawn = /obj/item/stack/material/wood/hard
+
 /obj/fiftyspawner/log
 	name = "stack of logs"
 	type_to_spawn = /obj/item/stack/material/log
@@ -99,6 +103,10 @@
 /obj/fiftyspawner/log/sif
 	name = "stack of alien logs"
 	type_to_spawn = /obj/item/stack/material/log/sif
+
+/obj/fiftyspawner/log/hard
+	name = "stack of hardwood logs"
+	type_to_spawn = /obj/item/stack/material/log/hard
 
 /obj/fiftyspawner/cloth
 	name = "stack of cloth"

--- a/code/modules/materials/materials/organic/wood.dm
+++ b/code/modules/materials/materials/organic/wood.dm
@@ -65,6 +65,29 @@
 			recipes -= r_recipe
 			continue
 
+/datum/material/wood/hardwood
+	name = MAT_HARDWOOD
+	stack_type = /obj/item/stack/material/wood/hard
+	icon_colour = "#42291a"
+	icon_base = "stone"
+	icon_reinf = "reinf_stone"
+	integrity = 65	//a bit stronger than regular wood
+	hardness = 20	
+	weight = 20	//likewise, heavier
+
+/datum/material/wood/hardwood/generate_recipes()
+	..()
+	for(var/datum/stack_recipe/r_recipe in recipes)
+		if(r_recipe.title == "wood floor tile")
+			recipes -= r_recipe
+			continue
+		if(r_recipe.title == "wooden chair")
+			recipes -= r_recipe
+			continue
+		if(r_recipe.title == "wooden standup figure")
+			recipes -= r_recipe
+			continue
+
 /datum/material/wood/log
 	name = MAT_LOG
 	display_name = "wood" // will lead to "wood log"
@@ -87,6 +110,11 @@
 	icon_colour = "#0099cc" // Cyan-ish
 	stack_origin_tech = list(TECH_MATERIAL = 2, TECH_BIO = 2)
 	stack_type = /obj/item/stack/material/log/sif
+
+/datum/material/wood/log/hard
+	name = MAT_HARDLOG
+	icon_colour = "#6f432a"
+	stack_type = /obj/item/stack/material/log/hard
 
 //VOREStation Addition Start
 /datum/material/wood/stick

--- a/code/modules/materials/sheets/organic/wood.dm
+++ b/code/modules/materials/sheets/organic/wood.dm
@@ -13,6 +13,12 @@
 	color = "#0099cc"
 	default_type = MAT_SIFWOOD
 
+/obj/item/stack/material/wood/hard
+	name = "hardwood plank"
+	color = "#42291a"
+	default_type = MAT_HARDWOOD
+	description_info = "Rich, lustrous hardwood, imported from offworld at moderate expense. Mostly used for luxurious furniture, and not very good for weapons or other structures."
+
 /obj/item/stack/material/log
 	name = "log"
 	icon_state = "sheet-log"
@@ -31,6 +37,12 @@
 	default_type = MAT_SIFLOG
 	color = "#0099cc"
 	plank_type = /obj/item/stack/material/wood/sif
+
+/obj/item/stack/material/log/hard
+	name = "hardwood log"
+	default_type = MAT_HARDLOG
+	color = "#6f432a"
+	plank_type = /obj/item/stack/material/wood/hard
 
 /obj/item/stack/material/log/attackby(var/obj/item/W, var/mob/user)
 	if(!istype(W) || W.force <= 0)

--- a/code/modules/tables/presets.dm
+++ b/code/modules/tables/presets.dm
@@ -75,6 +75,14 @@
 	reinforced = get_material_by_name(MAT_STEEL)
 	..()
 
+/obj/structure/table/hardwoodtable
+	icon_state = "stone_preview"
+	color = "#42291a"
+
+/obj/structure/table/hardwoodtable/Initialize(mapload)
+	material = get_material_by_name("hardwood")
+	return ..()
+
 /obj/structure/table/gamblingtable
 	icon_state = "gamble_preview"
 


### PR DESCRIPTION
Tweaked copy of [CITRP3552](https://github.com/Citadel-Station-13/Citadel-Station-13-RP/pull/3552).

In summary;
Adds a hardwood subtype of regular wood, which uses the big table appearance to give it a glossy/shiny finish. Includes table/wall/door presets for mapping, logs, and supplypack. Can only be acquired via cargo supplypack or adminspawn. Crafting options are slightly limited compared to regular wood.

Demo image, showing the Tether's bar remodelled with hardwood in place of marble;
![image](https://user-images.githubusercontent.com/49700375/139227803-fa7da4f6-bf16-478f-8a4b-6fd4b47b3f00.png)

Looks good as big office desks or the like. Could be mapped in as a default replacement to various head-of-staff desks, used in pois, etc.

No special uses or requirements for crafting or the like.

:cl:
add - added hardwood material, orderable via cargo
/:cl: