### PR TITLE
Makes some species specific emotes general

### DIFF
--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -157,7 +157,16 @@ var/list/_human_default_emotes = list(
 	/decl/emote/audible/zoom,
 	/decl/emote/audible/mothscream,
 	/decl/emote/audible/mothchitter,
-	/decl/emote/audible/mothlaugh
+	/decl/emote/audible/mothlaugh,
+	/decl/emote/audible/multichirp,
+	/decl/emote/audible/gnarl,
+	/decl/emote/audible/teshsqueak,
+	/decl/emote/audible/teshchirp,
+	/decl/emote/audible/teshtrill,
+	/decl/emote/visible/bounce,
+	/decl/emote/visible/jiggle,
+	/decl/emote/visible/lightup,
+	/decl/emote/visible/vibrate
 
 	//VOREStation Add End
 )


### PR DESCRIPTION
Adds species specific emotes to the general carbon list. Included is: mchirp (audible)
gnarl (audible)
surprised (audible)
tchirp (audible)
trill (audible)
bounce
jiggle
light
vibrate