### PR TITLE
[station] tag for paperwork

### DIFF
--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -324,6 +324,7 @@
 	t = replacetext(t, "\[/u\]", "</U>")
 	t = replacetext(t, "\[time\]", "[stationtime2text()]")
 	t = replacetext(t, "\[date\]", "[stationdate2text()]")
+	t = replacetext(t, "\[station\]", "[station_name()]")
 	t = replacetext(t, "\[large\]", "<font size=\"4\">")
 	t = replacetext(t, "\[/large\]", "</font>")
 	if(findtext(t, "\[sign\]"))


### PR DESCRIPTION
By request, adds a [station] tag for paperwork that pulls the current full map name.

![image](https://user-images.githubusercontent.com/49700375/152468335-0496eba9-2fb0-4d2a-8ddc-43d8412624fb.png)