### PR TITLE
Enables persistance on all z-levels that have persistance flag, not just station ones

### DIFF
--- a/code/controllers/subsystems/persistence.dm
+++ b/code/controllers/subsystems/persistence.dm
@@ -4,7 +4,7 @@ SUBSYSTEM_DEF(persistence)
 	flags = SS_NO_FIRE
 	var/list/tracking_values = list()
 	var/list/persistence_datums = list()
-	
+
 	/// Places our subsystem can spawn paintings (helps with art spawning differently across maps)
 	var/list/obj/structure/sign/painting/painting_frames = list()
 	var/list/all_paintings = list()
@@ -34,10 +34,6 @@ SUBSYSTEM_DEF(persistence)
 
 	var/area/A = get_area(T)
 	if(!A || (A.flags & AREA_FLAG_IS_NOT_PERSISTENT))
-		return
-
-//	if((!T.z in GLOB.using_map.station_levels) || !initialized)
-	if(!(T.z in using_map.station_levels))
 		return
 
 	if(!(T.z in using_map.persist_levels))

--- a/code/modules/persistence/datum/persistence_datum.dm
+++ b/code/modules/persistence/datum/persistence_datum.dm
@@ -71,7 +71,7 @@
 				return
 
 		var/_z = token["z"]
-		if(_z in using_map.station_levels)
+		if(_z in using_map.persist_levels)
 			. = GetValidTurf(locate(token["x"], token["y"], _z), token)
 			if(.)
 				CreateEntryInstance(., token)
@@ -82,7 +82,7 @@
 	if(GetEntryAge(entry) >= entries_expire_at)
 		return FALSE
 	var/turf/T = get_turf(entry)
-	if(!T || !(T.z in using_map.station_levels) )
+	if(!T || !(T.z in using_map.persist_levels) )
 		return FALSE
 	var/area/A = get_area(T)
 	if(!A || (A.flags & AREA_FLAG_IS_NOT_PERSISTENT))
@@ -104,7 +104,7 @@
 /datum/persistent/proc/Shutdown()
 	if(fexists(filename))
 		fdel(filename)
-	
+
 	var/list/to_store = list()
 	for(var/thing in SSpersistence.tracking_values[type])
 		if(!IsValidEntry(thing))
@@ -121,10 +121,10 @@
 	var/list/my_tracks = SSpersistence.tracking_values[type]
 	if(!my_tracks?.len)
 		return
-	
+
 	. = list("<tr><td colspan = 4><b>[capitalize(name)]</b></td></tr>")
 	. += "<tr><td colspan = 4><hr></td></tr>"
-	
+
 	for(var/thing in my_tracks)
 		. += "<tr>[GetAdminDataStringFor(thing, can_modify, user)]</tr>"
 	. += "<tr><td colspan = 4><hr></td></tr>"


### PR DESCRIPTION
Hopefully Fixes #11436 and Fixes #11626. I lack the mean to really exhaustively test this at the moment, but this absolutely should have no effect on normal station's persistence while hopefully enabling persistence on levels that have flag for it, but don't have station flag.