### PR TITLE
Blast doors now properly resist fire

### DIFF
--- a/code/game/machinery/doors/door_vr.dm
+++ b/code/game/machinery/doors/door_vr.dm
@@ -101,7 +101,19 @@
 /obj/machinery/door/blast/regular/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
 	return // blast doors are immune to fire completely.
 
-/obj/machinery/door/blast/regular/
+/obj/machinery/door/blast/regular
+	heat_proof = 1 //just so repairing them doesn't try to fireproof something that never takes fire damage
+
+/obj/machinery/door/blast/angled/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
+	return // blast doors are immune to fire completely.
+
+/obj/machinery/door/blast/angled
+	heat_proof = 1 //just so repairing them doesn't try to fireproof something that never takes fire damage
+
+/obj/machinery/door/blast/puzzle/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
+	return // blast doors are immune to fire completely.
+
+/obj/machinery/door/blast/puzzle
 	heat_proof = 1 //just so repairing them doesn't try to fireproof something that never takes fire damage
 
 /obj/machinery/door/proc/toggle()


### PR DESCRIPTION
Angled doors are different subtype from regular instead of just being subtype OF regular with different sprites for some reason.

Also gives puzzle doors heat resistance too while at it.