### PR TITLE
Adds in 'compliance implant'

### DIFF
--- a/code/game/objects/items/contraband_vr.dm
+++ b/code/game/objects/items/contraband_vr.dm
@@ -51,6 +51,7 @@
 						/obj/item/device/perfect_tele,
 						/obj/item/device/sleevemate,
 						/obj/item/weapon/disk/nifsoft/compliance,
+						/obj/item/weapon/implanter/compliance,
 						/obj/item/seeds/ambrosiadeusseed,
 						/obj/item/seeds/ambrosiavulgarisseed,
 						/obj/item/seeds/libertymycelium,

--- a/code/game/objects/items/weapons/implants/implant_vr.dm
+++ b/code/game/objects/items/weapons/implants/implant_vr.dm
@@ -198,11 +198,11 @@ Obviously lethal commands such as telling the subject to kill themselves or harm
 	var/mob/living/carbon/human/target = source
 	if(!target.nif || target.nif.stat != NIF_WORKING) //No nif or their NIF is broken.
 		to_chat(target, "<span class='notice'>You suddenly feel compelled to follow the following commands: [laws]</span>")
-		to_chat(target, "<span class='notice'>((OOC NOTE: Obviously lethal commands or commands that harm others should be disregarded.))</span>")
+		to_chat(target, "<span class='notice'>((OOC NOTE: Obviously suicidal commands should be disregarded. The implant doesn't stop your self preservation.))</span>")
 		to_chat(target, "<span class='notice'>((OOC NOTE: Your new commands can be checked at any time by using the 'notes' command in chat. Additionally, if you did not agree to this, you are not compelled to follow the implant.))</span>")
 		target.add_memory(laws)
 		return
 	else //You got a nif...Upload time.
 		new nif_payload(target.nif,laws)
-		to_chat(target, "<span class='notice'>((OOC NOTE: Obviously lethal commands or commands that harm others should be disregarded.))</span>")
+		to_chat(target, "<span class='notice'>((OOC NOTE: Obviously suicidal commands should be disregarded. The implant doesn't stop your self preservation.))</span>")
 		to_chat(target, "<span class='notice'>((OOC NOTE: If you did not agree to this, you are not compelled to follow the laws.))</span>")

--- a/code/game/objects/items/weapons/implants/implant_vr.dm
+++ b/code/game/objects/items/weapons/implants/implant_vr.dm
@@ -198,11 +198,11 @@ Obviously lethal commands such as telling the subject to kill themselves or harm
 	var/mob/living/carbon/human/target = source
 	if(!target.nif || target.nif.stat != NIF_WORKING) //No nif or their NIF is broken.
 		to_chat(target, "<span class='notice'>You suddenly feel compelled to follow the following commands: [laws]</span>")
-		to_chat(target, "<span class='notice'>((OOC NOTE: Obviously suicidal commands should be disregarded. The implant doesn't stop your self preservation.))</span>")
+		to_chat(target, "<span class='notice'>((OOC NOTE: Commands that go against server rules should be disregarded and ahelped.))</span>")
 		to_chat(target, "<span class='notice'>((OOC NOTE: Your new commands can be checked at any time by using the 'notes' command in chat. Additionally, if you did not agree to this, you are not compelled to follow the implant.))</span>")
 		target.add_memory(laws)
 		return
 	else //You got a nif...Upload time.
 		new nif_payload(target.nif,laws)
-		to_chat(target, "<span class='notice'>((OOC NOTE: Obviously suicidal commands should be disregarded. The implant doesn't stop your self preservation.))</span>")
+		to_chat(target, "<span class='notice'>((OOC NOTE: Commands that go against server rules should be disregarded and ahelped.))</span>")
 		to_chat(target, "<span class='notice'>((OOC NOTE: If you did not agree to this, you are not compelled to follow the laws.))</span>")

--- a/code/game/objects/items/weapons/implants/implant_vr.dm
+++ b/code/game/objects/items/weapons/implants/implant_vr.dm
@@ -133,3 +133,76 @@
 	..()
 	update()
 	return
+
+
+//////////////////////////////
+//	Compliance Implant
+//////////////////////////////
+/obj/item/weapon/implanter/compliance
+	name = "compliance implant"
+	desc = "Implant which allows for implanting 'laws' or 'commands' in the host. Has a minature keyboard for typing laws into."
+	description_info = {"An implant that allows for a 'law' or 'command' to be uploaded in the implanted host.
+In un-modified organics, this is performed through manipulation of the nervous system and release of chemicals to ensure continued compliance.
+In synthetics or modified organics, this implant uploads a virus to any compatable hardware.
+Due to the small chemical capacity of the implant, the life of the implant is relatively small, wearing off within 24 hours or sooner.
+Obviously lethal commands such as telling the subject to kill themselves or harm others will result in the command being disregarded."}
+
+	description_fluff = "Due to the illegality of these types of implants, they are often made in clandestine facilities with a complete lack of quality control \
+	and as such, may malfunction or simply not work whatsoever. After loyalty implants were outlawed in many civilized areas of space, an abundance of readily \
+	available implanters and implants became available for purchase on the black market, with some deciding to modify them. Now, they are often used by illegal \
+	entities to perform espionage and in some parts of space are used off the books for interrogation. Most of the makers of these modified implants have put in \
+	safeties to prevent lethal or actively harmful commands from being input to lessen the severity of the crime if they are caught. This one has a golden stamp \
+	with the shape of a star on it, the letters 'KE' in black text on it."
+
+/obj/item/weapon/implanter/compliance/New()
+	src.imp = new /obj/item/weapon/implant/compliance( src )
+	..()
+	update()
+	return
+
+/obj/item/weapon/implanter/compliance/attack_self(mob/user)
+	if(istype(imp,/obj/item/weapon/implant/compliance))
+		var/obj/item/weapon/implant/compliance/implant = imp
+		var/newlaws = tgui_input_text(user, "Please Input Laws", "Compliance Laws", "", multiline = TRUE, prevent_enter = TRUE)
+		newlaws = sanitize(newlaws,2048)
+		if(newlaws)
+			to_chat(user,"You set the laws to: <br><span class='notice'>[newlaws]</span>")
+			implant.laws = newlaws //Organic
+	else //No using other implants.
+		to_chat(user,"A red warning pops up on the implanter's micro-screen: 'INVALID IMPLANT DETECTED.'</span>")
+
+
+/obj/item/weapon/implant/compliance
+	name = "compliance implant"
+	desc = "Implant which allows for forcing obedience in the host."
+	icon_state = "implant_evil"
+	var/active = TRUE
+	var/laws = "CHANGE BEFORE IMPLANTATION"
+	var/nif_payload = /datum/nifsoft/compliance
+
+/obj/item/weapon/implant/compliance/get_data()
+	var/dat = {"
+<b>Implant Specifications:</b><BR>
+<b>Name:</b>Compliance Implant<BR>
+<b>Life:</b>24 Hours<BR>
+<HR>
+<b>Function:</b> Forces a subject to follow a set of laws.<BR>
+<HR>
+<b>Set Laws:</b>[laws]"}
+	return dat
+
+/obj/item/weapon/implant/compliance/post_implant(mob/source, mob/living/user = usr)
+	if(!ishuman(source)) //No compliance implanting non-humans.
+		return
+
+	var/mob/living/carbon/human/target = source
+	if(!target.nif || target.nif.stat != NIF_WORKING) //No nif or their NIF is broken.
+		to_chat(target, "<span class='notice'>You suddenly feel compelled to follow the following commands: [laws]</span>")
+		to_chat(target, "<span class='notice'>((OOC NOTE: Obviously lethal commands or commands that harm others should be disregarded.))</span>")
+		to_chat(target, "<span class='notice'>((OOC NOTE: Your new commands can be checked at any time by using the 'notes' command in chat. Additionally, if you did not agree to this, you are not compelled to follow the implant.))</span>")
+		target.add_memory(laws)
+		return
+	else //You got a nif...Upload time.
+		new nif_payload(target.nif,laws)
+		to_chat(target, "<span class='notice'>((OOC NOTE: Obviously lethal commands or commands that harm others should be disregarded.))</span>")
+		to_chat(target, "<span class='notice'>((OOC NOTE: If you did not agree to this, you are not compelled to follow the laws.))</span>")

--- a/code/game/objects/items/weapons/implants/implant_vr.dm
+++ b/code/game/objects/items/weapons/implants/implant_vr.dm
@@ -169,7 +169,7 @@ Obviously lethal commands such as telling the subject to kill themselves or harm
 			to_chat(user,"You set the laws to: <br><span class='notice'>[newlaws]</span>")
 			implant.laws = newlaws //Organic
 	else //No using other implants.
-		to_chat(user,"A red warning pops up on the implanter's micro-screen: 'INVALID IMPLANT DETECTED.'</span>")
+		to_chat(user,"<span class='notice'>A red warning pops up on the implanter's micro-screen: 'INVALID IMPLANT DETECTED.'</span>")
 
 
 /obj/item/weapon/implant/compliance

--- a/code/game/objects/items/weapons/implants/implant_vr.dm
+++ b/code/game/objects/items/weapons/implants/implant_vr.dm
@@ -144,8 +144,7 @@
 	description_info = {"An implant that allows for a 'law' or 'command' to be uploaded in the implanted host.
 In un-modified organics, this is performed through manipulation of the nervous system and release of chemicals to ensure continued compliance.
 In synthetics or modified organics, this implant uploads a virus to any compatable hardware.
-Due to the small chemical capacity of the implant, the life of the implant is relatively small, wearing off within 24 hours or sooner.
-Obviously lethal commands such as telling the subject to kill themselves or harm others will result in the command being disregarded."}
+Due to the small chemical capacity of the implant, the life of the implant is relatively small, wearing off within 24 hours or sooner."}
 
 	description_fluff = "Due to the illegality of these types of implants, they are often made in clandestine facilities with a complete lack of quality control \
 	and as such, may malfunction or simply not work whatsoever. After loyalty implants were outlawed in many civilized areas of space, an abundance of readily \

--- a/code/game/objects/structures/trash_pile_vr.dm
+++ b/code/game/objects/structures/trash_pile_vr.dm
@@ -302,6 +302,7 @@
 					prob(1);/obj/item/weapon/beartrap,
 					prob(1);/obj/item/weapon/cell/hyper/empty,
 					prob(1);/obj/item/weapon/disk/nifsoft/compliance,
+					prob(1);/obj/item/weapon/implanter/compliance,
 					prob(1);/obj/item/weapon/material/knife/tacknife,
 					prob(1);/obj/item/weapon/storage/box/survival/space,
 					prob(1);/obj/item/weapon/storage/secure/briefcase/trashmoney,

--- a/code/modules/economy/vending_machines_vr.dm
+++ b/code/modules/economy/vending_machines_vr.dm
@@ -7,6 +7,7 @@
 	products += list(/obj/item/weapon/gun/energy/taser = 8,/obj/item/weapon/gun/energy/stunrevolver = 4,
 					/obj/item/weapon/reagent_containers/spray/pepper = 6,/obj/item/taperoll/police = 6,
 					/obj/item/clothing/glasses/omnihud/sec = 6)
+	contraband += list(/obj/item/weapon/implanter/compliance = 1)
 	..()
 
 /obj/machinery/vending/tool/New()


### PR DESCRIPTION
- Adds in a 'compliance implant'. This is an implant that works just like a compliance disk, in case people want to do law stuff without NIFs. (Also works on NIFs as well as requested.)
- Is able to be found in contraband packs, trash piles, and is contraband in the security vending machine. (Since putting it in the 'gadget' vending machine didn't seem right.)

Works exactly like a compliance disk does but also is a removable implant for non-NIF'd people.
<img width="616" alt="dreamseeker_2022-09-29_19-20-35" src="https://user-images.githubusercontent.com/15969779/193160870-b0be294d-e45c-46f9-81e2-5edc767dd771.png">

<img width="529" alt="dreamseeker_2022-09-29_19-22-19" src="https://user-images.githubusercontent.com/15969779/193160852-31504e79-08d4-450c-9e7a-f0f219faae4f.png">

<img width="250" alt="2022-09-29_19-07-37" src="https://user-images.githubusercontent.com/15969779/193160840-1f7b7c29-fef1-4941-98a7-6145ed3f8804.png">



🆑
add: Compliance implants are here! Can be found in trash piles, contraband crates, or by hacking the security vendor. Works like a compliance disk but can be used in non-NIF'd people!
/🆑