### PR TITLE
Fixes "Lick Wounds" Verb Range

### DIFF
--- a/code/modules/mob/living/carbon/lick_wounds.dm
+++ b/code/modules/mob/living/carbon/lick_wounds.dm
@@ -1,4 +1,4 @@
-/mob/living/carbon/human/proc/lick_wounds(var/mob/living/carbon/M) // Allows the user to lick themselves. Given how rarely this trait is used, I don't see an issue with a slight buff.
+/mob/living/carbon/human/proc/lick_wounds(var/mob/living/carbon/M as mob in range(1)) // Allows the user to lick themselves. Given how rarely this trait is used, I don't see an issue with a slight buff.
 	set name = "Lick Wounds"
 	set category = "Abilities"
 	set desc = "Disinfect and heal small wounds with your saliva."


### PR DESCRIPTION
Generally makes the verb a bit easier/less annoying to use.
For example: 
- If multiple mobs are around, only those are shown in the popup list that are right next to one.
- If no other mob is directly next to one (but still in the same room), it is possible to directly instantly use the verb on oneself without needing to select the character

Thanks to @Heroman3003 for the solution suggestion!