### PR TITLE
A bit more hardening of SQL Injection (of stuff using old sql_sanitize_text proc)

### DIFF
--- a/code/controllers/subsystems/persist_vr.dm
+++ b/code/controllers/subsystems/persist_vr.dm
@@ -81,8 +81,8 @@ SUBSYSTEM_DEF(persist)
 		dept_hours[department_earning] = min(config.pto_cap, dept_hours[department_earning])
 
 		// Okay we figured it out, lets update database!
-		var/sql_ckey = sql_sanitize_text(C.ckey)
-		var/sql_dpt = sql_sanitize_text(department_earning)
+		var/sql_ckey = sanitizeSQL(C.ckey)
+		var/sql_dpt = sanitizeSQL(department_earning)
 		var/sql_bal = text2num("[C.department_hours[department_earning]]")
 		var/sql_total = text2num("[C.play_hours[department_earning]]")
 		var/DBQuery/query = dbcon.NewQuery("INSERT INTO vr_player_hours (ckey, department, hours, total_hours) VALUES ('[sql_ckey]', '[sql_dpt]', [sql_bal], [sql_total]) ON DUPLICATE KEY UPDATE hours = VALUES(hours), total_hours = VALUES(total_hours)")

--- a/code/controllers/subsystems/sqlite.dm
+++ b/code/controllers/subsystems/sqlite.dm
@@ -80,9 +80,9 @@ SUBSYSTEM_DEF(sqlite)
 		CRASH("One or more parameters was invalid.")
 
 	// Sanitize everything to avoid sneaky stuff.
-	var/sqlite_author = sql_sanitize_text(ckey(lowertext(author)))
-	var/sqlite_content = sql_sanitize_text(content)
-	var/sqlite_topic = sql_sanitize_text(topic)
+	var/sqlite_author = sanitizeSQL(ckey(lowertext(author)))
+	var/sqlite_content = sanitizeSQL(content)
+	var/sqlite_topic = sanitizeSQL(topic)
 
 	var/database/query/query = new(
 	"INSERT INTO [SQLITE_TABLE_FEEDBACK] (\
@@ -121,8 +121,8 @@ SUBSYSTEM_DEF(sqlite)
 
 // Returns how many days someone has to wait, to submit more feedback, or 0 if they can do so right now.
 /datum/controller/subsystem/sqlite/proc/get_feedback_cooldown(player_ckey, cooldown, database/sqlite_object)
-	player_ckey = sql_sanitize_text(ckey(lowertext(player_ckey)))
-	var/potential_hashed_ckey = sql_sanitize_text(md5(player_ckey + SSsqlite.get_feedback_pepper()))
+	player_ckey = sanitizeSQL(ckey(lowertext(player_ckey)))
+	var/potential_hashed_ckey = sanitizeSQL(md5(player_ckey + SSsqlite.get_feedback_pepper()))
 
 	// First query is to get the most recent time the player has submitted feedback.
 	var/database/query/query = new({"

--- a/code/modules/admin/DB ban/functions.dm
+++ b/code/modules/admin/DB ban/functions.dm
@@ -78,7 +78,7 @@
 		else
 			adminwho += ", [C]"
 
-	reason = sql_sanitize_text(reason)
+	reason = sanitizeSQL(reason)
 
 	var/sql = "INSERT INTO erro_ban (`id`,`bantime`,`serverip`,`bantype`,`reason`,`job`,`duration`,`rounds`,`expiration_time`,`ckey`,`computerid`,`ip`,`a_ckey`,`a_computerid`,`a_ip`,`who`,`adminwho`,`edits`,`unbanned`,`unbanned_datetime`,`unbanned_ckey`,`unbanned_computerid`,`unbanned_ip`) VALUES (null, Now(), '[serverip]', '[bantype_str]', '[reason]', '[job]', [(duration)?"[duration]":"0"], [(rounds)?"[rounds]":"0"], Now() + INTERVAL [(duration>0) ? duration : 0] MINUTE, '[ckey]', '[computerid]', '[ip]', '[a_ckey]', '[a_computerid]', '[a_ip]', '[who]', '[adminwho]', '', null, null, null, null, null)"
 	var/DBQuery/query_insert = dbcon.NewQuery(sql)
@@ -176,14 +176,14 @@
 		to_chat(usr, "<span class='filter_adminlog'>Invalid ban id. Contact the database admin</span>")
 		return
 
-	reason = sql_sanitize_text(reason)
+	reason = sanitizeSQL(reason)
 	var/value
 
 	switch(param)
 		if("reason")
 			if(!value)
 				value = sanitize(tgui_input_text(usr, "Insert the new reason for [pckey]'s ban", "New Reason", "[reason]", null))
-				value = sql_sanitize_text(value)
+				value = sanitizeSQL(value)
 				if(!value)
 					to_chat(usr, "Cancelled")
 					return
@@ -339,8 +339,8 @@
 
 		adminckey = ckey(adminckey)
 		playerckey = ckey(playerckey)
-		playerip = sql_sanitize_text(playerip)
-		playercid = sql_sanitize_text(playercid)
+		playerip = sanitizeSQL(playerip)
+		playercid = sanitizeSQL(playercid)
 
 		if(adminckey || playerckey || playerip || playercid || dbbantype)
 

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -99,8 +99,8 @@
 			to_chat(src, "<span class='warning'>Sorry, that link doesn't appear to be valid. Please try again.</span>")
 			return
 
-		var/sql_discord = sql_sanitize_text(their_id)
-		var/sql_ckey = sql_sanitize_text(ckey)
+		var/sql_discord = sanitizeSQL(their_id)
+		var/sql_ckey = sanitizeSQL(ckey)
 		var/DBQuery/query = dbcon.NewQuery("UPDATE erro_player SET discord_id = '[sql_discord]' WHERE ckey = '[sql_ckey]'")
 		if(query.Execute())
 			to_chat(src, "<span class='notice'>Registration complete! Thank you for taking the time to register your Discord ID.</span>")
@@ -296,7 +296,7 @@
 	if(!dbcon.IsConnected())
 		return null
 
-	var/sql_ckey = sql_sanitize_text(ckey(key))
+	var/sql_ckey = sanitizeSQL(ckey(key))
 
 	var/DBQuery/query = dbcon.NewQuery("SELECT datediff(Now(),firstseen) as age FROM erro_player WHERE ckey = '[sql_ckey]'")
 	query.Execute()
@@ -316,7 +316,7 @@
 	if(!dbcon.IsConnected())
 		return
 
-	var/sql_ckey = sql_sanitize_text(src.ckey)
+	var/sql_ckey = sanitizeSQL(src.ckey)
 
 	var/DBQuery/query = dbcon.NewQuery("SELECT id, datediff(Now(),firstseen) as age FROM erro_player WHERE ckey = '[sql_ckey]'")
 	query.Execute()
@@ -358,9 +358,9 @@
 	if(src.holder)
 		admin_rank = src.holder.rank
 
-	var/sql_ip = sql_sanitize_text(src.address)
-	var/sql_computerid = sql_sanitize_text(src.computer_id)
-	var/sql_admin_rank = sql_sanitize_text(admin_rank)
+	var/sql_ip = sanitizeSQL(src.address)
+	var/sql_computerid = sanitizeSQL(src.computer_id)
+	var/sql_admin_rank = sanitizeSQL(admin_rank)
 
 	// If you're about to disconnect the player, you have to use to_chat_immediate otherwise they won't get the message (SSchat will queue it)
 

--- a/code/modules/research/message_server.dm
+++ b/code/modules/research/message_server.dm
@@ -365,17 +365,10 @@ var/obj/machinery/blackbox_recorder/blackbox
 		var/DBQuery/query_insert = dbcon.NewQuery(sql)
 		query_insert.Execute()
 
-// Sanitize inputs to avoid SQL injection attacks
-/proc/sql_sanitize_text(var/text)
-	text = replacetext(text, "'", "''")
-	text = replacetext(text, ";", "")
-	text = replacetext(text, "&", "")
-	return text
-
 /proc/feedback_set(var/variable,var/value)
 	if(!blackbox) return
 
-	variable = sql_sanitize_text(variable)
+	variable = sanitizeSQL(variable)
 
 	var/datum/feedback_variable/FV = blackbox.find_feedback_datum(variable)
 
@@ -386,7 +379,7 @@ var/obj/machinery/blackbox_recorder/blackbox
 /proc/feedback_inc(var/variable,var/value)
 	if(!blackbox) return
 
-	variable = sql_sanitize_text(variable)
+	variable = sanitizeSQL(variable)
 
 	var/datum/feedback_variable/FV = blackbox.find_feedback_datum(variable)
 
@@ -397,7 +390,7 @@ var/obj/machinery/blackbox_recorder/blackbox
 /proc/feedback_dec(var/variable,var/value)
 	if(!blackbox) return
 
-	variable = sql_sanitize_text(variable)
+	variable = sanitizeSQL(variable)
 
 	var/datum/feedback_variable/FV = blackbox.find_feedback_datum(variable)
 
@@ -408,8 +401,8 @@ var/obj/machinery/blackbox_recorder/blackbox
 /proc/feedback_set_details(var/variable,var/details)
 	if(!blackbox) return
 
-	variable = sql_sanitize_text(variable)
-	details = sql_sanitize_text(details)
+	variable = sanitizeSQL(variable)
+	details = sanitizeSQL(details)
 
 	var/datum/feedback_variable/FV = blackbox.find_feedback_datum(variable)
 
@@ -420,8 +413,8 @@ var/obj/machinery/blackbox_recorder/blackbox
 /proc/feedback_add_details(var/variable,var/details)
 	if(!blackbox) return
 
-	variable = sql_sanitize_text(variable)
-	details = sql_sanitize_text(details)
+	variable = sanitizeSQL(variable)
+	details = sanitizeSQL(details)
 
 	var/datum/feedback_variable/FV = blackbox.find_feedback_datum(variable)
 

--- a/code/modules/tgs/v5/chat_commands.dm
+++ b/code/modules/tgs/v5/chat_commands.dm
@@ -91,7 +91,7 @@ GLOBAL_LIST_EMPTY(pending_discord_registrations)
 
 /datum/tgs_chat_command/register/Run(datum/tgs_chat_user/sender, params)
 	// Try to find if that ID is registered to someone already
-	var/sql_discord = sql_sanitize_text(sender.id)
+	var/sql_discord = sanitizeSQL(sender.id)
 	var/DBQuery/query = dbcon.NewQuery("SELECT discord_id FROM erro_player WHERE discord_id = '[sql_discord]'")
 	query.Execute()
 	if(query.NextRow())
@@ -114,7 +114,7 @@ GLOBAL_LIST_EMPTY(pending_discord_registrations)
 	if(!user)
 		return "[sender.friendly_name], I couldn't find a logged-in user with the username of '[key_to_find]', which is what you provided after conversion to Byond's ckey format. Please connect to the game server and try again."
 
-	var/sql_ckey = sql_sanitize_text(key_to_find)
+	var/sql_ckey = sanitizeSQL(key_to_find)
 	query = dbcon.NewQuery("SELECT discord_id FROM erro_player WHERE ckey = '[sql_ckey]'")
 	query.Execute()
 


### PR DESCRIPTION
Note: I do not currently have a TGS instance with a linked discord bot in a testing server myself to test out the communication and registering of that stuff. The departmental hours (at least for fetching the time) system uses the correct proc already, just the inserting of new time is wrong. Though this would have to be observed and tested if there are any issues.

Generally, the logs should be also checked if there are any SQL related errors around (if sufficient logging is actually in place).

Using own function to sanitize SQL is not a good idea.
Or at the very least the sql_sanitize_text is not enough to properly sanitize incoming SQL stuff.

Updates (Queries)/Variables:

- Departmental Hours (Inserting new time)
- SQLite Subsystem
- Banning
- Registering new account (Linking with Discord)
- Some TGS Communication