### PR TITLE
Fixes a runtime with hair cycling

### DIFF
--- a/code/modules/mob/new_player/sprite_accessories.dm
+++ b/code/modules/mob/new_player/sprite_accessories.dm
@@ -56,7 +56,7 @@
 	var/flags
 
 /datum/sprite_accessory/hair/eighties
-	name = "80's"
+	name = "80s"
 	icon_state = "hair_80s"
 	flags = HAIR_TIEABLE
 


### PR DESCRIPTION
The sprite accessories dont like having ' in the much aparently... This will deselect 80's hair since name was changed to 80s but I imagine its an easy fix, and it wont runtime when trying to list-cycle