### PR TITLE
Account for Sleevecards and mild pAI use screen revamp

### DIFF
--- a/code/game/objects/items/devices/paicard.dm
+++ b/code/game/objects/items/devices/paicard.dm
@@ -222,8 +222,10 @@ GLOBAL_LIST_BOILERPLATE(all_pai_cards, /obj/item/device/paicard)
 			<b><font size='3px'>Personal AI Device</font></b><br><br>
 			<table class="request">
 				<tr>
-					<td class="request">Installed Personality:</td>
-					<td>[pai.name]</td>
+					<td><font size='5px'; color=[screen_color]><b>[pai.name]</b></font></td>
+				</tr>
+				<tr>
+					<td class="request">Integrity: [pai.health]</td>
 				</tr>
 				<tr>
 					<td class="request">Prime directive:</td>


### PR DESCRIPTION
Sleevecards don't normally get the directives window, so! This makes it so their directives UI button lets them know that they don't have any directives!

This also allows sleevecards to be emagged! An emagged sleevecard gets directives and the typical pAI card use screen that lets someone register themselves as their master and set directives.

This also changes the way infomorphs are named. The card itself stays with the format of 'Sleevecard (name)', but the mob itself just gets named the name instead, so it's less awkward to roleplay with/as.

This also modifies the pAI card use screen a little bit, to make the name more prominent, and colored the same as the pAI screen/eye color! Also added the current pAI health to the screen.

![image](https://user-images.githubusercontent.com/24854483/175754758-c7770d3c-3596-47f9-94de-c6fabd705af6.png)
