### PR TITLE
Fixes sofa paths

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -320,21 +320,24 @@
 	icon_state = "corp_sofamiddle"
 	applies_material_colour = FALSE
 
-/obj/structure/bed/chair/sofa/corp/left
+/obj/structure/bed/chair/sofa/left/corp
 	icon_state = "corp_sofaend_left"
 	base_icon = "corp_sofaend_left"
+	applies_material_colour = FALSE
 
-/obj/structure/bed/chair/sofa/corp/right
+/obj/structure/bed/chair/sofa/right/corp
 	icon_state = "corp_sofaend_right"
 	base_icon = "corp_sofaend_right"
+	applies_material_colour = FALSE
 
-/obj/structure/bed/chair/sofa/corp/corner
+/obj/structure/bed/chair/sofa/corner/corp
 	icon_state = "corp_sofacorner"
 	base_icon = "corp_sofacorner"
-	corner_piece = TRUE
+	applies_material_colour = FALSE
+	//corner_piece = TRUE //No need to re-state this, as the parent object already handles corners
 
 //color variations
-
+//Middle sofas first
 /obj/structure/bed/chair/sofa
 	sofa_material = "carpet"
 
@@ -379,92 +382,92 @@
 /obj/structure/bed/chair/sofa/corner
 	icon_state = "sofacorner"
 
-/obj/structure/bed/chair/sofa/brown/left
-	icon_state = "sofaend_left"
+/obj/structure/bed/chair/sofa/left/brown
+	sofa_material = "leather"
 
-/obj/structure/bed/chair/sofa/brown/right
-	icon_state = "sofaend_right"
+/obj/structure/bed/chair/sofa/right/brown
+	sofa_material = "leather"
 
-/obj/structure/bed/chair/sofa/brown/corner
-	icon_state = "sofacorner"
+/obj/structure/bed/chair/sofa/corner/brown
+	sofa_material = "leather"
 
-/obj/structure/bed/chair/sofa/teal/left
-	icon_state = "sofaend_left"
+/obj/structure/bed/chair/sofa/left/teal
+	sofa_material = "teal"
 
-/obj/structure/bed/chair/sofa/teal/right
-	icon_state = "sofaend_right"
+/obj/structure/bed/chair/sofa/right/teal
+	sofa_material = "teal"
 
-/obj/structure/bed/chair/sofa/teal/corner
-	icon_state = "sofacorner"
+/obj/structure/bed/chair/sofa/corner/teal
+	sofa_material = "teal"
 
-/obj/structure/bed/chair/sofa/black/left
-	icon_state = "sofaend_left"
+/obj/structure/bed/chair/sofa/left/black
+	sofa_material = "black"
 
-/obj/structure/bed/chair/sofa/black/right
-	icon_state = "sofaend_right"
+/obj/structure/bed/chair/sofa/right/black
+	sofa_material = "black"
 
-/obj/structure/bed/chair/sofa/black/corner
-	icon_state = "sofacorner"
+/obj/structure/bed/chair/sofa/corner/black
+	sofa_material = "black"
 
-/obj/structure/bed/chair/sofa/green/left
-	icon_state = "sofaend_left"
+/obj/structure/bed/chair/sofa/left/green
+	sofa_material = "green"
 
-/obj/structure/bed/chair/sofa/green/right
-	icon_state = "sofaend_right"
+/obj/structure/bed/chair/sofa/right/green
+	sofa_material = "green"
 
-/obj/structure/bed/chair/sofa/green/corner
-	icon_state = "sofacorner"
+/obj/structure/bed/chair/sofa/corner/green
+	sofa_material = "green"
 
-/obj/structure/bed/chair/sofa/purp/left
-	icon_state = "sofaend_left"
+/obj/structure/bed/chair/sofa/left/purp
+	sofa_material = "purple"
 
-/obj/structure/bed/chair/sofa/purp/right
-	icon_state = "sofaend_right"
+/obj/structure/bed/chair/sofa/right/purp
+	sofa_material = "purple"
 
-/obj/structure/bed/chair/sofa/purp/corner
-	icon_state = "sofacorner"
+/obj/structure/bed/chair/sofa/corner/purp
+	sofa_material = "purple"
 
-/obj/structure/bed/chair/sofa/blue/left
-	icon_state = "sofaend_left"
+/obj/structure/bed/chair/sofa/left/blue
+	sofa_material = "blue"
 
-/obj/structure/bed/chair/sofa/blue/right
-	icon_state = "sofaend_right"
+/obj/structure/bed/chair/sofa/right/blue
+	sofa_material = "blue"
 
-/obj/structure/bed/chair/sofa/blue/corner
-	icon_state = "sofacorner"
+/obj/structure/bed/chair/sofa/corner/blue
+	sofa_material = "blue"
 
-/obj/structure/bed/chair/sofa/beige/left
-	icon_state = "sofaend_left"
+/obj/structure/bed/chair/sofa/left/beige
+	sofa_material = "beige"
 
-/obj/structure/bed/chair/sofa/beige/right
-	icon_state = "sofaend_right"
+/obj/structure/bed/chair/sofa/right/beige
+	sofa_material = "beige"
 
-/obj/structure/bed/chair/sofa/beige/corner
-	icon_state = "sofacorner"
+/obj/structure/bed/chair/sofa/corner/beige
+	sofa_material = "beige"
 
-/obj/structure/bed/chair/sofa/lime/left
-	icon_state = "sofaend_left"
+/obj/structure/bed/chair/sofa/left/lime
+	sofa_material = "lime"
 
-/obj/structure/bed/chair/sofa/lime/right
-	icon_state = "sofaend_right"
+/obj/structure/bed/chair/sofa/right/lime
+	sofa_material = "lime"
 
-/obj/structure/bed/chair/sofa/lime/corner
-	icon_state = "sofacorner"
+/obj/structure/bed/chair/sofa/corner/lime
+	sofa_material = "lime"
 
-/obj/structure/bed/chair/sofa/yellow/left
-	icon_state = "sofaend_left"
+/obj/structure/bed/chair/sofa/left/yellow
+	sofa_material = "yellow"
 
-/obj/structure/bed/chair/sofa/yellow/right
-	icon_state = "sofaend_right"
+/obj/structure/bed/chair/sofa/right/yellow
+	sofa_material = "yellow"
 
-/obj/structure/bed/chair/sofa/yellow/corner
-	icon_state = "sofacorner"
+/obj/structure/bed/chair/sofa/corner/yellow
+	sofa_material = "yellow"
 
-/obj/structure/bed/chair/sofa/orange/left
-	icon_state = "sofaend_left"
+/obj/structure/bed/chair/sofa/left/orange
+	sofa_material = "orange"
 
-/obj/structure/bed/chair/sofa/orange/right
-	icon_state = "sofaend_right"
+/obj/structure/bed/chair/sofa/right/orange
+	sofa_material = "orange"
 
-/obj/structure/bed/chair/sofa/orange/corner
-	icon_state = "sofacorner"
+/obj/structure/bed/chair/sofa/corner/orange
+	sofa_material = "orange"

--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -320,21 +320,18 @@
 	icon_state = "corp_sofamiddle"
 	applies_material_colour = FALSE
 
-/obj/structure/bed/chair/sofa/left/corp
+/obj/structure/bed/chair/sofa/corp/left
 	icon_state = "corp_sofaend_left"
 	base_icon = "corp_sofaend_left"
-	applies_material_colour = FALSE
 
-/obj/structure/bed/chair/sofa/right/corp
+/obj/structure/bed/chair/sofa/corp/right
 	icon_state = "corp_sofaend_right"
 	base_icon = "corp_sofaend_right"
-	applies_material_colour = FALSE
 
-/obj/structure/bed/chair/sofa/corner/corp
+/obj/structure/bed/chair/sofa/corp/corner
 	icon_state = "corp_sofacorner"
 	base_icon = "corp_sofacorner"
-	applies_material_colour = FALSE
-	//corner_piece = TRUE //No need to re-state this, as the parent object already handles corners
+	corner_piece = TRUE
 
 //color variations
 //Middle sofas first

--- a/code/modules/materials/materials/metals/steel_vr.dm
+++ b/code/modules/materials/materials/metals/steel_vr.dm
@@ -39,44 +39,44 @@
 			new /datum/stack_recipe("red sofa right", /obj/structure/bed/chair/sofa/right, 1, one_per_turf = 1, on_floor = 1), \
 			new /datum/stack_recipe("red sofa corner", /obj/structure/bed/chair/sofa/corner, 1, one_per_turf = 1, on_floor = 1), \
 			new /datum/stack_recipe("brown sofa middle", /obj/structure/bed/chair/sofa/brown, 1, one_per_turf = 1, on_floor = 1), \
-			new /datum/stack_recipe("brown sofa left", /obj/structure/bed/chair/sofa/brown/left, 1, one_per_turf = 1, on_floor = 1), \
-			new /datum/stack_recipe("brown sofa right", /obj/structure/bed/chair/sofa/brown/right, 1, one_per_turf = 1, on_floor = 1), \
-			new /datum/stack_recipe("brown sofa corner", /obj/structure/bed/chair/sofa/brown/corner, 1, one_per_turf = 1, on_floor = 1), \
+			new /datum/stack_recipe("brown sofa left", /obj/structure/bed/chair/sofa/left/brown, 1, one_per_turf = 1, on_floor = 1), \
+			new /datum/stack_recipe("brown sofa right", /obj/structure/bed/chair/sofa/right/brown, 1, one_per_turf = 1, on_floor = 1), \
+			new /datum/stack_recipe("brown sofa corner", /obj/structure/bed/chair/sofa/corner/brown, 1, one_per_turf = 1, on_floor = 1), \
 			new /datum/stack_recipe("teal sofa middle", /obj/structure/bed/chair/sofa/teal, 1, one_per_turf = 1, on_floor = 1), \
-			new /datum/stack_recipe("teal sofa left", /obj/structure/bed/chair/sofa/teal/left, 1, one_per_turf = 1, on_floor = 1), \
-			new /datum/stack_recipe("teal sofa right", /obj/structure/bed/chair/sofa/teal/right, 1, one_per_turf = 1, on_floor = 1), \
-			new /datum/stack_recipe("teal sofa corner", /obj/structure/bed/chair/sofa/teal/corner, 1, one_per_turf = 1, on_floor = 1), \
+			new /datum/stack_recipe("teal sofa left", /obj/structure/bed/chair/sofa/left/teal, 1, one_per_turf = 1, on_floor = 1), \
+			new /datum/stack_recipe("teal sofa right", /obj/structure/bed/chair/sofa/right/teal, 1, one_per_turf = 1, on_floor = 1), \
+			new /datum/stack_recipe("teal sofa corner", /obj/structure/bed/chair/sofa/corner/teal, 1, one_per_turf = 1, on_floor = 1), \
 			new /datum/stack_recipe("black sofa middle", /obj/structure/bed/chair/sofa/black, 1, one_per_turf = 1, on_floor = 1), \
-			new /datum/stack_recipe("black sofa left", /obj/structure/bed/chair/sofa/black/left, 1, one_per_turf = 1, on_floor = 1), \
-			new /datum/stack_recipe("black sofa right", /obj/structure/bed/chair/sofa/black/right, 1, one_per_turf = 1, on_floor = 1), \
-			new /datum/stack_recipe("black sofa corner", /obj/structure/bed/chair/sofa/black/corner, 1, one_per_turf = 1, on_floor = 1), \
+			new /datum/stack_recipe("black sofa left", /obj/structure/bed/chair/sofa/left/black, 1, one_per_turf = 1, on_floor = 1), \
+			new /datum/stack_recipe("black sofa right", /obj/structure/bed/chair/sofa/right/black, 1, one_per_turf = 1, on_floor = 1), \
+			new /datum/stack_recipe("black sofa corner", /obj/structure/bed/chair/sofa/corner/black, 1, one_per_turf = 1, on_floor = 1), \
 			new /datum/stack_recipe("green sofa middle", /obj/structure/bed/chair/sofa/green, 1, one_per_turf = 1, on_floor = 1), \
-			new /datum/stack_recipe("green sofa left", /obj/structure/bed/chair/sofa/green/left, 1, one_per_turf = 1, on_floor = 1), \
-			new /datum/stack_recipe("green sofa right", /obj/structure/bed/chair/sofa/green/right, 1, one_per_turf = 1, on_floor = 1), \
-			new /datum/stack_recipe("green sofa corner", /obj/structure/bed/chair/sofa/green/corner, 1, one_per_turf = 1, on_floor = 1), \
+			new /datum/stack_recipe("green sofa left", /obj/structure/bed/chair/sofa/left/green, 1, one_per_turf = 1, on_floor = 1), \
+			new /datum/stack_recipe("green sofa right", /obj/structure/bed/chair/sofa/right/green, 1, one_per_turf = 1, on_floor = 1), \
+			new /datum/stack_recipe("green sofa corner", /obj/structure/bed/chair/sofa/corner/green, 1, one_per_turf = 1, on_floor = 1), \
 			new /datum/stack_recipe("purple sofa middle", /obj/structure/bed/chair/sofa/purp, 1, one_per_turf = 1, on_floor = 1), \
-			new /datum/stack_recipe("purple sofa left", /obj/structure/bed/chair/sofa/purp/left, 1, one_per_turf = 1, on_floor = 1), \
-			new /datum/stack_recipe("purple sofa right", /obj/structure/bed/chair/sofa/purp/right, 1, one_per_turf = 1, on_floor = 1), \
-			new /datum/stack_recipe("purple sofa corner", /obj/structure/bed/chair/sofa/purp/corner, 1, one_per_turf = 1, on_floor = 1), \
+			new /datum/stack_recipe("purple sofa left", /obj/structure/bed/chair/sofa/left/purp, 1, one_per_turf = 1, on_floor = 1), \
+			new /datum/stack_recipe("purple sofa right", /obj/structure/bed/chair/sofa/right/purp, 1, one_per_turf = 1, on_floor = 1), \
+			new /datum/stack_recipe("purple sofa corner", /obj/structure/bed/chair/sofa/corner/purp, 1, one_per_turf = 1, on_floor = 1), \
 			new /datum/stack_recipe("blue sofa middle", /obj/structure/bed/chair/sofa/blue, 1, one_per_turf = 1, on_floor = 1), \
-			new /datum/stack_recipe("blue sofa left", /obj/structure/bed/chair/sofa/blue/left, 1, one_per_turf = 1, on_floor = 1), \
-			new /datum/stack_recipe("blue sofa right", /obj/structure/bed/chair/sofa/blue/right, 1, one_per_turf = 1, on_floor = 1), \
-			new /datum/stack_recipe("blue sofa corner", /obj/structure/bed/chair/sofa/blue/corner, 1, one_per_turf = 1, on_floor = 1), \
+			new /datum/stack_recipe("blue sofa left", /obj/structure/bed/chair/sofa/left/blue, 1, one_per_turf = 1, on_floor = 1), \
+			new /datum/stack_recipe("blue sofa right", /obj/structure/bed/chair/sofa/right/blue, 1, one_per_turf = 1, on_floor = 1), \
+			new /datum/stack_recipe("blue sofa corner", /obj/structure/bed/chair/sofa/corner/blue, 1, one_per_turf = 1, on_floor = 1), \
 			new /datum/stack_recipe("beige sofa middle", /obj/structure/bed/chair/sofa/beige, 1, one_per_turf = 1, on_floor = 1), \
-			new /datum/stack_recipe("beige sofa left", /obj/structure/bed/chair/sofa/beige/left, 1, one_per_turf = 1, on_floor = 1), \
-			new /datum/stack_recipe("beige sofa right", /obj/structure/bed/chair/sofa/beige/right, 1, one_per_turf = 1, on_floor = 1), \
-			new /datum/stack_recipe("beige sofa corner", /obj/structure/bed/chair/sofa/beige/corner, 1, one_per_turf = 1, on_floor = 1), \
+			new /datum/stack_recipe("beige sofa left", /obj/structure/bed/chair/sofa/left/beige, 1, one_per_turf = 1, on_floor = 1), \
+			new /datum/stack_recipe("beige sofa right", /obj/structure/bed/chair/sofa/right/beige, 1, one_per_turf = 1, on_floor = 1), \
+			new /datum/stack_recipe("beige sofa corner", /obj/structure/bed/chair/sofa/corner/beige, 1, one_per_turf = 1, on_floor = 1), \
 			new /datum/stack_recipe("lime sofa middle", /obj/structure/bed/chair/sofa/lime, 1, one_per_turf = 1, on_floor = 1), \
-			new /datum/stack_recipe("lime sofa left", /obj/structure/bed/chair/sofa/lime/left, 1, one_per_turf = 1, on_floor = 1), \
-			new /datum/stack_recipe("lime sofa right", /obj/structure/bed/chair/sofa/lime/right, 1, one_per_turf = 1, on_floor = 1), \
-			new /datum/stack_recipe("lime sofa corner", /obj/structure/bed/chair/sofa/lime/corner, 1, one_per_turf = 1, on_floor = 1), \
+			new /datum/stack_recipe("lime sofa left", /obj/structure/bed/chair/sofa/left/lime, 1, one_per_turf = 1, on_floor = 1), \
+			new /datum/stack_recipe("lime sofa right", /obj/structure/bed/chair/sofa/right/lime, 1, one_per_turf = 1, on_floor = 1), \
+			new /datum/stack_recipe("lime sofa corner", /obj/structure/bed/chair/sofa/corner/lime, 1, one_per_turf = 1, on_floor = 1), \
 			new /datum/stack_recipe("yellow sofa middle", /obj/structure/bed/chair/sofa/yellow, 1, one_per_turf = 1, on_floor = 1), \
-			new /datum/stack_recipe("yellow sofa left", /obj/structure/bed/chair/sofa/yellow/left, 1, one_per_turf = 1, on_floor = 1), \
-			new /datum/stack_recipe("yellow sofa right", /obj/structure/bed/chair/sofa/yellow/right, 1, one_per_turf = 1, on_floor = 1), \
-			new /datum/stack_recipe("yellow sofa corner", /obj/structure/bed/chair/sofa/yellow/corner, 1, one_per_turf = 1, on_floor = 1), \
+			new /datum/stack_recipe("yellow sofa left", /obj/structure/bed/chair/sofa/left/yellow, 1, one_per_turf = 1, on_floor = 1), \
+			new /datum/stack_recipe("yellow sofa right", /obj/structure/bed/chair/sofa/right/yellow, 1, one_per_turf = 1, on_floor = 1), \
+			new /datum/stack_recipe("yellow sofa corner", /obj/structure/bed/chair/sofa/corner/yellow, 1, one_per_turf = 1, on_floor = 1), \
 			new /datum/stack_recipe("orange sofa middle", /obj/structure/bed/chair/sofa/orange, 1, one_per_turf = 1, on_floor = 1), \
-			new /datum/stack_recipe("orange sofa left", /obj/structure/bed/chair/sofa/orange/left, 1, one_per_turf = 1, on_floor = 1), \
-			new /datum/stack_recipe("orange sofa right", /obj/structure/bed/chair/sofa/orange/right, 1, one_per_turf = 1, on_floor = 1), \
-			new /datum/stack_recipe("orange sofa corner", /obj/structure/bed/chair/sofa/orange/corner, 1, one_per_turf = 1, on_floor = 1), \
+			new /datum/stack_recipe("orange sofa left", /obj/structure/bed/chair/sofa/left/orange, 1, one_per_turf = 1, on_floor = 1), \
+			new /datum/stack_recipe("orange sofa right", /obj/structure/bed/chair/sofa/right/orange, 1, one_per_turf = 1, on_floor = 1), \
+			new /datum/stack_recipe("orange sofa corner", /obj/structure/bed/chair/sofa/corner/orange, 1, one_per_turf = 1, on_floor = 1), \
 			)),
 	)

--- a/maps/expedition_vr/beach/submaps/speakeasy_vr.dmm
+++ b/maps/expedition_vr/beach/submaps/speakeasy_vr.dmm
@@ -76,7 +76,7 @@
 /turf/simulated/wall/wood,
 /area/submap/Speakeasy)
 "x" = (
-/obj/structure/bed/chair/sofa/blue/left{
+/obj/structure/bed/chair/sofa/left/blue{
 	dir = 4
 	},
 /turf/simulated/floor/wood,
@@ -88,7 +88,7 @@
 /turf/simulated/mineral/floor/cave,
 /area/submap/Speakeasy)
 "D" = (
-/obj/structure/bed/chair/sofa/black/corner{
+/obj/structure/bed/chair/sofa/corner/black{
 	dir = 4
 	},
 /turf/simulated/floor/wood,
@@ -141,7 +141,7 @@
 /turf/simulated/floor/wood,
 /area/submap/Speakeasy)
 "U" = (
-/obj/structure/bed/chair/sofa/blue/right{
+/obj/structure/bed/chair/sofa/right/blue{
 	dir = 1
 	},
 /turf/simulated/floor/wood,

--- a/maps/submaps/surface_submaps/wilderness/emptycabin.dmm
+++ b/maps/submaps/surface_submaps/wilderness/emptycabin.dmm
@@ -35,7 +35,7 @@
 /turf/simulated/floor/wood/sif,
 /area/submap/EmptyCabin)
 "i" = (
-/obj/structure/bed/chair/sofa/blue/left{
+/obj/structure/bed/chair/sofa/left/blue{
 	dir = 1
 	},
 /turf/simulated/floor/wood/sif,
@@ -135,7 +135,7 @@
 /turf/simulated/floor/wood/sif,
 /area/submap/EmptyCabin)
 "J" = (
-/obj/structure/bed/chair/sofa/blue/right{
+/obj/structure/bed/chair/sofa/right/blue{
 	dir = 1
 	},
 /turf/simulated/floor/wood/sif,


### PR DESCRIPTION
Sofas used to have really weird subtypes, now they correctly inherit from either the base (middle), left, right, or corner, which solves the issue with layers on the non-red corner sofas (which red sofas were exempt from due to them being the base object type which other sofas were *supposed* to inherit from).

This Fixes #12154.