### PR TITLE
adds a button for ingesting dogborg sleeper contents + couple other miscellaneous slightly related fixes

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_vr.dm
+++ b/code/modules/mob/living/silicon/robot/robot_vr.dm
@@ -87,6 +87,10 @@
 		return
 	return feed_grabbed_to_self(src,T)
 
+/mob/living/silicon/robot/lay_down()
+	 . = ..()
+	 updateicon()
+
 /mob/living/silicon/robot/proc/rest_style()
 	set name = "Switch Rest Style"
 	set category = "IC"


### PR DESCRIPTION
default is disposal now, which ejects it as normal
ingestion puts them in the current belly

before this, neither option made any difference whatsoever, the code didn't even actually use the eject_port for anything when ejecting

also fixes the laying down delay issue (lay down > three seconds later the sprite finally updates and lays down)
also fixes the fact that there was almost always a greyed out self clean button because the else statement was in the wrong spot
makes it so the buttons wrap around the window instead of being cut off so you don't have to constantly resize it