### PR TITLE
Fixes produce persistance

### DIFF
--- a/code/modules/persistence/storage/smartfridge.dm
+++ b/code/modules/persistence/storage/smartfridge.dm
@@ -65,12 +65,12 @@
 /datum/persistent/storage/smartfridge/produce
 	name = "fruit storage"
 	max_storage = 50
-	store_per_type = FALSE
+	store_per_type = TRUE
 	target_type = /obj/machinery/smartfridge/produce
 
 /datum/persistent/storage/smartfridge/produce/lossy
 	name = "fruit storage lossy"
-	go_missing_chance = 12.5 // 10% loss between rounds
+	go_missing_chance = 10 // 10% loss chance between rounds
 
 /datum/persistent/storage/smartfridge/produce/generate_items(var/list/L)			// Mostly same as storage/generate_items() but without converting string to path
 	. = list()


### PR DESCRIPTION
Fixes #12017
Fixes  #13019

Should now properly save and load all entries rather than only first 50 items (although loss means some entries and produce-per-entires will still be lost, 10% on average).