### PR TITLE
Fixes autolathe, material and smartfridge issues

### DIFF
--- a/code/datums/components/material_container.dm
+++ b/code/datums/components/material_container.dm
@@ -140,12 +140,7 @@
 		return
 
 	// Cache this since S may go away after use()
-	var/list/sheet_matter
-	if(istype(S, /obj/item/stack/material))
-		var/obj/item/stack/material/MS = S
-		sheet_matter = list(MS.material.name = 2000)
-	else
-		sheet_matter = S.matter
+	var/list/sheet_matter = S.matter
 
 	// Calculate total amount of material for one sheet
 	var/matter_per_sheet = 0

--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -104,7 +104,7 @@
 
 	if(shocked)
 		shock(user, 50)
-	
+
 	tgui_interact(user)
 
 /obj/machinery/autolathe/attackby(var/obj/item/O as obj, var/mob/user as mob)
@@ -135,7 +135,7 @@
 	if(istype(O,/obj/item/ammo_magazine/clip) || istype(O,/obj/item/ammo_magazine/s357) || istype(O,/obj/item/ammo_magazine/s38) || istype (O,/obj/item/ammo_magazine/s44)/* VOREstation Edit*/) // Prevents ammo recycling exploit with speedloaders.
 		to_chat(user, "\The [O] is too hazardous to recycle with the autolathe!")
 		return
-	
+
 	return ..()
 
 /obj/machinery/autolathe/attack_hand(mob/user as mob)
@@ -177,12 +177,12 @@
 						max_sheets = 0
 				//Build list of multipliers for sheets.
 				multiplier = tgui_input_number(usr, "How many do you want to print? (0-[max_sheets])", null, null, max_sheets, 0)
-				if(!multiplier || multiplier <= 0 || multiplier > max_sheets || tgui_status(usr, state) != STATUS_INTERACTIVE)
+				if(!multiplier || multiplier <= 0 || (multiplier != round(multiplier)) || multiplier > max_sheets || tgui_status(usr, state) != STATUS_INTERACTIVE)
 					return FALSE
 
 			//Check if we still have the materials.
 			var/coeff = (making.no_scale ? 1 : mat_efficiency) //stacks are unaffected by production coefficient
-			
+
 			for(var/datum/material/used_material as anything in making.resources)
 				var/amount_needed = making.resources[used_material] * coeff * multiplier
 				materials_used[used_material] = amount_needed
@@ -190,7 +190,7 @@
 			if(LAZYLEN(materials_used))
 				if(!materials.has_materials(materials_used))
 					return
-				
+
 				materials.use_materials(materials_used)
 
 			busy = making.name

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -240,7 +240,7 @@
 //Return 1 if an immediate subsequent call to use() would succeed.
 //Ensures that code dealing with stacks uses the same logic
 /obj/item/stack/proc/can_use(var/used)
-	if(used < 0 || used % 1)
+	if(used < 0 || (used != round(used)))
 		stack_trace("Tried to use a bad stack amount: [used]")
 		return 0
 	if(get_amount() < used)
@@ -265,7 +265,7 @@
 		return 1
 
 /obj/item/stack/proc/add(var/extra)
-	if(extra < 0 || extra % 1)
+	if(extra < 0 || (extra != round(extra)))
 		stack_trace("Tried to add a bad stack amount: [extra]")
 		return 0
 	if(!uses_charge)
@@ -283,7 +283,7 @@
 			S.add_charge(charge_costs[i] * extra)
 
 /obj/item/stack/proc/set_amount(var/new_amount, var/no_limits = FALSE)
-	if(new_amount < 0 || new_amount % 1)
+	if(new_amount < 0 || (new_amount != round(new_amount)))
 		stack_trace("Tried to set a bad stack amount: [new_amount]")
 		return 0
 
@@ -321,7 +321,7 @@
 	if (isnull(tamount))
 		tamount = src.get_amount()
 
-	if(tamount < 0 || tamount % 1)
+	if(tamount < 0 || (tamount != round(tamount)))
 		stack_trace("Tried to transfer a bad stack amount: [tamount]")
 		return 0
 
@@ -347,7 +347,7 @@
 	if(uses_charge)
 		return null
 
-	if(tamount < 0 || tamount % 1)
+	if(tamount < 0 || (tamount != round(tamount)))
 		stack_trace("Tried to split a bad stack amount: [tamount]")
 		return null
 
@@ -403,6 +403,9 @@
 /obj/item/stack/attack_hand(mob/user as mob)
 	if (user.get_inactive_hand() == src)
 		var/N = tgui_input_number(usr, "How many stacks of [src] would you like to split off?  There are currently [amount].", "Split stacks", 1, amount, 1)
+		if(N != round(N))
+			to_chat(user, "<span class='warning'>You cannot separate a non-whole number of stacks!</span>")
+			return
 		if(N)
 			var/obj/item/stack/F = src.split(N)
 			if (F)

--- a/code/modules/food/kitchen/smartfridge/smartfridge.dm
+++ b/code/modules/food/kitchen/smartfridge/smartfridge.dm
@@ -217,14 +217,14 @@
 				amount = params["amount"]
 			else
 				amount = tgui_input_number(usr, "How many items?", "How many items would you like to take out?", 1)
-			
+
 			if(QDELETED(src) || QDELETED(usr) || !usr.Adjacent(src))
 				return FALSE
-			
+
 			var/index = text2num(params["index"])
 			if(index < 1 || index > LAZYLEN(item_records))
 				return TRUE
-			
+
 			vend(item_records[index], amount)
 			return TRUE
 	return FALSE
@@ -257,7 +257,7 @@
 	if(stat & (NOPOWER|BROKEN))
 		return TRUE
 	if(usr.contents.Find(src) || (in_range(src, usr) && istype(loc, /turf)))
-		if(!allowed(usr) && !emagged && locked != -1 && action == "Release")
+		if((!allowed(usr) && scan_id) && !emagged && locked != -1 && action == "Release")
 			to_chat(usr, "<span class='warning'>Access denied.</span>")
 			return TRUE
 	return ..()

--- a/code/modules/materials/materials/glass.dm
+++ b/code/modules/materials/materials/glass.dm
@@ -132,13 +132,12 @@
 	display_name = "reinforced borosilicate glass"
 	stack_type = /obj/item/stack/material/glass/phoronrglass
 	stack_origin_tech = list(TECH_MATERIAL = 5)
-	composite_material = list() //todo
 	window_options = list("One Direction" = 1, "Full Window" = 4)
 	created_window = /obj/structure/window/phoronreinforced
 	created_fulltile_window = /obj/structure/window/phoronreinforced/full
 	hardness = 40
 	weight = 30
 	stack_origin_tech = list(TECH_MATERIAL = 2)
-	composite_material = list(MAT_STEEL = SHEET_MATERIAL_AMOUNT / 2, "borosilicate glass" = SHEET_MATERIAL_AMOUNT)
+	composite_material = list(MAT_STEEL = SHEET_MATERIAL_AMOUNT / 2, MAT_PGLASS = SHEET_MATERIAL_AMOUNT)
 	rod_product = null
 	flags = MATERIAL_UNMELTABLE

--- a/code/modules/materials/materials/glass_vr.dm
+++ b/code/modules/materials/materials/glass_vr.dm
@@ -13,7 +13,6 @@
 	created_fulltile_window = /obj/structure/window/titanium/full
 	wire_product = null
 	rod_product = /obj/item/stack/material/glass/titanium
-	composite_material = list(MAT_TITANIUM = SHEET_MATERIAL_AMOUNT, MAT_GLASS = SHEET_MATERIAL_AMOUNT)
 
 /datum/material/glass/plastaniumglass
 	name = MAT_PLASTITANIUMGLASS
@@ -30,4 +29,3 @@
 	created_fulltile_window = /obj/structure/window/plastitanium/full
 	wire_product = null
 	rod_product = /obj/item/stack/material/glass/plastitanium
-	composite_material = list(MAT_PLASTITANIUM = SHEET_MATERIAL_AMOUNT, MAT_GLASS = SHEET_MATERIAL_AMOUNT)

--- a/code/modules/materials/materials/metals/hull.dm
+++ b/code/modules/materials/materials/metals/hull.dm
@@ -7,6 +7,7 @@
 	icon_reinf = "reinf_mesh"
 	icon_colour = "#666677"
 	flags = MATERIAL_UNMELTABLE
+	composite_material = list(MAT_STEEL = SHEET_MATERIAL_AMOUNT)
 
 /datum/material/steel/hull/place_sheet(var/turf/target) //Deconstructed into normal steel sheets.
 	new /obj/item/stack/material/steel(target)
@@ -20,6 +21,7 @@
 	icon_colour = "#777788"
 	explosion_resistance = 40
 	flags = MATERIAL_UNMELTABLE
+	composite_material = list(MAT_PLASTEEL = SHEET_MATERIAL_AMOUNT)
 
 /datum/material/plasteel/hull/place_sheet(var/turf/target) //Deconstructed into normal plasteel sheets.
 	new /obj/item/stack/material/plasteel(target)
@@ -33,6 +35,7 @@
 	explosion_resistance = 90
 	reflectivity = 0.9
 	flags = MATERIAL_UNMELTABLE
+	composite_material = list(MAT_DURASTEEL = SHEET_MATERIAL_AMOUNT)
 
 /datum/material/durasteel/hull/place_sheet(var/turf/target) //Deconstructed into normal durasteel sheets.
 	new /obj/item/stack/material/durasteel(target)
@@ -43,6 +46,7 @@
 	icon_base = "hull"
 	icon_reinf = "reinf_mesh"
 	flags = MATERIAL_UNMELTABLE
+	composite_material = list(MAT_TITANIUM = SHEET_MATERIAL_AMOUNT)
 
 /datum/material/titanium/hull/place_sheet(var/turf/target) //Deconstructed into normal titanium sheets.
 	new /obj/item/stack/material/titanium(target)
@@ -53,6 +57,7 @@
 	icon_base = "hull"
 	icon_reinf = "reinf_mesh"
 	flags = MATERIAL_UNMELTABLE
+	composite_material = list(MAT_MORPHIUM = SHEET_MATERIAL_AMOUNT)
 
 /datum/material/morphium/hull/place_sheet(var/turf/target)
 	new /obj/item/stack/material/morphium(target)

--- a/code/modules/materials/materials/metals/hull_vr.dm
+++ b/code/modules/materials/materials/metals/hull_vr.dm
@@ -5,6 +5,7 @@
 	icon_reinf = "reinf_mesh"
 	icon_colour = "#585658"
 	explosion_resistance = 50
+	composite_material = list(MAT_PLASTITANIUM = SHEET_MATERIAL_AMOUNT)
 
 /datum/material/plastitanium/hull/place_sheet(var/turf/target) //Deconstructed into normal plasteel sheets.
 	new /obj/item/stack/material/plastitanium(target)
@@ -15,6 +16,7 @@
 	icon_base = "hull"
 	icon_reinf = "reinf_mesh"
 	explosion_resistance = 50
+	composite_material = list(MAT_GOLD = SHEET_MATERIAL_AMOUNT)
 
 /datum/material/gold/hull/place_sheet(var/turf/target) //Deconstructed into normal gold sheets.
 	new /obj/item/stack/material/gold(target)

--- a/code/modules/materials/materials/metals/metals.dm
+++ b/code/modules/materials/materials/metals/metals.dm
@@ -17,7 +17,6 @@
 	protectiveness = 60 // 75%
 	reflectivity = 0.7 // Not a perfect mirror, but close.
 	stack_origin_tech = list(TECH_MATERIAL = 8)
-	composite_material = list("plasteel" = SHEET_MATERIAL_AMOUNT, "diamond" = SHEET_MATERIAL_AMOUNT) //shrug
 	supply_conversion_value = 9
 
 /datum/material/titanium
@@ -28,7 +27,6 @@
 	door_icon_base = "metal"
 	icon_colour = "#D1E6E3"
 	icon_reinf = "reinf_metal"
-	composite_material = null
 
 /datum/material/iron
 	name = "iron"

--- a/code/modules/materials/materials/metals/plasteel.dm
+++ b/code/modules/materials/materials/metals/plasteel.dm
@@ -12,7 +12,6 @@
 	protectiveness = 20 // 50%
 	conductivity = 13 // For the purposes of balance.
 	stack_origin_tech = list(TECH_MATERIAL = 2)
-	composite_material = list(MAT_STEEL = SHEET_MATERIAL_AMOUNT, "platinum" = SHEET_MATERIAL_AMOUNT) //todo
 	supply_conversion_value = 6
 
 /datum/material/plasteel/generate_recipes()
@@ -38,3 +37,4 @@
 	stack_type = /obj/item/stack/material/plasteel/rebar
 	sheet_singular_name = "rod"
 	sheet_plural_name = "rods"
+	composite_material = list(MAT_PLASTEEL = SHEET_MATERIAL_AMOUNT)

--- a/code/modules/materials/materials/metals/plasteel_vr.dm
+++ b/code/modules/materials/materials/metals/plasteel_vr.dm
@@ -12,7 +12,6 @@
 	protectiveness = 30
 	conductivity = 7
 	stack_origin_tech = list(TECH_MATERIAL = 5)
-	composite_material = list(MAT_TITANIUM = SHEET_MATERIAL_AMOUNT, MAT_PLASTEEL = SHEET_MATERIAL_AMOUNT)
 	supply_conversion_value = 8
 
 /datum/material/plastitanium/generate_recipes()

--- a/maps/tether/tether-03-surface3.dmm
+++ b/maps/tether/tether-03-surface3.dmm
@@ -22721,14 +22721,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/tether/surfacebase/shuttle_pad)
-"aLb" = (
-/obj/effect/floor_decal/corner/grey/diagonal,
-/obj/machinery/smartfridge{
-	req_access = list(28)
-	},
-/obj/machinery/door/firedoor/glass,
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/kitchen)
 "aLc" = (
 /obj/effect/floor_decal/corner/grey/diagonal,
 /obj/effect/landmark/start{
@@ -61357,7 +61349,7 @@ bpC
 bge
 bgA
 bgA
-aLb
+aru
 bfX
 bgz
 bgz


### PR DESCRIPTION
For Smartfridge:
- Fixes #14258. Aparently the id scan was completely unused var on smartfridges. Well, I made it used on secure ones.
- Also removes the smartfridge between bar and kitchen on tether. It was a non-secure smartfridge with access restriction that did nothing, and it ALSO was 'generic' smartfridge meaning nothing could ever be put into it. And the fact that nobody ever reported on the fact that you literally cannot put anything ever into that smartfridge only highlights its uselessness with the fact that nobody even tried using it, so away it goes.

For material:
- Adjusts sanity checks for decimal stack splitting. It wasn't working right. Now it does. F ur dupes.

For autolathe:
- Fixes #12114. It was related to decimal stacks. F ur dupes. Next time there's infinite material exploit related to people inputting decimals instead of whole numbers, instead of fixing it I will make it so that lightning strikes you when you try doing it.
- Undoes #14203. Instead fixes same issue in better way by changing which materials are actually composite and in what ways they are composite. Now only 'composite' materials are rglass, rphoronglass, all hull materials and rebar plasteel. Rglasses are just base glass sheet + half a steel sheet; while hull materials and rebar are just their 'original' material sheet. This allows them all to still be easily obtainable via autolathe; while disabling autolathe from doubling as a smelter furnace for alloying.