### PR TITLE
Fixing Stack Deletion

### DIFF
--- a/code/game/objects/items/stacks/stack_vr.dm
+++ b/code/game/objects/items/stacks/stack_vr.dm
@@ -1,13 +1,6 @@
 // Porting stack dragging/auto stacking from TG.
 
 /obj/item/stack/proc/merge(obj/item/stack/S) //Merge src into S, as much as possible
-	if(uses_charge || S.uses_charge) // This should realistically never happen, but in case it does lets avoid breaking things.
-		return
-	if(S.stacktype != stacktype)
-		return
-	if(S.amount >= S.max_amount)
-		return
-
 	var/transfer = get_amount()
 	transfer = min(transfer, S.max_amount - S.amount)
 	if(pulledby)
@@ -18,7 +11,27 @@
 	use(transfer)
 	S.add(transfer)
 
+/obj/item/stack/proc/can_merge(obj/item/stack/S)
+	if(uses_charge || S.uses_charge) // This should realistically never happen, but in case it does lets avoid breaking things.
+		return
+	if(S.stacktype != stacktype)
+		return
+	if(S.amount >= S.max_amount)
+		return
+	if(!isturf(loc) || !isturf(S.loc))
+		return FALSE
+	if(src == S)
+		return FALSE
+	if(ismob(S.loc) || ismob(loc))
+		return FALSE
+	if(S.throwing || throwing)
+		return FALSE
+	if(S.amount < 1 || amount < 1)
+		return FALSE
+	return TRUE
+
 /obj/item/stack/Crossed(var/atom/movable/AM)
-	if(isturf(AM.loc) && AM != src && istype(AM, src.type) && !AM.throwing)
-		merge(AM)
+	if(istype(AM, src.type)) // Sanity so we don't try to merge non-stacks.
+		if(can_merge(AM))
+			merge(AM)
 	return ..()


### PR DESCRIPTION
Moved auto merge stack checks from a very long line into a proc and added checks preventing 0 sheet stacks from merging automatically.

Fixes:  #12840