### PR TITLE
Makes Talon Captain restricted behind 60 hours of Talon playtime

### DIFF
--- a/code/__defines/misc_vr.dm
+++ b/code/__defines/misc_vr.dm
@@ -58,6 +58,7 @@
 #define PTO_CARGO			"Cargo"
 #define PTO_CIVILIAN		"Civilian"
 #define PTO_CYBORG			"Cyborg"
+#define PTO_TALON			"Talon Contractor"
 
 #define DEPARTMENT_TALON	"ITV Talon"
 

--- a/code/controllers/subsystems/persist_vr.dm
+++ b/code/controllers/subsystems/persist_vr.dm
@@ -63,10 +63,11 @@ SUBSYSTEM_DEF(persist)
 		LAZYINITLIST(C.play_hours)
 		var/dept_hours = C.department_hours
 		var/play_hours = C.play_hours
-		if(isnum(dept_hours[department_earning]))
-			dept_hours[department_earning] += pto_factored
-		else
-			dept_hours[department_earning] = pto_factored
+		if(!(J.playtime_only))
+			if(isnum(dept_hours[department_earning]))
+				dept_hours[department_earning] += pto_factored
+			else
+				dept_hours[department_earning] = pto_factored
 
 		// If they're earning PTO they must be in a useful job so are earning playtime in that department
 		if(J.timeoff_factor > 0)

--- a/code/game/jobs/job/job_vr.dm
+++ b/code/game/jobs/job/job_vr.dm
@@ -17,6 +17,9 @@
 	//Time required in the department as other jobs before playing this one (in hours)
 	var/dept_time_required = 0
 
+	//Do we forbid ourselves from earning PTO?
+	var/playtime_only = FALSE
+
 // Check client-specific availability rules.
 /datum/job/proc/player_has_enough_pto(client/C)
 	return timeoff_factor >= 0 || (C && LAZYACCESS(C.department_hours, pto_type) > 0)

--- a/maps/tether/tether_jobs.dm
+++ b/maps/tether/tether_jobs.dm
@@ -25,7 +25,10 @@
 	selection_color = "#999999"
 	economic_modifier = 7
 	minimal_player_age = 14
-	pto_type = null
+	playtime_only = TRUE
+	pto_type = PTO_TALON
+	timeoff_factor = 1
+	dept_time_required = 60
 	access = list(access_talon)
 	minimal_access = list(access_talon)
 	alt_titles = list("Talon Commander" = /datum/alt_title/talon_commander)
@@ -49,7 +52,9 @@
 	selection_color = "#aaaaaa"
 	economic_modifier = 5
 	minimal_player_age = 14
-	pto_type = null
+	playtime_only = TRUE
+	pto_type = PTO_TALON
+	timeoff_factor = 1
 	access = list(access_talon)
 	minimal_access = list(access_talon)
 	alt_titles = list("Talon Medic" = /datum/alt_title/talon_medic)
@@ -74,7 +79,9 @@
 	selection_color = "#aaaaaa"
 	economic_modifier = 5
 	minimal_player_age = 14
-	pto_type = null
+	playtime_only = TRUE
+	pto_type = PTO_TALON
+	timeoff_factor = 1
 	access = list(access_talon)
 	minimal_access = list(access_talon)
 	alt_titles = list("Talon Technician" = /datum/alt_title/talon_tech)
@@ -99,7 +106,9 @@
 	selection_color = "#aaaaaa"
 	economic_modifier = 5
 	minimal_player_age = 14
-	pto_type = null
+	playtime_only = TRUE
+	pto_type = PTO_TALON
+	timeoff_factor = 1
 	access = list(access_talon)
 	minimal_access = list(access_talon)
 	alt_titles = list("Talon Helmsman" = /datum/alt_title/talon_helmsman)
@@ -124,7 +133,9 @@
 	selection_color = "#aaaaaa"
 	economic_modifier = 5
 	minimal_player_age = 14
-	pto_type = null
+	playtime_only = TRUE
+	pto_type = PTO_TALON
+	timeoff_factor = 1
 	access = list(access_talon)
 	minimal_access = list(access_talon)
 	alt_titles = list("Talon Security" = /datum/alt_title/talon_security)
@@ -148,7 +159,9 @@
 	selection_color = "#aaaaaa"
 	economic_modifier = 5
 	minimal_player_age = 14
-	pto_type = null
+	playtime_only = TRUE
+	pto_type = PTO_TALON
+	timeoff_factor = 1
 	access = list(access_talon)
 	minimal_access = list(access_talon)
 	alt_titles = list("Talon Excavator" = /datum/alt_title/talon_excavator)


### PR DESCRIPTION
This does NOT allow Talon to earn PTO, only the invisible depthours, which in turn are checked when checking for Talon Captain job.