### PR TITLE
Fixes item digestion vore stat count

### DIFF
--- a/code/modules/vore/eating/belly_obj_vr.dm
+++ b/code/modules/vore/eating/belly_obj_vr.dm
@@ -797,7 +797,7 @@
 					continue
 				prey.languages += L
 				prey.temp_languages += L
-				
+
 ////////////////////////////////////////////////////////////////////////
 
 
@@ -810,7 +810,6 @@
 		items_preserved |= item
 	else
 		owner.adjust_nutrition((nutrition_percent / 100) * 5 * digested)
-		GLOB.items_digested_roundstat++
 		if(isrobot(owner))
 			var/mob/living/silicon/robot/R = owner
 			R.cell.charge += ((nutrition_percent / 100) * 50 * digested)

--- a/code/modules/vore/eating/digest_act_vr.dm
+++ b/code/modules/vore/eating/digest_act_vr.dm
@@ -19,6 +19,7 @@
 					qdel(O)
 			else if(item_storage)
 				O.forceMove(item_storage)
+		GLOB.items_digested_roundstat++
 		qdel(src)
 		return w_class
 
@@ -57,6 +58,7 @@
 				S.use(1)
 				digest_stage = w_class
 		else
+			GLOB.items_digested_roundstat++
 			qdel(src)
 	if(g_damage > w_class)
 		return w_class


### PR DESCRIPTION
Makes the stat count the things when the item is actually digested instead of counting every tick of partial digestion that may have affected it.