### PR TITLE
Simplified Hacktool

### DIFF
--- a/code/game/objects/items/devices/hacktool.dm
+++ b/code/game/objects/items/devices/hacktool.dm
@@ -46,10 +46,12 @@
 
 	// Note, if you ever want to expand supported_types, you must manually add the custom state argument to their tgui_interact
 	// DISABLED: too fancy, too high-effort // A.tgui_interact(user, custom_state = hack_state)
-	// Just brute-force it open
+	// Just brute-force it
 	if(istype(A, /obj/machinery/door/airlock))
 		var/obj/machinery/door/airlock/D = A
-		if(D.locked == TRUE && full_override == FALSE)
+		if(!D.arePowerSystemsOn())
+			to_chat(user, "<span class='warning'>No response from remote, check door power.</span>")
+		else if(D.locked == TRUE && full_override == FALSE)
 			to_chat(user, "<span class='warning'>Unable to override door bolts!</span>")
 		else if(D.locked == TRUE && full_override == TRUE && D.arePowerSystemsOn())
 			to_chat(user, "<span class='notice'>Door bolts overridden.</span>")

--- a/code/game/objects/items/devices/hacktool.dm
+++ b/code/game/objects/items/devices/hacktool.dm
@@ -1,11 +1,17 @@
 /obj/item/device/multitool/hacktool
 	var/is_hacking = 0
 	var/max_known_targets
+	var/hackspeed = 1
+	var/full_override = FALSE	//can we override door bolts too? defaults to false for event/safety reasons
 
 	var/in_hack_mode = 0
 	var/list/known_targets
 	var/list/supported_types
 	var/datum/tgui_state/default/must_hack/hack_state
+	
+/obj/item/device/multitool/hacktool/override
+	hackspeed = 0.75
+	full_override = TRUE
 
 /obj/item/device/multitool/hacktool/New()
 	..()
@@ -39,7 +45,21 @@
 		return 0
 
 	// Note, if you ever want to expand supported_types, you must manually add the custom state argument to their tgui_interact
-	A.tgui_interact(user, custom_state = hack_state)
+	// DISABLED: too fancy, too high-effort // A.tgui_interact(user, custom_state = hack_state)
+	// Just brute-force it open
+	if(istype(A, /obj/machinery/door/airlock))
+		var/obj/machinery/door/airlock/D = A
+		if(D.locked == TRUE && full_override == FALSE)
+			to_chat(user, "<span class='warning'>Unable to override door bolts!</span>")
+		else if(D.locked == TRUE && full_override == TRUE && D.arePowerSystemsOn())
+			to_chat(user, "<span class='notice'>Door bolts overridden.</span>")
+			D.unlock()
+		else if(D.density == TRUE && D.locked == FALSE)
+			to_chat(user, "<span class='notice'>Overriding access. Door opening.</span>")
+			D.open()
+		else if(D.density == FALSE && D.locked == FALSE)
+			to_chat(user, "<span class='notice'>Overriding access. Door closing.</span>")
+			D.close()
 	return 1
 
 /obj/item/device/multitool/hacktool/proc/attempt_hack(var/mob/user, var/atom/target)
@@ -56,8 +76,9 @@
 
 	to_chat(user, "<span class='notice'>You begin hacking \the [target]...</span>")
 	is_hacking = 1
-	// On average hackin takes ~30 seconds. Fairly small random span to avoid people simply aborting and trying again
-	var/hack_result = do_after(user, (20 SECONDS + rand(0, 10 SECONDS) + rand(0, 10 SECONDS)))
+	// On average hackin takes ~15 seconds. Fairly small random span to avoid people simply aborting and trying again
+	// Reduced hack duration to compensate for the reduced functionality 
+	var/hack_result = do_after(user, ((10 SECONDS + rand(0, 10 SECONDS))*hackspeed))
 	is_hacking = 0
 
 	if(hack_result && in_hack_mode)


### PR DESCRIPTION
Something about the TGUI interface for the old hacktool just doesn't work, so fuck it, I've stripped out the fancy functionality for a much simpler approach.

Its function is now very simple; it can let you use doors that you don't have permissions for. Hacked doors can be opened or closed, and the tool 'remembers' a short list of recently-hacked doors so you don't need to rehack them constantly. In exchange for the reduced functionality, the overall hack time is now a lot shorter. It also can't raise lowered bolts unless you have the special subtype (so, if you want to hack into capital-S Secure areas, you need to do it the old-fashioned way).

Fixing the TGUI is too much of a headache and this isn't a traitor-oriented server, so I don't really see the need to go through the trouble of making it so people can go around messing with doors on a whim by electrifying/bolting/de-safetying them. Might as well just make it a nice easy *open sesame* tool.

They have not been added to any loot sources in this PR: I leave availability up to the staff's discretion.