### PR TITLE
add Hunterbirk to Protean whitelist

### DIFF
--- a/config/alienwhitelist.txt
+++ b/config/alienwhitelist.txt
@@ -32,6 +32,7 @@ h0lysquirr3l - Protean
 hawkerthegreat - Vox
 hollifex - Diona
 huenererschrecker - Xenochimera
+hunterbirk - Protean
 hunterbirk - Xenochimera
 idcaboutaname - Protean
 inuzari - Diona


### PR DESCRIPTION
adds Protean as a playable character by ckey Hunterbirk.

Whitelist application is approved as seen here:
https://forum.vore-station.net/viewtopic.php?f=45&t=2068