### PR TITLE
Minor food tweaks

### DIFF
--- a/code/modules/food/food/snacks.dm
+++ b/code/modules/food/food/snacks.dm
@@ -7,6 +7,7 @@
 	center_of_mass = list("x"=16, "y"=16)
 	w_class = ITEMSIZE_SMALL
 	force = 0
+	volume = 80
 
 	var/bitesize = 1
 	var/bitecount = 0

--- a/code/modules/reagents/reactions/instant/food.dm
+++ b/code/modules/reagents/reactions/instant/food.dm
@@ -125,6 +125,7 @@
 	id = "meatball"
 	result = null
 	required_reagents = list("protein" = 3, "flour" = 5)
+	catalysts = list("enzyme" = 5)
 	result_amount = 3
 
 /decl/chemical_reaction/instant/food/meatball/on_reaction(var/datum/reagents/holder, var/created_volume)


### PR DESCRIPTION
Increases food item reagent volume to 80 (up from 50). Mostly to account for larger food items having a TON of reagents in them that don't fit by time you reach final step.

Makes meatball reaction require 5 units enzyme as a catalyst to prevent meatballs forming out of cooking recipies that happen to contain both flour and meat.