### PR TITLE
Adds facility_type map var for the announcement messages

### DIFF
--- a/code/modules/events/aurora_caelus.dm
+++ b/code/modules/events/aurora_caelus.dm
@@ -5,13 +5,13 @@
 	endWhen = 126
 
 /datum/event/aurora_caelus/announce()
-	command_announcement.Announce("[station_name()]: A harmless cloud of ions is approaching your station, and will exhaust their energy battering the hull. \
+	command_announcement.Announce("[station_name()]: A harmless cloud of ions is approaching your [using_map.facility_type], and will exhaust their energy battering the hull. \
 	Nanotrasen has approved a short break for all employees to relax and observe this very rare event. \
 	During this time, starlight will be bright but gentle, shifting between quiet green and blue colors. \
 	Any staff who would like to view these lights for themselves may proceed to the area nearest to them with viewing ports to open space. \
 	You will have approximately two minutes before the ions begin to reach the hull. \
 	We hope you enjoy the lights.", "Nanotrasen Meteorology Division", new_sound = 'sound/AI/aurora.ogg') //VOREStation Edit
-	
+
 /datum/event/aurora_caelus/start()
 	affecting_z -= global.using_map.sealed_levels // Space levels only please!
 	for(var/mob/M in player_list)
@@ -31,6 +31,6 @@ Please return to your workplace and continue work as normal. \
 Have a pleasant shift, [station_name()], and thank you for watching with us.",
 "Nanotrasen Meteorology Division", new_sound = 'sound/AI/aurora_end.ogg') //VOREStation Edit
 	..()
-	
+
 /datum/event/aurora_caelus/overmap/announce()
 	return

--- a/code/modules/events/ian_storm_vr.dm
+++ b/code/modules/events/ian_storm_vr.dm
@@ -4,7 +4,7 @@
 	endWhen = 3
 
 /datum/event/ianstorm/announce()
-	command_announcement.Announce("It has come to our attention that the station passed through an ion storm.  Please monitor all electronic equipment for malfunctions.", "Anomaly Alert", 'sound/AI/ian_storm.ogg')
+	command_announcement.Announce("It has come to our attention that the [using_map.facility_type] passed through an ion storm.  Please monitor all electronic equipment for malfunctions.", "Anomaly Alert", 'sound/AI/ian_storm.ogg')
 	spawn(7 SECONDS)
 		command_announcement.Announce("Wait. No, thats wrong.  The station passed through an IAN storm!.", "Ian Alert")
 

--- a/code/modules/events/prison_break.dm
+++ b/code/modules/events/prison_break.dm
@@ -37,7 +37,7 @@
 
 /datum/event/prison_break/announce()
 	if(areas && areas.len > 0)
-		command_announcement.Announce("[pick("Gr3y.T1d3 virus","Malignant trojan")] detected in [station_name()] [(eventDept == "Security")? "imprisonment":"containment"] subroutines. Secure any compromised areas immediately. Station AI involvement is recommended.", "[eventDept] Alert")
+		command_announcement.Announce("[pick("Gr3y.T1d3 virus","Malignant trojan")] detected in [station_name()] [(eventDept == "Security")? "imprisonment":"containment"] subroutines. Secure any compromised areas immediately. Involvement of [using_map.facility_type] AI is recommended.", "[eventDept] Alert")
 
 
 /datum/event/prison_break/start()

--- a/code/modules/events/radiation_storm.dm
+++ b/code/modules/events/radiation_storm.dm
@@ -16,7 +16,7 @@
 
 /datum/event/radiation_storm/tick()
 	if(activeFor == enterBelt)
-		command_announcement.Announce("The station has entered the radiation belt. Please remain in a sheltered area until we have passed the radiation belt.", "Anomaly Alert")
+		command_announcement.Announce("The [using_map.facility_type] has entered the radiation belt. Please remain in a sheltered area until we have passed the radiation belt.", "Anomaly Alert")
 		radiate()
 
 	if(activeFor >= enterBelt && activeFor <= leaveBelt)
@@ -27,7 +27,7 @@
 		radiate()
 
 	else if(activeFor == leaveBelt)
-		command_announcement.Announce("The station has passed the radiation belt. Please allow for up to one minute while radiation levels dissipate, and report to medbay if you experience any unusual symptoms. Maintenance will lose all access again shortly.", "Anomaly Alert")
+		command_announcement.Announce("The [using_map.facility_type] has passed the radiation belt. Please allow for up to one minute while radiation levels dissipate, and report to medbay if you experience any unusual symptoms. Maintenance will lose all access again shortly.", "Anomaly Alert")
 /datum/event/radiation_storm/proc/radiate()
 	var/radiation_level = rand(15, 35)
 	for(var/z in using_map.station_levels)

--- a/code/modules/events/rogue_drones.dm
+++ b/code/modules/events/rogue_drones.dm
@@ -35,7 +35,7 @@
 		if(4)
 			msg = "A passing derelict ship's drone defense systems have just activated. If any are sighted in the area, use caution."
 		if(5)
-			msg = "We're detecting a swarm of small objects approaching your station.  Most likely a bunch of drones.  Please exercise caution if you see any."
+			msg = "We're detecting a swarm of small objects approaching your [using_map.facility_type].  Most likely a bunch of drones.  Please exercise caution if you see any."
 	//VOREStation Edit End
 	command_announcement.Announce(msg, "Rogue drone alert")
 

--- a/code/modules/events/solar_storm.dm
+++ b/code/modules/events/solar_storm.dm
@@ -9,7 +9,7 @@
 	endWhen = startWhen + rand(30,90) + rand(30,90) //2-6 minute duration
 
 /datum/event/solar_storm/announce()
-	command_announcement.Announce("A solar storm has been detected approaching \the [station_name()]. Please halt all EVA activites immediately and return to the interior of the station.", "Anomaly Alert", new_sound = 'sound/AI/radiation.ogg')
+	command_announcement.Announce("A solar storm has been detected approaching \the [station_name()]. Please halt all EVA activites immediately and return to the interior of the [using_map.facility_type].", "Anomaly Alert", new_sound = 'sound/AI/radiation.ogg')
 	adjust_solar_output(1.5)
 
 /datum/event/solar_storm/proc/adjust_solar_output(var/mult = 1)
@@ -18,7 +18,7 @@
 
 
 /datum/event/solar_storm/start()
-	command_announcement.Announce("The solar storm has reached the station. Please refrain from EVA and remain inside the station until it has passed.", "Anomaly Alert")
+	command_announcement.Announce("The solar storm has reached the [using_map.facility_type]. Please refrain from EVA and remain inside the station until it has passed.", "Anomaly Alert")
 	adjust_solar_output(5)
 
 
@@ -40,7 +40,7 @@
 		L.rad_act(rand(15, 30))
 
 /datum/event/solar_storm/end()
-	command_announcement.Announce("The solar storm has passed the station. It is now safe to resume EVA activities. Please report to medbay if you experience any unusual symptoms. ", "Anomaly Alert")
+	command_announcement.Announce("The solar storm has passed the [using_map.facility_type]. It is now safe to resume EVA activities. Please report to medbay if you experience any unusual symptoms. ", "Anomaly Alert")
 	adjust_solar_output()
 
 

--- a/code/modules/events/supply_demand_vr.dm
+++ b/code/modules/events/supply_demand_vr.dm
@@ -63,7 +63,7 @@
 		send_console_message(message, dpt);
 
 	// Also announce over main comms so people know to look
-	command_announcement.Announce("An order for the station to deliver supplies to [command_name()] has been delivered to all supply Request Consoles", my_department)
+	command_announcement.Announce("An order for the [using_map.facility_type] to deliver supplies to [command_name()] has been delivered to all supply Request Consoles", my_department)
 
 /datum/event/supply_demand/tick()
 	if(required_items.len == 0)

--- a/code/modules/events/wallrot.dm
+++ b/code/modules/events/wallrot.dm
@@ -15,7 +15,7 @@
 
 /datum/event/wallrot/announce()
 	if(center)
-		command_announcement.Announce("Harmful fungi detected on \the [station_name()] nearby [center.loc.name]. Station structures may be contaminated.", "Biohazard Alert")
+		command_announcement.Announce("Harmful fungi detected on \the [station_name()] and [using_map.facility_type] structures nearby [center.loc.name] may be contaminated.", "Biohazard Alert")
 
 /datum/event/wallrot/start()
 	spawn()

--- a/code/modules/events/wormholes.dm
+++ b/code/modules/events/wormholes.dm
@@ -6,4 +6,4 @@
 	wormhole_event()
 
 /datum/event/wormholes/end()
-	command_announcement.Announce("There are no more space-time anomalies detected on the station.", "Anomaly Alert")
+	command_announcement.Announce("There are no more space-time anomalies detected on the [using_map.facility_type].", "Anomaly Alert")

--- a/maps/stellardelight/stellar_delight_defines.dm
+++ b/maps/stellardelight/stellar_delight_defines.dm
@@ -54,6 +54,7 @@
 */
 	station_name  = "NRV Stellar Delight"
 	station_short = "Stellar Delight"
+	facility_type = "ship"
 	dock_name     = "Virgo-3B Colony"
 	dock_type     = "surface"
 	boss_name     = "Central Command"

--- a/maps/tether/tether_defines.dm
+++ b/maps/tether/tether_defines.dm
@@ -68,6 +68,7 @@
 
 	station_name  = "NSB Adephagia"
 	station_short = "Tether"
+	facility_type = "station"
 	dock_name     = "Virgo-3B Colony"
 	dock_type     = "surface"
 	boss_name     = "Central Command"

--- a/maps/~map_system/maps.dm
+++ b/maps/~map_system/maps.dm
@@ -81,6 +81,7 @@ var/list/all_maps = list()
 
 	var/station_name  = "BAD Station"
 	var/station_short = "Baddy"
+	var/facility_type = "facility"
 	var/dock_name     = "THE PirateBay"
 	var/dock_type     = "station"	//VOREStation Edit - for a list of valid types see the switch block in air_traffic.dm at line 148
 	var/boss_name     = "Captain Roger"


### PR DESCRIPTION
Fixes #11750, although potentially only partially. if there are cases elsewheer in code though, those can be reported separately.

Adds a variable to map system that determines what type of 'facility' map is and uses that var for event announcement. Tether is 'station', while Stellar Delight is 'ship'.