### PR TITLE
Add digi5 to Black-Eyed Shadekin whitelist

### DIFF
--- a/config/alienwhitelist.txt
+++ b/config/alienwhitelist.txt
@@ -32,6 +32,7 @@ cryohydra - Protean
 cubejackal - Black-Eyed Shadekin
 detectivegoogle - Protean
 digi5 - Protean
+digi5 - Black-Eyed Shadekin
 digitalsquirrel95 - Black-Eyed Shadekin
 digitalsquirrel95 - Protean
 draycu - Vox


### PR DESCRIPTION
Adds digi5 to the Black-Eyed Shadekin species whitelist, as per this forum post:
https://forum.vore-station.net/viewtopic.php?f=46&t=2181

uwu vories