### PR TITLE
Adds neutral trait for synthetics to toggle cosmetic pain messages

### DIFF
--- a/code/modules/mob/living/carbon/human/life_vr.dm
+++ b/code/modules/mob/living/carbon/human/life_vr.dm
@@ -78,3 +78,8 @@
 	// Moving around increases germ_level faster
 	if(germ_level < GERM_LEVEL_MOVE_CAP && prob(8))
 		germ_level++
+
+
+/mob/living/carbon
+	var/synth_cosmetic_pain = FALSE
+

--- a/code/modules/mob/living/carbon/human/species/station/station_special_abilities_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_special_abilities_vr.dm
@@ -1153,3 +1153,16 @@
 			"<span class='danger'>You are dragged below the water and feel yourself slipping directly into \the [src]'s [vore_selected]!</span>")
 		to_chat(src, "<span class='notice'>You successfully drag \the [target] into the water, slipping them into your [vore_selected].</span>")
 		target.forceMove(src.vore_selected)
+
+
+/mob/living/carbon/human/proc/toggle_pain_module()
+	set name = "Toggle pain simulation."
+	set desc = "Turn on your pain simulation for that organic experience! Or turn it off for repairs, or if it's too much."
+	set category = "Abilities"
+
+	if(synth_cosmetic_pain)
+		to_chat(src, "<span class='notice'> You turn off your pain simulators.</span>")
+	else
+		to_chat(src, "<span class='danger'> You turn on your pain simulators </span>")
+
+	synth_cosmetic_pain = !synth_cosmetic_pain

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
@@ -610,3 +610,15 @@
 	can_take = SYNTHETICS
 	var_changes = list("organic_food_coeff" = 0, "synthetic_food_coeff" = 0.3, digestion_efficiency = 0.5)
 	excludes = list(/datum/trait/neutral/synth_chemfurnace)
+
+/datum/trait/neutral/synth_cosmetic_pain
+	name = "Pain simulation"
+	desc = "You have added modules in your synthetic shell that simulates the sensation of pain. You are able to turn this on and off for repairs as needed or convenience at will."
+	cost = 0
+	custom_only = FALSE
+	can_take = SYNTHETICS
+
+
+/datum/trait/neutral/synth_cosmetic_pain/apply(var/datum/species/S,var/mob/living/carbon/human/H)
+	..(S,H)
+	H.verbs |= /mob/living/carbon/human/proc/toggle_pain_module

--- a/code/modules/organs/pain.dm
+++ b/code/modules/organs/pain.dm
@@ -9,7 +9,7 @@
 // power decides how much painkillers will stop the message
 // force means it ignores anti-spam timer
 /mob/living/carbon/proc/custom_pain(message, power, force)
-	if(!message || stat || !can_feel_pain() || chem_effects[CE_PAINKILLER] > power)
+	if((!message || stat || !can_feel_pain() || chem_effects[CE_PAINKILLER] > power) && !synth_cosmetic_pain)
 		return 0
 	message = "<span class='danger'>[message]</span>"
 	if(power >= 50)
@@ -25,7 +25,7 @@
 	if(stat)
 		return
 
-	if(!can_feel_pain())
+	if(!can_feel_pain() && !synth_cosmetic_pain)
 		return
 
 	if(world.time < next_pain_time)
@@ -33,7 +33,7 @@
 	var/maxdam = 0
 	var/obj/item/organ/external/damaged_organ = null
 	for(var/obj/item/organ/external/E in organs)
-		if(!E.organ_can_feel_pain()) continue
+		if(!E.organ_can_feel_pain() && !synth_cosmetic_pain) continue
 		var/dam = E.get_damage()
 		// make the choice of the organ depend on damage,
 		// but also sometimes use one of the less damaged ones


### PR DESCRIPTION
Synthetics by default do not feel pain, and are NOT affected by the negative mechanics of pain.

This trait enables synthetics to have the **cosmetic effects** (spam of pain messages) of pain available at will. 

Every carbon mob starts with synth_cosmetic_pain = FALSE, and while set to FALSE previous functionality occurs.

When synth_cosmetic_pain = TRUE, the following happens:
![image](https://user-images.githubusercontent.com/20523270/188511145-a8fffd52-89fe-4925-a618-a78346cee727.png)

The moment it's toggled back off, the pain messages stop.


Potential mechanical advantage: Synth players will be able to tell how much damage their limbs have by looking at chat log rather than the damage doll or self-diagnostic. This makes no difference.