### PR TITLE
Allows suit, mask and head slot items in loadout to override job items

### DIFF
--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -427,9 +427,10 @@ var/global/datum/controller/occupations/job_master
 				// Try desperately (and sorta poorly) to equip the item. Now with increased desperation!
 				if(G.slot && !(G.slot in custom_equip_slots))
 					var/metadata = H.client.prefs.gear[G.display_name]
-					if(G.slot == slot_wear_mask || G.slot == slot_wear_suit || G.slot == slot_head)
-						custom_equip_leftovers += thing
-					else if(H.equip_to_slot_or_del(G.spawn_item(H, metadata), G.slot))
+					//if(G.slot == slot_wear_mask || G.slot == slot_wear_suit || G.slot == slot_head)
+					//	custom_equip_leftovers += thing\
+					//else
+					if(H.equip_to_slot_or_del(G.spawn_item(H, metadata), G.slot))
 						to_chat(H, "<span class='notice'>Equipping you with \the [thing]!</span>")
 						if(G.slot != slot_tie)
 							custom_equip_slots.Add(G.slot)

--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -428,7 +428,7 @@ var/global/datum/controller/occupations/job_master
 				if(G.slot && !(G.slot in custom_equip_slots))
 					var/metadata = H.client.prefs.gear[G.display_name]
 					//if(G.slot == slot_wear_mask || G.slot == slot_wear_suit || G.slot == slot_head)
-					//	custom_equip_leftovers += thing\
+					//	custom_equip_leftovers += thing
 					//else
 					if(H.equip_to_slot_or_del(G.spawn_item(H, metadata), G.slot))
 						to_chat(H, "<span class='notice'>Equipping you with \the [thing]!</span>")


### PR DESCRIPTION
Title. Finally stops the garbage overflow of labcoats, jackets and hard hats.