### PR TITLE
Fixes a bunch of xenobio bugs

### DIFF
--- a/code/modules/mob/living/simple_mob/subtypes/slime/slime.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/slime/slime.dm
@@ -162,6 +162,10 @@ var/list/_slime_default_emotes = list(
 			return TRUE
 		else
 			return FALSE
+	if(ishuman(L))
+		var/mob/living/carbon/human/H = L
+		if(istype(H.species, /datum/species/monkey))	// Monke always food
+			return FALSE
 	// The other stuff was already checked in parent proc, and the . variable will implicitly return the correct value.
 
 // Slimes regenerate passively.

--- a/code/modules/mob/living/simple_mob/subtypes/slime/xenobio/defense.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/slime/xenobio/defense.dm
@@ -51,4 +51,4 @@
 // Getting slimebatoned/xenotased.
 /mob/living/simple_mob/slime/xenobio/slimebatoned(mob/living/user, amount)
 	adjust_discipline(round(amount/2))
-	Weaken(amount) // This needs to come afterwards or else it will always be considered abuse to the slime.
+	Weaken(amount*5) // This needs to come afterwards or else it will always be considered abuse to the slime. Multiply by 5 for stun to not end instantly.

--- a/code/modules/mob/living/simple_mob/subtypes/slime/xenobio/subtypes.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/slime/xenobio/subtypes.dm
@@ -563,7 +563,7 @@
 
 /datum/modifier/aura/slime_heal
 	name = "slime mending"
-	desc = "You feel somewhat gooy."
+	desc = "You feel somewhat gooey."
 	mob_overlay_state = "pink_sparkles"
 	stacks = MODIFIER_STACK_FORBID
 	aura_max_distance = 2
@@ -605,6 +605,7 @@
 		)
 
 /mob/living/simple_mob/slime/xenobio/gold/slimebatoned(mob/living/user, amount)
+	adjust_discipline(round(amount/2))
 	power_charge = between(0, power_charge + amount, 10)
 
 /mob/living/simple_mob/slime/xenobio/gold/get_description_interaction() // So it doesn't say to use a baton on them.


### PR DESCRIPTION
Fixed gold slimes not being disciplined by tasers/batons (they still don't get stunned by them)
Increased stun duration of slimes by tasers/batons 5fold (because the stun literally lasts a tick or two of life, renderign itself meaningless and makign shooting over them with slime taser way harder)
Fixed loyalty potion'd slimes not attacking monkeys for sustenance.