### PR TITLE
Makes NIFs not get automatically lost (hopefully)

### DIFF
--- a/code/modules/client/preference_setup/vore/08_nif.dm
+++ b/code/modules/client/preference_setup/vore/08_nif.dm
@@ -38,11 +38,17 @@
 	if((character.type == /mob/living/carbon/human) && ispath(pref.nif_path) && pref.nif_durability)
 		new pref.nif_path(character,pref.nif_durability,pref.nif_savedata)
 
+		/*
 		//And now here's the trick. We wipe these so that if they die, they lose the NIF.
 		//Backup implants will start saving this again periodically, and so will cryo'ing out.
 		pref.nif_path = null
 		pref.nif_durability = null
 		pref.nif_savedata = null
+		*/
+		//No we do not, that's lame and admins have to re-NIF them later.
+		//If they leave round or get their NIF extracted, it will save as 'gone' anyway
+		//Let's give a more minor punishment for not properly backing up instead!
+		pref.nif_durability -= rand(10, 15)
 		var/savefile/S = new /savefile(pref.path)
 		if(!S) WARNING ("Couldn't load NIF save savefile? [pref.real_name]")
 		S.cd = "/character[pref.default_slot]"

--- a/code/modules/client/preference_setup/vore/08_nif.dm
+++ b/code/modules/client/preference_setup/vore/08_nif.dm
@@ -46,9 +46,8 @@
 		pref.nif_savedata = null
 		*/
 		//No we do not, that's lame and admins have to re-NIF them later.
-		//If they leave round or get their NIF extracted, it will save as 'gone' anyway
-		//Let's give a more minor punishment for not properly backing up instead!
-		pref.nif_durability -= rand(10, 15)
+		//If they leave round after they get their NIF extracted, it will save as 'gone' anyway
+		//The NIF will save automatically every time durability changes too now.
 		var/savefile/S = new /savefile(pref.path)
 		if(!S) WARNING ("Couldn't load NIF save savefile? [pref.real_name]")
 		S.cd = "/character[pref.default_slot]"

--- a/code/modules/nifsoft/nif.dm
+++ b/code/modules/nifsoft/nif.dm
@@ -197,6 +197,9 @@ You can also set the stat of a NIF to NIF_TEMPFAIL without any issues to disable
 	wear *= (rand(85,115) / 100) //Apparently rand() only takes integers.
 	durability -= wear
 
+	if(human)
+		persist_nif_data(human)
+
 	if(durability <= 0)
 		stat = NIF_TEMPFAIL
 		update_icon()
@@ -204,6 +207,13 @@ You can also set the stat of a NIF to NIF_TEMPFAIL without any issues to disable
 		if(human)
 			notify("Danger! General system insta#^!($",TRUE)
 			to_chat(human,"<span class='danger'>Your NIF vision overlays disappear and your head suddenly seems very quiet...</span>")
+
+//Repair update/check proc
+/obj/item/device/nif/proc/repair(var/repair = 0)
+	durability = min(durability + repair, initial(durability))
+
+	if(human)
+		persist_nif_data(human)
 
 //Attackby proc, for maintenance
 /obj/item/device/nif/attackby(obj/item/weapon/W, mob/user as mob)
@@ -233,7 +243,7 @@ You can also set the stat of a NIF to NIF_TEMPFAIL without any issues to disable
 			user.visible_message("[user] closes up \the [src].","<span class='notice'>You re-seal \the [src] for use once more.</span>")
 			playsound(src, 'sound/items/Screwdriver.ogg', 50, 1)
 			open = FALSE
-			durability = initial(durability)
+			repair(initial(durability))
 			stat = NIF_PREINSTALL
 			update_icon()
 

--- a/code/modules/reagents/reagents/other_vr.dm
+++ b/code/modules/reagents/reagents/other_vr.dm
@@ -47,7 +47,7 @@
 			var/obj/item/device/nif/nif = H.nif //L o c a l
 			if(nif.stat == NIF_TEMPFAIL)
 				nif.stat = NIF_INSTALLING
-			nif.durability = min(nif.durability + removed, initial(nif.durability))
+			nif.repair(removed)
 
 /datum/reagent/firefighting_foam
 	name = "Firefighting Foam"
@@ -120,7 +120,7 @@
 			var/obj/item/device/nif/nif = H.nif //L o c a l
 			if(nif.stat == NIF_TEMPFAIL)
 				nif.stat = NIF_INSTALLING
-			nif.durability = min(nif.durability + removed*0.1, initial(nif.durability))
+			nif.repair(removed*0.1)
 
 //Special toxins for solargrubs
 /datum/reagent/grubshock


### PR DESCRIPTION
~~Makes it so that instead of erasing NIF from savefile and re-saving them later, NIFs only get their savefile durability reduced. This is still minorly punishing for not backing up, but not nearly as harshly as full on deletion. Eases job for admins too.~~

~~Properly backed up people will have these durability changes overridden anyway, so that won't cause issues, and if you leave round after extracting a NIF, well, it will also be overridden with nothingness. So this should only affect situations where NIF just disappears.~~

Adjusted based on feedback. Now NIFs simply saves whenever durability changes, upwards or downwards. Saving from backup implants and end of round happens still too.