### PR TITLE
Engineering & Medical Contractor alt-titles

### DIFF
--- a/code/game/jobs/job/engineering_vr.dm
+++ b/code/game/jobs/job/engineering_vr.dm
@@ -27,12 +27,17 @@
 /datum/job/engineer
 	pto_type = PTO_ENGINEERING
 	alt_titles = list("Maintenance Technician" = /datum/alt_title/maint_tech, "Engine Technician" = /datum/alt_title/engine_tech,
-						"Electrician" = /datum/alt_title/electrician, "Construction Engineer" = /datum/alt_title/construction_engi)
+						"Electrician" = /datum/alt_title/electrician, "Construction Engineer" = /datum/alt_title/construction_engi, "Engineering Contractor" = /datum/alt_title/engineering_contractor)
 
 /datum/alt_title/construction_engi
 	title = "Construction Engineer"
 	title_blurb = "A Construction Engineer fulfills similar duties to other engineers, but usually occupies spare time with construction of extra facilities in dedicated areas or \
 					as additions to station layout."
+
+/datum/alt_title/engineering_contractor
+	title = "Engineering Contractor"
+	title_blurb = "An Engineering Contractor fulfills similar duties to other engineers, but isn't directly employed by NT proper.
+
 
 
 

--- a/code/game/jobs/job/engineering_vr.dm
+++ b/code/game/jobs/job/engineering_vr.dm
@@ -36,7 +36,7 @@
 
 /datum/alt_title/engineering_contractor
 	title = "Engineering Contractor"
-	title_blurb = "An Engineering Contractor fulfills similar duties to other engineers, but isn't directly employed by NT proper.
+	title_blurb = "An Engineering Contractor fulfills similar duties to other engineers, but isn't directly employed by NT proper."
 
 
 

--- a/code/game/jobs/job/medical_vr.dm
+++ b/code/game/jobs/job/medical_vr.dm
@@ -27,7 +27,7 @@
 	pto_type = PTO_MEDICAL
 	alt_titles = list("Physician" = /datum/alt_title/physician, "Medical Practitioner" = /datum/alt_title/medical_practitioner, "Surgeon" = /datum/alt_title/surgeon,
 						"Emergency Physician" = /datum/alt_title/emergency_physician, "Nurse" = /datum/alt_title/nurse, "Orderly" = /datum/alt_title/orderly,
-						"Virologist" = /datum/alt_title/virologist, "Medical Contractor = /datum/alt_title/medical_contractor)
+						"Virologist" = /datum/alt_title/virologist, "Medical Contractor" = /datum/alt_title/medical_contractor)
 
 
 /datum/alt_title/physician

--- a/code/game/jobs/job/medical_vr.dm
+++ b/code/game/jobs/job/medical_vr.dm
@@ -44,7 +44,7 @@
 
 /datum/alt_title/medical_contractor
 	title = "Medical Contractor"
-	title_blurb = "A Medical Contractor can be anything from a full-blown doctor to the likes of a nurse or orderly, but isn't directly employed by NT proper.
+	title_blurb = "A Medical Contractor can be anything from a full-blown doctor to the likes of a nurse or orderly, but isn't directly employed by NT proper."
 
 
 /datum/job/chemist

--- a/code/game/jobs/job/medical_vr.dm
+++ b/code/game/jobs/job/medical_vr.dm
@@ -27,7 +27,7 @@
 	pto_type = PTO_MEDICAL
 	alt_titles = list("Physician" = /datum/alt_title/physician, "Medical Practitioner" = /datum/alt_title/medical_practitioner, "Surgeon" = /datum/alt_title/surgeon,
 						"Emergency Physician" = /datum/alt_title/emergency_physician, "Nurse" = /datum/alt_title/nurse, "Orderly" = /datum/alt_title/orderly,
-						"Virologist" = /datum/alt_title/virologist)
+						"Virologist" = /datum/alt_title/virologist, "Medical Contractor = /datum/alt_title/medical_contractor)
 
 
 /datum/alt_title/physician
@@ -41,6 +41,10 @@
 	title_blurb = "An Orderly acts as Medbay's general helping hand, assisting any doctor that might need some form of help, as well as handling manual \
 					and dirty labor around the department."
 	title_outfit = /decl/hierarchy/outfit/job/medical/doctor/nurse
+
+/datum/alt_title/medical_contractor
+	title = "Medical Contractor"
+	title_blurb = "A Medical Contractor can be anything from a full-blown doctor to the likes of a nurse or orderly, but isn't directly employed by NT proper.
 
 
 /datum/job/chemist


### PR DESCRIPTION
Throws in both "Engineering Contractor" & "Medical Contractor" as new alt-titles for station engineer & doctor respectively, with small blurbs for the both.

Quick & dirty webedit, if I screwed something up I'll sort it later on