### PR TITLE
item bank - blacklists Alien Circuits

### DIFF
--- a/code/modules/client/stored_item.dm
+++ b/code/modules/client/stored_item.dm
@@ -232,6 +232,8 @@
 	persist_storable = FALSE
 /obj/item/weapon/melee/cursedblade
 	persist_storable = FALSE
+/obj/item/weapon/circuitboard/mecha/imperion
+	persist_storable = FALSE
 /obj/item/device/paicard
 	persist_storable = FALSE
 /obj/item/organ


### PR DESCRIPTION
storing those only allows people to get precursor tech roundstart, instead of having someone do xenoarch for it. 
that's stupid and goes against what the bank is for, especially when there's like 5 randomized ones that can be printed in rnd, allowing people to just put a different subtype back in once they've used the one retrieved.