### PR TITLE
Door Interact Tweaks

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -979,6 +979,7 @@ About the new airlock wires panel:
 	return
 
 /obj/machinery/door/airlock/AltClick(mob/user as mob)
+	. = ..()
 	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 	if(!Adjacent(user))
 		return
@@ -988,13 +989,13 @@ About the new airlock wires panel:
 		if(icon_state == "door_closed" && arePowerSystemsOn())
 			flick("door_deny", src)
 		playsound(src, knock_hammer_sound, 50, 0, 3)
-	else if(arePowerSystemsOn())
+	else if(arePowerSystemsOn() && user.a_intent == I_HELP)
 		src.visible_message("[user] presses the door bell on \the [src].", "\The [src]'s bell rings.")
 		src.add_fingerprint(user)
 		if(icon_state == "door_closed")
 			flick("door_deny", src)
 		playsound(src, knock_sound, 50, 0, 3)
-	else
+	else if(user.a_intent == I_HELP)
 		src.visible_message("[user] knocks on \the [src].", "Someone knocks on \the [src].")
 		src.add_fingerprint(user)
 		playsound(src, knock_unpowered_sound, 50, 0, 3)

--- a/code/game/objects/structures/simple_doors.dm
+++ b/code/game/objects/structures/simple_doors.dm
@@ -71,6 +71,7 @@
 	return TryToSwitchState(user)
 
 /obj/structure/simple_door/AltClick(mob/user as mob)
+	. = ..()
 	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 	if(!Adjacent(user))
 		return
@@ -78,7 +79,7 @@
 		src.visible_message("<span class='warning'>[user] hammers on \the [src]!</span>", "<span class='warning'>Someone hammers loudly on \the [src]!</span>")
 		src.add_fingerprint(user)
 		playsound(src, knock_hammer_sound, 50, 0, 3)
-	else
+	else if(user.a_intent == I_HELP)
 		src.visible_message("[user] knocks on \the [src].", "Someone knocks on \the [src].")
 		src.add_fingerprint(user)
 		playsound(src, knock_sound, 50, 0, 3)


### PR DESCRIPTION
A little update to #11594 after giving it some thought. My initial PR was a bit shortsighted, so I've made two changes;

1. Knocking now only occurs if you're on HELP intent. DISARM and GRAB cause nothing to happen. HARM is still hammering on doors.
2. This code no longer intercepts/prevents the "view tile contents in a tab" functionality, so you can grab stuff under closed doors without using the rightclick menu.

On the one hand I think it's kinda silly that anything on the same tile as a door is basically in a superposition where it can be grabbed from either side, *but* IMO doors should also be like rimworld and be held open by larger items rather than whatever you call the current behaviour. Smaller items (wrappers, bottles, cans, etc.) should be crushed or just launched to one side, larger ones should cause the door to ping back open after it tries to close, similar to how they won't close on mobs.

Not that I can be bothered to code anything like that right now. So this is kind of a stopgap and an "oops, I overlooked something" I guess.