### PR TITLE
Fixes mobs falling asleep when fainting

### DIFF
--- a/code/modules/emotes/definitions/visible.dm
+++ b/code/modules/emotes/definitions/visible.dm
@@ -116,7 +116,7 @@
 
 /decl/emote/visible/faint/do_extra(var/mob/user)
 	. = ..()
-	if(istype(user) && !user.sleeping)
+	if(iscarbon(user) && !user.sleeping)
 		user.Sleeping(10)
 
 /decl/emote/visible/frown


### PR DESCRIPTION
Fixes #14407

Making mobs tick down sleep would be a bit annoying but thats not a status theyre supposed to have anyway so makes them not get it from fainting.