### PR TITLE
Trash pile adjustments

### DIFF
--- a/code/game/objects/items/weapons/id cards/cards_vr.dm
+++ b/code/game/objects/items/weapons/id cards/cards_vr.dm
@@ -8,3 +8,6 @@
 /obj/item/weapon/card/emag/used/Initialize()
 	. = ..()
 	uses = rand(1, 5)
+
+/obj/item/weapon/card/emag/one
+	uses = 1

--- a/code/game/objects/items/weapons/id cards/cards_vr.dm
+++ b/code/game/objects/items/weapons/id cards/cards_vr.dm
@@ -8,6 +8,3 @@
 /obj/item/weapon/card/emag/used/Initialize()
 	. = ..()
 	uses = rand(1, 5)
-
-/obj/item/weapon/card/emag/one
-	uses = 1

--- a/code/game/objects/structures/trash_pile_vr.dm
+++ b/code/game/objects/structures/trash_pile_vr.dm
@@ -22,7 +22,6 @@
 		/obj/item/weapon/bluespace_harpoon,
 		/obj/item/clothing/glasses/thermal/syndi,
 		/obj/item/weapon/gun/energy/netgun,
-		/obj/item/weapon/card/emag/one,
 		/obj/item/weapon/gun/projectile/dartgun,
 		/obj/item/clothing/gloves/black/bloodletter,
 		/obj/item/weapon/gun/energy/mouseray/metamorphosis

--- a/code/game/objects/structures/trash_pile_vr.dm
+++ b/code/game/objects/structures/trash_pile_vr.dm
@@ -23,7 +23,7 @@
 		/obj/item/clothing/glasses/thermal/syndi,
 		/obj/item/weapon/gun/energy/netgun,
 		/obj/item/weapon/gun/projectile/pirate,
-		/obj/item/clothing/accessory/permit/gun,
+		/obj/item/weapon/card/emag/one,
 		/obj/item/weapon/gun/projectile/dartgun,
 		/obj/item/clothing/gloves/black/bloodletter,
 		/obj/item/weapon/gun/energy/mouseray/metamorphosis
@@ -263,7 +263,7 @@
 					prob(1);/obj/item/device/flashlight/glowstick/yellow,
 					prob(1);/obj/item/device/flashlight/pen,
 					prob(1);/obj/item/device/paicard,
-					prob(1);/obj/item/weapon/card/emag,
+					prob(1);/obj/item/clothing/accessory/permit/gun,
 					prob(1);/obj/item/clothing/mask/gas/voice,
 					prob(1);/obj/item/weapon/spacecash/c100,
 					prob(1);/obj/item/weapon/spacecash/c50,

--- a/code/game/objects/structures/trash_pile_vr.dm
+++ b/code/game/objects/structures/trash_pile_vr.dm
@@ -292,6 +292,7 @@
 					prob(2);/obj/item/clothing/under/hyperfiber/bluespace,
 					prob(2);/obj/item/selectable_item/chemistrykit/size,
 					prob(2);/obj/item/selectable_item/chemistrykit/gender,
+					prob(2);/obj/item/clothing/gloves/bluespace/emagged,
 					prob(1);/obj/item/clothing/suit/storage/vest/heavy/merc,
 					prob(1);/obj/item/device/nif/bad,
 					prob(1);/obj/item/device/radio_jammer,
@@ -308,6 +309,7 @@
 					prob(1);/obj/item/weapon/reagent_containers/syringe/steroid,
 					prob(1);/obj/item/capture_crystal,
 					prob(1);/obj/item/device/perfect_tele/one_beacon,
+					prob(1);/obj/item/clothing/gloves/bluespace,
 					prob(1);/obj/item/weapon/gun/energy/mouseray)
 
 	var/obj/item/I = new path()

--- a/code/game/objects/structures/trash_pile_vr.dm
+++ b/code/game/objects/structures/trash_pile_vr.dm
@@ -22,7 +22,6 @@
 		/obj/item/weapon/bluespace_harpoon,
 		/obj/item/clothing/glasses/thermal/syndi,
 		/obj/item/weapon/gun/energy/netgun,
-		/obj/item/weapon/gun/projectile/pirate,
 		/obj/item/weapon/card/emag/one,
 		/obj/item/weapon/gun/projectile/dartgun,
 		/obj/item/clothing/gloves/black/bloodletter,
@@ -309,6 +308,7 @@
 					prob(1);/obj/item/device/survivalcapsule/popcabin,
 					prob(1);/obj/item/weapon/reagent_containers/syringe/steroid,
 					prob(1);/obj/item/capture_crystal,
+					prob(1);/obj/item/device/perfect_tele/one_beacon,
 					prob(1);/obj/item/weapon/gun/energy/mouseray)
 
 	var/obj/item/I = new path()

--- a/code/modules/clothing/under/miscellaneous_vr.dm
+++ b/code/modules/clothing/under/miscellaneous_vr.dm
@@ -175,6 +175,15 @@
 		user.visible_message("<span class='notice'>\The [user] swipes the [emag_source] over the \the [src].</span>","<span class='notice'>You swipes the [emag_source] over the \the [src].</span>")
 		return 1
 
+/obj/item/clothing/gloves/bluespace/emagged
+	emagged = TRUE
+
+/obj/item/clothing/gloves/bluespace/emagged/Initialize()
+	. = ..()
+	target_size = (rand(1,300)) /100
+	if(target_size < 0.1)
+		target_size = 0.1
+
 //Same as Nanotrasen Security Uniforms
 /obj/item/clothing/under/ert
 	armor = list(melee = 5, bullet = 10, laser = 10, energy = 5, bomb = 5, bio = 0, rad = 0)


### PR DESCRIPTION
- Removes the zip gun from the gamma list
- Removes the emag from the alpha list
- Moves the weapon permit from the gamma list to the alpha list
- Adds the single-beacon translocator to the beta list
- Adds size bracelets (including an emagged variant) to the beta list