### PR TITLE
Fixes healbelly for synthmorphs draining nutrition forever

### DIFF
--- a/code/modules/vore/eating/bellymodes_datum_vr.dm
+++ b/code/modules/vore/eating/bellymodes_datum_vr.dm
@@ -130,11 +130,12 @@ GLOBAL_LIST_INIT(digest_modes, list())
 			var/obj/item/organ/external/O = E
 			if(O.brute_dam > 0 || O.burn_dam > 0) //Making sure healing continues until fixed.
 				O.heal_damage(0.5, 0.5, 0, 1) // Less effective healing as able to fix broken limbs
+				B.owner.adjust_nutrition(-5)  // More costly for the pred, since metals and stuff
 			if(L.health < L.maxHealth)
 				L.adjustToxLoss(-2)
 				L.adjustOxyLoss(-2)
 				L.adjustCloneLoss(-1)
-		B.owner.adjust_nutrition(-5)  // More costly for the pred, since metals and stuff
+				B.owner.adjust_nutrition(-1)  // Normal cost per old functionality
 	if(B.owner.nutrition > 90 && (L.health < L.maxHealth) && !H.isSynthetic())
 		L.adjustBruteLoss(-2.5)
 		L.adjustFireLoss(-2.5)


### PR DESCRIPTION
Made a little oopsie that local testing didn't catch. It's a minor bug. Basically, if you put a synthmorph into a healbelly it will continue to drain your nutrition until you're starving. Very good for weight loss, but inconsistent with organics.

Bug was caused by my nested if statements. I only check for organ/total health in the second layer, and I put nutrition drain onto the first (where I only check if they're a synth)

Moved nutrition drain to only occur when either limbs are damaged, or there's toxloss to repair.

Further, adjusted burn/bruteloss repair to retain -5 nutrition change, and returned toxloss to only take 1 nutrition as per original functionality (could always repair toxloss for synths for 1 nutrition).