### PR TITLE
Xenobio fixes

### DIFF
--- a/code/modules/ai/ai_holder_movement.dm
+++ b/code/modules/ai/ai_holder_movement.dm
@@ -145,6 +145,8 @@
 
 // Wanders randomly in cardinal directions.
 /datum/ai_holder/proc/handle_wander_movement()
+	if(!holder)
+		return
 	ai_log("handle_wander_movement() : Entered.", AI_LOG_TRACE)
 	if(isturf(holder.loc) && can_act())
 		wander_delay--
@@ -164,13 +166,13 @@
 	// No target, don't use the ladder
 	// Target is visible, don't use the ladder
 	if(!target || can_see_target(target))
-		return 
+		return
 
 	var/has_hands = TRUE
 	if(istype(holder, /mob/living/simple_mob))
 		var/mob/living/simple_mob/S = holder
 		has_hands = S.has_hands
-	
+
 	// Don't have means to use a ladder or the space around it, don't use the ladder
 	if(!has_hands && !holder.hovering)
 		return
@@ -178,7 +180,7 @@
 	var/obj/structure/ladder/L = locate() in get_turf(holder)
 	if(!istype(L))
 		return // No ladder, can't use it
-	
+
 	if(!holder.may_climb_ladders(L))
 		return // Can't climb the ladder for other reasons (Probably inconsequential?)
 
@@ -187,6 +189,6 @@
 		directions += L.target_down
 	if(L.allowed_directions & UP)
 		directions += L.target_up
-	
+
 	if(directions.len)
 		L.climbLadder(holder, pick(directions))

--- a/code/modules/mob/living/simple_mob/subtypes/slime/xenobio/xenobio.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/slime/xenobio/xenobio.dm
@@ -225,7 +225,11 @@
 				if(T.density) // No walls.
 					continue
 				for(var/atom/movable/AM in T)
-					if(AM.density || istype(AM, /mob/living/simple_mob/slime))
+					if(istype(AM, /mob/living/simple_mob/slime) || !(AM.CanPass(src, T)))
+						free = FALSE
+						break
+				for(var/atom/movable/AM in get_turf(src))
+					if(!(AM.CanPass(src, T)) && !(AM == src))
 						free = FALSE
 						break
 
@@ -238,7 +242,7 @@
 
 			var/list/babies = list()
 			for(var/i = 1 to split_amount)
-				babies.Add(make_new_slime())
+				babies.Add(make_new_slime(no_step = i))
 
 			var/mob/living/simple_mob/slime/new_slime = pick(babies)
 			new_slime.universal_speak = universal_speak
@@ -253,7 +257,7 @@
 		to_chat(src, span("warning", "I have not evolved enough to reproduce yet..."))
 
 // Used when reproducing or dying.
-/mob/living/simple_mob/slime/xenobio/proc/make_new_slime(var/desired_type)
+/mob/living/simple_mob/slime/xenobio/proc/make_new_slime(var/desired_type, var/no_step)
 	var/t = src.type
 	if(desired_type)
 		t = desired_type
@@ -275,7 +279,8 @@
 	baby.faction = faction
 	baby.friends = friends.Copy()
 
-	step_away(baby, src)
+	if(no_step != 1)
+		step_away(baby, src)
 	return baby
 
 /mob/living/simple_mob/slime/xenobio/get_description_interaction()


### PR DESCRIPTION
Fixes slimes being able to stack infinitely in some circumstances (they can still stack under specific circumstances, but only once and not infinitely, so less chances of amber overload)

Fixes a runtime caused by slimes trying to process movement after splitting