### PR TITLE
adds admin ghost privacy override preference

### DIFF
--- a/code/modules/admin/admin_verb_lists_vr.dm
+++ b/code/modules/admin/admin_verb_lists_vr.dm
@@ -19,7 +19,8 @@ var/list/admin_verbs_default = list(
 //	/client/proc/deadchat				//toggles deadchat on/off,
 //	/client/proc/toggle_ahelp_sound,
 	/client/proc/toggle_admin_global_looc,
-	/client/proc/toggle_admin_deadchat
+	/client/proc/toggle_admin_deadchat,
+	/client/proc/toggle_admin_ghost_privacy
 	)
 
 var/list/admin_verbs_admin = list(

--- a/code/modules/client/preference_setup/global/setting_datums.dm
+++ b/code/modules/client/preference_setup/global/setting_datums.dm
@@ -420,7 +420,13 @@ var/list/_client_preferences_by_type
 	key = "CHAT_RLOOC"
 	enabled_description = "Show"
 	disabled_description = "Hide"
-
+//VOREStation edit
+/datum/client_preference/holder/show_subtles
+	description ="Admin ghost privacy override"
+	key = "CHAT_HSUBTLES"
+	enabled_description = "Enabled"
+	disabled_description = "Disabled"
+//VOREStation edit end
 /datum/client_preference/holder/show_staff_dsay
 	description ="Staff Deadchat"
 	key = "CHAT_ADSAY"

--- a/code/modules/client/preferences_vr.dm
+++ b/code/modules/client/preferences_vr.dm
@@ -120,3 +120,18 @@
 	SScharacter_setup.queue_preferences_save(prefs)
 
 	feedback_add_details("admin_verb", "TSoundMentorhelps")
+
+//General
+/client/proc/toggle_admin_ghost_privacy()
+	set name = "Toggle Admin Hidden Subtles"
+	set category = "Preferences"
+	set desc = "Toggles seeing subtles/whispers for clients with the ghost privacy option on."
+
+	var/pref_path = /datum/client_preference/holder/show_subtles
+
+	if(holder)
+		toggle_preference(pref_path)
+		to_chat(src,"You will [ (is_preference_enabled(pref_path)) ? "now" : "no longer"] hear see ghost privacy hidden subtles/whispers.")
+		SScharacter_setup.queue_preferences_save(prefs)
+
+	feedback_add_details("admin_verb","TAHiddenSubtles") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!

--- a/code/modules/mob/hear_say.dm
+++ b/code/modules/mob/hear_say.dm
@@ -62,7 +62,7 @@
 	else
 		return stars(SP.message)
 
-/mob/proc/hear_say(var/list/message_pieces, var/verb = "says", var/italics = 0, var/mob/speaker = null, var/sound/speech_sound, var/sound_vol)
+/mob/proc/hear_say(var/list/message_pieces, var/verb = "says", var/italics = 0, var/mob/speaker = null, var/sound/speech_sound, var/sound_vol, var/admin_heard_anyway) //VOREStation edit: admin ghost privacy override toggle
 	if(!client && !teleop)
 		return FALSE
 
@@ -118,7 +118,7 @@
 			to_chat(src, "<span class='filter_say'><span class='name'>[speaker_name]</span>[speaker.GetAltName()] makes a noise, possibly speech, but you cannot hear them.</span>")
 	else
 		var/message_to_send = null
-		message_to_send = "<span class='game say'><span class='name'>[speaker_name]</span>[speaker.GetAltName()] [track][message]</span>"
+		message_to_send = "<span class='game say'>[admin_heard_anyway ? "<b>(H)</b> " : ""]<span class='name'>[speaker_name]</span>[speaker.GetAltName()] [track][message]</span>" //VOREStation edit: admin ghost privacy override toggle
 		if(check_mentioned(multilingual_to_message(message_pieces)) && is_preference_enabled(/datum/client_preference/check_mention))
 			message_to_send = "<font size='3'><b>[message_to_send]</b></font>"
 

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -359,7 +359,8 @@ var/list/channel_to_radio_key = new
 
 			if(M && src) //If we still exist, when the spawn processes
 				//VOREStation Add - Ghosts don't hear whispers
-				if(whispering && !is_preference_enabled(/datum/client_preference/whisubtle_vis) && isobserver(M) && !M.client?.holder)
+				var/admin_heard_anyway = isobserver(M) && ((!whispering || is_preference_enabled(/datum/client_preference/whisubtle_vis)) ? FALSE : (M.client?.holder && M.client?.is_preference_enabled(/datum/client_preference/holder/show_subtles)))
+				if(whispering && !is_preference_enabled(/datum/client_preference/whisubtle_vis) && isobserver(M) && !(M.client?.holder && M.client?.is_preference_enabled(/datum/client_preference/holder/show_subtles)))
 					M.show_message("<span class='game say'><span class='name'>[src.name]</span> [w_not_heard].</span>", 2)
 					return
 				//VOREStation Add End
@@ -368,7 +369,7 @@ var/list/channel_to_radio_key = new
 				var/runechat_enabled = M.client?.is_preference_enabled(/datum/client_preference/runechat_mob)
 
 				if(dst <= message_range || (M.stat == DEAD && !forbid_seeing_deadchat)) //Inside normal message range, or dead with ears (handled in the view proc)
-					if(M.hear_say(message_pieces, verb, italics, src, speech_sound, sound_vol))
+					if(M.hear_say(message_pieces, verb, italics, src, speech_sound, sound_vol, admin_heard_anyway)) //VOREStation edit: admins overriding ghost privacy toggle
 						if(M.client && !runechat_enabled)
 							var/image/I1 = listening[M] || speech_bubble
 							images_to_clients[I1] |= M.client

--- a/code/modules/mob/living/silicon/pai/pai_vr.dm
+++ b/code/modules/mob/living/silicon/pai/pai_vr.dm
@@ -504,8 +504,9 @@
 		if (istype(G, /mob/new_player))
 			continue
 		else if(isobserver(G) && G.is_preference_enabled(/datum/client_preference/ghost_ears))
-			if(is_preference_enabled(/datum/client_preference/whisubtle_vis) || G.client.holder)
-				to_chat(G, "<span class='cult'>[src.name]'s screen prints, \"[message]\"</span>")
+			var/admin_heard_anyway = !is_preference_enabled(/datum/client_preference/whisubtle_vis) && (G.client.holder && G.client.is_preference_enabled(/datum/client_preference/holder/show_subtles))
+			if(is_preference_enabled(/datum/client_preference/whisubtle_vis) || (G.client.holder && G.client.is_preference_enabled(/datum/client_preference/holder/show_subtles)))
+				to_chat(G, "<span class='cult'>[admin_heard_anyway ? "<b>(H)</b> " : ""][src.name]'s screen prints, \"[message]\"</span>")
 
 /mob/living/silicon/pai/proc/touch_window(soft_name)	//This lets us touch TGUI procs and windows that may be nested behind other TGUI procs and windows
 	if(stat != CONSCIOUS)								//so we can access our software without having to open up the software interface TGUI window


### PR DESCRIPTION
adds a preference so that admins can toggle whether they can hear ghost privacy hidden whispers/subtles anyway (they could already by the way, this just makes it so they can turn it off)

also makes it so that when ghost privacy is overridden it prepends a "(H)" to the message (for "hidden")