### PR TITLE
Minor name change to pineapple ring

### DIFF
--- a/code/modules/food/food/snacks.dm
+++ b/code/modules/food/food/snacks.dm
@@ -4959,7 +4959,7 @@
 	reagents.add_reagent("protein",5)
 
 /obj/item/weapon/reagent_containers/food/snacks/pineapple_ring
-	name = "pineapple ring"
+	name = "pineapple rings"
 	desc = "So retro."
 	icon_state = "pineapple_ring"
 	nutriment_desc = list("sweetness" = 2)


### PR DESCRIPTION
Renames "pineapple ring" to "pineapple rings", as sprite implies its a stack of pineapple rings.

Technically Fixes #9954, since I'm certain that only one stack being produced from a single pinapple is fully intentional.