### PR TITLE
Xenochimera Fix for Numbing Fangs/Sharp Melee overriding Claws

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/xenochimera_trait_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/xenochimera_trait_vr.dm
@@ -43,6 +43,7 @@
 	cost = 0
 	category = 0
 	custom_only = FALSE
+	var_changes = list("unarmed_types" = list(/datum/unarmed_attack/stomp, /datum/unarmed_attack/kick, /datum/unarmed_attack/claws/chimera, /datum/unarmed_attack/bite/sharp, /datum/unarmed_attack/bite/sharp/numbing)) // Fixes the parent forgetting to add 'chimera-specific claws
 
 /datum/trait/positive/snowwalker/xenochimera
 	sort = TRAIT_SORT_SPECIES


### PR DESCRIPTION
Claws were being reset to the default attacks list for numbing/etc, rather than using the chimera specific subset, because in order to update attacks we have to replace the entire list. CODE. <:
