### PR TITLE
Why were these in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,9 +22,6 @@ cfg/
 !/.vscode/settings.json
 !/.vscode/tasks.json
 
-code/game/gamemodes/technomancer/spells/projectile/overload.dm
-code/game/gamemodes/technomancer/spells/projectile/overload.dm
-code/modules/client/preference_setup/loadout/loadout_xeno.dm
 temp.dmi
 
 node_modules/


### PR DESCRIPTION
It makes no sense and if someone ever wanted to make a change they would be incapable of doing so

Also overload was listed there twice and after looking back at it, this was included in a Polaris sync I did 6 years ago, meaning that this was due to some kind of mistake.