### PR TITLE
Fixes bug regarding feral xenochimera and treating others/being treated

### DIFF
--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -20,7 +20,7 @@
 		to_chat(user, "<span class='warning'>\The [src] cannot be applied to [M]!</span>")
 		return 1
 
-	if (!M.IsAdvancedToolUser())
+	if (!user.IsAdvancedToolUser())
 		to_chat(user, "<span class='warning'>You don't have the dexterity to do this!</span>")
 		return 1
 


### PR DESCRIPTION
This bug prevented feral xenochimera or other 'non-dexterous' creatures from being healed, and also allowed them to heal others.