### PR TITLE
Fixes micro pick-up temporary toggle to work properly

### DIFF
--- a/code/modules/vore/resizing/resize_vr.dm
+++ b/code/modules/vore/resizing/resize_vr.dm
@@ -167,7 +167,7 @@
  * @return false if normal code should continue, 1 to prevent normal code.
  */
 /mob/living/proc/attempt_to_scoop(mob/living/M, mob/living/G) //second one is for the Grabber, only exists for animals to self-grab
-	if(!(pickup_pref && M.pickup_pref && pickup_active))
+	if(!(pickup_pref && M.pickup_pref && M.pickup_active))
 		return 0
 	if(!(M.a_intent == I_HELP))
 		return 0


### PR DESCRIPTION
As description and my own intent states, it was SUPPOSED to be something for the big to toggle when they want to pat the micro without completely disabling interactions. However due to a bug, the pref affected not whether you will help-intent pick up micros but whether others can pick you up. This fixes that, to bring it in line with verb description.