### PR TITLE
yet another PR touching kinetic accelerators

### DIFF
--- a/code/modules/mining/ore_redemption_machine/equipment_vendor.dm
+++ b/code/modules/mining/ore_redemption_machine/equipment_vendor.dm
@@ -123,12 +123,13 @@
 		EQUIPMENT("KA Cooldown Decrease",		/obj/item/borg/upgrade/modkit/cooldown,							1200),
 		EQUIPMENT("KA Range Increase",			/obj/item/borg/upgrade/modkit/range,							1000),
 		EQUIPMENT("KA Temperature Modulator",	/obj/item/borg/upgrade/modkit/heater,							1000),
-		EQUIPMENT("KA Off-Station Modulator",	/obj/item/borg/upgrade/modkit/indoors/offsite, 					1500),
+		EQUIPMENT("KA Off-Station Modulator",	/obj/item/borg/upgrade/modkit/offsite, 							1750),
 		EQUIPMENT("KA Holster",					/obj/item/clothing/accessory/holster/waist/kinetic_accelerator,	350),
 		EQUIPMENT("KA Super Chassis",			/obj/item/borg/upgrade/modkit/chassis_mod,						250),
 		EQUIPMENT("KA Hyper Chassis",			/obj/item/borg/upgrade/modkit/chassis_mod/orange,				300),
 		EQUIPMENT("KA Adjustable Tracer Rounds",/obj/item/borg/upgrade/modkit/tracer/adjustable,				175),
 		EQUIPMENT("KA White Tracer Rounds",		/obj/item/borg/upgrade/modkit/tracer,							125),
+		EQUIPMENT("Premium Kinetic Accelerator",/obj/item/weapon/gun/energy/kinetic_accelerator/premium,		12000),
 	)
 	prize_list["Digging Tools"] = list(
 		// EQUIPMENT("Diamond Pickaxe",	/obj/item/weapon/pickaxe/diamond,				2000),

--- a/code/modules/mining/ore_redemption_machine/equipment_vendor.dm
+++ b/code/modules/mining/ore_redemption_machine/equipment_vendor.dm
@@ -129,7 +129,7 @@
 		EQUIPMENT("KA Hyper Chassis",			/obj/item/borg/upgrade/modkit/chassis_mod/orange,				300),
 		EQUIPMENT("KA Adjustable Tracer Rounds",/obj/item/borg/upgrade/modkit/tracer/adjustable,				175),
 		EQUIPMENT("KA White Tracer Rounds",		/obj/item/borg/upgrade/modkit/tracer,							125),
-		EQUIPMENT("Premium Kinetic Accelerator",/obj/item/weapon/gun/energy/kinetic_accelerator/premium,		12000),
+		EQUIPMENT("Premium Kinetic Accelerator",/obj/item/weapon/gun/energy/kinetic_accelerator/premiumka,		12000),
 	)
 	prize_list["Digging Tools"] = list(
 		// EQUIPMENT("Diamond Pickaxe",	/obj/item/weapon/pickaxe/diamond,				2000),

--- a/code/modules/projectiles/guns/energy/kinetic_accelerator_vr.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator_vr.dm
@@ -273,6 +273,7 @@
 		else if(environment == KA_ENVIRO_TYPE_OFFSITE)
 			if(!offsite_environment_check(get_turf(src)))
 				name = "nullified [name]"
+				nodamage = TRUE
 				damage = 0
 				pressure_decrease_active = TRUE
 	return ..()
@@ -292,6 +293,7 @@
 		else if(environment == KA_ENVIRO_TYPE_OFFSITE)
 			if(!offsite_environment_check(get_turf(src)))
 				name = "nullified [name]"
+				nodamage = TRUE
 				damage = 0
 				pressure_decrease_active = TRUE
 	return ..()
@@ -323,6 +325,7 @@
 		else if(environment == KA_ENVIRO_TYPE_OFFSITE)
 			if(!offsite_environment_check(get_turf(src)))
 				name = "nullified [name]"
+				nodamage = TRUE
 				damage = 0
 				pressure_decrease_active = TRUE
 	var/turf/target_turf = get_turf(target)
@@ -546,7 +549,7 @@
 //Tendril-unique modules
 /obj/item/borg/upgrade/modkit/cooldown/repeater
 	name = "rapid repeater"
-	desc = "Quarters the kinetic accelerator's cooldown on striking a living target, but greatly increases the base cooldown."
+	desc = "Quarters the kinetic accelerator's cooldown on striking a living or mineral target, but greatly increases the base cooldown."
 	denied_type = /obj/item/borg/upgrade/modkit/cooldown/repeater
 	modifier = -14 //Makes the cooldown 3 seconds(with no cooldown mods) if you miss. Don't miss.
 	cost = 50
@@ -654,6 +657,8 @@
 	name = "offsite pressure modulator"
 	desc = "A non-standard modification kit that increases the damage a kinetic accelerator does in pressurized environments, \
 	in exchange for nullifying any projected forces while on or in an associated facility."
+	denied_type = /obj/item/borg/upgrade/modkit/heater
+	maximum_of_type = 1
 	cost = 35
 
 /obj/item/borg/upgrade/modkit/indoors/offsite/modify_projectile(obj/item/projectile/kinetic/K)
@@ -664,7 +669,7 @@
 	name = "temperature modulator"
 	desc = "A remarkably unusual modification kit that makes kinetic accelerators more usable in hot, overpressurized environments, \
 	in exchange for making them weak elsewhere, like the cold or in space."
-	denied_type = /obj/item/borg/upgrade/modkit/indoors
+	denied_type = /obj/item/borg/upgrade/modkit/offsite
 	maximum_of_type = 1
 	cost = 10
 

--- a/code/modules/telesci/quantum_pad.dm
+++ b/code/modules/telesci/quantum_pad.dm
@@ -235,7 +235,7 @@
 	// Otherwise we'll need a powernet
 	var/power_to_use = 10000 / power_efficiency
 	if(boosted)
-		power_to_use * 5
+		power_to_use *= 5
 	if(draw_power(power_to_use) != power_to_use)
 		return FALSE
 	return TRUE


### PR DESCRIPTION
- adds the premium KA to the mining vendor at a whopping **12,000 points** for a mod-free extra tile of range and 10 more damage
- makes sure to give nullified KA blasts nodamage = 1 to hopefully avoid other shenanigans
- repaths the offstation modulator to actually offstation modulate, while also raising the price 1500 -> 1750 due to the additional flexiblity granted
- makes the offsite and heat modulators mutually exclusive