### PR TITLE
Adding Mining AOE PKA Upgrade to the Protolathe

### DIFF
--- a/code/modules/research/designs/mining_toys.dm
+++ b/code/modules/research/designs/mining_toys.dm
@@ -50,6 +50,7 @@
 	sort_string = "FBAAA"
 
 /datum/design/item/weapon/mining/upgradeAOE
+	name = "Mining Explosion Upgrade"
 	desc = "An area of effect upgrade for the Proto-Kinetic Accelerator."
 	id = "pka_mineaoe"
 	req_tech = list(TECH_COMBAT = 7, TECH_MATERIAL = 8, TECH_ENGINEERING = 7) // Lets make this endgame level tech, due to it's power.

--- a/code/modules/research/designs/mining_toys.dm
+++ b/code/modules/research/designs/mining_toys.dm
@@ -48,3 +48,11 @@
 	materials = list(MAT_STEEL = 1000,MAT_GLASS = 1000)
 	build_path = /obj/item/device/depth_scanner
 	sort_string = "FBAAA"
+
+/datum/design/item/weapon/mining/upgradeAOE
+	desc = "An area of effect upgrade for the Proto-Kinetic Accelerator."
+	id = "pka_mineaoe"
+	req_tech = list(TECH_COMBAT = 7, TECH_MATERIAL = 8, TECH_ENGINEERING = 7) // Lets make this endgame level tech, due to it's power.
+	materials = list(MAT_STEEL = 5000, MAT_GLASS = 5000, MAT_SILVER = 500, MAT_GOLD = 500, MAT_URANIUM = 2000, MAT_PHORON = 2000)
+	build_path = /obj/item/borg/upgrade/modkit/aoe/turfs
+	sort_string = "FAAF"


### PR DESCRIPTION
What it says on the tin, the Mining AOE Upgrade for the PKA is added to the protolathe so science can print nice stuff for miners who don't wanna use a phoron bore, or for mineborgs who want to be effective.

It requires Combat Level 7, Material Level 8 and Engineering Level 7 to ensure it can only be built after materials are delivered to science and RnD is done.