### PR TITLE
Use LAZYSET to add people to prey excludes

### DIFF
--- a/code/modules/mob/living/simple_mob/simple_mob_vr.dm
+++ b/code/modules/mob/living/simple_mob/simple_mob_vr.dm
@@ -57,8 +57,7 @@
 // Release belly contents before being gc'd!
 /mob/living/simple_mob/Destroy()
 	release_vore_contents()
-	if(prey_excludes)
-		prey_excludes.Cut()
+	LAZYCLEARLIST(prey_excludes)
 	return ..()
 
 //For all those ID-having mobs
@@ -113,7 +112,7 @@
 	if(!M.allowmobvore || !M.devourable) // Don't eat people who don't want to be ate by mobs
 		//ai_log("vr/wont eat [M] because they don't allow mob vore", 3) //VORESTATION AI TEMPORARY REMOVAL
 		return 0
-	if(M in prey_excludes) // They're excluded
+	if(LAZYFIND(prey_excludes, M)) // They're excluded
 		//ai_log("vr/wont eat [M] because they are excluded", 3) //VORESTATION AI TEMPORARY REMOVAL
 		return 0
 	if(M.size_multiplier < vore_min_size || M.size_multiplier > vore_max_size)

--- a/code/modules/mob/living/simple_mob/subtypes/vore/pakkun.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/pakkun.dm
@@ -109,7 +109,7 @@
 			continue
 	if(istype(holder, /mob/living/simple_mob))
 		var/mob/living/simple_mob/SM = holder
-		our_targets -= SM.prey_excludes
+		our_targets -= SM.prey_excludes // Lazylist, but subtracting a null from the list seems fine.
 	return our_targets
 
 /datum/ai_holder/simple_mob/ranged/pakkun/can_attack(atom/movable/the_target, var/vision_required = TRUE)
@@ -120,14 +120,14 @@
 			return FALSE
 		if(istype(holder, /mob/living/simple_mob))
 			var/mob/living/simple_mob/SM = holder
-			if(L in SM.prey_excludes)
+			if(LAZYFIND(SM.prey_excludes, L))
 				return FALSE
 	else
 		return FALSE
 
 /mob/living/simple_mob/vore/pakkun/on_throw_vore_special(var/pred, var/mob/living/target)
 	if(pred && !extra_posessive)
-		prey_excludes += target
+		LAZYSET(prey_excludes, target, world.time)
 		addtimer(CALLBACK(src, .proc/removeMobFromPreyExcludes, weakref(target)), 5 MINUTES)
 	if(ai_holder)
 		ai_holder.remove_target()
@@ -151,8 +151,8 @@
         user.visible_message("<span class='info'>[user] swats [src] with [O]!</span>")
         release_vore_contents()
         for(var/mob/living/L in living_mobs(0))
-            if(!(L in prey_excludes))
-                prey_excludes += L
+            if(!(LAZYFIND(prey_excludes, L)))
+                LAZYSET(prey_excludes, L, world.time)
                 addtimer(CALLBACK(src, .proc/removeMobFromPreyExcludes, weakref(L)), 5 MINUTES)
     else
         ..()

--- a/code/modules/mob/living/simple_mob/subtypes/vore/zz_vore_overrides.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/zz_vore_overrides.dm
@@ -188,10 +188,10 @@
 /* //VOREStation AI Temporary Removal
 /mob/living/simple_mob/animal/passive/cat/fluff/EatTarget()
 	var/mob/living/TM = target_mob
-	prey_excludes += TM //so they won't immediately re-eat someone who struggles out (or gets newspapered out) as soon as they're ate
+	LAZYSET(prey_excludes, TM, world.time) //so they won't immediately re-eat someone who struggles out (or gets newspapered out) as soon as they're ate
 	spawn(3600) // but if they hang around and get comfortable, they might get ate again
 		if(src && TM)
-			prey_excludes -= TM
+			LAZYREMOVE(prey_excludes, TM)
 	..() // will_eat check is carried out before EatTarget is called, so prey on the prey_excludes list isn't a problem.
 */
 

--- a/code/modules/vore/eating/living_vr.dm
+++ b/code/modules/vore/eating/living_vr.dm
@@ -493,7 +493,7 @@
 		muffled = FALSE		//Removes Muffling
 		forceMove(get_turf(src)) //Just move me up to the turf, let's not cascade through bellies, there's been a problem, let's just leave.
 		for(var/mob/living/simple_mob/SA in range(10))
-			SA.prey_excludes[src] = world.time
+			LAZYSET(SA.prey_excludes, src, world.time)
 		log_and_message_admins("[key_name(src)] used the OOC escape button to get out of [key_name(B.owner)] ([B.owner ? "<a href='?_src_=holder;adminplayerobservecoodjump=1;X=[B.owner.x];Y=[B.owner.y];Z=[B.owner.z]'>JMP</a>" : "null"])")
 
 		if(!ishuman(B.owner))

--- a/code/modules/vore/eating/simple_animal_vr.dm
+++ b/code/modules/vore/eating/simple_animal_vr.dm
@@ -1,7 +1,7 @@
 ///////////////////// Simple Animal /////////////////////
 /mob/living/simple_mob
 	var/swallowTime = (3 SECONDS)		//How long it takes to eat its prey in 1/10 of a second. The default is 3 seconds.
-	var/list/prey_excludes = list()		//For excluding people from being eaten.
+	var/list/prey_excludes = null		//For excluding people from being eaten.
 
 //
 // Simple nom proc for if you get ckey'd into a simple_mob mob! Avoids grabs.
@@ -86,17 +86,16 @@
 			user.visible_message("<span class='info'>[user] swats [src] with [O]!</span>")
 			release_vore_contents()
 			for(var/mob/living/L in living_mobs(0)) //add everyone on the tile to the do-not-eat list for a while
-				if(!(L in prey_excludes)) // Unless they're already on it, just to avoid fuckery.
-					prey_excludes += L
+				if(!(LAZYFIND(prey_excludes, L))) // Unless they're already on it, just to avoid fuckery.
+					LAZYSET(prey_excludes, L, world.time)
 					addtimer(CALLBACK(src, .proc/removeMobFromPreyExcludes, weakref(L)), 5 MINUTES)
 	else if(istype(O, /obj/item/device/healthanalyzer))
 		var/healthpercent = health/maxHealth*100
-		to_chat(user, "<span class='notice'>[src] seems to be [healthpercent]% healthy.</span>")		
+		to_chat(user, "<span class='notice'>[src] seems to be [healthpercent]% healthy.</span>")
 	else
 		..()
 
 /mob/living/simple_mob/proc/removeMobFromPreyExcludes(weakref/target)
 	if(isweakref(target))
 		var/mob/living/L = target.resolve()
-		if(L)
-			LAZYREMOVE(prey_excludes, L)
+		LAZYREMOVE(prey_excludes, L) // It's fine to remove a null from the list if we couldn't resolve L


### PR DESCRIPTION
Fixes an oversight, the 'remove' side of this uses LAZYREMOVE and nulls the list, causing this 'add' side to fail.

EDIT: Seems like the remove side of this was the only place that considered this a lazylist, but that's probably how it should be, so fixed any references to prey_exclude that didn't treat it as such.

The list structure is keys of objects to values of time added to exclusion list. Not really necessary anymore as the removal is done by addtimer, but no reason to really change it either. Might be useful for admins looking at the list or something.

Fixes #13948 