### PR TITLE
Adds traits that reduce nutrition gain

### DIFF
--- a/code/modules/mob/living/carbon/human/human_vr.dm
+++ b/code/modules/mob/living/carbon/human/human_vr.dm
@@ -15,3 +15,7 @@
 
 /mob/living/carbon/human/get_digestion_nutrition_modifier()
 	return species.digestion_nutrition_modifier
+
+/mob/living/carbon/human/get_digestion_efficiency_modifier()
+	return species.digestion_efficiency
+

--- a/code/modules/mob/living/carbon/human/species/species_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/species_vr.dm
@@ -8,6 +8,7 @@
 
 	var/organic_food_coeff = 1
 	var/synthetic_food_coeff = 0
+	var/digestion_efficiency = 1 //VORE specific digestion var
 	//var/vore_numbing = 0
 	var/metabolism = 0.0015
 	var/lightweight = FALSE //Oof! Nonhelpful bump stumbles.

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
@@ -162,7 +162,7 @@
 
 /datum/trait/neutral/synth_chemfurnace
 	name = "Biofuel Processor"
-	desc = "You are able to gain energy through consuming and processing normal food. Energy-dense foods such as protein bars and survival food will yield the best results. NOTE: Only affects normal food, not alternate (vore, blood, succubusdrain)"
+	desc = "You are able to gain energy through consuming and processing normal food. Energy-dense foods such as protein bars and survival food will yield the best results."
 	cost = 0
 	custom_only = FALSE
 	can_take = SYNTHETICS
@@ -586,27 +586,27 @@
 
 /datum/trait/neutral/food_value_down
 	name = "Insatiable"
-	desc = "You need to eat a third of a plate more to be sated. NOTE: Only affects normal food, not alternate (vore, blood, succubusdrain)"
+	desc = "You need to eat a third of a plate more to be sated."
 	cost = 0
 	custom_only = FALSE
 	can_take = ORGANICS
-	var_changes = list(organic_food_coeff = 0.67)
+	var_changes = list(organic_food_coeff = 0.67, digestion_efficiency = 0.66)
 	excludes = list(/datum/trait/neutral/bloodsucker)
 
 /datum/trait/neutral/food_value_down_plus
 	name = "Insatiable, Greater"
-	desc = "You need to eat three times as much to feel sated. NOTE: Only affects normal food, not alternate (vore, blood, succubusdrain)"
+	desc = "You need to eat three times as much to feel sated."
 	cost = 0
 	custom_only = FALSE
 	can_take = ORGANICS
-	var_changes = list(organic_food_coeff = 0.33)
+	var_changes = list(organic_food_coeff = 0.33, digestion_efficiency = 0.33)
 	excludes = list(/datum/trait/neutral/bloodsucker, /datum/trait/neutral/food_value_down)
 
 /datum/trait/neutral/biofuel_value_down
 	name = "Discount Biofuel processor"
-	desc = "You are able to gain energy through consuming and processing normal food. Unfortunately, it is half as effective as premium models. NOTE: Only affects normal food, not alternate (vore, blood, succubusdrain)"
+	desc = "You are able to gain energy through consuming and processing normal food. Unfortunately, it is half as effective as premium models."
 	cost = 0
 	custom_only = FALSE
 	can_take = SYNTHETICS
-	var_changes = list("organic_food_coeff" = 0, "synthetic_food_coeff" = 0.3)
+	var_changes = list("organic_food_coeff" = 0, "synthetic_food_coeff" = 0.3, digestion_efficiency = 0.5)
 	excludes = list(/datum/trait/neutral/synth_chemfurnace)

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
@@ -162,7 +162,7 @@
 
 /datum/trait/neutral/synth_chemfurnace
 	name = "Biofuel Processor"
-	desc = "You are able to gain energy through consuming and processing normal food. Energy-dense foods such as protein bars and survival food will yield the best results."
+	desc = "You are able to gain energy through consuming and processing normal food. Energy-dense foods such as protein bars and survival food will yield the best results. NOTE: Only affects normal food, not alternate (vore, blood, succubusdrain)"
 	cost = 0
 	custom_only = FALSE
 	can_take = SYNTHETICS
@@ -582,3 +582,31 @@
 	cost = 0
 	custom_only = FALSE
 	var_changes = list("digestion_nutrition_modifier" = 0.25)
+
+
+/datum/trait/neutral/food_value_down
+	name = "Insatiable"
+	desc = "You need to eat a third of a plate more to be sated. NOTE: Only affects normal food, not alternate (vore, blood, succubusdrain)"
+	cost = 0
+	custom_only = FALSE
+	can_take = ORGANICS
+	var_changes = list(organic_food_coeff = 0.67)
+	excludes = list(/datum/trait/neutral/bloodsucker)
+
+/datum/trait/neutral/food_value_down_plus
+	name = "Insatiable, Greater"
+	desc = "You need to eat three times as much to feel sated. NOTE: Only affects normal food, not alternate (vore, blood, succubusdrain)"
+	cost = 0
+	custom_only = FALSE
+	can_take = ORGANICS
+	var_changes = list(organic_food_coeff = 0.33)
+	excludes = list(/datum/trait/neutral/bloodsucker, /datum/trait/neutral/food_value_down)
+
+/datum/trait/neutral/biofuel_value_down
+	name = "Discount Biofuel processor"
+	desc = "You are able to gain energy through consuming and processing normal food. Unfortunately, it is half as effective as premium models. NOTE: Only affects normal food, not alternate (vore, blood, succubusdrain)"
+	cost = 0
+	custom_only = FALSE
+	can_take = SYNTHETICS
+	var_changes = list("organic_food_coeff" = 0, "synthetic_food_coeff" = 0.3)
+	excludes = list(/datum/trait/neutral/synth_chemfurnace)

--- a/code/modules/vore/eating/bellymodes_datum_vr.dm
+++ b/code/modules/vore/eating/bellymodes_datum_vr.dm
@@ -63,9 +63,9 @@ GLOBAL_LIST_INIT(digest_modes, list())
 		var/mob/living/silicon/robot/R = B.owner
 		R.cell.charge += 25 * damage_gain
 	if(offset) // If any different than default weight, multiply the % of offset.
-		B.owner.adjust_nutrition(offset*(4.5 * (damage_gain) / difference)*L.get_digestion_nutrition_modifier()) //4.5 nutrition points per health point. Normal same size 100+100 health prey with average weight would give 900 points if the digestion was instant. With all the size/weight offset taxes plus over time oxyloss+hunger taxes deducted with non-instant digestion, this should be enough to not leave the pred starved.
+		B.owner.adjust_nutrition(offset*(4.5 * (damage_gain) / difference)*L.get_digestion_nutrition_modifier()*B.owner.get_digestion_efficiency_modifier()) //4.5 nutrition points per health point. Normal same size 100+100 health prey with average weight would give 900 points if the digestion was instant. With all the size/weight offset taxes plus over time oxyloss+hunger taxes deducted with non-instant digestion, this should be enough to not leave the pred starved.
 	else
-		B.owner.adjust_nutrition((4.5 * (damage_gain) / difference)*L.get_digestion_nutrition_modifier())
+		B.owner.adjust_nutrition((4.5 * (damage_gain) / difference)*L.get_digestion_nutrition_modifier()*B.owner.get_digestion_efficiency_modifier())
 	if(L.stat != oldstat)
 		return list("to_update" = TRUE)
 

--- a/code/modules/vore/eating/bellymodes_vr.dm
+++ b/code/modules/vore/eating/bellymodes_vr.dm
@@ -291,6 +291,7 @@
 		GLOB.prey_digested_roundstat++
 
 	var/personal_nutrition_modifier = M.get_digestion_nutrition_modifier()
+	var/pred_digestion_efficiency = owner.get_digestion_efficiency_modifier()
 
 	if((mode_flags & DM_FLAG_LEAVEREMAINS) && M.digest_leave_remains)
 		handle_remains_leaving(M)
@@ -301,7 +302,7 @@
 		var/mob/living/silicon/robot/R = owner
 		R.cell.charge += (nutrition_percent / 100) * compensation * 25 * personal_nutrition_modifier
 	else
-		owner.adjust_nutrition((nutrition_percent / 100) * compensation * 4.5 * personal_nutrition_modifier)
+		owner.adjust_nutrition((nutrition_percent / 100) * compensation * 4.5 * personal_nutrition_modifier * pred_digestion_efficiency)
 
 /obj/belly/proc/steal_nutrition(mob/living/L)
 	if(L.nutrition >= 100)

--- a/code/modules/vore/eating/living_vr.dm
+++ b/code/modules/vore/eating/living_vr.dm
@@ -727,6 +727,9 @@
 /mob/living/proc/get_digestion_nutrition_modifier()
 	return 1
 
+/mob/living/proc/get_digestion_efficiency_modifier()
+	return 1
+
 /mob/living/proc/eat_trash()
 	set name = "Eat Trash"
 	set category = "Abilities"


### PR DESCRIPTION
Requested in #Dev-Suggestions

Adds 3 traits:
1. Reduces nutrition gain by 1/3 (multiplies food reagent to nutrition by 0.67) for organics
2. Reduces nutrition gain by 2/3 (multriplies food reagent to nutrition by 0.33) for organics
3. Reduces nutrition gain by 1/2 (changes 0.6 multiplier to 0.3) for synthetics

The traits are mutually exclusive. Furthermore, the synth one is exclusive with biofuel processor, acting as a "discount" variant.

Tested for "normal" and 0.33
Took vulpkanin, ate 1 protein bar from sweatmax.
```
1.0:
Starting nutrition: 345
End nutrition: 580
0.33:
Starting nutrition: 352
End nutrition: 440
```

Did not test for synth, as it's already proven to work and I just changed a number.


edit:

Per request, made them affect VORE.

Testing:
```
ate 500 nutrition, 100% prey as 100% pred, at 6/6/12

default:
starting nutrition: 217
end nutrition: 1552
diff: 1335

Insatiable:
starting nutrition: 397
end nutrition: 1263
diff: 866

Insatiable, Greater:
starting nutrition: 250
end nutrition: 690
diff: 440

(synth pred)
default:
starting nutrition: 351
end nutrtition: 1666
diff: 1315

(synth pred)
Discount biofuel processor:
starting nutrition: 327
end nutrtition: 994
diff: 667 
```