### PR TITLE
Lipozine Plus

### DIFF
--- a/code/modules/reagents/reactions/instant/instant_vr.dm
+++ b/code/modules/reagents/reactions/instant/instant_vr.dm
@@ -163,6 +163,13 @@
 	required_reagents = list("carbon" = 3, "iron" = 1, "nitrogen" = 3)
 	result_amount = 7
 
+/decl/chemical_reaction/instant/lipozineplus
+	name = "Lipozine Plus"
+	id = "Lipozine Plus"
+	result = "lipozineplus"
+	required_reagents = list("lipozine" = 1, "diethylamine" = 1)
+	result_amount = 2
+
 ///////////////////////////////////////////////////////////////////////////////////
 /// Reagent colonies.
 /decl/chemical_reaction/instant/meatcolony

--- a/code/modules/reagents/reactions/instant/instant_vr.dm
+++ b/code/modules/reagents/reactions/instant/instant_vr.dm
@@ -163,12 +163,19 @@
 	required_reagents = list("carbon" = 3, "iron" = 1, "nitrogen" = 3)
 	result_amount = 7
 
-/decl/chemical_reaction/instant/lipozineplus
-	name = "Lipozine Plus"
-	id = "Lipozine Plus"
-	result = "lipozineplus"
+/decl/chemical_reaction/instant/lipozilase
+	name = "Lipozilase"
+	id = "Lipozilase"
+	result = "lipozilase"
 	required_reagents = list("lipozine" = 1, "diethylamine" = 1)
 	result_amount = 2
+
+/decl/chemical_reaction/instant/lipostipo
+	name = "Lipostipo"
+	id = "Lipostipo"
+	result = "lipostipo"
+	required_reagents = list("lipozine" = 1, "nutriment" = 1, "fluorine" = 1)
+	result_amount = 3
 
 ///////////////////////////////////////////////////////////////////////////////////
 /// Reagent colonies.

--- a/code/modules/reagents/reagents/medicine_vr.dm
+++ b/code/modules/reagents/reagents/medicine_vr.dm
@@ -111,3 +111,17 @@
 		return
 	if(prob(10)) //Miniscule chance of removing some toxins.
 		M.adjustToxLoss(-10 * removed)
+
+/datum/reagent/lipozineplus // The anti-nutriment that rapidly removes weight.
+	name = "Lipozine Plus"
+	id = "lipozineplus"
+	description = "A chemical compound that causes a dangerously powerful fat-burning reaction."
+	taste_description = "mothballs"
+	reagent_state = LIQUID
+	color = "#47AD6D"
+	overdose = REAGENTS_OVERDOSE
+
+/datum/reagent/lipozineplus/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
+	M.adjust_nutrition(-20 * removed)
+	if(M.weight > 50)
+		M.weight -= 0.3

--- a/code/modules/reagents/reagents/medicine_vr.dm
+++ b/code/modules/reagents/reagents/medicine_vr.dm
@@ -125,3 +125,30 @@
 	M.adjust_nutrition(-20 * removed)
 	if(M.weight > 50)
 		M.weight -= 0.3
+
+/datum/reagent/lipozilase // The anti-nutriment that rapidly removes weight.
+	name = "Lipozilase"
+	id = "lipozilase"
+	description = "A chemical compound that causes a dangerously powerful fat-burning reaction."
+	taste_description = "blandness"
+	reagent_state = LIQUID
+	color = "#47AD6D"
+	overdose = REAGENTS_OVERDOSE
+
+/datum/reagent/lipozilase/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
+	M.adjust_nutrition(-20 * removed)
+	if(M.weight > 50)
+		M.weight -= 0.3
+
+/datum/reagent/lipostipo // The drug that rapidly increases weight.
+	name = "Lipostipo"
+	id = "lipostipo"
+	description = "A chemical compound that causes a dangerously powerful fat-adding reaction."
+	taste_description = "blubber"
+	reagent_state = LIQUID
+	color = "#61731C"
+	overdose = REAGENTS_OVERDOSE
+
+/datum/reagent/lipostipo/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
+	if(M.weight < 500) // No nutrition addedn from this horribly unhealthy drug, just makes you fat without even filling you up.
+		M.weight += 0.3

--- a/code/modules/reagents/reagents/medicine_vr.dm
+++ b/code/modules/reagents/reagents/medicine_vr.dm
@@ -112,20 +112,6 @@
 	if(prob(10)) //Miniscule chance of removing some toxins.
 		M.adjustToxLoss(-10 * removed)
 
-/datum/reagent/lipozineplus // The anti-nutriment that rapidly removes weight.
-	name = "Lipozine Plus"
-	id = "lipozineplus"
-	description = "A chemical compound that causes a dangerously powerful fat-burning reaction."
-	taste_description = "mothballs"
-	reagent_state = LIQUID
-	color = "#47AD6D"
-	overdose = REAGENTS_OVERDOSE
-
-/datum/reagent/lipozineplus/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
-	M.adjust_nutrition(-20 * removed)
-	if(M.weight > 50)
-		M.weight -= 0.3
-
 /datum/reagent/lipozilase // The anti-nutriment that rapidly removes weight.
 	name = "Lipozilase"
 	id = "lipozilase"

--- a/code/modules/reagents/reagents/medicine_vr.dm
+++ b/code/modules/reagents/reagents/medicine_vr.dm
@@ -150,5 +150,6 @@
 	overdose = REAGENTS_OVERDOSE
 
 /datum/reagent/lipostipo/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
-	if(M.weight < 500) // No nutrition addedn from this horribly unhealthy drug, just makes you fat without even filling you up.
+	M.adjust_nutrition(-20 * removed)
+	if(M.weight < 500)
 		M.weight += 0.3


### PR DESCRIPTION
Adds a drug called Lipozine Plus, made with lipozine and diethylamine. Causes both a nutrition drain and a steady drain of actual weight from the person who has drunk it. Drains weight at a rate of 3 lbs per 1u, has an overdose limit of 30u with the normal toxin effect. Does not check for weight loss rate, as it's pretty much a scene tool used to modify weight directly. Stops draining weight when it reaches 50lbs.
Tested locally and seems to work as expected.

I'm sorry that I didn't want to figure out how to make an overdose cause you to spontaneously combust, tost.