### PR TITLE
Let anyone remove their tail

### DIFF
--- a/code/modules/mob/new_player/sprite_accessories_tail.dm
+++ b/code/modules/mob/new_player/sprite_accessories_tail.dm
@@ -41,7 +41,7 @@
 	icon = null
 	icon_state = null
 
-	species_allowed = list(SPECIES_TAJ, SPECIES_UNATHI, SPECIES_TESHARI, SPECIES_EVENT1, SPECIES_EVENT2, SPECIES_EVENT3)
+//	species_allowed = list(SPECIES_TAJ, SPECIES_UNATHI, SPECIES_TESHARI, SPECIES_EVENT1, SPECIES_EVENT2, SPECIES_EVENT3)	//VOREStation Removal - Why. Let anyone remove their tails
 
 /datum/sprite_accessory/tail/squirrel_orange
 	name = "squirel, orange"


### PR DESCRIPTION
Removes the species restriction on the 'hide species-sprite tail' option. 

I don't really understand WHY there's a restriction on it, but! This should remove that.