### PR TITLE
Fixes invisible Heat Exchange Pipes

### DIFF
--- a/code/game/machinery/pipe/pipe_recipes.dm
+++ b/code/game/machinery/pipe/pipe_recipes.dm
@@ -134,7 +134,7 @@ GLOBAL_LIST_INIT(disposal_pipe_recipes, list(
 	dirtype = initial(construction_type.dispenser_class)
 	if (dirtype == PIPE_TRIN_M)
 		icon_state_m = "[icon_state]m"
-	paintable = ispath(path, /obj/machinery/atmospherics/pipe) && !(ispath(path, /obj/machinery/atmospherics/pipe/vent))	// VOREStation Add
+	paintable = !ispath(path, /obj/machinery/atmospherics/pipe/simple/heat_exchanging) && ispath(path, /obj/machinery/atmospherics/pipe) && !(ispath(path, /obj/machinery/atmospherics/pipe/vent))	// VOREStation Add
 
 
 //

--- a/code/game/objects/structures/crates_lockers/_closets_appearance_definitions.dm
+++ b/code/game/objects/structures/crates_lockers/_closets_appearance_definitions.dm
@@ -1444,6 +1444,13 @@
 		"stripes" = COLOR_OFF_WHITE,
 		"glass" = COLOR_WHITE
 	)
+	
+/decl/closet_appearance/wall_double/survival
+	color = COLOR_CYAN_BLUE
+	decals = null
+	extra_decals = list(
+		"stripe_outer" = COLOR_WHITE
+	)
 
 // Carts
 /decl/closet_appearance/cart

--- a/code/game/objects/structures/crates_lockers/closets/walllocker.dm
+++ b/code/game/objects/structures/crates_lockers/closets/walllocker.dm
@@ -183,3 +183,41 @@
 /obj/structure/closet/walllocker_double/hydrant/east
 	pixel_x = 32
 	dir = EAST
+
+/obj/structure/closet/walllocker_double/survival
+	desc = "A wall mounted storage cabinet. It contains a small amount of emergency supplies for wilderness survival, but they probably won't last very long."
+	name = "Emergency Survival Wall Cabinet"
+	icon = 'icons/obj/closets/bases/wall_double.dmi'
+	closet_appearance = /decl/closet_appearance/wall_double/survival
+	density = FALSE
+	anchored = TRUE
+	store_mobs = 0
+	wall_mounted = 1
+	plane = TURF_PLANE
+	layer = ABOVE_TURF_LAYER
+
+	starts_with = list(
+		/obj/item/clothing/suit/space/emergency,
+		/obj/item/clothing/head/helmet/space/emergency,
+		/obj/item/clothing/mask/breath,
+		/obj/item/weapon/tank/oxygen,
+		/obj/item/device/gps,
+		/obj/item/weapon/material/knife/tacknife/survival,
+		/obj/random/mre,
+		/obj/item/weapon/reagent_containers/food/drinks/cans/waterbottle)
+
+/obj/structure/closet/walllocker_double/survival/north
+	pixel_y = 32
+	dir = SOUTH
+
+/obj/structure/closet/walllocker_double/survival/south
+	pixel_y = -32
+	dir = NORTH
+
+/obj/structure/closet/walllocker_double/survival/west
+	pixel_x = -32
+	dir = WEST
+
+/obj/structure/closet/walllocker_double/survival/east
+	pixel_x = 32
+	dir = EAST

--- a/maps/offmap_vr/talon/talon_v2.dm
+++ b/maps/offmap_vr/talon/talon_v2.dm
@@ -47,7 +47,7 @@ var/global/list/latejoin_talon = list()
 	vessel_mass = 10000
 	vessel_size = SHIP_SIZE_LARGE
 	initial_generic_waypoints = list("talon_v2_near_fore_port", "talon_v2_near_fore_star", "talon_v2_near_aft_port", "talon_v2_near_aft_star", "talon_v2_wing_port", "talon_v2_wing_star")
-	initial_restricted_waypoints = list("Talon's Shuttle" = list("offmap_spawn_talonboat"))
+	initial_restricted_waypoints = list("Talon's Shuttle" = list("offmap_spawn_talonboat"), "Talon's Escape Pod" = list("offmap_spawn_talonpod"))
 
 	skybox_icon = 'talon.dmi'
 	skybox_icon_state = "skybox"
@@ -55,7 +55,7 @@ var/global/list/latejoin_talon = list()
 	skybox_pixel_y = 60
 
 	levels_for_distress = list(1, Z_LEVEL_BEACH, Z_LEVEL_AEROSTAT, Z_LEVEL_DEBRISFIELD, Z_LEVEL_FUELDEPOT)
-	unowned_areas = list(/area/shuttle/talonboat)
+	unowned_areas = list(/area/shuttle/talonboat,/area/shuttle/talonpod)
 
 // The shuttle's 'shuttle' computer
 /obj/machinery/computer/shuttle_control/explore/talonboat
@@ -69,6 +69,8 @@ var/global/list/latejoin_talon = list()
 	vessel_mass = 1000
 	vessel_size = SHIP_SIZE_TINY
 	shuttle = "Talon's Shuttle"
+
+	levels_for_distress = list(1, Z_LEVEL_BEACH, Z_LEVEL_AEROSTAT, Z_LEVEL_DEBRISFIELD, Z_LEVEL_FUELDEPOT)
 
 // A shuttle lateloader landmark
 /obj/effect/shuttle_landmark/shuttle_initializer/talonboat
@@ -90,6 +92,49 @@ var/global/list/latejoin_talon = list()
 
 /area/shuttle/talonboat
 	name = "Talon's Shuttle"
+	requires_power = 1
+	icon = 'icons/turf/areas_vr_talon.dmi'
+	icon_state = "green"
+
+
+///////////////////////////
+//// The Escape Pod
+
+// The shuttle's 'shuttle' computer
+/obj/machinery/computer/shuttle_control/explore/talon_escape
+	name = "shuttle control console"
+	shuttle_tag = "Talon's Escape Pod"
+	req_one_access = list(access_talon)
+
+/obj/effect/overmap/visitable/ship/landable/talon_pod
+	name = "ITV Talon Escape Pod"
+	desc = "An emergency escape pod from the ITV Talon."
+	vessel_mass = 500
+	vessel_size = SHIP_SIZE_TINY
+	shuttle = "Talon's Escape Pod"
+
+	levels_for_distress = list(1, Z_LEVEL_BEACH, Z_LEVEL_AEROSTAT, Z_LEVEL_DEBRISFIELD, Z_LEVEL_FUELDEPOT)
+
+// A shuttle lateloader landmark
+/obj/effect/shuttle_landmark/shuttle_initializer/talonpod
+	name = "Talon's pod bay"
+	base_area = /area/talon_v2/pod_hangar
+	base_turf = /turf/simulated/floor/reinforced
+	landmark_tag = "offmap_spawn_talonpod"
+	docking_controller = "talon_podbay"
+	shuttle_type = /datum/shuttle/autodock/overmap/talonpod
+
+// The talon's boat
+/datum/shuttle/autodock/overmap/talonpod
+	name = "Talon's Escape Pod"
+	current_location = "offmap_spawn_talonpod"
+	docking_controller_tag = "talonpod_docker"
+	shuttle_area = /area/shuttle/talonpod
+	fuel_consumption = 1
+	defer_initialisation = TRUE
+
+/area/shuttle/talonpod
+	name = "Talon's Escape Pod"
 	requires_power = 1
 	icon = 'icons/turf/areas_vr_talon.dmi'
 	icon_state = "green"
@@ -183,6 +228,37 @@ finally, make sure you check the shuttle's APC power level before you head out! 
 I recommend packing a spare battery (there should be a few in engineering you can borrow and charge up) to be safe. don't wanna get stranded!<br>\
 <br>\
 speaking of, if some dumbass does take it and fly off solo then get themselves killed, you can use the remote console in the little spot north of the hangar to initiate basic remote maneuvers. it can't do long-range flight, but the shuttle has some basic autopilot routines for stable orbit and docking that you can ping. this won't help if the shuttle's grounded <b>and</b> out of battery, but better than nothing, right?<br>\
+<br>\
+<i>Harry Townes</i>"}
+
+/obj/item/weapon/paper/talon_cannon
+	name = "ITV Talon OFD Console"
+	info = {"to whoever's got the itchiest trigger finger,<br>\
+as a reward for recent good performance, the lads upstairs have seen fit to have our ship retrofitted with an Obstruction Field Disperser. This fancy bit of hardware can be used to, well, 'disperse' 'obstructions'. asteroids or carp shoals in the way? no problem! load her up and fire! range is pretty short though.<br>\
+<br>\
+they haven't issued very much ammo for it, so if you want more you'll have to trade with those nanotrasen boys and girls. use the blue ones for ion storms and electrical clouds, and the red ones for asteroids and carp. calibration and aiming the thing is a bit of a pain but you'll figure it out. pre-calibrate then mess with the numbers until accuracy hits 100%.<br>\
+<br>\
+aside from that, only thing you really need to keep in mind is that it'll explode pretty spectacularly if you try to fire it whilst it's cooling down *or* if the hatch is closed. hatch is rigged to the bridge shutter controls.<br>\
+<br>\
+oh, and it's not a weapon. don't try to shoot other ships with it or anything, it won't work.<br>\
+<br>\
+<i>Harry Townes</i>"}
+
+/obj/item/weapon/paper/talon_escape_pod
+	name = "ITV Talon Escape Pod"
+	info = {"to whoever's stuck bailing out,<br>\
+after some extensive retrofits to comply with starfaring vessel regulations, our lovely little ship has been outfitted with a proper escape pod, which you are now standing in if you are reading this paper! congratulations!<br>\
+<br>\
+in the untimely event that you actually need to use it and survive long enough to, here's what you need to know;<br>\
+1. the thrusters don't have enough power to really fly around in space very much.<br>\
+2. you probably don't have very much air either.<br>\
+3. on the plus side, plenty of seats and supplies.<br>\
+4. remember to hit the emergency distress signal button.<br>\
+5. you have no sensors, so I hope you wrote down or remember what's around.<br>\
+<br>\
+if you have to punch out, do it whilst the ship is in open space. the pod has <b><u>nothing</u></b> to stop space debris ventilating it! it is rated for reentry though, so if you can bail over a planet it should be able to take you down to a safe landing spot. from there, use the emergency supplies and try to hold out until rescue comes.<br>\
+<br>\
+personally I recommend using the ship's boat if you need to evacuate, but if you're stuck with the pod then... good luck!<br>\
 <br>\
 <i>Harry Townes</i>"}
 

--- a/maps/offmap_vr/talon/talon_v2.dmm
+++ b/maps/offmap_vr/talon/talon_v2.dmm
@@ -2,794 +2,226 @@
 "aa" = (
 /turf/space,
 /area/space)
-"ab" = (
-/obj/machinery/mineral/input,
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "talonrefinery"
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/refining)
 "ac" = (
-/obj/machinery/mineral/processing_unit_console{
+/obj/machinery/computer/ship/helm{
 	req_one_access = list(301)
 	},
-/obj/structure/girder,
-/obj/structure/railing/grey{
-	dir = 4
-	},
-/obj/structure/railing/grey,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced,
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/refining)
-"ad" = (
-/obj/structure/extinguisher_cabinet{
-	dir = 8;
-	pixel_x = 30
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/brig)
-"ae" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway/fore)
-"af" = (
-/obj/structure/closet/secure_closet/talon_guard,
-/obj/item/device/radio/off{
-	channels = list("Talon" = 1)
-	},
-/obj/item/weapon/storage/box/nifsofts_security,
-/turf/simulated/floor/wood,
-/area/talon_v2/crew_quarters/sec_room)
-"ag" = (
-/obj/structure/closet/secure_closet/talon_doctor,
-/obj/item/device/radio/off{
-	channels = list("Talon" = 1)
-	},
-/obj/item/weapon/storage/box/nifsofts_medical,
-/turf/simulated/floor/wood,
-/area/talon_v2/crew_quarters/med_room)
-"ah" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/camera/network/talon,
-/obj/machinery/atm{
-	pixel_y = 31
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway/star)
-"ai" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/talon_v2/crew_quarters/sec_room)
-"aj" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
-/obj/random/multiple/corp_crate/talon_cargo,
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/maintenance/wing_starboard)
-"ak" = (
-/obj/effect/floor_decal/industrial/warning/dust{
-	dir = 9
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/talon_v2/engineering/port)
-"al" = (
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/central_hallway)
-"am" = (
-/obj/machinery/alarm/talon{
-	dir = 4;
-	pixel_x = -22
-	},
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/machinery/power/apc/talon{
-	dir = 1;
-	name = "north bump";
-	pixel_y = 28
-	},
-/obj/structure/table/steel,
-/obj/item/weapon/storage/box/nifsofts_mining,
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/refining)
-"an" = (
-/obj/effect/floor_decal/industrial/warning,
-/obj/machinery/light_switch{
-	pixel_y = 24
-	},
 /obj/machinery/camera/network/talon,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/hangar)
-"ao" = (
-/obj/structure/table/rack/steel,
-/obj/random/maintenance/engineering,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/port_store)
-"ap" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/structure/table/steel,
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 32
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/bridge)
+"ad" = (
+/obj/machinery/door/firedoor/glass/talon,
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced{
+	dir = 4
 	},
-/obj/fiftyspawner/uranium,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/generators)
-"aq" = (
-/obj/machinery/recharge_station,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/generators)
-"ar" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/structure/table/steel,
-/obj/machinery/recharger,
-/obj/item/device/geiger{
-	pixel_x = -7
-	},
-/obj/machinery/alarm/talon{
-	pixel_y = 24
-	},
-/obj/machinery/camera/network/talon{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/generators)
-"as" = (
-/obj/machinery/holoposter{
-	dir = 8;
-	pixel_x = -32
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway/fore)
-"at" = (
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 6
-	},
-/obj/effect/floor_decal/industrial/warning{
+/obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/port)
-"au" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/structure/catwalk,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/door/blast/regular/open{
+	dir = 4;
+	id = "talon_bridge_shields"
 	},
 /turf/simulated/floor/plating,
-/area/talon_v2/engineering)
-"av" = (
-/obj/structure/table/standard,
-/obj/machinery/recharger,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -25
-	},
-/obj/machinery/light/small{
-	dir = 8
+/area/talon_v2/bridge)
+"ae" = (
+/obj/machinery/vending/sovietsoda,
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/central_hallway/fore)
+"af" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/aux,
+/obj/structure/sign/painting/public{
+	pixel_x = -30
 	},
 /turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/workroom)
-"aw" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/area/talon_v2/central_hallway/fore)
+"ag" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/aux,
+/obj/machinery/alarm/talon{
+	dir = 8;
+	pixel_x = 22
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/talon_v2/crew_quarters/med_room)
-"ax" = (
-/obj/structure/closet/secure_closet/talon_engineer,
-/obj/item/device/radio/off{
-	channels = list("Talon" = 1)
-	},
-/obj/item/weapon/storage/box/nifsofts_engineering,
-/turf/simulated/floor/wood,
-/area/talon_v2/crew_quarters/eng_room)
-"ay" = (
-/obj/machinery/disposal/wall{
-	dir = 4
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/central_hallway/fore)
+"ah" = (
+/obj/machinery/light{
+	dir = 8
 	},
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
-/obj/structure/sign/painting/public{
-	pixel_x = -30
-	},
-/turf/simulated/floor/wood,
-/area/talon_v2/crew_quarters/meditation)
-"az" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/structure/cable/yellow{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/structure/cable/yellow{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/structure/catwalk,
-/obj/machinery/power/apc/talon/hyper{
-	dir = 8;
-	pixel_x = -24
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/generators)
-"aA" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/structure/cable/yellow{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/structure/cable/yellow{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/generators)
-"aB" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/effect/catwalk_plated,
-/obj/structure/disposalpipe/junction{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/central_hallway/star)
-"aC" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor/glass/talon,
-/obj/structure/sign/warning/nosmoking_1{
-	pixel_x = -26
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/airlock/engineering{
-	name = "Talon Port Engines";
-	req_one_access = list(301)
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/port)
-"aD" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/structure/cable/yellow{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/structure/cable/yellow{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/structure/cable/yellow{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/generators)
-"aE" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor/glass/talon,
-/obj/machinery/door/airlock/hatch{
-	name = "Generator Room";
-	req_one_access = list(301)
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/sign/warning/radioactive{
-	pixel_y = 32
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/generators)
-"aF" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/vending/medical_talon{
+/obj/machinery/disposal/wall{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/talon_v2/medical)
-"aG" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/catwalk,
+"aj" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering)
-"aH" = (
-/obj/effect/map_helper/airlock/atmos/chamber_pump,
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
+/obj/machinery/alarm/talon{
+	dir = 4;
+	pixel_x = -22
 	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/aux{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/shuttle/talonboat)
-"aI" = (
-/obj/machinery/atmospherics/pipe/manifold/visible,
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/atmospherics)
-"aJ" = (
-/obj/structure/cable/yellow,
-/obj/machinery/power/rtg/advanced,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/generators)
-"aK" = (
-/obj/structure/cable/yellow,
-/obj/machinery/light/small,
-/obj/machinery/power/port_gen/pacman/super/potato,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/generators)
-"aL" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/wall/rshull,
-/area/talon_v2/engineering/star_store)
-"aN" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/brig)
-"aO" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/bridge)
-"aP" = (
-/obj/machinery/power/apc/talon/hyper{
-	pixel_y = -24
-	},
-/obj/effect/catwalk_plated/dark,
-/obj/structure/closet/walllocker_double/hydrant/west,
-/obj/structure/cable/green,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering)
-"aQ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering)
-"aR" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/wall/rshull,
-/area/talon_v2/maintenance/aft_port)
-"aS" = (
-/obj/machinery/door/firedoor/glass/talon,
-/obj/machinery/door/airlock/command{
-	name = "Bridge";
-	req_one_access = list(301)
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/bridge)
-"aT" = (
-/obj/structure/handrail,
-/turf/simulated/floor/tiled/techmaint,
+/obj/random/multiple/corp_crate/talon_cargo,
+/obj/structure/railing/grey,
+/turf/simulated/floor/tiled/techfloor,
 /area/talon_v2/maintenance/wing_starboard)
-"aU" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+"ak" = (
+/obj/effect/floor_decal/industrial/outline/red,
+/obj/machinery/atmospherics/portables_connector{
+	dir = 4
 	},
+/obj/structure/railing/grey,
+/obj/machinery/portable_atmospherics/canister/phoron/engine_setup,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/port)
+"al" = (
+/obj/structure/table/woodentable,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/item/modular_computer/laptop/preset/custom_loadout/standard/talon/pilot,
+/turf/simulated/floor/carpet,
+/area/talon_v2/crew_quarters/pilot_room)
+"am" = (
+/obj/machinery/computer/ship/navigation{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/bridge)
+"an" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/sign/department/bridge{
-	pixel_y = 31
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
-/obj/machinery/camera/network/talon,
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway/fore)
-"aV" = (
-/obj/machinery/light/small,
-/obj/machinery/light_switch{
+/obj/structure/sign/directions/bar{
 	dir = 1;
-	pixel_x = 2;
-	pixel_y = -28
-	},
-/obj/structure/cable/yellow{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/power/terminal{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering)
-"aW" = (
-/obj/effect/shuttle_landmark/shuttle_initializer/talonboat,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 4
-	},
-/obj/effect/overmap/visitable/ship/landable/talon_boat,
-/obj/structure/handrail,
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/aux{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/shuttle/talonboat)
-"aZ" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+	pixel_x = 32;
+	pixel_y = -3
 	},
 /obj/structure/sign/directions/bridge{
 	dir = 1;
-	pixel_x = 32
+	pixel_x = 32;
+	pixel_y = 3
 	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway/fore)
-"ba" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/maintenance/wing_port)
-"bc" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/atmospherics/portables_connector{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/outline/red,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/atmospherics)
-"bd" = (
-/obj/machinery/vending/dinnerware{
-	dir = 1
-	},
-/turf/simulated/floor/wood,
-/area/talon_v2/crew_quarters/bar)
-"bf" = (
-/obj/structure/railing/grey{
-	dir = 1
-	},
-/obj/machinery/oxygen_pump{
-	dir = 8;
-	pixel_x = -30
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/handrail{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/bridge)
-"bg" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/crew_quarters/restrooms)
-"bh" = (
-/obj/effect/map_helper/airlock/atmos/chamber_pump,
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/aux,
-/obj/structure/handrail,
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/maintenance/wing_port)
-"bk" = (
-/obj/structure/table/woodentable,
-/obj/machinery/firealarm{
-	dir = 4;
-	layer = 3.3;
-	pixel_x = 26
-	},
-/obj/machinery/power/apc/talon{
-	name = "south bump";
-	pixel_y = -24
-	},
-/obj/structure/cable/green,
-/obj/item/weapon/paper/talon_captain,
-/turf/simulated/floor/carpet/blucarpet,
-/area/talon_v2/crew_quarters/cap_room)
-"bo" = (
-/obj/machinery/computer/ship/engines,
-/turf/simulated/floor/tiled/techfloor,
-/area/shuttle/talonboat)
-"bp" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/holoposter{
-	pixel_y = -32
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/talon_v2/central_hallway)
-"bq" = (
-/obj/machinery/suit_cycler/vintage/tguard,
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/brig)
-"br" = (
-/obj/effect/floor_decal/industrial/warning/corner,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/hangar)
-"by" = (
-/obj/effect/floor_decal/industrial/warning{
+"ao" = (
+/obj/machinery/computer/ship/sensors{
 	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/hangar)
-"bz" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
 	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/armory)
-"bA" = (
-/obj/effect/floor_decal/industrial/warning/dust/corner{
-	dir = 4
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/space)
-"bB" = (
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/bridge)
+"ap" = (
 /obj/structure/railing/grey{
 	dir = 1
 	},
-/obj/structure/flora/pottedplant/small,
+/obj/structure/flora/pottedplant/sticky,
 /turf/simulated/floor/tiled/techfloor,
 /area/talon_v2/bridge)
-"bC" = (
-/obj/machinery/power/pointdefense{
-	id_tag = "talon_pd"
-	},
-/obj/structure/cable/green,
-/obj/effect/floor_decal/industrial/warning/dust{
-	dir = 10
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/space)
-"bI" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/central_hallway/fore)
-"bJ" = (
-/obj/machinery/atmospherics/pipe/manifold4w/visible/yellow,
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
+"aq" = (
 /obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/starboard)
-"bK" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/maintenance/wing_starboard)
-"bM" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor/glass/talon,
-/obj/machinery/door/airlock/maintenance/common,
-/turf/simulated/floor/plating,
-/area/talon_v2/maintenance/aft_starboard)
-"bN" = (
-/obj/machinery/light_switch{
-	dir = 1;
-	pixel_y = -26
-	},
-/obj/structure/table/woodentable,
-/obj/machinery/button/remote/blast_door{
+/obj/structure/extinguisher_cabinet{
 	dir = 4;
-	id = "talon_quietroom";
-	name = "window blast shields";
+	pixel_x = -30
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering)
+"ar" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 9
+	},
+/obj/structure/railing/grey{
+	dir = 8
+	},
+/obj/structure/table/steel,
+/obj/random/maintenance/engineering,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/engineering)
+"as" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/sign/department/commander{
 	pixel_x = -28
 	},
-/obj/machinery/recharger,
-/turf/simulated/floor/wood,
-/area/talon_v2/crew_quarters/meditation)
-"bP" = (
-/obj/machinery/door/firedoor/glass/talon,
-/obj/machinery/door/airlock/maintenance/common,
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway/fore)
+"at" = (
+/obj/structure/bed/chair/bay/comfy/brown{
+	dir = 1
+	},
+/obj/structure/panic_button{
+	pixel_x = 32;
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/bridge)
+"au" = (
+/obj/structure/bed/chair/bay/chair,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/engineering)
+"av" = (
+/obj/structure/table/standard,
+/obj/fiftyspawner/steel,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/item/device/paicard,
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/workroom)
+"ax" = (
+/obj/machinery/mineral/unloading_machine,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/refining)
+"ay" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/camera/network/talon,
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway/port)
+"az" = (
+/obj/machinery/computer/ship/engines{
+	dir = 8;
+	req_one_access = list(301)
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/bridge)
+"aA" = (
+/obj/structure/catwalk,
+/obj/machinery/light/small{
+	dir = 8
+	},
 /turf/simulated/floor/plating,
-/area/talon_v2/maintenance/aft_starboard)
-"bQ" = (
+/area/talon_v2/engineering)
+"aB" = (
 /obj/machinery/optable,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
@@ -803,567 +235,276 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/talon_v2/medical)
-"bU" = (
-/obj/structure/table/steel,
-/obj/item/device/measuring_tape,
-/obj/item/weapon/tool/wrench,
-/obj/item/weapon/storage/excavation,
-/obj/item/stack/flag/yellow,
-/obj/item/weapon/pickaxe,
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/anomaly_storage)
-"bV" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/gen_store)
-"bX" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/structure/extinguisher_cabinet{
-	dir = 1;
-	pixel_y = -32
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway/star)
-"bY" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/structure/closet/emergsuit_wall{
-	dir = 8;
-	pixel_x = -32
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/port)
-"bZ" = (
-/obj/machinery/oxygen_pump{
-	dir = 1;
-	pixel_y = -30
-	},
-/obj/structure/handrail{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/bridge)
-"ca" = (
+"aC" = (
 /obj/structure/cable/green{
-	d1 = 4;
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
 	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway/star)
-"cc" = (
-/obj/machinery/atmospherics/portables_connector,
-/obj/effect/floor_decal/industrial/outline,
-/obj/machinery/portable_atmospherics/powered/pump/filled,
-/obj/structure/railing/grey{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/manifold/visible,
+/obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/talon_v2/engineering/atmospherics)
-"ce" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1
+"aD" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway)
-"cf" = (
-/obj/machinery/button/remote/airlock{
-	dir = 8;
-	id = "talon_meddoor";
-	name = "Door Bolts";
-	pixel_x = -28;
-	specialfunctions = 4
-	},
-/obj/machinery/light{
+/obj/structure/railing/grey{
 	dir = 8
 	},
-/obj/effect/landmark/start{
-	name = "Talon Doctor"
-	},
-/turf/simulated/floor/carpet,
-/area/talon_v2/crew_quarters/med_room)
-"cg" = (
-/obj/structure/catwalk,
-/obj/machinery/alarm/talon{
-	dir = 4;
-	pixel_x = -22
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/maintenance/aft_starboard)
-"ch" = (
-/turf/simulated/wall/rshull,
-/area/talon_v2/anomaly_storage)
-"ck" = (
-/obj/machinery/door/firedoor/glass/talon,
-/obj/machinery/door/airlock/maintenance/engi{
-	name = "Starboard Eng. Storage";
-	req_one_access = list(301)
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/star_store)
-"cl" = (
-/obj/machinery/disposal/wall{
-	dir = 1
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/engineering/star_store)
-"cm" = (
-/obj/effect/floor_decal/industrial/outline/red,
-/obj/machinery/atmospherics/portables_connector{
-	dir = 8
+/obj/effect/floor_decal/industrial/warning{
+	dir = 10
 	},
 /obj/structure/railing/grey,
-/obj/machinery/portable_atmospherics/canister/phoron/engine_setup,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/port)
-"cn" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
+/obj/structure/table/steel,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/engineering)
+"aE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/maintenance/wing_starboard)
-"cp" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/talon_v2/crew_quarters/cap_room)
-"cr" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway)
-"ct" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/railing/grey{
-	dir = 1
-	},
-/obj/random/multiple/corp_crate/talon_cargo,
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/maintenance/wing_starboard)
-"cv" = (
-/obj/structure/bed/chair/office/light{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/workroom)
-"cw" = (
-/obj/structure/catwalk,
-/obj/structure/handrail,
-/turf/simulated/floor/reinforced/airless,
-/area/talon_v2/maintenance/aft_port)
-"cx" = (
-/obj/machinery/recharge_station,
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/bridge)
-"cB" = (
+/obj/structure/railing/grey,
+/obj/effect/floor_decal/industrial/warning,
+/obj/structure/table/steel,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/engineering)
+"aF" = (
 /obj/machinery/door/firedoor/glass/talon,
-/obj/machinery/door/airlock/maintenance/common,
-/turf/simulated/floor/plating,
-/area/talon_v2/maintenance/aft_port)
-"cE" = (
-/obj/machinery/camera/network/talon{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/maintenance/wing_port)
-"cG" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/closet/walllocker/medical/east,
-/obj/item/weapon/storage/firstaid/regular,
-/obj/item/weapon/storage/firstaid/o2,
-/obj/item/weapon/storage/firstaid/fire,
-/obj/item/device/radio/off{
-	channels = list("Talon" = 1)
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/brig)
-"cH" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/camera/network/talon,
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway/star)
-"cK" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
 /obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/glass/talon,
-/obj/machinery/door/blast/regular/open{
-	id = "talon_boat_cockpit"
-	},
-/obj/structure/window/reinforced{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/shuttle/talonboat)
-"cM" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
+/obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/structure/closet/walllocker_double/east,
+/obj/machinery/door/blast/regular/open{
+	dir = 2;
+	id = "talon_bridge_shields"
+	},
+/obj/machinery/door/blast/regular/open{
+	dir = 2;
+	id = "talon_bridge_shields"
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/bridge)
+"aG" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/computer/ship/engines{
+	dir = 1
+	},
+/obj/structure/railing/grey,
+/obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/engineering/star_store)
-"cN" = (
+/area/talon_v2/engineering)
+"aH" = (
+/obj/structure/closet/walllocker/medical/east,
+/obj/item/weapon/storage/firstaid/regular,
+/obj/item/weapon/storage/firstaid/o2,
+/obj/item/weapon/extinguisher/mini,
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/talonboat)
+"aI" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/atmospherics)
+"aJ" = (
 /obj/machinery/door/firedoor/glass/talon,
-/obj/machinery/door/airlock/security{
-	id_tag = "talon_secdoor";
-	name = "Guard's Cabin";
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/engineeringatmos{
+	name = "Talon Atmospherics";
 	req_one_access = list(301)
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/crew_quarters/sec_room)
-"cS" = (
-/obj/structure/catwalk,
-/obj/machinery/firealarm{
+/obj/structure/sign/directions/engineering/atmospherics{
+	dir = 8;
+	pixel_y = 35
+	},
+/obj/structure/sign/directions/engineering{
 	dir = 4;
-	pixel_x = 26
+	pixel_y = 29
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/atmospherics)
+"aK" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/catwalk,
+/obj/structure/closet/walllocker/medical/south,
+/obj/item/weapon/storage/firstaid/regular,
+/obj/item/weapon/storage/firstaid/fire,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering)
+"aL" = (
+/obj/structure/table/rack/shelf/steel,
+/obj/random/maintenance/engineering,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/star_store)
+"aN" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/bridge)
+"aO" = (
+/obj/structure/hull_corner{
+	dir = 8
+	},
+/obj/structure/lattice,
+/turf/space,
+/area/space)
+"aP" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering)
+"aQ" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering)
+"aR" = (
+/obj/machinery/door/firedoor/glass/talon,
+/obj/machinery/door/airlock/maintenance/common,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/aft_port)
+"aS" = (
+/obj/machinery/door/firedoor/glass/talon,
+/obj/machinery/door/airlock/command{
+	name = "Bridge";
+	req_one_access = list(301)
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/bridge)
+"aT" = (
+/obj/machinery/door/firedoor/glass/talon,
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/bridge)
+"aU" = (
+/obj/machinery/door/firedoor/glass/talon,
+/obj/machinery/door/airlock/command{
+	name = "Bridge";
+	req_one_access = list(301)
 	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/plating,
-/area/talon_v2/maintenance/fore_port)
-"cT" = (
-/obj/structure/catwalk,
-/obj/machinery/light/small,
-/turf/simulated/floor/plating,
-/area/talon_v2/maintenance/fore_port)
-"cU" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 4
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/bridge)
+"aV" = (
+/obj/structure/disposalpipe/junction/yjunction{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
-/area/talon_v2/engineering/starboard)
-"cV" = (
+/area/talon_v2/engineering)
+"aW" = (
+/obj/machinery/atmospherics/portables_connector/fuel{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/canister/phoron,
+/obj/effect/floor_decal/industrial/outline/red,
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/talonboat)
+"aZ" = (
+/obj/machinery/shipsensors{
+	dir = 1
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/talon_v2/bridge)
+"ba" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/random/multiple/corp_crate/talon_cargo,
+/obj/structure/railing/grey{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/maintenance/wing_port)
+"bc" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/holoposter{
+	pixel_y = -32
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway)
+"bd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
 	icon_state = "pipe-c"
 	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/power/sensor{
-	name = "Talon Main Grid";
-	name_tag = "TLN-MAIN-GRID"
-	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/structure/cable/green,
-/obj/effect/catwalk_plated/dark,
-/obj/structure/sign/department/eng{
-	name = "ENGINEER'S QUARTERS";
-	pixel_x = 32
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering)
-"cX" = (
-/obj/effect/floor_decal/industrial/warning/corner,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/anomaly_storage)
-"cZ" = (
-/obj/structure/table/woodentable,
-/obj/item/device/paicard,
-/turf/simulated/floor/wood,
-/area/talon_v2/crew_quarters/meditation)
-"da" = (
-/obj/machinery/door/airlock/glass_external{
-	req_one_access = list(301)
-	},
-/obj/effect/map_helper/airlock/door/int_door,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/maintenance/wing_starboard)
-"db" = (
 /turf/simulated/wall/shull,
-/area/talon_v2/brig)
-"dc" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/aux,
-/obj/machinery/alarm/talon{
-	dir = 8;
-	pixel_x = 22
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/central_hallway/fore)
-"dd" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/aux,
-/obj/machinery/door/firedoor/glass/talon,
-/obj/machinery/door/airlock/maintenance/common,
-/turf/simulated/floor/plating,
-/area/talon_v2/maintenance/wing_starboard)
-"dh" = (
-/obj/structure/ore_box,
-/obj/structure/railing/grey,
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/refining)
-"di" = (
-/obj/machinery/door/firedoor/glass/talon,
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/door/blast/regular/open{
-	dir = 4;
-	id = "talon_bridge_shields"
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/bridge)
-"dj" = (
-/obj/machinery/light/small,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/talon_v2/maintenance/aft_starboard)
-"dl" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/catwalk,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/port_store)
-"dn" = (
-/obj/machinery/door/firedoor/glass/talon,
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/door/blast/regular/open{
-	dir = 4;
-	id = "talon_bridge_shields"
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/bridge)
-"dp" = (
-/obj/machinery/computer/ship/sensors{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/bridge)
-"dq" = (
-/obj/machinery/atmospherics/binary/pump/high_power/on{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/closet/emergsuit_wall{
-	dir = 1;
-	pixel_y = -32
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/atmospherics)
-"dr" = (
-/obj/machinery/door/firedoor/glass/talon,
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/door/blast/regular/open{
-	dir = 4;
-	id = "talon_bridge_shields"
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/bridge)
-"ds" = (
-/obj/machinery/door/firedoor/glass/talon,
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced,
-/obj/machinery/door/blast/regular/open{
-	dir = 2;
-	id = "talon_bridge_shields"
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/bridge)
-"dt" = (
-/obj/machinery/door/firedoor/glass/talon,
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/blast/regular/open{
-	dir = 2;
-	id = "talon_bridge_shields"
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/bridge)
-"dv" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/talon_v2/maintenance/aft_starboard)
-"dw" = (
-/obj/machinery/vending/wallmed1{
-	emagged = 1;
-	pixel_y = 32;
-	shut_up = 0
-	},
-/turf/simulated/floor/wood,
-/area/talon_v2/crew_quarters/bar)
-"dz" = (
-/obj/machinery/door/firedoor/glass/talon,
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/door/blast/regular/open{
-	dir = 2;
-	id = "talon_bridge_shields"
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/bridge)
-"dA" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/port_store)
-"dC" = (
+/area/talon_v2/ofd_ops)
+"bf" = (
 /obj/structure/railing/grey,
 /obj/machinery/light{
 	dir = 8
@@ -1379,209 +520,60 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/talon_v2/bridge)
-"dD" = (
-/obj/structure/railing/grey{
+"bg" = (
+/obj/machinery/door/firedoor/glass/talon,
+/obj/machinery/door/airlock/medical{
+	id_tag = "talon_meddoor";
+	name = "Doctor's Cabin";
+	req_one_access = list(301)
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/crew_quarters/med_room)
+"bh" = (
+/obj/effect/floor_decal/industrial/warning/dust{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/bridge)
-"dF" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/space)
+"bi" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/catwalk,
+/obj/machinery/camera/network/talon{
+	dir = 1
+	},
+/obj/structure/closet/walllocker_double/hydrant/south,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/atmospherics)
+"bn" = (
+/obj/structure/hull_corner{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/turf/space,
+/area/space)
+"bo" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/closet/emergsuit_wall{
-	dir = 1;
-	pixel_y = -32
+/obj/machinery/computer/ship/sensors{
+	dir = 8
 	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/techmaint,
+/turf/simulated/floor/tiled/techfloor,
 /area/talon_v2/central_hallway)
-"dG" = (
-/obj/machinery/door/firedoor/glass/talon,
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/door/blast/regular/open{
-	dir = 2;
-	id = "talon_bridge_shields"
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/bridge)
-"dJ" = (
-/obj/structure/catwalk,
-/obj/structure/trash_pile,
-/turf/simulated/floor/plating,
-/area/talon_v2/maintenance/aft_starboard)
-"dK" = (
-/obj/machinery/power/pointdefense{
-	id_tag = "talon_pd"
-	},
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/effect/floor_decal/industrial/warning/dust{
-	dir = 9
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/space)
-"dL" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/port_store)
-"dN" = (
-/obj/structure/table/rack/shelf/steel,
-/obj/item/device/suit_cooling_unit,
-/obj/item/weapon/tank/oxygen,
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/secure_storage)
-"dO" = (
-/obj/structure/sign/warning/airlock{
-	pixel_x = -31
-	},
-/obj/effect/floor_decal/industrial/warning,
-/obj/structure/handrail{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/maintenance/wing_starboard)
-"dP" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/maintenance/wing_port)
-"dQ" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/maintenance/wing_starboard)
-"dR" = (
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/atmospherics)
-"dT" = (
-/obj/structure/table/standard,
-/obj/fiftyspawner/steel,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/item/device/paicard,
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/workroom)
-"dV" = (
-/obj/machinery/door/airlock/glass_external{
-	req_one_access = list(301)
-	},
-/obj/effect/map_helper/airlock/door/int_door,
-/obj/machinery/atmospherics/pipe/simple/hidden/aux{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/maintenance/fore_starboard)
-"dW" = (
-/obj/structure/railing/grey{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/bridge)
-"dX" = (
-/obj/machinery/computer/ship/navigation,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/button/remote/blast_door{
-	id = "talon_bridge_shields";
-	name = "bridge blast shields";
-	pixel_y = 16
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/bridge)
-"dY" = (
-/obj/machinery/door/firedoor/glass/talon,
-/obj/machinery/door/airlock/maintenance/common,
-/turf/simulated/floor/plating,
-/area/talon_v2/maintenance/fore_starboard)
-"dZ" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/railing/grey,
-/obj/random/multiple/corp_crate/talon_cargo,
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/maintenance/wing_port)
-"ed" = (
-/obj/structure/railing/grey{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/bridge)
-"ef" = (
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/bridge)
-"eg" = (
+"bp" = (
 /obj/machinery/alarm/talon{
 	dir = 8;
 	pixel_x = 22
@@ -1595,260 +587,63 @@
 /obj/item/weapon/bedsheet/red,
 /turf/simulated/floor/carpet,
 /area/talon_v2/crew_quarters/sec_room)
-"eh" = (
-/obj/machinery/door/firedoor/glass/talon,
+"br" = (
+/obj/structure/flora/pottedplant/fern,
+/obj/machinery/holoposter{
+	dir = 1;
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/central_hallway)
+"bt" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment{
-	dir = 1
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/turf/simulated/floor/plating,
-/area/talon_v2/bridge)
-"ei" = (
-/obj/machinery/conveyor{
-	id = "talontrash"
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering)
-"ej" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+/obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
+/obj/machinery/door/blast/regular/open{
+	id = "talon_windows"
 	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/effect/catwalk_plated,
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/central_hallway/fore)
-"ek" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/random/multiple/corp_crate/talon_cargo,
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/maintenance/wing_port)
-"el" = (
-/obj/machinery/vending/engineering{
-	products = list(/obj/item/clothing/under/rank/chief_engineer = 4, /obj/item/clothing/under/rank/engineer = 4, /obj/item/clothing/shoes/orange = 4, /obj/item/clothing/head/hardhat = 4, /obj/item/weapon/storage/belt/utility = 4, /obj/item/clothing/glasses/meson = 4, /obj/item/clothing/gloves/yellow = 4, /obj/item/weapon/tool/screwdriver = 12, /obj/item/weapon/tool/crowbar = 12, /obj/item/weapon/tool/wirecutters = 12, /obj/item/device/multitool = 12, /obj/item/weapon/tool/wrench = 12, /obj/item/device/t_scanner = 12, /obj/item/stack/cable_coil/heavyduty = 8, /obj/item/weapon/cell = 8, /obj/item/weapon/weldingtool = 8, /obj/item/clothing/head/welding = 8, /obj/item/weapon/light/tube = 10, /obj/item/clothing/head/hardhat/red = 4, /obj/item/clothing/suit/fire = 4, /obj/item/weapon/stock_parts/scanning_module = 5, /obj/item/weapon/stock_parts/micro_laser = 5, /obj/item/weapon/stock_parts/matter_bin = 5, /obj/item/weapon/stock_parts/manipulator = 5, /obj/item/weapon/stock_parts/console_screen = 5);
-	req_access = list(301);
-	req_log_access = 301;
-	req_one_access = list(301)
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/engineering/star_store)
-"eo" = (
+/obj/machinery/door/firedoor/glass/talon,
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/turf/simulated/floor/plating,
+/area/talon_v2/crew_quarters/bar)
+"bx" = (
+/obj/structure/trash_pile,
+/obj/machinery/camera/network/talon,
+/obj/structure/railing/grey{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/closet/emergsuit_wall{
-	pixel_y = 32
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway/star)
-"ep" = (
-/obj/machinery/conveyor{
-	dir = 8;
-	id = "talontrash"
-	},
-/obj/machinery/door/blast/regular{
-	dir = 4;
-	id = "talontrashblast"
 	},
 /turf/simulated/floor/plating,
-/area/talon_v2/engineering/starboard)
-"eq" = (
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/port_store)
-"er" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
+/area/talon_v2/engineering/star_store)
+"bz" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/random/multiple/corp_crate/talon_cargo,
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/maintenance/wing_starboard)
-"eu" = (
-/obj/structure/catwalk,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/talon_v2/maintenance/fore_starboard)
-"ew" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/maintenance/wing_port)
-"ex" = (
-/obj/machinery/conveyor{
-	dir = 8;
-	id = "talontrash"
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/starboard)
-"ey" = (
-/obj/machinery/button/remote/airlock{
-	dir = 4;
-	id = "talon_capdoor";
-	name = "Door Bolts";
-	pixel_x = 28;
-	specialfunctions = 4
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/wood,
-/area/talon_v2/crew_quarters/cap_room)
-"ez" = (
-/obj/machinery/light/small,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/talon_v2/maintenance/aft_port)
-"eC" = (
-/obj/effect/floor_decal/industrial/outline/red,
-/obj/machinery/atmospherics/portables_connector{
-	dir = 8
-	},
-/obj/structure/railing/grey,
-/obj/machinery/portable_atmospherics/canister/phoron/engine_setup,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/starboard)
-"eD" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/structure/disposalpipe/junction{
-	dir = 4;
-	icon_state = "pipe-j2"
-	},
-/turf/simulated/floor/tiled/white,
-/area/talon_v2/medical)
-"eF" = (
-/obj/structure/disposaloutlet{
-	dir = 8
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/starboard)
-"eG" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/secure_storage)
-"eH" = (
-/obj/effect/shuttle_landmark/premade/talon_v2_near_aft_port,
-/turf/space,
-/area/space)
-"eI" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/structure/railing/grey{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering)
-"eK" = (
-/obj/machinery/disposal/deliveryChute{
-	dir = 1
-	},
-/obj/structure/disposalpipe/trunk,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering)
-"eL" = (
-/obj/structure/railing/grey{
-	dir = 1
-	},
-/obj/structure/flora/pottedplant/sticky,
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/bridge)
-"eM" = (
-/obj/machinery/door/window/brigdoor/eastleft{
-	dir = 1;
-	req_access = list(301)
-	},
-/obj/machinery/button/remote/blast_door{
-	dir = 1;
-	id = "talontrashblast";
-	pixel_y = -28
-	},
-/obj/machinery/conveyor_switch/oneway{
-	id = "talontrash"
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/starboard)
-"eN" = (
-/obj/machinery/light/small,
-/obj/structure/railing/grey{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/starboard)
-"eP" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/wall/rshull,
-/area/talon_v2/engineering)
-"eR" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/loot_pile/maint/trash,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering)
-"eS" = (
-/obj/structure/table/rack/shelf/steel,
-/obj/item/weapon/gun/energy/locked/frontier/holdout/unlocked,
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/armory)
-"eT" = (
+/area/talon_v2/central_hallway/port)
+"bB" = (
 /obj/structure/railing/grey,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -1867,499 +662,100 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/talon_v2/bridge)
-"eV" = (
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/workroom)
-"eX" = (
-/obj/machinery/atmospherics/portables_connector/aux,
-/obj/effect/floor_decal/industrial/outline,
-/obj/structure/railing/grey,
-/obj/machinery/portable_atmospherics/canister/air,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/port_store)
-"eY" = (
-/obj/structure/sign/warning/airlock{
-	pixel_y = -32
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/aux{
-	dir = 5
-	},
-/obj/machinery/light/small,
-/turf/simulated/floor/plating,
-/area/talon_v2/maintenance/aft_port)
-"eZ" = (
-/obj/effect/map_helper/airlock/sensor/int_sensor,
-/obj/machinery/atmospherics/pipe/simple/hidden/aux{
-	dir = 10
-	},
-/obj/machinery/airlock_sensor{
-	dir = 8;
-	pixel_x = 28;
-	req_one_access = list(301)
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/talon_v2/maintenance/aft_port)
-"fa" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/warning,
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/anomaly_storage)
-"fb" = (
-/turf/simulated/wall/shull,
-/area/talon_v2/engineering/star_store)
-"fd" = (
-/obj/structure/table/rack/shelf/steel,
-/obj/item/clothing/head/beret/talon,
-/obj/item/clothing/head/beret/talon,
-/obj/item/clothing/head/beret/talon,
-/obj/item/clothing/head/beret/talon,
-/obj/item/clothing/suit/storage/hooded/wintercoat/talon,
-/obj/item/clothing/suit/storage/hooded/wintercoat/talon,
-/obj/item/clothing/suit/storage/hooded/wintercoat/talon,
-/obj/item/clothing/suit/storage/hooded/wintercoat/talon,
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/secure_storage)
-"ff" = (
-/obj/effect/map_helper/airlock/sensor/int_sensor,
-/obj/machinery/atmospherics/pipe/simple/hidden/aux{
-	dir = 6
-	},
-/obj/machinery/airlock_sensor{
-	dir = 4;
-	pixel_x = -28;
-	req_one_access = list(301)
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/talon_v2/maintenance/aft_starboard)
-"fg" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/structure/table/rack/steel,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/star_store)
-"fh" = (
-/obj/structure/sign/warning/airlock{
-	pixel_y = -32
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/aux{
-	dir = 9
-	},
-/obj/machinery/light/small,
-/turf/simulated/floor/plating,
-/area/talon_v2/maintenance/aft_starboard)
-"fi" = (
-/obj/structure/table/rack/shelf/steel,
-/obj/random/maintenance/engineering,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/star_store)
-"fj" = (
-/obj/structure/closet/walllocker_double/hydrant/west,
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/secure_storage)
-"fk" = (
-/obj/structure/railing/grey{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/machinery/smartfridge/sheets/persistent_lossy{
-	layer = 3.3
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/refining)
-"fm" = (
-/obj/machinery/door/airlock/glass_external{
-	req_one_access = list(301)
-	},
-/obj/effect/map_helper/airlock/door/int_door,
-/obj/machinery/atmospherics/pipe/simple/hidden/aux,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/maintenance/aft_port)
-"fn" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/aux{
-	dir = 4
-	},
-/obj/effect/map_helper/airlock/atmos/chamber_pump,
-/obj/structure/handrail{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/warning,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/maintenance/aft_port)
-"fo" = (
-/obj/machinery/door/firedoor/glass/talon,
-/obj/machinery/door/airlock/glass{
-	name = "Cantina"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/crew_quarters/bar)
-"fp" = (
-/obj/machinery/door/firedoor/glass/talon,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+"bC" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock{
-	name = "Storage Room"
+/obj/structure/catwalk,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/aft_port)
+"bG" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/glass/talon,
+/obj/machinery/door/airlock/maintenance/common,
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/aft_port)
+"bI" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/sign/department/bridge{
+	pixel_y = 31
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/obj/machinery/camera/network/talon,
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/central_hallway/fore)
+"bJ" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/sign/directions/bridge{
+	dir = 1;
+	pixel_x = 32
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/gen_store)
-"fq" = (
-/obj/effect/map_helper/airlock/sensor/chamber_sensor,
-/obj/machinery/atmospherics/pipe/simple/hidden/aux{
-	dir = 9
-	},
-/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	dir = 1;
-	id_tag = "talon_port_aft";
-	pixel_y = -30;
-	req_one_access = list(301)
-	},
-/obj/machinery/airlock_sensor{
-	dir = 8;
-	pixel_x = 28;
-	req_one_access = list(301)
-	},
-/obj/machinery/light/small,
-/obj/structure/handrail{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/maintenance/aft_port)
-"fr" = (
-/obj/effect/map_helper/airlock/sensor/chamber_sensor,
-/obj/machinery/atmospherics/pipe/simple/hidden/aux{
-	dir = 5
-	},
-/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	dir = 1;
-	id_tag = "talon_starboard_aft";
-	pixel_y = -30;
-	req_one_access = list(301)
-	},
-/obj/machinery/airlock_sensor{
+/area/talon_v2/central_hallway/fore)
+"bK" = (
+/obj/machinery/power/apc/talon{
 	dir = 4;
-	pixel_x = -28;
-	req_one_access = list(301)
+	name = "east bump";
+	pixel_x = 24
 	},
-/obj/machinery/light/small,
-/obj/structure/handrail{
-	dir = 4
+/obj/structure/cable/green,
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
 	},
-/obj/effect/floor_decal/industrial/warning/corner,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/maintenance/aft_starboard)
-"fs" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/aux{
-	dir = 8
-	},
-/obj/effect/map_helper/airlock/atmos/chamber_pump,
 /obj/structure/handrail{
 	dir = 8
 	},
-/obj/effect/floor_decal/industrial/warning,
-/turf/simulated/floor/tiled/techfloor/grid,
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/maintenance/wing_starboard)
+"bM" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/catwalk,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
 /area/talon_v2/maintenance/aft_starboard)
-"fv" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/random/multiple/corp_crate/talon_cargo,
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/maintenance/wing_port)
-"fw" = (
-/obj/structure/railing/grey,
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/obj/structure/extinguisher_cabinet{
-	dir = 8;
-	pixel_x = 30
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/bridge)
-"fx" = (
-/obj/structure/table/steel,
-/obj/machinery/cell_charger,
-/obj/item/weapon/cell/apc,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/engineering)
-"fz" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/wood,
-/area/talon_v2/crew_quarters/cap_room)
-"fC" = (
+"bN" = (
 /obj/structure/reagent_dispensers/water_cooler/full,
 /obj/structure/sign/painting/public{
 	pixel_y = 30
 	},
 /turf/simulated/floor/wood,
 /area/talon_v2/crew_quarters/bar)
-"fF" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/atmospherics)
-"fG" = (
-/obj/machinery/door/airlock/glass_external{
-	req_one_access = list(301)
-	},
-/obj/effect/map_helper/airlock/door/ext_door,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/maintenance/aft_port)
-"fM" = (
-/obj/structure/table/woodentable,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
-/turf/simulated/floor/wood,
-/area/talon_v2/crew_quarters/meditation)
-"fN" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/firealarm{
-	layer = 3.3;
-	pixel_y = 26
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway/star)
-"fQ" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+"bP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering)
-"fR" = (
-/obj/effect/map_helper/airlock/sensor/ext_sensor,
-/obj/machinery/airlock_sensor{
-	pixel_x = -28;
-	pixel_y = 28;
-	req_one_access = list(301)
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/reinforced/airless,
-/area/talon_v2/maintenance/aft_port)
-"fS" = (
-/obj/effect/map_helper/airlock/sensor/ext_sensor,
-/obj/machinery/airlock_sensor{
-	pixel_x = 28;
-	pixel_y = 28;
-	req_one_access = list(301)
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/reinforced/airless,
-/area/talon_v2/maintenance/aft_starboard)
-"fU" = (
-/obj/machinery/computer/ship/engines{
-	dir = 8;
-	req_one_access = list(301)
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/bridge)
-"fV" = (
-/turf/simulated/wall/shull,
-/area/talon_v2/hangar)
-"fW" = (
-/turf/simulated/wall/shull,
-/area/talon_v2/refining)
-"gb" = (
-/obj/structure/bed/chair/wood,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/sign/painting/public{
-	pixel_x = 30
-	},
-/turf/simulated/floor/carpet/blucarpet,
-/area/talon_v2/crew_quarters/cap_room)
-"gc" = (
-/obj/effect/map_helper/airlock/atmos/chamber_pump,
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/aux{
-	dir = 1
-	},
-/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	dir = 1;
-	id_tag = "talon_port";
-	pixel_y = -30;
-	req_one_access = list(301)
-	},
-/obj/machinery/light/small,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/maintenance/wing_port)
-"gd" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/junction{
-	dir = 8;
+	dir = 2;
 	icon_state = "pipe-j2"
 	},
-/turf/simulated/floor/wood,
-/area/talon_v2/crew_quarters/eng_room)
-"ge" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/turf/simulated/floor/wood,
-/area/talon_v2/crew_quarters/bar)
-"gg" = (
-/obj/machinery/light_switch{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/structure/table/rack/shelf/steel,
-/obj/item/weapon/whetstone,
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/armory)
-"gj" = (
-/obj/machinery/power/sensor{
-	name = "Talon Power Generation";
-	name_tag = "TLN-PWR-GEN"
-	},
-/obj/structure/cable/yellow{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/structure/cable/yellow,
-/obj/structure/cable/yellow{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/structure/cable/yellow{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/obj/effect/catwalk_plated/dark,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering)
-"gl" = (
-/obj/structure/catwalk,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering)
-"gm" = (
-/obj/structure/table/woodentable,
-/turf/simulated/floor/wood,
-/area/talon_v2/crew_quarters/cap_room)
-"gn" = (
-/obj/machinery/alarm/talon{
-	dir = 1;
-	pixel_y = -25
-	},
-/obj/structure/table/standard,
-/obj/machinery/photocopier/faxmachine/talon,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/workroom)
-"go" = (
-/obj/machinery/alarm/talon{
-	dir = 8;
-	pixel_x = 22
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/talon_v2/maintenance/aft_port)
-"gr" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/aux{
-	dir = 5
-	},
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/machinery/power/apc/talon{
-	name = "south bump";
-	pixel_y = -24
-	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/maintenance/fore_port)
-"gs" = (
-/obj/effect/floor_decal/emblem/talon_big{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment{
-	dir = 1
-	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -2367,838 +763,113 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/talon_v2/central_hallway/fore)
-"gt" = (
-/turf/simulated/floor/carpet/blucarpet,
-/area/talon_v2/crew_quarters/cap_room)
-"gu" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+"bQ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/effect/floor_decal/industrial/warning/dust/corner,
-/turf/simulated/floor/reinforced/airless,
-/area/space)
-"gx" = (
-/obj/machinery/portable_atmospherics/canister/air,
-/obj/structure/railing/grey,
-/obj/effect/floor_decal/industrial/outline,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/atmospherics)
-"gA" = (
-/obj/structure/table/rack/steel,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/item/weapon/storage/firstaid/regular,
+/obj/item/weapon/storage/firstaid/o2,
+/obj/structure/closet/walllocker/medical/south,
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/crew_quarters/restrooms)
+"bT" = (
+/obj/effect/floor_decal/industrial/outline/red,
+/obj/machinery/portable_atmospherics/canister/empty/phoron,
 /turf/simulated/floor/plating,
 /area/talon_v2/engineering/star_store)
-"gB" = (
+"bU" = (
 /obj/machinery/light{
-	dir = 1
+	dir = 4
 	},
-/obj/structure/bed/chair/bay/chair,
-/obj/machinery/camera/network/talon,
-/obj/machinery/button/remote/blast_door{
-	id = "talon_brig2";
-	name = "Cell 2 Shutters";
-	pixel_x = 7;
-	pixel_y = 28;
-	req_one_access = list(301)
-	},
-/obj/machinery/button/remote/blast_door{
-	id = "talon_brig1";
-	name = "Cell 1 Shutters";
-	pixel_x = -8;
-	pixel_y = 28;
-	req_one_access = list(301)
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/brig)
-"gD" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/floor_decal/industrial/warning/dust{
-	dir = 8
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/space)
-"gE" = (
-/obj/structure/catwalk,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/maintenance/fore_starboard)
-"gF" = (
-/obj/machinery/ntnet_relay,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/engineering)
-"gH" = (
-/obj/machinery/door/firedoor/glass/talon,
-/obj/machinery/door/airlock/multi_tile/glass{
-	dir = 1;
-	name = "Cargo Bay";
-	req_one_access = list(301)
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway/port)
-"gI" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/talon_v2/maintenance/aft_port)
-"gJ" = (
-/obj/machinery/door/blast/regular{
-	dir = 4;
-	id = "talon_cargo_port";
-	name = "Cargo Loading Hatch"
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/maintenance/wing_port)
-"gM" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/structure/catwalk,
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/starboard)
-"gN" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/obj/effect/catwalk_plated,
 /obj/structure/disposalpipe/segment{
-	dir = 1
+	dir = 4
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/techmaint,
 /area/talon_v2/central_hallway/fore)
-"gO" = (
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 9
-	},
+"bW" = (
 /obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/port)
-"gP" = (
-/obj/effect/floor_decal/industrial/warning/dust/corner{
 	dir = 1
 	},
-/obj/structure/hull_corner/long_vert{
-	dir = 5
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/space)
-"gR" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/refining)
-"gU" = (
-/obj/machinery/power/apc/talon{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
-/obj/structure/cable/green,
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/structure/handrail{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/maintenance/wing_starboard)
-"gV" = (
-/obj/structure/disposalpipe/segment{
+/obj/structure/ship_munition/disperser_charge/explosive,
+/obj/structure/railing{
 	dir = 1
 	},
-/obj/machinery/holoposter{
-	dir = 4;
-	pixel_x = 32
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway)
-"gX" = (
-/obj/structure/hull_corner/long_horiz{
-	dir = 10
-	},
-/turf/space,
-/area/space)
-"hb" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/camera/network/talon{
-	dir = 1
-	},
-/obj/structure/vehiclecage/quadbike,
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/maintenance/wing_starboard)
-"hc" = (
-/obj/effect/floor_decal/emblem/talon_big{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/central_hallway/fore)
-"hg" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/holoposter{
-	dir = 8;
-	pixel_x = -32
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway)
-"hh" = (
-/obj/machinery/door/firedoor/glass/talon,
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/machinery/door/blast/regular/open{
-	dir = 4;
-	id = "talon_bridge_shields"
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/bridge)
-"hi" = (
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 8
-	},
-/obj/machinery/alarm/talon{
-	dir = 8;
-	pixel_x = 22
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/anomaly_storage)
-"hj" = (
-/turf/simulated/wall/rshull,
-/area/talon_v2/engineering/star_store)
-"hk" = (
-/obj/machinery/light/small,
-/obj/structure/sign/directions/engineering/engeqp{
-	pixel_y = -24
-	},
-/turf/simulated/floor/carpet,
-/area/talon_v2/crew_quarters/eng_room)
-"ho" = (
-/obj/structure/bed/chair/bay/shuttle{
-	dir = 1
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/shuttle/talonboat)
-"hp" = (
-/obj/machinery/atmospherics/binary/algae_farm/filled{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/atmospherics)
-"hr" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/hangar)
-"hs" = (
-/obj/machinery/door/firedoor/glass/talon,
-/obj/machinery/door/airlock/glass{
-	name = "Cantina"
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/crew_quarters/bar)
-"hu" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/bridge)
-"hw" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 6
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/atmospherics)
-"hA" = (
-/obj/structure/bookcase/manuals/engineering,
-/turf/simulated/floor/wood,
-/area/talon_v2/crew_quarters/meditation)
-"hD" = (
-/obj/structure/closet/autolok_wall{
-	dir = 1;
-	pixel_y = -32
-	},
-/obj/structure/handrail{
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 1
-	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/aux{
-	dir = 4
-	},
-/obj/effect/map_helper/airlock/atmos/chamber_pump,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/shuttle/talonboat)
-"hG" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/floor_decal/industrial/warning/dust/corner{
-	dir = 8
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/space)
-"hH" = (
-/obj/effect/map_helper/airlock/sensor/int_sensor,
-/obj/machinery/airlock_sensor{
-	dir = 1;
-	pixel_y = -23;
-	req_one_access = list(301)
-	},
-/obj/structure/bed/chair/bay/shuttle{
-	dir = 1
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/shuttle/talonboat)
-"hK" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/wall/rshull,
-/area/talon_v2/maintenance/aft_starboard)
-"hL" = (
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/talon_v2/maintenance/aft_starboard)
-"hM" = (
-/obj/structure/table/woodentable,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/item/modular_computer/laptop/preset/custom_loadout/standard/talon/medical,
+/turf/simulated/floor/reinforced,
+/area/talon_v2/ofd_ops)
+"bX" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
-/turf/simulated/floor/carpet,
-/area/talon_v2/crew_quarters/med_room)
-"hP" = (
-/obj/machinery/power/pointdefense{
-	id_tag = "talon_pd"
+/turf/simulated/floor/tiled/white,
+/area/talon_v2/medical)
+"bY" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 9
 	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/effect/floor_decal/industrial/warning/dust{
-	dir = 5
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/space)
-"hQ" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/armory)
-"hS" = (
 /obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/talon_v2/maintenance/fore_port)
-"hT" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/central_hallway/fore)
-"hU" = (
-/obj/machinery/camera/network/talon{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/brig)
-"hW" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/wall/rshull,
-/area/talon_v2/maintenance/aft_port)
-"hY" = (
-/obj/machinery/atmospherics/portables_connector{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/outline,
+/obj/structure/railing/grey,
 /turf/simulated/floor/plating,
 /area/talon_v2/engineering/atmospherics)
-"ia" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+"bZ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/wall/shull,
 /area/talon_v2/crew_quarters/bar)
-"ig" = (
-/obj/structure/sign/warning/nosmoking_1{
-	pixel_x = 26
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/obj/structure/catwalk,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering)
-"ii" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/star_store)
-"ik" = (
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/power/apc/talon{
-	dir = 1;
-	name = "north bump";
-	pixel_y = 28
-	},
-/obj/structure/catwalk,
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/maintenance/aft_starboard)
-"in" = (
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/star_store)
-"iq" = (
-/turf/simulated/floor/wood,
-/area/talon_v2/crew_quarters/eng_room)
-"ir" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/random/multiple/corp_crate/talon_cargo,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/maintenance/wing_port)
-"iv" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/aux{
-	dir = 6
-	},
-/obj/structure/handrail,
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/maintenance/fore_port)
-"iw" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/door/blast/regular/open{
-	id = "talon_windows"
-	},
-/obj/machinery/door/firedoor/glass/talon,
-/turf/simulated/floor/plating,
-/area/talon_v2/crew_quarters/bar)
-"iy" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/obj/structure/catwalk,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/maintenance/aft_port)
-"iz" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/wood,
-/area/talon_v2/crew_quarters/bar)
-"iB" = (
-/obj/machinery/mineral/stacking_machine,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/refining)
-"iD" = (
-/obj/structure/catwalk,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/talon_v2/maintenance/aft_port)
-"iF" = (
-/obj/machinery/airlock_sensor{
-	dir = 4;
-	pixel_x = -28;
-	pixel_y = 28;
-	req_one_access = list(301)
-	},
-/obj/effect/map_helper/airlock/sensor/ext_sensor,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/reinforced/airless,
-/area/talon_v2/maintenance/wing_starboard)
-"iI" = (
-/obj/machinery/atmospherics/portables_connector/aux{
-	dir = 4
-	},
-/obj/machinery/light/small,
-/obj/effect/floor_decal/industrial/outline,
-/obj/machinery/portable_atmospherics/canister/air,
-/obj/machinery/alarm/talon{
-	dir = 1;
-	pixel_y = -25
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/shuttle/talonboat)
-"iJ" = (
-/obj/structure/catwalk,
-/obj/machinery/alarm/talon{
-	dir = 4;
-	pixel_x = -22
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/star_store)
-"iM" = (
-/obj/structure/catwalk,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/maintenance/fore_starboard)
-"iN" = (
-/obj/machinery/vending/engivend{
-	products = list(/obj/item/device/geiger = 4, /obj/item/clothing/glasses/meson = 2, /obj/item/device/multitool = 4, /obj/item/weapon/cell/high = 10, /obj/item/weapon/airlock_electronics = 10, /obj/item/weapon/module/power_control = 10, /obj/item/weapon/circuitboard/airalarm = 10, /obj/item/weapon/circuitboard/firealarm = 10, /obj/item/weapon/circuitboard/status_display = 2, /obj/item/weapon/circuitboard/ai_status_display = 2, /obj/item/weapon/circuitboard/newscaster = 2, /obj/item/weapon/circuitboard/holopad = 2, /obj/item/weapon/circuitboard/intercom = 4, /obj/item/weapon/circuitboard/security/telescreen/entertainment = 4, /obj/item/weapon/stock_parts/motor = 2, /obj/item/weapon/stock_parts/spring = 2, /obj/item/weapon/stock_parts/gear = 2, /obj/item/weapon/circuitboard/atm, /obj/item/weapon/circuitboard/guestpass, /obj/item/weapon/circuitboard/keycard_auth, /obj/item/weapon/circuitboard/photocopier, /obj/item/weapon/circuitboard/fax, /obj/item/weapon/circuitboard/request, /obj/item/weapon/circuitboard/microwave, /obj/item/weapon/circuitboard/washing, /obj/item/weapon/circuitboard/scanner_console, /obj/item/weapon/circuitboard/sleeper_console, /obj/item/weapon/circuitboard/body_scanner, /obj/item/weapon/circuitboard/sleeper, /obj/item/weapon/circuitboard/dna_analyzer, /obj/item/weapon/circuitboard/partslathe);
-	req_access = list(301);
-	req_log_access = 301
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/engineering/star_store)
-"iP" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/central_hallway/fore)
-"iQ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/carpet,
-/area/talon_v2/crew_quarters/med_room)
-"iR" = (
-/obj/machinery/atmospherics/pipe/simple/visible/yellow,
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/port)
-"iS" = (
+"cc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/visible/yellow,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/port)
-"iU" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/obj/random/multiple/corp_crate/talon_cargo,
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/maintenance/wing_starboard)
-"iV" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/bridge)
-"jb" = (
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 4
-	},
 /obj/structure/cable/green{
 	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/hangar)
-"jc" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/railing/grey,
-/obj/structure/railing/grey{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 6
-	},
-/obj/machinery/power/shield_generator/charged,
-/obj/structure/cable/green{
 	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/engineering)
-"jg" = (
-/obj/effect/landmark/start{
-	name = "Talon Pilot"
-	},
-/obj/machinery/light_switch{
-	dir = 8;
-	pixel_x = 24
-	},
-/turf/simulated/floor/carpet,
-/area/talon_v2/crew_quarters/pilot_room)
-"jh" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/random/multiple/corp_crate/talon_cargo,
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/maintenance/wing_port)
-"ji" = (
-/obj/structure/table/rack/shelf/steel,
-/obj/item/weapon/gun/energy/gun,
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/armory)
-"jk" = (
-/obj/structure/hull_corner/long_vert{
-	dir = 5
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/space)
-"jr" = (
-/obj/structure/fitness/weightlifter,
-/obj/machinery/camera/network/talon{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/workroom)
-"ju" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/crew_quarters/restrooms)
-"jv" = (
-/obj/structure/table/woodentable,
-/obj/machinery/button/remote/blast_door{
-	dir = 8;
-	id = "talon_quietroom";
-	name = "window blast shields";
-	pixel_x = 28
+/area/talon_v2/armory)
+"cd" = (
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/star_store)
+"ce" = (
+/obj/machinery/cryopod/talon,
+/obj/machinery/camera/network/talon,
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/central_hallway)
+"cf" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/structure/closet/walllocker/medical/south,
 /obj/item/weapon/storage/firstaid/regular,
 /obj/item/weapon/storage/firstaid/o2,
-/turf/simulated/floor/wood,
-/area/talon_v2/crew_quarters/meditation)
-"jx" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/structure/closet/walllocker_double/hydrant/west,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/port_store)
-"jy" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/effect/floor_decal/industrial/warning/dust{
-	dir = 4
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/space)
-"jC" = (
-/obj/machinery/atmospherics/pipe/tank/oxygen{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/atmospherics)
-"jD" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/item/device/radio/off{
+	channels = list("Talon" = 1)
 	},
 /turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/bridge)
-"jF" = (
-/obj/structure/table/bench/wooden,
-/turf/simulated/floor/wood,
-/area/talon_v2/crew_quarters/cap_room)
-"jG" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/visible,
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/atmospherics)
-"jI" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
+/area/talon_v2/central_hallway/fore)
+"cg" = (
+/obj/machinery/disposal/wall{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/maintenance/wing_starboard)
-"jL" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/closet/emergsuit_wall{
-	dir = 1;
-	pixel_y = -32
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway/port)
-"jM" = (
-/obj/machinery/door/firedoor/glass/talon,
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/structure/window/reinforced{
+/obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/hangar)
-"jN" = (
-/obj/structure/table/standard,
-/obj/item/weapon/paper_bin,
-/obj/item/weapon/pen,
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
+/turf/simulated/floor/wood,
+/area/talon_v2/crew_quarters/bar)
+"ch" = (
+/obj/structure/closet/excavation,
 /turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/brig)
-"jO" = (
+/area/talon_v2/anomaly_storage)
+"ci" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -3208,1987 +879,81 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway)
-"jQ" = (
-/obj/machinery/power/apc/talon{
-	name = "south bump";
-	pixel_y = -24
-	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/gen_store)
-"jS" = (
-/obj/machinery/mineral/output,
-/obj/machinery/conveyor{
-	dir = 8;
-	id = "talonrefinery"
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/refining)
-"jY" = (
-/obj/structure/table/steel,
-/obj/item/weapon/storage/bag/ore,
-/obj/item/weapon/pickaxe/drill,
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/refining)
-"kc" = (
-/obj/machinery/conveyor{
+/obj/structure/closet/emergsuit_wall{
 	dir = 1;
-	id = "talonrefinery"
+	pixel_y = -32
 	},
-/obj/structure/sign/warning/moving_parts{
-	pixel_x = 32
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/refining)
-"kd" = (
-/obj/effect/shuttle_landmark/premade/talon_v2_wing_star,
-/turf/space,
-/area/space)
-"ke" = (
-/obj/structure/catwalk,
-/turf/simulated/floor/reinforced/airless,
-/area/talon_v2/maintenance/wing_starboard)
-"kf" = (
-/obj/machinery/power/apc/talon{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -28
-	},
-/obj/structure/cable/green,
 /obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/structure/handrail{
-	dir = 4
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/maintenance/wing_port)
-"kg" = (
-/turf/simulated/floor/tiled/techfloor,
 /area/talon_v2/central_hallway)
-"ki" = (
-/obj/machinery/atmospherics/unary/engine/bigger{
-	dir = 1
-	},
-/turf/space,
-/area/talon_v2/engineering/port)
-"kj" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/aux{
-	dir = 4
-	},
+"ck" = (
 /obj/machinery/door/firedoor/glass/talon,
-/obj/machinery/door/airlock/maintenance/common,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/maintenance/fore_starboard)
-"kk" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/light,
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway/port)
-"kl" = (
-/obj/structure/sign/warning/airlock{
-	pixel_x = -31
-	},
-/obj/structure/handrail,
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/maintenance/wing_port)
-"kn" = (
-/obj/structure/closet/secure_closet/personal/cabinet{
-	locked = 0
-	},
-/turf/simulated/floor/wood,
-/area/talon_v2/crew_quarters/eng_room)
-"kr" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway/star)
-"kt" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/port)
-"ku" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/random/multiple/corp_crate/talon_cargo,
-/obj/structure/railing/grey{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/maintenance/wing_starboard)
-"kx" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/port_store)
-"kz" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/light/small,
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/port)
-"kA" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/atmospherics)
-"kC" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/aux{
-	dir = 1
-	},
-/obj/effect/map_helper/airlock/atmos/chamber_pump,
-/obj/structure/handrail{
-	dir = 1
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/engineering{
+	id_tag = "talon_engdoor";
+	name = "Engineer's Cabin";
+	req_one_access = list(301)
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/maintenance/fore_starboard)
-"kD" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/light_switch{
-	dir = 4;
-	pixel_x = -26;
-	pixel_y = -25
-	},
+/area/talon_v2/engineering/star_store)
+"cl" = (
+/obj/structure/table/woodentable,
 /turf/simulated/floor/wood,
 /area/talon_v2/crew_quarters/bar)
-"kG" = (
-/obj/structure/table/marble,
-/obj/effect/floor_decal/corner/black/diagonal,
-/obj/machinery/camera/network/talon{
-	dir = 8
-	},
-/obj/random/mre,
-/obj/random/mre,
-/obj/random/mre,
-/obj/random/mre,
-/obj/random/mre,
-/obj/random/mre,
-/obj/structure/closet/walllocker_double/kitchen/east{
-	name = "Ration Cabinet"
-	},
-/turf/simulated/floor/tiled/white,
-/area/talon_v2/crew_quarters/bar)
-"kH" = (
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway/fore)
-"kI" = (
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/aux,
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/fuel,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/effect/catwalk_plated/dark,
-/turf/simulated/floor/plating,
-/area/shuttle/talonboat)
-"kJ" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/port_store)
-"kM" = (
-/obj/structure/closet/autolok_wall{
-	dir = 1;
-	pixel_y = -32
-	},
-/obj/structure/handrail{
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 4
-	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/aux{
-	dir = 8
-	},
-/obj/effect/map_helper/airlock/atmos/chamber_pump,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/shuttle/talonboat)
-"kP" = (
-/obj/structure/extinguisher_cabinet{
-	dir = 1;
-	pixel_y = -32
-	},
-/obj/machinery/power/smes/buildable/offmap_spawn{
-	RCon_tag = "Talon Port SMES"
-	},
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering)
-"kR" = (
-/obj/structure/handrail,
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/maintenance/wing_port)
-"kS" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
+"cn" = (
 /obj/machinery/light/small{
-	dir = 4
+	dir = 1
 	},
-/obj/machinery/alarm/talon{
-	dir = 8;
-	pixel_x = 22
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/starboard)
-"kT" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 9
-	},
-/obj/structure/catwalk,
-/obj/structure/railing/grey,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/atmospherics)
-"kU" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/maintenance/wing_starboard)
+"cp" = (
+/obj/machinery/button/remote/airlock{
+	dir = 4;
+	id = "talon_capdoor";
+	name = "Door Bolts";
+	pixel_x = 28;
+	specialfunctions = 4
 	},
 /obj/structure/cable/green{
 	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway/fore)
-"kW" = (
+/turf/simulated/floor/wood,
+/area/talon_v2/crew_quarters/cap_room)
+"ct" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/random/multiple/corp_crate/talon_cargo,
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/maintenance/wing_starboard)
+"cw" = (
+/obj/machinery/door/firedoor/glass/talon,
+/obj/machinery/door/airlock/maintenance/common,
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/aft_port)
+"cy" = (
 /obj/effect/shuttle_landmark/premade/talon_v2_near_fore_star,
 /turf/space,
 /area/space)
-"kX" = (
-/obj/machinery/door/firedoor/glass/talon,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway/star)
-"kY" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/aux{
-	dir = 6
-	},
-/obj/machinery/airlock_sensor{
-	dir = 8;
-	pixel_x = 28;
-	pixel_y = 28;
-	req_one_access = list(301)
-	},
-/obj/effect/map_helper/airlock/sensor/int_sensor,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/maintenance/wing_starboard)
-"kZ" = (
-/obj/structure/railing/grey{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/refining)
-"lc" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/structure/table/woodentable,
-/turf/simulated/floor/wood,
-/area/talon_v2/crew_quarters/bar)
-"le" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/handrail{
-	dir = 4
-	},
-/obj/structure/closet/emergsuit_wall{
-	dir = 8;
-	pixel_x = -32
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/maintenance/wing_port)
-"lf" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/port_store)
-"lg" = (
-/obj/machinery/door/airlock/glass_external{
-	req_one_access = list(301)
-	},
-/obj/effect/map_helper/airlock/door/int_door,
-/obj/machinery/atmospherics/pipe/simple/hidden/aux{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/maintenance/fore_port)
-"lj" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/effect/catwalk_plated,
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/central_hallway/fore)
-"lk" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/maintenance/wing_port)
-"lm" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/structure/handrail,
-/obj/structure/closet/autolok_wall{
-	pixel_y = 32
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/shuttle/talonboat)
-"ln" = (
-/obj/structure/table/rack/shelf/steel,
-/obj/item/clothing/shoes/magboots,
-/obj/item/clothing/shoes/magboots,
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/secure_storage)
-"lr" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/port)
-"ls" = (
-/obj/structure/bed/chair/bay/comfy/brown{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/bridge)
-"lv" = (
-/obj/structure/railing/grey{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/conveyor_switch/oneway{
-	id = "talonrefinery";
-	name = "Conveyor Control";
-	req_one_access = list(301)
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/refining)
-"lw" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor/glass/talon,
-/obj/structure/sign/warning/nosmoking_1{
-	pixel_x = 26
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/airlock/engineering{
-	name = "Talon Starboard Engines";
-	req_one_access = list(301)
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/starboard)
-"lx" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/catwalk,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/maintenance/fore_starboard)
-"lA" = (
-/obj/machinery/light/small,
-/obj/structure/railing/grey{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/refining)
-"lB" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway)
-"lC" = (
-/obj/machinery/atmospherics/portables_connector/fuel{
-	dir = 4
-	},
-/obj/machinery/portable_atmospherics/canister/phoron,
-/obj/effect/floor_decal/industrial/outline/red,
-/turf/simulated/floor/tiled/techfloor,
-/area/shuttle/talonboat)
-"lD" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/landmark/start{
-	name = "Talon Guard"
-	},
-/obj/machinery/button/remote/airlock{
-	dir = 8;
-	id = "talon_secdoor";
-	name = "Door Bolts";
-	pixel_x = 28;
-	specialfunctions = 4
-	},
-/turf/simulated/floor/carpet,
-/area/talon_v2/crew_quarters/sec_room)
-"lF" = (
-/obj/machinery/light_switch{
-	dir = 1;
-	pixel_y = -26
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/gen_store)
-"lI" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/holoposter{
-	pixel_y = -32
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/central_hallway/fore)
-"lJ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/armory)
-"lM" = (
-/obj/effect/landmark/start{
-	name = "Talon Captain"
-	},
-/turf/simulated/floor/carpet/blucarpet,
-/area/talon_v2/crew_quarters/cap_room)
-"lN" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/port_store)
-"lO" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/closet/emergsuit_wall{
-	pixel_y = 32
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/central_hallway/fore)
-"lP" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/closet/walllocker_double/hydrant/west,
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/maintenance/wing_starboard)
-"lR" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/loading{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/refining)
-"lS" = (
-/obj/machinery/door/firedoor/glass/talon,
-/obj/machinery/door/airlock/maintenance/common,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/maintenance/fore_port)
-"lT" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 10
-	},
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 4
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/starboard)
-"lU" = (
-/turf/simulated/wall/shull,
-/area/talon_v2/crew_quarters/pilot_room)
-"lV" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/catwalk,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/maintenance/aft_port)
-"lW" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/holoposter{
-	dir = 1;
-	pixel_y = 32
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway/port)
-"lX" = (
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 5
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/starboard)
-"lZ" = (
-/obj/item/modular_computer/console/preset/talon,
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/bridge)
-"ma" = (
-/obj/machinery/cryopod/robot/talon,
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/central_hallway)
-"mb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/aux{
-	dir = 5
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/holoposter{
-	pixel_y = -32
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/central_hallway/fore)
-"mc" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment{
-	dir = 1
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway/fore)
-"md" = (
-/obj/structure/railing/grey{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/atmospherics)
-"me" = (
-/obj/structure/table/rack/shelf/steel,
-/obj/item/clothing/accessory/holster/machete,
-/obj/item/weapon/material/knife/machete,
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/armory)
-"mk" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/catwalk,
-/obj/machinery/light_switch{
-	pixel_y = 24
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/atmospherics)
-"ml" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/railing/grey{
-	dir = 1
-	},
-/obj/random/multiple/corp_crate/talon_cargo,
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/maintenance/wing_starboard)
-"mm" = (
-/obj/structure/catwalk,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/maintenance/aft_starboard)
-"mo" = (
-/obj/effect/floor_decal/industrial/warning/dust/corner{
-	dir = 8
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/space)
-"ms" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/obj/machinery/light_switch{
-	pixel_y = 24
-	},
-/turf/simulated/floor/wood,
-/area/talon_v2/crew_quarters/eng_room)
-"mt" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/aux,
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/maintenance/wing_port)
-"mu" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/holoposter{
-	pixel_y = -32
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway/port)
-"mw" = (
-/turf/simulated/wall/shull,
-/area/talon_v2/maintenance/wing_starboard)
-"mx" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/catwalk_plated,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/central_hallway)
-"mA" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/aux{
-	dir = 8
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/maintenance/wing_port)
-"mC" = (
-/obj/structure/sign/warning/airlock{
-	pixel_x = -31
-	},
-/obj/effect/floor_decal/industrial/warning,
-/obj/structure/handrail{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/maintenance/wing_port)
-"mE" = (
-/obj/structure/sign/directions/cargo/refinery{
-	pixel_y = -32
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway/star)
-"mG" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/closet/walllocker/medical/west,
-/obj/item/weapon/storage/firstaid/regular,
-/obj/item/weapon/storage/firstaid/o2,
-/obj/item/device/radio/off{
-	channels = list("Talon" = 1)
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/maintenance/wing_starboard)
-"mH" = (
-/obj/structure/catwalk,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/star_store)
-"mI" = (
-/obj/structure/hull_corner{
-	dir = 8
-	},
-/turf/space,
-/area/space)
-"mM" = (
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering)
-"mO" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/structure/railing/grey{
-	dir = 4
-	},
-/obj/structure/railing/grey{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering)
-"mP" = (
-/obj/structure/railing/grey,
-/obj/structure/railing/grey{
-	dir = 4
-	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/refining)
-"mQ" = (
-/obj/structure/railing/grey,
-/obj/structure/window/reinforced,
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/refining)
-"mS" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/refining)
-"mT" = (
-/obj/effect/map_helper/airlock/atmos/chamber_pump,
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/aux{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/shuttle/talonboat)
-"mV" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/maintenance/wing_starboard)
-"mX" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/atmospherics/portables_connector{
-	dir = 8
-	},
-/obj/machinery/portable_atmospherics/canister/empty/carbon_dioxide,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/atmospherics)
-"mZ" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/junction,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway/fore)
-"nb" = (
-/obj/structure/flora/pottedplant/minitree,
-/obj/machinery/holoposter{
-	dir = 1;
-	pixel_y = 32
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/central_hallway)
-"nc" = (
-/obj/machinery/camera/network/talon{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/maintenance/wing_starboard)
-"ne" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/space)
-"ng" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/camera/network/talon{
-	dir = 1
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway)
-"nh" = (
-/obj/effect/floor_decal/industrial/warning/dust{
-	dir = 9
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/talon_v2/engineering/starboard)
-"nk" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/wall/rshull,
-/area/talon_v2/maintenance/wing_port)
-"nl" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/floor_decal/industrial/warning/dust{
-	dir = 1
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/space)
-"nn" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway)
-"nq" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway)
-"ns" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment{
-	dir = 1
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/wood,
-/area/talon_v2/crew_quarters/pilot_room)
-"nu" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/talon_v2/crew_quarters/sec_room)
-"nw" = (
-/obj/structure/catwalk,
-/obj/structure/handrail{
-	dir = 4
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/talon_v2/maintenance/fore_starboard)
-"nx" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/obj/item/modular_computer/console/preset/talon{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/engineering)
-"nz" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/aux,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/light/small,
-/obj/structure/closet/emergsuit_wall{
-	dir = 1;
-	pixel_y = -32
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/maintenance/fore_port)
-"nB" = (
-/obj/machinery/alarm/talon{
-	dir = 4;
-	pixel_x = -22
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/central_hallway/fore)
-"nC" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/red{
-	dir = 8
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/atmospherics)
-"nD" = (
-/obj/structure/table/woodentable,
-/obj/machinery/camera/network/talon{
-	dir = 8
-	},
-/obj/machinery/recharger,
-/turf/simulated/floor/wood,
-/area/talon_v2/crew_quarters/eng_room)
-"nE" = (
-/obj/structure/table/woodentable,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/obj/item/weapon/paper/talon_guard,
-/turf/simulated/floor/carpet,
-/area/talon_v2/crew_quarters/sec_room)
-"nH" = (
-/obj/machinery/light,
-/obj/structure/extinguisher_cabinet{
-	dir = 1;
-	pixel_y = -32
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/central_hallway/fore)
-"nI" = (
-/obj/machinery/power/smes/buildable/offmap_spawn{
-	RCon_tag = "Talon Port SMES"
-	},
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering)
-"nK" = (
-/obj/structure/closet/walllocker/emerglocker/west,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/armory)
-"nL" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/starboard)
-"nM" = (
-/obj/machinery/door/firedoor/glass/talon,
-/obj/machinery/door/airlock{
-	id_tag = "talon_restroom2";
-	name = "Unisex Restroom"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/talon_v2/crew_quarters/restrooms)
-"nN" = (
-/obj/structure/sign/warning/nosmoking_1{
-	pixel_x = 26
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/port)
-"nP" = (
-/obj/structure/catwalk,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/atmospherics)
-"nS" = (
-/obj/machinery/atmospherics/portables_connector/aux,
-/obj/effect/floor_decal/industrial/outline,
-/obj/machinery/portable_atmospherics/canister/air,
-/turf/simulated/floor/plating,
-/area/talon_v2/maintenance/fore_starboard)
-"nW" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/structure/noticeboard{
-	pixel_x = -32
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/central_hallway/fore)
-"oc" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway)
-"od" = (
-/turf/simulated/floor/reinforced,
-/area/talon_v2/hangar)
-"oh" = (
-/turf/simulated/wall/rshull,
-/area/talon_v2/crew_quarters/bar)
-"ol" = (
-/obj/machinery/door/airlock/glass_external{
-	req_one_access = list(301)
-	},
-/obj/effect/map_helper/airlock/door/ext_door,
-/obj/machinery/door/blast/regular/open{
-	id = "talon_boat_east"
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/aux{
-	dir = 4
-	},
-/obj/effect/map_helper/airlock/sensor/ext_sensor,
-/obj/machinery/airlock_sensor/airlock_exterior/shuttle{
-	dir = 4;
-	pixel_x = 11;
-	pixel_y = 24;
-	req_one_access = list(301)
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/shuttle/talonboat)
-"om" = (
+"cA" = (
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/talon_v2/maintenance/wing_port)
-"on" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/wood,
-/area/talon_v2/crew_quarters/pilot_room)
-"oo" = (
-/obj/machinery/door/firedoor/glass/talon,
-/obj/machinery/door/airlock/glass,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway/fore)
-"op" = (
-/obj/machinery/alarm/talon{
-	dir = 4;
-	pixel_x = -22
-	},
-/turf/simulated/floor/tiled/white,
-/area/talon_v2/medical)
-"oq" = (
-/obj/structure/sign/warning/airlock{
-	pixel_x = 32
-	},
-/obj/effect/floor_decal/industrial/warning,
-/obj/structure/handrail{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/maintenance/wing_port)
-"or" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/refining)
-"ow" = (
-/obj/machinery/light,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/extinguisher_cabinet{
-	dir = 1;
-	pixel_y = -32
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/central_hallway/fore)
-"ox" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway)
-"oz" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/atmospherics)
-"oA" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/hangar)
-"oC" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/door/blast/regular/open{
-	id = "talon_windows"
-	},
-/obj/machinery/door/firedoor/glass/talon,
-/turf/simulated/floor/plating,
-/area/talon_v2/crew_quarters/cap_room)
-"oF" = (
-/obj/machinery/light_switch{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/item/device/mass_spectrometer/adv,
-/obj/structure/table/standard,
-/turf/simulated/floor/tiled/white,
-/area/talon_v2/medical)
-"oG" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/effect/floor_decal/industrial/outline/blue,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/atmospherics)
-"oK" = (
-/obj/structure/sign/warning/nosmoking_1{
-	pixel_x = -26
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/star_store)
-"oN" = (
-/obj/machinery/door/firedoor/glass/talon,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/glass_research{
-	name = "Anomaly Storage";
-	req_one_access = list(301)
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/anomaly_storage)
-"oO" = (
-/obj/structure/closet/emergsuit_wall{
-	dir = 1;
-	pixel_y = -32
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway/star)
-"oS" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/computer/guestpass{
-	dir = 8;
-	pixel_x = 26
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway)
-"oT" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/aux{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/maintenance/wing_starboard)
-"oU" = (
-/obj/machinery/door/firedoor/glass/talon,
-/obj/machinery/door/airlock/maintenance/common,
-/turf/simulated/floor/plating,
-/area/talon_v2/maintenance/fore_port)
-"oV" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/talon_v2/crew_quarters/med_room)
-"oW" = (
-/obj/structure/sink{
-	pixel_y = 22
-	},
-/obj/structure/mirror{
-	pixel_y = 32
-	},
-/obj/machinery/button/remote/airlock{
-	dir = 8;
-	id = "talon_restroom2";
-	name = "Door Bolts";
-	pixel_x = -28;
-	specialfunctions = 4
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/tiled/white,
-/area/talon_v2/crew_quarters/restrooms)
-"pa" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/maintenance/wing_port)
-"pb" = (
-/obj/machinery/camera/network/talon{
-	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/talon_v2/crew_quarters/cap_room)
-"pc" = (
-/obj/machinery/washing_machine,
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/crew_quarters/restrooms)
-"pf" = (
-/obj/effect/floor_decal/industrial/outline/red,
-/obj/machinery/atmospherics/portables_connector{
-	dir = 8
-	},
-/obj/machinery/portable_atmospherics/canister/phoron/engine_setup,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/port)
-"pi" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/aux{
-	dir = 5
-	},
-/obj/structure/closet/emergsuit_wall{
-	dir = 1;
-	pixel_y = -32
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/maintenance/wing_starboard)
-"pk" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/fuel,
-/turf/simulated/wall/rshull,
-/area/shuttle/talonboat)
-"pl" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway)
-"pn" = (
-/obj/structure/flora/pottedplant/fern,
-/obj/machinery/holoposter{
-	dir = 1;
-	pixel_y = 32
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/central_hallway)
-"po" = (
-/obj/machinery/fitness/punching_bag,
-/obj/structure/sign/painting/public{
-	pixel_x = 30
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/workroom)
-"pp" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/junction{
-	dir = 4;
-	icon_state = "pipe-j2"
-	},
-/obj/structure/closet/walllocker_double/hydrant/east,
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway)
-"pr" = (
-/obj/structure/railing/grey{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 6
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/atmospherics)
-"pt" = (
-/obj/structure/cable/yellow{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/power/terminal{
-	dir = 4
-	},
-/obj/structure/railing/grey{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering)
-"pv" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/machinery/alarm/talon{
-	pixel_y = 28
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/engineering/star_store)
-"pw" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/catwalk,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/light_switch{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering)
-"px" = (
-/obj/machinery/oxygen_pump{
-	dir = 4;
-	pixel_x = 30
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/carpet/blucarpet,
-/area/talon_v2/crew_quarters/cap_room)
-"pA" = (
-/obj/structure/disposalpipe/junction/yjunction{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering)
-"pB" = (
-/obj/structure/table/standard,
-/obj/machinery/alarm/talon{
-	dir = 4;
-	pixel_x = -22
-	},
-/obj/item/device/radio/off{
-	channels = list("Talon" = 1)
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/crew_quarters/restrooms)
-"pC" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1
-	},
-/obj/structure/extinguisher_cabinet{
-	dir = 8;
-	pixel_x = 30
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway)
-"pE" = (
-/obj/structure/catwalk,
-/obj/structure/railing/grey,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/atmospherics)
-"pG" = (
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway)
-"pH" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/hangar)
-"pK" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/aux,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/light/small,
-/obj/structure/closet/emergsuit_wall{
-	dir = 1;
-	pixel_y = -32
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/maintenance/fore_starboard)
-"pL" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/structure/sign/department/commander{
-	pixel_x = -28
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/central_hallway/fore)
-"pN" = (
-/turf/simulated/floor/carpet,
-/area/talon_v2/crew_quarters/pilot_room)
-"pQ" = (
-/obj/machinery/light/small,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/atmospherics)
-"pR" = (
-/obj/structure/extinguisher_cabinet{
-	dir = 1;
-	pixel_y = -32
-	},
-/obj/structure/table/steel,
-/obj/item/device/radio/off{
-	channels = list("Talon" = 1)
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/atmospherics)
-"pT" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering)
-"pV" = (
-/obj/machinery/atmospherics/binary/pump/high_power/on,
-/obj/structure/railing/grey{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/starboard)
-"pZ" = (
-/obj/structure/table/rack/shelf/steel,
-/obj/random/maintenance/engineering,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/port_store)
-"qa" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/talon_v2/maintenance/aft_port)
-"qb" = (
-/obj/structure/bed/chair/wood,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/carpet/blucarpet,
-/area/talon_v2/crew_quarters/cap_room)
-"qc" = (
-/obj/structure/bed/chair/bay/chair,
-/obj/machinery/alarm/talon{
-	pixel_y = 24
-	},
-/turf/simulated/floor/wood,
-/area/talon_v2/crew_quarters/bar)
-"qe" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/obj/machinery/light_switch{
-	dir = 8;
-	pixel_x = 24
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/hangar)
-"qi" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/camera/network/talon,
-/obj/structure/railing/grey{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/port_store)
-"qk" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/maintenance/wing_port)
-"ql" = (
-/obj/structure/hull_corner{
-	dir = 4
-	},
-/turf/space,
-/area/space)
-"qm" = (
-/obj/machinery/door/window/brigdoor/eastleft{
-	dir = 1;
-	req_access = list(301)
-	},
-/obj/machinery/door/window/brigdoor/eastleft{
-	dir = 2;
-	req_access = list(301)
-	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/blast/shutters{
-	density = 0;
-	dir = 2;
-	icon_state = "shutter0";
-	id = "talon_brig1";
-	name = "Cell Shutters";
-	opacity = 0
-	},
-/obj/machinery/door/firedoor/glass/talon,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/brig)
-"qn" = (
-/obj/structure/hull_corner{
-	dir = 8
-	},
-/obj/structure/lattice,
-/turf/space,
-/area/space)
-"qo" = (
-/obj/structure/table/rack/steel,
-/obj/random/maintenance/engineering,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/star_store)
-"qp" = (
-/turf/simulated/wall/shull,
-/area/talon_v2/crew_quarters/bar)
-"qq" = (
-/obj/structure/closet/walllocker_double/south,
-/obj/structure/handrail{
-	dir = 1
-	},
-/obj/item/weapon/storage/toolbox/mechanical,
-/obj/machinery/atmospherics/pipe/simple/hidden/aux{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/shuttle/talonboat)
-"qr" = (
-/turf/simulated/wall/shull,
-/area/talon_v2/crew_quarters/med_room)
-"qs" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor/glass/talon,
-/obj/machinery/door/airlock/multi_tile/glass{
-	dir = 1;
-	req_one_access = list(301)
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway/port)
-"qt" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/hangar)
-"qu" = (
-/obj/structure/barricade,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/port_store)
-"qv" = (
-/obj/structure/table/rack/steel,
-/obj/machinery/power/apc/talon{
-	name = "south bump";
-	pixel_y = -24
-	},
-/obj/structure/cable/green,
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/armory)
-"qw" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 9
-	},
-/obj/structure/cable/green,
-/obj/machinery/power/apc/talon{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/atmospherics)
-"qy" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/effect/floor_decal/industrial/warning/dust{
-	dir = 8
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/space)
-"qC" = (
-/obj/machinery/door/firedoor/glass/talon,
-/obj/machinery/door/airlock/maintenance/engi{
-	name = "Port Eng. Storage";
-	req_one_access = list(301)
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/port_store)
-"qD" = (
-/obj/structure/table/standard,
-/obj/item/weapon/storage/toolbox/electrical,
-/obj/item/weapon/pipe_dispenser,
-/obj/machinery/light/small,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/engineering/star_store)
-"qE" = (
+"cB" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
@@ -5196,454 +961,163 @@
 	dir = 4
 	},
 /turf/simulated/floor/wood,
-/area/talon_v2/crew_quarters/sec_room)
-"qH" = (
-/obj/machinery/door/firedoor/glass/talon,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/mining{
-	name = "Refinery";
-	req_one_access = list(301)
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/refining)
-"qI" = (
-/obj/structure/table/woodentable,
-/turf/simulated/floor/wood,
-/area/talon_v2/crew_quarters/bar)
-"qJ" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway/port)
-"qK" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/effect/catwalk_plated,
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/central_hallway/star)
-"qL" = (
-/obj/structure/closet/walllocker_double/south,
-/obj/machinery/light,
-/obj/item/weapon/extinguisher,
-/obj/item/stack/cable_coil/green,
-/obj/item/stack/cable_coil/green,
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/aux{
-	dir = 8
-	},
-/obj/effect/map_helper/airlock/atmos/chamber_pump,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/shuttle/talonboat)
-"qN" = (
-/turf/simulated/wall/shull{
-	can_open = 1
-	},
-/area/talon_v2/workroom)
-"qO" = (
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/power/apc/talon{
-	dir = 1;
-	name = "north bump";
-	pixel_y = 28
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/brig)
-"qP" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/random/multiple/corp_crate/talon_cargo,
+/area/talon_v2/crew_quarters/cap_room)
+"cC" = (
 /obj/structure/railing/grey{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/maintenance/wing_port)
-"qQ" = (
-/obj/structure/sign/warning/moving_parts{
-	pixel_y = -32
-	},
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "talonrefinery"
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/refining)
-"qU" = (
-/obj/machinery/power/apc/talon{
-	name = "south bump";
-	pixel_y = -24
-	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/structure/handrail{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/bridge)
-"qV" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/maintenance/wing_port)
-"qW" = (
-/obj/machinery/atmospherics/omni/atmos_filter{
-	name = "CO2 Filter";
-	tag_east = 2;
-	tag_north = 1;
-	tag_south = 5
-	},
-/obj/effect/catwalk_plated/dark,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/atmospherics)
-"qX" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/floor_decal/industrial/warning/dust{
-	dir = 4
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/space)
-"rg" = (
-/obj/machinery/door/firedoor/glass/talon,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway/port)
-"rh" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/obj/structure/closet/walllocker_double/hydrant/west,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/anomaly_storage)
-"ri" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/maintenance/wing_port)
-"rj" = (
-/obj/machinery/holoposter{
-	pixel_y = -32
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway/star)
-"rk" = (
-/obj/machinery/atmospherics/pipe/simple/visible/blue{
-	dir = 6
-	},
-/obj/structure/closet/emergsuit_wall{
-	pixel_y = 32
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/atmospherics)
-"rl" = (
-/obj/effect/floor_decal/industrial/warning/dust{
-	dir = 1
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/talon_v2/engineering/starboard)
-"rm" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/aux,
-/obj/machinery/door/firedoor/glass/talon,
-/obj/machinery/door/airlock/maintenance/common,
-/turf/simulated/floor/plating,
-/area/talon_v2/maintenance/wing_port)
-"rq" = (
-/obj/structure/bed,
-/obj/item/weapon/bedsheet/mime,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/brig)
-"rt" = (
-/obj/effect/floor_decal/emblem/talon_big,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/central_hallway/fore)
-"ru" = (
-/obj/machinery/door/firedoor/glass/talon,
-/obj/machinery/door/airlock/glass,
-/obj/structure/disposalpipe/segment{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway/fore)
-"rv" = (
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/workroom)
-"rw" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/machinery/power/apc/talon{
-	dir = 1;
-	name = "north bump";
-	pixel_y = 28
-	},
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/structure/catwalk,
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/maintenance/aft_port)
-"rx" = (
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/talon_v2/maintenance/fore_starboard)
-"rz" = (
-/obj/structure/closet/crate/hydroponics,
-/obj/item/stack/material/algae,
-/obj/item/stack/material/algae,
-/obj/item/stack/material/algae,
-/obj/item/stack/material/algae,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/atmospherics)
-"rB" = (
-/obj/structure/railing/grey,
-/obj/effect/floor_decal/industrial/outline/red,
-/obj/machinery/portable_atmospherics/canister/empty/phoron,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/port_store)
-"rC" = (
-/obj/structure/table/standard,
-/obj/item/weapon/storage/box/handcuffs,
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/brig)
-"rF" = (
-/obj/machinery/suit_cycler/vintage/tcrew,
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/secure_storage)
-"rG" = (
-/obj/structure/table/standard,
-/obj/item/weapon/storage/firstaid/regular,
-/obj/item/weapon/storage/firstaid/adv{
-	pixel_x = 2;
-	pixel_y = 5
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/structure/closet/walllocker_double/medical/south,
-/turf/simulated/floor/tiled/white,
-/area/talon_v2/medical)
-"rI" = (
-/obj/machinery/door/firedoor/glass/talon,
-/obj/machinery/door/airlock/glass{
-	name = "Hangar Bay";
-	req_one_access = list(301)
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/hangar)
-"rJ" = (
-/obj/machinery/firealarm{
-	layer = 3.3;
-	pixel_y = 26
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/catwalk,
-/obj/machinery/camera/network/talon,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/port_store)
-"rL" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/talon_v2/maintenance/aft_starboard)
-"rP" = (
-/obj/effect/floor_decal/industrial/outline/red,
-/obj/machinery/atmospherics/portables_connector{
-	dir = 4
-	},
-/obj/structure/railing/grey,
-/obj/machinery/portable_atmospherics/canister/phoron/engine_setup,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/port)
-"rQ" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/talon_v2/crew_quarters/restrooms)
-"rR" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/alarm/talon{
-	dir = 4;
-	pixel_x = -22
-	},
-/obj/random/multiple/corp_crate/talon_cargo,
-/obj/structure/railing/grey,
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/maintenance/wing_starboard)
-"rS" = (
-/obj/effect/floor_decal/industrial/outline/red,
-/obj/machinery/atmospherics/portables_connector{
-	dir = 4
-	},
-/obj/structure/railing/grey,
-/obj/machinery/portable_atmospherics/canister/phoron/engine_setup,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/starboard)
-"rT" = (
-/obj/machinery/door/firedoor/glass/talon,
-/obj/machinery/door/airlock/engineering{
-	name = "Talon Starboard Engines";
-	req_one_access = list(301)
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/starboard)
-"rU" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 1
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway)
-"rW" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/talon_v2/maintenance/aft_port)
-"sc" = (
-/obj/structure/catwalk,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/port_store)
-"se" = (
-/obj/structure/closet/crate/engineering,
-/obj/fiftyspawner/cardboard,
-/obj/fiftyspawner/floor,
-/obj/fiftyspawner/glass,
-/obj/fiftyspawner/plastic,
-/obj/fiftyspawner/steel,
-/obj/fiftyspawner/wood,
-/obj/item/stack/material/plasteel{
-	amount = 30
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/port_store)
-"sf" = (
-/obj/effect/floor_decal/industrial/warning,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/hangar)
-"sh" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/maintenance/wing_starboard)
-"sl" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/talon_v2/engineering/star_store)
-"sn" = (
+"cG" = (
+/obj/machinery/door/firedoor/glass/talon,
+/obj/machinery/door/airlock/security{
+	id_tag = "talon_secdoor";
+	name = "Guard's Cabin";
+	req_one_access = list(301)
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/crew_quarters/sec_room)
+"cH" = (
+/obj/machinery/fitness/punching_bag,
+/obj/structure/sign/painting/public{
+	pixel_x = 30
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/workroom)
+"cK" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/glass/talon,
+/obj/machinery/door/blast/regular/open{
+	id = "talon_boat_cockpit"
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/talonboat)
+"cL" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/railing/grey{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/port_store)
+"cN" = (
+/obj/machinery/door/firedoor/glass/talon,
+/obj/machinery/door/airlock/maintenance/sec{
+	id_tag = "talon_secdoor";
+	req_one_access = list(301)
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/crew_quarters/sec_room)
+"cP" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/starboard)
+"cU" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/structure/catwalk,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/structure/railing/grey{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/starboard)
+"cV" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/catwalk,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/structure/closet/walllocker_double/east,
+/obj/item/weapon/cell/device/weapon,
+/obj/item/weapon/cell/device/weapon,
+/obj/item/weapon/cell/device,
+/obj/item/weapon/cell/device,
+/obj/random/maintenance/engineering,
+/obj/random/maintenance/engineering,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering)
+"cX" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway/star)
+"cZ" = (
+/obj/machinery/door/firedoor/glass/talon,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/obj/machinery/door/airlock{
+	name = "Observation Room"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/crew_quarters/meditation)
+"db" = (
+/turf/simulated/wall/shull,
+/area/talon_v2/brig)
+"dd" = (
+/obj/structure/sign/warning/airlock{
+	pixel_x = 32
+	},
+/obj/structure/handrail,
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/maintenance/wing_starboard)
+"dj" = (
 /obj/machinery/door/firedoor/glass/talon,
 /obj/machinery/door/airlock/command{
 	id_tag = "talon_capdoor";
@@ -5666,651 +1140,27 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/talon_v2/crew_quarters/cap_room)
-"so" = (
-/obj/item/weapon/storage/dicecup/loaded{
-	pixel_x = 7;
-	pixel_y = 11
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/black/diagonal,
-/obj/structure/table/marble,
-/obj/item/weapon/deck/cards{
-	pixel_x = 3
-	},
-/turf/simulated/floor/tiled/white,
-/area/talon_v2/crew_quarters/bar)
-"ss" = (
-/obj/structure/sign/periodic{
-	pixel_y = 32
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/workroom)
-"sv" = (
-/obj/structure/table/rack/shelf/steel,
-/obj/item/weapon/gun/energy/gun/burst,
-/obj/item/weapon/cell/device/weapon{
-	pixel_x = -5;
-	pixel_y = 2
-	},
-/obj/item/weapon/cell/device/weapon,
-/obj/item/clothing/accessory/holster/waist,
-/obj/machinery/light_switch{
-	dir = 1;
-	pixel_y = -26
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/armory)
-"sw" = (
-/obj/machinery/power/apc/talon{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -28
-	},
+"dl" = (
 /obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/crew_quarters/restrooms)
-"sx" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/structure/closet/emergsuit_wall{
-	dir = 4;
-	pixel_x = 32
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/maintenance/wing_port)
-"sz" = (
-/obj/machinery/door/blast/regular/open{
-	dir = 4;
-	id = "talon_bridge_shields"
-	},
-/obj/effect/floor_decal/industrial/warning/dust{
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/warning/dust,
-/turf/simulated/floor/reinforced/airless,
-/area/talon_v2/bridge)
-"sC" = (
-/obj/structure/closet/walllocker_double/hydrant/west,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/engineering/star_store)
-"sD" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1
-	},
-/obj/structure/sign/directions/bar{
-	dir = 1;
-	pixel_x = -32;
-	pixel_y = -3
-	},
-/obj/structure/sign/directions/bridge{
-	dir = 1;
-	pixel_x = -32;
-	pixel_y = 3
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway)
-"sE" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/structure/catwalk,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
 /turf/simulated/floor/plating,
-/area/talon_v2/engineering/port_store)
-"sF" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/junction{
-	dir = 2;
-	icon_state = "pipe-j2"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway/fore)
-"sI" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/maintenance/fore_starboard)
-"sJ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/power/apc/talon{
-	name = "south bump";
-	pixel_y = -24
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway)
-"sK" = (
+/area/talon_v2/engineering/atmospherics)
+"dn" = (
+/obj/machinery/door/firedoor/glass/talon,
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
 /obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/door/blast/shutters{
-	density = 0;
-	dir = 2;
-	icon_state = "shutter0";
-	id = "talon_brig2";
-	name = "Cell Shutters";
-	opacity = 0
-	},
-/obj/machinery/door/firedoor/glass/talon,
-/turf/simulated/floor/plating,
-/area/talon_v2/brig)
-"sL" = (
-/obj/machinery/power/apc/talon{
-	dir = 1;
-	name = "north bump";
-	pixel_y = 28
-	},
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 10
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/starboard)
-"sM" = (
-/obj/effect/landmark/map_data/talon,
-/turf/space,
-/area/space)
-"sT" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/random/multiple/corp_crate/talon_cargo,
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/maintenance/wing_port)
-"sV" = (
-/obj/structure/catwalk,
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/maintenance/fore_starboard)
-"sZ" = (
-/obj/structure/catwalk,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/maintenance/aft_starboard)
-"ta" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/warning,
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/anomaly_storage)
-"tb" = (
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/central_hallway/fore)
-"tc" = (
-/obj/machinery/door/firedoor/glass/talon,
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/central_hallway/fore)
-"td" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/maintenance/wing_starboard)
-"te" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor/glass/talon,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/airlock/engineering{
-	id_tag = "talon_engdoor";
-	name = "Engineer's Cabin";
-	req_one_access = list(301)
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/crew_quarters/eng_room)
-"tf" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/white,
-/area/talon_v2/medical)
-"tg" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/catwalk,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/maintenance/aft_starboard)
-"ti" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 6
-	},
-/obj/structure/sign/warning/nosmoking_1{
-	pixel_x = -26
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/atmospherics)
-"tj" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway/fore)
-"tk" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway)
-"tl" = (
-/obj/effect/floor_decal/emblem/talon_big{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/central_hallway/fore)
-"tm" = (
-/obj/structure/lattice,
-/turf/space,
-/area/space)
-"tn" = (
-/obj/structure/table/rack/shelf/steel,
-/obj/machinery/recharger/wallcharger{
-	pixel_x = 5;
-	pixel_y = 24
-	},
-/obj/item/weapon/storage/backpack/dufflebag/talon,
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/armory)
-"to" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/sign/directions/medical{
-	dir = 4;
-	pixel_x = 32;
-	pixel_y = -3
-	},
-/obj/structure/sign/directions/engineering{
-	pixel_x = 32;
-	pixel_y = 3
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway)
-"tp" = (
-/obj/machinery/atmospherics/pipe/simple/visible,
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/atmospherics)
-"tu" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/talon_v2/medical)
-"tw" = (
-/obj/machinery/door/firedoor/glass/talon,
-/obj/machinery/door/airlock/medical{
-	id_tag = "talon_meddoor";
-	name = "Doctor's Cabin";
-	req_one_access = list(301)
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/crew_quarters/med_room)
-"tx" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/obj/structure/sign/directions/engineering{
-	pixel_x = 32;
-	pixel_y = -6
-	},
-/obj/structure/sign/directions/cargo{
-	dir = 4;
-	pixel_x = 32
-	},
-/obj/structure/sign/directions/science/xenoarch{
-	dir = 4;
-	pixel_x = 32;
-	pixel_y = 6
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway)
-"ty" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/maintenance/wing_port)
-"tz" = (
-/obj/structure/closet/secure_closet/talon_pilot,
-/obj/item/device/radio/off{
-	channels = list("Talon" = 1)
-	},
-/turf/simulated/floor/wood,
-/area/talon_v2/crew_quarters/pilot_room)
-"tA" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/closet/walllocker_double/hydrant/east,
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/armory)
-"tB" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/closet/walllocker_double/east,
-/obj/item/weapon/storage/toolbox/electrical,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering)
-"tC" = (
-/turf/simulated/wall/rshull,
-/area/talon_v2/maintenance/aft_port)
-"tD" = (
-/obj/structure/table/rack/shelf/steel,
-/obj/random/maintenance/cargo,
-/obj/random/maintenance/cargo,
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/gen_store)
-"tE" = (
-/obj/machinery/embedded_controller/radio/simple_docking_controller{
-	frequency = 1380;
-	id_tag = "talonboat_docker";
-	pixel_y = 24
-	},
-/obj/machinery/computer/shuttle_control/explore/talonboat{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/shuttle/talonboat)
-"tJ" = (
-/obj/structure/railing/grey{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/table/steel,
-/obj/machinery/recharger,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/refining)
-"tK" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway)
-"tM" = (
-/obj/structure/mopbucket,
-/obj/item/weapon/mop,
-/obj/item/weapon/reagent_containers/glass/bucket,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/engineering/star_store)
-"tQ" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/star_store)
-"tR" = (
-/obj/structure/table/marble,
-/obj/machinery/chemical_dispenser/bar_soft/full{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/black/diagonal,
-/turf/simulated/floor/tiled/white,
-/area/talon_v2/crew_quarters/bar)
-"tU" = (
-/obj/machinery/door/firedoor/glass/talon,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway/port)
-"tX" = (
-/obj/structure/railing/grey{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/refining)
-"tY" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/machinery/disposal/wall{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/brig)
-"tZ" = (
-/obj/structure/hull_corner/long_horiz{
-	dir = 5
-	},
-/turf/space,
-/area/space)
-"ub" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 10
-	},
-/turf/simulated/wall/rshull,
-/area/shuttle/talonboat)
-"uc" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/closet/emergsuit_wall{
-	dir = 8;
-	pixel_x = -32
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/maintenance/wing_starboard)
-"ud" = (
-/obj/effect/map_helper/airlock/atmos/chamber_pump,
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/aux,
-/obj/machinery/airlock_sensor{
-	pixel_y = 28;
-	req_one_access = list(301)
-	},
-/obj/effect/map_helper/airlock/sensor/chamber_sensor,
-/obj/structure/handrail,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/maintenance/wing_starboard)
-"uf" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/catwalk,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/maintenance/aft_port)
-"uh" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/talon_v2/medical)
-"ui" = (
-/obj/structure/table/rack/shelf/steel,
-/obj/item/weapon/tank/jetpack/carbondioxide,
-/obj/item/weapon/tank/jetpack/carbondioxide,
-/obj/item/weapon/tank/jetpack/carbondioxide,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/secure_storage)
-"uk" = (
-/obj/machinery/power/apc/talon{
-	dir = 1;
-	name = "north bump";
-	pixel_y = 28
-	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/turf/simulated/floor/wood,
-/area/talon_v2/crew_quarters/eng_room)
-"ul" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway/port)
-"um" = (
-/obj/machinery/door/firedoor/glass/talon,
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
 	},
 /obj/machinery/door/blast/regular/open{
 	dir = 4;
@@ -6318,204 +1168,119 @@
 	},
 /turf/simulated/floor/plating,
 /area/talon_v2/bridge)
-"up" = (
-/obj/machinery/power/pointdefense{
-	id_tag = "talon_pd"
-	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/effect/floor_decal/industrial/warning/dust{
-	dir = 6
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/space)
-"uv" = (
-/obj/structure/barricade,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/star_store)
-"uw" = (
-/obj/structure/flora/pottedplant/tall,
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/crew_quarters/restrooms)
-"ux" = (
-/obj/structure/closet/secure_closet/personal/cabinet{
-	locked = 0
-	},
-/turf/simulated/floor/wood,
-/area/talon_v2/crew_quarters/med_room)
-"uz" = (
-/obj/structure/catwalk,
-/obj/structure/railing/grey{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/maintenance/fore_starboard)
-"uA" = (
-/obj/machinery/power/apc/talon{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/wood,
-/area/talon_v2/crew_quarters/pilot_room)
-"uB" = (
-/obj/structure/bed/chair/bay/chair{
-	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/talon_v2/crew_quarters/bar)
-"uF" = (
-/obj/structure/table/rack/shelf/steel,
-/obj/item/clothing/suit/space/void/refurb/talon,
-/obj/item/clothing/head/helmet/space/void/refurb/talon,
-/obj/machinery/camera/network/talon,
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/secure_storage)
-"uH" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/portable_atmospherics/canister/empty,
-/obj/machinery/atmospherics/portables_connector{
-	dir = 8
-	},
+"dp" = (
 /obj/structure/railing/grey{
 	dir = 1
 	},
+/obj/machinery/oxygen_pump{
+	dir = 8;
+	pixel_x = -30
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/handrail{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/bridge)
+"dq" = (
+/obj/machinery/atmospherics/pipe/manifold4w/visible,
 /turf/simulated/floor/plating,
 /area/talon_v2/engineering/atmospherics)
-"uI" = (
-/obj/machinery/atmospherics/pipe/simple/visible/yellow,
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/starboard)
-"uJ" = (
-/obj/structure/sign/warning/airlock{
-	pixel_x = 32
-	},
-/obj/structure/handrail,
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/maintenance/wing_starboard)
-"uK" = (
-/obj/effect/floor_decal/industrial/warning/dust{
-	dir = 4
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/space)
-"uL" = (
-/obj/structure/hull_corner/long_vert{
-	dir = 5
-	},
-/turf/space,
-/area/space)
-"uM" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1
-	},
-/obj/structure/closet/emergsuit_wall{
-	dir = 4;
-	pixel_x = 32
-	},
+"dr" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway)
-"uO" = (
-/obj/structure/flora/pottedplant/shoot,
-/turf/simulated/floor/wood,
-/area/talon_v2/crew_quarters/cap_room)
-"uQ" = (
-/obj/structure/table/rack/shelf/steel,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/star_store)
-"uR" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/structure/railing/grey,
-/obj/structure/railing/grey{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering)
-"uS" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/sign/department/biblio{
-	pixel_y = -32
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway/port)
-"uT" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/maintenance/wing_port)
-"uU" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/shuttle/talonboat)
-"uV" = (
-/obj/structure/closet/walllocker_double/south,
-/obj/structure/handrail{
-	dir = 1
-	},
-/obj/item/weapon/storage/toolbox/emergency,
-/obj/machinery/atmospherics/pipe/manifold/hidden/aux,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/shuttle/talonboat)
-"uW" = (
-/obj/structure/table/rack/steel,
-/obj/item/clothing/suit/space/void/refurb/talon,
-/obj/item/clothing/head/helmet/space/void/refurb/talon,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
+/turf/simulated/wall/rshull,
+/area/talon_v2/maintenance/aft_starboard)
+"dt" = (
+/obj/machinery/door/firedoor/glass/talon,
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/secure_storage)
-"uZ" = (
-/obj/structure/closet/wardrobe/black{
-	starts_with = list(/obj/item/clothing/under/color/black = 4, /obj/item/clothing/accessory/storage/black_vest = 4, /obj/item/clothing/accessory/storage/black_drop_pouches = 4, /obj/item/clothing/gloves/black = 4, /obj/item/clothing/head/soft/black = 4, /obj/item/clothing/mask/balaclava = 4, /obj/item/clothing/mask/bandana = 4, /obj/item/clothing/mask/gas/commando = 4, /obj/item/weapon/storage/backpack/messenger/black = 4, /obj/item/weapon/storage/backpack/dufflebag = 4, /obj/item/clothing/shoes/black = 4, /obj/item/clothing/shoes/boots/duty = 4)
+/obj/structure/window/reinforced,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/crew_quarters/restrooms)
-"va" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/machinery/door/blast/regular/open{
+	dir = 2;
+	id = "talon_bridge_shields"
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/bridge)
+"dv" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/disposalpipe/junction,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/catwalk_plated/dark,
+/turf/simulated/floor/plating,
+/area/talon_v2/central_hallway/fore)
+"dw" = (
+/obj/machinery/vending/wallmed1{
+	emagged = 1;
+	pixel_y = 32;
+	shut_up = 0
+	},
+/turf/simulated/floor/wood,
+/area/talon_v2/crew_quarters/bar)
+"dA" = (
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway/fore)
+"dB" = (
+/obj/machinery/atmospherics/pipe/simple/visible/yellow,
+/turf/simulated/wall/rshull,
+/area/talon_v2/engineering/port)
+"dC" = (
+/obj/machinery/alarm/talon{
+	dir = 1;
+	pixel_y = -22
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/bridge)
+"dD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+	dir = 10
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/sign/department/eng{
-	pixel_y = -32
-	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/bridge)
+"dH" = (
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway)
-"vb" = (
+/turf/simulated/wall/rshull,
+/area/talon_v2/engineering/star_store)
+"dI" = (
+/obj/machinery/light/small,
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_x = 2;
+	pixel_y = -28
+	},
 /obj/structure/cable/yellow{
 	d2 = 8;
 	icon_state = "0-8"
@@ -6525,1631 +1290,54 @@
 	},
 /turf/simulated/floor/plating,
 /area/talon_v2/engineering)
-"vc" = (
-/obj/structure/catwalk,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+"dJ" = (
+/obj/machinery/conveyor{
+	dir = 1;
+	id = "talonrefinery"
 	},
-/turf/simulated/floor/plating,
-/area/talon_v2/maintenance/aft_starboard)
-"vd" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/yellow,
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/starboard)
-"ve" = (
-/obj/machinery/suit_cycler/vintage/tmedic,
-/turf/simulated/floor/wood,
-/area/talon_v2/crew_quarters/med_room)
-"vh" = (
-/obj/machinery/atmospherics/binary/pump/high_power/on,
-/obj/structure/railing/grey{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/port)
-"vi" = (
-/obj/effect/floor_decal/industrial/outline/red,
-/obj/machinery/atmospherics/portables_connector{
-	dir = 4
-	},
-/obj/machinery/portable_atmospherics/canister/phoron/engine_setup,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/port)
-"vp" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/effect/catwalk_plated,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/brig)
-"vs" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/talon_v2/medical)
-"vt" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/workroom)
-"vw" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/holoposter{
-	dir = 4;
+/obj/structure/sign/warning/moving_parts{
 	pixel_x = 32
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway)
-"vx" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/techmaint,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/talon_v2/refining)
-"vy" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/structure/handrail,
-/obj/structure/closet/autolok_wall{
-	pixel_y = 32
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/shuttle/talonboat)
-"vz" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/effect/floor_decal/industrial/warning{
-	dir = 9
-	},
-/obj/structure/railing/grey{
-	dir = 8
-	},
-/obj/structure/table/steel,
-/obj/random/maintenance/engineering,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/engineering)
-"vA" = (
-/obj/structure/bed/chair/bay/chair{
-	dir = 1
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/obj/machinery/light,
-/obj/machinery/alarm/talon{
-	dir = 1;
-	pixel_y = -25
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/shuttle/talonboat)
-"vB" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/obj/structure/catwalk,
-/obj/structure/extinguisher_cabinet{
-	dir = 1;
-	pixel_y = -32
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/port)
-"vC" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/structure/catwalk,
-/obj/structure/catwalk,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/maintenance/aft_port)
-"vE" = (
-/obj/structure/railing/grey{
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/outline/red,
-/obj/machinery/portable_atmospherics/canister/empty/phoron,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/star_store)
-"vF" = (
-/obj/effect/landmark/talon,
-/obj/structure/handrail,
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/central_hallway)
-"vG" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway/star)
-"vH" = (
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/power/apc/talon{
-	dir = 1;
-	name = "north bump";
-	pixel_y = 28
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/anomaly_storage)
-"vJ" = (
-/obj/machinery/door/firedoor/glass/talon,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway/star)
-"vL" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/catwalk,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/maintenance/aft_starboard)
-"vP" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/visible,
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/atmospherics)
-"vR" = (
-/obj/structure/handrail{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/maintenance/wing_port)
-"vU" = (
-/obj/machinery/door/firedoor/glass/talon,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/airlock/medical{
-	id_tag = "talon_meddoor";
-	name = "Doctor's Cabin";
-	req_one_access = list(301)
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/crew_quarters/med_room)
-"vV" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/closet/crate/secure/phoron{
-	req_one_access = list(301)
-	},
-/obj/item/weapon/tank/phoron/pressurized{
-	pixel_x = -3
-	},
-/obj/item/weapon/tank/phoron/pressurized{
-	pixel_x = 3
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/shuttle/talonboat)
-"vW" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/maintenance/wing_port)
-"vY" = (
-/obj/structure/table/steel,
-/obj/item/weapon/pickaxe/drill,
-/obj/machinery/button/remote/blast_door{
-	id = "talon_boat_cockpit";
-	pixel_y = 28
-	},
-/obj/item/device/radio/off{
-	channels = list("Talon" = 1)
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/shuttle/talonboat)
-"vZ" = (
-/obj/machinery/door/firedoor/glass/talon,
-/obj/machinery/door/airlock/medical{
-	req_one_access = list(301)
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/medical)
-"wa" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/bed/chair/bay/chair,
-/turf/simulated/floor/carpet,
-/area/talon_v2/crew_quarters/sec_room)
-"wd" = (
-/turf/simulated/floor/plating,
-/area/talon_v2/maintenance/fore_port)
-"we" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/space)
-"wg" = (
-/obj/structure/sign/directions/engineering{
-	pixel_x = 32;
-	pixel_y = 3
-	},
-/obj/structure/sign/directions/medical{
-	pixel_x = 32;
-	pixel_y = -3
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway)
-"wh" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/light,
-/obj/structure/sign/department/armory{
-	pixel_y = -32
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway/port)
-"wi" = (
-/turf/simulated/wall/rshull,
-/area/talon_v2/maintenance/fore_port)
-"wj" = (
-/obj/machinery/atmospherics/pipe/simple/visible/yellow,
-/turf/simulated/wall/rshull,
-/area/talon_v2/engineering/starboard)
-"wm" = (
-/obj/structure/railing/grey{
-	dir = 1
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/bridge)
-"wo" = (
-/obj/machinery/suit_cycler/vintage/tcaptain,
-/turf/simulated/floor/wood,
-/area/talon_v2/crew_quarters/cap_room)
-"wr" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/structure/closet/emergsuit_wall{
-	dir = 8;
-	pixel_x = -32
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/maintenance/wing_starboard)
-"ws" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/floor_decal/industrial/warning,
-/obj/structure/handrail{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/maintenance/wing_port)
-"wu" = (
-/obj/structure/catwalk,
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering)
-"wx" = (
-/obj/structure/bed/chair/bay/chair{
-	dir = 1
-	},
-/turf/simulated/floor/carpet,
-/area/talon_v2/crew_quarters/eng_room)
-"wy" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/structure/catwalk,
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering)
-"wz" = (
-/obj/machinery/atmospherics/pipe/manifold4w/visible/yellow,
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/port)
-"wB" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/maintenance/wing_port)
-"wF" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/random/multiple/corp_crate/talon_cargo,
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/maintenance/wing_starboard)
-"wH" = (
-/obj/machinery/pointdefense_control{
-	id_tag = "talon_pd"
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/engineering)
-"wM" = (
-/obj/structure/closet/walllocker/emerglocker/west,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/secure_storage)
-"wN" = (
-/obj/structure/catwalk,
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/maintenance/fore_starboard)
-"wO" = (
-/obj/structure/bed/chair/bay/comfy/brown{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/bridge)
-"wP" = (
-/obj/structure/catwalk,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/talon_v2/maintenance/fore_port)
-"wS" = (
-/obj/structure/catwalk,
-/obj/structure/railing/grey{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/atmospherics)
-"wU" = (
-/obj/machinery/door/firedoor/glass/talon,
-/obj/machinery/door/airlock/maintenance/sec{
-	id_tag = "talon_secdoor";
-	req_one_access = list(301)
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/crew_quarters/sec_room)
-"wV" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/flora/pottedplant/mysterious,
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/central_hallway/fore)
-"wW" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor/glass/talon,
-/obj/machinery/door/airlock/engineeringatmos{
-	name = "Talon Atmospherics";
-	req_one_access = list(301)
-	},
-/obj/structure/sign/warning/nosmoking_1{
-	pixel_x = 26
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/engineering/atmospherics)
-"wX" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/aux{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/shuttle/talonboat)
-"wZ" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/engineering/star_store)
-"xb" = (
-/obj/structure/table/woodentable,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/obj/item/weapon/paper/dockingcodes,
-/turf/simulated/floor/carpet/blucarpet,
-/area/talon_v2/crew_quarters/cap_room)
-"xd" = (
-/obj/structure/bed/chair/bay/chair,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/turf/simulated/floor/wood,
-/area/talon_v2/crew_quarters/meditation)
-"xf" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/sign/directions/security/armory{
-	dir = 10;
-	pixel_x = -32;
-	pixel_y = -6
-	},
-/obj/structure/sign/directions/security{
-	dir = 1;
-	pixel_x = -32;
-	pixel_y = 6
-	},
-/obj/structure/sign/directions/security/brig{
-	dir = 1;
-	pixel_x = -32
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway)
-"xh" = (
-/obj/machinery/computer/ship/helm{
-	req_one_access = list(301)
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/camera/network/talon,
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/bridge)
-"xi" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/random/multiple/corp_crate/talon_cargo,
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/maintenance/wing_starboard)
-"xk" = (
-/obj/structure/extinguisher_cabinet{
-	dir = 1;
-	pixel_y = -32
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/port_store)
-"xm" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/sign/department/bar{
-	pixel_x = 29
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/central_hallway/fore)
-"xq" = (
-/obj/effect/floor_decal/corner/black/diagonal,
-/obj/structure/table/marble,
-/turf/simulated/floor/tiled/white,
-/area/talon_v2/crew_quarters/bar)
-"xr" = (
-/obj/structure/catwalk,
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/maintenance/aft_starboard)
-"xt" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway/port)
-"xu" = (
-/obj/structure/railing/grey,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/bridge)
-"xv" = (
-/obj/machinery/alarm/talon{
-	dir = 8;
-	pixel_x = 22
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/carpet/blucarpet,
-/area/talon_v2/crew_quarters/cap_room)
-"xw" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/machinery/disposal/wall{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/workroom)
-"xx" = (
-/obj/machinery/atmospherics/pipe/simple/visible/red{
-	dir = 6
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/atmospherics)
-"xB" = (
-/obj/machinery/power/pointdefense{
-	id_tag = "talon_pd"
-	},
-/obj/effect/floor_decal/industrial/warning/dust{
-	dir = 5
-	},
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/space)
-"xE" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/handrail,
-/obj/machinery/firealarm{
-	layer = 3.3;
-	pixel_y = 26
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/shuttle/talonboat)
-"xH" = (
-/turf/simulated/wall/rshull,
-/area/talon_v2/engineering/port_store)
-"xJ" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/closet/emergsuit_wall{
-	pixel_y = 32
-	},
-/turf/simulated/floor/wood,
-/area/talon_v2/crew_quarters/eng_room)
-"xL" = (
-/obj/machinery/alarm/talon{
-	dir = 8;
-	pixel_x = 22
-	},
-/obj/structure/catwalk,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/maintenance/fore_port)
-"xM" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/machinery/door/blast/regular/open{
-	dir = 4;
-	id = "talon_quietroom"
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/crew_quarters/meditation)
-"xN" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/talon_v2/crew_quarters/sec_room)
-"xP" = (
-/obj/structure/catwalk,
-/obj/structure/barricade,
-/turf/simulated/floor/plating,
-/area/talon_v2/maintenance/aft_starboard)
-"xQ" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/holoposter{
-	dir = 1;
-	pixel_y = 32
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway/star)
-"xR" = (
-/obj/machinery/alarm/talon{
-	dir = 1;
-	pixel_y = -25
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway/star)
-"xW" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering)
-"xX" = (
-/obj/machinery/door/blast/regular{
-	dir = 4;
-	id = "talon_cargo_star";
-	name = "Cargo Loading Hatch"
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/maintenance/wing_starboard)
-"xZ" = (
-/obj/structure/bookcase/manuals/xenoarchaeology,
-/obj/structure/closet/emergsuit_wall{
-	dir = 4;
-	pixel_x = 32
-	},
-/turf/simulated/floor/wood,
-/area/talon_v2/crew_quarters/meditation)
-"ya" = (
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/star_store)
-"yc" = (
-/obj/machinery/light/small,
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/atmospherics)
-"yd" = (
-/obj/machinery/light_switch{
-	dir = 4;
-	pixel_x = -24
-	},
-/turf/simulated/floor/wood,
-/area/talon_v2/crew_quarters/sec_room)
-"yf" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/maintenance/wing_starboard)
-"yg" = (
-/obj/machinery/door/firedoor/glass/talon,
-/obj/machinery/door/airlock/maintenance/common,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plating,
-/area/talon_v2/maintenance/aft_port)
-"yh" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/holoposter{
-	pixel_y = -32
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway)
-"yj" = (
-/obj/machinery/door/firedoor/glass/talon,
-/obj/machinery/door/airlock/multi_tile/glass{
-	dir = 1;
-	req_one_access = list(301)
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway/star)
-"ym" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/effect/catwalk_plated,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/sign/department/medbay{
-	pixel_y = 32
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/central_hallway/star)
-"yo" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/catwalk,
-/obj/structure/closet/walllocker_double/west,
-/obj/item/weapon/cell/apc,
-/obj/item/weapon/cell/apc,
-/obj/random/maintenance/engineering,
-/obj/random/maintenance/engineering,
-/obj/item/device/radio/off{
-	channels = list("Talon" = 1)
-	},
-/obj/item/clothing/suit/radiation,
-/obj/item/clothing/head/radiation,
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering)
-"yp" = (
-/obj/item/modular_computer/console/preset/talon{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/brig)
-"yq" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/atmospherics)
-"yr" = (
-/obj/effect/overmap/visitable/ship/talon,
-/turf/space,
-/area/space)
-"yu" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/wall/rshull,
-/area/talon_v2/maintenance/fore_starboard)
-"yv" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/aux{
-	dir = 10
-	},
-/obj/structure/handrail,
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/maintenance/fore_starboard)
-"yw" = (
-/obj/structure/catwalk,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/talon_v2/maintenance/wing_port)
-"yx" = (
-/obj/machinery/door/firedoor/glass/talon,
-/obj/machinery/door/airlock/maintenance/common,
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/talon_v2/maintenance/aft_starboard)
-"yA" = (
-/obj/structure/bed/chair/bay/chair{
-	dir = 1
-	},
-/turf/simulated/floor/carpet/blucarpet,
-/area/talon_v2/crew_quarters/cap_room)
-"yC" = (
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/maintenance/wing_starboard)
-"yD" = (
-/obj/machinery/power/apc/talon{
-	dir = 1;
-	name = "north bump";
-	pixel_y = 28
-	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 6
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/port)
-"yF" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/atmospherics)
-"yJ" = (
-/obj/machinery/door/firedoor/glass/talon,
-/obj/machinery/door/airlock/maintenance/common,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/maintenance/wing_port)
-"yN" = (
-/obj/structure/trash_pile,
-/obj/machinery/camera/network/talon,
-/obj/structure/railing/grey{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/star_store)
-"yO" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/structure/table/rack/steel,
-/obj/random/maintenance/engineering,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/port_store)
-"yP" = (
-/obj/machinery/vending/food{
-	dir = 1
-	},
-/turf/simulated/floor/wood,
-/area/talon_v2/crew_quarters/bar)
-"yR" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/sign/directions/security/armory{
-	pixel_x = -32
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway)
-"yU" = (
-/obj/structure/table/woodentable,
-/obj/item/modular_computer/laptop/preset/custom_loadout/standard/talon/engineer,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
-/turf/simulated/floor/carpet,
-/area/talon_v2/crew_quarters/eng_room)
-"yV" = (
-/obj/machinery/door/firedoor/glass/talon,
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/hangar)
-"yW" = (
-/turf/simulated/wall/shull{
-	can_open = 1
-	},
-/area/talon_v2/engineering/atmospherics)
-"yX" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/engineering/star_store)
-"yY" = (
-/obj/structure/railing/grey{
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/outline/red,
-/obj/machinery/portable_atmospherics/canister/empty/phoron,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/port_store)
-"yZ" = (
-/obj/structure/closet/crate,
-/obj/structure/railing/grey{
-	dir = 1
-	},
-/obj/machinery/camera/network/talon{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/refining)
-"zd" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway/star)
-"zj" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/camera/network/talon,
-/obj/random/multiple/corp_crate/talon_cargo,
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/maintenance/wing_starboard)
-"zm" = (
-/turf/simulated/wall/rshull,
-/area/talon_v2/engineering/starboard)
-"zn" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/closet/walllocker_double/hydrant/east,
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/maintenance/wing_port)
-"zo" = (
-/obj/machinery/media/jukebox,
-/obj/machinery/light,
-/turf/simulated/floor/wood,
-/area/talon_v2/crew_quarters/bar)
-"zq" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/wall/rshull,
-/area/talon_v2/maintenance/fore_port)
-"zs" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor/glass/talon,
-/obj/machinery/door/airlock/engineering{
-	name = "Talon Port Engines & Spare Fuel";
-	req_one_access = list(301)
-	},
-/obj/structure/sign/warning/nosmoking_1{
-	pixel_x = -26
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/port)
-"zu" = (
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/crew_quarters/restrooms)
-"zv" = (
-/obj/structure/table/rack/shelf/steel,
-/obj/item/weapon/tank/oxygen,
-/obj/item/weapon/tank/oxygen,
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/secure_storage)
-"zw" = (
-/obj/effect/floor_decal/emblem/talon_big{
-	dir = 8
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/central_hallway/fore)
-"zy" = (
-/obj/structure/closet/emergsuit_wall{
-	pixel_y = 32
-	},
-/turf/simulated/floor/wood,
-/area/talon_v2/crew_quarters/med_room)
-"zz" = (
-/obj/structure/table/rack/shelf/steel,
-/obj/random/maintenance/cargo,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/random/maintenance/cargo,
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/gen_store)
-"zB" = (
-/obj/structure/table/rack/shelf/steel,
-/obj/item/clothing/head/helmet/space/void/refurb/talon,
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/secure_storage)
-"zC" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/aux{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/shuttle/talonboat)
-"zF" = (
-/obj/structure/catwalk,
-/obj/structure/handrail{
-	dir = 4
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/talon_v2/maintenance/wing_starboard)
-"zH" = (
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/brig)
-"zI" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/maintenance/wing_starboard)
-"zJ" = (
-/obj/machinery/vending/tool{
-	req_log_access = 301
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/engineering/star_store)
-"zK" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/wood,
-/area/talon_v2/crew_quarters/meditation)
-"zL" = (
-/obj/machinery/atmospherics/portables_connector,
-/obj/effect/floor_decal/industrial/outline,
-/obj/machinery/portable_atmospherics/powered/pump/filled,
-/obj/structure/railing/grey{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/atmospherics)
-"zM" = (
-/obj/machinery/door/window/brigdoor/eastright{
-	req_access = list();
-	req_one_access = list(301)
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/port)
-"zQ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/wood,
-/area/talon_v2/crew_quarters/sec_room)
-"zT" = (
-/obj/machinery/airlock_sensor{
-	dir = 8;
-	pixel_x = 28;
-	pixel_y = 28;
-	req_one_access = list(301)
-	},
-/obj/effect/map_helper/airlock/sensor/ext_sensor,
-/obj/structure/catwalk,
-/turf/simulated/floor/reinforced/airless,
-/area/talon_v2/maintenance/fore_port)
-"zV" = (
-/obj/machinery/atmospherics/pipe/manifold4w/visible,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/atmospherics)
-"zW" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/shuttle/talonboat)
-"zX" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 1
-	},
-/obj/machinery/camera/network/talon{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/bridge)
-"zZ" = (
-/obj/machinery/alarm/talon{
-	dir = 4;
-	pixel_x = -22
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/talon_v2/maintenance/fore_starboard)
-"Ad" = (
-/obj/structure/bed/chair/bay/chair{
-	dir = 4
-	},
-/obj/machinery/power/apc/talon{
-	name = "south bump";
-	pixel_y = -24
-	},
-/obj/structure/cable/green,
-/turf/simulated/floor/wood,
-/area/talon_v2/crew_quarters/bar)
-"Ag" = (
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/aux,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/maintenance/wing_starboard)
-"Aj" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/maintenance/wing_starboard)
-"An" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/secure_storage)
-"Aq" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/sign/department/telecoms{
-	pixel_y = -31
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway)
-"As" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/hangar)
-"At" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/maintenance/wing_port)
-"Av" = (
-/obj/structure/catwalk,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/maintenance/aft_starboard)
-"Aw" = (
+"dK" = (
 /obj/machinery/door/firedoor/glass/talon,
 /obj/machinery/door/airlock/glass{
-	name = "Flight Control"
+	name = "Cantina"
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/central_hallway)
-"Ax" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/crew_quarters/bar)
+"dL" = (
+/obj/structure/railing/grey{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/wood,
-/area/talon_v2/crew_quarters/eng_room)
-"Az" = (
-/obj/structure/table/steel,
-/obj/item/device/radio/off{
-	channels = list("Talon" = 1);
-	pixel_y = 6
-	},
-/obj/item/device/radio/off{
-	channels = list("Talon" = 1);
-	pixel_x = -6;
-	pixel_y = 4
-	},
-/obj/item/device/radio/off{
-	channels = list("Talon" = 1);
-	pixel_x = 6;
-	pixel_y = 4
-	},
-/obj/item/device/radio/off{
-	channels = list("Talon" = 1)
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/secure_storage)
-"AD" = (
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/atmospherics)
+"dN" = (
 /obj/structure/table/rack/shelf/steel,
 /obj/item/clothing/suit/space/void/refurb/talon,
 /obj/item/clothing/head/helmet/space/void/refurb/talon,
 /turf/simulated/floor/tiled/techfloor,
 /area/talon_v2/secure_storage)
-"AE" = (
-/obj/machinery/atmospherics/portables_connector,
-/obj/effect/floor_decal/industrial/outline/blue,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/atmospherics)
-"AH" = (
-/obj/machinery/power/apc/talon{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -28
-	},
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/structure/disposalpipe/segment{
+"dO" = (
+/obj/machinery/light_switch{
 	dir = 4;
-	icon_state = "pipe-c"
+	pixel_x = -26;
+	pixel_y = 24
 	},
 /turf/simulated/floor/wood,
-/area/talon_v2/crew_quarters/sec_room)
-"AI" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway)
-"AJ" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/catwalk,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/star_store)
-"AL" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
+/area/talon_v2/crew_quarters/bar)
+"dP" = (
+/obj/effect/shuttle_landmark/premade/talon_v2_near_fore_port,
+/turf/space,
+/area/space)
+"dT" = (
+/obj/machinery/light{
 	dir = 8
 	},
-/obj/structure/closet/emergsuit_wall{
-	dir = 4;
-	pixel_x = 32
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/starboard)
-"AN" = (
-/obj/machinery/door/airlock/glass_external{
-	req_one_access = list(301)
-	},
-/obj/effect/map_helper/airlock/door/ext_door,
-/obj/machinery/door/blast/regular/open{
-	id = "talon_boat_east"
-	},
-/obj/machinery/button/remote/blast_door{
-	dir = 1;
-	id = "talon_boat_east";
-	pixel_y = -28;
-	req_one_access = list(301)
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/shuttle/talonboat)
-"AO" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment{
-	dir = 1
-	},
-/obj/structure/sign/department/medbay{
-	name = "DOCTOR'S QUARTERS";
-	pixel_x = 32
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway/fore)
-"AQ" = (
-/obj/structure/table/woodentable,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/obj/item/weapon/paper/talon_doctor,
-/turf/simulated/floor/carpet,
-/area/talon_v2/crew_quarters/med_room)
-"AR" = (
-/obj/structure/table/rack/shelf/steel,
-/obj/item/weapon/tank/jetpack/carbondioxide,
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/secure_storage)
-"AS" = (
+/turf/simulated/floor/wood,
+/area/talon_v2/crew_quarters/cap_room)
+"dW" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
@@ -8158,504 +1346,34 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/talon_v2/bridge)
-"AT" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/starboard)
-"AU" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/random/multiple/corp_crate/talon_cargo,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/maintenance/wing_starboard)
-"AV" = (
-/obj/effect/floor_decal/industrial/warning{
+"dX" = (
+/obj/structure/bed/chair/bay/comfy/brown{
 	dir = 1
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/extinguisher_cabinet{
-	dir = 1;
-	pixel_y = -32
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/hangar)
-"AW" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/hangar)
-"AX" = (
-/obj/machinery/door/firedoor/glass/talon,
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/turf/simulated/floor/plating,
-/area/talon_v2/crew_quarters/bar)
-"AY" = (
-/obj/machinery/mineral/unloading_machine,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/refining)
-"AZ" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/catwalk,
-/obj/structure/closet/emergsuit_wall{
-	dir = 1;
-	pixel_y = -32
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering)
-"Bb" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering)
-"Bc" = (
-/obj/effect/floor_decal/industrial/warning/dust{
-	dir = 5
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/talon_v2/engineering/port)
-"Bd" = (
-/obj/machinery/computer/ship/sensors,
-/turf/simulated/floor/tiled/techfloor,
-/area/shuttle/talonboat)
-"Be" = (
-/turf/simulated/wall/shull{
-	can_open = 1
-	},
-/area/talon_v2/gen_store)
-"Bf" = (
-/obj/machinery/shipsensors{
-	dir = 1
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/talon_v2/bridge)
-"Bi" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway/fore)
-"Bk" = (
-/obj/machinery/atmospherics/binary/pump/high_power/on{
-	dir = 4
-	},
-/obj/structure/railing/grey{
-	dir = 4
-	},
-/obj/structure/railing/grey{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/atmospherics)
-"Bn" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 9
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/atmospherics)
-"Bq" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/bridge)
-"Br" = (
-/obj/machinery/airlock_sensor{
-	dir = 8;
-	pixel_x = 28;
-	pixel_y = 28;
-	req_one_access = list(301)
-	},
-/obj/effect/map_helper/airlock/sensor/ext_sensor,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/reinforced/airless,
-/area/talon_v2/maintenance/wing_port)
-"Bs" = (
-/obj/machinery/door/firedoor/glass/talon,
-/obj/machinery/door/airlock/maintenance/sec{
-	req_one_access = list(301)
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/brig)
-"Bt" = (
-/obj/machinery/door/firedoor/glass/talon,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment{
-	dir = 1
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway/fore)
-"Bu" = (
-/obj/structure/table/woodentable,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/simulated/floor/wood,
-/area/talon_v2/crew_quarters/meditation)
-"Bv" = (
-/obj/machinery/button/remote/blast_door{
-	id = "talon_cargo_port";
-	name = "Cargo Loading Hatches";
-	pixel_y = -28
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/door/window/brigdoor/northleft{
-	req_access = list();
-	req_one_access = list(301)
-	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/maintenance/wing_port)
-"Bw" = (
-/turf/simulated/wall/shull,
-/area/talon_v2/workroom)
-"By" = (
-/turf/simulated/floor/wood,
-/area/talon_v2/crew_quarters/bar)
-"BB" = (
-/obj/machinery/door/airlock/glass_external{
-	req_one_access = list(301)
-	},
-/obj/effect/map_helper/airlock/door/ext_door,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/maintenance/fore_port)
-"BC" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26
-	},
-/obj/random/multiple/corp_crate/talon_cargo,
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/maintenance/wing_port)
-"BF" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/random/multiple/corp_crate/talon_cargo,
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/maintenance/wing_starboard)
-"BH" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/item/weapon/storage/firstaid/regular,
-/obj/item/weapon/storage/firstaid/o2,
-/obj/structure/closet/walllocker/medical/south,
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/crew_quarters/restrooms)
-"BJ" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/effect/catwalk_plated,
-/obj/structure/disposalpipe/junction{
 	dir = 2;
-	icon_state = "pipe-j2"
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/central_hallway)
-"BK" = (
-/obj/structure/disposalpipe/trunk,
-/obj/machinery/disposal/wall,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/engineering)
-"BN" = (
-/turf/simulated/wall/shull{
-	can_open = 1
-	},
-/area/talon_v2/crew_quarters/restrooms)
-"BO" = (
-/obj/machinery/light/small,
-/obj/machinery/atmospherics/binary/pump/on{
-	dir = 8;
-	name = "Waste Compresser"
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/atmospherics)
-"BT" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/atmospherics)
-"BU" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/structure/closet/emergsuit_wall{
-	dir = 8;
-	pixel_x = -32
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/crew_quarters/restrooms)
-"BV" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/maintenance/wing_port)
-"BW" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/aux{
-	dir = 1
-	},
-/obj/effect/map_helper/airlock/atmos/chamber_pump,
-/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	dir = 1;
-	id_tag = "talon_starboard_fore";
-	pixel_y = -30;
-	req_one_access = list(301)
-	},
-/obj/structure/handrail{
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/maintenance/fore_starboard)
-"BX" = (
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
+/area/talon_v2/bridge)
+"dZ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/wood,
+/area/talon_v2/crew_quarters/cap_room)
+"ec" = (
 /obj/machinery/power/apc/talon{
 	dir = 1;
 	name = "north bump";
 	pixel_y = 28
 	},
-/obj/structure/table/rack/steel,
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/secure_storage)
-"BY" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/wood,
-/area/talon_v2/crew_quarters/cap_room)
-"BZ" = (
-/obj/structure/table/woodentable,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/item/weapon/paper/talon_power,
-/turf/simulated/floor/carpet,
-/area/talon_v2/crew_quarters/eng_room)
-"Cb" = (
-/obj/machinery/door/firedoor/glass/talon,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/airlock/glass_centcom{
-	name = "Talon Storage";
-	req_one_access = list(301)
-	},
 /obj/structure/cable/green{
-	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/secure_storage)
-"Cd" = (
-/obj/structure/closet/secure_closet/personal/cabinet{
-	locked = 0
-	},
-/obj/machinery/camera/network/talon{
-	dir = 1
-	},
-/turf/simulated/floor/carpet,
-/area/talon_v2/crew_quarters/pilot_room)
-"Ce" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/aux{
-	dir = 10
-	},
-/obj/machinery/airlock_sensor{
-	dir = 4;
-	pixel_x = -28;
-	pixel_y = 28;
-	req_one_access = list(301)
-	},
-/obj/effect/map_helper/airlock/sensor/int_sensor,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/maintenance/wing_port)
-"Cf" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/machinery/door/blast/regular/open{
-	dir = 4;
-	id = "talon_anomalystorage"
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/anomaly_storage)
-"Cg" = (
-/obj/structure/bed/chair/office/light,
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/workroom)
-"Ck" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/catwalk,
-/obj/structure/closet/walllocker/medical/south,
-/obj/item/weapon/storage/firstaid/regular,
-/obj/item/weapon/storage/firstaid/fire,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering)
-"Cq" = (
-/obj/effect/map_helper/airlock/door/ext_door,
-/obj/machinery/door/airlock/glass_external{
-	req_one_access = list(301)
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/maintenance/wing_starboard)
-"Cr" = (
-/obj/structure/trash_pile,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/port_store)
-"Cs" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/catwalk,
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/obj/structure/closet/walllocker_double/east,
-/obj/item/weapon/cell/device/weapon,
-/obj/item/weapon/cell/device/weapon,
-/obj/item/weapon/cell/device,
-/obj/item/weapon/cell/device,
-/obj/random/maintenance/engineering,
-/obj/random/maintenance/engineering,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering)
-"Cw" = (
-/obj/structure/bed/chair/bay/chair{
-	dir = 1
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/machinery/light,
-/obj/machinery/light_switch{
-	dir = 1;
-	pixel_x = 8;
-	pixel_y = -26
-	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_x = -6;
-	pixel_y = -24
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/tiled/techfloor,
-/area/shuttle/talonboat)
-"Cx" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/sign/department/shield{
-	pixel_y = -31
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway)
-"Cy" = (
-/obj/machinery/light/small{
+/area/talon_v2/ofd_ops)
+"ed" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
 /obj/structure/cable/green{
@@ -8663,344 +1381,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/talon_v2/maintenance/aft_starboard)
-"CA" = (
-/obj/machinery/atmospherics/pipe/simple/visible/red,
-/obj/structure/catwalk,
-/obj/structure/railing/grey,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/atmospherics)
-"CB" = (
-/obj/machinery/suit_cycler/vintage/tpilot,
-/obj/machinery/button/remote/airlock{
-	id = "talon_pilotdoor";
-	name = "Door Bolts";
-	pixel_y = 28;
-	specialfunctions = 4
-	},
-/turf/simulated/floor/wood,
-/area/talon_v2/crew_quarters/pilot_room)
-"CC" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 4
-	},
-/obj/structure/railing/grey{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/atmospherics)
-"CD" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 4
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/atmospherics)
-"CE" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/maintenance/wing_port)
-"CF" = (
-/obj/machinery/door/firedoor/glass/talon,
-/obj/machinery/door/airlock{
-	id_tag = "talon_charger";
-	name = "Cyborg Recharging Station"
-	},
-/turf/simulated/floor/tiled/white,
-/area/talon_v2/crew_quarters/restrooms)
-"CH" = (
-/obj/structure/table/woodentable,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
-/obj/item/weapon/paper/talon_pilot,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
-/turf/simulated/floor/carpet,
-/area/talon_v2/crew_quarters/pilot_room)
-"CI" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/closet/emergsuit_wall{
-	dir = 4;
-	pixel_x = 32
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/maintenance/wing_port)
-"CL" = (
-/obj/machinery/light/small,
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/talon_v2/maintenance/fore_starboard)
-"CN" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway/fore)
-"CO" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway)
-"CP" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/camera/network/talon,
-/obj/machinery/atm{
-	pixel_y = 31
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway/port)
-"CS" = (
-/obj/machinery/door/firedoor/glass/talon,
-/obj/machinery/door/airlock/maintenance/medical{
-	req_one_access = list(301)
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/medical)
-"CU" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/anomaly_storage)
-"CV" = (
-/obj/structure/catwalk,
-/obj/machinery/alarm/talon{
-	dir = 8;
-	pixel_x = 22
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/port_store)
-"CX" = (
-/turf/simulated/wall/shull,
-/area/talon_v2/maintenance/fore_port)
-"CY" = (
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/maintenance/wing_port)
-"Dc" = (
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/gen_store)
-"Dd" = (
-/turf/simulated/wall/shull,
-/area/talon_v2/secure_storage)
-"Dg" = (
-/obj/structure/hull_corner/long_vert{
-	dir = 9
-	},
-/turf/space,
-/area/space)
-"Dh" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering)
-"Di" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/item/weapon/storage/firstaid/regular,
-/obj/item/weapon/storage/firstaid/o2,
-/obj/structure/closet/walllocker/medical/east,
-/obj/item/device/radio/off{
-	channels = list("Talon" = 1)
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/maintenance/wing_port)
-"Dj" = (
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/hangar)
-"Dm" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway)
-"Dp" = (
-/obj/structure/catwalk,
-/turf/simulated/floor/reinforced/airless,
-/area/talon_v2/maintenance/wing_port)
-"Dq" = (
-/turf/simulated/wall/rshull,
-/area/talon_v2/maintenance/aft_starboard)
-"Ds" = (
-/obj/machinery/atmospherics/pipe/manifold/visible{
-	dir = 4
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/atmospherics)
-"Du" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/aux{
-	dir = 4
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/maintenance/wing_port)
-"Dx" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway/star)
-"Dy" = (
-/obj/machinery/door/airlock/glass_external{
-	req_one_access = list(301)
-	},
-/obj/effect/map_helper/airlock/door/ext_door,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/maintenance/wing_starboard)
-"DB" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/glass/talon,
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/hangar)
-"DC" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/glass/talon,
-/obj/machinery/door/blast/regular/open{
-	id = "talon_boat_cockpit"
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/shuttle/talonboat)
-"DD" = (
-/turf/simulated/wall/shull,
-/area/talon_v2/maintenance/aft_starboard)
-"DG" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/junction{
-	dir = 4;
-	icon_state = "pipe-j2"
-	},
-/obj/structure/closet/walllocker_double/hydrant/west,
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway)
-"DH" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/aux,
-/obj/machinery/camera/network/talon{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/central_hallway/fore)
-"DI" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/railing/grey,
-/obj/random/multiple/corp_crate/talon_cargo,
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/maintenance/wing_starboard)
-"DK" = (
-/obj/machinery/vending/nifsoft_shop,
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/central_hallway/fore)
-"DM" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/catwalk,
-/obj/structure/railing/grey{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/atmospherics)
-"DP" = (
-/obj/structure/girder,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/atmospherics)
-"DR" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 9
-	},
-/obj/structure/catwalk,
-/obj/structure/railing/grey{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/atmospherics)
-"DU" = (
+/area/talon_v2/bridge)
+"eg" = (
 /obj/machinery/vending/boozeomat{
 	density = 0;
 	pixel_y = 32;
@@ -9025,246 +1408,260 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/talon_v2/crew_quarters/bar)
-"DW" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/random/multiple/corp_crate/talon_cargo,
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/maintenance/wing_port)
-"DX" = (
-/obj/machinery/power/pointdefense{
-	id_tag = "talon_pd"
-	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/effect/floor_decal/industrial/warning/dust{
-	dir = 6
-	},
-/obj/effect/floor_decal/industrial/warning/dust{
-	dir = 5
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/space)
-"DY" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
+"eh" = (
+/obj/structure/flora/pottedplant/shoot,
+/turf/simulated/floor/wood,
+/area/talon_v2/crew_quarters/cap_room)
+"ei" = (
+/obj/machinery/recharge_station,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/generators)
+"ej" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/talon_v2/maintenance/aft_port)
-"Ea" = (
-/obj/machinery/computer/ship/sensors{
-	dir = 8
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/bridge)
-"Eb" = (
-/obj/structure/reagent_dispensers/watertank/high,
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/gen_store)
-"Ef" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/red{
-	dir = 1
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/atmospherics)
-"Ek" = (
-/obj/machinery/door/firedoor/glass/talon,
-/obj/machinery/door/airlock{
-	id_tag = "talon_pilotdoor";
-	name = "Pilot's Cabin";
-	req_one_access = list(301)
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/crew_quarters/pilot_room)
-"En" = (
-/obj/structure/table/standard,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/brig)
-"Eo" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/glass/talon,
-/obj/machinery/door/blast/regular/open{
-	dir = 4;
-	id = "talon_boat_cockpit"
-	},
-/obj/structure/window/reinforced,
-/turf/simulated/floor/plating,
-/area/shuttle/talonboat)
-"Ep" = (
-/obj/structure/table/rack/shelf/steel,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/port_store)
-"Eq" = (
-/obj/structure/closet/emergsuit_wall{
-	dir = 4;
-	pixel_x = 32
-	},
-/turf/simulated/floor/carpet,
-/area/talon_v2/crew_quarters/pilot_room)
-"Er" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/outline/red,
-/obj/machinery/portable_atmospherics/canister/empty/phoron,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/port_store)
-"Et" = (
-/obj/structure/catwalk,
-/obj/structure/trash_pile,
-/turf/simulated/floor/plating,
-/area/talon_v2/maintenance/fore_port)
-"Ev" = (
-/obj/effect/floor_decal/emblem/talon_big{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/central_hallway/fore)
-"Ew" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/armory)
-"Ey" = (
-/obj/structure/table/rack/steel,
-/obj/item/device/suit_cooling_unit,
-/obj/item/device/suit_cooling_unit,
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/secure_storage)
-"EB" = (
+/area/talon_v2/central_hallway/fore)
+"ek" = (
+/obj/structure/table/woodentable,
+/obj/item/modular_computer/tablet/preset/custom_loadout/advanced,
+/obj/item/weapon/paper_bin,
+/obj/item/weapon/pen,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
+/turf/simulated/floor/carpet/blucarpet,
+/area/talon_v2/crew_quarters/cap_room)
+"el" = (
+/obj/structure/table/woodentable,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/item/weapon/paper/dockingcodes,
+/turf/simulated/floor/carpet/blucarpet,
+/area/talon_v2/crew_quarters/cap_room)
+"ep" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/structure/table/steel,
+/obj/machinery/recharger,
+/obj/item/device/geiger{
+	pixel_x = -7
+	},
+/obj/machinery/alarm/talon{
+	pixel_y = 24
+	},
+/obj/machinery/camera/network/talon{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/generators)
+"eq" = (
+/obj/machinery/light/small,
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_x = 2;
+	pixel_y = -28
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
 /turf/simulated/floor/plating,
 /area/talon_v2/engineering/port_store)
-"ED" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
+"er" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/railing/grey,
+/obj/random/multiple/corp_crate/talon_cargo,
 /turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/secure_storage)
-"EF" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/obj/effect/catwalk_plated,
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/disposalpipe/junction,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/central_hallway/fore)
-"EH" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
+/area/talon_v2/maintenance/wing_starboard)
+"et" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/wood,
-/area/talon_v2/crew_quarters/med_room)
-"EI" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 4
-	},
-/obj/structure/catwalk,
-/obj/structure/railing/grey,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/atmospherics)
-"EJ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 6
-	},
-/turf/simulated/wall/rshull,
-/area/shuttle/talonboat)
-"EL" = (
+/area/talon_v2/crew_quarters/eng_room)
+"eu" = (
+/obj/item/modular_computer/console/preset/talon,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+/turf/simulated/floor/carpet/blucarpet,
+/area/talon_v2/crew_quarters/cap_room)
+"ex" = (
+/obj/machinery/alarm/talon{
+	dir = 4;
+	pixel_x = -22
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/maintenance/wing_port)
-"EN" = (
-/obj/item/weapon/storage/firstaid/regular,
-/obj/item/weapon/storage/firstaid/o2,
-/obj/structure/closet/walllocker/medical/north,
-/obj/item/device/radio/off{
-	channels = list("Talon" = 1)
+/area/talon_v2/central_hallway/fore)
+"ey" = (
+/obj/structure/bed/chair/wood,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/sign/painting/public{
+	pixel_x = 30
+	},
+/turf/simulated/floor/carpet/blucarpet,
+/area/talon_v2/crew_quarters/cap_room)
+"ez" = (
+/obj/effect/floor_decal/corner/black/diagonal,
+/obj/structure/table/marble,
+/turf/simulated/floor/tiled/white,
+/area/talon_v2/crew_quarters/bar)
+"eA" = (
+/obj/machinery/atmospherics/unary/engine/bigger{
+	dir = 1
+	},
+/turf/space,
+/area/talon_v2/engineering/port)
+"eB" = (
+/obj/structure/sign/warning/pods{
+	dir = 4;
+	pixel_x = 32
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway/fore)
+"eC" = (
+/obj/structure/closet/walllocker_double/hydrant/west,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/engineering/star_store)
+"eD" = (
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/crew_quarters/restrooms)
+"eF" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering)
+"eG" = (
+/obj/structure/table/marble,
+/obj/machinery/chemical_dispenser/bar_soft/full{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/black/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/talon_v2/crew_quarters/bar)
+"eH" = (
+/obj/structure/sign/painting/public{
+	pixel_x = -30
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway/fore)
+"eI" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering)
+"eK" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/cable/yellow{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/generators)
+"eL" = (
+/obj/structure/railing/grey,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/talon_v2/bridge)
-"EO" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/manifold/visible/yellow{
-	dir = 1
+"eM" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/structure/railing/grey{
+/obj/machinery/door/firedoor/glass/talon,
+/obj/machinery/door/airlock/hatch{
+	name = "Generator Room";
+	req_one_access = list(301)
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/sign/warning/radioactive{
+	pixel_y = 32
+	},
 /turf/simulated/floor/plating,
-/area/talon_v2/engineering/port)
-"EP" = (
+/area/talon_v2/engineering/generators)
+"eN" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering)
+"eP" = (
+/obj/structure/cable/yellow,
+/obj/machinery/light/small,
+/obj/machinery/power/port_gen/pacman/super/potato,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/generators)
+"eQ" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -9281,22 +1678,352 @@
 	},
 /turf/simulated/floor/plating,
 /area/talon_v2/maintenance/aft_starboard)
-"ES" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+"eR" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/floor_decal/corner/black/diagonal,
+/obj/item/weapon/stool/baystool/padded{
 	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/talon_v2/crew_quarters/bar)
+"eS" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/light,
+/obj/structure/sign/department/armory{
+	pixel_y = -32
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway/port)
+"eU" = (
+/obj/machinery/door/blast/regular/open{
+	dir = 4;
+	id = "talon_bridge_shields"
+	},
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning/dust,
+/turf/simulated/floor/reinforced/airless,
+/area/talon_v2/bridge)
+"eX" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/black/diagonal,
+/obj/structure/table/marble,
+/obj/item/device/radio/off{
+	channels = list("Talon" = 1)
+	},
+/turf/simulated/floor/tiled/white,
+/area/talon_v2/crew_quarters/bar)
+"eY" = (
+/obj/structure/table/marble,
+/obj/effect/floor_decal/corner/black/diagonal,
+/obj/machinery/camera/network/talon{
+	dir = 8
+	},
+/obj/random/mre,
+/obj/random/mre,
+/obj/random/mre,
+/obj/random/mre,
+/obj/random/mre,
+/obj/random/mre,
+/obj/structure/closet/walllocker_double/kitchen/east{
+	name = "Ration Cabinet"
+	},
+/turf/simulated/floor/tiled/white,
+/area/talon_v2/crew_quarters/bar)
+"eZ" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/port_store)
+"fa" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway/port)
-"ET" = (
+/area/talon_v2/central_hallway/star)
+"fb" = (
+/turf/simulated/wall/shull,
+/area/talon_v2/engineering/star_store)
+"fc" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/engineering/star_store)
+"fd" = (
+/obj/structure/table/rack/shelf/steel,
+/obj/item/device/suit_cooling_unit,
+/obj/item/device/suit_cooling_unit,
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/secure_storage)
+"ff" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/star_store)
+"fg" = (
+/obj/structure/table/woodentable,
+/obj/item/clothing/accessory/talon{
+	pixel_x = 4;
+	pixel_y = 7
+	},
+/obj/item/clothing/head/caphat/talon{
+	pixel_x = -5
+	},
+/turf/simulated/floor/wood,
+/area/talon_v2/crew_quarters/cap_room)
+"fh" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/catwalk_plated/dark,
+/turf/simulated/floor/plating,
+/area/talon_v2/central_hallway/fore)
+"fi" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/structure/closet/walllocker_double/east,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/engineering/star_store)
+"fj" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway/fore)
+"fm" = (
+/obj/structure/catwalk,
+/obj/machinery/alarm/talon{
+	dir = 8;
+	pixel_x = 22
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/port_store)
+"fn" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/wood,
+/area/talon_v2/crew_quarters/bar)
+"fo" = (
+/obj/machinery/door/firedoor/glass/talon,
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/turf/simulated/floor/plating,
+/area/talon_v2/crew_quarters/bar)
+"fp" = (
+/obj/structure/closet/crate,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/clean,
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/gen_store)
+"fq" = (
+/obj/structure/catwalk,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/port_store)
+"fr" = (
+/obj/structure/catwalk,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/star_store)
+"fs" = (
+/obj/structure/bed/chair/bay/chair,
+/turf/simulated/floor/wood,
+/area/talon_v2/crew_quarters/bar)
+"ft" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 6
+	},
+/obj/structure/sign/warning/nosmoking_1{
+	pixel_x = -26
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/atmospherics)
+"fu" = (
+/obj/structure/railing/grey{
+	dir = 1
+	},
+/obj/machinery/power/smes/buildable/offmap_spawn{
+	RCon_tag = "Talon Port SMES"
+	},
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering)
+"fw" = (
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/bridge)
+"fx" = (
+/obj/structure/table/woodentable,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/wood,
+/area/talon_v2/crew_quarters/cap_room)
+"fA" = (
+/obj/machinery/atmospherics/pipe/tank/air/full{
+	dir = 8
+	},
+/obj/structure/railing/grey,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/atmospherics)
+"fF" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/armory)
+"fG" = (
+/obj/machinery/atmospherics/portables_connector/aux,
+/obj/effect/floor_decal/industrial/outline,
+/obj/structure/railing/grey,
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/port_store)
+"fM" = (
+/obj/structure/bed/double/padded,
+/obj/item/weapon/bedsheet/bluedouble,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/carpet/blucarpet,
+/area/talon_v2/crew_quarters/cap_room)
+"fN" = (
+/obj/structure/table/woodentable,
+/obj/machinery/firealarm{
+	dir = 4;
+	layer = 3.3;
+	pixel_x = 26
+	},
+/obj/machinery/power/apc/talon{
+	name = "south bump";
+	pixel_y = -24
+	},
+/obj/structure/cable/green,
+/obj/item/weapon/paper/talon_captain,
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/carpet/blucarpet,
+/area/talon_v2/crew_quarters/cap_room)
+"fQ" = (
+/obj/structure/railing/grey{
+	dir = 4
+	},
+/obj/structure/table/steel,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 5
+	},
+/obj/item/weapon/paper/talon_shields,
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/engineering)
+"fR" = (
+/obj/structure/sign/warning/airlock{
+	pixel_y = -32
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/aux{
+	dir = 5
+	},
+/obj/machinery/light/small,
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/aft_port)
+"fS" = (
+/obj/structure/sign/warning/airlock{
+	pixel_y = -32
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/aux{
+	dir = 9
+	},
+/obj/machinery/light/small,
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/aft_starboard)
+"fU" = (
 /obj/structure/railing/grey{
 	dir = 1
 	},
@@ -9314,118 +2041,117 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/talon_v2/bridge)
-"EU" = (
-/turf/simulated/wall/rshull,
-/area/talon_v2/maintenance/fore_starboard)
-"EV" = (
-/obj/machinery/alarm/talon{
-	dir = 1;
-	pixel_y = -25
-	},
-/obj/structure/table/rack/steel,
-/obj/item/weapon/grenade/spawnergrenade/manhacks/mercenary{
-	pixel_x = -5;
-	pixel_y = 4
-	},
-/obj/item/device/spaceflare,
-/obj/machinery/camera/network/talon{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/armory)
-"EX" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/handrail{
-	dir = 8
-	},
-/obj/structure/extinguisher_cabinet{
-	dir = 8;
-	pixel_x = 30
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/maintenance/wing_starboard)
-"Fc" = (
-/obj/structure/table/rack/shelf/steel,
-/obj/item/clothing/suit/space/void/refurb/talon,
-/obj/machinery/light_switch{
-	dir = 1;
-	pixel_y = -26
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/secure_storage)
-"Fd" = (
-/obj/effect/floor_decal/industrial/warning,
-/obj/machinery/embedded_controller/radio/simple_docking_controller{
-	frequency = 1380;
-	id_tag = "talon_boatbay";
-	pixel_y = 26
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
+"fV" = (
+/turf/simulated/wall/shull,
 /area/talon_v2/hangar)
-"Fe" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/effect/floor_decal/industrial/warning/corner,
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/anomaly_storage)
-"Ff" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/central_hallway/fore)
-"Fg" = (
-/obj/effect/floor_decal/industrial/warning/dust{
-	dir = 8
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/space)
-"Fj" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/structure/disposalpipe/segment{
+"fW" = (
+/turf/simulated/wall/shull,
+/area/talon_v2/refining)
+"fX" = (
+/turf/simulated/wall/rshull,
+/area/talon_v2/ofd_ops)
+"gb" = (
+/obj/machinery/light{
 	dir = 4
 	},
-/obj/structure/closet/walllocker/medical/north,
-/obj/item/weapon/storage/firstaid/regular,
-/obj/item/weapon/storage/firstaid/o2,
-/obj/item/device/radio/off{
-	channels = list("Talon" = 1)
+/obj/structure/sign/department/bar{
+	pixel_x = 29
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway/fore)
+"gd" = (
+/obj/effect/floor_decal/industrial/loading,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/refining)
+"ge" = (
+/obj/machinery/vending/coffee{
+	dir = 1
 	},
 /turf/simulated/floor/wood,
-/area/talon_v2/crew_quarters/cap_room)
-"Fk" = (
-/obj/machinery/power/pointdefense{
-	id_tag = "talon_pd"
+/area/talon_v2/crew_quarters/bar)
+"gh" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/light/small{
+	dir = 8
 	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/aft_port)
+"gi" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 10
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 4
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/starboard)
+"gj" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/railing/grey,
+/obj/structure/railing/grey{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 6
+	},
+/obj/machinery/power/shield_generator/charged,
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/engineering)
+"gk" = (
+/obj/machinery/media/jukebox,
+/obj/machinery/light,
+/turf/simulated/floor/wood,
+/area/talon_v2/crew_quarters/bar)
+"gm" = (
+/obj/structure/bed/chair/bay/chair{
+	dir = 4
+	},
+/obj/machinery/power/apc/talon{
+	name = "south bump";
+	pixel_y = -24
+	},
+/obj/structure/cable/green,
 /obj/structure/cable/green{
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/effect/floor_decal/industrial/warning/dust{
-	dir = 10
+/turf/simulated/floor/wood,
+/area/talon_v2/crew_quarters/bar)
+"gn" = (
+/turf/simulated/wall/shull{
+	can_open = 1
 	},
-/turf/simulated/floor/reinforced/airless,
-/area/space)
-"Fn" = (
-/obj/machinery/door/firedoor/glass/talon,
-/obj/machinery/door/airlock/medical{
-	req_one_access = list(301)
+/area/talon_v2/workroom)
+"go" = (
+/obj/structure/closet/walllocker/emerglocker/west,
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/armory)
+"gr" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/aux{
+	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/handrail,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/maintenance/fore_port)
+"gs" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
@@ -9434,99 +2160,1422 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/white,
-/area/talon_v2/medical)
-"Fo" = (
-/obj/structure/railing/grey{
-	dir = 8
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
+/obj/effect/catwalk_plated/dark,
 /turf/simulated/floor/plating,
-/area/talon_v2/engineering/atmospherics)
-"Fq" = (
-/obj/effect/landmark/talon,
-/obj/structure/handrail,
-/obj/machinery/computer/cryopod{
-	pixel_y = 32
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/central_hallway)
-"Ft" = (
-/obj/structure/hull_corner/long_horiz{
-	dir = 6
-	},
-/turf/space,
-/area/space)
-"Fv" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/bridge)
-"Fx" = (
-/obj/structure/catwalk,
-/obj/structure/extinguisher_cabinet{
-	dir = 4;
-	pixel_x = -30
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering)
-"Fy" = (
-/obj/effect/map_helper/airlock/door/int_door,
-/obj/machinery/atmospherics/pipe/simple/hidden/aux,
-/obj/machinery/door/airlock/glass_external{
-	req_one_access = list(301)
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
+/area/talon_v2/central_hallway/fore)
+"gu" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/effect/floor_decal/industrial/warning,
+/obj/structure/handrail{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/shuttle/talonboat)
-"Fz" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/aux,
-/obj/structure/sign/painting/public{
-	pixel_x = -30
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/central_hallway/fore)
-"FB" = (
-/obj/effect/landmark/start{
-	name = "Talon Engineer"
-	},
-/turf/simulated/floor/carpet,
-/area/talon_v2/crew_quarters/eng_room)
-"FG" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/port_store)
-"FH" = (
-/obj/structure/sign/painting/public{
-	pixel_x = -30
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/central_hallway/fore)
-"FJ" = (
-/obj/machinery/light/small{
+/area/talon_v2/maintenance/wing_port)
+"gx" = (
+/obj/effect/floor_decal/industrial/warning/dust{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
+/obj/effect/floor_decal/industrial/warning/dust,
+/obj/machinery/door/blast/regular/open{
+	dir = 4;
+	id = "talon_bridge_shields"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
+/turf/simulated/floor/reinforced/airless,
+/area/talon_v2/ofd_ops)
+"gA" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/star_store)
+"gC" = (
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering)
+"gF" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/machinery/power/apc/talon{
+	name = "south bump";
+	pixel_y = -24
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/camera/network/talon{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/hangar)
+"gH" = (
+/obj/machinery/embedded_controller/radio/simple_docking_controller{
+	dir = 8;
+	frequency = 1380;
+	id_tag = "talon_podbay";
+	pixel_x = 26
+	},
+/obj/effect/floor_decal/industrial/warning/corner,
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway/fore)
+"gI" = (
+/obj/machinery/door/firedoor/glass/talon,
+/obj/machinery/door/airlock/maintenance/common,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/fore_port)
+"gK" = (
+/obj/machinery/power/pointdefense{
+	id_tag = "talon_pd"
+	},
+/obj/structure/cable/green,
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 6
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/space)
+"gL" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 5
 	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/alarm/talon{
+	dir = 1;
+	pixel_y = -25
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/atmospherics)
+"gM" = (
+/obj/machinery/disposal/deliveryChute{
+	dir = 4
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/turf/simulated/floor/reinforced,
+/area/talon_v2/ofd_ops)
+"gN" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/turf/simulated/floor/reinforced,
+/area/talon_v2/ofd_ops)
+"gO" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/ofd_ops)
+"gR" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/loading{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/refining)
+"gS" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/port_store)
+"gU" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/maintenance/wing_starboard)
+"gV" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway)
+"gW" = (
+/obj/machinery/computer/ship/sensors,
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/ofd_ops)
+"gX" = (
+/obj/machinery/door/airlock/glass_external,
+/obj/effect/map_helper/airlock/door/int_door,
+/obj/machinery/atmospherics/pipe/manifold/hidden/aux,
+/obj/machinery/atmospherics/pipe/simple/hidden/aux{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/ofd_ops)
+"ha" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/alarm/talon{
+	dir = 4;
+	pixel_x = -22
+	},
+/obj/structure/closet/walllocker_double/east,
+/obj/random/maintenance/engineering,
+/obj/random/maintenance/engineering,
+/obj/random/maintenance/engineering,
+/obj/random/maintenance/engineering,
+/obj/random/maintenance/engineering,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering)
+"hb" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/random/multiple/corp_crate/talon_cargo,
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/maintenance/wing_starboard)
+"hd" = (
+/obj/machinery/door/airlock/glass_external{
+	req_one_access = list(301)
+	},
+/obj/effect/map_helper/airlock/door/ext_door,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/maintenance/aft_port)
+"hg" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/ofd_ops)
+"hh" = (
+/obj/machinery/door/firedoor/glass/talon,
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/obj/machinery/door/blast/regular/open{
+	dir = 2;
+	id = "talon_bridge_shields"
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/bridge)
+"hi" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/camera/network/talon,
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway/star)
+"hj" = (
+/turf/simulated/wall/rshull,
+/area/talon_v2/engineering/star_store)
+"hk" = (
+/obj/machinery/power/apc/talon{
+	dir = 1;
+	name = "north bump";
+	pixel_y = 28
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/talon_v2/crew_quarters/eng_room)
+"hp" = (
+/obj/structure/catwalk,
+/obj/structure/railing/grey{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/atmospherics)
+"hq" = (
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 4
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/space)
+"hr" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway)
+"hs" = (
+/turf/simulated/wall/shull,
+/area/talon_v2/crew_quarters/bar)
+"hu" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/map_helper/airlock/door/simple,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/door/airlock/angled_tgmc/wide/generic_steel{
+	density = 0;
+	icon_state = "door_open";
+	name = "Escape Pod Hatch"
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/shuttle/talonpod)
+"hw" = (
+/obj/machinery/atmospherics/pipe/simple/visible/blue,
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/atmospherics)
+"hz" = (
+/obj/machinery/power/pointdefense{
+	id_tag = "talon_pd"
+	},
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 10
+	},
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/space)
+"hA" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/fuel_port{
+	dir = 1;
+	pixel_x = 8;
+	pixel_y = -28
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/machinery/embedded_controller/radio/simple_docking_controller{
+	dir = 1;
+	frequency = 1380;
+	id_tag = "talonpod_docker";
+	pixel_x = -8;
+	pixel_y = -24;
+	req_one_access = list(301)
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/talonpod)
+"hD" = (
+/obj/machinery/atmospherics/portables_connector/aux{
+	dir = 4
+	},
+/obj/machinery/light/small,
+/obj/effect/floor_decal/industrial/outline,
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/machinery/alarm/talon{
+	dir = 1;
+	pixel_y = -25
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/talonboat)
+"hG" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/industrial/warning,
+/obj/structure/handrail{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/maintenance/wing_starboard)
+"hH" = (
+/obj/structure/bed/chair/bay/chair{
+	dir = 1
+	},
+/obj/machinery/light,
+/obj/machinery/alarm/talon{
+	dir = 1;
+	pixel_y = -25
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/talonboat)
+"hK" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/catwalk,
+/obj/machinery/alarm/talon{
+	dir = 4;
+	pixel_x = -22
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/aft_starboard)
+"hL" = (
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/aft_starboard)
+"hM" = (
+/obj/effect/map_helper/airlock/sensor/chamber_sensor,
+/obj/machinery/airlock_sensor{
+	dir = 1;
+	pixel_y = -28;
+	req_one_access = list(301)
+	},
+/obj/structure/handrail{
+	dir = 1
+	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/aux{
+	dir = 1
+	},
+/obj/effect/map_helper/airlock/atmos/chamber_pump,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/ofd_ops)
+"hO" = (
+/obj/structure/sign/directions/bridge{
+	dir = 1;
+	pixel_x = -32
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway/fore)
+"hP" = (
+/obj/structure/handrail{
+	dir = 1
+	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/aux{
+	dir = 1
+	},
+/obj/effect/map_helper/airlock/atmos/chamber_pump,
+/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
+	dir = 1;
+	id_tag = "talon_ofd";
+	pixel_y = -30;
+	req_one_access = list(301)
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/ofd_ops)
+"hQ" = (
+/obj/machinery/door/firedoor/glass/talon,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/airlock/glass_security{
+	name = "Talon Armory";
+	req_one_access = list(301)
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/armory)
+"hT" = (
+/obj/machinery/door/firedoor/glass/talon,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/map_helper/airlock/door/simple,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/door/airlock/multi_tile/glass{
+	dir = 1;
+	name = "Escape Pod";
+	req_one_access = list(301)
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/central_hallway/fore)
+"hW" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/catwalk,
+/obj/machinery/alarm/talon{
+	dir = 8;
+	pixel_x = 22
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/aft_port)
+"hY" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/hangar)
+"ia" = (
+/obj/machinery/vending/dinnerware{
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/talon_v2/crew_quarters/bar)
+"ib" = (
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/aft_port)
+"ie" = (
+/obj/structure/hull_corner/long_horiz{
+	dir = 5
+	},
+/turf/space,
+/area/space)
+"ig" = (
+/obj/machinery/door/firedoor/glass/talon,
+/obj/machinery/door/airlock/engineering{
+	name = "Talon Engineering";
+	req_one_access = list(301)
+	},
+/obj/structure/sign/warning/nosmoking_1{
+	pixel_x = -26
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering)
+"ii" = (
+/obj/machinery/vending/engivend{
+	products = list(/obj/item/device/geiger = 4, /obj/item/clothing/glasses/meson = 2, /obj/item/device/multitool = 4, /obj/item/weapon/cell/high = 10, /obj/item/weapon/airlock_electronics = 10, /obj/item/weapon/module/power_control = 10, /obj/item/weapon/circuitboard/airalarm = 10, /obj/item/weapon/circuitboard/firealarm = 10, /obj/item/weapon/circuitboard/status_display = 2, /obj/item/weapon/circuitboard/ai_status_display = 2, /obj/item/weapon/circuitboard/newscaster = 2, /obj/item/weapon/circuitboard/holopad = 2, /obj/item/weapon/circuitboard/intercom = 4, /obj/item/weapon/circuitboard/security/telescreen/entertainment = 4, /obj/item/weapon/stock_parts/motor = 2, /obj/item/weapon/stock_parts/spring = 2, /obj/item/weapon/stock_parts/gear = 2, /obj/item/weapon/circuitboard/atm, /obj/item/weapon/circuitboard/guestpass, /obj/item/weapon/circuitboard/keycard_auth, /obj/item/weapon/circuitboard/photocopier, /obj/item/weapon/circuitboard/fax, /obj/item/weapon/circuitboard/request, /obj/item/weapon/circuitboard/microwave, /obj/item/weapon/circuitboard/washing, /obj/item/weapon/circuitboard/scanner_console, /obj/item/weapon/circuitboard/sleeper_console, /obj/item/weapon/circuitboard/body_scanner, /obj/item/weapon/circuitboard/sleeper, /obj/item/weapon/circuitboard/dna_analyzer, /obj/item/weapon/circuitboard/partslathe);
+	req_access = list(301);
+	req_log_access = 301
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/engineering/star_store)
+"ik" = (
+/obj/machinery/door/firedoor/glass/talon,
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/ofd_ops)
+"il" = (
+/obj/structure/ship_munition/disperser_charge/emp,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor/reinforced,
+/area/talon_v2/ofd_ops)
+"im" = (
+/obj/structure/railing/grey{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/bridge)
+"in" = (
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/star_store)
+"io" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering)
+"iq" = (
+/obj/machinery/mineral/input,
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "talonrefinery"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/refining)
+"ir" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/aux,
+/obj/machinery/door/firedoor/glass/talon,
+/obj/machinery/door/airlock/maintenance/common,
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/wing_port)
+"is" = (
+/obj/structure/catwalk,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/aft_starboard)
+"it" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/aft_port)
+"iy" = (
+/obj/structure/catwalk,
+/obj/structure/trash_pile,
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/aft_port)
+"iz" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/light_switch{
+	dir = 4;
+	pixel_x = -26;
+	pixel_y = -25
+	},
+/turf/simulated/floor/wood,
+/area/talon_v2/crew_quarters/bar)
+"iB" = (
+/obj/structure/hull_corner{
+	dir = 4
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/talon_v2/ofd_ops)
+"iC" = (
+/obj/structure/table/rack/shelf/steel,
+/obj/random/maintenance/engineering,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/port_store)
+"iD" = (
+/obj/effect/map_helper/airlock/sensor/int_sensor,
+/obj/machinery/atmospherics/pipe/simple/hidden/aux{
+	dir = 10
+	},
+/obj/machinery/airlock_sensor{
+	dir = 8;
+	pixel_x = 28;
+	req_one_access = list(301)
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/aft_port)
+"iE" = (
+/obj/structure/catwalk,
+/obj/structure/handrail{
+	dir = 4
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/talon_v2/maintenance/fore_starboard)
+"iF" = (
+/obj/structure/catwalk,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/talon_v2/maintenance/fore_port)
+"iH" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/outline/red,
+/obj/machinery/portable_atmospherics/canister/empty/phoron,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/star_store)
+"iI" = (
+/obj/structure/table/steel,
+/obj/structure/closet/autolok_wall{
+	dir = 1;
+	pixel_y = -32
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/talonboat)
+"iJ" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/aux{
+	dir = 1
+	},
+/obj/effect/map_helper/airlock/atmos/chamber_pump,
+/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
+	dir = 1;
+	id_tag = "talon_port_fore";
+	pixel_y = -30;
+	req_one_access = list(301)
+	},
+/obj/structure/handrail{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/maintenance/fore_port)
+"iK" = (
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/aft_starboard)
+"iL" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/aux{
+	dir = 1
+	},
+/obj/effect/map_helper/airlock/atmos/chamber_pump,
+/obj/structure/handrail{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/maintenance/fore_port)
+"iM" = (
+/obj/machinery/power/pointdefense{
+	id_tag = "talon_pd"
+	},
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 5
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/space)
+"iN" = (
+/obj/structure/table/woodentable,
+/obj/item/modular_computer/laptop/preset/custom_loadout/standard/talon/engineer,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/turf/simulated/floor/carpet,
+/area/talon_v2/crew_quarters/eng_room)
+"iO" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/aux,
+/obj/machinery/camera/network/talon{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/central_hallway/fore)
+"iP" = (
+/obj/machinery/door/firedoor/glass/talon,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/glass_security{
+	name = "O.F.D. Ops";
+	req_one_access = list(301)
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/ofd_ops)
+"iQ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/aux{
+	dir = 5
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/holoposter{
+	pixel_y = -32
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/central_hallway/fore)
+"iR" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/port)
+"iS" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/central_hallway/fore)
+"iU" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/maintenance/wing_starboard)
+"jg" = (
+/obj/effect/floor_decal/emblem/talon_big{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/central_hallway/fore)
+"jh" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/railing/grey,
+/obj/random/multiple/corp_crate/talon_cargo,
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/maintenance/wing_port)
+"jj" = (
+/obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/port_store)
+"jk" = (
+/obj/effect/map_helper/airlock/door/ext_door,
+/obj/machinery/door/airlock/glass_external{
+	req_one_access = list(301)
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/airlock_sensor{
+	pixel_y = 24;
+	req_one_access = list(301)
+	},
+/obj/effect/map_helper/airlock/sensor/ext_sensor,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/maintenance/wing_port)
+"jn" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/engineering/star_store)
+"jr" = (
+/obj/machinery/light/small,
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/fore_starboard)
+"ju" = (
+/obj/effect/floor_decal/emblem/talon_big{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/central_hallway/fore)
+"jv" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/central_hallway/fore)
+"jx" = (
+/obj/machinery/atmospherics/pipe/manifold/visible,
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/atmospherics)
+"jy" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/blast/regular{
+	dir = 4;
+	id = "talon_cargo_port";
+	name = "Cargo Loading Hatch"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/maintenance/wing_port)
+"jC" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/atmospherics)
+"jF" = (
+/obj/structure/table/bench/wooden,
+/turf/simulated/floor/wood,
+/area/talon_v2/crew_quarters/cap_room)
+"jG" = (
+/obj/machinery/atmospherics/pipe/manifold/visible/blue{
+	dir = 8
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/atmospherics)
+"jJ" = (
+/obj/machinery/atmospherics/pipe/manifold4w/visible/yellow,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/starboard)
+"jM" = (
+/obj/machinery/door/firedoor/glass/talon,
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/hangar)
+"jN" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/aux,
+/obj/machinery/camera/network/talon{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/central_hallway/fore)
+"jO" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/hangar)
+"jQ" = (
+/turf/simulated/wall/shull{
+	can_open = 1
+	},
+/area/talon_v2/gen_store)
+"jS" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/aux{
+	dir = 1
+	},
+/obj/effect/map_helper/airlock/atmos/chamber_pump,
+/obj/structure/handrail{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/maintenance/fore_starboard)
+"jY" = (
+/obj/structure/ore_box,
+/obj/structure/railing/grey,
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/refining)
+"kc" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 1;
+	pixel_y = -32
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway/star)
+"kd" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/aux{
+	dir = 1
+	},
+/obj/effect/map_helper/airlock/atmos/chamber_pump,
+/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
+	dir = 1;
+	id_tag = "talon_starboard_fore";
+	pixel_y = -30;
+	req_one_access = list(301)
+	},
+/obj/structure/handrail{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/maintenance/fore_starboard)
+"ke" = (
+/obj/structure/catwalk,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/talon_v2/maintenance/fore_starboard)
+"kf" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/maintenance/wing_port)
+"kg" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/structure/bed/chair/bay/chair{
+	dir = 8
+	},
+/turf/simulated/floor/carpet,
+/area/talon_v2/crew_quarters/pilot_room)
+"kh" = (
+/obj/structure/hull_corner/long_horiz{
+	dir = 9
+	},
+/turf/space,
+/area/space)
+"ki" = (
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 6
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/port)
+"kj" = (
+/obj/machinery/door/airlock/glass_external{
+	req_one_access = list(301)
+	},
+/obj/effect/map_helper/airlock/door/int_door,
+/obj/machinery/atmospherics/pipe/simple/hidden/aux{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/maintenance/fore_starboard)
+"kk" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/reagent_dispensers/fueltank/high,
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/gen_store)
+"kl" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/central_hallway/fore)
+"kn" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway/fore)
+"kt" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/visible{
+	dir = 8
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/atmospherics)
+"kv" = (
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/aux,
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/fuel,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/effect/catwalk_plated/dark,
+/turf/simulated/floor/plating,
+/area/shuttle/talonboat)
+"kw" = (
+/obj/structure/table/marble,
+/obj/machinery/chemical_dispenser/bar_alc/full{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/black/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/talon_v2/crew_quarters/bar)
+"kx" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/talon_v2/engineering/port_store)
-"FK" = (
+"kz" = (
+/obj/effect/floor_decal/industrial/outline/red,
+/obj/machinery/atmospherics/portables_connector{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/canister/phoron/engine_setup,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/port)
+"kC" = (
+/obj/structure/bed/chair/bay/shuttle{
+	dir = 4
+	},
+/obj/machinery/light,
+/obj/structure/closet/walllocker_double/survival/south,
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/talonpod)
+"kD" = (
+/obj/machinery/vending/food{
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/talon_v2/crew_quarters/bar)
+"kG" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/wood,
+/area/talon_v2/crew_quarters/bar)
+"kH" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 4;
+	icon_state = "pipe-j2"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway/fore)
+"kI" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/effect/catwalk_plated/dark,
+/turf/simulated/floor/plating,
+/area/shuttle/talonboat)
+"kJ" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/central_hallway/fore)
+"kM" = (
+/obj/machinery/light/small,
+/obj/structure/bed/chair/bay/shuttle{
+	dir = 1
+	},
+/obj/machinery/power/apc/talon/hyper{
+	pixel_y = -24
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/talonboat)
+"kP" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/structure/railing/grey,
+/obj/structure/railing/grey{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering)
+"kQ" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/light/small,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/atmospherics)
+"kR" = (
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/fore_port)
+"kS" = (
+/obj/effect/floor_decal/industrial/outline/red,
+/obj/machinery/atmospherics/portables_connector{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/canister/phoron/engine_setup,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/starboard)
+"kV" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/light/small,
+/obj/machinery/atmospherics/pipe/simple/visible/yellow,
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/starboard)
+"kW" = (
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/fore_starboard)
+"kX" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/wall/rshull,
+/area/talon_v2/maintenance/fore_port)
+"kZ" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/fore_port)
+"lc" = (
+/obj/machinery/door/firedoor/glass/talon,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/door/airlock/maintenance/engi{
+	name = "Engine Crawlway Access";
+	req_one_access = list(301)
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/starboard)
+"le" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/closet/emergsuit_wall{
+	dir = 1;
+	pixel_y = -32
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/central_hallway/fore)
+"lf" = (
+/obj/effect/floor_decal/industrial/outline/red,
+/obj/machinery/portable_atmospherics/canister/empty/phoron,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/port_store)
+"lk" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/closet/walllocker_double/hydrant/east,
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/maintenance/wing_port)
+"ll" = (
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "talontrash"
+	},
+/obj/machinery/door/blast/regular{
+	dir = 4;
+	id = "talontrashblast"
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/starboard)
+"lm" = (
+/obj/machinery/computer/ship/helm{
+	req_one_access = list(301)
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/talonboat)
+"lq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -9546,63 +3595,1456 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/talon_v2/central_hallway)
-"FM" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
+"lr" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/crew_quarters/restrooms)
-"FN" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
+/area/talon_v2/central_hallway/fore)
+"ls" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
 /obj/machinery/camera/network/talon{
 	dir = 1
 	},
-/obj/structure/vehiclecage/quadbike,
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/maintenance/wing_port)
-"FO" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/bridge)
+"lv" = (
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway/star)
+"lw" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering)
+"lx" = (
+/obj/machinery/light,
+/obj/structure/extinguisher_cabinet{
+	dir = 1;
+	pixel_y = -32
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/central_hallway/fore)
+"ly" = (
+/obj/machinery/power/pointdefense{
+	id_tag = "talon_pd"
+	},
+/obj/structure/cable/green,
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 10
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/space)
+"lA" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/refining)
+"lB" = (
+/obj/machinery/light,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 1;
+	pixel_y = -32
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/central_hallway/fore)
+"lC" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/flora/pottedplant/mysterious,
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/central_hallway/fore)
+"lD" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/holoposter{
+	pixel_y = -32
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/central_hallway/fore)
+"lF" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/fore_starboard)
+"lG" = (
+/obj/structure/sign/warning/airlock{
+	pixel_x = -31
+	},
+/obj/effect/floor_decal/industrial/warning,
+/obj/structure/handrail{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/maintenance/wing_starboard)
+"lI" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/atm{
+	pixel_y = 31
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/central_hallway/fore)
+"lJ" = (
+/obj/machinery/door/firedoor/glass/talon,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/airlock/glass_centcom{
+	name = "Talon Storage";
+	req_one_access = list(301)
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/secure_storage)
+"lK" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/door/blast/regular/open{
+	dir = 4;
+	id = "talon_anomalystorage"
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/anomaly_storage)
+"lM" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 4
+	},
+/obj/structure/railing/grey{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/atmospherics)
+"lN" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/port_store)
+"lQ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 4
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/port)
+"lR" = (
+/obj/machinery/door/firedoor/glass/talon,
+/obj/machinery/door/airlock/medical{
+	req_one_access = list(301)
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/white,
+/area/talon_v2/medical)
+"lS" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/wall/rshull,
+/area/talon_v2/maintenance/fore_starboard)
+"lT" = (
+/obj/structure/hull_corner,
+/turf/space,
+/area/space)
+"lU" = (
+/turf/simulated/wall/shull,
+/area/talon_v2/crew_quarters/pilot_room)
+"lX" = (
+/obj/machinery/door/firedoor/glass/talon,
+/obj/machinery/door/airlock/maintenance/common,
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/fore_port)
+"lY" = (
+/obj/structure/barricade,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/star_store)
+"lZ" = (
+/obj/machinery/door/firedoor/glass/talon,
+/obj/machinery/door/airlock/glass,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway/fore)
+"ma" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/talon_v2/crew_quarters/sec_room)
+"mb" = (
+/obj/effect/map_helper/airlock/sensor/int_sensor,
+/obj/machinery/airlock_sensor{
+	dir = 8;
+	pixel_x = 28;
+	pixel_y = -28;
+	req_one_access = list(301)
+	},
+/obj/structure/sign/warning/airlock{
+	pixel_y = 32
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/aux{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/maintenance/fore_starboard)
+"mc" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway/fore)
+"md" = (
+/obj/machinery/atmospherics/pipe/manifold/visible/red{
+	dir = 1
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/atmospherics)
+"mg" = (
+/obj/structure/mopbucket,
+/obj/item/weapon/mop,
+/obj/item/weapon/reagent_containers/glass/bucket,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/engineering/star_store)
+"mk" = (
+/obj/machinery/door/firedoor/glass/talon,
+/obj/machinery/door/airlock/glass,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway/fore)
+"ml" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/random/multiple/corp_crate/talon_cargo,
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/maintenance/wing_starboard)
+"mm" = (
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/aft_starboard)
+"mo" = (
+/obj/machinery/door/blast/regular{
+	dir = 4;
+	id = "talon_cargo_port";
+	name = "Cargo Loading Hatch"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/maintenance/wing_port)
+"mq" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
 	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/aft_starboard)
+"mr" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/talon_v2/crew_quarters/eng_room)
+"mu" = (
+/obj/structure/table/rack/shelf/steel,
+/obj/random/maintenance/cargo,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/random/maintenance/cargo,
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/gen_store)
+"mw" = (
+/turf/simulated/wall/shull,
+/area/talon_v2/maintenance/wing_starboard)
+"mx" = (
+/obj/structure/table/woodentable,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/item/modular_computer/laptop/preset/custom_loadout/standard/talon/security,
+/obj/machinery/camera/network/talon{
+	dir = 1
+	},
+/turf/simulated/floor/carpet,
+/area/talon_v2/crew_quarters/sec_room)
+"mE" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/talon_v2/medical)
+"mG" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/maintenance/wing_starboard)
+"mH" = (
+/obj/machinery/door/firedoor/glass/talon,
+/obj/machinery/door/airlock/maintenance/common,
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/fore_starboard)
+"mI" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/fore_port)
+"mN" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/structure/catwalk,
+/obj/structure/extinguisher_cabinet{
+	dir = 1;
+	pixel_y = -32
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/port)
+"mO" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/camera/network/talon{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway)
+"mS" = (
+/turf/simulated/floor/wood,
+/area/talon_v2/crew_quarters/sec_room)
+"mT" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/closet/crate/secure/phoron{
+	req_one_access = list(301)
+	},
+/obj/item/weapon/tank/phoron/pressurized{
+	pixel_x = -3
+	},
+/obj/item/weapon/tank/phoron/pressurized{
+	pixel_x = 3
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/talonboat)
+"mV" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/structure/handrail{
+	dir = 8
+	},
+/obj/structure/closet/emergsuit_wall{
+	dir = 4;
+	pixel_x = 32
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/maintenance/wing_starboard)
+"mX" = (
+/obj/machinery/light/small,
+/obj/machinery/atmospherics/binary/pump/on{
+	dir = 8;
+	name = "Waste Compresser"
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/atmospherics)
+"mZ" = (
+/obj/machinery/vending/snack,
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/central_hallway/fore)
+"na" = (
+/obj/machinery/atmospherics/pipe/simple/visible/yellow,
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/starboard)
+"nb" = (
+/obj/machinery/door/firedoor/glass/talon,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/airlock/medical{
+	id_tag = "talon_meddoor";
+	name = "Doctor's Cabin";
+	req_one_access = list(301)
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/crew_quarters/med_room)
+"ne" = (
+/obj/structure/closet/secure_closet/personal/cabinet{
+	locked = 0
+	},
+/turf/simulated/floor/wood,
+/area/talon_v2/crew_quarters/sec_room)
+"ng" = (
+/obj/structure/closet/secure_closet/talon_guard,
+/obj/item/device/radio/off{
+	channels = list("Talon" = 1)
+	},
+/obj/item/weapon/storage/box/nifsofts_security,
+/turf/simulated/floor/wood,
+/area/talon_v2/crew_quarters/sec_room)
+"nh" = (
+/obj/effect/floor_decal/industrial/outline/red,
+/obj/machinery/atmospherics/portables_connector{
+	dir = 4
+	},
+/obj/structure/railing/grey,
+/obj/machinery/portable_atmospherics/canister/phoron/engine_setup,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/starboard)
+"nk" = (
+/obj/machinery/suit_cycler/vintage/tguard,
+/turf/simulated/floor/wood,
+/area/talon_v2/crew_quarters/sec_room)
+"nl" = (
 /obj/structure/cable/green{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
 	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/maintenance/wing_port)
+"nn" = (
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
+/obj/effect/catwalk_plated,
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/central_hallway)
+"no" = (
+/obj/machinery/suit_cycler/vintage/tmedic,
+/turf/simulated/floor/wood,
+/area/talon_v2/crew_quarters/med_room)
+"np" = (
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
-/area/talon_v2/maintenance/aft_port)
-"FR" = (
+/area/talon_v2/engineering/port_store)
+"nq" = (
+/obj/structure/closet/secure_closet/talon_doctor,
+/obj/item/device/radio/off{
+	channels = list("Talon" = 1)
+	},
+/obj/item/weapon/storage/box/nifsofts_medical,
+/turf/simulated/floor/wood,
+/area/talon_v2/crew_quarters/med_room)
+"ns" = (
+/obj/effect/floor_decal/emblem/talon_big/center,
+/obj/structure/cable/green,
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/central_hallway/fore)
+"nt" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/structure/table/rack/steel,
+/obj/random/maintenance/engineering,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/port_store)
+"nw" = (
+/obj/structure/closet/secure_closet/personal/cabinet{
+	locked = 0
+	},
+/turf/simulated/floor/wood,
+/area/talon_v2/crew_quarters/med_room)
+"nz" = (
+/obj/effect/map_helper/airlock/sensor/chamber_sensor,
+/obj/machinery/atmospherics/pipe/manifold/hidden/aux{
+	dir = 1
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/airlock_sensor{
+	pixel_y = 28;
+	req_one_access = list(301)
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/maintenance/fore_port)
+"nB" = (
+/obj/structure/closet/emergsuit_wall{
+	pixel_y = 32
+	},
+/turf/simulated/floor/wood,
+/area/talon_v2/crew_quarters/med_room)
+"nC" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/fore_starboard)
+"nD" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/closet/emergsuit_wall{
+	pixel_y = 32
+	},
+/turf/simulated/floor/wood,
+/area/talon_v2/crew_quarters/eng_room)
+"nE" = (
+/obj/machinery/power/apc/talon{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -28
+	},
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/wood,
+/area/talon_v2/crew_quarters/sec_room)
+"nH" = (
+/obj/machinery/power/apc/talon{
+	dir = 1;
+	name = "north bump";
+	pixel_y = 28
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/structure/table/standard,
+/obj/machinery/recharger,
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/central_hallway/fore)
+"nI" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering)
+"nJ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/port)
+"nK" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/closet/emergsuit_wall{
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway/port)
+"nL" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/machinery/disposal/wall{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/talon_v2/crew_quarters/pilot_room)
+"nM" = (
+/obj/machinery/power/apc/talon{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/wood,
+/area/talon_v2/crew_quarters/pilot_room)
+"nN" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/talon_v2/crew_quarters/med_room)
+"nP" = (
+/obj/machinery/atmospherics/portables_connector,
+/obj/effect/floor_decal/industrial/outline,
+/obj/machinery/portable_atmospherics/powered/pump/filled,
+/obj/structure/railing/grey{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/atmospherics)
+"nV" = (
+/obj/machinery/power/apc/talon{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/wood,
+/area/talon_v2/crew_quarters/med_room)
+"nW" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/wood,
+/area/talon_v2/crew_quarters/sec_room)
+"nY" = (
+/obj/machinery/door/blast/regular/open{
+	id = "talon_boat_east"
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/aux{
+	dir = 4
+	},
+/obj/machinery/airlock_sensor/airlock_exterior/shuttle{
+	dir = 4;
+	pixel_x = 11;
+	pixel_y = 24;
+	req_one_access = list(301)
+	},
+/obj/machinery/button/remote/airlock{
+	id = "tal_shuttle_sb";
+	name = "Starboard Airlock Control";
+	pixel_x = -9;
+	pixel_y = 24;
+	specialfunctions = 4
+	},
+/obj/machinery/door/airlock/glass_external{
+	frequency = 1420;
+	id_tag = "tal_shuttle_sb";
+	req_one_access = list(301)
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/shuttle/talonboat)
+"od" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway)
+"oh" = (
+/obj/item/weapon/storage/dicecup/loaded{
+	pixel_x = 7;
+	pixel_y = 11
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/black/diagonal,
+/obj/structure/table/marble,
+/obj/item/weapon/deck/cards{
+	pixel_x = 3
+	},
+/turf/simulated/floor/tiled/white,
+/area/talon_v2/crew_quarters/bar)
+"ok" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/conveyor{
+	dir = 1;
+	id = "talonrefinery"
+	},
+/obj/machinery/mineral/output,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/refining)
+"ol" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/landmark/start{
+	name = "Talon Guard"
+	},
+/obj/machinery/button/remote/airlock{
+	dir = 8;
+	id = "talon_secdoor";
+	name = "Door Bolts";
+	pixel_x = 28;
+	specialfunctions = 4
+	},
+/turf/simulated/floor/carpet,
+/area/talon_v2/crew_quarters/sec_room)
+"on" = (
+/obj/effect/floor_decal/emblem/talon_big,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/central_hallway/fore)
+"oo" = (
+/obj/structure/closet/emergsuit_wall{
+	dir = 4;
+	pixel_x = 32
+	},
+/turf/simulated/floor/carpet,
+/area/talon_v2/crew_quarters/pilot_room)
+"op" = (
+/obj/machinery/button/remote/airlock{
+	dir = 8;
+	id = "talon_meddoor";
+	name = "Door Bolts";
+	pixel_x = -28;
+	specialfunctions = 4
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/landmark/start{
+	name = "Talon Doctor"
+	},
+/turf/simulated/floor/carpet,
+/area/talon_v2/crew_quarters/med_room)
+"oq" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/carpet,
+/area/talon_v2/crew_quarters/med_room)
+"or" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/refining)
+"ot" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/wood,
+/area/talon_v2/crew_quarters/med_room)
+"ov" = (
+/obj/machinery/alarm/talon{
+	dir = 4;
+	pixel_x = -22
+	},
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_x = 2;
+	pixel_y = -28
+	},
+/obj/structure/bed/pod,
+/obj/item/weapon/bedsheet/medical,
+/turf/simulated/floor/carpet,
+/area/talon_v2/crew_quarters/med_room)
+"ow" = (
+/obj/structure/disposalpipe/trunk,
+/obj/machinery/disposal,
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/central_hallway/fore)
+"oA" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/hangar)
+"oB" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/power/apc/talon{
+	dir = 1;
+	name = "north bump";
+	pixel_y = 28
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/structure/catwalk,
 /obj/structure/cable/green{
 	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/aft_port)
+"oE" = (
+/obj/structure/railing/grey{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/outline/red,
+/obj/machinery/portable_atmospherics/canister/empty/phoron,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/star_store)
+"oF" = (
+/obj/structure/table/standard,
+/obj/machinery/alarm/talon{
+	dir = 4;
+	pixel_x = -22
+	},
+/obj/item/device/radio/off{
+	channels = list("Talon" = 1)
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/crew_quarters/restrooms)
+"oN" = (
+/obj/machinery/alarm/talon{
+	dir = 1;
+	pixel_y = -25
+	},
+/obj/structure/table/standard,
+/obj/machinery/photocopier/faxmachine/talon,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/workroom)
+"oO" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/workroom)
+"oS" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 8;
+	pixel_x = 30
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway)
+"oV" = (
+/obj/structure/table/woodentable,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/item/weapon/paper/talon_doctor,
+/turf/simulated/floor/carpet,
+/area/talon_v2/crew_quarters/med_room)
+"oW" = (
+/obj/structure/sign/directions/medical{
+	pixel_y = -32
+	},
+/obj/machinery/camera/network/talon{
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/talon_v2/crew_quarters/med_room)
+"pa" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/structure/handrail{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 4;
+	pixel_x = -30
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/maintenance/wing_port)
+"pb" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/talon_v2/crew_quarters/cap_room)
+"pc" = (
+/obj/machinery/power/pointdefense{
+	id_tag = "talon_pd"
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 9
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/space)
+"pf" = (
+/obj/machinery/portable_atmospherics/canister/phoron/engine_setup,
+/obj/effect/floor_decal/industrial/outline/red,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/port)
+"pg" = (
+/obj/machinery/atmospherics/pipe/simple/visible,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/atmospherics)
+"pi" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/aux{
+	dir = 6
+	},
+/obj/machinery/airlock_sensor{
+	dir = 8;
+	pixel_x = 28;
+	pixel_y = 28;
+	req_one_access = list(301)
+	},
+/obj/effect/map_helper/airlock/sensor/int_sensor,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/maintenance/wing_starboard)
+"pk" = (
+/obj/effect/map_helper/airlock/door/int_door,
+/obj/machinery/atmospherics/pipe/simple/hidden/aux,
+/obj/machinery/door/airlock/glass_external{
+	req_one_access = list(301)
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/shuttle/talonboat)
+"pl" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/carpet,
+/area/talon_v2/crew_quarters/sec_room)
+"pn" = (
+/obj/machinery/door/firedoor/glass/talon,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/airlock/security{
+	id_tag = "talon_secdoor";
+	name = "Guard's Cabin";
+	req_one_access = list(301)
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/crew_quarters/sec_room)
+"pp" = (
+/turf/simulated/floor/carpet,
+/area/talon_v2/crew_quarters/pilot_room)
+"pq" = (
+/obj/effect/landmark/start{
+	name = "Talon Engineer"
+	},
+/turf/simulated/floor/carpet,
+/area/talon_v2/crew_quarters/eng_room)
+"pr" = (
+/obj/machinery/atmospherics/pipe/simple/visible/universal{
+	name = "Waste to Filter"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/atmospherics)
+"ps" = (
+/obj/structure/catwalk,
+/obj/machinery/alarm/talon{
+	dir = 4;
+	pixel_x = -22
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/aft_starboard)
+"pt" = (
+/obj/structure/catwalk,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering)
+"pv" = (
+/turf/simulated/floor/wood,
+/area/talon_v2/crew_quarters/eng_room)
+"pw" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/holoposter{
+	dir = 4;
+	pixel_x = 32
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway)
+"px" = (
+/obj/machinery/camera/network/talon{
 	dir = 1
 	},
-/obj/effect/catwalk_plated,
-/turf/simulated/floor/plating,
+/obj/structure/safe/floor{
+	name = "smuggling compartment"
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/carpet/blucarpet,
+/area/talon_v2/crew_quarters/cap_room)
+"pz" = (
+/obj/effect/floor_decal/emblem/talon,
+/turf/simulated/floor/reinforced/airless,
+/area/space)
+"pA" = (
+/obj/machinery/recharge_station,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/engineering)
+"pB" = (
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/crew_quarters/restrooms)
+"pC" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway)
+"pE" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/camera/network/talon{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway)
+"pG" = (
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway)
+"pH" = (
+/obj/machinery/alarm/talon{
+	dir = 8;
+	pixel_x = 22
+	},
+/obj/structure/bed/pod,
+/obj/item/weapon/bedsheet/blue,
+/obj/machinery/computer/ship/navigation/telescreen{
+	pixel_y = -32
+	},
+/obj/machinery/light,
+/turf/simulated/floor/carpet,
+/area/talon_v2/crew_quarters/pilot_room)
+"pK" = (
+/obj/effect/map_helper/airlock/sensor/chamber_sensor,
+/obj/machinery/atmospherics/pipe/manifold/hidden/aux{
+	dir = 1
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/airlock_sensor{
+	pixel_y = 28;
+	req_one_access = list(301)
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/maintenance/fore_starboard)
+"pL" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
 /area/talon_v2/central_hallway/fore)
-"FS" = (
+"pM" = (
+/turf/space,
+/area/talon_v2/engineering/starboard)
+"pN" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/wood,
+/area/talon_v2/crew_quarters/pilot_room)
+"pR" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/atmospherics)
+"pS" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/machinery/disposal/wall{
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/talon_v2/crew_quarters/eng_room)
+"pU" = (
+/obj/structure/table/standard,
+/obj/item/weapon/storage/toolbox/mechanical,
+/obj/item/weapon/storage/box/mousetraps,
+/obj/item/weapon/storage/box/lights/mixed,
+/obj/item/weapon/reagent_containers/spray/cleaner,
+/obj/item/weapon/reagent_containers/glass/rag,
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_x = 2;
+	pixel_y = -28
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/engineering/star_store)
+"pV" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/starboard)
+"pY" = (
+/obj/machinery/light/small,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/atmospherics)
+"pZ" = (
+/obj/structure/closet/crate/engineering,
+/obj/fiftyspawner/cardboard,
+/obj/fiftyspawner/floor,
+/obj/fiftyspawner/glass,
+/obj/fiftyspawner/plastic,
+/obj/fiftyspawner/steel,
+/obj/fiftyspawner/wood,
+/obj/item/stack/material/plasteel{
+	amount = 30
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/port_store)
+"qa" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/catwalk,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/aft_port)
+"qb" = (
+/obj/machinery/door/firedoor/glass/talon,
+/obj/machinery/door/airlock/glass,
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway/fore)
+"qe" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/hangar)
+"qf" = (
+/obj/structure/table/rack/steel,
+/obj/random/maintenance/engineering,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/port_store)
+"qg" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 5
 	},
@@ -9617,118 +5059,270 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/talon_v2/engineering/atmospherics)
-"FT" = (
-/obj/machinery/door/firedoor/glass/talon,
-/obj/machinery/door/airlock/engineering{
-	name = "Talon Engineering";
-	req_one_access = list(301)
+"qi" = (
+/obj/machinery/firealarm{
+	layer = 3.3;
+	pixel_y = 26
 	},
-/obj/structure/sign/warning/nosmoking_1{
-	pixel_x = -26
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering)
-"FU" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/structure/catwalk,
+/obj/machinery/camera/network/talon,
 /turf/simulated/floor/plating,
-/area/talon_v2/engineering/star_store)
-"FX" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/closet/emergsuit_wall{
-	dir = 8;
-	pixel_x = -32
+/area/talon_v2/engineering/port_store)
+"qk" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/bed/chair/bay/chair,
+/obj/machinery/camera/network/talon,
+/obj/machinery/button/remote/blast_door{
+	id = "talon_brig2";
+	name = "Cell 2 Shutters";
+	pixel_x = 7;
+	pixel_y = 28;
+	req_one_access = list(301)
+	},
+/obj/machinery/button/remote/blast_door{
+	id = "talon_brig1";
+	name = "Cell 1 Shutters";
+	pixel_x = -8;
+	pixel_y = 28;
+	req_one_access = list(301)
 	},
 /turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/brig)
+"qm" = (
+/obj/machinery/vending/security{
+	req_access = list(301);
+	req_log_access = 301
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/brig)
+"qo" = (
+/obj/machinery/cryopod/talon{
+	dir = 4
+	},
+/obj/machinery/camera/network/talon,
+/turf/simulated/floor/tiled/techfloor,
 /area/talon_v2/central_hallway)
-"FY" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+"qq" = (
+/obj/effect/map_helper/airlock/sensor/int_sensor,
+/obj/machinery/airlock_sensor{
+	dir = 1;
+	pixel_y = -23;
+	req_one_access = list(301)
+	},
+/obj/structure/bed/chair/bay/shuttle{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/talonboat)
+"qr" = (
+/turf/simulated/wall/shull,
+/area/talon_v2/crew_quarters/med_room)
+"qs" = (
+/obj/effect/landmark/talon,
+/obj/structure/handrail,
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/central_hallway)
+"qt" = (
+/obj/effect/map_helper/airlock/atmos/chamber_pump,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/aux{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/shuttle/talonboat)
+"qu" = (
+/obj/structure/railing/grey,
+/obj/effect/floor_decal/industrial/outline/red,
+/obj/machinery/portable_atmospherics/canister/empty/phoron,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/port_store)
+"qv" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/armory)
+"qw" = (
+/obj/structure/railing/grey,
+/obj/machinery/atmospherics/pipe/manifold/visible/blue,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/atmospherics)
+"qx" = (
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/talon_v2/engineering/port)
-"FZ" = (
-/obj/structure/catwalk,
-/obj/structure/handrail{
-	dir = 8
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/talon_v2/maintenance/wing_port)
-"Ga" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/extinguisher_cabinet{
-	dir = 4;
-	pixel_x = -30
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway)
-"Gb" = (
+"qy" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/door/blast/regular{
+	dir = 4;
+	id = "talon_cargo_star";
+	name = "Cargo Loading Hatch"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/maintenance/wing_starboard)
+"qz" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/aux{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/ofd_ops)
+"qA" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/refining)
+"qC" = (
 /obj/machinery/door/firedoor/glass/talon,
-/obj/machinery/door/airlock/engineering{
-	name = "Talon Starboard Engines & Trash Management";
+/obj/machinery/door/airlock/engineeringatmos{
+	name = "Talon Atmospherics";
 	req_one_access = list(301)
 	},
-/obj/structure/sign/warning/nosmoking_1{
-	pixel_x = 26
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
-/area/talon_v2/engineering/starboard)
-"Ge" = (
+/area/talon_v2/engineering/port_store)
+"qD" = (
+/obj/machinery/button/remote/airlock{
+	dir = 8;
+	id = "talon_engdoor";
+	name = "Door Bolts";
+	pixel_x = -28;
+	specialfunctions = 4
+	},
+/obj/item/weapon/bedsheet/orange,
+/obj/structure/bed/pod,
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_y = -26
+	},
+/turf/simulated/floor/carpet,
+/area/talon_v2/crew_quarters/eng_room)
+"qE" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/aux{
+	dir = 5
+	},
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc/talon{
+	name = "south bump";
+	pixel_y = -24
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/fore_port)
+"qG" = (
+/obj/structure/hull_corner,
+/turf/simulated/floor/reinforced/airless,
+/area/talon_v2/ofd_ops)
+"qH" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/camera/network/talon{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/talon_v2/medical)
+"qI" = (
+/obj/structure/bed/chair/bay/chair,
+/obj/machinery/alarm/talon{
+	pixel_y = 24
+	},
+/turf/simulated/floor/wood,
+/area/talon_v2/crew_quarters/bar)
+"qJ" = (
+/obj/structure/reagent_dispensers/watertank/high,
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/gen_store)
+"qK" = (
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/workroom)
+"qL" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/aux{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/talonboat)
+"qM" = (
 /obj/structure/closet/secure_closet/personal/cabinet{
 	locked = 0
 	},
 /turf/simulated/floor/wood,
-/area/talon_v2/crew_quarters/sec_room)
-"Gg" = (
-/obj/machinery/vending/sovietsoda,
+/area/talon_v2/crew_quarters/eng_room)
+"qO" = (
+/obj/machinery/cryopod/robot/talon,
 /turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/central_hallway/fore)
-"Gh" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 6
+/area/talon_v2/central_hallway)
+"qP" = (
+/obj/effect/landmark/talon,
+/obj/structure/handrail,
+/obj/machinery/computer/cryopod{
+	pixel_y = 32
 	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/atmospherics)
-"Gj" = (
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/central_hallway)
+"qQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/refining)
+"qU" = (
+/obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/camera/network/talon{
-	dir = 1
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway/fore)
+"qV" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -9736,75 +5330,338 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway)
-"Gl" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/obj/effect/catwalk_plated,
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/obj/structure/sign/directions/engineering/atmospherics{
-	pixel_x = -32
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/central_hallway)
-"Gm" = (
-/obj/machinery/conveyor{
-	dir = 8;
-	id = "talonrefinery"
-	},
-/obj/structure/sign/warning/moving_parts{
-	pixel_y = 32
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/refining)
-"Gn" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/table/rack/shelf/steel,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/port_store)
-"Go" = (
-/obj/effect/map_helper/airlock/atmos/chamber_pump,
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/aux,
-/obj/machinery/airlock_sensor{
-	pixel_y = 28;
-	req_one_access = list(301)
-	},
-/obj/effect/map_helper/airlock/sensor/chamber_sensor,
-/obj/structure/handrail,
-/turf/simulated/floor/tiled/techfloor/grid,
 /area/talon_v2/maintenance/wing_port)
-"Gp" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+"qW" = (
+/obj/machinery/atmospherics/pipe/simple/visible/red{
+	dir = 10
+	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
-/area/talon_v2/engineering/starboard)
-"Gq" = (
-/obj/structure/sink{
-	pixel_y = 22
-	},
-/obj/structure/mirror{
-	pixel_y = 32
-	},
-/obj/machinery/button/remote/airlock{
-	dir = 1;
-	id = "talon_charger";
-	name = "Door Bolts";
-	pixel_y = -28;
-	specialfunctions = 4
+/area/talon_v2/engineering/atmospherics)
+"rc" = (
+/obj/machinery/recharge_station,
+/obj/machinery/light/small{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/talon_v2/crew_quarters/restrooms)
-"Gs" = (
+"rg" = (
+/obj/item/modular_computer/console/preset/talon{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/brig)
+"rh" = (
+/obj/structure/closet/emergsuit_wall{
+	dir = 1;
+	pixel_y = -32
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway/star)
+"ri" = (
+/obj/structure/table/standard,
+/obj/item/weapon/paper_bin,
+/obj/item/weapon/pen,
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/brig)
+"rj" = (
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/brig)
+"rk" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 1;
+	pixel_y = -32
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/hangar)
+"rl" = (
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 9
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/starboard)
+"rm" = (
+/obj/structure/sign/warning/airlock{
+	pixel_x = -31
+	},
+/obj/structure/handrail,
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/maintenance/wing_port)
+"rn" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/outline/red,
+/obj/machinery/portable_atmospherics/canister/empty/phoron,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/port_store)
+"rq" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/brig)
+"rt" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/glass/talon,
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/turf/simulated/floor/plating,
+/area/talon_v2/central_hallway/fore)
+"ru" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/obj/structure/sign/department/medbay{
+	name = "DOCTOR'S QUARTERS";
+	pixel_x = 32
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway/fore)
+"rw" = (
+/obj/machinery/door/firedoor/glass/talon,
+/obj/machinery/door/airlock/glass{
+	name = "Flight Control"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/central_hallway)
+"rx" = (
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/fore_starboard)
+"rz" = (
+/obj/machinery/atmospherics/pipe/simple/visible/red{
+	dir = 6
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/atmospherics)
+"rG" = (
+/obj/structure/table/standard,
+/obj/machinery/reagentgrinder,
+/turf/simulated/floor/tiled/white,
+/area/talon_v2/medical)
+"rI" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/machinery/light_switch{
+	dir = 4;
+	pixel_x = -24
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/hangar)
+"rJ" = (
+/obj/structure/closet/crate/hydroponics,
+/obj/item/stack/material/algae,
+/obj/item/stack/material/algae,
+/obj/item/stack/material/algae,
+/obj/item/stack/material/algae,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/atmospherics)
+"rK" = (
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/central_hallway)
+"rL" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/aft_starboard)
+"rP" = (
+/obj/structure/closet/emergsuit_wall{
+	dir = 4;
+	pixel_x = 32
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/port_store)
+"rQ" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/toilet,
+/turf/simulated/floor/tiled/white,
+/area/talon_v2/crew_quarters/restrooms)
+"rR" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/closet/emergsuit_wall{
+	dir = 8;
+	pixel_x = -32
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/maintenance/wing_starboard)
+"rS" = (
+/obj/machinery/door/window/brigdoor/eastleft{
+	dir = 1;
+	req_access = list(301)
+	},
+/obj/machinery/button/remote/blast_door{
+	dir = 1;
+	id = "talontrashblast";
+	pixel_y = -28
+	},
+/obj/machinery/conveyor_switch/oneway{
+	id = "talontrash"
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/starboard)
+"rT" = (
+/obj/structure/sign/directions/engineering{
+	pixel_x = 32;
+	pixel_y = 3
+	},
+/obj/structure/sign/directions/medical{
+	pixel_x = 32;
+	pixel_y = -3
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway)
+"rU" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/machinery/disposal/wall{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/brig)
+"rW" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/aft_port)
+"rZ" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 9
+	},
+/obj/structure/cable/green,
+/obj/machinery/power/apc/talon{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/atmospherics)
+"sc" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/brig)
+"se" = (
+/obj/structure/extinguisher_cabinet{
+	dir = 1;
+	pixel_y = -32
+	},
+/obj/structure/table/steel,
+/obj/item/device/radio/off{
+	channels = list("Talon" = 1)
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/atmospherics)
+"sf" = (
+/obj/machinery/door/firedoor/glass/talon,
+/obj/machinery/door/airlock{
+	id_tag = "talon_pilotdoor";
+	name = "Pilot's Cabin";
+	req_one_access = list(301)
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/crew_quarters/pilot_room)
+"sh" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/effect/catwalk_plated,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/brig)
+"sk" = (
+/obj/machinery/alarm/talon{
+	dir = 1;
+	pixel_y = -22
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/structure/railing/grey{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/port_store)
+"sl" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
@@ -9821,104 +5678,7 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/talon_v2/brig)
-"Gv" = (
-/obj/structure/handrail{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/maintenance/wing_starboard)
-"Gw" = (
-/obj/machinery/door/firedoor/glass/talon,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment{
-	dir = 1
-	},
-/obj/machinery/door/airlock{
-	id_tag = "talon_pilotdoor";
-	name = "Pilot's Cabin";
-	req_one_access = list(301)
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/crew_quarters/pilot_room)
-"Gx" = (
-/obj/machinery/power/apc/talon{
-	name = "south bump";
-	pixel_y = -24
-	},
-/obj/structure/cable/green,
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway/star)
-"Gy" = (
-/obj/effect/floor_decal/industrial/warning/dust{
-	dir = 5
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/talon_v2/engineering/starboard)
-"GC" = (
-/obj/machinery/power/pointdefense{
-	id_tag = "talon_pd"
-	},
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/effect/floor_decal/industrial/warning/dust{
-	dir = 10
-	},
-/obj/effect/floor_decal/industrial/warning/dust{
-	dir = 9
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/space)
-"GE" = (
-/obj/machinery/door/firedoor/glass/talon,
-/obj/machinery/door/airlock/maintenance/engi{
-	name = "Port Eng. Storage";
-	req_one_access = list(301)
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/port_store)
-"GF" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/machinery/firealarm{
-	layer = 3.3;
-	pixel_y = 26
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/gen_store)
-"GH" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway/port)
-"GJ" = (
-/obj/structure/sink{
-	pixel_y = 22
-	},
-/obj/structure/medical_stand/anesthetic,
-/turf/simulated/floor/tiled/white,
-/area/talon_v2/medical)
-"GK" = (
+"sn" = (
 /obj/machinery/door/firedoor/glass/talon,
 /obj/machinery/door/airlock/glass_security{
 	name = "Talon Brig/Sec";
@@ -9940,298 +5700,931 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/talon_v2/brig)
-"GQ" = (
-/obj/machinery/atmospherics/pipe/simple/visible/blue,
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/atmospherics)
-"GT" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/maintenance/wing_starboard)
-"GU" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/obj/machinery/light/small{
+"so" = (
+/obj/effect/floor_decal/corner/black/diagonal,
+/obj/structure/table/marble,
+/obj/random/pizzabox,
+/turf/simulated/floor/tiled/white,
+/area/talon_v2/crew_quarters/bar)
+"sq" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/anomaly_storage)
-"GV" = (
-/obj/machinery/alarm/talon{
-	dir = 1;
-	pixel_y = -22
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/structure/railing/grey{
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/port_store)
-"GW" = (
-/obj/machinery/atmospherics/omni/atmos_filter{
-	name = "N2/O2 Filter";
-	tag_east = 4;
-	tag_north = 3;
-	tag_south = 2;
-	tag_west = 1
-	},
-/obj/effect/catwalk_plated/dark,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/atmospherics)
-"GY" = (
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/catwalk,
-/obj/machinery/camera/network/talon{
-	dir = 1
-	},
-/obj/structure/closet/walllocker_double/hydrant/south,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/atmospherics)
-"Ha" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/effect/catwalk_plated,
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
+/turf/simulated/floor/plating,
+/area/talon_v2/central_hallway)
+"ss" = (
 /obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/atmospherics)
-"Hb" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/aux{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/maintenance/wing_starboard)
-"Hc" = (
 /obj/structure/cable/green{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
 	},
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/fore_starboard)
+"su" = (
+/obj/structure/railing/grey{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 6
+	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
-/area/talon_v2/engineering)
-"Hf" = (
+/area/talon_v2/engineering/atmospherics)
+"sv" = (
+/obj/structure/table/rack/shelf/steel,
+/obj/item/weapon/gun/energy/netgun,
+/obj/item/weapon/cell/device/weapon{
+	pixel_x = -5;
+	pixel_y = 2
+	},
+/obj/item/weapon/cell/device/weapon{
+	pixel_x = -5;
+	pixel_y = 2
+	},
+/obj/item/weapon/cell/device/weapon,
+/obj/item/clothing/accessory/holster/waist,
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/armory)
+"sw" = (
+/obj/machinery/light_switch{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/simulated/floor/wood,
+/area/talon_v2/crew_quarters/med_room)
+"sx" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/light_switch{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/random/multiple/corp_crate/talon_cargo,
+/obj/structure/railing/grey{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/maintenance/wing_port)
+"sz" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/port)
+"sB" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
+	dir = 9
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
-/area/talon_v2/engineering/port)
-"Hg" = (
+/area/talon_v2/engineering/star_store)
+"sC" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/closet/walllocker_double/east,
+/obj/item/weapon/storage/toolbox/electrical,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering)
+"sD" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 2;
+	icon_state = "pipe-j2"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway/fore)
+"sE" = (
+/obj/machinery/atmospherics/binary/pump/high_power/on{
+	dir = 8
+	},
 /obj/structure/railing/grey{
 	dir = 4
 	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/obj/structure/table/steel,
-/obj/item/stack/marker_beacon/thirty,
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/refining)
-"Hh" = (
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/atmospherics)
+"sF" = (
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/holoposter{
+	pixel_y = -32
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway)
+"sG" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 8
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/space)
+"sI" = (
+/obj/machinery/door/airlock/glass_external{
+	req_one_access = list(301)
+	},
+/obj/effect/map_helper/airlock/door/ext_door,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/maintenance/fore_starboard)
+"sJ" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/fuel,
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/turf/simulated/wall/rshull,
+/area/shuttle/talonboat)
+"sK" = (
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc/talon{
+	dir = 1;
+	name = "north bump";
+	pixel_y = 28
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/brig)
+"sL" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 4;
+	icon_state = "pipe-j2"
+	},
+/obj/structure/closet/walllocker_double/hydrant/east,
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway)
+"sM" = (
+/obj/effect/landmark/map_data/talon,
+/turf/space,
+/area/space)
+"sP" = (
+/obj/machinery/door/firedoor/glass/talon,
+/obj/machinery/door/airlock/maintenance/engi{
+	name = "Port Eng. Storage";
+	req_one_access = list(301)
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/port_store)
+"sR" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/camera/network/talon{
+	dir = 1
+	},
+/obj/structure/vehiclecage/quadbike,
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/maintenance/wing_starboard)
+"sT" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/railing/grey,
+/obj/random/multiple/corp_crate/talon_cargo,
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/maintenance/wing_port)
+"sZ" = (
+/obj/structure/catwalk,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/aft_starboard)
+"ta" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/effect/catwalk_plated,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/central_hallway/star)
+"tb" = (
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/central_hallway/fore)
+"tc" = (
+/obj/machinery/power/pointdefense{
+	id_tag = "talon_pd"
+	},
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 9
+	},
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/space)
+"td" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/wall/shull,
+/area/talon_v2/central_hallway)
+"tf" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 4;
+	icon_state = "pipe-j2"
+	},
+/obj/structure/closet/walllocker_double/hydrant/west,
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway)
+"tg" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/aft_starboard)
+"th" = (
+/obj/machinery/camera/network/talon{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/brig)
+"ti" = (
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/obj/structure/railing/grey{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/outline/red,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/atmospherics)
+"tj" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/junction,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway/fore)
+"tk" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/obj/structure/closet/emergsuit_wall{
+	dir = 4;
+	pixel_x = 32
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway)
+"tm" = (
+/obj/structure/lattice,
+/turf/space,
+/area/space)
+"tn" = (
+/obj/structure/closet/emergsuit_wall{
+	dir = 1;
+	pixel_y = -32
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/brig)
+"to" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway)
+"tp" = (
+/obj/machinery/atmospherics/pipe/simple/visible/red{
+	dir = 9
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/atmospherics)
+"tq" = (
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/aft_starboard)
+"tu" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/crew_quarters/restrooms)
+"tw" = (
+/obj/machinery/door/firedoor/glass/talon,
+/obj/machinery/door/airlock/maintenance/medical{
+	id_tag = "talon_meddoor";
+	req_one_access = list(301)
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/crew_quarters/med_room)
+"tx" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/computer/guestpass{
+	dir = 8;
+	pixel_x = 26
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway)
+"tz" = (
+/obj/effect/floor_decal/emblem/talon_big{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/central_hallway/fore)
+"tA" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/brig)
+"tB" = (
+/obj/structure/sign/warning/nosmoking_1{
+	pixel_x = 26
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering)
+"tC" = (
+/turf/simulated/wall/rshull,
+/area/talon_v2/maintenance/aft_port)
+"tE" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/closet/walllocker/medical/east,
+/obj/item/weapon/storage/firstaid/regular,
+/obj/item/weapon/storage/firstaid/o2,
+/obj/item/weapon/storage/firstaid/fire,
+/obj/item/device/radio/off{
+	channels = list("Talon" = 1)
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/brig)
+"tJ" = (
+/obj/structure/railing/grey{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/refining)
+"tK" = (
+/obj/structure/table/woodentable,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/obj/item/modular_computer/laptop/preset/custom_loadout/standard/talon/medical,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor/carpet,
+/area/talon_v2/crew_quarters/med_room)
+"tM" = (
+/obj/structure/table/woodentable,
+/obj/machinery/camera/network/talon{
+	dir = 8
+	},
+/obj/machinery/recharger,
+/turf/simulated/floor/wood,
+/area/talon_v2/crew_quarters/eng_room)
+"tQ" = (
+/obj/machinery/light{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/talon_v2/central_hallway)
-"Hj" = (
-/obj/structure/catwalk,
+"tS" = (
+/obj/structure/railing/grey,
+/obj/effect/floor_decal/industrial/outline/red,
+/obj/machinery/portable_atmospherics/canister/empty/phoron,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/star_store)
+"tU" = (
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/reinforced/airless,
-/area/talon_v2/maintenance/wing_starboard)
-"Hl" = (
-/obj/effect/floor_decal/corner/black/diagonal,
-/turf/simulated/floor/tiled/white,
-/area/talon_v2/crew_quarters/bar)
-"Hn" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway)
+"tX" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/port)
-"Ho" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/computer/ship/engines{
-	dir = 1
-	},
-/obj/structure/railing/grey,
-/obj/effect/floor_decal/industrial/warning,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/engineering)
-"Hq" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/table/standard,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
-/obj/machinery/camera/network/talon{
-	dir = 4
-	},
-/obj/machinery/recharger,
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/crew_quarters/restrooms)
-"Hr" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/anomaly_storage)
-"Ht" = (
-/obj/effect/map_helper/airlock/sensor/chamber_sensor,
-/obj/machinery/atmospherics/pipe/manifold/hidden/aux{
-	dir = 1
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/machinery/airlock_sensor{
-	pixel_y = 28;
-	req_one_access = list(301)
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/maintenance/fore_port)
-"Hu" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/workroom)
-"Hw" = (
-/obj/structure/railing/grey,
-/obj/effect/floor_decal/emblem/talon,
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/bridge)
-"Hz" = (
-/obj/structure/hull_corner,
-/turf/space,
-/area/space)
-"HA" = (
-/obj/machinery/door/firedoor/glass/talon,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/airlock/glass_security{
-	name = "Talon Armory";
-	req_one_access = list(301)
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/armory)
-"HC" = (
+/area/talon_v2/central_hallway/star)
+"tZ" = (
+/obj/machinery/door/firedoor/glass/talon,
+/obj/machinery/door/airlock{
+	name = "Restrooms & Charger"
+	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/maintenance/wing_starboard)
-"HD" = (
-/obj/machinery/atmospherics/pipe/manifold4w/visible/yellow,
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
+/area/talon_v2/crew_quarters/restrooms)
+"ub" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/starboard)
-"HE" = (
-/obj/item/modular_computer/console/preset/talon,
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/crew_quarters/restrooms)
+"uc" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/crew_quarters/restrooms)
+"uf" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/carpet/blucarpet,
-/area/talon_v2/crew_quarters/cap_room)
-"HF" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/machinery/disposal,
-/obj/structure/sign/directions/medical{
-	pixel_y = -32
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/crew_quarters/restrooms)
-"HG" = (
-/obj/machinery/mineral/stacking_unit_console{
-	pixel_y = -6;
-	req_one_access = list(301)
-	},
-/obj/structure/girder,
-/obj/structure/railing/grey{
-	dir = 4
-	},
-/obj/structure/railing/grey{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/refining)
-"HH" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 4
-	},
-/obj/effect/catwalk_plated/dark,
+/obj/structure/catwalk,
 /turf/simulated/floor/plating,
+/area/talon_v2/maintenance/aft_port)
+"uh" = (
+/obj/machinery/door/firedoor/glass/talon,
+/obj/machinery/door/airlock{
+	id_tag = "talon_restroom1";
+	name = "Unisex Restroom"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/talon_v2/crew_quarters/restrooms)
+"ui" = (
+/obj/structure/bed,
+/obj/item/weapon/bedsheet/mime,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/brig)
+"uk" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/white,
+/area/talon_v2/crew_quarters/restrooms)
+"ul" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/gen_store)
+"um" = (
+/obj/machinery/door/firedoor/glass/talon,
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced,
+/obj/machinery/door/blast/regular/open{
+	dir = 2;
+	id = "talon_bridge_shields"
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/bridge)
+"uo" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/ofd_ops)
+"up" = (
+/turf/simulated/wall/rshull,
+/area/talon_v2/anomaly_storage)
+"uu" = (
+/obj/structure/hull_corner/long_vert{
+	dir = 9
+	},
+/turf/space,
+/area/space)
+"uv" = (
+/obj/machinery/shower,
+/obj/item/weapon/soap/deluxe,
+/obj/structure/curtain,
+/turf/simulated/floor/tiled/white,
+/area/talon_v2/crew_quarters/restrooms)
+"uw" = (
+/obj/effect/floor_decal/industrial/warning/corner,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/hangar)
+"uz" = (
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/fore_starboard)
+"uA" = (
+/obj/effect/floor_decal/emblem/talon_big{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/central_hallway/fore)
+"uC" = (
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 5
+	},
+/turf/simulated/floor/reinforced/airless,
 /area/talon_v2/engineering/port)
-"HI" = (
-/obj/structure/disposalpipe/segment,
+"uF" = (
+/obj/machinery/door/window/brigdoor/eastleft{
+	dir = 1;
+	req_access = list(301)
+	},
+/obj/machinery/door/window/brigdoor/eastleft{
+	dir = 2;
+	req_access = list(301)
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id = "talon_brig1";
+	name = "Cell Shutters";
+	opacity = 0
+	},
+/obj/machinery/door/firedoor/glass/talon,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/brig)
+"uG" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/structure/catwalk,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/aft_port)
+"uH" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 6
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/atmospherics)
+"uI" = (
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 6
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	layer = 3.3;
+	pixel_y = 26
+	},
+/obj/structure/catwalk,
+/obj/machinery/camera/network/talon,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/starboard)
+"uJ" = (
+/obj/effect/floor_decal/industrial/warning,
+/obj/machinery/light_switch{
+	pixel_y = 24
+	},
+/obj/machinery/camera/network/talon,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/hangar)
+"uL" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/wall/rshull,
+/area/talon_v2/maintenance/aft_port)
+"uM" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway)
+"uO" = (
+/obj/machinery/power/pointdefense{
+	id_tag = "talon_pd"
+	},
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 9
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/space)
+"uQ" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/alarm/talon{
+	pixel_y = 28
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/engineering/star_store)
+"uR" = (
+/obj/structure/table/steel,
+/obj/machinery/cell_charger,
+/obj/item/weapon/cell/apc,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/engineering)
+"uS" = (
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/gen_store)
+"uU" = (
+/obj/structure/bed/chair/bay/chair{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/talonboat)
+"uV" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/aux{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/handrail{
+	dir = 1
+	},
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_x = 8;
+	pixel_y = -26
+	},
+/obj/structure/fuel_port/heavy{
+	dir = 1;
+	pixel_y = -28
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/talonboat)
+"uW" = (
+/obj/structure/table/standard,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/brig)
+"uY" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/wall/shull,
+/area/talon_v2/ofd_ops)
+"uZ" = (
+/obj/structure/catwalk,
+/obj/structure/trash_pile,
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/fore_starboard)
+"va" = (
+/obj/effect/floor_decal/industrial/warning,
+/obj/machinery/embedded_controller/radio/simple_docking_controller{
+	frequency = 1380;
+	id_tag = "talon_boatbay";
+	pixel_y = 26
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/hangar)
+"vb" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/talon_v2/engineering)
-"HK" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+"vc" = (
+/obj/structure/catwalk,
+/obj/structure/trash_pile,
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/aft_starboard)
+"vd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/starboard)
+"ve" = (
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/hangar)
+"vh" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/obj/machinery/light/small,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/port)
+"vi" = (
 /obj/machinery/alarm/talon{
 	dir = 8;
 	pixel_x = 22
@@ -10243,99 +6636,625 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
-/area/talon_v2/engineering)
-"HN" = (
-/obj/structure/sign/warning/nosmoking_1{
-	pixel_x = 26
-	},
-/obj/structure/table/rack/shelf/steel,
-/obj/random/maintenance/engineering,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/port_store)
-"HS" = (
-/turf/simulated/wall/shull,
-/area/talon_v2/anomaly_storage)
-"HT" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/structure/table/rack/steel,
-/obj/item/weapon/shovel,
-/obj/item/weapon/shovel,
-/obj/item/weapon/mining_scanner,
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/refining)
-"HU" = (
-/obj/machinery/recharge_station,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/engineering)
-"HW" = (
-/obj/machinery/disposal/wall{
+/area/talon_v2/maintenance/fore_port)
+"vj" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/aux{
 	dir = 4
 	},
-/obj/structure/disposalpipe/trunk{
-	dir = 8
+/obj/effect/map_helper/airlock/atmos/chamber_pump,
+/obj/structure/handrail{
+	dir = 4
 	},
-/turf/simulated/floor/wood,
-/area/talon_v2/crew_quarters/bar)
-"HX" = (
-/obj/structure/table/standard,
-/obj/item/device/defib_kit/jumper_kit/loaded,
-/obj/item/device/defib_kit/loaded,
-/obj/item/weapon/storage/belt/medical/emt,
-/obj/item/device/sleevemate,
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/maintenance/aft_port)
+"vk" = (
+/obj/machinery/atmospherics/unary/engine/bigger{
+	dir = 1
+	},
+/turf/space,
+/area/talon_v2/engineering/starboard)
+"vp" = (
+/obj/structure/bed/chair/bay/chair,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/brig)
+"vr" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/maintenance/wing_starboard)
+"vs" = (
+/obj/machinery/smartfridge/chemistry{
+	req_access = list(301);
+	req_one_access = list(301)
+	},
 /turf/simulated/floor/tiled/white,
 /area/talon_v2/medical)
-"HZ" = (
-/obj/machinery/door/airlock/glass_external{
-	req_one_access = list(301)
+"vt" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
 	},
-/obj/effect/map_helper/airlock/door/ext_door,
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/maintenance/fore_starboard)
-"Ia" = (
-/obj/machinery/door/airlock/multi_tile/glass{
-	dir = 1;
-	name = "Hangar Bay";
-	req_one_access = list(301)
-	},
-/obj/machinery/door/firedoor/glass/talon,
-/turf/simulated/floor/tiled/techfloor,
 /area/talon_v2/hangar)
-"Id" = (
+"vx" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/refining)
+"vy" = (
+/obj/machinery/computer/ship/engines,
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/talonboat)
+"vz" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/closet/walllocker_double/hydrant/south,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway)
+"vB" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/catwalk,
-/obj/machinery/door/firedoor/glass/talon,
-/obj/machinery/door/airlock/maintenance/common,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/port)
+"vC" = (
+/obj/machinery/shipsensors{
+	dir = 1
+	},
+/turf/simulated/floor/reinforced,
+/area/shuttle/talonboat)
+"vE" = (
+/obj/structure/hull_corner{
+	dir = 8
+	},
+/turf/simulated/floor/reinforced,
+/area/shuttle/talonboat)
+"vF" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/talon_v2/crew_quarters/sec_room)
+"vG" = (
+/obj/structure/extinguisher_cabinet{
+	dir = 1;
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/workroom)
+"vH" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/hangar)
+"vJ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/crew_quarters/restrooms)
+"vK" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/catwalk,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
+/area/talon_v2/maintenance/aft_port)
+"vL" = (
+/obj/machinery/power/pointdefense{
+	id_tag = "talon_pd"
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 5
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/space)
+"vO" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering)
+"vP" = (
+/obj/machinery/atmospherics/pipe/simple/visible/blue{
+	dir = 10
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/atmospherics)
+"vR" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/aux{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/wing_port)
+"vU" = (
+/obj/machinery/door/firedoor/glass/talon,
+/obj/machinery/door/airlock/maintenance/sec{
+	req_one_access = list(301)
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/brig)
+"vV" = (
+/obj/machinery/computer/shuttle_control/explore/talonboat{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/talonboat)
+"vY" = (
+/obj/machinery/light/small,
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/brig)
+"vZ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/crew_quarters/restrooms)
+"wa" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/aux{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/glass/talon,
+/obj/machinery/door/airlock/maintenance/common,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
 /area/talon_v2/maintenance/fore_port)
-"Ie" = (
+"wc" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering)
+"we" = (
+/obj/structure/catwalk,
+/obj/structure/railing/grey{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/fore_starboard)
+"wf" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/aft_port)
+"wg" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/bed/chair/bay/chair,
+/turf/simulated/floor/carpet,
+/area/talon_v2/crew_quarters/med_room)
+"wh" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/secure_storage)
+"wi" = (
+/obj/machinery/door/airlock/glass_external,
+/obj/effect/map_helper/airlock/door/ext_door,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/ofd_ops)
+"wm" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/bridge)
+"wn" = (
+/obj/structure/disposaloutlet,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/talon_v2/engineering)
+"wp" = (
+/obj/effect/map_helper/airlock/sensor/ext_sensor,
+/obj/machinery/airlock_sensor{
+	pixel_x = -28;
+	pixel_y = 28;
+	req_one_access = list(301)
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/reinforced/airless,
+/area/talon_v2/maintenance/aft_port)
+"wr" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/machinery/light_switch{
+	dir = 4;
+	pixel_x = -24
+	},
+/obj/random/multiple/corp_crate/talon_cargo,
+/obj/structure/railing/grey{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/maintenance/wing_starboard)
+"ws" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/random/multiple/corp_crate/talon_cargo,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/maintenance/wing_port)
+"wu" = (
+/obj/structure/catwalk,
+/obj/structure/trash_pile,
+/obj/structure/railing/grey{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/fore_port)
+"wv" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/extinguisher_cabinet{
+	dir = 4;
+	pixel_x = -30
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway)
+"ww" = (
+/obj/machinery/power/pointdefense{
+	id_tag = "talon_pd"
+	},
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 10
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/space)
+"wx" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/obj/machinery/holoposter{
+	dir = 4;
+	pixel_x = 32
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway)
+"wy" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/catwalk,
+/obj/structure/disposalpipe/segment,
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/structure/flora/pottedplant/thinbush,
+/obj/machinery/light_switch{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering)
+"wz" = (
+/obj/machinery/door/window/brigdoor/eastleft{
+	req_access = list();
+	req_one_access = list(301)
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/port)
+"wF" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/maintenance/wing_starboard)
+"wG" = (
+/obj/machinery/power/pointdefense{
+	id_tag = "talon_pd"
+	},
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 5
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/space)
+"wI" = (
+/obj/structure/sign/warning/nosmoking_1{
+	pixel_x = 26
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/port)
+"wK" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 9
+	},
+/obj/structure/catwalk,
+/obj/structure/railing/grey{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/atmospherics)
+"wM" = (
+/obj/machinery/suit_cycler/vintage/tguard,
 /turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/workroom)
-"If" = (
-/obj/effect/map_helper/airlock/door/int_door,
+/area/talon_v2/brig)
+"wN" = (
+/obj/machinery/door/firedoor/glass/talon,
+/obj/machinery/door/airlock/medical{
+	req_one_access = list(301)
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/medical)
+"wP" = (
+/obj/machinery/disperser/back{
+	dir = 1
+	},
+/obj/effect/map_helper/airlock/sensor/ext_sensor,
+/obj/machinery/airlock_sensor{
+	dir = 8;
+	pixel_x = 28;
+	pixel_y = 28;
+	req_one_access = list(301)
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/talon_v2/ofd_ops)
+"wQ" = (
+/obj/structure/trash_pile,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/port_store)
+"wS" = (
+/obj/structure/closet/wardrobe/black{
+	starts_with = list(/obj/item/clothing/under/color/black = 4, /obj/item/clothing/accessory/storage/black_vest = 4, /obj/item/clothing/accessory/storage/black_drop_pouches = 4, /obj/item/clothing/gloves/black = 4, /obj/item/clothing/head/soft/black = 4, /obj/item/clothing/mask/balaclava = 4, /obj/item/clothing/mask/bandana = 4, /obj/item/clothing/mask/gas/commando = 4, /obj/item/weapon/storage/backpack/messenger/black = 4, /obj/item/weapon/storage/backpack/dufflebag = 4, /obj/item/clothing/shoes/black = 4, /obj/item/clothing/shoes/boots/duty = 4)
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/armory)
+"wT" = (
+/obj/machinery/power/pointdefense{
+	id_tag = "talon_pd"
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 6
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/space)
+"wV" = (
+/obj/machinery/vending/fitness,
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/central_hallway/fore)
+"wX" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/talonboat)
+"xa" = (
 /obj/machinery/door/airlock/glass_external{
 	req_one_access = list(301)
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/aux{
+/obj/effect/map_helper/airlock/door/int_door,
+/obj/machinery/atmospherics/pipe/simple/hidden/aux,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/maintenance/aft_starboard)
+"xb" = (
+/obj/structure/bed/chair/bay/chair{
+	dir = 1
+	},
+/turf/simulated/floor/carpet/blucarpet,
+/area/talon_v2/crew_quarters/cap_room)
+"xd" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/closet/emergsuit_wall{
+	dir = 1;
+	pixel_y = -32
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway/port)
+"xf" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway)
+"xg" = (
+/obj/machinery/button/remote/blast_door{
+	id = "talon_cargo_star";
+	name = "Cargo Loading Hatches";
+	pixel_y = -28
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
 	dir = 4
+	},
+/obj/machinery/door/window/brigdoor/northright{
+	req_access = list();
+	req_one_access = list(301)
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/maintenance/wing_starboard)
+"xh" = (
+/obj/structure/bed/chair/bay/comfy/brown{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/bridge)
+"xj" = (
+/obj/machinery/vending/engineering{
+	products = list(/obj/item/clothing/under/rank/chief_engineer = 4, /obj/item/clothing/under/rank/engineer = 4, /obj/item/clothing/shoes/orange = 4, /obj/item/clothing/head/hardhat = 4, /obj/item/weapon/storage/belt/utility = 4, /obj/item/clothing/glasses/meson = 4, /obj/item/clothing/gloves/yellow = 4, /obj/item/weapon/tool/screwdriver = 12, /obj/item/weapon/tool/crowbar = 12, /obj/item/weapon/tool/wirecutters = 12, /obj/item/device/multitool = 12, /obj/item/weapon/tool/wrench = 12, /obj/item/device/t_scanner = 12, /obj/item/stack/cable_coil/heavyduty = 8, /obj/item/weapon/cell = 8, /obj/item/weapon/weldingtool = 8, /obj/item/clothing/head/welding = 8, /obj/item/weapon/light/tube = 10, /obj/item/clothing/head/hardhat/red = 4, /obj/item/clothing/suit/fire = 4, /obj/item/weapon/stock_parts/scanning_module = 5, /obj/item/weapon/stock_parts/micro_laser = 5, /obj/item/weapon/stock_parts/matter_bin = 5, /obj/item/weapon/stock_parts/manipulator = 5, /obj/item/weapon/stock_parts/console_screen = 5);
+	req_access = list(301);
+	req_log_access = 301;
+	req_one_access = list(301)
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/engineering/star_store)
+"xk" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/atmospherics/portables_connector{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/canister/empty/carbon_dioxide,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/atmospherics)
+"xm" = (
+/obj/machinery/door/firedoor/glass/talon,
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1
 	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/maintenance/wing_starboard)
-"Ig" = (
+/obj/machinery/door/blast/regular/open{
+	dir = 4;
+	id = "talon_bridge_shields"
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/bridge)
+"xo" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/aft_port)
+"xr" = (
 /obj/machinery/light/small{
 	dir = 4
 	},
@@ -10346,7 +7265,970 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/talon_v2/refining)
-"Ih" = (
+"xs" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/industrial/warning/dust/corner,
+/turf/simulated/floor/reinforced/airless,
+/area/space)
+"xu" = (
+/obj/item/modular_computer/console/preset/talon,
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/bridge)
+"xv" = (
+/obj/machinery/oxygen_pump{
+	dir = 4;
+	pixel_x = 30
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/carpet/blucarpet,
+/area/talon_v2/crew_quarters/cap_room)
+"xw" = (
+/obj/machinery/door/firedoor/glass/talon,
+/obj/machinery/door/airlock/maintenance/common,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/wing_port)
+"xx" = (
+/obj/structure/table/rack/steel,
+/obj/machinery/power/apc/talon{
+	name = "south bump";
+	pixel_y = -24
+	},
+/obj/structure/cable/green,
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/armory)
+"xB" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/catwalk,
+/obj/machinery/light/small,
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/fore_port)
+"xE" = (
+/obj/structure/catwalk,
+/obj/machinery/door/firedoor/glass/talon,
+/obj/machinery/door/airlock/maintenance/common,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/fore_port)
+"xH" = (
+/turf/simulated/wall/rshull,
+/area/talon_v2/engineering/port_store)
+"xK" = (
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 5
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/starboard)
+"xL" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/wall/rshull,
+/area/talon_v2/maintenance/fore_port)
+"xM" = (
+/obj/structure/bookcase/manuals/medical,
+/obj/machinery/camera/network/talon,
+/turf/simulated/floor/wood,
+/area/talon_v2/crew_quarters/meditation)
+"xN" = (
+/obj/machinery/door/firedoor/glass/talon,
+/obj/machinery/door/airlock/maintenance/common,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/wing_starboard)
+"xP" = (
+/obj/structure/closet/walllocker/emerglocker/west,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/secure_storage)
+"xQ" = (
+/obj/machinery/suit_cycler/vintage/tmedic,
+/turf/simulated/floor/tiled/white,
+/area/talon_v2/medical)
+"xR" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/machinery/disposal/wall{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/workroom)
+"xV" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 4
+	},
+/obj/structure/catwalk,
+/obj/structure/railing/grey,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/atmospherics)
+"xW" = (
+/obj/machinery/conveyor{
+	id = "talontrash"
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering)
+"xY" = (
+/obj/machinery/door/firedoor/glass/talon,
+/obj/machinery/door/airlock/engineering{
+	name = "Talon Starboard Engines";
+	req_one_access = list(301)
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/starboard)
+"xZ" = (
+/obj/structure/closet/walllocker/emerglocker/east,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/secure_storage)
+"ya" = (
+/obj/structure/table/standard,
+/obj/item/weapon/storage/toolbox/electrical,
+/obj/item/weapon/pipe_dispenser,
+/obj/machinery/light/small,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/engineering/star_store)
+"yc" = (
+/obj/structure/catwalk,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/atmospherics)
+"yd" = (
+/obj/machinery/light_switch{
+	dir = 4;
+	pixel_x = -24
+	},
+/obj/item/device/mass_spectrometer/adv,
+/obj/structure/table/standard,
+/turf/simulated/floor/tiled/white,
+/area/talon_v2/medical)
+"yh" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 6
+	},
+/turf/simulated/wall/rshull,
+/area/shuttle/talonboat)
+"yi" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/wood,
+/area/talon_v2/crew_quarters/cap_room)
+"yj" = (
+/obj/structure/table/standard,
+/obj/machinery/chemical_dispenser/full,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/talon_v2/medical)
+"yl" = (
+/obj/structure/sign/warning/airlock{
+	pixel_x = 32
+	},
+/obj/effect/floor_decal/industrial/warning,
+/obj/structure/handrail{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/maintenance/wing_port)
+"ym" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 4;
+	icon_state = "pipe-j2"
+	},
+/turf/simulated/floor/tiled/white,
+/area/talon_v2/medical)
+"yn" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/aft_port)
+"yo" = (
+/obj/structure/catwalk,
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering)
+"yq" = (
+/obj/structure/table/rack/steel,
+/obj/item/clothing/shoes/magboots,
+/obj/item/clothing/suit/space/syndicate/black,
+/obj/item/clothing/head/helmet/space/syndicate/black,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/armory)
+"yr" = (
+/obj/effect/overmap/visitable/ship/talon,
+/turf/space,
+/area/space)
+"ys" = (
+/obj/structure/hull_corner{
+	dir = 1
+	},
+/turf/space,
+/area/space)
+"yt" = (
+/obj/item/weapon/storage/firstaid/regular,
+/obj/item/weapon/storage/firstaid/o2,
+/obj/structure/closet/walllocker/medical/north,
+/obj/item/device/radio/off{
+	channels = list("Talon" = 1)
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/bridge)
+"yu" = (
+/obj/effect/map_helper/airlock/sensor/ext_sensor,
+/obj/machinery/airlock_sensor{
+	dir = 4;
+	pixel_x = -28;
+	pixel_y = 28;
+	req_one_access = list(301)
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/reinforced/airless,
+/area/talon_v2/maintenance/fore_starboard)
+"yv" = (
+/obj/machinery/computer/shuttle_control/explore/talon_escape{
+	dir = 8
+	},
+/obj/machinery/alarm/talon{
+	pixel_y = 24
+	},
+/obj/item/weapon/paper/talon_escape_pod,
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/talonpod)
+"yw" = (
+/obj/machinery/door/firedoor/glass/talon,
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/door/blast/regular/open{
+	dir = 4;
+	id = "talon_bridge_shields"
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/bridge)
+"yx" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/random/medical,
+/obj/random/medical,
+/obj/random/medical,
+/obj/random/medical,
+/obj/structure/closet/walllocker_double/medical/west,
+/turf/simulated/floor/tiled/white,
+/area/talon_v2/medical)
+"yz" = (
+/obj/machinery/door/airlock/glass_external{
+	req_one_access = list(301)
+	},
+/obj/effect/map_helper/airlock/door/ext_door,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/maintenance/aft_starboard)
+"yA" = (
+/obj/effect/landmark/start{
+	name = "Talon Captain"
+	},
+/turf/simulated/floor/carpet/blucarpet,
+/area/talon_v2/crew_quarters/cap_room)
+"yC" = (
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/maintenance/wing_starboard)
+"yD" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/tiled/white,
+/area/talon_v2/medical)
+"yF" = (
+/obj/item/weapon/storage/firstaid/toxin,
+/obj/item/weapon/storage/firstaid/toxin,
+/obj/item/weapon/storage/firstaid/o2,
+/obj/item/weapon/storage/firstaid/o2,
+/obj/item/weapon/storage/firstaid/fire,
+/obj/item/weapon/storage/firstaid/fire,
+/obj/item/weapon/storage/firstaid/adv,
+/obj/item/weapon/storage/firstaid/adv,
+/obj/structure/closet/walllocker_double/medical/east,
+/turf/simulated/floor/tiled/white,
+/area/talon_v2/medical)
+"yH" = (
+/obj/machinery/disposal/wall{
+	dir = 1
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/engineering/star_store)
+"yJ" = (
+/obj/structure/table/standard,
+/obj/fiftyspawner/glass,
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/workroom)
+"yK" = (
+/obj/machinery/light/small,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/aft_starboard)
+"yM" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/atmospherics/portables_connector{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/outline/red,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/atmospherics)
+"yN" = (
+/obj/machinery/power/apc/talon{
+	dir = 1;
+	name = "north bump";
+	pixel_y = 28
+	},
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/camera/network/talon,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/engineering/star_store)
+"yO" = (
+/obj/structure/bed/chair/office/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/workroom)
+"yR" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/structure/table/standard,
+/obj/machinery/cell_charger,
+/obj/item/weapon/storage/firstaid/regular,
+/obj/item/weapon/storage/firstaid/o2,
+/obj/structure/closet/walllocker/medical/north,
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/workroom)
+"yS" = (
+/turf/simulated/wall/shull{
+	can_open = 1
+	},
+/area/talon_v2/engineering/port_store)
+"yU" = (
+/obj/machinery/mineral/mint,
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/refining)
+"yV" = (
+/obj/structure/closet/secure_closet/personal/cabinet{
+	locked = 0
+	},
+/obj/machinery/camera/network/talon{
+	dir = 1
+	},
+/turf/simulated/floor/carpet,
+/area/talon_v2/crew_quarters/pilot_room)
+"yW" = (
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/structure/railing/grey,
+/obj/effect/floor_decal/industrial/outline,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/atmospherics)
+"yY" = (
+/obj/structure/table/rack/shelf/steel,
+/obj/item/weapon/tank/jetpack/carbondioxide,
+/obj/item/weapon/tank/jetpack/carbondioxide,
+/obj/item/weapon/tank/jetpack/carbondioxide,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/secure_storage)
+"yZ" = (
+/obj/machinery/alarm/talon{
+	dir = 4;
+	pixel_x = -22
+	},
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc/talon{
+	dir = 1;
+	name = "north bump";
+	pixel_y = 28
+	},
+/obj/structure/table/steel,
+/obj/item/weapon/storage/box/nifsofts_mining,
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/refining)
+"zd" = (
+/obj/structure/fitness/weightlifter,
+/obj/machinery/camera/network/talon{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/workroom)
+"ze" = (
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway/fore)
+"zh" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/visible/yellow,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/port)
+"zj" = (
+/obj/structure/table/rack/steel,
+/obj/item/clothing/suit/space/void/refurb/talon,
+/obj/item/clothing/head/helmet/space/void/refurb/talon,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/secure_storage)
+"zk" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/wall/rshull,
+/area/talon_v2/engineering/port_store)
+"zm" = (
+/turf/simulated/wall/rshull,
+/area/talon_v2/engineering/starboard)
+"zo" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/port_store)
+"zq" = (
+/obj/machinery/airlock_sensor{
+	dir = 8;
+	pixel_x = 28;
+	pixel_y = 28;
+	req_one_access = list(301)
+	},
+/obj/effect/map_helper/airlock/sensor/ext_sensor,
+/obj/structure/catwalk,
+/obj/structure/handrail,
+/turf/simulated/floor/reinforced/airless,
+/area/talon_v2/maintenance/fore_port)
+"zs" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/visible,
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/atmospherics)
+"zu" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/machinery/disposal/wall{
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/talon_v2/crew_quarters/med_room)
+"zv" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id = "talon_brig1";
+	name = "Cell Shutters";
+	opacity = 0
+	},
+/obj/machinery/door/firedoor/glass/talon,
+/turf/simulated/floor/plating,
+/area/talon_v2/brig)
+"zw" = (
+/obj/machinery/door/airlock/medical{
+	name = "Medical Storage";
+	req_one_access = list(301)
+	},
+/obj/machinery/door/firedoor/glass/talon,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/talon_v2/medical)
+"zz" = (
+/obj/structure/catwalk,
+/obj/machinery/light/small,
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/fore_port)
+"zA" = (
+/obj/machinery/suit_cycler/vintage/tengi,
+/turf/simulated/floor/wood,
+/area/talon_v2/crew_quarters/eng_room)
+"zB" = (
+/obj/structure/table/rack/shelf/steel,
+/obj/item/clothing/suit/space/void/refurb/talon,
+/obj/item/clothing/head/helmet/space/void/refurb/talon,
+/obj/machinery/camera/network/talon,
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/secure_storage)
+"zC" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/talonboat)
+"zE" = (
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/structure/railing/grey{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/outline,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/atmospherics)
+"zH" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/machinery/disposal/wall{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/talon_v2/crew_quarters/sec_room)
+"zI" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/random/multiple/corp_crate/talon_cargo,
+/obj/structure/railing/grey{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/maintenance/wing_starboard)
+"zJ" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/camera/network/talon{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering)
+"zK" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/light,
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway/port)
+"zL" = (
+/obj/structure/table/rack/shelf/steel,
+/obj/item/weapon/gun/energy/locked/frontier/holdout/unlocked,
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/armory)
+"zM" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/portable_atmospherics/canister/empty,
+/obj/machinery/atmospherics/portables_connector{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/atmospherics)
+"zQ" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/aux,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/light/small,
+/obj/structure/closet/emergsuit_wall{
+	dir = 1;
+	pixel_y = -32
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/fore_port)
+"zT" = (
+/obj/machinery/disperser/middle{
+	dir = 1
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/talon_v2/ofd_ops)
+"zV" = (
+/obj/machinery/atmospherics/pipe/simple/visible/universal{
+	dir = 8;
+	name = "Air to Distro"
+	},
+/obj/machinery/camera/network/talon,
+/obj/structure/railing/grey{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/atmospherics)
+"zX" = (
+/obj/machinery/door/firedoor/glass/talon,
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/door/blast/regular/open{
+	dir = 4;
+	id = "talon_bridge_shields"
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/bridge)
+"zZ" = (
+/obj/structure/table/standard,
+/obj/item/clothing/gloves/sterile/nitrile,
+/obj/item/clothing/mask/surgical,
+/obj/item/clothing/suit/surgicalapron,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/structure/sign/warning/nosmoking_1{
+	pixel_x = 26
+	},
+/turf/simulated/floor/tiled/white,
+/area/talon_v2/medical)
+"Af" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/camera/network/talon,
+/obj/structure/railing/grey{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/port_store)
+"Ag" = (
+/obj/machinery/alarm/talon{
+	dir = 4;
+	pixel_x = -22
+	},
+/turf/simulated/floor/tiled/white,
+/area/talon_v2/medical)
+"Ak" = (
+/obj/machinery/door/firedoor/glass/talon,
+/obj/machinery/door/airlock/glass,
+/obj/structure/sign/directions/bar{
+	dir = 1;
+	pixel_x = 32
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway/fore)
+"An" = (
+/obj/structure/bed/chair/office/light,
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/workroom)
+"Aq" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/structure/flora/pottedplant/thinbush,
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/workroom)
+"As" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/closet/walllocker_double/hydrant/west,
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/maintenance/wing_starboard)
+"Au" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/glass/talon,
+/obj/machinery/door/airlock/maintenance/common,
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/aft_starboard)
+"Av" = (
+/obj/effect/floor_decal/emblem/talon,
+/turf/simulated/wall/rshull,
+/area/talon_v2/maintenance/wing_port)
+"Aw" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/wall/rshull,
+/area/talon_v2/maintenance/wing_port)
+"Ax" = (
+/obj/structure/table/steel,
+/obj/item/weapon/storage/bag/ore,
+/obj/item/weapon/pickaxe/drill,
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/refining)
+"Az" = (
+/obj/structure/table/rack/steel,
+/obj/item/device/suit_cooling_unit,
+/obj/item/device/suit_cooling_unit,
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/secure_storage)
+"AB" = (
+/obj/structure/catwalk,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/aft_starboard)
+"AD" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/maintenance/wing_port)
+"AE" = (
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_y = -26
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/gen_store)
+"AH" = (
+/obj/machinery/atmospherics/portables_connector/aux,
+/obj/effect/floor_decal/industrial/outline,
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/fore_port)
+"AI" = (
+/obj/machinery/power/apc/talon{
+	name = "south bump";
+	pixel_y = -24
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/gen_store)
+"AJ" = (
+/obj/machinery/alarm/talon{
+	dir = 1;
+	pixel_y = -25
+	},
+/obj/structure/reagent_dispensers/foam,
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/gen_store)
+"AL" = (
+/obj/structure/cable/yellow{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/terminal{
+	dir = 4
+	},
+/obj/structure/railing/grey{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering)
+"AN" = (
+/obj/structure/table/rack/shelf/steel,
+/obj/item/clothing/head/beret/talon,
+/obj/item/clothing/head/beret/talon,
+/obj/item/clothing/head/beret/talon,
+/obj/item/clothing/head/beret/talon,
+/obj/item/clothing/suit/storage/hooded/wintercoat/talon,
+/obj/item/clothing/suit/storage/hooded/wintercoat/talon,
+/obj/item/clothing/suit/storage/hooded/wintercoat/talon,
+/obj/item/clothing/suit/storage/hooded/wintercoat/talon,
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/secure_storage)
+"AO" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/effect/catwalk_plated,
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/central_hallway/fore)
+"AQ" = (
+/obj/structure/table/rack/shelf/steel,
+/obj/item/clothing/shoes/magboots,
+/obj/item/clothing/shoes/magboots,
+/obj/item/clothing/shoes/magboots,
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/secure_storage)
+"AS" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/bridge)
+"AT" = (
+/obj/structure/cable/yellow{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/terminal{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering)
+"AU" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/aux,
+/obj/machinery/door/firedoor/glass/talon,
+/obj/machinery/door/airlock/maintenance/common,
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/wing_starboard)
+"AV" = (
 /obj/machinery/door/airlock/glass_external{
 	req_one_access = list(301)
 	},
@@ -10362,30 +8244,522 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/shuttle/talonboat)
-"Ii" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
+"AY" = (
 /obj/structure/railing/grey{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 10
-	},
-/obj/structure/railing/grey,
-/obj/structure/table/steel,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/engineering)
-"Ij" = (
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
 	},
-/obj/effect/floor_decal/industrial/warning/corner{
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/structure/table/steel,
+/obj/item/stack/marker_beacon/thirty,
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/refining)
+"AZ" = (
+/obj/machinery/telecomms/allinone/talon{
+	id = "talon_aio";
+	network = "Talon"
+	},
+/obj/machinery/light/small{
 	dir = 1
 	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/engineering)
+"Ba" = (
+/obj/structure/table/rack/shelf/steel,
+/obj/item/device/suit_cooling_unit,
+/obj/item/weapon/tank/oxygen,
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/secure_storage)
+"Bb" = (
+/obj/structure/catwalk,
+/obj/structure/disposalpipe/junction/yjunction,
 /turf/simulated/floor/plating,
-/area/talon_v2/engineering/starboard)
-"Il" = (
+/area/talon_v2/engineering)
+"Bc" = (
+/obj/effect/floor_decal/industrial/outline/red,
+/obj/machinery/atmospherics/portables_connector{
+	dir = 8
+	},
+/obj/structure/railing/grey,
+/obj/machinery/portable_atmospherics/canister/phoron/engine_setup,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/port)
+"Bd" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/bed/chair/bay/chair,
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/central_hallway)
+"Be" = (
+/obj/machinery/door/firedoor/glass/talon,
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/turf/simulated/floor/plating,
+/area/talon_v2/ofd_ops)
+"Bf" = (
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/maintenance/wing_starboard)
+"Bi" = (
+/obj/structure/table/rack/shelf/steel,
+/obj/item/clothing/suit/space/void/refurb/talon,
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_y = -26
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/secure_storage)
+"Bj" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/aft_starboard)
+"Bm" = (
+/obj/structure/hull_corner{
+	dir = 8
+	},
+/turf/space,
+/area/space)
+"Bn" = (
+/obj/machinery/atmospherics/binary/pump/on{
+	dir = 8;
+	name = "Air to Distro"
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/atmospherics)
+"Bq" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/bridge)
+"Bt" = (
+/obj/structure/table/steel,
+/obj/item/device/radio/off{
+	channels = list("Talon" = 1);
+	pixel_y = 6
+	},
+/obj/item/device/radio/off{
+	channels = list("Talon" = 1);
+	pixel_x = -6;
+	pixel_y = 4
+	},
+/obj/item/device/radio/off{
+	channels = list("Talon" = 1);
+	pixel_x = 6;
+	pixel_y = 4
+	},
+/obj/item/device/radio/off{
+	channels = list("Talon" = 1)
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/secure_storage)
+"Bu" = (
+/obj/machinery/alarm/talon{
+	dir = 1;
+	pixel_y = -25
+	},
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/secure_storage)
+"Bv" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/maintenance/wing_port)
+"Bw" = (
+/turf/simulated/wall/shull,
+/area/talon_v2/workroom)
+"By" = (
+/obj/structure/extinguisher_cabinet{
+	dir = 8;
+	pixel_x = 30
+	},
+/obj/structure/flora/pottedplant/orientaltree,
+/turf/simulated/floor/wood,
+/area/talon_v2/crew_quarters/bar)
+"Bz" = (
+/obj/machinery/atmospherics/pipe/manifold/visible{
+	dir = 1
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/atmospherics)
+"BC" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/alarm/talon{
+	dir = 8;
+	pixel_x = 22
+	},
+/obj/random/multiple/corp_crate/talon_cargo,
+/obj/structure/railing/grey,
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/maintenance/wing_port)
+"BD" = (
+/obj/machinery/door/firedoor/glass/talon,
+/obj/machinery/door/airlock/maintenance/engi{
+	name = "Talon Atmospherics Maintenance Access";
+	req_one_access = list(301)
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/atmospherics)
+"BH" = (
+/obj/structure/closet/wardrobe/black{
+	starts_with = list(/obj/item/clothing/under/color/black = 4, /obj/item/clothing/accessory/storage/black_vest = 4, /obj/item/clothing/accessory/storage/black_drop_pouches = 4, /obj/item/clothing/gloves/black = 4, /obj/item/clothing/head/soft/black = 4, /obj/item/clothing/mask/balaclava = 4, /obj/item/clothing/mask/bandana = 4, /obj/item/clothing/mask/gas/commando = 4, /obj/item/weapon/storage/backpack/messenger/black = 4, /obj/item/weapon/storage/backpack/dufflebag = 4, /obj/item/clothing/shoes/black = 4, /obj/item/clothing/shoes/boots/duty = 4)
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/crew_quarters/restrooms)
+"BI" = (
+/obj/machinery/atmospherics/portables_connector,
+/obj/effect/floor_decal/industrial/outline,
+/obj/machinery/portable_atmospherics/powered/pump/filled,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/atmospherics)
+"BK" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 1;
+	pixel_y = -32
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/hangar)
+"BO" = (
+/obj/machinery/power/apc/talon{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -28
+	},
+/obj/structure/table/standard,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -25
+	},
+/obj/machinery/recharger,
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/tiled/white,
+/area/talon_v2/medical)
+"BT" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/talon_v2/medical)
+"BU" = (
+/obj/structure/table/standard,
+/obj/item/weapon/storage/firstaid/regular,
+/obj/item/weapon/storage/firstaid/adv{
+	pixel_x = 2;
+	pixel_y = 5
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/structure/closet/walllocker_double/medical/south,
+/turf/simulated/floor/tiled/white,
+/area/talon_v2/medical)
+"BV" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/maintenance/wing_port)
+"BW" = (
+/obj/structure/panic_button,
+/obj/structure/table/steel,
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/talonpod)
+"BX" = (
+/obj/structure/table/standard,
+/obj/item/weapon/storage/firstaid/surgery,
+/obj/item/stack/nanopaste{
+	pixel_x = -7;
+	pixel_y = -4
+	},
+/obj/item/stack/nanopaste{
+	pixel_x = 9;
+	pixel_y = -4
+	},
+/obj/item/device/robotanalyzer{
+	pixel_y = -8
+	},
+/obj/machinery/alarm/talon{
+	dir = 8;
+	pixel_x = 22
+	},
+/turf/simulated/floor/tiled/white,
+/area/talon_v2/medical)
+"BY" = (
+/obj/structure/bed/chair/wood,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/carpet/blucarpet,
+/area/talon_v2/crew_quarters/cap_room)
+"BZ" = (
+/obj/machinery/light/small,
+/obj/structure/railing/grey{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/refining)
+"Cb" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/secure_storage)
+"Cd" = (
+/obj/structure/closet/secure_closet/talon_pilot,
+/obj/item/device/radio/off{
+	channels = list("Talon" = 1)
+	},
+/turf/simulated/floor/wood,
+/area/talon_v2/crew_quarters/pilot_room)
+"Cf" = (
+/obj/structure/table/rack/steel,
+/obj/item/clothing/suit/space/anomaly,
+/obj/item/clothing/head/helmet/space/anomaly,
+/obj/item/clothing/mask/breath,
+/obj/item/weapon/storage/belt/archaeology,
+/obj/machinery/light_switch{
+	pixel_y = 24
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/anomaly_storage)
+"Ck" = (
+/obj/machinery/ntnet_relay,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/engineering)
+"Cq" = (
+/obj/structure/table/standard,
+/obj/machinery/chemical_dispenser/biochemistry/full,
+/turf/simulated/floor/tiled/white,
+/area/talon_v2/medical)
+"Cr" = (
+/obj/structure/railing/grey{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/outline/red,
+/obj/machinery/portable_atmospherics/canister/empty/phoron,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/port_store)
+"Cv" = (
+/obj/structure/disposaloutlet{
+	dir = 1
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/talon_v2/ofd_ops)
+"Cy" = (
+/obj/structure/table/standard,
+/obj/item/device/defib_kit/jumper_kit/loaded,
+/obj/item/device/defib_kit/loaded,
+/obj/item/weapon/storage/belt/medical/emt,
+/obj/item/device/sleevemate,
+/turf/simulated/floor/tiled/white,
+/area/talon_v2/medical)
+"CA" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/effect/catwalk_plated,
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/structure/sign/directions/engineering/atmospherics{
+	pixel_x = -32
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/central_hallway)
+"CB" = (
+/obj/effect/floor_decal/emblem/talon_big{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/central_hallway/fore)
+"CC" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/atmospherics)
+"CE" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/handrail{
+	dir = 4
+	},
+/obj/structure/closet/emergsuit_wall{
+	dir = 8;
+	pixel_x = -32
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/maintenance/wing_port)
+"CF" = (
+/obj/item/weapon/storage/box/bodybags,
+/obj/item/roller,
+/obj/item/roller{
+	pixel_y = 8
+	},
+/obj/structure/table/standard,
+/turf/simulated/floor/tiled/white,
+/area/talon_v2/medical)
+"CH" = (
+/obj/structure/table/standard,
+/obj/machinery/recharger,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -25
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/workroom)
+"CI" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/workroom)
+"CJ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/aft_port)
+"CK" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/catwalk,
+/obj/structure/closet/walllocker_double/west,
+/obj/item/weapon/cell/apc,
+/obj/item/weapon/cell/apc,
+/obj/random/maintenance/engineering,
+/obj/random/maintenance/engineering,
+/obj/item/device/radio/off{
+	channels = list("Talon" = 1)
+	},
+/obj/item/clothing/suit/radiation,
+/obj/item/clothing/head/radiation,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering)
+"CM" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/engineering/star_store)
+"CN" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/noticeboard{
+	pixel_x = -32
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway/fore)
+"CO" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway)
+"CP" = (
+/obj/machinery/suit_cycler/vintage/tcrew,
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/secure_storage)
+"CR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -10394,8 +8768,952 @@
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
+/area/talon_v2/engineering/atmospherics)
+"CS" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/workroom)
+"CU" = (
+/obj/item/modular_computer/console/preset/talon{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/workroom)
+"CV" = (
+/obj/machinery/power/apc/talon{
+	name = "south bump";
+	pixel_y = -24
+	},
+/obj/structure/table/standard,
+/obj/item/weapon/paper_bin,
+/obj/item/weapon/pen,
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/workroom)
+"CX" = (
+/obj/machinery/disperser/front{
+	dir = 1
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/talon_v2/ofd_ops)
+"CY" = (
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/maintenance/wing_port)
+"Dd" = (
+/turf/simulated/wall/shull,
+/area/talon_v2/secure_storage)
+"Dg" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/wall/rshull,
+/area/talon_v2/maintenance/aft_starboard)
+"Di" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/maintenance/wing_port)
+"Dj" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/hangar)
+"Dk" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/holoposter{
+	dir = 1;
+	pixel_y = 32
+	},
+/turf/simulated/floor/wood,
+/area/talon_v2/crew_quarters/bar)
+"Dl" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/maintenance/wing_starboard)
+"Dm" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/wall/rshull,
+/area/talon_v2/maintenance/wing_starboard)
+"Dq" = (
+/turf/simulated/wall/rshull,
+/area/talon_v2/maintenance/aft_starboard)
+"Ds" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/atmospherics)
+"Du" = (
+/obj/effect/floor_decal/emblem/talon,
+/turf/simulated/wall/rshull,
+/area/talon_v2/maintenance/wing_starboard)
+"Dx" = (
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/workroom)
+"Dy" = (
+/obj/effect/map_helper/airlock/atmos/chamber_pump,
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/aux,
+/obj/structure/handrail,
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/maintenance/wing_port)
+"DB" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/railing/grey,
+/obj/random/multiple/corp_crate/talon_cargo,
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/maintenance/wing_port)
+"DC" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/glass/talon,
+/obj/machinery/door/blast/regular/open{
+	id = "talon_boat_cockpit"
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/talonboat)
+"DD" = (
+/turf/simulated/wall/shull,
+/area/talon_v2/maintenance/aft_starboard)
+"DG" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway/fore)
+"DH" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/aux{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/ofd_ops)
+"DI" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/camera/network/talon,
+/obj/random/multiple/corp_crate/talon_cargo,
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/maintenance/wing_starboard)
+"DK" = (
+/obj/structure/bed/chair/bay/chair{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/ofd_ops)
+"DM" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/atmospherics)
+"DN" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/aft_port)
+"DP" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/catwalk,
+/obj/machinery/light_switch{
+	pixel_y = 24
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/atmospherics)
+"DR" = (
+/obj/structure/railing/grey{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/atmospherics)
+"DU" = (
+/obj/effect/floor_decal/corner/black/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/talon_v2/crew_quarters/bar)
+"DV" = (
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 9
+	},
+/turf/simulated/floor/reinforced/airless,
 /area/talon_v2/engineering/starboard)
-"Im" = (
+"DW" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/maintenance/wing_port)
+"DX" = (
+/obj/machinery/camera/network/talon{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway)
+"DY" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/railing/grey,
+/obj/random/multiple/corp_crate/talon_cargo,
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/maintenance/wing_starboard)
+"DZ" = (
+/obj/structure/closet/secure_closet/talon_captain,
+/obj/item/device/radio/off{
+	channels = list("Talon" = 1)
+	},
+/turf/simulated/floor/wood,
+/area/talon_v2/crew_quarters/cap_room)
+"Ea" = (
+/obj/structure/railing/grey{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/bridge)
+"Ee" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/visible/yellow,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/starboard)
+"Ef" = (
+/obj/structure/table/rack/shelf/steel,
+/obj/item/weapon/gun/energy/gun/burst,
+/obj/item/weapon/cell/device/weapon{
+	pixel_x = -5;
+	pixel_y = 2
+	},
+/obj/item/weapon/cell/device/weapon,
+/obj/item/clothing/accessory/holster/waist,
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_y = -26
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/armory)
+"Ei" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/refining)
+"Ej" = (
+/obj/structure/table/rack/steel,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/star_store)
+"Ek" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/wood,
+/area/talon_v2/crew_quarters/pilot_room)
+"En" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/brig)
+"Eo" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/central_hallway)
+"Ep" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/structure/closet/walllocker_double/hydrant/west,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/port_store)
+"Eq" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/central_hallway/fore)
+"Er" = (
+/obj/structure/loot_pile/maint/boxfort,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/port_store)
+"Ev" = (
+/obj/effect/map_helper/airlock/atmos/chamber_pump,
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/aux,
+/obj/structure/handrail,
+/obj/effect/floor_decal/industrial/warning/corner,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/maintenance/wing_starboard)
+"Ew" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/camera/network/talon,
+/obj/machinery/atm{
+	pixel_y = 31
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway/port)
+"Ey" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id = "talon_brig2";
+	name = "Cell Shutters";
+	opacity = 0
+	},
+/obj/machinery/door/firedoor/glass/talon,
+/turf/simulated/floor/plating,
+/area/talon_v2/brig)
+"EB" = (
+/obj/effect/shuttle_landmark/premade/talon_v2_wing_port,
+/turf/simulated/floor/reinforced/airless,
+/area/space)
+"ED" = (
+/obj/machinery/door/window/brigdoor/eastleft{
+	dir = 1;
+	req_access = list(301)
+	},
+/obj/machinery/door/window/brigdoor/eastleft{
+	dir = 2;
+	req_access = list(301)
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id = "talon_brig2";
+	name = "Cell Shutters";
+	opacity = 0
+	},
+/obj/machinery/door/firedoor/glass/talon,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/brig)
+"EE" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/catwalk,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/aft_port)
+"EF" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/aux{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/maintenance/wing_port)
+"EH" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/aux,
+/obj/machinery/recharge_station,
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/central_hallway/fore)
+"EI" = (
+/obj/structure/catwalk,
+/obj/structure/railing/grey,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/atmospherics)
+"EJ" = (
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/aux,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/maintenance/wing_port)
+"EL" = (
+/obj/machinery/power/apc/talon{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -28
+	},
+/obj/structure/cable/green,
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/structure/handrail{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/maintenance/wing_port)
+"EN" = (
+/obj/machinery/door/firedoor/glass/talon,
+/obj/machinery/door/airlock/command{
+	id_tag = "talon_capdoor";
+	name = "Captain's Cabin";
+	req_one_access = list(301)
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/bridge)
+"EO" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/structure/closet/emergsuit_wall{
+	dir = 8;
+	pixel_x = -32
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/port)
+"EP" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/maintenance/wing_port)
+"ES" = (
+/obj/structure/table/rack/shelf/steel,
+/obj/item/clothing/shoes/magboots,
+/obj/item/clothing/shoes/magboots,
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/secure_storage)
+"ET" = (
+/obj/structure/railing/grey,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 8;
+	pixel_x = 30
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/bridge)
+"EV" = (
+/obj/structure/table/rack/steel,
+/obj/item/clothing/shoes/leg_guard/combat,
+/obj/item/clothing/gloves/arm_guard/combat,
+/obj/item/clothing/under/syndicate/combat,
+/obj/item/clothing/suit/armor/combat,
+/obj/item/clothing/head/helmet/combat,
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/armory)
+"EX" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/maintenance/wing_port)
+"EY" = (
+/obj/structure/extinguisher_cabinet{
+	dir = 1;
+	pixel_y = -32
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/port_store)
+"Fa" = (
+/obj/effect/map_helper/airlock/sensor/ext_sensor,
+/obj/machinery/airlock_sensor{
+	pixel_x = 28;
+	pixel_y = 28;
+	req_one_access = list(301)
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/reinforced/airless,
+/area/talon_v2/maintenance/aft_starboard)
+"Fc" = (
+/obj/structure/table/rack/shelf/steel,
+/obj/item/weapon/tank/oxygen,
+/obj/item/weapon/tank/oxygen,
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/secure_storage)
+"Fd" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/obj/structure/sign/directions/bar{
+	dir = 1;
+	pixel_x = -32;
+	pixel_y = -3
+	},
+/obj/structure/sign/directions/bridge{
+	dir = 1;
+	pixel_x = -32;
+	pixel_y = 3
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway)
+"Fe" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/effect/catwalk_plated,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/central_hallway/star)
+"Ff" = (
+/turf/simulated/wall/tgmc/rwall,
+/area/shuttle/talonpod)
+"Fg" = (
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 1
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/space)
+"Fh" = (
+/obj/structure/sign/warning/airlock{
+	pixel_x = 32
+	},
+/obj/effect/floor_decal/industrial/warning,
+/obj/structure/handrail{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/maintenance/wing_starboard)
+"Fj" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/closet/walllocker/medical/north,
+/obj/item/weapon/storage/firstaid/regular,
+/obj/item/weapon/storage/firstaid/o2,
+/obj/item/device/radio/off{
+	channels = list("Talon" = 1)
+	},
+/turf/simulated/floor/wood,
+/area/talon_v2/crew_quarters/cap_room)
+"Fk" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/maintenance/wing_port)
+"Fn" = (
+/turf/simulated/floor/tiled/white,
+/area/talon_v2/medical)
+"Fo" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway)
+"Fq" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/talon_v2/crew_quarters/med_room)
+"Fr" = (
+/obj/machinery/mineral/processing_unit{
+	points_mult = 0
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/refining)
+"Ft" = (
+/obj/machinery/door/firedoor/glass/talon,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway/port)
+"Fv" = (
+/obj/machinery/power/apc/talon{
+	name = "south bump";
+	pixel_y = -24
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/handrail{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/bridge)
+"Fw" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 4
+	},
+/obj/effect/catwalk_plated/dark,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/port)
+"Fx" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/power/apc/talon{
+	name = "south bump";
+	pixel_y = -24
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway)
+"Fy" = (
+/obj/machinery/door/firedoor/glass/talon,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/airlock/voidcraft{
+	name = "Cabin Access";
+	req_one_access = list(301)
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/talonboat)
+"Fz" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/aux,
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/structure/ship_munition/disperser_charge/emp,
+/turf/simulated/floor/reinforced,
+/area/talon_v2/ofd_ops)
+"FB" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	layer = 3.3;
+	pixel_y = 26
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway/port)
+"FC" = (
+/obj/machinery/drone_fabricator/talon,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/port_store)
+"FG" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/port_store)
+"FK" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc/talon{
+	dir = 1;
+	name = "north bump";
+	pixel_y = 28
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway/port)
+"FM" = (
+/obj/machinery/washing_machine,
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/crew_quarters/restrooms)
+"FN" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/random/multiple/corp_crate/talon_cargo,
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/maintenance/wing_port)
+"FO" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/closet/walllocker_double/hydrant/north,
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway/port)
+"FP" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/structure/catwalk,
+/obj/structure/extinguisher_cabinet{
+	dir = 1;
+	pixel_y = -32
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/starboard)
+"FT" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway)
+"FU" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/star_store)
+"FX" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/structure/sign/directions/security{
+	dir = 8;
+	pixel_x = -32;
+	pixel_y = 3
+	},
+/obj/structure/sign/directions/security/brig{
+	dir = 8;
+	pixel_x = -32;
+	pixel_y = -3
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway)
+"FY" = (
+/obj/machinery/power/apc/talon{
+	dir = 1;
+	name = "north bump";
+	pixel_y = 28
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 6
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/port)
+"FZ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway/port)
+"Ga" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/sign/directions/security/armory{
+	pixel_x = -32
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway)
+"Gb" = (
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -10412,276 +9730,685 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/talon_v2/engineering)
-"In" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+"Gg" = (
+/obj/machinery/computer/ship/disperser{
 	dir = 8
 	},
+/obj/item/weapon/paper/talon_cannon,
+/obj/machinery/alarm/talon{
+	pixel_y = 24
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/ofd_ops)
+"Gi" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/bridge)
-"Io" = (
-/obj/machinery/atmospherics/portables_connector/aux,
-/obj/effect/floor_decal/industrial/outline,
-/obj/machinery/portable_atmospherics/canister/air,
-/turf/simulated/floor/plating,
-/area/talon_v2/maintenance/fore_port)
-"Ip" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/effect/floor_decal/corner/black/diagonal,
-/obj/item/weapon/stool/baystool/padded{
+/obj/structure/catwalk,
+/obj/machinery/light/small{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/white,
-/area/talon_v2/crew_quarters/bar)
-"Iq" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/port_store)
+"Gl" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/holoposter{
+	dir = 8;
+	pixel_x = -32
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/talon_v2/central_hallway)
-"Ir" = (
-/obj/structure/loot_pile/maint/boxfort,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/port_store)
-"Is" = (
-/obj/machinery/camera/network/talon{
-	dir = 1
+"Gm" = (
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
+/obj/effect/catwalk_plated,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/structure/safe/floor{
-	name = "smuggling compartment"
-	},
-/turf/simulated/floor/carpet/blucarpet,
-/area/talon_v2/crew_quarters/cap_room)
-"It" = (
-/obj/structure/closet/crate,
-/obj/structure/railing/grey,
-/obj/structure/extinguisher_cabinet{
-	dir = 4;
-	pixel_x = -30
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/refining)
-"Iu" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/workroom)
-"Iv" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/firedoor/glass/talon,
-/obj/machinery/door/airlock/maintenance/common,
-/turf/simulated/floor/plating,
-/area/talon_v2/maintenance/aft_port)
-"Ix" = (
-/obj/structure/bed/chair/bay/chair,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/brig)
-"Iz" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/maintenance/wing_starboard)
-"IC" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/railing/grey{
-	dir = 4
-	},
 /turf/simulated/floor/plating,
-/area/talon_v2/engineering/port_store)
-"ID" = (
-/obj/effect/floor_decal/industrial/warning/dust{
-	dir = 1
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/talon_v2/engineering/port)
-"IE" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/maintenance/wing_port)
-"IF" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/aux{
-	dir = 9
+/area/talon_v2/central_hallway/port)
+"Gn" = (
+/obj/machinery/power/apc/talon{
+	dir = 1;
+	name = "north bump";
+	pixel_y = 28
 	},
 /obj/structure/cable/green{
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/machinery/power/apc/talon{
-	name = "south bump";
-	pixel_y = -24
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/port_store)
+"Gp" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/starboard)
+"Gq" = (
+/obj/machinery/door/firedoor/glass/talon,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway/port)
+"Gr" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/maintenance/wing_starboard)
+"Gs" = (
+/obj/machinery/light_switch{
+	dir = 4;
+	pixel_x = -24
+	},
+/turf/simulated/floor/wood,
+/area/talon_v2/crew_quarters/sec_room)
+"Gu" = (
+/obj/structure/table/rack/steel,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/port_store)
+"Gv" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/aux{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/wing_starboard)
+"Gw" = (
+/obj/effect/floor_decal/emblem/talon_big{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/central_hallway/fore)
+"Gx" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 8;
+	pixel_x = 30
+	},
+/turf/simulated/floor/tiled/white,
+/area/talon_v2/medical)
+"Gy" = (
+/obj/effect/floor_decal/industrial/outline/red,
+/obj/machinery/atmospherics/portables_connector{
+	dir = 8
+	},
+/obj/structure/railing/grey,
+/obj/machinery/portable_atmospherics/canister/phoron/engine_setup,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/starboard)
+"Gz" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 4
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/space)
+"GA" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering)
+"GC" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway)
+"GE" = (
+/obj/machinery/atmospherics/binary/algae_farm/filled{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/atmospherics)
+"GH" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	layer = 3.3;
+	pixel_y = 26
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/gen_store)
+"GJ" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/structure/table/standard,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/obj/machinery/camera/network/talon{
+	dir = 4
+	},
+/obj/machinery/recharger,
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/crew_quarters/restrooms)
+"GK" = (
+/obj/structure/closet/emergsuit_wall{
+	dir = 1;
+	pixel_y = -32
+	},
+/turf/simulated/floor/wood,
+/area/talon_v2/crew_quarters/sec_room)
+"GP" = (
+/obj/machinery/power/smes/buildable/offmap_spawn{
+	RCon_tag = "Talon Port SMES"
 	},
 /obj/structure/cable/green{
 	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
-/area/talon_v2/maintenance/fore_starboard)
-"IG" = (
-/obj/machinery/atmospherics/pipe/simple/visible/universal{
-	name = "Waste to Filter"
+/area/talon_v2/engineering)
+"GQ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway)
+"GU" = (
+/obj/machinery/light,
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway/star)
+"GV" = (
+/obj/machinery/light/small,
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/talon_v2/engineering/atmospherics)
-"IJ" = (
+"GW" = (
+/obj/machinery/atmospherics/pipe/simple/visible/red,
 /obj/structure/catwalk,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
+/obj/structure/railing/grey,
 /turf/simulated/floor/plating,
-/area/talon_v2/maintenance/aft_starboard)
-"IK" = (
-/turf/simulated/wall/rshull,
-/area/talon_v2/engineering/generators)
-"IL" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/fuel{
-	dir = 1
+/area/talon_v2/engineering/atmospherics)
+"GY" = (
+/obj/structure/girder,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/atmospherics)
+"GZ" = (
+/obj/machinery/light/small{
+	dir = 8
 	},
-/turf/simulated/wall/rshull,
-/area/shuttle/talonboat)
-"IM" = (
+/obj/structure/table/rack/steel,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/star_store)
+"Ha" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/effect/floor_decal/industrial/outline/blue,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/atmospherics)
+"Hb" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/maintenance/wing_starboard)
+"Hc" = (
+/obj/structure/disposalpipe/trunk,
+/obj/machinery/disposal/wall,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/engineering)
+"Hf" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 6
 	},
 /obj/structure/catwalk,
-/obj/structure/disposalpipe/segment{
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/atmospherics)
+"Hg" = (
+/obj/machinery/conveyor{
 	dir = 8;
-	icon_state = "pipe-c"
+	id = "talonrefinery"
 	},
-/obj/structure/railing/grey{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/starboard)
-"IN" = (
-/obj/structure/table/steel,
-/obj/machinery/camera/network/talon,
-/obj/machinery/cell_charger,
-/obj/item/weapon/cell/apc,
+/obj/structure/plasticflaps,
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/engineering)
-"IP" = (
-/obj/structure/catwalk,
-/obj/structure/barricade,
-/turf/simulated/floor/plating,
-/area/talon_v2/maintenance/aft_port)
-"IR" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/aux{
+/area/talon_v2/refining)
+"Hh" = (
+/obj/structure/table/woodentable,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/obj/effect/map_helper/airlock/atmos/chamber_pump,
-/obj/structure/handrail{
-	dir = 1
+/obj/item/weapon/paper/talon_guard,
+/turf/simulated/floor/carpet,
+/area/talon_v2/crew_quarters/sec_room)
+"Hj" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/maintenance/fore_port)
-"IS" = (
-/obj/effect/floor_decal/industrial/warning/corner{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
+/obj/machinery/door/firedoor/glass/talon,
 /turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/anomaly_storage)
-"IU" = (
-/obj/structure/bookcase/manuals/research_and_development,
-/turf/simulated/floor/wood,
-/area/talon_v2/crew_quarters/meditation)
-"IW" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/sign/department/armory{
-	name = "GUARD'S QUARTERS";
+/area/talon_v2/hangar)
+"Hn" = (
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 10
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	layer = 3.3;
+	pixel_y = 26
+	},
+/obj/structure/catwalk,
+/obj/machinery/camera/network/talon,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/port)
+"Hq" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/closet/emergsuit_wall{
+	dir = 8;
 	pixel_x = -32
 	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/crew_quarters/restrooms)
+"Hr" = (
+/obj/effect/map_helper/airlock/sensor/chamber_sensor,
+/obj/machinery/airlock_sensor{
+	pixel_y = 24;
+	req_one_access = list(301)
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/aux{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 4
+	},
+/obj/structure/handrail,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/shuttle/talonboat)
+"Ht" = (
+/obj/machinery/door/firedoor/glass/talon,
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/turf/simulated/floor/plating,
+/area/talon_v2/ofd_ops)
+"Hu" = (
+/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
+	id_tag = "talon_boat";
+	pixel_y = 24
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/aux{
+	dir = 1
+	},
+/obj/structure/handrail,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/shuttle/talonboat)
+"Hv" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/structure/railing/grey{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering)
+"Hw" = (
+/obj/machinery/computer/ship/navigation,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/button/remote/blast_door{
+	id = "talon_bridge_shields";
+	name = "bridge blast shields";
+	pixel_y = 16
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/bridge)
+"Hx" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 4
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/starboard)
+"Hy" = (
+/obj/structure/handrail,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/aux{
+	dir = 4
+	},
+/obj/structure/closet/walllocker_double/survival/north,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/shuttle/talonboat)
+"Hz" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/glass/talon,
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/hangar)
+"HA" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway/fore)
-"IX" = (
-/obj/structure/table/rack/shelf/steel,
-/obj/item/clothing/shoes/magboots,
-/obj/item/clothing/shoes/magboots,
-/obj/item/clothing/shoes/magboots,
-/turf/simulated/floor/tiled/techfloor,
 /area/talon_v2/secure_storage)
-"IY" = (
+"HD" = (
+/obj/structure/disposaloutlet{
+	dir = 8
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/starboard)
+"HE" = (
+/obj/machinery/alarm/talon{
+	dir = 8;
+	pixel_x = 22
+	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/wood,
-/area/talon_v2/crew_quarters/eng_room)
-"Jd" = (
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 1
+/turf/simulated/floor/carpet/blucarpet,
+/area/talon_v2/crew_quarters/cap_room)
+"HF" = (
+/obj/machinery/power/apc/talon{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -28
 	},
-/obj/machinery/suspension_gen{
-	req_access = list(301)
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/anomaly_storage)
-"Jf" = (
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/crew_quarters/restrooms)
+"HG" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/closet/emergsuit_wall{
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway/star)
+"HH" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /obj/machinery/door/firedoor/glass/talon,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/sign/warning/nosmoking_1{
+	pixel_x = -26
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/engineering{
-	id_tag = "talon_engdoor";
-	name = "Engineer's Cabin";
+	name = "Talon Port Engines";
 	req_one_access = list(301)
 	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/engineering/star_store)
-"Ji" = (
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/port)
+"HI" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/loot_pile/maint/trash,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering)
+"HK" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/effect/catwalk_plated,
+/obj/structure/disposalpipe/junction,
+/obj/structure/sign/directions/engineering{
+	pixel_x = 32;
+	pixel_y = -3
+	},
+/obj/structure/sign/directions/engineering/atmospherics{
+	dir = 8;
+	pixel_x = 32;
+	pixel_y = 3
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/central_hallway)
+"HN" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway)
+"HS" = (
+/turf/simulated/wall/shull,
+/area/talon_v2/anomaly_storage)
+"HT" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/effect/catwalk_plated,
+/obj/structure/disposalpipe/junction{
+	dir = 2;
+	icon_state = "pipe-j2"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/central_hallway)
+"HU" = (
+/obj/machinery/door/firedoor/glass/talon,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway/star)
+"HV" = (
+/obj/machinery/alarm/talon{
+	dir = 1;
+	pixel_y = -25
+	},
+/obj/structure/table/rack/steel,
+/obj/item/weapon/grenade/spawnergrenade/manhacks/mercenary{
+	pixel_x = -5;
+	pixel_y = 4
+	},
+/obj/item/device/spaceflare,
+/obj/machinery/camera/network/talon{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/armory)
+"HW" = (
 /obj/machinery/door/firedoor/glass/talon,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -10695,17 +10422,1341 @@
 	},
 /turf/simulated/floor/plating,
 /area/talon_v2/engineering/port)
-"Jk" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
+"HX" = (
+/obj/machinery/vending/blood{
+	req_access = list(301);
+	req_log_access = 301
 	},
-/obj/structure/bed/chair/bay/chair{
+/turf/simulated/floor/tiled/white,
+/area/talon_v2/medical)
+"HY" = (
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/manifold/visible/yellow{
+	dir = 1
+	},
+/obj/structure/railing/grey{
 	dir = 8
 	},
-/turf/simulated/floor/carpet,
-/area/talon_v2/crew_quarters/pilot_room)
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/starboard)
+"HZ" = (
+/turf/simulated/wall/tgmc/window/rwall,
+/area/shuttle/talonpod)
+"Ia" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/holoposter{
+	dir = 1;
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway/star)
+"Id" = (
+/obj/structure/catwalk,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/fore_port)
+"Ie" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/fore_starboard)
+"If" = (
+/obj/structure/hull_corner/long_horiz{
+	dir = 10
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/space)
+"Ig" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/mineral/input,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/refining)
+"Ih" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway/star)
+"Ij" = (
+/obj/machinery/door/firedoor/glass/talon,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway/star)
+"Il" = (
+/obj/machinery/power/apc/talon{
+	dir = 1;
+	name = "north bump";
+	pixel_y = 28
+	},
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 10
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/starboard)
+"Im" = (
+/obj/structure/catwalk,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering)
+"In" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/bridge)
+"Ip" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/floor_decal/corner/black/diagonal,
+/obj/item/weapon/stool/baystool/padded{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/talon_v2/crew_quarters/bar)
+"Iq" = (
+/obj/machinery/camera/network/talon{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway)
+"Ir" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/port_store)
+"Is" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/maintenance/wing_starboard)
+"It" = (
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/obj/structure/ore_box,
+/obj/structure/railing/grey{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/refining)
+"Iu" = (
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/fore_starboard)
+"Iv" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/maintenance/wing_starboard)
+"Ix" = (
+/obj/structure/table/standard,
+/obj/item/weapon/storage/box/donut,
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/machinery/alarm/talon{
+	dir = 4;
+	pixel_x = -22
+	},
+/obj/machinery/firealarm{
+	layer = 3.3;
+	pixel_y = 26
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/brig)
+"Iz" = (
+/obj/structure/handrail,
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/maintenance/wing_starboard)
+"IA" = (
+/obj/machinery/atmospherics/pipe/manifold/visible{
+	dir = 4
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/atmospherics)
+"IC" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/port_store)
+"ID" = (
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 9
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/port)
+"IF" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/aux{
+	dir = 10
+	},
+/obj/structure/handrail,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/maintenance/fore_starboard)
+"IJ" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/maintenance/wing_starboard)
+"IK" = (
+/turf/simulated/wall/rshull,
+/area/talon_v2/engineering/generators)
+"IL" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/maintenance/wing_starboard)
+"IM" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering)
+"IN" = (
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/hangar)
+"IO" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/structure/catwalk,
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/aft_port)
+"IP" = (
+/turf/simulated/wall/shull,
+/area/talon_v2/maintenance/aft_port)
+"IS" = (
+/obj/machinery/door/firedoor/glass/talon,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/glass_research{
+	name = "Anomaly Storage";
+	req_one_access = list(301)
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/anomaly_storage)
+"IU" = (
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/aux,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/maintenance/wing_starboard)
+"IW" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
+/area/talon_v2/central_hallway/fore)
+"IY" = (
+/obj/structure/sign/warning/moving_parts{
+	pixel_y = -32
+	},
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "talonrefinery"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/refining)
+"Jd" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/aux{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/maintenance/wing_starboard)
+"Je" = (
+/obj/structure/handrail{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/maintenance/wing_starboard)
+"Jf" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/junction{
+	dir = 8;
+	icon_state = "pipe-j2"
+	},
+/turf/simulated/floor/wood,
+/area/talon_v2/crew_quarters/eng_room)
+"Ji" = (
+/obj/effect/shuttle_landmark/premade/talon_v2_wing_star,
+/turf/simulated/floor/reinforced/airless,
+/area/space)
+"Jk" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway/fore)
+"Jl" = (
+/obj/effect/map_helper/airlock/sensor/chamber_sensor,
+/obj/machinery/atmospherics/pipe/simple/hidden/aux{
+	dir = 5
+	},
+/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
+	dir = 1;
+	id_tag = "talon_starboard_aft";
+	pixel_y = -30;
+	req_one_access = list(301)
+	},
+/obj/machinery/airlock_sensor{
+	dir = 4;
+	pixel_x = -28;
+	req_one_access = list(301)
+	},
+/obj/machinery/light/small,
+/obj/structure/handrail{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning/corner,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/maintenance/aft_starboard)
 "Jm" = (
+/obj/effect/map_helper/airlock/atmos/chamber_pump,
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/aux{
+	dir = 1
+	},
+/obj/structure/handrail{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/machinery/embedded_controller/radio/airlock/docking_port{
+	dir = 1;
+	id_tag = "talon_port";
+	pixel_y = -30;
+	req_one_access = list(301)
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/maintenance/wing_port)
+"Jp" = (
+/obj/effect/map_helper/airlock/atmos/chamber_pump,
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/aux{
+	dir = 1
+	},
+/obj/machinery/light/small,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/maintenance/wing_port)
+"Jr" = (
+/obj/machinery/door/airlock/glass_external{
+	req_one_access = list(301)
+	},
+/obj/effect/map_helper/airlock/door/int_door,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/maintenance/wing_port)
+"Jt" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/aux,
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/maintenance/wing_port)
+"Ju" = (
+/obj/machinery/camera/network/talon{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/maintenance/wing_port)
+"Jv" = (
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/atmospherics)
+"Jw" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor/glass/talon,
+/obj/machinery/door/airlock/engineeringatmos{
+	name = "Talon Atmospherics";
+	req_one_access = list(301)
+	},
+/obj/structure/sign/warning/nosmoking_1{
+	pixel_x = 26
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/engineering/atmospherics)
+"Jy" = (
+/obj/effect/map_helper/airlock/sensor/chamber_sensor,
+/obj/machinery/atmospherics/pipe/simple/hidden/aux{
+	dir = 9
+	},
+/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
+	dir = 1;
+	id_tag = "talon_port_aft";
+	pixel_y = -30;
+	req_one_access = list(301)
+	},
+/obj/machinery/airlock_sensor{
+	dir = 8;
+	pixel_x = 28;
+	req_one_access = list(301)
+	},
+/obj/machinery/light/small,
+/obj/structure/handrail{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/maintenance/aft_port)
+"Jz" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/space)
+"JA" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/glass/talon,
+/obj/machinery/door/blast/regular/open{
+	dir = 4;
+	id = "talon_boat_cockpit"
+	},
+/obj/structure/window/reinforced,
+/turf/simulated/floor/plating,
+/area/shuttle/talonboat)
+"JB" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/maintenance/wing_port)
+"JC" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/computer/shuttle_control/explore/talonboat{
+	dir = 4;
+	name = "boat remote control console"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/central_hallway)
+"JI" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/talon_v2/crew_quarters/restrooms)
+"JJ" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/maintenance/wing_port)
+"JK" = (
+/obj/structure/railing/grey{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/refining)
+"JL" = (
+/turf/simulated/wall/shull,
+/area/talon_v2/ofd_ops)
+"JM" = (
+/obj/machinery/atmospherics/pipe/simple/visible/yellow,
+/turf/simulated/wall/rshull,
+/area/talon_v2/engineering/starboard)
+"JN" = (
+/obj/structure/catwalk,
+/obj/structure/barricade,
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/aft_starboard)
+"JO" = (
+/obj/machinery/computer/ship/sensors{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/bridge)
+"JQ" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/maintenance/wing_port)
+"JR" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/yellow,
+/obj/machinery/alarm/talon{
+	dir = 4;
+	pixel_x = -22
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/port)
+"JU" = (
+/obj/machinery/atmospherics/binary/pump/high_power/on,
+/obj/structure/railing/grey{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/starboard)
+"JV" = (
+/obj/effect/map_helper/airlock/door/int_door,
+/obj/machinery/door/airlock/glass_external{
+	req_one_access = list(301)
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/aux{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/maintenance/wing_starboard)
+"JZ" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway/fore)
+"Ke" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/holoposter{
+	pixel_y = -32
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway/port)
+"Kf" = (
+/obj/machinery/door/firedoor/glass/talon,
+/obj/machinery/door/airlock/multi_tile/glass{
+	dir = 1;
+	name = "Cargo Bay";
+	req_one_access = list(301)
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway/port)
+"Kg" = (
+/obj/machinery/light_switch{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/simulated/floor/wood,
+/area/talon_v2/crew_quarters/cap_room)
+"Kk" = (
+/obj/machinery/door/airlock/glass_external{
+	req_one_access = list(301)
+	},
+/obj/effect/map_helper/airlock/door/ext_door,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/maintenance/fore_port)
+"Km" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/aux{
+	dir = 8
+	},
+/obj/effect/map_helper/airlock/atmos/chamber_pump,
+/obj/structure/handrail{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/maintenance/aft_starboard)
+"Kn" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 1;
+	pixel_y = -32
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway/port)
+"Ko" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway/port)
+"Kp" = (
+/obj/machinery/chem_master,
+/turf/simulated/floor/tiled/white,
+/area/talon_v2/medical)
+"Ks" = (
+/obj/machinery/door/firedoor/glass/talon,
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/hangar)
+"Kv" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/alarm/talon{
+	dir = 1;
+	pixel_y = -25
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway/port)
+"Kx" = (
+/obj/machinery/recharger/wallcharger{
+	pixel_x = 5;
+	pixel_y = 24
+	},
+/obj/structure/table/rack/shelf/steel,
+/obj/item/device/radio/off{
+	channels = list("Talon" = 1);
+	pixel_y = 6
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/armory)
+"Kz" = (
+/obj/machinery/holoposter{
+	dir = 8;
+	pixel_x = -32
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway/fore)
+"KB" = (
+/turf/simulated/wall/shull,
+/area/talon_v2/maintenance/fore_port)
+"KC" = (
+/obj/structure/closet/walllocker_double/hydrant/west,
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/secure_storage)
+"KE" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/glass/talon,
+/obj/machinery/door/airlock/multi_tile/glass{
+	dir = 1;
+	req_one_access = list(301)
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway/port)
+"KH" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/port_store)
+"KI" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway)
+"KJ" = (
+/obj/structure/table/bench/wooden,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/wood,
+/area/talon_v2/crew_quarters/cap_room)
+"KM" = (
+/obj/structure/table/rack/shelf/steel,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/port_store)
+"KN" = (
+/obj/structure/table/steel,
+/obj/item/weapon/pickaxe/drill,
+/obj/machinery/button/remote/blast_door{
+	id = "talon_boat_cockpit";
+	pixel_x = 6;
+	pixel_y = 28
+	},
+/obj/item/device/radio/off{
+	channels = list("Talon" = 1)
+	},
+/obj/machinery/embedded_controller/radio/simple_docking_controller{
+	frequency = 1380;
+	id_tag = "talonboat_docker";
+	pixel_x = -6;
+	pixel_y = 24
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/talonboat)
+"KO" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway)
+"KQ" = (
+/obj/structure/railing/grey,
+/obj/effect/floor_decal/emblem/talon,
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/bridge)
+"KS" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/outline,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/atmospherics)
+"KT" = (
+/obj/machinery/atmospherics/portables_connector/aux,
+/obj/effect/floor_decal/industrial/outline,
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/structure/railing/grey,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/star_store)
+"KU" = (
+/turf/simulated/wall/shull,
+/area/talon_v2/engineering/port_store)
+"KX" = (
+/obj/machinery/door/airlock/multi_tile/glass{
+	dir = 1;
+	name = "Hangar Bay";
+	req_one_access = list(301)
+	},
+/obj/machinery/door/firedoor/glass/talon,
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/hangar)
+"KY" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/aux{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/shuttle/talonboat)
+"KZ" = (
+/obj/effect/map_helper/airlock/sensor/int_sensor,
+/obj/machinery/atmospherics/pipe/simple/hidden/aux{
+	dir = 6
+	},
+/obj/machinery/airlock_sensor{
+	dir = 4;
+	pixel_x = -28;
+	req_one_access = list(301)
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/aft_starboard)
+"Lc" = (
+/obj/effect/map_helper/airlock/atmos/chamber_pump,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/aux{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/shuttle/talonboat)
+"Le" = (
+/obj/machinery/door/firedoor/glass/talon,
+/obj/machinery/door/airlock/multi_tile/glass{
+	dir = 1;
+	req_one_access = list(301)
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway/star)
+"Lg" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway/star)
+"Li" = (
+/obj/structure/flora/pottedplant/minitree,
+/obj/machinery/holoposter{
+	dir = 1;
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/central_hallway)
+"Lj" = (
+/obj/structure/sign/directions/cargo/refinery{
+	pixel_y = -32
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway/star)
+"Lk" = (
+/obj/machinery/door/firedoor/glass/talon,
+/obj/machinery/door/airlock/maintenance/common,
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/aft_starboard)
+"Ll" = (
+/obj/structure/table/woodentable,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/item/weapon/paper/talon_power,
+/turf/simulated/floor/carpet,
+/area/talon_v2/crew_quarters/eng_room)
+"Ln" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/outline/red,
+/obj/machinery/portable_atmospherics/powered/scrubber,
+/obj/structure/railing/grey{
+	dir = 8
+	},
+/obj/structure/railing/grey,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/atmospherics)
+"Lo" = (
+/obj/machinery/holoposter{
+	pixel_y = -32
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway/star)
+"Lr" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/hangar)
+"Ls" = (
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/pointdefense{
+	id_tag = "talon_pd"
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/space)
+"Lu" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/engineering/star_store)
+"Lv" = (
+/obj/structure/cable/yellow,
+/obj/machinery/power/rtg/advanced,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/generators)
+"Lw" = (
+/obj/machinery/door/firedoor/glass/talon,
+/obj/machinery/door/airlock/maintenance/engi{
+	name = "Starboard Eng. Storage";
+	req_one_access = list(301)
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/star_store)
+"Lx" = (
+/obj/machinery/door/firedoor/glass/talon,
+/obj/machinery/door/airlock/glass{
+	name = "Workroom"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/workroom)
+"Ly" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/closet/walllocker_double/hydrant/north,
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway/star)
+"Lz" = (
+/obj/machinery/power/apc/talon{
+	name = "south bump";
+	pixel_y = -24
+	},
+/obj/structure/cable/green,
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway/star)
+"LA" = (
+/obj/machinery/alarm/talon{
+	dir = 1;
+	pixel_y = -25
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway/star)
+"LB" = (
+/obj/machinery/door/firedoor/glass/talon,
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/door/blast/regular/open{
+	dir = 2;
+	id = "talon_bridge_shields"
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/bridge)
+"LC" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway/fore)
+"LD" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/sign/directions/medical{
+	dir = 4;
+	pixel_x = 32;
+	pixel_y = -3
+	},
+/obj/structure/sign/directions/engineering{
+	pixel_x = 32;
+	pixel_y = 3
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway)
+"LF" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	layer = 3.3;
+	pixel_y = 26
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway/star)
+"LH" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/door/blast/regular/open{
+	id = "talon_windows"
+	},
+/obj/machinery/door/firedoor/glass/talon,
+/turf/simulated/floor/plating,
+/area/talon_v2/crew_quarters/bar)
+"LI" = (
+/obj/machinery/door/firedoor/glass/talon,
+/obj/machinery/door/airlock/multi_tile/glass{
+	dir = 1;
+	name = "Cargo Bay";
+	req_one_access = list(301)
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway/star)
+"LJ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/cable/yellow{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/generators)
+"LL" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/fore_port)
+"LM" = (
+/obj/machinery/atmospherics/binary/pump/fuel,
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/talonboat)
+"LN" = (
+/obj/structure/table/steel,
+/obj/machinery/camera/network/talon,
+/obj/machinery/cell_charger,
+/obj/item/weapon/cell/apc,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/engineering)
+"LO" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/aft_port)
+"LQ" = (
 /obj/effect/map_helper/airlock/door/ext_door,
 /obj/machinery/door/airlock/glass_external{
 	req_one_access = list(301)
@@ -10733,787 +11784,55 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/shuttle/talonboat)
-"Jp" = (
-/obj/structure/closet/excavation,
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/anomaly_storage)
-"Jr" = (
+"LR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
-/obj/structure/catwalk,
-/obj/machinery/light/small{
-	dir = 4
+/obj/machinery/alarm/talon{
+	pixel_y = 28
+	},
+/turf/simulated/floor/wood,
+/area/talon_v2/crew_quarters/eng_room)
+"LT" = (
+/obj/structure/table/rack/shelf/steel,
+/obj/random/maintenance/cargo,
+/obj/random/maintenance/cargo,
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/gen_store)
+"LU" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/structure/cable/green{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/plating,
-/area/talon_v2/maintenance/aft_port)
-"Jt" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/effect/catwalk_plated,
 /obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/workroom)
-"Ju" = (
-/obj/machinery/conveyor{
-	dir = 8;
-	id = "talonrefinery"
-	},
-/obj/structure/plasticflaps,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/refining)
-"Jv" = (
-/obj/machinery/atmospherics/pipe/manifold/visible{
-	dir = 1
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/atmospherics)
-"Jw" = (
-/obj/machinery/atmospherics/pipe/simple/visible/red{
-	dir = 9
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/atmospherics)
-"Jz" = (
-/obj/effect/map_helper/airlock/atmos/chamber_pump,
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/aux{
-	dir = 1
-	},
-/obj/structure/handrail{
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/maintenance/wing_port)
-"JA" = (
-/obj/machinery/door/firedoor/glass/talon,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/airlock/voidcraft{
-	name = "Cabin Access";
-	req_one_access = list(301)
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/shuttle/talonboat)
-"JB" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/catwalk,
-/obj/machinery/light/small{
 	dir = 4
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/maintenance/aft_port)
-"JC" = (
-/obj/machinery/computer/ship/helm{
-	req_one_access = list(301)
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/shuttle/talonboat)
-"JE" = (
-/obj/machinery/power/apc/talon{
-	dir = 1;
-	name = "north bump";
-	pixel_y = 28
-	},
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/structure/table/standard,
-/obj/machinery/recharger,
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/central_hallway/fore)
-"JF" = (
-/obj/structure/catwalk,
-/obj/structure/trash_pile,
-/obj/structure/railing/grey{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/maintenance/fore_port)
-"JG" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/closet/crate,
-/obj/random/maintenance/clean,
-/obj/random/maintenance/clean,
-/obj/random/maintenance/clean,
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/gen_store)
-"JH" = (
-/obj/structure/extinguisher_cabinet{
-	dir = 1;
+/obj/structure/sign/department/medbay{
 	pixel_y = 32
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/workroom)
-"JI" = (
-/obj/machinery/door/airlock/medical{
-	name = "Medical Storage";
-	req_one_access = list(301)
-	},
-/obj/machinery/door/firedoor/glass/talon,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/talon_v2/medical)
-"JJ" = (
-/obj/effect/map_helper/airlock/sensor/ext_sensor,
-/obj/machinery/airlock_sensor{
-	dir = 4;
-	pixel_x = -28;
-	pixel_y = 28;
-	req_one_access = list(301)
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/reinforced/airless,
-/area/talon_v2/maintenance/fore_starboard)
-"JK" = (
-/obj/machinery/suit_cycler/vintage/tengi,
-/turf/simulated/floor/wood,
-/area/talon_v2/crew_quarters/eng_room)
-"JL" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway/fore)
-"JO" = (
-/turf/simulated/wall/rshull,
-/area/talon_v2/bridge)
-"JP" = (
-/obj/machinery/door/blast/regular/open{
-	dir = 2;
-	id = "talon_bridge_shields"
-	},
-/obj/effect/floor_decal/industrial/warning/dust{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/warning/dust{
-	dir = 4
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/talon_v2/bridge)
-"JQ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 10
-	},
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 4
-	},
 /turf/simulated/floor/plating,
-/area/talon_v2/engineering/port)
-"JT" = (
-/obj/structure/table/rack/steel,
-/obj/item/clothing/shoes/magboots,
-/obj/item/clothing/suit/space/syndicate/black,
-/obj/item/clothing/head/helmet/space/syndicate/black,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/armory)
-"JV" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/aux{
-	dir = 4
-	},
-/obj/structure/closet/emergsuit_wall{
-	dir = 1;
-	pixel_y = -32
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/maintenance/wing_starboard)
-"JW" = (
-/obj/structure/catwalk,
-/obj/structure/handrail,
-/turf/simulated/floor/reinforced/airless,
-/area/talon_v2/maintenance/aft_starboard)
-"JX" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/machinery/door/firedoor/glass/talon,
-/turf/simulated/floor/plating,
-/area/talon_v2/secure_storage)
-"Ka" = (
-/turf/simulated/wall/shull,
-/area/talon_v2/maintenance/fore_starboard)
-"Kc" = (
-/obj/structure/table/steel,
-/obj/structure/closet/autolok_wall{
-	dir = 1;
-	pixel_y = -32
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/shuttle/talonboat)
-"Kd" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/talon_v2/maintenance/fore_starboard)
-"Ke" = (
-/obj/machinery/alarm/talon{
-	dir = 8;
-	pixel_x = 22
-	},
-/obj/structure/flora/pottedplant,
-/turf/simulated/floor/wood,
-/area/talon_v2/crew_quarters/meditation)
-"Kf" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/catwalk,
-/obj/machinery/light/small,
-/turf/simulated/floor/plating,
-/area/talon_v2/maintenance/fore_port)
-"Kg" = (
-/obj/structure/closet/secure_closet/talon_captain,
-/obj/item/device/radio/off{
-	channels = list("Talon" = 1)
-	},
-/turf/simulated/floor/wood,
-/area/talon_v2/crew_quarters/cap_room)
-"Kh" = (
-/obj/machinery/door/firedoor/glass/talon,
-/obj/structure/sign/directions/bridge{
-	dir = 1;
-	pixel_x = 32;
-	pixel_y = 3
-	},
-/obj/structure/sign/directions/bar{
-	dir = 1;
-	pixel_x = 32;
-	pixel_y = -3
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/central_hallway/fore)
-"Kj" = (
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/brig)
-"Kk" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/maintenance/fore_port)
-"Kl" = (
-/obj/effect/floor_decal/industrial/warning/dust{
-	dir = 1
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/space)
-"Ko" = (
-/obj/machinery/suit_cycler/vintage/tmedic,
-/turf/simulated/floor/tiled/white,
-/area/talon_v2/medical)
-"Kp" = (
-/obj/structure/table/standard,
-/obj/item/weapon/storage/firstaid/surgery,
-/obj/item/stack/nanopaste{
-	pixel_x = -7;
-	pixel_y = -4
-	},
-/obj/item/stack/nanopaste{
-	pixel_x = 9;
-	pixel_y = -4
-	},
-/obj/item/device/robotanalyzer{
-	pixel_y = -8
-	},
-/obj/machinery/alarm/talon{
-	dir = 8;
-	pixel_x = 22
-	},
-/turf/simulated/floor/tiled/white,
-/area/talon_v2/medical)
-"Kr" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/structure/closet/crate,
-/obj/random/maintenance/clean,
-/obj/random/maintenance/clean,
-/obj/random/maintenance/clean,
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/gen_store)
-"Ks" = (
-/obj/machinery/door/firedoor/glass/talon,
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/hangar)
-"Kt" = (
-/obj/machinery/door/airlock/glass_external{
-	req_one_access = list(301)
-	},
-/obj/effect/map_helper/airlock/door/int_door,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/maintenance/wing_port)
-"Kv" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/catwalk,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/port_store)
-"Kx" = (
-/obj/structure/closet/wardrobe/black{
-	starts_with = list(/obj/item/clothing/under/color/black = 4, /obj/item/clothing/accessory/storage/black_vest = 4, /obj/item/clothing/accessory/storage/black_drop_pouches = 4, /obj/item/clothing/gloves/black = 4, /obj/item/clothing/head/soft/black = 4, /obj/item/clothing/mask/balaclava = 4, /obj/item/clothing/mask/bandana = 4, /obj/item/clothing/mask/gas/commando = 4, /obj/item/weapon/storage/backpack/messenger/black = 4, /obj/item/weapon/storage/backpack/dufflebag = 4, /obj/item/clothing/shoes/black = 4, /obj/item/clothing/shoes/boots/duty = 4)
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/armory)
-"Kz" = (
-/obj/machinery/door/firedoor/glass/talon,
-/obj/machinery/door/airlock/command{
-	name = "Bridge";
-	req_one_access = list(301)
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/bridge)
-"KA" = (
-/obj/structure/catwalk,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering)
-"KB" = (
-/turf/simulated/floor/wood,
-/area/talon_v2/crew_quarters/sec_room)
-"KC" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway/port)
-"KD" = (
-/obj/machinery/atmospherics/pipe/tank/air/full{
+/area/talon_v2/central_hallway/star)
+"LV" = (
+/obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 8
 	},
 /obj/structure/railing/grey,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/atmospherics)
-"KE" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/camera/network/talon,
-/obj/random/multiple/corp_crate/talon_cargo,
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/maintenance/wing_port)
-"KI" = (
-/obj/structure/catwalk,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/maintenance/fore_port)
-"KM" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/wall/rshull,
-/area/talon_v2/engineering/port_store)
-"KN" = (
-/obj/structure/bed/chair/bay/shuttle{
-	dir = 1
-	},
-/obj/structure/closet/walllocker/medical/east,
-/obj/item/weapon/storage/firstaid/regular,
-/obj/item/weapon/storage/firstaid/o2,
-/obj/item/weapon/extinguisher/mini,
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/shuttle/talonboat)
-"KO" = (
-/turf/simulated/wall/shull{
-	can_open = 1
-	},
-/area/talon_v2/engineering/port_store)
-"KS" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/atmospherics)
-"KT" = (
-/obj/machinery/door/airlock/glass_external{
-	req_one_access = list(301)
-	},
-/obj/effect/map_helper/airlock/door/ext_door,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/maintenance/aft_starboard)
-"KU" = (
-/turf/simulated/wall/shull,
-/area/talon_v2/engineering/port_store)
-"KX" = (
-/obj/machinery/door/firedoor/glass/talon,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/engineeringatmos{
-	name = "Talon Atmospherics";
-	req_one_access = list(301)
-	},
-/obj/structure/sign/directions/engineering/atmospherics{
-	dir = 8;
-	pixel_y = 35
-	},
-/obj/structure/sign/directions/engineering{
-	dir = 4;
-	pixel_y = 29
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/atmospherics)
-"KY" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/firealarm{
-	layer = 3.3;
-	pixel_y = 26
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway/port)
-"KZ" = (
-/obj/structure/catwalk,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/talon_v2/maintenance/aft_starboard)
-"Lc" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/talon_v2/medical)
-"Le" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/maintenance/wing_starboard)
-"Li" = (
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/hangar)
-"Lj" = (
-/obj/effect/map_helper/airlock/door/ext_door,
-/obj/machinery/door/airlock/glass_external{
-	req_one_access = list(301)
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/maintenance/wing_port)
-"Lk" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/wall/rshull,
-/area/talon_v2/maintenance/aft_starboard)
-"Ll" = (
-/obj/machinery/power/apc/talon{
-	dir = 1;
-	name = "north bump";
-	pixel_y = 28
-	},
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/machinery/camera/network/talon,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/engineering/star_store)
-"Lo" = (
-/obj/structure/sign/warning/nosmoking_1{
-	pixel_x = -26
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 6
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/starboard)
-"Lr" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/hangar)
-"Lt" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/bridge)
-"Lu" = (
-/obj/structure/railing/grey{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/star_store)
-"Lx" = (
-/obj/structure/table/rack/steel,
-/obj/item/clothing/suit/space/anomaly,
-/obj/item/clothing/head/helmet/space/anomaly,
-/obj/item/clothing/mask/breath,
-/obj/item/weapon/storage/belt/archaeology,
-/obj/machinery/light_switch{
-	pixel_y = 24
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/anomaly_storage)
-"Ly" = (
-/obj/machinery/conveyor{
-	dir = 1;
-	id = "talonrefinery"
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/refining)
-"Lz" = (
-/obj/effect/floor_decal/emblem/talon,
-/turf/simulated/floor/reinforced/airless,
-/area/space)
-"LA" = (
-/obj/structure/catwalk,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/maintenance/aft_port)
-"LB" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway/fore)
-"LD" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway)
-"LF" = (
-/obj/structure/catwalk,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/maintenance/aft_starboard)
-"LI" = (
-/obj/machinery/door/firedoor/glass/talon,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/door/airlock/maintenance/engi{
-	name = "Engine Crawlway Access";
-	req_one_access = list(301)
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/starboard)
-"LL" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/structure/reagent_dispensers/fueltank/high,
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/gen_store)
-"LM" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/aux{
-	dir = 1
-	},
-/obj/effect/map_helper/airlock/atmos/chamber_pump,
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/shuttle/talonboat)
-"LN" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering)
-"LO" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/structure/catwalk,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/maintenance/aft_port)
-"LT" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/camera/network/talon,
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway/port)
-"LU" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/refining)
-"LV" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/portable_atmospherics/canister/empty,
-/obj/machinery/atmospherics/portables_connector{
-	dir = 8
-	},
 /turf/simulated/floor/plating,
 /area/talon_v2/engineering/atmospherics)
 "LX" = (
@@ -11522,598 +11841,82 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor/glass/talon,
-/obj/machinery/door/airlock/maintenance/common,
+/obj/structure/catwalk,
+/obj/machinery/light/small{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/talon_v2/maintenance/aft_port)
 "LY" = (
-/turf/simulated/wall/shull,
-/area/talon_v2/engineering)
-"Mb" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/machinery/light_switch{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/random/multiple/corp_crate/talon_cargo,
-/obj/structure/railing/grey{
+/obj/effect/map_helper/airlock/atmos/pump_out_external,
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/techfloor,
+/obj/effect/floor_decal/industrial/warning/cee,
+/obj/structure/handrail,
+/turf/simulated/floor/reinforced,
+/area/shuttle/talonboat)
+"Mb" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/closet/walllocker/medical/west,
+/obj/item/weapon/storage/firstaid/regular,
+/obj/item/weapon/storage/firstaid/o2,
+/obj/item/device/radio/off{
+	channels = list("Talon" = 1)
+	},
+/turf/simulated/floor/tiled/techmaint,
 /area/talon_v2/maintenance/wing_starboard)
 "Mc" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/railing/grey,
+/obj/machinery/camera/network/talon,
 /obj/random/multiple/corp_crate/talon_cargo,
 /turf/simulated/floor/tiled/techfloor,
 /area/talon_v2/maintenance/wing_port)
 "Mf" = (
-/obj/machinery/atmospherics/portables_connector/aux,
-/obj/effect/floor_decal/industrial/outline,
-/obj/machinery/portable_atmospherics/canister/air,
-/obj/structure/railing/grey,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/star_store)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/maintenance/wing_starboard)
 "Mg" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/tiled/white,
-/area/talon_v2/medical)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/maintenance/wing_starboard)
 "Mh" = (
-/obj/machinery/light/small,
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/brig)
+/obj/machinery/camera/network/talon{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/maintenance/wing_starboard)
 "Mi" = (
-/obj/structure/catwalk,
-/obj/structure/trash_pile,
-/turf/simulated/floor/plating,
-/area/talon_v2/maintenance/aft_port)
+/obj/machinery/light_switch{
+	dir = 4;
+	pixel_x = -24
+	},
+/obj/structure/table/rack/shelf/steel,
+/obj/item/weapon/whetstone,
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/armory)
 "Mj" = (
-/obj/machinery/computer/ship/navigation{
-	dir = 4
+/obj/structure/railing/grey{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/talon_v2/bridge)
 "Ml" = (
-/obj/machinery/light,
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway/star)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/vending/medical_talon{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/talon_v2/medical)
 "Mm" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/structure/catwalk,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/maintenance/aft_starboard)
+/obj/machinery/atmospherics/pipe/simple/hidden/aux,
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/maintenance/wing_starboard)
 "Mo" = (
-/obj/machinery/atmospherics/binary/pump/high_power/on{
-	dir = 8
-	},
-/obj/structure/railing/grey{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/atmospherics)
-"Mp" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/crew_quarters/restrooms)
-"Mr" = (
-/obj/structure/disposaloutlet,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/talon_v2/engineering)
-"Mu" = (
-/obj/effect/floor_decal/industrial/warning/dust/corner,
-/turf/simulated/floor/reinforced/airless,
-/area/space)
-"Mv" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/catwalk,
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/maintenance/fore_starboard)
-"MA" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/central_hallway/fore)
-"MB" = (
-/obj/structure/sign/directions/medical{
-	pixel_y = -32
-	},
-/obj/machinery/camera/network/talon{
-	dir = 1
-	},
-/turf/simulated/floor/wood,
-/area/talon_v2/crew_quarters/med_room)
-"MD" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/light/small,
-/obj/machinery/atmospherics/pipe/simple/visible/yellow,
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/starboard)
-"ME" = (
-/obj/structure/handrail,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/aux{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/shuttle/talonboat)
-"MG" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/talon_v2/medical)
-"ML" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/wall/rshull,
-/area/talon_v2/maintenance/fore_port)
-"MO" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/talon_v2/crew_quarters/eng_room)
-"MP" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/maintenance/wing_starboard)
-"MQ" = (
-/obj/structure/table/marble,
-/obj/machinery/chemical_dispenser/bar_alc/full{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/black/diagonal,
-/turf/simulated/floor/tiled/white,
-/area/talon_v2/crew_quarters/bar)
-"MR" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/random/multiple/corp_crate/talon_cargo,
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/maintenance/wing_starboard)
-"MT" = (
-/obj/machinery/light/small,
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/talon_v2/maintenance/fore_port)
-"MU" = (
-/obj/machinery/door/firedoor/glass/talon,
-/obj/machinery/door/airlock{
-	id_tag = "talon_restroom1";
-	name = "Unisex Restroom"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/talon_v2/crew_quarters/restrooms)
-"MV" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/visible/yellow{
-	dir = 1
-	},
-/obj/effect/catwalk_plated/dark,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/starboard)
-"MX" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/floor_decal/industrial/warning,
-/obj/structure/handrail{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/maintenance/wing_starboard)
-"Na" = (
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway/star)
-"Nb" = (
-/obj/machinery/smartfridge/chemistry{
-	req_access = list(301);
-	req_one_access = list(301)
-	},
-/turf/simulated/floor/tiled/white,
-/area/talon_v2/medical)
-"Nc" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/camera/network/talon{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering)
-"Nf" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/hangar)
-"Nh" = (
-/obj/structure/railing/grey,
-/obj/machinery/atmospherics/pipe/manifold/visible/blue,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/atmospherics)
-"Nj" = (
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/aux,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/maintenance/wing_port)
-"Nk" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/yellow,
-/obj/machinery/alarm/talon{
-	dir = 4;
-	pixel_x = -22
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/port)
-"Nl" = (
-/turf/simulated/wall/shull,
-/area/talon_v2/crew_quarters/meditation)
-"Nm" = (
-/obj/effect/floor_decal/industrial/warning,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/maintenance/wing_starboard)
-"Nn" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/visible,
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/atmospherics)
-"Nq" = (
-/turf/simulated/wall/shull,
-/area/talon_v2/crew_quarters/cap_room)
-"Ns" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/hangar)
-"Nt" = (
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 9
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/starboard)
-"Nv" = (
-/obj/machinery/recharger/wallcharger{
-	pixel_x = 5;
-	pixel_y = 24
-	},
-/obj/structure/table/rack/shelf/steel,
-/obj/item/device/radio/off{
-	channels = list("Talon" = 1);
-	pixel_y = 6
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/armory)
-"Nw" = (
-/obj/structure/sign/directions/science/xenoarch{
-	pixel_y = -32
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway/star)
-"Nz" = (
-/obj/structure/table/standard,
-/obj/item/clothing/gloves/sterile/nitrile,
-/obj/item/clothing/mask/surgical,
-/obj/item/clothing/suit/surgicalapron,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/obj/structure/sign/warning/nosmoking_1{
-	pixel_x = 26
-	},
-/turf/simulated/floor/tiled/white,
-/area/talon_v2/medical)
-"NB" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/talon_v2/maintenance/aft_port)
-"NC" = (
-/turf/simulated/wall/shull,
-/area/talon_v2/crew_quarters/sec_room)
-"NE" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment{
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/holoposter{
-	dir = 8;
-	pixel_x = -32
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway)
-"NI" = (
-/obj/machinery/vending/snack,
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/central_hallway/fore)
-"NK" = (
-/obj/machinery/suit_cycler/vintage/tguard,
-/turf/simulated/floor/wood,
-/area/talon_v2/crew_quarters/sec_room)
-"NM" = (
-/obj/structure/table/rack/steel,
-/obj/item/clothing/shoes/leg_guard/combat,
-/obj/item/clothing/gloves/arm_guard/combat,
-/obj/item/clothing/under/syndicate/combat,
-/obj/item/clothing/suit/armor/combat,
-/obj/item/clothing/head/helmet/combat,
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/armory)
-"NO" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/machinery/disposal/wall{
-	dir = 8
-	},
-/turf/simulated/floor/wood,
-/area/talon_v2/crew_quarters/med_room)
-"NQ" = (
-/obj/effect/map_helper/airlock/atmos/chamber_pump,
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/aux{
-	dir = 1
-	},
-/obj/machinery/light/small,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/maintenance/wing_starboard)
-"NR" = (
-/obj/structure/catwalk,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/maintenance/fore_port)
-"NS" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/aux{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/maintenance/wing_port)
-"NT" = (
-/obj/effect/map_helper/airlock/atmos/chamber_pump,
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/aux,
-/obj/structure/handrail,
-/obj/effect/floor_decal/industrial/warning/corner,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/maintenance/wing_starboard)
-"NU" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/wall/shull,
-/area/talon_v2/central_hallway)
-"NV" = (
-/turf/simulated/wall/rshull,
-/area/talon_v2/crew_quarters/cap_room)
-"NW" = (
-/obj/structure/table/rack/shelf/steel,
-/obj/item/weapon/gun/energy/netgun,
-/obj/item/weapon/cell/device/weapon{
-	pixel_x = -5;
-	pixel_y = 2
-	},
-/obj/item/weapon/cell/device/weapon{
-	pixel_x = -5;
-	pixel_y = 2
-	},
-/obj/item/weapon/cell/device/weapon,
-/obj/item/clothing/accessory/holster/waist,
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/armory)
-"NZ" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway/star)
-"Ob" = (
-/obj/effect/floor_decal/industrial/outline/red,
-/obj/machinery/atmospherics/portables_connector{
-	dir = 4
-	},
-/obj/machinery/portable_atmospherics/canister/phoron/engine_setup,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/starboard)
-"Od" = (
-/obj/structure/table/standard,
-/obj/machinery/reagentgrinder,
-/turf/simulated/floor/tiled/white,
-/area/talon_v2/medical)
-"Og" = (
-/obj/machinery/light_switch{
-	dir = 8;
-	pixel_x = 24
-	},
-/turf/simulated/floor/wood,
-/area/talon_v2/crew_quarters/med_room)
-"Oi" = (
-/obj/machinery/atmospherics/portables_connector,
-/obj/effect/floor_decal/industrial/outline,
-/obj/machinery/portable_atmospherics/powered/pump/filled,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/atmospherics)
-"Oj" = (
-/turf/simulated/wall/shull,
-/area/talon_v2/armory)
-"Ok" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
-/obj/structure/ore_box,
-/obj/structure/railing/grey{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/refining)
-"Om" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/talon_v2/maintenance/fore_port)
-"On" = (
-/obj/machinery/chem_master,
-/turf/simulated/floor/tiled/white,
-/area/talon_v2/medical)
-"Oo" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/talon_v2/maintenance/aft_starboard)
-"Op" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 1
 	},
@@ -12125,271 +11928,230 @@
 /obj/structure/railing/grey,
 /turf/simulated/floor/plating,
 /area/talon_v2/engineering/atmospherics)
-"Oq" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
+"Mp" = (
+/obj/machinery/door/airlock/glass_external{
+	req_one_access = list(301)
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/floor_decal/corner/black/diagonal,
-/obj/item/weapon/stool/baystool/padded{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/talon_v2/crew_quarters/bar)
-"Ot" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/random/multiple/corp_crate/talon_cargo,
-/turf/simulated/floor/tiled/techfloor,
+/obj/effect/map_helper/airlock/door/int_door,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/talon_v2/maintenance/wing_starboard)
-"Ow" = (
-/obj/machinery/vending/coffee{
-	dir = 1
-	},
-/turf/simulated/floor/wood,
-/area/talon_v2/crew_quarters/bar)
-"OB" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/structure/handrail{
-	dir = 4
-	},
-/obj/structure/extinguisher_cabinet{
-	dir = 4;
-	pixel_x = -30
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/maintenance/wing_port)
-"OD" = (
-/obj/machinery/light{
+"Mr" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/machinery/light/small{
 	dir = 8
 	},
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/machinery/disposal/wall{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/talon_v2/medical)
-"OE" = (
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 5
-	},
+/obj/structure/railing/grey,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering)
+"Ms" = (
+/obj/machinery/atmospherics/pipe/manifold4w/visible/yellow,
 /obj/effect/floor_decal/industrial/warning{
-	dir = 4
+	dir = 8
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/talon_v2/engineering/port)
-"OH" = (
-/obj/machinery/power/pointdefense{
-	id_tag = "talon_pd"
-	},
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
+"Mt" = (
 /obj/effect/floor_decal/industrial/warning/dust{
 	dir = 9
 	},
 /turf/simulated/floor/reinforced/airless,
-/area/space)
-"OI" = (
-/obj/effect/floor_decal/industrial/loading,
+/area/talon_v2/engineering/port)
+"Mu" = (
+/obj/machinery/door/blast/regular{
+	dir = 4;
+	id = "talon_cargo_star";
+	name = "Cargo Loading Hatch"
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/refining)
-"OJ" = (
-/obj/machinery/atmospherics/pipe/simple/visible,
+/area/talon_v2/maintenance/wing_starboard)
+"Mv" = (
+/obj/effect/map_helper/airlock/atmos/chamber_pump,
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/aux{
+	dir = 1
+	},
+/obj/machinery/light/small,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/maintenance/wing_starboard)
+"My" = (
+/obj/machinery/door/firedoor/glass/talon,
+/obj/machinery/door/airlock/glass{
+	name = "Cantina"
+	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/crew_quarters/bar)
+"Mz" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/door/blast/regular/open{
+	id = "talon_windows"
+	},
+/obj/machinery/door/firedoor/glass/talon,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/crew_quarters/cap_room)
+"MB" = (
+/obj/effect/map_helper/airlock/atmos/chamber_pump,
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/aux{
+	dir = 1
+	},
+/obj/structure/handrail{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/machinery/embedded_controller/radio/airlock/docking_port{
+	dir = 1;
+	id_tag = "talon_starboard";
+	pixel_y = -30;
+	req_one_access = list(301)
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/maintenance/wing_starboard)
+"MD" = (
+/obj/effect/floor_decal/industrial/outline/red,
+/obj/machinery/atmospherics/portables_connector{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/canister/phoron/engine_setup,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/starboard)
+"ME" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	layer = 3.3;
+	pixel_y = 26
+	},
+/obj/structure/bed/chair/bay/shuttle,
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/talonboat)
+"MF" = (
+/obj/machinery/light/small{
+	dir = 1
 	},
 /obj/structure/catwalk,
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/atmospherics)
-"OK" = (
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
-/obj/effect/catwalk_plated,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/central_hallway/port)
-"OL" = (
 /obj/structure/railing/grey{
 	dir = 1
 	},
-/obj/machinery/power/smes/buildable/offmap_spawn{
-	RCon_tag = "Talon Port SMES"
-	},
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
 /turf/simulated/floor/plating,
-/area/talon_v2/engineering)
-"OM" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
+/area/talon_v2/engineering/atmospherics)
+"MG" = (
+/obj/machinery/door/firedoor/glass/talon,
+/obj/machinery/door/airlock{
+	id_tag = "talon_restroom2";
+	name = "Unisex Restroom"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/crew_quarters/restrooms)
-"ON" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/alarm/talon{
-	dir = 1;
-	pixel_y = -25
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway/port)
-"OP" = (
-/obj/machinery/portable_atmospherics/canister/nitrogen,
-/obj/structure/railing/grey{
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/outline/red,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/atmospherics)
-"OQ" = (
-/turf/simulated/wall/shull,
-/area/talon_v2/gen_store)
-"OR" = (
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/talon_v2/crew_quarters/meditation)
-"OS" = (
-/obj/structure/sign/department/bridge{
-	name = "PILOT'S QUARTERS";
-	pixel_y = -32
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/central_hallway/fore)
-"OT" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/space)
-"OU" = (
-/obj/machinery/portable_atmospherics/canister/air,
-/obj/structure/railing/grey{
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/outline,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/atmospherics)
-"OW" = (
-/obj/effect/shuttle_landmark/premade/talon_v2_near_aft_star,
-/turf/space,
-/area/space)
-"OX" = (
-/obj/structure/bed/chair/bay/chair,
-/turf/simulated/floor/wood,
-/area/talon_v2/crew_quarters/bar)
-"OY" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/black/diagonal,
-/obj/structure/table/marble,
-/obj/item/device/radio/off{
-	channels = list("Talon" = 1)
 	},
 /turf/simulated/floor/tiled/white,
-/area/talon_v2/crew_quarters/bar)
-"OZ" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+/area/talon_v2/crew_quarters/restrooms)
+"ML" = (
+/obj/machinery/door/airlock/glass_external{
+	req_one_access = list(301)
 	},
+/obj/effect/map_helper/airlock/door/ext_door,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/maintenance/wing_starboard)
+"MO" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/railing/grey{
+	dir = 1
+	},
+/obj/random/multiple/corp_crate/talon_cargo,
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/maintenance/wing_port)
+"MP" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/railing/grey{
+	dir = 1
+	},
+/obj/random/multiple/corp_crate/talon_cargo,
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/maintenance/wing_port)
+"MU" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor/glass/talon,
+/obj/machinery/door/airlock/maintenance/common,
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/aft_port)
+"MV" = (
 /obj/structure/cable/green{
 	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/maintenance/wing_port)
-"Pb" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
+/obj/machinery/door/firedoor/glass/talon,
+/obj/structure/sign/warning/nosmoking_1{
+	pixel_x = 26
 	},
-/turf/simulated/floor/wood,
-/area/talon_v2/crew_quarters/med_room)
-"Pd" = (
-/obj/structure/hull_corner/long_horiz{
-	dir = 6
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/airlock/engineering{
+	name = "Talon Starboard Engines";
+	req_one_access = list(301)
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/starboard)
+"MW" = (
+/obj/machinery/recharge_station,
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/bridge)
+"MZ" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/industrial/warning/dust/corner{
+	dir = 8
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/space)
-"Pe" = (
-/turf/simulated/floor/wood,
-/area/talon_v2/crew_quarters/cap_room)
-"Pf" = (
-/obj/structure/railing/grey,
-/obj/effect/floor_decal/industrial/outline/red,
-/obj/machinery/portable_atmospherics/canister/empty/phoron,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/star_store)
-"Pg" = (
-/obj/machinery/vending/fitness,
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/central_hallway/fore)
-"Ph" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/aux{
+"Na" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/closet/emergsuit_wall{
-	dir = 1;
-	pixel_y = -32
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
 	},
-/turf/simulated/floor/plating,
-/area/talon_v2/maintenance/wing_port)
-"Pj" = (
+/turf/simulated/floor/tiled/white,
+/area/talon_v2/medical)
+"Nb" = (
 /obj/machinery/light/small{
 	dir = 4
 	},
@@ -12403,651 +12165,59 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/talon_v2/crew_quarters/restrooms)
-"Pk" = (
-/obj/effect/floor_decal/corner/black/diagonal,
-/obj/structure/table/marble,
-/obj/random/pizzabox,
-/turf/simulated/floor/tiled/white,
-/area/talon_v2/crew_quarters/bar)
-"Pl" = (
+"Nc" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/alarm/talon{
+	dir = 8;
+	pixel_x = 22
+	},
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering)
+"Ne" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/wall/rshull,
+/area/talon_v2/maintenance/aft_port)
+"Nf" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/hangar)
+"Nh" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
 /obj/machinery/door/firedoor/glass/talon,
-/obj/machinery/door/airlock/maintenance/engi{
-	name = "Talon Atmospherics Maintenance Access";
-	req_one_access = list(301)
+/turf/simulated/floor/plating,
+/area/talon_v2/armory)
+"Nl" = (
+/turf/simulated/wall/shull,
+/area/talon_v2/crew_quarters/meditation)
+"Nn" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/visible,
+/obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/talon_v2/engineering/atmospherics)
-"Pm" = (
-/obj/structure/table/rack/shelf/steel,
-/obj/machinery/recharger/wallcharger{
-	pixel_x = 5;
-	pixel_y = 24
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/armory)
-"Po" = (
-/obj/effect/map_helper/airlock/door/simple,
-/obj/machinery/door/airlock/glass_external{
-	req_one_access = list(301)
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/shuttle/talonboat)
-"Pr" = (
-/obj/machinery/shower,
-/obj/item/weapon/soap/deluxe,
-/obj/structure/curtain,
-/turf/simulated/floor/tiled/white,
-/area/talon_v2/crew_quarters/restrooms)
-"Ps" = (
-/obj/machinery/power/apc/talon{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -28
-	},
-/obj/structure/table/standard,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -25
-	},
-/obj/machinery/recharger,
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/tiled/white,
-/area/talon_v2/medical)
-"Pt" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 1
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/port)
-"Pu" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering)
-"Pv" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/maintenance/wing_starboard)
-"Px" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/railing/grey{
-	dir = 1
-	},
-/obj/random/multiple/corp_crate/talon_cargo,
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/maintenance/wing_port)
-"Py" = (
-/obj/machinery/atmospherics/pipe/simple/visible/yellow,
-/turf/simulated/wall/rshull,
-/area/talon_v2/engineering/port)
-"PB" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/structure/extinguisher_cabinet{
-	dir = 1;
-	pixel_y = -32
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway/port)
-"PC" = (
-/obj/machinery/door/firedoor/glass/talon,
-/obj/machinery/door/airlock/multi_tile/glass{
-	dir = 1;
-	name = "Cargo Bay";
-	req_one_access = list(301)
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway/star)
-"PE" = (
-/obj/effect/floor_decal/emblem/talon_big{
-	dir = 9
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/central_hallway/fore)
-"PF" = (
-/obj/structure/catwalk,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering)
-"PG" = (
-/turf/simulated/floor/plating,
-/area/talon_v2/maintenance/fore_starboard)
-"PH" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/manifold/visible/yellow{
-	dir = 1
-	},
-/obj/structure/railing/grey{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/starboard)
-"PI" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/mineral/input,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/refining)
-"PK" = (
-/obj/effect/shuttle_landmark/premade/talon_v2_near_fore_port,
-/turf/space,
-/area/space)
-"PL" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/maintenance/wing_port)
-"PO" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment{
-	dir = 1
-	},
-/turf/simulated/floor/wood,
-/area/talon_v2/crew_quarters/meditation)
-"PP" = (
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
-/obj/effect/catwalk_plated,
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/central_hallway)
-"PR" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/machinery/disposal/wall{
-	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/talon_v2/crew_quarters/pilot_room)
-"PU" = (
-/obj/machinery/alarm/talon{
-	dir = 1;
-	pixel_y = -22
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/bridge)
-"PV" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/maintenance/wing_port)
-"PW" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+"Nq" = (
 /turf/simulated/wall/shull,
-/area/talon_v2/crew_quarters/bar)
-"PX" = (
-/obj/machinery/door/firedoor/glass/talon,
-/obj/machinery/door/airlock{
-	name = "Restrooms & Charger"
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/crew_quarters/restrooms)
-"PZ" = (
-/obj/structure/bed/chair/wood,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/carpet/blucarpet,
 /area/talon_v2/crew_quarters/cap_room)
-"Qa" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/railing/grey,
-/obj/effect/floor_decal/industrial/warning,
-/obj/structure/table/steel,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/engineering)
-"Qb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/crew_quarters/restrooms)
-"Qc" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/maintenance/wing_starboard)
-"Qi" = (
-/obj/effect/map_helper/airlock/sensor/int_sensor,
-/obj/structure/sign/warning/airlock{
-	pixel_y = 32
-	},
-/obj/machinery/airlock_sensor{
-	dir = 4;
-	pixel_x = -28;
-	pixel_y = -28;
-	req_one_access = list(301)
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/aux{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/maintenance/fore_port)
-"Qj" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/effect/catwalk_plated,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/central_hallway/port)
-"Qk" = (
-/obj/machinery/door/airlock/glass_external{
-	req_one_access = list(301)
-	},
-/obj/effect/map_helper/airlock/door/ext_door,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/maintenance/wing_port)
-"Qm" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/catwalk,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/maintenance/aft_port)
-"Qn" = (
-/obj/structure/closet/secure_closet/chemical{
-	req_access = list(301)
-	},
-/obj/item/weapon/reagent_containers/spray/cleaner{
-	desc = "Someone has crossed out the 'Space' from Space Cleaner and written in Chemistry. Scrawled on the back is, 'Okay, whoever filled this with polytrinic acid, it was only funny the first time. It was hard enough replacing the CMO's first cat!'";
-	name = "Chemistry Cleaner"
-	},
-/turf/simulated/floor/tiled/white,
-/area/talon_v2/medical)
-"Qo" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/aux{
-	dir = 9
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/central_hallway/fore)
-"Qq" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/railing/grey,
-/obj/random/multiple/corp_crate/talon_cargo,
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/maintenance/wing_starboard)
-"Qu" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/catwalk,
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/maintenance/aft_port)
-"Qv" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/port_store)
-"Qx" = (
-/obj/structure/catwalk,
-/obj/structure/closet/walllocker_double/west,
-/obj/item/weapon/storage/toolbox/electrical,
-/obj/item/weapon/storage/toolbox/mechanical,
-/obj/item/stack/cable_coil/green,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering)
-"Qy" = (
-/obj/machinery/door/firedoor/glass/talon,
-/obj/machinery/door/airlock/maintenance/medical{
-	id_tag = "talon_meddoor";
-	req_one_access = list(301)
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/crew_quarters/med_room)
-"Qz" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/catwalk,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/star_store)
-"QA" = (
-/obj/structure/hull_corner/long_horiz{
-	dir = 9
-	},
-/turf/space,
-/area/space)
-"QB" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/turf/simulated/floor/tiled/white,
-/area/talon_v2/crew_quarters/restrooms)
-"QC" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/central_hallway/fore)
-"QD" = (
-/obj/machinery/alarm/talon{
-	dir = 1;
-	pixel_y = -25
-	},
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/secure_storage)
-"QE" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/junction{
-	dir = 4;
-	icon_state = "pipe-j2"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway/fore)
-"QF" = (
-/obj/structure/closet/emergsuit_wall{
-	dir = 4;
-	pixel_x = 32
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/port_store)
-"QG" = (
-/obj/structure/table/standard,
-/obj/item/weapon/storage/box/donut,
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/machinery/alarm/talon{
-	dir = 4;
-	pixel_x = -22
-	},
-/obj/machinery/firealarm{
-	layer = 3.3;
-	pixel_y = 26
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/brig)
-"QH" = (
-/obj/machinery/recharge_station,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/talon_v2/crew_quarters/restrooms)
-"QI" = (
-/obj/effect/floor_decal/industrial/warning/dust/corner{
-	dir = 1
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/space)
-"QJ" = (
-/obj/structure/catwalk,
-/obj/structure/disposalpipe/junction/yjunction,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering)
-"QM" = (
-/obj/machinery/atmospherics/unary/engine{
-	dir = 1
-	},
-/turf/simulated/floor/reinforced,
-/area/shuttle/talonboat)
-"QN" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/carpet,
-/area/talon_v2/crew_quarters/sec_room)
-"QR" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/turf/simulated/floor/wood,
-/area/talon_v2/crew_quarters/meditation)
-"QS" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway)
-"QV" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/aux{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/glass/talon,
-/obj/machinery/door/airlock/maintenance/common,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/maintenance/fore_port)
-"QY" = (
-/obj/structure/catwalk,
-/obj/structure/trash_pile,
-/turf/simulated/floor/plating,
-/area/talon_v2/maintenance/fore_starboard)
-"Rb" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/port)
-"Rd" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering)
-"Re" = (
-/obj/structure/closet/crate,
-/obj/random/maintenance/clean,
-/obj/random/maintenance/clean,
-/obj/random/maintenance/clean,
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/gen_store)
-"Rf" = (
-/turf/simulated/wall/shull{
-	can_open = 1
-	},
-/area/talon_v2/engineering/star_store)
-"Rg" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/engineering/star_store)
-"Ri" = (
-/obj/machinery/power/pointdefense{
-	id_tag = "talon_pd"
-	},
-/obj/structure/cable/green,
-/obj/effect/floor_decal/industrial/warning/dust{
-	dir = 6
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/space)
-"Rj" = (
-/obj/machinery/door/firedoor/glass/talon,
-/obj/machinery/door/airlock/engineeringatmos{
-	name = "Talon Atmospherics";
-	req_one_access = list(301)
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/port_store)
-"Rp" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/wood,
-/area/talon_v2/crew_quarters/meditation)
-"Rs" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/machinery/disposal/wall{
-	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/talon_v2/crew_quarters/cap_room)
-"Rt" = (
-/obj/machinery/drone_fabricator/talon,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/port_store)
-"Ru" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/random/multiple/corp_crate/talon_cargo,
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/maintenance/wing_port)
-"Rx" = (
-/turf/space,
-/area/talon_v2/engineering/port)
-"Ry" = (
-/obj/machinery/mineral/processing_unit{
-	points_mult = 0
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/refining)
-"RA" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/star_store)
-"RB" = (
+"Ns" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment{
@@ -13068,511 +12238,14 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/talon_v2/central_hallway)
-"RC" = (
-/obj/effect/floor_decal/emblem/talon_big/center,
-/obj/structure/cable/green,
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/central_hallway/fore)
-"RD" = (
-/obj/machinery/power/pointdefense{
-	id_tag = "talon_pd"
-	},
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/space)
-"RE" = (
-/obj/structure/trash_pile,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/star_store)
-"RF" = (
-/obj/machinery/door/firedoor/glass/talon,
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/obj/machinery/door/blast/regular/open{
-	dir = 2;
-	id = "talon_bridge_shields"
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/bridge)
-"RG" = (
-/obj/structure/table/standard,
-/obj/item/weapon/storage/toolbox/mechanical,
-/obj/item/weapon/storage/box/mousetraps,
-/obj/item/weapon/storage/box/lights/mixed,
-/obj/item/weapon/reagent_containers/spray/cleaner,
-/obj/item/weapon/reagent_containers/glass/rag,
-/obj/machinery/light_switch{
-	dir = 1;
-	pixel_x = 2;
-	pixel_y = -28
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/engineering/star_store)
-"RI" = (
-/obj/effect/floor_decal/industrial/outline/red,
-/obj/machinery/atmospherics/portables_connector{
-	dir = 8
-	},
-/obj/machinery/portable_atmospherics/canister/phoron/engine_setup,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/starboard)
-"RJ" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/central_hallway/fore)
-"RK" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway/port)
-"RL" = (
-/obj/structure/bed/chair/bay/chair{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/shuttle/talonboat)
-"RO" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/starboard)
-"RP" = (
-/obj/effect/map_helper/airlock/sensor/chamber_sensor,
-/obj/machinery/airlock_sensor{
-	pixel_y = 24;
-	req_one_access = list(301)
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/aux{
-	dir = 1
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 4
-	},
-/obj/structure/handrail,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/shuttle/talonboat)
-"RQ" = (
-/turf/simulated/wall/shull,
-/area/talon_v2/medical)
-"RV" = (
-/obj/machinery/atmospherics/pipe/manifold4w/visible/yellow,
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/port)
-"RW" = (
-/obj/structure/table/rack/shelf/steel,
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/armory)
-"Sa" = (
-/obj/machinery/atmospherics/pipe/simple/visible/red{
-	dir = 10
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/atmospherics)
-"Sb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/wood,
-/area/talon_v2/crew_quarters/cap_room)
-"Sd" = (
-/obj/machinery/door/firedoor/glass/talon,
-/obj/machinery/door/airlock/engineering{
-	name = "Talon Port Engines";
-	req_one_access = list(301)
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/port)
-"Sg" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/structure/table/standard,
-/obj/machinery/cell_charger,
-/obj/item/weapon/storage/firstaid/regular,
-/obj/item/weapon/storage/firstaid/o2,
-/obj/structure/closet/walllocker/medical/north,
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/workroom)
-"Si" = (
-/obj/structure/table/rack/shelf/steel,
-/obj/item/weapon/gun/energy/netgun,
-/obj/item/weapon/cell/device/weapon{
-	pixel_x = -5;
-	pixel_y = 2
-	},
-/obj/item/weapon/cell/device/weapon,
-/obj/item/clothing/accessory/holster/waist,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/armory)
-"Sj" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/structure/extinguisher_cabinet{
-	dir = 8;
-	pixel_x = 30
-	},
-/turf/simulated/floor/tiled/white,
-/area/talon_v2/medical)
-"Sk" = (
-/turf/simulated/wall/shull,
-/area/talon_v2/crew_quarters/restrooms)
-"Sn" = (
-/turf/simulated/wall/rshull,
-/area/talon_v2/crew_quarters/meditation)
-"So" = (
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/armory)
-"Sr" = (
+"Nt" = (
+/obj/machinery/light/small,
 /obj/structure/railing/grey{
-	dir = 4
-	},
-/obj/structure/table/steel,
-/obj/effect/floor_decal/industrial/warning{
-	dir = 5
-	},
-/obj/item/weapon/paper/talon_shields,
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/engineering)
-"Ss" = (
-/obj/machinery/light_switch{
-	dir = 8;
-	pixel_x = 24
-	},
-/turf/simulated/floor/wood,
-/area/talon_v2/crew_quarters/cap_room)
-"St" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/computer/shuttle_control/explore/talonboat{
-	dir = 4;
-	name = "boat remote control console"
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/central_hallway)
-"Su" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/light/small,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/atmospherics)
-"Sv" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/closet/walllocker_double/hydrant/south,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway)
-"Sx" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/structure/window/reinforced{
 	dir = 1
-	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/door/blast/shutters{
-	density = 0;
-	dir = 2;
-	icon_state = "shutter0";
-	id = "talon_brig1";
-	name = "Cell Shutters";
-	opacity = 0
-	},
-/obj/machinery/door/firedoor/glass/talon,
-/turf/simulated/floor/plating,
-/area/talon_v2/brig)
-"Sz" = (
-/obj/machinery/cryopod/talon{
-	dir = 4
-	},
-/obj/machinery/camera/network/talon,
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/central_hallway)
-"SE" = (
-/obj/machinery/light/small,
-/obj/machinery/light_switch{
-	dir = 1;
-	pixel_x = 2;
-	pixel_y = -28
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/port_store)
-"SG" = (
-/obj/machinery/button/remote/blast_door{
-	id = "talon_cargo_star";
-	name = "Cargo Loading Hatches";
-	pixel_y = -28
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/door/window/brigdoor/northright{
-	req_access = list();
-	req_one_access = list(301)
-	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/maintenance/wing_starboard)
-"SL" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/turf/simulated/floor/carpet,
-/area/talon_v2/crew_quarters/pilot_room)
-"SN" = (
-/obj/machinery/alarm/talon{
-	dir = 4;
-	pixel_x = -22
-	},
-/obj/machinery/light_switch{
-	dir = 1;
-	pixel_x = 2;
-	pixel_y = -28
-	},
-/obj/structure/bed/pod,
-/obj/item/weapon/bedsheet/medical,
-/turf/simulated/floor/carpet,
-/area/talon_v2/crew_quarters/med_room)
-"SQ" = (
-/obj/machinery/door/firedoor/glass/talon,
-/obj/machinery/door/airlock/glass,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment{
-	dir = 1
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway/fore)
-"ST" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/obj/structure/handrail{
-	dir = 8
-	},
-/obj/structure/closet/emergsuit_wall{
-	dir = 4;
-	pixel_x = 32
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/maintenance/wing_starboard)
-"SU" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/secure_storage)
-"SW" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/catwalk,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/star_store)
-"SX" = (
-/obj/structure/closet/walllocker/emerglocker/west,
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/armory)
-"SY" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway)
-"Ta" = (
-/obj/machinery/vending/blood{
-	req_access = list(301);
-	req_log_access = 301
-	},
-/turf/simulated/floor/tiled/white,
-/area/talon_v2/medical)
-"Tb" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/outline/red,
-/obj/machinery/portable_atmospherics/canister/empty/phoron,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/star_store)
-"Td" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/effect/catwalk_plated,
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/central_hallway/star)
-"Te" = (
-/obj/effect/shuttle_landmark/premade/talon_v2_wing_port,
-/turf/space,
-/area/space)
-"Tf" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/obj/structure/catwalk,
-/obj/structure/extinguisher_cabinet{
-	dir = 1;
-	pixel_y = -32
 	},
 /turf/simulated/floor/plating,
 /area/talon_v2/engineering/starboard)
-"Tg" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/engineering/star_store)
-"Ti" = (
-/obj/structure/table/rack/shelf/steel,
-/obj/item/device/suit_cooling_unit,
-/obj/item/device/suit_cooling_unit,
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/secure_storage)
-"Tl" = (
+"Nu" = (
 /obj/machinery/light/small{
 	dir = 4
 	},
@@ -13589,17 +12262,636 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/talon_v2/maintenance/aft_port)
-"To" = (
-/obj/machinery/light{
+"Nv" = (
+/obj/structure/handrail{
 	dir = 1
 	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/aux{
+	dir = 4
+	},
+/obj/effect/map_helper/airlock/atmos/chamber_pump,
+/obj/structure/closet/walllocker_double/survival/south,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/shuttle/talonboat)
+"Nw" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/workroom)
+"Nz" = (
+/obj/structure/closet/walllocker_double/south,
+/obj/structure/handrail{
+	dir = 1
+	},
+/obj/item/weapon/storage/toolbox/emergency,
+/obj/machinery/atmospherics/pipe/simple/hidden/aux{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/shuttle/talonboat)
+"NB" = (
+/obj/structure/closet/walllocker_double/south,
+/obj/machinery/light,
+/obj/item/weapon/extinguisher,
+/obj/item/stack/cable_coil/green,
+/obj/item/stack/cable_coil/green,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
+/obj/effect/map_helper/airlock/atmos/pump_out_internal,
+/obj/machinery/atmospherics/unary/vent_pump/high_volume,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/shuttle/talonboat)
+"NC" = (
+/turf/simulated/wall/shull,
+/area/talon_v2/crew_quarters/sec_room)
+"NE" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/sign/directions/security/armory{
+	dir = 10;
+	pixel_x = -32;
+	pixel_y = -6
+	},
+/obj/structure/sign/directions/security{
+	dir = 1;
+	pixel_x = -32;
+	pixel_y = 6
+	},
+/obj/structure/sign/directions/security/brig{
+	dir = 1;
+	pixel_x = -32
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway)
+"NF" = (
+/obj/machinery/door/firedoor/glass/talon,
+/obj/machinery/door/airlock/maintenance/engi{
+	name = "Port Eng. Storage";
+	req_one_access = list(301)
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/port_store)
+"NG" = (
+/obj/structure/closet/walllocker_double/south,
+/obj/structure/handrail{
+	dir = 1
+	},
+/obj/item/weapon/storage/toolbox/mechanical,
+/obj/machinery/atmospherics/pipe/simple/hidden/aux{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/shuttle/talonboat)
+"NH" = (
+/obj/machinery/atmospherics/pipe/simple/visible/yellow,
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/port)
+"NI" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/shuttle/talonpod)
+"NK" = (
+/obj/structure/handrail{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/aux{
+	dir = 8
+	},
+/obj/effect/map_helper/airlock/atmos/chamber_pump,
+/obj/structure/closet/walllocker_double/survival/south,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/shuttle/talonboat)
+"NO" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/aux{
+	dir = 9
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc/talon{
+	name = "south bump";
+	pixel_y = -24
+	},
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/fore_starboard)
+"NR" = (
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/fore_port)
+"NS" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/maintenance/wing_port)
+"NT" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 1
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/space)
+"NU" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/machinery/light_switch{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/hangar)
+"NW" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/machinery/door/firedoor/glass/talon,
+/turf/simulated/floor/plating,
+/area/talon_v2/secure_storage)
+"NZ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/talon_v2/medical)
+"Ob" = (
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "talontrash"
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/starboard)
+"Oc" = (
+/obj/structure/catwalk,
+/obj/structure/barricade,
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/aft_port)
+"Od" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/structure/sign/directions/engineering{
+	pixel_x = 32;
+	pixel_y = -6
+	},
+/obj/structure/sign/directions/cargo{
+	dir = 4;
+	pixel_x = 32
+	},
+/obj/structure/sign/directions/science/xenoarch{
+	dir = 4;
+	pixel_x = 32;
+	pixel_y = 6
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway)
+"Og" = (
+/obj/machinery/door/firedoor/glass/talon,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/mining{
+	name = "Refinery";
+	req_one_access = list(301)
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/refining)
+"Oi" = (
+/obj/structure/table/rack/shelf/steel,
+/obj/item/weapon/gun/energy/netgun,
+/obj/item/weapon/cell/device/weapon{
+	pixel_x = -5;
+	pixel_y = 2
+	},
+/obj/item/weapon/cell/device/weapon,
+/obj/item/clothing/accessory/holster/waist,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/armory)
+"Oj" = (
+/turf/simulated/wall/shull,
+/area/talon_v2/armory)
+"Ok" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/camera/network/talon,
 /obj/machinery/atm{
 	pixel_y = 31
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/central_hallway/fore)
-"Tq" = (
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway/star)
+"Ol" = (
+/turf/simulated/wall/shull{
+	can_open = 1
+	},
+/area/talon_v2/engineering/star_store)
+"On" = (
 /obj/machinery/door/firedoor/glass/talon,
+/obj/machinery/door/airlock/maintenance/common,
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/aft_starboard)
+"Oo" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/railing/grey{
+	dir = 1
+	},
+/obj/random/multiple/corp_crate/talon_cargo,
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/maintenance/wing_starboard)
+"Op" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/railing/grey{
+	dir = 1
+	},
+/obj/random/multiple/corp_crate/talon_cargo,
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/maintenance/wing_starboard)
+"Ot" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/railing/grey,
+/obj/random/multiple/corp_crate/talon_cargo,
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/maintenance/wing_starboard)
+"Ov" = (
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 1
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/talon_v2/engineering/starboard)
+"Oy" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/port_store)
+"Oz" = (
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc/talon{
+	dir = 1;
+	name = "north bump";
+	pixel_y = 28
+	},
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/aft_starboard)
+"OB" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/maintenance/wing_port)
+"OD" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/machinery/disposal,
+/obj/structure/sign/directions/medical{
+	pixel_y = -32
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/crew_quarters/restrooms)
+"OE" = (
+/obj/machinery/door/window/brigdoor/eastright{
+	req_access = list();
+	req_one_access = list(301)
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/port)
+"OF" = (
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/aft_starboard)
+"OH" = (
+/obj/machinery/atmospherics/portables_connector/aux{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/outline,
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/wing_port)
+"OJ" = (
+/obj/machinery/atmospherics/pipe/simple/visible/blue{
+	dir = 6
+	},
+/obj/structure/closet/emergsuit_wall{
+	pixel_y = 32
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/atmospherics)
+"OK" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/structure/closet/crate,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/clean,
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/gen_store)
+"OL" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/structure/railing/grey{
+	dir = 4
+	},
+/obj/structure/railing/grey{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering)
+"OM" = (
+/obj/machinery/door/firedoor/glass/talon,
+/obj/machinery/door/airlock{
+	id_tag = "talon_charger";
+	name = "Cyborg Recharging Station"
+	},
+/turf/simulated/floor/tiled/white,
+/area/talon_v2/crew_quarters/restrooms)
+"ON" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/aux{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/wing_port)
+"OP" = (
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/armory)
+"OQ" = (
+/turf/simulated/wall/shull,
+/area/talon_v2/gen_store)
+"OR" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway/port)
+"OS" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/random/multiple/corp_crate/talon_cargo,
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/maintenance/wing_port)
+"OT" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/maintenance/wing_port)
+"OW" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/random/multiple/corp_crate/talon_cargo,
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/maintenance/wing_port)
+"OX" = (
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/obj/structure/table/woodentable,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/wood,
+/area/talon_v2/crew_quarters/bar)
+"OY" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/turf/simulated/floor/wood,
+/area/talon_v2/crew_quarters/bar)
+"OZ" = (
+/obj/structure/handrail,
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/maintenance/wing_port)
+"Pb" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/aux,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/light/small,
+/obj/structure/closet/emergsuit_wall{
+	dir = 1;
+	pixel_y = -32
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/fore_starboard)
+"Pd" = (
+/obj/effect/floor_decal/industrial/warning/dust/corner,
+/turf/simulated/floor/reinforced/airless,
+/area/space)
+"Pe" = (
+/obj/machinery/camera/network/talon{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/talon_v2/crew_quarters/cap_room)
+"Pf" = (
+/obj/structure/sign/warning/nosmoking_1{
+	pixel_x = -26
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/star_store)
+"Pg" = (
+/obj/machinery/power/apc/talon/hyper{
+	dir = 1;
+	pixel_y = 24
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/effect/shuttle_landmark/shuttle_initializer/talonpod,
+/obj/effect/overmap/visitable/ship/landable/talon_pod,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/talonpod)
+"Ph" = (
+/obj/effect/map_helper/airlock/door/int_door,
+/obj/machinery/door/airlock/glass_external{
+	req_one_access = list(301)
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/aux{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/maintenance/wing_port)
+"Pi" = (
+/obj/machinery/door/firedoor/glass/talon,
+/obj/machinery/door/airlock/engineering{
+	name = "Talon Port Engines";
+	req_one_access = list(301)
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/port)
+"Pj" = (
+/obj/structure/sink{
+	pixel_y = 22
+	},
+/obj/structure/mirror{
+	pixel_y = 32
+	},
+/obj/machinery/button/remote/airlock{
+	dir = 1;
+	id = "talon_charger";
+	name = "Door Bolts";
+	pixel_y = -28;
+	specialfunctions = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/talon_v2/crew_quarters/restrooms)
+"Pk" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/structure/catwalk,
+/obj/machinery/power/apc/talon/hyper{
+	dir = 8;
+	pixel_x = -24
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/generators)
+"Pl" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
+	},
+/obj/random/multiple/corp_crate/talon_cargo,
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/maintenance/wing_port)
+"Pm" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -13610,52 +12902,279 @@
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
-/obj/machinery/door/airlock{
-	name = "Observation Room"
-	},
-/turf/simulated/floor/tiled/techmaint,
+/turf/simulated/floor/wood,
 /area/talon_v2/crew_quarters/meditation)
-"Tr" = (
+"Po" = (
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/hangar)
+"Pq" = (
+/obj/machinery/atmospherics/pipe/manifold4w/visible/yellow,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/port)
+"Pr" = (
+/obj/structure/bookcase/manuals/research_and_development,
+/turf/simulated/floor/wood,
+/area/talon_v2/crew_quarters/meditation)
+"Ps" = (
+/obj/structure/sink{
+	pixel_y = 22
+	},
+/obj/structure/medical_stand/anesthetic,
+/turf/simulated/floor/tiled/white,
+/area/talon_v2/medical)
+"Pt" = (
+/obj/structure/bookcase/manuals/xenoarchaeology,
+/obj/structure/closet/emergsuit_wall{
+	dir = 4;
+	pixel_x = 32
+	},
+/turf/simulated/floor/wood,
+/area/talon_v2/crew_quarters/meditation)
+"Pv" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/aux{
+	dir = 5
+	},
+/obj/structure/closet/emergsuit_wall{
+	dir = 1;
+	pixel_y = -32
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/wing_starboard)
+"Px" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
+	dir = 10
 	},
+/obj/random/multiple/corp_crate/talon_cargo,
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/maintenance/wing_port)
+"Py" = (
+/obj/effect/floor_decal/industrial/outline/red,
+/obj/machinery/atmospherics/portables_connector{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/canister/phoron/engine_setup,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/port)
+"PA" = (
+/obj/structure/railing/grey{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/table/steel,
+/obj/machinery/recharger,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/refining)
+"PB" = (
+/obj/structure/table/rack/shelf/steel,
+/obj/machinery/recharger/wallcharger{
+	pixel_x = 5;
+	pixel_y = 24
+	},
+/obj/item/weapon/storage/backpack/dufflebag/talon,
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/armory)
+"PC" = (
+/obj/structure/table/rack/shelf/steel,
+/obj/machinery/recharger/wallcharger{
+	pixel_x = 5;
+	pixel_y = 24
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/armory)
+"PD" = (
+/obj/structure/extinguisher_cabinet{
+	dir = 1;
+	pixel_y = -32
+	},
+/obj/machinery/power/smes/buildable/offmap_spawn{
+	RCon_tag = "Talon Port SMES"
+	},
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering)
+"PF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
+	dir = 4
 	},
-/obj/structure/sign/directions/security{
-	dir = 8;
-	pixel_x = -32;
-	pixel_y = 3
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/structure/sign/directions/security/brig{
-	dir = 8;
-	pixel_x = -32;
-	pixel_y = -3
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/sign/department/eng{
+	pixel_y = -32
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/talon_v2/central_hallway)
-"Tt" = (
+"PH" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/structure/closet/emergsuit_wall{
+	dir = 4;
+	pixel_x = 32
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/starboard)
+"PI" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 10
+	},
 /turf/simulated/wall/rshull,
 /area/shuttle/talonboat)
-"Tw" = (
-/obj/machinery/atmospherics/binary/pump/fuel,
-/turf/simulated/floor/tiled/techfloor,
-/area/shuttle/talonboat)
-"Tz" = (
+"PK" = (
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "talonrefinery"
+	},
+/obj/structure/sign/warning/moving_parts{
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/refining)
+"PL" = (
 /obj/structure/hull_corner/long_horiz{
+	dir = 6
+	},
+/turf/space,
+/area/space)
+"PO" = (
+/obj/machinery/door/firedoor/glass/talon,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock{
+	name = "Storage Room"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/gen_store)
+"PP" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/holoposter{
+	dir = 8;
+	pixel_x = -32
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway)
+"PR" = (
+/obj/effect/floor_decal/emblem/talon_big{
 	dir = 10
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/central_hallway/fore)
+"PT" = (
+/obj/machinery/power/pointdefense{
+	id_tag = "talon_pd"
+	},
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 10
+	},
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 9
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/space)
-"TA" = (
+"PX" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/anomaly_storage)
+"Qa" = (
 /turf/simulated/wall/shull,
-/area/talon_v2/maintenance/wing_port)
-"TB" = (
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
-/obj/effect/catwalk_plated,
-/obj/structure/disposalpipe/segment{
+/area/talon_v2/engineering)
+"Qb" = (
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc/talon{
+	dir = 1;
+	name = "north bump";
+	pixel_y = 28
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/anomaly_storage)
+"Qc" = (
+/obj/structure/table/steel,
+/obj/item/device/measuring_tape,
+/obj/item/weapon/tool/wrench,
+/obj/item/weapon/storage/excavation,
+/obj/item/stack/flag/yellow,
+/obj/item/weapon/pickaxe,
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/anomaly_storage)
+"Qe" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/wall/shull,
+/area/talon_v2/ofd_ops)
+"Qf" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/visible/yellow{
+	dir = 1
+	},
+/obj/effect/catwalk_plated/dark,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/starboard)
+"Qi" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/map_helper/airlock/sensor/int_sensor,
+/obj/machinery/airlock_sensor{
+	dir = 4;
+	pixel_x = -28;
+	req_one_access = list(301)
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/ofd_ops)
+"Qj" = (
+/obj/structure/catwalk,
+/obj/machinery/light/small{
+	dir = 8
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -13663,15 +13182,98 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
-/area/talon_v2/central_hallway/port)
-"TD" = (
-/obj/structure/bed/chair/bay/chair,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/area/talon_v2/maintenance/fore_port)
+"Qk" = (
+/obj/structure/hull_corner/long_horiz{
+	dir = 6
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/space)
+"Qm" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/obj/random/multiple/corp_crate/talon_cargo,
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/maintenance/wing_starboard)
+"Qn" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/random/multiple/corp_crate/talon_cargo,
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/maintenance/wing_starboard)
+"Qo" = (
+/obj/effect/map_helper/airlock/sensor/int_sensor,
+/obj/structure/sign/warning/airlock{
+	pixel_y = 32
+	},
+/obj/machinery/airlock_sensor{
+	dir = 4;
+	pixel_x = -28;
+	pixel_y = -28;
+	req_one_access = list(301)
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/aux{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/maintenance/fore_port)
+"Qq" = (
+/obj/structure/hull_corner/long_horiz{
 	dir = 10
 	},
-/turf/simulated/floor/wood,
-/area/talon_v2/crew_quarters/meditation)
-"TE" = (
+/turf/space,
+/area/space)
+"Qt" = (
+/obj/machinery/power/apc/talon/hyper{
+	pixel_y = -24
+	},
+/obj/effect/catwalk_plated/dark,
+/obj/structure/closet/walllocker_double/hydrant/west,
+/obj/structure/cable/green,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering)
+"Qu" = (
+/obj/structure/table/rack/shelf/steel,
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/armory)
+"Qx" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/random/multiple/corp_crate/talon_cargo,
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/maintenance/wing_starboard)
+"Qy" = (
+/turf/simulated/wall/shull,
+/area/talon_v2/maintenance/fore_starboard)
+"Qz" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/handrail{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	dir = 8;
+	pixel_x = 30
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/maintenance/wing_starboard)
+"QA" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/random/multiple/corp_crate/talon_cargo,
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/maintenance/wing_port)
+"QB" = (
 /obj/structure/sink{
 	pixel_y = 22
 	},
@@ -13688,85 +13290,446 @@
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled/white,
 /area/talon_v2/crew_quarters/restrooms)
-"TG" = (
-/obj/machinery/power/apc/talon{
-	dir = 1;
-	name = "north bump";
-	pixel_y = 28
-	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
+"QC" = (
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/bridge)
+"QD" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/secure_storage)
+"QE" = (
+/turf/simulated/wall/rshull,
+/area/talon_v2/central_hallway/fore)
+"QF" = (
+/obj/machinery/atmospherics/pipe/simple/visible,
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
-/area/talon_v2/engineering/port_store)
-"TJ" = (
-/obj/structure/catwalk,
+/area/talon_v2/engineering/atmospherics)
+"QH" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/aux{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/wing_starboard)
+"QI" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/maintenance/wing_port)
+"QJ" = (
+/obj/machinery/atmospherics/portables_connector/aux{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/outline,
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/wing_starboard)
+"QM" = (
+/obj/effect/shuttle_landmark/shuttle_initializer/talonboat,
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/plating,
-/area/talon_v2/maintenance/aft_starboard)
-"TL" = (
-/obj/machinery/alarm/talon{
-	dir = 8;
-	pixel_x = 22
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 4
 	},
-/obj/structure/bed/pod,
-/obj/item/weapon/bedsheet/blue,
-/obj/machinery/computer/ship/navigation/telescreen{
-	pixel_y = -32
-	},
-/obj/machinery/light,
-/turf/simulated/floor/carpet,
-/area/talon_v2/crew_quarters/pilot_room)
-"TN" = (
-/obj/structure/catwalk,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/port_store)
-"TO" = (
-/obj/structure/sign/warning/airlock{
-	pixel_x = 32
-	},
-/obj/effect/floor_decal/industrial/warning,
-/obj/structure/handrail{
+/obj/effect/overmap/visitable/ship/landable/talon_boat,
+/obj/structure/handrail,
+/obj/effect/floor_decal/industrial/warning{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/aux{
+	dir = 4
+	},
+/obj/structure/closet/walllocker_double/survival/north,
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/maintenance/wing_starboard)
-"TP" = (
-/obj/effect/map_helper/airlock/sensor/int_sensor,
-/obj/machinery/airlock_sensor{
-	dir = 8;
-	pixel_x = 28;
-	pixel_y = -28;
+/area/shuttle/talonboat)
+"QN" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/aux{
+	dir = 9
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/central_hallway/fore)
+"QO" = (
+/obj/machinery/door/blast/regular/open{
+	dir = 2;
+	id = "talon_bridge_shields"
+	},
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 4
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/talon_v2/bridge)
+"QP" = (
+/obj/effect/shuttle_landmark/premade/talon_v2_near_aft_port,
+/turf/space,
+/area/space)
+"QR" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway/port)
+"QS" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway)
+"QU" = (
+/turf/simulated/wall/rshull,
+/area/talon_v2/crew_quarters/bar)
+"QV" = (
+/obj/machinery/door/airlock/glass_external{
 	req_one_access = list(301)
 	},
-/obj/structure/sign/warning/airlock{
-	pixel_y = 32
-	},
+/obj/effect/map_helper/airlock/door/int_door,
 /obj/machinery/atmospherics/pipe/simple/hidden/aux{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/maintenance/fore_port)
+"QW" = (
+/obj/machinery/atmospherics/pipe/manifold/visible/red{
+	dir = 8
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/atmospherics)
+"Ra" = (
+/obj/structure/railing/grey{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/bridge)
+"Rb" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/glass/talon,
+/obj/machinery/door/airlock/engineering{
+	name = "Talon Port Engines & Spare Fuel";
+	req_one_access = list(301)
+	},
+/obj/structure/sign/warning/nosmoking_1{
+	pixel_x = -26
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/port)
+"Rd" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/structure/catwalk,
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering)
+"Re" = (
+/turf/simulated/wall/rshull,
+/area/talon_v2/maintenance/fore_port)
+"Rf" = (
+/obj/structure/hull_corner/long_vert{
+	dir = 5
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/space)
+"Rg" = (
+/obj/structure/bed/chair/bay/chair{
+	dir = 1
+	},
+/turf/simulated/floor/carpet,
+/area/talon_v2/crew_quarters/eng_room)
+"Ri" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/catwalk,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/aft_starboard)
+"Rj" = (
+/obj/machinery/atmospherics/binary/pump/high_power/on{
+	dir = 4
+	},
+/obj/structure/railing/grey{
+	dir = 4
+	},
+/obj/structure/railing/grey{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/atmospherics)
+"Rk" = (
+/obj/effect/shuttle_landmark/premade/talon_v2_near_aft_star,
+/turf/space,
+/area/space)
+"Rn" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/structure/catwalk,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/starboard)
+"Rp" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway/port)
+"Rs" = (
+/turf/simulated/floor/wood,
+/area/talon_v2/crew_quarters/cap_room)
+"Rt" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 4
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/atmospherics)
+"Ru" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/maintenance/wing_port)
+"Rx" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/maintenance/fore_starboard)
-"TR" = (
-/turf/simulated/wall/rshull,
-/area/talon_v2/maintenance/wing_port)
-"TT" = (
-/mob/living/simple_mob/animal/passive/dog/corgi/puppy{
-	desc = "That's Hendrickson, warden of the Talon's brig. No schemes can escape the watchful gleam of this corgi's deep, dark eyes.";
-	name = "Hendrickson"
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 4
 	},
-/obj/structure/dogbed,
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 1
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/port)
+"Ry" = (
+/obj/machinery/mineral/stacking_machine,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/refining)
+"RA" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/aux{
+	dir = 4
+	},
+/obj/structure/closet/emergsuit_wall{
+	dir = 1;
+	pixel_y = -32
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/wing_port)
+"RB" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/computer/guestpass{
+	dir = 4;
+	pixel_x = -26
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway)
+"RC" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/aux{
+	dir = 9
+	},
+/obj/structure/closet/emergsuit_wall{
+	dir = 1;
+	pixel_y = -32
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/wing_port)
+"RE" = (
+/obj/structure/table/rack/steel,
+/obj/random/maintenance/engineering,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/star_store)
+"RF" = (
+/obj/structure/railing/grey{
+	dir = 1
+	},
+/obj/structure/flora/pottedplant/small,
 /turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/brig)
-"TW" = (
+/area/talon_v2/bridge)
+"RG" = (
+/obj/machinery/light/small,
+/obj/structure/sign/directions/engineering/engeqp{
+	pixel_y = -24
+	},
+/turf/simulated/floor/carpet,
+/area/talon_v2/crew_quarters/eng_room)
+"RI" = (
+/obj/machinery/vending/tool{
+	req_log_access = 301
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/engineering/star_store)
+"RJ" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/structure/ship_munition/disperser_charge/explosive,
+/turf/simulated/floor/reinforced,
+/area/talon_v2/ofd_ops)
+"RK" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/closet/crate,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/clean,
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/gen_store)
+"RO" = (
+/obj/machinery/power/sensor{
+	name = "Talon Power Generation";
+	name_tag = "TLN-PWR-GEN"
+	},
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/cable/yellow,
+/obj/structure/cable/yellow{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/effect/catwalk_plated/dark,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering)
+"RP" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/structure/handrail,
+/obj/structure/closet/autolok_wall{
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/talonboat)
+"RQ" = (
+/turf/simulated/wall/shull,
+/area/talon_v2/medical)
+"RT" = (
+/obj/machinery/atmospherics/omni/atmos_filter{
+	name = "N2/O2 Filter";
+	tag_east = 4;
+	tag_north = 3;
+	tag_south = 2;
+	tag_west = 1
+	},
+/obj/effect/catwalk_plated/dark,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/atmospherics)
+"RV" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/random/multiple/corp_crate/talon_cargo,
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/maintenance/wing_port)
+"RZ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/talon_v2/crew_quarters/meditation)
+"Sa" = (
+/obj/structure/table/rack/shelf/steel,
+/obj/item/weapon/gun/energy/gun,
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/armory)
+"Sb" = (
+/obj/structure/bed/chair/wood,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/carpet/blucarpet,
+/area/talon_v2/crew_quarters/cap_room)
+"Sd" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 4;
@@ -13780,880 +13743,378 @@
 	},
 /turf/simulated/floor/wood,
 /area/talon_v2/crew_quarters/meditation)
-"TX" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
+"Sf" = (
 /obj/structure/catwalk,
-/turf/simulated/floor/plating,
+/obj/structure/handrail,
+/turf/simulated/floor/reinforced/airless,
 /area/talon_v2/maintenance/aft_port)
-"TZ" = (
-/obj/machinery/atmospherics/pipe/manifold/visible{
-	dir = 8
-	},
-/obj/structure/railing/grey,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/atmospherics)
-"Ua" = (
-/obj/machinery/camera/network/talon{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway)
-"Uf" = (
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 6
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/obj/machinery/firealarm{
-	layer = 3.3;
-	pixel_y = 26
-	},
-/obj/structure/catwalk,
-/obj/machinery/camera/network/talon,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/starboard)
-"Ug" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/hangar)
-"Uh" = (
-/obj/machinery/atmospherics/pipe/simple/visible/blue{
-	dir = 10
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/atmospherics)
-"Uj" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/bed/chair/bay/chair,
-/turf/simulated/floor/carpet,
-/area/talon_v2/crew_quarters/med_room)
-"Uk" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/maintenance/wing_starboard)
-"Um" = (
-/obj/machinery/mineral/mint,
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/refining)
-"Un" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 5
-	},
+"Sg" = (
+/turf/simulated/wall/rshull,
+/area/talon_v2/maintenance/fore_starboard)
+"Si" = (
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/alarm/talon{
-	dir = 1;
-	pixel_y = -25
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/atmospherics)
-"Uo" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/catwalk,
-/obj/machinery/alarm/talon{
-	dir = 4;
-	pixel_x = -22
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/maintenance/aft_starboard)
-"Up" = (
-/turf/simulated/wall/rshull,
-/area/talon_v2/maintenance/wing_starboard)
-"Ur" = (
-/obj/structure/table/woodentable,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/item/modular_computer/laptop/preset/custom_loadout/standard/talon/pilot,
-/turf/simulated/floor/carpet,
-/area/talon_v2/crew_quarters/pilot_room)
-"Us" = (
-/obj/effect/map_helper/airlock/atmos/chamber_pump,
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/aux{
-	dir = 1
-	},
-/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	dir = 1;
-	id_tag = "talon_starboard";
-	pixel_y = -30;
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway/port)
+"Sj" = (
+/obj/machinery/door/firedoor/glass/talon,
+/obj/machinery/door/airlock/maintenance/medical{
 	req_one_access = list(301)
 	},
-/obj/structure/handrail{
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/warning{
+/turf/simulated/floor/plating,
+/area/talon_v2/medical)
+"Sk" = (
+/turf/simulated/wall/shull,
+/area/talon_v2/crew_quarters/restrooms)
+"Sn" = (
+/obj/structure/bookcase/manuals/engineering,
+/turf/simulated/floor/wood,
+/area/talon_v2/crew_quarters/meditation)
+"So" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/maintenance/wing_starboard)
-"Uu" = (
-/obj/machinery/light{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/holoposter{
+	dir = 1;
+	pixel_y = 32
+	},
 /turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway)
-"Uw" = (
-/obj/structure/bed/chair/bay/chair,
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
+/area/talon_v2/central_hallway/port)
+"Sr" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/engineering)
-"Ux" = (
-/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	id_tag = "talon_boat";
-	pixel_y = 24
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/aux{
-	dir = 1
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/structure/handrail,
+/obj/structure/sign/department/shield{
+	pixel_y = -31
+	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/shuttle/talonboat)
-"Uz" = (
-/obj/structure/catwalk,
-/obj/structure/handrail{
-	dir = 8
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/talon_v2/maintenance/fore_port)
-"UA" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/aux{
-	dir = 4
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/maintenance/wing_starboard)
-"UB" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/hangar)
-"UC" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/toilet,
-/turf/simulated/floor/tiled/white,
-/area/talon_v2/crew_quarters/restrooms)
-"UF" = (
-/obj/structure/bookcase/manuals/medical,
-/obj/machinery/camera/network/talon,
-/turf/simulated/floor/wood,
-/area/talon_v2/crew_quarters/meditation)
-"UG" = (
-/obj/machinery/camera/network/talon{
-	dir = 8
-	},
 /turf/simulated/floor/tiled/techmaint,
 /area/talon_v2/central_hallway)
-"UI" = (
-/obj/machinery/power/pointdefense{
-	id_tag = "talon_pd"
-	},
+"Ss" = (
 /obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/turf/simulated/floor/reinforced/airless,
-/area/space)
-"UJ" = (
-/obj/structure/railing/grey{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/bridge)
-"UK" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/talon_v2/crew_quarters/cap_room)
+"St" = (
+/obj/structure/table/woodentable,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
-/obj/machinery/light/small,
+/obj/item/weapon/paper/talon_pilot,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/turf/simulated/floor/carpet,
+/area/talon_v2/crew_quarters/pilot_room)
+"Su" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 9
+	},
+/obj/structure/catwalk,
 /turf/simulated/floor/plating,
-/area/talon_v2/engineering/port)
-"UL" = (
-/obj/structure/disposalpipe/trunk,
-/obj/machinery/disposal,
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/central_hallway/fore)
-"UN" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
+/area/talon_v2/engineering/atmospherics)
+"Sv" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/fuel{
+	dir = 1
+	},
+/turf/simulated/wall/rshull,
+/area/shuttle/talonboat)
+"Sx" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/wood,
+/area/talon_v2/crew_quarters/meditation)
+"Sy" = (
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 5
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/talon_v2/engineering/starboard)
+"Sz" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/visible/yellow,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/starboard)
-"UR" = (
-/obj/machinery/power/pointdefense{
-	id_tag = "talon_pd"
-	},
-/obj/effect/floor_decal/industrial/warning/dust{
-	dir = 10
-	},
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/space)
-"UW" = (
-/obj/machinery/power/pointdefense{
-	id_tag = "talon_pd"
-	},
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/space)
-"UX" = (
-/obj/structure/closet/emergsuit_wall{
-	dir = 1;
-	pixel_y = -32
 	},
 /turf/simulated/floor/wood,
 /area/talon_v2/crew_quarters/sec_room)
-"Va" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+"SC" = (
+/obj/machinery/button/remote/blast_door{
+	id = "talon_cargo_port";
+	name = "Cargo Loading Hatches";
+	pixel_y = -28
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/obj/structure/window/reinforced{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway/port)
-"Vc" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/bridge)
-"Vf" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/computer/guestpass{
-	dir = 4;
-	pixel_x = -26
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway)
-"Vg" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/catwalk,
-/obj/machinery/light/small{
+/obj/structure/window/reinforced{
 	dir = 8
 	},
-/turf/simulated/floor/plating,
-/area/talon_v2/maintenance/aft_port)
-"Vh" = (
-/obj/structure/hull_corner{
-	dir = 1
-	},
-/turf/space,
-/area/space)
-"Vi" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 1
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway)
-"Vj" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/aux{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/shuttle/talonboat)
-"Vo" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/brig)
-"Vp" = (
-/obj/structure/table/woodentable,
-/obj/item/modular_computer/tablet/preset/custom_loadout/advanced,
-/obj/item/weapon/paper_bin,
-/obj/item/weapon/pen,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
-/turf/simulated/floor/carpet/blucarpet,
-/area/talon_v2/crew_quarters/cap_room)
-"Vs" = (
-/obj/machinery/atmospherics/pipe/tank/nitrogen{
-	dir = 8
-	},
-/obj/structure/railing/grey,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/atmospherics)
-"Vt" = (
-/obj/machinery/door/firedoor/glass/talon,
-/obj/machinery/door/airlock/glass{
-	name = "Workroom"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/workroom)
-"Vv" = (
-/obj/machinery/portable_atmospherics/canister/phoron/engine_setup,
-/obj/effect/floor_decal/industrial/outline/red,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/port)
-"Vw" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/alarm/talon{
-	dir = 8;
-	pixel_x = 22
-	},
-/obj/random/multiple/corp_crate/talon_cargo,
-/obj/structure/railing/grey,
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/maintenance/wing_port)
-"Vx" = (
-/obj/machinery/door/firedoor/glass/talon,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/airlock/security{
-	id_tag = "talon_secdoor";
-	name = "Guard's Cabin";
+/obj/machinery/door/window/brigdoor/northleft{
+	req_access = list();
 	req_one_access = list(301)
 	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/crew_quarters/sec_room)
-"VD" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/random/multiple/corp_crate/talon_cargo,
+/obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/techfloor,
 /area/talon_v2/maintenance/wing_port)
-"VE" = (
-/obj/item/weapon/storage/box/bodybags,
-/obj/item/roller,
-/obj/item/roller{
-	pixel_y = 8
+"SE" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/structure/table/standard,
-/turf/simulated/floor/tiled/white,
-/area/talon_v2/medical)
-"VF" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/floor_decal/corner/black/diagonal,
-/obj/item/weapon/stool/baystool/padded{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/talon_v2/crew_quarters/bar)
-"VH" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
-/area/talon_v2/engineering/port)
-"VI" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/wall/rshull,
-/area/talon_v2/bridge)
-"VK" = (
-/obj/machinery/atmospherics/omni/mixer{
-	name = "Air Mixer";
-	tag_north = 2;
-	tag_south = 1;
-	tag_south_con = 0.79;
-	tag_west = 1;
-	tag_west_con = 0.21
-	},
-/obj/effect/catwalk_plated/dark,
-/turf/simulated/floor/plating,
 /area/talon_v2/engineering/atmospherics)
-"VO" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+"SG" = (
+/obj/machinery/light/small{
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 1;
 	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/power/apc/talon{
-	dir = 1;
-	name = "north bump";
-	pixel_y = 28
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway/port)
-"VQ" = (
-/obj/machinery/door/firedoor/glass/talon,
-/obj/machinery/door/airlock/maintenance/common,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
 /area/talon_v2/maintenance/wing_starboard)
-"VS" = (
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/refining)
-"VT" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/aux,
-/obj/machinery/recharge_station,
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/central_hallway/fore)
-"VX" = (
-/obj/machinery/alarm/talon{
-	dir = 1;
-	pixel_y = -25
-	},
-/obj/structure/reagent_dispensers/foam,
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/gen_store)
-"VY" = (
-/obj/structure/closet/walllocker/emerglocker/east,
+"SJ" = (
 /obj/machinery/light{
 	dir = 4
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/secure_storage)
-"Wa" = (
-/obj/machinery/atmospherics/portables_connector/aux{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/outline,
-/obj/machinery/portable_atmospherics/canister/air,
-/turf/simulated/floor/plating,
-/area/talon_v2/maintenance/wing_port)
-"Wb" = (
-/obj/machinery/shipsensors{
-	dir = 1
-	},
-/turf/simulated/floor/reinforced,
-/area/shuttle/talonboat)
-"Wc" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/obj/machinery/power/apc/talon{
-	name = "south bump";
-	pixel_y = -24
 	},
 /obj/structure/cable/green{
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/machinery/camera/network/talon{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/hangar)
-"Wd" = (
-/obj/machinery/autolathe,
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/workroom)
-"Wf" = (
-/obj/machinery/door/airlock/glass_external{
-	req_one_access = list(301)
-	},
-/obj/effect/map_helper/airlock/door/int_door,
-/obj/machinery/atmospherics/pipe/simple/hidden/aux,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/maintenance/aft_starboard)
-"Wj" = (
-/obj/structure/table/standard,
-/obj/machinery/chemical_dispenser/biochemistry/full,
-/turf/simulated/floor/tiled/white,
-/area/talon_v2/medical)
-"Wk" = (
-/obj/structure/table/standard,
-/obj/machinery/chemical_dispenser/full,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/talon_v2/medical)
-"Wl" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/gen_store)
-"Wm" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/closet/walllocker_double/hydrant/north,
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway/port)
-"Wo" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/blast/regular{
+/obj/machinery/power/apc/talon{
 	dir = 4;
-	id = "talon_cargo_star";
-	name = "Cargo Loading Hatch"
+	name = "east bump";
+	pixel_x = 24
 	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/maintenance/wing_starboard)
-"Wp" = (
-/obj/structure/table/woodentable,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/item/modular_computer/laptop/preset/custom_loadout/standard/talon/security,
-/obj/machinery/camera/network/talon{
-	dir = 1
-	},
-/turf/simulated/floor/carpet,
-/area/talon_v2/crew_quarters/sec_room)
-"Wq" = (
-/obj/machinery/door/firedoor/glass/talon,
-/obj/machinery/door/airlock/command{
-	id_tag = "talon_capdoor";
-	name = "Captain's Cabin";
-	req_one_access = list(301)
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/bridge)
-"Wr" = (
+/turf/simulated/floor/wood,
+/area/talon_v2/crew_quarters/meditation)
+"SK" = (
+/obj/machinery/light/small,
 /obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/bed/chair/bay/chair,
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/central_hallway)
-"Ws" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/aft_port)
+"SL" = (
+/obj/machinery/door/firedoor/glass/talon,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/railing/grey,
-/obj/random/multiple/corp_crate/talon_cargo,
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/maintenance/wing_starboard)
-"Wt" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/obj/effect/catwalk_plated,
-/obj/structure/disposalpipe/junction,
-/obj/structure/sign/directions/engineering{
-	pixel_x = 32;
-	pixel_y = -3
-	},
-/obj/structure/sign/directions/engineering/atmospherics{
-	dir = 8;
-	pixel_x = 32;
-	pixel_y = 3
+/obj/machinery/door/airlock{
+	id_tag = "talon_pilotdoor";
+	name = "Pilot's Cabin";
+	req_one_access = list(301)
 	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/crew_quarters/pilot_room)
+"SN" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/armory)
+"SQ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/sign/department/armory{
+	name = "GUARD'S QUARTERS";
+	pixel_x = -32
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway/fore)
+"SS" = (
+/obj/machinery/power/pointdefense{
+	id_tag = "talon_pd"
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/space)
+"ST" = (
 /obj/structure/cable/green{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/plating,
-/area/talon_v2/central_hallway)
-"Wu" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/turf/simulated/floor/tiled/white,
-/area/talon_v2/medical)
-"Wy" = (
-/obj/machinery/cryopod/talon,
-/obj/machinery/camera/network/talon,
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/central_hallway)
-"Wz" = (
-/obj/machinery/button/remote/airlock{
-	dir = 8;
-	id = "talon_engdoor";
-	name = "Door Bolts";
-	pixel_x = -28;
-	specialfunctions = 4
-	},
-/obj/item/weapon/bedsheet/orange,
-/obj/structure/bed/pod,
-/obj/machinery/light_switch{
-	dir = 1;
-	pixel_y = -26
-	},
-/turf/simulated/floor/carpet,
-/area/talon_v2/crew_quarters/eng_room)
-"WB" = (
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/closet/walllocker_double/hydrant/north,
 /turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway/star)
-"WC" = (
-/obj/structure/hull_corner/long_vert{
-	dir = 9
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/space)
-"WF" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+/area/talon_v2/maintenance/wing_starboard)
+"SU" = (
+/obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/port)
-"WJ" = (
-/turf/simulated/wall/shull,
-/area/talon_v2/crew_quarters/eng_room)
-"WK" = (
-/obj/structure/table/woodentable,
-/obj/item/clothing/accessory/talon{
-	pixel_x = 4;
-	pixel_y = 7
-	},
-/obj/item/clothing/head/caphat/talon{
-	pixel_x = -5
-	},
-/turf/simulated/floor/wood,
-/area/talon_v2/crew_quarters/cap_room)
-"WM" = (
-/obj/machinery/atmospherics/unary/engine/bigger{
+/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
-/turf/space,
-/area/talon_v2/engineering/starboard)
-"WN" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/blue{
-	dir = 8
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/atmospherics)
-"WQ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/aux,
-/obj/machinery/camera/network/talon{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/central_hallway/fore)
-"WS" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/machinery/alarm/talon{
-	pixel_y = 28
-	},
-/turf/simulated/floor/wood,
-/area/talon_v2/crew_quarters/eng_room)
-"WT" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/closet/emergsuit_wall{
-	dir = 1;
-	pixel_y = -32
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/central_hallway/fore)
-"WU" = (
-/obj/effect/floor_decal/industrial/outline/red,
-/obj/machinery/portable_atmospherics/canister/empty/phoron,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/star_store)
-"WY" = (
-/obj/machinery/atmospherics/pipe/simple/visible/red,
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/atmospherics)
-"WZ" = (
-/turf/simulated/wall/shull,
-/area/talon_v2/maintenance/aft_port)
-"Xa" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/catwalk,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/plating,
-/area/talon_v2/maintenance/aft_port)
-"Xb" = (
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/hangar)
+"SV" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/power/sensor{
+	name = "Talon Main Grid";
+	name_tag = "TLN-MAIN-GRID"
+	},
 /obj/structure/cable/green{
-	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "0-8"
 	},
-/turf/simulated/wall/rshull,
-/area/talon_v2/maintenance/wing_starboard)
-"Xf" = (
-/obj/machinery/telecomms/allinone/talon{
-	id = "talon_aio";
-	network = "Talon"
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
 	},
+/obj/structure/cable/green,
+/obj/effect/catwalk_plated/dark,
+/obj/structure/sign/department/eng{
+	name = "ENGINEER'S QUARTERS";
+	pixel_x = 32
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering)
+"SW" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/star_store)
+"SX" = (
+/obj/structure/hull_corner{
+	dir = 4
+	},
+/turf/simulated/floor/reinforced,
+/area/shuttle/talonboat)
+"SY" = (
+/obj/machinery/atmospherics/unary/engine{
+	dir = 1
+	},
+/turf/simulated/floor/reinforced,
+/area/shuttle/talonboat)
+"SZ" = (
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 1
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/talon_v2/engineering/port)
+"Ta" = (
+/obj/structure/hull_corner{
+	dir = 1
+	},
+/turf/simulated/floor/reinforced,
+/area/shuttle/talonboat)
+"Tb" = (
+/obj/structure/table/rack/shelf/steel,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/star_store)
+"Td" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/workroom)
+"Tf" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/engineering)
-"Xh" = (
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/starboard)
+"Tg" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/wood,
+/area/talon_v2/crew_quarters/eng_room)
+"Ti" = (
+/obj/structure/table/standard,
+/obj/item/weapon/storage/box/handcuffs,
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/brig)
+"Tk" = (
 /obj/machinery/door/firedoor/glass/talon,
 /obj/machinery/door/airlock/maintenance/engi{
 	name = "Starboard Eng. Storage";
@@ -14666,56 +14127,72 @@
 	},
 /turf/simulated/floor/plating,
 /area/talon_v2/engineering/star_store)
-"Xi" = (
+"Tl" = (
+/turf/simulated/wall/shull{
+	can_open = 1
+	},
+/area/talon_v2/engineering/atmospherics)
+"Tm" = (
+/obj/structure/catwalk,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/talon_v2/maintenance/aft_starboard)
+"To" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/ofd_ops)
+"Tq" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/maintenance/wing_port)
-"Xj" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/aux,
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/maintenance/wing_starboard)
-"Xl" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/camera/network/talon{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/talon_v2/medical)
-"Xm" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/brig)
-"Xn" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/area/talon_v2/gen_store)
+"Tr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment{
+/obj/structure/bed/chair/bay/chair,
+/turf/simulated/floor/carpet,
+/area/talon_v2/crew_quarters/sec_room)
+"Ts" = (
+/obj/structure/sign/warning/nosmoking_1{
+	pixel_x = 26
+	},
+/obj/structure/table/rack/shelf/steel,
+/obj/random/maintenance/engineering,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/port_store)
+"Tt" = (
+/turf/simulated/wall/rshull,
+/area/shuttle/talonboat)
+"Tw" = (
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/talonboat)
+"Tz" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
-/obj/structure/sign/directions/bar{
-	dir = 1;
-	pixel_x = 32;
-	pixel_y = -3
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/hangar)
+"TA" = (
+/turf/simulated/wall/shull,
+/area/talon_v2/maintenance/wing_port)
+"TB" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
 	},
-/obj/structure/sign/directions/bridge{
-	dir = 1;
-	pixel_x = 32;
-	pixel_y = 3
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -14723,30 +14200,595 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway)
-"Xo" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/aux{
-	dir = 4
+/area/talon_v2/secure_storage)
+"TD" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/handrail{
+/obj/structure/sign/department/biblio{
+	pixel_y = -32
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway/port)
+"TE" = (
+/obj/structure/railing/grey{
 	dir = 1
 	},
-/obj/machinery/light_switch{
-	dir = 1;
-	pixel_x = 8;
-	pixel_y = -26
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/obj/structure/fuel_port/heavy{
+/obj/machinery/smartfridge/sheets/persistent_lossy{
+	layer = 3.3
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/refining)
+"TF" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/starboard)
+"TG" = (
+/obj/machinery/atmospherics/omni/atmos_filter{
+	name = "CO2 Filter";
+	tag_east = 2;
+	tag_north = 1;
+	tag_south = 5
+	},
+/obj/effect/catwalk_plated/dark,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/atmospherics)
+"TH" = (
+/obj/structure/closet/crate,
+/obj/structure/railing/grey,
+/obj/structure/extinguisher_cabinet{
+	dir = 4;
+	pixel_x = -30
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/refining)
+"TJ" = (
+/obj/machinery/mineral/stacking_unit_console{
+	pixel_y = -6;
+	req_one_access = list(301)
+	},
+/obj/structure/girder,
+/obj/structure/railing/grey{
+	dir = 4
+	},
+/obj/structure/railing/grey{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/refining)
+"TL" = (
+/obj/machinery/suit_cycler/vintage/tpilot,
+/obj/machinery/button/remote/airlock{
+	id = "talon_pilotdoor";
+	name = "Door Bolts";
+	pixel_y = 28;
+	specialfunctions = 4
+	},
+/turf/simulated/floor/wood,
+/area/talon_v2/crew_quarters/pilot_room)
+"TN" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/port_store)
+"TO" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/random/multiple/corp_crate/talon_cargo,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/maintenance/wing_starboard)
+"TP" = (
+/obj/structure/bed/chair/bay/shuttle,
+/obj/structure/closet/walllocker_double/survival/north,
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/talonpod)
+"TR" = (
+/obj/effect/floor_decal/industrial/warning/dust/corner{
+	dir = 4
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/space)
+"TW" = (
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
+/obj/effect/catwalk_plated,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/central_hallway/port)
+"TX" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/aft_port)
+"TY" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/item/modular_computer/console/preset/talon{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/engineering)
+"TZ" = (
+/obj/machinery/conveyor{
 	dir = 1;
-	pixel_y = -28
+	id = "talonrefinery"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/refining)
+"Ua" = (
+/obj/effect/floor_decal/industrial/warning/corner,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/anomaly_storage)
+"Uc" = (
+/obj/machinery/atmospherics/pipe/simple/visible/red,
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/atmospherics)
+"Ud" = (
+/obj/structure/bed/chair/bay/chair{
+	dir = 1
+	},
+/obj/structure/panic_button{
+	pixel_x = -32;
+	pixel_y = 32
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/talonboat)
-"Xp" = (
+"Ue" = (
+/obj/machinery/power/pointdefense{
+	id_tag = "talon_pd"
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 5
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/space)
+"Uf" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/anomaly_storage)
+"Ug" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/hangar)
+"Uh" = (
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/hangar)
+"Uj" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/aux{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/glass/talon,
+/obj/machinery/door/airlock/maintenance/common,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/fore_starboard)
+"Uk" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/maintenance/wing_starboard)
+"Um" = (
+/obj/structure/closet/crate,
+/obj/structure/railing/grey{
+	dir = 1
+	},
+/obj/machinery/camera/network/talon{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/refining)
+"Un" = (
+/obj/machinery/atmospherics/pipe/tank/oxygen{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/talon_v2/engineering/atmospherics)
-"Xq" = (
+"Uo" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/effect/floor_decal/industrial/warning/corner,
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/anomaly_storage)
+"Up" = (
+/obj/effect/floor_decal/industrial/warning/dust/corner{
+	dir = 1
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/space)
+"Ur" = (
+/obj/structure/sign/department/bridge{
+	name = "PILOT'S QUARTERS";
+	pixel_y = -32
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/central_hallway/fore)
+"Us" = (
+/obj/structure/hull_corner/long_horiz{
+	dir = 10
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/space)
+"Ut" = (
+/turf/simulated/wall/rshull,
+/area/talon_v2/crew_quarters/cap_room)
+"Uu" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/closet/emergsuit_wall{
+	dir = 8;
+	pixel_x = -32
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway)
+"Uv" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/catwalk,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/star_store)
+"Uw" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/sign/department/telecoms{
+	pixel_y = -31
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway)
+"Ux" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/structure/closet/autolok_wall{
+	pixel_y = 32
+	},
+/obj/structure/bed/chair/bay/shuttle,
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/talonboat)
+"UA" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/anomaly_storage)
+"UB" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway)
+"UC" = (
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 8
+	},
+/obj/machinery/alarm/talon{
+	dir = 8;
+	pixel_x = 22
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/anomaly_storage)
+"UD" = (
+/obj/machinery/atmospherics/binary/pump/high_power/on,
+/obj/structure/railing/grey{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/port)
+"UF" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/random/multiple/corp_crate/talon_cargo,
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/maintenance/wing_starboard)
+"UG" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/aux{
+	dir = 4
+	},
+/obj/structure/closet/emergsuit_wall{
+	dir = 1;
+	pixel_y = -32
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/wing_starboard)
+"UJ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/bridge)
+"UK" = (
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/atmospherics)
+"UL" = (
+/obj/machinery/door/firedoor/glass/talon,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/central_hallway/fore)
+"UM" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/aft_starboard)
+"UN" = (
+/obj/structure/hull_corner/long_vert{
+	dir = 9
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/space)
+"UQ" = (
+/obj/structure/sign/warning/airlock{
+	pixel_x = -31
+	},
+/obj/effect/floor_decal/industrial/warning,
+/obj/structure/handrail{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/maintenance/wing_port)
+"UR" = (
+/turf/simulated/wall/rshull,
+/area/talon_v2/crew_quarters/meditation)
+"US" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/yellow,
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/starboard)
+"UW" = (
+/obj/effect/floor_decal/industrial/warning/dust,
+/turf/simulated/floor/reinforced/airless,
+/area/space)
+"UX" = (
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/talon_v2/crew_quarters/meditation)
+"Va" = (
+/obj/structure/bed/chair/bay/chair,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/turf/simulated/floor/wood,
+/area/talon_v2/crew_quarters/meditation)
+"Vc" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/bridge)
+"Vf" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/turf/simulated/floor/wood,
+/area/talon_v2/crew_quarters/meditation)
+"Vg" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/effect/catwalk_plated,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/central_hallway/port)
+"Vh" = (
+/obj/machinery/disposal/wall{
+	dir = 4
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/structure/sign/painting/public{
+	pixel_x = -30
+	},
+/turf/simulated/floor/wood,
+/area/talon_v2/crew_quarters/meditation)
+"Vi" = (
+/obj/structure/bed/chair/bay/chair,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/turf/simulated/floor/wood,
+/area/talon_v2/crew_quarters/meditation)
+"Vj" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/talonboat)
+"Vl" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/camera/network/talon{
+	dir = 1
+	},
+/obj/structure/vehiclecage/quadbike,
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/maintenance/wing_port)
+"Vp" = (
+/turf/simulated/floor/carpet/blucarpet,
+/area/talon_v2/crew_quarters/cap_room)
+"Vr" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/wood,
+/area/talon_v2/crew_quarters/eng_room)
+"Vs" = (
+/obj/machinery/alarm/talon{
+	dir = 8;
+	pixel_x = 22
+	},
+/obj/structure/flora/pottedplant,
+/turf/simulated/floor/wood,
+/area/talon_v2/crew_quarters/meditation)
+"Vt" = (
+/obj/structure/sign/periodic{
+	pixel_y = 32
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/workroom)
+"Vu" = (
 /obj/effect/floor_decal/industrial/warning/dust/corner{
 	dir = 4
 	},
@@ -14755,84 +14797,744 @@
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/space)
-"Xy" = (
+"Vv" = (
+/obj/structure/table/rack/shelf/steel,
+/obj/item/clothing/accessory/holster/machete,
+/obj/item/weapon/material/knife/machete,
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/armory)
+"Vw" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/closet/emergsuit_wall{
+	dir = 4;
+	pixel_x = 32
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/maintenance/wing_port)
+"Vx" = (
+/obj/structure/railing/grey{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/conveyor_switch/oneway{
+	id = "talonrefinery";
+	name = "Conveyor Control";
+	req_one_access = list(301)
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/refining)
+"Vy" = (
+/obj/machinery/power/pointdefense{
+	id_tag = "talon_pd"
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 6
+	},
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 5
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/space)
+"Vz" = (
+/obj/structure/catwalk,
+/obj/structure/handrail,
+/turf/simulated/floor/reinforced/airless,
+/area/talon_v2/maintenance/aft_starboard)
+"VD" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/wood,
-/area/talon_v2/crew_quarters/cap_room)
-"XB" = (
-/obj/machinery/light_switch{
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/maintenance/wing_port)
+"VE" = (
+/obj/structure/closet/emergsuit_wall{
 	dir = 4;
-	pixel_x = -26;
-	pixel_y = 24
+	pixel_x = 32
 	},
-/turf/simulated/floor/wood,
-/area/talon_v2/crew_quarters/bar)
-"XC" = (
-/obj/machinery/atmospherics/portables_connector/aux{
+/turf/simulated/floor/tiled/white,
+/area/talon_v2/medical)
+"VH" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/port)
+"VJ" = (
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/manifold/visible/yellow{
+	dir = 1
+	},
+/obj/structure/railing/grey{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/port)
+"VK" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/structure/closet/walllocker_double/hydrant/west,
+/obj/machinery/light/small{
 	dir = 8
 	},
-/obj/effect/floor_decal/industrial/outline,
-/obj/machinery/portable_atmospherics/canister/air,
-/turf/simulated/floor/plating,
-/area/talon_v2/maintenance/wing_starboard)
-"XD" = (
-/obj/structure/table/standard,
-/obj/fiftyspawner/glass,
 /turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/workroom)
-"XE" = (
+/area/talon_v2/anomaly_storage)
+"VL" = (
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/closet/walllocker/medical/south,
-/obj/item/weapon/storage/firstaid/regular,
-/obj/item/weapon/storage/firstaid/o2,
+/obj/structure/catwalk,
+/obj/structure/closet/emergsuit_wall{
+	dir = 1;
+	pixel_y = -32
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering)
+"VM" = (
+/obj/machinery/atmospherics/pipe/tank/nitrogen{
+	dir = 8
+	},
+/obj/structure/railing/grey,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/atmospherics)
+"VN" = (
+/obj/structure/hull_corner/long_vert{
+	dir = 5
+	},
+/turf/space,
+/area/space)
+"VO" = (
+/obj/structure/anomaly_container,
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/anomaly_storage)
+"VQ" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/anomaly_storage)
+"VS" = (
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/refining)
+"VT" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/aux,
+/turf/simulated/wall/shull,
+/area/talon_v2/ofd_ops)
+"VX" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/anomaly_storage)
+"VY" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/brig)
+"VZ" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/alarm/talon{
+	dir = 8;
+	pixel_x = 22
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/starboard)
+"Wa" = (
+/obj/effect/map_helper/airlock/atmos/chamber_pump,
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/aux,
+/obj/machinery/airlock_sensor{
+	pixel_y = 28;
+	req_one_access = list(301)
+	},
+/obj/effect/map_helper/airlock/sensor/chamber_sensor,
+/obj/structure/handrail,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/maintenance/wing_port)
+"Wb" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway)
+"Wc" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/aux{
+	dir = 1
+	},
+/obj/effect/map_helper/airlock/atmos/chamber_pump,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/shuttle/talonboat)
+"Wd" = (
+/obj/effect/floor_decal/industrial/warning/dust/corner{
+	dir = 8
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/space)
+"Wf" = (
+/obj/structure/catwalk,
+/obj/machinery/alarm/talon{
+	dir = 4;
+	pixel_x = -22
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/star_store)
+"Wj" = (
+/obj/structure/closet/secure_closet/chemical{
+	req_access = list(301)
+	},
+/obj/item/weapon/reagent_containers/spray/cleaner{
+	desc = "Someone has crossed out the 'Space' from Space Cleaner and written in Chemistry. Scrawled on the back is, 'Okay, whoever filled this with polytrinic acid, it was only funny the first time. It was hard enough replacing the CMO's first cat!'";
+	name = "Chemistry Cleaner"
+	},
+/turf/simulated/floor/tiled/white,
+/area/talon_v2/medical)
+"Wk" = (
+/obj/structure/sink{
+	pixel_y = 22
+	},
+/obj/structure/mirror{
+	pixel_y = 32
+	},
+/obj/machinery/button/remote/airlock{
+	dir = 8;
+	id = "talon_restroom2";
+	name = "Door Bolts";
+	pixel_x = -28;
+	specialfunctions = 4
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/tiled/white,
+/area/talon_v2/crew_quarters/restrooms)
+"Wl" = (
+/obj/machinery/power/pointdefense{
+	id_tag = "talon_pd"
+	},
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/space)
+"Wm" = (
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/secure_storage)
+"Wo" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 8
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/space)
+"Wp" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/wall/rshull,
+/area/talon_v2/maintenance/wing_port)
+"Wq" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/maintenance/wing_port)
+"Wr" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/turf/simulated/floor/carpet,
+/area/talon_v2/crew_quarters/pilot_room)
+"Wt" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway)
+"Wu" = (
+/turf/simulated/wall/shull{
+	can_open = 1
+	},
+/area/talon_v2/crew_quarters/restrooms)
+"Wx" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/structure/closet/emergsuit_wall{
+	dir = 4;
+	pixel_x = 32
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/maintenance/wing_port)
+"Wy" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/talon_v2/crew_quarters/med_room)
+"Wz" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/light_switch{
+	pixel_y = 24
+	},
+/turf/simulated/floor/wood,
+/area/talon_v2/crew_quarters/eng_room)
+"WB" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/white,
+/area/talon_v2/medical)
+"WC" = (
+/obj/effect/map_helper/airlock/door/ext_door,
+/obj/machinery/door/airlock/glass_external{
+	req_one_access = list(301)
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/map_helper/airlock/sensor/ext_sensor,
+/obj/machinery/airlock_sensor{
+	pixel_y = 24;
+	req_one_access = list(301)
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/maintenance/wing_starboard)
+"WF" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/port)
+"WI" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/central_hallway/fore)
+"WJ" = (
+/turf/simulated/wall/shull,
+/area/talon_v2/crew_quarters/eng_room)
+"WK" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/door/blast/regular/open{
+	id = "talon_windows"
+	},
+/obj/machinery/door/firedoor/glass/talon,
+/turf/simulated/floor/plating,
+/area/talon_v2/crew_quarters/cap_room)
+"WL" = (
+/turf/simulated/wall/rshull,
+/area/talon_v2/bridge)
+"WM" = (
+/obj/structure/sign/warning/nosmoking_1{
+	pixel_x = -26
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 6
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/starboard)
+"WN" = (
+/obj/machinery/door/firedoor/glass/talon,
+/obj/machinery/door/airlock/glass{
+	name = "Hangar Bay";
+	req_one_access = list(301)
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/hangar)
+"WQ" = (
+/obj/structure/bed/chair/bay/shuttle{
+	dir = 1
+	},
+/obj/structure/closet/walllocker_double/survival/south,
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/talonpod)
+"WS" = (
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_y = -26
+	},
+/obj/structure/table/woodentable,
+/obj/machinery/button/remote/blast_door{
+	dir = 4;
+	id = "talon_quietroom";
+	name = "window blast shields";
+	pixel_x = -28
+	},
+/obj/machinery/recharger,
+/turf/simulated/floor/wood,
+/area/talon_v2/crew_quarters/meditation)
+"WT" = (
+/obj/machinery/vending/nifsoft_shop,
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/central_hallway/fore)
+"WU" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/star_store)
+"WV" = (
+/obj/structure/catwalk,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/talon_v2/maintenance/aft_port)
+"WY" = (
+/obj/machinery/atmospherics/portables_connector,
+/obj/effect/floor_decal/industrial/outline,
+/obj/machinery/portable_atmospherics/powered/pump/filled,
+/obj/structure/railing/grey{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/atmospherics)
+"WZ" = (
+/obj/structure/closet/walllocker/emerglocker/west,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/armory)
+"Xa" = (
+/obj/machinery/alarm/talon{
+	dir = 8;
+	pixel_x = 22
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/aft_port)
+"Xb" = (
+/obj/structure/table/woodentable,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/talon_v2/crew_quarters/meditation)
+"Xe" = (
+/obj/machinery/door/firedoor/glass/talon,
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/door/blast/regular/open{
+	dir = 2;
+	id = "talon_bridge_shields"
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/bridge)
+"Xf" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/hangar)
+"Xh" = (
+/obj/structure/closet/secure_closet/talon_engineer,
 /obj/item/device/radio/off{
 	channels = list("Talon" = 1)
+	},
+/obj/item/weapon/storage/box/nifsofts_engineering,
+/turf/simulated/floor/wood,
+/area/talon_v2/crew_quarters/eng_room)
+"Xi" = (
+/obj/structure/table/woodentable,
+/obj/item/device/paicard,
+/turf/simulated/floor/wood,
+/area/talon_v2/crew_quarters/meditation)
+"Xl" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/talon_v2/medical)
+"Xm" = (
+/obj/machinery/light/small,
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/fore_port)
+"Xn" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/effect/catwalk_plated,
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/central_hallway/fore)
+"Xo" = (
+/obj/structure/bed/chair/bay/chair{
+	dir = 1
+	},
+/obj/machinery/light,
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_x = 8;
+	pixel_y = -26
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_x = -6;
+	pixel_y = -24
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/talonboat)
+"Xp" = (
+/obj/machinery/atmospherics/portables_connector,
+/obj/effect/floor_decal/industrial/outline/blue,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/atmospherics)
+"Xq" = (
+/turf/simulated/wall/rshull,
+/area/talon_v2/maintenance/wing_starboard)
+"Xr" = (
+/turf/space,
+/area/talon_v2/engineering/port)
+"Xw" = (
+/obj/structure/catwalk,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/aft_starboard)
+"Xy" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/wood,
+/area/talon_v2/crew_quarters/cap_room)
+"XA" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering)
+"XB" = (
+/turf/simulated/floor/wood,
+/area/talon_v2/crew_quarters/bar)
+"XC" = (
+/obj/effect/map_helper/airlock/atmos/chamber_pump,
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/aux,
+/obj/machinery/airlock_sensor{
+	pixel_y = 28;
+	req_one_access = list(301)
+	},
+/obj/effect/map_helper/airlock/sensor/chamber_sensor,
+/obj/structure/handrail,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/maintenance/wing_starboard)
+"XD" = (
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/fore_starboard)
+"XE" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/closet/emergsuit_wall{
+	pixel_y = 32
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/talon_v2/central_hallway/fore)
 "XG" = (
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/secure_storage)
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/brig)
 "XH" = (
 /turf/simulated/floor/plating,
 /area/talon_v2/engineering/port_store)
 "XJ" = (
-/obj/structure/anomaly_container,
+/obj/structure/sign/directions/science/xenoarch{
+	pixel_y = -32
+	},
 /turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/anomaly_storage)
+/area/talon_v2/central_hallway/star)
 "XK" = (
-/obj/effect/map_helper/airlock/door/int_door,
-/obj/machinery/door/airlock/glass_external{
-	req_one_access = list(301)
+/obj/structure/table/woodentable,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/aux{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/maintenance/wing_port)
+/turf/simulated/floor/wood,
+/area/talon_v2/crew_quarters/meditation)
 "XO" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/oxygen_pump{
+	dir = 1;
+	pixel_y = -30
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/handrail{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/talon_v2/bridge)
@@ -14840,26 +15542,260 @@
 /turf/simulated/floor/reinforced/airless,
 /area/space)
 "XQ" = (
-/obj/structure/closet/emergsuit_wall{
-	dir = 1;
-	pixel_y = -32
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/brig)
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/fore_port)
 "XR" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/effect/catwalk_plated,
+/obj/structure/disposalpipe/junction{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/central_hallway/star)
+"XS" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/portable_atmospherics/canister/empty,
+/obj/machinery/atmospherics/portables_connector{
+	dir = 8
+	},
+/obj/structure/railing/grey{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/atmospherics)
+"XT" = (
+/obj/structure/table/woodentable,
+/obj/machinery/button/remote/blast_door{
+	dir = 8;
+	id = "talon_quietroom";
+	name = "window blast shields";
+	pixel_x = 28
+	},
+/obj/structure/closet/walllocker/medical/south,
+/obj/item/weapon/storage/firstaid/regular,
+/obj/item/weapon/storage/firstaid/o2,
+/turf/simulated/floor/wood,
+/area/talon_v2/crew_quarters/meditation)
+"XU" = (
+/obj/structure/bed/chair/bay/chair{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/talon_v2/crew_quarters/bar)
+"XW" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/closet/walllocker_double/hydrant/east,
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/armory)
+"XX" = (
+/obj/effect/landmark/start{
+	name = "Talon Pilot"
+	},
+/obj/machinery/light_switch{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/simulated/floor/carpet,
+/area/talon_v2/crew_quarters/pilot_room)
+"XY" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway)
+"XZ" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/random/multiple/corp_crate/talon_cargo,
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/maintenance/wing_starboard)
+"Ya" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/item/weapon/storage/firstaid/regular,
+/obj/item/weapon/storage/firstaid/o2,
+/obj/structure/closet/walllocker/medical/east,
+/obj/item/device/radio/off{
+	channels = list("Talon" = 1)
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/maintenance/wing_port)
+"Yb" = (
+/obj/machinery/computer/ship/sensors,
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/talonboat)
+"Yc" = (
 /turf/simulated/floor/tiled/techfloor,
 /area/talon_v2/refining)
-"XS" = (
-/obj/machinery/door/window/brigdoor/eastleft{
-	req_access = list();
+"Ye" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/aux{
+	dir = 10
+	},
+/obj/machinery/airlock_sensor{
+	dir = 4;
+	pixel_x = -28;
+	pixel_y = 28;
 	req_one_access = list(301)
 	},
-/obj/effect/floor_decal/industrial/warning{
+/obj/effect/map_helper/airlock/sensor/int_sensor,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/maintenance/wing_port)
+"Yf" = (
+/obj/machinery/door/firedoor/glass/talon,
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/hangar)
+"Yg" = (
+/obj/machinery/door/airlock/glass_external{
+	req_one_access = list(301)
+	},
+/obj/effect/map_helper/airlock/door/int_door,
+/obj/machinery/atmospherics/pipe/simple/hidden/aux,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/maintenance/aft_port)
+"Yh" = (
+/obj/machinery/suit_cycler/vintage/tcaptain,
+/turf/simulated/floor/wood,
+/area/talon_v2/crew_quarters/cap_room)
+"Yj" = (
+/obj/structure/catwalk,
+/obj/structure/closet/walllocker_double/west,
+/obj/item/weapon/storage/toolbox/electrical,
+/obj/item/weapon/storage/toolbox/mechanical,
+/obj/item/stack/cable_coil/green,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering)
+"Yk" = (
+/turf/simulated/floor/reinforced,
+/area/talon_v2/ofd_ops)
+"Ym" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/table/rack/steel,
+/obj/item/weapon/shovel,
+/obj/item/weapon/shovel,
+/obj/item/weapon/mining_scanner,
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/refining)
+"Yo" = (
+/obj/structure/catwalk,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/fore_starboard)
+"Yp" = (
+/obj/structure/railing/grey,
+/obj/structure/railing/grey{
+	dir = 4
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/refining)
+"Yq" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/yellow,
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/port)
+"Yr" = (
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 8
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/space)
+"Yt" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/catwalk,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/fore_starboard)
+"Yu" = (
+/turf/simulated/wall/rshull,
+/area/talon_v2/maintenance/wing_port)
+"Yv" = (
+/mob/living/simple_mob/animal/passive/dog/corgi/puppy{
+	desc = "That's Hendrickson, warden of the Talon's brig. No schemes can escape the watchful gleam of this corgi's deep, dark eyes.";
+	name = "Hendrickson"
+	},
+/obj/structure/dogbed,
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/brig)
+"Yw" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 10
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/talon_v2/engineering/port)
-"XT" = (
+"Yx" = (
+/obj/machinery/mineral/processing_unit_console{
+	req_one_access = list(301)
+	},
+/obj/structure/girder,
+/obj/structure/railing/grey{
+	dir = 4
+	},
+/obj/structure/railing/grey,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced,
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/refining)
+"Yy" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 4
 	},
@@ -14871,365 +15807,90 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/talon_v2/anomaly_storage)
-"XU" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/holoposter{
-	dir = 1;
-	pixel_y = 32
-	},
-/turf/simulated/floor/wood,
-/area/talon_v2/crew_quarters/bar)
-"XW" = (
-/obj/machinery/power/pointdefense{
-	id_tag = "talon_pd"
-	},
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/effect/floor_decal/industrial/warning/dust{
-	dir = 5
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/space)
-"XX" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/computer/ship/sensors{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/central_hallway)
-"XY" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/atmospherics)
-"XZ" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/maintenance/wing_starboard)
-"Ya" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/light_switch{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/random/multiple/corp_crate/talon_cargo,
-/obj/structure/railing/grey{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/maintenance/wing_port)
-"Yb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/effect/catwalk_plated/dark,
-/turf/simulated/floor/plating,
-/area/shuttle/talonboat)
-"Yc" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/refining)
-"Ye" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/aux{
-	dir = 9
-	},
-/obj/structure/closet/emergsuit_wall{
-	dir = 1;
-	pixel_y = -32
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/maintenance/wing_port)
-"Yf" = (
-/turf/simulated/floor/tiled/techfloor,
-/area/shuttle/talonboat)
-"Ym" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/blast/regular{
-	dir = 4;
-	id = "talon_cargo_port";
-	name = "Cargo Loading Hatch"
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/maintenance/wing_port)
-"Yo" = (
-/obj/structure/closet/emergsuit_wall{
-	dir = 4;
-	pixel_x = 32
-	},
-/turf/simulated/floor/tiled/white,
-/area/talon_v2/medical)
-"Yp" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/machinery/disposal/wall{
-	dir = 8
-	},
-/turf/simulated/floor/wood,
-/area/talon_v2/crew_quarters/eng_room)
-"Yt" = (
-/obj/machinery/power/apc/talon{
-	name = "south bump";
-	pixel_y = -24
-	},
-/obj/structure/table/standard,
-/obj/item/weapon/paper_bin,
-/obj/item/weapon/pen,
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/workroom)
-"Yu" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/railing/grey,
-/obj/random/multiple/corp_crate/talon_cargo,
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/maintenance/wing_port)
-"Yv" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/brig)
-"Yx" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor/glass/talon,
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/hangar)
-"Yy" = (
-/obj/item/modular_computer/console/preset/talon{
-	dir = 1
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/workroom)
 "Yz" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/atmospherics/omni/mixer{
+	name = "Air Mixer";
+	tag_north = 2;
+	tag_south = 1;
+	tag_south_con = 0.79;
+	tag_west = 1;
+	tag_west_con = 0.21
 	},
-/obj/machinery/atmospherics/pipe/manifold/visible{
-	dir = 8
-	},
-/obj/structure/catwalk,
+/obj/effect/catwalk_plated/dark,
 /turf/simulated/floor/plating,
 /area/talon_v2/engineering/atmospherics)
 "YA" = (
-/obj/structure/bed/chair/bay/comfy/brown{
+/obj/structure/railing/grey{
 	dir = 1
 	},
-/obj/structure/panic_button{
-	pixel_x = 32;
-	pixel_y = 32
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/techmaint,
+/turf/simulated/floor/tiled/techfloor,
 /area/talon_v2/bridge)
 "YB" = (
-/obj/effect/map_helper/airlock/sensor/chamber_sensor,
-/obj/machinery/atmospherics/pipe/manifold/hidden/aux{
-	dir = 1
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/machinery/airlock_sensor{
-	pixel_y = 28;
-	req_one_access = list(301)
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/maintenance/fore_starboard)
-"YC" = (
-/obj/machinery/atmospherics/pipe/simple/visible/universal{
-	dir = 8;
-	name = "Air to Distro"
-	},
-/obj/machinery/camera/network/talon,
-/obj/structure/railing/grey{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/atmospherics)
-"YD" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/random/medical,
-/obj/random/medical,
-/obj/random/medical,
-/obj/random/medical,
-/obj/structure/closet/walllocker_double/medical/west,
-/turf/simulated/floor/tiled/white,
-/area/talon_v2/medical)
-"YI" = (
-/obj/machinery/door/window/brigdoor/eastleft{
-	dir = 1;
-	req_access = list(301)
-	},
-/obj/machinery/door/window/brigdoor/eastleft{
-	dir = 2;
-	req_access = list(301)
-	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/blast/shutters{
-	density = 0;
-	dir = 2;
-	icon_state = "shutter0";
-	id = "talon_brig2";
-	name = "Cell Shutters";
-	opacity = 0
-	},
-/obj/machinery/door/firedoor/glass/talon,
-/obj/machinery/light/small{
+/obj/structure/bed/chair/bay/shuttle{
 	dir = 4
+	},
+/obj/structure/closet/walllocker_double/survival/north,
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/talonpod)
+"YC" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway)
+"YD" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/anomaly_storage)
+"YG" = (
+/obj/machinery/atmospherics/pipe/manifold4w/visible/yellow,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/starboard)
+"YH" = (
+/obj/structure/trash_pile,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/star_store)
+"YI" = (
+/obj/structure/extinguisher_cabinet{
+	dir = 8;
+	pixel_x = 30
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/talon_v2/brig)
 "YJ" = (
 /obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/power/apc/talon{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
-/turf/simulated/floor/wood,
-/area/talon_v2/crew_quarters/meditation)
-"YL" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/talon_v2/crew_quarters/eng_room)
-"YN" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/anomaly_storage)
-"YP" = (
-/obj/structure/bed/double/padded,
-/obj/item/weapon/bedsheet/bluedouble,
-/turf/simulated/floor/carpet/blucarpet,
-/area/talon_v2/crew_quarters/cap_room)
-"YQ" = (
-/obj/item/weapon/storage/firstaid/toxin,
-/obj/item/weapon/storage/firstaid/toxin,
-/obj/item/weapon/storage/firstaid/o2,
-/obj/item/weapon/storage/firstaid/o2,
-/obj/item/weapon/storage/firstaid/fire,
-/obj/item/weapon/storage/firstaid/fire,
-/obj/item/weapon/storage/firstaid/adv,
-/obj/item/weapon/storage/firstaid/adv,
-/obj/structure/closet/walllocker_double/medical/east,
-/turf/simulated/floor/tiled/white,
-/area/talon_v2/medical)
-"YR" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway)
-"YS" = (
-/turf/simulated/floor/tiled/white,
-/area/talon_v2/medical)
-"YT" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/alarm/talon{
-	dir = 4;
-	pixel_x = -22
-	},
-/obj/structure/closet/walllocker_double/east,
-/obj/random/maintenance/engineering,
-/obj/random/maintenance/engineering,
-/obj/random/maintenance/engineering,
-/obj/random/maintenance/engineering,
-/obj/random/maintenance/engineering,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering)
-"YW" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/starboard)
-"YX" = (
+/area/talon_v2/central_hallway/port)
+"YL" = (
+/obj/structure/railing/grey,
+/obj/structure/window/reinforced,
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/refining)
+"YN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
@@ -15238,158 +15899,237 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/central_hallway/star)
+"YO" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/light/small,
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/port)
+"YP" = (
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/anomaly_storage)
+"YQ" = (
+/obj/machinery/alarm/talon{
+	dir = 4;
+	pixel_x = -22
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/fore_starboard)
+"YR" = (
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 1
+	},
+/obj/machinery/suspension_gen{
+	req_access = list(301)
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/anomaly_storage)
+"YS" = (
+/obj/structure/flora/pottedplant/tall,
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/crew_quarters/restrooms)
+"YT" = (
+/obj/machinery/disposal/deliveryChute{
+	dir = 1
+	},
+/obj/structure/disposalpipe/trunk,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering)
+"YW" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/glass/talon,
+/obj/machinery/door/airlock/engineering{
+	name = "Talon Starboard Engines & Trash Management";
+	req_one_access = list(301)
+	},
+/obj/structure/sign/warning/nosmoking_1{
+	pixel_x = 26
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/starboard)
+"YX" = (
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc/talon{
+	dir = 1;
+	name = "north bump";
+	pixel_y = 28
+	},
+/obj/structure/table/rack/steel,
+/turf/simulated/floor/tiled/techfloor,
 /area/talon_v2/secure_storage)
 "YY" = (
-/obj/structure/reagent_dispensers/watertank,
+/obj/machinery/autolathe,
 /turf/simulated/floor/tiled/techfloor,
 /area/talon_v2/workroom)
 "YZ" = (
-/obj/machinery/power/apc/talon{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
+/obj/machinery/atmospherics/portables_connector/aux,
+/obj/effect/floor_decal/industrial/outline,
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/fore_starboard)
+"Zb" = (
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/structure/table/steel,
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 32
 	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
+/obj/fiftyspawner/uranium,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/wood,
-/area/talon_v2/crew_quarters/med_room)
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/generators)
 "Zc" = (
 /turf/simulated/wall/shull,
 /area/talon_v2/engineering/atmospherics)
 "Zd" = (
-/obj/effect/floor_decal/emblem/talon_big{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/techfloor,
+/obj/machinery/door/firedoor/glass/talon,
+/obj/machinery/door/airlock/glass,
+/turf/simulated/floor/tiled/techmaint,
 /area/talon_v2/central_hallway/fore)
 "Ze" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/railing/grey{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
 	},
 /obj/random/multiple/corp_crate/talon_cargo,
 /turf/simulated/floor/tiled/techfloor,
 /area/talon_v2/maintenance/wing_port)
 "Zf" = (
-/obj/structure/extinguisher_cabinet{
-	dir = 8;
-	pixel_x = 30
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
 	},
-/obj/structure/flora/pottedplant/orientaltree,
-/turf/simulated/floor/wood,
+/obj/effect/floor_decal/corner/black/diagonal,
+/obj/item/weapon/stool/baystool/padded{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
 /area/talon_v2/crew_quarters/bar)
 "Zg" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/light/small{
+	dir = 8
 	},
-/obj/structure/catwalk,
-/obj/machinery/alarm/talon{
+/obj/structure/closet/emergsuit_wall{
 	dir = 8;
-	pixel_x = 22
+	pixel_x = -32
 	},
-/turf/simulated/floor/plating,
-/area/talon_v2/maintenance/aft_port)
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/maintenance/wing_starboard)
 "Zh" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/talon_v2/hangar)
 "Zi" = (
-/turf/space,
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
 /area/talon_v2/engineering/starboard)
 "Zk" = (
 /turf/simulated/wall/rshull,
 /area/talon_v2/engineering/port)
-"Zm" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/machinery/door/firedoor/glass/talon,
+"Zl" = (
+/obj/structure/barricade,
 /turf/simulated/floor/plating,
-/area/talon_v2/armory)
+/area/talon_v2/engineering/port_store)
+"Zm" = (
+/obj/structure/table/rack/shelf/steel,
+/obj/item/clothing/head/helmet/space/void/refurb/talon,
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/secure_storage)
 "Zn" = (
-/obj/structure/table/rack/steel,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
 /turf/simulated/floor/plating,
 /area/talon_v2/engineering/port_store)
 "Zo" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/pointdefense_control{
+	id_tag = "talon_pd"
 	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/talon_v2/engineering)
 "Zp" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/obj/machinery/light_switch{
-	dir = 4;
-	pixel_x = -24
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/hangar)
-"Zr" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/obj/structure/extinguisher_cabinet{
-	dir = 1;
-	pixel_y = -32
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/hangar)
-"Zv" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/structure/disposalpipe/junction{
-	dir = 2;
-	icon_state = "pipe-j2"
-	},
 /turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway/fore)
-"Zx" = (
-/obj/effect/floor_decal/industrial/outline/red,
-/obj/machinery/portable_atmospherics/canister/empty/phoron,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/port_store)
-"Zy" = (
+/area/talon_v2/maintenance/wing_starboard)
+"Zr" = (
+/obj/machinery/door/airlock/glass_external{
+	frequency = 1420;
+	id_tag = "tal_shuttle_sb";
+	req_one_access = list(301)
+	},
+/obj/machinery/door/blast/regular/open{
+	id = "talon_boat_east"
+	},
+/obj/machinery/button/remote/blast_door{
+	dir = 1;
+	id = "talon_boat_east";
+	pixel_y = -28;
+	req_one_access = list(301)
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/shuttle/talonboat)
+"Zv" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/wall/rshull,
+/area/talon_v2/maintenance/wing_starboard)
+"Zw" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/glass/talon,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -15399,141 +16139,156 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/brig)
-"Zz" = (
-/obj/machinery/light/small,
-/obj/structure/bed/chair/bay/shuttle{
+/obj/machinery/door/airlock/engineering{
+	id_tag = "talon_engdoor";
+	name = "Engineer's Cabin";
+	req_one_access = list(301)
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/crew_quarters/eng_room)
+"Zx" = (
+/obj/machinery/light/small{
 	dir = 1
 	},
-/obj/machinery/power/apc/talon/hyper{
-	pixel_y = -24
+/obj/structure/table/rack/shelf/steel,
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/port_store)
+"Zz" = (
+/obj/structure/table/steel,
+/obj/structure/closet/autolok_wall{
+	dir = 1;
+	pixel_y = -32
 	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/talonboat)
 "ZA" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/conveyor{
-	dir = 1;
-	id = "talonrefinery"
-	},
-/obj/machinery/mineral/output,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/mineral/input,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/talon_v2/refining)
 "ZB" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+/obj/machinery/light/small{
+	dir = 1
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/talon_v2/engineering/atmospherics)
 "ZC" = (
-/obj/machinery/door/firedoor/glass/talon,
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/door/blast/regular/open{
-	dir = 2;
-	id = "talon_bridge_shields"
-	},
-/obj/machinery/door/blast/regular/open{
-	dir = 2;
-	id = "talon_bridge_shields"
-	},
-/turf/simulated/floor/plating,
+/turf/simulated/wall/rshull,
 /area/talon_v2/bridge)
-"ZE" = (
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 10
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/obj/machinery/firealarm{
-	layer = 3.3;
-	pixel_y = 26
-	},
-/obj/structure/catwalk,
-/obj/machinery/camera/network/talon,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/port)
-"ZF" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/closet/emergsuit_wall{
-	pixel_y = 32
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/talon_v2/central_hallway/port)
-"ZI" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/aux{
-	dir = 1
-	},
-/obj/effect/map_helper/airlock/atmos/chamber_pump,
-/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	dir = 1;
-	id_tag = "talon_port_fore";
-	pixel_y = -30;
-	req_one_access = list(301)
-	},
-/obj/structure/handrail{
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/maintenance/fore_port)
-"ZJ" = (
-/obj/effect/floor_decal/industrial/warning/dust,
-/turf/simulated/floor/reinforced/airless,
-/area/space)
-"ZK" = (
+"ZD" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/talon_v2/maintenance/fore_port)
-"ZO" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/hangar)
-"ZP" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/structure/railing/grey,
 /turf/simulated/floor/plating,
+/area/talon_v2/engineering/star_store)
+"ZE" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 4
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/space)
+"ZF" = (
+/obj/structure/table/rack/shelf/steel,
+/obj/item/weapon/tank/jetpack/carbondioxide,
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/secure_storage)
+"ZH" = (
+/obj/machinery/atmospherics/binary/pump/high_power/on{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/closet/emergsuit_wall{
+	dir = 1;
+	pixel_y = -32
+	},
+/turf/simulated/floor/plating,
+/area/talon_v2/engineering/atmospherics)
+"ZI" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/aux{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/ofd_ops)
+"ZJ" = (
+/obj/machinery/door/airlock/glass_external{
+	req_one_access = list(301)
+	},
+/obj/effect/map_helper/airlock/door/ext_door,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/maintenance/wing_port)
+"ZK" = (
+/obj/machinery/power/pointdefense{
+	id_tag = "talon_pd"
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/space)
+"ZO" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/aux{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/shuttle/talonboat)
+"ZP" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/wall/rshull,
 /area/talon_v2/engineering)
 "ZQ" = (
+/obj/effect/floor_decal/industrial/warning/dust/corner{
+	dir = 1
+	},
+/obj/structure/hull_corner/long_vert{
+	dir = 5
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/space)
+"ZR" = (
+/obj/machinery/mineral/output,
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "talonrefinery"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/talon_v2/refining)
+"ZS" = (
+/obj/structure/handrail{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/talon_v2/maintenance/wing_port)
+"ZW" = (
+/obj/structure/catwalk,
+/obj/structure/trash_pile,
+/turf/simulated/floor/plating,
+/area/talon_v2/maintenance/fore_port)
+"ZY" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -15541,46 +16296,19 @@
 	},
 /turf/simulated/wall/rshull,
 /area/talon_v2/maintenance/fore_starboard)
-"ZR" = (
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/mineral/input,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/talon_v2/refining)
-"ZS" = (
-/obj/machinery/atmospherics/portables_connector{
+"ZZ" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/effect/floor_decal/industrial/outline/red,
-/obj/machinery/portable_atmospherics/powered/scrubber,
-/obj/structure/railing/grey{
-	dir = 8
-	},
-/obj/structure/railing/grey,
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/atmospherics)
-"ZW" = (
-/obj/machinery/vending/security{
-	req_access = list(301);
-	req_log_access = 301
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/brig)
-"ZY" = (
-/obj/structure/catwalk,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/obj/machinery/door/blast/regular/open{
+	dir = 4;
+	id = "talon_quietroom"
 	},
 /turf/simulated/floor/plating,
-/area/talon_v2/maintenance/fore_starboard)
-"ZZ" = (
-/obj/machinery/atmospherics/binary/pump/on{
-	dir = 8;
-	name = "Air to Distro"
-	},
-/turf/simulated/floor/plating,
-/area/talon_v2/engineering/atmospherics)
+/area/talon_v2/crew_quarters/meditation)
 
 (1,1,1) = {"
 aa
@@ -18821,11 +19549,11 @@ aa
 aa
 aa
 aa
-eH
 aa
 aa
 aa
 aa
+QP
 aa
 aa
 aa
@@ -19484,7 +20212,7 @@ aa
 aa
 aa
 aa
-Te
+aa
 aa
 aa
 aa
@@ -19756,24 +20484,24 @@ aa
 aa
 aa
 aa
+aa
+aa
+aa
+aa
 tm
 tm
 tm
 XP
 XP
-Mu
-uK
-bA
 XP
 XP
 XP
 XP
 XP
 XP
-aa
-aa
-aa
-aa
+XP
+XP
+XP
 aa
 aa
 aa
@@ -19902,22 +20630,22 @@ aa
 aa
 aa
 aa
-XP
-ZJ
-UW
-nl
-OT
-OT
-OT
-OT
-we
-XP
-XP
-XP
 aa
 aa
 aa
 aa
+XP
+XP
+XP
+XP
+XP
+XP
+XP
+XP
+XP
+EB
+XP
+XP
 aa
 aa
 aa
@@ -20015,7 +20743,11 @@ aa
 aa
 aa
 aa
-PK
+aa
+aa
+aa
+aa
+dP
 aa
 aa
 aa
@@ -20045,25 +20777,21 @@ aa
 aa
 tm
 tm
-mo
-Fg
-QI
 XP
 XP
-Lz
-FZ
-Br
-Dp
-yw
 XP
 XP
-Mu
-uK
-bA
-aa
-aa
-aa
-aa
+XP
+XP
+XP
+XP
+XP
+XP
+XP
+XP
+Pd
+hq
+TR
 aa
 aa
 aa
@@ -20188,25 +20916,25 @@ aa
 aa
 aa
 aa
-XP
-XP
-XP
+aa
+aa
+aa
 Pd
-TR
-TR
-Lj
-Qk
+hq
 TR
 XP
+Qk
+Av
+Yu
 jk
 ZJ
-RD
-Kl
+Yu
 XP
-aa
-aa
-aa
-aa
+Rf
+UW
+Wl
+Fg
+XP
 aa
 aa
 aa
@@ -20332,24 +21060,24 @@ aa
 aa
 aa
 aa
-XP
-XP
-TR
+aa
+aa
+SS
 bh
-mA
 Jz
-TR
-TR
-TR
-TR
-gD
-gP
+Jz
+Aw
+Dy
+EF
+Jm
+Yu
+Yu
+Yu
+Yu
+Wo
+ZQ
 XP
 XP
-aa
-aa
-aa
-aa
 aa
 aa
 aa
@@ -20474,26 +21202,26 @@ aa
 aa
 aa
 aa
-Pd
-TR
-TR
-Go
-Nj
-gc
+aa
+aa
+aa
+Up
+Qk
+Yu
+Yu
+Wa
+EJ
+Jp
 TA
-Wa
-Wa
-TR
-nk
-TR
-TR
+OH
+OH
+Yu
+Wp
+Yu
+Yu
 XP
-jk
+Rf
 XP
-aa
-aa
-aa
-aa
 aa
 aa
 aa
@@ -20616,28 +21344,28 @@ aa
 aa
 aa
 aa
+aa
+aa
+aa
+aa
 XP
-TR
+Yu
 TA
 TA
-XK
-Kt
-TA
-Du
 Ph
+Jr
 TA
-ir
 vR
+RA
+TA
+ws
+ZS
+Yu
+Yu
+Yu
+Yu
 TR
-TR
-TR
-TR
-bA
 XP
-aa
-aa
-aa
-aa
 aa
 aa
 aa
@@ -20757,31 +21485,31 @@ aa
 aa
 aa
 aa
-Ft
-TR
-TR
-kl
-ty
-Ce
-mt
+aa
+aa
+aa
+aa
+PL
+Yu
+Yu
 rm
 NS
 Ye
-TA
+Jt
 ir
+ON
+RC
+TA
+ws
 CY
-ty
-vR
-mC
-gJ
-Kl
+NS
+ZS
+UQ
+mo
+Fg
 XP
 XP
 XP
-aa
-aa
-aa
-aa
 aa
 aa
 aa
@@ -20900,32 +21628,32 @@ aa
 aa
 aa
 aa
-TR
-VD
-VD
-dZ
-uT
-cE
+aa
+aa
+aa
+aa
+Yu
+QA
+QA
+DB
+EP
+Ju
 TA
 TA
 TA
 TA
-ir
-CY
-Xi
-CE
 ws
-Ym
+CY
 nl
 OT
 gu
 jy
-bA
+NT
+Jz
+xs
+Gz
+TR
 XP
-aa
-aa
-aa
-aa
 aa
 aa
 aa
@@ -21040,34 +21768,34 @@ aa
 aa
 aa
 aa
-Ft
-TR
-TR
-kR
+aa
+aa
+aa
+aa
 PL
-CY
-vW
+Yu
+Yu
 OZ
 kf
-le
+CY
 OB
 qV
 EL
 CE
 pa
 Bv
-TR
-TR
+Wq
+OT
 QI
+SC
+Yu
+Yu
+Up
 XP
-ZJ
-UI
-Kl
+UW
+ZK
+Fg
 XP
-aa
-aa
-aa
-aa
 aa
 aa
 aa
@@ -21183,32 +21911,32 @@ aa
 aa
 aa
 aa
-TR
-VD
-VD
-ek
+aa
+aa
+aa
+aa
 Yu
-wB
-At
+QA
+QA
 Px
 jh
 Ru
-VD
-VD
-VD
+JB
+MO
+OS
+RV
+QA
+QA
+QA
 CY
-om
-gJ
-Kl
-XP
-XP
+cA
 mo
 Fg
-QI
-aa
-aa
-aa
-aa
+XP
+XP
+Wd
+Yr
+Up
 aa
 aa
 aa
@@ -21323,15 +22051,19 @@ aa
 aa
 aa
 aa
-Ft
-TR
-TR
-ri
-CY
-CY
-CY
+aa
+aa
+aa
+aa
+PL
+Yu
+Yu
 BV
-uT
+CY
+CY
+CY
+EX
+EP
 CY
 CY
 CY
@@ -21339,13 +22071,9 @@ CY
 CY
 CY
 CY
-oq
-gJ
-Kl
-aa
-aa
-aa
-aa
+yl
+mo
+Fg
 aa
 aa
 aa
@@ -21466,28 +22194,28 @@ aa
 aa
 aa
 aa
-TR
-KE
-VD
-VD
-fv
+aa
+aa
+aa
+aa
+Yu
 Mc
-IE
-PV
+QA
+QA
 Ze
 sT
 DW
-VD
-CY
-CY
+JJ
+MP
+OW
 FN
-TR
-TR
-QI
-aa
-aa
-aa
-aa
+QA
+CY
+CY
+Vl
+Yu
+Yu
+Up
 aa
 aa
 aa
@@ -21606,29 +22334,29 @@ aa
 aa
 aa
 aa
-Ft
-TR
-TR
-kR
-CY
-CY
-ew
-CY
-qk
-uT
-CY
-CY
-ew
-CY
-CY
-VD
-TR
-TR
-Vh
 aa
 aa
 aa
 aa
+PL
+Yu
+Yu
+OZ
+CY
+CY
+AD
+CY
+Fk
+EP
+CY
+CY
+AD
+CY
+CY
+QA
+Yu
+Yu
+ys
 aa
 aa
 aa
@@ -21749,11 +22477,11 @@ aa
 aa
 aa
 aa
-TR
-dP
-CI
-qP
-zn
+aa
+aa
+aa
+aa
+Yu
 Di
 Vw
 ba
@@ -21761,15 +22489,15 @@ lk
 Ya
 BC
 VD
-VD
+JQ
 sx
-VD
-TR
+Pl
 QA
-aa
-aa
-aa
-aa
+QA
+Wx
+QA
+Yu
+kh
 aa
 aa
 aa
@@ -21890,27 +22618,27 @@ aa
 aa
 aa
 aa
-TR
-TR
-yJ
-OQ
-OQ
-OQ
-OQ
-OQ
-rg
-gH
-Nl
-Nl
-Nl
-Nl
-Nl
-Sn
-TR
 aa
 aa
 aa
 aa
+Yu
+Yu
+xw
+OQ
+OQ
+OQ
+OQ
+OQ
+Ft
+Kf
+Nl
+Nl
+Nl
+Nl
+Nl
+UR
+Yu
 aa
 aa
 aa
@@ -22031,28 +22759,28 @@ aa
 aa
 aa
 aa
-OH
-ML
-ZK
-Kf
-OQ
-tD
+aa
+aa
+aa
+aa
+pc
+xL
 LL
-tD
+xB
 OQ
 LT
 kk
-Nl
-hA
+LT
+OQ
 ay
 zK
-bN
+Nl
 Sn
 Vh
-aa
-aa
-aa
-aa
+UX
+WS
+UR
+ys
 aa
 aa
 aa
@@ -22172,28 +22900,28 @@ aa
 aa
 aa
 aa
-Hz
-wi
-wi
-hS
+aa
+aa
+aa
+aa
+lT
+Re
+Re
+XQ
 OQ
-OQ
-GF
-Dc
-lF
 OQ
 GH
-jL
-Nl
-UF
+uS
+AE
+OQ
 OR
 xd
-fM
+Nl
 xM
-aa
-aa
-aa
-aa
+RZ
+Va
+Xb
+ZZ
 aa
 aa
 aa
@@ -22313,16 +23041,16 @@ aa
 aa
 aa
 aa
-Hz
-wi
-wi
-Et
-hS
-OQ
+aa
+aa
+aa
+aa
+lT
 Re
-Kr
-JG
-Wl
+Re
+ZW
+XQ
+OQ
 fp
 OK
 RK
@@ -22331,11 +23059,11 @@ PO
 TW
 QR
 cZ
-xM
-aa
-aa
-aa
-aa
+Pm
+Sd
+Vf
+Xi
+ZZ
 aa
 aa
 aa
@@ -22454,30 +23182,30 @@ aa
 aa
 aa
 aa
-Hz
-wi
-wi
-hS
-hS
-hS
-Be
-Dc
-bV
-Dc
+aa
+aa
+aa
+aa
+lT
+Re
+Re
+XQ
+XQ
+XQ
 jQ
-OQ
+uS
 ul
 uS
-Nl
-IU
+AI
+OQ
 Rp
 TD
-Bu
-xM
-aa
-aa
-aa
-aa
+Nl
+Pr
+Sx
+Vi
+XK
+ZZ
 aa
 aa
 aa
@@ -22595,32 +23323,32 @@ aa
 aa
 aa
 aa
-Hz
-wi
-wi
-Et
-hS
-hS
-cT
-OQ
-tD
-Eb
+aa
+aa
+aa
+aa
+lT
+Re
+Re
+ZW
+XQ
+XQ
 zz
-VX
 OQ
+LT
 qJ
 mu
-Nl
-xZ
+AJ
+OQ
 YJ
 Ke
-jv
-Sn
-ql
-aa
-aa
-aa
-aa
+Nl
+Pt
+SJ
+Vs
+XT
+UR
+bn
 aa
 aa
 aa
@@ -22736,36 +23464,36 @@ aa
 aa
 aa
 aa
-Hz
-wi
-wi
-hS
-hS
-hS
-hS
-JF
+aa
+aa
+aa
+aa
+lT
+Re
+Re
+XQ
+XQ
+XQ
+XQ
+wu
 OQ
 OQ
 OQ
 OQ
 OQ
 OQ
-KY
-PB
+FB
+Kn
 Nl
 Nl
 Nl
 Nl
 Nl
-Sn
-tC
-tC
-tC
 UR
-aa
-aa
-aa
-aa
+tC
+tC
+tC
+hz
 aa
 aa
 aa
@@ -22877,41 +23605,41 @@ aa
 aa
 aa
 aa
-OH
-ML
-ML
-NR
-NR
-cS
+aa
+aa
+aa
+aa
+pc
+xL
 xL
 NR
 NR
 Id
+vi
 NR
-KI
 NR
+xE
 NR
-lS
 Qj
-Va
-Iv
+NR
+NR
 gI
 Vg
-gI
-gI
-yg
+Ko
+MU
+TX
 qa
 TX
-tC
+TX
 aR
+gh
+wf
 tC
-tC
-aa
 uL
+tC
+tC
 aa
-aa
-aa
-aa
+VN
 aa
 aa
 aa
@@ -23018,15 +23746,19 @@ aa
 aa
 aa
 aa
-Hz
-wi
-wi
-hS
-MT
+aa
+aa
+aa
+aa
+lT
+Re
+Re
+XQ
+Xm
 db
 db
 db
-Bs
+vU
 db
 Dd
 Dd
@@ -23034,29 +23766,25 @@ Dd
 Dd
 Dd
 Dd
-VO
-ON
+FK
+Kv
 Oj
 Oj
 Oj
 Oj
 Oj
 Oj
-WZ
-NB
-TX
-LA
 IP
+CJ
+wf
+ib
+Oc
 tC
 tC
 tC
 tC
 aa
-uL
-aa
-aa
-aa
-aa
+VN
 aa
 aa
 aa
@@ -23159,44 +23887,48 @@ aa
 aa
 aa
 aa
-Hz
-wi
-wi
-hS
-hS
+aa
+aa
+aa
+aa
+lT
+Re
+Re
+XQ
+XQ
 db
-db
-rC
-bq
-Kj
 db
 Ti
 wM
-AR
-fj
+XG
+db
 fd
-Dd
+xP
 ZF
 KC
-Oj
-tn
+AN
+Dd
 nK
-gg
-SX
-RW
+Si
+Oj
+PB
 WZ
 Mi
 go
 Qu
-lV
+IP
 iy
 Xa
 LO
+xo
+yn
+vK
+DN
 tC
 tC
 tC
 tC
-Fk
+ww
 XP
 XP
 XP
@@ -23208,7 +23940,7 @@ XP
 XP
 XP
 XP
-GC
+PT
 tm
 tm
 tm
@@ -23223,10 +23955,6 @@ tm
 tm
 tm
 tm
-aa
-aa
-aa
-aa
 aa
 aa
 aa
@@ -23300,47 +24028,49 @@ aa
 aa
 aa
 aa
-Hz
-wi
-wi
-hS
-hS
+aa
+aa
+aa
+aa
+lT
+Re
+Re
+XQ
+XQ
 db
 db
-hU
-Kj
-Kj
-Mh
-db
-AR
+th
 XG
-zv
 XG
-IX
+vY
+db
+ZF
+Wm
+Fc
+Wm
+AQ
 Dd
-lW
-KC
+So
+Si
 Oj
-Pm
-So
-me
-So
-RW
+PC
+OP
+Vv
+OP
+Qu
 Zc
 Zc
 Zc
 Zc
 Zc
-Pl
+BD
 Zc
-Jr
-Xa
-Xa
-vC
+uG
+vK
+vK
+IO
 tC
-aR
-tC
-tC
+uL
 tC
 tC
 tC
@@ -23350,7 +24080,9 @@ tC
 tC
 tC
 tC
-aR
+tC
+tC
+uL
 tC
 tC
 tC
@@ -23365,10 +24097,6 @@ tC
 tC
 tC
 XP
-aa
-aa
-aa
-aa
 aa
 aa
 aa
@@ -23441,78 +24169,78 @@ aa
 aa
 aa
 aa
-Hz
-wi
-wi
-hS
-hS
-db
-db
-tY
+aa
+aa
+aa
+aa
+lT
+Re
+Re
+XQ
 XQ
 db
 db
+rU
+tn
 db
 db
-AD
-XG
-XG
-XG
+db
+db
 dN
-Dd
 Wm
-KC
-Oj
-Pm
-So
-So
-So
-RW
-Zc
-oG
-OP
-OU
-gx
-pQ
-Zc
-Zc
-yW
-Zc
-rw
+Wm
+Wm
+Ba
+Dd
 FO
+Si
+Oj
+PC
+OP
+OP
+OP
+Qu
+Zc
+Ha
+ti
+zE
+yW
+pY
+Zc
+Zc
 Tl
+Zc
+oB
+it
+Nu
+bG
+rW
+rW
+rW
+rW
 LX
 rW
 rW
 rW
+bG
 rW
-Qm
-rW
-rW
-rW
-LX
-rW
-JB
+EE
 rW
 rW
 rW
 rW
 rW
-DY
-rW
-rW
-Zg
 uf
 rW
-ez
+rW
 hW
 bC
+rW
+SK
+Ne
+ly
 tm
 tm
-aa
-aa
-aa
-aa
 aa
 aa
 aa
@@ -23575,53 +24303,57 @@ aa
 aa
 aa
 aa
+XP
+XP
+XP
+XP
+XP
+XP
 aa
 aa
 aa
 aa
 aa
-aa
-aa
-Hz
-wi
-wi
-hS
-hS
+lT
+Re
+Re
+XQ
+XQ
 db
 db
-QG
-Vo
-Kj
-Sx
 Ix
 En
-db
+XG
 zv
-XG
-ln
-XG
+vp
+uW
+db
 Fc
-Dd
+Wm
 ES
-KC
+Wm
+Bi
+Dd
+FZ
+Si
 Oj
-Nv
-So
-RW
-So
 Kx
-Zc
-oG
+OP
+Qu
 OP
 wS
-dR
+Zc
 Ha
 ti
 hp
-FS
+Jv
+CR
+ft
+GE
+qg
 Zc
 KU
-GE
+sP
 KU
 KU
 KU
@@ -23639,22 +24371,18 @@ KU
 KU
 KU
 KU
-KO
+yS
 KU
 KU
 KU
 KU
 KU
 KU
-cB
-tC
-tC
-tC
 cw
-aa
-aa
-aa
-aa
+tC
+tC
+tC
+Sf
 aa
 aa
 aa
@@ -23716,68 +24444,71 @@ aa
 aa
 aa
 aa
+XP
+qG
+JL
+JL
+JL
+JL
+iB
 aa
 aa
 aa
 aa
-aa
-aa
-aa
-dK
-wi
-wi
-Et
-hS
-MT
-db
+uO
+Re
+Re
 ZW
-TT
+XQ
 Xm
-aN
+db
 qm
 Yv
 rq
-db
+tA
 uF
-XG
+VY
 ui
-XG
+db
 zB
-JX
-ul
-KC
+Wm
+yY
+Wm
 Zm
-NM
-So
-JT
-So
+NW
+Rp
+Si
+Nh
 EV
-Zc
+OP
 yq
-dR
-dR
-BT
+OP
+HV
+Zc
 ZB
 Jv
-hp
+Jv
 aI
 pR
-KU
-FJ
+Bz
+GE
 jx
 se
 KU
 Ir
 Ep
 pZ
-yY
+KU
 Er
-rB
-XH
+KM
+iC
 Cr
-XH
+rn
 qu
 XH
+wQ
+XH
+Zl
 XH
 XH
 XH
@@ -23787,18 +24518,15 @@ XH
 XH
 XH
 XH
-eX
-eY
-tC
-fn
+XH
 fG
 fR
+tC
+vj
+hd
+wp
 XP
 XP
-aa
-aa
-aa
-aa
 aa
 aa
 aa
@@ -23858,59 +24586,63 @@ aa
 aa
 aa
 aa
-aa
-aa
-Uz
+XP
+gx
+CX
 zT
 wP
-wi
-wi
+Cv
+JL
 zq
-wi
-Om
-hS
-hS
-Et
-db
-gB
-yp
-Zy
+iF
+Re
+Re
+kX
+Re
+mI
 XQ
+XQ
+ZW
+db
+qk
+rg
+sc
+tn
 db
 db
 db
 db
-BX
-SU
-eG
-YX
 YX
 Cb
 TB
-xt
+HA
 HA
 lJ
-lJ
+Gm
 bz
 hQ
 qv
-Zc
+qv
 cc
 fF
 xx
-ZS
+Zc
 nP
 CC
 rz
-CD
+Ln
 yc
-KU
+lM
 rJ
-Qv
+Rt
 GV
 KU
 qi
 IC
+sk
+KU
+Af
+cL
 lN
 lN
 lN
@@ -23925,20 +24657,16 @@ lN
 lN
 lN
 lN
-Kv
-kJ
-CV
-sc
-eq
+Gi
 eZ
 fm
 fq
-tC
+np
 iD
-aa
-aa
-aa
-aa
+Yg
+Jy
+tC
+WV
 aa
 aa
 aa
@@ -23998,54 +24726,54 @@ aa
 aa
 aa
 aa
-aa
 XP
 XP
-XP
-NV
-BB
+tc
+fX
+uY
+Qe
 wi
-wi
-wd
+bd
+JL
 Kk
-oU
-hS
+Re
+Re
+kR
+kZ
+lX
+XQ
 NC
 NC
 NC
 NC
-qO
-jN
-vp
-Kj
 sK
-Ix
-En
-db
+ri
+sh
+XG
 Ey
-XG
+vp
 uW
-XG
+db
 Az
-JX
-ul
-KC
-Zm
+Wm
+zj
+Wm
+Bt
 NW
-So
+Rp
 Si
-So
+Nh
 sv
-Zc
+OP
 Oi
-kA
+OP
 Ef
-Op
-dR
-Bk
+Zc
+BI
+Ds
 md
 Mo
-oz
+Jv
 Rj
 dL
 sE
@@ -24053,22 +24781,26 @@ dl
 qC
 kx
 TN
-TN
+zo
+NF
+KH
+jj
+jj
 FG
 FG
 FG
 FG
 FG
-dA
-EB
-yO
-ao
 Zn
-Ep
-pZ
-pZ
-xH
+gS
+nt
+qf
+Gu
 KM
+iC
+iC
+xH
+zk
 xH
 xH
 xH
@@ -24076,15 +24808,11 @@ tC
 tC
 tC
 tC
-Lz
+pz
 XP
 XP
 XP
 XP
-aa
-aa
-aa
-aa
 aa
 aa
 aa
@@ -24137,72 +24865,76 @@ aa
 aa
 aa
 aa
-aa
 XP
 XP
 XP
-NV
-oC
-oC
-NV
-iv
+Ut
+WK
+Mz
+Ut
+gM
+Ht
 ZI
-CX
-Io
+hM
+JL
 gr
-NC
-wU
-NC
+iJ
+KB
+AH
 qE
-yd
+NC
 cN
-ad
+NC
 zH
 Gs
 cG
 YI
-Yv
-rq
-db
+rj
+sl
+tE
 ED
 VY
-rF
-An
+ui
+db
 QD
-Dd
+xZ
 CP
 wh
-Oj
-eS
+Bu
+Dd
 Ew
 eS
-tA
-ji
-Zc
+Oj
 zL
-kA
+SN
+zL
+XW
 Sa
-nC
+Zc
 WY
 Ds
 qW
-aI
-KS
-KU
+QW
+Uc
+IA
 TG
-XH
+jx
 SE
 KU
 Gn
-HN
+XH
 eq
-yY
+KU
 Zx
-rB
-Ep
-pZ
-lf
+Ts
+np
 Cr
+lf
+qu
+KM
+iC
+Oy
+wQ
 xH
 xH
 xH
@@ -24210,7 +24942,7 @@ xH
 xH
 xH
 xH
-up
+wT
 XP
 XP
 XP
@@ -24219,10 +24951,6 @@ XP
 tm
 tm
 tm
-aa
-aa
-aa
-aa
 aa
 aa
 aa
@@ -24269,7 +24997,6 @@ aa
 aa
 aa
 aa
-aa
 tm
 tm
 tm
@@ -24280,27 +25007,32 @@ XP
 XP
 XP
 XP
-NV
-oC
-oC
-NV
+Ut
 WK
-gm
+WK
+Ut
+fg
+fx
 Nq
+Yk
 Ht
-IR
-CX
-Io
+qz
+hP
+JL
 nz
-NC
+iL
 KB
 AH
 zQ
-UX
+NC
+mS
+nE
+nW
+GK
 NC
 db
 db
-GK
+sn
 db
 db
 db
@@ -24312,8 +25044,8 @@ Dd
 Dd
 Dd
 Dd
-tU
-qs
+Gq
+KE
 Oj
 Oj
 Oj
@@ -24321,23 +25053,23 @@ Oj
 Oj
 Oj
 Zc
-mk
-yF
-pE
-BO
 DP
 DM
-CD
+EI
 mX
 GY
-Zk
+MF
 Rt
 xk
+bi
+Zk
+FC
+EY
 Zk
 Zk
 Zk
 Zk
-Sd
+Pi
 Zk
 Zk
 Zk
@@ -24347,11 +25079,7 @@ xH
 xH
 xH
 aa
-Dg
-aa
-aa
-aa
-aa
+uu
 aa
 aa
 aa
@@ -24416,55 +25144,55 @@ aa
 aa
 aa
 aa
-aa
 XP
-JO
-JP
-NV
-NV
-NV
-uO
-Pe
-wo
+WL
+QO
+Ut
+Ut
+Ut
+eh
+Rs
+Yh
 jF
-jF
+KJ
 Nq
-lg
-CX
-CX
-CX
+gN
+JL
+gX
+ik
+JL
 QV
-NC
-Ge
-nu
+KB
+KB
+KB
 wa
-Wp
 NC
+ne
 Sz
 Tr
 mx
-yR
-QS
+NC
+qo
 FX
-QS
+sq
 Ga
 QS
 Uu
-hg
 QS
-Vf
+wv
+QS
 xf
 PP
-Dm
+QS
 RB
 NE
 nn
-nn
-nn
+KI
+Ns
 Gl
-wW
 XY
-IG
+XY
+XY
 CA
 Jw
 jC
@@ -24472,22 +25200,22 @@ pr
 GW
 tp
 Un
+su
+RT
+QF
+gL
 Zk
 XH
-QF
-Zk
-vi
-vi
 rP
-at
-Nk
+Zk
+Py
 Py
 ak
 ki
-aa
-aa
-aa
-aa
+JR
+dB
+Mt
+eA
 aa
 aa
 aa
@@ -24557,35 +25285,39 @@ aa
 aa
 aa
 aa
-aa
 XP
 XP
-sz
-Bf
-NV
+eU
+aZ
+Ut
+cB
+dT
 Rs
-fz
-Pe
-Pe
-Pe
-Pe
-Pe
+Rs
+Rs
+Rs
+yi
 Nq
+ec
 Qi
 DH
 Fz
 VT
 Qo
-NC
+iO
 af
-ai
+EH
 QN
-nE
 NC
+ng
 vF
 pl
 Hh
-nq
+NC
+qs
+UB
+hr
+tQ
 pG
 pG
 pG
@@ -24595,41 +25327,37 @@ pG
 pG
 pG
 pG
-UG
-YR
-lB
 Iq
-Iq
-Iq
-Iq
-ox
-Gj
-Zc
+GC
+KO
+YC
+YC
+YC
 YC
 Fo
 pE
-AE
+Zc
 zV
 DR
 EI
 Xp
 dq
+wK
+xV
+UK
+ZH
 Zk
 Zk
 Zk
 Zk
-ZE
-RV
-gO
-Pt
 Hn
-Zk
+Ms
 ID
 Rx
-aa
-aa
-aa
-aa
+sz
+Zk
+SZ
+Xr
 aa
 aa
 aa
@@ -24696,37 +25424,41 @@ aa
 aa
 aa
 aa
-aa
 XP
 XP
-dK
-JO
-JO
-JO
-NV
-NV
+uO
+WL
+WL
+WL
+Ut
+Ut
 Fj
+dZ
 Sb
-PZ
+ek
 Vp
-gt
-gt
-Is
+Vp
+px
 Nq
+gO
 To
-tb
-tb
-tb
+hg
+il
+JL
 lI
-NC
-NK
-xN
+tb
+tb
+tb
 lD
-eg
 NC
+nk
 ma
-pl
+ol
 bp
+NC
+qO
+UB
+sF
 fV
 Ks
 Ks
@@ -24738,40 +25470,36 @@ Ks
 Ks
 Ks
 fV
-DB
-Ia
+Hj
+KX
 fV
 Ks
 Ks
 Ks
 fV
-FK
+lq
 Zc
-ZZ
-Xp
-dR
-Gh
 Bn
-Gh
-kT
-Xp
+UK
+Jv
+uH
 Su
-Zk
+uH
 bY
 UK
+kQ
 Zk
-lr
 EO
 vh
-iS
+Zk
 iR
-Py
-ID
-ki
-aa
-aa
-aa
-aa
+VJ
+UD
+zh
+NH
+dB
+SZ
+eA
 aa
 aa
 aa
@@ -24835,43 +25563,47 @@ aa
 aa
 aa
 aa
-aa
 XP
 XP
 XP
-JO
-dz
-VI
-JO
+WL
+Xe
+ZC
+WL
+yt
 EN
-Wq
+Rs
 Pe
 pb
 Xy
 BY
-qb
+el
 xb
 yA
-lM
-YP
+fM
 Nq
+gW
 DK
-tb
+uo
 RJ
-tb
+JL
 WT
-NC
-NC
-Vx
-NC
+tb
+kl
+tb
+le
 NC
 NC
 pn
-pl
-Hh
-rI
+NC
+NC
+NC
 br
 UB
+hr
+WN
+uw
+vt
 Nf
 Nf
 Nf
@@ -24880,19 +25612,15 @@ Nf
 Nf
 Nf
 Nf
-As
-Ns
-Zp
-Ns
 Lr
-jb
+jO
 rI
 jO
-Zc
+SU
 Uh
 WN
 GQ
-VK
+Zc
 vP
 jG
 hw
@@ -24907,13 +25635,13 @@ WF
 VH
 HH
 vB
+lQ
+nJ
+Fw
+mN
 Zk
-ID
-Rx
-aa
-aa
-aa
-aa
+SZ
+Xr
 aa
 aa
 aa
@@ -24973,89 +25701,89 @@ aa
 aa
 aa
 aa
-tm
-tm
-tm
+aa
+aa
 tm
 XP
-JO
-dz
-dz
+WL
+Xe
+Xe
+WL
 JO
 dp
 bf
 dC
-PU
-JO
+WL
+DZ
 Kg
 Ss
 cp
 ey
-gb
+eu
 HE
 xv
-px
-bk
+fN
 Nq
+JL
 Gg
-tb
-FR
+uo
+bW
 JL
 ae
-oo
+tb
 IW
 ej
-mc
-mc
+lr
+lZ
 SQ
 Xn
-Vi
-pp
-fV
+mc
+mc
+mk
 an
 Wb
-Tt
-cK
-cK
-Tt
-cK
-cK
-cK
-Tt
-Jm
-Ih
-Tt
-Tt
-Tt
-AV
+sL
 fV
-jO
-Zc
+uJ
+vC
+Tt
+cK
+cK
+Tt
+cK
+Tt
+cK
+Tt
+LQ
+AV
+Tt
+Tt
+SX
 rk
-Nh
-Gh
-TZ
+fV
+GQ
+Zc
 OJ
 qw
 uH
 LV
-LV
-Zk
+pg
+rZ
 XS
 zM
+zM
 Zk
-yD
 wz
 OE
-JQ
+Zk
 FY
-Py
-ID
-ki
-aa
-aa
-aa
-aa
+Pq
+qx
+Yw
+Yq
+dB
+SZ
+eA
 aa
 aa
 aa
@@ -25117,33 +25845,37 @@ aa
 aa
 aa
 aa
-aa
-dK
+uO
+zX
 um
-ds
+RF
 bB
-eT
-lZ
-wO
-wm
+xu
+xh
+YA
+aN
 XO
-bZ
-JO
+WL
 Nq
 Nq
-sn
-Nq
-Nq
+dj
 Nq
 Nq
 Nq
 Nq
 Nq
-JE
+Nq
+Nq
+JL
+Be
 iP
-kU
-tb
+JL
+JL
 nH
+iS
+kn
+tb
+lx
 lU
 lU
 lU
@@ -25151,53 +25883,49 @@ lU
 lU
 lU
 lU
-Aw
-NU
+rw
+td
 fV
-sf
+Po
 Tt
 Tt
-tE
-Kc
-Tt
-lC
 vV
 iI
 Tt
 aW
 mT
 hD
-EJ
+Tt
 QM
 qt
-yV
+Nv
 yh
-Zc
+SY
 hY
-KD
+Yf
 bc
-Vs
+Zc
 KS
+fA
+yM
+VM
+SE
 IK
 IK
 IK
 IK
 IK
-Vv
-Vv
+pf
+pf
 Zk
-pf
-pf
-cm
-nN
 kz
-Zk
+kz
 Bc
-Rx
-aa
-aa
-aa
-aa
+wI
+YO
+Zk
+uC
+Xr
 aa
 aa
 aa
@@ -25259,72 +25987,76 @@ aa
 aa
 aa
 aa
-XP
-di
-ds
+xm
+um
+am
 Mj
 dD
-iV
 Bq
 Bq
+Ra
 dW
 AS
-hu
+aS
 Kz
 as
 pL
-LB
-tb
-QC
-nB
-FH
-tb
-nW
-tc
-tb
-PE
-zw
+dA
+ze
+ex
+eH
+dA
+CN
+hO
+dA
+dA
+LC
+dA
 Zd
-OS
-lU
+dA
+jg
 tz
 PR
 Ur
-CH
-Cd
 lU
+Cd
+nL
 al
 St
 yV
-sf
+lU
 Eo
 JC
-RL
-Cw
-Tt
+Yf
+Po
+JA
 lm
-uU
+Ud
 Xo
 Tt
 RP
 wX
 uV
-IL
-QM
-qt
-yV
-dF
+Tt
+Hr
+KY
+Nz
+Sv
+SY
+hY
+Yf
+ci
 Zc
 Zc
 Zc
 Zc
 Zc
-KX
-IK
-ap
-az
 aJ
 IK
+Zb
+Pk
+Lv
+IK
 Zk
 Zk
 Zk
@@ -25332,14 +26064,10 @@ Zk
 Zk
 Zk
 Zk
-Ji
+HW
 Zk
 Zk
 Zk
-aa
-aa
-aa
-aa
 aa
 aa
 aa
@@ -25401,33 +26129,33 @@ aa
 aa
 aa
 aa
-XP
 dn
+ac
 xh
-wO
-ef
-ef
-ef
+QC
+QC
+QC
+KQ
 Hw
 dX
 ls
-zX
-eh
-aU
-sF
-EF
-mc
-mc
-mc
-mc
-gN
-mc
-Bt
-mc
+aT
+bI
+bP
+dv
+WI
+WI
+WI
+WI
+fh
+WI
+WI
+WI
+WI
 gs
-RC
+WI
 rt
-Bi
+WI
 Gw
 ns
 on
@@ -25437,12 +26165,12 @@ pN
 Ek
 kg
 Wr
-yV
+pp
 sf
-Eo
+rK
 Bd
 Yf
-zW
+Po
 JA
 Yb
 Tw
@@ -25452,17 +26180,17 @@ kI
 LM
 qL
 pk
-Tt
+kv
 Wc
-fV
+NB
 sJ
 LY
 gF
-Qx
+fV
 Fx
-gl
+Qa
 Ck
-IK
+Yj
 aq
 aA
 aK
@@ -25470,18 +26198,18 @@ IK
 ei
 eK
 eP
-eR
+IK
 xW
 YT
 ZP
 HI
 eI
-eP
+ha
 Mr
-aa
-aa
-aa
-aa
+vO
+Hv
+ZP
+wn
 aa
 aa
 aa
@@ -25543,87 +26271,87 @@ aa
 aa
 aa
 aa
-XP
-dr
+yw
 dt
+ao
 Ea
 UJ
-jD
 Vc
 Vc
+im
 ed
 In
-aO
-aS
-aZ
-MA
-kH
-tb
-tb
-tb
-tb
-CN
-xm
-Kh
-tb
-hc
-Ev
-tl
-bI
-lU
+aU
+bJ
+bU
+dA
+dA
+dA
+dA
+dA
+fj
+gb
+dA
+gH
+qU
+JZ
+eB
+Ak
+dA
+ju
 CB
 uA
 Eq
-jg
-TL
 lU
-al
+TL
+nM
+oo
 XX
-yV
-sf
+pH
+lU
 Eo
 bo
-RL
-vA
-Tt
+Yf
+Po
+JA
 vy
-ho
+uU
 hH
 Tt
 Ux
 zC
 qq
-IL
-QM
+Tt
+Hu
 ZO
-yV
+NG
 Sv
-LY
+SY
 Xf
-mM
+Yf
 vz
-Ii
+Qa
 AZ
-IK
+gC
 ar
 aD
-aJ
+VL
 IK
 ep
+LJ
+Lv
+IK
+ll
 zm
 zm
 zm
 zm
 zm
 zm
-LI
+lc
 zm
 zm
 zm
-aa
-aa
-aa
-aa
 aa
 aa
 aa
@@ -25685,33 +26413,37 @@ aa
 aa
 aa
 aa
-aa
-hP
+Ue
+ad
 hh
-RF
+ap
 eL
 xu
-lZ
+at
 YA
 wm
 Fv
-qU
-JO
-qp
-PW
-fo
-AX
-AX
-AX
-AX
+WL
 hs
-qp
-qp
+bZ
+dK
+fo
+fo
+fo
+fo
+My
+hs
+QU
+QE
 UL
 hT
 QE
-tb
+QE
 ow
+jv
+kH
+tb
+lB
 lU
 lU
 lU
@@ -25719,53 +26451,49 @@ lU
 lU
 lU
 lU
-Aw
-NU
+rw
+td
 fV
-sf
+Po
 Tt
 Tt
-vY
-Kc
-Tt
-xE
 KN
 Zz
 Tt
 ME
 aH
 kM
-ub
-QM
-ZO
-yV
-jO
-LY
-wH
-mM
-nx
+Tt
+Hy
+Lc
+NK
+PI
+SY
+Xf
+Yf
+GQ
 Qa
 Zo
-IK
-IK
+gC
+TY
 aE
+GA
 IK
 IK
-ex
 eM
-zm
-Ob
+IK
+IK
 Ob
 rS
-Lo
+zm
 MD
-wj
+MD
 nh
 WM
-aa
-aa
-aa
-aa
+kV
+JM
+DV
+vk
 aa
 aa
 aa
@@ -25828,86 +26556,86 @@ aa
 aa
 aa
 aa
-aa
 XP
-JO
-dG
-dG
-JO
+WL
+LB
+LB
+WL
+az
 fU
 ET
 fw
-Lt
-JO
-fC
-HW
+WL
+bN
+cg
+dO
 XB
-By
-By
-By
-By
+XB
+XB
+XB
+iz
 kD
-yP
-qp
+QU
+Ff
 NI
-tb
-lj
-mc
+hu
+Ff
+QE
 mZ
-SQ
+tb
 AO
-Zv
+mc
 tj
-tj
+mk
 ru
 sD
-oc
 DG
-fV
+DG
+qb
 Fd
 od
-Tt
-DC
-DC
-Tt
-Po
-Tt
-DC
-Tt
-ol
-AN
-Tt
-Tt
-Tt
-Zr
+tf
 fV
-Aq
-LY
+va
+vE
+Tt
+DC
+DC
+Tt
+DC
+Tt
+DC
+Tt
+nY
+Zr
+Tt
+Tt
+Ta
 BK
-wu
+fV
 Uw
-Ho
+Qa
 Hc
 yo
 au
 aG
 aP
-zm
+CK
 eF
 eN
+Qt
 zm
-sL
 HD
 Nt
-Ij
-Il
 zm
+Il
+jJ
 rl
 Zi
-aa
-aa
-aa
-aa
+cP
+zm
+Ov
+pM
 aa
 aa
 aa
@@ -25969,66 +26697,66 @@ aa
 aa
 aa
 aa
-aa
 tm
 tm
 XP
 XP
 XP
-JO
+WL
+aF
 ZC
-VI
-JO
-cx
-JO
+WL
+MW
+WL
 dw
+XB
 By
 Zf
 Ip
-VF
-VF
-Oq
+Ip
+eR
+OY
 ge
-Ow
-qp
-Pg
-tb
+QU
 Ff
-tb
+Pg
+hA
+Ff
+QE
 wV
-qr
-qr
-vU
-qr
+tb
+kJ
+tb
+lC
 qr
 qr
 nb
-pG
-Hh
-rI
+qr
+qr
+qr
 Li
-pH
+pG
 hr
-hr
-hr
-hr
+WN
+ve
+vH
 Ug
-AW
-AW
-AW
+Ug
+Ug
+Ug
 Zh
-by
 qe
-by
+qe
+qe
 oA
 Dj
-rI
-Cx
-LY
+NU
+Dj
+Tz
 IN
-KA
+WN
 Sr
-jc
+Qa
 LN
 Im
 fQ
@@ -26043,13 +26771,13 @@ cU
 Gp
 MV
 vd
-wj
-rl
-WM
-aa
-aa
-aa
-aa
+Hx
+TF
+Qf
+US
+JM
+Ov
+vk
 aa
 aa
 aa
@@ -26116,37 +26844,41 @@ aa
 aa
 aa
 aa
-aa
 XP
 XP
-hP
-JO
-JO
-JO
+Ue
+WL
+WL
+WL
+Dk
 XU
-uB
+QU
 oh
 so
-Pk
-xq
-OY
+ez
+eX
+fn
 ia
-bd
-qp
-lO
-tb
-tb
-tb
+QU
+Ff
+TP
+WQ
+Ff
+QE
 XE
-qr
-ve
-oV
+tb
+tb
+tb
 cf
-SN
 qr
-ma
+no
+nN
+op
+ov
+qr
+qO
 pG
-bp
+sF
 fV
 Ks
 jM
@@ -26158,40 +26890,36 @@ jM
 jM
 jM
 fV
-Yx
-Ia
+Hz
+KX
 fV
 Ks
 jM
 jM
 fV
-va
-LY
-HU
-QJ
 PF
-pT
+Qa
 pA
 Bb
 pt
 vb
 aV
-zm
+wc
 AL
 AT
+dI
 zm
-nL
 PH
 pV
-UN
-Tf
 zm
-rl
-Zi
-aa
-aa
-aa
-aa
+Tf
+HY
+JU
+Ee
+FP
+zm
+Ov
+pM
 aa
 aa
 aa
@@ -26261,79 +26989,79 @@ aa
 aa
 aa
 aa
-aa
-mI
-JO
-JO
-qc
+Bm
+WL
+WL
 qI
-oh
+cl
+QU
+eg
 DU
-Hl
-Hl
-Hl
-ia
-zo
-qp
+DU
+DU
+fn
+gk
+QU
+Ff
 TP
 WQ
-dc
-VT
+Ff
+QE
 mb
-qr
+jN
 ag
 EH
 iQ
-AQ
 qr
+nq
 Fq
+oq
+oV
+qr
+qP
 pG
-Hh
-SY
-pG
-pG
-pG
-pG
-pG
-pG
-pG
-pG
-pG
-Ua
-AI
+hr
+tU
 pG
 pG
 pG
 pG
 pG
-SY
-ng
-LY
-fx
-KA
+pG
+pG
+pG
+pG
+DX
+HN
+pG
+pG
+pG
+pG
+pG
+tU
 mO
-Pu
+Qa
 uR
-Dh
+Im
 OL
 nI
 kP
+XA
+fu
+GP
+PD
 zm
 zm
 zm
 zm
-Uf
-bJ
-lX
-lT
 uI
-wj
-rl
-WM
-aa
-aa
-aa
-aa
+YG
+xK
+gi
+na
+JM
+Ov
+vk
 aa
 aa
 aa
@@ -26401,58 +27129,58 @@ aa
 aa
 aa
 aa
-aa
 tm
 tm
 tm
-qn
-JO
-iw
-iw
-oh
-oh
-MQ
-tR
+aO
+WL
+LH
+LH
+QU
+QU
+kw
+eG
+eY
 kG
-iz
-Ad
-qp
-dV
-Ka
-Ka
-Ka
+gm
+QU
+Ff
+TP
+WQ
+Ff
+QE
 kj
-qr
-ux
-aw
+Qy
+Qy
+Qy
 Uj
-hM
 qr
+nw
 Wy
 wg
 tK
-rU
+qr
 ce
-ce
+rT
 uM
 gV
 pC
-cr
+pC
 tk
-tk
+wx
 oS
 to
-BJ
+CO
 CO
 tx
 LD
-CO
-vw
-CO
+HT
+FT
+Od
 Wt
 FT
 pw
-Cs
+FT
 HK
 ig
 wy
@@ -26460,22 +27188,22 @@ cV
 Nc
 tB
 Rd
-zm
+SV
 zJ
 sC
+io
 zm
-RI
 RI
 eC
-gM
-kS
 zm
+kS
+kS
 Gy
-Zi
-aa
-aa
-aa
-aa
+Rn
+VZ
+zm
+Sy
+pM
 aa
 aa
 aa
@@ -26547,33 +27275,37 @@ aa
 aa
 aa
 aa
-aa
 XP
 XP
 XP
 XP
-oh
-iw
-iw
-oh
+QU
+LH
+LH
+QU
+fs
 OX
-lc
-qp
+QU
+Ff
 YB
 kC
-Ka
-nS
+Ff
+QE
 pK
-qr
-zy
+jS
+Qy
 YZ
 Pb
-MB
+qr
+nB
+nV
+ot
+oW
 qr
 Sk
 Sk
 Sk
-PX
+tZ
 Sk
 Sk
 Sk
@@ -26584,32 +27316,32 @@ RQ
 RQ
 RQ
 RQ
-kX
-yj
+HU
+Le
 fW
 fW
 fW
 fW
 fW
 fW
-LY
-LY
-LY
-LY
+Qa
+Qa
+Qa
+Qa
 WJ
-te
+Zw
 WJ
 WJ
 WJ
 WJ
 zm
-el
-cl
+xj
+yH
 zm
 zm
 zm
 zm
-rT
+xY
 zm
 zm
 zm
@@ -26619,11 +27351,7 @@ hj
 hj
 hj
 aa
-uL
-aa
-aa
-aa
-aa
+VN
 aa
 aa
 aa
@@ -26693,72 +27421,76 @@ aa
 aa
 aa
 aa
-aa
 XP
 XP
 XP
-oh
-iw
-iw
-oh
+QU
+LH
+bt
+QU
+Ff
 yv
 BW
-Ka
-nS
+Ff
+QE
 IF
-qr
+kd
 Qy
-qr
+YZ
 NO
-Og
+qr
 tw
-BU
+qr
 zu
 sw
 bg
 Hq
 pB
 HF
-RQ
+ub
 GJ
 oF
 OD
-aF
-Ps
 RQ
+Ps
+yd
 ah
 Ml
-fW
-am
+BO
+RQ
 Ok
-dh
-HT
+GU
+fW
 yZ
 It
 jY
-jY
+Ym
 Um
-WJ
-ms
+TH
+Ax
 Ax
 yU
-wx
+WJ
 Wz
-fb
+Vr
 iN
 Rg
 qD
 fb
 ii
-oK
+Lu
 ya
-vE
+fb
 WU
 Pf
-fi
-uQ
-fi
-uQ
+cd
+oE
+bT
+tS
+aL
+Tb
+aL
+Tb
 hj
 hj
 hj
@@ -26766,7 +27498,7 @@ hj
 hj
 hj
 hj
-Fk
+ww
 XP
 XP
 XP
@@ -26775,10 +27507,6 @@ XP
 tm
 tm
 tm
-aa
-aa
-aa
-aa
 aa
 aa
 aa
@@ -26838,77 +27566,81 @@ aa
 aa
 aa
 aa
-aa
 XP
 XP
-XP
-oh
+wG
+QU
+Ff
 HZ
-EU
-EU
-PG
+HZ
+Ff
+QE
 sI
-dY
+Sg
+Sg
+kW
+lF
+mH
 rx
 qr
 qr
 qr
 qr
-CF
-Sk
-pc
-Qb
 OM
-Mp
+Sk
 FM
 vZ
 tu
-tu
+vJ
 eD
-YS
+wN
 Xl
-RQ
+Xl
 ym
-kr
+Fn
 qH
-mS
+RQ
 LU
-LU
-LU
+Lg
+Og
 vx
 or
-VS
-VS
+or
+or
 lA
-WJ
-uk
-MO
+Ei
+VS
+VS
 BZ
-FB
+WJ
 hk
-fb
+mr
 Ll
-Rg
+pq
 RG
 fb
 yN
 Lu
-ya
+pU
+fb
+bx
+cC
+cd
 in
 in
 in
 in
 in
-sl
-in
-fg
-qo
 gA
-fi
-uQ
+in
+GZ
 RE
-hj
+Ej
 aL
+Tb
+YH
+hj
+dH
 hj
 hj
 hj
@@ -26916,15 +27648,11 @@ Dq
 Dq
 Dq
 Dq
-Lz
+pz
 XP
 XP
 XP
 XP
-aa
-aa
-aa
-aa
 aa
 aa
 aa
@@ -26983,56 +27711,60 @@ aa
 aa
 aa
 aa
-aa
-nw
-JJ
-eu
-EU
-EU
+XP
+XP
+XP
+XP
+XP
+iE
 yu
-EU
-Kd
+ke
+Sg
+Sg
+lS
+Sg
+nC
 rx
 rx
-QY
-Sk
-Gq
-Sk
 uZ
-ju
+Sk
 Pj
-uw
+Sk
 BH
-RQ
+uc
 Nb
 YS
 bQ
-Lc
+RQ
 vs
 Fn
 aB
 mE
-fW
+BT
 lR
 XR
-VS
-XR
+Lj
+fW
 gR
 Yc
 VS
-OI
+Yc
 qQ
-WJ
-WS
+qA
+VS
 gd
 IY
-IY
-IY
+WJ
+LR
 Jf
 Tg
-wZ
-yX
+Tg
+Tg
 ck
+jn
+fc
+CM
+Lw
 SW
 SW
 SW
@@ -27041,28 +27773,24 @@ SW
 SW
 SW
 SW
-RA
-AJ
+sB
+Uv
 FU
 FU
 FU
 FU
 FU
 FU
-Qz
-tQ
-iJ
-mH
-ya
+ZD
 ff
 Wf
 fr
-Dq
+cd
 KZ
-aa
-aa
-aa
-aa
+xa
+Jl
+Dq
+Tm
 aa
 aa
 aa
@@ -27131,56 +27859,60 @@ aa
 aa
 aa
 aa
-hP
-EU
-EU
+aa
+aa
+aa
+aa
+Ue
+Sg
+Sg
 rx
 rx
-CL
+jr
 Sk
-QH
-Sk
-Sk
-MU
+rc
 Sk
 Sk
-nM
-RQ
-Od
-YS
+uh
+Sk
+Sk
 MG
-tf
-rG
 RQ
-ca
+rG
+Fn
+NZ
 Na
-fW
-Gm
+BU
+RQ
 tX
+lv
+fW
+PK
+tJ
 VS
-XR
-gR
 Yc
-XR
-mQ
-ab
-WJ
-xJ
+qQ
+qA
+Yc
 YL
 iq
-iq
+WJ
 nD
-fb
+et
 pv
-cM
+pv
 tM
 fb
 uQ
 fi
-fi
-vE
+mg
+fb
 Tb
-Pf
+aL
+aL
+oE
+iH
+tS
 in
 in
 in
@@ -27190,23 +27922,19 @@ in
 in
 in
 in
-uv
+lY
 in
 in
 in
 in
-Mf
-fh
-Dq
-fs
 KT
 fS
+Dq
+Km
+yz
+Fa
 XP
 XP
-aa
-aa
-aa
-aa
 aa
 aa
 aa
@@ -27274,46 +28002,50 @@ aa
 aa
 aa
 aa
-mI
-EU
-EU
+aa
+aa
+aa
+aa
+Bm
+Sg
+Sg
 rx
 rx
 Sk
 Sk
 Sk
-TE
 QB
+uk
 Sk
-oW
-QB
-RQ
-On
 Wk
-MG
-Nz
-Kp
+uk
 RQ
+Kp
+yj
 NZ
-Na
+zZ
+BX
+RQ
+cX
+lv
 fW
-Ju
-tX
-VS
-XR
 Hg
 tJ
-kZ
-mP
+VS
+Yc
 AY
-WJ
+PA
 JK
 Yp
 ax
-kn
+WJ
+zA
+pS
+Xh
+qM
 WJ
 fb
-Xh
+Tk
 fb
 fb
 fb
@@ -27325,7 +28057,7 @@ fb
 fb
 fb
 fb
-Rf
+Ol
 fb
 fb
 fb
@@ -27338,15 +28070,11 @@ fb
 fb
 fb
 fb
-bP
+Lk
 Dq
 Dq
 Dq
-JW
-aa
-aa
-aa
-aa
+Vz
 aa
 aa
 aa
@@ -27417,78 +28145,78 @@ aa
 aa
 aa
 aa
-mI
-EU
-EU
+aa
+aa
+aa
+aa
+Bm
+Sg
+Sg
 rx
 rx
-QY
+uZ
 Sk
-UC
 rQ
+JI
 Sk
-UC
 rQ
-RQ
-RQ
-RQ
 JI
 RQ
 RQ
 RQ
-ca
-rj
+zw
+RQ
+RQ
+RQ
+tX
+Lo
 fW
-jS
-fk
-VS
-mQ
 ZR
-Ly
-kc
-Ly
+TE
+VS
+YL
 ZA
+TZ
+dJ
+TZ
+ok
 fW
 DD
 DD
 DD
 DD
 DD
-ik
-dv
-Oo
+Oz
+UM
+mq
+Au
+rL
+rL
+rL
+rL
 bM
 rL
 rL
 rL
+Au
 rL
-vL
-rL
-rL
-rL
-bM
-rL
-EP
+eQ
 rL
 rL
 rL
 rL
 rL
-Cy
-rL
-rL
-Uo
 tg
 rL
-dj
+rL
 hK
 Ri
+rL
+yK
+dr
+gK
 tm
 tm
-aa
-aa
-aa
-aa
 aa
 aa
 aa
@@ -27560,57 +28288,61 @@ aa
 aa
 aa
 aa
-mI
-EU
-EU
+aa
+aa
+aa
+aa
+Bm
+Sg
+Sg
 rx
 rx
 Sk
 Sk
-Pr
+uv
 Sk
 Sk
-Pr
+uv
 RQ
-Qn
-YD
-MG
-op
 Wj
+yx
+NZ
+Ag
+Cq
 RQ
-eo
-Na
-fW
-iB
 HG
 lv
-ac
+fW
 Ry
+TJ
+Vx
+Yx
+Fr
 fW
 fW
 fW
 fW
 fW
-dJ
-cg
-IJ
-Av
 vc
-mm
+ps
+Xw
+AB
+tq
+OF
 Dq
-Lk
-Dq
-Dq
-Dq
-Dq
-Dq
-Dq
+Dg
 Dq
 Dq
 Dq
 Dq
 Dq
-Lk
+Dq
+Dq
+Dq
+Dq
+Dq
+Dq
+Dg
 Dq
 Dq
 Dq
@@ -27625,10 +28357,6 @@ Dq
 Dq
 Dq
 XP
-aa
-aa
-aa
-aa
 aa
 aa
 aa
@@ -27703,44 +28431,48 @@ aa
 aa
 aa
 aa
-mI
-EU
-EU
+aa
+aa
+aa
+aa
+Bm
+Sg
+Sg
 rx
-CL
+jr
 Sk
-BN
-Sk
-Sk
-BN
-RQ
-Ta
-Mg
 Wu
-uh
-HX
+Sk
+Sk
+Wu
 RQ
+HX
+yD
 WB
 bX
-fW
-PI
+Cy
+RQ
 Ly
 kc
-Ly
-Ig
 fW
+Ig
+TZ
 dJ
-hL
+TZ
 xr
-Mm
+fW
 vc
-vc
+hL
 mm
+Bj
+tq
+tq
+OF
 Dq
 Dq
 Dq
 Dq
-up
+wT
 XP
 XP
 XP
@@ -27752,7 +28484,7 @@ XP
 XP
 XP
 XP
-DX
+Vy
 tm
 tm
 tm
@@ -27767,10 +28499,6 @@ tm
 tm
 tm
 tm
-aa
-aa
-aa
-aa
 aa
 aa
 aa
@@ -27846,24 +28574,28 @@ aa
 aa
 aa
 aa
-mI
-EU
-EU
+aa
+aa
+aa
+aa
+Bm
+Sg
+Sg
 rx
 rx
 rx
-gE
-zZ
-rx
-CS
 Yo
 YQ
-Ko
+rx
 Sj
 VE
-RQ
+yF
 xQ
 Gx
+CF
+RQ
+Ia
+Lz
 fW
 fW
 fW
@@ -27873,18 +28605,14 @@ fW
 fW
 hL
 hL
-TJ
-xP
+iK
+JN
 Dq
 Dq
 Dq
 Dq
 aa
-Dg
-aa
-aa
-aa
-aa
+uu
 aa
 aa
 aa
@@ -27989,14 +28717,18 @@ aa
 aa
 aa
 aa
-xB
-ZQ
-ZQ
-iM
-iM
+aa
+aa
+aa
+aa
 iM
 ZY
+ZY
 uz
+uz
+uz
+Iu
+we
 RQ
 RQ
 RQ
@@ -28004,26 +28736,22 @@ RQ
 RQ
 RQ
 RQ
-fN
-Na
-yx
-hL
 LF
+lv
+On
 hL
-hL
-bP
 sZ
 hL
-Dq
+hL
 Lk
+is
+hL
 Dq
-Dq
-aa
 Dg
+Dq
+Dq
 aa
-aa
-aa
-aa
+uu
 aa
 aa
 aa
@@ -28132,36 +28860,36 @@ aa
 aa
 aa
 aa
-mI
-EU
-EU
-QY
+aa
+aa
+aa
+aa
+Bm
+Sg
+Sg
+uZ
 rx
-sV
-CL
-Bw
-dT
 XD
 jr
-xw
-av
 Bw
+av
+yJ
 zd
 xR
+CH
+Bw
+Ih
+LA
 HS
 HS
 HS
 HS
 HS
-ch
-Dq
-Dq
-Dq
 up
-aa
-aa
-aa
-aa
+Dq
+Dq
+Dq
+wT
 aa
 aa
 aa
@@ -28275,32 +29003,32 @@ aa
 aa
 aa
 aa
-mI
-EU
-EU
+aa
+aa
+aa
+aa
+Bm
+Sg
+Sg
 rx
-sV
-QY
+XD
+uZ
 Bw
-Wd
-cv
-rv
-Hu
 YY
-Bw
-NZ
+yO
+Dx
 oO
-HS
-Jp
+CI
+Bw
 cX
 rh
-XT
+HS
 ch
-Vh
-aa
-aa
-aa
-aa
+Ua
+VK
+Yy
+up
+ys
 aa
 aa
 aa
@@ -28418,30 +29146,30 @@ aa
 aa
 aa
 aa
-mI
-EU
-EU
-wN
-ZY
-Bw
-Bw
+aa
+aa
+aa
+aa
+Bm
+Sg
+Sg
 ss
 Iu
-Jt
-vt
+Bw
+Bw
 Vt
 Td
 Nw
-HS
+CS
 Lx
 ta
 XJ
-Hr
+HS
 Cf
-aa
-aa
-aa
-aa
+Uf
+VO
+YD
+lK
 aa
 aa
 aa
@@ -28561,29 +29289,29 @@ aa
 aa
 aa
 aa
-mI
-EU
-EU
-wN
-ZY
-qN
+aa
+aa
+aa
+aa
+Bm
 Sg
-eV
-rv
+Sg
+ss
+Iu
 gn
-Bw
+yR
 qK
 Dx
 oN
-CU
+Bw
 Fe
 YN
 IS
-Cf
-aa
-aa
-aa
-aa
+PX
+Uo
+VQ
+YP
+lK
 aa
 aa
 aa
@@ -28704,28 +29432,28 @@ aa
 aa
 aa
 aa
-mI
-EU
-EU
-sV
+aa
+aa
+aa
+aa
+Bm
+Sg
+Sg
+XD
 Bw
-Bw
-JH
-Cg
-Yy
 Bw
 vG
-Na
-HS
-vH
+An
+CU
+Bw
 fa
-XJ
-Hr
-Cf
-aa
-aa
-aa
-aa
+lv
+HS
+Qb
+UA
+VO
+YD
+lK
 aa
 aa
 aa
@@ -28847,28 +29575,28 @@ aa
 aa
 aa
 aa
-XW
-ZQ
-Mv
-lx
-Bw
-po
+aa
+aa
+aa
+aa
+vL
+ZY
 Ie
 Yt
 Bw
 cH
-Ml
-HS
-bU
+Aq
+CV
+Bw
 hi
 GU
-Jd
-ch
-ql
-aa
-aa
-aa
-aa
+HS
+Qc
+UC
+VX
+YR
+up
+bn
 aa
 aa
 aa
@@ -28990,28 +29718,28 @@ aa
 aa
 aa
 aa
-Up
-Up
-VQ
-Bw
-Bw
-Bw
-Bw
-Bw
-vJ
-PC
-HS
-HS
-HS
-HS
-HS
-ch
-Up
-tZ
 aa
 aa
 aa
 aa
+Xq
+Xq
+xN
+Bw
+Bw
+Bw
+Bw
+Bw
+Ij
+LI
+HS
+HS
+HS
+HS
+HS
+up
+Xq
+ie
 aa
 aa
 aa
@@ -29132,27 +29860,27 @@ aa
 aa
 aa
 aa
-gX
-Up
-sh
-uc
-ku
-lP
+aa
+aa
+aa
+aa
+Qq
+Xq
 mG
 rR
 zI
-yC
+As
 Mb
 aj
-BF
-BF
+Is
+yC
 wr
-BF
-Up
-aa
-aa
-aa
-aa
+Qm
+XZ
+XZ
+Zg
+XZ
+Xq
 aa
 aa
 aa
@@ -29275,28 +30003,28 @@ aa
 aa
 aa
 aa
-Up
-Up
-aT
-yC
-yC
-jI
-yC
-td
-yC
-yC
-yC
-jI
-yC
-yC
-BF
-Up
-Up
-ql
 aa
 aa
 aa
 aa
+Xq
+Xq
+Iz
+yC
+yC
+Dl
+yC
+Iv
+yC
+yC
+yC
+Dl
+yC
+yC
+XZ
+Xq
+Xq
+bn
 aa
 aa
 aa
@@ -29417,29 +30145,29 @@ aa
 aa
 aa
 aa
-gX
-Up
-zj
-BF
-BF
-xi
+aa
+aa
+aa
+aa
+Qq
+Xq
 DI
 XZ
-Aj
+XZ
 ct
 er
 wF
-BF
-yC
-yC
+Mf
+Oo
+Qn
 hb
-Up
-Up
-bA
-aa
-aa
-aa
-aa
+XZ
+yC
+yC
+sR
+Xq
+Xq
+TR
 aa
 aa
 aa
@@ -29560,28 +30288,28 @@ aa
 aa
 aa
 aa
-Up
-Up
-Le
-yC
-yC
-yC
+aa
+aa
+aa
+aa
+Xq
+Xq
 cn
 yC
 yC
 yC
+IJ
 yC
 yC
 yC
 yC
 yC
-dO
-xX
-Kl
-aa
-aa
-aa
-aa
+yC
+yC
+yC
+lG
+Mu
+Fg
 aa
 aa
 aa
@@ -29702,33 +30430,33 @@ aa
 aa
 aa
 aa
-gX
-Up
-BF
-BF
-MR
-Ws
-yf
-GT
+aa
+aa
+aa
+aa
+Qq
+Xq
+XZ
+XZ
 ml
 Ot
 iU
-BF
-BF
-BF
+Mg
+Op
+Qx
+UF
+XZ
+XZ
+XZ
 yC
-Nm
-xX
-Kl
-XP
-XP
+Bf
 Mu
-uK
-bA
-aa
-aa
-aa
-aa
+Fg
+XP
+XP
+Pd
+hq
+TR
 aa
 aa
 aa
@@ -29845,33 +30573,33 @@ aa
 aa
 aa
 aa
-Up
-Up
-aT
-MP
-yC
-dQ
+aa
+aa
+aa
+aa
+Xq
+Xq
 Iz
 gU
-EX
+yC
 ST
 Uk
 bK
-Iz
+Qz
 mV
 SG
-Up
-Up
-bA
+Zp
+Uk
+vr
+xg
+Xq
+Xq
+TR
 XP
-ZJ
-RD
-Kl
+UW
+Wl
+Fg
 XP
-aa
-aa
-aa
-aa
 aa
 aa
 aa
@@ -29987,33 +30715,33 @@ aa
 aa
 aa
 aa
-gX
-Up
-BF
-BF
+aa
+aa
+aa
+aa
 Qq
-HC
-nc
+Xq
+XZ
+XZ
+DY
+IL
+Mh
 mw
 mw
 mw
 mw
-AU
+TO
 yC
-Qc
-Iz
-MX
-Wo
-nl
-OT
+Gr
+Uk
 hG
 qy
-QI
+NT
+Jz
+MZ
+sG
+Up
 XP
-aa
-aa
-aa
-aa
 aa
 aa
 aa
@@ -30130,30 +30858,30 @@ aa
 aa
 aa
 aa
-Up
-Up
-uJ
-Pv
-kY
-Xj
+aa
+aa
+aa
+aa
+Xq
+Xq
 dd
 Hb
 pi
-mw
+Mm
 AU
-yC
+QH
 Pv
-Gv
+mw
 TO
-xX
-Kl
+yC
+Hb
+Je
+Fh
+Mu
+Fg
 XP
 XP
 XP
-aa
-aa
-aa
-aa
 aa
 aa
 aa
@@ -30272,28 +31000,28 @@ aa
 aa
 aa
 aa
-Tz
-Up
-mw
-mw
+aa
+aa
+aa
+aa
 If
-da
+Xq
 mw
-UA
+mw
 JV
+Mp
 mw
-AU
 Gv
+UG
+mw
+TO
+Je
+Xq
+Xq
+Xq
+Xq
 Up
-Up
-Up
-Up
-QI
 XP
-aa
-aa
-aa
-aa
 aa
 aa
 aa
@@ -30414,26 +31142,26 @@ aa
 aa
 aa
 aa
+aa
+aa
+aa
+TR
 XP
-Up
-Up
-ud
-Ag
-NQ
+Xq
+Xq
+XC
+IU
+Mv
 mw
-XC
-XC
-Up
-Xb
-Up
-Up
+QJ
+QJ
+Xq
+Zv
+Xq
+Xq
 XP
-WC
+UN
 XP
-aa
-aa
-aa
-aa
 aa
 aa
 aa
@@ -30556,24 +31284,24 @@ aa
 aa
 aa
 aa
-XP
-Tz
-Up
+aa
+aa
+Ls
 NT
-oT
+Jz
 Us
-Up
-Up
-Up
-Up
-qX
+Dm
+Ev
+Jd
+MB
 Xq
+Xq
+Xq
+Xq
+ZE
+Vu
 XP
 XP
-aa
-aa
-aa
-aa
 aa
 aa
 aa
@@ -30696,25 +31424,25 @@ aa
 aa
 aa
 aa
-XP
-XP
-XP
-XP
-Up
-Up
-Cq
-Dy
+aa
+aa
+aa
+aa
+Yr
 Up
 XP
+XP
+Du
+Xq
 WC
-ZJ
-UI
-Kl
+ML
+Xq
 XP
-aa
-aa
-aa
-aa
+UN
+UW
+ZK
+Fg
+XP
 aa
 aa
 aa
@@ -30835,27 +31563,27 @@ aa
 aa
 aa
 aa
+aa
+aa
+aa
+aa
 tm
 tm
-Mu
-uK
-bA
 XP
 XP
-Lz
-zF
-iF
-ke
-Hj
 XP
 XP
-mo
-Fg
-QI
-aa
-aa
-aa
-aa
+XP
+XP
+XP
+XP
+XP
+XP
+XP
+XP
+Wd
+Yr
+Up
 aa
 aa
 aa
@@ -30978,22 +31706,22 @@ aa
 aa
 aa
 aa
-XP
-ZJ
-UW
-nl
-OT
-OT
-OT
-OT
-ne
-XP
-XP
-XP
 aa
 aa
 aa
 aa
+XP
+XP
+XP
+XP
+XP
+XP
+XP
+XP
+Ji
+XP
+XP
+XP
 aa
 aa
 aa
@@ -31089,7 +31817,11 @@ aa
 aa
 aa
 aa
-kW
+aa
+aa
+aa
+aa
+cy
 aa
 aa
 aa
@@ -31121,19 +31853,15 @@ tm
 tm
 XP
 XP
-mo
-Fg
-QI
 XP
 XP
 XP
 XP
 XP
 XP
-aa
-aa
-aa
-aa
+XP
+XP
+XP
 aa
 aa
 aa
@@ -31412,7 +32140,7 @@ aa
 aa
 aa
 aa
-kd
+aa
 aa
 aa
 aa
@@ -32312,11 +33040,11 @@ aa
 aa
 aa
 aa
-OW
 aa
 aa
 aa
 aa
+Rk
 aa
 aa
 aa

--- a/maps/offmap_vr/talon/talon_v2_areas.dm
+++ b/maps/offmap_vr/talon/talon_v2_areas.dm
@@ -50,6 +50,9 @@
 /area/talon_v2/hangar
 	name = "\improper Talon - Hangar"
 	icon_state = "red"
+/area/talon_v2/pod_hangar
+	name = "\improper Talon - Pod Hangar"
+	icon_state = "red"
 
 /area/talon_v2/engineering
 	name = "\improper Talon - Engineering"
@@ -89,6 +92,9 @@
 	icon_state = "red"
 /area/talon_v2/secure_storage
 	name = "\improper Talon - Secure Storage"
+	icon_state = "red"
+/area/talon_v2/ofd_ops
+	name = "\improper Talon - OFD Ops"
 	icon_state = "red"
 /area/talon_v2/bridge
 	name = "\improper Talon - Bridge"


### PR DESCRIPTION
Stops HE Pipes from being invisible.

Heat Exchange pipes sprites can't be painted, this stops the RPD from trying to paint them.

This fixes #9586