### PR TITLE
Adds "Grit" Positive trait

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/positive.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/positive.dm
@@ -200,3 +200,12 @@
 	var_changes = list("gun_accuracy_mod" = 25)
 	custom_only = FALSE
 	varchange_type = TRAIT_VARCHANGE_MORE_BETTER
+
+/datum/trait/negative/pain_tolerance
+	name = "Grit"
+	desc = "You can keep going a little longer, a little harder when you get hurt, Injuries only inflict 85% as much pain, and slowdown from pain is 85% as effective."
+	cost = 2
+	var_changes = list("trauma_mod" = 0.85)
+	excludes = list(/datum/trait/negative/neural_hypersensitivity)
+	can_take = ORGANICS
+


### PR DESCRIPTION
A reverse of Neural Hypersensitivity.

How Neural hypersensitivity works:

> In essence, I've changed how "traumatic_shock", that is the variable used to determine when a human mob starts to stutter in pain, have their eyes go blurry and enter pain crit, is calculated by multiplying traumatic_shock acquired from dislocated limbs, oxy/tox/brute/burn/clone damage with the new variable.
> 
> I've also decided to keep the traumatic_shock reduction from slurred speech (which is acquired from overdosing on alcohol and drinking deathbell), which I did because I thought brain damage also causes slurring (turns out nope). I ended up keeping it to avoid conflicts from an earlyport, and considering the effects of alcohol on combat (makes it impossible if you're at the point that you're slurring), it shouldn't have balance issues. If necessary, I can change the calculation to exclude slurring as it excludes painkillers.
> 
> At the moment the simplified calculation is ((Sum of damage derived pain) - (slurred speech))*trauma_mod-(pain_killer)=final value
> 
> The default value of the new variable "trauma_mod" is 1, i.e.: the calculation is unchanged.
> 
> Taking the trait changes this to 2, making the person taking it rack up traumatic_shock twice as fast, and thus go into pain crit at e.g.:
> 50 oxy over default 100
> 41.2 brute/born over 83
> 71 tox over 142
> 25 halloss over 50
> 
> While needing twice as much/powerful pain killer for the same effect.
> 
> I am uncertain as to what cost is appropriate for this, I think 1 might be fair considering pain killers can still counter it.

In this aspect, this trait will delay starting to accumulate shock by 15%

Furthermore, I've later modified neural hypersensitivity to also affect slowdown:

> Previously, taking neural hypersensitivity made you hit critical roughly twice as earlier. This was an oversight in my implementation, as I thought traumatic_shock was all there was to pain code.
> 
> With this buff, the following will occur:
> 
> Pain messages occur at half as much damage (just 6 damage is enough for something to "hurt badly", 46 for "terrible pain"
> chance to drop items due to pain occurs at 25 damage rather than, 50, with calculation of (damage*2)/25 as probability
> Slowdown occurs at 20 damage, and slowdown calculation is changed to account for pain sensitivity.
> old slowdown calculation:
> If (maxhealth-health-painkillers) >= 40
> (maxhealth - health - painkillers) / 25
> 
> new calculation:
> if( (maxhealth-health)*2 - painkillers) >= 40
> ((maxhealth - health) * 2 - painkillers) / 25
> 
> This was intended functionality of neural hypersensitivty (original PR: https://github.com/VOREStation/VOREStation/pull/9406 ), but back then I did not know that there was more to paincode.
> 
> Tested on local.
> 
> Pain occurs earlier: yes -> expected
> Item drop: Likely yes, not conclusive -> expecting? It should work
> slowdown: definite yes -> expected
> Does it affect characters withOUT neural hypersensitivity? No -> expected.
> n.b.: It already affected slowdown in a round-about way: when shock_stage reached 10, delay was increased by 3. It helped reach shock_stage 10 as described in cited PR.



trauma_mod implementation:

Shock: https://github.com/VOREStation/VOREStation/pull/9406
Slowdown/pain messages: https://github.com/VOREStation/VOREStation/pull/13597




This was a requested trait. Cost, values are ready to change.