### PR TITLE
Adds free AI shell landmarks to SD and RP

### DIFF
--- a/maps/groundbase/gb-z1.dmm
+++ b/maps/groundbase/gb-z1.dmm
@@ -5721,6 +5721,11 @@
 /obj/machinery/vending/altevian,
 /turf/simulated/floor/tiled,
 /area/groundbase/civilian/foodplace)
+"mB" = (
+/obj/machinery/light,
+/obj/effect/landmark/free_ai_shell,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/groundbase/command/ai/upload)
 "mC" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -14701,10 +14706,6 @@
 	},
 /turf/simulated/floor/outdoors/sidewalk/slab/virgo3c,
 /area/groundbase/level1/centsquare)
-"IL" = (
-/obj/machinery/light,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/groundbase/command/ai/upload)
 "IM" = (
 /obj/structure/sign/painting/public{
 	pixel_y = 30
@@ -24651,7 +24652,7 @@ yJ
 XU
 xA
 rM
-IL
+mB
 XY
 MO
 FF

--- a/maps/stellar_delight/stellar_delight3.dmm
+++ b/maps/stellar_delight/stellar_delight3.dmm
@@ -63,6 +63,7 @@
 /turf/simulated/floor,
 /area/stellardelight/deck3/portdock)
 "aj" = (
+/obj/effect/landmark/free_ai_shell,
 /turf/simulated/floor/carpet/turcarpet,
 /area/ai)
 "ak" = (


### PR DESCRIPTION
This does not mean the shells will spawn on those maps immideately. This is just landmarks, so that if config responsible for AI getting free shells is enabled, they have the spots for it pre-designated already.