### PR TITLE
More fixes/adjustments for BSH

### DIFF
--- a/code/modules/projectiles/guns/energy/bsharpoon_vr.dm
+++ b/code/modules/projectiles/guns/energy/bsharpoon_vr.dm
@@ -18,6 +18,7 @@
 	var/transforming = 0
 	var/failure_chance = 15 // This can become negative with part tiers above 3, which helps offset penalties
 	var/obj/item/weapon/stock_parts/scanning_module/scanmod
+	var/dropnoms_active = TRUE
 
 /obj/item/weapon/bluespace_harpoon/Initialize()
 	. = ..()
@@ -26,6 +27,8 @@
 
 /obj/item/weapon/bluespace_harpoon/examine(var/mob/user)
 	. = ..()
+	. += "It is currently in [mode ? "transmitting" : "recieving"] mode."
+	. += "Spatial rearrangement is [dropnoms_active ? "active" : "inactive"]."
 	if(Adjacent(user))
 		. += "It has [scanmod ? scanmod : "no scanner module"] installed."
 
@@ -120,7 +123,7 @@
 
 	var/mob/living/living_user = user
 	var/can_dropnom = TRUE
-	if(!istype(living_user))
+	if(!dropnoms_active || !istype(living_user))
 		can_dropnom = FALSE
 
 	if(mode)
@@ -138,9 +141,7 @@
 						belly_dest = pick(living_user.vore_organs)
 					if(belly_dest)
 						for(var/mob/living/prey in ToTurf)
-							if(prey == user)	//You can't eat yourself, silly!
-								continue
-							if(prey.can_be_drop_prey)
+							if(prey != user && prey.can_be_drop_prey)
 								prey.forceMove(belly_dest)
 								vore_happened = TRUE
 								to_chat(prey, "<span class='danger'>[living_user] materializes around you, as you end up in their [belly_dest]!</span>")
@@ -148,7 +149,7 @@
 				if(can_dropnom && !vore_happened && living_user.can_be_drop_prey)
 					var/mob/living/pred
 					for(var/mob/living/potential_pred in ToTurf)
-						if(potential_pred.can_be_drop_pred)
+						if(potential_pred != user && potential_pred.can_be_drop_pred)
 							pred = potential_pred
 					if(pred)
 						var/obj/belly/belly_dest
@@ -203,14 +204,23 @@
 	return chande_fire_mode(user)
 
 /obj/item/weapon/bluespace_harpoon/verb/chande_fire_mode(mob/user as mob)
-	set name = "Change fire mode"
+	set name = "Change Fire Mode"
 	set category = "Object"
-	set src in oview(1)
+	set src in range(0)
+
 	if(transforming) return
 	mode = !mode
 	transforming = 1
 	to_chat(user,"<span class = 'info'>You change \the [src]'s mode to [mode ? "transmiting" : "receiving"].</span>")
 	update_icon()
+
+/obj/item/weapon/bluespace_harpoon/verb/chande_dropnom_mode(mob/user as mob)
+	set name = "Toggle Spatial Rearrangement"
+	set category = "Object"
+	set src in range(0)
+
+	dropnoms_active = !dropnoms_active
+	to_chat(user,"<span class = 'info'>You switch \the [src]'s spatial rearrangement [dropnoms_active ? "on" : "off"]. (Telenoms [dropnoms_active ? "enabled" : "dsiabled"])</span>")
 
 /obj/item/weapon/bluespace_harpoon/update_icon()
 	if(transforming)


### PR DESCRIPTION
Fully fixes the self-swallowing thing if you had both drop-prey and drop-pred on (yes, it still happened).

Adds a new toggle for BSH that prevents the dropnoms from happening. Available in rightclick context menu. Dropnoms are enabled by default.

Also fixes regular mode switch missing from rightclick menu.