### PR TITLE
Adds a toggle to hide tails.

### DIFF
--- a/code/modules/mob/living/carbon/human/emote_vr.dm
+++ b/code/modules/mob/living/carbon/human/emote_vr.dm
@@ -61,3 +61,26 @@
 	else
 		message = "hides their wings."
 	visible_message("[src] [message]")
+
+/mob/living/carbon/human/verb/hide_tail_vr()
+	set name = "Show/Hide tail"
+	set category = "IC"
+	set desc = "Hide your tail, or show it if you already hid it."
+	if(!tail_style) //Just some checks.
+		to_chat(src,"<span class='notice'>You have no tail to hide!</span>")
+		return
+	else //They got a tail. Let's make sure it ain't hiding stuff!
+		var/datum/sprite_accessory/tail/current_tail = tail_style
+		if((current_tail.hide_body_parts && current_tail.hide_body_parts.len) || current_tail.clip_mask_state || current_tail.clip_mask)
+			to_chat(src,"<span class='notice'>Your current tail is too considerable to hide!</span>")
+			return
+	if(species.tail) //If they're using this verb, they already have a custom tail. This prevents their species tail from showing.
+		species.tail = null //Honestly, this should probably be done when a custom tail is chosen, but this is the only time it'd ever matter.
+	tail_hidden = !tail_hidden
+	update_tail_showing()
+	var/message = ""
+	if(!tail_hidden)
+		message = "reveals their tail!"
+	else
+		message = "hides their tail."
+	visible_message("[src] [message]")

--- a/code/modules/mob/living/carbon/human/human_defines_vr.dm
+++ b/code/modules/mob/living/carbon/human/human_defines_vr.dm
@@ -8,6 +8,7 @@
 	var/ability_flags = 0	//Shadekin abilities/potentially other species-based?
 	var/sensorpref = 5		//Suit sensor loadout pref
 	var/wings_hidden = FALSE
+	var/tail_hidden = FALSE
 
 /mob/living/carbon/human/proc/shadekin_get_energy()
 	var/datum/species/shadekin/SK = species

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -1239,13 +1239,13 @@ var/global/list/damage_icon_parts = list() //see UpdateDamageIcon()
 /mob/living/carbon/human/proc/get_tail_image()
 	//If you are FBP with tail style and didn't set a custom one
 	var/datum/robolimb/model = isSynthetic()
-	if(istype(model) && model.includes_tail && !tail_style)
+	if(istype(model) && model.includes_tail && !tail_style && !tail_hidden)
 		var/icon/tail_s = new/icon("icon" = synthetic.icon, "icon_state" = "tail")
 		tail_s.Blend(rgb(src.r_skin, src.g_skin, src.b_skin), species.color_mult ? ICON_MULTIPLY : ICON_ADD)
 		return image(tail_s)
 
 	//If you have a custom tail selected
-	if(tail_style && !(wear_suit && wear_suit.flags_inv & HIDETAIL && !istaurtail(tail_style)))
+	if(tail_style && !(wear_suit && wear_suit.flags_inv & HIDETAIL && !istaurtail(tail_style)) && !tail_hidden)
 		var/icon/tail_s = new/icon("icon" = tail_style.icon, "icon_state" = (tail_style.can_loaf && resting) ? "[tail_style.icon_state]_loaf" : (wagging && tail_style.ani_state ? tail_style.ani_state : tail_style.icon_state)) // VOREStation Edit: Taur Loafing
 		if(tail_style.can_loaf && !is_shifted)
 			pixel_y = (resting) ? -tail_style.loaf_offset : 0 //move player down, then taur up, to fit the overlays correctly // VOREStation Edit: Taur Loafing


### PR DESCRIPTION
- Custom Tails can now be hidden and unhidden with the usage of a new verb!

- Overwrites the species specific tail when used (As the usage of this verb means that the user has a custom tail and the species tail is irrelevant).
This should honestly be done when a custom tail is chosen, but I'd rather not break anything and this is a simple way of doing such.

- Taurs (and any others with tails that block body parts) are incapable of doing so.