### PR TITLE
fixed Obengrad whitelist typo

### DIFF
--- a/config/alienwhitelist.txt
+++ b/config/alienwhitelist.txt
@@ -162,4 +162,4 @@ yeehawguvnah - Xenochimera
 zalvine - Shadekin Empathy
 zammyman215 - Vox
 zeracyfr - Xenochimera
-Obengrad - Diona
+obengrad - Diona

--- a/config/alienwhitelist.txt
+++ b/config/alienwhitelist.txt
@@ -88,6 +88,7 @@ mullins111 - Black-Eyed Shadekin
 natje - Xenochimera
 nerdass - Protean
 newyorks - Protean
+obengrad - Diona
 omegamech - Black-Eyed Shadekin
 oneofmanynames385 - Protean
 ontejbjoav - Black-Eyed Shadekin
@@ -162,4 +163,3 @@ yeehawguvnah - Xenochimera
 zalvine - Shadekin Empathy
 zammyman215 - Vox
 zeracyfr - Xenochimera
-obengrad - Diona


### PR DESCRIPTION
Apparently the whitelist being case sensitive is a thing, which I would've known if I had read it before modifying it.

https://forum.vore-station.net/viewtopic.php?f=46&t=2204