### PR TITLE
Fixes MMIs to restore vision

### DIFF
--- a/code/modules/mob/living/carbon/brain/MMI.dm
+++ b/code/modules/mob/living/carbon/brain/MMI.dm
@@ -66,6 +66,7 @@
 		brainmob.loc = src
 		brainmob.container = src
 		brainmob.set_stat(CONSCIOUS)
+		brainmob.blinded = 0 //VOREedit Fixes MMIs vision
 		dead_mob_list -= brainmob//Update dem lists
 		living_mob_list += brainmob
 


### PR DESCRIPTION
The blindness you get from MMIs has been fixed, looks like it failed to remove your blindness proc.

Being removed from MMI re-blinds you again like the meat brain you are.

Fixes #14116 