### PR TITLE
Fixes runtime from mobs without minds

### DIFF
--- a/code/modules/player_tips_vr/player_tips_controller_vr.dm
+++ b/code/modules/player_tips_vr/player_tips_controller_vr.dm
@@ -16,6 +16,8 @@ Controlled by the player_tips subsystem under code/controllers/subsystems/player
 //Called every 5 minutes as defined in the subsystem.
 /datum/player_tips/proc/send_tips()
 	if(world.time > last_tip_time + tip_delay)
+		last_tip_time = world.time
+		tip_delay = rand(min_tip_delay, max_tip_delay)
 		var/tip = pick_tip("none") //"none" picks a random topic of advice.
 		var/stopWhile = 0
 		while(tip == last_tip) //Prevent posting the same tip twice in a row if possible, but don't force it.
@@ -23,17 +25,13 @@ Controlled by the player_tips subsystem under code/controllers/subsystems/player
 			stopWhile = stopWhile + 1
 			if(stopWhile >= 10)
 				break
-
+		last_tip = tip
 		for(var/mob/M in player_list)
 			if(M.is_preference_enabled(/datum/client_preference/player_tips))
-				if(!(M.mind.key in HasReceived))
+				if(!M.key && !(M.key in HasReceived))
 					to_chat(M, SPAN_WARNING("You have periodic player tips enabled. You may turn them off at any time with the Toggle Receiving Player Tips verb in Preferences, or in character set up under the OOC tab!\n Player tips appear every 45-75 minutes."))
-					HasReceived.Add(M.mind.key)
+					HasReceived.Add(M.key)
 				to_chat(M, SPAN_NOTICE("[tip]"))
-
-		last_tip = tip
-		last_tip_time = world.time
-		tip_delay = rand(min_tip_delay, max_tip_delay)
 
 
 


### PR DESCRIPTION
Unfortunately, I did not test things as an observer long enough to notice the runtime, focusing too much on avoiding repetition  of the "how to turn me off" if you resleeve/get digested/etc.

Unfortunately, this led to me missing that ghosts and potential other cases might have mobs which do not have a mind, causing the system to break and behave frustratingly.

This should fix it in 3 parts:

1. Making sure we save world.time as last_tip_time even if the player_list checking breaks. Likewise, we generate a new random number before the whole player_list check fires.
2. We retrieve the key var from the mob, rather than mob.mind. I didn't realize player_list had had entries of mobs that did not have minds, misunderstanding what "mind" refers to.
3. For safety, we only do anything with the mob.key var if it is not Null. If it's Null, we skip the whole list comparison and just send the tip without telling the player how to turn it off (or checking if they even need to be told). 