### PR TITLE
Comments out color ranger helmets

### DIFF
--- a/code/modules/clothing/head/hardhat.dm
+++ b/code/modules/clothing/head/hardhat.dm
@@ -84,6 +84,9 @@
  * Ranger Hats
  */
 
+	//Missing onmob sprites.
+
+/*
 /obj/item/clothing/head/hardhat/ranger
 	var/hatcolor = "white"
 	name = "ranger helmet"
@@ -117,3 +120,4 @@
 
 /obj/item/clothing/head/hardhat/ranger/yellow
 	hatcolor = "yellow"
+*/


### PR DESCRIPTION
I've looked all over, but if they even ever had onmob sprites, I can't find those. Since I'm no spriter and without sprites hats are broken, gonna comment it out so that they don't show up in loadout.

Technically temporarily fixes #10747