### PR TITLE
makes large autoinjectors cheaper

### DIFF
--- a/code/datums/autolathe/medical_vr.dm
+++ b/code/datums/autolathe/medical_vr.dm
@@ -5,4 +5,4 @@
 /datum/category_item/autolathe/medical/autoinjector/biginjector
 	name = "empty large autoinjector"
 	path =/obj/item/weapon/reagent_containers/hypospray/autoinjector/biginjector/empty
-	resources = list(MAT_PLASTIC = 2000)
+	resources = list(MAT_PLASTIC = 500)

--- a/code/datums/autolathe/medical_vr.dm
+++ b/code/datums/autolathe/medical_vr.dm
@@ -1,6 +1,7 @@
 /datum/category_item/autolathe/medical/autoinjector
 	name = "empty autoinjector"
 	path =/obj/item/weapon/reagent_containers/hypospray/autoinjector/empty
+	resources = list(MAT_PLASTIC = 10) //for recycling purposes mostly
 
 /datum/category_item/autolathe/medical/autoinjector/biginjector
 	name = "empty large autoinjector"


### PR DESCRIPTION
i forgot that upgrading the autolathe doesn't make it require less mats per thingie printed
which made one large autoinjector cost one whole plastic sheet, even with upgrades
which, really, is way too much for an autoinjector, given how a regular one costs literally nothing*

*edit: now costs 10 plastic after suggestion 
