### PR TITLE
Public Hand Labelers (Rascal's Pass)

### DIFF
--- a/maps/groundbase/gb-z1.dmm
+++ b/maps/groundbase/gb-z1.dmm
@@ -7666,6 +7666,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/item/weapon/hand_labeler,
 /turf/simulated/floor/tiled,
 /area/groundbase/civilian/toolstorage)
 "sQ" = (

--- a/maps/groundbase/gb-z2.dmm
+++ b/maps/groundbase/gb-z2.dmm
@@ -17624,6 +17624,7 @@
 /obj/machinery/recharger{
 	pixel_y = 5
 	},
+/obj/item/weapon/hand_labeler,
 /turf/simulated/floor/wood,
 /area/groundbase/civilian/library)
 "Zw" = (


### PR DESCRIPTION
The Hand Labelers on Rascal's Pass seemed to be very scarce. This PR adds them to two new public accessible locations:
- Library
- Tool Storage