### PR TITLE
Fixes the VR pods to keep your character sprites perfectly copied.

### DIFF
--- a/code/game/machinery/virtual_reality/vr_console.dm
+++ b/code/game/machinery/virtual_reality/vr_console.dm
@@ -2,9 +2,9 @@
 	name = "virtual reality sleeper"
 	desc = "A fancy bed with built-in sensory I/O ports and connectors to interface users' minds with their bodies in virtual reality."
 	icon = 'icons/obj/Cryogenic2.dmi'
-	icon_state = "syndipod_0"
+	icon_state = "body_scanner_0"
 
-	var/base_state = "syndipod_"
+	var/base_state = "body_scanner_"
 
 	density = TRUE
 	anchored = TRUE
@@ -245,9 +245,14 @@
 		if(occupant.species.name != "Promethean" && occupant.species.name != "Human" && mirror_first_occupant)
 			avatar.shapeshifter_change_shape(occupant.species.name)
 		avatar.forceMove(get_turf(S))			// Put the mob on the landmark, instead of inside it
-		avatar.Sleeping(1)
+
 
 		occupant.enter_vr(avatar)
+		//Yes, I am using a aheal just so your markings transfer over, I could not get .prefs.copy_to working. This is very stupid, and I can't be assed to rewrite this.  Too bad!
+		avatar.revive()
+		avatar.revive()
+		avatar.verbs += /mob/living/carbon/human/proc/exit_vr //ahealing removes the prommie verbs and the VR verbs, giving it back
+		avatar.Sleeping(1)
 
 		// Prompt for username after they've enterred the body.
 		var/newname = sanitize(tgui_input_text(avatar, "You are entering virtual reality. Your username is currently [src.name]. Would you like to change it to something else?", "Name change", null, MAX_NAME_LEN), MAX_NAME_LEN)

--- a/code/modules/mob/living/carbon/human/species/virtual_reality/avatar.dm
+++ b/code/modules/mob/living/carbon/human/species/virtual_reality/avatar.dm
@@ -81,7 +81,7 @@
 	// Move the mind
 	avatar.Sleeping(1)
 	src.mind.transfer_to(avatar)
-	to_chat(avatar, "<b>You have enterred Virtual Reality!\nAll normal gameplay rules still apply.\nWounds you suffer here won't persist when you leave VR, but some of the pain will.\nYou can leave VR at any time by using the \"Exit Virtual Reality\" verb in the Abilities tab, or by ghosting.\nYou can modify your appearance by using various \"Change \[X\]\" verbs in the Abilities tab.</b>")
+	to_chat(avatar, "<b>You have enterred Virtual Reality!\nAll normal gameplay rules still apply.\nWounds you suffer here won't persist when you leave VR, but some of the pain will.\nYou can leave VR at any time by using the \"Exit Virtual Reality\" verb in the Abilities tab, or by ghosting.</b>") //No more prommie VR thing, so removed tidbit about changing appearance
 	to_chat(avatar, "<span class='notice'> You black out for a moment, and wake to find yourself in a new body in virtual reality.</span>") // So this is what VR feels like?
 
 // exit_vr is called on the vr mob, and puts the mind back into the original mob


### PR DESCRIPTION
- Fixes the VR pods so they now duplicate your actual character, the way this is done is very jank but Cameron told me it works enough.
- Changed the sprites to the VR sleeper to the green pods because the syndipods dont have dir sprites.
- Going into VR will give you an option to change your name or leave it blank to keep default.
- This transfers all markings and (I think vore bellies) too.
- Ghosting, Using Exit-VR, dieing, getting gibbed, etc etc will take you back to the real world (But pain stays!)
- I double checked to make sure and it does NOT affect auto transcore (If it were enabled)

Map NOT included. This is just a fix and nothing else.

https://user-images.githubusercontent.com/10555869/189488430-0aaa8aea-0943-421d-b1ad-62a165d865e6.mp4


https://user-images.githubusercontent.com/10555869/189488452-079dc002-e190-4a3c-b0ab-95523ec691df.mp4

**KNOWN ISSUES/PROBLEMS**

- There is no body cleanup system, so someone can just keep commiting suicide to make more bodies.
- Getting admin deleted will break the VR system.
- Chances are getting digested will instantly kick you back to the real world

