### PR TITLE
Trait Tweak - Positives capped at 4, Negatives Uncapped

### DIFF
--- a/code/__defines/misc_vr.dm
+++ b/code/__defines/misc_vr.dm
@@ -20,7 +20,7 @@
 
 //For custom species
 #define STARTING_SPECIES_POINTS 2
-#define MAX_SPECIES_TRAITS 5
+#define MAX_SPECIES_TRAITS 4	// Cap positive traits at 4, given negatives are unlimited. Prior number was 5.
 
 // Xenochimera thing mostly
 #define REVIVING_NOW		-1

--- a/code/modules/client/preference_setup/vore/07_traits.dm
+++ b/code/modules/client/preference_setup/vore/07_traits.dm
@@ -165,28 +165,29 @@
 	if(pref.species == SPECIES_CUSTOM)
 		var/points_left = pref.starting_trait_points
 
-		for(var/T in pref.pos_traits + pref.neg_traits)
+		for(var/T in pref.pos_traits + pref.neg_traits) // Only Positive traits cost slots now.
 			points_left -= traits_costs[T]
+		for(var/T in pref.pos_traits)
 			traits_left--
 		. += "<b>Traits Left:</b> [traits_left]<br>"
 		. += "<b>Points Left:</b> [points_left]<br>"
 		if(points_left < 0 || traits_left < 0 || !pref.custom_species)
 			. += "<span style='color:red;'><b>^ Fix things! ^</b></span><br>"
 
-		. += "<a href='?src=\ref[src];add_trait=[POSITIVE_MODE]'>Positive Trait +</a><br>"
+		. += "<a href='?src=\ref[src];add_trait=[POSITIVE_MODE]'>Positive Trait(s) (Limited) +</a><br>" // More obvious/clear to players.
 		. += "<ul>"
 		for(var/T in pref.pos_traits)
 			var/datum/trait/trait = positive_traits[T]
 			. += "<li>- <a href='?src=\ref[src];clicked_pos_trait=[T]'>[trait.name] ([trait.cost])</a></li>"
 		. += "</ul>"
 
-		. += "<a href='?src=\ref[src];add_trait=[NEGATIVE_MODE]'>Negative Trait +</a><br>"
+		. += "<a href='?src=\ref[src];add_trait=[NEGATIVE_MODE]'>Negative Trait(s) (No Limit) +</a><br>" // More obvious/clear to players.
 		. += "<ul>"
 		for(var/T in pref.neg_traits)
 			var/datum/trait/trait = negative_traits[T]
 			. += "<li>- <a href='?src=\ref[src];clicked_neg_trait=[T]'>[trait.name] ([trait.cost])</a></li>"
 		. += "</ul>"
-	. += "<a href='?src=\ref[src];add_trait=[NEUTRAL_MODE]'>Neutral Trait +</a><br>"
+	. += "<a href='?src=\ref[src];add_trait=[NEUTRAL_MODE]'>Neutral Trait(s) (No Limit) +</a><br>" // More obvious/clear to players.
 	. += "<ul>"
 	for(var/T in pref.neu_traits)
 		var/datum/trait/trait = neutral_traits[T]
@@ -318,7 +319,7 @@
 		for(var/T in pref.pos_traits + pref.neu_traits + pref.neg_traits)
 			points_left -= traits_costs[T]
 
-		var/traits_left = pref.max_traits - (pref.pos_traits.len + pref.neg_traits.len)
+		var/traits_left = pref.max_traits - pref.pos_traits.len // Only positive traits have a slot limit, to prevent broken builds
 
 		var/message = "Select a trait to learn more."
 		if(mode != NEUTRAL_MODE)

--- a/code/modules/mob/new_player/new_player_vr.dm
+++ b/code/modules/mob/new_player/new_player_vr.dm
@@ -48,7 +48,7 @@
 		for(var/datum/trait/T as anything in megalist)
 			var/cost = traits_costs[T]
 
-			if(cost)
+			if(cost > 0)
 				traits_left--
 
 			//A trait was removed from the game


### PR DESCRIPTION
As above.
Traits now have an unlimited amount for negatives, given they are intended to harm you.
Positives have a cap of 4 total.
Prior to this, one could do 4 positives and 1 extremely expensive negative, but no other 'fun' negatives.

Now, one can still do 4 strong positives, but as many negatives as they like.
IDEALLY this will allow for custom setups with a lot of small-cost negatives for higher cost positives.

Upstream port of https://github.com/CHOMPStation2/CHOMPStation2/pull/3958
