### PR TITLE
Update rechargestation.dm

### DIFF
--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -71,7 +71,7 @@
 //Processes the occupant, drawing from the internal power cell if needed.
 /obj/machinery/recharge_station/proc/process_occupant()
 	if(isrobot(occupant))
-		var/mob/living/silicon/robot/R = occupant
+		var/mob/living/silicon/robot/R = occupant  //VOREStation Edit
 		if(R.module)
 			R.module.respawn_consumable(R, charging_power * CELLRATE / 250) //consumables are magical, apparently
 		if(R.cell && !R.cell.fully_charged())
@@ -84,6 +84,17 @@
 			R.adjustBruteLoss(-weld_rate)
 		if(wire_rate && R.getFireLoss() && cell.checked_use(wire_power_use * wire_rate * CELLRATE))
 			R.adjustFireLoss(-wire_rate)
+	
+	//VOREStation Add Start
+	else if(ispAI(occupant))
+		var/mob/living/silicon/pai/P = occupant
+			
+		if(P.nutrition < 400)
+			P.nutrition = min(P.nutrition+10, 400)
+			cell.use(7000/450*10)
+	//VOREStation Add End
+		
+		//do stuff
 	else if(ishuman(occupant))
 		var/mob/living/carbon/human/H = occupant
 
@@ -258,6 +269,21 @@
 		occupant = R
 		update_icon()
 		return 1
+		
+	//VOREStation Add Start
+	else if(istype(L, /mob/living/silicon/pai))
+		var/mob/living/silicon/pai/P = L
+
+		if(P.incapacitated())
+			return
+
+		add_fingerprint(P)
+		P.reset_view(src)
+		P.forceMove(src)
+		occupant = P
+		update_icon()
+		return 1
+	//VOREStation Add End
 
 	else if(istype(L,  /mob/living/carbon/human))
 		var/mob/living/carbon/human/H = L

--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -93,8 +93,7 @@
 			P.nutrition = min(P.nutrition+10, 400)
 			cell.use(7000/450*10)
 	//VOREStation Add End
-		
-		//do stuff
+
 	else if(ishuman(occupant))
 		var/mob/living/carbon/human/H = occupant
 

--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -71,7 +71,7 @@
 //Processes the occupant, drawing from the internal power cell if needed.
 /obj/machinery/recharge_station/proc/process_occupant()
 	if(isrobot(occupant))
-		var/mob/living/silicon/robot/R = occupant  //VOREStation Edit
+		var/mob/living/silicon/robot/R = occupant
 		if(R.module)
 			R.module.respawn_consumable(R, charging_power * CELLRATE / 250) //consumables are magical, apparently
 		if(R.cell && !R.cell.fully_charged())


### PR DESCRIPTION
Allows pAIs to recharge using cyborg chargers, as an alternative to #13888

Recharge rate is the same as for synths (10 per processing tick) and it caps at the pAI's starting amount (400).

Only gently tested, because pAI stuff is difficult to test alone.