### PR TITLE
Replaces mining drones with salvage drones. Splits them up

### DIFF
--- a/maps/submaps/pois_vr/debris_field/mining_drones.dmm
+++ b/maps/submaps/pois_vr/debris_field/mining_drones.dmm
@@ -6,9 +6,7 @@
 /turf/simulated/mineral/vacuum,
 /area/space)
 "c" = (
-/mob/living/simple_mob/mechanical/mining_drone{
-	faction = "poi_mining_drones"
-	},
+/mob/living/simple_mob/mechanical/mining_drone/scavenger,
 /turf/simulated/floor/airless,
 /area/submap/debrisfield/mining_outpost)
 "d" = (
@@ -86,6 +84,7 @@
 /area/submap/debrisfield/mining_outpost)
 "p" = (
 /obj/item/weapon/material/shard,
+/mob/living/simple_mob/mechanical/mining_drone/scavenger,
 /turf/space,
 /area/space)
 "q" = (
@@ -262,9 +261,9 @@ v
 a
 B
 f
-c
 f
 c
+f
 f
 f
 "}


### PR DESCRIPTION
https://github.com/VOREStation/VOREStation/pull/14575

Mining drones were a major challenge in the debris field for players, heavily punishing mistakes like slipping and then wiped parties when they brought them back to the ship by accident.

This PR replaces the mining drones with the salvage subtype - dealing half as much damage, allowing players to learn and adapt rather than taking them out very quickly. They should still be one of the highest threats of common POIs though.

Furthermore, it splits the salvage drones to spawn on separate sides, trying to make unfortunate POI placement where the mining drones are placed right next to the shuttle and consequently aggro the team before they get their bearings.

Edited to add since mapdiff bot JUST SO HAPPENED TO CUT OFF THE RELEVANT PART:

How the spawns are now:
![image](https://user-images.githubusercontent.com/20523270/223774709-f92a2e85-3091-4bcb-99a0-745e025a25b5.png)


How they were:
![image](https://user-images.githubusercontent.com/20523270/223774780-54eef0a6-cd18-43b6-8c58-13fb32b08bb6.png)
