### PR TITLE
Adds transcore ping to brainmobs

### DIFF
--- a/code/modules/mob/living/carbon/brain/brain.dm
+++ b/code/modules/mob/living/carbon/brain/brain.dm
@@ -70,3 +70,31 @@
 		typing = FALSE
 
 	return state
+
+// Vorestation edit start
+
+/mob/living/carbon/brain/verb/backup_ping()
+	set category = "IC"
+	set name = "Notify Transcore"
+	set desc = "Your body is gone. Notify robotics to be resleeved!"
+	var/datum/transcore_db/db = SStranscore.db_by_mind_name(mind.name)
+	if(db)
+		var/datum/transhuman/mind_record/record = db.backed_up[src.mind.name]
+		if(!(record.dead_state == MR_DEAD))	
+			if((world.time - timeofhostdeath ) > 5 MINUTES)	//Allows notify transcore to be used if you have an entry but for some reason weren't marked as dead
+				record.dead_state = MR_DEAD				//Such as if you got scanned but didn't take an implant. It's a little funky, but I mean, you got scanned
+				db.notify(record)						//So you probably will want to let someone know if you die.
+				record.last_notification = world.time
+				to_chat(src, "<span class='notice'>New notification has been sent.</span>")
+			else
+				to_chat(src, "<span class='warning'>Your backup is not past-due yet.</span>")
+		else if((world.time - record.last_notification) < 5 MINUTES)
+			to_chat(src, "<span class='warning'>Too little time has passed since your last notification.</span>")
+		else
+			db.notify(record)
+			record.last_notification = world.time
+			to_chat(src, "<span class='notice'>New notification has been sent.</span>")
+	else
+		to_chat(src,"<span class='warning'>No backup record could be found, sorry.</span>")
+
+// VS edit ends


### PR DESCRIPTION
Normally, posibrains relied on automatic notification to notify robotics they need resleeving. This was removed due to to autoresleeving.

For a posibrain to notify robotics, they had to ghost out of their posibrain to do so. With this, I ran into issues which I believe were not yet fixed (https://github.com/VOREStation/VOREStation/issues/12512) 

It should work fine as long as you don't ghost out of your posi. 

As such, I decided to add the ability to posibrains that were gibbed/had their body digested to notify robotics/science they need a new body. This appears as a verb in the "IC" tab.


**Testing:**

- Posibrain crew does NOT get the verb while alive.
- Posibrain DOES get the verb after getting gibbed.
- On local testing, backup implants did not work for organics nor synthethics. Kiosk worked. I think this may be due to backup frequency or local server issues.
- After pressing notify transcore, science intercom successfully called for resleeving in case of IPC.
- After pressing notify transcore, medical intercom successfully did NOT call for resleeving in case of IPC
- Could NOT test the actual resleeving process. However, the notification ping should NOT affect that, therefore it SHOULD be fine. Resleeving as posibrain worked last I checked, as long as you don't ghost out.

**Possible issue:**
Current implementation theoretically also allows MMIs and dronebrains if they become brainmobs to do the same. I do not think this is an issue.