### PR TITLE
Adds light and heavy frame traits

### DIFF
--- a/code/game/mecha/micro/micro.dm
+++ b/code/game/mecha/micro/micro.dm
@@ -121,7 +121,7 @@
 
 /obj/mecha/micro/move_inside()
 	var/mob/living/carbon/C = usr
-	if (C.size_multiplier >= 0.5)
+	if (C.get_effective_size(TRUE) >= 0.5)
 		to_chat(C, "<span class='warning'>You can't fit in this suit!</span>")
 		return
 	else
@@ -129,7 +129,7 @@
 
 /obj/mecha/micro/move_inside_passenger()
 	var/mob/living/carbon/C = usr
-	if (C.size_multiplier >= 0.5)
+	if (C.get_effective_size(TRUE) >= 0.5)
 		to_chat(C, "<span class='warning'>You can't fit in this suit!</span>")
 		return
 	else

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -877,8 +877,8 @@
 	if(target != user) return // If the user didn't drag themselves, exit
 	if(user.incapacitated() || user.buckled) return // If user is incapacitated or buckled, exit
 	if(get_holder_of_type(src, /mob/living/carbon/human) == user) return // No jumping into your own equipment
-	if(ishuman(user) && user.get_effective_size() > 0.25) return // Only micro characters
-	if(ismouse(user) && user.get_effective_size() > 1) return // Only normal sized mice or less
+	if(ishuman(user) && user.get_effective_size(TRUE) > 0.25) return // Only micro characters
+	if(ismouse(user) && user.get_effective_size(TRUE) > 1) return // Only normal sized mice or less
 
 	// Create a dummy holder with user's size to test insertion
 	var/obj/item/weapon/holder/D = new/obj/item/weapon/holder

--- a/code/modules/mob/living/carbon/human/examine_vr.dm
+++ b/code/modules/mob/living/carbon/human/examine_vr.dm
@@ -83,13 +83,13 @@
 
 /mob/living/carbon/human/proc/examine_pickup_size(mob/living/H)
 	var/message = ""
-	if(istype(H) && (H.get_effective_size() - src.get_effective_size()) >= 0.50)
+	if(istype(H) && (H.get_effective_size(FALSE) - src.get_effective_size(TRUE)) >= 0.50)
 		message = "<font color='blue'>They are small enough that you could easily pick them up!</font>"
 	return message
 
 /mob/living/carbon/human/proc/examine_step_size(mob/living/H)
 	var/message = ""
-	if(istype(H) && (H.get_effective_size() - src.get_effective_size()) >= 0.75)
+	if(istype(H) && (H.get_effective_size(FALSE) - src.get_effective_size(TRUE)) >= 0.75)
 		message = "<font color='red'>They are small enough that you could easily trample them!</font>"
 	return message
 

--- a/code/modules/mob/living/carbon/human/species/species_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/species_vr.dm
@@ -27,6 +27,9 @@
 	var/list/copy_vars = list("base_species", "icobase", "deform", "tail", "tail_animation", "icobase_tail", "color_mult", "primitive_form", "appearance_flags", "flesh_color", "base_color", "blood_mask", "damage_mask", "damage_overlays", "move_trail", "has_floating_eyes")
 	var/trait_points = 0
 
+	var/micro_size_mod = 0		// How different is our size for interactions that involve us being small?
+	var/macro_size_mod = 0		// How different is our size for interactions that involve us being big?
+
 
 /datum/species/proc/give_numbing_bite() //Holy SHIT this is hacky, but it works. Updating a mob's attacks mid game is insane.
 	unarmed_attacks = list()

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
@@ -539,3 +539,17 @@
 /datum/trait/neutral/vertical_nom/apply(var/datum/species/S,var/mob/living/carbon/human/H)
 	..(S,H)
 	H.verbs |= /mob/living/proc/vertical_nom
+
+/datum/trait/neutral/micro_size_down
+	name = "Light Frame"
+	desc = "You are considered smaller than you are for micro interactions."
+	cost = 0
+	custom_only = FALSE
+	var_changes = list("micro_size_mod" = -0.15)
+
+/datum/trait/neutral/micro_size_up
+	name = "Heavy Frame"
+	desc = "You are considered bigger than you are for micro interactions."
+	cost = 0
+	custom_only = FALSE
+	var_changes = list("micro_size_mod" = 0.15)

--- a/code/modules/vore/resizing/resize_vr.dm
+++ b/code/modules/vore/resizing/resize_vr.dm
@@ -39,11 +39,19 @@
  * but in the future we may also incorporate the "mob_size", so that
  * a macro mouse is still only effectively "normal" or a micro dragon is still large etc.
  */
-/mob/proc/get_effective_size()
+/mob/proc/get_effective_size(var/micro = FALSE)
 	return 100000 //Whatever it is, it's too big to pick up, or it's a ghost, or something.
 
-/mob/living/get_effective_size()
+/mob/living/get_effective_size(var/micro = FALSE)
 	return size_multiplier
+
+/mob/living/carbon/human/get_effective_size(var/micro = FALSE)		// Set micro to TRUE for interactions where you're small, to FALSE for ones where you're large.
+	var/effective_size = size_multiplier
+	if(micro)
+		effective_size += species.micro_size_mod
+	else
+		effective_size += species.macro_size_mod
+	return effective_size
 
 /atom/movable/proc/size_range_check(size_select)		//both objects and mobs needs to have that
 	var/area/A = get_area(src) //Get the atom's area to check for size limit.
@@ -163,7 +171,7 @@
 		return 0
 	if(!(M.a_intent == I_HELP))
 		return 0
-	var/size_diff = M.get_effective_size() - get_effective_size()
+	var/size_diff = M.get_effective_size(FALSE) - get_effective_size(TRUE)
 	if(!holder_default && holder_type)
 		holder_default = holder_type
 	if(!istype(M))
@@ -197,16 +205,16 @@
 		return TRUE
 
 	//Both small! Go ahead and go.
-	if(get_effective_size() <= RESIZE_A_SMALLTINY && tmob.get_effective_size() <= RESIZE_A_SMALLTINY)
+	if(get_effective_size(TRUE) <= RESIZE_A_SMALLTINY && tmob.get_effective_size(TRUE) <= RESIZE_A_SMALLTINY)		// For help intent interaction just assume both are 'smol'
 		return TRUE
 
 	//Worthy of doing messages at all
-	if(abs(get_effective_size() - tmob.get_effective_size()) >= 0.50)
+	if(abs(get_effective_size(TRUE) - tmob.get_effective_size(TRUE)) >= 0.50)
 		var/src_message = null
 		var/tmob_message = null
 
 		//Smaller person being stepped onto
-		if(get_effective_size() > tmob.get_effective_size() && ishuman(src))
+		if(get_effective_size(TRUE) > tmob.get_effective_size(TRUE) && ishuman(src))
 			src_message = "You carefully step over [tmob]."
 			tmob_message = "[src] steps over you carefully!"
 			var/mob/living/carbon/human/H = src
@@ -218,7 +226,7 @@
 				tmob_message = tail.msg_prey_help_run
 
 		//Smaller person stepping under larger person
-		else if(get_effective_size() < tmob.get_effective_size() && ishuman(tmob))
+		else if(get_effective_size(TRUE) < tmob.get_effective_size(TRUE) && ishuman(tmob))
 			src_message = "You run between [tmob]'s legs."
 			tmob_message = "[src] runs between your legs."
 			var/mob/living/carbon/human/H = tmob
@@ -269,7 +277,7 @@
 
 	// We need to be above a certain size ratio in order to do anything to the prey.
 	// For DISARM and HURT intent, this is >=0.75, for GRAB it is >=0.5
-	var/size_ratio = get_effective_size() - tmob.get_effective_size()
+	var/size_ratio = get_effective_size(FALSE) - tmob.get_effective_size(TRUE)
 	if(a_intent == I_GRAB && size_ratio < 0.5)
 		return FALSE
 	if((a_intent == I_DISARM || a_intent == I_HURT) && size_ratio < 0.75)

--- a/code/modules/vore/resizing/sizegun_slow_vr.dm
+++ b/code/modules/vore/resizing/sizegun_slow_vr.dm
@@ -50,16 +50,16 @@
 	if(unresizable)
 		return TRUE
 
-	if(!(target.has_large_resize_bounds()) && (target.get_effective_size() >= RESIZE_MAXIMUM) && sizeshift_mode == SIZE_GROW)
+	if(!(target.has_large_resize_bounds()) && (target.size_multiplier >= RESIZE_MAXIMUM) && sizeshift_mode == SIZE_GROW)
 		return TRUE
 
-	if(target.get_effective_size() >= RESIZE_MAXIMUM_DORMS && sizeshift_mode == SIZE_GROW)
+	if(target.size_multiplier >= RESIZE_MAXIMUM_DORMS && sizeshift_mode == SIZE_GROW)
 		return TRUE
 
-	if(!(target.has_large_resize_bounds()) && (target.get_effective_size() <= RESIZE_MINIMUM) && sizeshift_mode == SIZE_SHRINK)
+	if(!(target.has_large_resize_bounds()) && (target.size_multiplier <= RESIZE_MINIMUM) && sizeshift_mode == SIZE_SHRINK)
 		return TRUE
 
-	if(target.get_effective_size() <= RESIZE_MINIMUM_DORMS && sizeshift_mode == SIZE_SHRINK)
+	if(target.size_multiplier <= RESIZE_MINIMUM_DORMS && sizeshift_mode == SIZE_SHRINK)
 		return TRUE
 
 	return FALSE
@@ -123,9 +123,9 @@
 		stoplag(3)
 
 		if(sizeshift_mode == SIZE_SHRINK)
-			L.resize((L.get_effective_size() - size_increment), uncapped = L.has_large_resize_bounds(), aura_animation = FALSE)
+			L.resize((L.size_multiplier - size_increment), uncapped = L.has_large_resize_bounds(), aura_animation = FALSE)
 		else if(sizeshift_mode == SIZE_GROW)
-			L.resize((L.get_effective_size() + size_increment), uncapped = L.has_large_resize_bounds(), aura_animation = FALSE)
+			L.resize((L.size_multiplier + size_increment), uncapped = L.has_large_resize_bounds(), aura_animation = FALSE)
 
 	busy = FALSE
 	current_target = null

--- a/code/modules/vore/smoleworld/smoleworld_vr.dm
+++ b/code/modules/vore/smoleworld/smoleworld_vr.dm
@@ -19,9 +19,9 @@
 		var/mob/living/L = A
 		if(L.hovering) // Flying things shouldn't make footprints.
 			return ..()
-		if(L.get_effective_size() <= RESIZE_NORMAL)
+		if(L.get_effective_size(FALSE) <= RESIZE_NORMAL)
 			return ..()
-		if(L.get_effective_size() >= RESIZE_A_BIGNORMAL)
+		if(L.get_effective_size(FALSE) >= RESIZE_A_BIGNORMAL)
 			playsound(src, 'sound/effects/footstep/giantstep_gigga.ogg', 35, 1, -1, volume_channel = VOLUME_CHANNEL_MASTER)
 			var/mdir = "[A.dir]"
 			crossed_dirs[mdir] = 1
@@ -365,7 +365,7 @@
 //	. = ..()
 //	if(.)
 //
-//		if(M.get_effective_size() > RESIZE_TINY)
+//		if(M.get_effective_size(TRUE) > RESIZE_TINY)
 //			to_chat(M, SPAN_WARNING("You are to big to fit in \the [src]."))
 	//		. = FALSE
 //


### PR DESCRIPTION
Neutral all-species traits both.

They modify your threshold for sizey interactions when on 'micro' end of things without actually changing your size. Only 15% worth. Mostly to allow people to have better-looking sprites without completely opting out of step or pickup interactions. Or to have smaller sprite and do opt out of such.