### PR TITLE
Some runtime fixes

### DIFF
--- a/code/controllers/subsystems/xenoarch.dm
+++ b/code/controllers/subsystems/xenoarch.dm
@@ -31,13 +31,13 @@ SUBSYSTEM_DEF(xenoarch)
 
 /datum/controller/subsystem/xenoarch/proc/SetupXenoarch()
 	for(var/turf/simulated/mineral/M in world)
-		if(!M.density || (M.z in using_map.xenoarch_exempt_levels))
+		if(!M.density)
 			continue
 
 		if(isnull(M.geologic_data))
 			M.geologic_data = new /datum/geosample(M)
 
-		if(!prob(XENOARCH_SPAWN_CHANCE))
+		if((M.z in using_map.xenoarch_exempt_levels) || !prob(XENOARCH_SPAWN_CHANCE))
 			continue
 
 		var/farEnough = 1

--- a/code/modules/emotes/definitions/audible_scream_vr.dm
+++ b/code/modules/emotes/definitions/audible_scream_vr.dm
@@ -1,12 +1,13 @@
 /decl/emote/audible/scream/get_emote_sound(var/atom/user)
-	var/mob/living/carbon/human/H = user
-	if(H.get_gender() == FEMALE)
-		return list(
-			"sound" = H.species.female_scream_sound,
-			"vol" = emote_volume
-		)
-	else
-		return list(
-			"sound" = H.species.male_scream_sound,
-			"vol" = emote_volume
-		)
+	if(ishuman(user))
+		var/mob/living/carbon/human/H = user
+		if(H.get_gender() == FEMALE)
+			return list(
+				"sound" = H.species.female_scream_sound,
+				"vol" = emote_volume
+			)
+		else
+			return list(
+				"sound" = H.species.male_scream_sound,
+				"vol" = emote_volume
+			)

--- a/code/modules/food/food/snacks.dm
+++ b/code/modules/food/food/snacks.dm
@@ -1132,10 +1132,11 @@
 		to_chat(user, "<span class='notice'>The heating chemicals have already been spent.</span>")
 		return
 	has_been_heated = 1
-	user.visible_message("<span class='notice'>[user] crushes \the [src] package.</span>", "You crush \the [src] package and feel a comfortable heat build up.")
+	user.visible_message("<span class='notice'>[user] crushes \the [src] package.</span>", "You crush \the [src] package and feel a comfortable heat build up. Now just to wait for it to be ready.")
 	spawn(200)
-		to_chat(user, "You think \the [src] is ready to eat about now.")
-		heat()
+		if(src && src.loc == user)
+			to_chat(user, "You think \the [src] is ready to eat about now.")
+			heat()
 
 /obj/item/weapon/reagent_containers/food/snacks/brainburger
 	name = "brainburger"

--- a/code/modules/food/food/snacks.dm
+++ b/code/modules/food/food/snacks.dm
@@ -1134,8 +1134,9 @@
 	has_been_heated = 1
 	user.visible_message("<span class='notice'>[user] crushes \the [src] package.</span>", "You crush \the [src] package and feel a comfortable heat build up. Now just to wait for it to be ready.")
 	spawn(200)
-		if(src && src.loc == user)
-			to_chat(user, "You think \the [src] is ready to eat about now.")
+		if(src)
+			if(src.loc == user)
+				to_chat(user, "You think \the [src] is ready to eat about now.")
 			heat()
 
 /obj/item/weapon/reagent_containers/food/snacks/brainburger

--- a/code/modules/mob/living/carbon/human/species/species_getters.dm
+++ b/code/modules/mob/living/carbon/human/species/species_getters.dm
@@ -93,12 +93,12 @@
 	var/list/custom_cold = H.custom_cold
 	var/list/custom_heat = H.custom_heat
 	if(msg_type == ENVIRONMENT_COMFORT_MARKER_COLD && length(cold_discomfort_strings) /*&& !covered*/)
-		if(custom_cold.len > 0)
+		if(custom_cold && custom_cold.len > 0)
 			discomfort_message = pick(custom_cold)
 		else
 			discomfort_message = pick(cold_discomfort_strings)
 	else if(msg_type == ENVIRONMENT_COMFORT_MARKER_HOT && length(heat_discomfort_strings) /*&& covered*/)
-		if(custom_heat.len > 0)
+		if(custom_heat && custom_heat.len > 0)
 			discomfort_message = pick(custom_heat)
 		else
 			discomfort_message = pick(heat_discomfort_strings)


### PR DESCRIPTION
Fixes runtime with heat/cold messages being missing

Fixes runtime with digging on xenoarch exempt levels

Fixes runtime with silicons using *scream

Fixes runtime with eating a sin pocket before its been fully heated (and adjusts its message to properly convey need to wait)