### PR TITLE
Brightens Sol Common Language Color

### DIFF
--- a/code/modules/vchat/css/ss13styles.css
+++ b/code/modules/vchat/css/ss13styles.css
@@ -157,7 +157,7 @@ h1.alert, h2.alert		{color: #000000;}
 .skrell					{color: #00B0B3;}
 .skrellfar				{color: #70FCFF;}
 .soghun					{color: #50BA6C;}
-.solcom					{color: #22228B;}
+.solcom					{color: #3333CE;} /* VOREStation Edit */
 .changeling				{color: #800080;}
 .sergal					{color: #0077FF;}
 .birdsongc				{color: #CC9900;}


### PR DESCRIPTION
This is my very simple modification of the color Sol Common uses in VChat; the previous color looks too close to black in light mode, and so dark as to be unreadable in dark mode.

Example:
![2022-05-05 (8)](https://user-images.githubusercontent.com/17329033/167072443-34c8a9c3-50e3-40a8-b20e-7bf7f78e378e.png)

The color may still not be ideal, but I did not want to tweak it too much: I simply raised the brightness by 50%.