### PR TITLE
Allows you to select if you want to heal brute or burn via surgery

### DIFF
--- a/code/modules/surgery/external_repair.dm
+++ b/code/modules/surgery/external_repair.dm
@@ -106,8 +106,6 @@
 		var/obj/item/organ/external/affected = target.get_organ(target_zone)
 		if(affected.burn_stage < 1 || !(affected.burn_dam))
 			return 0
-		if(affected.burn_dam < affected.brute_dam)
-			return 0
 		return 1
 	return 0
 
@@ -172,8 +170,6 @@
 	if(..())
 		var/obj/item/organ/external/affected = target.get_organ(target_zone)
 		if(affected.brute_stage < 1 || !(affected.brute_dam))
-			return 0
-		if(affected.brute_dam < affected.burn_dam)
 			return 0
 		return 1
 	return 0


### PR DESCRIPTION
Instead of shoehorning the player into healing the most damaged type.

This mechanic was also poorly explained and I have people DMing me about "This surgery is bugged it won't let me heal XYZ" when it was actually just a old-code blocking you from healing the lesser damage. 

With the new surgery, this is a thing of the past and can be safely removed.