### PR TITLE
Makes messages for climbing up/down rafters a bit more obvious

### DIFF
--- a/code/modules/multiz/movement.dm
+++ b/code/modules/multiz/movement.dm
@@ -59,7 +59,7 @@
 			if(lattice)
 				var/pull_up_time = max(5 SECONDS + (src.movement_delay() * 10), 1)
 				to_chat(src, "<span class='notice'>You grab \the [lattice] and start pulling yourself upward...</span>")
-				destination.audible_message("<span class='notice'>You hear something climbing up \the [lattice].</span>", runemessage = "clank clang")
+				src.audible_message("<span class='notice'>[src] begins climbing up \the [lattice].</span>", runemessage = "clank clang")
 				if(do_after(src, pull_up_time))
 					to_chat(src, "<span class='notice'>You pull yourself up.</span>")
 				else
@@ -74,14 +74,14 @@
 				if(!destination?.Enter(src, old_dest))
 					to_chat(src, "<span class='notice'>There's something in the way up above in that direction, try another.</span>")
 					return 0
-				destination.audible_message("<span class='notice'>You hear something climbing up \the [catwalk].</span>", runemessage = "clank clang")
+				src.audible_message("<span class='notice'>[src] begins climbing up \the [lattice].</span>", runemessage = "clank clang")
 				if(do_after(src, pull_up_time))
 					to_chat(src, "<span class='notice'>You pull yourself up.</span>")
 				else
 					to_chat(src, "<span class='warning'>You gave up on pulling yourself up.</span>")
 					return 0
 
-			else if(ismob(src)) //VOREStation Edit Start. Are they a mob, and are they currently flying??
+			else if(isliving(src)) //VOREStation Edit Start. Are they a mob, and are they currently flying??
 				var/mob/living/H = src
 				if(H.flying)
 					if(H.incapacitated(INCAPACITATION_ALL))
@@ -90,7 +90,6 @@
 						return 0
 					var/fly_time = max(7 SECONDS + (H.movement_delay() * 10), 1) //So it's not too useful for combat. Could make this variable somehow, but that's down the road.
 					to_chat(src, "<span class='notice'>You begin to fly upwards...</span>")
-					destination.audible_message("<span class='notice'>You hear the flapping of wings.</span>", runemessage = "flap flap")
 					H.audible_message("<span class='notice'>[H] begins to flap \his wings, preparing to move upwards!</span>", runemessage = "flap flap")
 					if(do_after(H, fly_time) && H.flying)
 						to_chat(src, "<span class='notice'>You fly upwards.</span>")
@@ -111,6 +110,11 @@
 			return 0
 	if(!Move(destination))
 		return 0
+	if(isliving(src))
+		if(direction == UP)
+			src.audible_message("<span class='notice'>[src] moves up.</span>")
+		else if(direction == DOWN)
+			src.audible_message("<span class='notice'>[src] moves down.</span>")
 	return 1
 
 /mob/proc/can_overcome_gravity()


### PR DESCRIPTION
Adds a proper message for both when someone starts and ends climbing, that is visible to both those above and below. A single ambiguous 'you can hear something climbing' when you can actually SEE someone climbing was silly.