### PR TITLE
Buffs Blockers and alters the new sound toggle verbs again

### DIFF
--- a/code/game/objects/structures/map_blocker_vr.dm
+++ b/code/game/objects/structures/map_blocker_vr.dm
@@ -8,8 +8,11 @@
 	opacity = 0
 	density = TRUE
 	unacidable = TRUE
+	plane = PLANE_BUILDMODE
 
+/*	//VOREStation Edit
 /obj/effect/blocker/Initialize() // For non-gateway maps.
 	. = ..()
 	icon = null
 	icon_state = null
+*/

--- a/code/modules/client/preferences_toggle_procs.dm
+++ b/code/modules/client/preferences_toggle_procs.dm
@@ -407,7 +407,7 @@
 	feedback_add_details("admin_verb","TRadioSounds")
 
 /client/verb/toggle_say_sounds()
-	set name = "Sound Toggle: Say"
+	set name = "Sound-Toggle-Say"
 	set category = "Preferences"
 	set desc = "Toggle hearing a sound when somebody speaks using say."
 
@@ -420,7 +420,7 @@
 	feedback_add_details("admin_verb","TSaySounds")
 
 /client/verb/toggle_emote_sounds()
-	set name = "Sound Toggle: Me"
+	set name = "Sound-Toggle-Me"
 	set category = "Preferences"
 	set desc = "Toggle hearing a sound when somebody speaks using me ."
 
@@ -433,7 +433,7 @@
 	feedback_add_details("admin_verb","TMeSounds")
 
 /client/verb/toggle_whisper_sounds()
-	set name = "Sound Toggle: Whisper"
+	set name = "Sound-Toggle-Whisper"
 	set category = "Preferences"
 	set desc = "Toggle hearing a sound when somebody speaks using whisper."
 
@@ -446,7 +446,7 @@
 	feedback_add_details("admin_verb","TWhisperSounds")
 
 /client/verb/toggle_subtle_sounds()
-	set name = "Sound Toggle: Subtle"
+	set name = "Sound-Toggle-Subtle"
 	set category = "Preferences"
 	set desc = "Toggle hearing a sound when somebody uses subtle."
 


### PR DESCRIPTION
I added hyphens instead of spaces for the new verbs because typing any of the verbs they relate to in the bottom bar defaults to the toggle verb instead of the normal verb. :U

With the hyphens instead of spaces it doesn't do that anymore!

Also makes it so that the 'blocker' effect doesn't appear in the right click menu for people, but it DOES actually show up visibly when one toggles build mode on!