### PR TITLE
Allow all preset request consoles to make announcements

### DIFF
--- a/code/game/machinery/requests_console_vr.dm
+++ b/code/game/machinery/requests_console_vr.dm
@@ -10,7 +10,7 @@
 	name = ""
 	department = ""
 	departmentType = ""
-	announcementConsole = 0
+	announcementConsole = TRUE
 
 // Departments
 /obj/machinery/requests_console/preset/cargo


### PR DESCRIPTION
Don't see why we wouldn't do this, department announcements are cool

Per a suggestion in General Feedback