### PR TITLE
Permit (Some) Linebreaks

### DIFF
--- a/code/_helpers/text.dm
+++ b/code/_helpers/text.dm
@@ -52,7 +52,9 @@
 		input = copytext(input,1,max_length)
 
 	if(extra)
-		input = replace_characters(input, list("\n"=" ","\t"=" "))
+		var/temp_input = replace_characters(input, list("\n"="  ","\t"=" "))//one character is replaced by two
+		if(length(input) < (length(temp_input) - 6))//6 is the number of linebreaks allowed per message
+			input = replace_characters(temp_input,list("  "=" "))//replace again, this time the double spaces with single ones
 
 	if(encode)
 		// The below \ escapes have a space inserted to attempt to enable CI auto-checking of span class usage. Please do not remove the space.


### PR DESCRIPTION
Allows up to 6 linebreaks using `\n`. Anything more than that and it'll sanitize them all out again. Use double (`\n\n`) for a full paragraph break, so you can get four paragraphs total if you're going absolutely all-out.

Code lifted from CitRP.