### PR TITLE
EVENTS AND LANDMARKS - OH BOY MORE COMEDY

### DIFF
--- a/code/game/objects/effects/landmarks.dm
+++ b/code/game/objects/effects/landmarks.dm
@@ -61,10 +61,6 @@
 			prisonsecuritywarp += loc
 			delete_me = 1
 			return
-		if("blobstart")
-			blobstart += loc
-			delete_me = 1
-			return
 		if("xeno_spawn")
 			xeno_spawn += loc
 			delete_me = 1

--- a/code/game/objects/effects/landmarks.dm
+++ b/code/game/objects/effects/landmarks.dm
@@ -61,6 +61,10 @@
 			prisonsecuritywarp += loc
 			delete_me = 1
 			return
+		if("blobstart")
+			blobstart += loc
+			delete_me = 1
+			return
 		if("xeno_spawn")
 			xeno_spawn += loc
 			delete_me = 1

--- a/code/game/objects/effects/landmarks_vr.dm
+++ b/code/game/objects/effects/landmarks_vr.dm
@@ -1,6 +1,12 @@
 /obj/effect/landmark
 	var/abductor = 0
 
+/obj/effect/landmark/vines
+	name = "vinestart"
+
+/obj/effect/landmark/vermin
+	name = "verminstart"
+
 /obj/effect/landmark/late_antag
 	name = "Antag Latespawn"
 	var/antag_id

--- a/code/global_vr.dm
+++ b/code/global_vr.dm
@@ -1,4 +1,5 @@
 var/list/vinestart			= list()
+var/list/verminstart		= list()
 
 var/list/awayabductors = list() // List of scatter landmarks for Abductors in Gateways
 var/list/eventdestinations = list() // List of scatter landmarks for VOREStation event portals

--- a/code/modules/events/carp_migration.dm
+++ b/code/modules/events/carp_migration.dm
@@ -26,7 +26,7 @@
 	if(activeFor % 5 != 0)
 		return // Only process every 10 seconds.
 	if(count_spawned_carps() < carp_cap)
-		spawn_fish(rand(1, severity * 2) - 1, severity, severity * 2)
+		spawn_fish(rand(3, 3 + severity * 2) - 1, 1, severity + 2)
 
 /datum/event/carp_migration/proc/spawn_fish(var/num_groups, var/group_size_min, var/group_size_max, var/dir)
 	if(isnull(dir))

--- a/code/modules/events/drone_pod_vr.dm
+++ b/code/modules/events/drone_pod_vr.dm
@@ -22,7 +22,7 @@
 		qdel(target_spot)
 
 /datum/event/drone_pod_drop/announce()
-	command_announcement.Announce("An unidentified drone pod has been detected landing near the surface facilty. Open and examine at your own risk.", "NanoTrasen Orbital Monitoring")
+	command_announcement.Announce("An unidentified drone pod has been detected on a collision course towards the [location_name()]. Open and examine at your own risk.", "[location_name()] Sensor Network")
 
 /datum/event/drone_pod_drop/start()
 	if(!land_target)

--- a/code/modules/events/event_container_vr.dm
+++ b/code/modules/events/event_container_vr.dm
@@ -84,7 +84,8 @@
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Grub Infestation",			/datum/event/grub_infestation,			0,		list(ASSIGNMENT_SECURITY = 10, ASSIGNMENT_ENGINEER = 30), 1),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Drone Pod Drop",			/datum/event/drone_pod_drop,			10,		list(ASSIGNMENT_SCIENTIST = 40), 1),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Morph Spawn",				/datum/event/morph_spawn,				75,		list(ASSIGNMENT_SECURITY = 30, ASSIGNMENT_SCIENTIST = 10), 1),
-		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Maintenance Predator",		/datum/event/maintenance_predator,		75,		list(ASSIGNMENT_SECURITY = 40), 0)
+		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Maintenance Predator",		/datum/event/maintenance_predator,		75,		list(ASSIGNMENT_SECURITY = 40), 0),
+		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Jellyfish School",			/datum/event/jellyfish_migration,		5,		list(ASSIGNMENT_ANY = 1, ASSIGNMENT_SECURITY = 5, ASSIGNMENT_MEDICAL = 3), 1),
 	)
 	add_disabled_events(list(
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Appendicitis", 			/datum/event/spontaneous_appendicitis, 	0,		list(ASSIGNMENT_MEDICAL = 30), 1),
@@ -97,17 +98,18 @@
 
 /datum/event_container/major/New()
 	available_events = list(
-		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Nothing",				/datum/event/nothing,			3600),
-		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Atmos Leak",			/datum/event/atmos_leak, 		30,		list(ASSIGNMENT_ENGINEER = 25), 1),
-		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Meteor Strike",		/datum/event/meteor_strike,		10,		list(ASSIGNMENT_ENGINEER = 15), 1),
-		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Space Vines",			/datum/event/spacevine, 		20,		list(ASSIGNMENT_ENGINEER = 7), 1),
-		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Carp Migration",		/datum/event/carp_migration,	10,		list(ASSIGNMENT_SECURITY = 5), 1),
-		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Containment Breach",	/datum/event/prison_break/station,0,	list(ASSIGNMENT_ANY = 5), 1),
+		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Nothing",				/datum/event/nothing,				3600),
+		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Atmos Leak",			/datum/event/atmos_leak, 			30,		list(ASSIGNMENT_ENGINEER = 25), 1),
+		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Space Vines",			/datum/event/spacevine, 			20,		list(ASSIGNMENT_ENGINEER = 7), 1),
+		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Carp Migration",		/datum/event/carp_migration,		10,		list(ASSIGNMENT_SECURITY = 5), 1),
+		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Containment Breach",	/datum/event/prison_break/station,	0,	list(ASSIGNMENT_ANY = 5), 1),
+		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Jellyfish Migration",	/datum/event/jellyfish_migration,	5,	list(ASSIGNMENT_ANY = 1, ASSIGNMENT_SECURITY = 5, ASSIGNMENT_MEDICAL = 3), 1),
 	)
 	add_disabled_events(list(
-		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Blob",				/datum/event/blob, 				10,	list(ASSIGNMENT_ENGINEER = 60), 1),
-		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Meteor Wave",			/datum/event/meteor_wave,		30,		list(ASSIGNMENT_ENGINEER = 15),	1),
-		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Supply Demand",		/datum/event/supply_demand,		0,		list(ASSIGNMENT_ANY = 5, ASSIGNMENT_SCIENCE = 15, ASSIGNMENT_GARDENER = 10, ASSIGNMENT_ENGINEER = 10, ASSIGNMENT_MEDICAL = 15), 1),
+		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Meteor Strike",		/datum/event/meteor_strike,			10,		list(ASSIGNMENT_ENGINEER = 15), 1),
+		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Blob",				/datum/event/blob, 					10,	list(ASSIGNMENT_ENGINEER = 60), 1),
+		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Meteor Wave",			/datum/event/meteor_wave,			30,		list(ASSIGNMENT_ENGINEER = 15),	1),
+		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Supply Demand",		/datum/event/supply_demand,			0,		list(ASSIGNMENT_ANY = 5, ASSIGNMENT_SCIENCE = 15, ASSIGNMENT_GARDENER = 10, ASSIGNMENT_ENGINEER = 10, ASSIGNMENT_MEDICAL = 15), 1),
 	))
 
 #undef ASSIGNMENT_ANY

--- a/code/modules/events/infestation.dm
+++ b/code/modules/events/infestation.dm
@@ -1,120 +1,78 @@
-#define LOC_KITCHEN 0
-#define LOC_ATMOS 1
-#define LOC_CHAPEL 2
-#define LOC_LIBRARY 3
-#define LOC_HYDRO 4
-#define LOC_CONSTR 5
-#define LOC_TECH 6
-#define LOC_GARDEN 7
-#define LOC_STEMNGR 8
-#define LOC_RESEARCH 9
-
 #define VERM_MICE 0
 #define VERM_LIZARDS 1
-#define VERM_SPIDERS 2
 
 /datum/event/infestation
 	announceWhen = 10
 	endWhen = 11
-	var/location
 	var/locstring
 	var/vermin
 	var/vermstring
+	var/list/spawned_vermin = list()
+	var/spawn_types
+	var/num_groups
+	var/prep_size_min
+	var/prep_size_max
+	var/vermin_cap = 40
+	var/list/spawn_locations = list()
 
 /datum/event/infestation/start()
-
-	location = rand(0,9)
-	var/list/turf/simulated/floor/turfs = list()
-	var/spawn_area_type
-	switch(location)
-		if(LOC_KITCHEN)
-			spawn_area_type = /area/crew_quarters/kitchen
-			locstring = "the kitchen"
-		if(LOC_ATMOS)
-			spawn_area_type = /area/engineering/atmos
-			locstring = "atmospherics"
-		if(LOC_CHAPEL)
-			spawn_area_type = /area/chapel/main
-			locstring = "the chapel"
-		if(LOC_LIBRARY)
-			spawn_area_type = /area/library
-			locstring = "the library"
-		if(LOC_HYDRO)
-			spawn_area_type = /area/hydroponics
-			locstring = "hydroponics"
-		if(LOC_CONSTR)
-			spawn_area_type = /area/construction
-			locstring = "the construction area"
-		if(LOC_TECH)
-			spawn_area_type = /area/storage/tech
-			locstring = "technical storage"
-		if(LOC_GARDEN)
-			spawn_area_type = /area/hydroponics/garden
-			locstring = "the public garden"
-		if(LOC_STEMNGR)
-			spawn_area_type = /area/crew_quarters/captain
-			locstring = "the site manager's office"
-		if(LOC_RESEARCH)
-			spawn_area_type = /area/rnd/research
-			locstring = "the research division"
-
-	for(var/areapath in typesof(spawn_area_type))
-		var/area/A = locate(areapath)
-		for(var/turf/simulated/floor/F in A.contents)
-			//VOREStation Edit - Fixes event
-			var/blocked = FALSE
-			for(var/atom/movable/AM in F)
-				if(AM.density)
-					blocked = TRUE
-			if(!blocked)
-				turfs += F
-			//VOREStation Edit - Fixes event
-
-	var/list/spawn_types = list()
-	var/max_number
-	vermin = rand(0,2)
+	vermin = rand(0,1)
 	switch(vermin)
 		if(VERM_MICE)
-			spawn_types = list(/mob/living/simple_mob/animal/passive/mouse/gray, /mob/living/simple_mob/animal/passive/mouse/brown, /mob/living/simple_mob/animal/passive/mouse/white)
-			max_number = 12
+			spawn_types = /mob/living/simple_mob/animal/passive/mouse/gray
+			prep_size_min = 1
+			prep_size_max = 4
 			vermstring = "mice"
 		if(VERM_LIZARDS)
-			spawn_types = list(/mob/living/simple_mob/animal/passive/lizard)
-			max_number = 6
+			spawn_types = /mob/living/simple_mob/animal/passive/lizard
+			prep_size_min = 1
+			prep_size_max = 3
 			vermstring = "lizards"
-		if(VERM_SPIDERS)
-			spawn_types = list(/obj/effect/spider/spiderling)
-			max_number = 3
-			vermstring = "spiders"
+	// Check if any landmarks exist!
+	for(var/obj/effect/landmark/C in landmarks_list)
+		if(C.name == "verminstart")
+			spawn_locations.Add(C.loc)
 
-	spawn(0)
-		var/num = rand(2,max_number)
-		while(turfs.len > 0 && num > 0)
-			var/turf/simulated/floor/T = pick(turfs)
-			turfs.Remove(T)
-			num--
 
-			if(vermin == VERM_SPIDERS)
-				var/obj/effect/spider/spiderling/S = new(T)
-				S.amount_grown = -1
-			else
-				var/spawn_type = pick(spawn_types)
-				new spawn_type(T)
+/datum/event/infestation/tick()
+	if(activeFor % 5 != 0)
+		return // Only process every 10 seconds.
+	if(count_spawned_vermin() < vermin_cap)
+		spawn_vermin(rand(4,10), prep_size_min, prep_size_max)
+
+/datum/event/infestation/proc/spawn_vermin(var/num_groups, var/group_size_min, var/group_size_max)
+	if(spawn_locations.len) // Okay we've got landmarks, lets use those!
+		shuffle_inplace(spawn_locations)
+		num_groups = min(num_groups, spawn_locations.len)
+		for (var/i = 1, i <= num_groups, i++)
+			var/group_size = rand(group_size_min, group_size_max)
+			for (var/j = 0, j < group_size, j++)
+				spawn_one_vermin(spawn_locations[i])
+		return
+
+// Spawn a single vermin at given location.
+/datum/event/infestation/proc/spawn_one_vermin(var/loc)
+	var/mob/living/simple_mob/animal/M = new spawn_types(loc)
+	GLOB.destroyed_event.register(M, src, .proc/on_vermin_destruction)
+	spawned_vermin.Add(M)
+	return M
+
+// Counts living vermin spawned by this event.
+/datum/event/infestation/proc/count_spawned_vermin()
+	. = 0
+	for(var/mob/living/simple_mob/animal/M as anything in spawned_vermin)
+		if(!QDELETED(M) && M.stat != DEAD)
+			. += 1
+
+// If vermin is kill, remove it from the list.
+/datum/event/infestation/proc/on_vermin_destruction(var/mob/M)
+	spawned_vermin -= M
+	GLOB.destroyed_event.unregister(M, src, .proc/on_vermin_destruction)
+
 
 
 /datum/event/infestation/announce()
-	command_announcement.Announce("Bioscans indicate that [vermstring] have been breeding in [locstring]. Clear them out, before this starts to affect productivity.", "Vermin infestation")
-
-#undef LOC_KITCHEN
-#undef LOC_ATMOS
-#undef LOC_CHAPEL
-#undef LOC_LIBRARY
-#undef LOC_HYDRO
-#undef LOC_TECH
-#undef LOC_GARDEN
-#undef LOC_STEMNGR
-#undef LOC_RESEARCH
+	command_announcement.Announce("Bioscans indicate that [vermstring] have been breeding all over the facility. Clear them out, before this starts to affect productivity.", "Vermin infestation")
 
 #undef VERM_MICE
 #undef VERM_LIZARDS
-#undef VERM_SPIDERS

--- a/code/modules/events/jellyfish_migration.dm
+++ b/code/modules/events/jellyfish_migration.dm
@@ -1,0 +1,102 @@
+/datum/event/jellyfish_migration
+	startWhen		= 0		// Start immediately
+	announceWhen	= 45	// Adjusted by setup
+	endWhen			= 75	// Adjusted by setup
+	var/jellyfish_cap	= 20
+	var/list/spawned_jellyfish = list()
+
+/datum/event/jellyfish_migration/setup()
+	announceWhen = rand(30, 60) // 1 to 2 minutes
+	endWhen += severity * 25
+	jellyfish_cap = 2 + 3 ** severity // No more than this many at once regardless of waves. (5, 11, 29)
+
+/datum/event/jellyfish_migration/start()
+	affecting_z -= global.using_map.sealed_levels // Space levels only please!
+	..()
+
+/datum/event/jellyfish_migration/announce()
+	var/announcement = ""
+	if(severity == EVENT_LEVEL_MAJOR)
+		announcement = "Massive migration of unknown biological entities has been detected near [location_name()], please stand-by."
+	else
+		announcement = "Unknown biological [spawned_jellyfish.len == 1 ? "entity has" : "entities have"] been detected near [location_name()], please stand-by."
+	command_announcement.Announce(announcement, "Lifesign Alert")
+
+/datum/event/jellyfish_migration/tick()
+	if(activeFor % 5 != 0)
+		return // Only process every 10 seconds.
+	if(count_spawned_jellyfish() < jellyfish_cap)
+		spawn_fish(rand(3, 3 + severity * 2) - 1, 1, severity + 2)
+
+/datum/event/jellyfish_migration/proc/spawn_fish(var/num_groups, var/group_size_min, var/group_size_max, var/dir)
+	if(isnull(dir))
+		dir = (victim && prob(80)) ? victim.fore_dir : pick(GLOB.cardinal)
+
+	// Check if any landmarks exist! These will use the carp spawn since they already would spawn in these similar spots.
+	var/list/spawn_locations = list()
+	for(var/obj/effect/landmark/C in landmarks_list)
+		if(C.name == "carpspawn" && (C.z in affecting_z))
+			spawn_locations.Add(C.loc)
+	if(spawn_locations.len) // Okay we've got landmarks, lets use those!
+		shuffle_inplace(spawn_locations)
+		num_groups = min(num_groups, spawn_locations.len)
+		for (var/i = 1, i <= num_groups, i++)
+			var/group_size = rand(group_size_min, group_size_max)
+			for (var/j = 0, j < group_size, j++)
+				spawn_one_jellyfish(spawn_locations[i])
+		return
+
+	// Okay we did *not* have any landmarks, so lets do our best!
+	var/i = 1
+	while (i <= num_groups)
+		var/Z = pick(affecting_z)
+		var/group_size = rand(group_size_min, group_size_max)
+		var/turf/map_center = locate(round(world.maxx/2), round(world.maxy/2), Z)
+		var/turf/group_center = pick_random_edge_turf(dir, Z, TRANSITIONEDGE + 2)
+		var/list/turfs = getcircle(group_center, 2)
+		for (var/j = 0, j < group_size, j++)
+			var/mob/living/simple_mob/animal/M = spawn_one_jellyfish(turfs[(i % turfs.len) + 1])
+			// Ray trace towards middle of the map to find where they can stop just outside of structure/ship.
+			var/turf/target
+			for(var/turf/T in getline(get_turf(M), map_center))
+				if(!T.is_space())
+					break;
+				target = T
+			if(target)
+				M.ai_holder?.give_destination(target) // Ask jellyfish to swim towards the middle of the map
+		i++
+
+// Spawn a single jellyfish at given location.
+/datum/event/jellyfish_migration/proc/spawn_one_jellyfish(var/loc)
+	var/mob/living/simple_mob/animal/M = new /mob/living/simple_mob/vore/alienanimals/space_jellyfish(loc)
+	GLOB.destroyed_event.register(M, src, .proc/on_jellyfish_destruction)
+	spawned_jellyfish.Add(M)
+	return M
+
+// Counts living jellyfish spawned by this event.
+/datum/event/jellyfish_migration/proc/count_spawned_jellyfish()
+	. = 0
+	for(var/mob/living/simple_mob/animal/M as anything in spawned_jellyfish)
+		if(!QDELETED(M) && M.stat != DEAD)
+			. += 1
+
+// If jellyfish is bomphed, remove it from the list.
+/datum/event/jellyfish_migration/proc/on_jellyfish_destruction(var/mob/M)
+	spawned_jellyfish -= M
+	GLOB.destroyed_event.unregister(M, src, .proc/on_jellyfish_destruction)
+
+/datum/event/jellyfish_migration/end()
+	. = ..()
+	// Clean up jellyfish that died in space for some reason.
+	spawn(0)
+		for(var/mob/living/simple_mob/SM in spawned_jellyfish)
+			if(SM.stat == DEAD)
+				var/turf/T = get_turf(SM)
+				if(istype(T, /turf/space))
+					if(prob(75))
+						qdel(SM)
+			CHECK_TICK
+
+// Overmap version
+/datum/event/jellyfish_migration/overmap/announce()
+	return

--- a/maps/stellardelight/stellar_delight1.dmm
+++ b/maps/stellardelight/stellar_delight1.dmm
@@ -655,9 +655,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/catwalk_plated/dark,
-/obj/effect/landmark{
-	name = "vinestart"
-	},
+/obj/effect/landmark/vines,
 /turf/simulated/floor,
 /area/stellardelight/deck1/port)
 "bx" = (
@@ -1308,9 +1306,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
-/obj/effect/landmark{
-	name = "vinestart"
-	},
+/obj/effect/landmark/vines,
 /turf/simulated/floor/tiled/techmaint,
 /area/stellardelight/deck1/starboard)
 "cV" = (
@@ -2045,6 +2041,12 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/stellardelight/deck1/researchserver)
+"et" = (
+/obj/effect/landmark{
+	name = "droppod_landing"
+	},
+/turf/space,
+/area/space)
 "eu" = (
 /obj/structure/cable/green{
 	color = "#42038a";
@@ -4723,9 +4725,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
-/obj/effect/landmark{
-	name = "vinestart"
-	},
+/obj/effect/landmark/vines,
 /turf/simulated/floor/tiled/techmaint,
 /area/stellardelight/deck1/aft)
 "jV" = (
@@ -6906,6 +6906,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
+/obj/effect/landmark/vermin,
 /turf/simulated/floor/tiled/dark,
 /area/security/security_cell_hallway)
 "oC" = (
@@ -7162,9 +7163,7 @@
 	dir = 8
 	},
 /obj/effect/catwalk_plated/dark,
-/obj/effect/landmark{
-	name = "vinestart"
-	},
+/obj/effect/landmark/vines,
 /turf/simulated/floor,
 /area/stellardelight/deck1/starboard)
 "ph" = (
@@ -8810,6 +8809,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
+/obj/effect/landmark/vermin,
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
 "sC" = (
@@ -10476,6 +10476,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
+/obj/effect/landmark/vermin,
 /turf/simulated/floor/carpet/bcarpet,
 /area/stellardelight/deck1/starboard)
 "wo" = (
@@ -10796,9 +10797,7 @@
 /obj/effect/floor_decal/milspec/color/red/half{
 	dir = 1
 	},
-/obj/effect/landmark{
-	name = "vinestart"
-	},
+/obj/effect/landmark/vines,
 /turf/simulated/floor/tiled/techmaint,
 /area/stellardelight/deck1/fore)
 "xa" = (
@@ -11889,6 +11888,7 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/milspec/color/black,
+/obj/effect/landmark/vermin,
 /turf/simulated/floor/tiled/dark,
 /area/security/armoury)
 "zq" = (
@@ -12944,6 +12944,7 @@
 /obj/effect/floor_decal/milspec/color/red/half{
 	dir = 1
 	},
+/obj/effect/landmark/vermin,
 /turf/simulated/floor/tiled/techmaint,
 /area/stellardelight/deck1/fore)
 "BB" = (
@@ -13043,6 +13044,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
+/obj/effect/landmark/vermin,
 /turf/simulated/floor/tiled/milspec,
 /area/stellardelight/deck1/exploration)
 "BI" = (
@@ -14181,9 +14183,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/obj/effect/landmark{
-	name = "vinestart"
-	},
+/obj/effect/landmark/vines,
 /turf/simulated/floor/tiled/techmaint,
 /area/stellardelight/deck1/port)
 "Eq" = (
@@ -16456,6 +16456,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
+/obj/effect/landmark/vermin,
 /turf/simulated/floor/tiled/steel_grid,
 /area/rnd/research)
 "Jd" = (
@@ -19899,6 +19900,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/machinery/alarm/angled,
 /obj/effect/floor_decal/milspec/color/black,
+/obj/effect/landmark/vermin,
 /turf/simulated/floor/tiled/dark,
 /area/security/armoury)
 "QQ" = (
@@ -21222,9 +21224,7 @@
 /obj/structure/closet/crate/bin{
 	anchored = 1
 	},
-/obj/effect/landmark{
-	name = "vinestart"
-	},
+/obj/effect/landmark/vines,
 /turf/simulated/floor/tiled/milspec,
 /area/stellardelight/deck1/exploration)
 "TB" = (
@@ -21830,6 +21830,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
+/obj/effect/landmark/vermin,
 /turf/simulated/floor/reinforced,
 /area/stellardelight/deck1/shuttlebay)
 "UK" = (
@@ -22185,6 +22186,7 @@
 /obj/item/weapon/book/manual/supermatter_engine,
 /obj/item/weapon/book/manual/tesla_engine,
 /obj/item/weapon/book/manual/virology,
+/obj/effect/landmark/vermin,
 /turf/simulated/floor/wood,
 /area/library)
 "Vq" = (
@@ -22942,6 +22944,7 @@
 /obj/item/weapon/tank/jetpack/carbondioxide,
 /obj/item/weapon/tank/jetpack/carbondioxide,
 /obj/item/weapon/tank/jetpack/carbondioxide,
+/obj/effect/landmark/vermin,
 /turf/simulated/floor/tiled/eris/white/gray_platform,
 /area/gateway)
 "WU" = (
@@ -24044,6 +24047,12 @@
 /obj/machinery/recharge_station,
 /turf/simulated/floor/bluegrid,
 /area/assembly/robotics)
+"Zd" = (
+/obj/effect/landmark{
+	name = "carpspawn"
+	},
+/turf/space,
+/area/space)
 "Ze" = (
 /obj/machinery/door/firedoor/glass,
 /obj/structure/window/bay/reinforced,
@@ -27549,7 +27558,7 @@ uq
 uq
 uq
 uq
-uq
+Zd
 uq
 uq
 uq
@@ -28089,7 +28098,7 @@ uq
 uq
 uq
 uq
-uq
+Zd
 uq
 uq
 uq
@@ -28271,7 +28280,7 @@ uq
 uq
 uq
 uq
-uq
+Zd
 uq
 uq
 uq
@@ -28336,7 +28345,7 @@ uq
 uq
 uq
 uq
-uq
+Zd
 uq
 uq
 uq
@@ -28713,7 +28722,7 @@ uq
 uq
 uq
 uq
-uq
+Zd
 uq
 uq
 uq
@@ -29070,7 +29079,7 @@ uq
 uq
 uq
 uq
-uq
+Zd
 uq
 uq
 uq
@@ -29741,7 +29750,7 @@ uq
 uq
 uq
 uq
-uq
+Zd
 uq
 uq
 uq
@@ -30841,7 +30850,7 @@ RF
 RF
 uq
 uq
-uq
+et
 uq
 uq
 uq
@@ -32265,7 +32274,7 @@ uq
 uq
 uq
 uq
-uq
+Zd
 uq
 uq
 uq
@@ -32438,7 +32447,7 @@ uq
 uq
 uq
 uq
-uq
+Zd
 uq
 uq
 uq
@@ -34710,7 +34719,7 @@ uq
 uq
 uq
 uq
-uq
+Zd
 uq
 uq
 uq
@@ -37799,7 +37808,7 @@ EG
 RF
 uq
 uq
-uq
+et
 uq
 uq
 uq
@@ -38262,7 +38271,7 @@ uq
 uq
 uq
 uq
-uq
+Zd
 uq
 uq
 uq
@@ -38371,7 +38380,7 @@ uq
 uq
 uq
 uq
-uq
+Zd
 uq
 uq
 uq
@@ -39007,7 +39016,7 @@ uq
 uq
 uq
 uq
-uq
+Zd
 uq
 uq
 uq
@@ -39419,7 +39428,7 @@ uq
 uq
 uq
 uq
-uq
+Zd
 uq
 uq
 uq
@@ -39727,7 +39736,7 @@ uq
 uq
 uq
 uq
-uq
+Zd
 uq
 uq
 uq
@@ -40200,7 +40209,7 @@ uq
 uq
 uq
 uq
-uq
+Zd
 uq
 uq
 uq
@@ -40597,7 +40606,7 @@ uq
 uq
 uq
 uq
-uq
+Zd
 uq
 uq
 uq
@@ -41613,7 +41622,7 @@ uq
 uq
 uq
 uq
-uq
+Zd
 uq
 uq
 uq

--- a/maps/stellardelight/stellar_delight2.dmm
+++ b/maps/stellardelight/stellar_delight2.dmm
@@ -2433,6 +2433,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/effect/landmark/vermin,
 /turf/simulated/floor/wood,
 /area/crew_quarters/captain)
 "fp" = (
@@ -2588,6 +2589,7 @@
 "fL" = (
 /obj/machinery/computer/arcade/battle,
 /obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/effect/landmark/vermin,
 /turf/simulated/floor/tiled/eris/dark/cargo,
 /area/crew_quarters/recreation_area)
 "fN" = (
@@ -3114,6 +3116,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
+/obj/effect/landmark/vermin,
 /turf/simulated/floor/tiled/techmaint,
 /area/storage/primary)
 "gS" = (
@@ -5496,9 +5499,7 @@
 	},
 /obj/machinery/vending/loadout/loadout_misc,
 /obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/effect/landmark{
-	name = "vinestart"
-	},
+/obj/effect/landmark/vines,
 /turf/simulated/floor/holofloor/tiled/dark,
 /area/crew_quarters/locker)
 "me" = (
@@ -5514,9 +5515,7 @@
 "mg" = (
 /obj/random/vendordrink,
 /obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/effect/landmark{
-	name = "vinestart"
-	},
+/obj/effect/landmark/vines,
 /turf/simulated/floor/tiled/steel_ridged,
 /area/stellardelight/deck2/port)
 "mh" = (
@@ -5751,6 +5750,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/effect/landmark/vermin,
 /turf/simulated/floor/wood,
 /area/stellardelight/deck2/briefingroom)
 "mI" = (
@@ -5845,6 +5845,9 @@
 "mS" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
+	},
+/obj/effect/landmark{
+	name = "verminstart"
 	},
 /turf/simulated/floor/grass,
 /area/hydroponics)
@@ -6232,6 +6235,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
+/obj/effect/landmark/vermin,
 /turf/simulated/floor/lino,
 /area/crew_quarters/bar)
 "nR" = (
@@ -7236,6 +7240,7 @@
 	icon_state = "2-4"
 	},
 /obj/structure/closet/secure_closet/engineering_personal,
+/obj/effect/landmark/vermin,
 /turf/simulated/floor/tiled/eris/dark/orangecorner,
 /area/engineering/locker_room)
 "qe" = (
@@ -7370,6 +7375,7 @@
 /obj/machinery/newscaster{
 	pixel_y = 28
 	},
+/obj/effect/landmark/vermin,
 /turf/simulated/floor/tiled,
 /area/storage/art)
 "qt" = (
@@ -7973,9 +7979,7 @@
 	dir = 4;
 	pixel_x = 24
 	},
-/obj/effect/landmark{
-	name = "vinestart"
-	},
+/obj/effect/landmark/vines,
 /turf/simulated/floor/tiled/techmaint,
 /area/storage/primary)
 "rF" = (
@@ -9151,9 +9155,7 @@
 "us" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/machinery/recharge_station,
-/obj/effect/landmark{
-	name = "vinestart"
-	},
+/obj/effect/landmark/vines,
 /turf/simulated/floor/tiled/steel_ridged,
 /area/stellardelight/deck2/starboard)
 "ut" = (
@@ -9755,6 +9757,7 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
+/obj/effect/landmark/vermin,
 /turf/simulated/floor/tiled/monotile,
 /area/hydroponics)
 "vQ" = (
@@ -10009,6 +10012,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
+/obj/effect/landmark/vermin,
 /turf/simulated/floor/tiled/eris/white/bluecorner,
 /area/stellardelight/deck2/triage)
 "wy" = (
@@ -12706,6 +12710,7 @@
 /obj/structure/cable/orange{
 	icon_state = "1-8"
 	},
+/obj/effect/landmark/vermin,
 /turf/simulated/floor/tiled/techfloor,
 /area/engineering/atmos/monitoring)
 "CO" = (
@@ -12959,6 +12964,7 @@
 	dir = 1
 	},
 /obj/structure/undies_wardrobe,
+/obj/effect/landmark/vermin,
 /turf/simulated/floor/holofloor/tiled/dark,
 /area/crew_quarters/locker)
 "Dv" = (
@@ -14263,6 +14269,7 @@
 /obj/effect/floor_decal/milspec/color/silver/corner{
 	dir = 8
 	},
+/obj/effect/landmark/vines,
 /turf/simulated/floor/tiled,
 /area/stellardelight/deck2/fore)
 "Gb" = (
@@ -14771,6 +14778,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
+/obj/effect/landmark/vermin,
 /turf/simulated/floor/tiled/eris/steel/cargo,
 /area/quartermaster/storage)
 "Hf" = (
@@ -15302,6 +15310,7 @@
 /obj/random/vendordrink,
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/machinery/firealarm/angled,
+/obj/effect/landmark/vermin,
 /turf/simulated/floor/tiled,
 /area/stellardelight/deck2/aftstarboard)
 "Il" = (
@@ -15345,6 +15354,7 @@
 	},
 /obj/structure/table/steel_reinforced,
 /obj/item/device/retail_scanner/command,
+/obj/effect/landmark/vermin,
 /turf/simulated/floor/tiled/eris/dark/monofloor,
 /area/bridge)
 "Ip" = (
@@ -16356,9 +16366,7 @@
 /obj/item/paint_palette,
 /obj/item/paint_brush,
 /obj/item/paint_brush,
-/obj/effect/landmark{
-	name = "vinestart"
-	},
+/obj/effect/landmark/vines,
 /turf/simulated/floor/tiled,
 /area/storage/art)
 "KD" = (
@@ -16547,6 +16555,7 @@
 /obj/machinery/camera/network/medbay{
 	dir = 8
 	},
+/obj/effect/landmark/vermin,
 /turf/simulated/floor/tiled/eris/white/bluecorner,
 /area/medical/chemistry)
 "La" = (
@@ -17951,6 +17960,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/wood,
 /area/stellardelight/deck2/barbackroom)
+"Oh" = (
+/obj/effect/landmark{
+	name = "carpspawn"
+	},
+/turf/space,
+/area/space)
 "Oi" = (
 /obj/machinery/firealarm/angled,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -18134,6 +18149,9 @@
 /obj/machinery/status_display{
 	pixel_y = 32
 	},
+/obj/effect/landmark{
+	name = "verminstart"
+	},
 /turf/simulated/floor/tiled/eris/cafe,
 /area/crew_quarters/kitchen)
 "OB" = (
@@ -18231,9 +18249,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/obj/effect/landmark{
-	name = "vinestart"
-	},
+/obj/effect/landmark/vines,
 /turf/simulated/floor/tiled/eris/steel/brown_platform,
 /area/quartermaster/storage)
 "OQ" = (
@@ -18495,6 +18511,12 @@
 	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/stellardelight/deck2/starboard)
+"Pp" = (
+/obj/effect/landmark{
+	name = "droppod_landing"
+	},
+/turf/space,
+/area/space)
 "Pq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
 	dir = 9
@@ -20251,6 +20273,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
+/obj/effect/landmark/vermin,
 /turf/simulated/floor/tiled/eris/white/bluecorner,
 /area/medical/cmostore)
 "Tn" = (
@@ -21913,6 +21936,7 @@
 /obj/effect/floor_decal/steeldecal/steel_decals6{
 	dir = 4
 	},
+/obj/effect/landmark/vines,
 /turf/simulated/floor/tiled,
 /area/stellardelight/deck2/fore)
 "Xf" = (
@@ -22713,6 +22737,7 @@
 "YW" = (
 /obj/random/vendordrink,
 /obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/effect/landmark/vermin,
 /turf/simulated/floor/tiled/steel_ridged,
 /area/stellardelight/deck2/starboard)
 "YX" = (
@@ -25832,7 +25857,7 @@ Jh
 Jh
 Jh
 Jh
-Jh
+Oh
 Jh
 Jh
 Jh
@@ -26237,7 +26262,7 @@ Jh
 Jh
 Jh
 Jh
-Jh
+Oh
 Jh
 Jh
 Jh
@@ -26637,7 +26662,7 @@ Jh
 Jh
 Jh
 Jh
-Jh
+Oh
 Jh
 Jh
 Jh
@@ -26858,7 +26883,7 @@ Jh
 Jh
 Jh
 Jh
-Jh
+Oh
 Jh
 Jh
 Jh
@@ -27807,7 +27832,7 @@ Jh
 Jh
 Jh
 Jh
-Jh
+Oh
 Jh
 Jh
 Jh
@@ -28779,7 +28804,7 @@ Jh
 Jh
 Jh
 Jh
-Jh
+Pp
 Jh
 Jh
 Jh
@@ -28890,7 +28915,7 @@ Jh
 Jh
 Jh
 Jh
-Jh
+Oh
 Jh
 Jh
 Jh
@@ -30574,7 +30599,7 @@ Jh
 Jh
 Jh
 Jh
-Jh
+Oh
 Jh
 Jh
 Jh
@@ -31869,7 +31894,7 @@ Jh
 Jh
 Jh
 Jh
-Jh
+Oh
 Jh
 Jh
 Jh
@@ -33124,7 +33149,7 @@ Jh
 Jh
 Jh
 Jh
-Jh
+Oh
 Jh
 Jh
 Jh
@@ -34994,7 +35019,7 @@ Jh
 Jh
 Jh
 Jh
-Jh
+Oh
 Jh
 Jh
 Jh
@@ -36393,7 +36418,7 @@ Jh
 Jh
 Jh
 Jh
-Jh
+Oh
 Jh
 Jh
 Jh
@@ -36888,7 +36913,7 @@ bw
 Jh
 Jh
 Jh
-Jh
+Oh
 Jh
 Jh
 Jh
@@ -37301,7 +37326,7 @@ Jh
 Jh
 Jh
 Jh
-Jh
+Pp
 Jh
 Jh
 Jh
@@ -37379,7 +37404,7 @@ NL
 NL
 Jh
 Jh
-Jh
+Pp
 Jh
 Jh
 Jh
@@ -37701,7 +37726,7 @@ Jh
 Jh
 Jh
 Jh
-Jh
+Oh
 Jh
 Jh
 Jh
@@ -38292,7 +38317,7 @@ Jh
 Jh
 Jh
 Jh
-Jh
+Oh
 Jh
 Jh
 Jh
@@ -39457,6 +39482,7 @@ Jh
 Jh
 Jh
 Jh
+Oh
 Jh
 Jh
 Jh
@@ -39501,8 +39527,7 @@ Jh
 Jh
 Jh
 Jh
-Jh
-Jh
+Oh
 Jh
 Jh
 Jh
@@ -40187,7 +40212,7 @@ Jh
 Jh
 Jh
 Jh
-Jh
+Oh
 Jh
 Jh
 Jh

--- a/maps/stellardelight/stellar_delight3.dmm
+++ b/maps/stellardelight/stellar_delight3.dmm
@@ -230,9 +230,7 @@
 /area/stellardelight/deck3/aft)
 "ba" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/effect/landmark{
-	name = "vinestart"
-	},
+/obj/effect/landmark/vines,
 /turf/simulated/open,
 /area/stellardelight/deck2/fore)
 "bb" = (
@@ -501,6 +499,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
+/obj/effect/landmark/vines,
 /turf/simulated/open,
 /area/crew_quarters/bar)
 "cb" = (
@@ -5885,6 +5884,13 @@
 /obj/structure/low_wall/bay/reinforced/steel,
 /turf/simulated/floor,
 /area/stellardelight/deck2/port)
+"wc" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/effect/landmark/vermin,
+/turf/simulated/open,
+/area/stellardelight/deck2/starboard)
 "wd" = (
 /obj/structure/table/standard,
 /obj/item/weapon/aiModule/oxygen,
@@ -6296,6 +6302,7 @@
 /obj/effect/floor_decal/steeldecal/steel_decals5{
 	dir = 4
 	},
+/obj/effect/landmark/vermin,
 /turf/simulated/floor/tiled,
 /area/stellardelight/deck3/starboarddock)
 "xE" = (
@@ -6414,9 +6421,6 @@
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
-	},
-/obj/effect/landmark{
-	name = "vinestart"
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/stellardelight/deck3/commandhall)
@@ -6732,6 +6736,12 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/ai_upload)
+"zk" = (
+/obj/effect/landmark{
+	name = "droppod_landing"
+	},
+/turf/space,
+/area/space)
 "zm" = (
 /obj/structure/cable/blue{
 	icon_state = "4-8"
@@ -7664,6 +7674,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
+/obj/effect/landmark/vermin,
 /turf/simulated/open,
 /area/stellardelight/deck2/fore)
 "Cc" = (
@@ -8229,6 +8240,12 @@
 /obj/random/trash_pile,
 /turf/simulated/floor,
 /area/maintenance/stellardelight/deck3/portcent)
+"El" = (
+/obj/effect/landmark{
+	name = "carpspawn"
+	},
+/turf/space,
+/area/space)
 "En" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 1
@@ -8475,6 +8492,7 @@
 /obj/effect/floor_decal/steeldecal/steel_decals5{
 	dir = 1
 	},
+/obj/effect/landmark/vermin,
 /turf/simulated/floor/tiled,
 /area/stellardelight/deck3/aft)
 "Fg" = (
@@ -9342,9 +9360,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
-/obj/effect/landmark{
-	name = "vinestart"
-	},
+/obj/effect/landmark/vines,
 /turf/simulated/open,
 /area/stellardelight/deck2/fore)
 "IG" = (
@@ -10272,9 +10288,7 @@
 	dir = 4;
 	pixel_x = 27
 	},
-/obj/effect/landmark{
-	name = "vinestart"
-	},
+/obj/effect/landmark/vines,
 /turf/simulated/floor/tiled,
 /area/stellardelight/deck3/starboarddock)
 "LR" = (
@@ -10456,9 +10470,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/obj/effect/landmark{
-	name = "vinestart"
-	},
+/obj/effect/landmark/vines,
 /turf/simulated/open,
 /area/stellardelight/deck2/fore)
 "Mw" = (
@@ -10671,9 +10683,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/obj/effect/landmark{
-	name = "vinestart"
-	},
+/obj/effect/landmark/vines,
 /turf/simulated/open,
 /area/stellardelight/deck2/port)
 "Ne" = (
@@ -11319,9 +11329,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
-/obj/effect/landmark{
-	name = "vinestart"
-	},
+/obj/effect/landmark/vines,
 /turf/simulated/open,
 /area/stellardelight/deck2/starboard)
 "Pa" = (
@@ -12580,6 +12588,7 @@
 /area/ai_server_room)
 "TO" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/effect/landmark/vermin,
 /turf/simulated/floor/tiled/monotile,
 /area/stellardelight/deck3/commandhall)
 "TP" = (
@@ -12856,9 +12865,7 @@
 	dir = 8;
 	pixel_x = -27
 	},
-/obj/effect/landmark{
-	name = "vinestart"
-	},
+/obj/effect/landmark/vines,
 /turf/simulated/floor/tiled,
 /area/stellardelight/deck3/portdock)
 "UX" = (
@@ -13483,6 +13490,7 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
+/obj/effect/landmark/vermin,
 /turf/simulated/open,
 /area/crew_quarters/bar)
 "Xd" = (
@@ -16918,7 +16926,7 @@ Jh
 Jh
 Jh
 Jh
-Jh
+El
 Jh
 Jh
 Jh
@@ -17451,7 +17459,7 @@ Jh
 Jh
 Jh
 Jh
-Jh
+El
 Jh
 Jh
 Jh
@@ -18322,7 +18330,7 @@ Jh
 Jh
 Jh
 Jh
-Jh
+El
 Jh
 Jh
 Jh
@@ -18386,6 +18394,7 @@ Jh
 Jh
 Jh
 Jh
+El
 Jh
 Jh
 Jh
@@ -18421,8 +18430,7 @@ Jh
 Jh
 Jh
 Jh
-Jh
-Jh
+El
 Jh
 Jh
 Jh
@@ -19160,7 +19168,7 @@ Jh
 Jh
 Jh
 Jh
-Jh
+zk
 Jh
 Jh
 Jh
@@ -19256,7 +19264,7 @@ Jh
 Jh
 Jh
 Jh
-Jh
+El
 Jh
 Jh
 Jh
@@ -19630,7 +19638,7 @@ NL
 NL
 Jh
 Jh
-Jh
+zk
 Jh
 Jh
 Jh
@@ -20416,7 +20424,7 @@ Jh
 Jh
 Jh
 Jh
-Jh
+El
 Jh
 Jh
 Jh
@@ -21473,7 +21481,7 @@ NL
 Jh
 Jh
 Jh
-Jh
+El
 Jh
 Jh
 Jh
@@ -21906,7 +21914,7 @@ Jh
 Jh
 Jh
 Jh
-Jh
+El
 Jh
 Jh
 Jh
@@ -22209,7 +22217,7 @@ Jh
 Jh
 Jh
 Jh
-Jh
+El
 Jh
 Jh
 Jh
@@ -25669,7 +25677,7 @@ qF
 hC
 aJ
 ow
-ZC
+wc
 ow
 yP
 Ks
@@ -27153,7 +27161,7 @@ NL
 Jh
 Jh
 Jh
-Jh
+El
 Jh
 Jh
 Jh
@@ -27720,7 +27728,7 @@ NL
 NL
 Jh
 Jh
-Jh
+zk
 Jh
 Jh
 Jh
@@ -27941,7 +27949,7 @@ Jh
 Jh
 Jh
 Jh
-Jh
+El
 Jh
 Jh
 Jh
@@ -28204,7 +28212,7 @@ Jh
 Jh
 Jh
 Jh
-Jh
+zk
 Jh
 Jh
 Jh
@@ -28683,7 +28691,7 @@ Jh
 Jh
 Jh
 Jh
-Jh
+zk
 Jh
 Jh
 Jh
@@ -29192,7 +29200,7 @@ Jh
 Jh
 Jh
 Jh
-Jh
+El
 Jh
 Jh
 Jh
@@ -29926,6 +29934,7 @@ Jh
 Jh
 Jh
 Jh
+El
 Jh
 Jh
 Jh
@@ -29972,8 +29981,7 @@ Jh
 Jh
 Jh
 Jh
-Jh
-Jh
+El
 Jh
 Jh
 Jh
@@ -30022,6 +30030,7 @@ Jh
 Jh
 Jh
 Jh
+El
 Jh
 Jh
 Jh
@@ -30138,8 +30147,7 @@ Jh
 Jh
 Jh
 Jh
-Jh
-Jh
+El
 Jh
 Jh
 Jh
@@ -30670,7 +30678,7 @@ Jh
 Jh
 Jh
 Jh
-Jh
+El
 Jh
 Jh
 Jh

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -2193,6 +2193,7 @@
 #include "code\modules\events\ian_storm_vr.dm"
 #include "code\modules\events\infestation.dm"
 #include "code\modules\events\ion_storm.dm"
+#include "code\modules\events\jellyfish_migration.dm"
 #include "code\modules\events\maintenance_predator_vr.dm"
 #include "code\modules\events\meteor_strike_vr.dm"
 #include "code\modules\events\meteors.dm"


### PR DESCRIPTION
The following PR will do a FEW things

* Adds a new Jellyfish Migration Event
* Updated Vermin Infestation to now spawn via landmarks vs. areas and airvents (This is to allow it so there are more spots and unique areas we can drop the critters at)
* Updated Carp Migration & Rogue Drone event numbers, and also added landmarks around
* Updated Drop Pod Event with new locations and updated the flavor text of the event
* Disabled Meteor Strike RNG event as it didn't make much sense with the current set-up 