### PR TITLE
Frozen Organ Crates

### DIFF
--- a/code/game/objects/random/mapping.dm
+++ b/code/game/objects/random/mapping.dm
@@ -837,7 +837,14 @@
 				/obj/random/firstaid,
 				/obj/random/unidentified_medicine/fresh_medicine,
 				/obj/random/unidentified_medicine/fresh_medicine,
-				/obj/structure/closet/crate/veymed //VM FAKS
+				/obj/structure/closet/crate/freezer/veymed //VM FAKS
+			),
+			prob(5);list(
+				/obj/random/internal_organ,
+				/obj/random/internal_organ,
+				/obj/random/internal_organ,
+				/obj/random/internal_organ,
+				/obj/structure/closet/crate/freezer/veymed //VM ORGANSES
 			),
 			prob(10);list(
 				/obj/random/tech_supply/nofail,
@@ -854,7 +861,7 @@
 				/obj/random/medical/pillbottle,
 				/obj/random/medical/lite,
 				/obj/random/medical/lite,
-				/obj/structure/closet/crate/zenghu //ZENGHU GRABBAG
+				/obj/structure/closet/crate/freezer/zenghu //ZENGHU GRABBAG
 			),
 			prob(10);list(
 				/obj/random/medical/pillbottle,
@@ -863,7 +870,7 @@
 				/obj/random/medical/pillbottle,
 				/obj/random/unidentified_medicine/fresh_medicine,
 				/obj/random/unidentified_medicine/fresh_medicine,
-				/obj/structure/closet/crate/zenghu //ZENGHU PILLS
+				/obj/structure/closet/crate/freezer/zenghu //ZENGHU PILLS
 			),
 			prob(10);list(
 				/obj/item/device/toner,
@@ -1099,7 +1106,7 @@
 				/obj/random/medical,
 				/obj/random/medical/lite,
 				/obj/random/medical/lite,
-				/obj/structure/closet/crate/veymed //VM GRABBAG
+				/obj/structure/closet/crate/freezer/veymed //VM GRABBAG
 			),
 			prob(10);list(
 				/obj/random/firstaid,
@@ -1108,7 +1115,14 @@
 				/obj/random/firstaid,
 				/obj/random/unidentified_medicine/fresh_medicine,
 				/obj/random/unidentified_medicine/fresh_medicine,
-				/obj/structure/closet/crate/veymed //VM FAKS
+				/obj/structure/closet/crate/freezer/veymed //VM FAKS
+			),
+			prob(5);list(
+				/obj/random/internal_organ,
+				/obj/random/internal_organ,
+				/obj/random/internal_organ,
+				/obj/random/internal_organ,
+				/obj/structure/closet/crate/freezer/veymed //VM ORGANSES
 			),
 			prob(10);list(
 				/obj/random/tech_supply/nofail,
@@ -1125,7 +1139,7 @@
 				/obj/random/medical/pillbottle,
 				/obj/random/medical/lite,
 				/obj/random/medical/lite,
-				/obj/structure/closet/crate/zenghu //ZENGHU GRABBAG
+				/obj/structure/closet/crate/freezer/zenghu //ZENGHU GRABBAG
 			),
 			prob(10);list(
 				/obj/random/medical/pillbottle,
@@ -1134,7 +1148,7 @@
 				/obj/random/medical/pillbottle,
 				/obj/random/unidentified_medicine/fresh_medicine,
 				/obj/random/unidentified_medicine/fresh_medicine,
-				/obj/structure/closet/crate/zenghu //ZENGHU PILLS
+				/obj/structure/closet/crate/freezer/zenghu //ZENGHU PILLS
 			),
 			prob(10);list(
 				/obj/item/device/toner,

--- a/code/game/objects/random/misc_vr.dm
+++ b/code/game/objects/random/misc_vr.dm
@@ -224,7 +224,7 @@
 	icon_state = "heart"
 	spawn_nothing_percentage = 10
 
-/obj/random/organ/item_to_spawn()
+/obj/random/internal_organ/item_to_spawn()
 	return pick(prob(5);/obj/item/organ/internal/appendix,
 				prob(5);/obj/item/organ/internal/eyes,
 				prob(5);/obj/item/organ/internal/heart,

--- a/code/game/objects/random/misc_vr.dm
+++ b/code/game/objects/random/misc_vr.dm
@@ -216,3 +216,22 @@
 				prob(5);/obj/item/instrument/glockenspiel,
 				prob(1);/obj/item/instrument/musicalmoth
 				)
+
+/obj/random/internal_organ
+	name = "random organ"
+	desc = "A random internal organ. Juicy fresh! Or... maybe not."
+	icon = 'icons/obj/surgery.dmi'
+	icon_state = "heart"
+	spawn_nothing_percentage = 10
+
+/obj/random/organ/item_to_spawn()
+	return pick(prob(5);/obj/item/organ/internal/appendix,
+				prob(5);/obj/item/organ/internal/eyes,
+				prob(5);/obj/item/organ/internal/heart,
+				prob(5);/obj/item/organ/internal/kidneys,
+				prob(5);/obj/item/organ/internal/liver,
+				prob(5);/obj/item/organ/internal/spleen,
+				prob(5);/obj/item/organ/internal/lungs,
+				prob(5);/obj/item/organ/internal/stomach,
+				prob(5);/obj/item/organ/internal/voicebox,
+				)

--- a/code/game/objects/structures/crates_lockers/_closets_appearance_definitions.dm
+++ b/code/game/objects/structures/crates_lockers/_closets_appearance_definitions.dm
@@ -809,6 +809,19 @@
 		"nano" = COLOR_OFF_WHITE
 	)
 
+/decl/closet_appearance/crate/freezer/veymed
+	color = COLOR_BABY_BLUE
+	extra_decals = list(
+		"lid_stripes" = COLOR_RED,
+		"crate_cross" = COLOR_GREEN
+	)
+
+/decl/closet_appearance/crate/freezer/zenghu
+	color = COLOR_BABY_BLUE
+	extra_decals = list(
+		"zenghu" = COLOR_OFF_WHITE
+	)
+
 // Corporate Branding
 
 /decl/closet_appearance/crate/aether

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -308,6 +308,14 @@
 	desc = "A freezer stamped with the logo of NanoTrasen."
 	closet_appearance = /decl/closet_appearance/crate/freezer/nanotrasen
 
+/obj/structure/closet/crate/freezer/veymed
+	desc = "A freezer stamped with the logo of Vey-Medical."
+	closet_appearance = /decl/closet_appearance/crate/freezer/veymed
+
+/obj/structure/closet/crate/freezer/zenghu
+	desc = "A freezer stamped with the logo of Zeng-Hu Pharmaceuticals."
+	closet_appearance = /decl/closet_appearance/crate/freezer/zenghu
+
 /obj/structure/closet/crate/freezer/return_air()
 	var/datum/gas_mixture/gas = (..())
 	if(!gas)	return null

--- a/maps/offmap_vr/talon/talon_v2.dm
+++ b/maps/offmap_vr/talon/talon_v2.dm
@@ -903,7 +903,7 @@ personally I recommend using the ship's boat if you need to evacuate, but if you
 				/obj/random/medical,
 				/obj/random/medical/lite,
 				/obj/random/medical/lite,
-				/obj/structure/closet/crate/veymed //VM GRABBAG
+				/obj/structure/closet/crate/freezer/veymed //VM GRABBAG
 			),
 			prob(10);list(
 				/obj/random/firstaid,
@@ -912,7 +912,14 @@ personally I recommend using the ship's boat if you need to evacuate, but if you
 				/obj/random/firstaid,
 				/obj/random/unidentified_medicine/fresh_medicine,
 				/obj/random/unidentified_medicine/fresh_medicine,
-				/obj/structure/closet/crate/veymed //VM FAKS
+				/obj/structure/closet/crate/freezer/veymed //VM FAKS
+			),
+			prob(5);list(
+				/obj/random/internal_organ,
+				/obj/random/internal_organ,
+				/obj/random/internal_organ,
+				/obj/random/internal_organ,
+				/obj/structure/closet/crate/freezer/veymed //VM ORGANSES
 			),
 			prob(10);list(
 				/obj/random/tech_supply/nofail,
@@ -929,7 +936,7 @@ personally I recommend using the ship's boat if you need to evacuate, but if you
 				/obj/random/medical/pillbottle,
 				/obj/random/medical/lite,
 				/obj/random/medical/lite,
-				/obj/structure/closet/crate/zenghu //ZENGHU GRABBAG
+				/obj/structure/closet/crate/freezer/zenghu //ZENGHU GRABBAG
 			),
 			prob(10);list(
 				/obj/random/medical/pillbottle,
@@ -938,7 +945,7 @@ personally I recommend using the ship's boat if you need to evacuate, but if you
 				/obj/random/medical/pillbottle,
 				/obj/random/unidentified_medicine/fresh_medicine,
 				/obj/random/unidentified_medicine/fresh_medicine,
-				/obj/structure/closet/crate/zenghu //ZENGHU PILLS
+				/obj/structure/closet/crate/freezer/zenghu //ZENGHU PILLS
 			),
 			prob(10);list(
 				/obj/item/device/toner,


### PR DESCRIPTION
Adds a random organ spawner and a (relatively) rare vey-med crate to the random crate spawns which can contain up to four random basic non-brain internal organs (the random organ spawner has a 10% no-item rate).

Also adds veymed and zenghu styles for freezer crates, and changes the existing medical supply crate spawns to use the freezer crates.

As far as I can tell freezer crates are flagged to preserve organs, so as long as the crates are left closed they should be OK. I can't imagine there really being a circumstance in which they'll be used, but hey, most of the Talon loot is fluff anyways.

Random organs and crates; 
heart -> liver -> kidneys -> ??? -> ???
![image](https://user-images.githubusercontent.com/49700375/224853046-cbe0c590-3613-45bd-a809-ae6d7285f5b7.png)
plain freezer -> centauri -> NT -> VM -> ZH