### PR TITLE
Weapon Info on Examine

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -25,6 +25,7 @@
 	var/list/origin_tech = null	//Used by R&D to determine what research bonuses it grants.
 	var/list/attack_verb //Used in attackby() to say how something was attacked "[x] has been [z.attack_verb] by [y] with [z]"
 	var/force = 0
+	var/can_cleave = FALSE // If true, a 'cleaving' attack will occur.
 
 	var/heat_protection = 0 //flags which determine which body parts are protected from heat. Use the HEAD, UPPER_TORSO, LOWER_TORSO, etc. flags. See setup.dm
 	var/cold_protection = 0 //flags which determine which body parts are protected from cold. Use the HEAD, UPPER_TORSO, LOWER_TORSO, etc. flags. See setup.dm

--- a/code/game/objects/items/weapons/material/twohanded.dm
+++ b/code/game/objects/items/weapons/material/twohanded.dm
@@ -145,7 +145,6 @@
 	base_icon = "spearglass"
 	name = "spear"
 	desc = "A haphazardly-constructed yet still deadly weapon of ancient design."
-	description_info = "This weapon can strike from two tiles away, and over certain objects such as tables, or other people."
 	force = 10
 	w_class = ITEMSIZE_LARGE
 	slot_flags = SLOT_BACK

--- a/code/game/objects/items/weapons/melee/energy.dm
+++ b/code/game/objects/items/weapons/melee/energy.dm
@@ -2,11 +2,12 @@
 	var/active = 0
 	var/active_force
 	var/active_throwforce
+	var/active_armourpen
 	var/active_w_class
 	var/active_embed_chance = 0		//In the off chance one of these is supposed to embed, you can just tweak this var
 	sharp = FALSE
 	edge = FALSE
-	armor_penetration = 50
+	armor_penetration = 0
 	flags = NOCONDUCT | NOBLOODY
 	var/lrange = 2
 	var/lpower = 2
@@ -54,6 +55,7 @@
 	embed_chance = active_embed_chance
 	force = active_force
 	throwforce = active_throwforce
+	armor_penetration = active_armourpen
 	sharp = TRUE
 	edge = TRUE
 	w_class = active_w_class
@@ -70,6 +72,7 @@
 	embed_chance = initial(embed_chance)
 	force = initial(force)
 	throwforce = initial(throwforce)
+	armor_penetration = initial(armor_penetration)
 	sharp = initial(sharp)
 	edge = initial(edge)
 	w_class = initial(w_class)
@@ -192,7 +195,8 @@
 
 /obj/item/weapon/melee/energy/examine(mob/user)
 	. = ..()
-	. += "<span class='notice'>Alt-click to recolor it.</span>"
+	if(colorable)
+		. += "<span class='notice'>Alt-click to recolor it.</span>"
 
 /*
  * Energy Axe
@@ -206,11 +210,13 @@
 	lcolor = null
 	//active_force = 150 //holy...
 	active_force = 60
+	active_armourpen = 65
 	active_throwforce = 35
 	active_w_class = ITEMSIZE_HUGE
 	//force = 40
 	//throwforce = 25
 	force = 20
+	armor_penetration = 20
 	throwforce = 10
 	throw_speed = 1
 	throw_range = 5
@@ -236,6 +242,7 @@
 	desc = "An energised axe."
 	active_force = 35
 	active_throwforce = 20
+	active_armourpen = 30
 	force = 15
 
 	use_cell = TRUE
@@ -255,6 +262,7 @@
 	icon_state = "esword"
 	item_state = "esword"
 	active_force = 30
+	active_armourpen = 50
 	active_throwforce = 20
 	active_w_class = ITEMSIZE_LARGE
 	force = 3
@@ -264,8 +272,6 @@
 	w_class = ITEMSIZE_SMALL
 	flags = NOBLOODY
 	origin_tech = list(TECH_MAGNET = 3, TECH_ILLEGAL = 4)
-	sharp = TRUE
-	edge = TRUE
 	colorable = TRUE
 	drop_sound = 'sound/items/drop/sword.ogg'
 	pickup_sound = 'sound/items/pickup/sword.ogg'
@@ -344,6 +350,7 @@
 	icon_state = "ionrapier"
 	item_state = "ionrapier"
 	active_force = 5
+	active_armourpen = 80
 	active_throwforce = 3
 	active_embed_chance = 0
 	sharp = TRUE
@@ -383,7 +390,7 @@
 	name = "zero-point lance"
 	desc = "Designed specifically for disrupting electronics at relatively close range, however it is still capable of dealing some damage to living beings."
 	active_force = 20
-	armor_penetration = 15
+	active_armourpen = 15
 	reach = 2
 
 /*
@@ -395,7 +402,7 @@
 	desc = "A small, handheld device which emits a high-energy 'blade'."
 	origin_tech = list(TECH_COMBAT = 5, TECH_MAGNET = 3, TECH_ILLEGAL = 4)
 	active_force = 25
-	armor_penetration = 25
+	active_armourpen = 25
 	projectile_parry_chance = 40
 	colorable = TRUE
 
@@ -501,7 +508,7 @@
 	name = "energy spear"
 	desc = "Concentrated energy forming a sharp tip at the end of a long rod."
 	icon_state = "espear"
-	armor_penetration = 75
+	armor_penetration = 0
 	sharp = TRUE
 	edge = TRUE
 	force = 5
@@ -511,6 +518,7 @@
 	reach = 2
 	w_class = ITEMSIZE_LARGE
 	active_force = 25
+	active_armourpen = 75
 	active_throwforce = 30
 	active_w_class = ITEMSIZE_HUGE
 	colorable = TRUE

--- a/code/game/objects/weapons.dm
+++ b/code/game/objects/weapons.dm
@@ -2,7 +2,6 @@
 	name = "weapon"
 	icon = 'icons/obj/weapons.dmi'
 	hitsound = "swing_hit"
-	var/can_cleave = FALSE // If true, a 'cleaving' attack will occur.
 	var/cleaving = FALSE // Used to avoid infinite cleaving.
 
 /obj/item/weapon/Bump(mob/M as mob)

--- a/code/modules/examine/descriptions/guns.dm
+++ b/code/modules/examine/descriptions/guns.dm
@@ -5,8 +5,11 @@
 		P = new energy_gun.projectile_type()
 	else if(istype(src, /obj/item/weapon/gun/projectile/shotgun/pump))
 		var/obj/item/weapon/gun/projectile/shotgun/pump/projectile_gun = src
-		var/obj/item/ammo_casing/ammo = projectile_gun.chambered
-		P = ammo.BB
+		if(isnull(projectile_gun.chambered) || isnull(projectile_gun.chambered.BB))
+			return "no"
+		else
+			var/obj/item/ammo_casing/ammo = projectile_gun.chambered
+			P = ammo.BB
 	else if(istype(src, /obj/item/weapon/gun/projectile))
 		var/obj/item/weapon/gun/projectile/projectile_gun = src
 		var/obj/item/ammo_casing/ammo
@@ -41,8 +44,11 @@
 		P = new energy_gun.projectile_type()
 	else if(istype(src, /obj/item/weapon/gun/projectile/shotgun/pump))
 		var/obj/item/weapon/gun/projectile/shotgun/pump/projectile_gun = src
-		var/obj/item/ammo_casing/ammo = projectile_gun.chambered
-		P = ammo.BB
+		if(isnull(projectile_gun.chambered) || isnull(projectile_gun.chambered.BB))
+			return "as it has no projectile loaded"
+		else
+			var/obj/item/ammo_casing/ammo = projectile_gun.chambered
+			P = ammo.BB
 	else if(istype(src, /obj/item/weapon/gun/projectile))
 		var/obj/item/weapon/gun/projectile/projectile_gun = src
 		var/obj/item/ammo_casing/ammo
@@ -107,7 +113,10 @@
 		is_loaded = LAZYLEN(src.contents)
 	if(istype(src, /obj/item/weapon/gun/projectile/shotgun/pump))
 		var/obj/item/weapon/gun/projectile/shotgun/pump/shotgun = src
-		is_loaded = shotgun.chambered
+		if(isnull(shotgun.chambered) || isnull(shotgun.chambered.BB))
+			is_loaded = null
+		else
+			is_loaded = shotgun.chambered
 	if(istype(src, /obj/item/weapon/gun/projectile))
 		var/obj/item/weapon/gun/projectile/projectile_gun = src
 		var/ammo

--- a/code/modules/examine/descriptions/guns.dm
+++ b/code/modules/examine/descriptions/guns.dm
@@ -16,6 +16,8 @@
 			ammo = projectile_gun.contents[1]
 		P = ammo.BB
 	switch(P.damage)
+		if(0)
+			return "no"
 		if(1 to 5)
 			return "a very small amount of"
 		if(6 to 15)

--- a/code/modules/examine/descriptions/guns.dm
+++ b/code/modules/examine/descriptions/guns.dm
@@ -1,0 +1,133 @@
+/obj/item/weapon/gun/proc/describe_firepower()
+	var/obj/item/projectile/P
+	if(istype(src, /obj/item/weapon/gun/energy))
+		var/obj/item/weapon/gun/energy/energy_gun = src
+		P = new energy_gun.projectile_type()
+	else if(istype(src, /obj/item/weapon/gun/projectile/shotgun/pump))
+		var/obj/item/weapon/gun/projectile/shotgun/pump/projectile_gun = src
+		var/obj/item/ammo_casing/ammo = projectile_gun.chambered
+		P = ammo.BB
+	else if(istype(src, /obj/item/weapon/gun/projectile))
+		var/obj/item/weapon/gun/projectile/projectile_gun = src
+		var/obj/item/ammo_casing/ammo
+		if(projectile_gun.ammo_magazine)
+			ammo = projectile_gun.ammo_magazine.contents[1]
+		else
+			ammo = projectile_gun.contents[1]
+		P = ammo.BB
+	switch(P.damage)
+		if(1 to 5)
+			return "a very small amount of"
+		if(6 to 15)
+			return "a small amount of"
+		if(16 to 25)
+			return "a modest amount of"
+		if(26 to 40)
+			return "a respectable amount of"
+		if(41 to 60)
+			return "a serious amount of"
+		if(61 to 80)
+			return "a lot of"
+		if(81 to 2000)
+			return "a ruinous amount of"
+	qdel(P)
+
+/obj/item/weapon/gun/proc/describe_proj_penetration()
+	var/obj/item/projectile/P
+	if(istype(src, /obj/item/weapon/gun/energy))
+		var/obj/item/weapon/gun/energy/energy_gun = src
+		P = new energy_gun.projectile_type()
+	else if(istype(src, /obj/item/weapon/gun/projectile/shotgun/pump))
+		var/obj/item/weapon/gun/projectile/shotgun/pump/projectile_gun = src
+		var/obj/item/ammo_casing/ammo = projectile_gun.chambered
+		P = ammo.BB
+	else if(istype(src, /obj/item/weapon/gun/projectile))
+		var/obj/item/weapon/gun/projectile/projectile_gun = src
+		var/obj/item/ammo_casing/ammo
+		if(projectile_gun.ammo_magazine)
+			ammo = projectile_gun.ammo_magazine.contents[1]
+		else
+			ammo = projectile_gun.contents[1]
+		P = ammo.BB
+	switch(P.armor_penetration)
+		if(0)
+			return "cannot pierce armor"
+		if(1 to 20)
+			return "barely pierces armor"
+		if(21 to 30)
+			return "slightly pierces armor"
+		if(31 to 40)
+			return "reliably pierces lighter armors"
+		if(41 to 50)
+			return "pierces standard-issue armor reliably"
+		if(51 to 60)
+			return "pierces most armor reliably"
+		if(61 to 70)
+			return "pierces a great deal of armor"
+		if(71 to 80)
+			return "pierces the vast majority of armor"
+		if(81 to 99)
+			return "almost completely pierces all armor"
+		if(100 to 1000)
+			return "completely and utterly pierces all armor"
+	qdel(P)
+
+/obj/item/weapon/gun/proc/describe_firerate()
+	switch(fire_delay)
+		if(0)
+			return "no delay"
+		if(1 to 4)
+			return "a very short delay"
+		if(5 to 8)
+			return "a short delay"
+		if(9 to 12)
+			return "a moderate delay"
+		if(13 to 15)
+			return "a noticeable delay"
+		if(16 to 20)
+			return "a distinct delay"
+		if(21 to 30)
+			return "a long delay"
+		if(31 to 50)
+			return "a very long delay"
+		if(51 to 100)
+			return "an extremely long delay"
+
+/obj/item/weapon/gun/get_description_info()
+	var/is_loaded
+	var/non_lethal
+	var/non_lethal_list = list(/obj/item/weapon/gun/energy/medigun,/obj/item/weapon/gun/energy/mouseray,/obj/item/weapon/gun/energy/temperature,/obj/item/weapon/gun/energy/sizegun,/obj/item/weapon/gun/projectile/shotgun/pump/toy)
+	var/weapon_stats = description_info + "\
+	<br>"
+	if(istype(src, /obj/item/weapon/gun/energy))
+		is_loaded = LAZYLEN(src.contents)
+	else if(istype(src, /obj/item/weapon/gun/projectile/shotgun/pump))
+		var/obj/item/weapon/gun/projectile/shotgun/pump/shotgun = src
+		is_loaded = shotgun.chambered
+	else if(istype(src, /obj/item/weapon/gun/projectile))
+		var/obj/item/weapon/gun/projectile/projectile_gun = src
+		var/ammo
+		if(projectile_gun.ammo_magazine)
+			ammo = projectile_gun.ammo_magazine.contents
+		else
+			ammo = projectile_gun.contents
+		is_loaded = LAZYLEN(ammo)
+	else for(var/path in non_lethal_list)
+		if(istype(src,path))
+			is_loaded = null
+			non_lethal = TRUE
+
+	if(is_loaded)
+		weapon_stats += "\nIf fired, it would deal [describe_firepower()] damage, [describe_proj_penetration()], and has [describe_firerate()] between shots."
+	else if(non_lethal)
+		weapon_stats += "\nThis is an entirely non-lethal weapon, such as a mouseray, toy, or sizegun!"
+	else
+		weapon_stats += "\nIt isn't loaded!"
+	if(force)
+		weapon_stats += "\nIf used in melee, it deals [describe_power()] [sharp ? "sharp" : "blunt"] damage, [describe_penetration()], and has [describe_speed()]."
+	if(can_cleave)
+		weapon_stats += "\nIt is capable of hitting multiple targets with a single swing."
+	if(reach > 1)
+		weapon_stats += "\nIt can attack targets up to [reach] tiles away, and can attack over certain objects."
+
+	return weapon_stats

--- a/code/modules/examine/descriptions/guns.dm
+++ b/code/modules/examine/descriptions/guns.dm
@@ -96,15 +96,17 @@
 /obj/item/weapon/gun/get_description_info()
 	var/is_loaded
 	var/non_lethal
-	var/non_lethal_list = list(/obj/item/weapon/gun/energy/medigun,/obj/item/weapon/gun/energy/mouseray,/obj/item/weapon/gun/energy/temperature,/obj/item/weapon/gun/energy/sizegun,/obj/item/weapon/gun/projectile/shotgun/pump/toy)
+	var/non_lethal_list = list(/obj/item/weapon/gun/energy/medigun,/obj/item/weapon/gun/energy/mouseray,/obj/item/weapon/gun/energy/temperature,/obj/item/weapon/gun/energy/sizegun,/obj/item/weapon/gun/projectile/shotgun/pump/toy,/obj/item/weapon/gun/projectile/revolver/toy,/obj/item/weapon/gun/projectile/pistol/toy,/obj/item/weapon/gun/projectile/automatic/toy)
+	var/less_lethal
+	var/less_lethal_list = list(/obj/item/weapon/gun/energy/taser,/obj/item/weapon/gun/energy/stunrevolver,/obj/item/weapon/gun/energy/plasmastun,/obj/item/weapon/gun/energy/bfgtaser)
 	var/weapon_stats = description_info + "\
 	<br>"
 	if(istype(src, /obj/item/weapon/gun/energy))
 		is_loaded = LAZYLEN(src.contents)
-	else if(istype(src, /obj/item/weapon/gun/projectile/shotgun/pump))
+	if(istype(src, /obj/item/weapon/gun/projectile/shotgun/pump))
 		var/obj/item/weapon/gun/projectile/shotgun/pump/shotgun = src
 		is_loaded = shotgun.chambered
-	else if(istype(src, /obj/item/weapon/gun/projectile))
+	if(istype(src, /obj/item/weapon/gun/projectile))
 		var/obj/item/weapon/gun/projectile/projectile_gun = src
 		var/ammo
 		if(projectile_gun.ammo_magazine)
@@ -112,15 +114,21 @@
 		else
 			ammo = projectile_gun.contents
 		is_loaded = LAZYLEN(ammo)
-	else for(var/path in non_lethal_list)
-		if(istype(src,path))
+	for(var/llweapontype in less_lethal_list)
+		if(istype(src,llweapontype))
+			is_loaded = null
+			less_lethal = TRUE
+	for(var/nlweapontype in non_lethal_list)
+		if(istype(src,nlweapontype))
 			is_loaded = null
 			non_lethal = TRUE
 
 	if(is_loaded)
 		weapon_stats += "\nIf fired, it would deal [describe_firepower()] damage, [describe_proj_penetration()], and has [describe_firerate()] between shots."
+	else if(less_lethal)
+		weapon_stats += "\nIf fired, it would deal stunning damage to incapacitate targets, and has [describe_firerate()] between shots."
 	else if(non_lethal)
-		weapon_stats += "\nThis is an entirely non-lethal weapon, such as a mouseray, toy, or sizegun!"
+		weapon_stats += "\nThis is an entirely non-lethal weapon, such as a mouseray, toy, or sizegun! Its effects cannot easily be quantified."
 	else
 		weapon_stats += "\nIt isn't loaded!"
 	if(force)

--- a/code/modules/examine/descriptions/items.dm
+++ b/code/modules/examine/descriptions/items.dm
@@ -1,0 +1,75 @@
+/obj/item/proc/describe_power()
+	switch(force)
+		if(1 to 2)
+			return "a very small amount of"
+		if(3 to 5)
+			return "a small amount of"
+		if(6 to 10)
+			return "a modest amount of"
+		if(11 to 15)
+			return "a respectable amount of"
+		if(16 to 20)
+			return "a serious amount of"
+		if(21 to 100)
+			return "a lot of"
+
+/obj/item/proc/describe_throwpower()
+	switch(throwforce)
+		if(1 to 2)
+			return "a very small amount of"
+		if(3 to 5)
+			return "a small amount of"
+		if(6 to 10)
+			return "a modest amount of"
+		if(11 to 15)
+			return "a respectable amount of"
+		if(16 to 20)
+			return "a serious amount of"
+		if(21 to 100)
+			return "a lot of"
+
+/obj/item/proc/describe_penetration()
+	switch(armor_penetration)
+		if(0)
+			return "cannot pierce armor"
+		if(1 to 20)
+			return "barely pierces armor"
+		if(21 to 30)
+			return "slightly pierces armor"
+		if(31 to 40)
+			return "reliably pierces lighter armors"
+		if(41 to 50)
+			return "pierces standard-issue armor reliably"
+		if(51 to 60)
+			return "pierces most armor reliably"
+		if(61 to 70)
+			return "pierces a great deal of armor"
+		if(71 to 80)
+			return "pierces the vast majority of armor"
+		if(81 to 99)
+			return "almost completely pierces all armor"
+		if(100)
+			return "completely and utterly pierces all armor"
+
+/obj/item/proc/describe_speed()
+	if(attackspeed > DEFAULT_ATTACK_COOLDOWN)
+		return "a slow attack speed"
+	else if(attackspeed < DEFAULT_ATTACK_COOLDOWN)
+		return "a high attack speed"
+	else
+		return "an average attack speed"
+
+/obj/item/get_description_info()
+	var/weapon_stats = description_info + "\
+	<br>"
+
+	if(force)
+		weapon_stats += "\nIf used in melee, it deals [describe_power()] [sharp ? "sharp" : "blunt"] damage, [describe_penetration()], and has [describe_speed()]."
+	if(throwforce)
+		weapon_stats += "\nIf thrown, it would deal [describe_throwpower()] [sharp ? "sharp" : "blunt"] damage."
+	if(can_cleave)
+		weapon_stats += "\nIt is capable of hitting multiple targets with a single swing."
+	if(reach > 1)
+		weapon_stats += "\nIt can attack targets up to [reach] tiles away, and can attack over certain objects."
+
+	return weapon_stats

--- a/code/modules/examine/descriptions/items.dm
+++ b/code/modules/examine/descriptions/items.dm
@@ -1,5 +1,7 @@
 /obj/item/proc/describe_power()
 	switch(force)
+		if(0)
+			return "a negligable amount of"
 		if(1 to 2)
 			return "a very small amount of"
 		if(3 to 5)
@@ -7,11 +9,17 @@
 		if(6 to 10)
 			return "a modest amount of"
 		if(11 to 15)
-			return "a respectable amount of"
+			return "a moderate amount of"
 		if(16 to 20)
+			return "a respectable amount of"
+		if(21 to 35)
 			return "a serious amount of"
-		if(21 to 100)
-			return "a lot of"
+		if(36 to 50)
+			return "a very serious amount of"
+		if(51 to 100)
+			return "a very lethal amount of"
+		if(101 to 2000)
+			return "a truly ruinous amount of"
 
 /obj/item/proc/describe_throwpower()
 	switch(throwforce)

--- a/code/modules/examine/descriptions/items.dm
+++ b/code/modules/examine/descriptions/items.dm
@@ -23,6 +23,8 @@
 
 /obj/item/proc/describe_throwpower()
 	switch(throwforce)
+		if(0)
+			return "a negligable amount of"
 		if(1 to 2)
 			return "a very small amount of"
 		if(3 to 5)
@@ -30,11 +32,17 @@
 		if(6 to 10)
 			return "a modest amount of"
 		if(11 to 15)
-			return "a respectable amount of"
+			return "a moderate amount of"
 		if(16 to 20)
+			return "a respectable amount of"
+		if(21 to 35)
 			return "a serious amount of"
-		if(21 to 100)
-			return "a lot of"
+		if(36 to 50)
+			return "a very serious amount of"
+		if(51 to 100)
+			return "a very lethal amount of"
+		if(101 to 2000)
+			return "a truly ruinous amount of"
 
 /obj/item/proc/describe_penetration()
 	switch(armor_penetration)
@@ -56,7 +64,7 @@
 			return "pierces the vast majority of armor"
 		if(81 to 99)
 			return "almost completely pierces all armor"
-		if(100)
+		if(100 to 1000)
 			return "completely and utterly pierces all armor"
 
 /obj/item/proc/describe_speed()

--- a/code/modules/examine/descriptions/weapons.dm
+++ b/code/modules/examine/descriptions/weapons.dm
@@ -77,6 +77,30 @@
 //*******
 //*Melee*
 //*******
+/*
+/obj/item/weapon/melee/baton/proc/describe_agonypower()
+	switch(agonyforce)
+		if(1 to 20)
+			return "a mild amount of"
+		if(21 to 40)
+			return "a modest amount of"
+		if(41 to 60)
+			return "a moderate amount of"
+		if(61 to 80)
+			return "a serious amount of"
+		if(81 to 100)
+			return "a significant amount of"
+
+/obj/item/weapon/melee/baton/get_description_info()
+	. = ..()
+	var/baton_stats = description_info + "\
+	<br>"
+
+	if(agonyforce)
+		baton_stats += "\nIt also inflicts [describe_agonypower()] pain, if charged and active."
+
+	return baton_stats
+*/
 
 /obj/item/weapon/melee/baton
 	description_info = "The baton needs to be turned on to apply the stunning effect.  Use it in your hand to toggle it on or off.  If your intent is \

--- a/code/modules/projectiles/guns/energy/gunsword_vr.dm
+++ b/code/modules/projectiles/guns/energy/gunsword_vr.dm
@@ -45,12 +45,13 @@
 
 	var/active = 0
 	var/active_force = 30
+	var/active_armourpen = 50
 	var/active_throwforce = 20
 	var/active_w_class = ITEMSIZE_LARGE
 	var/active_embed_chance = 0		//In the off chance one of these is supposed to embed, you can just tweak this var
 	sharp = FALSE
 	edge = FALSE
-	armor_penetration = 50
+	armor_penetration = 0
 	flags = NOBLOODY
 	var/lrange = 2
 	var/lpower = 2
@@ -65,6 +66,7 @@
 	active = 1
 	embed_chance = active_embed_chance
 	force = active_force
+	armor_penetration = active_armourpen
 	throwforce = active_throwforce
 	sharp = TRUE
 	edge = TRUE
@@ -84,6 +86,7 @@
 	active = 0
 	embed_chance = initial(embed_chance)
 	force = initial(force)
+	armor_penetration = initial(armor_penetration)
 	throwforce = initial(throwforce)
 	sharp = initial(sharp)
 	edge = initial(edge)

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -2269,6 +2269,7 @@
 #include "code\modules\examine\descriptions\containers.dm"
 #include "code\modules\examine\descriptions\devices.dm"
 #include "code\modules\examine\descriptions\engineering.dm"
+#include "code\modules\examine\descriptions\items.dm"
 #include "code\modules\examine\descriptions\machines.dm"
 #include "code\modules\examine\descriptions\medical.dm"
 #include "code\modules\examine\descriptions\mobs.dm"

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -2269,6 +2269,7 @@
 #include "code\modules\examine\descriptions\containers.dm"
 #include "code\modules\examine\descriptions\devices.dm"
 #include "code\modules\examine\descriptions\engineering.dm"
+#include "code\modules\examine\descriptions\guns.dm"
 #include "code\modules\examine\descriptions\items.dm"
 #include "code\modules\examine\descriptions\machines.dm"
 #include "code\modules\examine\descriptions\medical.dm"


### PR DESCRIPTION
As requested, this PR adds rough details of an object's relative power to its description when examined, similar to the rough details provided when examining armour;
![image](https://user-images.githubusercontent.com/49700375/224522173-fcdb6a0a-e655-4a83-b79a-115cbf323cd7.png)
![image](https://user-images.githubusercontent.com/49700375/224522178-887e2a0b-cca5-4ee2-b239-cad91774a768.png)
As demonstrated above, it also explains if the weapon can cleave or has reach. This covers everything from `obj/item` down, so you can learn that, hey, the maglight is a mildly effective melee weapon!

The specific values are obfuscated similar to armour values, as giving players the exact damage/etc. numbers isn't really useful without other context. Most players probably know that your average carbon has 100hp before going into softcrit, and 'dies' at -100hp, but simplemob health and armour can be all over the place.

~~I intend to expand this to cover the power of loaded/charged firearms in the future, but that will be a slightly more complicated project.~~ I also intended detail baton stunning power but the procs aren't cooperating.

As a side-effect this PR also makes some changes to e-swords and similar energy weapons, toggling their armour penetration along with their active state. A deactivated e-sword can no longer punch through armour to deal minor cuts (though a deactivated energy-axe is still quite powerful).

~~Some of the numbers/descriptors are not quite final and need adjusting.~~