### PR TITLE
Fixes Ghost Sight being missing from Preference verbs

### DIFF
--- a/code/modules/client/preferences_toggle_procs.dm
+++ b/code/modules/client/preferences_toggle_procs.dm
@@ -15,7 +15,7 @@
 	feedback_add_details("admin_verb","TGEars") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /client/verb/toggle_ghost_vision()
-	set name = "Toggle Ghost Vision"
+	set name = "Toggle Ghost Sight"
 	set category = "Preferences"
 	set desc = "Toggles between seeing all mob emotes and only nearby mob emotes as an observer."
 


### PR DESCRIPTION
This one is probably mostly on me since I believe I last touched this but Ghost Sight toggle ended up being named same as Ghost Vision toggle and due to how verbs work, only one of Ghost Vision toggles appeared. It is still togglable in char setup, just not in preferences tab. Well, this fixes that.