### PR TITLE
reworks 'sword' crate

### DIFF
--- a/code/datums/supplypacks/misc_vr.dm
+++ b/code/datums/supplypacks/misc_vr.dm
@@ -158,16 +158,3 @@
 	cost = 300
 	containertype = /obj/structure/closet/crate
 	containername = "cordless jukebox speakers crate"
-
-/datum/supply_pack/misc/sword
-	name = "sword"
-	contains = list(
-	/obj/item/weapon/material/sword =2
-	)
-	cost =100
-	access = list(access_explorer,
-				  access_security,)
-
-	one_access = TRUE
-	containername = "sword crate"
-	containertype = /obj/structure/closet/crate/secure/gear

--- a/code/datums/supplypacks/munitions.dm
+++ b/code/datums/supplypacks/munitions.dm
@@ -187,6 +187,14 @@
 	containername = "Magnetic ammunition crate"
 	access = access_security
 
+/datum/supply_pack/munitions/claymore
+	name = "Weapons - Melee - Claymores"
+	contains = list(/obj/item/weapon/material/sword = 2)
+	cost = 150
+	containertype = /obj/structure/closet/crate/secure/weapon
+	containername = "Claymore crate"
+	access = access_armory //two swords that are a one-hit 40 brute + IB chance should be armory-locked
+
 /datum/supply_pack/munitions/shotgunammo
 	name = "Ammunition - Shotgun shells"
 	contains = list(


### PR DESCRIPTION
- gives it an actual name that's not just 'sword'
- moves it from miscellaneous tab to munitions (where all other weapons are)
- makes its crate match other weapon crates
- strips explo & base sec access, makes it warden access
- 50 points more expensive

**about access and price tweaks**
claymores are OP, plain and simple. steel claymores are 40 brute damage on a base human, with a chance of IB, in one hit. with the mats fridge, it's easy to get roundstart dura to turn them into durasteel claymore, which are 80 brute per hit on a base human. they also have a parry chance that makes them extremely appealing for PvE (and for very rare cases of PvP).
as such, i felt they should be a smidge more expensive (though that can be reverted if asked), and put on the same level as other weapons available in cargo. why such powerful swords were made explo and base sec access in the first place, i've no idea, but it's kind of baffling.