### PR TITLE
Fixes active edges and other minor startup issues in gateway areas

### DIFF
--- a/code/modules/mining/mine_turfs_vr.dm
+++ b/code/modules/mining/mine_turfs_vr.dm
@@ -14,6 +14,16 @@
 /turf/simulated/mineral/floor/ignore_cavegen
 	ignore_cavegen = TRUE
 
+/turf/simulated/mineral/ignore_cavegen/cave
+	oxygen = MOLES_O2STANDARD
+	nitrogen = MOLES_N2STANDARD
+	temperature	= T20C
+
+/turf/simulated/mineral/floor/ignore_cavegen/cave
+	oxygen = MOLES_O2STANDARD
+	nitrogen = MOLES_N2STANDARD
+	temperature	= T20C
+
 /turf/simulated/mineral/vacuum
 	oxygen = 0
 	nitrogen = 0

--- a/maps/gateway_vr/listeningpost.dmm
+++ b/maps/gateway_vr/listeningpost.dmm
@@ -211,7 +211,7 @@
 /turf/simulated/mineral/floor,
 /area/mine/unexplored)
 "aL" = (
-/turf/simulated/floor/greengrid,
+/turf/simulated/floor/greengrid/airless,
 /area/mine/explored)
 "aM" = (
 /turf/simulated/mineral/floor,
@@ -220,51 +220,51 @@
 /obj/machinery/gateway{
 	dir = 9
 	},
-/turf/simulated/floor/greengrid,
+/turf/simulated/floor/greengrid/airless,
 /area/mine/explored)
 "aO" = (
 /obj/machinery/gateway{
 	dir = 1
 	},
-/turf/simulated/floor/greengrid,
+/turf/simulated/floor/greengrid/airless,
 /area/mine/explored)
 "aP" = (
 /obj/machinery/gateway{
 	dir = 5
 	},
-/turf/simulated/floor/greengrid,
+/turf/simulated/floor/greengrid/airless,
 /area/mine/explored)
 "aQ" = (
 /obj/machinery/gateway{
 	dir = 8
 	},
-/turf/simulated/floor/greengrid,
+/turf/simulated/floor/greengrid/airless,
 /area/mine/explored)
 "aR" = (
 /obj/machinery/gateway/centeraway,
-/turf/simulated/floor/greengrid,
+/turf/simulated/floor/greengrid/airless,
 /area/mine/explored)
 "aS" = (
 /obj/machinery/gateway{
 	dir = 4
 	},
-/turf/simulated/floor/greengrid,
+/turf/simulated/floor/greengrid/airless,
 /area/mine/explored)
 "aT" = (
 /obj/machinery/gateway{
 	dir = 10
 	},
-/turf/simulated/floor/greengrid,
+/turf/simulated/floor/greengrid/airless,
 /area/mine/explored)
 "aU" = (
 /obj/machinery/gateway,
-/turf/simulated/floor/greengrid,
+/turf/simulated/floor/greengrid/airless,
 /area/mine/explored)
 "aV" = (
 /obj/machinery/gateway{
 	dir = 6
 	},
-/turf/simulated/floor/greengrid,
+/turf/simulated/floor/greengrid/airless,
 /area/mine/explored)
 "aW" = (
 /obj/effect/overmap/visitable/sector/common_gateway/listeningpost,

--- a/maps/gateway_vr/variable/arynthilake_a.dmm
+++ b/maps/gateway_vr/variable/arynthilake_a.dmm
@@ -3,7 +3,7 @@
 /turf/unsimulated/mineral,
 /area/gateway/arynthilake)
 "ac" = (
-/turf/simulated/mineral/ignore_cavegen,
+/turf/simulated/mineral/ignore_cavegen/cave,
 /area/gateway/arynthilake)
 "ae" = (
 /obj/effect/floor_decal/techfloor{
@@ -18,7 +18,7 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/gateway/arynthilake/gateway)
 "af" = (
-/turf/simulated/mineral/floor/ignore_cavegen,
+/turf/simulated/mineral/floor/ignore_cavegen/cave,
 /area/gateway/arynthilake)
 "ag" = (
 /turf/simulated/wall/r_wall,
@@ -147,7 +147,7 @@
 /area/gateway/arynthilake/oldcabin)
 "aV" = (
 /obj/item/weapon/lampshade,
-/turf/simulated/mineral/floor/ignore_cavegen,
+/turf/simulated/mineral/floor/ignore_cavegen/cave,
 /area/gateway/arynthilake/caves)
 "aX" = (
 /turf/simulated/floor/carpet/bcarpet,
@@ -227,13 +227,13 @@
 /area/gateway/arynthilake)
 "bn" = (
 /obj/structure/table/steel,
-/turf/simulated/mineral/floor/ignore_cavegen{
+/turf/simulated/mineral/floor/ignore_cavegen/cave{
 	outdoors = 1
 	},
 /area/gateway/arynthilake)
 "bo" = (
 /obj/structure/table,
-/turf/simulated/mineral/floor/ignore_cavegen{
+/turf/simulated/mineral/floor/ignore_cavegen/cave{
 	outdoors = 1
 	},
 /area/gateway/arynthilake)
@@ -345,7 +345,7 @@
 /obj/item/stack/material/steel{
 	amount = 50
 	},
-/turf/simulated/mineral/floor/ignore_cavegen{
+/turf/simulated/mineral/floor/ignore_cavegen/cave{
 	outdoors = 1
 	},
 /area/gateway/arynthilake)
@@ -540,7 +540,7 @@
 /area/gateway/arynthilake/dome)
 "eV" = (
 /obj/effect/landmark/mcguffin_spawner,
-/turf/simulated/mineral/floor/ignore_cavegen,
+/turf/simulated/mineral/floor/ignore_cavegen/cave,
 /area/gateway/arynthilake/caves)
 "eW" = (
 /obj/item/device/analyzer/plant_analyzer,
@@ -727,7 +727,7 @@
 	},
 /area/gateway/arynthilake/dome)
 "jI" = (
-/turf/simulated/mineral/floor/ignore_cavegen,
+/turf/simulated/mineral/floor/ignore_cavegen/cave,
 /area/gateway/arynthilake/caves)
 "jK" = (
 /obj/structure/table/rack/shelf/steel,
@@ -919,7 +919,7 @@
 /area/gateway/arynthilake)
 "nc" = (
 /obj/random/awayloot,
-/turf/simulated/mineral/floor/ignore_cavegen,
+/turf/simulated/mineral/floor/ignore_cavegen/cave,
 /area/gateway/arynthilake/caves)
 "np" = (
 /obj/random/mob/semirandom_mob_spawner/animal/e,
@@ -927,7 +927,7 @@
 /area/gateway/arynthilake)
 "nr" = (
 /obj/effect/fake_sun,
-/turf/simulated/mineral/ignore_cavegen,
+/turf/simulated/mineral/ignore_cavegen/cave,
 /area/gateway/arynthilake/caves)
 "nx" = (
 /obj/machinery/door/airlock/engineering,
@@ -1176,7 +1176,7 @@
 /area/gateway/arynthilake/engine)
 "sl" = (
 /obj/effect/overmap/visitable/sector/common_gateway/arynthilake,
-/turf/simulated/mineral/ignore_cavegen,
+/turf/simulated/mineral/ignore_cavegen/cave,
 /area/gateway/arynthilake/caves)
 "sA" = (
 /obj/structure/table/rack/steel,
@@ -1754,7 +1754,7 @@
 /area/gateway/arynthilake/engine)
 "Iq" = (
 /obj/random/mob/semirandom_mob_spawner/humanoid/retaliate,
-/turf/simulated/mineral/floor/ignore_cavegen{
+/turf/simulated/mineral/floor/ignore_cavegen/cave{
 	outdoors = 1
 	},
 /area/gateway/arynthilake)
@@ -1813,7 +1813,7 @@
 /turf/simulated/floor/tiled/eris/techmaint_cargo,
 /area/gateway/arynthilake/dome)
 "JK" = (
-/turf/simulated/mineral/floor/ignore_cavegen{
+/turf/simulated/mineral/floor/ignore_cavegen/cave{
 	outdoors = 1
 	},
 /area/gateway/arynthilake)
@@ -1936,7 +1936,7 @@
 /turf/simulated/floor/carpet/purcarpet,
 /area/gateway/arynthilake/dome)
 "MD" = (
-/turf/simulated/mineral/floor/ignore_cavegen{
+/turf/simulated/mineral/floor/ignore_cavegen/cave{
 	outdoors = 1
 	},
 /area/gateway/arynthilake/caves)
@@ -2070,7 +2070,7 @@
 /area/gateway/arynthilake/dome)
 "Or" = (
 /obj/effect/landmark/hidden_level,
-/turf/simulated/mineral/ignore_cavegen,
+/turf/simulated/mineral/ignore_cavegen/cave,
 /area/gateway/arynthilake/caves)
 "OC" = (
 /turf/simulated/floor/carpet/blucarpet{
@@ -2150,7 +2150,7 @@
 /turf/simulated/floor/tiled/steel_ridged,
 /area/gateway/arynthilake/engine)
 "Qr" = (
-/turf/simulated/mineral/ignore_cavegen,
+/turf/simulated/mineral/ignore_cavegen/cave,
 /area/gateway/arynthilake/caves)
 "Qx" = (
 /obj/random/mob/semirandom_mob_spawner/robot/retaliate,
@@ -2308,7 +2308,7 @@
 /turf/simulated/floor/wood,
 /area/gateway/arynthilake/dome)
 "UZ" = (
-/turf/simulated/mineral/ignore_cavegen,
+/turf/simulated/mineral/ignore_cavegen/cave,
 /area/gateway/arynthilake/caveruins)
 "Vf" = (
 /obj/structure/closet,
@@ -2355,7 +2355,7 @@
 /area/gateway/arynthilake/caveruins)
 "We" = (
 /obj/random/mob/semirandom_mob_spawner/monster/e,
-/turf/simulated/mineral/floor/ignore_cavegen,
+/turf/simulated/mineral/floor/ignore_cavegen/cave,
 /area/gateway/arynthilake/caves)
 "Wj" = (
 /obj/machinery/light{

--- a/maps/gateway_vr/variable/arynthilake_b.dmm
+++ b/maps/gateway_vr/variable/arynthilake_b.dmm
@@ -3,7 +3,7 @@
 /obj/item/stack/material/steel{
 	amount = 50
 	},
-/turf/simulated/mineral/floor/ignore_cavegen{
+/turf/simulated/mineral/floor/ignore_cavegen/cave{
 	outdoors = 1
 	},
 /area/gateway/arynthilake)
@@ -41,7 +41,7 @@
 /area/gateway/arynthilake/dome)
 "bs" = (
 /obj/effect/landmark/mcguffin_spawner,
-/turf/simulated/mineral/floor/ignore_cavegen,
+/turf/simulated/mineral/floor/ignore_cavegen/cave,
 /area/gateway/arynthilake/caves)
 "bw" = (
 /obj/structure/table/sifwooden_reinforced,
@@ -72,7 +72,7 @@
 /turf/simulated/floor/carpet/purcarpet,
 /area/gateway/arynthilake/dome)
 "cg" = (
-/turf/simulated/mineral/ignore_cavegen,
+/turf/simulated/mineral/ignore_cavegen/cave,
 /area/gateway/arynthilake)
 "ch" = (
 /turf/simulated/floor/plating{
@@ -230,7 +230,7 @@
 /turf/simulated/floor/tiled/eris,
 /area/gateway/arynthilake/engine)
 "ek" = (
-/turf/simulated/mineral/ignore_cavegen,
+/turf/simulated/mineral/ignore_cavegen/cave,
 /area/gateway/arynthilake/caves)
 "eq" = (
 /obj/structure/lattice,
@@ -247,7 +247,7 @@
 /area/gateway/arynthilake/dome)
 "eN" = (
 /obj/effect/fake_sun,
-/turf/simulated/mineral/ignore_cavegen,
+/turf/simulated/mineral/ignore_cavegen/cave,
 /area/gateway/arynthilake/caves)
 "eP" = (
 /obj/structure/table/standard{
@@ -309,7 +309,7 @@
 /area/gateway/arynthilake/dome)
 "fC" = (
 /obj/effect/overmap/visitable/sector/common_gateway/arynthilake,
-/turf/simulated/mineral/ignore_cavegen,
+/turf/simulated/mineral/ignore_cavegen/cave,
 /area/gateway/arynthilake/caves)
 "fX" = (
 /obj/structure/table/standard{
@@ -467,7 +467,7 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/gateway/arynthilake/gateway)
 "iX" = (
-/turf/simulated/mineral/floor/ignore_cavegen,
+/turf/simulated/mineral/floor/ignore_cavegen/cave,
 /area/gateway/arynthilake)
 "jh" = (
 /obj/structure/cable/green{
@@ -731,7 +731,7 @@
 /area/gateway/arynthilake/dome)
 "nK" = (
 /obj/structure/table/steel,
-/turf/simulated/mineral/floor/ignore_cavegen{
+/turf/simulated/mineral/floor/ignore_cavegen/cave{
 	outdoors = 1
 	},
 /area/gateway/arynthilake)
@@ -838,7 +838,7 @@
 /area/gateway/arynthilake/dome)
 "pS" = (
 /obj/random/awayloot,
-/turf/simulated/mineral/floor/ignore_cavegen,
+/turf/simulated/mineral/floor/ignore_cavegen/cave,
 /area/gateway/arynthilake/caves)
 "pT" = (
 /obj/structure/bed/double/padded,
@@ -886,7 +886,7 @@
 /turf/simulated/floor/beach/sand/desert,
 /area/gateway/arynthilake/caves)
 "rt" = (
-/turf/simulated/mineral/floor/ignore_cavegen{
+/turf/simulated/mineral/floor/ignore_cavegen/cave{
 	outdoors = 1
 	},
 /area/gateway/arynthilake)
@@ -929,7 +929,7 @@
 /area/gateway/arynthilake/dome)
 "si" = (
 /obj/structure/table,
-/turf/simulated/mineral/floor/ignore_cavegen{
+/turf/simulated/mineral/floor/ignore_cavegen/cave{
 	outdoors = 1
 	},
 /area/gateway/arynthilake)
@@ -1187,7 +1187,7 @@
 /turf/simulated/floor/water,
 /area/gateway/arynthilake/caves)
 "zs" = (
-/turf/simulated/mineral/ignore_cavegen,
+/turf/simulated/mineral/ignore_cavegen/cave,
 /area/gateway/arynthilake/caveruins)
 "zt" = (
 /obj/structure/table/rack,
@@ -1337,7 +1337,7 @@
 /area/gateway/arynthilake)
 "Ev" = (
 /obj/random/mob/semirandom_mob_spawner/monster,
-/turf/simulated/mineral/floor/ignore_cavegen{
+/turf/simulated/mineral/floor/ignore_cavegen/cave{
 	outdoors = 1
 	},
 /area/gateway/arynthilake)
@@ -1472,7 +1472,7 @@
 /turf/simulated/floor/plating/external,
 /area/gateway/arynthilake/caveruins)
 "Hw" = (
-/turf/simulated/mineral/floor/ignore_cavegen,
+/turf/simulated/mineral/floor/ignore_cavegen/cave,
 /area/gateway/arynthilake/caves)
 "HK" = (
 /obj/machinery/light,
@@ -1564,7 +1564,7 @@
 /area/gateway/arynthilake/dome)
 "JB" = (
 /obj/item/weapon/lampshade,
-/turf/simulated/mineral/floor/ignore_cavegen,
+/turf/simulated/mineral/floor/ignore_cavegen/cave,
 /area/gateway/arynthilake/caves)
 "JK" = (
 /obj/structure/table/marble,
@@ -1666,7 +1666,7 @@
 /turf/simulated/floor/outdoors/grass/forest,
 /area/gateway/arynthilake)
 "KQ" = (
-/turf/simulated/mineral/floor/ignore_cavegen{
+/turf/simulated/mineral/floor/ignore_cavegen/cave{
 	outdoors = 1
 	},
 /area/gateway/arynthilake/caves)
@@ -1707,7 +1707,7 @@
 /area/gateway/arynthilake/caveruins)
 "LR" = (
 /obj/random/mob/semirandom_mob_spawner/monster/f,
-/turf/simulated/mineral/floor/ignore_cavegen,
+/turf/simulated/mineral/floor/ignore_cavegen/cave,
 /area/gateway/arynthilake/caves)
 "LY" = (
 /obj/random/mob/semirandom_mob_spawner/animal/retaliate/c,
@@ -1841,7 +1841,7 @@
 /area/gateway/arynthilake/dome)
 "NX" = (
 /obj/random/mob/semirandom_mob_spawner/monster/e,
-/turf/simulated/mineral/floor/ignore_cavegen,
+/turf/simulated/mineral/floor/ignore_cavegen/cave,
 /area/gateway/arynthilake/caves)
 "Ob" = (
 /obj/structure/catwalk,
@@ -2024,7 +2024,7 @@
 /area/gateway/arynthilake/dome)
 "Ry" = (
 /obj/effect/landmark/hidden_level,
-/turf/simulated/mineral/ignore_cavegen,
+/turf/simulated/mineral/ignore_cavegen/cave,
 /area/gateway/arynthilake/caves)
 "RK" = (
 /obj/structure/table/fancyblack,
@@ -2153,7 +2153,7 @@
 /area/gateway/arynthilake/dome)
 "Uq" = (
 /obj/random/mob/semirandom_mob_spawner/monster/b,
-/turf/simulated/mineral/floor/ignore_cavegen,
+/turf/simulated/mineral/floor/ignore_cavegen/cave,
 /area/gateway/arynthilake/caves)
 "UA" = (
 /turf/simulated/wall/sifwood,

--- a/maps/gateway_vr/variable/arynthilakeunderground_a.dmm
+++ b/maps/gateway_vr/variable/arynthilakeunderground_a.dmm
@@ -306,9 +306,7 @@
 /turf/simulated/floor/tiled/eris/steel/techfloor,
 /area/gateway/arynthilake/engine)
 "LF" = (
-/turf/simulated/floor/plating/eris/under{
-	temperature = 258.15
-	},
+/turf/simulated/floor/plating/eris/under,
 /area/gateway/arynthilake/underground/maintenance)
 "LY" = (
 /turf/simulated/floor/beach/sand/desert,

--- a/maps/gateway_vr/variable/arynthilakeunderground_a.dmm
+++ b/maps/gateway_vr/variable/arynthilakeunderground_a.dmm
@@ -44,7 +44,7 @@
 /turf/simulated/floor/tiled/eris/steel/techfloor,
 /area/gateway/arynthilake/engine)
 "gh" = (
-/turf/simulated/mineral/ignore_cavegen,
+/turf/simulated/mineral/ignore_cavegen/cave,
 /area/gateway/arynthilake/underground)
 "hB" = (
 /obj/structure/table/steel_reinforced,
@@ -123,10 +123,10 @@
 /area/gateway/arynthilake/engine)
 "nD" = (
 /obj/effect/landmark/hidden_level,
-/turf/simulated/mineral/ignore_cavegen,
+/turf/simulated/mineral/ignore_cavegen/cave,
 /area/gateway/arynthilake/underground)
 "nO" = (
-/turf/simulated/mineral/floor/ignore_cavegen,
+/turf/simulated/mineral/floor/ignore_cavegen/cave,
 /area/gateway/arynthilake/underground)
 "oM" = (
 /turf/simulated/floor/plating/eris/under,
@@ -157,7 +157,7 @@
 /area/gateway/arynthilake/engine)
 "qU" = (
 /obj/random/awayloot,
-/turf/simulated/mineral/floor/ignore_cavegen,
+/turf/simulated/mineral/floor/ignore_cavegen/cave,
 /area/gateway/arynthilake/underground)
 "qX" = (
 /obj/machinery/porta_turret{
@@ -209,7 +209,7 @@
 /area/gateway/arynthilake/engine)
 "xh" = (
 /obj/machinery/crystal,
-/turf/simulated/mineral/floor/ignore_cavegen,
+/turf/simulated/mineral/floor/ignore_cavegen/cave,
 /area/gateway/arynthilake/underground)
 "zh" = (
 /obj/structure/ladder/up,
@@ -229,7 +229,7 @@
 /area/gateway/arynthilake/engine)
 "Bj" = (
 /obj/random/mob/semirandom_mob_spawner/monster/e,
-/turf/simulated/mineral/floor/ignore_cavegen,
+/turf/simulated/mineral/floor/ignore_cavegen/cave,
 /area/gateway/arynthilake/underground)
 "BJ" = (
 /obj/effect/landmark/gateway_scatter,
@@ -253,7 +253,7 @@
 /area/gateway/arynthilake/engine)
 "Eb" = (
 /obj/random/mob/semirandom_mob_spawner/monster/f,
-/turf/simulated/mineral/floor/ignore_cavegen,
+/turf/simulated/mineral/floor/ignore_cavegen/cave,
 /area/gateway/arynthilake/underground)
 "Ek" = (
 /obj/machinery/light/small{
@@ -381,7 +381,7 @@
 /area/gateway/arynthilake/underground/maintenance)
 "YC" = (
 /obj/random/mob/semirandom_mob_spawner/monster/d,
-/turf/simulated/mineral/floor/ignore_cavegen,
+/turf/simulated/mineral/floor/ignore_cavegen/cave,
 /area/gateway/arynthilake/underground)
 "ZY" = (
 /obj/structure/table/rack/shelf/steel,

--- a/maps/gateway_vr/variable/arynthilakeunderground_b.dmm
+++ b/maps/gateway_vr/variable/arynthilakeunderground_b.dmm
@@ -18,7 +18,7 @@
 /turf/simulated/floor/tiled/eris/steel/orangecorner,
 /area/gateway/arynthilake/engine)
 "bL" = (
-/turf/simulated/mineral/ignore_cavegen,
+/turf/simulated/mineral/ignore_cavegen/cave,
 /area/gateway/arynthilake/underground)
 "bX" = (
 /turf/unsimulated/mineral,
@@ -50,7 +50,7 @@
 /area/gateway/arynthilake/engine)
 "eQ" = (
 /obj/random/awayloot,
-/turf/simulated/mineral/floor/ignore_cavegen,
+/turf/simulated/mineral/floor/ignore_cavegen/cave,
 /area/gateway/arynthilake/underground)
 "fM" = (
 /turf/simulated/floor/tiled/eris/steel/danger,
@@ -105,7 +105,7 @@
 /area/gateway/arynthilake/engine)
 "jX" = (
 /obj/effect/landmark/hidden_level,
-/turf/simulated/mineral/ignore_cavegen,
+/turf/simulated/mineral/ignore_cavegen/cave,
 /area/gateway/arynthilake/underground)
 "kb" = (
 /turf/simulated/wall/r_wall,
@@ -188,11 +188,11 @@
 "vG" = (
 /obj/random/awayloot,
 /obj/random/mob/semirandom_mob_spawner/monster/f,
-/turf/simulated/mineral/floor/ignore_cavegen,
+/turf/simulated/mineral/floor/ignore_cavegen/cave,
 /area/gateway/arynthilake/underground)
 "wg" = (
 /obj/random/mob/semirandom_mob_spawner/monster/e,
-/turf/simulated/mineral/floor/ignore_cavegen,
+/turf/simulated/mineral/floor/ignore_cavegen/cave,
 /area/gateway/arynthilake/underground)
 "wi" = (
 /turf/simulated/wall/r_wall,
@@ -261,7 +261,7 @@
 /turf/simulated/floor/tiled/eris/techmaint,
 /area/gateway/arynthilake/engine)
 "Ff" = (
-/turf/simulated/mineral/floor/ignore_cavegen,
+/turf/simulated/mineral/floor/ignore_cavegen/cave,
 /area/gateway/arynthilake/underground)
 "Fs" = (
 /obj/structure/table/rack/shelf/steel,
@@ -323,7 +323,7 @@
 /area/gateway/arynthilake/underground/maintenance)
 "LR" = (
 /obj/random/mob/semirandom_mob_spawner/monster/f,
-/turf/simulated/mineral/floor/ignore_cavegen,
+/turf/simulated/mineral/floor/ignore_cavegen/cave,
 /area/gateway/arynthilake/underground)
 "LY" = (
 /obj/structure/table/steel_reinforced,
@@ -362,7 +362,7 @@
 /area/gateway/arynthilake/engine)
 "QA" = (
 /obj/machinery/crystal,
-/turf/simulated/mineral/floor/ignore_cavegen,
+/turf/simulated/mineral/floor/ignore_cavegen/cave,
 /area/gateway/arynthilake/underground)
 "QT" = (
 /obj/structure/table/steel_reinforced,
@@ -408,7 +408,7 @@
 /turf/simulated/floor/plating/eris/under,
 /area/gateway/arynthilake/underground/maintenance)
 "Xt" = (
-/turf/simulated/mineral/ignore_cavegen,
+/turf/simulated/mineral/ignore_cavegen/cave,
 /area/gateway/arynthilake/underground/maintenance)
 "Xx" = (
 /obj/structure/table/rack/shelf/steel,

--- a/maps/gateway_vr/variable/honlethhighlands_a.dmm
+++ b/maps/gateway_vr/variable/honlethhighlands_a.dmm
@@ -6,12 +6,12 @@
 	},
 /area/gateway/honlethhighlands)
 "ab" = (
-/turf/simulated/mineral/ignore_cavegen{
+/turf/simulated/mineral/ignore_cavegen/cave{
 	temperature = 253.15
 	},
 /area/gateway/honlethhighlands/caves)
 "ac" = (
-/turf/simulated/mineral/floor/ignore_cavegen{
+/turf/simulated/mineral/floor/ignore_cavegen/cave{
 	temperature = 253.15
 	},
 /area/gateway/honlethhighlands/caves)
@@ -125,7 +125,7 @@
 	},
 /area/gateway/honlethhighlands/caves)
 "aE" = (
-/turf/simulated/mineral/floor/ignore_cavegen{
+/turf/simulated/mineral/floor/ignore_cavegen/cave{
 	name = "dirt";
 	outdoors = 1;
 	temperature = 253.15
@@ -190,7 +190,7 @@
 /area/gateway/honlethhighlands/town/command)
 "aS" = (
 /obj/effect/landmark/gateway_scatter,
-/turf/simulated/mineral/floor/ignore_cavegen{
+/turf/simulated/mineral/floor/ignore_cavegen/cave{
 	temperature = 253.15
 	},
 /area/gateway/honlethhighlands/caves)
@@ -216,7 +216,7 @@
 	},
 /area/gateway/honlethhighlands)
 "aX" = (
-/turf/simulated/mineral/ignore_cavegen{
+/turf/simulated/mineral/ignore_cavegen/cave{
 	temperature = 253.15
 	},
 /area/gateway/honlethhighlands/beach)
@@ -308,7 +308,7 @@
 /area/gateway/honlethhighlands/beach)
 "bp" = (
 /obj/random/mob/semirandom_mob_spawner/animal/retaliate/c,
-/turf/simulated/mineral/floor/ignore_cavegen{
+/turf/simulated/mineral/floor/ignore_cavegen/cave{
 	temperature = 253.15
 	},
 /area/gateway/honlethhighlands/caves)
@@ -513,7 +513,7 @@
 /area/gateway/honlethhighlands/gate)
 "fa" = (
 /obj/random/mob/semirandom_mob_spawner/animal/retaliate/b,
-/turf/simulated/mineral/floor/ignore_cavegen{
+/turf/simulated/mineral/floor/ignore_cavegen/cave{
 	temperature = 253.15
 	},
 /area/gateway/honlethhighlands/caves)
@@ -540,7 +540,7 @@
 /obj/item/stack/material/wood,
 /obj/item/stack/material/wood,
 /obj/item/stack/material/wood,
-/turf/simulated/mineral/floor/ignore_cavegen{
+/turf/simulated/mineral/floor/ignore_cavegen/cave{
 	temperature = 253.15
 	},
 /area/gateway/honlethhighlands/caves)
@@ -665,7 +665,7 @@
 /area/gateway/honlethhighlands)
 "is" = (
 /obj/item/weapon/flame/lighter/random,
-/turf/simulated/mineral/floor/ignore_cavegen{
+/turf/simulated/mineral/floor/ignore_cavegen/cave{
 	temperature = 253.15
 	},
 /area/gateway/honlethhighlands/caves)
@@ -822,7 +822,7 @@
 /area/gateway/honlethhighlands/beach)
 "mG" = (
 /obj/structure/table/bench/wooden,
-/turf/simulated/mineral/floor/ignore_cavegen{
+/turf/simulated/mineral/floor/ignore_cavegen/cave{
 	temperature = 253.15
 	},
 /area/gateway/honlethhighlands/caves)
@@ -945,7 +945,7 @@
 "oe" = (
 /obj/structure/bonfire,
 /obj/random/meat,
-/turf/simulated/mineral/floor/ignore_cavegen{
+/turf/simulated/mineral/floor/ignore_cavegen/cave{
 	temperature = 253.15
 	},
 /area/gateway/honlethhighlands/caves)
@@ -1025,13 +1025,13 @@
 /area/gateway/honlethhighlands/town/engineering)
 "pT" = (
 /obj/effect/landmark/mcguffin_spawner,
-/turf/simulated/mineral/floor/ignore_cavegen{
+/turf/simulated/mineral/floor/ignore_cavegen/cave{
 	temperature = 253.15
 	},
 /area/gateway/honlethhighlands/caves)
 "pX" = (
 /obj/random/maintenance,
-/turf/simulated/mineral/floor/ignore_cavegen{
+/turf/simulated/mineral/floor/ignore_cavegen/cave{
 	temperature = 253.15
 	},
 /area/gateway/honlethhighlands/caves)
@@ -1643,7 +1643,7 @@
 /area/gateway/honlethhighlands/town/xenobio)
 "zE" = (
 /obj/random/junk,
-/turf/simulated/mineral/floor/ignore_cavegen{
+/turf/simulated/mineral/floor/ignore_cavegen/cave{
 	temperature = 253.15
 	},
 /area/gateway/honlethhighlands/caves)
@@ -1721,7 +1721,7 @@
 "AK" = (
 /obj/random/mre,
 /obj/random/mre,
-/turf/simulated/mineral/floor/ignore_cavegen{
+/turf/simulated/mineral/floor/ignore_cavegen/cave{
 	temperature = 253.15
 	},
 /area/gateway/honlethhighlands/caves)
@@ -1968,7 +1968,7 @@
 /area/gateway/honlethhighlands/gate)
 "Et" = (
 /obj/random/mob/semirandom_mob_spawner/animal/retaliate,
-/turf/simulated/mineral/floor/ignore_cavegen{
+/turf/simulated/mineral/floor/ignore_cavegen/cave{
 	temperature = 253.15
 	},
 /area/gateway/honlethhighlands/caves)
@@ -2204,7 +2204,7 @@
 /area/gateway/honlethhighlands/gate)
 "JM" = (
 /obj/random/cigarettes,
-/turf/simulated/mineral/floor/ignore_cavegen{
+/turf/simulated/mineral/floor/ignore_cavegen/cave{
 	temperature = 253.15
 	},
 /area/gateway/honlethhighlands/caves)
@@ -2262,7 +2262,7 @@
 /area/gateway/honlethhighlands/beach)
 "Ld" = (
 /obj/random/awayloot,
-/turf/simulated/mineral/floor/ignore_cavegen{
+/turf/simulated/mineral/floor/ignore_cavegen/cave{
 	temperature = 253.15
 	},
 /area/gateway/honlethhighlands/caves)
@@ -2321,7 +2321,7 @@
 "Ms" = (
 /obj/structure/table/bench/wooden,
 /obj/random/mob/semirandom_mob_spawner/humanoid/retaliate,
-/turf/simulated/mineral/floor/ignore_cavegen{
+/turf/simulated/mineral/floor/ignore_cavegen/cave{
 	temperature = 253.15
 	},
 /area/gateway/honlethhighlands/caves)
@@ -2556,7 +2556,7 @@
 /area/gateway/honlethhighlands/town/command)
 "Ro" = (
 /obj/random/mob/semirandom_mob_spawner/vore/passive/b,
-/turf/simulated/mineral/floor/ignore_cavegen{
+/turf/simulated/mineral/floor/ignore_cavegen/cave{
 	temperature = 253.15
 	},
 /area/gateway/honlethhighlands/caves)
@@ -2910,13 +2910,13 @@
 /area/gateway/honlethhighlands/town/bar)
 "Zw" = (
 /obj/random/mob/semirandom_mob_spawner/vore/passive,
-/turf/simulated/mineral/floor/ignore_cavegen{
+/turf/simulated/mineral/floor/ignore_cavegen/cave{
 	temperature = 253.15
 	},
 /area/gateway/honlethhighlands/caves)
 "Zy" = (
 /obj/random/drinkbottle,
-/turf/simulated/mineral/floor/ignore_cavegen{
+/turf/simulated/mineral/floor/ignore_cavegen/cave{
 	temperature = 253.15
 	},
 /area/gateway/honlethhighlands/caves)

--- a/maps/gateway_vr/variable/honlethhighlands_b.dmm
+++ b/maps/gateway_vr/variable/honlethhighlands_b.dmm
@@ -6,12 +6,12 @@
 	},
 /area/gateway/honlethhighlands)
 "ab" = (
-/turf/simulated/mineral/ignore_cavegen{
+/turf/simulated/mineral/ignore_cavegen/cave{
 	temperature = 253.15
 	},
 /area/gateway/honlethhighlands/caves)
 "ac" = (
-/turf/simulated/mineral/floor/ignore_cavegen{
+/turf/simulated/mineral/floor/ignore_cavegen/cave{
 	temperature = 253.15
 	},
 /area/gateway/honlethhighlands/caves)
@@ -125,7 +125,7 @@
 	},
 /area/gateway/honlethhighlands/caves)
 "aE" = (
-/turf/simulated/mineral/floor/ignore_cavegen{
+/turf/simulated/mineral/floor/ignore_cavegen/cave{
 	name = "dirt";
 	outdoors = 1;
 	temperature = 253.15
@@ -190,7 +190,7 @@
 /area/gateway/honlethhighlands/town/command)
 "aS" = (
 /obj/effect/landmark/gateway_scatter,
-/turf/simulated/mineral/floor/ignore_cavegen{
+/turf/simulated/mineral/floor/ignore_cavegen/cave{
 	temperature = 253.15
 	},
 /area/gateway/honlethhighlands/caves)
@@ -216,7 +216,7 @@
 	},
 /area/gateway/honlethhighlands)
 "aX" = (
-/turf/simulated/mineral/ignore_cavegen{
+/turf/simulated/mineral/ignore_cavegen/cave{
 	temperature = 253.15
 	},
 /area/gateway/honlethhighlands/beach)
@@ -520,7 +520,7 @@
 /obj/item/stack/material/wood,
 /obj/item/stack/material/wood,
 /obj/item/stack/material/wood,
-/turf/simulated/mineral/floor/ignore_cavegen{
+/turf/simulated/mineral/floor/ignore_cavegen/cave{
 	temperature = 253.15
 	},
 /area/gateway/honlethhighlands/caves)
@@ -656,13 +656,13 @@
 /area/gateway/honlethhighlands)
 "is" = (
 /obj/item/weapon/flame/lighter/random,
-/turf/simulated/mineral/floor/ignore_cavegen{
+/turf/simulated/mineral/floor/ignore_cavegen/cave{
 	temperature = 253.15
 	},
 /area/gateway/honlethhighlands/caves)
 "iw" = (
 /obj/random/mob/semirandom_mob_spawner/monster,
-/turf/simulated/mineral/floor/ignore_cavegen{
+/turf/simulated/mineral/floor/ignore_cavegen/cave{
 	temperature = 253.15
 	},
 /area/gateway/honlethhighlands/caves)
@@ -821,7 +821,7 @@
 "mo" = (
 /obj/structure/table/bench/wooden,
 /obj/random/mob/semirandom_mob_spawner/humanoid,
-/turf/simulated/mineral/floor/ignore_cavegen{
+/turf/simulated/mineral/floor/ignore_cavegen/cave{
 	temperature = 253.15
 	},
 /area/gateway/honlethhighlands/caves)
@@ -836,7 +836,7 @@
 /area/gateway/honlethhighlands)
 "mG" = (
 /obj/structure/table/bench/wooden,
-/turf/simulated/mineral/floor/ignore_cavegen{
+/turf/simulated/mineral/floor/ignore_cavegen/cave{
 	temperature = 253.15
 	},
 /area/gateway/honlethhighlands/caves)
@@ -944,7 +944,7 @@
 "oe" = (
 /obj/structure/bonfire,
 /obj/random/meat,
-/turf/simulated/mineral/floor/ignore_cavegen{
+/turf/simulated/mineral/floor/ignore_cavegen/cave{
 	temperature = 253.15
 	},
 /area/gateway/honlethhighlands/caves)
@@ -1033,13 +1033,13 @@
 /area/gateway/honlethhighlands/town/engineering)
 "pR" = (
 /obj/random/mob/semirandom_mob_spawner/monster/c,
-/turf/simulated/mineral/floor/ignore_cavegen{
+/turf/simulated/mineral/floor/ignore_cavegen/cave{
 	temperature = 253.15
 	},
 /area/gateway/honlethhighlands/caves)
 "pT" = (
 /obj/effect/landmark/mcguffin_spawner,
-/turf/simulated/mineral/floor/ignore_cavegen{
+/turf/simulated/mineral/floor/ignore_cavegen/cave{
 	temperature = 253.15
 	},
 /area/gateway/honlethhighlands/caves)
@@ -1155,7 +1155,7 @@
 /area/gateway/honlethhighlands/gate)
 "qO" = (
 /obj/random/mob/semirandom_mob_spawner/monster/f,
-/turf/simulated/mineral/floor/ignore_cavegen{
+/turf/simulated/mineral/floor/ignore_cavegen/cave{
 	temperature = 253.15
 	},
 /area/gateway/honlethhighlands/caves)
@@ -1509,7 +1509,7 @@
 /area/gateway/honlethhighlands/gate)
 "wF" = (
 /obj/random/mob/semirandom_mob_spawner/monster/b,
-/turf/simulated/mineral/floor/ignore_cavegen{
+/turf/simulated/mineral/floor/ignore_cavegen/cave{
 	temperature = 253.15
 	},
 /area/gateway/honlethhighlands/caves)
@@ -1677,7 +1677,7 @@
 /area/gateway/honlethhighlands/town/xenobio)
 "zE" = (
 /obj/random/junk,
-/turf/simulated/mineral/floor/ignore_cavegen{
+/turf/simulated/mineral/floor/ignore_cavegen/cave{
 	temperature = 253.15
 	},
 /area/gateway/honlethhighlands/caves)
@@ -1748,7 +1748,7 @@
 "AK" = (
 /obj/random/mre,
 /obj/random/mre,
-/turf/simulated/mineral/floor/ignore_cavegen{
+/turf/simulated/mineral/floor/ignore_cavegen/cave{
 	temperature = 253.15
 	},
 /area/gateway/honlethhighlands/caves)
@@ -2197,7 +2197,7 @@
 /area/gateway/honlethhighlands/gate)
 "JM" = (
 /obj/random/cigarettes,
-/turf/simulated/mineral/floor/ignore_cavegen{
+/turf/simulated/mineral/floor/ignore_cavegen/cave{
 	temperature = 253.15
 	},
 /area/gateway/honlethhighlands/caves)
@@ -2493,7 +2493,7 @@
 /area/gateway/honlethhighlands/gate)
 "Qm" = (
 /obj/random/mob/semirandom_mob_spawner/monster/e,
-/turf/simulated/mineral/floor/ignore_cavegen{
+/turf/simulated/mineral/floor/ignore_cavegen/cave{
 	temperature = 253.15
 	},
 /area/gateway/honlethhighlands/caves)
@@ -2578,7 +2578,7 @@
 /area/gateway/honlethhighlands/town/command)
 "Ro" = (
 /obj/random/mob/semirandom_mob_spawner/monster/d,
-/turf/simulated/mineral/floor/ignore_cavegen{
+/turf/simulated/mineral/floor/ignore_cavegen/cave{
 	temperature = 253.15
 	},
 /area/gateway/honlethhighlands/caves)
@@ -2634,7 +2634,7 @@
 /area/gateway/honlethhighlands/town/supply)
 "Td" = (
 /obj/random/awayloot,
-/turf/simulated/mineral/floor/ignore_cavegen{
+/turf/simulated/mineral/floor/ignore_cavegen/cave{
 	temperature = 253.15
 	},
 /area/gateway/honlethhighlands/caves)
@@ -2887,7 +2887,7 @@
 /area/gateway/honlethhighlands/town/command)
 "WQ" = (
 /obj/random/mob/semirandom_mob_spawner/humanoid,
-/turf/simulated/mineral/floor/ignore_cavegen{
+/turf/simulated/mineral/floor/ignore_cavegen/cave{
 	temperature = 253.15
 	},
 /area/gateway/honlethhighlands/caves)
@@ -2959,7 +2959,7 @@
 /area/gateway/honlethhighlands/town/bar)
 "Zy" = (
 /obj/random/drinkbottle,
-/turf/simulated/mineral/floor/ignore_cavegen{
+/turf/simulated/mineral/floor/ignore_cavegen/cave{
 	temperature = 253.15
 	},
 /area/gateway/honlethhighlands/caves)

--- a/maps/gateway_vr/wildwest.dmm
+++ b/maps/gateway_vr/wildwest.dmm
@@ -98,11 +98,6 @@
 	},
 /turf/space,
 /area/space)
-"ar" = (
-/obj/structure/lattice,
-/obj/structure/lattice,
-/turf/space,
-/area/space)
 "as" = (
 /obj/effect/gateway,
 /turf/simulated/floor/cult,
@@ -2420,7 +2415,7 @@ af
 af
 af
 af
-ar
+af
 af
 af
 af
@@ -7260,7 +7255,7 @@ fH
 gF
 cx
 aD
-ar
+af
 af
 ia
 ia
@@ -7543,7 +7538,7 @@ af
 af
 af
 af
-ar
+af
 ad
 fM
 nd
@@ -7671,7 +7666,7 @@ ia
 ia
 ia
 af
-ar
+af
 af
 af
 af


### PR DESCRIPTION
Specifically Arynthi Lake and Honleth Highlands. Both actively used a lot of subtypes of 'default' mineral turfs, which are vacuum. This adds a /cave subtype of ignore_cavegen mineral turfs that has air atmos and replaces all turfs on those two gateway maps and their variations with such. I dunno if other maps have similar issue or not, but active edges dont seem to be popping up on them so gonna leave alone for now. Does not affect temperature thing of Honleth Highlands.

Fixes some tiles in wild west having double lattice spawns

Fixes listening post's entrance having non-vacuum tiles of floor