### PR TITLE
Buffs Vore

### DIFF
--- a/code/modules/vore/eating/vorepanel_vr.dm
+++ b/code/modules/vore/eating/vorepanel_vr.dm
@@ -792,7 +792,7 @@
 						return
 					if(isliving(usr))
 						var/mob/living/l = usr
-						var/thismuch = ourtarget.health
+						var/thismuch = ourtarget.health + 100
 						if(ishuman(l))
 							var/mob/living/carbon/human/h = l
 							thismuch = thismuch * h.species.digestion_nutrition_modifier

--- a/code/modules/vore/eating/vorepanel_vr.dm
+++ b/code/modules/vore/eating/vorepanel_vr.dm
@@ -790,6 +790,13 @@
 					if(ourtarget.loc != b)
 						to_chat(usr, "<span class= 'warning'>\The [ourtarget] is no longer in \the [b].</span>")
 						return
+					if(isliving(usr))
+						var/mob/living/l = usr
+						var/thismuch = ourtarget.health
+						if(ishuman(l))
+							var/mob/living/carbon/human/h = l
+							thismuch = thismuch * h.species.digestion_nutrition_modifier
+						l.adjust_nutrition(thismuch)
 					b.handle_digestion_death(ourtarget)
 				if("Absorb")
 					if(tgui_alert(ourtarget, "\The [usr] is attempting to instantly absorb you. Is this something you are okay with happening to you?","Instant Absorb", list("No", "Yes")) != "Yes")


### PR DESCRIPTION
Adds the 'process' option to the list of things you can do to prey in your bellies!

This option will let you pick between digest and absorb, when you pick one, it lets the prey know what you are trying to do and has them confirm! If they confirm and are still in the belly, then that option will instantly happen to them.

The options available to you when you click it are dependent on the prey's prefs, so, if a prey has digest turned off, but absorb turned on, then it will only offer absorb! If they have both disabled, then it will tell you no!

This way if you want to gurg someone up real fast once your scene is done or whatever, you don't have to adjust all your gurg values or whatever.

This does also allow one to SELECTIVELY digest or absorb people even if they are in the same tummy, which I think is very radical.