### PR TITLE
Makes wounds disappear

### DIFF
--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -732,8 +732,8 @@ Note that amputating the affected organ does in fact remove the infection from t
 		return
 
 	for(var/datum/wound/W in wounds)
-		// wounds can disappear after 10 minutes at the earliest
-		if(W.damage <= 0 && W.created + 10 * 10 * 60 <= world.time)
+		// wounds used to be able to disappear after 10 minutes at the earliest, for now just remove them as soon as there is no damage
+		if(W.damage <= 0)
 			wounds -= W
 			continue
 			// let the GC handle the deletion of the wound

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -594,6 +594,8 @@ This function completely restores a damaged organ to perfect condition.
 		return 1
 	else
 		last_dam = brute_dam + burn_dam
+	if (number_wounds != 0)
+		return 1
 	if(germ_level)
 		return 1
 	return 0


### PR DESCRIPTION
Have you ever noticed that if you get scraped once sometimes it literally never goes away throughout the entire round? Even when all the damage is totally healed? Sometimes external organs don't process to save resources, and as a result (it seems) to almost never if ever properly remove healed wounds from external organs.

HOWEVER, THIS FIX WILL CAUSE EXTERNAL ORGANS THAT BASICALLY DON'T /REALLY/ NEED TO BE PROCESSED TO SIT IN THE PROCESSING QUEUE FOR ~10 minutes (the time wounds take to heal), so there's a nonzero chance this could cause a performance decrease, so I also consider removing that ten minute timer entirely.