### PR TITLE
Vore mobs can eat you while unconcious

### DIFF
--- a/code/modules/ai/ai_holder_targeting.dm
+++ b/code/modules/ai/ai_holder_targeting.dm
@@ -130,8 +130,15 @@
 			if(L.stat == UNCONSCIOUS)	// Do we have mauling? Yes? Then maul people who are sleeping but not SSD
 				if(mauling)
 					return TRUE
-				else if(unconscious_vore && L.allowmobvore) //VOREStation Add
-					return TRUE								//VOREStation Add
+				//VOREStation Add Start
+				else if(unconscious_vore && L.allowmobvore)
+					var/mob/living/simple_mob/vore/eater = holder
+					if(eater.prey_excludes[L])
+						return FALSE
+					if(eater.vore_fullness >= eater.vore_capacity)
+						return FALSE
+					return TRUE
+				//VOREStation Add End
 				else
 					return FALSE
 		if(holder.IIsAlly(L))

--- a/code/modules/ai/ai_holder_targeting.dm
+++ b/code/modules/ai/ai_holder_targeting.dm
@@ -133,11 +133,10 @@
 				//VOREStation Add Start
 				else if(unconscious_vore && L.allowmobvore)
 					var/mob/living/simple_mob/vore/eater = holder
-					if(eater.prey_excludes[L])
+					if(eater.will_eat(L))
+						return TRUE
+					else
 						return FALSE
-					if(eater.vore_fullness >= eater.vore_capacity)
-						return FALSE
-					return TRUE
 				//VOREStation Add End
 				else
 					return FALSE

--- a/code/modules/ai/ai_holder_targeting.dm
+++ b/code/modules/ai/ai_holder_targeting.dm
@@ -4,7 +4,8 @@
 	var/hostile = FALSE						// Do we try to hurt others?
 	var/retaliate = FALSE					// Attacks whatever struck it first. Mobs will still attack back if this is false but hostile is true.
 	var/mauling = FALSE						// Attacks unconscious mobs
-	var/handle_corpse = FALSE					// Allows AI to acknowledge corpses (e.g. nurse spiders)
+	var/unconscious_vore = FALSE			//VOREStation Add - allows a mob to go for unconcious targets IF their vore prefs align
+	var/handle_corpse = FALSE				// Allows AI to acknowledge corpses (e.g. nurse spiders)
 
 	var/atom/movable/target = null			// The thing (mob or object) we're trying to kill.
 	var/atom/movable/preferred_target = null// If set, and if given the chance, we will always prefer to target this over other options.
@@ -129,6 +130,8 @@
 			if(L.stat == UNCONSCIOUS)	// Do we have mauling? Yes? Then maul people who are sleeping but not SSD
 				if(mauling)
 					return TRUE
+				else if(unconscious_vore && L.allowmobvore) //VOREStation Add
+					return TRUE								//VOREStation Add
 				else
 					return FALSE
 		if(holder.IIsAlly(L))


### PR DESCRIPTION
-Only if it's enabled on the mob's AI holder
-Only if your settings are configured to allow it.

Otherwise it acts normal, doesn't bother SSD people, doesn't maul you while unconscious (unless it is set to do that, since that's an option that exists)

Important for a mob I will be adding soon.