### PR TITLE
Complicates Pakkuns

### DIFF
--- a/code/modules/mob/living/simple_mob/subtypes/vore/pakkun.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/pakkun.dm
@@ -20,6 +20,7 @@
 	icon_dead = "pakkun-dead"
 	icon_living = "pakkun"
 	icon_state = "pakkun"
+	icon_rest = "pakkun-rest"
 	icon = 'icons/mob/vore.dmi'
 
 	faction = "pakkun"
@@ -46,8 +47,46 @@
 	projectilesound = 'sound/effects/slime_squish.ogg'
 
 	ai_holder_type = /datum/ai_holder/simple_mob/ranged/pakkun
+	vore_default_mode = DM_SELECT
 
 	var/extra_posessive = FALSE					// Enable if you want their tummy hugs to be inescapable
+	var/autorest_cooldown = 100
+
+/mob/living/simple_mob/vore/pakkun/Life()
+	. = ..()
+	if(autorest_cooldown)
+		autorest_cooldown --
+	else if(prob(5) && ai_holder.stance == STANCE_IDLE)
+		autorest_cooldown = rand(50,200)
+		lay_down()
+
+/mob/living/simple_mob/vore/pakkun/lay_down()
+	. = ..()
+	if(client)
+		return
+	if(!ai_holder)
+		return
+
+	if(resting)
+		vore_selected.digest_mode = DM_UNABSORB
+		ai_holder.go_sleep()
+
+	else
+		vore_selected.digest_mode = vore_default_mode
+		ai_holder.go_wake()
+
+/mob/living/simple_mob/vore/pakkun/attack_hand(mob/user)
+	if(stat == DEAD)
+		return ..()
+	if(user.a_intent != I_HELP)
+		return ..()
+	if(resting)
+		playsound(src, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
+		user.visible_message("<span class='notice'>\The [user] shakes \the [src] awake.</span>","<span class='notice'>You shake \the [src] awake!</span>")
+		lay_down()
+		return
+	else
+		return ..()
 
 /datum/ai_holder/simple_mob/ranged/pakkun
 	pointblank = TRUE
@@ -121,6 +160,7 @@
 	icon_dead = "snapdragon-dead"
 	icon_living = "snapdragon"
 	icon_state = "snapdragon"
+	icon_rest = "snapdragon-rest"
 
 	extra_posessive = TRUE //you're gonna get KEPT, at least the first time you go in
 	maxHealth = 100
@@ -138,8 +178,10 @@
 	icon_dead = "snappy-dead"
 	icon_living = "snappy"
 	icon_state = "snappy"
+	icon_rest = "snappy-rest"
 
 	ai_holder_type = /datum/ai_holder/simple_mob/ranged/pakkun/snappy
+	vore_default_mode = DM_HOLD
 	var/list/petters = list()
 
 /datum/ai_holder/simple_mob/ranged/pakkun/snappy/list_targets()
@@ -172,4 +214,3 @@
 	most of her girth. Your movements are rewarded only with squeezing from outside, the skin of the reptile easily stretching out to match your movements no matter how hard you try to push. If anything, \
 	wriggling about just seems to prompt the playful creature to mess with you more, mooshing her paws into the bulges you make, wrapping both arms around you and squeezing you tight, making it absolutely \
 	plain that she's more than happy to just keep you in there - and is more than capable of doing so if she so chooses."
-

--- a/code/modules/mob/living/simple_mob/subtypes/vore/pakkun.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/pakkun.dm
@@ -54,6 +54,11 @@
 
 /mob/living/simple_mob/vore/pakkun/Life()
 	. = ..()
+	if(client)
+		return
+	if(!ai_holder)
+		return
+
 	if(autorest_cooldown)
 		autorest_cooldown --
 	else if(prob(5) && ai_holder.stance == STANCE_IDLE)


### PR DESCRIPTION
Pakkuns now occasionally try to rest!

When they rest, they set their digest mode to unabsorb! So, if you end up absorbed you can still escape eventually.

Resting Pakkun also have their AI set to sleep, so they will not engage, so this may be able to be used to sneak past, or up to them!

Also makes it so that when you help click them while they are resting, they will wake up! and re-enable their AI, if they have one.

They also turn their digest mode back to the default setting when they stop resting.

All of this of course, only happens when they don't have a client.