### PR TITLE
removes meme reaction, adds sickness to regen

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/station_special_abilities_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_special_abilities_vr.dm
@@ -118,10 +118,13 @@
 
 		//Dead when hatching
 		if(stat == DEAD)
+			var/sickness_duration = 10 MINUTES
 			//Reviving from ded takes extra nutrition - if it isn't provided from outside sources, it comes from you
 			if(!hasnutriment())
 				nutrition=nutrition * 0.75
+				sickness_duration = 20 MINUTES
 			chimera_hatch()
+			add_modifier(/datum/modifier/resleeving_sickness/chimera, sickness_duration)
 			adjustBrainLoss(5) // if they're reviving from dead, they come back with 5 brainloss on top of whatever's unhealed.
 			visible_message("<span class='warning'><p><font size=4>The former corpse staggers to its feet, all its former wounds having vanished...</font></p></span>") //Bloody hell...
 			clear_alert("hatch")
@@ -167,6 +170,13 @@
 	weakened = 2
 
 	revive_ready = world.time + 10 MINUTES //set the cooldown CHOMPEdit: Reduced this to 10 minutes, you're playing with fire if you're reviving that often.
+
+/datum/modifier/resleeving_sickness/chimera //near identical to the regular version, just with different flavortexts
+	name = "imperfect regeneration"
+	desc = "You feel rather weak and unfocused, having just regrown your body not so long ago."
+
+	on_created_text = "<span class='warning'><font size='3'>You feel weak and unsteady, that regeneration having been rougher than most.</font></span>"
+	on_expired_text = "<span class='notice'><font size='3'>You feel your strength and focus return to you.</font></span>"
 
 /mob/living/carbon/human/proc/revivingreset() // keep this as a debug proc or potential future use
 		revive_ready = REVIVING_READY

--- a/code/modules/reagents/reactions/instant/instant_vr.dm
+++ b/code/modules/reagents/reactions/instant/instant_vr.dm
@@ -102,31 +102,6 @@
 ///////////////////////////////////////////////////////////////////////////////////
 /// Miscellaneous Reactions
 
-/decl/chemical_reaction/instant/xenolazarus
-	name = "Discount Lazarus"
-	id = "discountlazarus"
-	result = null
-	required_reagents = list("monstertamer" = 5, "clonexadone" = 5)
-
-/decl/chemical_reaction/instant/xenolazarus/on_reaction(var/datum/reagents/holder, var/created_volume) //literally all this does is mash the regenerate button
-	if(ishuman(holder.my_atom))
-		var/mob/living/carbon/human/H = holder.my_atom
-		if(H.stat == DEAD && (/mob/living/carbon/human/proc/reconstitute_form in H.verbs)) //no magical regen for non-regenners, and can't force the reaction on live ones
-			if(H.hasnutriment()) // make sure it actually has the conditions to revive
-				if(H.revive_ready >= 1) // if it's not reviving, start doing so
-					H.revive_ready = REVIVING_READY // overrides the normal cooldown
-					H.visible_message("<span class='info'>[H] shudders briefly, then relaxes, faint movements stirring within.</span>")
-					H.chimera_regenerate()
-				else if (/mob/living/carbon/human/proc/hatch in H.verbs)// already reviving, check if they're ready to hatch
-					H.chimera_hatch()
-					H.visible_message("<span class='danger'><p><font size=4>[H] violently convulses and then bursts open, revealing a new, intact copy in the pool of viscera.</font></p></span>") // Hope you were wearing waterproofs, doc...
-					H.adjustBrainLoss(10) // they're reviving from dead, so take 10 brainloss
-				else //they're already reviving but haven't hatched. Give a little message to tell them to wait.
-					H.visible_message("<span class='info'>[H] stirs faintly, but doesn't appear to be ready to wake up yet.</span>")
-			else
-				H.visible_message("<span class='info'>[H] twitches for a moment, but remains still.</span>") // no nutriment
-
-
 /decl/chemical_reaction/instant/foam/softdrink
 	required_reagents = list("cola" = 1, "mint" = 1)
 


### PR DESCRIPTION
Removes the meme monstertamer reaction that existed mainly as a means for medbay to force a chimera regen - it's no longer needed as the regen cooldown has since been massively nerfed and chimera can now be defibbed normally.

Speaking of things that were implemented since chimera regen was a thing - they get a variant of resleeving sickness now if they revive from dead, just like everyone else. Dying sucks. Try not to do it. The duration is SLIGHTLY shorter to account for the time taken by regenerating in the first place.