### PR TITLE
Startreader Stunlocks Begone

### DIFF
--- a/code/modules/mob/living/simple_mob/subtypes/animal/alien animals/startreader.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/alien animals/startreader.dm
@@ -109,12 +109,11 @@
 	destructive = TRUE
 	violent_breakthrough = TRUE
 
-/mob/living/simple_mob/vore/alienanimals/startreader/apply_melee_effects(var/atom/A)
-	if(weakened) //Don't stun people while they're already stunned! That's SILLY!
+/mob/living/simple_mob/vore/alienanimals/startreader/apply_melee_effects(mob/living/L)
+	if(L.weakened) //Don't stun people while they're already stunned! That's SILLY!
 		return
 	if(prob(15))
-		var/mob/living/L = A
-		if(isliving(A))
+		if(isliving(L))
 			visible_message("<span class='danger'>\The [src] trips \the [L]!</span>!")
 			L.weakened += rand(1,10)
 


### PR DESCRIPTION
Fixes Startreaders checking *their own* weakened state when attacking, meaning every attack carried a 15% chance to stun even when the target was already stunned.

Tested in a dummy/mannequin in the minitest map. Couldn't inflict an additional stun whilst they were already weakened.

Should fix #12139.