### PR TITLE
Make Cooking Great Again [Tedium Update, Rebalance some cooking aspects]

### DIFF
--- a/code/modules/food/kitchen/microwave.dm
+++ b/code/modules/food/kitchen/microwave.dm
@@ -147,6 +147,34 @@
 				"<span class='notice'>You add \the [O] to \the [src].</span>")
 			SStgui.update_uis(src)
 			return
+	else if (istype(O,/obj/item/weapon/storage/bag/plants)) // There might be a better way about making plant bags dump their contents into a microwave, but it works.
+		var/obj/item/weapon/storage/bag/plants/bag = O
+		var/failed = 1
+		for(var/obj/item/G in O.contents)
+			if(!G.reagents || !G.reagents.total_volume)
+				continue
+			failed = 0
+			if(contents.len>=(max_n_of_items + component_parts.len + circuit_item_capacity))
+				to_chat(user, "<span class='warning'>This [src] is full of ingredients, you cannot put more.</span>")
+				return 0
+			else
+				bag.remove_from_storage(G, src)
+				contents += G
+				if(contents.len>=(max_n_of_items + component_parts.len + circuit_item_capacity))
+					break
+
+		if(failed)
+			to_chat(user, "Nothing in the plant bag is usable.")
+			return 0
+
+		if(!O.contents.len)
+			to_chat(user, "You empty \the [O] into \the [src].")
+		else
+			to_chat(user, "You fill \the [src] from \the [O].")
+
+		SStgui.update_uis(src)
+		return 0
+
 	else if(istype(O,/obj/item/weapon/reagent_containers/glass) || \
 			istype(O,/obj/item/weapon/reagent_containers/food/drinks) || \
 			istype(O,/obj/item/weapon/reagent_containers/food/condiment) \

--- a/code/modules/food/recipes_fryer.dm
+++ b/code/modules/food/recipes_fryer.dm
@@ -18,6 +18,7 @@
 	fruit = list("chili" = 1)
 	coating = /datum/reagent/nutriment/coating/batter
 	result = /obj/item/weapon/reagent_containers/food/snacks/jalapeno_poppers
+	result_quantity = 2
 
 /datum/recipe/risottoballs
 	appliance = FRYER
@@ -26,6 +27,7 @@
 	coating = /datum/reagent/nutriment/coating/batter
 	reagent_mix = RECIPE_REAGENT_REPLACE //Simplify end product
 	result = /obj/item/weapon/reagent_containers/food/snacks/risottoballs
+	result_quantity = 2
 
 /datum/recipe/bellefritter
 	appliance = FRYER
@@ -33,12 +35,14 @@
 	reagents = list("sugar" = 5)
 	items = list(/obj/item/weapon/reagent_containers/food/snacks/frostbelle)
 	result = /obj/item/weapon/reagent_containers/food/snacks/bellefritter
+	result_quantity = 2
 
 /datum/recipe/onionrings
 	appliance = FRYER
 	coating = /datum/reagent/nutriment/coating/batter
 	fruit = list("onion" = 1)
 	result = /obj/item/weapon/reagent_containers/food/snacks/onionrings
+	result_quantity = 2
 
 //Meaty Recipes
 //====================
@@ -169,6 +173,7 @@
 	appliance = FRYER
 	reagents = list("sugar" = 5, "batter" = 10)
 	result = /obj/item/weapon/reagent_containers/food/snacks/funnelcake
+	result_quantity = 2
 
 /datum/recipe/pisanggoreng
 	appliance = FRYER

--- a/code/modules/food/recipes_microwave.dm
+++ b/code/modules/food/recipes_microwave.dm
@@ -73,6 +73,7 @@ I said no!
 		/obj/item/weapon/reagent_containers/food/snacks/dough,
 	)
 	result = /obj/item/weapon/reagent_containers/food/snacks/muffin
+	result_quantity = 2
 
 /datum/recipe/eggplantparm
 	fruit = list("eggplant" = 1)
@@ -248,6 +249,7 @@ I said no!
 		/obj/item/weapon/reagent_containers/food/snacks/dough,
 	)
 	result = /obj/item/weapon/reagent_containers/food/snacks/rofflewaffles
+	result_quantity = 2
 
 /datum/recipe/stew
 	fruit = list("potato" = 1, "tomato" = 1, "carrot" = 1, "eggplant" = 1, "mushroom" = 1)
@@ -415,6 +417,7 @@ I said no!
 	fruit = list("plumphelmet" = 1)
 	reagents = list("water" = 5, "flour" = 5)
 	result = /obj/item/weapon/reagent_containers/food/snacks/plumphelmetbiscuit
+	result_quantity = 2
 
 /datum/recipe/mushroomsoup
 	fruit = list("mushroom" = 1)
@@ -478,6 +481,7 @@ I said no!
 		/obj/item/weapon/reagent_containers/food/snacks/sliceable/bread,
 	)
 	result = /obj/item/weapon/reagent_containers/food/snacks/stuffing
+	result_quantity = 2
 
 /datum/recipe/mashedpotato
 	items = list(
@@ -511,6 +515,7 @@ I said no!
 		/obj/item/weapon/reagent_containers/food/snacks/dough
 	)
 	result = /obj/item/weapon/reagent_containers/food/snacks/bun
+	result_quantity = 3
 
 /datum/recipe/microwaveflatbread
 	items = list(
@@ -536,6 +541,7 @@ I said no!
 		/obj/item/weapon/reagent_containers/food/snacks/rawsunflower
 	)
 	result = /obj/item/weapon/reagent_containers/food/snacks/roastedsunflower
+	result_quantity = 2
 
 /datum/recipe/roastedsunflowerseeds
 	reagents = list("sodiumchloride" = 1, "cookingoil" = 1)
@@ -543,6 +549,7 @@ I said no!
 		/obj/item/weapon/reagent_containers/food/snacks/rawsunflower
 	)
 	result = /obj/item/weapon/reagent_containers/food/snacks/roastedsunflower
+	result_quantity = 2
 
 /datum/recipe/roastedpeanutsunflowerseeds
 	reagents = list("sodiumchloride" = 1, "peanutoil" = 1)
@@ -550,21 +557,25 @@ I said no!
 		/obj/item/weapon/reagent_containers/food/snacks/rawsunflower
 	)
 	result = /obj/item/weapon/reagent_containers/food/snacks/roastedsunflower
+	result_quantity = 2
 
 /datum/recipe/roastedpeanuts
 	fruit = list("peanut" = 2)
 	reagents = list("sodiumchloride" = 2, "cookingoil" = 1)
 	result = /obj/item/weapon/reagent_containers/food/snacks/roastedpeanuts
+	result_quantity = 2
 
 /datum/recipe/roastedpeanutscorn
 	fruit = list("peanut" = 2)
 	reagents = list("sodiumchloride" = 2, "cornoil" = 1)
 	result = /obj/item/weapon/reagent_containers/food/snacks/roastedpeanuts
+	result_quantity = 2
 
 /datum/recipe/roastedpeanutspeanut
 	fruit = list("peanut" = 2)
 	reagents = list("sodiumchloride" = 2, "peanutoil" = 1)
 	result = /obj/item/weapon/reagent_containers/food/snacks/roastedpeanuts
+	result_quantity = 2
 
 /datum/recipe/mint
 	reagents = list("sugar" = 5, "frostoil" = 5)
@@ -596,6 +607,7 @@ I said no!
 	)
 	reagents = list("sugar" = 5, "egg" = 3)
 	result = /obj/item/weapon/reagent_containers/food/snacks/sugarcookie
+	result_quantity = 4
 
 /datum/recipe/berrymuffin
 	reagents = list("milk" = 5, "sugar" = 5)
@@ -604,6 +616,7 @@ I said no!
 	)
 	fruit = list("berries" = 1)
 	result = /obj/item/weapon/reagent_containers/food/snacks/berrymuffin/berry
+	result_quantity = 2
 
 /datum/recipe/poisonberrymuffin
 	reagents = list("milk" = 5, "sugar" = 5)
@@ -612,6 +625,7 @@ I said no!
 	)
 	fruit = list("poisonberries" = 1)
 	result = /obj/item/weapon/reagent_containers/food/snacks/berrymuffin/poison
+	result_quantity = 2
 
 /datum/recipe/ghostmuffin
 	reagents = list("milk" = 5, "sugar" = 5)
@@ -621,6 +635,7 @@ I said no!
 	)
 	fruit = list("berries" = 1)
 	result = /obj/item/weapon/reagent_containers/food/snacks/ghostmuffin/berry
+	result_quantity = 2
 
 /datum/recipe/poisonghostmuffin
 	reagents = list("milk" = 5, "sugar" = 5)
@@ -630,6 +645,7 @@ I said no!
 	)
 	fruit = list("poisonberries" = 1)
 	result = /obj/item/weapon/reagent_containers/food/snacks/ghostmuffin/poison
+	result_quantity = 2
 
 /datum/recipe/eggroll
 	reagents = list("soysauce" = 10)
@@ -841,6 +857,7 @@ I said no!
 	)
 	reagent_mix = RECIPE_REAGENT_REPLACE
 	result = /obj/item/weapon/reagent_containers/food/snacks/nugget
+	result_quantity = 3
 
 // Chip update
 /datum/recipe/microwavetortilla
@@ -850,6 +867,7 @@ I said no!
 	)
 	result = /obj/item/weapon/reagent_containers/food/snacks/tortilla
 	reagent_mix = RECIPE_REAGENT_REPLACE //no gross flour or water
+	result_quantity = 3
 
 /datum/recipe/taco
 	items = list(
@@ -1041,6 +1059,7 @@ I said no!
 	)
 	fruit = list("cabbage" = 1)
 	result = /obj/item/weapon/reagent_containers/food/snacks/stuffed_meatball
+	result_quantity = 2
 
 /datum/recipe/egg_pancake
 	items = list(

--- a/code/modules/food/recipes_microwave_vr.dm
+++ b/code/modules/food/recipes_microwave_vr.dm
@@ -37,6 +37,7 @@
 	)
 	result = /obj/item/weapon/reagent_containers/food/snacks/donerkebab
 
+
 /datum/recipe/roastbeef
 	fruit = list("carrot" = 2, "potato" = 2)
 	items = list(
@@ -150,7 +151,7 @@
 	result = /obj/item/weapon/storage/box/wings/tray
 
 /datum/recipe/bucket
-	fruit = list("potato" = 1)
+	fruit = list("durian" = 1)
 	items = list(
 		/obj/item/weapon/reagent_containers/food/snacks/meat,
 		/obj/item/weapon/reagent_containers/food/snacks/meat,

--- a/code/modules/food/recipes_oven.dm
+++ b/code/modules/food/recipes_oven.dm
@@ -77,8 +77,6 @@
 	appliance = OVEN
 	items = list(
 		/obj/item/weapon/reagent_containers/food/snacks/dough,
-		/obj/item/weapon/reagent_containers/food/snacks/dough,
-		/obj/item/weapon/reagent_containers/food/snacks/dough,
 		/obj/item/weapon/reagent_containers/food/snacks/dough
 	)
 	reagents = list("sodiumchloride" = 1, "yeast" = 5)
@@ -99,11 +97,8 @@
 	items = list(
 		/obj/item/weapon/reagent_containers/food/snacks/dough,
 		/obj/item/weapon/reagent_containers/food/snacks/dough,
-		/obj/item/weapon/reagent_containers/food/snacks/dough,
 		/obj/item/weapon/reagent_containers/food/snacks/tofu,
 		/obj/item/weapon/reagent_containers/food/snacks/tofu,
-		/obj/item/weapon/reagent_containers/food/snacks/tofu,
-		/obj/item/weapon/reagent_containers/food/snacks/cheesewedge,
 		/obj/item/weapon/reagent_containers/food/snacks/cheesewedge,
 		/obj/item/weapon/reagent_containers/food/snacks/cheesewedge
 	)
@@ -134,17 +129,15 @@
 		/obj/item/weapon/reagent_containers/food/snacks/sliceable/flatdough
 	)
 	result = /obj/item/weapon/reagent_containers/food/snacks/tortilla
+	result_quantity = 3
 
 /datum/recipe/meatbread
 	appliance = OVEN
 	items = list(
 		/obj/item/weapon/reagent_containers/food/snacks/dough,
 		/obj/item/weapon/reagent_containers/food/snacks/dough,
-		/obj/item/weapon/reagent_containers/food/snacks/dough,
 		/obj/item/weapon/reagent_containers/food/snacks/meat,
 		/obj/item/weapon/reagent_containers/food/snacks/meat,
-		/obj/item/weapon/reagent_containers/food/snacks/meat,
-		/obj/item/weapon/reagent_containers/food/snacks/cheesewedge,
 		/obj/item/weapon/reagent_containers/food/snacks/cheesewedge,
 		/obj/item/weapon/reagent_containers/food/snacks/cheesewedge
 	)
@@ -155,11 +148,8 @@
 	items = list(
 		/obj/item/weapon/reagent_containers/food/snacks/dough,
 		/obj/item/weapon/reagent_containers/food/snacks/dough,
-		/obj/item/weapon/reagent_containers/food/snacks/dough,
 		/obj/item/weapon/reagent_containers/food/snacks/meat/syntiflesh,
 		/obj/item/weapon/reagent_containers/food/snacks/meat/syntiflesh,
-		/obj/item/weapon/reagent_containers/food/snacks/meat/syntiflesh,
-		/obj/item/weapon/reagent_containers/food/snacks/cheesewedge,
 		/obj/item/weapon/reagent_containers/food/snacks/cheesewedge,
 		/obj/item/weapon/reagent_containers/food/snacks/cheesewedge
 	)
@@ -170,11 +160,8 @@
 	items = list(
 		/obj/item/weapon/reagent_containers/food/snacks/dough,
 		/obj/item/weapon/reagent_containers/food/snacks/dough,
-		/obj/item/weapon/reagent_containers/food/snacks/dough,
 		/obj/item/weapon/reagent_containers/food/snacks/xenomeat,
 		/obj/item/weapon/reagent_containers/food/snacks/xenomeat,
-		/obj/item/weapon/reagent_containers/food/snacks/xenomeat,
-		/obj/item/weapon/reagent_containers/food/snacks/cheesewedge,
 		/obj/item/weapon/reagent_containers/food/snacks/cheesewedge,
 		/obj/item/weapon/reagent_containers/food/snacks/cheesewedge
 	)
@@ -185,7 +172,6 @@
 	fruit = list("banana" = 1)
 	reagents = list("milk" = 5, "sugar" = 15)
 	items = list(
-		/obj/item/weapon/reagent_containers/food/snacks/dough,
 		/obj/item/weapon/reagent_containers/food/snacks/dough,
 		/obj/item/weapon/reagent_containers/food/snacks/dough
 	)
@@ -198,6 +184,7 @@
 		/obj/item/weapon/reagent_containers/food/snacks/dough
 	)
 	result = /obj/item/weapon/reagent_containers/food/snacks/bun
+	result_quantity = 3
 
 //Predesigned pies
 //=======================
@@ -273,6 +260,7 @@
 	reagents = list("sugar" = 10)
 	items = list(/obj/item/weapon/reagent_containers/food/snacks/sliceable/flatdough)
 	result = /obj/item/weapon/reagent_containers/food/snacks/appletart
+	result_quantity = 2
 	reagent_mix = RECIPE_REAGENT_REPLACE
 
 /datum/recipe/keylimepie
@@ -333,7 +321,6 @@
 	reagent_mix = RECIPE_REAGENT_REPLACE //No egg or mix in final recipe
 	result = /obj/item/weapon/reagent_containers/food/snacks/sliceable/brownies
 
-
 /datum/recipe/cosmicbrownies
 	appliance = OVEN
 	reagents = list("browniemix" = 10, "egg" = 3)
@@ -344,7 +331,7 @@
 /datum/recipe/buchedenoel
 	appliance = OVEN
 	fruit = list("berries" = 2)
-	reagents = list("milk" = 5, "flour" = 15, "cream" = 10, "coco" = 5, "egg" = 6)
+	reagents = list("cakebatter" = 20, "cream" = 10, "coco" = 5)
 	result = /obj/item/weapon/reagent_containers/food/snacks/sliceable/buchedenoel
 
 /datum/recipe/cinnamonbun
@@ -443,19 +430,19 @@
 //============
 /datum/recipe/cake
 	appliance = OVEN
-	reagents = list("milk" = 5, "flour" = 15, "sugar" = 15, "egg" = 9, "vanilla" = 1)
+	reagents = list("cakebatter" = 30, "vanilla" = 2)
 	result = /obj/item/weapon/reagent_containers/food/snacks/sliceable/plaincake
 	reagent_mix = RECIPE_REAGENT_REPLACE
 
 /datum/recipe/cake/carrot
 	appliance = OVEN
 	fruit = list("carrot" = 3)
-	reagents = list("milk" = 5, "flour" = 15, "egg" = 9,"sugar" = 5)
+	reagents = list("cakebatter" = 30)
 	result = /obj/item/weapon/reagent_containers/food/snacks/sliceable/carrotcake
 
 /datum/recipe/cake/cheese
 	appliance = OVEN
-	reagents = list("milk" = 5, "flour" = 15, "sugar" = 15, "egg" = 9)
+	reagents = list("cakebatter" = 30)
 	items = list(
 		/obj/item/weapon/reagent_containers/food/snacks/cheesewedge,
 		/obj/item/weapon/reagent_containers/food/snacks/cheesewedge
@@ -463,49 +450,48 @@
 	result = /obj/item/weapon/reagent_containers/food/snacks/sliceable/cheesecake
 
 /datum/recipe/cake/peanut
-	fruit = list("peanut" = 3)
-	reagents = list("milk" = 5, "flour" = 10, "sugar" = 5, "egg" = 6, "peanutbutter" = 5)
+	fruit = list("peanut" = 1)
+	reagents = list("cakebatter" = 30, "peanutbutter" = 5)
 	result = /obj/item/weapon/reagent_containers/food/snacks/sliceable/peanutcake
 
 /datum/recipe/cake/orange
 	appliance = OVEN
-	fruit = list("orange" = 1)
-	reagents = list("milk" = 5, "flour" = 15, "egg" = 9, "sugar" = 5)
+	fruit = list("orange" = 2)
+	reagents = list("cakebatter" = 30)
 	result = /obj/item/weapon/reagent_containers/food/snacks/sliceable/orangecake
 
 /datum/recipe/cake/lime
 	appliance = OVEN
-	fruit = list("lime" = 1)
-	reagents = list("milk" = 5, "flour" = 15, "egg" = 9, "limejuice" = 3, "sugar" = 5)
+	fruit = list("lime" = 2)
+	reagents = list("cakebatter" = 30)
 	result = /obj/item/weapon/reagent_containers/food/snacks/sliceable/limecake
 
 /datum/recipe/cake/lemon
 	appliance = OVEN
-	fruit = list("lemon" = 1)
-	reagents = list("milk" = 5, "flour" = 15, "egg" = 9, "lemonjuice" = 3, "sugar" = 5)
+	fruit = list("lemon" = 2)
+	reagents = list("cakebatter" = 30)
 	result = /obj/item/weapon/reagent_containers/food/snacks/sliceable/lemoncake
 
 /datum/recipe/cake/chocolate
 	appliance = OVEN
-	items = list(/obj/item/weapon/reagent_containers/food/snacks/chocolatebar)
-	reagents = list("milk" = 5, "flour" = 15, "egg" = 9, "coco" = 4, "sugar" = 5)
+	reagents = list("cakebatter" = 30, "coco" = 5)
 	result = /obj/item/weapon/reagent_containers/food/snacks/sliceable/chocolatecake
 
 /datum/recipe/cake/birthday
 	appliance = OVEN
-	reagents = list("milk" = 5, "flour" = 15, "sugar" = 15, "egg" = 9)
+	reagents = list("cakebatter" = 30)
 	items = list(/obj/item/clothing/head/cakehat)
 	result = /obj/item/weapon/reagent_containers/food/snacks/sliceable/birthdaycake
 
 /datum/recipe/cake/apple
 	appliance = OVEN
 	fruit = list("apple" = 2)
-	reagents = list("milk" = 5, "flour" = 15, "egg" = 9,"sugar" = 5)
+	reagents = list("cakebatter" = 30)
 	result = /obj/item/weapon/reagent_containers/food/snacks/sliceable/applecake
 
 /datum/recipe/cake/brain
 	appliance = OVEN
-	reagents = list("milk" = 5, "flour" = 15, "sugar" = 15, "egg" = 9)
+	reagents = list("cakebatter" = 30)
 	items = list(/obj/item/organ/internal/brain)
 	result = /obj/item/weapon/reagent_containers/food/snacks/sliceable/braincake
 
@@ -517,6 +503,7 @@
 		/obj/item/weapon/reagent_containers/food/snacks/sliceable/flatdough
 	)
 	result = /obj/item/weapon/reagent_containers/food/snacks/pancakes
+	result_quantity = 2
 
 /datum/recipe/pancakes/berry
 	appliance = OVEN
@@ -527,6 +514,7 @@
 		/obj/item/weapon/reagent_containers/food/snacks/sliceable/flatdough
 	)
 	result = /obj/item/weapon/reagent_containers/food/snacks/pancakes/berry
+	result_quantity = 2
 
 /datum/recipe/lasagna
 	appliance = OVEN
@@ -547,6 +535,7 @@
 	)
 	reagents = list("milk" = 5, "egg" = 3,"honey" = 5)
 	result = /obj/item/weapon/reagent_containers/food/snacks/honeybun
+	result_quantity = 4
 
 //Bacon
 /datum/recipe/bacon_oven
@@ -602,6 +591,7 @@
 	reagent_mix = RECIPE_REAGENT_REPLACE
 	items = list(/obj/item/weapon/reagent_containers/food/snacks/dough)
 	result = /obj/item/weapon/reagent_containers/food/snacks/croissant
+	result_quantity = 2
 
 /datum/recipe/macncheese
 	appliance = OVEN
@@ -639,6 +629,7 @@
 		/obj/item/weapon/reagent_containers/food/snacks/dough
 	)
 	result = /obj/item/weapon/reagent_containers/food/snacks/waffles
+	result_quantity = 2
 
 /datum/recipe/loadedbakedpotatooven
 	appliance = OVEN
@@ -656,6 +647,7 @@
 	)
 	reagent_mix = RECIPE_REAGENT_REPLACE //Water used up in cooking
 	result = /obj/item/weapon/reagent_containers/food/snacks/meatbun
+	result_quantity = 2
 
 /datum/recipe/spicedmeatbun
 	appliance = OVEN
@@ -666,6 +658,7 @@
 	)
 	reagent_mix = RECIPE_REAGENT_REPLACE //Water used up in cooking
 	result = /obj/item/weapon/reagent_containers/food/snacks/spicedmeatbun
+	result_quantity = 2
 
 /datum/recipe/custardbun
 	appliance = OVEN
@@ -687,6 +680,7 @@
 	)
 	reagent_mix = RECIPE_REAGENT_REPLACE //Simplify end product
 	result = /obj/item/weapon/reagent_containers/food/snacks/chickenmomo
+	result_quantity = 2
 
 /datum/recipe/veggiemomo
 	appliance = OVEN
@@ -699,3 +693,4 @@
 	)
 	reagent_mix = RECIPE_REAGENT_REPLACE //Get that water outta here
 	result = /obj/item/weapon/reagent_containers/food/snacks/veggiemomo
+	result_quantity = 2

--- a/code/modules/reagents/reactions/instant/food.dm
+++ b/code/modules/reagents/reactions/instant/food.dm
@@ -140,7 +140,7 @@
 	id = "dough"
 	result = null
 	required_reagents = list("egg" = 3, "flour" = 10)
-	inhibitors = list("water" = 1, "beer" = 1) //To prevent it messing with batter recipes
+	inhibitors = list("water" = 1, "beer" = 1, "sugar" = 1) //To prevent it messing with batter recipes
 	result_amount = 1
 
 /decl/chemical_reaction/instant/food/dough/on_reaction(var/datum/reagents/holder, var/created_volume)
@@ -188,6 +188,13 @@
 	result = "browniemix"
 	required_reagents = list("flour" = 5, "coco" = 5, "sugar" = 5)
 	result_amount = 15
+
+/decl/chemical_reaction/instant/food/cakebatter
+	name = "Cake Batter"
+	id = "cakebatter"
+	result = "cakebatter"
+	required_reagents = list("flour" = 15, "milk" = 10, "sugar" = 15, "egg" = 3)
+	result_amount = 60
 
 /decl/chemical_reaction/instant/food/butter
 	name = "Butter"

--- a/code/modules/reagents/reagents/food_drinks.dm
+++ b/code/modules/reagents/reagents/food_drinks.dm
@@ -692,6 +692,13 @@
 	reagent_state = SOLID
 	color = "#441a03"
 
+/datum/reagent/cakebatter
+	name = "Cake Batter"
+	id = "cakebatter"
+	description = "A batter for making delicious cakes."
+	reagent_state = LIQUID
+	color = "#F0EDDA"
+
 /datum/reagent/frostoil
 	name = "Frost Oil"
 	id = "frostoil"


### PR DESCRIPTION
Background:
--------

Cooking, even prior to the Aurora cooking update, was always a bit of a tedious task to do.

Many clicks, very time consuming, and with the Aurora update it seemed to make things a bit more tedious (even if mass producing was nice).

This sentiment was shared with a few other chefs players that I know, so I decided to make this update to try to alleviate some of these issues.

What's changed?:
--------

Well, the important changes are as follows:

-Rebalances some of the recipes, primarily by either lowering the required amount of items, or by making them produce multiple of the items (The bun recipe now produces three buns instead of one, etc)

-Adds in Cake Batter, a reagent that replaces the some of the ingredients required to make some cakes. Recipe is 15 flour, 10 milk, 15 sugar, and 1 egg. Results in 60 units. Bit less ingredients in total, especially EGG.

-Makes it so the plant bag can be used on the microwave to dump plants into it