### PR TITLE
Adds Fullscreen Toggle & Cross Origin Fix

### DIFF
--- a/code/modules/client/client defines.dm
+++ b/code/modules/client/client defines.dm
@@ -80,10 +80,15 @@
 	// Runechat messages
 	var/list/seen_messages
 
+	//Hide top bars
+	var/fullscreen = FALSE
+	//Hide status bar
+	var/show_status_bar = TRUE
+
 		///////////
 		// INPUT //
 		///////////
-	
+
 	/// Bitfield of modifier keys (Shift, Ctrl, Alt) held currently.
 	var/mod_keys_held = 0
 	/// Bitfield of movement keys (WASD/Cursor Keys) held currently.

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -86,7 +86,7 @@
 					return
 				sane = TRUE
 				break
-		
+
 		if(!sane)
 			to_chat(src, "<span class='warning'>Sorry, that link doesn't appear to be valid. Please try again.</span>")
 			return
@@ -564,3 +564,36 @@
 	set name = "TguiKeyUp"
 	set hidden = TRUE
 	return // stub
+
+/client/verb/toggle_fullscreen()
+	set name = "Toggle Fullscreen"
+	set category = "OOC"
+
+	fullscreen = !fullscreen
+
+	if (fullscreen)
+		winset(usr, "mainwindow", "on-size=")
+		winset(usr, "mainwindow", "titlebar=false")
+		winset(usr, "mainwindow", "can-resize=false")
+		winset(usr, "mainwindow", "menu=")
+		winset(usr, "mainwindow", "is-maximized=false")
+		winset(usr, "mainwindow", "is-maximized=true")
+	else
+		winset(usr, "mainwindow", "menu=menu")
+		winset(usr, "mainwindow", "titlebar=true")
+		winset(usr, "mainwindow", "can-resize=true")
+		winset(usr, "mainwindow", "is-maximized=false")
+		winset(usr, "mainwindow", "on-size=attempt_auto_fit_viewport") // The attempt_auto_fit_viewport() proc is not implemented yet
+
+/*
+/client/verb/toggle_status_bar()
+	set name = "Toggle Status Bar"
+	set category = "OOC"
+
+	show_status_bar = !show_status_bar
+
+	if (show_status_bar)
+		winset(usr, "input", "is-visible=true")
+	else
+		winset(usr, "input", "is-visible=false")
+*/

--- a/tgui/public/tgui.html
+++ b/tgui/public/tgui.html
@@ -301,6 +301,7 @@
     if (type === 'js') {
       var node = document.createElement('script');
       node.type = 'text/javascript';
+      node.crossOrigin = 'anonymous';
       // IE8: Prefer non-https protocols
       node.src = Byond.IS_LTE_IE9
         ? url.replace('https://', 'http://')


### PR DESCRIPTION
The Fullscreen is never on by default and only toggleable from the OOC tab.
Currently there is no preference for it to enable it by default.

Also still a very early version, automatic fitting of the viewport is not implemented yet.
The bottom bar does not disappear yet either (because it's weirder than the top one), but I will have that done soon.

This PR does not include a regenerated bundle (since only the html file was changed), the bot just puts a bundle tag on it if something inside tgui was changed.