### PR TITLE
Fixes player tips becoming spammy past 75 minutes

### DIFF
--- a/code/modules/player_tips_vr/player_tips_controller_vr.dm
+++ b/code/modules/player_tips_vr/player_tips_controller_vr.dm
@@ -30,6 +30,7 @@ Controlled by the player_tips subsystem under code/controllers/subsystems/player
 				to_chat(M, SPAN_NOTICE("[tip]"))
 
 		last_tip = tip
+		last_tip_time = world.time
 		tip_delay = rand(min_tip_delay, max_tip_delay)
 
 


### PR DESCRIPTION
Sorry about this one. Was not obvious when testing with only 1-2 minute delays.

