### PR TITLE
Fixes numbing_belly/painkillers NOT blocking shock messages

### DIFF
--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -84,7 +84,7 @@
 		handle_shock()
 
 		handle_pain()
-		
+
 		handle_allergens()
 
 		handle_medical_side_effects()
@@ -1621,32 +1621,39 @@
 		return 0
 
 	if(shock_stage == 10)
-		custom_pain("[pick("It hurts so much", "You really need some painkillers", "Dear god, the pain")]!", 40)
+		if(traumatic_shock >= 80)
+			custom_pain("[pick("It hurts so much", "You really need some painkillers", "Dear god, the pain")]!", 40)
 
 	if(shock_stage >= 30)
 		if(shock_stage == 30 && !isbelly(loc)) //VOREStation Edit
 			custom_emote(VISIBLE_MESSAGE, "is having trouble keeping their eyes open.")
 		eye_blurry = max(2, eye_blurry)
-		stuttering = max(stuttering, 5)
+		if(traumatic_shock >= 80)
+			stuttering = max(stuttering, 5)
+
 
 	if(shock_stage == 40)
-		to_chat(src, "<span class='danger'>[pick("The pain is excruciating", "Please&#44; just end the pain", "Your whole body is going numb")]!</span>")
+		if(traumatic_shock >= 80)
+			to_chat(src, "<span class='danger'>[pick("The pain is excruciating", "Please&#44; just end the pain", "Your whole body is going numb")]!</span>")
 
 	if (shock_stage >= 60)
 		if(shock_stage == 60 && !isbelly(loc)) //VOREStation Edit
 			custom_emote(VISIBLE_MESSAGE, "'s body becomes limp.")
 		if (prob(2))
-			to_chat(src, "<span class='danger'>[pick("The pain is excruciating", "Please&#44; just end the pain", "Your whole body is going numb")]!</span>")
+			if(traumatic_shock >= 80)
+				to_chat(src, "<span class='danger'>[pick("The pain is excruciating", "Please&#44; just end the pain", "Your whole body is going numb")]!</span>")
 			Weaken(20)
 
 	if(shock_stage >= 80)
 		if (prob(5))
-			to_chat(src, "<span class='danger'>[pick("The pain is excruciating", "Please&#44; just end the pain", "Your whole body is going numb")]!</span>")
+			if(traumatic_shock >= 80)
+				to_chat(src, "<span class='danger'>[pick("The pain is excruciating", "Please&#44; just end the pain", "Your whole body is going numb")]!</span>")
 			Weaken(20)
 
 	if(shock_stage >= 120)
 		if (prob(2))
-			to_chat(src, "<span class='danger'>[pick("You black out", "You feel like you could die any moment now", "You are about to lose consciousness")]!</span>")
+			if(traumatic_shock >= 80)
+				to_chat(src, "<span class='danger'>[pick("You black out", "You feel like you could die any moment now", "You are about to lose consciousness")]!</span>")
 			Paralyse(5)
 
 	if(shock_stage == 150)


### PR DESCRIPTION
Previously, this is how the code was:

If you suffer damage, sum all damage, multiply by sensitivity and subtract painkiller.
If this is greater than 80, increment "shock" by 1. At various points, start sending pain messages.

This is fine.

However, there was a bit of code that checked if your health was below a specific treshold. When this happened, it set your "shock" to 60 regardless of what happens. This allowed for people to get weakened, dizzy and paralyzed even on painkillers.

This is also fine.

However, pain messages going through even on painkillers was NOT fine.

So, what I did was take each shock_stage and wrap the pain message inside a check for traumatic shock.

This way, you still become dizzy, weakened and paralyzed from taking too much damage. Your screen still gets the red-out overlay with a lot of damage. However, the "Dear god the pain" "Please end my suffering" spiel no longer shows up IF you have a strong enough painkiller.

Numbing belly injects the prey with "Numbing enzyme", which has a CE_PAINKILLER value of 200.

This means, while digesting prey they will NEVER see pain messages while on numbing mode, for they must sustain 233 damage (assuming only brute and burn, oxloss is evenmore, toxloss is lower, cloneloss is lowest. Broken limbs are also lower. The goal here is to make digestion scenes less squick for those who want painless digestion, so brute/burn/ox needing to hit 233 is fine). Now, 233 brute/burn should kill everyone, so it's good. Worst case, we can jump the "numbing" enzyme to a higher CE_PAINKILLER value.

This also works for normal painkillers, but with a lower threshold.

Treshold to see **shock-based pain messages** with ONLY brute and BURN at sensitivty 1.

No painkiller: 66
Inaprovaline: 77
Tramadol: 135
Oxycodone: 233

I stress: This ONLY affect shock-based pain messages.

Spring-Skipper#2993 is working on a more thorough refractor, this is just a quick fix.


Tested:

Meatbag on land, no painkiller. Works as intended
- Traumatic_shock increases to 80
- Shock_stage increments by 1
- Shockstage jumps to 60 when under soft crit treshold if not 60 already
- Painmessages based on shockstage


Meatbag on land, with oxycodone, tramadol, etc. Works as intended
- Traumatic shock remains around 0 until injuries exceed painkiller
- Hit soft_crit treshold before traumatic shock hits 80 usually, skipping the earlier shock stage pain messages outright
- Shockstage jumps to 60 when this happens
- Pain messages only occur once traumatic shock reaches 80
- 
Meatbag in belly, no numbing: Works as intended
- Traumatic_shock increases to 80
- Shock_stage increments by 1
- Shockstage jumps to 60 when under soft crit treshold if not 60 already
- Painmessages based on shockstage

Meatbag in belly, with numbing: Works as intended
- Traumatic shock remains at 0 until death (painkiller needs (1.2*brute+1.2*burn)*sensitiivty > 80 + CE_PAINKILLER (which is 200), so barring neural hypersensitivity, they will always die before painkiller is no longer capable of helping
- shockstage jumps to 60 under soft crit treshold
- No pain messages received 