### PR TITLE
Makes player-controlled simplemobs not do attacks when on grab intent

### DIFF
--- a/code/modules/mob/living/simple_mob/on_click.dm
+++ b/code/modules/mob/living/simple_mob/on_click.dm
@@ -30,6 +30,8 @@
 		if(I_GRAB)
 			if(has_hands)
 				A.attack_hand(src)
+			else if(isliving(A) && src.client)
+				animal_nom(A)
 			else
 				attack_target(A)
 

--- a/code/modules/mob/living/simple_mob/simple_mob_vr.dm
+++ b/code/modules/mob/living/simple_mob/simple_mob_vr.dm
@@ -277,13 +277,6 @@
 		return MOVEMENT_FAILED //Mobs aren't that stupid, probably
 	return ..() // Procede as normal.
 
-//Grab = Nomf
-/mob/living/simple_mob/UnarmedAttack(var/atom/A, var/proximity)
-	. = ..()
-
-	if(a_intent == I_GRAB && isliving(A) && !has_hands)
-		animal_nom(A)
-
 // Riding
 /datum/riding/simple_mob
 	keytype = /obj/item/weapon/material/twohanded/riding_crop // Crack!


### PR DESCRIPTION
Makes it so that they don't attack and then attempt animal nom, just jumps directly to nom if possible.

Fixes #9380

Also gonna hijack this one to mark as Fixes #10245 because that was already implemented at some point and is tangentially related to other fixed issue.