### PR TITLE
Adds general-purpose cooking oil, replaces usages of corn oil

### DIFF
--- a/code/modules/economy/vending_machines.dm
+++ b/code/modules/economy/vending_machines.dm
@@ -57,7 +57,7 @@
 					/obj/item/weapon/reagent_containers/food/drinks/bottle/bluecuracao = 5,
 					/obj/item/weapon/reagent_containers/food/drinks/bottle/cognac = 5,
 					/obj/item/weapon/reagent_containers/food/drinks/bottle/grenadine = 5,
-					/obj/item/weapon/reagent_containers/food/condiment/cornoil = 5,
+					/obj/item/weapon/reagent_containers/food/condiment/cookingoil = 5,
 					/obj/item/weapon/reagent_containers/food/drinks/bottle/kahlua = 5,
 					/obj/item/weapon/reagent_containers/food/drinks/bottle/melonliquor = 5,
 					/obj/item/weapon/reagent_containers/food/drinks/bottle/peppermintschnapps = 5,
@@ -587,7 +587,7 @@
 	icon_state = "dinnerware"
 	products = list(
 	/obj/item/weapon/reagent_containers/food/condiment/yeast = 5,
-	/obj/item/weapon/reagent_containers/food/condiment/cornoil = 5,
+	/obj/item/weapon/reagent_containers/food/condiment/cookingoil = 5,
 	/obj/item/weapon/tray = 8,
 	/obj/item/weapon/material/kitchen/utensil/fork = 6,
 	/obj/item/weapon/material/knife/plastic = 6,

--- a/code/modules/food/food/condiment.dm
+++ b/code/modules/food/food/condiment.dm
@@ -101,9 +101,9 @@
 				desc = "Often used to flavor food or make people sneeze."
 				icon_state = "peppermillsmall"
 				center_of_mass = list("x"=17, "y"=11)
-			if("cornoil")
-				name = "Corn Oil"
-				desc = "A delicious oil used in cooking. Made from corn."
+			if("cookingoil")
+				name = "Cooking Oil"
+				desc = "A delicious oil used in cooking. General purpose."
 				icon_state = "oliveoil"
 				center_of_mass = list("x"=16, "y"=6)
 			if("sugar")
@@ -174,6 +174,13 @@
 /obj/item/weapon/reagent_containers/food/condiment/hotsauce/Initialize()
 	. = ..()
 	reagents.add_reagent("capsaicin", 50)
+
+/obj/item/weapon/reagent_containers/food/condiment/cookingoil
+	name = "Cooking Oil"
+
+/obj/item/weapon/reagent_containers/food/condiment/cookingoil/Initialize()
+	. = ..()
+	reagents.add_reagent("cookingoil", 50)
 
 /obj/item/weapon/reagent_containers/food/condiment/cornoil
 	name = "Corn Oil"

--- a/code/modules/food/food/snacks.dm
+++ b/code/modules/food/food/snacks.dm
@@ -3361,7 +3361,7 @@
 	. = ..()
 	reagents.add_reagent("blackpepper", 1)
 	reagents.add_reagent("sodiumchloride", 1)
-	reagents.add_reagent("cornoil", 1)
+	reagents.add_reagent("cookingoil", 1)
 
 /obj/item/weapon/reagent_containers/food/snacks/turkeyslice
 	name = "turkey drumstick"

--- a/code/modules/food/kitchen/cooking_machines/fryer.dm
+++ b/code/modules/food/kitchen/cooking_machines/fryer.dm
@@ -13,13 +13,13 @@
 	appliancetype = FRYER
 	active_power_usage = 12 KILOWATTS
 	heating_power = 12 KILOWATTS
-	
+
 	light_y = 15
-	
+
 	min_temp = 140 + T0C	// Same as above, increasing this to just under 2x to make the % increase on efficiency not quite so painful as it would be at 80.
 	optimal_temp = 400 + T0C // Increasing this to be 2x Oven to allow for a much higher/realistic frying temperatures. Doesn't really do anything but make heating the fryer take a bit longer.
 	optimal_power = 0.95 // .35 higher than the default to give fryers faster cooking speed.
-	
+
 	idle_power_usage = 3.6 KILOWATTS
 	// Power used to maintain temperature once it's heated.
 	// Going with 25% of the active power. This is a somewhat arbitrary value.
@@ -33,11 +33,11 @@
 
 	var/datum/reagents/oil
 	var/optimal_oil = 9000 //90 litres of cooking oil
-	
+
 /obj/machinery/appliance/cooker/fryer/Initialize()
 	. = ..()
 	fry_loop = new(list(src), FALSE)
-	
+
 	oil = new/datum/reagents(optimal_oil * 1.25, src)
 	var/variance = rand()*0.15
 	// Fryer is always a little below full, but its usually negligible
@@ -45,18 +45,18 @@
 	if(prob(20))
 		// Sometimes the fryer will start with much less than full oil, significantly impacting efficiency until filled
 		variance = rand()*0.5
-	oil.add_reagent("cornoil", optimal_oil*(1 - variance))
+	oil.add_reagent("cookingoil", optimal_oil*(1 - variance))
 
 /obj/machinery/appliance/cooker/fryer/Destroy()
 	QDEL_NULL(fry_loop)
 	QDEL_NULL(oil)
 	return ..()
-	
+
 /obj/machinery/appliance/cooker/fryer/examine(var/mob/user)
 	. = ..()
 	if(Adjacent(user))
 		to_chat(user, "Oil Level: [oil.total_volume]/[optimal_oil]")
-		
+
 /obj/machinery/appliance/cooker/fryer/update_icon() // We add our own version of the proc to use the special fryer double-lights.
 	cut_overlays()
 	var/image/light
@@ -69,7 +69,7 @@
 	light.pixel_x = light_x
 	light.pixel_y = light_y
 	add_overlay(light)
-		
+
 /obj/machinery/appliance/cooker/fryer/heat_up()
 	if (..())
 		//Set temperature of oil reagent
@@ -102,7 +102,7 @@
 
 
 	cooking_power *= oil_efficiency
-	
+
 /obj/machinery/appliance/cooker/fryer/update_icon()
 	if(!stat)
 		..()
@@ -119,7 +119,7 @@
 		if(fry_loop)
 			fry_loop.stop(src)
 	..()
-	
+
 //Fryer gradually infuses any cooked food with oil. Moar calories
 //This causes a slow drop in oil levels, encouraging refill after extended use
 /obj/machinery/appliance/cooker/fryer/do_cooking_tick(var/datum/cooking_item/CI)
@@ -177,13 +177,13 @@
 		return
 
 	// user.visible_message("<span class='danger'>\The [user] starts pushing \the [victim] into \the [src]!</span>")
-	
+
 	//Removed delay on this action in favour of a cooldown after it
 	//If you can lure someone close to the fryer and grab them then you deserve success.
 	//And a delay on this kind of niche action just ensures it never happens
 	//Cooldown ensures it can't be spammed to instakill someone
 	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN*3)
-	
+
 	fry_loop.start(src)
 
 	if(!do_mob(user, victim, 20))
@@ -239,9 +239,9 @@
 
 	//Coat the victim in some oil
 	oil.trans_to(victim, 40)
-	
+
 	fry_loop.stop()
-	
+
 /obj/machinery/appliance/cooker/fryer/attackby(var/obj/item/I, var/mob/user)
 	if(istype(I, /obj/item/weapon/reagent_containers/glass) && I.reagents)
 		if (I.reagents.total_volume <= 0 && oil)

--- a/code/modules/food/recipes_microwave.dm
+++ b/code/modules/food/recipes_microwave.dm
@@ -522,8 +522,15 @@ I said no!
 	)
 	result = /obj/item/weapon/reagent_containers/food/snacks/cutlet
 
-/datum/recipe/roastedsunflowerseeds
+/datum/recipe/roastedcornsunflowerseeds
 	reagents = list("sodiumchloride" = 1, "cornoil" = 1)
+	items = list(
+		/obj/item/weapon/reagent_containers/food/snacks/rawsunflower
+	)
+	result = /obj/item/weapon/reagent_containers/food/snacks/roastedsunflower
+
+/datum/recipe/roastedsunflowerseeds
+	reagents = list("sodiumchloride" = 1, "cookingoil" = 1)
 	items = list(
 		/obj/item/weapon/reagent_containers/food/snacks/rawsunflower
 	)
@@ -538,7 +545,17 @@ I said no!
 
 /datum/recipe/roastedpeanuts
 	fruit = list("peanut" = 2)
+	reagents = list("sodiumchloride" = 2, "cookingoil" = 1)
+	result = /obj/item/weapon/reagent_containers/food/snacks/roastedpeanuts
+
+/datum/recipe/roastedpeanutscorn
+	fruit = list("peanut" = 2)
 	reagents = list("sodiumchloride" = 2, "cornoil" = 1)
+	result = /obj/item/weapon/reagent_containers/food/snacks/roastedpeanuts
+
+/datum/recipe/roastedpeanutspeanut
+	fruit = list("peanut" = 2)
+	reagents = list("sodiumchloride" = 2, "peanutoil" = 1)
 	result = /obj/item/weapon/reagent_containers/food/snacks/roastedpeanuts
 
 /datum/recipe/mint

--- a/code/modules/reagents/machinery/dispenser/reagent_tank.dm
+++ b/code/modules/reagents/machinery/dispenser/reagent_tank.dm
@@ -461,7 +461,7 @@
 
 /obj/structure/reagent_dispensers/cookingoil/New()
 		..()
-		reagents.add_reagent("cornoil",5000)
+		reagents.add_reagent("cookingoil",5000)
 
 /obj/structure/reagent_dispensers/cookingoil/bullet_act(var/obj/item/projectile/Proj)
 	if(Proj.get_structure_damage())

--- a/code/modules/reagents/reactions/instant/drinks.dm
+++ b/code/modules/reagents/reactions/instant/drinks.dm
@@ -141,7 +141,7 @@
 	name = "Space Beer"
 	id = "spacebeer"
 	result = "beer"
-	required_reagents = list("cornoil" = 10)
+	required_reagents = list("cornoil" = 5, "flour" = 5)
 	catalysts = list("enzyme" = 5)
 	result_amount = 10
 
@@ -907,7 +907,7 @@
 	name = "Debugger"
 	id = "debugger"
 	result = "debugger"
-	required_reagents = list("fuel" = 1, "sugar" = 2, "cornoil" = 2)
+	required_reagents = list("fuel" = 1, "sugar" = 2, "cookingoil" = 2)
 	result_amount = 5
 
 /decl/chemical_reaction/instant/drinks/spacersbrew
@@ -1205,14 +1205,14 @@
 	name = "Oil Slick"
 	id = "oilslick"
 	result = "oilslick"
-	required_reagents = list("cornoil" = 2, "honey" = 1)
+	required_reagents = list("cookingoil" = 2, "honey" = 1)
 	result_amount = 3
 
 /decl/chemical_reaction/instant/drinks/slimeslam
 	name = "Slick Slime Slammer"
 	id = "slimeslammer"
 	result = "slimeslammer"
-	required_reagents = list("cornoil" = 2, "peanutbutter" = 1)
+	required_reagents = list("cookingoil" = 2, "peanutbutter" = 1)
 	result_amount = 3
 
 /decl/chemical_reaction/instant/drinks/virginsexonthebeach
@@ -1254,7 +1254,7 @@
 	name = "Soda Oil"
 	id = "sodaoil"
 	result = "sodaoil"
-	required_reagents = list("cornoil" = 4, "sodawater" = 1, "carbon" = 1, "tricordrazine" = 1)
+	required_reagents = list("cookingoil" = 4, "sodawater" = 1, "carbon" = 1, "tricordrazine" = 1)
 	result_amount = 6
 
 /decl/chemical_reaction/instant/drinks/fusionnaire

--- a/code/modules/reagents/reactions/instant/food.dm
+++ b/code/modules/reagents/reactions/instant/food.dm
@@ -52,6 +52,22 @@
 		new /obj/item/weapon/reagent_containers/food/snacks/chocolatebar(location)
 	return
 
+/decl/chemical_reaction/instant/food/cookingoilcorn
+	name = "Cooking Oil"
+	id = "cookingoilcorn"
+	result = "cookingoil"
+	required_reagents = list("cornoil" = 10)
+	catalysts = list("enzyme" = 5)
+	result_amount = 10
+
+/decl/chemical_reaction/instant/food/cookingoilpeanut
+	name = "Cooking Oil"
+	id = "cookingoilpeanut"
+	result = "cookingoil"
+	required_reagents = list("peanutoil" = 10)
+	catalysts = list("enzyme" = 5)
+	result_amount = 10
+
 /decl/chemical_reaction/instant/food/soysauce
 	name = "Soy Sauce"
 	id = "soysauce"
@@ -85,7 +101,7 @@
 	name = "mayonnaise"
 	id = "mayo"
 	result = "mayo"
-	required_reagents = list("egg" = 9, "cornoil" = 5, "lemonjuice" = 5, "sodiumchloride" = 1)
+	required_reagents = list("egg" = 9, "cookingoil" = 5, "lemonjuice" = 5, "sodiumchloride" = 1)
 	result_amount = 15
 
 /decl/chemical_reaction/instant/food/cheesewheel

--- a/code/modules/reagents/reagents/food_drinks.dm
+++ b/code/modules/reagents/reagents/food_drinks.dm
@@ -234,6 +234,12 @@
 			to_chat(M, "<span class='danger'>Searing hot oil burns you, wash it off quick!</span>")
 			lastburnmessage = world.time
 
+/datum/reagent/nutriment/triglyceride/oil/cooking
+	name = "Cooking Oil"
+	id = "cookingoil"
+	description = "A general-purpose cooking oil."
+	reagent_state = LIQUID
+
 /datum/reagent/nutriment/triglyceride/oil/corn
 	name = "Corn Oil"
 	id = "cornoil"


### PR DESCRIPTION
Adds Cooking Oil - separate reagent from Corn Oil that is produced either via 10 units Corn Oil + 5 units of UE as catalyst or via 10 units of Peanut Oil + 5 units of UE as catalyst

Replaces most usages of Corn Oil in recipies, food and drinks alike, with Cooking Oil. Roasted seed recipies can take any kind of oil though.
Replaces contents of bottles in vending machines, lockers and orderable tank in cargo with Cooking Oil

Changes beer recipe from 10 units of Corn Oil + 5 units of UE as catalyst to 5 units of Corn Oil + 5 units of Flour + 5 units of UE as catalyst.

Basically, this makes corn oil and peanut oil more equal, while also making the nitroglycerine bombmaking actually have to rely on botany or xenobotany instead of just ordering a tank of free corn oil.

Potential todo idea later if this is merged: sunflower seed oil as another oil option, with conversion to cooking oil recipe for it too.