### PR TITLE
Brings fairness back to holodeck

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -107,6 +107,8 @@
 
 	var/tip_timer // reference to timer id for a tooltip we might open soon
 
+	var/no_random_knockdown = FALSE			//stops item from being able to randomly knock people down in combat
+
 /obj/item/New()
 	..()
 	if(embed_chance < 0)

--- a/code/modules/holodeck/HolodeckObjects.dm
+++ b/code/modules/holodeck/HolodeckObjects.dm
@@ -278,6 +278,7 @@
 /obj/item/weapon/holo
 	damtype = HALLOSS
 	no_attack_log = 1
+	no_random_knockdown = TRUE
 
 /obj/item/weapon/holo/esword
 	desc = "May the force be within you. Sorta."

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -321,7 +321,7 @@ emp_act
 					H.bloody_body(src)
 					H.bloody_hands(src)
 
-		if(!stat)
+		if(!stat && !(I.no_random_knockdown))
 			switch(hit_zone)
 				if(BP_HEAD)//Harder to score a stun but if you do it lasts a bit longer
 					if(prob(effective_force))


### PR DESCRIPTION
At some point in ancient past, something broke targeting for torso. This meant that no weapon in the game could proc random knockdown chance when attacking people at the torso (but afaik it worked fine for head targeting). It was fixed recently. However, between it breaking and it being fixed, not only is it breaking when it was unnoticed, but it being even a thing that should happen has been forgotten; as well as a new mentality has formed around way holodeck thunderdome 'should be'. The random knockdown chance was supposed to be there all along but because it wasn't people assume the 'fair and non-rng' combat (haha) of holodeck was completely intentional.

In spirit of preserving competitive nature without ascending bugs to features and changing balance, this PR simply makes holodeck weapons specifically unable to RNG knockdown when hitting someone, be it head or torso. Also leaves room to leave out this knockdown of any other weapons needed in future.

Technically fixes #13021 even though its not a bug at all and this isn't a bugfix but a feature change.