### PR TITLE
un-nerfs fishing from previous change

### DIFF
--- a/code/modules/fishing/fishing_rod.dm
+++ b/code/modules/fishing/fishing_rod.dm
@@ -89,7 +89,7 @@
 		for(var/datum/reagent/re in Bait.reagents.reagent_list)
 			if(re.id == "nutriment" || re.id == "protein" || re.id == "glucose" || re.id == "fishbait")
 				foodvolume += re.volume
-
+		foodvolume = Bait.reagents.maximum_volume == 80 ? (min(foodvolume,50) * (Bait.reagents.maximum_volume / 50)) : Bait.reagents.maximum_volume // VOREStation edit: because of changes to max reagents in snacks, readjusts the foodvolume to have the same values as polaris again, but only when it has the same max volume as the changed amount in snacks (assuming the snacks reagent size stays the same...)
 		toolspeed = initial(toolspeed) * min(0.75, (0.5 / max(0.5, (foodvolume / Bait.reagents.maximum_volume))))
 
 	else

--- a/code/modules/fishing/fishing_rod.dm
+++ b/code/modules/fishing/fishing_rod.dm
@@ -89,8 +89,8 @@
 		for(var/datum/reagent/re in Bait.reagents.reagent_list)
 			if(re.id == "nutriment" || re.id == "protein" || re.id == "glucose" || re.id == "fishbait")
 				foodvolume += re.volume
-		foodvolume = Bait.reagents.maximum_volume == 80 ? (min(foodvolume,50) * (Bait.reagents.maximum_volume / 50)) : Bait.reagents.maximum_volume // VOREStation edit: because of changes to max reagents in snacks, readjusts the foodvolume to have the same values as polaris again, but only when it has the same max volume as the changed amount in snacks (assuming the snacks reagent size stays the same...)
-		toolspeed = initial(toolspeed) * min(0.75, (0.5 / max(0.5, (foodvolume / Bait.reagents.maximum_volume))))
+
+		toolspeed = initial(toolspeed) * 10*(0.01/(0.2*(foodvolume/Bait.reagents.maximum_volume + 0.5))) //VOREStation edit: gives fishing a universal formula because Polaris' doesn't work here. Min value of 1, max volume of 1/3, 0.5 at 1/2 filled with bait reagents.
 
 	else
 		toolspeed = initial(toolspeed)

--- a/code/modules/fishing/fishing_rod.dm
+++ b/code/modules/fishing/fishing_rod.dm
@@ -90,7 +90,7 @@
 			if(re.id == "nutriment" || re.id == "protein" || re.id == "glucose" || re.id == "fishbait")
 				foodvolume += re.volume
 
-		toolspeed = initial(toolspeed) * 10*(0.01/(0.2*(foodvolume/Bait.reagents.maximum_volume + 0.5))) //VOREStation edit: gives fishing a universal formula because Polaris' doesn't work here. Min value of 1, max volume of 1/3, 0.5 at 1/2 filled with bait reagents.
+		toolspeed = initial(toolspeed) * 10*(0.01/(0.2*(foodvolume/Bait.reagents.maximum_volume + 0.5))) //VOREStation edit: gives fishing a universal formula because Polaris' doesn't work here. Min value of 1, max value of 1/3, 0.5 at 1/2 filled with bait reagents.
 
 	else
 		toolspeed = initial(toolspeed)


### PR DESCRIPTION
PR #12142 changed the max volume of snacks, which affected fishing bait, to the point where even the deluxe bait only gives the minimum reduction, 0.75

this adjusts it to a completely different formula, based around what I think the general calculated bait values should be for the bait types.

![Screenshot 2023-01-03 112213](https://user-images.githubusercontent.com/49109742/210296880-0ee68913-72c0-46c8-beb8-b6c033084972.png)
