### PR TITLE
New pAI verb

### DIFF
--- a/code/game/objects/items/devices/paicard.dm
+++ b/code/game/objects/items/devices/paicard.dm
@@ -17,6 +17,7 @@ GLOBAL_LIST_BOILERPLATE(all_pai_cards, /obj/item/device/paicard)
 	var/image/screen_layer
 	var/screen_color = "#00ff0d"
 	var/last_notify = 0
+	var/screen_msg
 
 /obj/item/device/paicard/relaymove(var/mob/user, var/direction)
 	if(user.stat || user.stunned)
@@ -259,6 +260,8 @@ GLOBAL_LIST_BOILERPLATE(all_pai_cards, /obj/item/device/paicard)
 			</table>
 		"}
 		*/
+		if(screen_msg)
+			dat += "<b>Message from [pai.name]</b><br>[screen_msg]"
 	else
 		if(looking_for_personality)
 			dat += {"

--- a/code/modules/mob/living/silicon/pai/pai_vr.dm
+++ b/code/modules/mob/living/silicon/pai/pai_vr.dm
@@ -376,3 +376,58 @@
 	else
 		hide_glow = FALSE
 	update_icon()
+
+/mob/living/silicon/pai/verb/screen_message(message as text|null)
+	set category = "pAI Commands"
+	set name = "Screen Message"
+	set desc = "Allows you to display a message on your screen. This will show up in the chat of anyone who is holding your card."
+
+	if (src.client)
+		if(client.prefs.muted & MUTE_IC)
+			to_chat(src, "<span class='warning'>You cannot speak in IC (muted).</span>")
+			return
+	if(loc != card)
+		to_chat(src, "<span class='warning'>Your message won't be visible while unfolded!</span>")
+	if (!message)
+		message = tgui_input_text(src, "Enter text you would like to show on your screen.","Screen Message")
+	message = sanitize_or_reflect(message,src)
+	if (!message)
+		return
+	message = capitalize(message)
+	if (stat == DEAD)
+		return
+	card.screen_msg = message
+	var/logmsg = "(CARD SCREEN)[message]"
+	log_say(logmsg,src)
+	to_chat(src, "<span class='cult'>You print a message to your screen, \"[message]\"</span>")
+	if(isliving(card.loc))
+		var/mob/living/L = card.loc
+		if(L.client)
+			to_chat(L, "<span class='cult'>[src.name]'s screen prints, \"[message]\"</span>")
+		else return
+	else if(isbelly(card.loc))
+		var/obj/belly/b = card.loc
+		if(b.owner.client)
+			to_chat(b.owner, "<span class='cult'>[src.name]'s screen prints, \"[message]\"</span>")
+		else return
+	else if(istype(card.loc, /obj/item/device/pda))
+		var/obj/item/device/pda/p = card.loc
+		if(isliving(p.loc))
+			var/mob/living/L = p.loc
+			if(L.client)
+				to_chat(L, "<span class='cult'>[src.name]'s screen prints, \"[message]\"</span>")
+			else return
+		else if(isbelly(p.loc))
+			var/obj/belly/b = card.loc
+			if(b.owner.client)
+				to_chat(b.owner, "<span class='cult'>[src.name]'s screen prints, \"[message]\"</span>")
+			else return
+		else return
+	else return
+	to_chat(src, "<span class='notice'>Your message was relayed.</span>")
+	for (var/mob/G in player_list)
+		if (istype(G, /mob/new_player))
+			continue
+		else if(isobserver(G) && G.is_preference_enabled(/datum/client_preference/ghost_ears))
+			if(is_preference_enabled(/datum/client_preference/whisubtle_vis) || G.client.holder)
+				to_chat(G, "<span class='cult'>[src.name]'s screen prints, \"[message]\"</span>")

--- a/code/modules/vore/eating/living_vr.dm
+++ b/code/modules/vore/eating/living_vr.dm
@@ -767,9 +767,16 @@
 		else if(istype(I,/obj/item/weapon/bikehorn/tinytether))
 			to_chat(src, "<span class='notice'>You feel a rush of power swallowing such a large, err, tiny structure.</span>")
 			visible_message("<span class='warning'>[src] demonstrates their voracious capabilities by swallowing [I] whole!</span>")
-		else if(istype(I,/obj/item/device/paicard) || istype(I,/obj/item/device/mmi/digital/posibrain) || istype(I,/obj/item/device/aicard))
+		else if(istype(I,/obj/item/device/mmi/digital/posibrain) || istype(I,/obj/item/device/aicard))
 			visible_message("<span class='warning'>[src] demonstrates their voracious capabilities by swallowing [I] whole!</span>")
 			to_chat(src, "<span class='notice'>You can taste the sweet flavor of digital friendship. Or maybe it is something else.</span>")
+		else if(istype(I,/obj/item/device/paicard))
+			visible_message("<span class='warning'>[src] demonstrates their voracious capabilities by swallowing [I] whole!</span>")
+			to_chat(src, "<span class='notice'>You can taste the sweet flavor of digital friendship.</span>")
+			var/obj/item/device/paicard/ourcard = I
+			if(ourcard.pai && ourcard.pai.client && isbelly(ourcard.loc))
+				var/obj/belly/B = ourcard.loc
+				to_chat(ourcard.pai, "<span class= 'notice'><B>[B.desc]</B></span>")
 		else if(istype(I,/obj/item/weapon/reagent_containers/food))
 			var/obj/item/weapon/reagent_containers/food/F = I
 			if(!F.reagents.total_volume)


### PR DESCRIPTION
Screen Message allows a pAI to display a message on their screen.

This makes it so the message can be read if you open the card interface, and, if you happen to be holding the card in one of your inventory slots that isn't a container of something else (or if you have them in your PDA or tummy), then it will print the message in the chat.

I decided to let it work for the tummy thing despite not making logical sense because people use bellies for all kinds of stuff, and it's not like you can powergame this so WHATEVER!!!!!!!!!!!!!!!

Logs anything you write to this into say, annnnd. Yeah!

This should let people who like to play mute pocket friends (me) quietly talk to the person holding the card, even when comms are down! (wow!)