### PR TITLE
Makes fuzzycuffs easier to get out of

### DIFF
--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -141,7 +141,7 @@ var/last_chew = 0
 /obj/item/weapon/handcuffs/fuzzy
 	name = "fuzzy cuffs"
 	icon_state = "fuzzycuff"
-	breakouttime = 100 //these are toys like come on
+	breakouttime = 100 //VOREstation edit
 	desc = "Use this to keep... 'prisoners' in line."
 
 /obj/item/weapon/handcuffs/cable

--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -141,6 +141,7 @@ var/last_chew = 0
 /obj/item/weapon/handcuffs/fuzzy
 	name = "fuzzy cuffs"
 	icon_state = "fuzzycuff"
+	breakouttime = 100 //these are toys like come on
 	desc = "Use this to keep... 'prisoners' in line."
 
 /obj/item/weapon/handcuffs/cable


### PR DESCRIPTION
Was messing around in game with them and fuzzycuffs have the same breakout timer as normal cuffs.  They're toys, that doesn't seem 'reasonable' , that they're the same as proper handcuffs.  So this gives them a significantly reduced breakout timer.   10 seconds? Seems reasonable for toys.  