### PR TITLE
Lighting Underlay Stacking Fix

### DIFF
--- a/code/game/turfs/simulated/floor_types.dm
+++ b/code/game/turfs/simulated/floor_types.dm
@@ -111,7 +111,7 @@
 /turf/simulated/shuttle/proc/underlay_update()
 	if(!takes_underlays)
 		//Basically, if it's not forced, and we don't care, don't do it.
-		return 0
+		return
 
 	var/turf/under //May be a path or a turf
 	var/mutable_appearance/us = new(src) //We'll use this for changes later


### PR DESCRIPTION
Ported from Chomp. From https://github.com/CHOMPStation2/CHOMPStation2/pull/3072

Fixes what https://github.com/VOREStation/VOREStation/pull/11718 and https://github.com/VOREStation/VOREStation/pull/11687 was attempting to fix.

Return 0 would add a blank value to a LIST and there was no GC for it. Nothing else seems adversely affected by this change to remove the 0 and just have it return.