### PR TITLE
Fixes build mode and makes it not terrible.

### DIFF
--- a/code/modules/admin/verbs/buildmode.dm
+++ b/code/modules/admin/verbs/buildmode.dm
@@ -252,7 +252,7 @@
 			if(BUILDMODE_BASIC)
 
 				return 1
-			if(BUILDMODE_ADVANCED) //BUILDMODE-ADVANCED-DEBUGGING-COMMENT
+			if(BUILDMODE_ADVANCED)
 				objholder = get_path_from_partial_text()
 
 			if(BUILDMODE_EDIT)
@@ -373,7 +373,7 @@
 				easter_egg.color = "#a418c7"
 
 
-		if(BUILDMODE_ADVANCED) //BUILDMODE-ADVANCED-DEBUGGING-COMMENT
+		if(BUILDMODE_ADVANCED)
 			if(pa.Find("left") && !pa.Find("ctrl"))
 				if(ispath(holder.buildmode.objholder,/turf))
 					var/turf/T = get_turf(object)
@@ -638,7 +638,7 @@
 			to_chat(user, span("notice", "Band-selected [i] mobs."))
 			return
 
-/obj/effect/bmode/buildmode/proc/get_path_from_partial_text(default_path) //BUILDMODE-ADVANCED-DEBUGGING-COMMENT
+/obj/effect/bmode/buildmode/proc/get_path_from_partial_text(default_path)
 	var/desired_path = tgui_input_text(usr, "Enter full or partial typepath.","Typepath","[default_path]")
 
 	if(!desired_path)	//VOREStation Add - If you don't give it anything it builds a list of every possible thing in the game and crashes your client.

--- a/code/modules/admin/verbs/buildmode.dm
+++ b/code/modules/admin/verbs/buildmode.dm
@@ -189,6 +189,7 @@
 	var/atom/movable/throw_atom = null
 	var/list/selected_mobs = list()
 	var/copied_faction = null
+	var/warned = 0
 
 /obj/effect/bmode/buildholder/Destroy()
 	qdel(builddir)
@@ -219,7 +220,7 @@
 	screen_loc = "NORTH,WEST+2"
 	var/varholder = "name"
 	var/valueholder = "derp"
-	var/objholder = /obj/structure/closet
+	var/objholder = null
 	var/objsay = 1
 
 	var/wall_holder = /turf/simulated/wall
@@ -251,8 +252,8 @@
 			if(BUILDMODE_BASIC)
 
 				return 1
-			if(BUILDMODE_ADVANCED)
-				objholder = get_path_from_partial_text(/obj/structure/closet)
+			if(BUILDMODE_ADVANCED) //BUILDMODE-ADVANCED-DEBUGGING-COMMENT
+				objholder = get_path_from_partial_text()
 
 			if(BUILDMODE_EDIT)
 				var/list/locked = list("vars", "key", "ckey", "client", "firemut", "ishulk", "telekinesis", "xray", "virus", "viruses", "cuffed", "ka", "last_eaten", "urine")
@@ -330,7 +331,13 @@
 					return
 				else if(istype(object,/turf/simulated/floor))
 					var/turf/T = object
-					T.ChangeTurf(/turf/space)
+					if(!holder.warned)
+						var/warning = tgui_alert(user, "Are you -sure- you want to delete this turf and make it the base turf for this Z level?", "GRIEF ALERT", list("No", "Yes"))
+						if(warning == "Yes")
+							holder.warned = 1
+						else
+							return
+					T.ChangeTurf(get_base_turf_by_area(T)) //Defaults to Z if area does not have a special base turf.
 					return
 				else if(istype(object,/turf/simulated/wall/r_wall))
 					var/turf/T = object
@@ -358,8 +365,15 @@
 					if(NORTHWEST)
 						var/obj/structure/window/reinforced/WIN = new/obj/structure/window/reinforced(get_turf(object))
 						WIN.set_dir(NORTHWEST)
+			else if(istype(object,/turf) && pa.Find("ctrl") && pa.Find("alt") && pa.Find("middle"))
+				var/turf/T = object
+				var/obj/item/toy/plushie/teshari/easter_egg = new /obj/item/toy/plushie/teshari(T)
+				easter_egg.name = "coding teshari plushie"
+				easter_egg.desc = "A small purple teshari with a plush keyboard attached to it. Where did this come from?"
+				easter_egg.color = "#a418c7"
 
-		if(BUILDMODE_ADVANCED)
+
+		if(BUILDMODE_ADVANCED) //BUILDMODE-ADVANCED-DEBUGGING-COMMENT
 			if(pa.Find("left") && !pa.Find("ctrl"))
 				if(ispath(holder.buildmode.objholder,/turf))
 					var/turf/T = get_turf(object)
@@ -624,7 +638,7 @@
 			to_chat(user, span("notice", "Band-selected [i] mobs."))
 			return
 
-/obj/effect/bmode/buildmode/proc/get_path_from_partial_text(default_path)
+/obj/effect/bmode/buildmode/proc/get_path_from_partial_text(default_path) //BUILDMODE-ADVANCED-DEBUGGING-COMMENT
 	var/desired_path = tgui_input_text(usr, "Enter full or partial typepath.","Typepath","[default_path]")
 
 	if(!desired_path)	//VOREStation Add - If you don't give it anything it builds a list of every possible thing in the game and crashes your client.
@@ -647,8 +661,6 @@
 		result = matches[1]
 	else
 		result = tgui_input_list(usr, "Select an atom type", "Spawn Atom", matches, strict_modern = TRUE)
-		if(!objholder)
-			result = default_path
 	return result
 
 /obj/effect/bmode/buildmode/proc/make_rectangle(var/turf/A, var/turf/B, var/turf/wall_type, var/turf/floor_type)


### PR DESCRIPTION
- Makes Basic build mode warn you before you delete the ground and space everyone
- Makes Basic build mode turn the turf you deleted into the base turf for the area. If area base turf is not available, it goes with the base turf of the Z level.
- Makes Advanced build mode start with Null. No more spawning lockers and qdel()ing players!
- Fixes a longstanding bug where if you cancelled selection in build mode and then tried to select something from the list, it defaulted to a locker. Instead, if you cancel it, it defaults back to null and lists work like normal.


🆑
- bugfix: Fixes build mode. No more admins deleting or spacing you by mistake.

/🆑