### PR TITLE
Fixes pouches

### DIFF
--- a/code/game/objects/items/weapons/storage/pouches.dm
+++ b/code/game/objects/items/weapons/storage/pouches.dm
@@ -15,7 +15,7 @@
 	can_hold = null
 	pocketable = TRUE
 	
-	var/insert_delay = 0
+	var/insert_delay = 0 SECONDS
 	var/remove_delay = 2 SECONDS
 
 /obj/item/weapon/storage/pouch/stall_insertion(obj/item/W, mob/user)
@@ -23,26 +23,23 @@
 	if(user.get_active_hand() == src || user.get_inactive_hand() == src)
 		return TRUE // Skip delay
 
-	if(insert_delay && !do_after(user, 2 SECONDS, src, needhand = TRUE, exclusive = TASK_USER_EXCLUSIVE))
-		return FALSE // Moved or whatever
+	if(insert_delay && !do_after(user, insert_delay, src, needhand = TRUE, exclusive = TASK_USER_EXCLUSIVE))
+		return FALSE // Moved while there is a delay
 
-	if(W in src)
-		return TRUE // Item is still inside
-
-	return FALSE
+	return TRUE //Now we're allowed to put the item in the pouch
 
 /obj/item/weapon/storage/pouch/stall_removal(obj/item/W, mob/user)
 	// No delay if you have the pouch in your hands
 	if(user.get_active_hand() == src || user.get_inactive_hand() == src)
 		return TRUE // Skip delay
 	
-	if(remove_delay && !do_after(user, 2 SECONDS, src, needhand = TRUE, exclusive = TASK_USER_EXCLUSIVE))
-		return FALSE // Moved or whatever
+	if(remove_delay && !do_after(user, remove_delay, src, needhand = TRUE, exclusive = TASK_USER_EXCLUSIVE))
+		return FALSE // Moved while there is a delay
 
 	if(W in src)
 		return TRUE // Item is still inside
 
-	return FALSE
+	return FALSE //Item was somehow already removed
 
 /obj/item/weapon/storage/pouch/pocket_description(mob/haver, mob/examiner)
 	return "[src]"


### PR DESCRIPTION
This PR fixes the hardcoded insert- and remove-delays (the variables existed and was checked for but for some reason was not used to actually delay anything).
This also Fixes #12056 which was as a result of incorrectly copy-pasted code from the remove-delay code into the insert-delay code.
The insertion delay is still set to 0 by default, but now it should not only function properly, but the various pouches that inherit from the base version should now be able to have custom delays specific to them if need be.