### PR TITLE
Fixes an oversight with syringes.

### DIFF
--- a/code/modules/reagents/reagent_containers/syringes_vr.dm
+++ b/code/modules/reagents/reagent_containers/syringes_vr.dm
@@ -85,7 +85,7 @@
 
 //Allow for capped syringes
 /obj/item/weapon/reagent_containers/syringe/update_icon()
-	cut_overlays(src)
+	cut_overlays()
 
 	var/matrix/tf = matrix()
 	if(isstorage(loc))
@@ -101,12 +101,11 @@
 		icon_state = "capped"
 		return
 
-	var/list/new_overlays = list()
 	var/rounded_vol = round(reagents.total_volume, round(reagents.maximum_volume / 3))
 	if(reagents.total_volume)
 		filling = image(icon, src, "filler[rounded_vol]")
 		filling.color = reagents.get_color()
-		new_overlays += filling
+		add_overlay(filling)
 
 	if(ismob(loc))
 		var/injoverlay
@@ -115,9 +114,8 @@
 				injoverlay = "draw"
 			if (SYRINGE_INJECT)
 				injoverlay = "inject"
-		new_overlays += injoverlay
+		add_overlay(injoverlay)
 
-	add_overlay(new_overlays)
 	icon_state = "[rounded_vol]"
 	item_state = "syringe_[rounded_vol]"
 


### PR DESCRIPTION
- The bug was that it was cut_overlays(src) instead of just cut_overlays() This makes it so syringes won't make infinite overlays.
- Swaps it over to use add_overlay(XYZ) instead of add_overlay +=. This technically changes nothing but standardizes it.
![2022-10-12_23-12-54](https://user-images.githubusercontent.com/15969779/195493367-dd8f3848-366a-4671-896b-0169abf1423e.gif)
