### PR TITLE
stops ai controlled humanoids from spawning with sensors on

### DIFF
--- a/code/modules/mob/living/carbon/human/ai_controlled/ai_controlled_vr.dm
+++ b/code/modules/mob/living/carbon/human/ai_controlled/ai_controlled_vr.dm
@@ -1,0 +1,2 @@
+/mob/living/carbon/human/ai_controlled
+	sensorpref = 1

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -2849,6 +2849,7 @@
 #include "code\modules\mob\living\carbon\human\unarmed_attack.dm"
 #include "code\modules\mob\living\carbon\human\update_icons.dm"
 #include "code\modules\mob\living\carbon\human\ai_controlled\ai_controlled.dm"
+#include "code\modules\mob\living\carbon\human\ai_controlled\ai_controlled_vr.dm"
 #include "code\modules\mob\living\carbon\human\descriptors\_descriptors.dm"
 #include "code\modules\mob\living\carbon\human\descriptors\descriptors_generic.dm"
 #include "code\modules\mob\living\carbon\human\descriptors\descriptors_skrell.dm"


### PR DESCRIPTION
title

seeing **_.a!ei Uu.aspa.y (Experiment)_** and **_Beljbu Cpiglauuu (Experiment)_**, etc on sensors when signing up for medical is somewhat annoying

dunno if it actually needed to be in a new file...