### PR TITLE
Change painting persist decay

### DIFF
--- a/code/game/objects/structures/artstuff.dm
+++ b/code/game/objects/structures/artstuff.dm
@@ -336,6 +336,7 @@
 	var/persistence_id
 	var/loaded = FALSE
 	var/curator = "nobody! Report bug if you see this."
+	var/static/list/art_appreciators = list()
 
 //Presets for art gallery mapping, for paintings to be shared across stations
 /obj/structure/sign/painting/public
@@ -406,11 +407,12 @@
 	if(current_canvas)
 		current_canvas.tgui_interact(user)
 		. += "<span class='notice'>Use wirecutters to remove the painting.</span>"
-
+		. += "<span class='notice'>Paintings hung here are curated based on interest. The more often someone EXAMINEs the painting, the longer it will stay in rotation.</span>"
 		// Painting loaded and persistent frame, give a hint about removal safety
 		if(persistence_id)
 			if(loaded)
-				. += "<span class='notice'>Don't worry, the currently framed painting has already been entered into the archives and can be safely removed. It will still be used on future shifts.</span>"
+				. += "<span class='warning'>Don't worry, the currently framed painting has already been entered into the archives and can be safely removed. It will still be used on future shifts.</span>"
+				back_of_the_line(user)
 			else
 				. += "<span class='warning'>This painting has not been entered into the archives yet. Removing it will prevent that from happening.</span>"
 
@@ -553,6 +555,20 @@
 		"author" = current_canvas.author_name,
 		"ckey" = current_canvas.author_ckey
 	))
+
+/obj/structure/sign/painting/proc/back_of_the_line(mob/user)
+	if(user.ckey in art_appreciators)
+		return
+	if(!persistence_id || !current_canvas || current_canvas.no_save)
+		return
+	var/data = current_canvas.get_data_string()
+	var/md5 = md5(lowertext(data))
+	for(var/list/entry in SSpersistence.all_paintings)
+		if(entry["md5"] == md5 && entry["persistence_id"] == persistence_id)
+			SSpersistence.all_paintings.Remove(list(entry))
+			SSpersistence.all_paintings.Add(list(entry))
+			art_appreciators += user.ckey
+			to_chat(user, "<span class='notice'>Showing interest in this painting renews its position in the curator database.</span>")
 
 /obj/structure/sign/painting/vv_get_dropdown()
 	. = ..()

--- a/code/modules/persistence/paintings.dm
+++ b/code/modules/persistence/paintings.dm
@@ -1,6 +1,7 @@
 /datum/persistent/paintings
 	name = "paintings"
-	entries_expire_at = 1000 // Basically forever
+	//entries_expire_at = 1000 // Basically forever
+	var/max_entries = 1000 //1000 paintings is a lot, and will take a long time to cycle through.
 
 /datum/persistent/paintings/SetFilename()
     filename = "data/persistent/paintings.json"
@@ -14,7 +15,7 @@
 			token["age"]++ // Increment age!
 			if(!CheckTokenSanity(token))
 				tokens -= token
-	
+
 	SSpersistence.unpicked_paintings = SSpersistence.all_paintings.Copy()
 	
 	for(var/obj/structure/sign/painting/P in SSpersistence.painting_frames)
@@ -24,13 +25,28 @@
 	var/png_filename = "data/paintings/[token["persistence_id"]]/[token["md5"]].png"
 	if(!fexists(png_filename))
 		return FALSE
-	if(token["age"] > entries_expire_at)
-		fdel(png_filename)
-		return FALSE
+//	if(token["age"] > entries_expire_at)
+//		fdel(png_filename)
+//		return FALSE
 
 /datum/persistent/paintings/Shutdown()
 	for(var/obj/structure/sign/painting/P in SSpersistence.painting_frames)
 		P.save_persistent()
+
+	if(SSpersistence.all_paintings.len > max_entries)
+		var/this_many = SSpersistence.all_paintings.len
+		var/over = this_many - max_entries
+		log_admin("There are [over] more painting(s) stored than the maximum allowed.")
+		while(over > 0)
+			var/list/d = SSpersistence.all_paintings[1]
+			var/png_filename = "data/paintings/[d["persistence_id"]]/[d["md5"]].png"
+			fdel(png_filename)
+			if(SSpersistence.all_paintings.Remove(list(d)))
+				log_admin("A painting was deleted")
+			else
+				log_and_message_admins("Attempted to delete a painting, but failed.")
+			over --
+
 
 	if(fexists(filename))
 		fdel(filename)


### PR DESCRIPTION
Instead of paintings lasting 1000 shifts before being deleted

Now the system will store up to 1000 paintings, and remove the one at the top of the list (the earliest/oldest one) first when the maximum number of paintings is exceeded. 

Additionally, examining a painting that has been stored will move it to the bottom of the list, effectively renewing its lease in the system. 

This should make it so that paintings aren't just arbitrarily being removed for being old, and, the paintings that actually get looked at should stick around.