### PR TITLE
Fixing Stack Stacking

### DIFF
--- a/vorestation.dme
+++ b/vorestation.dme
@@ -1239,6 +1239,7 @@
 #include "code\game\objects\items\stacks\nanopaste_vr.dm"
 #include "code\game\objects\items\stacks\sandbags.dm"
 #include "code\game\objects\items\stacks\stack.dm"
+#include "code\game\objects\items\stacks\stack_vr.dm"
 #include "code\game\objects\items\stacks\telecrystal.dm"
 #include "code\game\objects\items\stacks\tickets.dm"
 #include "code\game\objects\items\stacks\tiles\fifty_spawner_tiles.dm"


### PR DESCRIPTION
Somehow I disabled stack_vr.dm from #12680 in #12685 

This fixes the oversight and enables the proper functionality of #12680 