### PR TITLE
Adds "History" section to Traveller's Guide

### DIFF
--- a/code/modules/lore_codex/lore_data_vr/history.dm
+++ b/code/modules/lore_codex/lore_data_vr/history.dm
@@ -1,0 +1,94 @@
+/datum/lore/codex/category/history
+	name = "Human History"
+	data = "The author of this guide wishes to offer their gratitude to NanoTrasen historian, Emir Bodoroczki for his assistance in condensing humanity’s history!"
+	children = list(
+		/datum/lore/codex/page/commonwealthbirth,
+		/datum/lore/codex/page/eagerhumanity,
+		/datum/lore/codex/page/hegemonywar,
+		/datum/lore/codex/page/secondawakening
+		)
+
+/datum/lore/codex/page/commonwealthbirth/add_content()
+	name = "The Birth of the Commonwealth"
+	keywords += list("Sol History","Birth of Commonwealth")
+	data = "In the mid 21st century, the Alden-Sarasprova particle was discovered by the precursor states of the Sol-Proycon Commonwealth. \
+	The European Union and the Moscow-Delhi-Islamabad pact initiated a joint space program to lay the first bricks of our great successes as a nation.\
+	<br><br>\
+	Unfortunately, bluespace travel was beyond our reach - phoron had still been a mystery, its fruits denied to us.\
+	But we were industrious, and began to colonise the gem of Humanity, Sol.\
+	<br><br>\
+	However, even without our stutter drives - we spread. With the aid of genetic engineering, we conquered space.\
+	Despite wars, despite traitors upon Mars who fled to their holdouts in the Ares Confederacy once the speed of light\
+	no longer tethered us - we thrived. By providence, our efforts were rewarded: phoron.\
+	Out in the Oort cloud, beyond our reach if not for our forefather’s ambition despite their scarce resources and primitive technology\
+	- phoron awaited us."
+
+/datum/lore/codex/page/eagerhumanity/add_content()
+	name = "An Eager Humanity"
+	keywords += list("Golden Age")
+	data = "Come the twenty second century, we spread past our blue jewel. Once a mathematical curiosity penned by Lara Alden, \
+	 then a confirmed fact by Dmitri Saraspova, and finally - an attainable commodity - we overcame the universal speed limit. \
+	  Phoron, laden with bluespace catalysts, had made our dreams reality.\
+	  <br><br>\
+	  Cygnus, Procyon, Proxima Centauri and many, many more worlds our ancestors had once dreamed of, \
+	  and that which had now become little more than a fact of life - had human boots kick up their dust.\
+	  We have made first contact - the Skrell. An enigmatic species - but friendly.\
+	  Unfortunately, with their technology came discord - their alien ways of life \
+	  infecting our impressionable youth out on the frontiers, far from the wisdom of the core.\
+	  <br><br> \
+	  As wars peppered our history, as have they became a fact of life once more\
+	  - rebellious, traitorous movements. World rejecting, foolishly, the yet-infant Commonwealth’s protection.\
+	  As expected - most failed to maintain their “self-realisation” - and made amends for their prodigal ways.\
+	  <br><br>\
+	  All, but those of the Elysian Colonies. Too far from the core, and the core itself was too tumultuous \
+	  - they broke away. One needs but look at worlds like Infernum \
+	  or the mutt-world of New Eden to realise this was not a victory. \
+	  Earth soon united under one banner, an inspiration to all of humanity.\
+	  A scarcity of resources necessitates unity. And that unity will bring luxury, rebirth \
+	  - one needs only wonder at the natural beauty of our home, the horrors of climate crises \
+	  but a distant memory. One needs only look at Mars, and behold its miracle despite Aresian sabotage.\
+	  <br><br>\
+	  The Commonwealth was now born, proper and true. \
+	  It was a prosperous age - with eager trade with our vulpkanin, skrell and tajaran friends."
+
+/datum/lore/codex/page/hegemonywar/add_content()
+	name = "The Hegemony War"
+	keywords += list("Hegemony War")
+	data = "Unfortunately, not all aliens were eager to trade. Especially not the treacherous Unathi.\
+	 Violating all that is just and fair, they conspired to weaken us in what are now the Salthan Fyrds\
+	 by sending forth the Rapala. It is commendable how cunning they were - exploiting our mythologies, beliefs and similarities.\
+	 <br><br>\
+	 We traded, we aided each other. We offered fair compensation for their guidance.\
+	 Then - the Unathi came, when we were most vulnerable and demanded the unthinkable\
+	 - to surrender our Liberty, our Independence, our Individuality and Equality and become\
+	 naught but another cog within their brutish protectorate.\
+	 <br><br>\
+	 Naturally, we rejected their demands.\
+	 <br><br>\
+	 Our war was costly - too costly, perhaps - but we persevered as Humanity is wont to do. \
+	 Forty years of suffering destroyed much of what we had achieved.\
+	 But in that forty years did our megacorporations step forth, offering aid where governments faltered.\
+	 Where public science’s glacial pace would have cost us lives, forever lost - NanoTrasen’s medical research cheated death!\
+	 Where Senate-governed mining operations would have wasted precious phoron to corruption \
+	 - NanoTrasen stepped up and delivered twice what our armies needed! \
+	 <br><br>\
+	 Peace soon came - albeit, we had to give up the Fyrds to avoid further loss of life and profit.\
+	 Something the short-sighted colonists refused to comply with.\
+	 Perhaps - exposure to the treacherous ways of the Hegemony sullied their sense \
+	 of honour as well - yet further proof of the dangers distance to \
+	 elderly guidance can bring to young worlds. \
+	 Although almost a century had passed since peace was signed, \
+	 the break-away Fyrders still seek to threaten trade."
+
+
+/datum/lore/codex/page/secondawakening/add_content()
+	name = "A Second Awakening"
+	keywords += list("Current Era")
+	data = "It is a shame that Unathi could not see the value of free market exchanges. \
+	Not long after the war, such activities revitalised our economy. With this trade came technology.\
+	And with this technology - came you, my dear reader.\
+	<br><br>\
+	Previously denied to us due to the astrogeographical hazards of the Core,\
+	the Coreward Periphery brought humanity many fresh worlds with untapped wells\
+	of purple gold. Whether alien, nomad - whether a Confederate who has seen the light \
+	- NanoTrasen welcomes you in the Virgo-Erigone system."

--- a/code/modules/lore_codex/lore_data_vr/main.dm
+++ b/code/modules/lore_codex/lore_data_vr/main.dm
@@ -4,10 +4,11 @@
 	<br><br>\
 	The many star systems inhabitied by humanity and friends can seem bewildering to the uninitiated. \
 	This guide seeks to provide valuable information to anyone new in the system. This edition is tailored for visitors to the Virgo-Erigone system, \
-	however it also contains useful general information about human space, such as locations you may hear about, the current (as of 2562) political climate, various aliens you \
+	however it also contains useful general information about human space, such as locations you may hear about, the current (as of 2322) political climate, various aliens you \
 	may meet in your travels, the big Trans-Stellars, and more."
 	children = list(
 		/datum/lore/codex/category/important_locations,
+		/datum/lore/codex/category/history,
 		/datum/lore/codex/category/species,
 		/datum/lore/codex/category/auto_org/tsc,
 		/datum/lore/codex/category/auto_org/other,
@@ -29,7 +30,7 @@
 	to an immigrant from another system, or even from outside human space, and anyone inbetween. The publisher wishes to note that any opinions expressed \
 	in this text does not reflect the opinions of the publisher, and are instead the author's.\
 	<br><br>\
-	Eshi Tache has also written other <i>The Traveler's Guide</i> books, including <i>Sol Edition</i>, <i>Tau Ceti Edition</i>, <i>Alpha Centauri Edition</i>, <i>Vir Edition</i>, and more, \
+	Eshi Tache has also written other <i>The Traveler's Guide</i> books, including <i>Sol Edition</i>, <i>Tau Ceti Edition</i>, <i>Alpha Centauri Edition</i>, <i>Virgo-Erigone Edition</i>, and more, \
 	which you can find in your local book store, library, or e-reader device. \
 	<br><br> \
 	((Please note - this is an IC book. Lore inside may exhibit biases differing from reality. Furthermore, it may be outdated in parts. Please consult the VOREStation Wiki \

--- a/code/modules/lore_codex/lore_data_vr/species.dm
+++ b/code/modules/lore_codex/lore_data_vr/species.dm
@@ -1,6 +1,6 @@
 /datum/lore/codex/category/species
 	name = "Species"
-	data = "There are many different types of lifeforms (both alive and artificial) in the galaxy, which you may find inside Vir."
+	data = "There are many different types of lifeforms (both alive and artificial) in the galaxy, which you may find inside the Virgo-Erigone system."
 	children = list(
 		/datum/lore/codex/page/human,
 		/datum/lore/codex/page/akula,
@@ -182,9 +182,9 @@
 	name = "Positronics"
 	keywords += list("Positronic", "Posi", "Posibrain", "Posibrains")
 	data = "A Positronic being, is an individual with a positronic brain, manufactured \
-	and fostered amongst organic life. Positronic brains enjoy the same legal status as a human in [quick_link("SolGov")] space, although discrimination is \
+	and fostered amongst organic life. Positronic brains enjoy the same legal status as a human in Sol-Procyon Commonwealth space, although discrimination is \
 	still prevalent, and are considered sapient on all accounts. They can be considered a \"synthetic species\". Half-developed and \
-	half-discovered in the 2280’s by a human black lab studying alien artifacts, the first positronic brain was an inch-wide cube \
+	half-discovered in the 2280's by a human black lab studying alien artifacts, the first positronic brain was an inch-wide cube \
 	of an palladium-iridium alloy, nano-etched with billions upon billions of conduits and connections. Upon activation, \
 	hard-booted with an emitter laser, the brain issued a single sentence before the neural pathways collapsed and \
 	it became an inert lump of platinum: \"What is my purpose?\"."
@@ -228,7 +228,7 @@
 
 
 /datum/lore/codex/page/cyborg/add_content()
-	name = "cyborgs"
+	name = "Cyborgs"
 	keywords += list("MMI", "Cyborg")
 	data = "A somewhat outdated form of synthetic life, powered by the brain of a sapient within a man-machine interface. \
 	Originally made in an effort to alleviate the drawbacks of drone intelligences - that is - their reprogrammability, \

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -2564,6 +2564,7 @@
 #include "code\modules\lore_codex\codex.dm"
 #include "code\modules\lore_codex\codex_tree.dm"
 #include "code\modules\lore_codex\pages.dm"
+#include "code\modules\lore_codex\lore_data_vr\history.dm"
 #include "code\modules\lore_codex\lore_data_vr\important_locations.dm"
 #include "code\modules\lore_codex\lore_data_vr\main.dm"
 #include "code\modules\lore_codex\lore_data_vr\orgs.dm"


### PR DESCRIPTION
Adds History per Loremaster-Hangout discussion (approved by Dragor). This is a highly condensed, biased perspective on History, written with heavy help from NanoTrasen by hands of a naive exploring resomi.

Also fixed mentions to Vir to Virgo-Erigone where it was obvious.

Fixed an instance of time travel.

Removed sneaky mention of SolGov that slipped my eyes.

Fixes some capitalisation issues.

Touches the .dme with a new #include 