### PR TITLE
Eyeglow Toggle

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/station_special_abilities_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_special_abilities_vr.dm
@@ -996,4 +996,10 @@
 	if(new_silk_color)
 		species.silk_color = new_silk_color
 
+/mob/living/carbon/human/proc/toggle_eye_glow()
+	set name = "Toggle Eye Glowing"
+	set category = "Abilities"
 
+	species.has_glowing_eyes = !species.has_glowing_eyes
+	update_eyes()
+	to_chat(src, "Your eyes [species.has_glowing_eyes ? "are now" : "are no longer"] glowing.")

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
@@ -155,6 +155,10 @@
 	custom_only = FALSE
 	var_changes = list("has_glowing_eyes" = 1)
 
+/datum/trait/neutral/glowing_eyes/apply(var/datum/species/S,var/mob/living/carbon/human/H)
+	..(S,H)
+	H.verbs |= /mob/living/carbon/human/proc/toggle_eye_glow
+
 /datum/trait/neutral/glowing_body
 	name = "Glowing Body"
 	desc = "Your body glows about as much as a PDA light! Settable color and toggle in Abilities tab ingame."


### PR DESCRIPTION
Inspired by some conversation in cadet-academy. Human-subtype carbons (standard player mobs, but not player-controlled simplemobs) can now toggle their eyeglow on and off with a button on the abilities tab. Should only be available if you have the glowing eyes trait.

Lightly tested, seems to work OK.