### PR TITLE
Lettuce Eat

### DIFF
--- a/code/modules/economy/vending_machines.dm
+++ b/code/modules/economy/vending_machines.dm
@@ -530,6 +530,7 @@
 					/obj/item/seeds/cocoapodseed = 3,
 					/obj/item/seeds/plumpmycelium = 2,
 					/obj/item/seeds/cabbageseed = 3,
+					/obj/item/seeds/lettuce = 3,
 					/obj/item/seeds/grapeseed = 3,
 					/obj/item/seeds/pumpkinseed = 3,
 					/obj/item/seeds/cherryseed = 3,

--- a/code/modules/food/recipes_grill.dm
+++ b/code/modules/food/recipes_grill.dm
@@ -281,7 +281,7 @@
 		/obj/item/weapon/reagent_containers/food/snacks/carpmeat
 	)
 	reagents = list("spacespice" = 1)
-	fruit = list("cabbage" = 1, "lime" = 1)
+	fruit = list("lettuce" = 1, "lime" = 1)
 	result = /obj/item/weapon/reagent_containers/food/snacks/sliceable/grilled_carp
 
 /datum/recipe/grilledcheese

--- a/code/modules/food/recipes_microwave.dm
+++ b/code/modules/food/recipes_microwave.dm
@@ -433,7 +433,7 @@ I said no!
 	result = /obj/item/weapon/reagent_containers/food/snacks/beetsoup
 
 /datum/recipe/tossedsalad
-	fruit = list("cabbage" = 2, "tomato" = 1, "carrot" = 1, "apple" = 1)
+	fruit = list("lettuce" = 2, "tomato" = 1, "carrot" = 1, "apple" = 1)
 	result = /obj/item/weapon/reagent_containers/food/snacks/tossedsalad
 
 /datum/recipe/flowersalad
@@ -1083,7 +1083,7 @@ I said no!
 	result = /obj/item/weapon/reagent_containers/food/snacks/fish_taco
 
 /datum/recipe/blt
-	fruit = list("tomato" = 1, "cabbage" = 1)
+	fruit = list("tomato" = 1, "lettuce" = 1)
 	items = list(
 		/obj/item/weapon/reagent_containers/food/snacks/slice/bread,
 		/obj/item/weapon/reagent_containers/food/snacks/slice/bread,

--- a/code/modules/food/recipes_microwave_vr.dm
+++ b/code/modules/food/recipes_microwave_vr.dm
@@ -100,7 +100,7 @@
 	result = /obj/item/weapon/reagent_containers/food/snacks/sliceable/sushi
 
 /datum/recipe/lobster
-	fruit = list("lemon" = 1, "cabbage" = 1)
+	fruit = list("lemon" = 1, "lettuce" = 1)
 	items = list(
 		/obj/item/weapon/reagent_containers/food/snacks/lobster
 	)

--- a/code/modules/hydroponics/seedtypes/lettuce.dm
+++ b/code/modules/hydroponics/seedtypes/lettuce.dm
@@ -3,7 +3,7 @@
 	name = "lettuce"
 	seed_name = "lettuce"
 	display_name = "lettuce"
-	kitchen_tag = "cabbage"
+	kitchen_tag = "lettuce"
 	chems = list("nutriment" = list(1,15))
 
 /datum/seed/lettuce/New()

--- a/code/modules/reagents/reagents/food_drinks.dm
+++ b/code/modules/reagents/reagents/food_drinks.dm
@@ -1004,6 +1004,16 @@
 	..()
 	M.reagents.add_reagent("imidazoline", removed * 0.2)
 
+/datum/reagent/drink/juice/lettuce
+	name = "Lettuce Juice"
+	id = "lettucejuice"
+	description = "It's mostly water, just a bit more lettucy."
+	taste_description = "fresh greens"
+	color = "#29df4b"
+
+	glass_name = "lettuce juice"
+	glass_desc = "This is just lettuce water. Fresh but boring."
+
 /datum/reagent/drink/juice
 	name = "Grape Juice"
 	id = "grapejuice"
@@ -1092,7 +1102,7 @@
 	glass_desc = "Vitamins! Yay!"
 	allergen_type = ALLERGEN_FRUIT //Oranges are fruit
 
-/datum/reagent/drink/orangejuice/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed)
+/datum/reagent/drink/juice/orange/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed)
 	..()
 	if(alien == IS_DIONA)
 		return


### PR DESCRIPTION
Celebrate Easter with this Rabbit approved food item.

Correctly ports over https://github.com/PolarisSS13/Polaris/pull/8536/files from Polaris.

Commit Description from Polaris:
We literally had lettuces this entire time but they weren't accessible and were functionally cabbages. What the fuck.
Changes a bunch of recipes that should absolutely use lettuce and not cabbage to use lettuce.
(Will require wiki update once merged, pls ping)

Also lettuce juice for the jokes and also fixes an undetected weirdness with orange juice pathing by accident.