### PR TITLE
Adding OOC Notes to Blobs

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/prommie_blob.dm
+++ b/code/modules/mob/living/carbon/human/species/station/prommie_blob.dm
@@ -383,6 +383,7 @@
 	blob.Weaken(2)
 	blob.transforming = TRUE
 	blob.ckey = ckey
+	blob.ooc_notes = ooc_notes
 	blob.transforming = FALSE
 	blob.name = name
 	blob.nutrition = nutrition
@@ -454,6 +455,7 @@
 	playsound(src.loc, "sound/effects/slime_squish.ogg", 15)
 	transforming = TRUE
 	ckey = blob.ckey
+	ooc_notes = blob.ooc_notes // Updating notes incase they change them in blob form.
 	transforming = FALSE
 	blob.name = "Promethean Blob"
 	var/obj/item/hat = blob.hat

--- a/code/modules/mob/living/carbon/human/species/station/protean_vr/protean_blob.dm
+++ b/code/modules/mob/living/carbon/human/species/station/protean_vr/protean_blob.dm
@@ -378,6 +378,7 @@ var/global/list/disallowed_protean_accessories = list(
 
 	//Put our owner in it (don't transfer var/mind)
 	blob.ckey = ckey
+	blob.ooc_notes = ooc_notes
 	temporary_form = blob
 
 	//Mail them to nullspace
@@ -459,6 +460,7 @@ var/global/list/disallowed_protean_accessories = list(
 
 	//Put our owner in it (don't transfer var/mind)
 	ckey = blob.ckey
+	ooc_notes = blob.ooc_notes // Lets give the protean any updated notes from blob form.
 	temporary_form = null
 
 	//Transfer vore organs


### PR DESCRIPTION
Now OOC Notes will be transfered to prommie blobs.

As an added bonus, the same functionality was added to protean blobs. Wow!

Any changes to notes made while in blob form will also be transferred back to human form.