### PR TITLE
Allergy Rebuff

### DIFF
--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -54,7 +54,7 @@
 	var/taste_sensitivity = TASTE_NORMAL							// How sensitive the species is to minute tastes.
 	var/allergens = null									// Things that will make this species very sick
 	var/allergen_reaction = AG_TOX_DMG|AG_OXY_DMG|AG_EMOTE|AG_PAIN|AG_WEAKEN		// What type of reactions will you have? These the 'main' options and are intended to approximate anaphylactic shock at high doses.
-	var/allergen_damage_severity = 1.2							// How bad are reactions to the allergen? Touch with extreme caution.
+	var/allergen_damage_severity = 3.6							// How bad are reactions to the allergen? Touch with extreme caution.
 	var/allergen_disable_severity = 3							// Whilst this determines how long nonlethal effects last and how common emotes are.
 
 	var/min_age = 17

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
@@ -248,10 +248,17 @@
 
 /datum/trait/neutral/allergen_reduced_effect
 	name = "Reduced Allergen Reaction"
-	desc = "This trait halves the lethality of allergen reactions. If you don't have any allergens set, it does nothing. It does not apply to nonlethal reactions or special reactions (such as unathi drowsiness from sugars)."
+	desc = "This trait drastically reduces the lethality of allergen reactions. If you don't have any allergens set, it does nothing. It does not apply to nonlethal reactions or special reactions (such as unathi drowsiness from sugars)."
 	cost = 0
 	custom_only = FALSE
 	var_changes = list("allergen_damage_severity" = 1.2)
+
+/datum/trait/neutral/allergen_increased_effect
+	name = "Increased Allergen Reaction"
+	desc = "This trait drastically increases the lethality of allergen reactions. If you don't have any allergens set, it does nothing. It does not apply to nonlethal reactions or special reactions (such as unathi drowsiness from sugars)."
+	cost = 0
+	custom_only = FALSE
+	var_changes = list("allergen_damage_severity" = 7.2)
 
 // Spicy Food Traits, from negative to positive.
 /datum/trait/neutral/spice_intolerance_extreme

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
@@ -251,7 +251,7 @@
 	desc = "This trait halves the lethality of allergen reactions. If you don't have any allergens set, it does nothing. It does not apply to nonlethal reactions or special reactions (such as unathi drowsiness from sugars)."
 	cost = 0
 	custom_only = FALSE
-	var_changes = list("allergen_damage_severity" = 0.6)
+	var_changes = list("allergen_damage_severity" = 1.2)
 
 // Spicy Food Traits, from negative to positive.
 /datum/trait/neutral/spice_intolerance_extreme


### PR DESCRIPTION
It has been brought to my attention that Polaris' tweaks to allergies made them a bit more anemic than I'd like. They were intended to be deadly, and now they should be. Damage severity has been tripled, and the old "reduced effect" trait is now the current baseline.

Also added an extra neutral trait that doubles the already increased lethalty, for people who really like to flirt with danger.