### PR TITLE
Adding text variables to vore-belly descriptions

### DIFF
--- a/code/modules/vore/eating/belly_obj_vr.dm
+++ b/code/modules/vore/eating/belly_obj_vr.dm
@@ -263,7 +263,7 @@
 			formatted_desc = replacetext(raw_desc, "%belly", lowertext(name)) //replace with this belly's name
 			formatted_desc = replacetext(formatted_desc, "%pred", owner) //replace with this belly's owner
 			formatted_desc = replacetext(formatted_desc, "%prey", M) //replace with whatever mob entered into this belly
-		to_chat(M, "<span class='notice'><B>[formatted_desc]</B></span>")
+			to_chat(M, "<span class='notice'><B>[formatted_desc]</B></span>")
 
 		var/taste
 		if(can_taste && (taste = M.get_taste_message(FALSE)))

--- a/code/modules/vore/eating/belly_obj_vr.dm
+++ b/code/modules/vore/eating/belly_obj_vr.dm
@@ -250,20 +250,21 @@
 	if(isliving(thing))
 		var/mob/living/M = thing
 		M.updateVRPanel()
+		var/raw_desc //Let's use this to avoid needing to write the reformat code twice
 		if(absorbed_desc && M.absorbed)
-			//Replace placeholder vars
-			var/formatted_abs_desc
-			formatted_abs_desc = replacetext(absorbed_desc, "%belly", lowertext(name)) //replace with this belly's name
-			formatted_abs_desc = replacetext(formatted_abs_desc, "%pred", owner) //replace with this belly's owner
-			formatted_abs_desc = replacetext(formatted_abs_desc, "%prey", M) //replace with whatever mob entered into this belly
-			to_chat(M, "<span class='notice'><B>[formatted_abs_desc]</B></span>")
+			raw_desc = absorbed_desc
 		else if(desc)
+			raw_desc = desc
+
+		//Was there a description text? If so, it's time to format it!
+		if(raw_desc)
 			//Replace placeholder vars
 			var/formatted_desc
-			formatted_desc = replacetext(desc, "%belly", lowertext(name)) //replace with this belly's name
+			formatted_desc = replacetext(raw_desc, "%belly", lowertext(name)) //replace with this belly's name
 			formatted_desc = replacetext(formatted_desc, "%pred", owner) //replace with this belly's owner
 			formatted_desc = replacetext(formatted_desc, "%prey", M) //replace with whatever mob entered into this belly
-			to_chat(M, "<span class='notice'><B>[formatted_desc]</B></span>")
+		to_chat(M, "<span class='notice'><B>[formatted_desc]</B></span>")
+
 		var/taste
 		if(can_taste && (taste = M.get_taste_message(FALSE)))
 			to_chat(owner, "<span class='notice'>[M] tastes of [taste].</span>")

--- a/code/modules/vore/eating/belly_obj_vr.dm
+++ b/code/modules/vore/eating/belly_obj_vr.dm
@@ -251,9 +251,19 @@
 		var/mob/living/M = thing
 		M.updateVRPanel()
 		if(absorbed_desc && M.absorbed)
-			to_chat(M, "<span class='notice'><B>[absorbed_desc]</B></span>")
+			//Replace placeholder vars
+			var/formatted_abs_desc
+			formatted_abs_desc = replacetext(absorbed_desc, "%belly", lowertext(name)) //replace with this belly's name
+			formatted_abs_desc = replacetext(formatted_abs_desc, "%pred", owner) //replace with this belly's owner
+			formatted_abs_desc = replacetext(formatted_abs_desc, "%prey", M) //replace with whatever mob entered into this belly
+			to_chat(M, "<span class='notice'><B>[formatted_abs_desc]</B></span>")
 		else if(desc)
-			to_chat(M, "<span class='notice'><B>[desc]</B></span>")
+			//Replace placeholder vars
+			var/formatted_desc
+			formatted_desc = replacetext(desc, "%belly", lowertext(name)) //replace with this belly's name
+			formatted_desc = replacetext(formatted_desc, "%pred", owner) //replace with this belly's owner
+			formatted_desc = replacetext(formatted_desc, "%prey", M) //replace with whatever mob entered into this belly
+			to_chat(M, "<span class='notice'><B>[formatted_desc]</B></span>")
 		var/taste
 		if(can_taste && (taste = M.get_taste_message(FALSE)))
 			to_chat(owner, "<span class='notice'>[M] tastes of [taste].</span>")
@@ -696,7 +706,12 @@
 
 
 	if(absorbed_desc)
-		to_chat(M, "<span class='notice'><B>[absorbed_desc]</B></span>")
+		//Replace placeholder vars
+		var/formatted_abs_desc
+		formatted_abs_desc = replacetext(absorbed_desc, "%belly", lowertext(name)) //replace with this belly's name
+		formatted_abs_desc = replacetext(formatted_abs_desc, "%pred", owner) //replace with this belly's owner
+		formatted_abs_desc = replacetext(formatted_abs_desc, "%prey", M) //replace with whatever mob entered into this belly
+		to_chat(M, "<span class='notice'><B>[formatted_abs_desc]</B></span>")
 
 	//Update owner
 	owner.updateVRPanel()

--- a/code/modules/vore/eating/vorepanel_vr.dm
+++ b/code/modules/vore/eating/vorepanel_vr.dm
@@ -709,7 +709,7 @@
 			host.vore_selected.egg_type = new_egg_type
 			. = TRUE
 		if("b_desc")
-			var/new_desc = html_encode(input(usr,"Belly Description ([BELLIES_DESC_MAX] char limit):","New Description",host.vore_selected.desc) as message|null)
+			var/new_desc = html_encode(input(usr,"Belly Description, '%pred' will be replaced with your name. '%prey' will be replaced with the prey's name. '%belly' will be replaced with your belly's name. ([BELLIES_DESC_MAX] char limit):","New Description",host.vore_selected.desc) as message|null)
 
 			if(new_desc)
 				new_desc = readd_quotes(new_desc)
@@ -719,7 +719,7 @@
 				host.vore_selected.desc = new_desc
 				. = TRUE
 		if("b_absorbed_desc")
-			var/new_desc = html_encode(input(usr,"Belly Description for absorbed prey ([BELLIES_DESC_MAX] char limit):","New Description",host.vore_selected.absorbed_desc) as message|null)
+			var/new_desc = html_encode(input(usr,"Belly Description for absorbed prey, '%pred' will be replaced with your name. '%prey' will be replaced with the prey's name. '%belly' will be replaced with your belly's name. ([BELLIES_DESC_MAX] char limit):","New Description",host.vore_selected.absorbed_desc) as message|null)
 
 			if(new_desc)
 				new_desc = readd_quotes(new_desc)

--- a/code/modules/vore/eating/vorepanel_vr.dm
+++ b/code/modules/vore/eating/vorepanel_vr.dm
@@ -101,6 +101,15 @@
 		else if(inside_belly.desc)
 			inside_desc = inside_belly.desc
 
+		//I'd rather not copy-paste this code twice into the previous if-statement
+		//Technically we could just format the text anyway, but IDK how demanding unnecessary text-replacements are
+		if((host.absorbed && inside_belly.absorbed_desc) || (inside_belly.desc))
+			var/formatted_desc
+			formatted_desc = replacetext(inside_desc, "%belly", lowertext(inside_belly.name)) //replace with this belly's name
+			formatted_desc = replacetext(formatted_desc, "%pred", pred) //replace with the pred of this belly
+			formatted_desc = replacetext(formatted_desc, "%prey", host) //replace with whoever's reading this
+			inside_desc = formatted_desc
+
 		inside = list(
 			"absorbed" = host.absorbed,
 			"belly_name" = inside_belly.name,


### PR DESCRIPTION
This adds the %belly, %pred, and %prey variables to the "description" and "absorb description" text fields for a belly, and adds the information about that to the text-box used to enter said descriptions.