### PR TITLE
Allows attacks to properly damage simple_mobs.

### DIFF
--- a/code/modules/mob/living/simple_mob/defense.dm
+++ b/code/modules/mob/living/simple_mob/defense.dm
@@ -45,7 +45,18 @@
 
 		if(I_HURT)
 			var/armor = run_armor_check(def_zone = null, attack_flag = "melee")
-			apply_damage(damage = harm_intent_damage, damagetype = BURN, def_zone = null, blocked = armor, blocked = resistance, used_weapon = null, sharp = FALSE, edge = FALSE)
+			if(istype(L,/mob/living/carbon/human)) //VOREStation EDIT START Is it a human?
+				var/mob/living/carbon/human/attacker = L //We are a human!
+				var/datum/unarmed_attack/attack = attacker.get_unarmed_attack(src, BP_TORSO) //What attack are we using? Also, just default to attacking the chest.
+				var/rand_damage = rand(1, 5) //Like normal human attacks, let's randomize the damage...
+				var/real_damage = rand_damage //Let's go ahead and start calculating our damage.
+				var/hit_dam_type = attack.damage_type //Let's get the type of damage. Brute? Burn? Defined by the unarmed_attack.
+				real_damage += attack.get_unarmed_damage(attacker) //Add the damage that their special attack has. Some have 0. Some have 15.
+				apply_damage(damage = real_damage, damagetype = hit_dam_type, def_zone = null, blocked = armor, blocked = resistance, used_weapon = null, sharp = FALSE, edge = FALSE)
+				L.visible_message("<span class='warning'>\The [L] [pick(attack.attack_verb)] \the [src]!</span>")
+				L.do_attack_animation(src)
+				return //VOREStation EDIT END
+			apply_damage(damage = harm_intent_damage, damagetype = BRUTE, def_zone = null, blocked = armor, blocked = resistance, used_weapon = null, sharp = FALSE, edge = FALSE) //VOREStation EDIT Somebody set this to burn instead of brute.
 			L.visible_message("<span class='warning'>\The [L] [response_harm] \the [src]!</span>")
 			L.do_attack_animation(src)
 

--- a/code/modules/mob/living/simple_mob/defense.dm
+++ b/code/modules/mob/living/simple_mob/defense.dm
@@ -52,6 +52,10 @@
 				var/real_damage = rand_damage //Let's go ahead and start calculating our damage.
 				var/hit_dam_type = attack.damage_type //Let's get the type of damage. Brute? Burn? Defined by the unarmed_attack.
 				real_damage += attack.get_unarmed_damage(attacker) //Add the damage that their special attack has. Some have 0. Some have 15.
+				if(real_damage <= damage_threshold)
+					L.visible_message("<span class='warning'>\The [L] uselessly hits \the [src]!</span>")
+					L.do_attack_animation(src)
+					return
 				apply_damage(damage = real_damage, damagetype = hit_dam_type, def_zone = null, blocked = armor, blocked = resistance, used_weapon = null, sharp = FALSE, edge = FALSE)
 				L.visible_message("<span class='warning'>\The [L] [pick(attack.attack_verb)] \the [src]!</span>")
 				L.do_attack_animation(src)

--- a/code/modules/mob/living/simple_mob/simple_mob_vr.dm
+++ b/code/modules/mob/living/simple_mob/simple_mob_vr.dm
@@ -51,6 +51,7 @@
 	var/obj/item/device/radio/headset/mob_headset/mob_radio		//Adminbus headset for simplemob shenanigans.
 	does_spin = FALSE
 	can_be_drop_pred = TRUE				// Mobs are pred by default.
+	var/damage_threshold  = 0 //For some mobs, they have a damage threshold required to deal damage to them.
 
 
 // Release belly contents before being gc'd!

--- a/code/modules/mob/living/simple_mob/subtypes/mechanical/mecha/mecha.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/mechanical/mecha/mecha.dm
@@ -13,6 +13,7 @@
 	turn_sound = 'sound/mecha/mechturn.ogg'
 	maxHealth = 300
 	mob_size = MOB_LARGE
+	damage_threshold = 5 //Anything that's 5 or less damage will not do damage.
 
 	organ_names = /decl/mob_organ_names/mecha
 


### PR DESCRIPTION
Actually way easier than I thought it'd be. Took me longer to actually find where all the damnable code was at then it took to code it.
- Fixes a bug which makes unarmed attacks do burn damage to mobs.
- Makes it so when mobs are attacked by an unarmed human, they take damage properly, much like normal unarmed attacks. 

This means that the damage one deals while unarmed is no longer hardcoded to whatever the person making the mob mistakenly put the "harm_intent_damage" as thinking it was for something else.

For reference:
Normal unarmed attacks deal 1d5 damage + the damage the unarmed_attack itself has. (Bloodletters has 15 for example.)

The code confirms the person attacking is a human, checks what unarmed attack they have selected (or if they have bloodletters selected/on), rolls a random dice between 1 and 5 for "damage" then adds the bonus damage certain unarmed_attacks have.

It also checks to see what type of damage that unarmed_attack should do, applies it (Brute?Burn?Tox?Oxy?Brain? Etc) and gives it a proper attack verb instead of just whatever the creator of the mob you're attacking decided it should be.

Photos:
Attacking w/ bloodletters: https://i.imgur.com/BzbmZGj.gif
Using various attacks: https://i.imgur.com/QdMtMV8.png

