### PR TITLE
Makes proteans use special NIF subtype

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/protean_vr/protean_species.dm
+++ b/code/modules/mob/living/carbon/human/species/station/protean_vr/protean_species.dm
@@ -147,10 +147,10 @@
 		if(!H) //Human could have been deleted in this amount of time. Observing does this, mannequins, etc.
 			return
 		if(!H.nif)
-			var/obj/item/device/nif/bioadap/new_nif = new()
+			var/obj/item/device/nif/protean/new_nif = new()
 			new_nif.quick_implant(H)
 		else
-			H.nif.durability = rand(21,25)
+			H.nif.durability = 25
 
 /datum/species/protean/hug(var/mob/living/carbon/human/H, var/mob/living/target)
 	return ..() //Wut

--- a/code/modules/nifsoft/nif.dm
+++ b/code/modules/nifsoft/nif.dm
@@ -608,6 +608,12 @@ You can also set the stat of a NIF to NIF_TEMPFAIL without any issues to disable
 	durability = 75
 	bioadap = TRUE
 
+/obj/item/device/nif/protean				// Proteans' integrated NIF
+	name = "protean integrated NIF"
+	desc = "A NIF that is part of a protean's body structure. Where did you get that anyway?"
+	durability = 25
+	bioadap = TRUE
+
 ////////////////////////////////
 // Special Promethean """surgery"""
 /obj/item/device/nif/attack(mob/living/M, mob/living/user, var/target_zone)


### PR DESCRIPTION
Fixes #11668 by making proteans spawn with special NIF that has max 25 durability to start with.

Also removes RNG aspect in proteans' starting NIF durability, now always 25 (up from 21-25)