### PR TITLE
Re-enables Amber Slime's feed aura (with restrictions)

### DIFF
--- a/code/modules/mob/living/simple_mob/subtypes/slime/xenobio/subtypes.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/slime/xenobio/subtypes.dm
@@ -439,15 +439,16 @@
 		/mob/living/simple_mob/slime/xenobio/amber
 	)
 
-/* VOREStation Edit. We've had enough server crashes.
 /mob/living/simple_mob/slime/xenobio/amber/handle_special()
 	if(stat != DEAD)
 		feed_aura()
 	..()
 
 /mob/living/simple_mob/slime/xenobio/amber/proc/feed_aura()
-	for(var/mob/living/L in view(2, src))
-		if(L == src) // Don't feed themselves, or it is impossible to stop infinite slimes without killing all of the ambers.
+	for(var/mob/living/L in view(1, src))
+		if(L.stat == DEAD || !IIsAlly(L))
+			continue
+		if(L == src || istype(L, /mob/living/simple_mob/slime/xenobio/amber)) // Don't feed themselves, or it is impossible to stop infinite slimes without killing all of the ambers.
 			continue
 		if(istype(L, /mob/living/simple_mob/slime/xenobio))
 			var/mob/living/simple_mob/slime/xenobio/X = L
@@ -457,7 +458,6 @@
 			if(H.isSynthetic())
 				continue
 			H.nutrition = between(0, H.nutrition + rand(15, 25), 800)
-*/
 
 /mob/living/simple_mob/slime/xenobio/cerulean
 	desc = "This slime is generally superior in a wide range of attributes, compared to the common slime.  The jack of all trades, but master of none."


### PR DESCRIPTION
Aura is back. But now it explicitly doesn't work on amber slimes anymore (and not just itself), meaning overly recursive server-crashing splits won't be a thing. Range of the ability has also been reduced by 1, meaning it will now only affect adjacent slimes/people; and made to not affect anything slime considers an enemy (meaning if it wasn't unified, it will not affect other slimes).