### PR TITLE
Removes the announcement for main pred and morph spawns

### DIFF
--- a/code/game/objects/structures/ghost_pods/event_vr.dm
+++ b/code/game/objects/structures/ghost_pods/event_vr.dm
@@ -80,11 +80,6 @@
 	to_chat(M, "<span class='warning'>You may be a spooky space monster, but your role is to facilitate spooky space monster roleplay, not to fight the station and kill people. You can of course eat and/or digest people as you like if OOC prefs align, but this should be done as part of roleplay. If you intend to fight the station and kill people and such, you need permission from the staff team. GENERALLY, this role should avoid well populated areas. You’re a weird spooky space monster, so the bar is probably not where you’d want to go if you intend to survive. Of course, you’re welcome to try to make friends and roleplay how you will in this regard, but something to keep in mind.</span>")
 	newPred.ckey = M.ckey
 	newPred.visible_message("<span class='warning'>[newPred] emerges from somewhere!</span>")
-
-	if(prob(announce_prob))
-		spawn(2 MINUTES)
-			command_announcement.Announce("Unexpected biosignature detected in the maintenance tunnels of [station_name()].", "Lifesign Alert")
-
 	qdel(src)
 
 /obj/structure/ghost_pod/ghost_activated/maintpred/no_announce
@@ -119,11 +114,6 @@
 
 	newMorph.ckey = M.ckey
 	newMorph.visible_message("<span class='warning'>A morph appears to crawl out of somewhere.</span>")
-
-	if(prob(announce_prob))
-		spawn(2 MINUTES)
-			command_announcement.Announce("Unexpected biosignature detected in the maintenance tunnels of [station_name()].", "Lifesign Alert")
-
 	qdel(src)
 
 /obj/structure/ghost_pod/ghost_activated/morphspawn/no_announce


### PR DESCRIPTION
The announcement only really encourages people to go hunting for it, and usually not in the good way, which can in general ruin the surprise that these roles can employ.

So! I think it would be better if we just didn't announce them publicly, since they aren't a thing we ever want people to go and respond to mechanically, and, I think that announcements like these ought to be reserved for things we want people responding to.