### PR TITLE
Fixes missing pipes on tether.

### DIFF
--- a/maps/tether/tether-05-station1.dmm
+++ b/maps/tether/tether-05-station1.dmm
@@ -3266,6 +3266,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/engineering/hallway)
 "afu" = (
@@ -5633,6 +5636,9 @@
 /obj/machinery/door/firedoor/glass/hidden/steel{
 	dir = 2
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/engineering/hallway)
 "alR" = (
@@ -7013,6 +7019,9 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/hallway)


### PR DESCRIPTION
The pipe meant to feed air mix from backup atmospherics to the portable air pumps had three pieces missing.

![pipefix](https://user-images.githubusercontent.com/73252543/225149967-9eef6512-e8e4-43eb-8133-61800c3e1c28.png)
