### PR TITLE
Changes the site manager's sidearm from a singular option to a choice instead

### DIFF
--- a/code/game/objects/items/gunbox_vr.dm
+++ b/code/game/objects/items/gunbox_vr.dm
@@ -19,3 +19,26 @@
 			if(istype(AM, /obj/item/weapon/gun))
 				to_chat(user, "You have chosen \the [AM]. Say hello to your new best friend.")
 		qdel(src)
+
+/*
+ * Site Manager's Box
+ */
+/obj/item/gunbox/captain
+	name = "Captain's sidearm box"
+	desc = "A secure box containing a sidearm befitting of the site manager. Includes both lethal and non-lethal munitions, beware what's loaded!"
+	icon = 'icons/obj/storage.dmi'
+	icon_state = "gunbox"
+/obj/item/gunbox/captain/attack_self(mob/living/user)
+	var/list/options = list()
+	options["M1911 (.45)"] = list(/obj/item/weapon/gun/projectile/colt/detective, /obj/item/ammo_magazine/m45/rubber, /obj/item/ammo_magazine/m45)
+	options["MT Mk58 (.45)"] = list(/obj/item/weapon/gun/projectile/sec, /obj/item/ammo_magazine/m45/rubber, /obj/item/ammo_magazine/m45)
+	options["LAEP80 \"Thor\" (Stun/Laser)"] = list(/obj/item/weapon/gun/energy/gun, /obj/item/weapon/cell/device/weapon, /obj/item/weapon/cell/device/weapon)
+	options["MarsTech P92X (9mm)"] = list(/obj/item/weapon/gun/projectile/p92x/rubber, /obj/item/ammo_magazine/m9mm/rubber, /obj/item/ammo_magazine/m9mm)
+	var/choice = tgui_input_list(user,"Would you prefer a ballistic pistol or an energy gun?", "Gun!", options)
+	if(src && choice)
+		var/list/things_to_spawn = options[choice]
+		for(var/new_type in things_to_spawn) // Spawn all the things, the gun and the ammo.
+			var/atom/movable/AM = new new_type(get_turf(src))
+			if(istype(AM, /obj/item/weapon/gun))
+				to_chat(user, "You have chosen \the [AM]. Say hello to your new friend.")
+		qdel(src)

--- a/code/game/objects/structures/crates_lockers/closets/secure/security_vr.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security_vr.dm
@@ -189,7 +189,7 @@
 		/obj/item/weapon/storage/lockbox/medal,
 		/obj/item/device/radio/headset/heads/captain,
 		/obj/item/device/radio/headset/heads/captain/alt,
-		/obj/item/weapon/gun/energy/gun,
+		/obj/item/gunbox/captain,
 		/obj/item/weapon/melee/telebaton,
 		/obj/item/device/flash,
 		/obj/item/weapon/storage/box/ids,


### PR DESCRIPTION
Like the title suggests, the e-gun inside the captain/site-manager/chief-paperpusher's locker is replaced with a gunbox giving the following options:

![image](https://user-images.githubusercontent.com/24844135/177024324-ff8893bc-2c64-40bf-b9f7-cf4df92848a2.png)

All come with both lethal & non-lethal ammunition (only a singular magazine of lethals for ballistic weapons, mind you), though if it's requested the lethal ammo can be swapped back to the non-lethal versions instead. 
Given they were trusted with a weapon capable of both prior, I thought the flexibility might be nice should they require it.

No fancy sprites or anything, uses the same sprite as the regular gunboxes in the armory.
![image](https://user-images.githubusercontent.com/24844135/177024370-c02b99f2-6c40-4fc2-a214-59edbfa7ff8d.png)
![image](https://user-images.githubusercontent.com/24844135/177024377-78b25604-cadf-4f9c-ad3d-581c0840ff41.png)
