### PR TITLE
Atmos Extinguisher sprite fix

### DIFF
--- a/code/game/objects/items/weapons/extinguisher.dm
+++ b/code/game/objects/items/weapons/extinguisher.dm
@@ -47,7 +47,7 @@
 	force = 3.0
 	max_water = 600
 	spray_particles = 3
-	sprite_name = "atmo_extinguisher"
+	sprite_name = "atmos_extinguisher"
 	rand_overlays = 0
 
 /obj/item/weapon/extinguisher/Initialize()


### PR DESCRIPTION
Looks like someone forgot an "s" in the sprite name, leading to the item turning invisible after toggling the safety off. 
This should fix it.