### PR TITLE
Shows how to ring an airlock's doorbell

### DIFF
--- a/code/modules/examine/descriptions/engineering.dm
+++ b/code/modules/examine/descriptions/engineering.dm
@@ -46,6 +46,8 @@
 	return results
 
 /obj/machinery/door/airlock/get_description_interaction()
+	description_info = "To ring an airlock's doorbell, hold Alt and click on the airlock with the Left Mouse Button." //vorestation edit
+	
 	var/list/results = list()
 
 	if(can_remove_electronics())


### PR DESCRIPTION
Third time's the charm.  This SHOULD ideally make it show up in purple text like everything else you see when examining an airlock.  Webedits are funky though.

If this one is deemed more acceptable I can and will happily delete the other PR that was attempting to do this but worse.  