### PR TITLE
Solar Tweak!

### DIFF
--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -1,4 +1,4 @@
-#define SOLAR_MAX_DIST 40
+//#define SOLAR_MAX_DIST 40		//VOREStation Removal
 #define SOLAR_AUTO_START_NO     0 // Will never start itself.
 #define SOLAR_AUTO_START_YES    1 // Will always start itself.
 #define SOLAR_AUTO_START_CONFIG 2 // Will start itself if config allows it (default is no).
@@ -26,6 +26,7 @@ GLOBAL_LIST_EMPTY(solars_list)
 	var/turn_angle = 0
 	var/obj/machinery/power/solar_control/control = null
 	var/glass_type = /obj/item/stack/material/glass
+	var/max_solar_distance = 40		//VOREStation Addition
 
 /obj/machinery/power/solar/drain_power()
 	return -1
@@ -41,10 +42,10 @@ GLOBAL_LIST_EMPTY(solars_list)
 	unset_control() //remove from control computer
 	. = ..()
 
-//set the control of the panel to a given computer if closer than SOLAR_MAX_DIST
+//set the control of the panel to a given computer if closer than max_solar_distance
 /obj/machinery/power/solar/proc/set_control(var/obj/machinery/power/solar_control/SC)
 	ASSERT(!control)
-	if(SC && (get_dist(src, SC) > SOLAR_MAX_DIST))
+	if(SC && (get_dist(src, SC) > max_solar_distance))
 		return 0
 	control = SC
 	return 1

--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -42,10 +42,10 @@ GLOBAL_LIST_EMPTY(solars_list)
 	unset_control() //remove from control computer
 	. = ..()
 
-//set the control of the panel to a given computer if closer than max_solar_distance
+//set the control of the panel to a given computer if closer than SOLAR_MAX_DIST
 /obj/machinery/power/solar/proc/set_control(var/obj/machinery/power/solar_control/SC)
 	ASSERT(!control)
-	if(SC && (get_dist(src, SC) > max_solar_distance))
+	if(SC && (get_dist(src, SC) > SOLAR_MAX_DIST))
 		return 0
 	control = SC
 	return 1

--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -26,7 +26,7 @@ GLOBAL_LIST_EMPTY(solars_list)
 	var/turn_angle = 0
 	var/obj/machinery/power/solar_control/control = null
 	var/glass_type = /obj/item/stack/material/glass
-	var/max_solar_distance = 40		//VOREStation Addition
+	var/SOLAR_MAX_DIST = 40		//VOREStation Addition
 
 /obj/machinery/power/solar/drain_power()
 	return -1

--- a/code/modules/power/tracker.dm
+++ b/code/modules/power/tracker.dm
@@ -16,6 +16,8 @@
 	var/id = 0
 	var/sun_angle = 0		// sun angle as set by sun datum
 	var/obj/machinery/power/solar_control/control = null
+	var/max_solar_distance = 40		//VOREStation Addition
+
 
 /obj/machinery/power/tracker/Initialize(mapload, glass_type)
 	. = ..()
@@ -26,9 +28,9 @@
 	unset_control() //remove from control computer
 	..()
 
-//set the control of the tracker to a given computer if closer than SOLAR_MAX_DIST
+//set the control of the tracker to a given computer if closer than max_solar_distance
 /obj/machinery/power/tracker/proc/set_control(var/obj/machinery/power/solar_control/SC)
-	if(SC && (get_dist(src, SC) > SOLAR_MAX_DIST))
+	if(SC && (get_dist(src, SC) > max_solar_distance))	//VOREStation Edit
 		return 0
 	control = SC
 	return 1

--- a/code/modules/power/tracker.dm
+++ b/code/modules/power/tracker.dm
@@ -28,9 +28,9 @@
 	unset_control() //remove from control computer
 	..()
 
-//set the control of the tracker to a given computer if closer than max_solar_distance
+//set the control of the tracker to a given computer if closer than SOLAR_MAX_DIST
 /obj/machinery/power/tracker/proc/set_control(var/obj/machinery/power/solar_control/SC)
-	if(SC && (get_dist(src, SC) > max_solar_distance))	//VOREStation Edit
+	if(SC && (get_dist(src, SC) > SOLAR_MAX_DIST))
 		return 0
 	control = SC
 	return 1

--- a/code/modules/power/tracker.dm
+++ b/code/modules/power/tracker.dm
@@ -16,7 +16,7 @@
 	var/id = 0
 	var/sun_angle = 0		// sun angle as set by sun datum
 	var/obj/machinery/power/solar_control/control = null
-	var/max_solar_distance = 40		//VOREStation Addition
+	var/SOLAR_MAX_DIST = 40		//VOREStation Addition
 
 
 /obj/machinery/power/tracker/Initialize(mapload, glass_type)


### PR DESCRIPTION
Makes the max distance a var instead of a define, that way it can be different depending on the situation.

It defaults to 40, so the default behavior is maintained.
I could probably define this on the map instead, but that doesn't really allow for one Z having one setting and another having another. So I decided to do this instead.