### PR TITLE
Allows Long Predatorial Reach to toggle modes.

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/station_special_abilities_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_special_abilities_vr.dm
@@ -1185,12 +1185,18 @@
 		to_chat(src, "<span class='warning'>It doesn't work that way.</span>")
 		return
 
-	var/choice = tgui_alert(src, "Do you wish to change the color of your appendage or use it?", "Selection List", list("Use it", "Color"))
+	var/choice = tgui_alert(src, "Do you wish to change the color of your appendage, use it, or change its functionality?", "Selection List", list("Use it", "Color", "Functionality"))
 
 	if(choice == "Color") //Easy way to set color so we don't bloat up the menu with even more buttons.
 		var/new_color = input(usr, "Choose a color to set your appendage to!", "", appendage_color) as color|null
 		if(new_color)
 			appendage_color = new_color
+	if(choice == "Functionality") //Easy way to set color so we don't bloat up the menu with even more buttons.
+		var/choice2 = tgui_alert(usr, "Choose if you want to be pulled to the target or pull them to you!", "Functionality Setting", list("Pull target to self", "Pull self to target"))
+		if(choice2 == "Pull target to self")
+			appendage_alt_setting = 0
+		else
+			appendage_alt_setting = 1
 	else
 		var/list/targets = list() //IF IT IS NOT BROKEN. DO NOT FIX IT.
 
@@ -1271,9 +1277,16 @@
 	if(istype(target, /mob/living))
 		var/mob/living/M = target
 		var/throw_range = get_dist(firer,M)
+		if(istype(firer, /mob/living)) //Let's check for any alt settings. Such as: User selected to be thrown at target.
+			var/mob/living/F = firer
+			if(F.appendage_alt_setting == 1)
+				F.throw_at(M, throw_range, firer.throw_speed, F) //Firer thrown at target.
+				F.updateicon()
+				return
 		if(istype(M))
 			M.throw_at(firer, throw_range, M.throw_speed, firer) //Fun fact: living things have a throw_speed of 2.
 			M.updateicon()
+			return
 		else //Anything that isn't a /living
 			return
 	if(istype(target, /obj/item/)) //We hit an object? Pull it. This can only happen via admin shenanigans such as a gun being VV'd with this projectile.

--- a/code/modules/mob/living/simple_mob/subtypes/vore/vore.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/vore.dm
@@ -28,6 +28,7 @@
 	noisy = client.prefs_vr.noisy
 	selective_preference = client.prefs_vr.selective_preference
 	appendage_color = client.prefs_vr.appendage_color
+	appendage_alt_setting = client.prefs_vr.appendage_alt_setting
 
 	drop_vore = client.prefs_vr.drop_vore
 	stumble_vore = client.prefs_vr.stumble_vore

--- a/code/modules/vore/eating/living_vr.dm
+++ b/code/modules/vore/eating/living_vr.dm
@@ -48,6 +48,7 @@
 	var/show_vore_fx = TRUE				// Show belly fullscreens
 	var/selective_preference = DM_DEFAULT	// Preference for selective bellymode
 	var/appendage_color = "#e03997" //Default pink. Used for the 'long_vore' trait.
+	var/appendage_alt_setting = FALSE	// Dictates if 'long_vore' user pulls prey to them or not. 1 = user thrown towards target.
 	var/regen_sounds = list(
 		'sound/effects/mob_effects/xenochimera/regen_1.ogg',
 		'sound/effects/mob_effects/xenochimera/regen_2.ogg',
@@ -277,6 +278,7 @@
 	P.allow_inbelly_spawning = src.allow_inbelly_spawning
 	P.allow_spontaneous_tf = src.allow_spontaneous_tf
 	P.appendage_color = src.appendage_color
+	P.appendage_alt_setting = src.appendage_alt_setting
 	P.step_mechanics_pref = src.step_mechanics_pref
 	P.pickup_pref = src.pickup_pref
 	P.drop_vore = src.drop_vore
@@ -325,6 +327,7 @@
 	allow_inbelly_spawning = P.allow_inbelly_spawning
 	allow_spontaneous_tf = P.allow_spontaneous_tf
 	appendage_color = P.appendage_color
+	appendage_alt_setting = P.appendage_alt_setting
 	step_mechanics_pref = P.step_mechanics_pref
 	pickup_pref = P.pickup_pref
 	drop_vore = P.drop_vore

--- a/code/modules/vore/eating/vore_vr.dm
+++ b/code/modules/vore/eating/vore_vr.dm
@@ -71,6 +71,7 @@ V::::::V           V::::::VO:::::::OOO:::::::ORR:::::R     R:::::REE::::::EEEEEE
 	var/vore_taste = "nothing in particular"
 	var/vore_smell = "nothing in particular"
 	var/appendage_color = "#e03997" //Default pink. Used for the 'long_vore' trait.
+	var/appendage_alt_setting = 0	//Decides if appendage user is thrown at target or not.
 
 	var/selective_preference = DM_DEFAULT
 
@@ -173,6 +174,7 @@ V::::::V           V::::::VO:::::::OOO:::::::ORR:::::R     R:::::REE::::::EEEEEE
 	permit_healbelly = json_from_file["permit_healbelly"]
 	noisy = json_from_file["noisy"]
 	appendage_color = json_from_file["appendage_color"]
+	appendage_alt_setting = json_from_file["appendage_alt_setting"]
 	selective_preference = json_from_file["selective_preference"]
 	show_vore_fx = json_from_file["show_vore_fx"]
 	can_be_drop_prey = json_from_file["can_be_drop_prey"]
@@ -214,6 +216,8 @@ V::::::V           V::::::VO:::::::OOO:::::::ORR:::::R     R:::::REE::::::EEEEEE
 		noisy = FALSE
 	if (isnull(appendage_color))
 		appendage_color = "#e03997"
+	if (isnull(appendage_alt_setting))
+		appendage_alt_setting = 0
 	if(isnull(show_vore_fx))
 		show_vore_fx = TRUE
 	if(isnull(can_be_drop_prey))
@@ -288,6 +292,7 @@ V::::::V           V::::::VO:::::::OOO:::::::ORR:::::R     R:::::REE::::::EEEEEE
 			"permit_healbelly"		= permit_healbelly,
 			"noisy" 				= noisy,
 			"appendage_color"		= appendage_color,
+			"appendage_alt_setting" = appendage_alt_setting,
 			"selective_preference"	= selective_preference,
 			"show_vore_fx"			= show_vore_fx,
 			"can_be_drop_prey"		= can_be_drop_prey,

--- a/code/modules/vore/eating/vorepanel_vr.dm
+++ b/code/modules/vore/eating/vorepanel_vr.dm
@@ -273,6 +273,7 @@
 		"allow_inbelly_spawning" = host.allow_inbelly_spawning,
 		"allow_spontaneous_tf" = host.allow_spontaneous_tf,
 		"appendage_color" = host.appendage_color,
+		"appendage_alt_setting" = host.appendage_alt_setting,
 		"step_mechanics_active" = host.step_mechanics_pref,
 		"pickup_mechanics_active" = host.pickup_pref,
 		"noisy" = host.noisy,

--- a/code/modules/vore/mouseray.dm
+++ b/code/modules/vore/mouseray.dm
@@ -232,6 +232,7 @@
 	new_mob.noisy = noisy
 	new_mob.selective_preference = selective_preference
 	new_mob.appendage_color = appendage_color
+	new_mob.appendage_alt_setting = appendage_alt_setting
 	new_mob.drop_vore = drop_vore
 	new_mob.stumble_vore = stumble_vore
 	new_mob.slip_vore = slip_vore


### PR DESCRIPTION
- Allows Long Predatorial Reach to toggle modes. This allows you to toggle a setting which will let you:
1. Throw yourself at a prey (and eat them)
2. Throw yourself at a pred (and get eaten)
3. Throw yourself at someone while having both pred and prey on and not know the results until you bump into them! (Them eating you gets priority if they also have both enabled!)


In Zero G:
![2022-09-13_23-35-44](https://user-images.githubusercontent.com/15969779/190054690-de84e522-1cd1-4511-b66e-a95535bd72a0.gif)

In Zero G:
![2022-09-13_23-36-37](https://user-images.githubusercontent.com/15969779/190054709-806e73ce-016f-4b3b-b173-ef98490f4856.gif)

In Zero G w/ no anchors nearby:
![2022-09-13_23-37-52](https://user-images.githubusercontent.com/15969779/190054722-43162a93-3cd8-41f4-b8d3-7af609a699d6.gif)
