### PR TITLE
Fixes ahelp fullmonty runtime

### DIFF
--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -207,7 +207,10 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 /datum/admin_help/proc/FullMonty(ref_src)
 	if(!ref_src)
 		ref_src = "\ref[src]"
-	. = ADMIN_FULLMONTY_NONAME(initiator.mob)
+	if(initiator && initiator.mob)
+		. = ADMIN_FULLMONTY_NONAME(initiator.mob)
+	else
+		. = "Initiator disconnected."
 	if(state == AHELP_ACTIVE)
 		. += ClosureLinks(ref_src)
 


### PR DESCRIPTION
This runtime causes the generation of the buttons inside of the new admin ticketpanel (or generally if its generated) to break, due to the initiator mob being null (for example: the initiator disconnected).

Unfortunately I was unable to test if this fixed work since I am currently only on my very weak mobile laptop.
Though this is only really an if statement checking if the initiator (and initiator.mob) isnt null, otherwise saying that the Initiator Disconnected.

Original Downstream PR:
https://github.com/CHOMPStation2/CHOMPStation2/pull/5191