### PR TITLE
Buffs artifact spawns in the map. Lowers rogueminer.

### DIFF
--- a/code/controllers/subsystems/xenoarch.dm
+++ b/code/controllers/subsystems/xenoarch.dm
@@ -1,8 +1,8 @@
 #define XENOARCH_SPAWN_CHANCE 0.5
 #define DIGSITESIZE_LOWER 4
 #define DIGSITESIZE_UPPER 12
-#define ARTIFACTSPAWNNUM_LOWER 6
-#define ARTIFACTSPAWNNUM_UPPER 12
+#define ARTIFACTSPAWNNUM_LOWER 12
+#define ARTIFACTSPAWNNUM_UPPER 24
 
 //
 // Xenoarch subsystem handles initialization of Xenoarcheaology artifacts and digsites.

--- a/code/modules/rogueminer_vr/zonemaster.dm
+++ b/code/modules/rogueminer_vr/zonemaster.dm
@@ -171,8 +171,8 @@
 	#define XENOARCH_SPAWN_CHANCE 0.3
 	#define DIGSITESIZE_LOWER 4
 	#define DIGSITESIZE_UPPER 12
-	#define ARTIFACTSPAWNNUM_LOWER 6
-	#define ARTIFACTSPAWNNUM_UPPER 12 //Replace with difficulty-based ones.
+	#define ARTIFACTSPAWNNUM_LOWER 1
+	#define ARTIFACTSPAWNNUM_UPPER 1 //Replace with difficulty-based ones.
 
 	if(!M.mineral && prob(rm_controller.diffstep_chances[rm_controller.diffstep])) //Difficulty translates directly into ore chance
 		rm_controller.dbg("ZM(par): Adding mineral to [M.x],[M.y].")


### PR DESCRIPTION
Artifacts used to be confined to about one Z level: The mining asteroid.

Now with there being a LOT more Z levels, this number really hasn't changed and it means that artifacts are harder to find, being spread across many more Z levels.

This could mean that if you had bad RNG, you would have 6 artifacts(large artifacts) spread across every Z level, meaning xenoarch would very quickly exhaust the possible artifacts they had nearby and after exploring every Z level that spawns artifacts, they'd only have 6 artifacts. This meant that with bad luck, xenoarch could very quickly reach their 'end point' and have to ask Mining to borrow their rogueminer shuttle (which was bugged, as mentioned below)

This doubles that number so now there is 12 artifacts that spawn by default, up to 24. I felt like increasing this even further to 18/36, but I felt like that would be too large of a jump. This should be a better fix and feedback can be given on if the numbers still need to be increased further.

Meanwhile, roguemining would spawn 6 to 12 artifacts per mining area visited. This meant each rogue mining area had as many artifacts as the entire universe had. This was obviously unintended, so this fixed that by lowering it to 0 or 1 artifact per roguemining Z level.