### PR TITLE
More appropriate stack digestion

### DIFF
--- a/code/modules/vore/eating/digest_act_vr.dm
+++ b/code/modules/vore/eating/digest_act_vr.dm
@@ -49,6 +49,13 @@
 					qdel(O)
 			else if(item_storage)
 				O.forceMove(item_storage)
+		if(istype(src,/obj/item/stack))
+			var/obj/item/stack/S = src
+			if(S.amount <= 1)
+				qdel(src)
+			else
+				S.amount--
+				digest_stage = w_class
 		qdel(src)
 	if(g_damage > w_class)
 		return w_class

--- a/code/modules/vore/eating/digest_act_vr.dm
+++ b/code/modules/vore/eating/digest_act_vr.dm
@@ -56,7 +56,8 @@
 			else
 				S.amount--
 				digest_stage = w_class
-		qdel(src)
+		else
+			qdel(src)
 	if(g_damage > w_class)
 		return w_class
 	return g_damage

--- a/code/modules/vore/eating/digest_act_vr.dm
+++ b/code/modules/vore/eating/digest_act_vr.dm
@@ -51,10 +51,10 @@
 				O.forceMove(item_storage)
 		if(istype(src,/obj/item/stack))
 			var/obj/item/stack/S = src
-			if(S.amount <= 1)
+			if(S.get_amount() <= 1)
 				qdel(src)
 			else
-				S.amount--
+				S.use(1)
 				digest_stage = w_class
 		else
 			qdel(src)


### PR DESCRIPTION
Makes digested stack items use one sheet/piece/whatever when digested and resets the stack item "health" for the digestion process to rinse and repeat until the stack is depleted rather than deleting it as a single sheet size food item regardless of the stack amount.