### PR TITLE
Fixes taur clothing breaking

### DIFF
--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -960,6 +960,8 @@ var/global/list/damage_icon_parts = list() //see UpdateDamageIcon()
 	var/tail_layer = GET_TAIL_LAYER
 	if(tail_alt && tail_layer == TAIL_NORTH_LAYER)
 		tail_layer = TAIL_NORTH_LAYER_ALT
+	if(src.tail_style && src.tail_style.clip_mask_state)
+		tail_layer = TAIL_SOUTH_LAYER		// Use default, let clip mask handle everything
 
 	var/image/tail_image = get_tail_image()
 	if(tail_image)
@@ -1001,6 +1003,8 @@ var/global/list/damage_icon_parts = list() //see UpdateDamageIcon()
 	var/tail_layer = GET_TAIL_LAYER
 	if(tail_alt && tail_layer == TAIL_NORTH_LAYER)
 		tail_layer = TAIL_NORTH_LAYER_ALT
+	if(src.tail_style && src.tail_style.clip_mask_state)
+		tail_layer = TAIL_SOUTH_LAYER		// Use default, let clip mask handle everything
 	var/image/tail_overlay = overlays_standing[tail_layer]
 
 	remove_layer(TAIL_NORTH_LAYER)


### PR DESCRIPTION
Basically makes taur clip mask override the rules and use default tail layer

Fixes #13140