### PR TITLE
Healing mobs aren't racist against all other simplemobs anymore

### DIFF
--- a/code/modules/mob/living/simple_mob/simple_mob_vr.dm
+++ b/code/modules/mob/living/simple_mob/simple_mob_vr.dm
@@ -53,6 +53,7 @@
 	can_be_drop_pred = TRUE				// Mobs are pred by default.
 	var/damage_threshold  = 0 //For some mobs, they have a damage threshold required to deal damage to them.
 
+	var/nom_mob = FALSE //If a mob is meant to be hostile for vore purposes but is otherwise not hostile, if true makes certain AI ignore the mob
 
 // Release belly contents before being gc'd!
 /mob/living/simple_mob/Destroy()

--- a/code/modules/mob/living/simple_mob/subtypes/vore/bigdragon.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/bigdragon.dm
@@ -191,6 +191,7 @@ I think I covered everything.
 	player_msg = "You're a variant of the large dragon stripped of its firebreath attack (harm intent). You can still charge (disarm) and tail sweep (grab). Rest to heal slowly. Check your abilities tab for functions."
 	norange = 1
 	noenrage = 1
+	nom_mob = TRUE
 
 // Weakened variant for maintpreds
 /mob/living/simple_mob/vore/bigdragon/friendly/maintpred
@@ -946,6 +947,17 @@ I think I covered everything.
 		if(L.stat)
 			if(L.stat == DEAD && !handle_corpse) // Leave dead things alone
 				return
+		if(isanimal(L))	//Don't attack simplemobs unless they are hostile.
+			var/mob/living/simple_mob/M = L
+			if(M.client)	//Don't attack players for no reason even if they're a traditionally hostile mob
+				return 0
+			if(M.nom_mob)	//Don't attack mobs that are hostile for their vore functions to work
+				return 0
+			if(M.ai_holder)	//Don't attack non-hostile mobs
+				if(M.ai_holder.hostile)
+					return 1
+				else return 0
+			else return 0
 		if(holder.IIsAlly(L))
 			if(confirmPatient(L))
 				holder.a_intent = I_HELP

--- a/code/modules/mob/living/simple_mob/subtypes/vore/leopardmander.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/leopardmander.dm
@@ -48,6 +48,8 @@
 	vore_bump_emote = "tries to snap up"
 	max_tox = 0 // for virgo3b survivability
 
+	nom_mob = TRUE
+
 /datum/category_item/catalogue/fauna/leopardmander
 	name = "Sivian Fauna - Va'aen Drake"
 	desc = "Classification: S Draconis uncia\

--- a/code/modules/mob/living/simple_mob/subtypes/vore/pakkun.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/pakkun.dm
@@ -52,6 +52,8 @@
 	var/extra_posessive = FALSE					// Enable if you want their tummy hugs to be inescapable
 	var/autorest_cooldown = 100
 
+	nom_mob = TRUE
+
 /mob/living/simple_mob/vore/pakkun/Life()
 	. = ..()
 	if(client)

--- a/code/modules/mob/living/simple_mob/subtypes/vore/shadekin/types.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/shadekin/types.dm
@@ -167,6 +167,8 @@
 	area is very taxing on you, but you gain energy extremely fast in any very dark area. You're weaker than other \
 	shadekin, but your fast energy generation in the dark allows you to phase shift more often."
 
+	nom_mob = TRUE
+
 /mob/living/simple_mob/shadekin/yellow
 	ai_holder_type = /datum/ai_holder/simple_mob/melee/hit_and_run
 


### PR DESCRIPTION
Adds the 'nom_mob' verb to simplemobs.

The AI that handles the healing variant of the big dragon and the leopardmander will ignore mobs with this variable. 

Additionally, made it so that this AI will ignore simplemobs with no AI, or an AI that is not hostile.

also makes it so they will ignore simplemobs who are player controlled even if their mob is traditionally hostile