### PR TITLE
Various text-box QoL stuff

### DIFF
--- a/code/modules/mob/say_vr.dm
+++ b/code/modules/mob/say_vr.dm
@@ -115,7 +115,7 @@
 
 ///// PSAY /////
 
-/mob/verb/psay(message as text|null)
+/mob/verb/psay(message as text)
 	set category = "IC"
 	set name = "Psay"
 	set desc = "Talk to people affected by complete absorbed or dominate predator/prey."
@@ -212,7 +212,7 @@
 
 ///// PME /////
 
-/mob/verb/pme(message as text|null)
+/mob/verb/pme(message as message)
 	set category = "IC"
 	set name = "Pme"
 	set desc = "Emote to people affected by complete absorbed or dominate predator/prey."
@@ -307,7 +307,7 @@
 		M.forced_psay = FALSE
 		M.me_verb(message)
 
-/mob/living/verb/player_narrate(message as text|null)
+/mob/living/verb/player_narrate(message as message)
 	set category = "IC"
 	set name = "Narrate (Player)"
 	set desc = "Narrate an action or event! An alternative to emoting, for when your emote shouldn't start with your name!"

--- a/code/modules/nifsoft/software/13_soulcatcher.dm
+++ b/code/modules/nifsoft/software/13_soulcatcher.dm
@@ -469,17 +469,17 @@
 
 ///////////////////
 //Verbs for humans
-/mob/proc/nsay(message as text|null)
+/mob/proc/nsay(message as text)
 	set name = "NSay"
 	set desc = "Speak into your NIF's Soulcatcher."
 	set category = "IC"
 
 	src.nsay_act(message)
 
-/mob/proc/nsay_act(message as text|null)
+/mob/proc/nsay_act(message as text)
 	to_chat(src, SPAN_WARNING("You must be a humanoid with a NIF implanted to use that."))
 
-/mob/living/carbon/human/nsay_act(message as text|null)
+/mob/living/carbon/human/nsay_act(message as text)
 	if(stat != CONSCIOUS)
 		to_chat(src,SPAN_WARNING("You can't use NSay while unconscious."))
 		return
@@ -499,17 +499,17 @@
 		var/sane_message = sanitize(message)
 		SC.say_into(sane_message,src)
 
-/mob/proc/nme(message as text|null)
+/mob/proc/nme(message as message)
 	set name = "NMe"
 	set desc = "Emote into your NIF's Soulcatcher."
 	set category = "IC"
 
 	src.nme_act(message)
 
-/mob/proc/nme_act(message as text|null)
+/mob/proc/nme_act(message as message)
 	to_chat(src, SPAN_WARNING("You must be a humanoid with a NIF implanted to use that."))
 
-/mob/living/carbon/human/nme_act(message as text|null)
+/mob/living/carbon/human/nme_act(message as message)
 	if(stat != CONSCIOUS)
 		to_chat(src,SPAN_WARNING("You can't use NMe while unconscious."))
 		return
@@ -574,7 +574,7 @@
 	QDEL_NULL(eyeobj)
 	soulcatcher.notify_into("[src] ended AR projection.")
 
-/mob/living/carbon/brain/caught_soul/verb/nsay_brain(message as text|null)
+/mob/living/carbon/brain/caught_soul/verb/nsay_brain(message as text)
 	set name = "NSay"
 	set desc = "Speak into the NIF's Soulcatcher (circumventing AR speaking)."
 	set category = "Soulcatcher"
@@ -585,7 +585,7 @@
 		var/sane_message = sanitize(message)
 		soulcatcher.say_into(sane_message,src,null)
 
-/mob/living/carbon/brain/caught_soul/verb/nme_brain(message as text|null)
+/mob/living/carbon/brain/caught_soul/verb/nme_brain(message as message)
 	set name = "NMe"
 	set desc = "Emote into the NIF's Soulcatcher (circumventing AR speaking)."
 	set category = "Soulcatcher"


### PR DESCRIPTION
Removes psay's "none" button, makes narrate & pme into multiline boxes & removes their "none" buttons too.

Should make the nif boxes in-line with others, single-line box for the "say"'s, multi for the "me"'s, ditches the funny "none" button as well.

Tested for the psay/pme, the nif-related ones _should_ work fine too.
