### PR TITLE
Makes security cyborg taser cost the same charge as security's tasers.

### DIFF
--- a/code/modules/projectiles/guns/energy/stun_vr.dm
+++ b/code/modules/projectiles/guns/energy/stun_vr.dm
@@ -4,3 +4,6 @@
 
 /obj/item/weapon/gun/energy/stunrevolver
 	charge_cost = 400
+
+/obj/item/weapon/gun/energy/taser/mounted/cyborg
+	charge_cost = 160


### PR DESCRIPTION
The history of taser charge+cost feels like a mess right now due to a history of vorestation/polaris commits.
But it seems like we're set on 15-shot tasers since they're 99% used on mobs which are often tanky/numerous enough to justify them.

So let's make the cyborg one not hot garbage in comparison.
I still believe it's a little bit worse since I consider cell swapping to be better than slowly drawing charge from a reserve cell, but that's something to discuss/address later.