### PR TITLE
Add charger penalty to biofuel processors

### DIFF
--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -100,7 +100,7 @@
 
 			// Also recharge their internal battery.
 			if(H.isSynthetic() && H.nutrition < 500) //VOREStation Edit
-				H.nutrition = min(H.nutrition+10, 500) //VOREStation Edit
+				H.nutrition = min(H.nutrition+(10*(1-H.species.synthetic_food_coeff)), 500) //VOREStation Edit
 				cell.use(7000/450*10)
 
 			// And clear up radiation

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
@@ -172,11 +172,12 @@
 
 /datum/trait/neutral/synth_chemfurnace
 	name = "Biofuel Processor"
-	desc = "You are able to gain energy through consuming and processing normal food. Energy-dense foods such as protein bars and survival food will yield the best results."
+	desc = "You are able to gain energy through consuming and processing normal food, at the cost of significantly slower recharging via cyborg chargers. Energy-dense foods such as protein bars and survival food will yield the best results."
 	cost = 0
 	custom_only = FALSE
 	can_take = SYNTHETICS
 	var_changes = list("organic_food_coeff" = 0, "synthetic_food_coeff" = 0.6)
+	excludes = list(/datum/trait/neutral/biofuel_value_down)
 
 /datum/trait/neutral/glowing_eyes
 	name = "Glowing Eyes"
@@ -614,7 +615,7 @@
 
 /datum/trait/neutral/biofuel_value_down
 	name = "Discount Biofuel processor"
-	desc = "You are able to gain energy through consuming and processing normal food. Unfortunately, it is half as effective as premium models."
+	desc = "You are able to gain energy through consuming and processing normal food. Unfortunately, it is half as effective as premium models. On the plus side, you still recharge from charging stations fairly efficiently."
 	cost = 0
 	custom_only = FALSE
 	can_take = SYNTHETICS


### PR DESCRIPTION
This takes an idea from #13102 and makes it so that charger recovery scales inversely with your biofuel processor efficiency.

To break it down simply;
- If you have no biofuel processor, you recharge normally; 10 nutrition per tick, up to 500.
- If you have the discount processor (30% nutrition gain from food, ish?) you recover 7 per tick.
- If you have a standard processor (60% nutrition gain from food) you recover only 4 per tick.

Now the 'standard' tier is actually a tradeoff as you *need* to have food available if you want to stay topped off, because if you don't (or can't) then recharging at a station will be much slower.

I considered adding a 'premium' tier which is 100% gain from food for no charger gain, but I'm not sure if that should be a positive or a neutral.