### PR TITLE
Allows use of Virtual Avatars in game without breaking things.

### DIFF
--- a/code/modules/mob/living/carbon/human/species/virtual_reality/avatar.dm
+++ b/code/modules/mob/living/carbon/human/species/virtual_reality/avatar.dm
@@ -35,7 +35,7 @@
 		/mob/living/carbon/human/proc/shapeshifter_select_hair_colors,
 		/mob/living/carbon/human/proc/shapeshifter_select_gender,
 		/mob/living/carbon/human/proc/regenerate,
-		/mob/living/carbon/human/proc/shapeshifter_change_opacity,
+		/mob/living/carbon/human/proc/promethean_select_opaqueness,
 		/mob/living/carbon/human/proc/exit_vr
 		)
 

--- a/code/modules/mob/living/carbon/human/species/virtual_reality/avatar.dm
+++ b/code/modules/mob/living/carbon/human/species/virtual_reality/avatar.dm
@@ -34,6 +34,10 @@
 		/mob/living/carbon/human/proc/shapeshifter_select_hair,
 		/mob/living/carbon/human/proc/shapeshifter_select_hair_colors,
 		/mob/living/carbon/human/proc/shapeshifter_select_gender,
+		/mob/living/carbon/human/proc/shapeshifter_select_wings,
+		/mob/living/carbon/human/proc/shapeshifter_select_tail,
+		/mob/living/carbon/human/proc/shapeshifter_select_ears,
+		/mob/living/proc/set_size,
 		/mob/living/carbon/human/proc/regenerate,
 		/mob/living/carbon/human/proc/promethean_select_opaqueness,
 		/mob/living/carbon/human/proc/exit_vr


### PR DESCRIPTION
No this isn't as amazing as it sounds. It's just that it allows for use of VR people without having a "Breaks everything" button that is vastly inferior to our custom coded promethean opaque toggle.
Gives them all the normal, Virgo specific promie stuff as well.