### PR TITLE
Enables healbelly for synthmorphs as prey

### DIFF
--- a/code/modules/vore/eating/bellymodes_datum_vr.dm
+++ b/code/modules/vore/eating/bellymodes_datum_vr.dm
@@ -124,7 +124,18 @@ GLOBAL_LIST_INIT(digest_modes, list())
 	var/oldstat = L.stat
 	if(L.stat == DEAD)
 		return null // Can't heal the dead with healbelly
-	if(B.owner.nutrition > 90 && (L.health < L.maxHealth))
+	var/mob/living/carbon/human/H = L
+	if(B.owner.nutrition > 90 && H.isSynthetic())
+		for(var/obj/item/organ/external/E in H.organs) //Needed for healing prosthetics
+			var/obj/item/organ/external/O = E
+			if(O.brute_dam > 0 || O.burn_dam > 0) //Making sure healing continues until fixed.
+				O.heal_damage(0.5, 0.5, 0, 1) // Less effective healing as able to fix broken limbs
+			if(L.health < L.maxHealth)
+				L.adjustToxLoss(-2)
+				L.adjustOxyLoss(-2)
+				L.adjustCloneLoss(-1)
+		B.owner.adjust_nutrition(-5)  // More costly for the pred, since metals and stuff
+	if(B.owner.nutrition > 90 && (L.health < L.maxHealth) && !H.isSynthetic())
 		L.adjustBruteLoss(-2.5)
 		L.adjustFireLoss(-2.5)
 		L.adjustToxLoss(-5)


### PR DESCRIPTION
Allows treating of synthmorph (IPC, FBP) crew using healbellies.

Does not allow for treatment of prosthetic limbs if still organic. MUST have prosthetic torso/head to qualify. ONLY repairs external organs (limbs, torso, head), internal organs still require surgery.

Tested locally by crowbaring one arm of SSD IPC, welding the other and putting them into healbelly. Damage was slowly removed until fully healthy.

Also tested with organic to make sure I didn't break anything. Worked like a charm!


Balance concerns:

None in my opinion. As it is presently, you can repair a synthmorph within 2-5 minutes (including building a table for ghetto surgery and disassembling it) if you know what you're doing and skip RP.

Even skipping RP and grab & gulping the synthmorph, at the rate of healing (0.5 per tic) at a somewhat substantial nutrition cost (5), it will take far longer for a synthmorph to be functional than doing ghetto surgery.

Why this is good for the server:

Scenario 1: There is a roboticist/sci-borg on shift, and their belly contains nanites or something that can fix synthetics. This allows for pred-pref roboticists to include vore in doing their job like medical staff.

Scenario 2: There is NO roboticist/sci-borg on shift. synthmorph goes to medical in desperation, and are told there's an "experimental" therapy. Cue dubcon vore scene where the synthmorph is only allowing themselves to be eaten for sake of treatment (while secretly enjoying it).

For scenario 2, it's faster to 6/6 digest a synthmorph then wait 15 minutes for auto resleever than to wait out the 0.5 healing for damage over 30 (where you can't just self-repair anymore).