### PR TITLE
SD - gives cmo & rd their folders

### DIFF
--- a/maps/stellardelight/stellar_delight3.dmm
+++ b/maps/stellardelight/stellar_delight3.dmm
@@ -13225,6 +13225,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
+/obj/item/weapon/folder/white_cmo,
 /turf/simulated/floor/tiled/eris/white/cargo,
 /area/crew_quarters/heads/cmo)
 "VG" = (
@@ -13678,6 +13679,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
+/obj/item/weapon/folder/white_rd,
 /turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/heads/hor)
 "Xo" = (


### PR DESCRIPTION
tiny map tweak that doesn't really matter. 
CMO and RD didn't have their special folders. i missed them.