### PR TITLE
Copy prefs to simple mob

### DIFF
--- a/code/modules/mob/living/simple_mob/subtypes/vore/vore.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/vore.dm
@@ -11,6 +11,29 @@
 	verbs |= /mob/living/simple_mob/proc/set_name
 	verbs |= /mob/living/simple_mob/proc/set_desc
 
+	digestable = client.prefs_vr.digestable
+	devourable = client.prefs_vr.devourable
+	absorbable = client.prefs_vr.absorbable
+	feeding = client.prefs_vr.feeding
+	can_be_drop_prey = client.prefs_vr.can_be_drop_prey
+	can_be_drop_pred = client.prefs_vr.can_be_drop_pred
+	allow_inbelly_spawning = client.prefs_vr.allow_inbelly_spawning
+	allow_spontaneous_tf = client.prefs_vr.allow_spontaneous_tf
+	digest_leave_remains = client.prefs_vr.digest_leave_remains
+	allowmobvore = client.prefs_vr.allowmobvore
+	permit_healbelly = client.prefs_vr.permit_healbelly
+	noisy = client.prefs_vr.noisy
+
+	drop_vore = client.prefs_vr.drop_vore
+	stumble_vore = client.prefs_vr.stumble_vore
+	slip_vore = client.prefs_vr.slip_vore
+
+	resizable = client.prefs_vr.resizable
+	show_vore_fx = client.prefs_vr.show_vore_fx
+	step_mechanics_pref = client.prefs_vr.step_mechanics_pref
+	pickup_pref = client.prefs_vr.pickup_pref
+
+
 /mob/living/simple_mob/proc/set_name()
 	set name = "Set Name"
 	set desc = "Sets your mobs name. You only get to do this once."

--- a/code/modules/mob/living/simple_mob/subtypes/vore/vore.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/vore.dm
@@ -11,6 +11,7 @@
 	verbs |= /mob/living/simple_mob/proc/set_name
 	verbs |= /mob/living/simple_mob/proc/set_desc
 
+	ooc_notes = client.prefs.metadata
 	digestable = client.prefs_vr.digestable
 	devourable = client.prefs_vr.devourable
 	absorbable = client.prefs_vr.absorbable


### PR DESCRIPTION
Makes it so that when you login to a simple mob, your basic vore preferences are copied to the mob (see: devourable, digestable, etc, but not things like bellies and the like)