### PR TITLE
Make build mode not crash your client

### DIFF
--- a/code/modules/admin/verbs/buildmode.dm
+++ b/code/modules/admin/verbs/buildmode.dm
@@ -627,6 +627,9 @@
 /obj/effect/bmode/buildmode/proc/get_path_from_partial_text(default_path)
 	var/desired_path = tgui_input_text(usr, "Enter full or partial typepath.","Typepath","[default_path]")
 
+	if(!desired_path)	//VOREStation Add - If you don't give it anything it builds a list of every possible thing in the game and crashes your client.
+		return			//VOREStation Add - And the main way for it to do that is to push the cancel button, which should just do nothing. :U
+
 	var/list/types = typesof(/atom)
 	var/list/matches = list()
 


### PR DESCRIPTION
If you right click on advanced build mode and then push cancel, or just push confirm without entering anything, it tries to build a list of every possible thing in the game, and usually crashes your client trying to display that list.

This makes it just not do anything if you don't give it an input. If you want to have a list of everything in the game you can probably still do that if you just enter / or whatever.