### PR TITLE
Fixes runtime spam caused by altclicking tiles

### DIFF
--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -310,7 +310,7 @@
 
 /turf/proc/try_graffiti(var/mob/vandal, var/obj/item/tool)
 
-	if(!tool.sharp || !can_engrave())
+	if(!tool || !tool.sharp || !can_engrave())
 		return FALSE
 
 	if(jobban_isbanned(vandal, "Graffiti"))


### PR DESCRIPTION
Fixes every unarmed altclick on turfs runtiming because nothing bothered to check whether the person was actually holding anything to engrave with.