### PR TITLE
[WIP] Adds exchange option for content inside bellies

### DIFF
--- a/code/modules/vore/eating/belly_obj_vr.dm
+++ b/code/modules/vore/eating/belly_obj_vr.dm
@@ -1045,9 +1045,9 @@
 
 	return see
 
-/obj/belly/proc/request_exchange(atom/moveable/content, mob/living/target, obj/belly/target_belly)
+/obj/belly/proc/request_exchange(atom/movable/content, mob/living/target, obj/belly/target_belly)
 
-/obj/belly/proc/process_exchange(atom/moveable/content, obj/belly/target)
+/obj/belly/proc/process_exchange(atom/movable/content, obj/belly/target)
 
 //Transfers contents from one belly to another
 /obj/belly/proc/transfer_contents(atom/movable/content, obj/belly/target, silent = 0)

--- a/code/modules/vore/eating/belly_obj_vr.dm
+++ b/code/modules/vore/eating/belly_obj_vr.dm
@@ -1045,6 +1045,10 @@
 
 	return see
 
+/obj/belly/proc/request_exchange(atom/moveable/content, mob/living/target, obj/belly/target_belly)
+
+/obj/belly/proc/process_exchange(atom/moveable/content, obj/belly/target)
+
 //Transfers contents from one belly to another
 /obj/belly/proc/transfer_contents(atom/movable/content, obj/belly/target, silent = 0)
 	if(!(content in src) || !istype(target))

--- a/code/modules/vore/eating/vorepanel_vr.dm
+++ b/code/modules/vore/eating/vorepanel_vr.dm
@@ -611,10 +611,10 @@
 	var/atom/movable/target = locate(params["pick"])
 	if(!(target in host.vore_selected))
 		return TRUE // Not in our X anymore, update UI
-	var/list/available_options = list("Examine", "Eject", "Move")
+	var/list/available_options = list("Examine", "Eject", "Move", "Exchange")
 	if(ishuman(target))
 		available_options += "Transform"
-	intent = tgui_alert(user, "What would you like to do with [target]?", "Vore Pick", available_options, strict_byond = TRUE)
+	intent = tgui_input_list(user, "What would you like to do with [target]?", "Vore Pick", available_options)
 	switch(intent)
 		if("Examine")
 			var/list/results = target.examine(host)
@@ -656,6 +656,23 @@
 			var/datum/tgui_module/appearance_changer/vore/V = new(host, H)
 			V.tgui_interact(user)
 			return TRUE
+
+		if("Exchange")
+			if(host.absorbed || host.stat)
+				to_chat(user,"<span class='warning'>You can't do that in your state!</span>")
+				return TRUE
+
+			var/mob/living/M = input(user, "Select the target to request an exchange of [target.name] with.", "Request Exchange") as mob in range(1)
+			if(get_dist(user,M) >= 2)
+				to_chat(user, "<span class='warning'>You need to be closer to do that.</span>")
+				return
+
+			var/obj/belly/B = tgui_input_list(user, "Select the target belly of [M.name].", "Request Exchange", M.vore_organs)
+			if(!B)
+				to_chat(user, "<span class='warning'>You need to select a valid target belly.</span>")
+				return
+
+			host.vore_selected.request_exchange(target, M, B)
 
 /datum/vore_look/proc/set_attr(mob/user, params)
 	if(!host.vore_selected)


### PR DESCRIPTION
Logic not implemented yet.

This option lets you ask someone else to exchange one of their contents for theirs.
It was brought up that usually two individuals have to eject the content they want to exchange, and exchange it like that.
This PR is supposed to eliminiate that step entirely.

Current State:
![grafik](https://user-images.githubusercontent.com/12716288/177003630-263e3878-9d65-4426-b22a-b304741da645.png)
![grafik](https://user-images.githubusercontent.com/12716288/177003633-ac78c2a1-0c63-4d81-950d-09dcc4bf9081.png)
![grafik](https://user-images.githubusercontent.com/12716288/177003636-cbf7509e-2c8e-4e51-abe0-eea0c99f0467.png)
