### PR TITLE
Fixes bugs related to weaversilk structures

### DIFF
--- a/code/modules/ai/ai_holder_combat.dm
+++ b/code/modules/ai/ai_holder_combat.dm
@@ -310,15 +310,20 @@
 
 		// Kill common obstacle in the way like tables.
 		var/obj/structure/obstacle = locate(/obj/structure, problem_turf)
-		if(istype(obstacle, /obj/structure/window) || istype(obstacle, /obj/structure/closet) || istype(obstacle, /obj/structure/table) || istype(obstacle, /obj/structure/grille) || istype(obstacle, /obj/effect/weaversilk/wall))	//VOREStation Edit: spdr
+		if(istype(obstacle, /obj/structure/window) || istype(obstacle, /obj/structure/closet) || istype(obstacle, /obj/structure/table) || istype(obstacle, /obj/structure/grille))
 			ai_log("destroy_surroundings() : Attacking generic structure.", AI_LOG_INFO)
 			return melee_attack(obstacle)
+
+		var/obj/effect/weaversilk/web = locate(/obj/effect/weaversilk, problem_turf)
+		if(istype(web, /obj/effect/weaversilk/wall))	//VOREStation Edit: spdr
+			ai_log("destroy_surroundings() : Attacking weaversilk effect.", AI_LOG_INFO)
+			return melee_attack(web)
 
 		for(var/obj/machinery/door/D in problem_turf) // Required since firelocks take up the same turf.
 			if(D.density)
 				ai_log("destroy_surroundings() : Attacking closed door.", AI_LOG_INFO)
 				return melee_attack(D)
-		
+
 		// Should always be last thing attempted
 		if(!problem_turf.opacity)
 			ai_log("destroy_surroundings() : Attacking a transparent (window?) turf.", AI_LOG_INFO)

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/weaver_objs.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/weaver_objs.dm
@@ -89,6 +89,7 @@
 	desc = "A silky, yet firm trap. Be careful not to step into it! Or don't..."
 	icon_state = "trap"
 	var/trap_active = TRUE
+	can_buckle = TRUE
 
 /obj/effect/weaversilk/trap/Crossed(atom/movable/AM as mob|obj)
 	if(AM.is_incorporeal())
@@ -106,16 +107,17 @@
 				"<b>You hear a squishy noise!</b>"
 				)
 			set_dir(L.dir)
-			can_buckle = TRUE
 			buckle_mob(L)
 			L.Stun(1)
 			to_chat(L, "<span class='danger'>The sticky fibers of \the [src] ensnare, trapping you in place!</span>")
 			trap_active = FALSE
-			can_buckle = initial(can_buckle)
 			desc += " Actually, it looks like it's been all spent."
 	..()
 
 
+
+/obj/effect/weaversilk/trap/MouseDrop_T(atom/movable/AM,mob/user)
+	return
 
 // Items
 


### PR DESCRIPTION
Fixes it being impossible to unbuckle from weaversilk trap by normal means 

Fixes mobs being unable to violently breakthrough through weaversilk walls

That second one was abused by explorer to cheese mobs instead of reporting it and very intentionally;  and I stg I added this trait and I will PR its removal if people try abusing it for gamey shit again.