### PR TITLE
Guide to Robotics wiki-link fix

### DIFF
--- a/code/game/objects/items/weapons/manuals.dm
+++ b/code/game/objects/items/weapons/manuals.dm
@@ -640,7 +640,7 @@
 		<html><head>
 		</head>
 		<body>
-		<iframe width='100%' height='97%' src="[config.wikiurl]Guide_to_Robotics=yes&remove_links=1" frameborder="0" id="main_frame"></iframe>
+		<iframe width='100%' height='97%' src="[config.wikiurl]Guide_to_Robotics&printable=yes&remove_links=1" frameborder="0" id="main_frame"></iframe>
 		</body>
 		</html>
 		"}


### PR DESCRIPTION
Just fixing something from https://github.com/VOREStation/VOREStation/pull/13295