### PR TITLE
Hotfix to make items not shoot out runtimes.

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -259,7 +259,7 @@
 			ghost.assumeform(src)
 			ghost.animate_towards(user)
 	//VORESTATION EDIT START. This handles possessed items.
-	if(src.possessed_voice.len && !(user.ckey in warned_of_possession)) //Is this item possessed?
+	if(src.possessed_voice && src.possessed_voice.len && !(user.ckey in warned_of_possession)) //Is this item possessed?
 		warned_of_possession |= user.ckey
 		tgui_alert_async(user,{"
 		THIS ITEM IS POSSESSED BY A PLAYER CURRENTLY IN THE ROUND. This could be by anomalous means or otherwise.


### PR DESCRIPTION
The game was checking for a variable that was 'null' to see if it has a length, which is something that doesn't occur.

This fixes that by simply making it check to see if it has a possessed_voice variable.