### PR TITLE
Makes brainzsnax actually snacks

### DIFF
--- a/code/modules/food/food/snacks.dm
+++ b/code/modules/food/food/snacks.dm
@@ -6922,10 +6922,11 @@
 	filling_color = "#caa3c9"
 	center_of_mass = list("x"=15, "y"=9)
 	bitesize = 2
+	var/brainmeat = "brain_protein"
 
 /obj/item/weapon/reagent_containers/food/snacks/canned/brainzsnax/Initialize()
 	. = ..()
-	reagents.add_reagent("brain_protein", 10)
+	reagents.add_reagent(brainmeat, 10)
 
 /obj/item/weapon/reagent_containers/food/snacks/canned/brainzsnax/red
 	name = "\improper BrainzSnax RED"
@@ -6939,10 +6940,7 @@
 	filling_color = "#a6898d"
 	center_of_mass = list("x"=15, "y"=9)
 	bitesize = 2
-
-/obj/item/weapon/reagent_containers/food/snacks/canned/brainzsnax/red/Initialize()
-	. = ..()
-	reagents.add_reagent("red_brain_protein", 10)
+	brainmeat = "red_brain_protein"
 
 //////////////Packaged Food - break open and eat//////////////
 

--- a/code/modules/reagents/reagents/food_drinks_vr.dm
+++ b/code/modules/reagents/reagents/food_drinks_vr.dm
@@ -536,6 +536,7 @@
 				H.feral = 0
 				to_chat(H, "<span class='info'>Your mind starts to clear, soothed into a state of clarity as your senses return.</span>")
 				log_and_message_admins("is no longer feral.", H)
+	..()
 
 /datum/reagent/nutriment/protein/brainzsnax/red
 	id = "red_brain_protein"

--- a/code/modules/reagents/reagents/food_drinks_vr.dm
+++ b/code/modules/reagents/reagents/food_drinks_vr.dm
@@ -140,7 +140,7 @@
 				M.adjust_nutrition(alt_nutriment_factor * removed)
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
-		if(H.feral > 0 && H.nutrition > 100 && H.traumatic_shock < min(60, H.nutrition/10) && H.jitteriness < 100) // same check as feral triggers to stop them immediately re-feralling
+		if(H.feral > 0 && H.nutrition > 150 && H.traumatic_shock < 20 && H.jitteriness < 100) //Same check as feral triggers to stop them immediately re-feralling
 			H.feral -= removed * 3 // should calm them down quick, provided they're actually in a state to STAY calm.
 			if (H.feral <=0) //check if they're unferalled
 				H.feral = 0
@@ -523,6 +523,7 @@
 	color = "#caa3c9"
 
 /datum/reagent/nutriment/protein/brainzsnax/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed)
+	..()
 	if(prob(5) && !(alien == IS_CHIMERA || alien == IS_SLIME || alien == IS_PLANT || alien == IS_DIONA || alien == IS_SHADEKIN && !M.isSynthetic()))
 		M.adjustBrainLoss(removed) //Any other species risks prion disease.
 		M.Confuse(5)
@@ -530,13 +531,12 @@
 
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
-		if(H.feral > 0 && H.nutrition > 100 && H.traumatic_shock < min(60, H.nutrition/10) && H.jitteriness < 100) //Same check as feral triggers to stop them immediately re-feralling
+		if(H.feral > 0 && H.nutrition > 150 && H.traumatic_shock < 20 && H.jitteriness < 100) //Same check as feral triggers to stop them immediately re-feralling
 			H.feral -= removed * 3 //Should calm them down quick, provided they're actually in a state to STAY calm.
 			if(H.feral <=0) //Check if they're unferalled
 				H.feral = 0
 				to_chat(H, "<span class='info'>Your mind starts to clear, soothed into a state of clarity as your senses return.</span>")
 				log_and_message_admins("is no longer feral.", H)
-	..()
 
 /datum/reagent/nutriment/protein/brainzsnax/red
 	id = "red_brain_protein"


### PR DESCRIPTION
Missing callback meant brainzsnax didn't actually provide any nutrition. This fixes that.

Also fixes the red variant adding both red reagent _and_ normal reagent.