### PR TITLE
Remove pkg-config:i386 from build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
         run: |
           sudo dpkg --add-architecture i386
           sudo apt update || true
-          sudo apt install zlib1g-dev:i386 libssl-dev:i386 pkg-config:i386
+          sudo apt install zlib1g-dev:i386 libssl-dev:i386
           ldd librust_g.so
       - name: Unit Tests
         run: |


### PR DESCRIPTION
Ubuntu (or perhaps GitHub's image of Ubuntu 20.04) messed up the deps for pkg-config:i386 (namely libglib2.0.0:i386). pkg-config:i386 doesn't appear to actually be required for rust though, so unsure why it was in this CI.