### PR TITLE
Update whitelist on robolimbs_vr.dm

### DIFF
--- a/code/modules/organs/robolimbs_vr.dm
+++ b/code/modules/organs/robolimbs_vr.dm
@@ -50,7 +50,7 @@ var/const/cyberbeast_monitor_styles = "blank=cyber_blank;\
 	blood_color = "#ff6a00"
 	unavailable_to_build = 1
 	includes_tail = 1
-	whitelisted_to = list("silencedmp5a5")
+	whitelisted_to = list("silencedmp5a5", "cgr")
 
 /obj/item/weapon/disk/limb/white_kryten
 	company = "White Kryten Cybernetics"


### PR DESCRIPTION
Through a complete fluke over a year ago one of my characters came in possession of the White Kryten arms manufactured by an admin event roboticist. I eventually figured out they were actually fluff items and contacted SilencedMP5A5 about it, who gave the all clear on using them; I asked them again recently if I could be added to the whitelist. This is less about being able to add it to other characters and more being able to change the sleeve of the character who owns them, since changing species (even Human -> Custom Species) resets all limbs and would make me lose the body parts. 