### PR TITLE
add epic player burrito justice to gray goo list

### DIFF
--- a/config/alienwhitelist.txt
+++ b/config/alienwhitelist.txt
@@ -16,6 +16,7 @@ beyondmylife - Protean
 bothnevarbackwards - Diona
 bricker98 - Protean
 bricker98 - Black-Eyed Shadekin
+burritojustice - Protean
 camanis - Protean
 cameron653 - Protean
 cgr - Protean


### PR DESCRIPTION
Protean whitelist approval reflected here: https://forum.vore-station.net/viewtopic.php?f=46&t=2222

Probably, anyways. I'm not logged into the forum so maybe I was actually called stinky and did not, in fact, get the WL.

also I edited this file through github because I'm too lazy to clone