### PR TITLE
Fixes a typo for the random mouseray spawner.

### DIFF
--- a/code/modules/vore/mouseray.dm
+++ b/code/modules/vore/mouseray.dm
@@ -434,7 +434,7 @@
 	icon_state = "fanc_trejur"
 	spawn_nothing_percentage = 0
 
-/obj/random/mainttoyloot/item_to_spawn()
+/obj/random/mouseray/item_to_spawn()
 	return pick(prob(300);/obj/item/weapon/gun/energy/mouseray,
 				prob(50);/obj/item/weapon/gun/energy/mouseray/corgi,
 				prob(50);/obj/item/weapon/gun/energy/mouseray/woof,


### PR DESCRIPTION
Typo had it as maintoyloot which overwrote the actual maintoyloot random spawner.

Presumably it was supposed to be mouseray, judging by what was above it.

This hotfixes it.