### PR TITLE
Gird check fixes

### DIFF
--- a/code/modules/events/grid_check.dm
+++ b/code/modules/events/grid_check.dm
@@ -1,23 +1,10 @@
-/datum/event/grid_check	//NOTE: Times are measured in master controller ticks!
-	announceWhen		= 5
-/*
-/datum/event/grid_check/setup()
-	endWhen = rand(30,120)
-*/
+/datum/event/grid_check
+
 /datum/event/grid_check/start()
 	// This sets off a chain of events that lead to the actual grid check (or perhaps worse).
 	// First, the Supermatter engine makes a power spike.
 	for(var/obj/machinery/power/generator/engine in machines)
-		engine.power_spike()
+		engine.power_spike(80)
 		break // Just one engine, please.
 	// After that, the engine checks if a grid checker exists on the same powernet, and if so, it triggers a blackout.
 	// If not, lots of stuff breaks.  See code/modules/power/generator.dm for that piece of code.
-//	power_failure(0)
-/*
-/datum/event/grid_check/announce()
-	if (prob(30))
-		command_announcement.Announce("Abnormal activity detected in [station_name()]'s powernet. As a precautionary measure, the station's power will be shut off for an indeterminate duration.", "Automated Grid Check", new_sound = 'sound/AI/poweroff.ogg')
-
-/datum/event/grid_check/end()
-	power_restore()
-*/

--- a/code/modules/power/generator.dm
+++ b/code/modules/power/generator.dm
@@ -261,11 +261,11 @@ GLOBAL_LIST_EMPTY(all_turbines)
 
 	src.set_dir(turn(src.dir, 90))
 
-/obj/machinery/power/generator/power_spike()
-//	if(!effective_gen >= max_power / 2 && powernet) // Don't make a spike if we're not making a whole lot of power.
+/obj/machinery/power/generator/power_spike(var/announce_prob = 30)
+//	if(!(effective_gen >= max_power / 2 && powernet)) // Don't make a spike if we're not making a whole lot of power.
 //		return
 
-	var/list/powernet_union = powernet.nodes
+	var/list/powernet_union = powernet.nodes.Copy()
 	for(var/obj/machinery/power/terminal/T in powernet.nodes)
 		if(T.master && istype(T.master, /obj/machinery/power/smes))
 			var/obj/machinery/power/smes/S = T.master
@@ -273,7 +273,7 @@ GLOBAL_LIST_EMPTY(all_turbines)
 
 	var/found_grid_checker = FALSE
 	for(var/obj/machinery/power/grid_checker/G in powernet_union)
-		G.power_failure(prob(30)) // If we found a grid checker, then all is well.
+		G.power_failure(announce_prob) // If we found a grid checker, then all is well.
 		found_grid_checker = TRUE
 	if(!found_grid_checker) // Otherwise lets break some stuff.
 		spawn(1)

--- a/code/modules/power/generator.dm
+++ b/code/modules/power/generator.dm
@@ -262,8 +262,8 @@ GLOBAL_LIST_EMPTY(all_turbines)
 	src.set_dir(turn(src.dir, 90))
 
 /obj/machinery/power/generator/power_spike(var/announce_prob = 30)
-//	if(!(effective_gen >= max_power / 2 && powernet)) // Don't make a spike if we're not making a whole lot of power.
-//		return
+	if(!(effective_gen >= max_power / 2 && powernet)) // Don't make a spike if we're not making a whole lot of power.
+		return
 
 	var/list/powernet_union = powernet.nodes.Copy()
 	for(var/obj/machinery/power/terminal/T in powernet.nodes)


### PR DESCRIPTION
Fixes grid check affecting subgrids that are properly separated

Makes grid check not occur at all when your TEG is not producing half its power or not connected to a powernet.

Also increases chance of announcement up to 80 from 30. Mostly for fluff, since with how rare it is already; announcement with that low chance plays even rarer. And effect of the event is obvious either way, really.