### PR TITLE
Fixes IDs getting the "digested" overlay up to infinity

### DIFF
--- a/code/modules/vore/eating/digest_act_vr.dm
+++ b/code/modules/vore/eating/digest_act_vr.dm
@@ -101,7 +101,8 @@
 		icon = 'icons/obj/card_vr.dmi'
 		icon_state = "[initial(icon_state)]_digested"
 	else
-		sprite_stack += "digested"
+		if(!sprite_stack.Find("digested"))
+			sprite_stack += "digested"
 	update_icon()
 	return FALSE
 


### PR DESCRIPTION
This PR enables a check if the "digested" overlay already exists in the overlay stack of the IDs.

I was informed about a similar to the recharge station overlay bug, which kept adding "digested" to the overlay stack of the IDs.

This also has caused some lag issue and could possibly cause the server to crash if purposefully or accidentally eating a lot of IDs with contamination on.