### PR TITLE
Plating can be built on most ground turfs.

### DIFF
--- a/code/game/turfs/flooring/flooring_vr.dm
+++ b/code/game/turfs/flooring/flooring_vr.dm
@@ -19,7 +19,8 @@
 	icon_base = "flesh_floor"
 
 /decl/flooring/grass/outdoors
-	flags = TURF_REMOVE_SHOVEL
+	flags = 0
+	build_type = null
 
 /decl/flooring/grass/outdoors/forest
 	icon = 'icons/turf/outdoors.dmi'
@@ -102,7 +103,7 @@
 
 /obj/item/stack/tile/floor/milspec/sterile
 	name = "sterile milspec floor tile"
-	
+
 /decl/flooring/tiling/milspec/raised
 	name = "raised milspec floor"
 	icon_base = "milspec_tcomms"

--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -27,6 +27,7 @@
 	var/initial_flooring
 	var/decl/flooring/flooring
 	var/mineral = DEFAULT_WALL_MATERIAL
+	var/can_be_plated = TRUE // This is here for inheritance's sake. Override to FALSE for turfs you don't want someone to simply slap a plating over such as hazards.
 
 	thermal_conductivity = 0.040
 	heat_capacity = 10000

--- a/code/game/turfs/simulated/floor_attackby.dm
+++ b/code/game/turfs/simulated/floor_attackby.dm
@@ -72,9 +72,23 @@
 			to_chat(user, "<span class='warning'>You must remove the [flooring.descriptor] first.</span>")
 			return
 		else if(istype(C, /obj/item/stack/tile))
-			try_replace_tile(C, user)
-			return
-	
+			if(try_replace_tile(C, user))
+				return
+			else if(istype(C, /obj/item/stack/tile/floor)) // While we're at it, let's see if this is a raw patch of natural sand, dirt, or whatever that you're trying to put a plating on.
+				if(!flooring.build_type && can_be_plated && !((flooring.flags & TURF_REMOVE_WRENCH) || (flooring.flags & TURF_REMOVE_CROWBAR) || (flooring.flags & TURF_REMOVE_SCREWDRIVER) || (flooring.flags & TURF_REMOVE_SHOVEL)))
+					for(var/obj/structure/P in contents)
+						if(istype(P, /obj/structure/flora))
+							to_chat(user, "<span class='warning'>The [P.name] is in the way, you'll have to get rid of it first.</span>")
+							return
+					var/obj/item/stack/tile/floor/S = C
+					if (S.get_amount() < 1)
+						return
+					S.use(1)
+					playsound(src, 'sound/weapons/Genhit.ogg', 50, 1)
+					ChangeTurf(/turf/simulated/floor, preserve_outdoors = TRUE)
+					return
+
+
 	// Floor is plating (or no flooring)
 	else
 		// Placing wires on plating
@@ -136,7 +150,7 @@
 						return
 					if(!can_remove_plating(user))
 						return
-					
+
 					user.visible_message("<span class='warning'>[user] begins cutting through [src].</span>", "<span class='warning'>You begin cutting through [src].</span>")
 					// This is slow because it's a potentially hostile action to just cut through places into space in the middle of the bar and such
 					// Presumably also the structural floor is thick?

--- a/code/game/turfs/simulated/lava.dm
+++ b/code/game/turfs/simulated/lava.dm
@@ -13,6 +13,7 @@
 	light_on = TRUE
 	movement_cost = 2
 	can_build_into_floor = TRUE
+	can_be_plated = FALSE
 	can_dirty = FALSE
 	initial_flooring = /decl/flooring/lava // Defining this in case someone DOES step on lava and survive. Somehow.
 	flags = TURF_ACID_IMMUNE

--- a/code/game/turfs/simulated/outdoors/outdoors.dm
+++ b/code/game/turfs/simulated/outdoors/outdoors.dm
@@ -8,7 +8,7 @@ var/list/turf_edge_cache = list()
 	var/outdoors = OUTDOORS_AREA
 
 /area
-	// If a turf's `outdoors` variable is set to `OUTDOORS_AREA`, 
+	// If a turf's `outdoors` variable is set to `OUTDOORS_AREA`,
 	// it will decide if it's outdoors or not when being initialized based on this var.
 	var/outdoors = OUTDOORS_NO
 

--- a/code/game/turfs/simulated/outdoors/outdoors_attackby.dm
+++ b/code/game/turfs/simulated/outdoors/outdoors_attackby.dm
@@ -1,7 +1,0 @@
-// this code here enables people to dig up worms from certain tiles.
-
-/turf/simulated/floor/outdoors/grass/attackby(obj/item/weapon/S as obj, mob/user as mob)
-	if(istype(S, /obj/item/stack/tile/floor))
-		ChangeTurf(/turf/simulated/floor, preserve_outdoors = TRUE)
-		return
-	. = ..()

--- a/code/game/turfs/simulated/outdoors/snow.dm
+++ b/code/game/turfs/simulated/outdoors/snow.dm
@@ -51,6 +51,7 @@
 	icon_state = "ice"
 	desc = "Looks slippery."
 	edge_blending_priority = 0
+	can_be_plated = FALSE
 
 /turf/simulated/floor/outdoors/ice/dark
 	name = "black ice"

--- a/code/game/turfs/simulated/water.dm
+++ b/code/game/turfs/simulated/water.dm
@@ -8,6 +8,7 @@
 	var/under_state = "rock"
 	edge_blending_priority = -1
 	movement_cost = 4
+	can_be_plated = FALSE
 	outdoors = OUTDOORS_YES
 	flags = TURF_ACID_IMMUNE
 

--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -403,30 +403,14 @@ var/list/mining_overlay_cache = list()
 					F.attackby(W,user)
 					return
 
-		else if(istype(W, /obj/item/stack/rods))
-			var/obj/structure/lattice/L = locate(/obj/structure/lattice, src)
-			if(L)
-				return
-			var/obj/item/stack/rods/R = W
-			if (R.use(1))
-				to_chat(user, "<span class='notice'>Constructing support lattice ...</span>")
-				playsound(src, 'sound/weapons/Genhit.ogg', 50, 1)
-				new /obj/structure/lattice(get_turf(src))
-
 		else if(istype(W, /obj/item/stack/tile/floor))
-			var/obj/structure/lattice/L = locate(/obj/structure/lattice, src)
-			if(L)
-				var/obj/item/stack/tile/floor/S = W
-				if (S.get_amount() < 1)
-					return
-				qdel(L)
-				playsound(src, 'sound/weapons/Genhit.ogg', 50, 1)
-				ChangeTurf(/turf/simulated/floor)
-				S.use(1)
+			var/obj/item/stack/tile/floor/S = W
+			if (S.get_amount() < 1)
 				return
-			else
-				to_chat(user, "<span class='warning'>The plating is going to need some support.</span>")
-				return
+			playsound(src, 'sound/weapons/Genhit.ogg', 50, 1)
+			ChangeTurf(/turf/simulated/floor)
+			S.use(1)
+			return
 
 
 	else

--- a/maps/groundbase/groundbase_things.dm
+++ b/maps/groundbase/groundbase_things.dm
@@ -76,6 +76,7 @@ VIRGO3B_TURF_CREATE(/turf/simulated/floor/outdoors/rocks)
 	desc = "Magnetic levitation tram tracks. Caution! Electrified!"
 	icon = 'icons/turf/flooring/maglevs.dmi'
 	icon_state = "maglevup"
+	can_be_plated = FALSE
 
 	var/area/shock_area = /area/centcom/terminal/tramfluff
 

--- a/maps/stellardelight/stellar_delight_things.dm
+++ b/maps/stellardelight/stellar_delight_things.dm
@@ -10,6 +10,7 @@
 	desc = "Magnetic levitation tram tracks. Caution! Electrified!"
 	icon = 'icons/turf/flooring/maglevs.dmi'
 	icon_state = "maglevup"
+	can_be_plated = FALSE
 
 	var/area/shock_area = /area/tether/surfacebase/tram
 

--- a/maps/tether/tether_things.dm
+++ b/maps/tether/tether_things.dm
@@ -145,6 +145,7 @@
 	desc = "Magnetic levitation tram tracks. Caution! Electrified!"
 	icon = 'icons/turf/flooring/maglevs.dmi'
 	icon_state = "maglevup"
+	can_be_plated = FALSE
 
 	var/area/shock_area = /area/tether/surfacebase/tram
 

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -1625,7 +1625,6 @@
 #include "code\game\turfs\simulated\outdoors\grass.dm"
 #include "code\game\turfs\simulated\outdoors\ironsand_vr.dm"
 #include "code\game\turfs\simulated\outdoors\outdoors.dm"
-#include "code\game\turfs\simulated\outdoors\outdoors_attackby.dm"
 #include "code\game\turfs\simulated\outdoors\outdoors_vr.dm"
 #include "code\game\turfs\simulated\outdoors\sky.dm"
 #include "code\game\turfs\simulated\outdoors\snow.dm"


### PR DESCRIPTION
Exactly what it says on the tin. This PR lets people lay plating on floor turfs as long as these conditions are met.

- The turf doesn't have an obtainable tile type.
- The turf cannot be deconstructed by normal means.
- It is not a specifically forbidden turf type, which currently includes lava, water, ice, and maglev tracks.

Mineral turfs also no longer need a support lattice.