### PR TITLE
stops absorbed chimeras going feral

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/station_special_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_special_vr.dm
@@ -142,14 +142,14 @@
 		cause = "jittery"
 
 	//check to see if they go feral if they weren't before
-	if(!feral)
+	if(!feral && !isbelly(H.loc))
 		// if stress is below 15, no chance of snapping. Also if they weren't feral before, they won't suddenly become feral unless they get MORE stressed
 		if((currentstress > laststress) && prob(clamp(currentstress-15, 0, 100)) )
 			go_feral(H, currentstress, cause)
 			feral = currentstress //update the local var
 
 		//they didn't go feral, give 'em a chance of hunger messages
-		else if(H.nutrition <= 200 && prob(0.5) && !isbelly(H.loc))
+		else if(H.nutrition <= 200 && prob(0.5))
 			switch(H.nutrition)
 				if(150 to 200)
 					to_chat(H,"<span class='info'>You feel rather hungry. It might be a good idea to find some some food...</span>")
@@ -158,7 +158,8 @@
 					danger = TRUE
 
 	//now the check's done, update their brain so it remembers how stressed they were
-	B.laststress = currentstress
+	if(B && !isbelly(H.loc)) //another sanity check for brain implant shenanigans, also no you don't get to hide in a belly and get your laststress set to a huge amount to skip rolls
+		B.laststress = currentstress
 
 	// Handle being feral
 	if(feral)


### PR DESCRIPTION
Moved the isbelly check to stop xenochimera from going hungerferal when they get absorbed.

Added a sanity check to provent possible runtimes and potential hiding-in-belly exploits. If you come out of the belly more stressed then you went in, you still have to roll when you get out.