### PR TITLE
Grabbing Borgs

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -778,6 +778,22 @@
 					playsound(src.loc, 'sound/effects/bang.ogg', 10, 1)
 					visible_message("<span class='warning'>[H] punches [src], but doesn't leave a dent.</span>")
 					return
+			if(I_GRAB)
+				if (user == src)
+					return
+				if (!(status_flags)) //& CANPUSH))
+					return
+
+				var/obj/item/weapon/grab/G = new /obj/item/weapon/grab(user, src)
+
+				user.put_in_active_hand(G)
+
+				G.synch()
+				G.affecting = src
+				LAssailant = user
+
+				user.visible_message("<span class='warning'>\The [user] has grabbed [src] passively!</span>")
+				user.do_attack_animation(src)
 			if(I_DISARM)
 				H.do_attack_animation(src)
 				playsound(src.loc, 'sound/effects/clang2.ogg', 10, 1)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -781,7 +781,7 @@
 			if(I_GRAB)
 				if (user == src)
 					return
-				if (!(status_flags)) //& CANPUSH))
+				if (!(status_flags && CANPUSH))
 					return
 
 				var/obj/item/weapon/grab/G = new /obj/item/weapon/grab(user, src)

--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -78,7 +78,7 @@
 		if(affecting.buckled)
 			return null
 		if(state >= GRAB_AGGRESSIVE)
-			animate(affecting, pixel_x = initial(affecting.pixel_x), pixel_y = initial(affecting.pixel_y), 4, 1)
+			animate(affecting, pixel_x = initial(affecting.default_pixel_x), pixel_y = initial(affecting.default_pixel_y), 4, 1)
 			return affecting
 
 	return null
@@ -194,10 +194,10 @@
 		qdel(src)
 		return
 	if(affecting.buckled)
-		animate(affecting, pixel_x = initial(affecting.pixel_x), pixel_y = initial(affecting.pixel_y), 4, 1, LINEAR_EASING)
+		animate(affecting, pixel_x = initial(affecting.default_pixel_x), pixel_y = initial(affecting.default_pixel_y), 4, 1, LINEAR_EASING)
 		return
 	if(affecting.lying && state != GRAB_KILL)
-		animate(affecting, pixel_x = initial(affecting.pixel_x), pixel_y = initial(affecting.pixel_y), 5, 1, LINEAR_EASING)
+		animate(affecting, pixel_x = initial(affecting.default_pixel_x), pixel_y = initial(affecting.default_pixel_y), 5, 1, LINEAR_EASING)
 		if(force_down)
 			affecting.set_dir(SOUTH) //face up
 		return
@@ -225,14 +225,14 @@
 
 	switch(adir)
 		if(NORTH)
-			animate(affecting, pixel_x = initial(affecting.pixel_x), pixel_y =-shift, 5, 1, LINEAR_EASING)
+			animate(affecting, pixel_x = initial(affecting.default_pixel_x), pixel_y =-shift, 5, 1, LINEAR_EASING)
 			affecting.layer = BELOW_MOB_LAYER
 		if(SOUTH)
-			animate(affecting, pixel_x = initial(affecting.pixel_x), pixel_y = shift, 5, 1, LINEAR_EASING)
+			animate(affecting, pixel_x = initial(affecting.default_pixel_x), pixel_y = shift, 5, 1, LINEAR_EASING)
 		if(WEST)
-			animate(affecting, pixel_x = shift, pixel_y = initial(affecting.pixel_y), 5, 1, LINEAR_EASING)
+			animate(affecting, pixel_x = shift, pixel_y = initial(affecting.default_pixel_y), 5, 1, LINEAR_EASING)
 		if(EAST)
-			animate(affecting, pixel_x =-shift, pixel_y = initial(affecting.pixel_y), 5, 1, LINEAR_EASING)
+			animate(affecting, pixel_x =-shift, pixel_y = initial(affecting.default_pixel_y), 5, 1, LINEAR_EASING)
 
 /obj/item/weapon/grab/proc/s_click(obj/screen/S)
 	if(QDELETED(src))
@@ -403,7 +403,7 @@
 	return mob_size_difference(A.mob_size, B.mob_size)
 
 /obj/item/weapon/grab/Destroy()
-	animate(affecting, pixel_x = initial(affecting.pixel_x), pixel_y = initial(affecting.pixel_y), 4, 1, LINEAR_EASING)
+	animate(affecting, pixel_x = initial(affecting.default_pixel_x), pixel_y = initial(affecting.default_pixel_y), 4, 1, LINEAR_EASING)
 	affecting.reset_plane_and_layer()
 	if(affecting)
 		affecting.grabbed_by -= src

--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -78,7 +78,7 @@
 		if(affecting.buckled)
 			return null
 		if(state >= GRAB_AGGRESSIVE)
-			animate(affecting, pixel_x = initial(affecting.default_pixel_x), pixel_y = initial(affecting.default_pixel_y), 4, 1)
+			animate(affecting, pixel_x = affecting.default_pixel_x, pixel_y = affecting.default_pixel_y, 4, 1)
 			return affecting
 
 	return null
@@ -194,10 +194,10 @@
 		qdel(src)
 		return
 	if(affecting.buckled)
-		animate(affecting, pixel_x = initial(affecting.default_pixel_x), pixel_y = initial(affecting.default_pixel_y), 4, 1, LINEAR_EASING)
+		animate(affecting, pixel_x = affecting.default_pixel_x, pixel_y = affecting.default_pixel_y, 4, 1, LINEAR_EASING)
 		return
 	if(affecting.lying && state != GRAB_KILL)
-		animate(affecting, pixel_x = initial(affecting.default_pixel_x), pixel_y = initial(affecting.default_pixel_y), 5, 1, LINEAR_EASING)
+		animate(affecting, pixel_x = affecting.default_pixel_x, pixel_y = affecting.default_pixel_y, 5, 1, LINEAR_EASING)
 		if(force_down)
 			affecting.set_dir(SOUTH) //face up
 		return
@@ -225,14 +225,14 @@
 
 	switch(adir)
 		if(NORTH)
-			animate(affecting, pixel_x = initial(affecting.default_pixel_x), pixel_y =-shift, 5, 1, LINEAR_EASING)
+			animate(affecting, pixel_x = affecting.default_pixel_x, pixel_y = affecting.default_pixel_y - shift, 5, 1, LINEAR_EASING)
 			affecting.layer = BELOW_MOB_LAYER
 		if(SOUTH)
-			animate(affecting, pixel_x = initial(affecting.default_pixel_x), pixel_y = shift, 5, 1, LINEAR_EASING)
+			animate(affecting, pixel_x = affecting.default_pixel_x, pixel_y = affecting.default_pixel_y + shift, 5, 1, LINEAR_EASING)
 		if(WEST)
-			animate(affecting, pixel_x = shift, pixel_y = initial(affecting.default_pixel_y), 5, 1, LINEAR_EASING)
+			animate(affecting, pixel_x = affecting.default_pixel_x + shift, pixel_y = affecting.default_pixel_y, 5, 1, LINEAR_EASING)
 		if(EAST)
-			animate(affecting, pixel_x =-shift, pixel_y = initial(affecting.default_pixel_y), 5, 1, LINEAR_EASING)
+			animate(affecting, pixel_x = affecting.default_pixel_x - shift, pixel_y = affecting.default_pixel_y, 5, 1, LINEAR_EASING)
 
 /obj/item/weapon/grab/proc/s_click(obj/screen/S)
 	if(QDELETED(src))
@@ -403,7 +403,7 @@
 	return mob_size_difference(A.mob_size, B.mob_size)
 
 /obj/item/weapon/grab/Destroy()
-	animate(affecting, pixel_x = initial(affecting.default_pixel_x), pixel_y = initial(affecting.default_pixel_y), 4, 1, LINEAR_EASING)
+	animate(affecting, pixel_x = affecting.default_pixel_x, pixel_y = affecting.default_pixel_y, 4, 1, LINEAR_EASING)
 	affecting.reset_plane_and_layer()
 	if(affecting)
 		affecting.grabbed_by -= src

--- a/code/modules/vore/eating/bellymodes_vr.dm
+++ b/code/modules/vore/eating/bellymodes_vr.dm
@@ -167,7 +167,7 @@
 			var/mob/living/L = A
 			touchable_mobs += L
 
-			if(L.absorbed)
+			if(L.absorbed && !issilicon(L))
 				L.Weaken(5)
 
 			// Fullscreen overlays
@@ -276,7 +276,7 @@
 
 	if(M.ckey)
 		GLOB.prey_digested_roundstat++
-	
+
 	if((mode_flags & DM_FLAG_LEAVEREMAINS) && M.digest_leave_remains)
 		handle_remains_leaving(M)
 	digestion_death(M)

--- a/code/modules/vore/eating/living_vr.dm
+++ b/code/modules/vore/eating/living_vr.dm
@@ -94,7 +94,7 @@
 		var/obj/item/weapon/grab/G = I
 
 		//Has to be aggressive grab, has to be living click-er and non-silicon grabbed
-		if(G.state >= GRAB_AGGRESSIVE && (isliving(user) && !issilicon(G.affecting)))
+		if(G.state >= GRAB_AGGRESSIVE && (isliving(user) ))
 			var/mob/living/attacker = user  // Typecast to living
 
 			// src is the mob clicked on and attempted predator
@@ -566,7 +566,7 @@
 	var/air_type = /datum/gas_mixture/belly_air
 	if(istype(lifeform))	// If this doesn't succeed, then 'lifeform' is actually a bag or capture crystal with someone inside
 		air_type = lifeform.get_perfect_belly_air_type()		// Without any overrides/changes, its gonna be /datum/gas_mixture/belly_air
-	
+
 	var/air = new air_type(1000)
 	return air
 

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -4107,6 +4107,6 @@
 #include "maps\submaps\space_submaps\debrisfield\debrisfield.dm"
 #include "maps\submaps\surface_submaps\wilderness\wilderness.dm"
 #include "maps\submaps\surface_submaps\wilderness\wilderness_areas.dm"
-#include "maps\virgo_minitest\virgo_minitest.dm"
+#include "maps\tether\tether.dm"
 #include "maps\~map_system\maps.dm"
 // END_INCLUDE

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -4107,6 +4107,6 @@
 #include "maps\submaps\space_submaps\debrisfield\debrisfield.dm"
 #include "maps\submaps\surface_submaps\wilderness\wilderness.dm"
 #include "maps\submaps\surface_submaps\wilderness\wilderness_areas.dm"
-#include "maps\tether\tether.dm"
+#include "maps\virgo_minitest\virgo_minitest.dm"
 #include "maps\~map_system\maps.dm"
 // END_INCLUDE


### PR DESCRIPTION
This changes grab and vore mechanics to allow for grabbing and eating borgs.

It also adjusts absorption on borgs, preventing the borg from being rendered unconscious while absorbed. This fixes #12374

Grab mechanics are changed slightly, for some reason they were using the initial value of pixel_x and pixel_y, instead of the much better default_pixel_x and default_pixel_y, this allows for grabbing pixel offset sprites such as dogborgs to behave properly.

TL;DR, eat the puppers