### PR TITLE
ERT/Von Braun updates

### DIFF
--- a/maps/submaps/admin_use_vr/ert.dm
+++ b/maps/submaps/admin_use_vr/ert.dm
@@ -93,6 +93,10 @@
 	name = "\improper NRV Von Braun - Cannon Control Room"
 	icon_state = "security_sub"
 
+/area/ship/ert/brig
+	name = "\improper NRV Von Braun - Prisoner Holding Area"
+	icon_state = "brig"
+
 /area/shuttle/ert_ship_boat
 	name = "\improper NRB Robineau"
 	icon_state = "yellow"

--- a/maps/submaps/admin_use_vr/ert.dmm
+++ b/maps/submaps/admin_use_vr/ert.dmm
@@ -14,15 +14,71 @@
 /turf/simulated/floor/reinforced/airless,
 /area/ship/ert/barracks)
 "ac" = (
+/obj/effect/shuttle_landmark/premade/ert_ship_port,
+/turf/space,
+/area/space)
+"ad" = (
+/obj/machinery/light/no_nightshift,
+/obj/machinery/porta_turret/stationary/CIWS,
+/turf/simulated/floor/reinforced/airless,
+/area/ship/ert/barracks)
+"ae" = (
 /obj/machinery/light/no_nightshift,
 /obj/machinery/porta_turret/stationary/CIWS,
 /turf/simulated/floor/reinforced/airless,
 /area/ship/ert/dock_port)
-"ad" = (
+"af" = (
 /obj/structure/hull_corner,
 /turf/simulated/floor/reinforced/airless,
 /area/ship/ert/dock_port)
-"ae" = (
+"ag" = (
+/obj/machinery/door/airlock/external,
+/obj/effect/map_helper/airlock/door/ext_door,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/dock_port)
+"ah" = (
+/obj/structure/hull_corner{
+	dir = 8
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/ship/ert/barracks)
+"aj" = (
+/obj/machinery/power/pointdefense{
+	id_tag = "vonbraun_pd"
+	},
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/ship/ert/engine)
+"al" = (
+/obj/structure/hull_corner/long_horiz{
+	dir = 6
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/ship/ert/hallways_aft)
+"ap" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/door/blast/regular/open{
+	dir = 4;
+	id = "braun_blast_shields";
+	name = "Blast Shield"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/barracks)
+"aq" = (
+/obj/machinery/atmospherics/pipe/simple/visible,
+/obj/machinery/meter,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/atmos)
+"au" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/map_helper/airlock/door/ext_door,
 /obj/machinery/airlock_sensor/airlock_exterior{
@@ -33,252 +89,99 @@
 /obj/effect/map_helper/airlock/sensor/ext_sensor,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/dock_port)
-"af" = (
-/obj/machinery/light/no_nightshift,
-/turf/simulated/floor/reinforced/airless,
+"av" = (
+/turf/simulated/floor/tiled/techmaint,
 /area/ship/ert/mech_bay)
-"ag" = (
-/obj/machinery/power/pointdefense{
-	id_tag = "vonbraun_pd"
-	},
-/obj/structure/cable/yellow{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/ship/ert/mech_bay)
-"ah" = (
-/turf/simulated/floor/reinforced/airless,
-/area/ship/ert/mech_bay)
-"ai" = (
-/obj/machinery/porta_turret/stationary/CIWS,
-/turf/simulated/floor/reinforced/airless,
-/area/ship/ert/mech_bay)
-"aj" = (
-/obj/machinery/light/no_nightshift,
-/turf/simulated/floor/reinforced/airless,
-/area/ship/ert/engine)
-"ak" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 6
-	},
-/turf/simulated/wall/rshull,
-/area/ship/ert/dock_port)
-"al" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 8
-	},
-/obj/effect/map_helper/airlock/atmos/chamber_pump,
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/obj/structure/sign/vacuum{
-	pixel_x = -32
-	},
+"ay" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/gear_dispenser/suit/ert,
 /turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/dock_port)
-"am" = (
-/obj/machinery/airlock_sensor{
+/area/ship/ert/barracks)
+"aB" = (
+/obj/structure/hull_corner,
+/turf/simulated/floor/reinforced/airless,
+/area/ship/ert/barracks)
+"aC" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/wall/shull,
+/area/ship/ert/med_surg)
+"aD" = (
+/obj/item/weapon/circuitboard/aiupload,
+/obj/item/weapon/circuitboard/borgupload,
+/obj/item/weapon/circuitboard/smes,
+/obj/item/weapon/aiModule/nanotrasen,
+/obj/item/weapon/aiModule/reset,
+/obj/item/weapon/aiModule/freeformcore,
+/obj/item/weapon/aiModule/protectStation,
+/obj/item/weapon/aiModule/quarantine,
+/obj/item/weapon/aiModule/paladin,
+/obj/item/weapon/aiModule/robocop,
+/obj/item/weapon/aiModule/safeguard,
+/obj/structure/table/steel_reinforced,
+/obj/item/weapon/smes_coil,
+/obj/item/weapon/smes_coil,
+/obj/item/device/t_scanner/advanced{
+	pixel_x = -3
+	},
+/obj/item/device/t_scanner/advanced{
+	pixel_x = 3
+	},
+/obj/machinery/power/apc/hyper{
+	alarms_hidden = 1;
+	name = "VB APC - South";
+	pixel_y = -24
+	},
+/obj/structure/cable/yellow,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/eng_storage)
+"aE" = (
+/obj/structure/table/rack/steel,
+/obj/item/clothing/accessory/storage/black_vest{
+	pixel_x = -4;
+	pixel_y = -4
+	},
+/obj/item/clothing/accessory/storage/black_vest{
+	pixel_x = -2;
+	pixel_y = -2
+	},
+/obj/item/clothing/accessory/storage/black_vest,
+/obj/item/clothing/accessory/storage/black_vest{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/clothing/accessory/storage/black_vest{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/clothing/accessory/storage/black_vest{
+	pixel_x = 6;
+	pixel_y = 6
+	},
+/obj/machinery/power/apc/hyper{
+	alarms_hidden = 1;
+	dir = 4;
+	name = "VB APC - East";
 	pixel_x = 24
 	},
-/obj/effect/map_helper/airlock/sensor/chamber_sensor,
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/dock_port)
-"an" = (
-/obj/machinery/light/no_nightshift{
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/dispenser/oxygen,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/barracks)
-"ao" = (
-/obj/structure/table/rack/steel,
-/obj/item/weapon/tank/jetpack/oxygen{
-	pixel_x = -4;
-	pixel_y = -4
-	},
-/obj/item/weapon/tank/jetpack/oxygen{
-	pixel_x = -2;
-	pixel_y = -2
-	},
-/obj/item/weapon/tank/jetpack/oxygen,
-/obj/item/weapon/tank/jetpack/oxygen{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/item/weapon/tank/jetpack/oxygen{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/item/weapon/tank/jetpack/oxygen{
-	pixel_x = 6;
-	pixel_y = 6
-	},
+/obj/structure/cable/yellow,
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/barracks)
-"ap" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/effect/floor_decal/industrial/outline/blue,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/barracks)
-"aq" = (
-/obj/machinery/telecomms/relay,
-/turf/simulated/floor/tiled/techfloor,
+"aF" = (
+/obj/structure/hull_corner/long_horiz{
+	dir = 6
+	},
+/turf/simulated/floor/reinforced/airless,
 /area/ship/ert/atmos)
-"ar" = (
-/obj/structure/table/rack/steel,
-/obj/item/toy/plushie/squid/blue{
-	desc = "A small, cute and loveable squid friend. This one is blue. Despite the name, it seems no more or less deadly than your regular plush squid.";
-	name = "NT 'Deathsquid' Plushie"
-	},
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/item/device/mapping_unit/deathsquad,
-/obj/item/device/holomap_beacon/deathsquad,
-/obj/item/device/holomap_beacon/deathsquad,
-/obj/item/device/holomap_beacon/deathsquad,
-/obj/item/device/holomap_beacon/deathsquad,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/barracks)
-"as" = (
-/obj/machinery/light_switch{
-	pixel_y = 23
-	},
-/obj/structure/table/woodentable,
-/obj/item/device/flashlight/lamp,
-/obj/item/device/holomap_beacon/ert,
-/obj/item/device/holomap_beacon/ert,
-/obj/item/device/mapping_unit/ert,
-/turf/simulated/floor/wood,
-/area/ship/ert/commander)
-"at" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/wood,
-/area/ship/ert/commander)
-"au" = (
-/obj/machinery/light/no_nightshift{
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/table/rack/steel,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/item/weapon/rig/ert/medical,
-/obj/item/weapon/rig/ert/medical,
-/obj/item/weapon/rig/ert/medical,
-/obj/item/weapon/rig/ert/medical,
-/obj/item/weapon/rig/ert/medical,
-/obj/item/weapon/rig/ert/medical,
-/obj/item/clothing/suit/armor/vest/ert/medical,
-/obj/item/clothing/suit/armor/vest/ert/medical,
-/obj/item/clothing/suit/armor/vest/ert/medical,
-/obj/item/clothing/suit/armor/vest/ert/medical,
-/obj/item/clothing/suit/armor/vest/ert/medical,
-/obj/item/clothing/suit/armor/vest/ert/medical,
-/obj/item/clothing/head/helmet/ert/medical,
-/obj/item/clothing/head/helmet/ert/medical,
-/obj/item/clothing/head/helmet/ert/medical,
-/obj/item/clothing/head/helmet/ert/medical,
-/obj/item/clothing/head/helmet/ert/medical,
-/obj/item/clothing/head/helmet/ert/medical,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/barracks)
-"av" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/gunnery)
-"aw" = (
-/obj/structure/table/rack/steel,
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/item/clothing/mask/gas{
-	pixel_x = -4;
-	pixel_y = -4
-	},
-/obj/item/clothing/mask/gas{
-	pixel_x = -2;
-	pixel_y = -2
-	},
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/item/clothing/mask/gas{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/item/clothing/mask/gas{
-	pixel_x = 6;
-	pixel_y = 6
-	},
-/obj/item/clothing/mask/gas/half,
-/obj/item/clothing/mask/gas/half,
-/obj/item/clothing/mask/gas/half,
-/obj/item/clothing/mask/gas/half,
-/obj/item/clothing/mask/gas/half,
-/obj/item/clothing/mask/gas/half,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/barracks)
-"ax" = (
-/obj/structure/hull_corner{
-	dir = 8
-	},
-/turf/simulated/shuttle/plating/airless/carry,
-/area/shuttle/ert_ship_boat)
-"ay" = (
-/obj/structure/table/rack/steel,
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/item/clothing/mask/gas{
-	pixel_x = -4;
-	pixel_y = -4
-	},
-/obj/item/clothing/mask/gas{
-	pixel_x = -2;
-	pixel_y = -2
-	},
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/item/clothing/mask/gas{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/item/clothing/mask/gas{
-	pixel_x = 6;
-	pixel_y = 6
-	},
-/obj/item/clothing/shoes/magboots/adv,
-/obj/item/clothing/shoes/magboots/adv,
-/obj/item/clothing/shoes/magboots/adv,
-/obj/item/clothing/shoes/magboots/adv,
-/obj/item/clothing/shoes/magboots/adv,
-/obj/item/clothing/shoes/magboots/adv,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/barracks)
-"az" = (
+"aG" = (
+/obj/machinery/light/no_nightshift,
+/turf/simulated/floor/reinforced/airless,
+/area/ship/ert/mech_bay)
+"aH" = (
 /obj/structure/table/rack/steel,
 /obj/item/weapon/storage/backpack/ert/security{
 	pixel_y = -3
@@ -305,231 +208,21 @@
 /obj/item/clothing/suit/space/void/responseteam/security,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/barracks)
-"aA" = (
-/obj/structure/table/rack/steel,
-/obj/item/weapon/rig/ert/security,
-/obj/item/weapon/rig/ert/security,
-/obj/item/weapon/rig/ert/security,
-/obj/item/weapon/rig/ert/security,
-/obj/item/weapon/rig/ert/security,
-/obj/item/weapon/rig/ert/security,
-/obj/item/clothing/suit/armor/vest/ert/security,
-/obj/item/clothing/suit/armor/vest/ert/security,
-/obj/item/clothing/suit/armor/vest/ert/security,
-/obj/item/clothing/suit/armor/vest/ert/security,
-/obj/item/clothing/suit/armor/vest/ert/security,
-/obj/item/clothing/suit/armor/vest/ert/security,
-/obj/item/clothing/head/helmet/ert/security,
-/obj/item/clothing/head/helmet/ert/security,
-/obj/item/clothing/head/helmet/ert/security,
-/obj/item/clothing/head/helmet/ert/security,
-/obj/item/clothing/head/helmet/ert/security,
-/obj/item/clothing/head/helmet/ert/security,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/barracks)
-"aB" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/table/rack/steel,
-/obj/structure/table/rack/steel,
-/obj/item/weapon/storage/belt/utility/chief/full{
-	pixel_y = -2
-	},
-/obj/item/weapon/storage/belt/utility/chief/full,
-/obj/item/weapon/storage/belt/utility/chief/full{
-	pixel_y = 2
-	},
-/obj/item/weapon/storage/belt/utility/chief/full{
-	pixel_y = 4
-	},
-/obj/item/weapon/storage/belt/utility/chief/full{
-	pixel_y = 6
-	},
-/obj/item/weapon/tank/emergency/oxygen/double,
-/obj/item/weapon/tank/emergency/oxygen/double,
-/obj/item/weapon/tank/emergency/oxygen/double,
-/obj/item/weapon/tank/emergency/oxygen/double,
-/obj/item/weapon/tank/emergency/oxygen/double,
-/obj/item/weapon/storage/belt/explorer/pathfinder{
-	name = "ERT belt"
-	},
-/obj/item/weapon/storage/belt/explorer/pathfinder{
-	name = "ERT belt"
-	},
-/obj/item/weapon/storage/belt/explorer/pathfinder{
-	name = "ERT belt"
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/barracks)
-"aC" = (
-/obj/machinery/power/pointdefense{
-	id_tag = "vonbraun_pd"
-	},
-/obj/structure/cable/yellow{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/ship/ert/med_surg)
-"aD" = (
-/obj/structure/table/steel_reinforced,
-/obj/machinery/alarm/alarms_hidden{
-	dir = 1;
-	pixel_y = -26
-	},
-/obj/fiftyspawner/tritium,
-/obj/fiftyspawner/tritium,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/eng_storage)
-"aE" = (
-/obj/machinery/alarm/alarms_hidden{
-	dir = 1;
-	pixel_y = -26
-	},
-/obj/structure/table/rack/steel,
-/obj/item/weapon/rig/ert/engineer,
-/obj/item/weapon/rig/ert/engineer,
-/obj/item/weapon/rig/ert/engineer,
-/obj/item/weapon/rig/ert/engineer,
-/obj/item/weapon/rig/ert/engineer,
-/obj/item/weapon/rig/ert/engineer,
-/obj/item/clothing/suit/armor/vest/ert/engineer,
-/obj/item/clothing/suit/armor/vest/ert/engineer,
-/obj/item/clothing/suit/armor/vest/ert/engineer,
-/obj/item/clothing/suit/armor/vest/ert/engineer,
-/obj/item/clothing/suit/armor/vest/ert/engineer,
-/obj/item/clothing/suit/armor/vest/ert/engineer,
-/obj/item/clothing/head/helmet/ert/engineer,
-/obj/item/clothing/head/helmet/ert/engineer,
-/obj/item/clothing/head/helmet/ert/engineer,
-/obj/item/clothing/head/helmet/ert/engineer,
-/obj/item/clothing/head/helmet/ert/engineer,
-/obj/item/clothing/head/helmet/ert/engineer,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/barracks)
-"aF" = (
-/obj/machinery/porta_turret/stationary/CIWS,
-/turf/simulated/floor/reinforced/airless,
-/area/ship/ert/atmos)
-"aG" = (
-/obj/structure/table/rack/steel,
-/obj/item/weapon/storage/backpack/ert/medical{
-	pixel_y = -3
-	},
-/obj/item/weapon/storage/backpack/ert/medical,
-/obj/item/weapon/storage/backpack/ert/medical{
-	pixel_y = 3
-	},
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/machinery/light/no_nightshift,
-/obj/item/weapon/storage/backpack/ert/medical{
-	pixel_y = 6
-	},
-/obj/item/weapon/storage/backpack/ert/medical{
-	pixel_y = 9
-	},
-/obj/item/weapon/storage/backpack/ert/medical{
-	pixel_y = 12
-	},
-/obj/item/clothing/suit/space/void/responseteam/medical,
-/obj/item/clothing/suit/space/void/responseteam/medical,
-/obj/item/clothing/suit/space/void/responseteam/medical,
-/obj/item/clothing/suit/space/void/responseteam/medical,
-/obj/item/clothing/suit/space/void/responseteam/medical,
-/obj/item/clothing/suit/space/void/responseteam/medical,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/barracks)
-"aH" = (
-/obj/item/weapon/storage/belt/medical/emt{
-	pixel_y = -4
-	},
-/obj/item/weapon/storage/belt/medical/emt{
-	pixel_y = -2
-	},
-/obj/item/weapon/storage/belt/medical/emt,
-/obj/item/weapon/storage/belt/medical/emt{
-	pixel_y = 2
-	},
-/obj/item/weapon/storage/belt/medical/emt{
-	pixel_y = 4
-	},
-/obj/item/weapon/storage/belt/medical/emt{
-	pixel_y = 6
-	},
-/obj/item/clothing/accessory/storage/white_vest{
-	pixel_y = -4
-	},
-/obj/item/clothing/accessory/storage/white_vest{
-	pixel_y = -2
-	},
-/obj/item/clothing/accessory/storage/white_vest,
-/obj/item/clothing/accessory/storage/white_vest{
-	pixel_y = 2
-	},
-/obj/item/clothing/accessory/storage/white_vest{
-	pixel_y = 4
-	},
-/obj/item/clothing/accessory/storage/white_vest{
-	pixel_y = 6
-	},
-/obj/structure/table/rack/steel,
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/item/weapon/storage/belt/explorer/pathfinder{
-	name = "ERT belt"
-	},
-/obj/item/weapon/storage/belt/explorer/pathfinder{
-	name = "ERT belt"
-	},
-/obj/item/weapon/storage/belt/explorer/pathfinder{
-	name = "ERT belt"
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/barracks)
 "aI" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/vending/fitness{
+	prices = list()
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/med)
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/hallways_aft)
 "aJ" = (
-/obj/item/device/multitool/station_buffered,
+/obj/machinery/atmospherics/pipe/simple/visible/universal,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/atmos)
-"aK" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/white{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/hangar)
 "aQ" = (
-/obj/structure/table/steel_reinforced,
-/obj/item/weapon/storage/firstaid/surgery,
-/obj/machinery/light/no_nightshift{
-	dir = 8
+/obj/structure/sign/department/operational{
+	name = "MEDICAL & SURGERY"
 	},
-/obj/item/weapon/surgical/bone_clamp,
-/obj/item/weapon/surgical/scalpel/manager,
-/obj/item/weapon/surgical/circular_saw/manager,
-/obj/item/stack/nanopaste,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/wall/shull,
 /area/ship/ert/med_surg)
 "aV" = (
 /obj/machinery/power/pointdefense{
@@ -542,11 +235,513 @@
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/ship/ert/eng_storage)
-"bp" = (
-/obj/machinery/atmospherics/pipe/simple/visible/universal,
+"aZ" = (
+/obj/structure/table/steel_reinforced,
+/obj/fiftyspawner/phoron,
+/obj/fiftyspawner/glass,
+/obj/fiftyspawner/glass,
+/obj/fiftyspawner/glass,
+/obj/fiftyspawner/glass,
+/obj/fiftyspawner/steel,
+/obj/fiftyspawner/steel,
+/obj/fiftyspawner/steel,
+/obj/fiftyspawner/steel,
+/obj/fiftyspawner/plasteel,
+/obj/fiftyspawner/plasteel,
+/obj/fiftyspawner/plasteel,
+/obj/fiftyspawner/plasteel,
+/obj/fiftyspawner/rglass,
+/obj/fiftyspawner/rglass,
+/obj/fiftyspawner/rglass,
+/obj/fiftyspawner/phoronglass,
+/obj/fiftyspawner/phoronglass,
+/obj/fiftyspawner/rods,
+/obj/fiftyspawner/rods,
+/obj/fiftyspawner/rods,
+/obj/fiftyspawner/rods,
 /turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/atmos)
+/area/ship/ert/eng_storage)
+"be" = (
+/obj/machinery/light/no_nightshift{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/yellow{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/sign/warning/engineering_access{
+	pixel_x = -32
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/corner/red{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/hallways_aft)
+"bh" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/corner/red{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/hallways_aft)
+"bn" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/machinery/alarm/alarms_hidden{
+	dir = 1;
+	pixel_y = -26
+	},
+/obj/effect/floor_decal/corner/white{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/hangar)
 "br" = (
+/obj/machinery/porta_turret/stationary/CIWS,
+/turf/simulated/floor/reinforced/airless,
+/area/ship/ert/mech_bay)
+"bv" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/door/airlock/glass_security{
+	name = "ORB Control";
+	req_one_access = list(103)
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/mech_bay)
+"bw" = (
+/obj/structure/table/rack/steel,
+/obj/item/weapon/storage/box/frags{
+	pixel_x = -2;
+	pixel_y = -2
+	},
+/obj/item/weapon/storage/box/frags{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/machinery/power/apc/hyper{
+	alarms_hidden = 1;
+	dir = 4;
+	name = "VB APC - East";
+	pixel_x = 24
+	},
+/obj/structure/cable/yellow,
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/armoury_dl)
+"bB" = (
+/obj/structure/hull_corner{
+	dir = 1
+	},
+/turf/space,
+/area/space)
+"bG" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/white,
+/area/ship/ert/med_surg)
+"bI" = (
+/obj/structure/railing/grey{
+	dir = 4
+	},
+/obj/structure/railing/grey{
+	dir = 1
+	},
+/obj/item/weapon/paper/vonbraun_shields,
+/obj/structure/table/steel_reinforced,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/bridge)
+"bJ" = (
+/turf/simulated/floor/reinforced/airless,
+/area/ship/ert/gunnery)
+"bM" = (
+/obj/machinery/light/no_nightshift{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/table/rack/steel,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/item/weapon/rig/ert/medical,
+/obj/item/weapon/rig/ert/medical,
+/obj/item/weapon/rig/ert/medical,
+/obj/item/weapon/rig/ert/medical,
+/obj/item/weapon/rig/ert/medical,
+/obj/item/weapon/rig/ert/medical,
+/obj/item/clothing/suit/armor/vest/ert/medical,
+/obj/item/clothing/suit/armor/vest/ert/medical,
+/obj/item/clothing/suit/armor/vest/ert/medical,
+/obj/item/clothing/suit/armor/vest/ert/medical,
+/obj/item/clothing/suit/armor/vest/ert/medical,
+/obj/item/clothing/suit/armor/vest/ert/medical,
+/obj/item/clothing/head/helmet/ert/medical,
+/obj/item/clothing/head/helmet/ert/medical,
+/obj/item/clothing/head/helmet/ert/medical,
+/obj/item/clothing/head/helmet/ert/medical,
+/obj/item/clothing/head/helmet/ert/medical,
+/obj/item/clothing/head/helmet/ert/medical,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/barracks)
+"bO" = (
+/obj/machinery/shipsensors{
+	dir = 1
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/ship/ert/atmos)
+"bR" = (
+/obj/machinery/porta_turret/stationary/CIWS,
+/turf/simulated/floor/reinforced/airless,
+/area/ship/ert/atmos)
+"bW" = (
+/turf/simulated/floor/reinforced/airless,
+/area/ship/ert/atmos)
+"ca" = (
+/obj/machinery/porta_turret/stationary/CIWS,
+/turf/simulated/floor/reinforced/airless,
+/area/ship/ert/gunnery)
+"cb" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/hallways_aft)
+"ch" = (
+/obj/machinery/power/pointdefense{
+	id_tag = "vonbraun_pd"
+	},
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/ship/ert/gunnery)
+"ci" = (
+/turf/simulated/floor/reinforced/airless,
+/area/ship/ert/med_surg)
+"cl" = (
+/obj/effect/shuttle_landmark/premade/ert_ship_near_aft,
+/turf/space,
+/area/space)
+"co" = (
+/obj/item/roller_holder,
+/obj/item/roller/adv,
+/obj/item/roller/adv{
+	pixel_y = 6
+	},
+/obj/item/roller/adv{
+	pixel_y = 12
+	},
+/obj/machinery/light/no_nightshift,
+/obj/effect/floor_decal/industrial/outline,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/med)
+"cs" = (
+/obj/machinery/light/no_nightshift,
+/turf/simulated/floor/reinforced/airless,
+/area/ship/ert/hallways_aft)
+"cu" = (
+/obj/machinery/light/no_nightshift,
+/turf/simulated/floor/reinforced/airless,
+/area/ship/ert/barracks)
+"cv" = (
+/obj/machinery/shieldgen,
+/obj/effect/floor_decal/industrial/outline/blue,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/eng_storage)
+"cJ" = (
+/obj/machinery/power/pointdefense{
+	id_tag = "vonbraun_pd"
+	},
+/obj/structure/cable/yellow{
+	d2 = 4;
+	dir = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/ship/ert/hallways_aft)
+"cO" = (
+/obj/machinery/bodyscanner{
+	dir = 8
+	},
+/obj/machinery/light/no_nightshift{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/ship/ert/med_surg)
+"cR" = (
+/obj/machinery/light/no_nightshift{
+	dir = 1
+	},
+/obj/machinery/porta_turret/stationary/CIWS,
+/turf/simulated/floor/reinforced/airless,
+/area/ship/ert/med)
+"cS" = (
+/turf/simulated/wall/shull,
+/area/ship/ert/hallways_aft)
+"cV" = (
+/obj/structure/table/steel_reinforced,
+/obj/fiftyspawner/durasteel,
+/obj/fiftyspawner/durasteel,
+/obj/fiftyspawner/durasteel,
+/obj/fiftyspawner/durasteel,
+/obj/fiftyspawner/titanium_glass,
+/obj/fiftyspawner/titanium_glass,
+/obj/fiftyspawner/titanium_glass,
+/obj/fiftyspawner/titanium_glass,
+/obj/fiftyspawner/plastitanium_glass,
+/obj/fiftyspawner/plastitanium_glass,
+/obj/fiftyspawner/plastitanium_glass,
+/obj/fiftyspawner/plastitanium_glass,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/eng_storage)
+"cW" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 6
+	},
+/turf/simulated/wall/rshull,
+/area/ship/ert/dock_port)
+"cY" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 8
+	},
+/obj/effect/map_helper/airlock/atmos/chamber_pump,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/structure/sign/vacuum{
+	pixel_x = -32
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/dock_port)
+"db" = (
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc/hyper{
+	alarms_hidden = 1;
+	dir = 4;
+	name = "VB APC - East";
+	pixel_x = 24
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/mech_bay)
+"dd" = (
+/obj/machinery/airlock_sensor{
+	pixel_x = 24
+	},
+/obj/effect/map_helper/airlock/sensor/chamber_sensor,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/dock_port)
+"de" = (
+/obj/structure/table/steel_reinforced,
+/obj/machinery/light/no_nightshift{
+	dir = 4
+	},
+/obj/machinery/alarm/alarms_hidden{
+	dir = 8;
+	pixel_x = 26
+	},
+/obj/item/weapon/reagent_containers/spray/cleaner,
+/obj/item/weapon/reagent_containers/spray/cleaner,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/brig)
+"dg" = (
+/obj/machinery/light/no_nightshift{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/dispenser/oxygen,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/barracks)
+"dj" = (
+/obj/structure/table/rack/steel,
+/obj/item/taperoll/engineering{
+	pixel_x = -6;
+	pixel_y = -6
+	},
+/obj/item/taperoll/engineering{
+	pixel_x = -2;
+	pixel_y = -2
+	},
+/obj/item/taperoll/engineering{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/taperoll/engineering{
+	pixel_x = 6;
+	pixel_y = 6
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/eng_storage)
+"dk" = (
+/obj/structure/table/rack/steel,
+/obj/item/weapon/gun/projectile/heavysniper,
+/obj/item/ammo_magazine/ammo_box/b145,
+/obj/item/ammo_magazine/ammo_box/b145,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/alarm/alarms_hidden{
+	dir = 1;
+	pixel_y = -26
+	},
+/obj/machinery/light/no_nightshift,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/armoury_dl)
+"dn" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/effect/floor_decal/industrial/outline/blue,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/barracks)
+"dq" = (
+/turf/simulated/wall/shull,
+/area/ship/ert/med_surg)
+"ds" = (
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	icon_state = "shutter0";
+	id = "braun_cells_privacy";
+	name = "Privacy Shutters";
+	opacity = 0
+	},
+/obj/structure/grille,
+/obj/structure/window/titanium/full,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/brig)
+"dx" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/med)
+"dA" = (
+/obj/effect/floor_decal/industrial/outline/blue,
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide/engine_setup,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/barracks)
+"dC" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/bridge)
+"dR" = (
+/obj/machinery/shield_capacitor,
+/obj/effect/floor_decal/industrial/outline/blue,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/eng_storage)
+"dT" = (
+/obj/effect/floor_decal/corner/red{
+	dir = 9
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/hangar)
+"dV" = (
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/barracks)
+"dW" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/wall/rshull,
+/area/ship/ert/gunnery)
+"dX" = (
 /obj/structure/table/rack/steel,
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/item/weapon/tank/jetpack/carbondioxide{
@@ -572,83 +767,204 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/barracks)
-"bt" = (
+"dY" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/machinery/door/blast/regular{
+	closed_layer = 4;
+	dir = 4;
+	id = "NRV_DELTA";
+	layer = 4
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/barracks)
+"dZ" = (
+/obj/machinery/recharge_station,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/bridge)
+"ea" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/corner/red{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/hallways_aft)
+"ee" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/wall/rshull,
+/area/ship/ert/mech_bay)
+"ef" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock/engineering{
+	req_one_access = list(103)
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/dock_port)
+"es" = (
+/obj/machinery/door/airlock/glass_command{
+	req_one_access = list(103)
+	},
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/light/no_nightshift,
+/obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/tiled/techmaint,
 /area/ship/ert/bridge)
-"bv" = (
-/obj/structure/grille,
-/obj/machinery/door/firedoor/border_only,
-/obj/structure/window/reinforced/full,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/turf/simulated/floor/airless,
-/area/ship/ert/gunnery)
-"bJ" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+"et" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 8
 	},
-/obj/effect/map_helper/airlock/atmos/chamber_pump,
-/obj/machinery/light/no_nightshift{
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/dock_star)
-"bM" = (
-/turf/simulated/wall/rshull,
-/area/ship/ert/mech_bay)
-"bO" = (
-/turf/simulated/floor/reinforced/airless,
-/area/ship/ert/atmos)
-"bR" = (
-/obj/machinery/light/no_nightshift,
-/turf/simulated/floor/reinforced/airless,
-/area/ship/ert/atmos)
-"bS" = (
+/area/ship/ert/engine)
+"eG" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/door/firedoor/multi_tile{
+	dir = 1;
+	req_one_access = list(103)
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/door/airlock/multi_tile/glass{
+	dir = 1;
+	name = "Outfitting";
+	req_one_access = list(103)
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/barracks)
+"eH" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/wall/rshull,
+/area/ship/ert/gunnery)
+"eI" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock/glass{
+	req_one_access = list(103)
+	},
+/obj/structure/sign/warning/airlock{
+	pixel_y = -32
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/dock_star)
+"eJ" = (
+/obj/machinery/shield_diffuser,
+/obj/machinery/door/blast/regular/open{
+	dir = 2;
+	id = "ERT_Blast_Windows";
+	name = "Blast Shield"
+	},
+/obj/machinery/door/blast/regular{
+	id = "ERT_Shuttle_Fore"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/shuttle/ert_ship_boat)
+"eO" = (
+/obj/machinery/light/no_nightshift{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/structure/table/steel_reinforced,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/brig)
+"eX" = (
+/obj/effect/landmark/late_antag/ert,
+/obj/structure/table/bench/steel,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/barracks)
+"fe" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/hallways)
+"ff" = (
+/obj/machinery/vending/food,
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/barracks)
+"fj" = (
+/obj/machinery/vending/security,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/barracks)
+"fk" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/wall/rshull,
+/area/ship/ert/gunnery)
+"fn" = (
+/obj/machinery/power/pointdefense{
+	id_tag = "vonbraun_pd"
+	},
+/obj/structure/cable/yellow{
+	d2 = 4;
+	dir = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/ship/ert/med)
+"fp" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/effect/landmark{
+	name = "Commando"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/barracks)
+"fr" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
 	},
 /obj/structure/cable/yellow{
 	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/med)
-"bU" = (
-/obj/structure/hull_corner/long_horiz{
-	dir = 5
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/ship/ert/hallways_aft)
-"bW" = (
-/obj/structure/hull_corner/long_horiz{
-	dir = 6
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/ship/ert/atmos)
-"ca" = (
+/area/ship/ert/eng_storage)
+"ft" = (
 /obj/machinery/sleeper{
 	dir = 4
 	},
@@ -662,143 +978,610 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/ship/ert/med_surg)
-"ch" = (
-/obj/machinery/door/airlock/glass_external,
-/obj/effect/map_helper/airlock/door/int_door,
+"fx" = (
+/obj/structure/table/rack/steel,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/item/clothing/mask/gas{
+	pixel_x = -4;
+	pixel_y = -4
+	},
+/obj/item/clothing/mask/gas{
+	pixel_x = -2;
+	pixel_y = -2
+	},
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/clothing/mask/gas{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/clothing/mask/gas{
+	pixel_x = 6;
+	pixel_y = 6
+	},
+/obj/item/clothing/shoes/magboots/adv,
+/obj/item/clothing/shoes/magboots/adv,
+/obj/item/clothing/shoes/magboots/adv,
+/obj/item/clothing/shoes/magboots/adv,
+/obj/item/clothing/shoes/magboots/adv,
+/obj/item/clothing/shoes/magboots/adv,
 /turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/dock_star)
-"ci" = (
-/turf/simulated/floor/reinforced/airless,
-/area/ship/ert/med_surg)
-"ck" = (
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/dock_star)
-"cl" = (
-/obj/effect/shuttle_landmark/premade/ert_ship_near_aft,
+/area/ship/ert/barracks)
+"fE" = (
+/obj/structure/hull_corner{
+	dir = 8
+	},
 /turf/space,
 /area/space)
-"cs" = (
+"fV" = (
+/obj/structure/bed/chair/bay/shuttle,
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/ert_ship_boat)
+"fW" = (
+/obj/effect/floor_decal/corner/yellow{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/red{
+	dir = 6
+	},
+/obj/machinery/light/no_nightshift,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_y = -23
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/hallways)
+"fZ" = (
+/obj/machinery/door/blast/regular{
+	closed_layer = 4;
+	dir = 4;
+	id = "NRV_DELTA";
+	layer = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/barracks)
+"ga" = (
+/obj/structure/table/steel_reinforced,
+/obj/machinery/light/no_nightshift{
+	dir = 1
+	},
+/obj/item/device/defib_kit/compact/combat/loaded{
+	pixel_y = -3
+	},
+/obj/item/device/defib_kit/compact/combat/loaded{
+	pixel_y = 3
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/med)
+"gf" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/weapon/storage/firstaid/surgery,
+/obj/item/weapon/storage/firstaid/surgery,
+/obj/item/weapon/surgical/bone_clamp,
+/obj/item/weapon/surgical/bone_clamp,
+/obj/item/weapon/surgical/scalpel/manager,
+/obj/item/weapon/surgical/scalpel/manager,
+/obj/item/weapon/surgical/circular_saw/manager,
+/obj/item/weapon/surgical/circular_saw/manager,
+/obj/item/stack/nanopaste,
+/obj/item/stack/nanopaste,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/med)
+"gi" = (
+/obj/structure/closet/crate/medical,
+/obj/item/weapon/storage/box/autoinjectors,
+/obj/item/weapon/storage/box/beakers,
+/obj/item/weapon/storage/box/bodybags,
+/obj/item/weapon/storage/box/bodybags{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/weapon/storage/box/gloves,
+/obj/item/weapon/storage/box/freezer,
+/obj/item/weapon/storage/box/masks,
+/obj/effect/floor_decal/industrial/outline,
+/obj/item/weapon/storage/box/bodybags,
+/obj/item/weapon/storage/box/bodybags,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/med)
+"gk" = (
+/obj/machinery/light/no_nightshift,
+/obj/machinery/teleport/hub,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/teleporter)
+"gl" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/landmark{
+	name = "Commando"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/barracks)
+"gn" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/atmos)
+"go" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/wall/rshull,
+/area/ship/ert/eng_storage)
+"gp" = (
+/obj/effect/map_helper/airlock/sensor/chamber_sensor,
+/obj/machinery/airlock_sensor{
+	pixel_x = 24
+	},
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/dock_star)
+"gq" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/white,
+/area/ship/ert/med_surg)
+"gs" = (
+/obj/machinery/door/airlock/external,
+/obj/effect/map_helper/airlock/door/ext_door,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/dock_star)
+"gw" = (
+/obj/structure/table/steel_reinforced,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/hallways_aft)
+"gx" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/wall/rshull,
+/area/ship/ert/hallways_aft)
+"gA" = (
+/obj/machinery/atmospherics/pipe/manifold/visible{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/atmos)
+"gF" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/rig_module/chem_dispenser/combat,
+/obj/item/rig_module/chem_dispenser/combat,
+/obj/item/rig_module/chem_dispenser/injector,
+/obj/item/rig_module/chem_dispenser/injector,
+/obj/item/rig_module/device/healthscanner,
+/obj/item/rig_module/device/healthscanner,
+/obj/item/rig_module/device/healthscanner,
+/obj/item/rig_module/device/healthscanner,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/mech_bay)
+"gI" = (
+/obj/machinery/light/no_nightshift{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning,
+/obj/structure/table/steel_reinforced,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/brig)
+"gN" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/firealarm/alarms_hidden{
+	dir = 1;
+	pixel_y = -26
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/atmos)
+"gP" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/teleporter)
+"gQ" = (
+/obj/machinery/door/firedoor,
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced,
+/obj/machinery/door/blast/regular/open{
+	dir = 8;
+	id = "ERT_Blast_Windows";
+	name = "Blast Shield"
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/ert_ship_boat)
+"gR" = (
 /obj/machinery/atmospherics/pipe/tank/air{
 	dir = 4;
 	start_pressure = 740.5
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/dock_port)
-"cu" = (
-/obj/machinery/light/no_nightshift,
-/obj/machinery/porta_turret/stationary/CIWS,
-/turf/simulated/floor/reinforced/airless,
-/area/ship/ert/barracks)
-"cv" = (
-/obj/machinery/shield_gen,
-/obj/effect/floor_decal/industrial/outline/blue,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/eng_storage)
-"cC" = (
-/obj/effect/floor_decal/corner/white{
-	dir = 4
-	},
-/obj/machinery/light_switch{
-	dir = 8;
-	pixel_x = 23
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/eng_storage)
-"cH" = (
-/obj/machinery/computer/ship/disperser{
-	dir = 8
-	},
-/obj/item/weapon/paper/vonbraun_cannon,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/gunnery)
-"cJ" = (
-/obj/machinery/light/no_nightshift{
-	dir = 1
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/ship/ert/hallways_aft)
-"cO" = (
-/obj/machinery/computer/operating,
+"gT" = (
+/obj/machinery/cryopod/ert_ship,
 /turf/simulated/floor/tiled/white,
 /area/ship/ert/med_surg)
-"cP" = (
-/obj/machinery/recharge_station,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/bridge)
-"cS" = (
-/turf/simulated/wall/shull,
-/area/ship/ert/hallways_aft)
-"cV" = (
-/obj/machinery/vending/assist,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/eng_storage)
-"cW" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 4
-	},
-/obj/machinery/meter,
-/obj/machinery/power/apc/hyper{
-	alarms_hidden = 1;
-	dir = 1;
-	name = "VB APC - North";
-	pixel_y = 24
+"gV" = (
+/obj/effect/floor_decal/corner/white{
+	dir = 6
 	},
 /obj/structure/cable/yellow{
-	d2 = 2;
-	icon_state = "0-2"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/machinery/light/small{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/dock_port)
-"cY" = (
-/obj/machinery/firealarm/alarms_hidden{
-	dir = 1;
-	pixel_y = -26
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/engine)
-"db" = (
-/obj/machinery/door/airlock/glass_external,
-/obj/effect/map_helper/airlock/door/int_door,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/gunnery)
-"dd" = (
-/obj/machinery/atmospherics/pipe/manifold/visible,
-/turf/simulated/wall/shull,
-/area/ship/ert/dock_port)
-"dg" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 8
-	},
-/obj/effect/map_helper/airlock/atmos/chamber_pump,
-/obj/machinery/light/no_nightshift{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/dock_port)
-"dk" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/obj/machinery/portable_atmospherics/powered/pump/filled,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/hangar)
-"dn" = (
-/obj/machinery/embedded_controller/radio/airlock/docking_port_multi{
-	dir = 8;
-	id_tag = "von_braun_port";
-	master_tag = "von_braun_master";
-	name = "Port Docking Control";
-	pixel_x = 22
+/area/ship/ert/eng_storage)
+"gW" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/rig_module/device/rcd{
+	pixel_x = -4;
+	pixel_y = -4
+	},
+/obj/item/rig_module/device/rcd{
+	pixel_x = -2;
+	pixel_y = -2
+	},
+/obj/item/rig_module/device/plasmacutter{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/rig_module/device/plasmacutter{
+	pixel_x = 4;
+	pixel_y = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/mech_bay)
+"gX" = (
+/obj/structure/table/rack/steel,
+/obj/item/ammo_magazine/m9mmp90{
+	pixel_x = 12
+	},
+/obj/item/ammo_magazine/m9mmp90{
+	pixel_x = 10
+	},
+/obj/item/ammo_magazine/m9mmp90{
+	pixel_x = 8
+	},
+/obj/item/ammo_magazine/m9mmp90{
+	pixel_x = 6
+	},
+/obj/item/ammo_magazine/m9mmp90{
+	pixel_x = 4
+	},
+/obj/item/ammo_magazine/m9mmp90{
+	pixel_x = 2
+	},
+/obj/item/ammo_magazine/m9mmp90,
+/obj/item/ammo_magazine/m9mmp90{
+	pixel_x = -2
+	},
+/obj/item/ammo_magazine/m9mmp90{
+	pixel_x = -4
+	},
+/obj/item/ammo_magazine/m9mmp90{
+	pixel_x = -6
+	},
+/obj/item/ammo_magazine/m9mmp90{
+	pixel_x = -8
+	},
+/obj/item/ammo_magazine/m9mmp90{
+	pixel_x = -10
+	},
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/item/weapon/gun/projectile/automatic/p90{
+	pixel_y = -6
+	},
+/obj/item/weapon/gun/projectile/automatic/p90{
+	pixel_y = -2
+	},
+/obj/item/weapon/gun/projectile/automatic/p90{
+	pixel_y = 2
+	},
+/obj/item/weapon/gun/projectile/automatic/p90{
+	pixel_y = 6
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/armoury_dl)
+"gZ" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/white,
+/area/ship/ert/med_surg)
+"ha" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock/highsecurity{
+	name = "Teleporter Chamber";
+	req_one_access = list(103)
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/teleporter)
+"hb" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/wall/rshull,
+/area/ship/ert/med_surg)
+"hc" = (
+/obj/machinery/sleep_console{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/ship/ert/med_surg)
+"hd" = (
+/obj/machinery/power/apc/hyper{
+	alarms_hidden = 1;
+	dir = 4;
+	name = "VB APC - East";
+	pixel_x = 24
+	},
+/obj/structure/cable/yellow,
+/obj/machinery/embedded_controller/radio/docking_port_multi{
+	child_names_txt = "Port Airlock Control;Starboard Airlock Control";
+	child_tags_txt = "von_braun_port;von_braun_star";
+	dir = 1;
+	id_tag = "von_braun_master";
+	pixel_y = -22
+	},
+/obj/machinery/light/no_nightshift,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/bridge)
+"hj" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/rig_module/device/drill{
+	pixel_y = -4
+	},
+/obj/item/rig_module/device/drill{
+	pixel_y = 4
+	},
+/obj/item/rig_module/maneuvering_jets{
+	pixel_x = -5
+	},
+/obj/item/rig_module/maneuvering_jets{
+	pixel_x = -2
+	},
+/obj/item/rig_module/maneuvering_jets{
+	pixel_x = 1
+	},
+/obj/item/rig_module/maneuvering_jets{
+	pixel_x = 4
+	},
+/obj/item/rig_module/maneuvering_jets{
+	pixel_x = 7
+	},
+/obj/item/rig_module/maneuvering_jets{
+	pixel_x = 10
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/mech_bay)
+"hl" = (
+/obj/effect/floor_decal/corner/red{
+	dir = 8
+	},
+/obj/structure/reagent_dispensers/foam,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/industrial/outline,
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/hangar)
+"hq" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/light_switch{
+	dir = 8;
+	pixel_x = 23
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/dock_star)
+"hs" = (
+/obj/machinery/atmospherics/pipe/manifold/visible,
+/turf/simulated/wall/shull,
 /area/ship/ert/dock_port)
-"dp" = (
+"hv" = (
+/obj/structure/closet/medical_wall{
+	pixel_x = 32
+	},
+/obj/item/weapon/storage/firstaid/adv{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/weapon/storage/firstaid/adv{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/weapon/storage/firstaid/fire{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/weapon/storage/firstaid/fire{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/weapon/storage/firstaid/o2,
+/obj/item/weapon/storage/firstaid/o2,
+/obj/item/weapon/storage/firstaid/toxin{
+	pixel_x = -2;
+	pixel_y = -2
+	},
+/obj/item/weapon/storage/firstaid/toxin{
+	pixel_x = -2;
+	pixel_y = -2
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/med)
+"hx" = (
+/obj/machinery/light/no_nightshift{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/hallways_aft)
+"hA" = (
+/obj/machinery/power/pointdefense{
+	id_tag = "vonbraun_pd"
+	},
+/obj/machinery/light/no_nightshift{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/ship/ert/engine)
+"hF" = (
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/teleporter)
+"hN" = (
+/obj/structure/closet/wardrobe/ert,
+/obj/item/modular_computer/tablet/preset/custom_loadout/elite,
+/obj/item/weapon/storage/box/survival/comp{
+	starts_with = list(/obj/item/weapon/tool/prybar/red,/obj/item/clothing/glasses/goggles,/obj/item/weapon/reagent_containers/hypospray/autoinjector,/obj/item/stack/medical/bruise_pack,/obj/item/device/flashlight/glowstick,/obj/item/weapon/reagent_containers/food/snacks/candy/proteinbar,/obj/item/clothing/mask/breath,/obj/item/weapon/tank/emergency/oxygen/engi)
+	},
+/obj/machinery/light/no_nightshift{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/item/modular_computer/laptop/preset/custom_loadout/elite,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/barracks)
+"hQ" = (
+/obj/machinery/door/airlock/glass_medical{
+	name = "Medical Bay";
+	req_access = list(103)
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/white,
+/area/ship/ert/med_surg)
+"hS" = (
+/obj/structure/closet/wardrobe/ert,
+/obj/item/modular_computer/tablet/preset/custom_loadout/elite,
+/obj/item/weapon/storage/box/survival/comp{
+	starts_with = list(/obj/item/weapon/tool/prybar/red,/obj/item/clothing/glasses/goggles,/obj/item/weapon/reagent_containers/hypospray/autoinjector,/obj/item/stack/medical/bruise_pack,/obj/item/device/flashlight/glowstick,/obj/item/weapon/reagent_containers/food/snacks/candy/proteinbar,/obj/item/clothing/mask/breath,/obj/item/weapon/tank/emergency/oxygen/engi)
+	},
+/obj/machinery/light/no_nightshift{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/item/modular_computer/laptop/preset/custom_loadout/elite,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/barracks)
+"hV" = (
+/obj/structure/closet/crate{
+	dir = 2
+	},
+/obj/item/ammo_magazine/m9mml/ap,
+/obj/item/ammo_magazine/m9mml/ap,
+/obj/item/ammo_magazine/m9mml/ap,
+/obj/item/ammo_magazine/m9mml/ap,
+/obj/item/ammo_magazine/m9mml/ap,
+/obj/item/ammo_magazine/m9mml/ap,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/industrial/outline/red,
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/armoury_dl)
+"hY" = (
 /obj/structure/table/rack/steel,
 /obj/item/weapon/rig/ert/assetprotection{
 	pixel_x = -4;
@@ -824,31 +1607,56 @@
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/barracks)
-"dq" = (
+"ia" = (
+/turf/simulated/wall/shull,
+/area/ship/ert/dock_port)
+"ii" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/fuel{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/engine)
+"ij" = (
+/turf/simulated/floor/tiled/white,
+/area/ship/ert/med_surg)
+"ik" = (
+/obj/structure/table/rack/steel,
+/obj/item/toy/plushie/squid/blue{
+	desc = "A small, cute and loveable squid friend. This one is blue. Despite the name, it seems no more or less deadly than your regular plush squid.";
+	name = "NT 'Deathsquid' Plushie"
+	},
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/item/device/mapping_unit/deathsquad,
+/obj/item/device/holomap_beacon/deathsquad,
+/obj/item/device/holomap_beacon/deathsquad,
+/obj/item/device/holomap_beacon/deathsquad,
+/obj/item/device/holomap_beacon/deathsquad,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/barracks)
+"ip" = (
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/barracks)
+"ir" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/wall/shull,
 /area/ship/ert/med_surg)
-"ds" = (
-/obj/structure/table/rack,
-/obj/item/weapon/storage/backpack/ert/commander,
-/obj/item/clothing/suit/space/void/responseteam/command,
-/obj/item/clothing/head/helmet/ert/command,
-/obj/item/clothing/suit/armor/vest/ert/command,
-/turf/simulated/floor/wood,
-/area/ship/ert/commander)
-"dx" = (
-/obj/effect/floor_decal/corner/white{
-	dir = 9
+"is" = (
+/obj/machinery/computer/cryopod/ert{
+	pixel_y = 32
 	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/med)
-"dA" = (
-/obj/machinery/door/airlock/glass_medical{
-	name = "Medical Bay";
-	req_access = list(103)
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/hangar)
-"dB" = (
+/turf/simulated/floor/tiled/white,
+/area/ship/ert/med_surg)
+"ix" = (
 /obj/structure/table/rack/steel,
 /obj/item/clothing/suit/armor/swat{
 	pixel_x = -4;
@@ -923,22 +1731,202 @@
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/barracks)
-"dT" = (
-/obj/machinery/door/firedoor,
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/structure/window/reinforced,
-/obj/machinery/door/blast/regular/open{
-	dir = 8;
-	id = "ERT_Blast_Windows";
-	name = "Blast Shield"
+"iz" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/structure/window/reinforced{
+/turf/simulated/wall/shull,
+/area/ship/ert/mech_bay)
+"iC" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/eng_storage)
+"iD" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/bridge)
+"iF" = (
+/obj/machinery/porta_turret/stationary/CIWS,
+/turf/simulated/floor/reinforced/airless,
+/area/ship/ert/med_surg)
+"iG" = (
+/obj/machinery/vending/tool,
+/obj/machinery/light/no_nightshift{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor,
-/area/shuttle/ert_ship_boat)
-"dV" = (
+/area/ship/ert/eng_storage)
+"iM" = (
+/obj/machinery/vending/wallmed1/public{
+	dir = 4;
+	pixel_x = -23
+	},
+/obj/structure/table/steel_reinforced,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/brig)
+"iO" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/light/no_nightshift{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/dock_port)
+"iR" = (
+/obj/machinery/airlock_sensor{
+	pixel_y = 21
+	},
+/obj/effect/map_helper/airlock/sensor/int_sensor,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/dock_port)
+"iT" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/hallways)
+"iW" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/firealarm/alarms_hidden{
+	pixel_y = 26
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/white,
+/area/ship/ert/med_surg)
+"iX" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/landmark{
+	name = "Commando"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/barracks)
+"iY" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled/white,
+/area/ship/ert/med_surg)
+"jb" = (
+/obj/machinery/autolathe{
+	desc = "Your typical Autolathe. It appears to have much more options than your regular one, however...";
+	hacked = 1;
+	name = "Unlocked Autolathe"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/eng_storage)
+"jd" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/structure/ship_munition/disperser_charge/explosive,
+/turf/simulated/floor/reinforced,
+/area/ship/ert/hallways_aft)
+"jg" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/brig)
+"jn" = (
+/obj/effect/floor_decal/corner/white{
+	dir = 4
+	},
+/obj/machinery/light_switch{
+	dir = 8;
+	pixel_x = 23
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/eng_storage)
+"jr" = (
+/obj/effect/floor_decal/industrial/warning,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/brig)
+"jt" = (
+/obj/machinery/computer/ship/sensors,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/structure/railing/grey{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/bridge)
+"jv" = (
 /obj/structure/table/rack/steel,
 /obj/item/clothing/glasses/thermal{
 	pixel_x = -4;
@@ -964,727 +1952,323 @@
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/barracks)
-"dW" = (
-/obj/structure/hull_corner{
-	dir = 8
-	},
-/turf/space,
-/area/space)
-"dX" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/engineering{
-	req_one_access = list(103)
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/dock_port)
-"dY" = (
-/obj/machinery/door/airlock/glass_external,
-/obj/effect/map_helper/airlock/door/int_door,
-/obj/machinery/door/firedoor/multi_tile,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/dock_port)
-"ee" = (
-/obj/machinery/door/airlock/glass_external,
-/obj/effect/map_helper/airlock/door/int_door,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/dock_port)
-"ef" = (
-/obj/structure/table/rack/steel,
-/obj/item/clothing/glasses/night{
-	pixel_x = -4;
-	pixel_y = -4
-	},
-/obj/item/clothing/glasses/night{
-	pixel_x = -2;
-	pixel_y = -2
-	},
-/obj/item/clothing/glasses/night,
-/obj/item/clothing/glasses/night{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/item/clothing/glasses/night{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/item/clothing/glasses/night{
-	pixel_x = 6;
-	pixel_y = 6
-	},
-/obj/machinery/firealarm/alarms_hidden{
-	pixel_y = 26
-	},
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/barracks)
-"eg" = (
-/obj/structure/table/rack/steel,
-/obj/item/clothing/glasses/night{
-	pixel_x = -4;
-	pixel_y = -4
-	},
-/obj/item/clothing/glasses/night{
-	pixel_x = -2;
-	pixel_y = -2
-	},
-/obj/item/clothing/glasses/night,
-/obj/item/clothing/glasses/night{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/item/clothing/glasses/night{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/item/clothing/glasses/night{
-	pixel_x = 6;
-	pixel_y = 6
-	},
-/obj/machinery/atm{
-	pixel_y = 26
-	},
-/obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/barracks)
-"ej" = (
-/obj/machinery/door/blast/regular{
-	id = "Von_Braun_Cannon";
-	name = "Cannon Firing Port"
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/ship/ert/gunnery)
-"es" = (
-/obj/structure/closet/crate{
-	dir = 2
-	},
-/obj/item/ammo_magazine/m9mml/ap,
-/obj/item/ammo_magazine/m9mml/ap,
-/obj/item/ammo_magazine/m9mml/ap,
-/obj/item/ammo_magazine/m9mml/ap,
-/obj/item/ammo_magazine/m9mml/ap,
-/obj/item/ammo_magazine/m9mml/ap,
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/floor_decal/industrial/outline/red,
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/armoury_dl)
-"et" = (
-/obj/machinery/atmospherics/pipe/manifold4w/visible/fuel,
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/machinery/door/blast/regular/open{
-	id = "VB_Rear_Blast";
-	name = "Blast Shield"
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/ship/ert/engine)
-"eD" = (
-/obj/structure/hull_corner{
-	dir = 4
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/ship/ert/med)
-"eF" = (
-/obj/effect/floor_decal/industrial/warning,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/teleporter)
-"eG" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
+"jy" = (
+/obj/item/device/aicard,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/barracks)
-"eH" = (
-/obj/structure/sign/department/cargo{
-	name = "ENGINEERING SUPPLIES"
-	},
-/turf/simulated/wall/rshull,
-/area/ship/ert/bridge)
-"eI" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/eng_storage)
-"eL" = (
-/mob/living/simple_mob/animal/passive/mimepet,
-/turf/simulated/floor/wood,
-/area/ship/ert/commander)
-"eO" = (
-/obj/effect/map_helper/airlock/atmos/chamber_pump,
-/obj/effect/map_helper/airlock/sensor/chamber_sensor,
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 1
-	},
-/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	id_tag = "vb_cannon_loader";
-	pixel_x = 24;
-	pixel_y = 23
-	},
-/obj/machinery/airlock_sensor{
-	pixel_x = -25;
-	pixel_y = 22
-	},
-/turf/simulated/floor/airless,
-/area/ship/ert/gunnery)
-"eP" = (
-/obj/structure/table/steel_reinforced,
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/item/weapon/storage/box/cdeathalarm_kit{
-	pixel_x = -1;
-	pixel_y = -1
-	},
-/obj/item/weapon/storage/box/cdeathalarm_kit{
-	pixel_x = 1;
-	pixel_y = 1
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/barracks)
-"eX" = (
-/obj/structure/table/steel_reinforced,
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/item/weapon/storage/box/backup_kit{
-	pixel_x = -1;
-	pixel_y = -1
-	},
-/obj/item/weapon/storage/box/backup_kit{
-	pixel_x = 1;
-	pixel_y = 1
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/barracks)
-"ff" = (
-/obj/machinery/vending/fitness,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/barracks)
-"fj" = (
-/obj/machinery/door/blast/regular{
-	closed_layer = 4;
-	dir = 4;
-	id = "NRV_DELTA";
-	layer = 4
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/barracks)
-"fk" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 4
-	},
-/obj/machinery/meter,
-/obj/machinery/power/apc/hyper{
-	alarms_hidden = 1;
-	name = "VB APC - South";
-	pixel_y = -24
-	},
-/obj/structure/cable/yellow,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/dock_star)
-"fp" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/barracks)
-"fr" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/eng_storage)
-"fx" = (
-/obj/structure/table/steel_reinforced,
-/obj/machinery/light/no_nightshift{
-	dir = 8
-	},
-/obj/machinery/firealarm/alarms_hidden{
-	pixel_y = 26
-	},
-/obj/machinery/light_switch{
-	dir = 4;
-	pixel_x = -23
-	},
-/obj/item/rig_module/sprinter{
-	pixel_x = -4;
-	pixel_y = 4
-	},
-/obj/item/rig_module/sprinter{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/item/rig_module/rescue_pharm{
-	pixel_y = -2
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/mech_bay)
-"fE" = (
-/obj/structure/table/steel_reinforced,
-/obj/item/rig_module/mounted{
-	pixel_x = -4;
-	pixel_y = -4
-	},
-/obj/item/rig_module/mounted/egun{
-	pixel_x = -2;
-	pixel_y = -2
-	},
-/obj/item/rig_module/mounted/egun,
-/obj/item/rig_module/mounted/egun{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/item/rig_module/mounted/egun{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/mech_bay)
-"fP" = (
-/obj/structure/table/steel_reinforced,
-/obj/item/rig_module/chem_dispenser/combat,
-/obj/item/rig_module/chem_dispenser/combat,
-/obj/item/rig_module/chem_dispenser/injector,
-/obj/item/rig_module/chem_dispenser/injector,
-/obj/item/rig_module/device/healthscanner,
-/obj/item/rig_module/device/healthscanner,
-/obj/item/rig_module/device/healthscanner,
-/obj/item/rig_module/device/healthscanner,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/mech_bay)
-"fU" = (
-/obj/structure/table/steel_reinforced,
-/obj/item/rig_module/device/rcd{
-	pixel_x = -4;
-	pixel_y = -4
-	},
-/obj/item/rig_module/device/rcd{
-	pixel_x = -2;
-	pixel_y = -2
-	},
-/obj/item/rig_module/device/plasmacutter{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/item/rig_module/device/plasmacutter{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/mech_bay)
-"fZ" = (
-/obj/structure/table/steel_reinforced,
-/obj/item/rig_module/device/drill{
-	pixel_y = -4
-	},
-/obj/item/rig_module/device/drill{
-	pixel_y = 4
-	},
-/obj/item/rig_module/maneuvering_jets{
-	pixel_x = -5
-	},
-/obj/item/rig_module/maneuvering_jets{
-	pixel_x = -2
-	},
-/obj/item/rig_module/maneuvering_jets{
-	pixel_x = 1
-	},
-/obj/item/rig_module/maneuvering_jets{
-	pixel_x = 4
-	},
-/obj/item/rig_module/maneuvering_jets{
-	pixel_x = 7
-	},
-/obj/item/rig_module/maneuvering_jets{
-	pixel_x = 10
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/mech_bay)
-"ga" = (
-/obj/structure/sign/department/operational{
-	name = "MEDICAL & SURGERY"
-	},
-/turf/simulated/wall/shull,
-/area/ship/ert/med_surg)
-"gf" = (
-/obj/machinery/bodyscanner{
-	dir = 8
-	},
-/obj/machinery/light/no_nightshift{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/ship/ert/med_surg)
-"gh" = (
-/obj/machinery/light/no_nightshift{
-	dir = 8
-	},
-/obj/machinery/button/remote/blast_door{
-	description_fluff = "\\(OOC) DO NOT TOUCH THIS BUTTON WITHOUT THE EXPLICIT PERMISSION OF AN ADMINISTRATOR.";
-	dir = 4;
-	id = "NRV_MECHS";
-	name = "MECH BAY CONTROL";
-	pixel_x = -25;
-	req_one_access = list(108)
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/gunnery)
-"gk" = (
-/obj/machinery/shieldwallgen,
-/obj/effect/floor_decal/industrial/outline/blue,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/eng_storage)
-"gl" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/barracks)
-"gn" = (
-/obj/machinery/light/no_nightshift,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+	dir = 9
 	},
 /obj/machinery/light_switch{
 	dir = 1;
 	pixel_y = -23
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/atmos)
-"go" = (
+/obj/structure/table/hardwoodtable,
+/turf/simulated/floor/wood,
+/area/ship/ert/commander)
+"jz" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/barracks)
+"jA" = (
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id = "braun_cells_privacy";
+	name = "Privacy Shutters";
+	opacity = 0
+	},
+/obj/structure/grille,
+/obj/structure/window/titanium/full,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/cable/yellow,
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/brig)
+"jD" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/barracks)
+"jJ" = (
+/obj/machinery/light/no_nightshift{
+	dir = 1
+	},
+/obj/machinery/porta_turret/stationary/CIWS,
+/turf/simulated/floor/reinforced/airless,
+/area/ship/ert/eng_storage)
+"jK" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/wall/rshull,
-/area/ship/ert/eng_storage)
-"gx" = (
-/obj/structure/table/rack/steel,
-/obj/item/weapon/melee/baton{
-	pixel_x = -6
-	},
-/obj/item/weapon/melee/baton{
-	pixel_x = -2
-	},
-/obj/item/weapon/melee/baton{
-	pixel_x = 2
-	},
-/obj/item/weapon/melee/baton{
-	pixel_x = 6
-	},
-/obj/item/weapon/shield/riot{
-	pixel_x = -6
-	},
-/obj/item/weapon/shield/riot{
-	pixel_x = -2
-	},
-/obj/item/weapon/shield/riot{
-	pixel_x = 2
-	},
-/obj/item/weapon/shield/riot{
-	pixel_x = 6
-	},
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/machinery/recharger/wallcharger{
-	pixel_x = -23;
-	pixel_y = 5
-	},
-/obj/machinery/recharger/wallcharger{
-	pixel_x = -23;
-	pixel_y = -4
-	},
-/obj/machinery/recharger/wallcharger{
-	pixel_x = -23;
-	pixel_y = -12
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/armoury_st)
-"gA" = (
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/atmos)
-"gF" = (
-/obj/machinery/light/no_nightshift{
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 10
-	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/barracks)
+"jQ" = (
+/obj/structure/ship_munition/disperser_charge/emp,
+/obj/effect/floor_decal/industrial/warning,
 /obj/structure/railing,
 /turf/simulated/floor/reinforced,
 /area/ship/ert/gunnery)
-"gN" = (
+"jU" = (
+/obj/structure/ship_munition/disperser_charge/emp,
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/reinforced,
+/area/ship/ert/gunnery)
+"jY" = (
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/barracks)
+"kg" = (
+/obj/structure/ship_munition/disperser_charge/emp,
+/obj/effect/floor_decal/industrial/warning,
+/obj/structure/railing,
 /obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
+/turf/simulated/floor/reinforced,
+/area/ship/ert/gunnery)
+"kh" = (
+/obj/machinery/firealarm/alarms_hidden{
+	pixel_y = 26
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/hallways_aft)
+"kk" = (
+/obj/machinery/light/no_nightshift{
+	dir = 1
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/ship/ert/engine)
+"kl" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/alarm/alarms_hidden{
+	dir = 1;
+	pixel_y = -26
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/dock_port)
+"km" = (
+/obj/machinery/chem_master,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/med)
+"kp" = (
+/obj/machinery/light/no_nightshift{
+	dir = 4
+	},
+/obj/machinery/atmospherics/portables_connector/fuel{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/industrial/outline/red,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/engine)
+"kt" = (
+/obj/structure/table/rack/steel,
+/obj/item/weapon/gun/energy/netgun{
+	pixel_y = -4
+	},
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/item/weapon/gun/energy/sniperrifle{
+	battery_lock = 0;
+	pixel_y = 6
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/armoury_st)
+"kw" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/teleporter)
+"kx" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/weapon/storage/box/pillbottles,
+/obj/item/weapon/storage/box/pillbottles,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/med)
+"ky" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/weapon/storage/firstaid/surgery,
+/obj/machinery/light/no_nightshift{
+	dir = 8
+	},
+/obj/item/weapon/surgical/bone_clamp,
+/obj/item/weapon/surgical/scalpel/manager,
+/obj/item/weapon/surgical/circular_saw/manager,
+/obj/item/stack/nanopaste,
+/turf/simulated/floor/tiled/white,
+/area/ship/ert/med_surg)
+"kz" = (
+/obj/effect/floor_decal/corner/red{
+	dir = 6
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/hallways)
+"kE" = (
+/obj/machinery/light/no_nightshift,
+/obj/machinery/firealarm/alarms_hidden{
+	dir = 1;
+	pixel_y = -26
+	},
+/obj/machinery/power/port_gen/pacman/mrs,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/eng_storage)
+"kG" = (
+/obj/structure/table/rack/steel,
+/obj/item/weapon/gun/projectile/automatic/z8{
+	pixel_y = 3
+	},
+/obj/item/weapon/gun/projectile/automatic/z8{
+	pixel_y = -3
+	},
+/obj/item/ammo_magazine/m762,
+/obj/item/ammo_magazine/m762,
+/obj/item/ammo_magazine/m762,
+/obj/item/ammo_magazine/m762,
+/obj/item/ammo_magazine/m762,
+/obj/item/ammo_magazine/m762,
+/obj/item/ammo_magazine/m762,
+/obj/item/ammo_magazine/m762,
+/obj/item/ammo_magazine/m762/ap,
+/obj/item/ammo_magazine/m762/ap,
+/obj/item/ammo_magazine/m762/ap,
+/obj/item/ammo_magazine/m762/ap,
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_y = -23
+	},
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/armoury_dl)
+"kJ" = (
+/turf/simulated/wall/rshull,
+/area/ship/ert/atmos)
+"kL" = (
+/obj/machinery/atmospherics/pipe/tank/air,
+/turf/simulated/floor/airless,
+/area/ship/ert/gunnery)
+"kM" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/effect/landmark{
+	name = "Commando"
+	},
+/obj/effect/catwalk_plated/techmaint,
+/turf/simulated/floor/plating,
+/area/ship/ert/barracks)
+"kO" = (
+/turf/simulated/floor/reinforced/airless,
+/area/ship/ert/dock_port)
+"kP" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/atmos)
+"kQ" = (
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 12;
+	pixel_y = 8
+	},
+/obj/structure/medical_stand,
+/turf/simulated/floor/tiled/white,
+/area/ship/ert/med_surg)
+"kS" = (
+/obj/machinery/light/no_nightshift{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/atmos)
+"kT" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 6
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/atmos)
-"gR" = (
-/obj/machinery/power/apc/hyper{
-	alarms_hidden = 1;
-	dir = 4;
-	name = "VB APC - East";
-	pixel_x = 24
-	},
-/obj/structure/cable/yellow{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/engine)
-"gW" = (
-/obj/machinery/disposal/deliveryChute{
-	dir = 8
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/structure/railing,
-/obj/effect/floor_decal/industrial/warning,
-/turf/simulated/floor/reinforced,
-/area/ship/ert/gunnery)
-"gX" = (
-/obj/structure/table/rack/steel,
-/obj/item/weapon/storage/box/emps{
-	pixel_x = -2;
-	pixel_y = -2
-	},
-/obj/item/weapon/storage/box/emps{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/armoury_dl)
-"gZ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/white,
-/area/ship/ert/med_surg)
-"ha" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/bridge)
-"hj" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/wall/rshull,
-/area/ship/ert/gunnery)
-"hk" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/structure/window/reinforced{
+"kW" = (
+/obj/machinery/computer/teleporter{
 	dir = 1
 	},
-/obj/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/visible,
-/turf/simulated/floor/airless,
-/area/ship/ert/gunnery)
-"hs" = (
-/obj/machinery/pointdefense_control{
-	id_tag = "vonbraun_pd"
-	},
-/obj/machinery/light/no_nightshift{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/bridge)
-"hv" = (
-/obj/machinery/sleeper{
-	dir = 8
-	},
-/obj/machinery/light/no_nightshift{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/white,
-/area/ship/ert/med_surg)
-"hx" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/light/no_nightshift{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/dock_port)
-"hH" = (
-/obj/machinery/airlock_sensor{
-	pixel_y = 21
-	},
-/obj/effect/map_helper/airlock/sensor/int_sensor,
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/dock_port)
-"hN" = (
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/alarm/alarms_hidden{
-	pixel_y = 26
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/engineering)
-"hP" = (
-/obj/machinery/autolathe{
-	desc = "Your typical Autolathe. It appears to have much more options than your regular one, however...";
-	hacked = 1;
-	name = "Unlocked Autolathe"
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/eng_storage)
-"hS" = (
-/obj/structure/closet/crate/freezer,
-/obj/item/weapon/reagent_containers/blood/OMinus,
-/obj/item/weapon/reagent_containers/blood/OMinus,
-/obj/item/weapon/reagent_containers/blood/OMinus,
-/obj/item/weapon/reagent_containers/blood/OMinus,
-/obj/item/weapon/reagent_containers/blood/OMinus,
-/obj/item/weapon/reagent_containers/blood/OMinus,
-/obj/item/weapon/reagent_containers/blood/OMinus,
-/obj/item/weapon/reagent_containers/blood/OMinus,
-/obj/machinery/light_switch{
-	dir = 1;
-	pixel_y = -23
-	},
-/obj/effect/floor_decal/industrial/outline,
-/turf/simulated/floor/tiled/white,
-/area/ship/ert/med_surg)
-"hU" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/dock_port)
-"hV" = (
-/obj/effect/floor_decal/corner/red{
-	dir = 9
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/hangar)
-"hY" = (
-/obj/structure/hull_corner{
-	dir = 4
-	},
+/area/ship/ert/teleporter)
+"kX" = (
+/obj/machinery/porta_turret/stationary/CIWS,
 /turf/simulated/floor/reinforced/airless,
-/area/ship/ert/dock_star)
-"ia" = (
+/area/ship/ert/engine)
+"kY" = (
+/obj/machinery/door/window/brigdoor/northleft,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/hallways_aft)
+"lm" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/wall/shull,
+/area/ship/ert/hallways_aft)
+"ls" = (
+/obj/machinery/door/airlock/glass_external,
+/obj/effect/map_helper/airlock/door/int_door,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/dock_port)
+"lv" = (
+/obj/machinery/embedded_controller/radio/airlock/docking_port_multi{
+	dir = 8;
+	id_tag = "von_braun_port";
+	master_tag = "von_braun_master";
+	name = "Port Docking Control";
+	pixel_x = 22
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/dock_port)
+"lx" = (
 /obj/structure/table/rack/steel,
 /obj/item/clothing/accessory/holster/leg{
 	pixel_x = -4;
@@ -1710,493 +2294,125 @@
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/barracks)
-"ib" = (
-/turf/simulated/floor/reinforced/airless,
-/area/ship/ert/hangar)
-"if" = (
+"lz" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/wall/rshull,
-/area/ship/ert/gunnery)
-"ij" = (
-/turf/simulated/floor/tiled/white,
-/area/ship/ert/med_surg)
-"ik" = (
 /obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/dock_port)
-"ip" = (
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/barracks)
-"iu" = (
-/obj/machinery/power/pointdefense{
-	id_tag = "vonbraun_pd"
-	},
-/obj/structure/cable/yellow{
+	d1 = 1;
 	d2 = 4;
-	dir = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/ship/ert/hallways_aft)
-"ix" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/glass{
-	req_one_access = list(103)
-	},
-/obj/structure/sign/warning/airlock{
-	pixel_y = -32
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/dock_star)
-"iy" = (
-/obj/machinery/alarm/alarms_hidden{
-	dir = 1;
-	pixel_y = -26
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/bridge)
-"iz" = (
-/obj/structure/ship_munition/disperser_charge/emp,
-/obj/effect/floor_decal/industrial/warning,
-/turf/simulated/floor/reinforced,
-/area/ship/ert/gunnery)
-"iB" = (
-/turf/simulated/wall/shull,
-/area/ship/ert/dock_port)
-"iC" = (
-/obj/item/device/healthanalyzer/phasic{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/item/device/healthanalyzer/phasic,
-/obj/item/device/healthanalyzer/phasic{
-	pixel_x = -2;
-	pixel_y = -2
-	},
-/obj/structure/table/rack/steel,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/outline,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/med)
-"iO" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/barracks)
-"iR" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/barracks)
-"iW" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/white,
-/area/ship/ert/med_surg)
-"iX" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/barracks)
-"jn" = (
-/obj/machinery/chem_master,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/med)
-"jv" = (
-/obj/machinery/computer/cryopod/ert{
-	pixel_y = 32
-	},
-/turf/simulated/floor/tiled/white,
-/area/ship/ert/med_surg)
-"jz" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/barracks)
-"jA" = (
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/teleporter)
-"jD" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/barracks)
-"jI" = (
-/obj/machinery/teleport/station,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/teleporter)
-"jK" = (
-/obj/machinery/door/airlock/glass_engineering{
-	name = "Engineering";
-	req_access = list(103)
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/mech_bay)
-"jQ" = (
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/mech_bay)
-"jU" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/mech_bay)
-"jY" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/mech_bay)
-"kf" = (
-/obj/structure/table/rack/steel,
-/obj/item/weapon/gun/projectile/automatic/pdw{
-	pixel_y = 6
-	},
-/obj/item/weapon/gun/projectile/automatic/pdw{
-	pixel_y = 4
-	},
-/obj/item/weapon/gun/projectile/automatic/pdw{
-	pixel_y = 2
-	},
-/obj/item/weapon/gun/projectile/automatic/pdw,
-/obj/item/weapon/gun/projectile/automatic/pdw{
-	pixel_y = -2
-	},
-/obj/item/weapon/gun/projectile/automatic/pdw{
-	pixel_y = -4
-	},
-/obj/item/ammo_magazine/m9mml{
-	pixel_x = 10
-	},
-/obj/item/ammo_magazine/m9mml{
-	pixel_x = 8
-	},
-/obj/item/ammo_magazine/m9mml{
-	pixel_x = 6
-	},
-/obj/item/ammo_magazine/m9mml{
-	pixel_x = 4
-	},
-/obj/item/ammo_magazine/m9mml{
-	pixel_x = 2
-	},
-/obj/item/ammo_magazine/m9mml,
-/obj/item/ammo_magazine/m9mml{
-	pixel_x = -2
-	},
-/obj/item/ammo_magazine/m9mml{
-	pixel_x = -4
-	},
-/obj/item/ammo_magazine/m9mml{
-	pixel_x = -6
-	},
-/obj/item/ammo_magazine/m9mml{
-	pixel_x = -8
-	},
-/obj/item/ammo_magazine/m9mml{
-	pixel_x = -10
-	},
-/obj/item/ammo_magazine/m9mml{
-	pixel_x = -12
-	},
-/obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/armoury_st)
-"kg" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/wall/rshull,
-/area/ship/ert/hallways_aft)
-"kh" = (
-/obj/machinery/light/no_nightshift{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/hallways_aft)
-"kl" = (
-/obj/effect/landmark{
-	name = "Commando"
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/barracks)
-"km" = (
-/obj/effect/floor_decal/corner/white{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/med)
-"kt" = (
-/obj/machinery/door/blast/regular/open{
-	id = "ERT_Shuttle_Rear";
-	name = "Boarding Hatch"
-	},
-/obj/machinery/button/remote/blast_door{
-	id = "ERT_Shuttle_Rear";
-	name = "ERT Shuttle Access";
-	pixel_y = 24;
-	req_access = list(103)
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/shuttle/ert_ship_boat)
-"kx" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/machinery/door/firedoor/border_only,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/med)
-"ky" = (
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/wall/shull,
-/area/ship/ert/med_surg)
-"kz" = (
-/obj/structure/closet/crate{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/item/weapon/plastique,
-/obj/item/weapon/plastique,
-/obj/item/weapon/plastique,
-/obj/item/weapon/plastique,
-/obj/effect/floor_decal/industrial/outline/red,
-/obj/item/weapon/plastique,
-/obj/item/weapon/plastique,
-/obj/item/weapon/plastique,
-/obj/item/weapon/plastique,
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/armoury_dl)
-"kG" = (
-/obj/effect/floor_decal/corner/white{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/hangar)
-"kJ" = (
-/turf/simulated/wall/rshull,
-/area/ship/ert/atmos)
-"kL" = (
-/obj/machinery/light/no_nightshift{
-	dir = 4
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/ship/ert/engine)
-"kM" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/barracks)
-"kO" = (
-/obj/structure/hull_corner{
-	dir = 8
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/ship/ert/barracks)
-"kP" = (
-/obj/machinery/atmospherics/pipe/tank/air{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/atmos)
-"kS" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/atmos)
-"kT" = (
-/obj/machinery/light/no_nightshift{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/atmos)
-"kW" = (
-/turf/simulated/wall/shull,
-/area/ship/ert/dock_star)
-"kX" = (
-/obj/machinery/atmospherics/pipe/manifold/visible{
-	dir = 1
-	},
-/turf/simulated/wall/shull,
-/area/ship/ert/dock_star)
-"kY" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/atmos)
-"lm" = (
-/obj/effect/floor_decal/industrial/outline/blue,
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide/engine_setup,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/barracks)
-"lq" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/warning,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/teleporter)
-"ls" = (
-/obj/machinery/atmospherics/portables_connector{
-	dir = 8
-	},
-/obj/machinery/portable_atmospherics/canister/empty,
-/obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/atmos)
-"lu" = (
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/hallways_aft)
-"lv" = (
-/obj/structure/closet/wardrobe/ert,
-/obj/item/modular_computer/tablet/preset/custom_loadout/elite,
-/obj/item/weapon/storage/box/survival/comp{
-	starts_with = list(/obj/item/weapon/tool/prybar/red,/obj/item/clothing/glasses/goggles,/obj/item/weapon/reagent_containers/hypospray/autoinjector,/obj/item/stack/medical/bruise_pack,/obj/item/device/flashlight/glowstick,/obj/item/weapon/reagent_containers/food/snacks/candy/proteinbar,/obj/item/clothing/mask/breath,/obj/item/weapon/tank/emergency/oxygen/engi)
-	},
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/item/modular_computer/laptop/preset/custom_loadout/elite,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/barracks)
-"lx" = (
-/obj/machinery/door/airlock/external,
-/obj/machinery/airlock_sensor/airlock_exterior{
-	pixel_x = 24;
-	pixel_y = -11
-	},
-/obj/effect/map_helper/airlock/door/ext_door,
-/obj/effect/map_helper/airlock/sensor/ext_sensor,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/dock_star)
-"lz" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/med)
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/effect/catwalk_plated/techmaint,
+/turf/simulated/floor/plating,
+/area/ship/ert/eng_storage)
 "lB" = (
-/obj/item/modular_computer/console/preset/engineering{
-	dir = 4
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/engineering)
-"lL" = (
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/dock_port)
-"lO" = (
-/obj/machinery/alarm/alarms_hidden{
-	dir = 1;
-	pixel_y = -26
+"lE" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/light_switch{
+	pixel_y = 23
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/teleporter)
+"lR" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/ship/ert/hallways_aft)
-"lR" = (
+"lZ" = (
+/turf/simulated/floor/reinforced/airless,
+/area/ship/ert/engine)
+"md" = (
+/obj/structure/table/rack/steel,
+/obj/item/ammo_magazine/ammo_box/b12g/pellet,
+/obj/item/ammo_magazine/ammo_box/b12g/pellet,
+/obj/item/ammo_magazine/ammo_box/b12g,
+/obj/item/ammo_magazine/ammo_box/b12g,
+/obj/item/ammo_magazine/ammo_box/b12g/emp,
+/obj/item/ammo_magazine/ammo_box/b12g/flash,
+/obj/item/ammo_magazine/ammo_box/b12g/beanbag,
+/obj/item/ammo_magazine/ammo_box/b12g/beanbag,
+/obj/item/ammo_magazine/ammo_box/b12g/stunshell,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/item/weapon/gun/projectile/automatic/as24{
+	pixel_y = 3
+	},
+/obj/item/weapon/gun/projectile/automatic/as24{
+	pixel_y = -3
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/armoury_dl)
+"mg" = (
+/obj/structure/bed/chair/bay/shuttle{
+	dir = 4
+	},
+/obj/machinery/button/remote/blast_door{
+	dir = 8;
+	id = "ERT_Blast_Windows";
+	name = "Emergency Blast Shields";
+	pixel_x = 55;
+	req_one_access = list(101)
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/shuttle/ert_ship_boat)
+"mh" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/med)
+"mj" = (
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/dock_port)
+"ml" = (
+/obj/machinery/light/no_nightshift,
+/obj/structure/sign/vacuum{
+	pixel_y = -32
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/hangar)
+"mp" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/fuel{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/engine)
+"mq" = (
 /obj/machinery/firealarm/alarms_hidden{
 	dir = 1;
 	pixel_y = -26
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/ship/ert/dock_port)
-"lV" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/machinery/alarm/alarms_hidden{
-	dir = 1;
-	pixel_y = -26
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/dock_port)
-"lX" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/light_switch{
-	dir = 8;
-	pixel_x = 23
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/dock_port)
-"lZ" = (
-/turf/simulated/floor/reinforced/airless,
-/area/ship/ert/engine)
-"mb" = (
+"mr" = (
 /obj/structure/table/rack/steel,
 /obj/item/weapon/storage/belt/security/tactical{
 	pixel_x = -4;
@@ -2243,65 +2459,17 @@
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/barracks)
-"mh" = (
-/obj/structure/closet/crate/freezer,
-/obj/item/weapon/reagent_containers/blood/OMinus,
-/obj/item/weapon/reagent_containers/blood/OMinus,
-/obj/item/weapon/reagent_containers/blood/OMinus,
-/obj/item/weapon/reagent_containers/blood/OMinus,
-/obj/item/weapon/reagent_containers/blood/OMinus,
-/obj/item/weapon/reagent_containers/blood/OMinus,
-/obj/item/weapon/reagent_containers/blood/OMinus,
-/obj/item/weapon/reagent_containers/blood/OMinus,
-/obj/effect/floor_decal/industrial/outline,
-/turf/simulated/floor/tiled/white,
-/area/ship/ert/med_surg)
-"mj" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/effect/landmark{
-	name = "Commando"
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/barracks)
-"mq" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/obj/effect/landmark{
-	name = "Commando"
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/barracks)
-"mr" = (
-/obj/structure/reagent_dispensers/water_cooler/full,
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/barracks)
 "mt" = (
-/obj/structure/cable/green,
 /obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
+/obj/machinery/power/apc/hyper{
+	alarms_hidden = 1;
+	dir = 4;
+	name = "VB APC - East";
+	pixel_x = 24
 	},
 /obj/structure/cable/green{
 	d2 = 8;
@@ -2309,15 +2477,49 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/engineering)
-"my" = (
+"mv" = (
+/turf/simulated/floor/tiled/techmaint,
+/area/shuttle/ert_ship_boat)
+"mC" = (
+/obj/effect/landmark{
+	name = "Commando"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/barracks)
+"mI" = (
+/obj/effect/landmark{
+	name = "Commando"
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/barracks)
+"mJ" = (
+/obj/machinery/teleport/station,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/teleporter)
+"mN" = (
+/obj/structure/medical_stand,
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 12;
+	pixel_y = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/ship/ert/med_surg)
+"mO" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/armoury_dl)
-"mC" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/hallways_aft)
+"mR" = (
 /obj/structure/cable/yellow{
 	d1 = 2;
 	d2 = 4;
@@ -2329,109 +2531,6 @@
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/barracks)
-"mF" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/barracks)
-"mH" = (
-/obj/structure/bed/chair/bay/shuttle,
-/obj/machinery/recharger/wallcharger{
-	pixel_x = -23;
-	pixel_y = 5
-	},
-/obj/machinery/recharger/wallcharger{
-	pixel_x = -23;
-	pixel_y = -4
-	},
-/obj/machinery/recharger/wallcharger{
-	pixel_x = -23;
-	pixel_y = -12
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/shuttle/ert_ship_boat)
-"mI" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor/multi_tile{
-	dir = 1;
-	req_one_access = list(103)
-	},
-/obj/machinery/door/airlock/multi_tile/glass{
-	dir = 1;
-	req_one_access = list(103)
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/barracks)
-"mJ" = (
-/obj/structure/table/steel_reinforced,
-/obj/fiftyspawner/durasteel,
-/obj/fiftyspawner/durasteel,
-/obj/fiftyspawner/durasteel,
-/obj/fiftyspawner/durasteel,
-/obj/fiftyspawner/titanium_glass,
-/obj/fiftyspawner/titanium_glass,
-/obj/fiftyspawner/titanium_glass,
-/obj/fiftyspawner/titanium_glass,
-/obj/fiftyspawner/plastitanium_glass,
-/obj/fiftyspawner/plastitanium_glass,
-/obj/fiftyspawner/plastitanium_glass,
-/obj/fiftyspawner/plastitanium_glass,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/eng_storage)
-"mN" = (
-/obj/machinery/sleep_console{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/ship/ert/med_surg)
-"mO" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/med)
-"mP" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/white,
-/area/ship/ert/med_surg)
-"mR" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/barracks)
-"mT" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/ship/ert/barracks)
@@ -2455,60 +2554,48 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/multi_tile{
-	dir = 1
-	},
-/obj/machinery/door/airlock/multi_tile/glass{
-	dir = 1;
-	req_one_access = list(103)
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/ship/ert/barracks)
-"na" = (
-/obj/machinery/airlock_sensor{
-	pixel_y = -23
-	},
-/obj/effect/map_helper/airlock/sensor/int_sensor,
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/dock_star)
 "nb" = (
-/obj/structure/table/rack/steel,
-/obj/item/weapon/gun/energy/xray{
-	pixel_y = -3
+/obj/structure/table/steel_reinforced,
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/item/weapon/storage/box/cdeathalarm_kit{
+	pixel_x = -1;
+	pixel_y = -1
 	},
-/obj/item/weapon/gun/energy/xray{
-	pixel_y = 3
+/obj/item/weapon/storage/box/cdeathalarm_kit{
+	pixel_x = 1;
+	pixel_y = 1
 	},
-/obj/machinery/light/no_nightshift,
-/obj/machinery/firealarm/alarms_hidden{
-	dir = 1;
-	pixel_y = -26
-	},
-/obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/armoury_dl)
+/area/ship/ert/barracks)
 "nc" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
-/obj/effect/catwalk_plated/techmaint,
-/turf/simulated/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/techmaint,
 /area/ship/ert/barracks)
+"nd" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/hallways_aft)
 "nl" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
@@ -2520,10 +2607,6 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/med_surg)
 "nn" = (
-/obj/machinery/door/airlock/glass_engineering{
-	name = "Engineering";
-	req_access = list(103)
-	},
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
@@ -2535,15 +2618,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/multi_tile{
-	dir = 1
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/mech_bay)
-"no" = (
-/obj/machinery/photocopier,
-/turf/simulated/floor/wood,
-/area/ship/ert/commander)
+/area/ship/ert/barracks)
 "np" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -2556,8 +2637,16 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/machinery/door/firedoor/multi_tile{
+	dir = 1
+	},
+/obj/machinery/door/airlock/multi_tile/glass{
+	dir = 1;
+	name = "Outfitting";
+	req_one_access = list(103)
+	},
 /turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/mech_bay)
+/area/ship/ert/barracks)
 "nq" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -2566,49 +2655,51 @@
 	},
 /turf/simulated/wall/rshull,
 /area/ship/ert/barracks)
-"nr" = (
-/obj/machinery/porta_turret/stationary/CIWS,
-/turf/simulated/floor/reinforced/airless,
-/area/ship/ert/gunnery)
 "nt" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/table/steel_reinforced,
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/item/weapon/storage/box/backup_kit{
+	pixel_x = -1;
+	pixel_y = -1
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/item/weapon/storage/box/backup_kit{
+	pixel_x = 1;
+	pixel_y = 1
 	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/mech_bay)
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/barracks)
 "nv" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/mech_bay)
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
+/obj/effect/catwalk_plated/techmaint,
+/turf/simulated/floor/plating,
+/area/ship/ert/barracks)
 "nx" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/vending/fitness{
+	prices = list()
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/glass_engineeringatmos{
-	req_one_access = list(103)
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/atmos)
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/barracks)
 "nz" = (
+/obj/machinery/light/no_nightshift{
+	dir = 8
+	},
+/obj/machinery/button/remote/blast_door{
+	description_fluff = "\\(OOC) DO NOT TOUCH THIS BUTTON WITHOUT THE EXPLICIT PERMISSION OF AN ADMINISTRATOR.";
+	dir = 4;
+	id = "NRV_MECHS";
+	name = "MECH BAY CONTROL";
+	pixel_x = -25;
+	req_one_access = list(108)
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/gunnery)
+"nB" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
@@ -2620,101 +2711,102 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/door/airlock/glass_security{
-	req_one_access = list(103)
-	},
 /turf/simulated/floor/tiled/techmaint,
 /area/ship/ert/mech_bay)
-"nB" = (
+"nC" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/gunnery)
+"nI" = (
+/obj/machinery/alarm/alarms_hidden{
+	dir = 8;
+	pixel_x = 26
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/gunnery)
-"nC" = (
-/turf/simulated/floor/reinforced/airless,
-/area/ship/ert/dock_star)
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/ship/ert/brig)
 "nM" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/engineering)
-"nX" = (
 /obj/machinery/light/no_nightshift{
 	dir = 1
 	},
-/obj/machinery/atmospherics/unary/engine{
+/obj/effect/floor_decal/industrial/warning{
+	dir = 10
+	},
+/obj/structure/railing,
+/turf/simulated/floor/reinforced,
+/area/ship/ert/gunnery)
+"nR" = (
+/obj/effect/floor_decal/industrial/warning,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/brig)
+"nU" = (
+/obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
-/turf/space,
-/area/ship/ert/engine)
-"nY" = (
-/obj/structure/ship_munition/disperser_charge/emp,
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
+/obj/machinery/button/remote/blast_door{
+	dir = 1;
+	id = "ERT_Shuttle_Fore";
+	name = "ERT Deployment Access";
+	pixel_y = -25;
+	req_access = list(103)
 	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/turf/simulated/floor/tiled/techmaint,
+/area/shuttle/ert_ship_boat)
+"nX" = (
+/obj/machinery/atmospherics/pipe/simple/visible/fuel{
+	dir = 10
 	},
-/turf/simulated/floor/reinforced,
-/area/ship/ert/hallways_aft)
-"oa" = (
-/obj/structure/table/rack,
-/obj/item/weapon/hand_tele,
-/obj/item/device/perfect_tele,
-/obj/item/device/binoculars,
-/obj/item/device/survivalcapsule{
-	pixel_x = 3
-	},
-/obj/item/device/survivalcapsule{
-	pixel_x = -3
-	},
-/turf/simulated/floor/wood,
-/area/ship/ert/commander)
-"og" = (
-/obj/machinery/door/firedoor/glass,
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
-/obj/structure/window/reinforced,
 /obj/machinery/door/blast/regular/open{
-	dir = 8;
-	id = "ERT_Blast_Windows";
+	id = "VB_Rear_Blast";
 	name = "Blast Shield"
 	},
 /obj/structure/window/reinforced{
-	dir = 1
+	dir = 8
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/shuttle/ert_ship_boat)
-"oi" = (
-/turf/simulated/wall/shull,
-/area/ship/ert/hangar)
-"oj" = (
-/obj/machinery/alarm/alarms_hidden{
-	pixel_y = 26
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/hallways_aft)
-"ok" = (
-/obj/machinery/alarm/alarms_hidden{
-	pixel_y = 26
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/techfloor,
+/turf/simulated/floor/plating,
 /area/ship/ert/engine)
-"op" = (
+"nY" = (
+/obj/machinery/door/blast/regular/open{
+	dir = 4;
+	id = "braun_blast_shields";
+	name = "Blast Shield"
+	},
+/turf/space,
+/area/space)
+"ob" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/engineering)
+"oi" = (
+/obj/machinery/disposal/deliveryChute{
+	dir = 8
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/structure/railing,
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/reinforced,
+/area/ship/ert/gunnery)
+"ok" = (
 /obj/machinery/firealarm/alarms_hidden{
 	pixel_y = 26
 	},
@@ -2723,110 +2815,293 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/engine)
-"os" = (
-/obj/machinery/atmospherics/pipe/manifold/visible{
-	dir = 4
+"om" = (
+/obj/structure/table/rack/steel,
+/obj/item/weapon/gun/launcher/grenade{
+	pixel_y = 3
 	},
+/obj/item/weapon/gun/launcher/grenade{
+	pixel_y = -3
+	},
+/obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/atmos)
-"oy" = (
-/obj/machinery/atmospherics/pipe/manifold/visible{
+/area/ship/ert/armoury_dl)
+"oo" = (
+/obj/structure/table/rack/steel,
+/obj/item/weapon/gun/energy/taser{
+	pixel_y = 3
+	},
+/obj/item/weapon/gun/energy/taser{
+	pixel_y = 1
+	},
+/obj/item/weapon/gun/energy/taser{
+	pixel_y = -1
+	},
+/obj/item/weapon/gun/energy/taser{
+	pixel_y = -3
+	},
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/armoury_st)
+"op" = (
+/obj/machinery/atmospherics/pipe/tank/phoron{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/atmos)
-"oC" = (
-/obj/machinery/portable_atmospherics/canister/air,
-/obj/effect/floor_decal/industrial/outline,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/eng_storage)
-"oN" = (
-/obj/effect/shuttle_landmark/premade/ert_ship_near_fore,
-/turf/space,
-/area/space)
-"oO" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/area/ship/ert/engine)
+"ot" = (
+/obj/machinery/door/airlock/glass_engineering{
+	name = "Engineering Control";
+	req_access = list(103)
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/eng_storage)
-"oQ" = (
-/obj/effect/floor_decal/corner/white{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/med)
-"oV" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor/border_only,
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/light/no_nightshift{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/dock_port)
-"oW" = (
-/obj/structure/table/rack/steel,
-/obj/item/clothing/accessory/storage/black_vest{
-	pixel_x = -4;
-	pixel_y = -4
-	},
-/obj/item/clothing/accessory/storage/black_vest{
-	pixel_x = -2;
-	pixel_y = -2
-	},
-/obj/item/clothing/accessory/storage/black_vest,
-/obj/item/clothing/accessory/storage/black_vest{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/item/clothing/accessory/storage/black_vest{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/item/clothing/accessory/storage/black_vest{
-	pixel_x = 6;
-	pixel_y = 6
-	},
+/area/ship/ert/engineering)
+"ox" = (
 /obj/machinery/power/apc/hyper{
 	alarms_hidden = 1;
 	dir = 4;
 	name = "VB APC - East";
 	pixel_x = 24
 	},
-/obj/structure/cable/yellow,
+/obj/machinery/vending/nifsoft_shop{
+	categories = 111;
+	desc = "For all your mindware and mindware accessories. Now paid for by Central!";
+	dir = 8;
+	emagged = 1;
+	name = "ERT NIFSoft Vendor"
+	},
+/obj/structure/cable/yellow{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/hallways)
+"oy" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/canister/empty,
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/barracks)
+/area/ship/ert/atmos)
+"oz" = (
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/structure/table/steel_reinforced,
+/obj/item/weapon/rcd/advanced/loaded{
+	desc = "A device used to rapidly build and deconstruct. This version works faster, and has a much larger capacity than a standard model, but doesn't work at range. Reload with compressed matter cartridges.";
+	name = "emergency rapid construction device";
+	pixel_y = 3;
+	ranged = 0
+	},
+/obj/item/weapon/rcd/advanced/loaded{
+	desc = "A device used to rapidly build and deconstruct. This version works faster, and has a much larger capacity than a standard model, but doesn't work at range. Reload with compressed matter cartridges.";
+	name = "emergency rapid construction device";
+	pixel_y = -3;
+	ranged = 0
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/eng_storage)
+"oC" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/alarm/alarms_hidden{
+	pixel_y = 26
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/dock_star)
+"oN" = (
+/obj/effect/shuttle_landmark/premade/ert_ship_near_fore,
+/turf/space,
+/area/space)
+"oO" = (
+/obj/machinery/airlock_sensor{
+	pixel_y = -23
+	},
+/obj/effect/map_helper/airlock/sensor/int_sensor,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/dock_star)
+"oV" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/wall/rshull,
+/area/ship/ert/gunnery)
 "oX" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/barracks)
+"pf" = (
+/obj/effect/landmark/map_data/ert_ship,
+/turf/space,
+/area/space)
+"pg" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock/glass{
+	req_one_access = list(103)
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/dock_port)
+"ph" = (
+/obj/structure/table/steel_reinforced,
+/obj/machinery/button/remote/blast_door{
+	dir = 4;
+	id = "braun_cells_privacy";
+	name = "Privacy Shutter Controls";
+	pixel_x = -24;
+	pixel_y = -9;
+	req_access = list(103)
+	},
+/obj/item/weapon/handcuffs,
+/obj/item/weapon/handcuffs,
+/obj/item/weapon/handcuffs,
+/obj/item/weapon/handcuffs,
+/obj/item/weapon/handcuffs/legcuffs,
+/obj/item/weapon/handcuffs/legcuffs,
+/obj/item/weapon/handcuffs/legcuffs,
+/obj/item/weapon/handcuffs/legcuffs,
+/obj/machinery/firealarm/alarms_hidden{
+	dir = 8;
+	pixel_x = -26;
+	pixel_y = 5
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/brig)
+"pi" = (
+/obj/machinery/alarm/alarms_hidden{
+	dir = 1;
+	pixel_y = -26
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/hallways_aft)
+"pm" = (
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/effect/floor_decal/industrial/outline,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/eng_storage)
+"pn" = (
+/obj/item/modular_computer/console/preset/engineering{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/engineering)
+"po" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/med)
+"pq" = (
+/obj/structure/table/rack/steel,
+/obj/item/weapon/storage/toolbox/mechanical{
+	pixel_x = -4;
+	pixel_y = -6
+	},
+/obj/item/weapon/storage/toolbox/mechanical{
+	pixel_x = -4;
+	pixel_y = -2
+	},
+/obj/item/weapon/storage/toolbox/electrical{
+	pixel_x = -4;
+	pixel_y = 2
+	},
+/obj/item/weapon/storage/toolbox/electrical{
+	pixel_x = -4;
+	pixel_y = 6
+	},
+/obj/item/weapon/storage/briefcase/inflatable{
+	pixel_x = 4;
+	pixel_y = -6
+	},
+/obj/item/weapon/storage/briefcase/inflatable{
+	pixel_x = 4;
+	pixel_y = -2
+	},
+/obj/item/weapon/storage/briefcase/inflatable{
+	pixel_x = 4;
+	pixel_y = 2
+	},
+/obj/item/weapon/storage/briefcase/inflatable{
+	pixel_x = 4;
+	pixel_y = 6
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/eng_storage)
+"pr" = (
+/obj/machinery/light/no_nightshift{
+	dir = 8
+	},
+/obj/structure/ship_munition/disperser_charge/explosive,
+/obj/machinery/firealarm/alarms_hidden{
+	dir = 1;
+	pixel_y = -26
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/simulated/floor/reinforced,
+/area/ship/ert/gunnery)
+"pt" = (
+/obj/structure/table/rack/steel,
+/obj/item/weapon/rig/ert/security,
+/obj/item/weapon/rig/ert/security,
+/obj/item/weapon/rig/ert/security,
+/obj/item/weapon/rig/ert/security,
+/obj/item/weapon/rig/ert/security,
+/obj/item/weapon/rig/ert/security,
+/obj/item/clothing/suit/armor/vest/ert/security,
+/obj/item/clothing/suit/armor/vest/ert/security,
+/obj/item/clothing/suit/armor/vest/ert/security,
+/obj/item/clothing/suit/armor/vest/ert/security,
+/obj/item/clothing/suit/armor/vest/ert/security,
+/obj/item/clothing/suit/armor/vest/ert/security,
+/obj/item/clothing/head/helmet/ert/security,
+/obj/item/clothing/head/helmet/ert/security,
+/obj/item/clothing/head/helmet/ert/security,
+/obj/item/clothing/head/helmet/ert/security,
+/obj/item/clothing/head/helmet/ert/security,
+/obj/item/clothing/head/helmet/ert/security,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/barracks)
+"pv" = (
 /obj/structure/table/rack/steel,
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/item/clothing/gloves/yellow{
@@ -2863,35 +3138,256 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/barracks)
-"pb" = (
-/obj/structure/medical_stand,
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 12;
-	pixel_y = 8
+"pw" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/white,
-/area/ship/ert/med_surg)
-"pf" = (
-/obj/effect/landmark/map_data/ert_ship,
-/turf/space,
-/area/space)
-"pg" = (
-/obj/effect/landmark{
-	name = "Commando"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/door/blast/regular/open{
+	dir = 2;
+	id = "braun_blast_shields";
+	name = "Blast Shield"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/bridge)
+"px" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock/glass{
+	req_one_access = list(103)
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/dock_star)
+"pA" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/visible,
+/turf/simulated/floor/airless,
+/area/ship/ert/gunnery)
+"pD" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/shuttle/ert_ship_boat)
+"pE" = (
+/obj/machinery/button/remote/blast_door{
+	dir = 1;
+	id = "Von_Braun_Cannon";
+	name = "Cannon Port Access";
+	pixel_y = -24;
+	req_one_access = list(103)
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/gunnery)
+"pG" = (
+/obj/machinery/alarm/alarms_hidden{
+	dir = 1;
+	pixel_y = -26
+	},
+/obj/structure/table/rack/steel,
+/obj/item/weapon/rig/ert/engineer,
+/obj/item/weapon/rig/ert/engineer,
+/obj/item/weapon/rig/ert/engineer,
+/obj/item/weapon/rig/ert/engineer,
+/obj/item/weapon/rig/ert/engineer,
+/obj/item/weapon/rig/ert/engineer,
+/obj/item/clothing/suit/armor/vest/ert/engineer,
+/obj/item/clothing/suit/armor/vest/ert/engineer,
+/obj/item/clothing/suit/armor/vest/ert/engineer,
+/obj/item/clothing/suit/armor/vest/ert/engineer,
+/obj/item/clothing/suit/armor/vest/ert/engineer,
+/obj/item/clothing/suit/armor/vest/ert/engineer,
+/obj/item/clothing/head/helmet/ert/engineer,
+/obj/item/clothing/head/helmet/ert/engineer,
+/obj/item/clothing/head/helmet/ert/engineer,
+/obj/item/clothing/head/helmet/ert/engineer,
+/obj/item/clothing/head/helmet/ert/engineer,
+/obj/item/clothing/head/helmet/ert/engineer,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/barracks)
+"pK" = (
+/obj/structure/table/rack/steel,
+/obj/item/weapon/storage/backpack/ert/medical{
+	pixel_y = -3
+	},
+/obj/item/weapon/storage/backpack/ert/medical,
+/obj/item/weapon/storage/backpack/ert/medical{
+	pixel_y = 3
+	},
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/light/no_nightshift,
+/obj/item/weapon/storage/backpack/ert/medical{
+	pixel_y = 6
+	},
+/obj/item/weapon/storage/backpack/ert/medical{
+	pixel_y = 9
+	},
+/obj/item/weapon/storage/backpack/ert/medical{
+	pixel_y = 12
+	},
+/obj/item/clothing/suit/space/void/responseteam/medical,
+/obj/item/clothing/suit/space/void/responseteam/medical,
+/obj/item/clothing/suit/space/void/responseteam/medical,
+/obj/item/clothing/suit/space/void/responseteam/medical,
+/obj/item/clothing/suit/space/void/responseteam/medical,
+/obj/item/clothing/suit/space/void/responseteam/medical,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/barracks)
+"pM" = (
+/obj/item/weapon/storage/belt/medical/emt{
+	pixel_y = -4
+	},
+/obj/item/weapon/storage/belt/medical/emt{
+	pixel_y = -2
+	},
+/obj/item/weapon/storage/belt/medical/emt,
+/obj/item/weapon/storage/belt/medical/emt{
+	pixel_y = 2
+	},
+/obj/item/weapon/storage/belt/medical/emt{
+	pixel_y = 4
+	},
+/obj/item/weapon/storage/belt/medical/emt{
+	pixel_y = 6
+	},
+/obj/item/clothing/accessory/storage/white_vest{
+	pixel_y = -4
+	},
+/obj/item/clothing/accessory/storage/white_vest{
+	pixel_y = -2
+	},
+/obj/item/clothing/accessory/storage/white_vest,
+/obj/item/clothing/accessory/storage/white_vest{
+	pixel_y = 2
+	},
+/obj/item/clothing/accessory/storage/white_vest{
+	pixel_y = 4
+	},
+/obj/item/clothing/accessory/storage/white_vest{
+	pixel_y = 6
+	},
+/obj/structure/table/rack/steel,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/item/weapon/storage/belt/explorer/pathfinder{
+	name = "ERT belt"
+	},
+/obj/item/weapon/storage/belt/explorer/pathfinder{
+	name = "ERT belt"
+	},
+/obj/item/weapon/storage/belt/explorer/pathfinder{
+	name = "ERT belt"
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/barracks)
-"pm" = (
-/obj/effect/floor_decal/corner/yellow{
-	dir = 9
+"pN" = (
+/obj/structure/disposaloutlet,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/airless,
+/area/ship/ert/gunnery)
+"pO" = (
+/obj/machinery/light/no_nightshift,
+/turf/simulated/floor/reinforced/airless,
+/area/ship/ert/gunnery)
+"pP" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 5
+	},
+/turf/simulated/wall/rshull,
+/area/ship/ert/dock_star)
+"pS" = (
+/obj/effect/shuttle_landmark/premade/ert_ship_near_port,
+/turf/space,
+/area/space)
+"pU" = (
+/obj/structure/sign/department/medbay{
+	name = "MEDICAL OUTFITTING & SUPPLIES"
+	},
+/turf/simulated/wall/shull,
+/area/ship/ert/med)
+"pV" = (
+/turf/simulated/wall/shull,
+/area/ship/ert/atmos)
+"pY" = (
+/obj/machinery/power/pointdefense{
+	id_tag = "vonbraun_pd"
+	},
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/ship/ert/engine)
+"pZ" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock/glass_security{
+	name = "Delta Armoury";
+	req_one_access = list(103)
+	},
+/obj/machinery/door/blast/regular{
+	closed_layer = 4;
+	id = "NRV_DELTA";
+	layer = 4
 	},
 /turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/armoury_dl)
+"qa" = (
+/obj/structure/closet/crate/medical,
+/obj/item/weapon/storage/mre/menu11,
+/obj/item/weapon/storage/mre/menu11,
+/obj/item/weapon/storage/mre/menu11,
+/obj/item/weapon/storage/mre/menu11,
+/obj/item/stack/nanopaste/advanced,
+/obj/item/stack/nanopaste/advanced,
+/obj/item/stack/nanopaste/advanced,
+/obj/item/weapon/reagent_containers/food/drinks/drinkingglass/fitnessflask/glucose,
+/obj/item/weapon/storage/pill_bottle/iron,
+/obj/item/weapon/storage/pill_bottle/iron,
+/obj/item/weapon/storage/pill_bottle/sleevingcure/full,
+/obj/item/weapon/storage/box/syringes,
+/obj/item/weapon/storage/box/syringes{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/machinery/light_switch{
+	dir = 8;
+	pixel_x = 23
+	},
+/obj/effect/floor_decal/industrial/outline,
+/turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/med)
-"po" = (
-/obj/machinery/door/airlock/glass_medical{
-	name = "Medical Bay";
-	req_access = list(103)
+"qc" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/ship/ert/med_surg)
+"ql" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -2900,50 +3396,13 @@
 	dir = 4
 	},
 /obj/structure/cable/yellow{
-	d1 = 4;
+	d1 = 2;
 	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "2-8"
 	},
-/turf/simulated/floor/tiled/white,
-/area/ship/ert/med_surg)
-"pq" = (
-/obj/structure/table/steel_reinforced,
-/obj/item/bodybag/cryobag{
-	pixel_x = -4;
-	pixel_y = -4
-	},
-/obj/item/bodybag/cryobag{
-	pixel_x = -2;
-	pixel_y = -2
-	},
-/obj/item/bodybag/cryobag,
-/obj/item/bodybag/cryobag{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/item/bodybag/cryobag{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/item/bodybag/cryobag{
-	pixel_x = 6;
-	pixel_y = 6
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/med)
-"pr" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/machinery/door/firedoor/border_only,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/simulated/floor/airless,
-/area/ship/ert/gunnery)
-"pt" = (
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/eng_storage)
+"qo" = (
 /obj/structure/table/rack/steel,
 /obj/item/clothing/suit/space/void/responseteam/janitor{
 	pixel_y = -2
@@ -2968,12 +3427,58 @@
 /obj/machinery/light/no_nightshift,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/barracks)
-"pv" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+"qp" = (
+/obj/machinery/door/airlock/glass_engineering{
+	name = "Engineering";
+	req_access = list(103)
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/barracks)
-"pz" = (
+/area/ship/ert/engineering)
+"qq" = (
+/obj/machinery/power/thermoregulator,
+/obj/effect/floor_decal/industrial/outline,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/eng_storage)
+"qt" = (
+/obj/structure/cable/green,
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/engineering)
+"qw" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
+/obj/effect/catwalk_plated/techmaint,
+/turf/simulated/floor/plating,
+/area/ship/ert/brig)
+"qy" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
@@ -2985,112 +3490,20 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/multi_tile{
-	dir = 1
-	},
-/obj/machinery/door/airlock/multi_tile/glass{
-	dir = 1;
-	req_one_access = list(103)
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/med)
-"pA" = (
-/obj/structure/ship_munition/disperser_charge/explosive,
-/obj/effect/floor_decal/industrial/warning,
-/turf/simulated/floor/reinforced,
-/area/ship/ert/hallways_aft)
-"pE" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/ship/ert/gunnery)
-"pG" = (
-/obj/structure/closet{
-	name = "custodial"
-	},
-/obj/item/weapon/reagent_containers/spray/cleaner{
-	pixel_x = -6
-	},
-/obj/item/weapon/reagent_containers/spray/cleaner{
-	pixel_x = -2
-	},
-/obj/item/weapon/reagent_containers/spray/cleaner{
-	pixel_x = 2
-	},
-/obj/item/weapon/reagent_containers/spray/cleaner{
-	pixel_x = 6
-	},
-/obj/item/weapon/reagent_containers/glass/bucket{
-	pixel_x = 6
-	},
-/obj/item/weapon/reagent_containers/glass/bucket{
-	pixel_x = 2
-	},
-/obj/item/weapon/reagent_containers/glass/bucket{
-	pixel_x = -2
-	},
-/obj/item/weapon/reagent_containers/glass/bucket{
-	pixel_x = -6
-	},
-/obj/item/weapon/mop{
-	pixel_x = 6
-	},
-/obj/item/weapon/mop{
-	pixel_x = 2
-	},
-/obj/item/weapon/mop{
-	pixel_x = -2
-	},
-/obj/item/weapon/mop{
-	pixel_x = -6
-	},
-/obj/item/weapon/rig/ert/janitor,
-/obj/item/device/lightreplacer{
-	pixel_y = -2
-	},
-/obj/item/device/lightreplacer{
-	pixel_y = 2
-	},
-/obj/item/weapon/storage/box/lights/mixed{
-	pixel_x = -1;
-	pixel_y = -1
-	},
-/obj/item/weapon/storage/box/lights/mixed{
-	pixel_x = 1;
-	pixel_y = 1
-	},
-/obj/machinery/light/no_nightshift,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/barracks)
-"pI" = (
-/obj/structure/table/rack/steel,
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/item/weapon/gun/energy/pulse_rifle{
-	pixel_y = 6
-	},
-/obj/item/weapon/gun/energy/pulse_rifle{
-	pixel_y = 4
-	},
-/obj/item/weapon/gun/energy/pulse_rifle{
-	pixel_y = 2
-	},
-/obj/item/weapon/gun/energy/pulse_rifle,
-/obj/item/weapon/gun/energy/pulse_rifle{
-	pixel_y = -2
-	},
-/obj/item/weapon/gun/energy/pulse_rifle{
-	pixel_y = -4
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/armoury_dl)
-"pK" = (
+/area/ship/ert/mech_bay)
+"qz" = (
 /obj/structure/sign/department/eng{
 	name = "RIG AND MECH BAY"
 	},
 /turf/simulated/wall/shull,
 /area/ship/ert/mech_bay)
-"pM" = (
+"qD" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/rig_module/mounted/taser{
 	pixel_x = -4;
@@ -3122,281 +3535,146 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/mech_bay)
-"pN" = (
-/obj/machinery/embedded_controller/radio/airlock/docking_port_multi{
-	dir = 8;
-	id_tag = "von_braun_star";
-	master_tag = "von_braun_master";
-	name = "Starboard Docking Control";
-	pixel_x = 22
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/dock_star)
-"pO" = (
-/obj/machinery/light/no_nightshift,
-/turf/simulated/floor/reinforced/airless,
-/area/ship/ert/gunnery)
-"pS" = (
-/obj/effect/shuttle_landmark/premade/ert_ship_near_port,
-/turf/space,
-/area/space)
-"pU" = (
-/obj/machinery/body_scanconsole,
-/turf/simulated/floor/tiled/white,
-/area/ship/ert/med_surg)
-"pV" = (
-/turf/simulated/wall/shull,
-/area/ship/ert/atmos)
-"pW" = (
-/obj/structure/table/rack/steel,
-/obj/item/weapon/gun/energy/plasmastun{
-	pixel_y = -3
-	},
-/obj/item/weapon/gun/energy/plasmastun{
-	pixel_y = 3
-	},
-/obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/armoury_dl)
-"pY" = (
-/obj/structure/table/steel_reinforced,
-/obj/item/weapon/cell/hyper,
-/obj/item/weapon/cell/hyper,
-/obj/item/weapon/cell/hyper,
-/obj/item/weapon/cell/hyper,
-/obj/item/weapon/cell/hyper,
-/obj/item/weapon/cell/hyper,
-/obj/item/weapon/cell/hyper,
-/obj/item/weapon/cell/hyper,
-/obj/machinery/cell_charger,
-/obj/item/weapon/cell/hyper,
-/obj/item/weapon/cell/hyper,
-/obj/item/weapon/cell/hyper,
-/obj/item/weapon/cell/hyper,
-/obj/item/weapon/tool/screwdriver,
-/obj/item/weapon/tool/wrench,
-/obj/item/weapon/tool/crowbar,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/mech_bay)
-"qa" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/wall/shull,
-/area/ship/ert/med_surg)
-"ql" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/med)
-"qo" = (
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/mech_bay)
-"qt" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/table/steel_reinforced,
-/obj/fiftyspawner/uranium,
-/obj/fiftyspawner/uranium,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/engineering)
-"qy" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/gunnery)
-"qz" = (
-/obj/machinery/light/no_nightshift{
-	dir = 8
-	},
-/obj/structure/ship_munition/disperser_charge/explosive,
-/obj/machinery/firealarm/alarms_hidden{
-	dir = 1;
-	pixel_y = -26
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/obj/structure/railing{
-	dir = 1
-	},
-/turf/simulated/floor/reinforced,
-/area/ship/ert/gunnery)
-"qA" = (
-/obj/effect/floor_decal/corner/white{
-	dir = 8
-	},
-/obj/machinery/light/no_nightshift{
-	dir = 1
-	},
-/obj/machinery/alarm/alarms_hidden{
-	pixel_y = 26
-	},
-/obj/machinery/recharge_station,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/med)
-"qD" = (
-/obj/structure/ship_munition/disperser_charge/explosive,
-/obj/machinery/alarm/alarms_hidden{
-	dir = 1;
-	pixel_y = -26
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/turf/simulated/floor/reinforced,
-/area/ship/ert/gunnery)
 "qF" = (
 /obj/machinery/light/no_nightshift{
 	dir = 1
 	},
 /obj/machinery/porta_turret/stationary/CIWS,
 /turf/simulated/floor/reinforced/airless,
-/area/ship/ert/eng_storage)
+/area/ship/ert/dock_star)
 "qJ" = (
-/obj/structure/table/rack/steel,
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/item/ammo_magazine/m545{
-	pixel_x = -8
-	},
-/obj/item/ammo_magazine/m545{
-	pixel_x = -5
-	},
-/obj/item/ammo_magazine/m545{
-	pixel_x = -2
-	},
-/obj/item/ammo_magazine/m545{
-	pixel_x = 1
-	},
-/obj/item/ammo_magazine/m545{
-	pixel_x = 4
-	},
-/obj/item/ammo_magazine/m545{
-	pixel_x = 7
-	},
-/obj/item/weapon/gun/projectile/automatic/sts35{
-	pixel_y = -2
-	},
-/obj/item/weapon/gun/projectile/automatic/sts35{
-	pixel_y = 2
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/armoury_st)
+/turf/simulated/wall/shull,
+/area/ship/ert/hallways)
 "qP" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/gunnery)
-"qR" = (
-/obj/machinery/recharge_station,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/atmos)
-"rn" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
+/obj/machinery/door/firedoor/multi_tile{
 	dir = 1
 	},
+/obj/machinery/door/airlock/glass_engineering{
+	name = "RIG Bay & ORB Access";
+	req_access = list(103)
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/mech_bay)
+"qR" = (
+/obj/machinery/light/no_nightshift,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_y = -23
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/atmos)
+"ra" = (
+/obj/machinery/power/pointdefense{
+	id_tag = "vonbraun_pd"
+	},
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/ship/ert/med_surg)
+"rc" = (
+/obj/structure/table/rack/steel,
+/obj/item/weapon/gun/projectile/automatic/l6_saw{
+	pixel_y = 3
+	},
+/obj/item/weapon/gun/projectile/automatic/l6_saw{
+	pixel_y = -3
+	},
+/obj/item/ammo_magazine/m545saw{
+	pixel_x = 6
+	},
+/obj/item/ammo_magazine/m545saw{
+	pixel_x = 2
+	},
+/obj/item/ammo_magazine/m545saw{
+	pixel_x = -2
+	},
+/obj/item/ammo_magazine/m545saw{
+	pixel_x = -6
+	},
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/armoury_dl)
+"rh" = (
+/turf/simulated/floor/reinforced/airless,
+/area/ship/ert/med)
+"rn" = (
+/obj/machinery/alarm/alarms_hidden{
+	dir = 1;
+	pixel_y = -26
 	},
 /turf/simulated/floor/tiled/white,
 /area/ship/ert/med_surg)
 "rp" = (
-/obj/structure/disposaloutlet,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/warning,
-/turf/simulated/floor/airless,
+/turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/gunnery)
 "rr" = (
-/obj/machinery/door/airlock/glass_external,
-/obj/effect/map_helper/airlock/door/ext_door,
-/turf/simulated/floor/airless,
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc/hyper{
+	alarms_hidden = 1;
+	dir = 8;
+	name = "VB APC - West";
+	pixel_x = -24
+	},
+/turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/gunnery)
 "rs" = (
-/obj/machinery/atmospherics/pipe/simple/visible/universal,
+/obj/machinery/power/apc/hyper{
+	alarms_hidden = 1;
+	dir = 4;
+	name = "VB APC - East";
+	pixel_x = 24
+	},
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/engine)
 "rt" = (
-/obj/machinery/atmospherics/pipe/tank/air{
-	dir = 4;
-	start_pressure = 740.5
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/dock_star)
-"ry" = (
-/obj/machinery/light/no_nightshift{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/machinery/light_switch{
-	pixel_y = 23
-	},
-/obj/structure/table/steel_reinforced,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/engineering)
-"rA" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/engine)
-"rB" = (
-/obj/structure/ship_munition/disperser_charge/emp,
-/obj/effect/floor_decal/industrial/warning,
-/obj/structure/railing,
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/reinforced,
-/area/ship/ert/gunnery)
-"rD" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/wall/rshull,
+/area/ship/ert/engine)
+"ry" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/engineering)
+"rA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 10
 	},
@@ -3407,47 +3685,148 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/engine)
-"rM" = (
-/obj/machinery/atmospherics/pipe/tank/air,
-/turf/simulated/floor/airless,
-/area/ship/ert/gunnery)
+"rD" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/brig)
 "rN" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/table/steel_reinforced,
+/obj/item/rig_module/mounted{
+	pixel_x = -4;
+	pixel_y = -4
+	},
+/obj/item/rig_module/mounted/egun{
+	pixel_x = -2;
+	pixel_y = -2
+	},
+/obj/item/rig_module/mounted/egun,
+/obj/item/rig_module/mounted/egun{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/rig_module/mounted/egun{
+	pixel_x = 4;
+	pixel_y = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/gunnery)
+/area/ship/ert/mech_bay)
 "rO" = (
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/gunnery)
-"rP" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/wall/rshull,
-/area/ship/ert/med_surg)
-"rR" = (
-/obj/machinery/atmospherics/pipe/tank/phoron{
+/obj/structure/table/steel_reinforced,
+/obj/machinery/light/no_nightshift{
 	dir = 8
 	},
-/obj/machinery/light/no_nightshift{
-	dir = 4
+/obj/machinery/firealarm/alarms_hidden{
+	pixel_y = 26
+	},
+/obj/machinery/light_switch{
+	dir = 4;
+	pixel_x = -23
+	},
+/obj/item/rig_module/sprinter{
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/obj/item/rig_module/sprinter{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/rig_module/rescue_pharm{
+	pixel_y = -2
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/engine)
+/area/ship/ert/mech_bay)
+"rP" = (
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/hallways_aft)
+"rR" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/dock_port)
 "rS" = (
-/obj/machinery/atmospherics/portables_connector{
+/obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 4
 	},
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/effect/floor_decal/industrial/outline/blue,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/atmos)
 "rV" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock/glass{
+	req_one_access = list(103)
+	},
+/obj/structure/sign/warning/airlock{
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/dock_port)
+"sc" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/blast/regular/open{
+	id = "VB_Rear_Blast";
+	name = "Blast Shield"
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/engineering)
+"sd" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/eng_storage)
+"sf" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/barracks)
+"sk" = (
 /obj/machinery/door/airlock/glass_medical{
 	name = "Medical Bay";
 	req_access = list(103)
@@ -3457,179 +3836,170 @@
 /obj/machinery/door/firedoor/multi_tile,
 /turf/simulated/floor/tiled/techmaint,
 /area/ship/ert/hangar)
-"sd" = (
-/obj/effect/floor_decal/corner/yellow{
-	dir = 9
+"sq" = (
+/obj/structure/table/rack,
+/obj/item/weapon/storage/secure/briefcase/nsfw_pack_hybrid,
+/obj/item/weapon/storage/belt/explorer/pathfinder{
+	name = "ERT belt"
 	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/med)
-"sf" = (
-/obj/structure/table/steel_reinforced,
-/obj/machinery/chemical_dispenser/ert,
-/obj/item/weapon/reagent_containers/glass/beaker/large,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/med)
-"so" = (
-/obj/machinery/light/no_nightshift,
-/obj/effect/floor_decal/industrial/outline/grey,
+/turf/simulated/floor/wood,
+/area/ship/ert/commander)
+"sr" = (
 /obj/structure/table/rack/steel,
-/obj/item/clothing/accessory/storage/brown_vest{
+/obj/item/clothing/glasses/night{
+	pixel_x = -4;
 	pixel_y = -4
 	},
-/obj/item/clothing/accessory/storage/brown_vest{
+/obj/item/clothing/glasses/night{
+	pixel_x = -2;
 	pixel_y = -2
 	},
-/obj/item/clothing/accessory/storage/brown_vest,
-/obj/item/clothing/accessory/storage/brown_vest{
+/obj/item/clothing/glasses/night,
+/obj/item/clothing/glasses/night{
+	pixel_x = 2;
 	pixel_y = 2
 	},
-/obj/item/clothing/accessory/storage/brown_vest{
+/obj/item/clothing/glasses/night{
+	pixel_x = 4;
 	pixel_y = 4
 	},
-/obj/item/clothing/accessory/storage/brown_vest{
+/obj/item/clothing/glasses/night{
+	pixel_x = 6;
 	pixel_y = 6
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/barracks)
-"sp" = (
-/turf/simulated/wall/rshull,
-/area/ship/ert/commander)
-"sq" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/atm{
+	pixel_y = 26
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/dock_port)
-"sr" = (
-/obj/machinery/vending/food,
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/barracks)
 "sw" = (
-/obj/machinery/firealarm/alarms_hidden{
-	pixel_y = 26
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id = "braun_cells_privacy";
+	name = "Privacy Shutters";
+	opacity = 0
 	},
+/obj/machinery/door/airlock/glass{
+	req_one_access = list(103)
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/teleporter)
+/area/ship/ert/brig)
+"sy" = (
+/obj/effect/floor_decal/corner/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/hangar)
 "sz" = (
-/obj/structure/closet/wardrobe/ert,
-/obj/item/modular_computer/tablet/preset/custom_loadout/elite,
-/obj/item/weapon/storage/box/survival/comp{
-	starts_with = list(/obj/item/weapon/tool/prybar/red,/obj/item/clothing/glasses/goggles,/obj/item/weapon/reagent_containers/hypospray/autoinjector,/obj/item/stack/medical/bruise_pack,/obj/item/device/flashlight/glowstick,/obj/item/weapon/reagent_containers/food/snacks/candy/proteinbar,/obj/item/clothing/mask/breath,/obj/item/weapon/tank/emergency/oxygen/engi)
-	},
-/obj/machinery/light/no_nightshift,
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/item/modular_computer/laptop/preset/custom_loadout/elite,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/barracks)
+/obj/structure/filingcabinet/filingcabinet,
+/turf/simulated/floor/wood,
+/area/ship/ert/commander)
 "sA" = (
+/obj/machinery/door/airlock/glass_command{
+	req_one_access = list(103)
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/item/modular_computer/console/preset/medical{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/techfloor,
+/obj/machinery/door/firedoor/border_only,
+/turf/simulated/floor/tiled/techmaint,
 /area/ship/ert/bridge)
-"sB" = (
-/obj/structure/hull_corner,
-/turf/simulated/floor/reinforced/airless,
-/area/ship/ert/barracks)
-"sC" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+"sF" = (
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/mech_bay)
+"sI" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/multi_tile{
 	dir = 1
+	},
+/obj/machinery/door/airlock/glass_security{
+	name = "Delta Armoury";
+	req_one_access = list(103)
+	},
+/obj/machinery/door/blast/regular{
+	closed_layer = 4;
+	id = "NRV_DELTA";
+	layer = 4
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/dock_star)
-"sF" = (
-/obj/structure/table/rack/steel,
-/obj/item/clothing/glasses/graviton{
-	pixel_x = -2;
-	pixel_y = -2
-	},
-/obj/item/clothing/glasses/graviton,
-/obj/item/clothing/glasses/graviton{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/item/clothing/glasses/graviton{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/barracks)
-"sH" = (
-/obj/machinery/computer/ship/sensors,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/structure/railing/grey{
+/area/ship/ert/armoury_dl)
+"sJ" = (
+/obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
 /turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/bridge)
-"sJ" = (
-/obj/structure/table/rack/steel,
-/obj/item/clothing/accessory/storage/black_vest{
-	pixel_x = -4;
+/area/ship/ert/brig)
+"sM" = (
+/obj/structure/bed/chair/bay/shuttle{
+	dir = 1
+	},
+/obj/machinery/recharger/wallcharger{
+	pixel_x = -23;
+	pixel_y = -12
+	},
+/obj/machinery/recharger/wallcharger{
+	pixel_x = -23;
 	pixel_y = -4
 	},
-/obj/item/clothing/accessory/storage/black_vest{
-	pixel_x = -2;
-	pixel_y = -2
+/obj/machinery/recharger/wallcharger{
+	pixel_x = -23;
+	pixel_y = 5
 	},
-/obj/item/clothing/accessory/storage/black_vest,
-/obj/item/clothing/accessory/storage/black_vest{
-	pixel_x = 2;
-	pixel_y = 2
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/ert_ship_boat)
+"sN" = (
+/obj/machinery/light/no_nightshift{
+	dir = 4
 	},
-/obj/item/clothing/accessory/storage/black_vest{
-	pixel_x = 4;
-	pixel_y = 4
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/teleporter)
+"sR" = (
+/obj/structure/table/rack/steel,
+/obj/item/weapon/gun/energy/xray{
+	pixel_y = -3
 	},
-/obj/item/clothing/accessory/storage/black_vest{
-	pixel_x = 6;
-	pixel_y = 6
+/obj/item/weapon/gun/energy/xray{
+	pixel_y = 3
 	},
-/obj/machinery/alarm/alarms_hidden{
+/obj/machinery/light/no_nightshift,
+/obj/machinery/firealarm/alarms_hidden{
 	dir = 1;
 	pixel_y = -26
 	},
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/barracks)
-"sS" = (
-/obj/machinery/shieldwallgen,
-/obj/machinery/light/no_nightshift{
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/outline/blue,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/eng_storage)
+/area/ship/ert/armoury_dl)
 "sU" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -3643,219 +4013,246 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/med)
+/area/ship/ert/eng_storage)
 "sW" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
 /obj/structure/cable/yellow{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/eng_storage)
+/obj/machinery/light/no_nightshift{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/dock_star)
 "sX" = (
+/obj/structure/bed/chair/bay/comfy/captain{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/button/remote/blast_door{
+	dir = 8;
+	id = "braun_blast_shields";
+	name = "Blast Shields Control";
+	pixel_x = 32;
+	pixel_y = 35;
+	req_one_access = list(101)
+	},
 /turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/hallways)
+/area/ship/ert/bridge)
 "ta" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor/multi_tile,
-/obj/machinery/door/airlock/multi_tile/glass{
-	req_one_access = list(103)
+/obj/machinery/airlock_sensor{
+	dir = 8;
+	pixel_x = 22;
+	pixel_y = -24
 	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/hangar)
-"tg" = (
-/obj/effect/floor_decal/corner/white{
-	dir = 6
+/obj/effect/map_helper/airlock/sensor/int_sensor,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/gunnery)
+"th" = (
+/obj/structure/hull_corner{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/techmaint,
+/turf/simulated/floor/reinforced/airless,
 /area/ship/ert/med)
 "tp" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/light/no_nightshift{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/dock_star)
-"tx" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/ship/ert/med_surg)
-"tA" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/dock_star)
-"tE" = (
-/obj/structure/sign/department/dock{
-	name = "ROBINEAU DOCK"
-	},
-/turf/simulated/wall/shull,
-/area/ship/ert/hangar)
-"tH" = (
-/turf/simulated/wall/rshull,
-/area/ship/ert/armoury_st)
-"tK" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/machinery/door/window/brigdoor/northleft,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
+/obj/machinery/door/airlock/glass_external,
+/obj/effect/map_helper/airlock/door/int_door,
 /turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/hallways_aft)
-"tL" = (
-/obj/machinery/atmospherics/pipe/simple/visible/fuel{
-	dir = 9
-	},
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/machinery/door/blast/regular/open{
-	id = "VB_Rear_Blast";
-	name = "Blast Shield"
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/ship/ert/engine)
-"tV" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/obj/machinery/light/no_nightshift,
-/turf/simulated/floor/tiled/techmaint,
-/area/shuttle/ert_ship_boat)
-"tW" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/obj/machinery/light/no_nightshift{
-	dir = 1
-	},
-/obj/machinery/embedded_controller/radio/simple_docking_controller{
-	id_tag = "ert_boarding_shuttle";
-	pixel_x = -8;
-	pixel_y = 22
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/shuttle/ert_ship_boat)
-"tX" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/machinery/door/firedoor/border_only,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/mech_bay)
-"tZ" = (
-/obj/effect/floor_decal/industrial/warning,
-/turf/simulated/floor/airless,
 /area/ship/ert/gunnery)
-"uf" = (
-/obj/structure/sign/nosmoking_1,
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/wall/rshull,
-/area/ship/ert/engine)
-"ug" = (
-/obj/item/device/healthanalyzer/phasic{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/item/device/healthanalyzer/phasic,
-/obj/item/device/healthanalyzer/phasic{
-	pixel_x = -2;
-	pixel_y = -2
-	},
-/obj/structure/table/rack/steel,
-/obj/machinery/atmospherics/unary/vent_pump/on{
+"ts" = (
+/obj/effect/floor_decal/industrial/warning{
 	dir = 1
-	},
-/obj/effect/floor_decal/industrial/outline,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/med)
-"uh" = (
-/obj/machinery/atmospherics/pipe/simple/visible/fuel{
-	dir = 10
-	},
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/machinery/door/blast/regular/open{
-	id = "VB_Rear_Blast";
-	name = "Blast Shield"
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/ship/ert/engine)
-"um" = (
-/obj/machinery/vending/engineering,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/eng_storage)
-"un" = (
-/obj/machinery/door/airlock/glass_medical{
-	name = "Medical Bay";
-	req_access = list(103)
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/effect/floor_decal/corner/white,
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/hangar)
+"tv" = (
+/obj/effect/floor_decal/corner/white{
+	dir = 8
+	},
+/obj/machinery/light/no_nightshift{
+	dir = 1
+	},
+/obj/machinery/alarm/alarms_hidden{
+	pixel_y = 26
+	},
+/obj/machinery/recharge_station,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/med)
+"tx" = (
+/obj/effect/map_helper/airlock/atmos/chamber_pump,
+/obj/effect/map_helper/airlock/sensor/chamber_sensor,
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 1
+	},
+/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
+	id_tag = "vb_cannon_loader";
+	pixel_x = 24;
+	pixel_y = 23
+	},
+/obj/machinery/airlock_sensor{
+	pixel_x = -25;
+	pixel_y = 22
+	},
+/turf/simulated/floor/airless,
+/area/ship/ert/gunnery)
+"tA" = (
+/obj/machinery/door/airlock/glass_external,
+/obj/effect/map_helper/airlock/door/ext_door,
+/turf/simulated/floor/airless,
+/area/ship/ert/gunnery)
+"tE" = (
+/obj/effect/map_helper/airlock/sensor/ext_sensor,
+/obj/machinery/airlock_sensor/airlock_exterior{
+	dir = 4;
+	pixel_x = 24;
+	pixel_y = 24
+	},
+/turf/simulated/floor/airless,
+/area/ship/ert/gunnery)
+"tH" = (
+/turf/simulated/wall/rshull,
+/area/ship/ert/armoury_st)
+"tL" = (
+/obj/machinery/flasher,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/ship/ert/brig)
+"tW" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/door/blast/regular/open{
+	dir = 2;
+	id = "braun_blast_shields";
+	name = "Blast Shield"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/armoury_st)
+"tX" = (
+/turf/simulated/wall/shull,
+/area/ship/ert/hangar)
+"tZ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/med)
-"uq" = (
-/obj/structure/sign/department/medbay,
-/turf/simulated/wall/shull,
-/area/ship/ert/med_surg)
-"us" = (
+/area/ship/ert/gunnery)
+"ua" = (
+/obj/structure/table/steel_reinforced,
+/obj/machinery/chemical_dispenser/full,
+/obj/item/weapon/reagent_containers/glass/beaker/large,
 /turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/bridge)
-"uu" = (
-/obj/machinery/firealarm/alarms_hidden{
-	pixel_y = 26
+/area/ship/ert/med)
+"uc" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/light/no_nightshift{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/dock_star)
-"ux" = (
+/area/ship/ert/bridge)
+"ue" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/white,
+/area/ship/ert/med_surg)
+"uf" = (
+/obj/machinery/light/no_nightshift{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/engine)
+"uh" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/engine)
+"uj" = (
+/obj/structure/hull_corner{
+	dir = 1
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/ship/ert/eng_storage)
+"uq" = (
+/obj/machinery/light/no_nightshift{
+	dir = 1
+	},
+/turf/simulated/floor/airless,
+/area/ship/ert/gunnery)
+"us" = (
+/obj/item/weapon/storage/box/trackimp,
+/obj/item/weapon/storage/box/cdeathalarm_kit,
+/obj/item/weapon/stamp/centcomm,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/table/hardwoodtable,
+/turf/simulated/floor/wood,
+/area/ship/ert/commander)
+"uu" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/hallways_aft)
+"uD" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
@@ -3864,81 +4261,40 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/engine)
 "uE" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 8
+/obj/structure/hull_corner/long_horiz{
+	dir = 5
 	},
-/obj/effect/map_helper/airlock/atmos/chamber_pump,
-/obj/effect/floor_decal/industrial/warning,
-/obj/structure/sign/vacuum{
-	pixel_x = -32
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/dock_star)
+/turf/simulated/floor/reinforced/airless,
+/area/ship/ert/hallways_aft)
 "uG" = (
-/obj/item/modular_computer/console/preset/sysadmin{
-	dir = 1
+/obj/structure/window/reinforced,
+/obj/effect/floor_decal/industrial/warning,
+/obj/structure/cable/yellow,
+/obj/machinery/shieldwallgen{
+	anchored = 1;
+	name = "secured shield generator";
+	req_access = list(103);
+	state = 1
 	},
+/obj/effect/floor_decal/industrial/outline/blue,
 /turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/bridge)
+/area/ship/ert/teleporter)
 "uJ" = (
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+/obj/machinery/light/no_nightshift,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/hallways_aft)
+"uK" = (
+/obj/machinery/atmospherics/pipe/tank/phoron{
+	dir = 8
 	},
 /obj/machinery/light/no_nightshift{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/dock_star)
-"uK" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/yellow{
-	dir = 8
+	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/engine)
 "uS" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/engine)
-"vb" = (
-/obj/machinery/sleeper{
-	dir = 4
-	},
-/obj/machinery/light/no_nightshift{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/ship/ert/med_surg)
-"vd" = (
-/obj/machinery/atmospherics/pipe/tank/phoron{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/engine)
-"vg" = (
-/obj/machinery/atmospherics/pipe/simple/visible,
-/obj/machinery/meter,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/atmos)
-"vi" = (
 /obj/machinery/door/airlock/glass_engineering{
-	name = "Engineering";
+	name = "Engine Bay";
 	req_access = list(103)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -3959,121 +4315,361 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/ship/ert/engineering)
-"vt" = (
-/obj/effect/floor_decal/corner/yellow{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/red{
-	dir = 6
-	},
-/obj/machinery/light/no_nightshift,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+"vb" = (
+/obj/machinery/light/no_nightshift{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/light_switch{
-	dir = 1;
-	pixel_y = -23
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/hallways)
-"vv" = (
-/obj/machinery/firealarm/alarms_hidden{
-	dir = 1;
-	pixel_y = -26
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/hallways_aft)
-"vw" = (
+/turf/simulated/floor/reinforced/airless,
+/area/ship/ert/engine)
+"vd" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/wall/shull,
-/area/ship/ert/barracks)
+/turf/simulated/wall/rshull,
+/area/ship/ert/engine)
+"vi" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/engineering)
+"vn" = (
+/obj/machinery/recharge_station,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/med)
+"vo" = (
+/obj/structure/window/reinforced,
+/obj/machinery/computer/shuttle_control/explore/ert_ship_boat{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/shuttle/ert_ship_boat)
+"vp" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/light/no_nightshift{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/dock_star)
+"vt" = (
+/obj/item/modular_computer/console/preset/sysadmin{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/bridge)
+"vw" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 4
+	},
+/obj/machinery/meter,
+/obj/machinery/power/apc/hyper{
+	alarms_hidden = 1;
+	dir = 1;
+	name = "VB APC - North";
+	pixel_y = 24
+	},
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/dock_port)
 "vK" = (
 /turf/simulated/wall/rshull,
 /area/ship/ert/gunnery)
-"vQ" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/warning,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/teleporter)
 "vX" = (
 /turf/simulated/wall/shull,
 /area/ship/ert/engineering)
+"vY" = (
+/obj/machinery/alarm/alarms_hidden{
+	dir = 8;
+	pixel_x = 26
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/ship/ert/brig)
 "wd" = (
-/obj/structure/sign/department/conference_room{
-	name = "OUTFITTING"
+/obj/machinery/atmospherics/pipe/tank/air{
+	dir = 4
 	},
-/turf/simulated/wall/rshull,
-/area/ship/ert/bridge)
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/atmos)
 "wh" = (
-/obj/machinery/light/no_nightshift{
-	dir = 1
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/gunnery)
 "wi" = (
+/obj/machinery/light/no_nightshift{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor/multi_tile,
-/obj/machinery/door/airlock/multi_tile/glass{
-	req_one_access = list(103)
-	},
 /turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/hallways)
-"wl" = (
-/obj/structure/table/rack/steel,
-/obj/item/weapon/gun/energy/gun{
-	pixel_y = 6
-	},
-/obj/item/weapon/gun/energy/gun{
-	pixel_y = 4
-	},
-/obj/item/weapon/gun/energy/gun{
-	pixel_y = 2
-	},
-/obj/item/weapon/gun/energy/gun,
-/obj/item/weapon/gun/energy/gun{
-	pixel_y = -2
-	},
-/obj/item/weapon/gun/energy/gun{
-	pixel_y = -4
-	},
-/obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/armoury_st)
-"wn" = (
-/obj/structure/sign/department/telecoms{
-	name = "TELEPORTER"
-	},
-/turf/simulated/wall/rshull,
-/area/ship/ert/teleporter)
-"wo" = (
-/obj/machinery/light/no_nightshift,
-/obj/machinery/teleport/hub,
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/teleporter)
+/area/ship/ert/hallways_aft)
 "wp" = (
-/obj/machinery/sleep_console,
+/turf/simulated/wall/shull,
+/area/ship/ert/med)
+"wq" = (
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id = "braun_cells_privacy";
+	name = "Privacy Shutters";
+	opacity = 0
+	},
+/obj/structure/grille,
+/obj/structure/window/titanium/full,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium,
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/brig)
+"wC" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/light_switch{
+	dir = 8;
+	pixel_x = 23
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/dock_port)
+"wG" = (
+/obj/structure/reagent_dispensers/water_cooler/full,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/barracks)
+"wI" = (
+/obj/machinery/door/firedoor/multi_tile{
+	dir = 1
+	},
+/obj/machinery/door/airlock/glass_medical{
+	name = "Medical Bay";
+	req_access = list(103)
+	},
 /turf/simulated/floor/tiled/white,
 /area/ship/ert/med_surg)
-"wr" = (
+"wM" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/wall/shull,
+/area/ship/ert/med_surg)
+"wO" = (
+/obj/machinery/light/no_nightshift,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/engineering)
+"wU" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/barracks)
+"wX" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/med)
+"wZ" = (
+/obj/machinery/power/apc/hyper{
+	alarms_hidden = 1;
+	name = "VB APC - South";
+	pixel_y = -24
+	},
+/obj/structure/cable/yellow,
+/turf/simulated/floor/tiled/white,
+/area/ship/ert/med_surg)
+"xc" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/barracks)
+"xe" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/glass_security{
+	name = "Prisoner Containment";
+	req_one_access = list(103)
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/brig)
+"xg" = (
+/obj/structure/sign/department/conference_room{
+	name = "OUTFITTING"
+	},
+/turf/simulated/wall/rshull,
+/area/ship/ert/bridge)
+"xj" = (
+/obj/machinery/door/window/brigdoor/northright,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/hallways_aft)
+"xo" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/white{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/hangar)
+"xq" = (
+/obj/structure/bed/chair/bay/shuttle,
+/obj/machinery/light/no_nightshift{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/ert_ship_boat)
+"xt" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/barracks)
+"xv" = (
+/obj/structure/table/rack/steel,
+/obj/item/weapon/melee/baton{
+	pixel_x = -6
+	},
+/obj/item/weapon/melee/baton{
+	pixel_x = -2
+	},
+/obj/item/weapon/melee/baton{
+	pixel_x = 2
+	},
+/obj/item/weapon/melee/baton{
+	pixel_x = 6
+	},
+/obj/item/weapon/shield/riot{
+	pixel_x = -6
+	},
+/obj/item/weapon/shield/riot{
+	pixel_x = -2
+	},
+/obj/item/weapon/shield/riot{
+	pixel_x = 2
+	},
+/obj/item/weapon/shield/riot{
+	pixel_x = 6
+	},
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/recharger/wallcharger{
+	pixel_x = -23;
+	pixel_y = 5
+	},
+/obj/machinery/recharger/wallcharger{
+	pixel_x = -23;
+	pixel_y = -4
+	},
+/obj/machinery/recharger/wallcharger{
+	pixel_x = -23;
+	pixel_y = -12
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/armoury_st)
+"xx" = (
 /obj/machinery/power/pointdefense{
 	id_tag = "vonbraun_pd"
 	},
@@ -4083,7 +4679,7 @@
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/ship/ert/hallways_aft)
-"wt" = (
+"xz" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/weapon/storage/firstaid/bonemed{
 	pixel_x = 4;
@@ -4103,82 +4699,51 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/med)
-"wC" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/tiled/white,
-/area/ship/ert/med_surg)
-"wG" = (
-/obj/structure/hull_corner/long_horiz{
-	dir = 5
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/ship/ert/engine)
-"wO" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
+"xC" = (
 /turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/engineering)
-"wU" = (
-/turf/simulated/wall/shull,
-/area/ship/ert/hallways)
-"wX" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
+/area/ship/ert/dock_star)
+"xD" = (
+/obj/structure/table/rack/steel,
+/obj/item/clothing/glasses/night{
+	pixel_x = -4;
+	pixel_y = -4
 	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/med)
-"wZ" = (
-/obj/machinery/oxygen_pump/anesthetic,
-/turf/simulated/wall/shull,
-/area/ship/ert/med_surg)
-"xc" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/item/clothing/glasses/night{
+	pixel_x = -2;
+	pixel_y = -2
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/item/clothing/glasses/night,
+/obj/item/clothing/glasses/night{
+	pixel_x = 2;
+	pixel_y = 2
 	},
-/obj/effect/landmark{
-	name = "Commando"
+/obj/item/clothing/glasses/night{
+	pixel_x = 4;
+	pixel_y = 4
 	},
+/obj/item/clothing/glasses/night{
+	pixel_x = 6;
+	pixel_y = 6
+	},
+/obj/machinery/firealarm/alarms_hidden{
+	pixel_y = 26
+	},
+/obj/effect/floor_decal/industrial/outline/grey,
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/techmaint,
+/turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/barracks)
-"xe" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/light/no_nightshift{
+"xE" = (
+/obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/bridge)
-"xg" = (
+/obj/structure/ship_munition/disperser_charge/emp,
+/turf/simulated/floor/reinforced,
+/area/ship/ert/hallways_aft)
+"xG" = (
 /obj/structure/table/rack/steel,
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/item/weapon/gun/energy/gun/nuclear{
@@ -4199,7 +4764,21 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/armoury_st)
-"xh" = (
+"xK" = (
+/obj/machinery/door/airlock/centcom{
+	name = "Commander's Quarters";
+	req_access = list(103)
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor/border_only,
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/commander)
+"xM" = (
 /obj/structure/table/rack/steel,
 /obj/machinery/light_switch{
 	pixel_y = 23
@@ -4257,7 +4836,2099 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/armoury_st)
-"xi" = (
+"xO" = (
+/obj/effect/floor_decal/industrial/warning,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/hangar)
+"xU" = (
+/obj/effect/floor_decal/corner/white{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/med)
+"xX" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/corner/blue{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/bridge)
+"xZ" = (
+/obj/item/modular_computer/console/preset/ert{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/bridge)
+"ya" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/gunnery)
+"yb" = (
+/obj/machinery/button/flasher{
+	pixel_x = -9;
+	pixel_y = 22
+	},
+/obj/machinery/button/remote/blast_door{
+	id = "braun_cells_privacy";
+	name = "Privacy Shutter Controls";
+	pixel_x = 8;
+	pixel_y = 25;
+	req_access = list(103)
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/brig)
+"yf" = (
+/obj/structure/table/rack/steel,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/item/ammo_magazine/m545{
+	pixel_x = -8
+	},
+/obj/item/ammo_magazine/m545{
+	pixel_x = -5
+	},
+/obj/item/ammo_magazine/m545{
+	pixel_x = -2
+	},
+/obj/item/ammo_magazine/m545{
+	pixel_x = 1
+	},
+/obj/item/ammo_magazine/m545{
+	pixel_x = 4
+	},
+/obj/item/ammo_magazine/m545{
+	pixel_x = 7
+	},
+/obj/item/weapon/gun/projectile/automatic/sts35{
+	pixel_y = -2
+	},
+/obj/item/weapon/gun/projectile/automatic/sts35{
+	pixel_y = 2
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/armoury_st)
+"yg" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/machinery/light/no_nightshift{
+	dir = 1
+	},
+/obj/machinery/embedded_controller/radio/simple_docking_controller{
+	id_tag = "ert_boarding_shuttle";
+	pixel_x = -8;
+	pixel_y = 22
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/shuttle/ert_ship_boat)
+"yi" = (
+/obj/structure/table/rack/steel,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/item/weapon/gun/projectile/automatic/z8{
+	pixel_y = -3
+	},
+/obj/item/weapon/gun/projectile/automatic/z8{
+	pixel_y = 3
+	},
+/obj/item/ammo_magazine/m762,
+/obj/item/ammo_magazine/m762,
+/obj/item/ammo_magazine/m762,
+/obj/item/ammo_magazine/m762,
+/obj/item/ammo_magazine/m762,
+/obj/item/ammo_magazine/m762,
+/obj/item/ammo_magazine/m762,
+/obj/item/ammo_magazine/m762,
+/obj/item/ammo_magazine/m762/ap,
+/obj/item/ammo_magazine/m762/ap,
+/obj/item/ammo_magazine/m762/ap,
+/obj/item/ammo_magazine/m762/ap,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/armoury_dl)
+"yj" = (
+/obj/structure/table/rack/steel,
+/obj/item/weapon/storage/box/flashbangs,
+/obj/item/weapon/storage/box/flashbangs,
+/obj/machinery/light/no_nightshift{
+	dir = 1
+	},
+/obj/machinery/alarm/alarms_hidden{
+	pixel_y = 26
+	},
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/item/weapon/storage/box/flashbangs,
+/obj/item/weapon/storage/box/smokes,
+/obj/item/weapon/storage/box/smokes,
+/obj/item/weapon/storage/box/teargas,
+/obj/item/weapon/storage/box/empslite,
+/obj/item/weapon/storage/box/empslite,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/armoury_st)
+"yl" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/door/blast/regular/open{
+	dir = 4;
+	id = "braun_blast_shields";
+	name = "Blast Shield"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/hallways_aft)
+"yo" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/gunnery)
+"yr" = (
+/obj/structure/bed/chair/bay/shuttle{
+	dir = 1
+	},
+/obj/machinery/light/no_nightshift{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/ert_ship_boat)
+"ys" = (
+/obj/structure/hull_corner{
+	dir = 1
+	},
+/turf/simulated/shuttle/plating/airless/carry,
+/area/shuttle/ert_ship_boat)
+"yv" = (
+/obj/machinery/computer/ship/sensors,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/gunnery)
+"yx" = (
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/machinery/alarm/alarms_hidden{
+	pixel_y = 26
+	},
+/obj/machinery/light_switch{
+	dir = 4;
+	pixel_x = -23
+	},
+/obj/effect/floor_decal/industrial/outline,
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/hangar)
+"yz" = (
+/turf/space,
+/area/space)
+"yB" = (
+/obj/structure/grille,
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/turf/simulated/floor/airless,
+/area/ship/ert/gunnery)
+"yD" = (
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/airless,
+/area/ship/ert/gunnery)
+"yF" = (
+/obj/machinery/sleeper{
+	dir = 4
+	},
+/obj/machinery/light/no_nightshift{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/ship/ert/med_surg)
+"yG" = (
+/obj/machinery/light/no_nightshift{
+	dir = 1
+	},
+/obj/machinery/atmospherics/unary/engine{
+	dir = 4
+	},
+/turf/space,
+/area/ship/ert/engine)
+"yH" = (
+/obj/machinery/alarm/alarms_hidden{
+	dir = 1;
+	pixel_y = -26
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/engine)
+"yJ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/hallways_aft)
+"yK" = (
+/obj/structure/bed/pod,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/ship/ert/brig)
+"yL" = (
+/obj/machinery/flasher,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/ship/ert/brig)
+"yM" = (
+/obj/machinery/atmospherics/pipe/tank/air{
+	dir = 4;
+	start_pressure = 740.5
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/dock_star)
+"yP" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/hangar)
+"yR" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/light/no_nightshift{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/dock_port)
+"yU" = (
+/obj/structure/table/rack/steel,
+/obj/effect/floor_decal/corner/red,
+/obj/item/device/radio/off{
+	pixel_x = -4;
+	pixel_y = -4
+	},
+/obj/item/device/radio/off{
+	pixel_x = -2;
+	pixel_y = -2
+	},
+/obj/item/device/radio/off,
+/obj/item/device/radio/off{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/device/radio/off{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/device/radio/off{
+	pixel_x = 6;
+	pixel_y = 6
+	},
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/hallways)
+"yX" = (
+/obj/effect/floor_decal/industrial/warning,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/embedded_controller/radio/simple_docking_controller{
+	id_tag = "ert_boarding_shuttle_dock";
+	pixel_y = 22
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/hangar)
+"yY" = (
+/turf/simulated/floor/reinforced/airless,
+/area/ship/ert/barracks)
+"za" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/machinery/button/remote/blast_door{
+	id = "ERT_Shuttle_Fore";
+	name = "ERT Deployment Access";
+	pixel_y = 24;
+	req_access = list(103)
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/shuttle/ert_ship_boat)
+"zb" = (
+/obj/effect/floor_decal/corner/white{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/med)
+"zg" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/alarm/alarms_hidden{
+	pixel_y = 26
+	},
+/obj/machinery/porta_turret/industrial/teleport_defense,
+/obj/effect/floor_decal/industrial/outline/red,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/teleporter)
+"zh" = (
+/obj/machinery/light/no_nightshift{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/light_switch{
+	pixel_y = 23
+	},
+/obj/structure/table/steel_reinforced,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/engineering)
+"zk" = (
+/obj/machinery/atmospherics/pipe/manifold/visible/yellow{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/engine)
+"zo" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/teleporter)
+"zs" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/bridge)
+"zK" = (
+/obj/machinery/alarm/alarms_hidden{
+	pixel_y = 26
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/hallways_aft)
+"zO" = (
+/obj/machinery/vending/engivend,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/eng_storage)
+"Ad" = (
+/obj/structure/closet/crate/freezer,
+/obj/item/weapon/reagent_containers/blood/OMinus,
+/obj/item/weapon/reagent_containers/blood/OMinus,
+/obj/item/weapon/reagent_containers/blood/OMinus,
+/obj/item/weapon/reagent_containers/blood/OMinus,
+/obj/item/weapon/reagent_containers/blood/OMinus,
+/obj/item/weapon/reagent_containers/blood/OMinus,
+/obj/item/weapon/reagent_containers/blood/OMinus,
+/obj/item/weapon/reagent_containers/blood/OMinus,
+/obj/effect/floor_decal/industrial/outline,
+/turf/simulated/floor/tiled/white,
+/area/ship/ert/med_surg)
+"Af" = (
+/obj/machinery/light/no_nightshift,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/table/rack/steel,
+/obj/item/clothing/accessory/storage/brown_vest{
+	pixel_y = -4
+	},
+/obj/item/clothing/accessory/storage/brown_vest{
+	pixel_y = -2
+	},
+/obj/item/clothing/accessory/storage/brown_vest,
+/obj/item/clothing/accessory/storage/brown_vest{
+	pixel_y = 2
+	},
+/obj/item/clothing/accessory/storage/brown_vest{
+	pixel_y = 4
+	},
+/obj/item/clothing/accessory/storage/brown_vest{
+	pixel_y = 6
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/barracks)
+"Ao" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/turf/simulated/floor/wood,
+/area/ship/ert/commander)
+"Aq" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/wood,
+/area/ship/ert/commander)
+"Ar" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/table/rack/steel,
+/obj/structure/table/rack/steel,
+/obj/item/weapon/storage/belt/utility/chief/full{
+	pixel_y = -2
+	},
+/obj/item/weapon/storage/belt/utility/chief/full,
+/obj/item/weapon/storage/belt/utility/chief/full{
+	pixel_y = 2
+	},
+/obj/item/weapon/storage/belt/utility/chief/full{
+	pixel_y = 4
+	},
+/obj/item/weapon/storage/belt/utility/chief/full{
+	pixel_y = 6
+	},
+/obj/item/weapon/tank/emergency/oxygen/double,
+/obj/item/weapon/tank/emergency/oxygen/double,
+/obj/item/weapon/tank/emergency/oxygen/double,
+/obj/item/weapon/tank/emergency/oxygen/double,
+/obj/item/weapon/tank/emergency/oxygen/double,
+/obj/item/weapon/storage/belt/explorer/pathfinder{
+	name = "ERT belt"
+	},
+/obj/item/weapon/storage/belt/explorer/pathfinder{
+	name = "ERT belt"
+	},
+/obj/item/weapon/storage/belt/explorer/pathfinder{
+	name = "ERT belt"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/barracks)
+"Av" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/item/weapon/implantpad,
+/obj/item/weapon/implanter,
+/obj/item/weapon/storage/box/admints,
+/obj/structure/table/hardwoodtable,
+/turf/simulated/floor/wood,
+/area/ship/ert/commander)
+"Ax" = (
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/teleporter)
+"Ay" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/bridge)
+"Az" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/barracks)
+"AC" = (
+/obj/structure/bed/chair/bay/shuttle,
+/obj/machinery/recharger/wallcharger{
+	pixel_x = -23;
+	pixel_y = 5
+	},
+/obj/machinery/recharger/wallcharger{
+	pixel_x = -23;
+	pixel_y = -4
+	},
+/obj/machinery/recharger/wallcharger{
+	pixel_x = -23;
+	pixel_y = -12
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/ert_ship_boat)
+"AI" = (
+/turf/simulated/wall/shull,
+/area/ship/ert/eng_storage)
+"AK" = (
+/obj/machinery/power/apc/hyper{
+	alarms_hidden = 1;
+	dir = 4;
+	name = "VB APC - East";
+	pixel_x = 24
+	},
+/obj/structure/cable/yellow{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/wood,
+/area/ship/ert/commander)
+"AN" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/wall/rshull,
+/area/ship/ert/engine)
+"AS" = (
+/obj/structure/closet{
+	name = "custodial"
+	},
+/obj/item/weapon/reagent_containers/spray/cleaner{
+	pixel_x = -6
+	},
+/obj/item/weapon/reagent_containers/spray/cleaner{
+	pixel_x = -2
+	},
+/obj/item/weapon/reagent_containers/spray/cleaner{
+	pixel_x = 2
+	},
+/obj/item/weapon/reagent_containers/spray/cleaner{
+	pixel_x = 6
+	},
+/obj/item/weapon/reagent_containers/glass/bucket{
+	pixel_x = 6
+	},
+/obj/item/weapon/reagent_containers/glass/bucket{
+	pixel_x = 2
+	},
+/obj/item/weapon/reagent_containers/glass/bucket{
+	pixel_x = -2
+	},
+/obj/item/weapon/reagent_containers/glass/bucket{
+	pixel_x = -6
+	},
+/obj/item/weapon/mop{
+	pixel_x = 6
+	},
+/obj/item/weapon/mop{
+	pixel_x = 2
+	},
+/obj/item/weapon/mop{
+	pixel_x = -2
+	},
+/obj/item/weapon/mop{
+	pixel_x = -6
+	},
+/obj/item/weapon/rig/ert/janitor,
+/obj/item/device/lightreplacer{
+	pixel_y = -2
+	},
+/obj/item/device/lightreplacer{
+	pixel_y = 2
+	},
+/obj/item/weapon/storage/box/lights/mixed{
+	pixel_x = -1;
+	pixel_y = -1
+	},
+/obj/item/weapon/storage/box/lights/mixed{
+	pixel_x = 1;
+	pixel_y = 1
+	},
+/obj/machinery/light/no_nightshift,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/barracks)
+"AT" = (
+/obj/item/device/healthanalyzer/phasic{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/device/healthanalyzer/phasic,
+/obj/item/device/healthanalyzer/phasic{
+	pixel_x = -2;
+	pixel_y = -2
+	},
+/obj/structure/table/rack/steel,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/outline,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/med)
+"AW" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/wall/rshull,
+/area/ship/ert/engine)
+"AX" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/barracks)
+"AY" = (
+/obj/machinery/firealarm/alarms_hidden{
+	pixel_y = 26
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/teleporter)
+"Bb" = (
+/obj/machinery/firealarm/alarms_hidden{
+	pixel_y = 26
+	},
+/obj/item/modular_computer/console/preset/security,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/bridge)
+"Bc" = (
+/obj/item/modular_computer/console/preset/security,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/bridge)
+"Bf" = (
+/obj/item/modular_computer/console/preset/research,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/bridge)
+"Bl" = (
+/obj/structure/ship_munition/disperser_charge/explosive,
+/obj/machinery/alarm/alarms_hidden{
+	dir = 1;
+	pixel_y = -26
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor/reinforced,
+/area/ship/ert/gunnery)
+"Bo" = (
+/turf/simulated/wall/shull,
+/area/ship/ert/barracks)
+"Bp" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor/multi_tile,
+/obj/machinery/door/airlock/multi_tile/glass{
+	req_one_access = list(103)
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/hallways)
+"Bq" = (
+/obj/item/modular_computer/console/preset/medical,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/bridge)
+"Br" = (
+/obj/machinery/shieldwallgen,
+/obj/machinery/light/no_nightshift{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/outline/blue,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/eng_storage)
+"Bx" = (
+/obj/structure/table/steel_reinforced,
+/obj/machinery/alarm/alarms_hidden{
+	dir = 1;
+	pixel_y = -26
+	},
+/obj/fiftyspawner/tritium,
+/obj/fiftyspawner/tritium,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/eng_storage)
+"BE" = (
+/obj/effect/floor_decal/corner/blue{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/light/no_nightshift{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/hallways)
+"BF" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/hallways)
+"BI" = (
+/turf/simulated/floor/reinforced/airless,
+/area/ship/ert/engineering)
+"BK" = (
+/obj/machinery/light/no_nightshift{
+	dir = 1
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/ship/ert/engineering)
+"BM" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/mech_bay)
+"BU" = (
+/obj/effect/floor_decal/corner/red{
+	dir = 6
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/light/no_nightshift{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/light_switch{
+	pixel_y = 23
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/hallways)
+"Cf" = (
+/turf/simulated/wall/shull,
+/area/ship/ert/mech_bay)
+"Ci" = (
+/obj/machinery/light/no_nightshift{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning,
+/obj/structure/table/steel_reinforced,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/brig)
+"Ck" = (
+/obj/machinery/door/airlock/glass_medical{
+	name = "Medical Bay";
+	req_access = list(103)
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/hangar)
+"Cn" = (
+/obj/machinery/computer/ship/helm{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/bridge)
+"Cr" = (
+/obj/machinery/door/airlock/glass_medical{
+	name = "Medical Bay";
+	req_access = list(103)
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/med_surg)
+"Cv" = (
+/obj/machinery/door/firedoor/multi_tile{
+	dir = 1
+	},
+/obj/machinery/door/airlock/glass_medical{
+	name = "Medical Bay";
+	req_access = list(103)
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/med)
+"Cx" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/barracks)
+"CC" = (
+/obj/machinery/shieldwallgen{
+	anchored = 1;
+	name = "secured shield generator";
+	req_access = list(103);
+	state = 1
+	},
+/obj/structure/window/reinforced,
+/obj/effect/floor_decal/industrial/warning,
+/obj/structure/cable/yellow,
+/obj/effect/floor_decal/industrial/outline/blue,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/teleporter)
+"CH" = (
+/obj/machinery/door/firedoor,
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced,
+/obj/machinery/door/blast/regular/open{
+	dir = 4;
+	id = "ERT_Blast_Windows";
+	name = "Blast Shield"
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/ert_ship_boat)
+"CK" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/dock_star)
+"CL" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/armoury_st)
+"CM" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/armoury_st)
+"CN" = (
+/obj/machinery/atmospherics/pipe/simple/visible/universal,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/engine)
+"CO" = (
+/obj/structure/ship_munition/disperser_charge/emp,
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/reinforced,
+/area/ship/ert/hallways_aft)
+"CP" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/white,
+/area/ship/ert/med_surg)
+"CR" = (
+/obj/machinery/computer/ship/disperser{
+	dir = 8
+	},
+/obj/item/weapon/paper/vonbraun_cannon,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/gunnery)
+"CT" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/atmos)
+"CX" = (
+/obj/machinery/button/flasher{
+	pixel_x = -9;
+	pixel_y = -22
+	},
+/obj/machinery/button/remote/blast_door{
+	dir = 1;
+	id = "braun_cells_privacy";
+	name = "Privacy Shutter Controls";
+	pixel_x = 9;
+	pixel_y = -24;
+	req_access = list(103)
+	},
+/obj/effect/floor_decal/industrial/warning,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/brig)
+"CZ" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/airless,
+/area/ship/ert/gunnery)
+"Dd" = (
+/obj/structure/table/rack/steel,
+/obj/item/weapon/tank/jetpack/oxygen{
+	pixel_x = -4;
+	pixel_y = -4
+	},
+/obj/item/weapon/tank/jetpack/oxygen{
+	pixel_x = -2;
+	pixel_y = -2
+	},
+/obj/item/weapon/tank/jetpack/oxygen,
+/obj/item/weapon/tank/jetpack/oxygen{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/weapon/tank/jetpack/oxygen{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/weapon/tank/jetpack/oxygen{
+	pixel_x = 6;
+	pixel_y = 6
+	},
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/barracks)
+"Dh" = (
+/obj/machinery/button/remote/blast_door{
+	id = "VB_Rear_Blast";
+	name = "Emergency Blast Doors";
+	pixel_y = 24;
+	req_access = list(103)
+	},
+/obj/structure/table/steel_reinforced,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/engineering)
+"Dk" = (
+/obj/structure/sign/nosmoking_1,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/wall/rshull,
+/area/ship/ert/engine)
+"Dm" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/stack/cable_coil,
+/obj/item/stack/cable_coil,
+/obj/item/stack/cable_coil,
+/obj/item/stack/cable_coil,
+/obj/item/stack/cable_coil,
+/obj/item/stack/cable_coil,
+/obj/item/weapon/grenade/chem_grenade/metalfoam,
+/obj/item/weapon/grenade/chem_grenade/metalfoam,
+/obj/item/weapon/grenade/chem_grenade/metalfoam,
+/obj/item/weapon/grenade/chem_grenade/metalfoam,
+/obj/item/weapon/grenade/chem_grenade/metalfoam,
+/obj/item/weapon/grenade/chem_grenade/metalfoam,
+/obj/machinery/light/no_nightshift,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/eng_storage)
+"Dn" = (
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/atmos)
+"Do" = (
+/obj/machinery/light/no_nightshift,
+/turf/simulated/floor/reinforced/airless,
+/area/ship/ert/engine)
+"Dp" = (
+/obj/item/device/perfect_tele_beacon/stationary{
+	tele_name = "NRB Robineau";
+	tele_network = "centcom"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/shuttle/ert_ship_boat)
+"Dt" = (
+/obj/machinery/disperser/back{
+	dir = 4
+	},
+/turf/simulated/floor/airless,
+/area/ship/ert/gunnery)
+"Du" = (
+/obj/machinery/button/remote/blast_door{
+	dir = 1;
+	id = "ERT_Shuttle_Rear";
+	name = "ERT Shuttle Access";
+	pixel_y = -25;
+	req_access = list(103)
+	},
+/obj/machinery/door/blast/regular/open{
+	id = "ERT_Shuttle_Rear";
+	name = "Boarding Hatch"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/shuttle/ert_ship_boat)
+"Dx" = (
+/obj/machinery/disperser/middle{
+	dir = 4
+	},
+/turf/simulated/floor/airless,
+/area/ship/ert/gunnery)
+"DJ" = (
+/obj/effect/floor_decal/corner/white{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/eng_storage)
+"DK" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/atmos)
+"DM" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/weapon/storage/firstaid/fire{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/weapon/storage/firstaid/fire{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/weapon/storage/firstaid/adv,
+/obj/item/weapon/storage/firstaid/adv{
+	pixel_x = -2;
+	pixel_y = -2
+	},
+/obj/effect/floor_decal/corner/yellow{
+	dir = 8
+	},
+/obj/machinery/firealarm/alarms_hidden{
+	pixel_y = 26
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/med)
+"DN" = (
+/obj/machinery/atmospherics/pipe/manifold4w/visible/fuel,
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/machinery/door/blast/regular/open{
+	id = "VB_Rear_Blast";
+	name = "Blast Shield"
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/ship/ert/engine)
+"DQ" = (
+/obj/machinery/disperser/front{
+	dir = 4
+	},
+/turf/simulated/floor/airless,
+/area/ship/ert/gunnery)
+"DS" = (
+/turf/simulated/wall/rshull,
+/area/ship/ert/hallways_aft)
+"Eb" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock/glass_security{
+	name = "Delta Armoury";
+	req_one_access = list(103)
+	},
+/obj/machinery/door/blast/regular{
+	closed_layer = 4;
+	id = "NRV_DELTA";
+	layer = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/armoury_dl)
+"Ed" = (
+/obj/machinery/door/blast/regular{
+	id = "Von_Braun_Cannon";
+	name = "Cannon Firing Port"
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/ship/ert/gunnery)
+"Ee" = (
+/obj/structure/table/rack/steel,
+/obj/item/weapon/gun/energy/plasmastun{
+	pixel_y = -3
+	},
+/obj/item/weapon/gun/energy/plasmastun{
+	pixel_y = 3
+	},
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/armoury_dl)
+"Em" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/blast/regular{
+	closed_layer = 4;
+	dir = 4;
+	id = "NRV_DELTA";
+	layer = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/armoury_dl)
+"Eo" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/dock_star)
+"Eq" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/ship/ert/gunnery)
+"Ev" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/light/no_nightshift{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/engine)
+"EB" = (
+/obj/structure/table/rack/steel,
+/obj/item/weapon/gun/energy/sniperrifle{
+	battery_lock = 0;
+	pixel_y = -3
+	},
+/obj/item/weapon/gun/energy/sniperrifle{
+	battery_lock = 0;
+	pixel_y = 3
+	},
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/armoury_dl)
+"ED" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/wood,
+/area/ship/ert/commander)
+"EF" = (
+/obj/machinery/shield_capacitor,
+/obj/effect/floor_decal/industrial/outline/blue,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/eng_storage)
+"EP" = (
+/obj/machinery/atmospherics/unary/engine{
+	dir = 4
+	},
+/turf/space,
+/area/ship/ert/engine)
+"ES" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/brig)
+"Fd" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/effect/floor_decal/industrial/outline/blue,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/atmos)
+"Ff" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/hangar)
+"Fg" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/wood,
+/area/ship/ert/commander)
+"Fl" = (
+/obj/structure/table/rack/steel,
+/obj/item/weapon/storage/box/handcuffs{
+	pixel_x = -2;
+	pixel_y = -2
+	},
+/obj/item/weapon/storage/box/handcuffs{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/effect/floor_decal/corner/red{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/hallways)
+"Fq" = (
+/obj/structure/table/rack/steel,
+/obj/item/weapon/gun/energy/gun/burst{
+	pixel_y = 3
+	},
+/obj/item/weapon/gun/energy/gun/burst{
+	pixel_y = -3
+	},
+/obj/item/weapon/gun/energy/lasershotgun{
+	pixel_y = -3
+	},
+/obj/item/weapon/gun/energy/lasershotgun{
+	pixel_y = 3
+	},
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/recharger/wallcharger{
+	pixel_x = -23;
+	pixel_y = -12
+	},
+/obj/machinery/recharger/wallcharger{
+	pixel_x = -23;
+	pixel_y = -4
+	},
+/obj/machinery/recharger/wallcharger{
+	pixel_x = -23;
+	pixel_y = 5
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/armoury_dl)
+"Fz" = (
+/obj/structure/bed/chair/comfy/black{
+	dir = 8
+	},
+/obj/machinery/light/no_nightshift{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/ship/ert/commander)
+"FE" = (
+/obj/structure/bed/chair/bay/chair/padded/blue{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/hallways_aft)
+"FF" = (
+/obj/machinery/light/no_nightshift{
+	dir = 1
+	},
+/obj/machinery/alarm/alarms_hidden{
+	pixel_y = 26
+	},
+/turf/simulated/floor/wood,
+/area/ship/ert/commander)
+"FG" = (
+/obj/machinery/computer/operating,
+/turf/simulated/floor/tiled/white,
+/area/ship/ert/med_surg)
+"FK" = (
+/obj/structure/bed/chair/bay/chair/padded/blue{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/bridge)
+"FM" = (
+/obj/machinery/firealarm/alarms_hidden{
+	dir = 1;
+	pixel_y = -26
+	},
+/obj/item/modular_computer/console/preset/medical{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/bridge)
+"FN" = (
+/obj/structure/bed/chair/bay/chair/padded/blue{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/bridge)
+"FO" = (
+/obj/machinery/light_switch{
+	pixel_y = 23
+	},
+/obj/structure/table/woodentable,
+/obj/item/device/flashlight/lamp,
+/obj/item/device/holomap_beacon/ert,
+/obj/item/device/holomap_beacon/ert,
+/obj/item/device/mapping_unit/ert,
+/turf/simulated/floor/wood,
+/area/ship/ert/commander)
+"FP" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/weapon/cell/hyper,
+/obj/item/weapon/cell/hyper,
+/obj/item/weapon/cell/hyper,
+/obj/item/weapon/cell/hyper,
+/obj/item/weapon/cell/hyper,
+/obj/item/weapon/cell/hyper,
+/obj/item/weapon/cell/hyper,
+/obj/item/weapon/cell/hyper,
+/obj/machinery/cell_charger,
+/obj/item/weapon/cell/hyper,
+/obj/item/weapon/cell/hyper,
+/obj/item/weapon/cell/hyper,
+/obj/item/weapon/cell/hyper,
+/obj/item/weapon/tool/screwdriver,
+/obj/item/weapon/tool/wrench,
+/obj/item/weapon/tool/crowbar,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/mech_bay)
+"FQ" = (
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/bridge)
+"FR" = (
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/armoury_st)
+"FS" = (
+/obj/item/modular_computer/console/preset/engineering{
+	dir = 4
+	},
+/obj/structure/panic_button{
+	pixel_x = -32
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/bridge)
+"FT" = (
+/obj/machinery/door/airlock/glass_command{
+	req_one_access = list(103)
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/bridge)
+"FV" = (
+/obj/structure/table/rack/steel,
+/obj/item/ammo_magazine/ammo_box/b12g/pellet,
+/obj/item/ammo_magazine/ammo_box/b12g/pellet,
+/obj/item/ammo_magazine/ammo_box/b12g,
+/obj/item/ammo_magazine/ammo_box/b12g,
+/obj/item/ammo_magazine/ammo_box/b12g/emp,
+/obj/item/ammo_magazine/ammo_box/b12g/flash,
+/obj/item/ammo_magazine/ammo_box/b12g/beanbag,
+/obj/item/ammo_magazine/ammo_box/b12g/beanbag,
+/obj/item/ammo_magazine/ammo_box/b12g/stunshell,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/item/weapon/gun/projectile/shotgun/pump/combat{
+	pixel_y = 3
+	},
+/obj/item/weapon/gun/projectile/shotgun/pump/combat{
+	pixel_y = -3
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/armoury_st)
+"FW" = (
+/obj/structure/closet/walllocker/emerglocker{
+	pixel_y = 32
+	},
+/obj/structure/bed/pod,
+/obj/item/weapon/bedsheet/blue,
+/obj/structure/curtain/open/bed,
+/turf/simulated/floor/wood,
+/area/ship/ert/commander)
+"FX" = (
+/obj/effect/floor_decal/corner/blue{
+	dir = 9
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/hallways)
+"FY" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/bridge)
+"Gl" = (
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/hallways)
+"Gn" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/wall/rshull,
+/area/ship/ert/med_surg)
+"Gs" = (
+/obj/machinery/vending/engineering,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/eng_storage)
+"Gu" = (
+/obj/machinery/optable,
+/turf/simulated/floor/tiled/white,
+/area/ship/ert/med_surg)
+"Gv" = (
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/hallways_aft)
+"Gw" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 8
+	},
+/obj/effect/map_helper/airlock/atmos/chamber_pump,
+/obj/machinery/light/no_nightshift{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/dock_port)
+"GE" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/effect/shuttle_landmark/shuttle_initializer/ert_ship_boat,
+/turf/simulated/floor/tiled/techmaint,
+/area/shuttle/ert_ship_boat)
+"GI" = (
+/obj/machinery/alarm/alarms_hidden{
+	pixel_y = 26
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/engine)
+"GJ" = (
+/turf/simulated/floor/reinforced/airless,
+/area/ship/ert/dock_star)
+"GK" = (
+/obj/effect/floor_decal/corner/red{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/hallways)
+"GO" = (
+/obj/machinery/photocopier,
+/turf/simulated/floor/wood,
+/area/ship/ert/commander)
+"GQ" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/turf/simulated/floor/wood,
+/area/ship/ert/commander)
+"GR" = (
+/obj/structure/closet/crate{
+	dir = 2
+	},
+/obj/effect/floor_decal/industrial/outline/red,
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/armoury_st)
+"GS" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/structure/table/steel_reinforced,
+/obj/item/weapon/rcd_ammo/large{
+	pixel_x = -8;
+	pixel_y = -8
+	},
+/obj/item/weapon/rcd_ammo/large{
+	pixel_x = -6;
+	pixel_y = -6
+	},
+/obj/item/weapon/rcd_ammo/large{
+	pixel_x = -4;
+	pixel_y = -4
+	},
+/obj/item/weapon/rcd_ammo/large{
+	pixel_x = -2;
+	pixel_y = -2
+	},
+/obj/item/weapon/rcd_ammo/large,
+/obj/item/weapon/rcd_ammo/large{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/weapon/rcd_ammo/large{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/weapon/rcd_ammo/large{
+	pixel_x = 6;
+	pixel_y = 6
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/eng_storage)
+"GT" = (
+/obj/effect/floor_decal/corner/white{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/med)
+"GU" = (
+/obj/structure/table/rack/steel,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/item/weapon/gun/energy/pulse_rifle{
+	pixel_y = 6
+	},
+/obj/item/weapon/gun/energy/pulse_rifle{
+	pixel_y = 4
+	},
+/obj/item/weapon/gun/energy/pulse_rifle{
+	pixel_y = 2
+	},
+/obj/item/weapon/gun/energy/pulse_rifle,
+/obj/item/weapon/gun/energy/pulse_rifle{
+	pixel_y = -2
+	},
+/obj/item/weapon/gun/energy/pulse_rifle{
+	pixel_y = -4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/armoury_dl)
+"GY" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/dock_port)
+"GZ" = (
+/obj/structure/shuttle/engine/propulsion{
+	dir = 8
+	},
+/turf/simulated/floor/reinforced,
+/area/shuttle/ert_ship_boat)
+"Hf" = (
+/turf/simulated/wall/rshull,
+/area/ship/ert/engine)
+"Hg" = (
+/obj/effect/floor_decal/corner/yellow{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/med)
+"Ho" = (
+/obj/machinery/power/emitter,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/eng_storage)
+"Hp" = (
+/obj/machinery/vending/medical{
+	req_access = null
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/med)
+"Hu" = (
+/obj/effect/floor_decal/corner/red{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/hangar)
+"HB" = (
+/obj/structure/closet/wardrobe/ert,
+/obj/item/modular_computer/tablet/preset/custom_loadout/elite,
+/obj/item/weapon/storage/box/survival/comp{
+	starts_with = list(/obj/item/weapon/tool/prybar/red,/obj/item/clothing/glasses/goggles,/obj/item/weapon/reagent_containers/hypospray/autoinjector,/obj/item/stack/medical/bruise_pack,/obj/item/device/flashlight/glowstick,/obj/item/weapon/reagent_containers/food/snacks/candy/proteinbar,/obj/item/clothing/mask/breath,/obj/item/weapon/tank/emergency/oxygen/engi)
+	},
+/obj/machinery/light/no_nightshift,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/item/modular_computer/laptop/preset/custom_loadout/elite,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/barracks)
+"HC" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/bodybag/cryobag{
+	pixel_x = -4;
+	pixel_y = -4
+	},
+/obj/item/bodybag/cryobag{
+	pixel_x = -2;
+	pixel_y = -2
+	},
+/obj/item/bodybag/cryobag,
+/obj/item/bodybag/cryobag{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/bodybag/cryobag{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/bodybag/cryobag{
+	pixel_x = 6;
+	pixel_y = 6
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/med)
+"HE" = (
+/obj/structure/table/rack/steel,
+/obj/item/clothing/glasses/graviton{
+	pixel_x = -2;
+	pixel_y = -2
+	},
+/obj/item/clothing/glasses/graviton,
+/obj/item/clothing/glasses/graviton{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/clothing/glasses/graviton{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/barracks)
+"HH" = (
+/obj/effect/floor_decal/corner/red{
+	dir = 9
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/hangar)
+"HK" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/shuttle/ert_ship_boat)
+"HL" = (
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	icon_state = "shutter0";
+	id = "braun_cells_privacy";
+	name = "Privacy Shutters";
+	opacity = 0
+	},
+/obj/machinery/door/airlock/glass{
+	req_one_access = list(103)
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/brig)
+"HO" = (
+/turf/simulated/wall/rshull,
+/area/shuttle/ert_ship_boat)
+"HR" = (
+/obj/structure/table/rack/steel,
+/obj/item/clothing/accessory/storage/black_vest{
+	pixel_x = -4;
+	pixel_y = -4
+	},
+/obj/item/clothing/accessory/storage/black_vest{
+	pixel_x = -2;
+	pixel_y = -2
+	},
+/obj/item/clothing/accessory/storage/black_vest,
+/obj/item/clothing/accessory/storage/black_vest{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/clothing/accessory/storage/black_vest{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/clothing/accessory/storage/black_vest{
+	pixel_x = 6;
+	pixel_y = 6
+	},
+/obj/machinery/alarm/alarms_hidden{
+	dir = 1;
+	pixel_y = -26
+	},
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/barracks)
+"HS" = (
+/obj/structure/bed/pod,
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/ship/ert/brig)
+"HT" = (
+/obj/machinery/door/firedoor,
+/obj/structure/grille,
+/obj/structure/window/titanium/full,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/effect/floor_decal/techfloor{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/brig)
+"Ia" = (
+/obj/machinery/power/pointdefense{
+	id_tag = "vonbraun_pd"
+	},
+/obj/structure/cable/yellow,
+/turf/simulated/floor/reinforced/airless,
+/area/ship/ert/engine)
+"Id" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/fuel{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/engine)
+"If" = (
+/obj/machinery/door/airlock/glass_external,
+/obj/effect/map_helper/airlock/door/int_door,
+/obj/machinery/door/firedoor/multi_tile,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/dock_star)
+"Ii" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor/multi_tile,
+/obj/machinery/door/airlock/multi_tile/glass{
+	req_one_access = list(103)
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/hangar)
+"Il" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/machinery/light/no_nightshift,
+/turf/simulated/floor/tiled/techmaint,
+/area/shuttle/ert_ship_boat)
+"Io" = (
+/obj/machinery/power/apc/hyper{
+	alarms_hidden = 1;
+	dir = 4;
+	name = "VB APC - East";
+	pixel_x = 24
+	},
+/obj/structure/cable/yellow{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/alarm/alarms_hidden{
+	dir = 1;
+	pixel_y = -26
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/atmos)
+"Ip" = (
+/obj/structure/sign/department/dock{
+	name = "ROBINEAU DOCK"
+	},
+/turf/simulated/wall/shull,
+/area/ship/ert/hangar)
+"Is" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/barracks)
+"Iu" = (
+/obj/machinery/power/pointdefense{
+	id_tag = "vonbraun_pd"
+	},
+/obj/structure/cable/yellow{
+	d2 = 4;
+	dir = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/ship/ert/med_surg)
+"Ix" = (
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	icon_state = "shutter0";
+	id = "braun_cells_privacy";
+	name = "Privacy Shutters";
+	opacity = 0
+	},
+/obj/structure/grille,
+/obj/structure/window/titanium/full,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/brig)
+"II" = (
+/obj/machinery/door/firedoor/multi_tile{
+	dir = 1
+	},
+/obj/machinery/door/airlock/multi_tile/glass{
+	dir = 1;
+	req_one_access = list(103)
+	},
+/turf/simulated/floor/tiled/white,
+/area/ship/ert/med_surg)
+"IK" = (
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	icon_state = "shutter0";
+	id = "braun_cells_privacy";
+	name = "Privacy Shutters";
+	opacity = 0
+	},
+/obj/structure/grille,
+/obj/structure/window/titanium/full,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium,
+/obj/structure/cable/yellow{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/brig)
+"IP" = (
+/obj/machinery/alarm/alarms_hidden{
+	dir = 4;
+	pixel_x = -26
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/ship/ert/brig)
+"Jd" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/barracks)
+"Je" = (
+/obj/machinery/oxygen_pump/anesthetic,
+/turf/simulated/wall/shull,
+/area/ship/ert/med_surg)
+"Jf" = (
+/obj/item/modular_computer/console/preset/command{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/bridge)
+"Jg" = (
+/obj/machinery/light/no_nightshift{
+	dir = 1
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/ship/ert/med_surg)
+"Jh" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/white,
+/area/ship/ert/med_surg)
+"Jk" = (
+/obj/item/modular_computer/console/preset/medical{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/bridge)
+"Jx" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/mech_bay)
+"Jy" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/hallways_aft)
+"JD" = (
+/obj/machinery/door/window/brigdoor/southright,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/hallways_aft)
+"JE" = (
 /obj/structure/table/rack/steel,
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/item/ammo_magazine/m545{
@@ -4286,26 +6957,333 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/armoury_st)
-"xt" = (
+"JF" = (
+/obj/machinery/vending/assist,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/eng_storage)
+"JG" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/machinery/light/no_nightshift{
+	dir = 8
+	},
+/obj/machinery/porta_turret/stationary/CIWS,
+/turf/simulated/floor/reinforced/airless,
+/area/ship/ert/gunnery)
+"JH" = (
+/obj/machinery/computer/ship/navigation{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/structure/railing/grey,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/bridge)
+"JJ" = (
+/obj/machinery/light/no_nightshift,
+/obj/machinery/atmospherics/unary/engine{
+	dir = 4
+	},
+/turf/space,
+/area/ship/ert/engine)
+"JM" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/barracks)
+"JO" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/effect/floor_decal/corner/red{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/hallways_aft)
+"JW" = (
+/obj/machinery/atmospherics/pipe/simple/visible/fuel{
+	dir = 9
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/machinery/door/blast/regular/open{
+	id = "VB_Rear_Blast";
+	name = "Blast Shield"
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/ship/ert/engine)
+"JX" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/hallways_aft)
+"JY" = (
+/obj/machinery/atmospherics/pipe/manifold/visible/fuel{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/engine)
+"Kb" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/engine)
+"Kj" = (
+/obj/machinery/telecomms/relay,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/atmos)
+"Kk" = (
+/obj/machinery/door/airlock/glass_external,
+/obj/effect/map_helper/airlock/door/int_door,
+/obj/machinery/door/firedoor/multi_tile,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/dock_port)
+"Kq" = (
+/obj/machinery/ntnet_relay,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/atmos)
+"Kr" = (
+/turf/simulated/floor/wood,
+/area/ship/ert/commander)
+"Ks" = (
+/obj/machinery/power/apc/hyper{
+	alarms_hidden = 1;
+	dir = 4;
+	name = "VB APC - East";
+	pixel_x = 24
+	},
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/brig)
+"Kt" = (
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/teleporter)
+"KB" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 8
+	},
+/obj/effect/map_helper/airlock/atmos/chamber_pump,
+/obj/effect/floor_decal/industrial/warning,
+/obj/structure/sign/vacuum{
+	pixel_x = -32
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/dock_star)
+"KE" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/light/no_nightshift{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/hallways_aft)
+"KF" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/white,
+/area/ship/ert/med_surg)
+"KG" = (
+/obj/machinery/embedded_controller/radio/airlock/docking_port_multi{
+	dir = 8;
+	id_tag = "von_braun_star";
+	master_tag = "von_braun_master";
+	name = "Starboard Docking Control";
+	pixel_x = 22
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/dock_star)
+"KH" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/brig)
+"KK" = (
+/mob/living/simple_mob/animal/passive/mimepet,
+/turf/simulated/floor/wood,
+/area/ship/ert/commander)
+"KM" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/corner/blue,
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/bridge)
+"KN" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/wall/shull,
+/area/ship/ert/barracks)
+"KO" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/dock_star)
+"KS" = (
 /obj/structure/table/rack/steel,
-/obj/item/weapon/storage/box/flashbangs,
-/obj/item/weapon/storage/box/flashbangs,
 /obj/machinery/light/no_nightshift{
 	dir = 1
 	},
-/obj/machinery/alarm/alarms_hidden{
+/obj/machinery/firealarm/alarms_hidden{
 	pixel_y = 26
 	},
+/obj/item/weapon/gun/energy/laser{
+	pixel_y = 6
+	},
+/obj/item/weapon/gun/energy/laser{
+	pixel_y = 4
+	},
 /obj/effect/floor_decal/industrial/outline/grey,
-/obj/item/weapon/storage/box/flashbangs,
-/obj/item/weapon/storage/box/smokes,
-/obj/item/weapon/storage/box/smokes,
-/obj/item/weapon/storage/box/teargas,
-/obj/item/weapon/storage/box/empslite,
-/obj/item/weapon/storage/box/empslite,
+/obj/item/weapon/gun/energy/laser{
+	pixel_y = 2
+	},
+/obj/item/weapon/gun/energy/laser,
+/obj/item/weapon/gun/energy/laser{
+	pixel_y = -2
+	},
+/obj/item/weapon/gun/energy/laser{
+	pixel_y = -4
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/armoury_st)
-"xv" = (
+"KT" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 8
+	},
+/obj/effect/map_helper/airlock/atmos/chamber_pump,
+/obj/machinery/light/no_nightshift{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/dock_star)
+"KW" = (
+/obj/structure/table/rack,
+/obj/item/weapon/hand_tele,
+/obj/item/device/perfect_tele,
+/obj/item/device/binoculars,
+/obj/item/device/survivalcapsule{
+	pixel_x = 3
+	},
+/obj/item/device/survivalcapsule{
+	pixel_x = -3
+	},
+/turf/simulated/floor/wood,
+/area/ship/ert/commander)
+"La" = (
+/obj/machinery/vending/coffee{
+	prices = list()
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/hallways_aft)
+"Lf" = (
+/obj/structure/ship_munition/disperser_charge/explosive,
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/reinforced,
+/area/ship/ert/hallways_aft)
+"Lh" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/med)
+"Lk" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/structure/railing/grey{
+	dir = 1
+	},
+/obj/structure/table/steel_reinforced,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/bridge)
+"Lm" = (
 /obj/structure/table/rack/steel,
 /obj/item/weapon/gun/energy/ionrifle/pistol{
 	pixel_y = 4
@@ -4330,274 +7308,106 @@
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/armoury_st)
-"xx" = (
-/obj/machinery/light/no_nightshift,
-/turf/simulated/floor/reinforced/airless,
-/area/ship/ert/hallways_aft)
-"xz" = (
-/obj/structure/closet/medical_wall{
-	pixel_x = 32
+"Lq" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced{
+	dir = 4
 	},
-/obj/item/weapon/storage/firstaid/adv{
-	pixel_x = 4;
-	pixel_y = 4
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/obj/item/weapon/storage/firstaid/adv{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/item/weapon/storage/firstaid/fire{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/item/weapon/storage/firstaid/fire{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/item/weapon/storage/firstaid/o2,
-/obj/item/weapon/storage/firstaid/o2,
-/obj/item/weapon/storage/firstaid/toxin{
-	pixel_x = -2;
-	pixel_y = -2
-	},
-/obj/item/weapon/storage/firstaid/toxin{
-	pixel_x = -2;
-	pixel_y = -2
+/obj/machinery/door/blast/regular/open{
+	dir = 2;
+	id = "braun_blast_shields";
+	name = "Blast Shield"
 	},
 /turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/med)
-"xA" = (
+/area/ship/ert/bridge)
+"LA" = (
+/obj/structure/table/rack/steel,
+/obj/item/weapon/material/knife/tacknife/combatknife{
+	pixel_x = -7
+	},
+/obj/item/weapon/material/knife/tacknife/combatknife{
+	pixel_x = -4
+	},
+/obj/item/weapon/material/knife/tacknife/combatknife{
+	pixel_x = -1
+	},
+/obj/item/weapon/material/knife/tacknife/combatknife{
+	pixel_x = 2
+	},
+/obj/item/weapon/material/knife/tacknife/combatknife{
+	pixel_x = 5
+	},
+/obj/item/weapon/material/knife/tacknife/combatknife{
+	pixel_x = 8
+	},
 /obj/effect/floor_decal/industrial/outline/grey,
-/obj/machinery/gear_dispenser/suit/ert,
 /turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/barracks)
-"xC" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/structure/table/steel_reinforced,
-/obj/item/weapon/rcd/advanced/loaded{
-	desc = "A device used to rapidly build and deconstruct. This version works faster, and has a much larger capacity than a standard model, but doesn't work at range. Reload with compressed matter cartridges.";
-	name = "emergency rapid construction device";
-	pixel_y = 3;
-	ranged = 0
+/area/ship/ert/hallways)
+"LB" = (
+/obj/effect/floor_decal/corner/white{
+	dir = 9
 	},
-/obj/item/weapon/rcd/advanced/loaded{
-	desc = "A device used to rapidly build and deconstruct. This version works faster, and has a much larger capacity than a standard model, but doesn't work at range. Reload with compressed matter cartridges.";
-	name = "emergency rapid construction device";
-	pixel_y = -3;
-	ranged = 0
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/eng_storage)
-"xD" = (
-/obj/effect/landmark/late_antag/ert,
-/obj/structure/table/bench/steel,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/barracks)
-"xG" = (
-/obj/machinery/portable_atmospherics/canister/air,
-/obj/machinery/alarm/alarms_hidden{
-	pixel_y = 26
-	},
-/obj/machinery/light_switch{
-	dir = 4;
-	pixel_x = -23
-	},
-/obj/effect/floor_decal/industrial/outline,
 /turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/hangar)
-"xM" = (
+/area/ship/ert/med)
+"LC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/techmaint,
 /area/ship/ert/hangar)
-"xO" = (
-/obj/effect/floor_decal/industrial/warning,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+"LF" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/hangar)
-"xU" = (
+/area/ship/ert/armoury_dl)
+"LH" = (
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/eng_storage)
+"LI" = (
+/obj/machinery/light/no_nightshift{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/hallways_aft)
+"LJ" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/white,
-/area/ship/ert/med_surg)
-"xZ" = (
-/obj/structure/table/rack/steel,
-/obj/item/weapon/gun/launcher/grenade{
-	pixel_y = 3
-	},
-/obj/item/weapon/gun/launcher/grenade{
-	pixel_y = -3
-	},
-/obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/armoury_dl)
-"ya" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/hallways_aft)
-"yf" = (
-/obj/effect/floor_decal/industrial/warning,
-/obj/machinery/space_heater,
-/obj/machinery/light/no_nightshift{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/hangar)
-"yg" = (
-/obj/machinery/door/firedoor/glass,
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/machinery/door/blast/regular/open{
-	dir = 2;
-	id = "ERT_Blast_Windows";
-	name = "Blast Shield"
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/shield_diffuser,
-/turf/simulated/floor/tiled/techfloor,
-/area/shuttle/ert_ship_boat)
-"yi" = (
-/obj/effect/floor_decal/corner/white{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/hangar)
-"yj" = (
-/obj/effect/floor_decal/industrial/warning,
-/obj/machinery/space_heater,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/hangar)
-"yl" = (
-/obj/structure/ship_munition/disperser_charge/emp,
-/obj/effect/floor_decal/industrial/warning,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/reinforced,
-/area/ship/ert/hallways_aft)
-"yo" = (
-/obj/machinery/door/airlock/external,
-/obj/effect/map_helper/airlock/door/ext_door,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/dock_star)
-"yp" = (
-/obj/structure/table/steel_reinforced,
-/obj/item/weapon/storage/firstaid/fire{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/item/weapon/storage/firstaid/fire{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/item/weapon/storage/firstaid/adv,
-/obj/item/weapon/storage/firstaid/adv{
-	pixel_x = -2;
-	pixel_y = -2
-	},
-/obj/effect/floor_decal/corner/yellow{
-	dir = 8
-	},
-/obj/machinery/firealarm/alarms_hidden{
-	pixel_y = 26
-	},
-/turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/med)
-"yv" = (
-/obj/effect/floor_decal/industrial/warning,
-/obj/machinery/pipedispenser/orderable,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/hangar)
-"yx" = (
-/obj/effect/floor_decal/industrial/warning,
-/obj/machinery/pipedispenser/disposal/orderable,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/hangar)
-"yz" = (
-/turf/space,
-/area/space)
-"yB" = (
-/obj/effect/floor_decal/industrial/warning,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/obj/machinery/firealarm/alarms_hidden{
-	pixel_y = 26
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/hangar)
-"yC" = (
-/obj/machinery/vending/engivend,
-/turf/simulated/floor/tiled/techfloor,
+"LM" = (
+/turf/simulated/floor/reinforced/airless,
 /area/ship/ert/eng_storage)
-"yD" = (
-/obj/machinery/light/no_nightshift{
-	dir = 1
-	},
-/obj/structure/sign/vacuum{
-	pixel_y = 32
-	},
-/obj/effect/floor_decal/industrial/warning,
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/hangar)
-"yG" = (
-/obj/structure/ship_munition/disperser_charge/explosive,
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/turf/simulated/floor/reinforced,
-/area/ship/ert/hallways_aft)
-"yI" = (
-/obj/structure/sign/department/medbay,
-/turf/simulated/wall/shull,
-/area/ship/ert/med)
-"yJ" = (
+"LP" = (
 /obj/structure/table/steel_reinforced,
 /obj/machinery/chemical_dispenser/biochemistry/full,
 /obj/machinery/light/no_nightshift,
@@ -4609,7 +7419,501 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/med)
-"yR" = (
+"LR" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning/corner,
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/hangar)
+"LV" = (
+/obj/effect/floor_decal/corner/blue{
+	dir = 9
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/hallways)
+"LW" = (
+/obj/machinery/door/airlock/glass_external,
+/obj/effect/map_helper/airlock/door/int_door,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/dock_star)
+"LZ" = (
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/catwalk_plated/techmaint,
+/turf/simulated/floor/plating,
+/area/ship/ert/med)
+"Mb" = (
+/obj/machinery/sleeper{
+	dir = 8
+	},
+/obj/machinery/light/no_nightshift{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/white,
+/area/ship/ert/med_surg)
+"Md" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/door/blast/regular/open{
+	dir = 2;
+	id = "braun_blast_shields";
+	name = "Blast Shield"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/armoury_st)
+"Me" = (
+/obj/structure/table/rack/steel,
+/obj/item/device/flash{
+	pixel_x = -4;
+	pixel_y = -4
+	},
+/obj/item/device/flash{
+	pixel_x = -2;
+	pixel_y = -2
+	},
+/obj/item/device/flash,
+/obj/item/device/flash{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/device/flash{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/device/flash{
+	pixel_x = 6;
+	pixel_y = 6
+	},
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/hallways)
+"Mj" = (
+/obj/machinery/door/airlock/glass_medical{
+	name = "Medical Bay";
+	req_access = list(103)
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/med)
+"Mk" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/teleporter)
+"Mm" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/table/steel_reinforced,
+/obj/item/weapon/melee/baton/loaded,
+/obj/item/weapon/melee/baton/loaded,
+/obj/item/weapon/cell/device/weapon,
+/obj/item/weapon/cell/device/weapon,
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/brig)
+"Mq" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/techmaint,
+/area/shuttle/ert_ship_boat)
+"Mr" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/powered/pump/filled,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/hangar)
+"Mt" = (
+/obj/structure/table/rack/steel,
+/obj/item/weapon/gun/projectile/automatic/pdw{
+	pixel_y = 6
+	},
+/obj/item/weapon/gun/projectile/automatic/pdw{
+	pixel_y = 4
+	},
+/obj/item/weapon/gun/projectile/automatic/pdw{
+	pixel_y = 2
+	},
+/obj/item/weapon/gun/projectile/automatic/pdw,
+/obj/item/weapon/gun/projectile/automatic/pdw{
+	pixel_y = -2
+	},
+/obj/item/weapon/gun/projectile/automatic/pdw{
+	pixel_y = -4
+	},
+/obj/item/ammo_magazine/m9mml{
+	pixel_x = 10
+	},
+/obj/item/ammo_magazine/m9mml{
+	pixel_x = 8
+	},
+/obj/item/ammo_magazine/m9mml{
+	pixel_x = 6
+	},
+/obj/item/ammo_magazine/m9mml{
+	pixel_x = 4
+	},
+/obj/item/ammo_magazine/m9mml{
+	pixel_x = 2
+	},
+/obj/item/ammo_magazine/m9mml,
+/obj/item/ammo_magazine/m9mml{
+	pixel_x = -2
+	},
+/obj/item/ammo_magazine/m9mml{
+	pixel_x = -4
+	},
+/obj/item/ammo_magazine/m9mml{
+	pixel_x = -6
+	},
+/obj/item/ammo_magazine/m9mml{
+	pixel_x = -8
+	},
+/obj/item/ammo_magazine/m9mml{
+	pixel_x = -10
+	},
+/obj/item/ammo_magazine/m9mml{
+	pixel_x = -12
+	},
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/armoury_st)
+"Mx" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/powered/scrubber,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/hangar)
+"My" = (
+/obj/effect/floor_decal/industrial/warning,
+/obj/machinery/space_heater,
+/obj/machinery/light/no_nightshift{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/hangar)
+"MC" = (
+/obj/effect/floor_decal/industrial/warning,
+/obj/machinery/pipedispenser/orderable,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/hangar)
+"MD" = (
+/obj/structure/table/rack/steel,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/item/weapon/gun/energy/locked/frontier/holdout/unlocked{
+	pixel_y = 6
+	},
+/obj/item/weapon/gun/energy/locked/frontier/holdout/unlocked{
+	pixel_y = 4
+	},
+/obj/item/weapon/gun/energy/locked/frontier/holdout/unlocked{
+	pixel_y = 2
+	},
+/obj/item/weapon/gun/energy/locked/frontier/holdout/unlocked,
+/obj/item/weapon/gun/energy/locked/frontier/holdout/unlocked{
+	pixel_y = -2
+	},
+/obj/item/weapon/gun/energy/locked/frontier/holdout/unlocked{
+	pixel_y = -4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/armoury_st)
+"MK" = (
+/obj/machinery/light/no_nightshift{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/engine)
+"ML" = (
+/obj/effect/floor_decal/industrial/warning,
+/obj/machinery/pipedispenser/disposal/orderable,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/hangar)
+"MO" = (
+/obj/machinery/light/no_nightshift{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/structure/table/steel_reinforced,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/brig)
+"MQ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/eng_storage)
+"MT" = (
+/obj/effect/floor_decal/corner/red{
+	dir = 1
+	},
+/obj/structure/reagent_dispensers/watertank/high,
+/obj/effect/floor_decal/industrial/outline/blue,
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/hangar)
+"MZ" = (
+/turf/simulated/wall/rshull,
+/area/ship/ert/med_surg)
+"Nb" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/table/steel_reinforced,
+/obj/fiftyspawner/uranium,
+/obj/fiftyspawner/uranium,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/engineering)
+"Nd" = (
+/obj/structure/table/rack/steel,
+/obj/effect/floor_decal/industrial/outline,
+/obj/item/weapon/hand_labeler,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/med)
+"Nf" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/armoury_st)
+"Ng" = (
+/obj/machinery/door/blast/regular/open{
+	id = "ERT_Shuttle_Rear";
+	name = "Boarding Hatch"
+	},
+/obj/machinery/button/remote/blast_door{
+	id = "ERT_Shuttle_Rear";
+	name = "ERT Shuttle Access";
+	pixel_y = 24;
+	req_access = list(103)
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/shuttle/ert_ship_boat)
+"Nh" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/brig)
+"Nk" = (
+/obj/effect/floor_decal/industrial/warning,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/machinery/firealarm/alarms_hidden{
+	pixel_y = 26
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/hangar)
+"Np" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/catwalk_plated/techfloor,
+/turf/simulated/floor/plating,
+/area/ship/ert/engine)
+"Nq" = (
+/obj/machinery/door/airlock/glass_engineering{
+	name = "RIG Bay & ORB Access";
+	req_access = list(103)
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/mech_bay)
+"Nu" = (
+/obj/machinery/light/no_nightshift{
+	dir = 1
+	},
+/obj/structure/sign/vacuum{
+	pixel_y = 32
+	},
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/hangar)
+"NH" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/binary/pump/fuel/on,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/engine)
+"NJ" = (
+/obj/machinery/body_scanconsole,
+/turf/simulated/floor/tiled/white,
+/area/ship/ert/med_surg)
+"NN" = (
+/obj/machinery/computer/operating{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/ship/ert/med_surg)
+"NO" = (
+/obj/machinery/alarm/alarms_hidden{
+	dir = 4;
+	pixel_x = -26
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/ship/ert/brig)
+"NP" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/engine)
+"NR" = (
 /obj/structure/cable/yellow{
 	d1 = 2;
 	d2 = 4;
@@ -4630,100 +7934,505 @@
 /obj/effect/catwalk_plated/techmaint,
 /turf/simulated/floor/plating,
 /area/ship/ert/engineering)
-"yX" = (
-/turf/simulated/wall/rshull,
-/area/ship/ert/hangar)
-"yY" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/machinery/door/firedoor/border_only,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
+"NU" = (
+/obj/effect/floor_decal/corner/yellow{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/blue{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/barracks)
-"za" = (
-/obj/effect/floor_decal/industrial/warning{
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
-/turf/simulated/floor/reinforced/airless,
-/area/ship/ert/hangar)
-"zb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/light/no_nightshift{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/hallways)
+"NY" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/firealarm/alarms_hidden{
-	pixel_y = 26
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/light/no_nightshift,
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/hallways_aft)
+"NZ" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/engineering)
+"Oa" = (
+/obj/effect/floor_decal/corner/yellow{
+	dir = 9
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/white,
-/area/ship/ert/med_surg)
-"zc" = (
-/turf/simulated/wall/shull,
-/area/ship/ert/eng_storage)
-"zg" = (
-/obj/item/modular_computer/console/preset/engineering{
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
+/obj/effect/floor_decal/corner/red{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/hallways_aft)
+"Of" = (
+/turf/simulated/wall/rshull,
+/area/ship/ert/hangar)
+"Og" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/panic_button{
-	pixel_x = -32
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock/glass_security{
+	name = "Prisoner Containment";
+	req_one_access = list(103)
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/brig)
+"Oh" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/brig)
+"Oi" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/bridge)
+"Ok" = (
+/obj/effect/floor_decal/industrial/warning,
+/obj/machinery/space_heater,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/hangar)
+"Om" = (
+/turf/simulated/floor/reinforced/airless,
+/area/ship/ert/mech_bay)
+"On" = (
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/armoury_dl)
+"Oq" = (
+/obj/machinery/firealarm/alarms_hidden{
+	dir = 1;
+	pixel_y = -26
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/hallways_aft)
+"Ow" = (
+/obj/machinery/vending/fitness{
+	dir = 1;
+	prices = list()
 	},
 /turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/bridge)
-"zh" = (
-/obj/machinery/button/remote/blast_door{
-	id = "VB_Rear_Blast";
-	name = "Emergency Blast Doors";
-	pixel_y = 24;
-	req_access = list(103)
+/area/ship/ert/hallways_aft)
+"Ox" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/structure/table/steel_reinforced,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/engineering)
-"zk" = (
-/obj/machinery/light/no_nightshift{
-	dir = 8
+"Oy" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/brig)
+"OA" = (
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/med)
+"OB" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/hallways)
+"OE" = (
+/turf/simulated/floor/reinforced/airless,
+/area/ship/ert/hangar)
+"OF" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
+/obj/effect/catwalk_plated/techmaint,
+/turf/simulated/floor/plating,
+/area/ship/ert/hallways_aft)
+"OG" = (
+/obj/machinery/shield_gen,
+/obj/effect/floor_decal/industrial/outline/blue,
 /turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/eng_storage)
+"OH" = (
+/obj/structure/cable/yellow,
+/obj/machinery/power/smes/buildable/point_of_interest,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/engineering)
+"OM" = (
+/obj/structure/sign/nosmoking_1,
+/turf/simulated/wall/rshull,
 /area/ship/ert/engine)
-"zo" = (
-/obj/item/modular_computer/console/preset/command{
-	dir = 1
+"ON" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/techfloor,
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/mech_bay)
+"OO" = (
+/obj/structure/sign/department/cargo{
+	name = "ENGINEERING SUPPLIES"
+	},
+/turf/simulated/wall/rshull,
 /area/ship/ert/bridge)
-"zr" = (
-/obj/effect/floor_decal/industrial/warning{
+"OR" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/bed/chair/bay/chair/padded/blue,
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/bridge)
+"OS" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/light/no_nightshift{
 	dir = 1
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/hallways_aft)
+"OT" = (
+/obj/item/device/multitool/station_buffered,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/atmos)
+"OU" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/machinery/alarm/alarms_hidden{
-	dir = 1;
-	pixel_y = -26
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/dock_port)
+"OV" = (
+/obj/structure/hull_corner{
+	dir = 4
 	},
-/obj/effect/floor_decal/corner/white{
+/turf/simulated/floor/reinforced/airless,
+/area/ship/ert/dock_star)
+"OW" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock/glass{
+	req_one_access = list(103)
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/bridge)
+"OX" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
+/obj/effect/catwalk_plated/techmaint,
+/turf/simulated/floor/plating,
+/area/ship/ert/bridge)
+"OY" = (
+/obj/structure/grille,
+/obj/structure/window/titanium/full,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/floor_decal/techfloor{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/hangar)
-"zs" = (
+/area/ship/ert/brig)
+"OZ" = (
+/obj/structure/table/rack/steel,
+/obj/item/weapon/reagent_containers/hypospray{
+	pixel_x = 6
+	},
+/obj/item/weapon/reagent_containers/hypospray{
+	pixel_x = 3
+	},
+/obj/item/weapon/reagent_containers/hypospray,
+/obj/item/weapon/reagent_containers/hypospray{
+	pixel_x = -3
+	},
+/obj/machinery/alarm/alarms_hidden{
+	pixel_y = 26
+	},
+/obj/effect/floor_decal/industrial/outline,
+/obj/item/weapon/reagent_containers/hypospray{
+	pixel_x = -6
+	},
+/obj/item/weapon/reagent_containers/hypospray{
+	pixel_x = -9
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/med)
+"Pc" = (
+/obj/structure/table/rack,
+/obj/item/ammo_magazine/m44{
+	pixel_x = -3
+	},
+/obj/item/ammo_magazine/m44{
+	pixel_x = 3
+	},
+/obj/item/weapon/gun/projectile/deagle,
+/turf/simulated/floor/wood,
+/area/ship/ert/commander)
+"Pe" = (
+/obj/structure/table/rack/steel,
+/obj/item/weapon/storage/box/emps{
+	pixel_x = -2;
+	pixel_y = -2
+	},
+/obj/item/weapon/storage/box/emps{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/armoury_dl)
+"Ph" = (
+/obj/item/device/healthanalyzer/phasic{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/device/healthanalyzer/phasic,
+/obj/item/device/healthanalyzer/phasic{
+	pixel_x = -2;
+	pixel_y = -2
+	},
+/obj/structure/table/rack/steel,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/outline,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/med)
+"Pj" = (
+/obj/machinery/light/no_nightshift{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/yellow{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/corner/red,
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/hallways_aft)
+"Pl" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/machinery/door/blast/regular{
+	closed_layer = 4;
+	dir = 4;
+	id = "NRV_DELTA";
+	layer = 4
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/armoury_dl)
+"Pn" = (
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/wood,
+/area/ship/ert/commander)
+"Pq" = (
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/med)
+"Pw" = (
+/obj/machinery/light/no_nightshift,
+/turf/simulated/floor/reinforced/airless,
+/area/ship/ert/atmos)
+"Px" = (
+/obj/structure/table/rack/steel,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/item/clothing/mask/gas{
+	pixel_x = -4;
+	pixel_y = -4
+	},
+/obj/item/clothing/mask/gas{
+	pixel_x = -2;
+	pixel_y = -2
+	},
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/clothing/mask/gas{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/clothing/mask/gas{
+	pixel_x = 6;
+	pixel_y = 6
+	},
+/obj/item/clothing/mask/gas/half,
+/obj/item/clothing/mask/gas/half,
+/obj/item/clothing/mask/gas/half,
+/obj/item/clothing/mask/gas/half,
+/obj/item/clothing/mask/gas/half,
+/obj/item/clothing/mask/gas/half,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/barracks)
+"Py" = (
+/obj/machinery/light/no_nightshift{
+	dir = 1
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/ship/ert/med)
+"PA" = (
+/obj/structure/bed/chair/bay/chair/padded/blue,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/med)
+"PC" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
@@ -4743,634 +8452,174 @@
 /obj/effect/catwalk_plated/techmaint,
 /turf/simulated/floor/plating,
 /area/ship/ert/hallways)
-"zB" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/floor_decal/corner/blue{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/bridge)
-"zP" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/wood,
-/area/ship/ert/commander)
-"zT" = (
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/wood,
-/area/ship/ert/commander)
-"Af" = (
-/obj/machinery/power/apc/hyper{
-	alarms_hidden = 1;
-	dir = 4;
-	name = "VB APC - East";
-	pixel_x = 24
-	},
-/obj/structure/cable/yellow,
-/obj/machinery/embedded_controller/radio/docking_port_multi{
-	child_names_txt = "Port Airlock Control;Starboard Airlock Control";
-	child_tags_txt = "von_braun_port;von_braun_star";
-	dir = 1;
-	id_tag = "von_braun_master";
-	pixel_y = -22
-	},
-/obj/machinery/light/no_nightshift,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/bridge)
-"Ah" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/structure/table/woodentable,
-/obj/item/weapon/implantpad,
-/obj/item/weapon/implanter,
-/obj/item/weapon/storage/box/admints,
-/turf/simulated/floor/wood,
-/area/ship/ert/commander)
-"Ai" = (
-/obj/machinery/firealarm/alarms_hidden{
-	pixel_y = 26
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/hallways_aft)
-"An" = (
-/obj/machinery/power/apc/hyper{
-	alarms_hidden = 1;
-	dir = 4;
-	name = "VB APC - East";
-	pixel_x = 24
-	},
-/obj/structure/cable/yellow{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/wood,
-/area/ship/ert/commander)
-"Ao" = (
-/obj/item/modular_computer/console/preset/medical{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/bridge)
-"Aq" = (
-/obj/machinery/firealarm/alarms_hidden{
-	pixel_y = 26
-	},
-/obj/item/modular_computer/console/preset/security,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/bridge)
-"Ar" = (
+"PD" = (
 /obj/structure/table/steel_reinforced,
-/obj/fiftyspawner/phoron,
-/obj/fiftyspawner/glass,
-/obj/fiftyspawner/glass,
-/obj/fiftyspawner/glass,
-/obj/fiftyspawner/glass,
-/obj/fiftyspawner/steel,
-/obj/fiftyspawner/steel,
-/obj/fiftyspawner/steel,
-/obj/fiftyspawner/steel,
-/obj/fiftyspawner/plasteel,
-/obj/fiftyspawner/plasteel,
-/obj/fiftyspawner/plasteel,
-/obj/fiftyspawner/plasteel,
-/obj/fiftyspawner/rglass,
-/obj/fiftyspawner/rglass,
-/obj/fiftyspawner/rglass,
-/obj/fiftyspawner/phoronglass,
-/obj/fiftyspawner/phoronglass,
-/obj/fiftyspawner/rods,
-/obj/fiftyspawner/rods,
-/obj/fiftyspawner/rods,
-/obj/fiftyspawner/rods,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/eng_storage)
-"Av" = (
-/obj/item/modular_computer/console/preset/security,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/bridge)
-"Ay" = (
-/obj/machinery/door/airlock/glass_security{
-	req_one_access = list(103)
+/obj/item/weapon/storage/firstaid/toxin{
+	pixel_x = 4;
+	pixel_y = 4
 	},
-/obj/machinery/door/blast/regular{
-	id = "NRV_DELTA"
+/obj/item/weapon/storage/firstaid/toxin{
+	pixel_x = 2;
+	pixel_y = 2
 	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/armoury_dl)
-"Az" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/wall/rshull,
-/area/ship/ert/engine)
-"AI" = (
-/obj/machinery/power/thermoregulator,
-/obj/effect/floor_decal/industrial/outline,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/eng_storage)
-"AK" = (
-/obj/item/modular_computer/console/preset/research,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/bridge)
-"AL" = (
-/obj/structure/table/steel_reinforced,
-/obj/item/weapon/storage/box/pillbottles,
-/obj/item/weapon/storage/box/pillbottles,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/med)
-"AS" = (
-/obj/item/modular_computer/console/preset/medical,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/bridge)
-"AW" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/wall/rshull,
-/area/ship/ert/engine)
-"AX" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/barracks)
-"AZ" = (
-/obj/machinery/alarm/alarms_hidden{
-	pixel_y = 26
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/bridge)
-"Bb" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/obj/machinery/light/no_nightshift{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/hallways)
-"Bc" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/hallways)
-"Bf" = (
-/obj/effect/floor_decal/corner/red{
-	dir = 6
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/item/weapon/storage/firstaid/o2,
+/obj/item/weapon/storage/firstaid/o2{
+	pixel_x = -2;
+	pixel_y = -2
 	},
 /obj/machinery/light/no_nightshift{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/light_switch{
-	pixel_y = 23
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/hallways)
-"Bj" = (
-/obj/machinery/shieldgen,
-/obj/effect/floor_decal/industrial/outline/blue,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/eng_storage)
-"Bl" = (
-/obj/machinery/disperser/back{
-	dir = 4
-	},
-/turf/simulated/floor/airless,
-/area/ship/ert/gunnery)
-"Bo" = (
-/turf/simulated/wall/shull,
-/area/ship/ert/barracks)
-"Bp" = (
-/obj/structure/table/rack/steel,
-/obj/item/weapon/gun/projectile/automatic/z8{
-	pixel_y = 3
-	},
-/obj/item/weapon/gun/projectile/automatic/z8{
-	pixel_y = -3
-	},
-/obj/item/ammo_magazine/m762,
-/obj/item/ammo_magazine/m762,
-/obj/item/ammo_magazine/m762,
-/obj/item/ammo_magazine/m762,
-/obj/item/ammo_magazine/m762,
-/obj/item/ammo_magazine/m762,
-/obj/item/ammo_magazine/m762,
-/obj/item/ammo_magazine/m762,
-/obj/item/ammo_magazine/m762/ap,
-/obj/item/ammo_magazine/m762/ap,
-/obj/item/ammo_magazine/m762/ap,
-/obj/item/ammo_magazine/m762/ap,
-/obj/machinery/light_switch{
-	dir = 1;
-	pixel_y = -23
-	},
-/obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/armoury_dl)
-"Bq" = (
-/obj/machinery/door/airlock/glass_security{
-	req_one_access = list(103)
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/armoury_st)
-"Br" = (
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/eng_storage)
-"Bx" = (
-/obj/structure/bed/chair/bay/chair/padded/blue,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/med)
-"BE" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+"PE" = (
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/eng_storage)
+"PG" = (
+/obj/effect/floor_decal/corner/white{
+	dir = 6
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/armoury_st)
-"BF" = (
+/area/ship/ert/med)
+"PH" = (
+/obj/machinery/pointdefense_control{
+	id_tag = "vonbraun_pd"
+	},
+/obj/machinery/light/no_nightshift{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/bridge)
+"PO" = (
+/obj/machinery/power/pointdefense{
+	id_tag = "vonbraun_pd"
+	},
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d2 = 2;
+	icon_state = "0-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/armoury_st)
-"BI" = (
+/turf/simulated/floor/reinforced/airless,
+/area/ship/ert/mech_bay)
+"PP" = (
 /obj/structure/hull_corner/long_horiz{
 	dir = 5
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/ship/ert/engineering)
-"BK" = (
-/obj/machinery/shipsensors,
-/turf/simulated/floor/reinforced/airless,
-/area/ship/ert/engineering)
-"BM" = (
-/obj/machinery/computer/ship/sensors,
+"PW" = (
+/obj/structure/table/steel_reinforced,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/ship/ert/brig)
+"Qb" = (
+/obj/machinery/light/no_nightshift{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/gunnery)
-"BU" = (
+/area/ship/ert/teleporter)
+"Qc" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/armoury_st)
-"BW" = (
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/hallways)
-"Ce" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/armoury_st)
-"Cf" = (
-/obj/structure/ship_munition/disperser_charge/emp,
-/obj/effect/floor_decal/industrial/warning,
-/obj/structure/railing,
-/turf/simulated/floor/reinforced,
-/area/ship/ert/gunnery)
-"Ci" = (
-/turf/simulated/floor/reinforced/airless,
-/area/ship/ert/eng_storage)
-"Cn" = (
-/obj/machinery/power/apc/hyper{
-	alarms_hidden = 1;
-	dir = 4;
-	name = "VB APC - East";
-	pixel_x = 24
-	},
-/obj/machinery/vending/nifsoft_shop{
-	categories = 111;
-	desc = "For all your mindware and mindware accessories. Now paid for by Central!";
-	dir = 8;
-	emagged = 1;
-	name = "ERT NIFSoft Vendor"
-	},
-/obj/structure/cable/yellow{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/hallways)
-"Cq" = (
-/obj/effect/floor_decal/corner/white{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/med)
-"Cr" = (
-/obj/machinery/porta_turret/stationary/CIWS,
-/turf/simulated/floor/reinforced/airless,
-/area/ship/ert/med_surg)
-"Cx" = (
-/turf/simulated/wall/shull,
-/area/ship/ert/mech_bay)
-"CH" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/structure/fans/hardlight,
-/obj/machinery/door/blast/regular{
-	id = "Von_Braun_Hangar";
-	name = "Hangar Blast Door"
-	},
-/turf/simulated/floor/reinforced,
-/area/ship/ert/hangar)
-"CI" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/machinery/door/firedoor/border_only,
-/obj/structure/window/reinforced{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/machinery/door/airlock/glass_security{
+	name = "Armoury";
+	req_one_access = list(103)
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/armoury_st)
+"Qd" = (
+/obj/machinery/light_switch{
+	dir = 4;
+	pixel_x = -23
 	},
 /turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/armoury_st)
-"CL" = (
-/obj/effect/floor_decal/corner/red{
-	dir = 8
+/area/ship/ert/bridge)
+"Qz" = (
+/obj/machinery/atmospherics/pipe/manifold/visible{
+	dir = 1
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
+/turf/simulated/wall/shull,
+/area/ship/ert/dock_star)
+"QE" = (
+/obj/machinery/door/firedoor/glass,
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced,
+/obj/machinery/door/blast/regular/open{
+	dir = 4;
+	id = "ERT_Blast_Windows";
+	name = "Blast Shield"
 	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/hangar)
-"CM" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/ert_ship_boat)
+"QF" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/hangar)
-"CN" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/area/ship/ert/teleporter)
+"QM" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/engine)
-"CP" = (
-/obj/machinery/door/firedoor/multi_tile{
+/obj/structure/table/steel_reinforced,
+/obj/item/device/laser_pointer/upgraded,
+/obj/item/device/laser_pointer/upgraded,
+/obj/item/device/flash,
+/obj/item/device/flash,
+/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
-/obj/machinery/door/airlock/multi_tile/glass{
-	dir = 1;
-	req_one_access = list(103)
-	},
-/turf/simulated/floor/tiled/white,
-/area/ship/ert/med_surg)
-"CR" = (
-/obj/machinery/light/no_nightshift,
-/turf/simulated/floor/reinforced/airless,
-/area/ship/ert/med_surg)
-"CT" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
 /turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/atmos)
-"CZ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/area/ship/ert/brig)
+"QP" = (
+/turf/simulated/wall/rshull,
+/area/ship/ert/armoury_dl)
+"QR" = (
+/obj/machinery/power/apc/hyper{
+	alarms_hidden = 1;
+	dir = 8;
+	name = "VB APC - West";
+	pixel_x = -24
+	},
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
+	},
 /obj/machinery/light/no_nightshift{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/engine)
-"Dd" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/machinery/door/blast/regular{
-	closed_layer = 4;
-	dir = 4;
-	id = "NRV_DELTA";
-	layer = 4
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/barracks)
-"Dh" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/blast/regular/open{
-	id = "VB_Rear_Blast";
-	name = "Blast Shield"
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/engineering)
-"Di" = (
-/obj/machinery/vending/medical{
-	req_access = null
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/med)
-"Dn" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/atmos)
-"Do" = (
-/obj/machinery/porta_turret/stationary/CIWS,
-/turf/simulated/floor/reinforced/airless,
-/area/ship/ert/engine)
-"Dt" = (
-/obj/structure/railing/grey,
-/obj/structure/railing/grey{
-	dir = 4
-	},
-/obj/structure/table/steel_reinforced,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/bridge)
-"Du" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/obj/machinery/button/remote/blast_door{
-	dir = 1;
-	id = "ERT_Shuttle_Fore";
-	name = "ERT Deployment Access";
-	pixel_y = -25;
-	req_access = list(103)
-	},
 /turf/simulated/floor/tiled/techmaint,
-/area/shuttle/ert_ship_boat)
-"Dx" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/glass{
-	req_one_access = list(103)
-	},
-/obj/structure/sign/warning/airlock{
-	pixel_y = 32
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/dock_port)
-"DJ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/med)
-"DK" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/atmos)
-"DM" = (
-/obj/structure/table/steel_reinforced,
-/obj/item/weapon/storage/firstaid/surgery,
-/obj/item/weapon/storage/firstaid/surgery,
-/obj/item/weapon/surgical/bone_clamp,
-/obj/item/weapon/surgical/bone_clamp,
-/obj/item/weapon/surgical/scalpel/manager,
-/obj/item/weapon/surgical/scalpel/manager,
-/obj/item/weapon/surgical/circular_saw/manager,
-/obj/item/weapon/surgical/circular_saw/manager,
-/obj/item/stack/nanopaste,
-/obj/item/stack/nanopaste,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/med)
-"DN" = (
-/obj/machinery/atmospherics/unary/engine{
-	dir = 4
-	},
-/turf/space,
-/area/ship/ert/engine)
-"DQ" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/atmos)
-"DR" = (
+/area/ship/ert/hangar)
+"QT" = (
 /obj/structure/table/rack/steel,
 /obj/item/weapon/extinguisher/mini,
 /obj/item/weapon/extinguisher/mini,
@@ -5393,84 +8642,139 @@
 /obj/item/weapon/extinguisher/mini,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/med)
-"DS" = (
-/turf/simulated/wall/rshull,
-/area/ship/ert/hallways_aft)
-"Ed" = (
-/obj/machinery/light/no_nightshift{
-	dir = 4
+"QV" = (
+/obj/machinery/door/firedoor/glass,
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced,
+/obj/machinery/door/blast/regular/open{
+	dir = 8;
+	id = "ERT_Blast_Windows";
+	name = "Blast Shield"
 	},
-/obj/effect/floor_decal/corner/yellow{
+/obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/sign/warning/engineering_access{
-	pixel_x = -32
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/hallways_aft)
-"Ee" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/white{
-	dir = 8
-	},
-/obj/machinery/portable_atmospherics/powered/pump/filled,
-/obj/machinery/light/no_nightshift,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/ert_ship_boat)
+"QZ" = (
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/engine)
+"Rc" = (
+/obj/machinery/door/blast/regular/open{
+	id = "ERT_Shuttle_Rear";
+	name = "Boarding Hatch"
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/hangar)
-"Eh" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/wood,
-/area/ship/ert/commander)
-"Eo" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
+/area/shuttle/ert_ship_boat)
+"Rd" = (
+/obj/machinery/porta_turret/stationary/CIWS,
+/turf/simulated/floor/reinforced/airless,
+/area/ship/ert/engineering)
+"Rh" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/eng_storage)
-"Eq" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
+/area/ship/ert/armoury_st)
+"Rt" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/shuttle/ert_ship_boat)
-"EA" = (
-/obj/structure/table/woodentable,
-/obj/item/weapon/storage/box/trackimp,
-/obj/item/weapon/storage/box/cdeathalarm_kit,
-/obj/item/weapon/stamp/centcomm,
+/area/ship/ert/armoury_st)
+"Rv" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/med)
+"Rw" = (
+/obj/effect/landmark/late_antag/ert,
+/obj/structure/table/bench/steel,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/barracks)
+"Rz" = (
+/obj/item/modular_computer/console/preset/engineering{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/bridge)
+"RB" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/wood,
-/area/ship/ert/commander)
-"EB" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/engine)
+"RC" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/engine)
+"RJ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 9
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/engine)
+"RN" = (
+/obj/structure/sign/department/medbay,
+/turf/simulated/wall/shull,
+/area/ship/ert/med_surg)
+"RQ" = (
+/obj/effect/floor_decal/corner/red{
+	dir = 8
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/hangar)
+"RU" = (
+/obj/machinery/light/no_nightshift,
+/turf/simulated/floor/reinforced/airless,
+/area/ship/ert/med_surg)
+"RV" = (
+/obj/effect/floor_decal/corner/blue{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/hallways)
+"RW" = (
+/obj/machinery/light/no_nightshift{
+	dir = 1
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/ship/ert/hallways_aft)
+"RX" = (
 /obj/effect/floor_decal/corner/white,
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/machinery/firealarm/alarms_hidden{
@@ -5484,224 +8788,240 @@
 /obj/effect/floor_decal/industrial/outline,
 /turf/simulated/floor/tiled/techmaint,
 /area/ship/ert/hangar)
-"EC" = (
-/obj/structure/bed/chair/comfy/black{
-	dir = 8
-	},
-/obj/machinery/light/no_nightshift{
-	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/ship/ert/commander)
-"ED" = (
-/obj/item/modular_computer/console/preset/ert{
-	dir = 4
-	},
-/obj/machinery/light/no_nightshift{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/bridge)
-"EG" = (
-/obj/structure/bed/chair/bay/shuttle{
+"Sc" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/obj/machinery/light/no_nightshift{
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/engineering)
+"Se" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/shuttle/ert_ship_boat)
-"EP" = (
-/obj/structure/closet/crate/medical,
-/obj/item/weapon/storage/box/autoinjectors,
-/obj/item/weapon/storage/box/beakers,
-/obj/item/weapon/storage/box/bodybags,
-/obj/item/weapon/storage/box/bodybags{
-	pixel_x = 2;
-	pixel_y = 2
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
 	},
-/obj/item/weapon/storage/box/gloves,
-/obj/item/weapon/storage/box/freezer,
-/obj/item/weapon/storage/box/masks,
-/obj/effect/floor_decal/industrial/outline,
-/obj/item/weapon/storage/box/bodybags,
-/obj/item/weapon/storage/box/bodybags,
-/turf/simulated/floor/tiled/techfloor,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techmaint,
 /area/ship/ert/med)
-"Fd" = (
-/obj/machinery/light/no_nightshift{
-	dir = 1
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/ship/ert/med)
-"Ff" = (
-/obj/machinery/light/no_nightshift,
-/obj/structure/sign/vacuum{
-	pixel_y = -32
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
+"Sh" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/ship/ert/hangar)
-"Fg" = (
-/obj/structure/bed/chair/bay/chair/padded/blue{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/bridge)
-"Fp" = (
-/obj/structure/sign/nosmoking_1,
-/turf/simulated/wall/rshull,
-/area/ship/ert/engineering)
-"Fq" = (
-/obj/structure/table/rack/steel,
-/obj/item/weapon/storage/box/frags{
-	pixel_x = -2;
-	pixel_y = -2
-	},
-/obj/item/weapon/storage/box/frags{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/machinery/power/apc/hyper{
-	alarms_hidden = 1;
-	dir = 4;
-	name = "VB APC - East";
-	pixel_x = 24
-	},
-/obj/structure/cable/yellow,
-/obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/armoury_dl)
-"Fz" = (
-/obj/structure/bed/chair/bay/chair/padded/blue{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/bridge)
-"FD" = (
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/bridge)
-"FF" = (
-/obj/effect/shuttle_landmark/premade/ert_ship_port,
-/turf/space,
-/area/space)
-"FG" = (
+"Si" = (
+/obj/structure/table/steel_reinforced,
+/obj/machinery/recharger,
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/wall/shull,
-/area/ship/ert/med_surg)
-"FJ" = (
-/obj/machinery/door/airlock/glass_command{
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/armoury_dl)
+"Sj" = (
+/turf/simulated/wall/rshull,
+/area/ship/ert/teleporter)
+"Sl" = (
+/obj/structure/sign/department/telecoms{
+	name = "TELEPORTER"
+	},
+/turf/simulated/wall/rshull,
+/area/ship/ert/teleporter)
+"Sn" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/glass_security{
+	name = "Delta Armoury";
 	req_one_access = list(103)
 	},
-/obj/machinery/door/firedoor/border_only,
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/bridge)
-"FK" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 9
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/hallways)
-"FL" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/wall/rshull,
-/area/ship/ert/gunnery)
-"FM" = (
-/obj/effect/floor_decal/corner/yellow{
-	dir = 10
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/obj/machinery/light/no_nightshift{
-	dir = 8
+/obj/machinery/door/blast/regular{
+	closed_layer = 4;
+	id = "NRV_DELTA";
+	layer = 4
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/hallways)
-"FN" = (
-/obj/effect/floor_decal/corner/red{
+/area/ship/ert/armoury_dl)
+"Sp" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/hallways)
-"FO" = (
-/obj/machinery/light/no_nightshift{
-	dir = 1
-	},
-/obj/machinery/porta_turret/stationary/CIWS,
-/turf/simulated/floor/reinforced/airless,
-/area/ship/ert/dock_star)
-"FP" = (
-/obj/structure/ship_munition/disperser_charge/explosive,
+/area/ship/ert/med)
+"Sr" = (
 /obj/effect/floor_decal/industrial/warning{
-	dir = 5
-	},
-/obj/structure/railing{
 	dir = 4
 	},
-/obj/structure/railing{
-	dir = 1
+/turf/simulated/floor/reinforced,
+/area/ship/ert/hangar)
+"St" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/structure/railing/grey,
+/obj/structure/table/steel_reinforced,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/bridge)
+"Sx" = (
+/obj/structure/bed/chair/bay/chair/padded/blue{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/bridge)
+"Sy" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/door/blast/regular{
+	closed_layer = 4;
+	id = "NRV_DELTA";
+	layer = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/armoury_dl)
+"SA" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/fans/hardlight,
+/obj/machinery/door/blast/regular{
+	id = "Von_Braun_Hangar";
+	name = "Hangar Blast Door"
 	},
 /turf/simulated/floor/reinforced,
-/area/ship/ert/gunnery)
-"FQ" = (
-/obj/machinery/door/airlock/glass_security{
-	req_one_access = list(103)
+/area/ship/ert/hangar)
+"SB" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
 	},
-/obj/machinery/door/firedoor/multi_tile{
+/turf/simulated/floor/reinforced/airless,
+/area/ship/ert/hangar)
+"SD" = (
+/obj/machinery/door/window/brigdoor/southleft{
+	req_access = list(150);
+	req_one_access = list(150)
+	},
+/obj/machinery/door/firedoor/glass,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/armoury_st)
-"FR" = (
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/armoury_st)
-"FT" = (
-/obj/structure/closet/crate{
-	dir = 2
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/ship/ert/brig)
+"SE" = (
+/obj/structure/sign/nosmoking_1,
+/turf/simulated/wall/rshull,
+/area/ship/ert/engineering)
+"SF" = (
+/obj/machinery/alarm/alarms_hidden{
+	pixel_y = 26
 	},
-/obj/effect/floor_decal/industrial/outline/red,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/bridge)
+"SG" = (
+/turf/simulated/wall/shull,
+/area/ship/ert/dock_star)
+"SI" = (
+/obj/machinery/firealarm/alarms_hidden{
+	pixel_y = 26
+	},
 /turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/armoury_st)
-"FW" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/area/ship/ert/dock_star)
+"SJ" = (
+/obj/structure/bed/chair/bay/chair/padded/blue{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/hallways_aft)
+"SN" = (
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/gunnery)
+"SO" = (
+/obj/effect/floor_decal/corner/white{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/med)
+"SV" = (
+/obj/machinery/shield_gen/external,
+/obj/effect/floor_decal/corner/white,
+/obj/effect/floor_decal/industrial/outline/blue,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/eng_storage)
+"SX" = (
+/obj/effect/shuttle_landmark/premade/ert_ship_star,
+/turf/space,
+/area/space)
+"SY" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock/glass_engineeringatmos{
+	name = "Atmospherics";
+	req_one_access = list(103)
+	},
 /turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/hallways_aft)
-"FX" = (
+/area/ship/ert/atmos)
+"SZ" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/hangar)
+"Td" = (
+/obj/effect/floor_decal/corner/yellow{
+	dir = 9
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/med)
+"Ti" = (
+/obj/item/weapon/paper_bin{
+	pixel_x = -3;
+	pixel_y = 8
+	},
+/obj/item/weapon/pen{
+	pixel_y = 4
+	},
+/obj/machinery/firealarm/alarms_hidden{
+	dir = 1;
+	pixel_y = -26
+	},
+/obj/item/toy/figure/ert,
+/obj/structure/table/hardwoodtable,
+/turf/simulated/floor/wood,
+/area/ship/ert/commander)
+"Tl" = (
 /obj/structure/table/steel_reinforced,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -5836,329 +9156,20 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/ship/ert/armoury_st)
-"FY" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/armoury_dl)
-"Ga" = (
-/obj/structure/table/steel_reinforced,
-/obj/machinery/recharger,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/armoury_st)
-"Gl" = (
-/obj/structure/table/rack/steel,
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/item/weapon/gun/projectile/automatic/z8{
-	pixel_y = -3
-	},
-/obj/item/weapon/gun/projectile/automatic/z8{
-	pixel_y = 3
-	},
-/obj/item/ammo_magazine/m762,
-/obj/item/ammo_magazine/m762,
-/obj/item/ammo_magazine/m762,
-/obj/item/ammo_magazine/m762,
-/obj/item/ammo_magazine/m762,
-/obj/item/ammo_magazine/m762,
-/obj/item/ammo_magazine/m762,
-/obj/item/ammo_magazine/m762,
-/obj/item/ammo_magazine/m762/ap,
-/obj/item/ammo_magazine/m762/ap,
-/obj/item/ammo_magazine/m762/ap,
-/obj/item/ammo_magazine/m762/ap,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/armoury_dl)
-"Gr" = (
-/obj/machinery/power/emitter,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/eng_storage)
-"Gu" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/wall/rshull,
-/area/ship/ert/med_surg)
-"Gv" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/machinery/door/window/brigdoor/southleft,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/hallways_aft)
-"Gw" = (
-/obj/structure/closet/wardrobe/ert,
-/obj/item/modular_computer/tablet/preset/custom_loadout/elite,
-/obj/item/weapon/storage/box/survival/comp{
-	starts_with = list(/obj/item/weapon/tool/prybar/red,/obj/item/clothing/glasses/goggles,/obj/item/weapon/reagent_containers/hypospray/autoinjector,/obj/item/stack/medical/bruise_pack,/obj/item/device/flashlight/glowstick,/obj/item/weapon/reagent_containers/food/snacks/candy/proteinbar,/obj/item/clothing/mask/breath,/obj/item/weapon/tank/emergency/oxygen/engi)
-	},
-/obj/machinery/light/no_nightshift{
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/item/modular_computer/laptop/preset/custom_loadout/elite,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/barracks)
-"GI" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/engine)
-"GJ" = (
-/obj/structure/hull_corner{
-	dir = 1
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/ship/ert/eng_storage)
-"GK" = (
-/obj/structure/closet/crate{
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/outline/red,
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/armoury_st)
-"GM" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/hallways)
-"GO" = (
-/obj/machinery/door/airlock/glass_security{
-	req_one_access = list(103)
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/armoury_st)
-"GR" = (
-/obj/effect/floor_decal/corner/red{
-	dir = 9
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/hangar)
-"GS" = (
-/obj/effect/floor_decal/corner/white{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/eng_storage)
-"GT" = (
-/obj/machinery/power/apc/hyper{
-	alarms_hidden = 1;
-	name = "VB APC - South";
-	pixel_y = -24
-	},
-/obj/structure/cable/yellow,
-/turf/simulated/floor/tiled/white,
-/area/ship/ert/med_surg)
-"GU" = (
-/obj/effect/floor_decal/corner/red{
-	dir = 8
-	},
-/obj/structure/reagent_dispensers/foam,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/floor_decal/industrial/outline,
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/hangar)
-"GY" = (
-/obj/machinery/cryopod/ert_ship,
-/turf/simulated/floor/tiled/white,
-/area/ship/ert/med_surg)
-"GZ" = (
-/obj/structure/bed/chair/bay/shuttle,
-/obj/machinery/light/no_nightshift{
+"Tp" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/shuttle/ert_ship_boat)
-"Hf" = (
-/turf/simulated/wall/rshull,
-/area/ship/ert/engine)
-"Hp" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/med)
-"Hq" = (
-/obj/machinery/door/firedoor/glass,
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/structure/window/reinforced,
-/obj/machinery/door/blast/regular/open{
-	dir = 4;
-	id = "ERT_Blast_Windows";
-	name = "Blast Shield"
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/shuttle/ert_ship_boat)
-"Hu" = (
-/obj/machinery/door/firedoor,
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/structure/window/reinforced,
-/obj/machinery/door/blast/regular/open{
-	dir = 4;
-	id = "ERT_Blast_Windows";
-	name = "Blast Shield"
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/shuttle/ert_ship_boat)
-"HB" = (
-/obj/structure/table/rack/steel,
-/obj/item/weapon/gun/energy/gun/burst{
-	pixel_y = 3
-	},
-/obj/item/weapon/gun/energy/gun/burst{
-	pixel_y = -3
-	},
-/obj/item/weapon/gun/energy/lasershotgun{
-	pixel_y = -3
-	},
-/obj/item/weapon/gun/energy/lasershotgun{
-	pixel_y = 3
-	},
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/machinery/recharger/wallcharger{
-	pixel_x = -23;
-	pixel_y = -12
-	},
-/obj/machinery/recharger/wallcharger{
-	pixel_x = -23;
-	pixel_y = -4
-	},
-/obj/machinery/recharger/wallcharger{
-	pixel_x = -23;
-	pixel_y = 5
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/armoury_dl)
-"HC" = (
-/obj/structure/closet/crate/medical,
-/obj/item/weapon/storage/mre/menu11,
-/obj/item/weapon/storage/mre/menu11,
-/obj/item/weapon/storage/mre/menu11,
-/obj/item/weapon/storage/mre/menu11,
-/obj/item/stack/nanopaste/advanced,
-/obj/item/stack/nanopaste/advanced,
-/obj/item/stack/nanopaste/advanced,
-/obj/item/weapon/reagent_containers/food/drinks/drinkingglass/fitnessflask/glucose,
-/obj/item/weapon/storage/pill_bottle/iron,
-/obj/item/weapon/storage/pill_bottle/iron,
-/obj/item/weapon/storage/pill_bottle/sleevingcure/full,
-/obj/item/weapon/storage/box/syringes,
-/obj/item/weapon/storage/box/syringes{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/machinery/light_switch{
-	dir = 8;
-	pixel_x = 23
-	},
-/obj/effect/floor_decal/industrial/outline,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/med)
-"HE" = (
-/turf/simulated/floor/reinforced/airless,
-/area/ship/ert/dock_port)
-"HH" = (
-/obj/structure/bed/chair/bay/shuttle{
-	dir = 1
-	},
-/obj/machinery/recharger/wallcharger{
-	pixel_x = -23;
-	pixel_y = -12
-	},
-/obj/machinery/recharger/wallcharger{
-	pixel_x = -23;
-	pixel_y = -4
-	},
-/obj/machinery/recharger/wallcharger{
-	pixel_x = -23;
-	pixel_y = 5
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/shuttle/ert_ship_boat)
-"HK" = (
-/obj/machinery/shield_diffuser,
-/obj/machinery/door/blast/regular/open{
-	dir = 2;
-	id = "ERT_Blast_Windows";
-	name = "Blast Shield"
-	},
-/obj/machinery/door/blast/regular{
-	id = "ERT_Shuttle_Fore"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/shuttle/ert_ship_boat)
-"HO" = (
-/turf/simulated/wall/rshull,
-/area/shuttle/ert_ship_boat)
-"HR" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/machinery/door/window/brigdoor/northright,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/hallways_aft)
-"HZ" = (
-/obj/machinery/computer/ship/navigation{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+	dir = 4
 	},
-/obj/structure/railing/grey,
+/obj/item/modular_computer/console/preset/medical{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/bridge)
-"Ia" = (
-/obj/machinery/light/no_nightshift{
-	dir = 1
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/ship/ert/engine)
-"Ib" = (
-/turf/simulated/floor/reinforced/airless,
-/area/ship/ert/hallways_aft)
-"Id" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/engine)
-"Ig" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/fuel{
-	dir = 4
-	},
+"Tx" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -6167,56 +9178,26 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/engine)
-"Ii" = (
-/obj/machinery/atmospherics/portables_connector/fuel{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/floor_decal/industrial/outline/red,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/engine)
-"Io" = (
+"TB" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
 	},
 /obj/machinery/firealarm/alarms_hidden{
-	dir = 1;
-	pixel_y = -26
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/atmos)
-"Ip" = (
-/obj/machinery/power/apc/hyper{
-	alarms_hidden = 1;
-	dir = 4;
-	name = "VB APC - East";
-	pixel_x = 24
+	pixel_y = 26
 	},
 /obj/structure/cable/yellow{
+	d1 = 2;
 	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/alarm/alarms_hidden{
-	dir = 1;
-	pixel_y = -26
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/atmos)
-"Is" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
+/area/ship/ert/engineering)
+"TD" = (
+/turf/simulated/wall/rshull,
+/area/ship/ert/mech_bay)
+"TF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -6224,121 +9205,17 @@
 	dir = 4
 	},
 /obj/structure/cable/yellow{
-	d1 = 1;
+	d1 = 4;
 	d2 = 8;
-	icon_state = "1-8"
+	icon_state = "4-8"
 	},
+/turf/simulated/floor/tiled/white,
+/area/ship/ert/med_surg)
+"TG" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/techmaint,
 /area/ship/ert/mech_bay)
-"Iv" = (
-/turf/simulated/floor/wood,
-/area/ship/ert/commander)
-"Ix" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/turf/simulated/floor/wood,
-/area/ship/ert/commander)
-"IA" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/barracks)
-"IF" = (
-/obj/structure/table/rack/steel,
-/obj/effect/floor_decal/industrial/outline,
-/obj/item/weapon/hand_labeler,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/med)
-"IK" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/turf/simulated/floor/wood,
-/area/ship/ert/commander)
-"IL" = (
-/obj/structure/table/woodentable,
-/obj/item/device/aicard,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/machinery/light_switch{
-	dir = 1;
-	pixel_y = -23
-	},
-/turf/simulated/floor/wood,
-/area/ship/ert/commander)
-"IZ" = (
-/obj/structure/table/woodentable,
-/obj/item/weapon/paper_bin{
-	pixel_x = -3;
-	pixel_y = 8
-	},
-/obj/item/weapon/pen{
-	pixel_y = 4
-	},
-/obj/machinery/firealarm/alarms_hidden{
-	dir = 1;
-	pixel_y = -26
-	},
-/obj/item/toy/figure/ert,
-/turf/simulated/floor/wood,
-/area/ship/ert/commander)
-"Jb" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/armoury_st)
-"Jc" = (
-/obj/structure/table/steel_reinforced,
-/obj/item/weapon/storage/firstaid/toxin{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/item/weapon/storage/firstaid/toxin{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/item/weapon/storage/firstaid/o2,
-/obj/item/weapon/storage/firstaid/o2{
-	pixel_x = -2;
-	pixel_y = -2
-	},
-/obj/machinery/light/no_nightshift{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/med)
-"Jd" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/barracks)
-"Jf" = (
+"TI" = (
 /obj/effect/floor_decal/corner/yellow{
 	dir = 10
 	},
@@ -6350,79 +9227,93 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/ship/ert/hallways)
-"Jg" = (
-/obj/machinery/light/no_nightshift{
-	dir = 1
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/ship/ert/med_surg)
-"Jk" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/structure/window/reinforced{
+"TM" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
 /turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/bridge)
-"Jl" = (
-/obj/effect/floor_decal/corner/blue{
+/area/ship/ert/atmos)
+"TP" = (
+/obj/machinery/flasher,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 1
 	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/ship/ert/brig)
+"TQ" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/white{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/hallways)
-"Js" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/hallways)
-"Jw" = (
-/obj/structure/table/rack/steel,
-/obj/item/weapon/storage/box/handcuffs{
-	pixel_x = -2;
-	pixel_y = -2
-	},
-/obj/item/weapon/storage/box/handcuffs{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/effect/floor_decal/corner/red{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/hallways)
-"Jx" = (
-/obj/item/device/perfect_tele_beacon/stationary{
-	tele_name = "NRB Robineau";
-	tele_network = "centcom"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/shuttle/ert_ship_boat)
-"JB" = (
-/turf/simulated/wall/rshull,
-/area/ship/ert/dock_port)
-"JE" = (
+/obj/machinery/portable_atmospherics/powered/pump/filled,
+/obj/machinery/light/no_nightshift,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/floor_decal/industrial/warning/corner,
 /turf/simulated/floor/tiled/techmaint,
 /area/ship/ert/hangar)
-"JG" = (
+"TR" = (
+/obj/structure/railing/grey,
+/obj/structure/railing/grey{
+	dir = 4
+	},
+/obj/structure/table/steel_reinforced,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/bridge)
+"TU" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/door/blast/regular/open{
+	dir = 4;
+	id = "braun_blast_shields";
+	name = "Blast Shield"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/med)
+"TW" = (
+/obj/item/device/perfect_tele_beacon/stationary{
+	tele_name = "NRV Von Braun Teleporter Room";
+	tele_network = "centcom"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/teleporter)
+"TX" = (
+/obj/machinery/door/window/brigdoor/southleft,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/hallways_aft)
+"TZ" = (
+/obj/structure/grille,
+/obj/structure/window/titanium/full,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/floor_decal/techfloor{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/brig)
+"Ue" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/atmos)
+"Uk" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -6431,7 +9322,495 @@
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/engineering)
-"JJ" = (
+"Ul" = (
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/teleporter)
+"Un" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/hallways_aft)
+"Ut" = (
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id = "braun_cells_privacy";
+	name = "Privacy Shutters";
+	opacity = 0
+	},
+/obj/structure/grille,
+/obj/structure/window/titanium/full,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/cable/yellow,
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/brig)
+"Uy" = (
+/obj/structure/table/rack/steel,
+/obj/item/weapon/gun/energy/gun{
+	pixel_y = 6
+	},
+/obj/item/weapon/gun/energy/gun{
+	pixel_y = 4
+	},
+/obj/item/weapon/gun/energy/gun{
+	pixel_y = 2
+	},
+/obj/item/weapon/gun/energy/gun,
+/obj/item/weapon/gun/energy/gun{
+	pixel_y = -2
+	},
+/obj/item/weapon/gun/energy/gun{
+	pixel_y = -4
+	},
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/armoury_st)
+"UD" = (
+/obj/structure/ship_munition/disperser_charge/explosive,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 5
+	},
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/simulated/floor/reinforced,
+/area/ship/ert/gunnery)
+"UE" = (
+/obj/structure/sign/warning/radioactive{
+	desc = "WARNING: VON BRAUN PTTOS EMIT RADIATION WHILST OPERATIONAL.";
+	name = "\improper RADIOACTIVE GENERATORS BEHIND THESE DOORS";
+	pixel_x = -16
+	},
+/turf/simulated/wall/shull,
+/area/ship/ert/engineering)
+"UH" = (
+/obj/machinery/alarm/alarms_hidden{
+	dir = 1;
+	pixel_y = -26
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/bridge)
+"UI" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/wall/rshull,
+/area/ship/ert/med)
+"UJ" = (
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id = "braun_cells_privacy";
+	name = "Privacy Shutters";
+	opacity = 0
+	},
+/obj/structure/grille,
+/obj/structure/window/titanium/full,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium,
+/obj/structure/cable/yellow{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/brig)
+"UK" = (
+/obj/structure/hull_corner/long_horiz{
+	dir = 5
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/ship/ert/engine)
+"UN" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/power/apc/hyper{
+	alarms_hidden = 1;
+	dir = 4;
+	name = "VB APC - East";
+	pixel_x = 24
+	},
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/yellow{
+	d2 = 4;
+	dir = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/hallways_aft)
+"UT" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/armoury_dl)
+"UU" = (
+/obj/machinery/door/window/brigdoor/northleft{
+	req_access = list(150);
+	req_one_access = list(150)
+	},
+/obj/machinery/door/firedoor/glass,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/ship/ert/brig)
+"UY" = (
+/obj/structure/table/rack,
+/obj/item/weapon/rig/ert,
+/obj/item/weapon/cell/slime,
+/turf/simulated/floor/wood,
+/area/ship/ert/commander)
+"Vc" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/engine)
+"Vd" = (
+/obj/structure/window/reinforced,
+/turf/simulated/floor/tiled/techmaint,
+/area/shuttle/ert_ship_boat)
+"Vg" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/hallways)
+"Vh" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/med)
+"Vn" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/armoury_dl)
+"Vp" = (
+/obj/machinery/computer/ship/engines{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/engineering)
+"Vq" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/mech_bay)
+"Vx" = (
+/obj/machinery/light/no_nightshift{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/engine)
+"VC" = (
+/obj/machinery/door/airlock/glass_security{
+	name = "Armoury";
+	req_one_access = list(103)
+	},
+/obj/machinery/door/firedoor/multi_tile{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/armoury_st)
+"VH" = (
+/obj/structure/table/steel_reinforced,
+/obj/machinery/recharger,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/armoury_st)
+"VJ" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/med)
+"VK" = (
+/obj/structure/hull_corner{
+	dir = 1
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/ship/ert/med)
+"VN" = (
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/gunnery)
+"VO" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/bridge)
+"VQ" = (
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/bridge)
+"Wh" = (
+/obj/structure/closet/crate{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/item/weapon/plastique,
+/obj/item/weapon/plastique,
+/obj/item/weapon/plastique,
+/obj/item/weapon/plastique,
+/obj/effect/floor_decal/industrial/outline/red,
+/obj/item/weapon/plastique,
+/obj/item/weapon/plastique,
+/obj/item/weapon/plastique,
+/obj/item/weapon/plastique,
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/armoury_dl)
+"Wl" = (
+/obj/structure/sign/department/medbay,
+/turf/simulated/wall/shull,
+/area/ship/ert/med)
+"Wq" = (
+/turf/simulated/wall/rshull,
+/area/ship/ert/commander)
+"Wu" = (
+/obj/structure/closet/crate{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/outline/red,
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/armoury_st)
+"Wv" = (
+/obj/effect/shuttle_landmark/premade/ert_ship_near_star,
+/turf/space,
+/area/space)
+"WA" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/armoury_dl)
+"WC" = (
+/turf/simulated/floor/reinforced,
+/area/ship/ert/hangar)
+"WE" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock/glass_security{
+	name = "Armoury";
+	req_one_access = list(103)
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/armoury_st)
+"WF" = (
+/obj/structure/hull_corner{
+	dir = 8
+	},
+/turf/simulated/shuttle/plating/airless/carry,
+/area/shuttle/ert_ship_boat)
+"WH" = (
+/obj/structure/closet/wardrobe/ert,
+/obj/item/modular_computer/tablet/preset/custom_loadout/elite,
+/obj/item/weapon/storage/box/survival/comp{
+	starts_with = list(/obj/item/weapon/tool/prybar/red,/obj/item/clothing/glasses/goggles,/obj/item/weapon/reagent_containers/hypospray/autoinjector,/obj/item/stack/medical/bruise_pack,/obj/item/device/flashlight/glowstick,/obj/item/weapon/reagent_containers/food/snacks/candy/proteinbar,/obj/item/clothing/mask/breath,/obj/item/weapon/tank/emergency/oxygen/engi)
+	},
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/item/modular_computer/laptop/preset/custom_loadout/elite,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/barracks)
+"WJ" = (
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/hangar)
+"WK" = (
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/hallways_aft)
+"WO" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/engine)
+"WP" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/shuttle/ert_ship_boat)
+"WS" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/bed/chair/bay/chair/padded/blue{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/engineering)
+"WT" = (
+/obj/machinery/door/firedoor/glass,
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/machinery/door/blast/regular/open{
+	dir = 2;
+	id = "ERT_Blast_Windows";
+	name = "Blast Shield"
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/shield_diffuser,
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/ert_ship_boat)
+"WV" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/effect/landmark{
+	name = "Commando"
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/barracks)
+"WX" = (
+/obj/machinery/recharge_station,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/atmos)
+"WZ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/hallways_aft)
+"Xg" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/engineering)
+"Xh" = (
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	icon_state = "shutter0";
+	id = "braun_cells_privacy";
+	name = "Privacy Shutters";
+	opacity = 0
+	},
+/obj/structure/grille,
+/obj/structure/window/titanium/full,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium,
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/brig)
+"Xo" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/med)
+"Xu" = (
+/obj/machinery/power/smes/buildable/point_of_interest,
+/obj/structure/cable/yellow,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/engineering)
+"Xv" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/armoury_dl)
+"Xw" = (
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/mech_bay)
+"Xz" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
@@ -6443,1181 +9822,114 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/dock_star)
-"JM" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/barracks)
-"JN" = (
-/obj/structure/bed/chair/bay/shuttle,
-/turf/simulated/floor/tiled/techfloor,
-/area/shuttle/ert_ship_boat)
-"JW" = (
-/obj/machinery/light/no_nightshift,
-/obj/machinery/atmospherics/unary/engine{
-	dir = 4
-	},
-/turf/space,
-/area/ship/ert/engine)
-"JX" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/glass{
-	req_one_access = list(103)
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/bridge)
-"JY" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/engine)
-"JZ" = (
-/obj/structure/table/rack/steel,
-/obj/item/weapon/gun/projectile/heavysniper,
-/obj/item/ammo_magazine/ammo_box/b145,
-/obj/item/ammo_magazine/ammo_box/b145,
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/machinery/alarm/alarms_hidden{
+"XB" = (
+/obj/structure/table/steel_reinforced,
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/ship/ert/brig)
+"XG" = (
+/turf/simulated/wall/rshull,
+/area/ship/ert/eng_storage)
+"XH" = (
+/obj/machinery/firealarm/alarms_hidden{
 	dir = 1;
 	pixel_y = -26
 	},
-/obj/machinery/light/no_nightshift,
 /turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/armoury_dl)
-"Kb" = (
-/obj/structure/railing/grey{
-	dir = 4
-	},
-/obj/structure/railing/grey{
-	dir = 1
-	},
-/obj/item/weapon/paper/vonbraun_shields,
-/obj/structure/table/steel_reinforced,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/bridge)
-"Kf" = (
-/obj/machinery/computer/teleporter{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/teleporter)
-"Kj" = (
-/obj/machinery/power/pointdefense{
-	id_tag = "vonbraun_pd"
-	},
+/area/ship/ert/engine)
+"XI" = (
 /obj/structure/cable/yellow{
-	d2 = 4;
-	icon_state = "0-4"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
+/obj/structure/table/steel_reinforced,
+/obj/item/weapon/gun/energy/sizegun,
+/obj/item/weapon/gun/energy/sizegun,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/brig)
+"XM" = (
 /turf/simulated/floor/reinforced/airless,
-/area/ship/ert/engine)
-"Kk" = (
-/obj/effect/landmark/late_antag/ert,
-/obj/structure/table/bench/steel,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/barracks)
-"Kq" = (
-/obj/machinery/light/no_nightshift{
-	dir = 4
-	},
-/obj/machinery/atmospherics/portables_connector/fuel{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/floor_decal/industrial/outline/red,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/engine)
-"Kr" = (
-/obj/machinery/light/no_nightshift{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/yellow{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/techmaint,
 /area/ship/ert/hallways_aft)
-"Ks" = (
-/obj/machinery/door/airlock/centcom{
-	name = "Commander";
-	req_access = list(103)
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor/border_only,
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/commander)
-"Kt" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/dock_star)
-"Kw" = (
-/obj/structure/sign/department/eng,
-/turf/simulated/wall/rshull,
-/area/ship/ert/bridge)
-"KB" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/machinery/door/firedoor/border_only,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/eng_storage)
-"KG" = (
-/obj/structure/table/rack/steel,
-/obj/item/weapon/storage/toolbox/mechanical{
-	pixel_x = -4;
-	pixel_y = -6
-	},
-/obj/item/weapon/storage/toolbox/mechanical{
-	pixel_x = -4;
-	pixel_y = -2
-	},
-/obj/item/weapon/storage/toolbox/electrical{
-	pixel_x = -4;
-	pixel_y = 2
-	},
-/obj/item/weapon/storage/toolbox/electrical{
-	pixel_x = -4;
-	pixel_y = 6
-	},
-/obj/item/weapon/storage/briefcase/inflatable{
-	pixel_x = 4;
-	pixel_y = -6
-	},
-/obj/item/weapon/storage/briefcase/inflatable{
-	pixel_x = 4;
-	pixel_y = -2
-	},
-/obj/item/weapon/storage/briefcase/inflatable{
-	pixel_x = 4;
-	pixel_y = 2
-	},
-/obj/item/weapon/storage/briefcase/inflatable{
-	pixel_x = 4;
-	pixel_y = 6
-	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/eng_storage)
-"KI" = (
-/turf/simulated/wall/shull,
-/area/ship/ert/med)
-"KJ" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/obj/structure/railing/grey{
-	dir = 1
-	},
-/obj/structure/table/steel_reinforced,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/bridge)
-"KK" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/wall/rshull,
-/area/ship/ert/engine)
-"KM" = (
-/obj/structure/bed/chair/bay/chair/padded/blue{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/bridge)
-"KN" = (
-/obj/structure/closet/wardrobe/ert,
-/obj/item/modular_computer/tablet/preset/custom_loadout/elite,
-/obj/item/weapon/storage/box/survival/comp{
-	starts_with = list(/obj/item/weapon/tool/prybar/red,/obj/item/clothing/glasses/goggles,/obj/item/weapon/reagent_containers/hypospray/autoinjector,/obj/item/stack/medical/bruise_pack,/obj/item/device/flashlight/glowstick,/obj/item/weapon/reagent_containers/food/snacks/candy/proteinbar,/obj/item/clothing/mask/breath,/obj/item/weapon/tank/emergency/oxygen/engi)
-	},
-/obj/machinery/light/no_nightshift{
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/item/modular_computer/laptop/preset/custom_loadout/elite,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/barracks)
-"KO" = (
-/obj/machinery/vending/tool,
-/obj/machinery/light/no_nightshift{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/eng_storage)
-"KS" = (
-/obj/machinery/door/airlock/centcom{
-	name = "Reactor Access";
-	req_access = list(103)
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/blast/regular/open{
-	dir = 4;
-	id = "VB_Rear_Blast";
-	name = "Blast Shield"
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/engineering)
-"KT" = (
-/obj/structure/table/steel_reinforced,
-/obj/item/stack/cable_coil,
-/obj/item/stack/cable_coil,
-/obj/item/stack/cable_coil,
-/obj/item/stack/cable_coil,
-/obj/item/stack/cable_coil,
-/obj/item/stack/cable_coil,
-/obj/item/weapon/grenade/chem_grenade/metalfoam,
-/obj/item/weapon/grenade/chem_grenade/metalfoam,
-/obj/item/weapon/grenade/chem_grenade/metalfoam,
-/obj/item/weapon/grenade/chem_grenade/metalfoam,
-/obj/item/weapon/grenade/chem_grenade/metalfoam,
-/obj/item/weapon/grenade/chem_grenade/metalfoam,
-/obj/machinery/light/no_nightshift,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/eng_storage)
-"KW" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/bridge)
-"La" = (
-/obj/item/modular_computer/console/preset/ert{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/bridge)
-"Lg" = (
-/obj/structure/table/rack/steel,
-/obj/item/taperoll/engineering{
-	pixel_x = -6;
-	pixel_y = -6
-	},
-/obj/item/taperoll/engineering{
-	pixel_x = -2;
-	pixel_y = -2
-	},
-/obj/item/taperoll/engineering{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/item/taperoll/engineering{
-	pixel_x = 6;
-	pixel_y = 6
-	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/eng_storage)
-"Lh" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
+"XN" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/med)
-"Lk" = (
-/obj/structure/table/rack/steel,
-/obj/item/weapon/material/knife/tacknife/combatknife{
-	pixel_x = -7
-	},
-/obj/item/weapon/material/knife/tacknife/combatknife{
-	pixel_x = -4
-	},
-/obj/item/weapon/material/knife/tacknife/combatknife{
-	pixel_x = -1
-	},
-/obj/item/weapon/material/knife/tacknife/combatknife{
-	pixel_x = 2
-	},
-/obj/item/weapon/material/knife/tacknife/combatknife{
-	pixel_x = 5
-	},
-/obj/item/weapon/material/knife/tacknife/combatknife{
-	pixel_x = 8
-	},
-/obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/hallways)
-"Lm" = (
-/obj/machinery/ntnet_relay,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/atmos)
-"Lq" = (
-/obj/structure/table/rack/steel,
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/item/weapon/gun/energy/locked/frontier/holdout/unlocked{
-	pixel_y = 6
-	},
-/obj/item/weapon/gun/energy/locked/frontier/holdout/unlocked{
-	pixel_y = 4
-	},
-/obj/item/weapon/gun/energy/locked/frontier/holdout/unlocked{
-	pixel_y = 2
-	},
-/obj/item/weapon/gun/energy/locked/frontier/holdout/unlocked,
-/obj/item/weapon/gun/energy/locked/frontier/holdout/unlocked{
-	pixel_y = -2
-	},
-/obj/item/weapon/gun/energy/locked/frontier/holdout/unlocked{
-	pixel_y = -4
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/armoury_st)
-"LA" = (
-/obj/structure/table/rack/steel,
-/obj/item/ammo_magazine/ammo_box/b12g/pellet,
-/obj/item/ammo_magazine/ammo_box/b12g/pellet,
-/obj/item/ammo_magazine/ammo_box/b12g,
-/obj/item/ammo_magazine/ammo_box/b12g,
-/obj/item/ammo_magazine/ammo_box/b12g/emp,
-/obj/item/ammo_magazine/ammo_box/b12g/flash,
-/obj/item/ammo_magazine/ammo_box/b12g/beanbag,
-/obj/item/ammo_magazine/ammo_box/b12g/beanbag,
-/obj/item/ammo_magazine/ammo_box/b12g/stunshell,
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/item/weapon/gun/projectile/shotgun/pump/combat{
-	pixel_y = 3
-	},
-/obj/item/weapon/gun/projectile/shotgun/pump/combat{
-	pixel_y = -3
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/armoury_st)
-"LB" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/machinery/door/firedoor/multi_tile{
+	dir = 1
+	},
+/obj/machinery/door/airlock/multi_tile/glass{
+	dir = 1;
+	req_one_access = list(103)
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/med)
+"XQ" = (
+/obj/structure/table/steel_reinforced,
+/obj/machinery/chemical_dispenser/ert,
+/obj/item/weapon/reagent_containers/glass/beaker/large,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/med)
+"XR" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/hallways_aft)
+"XS" = (
 /obj/structure/cable/yellow{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/white,
-/area/ship/ert/med_surg)
-"LC" = (
-/obj/structure/table/rack/steel,
-/obj/machinery/light/no_nightshift{
-	dir = 1
-	},
-/obj/machinery/firealarm/alarms_hidden{
+/obj/machinery/alarm/alarms_hidden{
 	pixel_y = 26
 	},
-/obj/item/weapon/gun/energy/laser{
-	pixel_y = 6
-	},
-/obj/item/weapon/gun/energy/laser{
-	pixel_y = 4
-	},
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/item/weapon/gun/energy/laser{
-	pixel_y = 2
-	},
-/obj/item/weapon/gun/energy/laser,
-/obj/item/weapon/gun/energy/laser{
-	pixel_y = -2
-	},
-/obj/item/weapon/gun/energy/laser{
-	pixel_y = -4
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/armoury_st)
-"LH" = (
-/obj/machinery/shield_gen/external,
-/obj/effect/floor_decal/corner/white,
-/obj/effect/floor_decal/industrial/outline/blue,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/eng_storage)
-"LJ" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/ship/ert/med_surg)
-"LM" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/wall/rshull,
-/area/ship/ert/med)
-"LR" = (
-/obj/machinery/door/airlock/external,
-/obj/effect/map_helper/airlock/door/ext_door,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/dock_port)
-"LV" = (
-/obj/structure/table/steel_reinforced,
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/machinery/button/remote/blast_door{
-	description_fluff = "\\(OOC) DO NOT TOUCH THIS BUTTON WITHOUT THE EXPLICIT PERMISSION OF AN ADMINISTRATOR.";
-	dir = 1;
-	id = "NRV_DELTA";
-	name = "DELTA ACCESS CONTROL";
-	req_one_access = list(108)
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/armoury_dl)
-"LX" = (
-/obj/structure/hull_corner/long_horiz{
-	dir = 6
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/ship/ert/hallways_aft)
-"LZ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/white,
-/area/ship/ert/med_surg)
-"Mb" = (
-/obj/machinery/computer/operating{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/ship/ert/med_surg)
-"Md" = (
-/obj/structure/table/rack/steel,
-/obj/item/weapon/gun/energy/taser{
-	pixel_y = 3
-	},
-/obj/item/weapon/gun/energy/taser{
-	pixel_y = 1
-	},
-/obj/item/weapon/gun/energy/taser{
-	pixel_y = -1
-	},
-/obj/item/weapon/gun/energy/taser{
-	pixel_y = -3
-	},
-/obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/armoury_st)
-"Me" = (
-/obj/structure/table/rack/steel,
-/obj/item/ammo_magazine/ammo_box/b12g/pellet,
-/obj/item/ammo_magazine/ammo_box/b12g/pellet,
-/obj/item/ammo_magazine/ammo_box/b12g,
-/obj/item/ammo_magazine/ammo_box/b12g,
-/obj/item/ammo_magazine/ammo_box/b12g/emp,
-/obj/item/ammo_magazine/ammo_box/b12g/flash,
-/obj/item/ammo_magazine/ammo_box/b12g/beanbag,
-/obj/item/ammo_magazine/ammo_box/b12g/beanbag,
-/obj/item/ammo_magazine/ammo_box/b12g/stunshell,
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/item/weapon/gun/projectile/automatic/as24{
-	pixel_y = 3
-	},
-/obj/item/weapon/gun/projectile/automatic/as24{
-	pixel_y = -3
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/armoury_dl)
-"Mm" = (
-/turf/simulated/wall/rshull,
-/area/ship/ert/teleporter)
-"Ms" = (
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/teleporter)
-"Mt" = (
-/obj/structure/table/rack/steel,
-/obj/item/weapon/gun/energy/netgun{
-	pixel_y = -4
-	},
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/item/weapon/gun/energy/sniperrifle{
-	battery_lock = 0;
-	pixel_y = 6
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/armoury_st)
-"Mv" = (
-/obj/item/device/perfect_tele_beacon/stationary{
-	tele_name = "NRV Von Braun Teleporter Room";
-	tele_network = "centcom"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/teleporter)
-"Mx" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/white,
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/hangar)
-"My" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/power/apc/hyper{
-	alarms_hidden = 1;
-	dir = 4;
-	name = "VB APC - East";
-	pixel_x = 24
-	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/engineering)
-"MC" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 12;
-	pixel_y = 8
-	},
-/obj/structure/medical_stand,
-/turf/simulated/floor/tiled/white,
-/area/ship/ert/med_surg)
-"MD" = (
-/obj/effect/floor_decal/corner/red{
-	dir = 1
-	},
-/obj/structure/reagent_dispensers/watertank/high,
-/obj/effect/floor_decal/industrial/outline/blue,
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/hangar)
-"MK" = (
-/obj/structure/sign/nosmoking_1,
-/turf/simulated/wall/rshull,
-/area/ship/ert/engine)
-"ML" = (
-/obj/machinery/door/blast/regular/open{
-	id = "ERT_Shuttle_Rear";
-	name = "Boarding Hatch"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/shuttle/ert_ship_boat)
-"MQ" = (
+"XU" = (
 /obj/effect/floor_decal/corner/white{
-	dir = 6
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/eng_storage)
-"MT" = (
-/turf/simulated/floor/tiled/techmaint,
-/area/shuttle/ert_ship_boat)
-"MU" = (
-/obj/structure/window/reinforced,
-/turf/simulated/floor/tiled/techmaint,
-/area/shuttle/ert_ship_boat)
-"MZ" = (
-/turf/simulated/wall/rshull,
-/area/ship/ert/med_surg)
-"Na" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/glass{
-	req_one_access = list(103)
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/dock_port)
-"Nb" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/engineering)
-"Nd" = (
-/obj/effect/floor_decal/corner/white{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/med)
-"Nf" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/hangar)
-"Ng" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/obj/machinery/button/remote/blast_door{
-	id = "ERT_Shuttle_Fore";
-	name = "ERT Deployment Access";
-	pixel_y = 24;
-	req_access = list(103)
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/shuttle/ert_ship_boat)
-"Nk" = (
-/obj/machinery/power/pointdefense{
-	id_tag = "vonbraun_pd"
-	},
-/obj/machinery/light/no_nightshift{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/ship/ert/engine)
-"Np" = (
-/obj/machinery/light/no_nightshift{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/engine)
-"Nq" = (
-/obj/structure/cable/yellow{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/power/apc/hyper{
-	alarms_hidden = 1;
-	dir = 8;
-	name = "VB APC - West";
-	pixel_x = -24
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/gunnery)
-"Nu" = (
-/obj/structure/hull_corner/long_horiz{
-	dir = 6
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/ship/ert/engine)
-"Nz" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/obj/machinery/portable_atmospherics/powered/scrubber,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/hangar)
-"NH" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/catwalk_plated/techfloor,
-/turf/simulated/floor/plating,
-/area/ship/ert/engine)
-"NI" = (
-/obj/structure/table/rack,
-/obj/item/weapon/storage/secure/briefcase/nsfw_pack_hybrid,
-/obj/item/weapon/storage/belt/explorer/pathfinder{
-	name = "ERT belt"
-	},
-/turf/simulated/floor/wood,
-/area/ship/ert/commander)
-"NJ" = (
-/obj/machinery/optable,
-/turf/simulated/floor/tiled/white,
-/area/ship/ert/med_surg)
-"NP" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/binary/pump/fuel/on,
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/engine)
-"NR" = (
-/obj/machinery/light/no_nightshift,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/engineering)
-"NU" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/armoury_dl)
-"NY" = (
-/obj/machinery/door/airlock/glass_command{
-	req_one_access = list(103)
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/bridge)
-"NZ" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/engineering)
-"Oa" = (
-/obj/machinery/door/airlock/glass_engineering{
-	name = "Engineering";
-	req_access = list(103)
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/engineering)
-"Of" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/engine)
-"Og" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/floor_decal/corner/yellow{
-	dir = 9
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/hallways_aft)
-"Oh" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/glass{
-	req_one_access = list(103)
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/hallways_aft)
-"Oi" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/bridge)
-"Ok" = (
-/obj/effect/floor_decal/industrial/warning,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/embedded_controller/radio/simple_docking_controller{
-	id_tag = "ert_boarding_shuttle_dock";
-	pixel_y = 22
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/hangar)
-"Om" = (
-/obj/machinery/power/pointdefense{
-	id_tag = "vonbraun_pd"
-	},
-/obj/structure/cable/yellow{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/ship/ert/gunnery)
-"On" = (
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/armoury_dl)
-"Oq" = (
-/obj/machinery/light/no_nightshift{
-	dir = 8
+	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/hallways_aft)
-"Ox" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/hangar)
+"XW" = (
+/turf/simulated/wall/rshull,
 /area/ship/ert/engineering)
-"Oy" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+"XX" = (
+/turf/simulated/wall/rshull,
+/area/ship/ert/brig)
+"XZ" = (
+/obj/machinery/door/airlock/external,
+/obj/machinery/airlock_sensor/airlock_exterior{
+	pixel_x = 24;
+	pixel_y = -11
 	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
-/obj/effect/catwalk_plated/techmaint,
-/turf/simulated/floor/plating,
-/area/ship/ert/bridge)
-"OA" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/med)
-"OE" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
-/obj/effect/catwalk_plated/techmaint,
-/turf/simulated/floor/plating,
-/area/ship/ert/bridge)
-"OF" = (
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/bridge)
-"OH" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/map_helper/airlock/door/ext_door,
+/obj/effect/map_helper/airlock/sensor/ext_sensor,
 /turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/engineering)
-"OM" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/obj/machinery/light/no_nightshift{
-	dir = 8
-	},
-/obj/machinery/porta_turret/stationary/CIWS,
-/turf/simulated/floor/reinforced/airless,
-/area/ship/ert/gunnery)
-"ON" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/gunnery)
-"OO" = (
-/obj/structure/table/rack/steel,
-/obj/item/weapon/gun/energy/sniperrifle{
-	battery_lock = 0;
-	pixel_y = -3
-	},
-/obj/item/weapon/gun/energy/sniperrifle{
-	battery_lock = 0;
-	pixel_y = 3
-	},
-/obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/armoury_dl)
-"OR" = (
-/obj/effect/floor_decal/corner/red{
-	dir = 6
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/hallways)
-"OS" = (
-/obj/structure/bed/chair/bay/comfy/captain{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/bridge)
-"OT" = (
-/obj/machinery/computer/ship/helm{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/bridge)
-"OU" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/landmark{
-	name = "Commando"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/barracks)
-"OW" = (
+/area/ship/ert/dock_star)
+"Yd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -7634,20 +9946,220 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/bridge)
-"OX" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+"Ye" = (
+/turf/simulated/wall/rshull,
+/area/ship/ert/dock_port)
+"Yf" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/machinery/meter,
+/obj/machinery/power/apc/hyper{
+	alarms_hidden = 1;
+	name = "VB APC - South";
+	pixel_y = -24
+	},
+/obj/structure/cable/yellow,
+/obj/machinery/light/small{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/bridge)
-"OY" = (
-/obj/effect/shuttle_landmark/premade/ert_ship_star,
-/turf/space,
-/area/space)
-"OZ" = (
+/area/ship/ert/dock_star)
+"Yk" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/barracks)
+"Ys" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/hallways_aft)
+"Yt" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/teleporter)
+"Yu" = (
+/obj/effect/floor_decal/corner/blue{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/hallways)
+"Yv" = (
+/obj/machinery/power/port_gen/pacman/super/potato,
+/obj/structure/cable/green,
+/obj/machinery/light/no_nightshift,
+/obj/effect/decal/cleanable/greenglow,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/engineering)
+"Yx" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/teleporter)
+"YC" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/med)
+"YH" = (
+/obj/machinery/vending/coffee{
+	dir = 1;
+	prices = list()
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/hallways_aft)
+"YK" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled/white,
+/area/ship/ert/med_surg)
+"YN" = (
+/obj/machinery/door/airlock/centcom{
+	name = "Reactor Access";
+	req_access = list(103)
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/blast/regular/open{
+	dir = 4;
+	id = "VB_Rear_Blast";
+	name = "Blast Shield"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/engineering)
+"YO" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/white,
+/area/ship/ert/med_surg)
+"YP" = (
+/obj/machinery/atmospherics/portables_connector/fuel{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/industrial/outline/red,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/engine)
+"YR" = (
+/obj/machinery/shipsensors,
+/turf/simulated/floor/reinforced/airless,
+/area/ship/ert/engineering)
+"YS" = (
+/obj/machinery/sleep_console,
+/turf/simulated/floor/tiled/white,
+/area/ship/ert/med_surg)
+"YU" = (
+/obj/structure/table/rack,
+/obj/item/weapon/storage/backpack/ert/commander,
+/obj/item/clothing/suit/space/void/responseteam/command,
+/obj/item/clothing/head/helmet/ert/command,
+/obj/item/clothing/suit/armor/vest/ert/command,
+/turf/simulated/floor/wood,
+/area/ship/ert/commander)
+"YW" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/armoury_dl)
+"YZ" = (
+/obj/structure/closet/crate/freezer,
+/obj/item/weapon/reagent_containers/blood/OMinus,
+/obj/item/weapon/reagent_containers/blood/OMinus,
+/obj/item/weapon/reagent_containers/blood/OMinus,
+/obj/item/weapon/reagent_containers/blood/OMinus,
+/obj/item/weapon/reagent_containers/blood/OMinus,
+/obj/item/weapon/reagent_containers/blood/OMinus,
+/obj/item/weapon/reagent_containers/blood/OMinus,
+/obj/item/weapon/reagent_containers/blood/OMinus,
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_y = -23
+	},
+/obj/effect/floor_decal/industrial/outline,
+/turf/simulated/floor/tiled/white,
+/area/ship/ert/med_surg)
+"Za" = (
+/obj/structure/bed/chair/bay/shuttle{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/ert_ship_boat)
+"Zb" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/engine)
+"Zc" = (
 /obj/structure/table/standard,
 /obj/item/weapon/soap{
 	pixel_x = -6;
@@ -7691,1374 +10203,46 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/med)
-"Pc" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
+"Zf" = (
+/obj/machinery/flasher,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/bridge)
-"Pe" = (
-/obj/machinery/button/remote/blast_door{
-	dir = 1;
-	id = "ERT_Shuttle_Rear";
-	name = "ERT Shuttle Access";
-	pixel_y = -25;
-	req_access = list(103)
-	},
-/obj/machinery/door/blast/regular/open{
-	id = "ERT_Shuttle_Rear";
-	name = "Boarding Hatch"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/shuttle/ert_ship_boat)
-"Pl" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/machinery/door/blast/regular{
-	closed_layer = 4;
-	dir = 4;
-	id = "NRV_DELTA";
-	layer = 4
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/armoury_dl)
-"Pn" = (
-/obj/item/modular_computer/console/preset/engineering{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/bridge)
-"Pq" = (
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/med)
-"Pw" = (
-/obj/machinery/shipsensors{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
 	},
-/turf/simulated/floor/reinforced/airless,
-/area/ship/ert/atmos)
-"Px" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/wall/shull,
-/area/ship/ert/mech_bay)
-"Py" = (
-/obj/machinery/light/no_nightshift{
-	dir = 1
-	},
-/obj/machinery/porta_turret/stationary/CIWS,
-/turf/simulated/floor/reinforced/airless,
-/area/ship/ert/med)
-"PA" = (
-/obj/machinery/recharge_station,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/med)
-"PC" = (
-/obj/machinery/door/blast/regular{
-	dir = 4;
-	id = "NRV_DELTA"
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/armoury_dl)
-"PD" = (
-/obj/structure/sign/department/medbay{
-	name = "MEDICAL OUTFITTING & SUPPLIES"
-	},
-/turf/simulated/wall/shull,
-/area/ship/ert/med)
-"PE" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/effect/catwalk_plated/techmaint,
-/turf/simulated/floor/plating,
-/area/ship/ert/eng_storage)
-"PG" = (
-/obj/machinery/alarm/alarms_hidden{
-	dir = 1;
-	pixel_y = -26
-	},
-/turf/simulated/floor/tiled/white,
-/area/ship/ert/med_surg)
-"PH" = (
-/obj/machinery/power/smes/buildable/point_of_interest,
-/obj/structure/cable/yellow,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/engineering)
-"PO" = (
-/turf/simulated/floor/reinforced/airless,
-/area/ship/ert/gunnery)
-"PP" = (
-/obj/machinery/porta_turret/stationary/CIWS,
-/turf/simulated/floor/reinforced/airless,
-/area/ship/ert/engineering)
-"PS" = (
-/obj/machinery/shield_capacitor,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/ship/ert/brig)
+"Zi" = (
+/obj/machinery/shieldwallgen,
 /obj/effect/floor_decal/industrial/outline/blue,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/eng_storage)
-"PX" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/teleporter)
-"Qc" = (
-/obj/machinery/power/apc/hyper{
-	alarms_hidden = 1;
-	dir = 8;
-	name = "VB APC - West";
-	pixel_x = -24
-	},
-/obj/structure/cable/yellow{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/light/no_nightshift{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/hangar)
-"Qh" = (
-/obj/machinery/light/no_nightshift{
-	dir = 1
-	},
-/obj/machinery/alarm/alarms_hidden{
-	pixel_y = 26
-	},
-/turf/simulated/floor/wood,
-/area/ship/ert/commander)
-"Ql" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/machinery/alarm/alarms_hidden{
-	pixel_y = 26
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/dock_star)
-"Qz" = (
-/obj/item/weapon/circuitboard/aiupload,
-/obj/item/weapon/circuitboard/borgupload,
-/obj/item/weapon/circuitboard/smes,
-/obj/item/weapon/aiModule/nanotrasen,
-/obj/item/weapon/aiModule/reset,
-/obj/item/weapon/aiModule/freeformcore,
-/obj/item/weapon/aiModule/protectStation,
-/obj/item/weapon/aiModule/quarantine,
-/obj/item/weapon/aiModule/paladin,
-/obj/item/weapon/aiModule/robocop,
-/obj/item/weapon/aiModule/safeguard,
-/obj/structure/table/steel_reinforced,
-/obj/item/weapon/smes_coil,
-/obj/item/weapon/smes_coil,
-/obj/item/device/t_scanner/advanced{
-	pixel_x = -3
-	},
-/obj/item/device/t_scanner/advanced{
-	pixel_x = 3
-	},
-/obj/machinery/power/apc/hyper{
-	alarms_hidden = 1;
-	name = "VB APC - South";
-	pixel_y = -24
-	},
-/obj/structure/cable/yellow,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/eng_storage)
-"QE" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/turf/simulated/floor/reinforced,
-/area/ship/ert/hangar)
-"QM" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/armoury_dl)
-"QP" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/shuttle/ert_ship_boat)
-"QR" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/techmaint,
-/area/shuttle/ert_ship_boat)
-"QS" = (
-/obj/structure/bed/chair/bay/shuttle{
-	dir = 4
-	},
-/obj/machinery/button/remote/blast_door{
-	dir = 8;
-	id = "ERT_Blast_Windows";
-	name = "Emergency Blast Shields";
-	pixel_x = 55;
-	req_one_access = list(101)
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/shuttle/ert_ship_boat)
-"QT" = (
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/med)
-"QV" = (
-/obj/structure/hull_corner{
-	dir = 1
-	},
-/turf/simulated/shuttle/plating/airless/carry,
-/area/shuttle/ert_ship_boat)
-"QX" = (
-/obj/structure/window/reinforced,
-/obj/machinery/computer/shuttle_control/explore/ert_ship_boat{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/shuttle/ert_ship_boat)
-"QY" = (
-/obj/structure/table/rack,
-/obj/item/weapon/rig/ert,
-/obj/item/weapon/cell/slime,
-/turf/simulated/floor/wood,
-/area/ship/ert/commander)
-"QZ" = (
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/engine)
-"Rc" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/obj/effect/shuttle_landmark/shuttle_initializer/ert_ship_boat,
-/turf/simulated/floor/tiled/techmaint,
-/area/shuttle/ert_ship_boat)
-"Rd" = (
-/obj/machinery/light/no_nightshift{
-	dir = 1
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/ship/ert/engineering)
-"Rh" = (
-/obj/machinery/door/airlock/glass_external,
-/obj/effect/map_helper/airlock/door/int_door,
-/obj/machinery/door/firedoor/multi_tile,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/dock_star)
-"Rt" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/bridge)
-"Rv" = (
-/obj/machinery/door/firedoor/multi_tile{
-	dir = 1
-	},
-/obj/machinery/door/airlock/glass_medical{
-	name = "Medical Bay";
-	req_access = list(103)
-	},
-/turf/simulated/floor/tiled/white,
-/area/ship/ert/med_surg)
-"Rw" = (
-/obj/machinery/vending/security,
-/turf/simulated/floor/tiled/techfloor,
+"Zo" = (
+/turf/simulated/wall/rshull,
 /area/ship/ert/barracks)
-"Rz" = (
-/obj/machinery/door/airlock/glass_security{
-	req_one_access = list(103)
-	},
-/obj/machinery/door/blast/regular{
-	id = "NRV_DELTA"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/multi_tile{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/armoury_dl)
-"RB" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/engine)
-"RC" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/fuel{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/engine)
-"RO" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 9
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/engine)
-"RQ" = (
-/obj/machinery/door/airlock/glass_engineering{
-	name = "Engineering";
-	req_access = list(103)
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor/border_only,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/engineering)
-"RS" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/highsecurity{
-	name = "Teleporter Chamber";
-	req_one_access = list(103)
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/teleporter)
-"Sc" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/engineering)
-"Sh" = (
-/obj/machinery/door/airlock/glass_medical{
-	name = "Medical Bay";
-	req_access = list(103)
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/med_surg)
-"Sj" = (
-/obj/machinery/light_switch{
-	dir = 4;
-	pixel_x = -23
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/bridge)
-"Sl" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/structure/railing/grey,
-/obj/structure/table/steel_reinforced,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/bridge)
-"Sp" = (
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/catwalk_plated/techmaint,
-/turf/simulated/floor/plating,
-/area/ship/ert/med)
-"Sr" = (
-/obj/machinery/light/no_nightshift,
-/turf/simulated/floor/reinforced/airless,
-/area/ship/ert/barracks)
-"St" = (
-/obj/structure/table/rack/steel,
-/obj/item/device/flash{
-	pixel_x = -4;
-	pixel_y = -4
-	},
-/obj/item/device/flash{
-	pixel_x = -2;
-	pixel_y = -2
-	},
-/obj/item/device/flash,
-/obj/item/device/flash{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/item/device/flash{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/item/device/flash{
-	pixel_x = 6;
-	pixel_y = 6
-	},
-/obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/hallways)
-"Sx" = (
-/obj/structure/table/rack/steel,
-/obj/item/ammo_magazine/m9mmp90{
-	pixel_x = 12
-	},
-/obj/item/ammo_magazine/m9mmp90{
-	pixel_x = 10
-	},
-/obj/item/ammo_magazine/m9mmp90{
-	pixel_x = 8
-	},
-/obj/item/ammo_magazine/m9mmp90{
-	pixel_x = 6
-	},
-/obj/item/ammo_magazine/m9mmp90{
-	pixel_x = 4
-	},
-/obj/item/ammo_magazine/m9mmp90{
-	pixel_x = 2
-	},
-/obj/item/ammo_magazine/m9mmp90,
-/obj/item/ammo_magazine/m9mmp90{
-	pixel_x = -2
-	},
-/obj/item/ammo_magazine/m9mmp90{
-	pixel_x = -4
-	},
-/obj/item/ammo_magazine/m9mmp90{
-	pixel_x = -6
-	},
-/obj/item/ammo_magazine/m9mmp90{
-	pixel_x = -8
-	},
-/obj/item/ammo_magazine/m9mmp90{
-	pixel_x = -10
-	},
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/item/weapon/gun/projectile/automatic/p90{
-	pixel_y = -6
-	},
-/obj/item/weapon/gun/projectile/automatic/p90{
-	pixel_y = -2
-	},
-/obj/item/weapon/gun/projectile/automatic/p90{
-	pixel_y = 2
-	},
-/obj/item/weapon/gun/projectile/automatic/p90{
-	pixel_y = 6
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/armoury_dl)
-"Sy" = (
-/obj/structure/table/rack/steel,
-/obj/item/weapon/gun/projectile/automatic/l6_saw{
-	pixel_y = 3
-	},
-/obj/item/weapon/gun/projectile/automatic/l6_saw{
-	pixel_y = -3
-	},
-/obj/item/ammo_magazine/m545saw{
-	pixel_x = 6
-	},
-/obj/item/ammo_magazine/m545saw{
-	pixel_x = 2
-	},
-/obj/item/ammo_magazine/m545saw{
-	pixel_x = -2
-	},
-/obj/item/ammo_magazine/m545saw{
-	pixel_x = -6
-	},
-/obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/armoury_dl)
-"Sz" = (
+"Zv" = (
 /turf/simulated/wall/rshull,
 /area/ship/ert/dock_star)
-"SA" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/power/apc/hyper{
-	alarms_hidden = 1;
-	dir = 4;
-	name = "VB APC - East";
-	pixel_x = 24
-	},
-/obj/structure/cable/yellow{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/yellow{
-	d2 = 4;
-	dir = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/hallways_aft)
-"SB" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/white,
-/area/ship/ert/med_surg)
-"SD" = (
-/obj/structure/table/rack,
-/obj/item/ammo_magazine/m44{
-	pixel_x = -3
-	},
-/obj/item/ammo_magazine/m44{
-	pixel_x = 3
-	},
-/obj/item/weapon/gun/projectile/deagle,
-/turf/simulated/floor/wood,
-/area/ship/ert/commander)
-"SE" = (
-/obj/machinery/light/no_nightshift{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/engine)
-"SF" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/armoury_st)
-"SG" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/eng_storage)
-"SI" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/structure/table/steel_reinforced,
-/obj/item/weapon/rcd_ammo/large{
-	pixel_x = -8;
-	pixel_y = -8
-	},
-/obj/item/weapon/rcd_ammo/large{
-	pixel_x = -6;
-	pixel_y = -6
-	},
-/obj/item/weapon/rcd_ammo/large{
-	pixel_x = -4;
-	pixel_y = -4
-	},
-/obj/item/weapon/rcd_ammo/large{
-	pixel_x = -2;
-	pixel_y = -2
-	},
-/obj/item/weapon/rcd_ammo/large,
-/obj/item/weapon/rcd_ammo/large{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/item/weapon/rcd_ammo/large{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/item/weapon/rcd_ammo/large{
-	pixel_x = 6;
-	pixel_y = 6
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/eng_storage)
-"SJ" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 5
-	},
-/turf/simulated/wall/rshull,
-/area/ship/ert/dock_star)
-"SN" = (
-/obj/effect/map_helper/airlock/sensor/ext_sensor,
-/obj/machinery/airlock_sensor/airlock_exterior{
-	dir = 4;
-	pixel_x = 24;
-	pixel_y = 24
-	},
-/turf/simulated/floor/airless,
-/area/ship/ert/gunnery)
-"SV" = (
-/obj/structure/table/rack/steel,
-/obj/item/weapon/reagent_containers/hypospray{
-	pixel_x = 6
-	},
-/obj/item/weapon/reagent_containers/hypospray{
-	pixel_x = 3
-	},
-/obj/item/weapon/reagent_containers/hypospray,
-/obj/item/weapon/reagent_containers/hypospray{
-	pixel_x = -3
-	},
-/obj/machinery/alarm/alarms_hidden{
-	pixel_y = 26
-	},
-/obj/effect/floor_decal/industrial/outline,
-/obj/item/weapon/reagent_containers/hypospray{
-	pixel_x = -6
-	},
-/obj/item/weapon/reagent_containers/hypospray{
-	pixel_x = -9
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/med)
-"SZ" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/shuttle/ert_ship_boat)
-"Tl" = (
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/hangar)
-"Tx" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/fuel{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/engine)
-"TB" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/engineering)
-"TD" = (
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/wall/rshull,
-/area/ship/ert/gunnery)
-"TF" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/white,
-/area/ship/ert/med_surg)
-"TG" = (
-/obj/machinery/airlock_sensor{
-	dir = 8;
-	pixel_x = 22;
-	pixel_y = -24
-	},
-/obj/effect/map_helper/airlock/sensor/int_sensor,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/gunnery)
-"TI" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/armoury_dl)
-"TM" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/hallways_aft)
-"TR" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/machinery/door/firedoor/border_only,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/door/blast/regular{
-	closed_layer = 4;
-	id = "NRV_DELTA";
-	layer = 4
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/armoury_dl)
-"TU" = (
-/turf/simulated/floor/reinforced/airless,
-/area/ship/ert/med)
-"TZ" = (
-/obj/effect/floor_decal/industrial/warning,
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/teleporter)
-"Ue" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/mech_bay)
-"Ul" = (
-/obj/machinery/firealarm/alarms_hidden{
-	dir = 1;
-	pixel_y = -26
-	},
-/obj/item/modular_computer/console/preset/medical{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/bridge)
-"Un" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/glass{
-	req_one_access = list(103)
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/dock_star)
-"Ut" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/machinery/alarm/alarms_hidden{
-	pixel_y = 26
-	},
-/obj/machinery/porta_turret/industrial/teleport_defense,
-/obj/effect/floor_decal/industrial/outline/red,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/teleporter)
-"UD" = (
-/obj/machinery/disperser/middle{
-	dir = 4
-	},
-/turf/simulated/floor/airless,
-/area/ship/ert/gunnery)
-"UH" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/armoury_dl)
-"UI" = (
-/obj/structure/hull_corner{
-	dir = 1
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/ship/ert/med)
-"UJ" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/teleporter)
-"UK" = (
-/obj/machinery/power/pointdefense{
-	id_tag = "vonbraun_pd"
-	},
-/obj/structure/cable/yellow,
-/turf/simulated/floor/reinforced/airless,
-/area/ship/ert/engine)
-"UN" = (
-/obj/machinery/power/pointdefense{
-	id_tag = "vonbraun_pd"
-	},
-/obj/structure/cable/yellow{
-	d2 = 4;
-	dir = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/ship/ert/med_surg)
-"UT" = (
-/obj/machinery/door/airlock/glass_security{
-	req_one_access = list(103)
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/blast/regular{
-	closed_layer = 4;
-	id = "NRV_DELTA";
-	layer = 4
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/armoury_dl)
-"UU" = (
-/obj/machinery/shieldwallgen{
-	anchored = 1;
-	name = "secured shield generator";
-	req_access = list(103);
-	state = 1
-	},
-/obj/structure/window/reinforced,
-/obj/effect/floor_decal/industrial/warning,
-/obj/structure/cable/yellow,
-/obj/effect/floor_decal/industrial/outline/blue,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/teleporter)
-"UY" = (
-/obj/structure/table/steel_reinforced,
-/obj/machinery/chemical_dispenser/full,
-/obj/item/weapon/reagent_containers/glass/beaker/large,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/med)
-"Vg" = (
-/obj/structure/table/steel_reinforced,
-/obj/machinery/recharger,
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/armoury_dl)
-"Vm" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/machinery/light_switch{
-	pixel_y = 23
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/teleporter)
-"Vn" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/hangar)
-"Vq" = (
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/gunnery)
-"Vx" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 9
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/engine)
-"VC" = (
-/obj/machinery/power/port_gen/pacman/super/potato,
-/obj/structure/cable/green,
-/obj/machinery/light/no_nightshift,
-/obj/effect/decal/cleanable/greenglow,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/engineering)
-"VH" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/wall/rshull,
-/area/ship/ert/mech_bay)
-"VJ" = (
-/obj/machinery/door/firedoor/multi_tile{
-	dir = 1
-	},
-/obj/machinery/door/airlock/glass_medical{
-	name = "Medical Bay";
-	req_access = list(103)
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/med)
-"VN" = (
-/obj/machinery/disperser/front{
-	dir = 4
-	},
-/turf/simulated/floor/airless,
-/area/ship/ert/gunnery)
-"VO" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/hallways)
-"VP" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/hallways)
-"VQ" = (
-/obj/structure/table/rack/steel,
-/obj/effect/floor_decal/corner/red,
-/obj/item/device/radio/off{
-	pixel_x = -4;
-	pixel_y = -4
-	},
-/obj/item/device/radio/off{
-	pixel_x = -2;
-	pixel_y = -2
-	},
-/obj/item/device/radio/off,
-/obj/item/device/radio/off{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/item/device/radio/off{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/item/device/radio/off{
-	pixel_x = 6;
-	pixel_y = 6
-	},
-/obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/hallways)
-"Wa" = (
-/obj/structure/closet/walllocker/emerglocker{
-	pixel_y = 32
-	},
-/obj/structure/bed/pod,
-/obj/item/weapon/bedsheet/blue,
-/obj/structure/curtain/open/bed,
-/turf/simulated/floor/wood,
-/area/ship/ert/commander)
-"Wj" = (
-/obj/machinery/light/no_nightshift{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/teleporter)
-"Wl" = (
-/obj/structure/table/steel_reinforced,
-/obj/machinery/light/no_nightshift{
-	dir = 1
-	},
-/obj/item/device/defib_kit/compact/combat/loaded{
-	pixel_y = -3
-	},
-/obj/item/device/defib_kit/compact/combat/loaded{
-	pixel_y = 3
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/med)
-"Wo" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/barracks)
-"Wq" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/floor_decal/corner/blue,
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/bridge)
-"Wu" = (
-/obj/machinery/door/airlock/glass_security{
-	req_one_access = list(103)
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/blast/regular{
-	closed_layer = 4;
-	id = "NRV_DELTA";
-	layer = 4
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/armoury_dl)
-"Wv" = (
-/obj/effect/shuttle_landmark/premade/ert_ship_near_star,
-/turf/space,
-/area/space)
-"WA" = (
-/obj/effect/floor_decal/corner/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/hangar)
-"WC" = (
-/turf/simulated/floor/reinforced,
-/area/ship/ert/hangar)
-"WE" = (
-/obj/effect/floor_decal/corner/red{
-	dir = 9
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/hangar)
-"WF" = (
-/obj/machinery/power/pointdefense{
-	id_tag = "vonbraun_pd"
-	},
-/obj/structure/cable/yellow{
-	d2 = 4;
-	dir = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/ship/ert/med)
-"WH" = (
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/barracks)
-"WJ" = (
-/obj/structure/bed/chair/bay/shuttle{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/shuttle/ert_ship_boat)
-"WK" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/light_switch{
-	dir = 8;
-	pixel_x = 23
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/dock_star)
-"WO" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/engine)
-"WR" = (
-/obj/structure/filingcabinet/filingcabinet,
-/turf/simulated/floor/wood,
-/area/ship/ert/commander)
-"WS" = (
-/obj/machinery/computer/ship/engines{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/engineering)
-"WV" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/barracks)
-"WX" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/effect/landmark{
-	name = "Commando"
-	},
-/obj/effect/catwalk_plated/techmaint,
-/turf/simulated/floor/plating,
-/area/ship/ert/barracks)
-"WZ" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/wall/rshull,
-/area/ship/ert/engine)
-"Xg" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/bed/chair/bay/chair/padded/blue{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/engineering)
-"Xh" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/obj/machinery/door/window/brigdoor/southright,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/hallways_aft)
-"Xo" = (
+"Zw" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/ship/ert/med)
-"Xu" = (
-/obj/structure/cable/yellow,
-/obj/machinery/power/smes/buildable/point_of_interest,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/engineering)
-"Xw" = (
-/obj/machinery/button/remote/blast_door{
-	dir = 1;
-	id = "Von_Braun_Cannon";
-	name = "Cannon Port Access";
-	pixel_y = -24;
-	req_one_access = list(103)
+"Zx" = (
+/obj/effect/floor_decal/corner/white{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/gunnery)
-"Xx" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/teleporter)
-"Xz" = (
-/obj/machinery/shield_capacitor,
-/obj/effect/floor_decal/industrial/outline/blue,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/eng_storage)
-"XB" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/teleporter)
-"XG" = (
-/turf/simulated/wall/rshull,
-/area/ship/ert/eng_storage)
-"XH" = (
-/obj/machinery/alarm/alarms_hidden{
-	dir = 1;
-	pixel_y = -26
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/engine)
-"XM" = (
-/obj/effect/map_helper/airlock/sensor/chamber_sensor,
-/obj/machinery/airlock_sensor{
-	pixel_x = 24
-	},
-/obj/effect/floor_decal/industrial/warning,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/dock_star)
-"XN" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/med)
-"XS" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/firealarm/alarms_hidden{
-	pixel_y = 26
-	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/engineering)
-"XW" = (
-/turf/simulated/wall/rshull,
-/area/ship/ert/engineering)
-"XX" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/teleporter)
-"Yd" = (
-/turf/simulated/wall/rshull,
-/area/ship/ert/armoury_dl)
-"Ye" = (
-/turf/simulated/floor/reinforced/airless,
-/area/ship/ert/barracks)
-"Yf" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/wall/shull,
-/area/ship/ert/eng_storage)
-"Yk" = (
-/obj/structure/cable/yellow{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/power/apc/hyper{
-	alarms_hidden = 1;
-	dir = 4;
-	name = "VB APC - East";
-	pixel_x = 24
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/mech_bay)
-"Yq" = (
+/area/ship/ert/hangar)
+"ZC" = (
 /obj/machinery/power/apc/hyper{
 	alarms_hidden = 1;
 	dir = 4;
@@ -9076,157 +10260,21 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/teleporter)
-"Yr" = (
-/obj/machinery/light/no_nightshift{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/teleporter)
-"Ys" = (
-/obj/structure/window/reinforced,
-/obj/effect/floor_decal/industrial/warning,
-/obj/structure/cable/yellow,
-/obj/machinery/shieldwallgen{
-	anchored = 1;
-	name = "secured shield generator";
-	req_access = list(103);
-	state = 1
-	},
-/obj/effect/floor_decal/industrial/outline/blue,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/teleporter)
-"Yt" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/bed/chair/bay/chair/padded/blue{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/bridge)
-"Yx" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/bridge)
-"YC" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/tiled/white,
-/area/ship/ert/med_surg)
-"YN" = (
-/obj/structure/sign/warning/radioactive{
-	desc = "WARNING: VON BRAUN PTTOS EMIT RADIATION WHILST OPERATIONAL.";
-	name = "\improper RADIOACTIVE GENERATORS BEHIND THESE DOORS";
-	pixel_x = -16
-	},
-/turf/simulated/wall/shull,
-/area/ship/ert/engineering)
-"YO" = (
-/obj/structure/hull_corner{
-	dir = 1
-	},
-/turf/space,
-/area/space)
-"YP" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/fuel{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/engine)
-"YR" = (
-/turf/simulated/floor/reinforced/airless,
-/area/ship/ert/engineering)
-"YU" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/light/no_nightshift{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/bridge)
-"YW" = (
-/obj/structure/shuttle/engine/propulsion{
-	dir = 8
-	},
-/turf/simulated/floor/reinforced,
-/area/shuttle/ert_ship_boat)
-"Zi" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/eng_storage)
-"Zo" = (
-/turf/simulated/wall/rshull,
-/area/ship/ert/barracks)
-"Zv" = (
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/eng_storage)
-"Zx" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/hangar)
-"ZC" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/bed/chair/bay/chair/padded/blue,
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/bridge)
 "ZF" = (
-/obj/item/roller_holder,
-/obj/item/roller/adv,
-/obj/item/roller/adv{
-	pixel_y = 6
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/obj/item/roller/adv{
-	pixel_y = 12
-	},
-/obj/machinery/light/no_nightshift,
-/obj/effect/floor_decal/industrial/outline,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/door/blast/regular/open{
+	dir = 4;
+	id = "braun_blast_shields";
+	name = "Blast Shield"
 	},
 /turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/med)
+/area/ship/ert/eng_storage)
 "ZI" = (
 /obj/machinery/power/terminal{
 	dir = 1
@@ -9237,13 +10285,26 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/engineering)
-"ZL" = (
-/obj/machinery/power/pointdefense{
-	id_tag = "vonbraun_pd"
-	},
+"ZK" = (
+/obj/structure/table/steel_reinforced,
 /obj/structure/cable/yellow{
-	d2 = 2;
-	icon_state = "0-2"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/machinery/button/remote/blast_door{
+	description_fluff = "\\(OOC) DO NOT TOUCH THIS BUTTON WITHOUT THE EXPLICIT PERMISSION OF AN ADMINISTRATOR.";
+	dir = 1;
+	id = "NRV_DELTA";
+	name = "DELTA ACCESS CONTROL";
+	req_one_access = list(108)
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/armoury_dl)
+"ZL" = (
+/obj/structure/hull_corner/long_horiz{
+	dir = 6
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/ship/ert/engine)
@@ -9252,71 +10313,61 @@
 /area/ship/ert/bridge)
 "ZP" = (
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/techmaint,
 /area/ship/ert/bridge)
+"ZQ" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/ship/ert/med_surg)
 "ZT" = (
 /turf/simulated/wall/rshull,
 /area/ship/ert/med)
 "ZU" = (
-/obj/machinery/light/no_nightshift,
-/obj/machinery/firealarm/alarms_hidden{
-	dir = 1;
-	pixel_y = -26
-	},
-/obj/machinery/power/port_gen/pacman/mrs,
-/obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/techfloor,
+/turf/simulated/wall/shull,
 /area/ship/ert/eng_storage)
 "ZW" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/med)
-"ZX" = (
-/obj/machinery/door/airlock/glass_command{
-	req_one_access = list(103)
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/bridge)
-"ZY" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 9
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/structure/cable/yellow{
 	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/hallways)
+/area/ship/ert/eng_storage)
+"ZX" = (
+/obj/item/modular_computer/console/preset/ert{
+	dir = 4
+	},
+/obj/machinery/light/no_nightshift{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/bridge)
+"ZY" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/bed/chair/bay/chair/padded/blue{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/bridge)
 
 (1,1,1) = {"
 yz
@@ -13933,7 +14984,7 @@ yz
 yz
 yz
 yz
-yz
+hA
 yz
 yz
 yz
@@ -14071,15 +15122,15 @@ yz
 yz
 yz
 yz
+kX
 yz
 yz
 yz
-yz
-Nk
-yz
+AW
 yz
 yz
 yz
+kX
 yz
 yz
 yz
@@ -14207,27 +15258,27 @@ yz
 yz
 yz
 yz
+lZ
+pY
+vb
 yz
 yz
 yz
-yz
-yz
-yz
-Do
-yz
-yz
-yz
+Hf
+yG
+EP
+JJ
 AW
+yG
+EP
+JJ
+Hf
 yz
 yz
 yz
-Do
-yz
-yz
-yz
-yz
-yz
-yz
+lZ
+pY
+lZ
 yz
 yz
 yz
@@ -14350,11 +15401,11 @@ yz
 yz
 yz
 lZ
-Kj
-kL
-yz
-yz
-yz
+AW
+Hf
+yG
+EP
+JJ
 Hf
 nX
 DN
@@ -14364,11 +15415,11 @@ nX
 DN
 JW
 Hf
-yz
-yz
-yz
-lZ
-Kj
+yG
+EP
+JJ
+Hf
+AW
 lZ
 yz
 yz
@@ -14491,7 +15542,7 @@ yz
 yz
 yz
 yz
-lZ
+kX
 AW
 Hf
 nX
@@ -14500,18 +15551,18 @@ JW
 Hf
 uh
 et
-tL
-AW
+uh
+Dk
 uh
 et
-tL
+uh
 Hf
 nX
 DN
 JW
 Hf
 AW
-lZ
+kX
 yz
 yz
 yz
@@ -14638,22 +15689,22 @@ AW
 Hf
 uh
 et
-tL
-Hf
-GI
-rA
-GI
+uh
+OM
+QZ
+WO
+Vc
 uf
-GI
-rA
-GI
-Hf
+Vc
+WO
+QZ
+OM
 uh
 et
-tL
+uh
 Hf
 AW
-Do
+kk
 yz
 yz
 yz
@@ -14776,25 +15827,25 @@ yz
 yz
 yz
 aj
-AW
-Hf
+rt
+vd
 GI
 rA
-GI
+Kb
 MK
-QZ
+Tx
 Id
 RB
 Np
-RB
-Id
-QZ
-MK
-GI
-rA
-GI
-Hf
-AW
+mp
+ii
+uD
+Ev
+Zb
+RJ
+yH
+vd
+AN
 Ia
 yz
 yz
@@ -14918,25 +15969,25 @@ yz
 yz
 yz
 ZL
-Az
-WZ
+Hf
+Hf
 ok
-rD
-ux
+zk
+zk
 zk
 CN
-Ig
+JY
 JY
 NH
 RC
-Tx
-WO
-CZ
-Of
+QZ
+QZ
+QZ
+QZ
 Vx
 XH
-WZ
-KK
+Hf
+Hf
 UK
 yz
 yz
@@ -15059,27 +16110,27 @@ yz
 yz
 yz
 yz
-Nu
+lZ
 Hf
 Hf
 op
 uK
-uK
-uK
+op
+op
 rs
 YP
-YP
+kp
 NP
-RO
+Vx
 QZ
 QZ
 QZ
 QZ
-SE
-cY
 Hf
 Hf
-wG
+Hf
+Hf
+lZ
 yz
 yz
 yz
@@ -15200,29 +16251,29 @@ yz
 yz
 yz
 yz
-yz
-lZ
-Hf
-Hf
-vd
-rR
-vd
-vd
-gR
-Ii
-Kq
+bW
+kJ
+kJ
+kJ
+kJ
+kJ
+kJ
+kJ
+kJ
+kJ
+kJ
 uS
 SE
-QZ
-QZ
-QZ
-QZ
-Hf
-Hf
-Hf
-Hf
-lZ
-yz
+sc
+sc
+sc
+sc
+SE
+XW
+XW
+XW
+XW
+BI
 yz
 yz
 yz
@@ -15344,24 +16395,24 @@ yz
 yz
 bO
 kJ
-kJ
-kJ
-kJ
-kJ
-kJ
-kJ
-kJ
-kJ
-kJ
+pV
+wd
+wd
+Fd
+Kj
+OT
+TM
+WX
+pV
 vi
-Fp
+vX
 Dh
-Dh
-Dh
-Dh
-Fp
-XW
-XW
+Vp
+pn
+ob
+YN
+Uk
+Yv
 XW
 XW
 YR
@@ -15488,7 +16539,7 @@ Pw
 kJ
 pV
 kP
-kP
+rS
 rS
 aq
 aJ
@@ -15501,9 +16552,9 @@ zh
 WS
 lB
 Ox
-KS
-JG
-VC
+vX
+XW
+XW
 XW
 XW
 BK
@@ -15630,20 +16681,20 @@ bR
 kJ
 pV
 kS
-os
-os
-vg
-bp
+Dn
+Dn
+Dn
+Dn
 Dn
 gn
-pV
+SY
 NR
-vX
+ot
 ry
 Xg
 Sc
 Nb
-vX
+UE
 XW
 XW
 XW
@@ -15774,20 +16825,20 @@ pV
 kT
 gA
 gA
-gA
-gA
-gA
+aq
+aJ
+Ue
 gN
-nx
-yR
-RQ
+pV
+NZ
+vX
 TB
 OH
-nM
+ZI
 qt
 YN
-XW
-XW
+Uk
+Yv
 XW
 XW
 PP
@@ -15913,11 +16964,11 @@ yz
 bW
 kJ
 pV
-kY
 oy
 oy
-vg
-bp
+oy
+Kq
+Dn
 DK
 Io
 pV
@@ -15927,9 +16978,9 @@ XS
 Xu
 ZI
 mt
-KS
-JG
-VC
+vX
+XW
+XW
 XW
 XW
 BI
@@ -16051,31 +17102,31 @@ yz
 yz
 yz
 yz
-yz
-bO
-kJ
+cs
+DS
+DS
 pV
-ls
-ls
-ls
-Lm
-gA
-DQ
-Ip
 pV
-NZ
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+qp
 vX
-hN
-PH
-ZI
-My
+vX
+vX
+vX
+vX
+vX
+vX
+vX
 vX
 XW
 XW
-XW
-XW
-YR
-yz
+RW
 yz
 yz
 yz
@@ -16194,29 +17245,29 @@ yz
 yz
 yz
 xx
-DS
-DS
-pV
-pV
-pV
-pV
-pV
-pV
-pV
-pV
-pV
+gx
+lm
+rP
+wi
+yJ
+yJ
+yJ
+yJ
+UN
+WZ
+Pj
 Oa
-vX
-vX
-vX
-vX
-vX
-vX
-vX
-vX
-vX
-XW
-XW
+be
+Jy
+Jy
+Jy
+Jy
+Jy
+yJ
+LI
+cb
+lm
+gx
 cJ
 yz
 yz
@@ -16335,31 +17386,31 @@ yz
 yz
 yz
 yz
-wr
-kg
-yl
-tK
+XM
+DS
+cS
+Gv
 Oq
-ya
-ya
-ya
-ya
-SA
-FW
-Kr
+XX
+XX
+XX
+XX
+XX
+XX
+XX
 Og
-Ed
-TM
-TM
-TM
-TM
-TM
-ya
+XX
+XX
+XX
+XX
+XX
+XX
+XX
 kh
 Gv
-nY
-kg
-iu
+cS
+DS
+XM
 yz
 yz
 yz
@@ -16477,31 +17528,31 @@ yz
 yz
 yz
 yz
-LX
-DS
-pA
-HR
-vv
-DS
-DS
-DS
-DS
-DS
-DS
-DS
-Oh
-DS
-DS
-DS
-DS
-DS
-DS
-DS
-Ai
+XM
+yl
+La
+Gv
+Un
+XX
+XB
+NO
+OY
+eO
 Xh
-yG
-DS
-bU
+ph
+Oh
+iM
+wq
+Ci
+HT
+IP
+PW
+XX
+Un
+Gv
+YH
+yl
+XM
 yz
 yz
 yz
@@ -16619,31 +17670,31 @@ yz
 yz
 yz
 yz
-Ib
-DS
-cS
-cS
-lu
-DS
-NI
-oa
+XM
+yl
+SJ
+Gv
+Un
+XX
+HS
+TP
 SD
-QY
+rD
 ds
-sp
-Oi
 Mm
+Nh
+QM
 jA
-Wj
+nR
 UU
-jA
-jA
-DS
-lu
-cS
-cS
-DS
-Ib
+yL
+yK
+XX
+Un
+Gv
+SJ
+yl
+XM
 yz
 yz
 yz
@@ -16760,33 +17811,33 @@ yz
 yz
 yz
 yz
-Ib
-DS
-DS
-cS
-cS
-oj
-DS
-Qh
-Iv
-Iv
-Iv
-Iv
-sp
-bt
-Mm
+yz
+XM
+yl
+gw
+Gv
+Un
+XX
+XX
+XX
+XX
+yb
+HL
+KH
+qw
+KH
 sw
-Xx
-eF
-Ms
-Kf
-DS
-lO
-cS
-DS
-DS
-DS
-Ib
+CX
+XX
+XX
+XX
+XX
+Un
+Gv
+gw
+yl
+XM
+yz
 yz
 yz
 yz
@@ -16902,33 +17953,33 @@ yz
 yz
 yz
 yz
-HE
-JB
-iB
-iB
-cS
-lu
-DS
-as
-Iv
-zP
-Eh
+yz
+XM
+yl
+FE
+Gv
+Un
+XX
+HS
+Zf
+SD
+sJ
 Ix
-sp
-Oi
-Mm
+ES
+jg
+XI
 Ut
-XB
-vQ
-Ms
-jI
-DS
-lu
-cS
-Sz
-Sz
-Sz
-nC
+jr
+UU
+tL
+yK
+XX
+Un
+Gv
+FE
+yl
+XM
+yz
 yz
 yz
 yz
@@ -17044,33 +18095,33 @@ yz
 yz
 yz
 yz
-ac
-JB
-cs
-iB
-iB
-Na
-JB
-Wa
-eL
-zT
-at
+yz
+XM
+yl
+aI
+Gv
+pi
+XX
+XB
+nI
+TZ
+MO
 IK
 Ks
 Oy
-RS
+de
 UJ
-PX
+gI
 TZ
-Mv
-wo
-Sz
-Un
-kW
-kW
-rt
-Sz
-FO
+vY
+PW
+XX
+zK
+Gv
+Ow
+yl
+XM
+yz
 yz
 yz
 yz
@@ -17186,33 +18237,33 @@ yz
 yz
 yz
 yz
-ad
-JB
-cW
-dX
+yz
+XM
+DS
+cS
 hx
-lL
-JB
-WR
-Iv
-Ah
-EA
-IL
-sp
-xe
-Mm
-Vm
+Un
 XX
-lq
-jA
-jA
-Sz
-ck
+XX
+XX
+XX
+XX
+XX
+XX
+xe
+XX
+XX
+XX
+XX
+XX
+XX
+XX
+Un
 uJ
-JJ
-fk
-Sz
-hY
+cS
+DS
+XM
+yz
 yz
 yz
 yz
@@ -17328,33 +18379,33 @@ yz
 yz
 yz
 yz
-JB
-ak
-dd
-iB
-hH
+yz
+xx
+gx
+lm
+mO
 lR
-JB
-no
-Iv
-An
-EC
-IZ
-sp
-Oi
-wn
-jA
-Yq
 Ys
-Yr
-jA
-Sz
+Ys
+Ys
+KE
+Ys
+Ys
+ea
+JO
+bh
+Ys
+Ys
+KE
+Ys
+Ys
+Ys
 uu
-na
-kW
-kX
-SJ
-Sz
+nd
+lm
+gx
+cJ
+yz
 yz
 yz
 yz
@@ -17468,37 +18519,37 @@ yz
 yz
 yz
 yz
-FF
 yz
-LR
+yz
+yz
 al
-dg
-dY
-hU
-lV
-JB
-JB
-ZM
-ZM
-ZM
-ZM
-ZM
+DS
+DS
+DS
+WK
+DS
+DS
+DS
+DS
+DS
+DS
+DS
 JX
-ZM
-ZM
-ZM
-ZM
-ZM
-Sz
-Sz
-Ql
-sC
-Rh
-bJ
+DS
+DS
+DS
+DS
+DS
+DS
+DS
+WK
+DS
+DS
+DS
 uE
-yo
 yz
-OY
+yz
+yz
 yz
 yz
 yz
@@ -17612,33 +18663,33 @@ yz
 yz
 yz
 yz
-ae
-am
-dn
-ee
-ik
-lX
-oV
+yz
+XM
+DS
+CO
+kY
+WK
+DS
 sq
 KW
-KW
-KW
+Pc
+UY
 YU
 Wq
-OE
-zB
-YU
-KW
-KW
-KW
+XR
+Sj
 Kt
-tp
+Qb
+CC
+Kt
+Kt
+DS
 WK
-tA
-ch
-pN
+TX
+xE
+DS
 XM
-lx
+yz
 yz
 yz
 yz
@@ -17754,33 +18805,33 @@ yz
 yz
 yz
 yz
-JB
-JB
-iB
-JB
-Dx
-iB
-iB
-iB
-ZM
-ZM
-ZM
-ZM
-Kw
+XM
+DS
+DS
+Lf
+xj
+WK
+DS
+FF
+Kr
+Kr
+Kr
+Kr
+Wq
 NY
-ZM
-ZM
-ZM
-ZM
-ZM
+Sj
+AY
+kw
+Ax
+hF
 kW
-kW
-kW
-ix
-kW
-kW
-Sz
-Sz
+DS
+WK
+JD
+jd
+DS
+DS
+XM
 yz
 yz
 yz
@@ -17897,31 +18948,31 @@ yz
 yz
 yz
 kO
-Zo
-Bo
+Ye
 ia
-ip
-mb
-mb
-Bo
-ZM
-ZM
+Ye
+DS
+WK
+DS
+FO
+Kr
+Pn
 ED
 Ao
-cP
-Oi
+Wq
+XR
 Sj
 zg
-ED
-ZM
-ZM
+Mk
+gP
+hF
 mJ
-Ar
-hP
-Br
-PS
-zc
-XG
+DS
+WK
+cS
+Zv
+Zv
+Zv
 GJ
 yz
 yz
@@ -18038,32 +19089,32 @@ yz
 yz
 yz
 yz
-cu
-Zo
-Bo
+ae
+Ye
+gR
 ia
-ip
+ia
 pg
-Kk
-lv
-ZM
+Ye
+FW
+KK
 Aq
 Fg
-FD
-FD
+GQ
+xK
 OF
 ha
-ha
+QF
 Yt
 Ul
-ZM
+TW
 gk
 Zv
+px
+SG
+SG
+yM
 Zv
-Br
-PS
-zc
-XG
 qF
 yz
 yz
@@ -18180,33 +19231,33 @@ yz
 yz
 yz
 yz
-ab
-nq
+af
+Ye
 vw
 ef
 iO
 mj
-Kk
+Ye
 sz
-ZM
+Kr
 Av
 us
-FD
-sH
+jy
+Wq
 OS
-HZ
-FD
+Sj
+lE
 Yx
 zo
-ZM
-sS
+Kt
+Kt
 Zv
 xC
 sW
 Xz
 Yf
-go
-aV
+Zv
+OV
 yz
 yz
 yz
@@ -18323,32 +19374,32 @@ yz
 yz
 yz
 Ye
-Zo
-Bo
-eg
+cW
+hs
+ia
 iR
 mq
-Kk
-lv
-ZM
+Ye
+GO
+Kr
 AK
 Fz
-FD
-KJ
-OT
+Ti
+Wq
+XR
 Sl
-FD
+Kt
 ZC
 uG
-ZM
-Bj
+sN
+Kt
 Zv
 SI
 oO
 SG
 Qz
-XG
-Ci
+pP
+Zv
 yz
 yz
 yz
@@ -18462,37 +19513,37 @@ yz
 yz
 yz
 yz
+ac
 yz
-yz
-Ye
-Zo
+ag
+cY
 Gw
 Kk
 OU
 kl
-Kk
-lv
+Ye
+Ye
 ZM
-AS
-us
-FD
-Kb
+ZM
+ZM
+ZM
+ZM
 OW
-Dt
-FD
-Yx
-Pn
 ZM
-um
+ZM
+ZM
+ZM
+ZM
+Zv
 Zv
 oC
 Eo
-Zv
+If
 KT
 KB
-Ci
+gs
 yz
-yz
+SX
 yz
 yz
 yz
@@ -18606,33 +19657,33 @@ yz
 yz
 yz
 yz
-Ye
-yY
+au
+dd
 lv
-Kk
-OU
-kl
-Kk
-sz
-ZM
-AZ
-FD
-FD
+ls
+rR
+wC
+yR
+GY
+ZP
+ZP
+ZP
+uc
 KM
 OX
-KM
-FD
+xX
+uc
 ZP
-iy
-ZM
+ZP
+ZP
 KO
-Zv
-oC
-Eo
-Zv
+vp
+hq
+CK
+LW
 KG
-KB
-Ci
+gp
+XZ
 yz
 yz
 yz
@@ -18749,32 +19800,32 @@ yz
 yz
 yz
 Ye
-yY
-lv
-Kk
-OU
-kl
-Kk
-lv
+Ye
+ia
+Ye
+rV
+ia
+ia
+ia
 ZM
-hs
-FD
-La
-La
+ZM
+ZM
+ZM
+ZM
 sA
-La
-La
-Rt
-Af
 ZM
-yC
-Zv
-Gr
+ZM
+ZM
+ZM
+ZM
+SG
+SG
+SG
 eI
+SG
+SG
 Zv
-Lg
-KB
-Ci
+Zv
 yz
 yz
 yz
@@ -18890,33 +19941,33 @@ yz
 yz
 yz
 yz
-Ye
-yY
-lv
-Kk
-OU
+ah
+Zo
+Bo
+lx
+ip
 mr
-WH
-sF
-wd
+mr
+Bo
 ZM
-FJ
+ZM
+ZX
 Jk
-Jk
-Pc
-Jk
-Jk
+dZ
+Oi
+Qd
+FS
 ZX
 ZM
-eH
+ZM
 cV
-Zv
-Gr
-eI
-Zv
+aZ
+jb
+PE
+EF
 AI
-KB
-Ci
+XG
+uj
 yz
 yz
 yz
@@ -19032,33 +20083,33 @@ yz
 yz
 yz
 yz
-Ye
-yY
-lv
-Kk
-WX
+ad
+Zo
+Bo
+lx
+ip
 mC
-IA
-IA
-wi
+Rw
+WH
+ZM
 Bb
 FK
-Jl
-GM
+VQ
+VQ
 zs
-GM
+VO
 VO
 ZY
 FM
-wi
+ZM
 Zi
-Zi
-Zi
+LH
+LH
 PE
-Zv
+EF
 AI
 XG
-Ci
+jJ
 yz
 yz
 yz
@@ -19180,24 +20231,24 @@ KN
 xD
 xc
 fp
-ip
-ip
-BW
+Rw
+HB
+ZM
 Bc
-BW
-Js
-BW
+FQ
+VQ
+jt
 sX
-BW
-VP
-sX
+JH
+VQ
+Ay
 Jf
-BW
+ZM
 Br
-Br
-Br
+LH
+oz
 fr
-SG
+dR
 ZU
 go
 aV
@@ -19316,33 +20367,33 @@ yz
 yz
 yz
 yz
-cu
+yY
 Zo
 Bo
 sr
 Jd
 WV
-oW
-sJ
-wU
+Rw
+WH
+ZM
 Bf
 FN
-Jw
+VQ
 Lk
 Cn
 St
 VQ
 OR
 vt
-wU
+ZM
 cv
 LH
 GS
 MQ
-cC
+iC
 aD
 XG
-qF
+LM
 yz
 yz
 yz
@@ -19458,33 +20509,33 @@ yz
 yz
 yz
 yz
-sB
+yY
 Zo
-Bo
-Bo
-Jd
+hN
+Rw
+gl
 mI
-Bo
-tH
-tH
+Rw
+WH
+ZM
 Bq
 FQ
-Jb
-Jb
+VQ
+bI
 Yd
 TR
-TR
+VQ
 Ay
 Rz
-Yd
-ZT
-yI
-QT
-pz
-KI
-KI
-ZT
-eD
+ZM
+Gs
+LH
+pm
+sd
+LH
+Dm
+ZF
+LM
 yz
 yz
 yz
@@ -19599,35 +20650,35 @@ yz
 yz
 yz
 yz
-Sr
-Zo
-Zo
-xA
-xA
-Jd
-mF
-az
-tH
-gx
+yz
+yY
+ap
+WH
+Rw
+gl
+mI
+Rw
+HB
+ZM
 SF
-FR
-FR
-kf
-Pl
+VQ
+VQ
 Sx
-On
+iD
+Sx
+VQ
 FY
 UH
-HB
-ZT
-yp
+ZM
+iG
+LH
 pm
 sd
-wt
+LH
 pq
-ZT
-ZT
-Fd
+ZF
+LM
+yz
 yz
 yz
 yz
@@ -19741,35 +20792,35 @@ yz
 yz
 yz
 yz
-ab
-nq
-an
-Wo
-Wo
+nY
+yY
+ap
+WH
+Rw
 gl
-fp
-so
-tH
-LC
-SF
-FR
-FR
-wl
-Pl
+mI
+Rw
+WH
+ZM
+PH
+VQ
 xZ
-On
-FY
-UH
-nb
-ZT
-Jc
-QT
-bS
-mO
-mO
+xZ
+Tp
+xZ
+xZ
+dC
+hd
+ZM
+zO
+LH
+Ho
+sU
+LH
+dj
 ZF
 LM
-WF
+yz
 yz
 yz
 yz
@@ -19883,35 +20934,35 @@ yz
 yz
 yz
 yz
-Ye
+yz
 yY
-ao
+ap
 WH
 Rw
-Jd
-mF
-aA
-tH
+gl
+wG
+dV
+HE
 xg
-SF
+ZM
 FT
-FR
 Lq
-Pl
-pI
-On
+Lq
+pw
+Lq
+Lq
 es
-UH
+ZM
 OO
-ZT
-Di
-QT
+JF
+LH
+Ho
 sU
-IF
-Pq
-AL
-kx
-TU
+LH
+qq
+ZF
+LM
+yz
 yz
 yz
 yz
@@ -20025,35 +21076,35 @@ yz
 yz
 yz
 yz
-Ye
+yz
 yY
 ap
 WH
-eP
+Rw
 kM
 mR
 oX
-tH
-xh
+oX
+Bp
 BE
 FX
-FR
-FR
+RV
+OB
 PC
-On
-On
+OB
+Yu
 LV
 NU
 Bp
-ZT
-Di
+ZW
+ZW
 ZW
 lz
-ug
-Pq
-EP
-kx
-TU
+LH
+qq
+XG
+LM
+yz
 yz
 yz
 yz
@@ -20167,35 +21218,35 @@ yz
 yz
 yz
 yz
-Ye
-yY
-lm
-WH
+yz
+ab
+nq
+hS
 eX
 iX
-mT
-aB
-tH
-xi
+mZ
+ip
+ip
+Gl
 BF
-Ga
-FR
-FR
-PC
-On
-On
+Gl
+iT
+Gl
+Vg
+Gl
+fe
 Vg
 TI
 Gl
-ZT
-DR
-aI
+PE
+PE
+PE
 ql
 iC
-Pq
-UY
-kx
-TU
+kE
+go
+aV
+yz
 yz
 yz
 yz
@@ -20309,35 +21360,35 @@ yz
 yz
 yz
 yz
-Ye
-yY
-br
-WH
+yz
+ad
+Zo
+Bo
 ff
-ip
-mV
+AX
+wU
 aE
-tH
+HR
 qJ
 BU
 GK
-FR
+Fl
 LA
-Pl
+ox
 Me
-On
+yU
 kz
-On
-pW
-ZT
+fW
+qJ
+OG
 SV
 DJ
-QT
+gV
 jn
 Bx
-sf
-kx
-TU
+XG
+jJ
+yz
 yz
 yz
 yz
@@ -20451,35 +21502,35 @@ yz
 yz
 yz
 yz
-ab
-nq
-au
-Wo
-Wo
+yz
+aB
+Zo
+Bo
+Bo
 AX
 eG
-aG
+Bo
 tH
-xt
-BU
-FR
-FR
+tH
+Qc
+VC
 Md
-Pl
+Md
+QP
 Sy
-On
-FY
-On
-JZ
+Sy
+Sn
+sI
+QP
 ZT
 Wl
 OA
 XN
-mO
-mO
-yJ
-LM
-WF
+wp
+wp
+ZT
+th
+yz
 yz
 yz
 yz
@@ -20596,27 +21647,27 @@ yz
 cu
 Zo
 Zo
-aw
 ay
-ip
-mV
+ay
+AX
+xt
 aH
 tH
 xv
-Ce
+CL
 FR
 FR
 Mt
 Pl
 gX
 On
-QM
-my
+UT
+WA
 Fq
 ZT
 DM
-DJ
-QT
+Hg
+Td
 xz
 HC
 ZT
@@ -20735,35 +21786,35 @@ yz
 yz
 yz
 yz
-yz
-kO
-Zo
-Bo
-Bo
-ip
+ab
+nq
+dg
+Cx
+Cx
+sf
 mZ
-Bo
+Af
 tH
-tH
-CI
-GO
-GO
-CI
-Yd
-TR
-Wu
+KS
+CL
+FR
+FR
+Uy
+Pl
+om
+On
 UT
-TR
-Yd
+WA
+sR
 ZT
 PD
-un
+OA
 VJ
-KI
-KI
-ZT
+Vh
+Vh
+co
 UI
-yz
+fn
 yz
 yz
 yz
@@ -20877,35 +21928,35 @@ yz
 yz
 yz
 yz
-yz
-Ye
+yY
+ap
 Dd
-dp
+dV
 fj
-ip
-mV
+AX
+xt
 pt
-oi
+tH
 xG
 CL
 GR
-GR
+FR
 MD
-Qc
+Pl
 GU
-WE
+On
 hV
 WA
 EB
-oi
-qA
-oQ
+ZT
+Hp
+OA
 dx
 Nd
-PA
+Pq
 kx
 TU
-yz
+rh
 yz
 yz
 yz
@@ -21019,35 +22070,35 @@ yz
 yz
 yz
 yz
-yz
-Ye
-Dd
-ar
-fj
+yY
+ap
+dn
+dV
+nb
 jz
 nc
 pv
-ta
+tH
 xM
 CM
 Tl
-Tl
-Tl
-Tl
-Tl
-Tl
-Tl
+FR
+FR
+Em
+On
+On
+ZK
 Vn
 kG
-rV
+ZT
 Hp
 Sp
 wX
+AT
 Pq
-Pq
-kx
+gi
 TU
-yz
+rh
 yz
 yz
 yz
@@ -21161,35 +22212,35 @@ yz
 yz
 yz
 yz
-yz
-Ye
-Dd
-dB
-fj
+yY
+ap
+dA
+dV
+nt
 jD
 JM
-ip
-Tl
+Ar
+tH
 JE
 Nf
-Nf
-Nf
-Nf
-Nf
-Nf
-Nf
-Nf
-Nf
+VH
+FR
+FR
+Em
+On
+On
+Si
+Xv
 yi
-dA
+ZT
 QT
 Lh
 Xo
+Ph
 Pq
-Pq
-kx
+ua
 TU
-yz
+rh
 yz
 yz
 yz
@@ -21303,35 +22354,35 @@ yz
 yz
 yz
 yz
-yz
-Ye
-Dd
+yY
+ap
+dX
 dV
-fj
+nx
 ip
 mV
 pG
-tE
+tH
 yf
-WC
-WC
-WC
-WC
-WC
-WC
-WC
-WC
-WC
+Rh
+Wu
+FR
+FV
+Pl
+md
+On
+Wh
+On
 Ee
-tE
+ZT
 OZ
-Cq
-tg
+YC
+OA
 km
 PA
-kx
+XQ
 TU
-yz
+rh
 yz
 yz
 yz
@@ -21445,35 +22496,35 @@ yz
 yz
 yz
 yz
-yz
-af
+ab
+nq
 bM
 Cx
 Cx
 jK
 nn
 pK
-Cx
+tH
 yj
-WC
-WC
-YW
-WC
-WC
-WC
-YW
-WC
-WC
+Rh
+FR
+FR
+oo
+Pl
+rc
+On
+UT
+On
 dk
-uq
+ZT
 ga
 po
 Rv
-dq
-dq
-MZ
-Jg
-yz
+Vh
+Vh
+LP
+UI
+fn
 yz
 yz
 yz
@@ -21587,35 +22638,35 @@ yz
 yz
 yz
 yz
-yz
-ag
-VH
+ad
+Zo
+Zo
 Px
 fx
-Ue
-Is
+ip
+mV
 pM
-Cx
-yj
-WC
-YW
-HO
+tH
+Lm
+Rt
+FR
+FR
 kt
-ML
+Pl
 Pe
-HO
+On
 YW
-WC
-dk
-dq
+LF
+bw
+ZT
 gf
 YC
-mP
+OA
 hv
 qa
-rP
-UN
-yz
+ZT
+ZT
+cR
 yz
 yz
 yz
@@ -21731,32 +22782,32 @@ yz
 yz
 yz
 ah
-bM
-Cx
-fE
-jQ
+Zo
+Bo
+Bo
+ip
 np
-pY
-tX
-yv
-WC
-HO
-HO
+Bo
+tH
+tH
+tW
+WE
+WE
 tW
 QP
-tV
-HO
-HO
-WC
-Nz
-nl
+Sy
+pZ
+Eb
+Sy
+QP
+ZT
 pU
-TF
-ij
+Mj
+Cv
 wp
-dq
-MZ
-ci
+wp
+ZT
+VK
 yz
 yz
 yz
@@ -21872,33 +22923,33 @@ yz
 yz
 yz
 yz
-ah
-bM
-Cx
-fP
-jU
-nt
+yY
+dY
+hY
+fZ
+ip
+mV
 qo
 tX
 yx
-WC
+RQ
 Hu
-mH
+Hu
 MT
 QR
-MT
+hl
 HH
 dT
-WC
-Nz
-nl
-ij
+sy
+RX
+tX
+tv
 LB
 xU
 GT
-dq
-MZ
-ci
+vn
+TU
+rh
 yz
 yz
 yz
@@ -22014,33 +23065,33 @@ yz
 yz
 yz
 yz
-ai
-bM
-Cx
-fU
+yY
+dY
+ik
+fZ
 jY
 nv
-qo
-tX
-xO
-WC
-Hq
-JN
-MT
-QS
-MT
+Az
+Ii
+LC
+Sh
 WJ
-og
-WC
-Nz
-nl
+WJ
+WJ
+WJ
+WJ
+WJ
+WJ
+yP
+XU
+sk
 mh
 LZ
 LJ
-hS
-dq
-MZ
-Cr
+Pq
+Pq
+TU
+rh
 yz
 yz
 yz
@@ -22156,33 +23207,33 @@ yz
 yz
 yz
 yz
-ah
-bM
-Cx
+yY
+dY
+ix
 fZ
 Yk
 Is
-qo
-tX
-xO
-WC
-Hu
-JN
-MU
-QX
-SZ
+ip
 WJ
-dT
-WC
+LR
+SZ
+SZ
+SZ
+SZ
+SZ
+SZ
+SZ
+SZ
+SZ
 Zx
-nl
-pb
-TF
-ij
-MC
-dq
-MZ
-ci
+Ck
+OA
+Se
+Zw
+Pq
+Pq
+TU
+rh
 yz
 yz
 yz
@@ -22298,33 +23349,33 @@ yz
 yz
 yz
 yz
-ah
-bM
-bM
-bM
-bM
-nz
-bM
-bM
-xO
+yY
+dY
+jv
+fZ
+ip
+mV
+AS
+Ip
+My
 WC
-Hq
-JN
-MU
-Eq
-SZ
-WJ
-og
 WC
-Zx
-nl
-dq
+WC
+WC
+WC
+WC
+WC
+WC
+WC
+TQ
+Ip
+Zc
 zb
 PG
-dq
-dq
-MZ
-ci
+SO
+vn
+TU
+rh
 yz
 yz
 yz
@@ -22440,30 +23491,30 @@ yz
 yz
 yz
 yz
-pO
-vK
+aG
+TD
 Cf
-gh
+Cf
 Nq
 qP
 qz
-vK
+Cf
 Ok
 WC
-Hu
-GZ
-MT
-Jx
-MT
-EG
-dT
 WC
-Zx
-nl
+GZ
+WC
+WC
+WC
+GZ
+WC
+WC
+Mr
+RN
 aQ
-TF
-ij
-aQ
+hQ
+wI
+dq
 dq
 MZ
 Jg
@@ -22583,32 +23634,32 @@ yz
 yz
 yz
 PO
-vK
+ee
 iz
 rO
 ON
 qy
 qD
-vK
-xO
+Cf
+Ok
 WC
-HO
+GZ
 HO
 Ng
 Rc
 Du
 HO
-HO
+GZ
 WC
-Zx
-nl
-cO
-TF
-ij
-Mb
+Mr
 dq
-MZ
-ci
+cO
+iY
+Jh
+Mb
+ir
+hb
+Iu
 yz
 yz
 yz
@@ -22724,30 +23775,30 @@ yz
 yz
 yz
 yz
-PO
+Om
 TD
-rB
+Cf
 rN
 av
 nB
 FP
-vK
-xO
+Jx
+MC
 WC
 HO
 HO
 yg
 HK
-yg
+Il
 HO
 HO
 WC
-Zx
+Mx
 nl
 NJ
 TF
 ij
-NJ
+YS
 dq
 MZ
 ci
@@ -22866,33 +23917,33 @@ yz
 yz
 yz
 yz
-nr
-FL
-vK
+Om
+TD
+Cf
 gF
-rO
+sF
 Vq
-Vq
-vK
-xO
+Xw
+Jx
+ML
 WC
-HO
-HO
-WC
-WC
-WC
-HO
-HO
+CH
+AC
+mv
+Mq
+mv
+sM
+gQ
 WC
 Mx
-dq
-wZ
+nl
+ij
 gZ
 CP
 wZ
 dq
 MZ
-Cr
+ci
 yz
 yz
 yz
@@ -23008,33 +24059,33 @@ yz
 yz
 yz
 yz
-PO
-FL
-vK
+br
+TD
+Cf
 gW
 TG
 BM
-Vq
-vK
+Xw
+Jx
 xO
 WC
-ax
-HO
-WC
-WC
-WC
-HO
+QE
+fV
+mv
+mg
+mv
+Za
 QV
 WC
-aK
-Sh
-ij
-TF
-ij
-ij
+Mx
+nl
+Ad
+gq
+qc
+YZ
 dq
 MZ
-ci
+iF
 yz
 yz
 yz
@@ -23150,30 +24201,30 @@ yz
 yz
 yz
 yz
-PO
-FL
-vK
+Om
+TD
+Cf
 hj
 db
-vK
+qy
 Xw
-vK
-yB
+Jx
+xO
 WC
+CH
+fV
+Vd
+vo
+pD
+Za
+gQ
 WC
-WC
-WC
-WC
-WC
-WC
-WC
-WC
-zr
-dq
+Ff
+nl
 mN
-SB
-tx
-mN
+TF
+ij
+kQ
 dq
 MZ
 ci
@@ -23293,32 +24344,32 @@ yz
 yz
 yz
 Om
-if
-rM
-hk
-eO
+TD
+TD
+TD
+TD
 bv
-cH
-vK
-yD
+TD
+TD
+xO
+WC
 QE
-QE
-QE
-QE
-QE
-QE
-QE
-QE
-QE
+fV
+Vd
+WP
+pD
+Za
+QV
+WC
 Ff
+nl
 dq
-vb
 iW
 rn
-ca
-qa
-rP
-UN
+dq
+dq
+MZ
+ci
 yz
 yz
 yz
@@ -23436,29 +24487,29 @@ yz
 yz
 pO
 vK
-vK
-hj
+jQ
+nz
 rr
-vK
+ya
 pr
 vK
 yX
+WC
 CH
-CH
-CH
-CH
-CH
-CH
-CH
-CH
-CH
-yX
-MZ
+xq
+mv
+Dp
+mv
+yr
+gQ
+WC
+Ff
+nl
 ky
-wC
+TF
 ij
+ky
 dq
-MZ
 MZ
 Jg
 yz
@@ -23576,33 +24627,33 @@ yz
 yz
 yz
 yz
-yz
+bJ
 vK
-vK
+jU
 rp
 SN
 tZ
 Bl
 vK
-ib
+xO
+WC
+HO
+HO
 za
-za
-za
-za
-za
-za
-za
-za
-za
-ib
-MZ
+GE
+nU
+HO
+HO
+WC
+Ff
+nl
 FG
-jv
+TF
 ij
+NN
 dq
 MZ
-MZ
-yz
+ci
 yz
 yz
 yz
@@ -23718,33 +24769,33 @@ yz
 yz
 yz
 yz
-yz
+bJ
 dW
-vK
-vK
+kg
+nC
 wh
-tZ
+yo
 UD
 vK
-yz
-yz
-yz
-yz
-yz
-yz
-yz
-yz
-yz
-yz
-yz
-MZ
+xO
+WC
+HO
+HO
+WT
+eJ
+WT
+HO
+HO
+WC
+Ff
+nl
 Gu
-GY
-GY
+TF
+ij
+Gu
+dq
 MZ
-MZ
-YO
-yz
+ci
 yz
 yz
 yz
@@ -23860,33 +24911,33 @@ yz
 yz
 yz
 yz
-yz
-yz
-dW
+ca
+eH
 vK
-vK
-tZ
+nM
+rp
+VN
 VN
 vK
-yz
-yz
-yz
-yz
-yz
-yz
-yz
-yz
-yz
-yz
-yz
+xO
+WC
+HO
+HO
+WC
+WC
+WC
+HO
+HO
+WC
+ts
+dq
+Je
+bG
+II
+Je
+dq
 MZ
-Gu
-MZ
-MZ
-MZ
-YO
-yz
-yz
+iF
 yz
 yz
 yz
@@ -24002,33 +25053,33 @@ yz
 yz
 yz
 yz
-yz
-yz
-yz
-dW
+bJ
+eH
 vK
+oi
+ta
+yv
+VN
 vK
-ej
-vK
-yz
-yz
-yz
-yz
-yz
-yz
-yz
-yz
-yz
-yz
-yz
+xO
+WC
+WF
+HO
+WC
+WC
+WC
+HO
+ys
+WC
+xo
 Cr
-Gu
+ij
+TF
+ij
+ij
+dq
 MZ
-MZ
-YO
-yz
-yz
-yz
+ci
 yz
 yz
 yz
@@ -24144,33 +25195,33 @@ yz
 yz
 yz
 yz
-yz
-yz
-yz
-yz
-dW
+bJ
+eH
+vK
+oV
+tp
 vK
 pE
-OM
-yz
-yz
-yz
-yz
-yz
-yz
-yz
-yz
-yz
-yz
-yz
-CR
-Gu
+vK
+Nk
+WC
+WC
+WC
+WC
+WC
+WC
+WC
+WC
+WC
+bn
+dq
+hc
+KF
+ZQ
+hc
+dq
 MZ
-YO
-yz
-yz
-yz
-yz
+ci
 yz
 yz
 yz
@@ -24286,33 +25337,33 @@ yz
 yz
 yz
 yz
-yz
-yz
-yz
-yz
-yz
-dW
-PO
-PO
-yz
-yz
-yz
-yz
-yz
-yz
-yz
-yz
-yz
-yz
-yz
-ci
-Gu
+ch
+fk
+kL
+pA
+tx
+yB
+CR
+vK
+Nu
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+Sr
+ml
+dq
+yF
 YO
-yz
-yz
-yz
-yz
-yz
+ue
+ft
+ir
+hb
+Iu
 yz
 yz
 yz
@@ -24428,33 +25479,33 @@ yz
 yz
 yz
 yz
-yz
-yz
-yz
-yz
-yz
-yz
-PO
-yz
-yz
-yz
-yz
-yz
-yz
-yz
-yz
-yz
-yz
-yz
-yz
-yz
+pO
+vK
+vK
+oV
+tA
+vK
+CZ
+vK
+Of
+SA
+SA
+SA
+SA
+SA
+SA
+SA
+SA
+SA
+Of
+MZ
 aC
-yz
-yz
-yz
-yz
-yz
-yz
+YK
+ij
+dq
+MZ
+MZ
+Jg
 yz
 yz
 yz
@@ -24571,31 +25622,31 @@ yz
 yz
 yz
 yz
-yz
-yz
-yz
-yz
-yz
-yz
-yz
-yz
-yz
-yz
-yz
-yz
-yz
-yz
-yz
-yz
-yz
-yz
-yz
-yz
-yz
-yz
-yz
-yz
-yz
+vK
+vK
+pN
+tE
+yD
+Dt
+vK
+OE
+SB
+SB
+SB
+SB
+SB
+SB
+SB
+SB
+SB
+OE
+MZ
+wM
+is
+ij
+dq
+MZ
+MZ
 yz
 yz
 yz
@@ -24713,6 +25764,13 @@ yz
 yz
 yz
 yz
+fE
+vK
+vK
+uq
+yD
+Dx
+vK
 yz
 yz
 yz
@@ -24724,20 +25782,13 @@ yz
 yz
 yz
 yz
-yz
-yz
-yz
-yz
-yz
-yz
-yz
-yz
-yz
-yz
-yz
-yz
-yz
-yz
+MZ
+Gn
+gT
+gT
+MZ
+MZ
+bB
 yz
 yz
 yz
@@ -24856,6 +25907,12 @@ yz
 yz
 yz
 yz
+fE
+vK
+vK
+yD
+DQ
+vK
 yz
 yz
 yz
@@ -24867,18 +25924,12 @@ yz
 yz
 yz
 yz
-yz
-yz
-yz
-yz
-yz
-yz
-yz
-yz
-yz
-yz
-yz
-yz
+MZ
+Gn
+MZ
+MZ
+MZ
+bB
 yz
 yz
 yz
@@ -24999,6 +26050,11 @@ yz
 yz
 yz
 yz
+fE
+vK
+vK
+Ed
+vK
 yz
 yz
 yz
@@ -25010,16 +26066,11 @@ yz
 yz
 yz
 yz
-yz
-yz
-yz
-yz
-yz
-yz
-yz
-yz
-yz
-yz
+iF
+Gn
+MZ
+MZ
+bB
 yz
 yz
 yz
@@ -25142,6 +26193,10 @@ yz
 yz
 yz
 yz
+fE
+vK
+Eq
+JG
 yz
 yz
 yz
@@ -25153,14 +26208,10 @@ yz
 yz
 yz
 yz
-yz
-yz
-yz
-yz
-yz
-yz
-yz
-yz
+RU
+Gn
+MZ
+bB
 yz
 yz
 yz
@@ -25285,6 +26336,9 @@ yz
 yz
 yz
 yz
+fE
+bJ
+bJ
 yz
 yz
 yz
@@ -25296,12 +26350,9 @@ yz
 yz
 yz
 yz
-yz
-yz
-yz
-yz
-yz
-yz
+ci
+Gn
+bB
 yz
 yz
 yz
@@ -25428,6 +26479,7 @@ yz
 yz
 yz
 yz
+bJ
 yz
 yz
 yz
@@ -25441,8 +26493,7 @@ yz
 yz
 yz
 yz
-yz
-yz
+ra
 yz
 yz
 yz

--- a/maps/submaps/admin_use_vr/ert.dmm
+++ b/maps/submaps/admin_use_vr/ert.dmm
@@ -208,12 +208,6 @@
 /obj/item/clothing/suit/space/void/responseteam/security,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/barracks)
-"aI" = (
-/obj/machinery/vending/fitness{
-	prices = list()
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/hallways_aft)
 "aJ" = (
 /obj/machinery/atmospherics/pipe/simple/visible/universal,
 /turf/simulated/floor/tiled/techfloor,
@@ -280,17 +274,6 @@
 	},
 /obj/effect/floor_decal/corner/red{
 	dir = 4
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/hallways_aft)
-"bh" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/floor_decal/corner/red{
-	dir = 1
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/ship/ert/hallways_aft)
@@ -493,6 +476,15 @@
 /obj/effect/floor_decal/industrial/outline/blue,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/eng_storage)
+"cz" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/brig)
 "cJ" = (
 /obj/machinery/power/pointdefense{
 	id_tag = "vonbraun_pd"
@@ -503,6 +495,10 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/reinforced/airless,
+/area/ship/ert/hallways_aft)
+"cM" = (
+/obj/structure/table/steel_reinforced,
+/turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/hallways_aft)
 "cO" = (
 /obj/machinery/bodyscanner{
@@ -581,19 +577,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/dock_port)
-"de" = (
-/obj/structure/table/steel_reinforced,
-/obj/machinery/light/no_nightshift{
-	dir = 4
-	},
-/obj/machinery/alarm/alarms_hidden{
-	dir = 8;
-	pixel_x = 26
-	},
-/obj/item/weapon/reagent_containers/spray/cleaner,
-/obj/item/weapon/reagent_containers/spray/cleaner,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/brig)
 "dg" = (
 /obj/machinery/light/no_nightshift{
 	dir = 1
@@ -783,17 +766,6 @@
 /obj/machinery/recharge_station,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/bridge)
-"ea" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/floor_decal/corner/red{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/hallways_aft)
 "ee" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -885,16 +857,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/shuttle/ert_ship_boat)
-"eO" = (
-/obj/machinery/light/no_nightshift{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/obj/structure/table/steel_reinforced,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/brig)
 "eX" = (
 /obj/effect/landmark/late_antag/ert,
 /obj/structure/table/bench/steel,
@@ -939,6 +901,17 @@
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/ship/ert/med)
+"fo" = (
+/obj/machinery/light/no_nightshift{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning,
+/obj/structure/table/steel_reinforced,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/brig)
 "fp" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -978,6 +951,15 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/ship/ert/med_surg)
+"fu" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/hallways_aft)
 "fx" = (
 /obj/structure/table/rack/steel,
 /obj/effect/floor_decal/industrial/outline/grey,
@@ -1016,6 +998,16 @@
 	},
 /turf/space,
 /area/space)
+"fS" = (
+/obj/machinery/alarm/alarms_hidden{
+	dir = 1;
+	pixel_y = -26
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/hallways_aft)
 "fV" = (
 /obj/structure/bed/chair/bay/shuttle,
 /turf/simulated/floor/tiled/techfloor,
@@ -1160,10 +1152,6 @@
 /obj/effect/map_helper/airlock/door/ext_door,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/dock_star)
-"gw" = (
-/obj/structure/table/steel_reinforced,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/hallways_aft)
 "gx" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -1190,14 +1178,6 @@
 /obj/item/rig_module/device/healthscanner,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/mech_bay)
-"gI" = (
-/obj/machinery/light/no_nightshift{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/warning,
-/obj/structure/table/steel_reinforced,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/brig)
 "gN" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -1334,6 +1314,17 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/armoury_dl)
+"gY" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
+/obj/effect/catwalk_plated/techmaint,
+/turf/simulated/floor/plating,
+/area/ship/ert/brig)
 "gZ" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -1563,6 +1554,13 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/barracks)
+"hU" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/structure/ship_munition/disperser_charge/explosive,
+/turf/simulated/floor/reinforced,
+/area/ship/ert/hallways_aft)
 "hV" = (
 /obj/structure/closet/crate{
 	dir = 2
@@ -1656,6 +1654,10 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/ship/ert/med_surg)
+"iw" = (
+/obj/machinery/door/window/brigdoor/northleft,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/hallways_aft)
 "ix" = (
 /obj/structure/table/rack/steel,
 /obj/item/clothing/suit/armor/swat{
@@ -1767,12 +1769,15 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/eng_storage)
-"iM" = (
-/obj/machinery/vending/wallmed1/public{
-	dir = 4;
-	pixel_x = -23
+"iK" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/structure/table/steel_reinforced,
+/obj/item/weapon/gun/energy/sizegun,
+/obj/item/weapon/gun/energy/sizegun,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/brig)
 "iO" = (
@@ -1865,37 +1870,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/eng_storage)
-"jd" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/obj/structure/ship_munition/disperser_charge/explosive,
-/turf/simulated/floor/reinforced,
-/area/ship/ert/hallways_aft)
-"jg" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/brig)
 "jn" = (
 /obj/effect/floor_decal/corner/white{
 	dir = 4
@@ -1906,16 +1880,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/eng_storage)
-"jr" = (
-/obj/effect/floor_decal/industrial/warning,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/brig)
 "jt" = (
 /obj/machinery/computer/ship/sensors,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -1999,6 +1963,13 @@
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/tiled/techmaint,
 /area/ship/ert/brig)
+"jB" = (
+/obj/machinery/alarm/alarms_hidden{
+	dir = 8;
+	pixel_x = 26
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/ship/ert/brig)
 "jD" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
@@ -2035,6 +2006,22 @@
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled/techmaint,
 /area/ship/ert/barracks)
+"jZ" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/table/steel_reinforced,
+/obj/item/device/laser_pointer/upgraded,
+/obj/item/device/laser_pointer/upgraded,
+/obj/item/device/flash,
+/obj/item/device/flash,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/brig)
 "kg" = (
 /obj/structure/ship_munition/disperser_charge/emp,
 /obj/effect/floor_decal/industrial/warning,
@@ -2241,10 +2228,6 @@
 /obj/machinery/porta_turret/stationary/CIWS,
 /turf/simulated/floor/reinforced/airless,
 /area/ship/ert/engine)
-"kY" = (
-/obj/machinery/door/window/brigdoor/northleft,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/hallways_aft)
 "lm" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -2335,6 +2318,17 @@
 	dir = 9
 	},
 /turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/hallways_aft)
+"lU" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/hallways_aft)
 "lZ" = (
 /turf/simulated/floor/reinforced/airless,
@@ -2480,6 +2474,29 @@
 "mv" = (
 /turf/simulated/floor/tiled/techmaint,
 /area/shuttle/ert_ship_boat)
+"mz" = (
+/obj/machinery/button/flasher{
+	pixel_x = -9;
+	pixel_y = 22
+	},
+/obj/machinery/button/remote/blast_door{
+	id = "braun_cells_privacy";
+	name = "Privacy Shutter Controls";
+	pixel_x = 8;
+	pixel_y = 25;
+	req_access = list(103)
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/brig)
 "mC" = (
 /obj/effect/landmark{
 	name = "Commando"
@@ -2510,15 +2527,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/ship/ert/med_surg)
-"mO" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/hallways_aft)
 "mR" = (
 /obj/structure/cable/yellow{
 	d1 = 2;
@@ -2548,6 +2556,17 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/ship/ert/barracks)
+"mX" = (
+/obj/machinery/light/no_nightshift{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning,
+/obj/structure/table/steel_reinforced,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/brig)
 "mZ" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -2585,17 +2604,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/ship/ert/barracks)
-"nd" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/hallways_aft)
 "nl" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
@@ -2721,16 +2729,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/gunnery)
-"nI" = (
-/obj/machinery/alarm/alarms_hidden{
-	dir = 8;
-	pixel_x = 26
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/ship/ert/brig)
 "nM" = (
 /obj/machinery/light/no_nightshift{
 	dir = 1
@@ -2741,16 +2739,17 @@
 /obj/structure/railing,
 /turf/simulated/floor/reinforced,
 /area/ship/ert/gunnery)
-"nR" = (
-/obj/effect/floor_decal/industrial/warning,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
+"nS" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
+/obj/effect/floor_decal/corner/red{
+	dir = 8
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/brig)
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/hallways_aft)
 "nU" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
@@ -2960,41 +2959,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/ship/ert/dock_port)
-"ph" = (
-/obj/structure/table/steel_reinforced,
-/obj/machinery/button/remote/blast_door{
-	dir = 4;
-	id = "braun_cells_privacy";
-	name = "Privacy Shutter Controls";
-	pixel_x = -24;
-	pixel_y = -9;
-	req_access = list(103)
-	},
-/obj/item/weapon/handcuffs,
-/obj/item/weapon/handcuffs,
-/obj/item/weapon/handcuffs,
-/obj/item/weapon/handcuffs,
-/obj/item/weapon/handcuffs/legcuffs,
-/obj/item/weapon/handcuffs/legcuffs,
-/obj/item/weapon/handcuffs/legcuffs,
-/obj/item/weapon/handcuffs/legcuffs,
-/obj/machinery/firealarm/alarms_hidden{
-	dir = 8;
-	pixel_x = -26;
-	pixel_y = 5
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/brig)
-"pi" = (
-/obj/machinery/alarm/alarms_hidden{
-	dir = 1;
-	pixel_y = -26
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/hallways_aft)
 "pm" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/effect/floor_decal/industrial/outline,
@@ -3316,6 +3280,19 @@
 	},
 /turf/simulated/wall/rshull,
 /area/ship/ert/dock_star)
+"pQ" = (
+/obj/machinery/light/no_nightshift{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/structure/table/steel_reinforced,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/brig)
 "pS" = (
 /obj/effect/shuttle_landmark/premade/ert_ship_near_port,
 /turf/space,
@@ -3468,15 +3445,8 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/engineering)
 "qw" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
-/obj/effect/catwalk_plated/techmaint,
-/turf/simulated/floor/plating,
+/obj/structure/bed/pod,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/ship/ert/brig)
 "qy" = (
 /obj/structure/cable/yellow{
@@ -3685,18 +3655,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/engine)
-"rD" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/brig)
 "rN" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/rig_module/mounted{
@@ -3923,6 +3881,19 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/tiled/techmaint,
 /area/ship/ert/bridge)
+"sE" = (
+/obj/structure/table/steel_reinforced,
+/obj/machinery/light/no_nightshift{
+	dir = 4
+	},
+/obj/machinery/alarm/alarms_hidden{
+	dir = 8;
+	pixel_x = 26
+	},
+/obj/item/weapon/reagent_containers/spray/cleaner,
+/obj/item/weapon/reagent_containers/spray/cleaner,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/brig)
 "sF" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled/techmaint,
@@ -3948,18 +3919,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/ship/ert/armoury_dl)
-"sJ" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/brig)
 "sM" = (
 /obj/structure/bed/chair/bay/shuttle{
 	dir = 1
@@ -4063,6 +4022,17 @@
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/ship/ert/med)
+"tn" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/light/no_nightshift{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/hallways_aft)
 "tp" = (
 /obj/machinery/door/airlock/glass_external,
 /obj/effect/map_helper/airlock/door/int_door,
@@ -4125,16 +4095,6 @@
 "tH" = (
 /turf/simulated/wall/rshull,
 /area/ship/ert/armoury_st)
-"tL" = (
-/obj/machinery/flasher,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/ship/ert/brig)
 "tW" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
@@ -4239,6 +4199,20 @@
 /obj/structure/table/hardwoodtable,
 /turf/simulated/floor/wood,
 /area/ship/ert/commander)
+"ut" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/hallways_aft)
 "uu" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -4402,16 +4376,6 @@
 "vX" = (
 /turf/simulated/wall/shull,
 /area/ship/ert/engineering)
-"vY" = (
-/obj/machinery/alarm/alarms_hidden{
-	dir = 8;
-	pixel_x = 26
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/ship/ert/brig)
 "wd" = (
 /obj/machinery/atmospherics/pipe/tank/air{
 	dir = 4
@@ -4597,10 +4561,6 @@
 	},
 /turf/simulated/wall/rshull,
 /area/ship/ert/bridge)
-"xj" = (
-/obj/machinery/door/window/brigdoor/northright,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/hallways_aft)
 "xo" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
@@ -4620,6 +4580,13 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/ert_ship_boat)
+"xs" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/brig)
 "xt" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -4736,13 +4703,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/barracks)
-"xE" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/obj/structure/ship_munition/disperser_charge/emp,
-/turf/simulated/floor/reinforced,
-/area/ship/ert/hallways_aft)
 "xG" = (
 /obj/structure/table/rack/steel,
 /obj/effect/floor_decal/industrial/outline/grey,
@@ -4843,6 +4803,19 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/ship/ert/hangar)
+"xR" = (
+/obj/machinery/light/no_nightshift{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/structure/table/steel_reinforced,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/brig)
 "xU" = (
 /obj/effect/floor_decal/corner/white{
 	dir = 9
@@ -4887,29 +4860,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/ship/ert/gunnery)
-"yb" = (
-/obj/machinery/button/flasher{
-	pixel_x = -9;
-	pixel_y = 22
-	},
-/obj/machinery/button/remote/blast_door{
-	id = "braun_cells_privacy";
-	name = "Privacy Shutter Controls";
-	pixel_x = 8;
-	pixel_y = 25;
-	req_access = list(103)
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/brig)
 "yf" = (
 /obj/structure/table/rack/steel,
 /obj/effect/floor_decal/industrial/outline/grey,
@@ -5109,23 +5059,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/ship/ert/hallways_aft)
-"yK" = (
-/obj/structure/bed/pod,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/ship/ert/brig)
-"yL" = (
-/obj/machinery/flasher,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/ship/ert/brig)
 "yM" = (
 /obj/machinery/atmospherics/pipe/tank/air{
 	dir = 4;
@@ -5278,7 +5211,11 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/ship/ert/bridge)
-"zK" = (
+"zO" = (
+/obj/machinery/vending/engivend,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/eng_storage)
+"zR" = (
 /obj/machinery/alarm/alarms_hidden{
 	pixel_y = 26
 	},
@@ -5287,10 +5224,15 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/ship/ert/hallways_aft)
-"zO" = (
-/obj/machinery/vending/engivend,
+"zT" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/eng_storage)
+/area/ship/ert/brig)
 "Ad" = (
 /obj/structure/closet/crate/freezer,
 /obj/item/weapon/reagent_containers/blood/OMinus,
@@ -5332,6 +5274,13 @@
 	},
 /turf/simulated/floor/wood,
 /area/ship/ert/commander)
+"Ap" = (
+/obj/machinery/vending/coffee{
+	dir = 1;
+	prices = list()
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/hallways_aft)
 "Aq" = (
 /obj/structure/cable/yellow{
 	d1 = 2;
@@ -5697,14 +5646,6 @@
 "Cf" = (
 /turf/simulated/wall/shull,
 /area/ship/ert/mech_bay)
-"Ci" = (
-/obj/machinery/light/no_nightshift{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/warning,
-/obj/structure/table/steel_reinforced,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/brig)
 "Ck" = (
 /obj/machinery/door/airlock/glass_medical{
 	name = "Medical Bay";
@@ -5826,11 +5767,6 @@
 /obj/machinery/atmospherics/pipe/simple/visible/universal,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/engine)
-"CO" = (
-/obj/structure/ship_munition/disperser_charge/emp,
-/obj/effect/floor_decal/industrial/warning,
-/turf/simulated/floor/reinforced,
-/area/ship/ert/hallways_aft)
 "CP" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -5855,24 +5791,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/atmos)
-"CX" = (
-/obj/machinery/button/flasher{
-	pixel_x = -9;
-	pixel_y = -22
-	},
-/obj/machinery/button/remote/blast_door{
-	dir = 1;
-	id = "braun_cells_privacy";
-	name = "Privacy Shutter Controls";
-	pixel_x = 9;
-	pixel_y = -24;
-	req_access = list(103)
-	},
-/obj/effect/floor_decal/industrial/warning,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/brig)
 "CZ" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
@@ -5987,6 +5905,10 @@
 	},
 /turf/simulated/floor/airless,
 /area/ship/ert/gunnery)
+"Dy" = (
+/obj/machinery/door/window/brigdoor/southright,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/hallways_aft)
 "DJ" = (
 /obj/effect/floor_decal/corner/white{
 	dir = 6
@@ -6148,14 +6070,6 @@
 	},
 /turf/space,
 /area/ship/ert/engine)
-"ES" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/brig)
 "Fd" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 4
@@ -6235,12 +6149,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/ship/ert/commander)
-"FE" = (
-/obj/structure/bed/chair/bay/chair/padded/blue{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/hallways_aft)
 "FF" = (
 /obj/machinery/light/no_nightshift{
 	dir = 1
@@ -6566,6 +6474,13 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/ship/ert/hangar)
+"Hz" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/structure/ship_munition/disperser_charge/emp,
+/turf/simulated/floor/reinforced,
+/area/ship/ert/hallways_aft)
 "HB" = (
 /obj/structure/closet/wardrobe/ert,
 /obj/item/modular_computer/tablet/preset/custom_loadout/elite,
@@ -6688,11 +6603,6 @@
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/barracks)
-"HS" = (
-/obj/structure/bed/pod,
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/ship/ert/brig)
 "HT" = (
 /obj/machinery/door/firedoor,
 /obj/structure/grille,
@@ -6855,16 +6765,6 @@
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/tiled/techmaint,
 /area/ship/ert/brig)
-"IP" = (
-/obj/machinery/alarm/alarms_hidden{
-	dir = 4;
-	pixel_x = -26
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/ship/ert/brig)
 "Jd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -6904,6 +6804,11 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/bridge)
+"Js" = (
+/obj/structure/ship_munition/disperser_charge/explosive,
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/reinforced,
+/area/ship/ert/hallways_aft)
 "Jx" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
@@ -6924,10 +6829,34 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/ship/ert/hallways_aft)
-"JD" = (
-/obj/machinery/door/window/brigdoor/southright,
+"Jz" = (
+/obj/structure/bed/chair/bay/chair/padded/blue{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/hallways_aft)
+"JA" = (
+/obj/machinery/button/flasher{
+	pixel_x = -9;
+	pixel_y = -22
+	},
+/obj/machinery/button/remote/blast_door{
+	dir = 1;
+	id = "braun_cells_privacy";
+	name = "Privacy Shutter Controls";
+	pixel_x = 9;
+	pixel_y = -24;
+	req_access = list(103)
+	},
+/obj/effect/floor_decal/industrial/warning,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/brig)
 "JE" = (
 /obj/structure/table/rack/steel,
 /obj/effect/floor_decal/industrial/outline/grey,
@@ -7002,33 +6931,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/ship/ert/barracks)
-"JO" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/effect/floor_decal/corner/red{
-	dir = 9
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/hallways_aft)
 "JW" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
 	dir = 9
@@ -7074,6 +6976,33 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/engine)
+"Kd" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/effect/floor_decal/corner/red{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/hallways_aft)
 "Kj" = (
 /obj/machinery/telecomms/relay,
 /turf/simulated/floor/tiled/techfloor,
@@ -7118,16 +7047,9 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/dock_star)
-"KE" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/light/no_nightshift{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/techmaint,
+"KD" = (
+/obj/machinery/door/window/brigdoor/northright,
+/turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/hallways_aft)
 "KF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -7153,13 +7075,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/dock_star)
-"KH" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/brig)
 "KK" = (
 /mob/living/simple_mob/animal/passive/mimepet,
 /turf/simulated/floor/wood,
@@ -7249,11 +7164,31 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/hallways_aft)
-"Lf" = (
-/obj/structure/ship_munition/disperser_charge/explosive,
-/obj/effect/floor_decal/industrial/warning,
-/turf/simulated/floor/reinforced,
-/area/ship/ert/hallways_aft)
+"Ld" = (
+/obj/structure/table/steel_reinforced,
+/obj/machinery/button/remote/blast_door{
+	dir = 4;
+	id = "braun_cells_privacy";
+	name = "Privacy Shutter Controls";
+	pixel_x = -24;
+	pixel_y = -9;
+	req_access = list(103)
+	},
+/obj/item/weapon/handcuffs,
+/obj/item/weapon/handcuffs,
+/obj/item/weapon/handcuffs,
+/obj/item/weapon/handcuffs,
+/obj/item/weapon/handcuffs/legcuffs,
+/obj/item/weapon/handcuffs/legcuffs,
+/obj/item/weapon/handcuffs/legcuffs,
+/obj/item/weapon/handcuffs/legcuffs,
+/obj/machinery/firealarm/alarms_hidden{
+	dir = 8;
+	pixel_x = -26;
+	pixel_y = 5
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/brig)
 "Lh" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -7404,6 +7339,13 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/ship/ert/med)
+"LL" = (
+/obj/machinery/alarm/alarms_hidden{
+	dir = 4;
+	pixel_x = -26
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/ship/ert/brig)
 "LM" = (
 /turf/simulated/floor/reinforced/airless,
 /area/ship/ert/eng_storage)
@@ -7522,6 +7464,10 @@
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/hallways)
+"Mi" = (
+/obj/machinery/door/window/brigdoor/southleft,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/hallways_aft)
 "Mj" = (
 /obj/machinery/door/airlock/glass_medical{
 	name = "Medical Bay";
@@ -7703,16 +7649,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/ship/ert/hangar)
-"MO" = (
-/obj/machinery/light/no_nightshift{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/obj/structure/table/steel_reinforced,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/brig)
 "MQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -7740,6 +7676,10 @@
 /obj/effect/floor_decal/industrial/outline/blue,
 /turf/simulated/floor/tiled/techmaint,
 /area/ship/ert/hangar)
+"MX" = (
+/obj/machinery/flasher,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/ship/ert/brig)
 "MZ" = (
 /turf/simulated/wall/rshull,
 /area/ship/ert/med_surg)
@@ -7884,16 +7824,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/ship/ert/med_surg)
-"NO" = (
-/obj/machinery/alarm/alarms_hidden{
-	dir = 4;
-	pixel_x = -26
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/ship/ert/brig)
 "NP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -8085,13 +8015,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/hallways_aft)
-"Ow" = (
-/obj/machinery/vending/fitness{
-	dir = 1;
-	prices = list()
-	},
-/turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/hallways_aft)
 "Ox" = (
 /obj/structure/cable/green{
@@ -8506,13 +8429,6 @@
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/ship/ert/engineering)
-"PW" = (
-/obj/structure/table/steel_reinforced,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/ship/ert/brig)
 "Qb" = (
 /obj/machinery/light/no_nightshift{
 	dir = 8
@@ -8584,22 +8500,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/ship/ert/teleporter)
-"QM" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/table/steel_reinforced,
-/obj/item/device/laser_pointer/upgraded,
-/obj/item/device/laser_pointer/upgraded,
-/obj/item/device/flash,
-/obj/item/device/flash,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/brig)
 "QP" = (
 /turf/simulated/wall/rshull,
 /area/ship/ert/armoury_dl)
@@ -8642,6 +8542,11 @@
 /obj/item/weapon/extinguisher/mini,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/med)
+"QU" = (
+/obj/structure/ship_munition/disperser_charge/emp,
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/reinforced,
+/area/ship/ert/hallways_aft)
 "QV" = (
 /obj/machinery/door/firedoor/glass,
 /obj/structure/grille,
@@ -8894,6 +8799,13 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/armoury_dl)
+"Sz" = (
+/obj/machinery/vending/fitness{
+	dir = 1;
+	prices = list()
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/hallways_aft)
 "SA" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/fans/hardlight,
@@ -8916,10 +8828,6 @@
 	},
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/ship/ert/brig)
 "SE" = (
@@ -8947,6 +8855,30 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/hallways_aft)
+"SM" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/brig)
 "SN" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled/techfloor,
@@ -9233,16 +9165,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/atmos)
-"TP" = (
-/obj/machinery/flasher,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/ship/ert/brig)
 "TQ" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
@@ -9287,10 +9209,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/ship/ert/teleporter)
-"TX" = (
-/obj/machinery/door/window/brigdoor/southleft,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/hallways_aft)
 "TZ" = (
 /obj/structure/grille,
 /obj/structure/window/titanium/full,
@@ -9313,6 +9231,13 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/atmos)
+"Ug" = (
+/obj/effect/floor_decal/industrial/warning,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/brig)
 "Uk" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -9358,6 +9283,12 @@
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/tiled/techmaint,
 /area/ship/ert/brig)
+"Ux" = (
+/obj/machinery/vending/fitness{
+	prices = list()
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/hallways_aft)
 "Uy" = (
 /obj/structure/table/rack/steel,
 /obj/item/weapon/gun/energy/gun{
@@ -9478,10 +9409,6 @@
 	},
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/ship/ert/brig)
 "UY" = (
@@ -9500,6 +9427,13 @@
 /obj/structure/window/reinforced,
 /turf/simulated/floor/tiled/techmaint,
 /area/shuttle/ert_ship_boat)
+"Vf" = (
+/obj/effect/floor_decal/industrial/warning,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/brig)
 "Vg" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -9567,6 +9501,17 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/ship/ert/armoury_st)
+"VI" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/corner/red{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/ship/ert/hallways_aft)
 "VJ" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -9746,6 +9691,14 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/barracks)
+"WW" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/brig)
 "WX" = (
 /obj/machinery/recharge_station,
 /turf/simulated/floor/tiled/techfloor,
@@ -9824,7 +9777,6 @@
 /area/ship/ert/dock_star)
 "XB" = (
 /obj/structure/table/steel_reinforced,
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/ship/ert/brig)
 "XG" = (
@@ -9837,17 +9789,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/engine)
-"XI" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/table/steel_reinforced,
-/obj/item/weapon/gun/energy/sizegun,
-/obj/item/weapon/gun/energy/sizegun,
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/brig)
 "XM" = (
 /turf/simulated/floor/reinforced/airless,
 /area/ship/ert/hallways_aft)
@@ -9878,20 +9819,6 @@
 /obj/item/weapon/reagent_containers/glass/beaker/large,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/med)
-"XR" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/ship/ert/hallways_aft)
 "XS" = (
 /obj/structure/cable/yellow{
 	d1 = 2;
@@ -10035,13 +9962,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/ship/ert/med)
-"YH" = (
-/obj/machinery/vending/coffee{
-	dir = 1;
-	prices = list()
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/ship/ert/hallways_aft)
 "YK" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -10124,6 +10044,14 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/ship/ert/armoury_dl)
+"YX" = (
+/obj/machinery/vending/wallmed1/public{
+	dir = 4;
+	pixel_x = -23
+	},
+/obj/structure/table/steel_reinforced,
+/turf/simulated/floor/tiled/techfloor,
+/area/ship/ert/brig)
 "YZ" = (
 /obj/structure/closet/crate/freezer,
 /obj/item/weapon/reagent_containers/blood/OMinus,
@@ -10203,16 +10131,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/ert/med)
-"Zf" = (
-/obj/machinery/flasher,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/ship/ert/brig)
 "Zi" = (
 /obj/machinery/shieldwallgen,
 /obj/effect/floor_decal/industrial/outline/blue,
@@ -17535,22 +17453,22 @@ Gv
 Un
 XX
 XB
-NO
+LL
 OY
-eO
+pQ
 Xh
-ph
+Ld
 Oh
-iM
+YX
 wq
-Ci
+mX
 HT
-IP
-PW
+LL
+XB
 XX
 Un
 Gv
-YH
+Ap
 yl
 XM
 yz
@@ -17676,19 +17594,19 @@ SJ
 Gv
 Un
 XX
-HS
-TP
+qw
+MX
 SD
-rD
+cz
 ds
 Mm
 Nh
-QM
+jZ
 jA
-nR
+Vf
 UU
-yL
-yK
+MX
+qw
 XX
 Un
 Gv
@@ -17814,27 +17732,27 @@ yz
 yz
 XM
 yl
-gw
+cM
 Gv
 Un
 XX
 XX
 XX
 XX
-yb
+mz
 HL
-KH
-qw
-KH
+xs
+gY
+xs
 sw
-CX
+JA
 XX
 XX
 XX
 XX
 Un
 Gv
-gw
+cM
 yl
 XM
 yz
@@ -17956,27 +17874,27 @@ yz
 yz
 XM
 yl
-FE
+Jz
 Gv
 Un
 XX
-HS
-Zf
+qw
+MX
 SD
-sJ
+zT
 Ix
-ES
-jg
-XI
+WW
+SM
+iK
 Ut
-jr
+Ug
 UU
-tL
-yK
+MX
+qw
 XX
 Un
 Gv
-FE
+Jz
 yl
 XM
 yz
@@ -18098,27 +18016,27 @@ yz
 yz
 XM
 yl
-aI
+Ux
 Gv
-pi
+fS
 XX
 XB
-nI
+jB
 TZ
-MO
+xR
 IK
 Ks
 Oy
-de
+sE
 UJ
-gI
+fo
 TZ
-vY
-PW
+jB
+XB
 XX
-zK
+zR
 Gv
-Ow
+Sz
 yl
 XM
 yz
@@ -18383,25 +18301,25 @@ yz
 xx
 gx
 lm
-mO
+fu
 lR
 Ys
 Ys
 Ys
-KE
+tn
 Ys
 Ys
-ea
-JO
-bh
+nS
+Kd
+VI
 Ys
 Ys
-KE
+tn
 Ys
 Ys
 Ys
 uu
-nd
+lU
 lm
 gx
 cJ
@@ -18666,8 +18584,8 @@ yz
 yz
 XM
 DS
-CO
-kY
+QU
+iw
 WK
 DS
 sq
@@ -18676,7 +18594,7 @@ Pc
 UY
 YU
 Wq
-XR
+ut
 Sj
 Kt
 Qb
@@ -18685,8 +18603,8 @@ Kt
 Kt
 DS
 WK
-TX
-xE
+Mi
+Hz
 DS
 XM
 yz
@@ -18808,8 +18726,8 @@ yz
 XM
 DS
 DS
-Lf
-xj
+Js
+KD
 WK
 DS
 FF
@@ -18827,8 +18745,8 @@ hF
 kW
 DS
 WK
-JD
-jd
+Dy
+hU
 DS
 DS
 XM
@@ -18960,7 +18878,7 @@ Pn
 ED
 Ao
 Wq
-XR
+ut
 Sj
 zg
 Mk
@@ -19386,7 +19304,7 @@ AK
 Fz
 Ti
 Wq
-XR
+ut
 Sl
 Kt
 ZC


### PR DESCRIPTION
Some long overdue tweaks to the ERT ship. I wanted to do a more thorough job updating it, but at this point something is better than nothing. Changes:
- Added brig! 4 cells, same as the Manta/Typhon but more cramped. Not really intended for saucy prison stuff, just holding bad guys for transfer, but it does have a few things. Achieved by lengthening the ship.
- Added some bay windows covering the long corridors flanking the brig, looking out into space. Each side has a table, a couple of seats, and a couple of free vendors for snacks/drinks. A couple other vendors have also been made free.
- Some doors now have more helpful/indicative names.
- Commander's table is now hardwood because why not.
- A button on the bridge now drops shutters over all external windows except the asset protection gear and rear engine viewports. It also drops some internal shutters on the bridge as immediate feedback for whether or not it worked.