### PR TITLE
Assistant alt title for Intern

### DIFF
--- a/code/game/jobs/job/assistant_vr.dm
+++ b/code/game/jobs/job/assistant_vr.dm
@@ -22,7 +22,8 @@
 					  "Security Cadet" = /datum/alt_title/intern_sec,
 					  "Jr. Cargo Tech" = /datum/alt_title/intern_crg,
 					  "Jr. Explorer" = /datum/alt_title/intern_exp,
-					  "Server" = /datum/alt_title/server)
+					  "Server" = /datum/alt_title/server,
+					  "Assistant" = /datum/alt_title/assistant)
 	job_description = "An Intern does whatever is requested of them, often doing so in process of learning \
 						another job. Though they are part of the crew, they have no real authority."
 	timeoff_factor = 0 // Interns, noh
@@ -66,6 +67,11 @@
 /datum/alt_title/server
 	title = "Server"
 	title_blurb = "A Server helps out kitchen and diner staff with various tasks, primarily food delivery. A Server has no real authority."
+	title_outfit = /decl/hierarchy/outfit/job/service/server
+
+/datum/alt_title/assistant
+	title = "Assistant"
+	title_blurb = "An assistant helps out wherever they might be needed. They have no authority, but can volunteer to help if help is needed."
 	title_outfit = /decl/hierarchy/outfit/job/service/server
 
 /datum/job/intern/New()


### PR DESCRIPTION
Assistant was renamed as a job to attempt to get away from the general SS13isms that come with the default position.

I think though that, as a title, it fits very well with Intern, especially considering it isn't the default role, or the default title for that role. 

Basically, it's what I'd use for playing intern, since when I'm playing intern I'm generally hopping on to be a helper who doesn't necessarily have responsibilities unless I volunteer for them.

And if that doesn't sound like 'someone who assists', I don't know what does. SO! (I thought about doing '[department] assistant' for all the different departments except command (since Command Assistant already exists as an alt title) but I sort of thought better of it.