### PR TITLE
Adds extra advice to Flavor Text popup

### DIFF
--- a/code/modules/client/preference_setup/general/06_flavor.dm
+++ b/code/modules/client/preference_setup/general/06_flavor.dm
@@ -88,7 +88,8 @@
 /datum/category_item/player_setup_item/general/flavor/proc/SetFlavorText(mob/user)
 	var/HTML = "<body>"
 	HTML += "<tt><center>"
-	HTML += "<b>Set Flavour Text</b> <hr />"
+	HTML += "<b>Set Flavor Text</b> <hr />"
+	HTML += "Note: This is not *literal* flavor of your character. This is visual description of what they look like. <hr />"
 	HTML += "<br></center>"
 	HTML += "<a href='?src=\ref[src];flavor_text=general'>General:</a> "
 	HTML += TextPreview(pref.flavor_texts["general"])


### PR DESCRIPTION
Since we are getting a lot of new players lately who do not read wiki guide to how to make character and take the Flavor Text way too literally.