### PR TITLE
Minor spelling mistake

### DIFF
--- a/code/modules/client/preference_setup/loadout/loadout_accessories.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_accessories.dm
@@ -340,7 +340,7 @@
 /datum/gear/accessory/corpbadge
 	display_name = "investigator holobadge (IAA)"
 	path = /obj/item/clothing/accessory/badge/holo/investigator
-	allowed_roles = list("Internal affairs agent")
+	allowed_roles = list("Internal Affairs Agent")
 
 /datum/gear/accessory/pressbadge
 	display_name = "corporate press pass"


### PR DESCRIPTION
Should make it so that IAA's can take their special badge in the loadout & actually spawn with it, adjusts allowed_roles to be in-line with other job-locked items (namely by giving it proper capitalization).

Filthy web edit, but by all accounts should work fine.