### PR TITLE
Adjusts Space Ghost

### DIFF
--- a/code/modules/mob/living/simple_mob/subtypes/animal/alien animals/spookyghost.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/alien animals/spookyghost.dm
@@ -192,7 +192,7 @@
 	. = ..()
 	icon_living = "spookyghost-[rand(1,2)]"
 	icon_state = icon_living
-	addtimer(CALLBACK(src, .proc/death), 2 MINUTES)
+	addtimer(CALLBACK(src, .proc/death), 35 SECONDS)
 	update_icon()
 
 /datum/ai_holder/simple_mob/melee/space_ghost

--- a/maps/om_adventure/pois/darkstar.dmm
+++ b/maps/om_adventure/pois/darkstar.dmm
@@ -2,11 +2,13 @@
 "a" = (
 /turf/template_noop,
 /area/template_noop)
-"e" = (
+"b" = (
+/mob/living/simple_mob/vore/alienanimals/space_ghost{
+	faction = "spookyland"
+	},
 /turf/simulated/floor/weird_things/dark,
 /area/om_adventure/poi/darkstar)
-"z" = (
-/mob/living/simple_mob/vore/alienanimals/space_ghost,
+"e" = (
 /turf/simulated/floor/weird_things/dark,
 /area/om_adventure/poi/darkstar)
 
@@ -50,7 +52,7 @@ a
 e
 e
 e
-z
+b
 e
 e
 e

--- a/maps/om_adventure/pois/fleshtear1.dmm
+++ b/maps/om_adventure/pois/fleshtear1.dmm
@@ -3,7 +3,9 @@
 /turf/template_noop,
 /area/template_noop)
 "b" = (
-/mob/living/simple_mob/creature,
+/mob/living/simple_mob/creature{
+	faction = "spookyland"
+	},
 /turf/simulated/floor/flesh{
 	base_icon = 'icons/turf/stomach_vr.dmi'
 	},

--- a/maps/om_adventure/pois/fleshtear2.dmm
+++ b/maps/om_adventure/pois/fleshtear2.dmm
@@ -4,15 +4,17 @@
 	base_icon = 'icons/turf/stomach_vr.dmi'
 	},
 /area/om_adventure/poi/fleshtear2)
-"B" = (
-/turf/template_noop,
-/area/template_noop)
-"H" = (
-/mob/living/simple_mob/creature,
+"b" = (
+/mob/living/simple_mob/creature{
+	faction = "spookyland"
+	},
 /turf/simulated/floor/flesh{
 	base_icon = 'icons/turf/stomach_vr.dmi'
 	},
 /area/om_adventure/poi/fleshtear2)
+"B" = (
+/turf/template_noop,
+/area/template_noop)
 
 (1,1,1) = {"
 B
@@ -45,7 +47,7 @@ B
 B
 B
 a
-H
+b
 a
 a
 B

--- a/maps/om_adventure/pois/fleshtear3.dmm
+++ b/maps/om_adventure/pois/fleshtear3.dmm
@@ -2,8 +2,10 @@
 "a" = (
 /turf/template_noop,
 /area/template_noop)
-"M" = (
-/mob/living/simple_mob/creature,
+"b" = (
+/mob/living/simple_mob/creature{
+	faction = "spookyland"
+	},
 /turf/simulated/floor/flesh{
 	base_icon = 'icons/turf/stomach_vr.dmi'
 	},
@@ -62,7 +64,7 @@ Q
 Q
 a
 Q
-M
+b
 Q
 Q
 a

--- a/maps/om_adventure/pois/fleshtear4.dmm
+++ b/maps/om_adventure/pois/fleshtear4.dmm
@@ -2,13 +2,15 @@
 "a" = (
 /turf/template_noop,
 /area/template_noop)
-"m" = (
+"b" = (
+/mob/living/simple_mob/creature{
+	faction = "spookyland"
+	},
 /turf/simulated/floor/flesh{
 	base_icon = 'icons/turf/stomach_vr.dmi'
 	},
 /area/om_adventure/poi/fleshtear4)
-"n" = (
-/mob/living/simple_mob/creature,
+"m" = (
 /turf/simulated/floor/flesh{
 	base_icon = 'icons/turf/stomach_vr.dmi'
 	},
@@ -31,7 +33,7 @@ a
 (3,1,1) = {"
 a
 a
-n
+b
 m
 a
 "}
@@ -65,7 +67,7 @@ a
 "}
 (8,1,1) = {"
 a
-n
+b
 m
 m
 a


### PR DESCRIPTION
Reduces life time of ghostling from 2 minutes to 35 seconds. This should reduce maximum amount active at any time from 17 to 5. And hopefully prevent lag vortexes from being nearly as bad if they happen to be created.

As additional measure, fixes factions of things in the whale to actually be universally matching and prevent mob infighting.