### PR TITLE
Analyzer information upgrade

### DIFF
--- a/code/_helpers/atmospherics.dm
+++ b/code/_helpers/atmospherics.dm
@@ -21,8 +21,9 @@
 		var/total_moles = mixture.total_moles
 		results += "<span class='notice'>Pressure: [round(pressure,0.1)] kPa</span>"
 		for(var/mix in mixture.gas)
-			results += "<span class='notice'>[gas_data.name[mix]]: [round((mixture.gas[mix] / total_moles) * 100)]%</span>"
+			results += "<span class='notice'>[gas_data.name[mix]]: [round((mixture.gas[mix] / total_moles) * 100)]% ([round(mixture.gas[mix], 0.01)] moles)</span>"
 		results += "<span class='notice'>Temperature: [round(mixture.temperature-T0C)]&deg;C</span>"
+		results += "<span class='notice'>Heat Capacity: [round(mixture.heat_capacity(),0.1)]</span>"
 	else
 		results += "<span class='notice'>\The [target] is empty!</span>"
 


### PR DESCRIPTION
Atmospheric analyzers can now show mole count & heat capacity of the local area & containers they're used on.

An example of what this looks like in practice - 
![image](https://user-images.githubusercontent.com/24844135/155829139-f38c1045-e2fd-4e04-8011-bcc88ea484d0.png)


