### PR TITLE
Fixes NIF repair tool using up nanopaste when full

### DIFF
--- a/code/game/objects/items/devices/advnifrepair.dm
+++ b/code/game/objects/items/devices/advnifrepair.dm
@@ -24,7 +24,7 @@
 /obj/item/device/nifrepairer/attackby(obj/W, mob/user)
 	if(istype(W,/obj/item/stack/nanopaste))
 		var/obj/item/stack/nanopaste/np = W
-		if(np.use(1) && supply.get_free_space() >= efficiency)
+		if((supply.get_free_space() >= efficiency) && np.use(1))
 			to_chat(user, "<span class='notice'>You convert some nanopaste into programmed nanites inside \the [src].</span>")
 			supply.add_reagent(id = "nifrepairnanites", amount = efficiency)
 			update_icon()


### PR DESCRIPTION
There was an unreported bug that was discovered yesterday while I was playing.

When using nanopaste on an adv. nif repair tool, you should only be able to expend 4 charges to hit the 60 maximum.

Unfortunately, the code was written in a way that used up the nanopaste charge before checking if the repair tool was actually full. This had the consequence of wasting up to 4 whole charges of nanopaste if you click too quickly.

~~Replaced "use(1)" proc with "(get_amount()". Only using "use(1) after confirming we have free space left.~~


Per maintainer advice, dropped get_amount() and just moved the np.use(1) to the right side of the if() check. Works.

