### PR TITLE
Prevents embedding of phishing links in debug logs

### DIFF
--- a/code/_helpers/logging.dm
+++ b/code/_helpers/logging.dm
@@ -37,7 +37,7 @@
 
 /proc/log_debug(text)
 	if (config.log_debug)
-		WRITE_LOG(debug_log, "DEBUG: [text]")
+		WRITE_LOG(debug_log, "DEBUG: [sanitize(text)]")
 
 	for(var/client/C in GLOB.admins)
 		if(C.is_preference_enabled(/datum/client_preference/debug/show_debug_logs))


### PR DESCRIPTION
With clever usage of some tools, users are able to send debug logs which will show to admins with the debug logs enabled.

While this isn't an intended function, it is harmless if properly sanitized.

Without sanitization, users could potentially send a phishing link through it with something like
"CRITICAL FAILURE: SERVER CRASH IMMINENT! CLICK [HERE] TO VIEW CAUSE"
and possibly set a fire under any maintainers ass and get them to click said link and cause them to fire off a command or be redirected to a website.

This PR properly sanitizes the debug text to prevent that from happening, so if some dummy tries to use fancy phishing tricks it'll be obvious and they can properly be smited.


Credit to Selis#7216 on discord for finding the exploit.