### PR TITLE
Removes R_STEALTH perm requirement for staff chats

### DIFF
--- a/code/modules/admin/verbs/adminsay.dm
+++ b/code/modules/admin/verbs/adminsay.dm
@@ -2,7 +2,7 @@
 	set category = "Special Verbs"
 	set name = "Asay" //Gave this shit a shorter name so you only have to time out "asay" rather than "admin say" to use it --NeoFite
 	set hidden = 1
-	if(!check_rights(R_ADMIN|R_STEALTH)) //VOREStation Edit
+	if(!check_rights(R_ADMIN)) //VOREStation Edit
 		return
 
 	msg = sanitize(msg)
@@ -11,11 +11,9 @@
 
 	log_adminsay(msg,src)
 
-	//VOREStation Edit Start - Adds R_STEALTH
 	for(var/client/C in GLOB.admins)
-		if(check_rights(R_ADMIN|R_STEALTH))
+		if(check_rights(R_ADMIN))
 			to_chat(C, "<span class='admin_channel'>" + create_text_tag("admin", "ADMIN:", C) + " <span class='name'>[key_name(usr, 1)]</span>([admin_jump_link(mob, src)]): <span class='message'>[msg]</span></span>")
-	//VOREStation Edit End
 
 	feedback_add_details("admin_verb","M") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
@@ -24,7 +22,7 @@
 	set name = "Msay"
 	set hidden = 1
 
-	if(!check_rights(R_ADMIN|R_MOD|R_SERVER|R_STEALTH)) //VOREStation Edit
+	if(!check_rights(R_ADMIN|R_MOD|R_SERVER)) //VOREStation Edit
 		return
 
 	msg = sanitize(msg)
@@ -37,7 +35,7 @@
 	if(check_rights(R_ADMIN, 0))
 		sender_name = "<span class='admin'>[sender_name]</span>"
 	for(var/client/C in GLOB.admins)
-		if(check_rights(R_ADMIN|R_MOD|R_SERVER|R_STEALTH)) //VOREStation Edit
+		if(check_rights(R_ADMIN|R_MOD|R_SERVER)) //VOREStation Edit
 			to_chat(C, "<span class='mod_channel'>" + create_text_tag("mod", "MOD:", C) + " <span class='name'>[sender_name]</span>([admin_jump_link(mob, C.holder)]): <span class='message'>[msg]</span></span>")
 
 	feedback_add_details("admin_verb","MS") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
@@ -47,7 +45,7 @@
 	set name = "Esay"
 	set hidden = 1
 
-	if(!check_rights(R_ADMIN|R_MOD|R_EVENT|R_SERVER|R_STEALTH)) //VOREStation Edit
+	if(!check_rights(R_ADMIN|R_MOD|R_EVENT|R_SERVER)) //VOREStation Edit
 		return
 
 	msg = sanitize(msg)


### PR DESCRIPTION
Does exactly what it says on the tin.

Removes staff with just R_STEALTH from being able to see:
Admin Chat
Moderator Chat
E Chat (I am not even sure if this is used. I don't even know what this chat is.)

This shouldn't effect any roles except for Retired Admin.