### PR TITLE
Makes improved health scanners able to pinpoint rads

### DIFF
--- a/code/game/objects/items/devices/scanners/health.dm
+++ b/code/game/objects/items/devices/scanners/health.dm
@@ -103,7 +103,7 @@
 		OX = fake_oxy > 50 ? 		"<span class='warning'>Severe oxygen deprivation detected</span>" 	: 	"Subject bloodstream oxygen level normal"
 	dat += "[OX] | [TX] | [BU] | [BR]<br>"
 	if(M.radiation)
-		if(advscan >= 2 && showadvscan == 1)
+		if(advscan && showadvscan == 1)
 			var/severity = ""
 			if(M.radiation >= 1500)
 				severity = "Lethal"
@@ -119,7 +119,7 @@
 		else
 			dat += "<span class='warning'>Acute radiation sickness detected.</span><br>"
 	if(M.accumulated_rads)
-		if(advscan >= 2 && showadvscan == 1)
+		if(advscan && showadvscan == 1)
 			var/severity = ""
 			if(M.accumulated_rads >= 1500)
 				severity = "Critical"
@@ -321,14 +321,14 @@
 		if(0)
 			to_chat(usr, "The scanner will now perform a basic analysis.")
 
-/obj/item/device/healthanalyzer/improved //reports bone fractures, IB, quantity of beneficial reagents in stomach; also regular health analyzer stuff
+/obj/item/device/healthanalyzer/improved //reports bone fractures, IB, radiation severity, quantity of beneficial reagents in stomach; also regular health analyzer stuff
 	name = "improved health analyzer"
 	desc = "A miracle of medical technology, this handheld scanner can produce an accurate and specific report of a patient's biosigns."
 	advscan = 1
 	origin_tech = list(TECH_MAGNET = 5, TECH_BIO = 6)
 	icon_state = "health1"
 
-/obj/item/device/healthanalyzer/advanced //reports all of the above, as well as radiation severity and minor brain damage
+/obj/item/device/healthanalyzer/advanced //reports all of the above and minor brain damage
 	name = "advanced health analyzer"
 	desc = "An even more advanced handheld health scanner, complete with a full biosign monitor and on-board radiation and neurological analysis suites."
 	advscan = 2


### PR DESCRIPTION
Because why not.
Currently science can make an improved health analyzer, the other are adminspawn/maintspawn/PoI spawn, and them having the ability to pinpoint rads really isn't worth it.

This gives science a reason to spend some resources on better health analyzers and medical a (slightly increased) reason to want improved health analyzers.