### PR TITLE
Switches workflows to use Ubuntu 20.04

### DIFF
--- a/.github/workflows/autochangelog.yml
+++ b/.github/workflows/autochangelog.yml
@@ -11,7 +11,7 @@ env:
 jobs:
   autochangelog:
     name: Autochangelog
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     if: github.event.pull_request.merged == true
     steps:
       - uses: /actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ env:
 jobs:
   file_tests:
     name: Run Linters
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - name: Ensure +x on CI directory
@@ -36,7 +36,7 @@ jobs:
 
   dreamchecker:
     name: DreamChecker
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
 
@@ -69,7 +69,7 @@ jobs:
     # name: Integration Tests (${{ matrix.map }})
     name: Integration Tests
     # needs: ['file_tests', 'dreamchecker']
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - name: Ensure +x on CI directory
@@ -120,7 +120,7 @@ jobs:
   tests_successful:
     name: Integration Tests
     needs: ['file_tests', 'dreamchecker', 'unit_tests']
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Report Success
         run: |

--- a/.github/workflows/render_nanomaps.yml
+++ b/.github/workflows/render_nanomaps.yml
@@ -19,7 +19,7 @@ jobs:
       pull-requests: write # to create pull requests (repo-sync/pull-request)
 
     name: 'Generate NanoMaps'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - name: Clone
       uses: actions/checkout@v3


### PR DESCRIPTION
So, ubuntu-latest is in the process of getting switched over to resolve as `ubuntu-22.04` instead of `ubuntu-20.04`
Which is nice and all, except using `ubuntu-22.04` completely breaks rust_g which thus prevents unit tests from working. And so to prevent this from happening, `ubuntu-latest` has been replaced with `ubuntu-20.04` in all the actions. (Mirroring how tg station and Citadel are doing their workflows at the moment in that respect)