### PR TITLE
Removes Anomalous Research Requirement from Graviton Goggles.

### DIFF
--- a/code/modules/research/designs/HUDs.dm
+++ b/code/modules/research/designs/HUDs.dm
@@ -41,7 +41,7 @@
 /datum/design/item/hud/graviton_visor
 	name = "graviton visor"
 	id = "graviton_goggles"
-	req_tech = list(TECH_MAGNET = 5, TECH_ENGINEERING = 3, TECH_BLUESPACE = 3, TECH_PHORON = 3, TECH_ARCANE = 1)
+	req_tech = list(TECH_MAGNET = 5, TECH_ENGINEERING = 3, TECH_BLUESPACE = 3, TECH_PHORON = 3)
 	materials = list(MAT_PLASTEEL = 2000, MAT_GLASS = 3000, MAT_PHORON = 1500, MAT_DIAMOND = 500)
 	build_path = /obj/item/clothing/glasses/graviton
 	sort_string = "EAAAE"

--- a/code/modules/research/designs/HUDs.dm
+++ b/code/modules/research/designs/HUDs.dm
@@ -42,6 +42,6 @@
 	name = "graviton visor"
 	id = "graviton_goggles"
 	req_tech = list(TECH_MAGNET = 5, TECH_ENGINEERING = 3, TECH_BLUESPACE = 3, TECH_PHORON = 3)
-	materials = list(MAT_PLASTEEL = 2000, MAT_GLASS = 3000, MAT_PHORON = 1500, MAT_DIAMOND = 500)
+	materials = list(MAT_PLASTEEL = 2000, MAT_GLASS = 3000, MAT_PHORON = 1500)
 	build_path = /obj/item/clothing/glasses/graviton
 	sort_string = "EAAAE"


### PR DESCRIPTION
This is an easily circumvented, vir native change that only serves to make mining more tedious.   I'm not even totally certain what the nerf was meant to accomplish.