### PR TITLE
Adds note to "Map merge" documentation in /guides

### DIFF
--- a/guides/New Mapper Mapmerge Readme.md
+++ b/guides/New Mapper Mapmerge Readme.md
@@ -5,3 +5,5 @@ Run dmm2tgm.bat, find the map you edited, and type it in. For instance, as of th
 If Tether Surface 2 is still 163, type in 163 and hit enter, it will run mapmerge. This reduces the filediff for easier Git merging.
 
 NOTE that this is not "merging" two maps together. ALL YOU ARE DOING IS REDUCING FILEDIFF. IF YOU NEED TO MAPMERGE PROPERLY, @ A DEVELOPER OR SOMEONE WITH MAPPING EXPERIENCE.
+
+NOTE 2: If you are using strongDMM and saving as a tgm filetype (as VerySoft's Rascal's Pass POI mapping guide in discord instructs), you do NOT need to use the dmm2tgm.bat utility. Saving it directly as a .tgm file is sufficient.


### PR DESCRIPTION
StrongDMM, used as described in https://github.com/Runa-Dacino/VOREStation/blob/update-documentation/guides/Guide%20to%20Your%20First%20POI%20Map.md
 and 

https://cdn.discordapp.com/attachments/173831852602294272/970792652440236042/map_guide_1.png

https://cdn.discordapp.com/attachments/173831852602294272/970792657645359124/map_guide_2.png

https://cdn.discordapp.com/attachments/173831852602294272/970792667153846393/map_guide_3.png

makes using the dmm2tgm.bat utility unnecessary per Killian's discord post.

![image](https://user-images.githubusercontent.com/20523270/188288125-af7f2363-d673-4fcf-87fa-9a038ace8aab.png)


I am changing this file in order to save future new mappers time of having to set up a windows python environment.

