### PR TITLE
[Mirror Fix] Bump terser from 5.14.1 to 5.14.2 in /tgui

### DIFF
--- a/tgui/packages/tgui-polyfill/package.json
+++ b/tgui/packages/tgui-polyfill/package.json
@@ -11,6 +11,6 @@
     "unfetch": "^4.2.0"
   },
   "devDependencies": {
-    "terser": "^5.13.1"
+    "terser": "^5.14.2"
   }
 }

--- a/tgui/yarn.lock
+++ b/tgui/yarn.lock
@@ -8882,7 +8882,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"terser@npm:^5.13.1, terser@npm:^5.7.2":
+"terser@npm:^5.14.2":
+  version: 5.14.2
+  resolution: "terser@npm:5.14.2"
+  dependencies:
+    "@jridgewell/source-map": ^0.3.2
+    acorn: ^8.5.0
+    commander: ^2.20.0
+    source-map-support: ~0.5.20
+  bin:
+    terser: bin/terser
+  checksum: cabb50a640d6c2cfb351e4f43dc7bf7436f649755bb83eb78b2cacda426d5e0979bd44e6f92d713f3ca0f0866e322739b9ced888ebbce6508ad872d08de74fcc
+  languageName: node
+  linkType: hard
+
+"terser@npm:^5.7.2":
   version: 5.14.1
   resolution: "terser@npm:5.14.1"
   dependencies:
@@ -8955,7 +8969,7 @@ __metadata:
   dependencies:
     core-js: ^3.22.5
     regenerator-runtime: ^0.13.9
-    terser: ^5.13.1
+    terser: ^5.14.2
     unfetch: ^4.2.0
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
terser package was updated, the yarn.log is now correct.

Resolves #13376.