### PR TITLE
Fixes some reagent dispenser fuckery

### DIFF
--- a/code/modules/reagents/machinery/dispenser/cartridge_presets.dm
+++ b/code/modules/reagents/machinery/dispenser/cartridge_presets.dm
@@ -115,6 +115,8 @@
 	spawn_reagent = "watermelonjuice"
 /obj/item/weapon/reagent_containers/chem_disp_cartridge/lemon
 	spawn_reagent = "lemonjuice"
+/obj/item/weapon/reagent_containers/chem_disp_cartridge/grapesoda
+	spawn_reagent = "grapesoda"
 
 // Bar, coffee
 /obj/item/weapon/reagent_containers/chem_disp_cartridge/coffee

--- a/code/modules/reagents/machinery/dispenser/dispenser2_energy.dm
+++ b/code/modules/reagents/machinery/dispenser/dispenser2_energy.dm
@@ -31,7 +31,8 @@
 	dispense_reagents = list(
 		"hydrogen", "lithium", "carbon", "nitrogen", "oxygen", "fluorine", "sodium",
 		"aluminum", "silicon", "phosphorus", "sulfur", "chlorine", "potassium", "iron",
-		"copper", "mercury", "radium", "water", "ethanol", "sugar", "sacid", "tungsten"
+		"copper", "mercury", "radium", "water", "ethanol", "sugar", "sacid", "tungsten",
+		"calcium"
 		)
 
 /obj/machinery/chemical_dispenser/ert
@@ -58,5 +59,5 @@
 /obj/machinery/chemical_dispenser/bar_coffee
 	dispense_reagents = list(
 		"coffee", "cafe_latte", "soy_latte", "hot_coco", "milk", "cream", "tea", "ice",
-		"orangejuice", "lemonjuice", "limejuice", "berryjuice", "mint", "decaf"
+		"orangejuice", "lemonjuice", "limejuice", "berryjuice", "mint", "decaf", "greentea"
 		)

--- a/code/modules/reagents/machinery/dispenser/dispenser_presets.dm
+++ b/code/modules/reagents/machinery/dispenser/dispenser_presets.dm
@@ -84,7 +84,8 @@
 			/obj/item/weapon/reagent_containers/chem_disp_cartridge/orange,
 			/obj/item/weapon/reagent_containers/chem_disp_cartridge/lime,
 			/obj/item/weapon/reagent_containers/chem_disp_cartridge/watermelon,
-			/obj/item/weapon/reagent_containers/chem_disp_cartridge/lemon
+			/obj/item/weapon/reagent_containers/chem_disp_cartridge/lemon,
+			/obj/item/weapon/reagent_containers/chem_disp_cartridge/grapesoda
 		)
 
 /obj/machinery/chemical_dispenser/bar_alc
@@ -115,7 +116,8 @@
 			/obj/item/weapon/reagent_containers/chem_disp_cartridge/cognac,
 			/obj/item/weapon/reagent_containers/chem_disp_cartridge/cider,
 			/obj/item/weapon/reagent_containers/chem_disp_cartridge/ale,
-			/obj/item/weapon/reagent_containers/chem_disp_cartridge/mead
+			/obj/item/weapon/reagent_containers/chem_disp_cartridge/mead,
+			/obj/item/weapon/reagent_containers/chem_disp_cartridge/bitters
 		)
 
 /obj/machinery/chemical_dispenser/bar_coffee

--- a/code/modules/reagents/machinery/dispenser/supply.dm
+++ b/code/modules/reagents/machinery/dispenser/supply.dm
@@ -52,7 +52,8 @@
 			/obj/item/weapon/reagent_containers/chem_disp_cartridge/ethanol,
 			/obj/item/weapon/reagent_containers/chem_disp_cartridge/sugar,
 			/obj/item/weapon/reagent_containers/chem_disp_cartridge/sacid,
-			/obj/item/weapon/reagent_containers/chem_disp_cartridge/tungsten
+			/obj/item/weapon/reagent_containers/chem_disp_cartridge/tungsten,
+			/obj/item/weapon/reagent_containers/chem_disp_cartridge/calcium
 		)
 	cost = 150
 	containertype = /obj/structure/closet/crate/secure
@@ -63,6 +64,12 @@
 /datum/supply_pack/alcohol_reagents
 	name = "Bar alcoholic dispenser refill"
 	contains = list(
+			/obj/item/weapon/reagent_containers/chem_disp_cartridge/lemon_lime,
+			/obj/item/weapon/reagent_containers/chem_disp_cartridge/sugar,
+			/obj/item/weapon/reagent_containers/chem_disp_cartridge/orange,
+			/obj/item/weapon/reagent_containers/chem_disp_cartridge/lime,
+			/obj/item/weapon/reagent_containers/chem_disp_cartridge/sodawater,
+			/obj/item/weapon/reagent_containers/chem_disp_cartridge/tonic,
 			/obj/item/weapon/reagent_containers/chem_disp_cartridge/beer,
 			/obj/item/weapon/reagent_containers/chem_disp_cartridge/kahlua,
 			/obj/item/weapon/reagent_containers/chem_disp_cartridge/whiskey,
@@ -74,6 +81,7 @@
 			/obj/item/weapon/reagent_containers/chem_disp_cartridge/tequila,
 			/obj/item/weapon/reagent_containers/chem_disp_cartridge/vermouth,
 			/obj/item/weapon/reagent_containers/chem_disp_cartridge/cognac,
+			/obj/item/weapon/reagent_containers/chem_disp_cartridge/cider,
 			/obj/item/weapon/reagent_containers/chem_disp_cartridge/ale,
 			/obj/item/weapon/reagent_containers/chem_disp_cartridge/mead,
 			/obj/item/weapon/reagent_containers/chem_disp_cartridge/bitters
@@ -104,7 +112,8 @@
 			/obj/item/weapon/reagent_containers/chem_disp_cartridge/orange,
 			/obj/item/weapon/reagent_containers/chem_disp_cartridge/lime,
 			/obj/item/weapon/reagent_containers/chem_disp_cartridge/watermelon,
-			/obj/item/weapon/reagent_containers/chem_disp_cartridge/lemon
+			/obj/item/weapon/reagent_containers/chem_disp_cartridge/lemon,
+			/obj/item/weapon/reagent_containers/chem_disp_cartridge/grapesoda
 		)
 	cost = 50
 	containertype = /obj/structure/closet/crate
@@ -120,8 +129,16 @@
 			/obj/item/weapon/reagent_containers/chem_disp_cartridge/hot_coco,
 			/obj/item/weapon/reagent_containers/chem_disp_cartridge/milk,
 			/obj/item/weapon/reagent_containers/chem_disp_cartridge/cream,
+			/obj/item/weapon/reagent_containers/chem_disp_cartridge/sugar,
 			/obj/item/weapon/reagent_containers/chem_disp_cartridge/tea,
-			/obj/item/weapon/reagent_containers/chem_disp_cartridge/ice
+			/obj/item/weapon/reagent_containers/chem_disp_cartridge/ice,
+			/obj/item/weapon/reagent_containers/chem_disp_cartridge/mint,
+			/obj/item/weapon/reagent_containers/chem_disp_cartridge/orange,
+			/obj/item/weapon/reagent_containers/chem_disp_cartridge/lemon,
+			/obj/item/weapon/reagent_containers/chem_disp_cartridge/lime,
+			/obj/item/weapon/reagent_containers/chem_disp_cartridge/berry,
+			/obj/item/weapon/reagent_containers/chem_disp_cartridge/greentea,
+			/obj/item/weapon/reagent_containers/chem_disp_cartridge/decaf
 		)
 	cost = 50
 	containertype = /obj/structure/closet/crate


### PR DESCRIPTION
Makes regular and coffee dispenser properly regenerate calcium and green tea respectively

Makes soda and alcohol dispensers spawn with grape soda and bitters respectively (they could regenerate those already but didnt have at start)

Adds calcium to regular dispenser refill crate
Adds cider, lemonlime, sugar, orange juice, lime juice, soda water and tonic to alcohol dispenser refill crate
Adds grape soda to softdrinks dispenser refill crate
Adds sugar, mint, orange juice, lemon juice, lime juice, berry juice, green tea and decaf coffee to coffee dispenser refill crate