### PR TITLE
Changelog Reroute

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -433,11 +433,14 @@
 /client/verb/changes()
 	set name = "Changelog"
 	set category = "OOC"
-	src << browse('html/changelog.html', "window=changes;size=675x650")
+	src << link("https://wiki.vore-station.net/Changelog")
+
+	/*
 	if(prefs.lastchangelog != changelog_hash)
 		prefs.lastchangelog = changelog_hash
 		SScharacter_setup.queue_preferences_save(prefs)
 		winset(src, "rpane.changelog", "background-color=none;font-style=;")
+	*/
 
 /mob/verb/observe()
 	set name = "Observe"

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -30,10 +30,11 @@
 
 /mob/new_player/proc/new_player_panel_proc()
 	var/output = "<div align='center'>"
-	/* VOREStation Removal
-	output += "[using_map.get_map_info()]"
+
+	output += "<b>Current Map:</b><br>"
+	output += "[using_map.full_name]"
 	output +="<hr>"
-	VOREStation Removal End */
+
 	output += "<p><a href='byond://?src=\ref[src];show_preferences=1'>Character Setup</A></p>"
 
 	if(!ticker || ticker.current_state <= GAME_STATE_PREGAME)
@@ -67,10 +68,7 @@
 			else
 				output += "<p><a href='byond://?src=\ref[src];showpoll=1'>Show Player Polls</A></p>"
 
-	if(client.check_for_new_server_news())
-		output += "<p><b><a href='byond://?src=\ref[src];shownews=1'>Show Game Updates</A> (NEW!)</b></p>"
-	else
-		output += "<p><a href='byond://?src=\ref[src];shownews=1'>Show Game Updates</A></p>"
+	output += "<p><a href='byond://?src=\ref[src];open_changelog=1'>View Changelog</A></p>"
 
 	if(SSsqlite.can_submit_feedback(client))
 		output += "<p>[href(src, list("give_feedback" = 1), "Give Feedback")]</p>"
@@ -347,6 +345,9 @@
 			client.feedback_form.display() // In case they closed the form early.
 		else
 			client.feedback_form = new(client)
+
+	if(href_list["open_changelog"])
+		src << link("https://wiki.vore-station.net/Changelog")
 
 /mob/new_player/proc/handle_server_news()
 	if(!client)


### PR DESCRIPTION
In lieu of formalizing the changelog update process so that it actually happens, I've rerouted the "Show Game Updates" button on the front-end menu and the "Changelog" verb to point to the wiki's changelog.

In an ideal world devs would use the proper tagging and changelog addition system to PRs to auto-write to the changelog.html that's stored in the game data. But for now I'd rather have links to the volunteer-maintained changelogs. If staff change their minds and decide to start enforcing the template & tag system, this can always be rolled back.

As an added bonus the current map name will now also be displayed at the top of the front-end menu, so you should never be surprised about which map you load into.