### PR TITLE
Using asterisk reflects your message before returning

### DIFF
--- a/code/modules/emotes/emote_mob.dm
+++ b/code/modules/emotes/emote_mob.dm
@@ -128,6 +128,7 @@
 	if(findtext(subtext, "*"))
 		// abort abort!
 		to_chat(emoter, SPAN_WARNING("You may use only one \"["*"]\" symbol in your emote."))
+		to_chat(emoter, SPAN_WARNING(message))
 		return
 
 	if(pretext)


### PR DESCRIPTION
Not sure why asterisks are a problem in emotes, but! This will reflect your message back at you instead of just deleting it.
Fixes https://github.com/VOREStation/VOREStation/issues/13992