### PR TITLE
equip_special

### DIFF
--- a/code/modules/clothing/under/miscellaneous_vr.dm
+++ b/code/modules/clothing/under/miscellaneous_vr.dm
@@ -127,6 +127,25 @@
 	var/emagged = FALSE
 	var/target_size = 1
 
+/obj/item/proc/equip_special()
+	return
+
+/obj/item/clothing/gloves/bluespace/equip_special()
+	var/mob/M = src.loc
+	if(ishuman(M))
+		var/mob/living/carbon/human/H = M
+		if(!H.resizable)
+			return
+		if(H.size_multiplier != target_size)
+			if(!(world.time - last_activated > 10 SECONDS))
+				to_chat(M, "<span class ='warning'>\The [src] flickers. It seems to be recharging.</span>")
+				return
+			last_activated = world.time
+			original_size = H.size_multiplier
+			H.resize(target_size, uncapped = emagged, ignore_prefs = FALSE)		//In case someone else tries to put it on you.
+			H.visible_message("<span class='warning'>The space around [H] distorts as they change size!</span>","<span class='notice'>The space around you distorts as you change size!</span>")
+			log_admin("Admin [key_name(M)]'s size was altered by a bluespace bracelet.")
+
 /obj/item/clothing/gloves/bluespace/mob_can_equip(mob/M, gloves, disable_warning = 0)
 	. = ..()
 	if(. && ishuman(M) && !disable_warning)

--- a/code/modules/clothing/under/miscellaneous_vr.dm
+++ b/code/modules/clothing/under/miscellaneous_vr.dm
@@ -146,22 +146,6 @@
 			H.visible_message("<span class='warning'>The space around [H] distorts as they change size!</span>","<span class='notice'>The space around you distorts as you change size!</span>")
 			log_admin("Admin [key_name(M)]'s size was altered by a bluespace bracelet.")
 
-/obj/item/clothing/gloves/bluespace/mob_can_equip(mob/M, gloves, disable_warning = 0)
-	. = ..()
-	if(. && ishuman(M) && !disable_warning)
-		var/mob/living/carbon/human/H = M
-		if(!H.resizable)
-			return
-		if(H.size_multiplier != target_size)
-			if(!(world.time - last_activated > 10 SECONDS))
-				to_chat(M, "<span class ='warning'>\The [src] flickers. It seems to be recharging.</span>")
-				return
-			last_activated = world.time
-			original_size = H.size_multiplier
-			H.resize(target_size, uncapped = emagged, ignore_prefs = FALSE)		//In case someone else tries to put it on you.
-			H.visible_message("<span class='warning'>The space around [H] distorts as they change size!</span>","<span class='notice'>The space around you distorts as you change size!</span>")
-			log_admin("Admin [key_name(M)]'s size was altered by a bluespace bracelet.")
-
 /obj/item/clothing/gloves/bluespace/mob_can_unequip(mob/M, gloves, disable_warning = 0)
 	. = ..()
 	if(. && ishuman(M) && original_size && !disable_warning)

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -16,17 +16,17 @@ This saves us from having to call add_fingerprint() any time something is put in
 		if(!I)
 			to_chat(H, "<span class='notice'>You are not holding anything to equip.</span>")
 			return
-		
+
 		var/moved = FALSE
-		
+
 		// Try an equipment slot
 		if(H.equip_to_appropriate_slot(I))
 			moved = TRUE
-		
+
 		// No? Try a storage item.
 		else if(H.equip_to_storage(I, TRUE))
 			moved = TRUE
-		
+
 		// No?! Well, give up.
 		if(!moved)
 			to_chat(H, "<span class='warning'>You are unable to equip that.</span>")
@@ -376,6 +376,12 @@ This saves us from having to call add_fingerprint() any time something is put in
 		W.zoom()
 
 	W.in_inactive_hand(src)
+
+	//VOREStation Addition Start
+	if(istype(W, /obj/item))
+		var/obj/item/I = W
+		I.equip_special()
+	//VOREStation Addition End
 
 	return 1
 


### PR DESCRIPTION
makes it so that when equipped, items call equip_special(). By default equip_special() does nothing. 

This also makes it so that if you use the hotkey to equip things, such as the size standardization bracelets, they will do the things they are supposed to.