### PR TITLE
Strapless satchel moved to bag selection

### DIFF
--- a/code/_helpers/global_lists.dm
+++ b/code/_helpers/global_lists.dm
@@ -52,7 +52,7 @@ GLOBAL_LIST_INIT(custom_species_bases, new) // Species that can be used for a Cu
 var/datum/category_collection/underwear/global_underwear = new()
 
 	//Backpacks
-var/global/list/backbaglist = list("Nothing", "Backpack", "Satchel", "Satchel Alt", "Messenger Bag", "Sports Bag")
+var/global/list/backbaglist = list("Nothing", "Backpack", "Satchel", "Satchel Alt", "Messenger Bag", "Sports Bag", "Strapless Satchel") //VOREStation edit
 var/global/list/pdachoicelist = list("Default", "Slim", "Old", "Rugged", "Holographic", "Wrist-Bound", "Slider")
 var/global/list/exclude_jobs = list(/datum/job/ai,/datum/job/cyborg)
 

--- a/code/datums/outfits/outfit.dm
+++ b/code/datums/outfits/outfit.dm
@@ -57,6 +57,7 @@ var/list/outfits_decls_by_type_
 	var/satchel_two  = /obj/item/weapon/storage/backpack/satchel
 	var/messenger_bag = /obj/item/weapon/storage/backpack/messenger
 	var/sports_bag = /obj/item/weapon/storage/backpack/sport
+	var/satchel_three = /obj/item/weapon/storage/backpack/satchel/strapless
 
 	var/flags // Specific flags
 
@@ -78,6 +79,7 @@ var/list/outfits_decls_by_type_
 			if(4) back = satchel_two
 			if(5) back = messenger_bag
 			if(6) back = sports_bag
+			if(7) back = satchel_three
 			else back = null
 
 /decl/hierarchy/outfit/proc/post_equip(mob/living/carbon/human/H)

--- a/code/modules/client/preference_setup/loadout/loadout_utility_vr.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_utility_vr.dm
@@ -74,10 +74,3 @@
 	display_name = "bluespace bracelet"
 	path = /obj/item/clothing/gloves/bluespace
 	cost = 5
-
-
-/datum/gear/utility/satchel_strapless
-	display_name = "satchel strapless"
-	path = /obj/item/weapon/storage/backpack/satchel/strapless
-	slot = slot_back
-	cost = 1


### PR DESCRIPTION
Adds the strapless bag to the selection available on the initial character setup screen, removes it from the loadout pages as a result.

Tested _fleetingly_ before work, but seemed to work just fine