### PR TITLE
Prevent the prettier plugin to run outside of tgui

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,5 @@
+# We don't want prettier to run on anything outside of the TGUI folder, so we have to do this.
+/*
+
+# We want it to run into the TGUI folder, however.
+!/tgui


### PR DESCRIPTION
This prevents the prettier vscode plugin to accidentally prettify/format files edited outside of the tgui directory.