### PR TITLE
Adds ability for items to be whitelisted for protean blob-drop; adds that to Freyr's mask

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -109,6 +109,8 @@
 
 	var/no_random_knockdown = FALSE			//stops item from being able to randomly knock people down in combat
 
+	var/protean_drop_whitelist = FALSE
+
 /obj/item/New()
 	..()
 	if(embed_chance < 0)

--- a/code/modules/mob/living/carbon/human/species/station/protean_vr/protean_blob.dm
+++ b/code/modules/mob/living/carbon/human/species/station/protean_vr/protean_blob.dm
@@ -360,6 +360,8 @@ var/global/list/disallowed_protean_accessories = list(
 	things_to_drop -= internal_organs //Mah sqeedily spooch
 
 	for(var/obj/item/I in things_to_drop) //rip hoarders
+		if(I.protean_drop_whitelist)
+			continue
 		drop_from_inventory(I)
 
 	if(w_uniform && istype(w_uniform,/obj/item/clothing)) //No webbings tho. We do this after in case a suit was in the way

--- a/code/modules/vore/fluffstuff/custom_clothes_vr.dm
+++ b/code/modules/vore/fluffstuff/custom_clothes_vr.dm
@@ -2539,6 +2539,7 @@ Departamental Swimsuits, for general use
 	body_parts_covered = FACE
 	flags_inv = HIDEFACE
 	item_flags = FLEXIBLEMATERIAL
+	protean_drop_whitelist = TRUE
 
 //codeme: Perrin Kade
 /obj/item/clothing/shoes/fluff/gildedshoes_perrin


### PR DESCRIPTION
The mask in question is, protean-wise completely decorative so its not mechanically advantageous to keep.