### PR TITLE
Makes the freezer able to hold more items at cost of size.

### DIFF
--- a/code/game/objects/items/weapons/storage/boxes_vr.dm
+++ b/code/game/objects/items/weapons/storage/boxes_vr.dm
@@ -36,3 +36,6 @@
 
 /obj/item/weapon/storage/box/brainzsnax/red
 	starts_with = list(/obj/item/weapon/reagent_containers/food/snacks/canned/brainzsnax/red = 6)
+
+/obj/item/weapon/storage/box/freezer
+	can_hold = list(/obj/item/organ, /obj/item/weapon/reagent_containers/blood, /obj/item/weapon/reagent_containers/glass, /obj/item/weapon/reagent_containers/food)


### PR DESCRIPTION
- Increases the size of the portable freezer itself by 50%
- Allows the freezer to hold bloodbags, beakers/bottles, drinks, and food instead of just organs.

Was talking to someone about freezer bags and how they are completely unused currently due to the restrictiveness of them, rendering them useless. This was due to the fact that freezer bags simply held organs and nothing else, which being able to print organs means it's completely useless unless doing ghetto surgery in the field (bad idea due to failure %) or saving an organ from the field to put back on a person (again, useless due to being able to print organs on station)

This change expands them somewhat, allowing them to hold a wider variety of things at the cost of an increased storage size.

As far as I was informed, they were nerfed on Polaris due to their capacity vs normal boxes, as people were filling them with beakers/pillbottles. This change ultimately resulted in medical just emptying out a medkit instead and using that store their pillbottles/beakers instead since it held slightly less.

# The dreaded math:
#### Beakers hold 60u.
(Large and bluespace beakers exist, but aren't as strong as the pillbottle volume, so not being factored in)
#### Pillbottles hold 14 pills which can each hold 60u each pill.
This means pillbottles have, per bottle, 840u max of raw-reagent-storage per bottle.

Currently a medical kit has a storage space of 14 (7 beakers / pillbottles) beaker / pillbottle volume: **(420u/5880u)**
The Portable Freezer has a storage space of 20 (10 beakers) w/ a total volume of: **(600u)**

Both of these have a storage_cost of 4, meaning that the value of each storage unit of backpack space was:

**Medical Kit: (105u/1470u) per backpack storage space used**
**Portable Freezer: (150u) per backpack storage space used** (prior to being limited to only being able to hold organs)

This meant that the portable freezer was ~50% more efficient per backpack space used than the medical kit when using only beakers.

With this change, it expands the portable freezer's list of items able to be held while making it slightly weaker than the medical kit.

Now with a storage_cost of 6, it means that the portable freezer still can hold 10 beakers but at the cost of 1.5x the size of a medical kit in terms of backpack storage.

What this comes out to is (100u) per backpack storage space used, meaning it is _slightly_ less efficient than a medical kit in terms of raw-reagent storage when using beakers, while still 58x weaker than a medkit when using pillbottles while also allowing for more uses than solely organs.

The portable freezer can't hold pillbottles either, meaning that when it comes to raw-reagent storage, the medical kit is still the tool of choice for raw-reagent-storage.