### PR TITLE
Item Bank - Do not store things crafted from material stacks

### DIFF
--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -212,7 +212,11 @@
 
 		O.set_dir(user.dir)
 		O.add_fingerprint(user)
-
+		//VOREStation Addition Start - Let's not store things that get crafted with materials like this, they won't spawn correctly when retrieved.
+		if (isobj(O))
+			var/obj/P = O
+			P.persist_storable = FALSE
+		//VOREStation Addition End
 		if (istype(O, /obj/item/stack))
 			var/obj/item/stack/S = O
 			S.amount = produced


### PR DESCRIPTION
The item bank doesn't store what such things are made out of, and so, such things will not be correct when retrieved. 

This does not block things from being stored when made from the common crafting menu though, since those things spawn a defined item type instead of setting up material properties. 