### PR TITLE
Adds ability to customize discomfort

### DIFF
--- a/code/game/dna/dna2.dm
+++ b/code/game/dna/dna2.dm
@@ -118,6 +118,8 @@ var/global/list/datum/dna/gene/dna_genes[0]
 	var/custom_ask
 	var/custom_whisper
 	var/custom_exclaim
+	var/list/custom_heat = list()
+	var/list/custom_cold = list()
 	// VOREStation
 
 	// New stuff
@@ -144,6 +146,8 @@ var/global/list/datum/dna/gene/dna_genes[0]
 	new_dna.custom_ask=custom_ask //VOREStaton Edit
 	new_dna.custom_whisper=custom_whisper //VOREStaton Edit
 	new_dna.custom_exclaim=custom_exclaim //VOREStaton Edit
+	new_dna.custom_heat=custom_heat //VOREStation Edit
+	new_dna.custom_cold=custom_cold //VOREStation Edit
 	var/list/body_markings_genetic = (body_markings - body_marking_nopersist_list)
 	new_dna.body_markings=body_markings_genetic.Copy()
 	for(var/b=1;b<=DNA_SE_LENGTH;b++)
@@ -216,6 +220,8 @@ var/global/list/datum/dna/gene/dna_genes[0]
 	src.custom_ask = character.custom_ask
 	src.custom_whisper = character.custom_whisper
 	src.custom_exclaim = character.custom_exclaim
+	src.custom_heat = character.custom_heat
+	src.custom_cold = character.custom_cold
 
 	// +1 to account for the none-of-the-above possibility
 	SetUIValueRange(DNA_UI_EAR_STYLE,	ear_style + 1,     ear_styles_list.len  + 1,  1)

--- a/code/game/dna/dna2_helpers.dm
+++ b/code/game/dna/dna2_helpers.dm
@@ -244,6 +244,8 @@
 		H.custom_whisper = dna.custom_whisper
 		H.custom_exclaim = dna.custom_exclaim
 		H.species.blood_color = dna.blood_color
+		H.custom_heat = dna.custom_heat
+		H.custom_cold = dna.custom_cold
 		var/datum/species/S = H.species
 		S.produceCopy(dna.species_traits, H, dna.base_species)
 		// VOREStation Edit End

--- a/code/modules/client/preference_setup/vore/07_traits.dm
+++ b/code/modules/client/preference_setup/vore/07_traits.dm
@@ -15,6 +15,9 @@
 	var/custom_ask = null
 	var/custom_exclaim = null
 
+	var/list/custom_heat = list()
+	var/list/custom_cold = list()
+
 	var/list/pos_traits	= list()	// What traits they've selected for their custom species
 	var/list/neu_traits = list()
 	var/list/neg_traits = list()
@@ -47,6 +50,9 @@
 	S["custom_ask"]		>> pref.custom_ask
 	S["custom_exclaim"]	>> pref.custom_exclaim
 
+	S["custom_heat"]	>> pref.custom_heat
+	S["custom_cold"]	>> pref.custom_cold
+
 /datum/category_item/player_setup_item/vore/traits/save_character(var/savefile/S)
 	S["custom_species"]	<< pref.custom_species
 	S["custom_base"]	<< pref.custom_base
@@ -63,6 +69,9 @@
 	S["custom_whisper"]	<< pref.custom_whisper
 	S["custom_ask"]		<< pref.custom_ask
 	S["custom_exclaim"]	<< pref.custom_exclaim
+
+	S["custom_heat"]	<< pref.custom_heat
+	S["custom_cold"]	<< pref.custom_cold
 
 /datum/category_item/player_setup_item/vore/traits/sanitize_character()
 	if(!pref.pos_traits) pref.pos_traits = list()
@@ -137,6 +146,9 @@
 	character.custom_ask		= lowertext(trim(pref.custom_ask))
 	character.custom_whisper	= lowertext(trim(pref.custom_whisper))
 	character.custom_exclaim	= lowertext(trim(pref.custom_exclaim))
+	character.custom_heat = pref.custom_heat
+	character.custom_cold = pref.custom_cold
+
 
 	if(character.isSynthetic())	//Checking if we have a synth on our hands, boys.
 		pref.dirty_synth = 1
@@ -158,6 +170,8 @@
 		//Statistics for this would be nice
 		var/english_traits = english_list(new_S.traits, and_text = ";", comma_text = ";")
 		log_game("TRAITS [pref.client_ckey]/([character]) with: [english_traits]") //Terrible 'fake' key_name()... but they aren't in the same entity yet
+
+
 
 /datum/category_item/player_setup_item/vore/traits/content(var/mob/user)
 	. += "<b>Custom Species Name:</b> "
@@ -222,6 +236,14 @@
 	. += "<b>Custom Exclaim: </b>"
 	. += "<a href='?src=\ref[src];custom_exclaim=1'>Set Exclaim Verb</a>"
 	. += "(<a href='?src=\ref[src];reset_exclaim=1'>Reset</A>)"
+	. += "<br>"
+	. += "<b>Custom heat Discomfort: </b>"
+	. += "<a href='?src=\ref[src];custom_heat=1'>Set Heat Messages</a>"
+	. += "(<a href='?src=\ref[src];reset_heat=1'>Reset</A>)"
+	. += "<br>"
+	. += "<b>Custom Cold Discomfort: </b>"
+	. += "<a href='?src=\ref[src];custom_cold=1'>Set Cold Messages</a>"
+	. += "(<a href='?src=\ref[src];reset_cold=1'>Reset</A>)"
 	. += "<br>"
 
 /datum/category_item/player_setup_item/vore/traits/OnTopic(var/href,var/list/href_list, var/mob/user)
@@ -313,6 +335,63 @@
 			pref.custom_exclaim = exclaim_choice
 		return TOPIC_REFRESH
 
+	else if(href_list["custom_heat"])
+		var/numMessages = pref.custom_heat.len
+		if(numMessages > 0)
+			var/alert = tgui_alert(user, "Edit current messages or add a new one?","Selection",list("Edit","Add", "Cancel"))
+			switch(alert)
+				if("Edit")
+					var/list/indices = list()
+					var/i
+					for(i=1, i<= numMessages, i++)
+						indices.Add(i)
+					var/index = tgui_input_list(user,"Select a message to edit:","Select Message", indices)
+					var/new_message = sanitize(tgui_input_text(usr, "Currently editing : [pref.custom_heat[index]]","Heat Discomfort", null, 300), 300)
+					if(new_message)
+						pref.custom_heat[index] = new_message
+				if("Add")
+					if(numMessages >= 10)
+						tgui_alert_async(usr, "Can't add more messages!", "Error")
+						return TOPIC_REFRESH
+					else
+						var/new_message = sanitize(tgui_input_text(usr, "Adding a new heat discomfort message", "Heat Discomfort", null, 300), 300)
+						if(new_message)
+							pref.custom_heat.Add(new_message)
+		else
+			var/new_message = sanitize(tgui_input_text(usr, "Adding a custom heat discomfort message !!!Overrides defaults!!!", "Heat Discomfort", null, 300), 300)
+			if(new_message)
+				pref.custom_heat.Add(new_message)
+		return TOPIC_REFRESH
+
+	else if(href_list["custom_cold"])
+		var/numMessages = pref.custom_cold.len
+		if(numMessages > 0)
+			var/alert = tgui_alert(user, "Edit current messages or add a new one?","Selection",list("Edit","Add", "Cancel"))
+			switch(alert)
+				if("Edit")
+					var/list/indices = list()
+					var/i
+					for(i=1, i<= numMessages, i++)
+						indices.Add(i)
+					var/index = tgui_input_list(user,"Select a message to edit:","Select Message", indices)
+					var/new_message = sanitize(tgui_input_text(usr, "Currently editing : [pref.custom_cold[index]]", "Custom Cold Discomfort", null, 300), 300)
+					if(new_message)
+						pref.custom_cold[index] = new_message
+				if("Add")
+					if(numMessages >= 10)
+						tgui_alert_async(usr, "Can't add more messages!", "Error")
+						return TOPIC_REFRESH
+					else
+						var/new_message = sanitize(tgui_input_text(usr, "Adding a new cold discomfort message", "Cold Discomfort", null, 300), 300)
+						if(new_message)
+							pref.custom_cold.Add(new_message)
+		else
+			var/new_message = sanitize(tgui_input_text(usr, "Adding a custom cold discomfort message !!!Overrides Defaults!!!","Cold Discomfort", null, 300), 300)
+			if(new_message)
+				pref.custom_cold.Add(new_message)
+		return TOPIC_REFRESH
+
+
 	else if(href_list["reset_say"])
 		var/say_choice = tgui_alert(usr, "Reset your Custom Say Verb?","Reset Verb",list("Yes","No"))
 		if(say_choice == "Yes")
@@ -335,6 +414,18 @@
 		var/exclaim_choice = tgui_alert(usr, "Reset your Custom Exclaim Verb?","Reset Verb",list("Yes","No"))
 		if(exclaim_choice == "Yes")
 			pref.custom_exclaim = null
+		return TOPIC_REFRESH
+
+	else if(href_list["reset_cold"])
+		var/cold_choice = tgui_alert(usr, "Reset your Custom Cold Discomfort messages?", "Reset Discomfort",list("Yes","No"))
+		if(cold_choice == "Yes")
+			pref.custom_cold = list()
+		return TOPIC_REFRESH
+
+	else if(href_list["reset_heat"])
+		var/heat_choice = tgui_alert(usr, "Reset your Custom Heat Discomfort messages?", "Reset Discomfort",list("Yes","No"))
+		if(heat_choice == "Yes")
+			pref.custom_heat = list()
 		return TOPIC_REFRESH
 
 	else if(href_list["add_trait"])

--- a/code/modules/client/preference_setup/vore/07_traits.dm
+++ b/code/modules/client/preference_setup/vore/07_traits.dm
@@ -337,13 +337,14 @@
 
 	else if(href_list["custom_heat"])
 		tgui_alert(user, "You are setting custom heat messages. These will overwrite your species' defaults. To return to defaults, click reset.")
-		var/new_message = sanitize(tgui_input_text(usr,"Use double enter between messages to enter a new one. Must be at least 3 characters long, 160 characters max and up to 10 messages are allowed.","Heat Discomfort messages",pref.custom_cold.Join("\n\n"), multiline= TRUE, prevent_enter = TRUE), MAX_MESSAGE_LEN,0,0,0)
+		var/old_message = pref.custom_heat.Join("\n\n")
+		var/new_message = sanitize(tgui_input_text(usr,"Use double enter between messages to enter a new one. Must be at least 3 characters long, 160 characters max and up to 10 messages are allowed.","Heat Discomfort messages",old_message, multiline= TRUE, prevent_enter = TRUE), MAX_MESSAGE_LEN,0,0,0)
 		if(length(new_message) > 0)
 			var/list/raw_list = splittext(new_message,"\n\n")
 			if(raw_list.len > 10)
 				raw_list.Cut(11)
 			for(var/i = 1, i <= raw_list.len, i++)
-				if(raw_list.len < 3 || raw_list.len > 160)
+				if(length(raw_list[i]) < 3 || length(raw_list[i]) > 160)
 					raw_list.Cut(i,i)
 				else
 					raw_list[i] = readd_quotes(raw_list[i])
@@ -353,13 +354,14 @@
 
 	else if(href_list["custom_cold"])
 		tgui_alert(user, "You are setting custom cold messages. These will overwrite your species' defaults. To return to defaults, click reset.")
-		var/new_message = sanitize(tgui_input_text(usr,"Use double enter between messages to enter a new one. Must be at least 3 characters long, 160 characters max and up to 10 messages are allowed.","Cold Discomfort messages",pref.custom_cold.Join("\n\n"), multiline= TRUE, prevent_enter = TRUE), MAX_MESSAGE_LEN,0,0,0)
+		var/old_message = pref.custom_heat.Join("\n\n")
+		var/new_message = sanitize(tgui_input_text(usr,"Use double enter between messages to enter a new one. Must be at least 3 characters long, 160 characters max and up to 10 messages are allowed.","Cold Discomfort messages",old_message, multiline= TRUE, prevent_enter = TRUE), MAX_MESSAGE_LEN,0,0,0)
 		if(length(new_message) > 0)
 			var/list/raw_list = splittext(new_message,"\n\n")
 			if(raw_list.len > 10)
 				raw_list.Cut(11)
 			for(var/i = 1, i <= raw_list.len, i++)
-				if(raw_list.len < 3 || raw_list.len > 160)
+				if(length(raw_list[i]) < 3 || length(raw_list[i]) > 160)
 					raw_list.Cut(i,i)
 				else
 					raw_list[i] = readd_quotes(raw_list[i])

--- a/code/modules/client/preference_setup/vore/07_traits.dm
+++ b/code/modules/client/preference_setup/vore/07_traits.dm
@@ -336,59 +336,35 @@
 		return TOPIC_REFRESH
 
 	else if(href_list["custom_heat"])
-		var/numMessages = pref.custom_heat.len
-		if(numMessages > 0)
-			var/alert = tgui_alert(user, "Edit current messages or add a new one?","Selection",list("Edit","Add", "Cancel"))
-			switch(alert)
-				if("Edit")
-					var/list/indices = list()
-					var/i
-					for(i=1, i<= numMessages, i++)
-						indices.Add(i)
-					var/index = tgui_input_list(user,"Select a message to edit:","Select Message", indices)
-					var/new_message = sanitize(tgui_input_text(usr, "Currently editing : [pref.custom_heat[index]]","Heat Discomfort", null, 300), 300)
-					if(new_message)
-						pref.custom_heat[index] = new_message
-				if("Add")
-					if(numMessages >= 10)
-						tgui_alert_async(usr, "Can't add more messages!", "Error")
-						return TOPIC_REFRESH
-					else
-						var/new_message = sanitize(tgui_input_text(usr, "Adding a new heat discomfort message", "Heat Discomfort", null, 300), 300)
-						if(new_message)
-							pref.custom_heat.Add(new_message)
-		else
-			var/new_message = sanitize(tgui_input_text(usr, "Adding a custom heat discomfort message !!!Overrides defaults!!!", "Heat Discomfort", null, 300), 300)
-			if(new_message)
-				pref.custom_heat.Add(new_message)
+		tgui_alert(user, "You are setting custom heat messages. These will overwrite your species' defaults. To return to defaults, click reset.")
+		var/new_message = sanitize(tgui_input_text(usr,"Use double enter between messages to enter a new one. Must be at least 3 characters long, 160 characters max and up to 10 messages are allowed.","Heat Discomfort messages",pref.custom_cold.Join("\n\n"), multiline= TRUE, prevent_enter = TRUE), MAX_MESSAGE_LEN,0,0,0)
+		if(length(new_message) > 0)
+			var/list/raw_list = splittext(new_message,"\n\n")
+			if(raw_list.len > 10)
+				raw_list.Cut(11)
+			for(var/i = 1, i <= raw_list.len, i++)
+				if(raw_list.len < 3 || raw_list.len > 160)
+					raw_list.Cut(i,i)
+				else
+					raw_list[i] = readd_quotes(raw_list[i])
+			ASSERT(raw_list.len <= 10)
+			pref.custom_heat = raw_list
 		return TOPIC_REFRESH
 
 	else if(href_list["custom_cold"])
-		var/numMessages = pref.custom_cold.len
-		if(numMessages > 0)
-			var/alert = tgui_alert(user, "Edit current messages or add a new one?","Selection",list("Edit","Add", "Cancel"))
-			switch(alert)
-				if("Edit")
-					var/list/indices = list()
-					var/i
-					for(i=1, i<= numMessages, i++)
-						indices.Add(i)
-					var/index = tgui_input_list(user,"Select a message to edit:","Select Message", indices)
-					var/new_message = sanitize(tgui_input_text(usr, "Currently editing : [pref.custom_cold[index]]", "Custom Cold Discomfort", null, 300), 300)
-					if(new_message)
-						pref.custom_cold[index] = new_message
-				if("Add")
-					if(numMessages >= 10)
-						tgui_alert_async(usr, "Can't add more messages!", "Error")
-						return TOPIC_REFRESH
-					else
-						var/new_message = sanitize(tgui_input_text(usr, "Adding a new cold discomfort message", "Cold Discomfort", null, 300), 300)
-						if(new_message)
-							pref.custom_cold.Add(new_message)
-		else
-			var/new_message = sanitize(tgui_input_text(usr, "Adding a custom cold discomfort message !!!Overrides Defaults!!!","Cold Discomfort", null, 300), 300)
-			if(new_message)
-				pref.custom_cold.Add(new_message)
+		tgui_alert(user, "You are setting custom cold messages. These will overwrite your species' defaults. To return to defaults, click reset.")
+		var/new_message = sanitize(tgui_input_text(usr,"Use double enter between messages to enter a new one. Must be at least 3 characters long, 160 characters max and up to 10 messages are allowed.","Cold Discomfort messages",pref.custom_cold.Join("\n\n"), multiline= TRUE, prevent_enter = TRUE), MAX_MESSAGE_LEN,0,0,0)
+		if(length(new_message) > 0)
+			var/list/raw_list = splittext(new_message,"\n\n")
+			if(raw_list.len > 10)
+				raw_list.Cut(11)
+			for(var/i = 1, i <= raw_list.len, i++)
+				if(raw_list.len < 3 || raw_list.len > 160)
+					raw_list.Cut(i,i)
+				else
+					raw_list[i] = readd_quotes(raw_list[i])
+			ASSERT(raw_list.len <= 10)
+			pref.custom_cold = raw_list
 		return TOPIC_REFRESH
 
 

--- a/code/modules/mob/living/carbon/human/species/species_getters.dm
+++ b/code/modules/mob/living/carbon/human/species/species_getters.dm
@@ -90,10 +90,18 @@
 	*/
 
 	var/discomfort_message
+	var/list/custom_cold = H.custom_cold
+	var/list/custom_heat = H.custom_heat
 	if(msg_type == ENVIRONMENT_COMFORT_MARKER_COLD && length(cold_discomfort_strings) /*&& !covered*/)
-		discomfort_message = pick(cold_discomfort_strings)
+		if(custom_cold.len > 0)
+			discomfort_message = pick(custom_cold)
+		else
+			discomfort_message = pick(cold_discomfort_strings)
 	else if(msg_type == ENVIRONMENT_COMFORT_MARKER_HOT && length(heat_discomfort_strings) /*&& covered*/)
-		discomfort_message = pick(heat_discomfort_strings)
+		if(custom_heat.len > 0)
+			discomfort_message = pick(custom_heat)
+		else
+			discomfort_message = pick(heat_discomfort_strings)
 
 	if(discomfort_message && prob(5))
 		to_chat(H, SPAN_DANGER(discomfort_message))

--- a/code/modules/mob/living/living_defines_vr.dm
+++ b/code/modules/mob/living/living_defines_vr.dm
@@ -11,3 +11,6 @@
 	var/custom_ask = null
 	var/custom_exclaim = null
 	var/custom_whisper = null
+//custom temperature discomfort vars
+	var/list/custom_heat = list()
+	var/list/custom_cold = list()


### PR DESCRIPTION
Both pre-made and custom species may now choose up to 10 messages each for warnings while overheated or cold.

If there are no custom messages, game falls back to defaults (which, if the pre-baked species lacks fluff, uses human)

There is a way to reset to defaults.

It is possible to go back and edit any of the 10 messages. The editor shows you the previously set message with an option to cancel out (this avoids over-writing the previous message).