### PR TITLE
Lets proteans crawl under and over tables.

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/protean_vr/protean_blob.dm
+++ b/code/modules/mob/living/carbon/human/species/station/protean_vr/protean_blob.dm
@@ -13,7 +13,7 @@
 	maxHealth = 200
 	health = 200
 	say_list_type = /datum/say_list/protean_blob
-
+	pass_flags = PASSTABLE
 	show_stat_health = FALSE //We will do it ourselves
 
 	response_help = "pets"


### PR DESCRIPTION
Considering they have the hide verb I'm assuming not being able to pass tables is an oversight.