### PR TITLE
Auto-Resleever accounts for brains

### DIFF
--- a/code/modules/resleeving/autoresleever.dm
+++ b/code/modules/resleeving/autoresleever.dm
@@ -65,8 +65,14 @@
 		return
 	
 	if(ghost.mind && ghost.mind.current && ghost.mind.current.stat != DEAD)
-		to_chat(ghost, "<span class='warning'>Your body is still alive, you cannot be resleeved.</span>")
-		return
+		if(istype(ghost.mind.current.loc, /obj/item/device/mmi))
+			if(tgui_alert(ghost, "Your brain is still alive, using the auto-resleever will delete that brain. Are you sure?", "Delete Brain", list("No","Yes")) != "Yes")
+				return
+			if(istype(ghost.mind.current.loc, /obj/item/device/mmi))
+				qdel(ghost.mind.current.loc)
+		else
+			to_chat(ghost, "<span class='warning'>Your body is still alive, you cannot be resleeved.</span>")
+			return
 
 	var/client/ghost_client = ghost.client
 	


### PR DESCRIPTION
If you click on the auto-resleever while you still have an active synth brain somewhere, it will ask you if you want to delete that brain. 

This is to prevent harvesting brain parts from dead people or other weirdness for brains getting turned in after they are killed and auto-resleeved.

Useful for if you got digested and forgotten, gibbed and your brain flew into a bush, etc.

Fixes https://github.com/VOREStation/VOREStation/issues/12536