### PR TITLE
Adjusts dogborg modules to be inline with regular modules

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_modules/station_vr.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules/station_vr.dm
@@ -270,20 +270,27 @@
 	src.modules += new /obj/item/device/dogborg/boop_module(src) //Boop the crew.
 	src.modules += new /obj/item/device/healthanalyzer(src) // See who's hurt specificially.
 	src.modules += new /obj/item/weapon/reagent_containers/syringe(src) //In case the chemist is nice!
-	src.modules += new /obj/item/weapon/reagent_containers/glass/beaker(src)//For holding the chemicals when the chemist is nice
+	src.modules += new /obj/item/weapon/reagent_containers/glass/beaker/large(src)//For holding the chemicals when the chemist is nice, made it the large variant in 2022
 	src.modules += new /obj/item/device/sleevemate(src) //Lets them scan people.
 	src.modules += new /obj/item/weapon/shockpaddles/robot/hound(src) //Paws of life
 	src.modules += new /obj/item/weapon/inflatable_dispenser/robot(src) //This is kinda important for rescuing people without making it worse for everyone
+	src.modules += new /obj/item/weapon/gripper/medical(src) //Let them do literally anything in medbay other than patch external damage and lick people
+	src.modules += new /obj/item/weapon/reagent_containers/dropper/industrial(src) //dropper is nice to have for so much actually
 	src.emag 	 = new /obj/item/weapon/dogborg/pounce(src) //Pounce
 
-	var/datum/matter_synth/medicine = new /datum/matter_synth/medicine(2000)
+	var/datum/matter_synth/medicine = new /datum/matter_synth/medicine(10000)
 	synths += medicine
 
 	var/obj/item/stack/medical/advanced/clotting/C = new (src)
+	var/obj/item/stack/medical/splint/S = new /obj/item/stack/medical/splint(src)
 	C.uses_charge = 1
-	C.charge_costs = list(1000)
+	C.charge_costs = list(5000)
 	C.synths = list(medicine)
+	S.uses_charge = 1
+	S.charge_costs = list(1000)
+	S.synths = list(medicine)
 	src.modules += C
+	src.modules += S
 
 	var/datum/matter_synth/water = new /datum/matter_synth(500)
 	water.name = "Water reserves"
@@ -487,7 +494,15 @@
 	//Added a circuit gripper
 	src.modules += new /obj/item/weapon/gripper/circuit(src)
 	src.modules += new /obj/item/weapon/gripper/no_use/organ/robotics(src)
+	//src.modules += new /obj/item/weapon/surgical/scalpel/cyborg(src) //these are on the normal one, but do not appear to have a purpose other than borging
+	//src.modules += new /obj/item/weapon/surgical/circular_saw/cyborg(src) //so I am leaving them here but commented out because robotics no do the borging w/o medical
+	src.modules += new /obj/item/weapon/portable_destructive_analyzer(src) //destructive analyzer option for pref respect while also being able to do job
 	src.modules += new /obj/item/weapon/gripper/no_use/mech(src)
+	src.modules += new /obj/item/weapon/shockpaddles/robot/jumper(src) //unkilling synths may be important actually
+	src.modules += new /obj/item/weapon/melee/baton/slime/robot(src) //save the xenobio from themselves
+	src.modules += new /obj/item/weapon/gun/energy/taser/xeno/robot(src) //save the xenobio from themselves from a distance
+	src.modules += new /obj/item/device/xenoarch_multi_tool(src) //go find fancy rock
+	src.modules += new /obj/item/weapon/pickaxe/excavationdrill(src) //go get fancy rock
 	src.emag = new /obj/item/weapon/hand_tele(src)
 
 	var/datum/matter_synth/water = new /datum/matter_synth(500)
@@ -579,27 +594,27 @@
 	//Painfully slow charger regen but high capacity. Also starts with low amount.
 	var/datum/matter_synth/metal = new /datum/matter_synth/metal()
 	metal.name = "Steel reserves"
-	metal.recharge_rate = 100
+	metal.recharge_rate = 500
 	metal.max_energy = 50000
 	metal.energy = 10000
 	var/datum/matter_synth/glass = new /datum/matter_synth/glass()
 	glass.name = "Glass reserves"
-	glass.recharge_rate = 100
+	glass.recharge_rate = 500
 	glass.max_energy = 50000
 	glass.energy = 10000
 	var/datum/matter_synth/wood = new /datum/matter_synth/wood()
 	wood.name = "Wood reserves"
-	wood.recharge_rate = 100
+	wood.recharge_rate = 500
 	wood.max_energy = 50000
 	wood.energy = 10000
 	var/datum/matter_synth/plastic = new /datum/matter_synth/plastic()
 	plastic.name = "Plastic reserves"
-	plastic.recharge_rate = 100
+	plastic.recharge_rate = 500
 	plastic.max_energy = 50000
 	plastic.energy = 10000
 	var/datum/matter_synth/plasteel = new /datum/matter_synth/plasteel()
 	plasteel.name = "Plasteel reserves"// Adding plasteel synthesizer to move in-line with Engiborg.
-	plasteel.recharge_rate = 100
+	plasteel.recharge_rate = 250
 	plasteel.max_energy = 20000
 	plasteel.energy = 10000
 	var/datum/matter_synth/water = new /datum/matter_synth(500)


### PR DESCRIPTION
tl;dr these things were designed with less functionality than regular silicons, but that didn't apply to every module. I have no idea why, I am assuming oversights. I have fixed the oversights.

- K9, Kmine, Service-hound, Janihound, and Boozehound are unaffected by this. I'll come back to those at a later date if I recognize any major capability gaps.
- Pupdozer has a less glacial material synth, now only 1/4 as fast as the base model instead of 1/20th the speed.
- Sci-Borg now has their sub-department tools, as well as jumper cables. This means they can save the xeno-bio's work instead of killing it, and do xeno-arch (or at least assist a miner who can break rock for you while you do it). Also un-dying synthmorphs. 
- Medihound now has splints, the ability to interact with beakers and stands by having a gripper, a larger internal beaker, and a dropper. This puts them roughly on par with the crisis module now. They can use 1 patch to 5 splints as the medicine ratio at the moment, I may add brute/burn specific patches from the crisis module and then also add the liquid patch to the crisis module.

TODO FOR MAYBE A LATER PR
- Make a surgeryhound (sprite may be easier than other stuff)
- Address carbon/silicon and silicon/silicon capability disparities in the five unaffected modules (some exist, mostly minor)
- make it so borgs (all relevant ones) can do NIF implant surgery