### PR TITLE
Replaces RP's carp, drone and jellyfish events with new Roaming Wildlife event

### DIFF
--- a/code/_helpers/global_lists_vr.dm
+++ b/code/_helpers/global_lists_vr.dm
@@ -827,6 +827,100 @@ var/global/list/xenobio_rainbow_extracts = list(
 										/obj/item/slime_extract/rainbow = 1)
 
 
+//// Wildlife lists
+//Listed by-type. Under each type are lists of lists that contain 'groupings' of wildlife. Sorted from 1 to 5 by threat level.
+
+var/global/list/event_wildlife_aquatic = list(
+										list(
+												list(/mob/living/simple_mob/animal/passive/fish/koi = 1,
+													 /mob/living/simple_mob/animal/passive/fish/pike = 2,
+													 /mob/living/simple_mob/animal/passive/fish/perch = 2,
+													 /mob/living/simple_mob/animal/passive/fish/salmon = 2,
+													 /mob/living/simple_mob/animal/passive/fish/trout = 2,
+													 /mob/living/simple_mob/animal/passive/fish/bass = 3),
+												list(/mob/living/simple_mob/animal/passive/fish/salmon = 1),
+												list(/mob/living/simple_mob/animal/passive/fish/perch = 1),
+												list(/mob/living/simple_mob/animal/passive/fish/trout = 1),
+												list(/mob/living/simple_mob/animal/passive/fish/bass = 1),
+												list(/mob/living/simple_mob/animal/passive/fish/pike = 1),
+												list(/mob/living/simple_mob/animal/passive/crab = 1)
+											),
+										list(
+												list(/mob/living/simple_mob/animal/sif/duck = 1),
+												list(/mob/living/simple_mob/animal/passive/fish/measelshark = 1),
+												list(/mob/living/simple_mob/vore/pakkun = 5,
+													 /mob/living/simple_mob/vore/pakkun/snapdragon = 1)
+											),
+										list(
+												list(/mob/living/simple_mob/animal/space/goose = 10,
+													 /mob/living/simple_mob/animal/space/goose/white = 1),
+												list(/mob/living/simple_mob/vore/alienanimals/space_jellyfish = 1)
+											),
+										list(
+												list(/mob/living/simple_mob/animal/sif/hooligan_crab = 1)
+											)
+										)
+
+var/global/list/event_wildlife_roaming = list(
+										list(
+												list(/mob/living/simple_mob/animal/passive/mouse/jerboa = 1,
+													 /mob/living/simple_mob/animal/passive/mouse/black = 2,
+													 /mob/living/simple_mob/animal/passive/mouse/brown = 2,
+													 /mob/living/simple_mob/animal/passive/mouse/gray = 2,
+													 /mob/living/simple_mob/animal/passive/mouse/white = 2,
+													 /mob/living/simple_mob/animal/passive/mouse/rat = 3),
+												list(/mob/living/simple_mob/animal/passive/bird/black_bird = 1,
+													 /mob/living/simple_mob/animal/passive/bird/azure_tit = 1,
+													 /mob/living/simple_mob/animal/passive/bird/european_robin = 1,
+													 /mob/living/simple_mob/animal/passive/bird/goldcrest = 1,
+													 /mob/living/simple_mob/animal/passive/bird/ringneck_dove = 1),
+												list(/mob/living/simple_mob/animal/passive/dog/corgi = 4,
+													 /mob/living/simple_mob/animal/passive/dog/corgi/puppy = 1),
+												list(/mob/living/simple_mob/vore/rabbit = 1),
+												list(/mob/living/simple_mob/vore/redpanda = 14,
+													 /mob/living/simple_mob/vore/redpanda/fae = 7,
+													 /mob/living/simple_mob/vore/redpanda/blue = 1),
+												list(/mob/living/simple_mob/animal/passive/cow = 1),
+												list(/mob/living/simple_mob/animal/passive/chicken = 4,
+													 /mob/living/simple_mob/animal/passive/chick = 1),
+												list(/mob/living/simple_mob/animal/passive/snake = 2,
+													 /mob/living/simple_mob/animal/passive/snake/red = 1,
+													 /mob/living/simple_mob/animal/passive/snake/python = 1)
+											),
+										list(
+												list(/mob/living/simple_mob/vore/horse/big = 7,
+													 /mob/living/simple_mob/vore/horse = 2),
+												list(/mob/living/simple_mob/vore/fennix = 1,
+													 /mob/living/simple_mob/vore/fennec = 4),
+												list(/mob/living/simple_mob/vore/bee = 1),
+												list(/mob/living/simple_mob/animal/passive/fox = 1),
+												list(/mob/living/simple_mob/vore/sheep = 3,
+													 /mob/living/simple_mob/animal/goat = 1),
+												list(/mob/living/simple_mob/vore/hippo = 1),
+												list(/mob/living/simple_mob/vore/alienanimals/dustjumper = 1),
+												list(/mob/living/simple_mob/vore/alienanimals/teppi = 1)
+											),
+										list(
+												list(/mob/living/simple_mob/vore/aggressive/frog = 1),
+												list(/mob/living/simple_mob/tomato = 1),
+												list(/mob/living/simple_mob/animal/wolf = 1),
+												list(/mob/living/simple_mob/vore/aggressive/dino = 1),
+												list(/mob/living/simple_mob/animal/space/bats = 1)
+											),
+										list(
+												list(/mob/living/simple_mob/animal/space/bear = 1),
+												list(/mob/living/simple_mob/vore/aggressive/deathclaw = 1),
+												list(/mob/living/simple_mob/otie = 1),
+												list(/mob/living/simple_mob/vore/aggressive/panther = 1),
+												list(/mob/living/simple_mob/vore/aggressive/rat = 1),
+												list(/mob/living/simple_mob/vore/aggressive/giant_snake = 1),
+												list(/mob/living/simple_mob/vore/aggressive/corrupthound = 1)
+											)
+										)
+
+
+
+
 // AREA GENERATION AND BLUEPRINT STUFF BELOW HERE
 // typecacheof(list) and list() are two completely separate things, don't break!
 

--- a/code/game/objects/effects/landmarks_vr.dm
+++ b/code/game/objects/effects/landmarks_vr.dm
@@ -7,6 +7,10 @@
 /obj/effect/landmark/vermin
 	name = "verminstart"
 
+/obj/effect/landmark/wildlife
+	name = "wildlife"
+	var/wildlife_type = 2		//1 for water, 2 for land; thats all for now
+
 /obj/effect/landmark/late_antag
 	name = "Antag Latespawn"
 	var/antag_id

--- a/code/modules/events/roaming_wildlife.dm
+++ b/code/modules/events/roaming_wildlife.dm
@@ -1,0 +1,68 @@
+/datum/event/roaming_wildlife
+	announceWhen = 10
+
+/datum/event/roaming_wildlife/start()
+	var/list/possible_spawns = list()
+	for(var/obj/effect/landmark/C in landmarks_list)
+		if(istype(C, /obj/effect/landmark/wildlife))
+			possible_spawns.Add(C)
+
+	if(!(possible_spawns.len))
+		return
+
+	var/threat_level
+	var/spawn_count
+	var/location_amount
+
+	var/points_to_spend
+
+	switch(severity)
+		if(EVENT_LEVEL_MUNDANE)
+			points_to_spend = 6
+		if(EVENT_LEVEL_MODERATE)
+			points_to_spend = 10
+		if(EVENT_LEVEL_MAJOR)
+			points_to_spend = 14
+
+	if(!points_to_spend)
+		return
+
+	threat_level = rand(1,4)
+	points_to_spend -= threat_level
+	spawn_count = rand(1, min(points_to_spend-1, 9))
+	points_to_spend -= spawn_count
+	location_amount = points_to_spend
+
+	for(var/i = 1, i <= location_amount, i++)
+		if(!(possible_spawns.len))
+			break
+		var/obj/effect/landmark/wildlife/WL = pick(possible_spawns)
+		possible_spawns -= WL
+		var/list/spawn_list
+		switch(WL.wildlife_type)
+			if(1)
+				spawn_list = event_wildlife_aquatic
+			if(2)
+				spawn_list = event_wildlife_roaming
+		if(!spawn_list)
+			continue
+
+		spawn_list = pick(spawn_list[threat_level])
+		var/spawn_type
+		var/spawn_pos = get_turf(WL)
+
+		for(var/j = 1, j <= spawn_count, j++)
+			spawn_type = pickweight(spawn_list)
+			var/mob/living/L = new spawn_type(spawn_pos)
+			step_away(L, WL)
+
+/datum/event/roaming_wildlife/announce()
+	var/message
+	switch(severity)
+		if(EVENT_LEVEL_MUNDANE)
+			message = "Minor movements of local wildlife have been detected within proximity of the facility."
+		if(EVENT_LEVEL_MODERATE)
+			message = "Notable amount of local wildlife has been detected entering area surrounding the facility. Take caution."
+		if(EVENT_LEVEL_MAJOR)
+			message = "A particularly large shift within wildlife movement has been detected. Take caution."
+	command_announcement.Announce(message, "Wildlife Monitoring")

--- a/code/modules/mob/living/simple_mob/subtypes/animal/passive/fish.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/passive/fish.dm
@@ -11,7 +11,7 @@
 	icon = 'icons/mob/fish.dmi'
 	item_state = "fish"
 
-	catalogue_data = list(/datum/category_item/catalogue/fauna/invasive_fish)
+	//catalogue_data = list(/datum/category_item/catalogue/fauna/invasive_fish)		 //TODO: write non-sif lore
 
 	mob_size = MOB_SMALL
 	// So fish are actually underwater.

--- a/code/modules/mob/living/simple_mob/subtypes/animal/sif/duck.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/sif/duck.dm
@@ -17,7 +17,7 @@
 	name = "crystal-feather duck"
 	desc = "A glittering flightless bird."
 	tt_desc = "S Anatidae vitriae"
-	catalogue_data = list(/datum/category_item/catalogue/fauna/crystalduck)
+	//catalogue_data = list(/datum/category_item/catalogue/fauna/crystalduck)		TODO: Write non-sif lore
 
 	faction = "duck"
 

--- a/code/modules/mob/living/simple_mob/subtypes/animal/sif/hooligan_crab.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/sif/hooligan_crab.dm
@@ -27,7 +27,7 @@
 	name = "hooligan crab"
 	desc = "A large, hard-shelled crustacean. This one is mostly grey. \
 	You probably shouldn't mess with it."
-	catalogue_data = list(/datum/category_item/catalogue/fauna/hooligan_crab)
+	//catalogue_data = list(/datum/category_item/catalogue/fauna/hooligan_crab)			//TODO: write non-sif lore
 
 	icon_state = "sif_crab"
 	icon_living = "sif_crab"

--- a/code/modules/mob/living/simple_mob/subtypes/vore/redpanda.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/redpanda.dm
@@ -47,6 +47,15 @@
 	icon_dead = "wah_fae_dead"
 	icon_rest = "wah_fae_rest"
 
+	vore_ignores_undigestable = 0	// wah don't care you're edible or not, you still go in
+	vore_digest_chance = 0			// instead of digesting if you struggle...
+	vore_absorb_chance = 20			// you get to become adorable purple wahpudge.
+	vore_bump_chance = 75
+	maxHealth = 100
+	health = 100
+	melee_damage_lower = 10
+	melee_damage_upper = 20
+
 /mob/living/simple_mob/vore/redpanda/blue
 	name = "blue wah"
 	desc = "Blue, but still cute!"

--- a/maps/groundbase/eastwilds/eastwilds1.dmm
+++ b/maps/groundbase/eastwilds/eastwilds1.dmm
@@ -29,6 +29,18 @@
 	outdoors = 0
 	},
 /area/submap/groundbase/wilderness/east)
+"g" = (
+/obj/effect/landmark/wildlife/water,
+/turf/simulated/floor/water,
+/area/submap/groundbase/wilderness/east)
+"h" = (
+/obj/effect/landmark/wildlife/forest,
+/turf/simulated/floor/outdoors/grass/seasonal/dark/notrees_nomobs_lowsnow,
+/area/submap/groundbase/wilderness/east/unexplored)
+"i" = (
+/obj/effect/landmark/wildlife/water,
+/turf/simulated/floor/water/deep,
+/area/submap/groundbase/wilderness/east)
 "l" = (
 /turf/simulated/floor/outdoors/grass/seasonal/dark/notrees_nomobs_lowsnow,
 /area/submap/groundbase/wilderness/east/unexplored)
@@ -47,12 +59,6 @@
 "r" = (
 /turf/simulated/mineral/cave,
 /area/submap/groundbase/wilderness/east/cave)
-"u" = (
-/obj/effect/landmark{
-	name = "carpspawn"
-	},
-/turf/simulated/floor/water/deep,
-/area/submap/groundbase/wilderness/east)
 "w" = (
 /obj/effect/map_effect/portal/master/side_a/gb_wilds/east_west{
 	dir = 8
@@ -61,12 +67,6 @@
 /area/submap/groundbase/wilderness/east)
 "y" = (
 /turf/simulated/mineral/ignore_cavegen,
-/area/submap/groundbase/wilderness/east)
-"B" = (
-/obj/effect/landmark{
-	name = "carpspawn"
-	},
-/turf/simulated/floor/water,
 /area/submap/groundbase/wilderness/east)
 "F" = (
 /turf/simulated/floor/outdoors/grass/seasonal/notrees_nomobs_lowsnow,
@@ -848,7 +848,7 @@ Z
 U
 U
 U
-U
+i
 U
 U
 U
@@ -1453,7 +1453,7 @@ U
 U
 Z
 Z
-Z
+g
 Z
 Z
 Z
@@ -2413,7 +2413,7 @@ U
 U
 U
 U
-u
+U
 U
 U
 U
@@ -2683,7 +2683,7 @@ U
 U
 U
 U
-u
+U
 U
 U
 U
@@ -3002,7 +3002,7 @@ U
 U
 U
 U
-u
+U
 U
 U
 U
@@ -3451,7 +3451,7 @@ U
 U
 U
 U
-u
+U
 U
 U
 U
@@ -3543,7 +3543,7 @@ U
 U
 U
 U
-u
+U
 U
 U
 U
@@ -3882,7 +3882,7 @@ U
 U
 Z
 Z
-Z
+g
 Z
 Z
 V
@@ -4236,7 +4236,7 @@ Z
 Z
 Z
 Z
-Z
+g
 U
 U
 U
@@ -4713,7 +4713,7 @@ U
 U
 Z
 Z
-Z
+g
 Z
 Z
 V
@@ -4809,7 +4809,7 @@ Z
 U
 U
 U
-u
+U
 U
 U
 U
@@ -4869,7 +4869,7 @@ Z
 Z
 Z
 U
-u
+U
 U
 U
 U
@@ -4888,7 +4888,7 @@ F
 F
 l
 l
-l
+h
 l
 l
 l
@@ -5242,7 +5242,7 @@ U
 U
 U
 U
-u
+U
 U
 U
 U
@@ -5275,7 +5275,7 @@ Z
 Z
 U
 U
-u
+U
 U
 U
 U
@@ -5444,7 +5444,7 @@ U
 U
 U
 U
-u
+U
 Z
 Z
 Z
@@ -5827,7 +5827,7 @@ l
 l
 l
 l
-l
+h
 l
 l
 l
@@ -6520,7 +6520,7 @@ U
 U
 U
 U
-U
+i
 Z
 Z
 Z
@@ -6548,7 +6548,7 @@ F
 V
 V
 Z
-B
+Z
 Z
 Z
 Z
@@ -6938,7 +6938,7 @@ Z
 Z
 Z
 Z
-u
+U
 U
 U
 U
@@ -7001,7 +7001,7 @@ U
 U
 U
 U
-u
+U
 U
 U
 Z
@@ -7260,7 +7260,7 @@ V
 Z
 Z
 Z
-Z
+g
 Z
 Z
 V
@@ -7998,7 +7998,7 @@ U
 Z
 Z
 Z
-Z
+g
 Z
 Z
 Z
@@ -8222,7 +8222,7 @@ U
 U
 U
 U
-u
+U
 U
 U
 U
@@ -8275,7 +8275,7 @@ U
 U
 U
 U
-u
+U
 U
 U
 U
@@ -8599,7 +8599,7 @@ l
 l
 l
 l
-l
+h
 l
 l
 l
@@ -9005,7 +9005,7 @@ l
 l
 l
 l
-l
+h
 l
 l
 l
@@ -9491,7 +9491,7 @@ r
 r
 Z
 Z
-B
+Z
 Z
 U
 U
@@ -9818,7 +9818,7 @@ l
 l
 l
 l
-l
+h
 l
 l
 l
@@ -10216,7 +10216,7 @@ U
 U
 U
 U
-u
+U
 U
 U
 Z
@@ -10352,7 +10352,7 @@ U
 U
 U
 U
-u
+U
 U
 U
 U
@@ -10404,7 +10404,7 @@ U
 U
 U
 U
-u
+U
 U
 U
 U
@@ -10929,7 +10929,7 @@ U
 U
 U
 U
-U
+i
 U
 Z
 Z
@@ -11249,7 +11249,7 @@ Z
 U
 U
 U
-u
+U
 U
 U
 U
@@ -11403,7 +11403,7 @@ U
 U
 U
 U
-u
+U
 U
 Z
 Z
@@ -11506,15 +11506,15 @@ U
 U
 U
 U
-u
 U
 U
 U
+U
 Z
 Z
 Z
 Z
-Z
+g
 Z
 Z
 Z
@@ -12111,7 +12111,7 @@ U
 U
 U
 Z
-Z
+g
 Z
 Z
 Z
@@ -12339,10 +12339,10 @@ Z
 Z
 Z
 Z
+g
 Z
 Z
 Z
-Z
 U
 U
 U
@@ -12367,7 +12367,7 @@ U
 U
 U
 U
-u
+U
 U
 U
 U
@@ -12486,7 +12486,7 @@ Z
 Z
 Z
 U
-u
+U
 U
 U
 U
@@ -12808,7 +12808,7 @@ U
 U
 U
 U
-u
+U
 U
 U
 U
@@ -13409,7 +13409,7 @@ l
 l
 l
 l
-l
+h
 l
 F
 F
@@ -13662,7 +13662,7 @@ Z
 U
 U
 U
-U
+i
 Z
 Z
 Z
@@ -13787,7 +13787,7 @@ Z
 Z
 U
 U
-u
+U
 U
 U
 U
@@ -13797,7 +13797,7 @@ Z
 Z
 Z
 Z
-B
+Z
 Z
 Z
 Z
@@ -14465,7 +14465,7 @@ F
 l
 l
 l
-l
+h
 l
 l
 l
@@ -15087,7 +15087,7 @@ l
 l
 l
 l
-l
+h
 l
 l
 F
@@ -15469,7 +15469,7 @@ l
 l
 l
 l
-l
+h
 l
 l
 l
@@ -15783,7 +15783,7 @@ Z
 Z
 Z
 Z
-Z
+g
 Z
 Z
 Z
@@ -15923,7 +15923,7 @@ V
 V
 V
 Z
-B
+Z
 Z
 Z
 Z
@@ -18355,7 +18355,7 @@ l
 l
 l
 l
-l
+h
 l
 F
 F

--- a/maps/groundbase/eastwilds/eastwilds2.dmm
+++ b/maps/groundbase/eastwilds/eastwilds2.dmm
@@ -18,6 +18,22 @@
 	},
 /turf/simulated/floor/water,
 /area/submap/groundbase/wilderness/east)
+"e" = (
+/obj/effect/landmark/wildlife/water,
+/turf/simulated/floor/water/deep,
+/area/submap/groundbase/wilderness/east)
+"f" = (
+/obj/effect/landmark/wildlife/forest,
+/turf/simulated/floor/outdoors/grass/seasonal/dark/notrees_nomobs_lowsnow,
+/area/submap/groundbase/wilderness/east/unexplored)
+"g" = (
+/obj/effect/landmark/wildlife/water,
+/turf/simulated/floor/water,
+/area/submap/groundbase/wilderness/east)
+"h" = (
+/obj/effect/landmark/wildlife/forest,
+/turf/simulated/floor/outdoors/grass/seasonal/notrees_nomobs_lowsnow,
+/area/submap/groundbase/wilderness/east/unexplored)
 "l" = (
 /turf/simulated/mineral/cave,
 /area/submap/groundbase/wilderness/east/cave)
@@ -41,12 +57,6 @@
 	},
 /turf/simulated/floor/water/deep,
 /area/submap/groundbase/wilderness/east)
-"B" = (
-/obj/effect/landmark{
-	name = "carpspawn"
-	},
-/turf/simulated/floor/water/deep,
-/area/submap/groundbase/wilderness/east)
 "F" = (
 /turf/simulated/floor/outdoors/grass/seasonal/notrees_nomobs_lowsnow,
 /area/submap/groundbase/wilderness/east/unexplored)
@@ -55,12 +65,6 @@
 	dir = 8
 	},
 /turf/simulated/floor/outdoors/grass/seasonal/dark/notrees_nomobs_lowsnow,
-/area/submap/groundbase/wilderness/east)
-"I" = (
-/obj/effect/landmark{
-	name = "carpspawn"
-	},
-/turf/simulated/floor/water,
 /area/submap/groundbase/wilderness/east)
 "V" = (
 /obj/effect/map_effect/portal/master/side_b/gb_wilds/east{
@@ -965,7 +969,7 @@ Z
 Z
 Z
 t
-B
+t
 t
 t
 Z
@@ -3098,7 +3102,7 @@ l
 l
 Z
 Z
-I
+Z
 t
 t
 t
@@ -3384,7 +3388,7 @@ Z
 Z
 Z
 t
-t
+e
 t
 Z
 Z
@@ -5087,7 +5091,7 @@ Z
 Z
 Z
 Z
-I
+Z
 n
 n
 F
@@ -5430,7 +5434,7 @@ b
 b
 b
 b
-b
+f
 F
 F
 F
@@ -5693,7 +5697,7 @@ F
 F
 F
 F
-b
+f
 b
 b
 b
@@ -5933,7 +5937,7 @@ F
 n
 Z
 Z
-I
+Z
 Z
 Z
 Z
@@ -5949,7 +5953,7 @@ b
 b
 b
 b
-b
+f
 b
 b
 b
@@ -6928,7 +6932,7 @@ t
 t
 t
 t
-I
+Z
 Z
 Z
 Z
@@ -7126,7 +7130,7 @@ b
 b
 b
 b
-b
+f
 b
 b
 b
@@ -7241,7 +7245,7 @@ Z
 t
 t
 t
-B
+e
 t
 t
 t
@@ -7531,7 +7535,7 @@ t
 t
 Z
 Z
-I
+Z
 Z
 n
 n
@@ -7778,7 +7782,7 @@ Z
 t
 t
 t
-t
+e
 t
 t
 Z
@@ -8060,7 +8064,7 @@ Z
 Z
 Z
 Z
-B
+t
 t
 t
 t
@@ -8144,7 +8148,7 @@ n
 n
 Z
 Z
-I
+Z
 Z
 Z
 Z
@@ -8357,7 +8361,7 @@ t
 t
 t
 t
-I
+Z
 Z
 Z
 Z
@@ -8711,7 +8715,7 @@ Z
 Z
 t
 t
-B
+t
 t
 t
 t
@@ -8920,7 +8924,7 @@ t
 t
 Z
 Z
-I
+Z
 Z
 Z
 Z
@@ -8991,8 +8995,8 @@ Z
 Z
 Z
 Z
+g
 Z
-Z
 t
 t
 t
@@ -9008,7 +9012,7 @@ t
 t
 t
 t
-B
+t
 Z
 Z
 Z
@@ -9083,7 +9087,7 @@ n
 n
 Z
 Z
-I
+Z
 t
 Z
 Z
@@ -9151,7 +9155,7 @@ t
 t
 t
 Z
-Z
+g
 Z
 Z
 Z
@@ -9428,7 +9432,7 @@ t
 t
 t
 t
-B
+t
 t
 t
 t
@@ -9444,7 +9448,7 @@ n
 F
 F
 F
-F
+h
 F
 F
 l
@@ -9705,7 +9709,7 @@ n
 Z
 Z
 Z
-I
+Z
 t
 t
 t
@@ -9809,7 +9813,7 @@ b
 b
 b
 b
-b
+f
 b
 b
 b
@@ -10119,7 +10123,7 @@ b
 b
 b
 b
-b
+f
 b
 b
 b
@@ -10348,7 +10352,7 @@ b
 b
 b
 b
-b
+f
 b
 b
 b
@@ -10704,7 +10708,7 @@ Z
 t
 t
 t
-B
+t
 t
 t
 t
@@ -11352,7 +11356,7 @@ n
 n
 n
 Z
-I
+Z
 Z
 n
 n
@@ -11529,18 +11533,18 @@ t
 t
 t
 t
-B
 t
 t
 t
 t
 t
 t
+t
 Z
 Z
 Z
 Z
-Z
+g
 Z
 Z
 Z
@@ -11548,7 +11552,7 @@ Z
 Z
 t
 t
-B
+t
 t
 t
 t
@@ -12537,7 +12541,7 @@ t
 t
 t
 t
-B
+t
 t
 t
 t
@@ -12803,7 +12807,7 @@ t
 t
 t
 t
-B
+t
 t
 t
 t
@@ -12903,7 +12907,7 @@ Z
 Z
 Z
 Z
-Z
+g
 Z
 Z
 Z
@@ -13547,7 +13551,7 @@ t
 t
 t
 t
-B
+t
 t
 Z
 Z
@@ -13911,7 +13915,7 @@ b
 b
 b
 b
-b
+f
 b
 b
 b
@@ -13969,7 +13973,7 @@ t
 t
 t
 t
-B
+t
 t
 t
 t
@@ -14215,7 +14219,7 @@ Z
 Z
 Z
 Z
-Z
+g
 t
 t
 t
@@ -14244,7 +14248,7 @@ t
 t
 t
 t
-t
+e
 t
 t
 t
@@ -14319,7 +14323,7 @@ Z
 Z
 Z
 Z
-I
+Z
 Z
 Z
 Z
@@ -14636,31 +14640,30 @@ n
 n
 Z
 Z
-I
-Z
-Z
-Z
-Z
-n
-n
-n
-n
-n
-n
-n
-n
-n
-n
-n
-n
 Z
 Z
 Z
 Z
 Z
+n
+n
+n
+n
+n
+n
+n
+n
+n
+n
+n
+n
+Z
+Z
+Z
+Z
+Z
 Z
 t
-B
 t
 t
 t
@@ -14672,7 +14675,8 @@ t
 t
 t
 t
-B
+t
+t
 t
 t
 t
@@ -15645,7 +15649,7 @@ F
 F
 F
 b
-b
+f
 b
 b
 F
@@ -16043,9 +16047,9 @@ Z
 Z
 Z
 Z
-I
 Z
 Z
+g
 Z
 Z
 Z
@@ -16097,7 +16101,6 @@ t
 t
 t
 t
-B
 t
 t
 t
@@ -16107,7 +16110,8 @@ t
 t
 t
 t
-B
+t
+t
 t
 t
 t
@@ -16368,7 +16372,6 @@ Z
 Z
 t
 t
-B
 t
 t
 t
@@ -16395,7 +16398,8 @@ t
 t
 t
 t
-Z
+t
+g
 Z
 Z
 n
@@ -16953,7 +16957,7 @@ t
 t
 t
 t
-B
+t
 t
 t
 t
@@ -17101,7 +17105,7 @@ t
 t
 t
 t
-B
+t
 Z
 Z
 Z
@@ -17300,7 +17304,7 @@ F
 F
 F
 b
-b
+f
 b
 b
 F
@@ -18470,7 +18474,7 @@ l
 l
 F
 F
-F
+h
 b
 b
 F

--- a/maps/groundbase/groundbase_events.dm
+++ b/maps/groundbase/groundbase_events.dm
@@ -29,68 +29,58 @@
 	available_events = list(
 		// Severity level, event name, even type, base weight, role weights, one shot, min weight, max weight. Last two only used if set and non-zero
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Nothing",			/datum/event/nothing,			400),
-		// Bluescreens APCs, but they still work
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "APC Damage",		/datum/event/apc_damage,		20, 	list(ASSIGNMENT_ENGINEER = 20), min_jobs = list(ASSIGNMENT_ENGINEER = 1)),
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Brand Intelligence",/datum/event/brand_intelligence, 0, 	list(ASSIGNMENT_ENGINEER = 10),	1, min_jobs = list(ASSIGNMENT_ENGINEER = 1)),
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Camera Damage",		/datum/event/camera_damage,		20, 	list(ASSIGNMENT_ENGINEER = 20, ASSIGNMENT_SECURITY = 5), min_jobs = list(ASSIGNMENT_ENGINEER = 1)),
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Canister Leak",		/datum/event/canister_leak,		10, 	list(ASSIGNMENT_ENGINEER = 20), min_jobs = list(ASSIGNMENT_ENGINEER = 1)),
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Economic News",		/datum/event/economic_event,	300),
-		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Lost Carp",			/datum/event/carp_migration, 	0, 		list(ASSIGNMENT_SECURITY = 10), 1, min_jobs = list(ASSIGNMENT_SECURITY = 3)),
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Money Hacker",		/datum/event/money_hacker, 		0, 		list(ASSIGNMENT_ANY = 4), 1, 10, 25),
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Money Lotto",		/datum/event/money_lotto, 		0, 		list(ASSIGNMENT_ANY = 1), 1, 5, 15),
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Shipping Error",	/datum/event/shipping_error	, 	30, 	list(ASSIGNMENT_ANY = 2), 0),
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Trivial News",		/datum/event/trivial_news, 		400),
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Lore News",			/datum/event/lore_news, 		400),
-		// Spawns mice, lizards, or dud spiderlings
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Vermin Infestation",/datum/event/infestation, 		50,		list(ASSIGNMENT_JANITOR = 25), 1),
-		// Rot only weakens walls, not destroy them
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Wallrot",			/datum/event/wallrot, 			0,		list(ASSIGNMENT_ENGINEER = 30), 1, min_jobs = list(ASSIGNMENT_ENGINEER = 1)),
+		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Passing Wildlife",  /datum/event/roaming_wildlife,  30,		list(ASSIGNMENT_SECURITY = 15), min_jobs = list(ASSIGNMENT_SECURITY = 1))
 	)
 	add_disabled_events(list(
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Ian Storm",			/datum/event/ianstorm,	 		1,		list(), 1),
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Supply Demand",		/datum/event/supply_demand,		0,		list(ASSIGNMENT_ANY = 5, ASSIGNMENT_SCIENCE = 15, ASSIGNMENT_GARDENER = 10, ASSIGNMENT_ENGINEER = 10, ASSIGNMENT_MEDICAL = 15), 1),
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Aurora Caelus",		/datum/event/aurora_caelus,		2,		list(), 1),
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Space Dust",		/datum/event/dust,	 			0, 		list(ASSIGNMENT_ENGINEER = 20), 0, 0, 50, min_jobs = list(ASSIGNMENT_ENGINEER = 2)),
+		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Lost Carp",			/datum/event/carp_migration, 	0, 		list(ASSIGNMENT_SECURITY = 10), 1, min_jobs = list(ASSIGNMENT_SECURITY = 3)),
 	))
 
 /datum/event_container/moderate/New()
 	available_events = list(
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Nothing",					/datum/event/nothing,					1600),
-		// Leaks gas into an unoccupied room.
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Atmos Leak",				/datum/event/atmos_leak, 				30,		list(ASSIGNMENT_ENGINEER = 25), 1, min_jobs = list(ASSIGNMENT_ENGINEER = 1)),
-		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Carp School",				/datum/event/carp_migration,			0, 		list(ASSIGNMENT_SECURITY = 30), 1, min_jobs = list(ASSIGNMENT_SECURITY = 3)),
-		// Just disables comms for a short while.
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Communication Blackout",	/datum/event/communications_blackout,	500,	list(), 1),
-		// Just blows out a few lights
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Electrical Storm",			/datum/event/electrical_storm, 			70,		list(ASSIGNMENT_ENGINEER = 25, ASSIGNMENT_JANITOR = 100), 1),
-		// Temporary power failure, but mitigatead by subgrids
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Grid Check",				/datum/event/grid_check, 				0,		list(ASSIGNMENT_ENGINEER = 25), 1, min_jobs = list(ASSIGNMENT_ENGINEER = 1)),
-		// Pure RP fun, no mechanical effects.
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Ion Storm",				/datum/event/ionstorm, 					0,		list(ASSIGNMENT_AI = 80, ASSIGNMENT_CYBORG = 50, ASSIGNMENT_SCIENTIST = 20), min_jobs = list(ASSIGNMENT_AI = 1)),
-		// Opens doors in brig.  So just RP fun
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Prison Break",				/datum/event/prison_break,				10,		list(ASSIGNMENT_SECURITY = 15, ASSIGNMENT_ENGINEER = 15), 1),
-		// Radiation, but only in space.
-		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Rogue Drones",				/datum/event/rogue_drone, 				0,		list(ASSIGNMENT_SECURITY = 20), 1, min_jobs = list(ASSIGNMENT_SECURITY = 3)),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Virology Breach",			/datum/event/prison_break/virology,		0,		list(ASSIGNMENT_MEDICAL = 15, ASSIGNMENT_ENGINEER = 15), 1),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Xenobiology Breach",		/datum/event/prison_break/xenobiology,	0,		list(ASSIGNMENT_SCIENTIST = 15, ASSIGNMENT_ENGINEER = 15), 1),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Spider Infestation",		/datum/event/spider_infestation, 		0,		list(ASSIGNMENT_SECURITY = 30), 1, min_jobs = list(ASSIGNMENT_SECURITY = 2)),
-		//Evil grubs that drain station power slightly
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Grub Infestation",			/datum/event/grub_infestation,			0,		list(ASSIGNMENT_SECURITY = 15, ASSIGNMENT_ENGINEER = 30), 1, min_jobs = list(ASSIGNMENT_SECURITY = 1, ASSIGNMENT_ENGINEER = 1)),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Drone Pod Drop",			/datum/event/drone_pod_drop,			40,		list(ASSIGNMENT_SCIENTIST = 40), 1),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Morph Spawn",				/datum/event/morph_spawn,				75,		list(ASSIGNMENT_ANY = 5), 0),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Maintenance Predator",		/datum/event/maintenance_predator,		100,	list(ASSIGNMENT_ANY = 5), 0),
-		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Jellyfish School",			/datum/event/jellyfish_migration,		0,		list(ASSIGNMENT_SECURITY = 15, ASSIGNMENT_MEDICAL = 3), 1, min_jobs = list(ASSIGNMENT_SECURITY = 2)),
+		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Roaming Wildlife",			/datum/event/roaming_wildlife,  		0,		list(ASSIGNMENT_SECURITY = 15, ASSIGNMENT_MEDICAL = 5), min_jobs = list(ASSIGNMENT_SECURITY = 2))
 	)
 	add_disabled_events(list(
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Appendicitis", 			/datum/event/spontaneous_appendicitis, 	0,		list(ASSIGNMENT_MEDICAL = 30), 1),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Meteor Shower",			/datum/event/meteor_wave,				30,		list(ASSIGNMENT_ENGINEER = 20)),
-		// Not bad (dorms are shielded) but inconvenient
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Radiation Storm",			/datum/event/radiation_storm, 			50,		list(ASSIGNMENT_MEDICAL = 50), 1),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Random Antagonist",		/datum/event/random_antag,		 		0,	list(ASSIGNMENT_SECURITY = 1), 1, 0, 5),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Supply Demand",			/datum/event/supply_demand,				0,		list(ASSIGNMENT_ANY = 5, ASSIGNMENT_SCIENCE = 15, ASSIGNMENT_GARDENER = 10, ASSIGNMENT_ENGINEER = 10, ASSIGNMENT_MEDICAL = 15), 1),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Solar Storm",				/datum/event/solar_storm, 				30,		list(ASSIGNMENT_ENGINEER = 40, ASSIGNMENT_SECURITY = 30), 1),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Gravity Failure",			/datum/event/gravity,	 				75,		list(ASSIGNMENT_ENGINEER = 60), 1),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Space Dust",				/datum/event/dust,	 					0,		list(ASSIGNMENT_ENGINEER = 20), 1, 0, 50, min_jobs = list(ASSIGNMENT_ENGINEER = 3)),
+		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Carp School",				/datum/event/carp_migration,			0, 		list(ASSIGNMENT_SECURITY = 30), 1, min_jobs = list(ASSIGNMENT_SECURITY = 3)),
+		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Rogue Drones",				/datum/event/rogue_drone, 				0,		list(ASSIGNMENT_SECURITY = 20), 1, min_jobs = list(ASSIGNMENT_SECURITY = 3)),
+		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Jellyfish School",			/datum/event/jellyfish_migration,		0,		list(ASSIGNMENT_SECURITY = 15, ASSIGNMENT_MEDICAL = 3), 1, min_jobs = list(ASSIGNMENT_SECURITY = 2)),
 	))
 
 /datum/event_container/major/New()
@@ -98,15 +88,16 @@
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Nothing",				/datum/event/nothing,				3600),
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Atmos Leak",			/datum/event/atmos_leak, 			20,		list(ASSIGNMENT_ENGINEER = 25), 1, min_jobs = list(ASSIGNMENT_ENGINEER = 1)),
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Space Vines",			/datum/event/spacevine, 			10,		list(ASSIGNMENT_ENGINEER = 3, ASSIGNMENT_GARDENER = 3, ASSIGNMENT_SCIENTIST = 3), 1),
-		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Carp Migration",		/datum/event/carp_migration,		10,		list(ASSIGNMENT_SECURITY = 5), 1, min_jobs = list(ASSIGNMENT_SECURITY = 3)),
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Containment Breach",	/datum/event/prison_break/station,	0,	list(ASSIGNMENT_ENGINEER = 5, ASSIGNMENT_MEDICAL = 5, ASSIGNMENT_SECURITY = 5, ASSIGNMENT_SCIENTIST = 5), 1),
-		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Jellyfish Migration",	/datum/event/jellyfish_migration,	5,	list(ASSIGNMENT_SECURITY = 5, ASSIGNMENT_MEDICAL = 3), 1, min_jobs = list(ASSIGNMENT_SECURITY = 2)),
+		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Amassing Wildlife",	/datum/event/roaming_wildlife,  	0,		list(ASSIGNMENT_SECURITY = 10, ASSIGNMENT_MEDICAL = 3), 1, min_jobs = list(ASSIGNMENT_SECURITY = 3))
 	)
 	add_disabled_events(list(
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Meteor Strike",		/datum/event/meteor_strike,			10,		list(ASSIGNMENT_ENGINEER = 15), 1),
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Blob",				/datum/event/blob, 					10,		list(ASSIGNMENT_ENGINEER = 60), 1),
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Meteor Wave",			/datum/event/meteor_wave,			30,		list(ASSIGNMENT_ENGINEER = 15),	1),
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Supply Demand",		/datum/event/supply_demand,			0,		list(ASSIGNMENT_ANY = 5, ASSIGNMENT_SCIENCE = 15, ASSIGNMENT_GARDENER = 10, ASSIGNMENT_ENGINEER = 10, ASSIGNMENT_MEDICAL = 15), 1),
+		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Jellyfish Migration",	/datum/event/jellyfish_migration,	5,	list(ASSIGNMENT_SECURITY = 5, ASSIGNMENT_MEDICAL = 3), 1, min_jobs = list(ASSIGNMENT_SECURITY = 2)),
+		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Carp Migration",		/datum/event/carp_migration,		10,		list(ASSIGNMENT_SECURITY = 5), 1, min_jobs = list(ASSIGNMENT_SECURITY = 3)),
 	))
 
 #undef ASSIGNMENT_ANY

--- a/maps/groundbase/groundbase_things.dm
+++ b/maps/groundbase/groundbase_things.dm
@@ -102,3 +102,13 @@ VIRGO3B_TURF_CREATE(/turf/simulated/floor/outdoors/rocks)
 /datum/map_template/shelter/New()
 	..()
 	banned_areas += list(/area/groundbase/level3/escapepad)
+
+// Landmarks for wildlife events
+
+/obj/effect/landmark/wildlife/water
+	name = "aquatic wildlife"
+	wildlife_type = 1
+
+/obj/effect/landmark/wildlife/forest
+	name = "roaming wildlife"
+	wildlife_type = 2

--- a/maps/groundbase/northwilds/northwilds1.dmm
+++ b/maps/groundbase/northwilds/northwilds1.dmm
@@ -6,6 +6,14 @@
 	name = "impassable rock"
 	},
 /area/submap/groundbase/wilderness/north)
+"b" = (
+/obj/effect/landmark/wildlife/forest,
+/turf/simulated/floor/outdoors/grass/seasonal/notrees_nomobs_lowsnow,
+/area/submap/groundbase/wilderness/north/unexplored)
+"c" = (
+/obj/effect/landmark/wildlife/forest,
+/turf/simulated/floor/outdoors/grass/seasonal/dark/notrees_nomobs_lowsnow,
+/area/submap/groundbase/wilderness/north/unexplored)
 "d" = (
 /obj/effect/map_effect/portal/line/side_b{
 	dir = 1
@@ -2124,7 +2132,7 @@ X
 X
 X
 X
-X
+c
 X
 X
 X
@@ -3671,7 +3679,7 @@ K
 K
 X
 X
-X
+c
 X
 X
 X
@@ -4265,7 +4273,7 @@ M
 M
 K
 K
-X
+c
 X
 X
 K
@@ -5849,7 +5857,7 @@ K
 X
 X
 X
-X
+c
 X
 K
 K
@@ -6668,7 +6676,7 @@ X
 X
 X
 X
-X
+c
 X
 K
 K
@@ -7252,7 +7260,7 @@ M
 M
 K
 X
-X
+c
 X
 K
 M
@@ -7638,7 +7646,7 @@ X
 X
 X
 X
-X
+c
 X
 X
 X
@@ -8614,7 +8622,7 @@ K
 K
 K
 X
-X
+c
 X
 X
 X
@@ -9269,7 +9277,7 @@ K
 K
 K
 X
-X
+c
 X
 X
 X
@@ -10573,7 +10581,7 @@ X
 X
 K
 K
-K
+b
 K
 K
 K
@@ -10876,7 +10884,7 @@ K
 X
 X
 X
-X
+c
 X
 X
 X
@@ -11537,7 +11545,7 @@ X
 X
 X
 X
-X
+c
 X
 X
 X
@@ -11634,7 +11642,7 @@ M
 K
 K
 X
-K
+b
 K
 K
 M
@@ -12082,7 +12090,7 @@ K
 K
 X
 X
-X
+c
 X
 X
 X
@@ -13767,7 +13775,7 @@ M
 M
 K
 K
-X
+c
 X
 X
 X
@@ -14025,7 +14033,7 @@ K
 K
 K
 X
-X
+c
 K
 K
 M
@@ -15026,7 +15034,7 @@ K
 K
 K
 X
-X
+c
 X
 X
 X
@@ -15479,7 +15487,7 @@ X
 X
 X
 X
-X
+c
 X
 X
 X
@@ -15499,7 +15507,7 @@ K
 X
 X
 X
-X
+c
 X
 X
 X
@@ -15991,7 +15999,7 @@ X
 X
 X
 X
-X
+c
 X
 X
 X
@@ -16648,7 +16656,7 @@ X
 X
 X
 X
-X
+c
 X
 X
 X
@@ -17166,7 +17174,7 @@ X
 X
 X
 X
-X
+c
 X
 X
 X

--- a/maps/groundbase/northwilds/northwilds2.dmm
+++ b/maps/groundbase/northwilds/northwilds2.dmm
@@ -6,6 +6,14 @@
 	name = "impassable rock"
 	},
 /area/submap/groundbase/wilderness/north)
+"b" = (
+/obj/effect/landmark/wildlife/forest,
+/turf/simulated/floor/outdoors/grass/seasonal/dark/notrees_nomobs_lowsnow,
+/area/submap/groundbase/wilderness/north/unexplored)
+"c" = (
+/obj/effect/landmark/wildlife/forest,
+/turf/simulated/floor/outdoors/grass/seasonal/notrees_nomobs_lowsnow,
+/area/submap/groundbase/wilderness/north/unexplored)
 "d" = (
 /obj/effect/map_effect/portal/line/side_b{
 	dir = 1
@@ -1408,7 +1416,7 @@ K
 K
 K
 X
-X
+b
 X
 K
 K
@@ -1775,7 +1783,7 @@ K
 K
 X
 X
-X
+b
 X
 X
 K
@@ -2010,7 +2018,7 @@ K
 K
 K
 K
-K
+c
 K
 K
 K
@@ -3265,7 +3273,7 @@ X
 X
 K
 K
-X
+b
 X
 X
 X
@@ -3876,7 +3884,7 @@ X
 X
 X
 X
-X
+b
 X
 X
 X
@@ -3943,7 +3951,7 @@ o
 K
 X
 X
-X
+b
 X
 K
 K
@@ -6037,7 +6045,7 @@ o
 o
 K
 K
-X
+b
 K
 o
 o
@@ -6424,7 +6432,7 @@ X
 X
 X
 X
-X
+b
 X
 K
 K
@@ -6725,7 +6733,7 @@ o
 o
 K
 X
-K
+c
 o
 o
 m
@@ -6969,7 +6977,7 @@ X
 X
 K
 K
-X
+b
 X
 X
 X
@@ -7079,7 +7087,7 @@ o
 o
 K
 K
-K
+c
 K
 o
 o
@@ -7189,7 +7197,7 @@ o
 o
 K
 X
-X
+b
 K
 K
 o
@@ -10437,7 +10445,7 @@ K
 X
 X
 X
-X
+b
 X
 K
 K
@@ -10668,7 +10676,7 @@ o
 K
 K
 X
-X
+b
 X
 K
 K
@@ -10738,7 +10746,7 @@ o
 K
 K
 X
-X
+b
 K
 K
 o
@@ -11115,7 +11123,7 @@ o
 o
 K
 X
-X
+b
 K
 o
 o
@@ -11350,7 +11358,7 @@ X
 X
 X
 K
-K
+c
 K
 K
 K
@@ -11617,7 +11625,7 @@ o
 o
 X
 X
-X
+b
 K
 K
 o
@@ -12885,7 +12893,7 @@ X
 X
 X
 X
-X
+b
 X
 X
 X
@@ -14743,7 +14751,7 @@ K
 K
 X
 X
-X
+b
 X
 K
 K
@@ -15141,7 +15149,7 @@ K
 K
 X
 X
-X
+b
 X
 X
 X
@@ -15551,7 +15559,7 @@ X
 X
 K
 K
-K
+c
 X
 X
 X
@@ -17339,7 +17347,7 @@ K
 K
 X
 X
-X
+b
 X
 X
 K
@@ -17729,7 +17737,7 @@ X
 X
 X
 X
-X
+b
 X
 X
 K

--- a/maps/groundbase/southwilds/southwilds1.dmm
+++ b/maps/groundbase/southwilds/southwilds1.dmm
@@ -6,6 +6,10 @@
 	name = "impassable rock"
 	},
 /area/submap/groundbase/wilderness/south)
+"b" = (
+/obj/effect/landmark/wildlife/forest,
+/turf/simulated/floor/outdoors/grass/seasonal/dark/notrees_nomobs_lowsnow,
+/area/submap/groundbase/wilderness/south/unexplored)
 "c" = (
 /turf/simulated/floor/water,
 /area/submap/groundbase/wilderness/south)
@@ -14,11 +18,17 @@
 	edge_blending_priority = -1
 	},
 /area/submap/groundbase/wilderness/south)
-"o" = (
-/obj/effect/landmark{
-	name = "carpspawn"
-	},
+"e" = (
+/obj/effect/landmark/wildlife/forest,
+/turf/simulated/floor/outdoors/grass/seasonal/notrees_nomobs_lowsnow,
+/area/submap/groundbase/wilderness/south/unexplored)
+"f" = (
+/obj/effect/landmark/wildlife/water,
 /turf/simulated/floor/water/deep,
+/area/submap/groundbase/wilderness/south)
+"g" = (
+/obj/effect/landmark/wildlife/water,
+/turf/simulated/floor/water,
 /area/submap/groundbase/wilderness/south)
 "p" = (
 /turf/simulated/floor/outdoors/grass/seasonal/notrees_nomobs_lowsnow,
@@ -44,12 +54,6 @@
 "H" = (
 /turf/simulated/floor/outdoors/grass/seasonal/notrees_nomobs_lowsnow,
 /area/submap/groundbase/wilderness/south/unexplored)
-"I" = (
-/obj/effect/landmark{
-	name = "carpspawn"
-	},
-/turf/simulated/floor/water,
-/area/submap/groundbase/wilderness/south)
 "K" = (
 /obj/effect/map_effect/portal/line/side_b,
 /turf/simulated/floor/outdoors/grass/seasonal/dark/notrees_nomobs_lowsnow,
@@ -1117,7 +1121,7 @@ H
 d
 c
 c
-F
+f
 F
 c
 d
@@ -1259,7 +1263,7 @@ d
 d
 c
 c
-o
+F
 c
 c
 c
@@ -2070,7 +2074,7 @@ H
 H
 Y
 Y
-Y
+b
 Y
 Y
 Y
@@ -3529,7 +3533,7 @@ Y
 Y
 Y
 Y
-Y
+b
 Y
 Y
 Y
@@ -4498,7 +4502,7 @@ Y
 Y
 Y
 Y
-Y
+b
 H
 d
 c
@@ -4647,7 +4651,7 @@ c
 c
 c
 F
-F
+f
 c
 c
 c
@@ -4787,7 +4791,7 @@ H
 d
 d
 c
-I
+c
 c
 F
 F
@@ -4858,7 +4862,7 @@ Y
 Y
 Y
 Y
-Y
+b
 Y
 Y
 H
@@ -4933,7 +4937,7 @@ c
 c
 F
 F
-o
+F
 c
 c
 c
@@ -5099,7 +5103,7 @@ F
 F
 F
 F
-F
+f
 F
 c
 c
@@ -5543,7 +5547,7 @@ Y
 Y
 Y
 Y
-Y
+b
 Y
 Y
 Y
@@ -6527,7 +6531,7 @@ d
 d
 c
 c
-I
+c
 c
 c
 c
@@ -7101,7 +7105,7 @@ c
 c
 c
 c
-o
+F
 F
 c
 c
@@ -7244,7 +7248,7 @@ F
 F
 F
 F
-F
+f
 F
 F
 F
@@ -8179,7 +8183,7 @@ H
 Y
 Y
 Y
-Y
+b
 Y
 Y
 Y
@@ -8392,7 +8396,7 @@ H
 Y
 Y
 Y
-Y
+b
 Y
 H
 H
@@ -9696,7 +9700,7 @@ H
 H
 H
 H
-H
+e
 H
 H
 H
@@ -9715,7 +9719,7 @@ H
 Y
 Y
 Y
-Y
+b
 Y
 Y
 Y
@@ -9777,7 +9781,7 @@ H
 Y
 Y
 Y
-Y
+b
 Y
 Y
 Y
@@ -10233,7 +10237,7 @@ d
 c
 c
 c
-o
+F
 c
 c
 c
@@ -11218,7 +11222,7 @@ H
 H
 Y
 Y
-Y
+b
 Y
 Y
 Y
@@ -11777,7 +11781,7 @@ d
 c
 F
 F
-I
+c
 c
 d
 d
@@ -11953,7 +11957,7 @@ d
 H
 Y
 Y
-Y
+b
 Y
 H
 H
@@ -12316,7 +12320,7 @@ Y
 Y
 H
 H
-H
+e
 H
 H
 H
@@ -12577,7 +12581,7 @@ H
 H
 H
 H
-H
+e
 H
 H
 H
@@ -12943,7 +12947,7 @@ d
 d
 c
 c
-I
+c
 c
 c
 c
@@ -13086,7 +13090,7 @@ c
 c
 c
 c
-c
+g
 c
 c
 c
@@ -13172,7 +13176,7 @@ c
 c
 c
 c
-I
+c
 c
 c
 d
@@ -13800,7 +13804,7 @@ d
 d
 c
 c
-I
+c
 c
 c
 c
@@ -13947,7 +13951,7 @@ d
 c
 c
 c
-o
+F
 F
 F
 c
@@ -14039,7 +14043,7 @@ F
 F
 F
 F
-o
+F
 F
 F
 F
@@ -14325,7 +14329,7 @@ F
 F
 F
 F
-F
+f
 F
 c
 c
@@ -14894,7 +14898,7 @@ c
 c
 F
 F
-o
+F
 F
 c
 c
@@ -15250,7 +15254,7 @@ d
 d
 c
 F
-o
+F
 c
 c
 c
@@ -16092,7 +16096,7 @@ Y
 Y
 Y
 Y
-Y
+b
 Y
 Y
 H
@@ -16705,7 +16709,7 @@ d
 c
 c
 F
-o
+F
 c
 c
 d
@@ -17262,7 +17266,7 @@ H
 H
 H
 Y
-Y
+b
 Y
 Y
 Y
@@ -17418,7 +17422,7 @@ d
 d
 d
 c
-F
+f
 F
 c
 c
@@ -17703,7 +17707,7 @@ H
 d
 c
 c
-o
+F
 c
 c
 d
@@ -18135,7 +18139,7 @@ d
 d
 H
 Y
-Y
+b
 Y
 Y
 Y
@@ -18372,7 +18376,7 @@ c
 c
 F
 F
-F
+f
 F
 F
 c
@@ -18513,7 +18517,7 @@ d
 c
 c
 F
-o
+F
 F
 F
 F
@@ -18659,7 +18663,7 @@ F
 F
 F
 F
-o
+F
 F
 c
 c

--- a/maps/groundbase/southwilds/southwilds2.dmm
+++ b/maps/groundbase/southwilds/southwilds2.dmm
@@ -6,9 +6,17 @@
 	name = "impassable rock"
 	},
 /area/submap/groundbase/wilderness/south)
+"b" = (
+/obj/effect/landmark/wildlife/forest,
+/turf/simulated/floor/outdoors/grass/seasonal/notrees_nomobs_lowsnow,
+/area/submap/groundbase/wilderness/south/unexplored)
 "c" = (
 /turf/simulated/mineral/cave,
 /area/submap/groundbase/wilderness/south/cave)
+"d" = (
+/obj/effect/landmark/wildlife/forest,
+/turf/simulated/floor/outdoors/grass/seasonal/dark/notrees_nomobs_lowsnow,
+/area/submap/groundbase/wilderness/south/unexplored)
 "l" = (
 /turf/simulated/floor/outdoors/grass/seasonal/notrees_nomobs_lowsnow,
 /area/submap/groundbase/wilderness/south)
@@ -2977,7 +2985,7 @@ H
 Y
 Y
 Y
-Y
+d
 Y
 Y
 Y
@@ -3101,7 +3109,7 @@ c
 H
 H
 Y
-Y
+d
 Y
 H
 c
@@ -4201,7 +4209,7 @@ H
 H
 H
 Y
-Y
+d
 Y
 H
 c
@@ -4289,7 +4297,7 @@ c
 H
 Y
 Y
-Y
+d
 Y
 H
 c
@@ -6684,7 +6692,7 @@ Y
 Y
 Y
 Y
-Y
+d
 Y
 Y
 Y
@@ -6883,9 +6891,9 @@ c
 c
 c
 H
+b
 H
 H
-H
 c
 c
 c
@@ -6905,24 +6913,6 @@ c
 c
 c
 H
-Y
-Y
-Y
-Y
-H
-H
-H
-H
-H
-H
-H
-H
-H
-Y
-Y
-Y
-Y
-Y
 Y
 Y
 Y
@@ -6933,6 +6923,24 @@ H
 H
 H
 H
+H
+H
+H
+Y
+Y
+Y
+Y
+Y
+Y
+Y
+Y
+Y
+H
+H
+H
+H
+H
+H
 c
 c
 c
@@ -6952,7 +6960,7 @@ Y
 Y
 Y
 Y
-Y
+d
 Y
 Y
 Y
@@ -7047,7 +7055,7 @@ c
 H
 H
 H
-Y
+d
 Y
 Y
 Y
@@ -7488,7 +7496,7 @@ Y
 Y
 Y
 Y
-Y
+d
 Y
 Y
 Y
@@ -7928,7 +7936,7 @@ H
 H
 H
 Y
-Y
+d
 Y
 Y
 Y
@@ -9793,7 +9801,7 @@ Y
 Y
 Y
 Y
-Y
+d
 Y
 Y
 Y
@@ -9924,7 +9932,7 @@ Y
 Y
 Y
 Y
-Y
+d
 Y
 Y
 Y
@@ -10120,7 +10128,7 @@ H
 Y
 Y
 Y
-Y
+d
 H
 H
 H
@@ -10469,7 +10477,7 @@ H
 Y
 Y
 Y
-Y
+d
 Y
 Y
 H
@@ -11774,7 +11782,7 @@ Y
 Y
 Y
 Y
-Y
+d
 Y
 Y
 Y
@@ -12285,7 +12293,7 @@ H
 H
 Y
 Y
-Y
+d
 Y
 Y
 Y
@@ -12363,7 +12371,7 @@ Y
 Y
 Y
 Y
-Y
+d
 Y
 H
 H
@@ -13600,7 +13608,7 @@ Y
 Y
 Y
 Y
-Y
+d
 H
 H
 H
@@ -14898,7 +14906,7 @@ H
 H
 H
 Y
-Y
+d
 H
 H
 H
@@ -15843,7 +15851,7 @@ Y
 Y
 Y
 Y
-Y
+d
 Y
 Y
 Y
@@ -16489,7 +16497,7 @@ Y
 Y
 Y
 Y
-Y
+d
 H
 H
 H

--- a/maps/groundbase/southwilds/southwilds3.dmm
+++ b/maps/groundbase/southwilds/southwilds3.dmm
@@ -24,6 +24,14 @@
 "f" = (
 /turf/simulated/floor/outdoors/grass/seasonal/dark/notrees_nomobs_lowsnow,
 /area/submap/groundbase/poi/wildvillage/plot/square)
+"g" = (
+/obj/effect/landmark/wildlife/forest,
+/turf/simulated/floor/outdoors/grass/seasonal/notrees_nomobs_lowsnow,
+/area/submap/groundbase/wilderness/south/unexplored)
+"h" = (
+/obj/effect/landmark/wildlife/forest,
+/turf/simulated/floor/outdoors/grass/seasonal/dark/notrees_nomobs_lowsnow,
+/area/submap/groundbase/wilderness/south/unexplored)
 "j" = (
 /turf/simulated/floor/outdoors/grass/seasonal/dark/notrees_nomobs_lowsnow,
 /area/submap/groundbase/poi/wildvillage/plot/wide)
@@ -3286,7 +3294,7 @@ H
 H
 Y
 Y
-Y
+h
 H
 H
 c
@@ -3443,7 +3451,7 @@ c
 H
 H
 H
-H
+g
 H
 H
 H
@@ -4190,7 +4198,7 @@ H
 H
 H
 Y
-Y
+h
 Y
 H
 H
@@ -4244,7 +4252,7 @@ H
 H
 H
 Y
-Y
+h
 Y
 H
 c
@@ -5705,7 +5713,7 @@ c
 H
 H
 Y
-Y
+h
 H
 H
 H
@@ -6665,7 +6673,7 @@ c
 c
 H
 Y
-Y
+h
 H
 H
 c
@@ -6736,7 +6744,7 @@ Y
 Y
 Y
 Y
-Y
+h
 Y
 Y
 H
@@ -6784,7 +6792,7 @@ c
 c
 c
 H
-H
+g
 H
 c
 c
@@ -9012,7 +9020,7 @@ H
 H
 H
 H
-Y
+h
 Y
 Y
 Y
@@ -10305,7 +10313,7 @@ Y
 Y
 H
 Y
-Y
+h
 H
 H
 H
@@ -12186,7 +12194,7 @@ c
 H
 Y
 Y
-Y
+h
 Y
 Y
 H
@@ -15177,7 +15185,7 @@ Y
 Y
 Y
 H
-H
+g
 H
 H
 c
@@ -15368,7 +15376,7 @@ c
 H
 H
 H
-H
+g
 H
 H
 H
@@ -15965,7 +15973,7 @@ H
 H
 H
 H
-H
+g
 H
 H
 c

--- a/maps/groundbase/westwilds/westwilds1.dmm
+++ b/maps/groundbase/westwilds/westwilds1.dmm
@@ -1,4 +1,8 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"aa" = (
+/obj/effect/landmark/wildlife/forest,
+/turf/simulated/floor/outdoors/grass/seasonal/dark/notrees_nomobs_lowsnow,
+/area/submap/groundbase/wilderness/west/unexplored)
 "ab" = (
 /turf/simulated/wall,
 /area/groundbase/science/outpost/anomaly_testing)
@@ -999,7 +1003,7 @@
 	name = "Burn Chamber Air Control";
 	output_tag = "burn_out";
 	pressure_setting = 0;
-	sensors = list("burn_sensor"="Burn Chamber Sensor")
+	sensors = list("burn_sensor" = "Burn Chamber Sensor")
 	},
 /turf/simulated/floor/tiled/white,
 /area/groundbase/science/outpost/toxins_mixing)
@@ -2538,7 +2542,7 @@
 /obj/machinery/vending/phoronresearch{
 	dir = 8;
 	name = "Toximate 2556";
-	products = list(/obj/item/device/transfer_valve=3,/obj/item/device/assembly/timer=6,/obj/item/device/assembly/signaler=6,/obj/item/device/assembly/prox_sensor=6,/obj/item/device/assembly/igniter=12)
+	products = list(/obj/item/device/transfer_valve = 3, /obj/item/device/assembly/timer = 6, /obj/item/device/assembly/signaler = 6, /obj/item/device/assembly/prox_sensor = 6, /obj/item/device/assembly/igniter = 12)
 	},
 /turf/simulated/floor/tiled,
 /area/groundbase/science/outpost/toxins_lab)
@@ -7812,7 +7816,7 @@ kc
 kc
 kc
 kc
-kc
+aa
 kc
 ia
 ia
@@ -9391,7 +9395,7 @@ kc
 kc
 kc
 kc
-kc
+aa
 kc
 kc
 kc
@@ -9698,7 +9702,7 @@ kc
 kc
 kc
 kc
-kc
+aa
 kc
 kc
 kc
@@ -11558,7 +11562,7 @@ ia
 ia
 kc
 kc
-kc
+aa
 ia
 ia
 ia
@@ -12047,7 +12051,7 @@ kc
 kc
 kc
 kc
-kc
+aa
 kc
 kc
 kc
@@ -13510,7 +13514,7 @@ ia
 ia
 kc
 kc
-kc
+aa
 kc
 kc
 kc
@@ -14483,7 +14487,7 @@ kc
 kc
 kc
 kc
-kc
+aa
 kc
 ia
 ia
@@ -14801,7 +14805,7 @@ kc
 kc
 kc
 kc
-kc
+aa
 kc
 kc
 kc
@@ -15289,7 +15293,7 @@ Xk
 ia
 kc
 kc
-kc
+aa
 kc
 ia
 ia
@@ -16525,7 +16529,7 @@ ia
 ia
 kc
 kc
-kc
+aa
 kc
 kc
 kc
@@ -18918,7 +18922,7 @@ ia
 ia
 ia
 kc
-kc
+aa
 kc
 kc
 kc
@@ -20545,7 +20549,7 @@ ia
 ia
 kc
 kc
-kc
+aa
 kc
 kc
 kc
@@ -22550,7 +22554,7 @@ ia
 ia
 ia
 kc
-kc
+aa
 kc
 kc
 kc

--- a/maps/groundbase/westwilds/westwilds2.dmm
+++ b/maps/groundbase/westwilds/westwilds2.dmm
@@ -31,6 +31,18 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/groundbase/science/outpost/anomaly_lab)
+"ae" = (
+/obj/effect/landmark/wildlife/forest,
+/turf/simulated/floor/outdoors/grass/seasonal/notrees_nomobs_lowsnow,
+/area/submap/groundbase/wilderness/west/unexplored)
+"af" = (
+/obj/effect/landmark/wildlife/water,
+/turf/simulated/floor/water,
+/area/submap/groundbase/wilderness/west/unexplored)
+"ag" = (
+/obj/effect/landmark/wildlife/forest,
+/turf/simulated/floor/outdoors/grass/seasonal/dark/notrees_nomobs_lowsnow,
+/area/submap/groundbase/wilderness/west/unexplored)
 "am" = (
 /obj/machinery/atmospherics/pipe/simple/visible/blue{
 	dir = 9
@@ -7248,7 +7260,7 @@ YK
 YK
 nr
 nr
-nr
+ae
 nr
 nr
 nr
@@ -9076,7 +9088,7 @@ nr
 YK
 YK
 YK
-YK
+ag
 YK
 YK
 YK
@@ -9547,7 +9559,7 @@ YK
 YK
 YK
 YK
-YK
+ag
 YK
 YK
 nr
@@ -12181,7 +12193,7 @@ nr
 nr
 nr
 nr
-nr
+ae
 YK
 YK
 YK
@@ -12687,7 +12699,7 @@ YK
 YK
 YK
 YK
-YK
+ag
 YK
 YK
 YK
@@ -13764,7 +13776,7 @@ YK
 YK
 YK
 YK
-YK
+ag
 nr
 nr
 nr
@@ -14089,7 +14101,7 @@ YK
 YK
 YK
 YK
-YK
+ag
 YK
 YK
 YK
@@ -15817,7 +15829,7 @@ YK
 YK
 YK
 YK
-nr
+ae
 nr
 nr
 Zm
@@ -16201,7 +16213,7 @@ nr
 YK
 YK
 YK
-YK
+ag
 YK
 YK
 YK
@@ -16299,7 +16311,7 @@ DA
 DA
 DA
 DA
-DA
+af
 DA
 DA
 DA
@@ -19566,7 +19578,7 @@ nr
 nr
 YK
 YK
-YK
+ag
 YK
 YK
 YK
@@ -22212,7 +22224,7 @@ Wl
 nr
 YK
 YK
-YK
+ag
 nr
 nr
 nr

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -2243,6 +2243,7 @@
 #include "code\modules\events\prison_break.dm"
 #include "code\modules\events\radiation_storm.dm"
 #include "code\modules\events\random_antagonist.dm"
+#include "code\modules\events\roaming_wildlife.dm"
 #include "code\modules\events\rogue_drones.dm"
 #include "code\modules\events\shipping_error.dm"
 #include "code\modules\events\solar_storm.dm"


### PR DESCRIPTION
Less sudden swarm gank, more environmental hazard style event that is also more appropriate for map environment that is RP.
Landmarks for wildlife spawns are scattered around surrounding areas.
Can be both passive, hostile or retaliate.
Spawns different sets of creatures on land and in water.
Amount of both mobs and spawn locations depends on severity of event.
Can and will fight 'naturally occuring' RP wildlife. Shenanigans can occur.
Appears in all three severity tiers. Requires minimum of 1/2/3 sec officers for mundane/moderate/major versions to appear. Event chance scales with amount of security for mundane, and amount of security and medical for moderate and major. Mundane and moderate versions can occur multiple times per shift.