### PR TITLE
stop double posting ooc notes

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -335,11 +335,6 @@
 		log_runtime(EXCEPTION("Warning: human/Topic was called with item [href_list["item"]], but the item Topic is deprecated!"))
 		// handle_strip(href_list["item"],usr)
 
-	// VOREStation Start
-	if(href_list["ooc_notes"])
-		src.Examine_OOC()
-	// VOREStation End
-
 	if (href_list["criminal"])
 		if(hasHUD(usr,"security"))
 


### PR DESCRIPTION
I moved the code to mob/living so more things can have ooc notes and didn't realize it was double posting them when you push the button. This fixes that.