### PR TITLE
Autoresleever checks for whitelist

### DIFF
--- a/code/modules/resleeving/autoresleever.dm
+++ b/code/modules/resleeving/autoresleever.dm
@@ -76,6 +76,18 @@
 
 	var/client/ghost_client = ghost.client
 	
+	if(!is_alien_whitelisted(ghost, GLOB.all_species[ghost_client?.prefs?.species]) && !check_rights(R_ADMIN, 0)) // Prevents a ghost ghosting in on a slot and spawning via a resleever with race they're not whitelisted for, getting around normal join restrictions.
+		to_chat(ghost, "<span class='warning'>You are not whitelisted to spawn as this species!</span>")
+		return
+	
+	var/datum/species/chosen_species
+	if(ghost.client.prefs.species) // In case we somehow don't have a species set here.
+		chosen_species = GLOB.all_species[ghost_client.prefs.species]
+		
+	if(chosen_species.flags && NO_SCAN) // Sanity. Prevents species like Xenochimera, Proteans, etc from rejoining the round via resleeve, as they should have their own methods of doing so already, as agreed to when you whitelist as them.
+		to_chat(ghost, "<span class='warning'>This species cannot be resleeved!</span>")
+		return
+	
 	//Name matching is ugly but mind doesn't persist to look at.
 	var/charjob
 	var/datum/data/record/record_found

--- a/code/modules/resleeving/autoresleever.dm
+++ b/code/modules/resleeving/autoresleever.dm
@@ -80,6 +80,7 @@
 		to_chat(ghost, "<span class='warning'>You are not whitelisted to spawn as this species!</span>")
 		return
 	
+	/* // Comments out NO_SCAN restriction, as per headmin/maintainer request.
 	var/datum/species/chosen_species
 	if(ghost.client.prefs.species) // In case we somehow don't have a species set here.
 		chosen_species = GLOB.all_species[ghost_client.prefs.species]
@@ -87,6 +88,7 @@
 	if(chosen_species.flags && NO_SCAN) // Sanity. Prevents species like Xenochimera, Proteans, etc from rejoining the round via resleeve, as they should have their own methods of doing so already, as agreed to when you whitelist as them.
 		to_chat(ghost, "<span class='warning'>This species cannot be resleeved!</span>")
 		return
+	*/
 	
 	//Name matching is ugly but mind doesn't persist to look at.
 	var/charjob


### PR DESCRIPTION
As it says.
Autoresleever will abort the spawn attempt if the client is not whitelisted for the species (as currently one can ghost, select an autoresleever, and spawn via it even on a whitelisted species they don't have access to normally.)
~Autoresleever will abort spawn attempt for species with NO_SCAN in their flags. This prevents Xenochimera/Proteans/etc from rejoining via Autoresleevers, as per whitelist expectations - Xenochimera even have specific lore stating they contaminate sleevers.~

Removed as per maintainer request here.

These changes will be applied to regular clonepod + resleeving pod eventually:tm:

Upstream port of sanity feature from https://github.com/CHOMPStation2/CHOMPStation2/pull/3938