### PR TITLE
Adds how to use  doorbells to Airlock descriptions

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -3,8 +3,8 @@
 
 /obj/machinery/door
 	name = "Door"
-	desc = "It opens and closes."
-	icon = 'icons/obj/doors/Doorint.dmi'
+	desc = "It opens and closes.  There's a little doorbell on the side of the airlock that you can ring by Holding Alt and Left Clicking it."  //Vorestation edit
+  	icon = 'icons/obj/doors/Doorint.dmi'
 	icon_state = "door1"
 	anchored = TRUE
 	opacity = 1


### PR DESCRIPTION
As far as I'm aware there's like zero  tutorial in game about how to use the doorbell system.  Admittedly if I was better I'd have liked to be able to make it look like how when examining airlocks you're told how to use tools on it, but unfortunately I am not that talented so this will do.  Unless changes are requested.  