### PR TITLE
Bugfix Palooza 

### DIFF
--- a/code/controllers/globals.dm
+++ b/code/controllers/globals.dm
@@ -36,7 +36,7 @@ GLOBAL_REAL(GLOB, /datum/controller/global_vars)
 	if(!statclick)
 		statclick = new/obj/effect/statclick/debug(null, "Initializing...", src)
 
-	stat("GLOB:", statclick.update("Edit"))
+	stat("GLOB:", "Button Removed Due To Crashing") //VOREStation Edit
 
 /datum/controller/global_vars/vv_edit_var(var_name, var_value)
 	if(gvars_datum_protected_varlist[var_name])

--- a/code/datums/helper_datums/teleport_vr.dm
+++ b/code/datums/helper_datums/teleport_vr.dm
@@ -1,6 +1,12 @@
 //wrapper
+//This teleport effect means that bluespace items will cause a teleport location variation of 1 to 100 tiles.
 /proc/do_noeffect_teleport(ateleatom, adestination, aprecision=0, afteleport=1, aeffectin=null, aeffectout=null, asoundin=null, asoundout=null, local=FALSE)
 	new /datum/teleport/instant/science/noeffect(arglist(args))
+	return
+
+//This teleport effect does not interact with bluespace items.
+/proc/do_safe_teleport(ateleatom, adestination, aprecision=0, afteleport=1, aeffectin=null, aeffectout=null, asoundin=null, asoundout=null, local=FALSE)
+	new /datum/teleport/instant(arglist(args))
 	return
 
 /datum/teleport/instant/science/noeffect/setEffects(datum/effect/effect/system/aeffectin,datum/effect/effect/system/aeffectout)

--- a/code/modules/multiz/portals_vr.dm
+++ b/code/modules/multiz/portals_vr.dm
@@ -132,9 +132,9 @@
 			to_chat(M, "<span class='notice'>Something blocks your way.</span>")
 			return
 		temptarg = pick(possible_turfs)
-		do_noeffect_teleport(M, temptarg, 0)
+		do_safe_teleport(M, temptarg, 0)
 	else if (istype(M, /atom/movable))
-		do_noeffect_teleport(M, target, 0)
+		do_safe_teleport(M, target, 0)
 
 /obj/structure/portal_event/Destroy()
 	if(target)
@@ -146,7 +146,7 @@
 			P.target = null
 		qdel_null(target)
 	. = ..()
-	
+
 /obj/structure/portal_target
 	name = "portal destination"
 	desc = "you shouldn't see this unless you're a ghost"

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -415,6 +415,7 @@ var/global/list/light_type_cache = list()
 	if(!shows_alerts)
 		return
 	current_alert = "atmos"
+	light_color = "#6D6DFC"
 	brightness_color = "#6D6DFC"
 	update()
 
@@ -422,6 +423,7 @@ var/global/list/light_type_cache = list()
 	if(!shows_alerts)
 		return
 	current_alert = "fire"
+	light_color = "#FF3030"
 	brightness_color = "#FF3030"
 	update()
 
@@ -455,6 +457,10 @@ var/global/list/light_type_cache = list()
 		var/correct_range = nightshift_enabled ? brightness_range_ns : brightness_range
 		var/correct_power = nightshift_enabled ? brightness_power_ns : brightness_power
 		var/correct_color = nightshift_enabled ? brightness_color_ns : brightness_color
+		if(current_alert) //Oh no, we're on fire! Or the atmos is bad! Let's change the color
+			correct_range = brightness_range
+			correct_power = brightness_power
+			correct_color = brightness_color
 		if(light_range != correct_range || light_power != correct_power || light_color != correct_color)
 			if(!auto_flicker)
 				switchcount++
@@ -483,7 +489,7 @@ var/global/list/light_type_cache = list()
 	else
 		update_use_power(USE_POWER_IDLE)
 		set_light(0)
-
+	update_light() //VOREStation Edit - Makes lights update when their color is changed.
 	update_active_power_usage((light_range * light_power) * LIGHTING_POWER_FACTOR)
 
 /obj/machinery/light/proc/nightshift_mode(var/state)


### PR DESCRIPTION
- Removes a button that allowed staff to immediately crash the server upon clicking it.
- Makes admin portals not randomize someone's teleportation if they have bluespace items.
- Makes lights properly change color and update, along with function properly with alarms(fire/atmos)