### PR TITLE
Start With Backup Implant setting

### DIFF
--- a/code/controllers/subsystems/ticker.dm
+++ b/code/controllers/subsystems/ticker.dm
@@ -441,11 +441,12 @@ var/global/datum/controller/subsystem/ticker/ticker
 				//equip_custom_items(player)	//VOREStation Removal
 				//player.apply_traits() //VOREStation Removal
 		//VOREStation Addition Start
-		if(player.client.prefs.auto_backup_implant)
-			var/obj/item/weapon/implant/backup/imp = new(src)
+		if(player.client)
+			if(player.client.prefs.auto_backup_implant)
+				var/obj/item/weapon/implant/backup/imp = new(src)
 
-			if(imp.handle_implant(player,player.zone_sel.selecting))
-				imp.post_implant(player)
+				if(imp.handle_implant(player,player.zone_sel.selecting))
+					imp.post_implant(player)
 		//VOREStation Addition End
 	if(captainless)
 		for(var/mob/M in player_list)

--- a/code/controllers/subsystems/ticker.dm
+++ b/code/controllers/subsystems/ticker.dm
@@ -440,6 +440,13 @@ var/global/datum/controller/subsystem/ticker/ticker
 				UpdateFactionList(player)
 				//equip_custom_items(player)	//VOREStation Removal
 				//player.apply_traits() //VOREStation Removal
+		//VOREStation Addition Start
+		if(player.client.prefs.auto_backup_implant)
+			var/obj/item/weapon/implant/backup/imp = new(src)
+
+			if(imp.handle_implant(player,player.zone_sel.selecting))
+				imp.post_implant(player)
+		//VOREStation Addition End
 	if(captainless)
 		for(var/mob/M in player_list)
 			if(!istype(M,/mob/new_player))

--- a/code/modules/client/preference_setup/vore/09_misc.dm
+++ b/code/modules/client/preference_setup/vore/09_misc.dm
@@ -9,6 +9,7 @@
 	S["directory_ad"]			>> pref.directory_ad
 	S["sensorpref"]				>> pref.sensorpref
 	S["capture_crystal"]		>> pref.capture_crystal
+	S["auto_backup_implant"]	>> pref.auto_backup_implant
 
 /datum/category_item/player_setup_item/vore/misc/save_character(var/savefile/S)
 	S["show_in_directory"]		<< pref.show_in_directory
@@ -17,7 +18,7 @@
 	S["directory_ad"]			<< pref.directory_ad
 	S["sensorpref"]				<< pref.sensorpref
 	S["capture_crystal"]		<< pref.capture_crystal
-
+	S["auto_backup_implant"]	<< pref.auto_backup_implant
 
 /datum/category_item/player_setup_item/vore/misc/copy_to_mob(var/mob/living/carbon/human/character)
 	if(pref.sensorpref > 5 || pref.sensorpref < 1)
@@ -31,6 +32,7 @@
 	pref.directory_erptag			= sanitize_inlist(pref.directory_erptag, GLOB.char_directory_erptags, initial(pref.directory_erptag))
 	pref.sensorpref				= sanitize_integer(pref.sensorpref, 1, sensorpreflist.len, initial(pref.sensorpref))
 	pref.capture_crystal		= sanitize_integer(pref.capture_crystal, 0, 1, initial(pref.capture_crystal))
+	pref.auto_backup_implant		= sanitize_integer(pref.auto_backup_implant, 0, 1, initial(pref.auto_backup_implant))
 
 /datum/category_item/player_setup_item/vore/misc/content(var/mob/user)
 	. += "<br>"
@@ -39,7 +41,8 @@
 	. += "<b>Character Directory ERP Tag:</b> <a href='?src=\ref[src];directory_erptag=1'><b>[pref.directory_erptag]</b></a><br>"
 	. += "<b>Character Directory Advertisement:</b> <a href='?src=\ref[src];directory_ad=1'><b>Set Directory Ad</b></a><br>"
 	. += "<b>Suit Sensors Preference:</b> <a [pref.sensorpref ? "" : ""] href='?src=\ref[src];toggle_sensor_setting=1'><b>[sensorpreflist[pref.sensorpref]]</b></a><br>"
-	. += "<b>Capture Crystal Preference</b> <a [pref.capture_crystal ? "class='linkOn'" : ""] href='?src=\ref[src];toggle_capture_crystal=1'><b>[pref.capture_crystal ? "Yes" : "No"]</b></a><br>"
+	. += "<b>Capture Crystal Preference:</b> <a [pref.capture_crystal ? "class='linkOn'" : ""] href='?src=\ref[src];toggle_capture_crystal=1'><b>[pref.capture_crystal ? "Yes" : "No"]</b></a><br>"
+	. += "<b>Spawn With Backup Implant:</b> <a [pref.auto_backup_implant ? "class='linkOn'" : ""] href='?src=\ref[src];toggle_implant=1'><b>[pref.auto_backup_implant ? "Yes" : "No"]</b></a><br>"
 
 /datum/category_item/player_setup_item/vore/misc/OnTopic(var/href, var/list/href_list, var/mob/user)
 	if(href_list["toggle_show_in_directory"])
@@ -71,5 +74,7 @@
 	else if(href_list["toggle_capture_crystal"])
 		pref.capture_crystal = pref.capture_crystal ? 0 : 1;
 		return TOPIC_REFRESH
-
+	else if(href_list["toggle_implant"])
+		pref.auto_backup_implant = pref.auto_backup_implant ? 0 : 1;
+		return TOPIC_REFRESH
 	return ..();

--- a/code/modules/client/preferences_vr.dm
+++ b/code/modules/client/preferences_vr.dm
@@ -5,6 +5,7 @@
 	var/directory_ad = ""		//Advertisement stuff to show in character directory.
 	var/sensorpref = 5			//Set character's suit sensor level
 	var/capture_crystal = 1	//Whether or not someone is able to be caught with capture crystals
+	var/auto_backup_implant = FALSE //Whether someone starts with a backup implant or not.
 
 	var/job_talon_high = 0
 	var/job_talon_med = 0

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -487,6 +487,12 @@
 		data_core.manifest_inject(character)
 		ticker.minds += character.mind//Cyborgs and AIs handle this in the transform proc.	//TODO!!!!! ~Carn
 
+	if(character.client.prefs.auto_backup_implant)
+		var/obj/item/weapon/implant/backup/imp = new(src)
+
+		if(imp.handle_implant(character,character.zone_sel.selecting))
+			imp.post_implant(character)
+
 	qdel(src) // Delete new_player mob
 
 /mob/new_player/proc/AnnounceCyborg(var/mob/living/character, var/rank, var/join_message, var/channel, var/zlevel)

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -486,12 +486,12 @@
 		AnnounceArrival(character, rank, join_message, announce_channel, character.z)
 		data_core.manifest_inject(character)
 		ticker.minds += character.mind//Cyborgs and AIs handle this in the transform proc.	//TODO!!!!! ~Carn
+	if(ishuman(character))
+		if(character.client.prefs.auto_backup_implant)
+			var/obj/item/weapon/implant/backup/imp = new(src)
 
-	if(character.client.prefs.auto_backup_implant)
-		var/obj/item/weapon/implant/backup/imp = new(src)
-
-		if(imp.handle_implant(character,character.zone_sel.selecting))
-			imp.post_implant(character)
+			if(imp.handle_implant(character,character.zone_sel.selecting))
+				imp.post_implant(character)
 
 	qdel(src) // Delete new_player mob
 


### PR DESCRIPTION
Allows one to spawn with a backup implant. Rather than requiring it to be obtained literally every single time you spawn, you can just spawn with one instead, if you don't want to go to medical!

ICly there's no real reason why you would get your implant removed every shift, and OOCly if for some reason we decide to make resleeving not possible one shift, we're going to remove the resleevers, not the implants, so this should only really affect people who don't like getting implants every shift, and should make things a little less stressful for medical.

This option defaults to 'off'. It must be enabled to spawn your character with an implant.