### PR TITLE
Fixes window icons on luxury yacht, nerfs royal spider eggs

### DIFF
--- a/maps/submaps/pois_vr/debris_field/debrisfield_things.dm
+++ b/maps/submaps/pois_vr/debris_field/debrisfield_things.dm
@@ -141,6 +141,29 @@
 	storedinfo += "09:13	*gruesome sounds of machines exploding, wet splatter and ominous hissing"
 	used_capacity = 1755 //almost full
 
+/obj/item/royal_spider_egg/tourist
+	name = "damaged royal spider egg"
+	desc = "This one is yet to be imprinted! It's a cointoss if the creature inside still lives..."
+	var/egg_health = 10 //probability of the egg containing a healthy spiderling.
+
+/obj/item/royal_spider_egg/tourist/attack_self(mob/user as mob)
+	var/response = tgui_alert(user, "Are you sure you want to try releasing the royal spiderling right now? \
+	It appears ready to imprint the moment its born.", "Royal Spider Egg", list("Yes", "No"))
+
+	if(response == "Yes")
+		var/turf/drop_loc = user.loc
+		if(!istype(drop_loc))
+			to_chat(user, "You need more space to release the egg!")
+		else if(prob(egg_health))
+			var/obj/effect/spider/spiderling/princess/royalty = new(drop_loc)
+			royalty.faction = user.faction //this can cause immense chaos, but it's low probability and admins said it's within limits.
+			qdel(src)
+		else
+			to_chat(user, SPAN_WARNING("The egg cracks open, splattering disgusting goop at your feet...\n \
+			Whatever life laid within shall never awaken, if it was even alive."))
+			new /obj/effect/decal/cleanable/spiderling_remains(drop_loc)
+			qdel(src)
+
 // End of Tourist ship stuff
 
 /obj/random/slimecore

--- a/maps/submaps/pois_vr/debris_field/debrisfield_things.dm
+++ b/maps/submaps/pois_vr/debris_field/debrisfield_things.dm
@@ -141,12 +141,14 @@
 	storedinfo += "09:13	*gruesome sounds of machines exploding, wet splatter and ominous hissing"
 	used_capacity = 1755 //almost full
 
-/obj/item/royal_spider_egg/tourist
+/obj/item/space_spider_egg
 	name = "ruptured giant spider egg"
 	desc = "An attempt by space-adapted giant spiders to reproduce! Unfortunately, their young cannot yet survive hard vacuum. Yet."
-	var/egg_health = 10 //probability of the egg containing a healthy spiderling.
+	icon = 'icons/obj/egg_new_vr.dmi'	//VOREStation Edit
+	icon_state = "egg_slimeglob"
+	origin_tech = list(TECH_BIO = 10)
 
-/obj/item/royal_spider_egg/tourist/attack_self(mob/user as mob)
+/obj/item/space_spider_egg/attack_self(mob/user as mob)
 	var/turf/drop_loc = user.loc
 	to_chat(user, SPAN_WARNING("The egg cracks open, splattering disgusting goop at your feet...\n \
 	Whatever life laid within shall never awaken, if it was even alive."))

--- a/maps/submaps/pois_vr/debris_field/debrisfield_things.dm
+++ b/maps/submaps/pois_vr/debris_field/debrisfield_things.dm
@@ -142,27 +142,16 @@
 	used_capacity = 1755 //almost full
 
 /obj/item/royal_spider_egg/tourist
-	name = "damaged royal spider egg"
-	desc = "This one is yet to be imprinted! It's a cointoss if the creature inside still lives..."
+	name = "ruptured giant spider egg"
+	desc = "An attempt by space-adapted giant spiders to reproduce! Unfortunately, their young cannot yet survive hard vacuum. Yet."
 	var/egg_health = 10 //probability of the egg containing a healthy spiderling.
 
 /obj/item/royal_spider_egg/tourist/attack_self(mob/user as mob)
-	var/response = tgui_alert(user, "Are you sure you want to try releasing the royal spiderling right now? \
-	It appears ready to imprint the moment its born.", "Royal Spider Egg", list("Yes", "No"))
-
-	if(response == "Yes")
-		var/turf/drop_loc = user.loc
-		if(!istype(drop_loc))
-			to_chat(user, "You need more space to release the egg!")
-		else if(prob(egg_health))
-			var/obj/effect/spider/spiderling/princess/royalty = new(drop_loc)
-			royalty.faction = user.faction //this can cause immense chaos, but it's low probability and admins said it's within limits.
-			qdel(src)
-		else
-			to_chat(user, SPAN_WARNING("The egg cracks open, splattering disgusting goop at your feet...\n \
-			Whatever life laid within shall never awaken, if it was even alive."))
-			new /obj/effect/decal/cleanable/spiderling_remains(drop_loc)
-			qdel(src)
+	var/turf/drop_loc = user.loc
+	to_chat(user, SPAN_WARNING("The egg cracks open, splattering disgusting goop at your feet...\n \
+	Whatever life laid within shall never awaken, if it was even alive."))
+	new /obj/effect/decal/cleanable/spiderling_remains(drop_loc)
+	qdel(src)
 
 // End of Tourist ship stuff
 

--- a/maps/submaps/pois_vr/debris_field/ship_tourist_overrun.dmm
+++ b/maps/submaps/pois_vr/debris_field/ship_tourist_overrun.dmm
@@ -1102,7 +1102,7 @@
 	},
 /obj/effect/map_helper/airlock/atmos/chamber_pump,
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	id_tag = tourist_airlock;
+	id_tag = "tourist_airlock";
 	pixel_y = -30
 	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{

--- a/maps/submaps/pois_vr/debris_field/ship_tourist_overrun.dmm
+++ b/maps/submaps/pois_vr/debris_field/ship_tourist_overrun.dmm
@@ -208,7 +208,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/item/royal_spider_egg/tourist,
+/obj/item/space_spider_egg,
 /turf/simulated/floor/airless,
 /area/submap/debrisfield/luxury_boat/engine)
 "eM" = (
@@ -817,7 +817,7 @@
 /obj/structure/cable/green{
 	icon_state = "1-8"
 	},
-/obj/item/royal_spider_egg/tourist,
+/obj/item/space_spider_egg,
 /turf/simulated/shuttle/plating/airless/carry,
 /area/submap/debrisfield/luxury_boat/engine)
 "wz" = (
@@ -1395,7 +1395,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/item/royal_spider_egg/tourist,
+/obj/item/space_spider_egg,
 /turf/simulated/floor/airless,
 /area/submap/debrisfield/luxury_boat/engine)
 "OP" = (

--- a/maps/submaps/pois_vr/debris_field/ship_tourist_overrun.dmm
+++ b/maps/submaps/pois_vr/debris_field/ship_tourist_overrun.dmm
@@ -154,7 +154,7 @@
 /area/submap/debrisfield/luxury_boat/crew)
 "ds" = (
 /obj/structure/shuttle/window,
-/turf/simulated/wall/fancy_shuttle/window,
+/turf/simulated/shuttle/floor/glass,
 /area/submap/debrisfield/luxury_boat/crew)
 "ea" = (
 /obj/structure/table/rack/gun_rack,
@@ -763,7 +763,7 @@
 /area/submap/debrisfield/luxury_boat/crew)
 "vc" = (
 /obj/structure/shuttle/window,
-/turf/simulated/wall/fancy_shuttle/window,
+/turf/simulated/shuttle/floor/glass,
 /area/submap/debrisfield/luxury_boat/bridge)
 "vl" = (
 /obj/machinery/door/window,

--- a/maps/submaps/pois_vr/debris_field/ship_tourist_overrun.dmm
+++ b/maps/submaps/pois_vr/debris_field/ship_tourist_overrun.dmm
@@ -202,13 +202,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/item/royal_spider_egg,
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/item/royal_spider_egg/tourist,
 /turf/simulated/floor/airless,
 /area/submap/debrisfield/luxury_boat/engine)
 "eM" = (
@@ -814,10 +814,10 @@
 /area/submap/debrisfield/luxury_boat/crew)
 "wy" = (
 /obj/structure/lattice,
-/obj/item/royal_spider_egg,
 /obj/structure/cable/green{
 	icon_state = "1-8"
 	},
+/obj/item/royal_spider_egg/tourist,
 /turf/simulated/shuttle/plating/airless/carry,
 /area/submap/debrisfield/luxury_boat/engine)
 "wz" = (
@@ -1389,13 +1389,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/item/royal_spider_egg,
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/item/royal_spider_egg/tourist,
 /turf/simulated/floor/airless,
 /area/submap/debrisfield/luxury_boat/engine)
 "OP" = (


### PR DESCRIPTION
Windows were apparently having a glitchy icon with my attempt to make them transparent. Tried a new attempt, this works.

Also, I was informed that you can use royal spider eggs in your hands - which, given I had 3 of them mapped in... would've caused immense chaos.

Made it so that the POI has a unique subtype of royal spider eggs that has a var-based probability of being crushed when used in your hand [(100-egg_health) probability, so 90% chance on default]. This means there is 3 rolls to spawn a spider princess at 10% chance, which should make it a unique reward to play with BUT avoid the utter chaos it'd cause if it was guaranteed.