### PR TITLE
Makes xeno egg ghost pods anchored

### DIFF
--- a/code/game/objects/structures/ghost_pods/antagonist.dm
+++ b/code/game/objects/structures/ghost_pods/antagonist.dm
@@ -11,6 +11,7 @@
 	density = FALSE
 	ghost_query_type = /datum/ghost_query/xenomorph_larva
 	delay_to_try_again = 1 MINUTES //10 minutes for egg to grow, 5 minutes for larva to mature
+	anchored = TRUE
 
 /obj/structure/ghost_pod/automatic/xenomorph_egg/create_occupant(var/mob/M)
 	var/mob/living/carbon/alien/larva/R = new(get_turf(src))

--- a/code/game/objects/structures/ghost_pods/antagonist.dm
+++ b/code/game/objects/structures/ghost_pods/antagonist.dm
@@ -6,7 +6,7 @@
 	description_info = "This contains a growing xenomorph larva, which may wake up at any moment. The larva will be another player, once activated."
 	icon = 'icons/mob/alien.dmi'
 	icon_state = "egg"
-	icon_state_opened = "egg_opened" //Can be placed on map with used = 1 for POI decorations
+	icon_state_opened = "egg_opened"
 	var/health = 50 //So they can be destroyed by the crew
 	density = FALSE
 	ghost_query_type = /datum/ghost_query/xenomorph_larva


### PR DESCRIPTION
- Anchors xenomorph egg ghost pods, forgot to do that little thing. Do'h!
- Removed comment on line 9, this trick doesn't always work. Best to not spread misinformation.