### PR TITLE
Makes NIFSoft vision modifiers mutually exclusive with goggle/visor based ones

### DIFF
--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -584,7 +584,7 @@
 				to_chat(src, "<span class='danger'>You feel your face burning and a searing heat in your lungs!</span>")
 
 		if(breath.temperature >= species.heat_discomfort_level)
-		
+
 			if(breath.temperature >= species.breath_heat_level_3)
 				apply_damage(HEAT_GAS_DAMAGE_LEVEL_3, BURN, BP_HEAD, used_weapon = "Excessive Heat")
 				throw_alert("temp", /obj/screen/alert/hot, HOT_ALERT_SEVERITY_MAX)
@@ -1408,12 +1408,10 @@
 		if(istype(rig) && rig.visor && !looking_elsewhere)
 			if(!rig.helmet || (head && rig.helmet == head))
 				if(rig.visor && rig.visor.vision && rig.visor.active && rig.visor.vision.glasses)
-					glasses_processed = 1
-					process_glasses(rig.visor.vision.glasses)
+					glasses_processed = process_glasses(rig.visor.vision.glasses)
 
 		if(glasses && !glasses_processed && !looking_elsewhere)
-			glasses_processed = 1
-			process_glasses(glasses)
+			glasses_processed = process_glasses(glasses)
 		if(XRAY in mutations)
 			sight |= SEE_TURFS|SEE_MOBS|SEE_OBJS
 			see_in_dark = 8
@@ -1422,6 +1420,15 @@
 		for(var/datum/modifier/M in modifiers)
 			if(!isnull(M.vision_flags))
 				sight |= M.vision_flags
+
+		if(!glasses_processed && nif)
+			var/datum/nifsoft/vision_soft
+			for(var/datum/nifsoft/NS in nif.nifsofts)
+				if(NS.vision_exclusive && NS.active)
+					vision_soft = NS
+					break
+			if(vision_soft)
+				glasses_processed = process_nifsoft_vision(vision_soft)		//not really glasses but equitable
 
 		if(!glasses_processed && (species.get_vision_flags(src) > 0))
 			sight |= species.get_vision_flags(src)
@@ -1451,19 +1458,34 @@
 	return 1
 
 /mob/living/carbon/human/proc/process_glasses(var/obj/item/clothing/glasses/G)
+	. = FALSE
 	if(G && G.active)
-		see_in_dark += G.darkness_view
+		if(G.darkness_view)
+			see_in_dark += G.darkness_view
+			. = TRUE
 		if(G.overlay && client)
 			client.screen |= G.overlay
 		if(G.vision_flags)
 			sight |= G.vision_flags
+			. = TRUE
 		if(istype(G,/obj/item/clothing/glasses/night) && !seer)
 			see_invisible = SEE_INVISIBLE_MINIMUM
 
 		if(G.see_invisible >= 0)
 			see_invisible = G.see_invisible
+			. = TRUE
 		else if(!druggy && !seer)
 			see_invisible = see_invisible_default
+
+/mob/living/carbon/human/proc/process_nifsoft_vision(var/datum/nifsoft/NS)
+	. = FALSE
+	if(NS && NS.active)
+		if(NS.darkness_view)
+			see_in_dark += NS.darkness_view
+			. = TRUE
+		if(NS.vision_flags_mob)
+			sight |= NS.vision_flags_mob
+			. = TRUE
 
 /mob/living/carbon/human/handle_random_events()
 	if(inStasisNow())

--- a/code/modules/nifsoft/nifsoft.dm
+++ b/code/modules/nifsoft/nifsoft.dm
@@ -35,7 +35,12 @@
 	var/combat_flags = 0	// Otherwise use set_flag/clear_flag in one of your own procs for tricks
 	var/other_flags = 0
 
+	var/vision_flags_mob = 0
+	var/darkness_view = 0
+
 	var/list/planes_enabled = null	// List of vision planes this nifsoft enables when active
+
+	var/vision_exclusive = FALSE	//Whether or not this NIFSoft provides exclusive vision modifier
 
 	var/list/incompatible_with = null // List of NIFSofts that are disabled when this one is enabled
 
@@ -99,6 +104,11 @@
 		nif.set_flag(combat_flags,NIF_FLAGS_COMBAT)
 		nif.set_flag(other_flags,NIF_FLAGS_OTHER)
 
+		if(vision_exclusive)
+			var/mob/living/carbon/human/H = nif.human
+			if(H && istype(H))
+				H.recalculate_vis()
+
 	return nif_result
 
 //Called when attempting to deactivate an implant
@@ -121,6 +131,11 @@
 		nif.clear_flag(health_flags,NIF_FLAGS_HEALTH)
 		nif.clear_flag(combat_flags,NIF_FLAGS_COMBAT)
 		nif.clear_flag(other_flags,NIF_FLAGS_OTHER)
+
+		if(vision_exclusive)
+			var/mob/living/carbon/human/H = nif.human
+			if(H && istype(H))
+				H.recalculate_vis()
 
 	return nif_result
 
@@ -215,7 +230,7 @@
 			qdel(src)
 		else
 			new stored_organic(Ht.nif,extra)
-			qdel(src)		
+			qdel(src)
 	else
 		icon_state = "[initial(icon_state)]"	//If it fails to apply to a valid target and doesn't get deleted, reset its icon state
 		update_icon()
@@ -348,7 +363,7 @@
 
 /datum/nifsoft/package/mining
 	software = list(/datum/nifsoft/material,/datum/nifsoft/spare_breath)
-	
+
 /datum/nifsoft/package/mining_synth
 	software = list(/datum/nifsoft/material,/datum/nifsoft/pressure,/datum/nifsoft/heatsinks)
 

--- a/code/modules/nifsoft/software/01_vision.dm
+++ b/code/modules/nifsoft/software/01_vision.dm
@@ -104,14 +104,9 @@
 	tick_flags = NIF_ACTIVETICK
 	planes_enabled = list(VIS_FULLBRIGHT, VIS_MESONS)
 	vision_flags = (NIF_V_MESONS)
+	vision_flags_mob = SEE_TURFS
 	incompatible_with = list(NIF_MATERIAL,NIF_THERMALS,NIF_NIGHTVIS)
-
-/datum/nifsoft/mesons/life()
-	if((. = ..()))
-		var/mob/living/carbon/human/H = nif.human
-		H.sight |= SEE_TURFS
-		if(H.client)
-			H.client.screen |= global_hud.meson
+	vision_exclusive = TRUE
 
 /datum/nifsoft/material
 	name = "Material Scanner"
@@ -123,14 +118,9 @@
 	tick_flags = NIF_ACTIVETICK
 	planes_enabled = list(VIS_FULLBRIGHT)
 	vision_flags = (NIF_V_MATERIAL)
+	vision_flags_mob = SEE_OBJS
 	incompatible_with = list(NIF_MESONS,NIF_THERMALS,NIF_NIGHTVIS)
-
-/datum/nifsoft/material/life()
-	if((. = ..()))
-		var/mob/living/carbon/human/H = nif.human
-		H.sight |= SEE_OBJS
-		if(H.client)
-			H.client.screen |= global_hud.material
+	vision_exclusive = TRUE
 
 /datum/nifsoft/thermals
 	name = "Thermal Scanner"
@@ -143,14 +133,9 @@
 	tick_flags = NIF_ACTIVETICK
 	planes_enabled = list(VIS_FULLBRIGHT, VIS_CLOAKED)
 	vision_flags = (NIF_V_THERMALS)
+	vision_flags_mob = SEE_MOBS
 	incompatible_with = list(NIF_MESONS,NIF_MATERIAL,NIF_NIGHTVIS)
-
-/datum/nifsoft/thermals/life()
-	if((. = ..()))
-		var/mob/living/carbon/human/H = nif.human
-		H.sight |= SEE_MOBS
-		if(H.client)
-			H.client.screen |= global_hud.thermal
+	vision_exclusive = TRUE
 
 /datum/nifsoft/nightvis
 	name = "Low-Light Amp"
@@ -162,11 +147,6 @@
 	tick_flags = NIF_ACTIVETICK
 	planes_enabled = list(VIS_FULLBRIGHT)
 	vision_flags = (NIF_V_NIGHTVIS)
+	darkness_view = 7
 	incompatible_with = list(NIF_MESONS,NIF_MATERIAL,NIF_THERMALS)
-
-/datum/nifsoft/nightvis/life()
-	if((. = ..()))
-		var/mob/living/carbon/human/H = nif.human
-		H.see_in_dark += 7
-		if(H.client)
-			H.client.screen |= global_hud.nvg
+	vision_exclusive = TRUE


### PR DESCRIPTION
Applies to mesons, nightvision, materials and thermals. 