### PR TITLE
Slip Vore

### DIFF
--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -138,8 +138,8 @@
 
 			if(M.slip("the [floor_type] floor", slip_stun))
 				for(var/i = 1 to slip_dist)
-					if(M.slip_vore_in_progress)	//Vore edit that's secretely a CHOMPEdit
-						break
+					if(isbelly(M.loc))	//VOREEdit, Stop the slip if we're in a belly. Inspired by a chompedit, cleaned it up with isbelly instead of a variable since the var was resetting too fast.
+						return
 					step(M, M.dir)
 					sleep(1)
 			else

--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -138,6 +138,8 @@
 
 			if(M.slip("the [floor_type] floor", slip_stun))
 				for(var/i = 1 to slip_dist)
+					if(M.slip_vore_in_progress)	//Vore edit that's secretely a CHOMPEdit
+						break
 					step(M, M.dir)
 					sleep(1)
 			else

--- a/code/modules/vore/eating/belly_obj_vr.dm
+++ b/code/modules/vore/eating/belly_obj_vr.dm
@@ -366,9 +366,11 @@
 		H.held_mob.muffled = FALSE
 		H.held_mob.forced_psay = FALSE
 
+	if(isliving(M))
+		var/mob/living/slip = M
+		slip.slip_protect = world.time + 25 // This is to prevent slipping back into your pred if they stand on soap or something.
 	//Place them into our drop_location
 	M.forceMove(drop_location())
-
 	items_preserved -= M
 
 	//Special treatment for absorbed prey
@@ -774,7 +776,7 @@
 /////////////////////////////////////////////////////////////////////////
 /obj/belly/proc/handle_absorb_langs()
 	owner.absorb_langs()
-				
+
 ////////////////////////////////////////////////////////////////////////
 
 

--- a/code/modules/vore/eating/living_vr.dm
+++ b/code/modules/vore/eating/living_vr.dm
@@ -504,9 +504,15 @@
 		to_chat(user, "<span class='notice'>They aren't able to be devoured.</span>")
 		log_and_message_admins("[key_name_admin(src)] attempted to devour [key_name_admin(prey)] against their prefs ([prey ? ADMIN_JMP(prey) : "null"])")
 		return FALSE
-
+	// Slipnoms from chompstation downstream, credit to cadyn for the original PR.
 	// Prepare messages
-	if(user == pred) //Feeding someone to yourself
+	if(prey.is_slipping)
+		attempt_msg = "<span class='warning'>It seems like [prey] is about to slide into [pred]'s [lowertext(belly.name)]!</span>"
+		success_msg = "<span class='warning'>[prey] suddenly slides into [pred]'s [lowertext(belly.name)]!</span>"
+	else if(pred.is_slipping)
+		attempt_msg = "<span class='warning'>It seems like [prey] is gonna end up inside [pred]'s [lowertext(belly.name)] as [pred] comes sliding over!</span>"
+		success_msg = "<span class='warning'>[prey] suddenly slips inside of [pred]'s [lowertext(belly.name)] as [pred] slides into them!</span>"
+	else if(user == pred) //Feeding someone to yourself
 		attempt_msg = "<span class='warning'>[pred] is attempting to [lowertext(belly.vore_verb)] [prey] into their [lowertext(belly.name)]!</span>"
 		success_msg = "<span class='warning'>[pred] manages to [lowertext(belly.vore_verb)] [prey] into their [lowertext(belly.name)]!</span>"
 	else //Feeding someone to another person
@@ -566,7 +572,7 @@
 	var/air_type = /datum/gas_mixture/belly_air
 	if(istype(lifeform))	// If this doesn't succeed, then 'lifeform' is actually a bag or capture crystal with someone inside
 		air_type = lifeform.get_perfect_belly_air_type()		// Without any overrides/changes, its gonna be /datum/gas_mixture/belly_air
-	
+
 	var/air = new air_type(1000)
 	return air
 

--- a/code/modules/vore/eating/slipvore_vr.dm
+++ b/code/modules/vore/eating/slipvore_vr.dm
@@ -3,9 +3,12 @@
 /mob/living
 	var/is_slipping = FALSE
 	var/slip_vore_in_progress = FALSE
+	var/slip_protect = 1
 
 /mob/living/proc/can_slip_vore(var/mob/living/target)
 	if(!target.is_slipping)	//Obviously they have to be slipping to get slip vored
+		return FALSE
+	if(world.time <= target.slip_protect)
 		return FALSE
 	if(!(src.can_be_drop_pred && target.devourable && target.can_be_drop_prey))	//Make sure both of their prefs align with what we're gonna do.
 		return FALSE
@@ -18,6 +21,8 @@
 /mob/living/proc/can_be_slip_vored_by(var/mob/living/target)
 	if(!target.is_slipping)	//Obviously they have to be slipping to get slip vored
 		return FALSE
+	if(world.time <= target.slip_protect)
+		return FALSE
 	if(!(target.can_be_drop_pred && src.devourable && src.can_be_drop_prey))	//Make sure both of their prefs align with what we're gonna do.
 		return FALSE
 	if(!is_vore_predator(target))	//Check their bellies and stuff
@@ -27,29 +32,20 @@
 	return TRUE
 
 /mob/living/Crossed(var/atom/movable/AM)
-	if(AM == src || AM.is_incorporeal()) // We're not going to run over ourselves or ghosts
-		return
-
-	if(istype(AM, /mob/living/bot/mulebot))
-		var/mob/living/bot/mulebot/MB = AM
-		MB.runOver(src)
-
-	if(istype(AM, /obj/vehicle))
-		var/obj/vehicle/V = AM
-		V.RunOver(src)
-
+	..()
 	var/mob/living/target = AM
 	if(istype(target) && !target.incorporeal_move && !src.incorporeal_move)	//The slip vore begins
 		if(can_slip_vore(target) && !src.slip_vore_in_progress && !target.slip_vore_in_progress)	//If we can vore them go for it
-			target.slip_vore_in_progress = TRUE //Make them stop slipping
 			perform_the_nom(src,target,src,src.vore_selected,1)
 			target.slip_vore_in_progress = FALSE
 			target.is_slipping = FALSE
+			return
 		else if(can_be_slip_vored_by(target) && !src.slip_vore_in_progress && !target.slip_vore_in_progress) //Otherwise, if they can vore us, make it happen.
-			target.slip_vore_in_progress = TRUE //Make them stop slipping
 			perform_the_nom(target,src,target,target.vore_selected,1)
-			target.slip_vore_in_progress = FALSE
-			target.is_slipping = FALSE
+			slip_vore_in_progress = FALSE
+			is_slipping = FALSE
+			return
+
 
 /mob/living/carbon/slip(var/slipped_on,stun_duration=8)
 	. = ..()

--- a/code/modules/vore/eating/slipvore_vr.dm
+++ b/code/modules/vore/eating/slipvore_vr.dm
@@ -1,0 +1,64 @@
+// Slipnoms from chompstation downstream, credit to cadyn for the original PR.
+
+/mob/living
+	var/is_slipping = FALSE
+	var/slip_vore_in_progress = FALSE
+
+/mob/living/proc/can_slip_vore(var/mob/living/target)
+	if(!target.is_slipping)	//Obviously they have to be slipping to get slip vored
+		return FALSE
+	if(!(src.can_be_drop_pred && target.devourable && target.can_be_drop_prey))	//Make sure both of their prefs align with what we're gonna do.
+		return FALSE
+	if(!is_vore_predator(src))	//Check their bellies and stuff
+		return FALSE
+	if(!src.vore_selected)	//Gotta have one selected as well.
+		return FALSE
+	return TRUE
+
+/mob/living/proc/can_be_slip_vored_by(var/mob/living/target)
+	if(!target.is_slipping)	//Obviously they have to be slipping to get slip vored
+		return FALSE
+	if(!(target.can_be_drop_pred && src.devourable && src.can_be_drop_prey))	//Make sure both of their prefs align with what we're gonna do.
+		return FALSE
+	if(!is_vore_predator(target))	//Check their bellies and stuff
+		return FALSE
+	if(!target.vore_selected)	//Gotta have one selected as well.
+		return FALSE
+	return TRUE
+
+/mob/living/Crossed(var/atom/movable/AM)
+	if(AM == src || AM.is_incorporeal()) // We're not going to run over ourselves or ghosts
+		return
+
+	if(istype(AM, /mob/living/bot/mulebot))
+		var/mob/living/bot/mulebot/MB = AM
+		MB.runOver(src)
+
+	if(istype(AM, /obj/vehicle))
+		var/obj/vehicle/V = AM
+		V.RunOver(src)
+
+	var/mob/living/target = AM
+	if(istype(target) && !target.incorporeal_move && !src.incorporeal_move)	//The slip vore begins
+		if(can_slip_vore(target) && !src.slip_vore_in_progress && !target.slip_vore_in_progress)	//If we can vore them go for it
+			target.slip_vore_in_progress = TRUE //Make them stop slipping
+			perform_the_nom(src,target,src,src.vore_selected,1)
+			target.slip_vore_in_progress = FALSE
+			target.is_slipping = FALSE
+		else if(can_be_slip_vored_by(target) && !src.slip_vore_in_progress && !target.slip_vore_in_progress) //Otherwise, if they can vore us, make it happen.
+			target.slip_vore_in_progress = TRUE //Make them stop slipping
+			perform_the_nom(target,src,target,target.vore_selected,1)
+			target.slip_vore_in_progress = FALSE
+			target.is_slipping = FALSE
+
+/mob/living/carbon/slip(var/slipped_on,stun_duration=8)
+	. = ..()
+	if(.)
+		is_slipping = TRUE
+	return .
+
+/mob/living/update_canmove()
+	. = ..()
+	if(is_slipping && !lying)
+		is_slipping = FALSE
+	return .

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -3960,6 +3960,7 @@
 #include "code\modules\vore\eating\living_vr.dm"
 #include "code\modules\vore\eating\silicon_vr.dm"
 #include "code\modules\vore\eating\simple_animal_vr.dm"
+#include "code\modules\vore\eating\slipvore_vr.dm"
 #include "code\modules\vore\eating\transforming_vr.dm"
 #include "code\modules\vore\eating\vore_vr.dm"
 #include "code\modules\vore\eating\vorehooks_vr.dm"
@@ -4112,6 +4113,6 @@
 #include "maps\submaps\space_submaps\debrisfield\debrisfield.dm"
 #include "maps\submaps\surface_submaps\wilderness\wilderness.dm"
 #include "maps\submaps\surface_submaps\wilderness\wilderness_areas.dm"
-#include "maps\tether\tether.dm"
+#include "maps\virgo_minitest\virgo_minitest.dm"
 #include "maps\~map_system\maps.dm"
 // END_INCLUDE

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -4113,6 +4113,6 @@
 #include "maps\submaps\space_submaps\debrisfield\debrisfield.dm"
 #include "maps\submaps\surface_submaps\wilderness\wilderness.dm"
 #include "maps\submaps\surface_submaps\wilderness\wilderness_areas.dm"
-#include "maps\virgo_minitest\virgo_minitest.dm"
+#include "maps\tether\tether.dm"
 #include "maps\~map_system\maps.dm"
 // END_INCLUDE


### PR DESCRIPTION
Ports slip vore from chompstation with some added polish.

Slips should halt correctly when being vored after running across space lube.

There is also a short timer added after being ejected from a belly, during that time frame you cannot slip vore.