### PR TITLE
Allowing micros to crawl into storage items

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -228,6 +228,9 @@
 		if(!temp)
 			to_chat(user, "<span class='notice'>You try to use your hand, but realize it is no longer attached!</span>")
 			return
+	if(istype(src, /obj/item/weapon/holder))
+		var/obj/item/weapon/holder/D = src
+		if(D.held_mob == user) return // No picking your own micro self up
 
 	var/old_loc = src.loc
 	if (istype(src.loc, /obj/item/weapon/storage))

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -25,7 +25,7 @@
 	var/max_w_class = ITEMSIZE_SMALL //Max size of objects that this object can store (in effect only if can_hold isn't set)
 	var/max_storage_space = ITEMSIZE_COST_SMALL * 4 //The sum of the storage costs of all the items in this storage item.
 	var/storage_slots = null //The number of storage slots in this container.  If null, it uses the volume-based storage instead.
-	
+
 	/// Boxes screen object for fixed-size storage (belts, etc)
 	var/obj/screen/storage/boxes = null
 	/// List of 'click catchers' for boxes for fixed-size storage
@@ -37,8 +37,8 @@
 	var/obj/screen/storage/storage_continue = null
 	/// For dynamic storage, the rightmost pixel column for the whole storage display. Decorative.
 	var/obj/screen/storage/storage_end = null
-	
-	/// The "X" button at the far right of the storage 
+
+	/// The "X" button at the far right of the storage
 	var/obj/screen/close/closer = null
 
 	var/use_to_pickup	//Set this to make it possible to use this item in an inverse way, so you can have the item in your hand and click items on the floor to pick them up.
@@ -189,12 +189,12 @@
 				return
 	if(user.s_active)
 		user.s_active.hide_from(user)
-	
+
 	var/client/C = user.client
 	if(!C)
 		return
 
-	if(storage_slots)	
+	if(storage_slots)
 		C.screen += src.boxes
 		create_slot_catchers()
 		C.screen += src.box_catchers
@@ -202,7 +202,7 @@
 		C.screen += src.storage_start
 		C.screen += src.storage_continue
 		C.screen += src.storage_end
-	
+
 	C.screen += src.closer
 	C.screen += src.contents
 
@@ -212,12 +212,12 @@
 /obj/item/weapon/storage/proc/hide_from(mob/user as mob)
 	var/client/C = user.client
 	LAZYREMOVE(is_seeing,user)
-	
+
 	if(!C)
 		if(!LAZYLEN(is_seeing))
 			clear_slot_catchers()
 		return
-	
+
 	if(storage_slots)
 		C.screen -= src.boxes
 		C.screen -= src.box_catchers
@@ -225,13 +225,13 @@
 		C.screen -= src.storage_start
 		C.screen -= src.storage_continue
 		C.screen -= src.storage_end
-	
+
 	C.screen -= src.closer
 	C.screen -= src.contents
-	
+
 	if(user.s_active == src)
 		user.s_active = null
-	
+
 	if(!LAZYLEN(is_seeing))
 		clear_slot_catchers()
 
@@ -330,7 +330,7 @@
 
 /obj/item/weapon/storage/proc/space_orient_objs(var/list/obj/item/display_contents)
 	SHOULD_NOT_SLEEP(TRUE)
-	
+
 	/// A prototype for drawing the leftmost border behind each item in storage
 	var/static/mutable_appearance/stored_start
 	/// A prototype for drawing the wide backing space behind each item in storage
@@ -856,7 +856,7 @@
 	ASSERT(held_item)
 	name += held_item.name
 	src.held_item = weakref(held_item)
-	
+
 /atom/movable/storage_slot/Destroy()
 	held_item = null
 
@@ -870,3 +870,32 @@
 	if(I)
 		usr.ClickOn(I)
 	return 1
+
+// Allows micros to drag themselves into storage items
+/obj/item/weapon/storage/MouseDrop_T(mob/living/target, mob/living/user)
+	if(!istype(user)) return // If the user passed in isn't a living mob, exit
+	if(target != user) return // If the user didn't drag themselves, exit
+	if(user.incapacitated() || user.buckled) return // If user is incapacitated or buckled, exit
+	if(get_holder_of_type(src, /mob/living/carbon/human) == user) return // No jumping into your own equipment
+	if(ishuman(user) && user.get_effective_size() > 0.25) return // Only micro characters
+	if(ismouse(user) && user.get_effective_size() > 1) return // Only normal sized mice or less
+
+	// Create a dummy holder with user's size to test insertion
+	var/obj/item/weapon/holder/D = new/obj/item/weapon/holder
+	if(ismouse(user))
+		D.w_class = ITEMSIZE_TINY // Mouse smol
+	else if(ishuman(user))
+		D.w_class = ITEMSIZE_SMALL // Players small
+	else        // Other creatures not accepted at this time
+		qdel(D) // If there's a better way to check the size of a
+		return  // mob's holder and if it fits, replace this slab
+	if(!src.can_be_inserted(D, 1)) // If the dummy item doesn't fit, exit
+		qdel(D)
+		return
+	qdel(D)
+
+	// Scoop and insert target into storage
+	var/obj/item/weapon/holder/H = new user.holder_type(get_turf(user), user)
+	src.handle_item_insertion(H, 1)
+	to_chat(user, "<span class='notice'>You climb into \the [src].</span>")
+	return ..()


### PR DESCRIPTION
Fixed a bug where a micro player could pick themselves up out of storage items if they used alt+click to open it. This would free them, but create an invisible, empty holder item in their hands which could then be placed in storages.

Added the ability for micros (size 25%) and observer mice (size 100% or lower) to drag their sprite over storage items in order to climb inside. Same as if a player were to pick them up and store them.