### PR TITLE
mining vendor 1000 thaler reward

### DIFF
--- a/code/modules/mining/ore_redemption_machine/equipment_vendor.dm
+++ b/code/modules/mining/ore_redemption_machine/equipment_vendor.dm
@@ -167,6 +167,7 @@
 		EQUIPMENT("Plush Toy",					/obj/random/plushie,												300),
 		EQUIPMENT("Soap",						/obj/item/weapon/soap/nanotrasen,									200),
 		EQUIPMENT("Thalers - 100",				/obj/item/weapon/spacecash/c100,									1000),
+		EQUIPMENT("Thalers - 1000",				/obj/item/weapon/spacecash/c1000,									10000),
 		EQUIPMENT("Umbrella",					/obj/item/weapon/melee/umbrella/random,								200),
 		EQUIPMENT("Whiskey",					/obj/item/weapon/reagent_containers/food/drinks/bottle/whiskey,		125),
 	)


### PR DESCRIPTION
- adds a bundle of 1000 thalers for 10,000 points in the mining vendor (since 100 thalers is 1000 points)

because i don't feel like getting carpal tunnel syndrome from converting points to cash after large hauls