### PR TITLE
[TGUI] Migration of deprecated packages

### DIFF
--- a/tgui/.gitignore
+++ b/tgui/.gitignore
@@ -15,6 +15,8 @@ package-lock.json
 ## Build artifacts
 /public/.tmp/**/*
 /public/*.map
+/public/tgui-bench.bundle.js
+/public/tgui-bench.bundle.css
 
 ## Previously ignored locations that are kept to avoid confusing git
 ## while transitioning to a new project structure.

--- a/tgui/package.json
+++ b/tgui/package.json
@@ -43,7 +43,6 @@
     "eslint-plugin-radar": "^0.2.1",
     "eslint-plugin-react": "^7.30.0",
     "eslint-plugin-unused-imports": "^2.0.0",
-    "file-loader": "^6.2.0",
     "inferno": "^7.4.11",
     "jest": "^28.1.0",
     "jest-circus": "^28.1.0",
@@ -56,7 +55,6 @@
     "style-loader": "^3.3.1",
     "terser-webpack-plugin": "^5.3.1",
     "typescript": "^4.6.4",
-    "url-loader": "^4.1.1",
     "webpack": "^5.72.1",
     "webpack-bundle-analyzer": "^4.5.0",
     "webpack-cli": "^4.9.2"

--- a/tgui/webpack.config.js
+++ b/tgui/webpack.config.js
@@ -85,14 +85,7 @@ module.exports = (env = {}, argv) => {
         },
         {
           test: /\.(png|jpg|svg)$/,
-          use: [
-            {
-              loader: require.resolve('url-loader'),
-              options: {
-                esModule: false,
-              },
-            },
-          ],
+          type: 'asset/inline',
         },
       ],
     },

--- a/tgui/yarn.lock
+++ b/tgui/yarn.lock
@@ -4614,18 +4614,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"file-loader@npm:^6.2.0":
-  version: 6.2.0
-  resolution: "file-loader@npm:6.2.0"
-  dependencies:
-    loader-utils: ^2.0.0
-    schema-utils: ^3.0.0
-  peerDependencies:
-    webpack: ^4.0.0 || ^5.0.0
-  checksum: faf43eecf233f4897b0150aaa874eeeac214e4f9de49738a9e0ef734a30b5260059e85b7edadf852b98e415f875bd5f12587768a93fd52aaf2e479ecf95fab20
-  languageName: node
-  linkType: hard
-
 "file-uri-to-path@npm:1.0.0":
   version: 1.0.0
   resolution: "file-uri-to-path@npm:1.0.0"
@@ -8202,7 +8190,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"schema-utils@npm:^3.0.0, schema-utils@npm:^3.1.0, schema-utils@npm:^3.1.1":
+"schema-utils@npm:^3.1.0, schema-utils@npm:^3.1.1":
   version: 3.1.1
   resolution: "schema-utils@npm:3.1.1"
   dependencies:
@@ -9001,7 +8989,6 @@ __metadata:
     eslint-plugin-radar: ^0.2.1
     eslint-plugin-react: ^7.30.0
     eslint-plugin-unused-imports: ^2.0.0
-    file-loader: ^6.2.0
     inferno: ^7.4.11
     jest: ^28.1.0
     jest-circus: ^28.1.0
@@ -9014,7 +9001,6 @@ __metadata:
     style-loader: ^3.3.1
     terser-webpack-plugin: ^5.3.1
     typescript: ^4.6.4
-    url-loader: ^4.1.1
     webpack: ^5.72.1
     webpack-bundle-analyzer: ^4.5.0
     webpack-cli: ^4.9.2
@@ -9500,23 +9486,6 @@ __metadata:
   dependencies:
     punycode: ^2.1.0
   checksum: 7167432de6817fe8e9e0c9684f1d2de2bb688c94388f7569f7dbdb1587c9f4ca2a77962f134ec90be0cc4d004c939ff0d05acc9f34a0db39a3c797dada262633
-  languageName: node
-  linkType: hard
-
-"url-loader@npm:^4.1.1":
-  version: 4.1.1
-  resolution: "url-loader@npm:4.1.1"
-  dependencies:
-    loader-utils: ^2.0.0
-    mime-types: ^2.1.27
-    schema-utils: ^3.0.0
-  peerDependencies:
-    file-loader: "*"
-    webpack: ^4.0.0 || ^5.0.0
-  peerDependenciesMeta:
-    file-loader:
-      optional: true
-  checksum: c1122a992c6cff70a7e56dfc2b7474534d48eb40b2cc75467cde0c6972e7597faf8e43acb4f45f93c2473645dfd803bcbc20960b57544dd1e4c96e77f72ba6fd
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR does not directly change anything in the bundle itself, so UIs should stay the same.

url-loader and file-loader has been deprecated as of webpack 5 (no updates/no new commits for over 2 years).

This has been tested with following UIs: Player Notes (incl. Player Notes Info), Vorepanel, APC, PDA, Communicator, ID Card
Also, following executeables have been tested: tgui.bat, tgui-bench.bat, tgui-dev-server.bat

Additionally more rules for gitignore to ignore bundle files generated by the benchmark executeable.
