### PR TITLE
Speeds up the initial NIF calibration timer.

### DIFF
--- a/code/modules/nifsoft/nif.dm
+++ b/code/modules/nifsoft/nif.dm
@@ -276,7 +276,7 @@ You can also set the stat of a NIF to NIF_TEMPFAIL without any issues to disable
 			install_done = world.time + 1 MINUTE
 			notify("Welcome back, [owner]! Performing quick-calibration...")
 		else if(!owner)
-			install_done = world.time + 35 MINUTES
+			install_done = world.time + 5 MINUTES
 			notify("Adapting to new user...")
 			sleep(5 SECONDS)
 			notify("Adjoining optic [human.isSynthetic() ? "interface" : "nerve"], please be patient.",TRUE)
@@ -286,7 +286,7 @@ You can also set the stat of a NIF to NIF_TEMPFAIL without any issues to disable
 			stat = NIF_TEMPFAIL
 			return FALSE
 
-	var/percent_done = (world.time - (install_done - (35 MINUTES))) / (35 MINUTES)
+	var/percent_done = (world.time - (install_done - (5 MINUTES))) / (5 MINUTES)
 
 	if(human.client)
 		human.client.screen.Add(global_hud.whitense) //This is the camera static


### PR DESCRIPTION
**About The Pull Request**

Lowers the NIF calibration timer from 35 minutes, to 5 minutes.

**Why It's Good For The Game**

I view this as more of a quality of life change then any kind of balance change, because I kept making new characters only to feel like I really didn't want to get a NIF for them because it sucks up so much of a given shift in that post-surgery state. Once you have one is it really easy to keep it healthy, and given that they are mostly just used for soulcatcher fun or other bits of creative flavor I really don't see why it should have to be so painful to acquire it. This should be enough time to give the same general feeling, but without dragging it out so long that it becomes really discouraging. There is also an exploit/oversight you can use to bypass most of the time already, and this helps stop me from getting into trouble by using it after I tired of installing it for like the 6th time already. Talked with a handful of people, and they all seemed to agree with me. So uh. Just waiting to see what the maintainers think of my logic here. It seemed like just getting people from science to make it, and people from medical to install it are the parts that can actually add RP to the shift, and they are both preserved here.