### PR TITLE
Fixes produce persistence

### DIFF
--- a/code/modules/persistence/storage/smartfridge.dm
+++ b/code/modules/persistence/storage/smartfridge.dm
@@ -52,11 +52,11 @@
 		// Delete some stacks if we want
 		if(stacks_go_missing)
 			var/fuzzy = rand(55,65)*0.01 // loss of 35-45% with rounding down
-			count = round(count*fuzzy) 
+			count = round(count*fuzzy)
 			if(count <= 0)
 				continue
-		
-		while(count > 0)	
+
+		while(count > 0)
 			inst = new real_path(null, min(count, max_amount))
 			count -= inst.get_amount()
 			. += inst
@@ -71,6 +71,16 @@
 /datum/persistent/storage/smartfridge/produce/lossy
 	name = "fruit storage lossy"
 	go_missing_chance = 12.5 // 10% loss between rounds
+
+/datum/persistent/storage/smartfridge/produce/generate_items(var/list/L)			// Mostly same as storage/generate_items() but without converting string to path
+	. = list()
+	for(var/fruit_type in L)
+		for(var/i in 1 to L[fruit_type])
+			if(prob(go_missing_chance))
+				continue
+			var/atom/A = create_item(fruit_type)
+			if(!QDELETED(A))
+				. += A
 
 /datum/persistent/storage/smartfridge/produce/create_item(var/seedtype)
 	return new /obj/item/weapon/reagent_containers/food/snacks/grown(null, seedtype) // Smartfridge will be stock()ed with it, loc is unimportant


### PR DESCRIPTION
The saving of it was fine, but loading failed to properly create the products. Whatever first shift after this releases will be, they'll get previous shift's produce persistence and from then it should work properly.

Fixes #11380 