### PR TITLE
Fixes a few bugs/runtimes

### DIFF
--- a/code/game/machinery/frame.dm
+++ b/code/game/machinery/frame.dm
@@ -81,31 +81,6 @@
 	frame_class = FRAME_CLASS_MACHINE
 	frame_size = 4
 
-/datum/frame/frame_types/oven
-	name = "Oven"
-	frame_class = FRAME_CLASS_MACHINE
-	frame_size = 4
-
-/datum/frame/frame_types/fryer
-	name = "Fryer"
-	frame_class = FRAME_CLASS_MACHINE
-	frame_size = 4
-
-/datum/frame/frame_types/grill
-	name = "Grill"
-	frame_class = FRAME_CLASS_MACHINE
-	frame_size = 4
-
-/datum/frame/frame_types/cerealmaker
-	name = "Cereal Maker"
-	frame_class = FRAME_CLASS_MACHINE
-	frame_size = 4
-
-/datum/frame/frame_types/candymachine
-	name = "Candy Machine"
-	frame_class = FRAME_CLASS_MACHINE
-	frame_size = 4
-
 /datum/frame/frame_types/fax
 	name = "Fax"
 	frame_class = FRAME_CLASS_MACHINE
@@ -221,7 +196,7 @@
 	frame_style = FRAME_STYLE_WALL
 	x_offset = 28
 	y_offset = 28
-	
+
 /datum/frame/frame_types/arfgs
 	name = "ARF Generator"
 	frame_class = FRAME_CLASS_MACHINE

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -322,7 +322,7 @@ GLOBAL_DATUM(autospeaker, /mob/living/silicon/ai/announcer)
 	GLOB.autospeaker.SetName(from)
 	Broadcast_Message(connection, GLOB.autospeaker,
 						0, "*garbled automated announcement*", src,
-						message_to_multilingual(message), from, "Automated Announcement", from, "synthesized voice",
+						message_to_multilingual(message, LANGUAGE_GALCOM), from, "Automated Announcement", from, "synthesized voice",
 						DATA_FAKE, 0, zlevels, connection.frequency, states)	//VOREStation Edit
 
 // Interprets the message mode when talking into a radio, possibly returning a connection datum

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -322,7 +322,7 @@ GLOBAL_DATUM(autospeaker, /mob/living/silicon/ai/announcer)
 	GLOB.autospeaker.SetName(from)
 	Broadcast_Message(connection, GLOB.autospeaker,
 						0, "*garbled automated announcement*", src,
-						message_to_multilingual(message, LANGUAGE_GALCOM), from, "Automated Announcement", from, "synthesized voice",
+						message_to_multilingual(message, GLOB.all_languages[LANGUAGE_GALCOM]), from, "Automated Announcement", from, "synthesized voice",
 						DATA_FAKE, 0, zlevels, connection.frequency, states)	//VOREStation Edit
 
 // Interprets the message mode when talking into a radio, possibly returning a connection datum

--- a/code/game/objects/items/weapons/circuitboards/machinery/kitchen_appliances.dm
+++ b/code/game/objects/items/weapons/circuitboards/machinery/kitchen_appliances.dm
@@ -16,7 +16,7 @@
 	name = T_BOARD("oven")
 	desc = "The circuitboard for an oven."
 	build_path = /obj/machinery/appliance/cooker/oven
-	board_type = new /datum/frame/frame_types/oven
+	board_type = new /datum/frame/frame_types/machine
 	matter = list(MAT_STEEL = 50, MAT_GLASS = 50)
 	req_components = list(
 							/obj/item/weapon/stock_parts/capacitor = 3,
@@ -27,17 +27,17 @@
 	name = T_BOARD("deep fryer")
 	desc = "The circuitboard for a deep fryer."
 	build_path = /obj/machinery/appliance/cooker/fryer
-	board_type = new /datum/frame/frame_types/fryer
+	board_type = new /datum/frame/frame_types/machine
 	req_components = list(
 							/obj/item/weapon/stock_parts/capacitor = 3,
 							/obj/item/weapon/stock_parts/scanning_module = 1,
 							/obj/item/weapon/stock_parts/matter_bin = 2)
-							
+
 /obj/item/weapon/circuitboard/grill
 	name = T_BOARD("grill")
 	desc = "The circuitboard for an industrial grill."
 	build_path = /obj/machinery/appliance/cooker/grill
-	board_type = new /datum/frame/frame_types/grill
+	board_type = new /datum/frame/frame_types/machine
 	req_components = list(
 							/obj/item/weapon/stock_parts/capacitor = 3,
 							/obj/item/weapon/stock_parts/scanning_module = 1,
@@ -47,7 +47,7 @@
 	name = T_BOARD("cereal maker")
 	desc = "The circuitboard for a cereal maker."
 	build_path = /obj/machinery/appliance/mixer/cereal
-	board_type = new /datum/frame/frame_types/cerealmaker
+	board_type = new /datum/frame/frame_types/machine
 	req_components = list(
 							/obj/item/weapon/stock_parts/capacitor = 3,
 							/obj/item/weapon/stock_parts/scanning_module = 1,
@@ -57,7 +57,7 @@
 	name = T_BOARD("candy machine")
 	desc = "The circuitboard for a candy machine."
 	build_path = /obj/machinery/appliance/mixer/candy
-	board_type = new /datum/frame/frame_types/candymachine
+	board_type = new /datum/frame/frame_types/machine
 	req_components = list(
 							/obj/item/weapon/stock_parts/capacitor = 3,
 							/obj/item/weapon/stock_parts/scanning_module = 1,

--- a/code/modules/mob/new_player/sprite_accessories.dm
+++ b/code/modules/mob/new_player/sprite_accessories.dm
@@ -1605,27 +1605,27 @@ shaved
 	icon_state = "facial_dwarf"
 
 /datum/sprite_accessory/facial_hair/threeOclock
-	name = "3 O'clock Shadow"
+	name = "3 O-clock Shadow"
 	icon_state = "facial_3oclock"
 
 /datum/sprite_accessory/facial_hair/threeOclockstache
-	name = "3 O'clock Shadow and Moustache"
+	name = "3 O-clock Shadow and Moustache"
 	icon_state = "facial_3oclockmoustache"
 
 /datum/sprite_accessory/facial_hair/fiveOclock
-	name = "5 O'clock Shadow"
+	name = "5 O-clock Shadow"
 	icon_state = "facial_5oclock"
 
 /datum/sprite_accessory/facial_hair/fiveOclockstache
-	name = "5 O'clock Shadow and Moustache"
+	name = "5 O-clock Shadow and Moustache"
 	icon_state = "facial_5oclockmoustache"
 
 /datum/sprite_accessory/facial_hair/sevenOclock
-	name = "7 O'clock Shadow"
+	name = "7 O-clock Shadow"
 	icon_state = "facial_7oclock"
 
 /datum/sprite_accessory/facial_hair/sevenOclockstache
-	name = "7 O'clock Shadow and Moustache"
+	name = "7 O-clock Shadow and Moustache"
 	icon_state = "facial_7oclockmoustache"
 
 /datum/sprite_accessory/facial_hair/mutton

--- a/code/modules/mob/new_player/sprite_accessories_vr.dm
+++ b/code/modules/mob/new_player/sprite_accessories_vr.dm
@@ -571,7 +571,7 @@
 	var/desc = "You should not see this..."
 
 /datum/sprite_accessory/hair_accessory/verie_hair_glow
-	name = "verie's hair glow"
+	name = "veries hair glow"
 	desc = ""
 	icon_state = "verie_hair_glow"
 	ignores_lighting = 1


### PR DESCRIPTION
Fixes runtime with simplemobs hearing autosay announcements (possibly allows them to hear them properly in process?)

Fixes runtime related to 's in names of sprite accessories

Fixes invisible frame types for grill, oven, fryer, cereal maker and candy machine by removing them all. All of those are now built using generic machine frame.