### PR TITLE
Makes all things that check for dorms check for forbid events var

### DIFF
--- a/code/_helpers/unsorted_vr.dm
+++ b/code/_helpers/unsorted_vr.dm
@@ -18,7 +18,8 @@
 			continue
 		if(vent.welded)
 			continue
-		if(istype(get_area(vent), /area/crew_quarters/sleep)) //No going to dorms
+		var/area/A = get_area(vent)
+		if(A.forbid_events)
 			continue
 		vent_list += vent
 	if(!vent_list.len)

--- a/code/modules/events/grubinfestation_vr.dm
+++ b/code/modules/events/grubinfestation_vr.dm
@@ -11,7 +11,8 @@
 	spawncount = rand(2 * severity, 6 * severity)
 
 	for(var/obj/machinery/atmospherics/unary/vent_pump/temp_vent in machines)
-		if(istype(get_area(temp_vent), /area/crew_quarters/sleep))
+		var/area/A = get_area(temp_vent)
+		if(A.forbid_events)
 			continue
 		if(!temp_vent.welded && temp_vent.network && (temp_vent.loc.z in using_map.station_levels))
 			if(temp_vent.network.normal_members.len > 50)

--- a/code/modules/events/spider_infestation.dm
+++ b/code/modules/events/spider_infestation.dm
@@ -19,7 +19,9 @@
 	for(var/obj/machinery/atmospherics/unary/vent_pump/temp_vent in machines)
 		if(!temp_vent.welded && temp_vent.network && (temp_vent.loc.z in using_map.station_levels))
 			if(temp_vent.network.normal_members.len > 50)
-				vents += temp_vent
+				var/area/A = get_area(temp_vent)
+				if(!(A.forbid_events))
+					vents += temp_vent
 
 	while((spawncount >= 1) && vents.len)
 		var/obj/vent = pick(vents)

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -365,7 +365,8 @@ GLOBAL_LIST_BOILERPLATE(all_singularities, /obj/singularity)
 		return 0
 
 	// VOREStation Edit Start
-	if(istype(get_area(T), /area/crew_quarters/sleep)) //No going to dorms
+	var/area/A = get_area(T)
+	if(A.forbid_events) //No going to dorms
 		return 0
 	// VOREStation Edit End
 

--- a/code/modules/xenoarcheaology/effect.dm
+++ b/code/modules/xenoarcheaology/effect.dm
@@ -158,7 +158,9 @@
 /proc/GetAnomalySusceptibility(var/mob/living/carbon/human/H)
 	if(!istype(H))
 		return 1
-	if(istype(get_area(H),/area/crew_quarters/sleep)) return 0 //VOREStation Edit - Dorms are protected from anomalies
+	var/area/A = get_area(H)
+	if(A.forbid_events)
+		return 0
 	var/protected = 0
 
 	//anomaly suits give best protection, but excavation suits are almost as good

--- a/maps/groundbase/groundbase_areas.dm
+++ b/maps/groundbase/groundbase_areas.dm
@@ -359,6 +359,7 @@
 /area/groundbase/civilian/arrivals
 	name = "Arrivals"
 	lightswitch = 1
+	forbid_events = TRUE
 /area/groundbase/civilian/toolstorage
 	name = "Tool Storage"
 	lightswitch = 1
@@ -417,10 +418,12 @@
 	name = "Men's Restroom"
 	sound_env = SOUND_ENVIRONMENT_BATHROOM
 	lightswitch = 1
+	forbid_events = TRUE
 /area/groundbase/civilian/womensrestroom
 	name = "Women's Restroom"
 	sound_env = SOUND_ENVIRONMENT_BATHROOM
 	lightswitch = 1
+	forbid_events = TRUE
 
 /area/groundbase/exploration
 	name = "Exploration"

--- a/maps/stellardelight/stellar_delight_areas.dm
+++ b/maps/stellardelight/stellar_delight_areas.dm
@@ -272,8 +272,10 @@
 
 /area/stellardelight/deck3/transitgateway
 	name = "Transit Gateway"
+	forbid_events = TRUE
 /area/stellardelight/deck3/cryo
 	name = "Cryogenic Storage"
+	forbid_events = TRUE
 
 /area/stellardelight/deck3/readingroom
 	name = "Reading Rooms"
@@ -281,7 +283,7 @@
 	flags = RAD_SHIELDED| BLUE_SHIELDED |AREA_FLAG_IS_NOT_PERSISTENT
 	soundproofed = TRUE
 	block_suit_sensors = TRUE
-	forbid_events = TRUE	
+	forbid_events = TRUE
 
 /area/stellardelight/deck3/portdock
 	name = "Port Dock"


### PR DESCRIPTION
Currently it was just checking for specific dorms subtype, which meant multiple areas with var set were ignored; and other maps didnt even use that specific subtype.