### PR TITLE
prevents persistent dirt (and other filth) from spawning in spess and walls

### DIFF
--- a/code/modules/persistence/effects/filth_vr.dm
+++ b/code/modules/persistence/effects/filth_vr.dm
@@ -4,6 +4,8 @@
 
 /datum/persistent/filth/CreateEntryInstance(var/turf/creating, var/list/token)
 	var/_path = token["path"]
+	if (isspace(creating) || iswall(creating))
+		return
 	if (saves_dirt)
 		new _path(creating, token["age"]+1, token["dirt"])
 	else

--- a/code/modules/persistence/effects/filth_vr.dm
+++ b/code/modules/persistence/effects/filth_vr.dm
@@ -4,7 +4,7 @@
 
 /datum/persistent/filth/CreateEntryInstance(var/turf/creating, var/list/token)
 	var/_path = token["path"]
-	if (isspace(creating) || iswall(creating))
+	if (isspace(creating) || iswall(creating) ||isopenspace(creating))
 		return
 	if (saves_dirt)
 		new _path(creating, token["age"]+1, token["dirt"])


### PR DESCRIPTION
a) build turf in spess/extend an old one
b) dirt
c) new round has spess dirt