### PR TITLE
Fixes some Oversights

### DIFF
--- a/code/datums/supplypacks/misc_vr.dm
+++ b/code/datums/supplypacks/misc_vr.dm
@@ -175,7 +175,7 @@
 	containertype = /obj/structure/closet/crate/secure/gear
 	containername = "exploration radio headsets crate"
 	access = list(
-		access_awayteam,
+		access_explorer,
 		access_eva,
 		access_pilot
 	)

--- a/code/datums/supplypacks/munitions_vr.dm
+++ b/code/datums/supplypacks/munitions_vr.dm
@@ -1,3 +1,4 @@
+/*
 /datum/supply_pack/munitions/expeditionguns
 	name = "Frontier phaser (station-locked) crate"
 	contains = list(
@@ -18,6 +19,7 @@
 	containertype = /obj/structure/closet/crate/secure
 	containername = "phaser handbow crate"
 	access = access_security
+*/
 
 /datum/supply_pack/munitions/ofd_charge_emp
 	name = "OFD Charge - EMP"

--- a/code/datums/supplypacks/supply.dm
+++ b/code/datums/supplypacks/supply.dm
@@ -179,7 +179,7 @@
 	cost=25
 	containertype = /obj/structure/closet/crate/secure/xion
 	containername = "Away Team equipment"
-	access = list(access_eva, access_awayteam)
+	access = list(access_eva, access_explorer)
 
 /datum/supply_pack/pilotgear
 	name= "Pilot gear"

--- a/code/datums/supplypacks/voidsuits_vr.dm
+++ b/code/datums/supplypacks/voidsuits_vr.dm
@@ -10,7 +10,7 @@
 	cost = 45
 	containertype = /obj/structure/closet/crate/secure
 	containername = "Away Team voidsuit crate"
-	access = list(access_eva, access_awayteam)
+	access = list(access_eva, access_explorer)
 
 /datum/supply_pack/voidsuits/explorer_medic
 	name = "Away Team Medic voidsuits"
@@ -105,7 +105,7 @@
 	cost = 150
 	containertype = /obj/structure/closet/crate/secure
 	name = "Commonwealth exploration voidsuit crate"
-	access = list(access_eva, access_awayteam)
+	access = list(access_eva, access_explorer)
 
 /datum/supply_pack/voidsuits/com_engineer
 	name = "Commonwealth engineering voidsuit"

--- a/code/game/jobs/access_datum_vr.dm
+++ b/code/game/jobs/access_datum_vr.dm
@@ -1,7 +1,7 @@
 //Moved from southern_cross_jobs.vr to fix a runtime
-var/const/access_awayteam = 43
-/datum/access/awayteam
-	id = access_awayteam
+var/const/access_explorer = 43
+/datum/access/explorer
+	id = access_explorer
 	desc = "Away Team"
 	region = ACCESS_REGION_GENERAL
 /*

--- a/code/game/machinery/suit_storage_unit_vr.dm
+++ b/code/game/machinery/suit_storage_unit_vr.dm
@@ -2,7 +2,7 @@
 
 /obj/machinery/suit_cycler/exploration
 	req_access = null
-	req_one_access = list(access_awayteam,access_medical_equip)
+	req_one_access = list(access_explorer,access_medical_equip)
 
 /obj/machinery/suit_cycler/pilot
 	req_access = list(access_pilot)

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -14,7 +14,7 @@ var/global/list/default_internal_channels = list(
 	num2text(SCI_FREQ) = list(access_tox, access_robotics, access_xenobiology),
 	num2text(SUP_FREQ) = list(access_cargo, access_mining_station),
 	num2text(SRV_FREQ) = list(access_janitor, access_library, access_hydroponics, access_bar, access_kitchen),
-	num2text(EXP_FREQ) = list(access_awayteam)	//VOREStation Edit
+	num2text(EXP_FREQ) = list(access_explorer)	//VOREStation Edit
 )
 
 var/global/list/default_medbay_channels = list(

--- a/code/game/objects/structures/crates_lockers/closets/misc_vr.dm
+++ b/code/game/objects/structures/crates_lockers/closets/misc_vr.dm
@@ -52,7 +52,7 @@
  */
 /obj/structure/closet/secure_closet/explorer
 	name = "away team locker"
-	req_access = list(access_awayteam)
+	req_access = list(access_explorer)
 	closet_appearance = /decl/closet_appearance/secure_closet/expedition/explorer
 
 	starts_with = list(
@@ -93,7 +93,7 @@
  */
 /obj/structure/closet/secure_closet/pathfinder
 	name = "pathfinder locker"
-	req_access = list(access_heads)
+	req_access = list(access_explorer)
 	closet_appearance = /decl/closet_appearance/secure_closet/expedition/pathfinder
 
 	starts_with = list(

--- a/maps/groundbase/gb-z3.dmm
+++ b/maps/groundbase/gb-z3.dmm
@@ -1567,7 +1567,7 @@
 	pixel_x = -32
 	},
 /obj/item/weapon/storage/box/nifsofts_pilot,
-/obj/item/device/multitool/groundbase_buffered,
+/obj/item/device/multitool/station_buffered,
 /obj/structure/table/steel,
 /turf/simulated/floor/tiled,
 /area/groundbase/civilian/pilot)

--- a/maps/groundbase/groundbase_telecomms.dm
+++ b/maps/groundbase/groundbase_telecomms.dm
@@ -74,14 +74,14 @@
 		num2text(SCI_FREQ) = list(access_tox,access_robotics,access_xenobiology),
 		num2text(SUP_FREQ) = list(access_cargo),
 		num2text(SRV_FREQ) = list(access_janitor, access_hydroponics),
-		num2text(EXP_FREQ) = list(access_awayteam)
+		num2text(EXP_FREQ) = list(access_explorer)
 	)
 
-/obj/item/device/multitool/groundbase_buffered
+/obj/item/device/multitool/station_buffered
 	name = "pre-linked multitool (Rascal's Pass hub)"
 	desc = "This multitool has already been linked to the groundbase telecomms hub and can be used to configure one (1) relay."
 
-/obj/item/device/multitool/groundbase_buffered/Initialize()
+/obj/item/device/multitool/station_buffered/Initialize()
 	. = ..()
 	buffer = locate(/obj/machinery/telecomms/hub/preset/groundbase)
 

--- a/maps/offmap_vr/talon/talon_v2.dmm
+++ b/maps/offmap_vr/talon/talon_v2.dmm
@@ -638,7 +638,7 @@
 /area/talon_v2/engineering/atmospherics)
 "bj" = (
 /obj/structure/table/rack/shelf/steel,
-/obj/item/weapon/gun/energy/taser,
+/obj/item/weapon/gun/energy/gun,
 /turf/simulated/floor/tiled/techfloor,
 /area/talon_v2/armory)
 "bn" = (

--- a/maps/offmap_vr/talon/talon_v2.dmm
+++ b/maps/offmap_vr/talon/talon_v2.dmm
@@ -2,6 +2,14 @@
 "aa" = (
 /turf/space,
 /area/space)
+"ab" = (
+/obj/structure/dogbed,
+/mob/living/simple_mob/animal/passive/dog/corgi/puppy{
+	desc = "That's Hendrickson, warden of the Talon's brig. No schemes can escape the watchful gleam of this corgi's deep, dark eyes.";
+	name = "Hendrickson"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/brig)
 "ac" = (
 /obj/machinery/computer/ship/helm{
 	req_one_access = list(301)
@@ -59,6 +67,11 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/talon_v2/medical)
+"ai" = (
+/obj/structure/table/rack/steel,
+/obj/item/clothing/under/syndicate/combat,
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/armory)
 "aj" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/cable/green{
@@ -372,6 +385,14 @@
 /obj/random/maintenance/engineering,
 /turf/simulated/floor/plating,
 /area/talon_v2/engineering/star_store)
+"aM" = (
+/obj/structure/table/rack/steel,
+/obj/item/clothing/shoes/magboots,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/armory)
 "aN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -476,6 +497,24 @@
 /obj/effect/floor_decal/industrial/outline/red,
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/talonboat)
+"aX" = (
+/obj/structure/table/rack/shelf/steel,
+/obj/item/weapon/cell/device/weapon{
+	pixel_x = -5;
+	pixel_y = 2
+	},
+/obj/item/weapon/cell/device/weapon,
+/obj/item/clothing/accessory/holster/waist,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/armory)
+"aY" = (
+/obj/structure/table/rack/shelf/steel,
+/obj/item/weapon/gun/energy/netgun,
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/armory)
 "aZ" = (
 /obj/machinery/shipsensors{
 	dir = 1
@@ -495,6 +534,18 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/talon_v2/maintenance/wing_port)
+"bb" = (
+/obj/machinery/alarm/talon{
+	dir = 1;
+	pixel_y = -25
+	},
+/obj/structure/table/rack/steel,
+/obj/item/device/spaceflare,
+/obj/machinery/camera/network/talon{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/armory)
 "bc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -522,6 +573,20 @@
 	},
 /turf/simulated/wall/shull,
 /area/talon_v2/ofd_ops)
+"be" = (
+/obj/structure/table/rack/shelf/steel,
+/obj/item/weapon/cell/device/weapon{
+	pixel_x = -5;
+	pixel_y = 2
+	},
+/obj/item/weapon/cell/device/weapon,
+/obj/item/clothing/accessory/holster/waist,
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_y = -26
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/armory)
 "bf" = (
 /obj/structure/railing/grey,
 /obj/machinery/light{
@@ -571,6 +636,11 @@
 /obj/structure/closet/walllocker_double/hydrant/south,
 /turf/simulated/floor/plating,
 /area/talon_v2/engineering/atmospherics)
+"bj" = (
+/obj/structure/table/rack/shelf/steel,
+/obj/item/weapon/gun/energy/taser,
+/turf/simulated/floor/tiled/techfloor,
+/area/talon_v2/armory)
 "bn" = (
 /obj/structure/hull_corner{
 	dir = 4
@@ -5833,21 +5903,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/talon_v2/engineering/atmospherics)
-"sv" = (
-/obj/structure/table/rack/shelf/steel,
-/obj/item/weapon/gun/energy/netgun,
-/obj/item/weapon/cell/device/weapon{
-	pixel_x = -5;
-	pixel_y = 2
-	},
-/obj/item/weapon/cell/device/weapon{
-	pixel_x = -5;
-	pixel_y = 2
-	},
-/obj/item/weapon/cell/device/weapon,
-/obj/item/clothing/accessory/holster/waist,
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/armory)
 "sw" = (
 /obj/machinery/light_switch{
 	dir = 8;
@@ -7649,16 +7704,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/talon_v2/engineering)
-"yq" = (
-/obj/structure/table/rack/steel,
-/obj/item/clothing/shoes/magboots,
-/obj/item/clothing/suit/space/syndicate/black,
-/obj/item/clothing/head/helmet/space/syndicate/black,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/armory)
 "yr" = (
 /obj/effect/overmap/visitable/ship/talon,
 /turf/space,
@@ -8077,11 +8122,6 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled/techmaint,
 /area/talon_v2/central_hallway/port)
-"zL" = (
-/obj/structure/table/rack/shelf/steel,
-/obj/item/weapon/gun/energy/locked/frontier/holdout/unlocked,
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/armory)
 "zM" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/portable_atmospherics/canister/empty,
@@ -9191,21 +9231,6 @@
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow,
 /turf/simulated/floor/plating,
 /area/talon_v2/engineering/starboard)
-"Ef" = (
-/obj/structure/table/rack/shelf/steel,
-/obj/item/weapon/gun/energy/gun/burst,
-/obj/item/weapon/cell/device/weapon{
-	pixel_x = -5;
-	pixel_y = 2
-	},
-/obj/item/weapon/cell/device/weapon,
-/obj/item/clothing/accessory/holster/waist,
-/obj/machinery/light_switch{
-	dir = 1;
-	pixel_y = -26
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/armory)
 "Ei" = (
 /obj/machinery/door/airlock/mining{
 	id_tag = "talon_minerdoor";
@@ -9488,15 +9513,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/talon_v2/bridge)
-"EV" = (
-/obj/structure/table/rack/steel,
-/obj/item/clothing/shoes/leg_guard/combat,
-/obj/item/clothing/gloves/arm_guard/combat,
-/obj/item/clothing/under/syndicate/combat,
-/obj/item/clothing/suit/armor/combat,
-/obj/item/clothing/head/helmet/combat,
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/armory)
 "EX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -10560,22 +10576,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/talon_v2/central_hallway/star)
-"HV" = (
-/obj/machinery/alarm/talon{
-	dir = 1;
-	pixel_y = -25
-	},
-/obj/structure/table/rack/steel,
-/obj/item/weapon/grenade/spawnergrenade/manhacks/mercenary{
-	pixel_x = -5;
-	pixel_y = 4
-	},
-/obj/item/device/spaceflare,
-/obj/machinery/camera/network/talon{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/armory)
 "HW" = (
 /obj/machinery/door/firedoor/glass/talon,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -12705,20 +12705,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/talon_v2/refining)
-"Oi" = (
-/obj/structure/table/rack/shelf/steel,
-/obj/item/weapon/gun/energy/netgun,
-/obj/item/weapon/cell/device/weapon{
-	pixel_x = -5;
-	pixel_y = 2
-	},
-/obj/item/weapon/cell/device/weapon,
-/obj/item/clothing/accessory/holster/waist,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/armory)
 "Oj" = (
 /turf/simulated/wall/shull,
 /area/talon_v2/armory)
@@ -13926,11 +13912,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/talon_v2/crew_quarters/meditation)
-"Sa" = (
-/obj/structure/table/rack/shelf/steel,
-/obj/item/weapon/gun/energy/gun,
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/armory)
 "Sb" = (
 /obj/structure/bed/chair/wood,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -14999,12 +14980,6 @@
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/space)
-"Vv" = (
-/obj/structure/table/rack/shelf/steel,
-/obj/item/clothing/accessory/holster/machete,
-/obj/item/weapon/material/knife/machete,
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/armory)
 "Vw" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -15983,14 +15958,6 @@
 "Yu" = (
 /turf/simulated/wall/rshull,
 /area/talon_v2/maintenance/wing_port)
-"Yv" = (
-/mob/living/simple_mob/animal/passive/dog/corgi/puppy{
-	desc = "That's Hendrickson, warden of the Talon's brig. No schemes can escape the watchful gleam of this corgi's deep, dark eyes.";
-	name = "Hendrickson"
-	},
-/obj/structure/dogbed,
-/turf/simulated/floor/tiled/techfloor,
-/area/talon_v2/brig)
 "Yw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -24284,7 +24251,7 @@ Si
 Oj
 PC
 OP
-Vv
+Qu
 OP
 Qu
 Zc
@@ -24692,7 +24659,7 @@ XQ
 Xm
 db
 qm
-Yv
+ab
 rq
 tA
 uF
@@ -24708,11 +24675,11 @@ NW
 Rp
 Si
 Nh
-EV
+ai
 OP
-yq
+aM
 OP
-HV
+bb
 Zc
 ZB
 Jv
@@ -24992,11 +24959,11 @@ NW
 Rp
 Si
 Nh
-sv
+Qu
 OP
-Oi
+aX
 OP
-Ef
+be
 Zc
 BI
 Ds
@@ -25134,11 +25101,11 @@ Dd
 Ew
 eS
 Oj
-zL
+Qu
 SN
-zL
+aY
 XW
-Sa
+bj
 Zc
 WY
 Ds

--- a/maps/stellar_delight/stellar_delight1.dmm
+++ b/maps/stellar_delight/stellar_delight1.dmm
@@ -246,7 +246,7 @@
 "ay" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/table/standard,
-/obj/item/device/multitool/sd_buffered{
+/obj/item/device/multitool/station_buffered{
 	pixel_y = 2
 	},
 /turf/simulated/floor/tiled/milspec,

--- a/maps/stellar_delight/stellar_delight_telecomms.dm
+++ b/maps/stellar_delight/stellar_delight_telecomms.dm
@@ -79,14 +79,14 @@
 		num2text(SCI_FREQ) = list(access_tox,access_robotics,access_xenobiology),
 		num2text(SUP_FREQ) = list(access_cargo),
 		num2text(SRV_FREQ) = list(access_janitor, access_hydroponics),
-		num2text(EXP_FREQ) = list(access_awayteam)
+		num2text(EXP_FREQ) = list(access_explorer)
 	)
 
-/obj/item/device/multitool/sd_buffered
+/obj/item/device/multitool/station_buffered
 	name = "pre-linked multitool (sd hub)"
 	desc = "This multitool has already been linked to the SD telecomms hub and can be used to configure one (1) relay."
 
-/obj/item/device/multitool/sd_buffered/Initialize()
+/obj/item/device/multitool/station_buffered/Initialize()
 	. = ..()
 	buffer = locate(/obj/machinery/telecomms/hub/preset/sd)
 

--- a/maps/submaps/admin_use_vr/ert.dmm
+++ b/maps/submaps/admin_use_vr/ert.dmm
@@ -349,9 +349,15 @@
 /obj/item/weapon/tank/emergency/oxygen/double,
 /obj/item/weapon/tank/emergency/oxygen/double,
 /obj/item/weapon/tank/emergency/oxygen/double,
-/obj/item/weapon/storage/belt/utility/holding,
-/obj/item/weapon/storage/belt/utility/holding,
-/obj/item/weapon/storage/belt/utility/holding,
+/obj/item/weapon/storage/belt/explorer/pathfinder{
+	name = "ERT belt"
+	},
+/obj/item/weapon/storage/belt/explorer/pathfinder{
+	name = "ERT belt"
+	},
+/obj/item/weapon/storage/belt/explorer/pathfinder{
+	name = "ERT belt"
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/barracks)
 "aC" = (
@@ -467,9 +473,15 @@
 	},
 /obj/structure/table/rack/steel,
 /obj/effect/floor_decal/industrial/outline/grey,
-/obj/item/weapon/storage/belt/medical/holding,
-/obj/item/weapon/storage/belt/medical/holding,
-/obj/item/weapon/storage/belt/medical/holding,
+/obj/item/weapon/storage/belt/explorer/pathfinder{
+	name = "ERT belt"
+	},
+/obj/item/weapon/storage/belt/explorer/pathfinder{
+	name = "ERT belt"
+	},
+/obj/item/weapon/storage/belt/explorer/pathfinder{
+	name = "ERT belt"
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/barracks)
 "aI" = (
@@ -492,7 +504,7 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/ship/ert/med)
 "aJ" = (
-/obj/item/device/multitool/tether_buffered,
+/obj/item/device/multitool/station_buffered,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/atmos)
 "aK" = (
@@ -7227,7 +7239,7 @@
 /obj/structure/table/rack,
 /obj/item/weapon/storage/secure/briefcase/nsfw_pack_hybrid,
 /obj/item/weapon/storage/belt/explorer/pathfinder{
-	name = "ERT Commander's belt"
+	name = "ERT belt"
 	},
 /turf/simulated/floor/wood,
 /area/ship/ert/commander)

--- a/maps/tether/tether_telecomms.dm
+++ b/maps/tether/tether_telecomms.dm
@@ -79,13 +79,13 @@
 		num2text(SCI_FREQ) = list(access_tox,access_robotics,access_xenobiology),
 		num2text(SUP_FREQ) = list(access_cargo),
 		num2text(SRV_FREQ) = list(access_janitor, access_hydroponics),
-		num2text(EXP_FREQ) = list(access_awayteam)
+		num2text(EXP_FREQ) = list(access_explorer)
 	)
 
-/obj/item/device/multitool/tether_buffered
+/obj/item/device/multitool/station_buffered
 	name = "pre-linked multitool (tether hub)"
 	desc = "This multitool has already been linked to the Tether telecomms hub and can be used to configure one (1) relay."
 
-/obj/item/device/multitool/tether_buffered/Initialize()
+/obj/item/device/multitool/station_buffered/Initialize()
 	. = ..()
 	buffer = locate(/obj/machinery/telecomms/hub/preset/tether)


### PR DESCRIPTION
- Removes Phasers from cargo ordering
- Removes weapons and combat armor from Talon, they still retain a net gun and an egun for defensive purposes.
- Renames access_awayteam back to access_explorer for compatibility reasons
- Standardizes the itempath of the buffer device across all three maps.
- Swaps out Belts of Holding in ERT Ship, since they now cause bluespace interference