### PR TITLE
Adjust voice/emote sound settings

### DIFF
--- a/code/modules/emotes/emote_mob.dm
+++ b/code/modules/emotes/emote_mob.dm
@@ -204,7 +204,7 @@
 
 		if(!T) return
 		if(client)
-			playsound(T, pick(emote_sound), 25, TRUE, falloff = 1 , is_global = TRUE, frequency = ourfreq, ignore_walls = FALSE, preference = /datum/client_preference/emote_sounds)
+			playsound(src, pick(emote_sound), 25, TRUE, extrarange = -3.5, falloff = 1, frequency = ourfreq, preference = /datum/client_preference/emote_sounds)
 
 		var/list/in_range = get_mobs_and_objs_in_view_fast(T,range,2,remote_ghosts = client ? TRUE : FALSE)
 		var/list/m_viewers = in_range["mobs"]

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -408,12 +408,12 @@ var/list/channel_to_radio_key = new
 		message = "([message_mode == "headset" ? "Common" : capitalize(message_mode)]) [message]" //Adds radio keys used if available
 	if(whispering)
 		if(do_sound && message)
-			playsound(T, pick(voice_sounds_list), 25, TRUE, extrarange = -6, falloff = 1 , is_global = TRUE, frequency = ourfreq, ignore_walls = FALSE, preference = /datum/client_preference/whisper_sounds)
+			playsound(T, pick(voice_sounds_list), 25, TRUE, extrarange = -6, falloff = 1, frequency = ourfreq, preference = /datum/client_preference/whisper_sounds)
 
 		log_whisper(message, src)
 	else
 		if(do_sound && message)
-			playsound(T, pick(voice_sounds_list), 75, TRUE, falloff = 1 , is_global = TRUE, frequency = ourfreq, ignore_walls = FALSE, preference = /datum/client_preference/say_sounds)
+			playsound(T, pick(voice_sounds_list), 75, TRUE, extrarange = -3.5, falloff = 1, frequency = ourfreq, preference = /datum/client_preference/say_sounds)
 		log_say(message, src)
 	return 1
 


### PR DESCRIPTION
Makes it so that the voice and emote sounds do not use the ignore_walls variable, and adjusts the extrarange variable to reach normal screen view range.

This was a frustrating decision to make. I adjusted the ignore_walls variable originally, because I wanted to make sure you were only hearing people you could see.

But. The way it works is, that first, it finds the turf of the sound source, then it checks to see who that turf can see, and delivers the sound to those ones.

This means that it will never deliver those sounds to anyone inside of micro holders, lockers, tummies, or anyone inside of anything, really. You can't even hear yourself, because the turf whatever you are in is on can't see you!

That's silly, but that's how it works. Maybe someone can make it better someday. 

SO, you will be able to hear say, whisper, and me sounds through walls now. I did ensure that that these sounds only go the standard view distance though, so you shouldn't hear people who would be off screen from you. (Whispers can only be heard from 2 tiles away)

I figured that, being as a major point of the sounds is knowing when you got a message, so not hearing them in very common situations is more of a priority than hearing some for people who are near you but out of sight. I'd prefer to have my cake and eat it too, but I don't know how to do that in this case, so! It be how it do.