### PR TITLE
Makes deconstructing and reconstructing SD shields not lose unique power consumption

### DIFF
--- a/maps/stellardelight/stellar_delight3.dmm
+++ b/maps/stellardelight/stellar_delight3.dmm
@@ -9856,9 +9856,7 @@
 /obj/machinery/computer/ship/navigation/telescreen{
 	pixel_x = 32
 	},
-/obj/machinery/power/shield_generator/charged{
-	power_coefficient = 0.33
-	},
+/obj/machinery/power/shield_generator/ship_optimized/charged,
 /obj/structure/cable,
 /turf/simulated/floor,
 /area/stellardelight/deck2/central)

--- a/maps/stellardelight/stellar_delight_things.dm
+++ b/maps/stellardelight/stellar_delight_things.dm
@@ -174,3 +174,17 @@
 
 /obj/machinery/power/quantumpad/scioutpost
 
+
+
+/obj/machinery/power/shield_generator/ship_optimized
+	power_coefficient = 0.33
+	circuit = /obj/item/weapon/circuitboard/shield_generator/ship_optimized
+
+// Starts fully charged
+/obj/machinery/power/shield_generator/ship_optimized/charged/Initialize()
+	. = ..()
+	current_energy = max_energy
+
+/obj/item/weapon/circuitboard/shield_generator/ship_optimized
+	name = T_BOARD("ship-optimized shield generator")
+	build_path = /obj/machinery/power/shield_generator/ship_optimized


### PR DESCRIPTION
Fixes #12057

Makes SD's shield generator a special subtype with unique board that is not obtainable any other way (other than admin spawning). Kind of silly that it's 'intentional' to lose all power when one accidental crowbarring with panel open can result in permanent loss of something rather important. So, special subtype of shield generator!