### PR TITLE
Adjusts sectors to have real_icons

### DIFF
--- a/code/modules/overmap/sectors.dm
+++ b/code/modules/overmap/sectors.dm
@@ -95,7 +95,7 @@
 /obj/effect/overmap/visitable/proc/gmtools_update_omobject_vars(var/setToHidden)
 	real_appearance = image(real_icon, src, real_icon_state)
 	real_appearance.override = TRUE
-	if(!setToHidden && known) //
+	if(setToHidden && known) //
 		name = unknown_name
 		icon = 'icons/obj/overmap.dmi'
 		icon_state = unknown_state


### PR DESCRIPTION
Fixes https://github.com/VOREStation/VOREStation/issues/14762
* Previous implementation relied on icon and icon_state at compile time.
* This prevented GMs from editing icon_state, as it always reverted to defaults when scanned
* GMs can now edit real_icon using var edit->E "Icon" to use non-standard icon_states
* GMs can now edit real_icon_state to choose specific state as a simple text var type edit
* GMs can call a proc called gmtools_update_omobject_vars(setToHidden) with an argument that forces known locations to become unknown again with an arg of "1"
* If GM uses arg of 0, proc simply changes how pilots inside the sector see their own ship by updating real_appearance with real_icon_state. With an arg of 1, it makes the area unknown again.
* real_appearance differs from icon_state if the area is known = False


Furthermore, see comment on the bugreport for parts involving name/desc already being fixed if using the "real_*" vars.

I tried to make real_icon be possible to be varedited using a simple text input. Unfortunately, I do not see any means to do so, thus GMs must use file or icon varedit options to actually touch it.

Testing:
- proc works to reset a visitable sector to known = false with all the visible stuff changed to reflect that even after it was scanned

As seen, changing the real_icon_state also works! If the real_icon_state is not found inside icon or real_icon, it will just change the icon to a "bug"
[- ](https://cdn.discordapp.com/attachments/173831852602294272/1093864067610988624/image.png)