### PR TITLE
SD - adds a box of mining nifsoft uploaders to mining prep

### DIFF
--- a/maps/stellardelight/stellar_delight1.dmm
+++ b/maps/stellardelight/stellar_delight1.dmm
@@ -18290,6 +18290,11 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/stellardelight/deck1/shower)
+"Na" = (
+/obj/item/weapon/storage/box/nifsofts_mining,
+/obj/structure/table/reinforced,
+/turf/simulated/floor/tiled/eris/steel/cargo,
+/area/stellardelight/deck1/miningequipment)
 "Nb" = (
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/blast/angled{
@@ -33583,7 +33588,7 @@ dl
 QK
 pV
 xf
-qV
+Na
 MG
 vC
 vi


### PR DESCRIPTION
could have sworn they were added in, but apparently not
removes a suit cycler to make room for a table but like, no one needs two cyclers. if they do, they can just take turns on the only cycler.