### PR TITLE
Mob Examine

### DIFF
--- a/code/modules/examine/examine_vr.dm
+++ b/code/modules/examine/examine_vr.dm
@@ -1,4 +1,4 @@
-/mob/verb/mob_examine(atom/A as mob in view(world.view, get_turf(src)))
+/mob/verb/mob_examine(atom/A as mob)
 	set name = "Mob Examine"
 	set desc = "Allows one to examine mobs they can see, even from inside of bellies and objects."
 	set category = "IC"
@@ -7,39 +7,42 @@
 		to_chat(src, "<span class='notice'>Something is there but you can't see it.</span>")
 		return 1
 
-	if(!isbelly(loc) && !istype(loc, /obj/item/weapon/holder))
+	if(!isbelly(loc) && !istype(loc, /obj/item/weapon/holder) && !isAI(src))
 		examinate(A)
 		return
-	if(!A)
-		return
-	var/list/results = A.examine(src)
-	if(!results || !results.len)
-		results = list("You were unable to examine that. Tell a developer!")
-	to_chat(src, jointext(results, "<br>"))
-	update_examine_panel(A)
-
-/mob/living/silicon/ai/mob_examine(atom/A as mob)
-	set name = "Mob Examine"
-	set desc = "Allows one to examine mobs they can see, even from inside of bellies and objects."
-	set category = "IC"
-	
 	var/list/E = list()
-	for(var/e in all_eyes)
-		for(var/atom/M as mob in view(world.view, get_turf(e)))
-			if(M == src || istype(M, /mob/observer/eye/aiEye))
+	if(isAI(src))
+		var/mob/living/silicon/ai/my_ai = src
+		for(var/e in my_ai.all_eyes)
+			for(var/atom/M in view(world.view, get_turf(e)))
+				if(M == src || istype(M, /mob/observer))
+					continue
+				if(ismob(M))
+					if(A && A == M)
+						var/list/results = A.examine(src)
+						if(!results || !results.len)
+							results = list("You were unable to examine that. Tell a developer!")
+						to_chat(src, jointext(results, "<br>"))
+						update_examine_panel(A)
+						return
+					else
+						E |= M	
+		if(E.len == 0)
+			return
+	else
+		for(var/atom/M in view(world.view, get_turf(src)))
+			if(M == src || istype(M, /mob/observer))
 				continue
-			if(ismob(M))
-				if(A && A == M)
-					var/list/results = A.examine(src)
-					if(!results || !results.len)
-						results = list("You were unable to examine that. Tell a developer!")
-					to_chat(src, jointext(results, "<br>"))
-					update_examine_panel(A)
-					return
-				else
-					E |= M	
+			E |= M	
 	if(E.len == 0)
 		return
+	if(A && A in E)
+		var/list/results = A.examine(src)
+		if(!results || !results.len)
+			results = list("You were unable to examine that. Tell a developer!")
+			to_chat(src, jointext(results, "<br>"))
+			update_examine_panel(A)
+			return
 	var/atom/B = input(usr, "What would you like to examine?", "Examine") as mob in E
 	if(!B)
 		return

--- a/code/modules/examine/examine_vr.dm
+++ b/code/modules/examine/examine_vr.dm
@@ -1,0 +1,19 @@
+/mob/verb/mob_examine(atom/A as mob in view(world.view, get_turf(src)))
+	set name = "Mob Examine"
+	set desc = "Allows one to examine mobs they can see, even from inside of bellies and objects."
+	set category = "IC"
+
+	if((is_blind(src) || usr.stat) && !isobserver(src))
+		to_chat(src, "<span class='notice'>Something is there but you can't see it.</span>")
+		return 1
+
+	if(!isbelly(loc) && !istype(loc, /obj/item/weapon/holder))
+		examinate(A)
+		return
+	if(!A)
+		return
+	var/list/results = A.examine(src)
+	if(!results || !results.len)
+		results = list("You were unable to examine that. Tell a developer!")
+	to_chat(src, jointext(results, "<br>"))
+	update_examine_panel(A)

--- a/code/modules/examine/examine_vr.dm
+++ b/code/modules/examine/examine_vr.dm
@@ -11,7 +11,16 @@
 	if(isAI(src))
 		var/mob/living/silicon/ai/my_ai = src
 		for(var/e in my_ai.all_eyes)
-			for(var/atom/M in view(world.view, get_turf(e)))
+			var/turf/my_turf = get_turf(e)
+			var/foundcam = FALSE
+			for(var/obj/cam in view(world.view, my_turf))
+				if(istype(cam, /obj/machinery/camera))
+					var/obj/machinery/camera/mycam = cam
+					if(!mycam.stat)
+						foundcam = TRUE
+			if(!foundcam)
+				continue
+			for(var/atom/M in view(world.view, my_turf))
 				if(M == src || istype(M, /mob/observer))
 					continue
 				if(ismob(M) && !M.invisibility)

--- a/code/modules/examine/examine_vr.dm
+++ b/code/modules/examine/examine_vr.dm
@@ -57,13 +57,6 @@
 	if(E.len == 0)
 		to_chat(src, SPAN_NOTICE("There are no mobs to examine."))
 		return
-	if(src && src in E)
-		var/list/results = src.examine(src)
-		if(!results || !results.len)
-			results = list("You were unable to examine that. Tell a developer!")
-			to_chat(src, jointext(results, "<br>"))
-			update_examine_panel(src)
-			return
 	var/atom/B = null
 	if(E.len == 1)
 		B = pick(E)

--- a/code/modules/examine/examine_vr.dm
+++ b/code/modules/examine/examine_vr.dm
@@ -17,3 +17,67 @@
 		results = list("You were unable to examine that. Tell a developer!")
 	to_chat(src, jointext(results, "<br>"))
 	update_examine_panel(A)
+
+/mob/living/silicon/ai/mob_examine(atom/A as mob)
+	set name = "Mob Examine"
+	set desc = "Allows one to examine mobs they can see, even from inside of bellies and objects."
+	set category = "IC"
+	
+	var/list/E = list()
+	for(var/e in all_eyes)
+		for(var/atom/M as mob in view(world.view, get_turf(e)))
+			if(M == src || istype(M, /mob/observer/eye/aiEye))
+				continue
+			if(ismob(M))
+				if(A && A == M)
+					var/list/results = A.examine(src)
+					if(!results || !results.len)
+						results = list("You were unable to examine that. Tell a developer!")
+					to_chat(src, jointext(results, "<br>"))
+					update_examine_panel(A)
+					return
+				else
+					E |= M	
+	if(E.len == 0)
+		return
+	var/atom/B = input(usr, "What would you like to examine?", "Examine") as mob in E
+	if(!B)
+		return
+	var/list/results = B.examine(src)
+	if(!results || !results.len)
+		results = list("You were unable to examine that. Tell a developer!")
+	to_chat(src, jointext(results, "<br>"))
+	update_examine_panel(B)
+
+/turf/simulated/open/verb/examine_below(mob/usr)
+	set name = "Examine Below"
+	set desc = "Allows one to examine things below them."
+	set src in oview(7)
+
+	
+	var/list/E = list()
+	var/list/T = list()
+	
+	var/keepgoing = TRUE
+	while(keepgoing)
+		var/t = GetBelow(src)
+		T |= t
+		if(!isopenspace(t))
+			keepgoing = FALSE
+	
+	for(var/trf in T)
+		for(var/O in trf)
+			if(isopenspace(O))
+				continue
+			E |= O
+
+	if(E.len == 0)
+		return
+	var/atom/B = input(usr, "What would you like to examine?", "Examine") as anything in E
+	if(!B)
+		return
+	var/list/results = B.examine(usr)
+	if(!results || !results.len)
+		results = list("You were unable to examine that. Tell a developer!")
+	to_chat(usr, jointext(results, "<br>"))
+	usr.update_examine_panel(B)

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -2227,6 +2227,7 @@
 #include "code\modules\events\supply_demand_vr.dm"
 #include "code\modules\events\wallrot.dm"
 #include "code\modules\examine\examine.dm"
+#include "code\modules\examine\examine_vr.dm"
 #include "code\modules\examine\stat_icons.dm"
 #include "code\modules\examine\descriptions\armor.dm"
 #include "code\modules\examine\descriptions\atmospherics.dm"


### PR DESCRIPTION
Introduces the 'Mob Examine' verb, which lives in the IC tab. 

This verb is functionally identical to regular examine, except:
-Mob Examine only works on mobs
-Mob Examine will allow you to examine people your character cannot technically 'see', such as in cases where you are in a belly, or in a micro holder, or you are in a locker, or you are an AI.

They do need to be visible to the turf whatever you are in occupies though, so it's not like you'll be able to xray people through walls, or inside of other people. However, this should enable people who are being held in hands or in tummies to examine the people around whoever is holding them for purposes of checking prefs and descriptions.

As a note, I did try to add this on to the basic examine verb to make it more seamless, but how examine gathers its targets is not something I really understand, and the way it works totally fails out before it even gets to the code in the verb, so I can't just tell it to run this proc if they're in a belly or a holder, and I didn't want to break some obscure part of how examine works by changing it. SO! Separate verb.

I also managed to get this to work with AIs and their eyes. It's a little more janky than I wish it was, since the eye needs to be in line of sight of the person. BUT! It does let the AI examine people, they might just have to get their eye up real close to them to get it to work. If you follow the person you want to examine it should work just fine.
