### PR TITLE
Adjustments to synthetic food processing

### DIFF
--- a/code/modules/organs/internal/stomach.dm
+++ b/code/modules/organs/internal/stomach.dm
@@ -65,10 +65,11 @@
 	if(owner && owner.stat != DEAD)
 		owner.bodytemperature += round(owner.robobody_count * 0.25, 0.1)
 
+/*			//VOREStation Removal - normal chem processing
 		if(ishuman(owner))
 			var/mob/living/carbon/human/H = owner
 
 			if(H.ingested?.total_volume && H.bloodstr)
 				H.ingested.trans_to_holder(H.bloodstr, rand(2,5))
-
+*/
 	return

--- a/code/modules/organs/subtypes/nano.dm
+++ b/code/modules/organs/subtypes/nano.dm
@@ -90,8 +90,7 @@
 	parent_organ = BP_TORSO
 	vital = TRUE
 	organ_verbs = list(
-		/mob/living/carbon/human/proc/self_diagnostics,
-		/mob/living/carbon/human/proc/reagent_purge
+		/mob/living/carbon/human/proc/self_diagnostics
 	)
 
 /obj/item/organ/internal/nano/refactory
@@ -104,6 +103,9 @@
 
 	var/list/materials = list(MAT_STEEL = 0)
 	var/max_storage = 10000
+	organ_verbs = list(
+		/mob/living/carbon/human/proc/reagent_purge
+	)
 
 /obj/item/organ/internal/nano/refactory/proc/get_stored_material(var/material)
 	if(status & ORGAN_DEAD)

--- a/code/modules/reagents/reagents/_reagents.dm
+++ b/code/modules/reagents/reagents/_reagents.dm
@@ -25,7 +25,7 @@
 
 	var/affects_dead = 0	// Does this chem process inside a corpse?
 	var/affects_robots = 0	// Does this chem process inside a Synth?
-	
+
 	var/allergen_type		// What potential allergens does this contain?
 	var/allergen_factor = 1	// If the potential allergens are mixed and low-volume, they're a bit less dangerous. Needed for drinks because they're a single reagent compared to food which contains multiple seperate reagents.
 
@@ -117,23 +117,28 @@
 			else
 				var/obj/item/organ/internal/heart/machine/Pump = H.internal_organs_by_name[O_PUMP]
 				var/obj/item/organ/internal/stomach/machine/Cycler = H.internal_organs_by_name[O_CYCLER]
+				var/obj/item/organ/internal/nano/refactory/Refactory = H.internal_organs_by_name[O_FACT]		//VOREStation Addition: Proteans
 
 				if(active_metab.metabolism_class == CHEM_BLOOD)
 					if(Pump)
 						removed *= 1.1 - Pump.damage / Pump.max_damage
+					else if(Refactory)		//VOREStation Addition: Proteans
+						removed *= 1.1 - Refactory.damage / Refactory.max_damage
 					else
 						removed *= 0.1
 
 				else if(active_metab.metabolism_class == CHEM_INGEST)	// If the pump is damaged, we waste chems from the tank.
 					if(Pump)
 						ingest_abs_mult *= max(0.25, 1 - Pump.damage / Pump.max_damage)
-
+					else if(Refactory)		//VOREStation Addition: Proteans
+						ingest_abs_mult *= max(0.25, 1 - Refactory.damage / Refactory.max_damage)
 					else
 						ingest_abs_mult *= 0.2
 
 					if(Cycler)	// If we're damaged, we empty our tank slower.
 						ingest_rem_mult = max(0.1, 1 - (Cycler.damage / Cycler.max_damage))
-
+					else if(Refactory)		//VOREStation Addition: Proteans
+						ingest_rem_mult = max(0.1, 1 - (Refactory.damage / Refactory.max_damage))
 					else
 						ingest_rem_mult = 0.1
 
@@ -165,9 +170,9 @@
 				affect_touch(M, alien, removed)
 	if(overdose && (volume > overdose * M?.species.chemOD_threshold) && (active_metab.metabolism_class != CHEM_TOUCH && !can_overdose_touch))
 		overdose(M, alien, removed)
-	if(M.species.allergens & allergen_type)	//uhoh, we can't handle this!	
+	if(M.species.allergens & allergen_type)	//uhoh, we can't handle this!
 		var/damage_severity = M.species.allergen_damage_severity*allergen_factor
-		var/disable_severity = M.species.allergen_disable_severity*allergen_factor	
+		var/disable_severity = M.species.allergen_disable_severity*allergen_factor
 		if(M.species.allergen_reaction & AG_TOX_DMG)
 			M.adjustToxLoss(damage_severity)
 		if(M.species.allergen_reaction & AG_OXY_DMG)

--- a/code/modules/reagents/reagents/food_drinks.dm
+++ b/code/modules/reagents/reagents/food_drinks.dm
@@ -42,10 +42,6 @@
 		M.adjustToxLoss(0.1 * removed)
 		return
 	affect_ingest(M, alien, removed)
-	//VOREStation Edits Start
-	if(M.isSynthetic() && M.nutrition < 500)
-		M.adjust_nutrition((nutriment_factor * removed) * M.species.synthetic_food_coeff)
-	//VOREStation Edits End
 	..()
 
 /datum/reagent/nutriment/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed)
@@ -60,6 +56,9 @@
 			M.heal_organ_damage(0.5 * removed, 0)
 			M.adjust_nutrition((nutriment_factor * removed) * M.species.organic_food_coeff)
 			M.add_chemical_effect(CE_BLOODRESTORE, 4 * removed)
+	else
+		M.adjust_nutrition((nutriment_factor * removed) * M.species.synthetic_food_coeff)
+
 	//VOREStation Edits Stop
 
 // Aurora Cooking Port Insertion Begin

--- a/code/modules/reagents/reagents/food_drinks.dm
+++ b/code/modules/reagents/reagents/food_drinks.dm
@@ -42,6 +42,10 @@
 		M.adjustToxLoss(0.1 * removed)
 		return
 	affect_ingest(M, alien, removed)
+	//VOREStation Edits Start
+	if(M.isSynthetic())
+		M.adjust_nutrition((nutriment_factor * removed) * M.species.synthetic_food_coeff)
+	//VOREStation Edits End
 	..()
 
 /datum/reagent/nutriment/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed)


### PR DESCRIPTION
Change 1 - synthetic stomach no longer automatically transfers semi-random amount of reagents into bloodstream. That was dumb, even for synth processing, since stomach and bloodstream are handled differently.

Change 2 - synths can now process food both in stomach and in bloodstream.

Change 3 - synths no longer have capped amount of food-provided nutrition.

Change 4 - protean Refactory now functions as both Pump and Cycler for purposes of reagent processing. Fixes #12458

Change 5 - proteans now have Reagent Purge provided by Refactory rather than Orchestrator (difference more in fluff than in practice).