### PR TITLE
Removes one comma

### DIFF
--- a/config/jukebox.json
+++ b/config/jukebox.json
@@ -3536,7 +3536,7 @@
 "artist": "Wesley Willis Fiasco",
 "secret": true,
 "lobby": false,
-"jukebox": true,
+"jukebox": true
 },
 {
 "url" : "https://cdn.discordapp.com/attachments/404660884531707906/676726491806957568/Cassette.mp3",


### PR DESCRIPTION
The jukebox was runtiming over this line, and VSC threw up an error about the comma, so, kill.