### PR TITLE
Enables Testing Character Voices in Setup

### DIFF
--- a/code/modules/client/preference_setup/vore/02_size.dm
+++ b/code/modules/client/preference_setup/vore/02_size.dm
@@ -102,6 +102,7 @@
 	. += "<b>Scaled Appearance:</b> <a [pref.fuzzy ? "" : ""] href='?src=\ref[src];toggle_fuzzy=1'><b>[pref.fuzzy ? "Fuzzy" : "Sharp"]</b></a><br>"
 	. += "<b>Voice Frequency:</b> <a href='?src=\ref[src];voice_freq=1'>[pref.voice_freq]</a><br>"
 	. += "<b>Voice Sounds:</b> <a href='?src=\ref[src];voice_sounds_list=1'>[pref.voice_sound]</a><br>"
+	. += "<a href='?src=\ref[src];voice_test=1'><b>Test Selected Voice</b></a><br>"
 	. += "<b>Custom Speech Bubble:</b> <a href='?src=\ref[src];customize_speech_bubble=1'>[pref.custom_speech_bubble]</a><br>"
 	. += "<br>"
 	. += "<b>Relative Weight:</b>  <a href='?src=\ref[src];weight=1'>[pref.weight_vr]</a><br>"
@@ -203,5 +204,40 @@
 		else
 			pref.custom_speech_bubble = choice
 		return TOPIC_REFRESH
+
+	else if(href_list["voice_test"])
+		var/sound/S = pick(pref.voice_sound)
+		switch(pref.voice_sound)
+			if("beep-boop")
+				S = sound(pick(talk_sound))
+			if("goon speak 1")
+				S = sound(pick(goon_speak_one_sound))
+			if("goon speak 2")
+				S = sound(pick(goon_speak_two_sound))
+			if("goon speak 3")
+				S = sound(pick(goon_speak_three_sound))
+			if("goon speak 4")
+				S = sound(pick(goon_speak_four_sound))
+			if("goon speak blub")
+				S = sound(pick(goon_speak_blub_sound))
+			if("goon speak bottalk")
+				S = sound(pick(goon_speak_bottalk_sound))
+			if("goon speak buwoo")
+				S = sound(pick(goon_speak_buwoo_sound))
+			if("goon speak cow")
+				S = sound(pick(goon_speak_cow_sound))
+			if("goon speak lizard")
+				S = sound(pick(goon_speak_lizard_sound))
+			if("goon speak pug")
+				S = sound(pick(goon_speak_pug_sound))
+			if("goon speak pugg")
+				S = sound(pick(goon_speak_pugg_sound))
+			if("goon speak roach")
+				S = sound(pick(goon_speak_roach_sound))
+			if("goon speak skelly")
+				S = sound(pick(goon_speak_skelly_sound))
+		S.frequency = pick(pref.voice_freq)
+		S.volume = 50
+		SEND_SOUND(user, S)
 
 	return ..();


### PR DESCRIPTION
This function was WIP in the past on CHOMP.
I went ahead and finished this up, originally just for CHOMP, and then figured I'd backport it upstream.
Port of https://github.com/CHOMPStation2/CHOMPStation2/pull/5805

TL;DR:
You can hit "Test Character Voice" in setup, to play a preview of what your voice will sound like with the selected type and frequency.

See demonstration [here](https://streamable.com/m6u9vc).
