### PR TITLE
Makes mob renaming not exclusive to vore subtype

### DIFF
--- a/code/modules/mob/living/simple_mob/subtypes/vore/vore.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/vore.dm
@@ -3,12 +3,12 @@
 	mob_bump_flag = 0
 	var/nameset
 
-/mob/living/simple_mob/vore/Login()
+/mob/living/simple_mob/Login()
 	. = ..()
-	verbs |= /mob/living/simple_mob/vore/proc/set_name
-	verbs |= /mob/living/simple_mob/vore/proc/set_desc
+	verbs |= /mob/living/simple_mob/proc/set_name
+	verbs |= /mob/living/simple_mob/proc/set_desc
 
-/mob/living/simple_mob/vore/proc/set_name()
+/mob/living/simple_mob/proc/set_name()
 	set name = "Set Name"
 	set desc = "Sets your mobs name. You only get to do this once."
 	set category = "Abilities"
@@ -22,7 +22,7 @@
 		voice_name = newname
 		nameset = 1
 
-/mob/living/simple_mob/vore/proc/set_desc()
+/mob/living/simple_mob/proc/set_desc()
 	set name = "Set Description"
 	set desc = "Set your description."
 	set category = "Abilities"

--- a/code/modules/mob/living/simple_mob/subtypes/vore/vore.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/vore.dm
@@ -1,6 +1,8 @@
 /mob/living/simple_mob/vore
 	mob_class = MOB_CLASS_ANIMAL
 	mob_bump_flag = 0
+
+/mob/living/simple_mob
 	var/nameset
 
 /mob/living/simple_mob/Login()

--- a/code/modules/mob/living/simple_mob/subtypes/vore/vore.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/vore.dm
@@ -4,6 +4,7 @@
 
 /mob/living/simple_mob
 	var/nameset
+	var/limit_renames = TRUE
 
 /mob/living/simple_mob/Login()
 	. = ..()
@@ -14,7 +15,7 @@
 	set name = "Set Name"
 	set desc = "Sets your mobs name. You only get to do this once."
 	set category = "Abilities"
-	if(nameset)
+	if(limit_renames && nameset)
 		to_chat(src, "<span class='userdanger'>You've already set your name. Ask an admin to toggle \"nameset\" to 0 if you really must.</span>")
 		return
 	var/newname


### PR DESCRIPTION
Only a fraction of voremobs are actually vore subtype and the verbs can be just as useful for even non-voremobs.
Also adds a var toggle to allow multiple name changes for event convenience.