### PR TITLE
Less Lethal Lung Damage.

### DIFF
--- a/code/modules/organs/internal/lungs.dm
+++ b/code/modules/organs/internal/lungs.dm
@@ -11,13 +11,25 @@
 	if(!owner)
 		return
 
-	if(is_bruised())
+	//VOREStation Edit Start Lungs were a surprisingly lethal cause of bloodloss.
+	if(is_broken())
 		if(prob(4))
-			spawn owner?.custom_emote(VISIBLE_MESSAGE, "coughs up blood!")
-			owner.drip(10)
-		if(prob(8))
+			spawn owner?.custom_emote(VISIBLE_MESSAGE, "coughs up a large amount of blood!")
+			var/bleeding_rng = rand(3,5)
+			owner.drip(bleeding_rng)
+		if(prob(8)) //This is a medical emergency. Will kill within minutes unless exceedingly lucky.
 			spawn owner?.custom_emote(VISIBLE_MESSAGE, "gasps for air!")
 			owner.AdjustLosebreath(15)
+
+	else if(is_bruised()) //Only bruised? That's an annoyance and can cause some more damage (via brainloss due to oxyloss)
+		if(prob(2)) //But let's not kill people too quickly.
+			spawn owner?.custom_emote(VISIBLE_MESSAGE, "coughs up a small amount of blood!")
+			var/bleeding_rng = rand(1,2)
+			owner.drip(bleeding_rng)
+		if(prob(4)) //Get to medical quickly. but shouldn't kill without exceedingly bad RNG.
+			spawn owner?.custom_emote(VISIBLE_MESSAGE, "gasps for air!")
+			owner.AdjustLosebreath(10) //Losebreath is a DoT that does 1:1 damage and prevents oxyloss healing via breathing.
+	//VOREStation Edit End
 
 	if(owner.internal_organs_by_name[O_BRAIN]) // As the brain starts having Trouble, the lungs start malfunctioning.
 		var/obj/item/organ/internal/brain/Brain = owner.internal_organs_by_name[O_BRAIN]


### PR DESCRIPTION
For reference:
Bruised requires 10 damage, which is what happens if you get an unlucky suffocation tick and your lungs get damaged.
Broken requires 30 damage, which won't occur without being heavily damaged.

This PR makes early stage lung damage less lethal due to blood loss (previously you dropped 10 blood units a cough, this makes the coughed up blood 1-2, which makes it more 'cosmetic' than lethal), while leaving a good possibility of death via suffocation without medical treatment, but not nearly as likely as prior. 

It requires a very long run of bad RNG to achieve enough oxyloss to reach crit.

Brain damage is still possible even with small amounts of oxyloss, , which will cause other problems later down the line meaning the afflicted person will either have a bad run of RNG and die or get enough brain damage that they start to suffocate, which will stack on top of their bruised lung. 

The brain damage is a much longer process to achieve however, meaning it gives people plenty of time to get back to station if they get whacked or forget their internals instead bleeding out at the speed of light while stabbing themselves with inaprovaline.

Meanwhile, late stage lung damage (30+) is untouched other than the blood loss being decreased. The blood loss, however, is not a concern at all as testing has shown you will very, _very_ quickly stack up too many losebreath stacks to recover from without **exceptionally** good rng on your side, resulting in your (slow) death without someone giving you breaths.

To reach 30 damage however requires actual damage to be done to your lungs via things such as piercing weapons or other internal organ damage sources to reach that point. Outside of that, late stage lung damage should be very, very rare.


This PR is mostly to address the problem people have with stepping out without internals on for a second, getting a very unlucky popped lung, and then immediately stacking up losebreath stacks as they start to suffocate to death while also having blood loss pile on. With non-medical crew assistance, they can survive the losebreath stacks (although they will still obtain brainloss) but won't bleed out nearly as quickly if at all from a simple burst lung.