### PR TITLE
Restart vote tweaks

### DIFF
--- a/code/controllers/subsystems/vote.dm
+++ b/code/controllers/subsystems/vote.dm
@@ -362,7 +362,8 @@ SUBSYSTEM_DEF(vote)
 
 		if(VOTE_RESTART)
 			if(config.allow_vote_restart || usr.client.holder)
-				if(!GLOB.admins.len || usr.client.holder)
+				var/admin_number_present = send2irc_adminless_only(initiator_ckey, name)
+				if(admin_number_present <= 0 || || usr.client.holder)
 					if(tgui_alert(usr, "Are you sure you want to start a RESTART VOTE? You should only do this if the server is dying and no staff are around to investigate.", "RESTART VOTE", list("No", "Yes I want to start a RESTART VOTE")) == "Yes I want to start a RESTART VOTE")
 						initiate_vote(VOTE_RESTART, usr.key)
 				else

--- a/code/controllers/subsystems/vote.dm
+++ b/code/controllers/subsystems/vote.dm
@@ -363,7 +363,7 @@ SUBSYSTEM_DEF(vote)
 		if(VOTE_RESTART)
 			if(config.allow_vote_restart || usr.client.holder)
 				var/admin_number_present = send2irc_adminless_only(initiator_ckey, name)
-				if(admin_number_present <= 0 || || usr.client.holder)
+				if(admin_number_present <= 0 || usr.client.holder)
 					if(tgui_alert(usr, "Are you sure you want to start a RESTART VOTE? You should only do this if the server is dying and no staff are around to investigate.", "RESTART VOTE", list("No", "Yes I want to start a RESTART VOTE")) == "Yes I want to start a RESTART VOTE")
 						initiate_vote(VOTE_RESTART, usr.key)
 				else

--- a/code/controllers/subsystems/vote.dm
+++ b/code/controllers/subsystems/vote.dm
@@ -362,7 +362,7 @@ SUBSYSTEM_DEF(vote)
 
 		if(VOTE_RESTART)
 			if(config.allow_vote_restart || usr.client.holder)
-				var/admin_number_present = send2irc_adminless_only(initiator_ckey, name)
+				var/admin_number_present = send2irc_adminless_only(usr.ckey, usr)
 				if(admin_number_present <= 0 || usr.client.holder)
 					if(tgui_alert(usr, "Are you sure you want to start a RESTART VOTE? You should only do this if the server is dying and no staff are around to investigate.", "RESTART VOTE", list("No", "Yes I want to start a RESTART VOTE")) == "Yes I want to start a RESTART VOTE")
 						initiate_vote(VOTE_RESTART, usr.key)

--- a/code/controllers/subsystems/vote.dm
+++ b/code/controllers/subsystems/vote.dm
@@ -362,7 +362,11 @@ SUBSYSTEM_DEF(vote)
 
 		if(VOTE_RESTART)
 			if(config.allow_vote_restart || usr.client.holder)
-				initiate_vote(VOTE_RESTART, usr.key)
+				if(!GLOB.admins.len || usr.client.holder)
+					if(tgui_alert(usr, "Are you sure you want to start a RESTART VOTE? You should only do this if the server is dying and no staff are around to investigate.", "RESTART VOTE", list("No", "Yes I want to start a RESTART VOTE")) == "Yes I want to start a RESTART VOTE")
+						initiate_vote(VOTE_RESTART, usr.key)
+				else
+					to_chat(usr, "<span class = 'warning'>You can't start a RESTART VOTE while there are staff around. If you are having an issue with the round, please ahelp it.</span>")
 		if(VOTE_GAMEMODE)
 			if(config.allow_vote_mode || usr.client.holder)
 				initiate_vote(VOTE_GAMEMODE, usr.key)


### PR DESCRIPTION
Makes it so you can only trigger restart votes if there are no staff on/if you are staff

still needs to be tested