### PR TITLE
Adds Temperature Adaptations to Xenochimera Trait List along with Autohiss.

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/xenochimera_trait_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/xenochimera_trait_vr.dm
@@ -1,7 +1,10 @@
 /*
 **	For now, these are just neutral traits for Xenochimera only to take.
-**	These are only traits that they should reasonably be able to evolve to acquire themselves.
-**	I won't add the resistances though because those are kinda lame for a 'chimera to take!
+**	Traits defined as custom_only = FALSE in neutral.dm will be available for Xenochimera to take as well.
+**	As such, be careful not to duplicate the traits, and only add dupes where necessary.
+**	IE: Heat/Cold Adapt and autohisses are added to Xenochimera because they reasonably could have evolved it, along with custom species.
+**	However, if custom_only = FALSE is set, then any species including things like humans can take it. A little silly.
+**	Therefore, use this file only for Xenochimera traits that you want to keep custom + Xenochim only.
 */
 /datum/trait/positive/weaver/xenochimera
 	sort = TRAIT_SORT_SPECIES
@@ -58,3 +61,56 @@
 	cost = 0
 	category = 0
 	custom_only = FALSE
+	
+/datum/trait/neutral/coldadapt/xenochimera
+	sort = TRAIT_SORT_SPECIES
+	allowed_species = list(SPECIES_XENOCHIMERA)
+	name = "Xenochimera: Temp. Adapted, Cold"
+	desc = "You have adapted to withstand much colder temperatures than other species, and can even be comfortable in extremely cold environments. You are also more vulnerable to hot environments, and have a lower body temperature as a consequence of these adaptations, thanks to your evolutionary efforts."
+	cost = 0
+	category = 0
+	can_take = ORGANICS // (Not sure if this is needed for Xenochimera-specific sub-version.)
+	custom_only = FALSE
+	excludes = list(/datum/trait/neutral/hotadapt, /datum/trait/neutral/hotadapt/xenochimera)
+
+/datum/trait/neutral/hotadapt/xenochimera
+	sort = TRAIT_SORT_SPECIES
+	allowed_species = list(SPECIES_XENOCHIMERA)
+	name = "Xenochimera: Temp. Adapted, Heat"
+	desc = "You have adapted to withstand much hotter temperatures than other species, and can even be comfortable in extremely hot environments. You are also more vulnerable to cold environments, and have a higher body temperature as a consequence of these adaptations, thanks to your evolutionary efforts."
+	cost = 0
+	category = 0
+	can_take = ORGANICS // negates the need for suit coolers entirely for synths, so no. (Not sure if this is needed for Xenochimera-specific sub-version.)
+	custom_only = FALSE
+	excludes = list(/datum/trait/neutral/coldadapt, /datum/trait/neutral/coldadapt/xenochimera)
+
+/datum/trait/neutral/autohiss_unathi/xenochimera
+	sort = TRAIT_SORT_SPECIES
+	allowed_species = list(SPECIES_XENOCHIMERA)
+	name = "Xenochimera: Autohiss (Unathi)"
+	desc = "You roll your S's and x's"
+	cost = 0
+	custom_only = FALSE
+	var_changes = list(
+	autohiss_basic_map = list(
+			"s" = list("ss", "sss", "ssss")
+		),
+	autohiss_extra_map = list(
+			"x" = list("ks", "kss", "ksss")
+		),
+	autohiss_exempt = list("Sinta'unathi"))
+	excludes = list(/datum/trait/neutral/autohiss_tajaran)
+
+/datum/trait/neutral/autohiss_tajaran/xenochimera
+	sort = TRAIT_SORT_SPECIES
+	allowed_species = list(SPECIES_XENOCHIMERA)
+	name = "Xenochimera: Autohiss (Tajaran)"
+	desc = "You roll your R's."
+	cost = 0
+	custom_only = FALSE
+	var_changes = list(
+	autohiss_basic_map = list(
+			"r" = list("rr", "rrr", "rrrr")
+		),
+	autohiss_exempt = list("Siik"))
+	excludes = list(/datum/trait/neutral/autohiss_unathi)


### PR DESCRIPTION
Ran these by Scree (Creator of Xenochimera) and he said these are fairly reasonable adaptations.

They're neutral traits available to custom species, and given that Xenochimera are also able to pretty much mix and match a lot of stuff based on what they've eaten/evolved, this will allow greater roleplay/adaptations to occur - for instance, a xenochimera that is well-suited to the warmth of the desert is going to struggle in cold areas, and vice versa.

(It's conceivable that a Xenochimera might eat a wolf, and adapt/evolve a super-thick coat of fur suited for winter planets.)

Upstream port of https://github.com/CHOMPStation2/CHOMPStation2/pull/2948
