### PR TITLE
Buff Shadekin Empathy (And other hive languages)

### DIFF
--- a/code/modules/mob/language/language.dm
+++ b/code/modules/mob/language/language.dm
@@ -130,11 +130,27 @@
 /datum/language/proc/broadcast(var/mob/living/speaker,var/message,var/speaker_mask)
 	log_say("(HIVE) [message]", speaker)
 
+	speaker.verbs |= /mob/proc/adjust_hive_range	//VOREStation Add - If you don't have the verb you should.
+
 	if(!speaker_mask) speaker_mask = speaker.name
 	message = "[get_spoken_verb(message)], \"[format_message(message, get_spoken_verb(message))]\""
-
-	for(var/mob/player in player_list)
-		player.hear_broadcast(src, speaker, speaker_mask, message)
+	//VOREStation Edit Start
+	if(speaker.hive_lang_range == -1)
+		var/turf/t = get_turf(speaker)
+		for(var/mob/player in player_list)
+			var/turf/b = get_turf(player)
+			if (t.z == b.z)
+				player.hear_broadcast(src, speaker, speaker_mask, message)
+	else if(speaker.hive_lang_range)
+		var/turf/t = get_turf(speaker)
+		for(var/mob/player in player_list)
+			var/turf/b = get_turf(player)
+			if(get_dist(t,b) <= speaker.hive_lang_range)
+				player.hear_broadcast(src, speaker, speaker_mask, message)
+	else
+		for(var/mob/player in player_list)
+			player.hear_broadcast(src, speaker, speaker_mask, message)
+	//VOREStation Edit End
 
 /mob/proc/hear_broadcast(var/datum/language/language, var/mob/speaker, var/speaker_name, var/message)
 	if((language in languages) && language.check_special_condition(src))

--- a/code/modules/mob/language/language.dm
+++ b/code/modules/mob/language/language.dm
@@ -187,6 +187,11 @@
 		return 0
 
 	languages.Add(new_language)
+	//VOREStation Addition Start
+	if(new_language.flags & HIVEMIND)
+		verbs |= /mob/proc/adjust_hive_range
+	//VOREStation Addition End
+
 	return 1
 
 /mob/proc/remove_language(var/rem_language)

--- a/code/modules/mob/language/snowflake.dm
+++ b/code/modules/mob/language/snowflake.dm
@@ -1,12 +1,12 @@
 /mob
 	var/hive_lang_range = 0
 
-/mob/proc/shadekin_empathy_range()
-	set name = "Adjust Empathy Range"
-	set desc = "Changes the range you will transmit your empathy to!"
+/mob/proc/adjust_hive_range()
+	set name = "Adjust Language Range"
+	set desc = "Changes the range you will transmit your hive language to!"
 	set category = "IC"
 
-	var/option = tgui_alert(src, "What range?", "Adjust empathy range", list("Global","This Z level","Local", "Subtle"))
+	var/option = tgui_alert(src, "What range?", "Adjust language range", list("Global","This Z level","Local", "Subtle"))
 
 	switch(option)
 		if("Global")
@@ -21,7 +21,7 @@
 /datum/language/shadekin/broadcast(var/mob/living/speaker,var/message,var/speaker_mask)
 	log_say("(HIVE) [message]", speaker)
 
-	speaker.verbs |= /mob/proc/shadekin_empathy_range
+	speaker.verbs |= /mob/proc/adjust_hive_range
 
 	if(!speaker_mask) speaker_mask = speaker.name
 	message = "[get_spoken_verb(message)], \"[format_message(message, get_spoken_verb(message))]\""

--- a/code/modules/mob/language/snowflake.dm
+++ b/code/modules/mob/language/snowflake.dm
@@ -2,11 +2,11 @@
 	var/hive_lang_range = 0
 
 /mob/proc/adjust_hive_range()
-	set name = "Adjust Language Range"
+	set name = "Adjust Special Language Range"
 	set desc = "Changes the range you will transmit your hive language to!"
 	set category = "IC"
 
-	var/option = tgui_alert(src, "What range?", "Adjust language range", list("Global","This Z level","Local", "Subtle"))
+	var/option = tgui_alert(src, "What range?", "Adjust special language range", list("Global","This Z level","Local", "Subtle"))
 
 	switch(option)
 		if("Global")
@@ -17,27 +17,3 @@
 			hive_lang_range = world.view
 		if("Subtle")
 			hive_lang_range = 1
-
-/datum/language/shadekin/broadcast(var/mob/living/speaker,var/message,var/speaker_mask)
-	log_say("(HIVE) [message]", speaker)
-
-	speaker.verbs |= /mob/proc/adjust_hive_range
-
-	if(!speaker_mask) speaker_mask = speaker.name
-	message = "[get_spoken_verb(message)], \"[format_message(message, get_spoken_verb(message))]\""
-
-	if(speaker.hive_lang_range == -1)
-		var/turf/t = get_turf(speaker)
-		for(var/mob/player in player_list)
-			var/turf/b = get_turf(player)
-			if (t.z == b.z)
-				player.hear_broadcast(src, speaker, speaker_mask, message)
-	else if(speaker.hive_lang_range)
-		var/turf/t = get_turf(speaker)
-		for(var/mob/player in player_list)
-			var/turf/b = get_turf(player)
-			if(get_dist(t,b) <= speaker.hive_lang_range)
-				player.hear_broadcast(src, speaker, speaker_mask, message)
-	else
-		for(var/mob/player in player_list)
-			player.hear_broadcast(src, speaker, speaker_mask, message)

--- a/code/modules/mob/language/snowflake.dm
+++ b/code/modules/mob/language/snowflake.dm
@@ -1,7 +1,7 @@
-mob
+/mob
 	var/hive_lang_range = 0
 
-mob/proc/shadekin_empathy_range()
+/mob/proc/shadekin_empathy_range()
 	set name = "Adjust Empathy Range"
 	set desc = "Changes the range you will transmit your empathy to!"
 	set category = "IC"

--- a/code/modules/mob/language/snowflake.dm
+++ b/code/modules/mob/language/snowflake.dm
@@ -1,0 +1,43 @@
+mob
+	var/hive_lang_range = 0
+
+mob/proc/shadekin_empathy_range()
+	set name = "Adjust Empathy Range"
+	set desc = "Changes the range you will transmit your empathy to!"
+	set category = "IC"
+
+	var/option = tgui_alert(src, "What range?", "Adjust empathy range", list("Global","This Z level","Local", "Subtle"))
+
+	switch(option)
+		if("Global")
+			hive_lang_range = 0
+		if("This Z level")
+			hive_lang_range = -1
+		if("Local")
+			hive_lang_range = world.view
+		if("Subtle")
+			hive_lang_range = 1
+
+/datum/language/shadekin/broadcast(var/mob/living/speaker,var/message,var/speaker_mask)
+	log_say("(HIVE) [message]", speaker)
+
+	speaker.verbs |= /mob/proc/shadekin_empathy_range
+
+	if(!speaker_mask) speaker_mask = speaker.name
+	message = "[get_spoken_verb(message)], \"[format_message(message, get_spoken_verb(message))]\""
+
+	if(speaker.hive_lang_range == -1)
+		var/turf/t = get_turf(speaker)
+		for(var/mob/player in player_list)
+			var/turf/b = get_turf(player)
+			if (t.z == b.z)
+				player.hear_broadcast(src, speaker, speaker_mask, message)
+	else if(speaker.hive_lang_range)
+		var/turf/t = get_turf(speaker)
+		for(var/mob/player in player_list)
+			var/turf/b = get_turf(player)
+			if(get_dist(t,b) <= speaker.hive_lang_range)
+				player.hear_broadcast(src, speaker, speaker_mask, message)
+	else
+		for(var/mob/player in player_list)
+			player.hear_broadcast(src, speaker, speaker_mask, message)

--- a/code/modules/mob/living/carbon/human/species/shadekin/shadekin.dm
+++ b/code/modules/mob/living/carbon/human/species/shadekin/shadekin.dm
@@ -21,7 +21,7 @@
 	unarmed_types = list(/datum/unarmed_attack/stomp, /datum/unarmed_attack/kick, /datum/unarmed_attack/claws/shadekin, /datum/unarmed_attack/bite/sharp/shadekin)
 	rarity_value = 15	//INTERDIMENSIONAL FLUFFERS
 
-	inherent_verbs = list(/mob/proc/shadekin_empathy_range)
+	inherent_verbs = list(/mob/proc/adjust_hive_range)
 
 	siemens_coefficient = 1
 	darksight = 10

--- a/code/modules/mob/living/carbon/human/species/shadekin/shadekin.dm
+++ b/code/modules/mob/living/carbon/human/species/shadekin/shadekin.dm
@@ -21,6 +21,8 @@
 	unarmed_types = list(/datum/unarmed_attack/stomp, /datum/unarmed_attack/kick, /datum/unarmed_attack/claws/shadekin, /datum/unarmed_attack/bite/sharp/shadekin)
 	rarity_value = 15	//INTERDIMENSIONAL FLUFFERS
 
+	inherent_verbs = list(/mob/proc/shadekin_empathy_range)
+
 	siemens_coefficient = 1
 	darksight = 10
 

--- a/code/modules/mob/living/carbon/human/species/station/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station.dm
@@ -557,7 +557,8 @@
 
 	inherent_verbs = list(
 		/mob/living/carbon/human/proc/diona_split_nymph,
-		/mob/living/carbon/human/proc/regenerate
+		/mob/living/carbon/human/proc/regenerate,
+		/mob/proc/adjust_hive_range	//VOREStation Add
 		)
 
 	warning_low_pressure = 50

--- a/code/modules/mob/living/carbon/human/species/station/station_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_vr.dm
@@ -454,7 +454,7 @@
 	unarmed_types = list(/datum/unarmed_attack/stomp, /datum/unarmed_attack/kick, /datum/unarmed_attack/claws, /datum/unarmed_attack/bite/sharp)
 	rarity_value = 5	//INTERDIMENSIONAL FLUFFERS
 
-	inherent_verbs = list(/mob/proc/shadekin_empathy_range)
+	inherent_verbs = list(/mob/proc/adjust_hive_range)
 
 	siemens_coefficient = 0
 	darksight = 10

--- a/code/modules/mob/living/carbon/human/species/station/station_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_vr.dm
@@ -454,6 +454,8 @@
 	unarmed_types = list(/datum/unarmed_attack/stomp, /datum/unarmed_attack/kick, /datum/unarmed_attack/claws, /datum/unarmed_attack/bite/sharp)
 	rarity_value = 5	//INTERDIMENSIONAL FLUFFERS
 
+	inherent_verbs = list(/mob/proc/shadekin_empathy_range)
+
 	siemens_coefficient = 0
 	darksight = 10
 

--- a/code/modules/mob/living/simple_mob/subtypes/vore/dominated_brain.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/dominated_brain.dm
@@ -154,6 +154,9 @@
 					langlist |= L.languages
 	if(langlist.len)
 		langlist -= languages
+		for(var/datum/language/L in langlist)
+			if(L.name == LANGUAGE_SHADEKIN)
+				verbs |= /mob/proc/shadekin_empathy_range
 		temp_languages |= langlist
 		languages |= langlist
 

--- a/code/modules/mob/living/simple_mob/subtypes/vore/dominated_brain.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/dominated_brain.dm
@@ -155,8 +155,8 @@
 	if(langlist.len)
 		langlist -= languages
 		for(var/datum/language/L in langlist)
-			if(L.name == LANGUAGE_SHADEKIN)
-				verbs |= /mob/proc/shadekin_empathy_range
+			if(L.flags & HIVEMIND)
+				verbs |= /mob/proc/adjust_hive_range
 		temp_languages |= langlist
 		languages |= langlist
 

--- a/code/modules/mob/living/simple_mob/subtypes/vore/shadekin/shadekin.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/shadekin/shadekin.dm
@@ -131,6 +131,8 @@
 
 	update_icon()
 
+	verbs |= /mob/proc/shadekin_empathy_range
+
 	return ..()
 
 /mob/living/simple_mob/shadekin/Destroy()

--- a/code/modules/mob/living/simple_mob/subtypes/vore/shadekin/shadekin.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/shadekin/shadekin.dm
@@ -131,7 +131,7 @@
 
 	update_icon()
 
-	verbs |= /mob/proc/shadekin_empathy_range
+	verbs |= /mob/proc/adjust_hive_range
 
 	return ..()
 

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -2748,6 +2748,7 @@
 #include "code\modules\mob\language\generic.dm"
 #include "code\modules\mob\language\language.dm"
 #include "code\modules\mob\language\outsider.dm"
+#include "code\modules\mob\language\snowflake.dm"
 #include "code\modules\mob\language\station.dm"
 #include "code\modules\mob\language\station_vr.dm"
 #include "code\modules\mob\language\synthetic.dm"


### PR DESCRIPTION
Gives you a verb called 'Adjust Special Language Range' if you have a hive language, that lets you set the range you want to send to.

Global - The current behavior and default, unlimited range
This Z - Only sends to people on the Z you are on
Local - Sends only to default view range
Subtle - Only adjacent

IF FOR WHATEVER REASON you have a hive language and don't have the verb, using the hive language once will add the verb to you. Just in case.

This way if you want to do empathy at your friend across the table and not invite every shadekin on the server to see what you're on about, now you can.
