### PR TITLE
Adds PrettyBuild to Tasks for VSCode

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -33,6 +33,19 @@
 			"problemMatcher": [],
 			"label": "tgui: build tgfont",
 			"detail": "node mkdist.cjs && fantasticon --config config.cjs"
+		},
+		{
+			"type": "shell",
+			"command": "tgui/bin/tgui",
+			"windows": {
+				"command": ".\\tgui\\bin\\tgui-prettybuild.bat"
+			},
+			"problemMatcher": [
+				"$tsc",
+				"$eslint-stylish"
+			],
+			"group": "build",
+			"label": "tgui: prettybuild"
 		}
 	]
 }


### PR DESCRIPTION
No more opening up your file directory to run the .bat, just do it from vscode instead.

add the deprecated label to the old tgui build if you are no longer using that in your workflow