### PR TITLE
Makes proteans gib on death

### DIFF
--- a/code/modules/mob/living/carbon/human/death_vr.dm
+++ b/code/modules/mob/living/carbon/human/death_vr.dm
@@ -1,13 +1,14 @@
 /mob/living/carbon/human/gib()
-	
-	//Drop the NIF, they're expensive, why not recover them? Also important for prometheans.
+
+	//Drop the NIF, they're expensive, why not recover them?
 	if(nif)
 		var/obj/item/device/nif/deadnif = nif //Unimplant removes the reference on the mob
-		deadnif.unimplant(src)
-		deadnif.forceMove(drop_location())
-		deadnif.throw_at(get_edge_target_turf(src,pick(alldirs)), rand(1,3), round(30/deadnif.w_class))
-		deadnif.wear(10) //Presumably it's gone through some shit if they got gibbed?
-	
+		if(!deadnif.gib_nodrop)
+			deadnif.unimplant(src)
+			deadnif.forceMove(drop_location())
+			deadnif.throw_at(get_edge_target_turf(src,pick(alldirs)), rand(1,3), round(30/deadnif.w_class))
+			deadnif.wear(10) //Presumably it's gone through some shit if they got gibbed?
+
 	. = ..()
 
 //Surprisingly this is only called for humans, but whatever!
@@ -15,10 +16,10 @@
 	//Not in a belly? Well, too bad!
 	if(!isbelly(H.loc))
 		return TRUE
-	
+
 	//What belly!
 	var/obj/belly/B = H.loc
-	
+
 	//Were they digesting and we have a mind you can update?
 	//Technically allows metagaming by allowing buddies to turn on digestion for like 2 seconds
 	//  to finish off critically wounded friends to avoid resleeving sickness, but like

--- a/code/modules/mob/living/carbon/human/species/station/protean_vr/protean_species.dm
+++ b/code/modules/mob/living/carbon/human/species/station/protean_vr/protean_species.dm
@@ -172,13 +172,9 @@
 
 	to_chat(H, "<span class='warning'>You died as a Protean. Please sit out of the round for at least 60 minutes before respawning, to represent the time it would take to ship a new-you to the station.</span>")
 
-	for(var/obj/item/organ/I in H.internal_organs)
-		I.removed()
-
-	for(var/obj/item/I in H.contents)
-		H.drop_from_inventory(I)
-
-	qdel(H)
+	spawn(1)
+		if(H)
+			H.gib()
 
 /datum/species/protean/handle_environment_special(var/mob/living/carbon/human/H)
 	if((H.getActualBruteLoss() + H.getActualFireLoss()) > H.maxHealth*0.5 && isturf(H.loc)) //So, only if we're not a blob (we're in nullspace) or in someone (or a locker, really, but whatever)

--- a/code/modules/nifsoft/nif.dm
+++ b/code/modules/nifsoft/nif.dm
@@ -28,6 +28,7 @@ You can also set the stat of a NIF to NIF_TEMPFAIL without any issues to disable
 
 	var/durability = 100					// Durability remaining
 	var/bioadap = FALSE						// If it'll work in fancy species
+	var/gib_nodrop = FALSE					// NIF self-destructs when owner is gibbed
 
 	var/tmp/power_usage = 0						// Nifsoft adds to this
 	var/tmp/mob/living/carbon/human/human		// Our owner!
@@ -613,6 +614,7 @@ You can also set the stat of a NIF to NIF_TEMPFAIL without any issues to disable
 	desc = "A NIF that is part of a protean's body structure. Where did you get that anyway?"
 	durability = 25
 	bioadap = TRUE
+	gib_nodrop = TRUE
 
 ////////////////////////////////
 // Special Promethean """surgery"""

--- a/code/modules/vore/eating/digest_act_vr.dm
+++ b/code/modules/vore/eating/digest_act_vr.dm
@@ -139,6 +139,10 @@
 	//Replace this with a VORE setting so all types of posibrains can/can't be digested on a whim
 	return FALSE
 
+/obj/item/organ/internal/nano/digest_act(atom/movable/item_storage = null)
+	//Make proteans recoverable too
+	return FALSE
+
 // Gradual damage measurement
 /obj/item
 	var/digest_stage = null


### PR DESCRIPTION
Should fix a runtime that happens when they die. Gib is basically same thing as 'drop all items and organs' anyway, just in a more violent way.

Also makes protean organs indigestible (for the potential future mechanics of protean recovery).

I originally planned to fix #9538, but it turns out it wasn't a bug anymore. But I found the runtime so I fixed that.
Fixes #9538 (doesn't cuz its not an issue anymore, but marking so that it closes that).