### PR TITLE
Enables Multi-Z Testing (Map & Wires)

### DIFF
--- a/code/unit_tests/map_tests.dm
+++ b/code/unit_tests/map_tests.dm
@@ -47,17 +47,16 @@
 			var/area_good = 1
 			var/bad_msg = "--------------- [A.name]([A.type])"
 
-
 			if(isnull(A.apc) && !(A.type in exempt_from_apc))
-				log_unit_test("[bad_msg] lacks an APC.")
+				log_unit_test("[bad_msg] lacks an APC. (X[A.x]|Y[A.y]) - Z[A.z])")
 				area_good = 0
 
 			if(!A.air_scrub_info.len && !(A.type in exempt_from_atmos))
-				log_unit_test("[bad_msg] lacks an Air scrubber.")
+				log_unit_test("[bad_msg] lacks an Air scrubber. (X[A.x]|Y[A.y]) - (Z[A.z]")
 				area_good = 0
 
 			if(!A.air_vent_info.len && !(A.type in exempt_from_atmos))
-				log_unit_test("[bad_msg] lacks an Air vent.")
+				log_unit_test("[bad_msg] lacks an Air vent. (X[A.x]|Y[A.y]) - (Z[A.z]")
 				area_good = 0
 
 			if(!area_good)
@@ -71,7 +70,7 @@
 	return 1
 
 /datum/unit_test/wire_test
-	name = "MAP: Cable Test Z level 1"
+	name = "MAP: Cable Test (Defined Z-Levels)"
 
 /datum/unit_test/wire_test/start_test()
 	var/wire_test_count = 0
@@ -81,11 +80,13 @@
 	var/list/cable_turfs = list()
 	var/list/dirs_checked = list()
 
+	var/list/zs_to_test = using_map.unit_test_z_levels || list(1) //Either you set it, or you just get z1
+
 	for(C in world)
 		T = null
 
 		T = get_turf(C)
-		if(T && T.z == 1)
+		if(T && (T.z in zs_to_test))
 			cable_turfs |= get_turf(C)
 
 	for(T in cable_turfs)

--- a/code/unit_tests/map_tests.dm
+++ b/code/unit_tests/map_tests.dm
@@ -1,5 +1,5 @@
 /datum/unit_test/apc_area_test
-	name = "MAP: Area Test APC / Scrubbers / Vents Z level 1"
+	name = "MAP: Area Test APC / Scrubbers / Vents (Defined Z-Levels)"
 
 /datum/unit_test/apc_area_test/start_test()
 	var/list/bad_areas = list()
@@ -121,12 +121,12 @@
 			var/a_gas = ""
 			for(var/gas in E.A.air.gas)
 				a_gas += "[gas]=[E.A.air.gas[gas]]"
-			
+
 			var/b_temp
 			var/b_moles
 			var/b_vol
 			var/b_gas = ""
-			
+
 			// Two zones mixing
 			if(istype(E, /connection_edge/zone))
 				var/connection_edge/zone/Z = E
@@ -144,11 +144,11 @@
 				b_vol = "Unsim"
 				for(var/gas in U.air.gas)
 					b_gas += "[gas]=[U.air.gas[gas]]"
-			
+
 			edge_log += "Active Edge [E] ([E.type])"
 			edge_log += "Edge side A: T:[a_temp], Mol:[a_moles], Vol:[a_vol], Gas:[a_gas]"
 			edge_log += "Edge side B: T:[b_temp], Mol:[b_moles], Vol:[b_vol], Gas:[b_gas]"
-			
+
 			for(var/turf/T in E.connecting_turfs)
 				edge_log += "+--- Connecting Turf [T] ([T.type]) @ [T.x], [T.y], [T.z] ([T.loc])"
 

--- a/code/unit_tests/map_tests.dm
+++ b/code/unit_tests/map_tests.dm
@@ -52,11 +52,11 @@
 				area_good = 0
 
 			if(!A.air_scrub_info.len && !(A.type in exempt_from_atmos))
-				log_unit_test("[bad_msg] lacks an Air scrubber. (X[A.x]|Y[A.y]) - (Z[A.z]")
+				log_unit_test("[bad_msg] lacks an Air scrubber. (X[A.x]|Y[A.y]) - (Z[A.z])")
 				area_good = 0
 
 			if(!A.air_vent_info.len && !(A.type in exempt_from_atmos))
-				log_unit_test("[bad_msg] lacks an Air vent. (X[A.x]|Y[A.y]) - (Z[A.z]")
+				log_unit_test("[bad_msg] lacks an Air vent. (X[A.x]|Y[A.y]) - (Z[A.z])")
 				area_good = 0
 
 			if(!area_good)

--- a/maps/groundbase/gb-z2.dmm
+++ b/maps/groundbase/gb-z2.dmm
@@ -587,9 +587,6 @@
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"bt" = (
-/turf/simulated/wall/r_wall,
-/area/groundbase/science)
 "bu" = (
 /obj/machinery/door/airlock/freezer{
 	name = "Kitchen";
@@ -22850,7 +22847,7 @@ Rh
 EJ
 YI
 ng
-bt
+PD
 AH
 lO
 Ga
@@ -22992,7 +22989,7 @@ Rh
 bO
 AZ
 ff
-bt
+PD
 IO
 qW
 PZ
@@ -23134,7 +23131,7 @@ Rh
 ff
 AZ
 ff
-bt
+PD
 nw
 qW
 lw
@@ -23276,7 +23273,7 @@ Rh
 Fk
 AZ
 yw
-bt
+PD
 ws
 qW
 lw
@@ -23418,7 +23415,7 @@ Rh
 vh
 Nb
 Ys
-bt
+PD
 aB
 PR
 lw
@@ -23560,7 +23557,7 @@ Rh
 PD
 qU
 PD
-bt
+PD
 Ov
 PR
 lw

--- a/maps/groundbase/groundbase_defines.dm
+++ b/maps/groundbase/groundbase_defines.dm
@@ -165,6 +165,11 @@
 
 	unit_test_exempt_from_atmos = list()
 
+	unit_test_z_levels = list(
+		Z_LEVEL_GB_BOTTOM,
+		Z_LEVEL_GB_MIDDLE,
+		Z_LEVEL_GB_TOP
+	)
 
 	lateload_z_levels = list(
 		list("Groundbase - Central Command"),
@@ -534,4 +539,3 @@
 */
 
 ////////////////////////////////////////////////////////////////////////
-

--- a/maps/groundbase/groundbase_defines.dm
+++ b/maps/groundbase/groundbase_defines.dm
@@ -124,6 +124,7 @@
 	default_skybox = /datum/skybox_settings/groundbase
 
 	unit_test_exempt_areas = list(		//These are all outside
+		/area/groundbase/exploration/shuttlepad,
 		/area/groundbase/level1,
 		/area/groundbase/level1/ne,
 		/area/groundbase/level1/nw,
@@ -140,11 +141,20 @@
 		/area/groundbase/level2/nw,
 		/area/groundbase/level2/se,
 		/area/groundbase/level2/sw,
+		/area/groundbase/level2/northspur,
+		/area/groundbase/level2/eastspur,
+		/area/groundbase/level2/westspur,
+		/area/groundbase/level2/southeastspur,
+		/area/groundbase/level2/southwestspur,
 		/area/groundbase/level3,
 		/area/groundbase/level3/ne,
 		/area/groundbase/level3/nw,
 		/area/groundbase/level3/se,
 		/area/groundbase/level3/sw,
+		/area/groundbase/level3/ne/open,
+		/area/groundbase/level3/nw/open,
+		/area/groundbase/level3/se/open,
+		/area/groundbase/level3/sw/open,
 		/area/maintenance/groundbase/level1/netunnel,
 		/area/maintenance/groundbase/level1/nwtunnel,
 		/area/maintenance/groundbase/level1/setunnel,

--- a/maps/groundbase/groundbase_defines.dm
+++ b/maps/groundbase/groundbase_defines.dm
@@ -124,6 +124,7 @@
 	default_skybox = /datum/skybox_settings/groundbase
 
 	unit_test_exempt_areas = list(		//These are all outside
+		/area/groundbase/cargo/bay,
 		/area/groundbase/exploration/shuttlepad,
 		/area/groundbase/level1,
 		/area/groundbase/level1/ne,

--- a/maps/groundbase/groundbase_defines.dm
+++ b/maps/groundbase/groundbase_defines.dm
@@ -125,6 +125,7 @@
 
 	unit_test_exempt_areas = list(		//These are all outside
 		/area/groundbase/cargo/bay,
+		/area/groundbase/civilian/bar/upper,
 		/area/groundbase/exploration/shuttlepad,
 		/area/groundbase/level1,
 		/area/groundbase/level1/ne,

--- a/maps/stellardelight/stellar_delight_defines.dm
+++ b/maps/stellardelight/stellar_delight_defines.dm
@@ -125,6 +125,11 @@
 
 	unit_test_exempt_from_atmos = list() //it maint
 
+	unit_test_z_levels = list(
+		Z_LEVEL_SHIP_LOW,
+		Z_LEVEL_SHIP_MID,
+		Z_LEVEL_SHIP_HIGH
+	)
 
 	lateload_z_levels = list(
 		list("Ship - Central Command"),

--- a/maps/tether/tether_defines.dm
+++ b/maps/tether/tether_defines.dm
@@ -152,6 +152,13 @@
 		/area/tether/surfacebase/lowernortheva/external, //it outside
 		/area/tether/surfacebase/security/gasstorage) //it maint
 
+	unit_test_z_levels = list(
+		Z_LEVEL_SURFACE_LOW,
+		Z_LEVEL_SURFACE_MID,
+		Z_LEVEL_SURFACE_HIGH,
+		Z_LEVEL_TRANSIT,
+		Z_LEVEL_SPACE_LOW
+	)
 
 	lateload_z_levels = list(
 		list("Tether - Centcom","Tether - Misc","Tether - Underdark","Tether - Plains"), //Stock Tether lateload maps


### PR DESCRIPTION
Let's enable that feature that was added 4 years ago, by adding missing defines.

Changes;
- Enables/Uses map Multi-Z Level testing by enabling the Z-Layers in the map definition files for Tether, Stellardelight and Groundbase
- Added Multi-Z Level testing support for the wire testing
- If the Multi-Z test finds an error, it will report back the coordinates of the erroring part/area (for Logs)
- Fixed a tiny part of science wall to have the proper area
- Updates test titles (for Logs)