### PR TITLE
Replaces some old code w/ IsAdvancedToolUser and fixes twohanded weapons for simple_mobs

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -159,6 +159,10 @@
 		var/obj/item/organ/external/hand = H.organs_by_name[check_hand]
 		if(istype(hand) && hand.is_usable())
 			return TRUE
+	var/mob/living/simple_mob/S = M
+	if(istype(S) && S.has_hands) //Are they a mob? And do they have hands?
+		return TRUE
+
 	return FALSE
 
 

--- a/code/game/objects/items/devices/scanners/gas.dm
+++ b/code/game/objects/items/devices/scanners/gas.dm
@@ -23,7 +23,7 @@
 /obj/item/device/analyzer/attack_self(mob/user as mob)
 	if (user.stat)
 		return
-	if (!(ishuman(user) || ticker) && ticker.mode.name != "monkey")
+	if (!user.IsAdvancedToolUser())
 		to_chat(usr, "<span class='warning'>You don't have the dexterity to do this!</span>")
 		return
 

--- a/code/game/objects/items/devices/scanners/health.dm
+++ b/code/game/objects/items/devices/scanners/health.dm
@@ -41,7 +41,7 @@
 		dat += "Body Temperature: ???"
 		user.show_message("<span class='notice'>[dat]</span>", 1)
 		return
-	if (!(ishuman(user) || ticker) && ticker.mode.name != "monkey")
+	if (!user.IsAdvancedToolUser())
 		to_chat(user, "<span class='warning'>You don't have the dexterity to do this!</span>")
 		return
 

--- a/code/game/objects/items/devices/scanners/mass_spectrometer.dm
+++ b/code/game/objects/items/devices/scanners/mass_spectrometer.dm
@@ -30,7 +30,7 @@
 /obj/item/device/mass_spectrometer/attack_self(mob/user as mob)
 	if (user.stat)
 		return
-	if (!(ishuman(user) || ticker) && ticker.mode.name != "monkey")
+	if (!user.IsAdvancedToolUser())
 		to_chat(user, "<span class='warning'>You don't have the dexterity to do this!</span>")
 		return
 	if(reagents.total_volume)

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -20,8 +20,7 @@
 		to_chat(user, "<span class='warning'>\The [src] cannot be applied to [M]!</span>")
 		return 1
 
-	if ( ! (istype(user, /mob/living/carbon/human) || \
-			istype(user, /mob/living/silicon)) )
+	if (!M.IsAdvancedToolUser())
 		to_chat(user, "<span class='warning'>You don't have the dexterity to do this!</span>")
 		return 1
 
@@ -129,7 +128,7 @@
 				if(used >= available)
 					to_chat(user, "<span class='warning'>You run out of [src]!</span>")
 					break
-				
+
 				if (W.current_stage <= W.max_bleeding_stage)
 					user.visible_message("<b>\The [user]</b> bandages \a [W.desc] on [M]'s [affecting.name].", \
 					                              "<span class='notice'>You bandage \a [W.desc] on [M]'s [affecting.name].</span>" )

--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -19,7 +19,7 @@
 	user.setClickCooldown(user.get_attack_speed(src))
 	user.do_attack_animation(M)
 
-	if (!(istype(user, /mob/living/carbon/human) || ticker) && ticker.mode.name != "monkey")
+	if (!user.IsAdvancedToolUser())
 		to_chat(user, "<span class='danger'>You don't have the dexterity to do this!</span>")
 		return
 

--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -352,7 +352,7 @@ var/list/mining_overlay_cache = list()
 //Not even going to touch this pile of spaghetti
 /turf/simulated/mineral/attackby(obj/item/weapon/W as obj, mob/user as mob)
 
-	if (!(istype(usr, /mob/living/carbon/human) || ticker) && ticker.mode.name != "monkey")
+	if (!user.IsAdvancedToolUser())
 		to_chat(user, "<span class='warning'>You don't have the dexterity to do this!</span>")
 		return
 

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -570,6 +570,7 @@
 
 	if(one_handed_penalty)
 		if(!src.is_held_twohanded(user))
+			to_chat(user, "<span class='warning'>IS HELD TWOHANDED PENALTY.</span>")
 			switch(one_handed_penalty)
 				if(1 to 15)
 					if(prob(50)) //don't need to tell them every single time
@@ -581,6 +582,7 @@
 				if(46 to INFINITY)
 					to_chat(user, "<span class='warning'>You struggle to keep \the [src] on target with just one hand!</span>")
 		else if(!user.can_wield_item(src))
+			to_chat(user, "<span class='warning'>CAN WIELD ITEM PENALTY.</span>")
 			switch(one_handed_penalty)
 				if(1 to 15)
 					if(prob(50)) //don't need to tell them every single time

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -570,7 +570,6 @@
 
 	if(one_handed_penalty)
 		if(!src.is_held_twohanded(user))
-			to_chat(user, "<span class='warning'>IS HELD TWOHANDED PENALTY.</span>")
 			switch(one_handed_penalty)
 				if(1 to 15)
 					if(prob(50)) //don't need to tell them every single time
@@ -582,7 +581,6 @@
 				if(46 to INFINITY)
 					to_chat(user, "<span class='warning'>You struggle to keep \the [src] on target with just one hand!</span>")
 		else if(!user.can_wield_item(src))
-			to_chat(user, "<span class='warning'>CAN WIELD ITEM PENALTY.</span>")
 			switch(one_handed_penalty)
 				if(1 to 15)
 					if(prob(50)) //don't need to tell them every single time


### PR DESCRIPTION
Modernizes code to today's standards. Replaced old (ishuman() && || ticker) checks with IsAdvancedToolUser. This means mobs that have hands can properly use said tools.

Also makes it so that simple_mobs that have hands can use two handed weapons and guns correctly.

So now scugs can put on bruise packs, ointment, and hit rocks. And the adminbus ERT&Syndi&Deathsquad slugcats can shoot guns properly.