### PR TITLE
Fixes recharge station overlays

### DIFF
--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -198,7 +198,7 @@
 		desc += "<br>It is capable of repairing burn damage."
 
 /obj/machinery/recharge_station/proc/build_overlays()
-	cut_overlay()
+	cut_overlays()
 	switch(round(chargepercentage()))
 		if(1 to 20)
 			add_overlay("statn_c0")


### PR DESCRIPTION
This PR fixes #13491, by actually cutting out the overlays with the correct proc.

The previous proc instantly failed as no overlay list was provided (the new one just cuts out all the overlays the machine has).

This was tested with multiple charge levels and the "our overlays" and "overlays" variables stayed at 1-2 at most.