### PR TITLE
Adds Soft Falling positive trait

### DIFF
--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -208,6 +208,7 @@
 	var/greater_form										// Greater form, if any, ie. human for monkeys.
 	var/holder_type
 	var/gluttonous											// Can eat some mobs. 1 for mice, 2 for monkeys, 3 for people.
+	var/soft_landing = FALSE								// Can fall down and land safely on small falls.
 
 	var/rarity_value = 1									// Relative rarity/collector value for this species.
 	var/economic_modifier = 2								// How much money this species makes
@@ -541,6 +542,20 @@
 		H.adjustToxLoss(amount)
 
 /datum/species/proc/handle_falling(mob/living/carbon/human/H, atom/hit_atom, damage_min, damage_max, silent, planetary)
+	if(soft_landing)
+		if(planetary || !istype(H))
+			return FALSE
+
+		var/turf/landing = get_turf(hit_atom)
+		if(!istype(landing))
+			return FALSE
+
+		if(!silent)
+			to_chat(H, SPAN_NOTICE("You manage to lower impact of the fall and land safely."))
+			landing.visible_message("<b>\The [H]</b> lowers down from above, landing safely.")
+			playsound(H, "rustle", 25, 1)
+		return TRUE
+
 	return FALSE
 
 /datum/species/proc/post_spawn_special(mob/living/carbon/human/H)

--- a/code/modules/mob/living/carbon/human/species/station/station_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_vr.dm
@@ -123,6 +123,7 @@
 	//brute_mod = 1.15
 	//burn_mod =  1.15
 	//gluttonous = 1
+	soft_landing = TRUE
 	num_alternate_languages = 3
 	secondary_langs = list(LANGUAGE_BIRDSONG)
 	name_language = LANGUAGE_BIRDSONG
@@ -361,6 +362,8 @@
 
 	min_age = 18
 	max_age = 80
+
+	soft_landing = TRUE
 
 	base_color = "#EECEB3"
 

--- a/code/modules/mob/living/carbon/human/species/station/teshari.dm
+++ b/code/modules/mob/living/carbon/human/species/station/teshari.dm
@@ -141,7 +141,7 @@
 		/datum/mob_descriptor/build = -3
 	)
 
-	var/static/list/flight_bodyparts = list(
+/*	var/static/list/flight_bodyparts = list(
 		BP_L_ARM,
 		BP_R_ARM,
 		BP_L_HAND,
@@ -150,7 +150,7 @@
 	var/static/list/flight_suit_blacklisted_types = list(
 		/obj/item/clothing/suit/space,
 		/obj/item/clothing/suit/straight_jacket
-	)
+	)*/
 
 	default_emotes = list(
 		/decl/emote/audible/teshsqueak,
@@ -161,13 +161,13 @@
 /datum/species/teshari/equip_survival_gear(var/mob/living/carbon/human/H)
 	..()
 	H.equip_to_slot_or_del(new /obj/item/clothing/shoes/sandal(H),slot_shoes)
-
+/*
 /datum/species/teshari/handle_falling(mob/living/carbon/human/H, atom/hit_atom, damage_min, damage_max, silent, planetary)
 
 	// Tesh can glide to save themselves from some falls. Basejumping bird
 	// without parachute, or falling bird without free wings, goes splat.
 
-	// Are we landing from orbit, or handcuffed/unconscious/tied to something? 
+	// Are we landing from orbit, or handcuffed/unconscious/tied to something?
 	if(planetary || !istype(H) || H.incapacitated(INCAPACITATION_DEFAULT|INCAPACITATION_DISABLED))
 		return ..()
 
@@ -211,3 +211,4 @@
 		H.Stun(1)
 		playsound(H, "rustle", 25, 1)
 	return TRUE
+*/

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/positive.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/positive.dm
@@ -116,7 +116,7 @@
 /datum/trait/positive/soft_landing
 	name = "Soft Landing"
 	desc = "You can fall from certain heights without suffering any injuries, be it via wings, lightness of frame or general dexterity."
-	cost = 0
+	cost = 1
 	var_changes = list("soft_landing" = TRUE)
 
 /datum/trait/positive/hardfeet

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/positive.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/positive.dm
@@ -113,6 +113,12 @@
 	H.verbs |= /mob/living/proc/flying_toggle
 	H.verbs |= /mob/living/proc/start_wings_hovering
 
+/datum/trait/positive/soft_landing
+	name = "Soft Landing"
+	desc = "You can fall from certain heights without suffering any injuries, be it via wings, lightness of frame or general dexterity."
+	cost = 0
+	var_changes = list("soft_landing" = TRUE)
+
 /datum/trait/positive/hardfeet
 	name = "Hard Feet"
 	desc = "Makes your nice clawed, scaled, hooved, armored, or otherwise just awfully calloused feet immune to glass shards."

--- a/code/modules/multiz/movement_vr.dm
+++ b/code/modules/multiz/movement_vr.dm
@@ -36,6 +36,11 @@
 	if(pred.softfall || (istype(pred, /mob/living/simple_mob) && pred.mob_size <= MOB_SMALL))		// TODO: add ability for mob below to be 'soft' and cushion fall
 		safe_fall = TRUE
 
+	if(istype(pred, /mob/living/carbon/human))
+		var/mob/living/carbon/human/H = pred
+		if(H.species.soft_landing)
+			safe_fall = TRUE
+
 	var/mob/living/prey = src
 	var/fallloc = prey.loc
 	if(pred.can_be_drop_pred && prey.can_be_drop_prey)


### PR DESCRIPTION
Adds new 1-cost positive trait, similarly to Winged Flight in balancing idea.
Soft Falling - causes falling from non-planetary heights to deal no damage and mitigates fall damage when landing on people and short stun from drop-nomming people.

Trait is present by default for Teshari, Rapala and Nevrean

Teshari's old slowfall has been removed along with both its unique messages as well as restrictions.