### PR TITLE
Adds belt slot flag to proto-kinetic machete and subtypes

### DIFF
--- a/code/modules/mining/kinetic_crusher.dm
+++ b/code/modules/mining/kinetic_crusher.dm
@@ -256,11 +256,9 @@
 	backstab_bonus = 40 // 100
 	thrown_bonus = 20 // 120
 	update_item_state = FALSE
+	slot_flags = SLOT_BELT
 
-
-/obj/item/weapon/kinetic_crusher/machete/Initialize()  //Making sure you can't store gauntlets/greaves on your belts.
-	if(w_class < ITEMSIZE_HUGE)
-		slot_flags = SLOT_BELT
+		
 
 
 /obj/item/weapon/kinetic_crusher/machete/gauntlets
@@ -280,6 +278,7 @@
 	detonation_damage = 37 // 75
 	backstab_bonus = 55 // 130
 	var/obj/item/offhand/crushergauntlets/offhand
+	slot_flags = null
 
 /obj/item/weapon/kinetic_crusher/machete/gauntlets/equipped()
 	. = ..()

--- a/code/modules/mining/kinetic_crusher.dm
+++ b/code/modules/mining/kinetic_crusher.dm
@@ -230,7 +230,7 @@
 	desc = "A modified design of a proto-kinetic crusher, it is still little more of a combination of various mining tools cobbled together \
 	and kit-bashed into a high-tech cleaver on a stick - with a handguard and a goliath hide grip. While it is still of little use to any \
 	but the most skilled and/or suicidal miners against local fauna, it's an elegant weapon for a more civilized hunter."
-    
+
     look gary there i am
     - hatterhat
 */
@@ -256,6 +256,11 @@
 	backstab_bonus = 40 // 100
 	thrown_bonus = 20 // 120
 	update_item_state = FALSE
+
+
+/obj/item/weapon/kinetic_crusher/machete/Initialize()  //Making sure you can't store gauntlets/greaves on your belts.
+	if(w_class < ITEMSIZE_HUGE)
+		slot_flags = SLOT_BELT
 
 
 /obj/item/weapon/kinetic_crusher/machete/gauntlets
@@ -379,6 +384,7 @@
 	backstab_bonus = 40 // 85
 	// gimmick mode
 	thrown_bonus = 50 // 135 but you drop your knife because you threw it
+
 
 
 //destablizing force


### PR DESCRIPTION
Enables wearing proto-kinetic machetes, daggers and future weapons that are below ITEMSIZE_HUGE on your belt-slot, like you can with plasteel machetes and various tools/knives.

ITEMSIZE_HUGE was specifically chose to prevent wearing gauntlets on belt, as doing so sounds ridiculous (greaves/gauntlets you quickdraw from your belt?).

Wearing a sword/dagger in your belt however makes more than sufficient sense to me.

Balance concerns:

- Miners/explorers may store their proto-kinetic sidearms in one more storage slot
- Caveat: Explorers can already store theirs in explorer belt.
- Caveat: Miners can NOT store theirs in mining belt
- Caveat: Since miners can NOT store theirs in their belt, and likely want to bring a belt with them AND a mining satchel - they have 3 items competing for belt slot.
  - Belt in belt slot: easier access to drill, GPS, umbrella and marker beacons. If not worn, must have 2 hands free to do the same.
  - Satchel in belt slot: Automatically collect dropped ore. If not worn, must be held in hand (does not collect from bag).
  - Plasteel/Proto-kinetic machete in belt allows for quick-draw if main weapon (KA, phaser) is dropped. If in bag, need to fumble for longer.
- Proto-kinetic dagger could ALREADY be carried in pocket slot.
- Plasteel Machete could ALREADY be carried in belt slot. 

As such, I do not believe allowing miners/exploration to wield their backup side-arm in an easy-to-reach slot is a balance concern. Doing so requires sacrificing convenience elsewhere.


Tested on local:
- Can wear machete/dagger on belt
- Can NOT wear crusher nor gauntlets on belt
- Crusher, machete, gauntlet and belt function as expected against mobs.