### PR TITLE
sanitizes selection of custom bases in prefs

### DIFF
--- a/code/modules/client/preference_setup/vore/07_traits.dm
+++ b/code/modules/client/preference_setup/vore/07_traits.dm
@@ -31,9 +31,9 @@
 	var/list/choices
 	var/datum/species/spec = GLOB.all_species[new_species]
 	if (spec.selects_bodytype == SELECTS_BODYTYPE_SHAPESHIFTER)
-		choices = spec.get_valid_shapeshifter_forms()
+		choices = spec.get_valid_shapeshifter_forms().Copy()
 	else if (spec.selects_bodytype == SELECTS_BODYTYPE_CUSTOM)
-		choices = GLOB.custom_species_bases
+		choices = GLOB.custom_species_bases.Copy()
 		if(new_species != SPECIES_CUSTOM)
 			choices = (choices | new_species)
 	return choices

--- a/code/modules/client/preference_setup/vore/07_traits.dm
+++ b/code/modules/client/preference_setup/vore/07_traits.dm
@@ -31,7 +31,8 @@
 	var/list/choices
 	var/datum/species/spec = GLOB.all_species[new_species]
 	if (spec.selects_bodytype == SELECTS_BODYTYPE_SHAPESHIFTER)
-		choices = spec.get_valid_shapeshifter_forms().Copy()
+		choices = spec.get_valid_shapeshifter_forms()
+		choices = choices.Copy()
 	else if (spec.selects_bodytype == SELECTS_BODYTYPE_CUSTOM)
 		choices = GLOB.custom_species_bases.Copy()
 		if(new_species != SPECIES_CUSTOM)


### PR DESCRIPTION
fixes #14382

(also actually enables *correct* body type selection for proteans, because I forgot about a shapeshifter check)