### PR TITLE
Sensible Dragon Boss Tweaks for Virgo

### DIFF
--- a/code/modules/mob/living/simple_mob/subtypes/vore/bigdragon.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/bigdragon.dm
@@ -71,7 +71,7 @@ I think I covered everything.
 	response_disarm = "shoves"
 	response_harm = "smacks"
 	movement_cooldown = 4 //Fixed from 2, given our slower natural speed any mob at movement cooldown 2 is a nightmare let alone a boss that has a pounce
-	maxHealth = 800 //Still double a Phoron Dragon, if it's gonna be on 3b, it shouldn't have broodmother level health
+	maxHealth = 800
 	attacktext = list("slashed")
 	see_in_dark = 8
 	minbodytemp = 0

--- a/code/modules/mob/living/simple_mob/subtypes/vore/bigdragon.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/bigdragon.dm
@@ -70,7 +70,7 @@ I think I covered everything.
 	response_help = "pats"
 	response_disarm = "shoves"
 	response_harm = "smacks"
-	movement_cooldown = 5 //Fixed from 2, given our slower natural speed any mob at movement cooldown 2 is a nightmare let alone a boss that has a pounce
+	movement_cooldown = 4 //Fixed from 2, given our slower natural speed any mob at movement cooldown 2 is a nightmare let alone a boss that has a pounce
 	maxHealth = 600 //Still double a Phoron Dragon, if it's gonna be on 3b, it shouldn't have broodmother level health
 	attacktext = list("slashed")
 	see_in_dark = 8

--- a/code/modules/mob/living/simple_mob/subtypes/vore/bigdragon.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/bigdragon.dm
@@ -71,7 +71,7 @@ I think I covered everything.
 	response_disarm = "shoves"
 	response_harm = "smacks"
 	movement_cooldown = 4 //Fixed from 2, given our slower natural speed any mob at movement cooldown 2 is a nightmare let alone a boss that has a pounce
-	maxHealth = 600 //Still double a Phoron Dragon, if it's gonna be on 3b, it shouldn't have broodmother level health
+	maxHealth = 800 //Still double a Phoron Dragon, if it's gonna be on 3b, it shouldn't have broodmother level health
 	attacktext = list("slashed")
 	see_in_dark = 8
 	minbodytemp = 0

--- a/code/modules/mob/living/simple_mob/subtypes/vore/bigdragon.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/bigdragon.dm
@@ -70,8 +70,8 @@ I think I covered everything.
 	response_help = "pats"
 	response_disarm = "shoves"
 	response_harm = "smacks"
-	movement_cooldown = 2
-	maxHealth = 800
+	movement_cooldown = 5 //Fixed from 2, given our slower natural speed any mob at movement cooldown 2 is a nightmare let alone a boss that has a pounce
+	maxHealth = 600 //Still double a Phoron Dragon, if it's gonna be on 3b, it shouldn't have broodmother level health
 	attacktext = list("slashed")
 	see_in_dark = 8
 	minbodytemp = 0
@@ -101,6 +101,7 @@ I think I covered everything.
 	devourable = 0	//No
 	universal_understand = 1 //So they can hear synth speach
 	max_tox = 0 // for virgo3b survivability
+	max_co2 = 0 // Also needed for 3b Survivability otherwise it chokes to death
 
 	special_attack_min_range = 1
 	special_attack_max_range = 10


### PR DESCRIPTION
A few minor tweaks to make the Dragon a more reasonable boss for Virgo purposes. Drastically cutting it's base speed from Movement Cooldown 2 to Movement Cooldown 5 and lowering health by 25%. Be warned, it still has it's pounce, so this doesn't magically become easy at all. However also fixed it's issue where it chokes to death so it can't just be cheesed. Still a bandaid fix, it's more suited for V2 admittedly, but something is better than nothing!