### PR TITLE
Adjustments to Mouse holse, micro hiding, and smole buildings! WOW!

### DIFF
--- a/code/game/objects/micro_structures.dm
+++ b/code/game/objects/micro_structures.dm
@@ -24,6 +24,7 @@
 	for(var/mob/thing in src.contents)
 		visible_message("<span class = 'warning'>\The [thing] tumbles out!</span>")
 		thing.forceMove(get_turf(src.loc))
+		thing.cancel_camera()
 
 	return ..()
 
@@ -54,6 +55,7 @@
 		switch(choice)
 			if("Exit")
 				user.forceMove(get_turf(src.loc))
+				user.cancel_camera()
 				user.visible_message("<span class = 'notice'>\The [user] climbs out of \the [src]!</span>")
 				return
 			if("Move")
@@ -100,6 +102,7 @@
 				if(!do_after(user, 10 SECONDS, exclusive = TRUE))
 					return
 				user.forceMove(choice)
+				user.cancel_camera()
 				var/obj/structure/micro_tunnel/da_oddawun = choice
 				da_oddawun.tunnel_notify(user)
 				return
@@ -183,10 +186,12 @@
 /obj/structure/micro_tunnel/proc/enter_tunnel(mob/living/k)
 	k.visible_message("<span class = 'notice'>\The [k] climbs into \the [src]!</span>")
 	k.forceMove(src)
+	k.cancel_camera()
 	to_chat(k,"<span class = 'notice'>You are inside of \the [src]. It's dark and gloomy inside of here. You can click upon the tunnel to exit, or travel to another tunnel if there are other tunnels linked to it.</span>")
 	tunnel_notify(k)
 
 /obj/structure/micro_tunnel/proc/tunnel_notify(var/mob/living/user)
+	to_chat(user, "<span class = 'notice'>You arrive inside \the [src].</span>")
 	var/our_message = "You can see "
 	var/found_stuff = FALSE
 	for(var/thing in src.contents)
@@ -233,6 +238,7 @@
 		switch(choice)
 			if("Exit")
 				usr.forceMove(get_turf(src.loc))
+				usr.cancel_camera()
 				usr.visible_message("<span class = 'notice'>\The [usr] climbs out of \the [src]!</span>")
 				return
 
@@ -267,6 +273,7 @@
 						contained_mobs |= issamob
 
 				usr.forceMove(our_choice)
+				usr.cancel_camera()
 
 				to_chat(usr,"<span class = 'notice'>You are inside of \the [our_choice]. You can click upon the thing you are in to exit, or travel to a nearby thing if there are other tunnels linked to it.</span>")
 
@@ -283,7 +290,7 @@
 				if(found_stuff)
 					to_chat(usr, "<span class = 'notice'>[our_message]inside of \the [src]!</span>")
 				if(prob(25))
-					our_choice.visible_message("<span class = 'warning'>Something moves inside of \the [src]. . .</span>")
+					our_choice.visible_message("<span class = 'warning'>Something moves inside of \the [our_choice]. . .</span>")
 				return
 			if("Cancel")
 				return
@@ -336,6 +343,7 @@
 
 	usr.visible_message("<span class = 'notice'>\The [usr] climbs into \the [src]!</span>")
 	usr.forceMove(src)
+	usr.cancel_camera()
 	to_chat(usr,"<span class = 'notice'>You are inside of \the [src]. You can click upon the tunnel to exit, or travel to another tunnel if there are other tunnels linked to it.</span>")
 
 	var/our_message = "You can see "
@@ -352,3 +360,20 @@
 		to_chat(usr, "<span class = 'notice'>[our_message]inside of \the [src]!</span>")
 	if(prob(25))
 		visible_message("<span class = 'warning'>Something moves inside of \the [src]. . .</span>")
+
+/obj/effect/mouse_hole_spawner
+	name = "mouse hole spawner"
+	icon = 'icons/obj/landmark_vr.dmi'
+	icon_state = "blue-x"
+	invisibility = 101
+
+	var/chance_to_spawn = 25
+
+/obj/effect/mouse_hole_spawner/Initialize()
+	. = ..()
+
+	if(prob(chance_to_spawn))
+		var/obj/structure/micro_tunnel/tunnel = new (get_turf(src.loc))
+		tunnel.set_dir(dir)
+
+	qdel(src)

--- a/code/game/objects/micro_structures.dm
+++ b/code/game/objects/micro_structures.dm
@@ -339,8 +339,6 @@
 			usr.visible_message("<span class = 'warning'>\The [usr] pulls \the [grabbed] out of \the [src]! ! !</span>")
 			return
 
-	if(tgui_alert(usr,"Do you want to go into \the [src]?","Enter [src]",list("Yes", "No")) != "Yes")
-		return
 	usr.visible_message("<span class = 'notice'>\The [usr] begins climbing into \the [src]!</span>")
 	if(!do_after(usr, 10 SECONDS, exclusive = TRUE))
 		to_chat(usr, "<span class = 'warning'>You didn't go into \the [src]!</span>")

--- a/code/game/objects/micro_structures.dm
+++ b/code/game/objects/micro_structures.dm
@@ -128,7 +128,8 @@
 			var/mob/living/carbon/human/h = user
 			var/mob/living/l = grabbed
 			if(isliving(grabbed))
-				l.attempt_to_scoop(h)
+				if(!l.attempt_to_scoop(h))
+					l.forceMove(get_turf(src.loc))
 			else
 				var/atom/movable/whatever = grabbed
 				whatever.forceMove(get_turf(src.loc))
@@ -140,7 +141,8 @@
 			var/mob/living/simple_mob/a = user
 			var/mob/living/l = grabbed
 			if(!a.has_hands || isliving(grabbed))
-				l.attempt_to_scoop(user)
+				if(!l.attempt_to_scoop(a))
+					l.forceMove(get_turf(src.loc))
 			else
 				var/atom/movable/whatever = grabbed
 				whatever.forceMove(get_turf(src.loc))
@@ -316,6 +318,8 @@
 			var/mob/living/l = grabbed
 			if(isliving(grabbed))
 				l.attempt_to_scoop(h)
+				if(!l.attempt_to_scoop(h))
+					l.forceMove(get_turf(src.loc))
 			else
 				var/atom/movable/whatever = grabbed
 				whatever.forceMove(get_turf(src.loc))
@@ -327,7 +331,8 @@
 			var/mob/living/simple_mob/a = usr
 			var/mob/living/l = grabbed
 			if(!a.has_hands || isliving(grabbed))
-				l.attempt_to_scoop(usr)
+				if(!l.attempt_to_scoop(a))
+					l.forceMove(get_turf(src.loc))
 			else
 				var/atom/movable/whatever = grabbed
 				whatever.forceMove(get_turf(src.loc))

--- a/code/modules/vore/smoleworld/smoleworld_vr.dm
+++ b/code/modules/vore/smoleworld/smoleworld_vr.dm
@@ -194,8 +194,10 @@
 	density = TRUE
 	anchored = TRUE
 	color = "#ffffff"
+	micro_target = TRUE	//Now micros can enter and navigate these things!!!
 	var/health = 75
 	var/damage
+
 //makes it so buildings can be dismaintaled or GodZilla style attacked
 /obj/structure/smolebuilding/attack_hand(mob/user)
 	if(user.a_intent == I_DISARM)

--- a/maps/groundbase/gb-z1.dmm
+++ b/maps/groundbase/gb-z1.dmm
@@ -5677,7 +5677,6 @@
 	id = "engine_public_access";
 	name = "Public Access Shutters";
 	pixel_x = -25;
-	pixel_y = 0;
 	req_access = list(10)
 	},
 /turf/simulated/floor/tiled,
@@ -5851,6 +5850,12 @@
 	outdoors = 0
 	},
 /area/maintenance/groundbase/level1/nwtunnel)
+"mQ" = (
+/obj/effect/mouse_hole_spawner{
+	dir = 8
+	},
+/turf/simulated/floor/outdoors/grass/virgo3c,
+/area/groundbase/level1/southeastspur)
 "mR" = (
 /obj/structure/bed/chair/comfy/orange{
 	dir = 4
@@ -10069,6 +10074,12 @@
 	},
 /turf/simulated/floor/tiled,
 /area/groundbase/civilian/foodplace)
+"xk" = (
+/obj/effect/mouse_hole_spawner{
+	dir = 1
+	},
+/turf/simulated/floor/outdoors/grass/virgo3c,
+/area/groundbase/level1/southwestspur)
 "xm" = (
 /obj/effect/floor_decal/industrial/danger,
 /obj/machinery/atmospherics/pipe/simple/hidden/black,
@@ -10305,6 +10316,12 @@
 	},
 /turf/simulated/floor,
 /area/prison/cell_block/gb)
+"xL" = (
+/obj/effect/mouse_hole_spawner{
+	dir = 8
+	},
+/turf/simulated/floor/outdoors/grass/virgo3c,
+/area/groundbase/level1/eastspur)
 "xM" = (
 /obj/machinery/firealarm,
 /turf/simulated/floor/tiled/dark,
@@ -14284,6 +14301,12 @@
 	},
 /turf/simulated/floor/outdoors/sidewalk/slab/virgo3c,
 /area/groundbase/level1/westspur)
+"HQ" = (
+/obj/effect/mouse_hole_spawner{
+	dir = 8
+	},
+/turf/simulated/floor/outdoors/grass/virgo3c,
+/area/groundbase/level1/centsquare)
 "HR" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -16583,6 +16606,12 @@
 	},
 /turf/simulated/floor/tiled,
 /area/groundbase/engineering/atmos)
+"Nu" = (
+/obj/effect/mouse_hole_spawner{
+	dir = 4
+	},
+/turf/simulated/floor/outdoors/grass/virgo3c,
+/area/groundbase/level1/westspur)
 "Nv" = (
 /turf/simulated/floor/outdoors/grass/forest/virgo3c,
 /area/groundbase/level1/centsquare)
@@ -16730,6 +16759,10 @@
 	},
 /turf/simulated/floor/outdoors/sidewalk/side/virgo3c,
 /area/groundbase/level1/northspur)
+"NM" = (
+/obj/effect/mouse_hole_spawner,
+/turf/simulated/floor/outdoors/grass/virgo3c,
+/area/groundbase/level1/westspur)
 "NN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -16993,6 +17026,12 @@
 /obj/machinery/recharge_station,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/groundbase/command/ai/robot)
+"Ov" = (
+/obj/effect/mouse_hole_spawner{
+	dir = 4
+	},
+/turf/simulated/floor/outdoors/grass/virgo3c,
+/area/groundbase/level1/southeastspur)
 "Ow" = (
 /obj/structure/railing/grey{
 	dir = 1
@@ -19652,6 +19691,14 @@
 	},
 /turf/simulated/floor/carpet/sblucarpet,
 /area/groundbase/security/hos)
+"Vp" = (
+/obj/effect/mouse_hole_spawner{
+	dir = 8
+	},
+/turf/simulated/floor/outdoors/newdirt_nograss/virgo3c{
+	outdoors = 0
+	},
+/area/maintenance/groundbase/level1/nwtunnel)
 "Vq" = (
 /turf/simulated/floor/outdoors/newdirt/virgo3c,
 /area/groundbase/level1/southwestspur)
@@ -26619,7 +26666,7 @@ cB
 cB
 cB
 cB
-cB
+Nu
 AZ
 cv
 px
@@ -28492,7 +28539,7 @@ EZ
 mh
 Iw
 Tf
-vM
+xk
 Wm
 vM
 vM
@@ -28563,7 +28610,7 @@ MO
 MO
 MO
 MO
-FF
+Vp
 FF
 MO
 FF
@@ -29172,7 +29219,7 @@ mk
 cB
 cB
 cB
-cB
+NM
 gv
 Az
 Kh
@@ -30008,7 +30055,7 @@ Eb
 Eb
 Eb
 Eb
-Eb
+HQ
 Eb
 Eb
 Eb
@@ -33544,7 +33591,7 @@ qE
 qE
 qE
 Eb
-Eb
+HQ
 Eb
 Eb
 Eb
@@ -35162,7 +35209,7 @@ Uf
 Uf
 Uf
 Uf
-ck
+Ov
 ck
 TW
 ck
@@ -36231,7 +36278,7 @@ Ah
 Ah
 Ah
 MK
-MK
+xL
 sF
 MK
 MK
@@ -36582,7 +36629,7 @@ Uf
 Uf
 Uf
 Uf
-ck
+mQ
 ck
 Ac
 ck

--- a/maps/groundbase/gb-z2.dmm
+++ b/maps/groundbase/gb-z2.dmm
@@ -3244,6 +3244,10 @@
 /obj/structure/bed/double/padded,
 /turf/simulated/floor/wood,
 /area/groundbase/dorms/room8)
+"jd" = (
+/obj/effect/mouse_hole_spawner,
+/turf/simulated/floor/outdoors/grass/virgo3c,
+/area/groundbase/level2/se)
 "je" = (
 /turf/unsimulated/wall/planetary/virgo3c,
 /area/groundbase/level2/se)
@@ -7808,6 +7812,12 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/groundbase/civilian/chapel)
+"wD" = (
+/obj/effect/mouse_hole_spawner{
+	dir = 4
+	},
+/turf/simulated/floor/outdoors/grass/virgo3c,
+/area/groundbase/level2/nw)
 "wE" = (
 /obj/structure/table/woodentable,
 /obj/machinery/camera/network/civilian,
@@ -9743,6 +9753,12 @@
 /obj/effect/landmark/start/chaplain,
 /turf/simulated/floor/lino,
 /area/groundbase/civilian/chapel/office)
+"Co" = (
+/obj/effect/mouse_hole_spawner{
+	dir = 4
+	},
+/turf/simulated/floor/outdoors/grass/virgo3c,
+/area/groundbase/level2/se)
 "Cq" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -10657,6 +10673,12 @@
 /obj/machinery/alarm,
 /turf/simulated/floor/wood,
 /area/groundbase/dorms/room4)
+"EP" = (
+/obj/effect/mouse_hole_spawner{
+	dir = 8
+	},
+/turf/simulated/floor/outdoors/grass/virgo3c,
+/area/groundbase/level2/ne)
 "EQ" = (
 /obj/structure/filingcabinet,
 /obj/machinery/atmospherics/unary/vent_pump/on,
@@ -11409,6 +11431,12 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
 /area/groundbase/medical/triage)
+"GY" = (
+/obj/effect/mouse_hole_spawner{
+	dir = 1
+	},
+/turf/simulated/floor/outdoors/grass/virgo3c,
+/area/groundbase/level2/nw)
 "GZ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -12469,6 +12497,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/dark,
 /area/groundbase/dorms)
+"JS" = (
+/obj/effect/mouse_hole_spawner{
+	dir = 1
+	},
+/turf/simulated/floor/outdoors/grass/virgo3c,
+/area/groundbase/level2/ne)
 "JT" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -13592,6 +13626,14 @@
 	edge_blending_priority = -1
 	},
 /area/groundbase/level2/ne)
+"MU" = (
+/obj/effect/mouse_hole_spawner{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/virgo3c{
+	edge_blending_priority = -1
+	},
+/area/groundbase/level2/se)
 "MV" = (
 /obj/machinery/alarm{
 	dir = 8
@@ -14253,6 +14295,10 @@
 	},
 /turf/simulated/floor/tiled,
 /area/groundbase/science/xenobot)
+"OM" = (
+/obj/effect/mouse_hole_spawner,
+/turf/simulated/floor/outdoors/grass/virgo3c,
+/area/groundbase/level2/ne)
 "ON" = (
 /turf/unsimulated/wall/planetary/virgo3c,
 /area/groundbase/level2/sw)
@@ -15014,6 +15060,12 @@
 	edge_blending_priority = -1;
 	outdoors = 0
 	},
+/area/groundbase/level2/nw)
+"QS" = (
+/obj/effect/mouse_hole_spawner{
+	dir = 8
+	},
+/turf/simulated/floor/outdoors/grass/virgo3c,
 /area/groundbase/level2/nw)
 "QV" = (
 /obj/structure/bed/chair/office/dark{
@@ -17007,6 +17059,10 @@
 	},
 /turf/simulated/floor/tiled,
 /area/groundbase/science/rnd)
+"WC" = (
+/obj/effect/mouse_hole_spawner,
+/turf/simulated/floor/outdoors/grass/virgo3c,
+/area/groundbase/level2/sw)
 "WD" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/outdoors/grass/virgo3c,
@@ -17784,6 +17840,12 @@
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
+"Zf" = (
+/obj/effect/mouse_hole_spawner{
+	dir = 1
+	},
+/turf/simulated/floor/outdoors/grass/virgo3c,
+/area/groundbase/level2/se)
 "Zg" = (
 /obj/machinery/light/bigfloorlamp,
 /turf/simulated/floor/outdoors/grass/virgo3c,
@@ -20982,7 +21044,7 @@ qr
 Vb
 zb
 Do
-bY
+GY
 bY
 bY
 sN
@@ -21693,7 +21755,7 @@ bY
 bY
 bY
 bY
-bY
+wD
 bY
 Hn
 Ja
@@ -23584,7 +23646,7 @@ jG
 jG
 RL
 jG
-jG
+WC
 Rh
 mZ
 kZ
@@ -23939,7 +24001,7 @@ Ip
 IQ
 gR
 rP
-bY
+GY
 fI
 bY
 FF
@@ -24247,7 +24309,7 @@ bY
 sZ
 bY
 bY
-bY
+QS
 bY
 pw
 pw
@@ -24826,7 +24888,7 @@ lM
 bY
 Oa
 lM
-bY
+wD
 Aq
 bY
 bY
@@ -29319,7 +29381,7 @@ ks
 to
 to
 to
-to
+OM
 Cz
 EQ
 ZD
@@ -30046,7 +30108,7 @@ Eq
 xP
 HJ
 Wj
-to
+JS
 to
 to
 to
@@ -30479,7 +30541,7 @@ to
 NC
 to
 to
-to
+OM
 sW
 sW
 sW
@@ -30815,7 +30877,7 @@ sx
 rK
 CK
 kU
-kU
+MU
 kU
 kU
 Bo
@@ -32055,7 +32117,7 @@ Nw
 KA
 Nw
 to
-to
+EP
 to
 to
 to
@@ -32503,7 +32565,7 @@ UE
 Bo
 cV
 Bo
-Bo
+jd
 ia
 Hc
 TX
@@ -33227,7 +33289,7 @@ SE
 gE
 hA
 an
-Bo
+Zf
 Bo
 Bo
 fk
@@ -35330,7 +35392,7 @@ Bo
 Bo
 Bo
 Bo
-Bo
+Co
 Bo
 Bo
 fk

--- a/maps/groundbase/gb-z3.dmm
+++ b/maps/groundbase/gb-z3.dmm
@@ -443,6 +443,12 @@
 	},
 /turf/simulated/floor/wood,
 /area/groundbase/medical/cmo)
+"hb" = (
+/obj/effect/mouse_hole_spawner{
+	dir = 4
+	},
+/turf/simulated/floor/outdoors/grass/virgo3c,
+/area/groundbase/level3/nw)
 "hl" = (
 /turf/simulated/wall,
 /area/groundbase/level3/escapepad)
@@ -855,6 +861,10 @@
 /obj/effect/landmark/start/explorer,
 /turf/simulated/floor/tiled,
 /area/groundbase/exploration/equipment)
+"nR" = (
+/obj/effect/mouse_hole_spawner,
+/turf/simulated/floor/outdoors/grass/virgo3c,
+/area/groundbase/level3/nw)
 "nU" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 10
@@ -1115,6 +1125,12 @@
 	outdoors = 0
 	},
 /area/groundbase/level3/escapepad)
+"rh" = (
+/obj/effect/mouse_hole_spawner{
+	dir = 1
+	},
+/turf/simulated/floor/outdoors/grass/virgo3c,
+/area/groundbase/level3/nw)
 "ro" = (
 /obj/structure/bed/padded,
 /obj/item/weapon/bedsheet/medical,
@@ -5898,7 +5914,7 @@ Xv
 Xv
 Xv
 qO
-qO
+nR
 fz
 dI
 dR
@@ -5906,7 +5922,7 @@ xO
 Nf
 TH
 fz
-qO
+rh
 qO
 qO
 qO
@@ -6474,7 +6490,7 @@ MF
 qO
 Qa
 Qa
-qO
+nR
 hl
 Rk
 ow
@@ -6606,7 +6622,7 @@ qO
 qO
 qO
 qO
-qO
+hb
 qO
 qO
 qO

--- a/maps/stellar_delight/stellar_delight1.dmm
+++ b/maps/stellar_delight/stellar_delight1.dmm
@@ -892,6 +892,18 @@
 	},
 /turf/simulated/floor/tiled/eris,
 /area/stellardelight/deck1/researchhall)
+"bO" = (
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/mouse_hole_spawner{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/stellardelight/deck1/port)
 "bP" = (
 /obj/machinery/light{
 	dir = 4
@@ -1811,6 +1823,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 1;
 	icon_state = "pipe-c"
+	},
+/obj/effect/mouse_hole_spawner{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/stellardelight/deck1/aft)
@@ -3384,6 +3399,12 @@
 "hg" = (
 /turf/simulated/floor/tiled/techmaint,
 /area/stellardelight/deck1/aft)
+"hh" = (
+/obj/effect/mouse_hole_spawner{
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/maintenance/stellardelight/deck1/portcent)
 "hi" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
@@ -4611,6 +4632,9 @@
 "jw" = (
 /obj/structure/cable/pink{
 	icon_state = "1-2"
+	},
+/obj/effect/mouse_hole_spawner{
+	dir = 8
 	},
 /turf/simulated/floor,
 /area/maintenance/stellardelight/deck1/starboardfore)
@@ -6066,6 +6090,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/effect/mouse_hole_spawner{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/stellardelight/deck1/aft)
 "mE" = (
@@ -6786,6 +6813,12 @@
 /obj/structure/flora/pottedplant/stoutbush,
 /turf/simulated/floor/tiled/techmaint,
 /area/stellardelight/deck1/port)
+"og" = (
+/obj/effect/mouse_hole_spawner{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/maintenance/security_port)
 "oh" = (
 /obj/structure/cable/white{
 	icon_state = "4-8"
@@ -11829,6 +11862,16 @@
 	},
 /turf/simulated/floor/lino,
 /area/chapel/office)
+"yW" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/milspec/color/emerald/half{
+	dir = 4
+	},
+/obj/effect/mouse_hole_spawner{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/stellardelight/deck1/aft)
 "yX" = (
 /obj/effect/shuttle_landmark/premade/sd/deck1/aft,
 /turf/space,
@@ -12439,6 +12482,9 @@
 /obj/structure/cable/green{
 	color = "#42038a";
 	icon_state = "1-8"
+	},
+/obj/effect/mouse_hole_spawner{
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/maintenance/stellardelight/deck1/exploration)
@@ -13974,6 +14020,18 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/techmaint,
 /area/stellardelight/deck1/port)
+"Dr" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/mouse_hole_spawner{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/maintenance/stellardelight/deck1/portaft)
 "Ds" = (
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/airlock/angled_bay/standard/color{
@@ -15730,6 +15788,9 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
+/obj/effect/mouse_hole_spawner{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/stellardelight/deck1/fore)
 "Hy" = (
@@ -16345,6 +16406,9 @@
 "IG" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/effect/mouse_hole_spawner{
+	dir = 1
 	},
 /turf/simulated/floor,
 /area/maintenance/stellardelight/deck1/starboardcent)
@@ -18083,6 +18147,18 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/stellardelight/deck1/fore)
+"Mn" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/mouse_hole_spawner{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/maintenance/stellardelight/deck1/exploration)
 "Mq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -18159,6 +18235,12 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/security_cell_hallway)
+"MC" = (
+/obj/effect/mouse_hole_spawner{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/stellardelight/deck1/starboard)
 "MD" = (
 /obj/structure/cable/green{
 	icon_state = "2-4"
@@ -21928,6 +22010,23 @@
 	},
 /turf/simulated/floor,
 /area/maintenance/stellardelight/deck1/starboardcent)
+"Uv" = (
+/obj/structure/cable/green{
+	color = "#42038a";
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	color = "#42038a";
+	icon_state = "1-4"
+	},
+/obj/effect/mouse_hole_spawner{
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/maintenance/stellardelight/deck1/starboardaft)
 "Uw" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
@@ -31458,7 +31557,7 @@ pP
 qq
 UQ
 Tb
-qq
+Mn
 PL
 DQ
 XM
@@ -31861,7 +31960,7 @@ RL
 Ib
 To
 bQ
-To
+Dr
 aO
 Ib
 To
@@ -32554,7 +32653,7 @@ fc
 eC
 eE
 gY
-gY
+hh
 km
 QB
 zi
@@ -32677,7 +32776,7 @@ Ii
 ks
 Te
 vx
-wf
+og
 Bf
 Yv
 yV
@@ -33125,7 +33224,7 @@ Vw
 ug
 ob
 nS
-Ov
+bO
 zM
 GX
 Fv
@@ -36111,7 +36210,7 @@ LE
 xx
 id
 yx
-ei
+MC
 ou
 Yt
 ei
@@ -36136,7 +36235,7 @@ kv
 jg
 XJ
 DK
-XJ
+yW
 XJ
 Hp
 RA
@@ -37254,7 +37353,7 @@ Dv
 Dv
 Dv
 Dv
-Qz
+Uv
 Dv
 lT
 Dv

--- a/maps/stellar_delight/stellar_delight2.dmm
+++ b/maps/stellar_delight/stellar_delight2.dmm
@@ -7899,6 +7899,9 @@
 /area/stellardelight/deck2/central)
 "rl" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/effect/mouse_hole_spawner{
+	dir = 4
+	},
 /turf/simulated/floor,
 /area/maintenance/stellardelight/deck2/starboardfore)
 "rm" = (
@@ -8986,6 +8989,9 @@
 	icon_state = "pipe-c"
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals5{
+	dir = 4
+	},
+/obj/effect/mouse_hole_spawner{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
@@ -14184,6 +14190,18 @@
 /obj/structure/medical_stand,
 /turf/simulated/floor/tiled/eris/white/bluecorner,
 /area/stellardelight/deck2/triage)
+"FI" = (
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/mouse_hole_spawner{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/maintenance/stellardelight/deck2/portaft)
 "FJ" = (
 /obj/machinery/door/firedoor/glass,
 /obj/structure/cable/green{
@@ -15985,6 +16003,15 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/eris/steel/cargo,
 /area/quartermaster/storage)
+"Jw" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/mouse_hole_spawner{
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/maintenance/stellardelight/deck2/starboardsolars)
 "Jx" = (
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'RADIOACTIVE AREA'";
@@ -21439,6 +21466,16 @@
 	},
 /turf/simulated/floor/lino,
 /area/crew_quarters/bar)
+"VD" = (
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/mouse_hole_spawner{
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/maintenance/stellardelight/deck2/portfore)
 "VE" = (
 /obj/structure/cable/blue{
 	icon_state = "4-8"
@@ -22019,6 +22056,15 @@
 	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/stellardelight/deck2/fuelstorage)
+"WV" = (
+/obj/effect/floor_decal/steeldecal/steel_decals5{
+	dir = 8
+	},
+/obj/effect/mouse_hole_spawner{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/stellardelight/deck2/port)
 "WW" = (
 /obj/machinery/power/apc/angled{
 	dir = 8
@@ -22292,6 +22338,15 @@
 	},
 /turf/simulated/floor/tiled,
 /area/storage/art)
+"XE" = (
+/obj/effect/floor_decal/steeldecal/steel_decals5{
+	dir = 4
+	},
+/obj/effect/mouse_hole_spawner{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/stellardelight/deck2/starboard)
 "XF" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/storage/firstaid/adv{
@@ -30418,7 +30473,7 @@ Gv
 Gv
 Gv
 Uv
-Gv
+VD
 yz
 KL
 WP
@@ -30573,7 +30628,7 @@ Yh
 Yh
 Yh
 AP
-Yh
+FI
 Yh
 Yh
 uL
@@ -30865,7 +30920,7 @@ zp
 eL
 fr
 vU
-MD
+WV
 MD
 fR
 IC
@@ -35687,7 +35742,7 @@ aL
 zS
 Wy
 xh
-Mk
+XE
 Mk
 fs
 Tk
@@ -35699,7 +35754,7 @@ LH
 Mk
 pm
 Mk
-Mk
+XE
 lv
 Aj
 LI
@@ -35980,7 +36035,7 @@ Ie
 HS
 am
 Cc
-aM
+Jw
 aM
 FT
 pj

--- a/maps/stellar_delight/stellar_delight3.dmm
+++ b/maps/stellar_delight/stellar_delight3.dmm
@@ -1580,6 +1580,9 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
+/obj/effect/mouse_hole_spawner{
+	dir = 4
+	},
 /turf/simulated/open,
 /area/crew_quarters/bar)
 "gh" = (
@@ -2437,6 +2440,13 @@
 	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/crew_quarters/heads/chief)
+"jo" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/mouse_hole_spawner{
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/maintenance/stellardelight/deck3/starboardaft)
 "jp" = (
 /obj/structure/closet,
 /obj/random/contraband,
@@ -4853,6 +4863,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/open,
 /area/stellardelight/deck2/port)
+"rW" = (
+/obj/effect/mouse_hole_spawner{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/maintenance/stellardelight/deck3/portfore)
 "rX" = (
 /obj/machinery/light{
 	dir = 1
@@ -5173,6 +5189,9 @@
 "tc" = (
 /obj/structure/cable/blue{
 	icon_state = "1-4"
+	},
+/obj/effect/mouse_hole_spawner{
+	dir = 8
 	},
 /turf/simulated/floor,
 /area/maintenance/stellardelight/deck3/starboardfore)
@@ -10286,6 +10305,12 @@
 	},
 /turf/simulated/floor,
 /area/maintenance/stellardelight/deck3/starboardfore)
+"Lo" = (
+/obj/effect/mouse_hole_spawner{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/maintenance/stellardelight/deck3/portaft)
 "Lr" = (
 /obj/effect/shuttle_landmark/premade/sd/deck3/starboardairlock,
 /turf/space,
@@ -11380,6 +11405,9 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
+/obj/effect/mouse_hole_spawner{
+	dir = 8
+	},
 /turf/simulated/floor,
 /area/maintenance/stellardelight/deck3/starboardcent)
 "OI" = (
@@ -12211,6 +12239,9 @@
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
+	},
+/obj/effect/mouse_hole_spawner{
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/maintenance/stellardelight/deck3/portcent)
@@ -13680,6 +13711,9 @@
 	icon_state = "1-2"
 	},
 /obj/effect/landmark/vermin,
+/obj/effect/mouse_hole_spawner{
+	dir = 8
+	},
 /turf/simulated/open,
 /area/crew_quarters/bar)
 "Xd" = (
@@ -21615,7 +21649,7 @@ pf
 Ns
 Ns
 Ns
-Ns
+rW
 Ns
 eF
 IP
@@ -21654,7 +21688,7 @@ IN
 xi
 dE
 dE
-dE
+Lo
 dE
 Sw
 dE
@@ -27049,7 +27083,7 @@ if
 if
 Ne
 iS
-iS
+jo
 Kz
 Dk
 qY

--- a/maps/tether/tether-01-surface1.dmm
+++ b/maps/tether/tether-01-surface1.dmm
@@ -3157,6 +3157,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/mouse_hole_spawner,
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/north_stairs_one)
 "afb" = (
@@ -7105,6 +7106,9 @@
 	},
 /obj/machinery/camera/network/civilian{
 	dir = 1
+	},
+/obj/effect/mouse_hole_spawner{
+	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/public_garden_one)
@@ -13056,6 +13060,9 @@
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
+	},
+/obj/effect/mouse_hole_spawner{
+	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/lower/solars)
@@ -28493,6 +28500,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/effect/mouse_hole_spawner{
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/visitor_lodging)
 "aWm" = (
@@ -31820,6 +31830,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/tether/surfacebase/funny/hideyhole)
+"bXC" = (
+/obj/effect/mouse_hole_spawner{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/lower/xenoflora)
 "bZC" = (
 /turf/simulated/floor/looking_glass,
 /area/looking_glass/lg_1)
@@ -32507,6 +32523,18 @@
 /obj/item/weapon/soap/nanotrasen,
 /turf/simulated/floor/tiled/freezer,
 /area/tether/surfacebase/security/brig/bathroom)
+"elf" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/brown/border,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 8
+	},
+/obj/effect/mouse_hole_spawner,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/lowernorthhall)
 "emK" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -32586,6 +32614,13 @@
 	},
 /turf/simulated/floor,
 /area/tether/surfacebase/security/gasstorage)
+"eyq" = (
+/obj/structure/catwalk,
+/obj/effect/mouse_hole_spawner{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/lower/xenoflora)
 "ezn" = (
 /obj/machinery/power/apc{
 	dir = 1;
@@ -33335,6 +33370,25 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/carpet/gaycarpet,
 /area/tether/surfacebase/funny/clownoffice)
+"gHx" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/floor_decal/rust,
+/obj/machinery/atmospherics/pipe/simple/visible/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/supply{
+	dir = 4
+	},
+/obj/effect/mouse_hole_spawner{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/lower/research)
 "gIa" = (
 /obj/structure/railing{
 	dir = 8
@@ -34102,6 +34156,11 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/lowerhall)
+"izF" = (
+/obj/structure/flora/pottedplant/stoutbush,
+/obj/effect/mouse_hole_spawner,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/tram)
 "iEk" = (
 /obj/machinery/button/remote/blast_door{
 	dir = 8;
@@ -34386,6 +34445,9 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/effect/mouse_hole_spawner{
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
@@ -35062,6 +35124,14 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/brig)
+"lma" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/mouse_hole_spawner{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/lower/research)
 "loc" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/manifold/visible/scrubbers{
@@ -36528,6 +36598,13 @@
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/tether/surfacebase/security/brig/bathroom)
+"oDt" = (
+/obj/structure/flora/pottedplant/stoutbush,
+/obj/effect/mouse_hole_spawner{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/tram)
 "oId" = (
 /obj/structure/closet{
 	desc = "Dents and old flaky paint blanket this old storage unit.";
@@ -36769,6 +36846,22 @@
 "pCj" = (
 /turf/simulated/wall/r_wall,
 /area/tether/surfacebase/security/brig)
+"pDY" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/obj/effect/mouse_hole_spawner{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/lower/first_west)
 "pFF" = (
 /obj/structure/catwalk,
 /obj/structure/cable/green{
@@ -38392,6 +38485,24 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/visitor_laundry)
+"uku" = (
+/obj/effect/floor_decal/corner/lightgrey{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/lightgrey{
+	dir = 5
+	},
+/obj/effect/floor_decal/borderfloor/shifted{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey/border/shifted{
+	dir = 1
+	},
+/obj/effect/mouse_hole_spawner{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/surface_one_hall)
 "ulr" = (
 /obj/effect/map_helper/airlock/door/int_door,
 /obj/machinery/access_button/airlock_interior{
@@ -39096,6 +39207,24 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/lower/mining_eva)
+"wDf" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 10
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 9
+	},
+/obj/effect/mouse_hole_spawner{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/surface_one_hall)
 "wOK" = (
 /obj/effect/floor_decal/rust,
 /obj/machinery/light/small{
@@ -39436,6 +39565,26 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/brig/storage)
+"xJs" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/orange{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/mouse_hole_spawner{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/steel_dirty,
+/area/maintenance/lower/atmos)
 "xOH" = (
 /obj/effect/floor_decal/spline/plain{
 	dir = 8
@@ -47215,7 +47364,7 @@ aah
 aah
 aah
 ahl
-ahL
+pDY
 anP
 adu
 ahl
@@ -47962,7 +48111,7 @@ awn
 awn
 aBP
 aCw
-aLv
+lma
 aCY
 aCZ
 aLv
@@ -49073,7 +49222,7 @@ aru
 aoH
 bcd
 apu
-aqb
+eyq
 ate
 apu
 bcd
@@ -49797,7 +49946,7 @@ ayH
 azN
 agM
 agM
-aAw
+gHx
 aBO
 aah
 aah
@@ -50782,7 +50931,7 @@ apu
 ahc
 agM
 bcp
-atL
+bXC
 atL
 atL
 atj
@@ -52030,7 +52179,7 @@ adP
 aao
 cPX
 afO
-aBB
+elf
 aCr
 dYd
 aEh
@@ -52959,7 +53108,7 @@ aUW
 aWf
 aWE
 aUb
-aXr
+xJs
 aXJ
 aYe
 aYe
@@ -53326,7 +53475,7 @@ anZ
 aol
 aoT
 apE
-aqh
+wDf
 aqL
 doa
 aqL
@@ -53355,7 +53504,7 @@ aCJ
 aCJ
 agM
 yaA
-vrS
+uku
 ayG
 qBb
 aJR
@@ -55465,7 +55614,7 @@ aah
 aah
 aah
 atx
-atW
+oDt
 auA
 auS
 avA
@@ -56197,7 +56346,7 @@ lsh
 wek
 pvL
 hOH
-atW
+izF
 atx
 aad
 aad

--- a/maps/tether/tether-02-surface2.dmm
+++ b/maps/tether/tether-02-surface2.dmm
@@ -16387,6 +16387,9 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/effect/mouse_hole_spawner{
+	dir = 1
+	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_two_hall)
 "aBJ" = (
@@ -23644,6 +23647,9 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/rust,
+/obj/effect/mouse_hole_spawner{
+	dir = 1
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/lower/public_garden_maintenence/upper)
 "aPw" = (
@@ -33136,6 +33142,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/tether/surfacebase/funny/hideyhole)
+"ftF" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/mouse_hole_spawner{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/tether/surfacebase/surface_two_hall)
 "fxr" = (
 /obj/machinery/light{
 	dir = 8
@@ -33172,6 +33187,19 @@
 	},
 /turf/simulated/floor/plating,
 /area/tether/surfacebase/fish_farm)
+"fYb" = (
+/obj/structure/catwalk,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/effect/mouse_hole_spawner{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/lower/mining)
 "gaR" = (
 /obj/item/device/radio/intercom/locked/ai_private{
 	dir = 4;
@@ -33391,6 +33419,12 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/ai_upload)
+"idw" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/yellow/border,
+/obj/effect/mouse_hole_spawner,
+/turf/simulated/floor/tiled/techmaint,
+/area/tether/surfacebase/surface_two_hall)
 "ilH" = (
 /obj/structure/table/standard,
 /obj/item/weapon/aiModule/reset,
@@ -34032,6 +34066,12 @@
 /obj/effect/floor_decal/techfloor,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/ai_upload)
+"nOG" = (
+/obj/effect/mouse_hole_spawner{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/tether/surfacebase/fish_farm)
 "nPO" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -34194,6 +34234,15 @@
 	},
 /turf/simulated/floor/bluegrid,
 /area/ai_upload)
+"pXo" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/mouse_hole_spawner{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/tether/surfacebase/surface_two_hall)
 "pYH" = (
 /obj/effect/floor_decal/techfloor/corner,
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -34202,6 +34251,12 @@
 /obj/machinery/porta_turret,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/ai_upload)
+"qbq" = (
+/obj/effect/mouse_hole_spawner{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint2)
 "qia" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -34545,6 +34600,20 @@
 	},
 /turf/simulated/floor/water/indoors,
 /area/tether/surfacebase/fish_farm)
+"sLA" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/mouse_hole_spawner{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/maintenance/readingrooms)
 "sLP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
@@ -34660,6 +34729,18 @@
 /obj/effect/floor_decal/corner_techfloor_grid,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/lower/south)
+"tuZ" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner_techfloor_grid{
+	dir = 6
+	},
+/obj/effect/mouse_hole_spawner{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/maintenance/lower/south)
 "tyG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -34708,6 +34789,21 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ai_upload)
+"tMW" = (
+/obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/simple/visible/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/visible/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/mouse_hole_spawner{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/lower/south)
 "tPB" = (
 /turf/simulated/floor/grass,
 /area/chapel/main)
@@ -34924,6 +35020,13 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
+"vok" = (
+/obj/structure/catwalk,
+/obj/effect/mouse_hole_spawner{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/lower/south)
 "voE" = (
 /obj/effect/floor_decal/corner_techfloor_grid,
 /obj/effect/floor_decal/corner_techfloor_grid{
@@ -35118,6 +35221,13 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/tether/surfacebase/medical/breakroom)
+"xem" = (
+/obj/structure/catwalk,
+/obj/effect/mouse_hole_spawner{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/lower/atmos)
 "xfa" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
@@ -41110,7 +41220,7 @@ aBB
 aCm
 aDj
 aDV
-aCm
+nOG
 aBB
 aOM
 aJf
@@ -43978,7 +44088,7 @@ aTA
 aUo
 aPJ
 aQw
-aQw
+qbq
 aXv
 aYd
 aYD
@@ -44711,7 +44821,7 @@ baA
 baW
 bbf
 aJX
-baW
+xem
 aIn
 aJZ
 baX
@@ -45986,7 +46096,7 @@ baW
 baW
 baW
 baW
-baW
+xem
 baW
 beT
 baz
@@ -46225,7 +46335,7 @@ ayF
 aEK
 ayF
 aFZ
-ayF
+ftF
 aAh
 aHp
 aHK
@@ -47798,7 +47908,7 @@ aAG
 aKw
 aLj
 aLO
-aMv
+idw
 aNj
 aNR
 aOH
@@ -49335,7 +49445,7 @@ avI
 awk
 avD
 axG
-ayl
+pXo
 ayO
 azh
 azR
@@ -49389,7 +49499,7 @@ aLY
 aLY
 aLY
 aLY
-aLX
+vok
 bdQ
 bdb
 aIo
@@ -49756,7 +49866,7 @@ aiK
 aiK
 aiK
 aiK
-auX
+fYb
 asV
 atY
 anW
@@ -50093,7 +50203,7 @@ aSo
 aSo
 bdu
 aSo
-aSo
+tMW
 aSo
 aSo
 bbR
@@ -50246,7 +50356,7 @@ bIG
 bde
 bdE
 csF
-cMd
+sLA
 jWK
 cMd
 gus
@@ -50790,7 +50900,7 @@ aRc
 aRH
 aSp
 aTp
-aSp
+tuZ
 aSp
 aSp
 aWy

--- a/maps/tether/tether-03-surface3.dmm
+++ b/maps/tether/tether-03-surface3.dmm
@@ -29491,6 +29491,9 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
+/obj/effect/mouse_hole_spawner{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/vacant/vacant_shop)
 "aYf" = (
@@ -37522,6 +37525,9 @@
 /obj/effect/floor_decal/techfloor/corner{
 	dir = 4
 	},
+/obj/effect/mouse_hole_spawner{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/maintenance/lower/medsec_maintenance)
 "boe" = (
@@ -37842,6 +37848,24 @@
 "bzK" = (
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/security/processing)
+"bCV" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 9
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 10
+	},
+/obj/effect/mouse_hole_spawner{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/surface_three_hall)
 "bEd" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -38461,6 +38485,22 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/shuttle_pad)
+"dDI" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/effect/mouse_hole_spawner{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/surface_three_hall)
 "dDQ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -38632,6 +38672,12 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/iaa/officeb)
+"eiR" = (
+/obj/effect/mouse_hole_spawner{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/southhall)
 "ely" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -40369,6 +40415,22 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/lower/third_south)
+"knW" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/obj/effect/mouse_hole_spawner{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/surface_three_hall)
 "kqo" = (
 /turf/simulated/wall,
 /area/tether/surfacebase/security/iaa/officea)
@@ -40974,6 +41036,21 @@
 	},
 /turf/simulated/floor/carpet/blue,
 /area/tether/surfacebase/security/breakroom)
+"mmk" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/lightgrey/border,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/mouse_hole_spawner,
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/surface_three_hall)
 "mwz" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 9
@@ -42279,6 +42356,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/grass,
 /area/hydroponics)
+"qGC" = (
+/obj/effect/mouse_hole_spawner{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/tether/surfacebase/shuttle_pad)
 "qGK" = (
 /obj/structure/table/reinforced,
 /obj/item/device/radio{
@@ -42330,6 +42413,16 @@
 /obj/machinery/portable_atmospherics/hydroponics,
 /turf/simulated/floor/grass,
 /area/hydroponics)
+"qQF" = (
+/obj/machinery/alarm{
+	pixel_y = 28
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/effect/mouse_hole_spawner{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/southhall)
 "qQZ" = (
 /obj/effect/floor_decal/techfloor,
 /obj/machinery/firealarm{
@@ -42943,6 +43036,12 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/barrestroom)
+"sUZ" = (
+/obj/effect/mouse_hole_spawner{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/tether/surfacebase/barbackmaintenance)
 "sVC" = (
 /obj/machinery/door/firedoor/glass/hidden/shuttle,
 /obj/machinery/door/blast/shuttle/open{
@@ -44190,6 +44289,27 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/tether/surfacebase/surface_three_hall)
+"xna" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 9
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 6
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey/bordercorner2{
+	dir = 1
+	},
+/obj/effect/mouse_hole_spawner{
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_three_hall)
@@ -50842,7 +50962,7 @@ eCg
 agw
 agw
 agw
-air
+knW
 aWF
 akn
 akS
@@ -54266,7 +54386,7 @@ aoX
 aqJ
 aoX
 aoX
-aix
+dDI
 avG
 apX
 alP
@@ -55262,7 +55382,7 @@ agw
 arF
 aix
 ajR
-apX
+mmk
 agw
 ats
 atH
@@ -55818,7 +55938,7 @@ aWV
 ali
 ali
 ali
-ali
+bCV
 ali
 uiW
 ali
@@ -57289,7 +57409,7 @@ aKg
 aKg
 aKe
 aOc
-aKe
+qGC
 aKg
 aKg
 aLA
@@ -57303,7 +57423,7 @@ bhm
 fsd
 qbo
 ome
-beU
+eiR
 gRG
 laB
 beU
@@ -58932,7 +59052,7 @@ asA
 aNy
 aNI
 aSb
-agp
+xna
 keg
 ycf
 ail
@@ -59265,7 +59385,7 @@ beh
 ayM
 aya
 bcd
-bcd
+sUZ
 ayE
 bfP
 aAl
@@ -59860,7 +59980,7 @@ aac
 aac
 aac
 aPs
-bhv
+qQF
 bhA
 bhC
 pSu

--- a/maps/tether/tether-04-transit.dmm
+++ b/maps/tether/tether-04-transit.dmm
@@ -97,6 +97,15 @@
 /obj/machinery/camera/network/civilian,
 /turf/simulated/floor/midpoint_glass/reinf,
 /area/tether/midpoint)
+"hW" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/mouse_hole_spawner{
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/tether/midpoint)
 "it" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/firedoor/glass/hidden{
@@ -151,6 +160,10 @@
 "kz" = (
 /turf/space/v3b_midpoint,
 /area/tether/transit)
+"lG" = (
+/obj/effect/mouse_hole_spawner,
+/turf/simulated/floor/wood,
+/area/tether/midpoint)
 "lL" = (
 /obj/effect/blocker,
 /turf/space/v3b_midpoint,
@@ -252,6 +265,12 @@
 	},
 /obj/machinery/media/jukebox,
 /turf/simulated/floor/tiled/monotile,
+/area/tether/midpoint)
+"rW" = (
+/obj/effect/mouse_hole_spawner{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
 /area/tether/midpoint)
 "sw" = (
 /obj/effect/floor_decal/corner/lightgrey{
@@ -9076,7 +9095,7 @@ pK
 pK
 Pz
 Wc
-pK
+rW
 pK
 Wc
 Pz
@@ -9923,7 +9942,7 @@ mT
 mT
 pK
 pK
-pK
+lG
 Dz
 Qv
 Hs
@@ -10502,7 +10521,7 @@ Hs
 Hs
 Dz
 PF
-Or
+hW
 pK
 pK
 mT

--- a/maps/tether/tether-05-station1.dmm
+++ b/maps/tether/tether-05-station1.dmm
@@ -16579,6 +16579,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/quartermaster/delivery)
+"cCM" = (
+/obj/effect/mouse_hole_spawner{
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/maintenance/station/exploration)
 "cDf" = (
 /obj/machinery/atmospherics/portables_connector/aux{
 	dir = 1
@@ -17358,6 +17364,9 @@
 	dir = 10
 	},
 /obj/structure/disposalpipe/segment,
+/obj/effect/mouse_hole_spawner{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/tether/station/dock_one)
 "doi" = (
@@ -21645,6 +21654,18 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/shuttle/excursion/general)
+"hFL" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/lightgrey/border,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 1
+	},
+/obj/effect/mouse_hole_spawner,
+/turf/simulated/floor/tiled,
+/area/tether/station/dock_two)
 "hFV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 10
@@ -25530,6 +25551,25 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/exploration/crew)
+"lcy" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 10
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 9
+	},
+/obj/effect/mouse_hole_spawner{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/station/atrium)
 "lfI" = (
 /obj/machinery/access_button{
 	command = "cycle_interior";
@@ -26902,6 +26942,12 @@
 	fancy_shuttle_tag = "explo"
 	},
 /area/shuttle/excursion/cockpit)
+"mmt" = (
+/obj/effect/mouse_hole_spawner{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/maintenance/station/exploration)
 "mmJ" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -27431,6 +27477,9 @@
 "mKL" = (
 /obj/structure/bed/chair/bar_stool,
 /obj/random/plushie,
+/obj/effect/mouse_hole_spawner{
+	dir = 1
+	},
 /turf/simulated/floor,
 /area/maintenance/station/eng_lower)
 "mKM" = (
@@ -47659,7 +47708,7 @@ jOH
 acn
 mnT
 vYJ
-vYJ
+lcy
 wRJ
 tRn
 lSs
@@ -50075,7 +50124,7 @@ lIB
 lIB
 lIB
 xdE
-pMf
+mmt
 gGC
 etY
 aac
@@ -50350,7 +50399,7 @@ etY
 hrw
 pMf
 pMf
-pMf
+cCM
 biX
 lUV
 xdE
@@ -53498,7 +53547,7 @@ aaa
 fLT
 wMe
 kOK
-klo
+hFL
 fLT
 aaa
 aaa


### PR DESCRIPTION
Just some stuff that came up with another round of testing.

Adds a bunch of mouse hole spawners to the various maps too. These are exclusively in hallways, maint tunnels, and on the outside of buildings, MOSTLY a little out of the way! These spawners have a 25% chance to spawn a mouse hole, so, there's a bunch of spawners, but not super tons of the holes usually. Rates might need to be adjusted on the tether a little, maybe! We'll see. I figured this would let people play with the new feature a little, without making it a whole thing. Mouse holes are pretty obvious when they are there, so people shouuuldn't be able to use it to snoop too much.