### PR TITLE
Adds Anesthetic Tanks to Medical Gripper

### DIFF
--- a/code/modules/mob/living/silicon/robot/drone/drone_items.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_items.dm
@@ -100,6 +100,7 @@
 		/obj/item/weapon/reagent_containers/pill,
 		/obj/item/weapon/reagent_containers/blood,
 		/obj/item/stack/material/phoron,
+		/obj/item/weapon/tank/anesthetic,
 		/obj/item/weapon/disk/body_record //Vorestation Edit: this lets you get an empty sleeve or help someone else
 		)
 


### PR DESCRIPTION
A small adjustment that allows medical borgs to take and place anesthetic tanks ONLY. Specifically no oxygen/nitrogen/phoron etc.

This isn't a power spike, but in the case of surgery/trauma borgs allows them to do their job still in the rare event a wall-mounted anesthetic pump is unusable.