### PR TITLE
Adds Submit To Prey Trait

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
@@ -500,3 +500,13 @@
 /datum/trait/neutral/dominate_prey/apply(var/datum/species/S,var/mob/living/carbon/human/H)
 	..(S,H)
 	H.verbs |= /mob/living/proc/dominate_prey
+
+/datum/trait/neutral/submit_to_prey
+	name = "Submit To Prey"
+	desc = "Allow prey's mind to control your own body."
+	cost = 0
+	custom_only = FALSE
+
+/datum/trait/neutral/submit_to_prey/apply(var/datum/species/S,var/mob/living/carbon/human/H)
+	..(S,H)
+	H.verbs |= /mob/living/proc/lend_prey_control


### PR DESCRIPTION
It's mostly identical in practical application to what Dominate Pred does, except the difference is that the pred is one initiating control switch, not the prey. They get to choose which if prey in the bellies get the offer. Otherwise, beyond slight difference in flavor texts here and there, the functionality and result is identical to Dominate Pred.