### PR TITLE
Trash eater tweak

### DIFF
--- a/code/modules/vore/eating/living_vr.dm
+++ b/code/modules/vore/eating/living_vr.dm
@@ -697,6 +697,9 @@
 	if(new_color)
 		glow_color = new_color
 
+/obj/item
+	var/trash_eatable = TRUE
+
 /mob/living/proc/eat_trash()
 	set name = "Eat Trash"
 	set category = "Abilities"
@@ -713,6 +716,10 @@
 
 	if(is_type_in_list(I,item_vore_blacklist))
 		to_chat(src, "<span class='warning'>You are not allowed to eat this.</span>")
+		return
+
+	if(!I.trash_eatable)
+		to_chat(src, "<span class='warning'>You can't eat that so casually!</span>")
 		return
 
 	if(istype(I, /obj/item/device/paicard))


### PR DESCRIPTION
Adds a var to items that disallows them being trash eaten in the round.

I'm very tired of EVERY SINGLE TIME I do any event involving any item that can be trash eaten, someone comes along and instantly deletes it and thinks it's cute. 