### PR TITLE
Makes player tips track CKeys to inform how to turn them off.

### DIFF
--- a/code/modules/player_tips_vr/player_tips_controller_vr.dm
+++ b/code/modules/player_tips_vr/player_tips_controller_vr.dm
@@ -11,6 +11,7 @@ Controlled by the player_tips subsystem under code/controllers/subsystems/player
 	var/tip_delay = 5 MINUTES //10 minute initial delay for first tip of the day. Timer starts 5 minutes after game starts, plus 5 minutes here. Gets overwritten afterwards
 	var/last_tip_time = 0
 	var/last_tip = null
+	var/list/HasReceived = list() //Tracking who received tips. We let them know how to turn them off if they're not on this list. Stores CKeys until round-end.
 
 //Called every 5 minutes as defined in the subsystem.
 /datum/player_tips/proc/send_tips()
@@ -25,8 +26,9 @@ Controlled by the player_tips subsystem under code/controllers/subsystems/player
 
 		for(var/mob/M in player_list)
 			if(M.is_preference_enabled(/datum/client_preference/player_tips))
-				if(!last_tip) //Notifying players how to turn tips off, or call them on-demand in a personalized manner.
+				if(!(M.mind.key in HasReceived))
 					to_chat(M, SPAN_WARNING("You have periodic player tips enabled. You may turn them off at any time with the Toggle Receiving Player Tips verb in Preferences, or in character set up under the OOC tab!\n Player tips appear every 45-75 minutes."))
+					HasReceived.Add(M.mind.key)
 				to_chat(M, SPAN_NOTICE("[tip]"))
 
 		last_tip = tip


### PR DESCRIPTION
After checking if the player wants tips, we check their CKey against a list.

If their CKey is not in the list, we let them know that they got tips turned ON and inform them how to turn them OFF. Afterwards, we store their CKey and send the tip of the hour.

CKey is retained until something resets the /datum/player_tips vars, which should only happen on round-end. 
This ensures swapping characters, being digested and resleeved or anything destroying your mob won't cause you to fall off the list.

If their CKey is on the list, we proceed with the random tip of the hour. 