### PR TITLE
Fixes runtime that breaks vorepanel

### DIFF
--- a/code/modules/client/preference_setup/global/02_settings.dm
+++ b/code/modules/client/preference_setup/global/02_settings.dm
@@ -91,7 +91,7 @@
 		preference = list(preference)
 	for(var/p in preference)
 		var/datum/client_preference/cp = get_client_preference(p)
-		if(!cp || !(cp.key in prefs.preferences_enabled))
+		if(!prefs || !cp || !(cp.key in prefs.preferences_enabled))
 			return FALSE
 	return TRUE
 


### PR DESCRIPTION
Sanity check to prevent a bug that has permanently bluescreened a mob's vorepanel twice this week on downstream.