### PR TITLE
rad apes real

### DIFF
--- a/code/modules/clothing/spacesuits/rig/modules/specific/passive_protection.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/specific/passive_protection.dm
@@ -73,7 +73,7 @@
 
 /obj/item/rig_module/rad_shield/advanced
 	name = "advanced radiation absorption device"
-	desc = "The acronym of this device - R.A.D. - and its full name both convey the application of the module. It has additional quality notices \
+	desc = "The acronym of this device - R.A.D. - and its full name both convey the application of the module. It has a changelog inscribed \
 	on the underside of the casing."
 	use_power_cost = 5
 	active_power_cost = 5

--- a/code/modules/research/mechfab_designs.dm
+++ b/code/modules/research/mechfab_designs.dm
@@ -1041,6 +1041,30 @@
 	materials = list(MAT_DURASTEEL = 5000, MAT_GRAPHITE = 3000, MAT_MORPHIUM = 1500, MAT_OSMIUM = 1500, MAT_PHORON = 1750, MAT_VERDANTIUM = 3000, MAT_SUPERMATTER = 2000)
 	build_path = /obj/item/rig_module/teleporter
 
+/datum/design/item/mechfab/rigsuit/radshield
+	name = "hardsuit radiation absorption device"
+	desc = "A miniaturized radiation absorption array, for use in hardsuits and providing full radiation protection."
+	id = "rig_component_radshield"
+	req_tech = list(TECH_MATERIAL = 5, TECH_ENGINEERING = 3, TECH_MAGNET = 4, TECH_POWER = 3, TECH_BLUESPACE = 4)
+	materials = list(MAT_STEEL = 8000, MAT_GRAPHITE = 3000, MAT_OSMIUM = 1500, MAT_PHORON = 2250, MAT_SILVER = 1500, MAT_GOLD = 1500)
+	build_path = /obj/item/rig_module/rad_shield
+
+/datum/design/item/mechfab/rigsuit/radshield_adv
+	name = "hardsuit advanced radiation absorption device"
+	desc = "An optimized, miniaturized radiation absorption array, for use in hardsuits and providing full radiation protection. Reduced power draw."
+	id = "rig_component_radshield_adv"
+	req_tech = list(TECH_MATERIAL = 7, TECH_ENGINEERING = 5, TECH_MAGNET = 5, TECH_POWER = 6, TECH_BLUESPACE = 4)
+	materials = list(MAT_PLASTEEL = 8000, MAT_GRAPHITE = 4000, MAT_OSMIUM = 2000, MAT_PHORON = 3250, MAT_SILVER = 2250, MAT_GOLD = 2250)
+	build_path = /obj/item/rig_module/rad_shield/advanced
+
+/datum/design/item/mechfab/rigsuit/atmosshield
+	name = "hardsuit atmospheric protection enhancement suite"
+	desc = "An advanced atmospheric protection suite, providing protection against both pressure and heat. At the cost of concerningly high power draw."
+	id = "rig_component_atmosshield"
+	req_tech = list(TECH_MATERIAL = 7, TECH_ENGINEERING = 5, TECH_MAGNET = 5, TECH_POWER = 6, TECH_BLUESPACE = 4)
+	materials = list(MAT_PLASTEEL = 8000, MAT_DURASTEEL = 4000, MAT_GRAPHITE = 8000, MAT_OSMIUM = 6000, MAT_PHORON = 6000, MAT_SILVER = 4000, MAT_GOLD = 4000)
+	build_path = /obj/item/rig_module/atmos_shield
+
 /datum/design/item/mechfab/uav/basic
 	name = "UAV - Recon Skimmer"
 	id = "recon_skimmer"


### PR DESCRIPTION
makes the RAD, ARAD, and APES modules printable. if you don't know what they are, here's the tl;dr:
RAD - full radiation protection, 250 power drawn from suit cell per tick
ARAD - see RAD, but power draw reduced to 50 per tick
APES - full fire/pressure protection, 250 power from suit cell per tick

radiation shield module:

	req_tech = list(TECH_MATERIAL = 5, TECH_ENGINEERING = 3, TECH_MAGNET = 4, TECH_POWER = 3, TECH_BLUESPACE = 4)
	materials = list(MAT_STEEL = 8000, MAT_GRAPHITE = 3000, MAT_OSMIUM = 1500, MAT_PHORON = 2250, MAT_SILVER = 1500, MAT_GOLD = 1500)

advanced radiation shield module:

	req_tech = list(TECH_MATERIAL = 7, TECH_ENGINEERING = 5, TECH_MAGNET = 5, TECH_POWER = 6, TECH_BLUESPACE = 4)
	materials = list(MAT_PLASTEEL = 8000, MAT_GRAPHITE = 4000, MAT_OSMIUM = 2000, MAT_PHORON = 3250, MAT_SILVER = 2250, MAT_GOLD = 2250)

atmos shield module:

	req_tech = list(TECH_MATERIAL = 7, TECH_ENGINEERING = 5, TECH_MAGNET = 5, TECH_POWER = 6, TECH_BLUESPACE = 4)
	materials = list(MAT_PLASTEEL = 8000, MAT_DURASTEEL = 4000, MAT_GRAPHITE = 8000, MAT_OSMIUM = 6000, MAT_PHORON = 6000, MAT_SILVER = 4000, MAT_GOLD = 4000)