### PR TITLE
Changes Schnapsen loadout description

### DIFF
--- a/code/modules/client/preference_setup/loadout/loadout_general_vr.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_general_vr.dm
@@ -94,5 +94,5 @@
 
 /datum/gear/schnapsen
 	display_name = "schnapsen playing cards"
-	description = "French-suit playing cards! Pre-picked for 2-player mode."
+	description = "An ancient Austro-Hungarian suit of cards!"
 	path = /obj/item/weapon/deck/schnapsen


### PR DESCRIPTION
Forgot to change description when updating the icons to use william tell pattern.