### PR TITLE
Makes mining drones have a smarter IFF

### DIFF
--- a/code/modules/mob/living/simple_mob/subtypes/mechanical/drones/mining_drone.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/mechanical/drones/mining_drone.dm
@@ -43,7 +43,7 @@
 	organ_names = /decl/mob_organ_names/miningdrone
 
 	ai_holder_type = /datum/ai_holder/simple_mob/ranged/kiting/threatening
-	say_list_type = /datum/say_list/malf_drone
+	say_list_type = /datum/say_list/malf_drone/mining
 
 	tame_items = list(
 	/obj/item/weapon/ore/verdantium = 90,
@@ -66,6 +66,8 @@
 
 	var/last_search = 0
 	var/search_cooldown = 5 SECONDS
+	var/ignoreunarmed = TRUE
+	var/allowedtools = list(/obj/item/weapon/pickaxe, /obj/item/weapon/gun/energy/kinetic_accelerator, /obj/item/weapon/gun/magnetic/matfed/phoronbore, /obj/item/weapon/kinetic_crusher)
 
 /mob/living/simple_mob/mechanical/mining_drone/Initialize()
 	ion_trail = new
@@ -99,11 +101,51 @@
 		return .
 
 	if(!.)
+		if(ai_holder.check_attacker(H)) //it doesn't care how nicely you're geared if you've attacked it
+			return FALSE
+
 		var/has_tool = FALSE
 		var/obj/item/I = H.get_active_hand()
-		if(istype(I,/obj/item/weapon/pickaxe))
-			has_tool = TRUE
+		if(!istype(I,/obj/item/weapon))
+			if(ignoreunarmed)
+				return TRUE
+			else //just so they don't attack "miners" for having their mining gear in their offhand
+				var/obj/item/OH = H.get_inactive_hand()
+				if(OH)
+					for (var/path in allowedtools)
+						if(istype(OH,path))
+							has_tool = TRUE
+							break
+		else
+			for (var/path in allowedtools)
+				if(istype(I,path))
+					has_tool = TRUE
+					break
+			if(!has_tool) //if a valid tool not found in main hand, check offhand
+				var/obj/item/OH = H.get_inactive_hand()
+				if(OH)
+					for (var/path in allowedtools)
+						if(istype(OH,path))
+							has_tool = TRUE
+							break
 		return has_tool
+
+// extra IFF aside from the above - will detect and react to the following attacks from allies (necessary as IIsAlly prevents retaliation if true)
+/mob/living/simple_mob/mechanical/mining_drone/attack_hand(mob/living/L)
+	..()
+	if(istype(L) && L.a_intent != I_HELP)
+		if(ai_holder)
+			ai_holder.add_attacker(L)
+
+/mob/living/simple_mob/mechanical/mining_drone/bullet_act(var/obj/item/projectile/P, var/def_zone)
+	..()
+	if(ai_holder && P.firer)
+		ai_holder.add_attacker(P.firer)
+
+/mob/living/simple_mob/mechanical/mining_drone/hit_with_weapon(obj/item/I, mob/living/user, var/effective_force, var/hit_zone)
+	..()
+	if(ai_holder)
+		ai_holder.add_attacker(user)
 
 /mob/living/simple_mob/mechanical/mining_drone/handle_special()
 	if(my_storage && (get_AI_stance() in list(STANCE_APPROACH, STANCE_IDLE, STANCE_FOLLOW)) && !is_AI_busy() && isturf(loc) && (world.time > last_search + search_cooldown) && (my_storage.contents.len < my_storage.max_storage_space))
@@ -129,3 +171,12 @@
 
 /decl/mob_organ_names/miningdrone
 	hit_zones = list("chassis", "comms array", "sensor suite", "left excavator module", "right excavator module", "maneuvering thruster")
+
+/datum/say_list/malf_drone/mining
+	say_threaten = list("Armed intruder detected.", "Lay down your weapons.", "Mining personnel only.", "Threat detected.", "Mining gear check: negative.")
+
+/mob/living/simple_mob/mechanical/mining_drone/scavenger //more aggro version for the debris field, with a weaker weapon
+	name = "scavenger drone"
+	ignoreunarmed = FALSE
+	allowedtools = list(/obj/item/weapon/pickaxe)
+	projectiletype = /obj/item/projectile/energy/excavate/weak

--- a/code/modules/projectiles/projectile/energy.dm
+++ b/code/modules/projectiles/projectile/energy.dm
@@ -131,6 +131,10 @@
 	combustion = FALSE
 	hud_state = "plasma_blast"
 
+/obj/item/projectile/energy/excavate/weak
+	damage = 15
+	excavation_amount = 100
+
 /obj/item/projectile/energy/dart
 	name = "dart"
 	icon_state = "toxin"


### PR DESCRIPTION
Mining drones are now somewhat more forgiving when it comes to detecting threats. From humans, at least - cyborgs will be treated exactly as before.

Instead of checking for a pickaxe in the active hand only, they now check your off-hand if they fail to find one there, and also look for kinetic crushers, phoron bores and kinetic accelerators. They will also (by default) ignore you if you don't have a weapon in your active hand at all.

Note, however, that they will now no longer ignore you walking up and smashing them to pieces with a pickaxe. Did you know you could do that? Well, you can't any more.

Adds scavenger drones, which are less forgiving - they don't care if you have an empty hand, they don't care about fancy equipment, they want to see a pickaxe or they want to see your blood.

Thankfully, these more aggressive scavenger drones only deal half as much damage.