### PR TITLE
[TEST FIRST] Miscellaneous ZAS Fixes and Optimizations!

### DIFF
--- a/code/ZAS/Fire.dm
+++ b/code/ZAS/Fire.dm
@@ -115,7 +115,7 @@ If it gains pressure too slowly, it may leak or just rupture instead of explodin
 	icon = 'icons/effects/fire.dmi'
 	icon_state = "1"
 	light_color = "#ED9200"
-	layer = TURF_LAYER
+	layer = GASFIRE_LAYER
 
 	var/firelevel = 1 //Calculated by gas_mixture.calculate_firelevel()
 

--- a/code/ZAS/Turf.dm
+++ b/code/ZAS/Turf.dm
@@ -1,3 +1,18 @@
+#define GET_ZONE_NEIGHBOURS(T, ret) \
+	ret = 0; \
+	if (T.zone) { \
+		for (var/_gzn_dir in GLOB.gzn_check) { \
+			var/turf/simulated/other = get_step(T, _gzn_dir); \
+			if (istype(other) && other.zone == T.zone) { \
+				var/block; \
+				ATMOS_CANPASS_TURF(block, other, T); \
+				if (!(block & AIR_BLOCKED)) { \
+					ret |= _gzn_dir; \
+				} \
+			} \
+		} \
+	}
+
 /turf/simulated/var/zone/zone
 /turf/simulated/var/open_directions
 
@@ -52,9 +67,8 @@
 */
 
 /turf/simulated/proc/can_safely_remove_from_zone()
-
-
-	if(!zone) return 1
+	if(!zone)
+		return TRUE
 
 	var/check_dirs = get_zone_neighbours(src)
 	var/unconnected_dirs = check_dirs
@@ -65,16 +79,25 @@
 	var/to_check = cornerdirs
 	#endif
 
-	for(var/dir in to_check)
+	//src is only connected to the zone by a single direction, this is a safe removal.
+	if (!(. & (. - 1)))
+		return TRUE
+
+	for(var/dir in GLOB.csrfz_check)
 		//for each pair of "adjacent" cardinals (e.g. NORTH and WEST, but not NORTH and SOUTH)
 		if((dir & check_dirs) == dir)
 			//check that they are connected by the corner turf
-			var/connected_dirs = get_zone_neighbours(get_step(src, dir))
-			if(connected_dirs && (dir & reverse_dir[connected_dirs]) == dir)
-				unconnected_dirs &= ~dir //they are, so unflag the cardinals in question
+			var/turf/simulated/T = get_step(src, dir)
+			if (!istype(T))
+				. &= ~dir
+				continue
 
-	//it is safe to remove src from the zone if all cardinals are connected by corner turfs
-	return !unconnected_dirs
+			var/connected_dirs
+			GET_ZONE_NEIGHBOURS(T, connected_dirs)
+			if(connected_dirs && (dir & GLOB.reverse_dir[connected_dirs]) == dir)
+				. &= ~dir //they are, so unflag the cardinals in question
+
+	return !.
 
 //helper for can_safely_remove_from_zone()
 /turf/simulated/proc/get_zone_neighbours(turf/simulated/T)
@@ -96,7 +119,8 @@
 		c_copy_air()
 		zone = null //Easier than iterating through the list at the zone.
 
-	var/s_block = c_airblock(src)
+	var/s_block
+	ATMOS_CANPASS_TURF(s_block, src, src)
 	if(s_block & AIR_BLOCKED)
 		#ifdef ZASDBG
 		if(verbose) to_world("Self-blocked.")
@@ -106,6 +130,7 @@
 			var/zone/z = zone
 
 			if(can_safely_remove_from_zone()) //Helps normal airlocks avoid rebuilding zones all the time
+				c_copy_air()
 				z.remove(src)
 			else
 				z.rebuild()

--- a/code/ZAS/Turf.dm
+++ b/code/ZAS/Turf.dm
@@ -72,7 +72,6 @@
 
 	var/check_dirs
 	GET_ZONE_NEIGHBOURS(src, check_dirs)
-	var/unconnected_dirs = check_dirs
 
 	//src is only connected to the zone by a single direction, this is a safe removal.
 	if (!(. & (. - 1)))

--- a/code/ZAS/Turf.dm
+++ b/code/ZAS/Turf.dm
@@ -70,14 +70,9 @@
 	if(!zone)
 		return TRUE
 
-	var/check_dirs = get_zone_neighbours(src)
+	var/check_dirs
+	GET_ZONE_NEIGHBOURS(src, check_dirs)
 	var/unconnected_dirs = check_dirs
-
-	#ifdef MULTIZAS
-	var/to_check = cornerdirsz
-	#else
-	var/to_check = cornerdirs
-	#endif
 
 	//src is only connected to the zone by a single direction, this is a safe removal.
 	if (!(. & (. - 1)))
@@ -97,21 +92,8 @@
 			if(connected_dirs && (dir & GLOB.reverse_dir[connected_dirs]) == dir)
 				. &= ~dir //they are, so unflag the cardinals in question
 
+	//it is safe to remove src from the zone if all cardinals are connected by corner turfs
 	return !.
-
-//helper for can_safely_remove_from_zone()
-/turf/simulated/proc/get_zone_neighbours(turf/simulated/T)
-	. = 0
-	if(istype(T) && T.zone)
-		#ifdef MULTIZAS
-		var/to_check = cardinalz
-		#else
-		var/to_check = cardinal
-		#endif
-		for(var/dir in to_check)
-			var/turf/simulated/other = get_step(T, dir)
-			if(istype(other) && other.zone == T.zone && !(other.c_airblock(T) & AIR_BLOCKED) && get_dist(src, other) <= 1)
-				. |= dir
 
 /turf/simulated/update_air_properties()
 

--- a/code/__defines/ZAS.dm
+++ b/code/__defines/ZAS.dm
@@ -11,3 +11,128 @@
 #define ATMOS_PASS_NO			2	// Never blocks air or zones.
 #define ATMOS_PASS_DENSITY		3	// Blocks air and zones if density = TRUE, allows both if density = FALSE
 #define ATMOS_PASS_PROC			4	// Call CanZASPass() using c_airblock
+
+#define NORTHUP (NORTH|UP)
+#define EASTUP (EAST|UP)
+#define SOUTHUP (SOUTH|UP)
+#define WESTUP (WEST|UP)
+#define NORTHDOWN (NORTH|DOWN)
+#define EASTDOWN (EAST|DOWN)
+#define SOUTHDOWN (SOUTH|DOWN)
+#define WESTDOWN (WEST|DOWN)
+
+#ifdef MULTIZAS
+
+GLOBAL_LIST_INIT(gzn_check, list(
+	NORTH,
+	SOUTH,
+	EAST,
+	WEST,
+	UP,
+	DOWN
+))
+
+GLOBAL_LIST_INIT(csrfz_check, list(
+	NORTHEAST,
+	NORTHWEST,
+	SOUTHEAST,
+	SOUTHWEST,
+	NORTHUP,
+	EASTUP,
+	WESTUP,
+	SOUTHUP,
+	NORTHDOWN,
+	EASTDOWN,
+	WESTDOWN,
+	SOUTHDOWN
+))
+
+#define ATMOS_CANPASS_TURF(ret,A,B) \
+	if (A.blocks_air & AIR_BLOCKED || B.blocks_air & AIR_BLOCKED) { \
+		ret = BLOCKED; \
+	} \
+	else if (B.z != A.z) { \
+		if (B.z < A.z) { \
+			ret = istype(A, /turf/simulated/open) ? ZONE_BLOCKED : BLOCKED; \
+		} \
+		else { \
+			ret = istype(B, /turf/simulated/open) ? ZONE_BLOCKED : BLOCKED; \
+		} \
+	} \
+	else if (A.blocks_air & ZONE_BLOCKED || B.blocks_air & ZONE_BLOCKED) { \
+		ret = (A.z == B.z) ? ZONE_BLOCKED : AIR_BLOCKED; \
+	} \
+	else if (A.contents.len) { \
+		ret = 0;\
+		for (var/thing in A) { \
+			var/atom/movable/AM = thing; \
+			switch (AM.can_atmos_pass) { \
+				if (ATMOS_PASS_YES) { \
+					continue; \
+				} \
+				if (ATMOS_PASS_DENSITY) { \
+					if (AM.density) { \
+						ret |= AIR_BLOCKED; \
+					} \
+				} \
+				if (ATMOS_PASS_PROC) { \
+					ret |= AM.c_airblock(B); \
+				} \
+				if (ATMOS_PASS_NO) { \
+					ret = BLOCKED; \
+				} \
+			} \
+			if (ret == BLOCKED) { \
+				break;\
+			}\
+		}\
+	}
+#else
+
+GLOBAL_LIST_INIT(csrfz_check, list(
+	NORTHEAST,
+	NORTHWEST,
+	SOUTHEAST,
+	SOUTHWEST
+))
+
+GLOBAL_LIST_INIT(gzn_check, list(
+	NORTH,
+	SOUTH,
+	EAST,
+	WEST
+))
+
+#define ATMOS_CANPASS_TURF(ret,A,B) \
+	if (A.blocks_air & AIR_BLOCKED || B.blocks_air & AIR_BLOCKED) { \
+		ret = BLOCKED; \
+	} \
+	else if (A.blocks_air & ZONE_BLOCKED || B.blocks_air & ZONE_BLOCKED) { \
+		ret = ZONE_BLOCKED; \
+	} \
+	else if (A.contents.len) { \
+		ret = 0;\
+		for (var/thing in A) { \
+			var/atom/movable/AM = thing; \
+			switch (AM.atmos_canpass) { \
+				if (ATMOS_PASS_YES) { \
+					continue; \
+				} \
+				if (ATMOS_PASS_DENSITY) { \
+					if (AM.density) { \
+						ret |= AIR_BLOCKED; \
+					} \
+				} \
+				if (ATMOS_PASS_PROC) { \
+					ret |= AM.c_airblock(B); \
+				} \
+				if (ATMOS_PASS_NO) { \
+					ret = BLOCKED; \
+				} \
+			} \
+			if (ret == BLOCKED) { \
+				break;\
+			}\
+		}\
+	}
+#endif

--- a/code/__defines/_planes+layers.dm
+++ b/code/__defines/_planes+layers.dm
@@ -71,6 +71,7 @@ What is the naming convention for planes or layers?
 	#define UNDERWATER_LAYER	2.5 // Anything on this layer will render under the water layer.
 	#define WATER_LAYER			3.0 // Layer for water overlays.
 	#define ABOVE_TURF_LAYER	3.1	// Snow and wallmounted/floormounted equipment
+	#define GASFIRE_LAYER		5.05 // Any gas fires that occur use this layer.
 #define DECAL_PLANE				-44 // Permanent decals
 	#define DECAL_LAYER			10
 #define DIRTY_PLANE				-43 // Nonpermanent decals

--- a/code/modules/admin/verbs/mapping.dm
+++ b/code/modules/admin/verbs/mapping.dm
@@ -199,7 +199,7 @@ var/list/debug_verbs = list (
 	var/icon/yellow = new('icons/misc/debug_group.dmi', "yellow")
 
 	for(var/turf/T in Z.contents)
-		images += image(yellow, T, "zasdebug", TURF_LAYER)
+		images += image(yellow, T, "zasdebug", PLANE_ADMIN2)
 		testZAScolors_turfs += T
 	for(var/connection_edge/zone/edge in Z.edges)
 		var/zone/connected = edge.get_connected_zone(Z)
@@ -235,7 +235,7 @@ var/list/debug_verbs = list (
 
 	testZAScolors_zones += location.zone
 	for(var/turf/T in location.zone.contents)
-		images += image(green, T,"zasdebug", TURF_LAYER)
+		images += image(green, T,"zasdebug", PLANE_ADMIN2)
 		testZAScolors_turfs += T
 	for(var/connection_edge/zone/edge in location.zone.edges)
 		var/zone/Z = edge.get_connected_zone(location.zone)
@@ -254,7 +254,7 @@ var/list/debug_verbs = list (
 			continue
 		if(T in testZAScolors_turfs)
 			continue
-		images += image(red, T, "zasdebug", TURF_LAYER)
+		images += image(red, T, "zasdebug", PLANE_ADMIN2)
 		testZAScolors_turfs += T
 
 /client/proc/testZAScolors_remove()

--- a/code/modules/admin/verbs/mapping.dm
+++ b/code/modules/admin/verbs/mapping.dm
@@ -241,7 +241,7 @@ var/list/debug_verbs = list (
 		var/zone/Z = edge.get_connected_zone(location.zone)
 		testZAScolors_zones += Z
 		for(var/turf/T in Z.contents)
-			images += image(blue, T,"zasdebug",TURF_LAYER)
+			images += image(blue, T,"zasdebug", PLANE_ADMIN2)
 			testZAScolors_turfs += T
 		for(var/connection_edge/zone/z_edge in Z.edges)
 			var/zone/connected = z_edge.get_connected_zone(Z)

--- a/code/modules/xgm/xgm_gas_data.dm
+++ b/code/modules/xgm/xgm_gas_data.dm
@@ -40,17 +40,25 @@
 		gas_data.specific_heat[gas.id] = gas.specific_heat
 		gas_data.molar_mass[gas.id] = gas.molar_mass
 		if(gas.tile_overlay)
-			gas_data.tile_overlay[gas.id] = new /atom/movable/gas_visuals(null, gas.tile_overlay)
-		if(gas.overlay_limit)	
+			gas_data.tile_overlay[gas.id] = gas.tile_overlay
+		if(gas.overlay_limit)
 			gas_data.overlay_limit[gas.id] = gas.overlay_limit
 		gas_data.flags[gas.id] = gas.flags
 
 	return 1
 
-/atom/movable/gas_visuals
+/obj/effect/gas_overlay
+	name = "gas"
+	desc = "You shouldn't be clicking this."
 	icon = 'icons/effects/tile_effects.dmi'
+	icon_state = "generic"
+	layer = GASFIRE_LAYER
+	appearance_flags = PIXEL_SCALE | RESET_COLOR
 	mouse_opacity = 0
-	plane = ABOVE_MOB_PLANE
-/atom/movable/gas_visuals/New(newloc, ico)
-	..()
-	icon_state = ico
+	var/gas_id
+
+/obj/effect/gas_overlay/Initialize(mapload, gas)
+	. = ..()
+	gas_id = gas
+	if(gas_data.tile_overlay[gas_id])
+		icon_state = gas_data.tile_overlay[gas_id]

--- a/code/modules/xgm/xgm_gas_mixture.dm
+++ b/code/modules/xgm/xgm_gas_mixture.dm
@@ -13,7 +13,7 @@
 	var/group_multiplier = 1
 
 	//List of active tile overlays for this gas_mixture.  Updated by check_tile_graphic()
-	var/list/graphic
+	var/list/graphic = list()
 
 	var/list/tile_overlay_cache
 

--- a/code/modules/xgm/xgm_gas_mixture.dm
+++ b/code/modules/xgm/xgm_gas_mixture.dm
@@ -338,7 +338,6 @@
 //Rechecks the gas_mixture and adjusts the graphic list if needed.
 //Two lists can be passed by reference if you need know specifically which graphics were added and removed.
 /datum/gas_mixture/proc/check_tile_graphic(list/graphic_add = null, list/graphic_remove = null)
-	var/list/cur_graphic = graphic // Cache for sanic speed
 	for(var/g in gas_data.overlay_limit)
 		//Overlay isn't applied for this gas, check if it's valid and needs to be added.
 		if(gas[g] > gas_data.overlay_limit[g])


### PR DESCRIPTION
So, ports  
`https://github.com/discordia-space/CEV-Eris/pull/7390`, `https://github.com/Baystation12/Baystation12/pull/32291` and `https://github.com/discordia-space/CEV-Eris/pull/1615`

In short:
- Fixes ZAS debug overlays not properly overlaying over everything they should. They use the ADMIN2 (15) layer now.
- Some minor weirdness fixes to logic.
- Makes gas overlays marginally less laggy by caching icons and using effects instead of atoms to render.
- Turns get_zone_neighbors into a define, saving precious performance on the extremely hot procs it's used on.
- Adds ATMOS_CANPASS_TURF, and replaces a couple of hot usages with it.

The performance uplift won't be amazing, but it should help with consistency at the very least.

Untested beyond compiling.