### PR TITLE
Sapient Bot Patches

### DIFF
--- a/code/modules/mob/living/bot/bot.dm
+++ b/code/modules/mob/living/bot/bot.dm
@@ -377,6 +377,7 @@
 	resetTarget()
 	patrol_path = list()
 	ignore_list = list()
+	update_canmove()
 	return 1
 
 /mob/living/bot/proc/turn_off()
@@ -384,6 +385,7 @@
 	busy = 0 // If ever stuck... reboot!
 	set_light(0)
 	update_icons()
+	update_canmove()
 
 /mob/living/bot/proc/explode()
 	if(paicard)
@@ -483,6 +485,11 @@
 
 /mob/living/bot/isSynthetic() //Robots are synthetic, no?
 	return 1
+
+/mob/living/bot/update_canmove()
+	..()
+	canmove = on
+	return canmove
 
 /mob/living/bot/proc/insertpai(mob/user, obj/item/device/paicard/card)
 	//var/obj/item/paicard/card = I

--- a/code/modules/mob/living/bot/bot.dm
+++ b/code/modules/mob/living/bot/bot.dm
@@ -543,8 +543,16 @@
 	init_vore() // ROBOT VORE
 	verbs |= /mob/living/proc/insidePanel
 
+	return ..()
+
 /mob/living/bot/Logout()
 	no_vore = TRUE // ROBOT VORE
 	release_vore_contents()
 	init_vore() // ROBOT VORE
 	verbs -= /mob/living/proc/insidePanel
+	no_vore = TRUE
+	devourable = FALSE
+	feeding = FALSE
+	can_be_drop_pred = FALSE
+
+	return ..()

--- a/code/modules/mob/living/bot/cleanbot.dm
+++ b/code/modules/mob/living/bot/cleanbot.dm
@@ -112,7 +112,10 @@
 
 	busy = 1
 	if(prob(20))
-		custom_emote(2, "begins to clean up \the [D]")
+		if(D == src)
+			custom_emote(2, "begins to clean up \the [loc]")
+		else
+			custom_emote(2, "begins to clean up \the [D]")
 	update_icons()
 	var/cleantime = 0
 	if(istype(D, /obj/effect/decal/cleanable))

--- a/code/modules/mob/living/bot/cleanbot.dm
+++ b/code/modules/mob/living/bot/cleanbot.dm
@@ -112,11 +112,6 @@
 		return
 
 	busy = 1
-	if(prob(20))
-		if(D == src)
-			custom_emote(2, "begins to clean up \the [loc]")
-		else
-			custom_emote(2, "begins to clean up \the [D]")
 	update_icons()
 	var/cleantime = 0
 	if(istype(D, /obj/effect/decal/cleanable))
@@ -139,7 +134,9 @@
 				cleantime += 10
 			if(istype(O,/obj/effect/rune) || istype(O,/obj/effect/decal/cleanable) || istype(O,/obj/effect/overlay))
 				cleantime += 50
-		if(cleantime > 0)
+		if(cleantime != 0)
+			if(prob(20))
+				custom_emote(2, "begins to clean up \the [loc]")
 			if(do_after(src, cleantime * cTimeMult))
 				clean_blood()
 				if(istype(loc, /turf/simulated))

--- a/code/modules/mob/living/bot/cleanbot.dm
+++ b/code/modules/mob/living/bot/cleanbot.dm
@@ -10,6 +10,7 @@
 	wait_if_pulled = 1
 	min_target_dist = 0
 
+	var/cTimeMult = 1 // A multiplier for how long it should take to clean. Anything bigger than one will increase time, less than one will make it faster.
 	var/vocal = 1
 	var/cleaning = 0
 	var/wet_floors = 0
@@ -120,7 +121,9 @@
 	var/cleantime = 0
 	if(istype(D, /obj/effect/decal/cleanable))
 		cleantime = istype(D, /obj/effect/decal/cleanable/dirt) ? 10 : 50
-		if(do_after(src, cleantime))
+		if(prob(20))
+			custom_emote(2, "begins to clean up \the [D]")
+		if(do_after(src, cleantime * cTimeMult))
 			if(istype(loc, /turf/simulated))
 				var/turf/simulated/f = loc
 				f.dirt = 0
@@ -136,14 +139,17 @@
 				cleantime += 10
 			if(istype(O,/obj/effect/rune) || istype(O,/obj/effect/decal/cleanable) || istype(O,/obj/effect/overlay))
 				cleantime += 50
-		if(do_after(src, cleantime))
-			clean_blood()
-			if(istype(loc, /turf/simulated))
-				var/turf/simulated/T = loc
-				T.dirt = 0
-			for(var/obj/effect/O in loc)
-				if(istype(O,/obj/effect/rune) || istype(O,/obj/effect/decal/cleanable) || istype(O,/obj/effect/overlay))
-					qdel(O)
+		if(cleantime > 0)
+			if(do_after(src, cleantime * cTimeMult))
+				clean_blood()
+				if(istype(loc, /turf/simulated))
+					var/turf/simulated/T = loc
+					T.dirt = 0
+				for(var/obj/effect/O in loc)
+					if(istype(O,/obj/effect/rune) || istype(O,/obj/effect/decal/cleanable) || istype(O,/obj/effect/overlay))
+						qdel(O)
+		else
+			handleIdle()
 	busy = 0
 	update_icons()
 

--- a/code/modules/mob/living/bot/cleanbot.dm
+++ b/code/modules/mob/living/bot/cleanbot.dm
@@ -99,12 +99,13 @@
 	if(get_turf(target) == src.loc)
 		UnarmedAttack(target)
 
-/mob/living/bot/cleanbot/UnarmedAttack(var/obj/effect/decal/cleanable/D, var/proximity)
+//mob/living/bot/cleanbot/UnarmedAttack(var/obj/effect/decal/cleanable/D, var/proximity)
+/mob/living/bot/cleanbot/UnarmedAttack(atom/D, var/proximity)
 	if(!..())
 		return
 
-	if(!istype(D))
-		return
+	//if(!istype(D))
+	//	return
 
 	if(D.loc != loc)
 		return
@@ -113,17 +114,33 @@
 	if(prob(20))
 		custom_emote(2, "begins to clean up \the [D]")
 	update_icons()
-	var/cleantime = istype(D, /obj/effect/decal/cleanable/dirt) ? 10 : 50
-	if(do_after(src, cleantime))
-		if(istype(loc, /turf/simulated))
-			var/turf/simulated/f = loc
-			f.dirt = 0
-		if(!D)
-			return
-		qdel(D)
-		if(D == target)
-			cleanbot_reserved_turfs -= target
-			target = null
+	var/cleantime = 0
+	if(istype(D, /obj/effect/decal/cleanable))
+		cleantime = istype(D, /obj/effect/decal/cleanable/dirt) ? 10 : 50
+		if(do_after(src, cleantime))
+			if(istype(loc, /turf/simulated))
+				var/turf/simulated/f = loc
+				f.dirt = 0
+			if(!D)
+				return
+			qdel(D)
+			if(D == target)
+				cleanbot_reserved_turfs -= target
+				target = null
+	else if(D == src)
+		for(var/obj/effect/O in loc)
+			if(istype(O, /obj/effect/decal/cleanable/dirt))
+				cleantime += 10
+			if(istype(O,/obj/effect/rune) || istype(O,/obj/effect/decal/cleanable) || istype(O,/obj/effect/overlay))
+				cleantime += 50
+		if(do_after(src, cleantime))
+			clean_blood()
+			if(istype(loc, /turf/simulated))
+				var/turf/simulated/T = loc
+				T.dirt = 0
+			for(var/obj/effect/O in loc)
+				if(istype(O,/obj/effect/rune) || istype(O,/obj/effect/decal/cleanable) || istype(O,/obj/effect/overlay))
+					qdel(O)
 	busy = 0
 	update_icons()
 

--- a/code/modules/mob/living/bot/edCLNbot.dm
+++ b/code/modules/mob/living/bot/edCLNbot.dm
@@ -11,6 +11,7 @@
 
 	patrol_speed = 3
 	target_speed = 6
+	cTimeMult = 0.3 // Big bois should be big fast :3
 
 	vocal = 1
 	cleaning = 0


### PR DESCRIPTION
Fixing login/out overwriting bot settings for bots, fixing vore settings being kept after logout.

This fixes a bug that caused sapient bots to not hear any sound.

Sapient cleanbots can now clean a whole turf by clicking on themselves, allowing the bot to clean dirt that they wouldn't previously have been able to. (They were only able to clean decals that were clickable, dirt is not.)