### PR TITLE
Allergen Reaction Tuning

### DIFF
--- a/code/__defines/species_languages.dm
+++ b/code/__defines/species_languages.dm
@@ -47,6 +47,7 @@
 #define AG_WEAKEN	0x10	// too weak to move, oof
 #define AG_BLURRY	0x20	// blurred vision!
 #define AG_SLEEPY	0x40	// fatigue/exhaustion
+#define AG_CONFUSE	0x80	// disorientation - VOREStation addition
 
 // Species spawn flags
 #define SPECIES_IS_WHITELISTED      0x1  // Must be whitelisted to play.

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -53,9 +53,9 @@
 
 	var/taste_sensitivity = TASTE_NORMAL							// How sensitive the species is to minute tastes.
 	var/allergens = null									// Things that will make this species very sick
-	var/allergen_reaction = AG_TOX_DMG|AG_OXY_DMG|AG_EMOTE|AG_PAIN|AG_WEAKEN		// What type of reactions will you have? These the 'main' options and are intended to approximate anaphylactic shock at high doses.
-	var/allergen_damage_severity = 3.6							// How bad are reactions to the allergen? Touch with extreme caution.
-	var/allergen_disable_severity = 3							// Whilst this determines how long nonlethal effects last and how common emotes are.
+	var/allergen_reaction = AG_TOX_DMG|AG_OXY_DMG|AG_EMOTE|AG_PAIN|AG_BLURRY		// What type of reactions will you have? These the 'main' options and are intended to approximate anaphylactic shock at high doses. VOREStation Edit'd.
+	var/allergen_damage_severity = 5							// How bad are reactions to the allergen? Touch with extreme caution. VOREStation Edit'd.
+	var/allergen_disable_severity = 4							// Whilst this determines how long nonlethal effects last and how common emotes are. VOREStation Edit'd.
 
 	var/min_age = 17
 	var/max_age = 70

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -53,7 +53,7 @@
 
 	var/taste_sensitivity = TASTE_NORMAL							// How sensitive the species is to minute tastes.
 	var/allergens = null									// Things that will make this species very sick
-	var/allergen_reaction = AG_TOX_DMG|AG_OXY_DMG|AG_EMOTE|AG_PAIN|AG_BLURRY		// What type of reactions will you have? These the 'main' options and are intended to approximate anaphylactic shock at high doses. VOREStation Edit'd.
+	var/allergen_reaction = AG_TOX_DMG|AG_OXY_DMG|AG_EMOTE|AG_PAIN|AG_BLURRY|AG_CONFUSE	// What type of reactions will you have? These the 'main' options and are intended to approximate anaphylactic shock at high doses. VOREStation Edit'd.
 	var/allergen_damage_severity = 5							// How bad are reactions to the allergen? Touch with extreme caution. VOREStation Edit'd.
 	var/allergen_disable_severity = 4							// Whilst this determines how long nonlethal effects last and how common emotes are. VOREStation Edit'd.
 

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
@@ -174,7 +174,7 @@
 //Allergen traits! Not available to any species with a base allergens var.
 /datum/trait/neutral/allergy
 	name = "Allergy: Gluten"
-	desc = "You're highly allergic to gluten proteins, which are found in most common grains."
+	desc = "You're highly allergic to gluten proteins, which are found in most common grains. NB: By taking this trait, you acknowledge there is a significant risk your character may suffer a fatal reaction if exposed to this substance."
 	cost = 0
 	custom_only = FALSE
 	var/allergen = ALLERGEN_GRAINS
@@ -185,80 +185,82 @@
 
 /datum/trait/neutral/allergy/meat
 	name = "Allergy: Meat"
-	desc = "You're highly allergic to just about any form of meat. You're probably better off just sticking to vegetables. NB: By taking this trait, you acknowledge there is a risk your character may suffer a fatal reaction if exposed to this substance."
+	desc = "You're highly allergic to just about any form of meat. You're probably better off just sticking to vegetables. NB: By taking this trait, you acknowledge there is a significant risk your character may suffer a fatal reaction if exposed to this substance."
 	cost = 0
 	custom_only = FALSE
 	allergen = ALLERGEN_MEAT
 
 /datum/trait/neutral/allergy/fish
 	name = "Allergy: Fish"
-	desc = "You're highly allergic to fish. It's probably best to avoid seafood in general. NB: By taking this trait, you acknowledge there is a risk your character may suffer a fatal reaction if exposed to this substance."
+	desc = "You're highly allergic to fish. It's probably best to avoid seafood in general. NB: By taking this trait, you acknowledge there is a significant risk your character may suffer a fatal reaction if exposed to this substance."
 	cost = 0
 	custom_only = FALSE
 	allergen = ALLERGEN_FISH
 
 /datum/trait/neutral/allergy/fruit
 	name = "Allergy: Fruit"
-	desc = "You're highly allergic to fruit. Vegetables are fine, but you should probably read up on how to tell the difference. Remember, tomatoes are a fruit. NB: By taking this trait, you acknowledge there is a risk your character may suffer a fatal reaction if exposed to this substance."
+	desc = "You're highly allergic to fruit. Vegetables are fine, but you should probably read up on how to tell the difference. Remember, tomatoes are a fruit. NB: By taking this trait, you acknowledge there is a significant risk your character may suffer a fatal reaction if exposed to this substance."
 	cost = 0
 	custom_only = FALSE
 	allergen = ALLERGEN_FRUIT
 
 /datum/trait/neutral/allergy/vegetable
 	name = "Allergy: Vegetable"
-	desc = "You're highly allergic to vegetables. Fruit are fine, but you should probably read up on how to tell the difference. NB: By taking this trait, you acknowledge there is a risk your character may suffer a fatal reaction if exposed to this substance."
+	desc = "You're highly allergic to vegetables. Fruit are fine, but you should probably read up on how to tell the difference. NB: By taking this trait, you acknowledge there is a significant risk your character may suffer a fatal reaction if exposed to this substance."
 	cost = 0
 	custom_only = FALSE
 	allergen = ALLERGEN_VEGETABLE
 
 /datum/trait/neutral/allergy/nuts
 	name = "Allergy: Nuts"
-	desc = "You're highly allergic to hard-shell seeds, such as peanuts. NB: By taking this trait, you acknowledge there is a risk your character may suffer a fatal reaction if exposed to this substance."
+	desc = "You're highly allergic to hard-shell seeds, such as peanuts. NB: By taking this trait, you acknowledge there is a significant risk your character may suffer a fatal reaction if exposed to this substance."
 	cost = 0
 	custom_only = FALSE
 	allergen = ALLERGEN_SEEDS
 
 /datum/trait/neutral/allergy/soy
 	name = "Allergy: Soy"
-	desc = "You're highly allergic to soybeans, and some other kinds of bean. NB: By taking this trait, you acknowledge there is a risk your character may suffer a fatal reaction if exposed to this substance."
+	desc = "You're highly allergic to soybeans, and some other kinds of bean. NB: By taking this trait, you acknowledge there is a significant risk your character may suffer a fatal reaction if exposed to this substance."
 	cost = 0
 	custom_only = FALSE
 	allergen = ALLERGEN_BEANS
 
 /datum/trait/neutral/allergy/dairy
 	name = "Allergy: Lactose"
-	desc = "You're highly allergic to lactose, and consequently, just about all forms of dairy. NB: By taking this trait, you acknowledge there is a risk your character may suffer a fatal reaction if exposed to this substance."
+	desc = "You're highly allergic to lactose, and consequently, just about all forms of dairy. NB: By taking this trait, you acknowledge there is a significant risk your character may suffer a fatal reaction if exposed to this substance."
 	cost = 0
 	custom_only = FALSE
 	allergen = ALLERGEN_DAIRY
 
 /datum/trait/neutral/allergy/fungi
 	name = "Allergy: Fungi"
-	desc = "You're highly allergic to fungi such as mushrooms. NB: By taking this trait, you acknowledge there is a risk your character may suffer a fatal reaction if exposed to this substance."
+	desc = "You're highly allergic to fungi such as mushrooms. NB: By taking this trait, you acknowledge there is a significant risk your character may suffer a fatal reaction if exposed to this substance."
 	cost = 0
 	custom_only = FALSE
 	allergen = ALLERGEN_FUNGI
 
 /datum/trait/neutral/allergy/coffee
 	name = "Allergy: Coffee"
-	desc = "You're highly allergic to coffee in specific. NB: By taking this trait, you acknowledge there is a risk your character may suffer a fatal reaction if exposed to this substance."
+	desc = "You're highly allergic to coffee in specific. NB: By taking this trait, you acknowledge there is a significant risk your character may suffer a fatal reaction if exposed to this substance."
 	cost = 0
 	custom_only = FALSE
 	allergen = ALLERGEN_COFFEE
 
 /datum/trait/neutral/allergen_reduced_effect
 	name = "Reduced Allergen Reaction"
-	desc = "This trait drastically reduces the lethality of allergen reactions. If you don't have any allergens set, it does nothing. It does not apply to nonlethal reactions or special reactions (such as unathi drowsiness from sugars)."
+	desc = "This trait drastically reduces the effects of allergen reactions. If you don't have any allergens set, it does nothing. It does not apply to special reactions (such as unathi drowsiness from sugars)."
 	cost = 0
 	custom_only = FALSE
-	var_changes = list("allergen_damage_severity" = 1.2)
+	var_changes = list("allergen_damage_severity" = 2.5, "allergen_disable_severity" = 3)
+	excludes = list(/datum/trait/neutral/allergen_increased_effect)
 
 /datum/trait/neutral/allergen_increased_effect
 	name = "Increased Allergen Reaction"
-	desc = "This trait drastically increases the lethality of allergen reactions. If you don't have any allergens set, it does nothing. It does not apply to nonlethal reactions or special reactions (such as unathi drowsiness from sugars)."
+	desc = "This trait drastically increases the effects of allergen reactions, enough that even a small dose can be lethal. If you don't have any allergens set, it does nothing. It does not apply to special reactions (such as unathi drowsiness from sugars)."
 	cost = 0
 	custom_only = FALSE
-	var_changes = list("allergen_damage_severity" = 7.2)
+	var_changes = list("allergen_damage_severity" = 10, "allergen_disable_severity" = 6)
+	excludes = list(/datum/trait/neutral/allergen_reduced_effect)
 
 // Spicy Food Traits, from negative to positive.
 /datum/trait/neutral/spice_intolerance_extreme

--- a/code/modules/reagents/reagents/_reagents.dm
+++ b/code/modules/reagents/reagents/_reagents.dm
@@ -182,6 +182,8 @@
 			M.eye_blurry = max(M.eye_blurry, disable_severity)
 		if(M.species.allergen_reaction & AG_SLEEPY)
 			M.drowsyness = max(M.drowsyness, disable_severity)
+		if(M.species.allergen_reaction & AG_CONFUSE) //VOREStation Addition
+			M.Confuse(disable_severity/4) //VOREStation Addition
 	remove_self(removed)
 	return
 

--- a/code/modules/reagents/reagents/_reagents.dm
+++ b/code/modules/reagents/reagents/_reagents.dm
@@ -168,14 +168,14 @@
 		if(M.species.allergen_reaction & AG_TOX_DMG)
 			M.adjustToxLoss(damage_severity)
 		if(M.species.allergen_reaction & AG_OXY_DMG)
-			M.adjustOxyLoss(damage_severity)
+			M.adjustOxyLoss(damage_severity*1.5) //VOREStation Edit
 			if(prob(2.5*disable_severity))
 				M.emote(pick("cough","gasp","choke"))
 		if(M.species.allergen_reaction & AG_EMOTE)
 			if(prob(2.5*disable_severity))	//this has a higher base chance, but not *too* high
 				M.emote(pick("pale","shiver","twitch"))
 		if(M.species.allergen_reaction & AG_PAIN)
-			M.adjustHalLoss(disable_severity)
+			M.adjustHalLoss(disable_severity*2) //VOREStation Edit
 		if(M.species.allergen_reaction & AG_WEAKEN)
 			M.Weaken(disable_severity)
 		if(M.species.allergen_reaction & AG_BLURRY)


### PR DESCRIPTION
Followup to #12161 that further tunes the effects;
- At @Wickedtemp 's suggestion I've removed the immediate stun/weaken, incap is now handled by (pain)crit.
- Standard effects now include blurred vision and brief confusion.
- Toxin damage has been tuned up slightly, so one unit of allergen should be around 25 toxin damage.
- Oxy damage receives an additional multiplier to compensate for the 5/s oxyloss heal mobs have whilst they can breathe, one unit of allergen should be around 38 oxy damage.
- This works out to about 60 damage total.
- Pain effects are doubled. Combined with the damage tweaks above, reactions will put you into paincrit on a delay.
- Reactivity traits now adjust the nonlethal effects as well.
- Gluten allergy trait got the boilerplate warning since it didn't have one.

In practice this means anyone suffering a bad reaction will now stumble around if they try to move and then get slammed into paincrit, but they will probably recover if they only had one unit of their trigger. Anything more than that will almost certainly require CPR/medical attention.

Actually tested this time.