### PR TITLE
Fixes species with custom MaxHealth being unable to Succumb to death

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -80,11 +80,15 @@
 
 /mob/living/verb/succumb()
 	set hidden = 1
-	if ((src.health < 0 && src.health > (5-src.getMaxHealth()))) // Health below Zero but above 5-away-from-death, as before, but variable
+//	if ((src.health < 0 && src.health > (5-src.getMaxHealth()))) // Health below Zero but above 5-away-from-death, as before, but variable
+	if (src.health < 0 && stat != DEAD)
 		src.death()
 		to_chat(src, "<font color='blue'>You have given up life and succumbed to death.</font>")
 	else
-		to_chat(src, "<font color='blue'>You are not injured enough to succumb to death!</font>")
+		if(stat == DEAD)
+			to_chat(src, "<font color='blue'>You are already dead!</font>")
+		else
+			to_chat(src, "<font color='blue'>You are not injured enough to succumb to death!</font>")
 
 /mob/living/proc/updatehealth()
 	if(status_flags & GODMODE)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -86,7 +86,7 @@
 		to_chat(src, "<font color='blue'>You have given up life and succumbed to death.</font>")
 	else
 		if(stat == DEAD)
-			to_chat(src, "<font color='blue'>You are already dead!</font>")
+			to_chat(src, "<font color='blue'>As much as you'd like, you can't die when already dead</font>")
 		else
 			to_chat(src, "<font color='blue'>You are not injured enough to succumb to death!</font>")
 


### PR DESCRIPTION
Species with custom maxhealth are unable to succumb when in crit under previous implementation.

This allows for anyone under 0 health to succumb to death, as long as not already dead.

Tested on local.