### PR TITLE
TGUI Bundle Update Label

### DIFF
--- a/.github/boring-cyborg.yml
+++ b/.github/boring-cyborg.yml
@@ -32,6 +32,10 @@ labelPRBasedOnFilePath:
   "Type: .git or .github":
     - '.github/**'
     - '.git/**'
+    
+  # Contains changes to the TGUI bundle
+  "Type: TGUI Bundle":
+    - 'tgui/public/**'
 
 ##### Greetings ########################################################################################################
 # Comment to be posted to welcome users when they open their first PR


### PR DESCRIPTION
It could be very useful for reviewers and developers to already see in the overview if one or multiple PRs are updating the TGUI bundle file at the same time (which could cause merge conflicts).

The interface files themselves are easier to be merged compared to this compressed compiled outcome.