### PR TITLE
Makes advanced health analyzers creatable via R&D

### DIFF
--- a/code/modules/research/designs/medical.dm
+++ b/code/modules/research/designs/medical.dm
@@ -88,6 +88,15 @@
 	build_path = /obj/item/device/healthanalyzer/improved
 	sort_string = "KBAAB"
 
+/datum/design/item/medical/advanced_analyzer
+	name = "advanced health analyzer"
+	desc = "An even more advanced handheld health scanner, complete with a full biosign monitor and on-board radiation and neurological analysis suites."
+	id = "improved_analyzer"
+	req_tech = list(TECH_MAGNET = 7, TECH_BIO = 7, TECH_DATA = 5)
+	materials = list(MAT_STEEL = 2000, MAT_GLASS = 4000, MAT_SILVER = 3500, MAT_GOLD = 2500, MAT_DIAMOND = 1250)
+	build_path = /obj/item/device/healthanalyzer/advanced
+	sort_string = "KBAAC"
+
 /datum/design/item/medical/advanced_roller
 	name = "advanced roller bed"
 	desc = "A more advanced version of the regular roller bed, with inbuilt surgical stabilisers and an improved folding system."

--- a/code/modules/research/designs/medical.dm
+++ b/code/modules/research/designs/medical.dm
@@ -91,7 +91,7 @@
 /datum/design/item/medical/advanced_analyzer
 	name = "advanced health analyzer"
 	desc = "An even more advanced handheld health scanner, complete with a full biosign monitor and on-board radiation and neurological analysis suites."
-	id = "improved_analyzer"
+	id = "advanced_analyzer"
 	req_tech = list(TECH_MAGNET = 7, TECH_BIO = 7, TECH_DATA = 5)
 	materials = list(MAT_STEEL = 2000, MAT_GLASS = 4000, MAT_SILVER = 3500, MAT_GOLD = 2500, MAT_DIAMOND = 1250)
 	build_path = /obj/item/device/healthanalyzer/advanced


### PR DESCRIPTION
This allows for a health analyzer that indicates how many rads are actually still in someone to be created. (And also tells if someone has minor brain damage according to the comments.)

Not really anything too game changing for medical, but if they want to have a _slightly_ better scanner than the improved one R&D can make, they can get this.