### PR TITLE
Adds new POI to RP, creates scug spawner object

### DIFF
--- a/code/game/objects/random/mob_vr.dm
+++ b/code/game/objects/random/mob_vr.dm
@@ -250,3 +250,57 @@
 				prob(1);/obj/random/coin,
 				prob(1);/obj/random/drinkbottle,
 				prob(1);/obj/random/tool/alien)
+
+//Scug spawner for the picnic!
+/obj/random/mob/wildscugs
+	name = "Random catslug spawner"
+	desc = "Spawns catslugs with random colours!"
+	icon_state = "vore"
+	mob_faction = "vore"
+	spawn_nothing_percentage = 25
+	mob_wander_distance = 4
+	mob_wander = 1
+	mob_returns_home = 1
+	var/newname = null
+	var/newdesc = null
+
+
+/obj/random/mob/wildscugs/item_to_spawn()
+	return pick(prob(99); /mob/living/simple_mob/vore/alienanimals/catslug,
+				prob(1); /mob/living/simple_mob/vore/alienanimals/catslug/suslug/color) //A super rare surprise
+
+/obj/random/mob/wildscugs/spawn_item()
+	var/build_path = item_to_spawn()
+
+	var/mob/living/simple_mob/M = new build_path(src.loc)
+	if(!istype(M))
+		return
+	if(M.has_AI())
+		var/datum/ai_holder/AI = M.ai_holder
+		AI.go_sleep() //Don't fight eachother while we're still setting up!
+		AI.returns_home = mob_returns_home
+		AI.wander = mob_wander
+		AI.max_home_distance = mob_wander_distance
+		if(overwrite_hostility)
+			AI.hostile = mob_hostile
+			AI.retaliate = mob_retaliate
+		AI.go_wake() //Now you can kill eachother if your faction didn't override.
+
+	if(pixel_x || pixel_y)
+		M.pixel_x = pixel_x
+		M.pixel_y = pixel_y
+
+	if(mob_faction)
+		M.faction = mob_faction
+
+	M.color = pick(COLOR_WHITE, COLOR_RED, COLOR_PURPLE, COLOR_YELLOW, COLOR_CYAN_BLUE, COLOR_RED_GRAY, COLOR_BEIGE, COLOR_PINK, COLOR_BLACK)
+	if(newname)
+		if(islist(newname))
+			M.name = pick(newname)
+		else
+			M.name = newname
+	if(newdesc)
+		if(islist(newdesc))
+			M.desc = pick(newdesc)
+		else
+			M.desc = newdesc

--- a/maps/groundbase/groundbase_poi_stuff.dm
+++ b/maps/groundbase/groundbase_poi_stuff.dm
@@ -13,6 +13,7 @@
 #include "pois/outdoors12.dmm"
 #include "pois/outdoors13.dmm"
 #include "pois/outdoors14.dmm"
+#include "pois/outdoors16.dmm"
 
 #include "pois/cave1.dmm"
 #include "pois/cave2.dmm"
@@ -220,6 +221,7 @@
 	mappath = 'pois/outdoors1.dmm'
 	cost = 10
 	allow_duplicates = TRUE
+
 /datum/map_template/groundbase/outdoor/thing2
 	name = "Outdoors2"
 	mappath = 'pois/outdoors2.dmm'
@@ -266,6 +268,10 @@
 /datum/map_template/groundbase/outdoor/thing15
 	name = "Outdoors15"
 	mappath = 'pois/outdoors15.dmm'
+	allow_duplicates = FALSE
+/datum/map_template/groundbase/outdoor/thing16
+	name = "Outdoors16"
+	mappath = 'pois/outdoors16.dmm'
 	allow_duplicates = FALSE
 
 /datum/map_template/groundbase/maintcaves/cave

--- a/maps/groundbase/pois/outdoors16.dmm
+++ b/maps/groundbase/pois/outdoors16.dmm
@@ -1,0 +1,221 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/obj/item/weapon/reagent_containers/food/snacks/chip/nacho/cheese,
+/turf/simulated/floor/outdoors/grass/seasonal/nomobs,
+/area/template_noop)
+"b" = (
+/obj/item/weapon/reagent_containers/food/snacks/chip/nacho/salsa,
+/turf/simulated/floor/outdoors/grass/seasonal/nomobs,
+/area/template_noop)
+"c" = (
+/obj/random/drinkbottle,
+/turf/simulated/floor/outdoors/grass/seasonal/nomobs,
+/area/template_noop)
+"d" = (
+/obj/structure/table/wooden_reinforced,
+/obj/item/weapon/storage/toolbox/lunchbox/cat/filled{
+	pixel_y = 8
+	},
+/obj/item/weapon/storage/toolbox/lunchbox/nymph/filled,
+/obj/item/clothing/suit/leathercoat{
+	desc = "Who would use a leather coat as a tablecloth?!";
+	name = "Tablecloth?!";
+	pixel_x = 5
+	},
+/obj/item/clothing/suit/greatcoat{
+	desc = "This great coat appears covered in food! Did... it get stolen and reused as ... ?!";
+	name = "Tablecloth?";
+	pixel_x = -9
+	},
+/turf/simulated/floor/outdoors/grass/seasonal/notrees_nomobs_nosnow,
+/area/template_noop)
+"g" = (
+/obj/effect/decal/cleanable/fruit_smudge,
+/obj/item/weapon/storage/mre/random,
+/turf/simulated/floor/outdoors/grass/seasonal/notrees_nomobs_lowsnow,
+/area/template_noop)
+"h" = (
+/obj/structure/table/bench/wooden,
+/obj/effect/decal/cleanable/filth,
+/obj/random/mob/wildscugs{
+	newdesc = "A wild catslug enjoying the simpler things in life: a picnic!";
+	newname = list("happy catslug", "rotund catslug", "anxious catslug", "angry Catslug", "content Catslug", "sad catslug")
+	},
+/turf/simulated/floor/outdoors/grass/seasonal/notrees_nomobs_nosnow,
+/area/template_noop)
+"i" = (
+/obj/structure/table/wooden_reinforced,
+/obj/random/pizzabox,
+/obj/item/weapon/storage/toolbox/lunchbox/mars/filled{
+	pixel_x = -10;
+	pixel_y = 11
+	},
+/obj/item/weapon/bedsheet/rd{
+	desc = "Is this Nubbins' doing?!";
+	name = "Strange tablecloth";
+	pixel_x = 11;
+	pixel_y = 12
+	},
+/obj/random/mug,
+/turf/simulated/floor/outdoors/grass/seasonal/notrees_nomobs_nosnow,
+/area/template_noop)
+"k" = (
+/obj/random/drinkbottle,
+/turf/simulated/floor/outdoors/grass/seasonal/notrees_nomobs_lowsnow,
+/area/template_noop)
+"m" = (
+/obj/random/coin,
+/turf/simulated/floor/outdoors/grass/seasonal/nomobs,
+/area/template_noop)
+"n" = (
+/obj/effect/decal/cleanable/filth,
+/turf/simulated/floor/outdoors/grass/seasonal/notrees_nomobs_lowsnow,
+/area/template_noop)
+"p" = (
+/obj/random/junk,
+/turf/simulated/floor/outdoors/grass/seasonal/nomobs,
+/area/template_noop)
+"s" = (
+/obj/structure/table/bench/wooden,
+/obj/random/mob/wildscugs{
+	newdesc = "A wild catslug enjoying the simpler things in life: a picnic!";
+	newname = list("happy catslug", "rotund catslug", "anxious catslug", "angry Catslug", "content Catslug", "sad catslug")
+	},
+/obj/item/weapon/ore/diamond{
+	name = "porl"
+	},
+/turf/simulated/floor/outdoors/grass/seasonal/notrees_nomobs_nosnow,
+/area/template_noop)
+"t" = (
+/obj/item/pizzavoucher,
+/turf/simulated/floor/outdoors/grass/seasonal/nomobs,
+/area/template_noop)
+"w" = (
+/obj/item/trash/chipbasket,
+/turf/simulated/floor/outdoors/grass/seasonal/nomobs,
+/area/template_noop)
+"z" = (
+/obj/random/drinksoft,
+/turf/simulated/floor/outdoors/grass/seasonal/notrees_nomobs_lowsnow,
+/area/template_noop)
+"A" = (
+/turf/simulated/floor/outdoors/grass/seasonal/nomobs,
+/area/template_noop)
+"F" = (
+/obj/structure/table/bench/wooden,
+/obj/random/mob/wildscugs{
+	newdesc = "A wild catslug enjoying the simpler things in life: a picnic!";
+	newname = list("happy catslug", "rotund catslug", "anxious catslug", "angry Catslug", "content Catslug", "sad catslug")
+	},
+/obj/item/weapon/material/twohanded/spear/foam{
+	desc = "The only way you can hunt things with this is by tickling them to death.";
+	name = "squishy foam spear"
+	},
+/turf/simulated/floor/outdoors/grass/seasonal/notrees_nomobs_nosnow,
+/area/template_noop)
+"J" = (
+/obj/structure/table/bench/wooden,
+/obj/random/mob/wildscugs{
+	newdesc = "A wild catslug enjoying the simpler things in life: a picnic!";
+	newname = list("happy catslug", "rotund catslug", "anxious catslug", "angry Catslug", "content Catslug", "sad catslug")
+	},
+/turf/simulated/floor/outdoors/grass/seasonal/notrees_nomobs_nosnow,
+/area/template_noop)
+"L" = (
+/obj/effect/decal/remains/lizard,
+/turf/simulated/floor/outdoors/grass/seasonal/nomobs,
+/area/template_noop)
+"N" = (
+/obj/structure/table/wooden_reinforced,
+/obj/item/weapon/bedsheet/hosdouble{
+	desc = "Odd, this tablecloth looks... suspiciously like the bedsheets NanoTrasen security staff use!";
+	name = "Picnic Blanket"
+	},
+/obj/item/weapon/bedsheet/hosdouble{
+	desc = "Odd, this tablecloth looks... suspiciously like the bedsheets NanoTrasen security staff use!";
+	name = "Picnic Blanket";
+	pixel_x = 11
+	},
+/obj/item/weapon/storage/toolbox/lunchbox/heart/filled,
+/turf/simulated/floor/outdoors/grass/seasonal/notrees_nomobs_nosnow,
+/area/template_noop)
+"O" = (
+/obj/structure/table/bench/wooden,
+/obj/random/mob/wildscugs{
+	newdesc = "A wild catslug enjoying the simpler things in life: a picnic!";
+	newname = list("happy catslug", "rotund catslug", "anxious catslug", "angry Catslug", "content Catslug", "sad catslug")
+	},
+/obj/random/mug,
+/turf/simulated/floor/outdoors/grass/seasonal/notrees_nomobs_nosnow,
+/area/template_noop)
+"Q" = (
+/obj/random/cigarettes,
+/turf/simulated/floor/outdoors/grass/seasonal/nomobs,
+/area/template_noop)
+"S" = (
+/obj/structure/table/bench/wooden,
+/obj/item/weapon/towel/random,
+/obj/random/mob/wildscugs{
+	newdesc = "A wild catslug enjoying the simpler things in life: a picnic!";
+	newname = list("happy catslug", "rotund catslug", "anxious catslug", "angry Catslug", "content Catslug", "sad catslug")
+	},
+/turf/simulated/floor/outdoors/grass/seasonal/notrees_nomobs_nosnow,
+/area/template_noop)
+"T" = (
+/obj/effect/decal/cleanable/tomato_smudge,
+/turf/simulated/floor/outdoors/grass/seasonal/notrees_nomobs_lowsnow,
+/area/template_noop)
+"Y" = (
+/obj/random/drinksoft,
+/turf/simulated/floor/outdoors/grass/seasonal/nomobs,
+/area/template_noop)
+
+(1,1,1) = {"
+c
+A
+A
+A
+A
+"}
+(2,1,1) = {"
+a
+T
+n
+n
+Y
+"}
+(3,1,1) = {"
+Q
+s
+h
+J
+w
+"}
+(4,1,1) = {"
+L
+N
+d
+i
+b
+"}
+(5,1,1) = {"
+t
+F
+O
+S
+m
+"}
+(6,1,1) = {"
+L
+z
+g
+k
+A
+"}
+(7,1,1) = {"
+A
+A
+A
+A
+p
+"}


### PR DESCRIPTION
Adds a new outdoors POI to Rascal's Pass.
Goal is comedy/light-heartedness where a gang of catslugs (6 rolls to spawn a scug, 25% chance to discord) have raided Rascal's during B shift and stole the HoS/RD's bedsheet, a bunch of jackets and coats and decided to hold a picnic !

To facilitate scuggery, a new mob spawner was made that creates scugs with variable colours, and if defined, allows for them to spawn with a pre-made name or pick from a list of custom names! It also allows doing the same for descriptions.

![image](https://user-images.githubusercontent.com/20523270/222550878-16d2f7f2-3ff3-42af-a849-3eaf783c31e9.png)


Tiles used are "nomob" for outside, nomob,notree,lowsnow around the table and nosnow+everything else under the table.

The "tablecloths" each have a unique name and description. Drinks are randomized.