### PR TITLE
Allows light manipulation via multitool.

### DIFF
--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -944,6 +944,13 @@ var/global/list/light_type_cache = list()
 	drop_sound = 'sound/items/drop/glass.ogg'
 	pickup_sound = 'sound/items/pickup/glass.ogg'
 
+	//VOREStation Edit Start - Modifiable Lighting
+	var/init_brightness_range = 8
+	var/init_brightness_power = 1
+	var/init_nightshift_range = 8
+	var/init_nightshift_power = 0.45
+	//VOREStation Edit End - Modifiable Lighting
+
 /obj/item/weapon/light/tube
 	name = "light tube"
 	desc = "A replacement light tube."
@@ -953,6 +960,8 @@ var/global/list/light_type_cache = list()
 	matter = list(MAT_GLASS = 100)
 	brightness_range = 7
 	brightness_power = 2
+	init_brightness_range = 7
+	init_brightness_power = 2
 
 /obj/item/weapon/light/tube/large
 	w_class = ITEMSIZE_SMALL
@@ -962,6 +971,11 @@ var/global/list/light_type_cache = list()
 
 	nightshift_range = 10
 	nightshift_power = 1.5
+
+	init_brightness_range = 15
+	init_brightness_power = 4
+	init_nightshift_range = 10
+	init_nightshift_power = 1.5
 
 /obj/item/weapon/light/bulb
 	name = "light bulb"
@@ -977,6 +991,11 @@ var/global/list/light_type_cache = list()
 	nightshift_range = 3
 	nightshift_power = 0.5
 
+	init_brightness_range = 5
+	init_brightness_power = 1
+	init_nightshift_range = 3
+	init_nightshift_power = 0.5
+
 // For 'floor lamps' in outdoor use and such
 /obj/item/weapon/light/bulb/large
 	name = "large light bulb"
@@ -986,6 +1005,11 @@ var/global/list/light_type_cache = list()
 	nightshift_range = 4
 	nightshift_power = 0.75
 
+	init_brightness_range = 7
+	init_brightness_power = 1.5
+	init_nightshift_range = 4
+	init_nightshift_power = 0.75
+
 /obj/item/weapon/light/throw_impact(atom/hit_atom)
 	..()
 	shatter()
@@ -994,6 +1018,7 @@ var/global/list/light_type_cache = list()
 	brightness_range = 4
 	color = "#da0205"
 	brightness_color = "#da0205"
+	init_brightness_range = 4
 
 /obj/item/weapon/light/bulb/fire
 	name = "fire bulb"
@@ -1036,7 +1061,56 @@ var/global/list/light_type_cache = list()
 // if a syringe, can inject phoron to make it explode
 /obj/item/weapon/light/attackby(var/obj/item/I, var/mob/user)
 	..()
-	if(istype(I, /obj/item/weapon/reagent_containers/syringe))
+
+	//VOREStation Edit Start - Multitool Lighting!
+	if(istype(I,/obj/item/device/multitool))
+		var/list/menu_list = list(
+		"Normal Range",
+		"Normal Brightness",
+		"Normal Color",
+		"Nightshift Range",
+		"Nightshift Brightness",
+		"Nightshift Color",
+		)
+
+		var/modification_decision = tgui_input_list(usr, "What do you wish to change about this light?", "Light Adjustment", menu_list)
+		if(!modification_decision)
+			return //They didn't select anything!
+		switch(modification_decision)
+			if("Normal Range")
+				var/new_range = tgui_input_number(usr, "Choose the new range of the light! (1-[init_brightness_range])", "", init_brightness_range, init_brightness_range, 1, 0)
+				if(new_range)
+					brightness_range = new_range
+
+			if("Normal Brightness")
+				var/new_power = tgui_input_number(usr, "Choose the new brightness of the light! (0.01 - [init_brightness_power])", "", init_brightness_power, init_brightness_power, 0.01, 0)
+				if(new_power)
+					brightness_power = new_power
+
+			if("Normal Color")
+				var/new_color = input(usr, "Choose a color to set the light to!", "", brightness_color) as color|null
+				if(new_color)
+					brightness_color = new_color
+
+			if("Nightshift Range")
+				var/new_range = tgui_input_number(usr, "Choose the new range of the light! (1-[init_nightshift_range])", "", init_nightshift_range, init_nightshift_range, 1)
+				if(new_range)
+					nightshift_range = new_range
+
+			if("Nightshift Brightness")
+				var/new_power = tgui_input_number(usr, "Choose the new brightness of the light! (0.01 - [init_nightshift_power])", "", init_nightshift_power, init_nightshift_power, 0.01)
+				if(new_power)
+					nightshift_power = new_power
+
+			if("Nightshift Color")
+				var/new_color = input(usr, "Choose a color to set the light to!", "", nightshift_color) as color|null
+				if(new_color)
+					nightshift_color = new_color
+
+			else //Should never happen.
+				return
+
+	else if(istype(I, /obj/item/weapon/reagent_containers/syringe))
 		var/obj/item/weapon/reagent_containers/syringe/S = I
 
 		to_chat(user, "You inject the solution into the [src].")


### PR DESCRIPTION
- Allows lights to be changed and manipulated via a multitool.

- Allows six things to be changed:
1. Normal operating Range
2. Normal operating Brightness
3. Normal operating Color
4. Nightshift Range
5. Nightshift Brightness
6. Nightshift Color

All these (barring color) have their max set to the light's individual variables. For example: You can't make a light tube brighter/shine further than it normally would.

![image](https://user-images.githubusercontent.com/15969779/188295223-adccd8e7-af14-49a0-b7d0-fa7cba9338df.png)

![image](https://user-images.githubusercontent.com/15969779/188295259-b1eb2b94-0fcd-4b27-958e-57236a845af2.png)
![image](https://user-images.githubusercontent.com/15969779/188295262-b5611177-a4a9-4489-b7ee-d01f523a709f.png)
