### PR TITLE
Opens up Field Medic's & Paramedic's winter coats to one another

### DIFF
--- a/code/modules/client/preference_setup/loadout/loadout_suit.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_suit.dm
@@ -398,7 +398,7 @@
 /datum/gear/suit/wintercoat/medical/para
 	display_name = "winter coat, paramedic"
 	path = /obj/item/clothing/suit/storage/hooded/wintercoat/medical/para
-	allowed_roles = list("Medical Doctor","Chief Medical Officer","Paramedic")
+	allowed_roles = list("Medical Doctor","Chief Medical Officer","Paramedic","Field Medic")
 
 /datum/gear/suit/wintercoat/medical/chemist
 	display_name = "winter coat, chemist"
@@ -413,7 +413,7 @@
 /datum/gear/suit/wintercoat/medical/sar
 	display_name = "winter coat, search and rescue"
 	path = /obj/item/clothing/suit/storage/hooded/wintercoat/medical/sar
-	allowed_roles = list("Chief Medical Officer", "Field Medic")
+	allowed_roles = list("Chief Medical Officer","Paramedic","Field Medic")
 
 /datum/gear/suit/wintercoat/science
 	display_name = "winter coat, science"


### PR DESCRIPTION
With the new Search & Rescue paramedic alt-title in, I thought it kinda weird that paramedics couldn't pick the SAR coat that exploration field medics get. 
So, now FM's can pick the paramedic winter coat (alongside the CMO & MD's who could take it as well), whilst paramedics are now able to pick the field medic's winter coat.

That's it, that's all this does.