### PR TITLE
Fixes xenochimera uninjured check

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/station_special_abilities_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_special_abilities_vr.dm
@@ -97,10 +97,10 @@
 	if (getBruteLoss() || getFireLoss() || getHalLoss() || getToxLoss() || getOxyLoss() || getBrainLoss()) //fails if they have any of the main damage types
 		return FALSE
 	for (var/obj/item/organ/O in organs) //check their organs just in case they're being sneaky and somehow have organ damage but no health damage
-		if (O.damage)
+		if (O.is_damaged() || O.status)
 			return FALSE
 	for (var/obj/item/organ/O in internal_organs) //check their organs just in case they're being sneaky and somehow have organ damage but no health damage
-		if (O.damage)
+		if (O.is_damaged() || O.status)
 			return FALSE
 	return TRUE
 


### PR DESCRIPTION
Fixes an edge case where a xenochimera could have a broken bone, but the bone itself have 0 damage, thereby allowing them to benefit from a 30 second regen.