### PR TITLE
Fixes tf ray simplemob id gender runtime

### DIFF
--- a/code/modules/vore/mouseray.dm
+++ b/code/modules/vore/mouseray.dm
@@ -140,7 +140,7 @@
 					N.gender = H.gender
 					N.identifying_gender = H.identifying_gender
 				else
-					new_mob.gender = H.identifying_gender
+					new_mob.gender = H.gender
 			else
 				new_mob.gender = M.gender
 				if(ishuman(new_mob))


### PR DESCRIPTION
mob gender var and the identifying_gender var aren't fully compatible, especially with simplemobs that don't even use identifying_gender or even regular gender aside from it simply existing in the vars. This fixes a completely function bricking runtime that happens when the ray tries to apply an undefined null var or nonstandard id gender var into a simplemob's standard gender var.