### PR TITLE
Allows simplemobs climb ladders + trash pile interaction fix

### DIFF
--- a/code/game/objects/structures/trash_pile_vr.dm
+++ b/code/game/objects/structures/trash_pile_vr.dm
@@ -69,13 +69,13 @@
 		var/mob/living/L = user
 		//They're in it, and want to get out.
 		if(L.loc == src)
-			var/choice = tgui_alert(usr, "Do you want to exit \the [src]?","Un-Hide?",list("Exit","Stay"))
+			var/choice = tgui_alert(user, "Do you want to exit \the [src]?","Un-Hide?",list("Exit","Stay"))
 			if(choice == "Exit")
 				if(L == hider)
 					hider = null
 				L.forceMove(get_turf(src))
 		else if(!hider)
-			var/choice = tgui_alert(usr, "Do you want to hide in \the [src]?","Un-Hide?",list("Hide","Stay"))
+			var/choice = tgui_alert(user, "Do you want to hide in \the [src]?","Un-Hide?",list("Hide","Stay"))
 			if(choice == "Hide" && !hider) //Check again because PROMPT
 				L.forceMove(src)
 				hider = L

--- a/code/modules/multiz/ladders.dm
+++ b/code/modules/multiz/ladders.dm
@@ -33,6 +33,13 @@
 		target_up = null
 	return ..()
 
+/obj/structure/ladder/attack_generic(mob/user)
+	//Simple Animal
+	if(isanimal(user))
+		attack_hand(user)
+	else
+		return ..()
+
 /obj/structure/ladder/attackby(obj/item/C as obj, mob/user as mob)
 	attack_hand(user)
 	return


### PR DESCRIPTION
Gives simplemobs ability to climb ladders up/down (requries you to be on harm intent to do, but its kinda consequence of how armless simplemob clicks work). Fixes #11308 by extent.

Also fixes being unable to hide in trash piles as simple mobs (same thing, must be on harm)