### PR TITLE
v2 science outpost rework

### DIFF
--- a/maps/expedition_vr/aerostat/_aerostat_science_outpost.dm
+++ b/maps/expedition_vr/aerostat/_aerostat_science_outpost.dm
@@ -280,6 +280,14 @@ VIRGO2_TURF_CREATE(/turf/simulated/floor/hull)
 	name = "Firing Range"
 	icon_state = "orawhisqu"
 
+/area/offmap/aerostat/inside/miscstorage
+	name = "Miscellaneous Storage"
+	icon_state = "orawhisqu"
+
+/area/offmap/aerostat/inside/virology
+	name = "Virology Lab"
+	icon_state = "yelwhicir"
+
 /area/offmap/aerostat/inside/south
 	name = "Miscellaneous Labs A"
 	icon_state = "blublasqu"

--- a/maps/expedition_vr/aerostat/aerostat_science_outpost.dmm
+++ b/maps/expedition_vr/aerostat/aerostat_science_outpost.dmm
@@ -22,18 +22,6 @@
 "ac" = (
 /turf/simulated/shuttle/wall/voidcraft/green/virgo2,
 /area/offmap/aerostat/inside/arm/nw)
-"ad" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/glass,
-/turf/simulated/floor/plating/virgo2,
-/area/offmap/aerostat/inside/northchamb)
 "ae" = (
 /obj/effect/floor_decal/industrial/warning/dust{
 	dir = 9
@@ -52,12 +40,6 @@
 	},
 /turf/simulated/floor/plating/virgo2,
 /area/offmap/aerostat/solars)
-"ag" = (
-/obj/structure/window/reinforced/full,
-/obj/structure/grille,
-/obj/machinery/door/firedoor/glass,
-/turf/simulated/floor,
-/area/offmap/aerostat/inside/toxins)
 "ah" = (
 /obj/structure/table/reinforced,
 /obj/machinery/recharger/wallcharger{
@@ -74,13 +56,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/firingrange)
-"ai" = (
-/obj/machinery/door/firedoor/glass,
-/obj/structure/window/reinforced/full,
-/obj/structure/grille,
-/obj/machinery/atmospherics/pipe/simple/hidden/green,
-/turf/simulated/floor,
-/area/offmap/aerostat/inside/toxins)
 "aj" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	id_tag = "anomaly_airlock_pump";
@@ -111,18 +86,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/airlock/south)
-"am" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/machinery/door/firedoor/glass,
-/obj/machinery/door/blast/shutters{
-	dir = 2;
-	id = "zorrenpartyroom";
-	layer = 3.3;
-	name = "shutter"
-	},
-/turf/simulated/floor/plating/virgo2,
-/area/offmap/aerostat/inside/zorrenoffice)
 "an" = (
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	dir = 5
@@ -232,6 +195,15 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/offmap/aerostat/inside/xenoarch)
+"aA" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/genetics)
 "aB" = (
 /obj/effect/floor_decal/rust,
 /obj/effect/floor_decal/industrial/warning/dust{
@@ -253,11 +225,11 @@
 /turf/simulated/floor,
 /area/offmap/aerostat/inside/airlock/west)
 "aF" = (
-/obj/machinery/atmospherics/unary/heat_exchanger,
-/obj/structure/window/basic,
-/obj/effect/floor_decal/corner/red/border,
-/turf/simulated/floor/tiled/steel_ridged,
-/area/offmap/aerostat/inside/toxins)
+/obj/machinery/atmospherics/unary/freezer{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/offmap/aerostat/inside/northchamb)
 "aG" = (
 /obj/machinery/power/solar,
 /obj/effect/floor_decal/rust,
@@ -266,11 +238,14 @@
 	},
 /turf/simulated/floor/plating/virgo2,
 /area/offmap/aerostat/solars)
-"aH" = (
-/turf/simulated/wall,
-/area/offmap/aerostat/inside/misclab)
 "aI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/blue,
+/obj/structure/bed/chair/office/light{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/toxins)
 "aJ" = (
@@ -293,6 +268,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
+/obj/structure/table/wooden_reinforced,
 /turf/simulated/floor/plating/virgo2,
 /area/offmap/aerostat/solars)
 "aN" = (
@@ -455,7 +431,10 @@
 /turf/simulated/floor/tiled/steel_ridged,
 /area/offmap/aerostat/inside/airlock/north)
 "bj" = (
-/obj/effect/floor_decal/industrial/warning/dust,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/sign/painting/public{
+	pixel_x = 30
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/northchamb)
 "bk" = (
@@ -491,16 +470,6 @@
 	},
 /turf/simulated/floor,
 /area/offmap/aerostat/inside/airlock/north)
-"bm" = (
-/obj/structure/cable/heavyduty{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/offmap/aerostat/inside/firingrange)
 "bn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
@@ -534,14 +503,12 @@
 /turf/simulated/floor/tiled/steel_ridged,
 /area/offmap/aerostat/inside/airlock/north)
 "bq" = (
-/obj/effect/floor_decal/industrial/warning/dust{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/vending/fitness{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/northchamb)
@@ -595,11 +562,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/atmos)
-"bx" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/table/reinforced,
-/turf/simulated/floor/tiled/white,
-/area/offmap/aerostat/inside/firingrange)
 "bz" = (
 /obj/structure/cable/heavyduty{
 	icon_state = "1-2"
@@ -623,9 +585,6 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/atmos)
 "bC" = (
-/obj/machinery/door/airlock/glass_research{
-	name = "Toxins Lab"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/green{
 	dir = 4
 	},
@@ -633,24 +592,27 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor/glass,
-/turf/simulated/floor/tiled/steel_ridged,
-/area/offmap/aerostat/inside/toxins)
+/turf/simulated/wall,
+/area/offmap/aerostat/inside/xenoarch)
 "bE" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 1
 	},
 /turf/simulated/wall/r_wall,
 /area/offmap/aerostat/inside/xenoarch)
+"bF" = (
+/obj/structure/bed/chair/comfy/black,
+/turf/simulated/floor/tiled/techfloor,
+/area/offmap/aerostat/inside/southchamb)
 "bG" = (
-/obj/structure/table/standard,
-/obj/item/stack/cable_coil,
-/obj/item/weapon/tool/wirecutters,
-/obj/item/stack/cable_coil,
-/obj/machinery/atmospherics/unary/vent_pump/on{
+/obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/item/weapon/tank/phoron,
+/obj/machinery/portable_atmospherics/canister/empty,
+/obj/machinery/door/window/brigdoor/eastleft{
+	dir = 2;
+	req_access = list(7)
+	},
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/toxins)
 "bI" = (
@@ -714,15 +676,11 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/northchamb)
-"bO" = (
-/obj/structure/cable/heavyduty{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/turf/simulated/floor/tiled/white,
-/area/offmap/aerostat/inside/firingrange)
 "bP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/red,
 /obj/machinery/meter,
@@ -734,11 +692,8 @@
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/toxins)
 "bR" = (
-/obj/machinery/atmospherics/pipe/simple/visible/red{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/toxins)
@@ -750,20 +705,6 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled/dark,
-/area/offmap/aerostat/inside/xenoarch)
-"bT" = (
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/warning,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/machinery/alarm{
-	dir = 4;
-	pixel_x = -23
-	},
-/turf/simulated/floor,
 /area/offmap/aerostat/inside/xenoarch)
 "bU" = (
 /obj/effect/floor_decal/industrial/warning/dust{
@@ -779,7 +720,7 @@
 	dir = 4
 	},
 /turf/simulated/wall,
-/area/offmap/aerostat/inside/toxins)
+/area/offmap/aerostat/inside/xenoarch)
 "bW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/green{
 	dir = 9
@@ -826,6 +767,12 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/northchamb)
+"ci" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/offmap/aerostat/inside/northchamb)
 "cj" = (
 /obj/structure/closet/emcloset,
 /turf/simulated/shuttle/floor/yellow,
@@ -865,7 +812,6 @@
 /obj/structure/cable/heavyduty{
 	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/westhall)
 "cp" = (
@@ -884,6 +830,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/easthall)
 "cr" = (
@@ -903,6 +852,12 @@
 	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/offmap/aerostat/inside/xenoarch)
+"cs" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/miscstorage)
 "ct" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1380;
@@ -972,14 +927,12 @@
 /turf/simulated/floor/plating/virgo2,
 /area/offmap/aerostat/inside/arm/nw)
 "cz" = (
-/obj/machinery/light{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
+	dir = 9
 	},
+/obj/structure/closet/wardrobe/genetics_white,
 /turf/simulated/floor/tiled/white,
-/area/offmap/aerostat/inside/misclab)
+/area/offmap/aerostat/inside/genetics)
 "cA" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/green,
 /turf/simulated/floor/tiled/techfloor,
@@ -997,6 +950,12 @@
 /obj/machinery/meter,
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/atmos)
+"cD" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/virology)
 "cE" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/black,
 /turf/simulated/floor/tiled/techfloor,
@@ -1005,8 +964,19 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
 	dir = 6
 	},
+/obj/machinery/light,
 /turf/simulated/floor/tiled/techfloor,
-/area/offmap/aerostat/inside/northchamb)
+/area/offmap/aerostat/inside/atmos)
+"cG" = (
+/obj/machinery/light/floortube{
+	dir = 4;
+	pixel_x = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/toxins)
 "cI" = (
 /obj/effect/floor_decal/industrial/warning/dust{
 	dir = 1
@@ -1043,6 +1013,20 @@
 	},
 /turf/simulated/floor,
 /area/offmap/aerostat/inside/arm/sw)
+"cM" = (
+/obj/structure/table/reinforced,
+/obj/item/weapon/storage/lockbox/vials,
+/obj/item/weapon/storage/fancy/vials,
+/obj/item/weapon/reagent_containers/syringe/antiviral,
+/obj/item/weapon/reagent_containers/syringe/antiviral,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/virology)
 "cO" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
@@ -1070,6 +1054,12 @@
 	},
 /turf/simulated/floor/bluegrid,
 /area/offmap/aerostat/inside/powercontrol)
+"cQ" = (
+/obj/structure/dispenser{
+	phorontanks = 0
+	},
+/turf/simulated/floor/tiled,
+/area/offmap/aerostat/inside/drillstorage)
 "cR" = (
 /obj/structure/bed/chair/sofa/purp/left,
 /obj/structure/sign/painting/public{
@@ -1077,6 +1067,10 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/offmap/aerostat/inside/lobby)
+"cT" = (
+/obj/machinery/smartfridge/chemistry/virology,
+/turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/virology)
 "cU" = (
 /turf/simulated/shuttle/wall/voidcraft/green/virgo2,
 /area/offmap/aerostat/inside/arm/sw)
@@ -1096,11 +1090,14 @@
 /turf/simulated/floor/tiled/dark,
 /area/offmap/aerostat/inside/xenoarch/chamber)
 "cX" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/northchamb)
@@ -1326,6 +1323,19 @@
 	},
 /turf/simulated/floor,
 /area/offmap/aerostat/inside/arm/ne)
+"dz" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/window/basic,
+/obj/structure/window/basic{
+	dir = 8
+	},
+/obj/machinery/atmospherics/unary/heat_exchanger,
+/obj/effect/floor_decal/corner/red/border{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/red/border,
+/turf/simulated/floor/tiled/steel_ridged,
+/area/offmap/aerostat/inside/toxins)
 "dA" = (
 /obj/effect/floor_decal/rust,
 /obj/effect/decal/cleanable/blood,
@@ -1389,8 +1399,24 @@
 /area/offmap/aerostat/solars)
 "dH" = (
 /obj/structure/table/standard,
+/obj/item/weapon/storage/backpack/parachute{
+	pixel_x = 6;
+	pixel_y = -6
+	},
+/obj/item/weapon/storage/backpack/parachute{
+	pixel_x = -6;
+	pixel_y = -6
+	},
+/obj/item/weapon/storage/backpack/parachute{
+	pixel_x = 6;
+	pixel_y = 6
+	},
+/obj/item/weapon/storage/backpack/parachute{
+	pixel_x = -6;
+	pixel_y = 6
+	},
 /turf/simulated/floor/tiled/white,
-/area/offmap/aerostat/inside/telesci)
+/area/offmap/aerostat/inside/miscstorage)
 "dI" = (
 /obj/machinery/power/solar,
 /obj/effect/floor_decal/industrial/warning/dust,
@@ -1554,12 +1580,8 @@
 /turf/simulated/floor,
 /area/offmap/aerostat/inside/arm/nw)
 "dY" = (
-/obj/effect/floor_decal/industrial/warning/dust{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/techfloor,
-/area/offmap/aerostat/inside/northchamb)
+/turf/simulated/shuttle/wall/voidcraft/green,
+/area/offmap/aerostat/inside/atmos)
 "dZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/structure/cable{
@@ -1598,6 +1620,8 @@
 /area/offmap/aerostat/inside/airlock/east)
 "ed" = (
 /obj/machinery/light,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/mining/brace,
 /turf/simulated/floor/tiled,
 /area/offmap/aerostat/inside/drillstorage)
 "ef" = (
@@ -1605,7 +1629,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
-/area/offmap/aerostat/inside/genetics)
+/area/offmap/aerostat/inside/misclab)
 "ei" = (
 /obj/effect/floor_decal/rust,
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
@@ -1623,39 +1647,55 @@
 /turf/simulated/shuttle/wall/voidcraft/green,
 /area/offmap/aerostat/inside/easthall)
 "el" = (
-/obj/machinery/atmospherics/portables_connector{
+/obj/machinery/atmospherics/pipe/tank/phoron{
 	dir = 8
 	},
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 23
-	},
 /turf/simulated/floor/tiled/techfloor,
-/area/offmap/aerostat/inside/northchamb)
+/area/offmap/aerostat/inside/atmos)
 "er" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/southchamb)
+"ev" = (
+/obj/structure/table/reinforced,
+/obj/item/weapon/storage/box/monkeycubes,
+/obj/item/weapon/storage/box/monkeycubes/wolpincubes,
+/obj/machinery/light,
+/turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/virology)
 "ey" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden{
-	dir = 8
-	},
 /turf/simulated/floor/tiled,
-/area/offmap/aerostat/inside/genetics)
+/area/offmap/aerostat/inside/misclab)
 "ez" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/green{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/turf/simulated/wall,
+/area/offmap/aerostat/inside/xenoarch)
+"eA" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/wall,
-/area/offmap/aerostat/inside/toxins)
+/obj/machinery/light/floortube{
+	dir = 4;
+	pixel_x = 5
+	},
+/turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/firingrange)
 "eE" = (
 /obj/structure/bed/chair/sofa/purp/right,
 /obj/structure/sign/painting/public{
@@ -1680,6 +1720,12 @@
 	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/offmap/aerostat/inside/xenoarch)
+"eJ" = (
+/obj/structure/bed/chair/comfy/black{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/offmap/aerostat/inside/southchamb)
 "eL" = (
 /obj/effect/floor_decal/rust,
 /obj/structure/cable/yellow{
@@ -1689,37 +1735,45 @@
 /turf/simulated/floor/plating/virgo2,
 /area/offmap/aerostat/solars)
 "eM" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/black{
-	dir = 5
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/black,
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/techfloor,
-/area/offmap/aerostat/inside/northchamb)
+/area/offmap/aerostat/inside/atmos)
 "eN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/wall,
 /area/offmap/aerostat/inside/firingrange)
 "eO" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/black{
-	dir = 1
+/obj/machinery/atmospherics/pipe/manifold/hidden/red{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor,
-/area/offmap/aerostat/inside/northchamb)
+/area/offmap/aerostat/inside/atmos)
 "eP" = (
 /obj/machinery/camera/network/research_outpost{
 	dir = 4
 	},
-/obj/structure/flora/pottedplant/unusual,
+/obj/structure/bed/chair/sofa/purp/left{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark,
 /area/offmap/aerostat/inside/lobby)
 "eR" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/black{
+/obj/machinery/atmospherics/pipe/simple/hidden/green{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/white,
-/area/offmap/aerostat/inside/toxins)
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/glass_research{
+	name = "Xenoarchaeology Storage"
+	},
+/turf/simulated/floor/tiled/steel_ridged,
+/area/offmap/aerostat/inside/xenoarch)
 "eT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -1731,9 +1785,11 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/xenoarch)
@@ -1741,24 +1797,23 @@
 /obj/structure/sign/painting/public{
 	pixel_x = -30
 	},
+/obj/structure/bed/chair/sofa/purp/right{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark,
 /area/offmap/aerostat/inside/lobby)
 "eW" = (
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/southchamb)
 "eX" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/black{
-	dir = 10
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/black,
 /turf/simulated/floor/tiled/techfloor,
-/area/offmap/aerostat/inside/northchamb)
+/area/offmap/aerostat/inside/atmos)
 "eZ" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden{
-	dir = 8
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/xenoarch)
 "fa" = (
@@ -1771,6 +1826,14 @@
 /area/offmap/aerostat/inside/airlock/east)
 "fb" = (
 /turf/simulated/shuttle/wall/voidcraft/green/virgo2,
+/area/offmap/aerostat/inside/arm/ne)
+"fc" = (
+/obj/structure/cable/heavyduty{
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/rust,
+/obj/effect/decal/cleanable/blood/oil,
+/turf/simulated/floor,
 /area/offmap/aerostat/inside/arm/ne)
 "fe" = (
 /obj/effect/decal/cleanable/cobweb2,
@@ -1791,8 +1854,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
 	dir = 4
 	},
+/obj/machinery/light,
 /turf/simulated/floor/tiled/techfloor,
-/area/offmap/aerostat/inside/northchamb)
+/area/offmap/aerostat/inside/atmos)
 "fg" = (
 /obj/effect/floor_decal/rust,
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
@@ -1804,18 +1868,37 @@
 /turf/simulated/floor/plating/virgo2,
 /area/offmap/aerostat/solars)
 "fh" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/green{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/white,
-/area/offmap/aerostat/inside/toxins)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/turf/simulated/wall,
+/area/offmap/aerostat/inside/xenoarch)
 "fi" = (
-/obj/structure/table/standard,
-/obj/machinery/computer/atmoscontrol/laptop{
-	monitored_alarm_ids = list("anomaly_testing");
-	req_one_access = list(47,24,11)
+/obj/machinery/atmospherics/pipe/simple/hidden/green{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/white,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/simulated/wall,
 /area/offmap/aerostat/inside/xenoarch)
 "fj" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden{
@@ -1834,35 +1917,41 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/airlock/north)
 "fn" = (
-/obj/structure/bed/chair/office/light{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/wall,
 /area/offmap/aerostat/inside/xenoarch)
 "fo" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 5
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
-/area/offmap/aerostat/inside/genetics)
+/area/offmap/aerostat/inside/misclab)
 "fp" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor/glass,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/easthall)
+"fr" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/offmap/aerostat/inside/drillstorage)
 "ft" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/machinery/vending/sovietsoda{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -1878,16 +1967,16 @@
 /area/offmap/aerostat/inside/southchamb)
 "fx" = (
 /obj/structure/bed/chair/office/light{
-	dir = 4
+	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/firingrange)
-"fA" = (
-/obj/machinery/light/small{
-	dir = 1
+"fC" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
-/area/offmap/aerostat/inside/xenoarch)
+/turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/toxins)
 "fD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/green,
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
@@ -1909,6 +1998,9 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/atmos)
 "fI" = (
@@ -1924,11 +2016,11 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/easthall)
 "fJ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
 	},
 /obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/white,
@@ -1958,20 +2050,22 @@
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating/virgo2,
 /area/offmap/aerostat/inside/arm/nw)
+"fP" = (
+/obj/structure/bed/chair/comfy/black{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/offmap/aerostat/inside/southchamb)
 "fQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/wall,
 /area/offmap/aerostat/inside/toxins)
 "fR" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/light_switch{
-	pixel_y = 24
-	},
-/turf/simulated/floor/tiled/white,
-/area/offmap/aerostat/inside/firingrange)
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/portable_atmospherics/powered/scrubber,
+/turf/simulated/floor/plating,
+/area/offmap/aerostat/inside/toxins)
 "fS" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
@@ -1986,11 +2080,18 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/machinery/chem_master,
+/obj/machinery/camera/network/research_outpost{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/xenoarch)
 "fV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/simulated/wall,
 /area/offmap/aerostat/inside/atmos)
@@ -2004,13 +2105,26 @@
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/plating/virgo2,
 /area/offmap/aerostat/inside/airlock/north)
+"fX" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/window/reinforced/full,
+/obj/structure/grille,
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/virology)
 "fY" = (
 /obj/structure/cable/heavyduty{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/turf/simulated/floor/tiled/white,
-/area/offmap/aerostat/inside/xenoarch)
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 4
+	},
+/obj/effect/floor_decal/rust,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor,
+/area/offmap/aerostat/inside/arm/ne)
 "ga" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -2018,6 +2132,10 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/xenoarch)
+"gb" = (
+/obj/machinery/computer/centrifuge,
+/turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/virology)
 "gd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 1
@@ -2037,7 +2155,7 @@
 /turf/simulated/shuttle/wall/voidcraft/hard_corner{
 	stripe_color = "#00FF00"
 	},
-/area/offmap/aerostat/inside/genetics)
+/area/offmap/aerostat/inside/westhall)
 "gh" = (
 /obj/machinery/atmospherics/binary/pump/on{
 	dir = 1
@@ -2058,8 +2176,23 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 5
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/northchamb)
+"gl" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/simulated/wall,
+/area/offmap/aerostat/inside/miscstorage)
 "gs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -2086,11 +2219,19 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/white,
-/area/offmap/aerostat/inside/xenoarch)
+/obj/effect/floor_decal/rust,
+/obj/structure/sign/poster{
+	dir = 8;
+	pixel_x = -32
+	},
+/turf/simulated/floor,
+/area/offmap/aerostat/inside/arm/ne)
 "gx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
 /area/offmap/aerostat/inside/xenoarch)
 "gy" = (
 /obj/structure/closet/crate/bin{
@@ -2098,6 +2239,17 @@
 	},
 /turf/simulated/floor/tiled,
 /area/offmap/aerostat/inside/drillstorage)
+"gz" = (
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/glass_research{
+	name = "Telescience"
+	},
+/obj/machinery/door/blast/regular/open{
+	id = telesci_blast;
+	name = "Blast Door"
+	},
+/turf/simulated/floor/reinforced,
+/area/offmap/aerostat/inside/telesci)
 "gC" = (
 /obj/machinery/alarm{
 	pixel_y = 26
@@ -2111,33 +2263,31 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -28
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
+/obj/effect/floor_decal/rust,
+/obj/effect/floor_decal/industrial/outline/red,
+/obj/structure/anomaly_container,
+/obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/white,
-/area/offmap/aerostat/inside/toxins)
+/turf/simulated/floor,
+/area/offmap/aerostat/inside/xenoarch)
 "gG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 9
+/obj/machinery/atmospherics/portables_connector{
+	dir = 8
 	},
+/obj/machinery/portable_atmospherics/canister/air,
 /turf/simulated/floor/tiled/techfloor,
-/area/offmap/aerostat/inside/northchamb)
-"gK" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/offmap/aerostat/inside/misclab)
+/area/offmap/aerostat/inside/atmos)
 "gL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/blue{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/structure/cable/heavyduty{
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/toxins)
@@ -2160,6 +2310,12 @@
 /obj/machinery/light/floortube{
 	dir = 4;
 	pixel_x = 5
+	},
+/obj/structure/bed/chair/comfy/black{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/southchamb)
@@ -2186,7 +2342,7 @@
 	dir = 4
 	},
 /turf/simulated/wall,
-/area/offmap/aerostat/inside/toxins)
+/area/offmap/aerostat/inside/xenoarch)
 "gS" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1380;
@@ -2205,25 +2361,31 @@
 	},
 /turf/simulated/floor/plating/virgo2,
 /area/offmap/aerostat/solars)
+"gU" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/blast/regular/open{
+	id = telesci_blast;
+	name = "Blast Door"
+	},
+/turf/simulated/floor/reinforced,
+/area/offmap/aerostat/inside/telesci)
 "gV" = (
-/obj/machinery/atmospherics/binary/pump/on{
-	name = "N2O pump"
+/obj/machinery/atmospherics/omni/atmos_filter{
+	name = "Phoron Filter";
+	tag_east = 6;
+	tag_north = 1;
+	tag_south = 2
 	},
 /turf/simulated/floor/tiled/techfloor,
-/area/offmap/aerostat/inside/northchamb)
-"gW" = (
-/obj/structure/cable/heavyduty{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/offmap/aerostat/inside/xenoarch)
+/area/offmap/aerostat/inside/atmos)
 "gX" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/red{
 	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/atmos)
@@ -2280,16 +2442,21 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/hidden,
-/turf/simulated/floor/tiled/techfloor,
-/area/offmap/aerostat/inside/northchamb)
-"hn" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/black,
-/turf/simulated/floor/tiled/techfloor,
-/area/offmap/aerostat/inside/northchamb)
-"hp" = (
-/obj/effect/floor_decal/industrial/warning/dust{
-	dir = 4
+/obj/machinery/light{
+	dir = 8
 	},
+/turf/simulated/floor/tiled/techfloor,
+/area/offmap/aerostat/inside/atmos)
+"hn" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/plating/virgo2,
+/area/offmap/aerostat/inside/atmos)
+"hp" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/northchamb)
@@ -2312,42 +2479,48 @@
 /turf/simulated/floor/bluegrid,
 /area/offmap/aerostat/inside/powercontrol)
 "hs" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
+/obj/structure/sign/poster{
+	dir = 4;
+	pixel_x = 32
 	},
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/toxins)
 "hu" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
-	dir = 4
+	dir = 10
 	},
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/toxins)
 "hv" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/tiled,
 /area/offmap/aerostat/inside/drillstorage)
-"hA" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/turf/simulated/floor,
-/area/offmap/aerostat/inside/xenoarch)
-"hB" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+"hw" = (
+/obj/structure/table/reinforced,
+/obj/item/weapon/reagent_containers/dropper,
+/obj/item/weapon/reagent_containers/glass/beaker,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/obj/machinery/camera/network/research_outpost{
-	dir = 4
+/obj/machinery/light{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
-/area/offmap/aerostat/inside/toxins)
+/area/offmap/aerostat/inside/virology)
+"hA" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/closet/crate,
+/obj/random/maintenance/research,
+/obj/random/maintenance/research,
+/obj/random/tool,
+/turf/simulated/floor,
+/area/offmap/aerostat/inside/arm/ne)
 "hC" = (
 /obj/structure/cable/heavyduty{
 	icon_state = "1-2"
@@ -2368,18 +2541,6 @@
 	},
 /turf/simulated/shuttle/floor/yellow,
 /area/shuttle/aerostat)
-"hG" = (
-/obj/machinery/portable_atmospherics/powered/scrubber/huge/stationary{
-	scrub_id = "science_outpost"
-	},
-/turf/simulated/floor/tiled/white,
-/area/offmap/aerostat/inside/toxins)
-"hJ" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/offmap/aerostat/inside/toxins)
 "hL" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -2389,12 +2550,6 @@
 /obj/structure/grille,
 /turf/simulated/floor,
 /area/offmap/aerostat/inside/toxins)
-"hM" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/offmap/aerostat/inside/genetics)
 "hN" = (
 /obj/structure/table/rack/shelf,
 /turf/simulated/floor/tiled/techfloor,
@@ -2406,9 +2561,8 @@
 /turf/simulated/shuttle/floor/yellow,
 /area/shuttle/aerostat)
 "hQ" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/mech_recharger,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/bluegrid,
 /area/offmap/aerostat/inside/drillstorage)
 "hS" = (
 /obj/machinery/alarm{
@@ -2451,36 +2605,50 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
+/obj/structure/flora/pottedplant/minitree,
 /turf/simulated/floor/tiled,
 /area/offmap/aerostat/inside/drillstorage)
 "ie" = (
 /turf/simulated/wall,
 /area/offmap/aerostat/inside/zorrenoffice)
 "if" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
-/area/offmap/aerostat/inside/genetics)
+/obj/machinery/camera/network/research_outpost,
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor,
+/area/offmap/aerostat/inside/westhall)
 "ig" = (
-/obj/structure/bed/chair/office/light{
-	dir = 8
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/obj/structure/window/reinforced{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/toxins)
 "ii" = (
-/obj/machinery/atmospherics/pipe/manifold/visible{
+/obj/machinery/atmospherics/pipe/simple/hidden/green{
 	dir = 4
 	},
-/obj/machinery/meter,
-/turf/simulated/floor/tiled/white,
-/area/offmap/aerostat/inside/toxins)
-"il" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/wall,
+/area/offmap/aerostat/inside/xenoarch)
+"ik" = (
+/obj/effect/floor_decal/rust,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor,
+/area/offmap/aerostat/inside/arm/ne)
+"il" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /obj/machinery/power/apc{
 	dir = 1;
@@ -2492,15 +2660,32 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/westhall)
 "io" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/machinery/bomb_tester,
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/obj/machinery/door/window/brigdoor/eastleft{
+	dir = 2;
+	req_access = list(7)
+	},
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/toxins)
+"is" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/curtain/open/shower/medical,
+/obj/machinery/shower{
+	pixel_y = 13
+	},
+/turf/simulated/floor/tiled/dark,
+/area/offmap/aerostat/inside/virology)
 "it" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -2526,16 +2711,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/airlock/east)
-"iB" = (
-/obj/structure/cable/heavyduty{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/white,
-/area/offmap/aerostat/inside/misclab)
 "iC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -2548,7 +2723,6 @@
 /obj/machinery/alarm{
 	pixel_y = 26
 	},
-/obj/structure/flora/pottedplant/unusual,
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/telesci)
 "iK" = (
@@ -2576,6 +2750,12 @@
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating/virgo2,
 /area/shuttle/aerostat)
+"iQ" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/offmap/aerostat/inside/southchamb)
 "iU" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -2583,11 +2763,22 @@
 /turf/simulated/shuttle/wall/voidcraft/green/virgo2,
 /area/offmap/aerostat/inside/arm/ne)
 "iV" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 5
-	},
+/obj/machinery/atmospherics/pipe/simple/visible,
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/toxins)
+"iW" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/plating/virgo2,
+/area/offmap/aerostat/inside/northchamb)
 "iX" = (
 /turf/simulated/wall,
 /area/offmap/aerostat/inside/firingrange)
@@ -2598,14 +2789,19 @@
 /obj/effect/floor_decal/industrial/danger{
 	dir = 8
 	},
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/xenoarch)
 "iZ" = (
 /obj/machinery/camera/network/research_outpost{
 	dir = 4
 	},
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/structure/closet/wardrobe/genetics_white,
 /turf/simulated/floor/tiled/white,
-/area/offmap/aerostat/inside/misclab)
+/area/offmap/aerostat/inside/genetics)
 "ja" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 4
@@ -2629,31 +2825,27 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
 	},
-/turf/simulated/floor/tiled/white,
-/area/offmap/aerostat/inside/xenoarch)
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor,
+/area/offmap/aerostat/inside/arm/ne)
 "ji" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/blue{
 	dir = 10
 	},
 /obj/structure/cable{
-	icon_state = "2-8"
+	icon_state = "2-4"
 	},
-/obj/machinery/medical_kiosk,
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/toxins)
 "jj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
-/obj/machinery/atmospherics/unary/freezer{
-	dir = 8;
-	icon_state = "freezer"
-	},
 /turf/simulated/floor/tiled,
-/area/offmap/aerostat/inside/genetics)
+/area/offmap/aerostat/inside/misclab)
 "jl" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	frequency = 1452
@@ -2662,6 +2854,12 @@
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating/virgo2,
 /area/offmap/aerostat/inside/xenoarch/chamber)
+"jm" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/wall,
+/area/offmap/aerostat/inside/arm/ne)
 "jn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -2682,20 +2880,21 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/westhall)
 "ju" = (
-/obj/machinery/portable_atmospherics/canister/nitrogen,
-/obj/structure/window/reinforced,
-/turf/simulated/floor/tiled/techfloor,
-/area/offmap/aerostat/inside/northchamb)
-"jw" = (
-/obj/structure/cable/heavyduty{
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/hidden/green{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/turf/simulated/floor/tiled/white,
-/area/offmap/aerostat/inside/firingrange)
+/turf/simulated/wall,
+/area/offmap/aerostat/inside/xenoarch)
+"jw" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled,
+/area/offmap/aerostat/inside/misclab)
 "jy" = (
 /obj/structure/cable/heavyduty{
 	icon_state = "1-2"
@@ -2707,13 +2906,16 @@
 /obj/structure/sign/painting/public{
 	pixel_y = 30
 	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/easthall)
 "jE" = (
 /obj/effect/floor_decal/industrial/warning/dust{
 	dir = 8
 	},
-/obj/structure/table/glass,
+/obj/structure/table/borosilicate,
 /turf/simulated/floor/tiled/dark,
 /area/offmap/aerostat/inside/lobby)
 "jF" = (
@@ -2730,14 +2932,16 @@
 /turf/simulated/floor/plating/virgo2,
 /area/offmap/aerostat/solars)
 "jH" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/black{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
 /obj/structure/cable{
 	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/trinary/mixer/m_mixer{
+	dir = 4;
+	name = "High Power Gas mixer";
+	power_rating = 15000
 	},
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/toxins)
@@ -2750,9 +2954,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/offmap/aerostat/inside/xenoarch/chamber)
-"jJ" = (
-/turf/simulated/shuttle/wall/voidcraft/green/virgo2/nocol,
-/area/offmap/aerostat/inside/airlock/east)
 "jL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
@@ -2773,17 +2974,19 @@
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/toxins)
 "jN" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/offmap/aerostat/inside/firingrange)
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/pipedispenser,
+/turf/simulated/floor/plating,
+/area/offmap/aerostat/inside/toxins)
 "jQ" = (
-/obj/machinery/light/floortube{
-	dir = 8;
-	pixel_x = -6
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/white,
+/obj/machinery/door/airlock/glass_research{
+	name = "Telescience"
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/tiled/steel_ridged,
 /area/offmap/aerostat/inside/telesci)
 "jR" = (
 /obj/effect/floor_decal/rust,
@@ -2795,12 +2998,6 @@
 	},
 /turf/simulated/floor/plating/virgo2,
 /area/offmap/aerostat/solars)
-"jS" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/offmap/aerostat/inside/genetics)
 "jT" = (
 /obj/structure/table/standard,
 /obj/item/weapon/tool/wrench{
@@ -2810,6 +3007,9 @@
 /obj/item/weapon/tool/wrench{
 	pixel_x = 2;
 	pixel_y = 2
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/toxins)
@@ -2823,11 +3023,9 @@
 /turf/simulated/floor/plating/virgo2,
 /area/offmap/aerostat/inside/arm/se)
 "jV" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/offmap/aerostat/inside/misclab)
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/simulated/floor/grass,
+/area/offmap/aerostat/inside/genetics)
 "jW" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
@@ -2847,9 +3045,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/turf/simulated/floor/tiled/white,
-/area/offmap/aerostat/inside/xenoarch)
+/obj/effect/floor_decal/rust,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor,
+/area/offmap/aerostat/inside/arm/ne)
 "ka" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 1
@@ -2894,6 +3093,9 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/wall,
 /area/offmap/aerostat/inside/toxins)
 "kg" = (
@@ -2902,7 +3104,7 @@
 	},
 /obj/effect/map_helper/airlock/sensor/ext_sensor,
 /turf/simulated/shuttle/wall/voidcraft/green/virgo2/nocol,
-/area/offmap/aerostat/inside/airlock/east)
+/area/offmap/aerostat/inside/virology)
 "kk" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
@@ -2927,7 +3129,7 @@
 	},
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/plating/virgo2,
-/area/offmap/aerostat/inside/northchamb)
+/area/offmap/aerostat/inside/atmos)
 "kp" = (
 /obj/effect/floor_decal/rust,
 /obj/effect/floor_decal/industrial/warning/dust{
@@ -2939,11 +3141,15 @@
 /turf/simulated/floor/plating/virgo2,
 /area/offmap/aerostat/solars)
 "kq" = (
-/obj/machinery/camera/network/research_outpost{
-	dir = 4
+/obj/machinery/power/apc{
+	dir = 4;
+	pixel_x = 28
 	},
-/turf/simulated/floor/tiled/white,
-/area/offmap/aerostat/inside/firingrange)
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/tiled,
+/area/offmap/aerostat/inside/misclab)
 "ks" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 4
@@ -2980,6 +3186,9 @@
 "kC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/camera/network/research_outpost{
+	dir = 8
+	},
+/obj/structure/bed/chair/sofa/purp/right{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
@@ -3057,14 +3266,11 @@
 /turf/simulated/floor/tiled/steel_ridged,
 /area/offmap/aerostat/inside/powercontrol)
 "kO" = (
-/obj/machinery/atmospherics/pipe/simple/visible/red{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
 /obj/machinery/camera/network/research_outpost{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/toxins)
@@ -3072,12 +3278,15 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/obj/machinery/atmospherics/binary/pump/on,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
-/area/offmap/aerostat/inside/genetics)
+/area/offmap/aerostat/inside/misclab)
+"kS" = (
+/obj/machinery/atmospherics/pipe/manifold/visible,
+/turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/toxins)
 "kV" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -3102,54 +3311,34 @@
 /turf/simulated/floor/plating/virgo2,
 /area/offmap/aerostat/inside/northchamb)
 "lb" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/obj/machinery/camera/network/research_outpost{
-	dir = 1
-	},
-/turf/simulated/floor,
-/area/offmap/aerostat/inside/xenoarch)
+/obj/structure/window/reinforced/full,
+/obj/structure/grille,
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/virology)
 "lc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/autolathe,
 /obj/machinery/camera/network/research_outpost{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/telesci)
 "ld" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
 	},
-/turf/simulated/floor/tiled/white,
-/area/offmap/aerostat/inside/toxins)
-"le" = (
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
-/obj/effect/floor_decal/industrial/warning/corner,
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor,
-/area/offmap/aerostat/inside/xenoarch)
+/turf/simulated/floor/tiled/techfloor,
+/area/offmap/aerostat/inside/northchamb)
 "lh" = (
-/obj/machinery/atmospherics/portables_connector{
-	dir = 1
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/manifold/visible{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/toxins)
@@ -3162,13 +3351,18 @@
 /turf/simulated/floor/tiled/steel_ridged,
 /area/offmap/aerostat/inside/airlock/north)
 "lk" = (
-/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
-/obj/machinery/door/window/brigdoor/eastleft{
-	req_access = list(7)
+/obj/machinery/atmospherics/pipe/simple/hidden/green{
+	dir = 4
 	},
-/obj/structure/window/reinforced,
-/turf/simulated/floor/tiled/techfloor,
-/area/offmap/aerostat/inside/northchamb)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/sign/directions/science/xenoarch,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/wall,
+/area/offmap/aerostat/inside/xenoarch)
 "ll" = (
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	dir = 5
@@ -3186,10 +3380,12 @@
 	},
 /turf/simulated/shuttle/wall/voidcraft/green/virgo2,
 /area/offmap/aerostat/inside/arm/sw)
-"lq" = (
-/obj/effect/floor_decal/industrial/outline/red,
-/turf/simulated/floor,
-/area/offmap/aerostat/inside/xenoarch)
+"lr" = (
+/obj/machinery/atmospherics/valve{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/toxins)
 "ls" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 6
@@ -3214,7 +3410,7 @@
 	},
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/plating/virgo2,
-/area/offmap/aerostat/inside/northchamb)
+/area/offmap/aerostat/inside/atmos)
 "lv" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 1
@@ -3222,14 +3418,32 @@
 /obj/effect/floor_decal/industrial/warning/cee{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 6
+	},
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/toxins)
 "lx" = (
 /obj/machinery/camera/network/research_outpost{
 	dir = 4
 	},
+/obj/structure/sign/painting/public{
+	pixel_x = -30
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/zorrenoffice)
+"ly" = (
+/obj/machinery/light_switch{
+	pixel_y = 25
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/genetics)
 "lz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -3247,38 +3461,33 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/westhall)
 "lA" = (
-/obj/machinery/mining/drill,
-/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/mineral/equipment_vendor,
 /turf/simulated/floor/tiled,
 /area/offmap/aerostat/inside/drillstorage)
-"lD" = (
-/obj/effect/floor_decal/industrial/warning{
+"lC" = (
+/obj/machinery/atmospherics/portables_connector{
 	dir = 8
 	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/effect/floor_decal/rust,
+/obj/machinery/camera/network/research_outpost{
+	dir = 8
 	},
-/obj/machinery/light,
 /turf/simulated/floor,
-/area/offmap/aerostat/inside/xenoarch)
+/area/offmap/aerostat/inside/arm/se)
 "lG" = (
-/obj/structure/table/standard,
-/obj/item/weapon/folder/white,
-/obj/item/weapon/pen,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/obj/machinery/light/small,
+/turf/simulated/floor/tiled/dark,
 /area/offmap/aerostat/inside/xenoarch)
 "lH" = (
-/obj/effect/floor_decal/industrial/warning/dust{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/offmap/aerostat/inside/northchamb)
+/turf/simulated/wall,
+/area/offmap/aerostat/inside/atmos)
 "lI" = (
 /obj/machinery/door/window/brigdoor/eastleft{
 	dir = 1;
@@ -3287,8 +3496,16 @@
 /turf/simulated/floor,
 /area/offmap/aerostat/inside/firingrange)
 "lK" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 10
+/obj/machinery/atmospherics/portables_connector{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/light_switch{
+	dir = 8;
+	pixel_x = 24;
+	pixel_y = -5
 	},
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/toxins)
@@ -3311,19 +3528,24 @@
 	},
 /turf/simulated/floor/bluegrid,
 /area/offmap/aerostat/inside/powercontrol)
-"lR" = (
-/obj/machinery/medical_kiosk,
-/turf/simulated/floor/tiled/white,
-/area/offmap/aerostat/inside/xenoarch)
+"lP" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/grass,
+/area/offmap/aerostat/inside/genetics)
+"lS" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/tiled/techfloor,
+/area/offmap/aerostat/inside/northchamb)
 "lT" = (
-/obj/machinery/pipedispenser,
+/obj/machinery/atmospherics/pipe/simple/hidden/green{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/toxins)
 "lW" = (
-/obj/machinery/light/floortube{
-	dir = 8;
-	pixel_x = -6
-	},
+/obj/machinery/atmospherics/binary/pump,
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/toxins)
 "lX" = (
@@ -3347,10 +3569,18 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/toxins)
-"mg" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+"md" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
 	},
+/turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/xenoarch)
+"me" = (
+/obj/machinery/light,
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/simulated/floor/grass,
+/area/offmap/aerostat/inside/genetics)
+"mg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 1
 	},
@@ -3360,28 +3590,45 @@
 /turf/simulated/floor/tiled,
 /area/offmap/aerostat/inside/drillstorage)
 "mi" = (
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/obj/structure/window/reinforced,
-/turf/simulated/floor/tiled/techfloor,
-/area/offmap/aerostat/inside/northchamb)
+/obj/machinery/atmospherics/pipe/simple/hidden/green{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/toxins)
 "mj" = (
 /obj/structure/cable/heavyduty{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/turf/simulated/floor/tiled/white,
-/area/offmap/aerostat/inside/xenoarch)
+/obj/effect/floor_decal/rust,
+/obj/random/maintenance/research,
+/obj/random/firstaid,
+/obj/random/maintenance/engineering,
+/obj/random/soap,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet,
+/turf/simulated/floor,
+/area/offmap/aerostat/inside/arm/ne)
 "mk" = (
 /obj/machinery/atmospherics/pipe/simple/visible/blue{
 	dir = 10
 	},
 /obj/machinery/meter,
-/obj/machinery/camera/network/research_outpost{
+/turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/toxins)
+"mm" = (
+/obj/effect/floor_decal/industrial/warning,
+/obj/structure/table/reinforced,
+/obj/item/clothing/glasses/goggles,
+/obj/item/clothing/ears/earmuffs,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
-/area/offmap/aerostat/inside/toxins)
+/area/offmap/aerostat/inside/firingrange)
 "mn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/door/airlock/glass_external/public,
@@ -3400,6 +3647,26 @@
 	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/offmap/aerostat/inside/toxins)
+"mp" = (
+/obj/structure/bed/chair/office/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/xenoarch)
+"ms" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/glass_research{
+	name = "Genetics Lab"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/steel_ridged,
+/area/offmap/aerostat/inside/genetics)
 "mt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -3410,6 +3677,7 @@
 /obj/machinery/alarm{
 	pixel_y = 26
 	},
+/obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/toxins)
 "mx" = (
@@ -3420,11 +3688,6 @@
 	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/offmap/aerostat/inside/airlock/north)
-"mz" = (
-/obj/effect/floor_decal/industrial/outline/red,
-/obj/structure/anomaly_container,
-/turf/simulated/floor,
-/area/offmap/aerostat/inside/xenoarch)
 "mA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
@@ -3437,14 +3700,15 @@
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/firingrange)
 "mD" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/green{
-	dir = 6
+/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
+/obj/machinery/door/window/brigdoor/eastleft{
+	dir = 2;
+	req_access = list(7)
 	},
-/obj/effect/floor_decal/industrial/warning/cee,
-/turf/simulated/floor/greengrid,
+/turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/toxins)
 "mE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -3487,28 +3751,39 @@
 	dir = 4
 	},
 /obj/structure/table/standard,
+/obj/random/tool,
+/obj/random/tool,
+/obj/structure/sign/poster{
+	dir = 4;
+	pixel_x = 32
+	},
 /turf/simulated/floor/tiled/white,
-/area/offmap/aerostat/inside/telesci)
+/area/offmap/aerostat/inside/miscstorage)
+"mI" = (
+/obj/structure/table/standard,
+/obj/item/weapon/reagent_containers/glass/bucket,
+/obj/item/stack/nanopaste,
+/obj/item/device/flashlight/lamp{
+	pixel_x = 5;
+	pixel_y = 9
+	},
+/turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/xenoarch)
+"mJ" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/portable_atmospherics/powered/pump,
+/turf/simulated/floor/plating,
+/area/offmap/aerostat/inside/toxins)
 "mL" = (
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/item/modular_computer/console,
-/turf/simulated/floor/tiled/white,
-/area/offmap/aerostat/inside/toxins)
-"mM" = (
-/obj/machinery/light{
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/machinery/atmospherics/portables_connector{
-	dir = 8
-	},
-/obj/machinery/portable_atmospherics/canister/air,
 /turf/simulated/floor/tiled/white,
-/area/offmap/aerostat/inside/xenoarch)
+/area/offmap/aerostat/inside/toxins)
 "mN" = (
 /turf/simulated/shuttle/wall/voidcraft/green,
 /area/offmap/aerostat/inside/arm/nw)
@@ -3556,16 +3831,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/shuttle/wall/voidcraft/green,
 /area/offmap/aerostat/inside/easthall)
-"mY" = (
-/obj/structure/cable/heavyduty{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/white,
-/area/offmap/aerostat/inside/firingrange)
 "mZ" = (
 /obj/effect/floor_decal/rust,
 /obj/structure/cable/yellow{
@@ -3584,14 +3849,22 @@
 /turf/simulated/floor/bluegrid,
 /area/offmap/aerostat/inside/powercontrol)
 "nb" = (
-/obj/machinery/vending/tool,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc{
+	dir = 4;
+	pixel_x = 28
+	},
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/toxins)
 "nf" = (
-/obj/machinery/atmospherics/pipe/manifold/visible{
-	dir = 8
+/obj/machinery/atmospherics/trinary/atmos_filter{
+	dir = 4;
+	name = "High Power Gas filter";
+	power_rating = 15000;
+	use_power = 0
 	},
-/obj/machinery/meter,
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/toxins)
 "nh" = (
@@ -3602,14 +3875,27 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/toxins)
+"ni" = (
+/obj/effect/floor_decal/rust,
+/obj/machinery/power/apc{
+	dir = 4;
+	pixel_x = 28
+	},
+/obj/structure/cable,
+/turf/simulated/floor,
+/area/offmap/aerostat/inside/westhall)
 "nm" = (
-/obj/machinery/atmospherics/unary/freezer{
-	dir = 8
+/obj/machinery/atmospherics/binary/pump/on{
+	name = "Scrubber to Waste"
 	},
 /turf/simulated/floor/tiled/techfloor,
-/area/offmap/aerostat/inside/northchamb)
+/area/offmap/aerostat/inside/atmos)
 "no" = (
 /obj/machinery/atmospherics/omni/mixer{
 	name = "Air Mixer";
@@ -3659,16 +3945,15 @@
 /obj/structure/cable/heavyduty{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/glass_research{
-	name = "Toxins Lab";
-	req_one_access = null
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/glass_research{
+	name = "Toxins Lab"
+	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/offmap/aerostat/inside/toxins)
 "nw" = (
@@ -3693,10 +3978,11 @@
 /turf/simulated/floor/tiled/steel_ridged,
 /area/offmap/aerostat/inside/toxins)
 "nB" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/black,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/manifold4w/visible,
+/obj/machinery/meter,
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/toxins)
 "nE" = (
@@ -3718,6 +4004,15 @@
 	},
 /turf/simulated/floor,
 /area/offmap/aerostat/inside/firingrange)
+"nG" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/offmap/aerostat/inside/easthall)
 "nJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
@@ -3725,15 +4020,6 @@
 	},
 /turf/simulated/shuttle/wall/voidcraft/green,
 /area/offmap/aerostat/inside/firingrange)
-"nK" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/wall,
-/area/offmap/aerostat/inside/toxins)
 "nL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/bluegrid,
@@ -3798,10 +4084,10 @@
 /turf/simulated/floor/reinforced/airless,
 /area/offmap/aerostat/inside/toxins)
 "nV" = (
-/obj/structure/cable/heavyduty{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/green,
+/obj/machinery/portable_atmospherics/powered/pump,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/light,
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/toxins)
 "nW" = (
@@ -3811,29 +4097,15 @@
 /turf/simulated/shuttle/wall/voidcraft/green/virgo2,
 /area/offmap/aerostat/inside/arm/ne)
 "nY" = (
-/obj/structure/table/rack,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/alarm{
 	dir = 4;
 	pixel_x = -23
 	},
-/obj/item/device/suit_cooling_unit,
-/obj/item/weapon/storage/belt/archaeology,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/suit/space/anomaly/heat,
-/obj/item/clothing/head/helmet/space/anomaly/heat,
-/obj/item/weapon/pickaxe,
-/obj/item/weapon/storage/excavation,
-/obj/item/stack/flag/yellow,
-/obj/item/weapon/tool/wrench,
-/obj/item/device/measuring_tape,
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/xenoarch)
 "oc" = (
-/obj/machinery/light{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/green{
+	dir = 9
 	},
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/toxins)
@@ -3854,6 +4126,13 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/toxins)
+"oi" = (
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -23
+	},
+/turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/toxins)
 "oj" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 8
@@ -3866,9 +4145,10 @@
 /turf/simulated/floor,
 /area/offmap/aerostat/inside/arm/sw)
 "ol" = (
-/obj/machinery/atmospherics/unary/freezer{
+/obj/structure/window/reinforced{
 	dir = 4
 	},
+/obj/machinery/portable_atmospherics/canister/phoron,
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/toxins)
 "om" = (
@@ -3886,17 +4166,12 @@
 /area/offmap/aerostat/inside/powercontrol)
 "oo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 5
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
-/area/offmap/aerostat/inside/genetics)
+/area/offmap/aerostat/inside/misclab)
 "op" = (
 /turf/simulated/wall/r_wall,
 /area/offmap/aerostat/inside/xenoarch)
@@ -3910,6 +4185,23 @@
 /obj/effect/map_helper/airlock/atmos/pump_out_internal,
 /turf/simulated/floor,
 /area/offmap/aerostat/inside/arm/nw)
+"ot" = (
+/turf/simulated/shuttle/wall/voidcraft/green,
+/area/offmap/aerostat/inside/virology)
+"ou" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/blue,
+/obj/structure/table/standard,
+/obj/item/weapon/tool/screwdriver,
+/obj/item/device/analyzer,
+/obj/item/weapon/tool/wrench,
+/obj/item/clothing/glasses/welding,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/machinery/power/apc,
+/obj/structure/cable,
+/turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/toxins)
 "ov" = (
 /obj/structure/cable/heavyduty{
 	icon_state = "4-8"
@@ -3947,6 +4239,9 @@
 /area/offmap/aerostat/inside/firingrange)
 "oG" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/easthall)
 "oJ" = (
@@ -3957,14 +4252,18 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
+/obj/structure/flora/pottedplant/subterranean,
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/northchamb)
 "oK" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/structure/dispenser,
-/obj/machinery/light,
+/obj/machinery/door/window/brigdoor/eastleft{
+	dir = 2;
+	req_access = list(7)
+	},
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/toxins)
 "oL" = (
@@ -4016,38 +4315,33 @@
 /area/offmap/aerostat/inside/toxins)
 "oY" = (
 /obj/structure/table/standard,
-/obj/item/weapon/tool/screwdriver,
-/obj/item/weapon/anobattery{
-	pixel_x = 5;
-	pixel_y = 2
+/obj/item/weapon/tool/crowbar,
+/obj/item/weapon/anodevice{
+	pixel_x = 1
 	},
-/obj/item/weapon/anobattery,
-/obj/item/weapon/anobattery{
-	pixel_x = -4;
-	pixel_y = 3
+/obj/item/weapon/anodevice{
+	pixel_x = -2
 	},
-/obj/item/weapon/anobattery{
-	pixel_x = -5;
-	pixel_y = -3
-	},
-/obj/effect/floor_decal/spline/plain{
-	dir = 1
-	},
-/obj/item/device/flashlight/lamp,
-/turf/simulated/floor/tiled,
+/obj/item/device/multitool,
+/obj/machinery/light,
+/turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/xenoarch)
 "oZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
-	icon_state = "0-8"
+	icon_state = "4-8"
 	},
-/obj/machinery/power/apc{
-	dir = 4;
-	pixel_x = 28
-	},
-/obj/structure/closet/wardrobe/genetics_white,
 /turf/simulated/floor/tiled,
-/area/offmap/aerostat/inside/genetics)
+/area/offmap/aerostat/inside/misclab)
+"pa" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/virology)
 "pd" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 8
@@ -4082,6 +4376,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/dark,
 /area/offmap/aerostat/inside/lobby)
+"ph" = (
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/black,
+/turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/toxins)
 "pj" = (
 /obj/effect/floor_decal/rust,
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
@@ -4091,6 +4389,7 @@
 /area/offmap/aerostat/solars)
 "pm" = (
 /obj/machinery/light,
+/obj/structure/table/wooden_reinforced,
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/southchamb)
 "pn" = (
@@ -4101,6 +4400,13 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/southchamb)
+"po" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden,
+/obj/machinery/camera/network/research_outpost{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/toxins)
 "pq" = (
 /obj/structure/table/steel_reinforced,
 /obj/machinery/door/window/brigdoor/eastright{
@@ -4121,8 +4427,12 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc,
 /turf/simulated/floor/tiled/techfloor,
-/area/offmap/aerostat/inside/northchamb)
+/area/offmap/aerostat/inside/atmos)
 "ps" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
@@ -4133,19 +4443,11 @@
 	},
 /turf/simulated/floor/plating/virgo2,
 /area/offmap/aerostat/solars)
-"pu" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/structure/flora/pottedplant/overgrown,
-/turf/simulated/floor/tiled/white,
-/area/offmap/aerostat/inside/firingrange)
 "py" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/black,
-/obj/machinery/atmospherics/binary/pump{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/wall,
 /area/offmap/aerostat/inside/toxins)
 "pz" = (
 /obj/structure/cable/heavyduty{
@@ -4162,10 +4464,6 @@
 /area/offmap/aerostat/inside/arm/se)
 "pA" = (
 /obj/structure/table/steel_reinforced,
-/obj/machinery/door/window/brigdoor/eastleft{
-	dir = 2;
-	req_access = list(1337)
-	},
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/blast/shutters{
 	dir = 2;
@@ -4200,14 +4498,14 @@
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/toxins)
 "pH" = (
-/obj/structure/cable{
-	icon_state = "2-4"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
 	},
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/techfloor,
-/area/offmap/aerostat/inside/southchamb)
+/area/offmap/aerostat/inside/northchamb)
 "pL" = (
 /obj/effect/floor_decal/rust,
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
@@ -4218,13 +4516,6 @@
 	},
 /turf/simulated/floor/plating/virgo2,
 /area/offmap/aerostat/solars)
-"pM" = (
-/obj/effect/floor_decal/industrial/warning/corner,
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 8
-	},
-/turf/simulated/floor,
-/area/offmap/aerostat/inside/xenoarch)
 "pP" = (
 /obj/machinery/light/floortube{
 	dir = 1;
@@ -4293,6 +4584,9 @@
 	dir = 8;
 	pixel_x = -6
 	},
+/obj/structure/bed/chair/comfy/black{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/southchamb)
 "pZ" = (
@@ -4311,32 +4605,28 @@
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/plating/virgo2,
 /area/offmap/aerostat/inside/southchamb)
-"qe" = (
-/obj/structure/cable/heavyduty{
-	icon_state = "1-2"
+"qf" = (
+/obj/effect/floor_decal/rust,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+/obj/effect/floor_decal/industrial/warning{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+/obj/machinery/alarm{
+	pixel_y = 26
 	},
-/turf/simulated/floor/tiled/white,
-/area/offmap/aerostat/inside/firingrange)
-"qf" = (
-/obj/structure/window/reinforced,
-/obj/machinery/portable_atmospherics/canister/phoron,
-/obj/machinery/door/window/brigdoor/eastleft{
-	req_access = list(7)
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/offmap/aerostat/inside/northchamb)
+/turf/simulated/floor,
+/area/offmap/aerostat/inside/xenoarch)
 "qh" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/red{
 	dir = 1
 	},
 /obj/machinery/light_switch{
 	pixel_y = 25
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/atmos)
@@ -4362,12 +4652,16 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/northchamb)
 "ql" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "2-8"
+	},
+/obj/structure/bed/chair/sofa/purp/left{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/offmap/aerostat/inside/lobby)
@@ -4375,7 +4669,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/structure/table/steel_reinforced,
+/obj/structure/table/borosilicate,
 /turf/simulated/floor/tiled/dark,
 /area/offmap/aerostat/inside/lobby)
 "qq" = (
@@ -4394,6 +4688,33 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/easthall)
+"qr" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = -4
+	},
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -23
+	},
+/turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/virology)
+"qt" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/simulated/floor/grass,
+/area/offmap/aerostat/inside/genetics)
+"qv" = (
+/obj/structure/cable/heavyduty{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/firingrange)
 "qw" = (
 /obj/machinery/power/apc{
 	dir = 4;
@@ -4425,6 +4746,13 @@
 "qC" = (
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/toxins)
+"qD" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/virology)
 "qE" = (
 /obj/structure/cable/heavyduty{
 	icon_state = "1-2"
@@ -4454,14 +4782,15 @@
 /turf/simulated/wall,
 /area/offmap/aerostat/inside/toxins)
 "qJ" = (
-/obj/machinery/atmospherics/omni/atmos_filter{
-	name = "N2O Filter";
-	tag_east = 7;
-	tag_north = 1;
-	tag_south = 2
-	},
+/obj/machinery/vending/cigarette,
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/northchamb)
+"qK" = (
+/obj/machinery/computer/telescience{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/telesci)
 "qL" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -4492,11 +4821,12 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/westhall)
 "qP" = (
-/obj/machinery/light{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/table/steel_reinforced,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/offmap/aerostat/inside/lobby)
 "qQ" = (
@@ -4504,7 +4834,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/wall,
 /area/offmap/aerostat/inside/xenoarch)
 "qR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -4514,12 +4844,11 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/southchamb)
 "qS" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/light{
-	dir = 4
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
-/area/offmap/aerostat/inside/genetics)
+/area/offmap/aerostat/inside/misclab)
 "qT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -4527,19 +4856,19 @@
 /turf/simulated/floor/tiled/dark,
 /area/offmap/aerostat/inside/lobby)
 "qU" = (
-/obj/machinery/alarm{
-	pixel_y = 26
+/obj/structure/window/reinforced{
+	dir = 4
 	},
-/obj/machinery/vending/phoronresearch{
-	name = "Toximate 2556";
-	products = list(/obj/item/device/transfer_valve = 3, /obj/item/device/assembly/timer = 6, /obj/item/device/assembly/signaler = 6, /obj/item/device/assembly/prox_sensor = 6, /obj/item/device/assembly/igniter = 12)
-	},
+/obj/machinery/portable_atmospherics/canister/nitrogen,
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/toxins)
 "qZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/techfloor,
-/area/offmap/aerostat/inside/northchamb)
+/area/offmap/aerostat/inside/atmos)
 "rd" = (
 /obj/machinery/atmospherics/pipe/simple/insulated,
 /obj/machinery/door/blast/regular{
@@ -4550,18 +4879,25 @@
 /turf/simulated/floor/reinforced/airless,
 /area/offmap/aerostat/inside/toxins)
 "re" = (
-/obj/machinery/atmospherics/pipe/tank/nitrous_oxide{
+/obj/machinery/atmospherics/unary/freezer{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor,
-/area/offmap/aerostat/inside/northchamb)
-"rg" = (
-/obj/machinery/light/floortube{
-	dir = 4;
-	pixel_x = 5
+/area/offmap/aerostat/inside/atmos)
+"rf" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 6
 	},
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/toxins)
+"rg" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/structure/closet/crate/science,
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor,
+/area/offmap/aerostat/inside/xenoarch)
 "ri" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/door/airlock/external{
@@ -4571,29 +4907,9 @@
 	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/offmap/aerostat/inside/airlock/north)
-"rk" = (
-/obj/effect/floor_decal/industrial/warning/corner,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor,
-/area/offmap/aerostat/inside/xenoarch)
 "rq" = (
 /turf/simulated/shuttle/wall/voidcraft/green,
 /area/offmap/aerostat/inside/firingrange)
-"rr" = (
-/obj/machinery/door/airlock/glass_research{
-	name = "Xenoarchaeology"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/glass,
-/turf/simulated/floor/tiled/steel_ridged,
-/area/offmap/aerostat/inside/xenoarch)
 "rs" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/dark,
@@ -4620,31 +4936,37 @@
 	},
 /turf/simulated/wall,
 /area/offmap/aerostat/inside/atmos)
-"rx" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/black{
-	dir = 10
-	},
+"ry" = (
+/obj/structure/flora/pottedplant/subterranean,
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/tiled/techfloor,
+/area/offmap/aerostat/inside/northchamb)
+"rz" = (
+/obj/structure/table/standard,
+/obj/item/weapon/tank/phoron,
+/obj/item/stack/cable_coil,
+/obj/item/stack/cable_coil,
+/obj/item/weapon/tool/wirecutters,
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/toxins)
-"ry" = (
-/turf/simulated/shuttle/wall/voidcraft/green,
-/area/offmap/aerostat/inside/xenoarch)
-"rF" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
+"rC" = (
+/obj/machinery/computer/diseasesplicer{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/machinery/alarm{
-	pixel_y = 26
-	},
-/turf/simulated/floor/tiled/dark,
-/area/offmap/aerostat/inside/xenoarch)
-"rH" = (
-/obj/structure/table/standard,
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/virology)
+"rH" = (
+/obj/structure/closet/crate/science,
+/obj/effect/floor_decal/rust,
+/obj/machinery/power/apc{
+	dir = 1;
+	pixel_y = 24
+	},
+/obj/structure/cable,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor,
 /area/offmap/aerostat/inside/xenoarch)
 "rI" = (
 /obj/machinery/atmospherics/pipe/simple/visible/black{
@@ -4665,6 +4987,12 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/airlock/north)
+"rP" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/wall,
+/area/offmap/aerostat/inside/xenoarch)
 "rS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
@@ -4678,18 +5006,35 @@
 	},
 /turf/simulated/shuttle/wall/voidcraft/green,
 /area/offmap/aerostat/inside/airlock/east)
+"rU" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/wall,
+/area/offmap/aerostat/inside/toxins)
+"rW" = (
+/obj/structure/bed/chair/office/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/genetics)
 "sb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/closet/excavation,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/xenoarch)
 "sc" = (
-/obj/effect/floor_decal/industrial/warning/dust{
+/obj/machinery/atmospherics/portables_connector{
 	dir = 8
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/machinery/portable_atmospherics/canister/air,
 /turf/simulated/floor/tiled/techfloor,
-/area/offmap/aerostat/inside/northchamb)
+/area/offmap/aerostat/inside/atmos)
 "se" = (
 /obj/effect/floor_decal/industrial/outline/red,
 /turf/simulated/floor/tiled/dark,
@@ -4717,18 +5062,30 @@
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/offmap/aerostat/inside/toxins)
+"sj" = (
+/obj/machinery/door/window/brigdoor/eastleft{
+	dir = 1;
+	req_access = null
+	},
+/turf/simulated/floor/grass,
+/area/offmap/aerostat/inside/genetics)
 "sk" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden,
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/airlock/south)
 "sm" = (
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/obj/machinery/door/window/brigdoor/eastleft{
-	req_access = list(7)
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
 	},
-/obj/structure/window/reinforced,
-/turf/simulated/floor/tiled/techfloor,
-/area/offmap/aerostat/inside/northchamb)
+/obj/structure/table/rack,
+/obj/item/clothing/suit/bio_suit/anomaly,
+/obj/item/clothing/head/bio_hood/anomaly,
+/obj/item/clothing/gloves/sterile/latex,
+/obj/item/clothing/glasses/science,
+/obj/item/clothing/mask/breath,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/xenoarch)
 "sn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/shuttle/wall/voidcraft/green/virgo2,
@@ -4777,20 +5134,24 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/zorrenoffice)
-"sz" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
+"sy" = (
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
-/turf/simulated/floor/tiled/white,
-/area/offmap/aerostat/inside/firingrange)
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/offmap/aerostat/inside/southchamb)
 "sD" = (
 /obj/structure/cable/heavyduty{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/white,
-/area/offmap/aerostat/inside/xenoarch)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor,
+/area/offmap/aerostat/inside/arm/ne)
 "sE" = (
 /obj/effect/floor_decal/rust,
 /obj/structure/cable/yellow{
@@ -4808,21 +5169,24 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/turf/simulated/floor/tiled/white,
-/area/offmap/aerostat/inside/xenoarch)
+/obj/effect/floor_decal/rust,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor,
+/area/offmap/aerostat/inside/arm/ne)
 "sJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/southchamb)
 "sK" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/offmap/aerostat/inside/lobby)
@@ -4831,7 +5195,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/portable_atmospherics/canister/empty,
 /obj/machinery/camera/network/research_outpost{
 	dir = 4
 	},
@@ -4853,6 +5216,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/table/standard,
+/obj/item/weapon/ore/bluespace_crystal,
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/telesci)
 "sQ" = (
@@ -4873,12 +5237,6 @@
 	dir = 9
 	},
 /turf/simulated/wall/r_wall,
-/area/offmap/aerostat/inside/xenoarch)
-"sW" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/turf/simulated/floor,
 /area/offmap/aerostat/inside/xenoarch)
 "sX" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
@@ -4906,6 +5264,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/shuttle/wall/voidcraft/green/virgo2,
 /area/offmap/aerostat/inside/arm/ne)
+"tf" = (
+/obj/structure/closet/crate/bin{
+	anchored = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/telesci)
 "tg" = (
 /obj/effect/shuttle_landmark{
 	base_area = /area/offmap/aerostat;
@@ -4920,17 +5284,25 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
+/obj/structure/closet/firecloset,
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/xenoarch)
+"tj" = (
+/obj/structure/cable/heavyduty{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/rust,
+/obj/structure/table/rack,
+/obj/random/contraband,
+/turf/simulated/floor,
+/area/offmap/aerostat/inside/arm/ne)
 "tk" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 10
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -4951,6 +5323,14 @@
 	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/offmap/aerostat/inside/airlock/north)
+"tn" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/structure/bed/padded,
+/obj/item/weapon/bedsheet/medical,
+/turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/virology)
 "tq" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 4;
@@ -4973,6 +5353,15 @@
 	},
 /turf/simulated/floor,
 /area/offmap/aerostat/inside/airlock/north)
+"tr" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/offmap/aerostat/inside/easthall)
 "ts" = (
 /obj/structure/shuttle/window,
 /obj/structure/grille,
@@ -4983,32 +5372,25 @@
 /turf/simulated/floor,
 /area/shuttle/aerostat)
 "tu" = (
-/obj/machinery/atmospherics/pipe/simple/visible,
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 10
+	},
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/toxins)
 "tv" = (
-/obj/machinery/door/airlock/glass_research{
-	name = "Toxins Lab";
-	req_one_access = null
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/glass_research{
+	name = "Toxins Lab"
+	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/offmap/aerostat/inside/toxins)
 "ty" = (
 /turf/simulated/shuttle/wall/voidcraft/green,
 /area/offmap/aerostat/inside/easthall)
-"tA" = (
-/obj/machinery/atmospherics/portables_connector{
-	dir = 8
-	},
-/obj/machinery/portable_atmospherics/canister/air,
-/turf/simulated/floor/tiled,
-/area/offmap/aerostat/inside/genetics)
 "tD" = (
-/obj/structure/bed/chair/office/light,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark,
 /area/offmap/aerostat/inside/xenoarch)
 "tE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
@@ -5028,44 +5410,35 @@
 /obj/effect/floor_decal/rust,
 /obj/machinery/power/apc{
 	dir = 8;
-	name = "east bump";
 	pixel_x = -22
 	},
 /turf/simulated/floor,
 /area/offmap/aerostat/inside/arm/se)
-"tG" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/offmap/aerostat/inside/misclab)
 "tH" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/wall,
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/machinery/door/blast/regular/open{
+	id = telesci_blast;
+	name = "Blast Door"
+	},
+/turf/simulated/floor/reinforced,
 /area/offmap/aerostat/inside/telesci)
 "tI" = (
 /obj/effect/floor_decal/industrial/danger/corner{
 	dir = 8
 	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/xenoarch)
 "tJ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/light/floortube{
-	dir = 8;
-	pixel_x = -6
+	dir = 5
 	},
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/firingrange)
 "tL" = (
-/obj/machinery/door/airlock/glass_research{
-	name = "Toxins Lab"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/green{
 	dir = 9
 	},
@@ -5073,8 +5446,14 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor/glass,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/door/airlock/glass_research{
+	name = "Xenoarchaeology Prep Room"
+	},
 /turf/simulated/floor/tiled/steel_ridged,
-/area/offmap/aerostat/inside/toxins)
+/area/offmap/aerostat/inside/xenoarch)
 "tM" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
@@ -5084,15 +5463,6 @@
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/plating/virgo2,
 /area/offmap/aerostat/inside/arm/ne)
-"tP" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/blue{
-	dir = 4
-	},
-/obj/machinery/alarm{
-	pixel_y = 26
-	},
-/turf/simulated/floor/tiled/white,
-/area/offmap/aerostat/inside/toxins)
 "tR" = (
 /obj/structure/flora/pottedplant/subterranean,
 /turf/simulated/floor/tiled/techfloor,
@@ -5105,71 +5475,70 @@
 /turf/simulated/shuttle/floor/yellow/airless,
 /area/shuttle/aerostat)
 "tU" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/machinery/light_switch{
 	pixel_y = 24
 	},
 /turf/simulated/floor/tiled,
-/area/offmap/aerostat/inside/genetics)
+/area/offmap/aerostat/inside/misclab)
 "tV" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/dispenser{
-	phorontanks = 0
-	},
-/obj/machinery/light_switch{
-	dir = 4;
-	pixel_x = -25;
-	pixel_y = -2
-	},
+/obj/machinery/suspension_gen,
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/xenoarch)
 "tY" = (
 /turf/simulated/shuttle/wall/voidcraft/green,
 /area/offmap/aerostat/inside/airlock/east)
 "ua" = (
-/obj/effect/floor_decal/industrial/warning/dust{
-	dir = 8
+/obj/machinery/door/airlock/glass_research{
+	name = "Atmospherics";
+	req_one_access = list(47,10)
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/offmap/aerostat/inside/northchamb)
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/tiled/steel_ridged,
+/area/offmap/aerostat/inside/atmos)
 "ud" = (
-/obj/structure/cable/heavyduty{
-	icon_state = "2-8"
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/cable/heavyduty{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/toxins)
+"uf" = (
+/obj/machinery/button/remote/blast_door{
+	dir = 1;
+	id = 2;
+	name = "Virology Emergency Quarantine";
+	pixel_y = 5
+	},
+/turf/simulated/wall,
+/area/offmap/aerostat/inside/virology)
 "ug" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/table/steel_reinforced,
 /obj/structure/sign/painting/public{
 	pixel_x = 30
 	},
+/obj/structure/table/borosilicate,
 /turf/simulated/floor/tiled/dark,
 /area/offmap/aerostat/inside/lobby)
 "uh" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
 /obj/structure/cable{
-	icon_state = "2-8"
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/techfloor,
-/area/offmap/aerostat/inside/southchamb)
+/area/offmap/aerostat/inside/northchamb)
 "uj" = (
-/obj/machinery/light/floortube{
-	dir = 4;
-	pixel_x = 5
-	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/telesci)
 "uk" = (
 /obj/machinery/light,
-/turf/simulated/floor/tiled/white,
-/area/offmap/aerostat/inside/misclab)
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor,
+/area/offmap/aerostat/inside/arm/se)
 "um" = (
 /obj/machinery/door/airlock/external,
 /obj/structure/cable{
@@ -5179,9 +5548,8 @@
 /turf/simulated/floor/tiled/steel_ridged,
 /area/offmap/aerostat/inside/northchamb)
 "un" = (
-/obj/structure/cable/heavyduty{
-	icon_state = "4-8"
-	},
+/obj/machinery/portable_atmospherics/powered/scrubber,
+/obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/toxins)
 "uq" = (
@@ -5192,7 +5560,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor,
-/area/offmap/aerostat/inside/northchamb)
+/area/offmap/aerostat/inside/atmos)
 "ur" = (
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	dir = 4
@@ -5212,6 +5580,12 @@
 	},
 /turf/simulated/wall,
 /area/offmap/aerostat/inside/firingrange)
+"ut" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/reinforced,
+/area/offmap/aerostat/inside/telesci)
 "uu" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/red{
 	dir = 1
@@ -5228,14 +5602,8 @@
 /obj/structure/window/basic{
 	dir = 1
 	},
-/obj/structure/window/basic{
-	dir = 8
-	},
 /obj/effect/floor_decal/corner/red/border{
 	dir = 1
-	},
-/obj/effect/floor_decal/corner/red/border{
-	dir = 8
 	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/offmap/aerostat/inside/toxins)
@@ -5257,12 +5625,6 @@
 "uA" = (
 /obj/machinery/atmospherics/unary/heat_exchanger,
 /obj/structure/window/basic,
-/obj/structure/window/basic{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/red/border{
-	dir = 8
-	},
 /obj/effect/floor_decal/corner/red/border,
 /turf/simulated/floor/tiled/steel_ridged,
 /area/offmap/aerostat/inside/toxins)
@@ -5271,23 +5633,50 @@
 /obj/machinery/camera/network/research_outpost{
 	dir = 4
 	},
+/obj/machinery/mining/drill,
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled,
 /area/offmap/aerostat/inside/drillstorage)
-"uG" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
+"uE" = (
+/obj/machinery/vending/snlvend{
+	dir = 8
 	},
+/turf/simulated/floor/tiled/techfloor,
+/area/offmap/aerostat/inside/southchamb)
+"uF" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/machinery/camera/network/research_outpost{
+	dir = 8
+	},
+/obj/structure/closet/firecloset,
+/turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/toxins)
+"uG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/camera/network/research_outpost,
+/obj/structure/table/rack,
+/obj/item/device/suit_cooling_unit,
+/obj/item/device/suit_cooling_unit,
 /turf/simulated/floor/tiled,
 /area/offmap/aerostat/inside/drillstorage)
+"uK" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/mining/drill,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled,
+/area/offmap/aerostat/inside/drillstorage)
+"uN" = (
+/obj/machinery/recharge_station,
+/turf/simulated/floor/tiled/techfloor,
+/area/offmap/aerostat/inside/northchamb)
 "uS" = (
 /turf/simulated/shuttle/wall/voidcraft/green,
 /area/offmap/aerostat/inside/arm/sw)
 "uV" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/black,
-/obj/machinery/atmospherics/pipe/simple/hidden/black{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/northchamb)
@@ -5298,8 +5687,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/southchamb)
+"va" = (
+/obj/structure/flora/ausbushes/brflowers,
+/turf/simulated/floor/grass,
+/area/offmap/aerostat/inside/genetics)
 "vb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
@@ -5314,9 +5708,12 @@
 /turf/simulated/floor/tiled/steel_ridged,
 /area/offmap/aerostat/inside/airlock/south)
 "vd" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/white,
-/area/offmap/aerostat/inside/misclab)
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/simulated/floor/grass,
+/area/offmap/aerostat/inside/genetics)
 "ve" = (
 /obj/machinery/door/blast/regular{
 	dir = 8;
@@ -5340,15 +5737,21 @@
 /turf/simulated/floor/tiled/steel_ridged,
 /area/offmap/aerostat/inside/airlock/south)
 "vm" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/machinery/door/window/brigdoor/eastleft{
-	req_access = list(7)
-	},
-/obj/structure/window/reinforced,
-/turf/simulated/floor/tiled/techfloor,
-/area/offmap/aerostat/inside/northchamb)
+/obj/structure/table/rack,
+/obj/item/clothing/suit/bio_suit/anomaly,
+/obj/item/clothing/head/bio_hood/anomaly,
+/obj/item/clothing/gloves/sterile/latex,
+/obj/item/clothing/glasses/science,
+/obj/item/clothing/mask/breath,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/xenoarch)
 "vo" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/structure/table/wooden_reinforced,
+/obj/machinery/chemical_dispenser/bar_coffee/full{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -5356,6 +5759,9 @@
 "vp" = (
 /obj/machinery/camera/network/research_outpost{
 	dir = 8
+	},
+/obj/structure/sign/painting/public{
+	pixel_x = 30
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/zorrenoffice)
@@ -5376,21 +5782,36 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/northchamb)
+"vu" = (
+/obj/structure/cable/heavyduty{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/firingrange)
 "vy" = (
 /obj/machinery/power/apc{
 	dir = 8;
-	name = "east bump";
 	pixel_x = -22
 	},
 /obj/structure/cable,
+/obj/structure/table/reinforced,
+/obj/item/weapon/storage/box/disks,
+/obj/item/weapon/storage/box/disks,
+/obj/item/toy/figure/geneticist,
 /turf/simulated/floor/tiled/white,
-/area/offmap/aerostat/inside/misclab)
+/area/offmap/aerostat/inside/genetics)
 "vz" = (
-/obj/machinery/light/floortube{
-	dir = 8;
-	pixel_x = -6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/camera/network/research_outpost,
+/obj/structure/table/rack,
+/obj/item/clothing/suit/bio_suit/anomaly,
+/obj/item/clothing/head/bio_hood/anomaly,
+/obj/item/clothing/gloves/sterile/latex,
+/obj/item/clothing/glasses/science,
+/obj/item/clothing/mask/breath,
+/obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/xenoarch)
 "vA" = (
@@ -5401,6 +5822,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/atmos)
 "vC" = (
@@ -5455,10 +5877,25 @@
 	name = "Firing Range";
 	req_one_access = null
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/tiled/steel_ridged,
 /area/offmap/aerostat/inside/firingrange)
+"vQ" = (
+/obj/item/modular_computer/console/preset/research{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	layer = 3.3;
+	pixel_x = 26
+	},
+/turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/xenoarch)
+"vR" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/wall,
+/area/offmap/aerostat/inside/xenoarch)
 "vT" = (
 /obj/structure/cable/heavyduty{
 	icon_state = "1-2"
@@ -5470,23 +5907,37 @@
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/tiled/steel_ridged,
 /area/offmap/aerostat/inside/firingrange)
+"vU" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/mining/brace,
+/turf/simulated/floor/tiled,
+/area/offmap/aerostat/inside/drillstorage)
 "vW" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/black{
-	dir = 1
+/obj/structure/cable/heavyduty{
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/white,
-/area/offmap/aerostat/inside/toxins)
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 9
+	},
+/obj/effect/floor_decal/rust,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor,
+/area/offmap/aerostat/inside/arm/ne)
 "vX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
 /turf/simulated/shuttle/wall,
 /area/shuttle/aerostat)
+"vY" = (
+/obj/machinery/bomb_tester,
+/turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/toxins)
 "wb" = (
-/obj/effect/floor_decal/industrial/warning/dust/corner{
-	dir = 8
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 23
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/northchamb)
 "wc" = (
@@ -5500,18 +5951,14 @@
 /turf/simulated/shuttle/wall/hard_corner,
 /area/shuttle/aerostat)
 "wg" = (
-/obj/effect/floor_decal/industrial/warning/dust{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -26
+/obj/machinery/vending/cola/soft{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/northchamb)
@@ -5527,9 +5974,6 @@
 "wi" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -5542,6 +5986,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/tiled/steel_ridged,
 /area/offmap/aerostat/inside/arm/se)
+"wl" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/dark,
+/area/offmap/aerostat/inside/lobby)
 "wm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 5
@@ -5553,6 +6001,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/structure/flora/pottedplant/unusual,
 /turf/simulated/floor/tiled/dark,
 /area/offmap/aerostat/inside/lobby)
 "wp" = (
@@ -5566,13 +6015,15 @@
 	},
 /turf/simulated/floor/tiled,
 /area/offmap/aerostat/inside/xenoarch)
-"wq" = (
-/obj/structure/closet/crate/science,
-/turf/simulated/floor,
-/area/offmap/aerostat/inside/xenoarch)
 "wr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/blue{
 	dir = 5
+	},
+/turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/toxins)
+"ws" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/black{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/toxins)
@@ -5582,6 +6033,12 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/southchamb)
+"wA" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/offmap/aerostat/inside/misclab)
 "wC" = (
 /turf/simulated/shuttle/wall/voidcraft/hard_corner{
 	stripe_color = "#00FF00"
@@ -5618,10 +6075,13 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/westhall)
 "wG" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/white,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/turf/simulated/wall,
 /area/offmap/aerostat/inside/toxins)
 "wI" = (
 /obj/structure/cable/heavyduty{
@@ -5651,10 +6111,14 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/southchamb)
-"wR" = (
-/obj/machinery/vending/tool,
-/turf/simulated/floor/tiled/white,
-/area/offmap/aerostat/inside/xenoarch)
+"wT" = (
+/obj/effect/floor_decal/rust,
+/obj/random/maintenance/research,
+/obj/random/maintenance/research,
+/obj/random/maintenance/engineering,
+/obj/structure/closet,
+/turf/simulated/floor,
+/area/offmap/aerostat/inside/arm/ne)
 "wY" = (
 /obj/machinery/alarm{
 	pixel_y = 26
@@ -5692,13 +6156,9 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/light_switch{
-	dir = 1;
-	pixel_x = 32;
-	pixel_y = -24
-	},
-/turf/simulated/floor/tiled/white,
-/area/offmap/aerostat/inside/xenoarch)
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor,
+/area/offmap/aerostat/inside/arm/ne)
 "xe" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -5706,32 +6166,35 @@
 /turf/simulated/floor/tiled/dark,
 /area/offmap/aerostat/inside/lobby)
 "xf" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/portables_connector{
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/manifold/visible{
+	dir = 1
+	},
+/obj/machinery/meter,
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/toxins)
 "xg" = (
-/obj/structure/cable/heavyduty{
-	icon_state = "4-8"
-	},
-/obj/machinery/alarm{
-	pixel_y = 26
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/machinery/camera/network/research_outpost{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/offmap/aerostat/inside/xenoarch)
+"xj" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/offmap/aerostat/inside/easthall)
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor,
+/area/offmap/aerostat/inside/arm/se)
 "xl" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -5761,28 +6224,49 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/radiocarbon_spectrometer,
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/xenoarch)
 "xs" = (
-/obj/structure/table/rack,
-/obj/item/clothing/suit/bio_suit/anomaly,
-/obj/item/clothing/head/bio_hood/anomaly,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/gloves/sterile/latex,
-/obj/item/clothing/glasses/science,
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning/corner,
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 4
+	},
+/turf/simulated/floor,
 /area/offmap/aerostat/inside/xenoarch)
 "xt" = (
 /turf/simulated/wall,
 /area/offmap/aerostat/inside/drillstorage)
 "xu" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/black{
-	dir = 5
+/obj/machinery/alarm{
+	alarm_id = "anomaly_testing";
+	dir = 4;
+	pixel_x = -23
 	},
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/toxins)
+"xv" = (
+/obj/structure/cable/heavyduty{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/sign/directions/science/xenoarch{
+	dir = 1;
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/offmap/aerostat/inside/easthall)
 "xw" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
@@ -5812,19 +6296,29 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/toxins)
-"xC" = (
-/obj/structure/filingcabinet/filingcabinet,
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 23
+"xB" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/white,
-/area/offmap/aerostat/inside/toxins)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/medical{
+	name = "Virology Lab";
+	req_access = list(39);
+	req_one_access = null
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/tiled/steel_ridged,
+/area/offmap/aerostat/inside/virology)
 "xD" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
-/obj/structure/table/steel_reinforced,
+/obj/structure/table/borosilicate,
 /turf/simulated/floor/tiled/dark,
 /area/offmap/aerostat/inside/lobby)
 "xF" = (
@@ -5837,21 +6331,39 @@
 /turf/simulated/floor/plating/virgo2,
 /area/offmap/aerostat/inside/arm/se)
 "xG" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/easthall)
-"xK" = (
-/obj/machinery/atmospherics/portables_connector{
-	dir = 8
+"xH" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/blast/shutters{
+	dir = 2;
+	id = "zorrenpartyroom";
+	layer = 3.3;
+	name = "shutter"
 	},
-/obj/effect/floor_decal/industrial/outline/red,
-/turf/simulated/floor/tiled/white,
-/area/offmap/aerostat/inside/toxins)
+/obj/machinery/vending/sovietsoda,
+/turf/simulated/floor/plating/virgo2,
+/area/offmap/aerostat/inside/zorrenoffice)
+"xK" = (
+/obj/effect/floor_decal/rust,
+/obj/effect/floor_decal/industrial/warning,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/offmap/aerostat/inside/xenoarch)
 "xM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
@@ -5869,12 +6381,13 @@
 /turf/simulated/floor/tiled/steel_ridged,
 /area/offmap/aerostat/inside/arm/sw)
 "xO" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/green{
+/obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/portable_atmospherics/canister/phoron,
+/obj/machinery/door/window/brigdoor/eastleft{
+	dir = 2;
+	req_access = list(7)
 	},
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/toxins)
@@ -5882,22 +6395,21 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/northchamb)
 "xR" = (
-/obj/machinery/light/floortube{
-	dir = 8;
-	pixel_x = -6
+/turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/genetics)
+"xS" = (
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/white,
-/area/offmap/aerostat/inside/misclab)
-"xS" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/offmap/aerostat/inside/xenoarch)
+/area/offmap/aerostat/inside/virology)
 "xU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/black,
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/toxins)
+"xV" = (
+/turf/simulated/wall,
+/area/offmap/aerostat/inside/virology)
 "xW" = (
 /obj/structure/cable/heavyduty{
 	icon_state = "1-2"
@@ -5920,11 +6432,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/offmap/aerostat/inside/atmos)
+"yd" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/turf/simulated/wall,
+/area/offmap/aerostat/inside/virology)
 "ye" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/item/modular_computer/console{
-	dir = 8
-	},
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/firingrange)
 "yi" = (
@@ -5948,12 +6466,12 @@
 /obj/structure/cable/heavyduty{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/turf/simulated/floor/tiled/white,
-/area/offmap/aerostat/inside/misclab)
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor,
+/area/offmap/aerostat/inside/arm/se)
 "yq" = (
 /obj/effect/floor_decal/industrial/warning/dust,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -5964,20 +6482,16 @@
 "yr" = (
 /turf/simulated/shuttle/wall/voidcraft/green,
 /area/offmap/aerostat/inside/drillstorage)
-"ys" = (
-/obj/effect/floor_decal/industrial/warning,
-/turf/simulated/floor,
-/area/offmap/aerostat/inside/xenoarch)
 "yu" = (
-/obj/effect/floor_decal/industrial/warning/dust/corner{
-	dir = 4
-	},
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
+	},
+/obj/machinery/vending/snack{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/northchamb)
@@ -6012,8 +6526,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/turf/simulated/floor/tiled/white,
-/area/offmap/aerostat/inside/xenoarch)
+/turf/simulated/wall,
+/area/offmap/aerostat/inside/arm/ne)
 "yD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
@@ -6029,14 +6543,11 @@
 /turf/simulated/floor/tiled/steel_ridged,
 /area/offmap/aerostat/inside/airlock/south)
 "yG" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/machinery/alarm{
 	pixel_y = 26
 	},
 /turf/simulated/floor/tiled,
-/area/offmap/aerostat/inside/genetics)
+/area/offmap/aerostat/inside/misclab)
 "yH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -6054,10 +6565,13 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/easthall)
 "yI" = (
-/obj/machinery/atmospherics/valve{
-	dir = 4
-	},
 /obj/machinery/light,
+/obj/machinery/atmospherics/pipe/simple/visible/red{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/toxins)
 "yK" = (
@@ -6066,6 +6580,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
+	},
+/obj/machinery/light/floortube{
+	dir = 8;
+	pixel_x = -6
 	},
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/firingrange)
@@ -6084,6 +6602,17 @@
 /obj/effect/map_helper/airlock/atmos/chamber_pump,
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/toxins)
+"yQ" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/rust,
+/obj/structure/table/rack,
+/obj/random/toolbox,
+/obj/random/soap,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor,
+/area/offmap/aerostat/inside/arm/ne)
 "yT" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 10
@@ -6095,11 +6624,11 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/atmos)
 "yX" = (
-/obj/machinery/light{
+/obj/machinery/camera/network/research_outpost{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/white,
-/area/offmap/aerostat/inside/firingrange)
+/turf/simulated/floor/tiled,
+/area/offmap/aerostat/inside/misclab)
 "yZ" = (
 /obj/structure/cable/heavyduty{
 	icon_state = "0-8"
@@ -6121,25 +6650,20 @@
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/toxins)
 "zc" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/wall,
-/area/offmap/aerostat/inside/misclab)
+/turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/telesci)
 "ze" = (
-/obj/machinery/artifact_analyser,
-/obj/machinery/camera/network/research_outpost{
-	dir = 8
+/turf/simulated/shuttle/wall/voidcraft/hard_corner{
+	stripe_color = "#00FF00"
 	},
-/turf/simulated/floor/tiled/dark,
-/area/offmap/aerostat/inside/xenoarch)
+/area/offmap/aerostat/inside/virology)
 "zf" = (
-/obj/structure/table/steel_reinforced,
 /obj/random/maintenance/research,
 /obj/structure/sign/painting/public{
 	pixel_x = -30
 	},
+/obj/structure/table/borosilicate,
 /turf/simulated/floor/tiled/dark,
 /area/offmap/aerostat/inside/lobby)
 "zg" = (
@@ -6161,13 +6685,11 @@
 /turf/simulated/floor/plating/virgo2,
 /area/offmap/aerostat/solars)
 "zn" = (
-/obj/effect/floor_decal/spline/plain{
-	dir = 4
+/obj/machinery/door/airlock/glass_research{
+	name = "Xenoarchaeology"
 	},
-/obj/item/modular_computer/console/preset/research{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/tiled/steel_ridged,
 /area/offmap/aerostat/inside/xenoarch)
 "zo" = (
 /obj/structure/cable{
@@ -6197,11 +6719,15 @@
 /turf/simulated/floor,
 /area/offmap/aerostat/inside/arm/ne)
 "zr" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
+/obj/effect/floor_decal/rust,
+/obj/effect/floor_decal/industrial/warning/corner{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
-/area/offmap/aerostat/inside/drillstorage)
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/offmap/aerostat/inside/xenoarch)
 "zt" = (
 /obj/machinery/door/airlock/glass_research{
 	req_one_access = null
@@ -6212,12 +6738,10 @@
 /turf/simulated/floor/tiled/steel_ridged,
 /area/offmap/aerostat/inside/zorrenoffice)
 "zu" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/machinery/camera/network/research_outpost{
-	dir = 8
-	},
+/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/toxins)
 "zw" = (
@@ -6234,10 +6758,17 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/easthall)
+"zz" = (
+/obj/structure/bed/chair/bay{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/virology)
 "zA" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
+/obj/structure/flora/pottedplant/crystal,
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/zorrenoffice)
 "zB" = (
@@ -6264,6 +6795,13 @@
 	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/offmap/aerostat/inside/airlock/south)
+"zD" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/vending/tool,
+/turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/toxins)
 "zE" = (
 /obj/machinery/power/apc{
 	dir = 1;
@@ -6288,6 +6826,9 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/southchamb)
+"zH" = (
+/turf/simulated/shuttle/wall/voidcraft/green,
+/area/offmap/aerostat/inside/misclab)
 "zI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
@@ -6295,12 +6836,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/xenoarch)
-"zJ" = (
-/obj/machinery/atmospherics/portables_connector{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/offmap/aerostat/inside/toxins)
 "zM" = (
 /obj/machinery/door/airlock/external,
 /obj/structure/cable{
@@ -6368,15 +6903,6 @@
 /obj/effect/map_helper/airlock/door/int_door,
 /turf/simulated/floor/tiled/steel_ridged,
 /area/offmap/aerostat/inside/arm/nw)
-"Aa" = (
-/obj/machinery/atmospherics/pipe/simple/visible/universal{
-	name = "Distro Loop Drain"
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/offmap/aerostat/inside/northchamb)
 "Ab" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 1
@@ -6409,18 +6935,11 @@
 /turf/simulated/floor,
 /area/offmap/aerostat/inside/arm/se)
 "Ae" = (
-/obj/structure/table/rack,
-/obj/item/device/suit_cooling_unit,
-/obj/item/weapon/storage/belt/archaeology,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/suit/space/anomaly/heat,
-/obj/item/clothing/head/helmet/space/anomaly/heat,
-/obj/item/weapon/pickaxe,
-/obj/item/weapon/storage/excavation,
-/obj/item/stack/flag/yellow,
-/obj/item/weapon/tool/wrench,
-/obj/item/device/measuring_tape,
-/turf/simulated/floor/tiled/white,
+/obj/machinery/door/airlock/glass_research{
+	name = "Xenoarchaeology Storage"
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/tiled/steel_ridged,
 /area/offmap/aerostat/inside/xenoarch)
 "Ah" = (
 /obj/structure/cable{
@@ -6428,6 +6947,13 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/offmap/aerostat/inside/xenoarch)
+"Ai" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/structure/table/standard,
+/turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/telesci)
 "Ak" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
 	dir = 5
@@ -6435,9 +6961,28 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/atmos)
 "Al" = (
-/obj/structure/filingcabinet/chestdrawer,
-/turf/simulated/floor/tiled,
+/obj/machinery/artifact_scanpad,
+/turf/simulated/floor/tiled/dark,
 /area/offmap/aerostat/inside/xenoarch)
+"An" = (
+/obj/structure/table/reinforced,
+/obj/item/weapon/storage/box/monkeycubes,
+/obj/item/weapon/storage/box/monkeycubes,
+/obj/item/weapon/storage/pill_bottle/dylovene,
+/obj/item/weapon/storage/pill_bottle/dylovene,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	layer = 3.3;
+	pixel_x = 26
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/genetics)
 "Ao" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
@@ -6448,11 +6993,15 @@
 /turf/simulated/floor/plating/virgo2,
 /area/offmap/aerostat/inside/southchamb)
 "Ap" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/flora/ausbushes/ppflowers,
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/white,
-/area/offmap/aerostat/inside/misclab)
+/turf/simulated/floor/grass,
+/area/offmap/aerostat/inside/genetics)
 "Aq" = (
 /obj/machinery/door/airlock/glass_research{
 	req_one_access = null
@@ -6468,13 +7017,14 @@
 /turf/simulated/floor/tiled/steel_ridged,
 /area/offmap/aerostat/inside/zorrenoffice)
 "Ar" = (
-/obj/machinery/portable_atmospherics/canister/nitrogen,
-/obj/machinery/door/window/brigdoor/eastleft{
-	req_access = list(7)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/glass_research{
+	name = "Xenoarchaeology Prep Room"
 	},
-/obj/structure/window/reinforced,
-/turf/simulated/floor/tiled/techfloor,
-/area/offmap/aerostat/inside/northchamb)
+/turf/simulated/floor/tiled/steel_ridged,
+/area/offmap/aerostat/inside/xenoarch)
 "As" = (
 /obj/machinery/door/airlock/glass_research{
 	name = "Atmospherics";
@@ -6490,9 +7040,6 @@
 /obj/effect/floor_decal/industrial/warning/dust,
 /obj/structure/table/standard,
 /obj/fiftyspawner/steel,
-/obj/machinery/camera/network/research_outpost{
-	dir = 1
-	},
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/toxins)
 "Au" = (
@@ -6517,13 +7064,11 @@
 /turf/simulated/floor/reinforced/airless,
 /area/offmap/aerostat/inside/toxins)
 "Ay" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
+/obj/machinery/atmospherics/pipe/manifold/visible/red,
+/obj/machinery/meter,
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/toxins)
 "Az" = (
@@ -6533,9 +7078,6 @@
 /turf/simulated/shuttle/wall/voidcraft/green,
 /area/offmap/aerostat/inside/powercontrol)
 "AB" = (
-/obj/machinery/door/airlock/glass_research{
-	name = "Xenoarchaeology"
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -6544,8 +7086,7 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/machinery/door/firedoor/glass,
-/turf/simulated/floor/tiled/steel_ridged,
+/turf/simulated/wall,
 /area/offmap/aerostat/inside/toxins)
 "AC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
@@ -6554,25 +7095,22 @@
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/toxins)
 "AD" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/rust,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor,
-/area/offmap/aerostat/inside/xenoarch)
+/area/offmap/aerostat/inside/arm/ne)
 "AE" = (
-/obj/effect/floor_decal/industrial/warning,
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
+/obj/item/weapon/virusdish/random,
+/obj/item/weapon/virusdish/random,
+/obj/item/weapon/virusdish/random,
+/obj/item/weapon/virusdish/random,
+/obj/item/weapon/virusdish/random,
+/obj/structure/closet/crate/medical{
+	name = "Virus Samples"
 	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor,
-/area/offmap/aerostat/inside/xenoarch)
+/turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/virology)
 "AF" = (
 /obj/structure/cable/heavyduty{
 	icon_state = "4-8"
@@ -6639,12 +7177,26 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/westhall)
+"AR" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/canister/air/airlock,
+/turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/firingrange)
 "AX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 5
 	},
 /turf/simulated/shuttle/wall/voidcraft/green/virgo2,
 /area/offmap/aerostat/inside/arm/se)
+"AY" = (
+/obj/machinery/portable_atmospherics/powered/scrubber/huge/stationary{
+	scrub_id = "science_outpost"
+	},
+/obj/machinery/light,
+/turf/simulated/floor/plating,
+/area/offmap/aerostat/inside/toxins)
 "Bb" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden,
 /obj/structure/cable{
@@ -6658,12 +7210,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/airlock/north)
-"Bc" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/wall,
-/area/offmap/aerostat/inside/toxins)
 "Be" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 6
@@ -6676,12 +7222,11 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/southchamb)
-"Bh" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 9
-	},
-/turf/simulated/floor/tiled,
-/area/offmap/aerostat/inside/genetics)
+"Bi" = (
+/obj/effect/floor_decal/rust,
+/obj/effect/decal/cleanable/blood/oil,
+/turf/simulated/floor,
+/area/offmap/aerostat/inside/arm/ne)
 "Bj" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -6689,11 +7234,24 @@
 /turf/simulated/floor/tiled/dark,
 /area/offmap/aerostat/inside/xenoarch/chamber)
 "Bk" = (
-/obj/machinery/atmospherics/portables_connector,
+/obj/structure/cable,
+/obj/machinery/power/apc{
+	dir = 1;
+	pixel_y = 24
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/dispenser{
+	phorontanks = 0
+	},
 /turf/simulated/floor/tiled/white,
-/area/offmap/aerostat/inside/toxins)
+/area/offmap/aerostat/inside/xenoarch)
 "Bm" = (
 /obj/machinery/camera/network/research_outpost,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/easthall)
 "Bo" = (
@@ -6727,53 +7285,34 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/southchamb)
-"Br" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/offmap/aerostat/inside/toxins)
 "Bs" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/blue,
 /turf/simulated/shuttle/wall/voidcraft/green,
 /area/offmap/aerostat/inside/powercontrol)
-"Bt" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
+"Bv" = (
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/structure/closet/crate/bin{
-	anchored = 1
+/obj/machinery/atmospherics/pipe/simple/visible,
+/obj/machinery/firealarm{
+	dir = 4;
+	layer = 3.3;
+	pixel_x = 26
 	},
-/turf/simulated/floor/tiled,
-/area/offmap/aerostat/inside/genetics)
-"Bu" = (
-/obj/machinery/dna_scannernew,
-/turf/simulated/floor/tiled,
-/area/offmap/aerostat/inside/genetics)
-"By" = (
 /turf/simulated/floor/tiled/white,
-/area/offmap/aerostat/inside/misclab)
+/area/offmap/aerostat/inside/toxins)
 "Bz" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/plating/virgo2,
-/area/offmap/aerostat/inside/genetics)
+/area/offmap/aerostat/inside/westhall)
 "BA" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/machinery/door/firedoor/glass,
-/turf/simulated/floor/plating/virgo2,
-/area/offmap/aerostat/inside/northchamb)
-"BB" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/red{
+	dir = 10
 	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/offmap/aerostat/inside/misclab)
+/turf/simulated/shuttle/wall/voidcraft/green,
+/area/offmap/aerostat/inside/atmos)
 "BE" = (
 /obj/machinery/light/floortube{
 	dir = 8;
@@ -6794,15 +7333,17 @@
 /turf/simulated/floor/tiled/dark,
 /area/offmap/aerostat/inside/lobby)
 "BG" = (
-/obj/machinery/portable_atmospherics/powered/scrubber/huge/stationary{
-	scrub_id = "science_outpost"
+/obj/machinery/atmospherics/pipe/simple/visible/blue{
+	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/blue,
+/obj/machinery/camera/network/research_outpost{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/toxins)
 "BH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/table/steel_reinforced,
+/obj/structure/table/borosilicate,
 /turf/simulated/floor/tiled/dark,
 /area/offmap/aerostat/inside/lobby)
 "BK" = (
@@ -6811,19 +7352,6 @@
 	},
 /turf/simulated/shuttle/wall/voidcraft/green,
 /area/offmap/aerostat/inside/airlock/east)
-"BM" = (
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/warning/corner,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/offmap/aerostat/inside/xenoarch)
 "BO" = (
 /obj/structure/cable/heavyduty{
 	icon_state = "0-8"
@@ -6876,9 +7404,15 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/easthall)
+"BT" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/toxins)
 "BU" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/toxins)
@@ -6897,20 +7431,18 @@
 	name = "Distro Loop Drain"
 	},
 /turf/simulated/floor/tiled/techfloor,
-/area/offmap/aerostat/inside/northchamb)
-"BX" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/area/offmap/aerostat/inside/atmos)
+"Ca" = (
+/obj/structure/table/standard,
+/obj/item/weapon/folder/white,
+/obj/item/weapon/pen/fountain,
+/obj/item/device/assembly_holder/timer_igniter,
+/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/obj/machinery/alarm{
-	pixel_y = 26
-	},
-/turf/simulated/floor/tiled/white,
-/area/offmap/aerostat/inside/misclab)
-"Ca" = (
-/obj/machinery/computer/area_atmos/tag{
-	dir = 8;
-	scrub_id = "science_outpost"
+/obj/item/weapon/weldingtool,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 30
 	},
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/toxins)
@@ -6921,17 +7453,23 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/wall,
-/area/offmap/aerostat/inside/toxins)
-"Cd" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/machinery/door/firedoor/glass,
-/turf/simulated/floor/plating/virgo2,
 /area/offmap/aerostat/inside/xenoarch)
+"Cd" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/offmap/aerostat/inside/northchamb)
 "Ce" = (
 /turf/simulated/wall,
 /area/offmap/aerostat/inside/atmos)
@@ -6966,39 +7504,23 @@
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/cyan,
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/atmos)
-"Cq" = (
-/obj/structure/reagent_dispensers/watertank,
-/turf/simulated/floor/tiled/white,
-/area/offmap/aerostat/inside/xenoarch)
-"Ct" = (
-/obj/machinery/light/floortube{
-	dir = 4;
-	pixel_x = 5
-	},
-/turf/simulated/floor/tiled/white,
-/area/offmap/aerostat/inside/misclab)
-"Cu" = (
-/obj/structure/closet/secure_closet/xenoarchaeologist,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/offmap/aerostat/inside/xenoarch)
-"Cw" = (
-/obj/structure/table/standard,
-/obj/item/weapon/tool/crowbar,
-/obj/item/weapon/anodevice{
-	pixel_x = -2
-	},
-/obj/item/weapon/anodevice{
-	pixel_x = 1
-	},
-/obj/item/device/multitool,
-/obj/effect/floor_decal/spline/plain{
-	dir = 1
-	},
+"Cm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techfloor,
+/area/offmap/aerostat/inside/northchamb)
+"Cu" = (
+/obj/structure/cable/heavyduty{
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/rust,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor,
+/area/offmap/aerostat/inside/arm/ne)
+"Cw" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/power/apc,
+/obj/structure/cable,
+/turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/xenoarch)
 "CA" = (
 /obj/effect/floor_decal/industrial/warning/dust{
@@ -7014,12 +7536,15 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/machinery/firealarm{
+	layer = 3.3;
+	pixel_y = -28
+	},
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/toxins)
 "CE" = (
-/obj/machinery/atmospherics/binary/pump,
-/obj/machinery/atmospherics/pipe/simple/hidden/universal{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/toxins)
@@ -7037,7 +7562,7 @@
 /obj/effect/floor_decal/industrial/warning/dust{
 	dir = 4
 	},
-/obj/structure/table/glass,
+/obj/structure/table/borosilicate,
 /turf/simulated/floor/tiled/dark,
 /area/offmap/aerostat/inside/lobby)
 "CJ" = (
@@ -7073,6 +7598,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/toxins)
+"CN" = (
+/obj/structure/table/wooden_reinforced,
+/turf/simulated/floor/tiled/techfloor,
+/area/offmap/aerostat/inside/southchamb)
 "CO" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
 	dir = 4
@@ -7095,30 +7624,28 @@
 /obj/structure/cable/heavyduty{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/machinery/door/firedoor/glass,
+/obj/effect/floor_decal/rust,
 /obj/machinery/door/airlock/maintenance/rnd{
 	req_one_access = null
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/machinery/door/firedoor/glass,
-/turf/simulated/floor/tiled/steel_ridged,
-/area/offmap/aerostat/inside/misclab)
+/turf/simulated/floor,
+/area/offmap/aerostat/inside/arm/se)
 "CT" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/obj/structure/table/steel_reinforced,
 /obj/random/firstaid,
+/obj/structure/table/borosilicate,
 /turf/simulated/floor/tiled/dark,
 /area/offmap/aerostat/inside/lobby)
 "CV" = (
 /obj/structure/cable/heavyduty{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
 /turf/simulated/floor/tiled/white,
-/area/offmap/aerostat/inside/misclab)
+/area/offmap/aerostat/inside/miscstorage)
 "Da" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/green{
 	dir = 1
@@ -7130,7 +7657,7 @@
 /area/offmap/aerostat/inside/atmos)
 "Db" = (
 /turf/simulated/shuttle/wall/voidcraft/green/virgo2/nocol,
-/area/offmap/aerostat/inside/xenoarch)
+/area/offmap/aerostat/inside/virology)
 "Dd" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
@@ -7139,9 +7666,11 @@
 /turf/simulated/floor/plating/virgo2,
 /area/offmap/aerostat/inside/airlock/east)
 "De" = (
-/obj/machinery/computer/telescience,
-/turf/simulated/floor/reinforced,
-/area/offmap/aerostat/inside/telesci)
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/miscstorage)
 "Dg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -7155,6 +7684,17 @@
 	},
 /turf/simulated/wall,
 /area/offmap/aerostat/inside/toxins)
+"Di" = (
+/obj/structure/flora/pottedplant/minitree,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc{
+	dir = 8;
+	pixel_x = -22
+	},
+/turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/virology)
 "Dk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/light/floortube{
@@ -7166,16 +7706,10 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/airlock/south)
-"Dl" = (
-/obj/structure/cable/heavyduty{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/white,
-/area/offmap/aerostat/inside/firingrange)
+"Dp" = (
+/obj/structure/sign/department/virology,
+/turf/simulated/shuttle/wall/voidcraft/green,
+/area/offmap/aerostat/inside/virology)
 "Dq" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -7226,13 +7760,28 @@
 /obj/structure/cable/heavyduty{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/turf/simulated/floor/tiled/white,
-/area/offmap/aerostat/inside/misclab)
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 6
+	},
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor,
+/area/offmap/aerostat/inside/arm/se)
 "DC" = (
 /turf/simulated/shuttle/wall/voidcraft/green,
 /area/offmap/aerostat/inside/airlock/south)
+"DD" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/outline/red,
+/turf/simulated/floor/tiled/techfloor,
+/area/offmap/aerostat/inside/atmos)
+"DE" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/miscstorage)
 "DF" = (
 /obj/machinery/door/airlock/multi_tile/metal{
 	dir = 1;
@@ -7249,19 +7798,15 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/structure/closet/crate/bin{
-	anchored = 1
-	},
+/obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/firingrange)
 "DH" = (
 /obj/structure/cable/heavyduty{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/sign/poster{
-	dir = 8;
-	pixel_x = -32
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/toxins)
@@ -7270,20 +7815,21 @@
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/toxins)
 "DJ" = (
-/obj/structure/cable/heavyduty{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/blue{
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/aux{
 	dir = 4
 	},
+/obj/structure/cable/heavyduty{
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/toxins)
 "DK" = (
 /obj/machinery/door/airlock/multi_tile/glass{
-	name = "Toxins Lab"
+	name = "Toxins Lab";
+	req_one_access = list(47)
 	},
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/tiled/steel_ridged,
@@ -7299,11 +7845,13 @@
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/toxins)
 "DM" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/red{
-	dir = 8
+/obj/machinery/alarm{
+	alarm_id = "anomaly_testing";
+	dir = 4;
+	pixel_x = -23
 	},
 /turf/simulated/floor/tiled/techfloor,
-/area/offmap/aerostat/inside/northchamb)
+/area/offmap/aerostat/inside/atmos)
 "DN" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 10
@@ -7317,12 +7865,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/power/apc{
 	dir = 8;
-	name = "east bump";
 	pixel_x = -22
 	},
 /obj/structure/cable,
-/obj/structure/table/standard,
-/obj/item/device/multitool,
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/telesci)
 "DP" = (
@@ -7345,6 +7890,10 @@
 	},
 /turf/simulated/floor,
 /area/offmap/aerostat/inside/airlock/south)
+"DV" = (
+/obj/machinery/recharge_station,
+/turf/simulated/floor/tiled/techfloor,
+/area/offmap/aerostat/inside/southchamb)
 "DY" = (
 /obj/effect/floor_decal/rust,
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction{
@@ -7353,11 +7902,10 @@
 /turf/simulated/floor/plating/virgo2,
 /area/offmap/aerostat/solars)
 "Eb" = (
-/obj/effect/floor_decal/spline/plain{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/offmap/aerostat/inside/xenoarch)
+/obj/machinery/portable_atmospherics/powered/pump,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/toxins)
 "Eh" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 1
@@ -7377,6 +7925,13 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/westhall)
+"Em" = (
+/obj/machinery/hologram/holopad,
+/obj/machinery/atmospherics/binary/pump{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/toxins)
 "Ep" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1380;
@@ -7398,6 +7953,10 @@
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/zorrenoffice)
+"Et" = (
+/obj/structure/ore_box,
+/turf/simulated/floor/tiled,
+/area/offmap/aerostat/inside/drillstorage)
 "Eu" = (
 /obj/machinery/atmospherics/portables_connector/aux{
 	dir = 4
@@ -7426,12 +7985,26 @@
 /area/offmap/aerostat/inside/firingrange)
 "Ey" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/universal,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
 /turf/simulated/floor/tiled,
-/area/offmap/aerostat/inside/genetics)
+/area/offmap/aerostat/inside/misclab)
+"EA" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/plating/virgo2,
+/area/offmap/aerostat/inside/misclab)
+"EC" = (
+/obj/structure/table/reinforced,
+/obj/item/weapon/reagent_containers/glass/beaker,
+/obj/item/weapon/reagent_containers/glass/beaker,
+/turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/virology)
 "ED" = (
 /obj/machinery/atmospherics/omni/atmos_filter{
 	name = "N2/O2 Filter";
@@ -7441,14 +8014,7 @@
 	tag_west = 3
 	},
 /turf/simulated/floor/tiled/techfloor,
-/area/offmap/aerostat/inside/northchamb)
-"EF" = (
-/obj/effect/floor_decal/industrial/warning,
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/turf/simulated/floor,
-/area/offmap/aerostat/inside/xenoarch)
+/area/offmap/aerostat/inside/atmos)
 "EI" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -7473,30 +8039,56 @@
 "EN" = (
 /turf/simulated/shuttle/wall/voidcraft/green,
 /area/offmap/aerostat/inside/airlock/west)
+"EP" = (
+/obj/structure/table/wooden_reinforced,
+/obj/item/weapon/reagent_containers/food/drinks/cup{
+	pixel_x = -5;
+	pixel_y = 4
+	},
+/obj/item/weapon/reagent_containers/food/drinks/cup{
+	pixel_x = 5;
+	pixel_y = 4
+	},
+/obj/item/weapon/reagent_containers/food/drinks/cup{
+	pixel_x = -5;
+	pixel_y = -4
+	},
+/obj/item/weapon/reagent_containers/food/drinks/cup{
+	pixel_x = 5;
+	pixel_y = -4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/offmap/aerostat/inside/southchamb)
 "EQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/bluegrid,
 /area/offmap/aerostat/inside/powercontrol)
 "ER" = (
-/obj/machinery/light{
-	dir = 1
+/turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/miscstorage)
+"ES" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	layer = 3.3;
+	pixel_x = 26
 	},
 /turf/simulated/floor/tiled/white,
-/area/offmap/aerostat/inside/misclab)
-"ES" = (
-/turf/simulated/floor/reinforced,
 /area/offmap/aerostat/inside/telesci)
 "EV" = (
 /obj/effect/floor_decal/industrial/warning/dust,
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/toxins)
+"EW" = (
+/obj/structure/table/standard,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/random/toolbox,
+/turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/miscstorage)
 "EX" = (
 /obj/structure/cable/heavyduty{
 	icon_state = "4-8"
-	},
-/obj/structure/sign/directions/science/xenoarch{
-	dir = 1;
-	pixel_y = 32
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
@@ -7504,14 +8096,17 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/easthall)
 "Fa" = (
 /obj/effect/floor_decal/industrial/warning/dust{
 	dir = 8
 	},
-/obj/structure/table/glass,
 /obj/random/maintenance/research,
+/obj/structure/table/borosilicate,
 /turf/simulated/floor/tiled/dark,
 /area/offmap/aerostat/inside/lobby)
 "Ff" = (
@@ -7525,7 +8120,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/tiled/techfloor,
-/area/offmap/aerostat/inside/northchamb)
+/area/offmap/aerostat/inside/atmos)
 "Fi" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 4
@@ -7549,6 +8144,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/xenoarch)
 "Fo" = (
@@ -7602,12 +8198,7 @@
 /turf/simulated/floor/reinforced/airless,
 /area/offmap/aerostat/inside/toxins)
 "Fw" = (
-/obj/machinery/atmospherics/trinary/atmos_filter{
-	dir = 4;
-	name = "High Power Gas filter";
-	power_rating = 15000;
-	use_power = 0
-	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/black,
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/toxins)
 "Fy" = (
@@ -7625,6 +8216,15 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/airlock/south)
+"FA" = (
+/obj/structure/bed/chair/comfy/black{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/offmap/aerostat/inside/southchamb)
 "FD" = (
 /obj/effect/floor_decal/industrial/warning/dust,
 /obj/structure/cable{
@@ -7633,8 +8233,8 @@
 /turf/simulated/floor/tiled/dark,
 /area/offmap/aerostat/inside/lobby)
 "FF" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/machinery/camera/network/research_outpost,
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/toxins)
 "FJ" = (
@@ -7644,11 +8244,8 @@
 /turf/simulated/shuttle/wall/voidcraft/green,
 /area/offmap/aerostat/inside/airlock/west)
 "FK" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 30
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
+/obj/machinery/portable_atmospherics/powered/scrubber/huge/stationary{
+	scrub_id = "science_outpost"
 	},
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/toxins)
@@ -7673,10 +8270,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
-	},
-/obj/machinery/light/floortube{
-	dir = 4;
-	pixel_x = 5
 	},
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/firingrange)
@@ -7709,20 +8302,22 @@
 /turf/simulated/floor/plating/virgo2,
 /area/offmap/aerostat/solars)
 "FX" = (
-/obj/structure/table/steel_reinforced,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/structure/table/borosilicate,
 /turf/simulated/floor/tiled/dark,
 /area/offmap/aerostat/inside/lobby)
-"Gb" = (
-/obj/effect/floor_decal/spline/plain{
-	dir = 4
+"FY" = (
+/turf/simulated/shuttle/wall/voidcraft/hard_corner{
+	stripe_color = "#00FF00"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/area/offmap/aerostat/inside/misclab)
+"FZ" = (
+/obj/machinery/alarm{
+	pixel_y = 26
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark,
 /area/offmap/aerostat/inside/xenoarch)
 "Gc" = (
 /obj/effect/shuttle_landmark{
@@ -7755,25 +8350,28 @@
 /turf/unsimulated/floor/sky/virgo2_sky,
 /area/offmap/aerostat)
 "Gf" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/structure/window/reinforced,
-/turf/simulated/floor/tiled/techfloor,
-/area/offmap/aerostat/inside/northchamb)
-"Gi" = (
-/obj/structure/cable{
-	icon_state = "2-8"
+/obj/effect/floor_decal/rust,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
 	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/offmap/aerostat/inside/xenoarch)
+"Gi" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/suspension_gen,
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/xenoarch)
 "Gl" = (
 /obj/effect/floor_decal/industrial/warning/dust{
 	dir = 4
 	},
-/obj/structure/table/glass,
 /obj/random/maintenance/research,
+/obj/structure/table/borosilicate,
 /turf/simulated/floor/tiled/dark,
 /area/offmap/aerostat/inside/lobby)
 "Gm" = (
@@ -7781,16 +8379,20 @@
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/tiled/steel_ridged,
 /area/offmap/aerostat/inside/powercontrol)
-"Go" = (
-/turf/simulated/floor/tiled,
-/area/offmap/aerostat/inside/genetics)
+"Gn" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/toxins)
 "Gq" = (
 /obj/structure/cable/heavyduty{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden,
-/turf/simulated/floor/tiled/white,
-/area/offmap/aerostat/inside/misclab)
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor,
+/area/offmap/aerostat/inside/arm/se)
 "Gr" = (
 /obj/structure/cable/heavyduty{
 	icon_state = "4-8"
@@ -7824,20 +8426,21 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/westhall)
 "Gt" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/machinery/portable_atmospherics/powered/scrubber/huge/stationary{
+	scrub_id = "science_outpost"
+	},
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/toxins)
 "Gu" = (
-/obj/machinery/door/airlock/glass_research{
-	name = "Toxins Lab"
+/obj/structure/window/reinforced{
+	dir = 4
 	},
-/obj/machinery/door/firedoor/glass,
+/obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/toxins)
-"Gv" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/turf/simulated/floor/tiled/white,
-/area/offmap/aerostat/inside/misclab)
 "Gy" = (
 /obj/structure/bed/chair/shuttle{
 	dir = 8
@@ -7905,7 +8508,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/wall,
-/area/offmap/aerostat/inside/toxins)
+/area/offmap/aerostat/inside/xenoarch)
 "GG" = (
 /obj/effect/floor_decal/rust,
 /obj/structure/cable/yellow{
@@ -7916,17 +8519,22 @@
 	},
 /turf/simulated/floor/plating/virgo2,
 /area/offmap/aerostat/solars)
-"GK" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
+"GI" = (
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_x = 32;
+	pixel_y = -24
 	},
+/turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/xenoarch)
+"GK" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/wall,
 /area/offmap/aerostat/inside/toxins)
 "GL" = (
-/obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/manifold/visible/red{
 	dir = 1
 	},
@@ -7944,6 +8552,14 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/zorrenoffice)
+"GO" = (
+/obj/structure/table/reinforced,
+/obj/item/weapon/folder/white,
+/obj/item/weapon/pen,
+/obj/item/weapon/paper_bin,
+/obj/item/weapon/hand_labeler,
+/turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/virology)
 "GP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
@@ -7952,15 +8568,10 @@
 /turf/simulated/wall,
 /area/offmap/aerostat/inside/telesci)
 "GR" = (
-/obj/structure/cable/heavyduty{
-	icon_state = "1-2"
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/white,
-/area/offmap/aerostat/inside/toxins)
+/obj/structure/closet/crate/science,
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor,
+/area/offmap/aerostat/inside/xenoarch)
 "GT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
@@ -7974,40 +8585,64 @@
 /obj/effect/floor_decal/industrial/danger/corner{
 	dir = 4
 	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	layer = 3.3;
+	pixel_y = -28
+	},
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/xenoarch)
 "GX" = (
-/obj/machinery/atmospherics/binary/pump{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/toxins)
+"Ha" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/machinery/light{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/toxins)
-"Ha" = (
-/obj/machinery/atmospherics/omni/atmos_filter{
-	name = "Phoron Filter";
-	tag_east = 6;
-	tag_north = 1;
-	tag_south = 2
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/offmap/aerostat/inside/northchamb)
 "Hb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/blue{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/green,
+/obj/structure/cable/heavyduty{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/toxins)
 "Hd" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/manifold/visible{
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/toxins)
+"Hh" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/table/standard,
+/obj/item/weapon/storage/box/beakers,
+/obj/item/weapon/reagent_containers/glass/beaker/large,
+/obj/item/weapon/reagent_containers/dropper,
+/obj/machinery/reagentgrinder,
+/obj/structure/reagent_dispensers/acid{
+	pixel_x = 31
+	},
+/turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/xenoarch)
 "Hj" = (
 /obj/structure/table/steel_reinforced,
 /obj/machinery/light_switch{
@@ -8036,13 +8671,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/easthall)
-"Hn" = (
-/obj/machinery/artifact_harvester,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/offmap/aerostat/inside/xenoarch)
 "Ho" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -8065,18 +8693,24 @@
 /turf/simulated/shuttle/floor/yellow/airless,
 /area/shuttle/aerostat)
 "Hq" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/westhall)
+"Hs" = (
+/obj/structure/cable/heavyduty{
+	icon_state = "1-2"
+	},
+/obj/machinery/camera/network/research_outpost{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/firingrange)
 "Ht" = (
 /turf/simulated/shuttle/wall/voidcraft/green,
-/area/offmap/aerostat/inside/misclab)
+/area/offmap/aerostat/inside/genetics)
 "Hu" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
@@ -8108,25 +8742,25 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/glass_research{
-	name = "Telescience"
+	name = "Miscellaneous Storage";
+	req_one_access = null
 	},
 /obj/machinery/door/firedoor/glass,
-/turf/simulated/floor/tiled/steel_ridged,
-/area/offmap/aerostat/inside/telesci)
-"Hx" = (
-/obj/machinery/atmospherics/portables_connector{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
+/turf/simulated/floor/tiled/steel_ridged,
+/area/offmap/aerostat/inside/miscstorage)
+"Hx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/portable_atmospherics/canister/air/airlock,
 /obj/machinery/camera/network/research_outpost{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/xenoarch)
 "Hy" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/northchamb)
@@ -8137,15 +8771,26 @@
 /turf/simulated/floor/bluegrid,
 /area/offmap/aerostat/inside/powercontrol)
 "HA" = (
-/obj/machinery/artifact_scanpad,
-/turf/simulated/floor/tiled/dark,
-/area/offmap/aerostat/inside/xenoarch)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/virology)
+"HE" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/virology)
 "HH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -8156,33 +8801,42 @@
 /obj/structure/cable/heavyduty{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/firingrange)
 "HK" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/black{
-	dir = 4
+/obj/structure/table/wooden_reinforced,
+/turf/simulated/floor/glass/reinforced{
+	color = "#eacd7c"
 	},
-/obj/machinery/light,
-/turf/simulated/floor/tiled/techfloor,
-/area/offmap/aerostat/inside/northchamb)
+/area/offmap/aerostat/glassgetsitsownarea)
 "HL" = (
-/obj/machinery/atmospherics/pipe/manifold4w/visible,
-/obj/machinery/meter,
+/obj/machinery/washing_machine,
 /turf/simulated/floor/tiled/white,
-/area/offmap/aerostat/inside/toxins)
+/area/offmap/aerostat/inside/xenoarch)
 "HM" = (
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/telesci)
+"HN" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/blast/shutters{
+	dir = 2;
+	id = "zorrenpartyroom";
+	layer = 3.3;
+	name = "shutter"
+	},
+/turf/simulated/floor/plating/virgo2,
+/area/offmap/aerostat/inside/zorrenoffice)
 "HO" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/structure/flora/pottedplant/subterranean,
+/obj/machinery/camera/network/research_outpost{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/xenoarch)
 "HQ" = (
@@ -8193,25 +8847,23 @@
 /turf/simulated/floor/plating/virgo2,
 /area/offmap/aerostat/inside/southchamb)
 "HR" = (
-/obj/structure/table/standard,
-/obj/item/device/gps{
-	pixel_x = -5;
-	pixel_y = 5
-	},
-/obj/item/device/gps{
-	pixel_x = -2;
-	pixel_y = 2
-	},
-/obj/item/device/gps{
-	pixel_x = 1;
-	pixel_y = -1
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled/white,
-/area/offmap/aerostat/inside/telesci)
+/area/offmap/aerostat/inside/miscstorage)
 "HS" = (
-/obj/structure/flora/pottedplant/crystal,
-/turf/simulated/floor/tiled/white,
-/area/offmap/aerostat/inside/firingrange)
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 10
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/offmap/aerostat/inside/westhall)
 "HT" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -8224,11 +8876,21 @@
 /obj/machinery/atmospherics/binary/pump/on{
 	dir = 8
 	},
+/obj/machinery/power/apc,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/toxins)
 "HV" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/red{
-	dir = 1
+/obj/machinery/atmospherics/portables_connector{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/outline/red,
+/obj/machinery/firealarm{
+	dir = 4;
+	layer = 3.3;
+	pixel_x = 26
 	},
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/toxins)
@@ -8241,10 +8903,11 @@
 /turf/simulated/floor/tiled/steel_ridged,
 /area/shuttle/aerostat)
 "Id" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/red,
-/obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/red{
+	dir = 9
 	},
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/toxins)
@@ -8255,25 +8918,31 @@
 /turf/simulated/shuttle/wall/voidcraft/green/virgo2/nocol,
 /area/offmap/aerostat/inside/airlock/east)
 "Ih" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/black{
-	dir = 6
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/portables_connector{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/toxins)
 "Ii" = (
-/obj/machinery/atmospherics/binary/pump/on{
-	name = "Scrubber to Waste"
-	},
 /obj/machinery/camera/network/research_outpost{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/red{
+	dir = 5
+	},
 /turf/simulated/floor/tiled/techfloor,
-/area/offmap/aerostat/inside/northchamb)
+/area/offmap/aerostat/inside/atmos)
 "Ij" = (
 /obj/effect/floor_decal/industrial/danger{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/camera/network/research_outpost{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
@@ -8292,27 +8961,21 @@
 /turf/simulated/floor/plating/virgo2,
 /area/offmap/aerostat/solars)
 "In" = (
-/obj/effect/floor_decal/industrial/warning/dust{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
+	dir = 1
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/offmap/aerostat/inside/northchamb)
+/turf/simulated/wall,
+/area/offmap/aerostat/inside/atmos)
 "Ip" = (
-/obj/structure/table/standard,
-/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/xenoarch)
 "Ir" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "east bump";
-	pixel_x = -22
+/obj/machinery/artifact_analyser,
+/obj/machinery/camera/network/research_outpost{
+	dir = 4
 	},
-/obj/structure/cable,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark,
 /area/offmap/aerostat/inside/xenoarch)
 "Is" = (
 /obj/machinery/atmospherics/valve,
@@ -8322,12 +8985,10 @@
 /turf/simulated/shuttle/wall/voidcraft/green,
 /area/offmap/aerostat/inside/arm/se)
 "Iu" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/light{
-	dir = 8
-	},
 /obj/structure/table/standard,
-/obj/item/weapon/ore/bluespace_crystal,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/telesci)
 "Iw" = (
@@ -8355,14 +9016,9 @@
 /turf/simulated/shuttle/wall/voidcraft/green,
 /area/offmap/aerostat/inside/airlock/south)
 "IA" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/blue{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/disease2/diseaseanalyser,
 /turf/simulated/floor/tiled/white,
-/area/offmap/aerostat/inside/toxins)
+/area/offmap/aerostat/inside/virology)
 "IB" = (
 /obj/structure/grille,
 /obj/structure/grille,
@@ -8380,6 +9036,7 @@
 /obj/structure/closet/crate/bin{
 	anchored = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/dark,
 /area/offmap/aerostat/inside/lobby)
 "IH" = (
@@ -8400,7 +9057,6 @@
 /obj/structure/cable,
 /obj/machinery/power/apc{
 	dir = 8;
-	name = "east bump";
 	pixel_x = -22
 	},
 /obj/machinery/mining/drill,
@@ -8422,16 +9078,29 @@
 /turf/simulated/floor/plating/virgo2,
 /area/offmap/aerostat/inside/southchamb)
 "IN" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 4
+	},
 /obj/machinery/atmospherics/binary/pump/on{
-	name = "phoron pump"
+	name = "N2O pump"
 	},
 /turf/simulated/floor/tiled/techfloor,
-/area/offmap/aerostat/inside/northchamb)
+/area/offmap/aerostat/inside/atmos)
+"IO" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/plating/virgo2,
+/area/offmap/aerostat/inside/virology)
 "IP" = (
 /turf/simulated/shuttle/wall/voidcraft/hard_corner{
 	stripe_color = "#00FF00"
 	},
-/area/offmap/aerostat/inside/misclab)
+/area/offmap/aerostat/inside/genetics)
+"IS" = (
+/obj/machinery/telepad,
+/turf/simulated/floor/reinforced,
+/area/offmap/aerostat/inside/telesci)
 "IV" = (
 /obj/machinery/airlock_sensor{
 	dir = 1;
@@ -8491,19 +9160,25 @@
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/plating/virgo2,
 /area/offmap/aerostat/inside/airlock/south)
-"Ji" = (
-/obj/structure/cable/heavyduty{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden{
-	dir = 8
+"Je" = (
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -23
 	},
 /turf/simulated/floor/tiled/white,
-/area/offmap/aerostat/inside/misclab)
+/area/offmap/aerostat/inside/virology)
+"Ji" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/rust,
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/maintenance/rnd{
+	req_one_access = null
+	},
+/turf/simulated/floor/tiled/steel_ridged,
+/area/offmap/aerostat/inside/arm/se)
 "Jn" = (
-/obj/structure/table/steel_reinforced,
 /obj/random/maintenance/research,
+/obj/structure/table/borosilicate,
 /turf/simulated/floor/tiled/dark,
 /area/offmap/aerostat/inside/lobby)
 "Jo" = (
@@ -8524,16 +9199,18 @@
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/xenoarch)
 "Jr" = (
-/obj/structure/sign/painting/public{
-	pixel_y = 30
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/machinery/light{
+	dir = 8
 	},
-/turf/simulated/floor/tiled/white,
-/area/offmap/aerostat/inside/toxins)
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor,
+/area/offmap/aerostat/inside/arm/ne)
 "Ju" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/black{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/wall,
 /area/offmap/aerostat/inside/toxins)
 "Jz" = (
 /obj/structure/grille,
@@ -8578,8 +9255,27 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/simulated/wall,
+/obj/machinery/door/airlock/glass_research{
+	name = "Toxins Lab"
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/tiled/steel_ridged,
 /area/offmap/aerostat/inside/toxins)
+"JE" = (
+/obj/structure/cable/heavyduty{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/alarm{
+	pixel_y = 26
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/offmap/aerostat/inside/easthall)
 "JG" = (
 /obj/structure/metal_edge,
 /turf/unsimulated/floor/sky/virgo2_sky,
@@ -8600,11 +9296,10 @@
 /turf/simulated/floor,
 /area/offmap/aerostat/inside/airlock/south)
 "JI" = (
-/obj/machinery/atmospherics/portables_connector{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/offmap/aerostat/inside/toxins)
+/obj/effect/floor_decal/rust,
+/obj/structure/closet/crate/science,
+/turf/simulated/floor,
+/area/offmap/aerostat/inside/xenoarch)
 "JJ" = (
 /obj/structure/grille,
 /obj/structure/window/phoronreinforced{
@@ -8616,13 +9311,13 @@
 /turf/simulated/floor/reinforced/airless,
 /area/offmap/aerostat/inside/toxins)
 "JM" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/airlock/glass_research{
-	name = "Toxins Lab";
-	req_one_access = null
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
 	},
-/obj/machinery/door/firedoor/glass,
-/turf/simulated/floor/tiled/steel_ridged,
+/obj/machinery/atmospherics/pipe/simple/hidden/green{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/toxins)
 "JP" = (
 /obj/structure/cable/heavyduty{
@@ -8634,19 +9329,17 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/easthall)
 "JQ" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
 /obj/machinery/light{
 	dir = 4
 	},
 /obj/structure/flora/pottedplant/minitree,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/dark,
 /area/offmap/aerostat/inside/lobby)
 "JR" = (
 /obj/machinery/light,
 /turf/simulated/floor/tiled/white,
-/area/offmap/aerostat/inside/xenoarch)
+/area/offmap/aerostat/inside/virology)
 "JS" = (
 /obj/machinery/light{
 	dir = 1
@@ -8667,14 +9360,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/door/airlock/glass_research{
-	name = "Toxins Lab"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/glass,
-/turf/simulated/floor/tiled/steel_ridged,
+/turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/toxins)
 "JX" = (
 /obj/structure/cable{
@@ -8685,6 +9374,10 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/offmap/aerostat/inside/lobby)
+"JY" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/xenoarch)
 "JZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -8692,8 +9385,11 @@
 /obj/machinery/light_switch{
 	pixel_y = 25
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/wall,
 /area/offmap/aerostat/inside/telesci)
+"Ka" = (
+/turf/simulated/shuttle/wall/voidcraft/hard_corner,
+/area/offmap/aerostat/inside/genetics)
 "Kc" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1380;
@@ -8709,15 +9405,9 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
+/obj/structure/flora/pottedplant/subterranean,
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/southchamb)
-"Ke" = (
-/obj/machinery/atmospherics/portables_connector{
-	dir = 4
-	},
-/obj/machinery/portable_atmospherics/canister/air/airlock,
-/turf/simulated/floor/tiled/white,
-/area/offmap/aerostat/inside/firingrange)
 "Kh" = (
 /obj/effect/floor_decal/industrial/warning/dust/corner,
 /turf/simulated/floor/tiled/dark,
@@ -8733,6 +9423,12 @@
 "Kj" = (
 /obj/structure/table/standard,
 /obj/item/device/analyzer,
+/obj/machinery/camera/network/research_outpost{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 9
+	},
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/toxins)
 "Kk" = (
@@ -8744,11 +9440,7 @@
 	},
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating/virgo2,
-/area/offmap/aerostat/inside/northchamb)
-"Kn" = (
-/obj/structure/closet/secure_closet/xenoarchaeologist,
-/turf/simulated/floor/tiled/white,
-/area/offmap/aerostat/inside/xenoarch)
+/area/offmap/aerostat/inside/atmos)
 "Ko" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -8766,18 +9458,14 @@
 	},
 /turf/simulated/shuttle/floor/yellow,
 /area/shuttle/aerostat)
-"Kr" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/offmap/aerostat/inside/genetics)
 "Kv" = (
-/turf/simulated/wall,
-/area/offmap/aerostat/inside/genetics)
+/obj/machinery/button/remote/blast_door{
+	id = telesci_blast;
+	name = "Blast Door Control";
+	pixel_x = 25
+	},
+/turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/telesci)
 "Kw" = (
 /obj/machinery/atmospherics/unary/heat_exchanger{
 	dir = 8
@@ -8790,6 +9478,18 @@
 	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/offmap/aerostat/inside/toxins)
+"Kz" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/offmap/aerostat/inside/misclab)
+"KA" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/offmap/aerostat/inside/westhall)
 "KC" = (
 /obj/machinery/alarm{
 	pixel_y = 26
@@ -8797,12 +9497,16 @@
 /turf/simulated/floor/tiled/dark,
 /area/offmap/aerostat/inside/lobby)
 "KD" = (
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/obj/machinery/door/window/brigdoor/eastleft{
-	req_access = list(7)
+/obj/structure/cable/heavyduty{
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/offmap/aerostat/inside/northchamb)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/glass_research{
+	name = "Toxins Lab"
+	},
+/turf/simulated/floor/tiled/steel_ridged,
+/area/offmap/aerostat/inside/toxins)
 "KE" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
@@ -8821,12 +9525,6 @@
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor,
 /area/offmap/aerostat/inside/arm/nw)
-"KG" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/tiled/white,
-/area/offmap/aerostat/inside/misclab)
 "KH" = (
 /obj/machinery/airlock_sensor/airlock_exterior{
 	dir = 6;
@@ -8855,33 +9553,33 @@
 "KK" = (
 /turf/simulated/shuttle/wall/voidcraft/green,
 /area/offmap/aerostat/inside/southchamb)
+"KM" = (
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/medical{
+	name = "Virology Isolation Room";
+	req_access = list (39)
+	},
+/turf/simulated/floor/tiled/steel_ridged,
+/area/offmap/aerostat/inside/virology)
 "KN" = (
 /turf/simulated/shuttle/wall/voidcraft/hard_corner{
 	stripe_color = "#00FF00"
 	},
-/area/offmap/aerostat/inside/xenoarch)
+/area/offmap/aerostat/inside/arm/ne)
 "KP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
 /turf/simulated/floor/tiled/techfloor,
-/area/offmap/aerostat/inside/northchamb)
+/area/offmap/aerostat/inside/atmos)
 "KS" = (
-/obj/machinery/atmospherics/pipe/manifold/visible{
-	dir = 4
-	},
 /obj/machinery/meter,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/visible,
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/toxins)
-"KU" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/offmap/aerostat/inside/xenoarch)
 "KW" = (
 /obj/effect/floor_decal/industrial/warning/dust,
 /obj/machinery/door/airlock/external{
@@ -8897,35 +9595,36 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
 	},
 /turf/simulated/wall,
-/area/offmap/aerostat/inside/toxins)
+/area/offmap/aerostat/inside/xenoarch)
 "Ld" = (
 /turf/simulated/floor,
 /area/offmap/aerostat/inside/firingrange)
 "Lf" = (
-/obj/structure/anomaly_container,
-/turf/simulated/floor,
+/obj/machinery/atmospherics/portables_connector{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/canister/air/airlock,
+/turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/xenoarch)
 "Lg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/table/steel_reinforced,
 /obj/random/firstaid,
 /obj/random/maintenance/research,
 /obj/structure/sign/painting/public{
 	pixel_x = -30
 	},
+/obj/structure/table/borosilicate,
 /turf/simulated/floor/tiled/dark,
 /area/offmap/aerostat/inside/lobby)
 "Lj" = (
-/obj/structure/cable/heavyduty{
-	icon_state = "1-4"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/aux{
 	dir = 9
 	},
+/obj/machinery/light,
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/toxins)
 "Ln" = (
@@ -8935,9 +9634,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/turf/simulated/floor/tiled/white,
-/area/offmap/aerostat/inside/xenoarch)
+/obj/effect/floor_decal/rust,
+/obj/structure/closet/crate,
+/obj/random/maintenance/engineering,
+/obj/random/maintenance/engineering,
+/obj/random/medical/pillbottle,
+/turf/simulated/floor,
+/area/offmap/aerostat/inside/arm/ne)
 "Lo" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 4
@@ -8948,38 +9651,40 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/airlock/north)
 "Lq" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/computer/scan_consolenew,
-/obj/item/weapon/paper{
-	info = "out of order"
-	},
-/obj/machinery/camera/network/research_outpost,
-/turf/simulated/floor/tiled,
-/area/offmap/aerostat/inside/genetics)
-"Ls" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
+/obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/white,
-/area/offmap/aerostat/inside/firingrange)
+/obj/effect/floor_decal/rust,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/offmap/aerostat/inside/westhall)
+"Ls" = (
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/machinery/door/airlock/maintenance/rnd{
+	req_one_access = null
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/steel_ridged,
+/area/offmap/aerostat/inside/westhall)
 "Lt" = (
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/westhall)
 "Lu" = (
-/obj/machinery/light_switch{
-	dir = 4;
-	pixel_x = -24
+/obj/machinery/light{
+	dir = 8
 	},
-/turf/simulated/floor/tiled/white,
-/area/offmap/aerostat/inside/misclab)
+/turf/simulated/floor/reinforced,
+/area/offmap/aerostat/inside/telesci)
 "Ly" = (
-/obj/machinery/camera/network/research_outpost{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/offmap/aerostat/inside/toxins)
+/obj/effect/floor_decal/rust,
+/obj/effect/floor_decal/industrial/outline/red,
+/obj/structure/anomaly_container,
+/turf/simulated/floor,
+/area/offmap/aerostat/inside/xenoarch)
 "LB" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /obj/structure/grille,
@@ -8987,6 +9692,13 @@
 /obj/structure/window/reinforced/full,
 /turf/simulated/floor,
 /area/offmap/aerostat/inside/xenoarch/chamber)
+"LD" = (
+/obj/structure/cable/heavyduty{
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor,
+/area/offmap/aerostat/inside/arm/ne)
 "LF" = (
 /obj/structure/cable/heavyduty{
 	icon_state = "1-4"
@@ -9007,35 +9719,15 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/zorrenoffice)
-"LI" = (
-/obj/structure/closet/firecloset,
-/obj/structure/sign/poster{
-	dir = 4;
-	pixel_x = 32
-	},
-/turf/simulated/floor/tiled/white,
-/area/offmap/aerostat/inside/xenoarch)
 "LK" = (
 /turf/simulated/shuttle/wall/voidcraft/green,
 /area/offmap/aerostat/inside/arm/ne)
-"LN" = (
-/obj/machinery/atmospherics/portables_connector{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/portable_atmospherics/canister/air,
-/turf/simulated/floor/tiled,
-/area/offmap/aerostat/inside/genetics)
 "LR" = (
-/obj/structure/cable/heavyduty{
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/simple/hidden/blue,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/wall,
 /area/offmap/aerostat/inside/toxins)
 "LS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -9047,11 +9739,13 @@
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/xenoarch)
 "LT" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
+/obj/machinery/atmospherics/portables_connector{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/white,
-/area/offmap/aerostat/inside/misclab)
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor,
+/area/offmap/aerostat/inside/arm/se)
 "LW" = (
 /obj/effect/shuttle_landmark{
 	base_area = /area/offmap/aerostat;
@@ -9063,15 +9757,11 @@
 /turf/unsimulated/floor/sky/virgo2_sky,
 /area/offmap/aerostat)
 "LY" = (
-/obj/effect/floor_decal/industrial/warning/corner,
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
-/turf/simulated/floor,
-/area/offmap/aerostat/inside/xenoarch)
+/turf/simulated/wall,
+/area/offmap/aerostat/inside/arm/ne)
 "LZ" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -9103,13 +9793,19 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/white,
-/area/offmap/aerostat/inside/xenoarch)
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor,
+/area/offmap/aerostat/inside/arm/ne)
 "Mc" = (
-/obj/machinery/telepad,
-/obj/effect/floor_decal/industrial/warning/full,
-/turf/simulated/floor/reinforced,
-/area/offmap/aerostat/inside/telesci)
+/obj/structure/cable/heavyduty{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/camera/network/research_outpost{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/miscstorage)
 "Md" = (
 /obj/structure/cable/heavyduty{
 	icon_state = "4-8"
@@ -9119,6 +9815,10 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/westhall)
+"Mf" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/firingrange)
 "Mg" = (
 /obj/machinery/atmospherics/unary/heater{
 	dir = 1;
@@ -9161,6 +9861,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
+/obj/structure/flora/pottedplant/mysterious,
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/zorrenoffice)
 "Ml" = (
@@ -9168,7 +9869,7 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled,
-/area/offmap/aerostat/inside/genetics)
+/area/offmap/aerostat/inside/misclab)
 "Mn" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -9176,23 +9877,13 @@
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/xenoarch)
 "Mp" = (
-/obj/structure/table/standard,
-/obj/item/weapon/storage/box/beakers,
-/obj/item/weapon/reagent_containers/glass/beaker/large,
-/obj/item/weapon/reagent_containers/dropper,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 8
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/wall,
 /area/offmap/aerostat/inside/xenoarch)
 "Ms" = (
 /obj/effect/floor_decal/industrial/warning/dust,
@@ -9207,10 +9898,20 @@
 	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/offmap/aerostat/inside/airlock/west)
-"Mv" = (
-/obj/machinery/atmospherics/pipe/simple/visible/red{
-	dir = 5
+"Mu" = (
+/obj/machinery/atmospherics/unary/freezer{
+	icon_state = "freezer"
 	},
+/obj/structure/sign/painting/public{
+	pixel_y = 30
+	},
+/turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/toxins)
+"Mv" = (
+/obj/machinery/atmospherics/pipe/manifold/visible/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/toxins)
 "Mw" = (
@@ -9231,33 +9932,47 @@
 	},
 /turf/simulated/shuttle/wall/voidcraft/green/virgo2,
 /area/offmap/aerostat/inside/arm/nw)
+"MA" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/firingrange)
+"MB" = (
+/obj/structure/sign/painting/public{
+	pixel_y = 30
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/genetics)
 "MC" = (
 /obj/effect/floor_decal/industrial/warning/dust,
 /turf/simulated/floor/tiled/dark,
 /area/offmap/aerostat/inside/lobby)
+"ME" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/virology)
 "MH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/toxins)
-"MK" = (
-/obj/effect/floor_decal/industrial/warning/corner,
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 1
-	},
-/turf/simulated/floor,
-/area/offmap/aerostat/inside/xenoarch)
 "ML" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/xenoarch)
@@ -9268,11 +9983,11 @@
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/toxins)
 "MO" = (
-/obj/machinery/atmospherics/pipe/tank/phoron{
+/obj/machinery/atmospherics/pipe/tank/nitrous_oxide{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor,
-/area/offmap/aerostat/inside/northchamb)
+/area/offmap/aerostat/inside/atmos)
 "MR" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -9286,6 +10001,12 @@
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating/virgo2,
 /area/offmap/aerostat/inside/toxins)
+"MZ" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/offmap/aerostat/inside/southchamb)
 "Na" = (
 /obj/effect/floor_decal/industrial/warning/dust{
 	dir = 1
@@ -9312,9 +10033,8 @@
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/firingrange)
 "Ng" = (
-/obj/effect/floor_decal/industrial/warning/dust/corner,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
+/obj/structure/sign/painting/public{
+	pixel_x = 30
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/northchamb)
@@ -9329,17 +10049,16 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/airlock/east)
 "Ni" = (
-/obj/machinery/atmospherics/trinary/mixer/m_mixer{
-	dir = 4;
-	name = "High Power Gas mixer";
-	power_rating = 15000
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/wall,
 /area/offmap/aerostat/inside/toxins)
 "Nk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/wall,
-/area/offmap/aerostat/inside/misclab)
+/area/offmap/aerostat/inside/genetics)
 "Nl" = (
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/firingrange)
@@ -9359,6 +10078,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/shuttle/wall/hard_corner,
 /area/shuttle/aerostat)
+"Np" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/xenoarch)
 "Nq" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 4
@@ -9367,35 +10092,50 @@
 /obj/effect/floor_decal/industrial/warning/dust,
 /turf/simulated/shuttle/floor/yellow/airless,
 /area/shuttle/aerostat)
+"Ns" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/flora/ausbushes/brflowers,
+/turf/simulated/floor/grass,
+/area/offmap/aerostat/inside/genetics)
 "Nu" = (
 /obj/machinery/atmospherics/pipe/simple/visible/blue{
 	dir = 5
 	},
+/obj/machinery/light,
 /turf/simulated/floor/plating,
 /area/offmap/aerostat/inside/toxins)
 "Nw" = (
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
 	},
-/obj/machinery/medical_kiosk,
+/obj/structure/table/standard,
+/obj/random/firstaid,
+/obj/item/weapon/storage/firstaid,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/white,
-/area/offmap/aerostat/inside/telesci)
+/area/offmap/aerostat/inside/miscstorage)
 "Ny" = (
-/obj/effect/floor_decal/industrial/warning/dust/corner{
-	dir = 1
-	},
-/obj/machinery/light,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/light{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/northchamb)
+"NA" = (
+/obj/effect/floor_decal/industrial/warning/cee{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/greengrid,
+/area/offmap/aerostat/inside/toxins)
 "NC" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -9424,6 +10164,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
+/obj/machinery/portable_atmospherics/powered/scrubber/huge/stationary{
+	scrub_id = "science_outpost"
+	},
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/toxins)
 "NJ" = (
@@ -9431,11 +10174,8 @@
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/firingrange)
 "NL" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
-/turf/simulated/floor,
-/area/offmap/aerostat/inside/xenoarch)
+/turf/simulated/wall,
+/area/offmap/aerostat/inside/arm/ne)
 "NM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/universal,
 /obj/structure/cable{
@@ -9448,7 +10188,7 @@
 	dir = 4
 	},
 /turf/simulated/shuttle/wall/voidcraft/green,
-/area/offmap/aerostat/inside/northchamb)
+/area/offmap/aerostat/inside/atmos)
 "NO" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -9459,6 +10199,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/southchamb)
+"NP" = (
+/turf/simulated/wall,
+/area/offmap/aerostat/inside/misclab)
 "NQ" = (
 /obj/effect/floor_decal/rust,
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
@@ -9467,16 +10210,13 @@
 /turf/simulated/floor/plating/virgo2,
 /area/offmap/aerostat/solars)
 "NT" = (
-/obj/machinery/atmospherics/portables_connector{
+/obj/structure/closet/excavation,
+/turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/xenoarch)
+"NU" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 1
 	},
-/obj/machinery/camera/network/research_outpost{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/offmap/aerostat/inside/toxins)
-"NU" = (
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/toxins)
 "NV" = (
@@ -9505,6 +10245,12 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/southchamb)
+"NY" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/virology)
 "NZ" = (
 /turf/simulated/shuttle/wall/voidcraft/green,
 /area/offmap/aerostat/inside/xenoarch/chamber)
@@ -9512,13 +10258,13 @@
 /obj/structure/cable/heavyduty{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/glass_research{
-	name = "Xenoarchaeology"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/maintenance/rnd{
+	req_one_access = null
+	},
 /turf/simulated/floor/tiled/steel_ridged,
-/area/offmap/aerostat/inside/xenoarch)
+/area/offmap/aerostat/inside/arm/ne)
 "Ob" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/structure/cable{
@@ -9532,12 +10278,8 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/offmap/aerostat/inside/lobby)
-"Oe" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled,
-/area/offmap/aerostat/inside/genetics)
 "Og" = (
-/obj/machinery/radiocarbon_spectrometer,
+/obj/structure/filingcabinet/chestdrawer,
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/xenoarch)
 "Oj" = (
@@ -9553,8 +10295,15 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/structure/flora/pottedplant/unusual,
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/telesci)
+"Op" = (
+/obj/machinery/atmospherics/pipe/simple/visible/red{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/toxins)
 "Os" = (
 /obj/structure/grille,
 /obj/machinery/door/firedoor/glass,
@@ -9587,23 +10336,11 @@
 	},
 /turf/simulated/wall,
 /area/offmap/aerostat/inside/toxins)
-"Ow" = (
-/obj/machinery/vending/wallmed1{
-	pixel_x = 30
-	},
-/obj/machinery/atmospherics/portables_connector{
-	dir = 8
-	},
-/obj/machinery/portable_atmospherics/canister/air,
-/turf/simulated/floor/tiled/white,
-/area/offmap/aerostat/inside/xenoarch)
 "Ox" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/green{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/toxins)
 "Oy" = (
@@ -9622,6 +10359,18 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/universal,
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/toxins)
+"OA" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/portables_connector{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/toxins)
 "OD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -9630,7 +10379,6 @@
 	dir = 4
 	},
 /obj/structure/table/reinforced,
-/obj/machinery/recharger,
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/firingrange)
 "OE" = (
@@ -9638,21 +10386,17 @@
 	dir = 4
 	},
 /obj/structure/table/standard,
-/obj/item/weapon/storage/backpack/parachute{
-	pixel_x = -6;
-	pixel_y = 6
+/obj/item/device/gps{
+	pixel_x = -5;
+	pixel_y = 5
 	},
-/obj/item/weapon/storage/backpack/parachute{
-	pixel_x = 6;
-	pixel_y = 6
+/obj/item/device/gps{
+	pixel_x = -2;
+	pixel_y = 2
 	},
-/obj/item/weapon/storage/backpack/parachute{
-	pixel_x = -6;
-	pixel_y = -6
-	},
-/obj/item/weapon/storage/backpack/parachute{
-	pixel_x = 6;
-	pixel_y = -6
+/obj/item/device/gps{
+	pixel_x = 1;
+	pixel_y = -1
 	},
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/telesci)
@@ -9670,24 +10414,27 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/southchamb)
 "OI" = (
-/obj/machinery/door/airlock/glass_research{
-	name = "Genetics Closet"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor/glass,
-/turf/simulated/floor/tiled/steel_ridged,
-/area/offmap/aerostat/inside/genetics)
-"OL" = (
-/obj/effect/floor_decal/industrial/warning/dust{
-	dir = 4
+/obj/machinery/door/airlock/glass_research{
+	name = "Miscellaneous Lab"
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/offmap/aerostat/inside/northchamb)
+/turf/simulated/floor/tiled/steel_ridged,
+/area/offmap/aerostat/inside/misclab)
+"OJ" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/xenoarch)
+"OL" = (
+/obj/structure/bed/chair/comfy/black,
+/turf/simulated/floor/glass/reinforced{
+	color = "#eacd7c"
+	},
+/area/offmap/aerostat/glassgetsitsownarea)
 "OM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
@@ -9702,10 +10449,29 @@
 	},
 /turf/simulated/floor/plating/virgo2,
 /area/offmap/aerostat/solars)
+"OO" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/techfloor,
+/area/offmap/aerostat/inside/atmos)
+"OP" = (
+/obj/machinery/door/firedoor/glass,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/medical{
+	name = "Virology Lab";
+	req_access = list(39);
+	req_one_access = null
+	},
+/obj/machinery/door/blast/regular/open{
+	id = 2;
+	name = "Virology Emergency Quarantine"
+	},
+/turf/simulated/floor/tiled/steel_ridged,
+/area/offmap/aerostat/inside/virology)
 "OR" = (
 /obj/machinery/power/apc{
 	dir = 8;
-	name = "east bump";
 	pixel_x = -22
 	},
 /obj/structure/cable{
@@ -9721,10 +10487,8 @@
 /turf/simulated/shuttle/plating/carry,
 /area/shuttle/aerostat)
 "OW" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	layer = 3.3;
-	pixel_x = 26
+/obj/machinery/atmospherics/unary/freezer{
+	icon_state = "freezer"
 	},
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/toxins)
@@ -9742,30 +10506,51 @@
 /turf/simulated/floor/tiled/dark,
 /area/offmap/aerostat/inside/lobby)
 "Pa" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/white,
-/area/offmap/aerostat/inside/misclab)
+/turf/simulated/floor/grass,
+/area/offmap/aerostat/inside/genetics)
 "Pe" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/black{
-	dir = 6
+/obj/machinery/atmospherics/binary/pump,
+/obj/machinery/atmospherics/pipe/simple/hidden/universal{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/toxins)
 "Ph" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
+/obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/dark,
-/area/offmap/aerostat/inside/xenoarch)
+/obj/structure/dispenser,
+/obj/machinery/alarm{
+	pixel_y = 26
+	},
+/turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/toxins)
+"Pi" = (
+/obj/structure/closet/walllocker_double/medical/west,
+/obj/structure/table/reinforced,
+/obj/item/weapon/soap,
+/obj/item/weapon/storage/box/gloves,
+/obj/item/weapon/storage/box/masks,
+/obj/item/weapon/storage/box/beakers,
+/obj/item/weapon/storage/box/beakers,
+/obj/item/weapon/storage/fancy/vials,
+/obj/item/weapon/storage/box/syringes,
+/obj/item/device/antibody_scanner,
+/obj/item/weapon/storage/box/syringes,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/virology)
 "Pl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/northchamb)
@@ -9776,18 +10561,22 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/easthall)
 "Pq" = (
-/obj/machinery/atmospherics/binary/pump{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/black,
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 9
 	},
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/toxins)
 "Pr" = (
-/obj/machinery/atmospherics/pipe/simple/visible/blue{
-	dir = 6
+/obj/machinery/atmospherics/pipe/simple/hidden/blue,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/filingcabinet/filingcabinet,
+/obj/machinery/light{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/toxins)
@@ -9824,13 +10613,15 @@
 /obj/structure/cable/heavyduty{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/airlock/glass_research{
-	name = "Telescience"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
 	},
-/obj/machinery/door/firedoor/glass,
-/turf/simulated/floor/tiled/steel_ridged,
-/area/offmap/aerostat/inside/telesci)
+/obj/structure/sign/poster{
+	dir = 8;
+	pixel_x = -32
+	},
+/turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/miscstorage)
 "PJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -9844,18 +10635,22 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/southchamb)
+"PK" = (
+/obj/structure/table/reinforced,
+/obj/machinery/camera/network/research_outpost{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/virology)
 "PN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 9
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/atmos)
-"PO" = (
-/turf/simulated/shuttle/wall/voidcraft/hard_corner,
-/area/offmap/aerostat/inside/misclab)
 "PP" = (
-/obj/structure/sign/painting/public{
-	pixel_x = 30
+/obj/structure/closet/crate/bin{
+	anchored = 1
 	},
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/toxins)
@@ -9884,26 +10679,25 @@
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating/virgo2,
 /area/offmap/aerostat/inside/toxins)
-"PT" = (
-/obj/effect/floor_decal/industrial/warning{
+"PU" = (
+/obj/structure/closet/secure_closet/xenoarchaeologist,
+/turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/xenoarch)
+"PX" = (
+/obj/machinery/atmospherics/portables_connector/aux{
 	dir = 4
 	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
+/obj/machinery/portable_atmospherics/canister/air,
 /obj/machinery/camera/network/research_outpost{
-	dir = 1
-	},
-/turf/simulated/floor,
-/area/offmap/aerostat/inside/xenoarch)
-"PU" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/black{
-	dir = 8
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/toxins)
 "Qa" = (
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/black,
+/obj/machinery/atmospherics/binary/pump{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/toxins)
 "Qb" = (
@@ -9926,9 +10720,11 @@
 /turf/simulated/wall,
 /area/offmap/aerostat/inside/toxins)
 "Qe" = (
-/obj/machinery/light{
-	dir = 1
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/machinery/light_switch{
+	pixel_y = 24
 	},
+/obj/structure/flora/pottedplant/crystal,
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/firingrange)
 "Qg" = (
@@ -9936,14 +10732,15 @@
 /turf/unsimulated/floor/sky/virgo2_sky,
 /area/offmap/aerostat)
 "Qh" = (
-/obj/structure/table/standard,
-/obj/item/stack/nanopaste,
-/obj/item/weapon/reagent_containers/glass/bucket,
-/obj/effect/floor_decal/spline/plain{
-	dir = 4
+/obj/machinery/vending/phoronresearch{
+	name = "Toximate 2556";
+	products = list(/obj/item/device/transfer_valve = 3, /obj/item/device/assembly/timer = 6, /obj/item/device/assembly/signaler = 6, /obj/item/device/assembly/prox_sensor = 6, /obj/item/device/assembly/igniter = 12)
 	},
-/turf/simulated/floor/tiled,
-/area/offmap/aerostat/inside/xenoarch)
+/obj/machinery/camera/network/research_outpost{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/toxins)
 "Qk" = (
 /obj/effect/floor_decal/rust,
 /obj/effect/floor_decal/industrial/warning/dust{
@@ -9969,12 +10766,14 @@
 /turf/simulated/floor/plating/virgo2,
 /area/offmap/aerostat/inside/drillstorage)
 "Qr" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/black{
-	dir = 4
+/obj/machinery/atmospherics/omni/atmos_filter{
+	name = "N2O Filter";
+	tag_east = 7;
+	tag_north = 1;
+	tag_south = 2
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/black,
 /turf/simulated/floor/tiled/techfloor,
-/area/offmap/aerostat/inside/northchamb)
+/area/offmap/aerostat/inside/atmos)
 "Qs" = (
 /obj/structure/cable/heavyduty{
 	icon_state = "4-8"
@@ -10023,26 +10822,30 @@
 /turf/simulated/floor/tiled/steel_ridged,
 /area/shuttle/aerostat)
 "Qz" = (
-/obj/item/weapon/storage/box/monkeycubes,
-/obj/item/weapon/storage/pill_bottle/dylovene,
-/obj/item/weapon/storage/pill_bottle/dylovene,
-/obj/item/weapon/storage/box/disks,
-/obj/item/toy/figure/geneticist,
-/turf/simulated/floor/tiled,
-/area/offmap/aerostat/inside/genetics)
+/obj/machinery/atmospherics/portables_connector{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor,
+/area/offmap/aerostat/inside/westhall)
 "QA" = (
 /obj/structure/table/standard,
-/obj/structure/reagent_dispensers/acid{
-	pixel_x = -32
+/obj/item/weapon/anobattery,
+/obj/item/weapon/anobattery{
+	pixel_x = 5;
+	pixel_y = 2
 	},
-/obj/machinery/reagentgrinder,
-/obj/effect/floor_decal/spline/plain{
-	dir = 1
+/obj/item/weapon/anobattery{
+	pixel_x = -4;
+	pixel_y = 3
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/item/weapon/anobattery{
+	pixel_x = -5;
+	pixel_y = -3
 	},
-/turf/simulated/floor/tiled,
+/obj/item/weapon/tool/screwdriver,
+/turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/xenoarch)
 "QE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
@@ -10051,14 +10854,9 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/atmos)
 "QH" = (
-/obj/effect/floor_decal/spline/plain{
-	dir = 5
-	},
-/obj/structure/closet/crate/bin{
-	anchored = 1
-	},
-/turf/simulated/floor/tiled,
-/area/offmap/aerostat/inside/xenoarch)
+/obj/structure/closet/firecloset,
+/turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/toxins)
 "QI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 5
@@ -10082,14 +10880,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/xenoarch)
-"QN" = (
-/obj/structure/table/standard,
-/obj/item/clothing/glasses/welding,
-/obj/item/weapon/weldingtool,
-/obj/item/device/analyzer,
-/obj/item/weapon/tool/wrench,
-/turf/simulated/floor/tiled/white,
-/area/offmap/aerostat/inside/toxins)
 "QO" = (
 /obj/machinery/atmospherics/pipe/manifold4w/visible/blue,
 /obj/machinery/meter,
@@ -10104,6 +10894,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
+/obj/structure/flora/pottedplant/mysterious,
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/zorrenoffice)
 "QT" = (
@@ -10137,8 +10928,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/closet/crate/bin{
-	anchored = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/green,
+/obj/machinery/firealarm{
+	dir = 4;
+	layer = 3.3;
+	pixel_x = 26
 	},
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/toxins)
@@ -10183,11 +10977,8 @@
 /turf/simulated/shuttle/wall/voidcraft/green,
 /area/offmap/aerostat/inside/airlock/north)
 "Rb" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/white,
-/area/offmap/aerostat/inside/misclab)
+/turf/simulated/wall,
+/area/offmap/aerostat/inside/genetics)
 "Rd" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
@@ -10206,14 +10997,13 @@
 /area/offmap/aerostat/inside/westhall)
 "Rf" = (
 /turf/simulated/shuttle/wall/voidcraft/hard_corner,
-/area/offmap/aerostat/inside/drillstorage)
+/area/offmap/aerostat/inside/arm/se)
 "Ri" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 8
 	},
-/obj/effect/floor_decal/industrial/outline/red,
 /turf/simulated/floor/tiled/techfloor,
-/area/offmap/aerostat/inside/northchamb)
+/area/offmap/aerostat/inside/atmos)
 "Rj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -10248,6 +11038,7 @@
 "Rm" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/structure/table/reinforced,
+/obj/machinery/recharger,
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/firingrange)
 "Rn" = (
@@ -10348,17 +11139,10 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/wall,
-/area/offmap/aerostat/inside/drillstorage)
+/area/offmap/aerostat/inside/miscstorage)
 "RE" = (
-/obj/machinery/atmospherics/portables_connector{
-	dir = 8
-	},
-/obj/machinery/portable_atmospherics/canister/air,
-/obj/machinery/camera/network/research_outpost{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/offmap/aerostat/inside/misclab)
+/turf/simulated/wall,
+/area/offmap/aerostat/inside/arm/se)
 "RF" = (
 /obj/structure/cable/heavyduty{
 	icon_state = "4-8"
@@ -10382,6 +11166,12 @@
 	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/offmap/aerostat/inside/airlock/south)
+"RI" = (
+/obj/machinery/atmospherics/binary/pump{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/toxins)
 "RK" = (
 /obj/effect/floor_decal/rust,
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
@@ -10404,6 +11194,9 @@
 /area/offmap/aerostat/inside/firingrange)
 "RM" = (
 /obj/machinery/door/firedoor/glass,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/easthall)
 "RN" = (
@@ -10421,19 +11214,21 @@
 /turf/simulated/floor,
 /area/offmap/aerostat/inside/arm/se)
 "RP" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/radiocarbon_spectrometer,
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/xenoarch)
 "RU" = (
-/obj/machinery/chem_master,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/structure/sign/poster{
 	dir = 8;
 	pixel_x = -32
 	},
-/turf/simulated/floor/tiled,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
 /area/offmap/aerostat/inside/xenoarch)
 "RV" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
@@ -10441,7 +11236,6 @@
 /area/shuttle/aerostat)
 "RW" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/structure/table/reinforced,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
@@ -10449,19 +11243,15 @@
 	dir = 8;
 	pixel_x = 24
 	},
+/obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/firingrange)
 "Sa" = (
-/obj/machinery/atmospherics/unary/heat_exchanger{
-	dir = 1
+/obj/machinery/atmospherics/portables_connector{
+	dir = 4
 	},
-/obj/structure/window/basic{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/red/border{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/steel_ridged,
+/obj/machinery/camera/network/research_outpost,
+/turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/toxins)
 "Sb" = (
 /obj/structure/cable/heavyduty{
@@ -10491,9 +11281,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -10503,6 +11290,9 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 30
 	},
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/toxins)
@@ -10516,7 +11306,12 @@
 /turf/simulated/shuttle/wall/voidcraft/green,
 /area/offmap/aerostat/inside/airlock/north)
 "Sr" = (
-/obj/machinery/atmospherics/binary/pump,
+/obj/machinery/atmospherics/pipe/manifold/visible{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/toxins)
 "Sv" = (
@@ -10532,10 +11327,23 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/white,
+/obj/machinery/door/airlock/glass_research{
+	name = "Toxins Lab"
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/tiled/steel_ridged,
 /area/offmap/aerostat/inside/toxins)
+"SC" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/window/reinforced/full,
+/obj/structure/grille,
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/virology)
 "SE" = (
-/obj/machinery/atmospherics/binary/pump{
+/obj/machinery/atmospherics/portables_connector{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
@@ -10553,12 +11361,26 @@
 /obj/effect/map_helper/airlock/atmos/pump_out_internal,
 /turf/simulated/floor,
 /area/offmap/aerostat/inside/arm/sw)
+"SH" = (
+/obj/machinery/alarm{
+	pixel_y = 26
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/genetics)
+"SI" = (
+/obj/machinery/computer/scan_consolenew{
+	dir = 8
+	},
+/obj/item/weapon/paper{
+	info = "out of order"
+	},
+/turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/genetics)
 "SJ" = (
-/obj/structure/table/standard,
-/obj/item/weapon/paper_bin,
-/obj/item/device/flashlight/lamp,
-/obj/machinery/light,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark,
 /area/offmap/aerostat/inside/xenoarch)
 "SL" = (
 /obj/structure/cable{
@@ -10567,10 +11389,14 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/zorrenoffice)
 "SN" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/machinery/suspension_gen,
-/turf/simulated/floor/tiled/white,
-/area/offmap/aerostat/inside/xenoarch)
+/obj/machinery/atmospherics/portables_connector{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/effect/floor_decal/rust,
+/obj/effect/decal/cleanable/cobweb,
+/turf/simulated/floor,
+/area/offmap/aerostat/inside/arm/ne)
 "SO" = (
 /obj/effect/floor_decal/industrial/warning/dust{
 	dir = 8
@@ -10585,12 +11411,9 @@
 /turf/simulated/floor/plating/virgo2,
 /area/offmap/aerostat/solars)
 "SP" = (
-/obj/machinery/vending/tool,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
+/obj/machinery/medical_kiosk,
 /turf/simulated/floor/tiled/white,
-/area/offmap/aerostat/inside/telesci)
+/area/offmap/aerostat/inside/miscstorage)
 "SQ" = (
 /obj/machinery/atmospherics/unary/heat_exchanger{
 	dir = 4
@@ -10670,25 +11493,16 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/tiled/white,
-/area/offmap/aerostat/inside/telesci)
+/area/offmap/aerostat/inside/miscstorage)
 "Td" = (
-/obj/machinery/door/airlock/glass_research{
-	name = "Toxins Lab"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor/glass,
-/turf/simulated/floor/tiled/steel_ridged,
+/obj/machinery/atmospherics/portables_connector,
+/turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/toxins)
 "Te" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/northchamb)
 "Tg" = (
@@ -10712,10 +11526,8 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/atmos)
 "Tn" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/toxins)
 "Tq" = (
@@ -10726,6 +11538,14 @@
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/westhall)
+"Tt" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/floor_decal/rust,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor,
+/area/offmap/aerostat/inside/arm/ne)
 "Tv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -10733,6 +11553,15 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/zorrenoffice)
+"Tx" = (
+/turf/simulated/wall,
+/area/offmap/aerostat/inside/miscstorage)
+"Tz" = (
+/obj/item/modular_computer/console/preset/research{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/telesci)
 "TB" = (
 /turf/simulated/shuttle/wall/voidcraft/hard_corner,
 /area/offmap/aerostat/inside/powercontrol)
@@ -10749,6 +11578,10 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/xenoarch)
+"TM" = (
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor,
+/area/offmap/aerostat/inside/arm/ne)
 "TO" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 1;
@@ -10815,13 +11648,15 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/airlock/north)
 "TW" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/green{
-	dir = 4
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/machinery/door/window/brigdoor/eastleft{
+	dir = 2;
+	req_access = list(7)
 	},
-/turf/simulated/wall,
+/turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/toxins)
 "TX" = (
 /obj/structure/window/reinforced{
@@ -10845,18 +11680,22 @@
 /turf/simulated/floor/plating/virgo2,
 /area/offmap/aerostat/inside/toxins)
 "TZ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 1
 	},
-/turf/simulated/floor/tiled/dark,
-/area/offmap/aerostat/inside/xenoarch)
-"Ub" = (
-/obj/machinery/atmospherics/portables_connector{
-	dir = 8
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
 	},
-/obj/machinery/portable_atmospherics/canister/air,
+/obj/structure/closet/l3closet/virology,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/white,
-/area/offmap/aerostat/inside/misclab)
+/area/offmap/aerostat/inside/virology)
+"Ub" = (
+/obj/machinery/vending/tool,
+/turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/miscstorage)
 "Ue" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
@@ -10869,12 +11708,24 @@
 /turf/simulated/shuttle/floor/yellow,
 /area/shuttle/aerostat)
 "Uf" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
 	},
-/obj/machinery/light/small,
-/turf/simulated/floor/tiled/dark,
-/area/offmap/aerostat/inside/xenoarch)
+/obj/structure/closet/wardrobe/virology_white,
+/obj/machinery/camera/network/research_outpost{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/virology)
+"Ug" = (
+/obj/effect/floor_decal/rust,
+/obj/random/maintenance/research,
+/obj/random/maintenance/research,
+/obj/random/tool,
+/obj/random/tool,
+/obj/structure/closet,
+/turf/simulated/floor,
+/area/offmap/aerostat/inside/arm/ne)
 "Uh" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -10882,19 +11733,16 @@
 /turf/simulated/wall,
 /area/offmap/aerostat/inside/telesci)
 "Ui" = (
-/obj/machinery/door/airlock/glass_research{
-	name = "Miscellaneous Lab"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/firedoor/glass,
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/steel_ridged,
-/area/offmap/aerostat/inside/misclab)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/dark,
+/area/offmap/aerostat/inside/lobby)
 "Uj" = (
-/obj/machinery/artifact_scanpad,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor,
 /area/offmap/aerostat/inside/xenoarch)
 "Ul" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -10911,6 +11759,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/bluegrid,
 /area/offmap/aerostat/inside/powercontrol)
+"Uo" = (
+/turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/virology)
 "Up" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
@@ -10934,10 +11785,11 @@
 /turf/simulated/floor,
 /area/offmap/aerostat/inside/arm/se)
 "Us" = (
-/obj/machinery/atmospherics/portables_connector,
-/obj/machinery/portable_atmospherics/canister/air,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 6
+	},
 /turf/simulated/floor/tiled/techfloor,
-/area/offmap/aerostat/inside/northchamb)
+/area/offmap/aerostat/inside/atmos)
 "Ut" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 9
@@ -10977,27 +11829,14 @@
 /turf/simulated/floor/tiled/dark,
 /area/offmap/aerostat/inside/xenoarch/chamber)
 "UA" = (
-/obj/machinery/washing_machine,
 /obj/machinery/alarm{
 	pixel_y = 26
 	},
 /obj/machinery/camera/network/research_outpost{
 	dir = 4
 	},
+/obj/machinery/medical_kiosk,
 /turf/simulated/floor/tiled/white,
-/area/offmap/aerostat/inside/xenoarch)
-"UB" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/warning,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor,
 /area/offmap/aerostat/inside/xenoarch)
 "UC" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -11025,14 +11864,21 @@
 /obj/structure/cable/heavyduty{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/firingrange)
 "UH" = (
-/obj/structure/closet/excavation,
+/obj/machinery/power/apc{
+	dir = 1;
+	pixel_y = 24
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/tiled/white,
-/area/offmap/aerostat/inside/xenoarch)
+/area/offmap/aerostat/inside/toxins)
 "UL" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -11042,15 +11888,22 @@
 	},
 /turf/simulated/floor/bluegrid,
 /area/offmap/aerostat/inside/powercontrol)
+"UM" = (
+/obj/structure/bed/chair/office/light,
+/turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/virology)
 "UO" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/turf/simulated/floor/reinforced,
+/area/offmap/aerostat/inside/telesci)
+"UP" = (
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/structure/sign/painting/public{
-	pixel_y = 30
+/obj/structure/closet/crate/bin{
+	anchored = 1
 	},
 /turf/simulated/floor/tiled/white,
-/area/offmap/aerostat/inside/misclab)
+/area/offmap/aerostat/inside/firingrange)
 "US" = (
 /obj/machinery/door/airlock/glass_research{
 	name = "Atmospherics";
@@ -11064,35 +11917,31 @@
 /turf/simulated/floor/tiled/steel_ridged,
 /area/offmap/aerostat/inside/atmos)
 "UV" = (
-/obj/effect/floor_decal/industrial/warning/corner,
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor,
-/area/offmap/aerostat/inside/xenoarch)
+/turf/simulated/wall,
+/area/offmap/aerostat/inside/arm/ne)
 "UW" = (
-/turf/simulated/shuttle/wall/voidcraft/green,
-/area/offmap/aerostat/inside/genetics)
-"UZ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
+	dir = 4
 	},
+/turf/simulated/wall,
+/area/offmap/aerostat/inside/telesci)
+"UZ" = (
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/machinery/portable_atmospherics/canister/empty,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/northchamb)
 "Va" = (
@@ -11106,8 +11955,19 @@
 	pixel_y = 26
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/structure/table/standard,
+/obj/machinery/computer/atmoscontrol/laptop{
+	monitored_alarm_ids = list("anomaly_testing");
+	req_one_access = list(47,24,11)
+	},
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/xenoarch)
+"Vd" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/green{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/toxins)
 "Ve" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 1
@@ -11121,29 +11981,31 @@
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/xenoarch)
 "Vi" = (
-/obj/structure/table/standard,
-/obj/item/device/assembly_holder/timer_igniter,
-/obj/item/weapon/tool/screwdriver,
-/obj/structure/sign/painting/public{
-	pixel_x = -30
+/obj/structure/window/reinforced{
+	dir = 4
 	},
-/obj/item/weapon/folder/white,
-/obj/item/weapon/pen/fountain,
+/obj/machinery/portable_atmospherics/canister/empty,
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/toxins)
-"Vk" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/dark,
-/area/offmap/aerostat/inside/xenoarch)
 "Vl" = (
 /obj/machinery/atmospherics/binary/algae_farm/filled{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/atmos)
+"Vo" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/offmap/aerostat/inside/lobby)
+"Vr" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/offmap/aerostat/inside/southchamb)
 "Vs" = (
 /obj/effect/floor_decal/rust,
 /obj/structure/cable/yellow{
@@ -11155,13 +12017,16 @@
 /turf/simulated/floor/plating/virgo2,
 /area/offmap/aerostat/solars)
 "Vt" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/suspension_gen,
 /obj/machinery/camera/network/research_outpost{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/white,
-/area/offmap/aerostat/inside/xenoarch)
+/obj/machinery/atmospherics/portables_connector{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor,
+/area/offmap/aerostat/inside/arm/ne)
 "Vu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -11170,11 +12035,11 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/zorrenoffice)
 "Vx" = (
-/obj/machinery/atmospherics/pipe/manifold/visible{
-	dir = 1
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
 	},
-/turf/simulated/floor/tiled/white,
-/area/offmap/aerostat/inside/toxins)
+/turf/simulated/floor,
+/area/offmap/aerostat/inside/xenoarch)
 "Vz" = (
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/telesci)
@@ -11212,6 +12077,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
+/obj/structure/flora/pottedplant/crystal,
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/zorrenoffice)
 "VJ" = (
@@ -11227,6 +12093,12 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/westhall)
+"VL" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/toxins)
 "VM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 10
@@ -11278,15 +12150,21 @@
 /turf/simulated/floor/plating/virgo2,
 /area/offmap/aerostat/inside/arm/ne)
 "VU" = (
-/obj/machinery/light{
-	dir = 1
+/obj/effect/floor_decal/rust,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
 	},
-/turf/simulated/floor/tiled/white,
-/area/offmap/aerostat/inside/toxins)
+/turf/simulated/floor,
+/area/offmap/aerostat/inside/xenoarch)
 "VX" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
 	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/xenoarch)
@@ -11297,16 +12175,11 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/southchamb)
 "Wb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/light{
-	dir = 8
+/obj/machinery/camera/network/research_outpost{
+	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/portable_atmospherics/canister/empty,
-/turf/simulated/floor/tiled/techfloor,
-/area/offmap/aerostat/inside/northchamb)
+/turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/virology)
 "Wd" = (
 /turf/simulated/shuttle/wall/voidcraft/hard_corner{
 	stripe_color = "#00FF00"
@@ -11332,20 +12205,30 @@
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/toxins)
 "Wh" = (
-/obj/machinery/camera/network/research_outpost{
-	dir = 8
+/obj/machinery/power/apc{
+	dir = 4;
+	pixel_x = 28
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/tiled/white,
-/area/offmap/aerostat/inside/telesci)
+/area/offmap/aerostat/inside/miscstorage)
 "Wi" = (
 /obj/structure/table/reinforced,
 /obj/machinery/recharger,
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/firingrange)
+"Wj" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/genetics)
 "Wk" = (
-/obj/machinery/portable_atmospherics/canister/empty,
-/turf/simulated/floor/tiled/techfloor,
-/area/offmap/aerostat/inside/northchamb)
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/toxins)
 "Wn" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -11369,6 +12252,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
+/obj/structure/flora/pottedplant/subterranean,
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/southchamb)
 "Wt" = (
@@ -11405,9 +12289,6 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/zorrenoffice)
 "Wz" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
@@ -11417,6 +12298,10 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/easthall)
 "WC" = (
@@ -11432,8 +12317,22 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
+/obj/structure/table/rack,
+/obj/item/clothing/suit/space/anomaly/heat,
+/obj/item/clothing/head/helmet/space/anomaly/heat,
+/obj/item/device/suit_cooling_unit,
+/obj/item/weapon/storage/excavation,
+/obj/item/weapon/tool/wrench,
+/obj/item/weapon/pickaxe,
+/obj/item/device/measuring_tape,
+/obj/item/weapon/storage/belt/archaeology,
+/obj/item/stack/flag/yellow,
+/obj/item/clothing/mask/breath,
+/obj/machinery/alarm{
+	pixel_y = 26
+	},
 /turf/simulated/floor/tiled/white,
-/area/offmap/aerostat/inside/toxins)
+/area/offmap/aerostat/inside/xenoarch)
 "WF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 4
@@ -11442,11 +12341,11 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/atmos)
 "WH" = (
-/obj/structure/table/steel_reinforced,
 /obj/random/maintenance/research,
 /obj/structure/sign/painting/public{
 	pixel_x = 30
 	},
+/obj/structure/table/borosilicate,
 /turf/simulated/floor/tiled/dark,
 /area/offmap/aerostat/inside/lobby)
 "WJ" = (
@@ -11466,20 +12365,27 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
-/area/offmap/aerostat/inside/telesci)
+/area/offmap/aerostat/inside/miscstorage)
+"WP" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/blue,
+/obj/machinery/medical_kiosk,
+/turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/toxins)
 "WQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/blue{
 	dir = 4
 	},
-/obj/machinery/power/apc{
-	dir = 1;
-	pixel_y = 24
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
+/obj/structure/cable/heavyduty{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/toxins)
+"WR" = (
+/obj/structure/table/reinforced,
+/obj/item/weapon/book/manual/virology,
+/obj/item/device/antibody_scanner,
+/turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/virology)
 "WS" = (
 /obj/effect/shuttle_landmark{
 	base_area = /area/offmap/aerostat;
@@ -11517,10 +12423,12 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/table/standard,
-/obj/item/weapon/tool/screwdriver,
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/telesci)
+"WY" = (
+/obj/machinery/atmospherics/pipe/simple/visible/red,
+/turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/toxins)
 "WZ" = (
 /obj/effect/floor_decal/industrial/warning/dust/corner{
 	dir = 4
@@ -11528,11 +12436,18 @@
 /turf/simulated/floor/tiled/dark,
 /area/offmap/aerostat/inside/lobby)
 "Xa" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 9
 	},
-/turf/simulated/floor/tiled,
-/area/offmap/aerostat/inside/genetics)
+/obj/effect/floor_decal/rust,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/offmap/aerostat/inside/westhall)
 "Xb" = (
 /obj/effect/floor_decal/rust,
 /obj/structure/cable/yellow{
@@ -11554,9 +12469,19 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/flora/pottedplant/subterranean,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/wall,
 /area/offmap/aerostat/inside/xenoarch)
+"Xm" = (
+/obj/machinery/power/apc{
+	dir = 8;
+	pixel_x = -22
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor,
+/area/offmap/aerostat/inside/arm/ne)
 "Xo" = (
 /obj/effect/floor_decal/industrial/danger{
 	dir = 1
@@ -11575,14 +12500,17 @@
 /turf/simulated/shuttle/floor/yellow,
 /area/shuttle/aerostat)
 "Xr" = (
-/obj/structure/window/reinforced,
-/obj/machinery/portable_atmospherics/canister/phoron,
-/turf/simulated/floor/tiled/techfloor,
-/area/offmap/aerostat/inside/northchamb)
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 6
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/toxins)
 "Xt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -11602,10 +12530,12 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
 	},
-/obj/item/modular_computer/console/preset/research,
+/obj/structure/table/standard,
+/obj/item/device/multitool,
+/obj/item/weapon/tool/screwdriver,
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/telesci)
 "XA" = (
@@ -11625,13 +12555,9 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/white,
-/area/offmap/aerostat/inside/xenoarch)
+/turf/simulated/floor,
+/area/offmap/aerostat/inside/arm/ne)
 "XH" = (
-/obj/structure/table/reinforced,
 /obj/machinery/recharger/wallcharger{
 	pixel_x = 4;
 	pixel_y = 20
@@ -11644,12 +12570,13 @@
 	pixel_x = 4;
 	pixel_y = 36
 	},
+/obj/item/modular_computer/console,
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/firingrange)
 "XJ" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/wall,
-/area/offmap/aerostat/inside/misclab)
+/area/offmap/aerostat/inside/genetics)
 "XK" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
@@ -11663,29 +12590,32 @@
 /turf/simulated/floor/plating/virgo2,
 /area/offmap/aerostat/inside/arm/ne)
 "XL" = (
-/obj/machinery/door/airlock/glass_research{
-	name = "Xenoarchaeology"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/steel_ridged,
-/area/offmap/aerostat/inside/xenoarch)
+/turf/simulated/wall,
+/area/offmap/aerostat/inside/virology)
 "XM" = (
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/airlock/south)
+"XN" = (
+/obj/structure/closet/crate/bin{
+	anchored = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/genetics)
 "XO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/closet/crate/bin{
-	anchored = 1
+/obj/structure/sign/painting/public{
+	pixel_y = 30
 	},
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/telesci)
@@ -11699,7 +12629,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/tiled/steel_ridged,
-/area/offmap/aerostat/inside/xenoarch)
+/area/offmap/aerostat/inside/arm/ne)
 "XQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/meter,
@@ -11718,11 +12648,20 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/westhall)
 "XV" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/black{
-	dir = 6
+/obj/structure/bed/chair/comfy/black{
+	dir = 1
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/offmap/aerostat/inside/northchamb)
+/turf/simulated/floor/glass/reinforced{
+	color = "#eacd7c"
+	},
+/area/offmap/aerostat/glassgetsitsownarea)
+"XW" = (
+/obj/machinery/light/floortube{
+	dir = 8;
+	pixel_x = -6
+	},
+/turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/toxins)
 "XX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
@@ -11751,20 +12690,21 @@
 /turf/simulated/floor/tiled,
 /area/offmap/aerostat/inside/drillstorage)
 "Yg" = (
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
-/turf/simulated/floor,
-/area/offmap/aerostat/inside/xenoarch)
+/obj/machinery/disease2/incubator,
+/obj/structure/reagent_dispensers/virusfood{
+	pixel_y = 28
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/virology)
 "Yh" = (
 /obj/structure/cable/heavyduty{
 	icon_state = "4-8"
@@ -11795,12 +12735,16 @@
 	},
 /obj/machinery/power/apc{
 	dir = 8;
-	name = "east bump";
 	pixel_x = -22
 	},
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor,
 /area/offmap/aerostat/inside/arm/ne)
+"Yj" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/black,
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/toxins)
 "Yl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/light/floortube{
@@ -11832,9 +12776,6 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/easthall)
 "Yp" = (
-/obj/machinery/atmospherics/pipe/simple/visible/red{
-	dir = 10
-	},
 /obj/machinery/light{
 	dir = 1
 	},
@@ -11857,7 +12798,11 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/zorrenoffice)
 "Yt" = (
-/obj/machinery/atmospherics/pipe/simple/visible/red,
+/obj/machinery/atmospherics/portables_connector,
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 4
+	},
+/obj/machinery/camera/network/research_outpost,
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/toxins)
 "Yu" = (
@@ -11871,52 +12816,79 @@
 /turf/simulated/floor/plating/virgo2,
 /area/offmap/aerostat/solars)
 "Yv" = (
-/obj/structure/closet/crate/bin{
-	anchored = 1
-	},
+/obj/machinery/autolathe,
 /turf/simulated/floor/tiled/white,
-/area/offmap/aerostat/inside/misclab)
+/area/offmap/aerostat/inside/miscstorage)
 "Yw" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden{
-	dir = 8
-	},
 /turf/simulated/floor/tiled,
-/area/offmap/aerostat/inside/genetics)
+/area/offmap/aerostat/inside/misclab)
 "Yx" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden,
 /turf/simulated/shuttle/wall/voidcraft/green,
 /area/offmap/aerostat/inside/airlock/west)
 "YB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
-	dir = 9
+	dir = 4
+	},
+/obj/machinery/atmospherics/binary/pump/on{
+	name = "phoron pump"
 	},
 /turf/simulated/floor/tiled/techfloor,
-/area/offmap/aerostat/inside/northchamb)
-"YE" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
+/area/offmap/aerostat/inside/atmos)
+"YC" = (
+/obj/structure/table/standard,
+/obj/item/weapon/paper_bin{
+	pixel_x = 4;
+	pixel_y = 6
 	},
-/turf/simulated/floor/tiled/white,
-/area/offmap/aerostat/inside/xenoarch)
-"YJ" = (
-/obj/machinery/portable_atmospherics/powered/scrubber/huge/stationary{
-	scrub_id = "science_outpost"
-	},
+/obj/item/weapon/folder/white,
+/obj/item/weapon/pen,
 /obj/machinery/light{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
-/area/offmap/aerostat/inside/toxins)
-"YN" = (
-/obj/effect/floor_decal/industrial/warning{
+/area/offmap/aerostat/inside/xenoarch)
+"YE" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/structure/reagent_dispensers/coolanttank,
+/turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/xenoarch)
+"YH" = (
+/obj/structure/table/reinforced,
+/obj/machinery/computer/med_data/laptop{
+	dir = 1
+	},
+/obj/machinery/camera/network/research_outpost{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/virology)
+"YJ" = (
+/obj/machinery/atmospherics/binary/pump{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+/turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/toxins)
+"YL" = (
+/obj/structure/bed/chair/bay,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
+/turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/genetics)
+"YN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor,
-/area/offmap/aerostat/inside/xenoarch)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/disease2/isolator,
+/obj/machinery/firealarm{
+	dir = 4;
+	layer = 3.3;
+	pixel_x = 26
+	},
+/turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/virology)
 "YS" = (
 /obj/machinery/door/blast/regular{
 	dir = 2;
@@ -11942,12 +12914,17 @@
 /turf/simulated/shuttle/wall/voidcraft/green/virgo2,
 /area/offmap/aerostat/inside/arm/se)
 "YX" = (
-/obj/structure/reagent_dispensers/coolanttank,
-/obj/machinery/camera/network/research_outpost{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/portables_connector{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
-/area/offmap/aerostat/inside/xenoarch)
+/area/offmap/aerostat/inside/toxins)
 "Zb" = (
 /obj/structure/cable/heavyduty{
 	icon_state = "4-8"
@@ -11958,11 +12935,10 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/easthall)
 "Zc" = (
-/obj/machinery/light/floortube{
-	dir = 4;
-	pixel_x = 5
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/closet/crate/bin{
+	anchored = 1
+	},
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/xenoarch)
 "Ze" = (
@@ -11972,36 +12948,59 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/offmap/aerostat/inside/northchamb)
+/turf/simulated/wall,
+/area/offmap/aerostat/inside/atmos)
 "Zg" = (
 /obj/machinery/camera/network/research_outpost,
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/westhall)
+"Zh" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/toxins)
 "Zi" = (
-/obj/machinery/atmospherics/binary/pump{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/visible/red{
+	dir = 1
+	},
+/obj/machinery/meter,
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/toxins)
 "Zj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/white,
+/obj/structure/window/basic{
+	dir = 1
+	},
+/obj/structure/window/basic{
+	dir = 8
+	},
+/obj/machinery/atmospherics/unary/heat_exchanger{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/steel_ridged,
 /area/offmap/aerostat/inside/toxins)
 "Zn" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/warning/cee,
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 5
+	},
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/toxins)
 "Zo" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/green{
-	dir = 6
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/black,
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/toxins)
 "Zp" = (
@@ -12018,11 +13017,22 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/zorrenoffice)
 "Zu" = (
-/obj/machinery/atmospherics/unary/freezer{
-	icon_state = "freezer"
+/obj/machinery/light{
+	dir = 4
 	},
+/obj/structure/table/rack,
+/obj/item/clothing/suit/space/anomaly/heat,
+/obj/item/clothing/head/helmet/space/anomaly/heat,
+/obj/item/device/suit_cooling_unit,
+/obj/item/weapon/storage/excavation,
+/obj/item/weapon/tool/wrench,
+/obj/item/weapon/pickaxe,
+/obj/item/device/measuring_tape,
+/obj/item/weapon/storage/belt/archaeology,
+/obj/item/stack/flag/yellow,
+/obj/item/clothing/mask/breath,
 /turf/simulated/floor/tiled/white,
-/area/offmap/aerostat/inside/toxins)
+/area/offmap/aerostat/inside/xenoarch)
 "Zv" = (
 /obj/machinery/embedded_controller/radio/airlock/docking_port{
 	cycle_to_external_air = 1;
@@ -12037,12 +13047,8 @@
 /area/offmap/aerostat/inside/toxins)
 "Zw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/closet/wardrobe/genetics_white,
-/obj/machinery/camera/network/research_outpost{
-	dir = 8
-	},
 /turf/simulated/floor/tiled,
-/area/offmap/aerostat/inside/genetics)
+/area/offmap/aerostat/inside/misclab)
 "Zx" = (
 /obj/effect/floor_decal/industrial/warning/dust,
 /obj/machinery/door/airlock/external{
@@ -12067,6 +13073,18 @@
 "ZA" = (
 /turf/simulated/floor/tiled,
 /area/offmap/aerostat/inside/xenoarch)
+"ZD" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = -4
+	},
+/turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/virology)
+"ZE" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/blue,
+/turf/simulated/wall,
+/area/offmap/aerostat/inside/toxins)
 "ZG" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 8
@@ -12081,6 +13099,10 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/westhall)
+"ZI" = (
+/obj/machinery/dna_scannernew,
+/turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/genetics)
 "ZJ" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -12135,13 +13157,35 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/easthall)
+"ZP" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/structure/closet/secure_closet/personal/patient,
+/obj/machinery/alarm{
+	pixel_y = 26
+	},
+/turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/virology)
 "ZR" = (
-/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
-/obj/structure/window/reinforced,
-/turf/simulated/floor/tiled/techfloor,
-/area/offmap/aerostat/inside/northchamb)
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/binary/pump{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled/white,
+/area/offmap/aerostat/inside/toxins)
 "ZS" = (
-/obj/machinery/atmospherics/pipe/manifold/visible,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/black{
+	dir = 1
+	},
 /obj/machinery/meter,
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/toxins)
@@ -17637,7 +18681,7 @@ XX
 Rl
 aE
 EN
-UW
+EN
 aw
 aw
 aw
@@ -17778,7 +18822,7 @@ he
 Yx
 cI
 KW
-EN
+Jo
 gf
 Bz
 aw
@@ -17920,8 +18964,8 @@ he
 FJ
 lL
 jL
-EN
-Bt
+Jo
+Qz
 Bz
 Bz
 aw
@@ -18064,7 +19108,7 @@ Wt
 qN
 Jo
 if
-Go
+Qz
 Bz
 Bz
 aw
@@ -18203,13 +19247,13 @@ PS
 PS
 Rr
 Re
-qN
-Jo
+HS
+Ls
 Lq
 Xa
-Go
+ni
 Bz
-UW
+Jo
 aw
 aw
 aw
@@ -18345,13 +19389,13 @@ oW
 PS
 Rr
 Lt
-qN
+KA
 Jo
-Bu
-if
-Go
-Go
-UW
+ZK
+ZK
+ZK
+ZK
+Jo
 Bz
 aw
 aw
@@ -18489,13 +19533,13 @@ Rr
 NV
 Hq
 Jo
-Kv
-Kr
-Go
-Go
-Go
-Bz
-Bz
+NP
+Yw
+wA
+Yw
+Yw
+EA
+EA
 aw
 aw
 aw
@@ -18631,14 +19675,14 @@ Qd
 Zg
 HH
 FU
-Kv
+NP
 yG
-Go
-Qz
-Go
-Go
-UW
-UW
+Yw
+Yw
+Yw
+Yw
+zH
+zH
 aw
 aw
 aw
@@ -18773,15 +19817,15 @@ Qd
 Tr
 Sl
 Lt
-Kv
+NP
 tU
-Go
-Go
-Go
-Go
-Go
-Bz
-Bz
+Yw
+Yw
+Yw
+Yw
+Yw
+EA
+EA
 aw
 aw
 aw
@@ -18921,10 +19965,10 @@ Ey
 kR
 fo
 Ml
-Go
-Go
-Bz
-Bz
+Yw
+Yw
+EA
+EA
 aw
 aw
 aw
@@ -19057,17 +20101,17 @@ TY
 ZK
 nR
 Lt
-Kv
-jS
+NP
+Yw
 Yw
 ey
-Bh
+jw
 ef
-Go
-Go
-Go
-Bz
-Bz
+Yw
+Yw
+Yw
+EA
+EA
 aw
 aw
 aw
@@ -19199,18 +20243,18 @@ xM
 ZK
 pP
 yN
-Kv
-tA
-LN
+NP
+Yw
+Yw
 jj
 Zw
 oZ
-Oe
+Zw
 qS
-Oe
-hM
-UW
-UW
+Yw
+Yw
+zH
+zH
 aw
 aw
 aw
@@ -19341,19 +20385,19 @@ pX
 ZK
 wF
 Lt
-Kv
-Kv
-Kv
-Kv
-Kv
-Kv
-Kv
-Kv
-Kv
-Kv
-Kv
-gf
-UW
+NP
+Yw
+Yw
+Yw
+Yw
+ef
+Yw
+Yw
+Yw
+Yw
+Yw
+FY
+zH
 aw
 aw
 aw
@@ -19467,7 +20511,7 @@ ac
 Rr
 Rr
 ce
-Eu
+PX
 Eu
 Dh
 Jp
@@ -19483,20 +20527,20 @@ CQ
 Qd
 lz
 Lt
-iX
-pu
-Nl
-Nl
+NP
+Yw
+Kz
+Yw
 yX
 kq
-Nl
-Nl
-Ke
-Ke
-yX
-sz
-rq
-rq
+Yw
+Yw
+Yw
+Kz
+Yw
+Yw
+zH
+zH
 aw
 aw
 aw
@@ -19614,11 +20658,11 @@ Lj
 Dh
 hu
 Pe
-xu
-qC
-qC
-qC
-hu
+ph
+RI
+WY
+Op
+lr
 Qd
 ux
 yO
@@ -19626,18 +20670,18 @@ Qd
 wF
 Lt
 iX
-fR
-Nl
-Nl
-Nl
-Nl
-Nl
-Nl
-Ls
-Ls
-Nl
-jN
-Nl
+iX
+iX
+iX
+iX
+iX
+iX
+iX
+iX
+iX
+iX
+iX
+iX
 oA
 rq
 rq
@@ -19750,15 +20794,15 @@ ac
 mN
 ce
 Qd
+qC
+WQ
 Qd
-jM
-un
 Dh
 Yp
 CE
 Qa
 GX
-Yt
+Yb
 Mv
 yI
 Qd
@@ -19768,20 +20812,20 @@ Qd
 il
 co
 vP
-Dl
 HJ
 HJ
 HJ
-HJ
-HJ
-qe
-mY
-bm
 UG
-jw
-bO
-bO
-bO
+Hs
+HJ
+HJ
+HJ
+HJ
+UG
+HJ
+HJ
+qv
+vu
 vT
 nN
 nN
@@ -19889,18 +20933,18 @@ aw
 aw
 aw
 Rr
-QN
+Vi
 Vi
 bG
-Qd
-tP
+qC
+WQ
 un
 Dh
 mu
 MH
 Zi
 Zj
-Zj
+dz
 Ay
 kO
 Qd
@@ -19911,19 +20955,19 @@ Ek
 ZH
 iX
 Qe
-Nl
-Nl
-Nl
-Nl
-Nl
+MA
+MA
+MA
+MA
+MA
 tJ
 Nl
 Nl
 Nl
 Nl
 Nl
-Nl
-Nl
+AR
+AR
 oA
 uS
 cU
@@ -20034,8 +21078,8 @@ Rr
 mL
 ig
 oK
-Qd
-IA
+qC
+WQ
 un
 Dh
 FF
@@ -20052,14 +21096,14 @@ Qd
 Ek
 ZH
 iX
-Nl
+UP
 Nl
 Nl
 Nl
 Nl
 Nl
 fJ
-vM
+mm
 Dq
 ZL
 TX
@@ -20173,23 +21217,23 @@ aw
 Rr
 Rr
 qU
-MM
-qC
+qU
+qU
 io
-ag
-jM
-un
+qC
+WQ
+Eb
 Dh
 Gt
 TF
 HV
-Sa
-aF
-bR
-Br
 Qd
-Zu
-DI
+Qd
+bR
+Gt
+Qd
+Mu
+po
 Qd
 PR
 ZH
@@ -20313,30 +21357,30 @@ aw
 aw
 de
 ce
-hG
-xC
 zu
-qC
+zu
+zu
+zu
 mD
-ai
+Vd
 Hb
 nV
 bW
-YJ
+Qd
 Sw
-xK
 Qd
 Qd
-fh
-YJ
 Qd
-Jr
+Qd
+Qd
+Qd
+qC
 HU
 kf
 ck
 Md
 iX
-HS
+at
 Nl
 Nl
 at
@@ -20455,23 +21499,23 @@ aw
 de
 de
 Qd
-Qd
-Qd
-Bc
+Ha
+Gu
+Gu
 Gu
 TW
-Qd
+lT
 WQ
-LR
+MM
 Qd
-Qd
+Ph
 JV
+NA
+vY
 Qd
-Qd
-Qd
-Qd
-Qd
-Qd
+FK
+Gn
+oi
 MM
 Sv
 Wn
@@ -20479,11 +21523,11 @@ VJ
 ZV
 iX
 DG
-Nl
+Mf
 Nl
 Wi
 Nl
-Nl
+Mf
 FT
 NJ
 lI
@@ -20595,24 +21639,24 @@ aw
 aw
 de
 wC
-xP
+aF
 Qd
 ol
-qC
-hB
-Yb
+ol
+ol
+ol
 xO
 JM
 gL
 ud
+KD
 jy
-GR
 xy
 jy
 DH
+KD
 jy
-DH
-GR
+jy
 jy
 TP
 DL
@@ -20736,26 +21780,26 @@ Qg
 aw
 de
 wC
-Xr
+uN
 Hy
 tv
 NU
 Yb
-wG
-Zo
+Yb
+Yb
 Ox
-Qd
+mi
 ji
 ib
-ib
-ib
+LR
+Pr
 nh
 aI
-aI
-aI
-aI
+ou
+ZE
+WP
 wr
-qC
+Zh
 qC
 CC
 Wn
@@ -20768,7 +21812,7 @@ Nl
 Nl
 Nl
 Nl
-yK
+eA
 NJ
 lI
 Ld
@@ -20877,8 +21921,8 @@ aw
 Qg
 de
 wC
-Gf
-Xr
+xP
+xP
 mt
 Qd
 NH
@@ -20886,26 +21930,26 @@ Oz
 CM
 hU
 QV
-Qd
+oc
 nb
-qC
 FK
-qC
+Qd
+Qh
 zb
 Ca
-qC
-qC
+rz
+Qd
 PP
 jM
 hs
-qC
-QV
+uF
+zD
 Wn
 XT
 ZH
 iX
 Rm
-bx
+ye
 ye
 Ew
 mA
@@ -20924,7 +21968,7 @@ ID
 ID
 iX
 PJ
-tR
+eW
 KK
 KK
 aw
@@ -21018,9 +22062,9 @@ aw
 aw
 de
 wC
-ZR
-Gf
-Xr
+Ny
+xP
+xP
 ch
 Qd
 Qd
@@ -21029,18 +22073,18 @@ Qd
 Ov
 SU
 GK
+wG
 OM
-OM
-nK
-OM
+GK
+GK
 zV
+rU
 OM
-Td
 OM
 OM
 JD
-nK
-OM
+GK
+rU
 kG
 Ry
 Yh
@@ -21066,8 +22110,8 @@ iX
 iX
 iX
 Nm
-eW
-eW
+bF
+CN
 KK
 KK
 Qg
@@ -21159,10 +22203,10 @@ aw
 aw
 de
 wC
-ju
-ZR
-Gf
-Xr
+xP
+xP
+xP
+xP
 mt
 Ce
 cB
@@ -21171,14 +22215,14 @@ cB
 cB
 GF
 gD
-qC
+xg
 Ly
-oc
-qC
+Qd
+FK
 mc
+Gn
+xu
 qC
-qC
-oc
 kt
 QO
 JT
@@ -21209,7 +22253,7 @@ VI
 ie
 JS
 eW
-eW
+fP
 wz
 KK
 KK
@@ -21300,11 +22344,11 @@ aw
 aw
 de
 de
-mi
-ju
-ZR
-Gf
-Xr
+xP
+xP
+xP
+xP
+xP
 lX
 Ce
 bK
@@ -21312,11 +22356,11 @@ CO
 Cl
 PN
 GF
-qC
-qC
-qC
-qC
-qC
+qf
+xs
+Gf
+Qd
+QH
 mc
 qC
 qC
@@ -21436,17 +22480,17 @@ aw
 aw
 aw
 aw
-ad
+iW
 la
 la
 la
-BA
-KD
-sm
-Ar
-lk
-vm
-qf
+de
+ld
+vt
+vt
+vt
+uh
+ge
 Pl
 As
 bw
@@ -21454,14 +22498,14 @@ AL
 WF
 XQ
 bC
-qC
-qC
-zJ
-zJ
-qC
+Ly
+xK
+Ly
+Qd
+Sa
 Ih
-xU
-xU
+qC
+rf
 xU
 xU
 Wf
@@ -21579,31 +22623,31 @@ aw
 aw
 aw
 kk
-Wk
+qJ
 UZ
-Wb
+vt
 sN
-vt
-vt
-vt
-vt
-vt
-vt
+pH
+OL
+HK
+XV
+Cd
+Cm
 wi
 Ce
 Ti
 bP
 no
 cC
-GF
+eR
 VU
-qC
+zr
 Vx
-HL
+Qd
 Sr
 nB
 lW
-qC
+Yj
 qC
 qC
 qC
@@ -21621,7 +22665,7 @@ Ym
 Ym
 Ym
 Ym
-Ym
+wl
 Ym
 Ym
 Ym
@@ -21636,9 +22680,9 @@ ie
 QX
 eW
 eW
-eW
-eW
-eW
+eJ
+eJ
+eJ
 eW
 Bq
 Eh
@@ -21721,14 +22765,14 @@ aw
 aw
 aw
 kk
-Wk
+ry
 Te
 xP
 xP
 xP
-xP
-xP
-xP
+OL
+HK
+XV
 xP
 xP
 oJ
@@ -21737,18 +22781,18 @@ qi
 Vl
 bA
 QE
-GF
-qC
-qC
+fh
+rg
+Uj
 JI
-JI
+Qd
+SE
+YX
 qC
-og
+AC
+XW
 qC
 qC
-qC
-qC
-Pr
 BG
 Az
 aJ
@@ -21778,9 +22822,9 @@ ie
 QX
 eW
 eW
-VG
-VG
-VG
+HK
+HK
+HK
 eW
 BP
 it
@@ -21865,13 +22909,13 @@ cO
 de
 qj
 cX
-Ng
+xP
+xP
+xP
 OL
-OL
-OL
-OL
-OL
-OL
+HK
+XV
+xP
 hp
 yu
 Ce
@@ -21879,19 +22923,19 @@ uu
 Vl
 cA
 QE
-GF
-qC
-qC
-qC
-qC
+fi
+rH
+Uj
+GR
+Qd
 qC
 og
 qC
-zJ
+AC
+fC
 qC
 qC
 Fi
-lT
 GB
 aK
 aQ
@@ -21916,13 +22960,13 @@ hN
 Ya
 Ya
 KI
-am
+HN
 QX
 eW
 eW
-eW
+fP
 pY
-eW
+fP
 eW
 wQ
 eW
@@ -22007,33 +23051,33 @@ rM
 um
 ge
 bN
-bj
-VG
-VG
-VG
-VG
-VG
-VG
-VG
+xP
+xP
+xP
+xP
+xP
+xP
+xP
+xP
 wg
 Ce
 ke
 Vl
 yU
 TR
-GF
-mu
-qC
-Bk
-nf
-Sr
-nB
-qC
+ii
+jF
+Ae
+jF
+Qd
+Td
+Zo
+lW
 Fw
 nf
 lh
+BT
 AC
-qC
 DK
 Mj
 bZ
@@ -22062,9 +23106,9 @@ pA
 QX
 eW
 eW
-eW
-eW
-eW
+VG
+VG
+VG
 eW
 Cj
 tE
@@ -22150,13 +23194,13 @@ gv
 oe
 gk
 bj
-VG
-VG
-VG
-VG
-VG
-VG
-VG
+uV
+wb
+xP
+Ng
+ci
+xP
+lS
 bq
 Ce
 fH
@@ -22165,17 +23209,17 @@ Da
 SW
 Cc
 Bk
-nf
-xU
-Ni
-qC
+Jq
+HL
+Qd
+Td
 jH
 OX
 Hd
 xf
+OA
 OX
-eR
-OX
+Hd
 fK
 UL
 cP
@@ -22201,13 +23245,13 @@ SL
 Ya
 Ya
 pq
-uh
-pH
-er
-er
-er
-er
-er
+QX
+eW
+eW
+VG
+VG
+VG
+MZ
 NE
 er
 er
@@ -22288,35 +23332,35 @@ cn
 cn
 fW
 gN
-de
-qj
+dY
+Ce
 Ze
-wb
+Ce
 In
-dY
-dY
+km
+km
 lH
+Ce
 ua
-ua
-sc
-Ny
+Ce
+rw
 Ce
 qh
 Vl
 cA
 QE
 ez
-qC
-Fi
-Bk
-ZS
-qC
-og
-qC
-Fi
-Fi
+sm
+Jq
+PU
+Qd
+UH
+ZR
 qC
 AC
+Fi
+Fi
+qC
 jT
 GB
 aO
@@ -22342,16 +23386,16 @@ KI
 Zs
 Ya
 KI
-am
-eW
-QX
-eW
-eW
+xH
+iQ
+sy
+er
+FA
 gP
-eW
-eW
+FA
+Vr
 OG
-eW
+tR
 KK
 DC
 Jd
@@ -22430,35 +23474,35 @@ aw
 aw
 aw
 aw
-kk
+hn
 Us
 hk
 BW
 KP
-xP
-xP
+pZ
+DM
 Fh
 qZ
-qZ
-qZ
+OO
+OO
 pr
 fV
 gX
 Vl
 cA
 QE
-ez
-hG
-vW
+ju
+vm
+Jq
 PU
 py
+Wk
+ZS
 xU
-nB
-rg
-AC
-AC
-qC
-AC
+ph
+ph
+ws
+xU
 Kj
 GB
 aP
@@ -22488,9 +23532,9 @@ ie
 eW
 QX
 eW
-VG
-VG
-VG
+HK
+HK
+HK
 eW
 OG
 pm
@@ -22572,35 +23616,35 @@ aw
 aw
 aw
 aw
-kk
-Us
+hn
+sc
 gG
-Aa
+BW
 Ii
-DM
-qJ
-Ha
-hn
-hn
-eM
+pZ
+pZ
+pZ
+pZ
+pZ
+pZ
 cF
 so
 ca
 Vl
 zF
 QE
-ez
-VU
-AC
-rx
+lk
+vz
+Jq
+PU
 Ju
-xU
+Xr
 Pq
-xU
-Qa
-Ju
-xU
-Wf
+qC
+Em
+cG
+qC
+qC
 At
 GB
 GB
@@ -22615,7 +23659,7 @@ xl
 Ym
 Ym
 Ym
-Ym
+wl
 Ym
 Ym
 Ym
@@ -22630,12 +23674,12 @@ ie
 eW
 QX
 eW
-eW
-eW
-eW
+fP
+fP
+fP
 eW
 OG
-eW
+EP
 HQ
 Qg
 aw
@@ -22732,15 +23776,15 @@ pZ
 PA
 fD
 tL
-qC
-AC
-qC
-qC
-Bk
+Jq
+Jq
+HO
+Ju
+Yt
 KS
 iV
-rx
-xu
+kS
+AC
 qC
 qC
 EV
@@ -22754,8 +23798,8 @@ eE
 Ym
 BF
 JX
-Ff
-Ff
+Ui
+sK
 sK
 Fs
 AN
@@ -22860,13 +23904,13 @@ aw
 aw
 aw
 aw
-de
-de
+dY
+dY
 re
-eO
+bL
 IN
-uV
-eM
+Ak
+pZ
 uq
 rw
 bL
@@ -22875,19 +23919,19 @@ nx
 cE
 KZ
 WD
-SE
-qC
-qC
-qC
+Jq
+NT
+Ju
+YJ
 mc
-ld
 qC
+VL
 AC
 qC
 gs
 yq
-oV
-oV
+mJ
+fR
 Rr
 Hl
 fI
@@ -22896,9 +23940,9 @@ ky
 Ym
 xl
 Ym
-Ym
-Ym
 xe
+Ym
+Ym
 Ym
 xl
 Ym
@@ -23003,13 +24047,13 @@ aw
 aw
 aw
 aw
-de
-de
+dY
+dY
 MO
-XV
+bL
 YB
-ff
-ff
+Ak
+QE
 rw
 Du
 yv
@@ -23017,19 +24061,19 @@ Du
 Du
 bV
 Zu
-ii
+Jq
 NT
-hJ
+Ju
 OW
-mc
+Bv
 lK
 tu
 Mg
 Oz
 So
 Tg
-oV
-oV
+jN
+AY
 Rr
 ak
 RF
@@ -23043,7 +24087,7 @@ IF
 JQ
 kC
 ql
-pf
+Vo
 qP
 ug
 CT
@@ -23146,22 +24190,22 @@ aw
 aw
 aw
 aw
-de
-de
+dY
+dY
 el
-XV
-YB
-HK
+QE
+QE
+QE
 mU
 km
 km
 km
 km
 gR
-fQ
-fQ
-fQ
-fQ
+vR
+Ar
+vR
+Ni
 fQ
 AB
 Qb
@@ -23180,24 +24224,24 @@ VA
 UC
 GP
 vK
+UW
 vK
 vK
-zc
+vK
+vK
 Nk
-Ui
-Nk
-Nk
+ms
 Nk
 Nk
 XJ
-aH
-aH
-aH
-aH
-aH
+Rb
+Rb
+Rb
+Rb
+Rb
 OG
 eW
-eW
+uE
 KK
 KK
 Qg
@@ -23289,10 +24333,10 @@ aw
 aw
 aw
 Qg
-de
-de
+dY
+dY
 Ri
-xP
+QE
 ff
 jF
 aj
@@ -23300,14 +24344,14 @@ bM
 da
 op
 Lf
-Lf
-Lf
-Lf
+Np
+Jq
+Ip
 jF
 UA
 Gi
 tV
-Mn
+Jq
 nY
 QA
 Mp
@@ -23324,21 +24368,21 @@ lc
 DO
 Iu
 tH
-Gv
+UO
 Lu
-KG
+UO
 Rb
-Rb
+ly
 vy
 iZ
 cz
 vd
-vd
+lP
 Pa
 jV
-aH
+Rb
 gC
-tR
+DV
 KK
 KK
 aw
@@ -23432,10 +24476,10 @@ aw
 aw
 Qg
 aw
-de
-de
-xP
-ff
+dY
+dY
+DD
+QE
 jF
 au
 bS
@@ -23450,7 +24494,7 @@ Mn
 kV
 Jq
 Jq
-Ae
+Jq
 oY
 fn
 gx
@@ -23461,24 +24505,24 @@ Gr
 BS
 Uh
 Xz
-Vz
-Vz
-Vz
-dH
-Yn
-BB
-By
-By
-By
-By
-By
-By
-By
-By
-By
-By
-By
-aH
+zc
+zc
+zc
+Ai
+tH
+UO
+UO
+UO
+Rb
+aA
+xR
+xR
+xR
+qt
+va
+Pa
+Pa
+Rb
 Wr
 KK
 KK
@@ -23575,9 +24619,9 @@ aw
 Qg
 aw
 aw
-de
-de
-ff
+dY
+dY
+QE
 jF
 az
 Ah
@@ -23590,13 +24634,13 @@ Ul
 Dg
 Ul
 ML
-Ul
-Ul
+sb
+sb
 sb
 Cw
 qQ
-ZA
-ZA
+FZ
+SJ
 SJ
 jF
 ak
@@ -23606,21 +24650,21 @@ OE
 Vz
 Vz
 Vz
-HR
-Yn
-gK
-By
-By
-By
-By
-By
-By
-By
-By
-By
-By
-By
-aH
+Vz
+gU
+UO
+UO
+UO
+Rb
+MB
+xR
+xR
+xR
+sj
+Pa
+Pa
+me
+Rb
 KK
 KK
 aw
@@ -23718,7 +24762,7 @@ Qg
 aw
 aw
 aw
-de
+dY
 NN
 jF
 bE
@@ -23734,12 +24778,12 @@ zI
 VX
 Zc
 ti
-UH
-QH
-Gb
-Eb
+Jq
+Jq
+Xg
+jF
 zn
-Qh
+jF
 jF
 qq
 Zb
@@ -23749,19 +24793,19 @@ Vz
 uj
 Vz
 Vz
-Yn
+gz
 UO
-By
-By
-By
-By
+IS
+UO
+Rb
+YL
 xR
-By
-By
-By
-By
-By
-uk
+Wj
+xR
+qt
+Pa
+jV
+Pa
 IP
 KK
 aw
@@ -23874,35 +24918,35 @@ wh
 QL
 Ve
 GW
-Ip
+jF
 RP
-Jq
-Jq
+md
+OJ
 LS
 Jq
 Jq
 Og
 jF
-Qs
+xv
 JP
 Uh
 iH
 Vz
-De
 Vz
 Vz
-Yn
-gK
-By
-By
-By
-By
-By
-By
-By
-By
-By
-By
+qK
+gU
+UO
+UO
+UO
+Rb
+YL
+xR
+xR
+xR
+Ns
+Pa
+Pa
 Ht
 Ht
 aw
@@ -24016,34 +25060,34 @@ wK
 ZA
 wp
 Ij
-fi
+jF
 YE
 hX
 hX
 ga
 Jq
-Jq
-YX
-jF
-xg
+mp
+GI
+zn
+CK
 BS
-Uh
+jQ
 HM
 Vz
-Mc
 Vz
 Vz
-Yn
-BX
-By
-By
-By
-By
-By
-By
-By
-By
-By
+Tz
+gU
+UO
+UO
+UO
+Rb
+SH
+xR
+rW
+xR
+qt
+Pa
 Ht
 Ht
 aw
@@ -24158,32 +25202,32 @@ DN
 iY
 Ab
 tI
-rH
-xq
-Ul
-Ul
-fT
-Jq
-Jq
-Og
 jF
-CK
+xq
+JY
+Hh
+fT
+YC
+vQ
+mI
+jF
+JE
 BS
 Uh
 Ol
-Vz
+rJ
 ES
-Vz
-Vz
-Yn
-gK
-By
-By
-By
-By
-By
-By
-By
+Kv
+tf
+gU
+UO
+ut
+UO
+Rb
+XN
+An
+SI
+ZI
 Ap
 Ht
 Ht
@@ -24295,38 +25339,38 @@ kY
 vJ
 vJ
 vJ
-HO
-hX
-hX
-hX
-hX
-vz
-RP
-Jq
-Jq
+jF
+jF
+jF
+jF
+jF
+jF
+rP
+jF
+jF
 Xg
-xs
-xs
-xs
+jF
+jF
+jF
 jF
 Gr
 BS
 Uh
 JZ
-Vz
-jQ
-Vz
-Vz
 Yn
-gK
-By
-By
-By
-By
-Ct
-By
-By
-PO
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
+Rb
+Rb
+Rb
+Rb
+Rb
+Ka
 It
 aY
 aY
@@ -24437,31 +25481,31 @@ LK
 KN
 SN
 Vt
-Ul
-Ul
-Ul
+Ug
+Jr
+AD
 sI
-Jq
-Jq
+ik
+TM
 gw
-Jq
-Jq
-LS
-Jq
-Jq
-JR
-jF
+wT
+Tt
+hA
+Bi
+Xm
+yQ
+jm
 EX
 cq
 Hw
 SY
 WN
 WN
-WN
+Mc
 WN
 PG
 CV
-iB
+CV
 Ji
 Dv
 yp
@@ -24578,15 +25622,15 @@ zp
 zp
 XP
 fY
-fY
-fY
-fY
-fY
+vW
+Cu
+LD
+fc
 Ln
 mj
-mj
+tj
 jZ
-gW
+xc
 XF
 Mb
 sD
@@ -24595,22 +25639,22 @@ xc
 Oa
 cm
 Va
-Uh
+gl
 Nw
-Vz
-Vz
-Vz
-dH
-Yn
+De
+HR
 ER
-tG
-tG
-By
-gK
+ER
+DE
+ER
+ER
+RE
+xj
+xj
 uk
-PO
-Ht
-Ht
+Rf
+It
+It
 aY
 aY
 aY
@@ -24718,39 +25762,39 @@ Up
 fb
 fb
 fb
-ry
-ry
+LK
+LK
 KN
-wR
-lR
-Hn
-Uj
-LI
-Cq
-LS
-Ow
-mM
+NL
+NL
+NL
+NL
+NL
+NL
+UV
+NL
+LY
 yA
-Kn
-Cu
-Kn
-jF
+NL
+NL
+NL
+NL
 yH
 Po
-Uh
+RD
 SP
-rJ
+cs
 Wh
 dH
 mH
-Yn
+EW
 Yv
 Ub
 RE
-By
 LT
-Ht
-Ht
+lC
+It
+It
 aw
 aw
 aw
@@ -24862,36 +25906,36 @@ aw
 aw
 aw
 aw
-ry
-KN
-jF
-jF
-jF
-jF
-jF
-rr
-jF
-jF
+ot
+ze
+cT
+NY
+Je
+Wb
+Di
+cM
+hw
+Pi
 XL
-jF
-jF
-jF
-jF
+is
+qr
+xV
+NP
 Yo
 Va
 RD
-xt
-xt
-xt
-xt
-xt
-xt
-xt
-xt
-xt
-xt
+Tx
+Tx
+Tx
+Tx
+Tx
+Tx
+Tx
+Tx
+RE
+RE
 Rf
-yr
+It
 aw
 aw
 aw
@@ -25005,19 +26049,19 @@ aw
 aw
 aw
 aw
-ry
-KN
-wq
-wq
-rk
-KU
-BM
-KU
-jF
-rF
-Vk
+ot
+ze
+AE
+Uo
+Uo
+HE
+HA
 xS
-jF
+xS
+xB
+xS
+xS
+OP
 oG
 Wz
 ZO
@@ -25027,7 +26071,7 @@ Jc
 GT
 II
 uD
-gi
+uK
 SV
 gi
 id
@@ -25148,18 +26192,18 @@ aw
 aw
 aw
 aw
-Cd
-Cd
-wq
-ys
-mz
-UB
-lq
-jF
-fA
+IO
+IO
+gb
+Uo
+Uo
+pa
+Uo
+GO
+yd
 TZ
 Uf
-jF
+xV
 Bm
 xG
 dV
@@ -25171,7 +26215,7 @@ Nn
 Nn
 Nn
 Nn
-Nn
+Et
 Qq
 Qq
 aw
@@ -25291,28 +26335,28 @@ aw
 aw
 aw
 aw
-Cd
-Cd
-pM
-hA
-UV
-PT
-jF
-HA
-ze
-Ph
-ry
+IO
+IO
+rC
+WR
+pa
+UM
+YH
+uf
+xV
+xV
+Dp
 RM
 fp
 ty
 xt
 Uw
 Nn
-Yc
-Yc
 Nn
 Nn
 Nn
+Nn
+Et
 Qq
 Qq
 aw
@@ -25434,25 +26478,25 @@ aw
 aw
 aw
 aw
-Cd
-Cd
-lq
-UB
-mz
-jF
-jF
-jF
-jF
-ry
+IO
+IO
+IA
+pa
+Uo
+Uo
+Uo
+ZD
+ev
+ot
 jA
-XA
+nG
 ty
 lA
 cf
 Nn
 Yc
 Yc
-Nn
+vU
 gy
 Qq
 Qq
@@ -25577,19 +26621,19 @@ aw
 aw
 aw
 aw
-ry
-ry
+ot
+ot
 Yg
 YN
-bT
-lq
-AE
-lq
-ry
+qD
+cD
+Uo
+EC
+ot
 zx
-XA
+tr
 ty
-lA
+hQ
 cf
 Nn
 Yc
@@ -25720,14 +26764,14 @@ aw
 aw
 aw
 aw
-Cd
-Cd
-NL
-LY
-AD
-le
+IO
+IO
+ot
+fX
+SC
+KM
 lb
-ry
+ot
 Va
 XA
 ty
@@ -25863,20 +26907,20 @@ aw
 aw
 aw
 aw
-Cd
-ry
-ys
-lq
-EF
-lq
-ry
+IO
+ot
+ZP
+ME
+Uo
+PK
+ot
 Rp
 XA
 ty
-hQ
-cf
+cQ
+fr
 Nn
-Nn
+vU
 yr
 Qq
 aw
@@ -26006,12 +27050,12 @@ aw
 aw
 aw
 aw
-ry
-Cd
-sW
-MK
-lD
-ry
+ot
+IO
+tn
+Uo
+JR
+ot
 AI
 oM
 mX
@@ -26149,11 +27193,11 @@ aw
 aw
 aw
 aw
-Cd
-Cd
-ys
-lq
-ry
+IO
+IO
+Uo
+Uo
+ot
 lZ
 Ma
 ek
@@ -26292,14 +27336,14 @@ aw
 aw
 aw
 aw
-Cd
-Cd
-sW
-tY
+IO
+IO
+zz
+ot
 iy
 Nh
 tY
-zr
+Nn
 Qq
 Qq
 aw
@@ -26435,9 +27479,9 @@ aw
 aw
 aw
 aw
-Cd
-KN
-tY
+IO
+ze
+ot
 Bo
 Bo
 rT
@@ -26579,7 +27623,7 @@ aw
 aw
 aw
 Db
-tY
+ot
 eb
 ec
 ka
@@ -26721,7 +27765,7 @@ aw
 aw
 aw
 aw
-jJ
+Db
 dP
 oU
 BK


### PR DESCRIPTION
- reworks the aerostat in general
- adds a virology lab with roundstart samples so medical can do viro work if they wish to. the viro lab on the ship can be used for emergency viro work (ie if we ever get a virus) while the aerostat one can be for experiments and such
- attempts to pretty up the north and south entrances because they're pretty empty right now

overall view
![genview](https://user-images.githubusercontent.com/75939194/143960384-9c661175-7b34-4566-a7b9-1355a60e5b54.png)

north entrance
![north](https://user-images.githubusercontent.com/75939194/143960400-85da5fb7-7a34-4938-bd2e-a9c938b72c26.png)

toxins, atmos (untouched), xenoarch prep
![tox](https://user-images.githubusercontent.com/75939194/143960422-0f082598-a2dc-43d4-ab44-25176b0d61de.png)


xenoarch, viro (plus a maint hallway to solars)
![xenovi](https://user-images.githubusercontent.com/75939194/143960464-e8f63059-cbb6-4db6-a323-f757a24d345e.png)

misc lab (empty), firing range
![firin](https://user-images.githubusercontent.com/75939194/143960509-612dc06a-e972-4d76-b408-728f21539ee1.png)

telesci (now more secure in case of unfortunate mob teleports), genetics (with a monkey pen, yay), mining storage (+a hallway and misc storage room to solars)
![telesci](https://user-images.githubusercontent.com/75939194/143960617-38640bad-0bd0-4bd2-8749-ae7c955a3d46.png)

south entrance
![south](https://user-images.githubusercontent.com/75939194/143960624-59c24ad9-e49b-4413-b577-d61f1bbc72bc.png)


