### PR TITLE
Fixes simplemobs appearing misleadingly starved

### DIFF
--- a/code/modules/mob/living/simple_mob/life.dm
+++ b/code/modules/mob/living/simple_mob/life.dm
@@ -55,7 +55,7 @@
 			healths.icon_state = "health7"
 
 	//Updates the nutrition while we're here
-	var/food_per = (nutrition / max_nutrition) * 100
+	var/food_per = (nutrition / 500) * 100 //VOREStation Edit: Bandaid hardcode number to avoid misleading percentage based hunger alerts with our 6k cap.
 	switch(food_per)
 		if(90 to INFINITY)
 			clear_alert("nutrition")


### PR DESCRIPTION
Changed the simplemob nutrition alert percentage math to use the polaris cap (grey nutrition) rather than our 6k voreblob cap, so a decently fed simplemob won't hud alert starvation just because their nutrition level happens to be far from the absolute max cap.