### PR TITLE
Shortwave Headsets Crate

### DIFF
--- a/code/datums/supplypacks/misc_vr.dm
+++ b/code/datums/supplypacks/misc_vr.dm
@@ -168,3 +168,18 @@
 	cost = 300
 	containertype = /obj/structure/closet/crate
 	containername = "cordless jukebox speakers crate"
+
+/datum/supply_pack/misc/explorer_headsets
+	name = "shortwave-capable headsets (x4)"
+	contains = list(
+		/obj/item/device/radio/headset/explorer = 4
+	)
+	cost = 20
+	containertype = /obj/structure/closet/crate/secure/gear
+	containername = "exploration radio headsets crate"
+	access = list(
+		access_explorer,
+		access_eva,
+		access_pilot
+	)
+	one_access = TRUE


### PR DESCRIPTION
Saw a few comments about there being a shortage of shortwave headsets for away teams, especially if no pathfinder was around, and figured, hey, you know what's a good solution? *Cargo*.

So, here's a new supplypack with four shortwave headsets. Find it under the Misc category. Requires basic explo, pilot, or EVA access to open, at least one of which ought to be covered either by an actual explorer, pilot, or HoP/SM.