### PR TITLE
Makes the reverse-mouseray able to be made via research.

### DIFF
--- a/code/modules/research/designs/medical_vr.dm
+++ b/code/modules/research/designs/medical_vr.dm
@@ -30,6 +30,15 @@
 	build_path = /obj/item/weapon/reagent_containers/hypospray/science
 	sort_string = "KCAVB"
 
+/datum/design/item/medical/recombobray
+	name = "recombobulation ray"
+	desc = "The Type Gamma Medical Recombobulation ray! A mysterious looking ray gun! It works to change people who have had their form significantly altered back into their original forms!"
+	id = "recombobray"
+	req_tech = list(TECH_MATERIAL = 3, TECH_ENGINEERING = 3, TECH_POWER = 4, TECH_BIO = 5, TECH_BLUESPACE = 4) //Not like these matter. *Glares at circuit printer.*
+	materials = list(MAT_STEEL = 1000, MAT_GLASS = 2000, MAT_URANIUM = 500, MAT_PHORON = 1500)
+	build_path = /obj/item/weapon/gun/energy/mouseray/medical
+	sort_string = "KCAVC"
+
 // ML-3M medigun and cells
 /datum/design/item/medical/cell_based/AssembleDesignName()
 	..()


### PR DESCRIPTION
Since TFs can happen and if the ray medical has gets lost by some means or something a backup would be needed.

- This allows it to be created in game without having to ahelp for a replacement.

Not that TFs are too common, but they're a maint loot spawn so it's good to be able to revert it.