### PR TITLE
Nerfs gravitons and morphium, adds lots of boards into autolathe

### DIFF
--- a/code/datums/autolathe/engineering_vr.dm
+++ b/code/datums/autolathe/engineering_vr.dm
@@ -25,3 +25,51 @@
 /datum/category_item/autolathe/engineering/candymachine
 	name = "candy machine electronics"
 	path =/obj/item/weapon/circuitboard/candymachine
+
+/datum/category_item/autolathe/engineering/battle_arcade
+	name = "battle arcade machine electronics"
+	path =/obj/item/weapon/circuitboard/arcade/battle
+
+/datum/category_item/autolathe/engineering/orion_trail
+	name = "orion trail aracade machine electronics"
+	path =/obj/item/weapon/circuitboard/arcade/orion_trail
+
+/datum/category_item/autolathe/engineering/clawmachine
+	name = "claw machine electronics"
+	path =/obj/item/weapon/circuitboard/arcade/clawmachine
+
+/datum/category_item/autolathe/engineering/jukebox
+	name = "jukebox electronics"
+	path =/obj/item/weapon/circuitboard/jukebox
+
+/datum/category_item/autolathe/engineering/mech_recharger
+	name = "mech recharging station electronics"
+	path =/obj/item/weapon/circuitboard/mech_recharger
+
+/datum/category_item/autolathe/engineering/recharge_station
+	name = "cyborg recharging station electronics"
+	path =/obj/item/weapon/circuitboard/recharge_station
+
+/datum/category_item/autolathe/engineering/batteryrack
+	name = "battery rack electronics"
+	path =/obj/item/weapon/circuitboard/batteryrack
+
+/datum/category_item/autolathe/engineering/grid_checker
+	name = "grid checker electronics"
+	path =/obj/item/weapon/circuitboard/grid_checker
+
+/datum/category_item/autolathe/engineering/breakerbox
+	name = "breaker box electronics"
+	path =/obj/item/weapon/circuitboard/breakerbox
+
+/datum/category_item/autolathe/engineering/gas_heater
+	name = "gas heater electronics"
+	path =/obj/item/weapon/circuitboard/unary_atmos/heater
+
+/datum/category_item/autolathe/engineering/gas_cooler
+	name = "gas cooler electronics"
+	path =/obj/item/weapon/circuitboard/unary_atmos/cooler
+
+/datum/category_item/autolathe/engineering/arf_generator
+	name = "atmospheric field generator electronics"
+	path =/obj/item/weapon/circuitboard/arf_generator

--- a/code/modules/materials/materials/gems.dm
+++ b/code/modules/materials/materials/gems.dm
@@ -148,7 +148,7 @@
 	explosion_resistance = 85
 	reflectivity = 0.2
 	radiation_resistance = 10
-	stack_origin_tech = list(TECH_MATERIAL = 8, TECH_ILLEGAL = 1, TECH_PHORON = 4, TECH_BLUESPACE = 4, TECH_ARCANE = 1)
+	stack_origin_tech = list(TECH_MATERIAL = 8, TECH_PHORON = 4, TECH_BLUESPACE = 4)
 	supply_conversion_value = 13
 
 

--- a/code/modules/research/designs/HUDs.dm
+++ b/code/modules/research/designs/HUDs.dm
@@ -41,7 +41,7 @@
 /datum/design/item/hud/graviton_visor
 	name = "graviton visor"
 	id = "graviton_goggles"
-	req_tech = list(TECH_MAGNET = 5, TECH_ENGINEERING = 3, TECH_BLUESPACE = 3, TECH_PHORON = 3)
-	materials = list(MAT_PLASTEEL = 2000, MAT_GLASS = 3000, MAT_PHORON = 1500)
+	req_tech = list(TECH_MAGNET = 5, TECH_ENGINEERING = 3, TECH_BLUESPACE = 3, TECH_PHORON = 3, TECH_ARCANE = 1)
+	materials = list(MAT_PLASTEEL = 2000, MAT_GLASS = 3000, MAT_PHORON = 1500, MAT_DIAMOND = 500)
 	build_path = /obj/item/clothing/glasses/graviton
 	sort_string = "EAAAE"


### PR DESCRIPTION
Gravitons now require first level Anomaly and 500 units (1/4th of a sheet) of diamonds to construct.
Morphium no longer gives Anomaly levels.

Adds following boards to autolathe: all three arcasdes, jukebox, mech recharger, borg recharger, battery rack, grid checker, breaker box, atmos heater and cooler, ARF.