### PR TITLE
Adjustments to mob falling mechanics

### DIFF
--- a/code/modules/multiz/movement.dm
+++ b/code/modules/multiz/movement.dm
@@ -467,13 +467,16 @@
 // Take damage from falling and hitting the ground
 /mob/living/fall_impact(var/atom/hit_atom, var/damage_min = 0, var/damage_max = 5, var/silent = FALSE, var/planetary = FALSE)
 	var/turf/landing = get_turf(hit_atom)
+	var/safe_fall = FALSE
+	if(src.softfall || (istype(src, /mob/living/simple_mob) && src.mob_size <= MOB_SMALL))
+		safe_fall = TRUE
 	if(planetary && src.CanParachute())
 		if(!silent)
 			visible_message("<span class='warning'>\The [src] glides in from above and lands on \the [landing]!</span>", \
 				"<span class='danger'>You land on \the [landing]!</span>", \
 				"You hear something land \the [landing].")
 		return
-	else if(!planetary && src.softfall) // Falling one floor and falling one atmosphere are very different things
+	else if(!planetary && safe_fall) // Falling one floor and falling one atmosphere are very different things
 		if(!silent)
 			visible_message("<span class='warning'>\The [src] falls from above and lands on \the [landing]!</span>", \
 				"<span class='danger'>You land on \the [landing]!</span>", \

--- a/code/modules/multiz/movement_vr.dm
+++ b/code/modules/multiz/movement_vr.dm
@@ -32,7 +32,10 @@
 		return 0
 
 	var/mob/living/pred = hit_atom
-	pred.visible_message("<span class='danger'>\The [hit_atom] falls onto \the [src]!</span>")
+	var/safe_fall = FALSE
+	if(pred.softfall || (istype(pred, /mob/living/simple_mob) && pred.mob_size <= MOB_SMALL))		// TODO: add ability for mob below to be 'soft' and cushion fall
+		safe_fall = TRUE
+
 	pred.Weaken(8)
 	var/mob/living/prey = src
 	var/fallloc = prey.loc
@@ -42,16 +45,20 @@
 	else if(prey.can_be_drop_pred && pred.can_be_drop_prey)
 		prey.feed_grabbed_to_self_falling_nom(prey,pred)
 	else
-		prey.Weaken(8)
 		pred.loc = prey.loc
-		playsound(src, "punch", 25, 1, -1)
-		var/tdamage
-		for(var/i = 1 to 10)
-			tdamage = rand(0, 10)/2
-			pred.adjustBruteLoss(tdamage)
-			prey.adjustBruteLoss(tdamage)
-		pred.updatehealth()
-		prey.updatehealth()
+		if(!safe_fall)
+			prey.Weaken(8)
+			playsound(src, "punch", 25, 1, -1)
+			var/tdamage
+			for(var/i = 1 to 5)			//Twice as less damage because cushioned fall, but both get damaged.
+				tdamage = rand(0, 5)
+				pred.adjustBruteLoss(tdamage)
+				prey.adjustBruteLoss(tdamage)
+			pred.updatehealth()
+			prey.updatehealth()
+			pred.visible_message("<span class='danger'>\The [pred] falls onto \the [src]!</span>")
+		else
+			pred.visible_message("<span class='notice'>\The [pred] safely brushes past \the [src] as they land.</span>")
 	return 1
 
 /mob/observer/dead/CheckFall()

--- a/code/modules/multiz/movement_vr.dm
+++ b/code/modules/multiz/movement_vr.dm
@@ -36,17 +36,22 @@
 	if(pred.softfall || (istype(pred, /mob/living/simple_mob) && pred.mob_size <= MOB_SMALL))		// TODO: add ability for mob below to be 'soft' and cushion fall
 		safe_fall = TRUE
 
-	pred.Weaken(8)
 	var/mob/living/prey = src
 	var/fallloc = prey.loc
 	if(pred.can_be_drop_pred && prey.can_be_drop_prey)
 		pred.feed_grabbed_to_self_falling_nom(pred,prey)
 		pred.loc = fallloc
+		if(!safe_fall)
+			pred.Weaken(8)
+		pred.visible_message("<span class='danger'>\The [pred] falls right onto \the [prey]!</span>")
 	else if(prey.can_be_drop_pred && pred.can_be_drop_prey)
 		prey.feed_grabbed_to_self_falling_nom(prey,pred)
+		pred.Weaken(4)
+		pred.visible_message("<span class='danger'>\The [pred] falls right into \the [prey]!</span>")
 	else
 		pred.loc = prey.loc
 		if(!safe_fall)
+			pred.Weaken(8)
 			prey.Weaken(8)
 			playsound(src, "punch", 25, 1, -1)
 			var/tdamage
@@ -56,9 +61,9 @@
 				prey.adjustBruteLoss(tdamage)
 			pred.updatehealth()
 			prey.updatehealth()
-			pred.visible_message("<span class='danger'>\The [pred] falls onto \the [src]!</span>")
+			pred.visible_message("<span class='danger'>\The [pred] falls onto \the [prey]!</span>")
 		else
-			pred.visible_message("<span class='notice'>\The [pred] safely brushes past \the [src] as they land.</span>")
+			pred.visible_message("<span class='notice'>\The [pred] safely brushes past \the [prey] as they land.</span>")
 	return 1
 
 /mob/observer/dead/CheckFall()


### PR DESCRIPTION
Makes simple mobs of size MOB_SMALL and smaller not take fall damage from non-planetary falls. Have you seen how high a height can small creatures fall off of and just run away afterwards?

Makes the softfall ability as well as the afromentioned new size-based change affect the falling on other mobs. If fall would be safe for the falling mob, then neither it, nor the la(d/ss) below is affected either. No change in situation where dropnom prefs match one way or another.

Reduced damage from one mob falling onto another. Instead of both recieving full fall damage individually, the damage of a single fall is now split between the two evenly.

In dropnoms, if pred is the one falling from above, then if the fall would have been safe, they are no longer stunned.