### PR TITLE
Adjust default prefs

### DIFF
--- a/code/modules/mob/living/simple_mob/simple_mob_vr.dm
+++ b/code/modules/mob/living/simple_mob/simple_mob_vr.dm
@@ -50,6 +50,8 @@
 
 	var/obj/item/device/radio/headset/mob_headset/mob_radio		//Adminbus headset for simplemob shenanigans.
 	does_spin = FALSE
+	can_be_drop_pred = TRUE				// Mobs are pred by default.
+
 
 // Release belly contents before being gc'd!
 /mob/living/simple_mob/Destroy()

--- a/code/modules/vore/eating/living_vr.dm
+++ b/code/modules/vore/eating/living_vr.dm
@@ -31,11 +31,11 @@
 	var/drain_finalized = 0				// Determines if the succubus drain will be KO'd/absorbed. Can be toggled on at any time.
 	var/fuzzy = 0						// Preference toggle for sharp/fuzzy icon.
 	var/permit_healbelly = TRUE
-	var/stumble_vore = FALSE
-	var/slip_vore = FALSE
-	var/drop_vore = FALSE
+	var/stumble_vore = TRUE				//Enabled by default since you have to enable drop pred/prey to do this anyway
+	var/slip_vore = TRUE				//Enabled by default since you have to enable drop pred/prey to do this anyway
+	var/drop_vore = TRUE				//Enabled by default since you have to enable drop pred/prey to do this anyway
 	var/can_be_drop_prey = FALSE
-	var/can_be_drop_pred = TRUE			// Mobs are pred by default.
+	var/can_be_drop_pred = FALSE
 	var/allow_spontaneous_tf = FALSE	// Obviously.
 	var/next_preyloop					// For Fancy sound internal loop
 	var/adminbus_trash = FALSE			// For abusing trash eater for event shenanigans.


### PR DESCRIPTION
Makes it so the stumble/slip/drop vore prefs are on by default, since you have to have the spontaneous vore option enabled for them to work to begin with. 

I figure, most people who wanted spontaneous vore on or off are probably okay with the various flavors of it if they had it on to begin with, otherwise they probably had it off. So, this would effectively return the default option to the previous norm, while still allowing for the nuance the new prefs allow for. (anyone who's saved their vore panel since then will have to update their prefs though)

Also makes both spontaneous vore options off by default for consistency. (And moves the enabling of the pred option to the simple mob file since that's what that was for anyway)