### PR TITLE
Calls reset_view when entering and exiting holders and bellies

### DIFF
--- a/code/modules/mob/holder.dm
+++ b/code/modules/mob/holder.dm
@@ -29,11 +29,13 @@ var/list/holder_mob_icon_cache = list()
 	ASSERT(ismob(held))
 	. = ..()
 	held.forceMove(src)
+	held.reset_view(src)
 	START_PROCESSING(SSobj, src)
 
 /obj/item/weapon/holder/Entered(mob/held, atom/OldLoc)
 	if(held_mob)
 		held.forceMove(get_turf(src))
+		held.reset_view(null)
 		return
 	ASSERT(ismob(held))
 	. = ..()
@@ -71,6 +73,7 @@ var/list/holder_mob_icon_cache = list()
 	held_mob.transform = original_transform
 	held_mob.vis_flags = original_vis_flags
 	held_mob.forceMove(get_turf(src))
+	held_mob.reset_view(null)
 	held_mob = null
 
 /obj/item/weapon/holder/throw_at(atom/target, range, speed, thrower)
@@ -103,9 +106,12 @@ var/list/holder_mob_icon_cache = list()
 			holster.clear_holster()
 		to_chat(held, "<span class='warning'>You extricate yourself from [holster].</span>")
 		forceMove(get_turf(src))
+		held.reset_view(null)
+
 	else if(isitem(loc))
 		to_chat(held, "<span class='warning'>You struggle free of [loc].</span>")
 		forceMove(get_turf(src))
+		held.reset_view(null)
 
 //Mob specific holders.
 /obj/item/weapon/holder/diona

--- a/code/modules/vore/eating/belly_obj_vr.dm
+++ b/code/modules/vore/eating/belly_obj_vr.dm
@@ -378,6 +378,9 @@
 		slip.slip_protect = world.time + 25 // This is to prevent slipping back into your pred if they stand on soap or something.
 	//Place them into our drop_location
 	M.forceMove(drop_location())
+	if(ismob(M))
+		var/mob/ourmob = M
+		ourmob.reset_view(null)
 	items_preserved -= M
 
 	//Special treatment for absorbed prey
@@ -416,6 +419,10 @@
 			soundfile = fancy_release_sounds[release_sound]
 		if(soundfile)
 			playsound(src, soundfile, vol = 100, vary = 1, falloff = VORE_SOUND_FALLOFF, preference = /datum/client_preference/eating_noises, volume_channel = VOLUME_CHANNEL_VORE)
+	//Should fix your view not following you out of mobs sometimes!
+	if(ismob(M))
+		var/mob/ourmob = M
+		ourmob.reset_view(null)
 
 	return 1
 
@@ -429,6 +436,9 @@
 		prey.buckled.unbuckle_mob()
 
 	prey.forceMove(src)
+	if(ismob(prey))
+		var/mob/ourmob = prey
+		ourmob.reset_view(owner)
 	owner.updateVRPanel()
 	if(isanimal(owner))
 		owner.update_icon()
@@ -722,6 +732,10 @@
 	//This is probably already the case, but for sub-prey, it won't be.
 	if(M.loc != src)
 		M.forceMove(src)
+
+	if(ismob(M))
+		var/mob/ourmob = M
+		ourmob.reset_view(owner)
 
 	//Seek out absorbed prey of the prey, absorb them too.
 	//This in particular will recurse oddly because if there is absorbed prey of prey of prey...
@@ -1033,6 +1047,9 @@
 	if(!(content in src) || !istype(target))
 		return
 	content.forceMove(target)
+	if(ismob(content))
+		var/mob/ourmob = content
+		ourmob.reset_view(owner)
 	if(isitem(content))
 		var/obj/item/I = content
 		if(istype(I,/obj/item/weapon/card/id))


### PR DESCRIPTION
There's been lots of times where I get picked up, eaten, dropped, or expelled where my view either becomes void or keeps following the person who did the thing.

This makes it so that in all these cases, reset_view is called after the procs responsible for that call forceMove. 

This should make it put your view back where it's supposed to be after any of those interactions.

With how often this happens to me, I'm really surprised people haven't complained about this. Does this just not happen to anyone else, or does everyone really push Cancel Camera View every time this happens?