### PR TITLE
Various minor fixes

### DIFF
--- a/code/game/objects/items/weapons/gift_wrappaper.dm
+++ b/code/game/objects/items/weapons/gift_wrappaper.dm
@@ -56,10 +56,7 @@
 	to_chat(user, "<span class='notice'>You cut open the present.</span>")
 
 	for(var/mob/M in src) //Should only be one but whatever.
-		M.loc = src.loc
-		if (M.client)
-			M.client.eye = M.client.mob
-			M.client.perspective = MOB_PERSPECTIVE
+		M.forceMove(src.loc)
 
 	qdel(src)
 
@@ -180,11 +177,7 @@
 			var/obj/effect/spresent/present = new /obj/effect/spresent (H.loc)
 			src.amount -= 2
 
-			if (H.client)
-				H.client.perspective = EYE_PERSPECTIVE
-				H.client.eye = present
-
-			H.loc = present
+			H.forceMove(present)
 
 			add_attack_logs(user,H,"Wrapped with [src]")
 		else

--- a/code/game/objects/items/weapons/tools/crowbar.dm
+++ b/code/game/objects/items/weapons/tools/crowbar.dm
@@ -99,6 +99,7 @@
 	playsound(src, 'sound/items/change_jaws.ogg', 50, 1)
 	user.drop_item(src)
 	counterpart.forceMove(get_turf(src))
+	counterpart.persist_storable = persist_storable
 	src.forceMove(counterpart)
 	user.put_in_active_hand(counterpart)
 	to_chat(user, "<span class='notice'>You attach the cutting jaws to [src].</span>")

--- a/code/game/objects/items/weapons/tools/screwdriver.dm
+++ b/code/game/objects/items/weapons/tools/screwdriver.dm
@@ -141,6 +141,7 @@
 	playsound(src,'sound/items/change_drill.ogg',50,1)
 	user.drop_item(src)
 	counterpart.forceMove(get_turf(src))
+	counterpart.persist_storable = persist_storable
 	src.forceMove(counterpart)
 	user.put_in_active_hand(counterpart)
 	to_chat(user, "<span class='notice'>You attach the bolt driver bit to [src].</span>")

--- a/code/game/objects/items/weapons/tools/wirecutters.dm
+++ b/code/game/objects/items/weapons/tools/wirecutters.dm
@@ -126,6 +126,7 @@
 	playsound(src, 'sound/items/change_jaws.ogg', 50, 1)
 	user.drop_item(src)
 	counterpart.forceMove(get_turf(src))
+	counterpart.persist_storable = persist_storable
 	src.forceMove(counterpart)
 	user.put_in_active_hand(counterpart)
 	to_chat(user, "<span class='notice'>You attach the pry jaws to [src].</span>")

--- a/code/game/objects/items/weapons/tools/wrench.dm
+++ b/code/game/objects/items/weapons/tools/wrench.dm
@@ -104,6 +104,7 @@
 	playsound(src,'sound/items/change_drill.ogg',50,1)
 	user.drop_item(src)
 	counterpart.forceMove(get_turf(src))
+	counterpart.persist_storable = persist_storable
 	src.forceMove(counterpart)
 	user.put_in_active_hand(counterpart)
 	to_chat(user, "<span class='notice'>You attach the screw driver bit to [src].</span>")

--- a/code/modules/assembly/signaler.dm
+++ b/code/modules/assembly/signaler.dm
@@ -15,7 +15,6 @@
 	var/airlock_wire = null
 	var/datum/wires/connected = null
 	var/datum/radio_frequency/radio_connection
-	var/deadman = FALSE
 
 /obj/item/device/assembly/signaler/Initialize()
 	. = ..()
@@ -130,27 +129,6 @@
 	radio_controller.remove_object(src, frequency)
 	frequency = new_frequency
 	radio_connection = radio_controller.add_object(src, frequency, RADIO_CHAT)
-
-/obj/item/device/assembly/signaler/process()
-	if(!deadman)
-		STOP_PROCESSING(SSobj, src)
-	var/mob/M = src.loc
-	if(!M || !ismob(M))
-		if(prob(5))
-			signal()
-		deadman = FALSE
-		STOP_PROCESSING(SSobj, src)
-	else if(prob(5))
-		M.visible_message("[M]'s finger twitches a bit over [src]'s signal button!")
-
-/obj/item/device/assembly/signaler/verb/deadman_it()
-	set src in usr
-	set name = "Threaten to push the button!"
-	set desc = "BOOOOM!"
-	deadman = TRUE
-	START_PROCESSING(SSobj, src)
-	log_and_message_admins("is threatening to trigger a signaler deadman's switch")
-	usr.visible_message("<font color='red'>[usr] moves their finger over [src]'s signal button...</font>")
 
 /obj/item/device/assembly/signaler/Destroy()
 	if(radio_controller)

--- a/code/modules/economy/coins.dm
+++ b/code/modules/economy/coins.dm
@@ -86,7 +86,7 @@
 			..()
 			return
 
-		var/obj/item/stack/cable_coil/CC = new (user.loc)
+		var/obj/item/stack/cable_coil/CC = new (user.loc, 1)
 		CC.update_icon()
 		cut_overlays()
 		string_attached = null

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -101,10 +101,6 @@
 
 /mob/living/bullet_act(var/obj/item/projectile/P, var/def_zone)
 
-	//Being hit while using a deadman switch
-	if(istype(get_active_hand(),/obj/item/device/assembly/signaler))
-		var/obj/item/device/assembly/signaler/signaler = get_active_hand()
-
 	if(ai_holder && P.firer)
 		ai_holder.react_to_attack(P.firer)
 

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -104,10 +104,6 @@
 	//Being hit while using a deadman switch
 	if(istype(get_active_hand(),/obj/item/device/assembly/signaler))
 		var/obj/item/device/assembly/signaler/signaler = get_active_hand()
-		if(signaler.deadman && prob(80))
-			log_and_message_admins("has triggered a signaler deadman's switch")
-			src.visible_message("<font color='red'>[src] triggers their deadman's switch!</font>")
-			signaler.signal()
 
 	if(ai_holder && P.firer)
 		ai_holder.react_to_attack(P.firer)

--- a/code/modules/power/cells/device_cells_vr.dm
+++ b/code/modules/power/cells/device_cells_vr.dm
@@ -12,6 +12,7 @@
 	user.put_in_active_hand(newcell)
 	var/percentage = charge/maxcharge
 	newcell.charge = newcell.maxcharge * percentage
+	newcell.persist_storable = persist_storable
 	qdel(src)
 
 //The machine cell
@@ -36,8 +37,9 @@
 	user.put_in_active_hand(newcell)
 	var/percentage = charge/maxcharge
 	newcell.charge = newcell.maxcharge * percentage
+	newcell.persist_storable = persist_storable
 	qdel(src)
-	
+
 // Bloo friendlier hybrid tech
 /obj/item/weapon/cell/device/weapon/recharge/alien/hybrid
 	icon = 'icons/obj/power_vr.dmi'

--- a/maps/expedition_vr/aerostat/_aerostat_science_outpost.dm
+++ b/maps/expedition_vr/aerostat/_aerostat_science_outpost.dm
@@ -48,6 +48,7 @@
 /obj/machinery/computer/shuttle_control/aerostat_shuttle
 	name = "aerostat ferry control console"
 	shuttle_tag = "Aerostat Ferry"
+	ai_control = TRUE
 
 /obj/tether_away_spawner/aerostat_inside
 	name = "Aerostat Indoors Spawner"


### PR DESCRIPTION
Updates how moving in/out of present wrapping is handled. This was last touched in like 2010, wasn't it? Fixes #14249 

Makes void cells and power tools properly inheirit persist_storable. Would need to be manually applied if any other items with such mechanics exist, but Fixes #14105 

Makes cutting wire off a coin only spawn 1 piece. Fixes #14104 

Removes Threaten To Push Button from signalers. Its a very unnecesary feature to even have, considering it has 100% hidden and unexplained mechanic of turning it into deadman switch that makes signaler unsafe. Generally not really wanted as a feature, and if just text is desired, people can use a 'me' for it. Technically fixes #13983

Allows robots to use mining ferry on SD version of aerostat. Fixes #13958