### PR TITLE
Nerfs mining yields for SD and RP

### DIFF
--- a/code/modules/random_map/noise/ore.dm
+++ b/code/modules/random_map/noise/ore.dm
@@ -53,7 +53,7 @@
 
 			var/current_cell = map[get_map_cell(x,y)]
 			if(current_cell < rare_val)      // Surface metals.
-				T.resources["hematite"] = rand(RESOURCE_MID_MIN, RESOURCE_HIGH_MAX)
+				T.resources["hematite"] = rand(RESOURCE_HIGH_MIN, RESOURCE_HIGH_MAX)
 				T.resources["gold"] =     rand(RESOURCE_LOW_MIN,  RESOURCE_LOW_MAX)
 				T.resources["silver"] =   rand(RESOURCE_LOW_MIN,  RESOURCE_LOW_MAX)
 				T.resources["uranium"] =  rand(RESOURCE_LOW_MIN,  RESOURCE_LOW_MAX)
@@ -81,17 +81,17 @@
 				T.resources["lead"] =     rand(RESOURCE_LOW_MIN, RESOURCE_MID_MAX)
 				T.resources["hydrogen"] = 0
 				T.resources["diamond"] =  0
-				T.resources["hematite"] = rand(RESOURCE_HIGH_MIN, RESOURCE_HIGH_MAX)
+				T.resources["hematite"] = 0
 				T.resources["marble"] =   0
 				//T.resources["copper"] =   0
 				//T.resources["tin"] =      rand(RESOURCE_MID_MIN, RESOURCE_MID_MAX)
 				//T.resources["bauxite"] =  0
-				T.resources["rutile"] =   rand(RESOURCE_LOW_MIN, RESOURCE_MID_MAX)
+				T.resources["rutile"] =   0
 				//T.resources["void opal"] = 0
 				//T.resources["quartz"] = 0
 				//T.resources["painite"] = 0
 			else                             // Deep metals.
-				T.resources["uranium"] =  rand(RESOURCE_MID_MIN,  RESOURCE_HIGH_MAX)
+				T.resources["uranium"] =  rand(RESOURCE_LOW_MIN,  RESOURCE_LOW_MAX)
 				T.resources["diamond"] =  rand(RESOURCE_LOW_MIN,  RESOURCE_LOW_MAX)
 				T.resources["verdantium"] = rand(RESOURCE_LOW_MIN, RESOURCE_MID_MAX)
 				T.resources["phoron"] =   rand(RESOURCE_HIGH_MIN, RESOURCE_HIGH_MAX)
@@ -99,13 +99,13 @@
 				T.resources["hydrogen"] = rand(RESOURCE_MID_MIN,  RESOURCE_MID_MAX)
 				T.resources["marble"] =   rand(RESOURCE_MID_MIN, RESOURCE_HIGH_MAX)
 				T.resources["lead"] =     rand(RESOURCE_LOW_MIN, RESOURCE_HIGH_MAX)
-				T.resources["hematite"] = rand(RESOURCE_HIGH_MIN, RESOURCE_HIGH_MAX)
-				T.resources["gold"] =     rand(RESOURCE_MID_MIN,  RESOURCE_HIGH_MAX)
-				T.resources["silver"] =   rand(RESOURCE_MID_MIN,  RESOURCE_HIGH_MAX)
+				T.resources["hematite"] = 0
+				T.resources["gold"] =     0
+				T.resources["silver"] =   0
 				//T.resources["copper"] =   0
 				//T.resources["tin"] =      0
 				//T.resources["bauxite"] =  0
-				T.resources["rutile"] =   rand(RESOURCE_MID_MIN, RESOURCE_HIGH_MAX)
+				T.resources["rutile"] =   0
 				//T.resources["void opal"] = 0
 				//T.resources["quartz"] = 0
 				//T.resources["painite"] = 0

--- a/maps/expedition_vr/aerostat/_aerostat.dm
+++ b/maps/expedition_vr/aerostat/_aerostat.dm
@@ -36,6 +36,81 @@
 /datum/random_map/noise/ore/virgo2/check_map_sanity()
 	return 1 //Totally random, but probably beneficial.
 
+/datum/random_map/noise/ore/virgo2/apply_to_turf(var/x,var/y)			//Same as normal + Rutile
+
+	var/tx = ((origin_x-1)+x)*chunk_size
+	var/ty = ((origin_y-1)+y)*chunk_size
+
+	for(var/i=0,i<chunk_size,i++)
+		for(var/j=0,j<chunk_size,j++)
+			var/turf/simulated/T = locate(tx+j, ty+i, origin_z)
+			if(!istype(T) || !T.has_resources)
+				continue
+			if(!priority_process) sleep(-1)
+			T.resources = list()
+			T.resources["silicates"] = rand(3,5)
+			T.resources["carbon"] = rand(3,5)
+
+			var/current_cell = map[get_map_cell(x,y)]
+			if(current_cell < rare_val)      // Surface metals.
+				T.resources["hematite"] = rand(RESOURCE_HIGH_MIN, RESOURCE_HIGH_MAX)
+				T.resources["gold"] =     rand(RESOURCE_LOW_MIN,  RESOURCE_LOW_MAX)
+				T.resources["silver"] =   rand(RESOURCE_LOW_MIN,  RESOURCE_LOW_MAX)
+				T.resources["uranium"] =  rand(RESOURCE_LOW_MIN,  RESOURCE_LOW_MAX)
+				T.resources["marble"] =   rand(RESOURCE_LOW_MIN, RESOURCE_MID_MAX)
+				T.resources["diamond"] =  0
+				T.resources["phoron"] =   0
+				T.resources["osmium"] =   0
+				T.resources["hydrogen"] = 0
+				T.resources["verdantium"] = 0
+				T.resources["lead"]     = 0
+				//T.resources["copper"] =   rand(RESOURCE_MID_MIN, RESOURCE_HIGH_MAX)
+				//T.resources["tin"] =      rand(RESOURCE_LOW_MIN, RESOURCE_MID_MAX)
+				//T.resources["bauxite"] =  rand(RESOURCE_LOW_MIN, RESOURCE_LOW_MAX)
+				T.resources["rutile"] =   rand(RESOURCE_LOW_MIN, RESOURCE_LOW_MAX)
+				//T.resources["void opal"] = 0
+				//T.resources["quartz"] = 0
+				//T.resources["painite"] = 0
+			else if(current_cell < deep_val) // Rare metals.
+				T.resources["gold"] =     rand(RESOURCE_MID_MIN,  RESOURCE_MID_MAX)
+				T.resources["silver"] =   rand(RESOURCE_MID_MIN,  RESOURCE_MID_MAX)
+				T.resources["uranium"] =  rand(RESOURCE_MID_MIN,  RESOURCE_MID_MAX)
+				T.resources["phoron"] =   rand(RESOURCE_MID_MIN,  RESOURCE_MID_MAX)
+				T.resources["osmium"] =   rand(RESOURCE_MID_MIN,  RESOURCE_MID_MAX)
+				T.resources["verdantium"] = rand(RESOURCE_LOW_MIN, RESOURCE_LOW_MAX)
+				T.resources["lead"] =     rand(RESOURCE_LOW_MIN, RESOURCE_MID_MAX)
+				T.resources["hydrogen"] = 0
+				T.resources["diamond"] =  0
+				T.resources["hematite"] = 0
+				T.resources["marble"] =   0
+				//T.resources["copper"] =   0
+				//T.resources["tin"] =      rand(RESOURCE_MID_MIN, RESOURCE_MID_MAX)
+				//T.resources["bauxite"] =  0
+				T.resources["rutile"] =   rand(RESOURCE_MID_MIN, RESOURCE_MID_MAX)
+				//T.resources["void opal"] = 0
+				//T.resources["quartz"] = 0
+				//T.resources["painite"] = 0
+			else                             // Deep metals.
+				T.resources["uranium"] =  rand(RESOURCE_LOW_MIN,  RESOURCE_LOW_MAX)
+				T.resources["diamond"] =  rand(RESOURCE_LOW_MIN,  RESOURCE_LOW_MAX)
+				T.resources["verdantium"] = rand(RESOURCE_LOW_MIN, RESOURCE_MID_MAX)
+				T.resources["phoron"] =   rand(RESOURCE_HIGH_MIN, RESOURCE_HIGH_MAX)
+				T.resources["osmium"] =   rand(RESOURCE_HIGH_MIN, RESOURCE_HIGH_MAX)
+				T.resources["hydrogen"] = rand(RESOURCE_MID_MIN,  RESOURCE_MID_MAX)
+				T.resources["marble"] =   rand(RESOURCE_MID_MIN, RESOURCE_HIGH_MAX)
+				T.resources["lead"] =     rand(RESOURCE_LOW_MIN, RESOURCE_HIGH_MAX)
+				T.resources["hematite"] = 0
+				T.resources["gold"] =     0
+				T.resources["silver"] =   0
+				//T.resources["copper"] =   0
+				//T.resources["tin"] =      0
+				//T.resources["bauxite"] =  0
+				T.resources["rutile"] =   rand(RESOURCE_HIGH_MIN, RESOURCE_HIGH_MAX)
+				//T.resources["void opal"] = 0
+				//T.resources["quartz"] = 0
+				//T.resources["painite"] = 0
+	return
+
 // -- Objs -- //
 
 /obj/machinery/computer/shuttle_control/aerostat_shuttle

--- a/maps/groundbase/groundbase_defines.dm
+++ b/maps/groundbase/groundbase_defines.dm
@@ -422,7 +422,7 @@
 	. = ..()
 //	seed_submaps(list(Z_LEVEL_MINING), 60, /area/gb_mine/unexplored, /datum/map_template/space_rocks)	//POI seeding
 	new /datum/random_map/automata/cave_system/no_cracks(null, 3, 3, Z_LEVEL_MINING, world.maxx - 4, world.maxy - 4)
-	new /datum/random_map/noise/ore/mining(null, 1, 1, Z_LEVEL_MINING, 64, 64)
+	new /datum/random_map/noise/ore/gb_mining(null, 1, 1, Z_LEVEL_MINING, 64, 64)
 
 /datum/map_z_level/gb_lateload/mining
 	z = Z_LEVEL_MINING

--- a/maps/groundbase/groundbase_mining.dm
+++ b/maps/groundbase/groundbase_mining.dm
@@ -8,7 +8,7 @@
 			"uranium" = 10,
 			"platinum" = 10,
 			"hematite" = 20,
-			"carbon" = 5,
+			"carbon" = 20,
 			"diamond" = 1,
 			"gold" = 8,
 			"silver" = 8,
@@ -21,7 +21,7 @@
 			"uranium" = 5,
 			"platinum" = 5,
 			"hematite" = 35,
-			"carbon" = 5,
+			"carbon" = 35,
 			"gold" = 3,
 			"silver" = 3,
 			"phoron" = 25,
@@ -32,10 +32,10 @@
 		UpdateMineral()
 	update_icon()
 
-/datum/random_map/noise/ore/mining
-	descriptor = "asteroid field ore distribution map"
-	deep_val = 0.2
-	rare_val = 0.1
+/datum/random_map/noise/ore/gb_mining
+	descriptor = "groundbase underground ore distribution map"
+	deep_val = 0.7
+	rare_val = 0.5
 
 /datum/random_map/noise/ore/mining/check_map_sanity()
 	return 1 //Totally random, but probably beneficial.

--- a/maps/stellar_delight/stellar_delight_defines.dm
+++ b/maps/stellar_delight/stellar_delight_defines.dm
@@ -339,7 +339,7 @@
 	. = ..()
 	seed_submaps(list(Z_LEVEL_SPACE_ROCKS), 60, /area/sdmine/unexplored, /datum/map_template/space_rocks)
 	new /datum/random_map/automata/cave_system/no_cracks(null, 3, 3, Z_LEVEL_SPACE_ROCKS, world.maxx - 4, world.maxy - 4)
-	new /datum/random_map/noise/ore/spacerocks(null, 1, 1, Z_LEVEL_SPACE_ROCKS, 64, 64)
+	new /datum/random_map/noise/ore(null, 1, 1, Z_LEVEL_SPACE_ROCKS, 64, 64)
 
 /datum/map_z_level/ship_lateload/space_rocks
 	z = Z_LEVEL_SPACE_ROCKS

--- a/maps/stellar_delight/stellar_delight_things.dm
+++ b/maps/stellar_delight/stellar_delight_things.dm
@@ -175,3 +175,6 @@
 
 /obj/machinery/power/quantumpad/scioutpost
 
+/datum/random_map/noise/ore/virgo2		// Less OP generation map, but better than Underdark
+	deep_val = 0.7
+	rare_val = 0.5

--- a/maps/stellar_delight/stellar_delight_turfs.dm
+++ b/maps/stellar_delight/stellar_delight_turfs.dm
@@ -45,3 +45,38 @@ VIRGO3B_TURF_CREATE(/turf/simulated/floor/outdoors/dirt)
 	icon_state = "asteroid"
 
 VIRGO3B_TURF_CREATE(/turf/simulated/floor/outdoors/rocks)
+
+/turf/simulated/mineral/virgo2/make_ore(var/rare_ore)					// Override V2 ore generation
+	if(mineral || ignore_mapgen)
+		return
+	var/mineral_name
+	if(rare_ore)
+		mineral_name = pickweight(list(
+			"marble" = 7,
+			"uranium" = 10,
+			"platinum" = 10,
+			"hematite" = 10,
+			"carbon" = 10,
+			"diamond" = 4,
+			"gold" = 15,
+			"silver" = 15,
+			"lead" = 5,
+			"verdantium" = 2,
+			"rutile" = 10))
+	else
+		mineral_name = pickweight(list(
+			"marble" = 5,
+			"uranium" = 7,
+			"platinum" = 7,
+			"hematite" = 28,
+			"carbon" = 28,
+			"diamond" = 2,
+			"gold" = 7,
+			"silver" = 7,
+			"lead" = 4,
+			"verdantium" = 1,
+			"rutile" = 10))
+	if(mineral_name && (mineral_name in GLOB.ore_data))
+		mineral = GLOB.ore_data[mineral_name]
+		UpdateMineral()
+	update_icon()

--- a/maps/submaps/space_rocks/space_rocks.dm
+++ b/maps/submaps/space_rocks/space_rocks.dm
@@ -11,7 +11,7 @@
 			"uranium" = 10,
 			"platinum" = 10,
 			"hematite" = 20,
-			"carbon" = 5,
+			"carbon" = 20,
 			"diamond" = 1,
 			"gold" = 8,
 			"silver" = 8,
@@ -24,7 +24,7 @@
 			"uranium" = 5,
 			"platinum" = 5,
 			"hematite" = 35,
-			"carbon" = 5,
+			"carbon" = 35,
 			"gold" = 3,
 			"silver" = 3,
 			"phoron" = 25,
@@ -35,15 +35,7 @@
 		UpdateMineral()
 	update_icon()
 
-/datum/random_map/noise/ore/spacerocks
-	descriptor = "asteroid field ore distribution map"
-	deep_val = 0.2
-	rare_val = 0.1
-
-/datum/random_map/noise/ore/spacerocks/check_map_sanity()
-	return 1 //Totally random, but probably beneficial.
-
-/area/sdmine/
+/area/sdmine
 	ambience = list('sound/ambience/ambimine.ogg', 'sound/ambience/song_game.ogg')
 	base_turf = /turf/simulated/mineral/floor/vacuum
 /area/sdmine/unexplored

--- a/maps/tether/submaps/_tether_submaps.dm
+++ b/maps/tether/submaps/_tether_submaps.dm
@@ -48,7 +48,7 @@
 	. = ..()
 	seed_submaps(list(Z_LEVEL_UNDERDARK), 100, /area/mine/unexplored/underdark, /datum/map_template/underdark)
 	new /datum/random_map/automata/cave_system/no_cracks(null, 3, 3, Z_LEVEL_UNDERDARK, world.maxx - 4, world.maxy - 4) // Create the mining Z-level.
-	new /datum/random_map/noise/ore(null, 1, 1, Z_LEVEL_UNDERDARK, 64, 64)         // Create the mining ore distribution map.
+	new /datum/random_map/noise/ore/underdark(null, 1, 1, Z_LEVEL_UNDERDARK, 64, 64)         // Create the mining ore distribution map.
 
 #include "../../submaps/surface_submaps/plains/plains_vr.dm"
 #include "../../submaps/surface_submaps/plains/plains_areas.dm"

--- a/maps/tether/submaps/underdark_pois/underdark_things.dm
+++ b/maps/tether/submaps/underdark_pois/underdark_things.dm
@@ -1,3 +1,8 @@
+/datum/random_map/noise/ore/underdark
+	descriptor = "Underdark ore distribution map"
+	deep_val = 0.7
+	rare_val = 0.5
+
 // Weakened version of Phoron spiders
 /mob/living/simple_mob/animal/giant_spider/phorogenic/weak
 	maxHealth = 100


### PR DESCRIPTION
Undoes effects of #12036 since it was a bandaid fix
Removes Rutile from deep spawning on every map except Virgo 2
Increased deep resources yields in Underdark somewhat
Increases carbon yields in surface resources for both SD's space rocks and RP's underground
Reduces deep resources on SD's space rocks to match 3b's surface
Reduces surface resources on SD version of Virgo 2 to match Underdark (+ rutile)
Reduces deep resources on SD version of Virgo 2 to match Underdark (+ rutile)
Reduces deep resources on RP underground to match Underdark

To note, this is primarily meant to bring other maps (SD and RP) to be more in match with Tether in terms of ore yield balancing, mostly underground ores. Using Virgo 2's deep ore map almost universally on those maps completely sent the mining balance in a whack and this is attempt to try and restore it. Possible fine-tuning per-map will be needed after this, but this should make all maps on approximately same page.