### PR TITLE
Adds Firm Body trait and throwforce resistance

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -435,6 +435,10 @@ emp_act
 		var/dtype = O.damtype
 		var/throw_damage = O.throwforce*(speed/THROWFORCE_SPEED_DIVISOR)
 
+		if(species && species.throwforce_absorb_threshold >= throw_damage)
+			visible_message("<b>\The [O]</b> simply bounces off of [src]'s body!")
+			return
+
 		var/zone
 		if (istype(O.thrower, /mob/living))
 			var/mob/living/L = O.thrower

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -99,6 +99,7 @@
 	var/flash_mod =     1								// Stun from blindness modifier (flashes and flashbangs)
 	var/flash_burn =    0								// how much damage to take from being flashed if light hypersensitive
 	var/sound_mod =     1								// Multiplier to the effective *range* of flashbangs. a flashbang's bang hits an entire screen radius, with some falloff.
+	var/throwforce_absorb_threshold = 0					// Ignore damage of thrown items below this value
 
 	var/chem_strength_heal =    1						// Multiplier to most beneficial chem strength
 	var/chem_strength_pain =    1						// Multiplier to painkiller strength (could be used in a negative trait to simulate long-term addiction reducing effects, etc.)

--- a/code/modules/mob/living/carbon/human/species/station/prometheans.dm
+++ b/code/modules/mob/living/carbon/human/species/station/prometheans.dm
@@ -58,6 +58,7 @@ var/datum/species/shapeshifter/promethean/prometheans
 	oxy_mod =		0
 	flash_mod =		0.5 //No centralized, lensed eyes.
 	item_slowdown_mod = 1.33
+	throwforce_absorb_threshold = 10
 
 	chem_strength_alcohol = 2
 

--- a/code/modules/mob/living/carbon/human/species/station/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station.dm
@@ -72,6 +72,7 @@
 	species_language = LANGUAGE_UNATHI
 	health_hud_intensity = 2.5
 	chem_strength_alcohol = 0.75
+	throwforce_absorb_threshold = 10
 
 	min_age = 32
 	max_age = 260
@@ -403,6 +404,7 @@
 	name_language = LANGUAGE_ZADDAT
 	species_language = LANGUAGE_ZADDAT
 	health_hud_intensity = 2.5
+	throwforce_absorb_threshold = 5
 
 	minimum_breath_pressure = 20 //have fun with underpressures. any higher than this and they'll be even less suitible for life on the station
 
@@ -518,6 +520,7 @@
 	health_hud_intensity = 2.5
 	item_slowdown_mod = 0.1
 	chem_strength_alcohol = 0
+	throwforce_absorb_threshold = 5
 
 	num_alternate_languages = 3
 	name_language = LANGUAGE_ROOTLOCAL

--- a/code/modules/mob/living/carbon/human/species/station/station_special_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_special_vr.dm
@@ -331,6 +331,7 @@
 	slowdown = -0.15	//Small speedboost, as they've got a bunch of legs. Or something. I dunno.
 	brute_mod = 0.8		//20% brute damage reduction
 	burn_mod =  1.15	//15% burn damage increase. They're spiders. Aerosol can+lighter = dead spiders.
+	throwforce_absorb_threshold = 10
 
 	num_alternate_languages = 3
 	species_language = LANGUAGE_VESPINAE

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/positive.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/positive.dm
@@ -212,3 +212,9 @@
 	excludes = list(/datum/trait/negative/neural_hypersensitivity)
 	can_take = ORGANICS
 
+/datum/trait/positive/throw_resistance
+	name = "Firm Body"
+	desc = "Your body is firm enough that small thrown items can't do anything to you."
+	cost = 1
+	var_changes = list("throwforce_absorb_threshold" = 10)
+


### PR DESCRIPTION
Allows species to 'resist' thrown items (explicitly not bullets/projectiles or normal melee hits though) damage up to a threshold by having a body firm enough that said thrown items simply bounce off. Also adds a trait for that. Value is 'up to 10 damage'. Anything past 10 will deal damage and deal it fully, anything below will be completely negated. Again, only applies to 'thrown' things. Trait is positive, cost is 1 point.

Unathi, Vasilissan and Promethean have that trait by default. Diona and Zaddat have half-strength version with up to 5 damage intead.

Good trait for your custom species that has hard scales/chitin/gelatinous shell/etc.