### PR TITLE
Borg Prey and Borg Feeding

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -784,9 +784,23 @@
 				visible_message("<span class='warning'>[H] taps [src].</span>")
 				return
 			if(I_GRAB)
-				if(is_vore_predator(H))
-					if(src.devourable)
+				if(is_vore_predator(H) && H.devourable && src.feeding && src.devourable)
+					var/switchy = tgui_alert(H, "Do you wish to eat [src] or feed yourself to them?", "Feed or Eat",list("Eat","Feed", "Nevermind!")
+					switch(switchy)
+					if("Nevermind!")
+						return
+					if("Eat")
 						feed_grabbed_to_self(H, src)
+						return
+					if("Feed")
+						H.feed_self_to_grabbed(H, src)
+						return
+				if(is_vore_predator(H) && src.devourable)
+					if(tgui_alert(H, "Do you wish to eat [src]?", "Eat?",list("Yes!", "Nevermind!")) == "Yes!")
+						feed_grabbed_to_self(H, src)
+						return
+				if(H.devourable && src.feeding)
+					if(tgui_alert(H, "Do you wish to feed yourself to [src]?", "Feed?",list("Yes!", "Nevermind!")) == "Yes!")
 
 //Robots take half damage from basic attacks.
 /mob/living/silicon/robot/attack_generic(var/mob/user, var/damage, var/attack_message)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -783,6 +783,10 @@
 				playsound(src.loc, 'sound/effects/clang2.ogg', 10, 1)
 				visible_message("<span class='warning'>[H] taps [src].</span>")
 				return
+			if(I_GRAB)
+				if(is_vore_predator(H))
+					if(src.devourable)
+						feed_grabbed_to_self(H, src)
 
 //Robots take half damage from basic attacks.
 /mob/living/silicon/robot/attack_generic(var/mob/user, var/damage, var/attack_message)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -785,22 +785,24 @@
 				return
 			if(I_GRAB)
 				if(is_vore_predator(H) && H.devourable && src.feeding && src.devourable)
-					var/switchy = tgui_alert(H, "Do you wish to eat [src] or feed yourself to them?", "Feed or Eat",list("Eat","Feed", "Nevermind!")
+					var/switchy = tgui_alert(H, "Do you wish to eat [src] or feed yourself to them?", "Feed or Eat",list("Eat","Feed", "Nevermind!"))
 					switch(switchy)
-					if("Nevermind!")
-						return
-					if("Eat")
-						feed_grabbed_to_self(H, src)
-						return
-					if("Feed")
-						H.feed_self_to_grabbed(H, src)
-						return
+						if("Nevermind!")
+							return
+						if("Eat")
+							feed_grabbed_to_self(H, src)
+							return
+						if("Feed")
+							H.feed_self_to_grabbed(H, src)
+							return
 				if(is_vore_predator(H) && src.devourable)
 					if(tgui_alert(H, "Do you wish to eat [src]?", "Eat?",list("Yes!", "Nevermind!")) == "Yes!")
 						feed_grabbed_to_self(H, src)
 						return
 				if(H.devourable && src.feeding)
 					if(tgui_alert(H, "Do you wish to feed yourself to [src]?", "Feed?",list("Yes!", "Nevermind!")) == "Yes!")
+						H.feed_self_to_grabbed(H, src)
+						return
 
 //Robots take half damage from basic attacks.
 /mob/living/silicon/robot/attack_generic(var/mob/user, var/damage, var/attack_message)

--- a/code/modules/vore/eating/bellymodes_vr.dm
+++ b/code/modules/vore/eating/bellymodes_vr.dm
@@ -167,7 +167,7 @@
 			var/mob/living/L = A
 			touchable_mobs += L
 
-			if(L.absorbed)
+			if(L.absorbed && !issilicon(L))
 				L.Weaken(5)
 
 			// Fullscreen overlays
@@ -280,7 +280,7 @@
 
 	if(M.ckey)
 		GLOB.prey_digested_roundstat++
-	
+
 	if((mode_flags & DM_FLAG_LEAVEREMAINS) && M.digest_leave_remains)
 		handle_remains_leaving(M)
 	digestion_death(M)

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -4107,6 +4107,6 @@
 #include "maps\submaps\space_submaps\debrisfield\debrisfield.dm"
 #include "maps\submaps\surface_submaps\wilderness\wilderness.dm"
 #include "maps\submaps\surface_submaps\wilderness\wilderness_areas.dm"
-#include "maps\virgo_minitest\virgo_minitest.dm"
+#include "maps\tether\tether.dm"
 #include "maps\~map_system\maps.dm"
 // END_INCLUDE

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -4107,6 +4107,6 @@
 #include "maps\submaps\space_submaps\debrisfield\debrisfield.dm"
 #include "maps\submaps\surface_submaps\wilderness\wilderness.dm"
 #include "maps\submaps\surface_submaps\wilderness\wilderness_areas.dm"
-#include "maps\tether\tether.dm"
+#include "maps\virgo_minitest\virgo_minitest.dm"
 #include "maps\~map_system\maps.dm"
 // END_INCLUDE


### PR DESCRIPTION
Allows easy eating and feeding of borgs.

Clicking a borg on grab intent will run a pref check, if both players prefs align one of several confirmation dialogue boxes will open. Assuming it is confirmed, then it will run a standard nom with timer.

If the borg is feedable, devourable, and the carbon is devourable then they get the switch menu, allowing to pick if they wish to feed themselves to the borg or to eat the borg.

If the borg is feedable but not devourable and the carbon is devourable, then they get the feeding menu, asking confirmation if the carbon wishes to feed themselves to the borg.

And lastly, if the borg is not feedable but is devourable, then the carbon will get a confirmation window if they wish to eat the borg.

This also fixes #12374
Borgs will no longer be stunned when absorbed.