### PR TITLE
Another capture crystal tweak

### DIFF
--- a/code/game/objects/items/devices/denecrotizer_vr.dm
+++ b/code/game/objects/items/devices/denecrotizer_vr.dm
@@ -76,6 +76,10 @@
 	// Clean up the simplemob
 	ghostjoin = FALSE
 	ghostjoin_icon()
+	if(capture_caught)
+		to_chat(src, "<span class='notice'>You are bound to [revivedby], follow their commands within reason and to the best of your abilities, and avoid betraying or abandoning them.</span><span class= warning> You are allied with [revivedby]. Do not attack anyone for no reason. Of course, you may do scenes as you like, but you must still respect preferences.</span>")
+		visible_message("[src]'s eyes flicker with a curious intelligence.", runemessage = "looks around")
+		return
 	if(revivedby != "no one")
 		to_chat(src, "<span class='notice'>Where once your life had been rough and scary, you have been assisted by [revivedby]. They seem to be the reason you are on your feet again... so perhaps you should help them out.</span> <span class= warning> Being as you were revived, you are allied with the station. Do not attack anyone unless they are threatening the one who revived you. And try to listen to the one who revived you within reason. Of course, you may do scenes as you like, but you must still respect preferences.</span>")
 		visible_message("[src]'s eyes flicker with a curious intelligence.", runemessage = "looks around")


### PR DESCRIPTION
You can now destroy the crystal to release whatever is inside of it.

You can now relinquish ownership ownership (without releasing the mob)

You can now toggle ghost join on and off on AI controlled mobs who have been caught by the capture crystal, rather than it being automatically on. (Once a ghost joins, it cannot be turned on again, of course)

And generally cleans up some of the interactions.