### PR TITLE
Buffs paperwork on Stellar Delight (adds paperbin to captain's office, shredder to meeting room)

### DIFF
--- a/maps/stellar_delight/stellar_delight2.dmm
+++ b/maps/stellar_delight/stellar_delight2.dmm
@@ -1477,15 +1477,23 @@
 /area/stellardelight/deck2/fore)
 "cZ" = (
 /obj/item/device/flashlight/lamp/green{
+	pixel_x = 7;
+	pixel_y = 16
+	},
+/obj/item/weapon/folder/blue_captain{
+	pixel_x = -6;
 	pixel_y = 7
 	},
-/obj/item/weapon/folder/blue_captain,
 /obj/structure/table/darkglass,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
 /obj/machinery/requests_console/preset/captain{
 	pixel_x = -30
+	},
+/obj/item/weapon/melee/chainofcommand,
+/obj/item/weapon/folder/blue_captain{
+	pixel_x = -6
 	},
 /turf/simulated/floor/carpet/blucarpet,
 /area/crew_quarters/captain)
@@ -10517,14 +10525,14 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/atmos/storage)
 "xv" = (
-/obj/item/weapon/melee/chainofcommand,
-/obj/item/weapon/coin/phoron{
-	desc = "The face of the coin shows a portrait of the explorer who discovered the Virgo-Erigone system. The back depicts a Zodiac symbol that represents Virgo.";
-	name = "limited edition phoron coin"
-	},
-/obj/item/weapon/folder/blue_captain,
-/obj/item/weapon/stamp/captain,
 /obj/structure/table/darkglass,
+/obj/machinery/computer/skills{
+	pixel_x = 9
+	},
+/obj/item/weapon/paper_bin{
+	pixel_x = -7;
+	pixel_y = -2
+	},
 /turf/simulated/floor/carpet/blucarpet,
 /area/crew_quarters/captain)
 "xw" = (
@@ -11717,6 +11725,7 @@
 /obj/structure/cable/blue{
 	icon_state = "1-2"
 	},
+/obj/machinery/papershredder,
 /turf/simulated/floor/wood,
 /area/stellardelight/deck2/briefingroom)
 "Ae" = (
@@ -12028,9 +12037,6 @@
 /turf/simulated/floor/lino,
 /area/crew_quarters/bar)
 "AO" = (
-/obj/machinery/computer/skills{
-	pixel_y = 7
-	},
 /obj/structure/table/darkglass,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -12039,6 +12045,16 @@
 	id = "captaindoor";
 	pixel_x = -15;
 	pixel_y = 2
+	},
+/obj/item/weapon/stamp/captain{
+	pixel_x = 10;
+	pixel_y = 6
+	},
+/obj/item/weapon/coin/phoron{
+	desc = "The face of the coin shows a portrait of the explorer who discovered the Virgo-Erigone system. The back depicts a Zodiac symbol that represents Virgo.";
+	name = "limited edition phoron coin";
+	pixel_x = 11;
+	pixel_y = -3
 	},
 /turf/simulated/floor/carpet/blucarpet,
 /area/crew_quarters/captain)


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/20523270/201472248-7a34ee7b-15f5-4bc1-b22c-df07ffa9aa8b.png)
![image](https://user-images.githubusercontent.com/20523270/201472253-7e8470e2-b87c-4e40-83c1-d4cbebe0159f.png)


Apparently the captain does not have a paper bin in their office. While there's one on the bridge, and you could also use your tablet/etc, a paperbin is just nice.

Furthermore, having the big employment records console between the visitor and captain chairs feels awkward. If you got someone in your office, you should be able to see them! As such, I moved the records console over to the right, allowing the captain to see thru the middle of their desk.

Since the console is now on the right, I moved the Chain of Command and spare folder under the lamp to the left. I moved stamp and fancy coin into the middle.

I did some pixel shifting to try and make things look nice and visible.

As far I remembered, only the HoP has a paper shredder. Thus, the only way to get rid of sensitive paperwork for everyone else is to just light it on fire. While that has a cool vibe - even cooler is to have the shredder in the command meeting room!

