### PR TITLE
Adds Food Stuffer trait

### DIFF
--- a/code/modules/food/food/snacks.dm
+++ b/code/modules/food/food/snacks.dm
@@ -91,6 +91,8 @@
 
 	if(istype(M, /mob/living/carbon))
 		//TODO: replace with standard_feed_mob() call.
+		var/swallow_whole = FALSE
+		var/obj/belly/belly_target				// These are surprise tools that will help us later
 
 		var/fullness = M.nutrition + (M.reagents.get_reagent_amount("nutriment") * 25)
 		if(M == user)								//If you're eating it yourself
@@ -151,6 +153,12 @@
 						unconcious = TRUE
 						blocked = H.check_mouth_coverage()
 
+				if(isliving(user))	// We definitely are, but never hurts to check
+					var/mob/living/L = user
+					swallow_whole = L.stuffing_feeder
+				if(swallow_whole)
+					belly_target = M.vore_selected
+
 				if(unconcious)
 					to_chat(user, "<span class='warning'>You can't feed [H] through \the [blocked] while they are unconcious!</span>")
 					return
@@ -159,21 +167,44 @@
 					to_chat(user, "<span class='warning'>\The [blocked] is in the way!</span>")
 					return
 
-				user.visible_message("<span class='danger'>[user] attempts to feed [M] [src].</span>")
+				if(swallow_whole)
+					if(!(M.feeding))
+						to_chat(user, "<span class='warning'>You can't feed [H] a whole [src] as they refuse to be fed whole things!</span>")
+						return
+					if(!belly_target)
+						to_chat(user, "<span class='warning'>You can't feed [H] a whole [src] as they don't appear to have a belly to fit it!</span>")
+						return
+
+				if(swallow_whole)
+					user.visible_message("<span class='danger'>[user] attempts to make [M] consume [src] whole into their [belly_target].</span>")
+				else
+					user.visible_message("<span class='danger'>[user] attempts to feed [M] [src].</span>")
+
+				var/feed_duration = 3 SECONDS
+				if(swallow_whole)
+					feed_duration = 5 SECONDS
 
 				user.setClickCooldown(user.get_attack_speed(src))
-				if(!do_mob(user, M)) return
+				if(!do_mob(user, M, feed_duration)) return
 
-				//Do we really care about this
-				add_attack_logs(user,M,"Fed with [src.name] containing [reagentlist(src)]", admin_notify = FALSE)
+				if(swallow_whole && !belly_target) return			// Just in case we lost belly mid-feed
 
-				user.visible_message("<span class='danger'>[user] feeds [M] [src].</span>")
+				if(swallow_whole)
+					add_attack_logs(user,M,"Whole-fed with [src.name] containing [reagentlist(src)] into [belly_target]", admin_notify = FALSE)
+					user.visible_message("<span class='danger'>[user] successfully forces [src] into [M]'s [belly_target].</span>")
+				else
+					add_attack_logs(user,M,"Fed with [src.name] containing [reagentlist(src)]", admin_notify = FALSE)
+					user.visible_message("<span class='danger'>[user] feeds [M] [src].</span>")
 
 			else
 				to_chat(user, "This creature does not seem to have a mouth!")
 				return
 
-		if(reagents)								//Handle ingestion of the reagent.
+		if(swallow_whole)
+			user.drop_item()
+			forceMove(belly_target)
+			return 1
+		else if(reagents)								//Handle ingestion of the reagent.
 			playsound(M,'sound/items/eatfood.ogg', rand(10,50), 1)
 			if(reagents.total_volume)
 				if(reagents.total_volume > bitesize)

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
@@ -138,6 +138,16 @@
 	..(S,H)
 	H.verbs |= /mob/living/carbon/human/proc/slime_feed
 
+/datum/trait/neutral/stuffing_feeder
+	name = "Food Stuffer"
+	desc = "Allows you to feed food to other people whole, rather than bite by bite."
+	cost = 0
+	custom_only = FALSE
+
+/datum/trait/neutral/stuffing_feeder/apply(var/datum/species/S,var/mob/living/carbon/human/H)
+	..(S,H)
+	H.verbs |= /mob/living/proc/toggle_stuffing_mode
+
 /datum/trait/neutral/hard_vore
 	name = "Brutal Predation"
 	desc = "Allows you to tear off limbs & tear out internal organs."
@@ -424,7 +434,7 @@
 	cost = 0
 	custom_only = FALSE
 	var_changes = list("chem_strength_alcohol" = 1.5)
-	
+
 /datum/trait/neutral/alcohol_tolerance_reset
 	name = "Liver of Unremarkableness"
 	desc = "This trait exists to reset alcohol (in)tolerance for non-custom species to baseline normal. It can only be taken by Skrell, Tajara, Unathi, Diona, and Prometheans, as it would have no effect on other species."

--- a/code/modules/vore/eating/living_vr.dm
+++ b/code/modules/vore/eating/living_vr.dm
@@ -42,6 +42,7 @@
 	var/can_be_drop_pred = FALSE
 	var/allow_spontaneous_tf = FALSE	// Obviously.
 	var/next_preyloop					// For Fancy sound internal loop
+	var/stuffing_feeder = FALSE			// Can feed foods to others whole, like trash eater can eat them on their own.
 	var/adminbus_trash = FALSE			// For abusing trash eater for event shenanigans.
 	var/adminbus_eat_minerals = FALSE	// This creature subsists on a diet of pure adminium.
 	var/vis_height = 32					// Sprite height used for resize features.
@@ -1018,6 +1019,14 @@
 
 	else //Not the droids we're looking for.
 		to_chat(src, "<span class='notice'>You pause for a moment to examine [I] and realize it's not even worth the energy to chew.</span>") //If it ain't ore or the type of sheets we can eat, bugger off!
+
+/mob/living/proc/toggle_stuffing_mode()
+	set name = "Toggle feeding mode"
+	set category = "Abilities"
+	set desc = "Switch whether you will try to feed other people food whole or normally, bite by bite."
+
+	stuffing_feeder = !stuffing_feeder
+	to_chat(src, "<span class='notice'>You will [stuffing_feeder ? "now" : "no longer"] try to feed food whole.</span>")
 
 /mob/living/proc/switch_scaling()
 	set name = "Switch scaling mode"


### PR DESCRIPTION
The trait gives you a new toggle in Abilities tab. It toggles your feeding mode, which always starts as default - current behaviour. You can toggle it to feeding whole. This allows you to feed food items (and ONLY food items) whole to people into bellies, akin to trash eater, under same conditions as normal feeding, but with slightly longer windup.