### PR TITLE
Fixes invisible Heat Exchange Pipes

### DIFF
--- a/code/game/machinery/pipe/pipe_recipes.dm
+++ b/code/game/machinery/pipe/pipe_recipes.dm
@@ -134,7 +134,7 @@ GLOBAL_LIST_INIT(disposal_pipe_recipes, list(
 	dirtype = initial(construction_type.dispenser_class)
 	if (dirtype == PIPE_TRIN_M)
 		icon_state_m = "[icon_state]m"
-	paintable = ispath(path, /obj/machinery/atmospherics/pipe) && !(ispath(path, /obj/machinery/atmospherics/pipe/vent))	// VOREStation Add
+	paintable = !ispath(path, /obj/machinery/atmospherics/pipe/simple/heat_exchanging) && ispath(path, /obj/machinery/atmospherics/pipe) && !(ispath(path, /obj/machinery/atmospherics/pipe/vent))	// VOREStation Add
 
 
 //

--- a/code/game/objects/items/weapons/RPD_vr.dm
+++ b/code/game/objects/items/weapons/RPD_vr.dm
@@ -16,7 +16,7 @@
 	item_icons = list(
 		slot_l_hand_str = 'icons/mob/items/lefthand_vr.dmi',
 		slot_r_hand_str = 'icons/mob/items/righthand_vr.dmi',
-	)	
+	)
 	flags = NOBLUDGEON
 	force = 10
 	throwforce = 10
@@ -184,9 +184,9 @@
 			activate()
 			animate_deletion(A)
 		return
-	
+
 	if((mode & PAINT_MODE)) //Paint pipes
-		if(istype(A, /obj/machinery/atmospherics/pipe))
+		if(!istype(A, /obj/machinery/atmospherics/pipe/simple/heat_exchanging) && istype(A, /obj/machinery/atmospherics/pipe))
 			var/obj/machinery/atmospherics/pipe/P = A
 			playsound(src, 'sound/machines/click.ogg', 50, 1)
 			P.change_color(pipe_colors[paint_color])


### PR DESCRIPTION
Stops HE Pipes from being invisible.

Heat Exchange pipes sprites can't be painted, this stops the RPD from trying to paint them.

This fixes #9586