### PR TITLE
Adjusts janiborg auto-cleaning feature

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_modules/station.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules/station.dm
@@ -580,6 +580,7 @@ var/global/list/robot_modules = list(
 	src.modules += new /obj/item/weapon/soap/nanotrasen(src)
 	src.modules += new /obj/item/weapon/storage/bag/trash(src)
 	src.modules += new /obj/item/weapon/mop(src)
+	src.modules += new /obj/item/pupscrubber(src)
 	src.modules += new /obj/item/device/lightreplacer(src)
 	src.emag = new /obj/item/weapon/reagent_containers/spray(src)
 	src.emag.reagents.add_reagent("lube", 250)

--- a/code/modules/mob/living/silicon/robot/robot_movement.dm
+++ b/code/modules/mob/living/silicon/robot/robot_movement.dm
@@ -67,7 +67,7 @@
 		if(isturf(tile))
 			B.gather_all(tile, src, 1) //Shhh, unless the bag fills, don't spam the borg's chat with stuff that's going on every time they move!
 
-	if(istype(module, /obj/item/weapon/robot_module/robot/janitor) && isturf(loc))
+	if(scrubbing && isturf(loc))
 		var/turf/tile = loc
 		tile.clean_blood()
 		if (istype(tile, /turf/simulated))

--- a/code/modules/mob/living/silicon/robot/robot_vr.dm
+++ b/code/modules/mob/living/silicon/robot/robot_vr.dm
@@ -130,36 +130,6 @@
 		icon_state = "[module_sprites[icontype]]-wreck"
 		add_overlay("wreck-overlay")
 
-/mob/living/silicon/robot/Moved(atom/old_loc, direction, forced = FALSE)
-	. = ..()
-	if(scrubbing && isturf(loc) && water_res?.energy >= 1)
-		var/turf/tile = loc
-		water_res.use_charge(1)
-		tile.clean_blood()
-		if(istype(tile, /turf/simulated))
-			var/turf/simulated/T = tile
-			T.dirt = 0
-		for(var/A in tile)
-			if(istype(A,/obj/effect/rune) || istype(A,/obj/effect/decal/cleanable) || istype(A,/obj/effect/overlay))
-				qdel(A)
-			else if(istype(A, /mob/living/carbon/human))
-				var/mob/living/carbon/human/cleaned_human = A
-				if(cleaned_human.lying)
-					if(cleaned_human.head)
-						cleaned_human.head.clean_blood()
-						cleaned_human.update_inv_head(0)
-					if(cleaned_human.wear_suit)
-						cleaned_human.wear_suit.clean_blood()
-						cleaned_human.update_inv_wear_suit(0)
-					else if(cleaned_human.w_uniform)
-						cleaned_human.w_uniform.clean_blood()
-						cleaned_human.update_inv_w_uniform(0)
-					if(cleaned_human.shoes)
-						cleaned_human.shoes.clean_blood()
-						cleaned_human.update_inv_shoes(0)
-					cleaned_human.clean_blood(1)
-					to_chat(cleaned_human, "<span class='warning'>[src] cleans your face!</span>")
-
 /mob/living/silicon/robot/proc/vr_sprite_check()
 	if(custom_sprite == TRUE)
 		return


### PR DESCRIPTION
Regular janitor borgs now, just like Janihounds, have floor scrubebr tool that can be turned on or off, defaulting to off too; instead of cleaning floors naturally. If its turned on, it stays on while 'undeployed' so that should be an easy toggle. Mostly a way to allow regular janiborgs to disable their cleaning if they wish so.

Also on either hound or normal borg, floor scrubber no longer consumes any water and can be used freely and indefinitely.

Closes #14306 because this is being officiated as a feature.