### PR TITLE
New->Init Pod Tweaks

### DIFF
--- a/code/datums/ghost_query.dm
+++ b/code/datums/ghost_query.dm
@@ -20,10 +20,10 @@
 
 	// Then wait awhile.
 	while(!finished)
-		spawn(1 SECOND)
-			wait_time -= 1 SECOND
-			if(wait_time <= 0)
-				finished = TRUE
+		sleep(1 SECOND)
+		wait_time -= 1 SECOND
+		if(wait_time <= 0)
+			finished = TRUE
 
 	// Prune the list after the wait, incase any candidates logged out.
 	for(var/mob/observer/dead/D as anything in candidates)

--- a/code/game/objects/effects/landmarks_poi_vr.dm
+++ b/code/game/objects/effects/landmarks_poi_vr.dm
@@ -10,7 +10,7 @@ var/global/list/global_used_pois = list()
 	var/remove_from_pool = TRUE
 
 /obj/effect/landmark/poi_loader/New()
-INITIALIZE_IMMEDIATE(/obj/effect/landmark/poi_loader)
+	LateInitialize(/obj/effect/landmark/poi_loader)
 
 /obj/effect/landmark/poi_loader/Initialize()
 	// LINTER FIX NOTE: would suggest moving this to a queue on a subsystem that can be expected to init appropriately

--- a/code/game/objects/structures/ghost_pods/event_vr.dm
+++ b/code/game/objects/structures/ghost_pods/event_vr.dm
@@ -9,7 +9,6 @@
 	anchored = TRUE
 	invisibility = INVISIBILITY_OBSERVER
 	spawn_active = TRUE
-	var/announce_prob = 35
 	var/list/possible_mobs = list("Rabbit" = /mob/living/simple_mob/vore/rabbit,
 								  "Red Panda" = /mob/living/simple_mob/vore/redpanda,
 								  "Fennec" = /mob/living/simple_mob/vore/fennec,
@@ -82,9 +81,6 @@
 	newPred.visible_message("<span class='warning'>[newPred] emerges from somewhere!</span>")
 	qdel(src)
 
-/obj/structure/ghost_pod/ghost_activated/maintpred/no_announce
-	announce_prob = 0
-
 /obj/structure/ghost_pod/ghost_activated/morphspawn
 	name = "weird goo"
 	desc = "A pile of weird gunk... Wait, is it actually moving?"
@@ -96,7 +92,6 @@
 	anchored = TRUE
 	invisibility = INVISIBILITY_OBSERVER
 	spawn_active = TRUE
-	var/announce_prob = 50
 
 /obj/structure/ghost_pod/ghost_activated/morphspawn/create_occupant(var/mob/M)
 	..()
@@ -115,6 +110,3 @@
 	newMorph.ckey = M.ckey
 	newMorph.visible_message("<span class='warning'>A morph appears to crawl out of somewhere.</span>")
 	qdel(src)
-
-/obj/structure/ghost_pod/ghost_activated/morphspawn/no_announce
-	announce_prob = 0

--- a/code/game/objects/structures/ghost_pods/ghost_pods.dm
+++ b/code/game/objects/structures/ghost_pods/ghost_pods.dm
@@ -57,7 +57,7 @@
 		// VOREStation Addition Start
 		if(!used)
 			activated = TRUE
-			ghostpod_startup(FALSE)
+			ghostpod_startup()
 		// VOREStation Addition End
 
 /obj/structure/ghost_pod/manual/attack_ai(var/mob/living/silicon/user)

--- a/code/game/objects/structures/ghost_pods/ghost_pods_vr.dm
+++ b/code/game/objects/structures/ghost_pods/ghost_pods_vr.dm
@@ -42,13 +42,10 @@
 
 	create_occupant(user)
 
-/obj/structure/ghost_pod/proc/ghostpod_startup(var/notify = FALSE)
+/obj/structure/ghost_pod/proc/ghostpod_startup()
 	if(!(src in active_ghost_pods))
 		active_ghost_pods += src
-	if(notify)
-		trigger()
 
 /obj/structure/ghost_pod/ghost_activated/Initialize()
 	. = ..()
-	// LINTER FIX NOTE: as with poi_loader, would suggest queing this, or possibly having it occur on LateInitialize or something with a set waitfor = FALSE
-	addtimer(CALLBACK(src, .proc/ghostpod_startup, spawn_active), 0)
+	ghostpod_startup()

--- a/code/modules/events/maintenance_predator_vr.dm
+++ b/code/modules/events/maintenance_predator_vr.dm
@@ -21,5 +21,4 @@
 
 	var/obj/structure/ghost_pod/ghost_activated/maintpred/M = new /obj/structure/ghost_pod/ghost_activated/maintpred(get_turf(spawnspot))
 	
-	if(prob(35))
-		M.trigger(null,"A maint pred event has occurred and called for ghosts to activate it.")
+	M.trigger(null,"A maint pred event has occurred and called for ghosts to activate it.")

--- a/code/modules/events/maintenance_predator_vr.dm
+++ b/code/modules/events/maintenance_predator_vr.dm
@@ -19,4 +19,7 @@
 		kill()		// To prevent fake announcements
 		return
 
-	new /obj/structure/ghost_pod/ghost_activated/maintpred(get_turf(spawnspot))
+	var/obj/structure/ghost_pod/ghost_activated/maintpred/M = new /obj/structure/ghost_pod/ghost_activated/maintpred(get_turf(spawnspot))
+	
+	if(prob(35))
+		M.trigger(null,"A maint pred event has occurred and called for ghosts to activate it.")

--- a/code/modules/events/morph_spawn_vr.dm
+++ b/code/modules/events/morph_spawn_vr.dm
@@ -19,4 +19,7 @@
 		kill()		// To prevent fake announcements
 		return
 
-	new /obj/structure/ghost_pod/ghost_activated/morphspawn(get_turf(spawnspot))
+	var/obj/structure/ghost_pod/ghost_activated/morphspawn/M = new /obj/structure/ghost_pod/ghost_activated/morphspawn(get_turf(spawnspot))
+	
+	if(prob(50))
+		M.trigger(null,"A morph spawn event has occurred and called for ghosts to activate it.")

--- a/code/modules/events/morph_spawn_vr.dm
+++ b/code/modules/events/morph_spawn_vr.dm
@@ -21,5 +21,4 @@
 
 	var/obj/structure/ghost_pod/ghost_activated/morphspawn/M = new /obj/structure/ghost_pod/ghost_activated/morphspawn(get_turf(spawnspot))
 	
-	if(prob(50))
-		M.trigger(null,"A morph spawn event has occurred and called for ghosts to activate it.")
+	M.trigger(null,"A morph spawn event has occurred and called for ghosts to activate it.")


### PR DESCRIPTION
Finally dug up those fixes I mentioned a little while back. This offloads the pod triggering the ghostprompt to be part of the event, rather than part of the pod being initialized and makes the poi_loader lateinit, so the linter *should* no longer get upset about there being a sleep in there.

Trigger chance is currently a prob but that can easily be removed to make it always alert ghosts if desired.

Tested and confirmed not to freeze local servers at least. I don't know if it'll actually still pass the linter, but it's worth a shot.