### PR TITLE
Removes hotfood vendors from station spawning

### DIFF
--- a/code/datums/supplypacks/vending_refills_vr.dm
+++ b/code/datums/supplypacks/vending_refills_vr.dm
@@ -18,11 +18,6 @@
 	name = "SweatMAX Vendor Refill Cartridge"
 	cost = 10
 
-/datum/supply_pack/vending_refills/hotfood
-	contains = list(/obj/item/weapon/refill_cartridge/autoname/food/hotfood)
-	name = "Hot Foods Vendor Refill Cartridge"
-	cost = 10
-
 /datum/supply_pack/vending_refills/weeb
 	contains = list(/obj/item/weapon/refill_cartridge/autoname/food/weeb)
 	name = "Nippon-tan Vendor Refill Cartridge"
@@ -122,7 +117,6 @@
 	num_contained = 5
 	contains = list(/obj/item/weapon/refill_cartridge/autoname/food/snack,
 					/obj/item/weapon/refill_cartridge/autoname/food/fitness,
-					/obj/item/weapon/refill_cartridge/autoname/food/hotfood,
 					/obj/item/weapon/refill_cartridge/autoname/food/weeb,
 					/obj/item/weapon/refill_cartridge/autoname/food/sol,
 					/obj/item/weapon/refill_cartridge/autoname/food/snix,

--- a/code/game/objects/random/mapping.dm
+++ b/code/game/objects/random/mapping.dm
@@ -77,7 +77,6 @@
 				prob(3);/obj/machinery/vending/fitness,
 				prob(4);/obj/machinery/vending/cigarette,
 				prob(3);/obj/machinery/vending/giftvendor,
-				prob(1);/obj/machinery/vending/hotfood,
 				prob(5);/obj/machinery/vending/weeb,
 				prob(5);/obj/machinery/vending/sol,
 				prob(5);/obj/machinery/vending/snix,

--- a/code/modules/economy/vending_refills.dm
+++ b/code/modules/economy/vending_refills.dm
@@ -49,7 +49,6 @@
 	icon_state = "rc_food"
 	refill_type = list(/obj/machinery/vending/snack,
 					   /obj/machinery/vending/fitness,
-					   /obj/machinery/vending/hotfood,
 					   /obj/machinery/vending/weeb,
 					   /obj/machinery/vending/sol,
 					   /obj/machinery/vending/snix,
@@ -103,9 +102,6 @@
 
 /obj/item/weapon/refill_cartridge/autoname/food/fitness
 	refill_type = /obj/machinery/vending/fitness
-
-/obj/item/weapon/refill_cartridge/autoname/food/hotfood
-	refill_type = /obj/machinery/vending/hotfood
 
 /obj/item/weapon/refill_cartridge/autoname/food/weeb
 	refill_type = /obj/machinery/vending/weeb


### PR DESCRIPTION
Its a vendor with poisoned food originally meant for spawning in pois with 'expired food' meme. It also randomly had carpotoxin aparently?! Basically makes it not appear in station spawning pool, and removes cartridges for it from cargo.