### PR TITLE
Makes engraving no-longer cause rage when trying to cut wires, amongst other things.

### DIFF
--- a/code/game/objects/items/weapons/material/knives.dm
+++ b/code/game/objects/items/weapons/material/knives.dm
@@ -1,6 +1,7 @@
 /obj/item/weapon/material/butterfly
 	name = "butterfly knife"
 	desc = "A basic metal blade concealed in a lightweight plasteel grip. Small enough when folded to fit in a pocket."
+	description_fluff = "This could be used to engrave messages on suitable surfaces if you really put your mind to it! Alt-click a floor or wall to engrave with it." //This way it's not a completely hidden, arcane art to engrave.
 	icon_state = "butterflyknife"
 	item_state = null
 	hitsound = null
@@ -63,6 +64,7 @@
 	icon = 'icons/obj/kitchen.dmi'
 	icon_state = "knife"
 	desc = "A general purpose Chef's Knife made by SpaceCook Incorporated. Guaranteed to stay sharp for years to come."
+	description_fluff = "This could be used to engrave messages on suitable surfaces if you really put your mind to it! Alt-click a floor or wall to engrave with it." //This way it's not a completely hidden, arcane art to engrave.
 	sharp = TRUE
 	edge = TRUE
 	force_divisor = 0.15 // 9 when wielded with hardness 60 (steel)

--- a/code/game/objects/items/weapons/tools/screwdriver.dm
+++ b/code/game/objects/items/weapons/tools/screwdriver.dm
@@ -4,6 +4,7 @@
 /obj/item/weapon/tool/screwdriver
 	name = "screwdriver"
 	desc = "You can be totally screwwy with this."
+	description_fluff = "This could be used to engrave messages on suitable surfaces if you really put your mind to it! Alt-click a floor or wall to engrave with it." //This way it's not a completely hidden, arcane art to engrave.
 	icon = 'icons/obj/tools.dmi'
 	icon_state = "screwdriver"
 	center_of_mass = list("x" = 13,"y" = 7)

--- a/code/game/objects/items/weapons/tools/wirecutters.dm
+++ b/code/game/objects/items/weapons/tools/wirecutters.dm
@@ -4,6 +4,7 @@
 /obj/item/weapon/tool/wirecutters
 	name = "wirecutters"
 	desc = "This cuts wires."
+	description_fluff = "This could be used to engrave messages on suitable surfaces if you really put your mind to it! Alt-click a floor or wall to engrave with it." //This way it's not a completely hidden, arcane art to engrave.
 	icon = 'icons/obj/tools.dmi'
 	icon_state = "cutters"
 	item_state = "cutters"

--- a/code/game/turfs/simulated/floor_attackby.dm
+++ b/code/game/turfs/simulated/floor_attackby.dm
@@ -8,13 +8,15 @@
 		if(L.a_intent != I_HELP)
 			attack_tile(C, L) // Be on help intent if you want to decon something.
 			return
-
+/*
+//By god, no I do NOT want to engrave when trying to cut wires, can't get this working with non-help intent either else you just swipe the tools over the floors.
 	if(!(C.has_tool_quality(TOOL_SCREWDRIVER) && flooring && (flooring.flags & TURF_REMOVE_SCREWDRIVER)))
 		if(isliving(user))
 			var/mob/living/L = user
 			if(L.a_intent == I_HELP)
 				if(try_graffiti(L, C)) // back by unpopular demand
 					return
+*/
 
 	// Multi-z roof building
 	if(istype(C, /obj/item/stack/tile/roofing))

--- a/code/game/turfs/simulated/wall_attacks.dm
+++ b/code/game/turfs/simulated/wall_attacks.dm
@@ -131,9 +131,12 @@
 
 	user.setClickCooldown(user.get_attack_speed(W))
 
+/*
+//As with the floors, only this time it works AND tries pushing the wall after it's done. 
 	if(!construction_stage && user.a_intent == I_HELP)
 		if(try_graffiti(user,W))
 			return
+*/
 
 	if (!user.IsAdvancedToolUser())
 		to_chat(user, "<span class='warning'>You don't have the dexterity to do this!</span>")

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -8,6 +8,7 @@
 /obj/item/weapon/reagent_containers/syringe
 	name = "syringe"
 	desc = "A syringe."
+	description_fluff = "This could be used to engrave messages on suitable surfaces if you really put your mind to it! Alt-click a floor or wall to engrave with it." //This way it's not a completely hidden, arcane art to engrave.
 	icon = 'icons/obj/syringe.dmi'
 	item_state = "syringe_0"
 	icon_state = "0"


### PR DESCRIPTION
Removes the click prompt for engraving on floors with tools, retains the alt-click option however.

And in line with Soft's comment in the last PR that touched this stuff, about not wanting this to be some arcane feature, the relevant tools now have a small addition to their examine text telling you _how_ to go about doing so.

Oh yeah, I forgot to attach a picture of what _the above_ looks like, so-
![image](https://user-images.githubusercontent.com/24844135/160262920-39d68e91-d001-4a8f-953d-1eb2e9bbb25d.png)
