### PR TITLE
Allows ore processors to start collecting ore pieces again

### DIFF
--- a/code/modules/mining/machinery/machine_processing.dm
+++ b/code/modules/mining/machinery/machine_processing.dm
@@ -253,6 +253,12 @@
 				ore_chunk.stored_ore[ore] = 0
 			qdel(ore_chunk)
 
+	for(var/obj/item/weapon/ore/O in input.loc)
+		if(!isnull(ores_stored[O.material]))
+			ores_stored[O.material]++
+			points += (ore_values[O.material]*points_mult)
+		qdel(O)
+
 	if(!active)
 		return
 


### PR DESCRIPTION
PR that added ore chunks removed that; and individual ore pieces can still be encountered in the wild and loaded into the conveyor, so this fixes them being unprocessable.