### PR TITLE
Deletes C&P Monolingual error

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/negative.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/negative.dm
@@ -146,13 +146,6 @@
 /datum/trait/negative/monolingual
 	name = "Monolingual"
 	desc = "You are not good at learning languages."
-	cost = -3
-	var_changes = list("num_alternate_languages" = 0)
-	varchange_type = TRAIT_VARCHANGE_MORE_BETTER
-
-/datum/trait/negative/monolingual
-	name = "Monolingual"
-	desc = "You are not good at learning languages."
 	cost = -1
 	var_changes = list("num_alternate_languages" = 0)
 	var_changes_pref = list("extra_languages" = -3)


### PR DESCRIPTION
Monolingual accidentally was copy & pasted twice. After looking at the PR and talking to the person responsible, worked out that it was supposed to be -1 instead of -3.

This, gameplay wise, changes absolutely nothing since the -1 version was already in play