### PR TITLE
Allergen Effect/Reaction Traits

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
@@ -278,7 +278,7 @@
 	allergen = ALLERGEN_COFFEE
 
 /datum/trait/neutral/allergy_reaction
-	name = "Reaction: Disable Toxicity"
+	name = "Allergy Reaction: Disable Toxicity"
 	desc = "Take this trait to disable the toxic damage effect of being exposed to one of your allergens. Combine with the Disable Suffocation trait to have purely nonlethal reactions."
 	cost = 0
 	custom_only = FALSE
@@ -289,63 +289,63 @@
 	..(S,H)
 
 /datum/trait/neutral/allergy_reaction/oxy
-	name = "Reaction: Disable Suffocation"
+	name = "Allergy Reaction: Disable Suffocation"
 	desc = "Take this trait to disable the oxygen deprivation damage effect of being exposed to one of your allergens. Combine with the Disable Toxicity trait to have purely nonlethal reactions."
 	cost = 0
 	custom_only = FALSE
 	reaction = AG_OXY_DMG
 
 /datum/trait/neutral/allergy_reaction/brute
-	name = "Reaction: Spontaneous Trauma"
+	name = "Allergy Reaction: Spontaneous Trauma"
 	desc = "When exposed to one of your allergens, your skin develops unnatural bruises and other 'stigmata'-like injuries. Be aware that untreated wounds may become infected."
 	cost = 0
 	custom_only = FALSE
 	reaction = AG_PHYS_DMG
 
 /datum/trait/neutral/allergy_reaction/burn
-	name = "Reaction: Blistering"
+	name = "Allergy Reaction: Blistering"
 	desc = "When exposed to one of your allergens, your skin develops unnatural blisters and burns, as if exposed to fire. Be aware that untreated burns are very susceptible to infection!"
 	cost = 0
 	custom_only = FALSE
 	reaction = AG_BURN_DMG
 
 /datum/trait/neutral/allergy_reaction/pain
-	name = "Reaction: Disable Pain"
+	name = "Allergy Reaction: Disable Pain"
 	desc = "Take this trait to disable experiencing pain after being exposed to one of your allergens."
 	cost = 0
 	custom_only = FALSE
 	reaction = AG_PAIN
 
 /datum/trait/neutral/allergy_reaction/weaken
-	name = "Reaction: Knockdown"
+	name = "Allergy Reaction: Knockdown"
 	desc = "When exposed to one of your allergens, you will experience sudden and abrupt loss of muscle control and tension, resulting in immediate collapse and immobility. Does nothing if you have no allergens."
 	cost = 0
 	custom_only = FALSE
 	reaction = AG_WEAKEN
 
 /datum/trait/neutral/allergy_reaction/blurry
-	name = "Reaction: Disable Blurring"
+	name = "Allergy Reaction: Disable Blurring"
 	desc = "Take this trait to disable the blurred/impeded vision effect of allergens."
 	cost = 0
 	custom_only = FALSE
 	reaction = AG_BLURRY
 
 /datum/trait/neutral/allergy_reaction/sleepy
-	name = "Reaction: Fatigue"
+	name = "Allergy Reaction: Fatigue"
 	desc = "When exposed to one of your allergens, you will experience fatigue and tiredness, and may potentially pass out entirely. Does nothing if you have no allergens."
 	cost = 0
 	custom_only = FALSE
 	reaction = AG_SLEEPY
 
 /datum/trait/neutral/allergy_reaction/confusion
-	name = "Reaction: Disable Confusion"
+	name = "Allergy Reaction: Disable Confusion"
 	desc = "Take this trait to disable the confusion/disorientation effect of allergens."
 	cost = 0
 	custom_only = FALSE
 	reaction = AG_CONFUSE
 
 /datum/trait/neutral/allergen_reduced_effect
-	name = "Reduced Allergen Reaction"
+	name = "Allergen Reaction: Reduced Intensity"
 	desc = "This trait drastically reduces the effects of allergen reactions. If you don't have any allergens set, it does nothing. It does not apply to special reactions (such as unathi drowsiness from sugars)."
 	cost = 0
 	custom_only = FALSE
@@ -353,7 +353,7 @@
 	excludes = list(/datum/trait/neutral/allergen_increased_effect)
 
 /datum/trait/neutral/allergen_increased_effect
-	name = "Increased Allergen Reaction"
+	name = "Allergen Reaction: Increased Intensity"
 	desc = "This trait drastically increases the effects of allergen reactions, enough that even a small dose can be lethal. If you don't have any allergens set, it does nothing. It does not apply to special reactions (such as unathi drowsiness from sugars)."
 	cost = 0
 	custom_only = FALSE

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
@@ -277,6 +277,73 @@
 	custom_only = FALSE
 	allergen = ALLERGEN_COFFEE
 
+/datum/trait/neutral/allergy_reaction
+	name = "Reaction: Disable Toxicity"
+	desc = "Take this trait to disable the toxic damage effect of being exposed to one of your allergens. Combine with the Disable Suffocation trait to have purely nonlethal reactions."
+	cost = 0
+	custom_only = FALSE
+	var/reaction = AG_TOX_DMG
+
+/datum/trait/neutral/allergy_reaction/apply(var/datum/species/S,var/mob/living/carbon/human/H)
+	S.allergen_reaction ^= reaction
+	..(S,H)
+
+/datum/trait/neutral/allergy_reaction/oxy
+	name = "Reaction: Disable Suffocation"
+	desc = "Take this trait to disable the oxygen deprivation damage effect of being exposed to one of your allergens. Combine with the Disable Toxicity trait to have purely nonlethal reactions."
+	cost = 0
+	custom_only = FALSE
+	reaction = AG_OXY_DMG
+
+/datum/trait/neutral/allergy_reaction/brute
+	name = "Reaction: Spontaneous Trauma"
+	desc = "When exposed to one of your allergens, your skin develops unnatural bruises and other 'stigmata'-like injuries. Be aware that untreated wounds may become infected."
+	cost = 0
+	custom_only = FALSE
+	reaction = AG_PHYS_DMG
+
+/datum/trait/neutral/allergy_reaction/burn
+	name = "Reaction: Blistering"
+	desc = "When exposed to one of your allergens, your skin develops unnatural blisters and burns, as if exposed to fire. Be aware that untreated burns are very susceptible to infection!"
+	cost = 0
+	custom_only = FALSE
+	reaction = AG_BURN_DMG
+
+/datum/trait/neutral/allergy_reaction/pain
+	name = "Reaction: Disable Pain"
+	desc = "Take this trait to disable experiencing pain after being exposed to one of your allergens."
+	cost = 0
+	custom_only = FALSE
+	reaction = AG_PAIN
+
+/datum/trait/neutral/allergy_reaction/weaken
+	name = "Reaction: Knockdown"
+	desc = "When exposed to one of your allergens, you will experience sudden and abrupt loss of muscle control and tension, resulting in immediate collapse and immobility. Does nothing if you have no allergens."
+	cost = 0
+	custom_only = FALSE
+	reaction = AG_WEAKEN
+
+/datum/trait/neutral/allergy_reaction/blurry
+	name = "Reaction: Disable Blurring"
+	desc = "Take this trait to disable the blurred/impeded vision effect of allergens."
+	cost = 0
+	custom_only = FALSE
+	reaction = AG_BLURRY
+
+/datum/trait/neutral/allergy_reaction/sleepy
+	name = "Reaction: Fatigue"
+	desc = "When exposed to one of your allergens, you will experience fatigue and tiredness, and may potentially pass out entirely. Does nothing if you have no allergens."
+	cost = 0
+	custom_only = FALSE
+	reaction = AG_SLEEPY
+
+/datum/trait/neutral/allergy_reaction/confusion
+	name = "Reaction: Disable Confusion"
+	desc = "Take this trait to disable the confusion/disorientation effect of allergens."
+	cost = 0
+	custom_only = FALSE
+	reaction = AG_CONFUSE
+
 /datum/trait/neutral/allergen_reduced_effect
 	name = "Reduced Allergen Reaction"
 	desc = "This trait drastically reduces the effects of allergen reactions. If you don't have any allergens set, it does nothing. It does not apply to special reactions (such as unathi drowsiness from sugars)."


### PR DESCRIPTION
This is another one of those little things that I should have put together a long time ago.

It adds a handful of new neutral traits that you can use to modify the actual reaction(s) you have to your allergens. Really uncomfortable with the idea of choking? You can disable oxydamage entirely. Want to remove the damage, confusion, and pain effects, and instead go into a kind of sleepy torpor-like state? You can do that too! Given the entire mechanic is opt-in I figure hey, more choice on what *kind* of reaction happens is good. The only effect/reaction that can't be disabled is the involuntary pale/shiver/etc. emotes, as I consider those an essential signal to bystanders that you haven't collapsed due to something (relatively) benign like SSD or whatever.

Just, you know, don't go crying to medical if you died from an itty bitty sip of milk because you decided to enable all the damage reactions _and_ added increased reaction strength too.

Tested locally and works as-intended so far as I can see.