### PR TITLE
Allows painkillers to negate slowdown due to damage

### DIFF
--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -20,7 +20,11 @@
 			. += M.slowdown
 
 	var/health_deficiency = (getMaxHealth() - health)
-	if(health_deficiency >= 40) . += (health_deficiency / 25)
+	if(health_deficiency >= 40) //VOREStation Edit Start
+		if(chem_effects[CE_PAINKILLER] > 0) //On painkillers? Reduce pain! On anti-painkillers? Increase pain!
+			health_deficiency = max(0, health_deficiency - src.chem_effects[CE_PAINKILLER])
+		if(health_deficiency >= 40) //Still in enough pain for it to be significant?
+			. += (health_deficiency / 25) //VOREStation Edit End
 
 	if(can_feel_pain())
 		if(halloss >= 10) . += (halloss / 10) //halloss shouldn't slow you down if you can't even feel it

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -21,7 +21,7 @@
 
 	var/health_deficiency = (getMaxHealth() - health)
 	if(health_deficiency >= 40) //VOREStation Edit Start
-		if(chem_effects[CE_PAINKILLER] > 0) //On painkillers? Reduce pain! On anti-painkillers? Increase pain!
+		if(chem_effects[CE_PAINKILLER]) //On painkillers? Reduce pain! On anti-painkillers? Increase pain!
 			health_deficiency = max(0, health_deficiency - src.chem_effects[CE_PAINKILLER])
 		if(health_deficiency >= 40) //Still in enough pain for it to be significant?
 			. += (health_deficiency / 25) //VOREStation Edit End


### PR DESCRIPTION
Prior to this change, painkillers worked on most causes of slowdown (reducing traumatic_shock, which when above 80, would start accumulating shock_stage) but not all.

Having 40 damage or more would cause you to have slowdown. 

Even if your arms and hands were hit with 10 damage each (40 damage total, no broken bones) and then you downed the strongest non-slowing down painkiller (tramadol) you would still be slowed down like it did nothing, even though the pain pills are taking off double the pain you're currently in.

With this change, it makes your pain take painkillers into account.

Additionally, as an unintended side effect, it allows for PAIN INCREASERS to be used. Meaning if the person is in any pain, it will amplify their pain slowdown.


I can't help but think this is a bug/an oversight as the code involved is **10 years old (https://i.imgur.com/kwt6CVw.png)** but it's been in the game so long that it can probably be viewed as a feature change as well.