### PR TITLE
hiden storage book

### DIFF
--- a/code/game/objects/items/weapons/storage/boxes_vr.dm
+++ b/code/game/objects/items/weapons/storage/boxes_vr.dm
@@ -36,3 +36,11 @@
 
 /obj/item/weapon/storage/box/brainzsnax/red
 	starts_with = list(/obj/item/weapon/reagent_containers/food/snacks/canned/brainzsnax/red = 6)
+
+/obj/item/weapon/storage/box/book
+	name = "storage box"
+	desc = "a hollow box for storage"
+	icon = 'icons/obj/library.dmi'
+	icon_state = "book1"
+	drop_sound = 'sound/bureaucracy/bookclose.ogg'
+	w_class = ITEMSIZE_NORMAL

--- a/code/game/objects/items/weapons/storage/boxes_vr.dm
+++ b/code/game/objects/items/weapons/storage/boxes_vr.dm
@@ -44,3 +44,4 @@
 	icon_state = "book1"
 	drop_sound = 'sound/bureaucracy/bookclose.ogg'
 	w_class = ITEMSIZE_NORMAL
+	var/max_storage_space = ITEMSIZE_COST_SMALL * 4

--- a/code/game/objects/items/weapons/storage/boxes_vr.dm
+++ b/code/game/objects/items/weapons/storage/boxes_vr.dm
@@ -44,4 +44,4 @@
 	icon_state = "book1"
 	drop_sound = 'sound/bureaucracy/bookclose.ogg'
 	w_class = ITEMSIZE_NORMAL
-	var/max_storage_space = ITEMSIZE_COST_SMALL * 4
+	max_storage_space = ITEMSIZE_COST_SMALL * 4

--- a/code/modules/client/preference_setup/loadout/loadout_utility_vr.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_utility_vr.dm
@@ -81,3 +81,8 @@
 	path = /obj/item/weapon/storage/backpack/satchel/strapless
 	slot = slot_back
 	cost = 1
+
+/datum/gear/utility/storage/box/book
+	display_name = "storage book"
+	path = /obj/item/weapon/storage/box/book
+	cost = 3


### PR DESCRIPTION
Did you know when a chaplin spawns the game changes all bibles to their holy book? And has some gibbing code.

Well this is just a box with smaller space, but looks like a book.  Useful if your charater has maint trash to smuggle or you charater just wants an important book to them.

It costs 3 points from the loadout menu, it's the same size as the 2 point fanny pack and is hidden/harder to spot so gets +1 like the bluespace badge of holding compared to webbing. 