### PR TITLE
Adjusts vulpkanin heat/cold handling. Makes them mid-way between human and taj.

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/station_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_vr.dm
@@ -235,6 +235,27 @@
 	wikilink="https://wiki.vore-station.net/Backstory#Vulpkanin"
 
 	catalogue_data = list(/datum/category_item/catalogue/fauna/vulpkanin)
+	
+	//Furry fox-like animals shouldn't start freezing at 5 degrees celsius.
+	//Minor cold is resisted, but not severe frost.
+	cold_discomfort_level = 263 //Not as good at surviving the frost as tajara, but still better than humans. 
+	
+	cold_level_1 = 243 //Default 260, other values remain at default. Starts taking damage at -30 celsius. Default tier 2 is -70 and tier 3 is -150
+	
+	
+	breath_cold_level_1 = 220 // Default 240, lower is better.	
+	
+	//While foxes can survive in deserts, that's handled by zorren. It's a good contrast that our vulp find heat a little uncomfortable.
+	
+	heat_discomfort_level = 295 //Just above standard 20 C to avoid heat message spam, same as Taj
+	
+	heat_level_1 = 345 //Default 360
+	heat_level_2 = 390 //Default 400
+	heat_level_3 = 900 //Default 1000
+
+	breath_heat_level_1 = 370	//Default 380 - Higher is better
+	breath_heat_level_2 = 445	//Default 450
+	breath_heat_level_3 = 1125	//Default 1250
 
 	primitive_form = "Wolpin"
 
@@ -248,6 +269,12 @@
 
 	min_age = 18
 	max_age = 80
+	
+	heat_discomfort_strings = list(
+		"Your fur prickles in the heat.",
+		"You feel uncomfortably warm.",
+		"Your overheated skin itches."
+		)
 
 /datum/species/unathi
 	mob_size = MOB_MEDIUM //To allow normal mob swapping


### PR DESCRIPTION
Getting cold-risk overlay at just 5 celsius is annoying. One would think a furry creature would be able to withstand temperatures until like -20.

With these changes, Vulpkanin will feel comfortable up until the temperature gets below -10 celsius. At which point, they get periodic warnings to get out. At -30 celsius, they start taking damage. 

Unlike Tajara, who specifically live in tundra conditions, Vulpkanin do not retain cold resistance in extreme conditions. Meaning, while tajara can survive - 70 celsius, vulpkanin start suffering as hard as humans do. Tajaran tresholds are -70 for first damage, -130 for second tier and -190 for third tier. 

To balance the increased cold resistance, Vulpkanin become uncomfortable in temperatures over 21.85 celsius (chosen to avoid spamming them, copied from taj). Thematically, vulpkanin being comfortable in cold is a nice mechanical contrast to zorren, who live in deserts. I won't touch them in this PR, but I think zorren could use a bit of nudge in opposite direction since they're supposed to be desert-adapted.


They start taking heat damage half-way between human and tajaran values. Across the board, it's reduced.


Also fixes vulpkanin somehow sweating in heat.