### PR TITLE
Makes droppods not do quintiple kaboom

### DIFF
--- a/code/modules/random_map/drop/droppod.dm
+++ b/code/modules/random_map/drop/droppod.dm
@@ -10,6 +10,7 @@
 	limit_x = 3
 	limit_y = 3
 	preserve_map = 0
+	max_attempts = 1
 
 	wall_type = /turf/simulated/wall/titanium
 	floor_type = /turf/simulated/floor/reinforced


### PR DESCRIPTION
Fixes #12524.

The general random map spawning code could probably use adjustements to not just keep re-generating things even after successful generation but aoaoaoao