### PR TITLE
Moves pilot to Civilian files and makes it earn Civilian PTO

### DIFF
--- a/code/game/jobs/job/civilian_vr.dm
+++ b/code/game/jobs/job/civilian_vr.dm
@@ -196,6 +196,38 @@
 	title = "Monk"
 
 
+//////////////////////////////////
+//		      	Pilot
+//////////////////////////////////
+
+/datum/job/pilot
+	title = "Pilot"
+	flag = PILOT
+	departments = list(DEPARTMENT_CIVILIAN)
+	department_flag = CIVILIAN
+	faction = "Station"
+	total_positions = 5
+	spawn_positions = 5
+	supervisors = "the Head of Personnel"
+	selection_color = "#515151"
+	economic_modifier = 5
+	minimal_player_age = 3
+	pto_type = PTO_CIVILIAN
+	access = list(access_pilot)
+	minimal_access = list(access_pilot)
+	outfit_type = /decl/hierarchy/outfit/job/pilot
+	job_description = "A Pilot flies the various shuttles in the Virgo-Erigone System."
+	alt_titles = list("Co-Pilot" = /datum/alt_title/co_pilot, "Navigator" = /datum/alt_title/navigator, "Helmsman" = /datum/alt_title/helmsman)
+
+/datum/alt_title/co_pilot
+	title = "Co-Pilot"
+	title_blurb = "A Co-Pilot is there primarily to assist main pilot as well as learn from them"
+
+/datum/alt_title/navigator
+	title = "Navigator"
+
+/datum/alt_title/helmsman
+	title = "Helmsman"
 
 //////////////////////////////////
 //			Entertainer

--- a/code/game/jobs/job/exploration_vr.dm
+++ b/code/game/jobs/job/exploration_vr.dm
@@ -55,37 +55,6 @@
 /datum/alt_title/exploration_manager
 	title = "Exploration Manager"
 
-
-/datum/job/pilot
-	title = "Pilot"
-	flag = PILOT
-	departments = list(DEPARTMENT_CIVILIAN)
-	department_flag = CIVILIAN
-	faction = "Station"
-	total_positions = 5
-	spawn_positions = 5
-	supervisors = "the Head of Personnel"
-	selection_color = "#515151"
-	economic_modifier = 5
-	minimal_player_age = 3
-	pto_type = PTO_EXPLORATION
-	access = list(access_pilot)
-	minimal_access = list(access_pilot)
-	outfit_type = /decl/hierarchy/outfit/job/pilot
-	job_description = "A Pilot flies the various shuttles in the Virgo-Erigone System."
-	alt_titles = list("Co-Pilot" = /datum/alt_title/co_pilot, "Navigator" = /datum/alt_title/navigator, "Helmsman" = /datum/alt_title/helmsman)
-
-/datum/alt_title/co_pilot
-	title = "Co-Pilot"
-	title_blurb = "A Co-Pilot is there primarily to assist main pilot as well as learn from them"
-
-/datum/alt_title/navigator
-	title = "Navigator"
-
-/datum/alt_title/helmsman
-	title = "Helmsman"
-
-
 /datum/job/explorer
 	title = "Explorer"
 	flag = EXPLORER


### PR DESCRIPTION
Everything about pilots except PTO has already been removed from exploration. Departments, heads, etc are all now treating pilot as if its entirely civilian job. As a result it earning exploration PTO is kinda weird, especially with it contributing to depthours of exploration and unlocking of pathfinder who is not actually in charge of the pilots. This PR moves pilot job code to civilian files (mostly for posterity) and changes the earned PTO type to be civilian.