### PR TITLE
pAI QOL

### DIFF
--- a/code/game/objects/items/devices/paicard.dm
+++ b/code/game/objects/items/devices/paicard.dm
@@ -1,3 +1,20 @@
+var/global/list/radio_channels_by_freq = list(
+	num2text(PUB_FREQ) = "Common",
+	num2text(AI_FREQ)  = "AI Private",
+	num2text(ENT_FREQ) = "Entertainment",
+	num2text(ERT_FREQ) = "Response Team",
+	num2text(COMM_FREQ)= "Command",
+	num2text(ENG_FREQ) = "Engineering",
+	num2text(MED_FREQ) = "Medical",
+	num2text(MED_I_FREQ)="Medical(I)",
+	num2text(SEC_FREQ) = "Security",
+	num2text(SEC_I_FREQ)="Security(I)",
+	num2text(SCI_FREQ) = "Science",
+	num2text(SUP_FREQ) = "Supply",
+	num2text(SRV_FREQ) = "Service",
+	num2text(EXP_FREQ) = "Explorer"
+	)
+
 GLOBAL_LIST_BOILERPLATE(all_pai_cards, /obj/item/device/paicard)
 
 /obj/item/device/paicard
@@ -11,7 +28,7 @@ GLOBAL_LIST_BOILERPLATE(all_pai_cards, /obj/item/device/paicard)
 	show_messages = 0
 	preserve_item = 1
 
-	var/obj/item/device/radio/radio
+	var/obj/item/device/radio/borg/pai/radio
 	var/looking_for_personality = 0
 	var/mob/living/silicon/pai/pai
 	var/image/screen_layer
@@ -42,10 +59,16 @@ GLOBAL_LIST_BOILERPLATE(all_pai_cards, /obj/item/device/paicard)
 	if(pai != null) //Have a person in them already?
 		return ..()
 
-	var/choice = tgui_alert(user, "You sure you want to inhabit this PAI?", "Confirmation", list("Yes", "No"))
-	if(choice == "No")
-		return ..()
+	if(jobban_isbanned(usr, "pAI"))
+		to_chat(usr,"<span class='warning'>You cannot join a pAI card when you are banned from playing as a pAI.</span>")
+		return
 
+	var/choice = tgui_alert(user, "You sure you want to inhabit this PAI, or submit yourself to being recruited?", "Confirmation", list("Inhabit", "Recruit", "Cancel"))
+	if(choice == "Cancel")
+		return ..()
+	if(choice == "Recruit")
+		paiController.recruitWindow(user)
+		return ..()
 	choice = tgui_alert(user, "Do you want to load your pAI data?", "Load", list("Yes", "No"))
 	var/actual_pai_name
 	var/turf/location = get_turf(src)
@@ -446,6 +469,34 @@ GLOBAL_LIST_BOILERPLATE(all_pai_cards, /obj/item/device/paicard)
 		to_chat(AI, span_notice("You feel a tad claustrophobic as your mind closes back into your card, ejecting from \the [initial(src.name)]."))
 		if(user)
 			to_chat(user, span_notice("You eject the card from \the [initial(src.name)]."))
+
+///////////////////////////////
+//////////pAI Radios//////////
+///////////////////////////////
+//Thanks heroman!
+
+/obj/item/device/radio/borg/pai
+	name = "integrated radio"
+	icon = 'icons/obj/robot_component.dmi' // Cyborgs radio icons should look like the component.
+	icon_state = "radio"
+	loudspeaker = FALSE
+
+/obj/item/device/radio/borg/pai/attackby(obj/item/weapon/W as obj, mob/user as mob)
+	return
+
+/obj/item/device/radio/borg/pai/recalculateChannels()
+	if(!istype(loc,/obj/item/device/paicard))
+		return
+	var/obj/item/device/paicard/card = loc
+	secure_radio_connections = list()
+	channels = list()
+
+	for(var/internal_chan in internal_channels)
+		var/ch_name = radio_channels_by_freq[internal_chan]
+		if(has_channel_access(card.pai, internal_chan))
+			channels += ch_name
+			channels[ch_name] = 1
+			secure_radio_connections[ch_name] = radio_controller.add_object(src, radiochannels[ch_name],  RADIO_CHAT)
 
 /obj/item/device/paicard/typeb
 	name = "personal AI device"

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -978,7 +978,14 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	set name = "Blank pAI alert"
 	set desc = "Flash an indicator light on available blank pAI devices for a smidgen of hope."
 	
+	if(jobban_isbanned(usr, "pAI"))
+		to_chat(usr,"<span class='warning'>You cannot alert pAI cards when you are banned from playing as a pAI.</span>")
+		return
+
 	if(usr.client.prefs?.be_special & BE_PAI)
+		var/choice = tgui_alert(usr, "Would you like to submit yourself to the recruitment list too?", "Confirmation", list("No", "Yes"))
+		if(choice == "Yes")
+			paiController.recruitWindow(usr)
 		var/count = 0
 		for(var/obj/item/device/paicard/p in all_pai_cards)
 			var/obj/item/device/paicard/PP = p

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -22,7 +22,7 @@
 	var/list/software = list()
 	var/userDNA		// The DNA string of our assigned user
 	var/obj/item/device/paicard/card	// The card we inhabit
-	var/obj/item/device/radio/radio		// Our primary radio
+	var/obj/item/device/radio/borg/pai/radio		// Our primary radio
 	var/obj/item/device/communicator/integrated/communicator	// Our integrated communicator.
 
 	var/chassis = "pai-repairbot"   // A record of your chosen chassis.
@@ -112,7 +112,7 @@
 	communicator = new(src)
 	if(card)
 		if(!card.radio)
-			card.radio = new /obj/item/device/radio(src.card)
+			card.radio = new /obj/item/device/radio/borg/pai(src.card)
 		radio = card.radio
 
 	//Default languages without universal translator software
@@ -135,7 +135,7 @@
 
 		var/datum/data/pda/app/messenger/M = pda.find_program(/datum/data/pda/app/messenger)
 		if(M)
-			M.toff = TRUE
+			M.toff = FALSE
 	..()
 
 /mob/living/silicon/pai/Login()
@@ -143,7 +143,6 @@
 	// Vorestation Edit: Meta Info for pAI
 	if (client.prefs)
 		ooc_notes = client.prefs.metadata
-
 
 // this function shows the information about being silenced as a pAI in the Status panel
 /mob/living/silicon/pai/proc/show_silenced()
@@ -403,12 +402,14 @@
 			M.drop_from_inventory(H)
 		H.loc = get_turf(src)
 		src.loc = get_turf(H)
-
-	// Move us into the card and move the card to the ground.
-	src.loc = card
-	card.loc = get_turf(card)
-	src.forceMove(card)
-	card.forceMove(card.loc)
+	
+	if(isbelly(loc))	//If in tumby, when fold up, card go into tumby
+		var/obj/belly/B = loc
+		src.forceMove(card)
+		card.forceMove(B)
+	else				//Otherwise go on floor
+		src.forceMove(card)
+		card.forceMove(get_turf(card))
 	canmove = 1
 	resting = 0
 	icon_state = "[chassis]"
@@ -441,11 +442,15 @@
 					idcard.access |= ID.access
 					to_chat(user, "<span class='notice'>You add the access from the [W] to [src].</span>")
 					to_chat(src, "<span class='notice'>\The [user] swipes the [W] over you. You copy the access codes.</span>")
+					if(radio)
+						radio.recalculateChannels()
 					return
 				if("Remove Access")
 					idcard.access = list()
 					to_chat(user, "<span class='notice'>You remove the access from [src].</span>")
 					to_chat(src, "<span class='warning'>\The [user] swipes the [W] over you, removing access codes from you.</span>")
+					if(radio)
+						radio.recalculateChannels()
 					return
 				if("Cancel")
 					return


### PR DESCRIPTION
Several tweaks and changes for pAI:

pAI banning:
clicking pAI cards and using the pAI alert ghost verb checks to see if you are banned from playing pAI now. Before only the original recruit prompt checked to see if you were banned from playing pAI! Now all existing forms of joining or asking to play as a pAI should check.

folding and bellies:
now if you end up in a belly as a pAI and you fold up, your card will land in the belly, instead of on the floor (unfolding already has a check to make it impossible to unfold while in a belly, since there's not enough space)

self add to recruit list:
Now when you click a pAI card as a ghost, or use the pAI alert ghost verb, you will be given the option of adding yourself to the pAI recruit list. If you do this, then anyone who checks their pAI cards could choose to pick you! You can of course also just not do this, and use both options as normal otherwise.

Originally you could only add yourself to the recruit list after someone had activated a pAI card and requested personalities. (And then promptly forgot to actually ever check back in with the device again. UWU)

pAI radio:
previously the pAI radio had just been a normal shortwave radio, with all the complications and limitations that implies

thanks to heroman's help though, pAIs now have a normal radio! It's channel access even still gets expanded or restricted based on its present available access, rather than dealing with headset keys! (since it needs to get that access from working with someone anyway)

With this, pAIs have access to juuuuuust about all the basic features one would kind of expect them to. 

There's still plenty of things to tweak and add, but these changes should bring them much more in line with what I think can be called 'complete'

All their stuff works I think!!!