### PR TITLE
Makes wounds take time to disappear again to fix bleeding surgery

### DIFF
--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -732,8 +732,8 @@ Note that amputating the affected organ does in fact remove the infection from t
 		return
 
 	for(var/datum/wound/W in wounds)
-		// wounds used to be able to disappear after 10 minutes at the earliest, for now just remove them as soon as there is no damage
-		if(W.damage <= 0)
+		// wounds can disappear after 10 minutes at the earliest
+		if(W.damage <= 0 && W.created + 10 MINUTES <= world.time)
 			wounds -= W
 			continue
 			// let the GC handle the deletion of the wound


### PR DESCRIPTION
Fixes #13695 

Partial revert of #13471 

Issue is that the 'incision' wound just disappears instantly. But then organ detects that its open and needs to bleed. But 'clamping' that the hemostat does only clamps wounds, not organ as a whole. So you can infinitely un-bleed organ that keeps re-bleeding. There is PROBABLY a better fix but I'm kinda too tired to look for it right now, plus 'wounds fading over time' thing was original intent of the PR anyway. I doubt performance will take that much of a hit.