### PR TITLE
Craftable matiral  shields

### DIFF
--- a/code/game/objects/items/weapons/material/shield_vr.dm
+++ b/code/game/objects/items/weapons/material/shield_vr.dm
@@ -2,8 +2,7 @@
 	name = "makeshift shield"
 	desc = "A makeshift shield"
 	icon = 'icons/obj/weapons.dmi'
-	icon_state = "eshield"
-	item_state = "eshield"
+	icon_state = "riot"
 	force_divisor = 0.07
 	sharp = FALSE
 	attack_verb = list ("attacked", "bashed", "smacked", "bonked", "spanked")

--- a/code/game/objects/items/weapons/material/shield_vr.dm
+++ b/code/game/objects/items/weapons/material/shield_vr.dm
@@ -1,0 +1,16 @@
+/obj/item/weapon/material/sword/shield
+	name = "makeshift shield"
+	desc = "A makeshift shield"
+	icon = 'icons/obj/weapons.dmi'
+	icon_state = "eshield"
+	item_state = "eshield"
+	force_divisor = 0.07
+	sharp = FALSE
+	attack_verb = list ("attacked", "bashed", "smacked", "bonked", "spanked")
+
+/obj/item/weapon/material/sword/handle_shield(mob/user, var/damage, atom/damage_source = null, mob/attacker = null, var/def_zone = null, var/attack_text = "the attack")
+	if(unique_parry_check((user*10), attacker, damage_source) && prob(50))
+		user.visible_message("<span class='danger'>\The [user] parries [attack_text] with \the [src]!</span>")
+		playsound(src, 'sound/weapons/punchmiss.ogg', 50, 1)
+		return 1
+	return 0

--- a/code/modules/materials/materials/_materials.dm
+++ b/code/modules/materials/materials/_materials.dm
@@ -109,7 +109,7 @@ var/list/name_to_material
 	var/datum/material/key = arguments[1]
 	if(istype(key))
 		return key // we want to convert anything we're given to a material
-	
+
 	if(istext(key))	// text ID
 		. = name_to_material[key]
 		if(!.)
@@ -347,7 +347,8 @@ var/list/name_to_material
 		new /datum/stack_recipe("[display_name] armor plate insert", /obj/item/weapon/material/armor_plating/insert, 2, time = 40, on_floor = 1, supplied_material = "[name]", pass_stack_color = TRUE),
 		new /datum/stack_recipe("[display_name] grave marker", /obj/item/weapon/material/gravemarker, 5, time = 50, supplied_material = "[name]", pass_stack_color = TRUE),
 		new /datum/stack_recipe("[display_name] ring", /obj/item/clothing/gloves/ring/material, 1, on_floor = 1, supplied_material = "[name]", pass_stack_color = TRUE),
-		new /datum/stack_recipe("[display_name] bracelet", /obj/item/clothing/accessory/bracelet/material, 1, on_floor = 1, supplied_material = "[name]", pass_stack_color = TRUE)
+		new /datum/stack_recipe("[display_name] bracelet", /obj/item/clothing/accessory/bracelet/material, 1, on_floor = 1, supplied_material = "[name]", pass_stack_color = TRUE),
+		new /datum/stack_recipe("[display_name] shield", /obj/item/weapon/material/sword/shield, 30, on_floor = 1, supplied_material = "[name]", pass_stack_color = TRUE),
 	)
 
 	if(integrity>=50)

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -1380,6 +1380,7 @@
 #include "code\game\objects\items\weapons\material\misc.dm"
 #include "code\game\objects\items\weapons\material\shards.dm"
 #include "code\game\objects\items\weapons\material\shards_vr.dm"
+#include "code\game\objects\items\weapons\material\shield_vr.dm"
 #include "code\game\objects\items\weapons\material\swords.dm"
 #include "code\game\objects\items\weapons\material\thrown.dm"
 #include "code\game\objects\items\weapons\material\twohanded.dm"


### PR DESCRIPTION
Currently uses the same parry chance as swords made out of the same material. Using some math however they do a 1/10 of the damage offensively. They currently cost 30 sheets to make

They currently use the riot sheild spirte (coloured to the material you used) Hopefully someone who can code better can get them in the crafting menu and be a bit more complicated to make. And I still need to get round to a more swash buckiler sprite for them