### PR TITLE
Removes a redundant icon update

### DIFF
--- a/code/modules/vore/eating/living_vr.dm
+++ b/code/modules/vore/eating/living_vr.dm
@@ -638,8 +638,6 @@
 		qdel(H)
 	else
 		belly.nom_mob(prey, user)
-	if(!ishuman(user))
-		user.update_icons()
 
 	// Inform Admins
 	if(pred == user)


### PR DESCRIPTION
The belly object already does it on its own when something enters it before this update would even happen, so all it actually ended up doing was messing up y_scale tweaked simplemob vertical offset by un-doing the update_transform that happened when prey entered the belly a few lines earlier into the proc.