### PR TITLE
Make vchat warning only fire if vchat is enabled

### DIFF
--- a/code/modules/vchat/vchat_client.dm
+++ b/code/modules/vchat/vchat_client.dm
@@ -161,6 +161,7 @@ GLOBAL_DATUM_INIT(iconCache, /savefile, new("data/iconCache.sav")) //Cache of ic
 	update_vis()
 
 	spawn()
+	if(owner.is_preference_enabled(/datum/client_preference/vchat_enable))
 		tgui_alert_async(owner,"VChat didn't load after some time. Switching to use oldchat as a fallback. Try using 'Reload VChat' verb in OOC verbs, or reconnecting to try again.")
 
 //Provide the JS with who we are


### PR DESCRIPTION
ME USE OLD CHAT

ME NOT LIKE THAT IT WARNS ME THAT VCHAT ISN'T WORKING EVERY TIME WHEN I HAVE THE PREFERENCE FOR IT DISABLED

So, this makes it only warn you about vchat not working if you have vchat enabled.