### PR TITLE
More light updates!

### DIFF
--- a/code/game/objects/items/devices/lightreplacer.dm
+++ b/code/game/objects/items/devices/lightreplacer.dm
@@ -53,6 +53,7 @@
 	var/emagged = 0
 	var/failmsg = ""
 	var/charge = 0
+	var/selected_color = LIGHT_COLOR_INCANDESCENT_TUBE //Default color!
 
 	// Eating used bulbs gives us bulb shards
 	var/bulb_shards = 0
@@ -141,6 +142,10 @@
 			return
 	*/
 	to_chat(usr, "It has [uses] lights remaining.")
+	var/new_color = input(usr, "Choose a color to set the light to! (Default is [LIGHT_COLOR_INCANDESCENT_TUBE])", "", selected_color) as color|null
+	if(new_color)
+		selected_color = new_color
+		to_chat(usr, "The light color has been changed.")
 
 /obj/item/device/lightreplacer/update_icon()
 	icon_state = "lightreplacer[emagged]"
@@ -184,19 +189,13 @@
 					to_chat(U, "<span class='notice'>\The [src] has fabricated a new bulb from the broken bulbs it has stored. It now has [uses] uses.</span>")
 					playsound(src, 'sound/machines/ding.ogg', 50, 1)
 				target.status = LIGHT_EMPTY
+				target.installed_light = null //Remove the light!
 				target.update()
 
 			var/obj/item/weapon/light/L2 = new target.light_type()
-
-			target.status = L2.status
-			target.switchcount = L2.switchcount
-			target.rigged = emagged
-			target.brightness_range = L2.brightness_range
-			target.brightness_power = L2.brightness_power
-			target.brightness_color = L2.brightness_color
-			target.on = target.has_power()
+			L2.brightness_color = selected_color
+			target.insert_bulb(L2) //Call the insertion proc.
 			target.update()
-			qdel(L2)
 
 			if(target.on && target.rigged)
 				target.explode()

--- a/code/modules/mob/living/silicon/robot/dogborg/dog_modules_vr.dm
+++ b/code/modules/mob/living/silicon/robot/dogborg/dog_modules_vr.dm
@@ -400,24 +400,33 @@
 	var/datum/matter_synth/glass = null
 
 /obj/item/device/lightreplacer/dogborg/attack_self(mob/user)//Recharger refill is so last season. Now we recycle without magic!
-	if(uses >= max_uses)
-		to_chat(user, "<span class='warning'>[src.name] is full.</span>")
+
+	var/choice = tgui_alert(user, "Do you wish to check the reserves or change the color?", "Selection List", list("Reserves", "Color"))
+	if(choice == "Color")
+		var/new_color = input(usr, "Choose a color to set the light to! (Default is [LIGHT_COLOR_INCANDESCENT_TUBE])", "", selected_color) as color|null
+		if(new_color)
+			selected_color = new_color
+			to_chat(user, "The light color has been changed.")
 		return
-	if(uses < max_uses && cooldown == 0)
-		if(glass.energy < 125)
-			to_chat(user, "<span class='warning'>Insufficient material reserves.</span>")
-			return
-		to_chat(user, "It has [uses] lights remaining. Attempting to fabricate a replacement. Please stand still.")
-		cooldown = 1
-		if(do_after(user, 50))
-			glass.use_charge(125)
-			add_uses(1)
-			cooldown = 0
-		else
-			cooldown = 0
 	else
-		to_chat(user, "It has [uses] lights remaining.")
-		return
+		if(uses >= max_uses)
+			to_chat(user, "<span class='warning'>[src.name] is full.</span>")
+			return
+		if(uses < max_uses && cooldown == 0)
+			if(glass.energy < 125)
+				to_chat(user, "<span class='warning'>Insufficient material reserves.</span>")
+				return
+			to_chat(user, "It has [uses] lights remaining. Attempting to fabricate a replacement. Please stand still.")
+			cooldown = 1
+			if(do_after(user, 50))
+				glass.use_charge(125)
+				add_uses(1)
+				cooldown = 0
+			else
+				cooldown = 0
+		else
+			to_chat(user, "It has [uses] lights remaining.")
+			return
 
 //Pounce stuff for K-9
 /obj/item/weapon/dogborg/pounce

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -143,7 +143,7 @@ GLOBAL_LIST_EMPTY(apcs)
 	var/updating_icon = 0
 	var/global/list/status_overlays_environ
 	var/alarms_hidden = FALSE //If power alarms from this APC are visible on consoles
-	
+
 	var/nightshift_lights = FALSE
 	var/nightshift_setting = NIGHTSHIFT_AUTO
 	var/last_nightshift_switch = 0
@@ -198,7 +198,7 @@ GLOBAL_LIST_EMPTY(apcs)
 
 	if(!pixel_x && !pixel_y)
 		offset_apc()
-	
+
 	if(building)
 		area = get_area(src)
 		area.apc = src
@@ -1361,6 +1361,7 @@ GLOBAL_LIST_EMPTY(apcs)
 
 	for(var/obj/machinery/light/L in area)
 		L.nightshift_mode(new_state)
+		L.update() //For some reason it gets hung up on updating the overlay for the light fixture somewhere down the line. This fixes it.
 		CHECK_TICK
 
 #undef APC_UPDATE_ICON_COOLDOWN

--- a/code/modules/power/lighting_vr.dm
+++ b/code/modules/power/lighting_vr.dm
@@ -14,6 +14,9 @@
 // create a new lighting fixture
 /obj/machinery/light/New()
 	..()
+	installed_light = new light_type
+	installed_light.status = status //This is just in case RNG decides to break the light at round start!
+	installed_light.update_icon() //Give it the proper sprite!
 	//Vorestation addition, so large mobs stop looking stupid in front of lights.
 	if (dir == SOUTH) // Lights are backwards, SOUTH lights face north (they are on south wall)
 		layer = ABOVE_MOB_LAYER


### PR DESCRIPTION
- Changes how lights function. Instead of lights being qdel'd when you take them in/out of light sockets, it now holds them _in_ the light socket! (Due to this change things have been thoroughly tested, numerous bugs squashed which arose due to this change, and then tested again.)
- Makes it so overlays update properly on lights
- Makes it so light colors persist, even if you turn an alarm off & on again (previously reset the light to normal)
- Made it so nightshift properly updates the overlays of lights.
- Updated the light replacer to swap lights in a more efficient way
- Makes it so light replacers can set the color of the lights being inserted. (This only affects the daytime lights. For more complex changes, a multitool is required.)

![image](https://user-images.githubusercontent.com/15969779/188506737-9542ad59-80d2-4f3f-b381-a9ae896ae8ff.png)

Due to the change of how lights function (bullet #1) I went ahead and very thoroughly tested this with every case imaginable, including round-start broken lights, burnt out lights, normal lights, etc etc.
