### PR TITLE
Adds more nanomeds to gb

### DIFF
--- a/maps/groundbase/gb-z1.dmm
+++ b/maps/groundbase/gb-z1.dmm
@@ -1003,6 +1003,9 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/machinery/vending/wallmed1/public{
+	pixel_y = 28
+	},
 /turf/simulated/floor/tiled/asteroid_steel,
 /area/groundbase/civilian/mensrestroom)
 "cq" = (
@@ -14711,7 +14714,7 @@
 	frequency = 1443;
 	level = 3;
 	name = "Distribution and Waste Monitor";
-	sensors = list("dist_main_meter" = "Surface - Distribution Loop", "scrub_main_meter" = "Surface - Scrubbers Loop", "mair_main_meter" = "Surface - Mixed Air Tank", "dist_aux_meter" = "Station - Distribution Loop", "scrub_aux_meter" = "Station - Scrubbers Loop", "mair_aux_meter" = "Station - Mixed Air Tank", "mair_mining_meter" = "Mining Outpost - Mixed Air Tank")
+	sensors = list("dist_main_meter"="Surface - Distribution Loop","scrub_main_meter"="Surface - Scrubbers Loop","mair_main_meter"="Surface - Mixed Air Tank","dist_aux_meter"="Station - Distribution Loop","scrub_aux_meter"="Station - Scrubbers Loop","mair_aux_meter"="Station - Mixed Air Tank","mair_mining_meter"="Mining Outpost - Mixed Air Tank")
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -19263,6 +19266,10 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/pink/full,
+/obj/machinery/vending/wallmed1/public{
+	pixel_y = -28;
+	dir = 1
+	},
 /turf/simulated/floor/tiled/white,
 /area/groundbase/civilian/womensrestroom)
 "TW" = (
@@ -20675,6 +20682,10 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/vending/wallmed1/public{
+	dir = 4;
+	pixel_x = -28
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/groundbase/civilian/arrivals)
 "Xz" = (

--- a/maps/groundbase/gb-z2.dmm
+++ b/maps/groundbase/gb-z2.dmm
@@ -2283,7 +2283,7 @@
 	name = "box of measuring cups";
 	pixel_x = 2;
 	pixel_y = 3;
-	starts_with = list(/obj/item/weapon/reagent_containers/glass/beaker/measuring_cup = 7)
+	starts_with = list(/obj/item/weapon/reagent_containers/glass/beaker/measuring_cup=7)
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -17192,6 +17192,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/groundbase/science/server)
+"Xb" = (
+/obj/machinery/vending/wallmed1/public{
+	dir = 4;
+	pixel_x = -28
+	},
+/turf/simulated/floor/tiled/white,
+/area/groundbase/dorms/bathroom)
 "Xc" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/reagent_containers/spray/cleaner{
@@ -24398,7 +24405,7 @@ ON
 fX
 eC
 LN
-kk
+Xb
 BY
 eC
 Mm

--- a/maps/groundbase/gb-z3.dmm
+++ b/maps/groundbase/gb-z3.dmm
@@ -1636,6 +1636,18 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/groundbase/medical/paramedic)
+"zW" = (
+/obj/structure/bed/chair/backed_red{
+	dir = 4
+	},
+/obj/machinery/vending/wallmed1/public{
+	pixel_y = -28;
+	dir = 1
+	},
+/turf/simulated/floor/outdoors/sidewalk/slab/virgo3c{
+	outdoors = 0
+	},
+/area/groundbase/level3/escapepad)
 "Aa" = (
 /obj/structure/bed/padded,
 /obj/item/weapon/bedsheet/medical,
@@ -6782,7 +6794,7 @@ ow
 ow
 Ii
 Ii
-Ii
+zW
 hl
 Kr
 Kr


### PR DESCRIPTION
It's what it says on the tin. Rascal's Pass is a fun map, but it lacks nanomeds that can be used to emergency stabilize someone when medical isn't around. I added nanomeds to every public bathroom that didn't have one, as well as one to the resleeving lobby and the departure seating area.