### PR TITLE
Tiny pipe fix & gas leak event fix

### DIFF
--- a/code/modules/events/atmos_leak.dm
+++ b/code/modules/events/atmos_leak.dm
@@ -14,25 +14,7 @@
 		/area/shuttle,
 		/area/crew_quarters,
 		/area/holodeck,
-		/area/engineering/engine_room,
-		/area/groundbase/level1/centsquare,
-		/area/groundbase/level1/eastspur,
-		/area/groundbase/level1/northspur,
-		/area/groundbase/level1/southeastspur,
-		/area/groundbase/level1/southwestspur,
-		/area/groundbase/level1/westspur,
-		/area/maintenance/groundbase/level1/netunnel,
-		/area/maintenance/groundbase/level1/nwtunnel,
-		/area/maintenance/groundbase/level1/setunnel,
-		/area/maintenance/groundbase/level1/swtunnel,
-		/area/groundbase/level3/ne,
-		/area/groundbase/level3/nw,
-		/area/groundbase/level3/se,
-		/area/groundbase/level3/sw,
-		/area/groundbase/level3/ne,
-		/area/groundbase/level3/nw,
-		/area/groundbase/level3/se,
-		/area/groundbase/level3/sw
+		/area/engineering/engine_room
 	)
 
 // Decide which area will be targeted!

--- a/code/modules/events/atmos_leak.dm
+++ b/code/modules/events/atmos_leak.dm
@@ -14,7 +14,25 @@
 		/area/shuttle,
 		/area/crew_quarters,
 		/area/holodeck,
-		/area/engineering/engine_room
+		/area/engineering/engine_room,
+		/area/groundbase/level1/centsquare,
+		/area/groundbase/level1/eastspur,
+		/area/groundbase/level1/northspur,
+		/area/groundbase/level1/southeastspur,
+		/area/groundbase/level1/southwestspur,
+		/area/groundbase/level1/westspur,
+		/area/maintenance/groundbase/level1/netunnel,
+		/area/maintenance/groundbase/level1/nwtunnel,
+		/area/maintenance/groundbase/level1/setunnel,
+		/area/maintenance/groundbase/level1/swtunnel,
+		/area/groundbase/level3/ne,
+		/area/groundbase/level3/nw,
+		/area/groundbase/level3/se,
+		/area/groundbase/level3/sw,
+		/area/groundbase/level3/ne,
+		/area/groundbase/level3/nw,
+		/area/groundbase/level3/se,
+		/area/groundbase/level3/sw
 	)
 
 // Decide which area will be targeted!

--- a/maps/groundbase/gb-z1.dmm
+++ b/maps/groundbase/gb-z1.dmm
@@ -7361,6 +7361,12 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/visible/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor,
 /area/groundbase/engineering/storage)
 "um" = (
@@ -10457,8 +10463,12 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/groundbase/engineering/storage)
 "Cy" = (
@@ -11550,6 +11560,12 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
 /area/groundbase/engineering/storage)
 "FP" = (
@@ -12537,11 +12553,17 @@
 /turf/simulated/floor/bluegrid,
 /area/groundbase/command/ai/storage)
 "ID" = (
-/obj/machinery/atmospherics/binary/pump/on{
-	name = "Scrubber to Waste"
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/techmaint,
-/area/groundbase/engineering/atmos)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/groundbase/engineering/storage)
 "IE" = (
 /turf/simulated/floor/outdoors/grass/virgo3c,
 /area/groundbase/civilian/arrivals)
@@ -14852,6 +14874,12 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/groundbase/civilian/bar)
+"OP" = (
+/obj/machinery/atmospherics/binary/pump/on{
+	name = "Scrubber to Waste"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/groundbase/engineering/atmos)
 "OQ" = (
 /obj/machinery/atmospherics/pipe/tank/carbon_dioxide,
 /turf/simulated/floor/tiled/techmaint,
@@ -15609,6 +15637,12 @@
 /obj/structure/dispenser,
 /obj/machinery/status_display{
 	pixel_y = 32
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/groundbase/engineering/storage)
@@ -31956,7 +31990,7 @@ IX
 IX
 ig
 JM
-Zx
+ID
 dX
 KD
 Ra
@@ -34084,13 +34118,13 @@ Ae
 Hr
 Wu
 uL
-ID
+rt
 jM
 jt
 jt
 jt
 jt
-rt
+OP
 vg
 lZ
 vg

--- a/maps/groundbase/groundbase_areas.dm
+++ b/maps/groundbase/groundbase_areas.dm
@@ -369,6 +369,7 @@
 	excluded |= /area/groundbase/level1/westspur
 	excluded |= /area/maintenance/groundbase/level1/netunnel
 	excluded |= /area/maintenance/groundbase/level1/nwtunnel
+	excluded |= /area/maintenance/groundbase/level1/stunnel
 	excluded |= /area/maintenance/groundbase/level1/setunnel
 	excluded |= /area/maintenance/groundbase/level1/swtunnel
 	excluded |= /area/groundbase/level2/ne

--- a/maps/groundbase/groundbase_areas.dm
+++ b/maps/groundbase/groundbase_areas.dm
@@ -358,3 +358,25 @@
 	icon_state = "orablacir"
 /area/groundbase/mining/explored
 	icon_state = "blublacir"
+
+// Exclude some more areas from the atmos leak event since its outside.
+/datum/event/atmos_leak/setup()
+	excluded |= /area/groundbase/level1/centsquare
+	excluded |= /area/groundbase/level1/eastspur
+	excluded |= /area/groundbase/level1/northspur
+	excluded |= /area/groundbase/level1/southeastspur
+	excluded |= /area/groundbase/level1/southwestspur
+	excluded |= /area/groundbase/level1/westspur
+	excluded |= /area/maintenance/groundbase/level1/netunnel
+	excluded |= /area/maintenance/groundbase/level1/nwtunnel
+	excluded |= /area/maintenance/groundbase/level1/setunnel
+	excluded |= /area/maintenance/groundbase/level1/swtunnel
+	excluded |= /area/groundbase/level3/ne
+	excluded |= /area/groundbase/level3/nw
+	excluded |= /area/groundbase/level3/se
+	excluded |= /area/groundbase/level3/sw
+	excluded |= /area/groundbase/level3/ne
+	excluded |= /area/groundbase/level3/nw
+	excluded |= /area/groundbase/level3/se
+	excluded |= /area/groundbase/level3/sw
+	..()

--- a/maps/groundbase/groundbase_areas.dm
+++ b/maps/groundbase/groundbase_areas.dm
@@ -371,10 +371,10 @@
 	excluded |= /area/maintenance/groundbase/level1/nwtunnel
 	excluded |= /area/maintenance/groundbase/level1/setunnel
 	excluded |= /area/maintenance/groundbase/level1/swtunnel
-	excluded |= /area/groundbase/level3/ne
-	excluded |= /area/groundbase/level3/nw
-	excluded |= /area/groundbase/level3/se
-	excluded |= /area/groundbase/level3/sw
+	excluded |= /area/groundbase/level2/ne
+	excluded |= /area/groundbase/level2/nw
+	excluded |= /area/groundbase/level2/se
+	excluded |= /area/groundbase/level2/sw
 	excluded |= /area/groundbase/level3/ne
 	excluded |= /area/groundbase/level3/nw
 	excluded |= /area/groundbase/level3/se


### PR DESCRIPTION
Fixes #12599

Fixes the issue of the gas leak event appearing on the outside (or in tunnels) of the groundbase map, spreading the gas everywhere on the outside.

The "Scrubber to Waste" pump was moved, due to it filling up the mobile scrubbers otherwise.

![grafik](https://user-images.githubusercontent.com/12716288/161398007-8c8154b5-c347-406e-8359-9630b90a23e9.png)
![grafik](https://user-images.githubusercontent.com/12716288/161398015-0ac8dbcf-f218-431e-b79e-3a5e53dc435b.png)
