### PR TITLE
Sapience Vore

### DIFF
--- a/code/modules/xenobio/items/slimepotions_vr.dm
+++ b/code/modules/xenobio/items/slimepotions_vr.dm
@@ -164,6 +164,8 @@
 	to_chat(user, "<span class='notice'>You feed \the [M] the agent. It may now eventually develop proper sapience.</span>")
 	M.ghostjoin = 1
 	active_ghost_pods |= M
+	if!(/mob/living/simple_mob/proc/animal_nom in M.verbs)
+		M.verbs += /mob/living/simple_mob/proc/animal_nom
 	M.ghostjoin_icon()
 	log_and_message_admins("[key_name_admin(user)] used a sapience potion on a simple mob: [M]. [ADMIN_FLW(src)]")
 	playsound(src, 'sound/effects/bubbles.ogg', 50, 1)

--- a/code/modules/xenobio/items/slimepotions_vr.dm
+++ b/code/modules/xenobio/items/slimepotions_vr.dm
@@ -164,7 +164,7 @@
 	to_chat(user, "<span class='notice'>You feed \the [M] the agent. It may now eventually develop proper sapience.</span>")
 	M.ghostjoin = 1
 	active_ghost_pods |= M
-	if!(/mob/living/simple_mob/proc/animal_nom in M.verbs)
+	if(!M.vore_active)
 		M.verbs += /mob/living/simple_mob/proc/animal_nom
 	M.ghostjoin_icon()
 	log_and_message_admins("[key_name_admin(user)] used a sapience potion on a simple mob: [M]. [ADMIN_FLW(src)]")

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -4102,7 +4102,6 @@
 #include "maps\expedition_vr\beach\submaps\mountains.dm"
 #include "maps\expedition_vr\beach\submaps\mountains_areas.dm"
 #include "maps\gateway_archive_vr\blackmarketpackers.dm"
-#include "maps\groundbase\groundbase.dm"
 #include "maps\offmap_vr\om_ships\abductor.dm"
 #include "maps\southern_cross\items\clothing\sc_accessory.dm"
 #include "maps\southern_cross\items\clothing\sc_suit.dm"
@@ -4119,5 +4118,6 @@
 #include "maps\submaps\space_submaps\debrisfield\debrisfield.dm"
 #include "maps\submaps\surface_submaps\wilderness\wilderness.dm"
 #include "maps\submaps\surface_submaps\wilderness\wilderness_areas.dm"
+#include "maps\virgo_minitest\virgo_minitest.dm"
 #include "maps\~map_system\maps.dm"
 // END_INCLUDE

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -4102,6 +4102,7 @@
 #include "maps\expedition_vr\beach\submaps\mountains.dm"
 #include "maps\expedition_vr\beach\submaps\mountains_areas.dm"
 #include "maps\gateway_archive_vr\blackmarketpackers.dm"
+#include "maps\groundbase\groundbase.dm"
 #include "maps\offmap_vr\om_ships\abductor.dm"
 #include "maps\southern_cross\items\clothing\sc_accessory.dm"
 #include "maps\southern_cross\items\clothing\sc_suit.dm"
@@ -4118,6 +4119,5 @@
 #include "maps\submaps\space_submaps\debrisfield\debrisfield.dm"
 #include "maps\submaps\surface_submaps\wilderness\wilderness.dm"
 #include "maps\submaps\surface_submaps\wilderness\wilderness_areas.dm"
-#include "maps\virgo_minitest\virgo_minitest.dm"
 #include "maps\~map_system\maps.dm"
 // END_INCLUDE


### PR DESCRIPTION
Gives non vore mobs the animal nom verb when fed a sapience potion, allowing for ghosts to use them for vore after setting up custom bellies.