### PR TITLE
Replaces adminhelp verb in macros/hotkeys

### DIFF
--- a/code/modules/mentor/mentor.dm
+++ b/code/modules/mentor/mentor.dm
@@ -159,6 +159,20 @@ var/list/mentor_verbs_default = list(
 /proc/has_mentor_powers(client/C)
 	return C.holder || C.mentorholder
 
+// This not really a great place to put it, but this verb replaces adminhelp in hotkeys so that people requesting help can select the type they need
+// You can still directly adminhelp if necessary, this ONLY replaces the inbuilt hotkeys
+
+/client/verb/requesthelp(msg as text)
+	set category = "Admin"
+	set name = "Request help"
+
+	if(tgui_alert(usr, "Select the help you need.","Request for Help",list("Adminhelp","Mentorhelp")) == "Mentorhelp")
+		mentorhelp(msg)
+		return
+
+	adminhelp(msg)
+
+
 /client/proc/cmd_mentor_pm(whom, msg, datum/mentor_help/MH)
 	set category = "Admin"
 	set name = "Mentor-PM"

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -229,7 +229,7 @@ macro "borghotkeymode"
 		command = "body-toggle-head"
 	elem 
 		name = "F1"
-		command = "adminhelp"
+		command = "request-help"
 	elem 
 		name = "CTRL+SHIFT+F1+REP"
 		command = ".options"
@@ -453,7 +453,7 @@ macro "macro"
 		command = "body-toggle-head"
 	elem 
 		name = "F1"
-		command = "adminhelp"
+		command = "request-help"
 	elem 
 		name = "CTRL+SHIFT+F1+REP"
 		command = ".options"
@@ -734,7 +734,7 @@ macro "hotkeymode"
 		command = "body-toggle-head"
 	elem 
 		name = "F1"
-		command = "adminhelp"
+		command = "request-help"
 	elem 
 		name = "CTRL+SHIFT+F1+REP"
 		command = ".options"
@@ -952,7 +952,7 @@ macro "borgmacro"
 		command = "body-toggle-head"
 	elem 
 		name = "F1"
-		command = "adminhelp"
+		command = "request-help"
 	elem 
 		name = "CTRL+SHIFT+F1+REP"
 		command = ".options"
@@ -1112,7 +1112,7 @@ menu "menu"
 		saved-params = "is-checked"
 	elem 
 		name = "&Admin help\tF1"
-		command = "adminhelp"
+		command = "request-help"
 		category = "&Help"
 		saved-params = "is-checked"
 	elem 


### PR DESCRIPTION
If you F1 it will prompt you to select adminhelp or mentorhelp, this is only a replacement in hotkeys you can still directly adminhelp if need be.