### PR TITLE
AI/Borgs and Shuttles

### DIFF
--- a/code/modules/overmap/ships/computers/computer_shims.dm
+++ b/code/modules/overmap/ships/computers/computer_shims.dm
@@ -50,6 +50,7 @@
 //
 /obj/machinery/computer/ship
 	var/core_skill = /datum/skill/devices //The skill used for skill checks for this machine (mostly so subtypes can use different skills).
+	var/ai_control = TRUE	//VOREStation Edit
 
 //
 // Topic
@@ -70,6 +71,11 @@
 	return TRUE
 
 /obj/machinery/computer/ship/attack_ai(mob/user)
+	//VOREStation Addition Start
+	if(!ai_control && issilicon(user))
+		to_chat(user, "<span class='warning'>Access Denied.</span>")
+		return
+	//VOREStation Addition End
 	if(tgui_status(user, tgui_state()) > STATUS_CLOSE)
 		return interface_interact(user)
 
@@ -82,6 +88,11 @@
 /obj/machinery/computer/ship/attack_hand(mob/user)
 	if((. = ..()))
 		return
+	//VOREStation Addition Start
+	if(!ai_control && issilicon(user))
+		to_chat(user, "<span class='warning'>Access Denied.</span>")
+		return TRUE
+	//VOREStation Addition End
 	if(!allowed(user))
 		to_chat(user, "<span class='warning'>Access Denied.</span>")
 		return TRUE

--- a/code/modules/overmap/ships/computers/helm.dm
+++ b/code/modules/overmap/ships/computers/helm.dm
@@ -29,6 +29,7 @@ GLOBAL_LIST_EMPTY(all_waypoints)
 	var/speedlimit = 1/(20 SECONDS) //top speed for autopilot, 5
 	var/accellimit = 0.001 //manual limiter for acceleration
 	req_one_access = list(access_pilot) //VOREStation Edit
+	ai_control = FALSE	//VOREStation Edit - AI/Borgs shouldn't really be flying off in ships without crew help
 
 // fancy sprite
 /obj/machinery/computer/ship/helm/adv

--- a/code/modules/shuttles/shuttle_console.dm
+++ b/code/modules/shuttles/shuttle_console.dm
@@ -10,10 +10,17 @@
 
 	var/skip_act = FALSE
 	var/tgui_subtemplate = "ShuttleControlConsoleDefault"
+	var/ai_control = FALSE	//VOREStation Edit - AI/Borgs shouldn't really be flying off in ships without crew help
 
 /obj/machinery/computer/shuttle_control/attack_hand(user as mob)
 	if(..(user))
 		return
+	//VOREStation Addition Start
+	if(!ai_control && issilicon(user))
+		to_chat(user, "<span class='warning'>Access Denied.</span>")
+		return TRUE
+	//VOREStation Addition End
+
 	//src.add_fingerprint(user)	//shouldn't need fingerprints just for looking at it.
 	if(!allowed(user))
 		to_chat(user, "<span class='warning'>Access Denied.</span>")

--- a/maps/tether/tether-03-surface3.dmm
+++ b/maps/tether/tether-03-surface3.dmm
@@ -23643,13 +23643,11 @@
 /turf/simulated/floor/plating,
 /area/bridge_hallway)
 "aNa" = (
-/obj/machinery/computer/shuttle_control/tether_backup{
-	req_one_access = list()
-	},
 /obj/effect/floor_decal/fancy_shuttle{
 	fancy_shuttle_tag = "lifeboat1";
 	name = "lifeboat1"
 	},
+/obj/machinery/computer/shuttle_control/tether_backup,
 /turf/simulated/floor/tiled,
 /area/shuttle/tether{
 	base_turf = /turf/simulated/floor/reinforced
@@ -39252,9 +39250,11 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/machinery/power/smes/buildable/point_of_interest,
 /obj/structure/cable/green{
 	icon_state = "0-8"
+	},
+/obj/machinery/power/smes/buildable{
+	charge = 500000
 	},
 /turf/simulated/floor/tiled,
 /area/shuttle/tourbus/general)

--- a/maps/tether/tether_shuttles.dm
+++ b/maps/tether/tether_shuttles.dm
@@ -5,7 +5,8 @@
 /obj/machinery/computer/shuttle_control/tether_backup
 	name = "tether backup shuttle control console"
 	shuttle_tag = "Tether Backup"
-	req_one_access = list(access_heads,access_pilot)
+	req_one_access = list()
+	ai_control = TRUE
 
 /obj/machinery/computer/shuttle_control/multi/mercenary
 	name = "vessel control console"


### PR DESCRIPTION
Replaces the tourbus SMES with the appropriate kind

Also, prevents AI/Borgs from accessing shortjump consoles on OM capable ships and helm consoles. 

In general, borgs should not be leaving the station to go fly around without crew there. And it's happened a number of times, that AI will get involved in ship operations if they have any camera they can see anywhere in there, even when the ship is far away, and in general I have never been a fan of AI piloting ships. (And they couldn't really do so very well anyway since they couldn't access the map.)

So! Now short jump consoles and helm control consoles require a person to fly, unless otherwise configured to allow it.