### PR TITLE
Do not merge. Base ideas for explo rework.

### DIFF
--- a/code/game/jobs/job/exploration_vr.dm
+++ b/code/game/jobs/job/exploration_vr.dm
@@ -92,8 +92,8 @@
 	departments = list(DEPARTMENT_PLANET)
 	department_flag = MEDSCI
 	faction = "Station"
-	total_positions = 3
-	spawn_positions = 3
+	total_positions = 2
+	spawn_positions = 2
 	supervisors = "the Pathfinder and the Head of Personnel"
 	selection_color = "#999440"
 	economic_modifier = 6
@@ -102,10 +102,8 @@
 	minimal_access = list(access_explorer, access_external_airlocks, access_eva)
 	outfit_type = /decl/hierarchy/outfit/job/explorer2
 	job_description = "An Explorer searches for interesting things, and returns them to the station."
-	alt_titles = list("Surveyor" = /datum/alt_title/surveyor, "Offsite Scout" = /datum/alt_title/offsite_scout)
+	alt_titles = list( "Offsite Scout" = /datum/alt_title/offsite_scout)
 
-/datum/alt_title/surveyor
-	title = "Surveyor"
 
 /datum/alt_title/offsite_scout
 	title = "Offsite Scout"
@@ -123,7 +121,7 @@
 	selection_color = "#999440"
 	economic_modifier = 6
 	minimal_player_age = 3
-	pto_type = PTO_EXPLORATION
+	pto_type = PTO_MEDICAL
 	access = list(access_medical, access_medical_equip, access_morgue, access_surgery, access_chemistry, access_eva, access_maint_tunnels, access_external_airlocks, access_pilot)
 	minimal_access = list(access_medical, access_medical_equip, access_morgue, access_pilot)
 	outfit_type = /decl/hierarchy/outfit/job/medical/sar
@@ -135,3 +133,46 @@
 
 /datum/alt_title/offsite_medic
 	title = "Offsite Medic"
+
+
+///explo offsite rework
+/datum/job/Archaeologist
+	title = "Archaeologist"
+	departments = list(DEPARTMENT_PLANET, DEPARTMENT_RESEARCH)
+	department_flag = MEDSCI
+	faction = "Station"
+	supervisors = "the Pathfinder and the Research Director"
+	total_positions = 2
+	spawn_positions = 2
+	pto_type = PTO_SCIENCE
+	access = list(access_tox, access_tox_storage, access_research, access_xenobiology, access_xenoarch, access_xenobotany)
+	minimal_access = list(access_tox, access_tox_storage, access_research, access_xenoarch,access_eva, access_maint_tunnels, access_external_airlocks,)
+	minimal_player_age = 14
+
+/datum/job/offsite_engineer
+	title = "Offsite Engineer"
+	flag = ENGINEER
+	departments = list(DEPARTMENT_ENGINEERING, DEPARTMENT_PLANET)
+	department_flag = ENGSEC
+	faction = "Station"
+	total_positions = 2
+	spawn_positions = 2
+	supervisors = "the Chief Engineer and the Pathfinder"
+	selection_color = "#5B4D20"
+	economic_modifier = 5
+	access = list(access_eva, access_engine, access_engine_equip, access_tech_storage, access_maint_tunnels, access_external_airlocks, access_construction, access_atmospherics)
+	minimal_access = list(access_explorer, access_external_airlocks,access_eva, access_engine, access_engine_equip, access_tech_storage, access_maint_tunnels, access_external_airlocks, access_construction, access_explorer, access_external_airlocks, access_eva)
+
+/datum/job/Surveyor
+	title = "Surveyor"
+	flag= MINER
+	departments = list(DEPARTMENT_CARGO,DEPARTMENT_PLANET)
+	department_flag = CIVILIAN
+	faction = "Station"
+	total_positions = 2
+	spawn_positions = 2
+	supervisors = "the Quartermaster, the Pathfinder, and the Head of Personnel"
+	selection_color = "#7a4f33"
+	economic_modifier = 5
+	access = list(access_maint_tunnels, access_mailsorting, access_cargo, access_cargo_bot, access_mining, access_mining_station,access_explorer, access_external_airlocks, access_eva)
+	minimal_access = list(access_mining, access_mining_station, access_mailsorting,access_explorer, access_external_airlocks, access_eva)


### PR DESCRIPTION
a small rework to explo to hopefully get the ball roleing with this. Please don't merge this is a bit too fiddly for me to be trusted with and it's gonna need a lot of hand holding by other devs to get this done.  I started talking about the idea in explo chat but it's already burried on discord too

with recent changes to pilots and the SD explo is a bit lost on what it is. There is also a problem of a lack of knowing who wants to take part and timeing issues. So I've added feild options for each department. Two slots so one person doesn't hog the slot every shift.

no changes to pilot. They are already ment to be off site service

explo change from 3 to 2.  suveryor alt title removed. Would put them with sec as the job is a little too combaty, however that gives them the tools to gatekeep events

offsite engineer. Engineers but off site. Report to the CE and Pathfinder. In the spirit of FMs have engineering access and should be the go to people for building complicated things.

Archaeologist- 2 slots. The scienest job. I expect this one to be more RP heavy, a mix of xenoArchaeologist and explorer. No robotics access. Currently R and D access, I'd like to see if this is a player base problem or a few rotten egg problem. They have access to xenobio and xenobotnay too. Lotta ways to RP science in the field. A few RDs have just been leaveing R and D open for everyone lately, so I don't see it being too much of an issue giving them back R and D access

Survyor- 2 slots. The cargo job. I think theese should be a lot more closer to miner than cargo tech. With a focus of salvageing and scouting for the real mining.  Again, cargo have been very open to ordering all kinds of stuff lately. I don't think it's still a problem like it was in early explo first shift. Plus if they do order all the things like many miners do, they can still go mine.


I think this is good because it helps to suggest ways to RP explo. I think it should suggest that you've to do more than loot and unga bunga, as well as giving onstation job options on low pops shifts. I think explorer is a little vauge that doesn't help. Archaeologist will make people think of indiana jones, collecting odd anomliles and stuff. Survyor makes it sound like your job is to go find important things and tell people who much they are. I'm couldn't think of a better name for offsite engineer, and I doupt calling the job Scree would go down well. 

Also haveing the department split up over every department should help put focus on events are not just for you. You are ment to be a mix of everydepartment now go act like it. It gives people like scree who want to do off site engineering but miss their chance to join due to doing engine set up a flag to pathfinders to go, hey I want to join don't just leave.
