### PR TITLE
Enables mobs to be able to be drop_preds by default. Also fixes prefs.

### DIFF
--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -327,7 +327,9 @@
 	//VORESTATION EDIT START - Allows for thrown vore!
 	//Throwing a prey into a pred takes priority. After that it checks to see if the person being thrown is a pred.
 	if(istype(AM, /mob/living))
-		var/mob/living/thrown_mob = AM
+		var/mob/living/thrown_mob = AM\
+		if(!client && !thrown_mob.allowmobvore)
+			return //The mob is AI controlled and the prey doesn't allow for mob vore allowed, don't even bother.
 		if((can_be_drop_pred && throw_vore) && (thrown_mob.devourable && thrown_mob.throw_vore && thrown_mob.can_be_drop_prey)) //Prey thrown into pred.
 			vore_selected.nom_mob(thrown_mob) //Eat them!!!
 			visible_message("<span class='warning'>[thrown_mob] is thrown right into [src]'s [lowertext(vore_selected.name)]!</span>")

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -327,7 +327,7 @@
 	//VORESTATION EDIT START - Allows for thrown vore!
 	//Throwing a prey into a pred takes priority. After that it checks to see if the person being thrown is a pred.
 	if(istype(AM, /mob/living))
-		var/mob/living/thrown_mob = AM\
+		var/mob/living/thrown_mob = AM
 		if(!client && !thrown_mob.allowmobvore)
 			return //The mob is AI controlled and the prey doesn't allow for mob vore allowed, don't even bother.
 		if((can_be_drop_pred && throw_vore) && (thrown_mob.devourable && thrown_mob.throw_vore && thrown_mob.can_be_drop_prey)) //Prey thrown into pred.

--- a/code/modules/mob/living/simple_mob/subtypes/vore/vore.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/vore.dm
@@ -1,6 +1,7 @@
 /mob/living/simple_mob/vore
 	mob_class = MOB_CLASS_ANIMAL
 	mob_bump_flag = 0
+	can_be_drop_pred = 1
 
 /mob/living/simple_mob
 	var/nameset


### PR DESCRIPTION
Because if you're thrown into a mob/stumble into a mob/slip into a mob, it probably wouldn't think twice about gulping you down. If this is an issue I can just remove it and leave the bugfix in, but given all this does is allow people to yeet themselves/slip/stumble into mobs if prefs align.

Also makes it so throwvore respects mobvore prefs.