### PR TITLE
Reduces range of lightning strike zaps to 1

### DIFF
--- a/code/modules/admin/verbs/lightning_strike.dm
+++ b/code/modules/admin/verbs/lightning_strike.dm
@@ -17,7 +17,7 @@
 	(<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[src.mob.x];Y=[src.mob.y];Z=[src.mob.z]'>JMP</a>)")
 
 #define LIGHTNING_REDIRECT_RANGE 28 // How far in tiles certain things draw lightning from.
-#define LIGHTNING_ZAP_RANGE 3 // How far the tesla effect zaps, as well as the bad effects from a direct strike.
+#define LIGHTNING_ZAP_RANGE 1 // How far the tesla effect zaps, as well as the bad effects from a direct strike.
 #define LIGHTNING_POWER 20000 // How much 'zap' is in a strike, used for tesla_zap().
 
 // The real lightning proc.


### PR DESCRIPTION
From 3. Should reduces likelyhood of actually getting hit by one without reducing commonality of lightning strikes any further; while also shielding indoors from getting struck.