### PR TITLE
Field Generators Glow!

### DIFF
--- a/code/modules/power/singularity/containment_field.dm
+++ b/code/modules/power/singularity/containment_field.dm
@@ -9,7 +9,10 @@
 	density = FALSE
 	unacidable = TRUE
 	use_power = USE_POWER_OFF
-	light_range = 4
+	light_on = TRUE
+	light_range = 2
+	light_power = 0.5
+	light_color = "#5BA8FF"
 	var/obj/machinery/field_generator/FG1 = null
 	var/obj/machinery/field_generator/FG2 = null
 	var/list/shockdirs

--- a/code/modules/power/singularity/field_generator.dm
+++ b/code/modules/power/singularity/field_generator.dm
@@ -36,6 +36,10 @@ field_generator power level display
 	var/gen_power_draw = 5500	//power needed per generator
 	var/field_power_draw = 2000	//power needed per field object
 
+	var/light_range_on = 3
+	var/light_power_on = 1
+	light_color = "#5BA8FF"
+
 
 /obj/machinery/field_generator/update_icon()
 	cut_overlays()
@@ -177,6 +181,7 @@ field_generator power level display
 	active = 0
 	spawn(1)
 		src.cleanup()
+		set_light(0)
 	update_icon()
 
 /obj/machinery/field_generator/proc/turn_on()
@@ -189,6 +194,7 @@ field_generator power level display
 			update_icon()
 			if(warming_up >= 3)
 				start_fields()
+				set_light(light_range_on, light_power_on)
 	update_icon()
 
 


### PR DESCRIPTION
Another really minor thing that was bothering me. Field generators emit fancy energy barriers and all, but don't emit light? No longer! Now they emit a cool blue glow whilst active, as do the actual containment fields.

Engineering: now with a significant reduction in the risk of walking into an energy barrier that can slap you for fifty damage!

![image](https://user-images.githubusercontent.com/49700375/230545310-4811a5b9-6696-4c2f-84e1-9a5355da7fb8.png)

Tested and works nicely.