### PR TITLE
Add the fennec crown to the fluff items list

### DIFF
--- a/code/modules/client/preference_setup/loadout/loadout_fluffitems_vr.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_fluffitems_vr.dm
@@ -561,6 +561,13 @@
 	ckeywhitelist = list("jemli")
 	character_name = list("Jemli")
 
+/datum/gear/fluff/fen_crown
+	path = /obj/item/clothing/head/crown
+	display_name = "Princess Crown"
+	slot = slot_head
+	ckeywhitelist = list("jemli")
+	character_name = list("Princess Afenia")
+
 /datum/gear/fluff/jeremiah_holster
 	path = /obj/item/clothing/accessory/holster/armpit
 	display_name = "Ace's Holster"


### PR DESCRIPTION
Fluff item was approved back in 2020 but was never added to the spawning list. https://forum.vore-station.net/viewtopic.php?f=27&t=1733