### PR TITLE
Admin Verbs

### DIFF
--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -298,7 +298,8 @@ var/global/list/default_medbay_channels = list(
 
 GLOBAL_DATUM(autospeaker, /mob/living/silicon/ai/announcer)
 
-/obj/item/device/radio/proc/autosay(var/message, var/from, var/channel, var/list/zlevels)
+/obj/item/device/radio/proc/autosay(var/message, var/from, var/channel, var/list/zlevels, var/states)	//VOREStation Edit
+
 	if(!GLOB.autospeaker)
 		return
 	var/datum/radio_frequency/connection = null
@@ -314,12 +315,15 @@ GLOBAL_DATUM(autospeaker, /mob/living/silicon/ai/announcer)
 
 	if(!LAZYLEN(zlevels))
 		zlevels = list(0)
-
+	//VOREStation Edit Start
+	if(!states)
+		states = "states"
+	//VOREStation Edit End
 	GLOB.autospeaker.SetName(from)
 	Broadcast_Message(connection, GLOB.autospeaker,
 						0, "*garbled automated announcement*", src,
 						message_to_multilingual(message), from, "Automated Announcement", from, "synthesized voice",
-						DATA_FAKE, 0, zlevels, connection.frequency, "states")
+						DATA_FAKE, 0, zlevels, connection.frequency, states)	//VOREStation Edit
 
 // Interprets the message mode when talking into a radio, possibly returning a connection datum
 /obj/item/device/radio/proc/handle_message_mode(mob/living/M as mob, list/message_pieces, message_mode)

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -714,10 +714,16 @@ var/datum/announcement/minor/admin_min_announcer = new
 		if(sender) //They put a sender
 			sender = sanitize(sender, 75, extra = 0)
 			var/message = input(usr, "Message content (max 500):", "Contents", "This is a test of the announcement system.") as null|message
-
+			var/msgverb = input(usr, "Name of verb (Such as 'states', 'says', 'asks', etc):", "Verb", "says") as null|text	//VOREStation Addition
 			if(message) //They put a message
 				message = sanitize(message, 500, extra = 0)
-				global_announcer.autosay("[message]", "[sender]", "[channel == "Common" ? null : channel]") //Common is a weird case, as it's not a "channel", it's just talking into a radio without a channel set.
+				//VOREStation Edit Start
+				if(msgverb)
+					msgverb = sanitize(msgverb, 50, extra = 0)
+				else
+					msgverb = "states"
+				global_announcer.autosay("[message]", "[sender]", "[channel == "Common" ? null : channel]", states = msgverb) //Common is a weird case, as it's not a "channel", it's just talking into a radio without a channel set.
+				//VOREStation Edit End
 				log_admin("Intercom: [key_name(usr)] : [sender]:[message]")
 
 	feedback_add_details("admin_verb","IN") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
@@ -802,7 +808,7 @@ var/datum/announcement/minor/admin_min_announcer = new
 			var/this_sender = decomposed[i]
 			var/this_message = decomposed[++i]
 			var/this_wait = decomposed[++i]
-			global_announcer.autosay("[this_message]", "[this_sender]", "[channel == "Common" ? null : channel]") //Common is a weird case, as it's not a "channel", it's just talking into a radio without a channel set.
+			global_announcer.autosay("[this_message]", "[this_sender]", "[channel == "Common" ? null : channel]", "says") //Common is a weird case, as it's not a "channel", it's just talking into a radio without a channel set.	//VOREStation Edit
 			sleep(this_wait SECONDS)
 
 /datum/admins/proc/toggleooc()

--- a/code/modules/admin/admin_verb_lists_vr.dm
+++ b/code/modules/admin/admin_verb_lists_vr.dm
@@ -157,7 +157,8 @@ var/list/admin_verbs_fun = list(
 	/client/proc/smite_vr, //VOREStation Add,
 	/client/proc/admin_lightning_strike,
 	/client/proc/resize, //VOREStation Add,
-	/client/proc/cmd_admin_droppod_deploy
+	/client/proc/cmd_admin_droppod_deploy,
+	/client/proc/adminorbit //VOREStation Add,
 	)
 
 var/list/admin_verbs_spawn = list(

--- a/code/modules/admin/admin_verbs_vr.dm
+++ b/code/modules/admin/admin_verbs_vr.dm
@@ -1,0 +1,55 @@
+/client/proc/adminorbit()
+	set category = "Fun"
+	set name = "Orbit Things"
+	set desc = "Makes something orbit around something else."
+	set popup_menu = FALSE
+
+	if(!holder) return
+	
+	var/center
+	var/atom/movable/orbiter
+	var/input
+
+	if(holder.marked_datum)
+		input = tgui_alert(usr, "You have \n[holder.marked_datum] marked, should this be the center of the orbit, or the orbiter?", "Orbit", list("Center", "Orbiter", "Neither"))
+		switch(input)
+			if("Center")
+				center = holder.marked_datum
+			if("Orbiter")
+				orbiter = holder.marked_datum
+	var/list/possible_things = list()
+	for(var/T as mob in view(view))	//Let's do mobs before objects
+		if(ismob(T))
+			possible_things |= T
+	for(var/T as obj in view(view))
+		if(isobj(T))
+			possible_things |= T
+	if(!center)
+		center = input(usr, "What should act as the center of the orbit?", "Center") as anything in possible_things
+		possible_things -= center
+	if(!orbiter)
+		orbiter = input(usr, "What should act as the orbiter of the orbit?", "Orbiter") as anything in possible_things
+	if(!center || !orbiter)
+		to_chat(usr, "<span class = 'warning'>A center of orbit and an orbiter must be configured. You can also do this by marking a target.</span>")
+		return
+	if(center == orbiter)
+		to_chat(usr, "<span class = 'warning'>The center of the orbit cannot also be the orbiter.</span>")
+		return
+	if(isturf(orbiter))
+		to_chat(usr, "<span class = 'warning'>The orbiter cannot be a turf. It can only be used as a center.</span>")
+		return
+	var/distance = input(usr, "How large will their orbit radius be? (In pixels. 32 is 'near around a character)", "Orbit Radius", 32) as num|null
+	var/speed = input(usr, "How fast will they orbit (negative numbers spin clockwise)", "Orbit Speed", 20) as num|null
+	var/segments = input(usr, "How many segments will they have in their orbit? (3 is a triangle, 36 is a circle, etc)", "Orbit Segments", 36) as num|null
+	var/clock = FALSE
+	if(!distance)
+		distance = 32
+	if(!speed)
+		speed = 20
+	else if (speed < 0)
+		clock = TRUE
+		speed *= -1
+	if(!segments)
+		segments = 36
+	if(tgui_alert(usr, "\The [orbiter] will orbit around [center]. Is this okay?", "Confirm Orbit", list("Yes", "No")) == "Yes")
+		orbiter.orbit(center, distance, clock, speed, segments)

--- a/code/modules/admin/admin_verbs_vr.dm
+++ b/code/modules/admin/admin_verbs_vr.dm
@@ -4,8 +4,9 @@
 	set desc = "Makes something orbit around something else."
 	set popup_menu = FALSE
 
-	if(!holder) return
-	
+	if(!check_rights(R_FUN))
+		return
+
 	var/center
 	var/atom/movable/orbiter
 	var/input

--- a/code/modules/admin/verbs/adminjump.dm
+++ b/code/modules/admin/verbs/adminjump.dm
@@ -124,15 +124,17 @@
 	else
 		tgui_alert_async(usr, "Admin jumping disabled")
 
-/client/proc/Getmob()
+/client/proc/Getmob(mob/living/M as mob)	//VOREStation Edit
 	set category = "Admin"
 	set name = "Get Mob"
 	set desc = "Mob to teleport"
+	set popup_menu = TRUE	//VOREStation Edit
 
 	if(!check_rights(R_ADMIN|R_MOD|R_DEBUG|R_EVENT))
 		return
 	if(config.allow_admin_jump)
-		var/mob/M = tgui_input_list(usr, "Pick a mob:", "Get Mob", mob_list)
+		if(!M)	//VOREStation Edit
+			M = tgui_input_list(usr, "Pick a mob:", "Get Mob", mob_list)	//VOREStation Edit
 		if(!M)
 			return
 		log_admin("[key_name(usr)] jumped [key_name(M)] to them")

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -1648,6 +1648,7 @@
 #include "code\modules\admin\admin_tools.dm"
 #include "code\modules\admin\admin_verb_lists_vr.dm"
 #include "code\modules\admin\admin_verbs.dm"
+#include "code\modules\admin\admin_verbs_vr.dm"
 #include "code\modules\admin\admin_vr.dm"
 #include "code\modules\admin\banjob.dm"
 #include "code\modules\admin\ckey_vr.dm"


### PR DESCRIPTION
Adjusts Intercom Msg a little

Adds Orbit Things verb, which allows staff to more easily orbit things around other things.

Also returns Get Mob to the right click menu, as that is a very super useful verb for doing events. Needing to open the player panel, or use the verb and hunt down your target in a menu seriously limits its utility for event making.