### PR TITLE
fixes psilocybin

### DIFF
--- a/code/modules/reagents/reagents/drugs.dm
+++ b/code/modules/reagents/reagents/drugs.dm
@@ -143,6 +143,7 @@
 
 	M.druggy = max(M.druggy, 30)
 
+	var/drug_strength = 20
 	var/effective_dose = dose
 	if(issmall(M)) effective_dose *= 2
 	if(effective_dose < 1 * threshold)
@@ -156,6 +157,7 @@
 		M.make_jittery(5)
 		M.make_dizzy(5)
 		M.druggy = max(M.druggy, 35)
+		M.hallucination = max(M.hallucination, drug_strength * threshold)
 		if(prob(5) && prob_proc == TRUE)
 			M.emote(pick("twitch", "giggle"))
 			prob_proc = FALSE
@@ -164,6 +166,7 @@
 		M.make_jittery(10)
 		M.make_dizzy(10)
 		M.druggy = max(M.druggy, 40)
+		M.hallucination = max(M.hallucination, drug_strength * threshold)
 		if(prob(10) && prob_proc == TRUE)
 			M.emote(pick("twitch", "giggle"))
 			prob_proc = FALSE

--- a/html/changelogs/cameron - drugfix.yml
+++ b/html/changelogs/cameron - drugfix.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Cameron
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "psilocybin now makes you hallucinate."


### PR DESCRIPTION
Does the bugfix that #13186 contains without adjusting hyperzine.

Adjusting hyperzine should be it's own individual PR.

I also want to fiddle with changelogs so this is the perfect opportunity





## changelog
🆑
fix: psilocybin now makes you hallucinate
/🆑