### PR TITLE
Fixes recursive explosions

### DIFF
--- a/code/game/objects/explosion_recursive.dm
+++ b/code/game/objects/explosion_recursive.dm
@@ -6,19 +6,14 @@
 /obj
 	var/explosion_resistance
 
-
-
-var/list/explosion_turfs = list()
-
-var/explosion_in_progress = 0
-
-
 /proc/explosion_rec(turf/epicenter, power)
+	var/list/explosion_turfs = list()
+	var/explosion_in_progress = 0
 
 	var/loopbreak = 0
 	while(explosion_in_progress)
 		if(loopbreak >= 15) return
-		sleep(10)
+		spawn(10)
 		loopbreak++
 
 	if(power <= 0) return
@@ -39,7 +34,7 @@ var/explosion_in_progress = 0
 	//This steap handles the gathering of turfs which will be ex_act() -ed in the next step. It also ensures each turf gets the maximum possible amount of power dealt to it.
 	for(var/direction in cardinal)
 		var/turf/T = get_step(epicenter, direction)
-		T.explosion_spread(power - epicenter.explosion_resistance, direction)
+		T.explosion_spread(power - epicenter.explosion_resistance, direction, explosion_turfs)
 
 	//This step applies the ex_act effects for the explosion, as planned in the previous step.
 	for(var/turf/T in explosion_turfs)
@@ -56,8 +51,10 @@ var/explosion_in_progress = 0
 		T.ex_act(severity)
 		if(!T)
 			T = locate(x,y,z)
-		for(var/atom/A in T)
-			A.ex_act(severity)
+		for(var/atom_movable in T.contents)
+			var/atom/movable/AM = atom_movable
+			if(AM && AM.simulated)
+				AM.ex_act(severity)
 
 	explosion_in_progress = 0
 
@@ -65,6 +62,9 @@ var/explosion_in_progress = 0
 	var/explosion_resistance
 
 /turf/space
+	explosion_resistance = 3
+
+/turf/simulated/open
 	explosion_resistance = 3
 
 /turf/simulated/floor
@@ -90,17 +90,12 @@ var/explosion_in_progress = 0
 
 //Code-wise, a safe value for power is something up to ~25 or ~30.. This does quite a bit of damage to the station.
 //direction is the direction that the spread took to come to this tile. So it is pointing in the main blast direction - meaning where this tile should spread most of it's force.
-/turf/proc/explosion_spread(power, direction)
+/turf/proc/explosion_spread(power, direction, var/list/explosion_turfs)
 	if(power <= 0)
 		return
-
-	/*
-	sleep(2)
-	new/obj/effect/debugging/marker(src)
-	*/
-
-	if(explosion_turfs[src] >= power)
-		return //The turf already sustained and spread a power greated than what we are dealing with. No point spreading again.
+	if(src in explosion_turfs)
+		if(explosion_turfs[src] >= power)
+			return //The turf already sustained and spread a power greated than what we are dealing with. No point spreading again.
 	explosion_turfs[src] = power
 
 	var/spread_power = power - src.explosion_resistance //This is the amount of power that will be spread to the tile in the direction of the blast
@@ -109,11 +104,11 @@ var/explosion_in_progress = 0
 			spread_power -= O.explosion_resistance
 
 	var/turf/T = get_step(src, direction)
-	T.explosion_spread(spread_power, direction)
+	T.explosion_spread(spread_power, direction, explosion_turfs)
 	T = get_step(src, turn(direction,90))
-	T.explosion_spread(spread_power, turn(direction,90))
+	T.explosion_spread(spread_power, turn(direction,90), explosion_turfs)
 	T = get_step(src, turn(direction,-90))
-	T.explosion_spread(spread_power, turn(direction,90))
+	T.explosion_spread(spread_power, turn(direction,-90), explosion_turfs)
 
 /turf/unsimulated/explosion_spread(power)
 	return //So it doesn't get to the parent proc, which simulates explosions


### PR DESCRIPTION
Makes them not bug out and not have infinite loops or make L shaped explosions.

Not enabled in the config, so doesn't technically effect us unless it's enabled down the line for whatever reason. 
(It makes explosions in open spaces larger and explosions in enclosed spaces smaller. Takes cover into account. Etc. More destructive booms but more realistic. Also is more resource intensive but I can't confirm how much.)

<img width="634" alt="Recursive fix" src="https://user-images.githubusercontent.com/15969779/191390727-8757b8da-acc4-44f9-bbe1-2218e24ef585.png">