### PR TITLE
Fixes zaddat lunchbox adding extra hypos on loadout survival lunchbox

### DIFF
--- a/code/game/objects/items/weapons/storage/toolbox_vr.dm
+++ b/code/game/objects/items/weapons/storage/toolbox_vr.dm
@@ -7,4 +7,5 @@
 	max_storage_space = ITEMSIZE_COST_SMALL * 6
 
 /obj/item/weapon/storage/toolbox/lunchbox/survival/zaddat
+	name = "zaddat survival lunchbox"
 	starts_with = list(/obj/item/weapon/reagent_containers/hypospray/autoinjector/biginjector/glucose = 6)


### PR DESCRIPTION
Fixes zaddat survival lunchbox adding extra glucose hypos on all survival lunchboxes, or more specifically just overriding the loadout survival lunchbox. (i think byond's recently gotten a change that has suddenly unearthed all these sorta old bugs by prioritizing the latest unnamed child types of things whenever names are involved)