### PR TITLE
Tweaks biofuel processor trait

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
@@ -164,7 +164,7 @@
 	cost = 0
 	custom_only = FALSE
 	can_take = SYNTHETICS
-	var_changes = list("organic_food_coeff" = 0.6, "synthetic_food_coeff" = 0.9)
+	var_changes = list("organic_food_coeff" = 0, "synthetic_food_coeff" = 0.6)
 
 /datum/trait/neutral/glowing_eyes
 	name = "Glowing Eyes"

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
@@ -164,7 +164,7 @@
 	cost = 0
 	custom_only = FALSE
 	can_take = SYNTHETICS
-	var_changes = list("organic_food_coeff" = 0, "synthetic_food_coeff" = 0.25)
+	var_changes = list("organic_food_coeff" = 0.6, "synthetic_food_coeff" = 0.9)
 
 /datum/trait/neutral/glowing_eyes
 	name = "Glowing Eyes"


### PR DESCRIPTION
Increases nutrition multiplier for biofuel processer from 25% to 60%

**Why:**
As it stands now Biofuel Processor is unnecessarily bad. Yeah sure, FBPs can charge but they can _also_ take trash eater which, correct me if I'm wrong, provides 50% the nutrition from food compared to the 25% biofuel processor provides. So the intent of this tweak is to make biofuel processor worth using over vacuuming food like a glutton.
Also I want to be horny with foodplay scenes as a robot.

I'd also like to make a suggestion for someone who actually knows their way around SS13 code:
An 'obligate' version of biofuel processor that provides full nutrition from food while disabling the use of cyborg chargers.