### PR TITLE
Map Tweaks!

### DIFF
--- a/maps/groundbase/gb-z1.dmm
+++ b/maps/groundbase/gb-z1.dmm
@@ -8563,6 +8563,7 @@
 /obj/item/gunbox/warden,
 /obj/structure/closet/secure_closet/warden,
 /obj/item/device/ticket_printer,
+/obj/item/weapon/gun/energy/sizegun,
 /turf/simulated/floor/tiled/dark,
 /area/groundbase/security/warden)
 "tx" = (

--- a/maps/stellar_delight/stellar_delight1.dmm
+++ b/maps/stellar_delight/stellar_delight1.dmm
@@ -255,7 +255,6 @@
 	color = "#42038a";
 	icon_state = "2-8"
 	},
-/mob/living/simple_mob/animal/passive/mimepet/gregory,
 /turf/simulated/floor/tiled/eris,
 /area/rnd/xenobiology/xenoflora)
 "aA" = (
@@ -4375,6 +4374,14 @@
 /turf/simulated/floor,
 /area/maintenance/stellardelight/deck1/exploration)
 "iV" = (
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/closet/walllocker_double/west{
+	desc = "A wall mounted storage cabinet marked with a cross and warning icon. This seems to contain an assortment of emergency supplies.";
+	name = "Emergency Cabinet"
+	},
 /obj/item/device/radio,
 /obj/item/device/radio,
 /obj/item/device/radio,
@@ -4383,13 +4390,6 @@
 /obj/item/weapon/tank/emergency/oxygen/engi,
 /obj/item/clothing/mask/breath,
 /obj/item/clothing/mask/breath,
-/obj/structure/closet/walllocker_double/south{
-	desc = "A wall mounted storage cabinet marked with a cross and warning icon. This seems to contain an assortment of emergency supplies.";
-	name = "Emergency Cabinet"
-	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/tiled/techmaint,
 /area/stellardelight/deck1/port)
 "iW" = (
@@ -5584,6 +5584,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/mob/living/simple_mob/animal/passive/mimepet/gregory,
 /turf/simulated/floor/tiled/steel_grid,
 /area/rnd/research)
 "lH" = (
@@ -10829,6 +10830,18 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
+/obj/structure/closet/walllocker_double/north{
+	desc = "A wall mounted storage cabinet marked with a cross and warning icon. This seems to contain an assortment of emergency supplies.";
+	name = "Emergency Cabinet"
+	},
+/obj/item/device/radio,
+/obj/item/device/radio,
+/obj/item/device/radio,
+/obj/item/weapon/storage/briefcase/inflatable,
+/obj/item/weapon/tank/emergency/oxygen/engi,
+/obj/item/weapon/tank/emergency/oxygen/engi,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
 /turf/simulated/floor/tiled/techmaint,
 /area/stellardelight/deck1/port)
 "wM" = (
@@ -13415,14 +13428,6 @@
 	},
 /turf/simulated/floor,
 /area/maintenance/stellardelight/deck1/exploration)
-"Ce" = (
-/obj/structure/low_wall/bay/reinforced/steel,
-/obj/structure/window/bay/reinforced,
-/obj/machinery/door/blast/angled{
-	dir = 4
-	},
-/turf/space,
-/area/rnd/xenobiology/xenoflora_storage)
 "Cf" = (
 /obj/structure/cable/pink{
 	icon_state = "4-8"
@@ -17840,11 +17845,12 @@
 /area/maintenance/stellardelight/deck1/starboardaft)
 "LG" = (
 /obj/machinery/door/firedoor/glass,
+/obj/machinery/door/blast/angled/open{
+	dir = 2;
+	id = "researchwindowlockdown"
+	},
 /obj/structure/window/bay/reinforced,
 /obj/structure/low_wall/bay/reinforced/steel,
-/obj/machinery/door/blast/angled{
-	id = "xenofloralockdown"
-	},
 /turf/simulated/floor,
 /area/rnd/xenobiology/xenoflora)
 "LH" = (
@@ -19634,6 +19640,18 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
 	},
+/obj/structure/closet/walllocker_double/north{
+	desc = "A wall mounted storage cabinet marked with a cross and warning icon. This seems to contain an assortment of emergency supplies.";
+	name = "Emergency Cabinet"
+	},
+/obj/item/device/radio,
+/obj/item/device/radio,
+/obj/item/device/radio,
+/obj/item/weapon/storage/briefcase/inflatable,
+/obj/item/weapon/tank/emergency/oxygen/engi,
+/obj/item/weapon/tank/emergency/oxygen/engi,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
 /turf/simulated/floor/tiled/techmaint,
 /area/stellardelight/deck1/aft)
 "PE" = (
@@ -20578,20 +20596,19 @@
 /turf/simulated/floor,
 /area/security/tactical)
 "Ry" = (
-/obj/item/device/radio,
-/obj/item/device/radio,
-/obj/item/device/radio,
-/obj/item/weapon/storage/briefcase/inflatable,
-/obj/item/weapon/tank/emergency/oxygen/engi,
-/obj/item/weapon/tank/emergency/oxygen/engi,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/obj/structure/closet/walllocker_double/south{
-	desc = "A wall mounted storage cabinet marked with a cross and warning icon. This seems to contain an assortment of emergency supplies.";
-	name = "Emergency Cabinet"
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/blast/angled/open{
+	dir = 2;
+	id = "researchwindowlockdown"
 	},
-/turf/simulated/floor/tiled/techmaint,
-/area/stellardelight/deck1/port)
+/obj/structure/window/bay/reinforced,
+/obj/structure/low_wall/bay/reinforced/steel,
+/obj/structure/cable/green{
+	color = "#42038a";
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/rnd/xenobiology/xenoflora_storage)
 "Rz" = (
 /turf/simulated/floor/tiled/milspec,
 /area/stellardelight/deck1/explobriefing)
@@ -20796,11 +20813,12 @@
 /area/security/security_lockerroom)
 "RV" = (
 /obj/machinery/door/firedoor/glass,
+/obj/machinery/door/blast/angled/open{
+	dir = 2;
+	id = "researchwindowlockdown"
+	},
 /obj/structure/window/bay/reinforced,
 /obj/structure/low_wall/bay/reinforced/steel,
-/obj/machinery/door/blast/angled{
-	id = "xenofloralockdown"
-	},
 /turf/simulated/floor,
 /area/rnd/xenobiology/xenoflora_storage)
 "RX" = (
@@ -22821,21 +22839,6 @@
 /obj/effect/floor_decal/milspec/color/black,
 /turf/simulated/floor/tiled/dark,
 /area/security/armoury)
-"VO" = (
-/obj/item/device/radio,
-/obj/item/device/radio,
-/obj/item/device/radio,
-/obj/item/weapon/storage/briefcase/inflatable,
-/obj/item/weapon/tank/emergency/oxygen/engi,
-/obj/item/weapon/tank/emergency/oxygen/engi,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/obj/structure/closet/walllocker_double/south{
-	desc = "A wall mounted storage cabinet marked with a cross and warning icon. This seems to contain an assortment of emergency supplies.";
-	name = "Emergency Cabinet"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/stellardelight/deck1/aft)
 "VP" = (
 /obj/structure/cable/green{
 	icon_state = "2-8"
@@ -33167,7 +33170,7 @@ Sa
 xC
 hR
 ke
-rg
+iV
 Wz
 re
 MI
@@ -34018,7 +34021,7 @@ XU
 bg
 iI
 Hl
-Ry
+YT
 oE
 FB
 Vt
@@ -34567,7 +34570,7 @@ gx
 yd
 YM
 wy
-iV
+kU
 ER
 zg
 aj
@@ -35030,7 +35033,7 @@ VA
 qD
 qD
 sM
-VO
+hg
 gQ
 xD
 pw
@@ -38732,12 +38735,12 @@ xo
 SR
 Vg
 pQ
-Ce
-Ce
+RV
+RV
 pQ
 pQ
-Ce
-Ce
+RV
+Ry
 pQ
 pQ
 bD

--- a/maps/stellar_delight/stellar_delight1.dmm
+++ b/maps/stellar_delight/stellar_delight1.dmm
@@ -5259,6 +5259,16 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/stellardelight/deck1/port)
+"kV" = (
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/blast/angled/open{
+	dir = 4;
+	id = "researchwindowlockdown"
+	},
+/obj/structure/window/bay/reinforced,
+/obj/structure/low_wall/bay/reinforced/steel,
+/turf/simulated/floor,
+/area/rnd/xenobiology/xenoflora_storage)
 "kY" = (
 /obj/structure/cable/pink{
 	icon_state = "1-2"
@@ -20598,7 +20608,7 @@
 "Ry" = (
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/blast/angled/open{
-	dir = 2;
+	dir = 4;
 	id = "researchwindowlockdown"
 	},
 /obj/structure/window/bay/reinforced,
@@ -38735,11 +38745,11 @@ xo
 SR
 Vg
 pQ
-RV
-RV
+kV
+kV
 pQ
 pQ
-RV
+kV
 Ry
 pQ
 pQ

--- a/maps/stellar_delight/stellar_delight2.dmm
+++ b/maps/stellar_delight/stellar_delight2.dmm
@@ -6152,8 +6152,8 @@
 /obj/item/clothing/mask/breath,
 /obj/item/clothing/mask/breath,
 /obj/structure/closet/walllocker_double/west{
-	name = "Emergency Cabinet";
-	desc = "A wall mounted storage cabinet marked with a cross and warning icon. This seems to contain an assortment of emergency supplies."
+	desc = "A wall mounted storage cabinet marked with a cross and warning icon. This seems to contain an assortment of emergency supplies.";
+	name = "Emergency Cabinet"
 	},
 /obj/effect/floor_decal/milspec/color/green/half{
 	dir = 8
@@ -20045,8 +20045,8 @@
 /obj/item/clothing/mask/breath,
 /obj/item/clothing/mask/breath,
 /obj/structure/closet/crate/medical{
-	name = "NanoTrasen Emergency Supply Crate";
-	desc = "A crate full of emergency supplies to help with response and rescue operations. A logo of NanoTrasen with a checkmark is stamped on the crate."
+	desc = "A crate full of emergency supplies to help with response and rescue operations. A logo of NanoTrasen with a checkmark is stamped on the crate.";
+	name = "NanoTrasen Emergency Supply Crate"
 	},
 /obj/item/weapon/storage/briefcase/inflatable,
 /obj/item/weapon/storage/firstaid/adv,
@@ -21335,21 +21335,6 @@
 	},
 /turf/simulated/floor/tiled/eris/dark/techfloor_grid,
 /area/storage/tech)
-"UW" = (
-/obj/item/device/radio,
-/obj/item/device/radio,
-/obj/item/device/radio,
-/obj/item/weapon/storage/briefcase/inflatable,
-/obj/item/weapon/tank/emergency/oxygen/engi,
-/obj/item/weapon/tank/emergency/oxygen/engi,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/obj/structure/closet/walllocker_double/north{
-	desc = "A wall mounted storage cabinet marked with a cross and warning icon. This seems to contain an assortment of emergency supplies.";
-	name = "Emergency Cabinet"
-	},
-/turf/simulated/floor/tiled/eris/dark/cargo,
-/area/crew_quarters/recreation_area)
 "UX" = (
 /obj/structure/table/gamblingtable,
 /turf/simulated/floor/carpet,
@@ -33048,7 +33033,7 @@ VG
 KH
 zz
 nt
-UW
+mt
 Bp
 oS
 oS
@@ -35036,7 +35021,7 @@ FA
 Zr
 sj
 FU
-Zr
+xS
 Zr
 vj
 pZ
@@ -35045,7 +35030,7 @@ Zr
 OV
 Zr
 Ye
-xS
+Zr
 Zr
 Zm
 OV

--- a/maps/stellar_delight/stellar_delight3.dmm
+++ b/maps/stellar_delight/stellar_delight3.dmm
@@ -1679,8 +1679,7 @@
 	desc = "A wall mounted storage cabinet marked with a cross and warning icon. This seems to contain an assortment of emergency supplies.";
 	name = "Emergency Cabinet"
 	},
-/obj/structure/lattice,
-/turf/simulated/open,
+/turf/simulated/floor,
 /area/stellardelight/deck2/fore)
 "gy" = (
 /obj/structure/closet/secure_closet/engineering_chief,
@@ -1866,14 +1865,6 @@
 	},
 /area/tcommsat/chamber)
 "gY" = (
-/obj/item/device/radio,
-/obj/item/device/radio,
-/obj/item/device/radio,
-/obj/item/weapon/storage/briefcase/inflatable,
-/obj/item/weapon/tank/emergency/oxygen/engi,
-/obj/item/weapon/tank/emergency/oxygen/engi,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
 /obj/structure/closet/walllocker_double/south{
 	desc = "A wall mounted storage cabinet marked with a cross and warning icon. This seems to contain an assortment of emergency supplies.";
 	name = "Emergency Cabinet"
@@ -2136,19 +2127,10 @@
 	},
 /area/tcommsat/chamber)
 "ie" = (
-/obj/item/device/radio,
-/obj/item/device/radio,
-/obj/item/device/radio,
-/obj/item/weapon/storage/briefcase/inflatable,
-/obj/item/weapon/tank/emergency/oxygen/engi,
-/obj/item/weapon/tank/emergency/oxygen/engi,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
 /obj/structure/closet/walllocker_double/south{
 	desc = "A wall mounted storage cabinet marked with a cross and warning icon. This seems to contain an assortment of emergency supplies.";
 	name = "Emergency Cabinet"
 	},
-/obj/structure/lattice,
 /turf/simulated/open,
 /area/stellardelight/deck2/starboard)
 "if" = (
@@ -9076,14 +9058,6 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/ai_server_room)
 "GV" = (
-/obj/item/device/radio,
-/obj/item/device/radio,
-/obj/item/device/radio,
-/obj/item/weapon/storage/briefcase/inflatable,
-/obj/item/weapon/tank/emergency/oxygen/engi,
-/obj/item/weapon/tank/emergency/oxygen/engi,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
 /obj/structure/closet/walllocker_double/south{
 	desc = "A wall mounted storage cabinet marked with a cross and warning icon. This seems to contain an assortment of emergency supplies.";
 	name = "Emergency Cabinet"
@@ -24555,7 +24529,7 @@ qp
 Qp
 Hf
 gO
-gx
+qF
 rc
 tJ
 aQ
@@ -24697,7 +24671,7 @@ oP
 dN
 UA
 Fj
-sO
+gx
 EJ
 rx
 rx
@@ -26449,7 +26423,7 @@ OA
 cz
 ow
 ok
-ie
+ow
 aA
 yw
 bb

--- a/maps/tether/tether-02-surface2.dmm
+++ b/maps/tether/tether-02-surface2.dmm
@@ -11777,6 +11777,7 @@
 	icon_state = "4-8"
 	},
 /obj/item/device/ticket_printer,
+/obj/item/weapon/gun/energy/sizegun,
 /turf/simulated/floor/tiled/dark,
 /area/tether/surfacebase/security/warden)
 "asF" = (

--- a/maps/tether/tether-03-surface3.dmm
+++ b/maps/tether/tether-03-surface3.dmm
@@ -44692,19 +44692,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tether/surfacebase/surface_three_hall)
-"xlK" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor/glass,
-/obj/effect/floor_decal/spline/plain{
-	dir = 1
-	},
-/obj/machinery/door/blast/gate/thin{
-	dir = 2;
-	id = "cafe";
-	layer = 3.3
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/kitchen)
 "xlW" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -60089,7 +60076,7 @@ beI
 bgn
 aKu
 anj
-xlK
+avo
 avz
 avM
 asX


### PR DESCRIPTION
Adds sizeguns to tether and gb warden's lockers for SD pairity.

Also adjusts recent SD map edits.
-Makes xenobot blast doors start open
-Fixed wiring and lack of solid turf under xenobot windows
-Moves Greg to R&D
-Moved south facing emergency cabinets so they don't face south
-Moved and removed some of the other emergency cabinets so that there are only one of those in each hazard control section they were present in. I am rather ambivalent to there being so many inflatables strewn all over the ship. That's what the hazard control sections are for. :I