### PR TITLE
Some scoopy holder nom tweaks

### DIFF
--- a/code/modules/mob/holder.dm
+++ b/code/modules/mob/holder.dm
@@ -28,20 +28,29 @@ var/list/holder_mob_icon_cache = list()
 /obj/item/weapon/holder/Initialize(mapload, mob/held)
 	ASSERT(ismob(held))
 	. = ..()
+	held.forceMove(src)
+	START_PROCESSING(SSobj, src)
+
+/obj/item/weapon/holder/Entered(mob/held, atom/OldLoc)
+	if(held_mob)
+		held.forceMove(get_turf(src))
+		return
+	ASSERT(ismob(held))
+	. = ..()
 	held_mob = held
 	original_vis_flags = held.vis_flags
 	held.vis_flags = VIS_INHERIT_ID|VIS_INHERIT_LAYER|VIS_INHERIT_PLANE
-
-	held.forceMove(src)
 	vis_contents += held
 	name = held.name
 	original_transform = held.transform
 	held.transform = null
 
-	// I really hate this, but I'm sleepy and unable to figure out a nice stateful way to do it
-	// Entered and Exited seem ideal but all the inventory procs are trash and put items on
-	// turfs before you when manhandling things in/out of backpacks and inventory slots.
-	START_PROCESSING(SSobj, src)
+/obj/item/weapon/holder/Exited(atom/movable/thing, atom/OldLoc)
+	if(thing == held_mob)
+		held_mob.transform = original_transform
+		held_mob.vis_flags = original_vis_flags
+		held_mob = null
+	..()
 
 /obj/item/weapon/holder/Destroy()
 	STOP_PROCESSING(SSobj, src)

--- a/code/modules/vore/eating/living_vr.dm
+++ b/code/modules/vore/eating/living_vr.dm
@@ -143,9 +143,7 @@
 		if(is_vore_predator(src))
 			for(var/mob/living/M in H.contents)
 				if(attacker.eat_held_mob(attacker, M, src))
-					if(H.held_mob == M)
-						H.held_mob = null
-			return TRUE //return TRUE to exit upper procs
+					return TRUE //return TRUE to exit upper procs
 		else
 			log_debug("[attacker] attempted to feed [H.contents] to [src] ([type]) but it failed.")
 
@@ -518,7 +516,16 @@
 	user.visible_message(success_msg)
 
 	// Actually shove prey into the belly.
-	belly.nom_mob(prey, user)
+	if(istype(prey.loc, /obj/item/weapon/holder))
+		var/obj/item/weapon/holder/H = prey.loc
+		for(var/mob/living/M in H.contents)
+			belly.nom_mob(M, user)
+			if(M.loc == H) // In case nom_mob failed somehow.
+				M.forceMove(get_turf(src))
+		H.held_mob = null
+		qdel(H)
+	else
+		belly.nom_mob(prey, user)
 	if(!ishuman(user))
 		user.update_icons()
 


### PR DESCRIPTION
Moves the part of the code handling the holder things on scooped up snacking to where the actual snacking happens, and also clears and deletes the holder afterward.
Also contains checks to make sure any undeclared stowaways in holder contents also get eaten (or dumped on the ground if that somehow fails) instead of getting deleted with the holder. Probably fixes a lag or garbage collection jank bug that sometimes makes the holder dump the prey back on ground after they've already been eaten, and also fixes the thing with the holder item still lingering in hand for the entire process cycle duration after the prey has already been eaten.
Also makes holders use Entered/Exited to do their things with the contained mob to make them function more reliably. (now makes sure only one mob can enter a holder, and now also clears the held_mob var and returns the held mob's transform appearance back to the mob without requiring the ground dump proc, which probably also fixes the thing with eaten held mobs sometimes getting released with messed up scaling etc)
Tested working nicely.