### PR TITLE
Map update

### DIFF
--- a/maps/stellardelight/stellar_delight1.dmm
+++ b/maps/stellardelight/stellar_delight1.dmm
@@ -3917,13 +3917,7 @@
 	name = "night shift APC";
 	nightshift_setting = 2
 	},
-/obj/random/soap,
-/obj/random/soap,
-/obj/item/weapon/towel/random,
-/obj/item/weapon/towel/random,
-/obj/item/clothing/under/bathrobe,
-/obj/item/clothing/under/bathrobe,
-/obj/structure/table/standard,
+/obj/structure/undies_wardrobe,
 /turf/simulated/floor/tiled/white,
 /area/stellardelight/deck1/shower)
 "io" = (
@@ -5078,6 +5072,10 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/stellardelight/deck1/port)
+"kX" = (
+/obj/item/weapon/bikehorn/rubberducky,
+/turf/simulated/floor/tiled/steel_ridged,
+/area/stellardelight/deck1/shower)
 "kY" = (
 /obj/structure/cable/pink{
 	icon_state = "1-2"
@@ -13529,9 +13527,9 @@
 /turf/simulated/floor/tiled/milspec,
 /area/stellardelight/deck1/exploequipment)
 "CU" = (
-/obj/machinery/washing_machine,
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/machinery/alarm/angled,
+/obj/structure/undies_wardrobe,
 /turf/simulated/floor/tiled/dark,
 /area/stellardelight/deck1/resleeving)
 "CV" = (
@@ -19254,7 +19252,6 @@
 /obj/item/clothing/under/bathrobe,
 /obj/item/clothing/under/bathrobe,
 /obj/structure/table/standard,
-/obj/item/weapon/bikehorn/rubberducky,
 /turf/simulated/floor/tiled/white,
 /area/stellardelight/deck1/shower)
 "PG" = (
@@ -32054,7 +32051,7 @@ SX
 it
 zP
 pS
-cu
+kX
 SV
 Ms
 Dy

--- a/maps/stellardelight/stellar_delight2.dmm
+++ b/maps/stellardelight/stellar_delight2.dmm
@@ -15489,10 +15489,6 @@
 	},
 /turf/simulated/floor/tiled/eris/steel/cargo,
 /area/quartermaster/storage)
-"IP" = (
-/obj/machinery/shield_gen/external,
-/turf/simulated/floor/plating,
-/area/engineering/storage)
 "IQ" = (
 /obj/structure/table/glass,
 /obj/machinery/door/window/southright{
@@ -36545,7 +36541,7 @@ By
 oR
 oR
 gV
-IP
+oR
 qr
 Vf
 Vf

--- a/maps/stellardelight/stellar_delight3.dmm
+++ b/maps/stellardelight/stellar_delight3.dmm
@@ -6438,7 +6438,6 @@
 	},
 /obj/item/weapon/folder/yellow,
 /obj/structure/table/darkglass,
-/obj/structure/table/darkglass,
 /obj/machinery/light,
 /turf/simulated/floor/tiled/dark,
 /area/lawoffice)
@@ -9615,7 +9614,9 @@
 /obj/machinery/computer/ship/navigation/telescreen{
 	pixel_x = 32
 	},
-/obj/machinery/power/shield_generator/charged,
+/obj/machinery/power/shield_generator/charged{
+	power_coefficient = 0.33
+	},
 /obj/structure/cable,
 /turf/simulated/floor,
 /area/stellardelight/deck2/central)


### PR DESCRIPTION
Various map tweaks:

Adds a undies wardrobe to medical and the showers

removes the hull shield from engineering - because parts of it plainly don't work correctly, it traps air when it's not supposed to, meteors just stop when they hit it rather than damaging it, making it essentially impervious to all damage except fists, while being vastly more cheap power wise than the advanced shield gen.

reduces the base power power coefficient on the advanced shield generator to 33%, to try to make it more reasonable to run indefinitely if engineering does some engine upgrades.