### PR TITLE
Adds ticket escalation

### DIFF
--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -185,6 +185,7 @@
 	GLOB.directory[ckey] = src
 
 	GLOB.ahelp_tickets.ClientLogin(src)
+	GLOB.mhelp_tickets.ClientLogin(src)
 
 	//Admin Authorisation
 	holder = admin_datums[ckey]
@@ -277,6 +278,7 @@
 		mentorholder.owner = null
 		GLOB.mentors -= src
 	GLOB.ahelp_tickets.ClientLogout(src)
+	GLOB.mhelp_tickets.ClientLogout(src)
 	GLOB.directory -= ckey
 	GLOB.clients -= src
 	return ..()

--- a/code/modules/mentor/mentor.dm
+++ b/code/modules/mentor/mentor.dm
@@ -107,7 +107,7 @@ var/list/mentor_verbs_default = list(
 	if(href_list["mhelp"])
 		var/mhelp_ref = href_list["mhelp"]
 		var/datum/mentor_help/MH = locate(mhelp_ref)
-		if (MH)
+		if (MH && istype(MH, /datum/mentor_help))
 			MH.Action(href_list["mhelp_action"])
 		else
 			to_chat(C, "Ticket [mhelp_ref] has been deleted!")
@@ -168,7 +168,8 @@ var/list/mentor_verbs_default = list(
 		to_chat(src, "<span class='pm warning'>Error: Mentor-PM: You are unable to use admin PM-s (muted).</span>")
 		return
 
-	if(!(has_mentor_powers(src)) && !current_mentorhelp)
+	//Not a mentor and no open ticket
+	if(!has_mentor_powers(src) && !current_mentorhelp)
 		to_chat(src, "<span class='pm warning'>You can no longer reply to this ticket, please open another one by using the Mentorhelp verb if need be.</span>")
 		to_chat(src, "<span class='pm notice'>Message: [msg]</span>")
 		return
@@ -181,16 +182,7 @@ var/list/mentor_verbs_default = list(
 	else if(istype(whom,/client))
 		recipient = whom
 
-	if(!recipient)
-		if(has_mentor_powers(src))
-			to_chat(src, "<span class='pm warning'>Error: Mentor-PM: Client not found.</span>")
-			to_chat(src, msg)
-		else
-			log_admin("Mentorhelp: [key_name(src)] sent [msg]")
-			current_mentorhelp.MessageNoRecipient(msg)
-		return
-
-		//get message text, limit it's length.and clean/escape html
+	//get message text, limit it's length.and clean/escape html
 	if(!msg)
 		msg = tgui_input_text(src,"Message:", "Mentor-PM to [whom]")
 
@@ -204,10 +196,17 @@ var/list/mentor_verbs_default = list(
 		if(!recipient)
 			if(has_mentor_powers(src))
 				to_chat(src, "<span class='pm warning'>Error:Mentor-PM: Client not found.</span>")
+				to_chat(src, msg)
 			else
-				log_admin("Mentorhelp: [key_name(src)] sent [msg]")
+				log_admin("Mentorhelp: [key_name(src)]: [msg]")
 				current_mentorhelp.MessageNoRecipient(msg)
 			return
+
+	//Has mentor powers but the recipient no longer has an open ticket
+	if(has_mentor_powers(src) && !recipient.current_mentorhelp)
+		to_chat(src, "<span class='pm warning'>You can no longer reply to this ticket.</span>")
+		to_chat(src, "<span class='pm notice'>Message: [msg]</span>")
+		return
 
 	if (src.handle_spam_prevention(msg,MUTE_ADMINHELP))
 		return
@@ -233,7 +232,7 @@ var/list/mentor_verbs_default = list(
 	to_chat(recipient, "<i><span class='mentor'>Mentor-PM from-<b><a href='?mentorhelp_msg=\ref[src]'>[src]</a></b>: [msg]</span></i>")
 	to_chat(src, "<i><span class='mentor'>Mentor-PM to-<b>[recipient]</b>: [msg]</span></i>")
 
-	log_admin("[key_name(src)] sent [msg] to [key_name(recipient)]")
+	log_admin("[key_name(src)]->[key_name(recipient)]: [msg]")
 
 	if(recipient.is_preference_enabled(/datum/client_preference/play_mentorhelp_ping))
 		recipient << 'sound/effects/mentorhelp.mp3'


### PR DESCRIPTION
Adds the last feature I really intended the mentor system to have; ticket escalation. This allows a ticket to be moved with its entire conversational history to an adminhelp if it's something a mentor can't or shouldn't resolve (obviously stuff like rule questions or button pressing should be immediately escalated, but for instance if it starts out a mechanics question but turns out to be a bug for example, a mentor can't fix that).

Also fixes various bugs like disconnection/reconnection not disassociating/reassociating your client with your mentorhelps, blocks mentors from replying to closed tickets, restores intended behavior of a person trying to respond to a specific mentor who has disconnected messaging all mentors instead, makes the logs slightly cleaner, and fixes an out of place span.