### PR TITLE
new particle smasher recipes

### DIFF
--- a/code/modules/materials/materials/gems.dm
+++ b/code/modules/materials/materials/gems.dm
@@ -67,7 +67,7 @@
 	tableslam_noise = 'sound/effects/Glasshit.ogg'
 	sheet_singular_name = "gem"
 	sheet_plural_name = "gems"
-	supply_conversion_value = 4
+	supply_conversion_value = 12 //if they take diamond to make via psmasher, they should be worth more than diamond
 
 /datum/material/void_opal
 	name = "void opal"

--- a/code/modules/power/singularity/particle_accelerator/particle_smasher.dm
+++ b/code/modules/power/singularity/particle_accelerator/particle_smasher.dm
@@ -379,3 +379,37 @@
 	required_atmos_temp_min = 3000
 	required_atmos_temp_max = 10000
 	probability = 1
+
+/datum/particle_smasher_recipe/sandstone_quartz
+	result = /obj/item/stack/material/quartz
+	required_material = /obj/item/stack/material/sandstone
+
+	required_energy_min = 200
+	required_energy_max = 300
+	probability = 50
+
+/datum/particle_smasher_recipe/diamond_painite
+	reagents = list("uranium" = 10, "iron" = 10)
+
+	result = /obj/item/stack/material/painite
+	required_material = /obj/item/stack/material/diamond
+
+	required_energy_min = 450
+	required_energy_max = 500
+
+	required_atmos_temp_min = 50
+	required_atmos_temp_max = 150
+	probability = 50
+
+/datum/particle_smasher_recipe/painite_void_opal
+	reagents = list("phoron" = 10, "aluminum" = 10, "sacid" = 10)
+	
+	result = /obj/item/stack/material/void_opal
+	required_material = /obj/item/stack/material/painite
+
+	required_energy_min = 500
+	required_energy_max = 550
+
+	required_atmos_temp_min = 1500
+	required_atmos_temp_max = 2000
+	probability = 50


### PR DESCRIPTION
adds recipes for quartz, painite and void opal via particle smashing
(also tweaks the value of painite for cargo exports)

why:
- more recipes for science to play with, because why not 
- gives more for mining to do bc you need phoron, uranium (albeit a little bit of those if you just make a few gems), and most importantly _diamond_ which is hard-ish to get
- a way to obtain these gems in game because they're pretty :)
- i'm also actually planning on adding a use for them down the line