### PR TITLE
Significantly buffs the impact of "Neural Hypersensitivty"

### DIFF
--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -20,7 +20,10 @@
 			. += M.slowdown
 
 	var/health_deficiency = (getMaxHealth() - health)
-	if(health_deficiency >= 40) //VOREStation Edit Start
+	if(istype(src, /mob/living/carbon/human)) //VOREStation Edit Start
+		var/mob/living/carbon/human/H = src
+		health_deficiency *= H.species.trauma_mod //Species pain sensitivity does not apply to painkillers, so we apply it before
+	if(health_deficiency >= 40)
 		if(chem_effects[CE_PAINKILLER]) //On painkillers? Reduce pain! On anti-painkillers? Increase pain!
 			health_deficiency = max(0, health_deficiency - src.chem_effects[CE_PAINKILLER])
 		if(health_deficiency >= 40) //Still in enough pain for it to be significant?

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/negative.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/negative.dm
@@ -124,7 +124,7 @@
 
 /datum/trait/negative/neural_hypersensitivity
 	name = "Neural Hypersensitivity"
-	desc = "Your nerves are particularly sensitive to physical changes, leading to experiencing twice the intensity of pain and pleasure alike. Doubles traumatic shock."
+	desc = "Your nerves are particularly sensitive to physical changes, leading to experiencing twice the intensity of pain and pleasure alike. Makes all pain effects twice as strong, and occur at half as much damage."
 	cost = -1
 	var_changes = list("trauma_mod" = 2)
 	can_take = ORGANICS

--- a/code/modules/organs/pain.dm
+++ b/code/modules/organs/pain.dm
@@ -40,9 +40,9 @@
 		if(dam > maxdam && (maxdam == 0 || prob(70)) )
 			damaged_organ = E
 			maxdam = dam
-			if(istype(src, /mob/living/carbon/human))
+			if(istype(src, /mob/living/carbon/human)) //VOREStation Edit Start
 				var/mob/living/carbon/human/H = src
-				maxdam *= H.species.trauma_mod
+				maxdam *= H.species.trauma_mod //VOREStation edit end
 	if(damaged_organ && chem_effects[CE_PAINKILLER] < maxdam)
 		if(maxdam > 10 && paralysis)
 			AdjustParalysis(-round(maxdam/10))

--- a/code/modules/organs/pain.dm
+++ b/code/modules/organs/pain.dm
@@ -40,6 +40,9 @@
 		if(dam > maxdam && (maxdam == 0 || prob(70)) )
 			damaged_organ = E
 			maxdam = dam
+			if(istype(src, /mob/living/carbon/human))
+				var/mob/living/carbon/human/H = src
+				maxdam *= H.species.trauma_mod
 	if(damaged_organ && chem_effects[CE_PAINKILLER] < maxdam)
 		if(maxdam > 10 && paralysis)
 			AdjustParalysis(-round(maxdam/10))


### PR DESCRIPTION
Previously, taking neural hypersensitivity made you hit critical roughly twice as earlier. This was an oversight in my implementation, as I thought traumatic_shock was all there was to pain code.

With this buff, the following will occur:

1. Pain messages occur at half as much damage (just 6 damage is enough for something to "hurt badly", 46 for "terrible pain"
2. chance to drop items due to pain occurs at 25 damage rather than, 50, with calculation of (damage*2)/25 as probability
3. Slowdown occurs at 20 damage, and slowdown calculation is changed to account for pain sensitivity.

old slowdown calculation:
If (maxhealth-health-painkillers) >= 40
(maxhealth - health - painkillers) / 25

new calculation:
if( (maxhealth-health)*2 - painkillers) >= 40
((maxhealth - health) * 2 - painkillers) / 25

This was intended functionality of neural hypersensitivty (original PR: https://github.com/VOREStation/VOREStation/pull/9406 ), but back then I did not know that there was more to paincode.

Tested on local. 
1. Pain occurs earlier: yes -> expected
2. Item drop: Likely yes, not conclusive -> expecting? It should work
3. slowdown: definite yes -> expected
4. Does it affect characters withOUT neural hypersensitivity? No -> expected.


n.b.: It already affected  slowdown in a round-about way: when shock_stage reached 10, delay was increased by 3.  It helped reach shock_stage 10 as described in cited PR.