### PR TITLE
Further Hacktool Adjustments

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -43,6 +43,7 @@
 	var/obj/item/weapon/airlock_electronics/electronics = null
 	var/hasShocked = 0 //Prevents multiple shocks from happening
 	var/secured_wires = 0
+	var/security_level = 1 //VOREStation Addition - acts as a multiplier on the time required to hack an airlock with a hacktool
 	var/datum/wires/airlock/wires = null
 
 	var/open_sound_powered = 'sound/machines/door/covert1o.ogg'
@@ -129,6 +130,7 @@
 	close_sound_powered = 'sound/machines/door/hall1c.ogg' // VOREStation Edit: Default door sounds for fancy, department-off.
 	department_open_powered = 'sound/machines/door/cmd3o.ogg'
 	department_close_powered = 'sound/machines/door/cmd3c.ogg'
+	security_level = 3	//VOREStation Addition
 
 /obj/machinery/door/airlock/security
 	name = "Security Airlock"
@@ -139,6 +141,7 @@
 	close_sound_powered = 'sound/machines/door/hall1c.ogg' // VOREStation Edit: Default door sounds for fancy, department-off.
 	department_open_powered = 'sound/machines/door/sec1o.ogg'
 	department_close_powered = 'sound/machines/door/sec1c.ogg'
+	security_level = 2	//VOREStation Addition
 
 /obj/machinery/door/airlock/engineering
 	name = "Engineering Airlock"
@@ -149,6 +152,7 @@
 	close_sound_powered = 'sound/machines/door/hall1c.ogg' // VOREStation Edit: Default door sounds for fancy, department-off.
 	department_open_powered = 'sound/machines/door/eng1o.ogg'
 	department_close_powered = 'sound/machines/door/eng1c.ogg'
+	security_level = 1.5	//VOREStation Addition
 
 /obj/machinery/door/airlock/engineeringatmos
 	name = "Atmospherics Airlock"
@@ -159,6 +163,7 @@
 	close_sound_powered = 'sound/machines/door/hall1c.ogg' // VOREStation Edit: Default door sounds for fancy, department-off.
 	department_open_powered = 'sound/machines/door/eng1o.ogg'
 	department_close_powered = 'sound/machines/door/eng1c.ogg'
+	security_level = 1.5	//VOREStation Addition
 
 /obj/machinery/door/airlock/medical
 	name = "Medical Airlock"
@@ -169,6 +174,7 @@
 	close_sound_powered = 'sound/machines/door/hall1c.ogg' // VOREStation Edit: Default door sounds for fancy, department-off.
 	department_open_powered = 'sound/machines/door/med1o.ogg'
 	department_close_powered = 'sound/machines/door/med1c.ogg'
+	security_level = 1.5	//VOREStation Addition
 
 /obj/machinery/door/airlock/maintenance
 	name = "Maintenance Access"
@@ -258,6 +264,7 @@
 	opacity = 1
 	open_sound_powered = 'sound/machines/door/cmd3o.ogg'
 	close_sound_powered = 'sound/machines/door/cmd3c.ogg'
+	security_level = 100	//VOREStation Addition
 
 /obj/machinery/door/airlock/glass_centcom
 	name = "Airlock"
@@ -266,6 +273,7 @@
 	glass = 1
 	open_sound_powered = 'sound/machines/door/cmd3o.ogg'
 	close_sound_powered = 'sound/machines/door/cmd3c.ogg'
+	security_level = 100	//VOREStation Addition
 
 /obj/machinery/door/airlock/vault
 	name = "Vault"
@@ -277,6 +285,7 @@
 	req_one_access = list(access_heads_vault)
 	open_sound_powered = 'sound/machines/door/vault1o.ogg'
 	close_sound_powered = 'sound/machines/door/vault1c.ogg'
+	security_level = 5	//VOREStation Addition
 
 /obj/machinery/door/airlock/vault/bolted
 	icon_state = "door_locked"
@@ -324,6 +333,7 @@
 	close_sound_powered = 'sound/machines/door/hall1c.ogg' // VOREStation Edit: Default door sounds for fancy, department-off.
 	department_open_powered = 'sound/machines/door/cmd1o.ogg'
 	department_close_powered = 'sound/machines/door/cmd1c.ogg'
+	security_level = 3	//VOREStation Addition
 
 /obj/machinery/door/airlock/glass_engineering
 	name = "Engineering Airlock"
@@ -337,6 +347,7 @@
 	req_one_access = list(access_engine)
 	department_open_powered = 'sound/machines/door/eng1o.ogg'
 	department_close_powered = 'sound/machines/door/eng1c.ogg'
+	security_level = 1.5	//VOREStation Addition
 
 /obj/machinery/door/airlock/glass_engineeringatmos
 	name = "Atmospherics Airlock"
@@ -352,6 +363,7 @@
 	close_sound_powered = 'sound/machines/door/hall1c.ogg' // VOREStation Edit: Default door sounds for fancy, department-off.
 	department_open_powered = 'sound/machines/door/eng1o.ogg'
 	department_close_powered = 'sound/machines/door/eng1c.ogg'
+	security_level = 1.5	//VOREStation Addition
 
 /obj/machinery/door/airlock/glass_security
 	name = "Security Airlock"
@@ -367,6 +379,7 @@
 	close_sound_powered = 'sound/machines/door/hall1c.ogg' // VOREStation Edit: Default door sounds for fancy, department-off.
 	department_open_powered = 'sound/machines/door/sec1o.ogg'
 	department_close_powered = 'sound/machines/door/sec1c.ogg'
+	security_level = 2	//VOREStation Addition
 
 /obj/machinery/door/airlock/glass_medical
 	name = "Medical Airlock"
@@ -382,6 +395,7 @@
 	close_sound_powered = 'sound/machines/door/hall1c.ogg' // VOREStation Edit: Default door sounds for fancy, department-off.
 	department_open_powered = 'sound/machines/door/med1o.ogg'
 	department_close_powered = 'sound/machines/door/med1c.ogg'
+	security_level = 1.5	//VOREStation Addition
 
 /obj/machinery/door/airlock/mining
 	name = "Mining Airlock"
@@ -402,6 +416,7 @@
 	close_sound_powered = 'sound/machines/door/hall1c.ogg' // VOREStation Edit: Default door sounds for fancy, department-off.
 	department_open_powered = 'sound/machines/door/eng1o.ogg'
 	department_close_powered = 'sound/machines/door/eng1c.ogg'
+	security_level = 1.5	//VOREStation Addition
 
 /obj/machinery/door/airlock/research
 	name = "Research Airlock"
@@ -411,6 +426,7 @@
 	close_sound_powered = 'sound/machines/door/hall1c.ogg' // VOREStation Edit: Default door sounds for fancy, department-off.
 	department_open_powered = 'sound/machines/door/sci1o.ogg'
 	department_close_powered = 'sound/machines/door/sci1c.ogg'
+	security_level = 2	//VOREStation Addition
 
 /obj/machinery/door/airlock/glass_research
 	name = "Research Airlock"
@@ -426,6 +442,7 @@
 	close_sound_powered = 'sound/machines/door/hall1c.ogg' // VOREStation Edit: Default door sounds for fancy, department-off.
 	department_open_powered = 'sound/machines/door/sci1o.ogg'
 	department_close_powered = 'sound/machines/door/sci1c.ogg'
+	security_level = 2	//VOREStation Addition
 
 /obj/machinery/door/airlock/glass_mining
 	name = "Mining Airlock"
@@ -456,6 +473,7 @@
 	close_sound_powered = 'sound/machines/door/hall1c.ogg' // VOREStation Edit: Default door sounds for fancy, department-off.
 	department_open_powered = 'sound/machines/door/eng1o.ogg'
 	department_close_powered = 'sound/machines/door/eng1c.ogg'
+	security_level = 1.5	//VOREStation Addition
 
 /obj/machinery/door/airlock/gold
 	name = "Gold Airlock"
@@ -540,6 +558,7 @@
 	close_sound_powered = 'sound/machines/door/hall1c.ogg' // VOREStation Edit: Default door sounds for fancy, department-off.
 	department_open_powered = 'sound/machines/door/sci1o.ogg'
 	department_close_powered = 'sound/machines/door/sci1c.ogg'
+	security_level = 1.5	//VOREStation Addition
 
 /obj/machinery/door/airlock/glass_science
 	name = "Glass Airlocks"
@@ -552,6 +571,7 @@
 	close_sound_powered = 'sound/machines/door/hall1c.ogg' // VOREStation Edit: Default door sounds for fancy, department-off.
 	department_open_powered = 'sound/machines/door/sci1o.ogg'
 	department_close_powered = 'sound/machines/door/sci1c.ogg'
+	security_level = 1.5	//VOREStation Addition
 
 /obj/machinery/door/airlock/highsecurity
 	name = "Secure Airlock"
@@ -562,6 +582,7 @@
 	req_one_access = list(access_heads_vault)
 	open_sound_powered = 'sound/machines/door/secure1o.ogg'
 	close_sound_powered = 'sound/machines/door/secure1c.ogg'
+	security_level = 4	//VOREStation Addition
 
 /obj/machinery/door/airlock/voidcraft
 	name = "voidcraft hatch"
@@ -609,6 +630,7 @@
 	hackProof = TRUE
 	assembly_type = /obj/structure/door_assembly/door_assembly_alien
 	req_one_access = list(access_alien)
+	security_level = 100	//VOREStation Addition
 
 /obj/machinery/door/airlock/alien/locked
 	icon_state = "door_locked"


### PR DESCRIPTION
Builds on #14137 slightly by adding a `security_level` value to airlocks and a `max_level` value to hacktools. The former acts as a multiplier to hacking time, and the latter serves as a hard cap on what can be hacked; if the `security_level` is too high then the hacktool won't work on the door at all.

Default `security_level` is 1, increasing to 1.5 for med/eng/atmos, 2 for sec/sci, 3 for command, 5 for the vault, and 100 for alien/centcomm doors, and default `max_level` is 4. Hacktime is 10-30 seconds, so hacking into security takes 20-60 seconds, and hacking into command takes 30-90 seconds.

This should allow event runners to add locked doors to their maps without having to worry about someone with a hacktool breaking things too badly, and prevents hacktools from letting people get into places they still really shouldn't be able to get into.