### PR TITLE
Allowing Morphs to Control Borgs

### DIFF
--- a/code/modules/mob/living/simple_mob/subtypes/vore/morph/morph.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/morph/morph.dm
@@ -265,7 +265,6 @@
 	var/list/possible_mobs = list()
 	for(var/obj/belly/B in src.vore_organs)
 		for(var/mob/living/H in B)
-			//if(ishuman(H) && H.ckey)
 			if( (ishuman(H) || isrobot(H)) && H.ckey )
 				possible_mobs += H
 			else
@@ -277,6 +276,7 @@
 		M = input
 		if(!M)
 			return
+		// Adding a ishuman check here, since silicon mobs don't have a resleeve_lock from what I can tell.
 		if(ishuman(M))
 			if(M.resleeve_lock && ckey != M.resleeve_lock)
 				to_chat(src, "<span class='warning'>\The [M] cannot be impersonated!</span>")

--- a/code/modules/mob/living/simple_mob/subtypes/vore/morph/morph.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/morph/morph.dm
@@ -264,8 +264,9 @@
 		return
 	var/list/possible_mobs = list()
 	for(var/obj/belly/B in src.vore_organs)
-		for(var/mob/living/carbon/human/H in B)
-			if(ishuman(H) && H.ckey)
+		for(var/mob/living/H in B)
+			//if(ishuman(H) && H.ckey)
+			if( (ishuman(H) || isrobot(H)) && H.ckey )
 				possible_mobs += H
 			else
 				continue
@@ -276,9 +277,10 @@
 		M = input
 		if(!M)
 			return
-		if(M.resleeve_lock && ckey != M.resleeve_lock)
-			to_chat(src, "<span class='warning'>\The [M] cannot be impersonated!</span>")
-			return
+		if(ishuman(M))
+			if(M.resleeve_lock && ckey != M.resleeve_lock)
+				to_chat(src, "<span class='warning'>\The [M] cannot be impersonated!</span>")
+				return
 		if(tgui_alert(src, "You selected [M] to attempt to take over. Are you sure?", "Take Over Prey",list("No","Yes")) == "Yes")
 			log_admin("[key_name_admin(src)] offered [M] to swap bodies as a morph.")
 			if(tgui_alert(M, "\The [src] has elected to attempt to take over your body and control you. Is this something you will allow to happen?", "Allow Morph To Take Over",list("No","Yes")) == "Yes")


### PR DESCRIPTION
This generalizes the mob variables for morph control, allowing silicon mobs (Borgs only for now) to also be controlled.

Technically simple mobs can also be made to work, but mobs without a default belly cause issues with the swap, therefore only borgs and carbon mobs are allowed for now.