### PR TITLE
Map tweaks

### DIFF
--- a/maps/expedition_vr/aerostat/aerostat_science_outpost.dmm
+++ b/maps/expedition_vr/aerostat/aerostat_science_outpost.dmm
@@ -2597,7 +2597,7 @@
 /obj/machinery/atmospherics/portables_connector{
 	dir = 1
 	},
-/obj/machinery/portable_atmospherics/canister/air/airlock,
+/obj/machinery/portable_atmospherics/canister/air,
 /turf/simulated/floor/tiled,
 /area/offmap/aerostat/inside/drillstorage)
 "jf" = (
@@ -3214,7 +3214,8 @@
 	icon_state = "4-8"
 	},
 /obj/structure/sign/poster{
-	dir = 1
+	dir = 1;
+	pixel_y = 32
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/westhall)
@@ -7231,7 +7232,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/sign/poster{
-	dir = 8
+	dir = 8;
+	pixel_x = -32
 	},
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/toxins)
@@ -7765,7 +7767,8 @@
 	dir = 4
 	},
 /obj/structure/sign/poster{
-	dir = 1
+	dir = 1;
+	pixel_y = 32
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/easthall)
@@ -8976,7 +8979,8 @@
 "LI" = (
 /obj/structure/closet/firecloset,
 /obj/structure/sign/poster{
-	dir = 4
+	dir = 4;
+	pixel_x = 32
 	},
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/xenoarch)
@@ -10395,7 +10399,8 @@
 	icon_state = "1-2"
 	},
 /obj/structure/sign/poster{
-	dir = 8
+	dir = 8;
+	pixel_x = -32
 	},
 /turf/simulated/floor/tiled,
 /area/offmap/aerostat/inside/xenoarch)

--- a/maps/stellardelight/stellar_delight2.dmm
+++ b/maps/stellardelight/stellar_delight2.dmm
@@ -1139,7 +1139,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
-/area/quartermaster/storage)
+/area/stellardelight/deck2/aftport)
 "cL" = (
 /obj/structure/cable/cyan{
 	icon_state = "2-8"
@@ -1301,18 +1301,6 @@
 	},
 /turf/simulated/floor/tiled/eris/dark/orangecorner,
 /area/engineering/locker_room)
-"db" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/quartermaster/storage)
 "dc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /obj/structure/cable/white{
@@ -1416,9 +1404,6 @@
 /turf/simulated/floor/tiled,
 /area/stellardelight/deck2/central)
 "dq" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -2921,9 +2906,6 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/atmos/storage)
 "gN" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
@@ -3635,6 +3617,7 @@
 	cur_coils = 4;
 	input_attempt = 1;
 	input_level = 500000;
+	name = "Main";
 	output_level = 1e+006
 	},
 /turf/simulated/floor/plating,
@@ -4118,7 +4101,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
-/area/quartermaster/storage)
+/area/stellardelight/deck2/aftport)
 "jO" = (
 /obj/machinery/door/firedoor/glass,
 /obj/structure/window/bay/reinforced,
@@ -4879,7 +4862,7 @@
 	},
 /obj/item/device/radio/beacon,
 /turf/simulated/floor/tiled,
-/area/quartermaster/storage)
+/area/stellardelight/deck2/aftport)
 "lo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -7034,7 +7017,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
-/area/quartermaster/storage)
+/area/stellardelight/deck2/aftport)
 "qd" = (
 /obj/item/device/radio/intercom{
 	dir = 1;
@@ -8009,9 +7992,6 @@
 /area/stellardelight/deck2/fore)
 "sk" = (
 /obj/machinery/door/firedoor/glass,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/airlock/angled_bay/standard/glass{
@@ -8576,7 +8556,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
-/area/quartermaster/storage)
+/area/stellardelight/deck2/aftport)
 "tB" = (
 /obj/machinery/firealarm/angled,
 /obj/structure/frame,
@@ -9879,9 +9859,6 @@
 /turf/simulated/floor/tiled/eris/steel/brown_platform,
 /area/crew_quarters/bar)
 "wH" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/eris/steel/brown_platform,
@@ -10238,7 +10215,7 @@
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals5,
 /turf/simulated/floor/tiled,
-/area/quartermaster/storage)
+/area/stellardelight/deck2/aftport)
 "xD" = (
 /obj/structure/bed/chair/backed_red{
 	dir = 4
@@ -10259,9 +10236,6 @@
 /turf/simulated/floor/carpet/turcarpet,
 /area/crew_quarters/recreation_area)
 "xG" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -12046,7 +12020,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/steeldecal/steel_decals5,
 /turf/simulated/floor/tiled,
-/area/quartermaster/storage)
+/area/stellardelight/deck2/aftport)
 "BM" = (
 /obj/structure/table/standard,
 /obj/item/weapon/folder/yellow,
@@ -12893,6 +12867,7 @@
 	charge = 2e+006;
 	input_attempt = 1;
 	input_level = 100000;
+	name = "Engine";
 	output_level = 200000
 	},
 /obj/structure/cable/cyan{
@@ -13049,10 +13024,6 @@
 	},
 /turf/simulated/floor,
 /area/maintenance/stellardelight/deck2/starboardsolars)
-"Eb" = (
-/obj/effect/floor_decal/steeldecal/steel_decals5,
-/turf/simulated/floor/tiled,
-/area/quartermaster/storage)
 "Ec" = (
 /obj/effect/floor_decal/steeldecal/steel_decals5{
 	dir = 1
@@ -14589,7 +14560,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
-/area/quartermaster/storage)
+/area/stellardelight/deck2/aftport)
 "Hk" = (
 /obj/machinery/camera/network/halls{
 	dir = 4
@@ -16203,9 +16174,6 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/engineering/atmos/monitoring)
 "KR" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
@@ -17103,7 +17071,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
-/area/quartermaster/storage)
+/area/stellardelight/deck2/aftport)
 "MS" = (
 /obj/structure/cable/white{
 	icon_state = "4-8"
@@ -17916,12 +17884,6 @@
 /turf/simulated/floor/tiled/eris/cafe,
 /area/crew_quarters/kitchen)
 "OP" = (
-/obj/machinery/power/apc/angled{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
@@ -18201,7 +18163,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
-/area/quartermaster/storage)
+/area/stellardelight/deck2/aftport)
 "Pu" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 4
@@ -18551,7 +18513,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
-/area/quartermaster/storage)
+/area/stellardelight/deck2/aftport)
 "Qg" = (
 /obj/structure/cable/orange{
 	icon_state = "1-8"
@@ -19533,9 +19495,6 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/stellardelight/deck2/fuelstorage)
 "Sv" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
@@ -20102,7 +20061,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
-/area/quartermaster/storage)
+/area/stellardelight/deck2/aftport)
 "TK" = (
 /obj/structure/closet/secure_closet/cargotech,
 /obj/item/weapon/stamp/cargo,
@@ -20226,7 +20185,7 @@
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals5,
 /turf/simulated/floor/tiled,
-/area/quartermaster/storage)
+/area/stellardelight/deck2/aftport)
 "Ub" = (
 /obj/structure/cable/green{
 	icon_state = "1-8"
@@ -20341,9 +20300,6 @@
 "Um" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -20774,7 +20730,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
-/area/quartermaster/storage)
+/area/stellardelight/deck2/aftport)
 "Vl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 4
@@ -22672,7 +22628,7 @@
 	pixel_y = 1
 	},
 /turf/simulated/floor/tiled,
-/area/stellardelight/deck2/aftstarboard)
+/area/stellardelight/deck2/aftport)
 "ZG" = (
 /obj/structure/cable/orange{
 	icon_state = "4-8"
@@ -32330,8 +32286,8 @@ XY
 pg
 QP
 jN
-db
-Eb
+ci
+eB
 OP
 TS
 XN
@@ -32472,8 +32428,8 @@ XY
 pg
 QP
 tA
-db
-Eb
+ci
+eB
 dq
 zj
 We
@@ -32614,8 +32570,8 @@ XY
 pg
 QP
 TJ
-db
-Eb
+ci
+eB
 dq
 zj
 GE
@@ -33040,8 +32996,8 @@ Kf
 AG
 QP
 Pt
-db
-Eb
+ci
+eB
 rv
 zj
 DV
@@ -33182,8 +33138,8 @@ kO
 yE
 QP
 jN
-db
-Eb
+ci
+eB
 gq
 HZ
 Nj
@@ -33466,8 +33422,8 @@ zL
 PY
 Ex
 ZF
-Jn
-zh
+ci
+eB
 cX
 ed
 du

--- a/maps/stellardelight/stellar_delight3.dmm
+++ b/maps/stellardelight/stellar_delight3.dmm
@@ -639,12 +639,12 @@
 /turf/simulated/floor/tiled,
 /area/crew_quarters/heads/hop)
 "cQ" = (
-/obj/machinery/portable_atmospherics/canister/air/airlock,
 /obj/machinery/atmospherics/portables_connector,
 /obj/structure/closet/emergsuit_wall{
 	dir = 4;
 	pixel_x = 27
 	},
+/obj/machinery/portable_atmospherics/canister/air,
 /turf/simulated/floor/tiled/eris/dark/cargo,
 /area/shuttle/sdboat/aft)
 "cS" = (
@@ -2553,10 +2553,6 @@
 	name = "Docking Port Airlock"
 	},
 /obj/effect/map_helper/airlock/door/ext_door,
-/obj/machinery/airlock_sensor/airlock_exterior/shuttle{
-	pixel_y = 32
-	},
-/obj/effect/map_helper/airlock/sensor/ext_sensor,
 /turf/simulated/floor/tiled/steel_ridged,
 /area/shuttle/sdboat/aft)
 "kB" = (
@@ -10002,6 +9998,13 @@
 	},
 /turf/simulated/floor,
 /area/maintenance/stellardelight/deck3/portaft)
+"LZ" = (
+/obj/machinery/airlock_sensor/airlock_exterior/shuttle{
+	dir = 6
+	},
+/obj/effect/map_helper/airlock/sensor/ext_sensor,
+/turf/simulated/wall/rshull,
+/area/shuttle/sdboat/aft)
 "Mc" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -21440,7 +21443,7 @@ mi
 Kj
 iM
 fn
-fn
+LZ
 kz
 fn
 fn


### PR DESCRIPTION
Fixes an issue with the Starstuff's airlock
Fixes an issue with the Aerostat shuttle's airlock

Fixes the posters on the Aerostat

Names the engine and main SMESs to make them easier to tell apart.