### PR TITLE
Adds verb to AR glasses to toggle vision planes

### DIFF
--- a/code/modules/clothing/glasses/hud_vr.dm
+++ b/code/modules/clothing/glasses/hud_vr.dm
@@ -13,6 +13,8 @@
 	var/flash_prot = 0 //0 for none, 1 for flash weapon protection, 2 for welder protection
 	enables_planes = list(VIS_CH_ID,VIS_CH_HEALTH_VR,VIS_AUGMENTED)
 	plane_slots = list(slot_glasses)
+	var/ar_toggled = TRUE //Used for toggle_ar_planes() verb
+
 
 /obj/item/clothing/glasses/omnihud/New()
 	..()
@@ -27,6 +29,14 @@
 	if(tgarscreen)
 		SStgui.close_uis(src)
 	..()
+
+/obj/item/clothing/glasses/omnihud/examine()
+	. = ..()
+	if(ar_toggled)
+		. += "\n <span class='notice'>The HUD indicator reads ON.</span>"
+	else
+		. += "\n <span class='notice'>The HUD indicator reads OFF.</span>"
+
 
 /obj/item/clothing/glasses/omnihud/emp_act(var/severity)
 	if(tgarscreen)
@@ -113,6 +123,29 @@
 		else
 			to_chat(usr, "The [src] don't seem to support this functionality.")
 	update_clothing_icon()
+
+/obj/item/clothing/glasses/omnihud/verb/toggle_ar_planes()
+	set name = "Toggle AR Heads-Up Display"
+	set desc = "Toggles the job icon and other non-manually requested displays. Does not disable Crew monitor and similar."
+	set category = "Object"
+	set src in usr
+
+	//We do not check if user can move or not, since this system is inspired to help see chat bubbles during scenes primarily.
+	//Preventing turning off the HUD could get in the way of scene flow.
+	usr.visible_emote("toggles a button on their [src.name]!") //Since we're turning stuff like arrest/medical HUD on/off, we should inform those nearby.
+	if(ar_toggled)
+		away_planes = enables_planes
+		enables_planes = null
+		to_chat(usr, SPAN_NOTICE("You disabled the Augmented Reality HUD of your [src.name]."))
+	else
+		enables_planes = away_planes
+		away_planes = null
+		to_chat(usr, SPAN_NOTICE("You enabled the Augmented Reality HUD of your [src.name]."))
+	ar_toggled = !ar_toggled
+	usr.update_action_buttons()
+	usr.recalculate_vis()
+
+
 
 /obj/item/clothing/glasses/omnihud/proc/ar_interact(var/mob/living/carbon/human/user)
 	return 0 //The base models do nothing.


### PR DESCRIPTION
I love glasses. Glasses are great. _insert fubuki glasses copypasta_
Unfortunately, AR glasses of any sort cause a HUD indicator for job to appear. 
Inconveniently it happens to block chat bubbles, forcing me to take my glasses off while my partner is typing to check if they're typing or crashed or waiting for me to finish.
I want to wear my AR glasses all the time because glasses are great.
This enables me to do so


*Also adds a redefinition of examine() to /omnihud path
*This redefinition gives information on examine if HUD should be ON/OFF
*The verb notifies nearby players through a visible_emote that you toggled your HUD
*Toggling saves current enabled_planes into a var to reload when you toggle it back on.
*The new verb appears as a right click option, and as a verb in "Object" tab.

The reason I did not use the pre-existing "can_toggle" var is because it relies on attackself from what I understand, and we overwrite that code for omnihuds to enable things like alarms, crew monitor and the like.

