### PR TITLE
Fixes simple_mob ID giving system

### DIFF
--- a/code/modules/mob/living/simple_mob/simple_mob.dm
+++ b/code/modules/mob/living/simple_mob/simple_mob.dm
@@ -166,13 +166,13 @@
 	var/understands_common = TRUE 		//VOREStation Edit - Makes it so that simplemobs can understand galcomm without being able to speak it.
 	var/heal_countdown = 5				//VOREStation Edit - A cooldown ticker for passive healing
 	var/list/myid_access = list() //VOREStation Edit
-	var/mobcard_provided = FALSE //VOREStation Edit
+	var/ID_provided = FALSE //VOREStation Edit
 
 /mob/living/simple_mob/Initialize()
 	verbs -= /mob/verb/observe
 	health = maxHealth
 
-	if(mobcard_provided) //VOREStation Edit
+	if(ID_provided) //VOREStation Edit
 		myid = new /obj/item/weapon/card/id(src)
 		myid.access = myid_access.Copy()
 

--- a/code/modules/mob/living/simple_mob/simple_mob.dm
+++ b/code/modules/mob/living/simple_mob/simple_mob.dm
@@ -165,8 +165,7 @@
 	var/limb_icon_key
 	var/understands_common = TRUE 		//VOREStation Edit - Makes it so that simplemobs can understand galcomm without being able to speak it.
 	var/heal_countdown = 5				//VOREStation Edit - A cooldown ticker for passive healing
-	var/obj/item/weapon/card/id/mobcard = null //VOREStation Edit
-	var/list/mobcard_access = list() //VOREStation Edit
+	var/list/myid_access = list() //VOREStation Edit
 	var/mobcard_provided = FALSE //VOREStation Edit
 
 /mob/living/simple_mob/Initialize()
@@ -174,8 +173,8 @@
 	health = maxHealth
 
 	if(mobcard_provided) //VOREStation Edit
-		mobcard = new /obj/item/weapon/card/id(src)
-		mobcard.access = mobcard_access.Copy()
+		myid = new /obj/item/weapon/card/id(src)
+		myid.access = myid_access.Copy()
 
 	for(var/L in has_langs)
 		languages |= GLOB.all_languages[L]
@@ -307,13 +306,3 @@
 
 /decl/mob_organ_names
 	var/list/hit_zones = list("body") //When in doubt, it's probably got a body.
-
-//VOREStation Add Start 	For allowing mobs with ID's door access
-/mob/living/simple_mob/Bump(var/atom/A)
-	if(mobcard && istype(A, /obj/machinery/door))
-		var/obj/machinery/door/D = A
-		if(client && !istype(D, /obj/machinery/door/firedoor) && !istype(D, /obj/machinery/door/blast) && !istype(D, /obj/machinery/door/airlock/lift) && D.check_access(mobcard))
-			D.open()
-	else
-		..()
-//Vorestation Add End

--- a/code/modules/mob/living/simple_mob/subtypes/animal/alien animals/catslug.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/alien animals/catslug.dm
@@ -426,7 +426,7 @@
 	catalogue_data = list(/datum/category_item/catalogue/fauna/catslug/custom/engislug)
 	holder_type = /obj/item/weapon/holder/catslug/custom/engislug
 	say_list_type = /datum/say_list/catslug/custom/engislug
-	mobcard_access = list(access_engine, access_engine_equip, access_tech_storage, access_maint_tunnels, access_construction, access_atmospherics)
+	myid_access = list(access_engine, access_engine_equip, access_tech_storage, access_maint_tunnels, access_construction, access_atmospherics)
 	siemens_coefficient = 0 		//Noodly fella's gone and built up an immunity from many small shocks
 
 	minbodytemp = 200
@@ -543,7 +543,7 @@
 		"bio" = 0,
 		"rad" = 0
 		)		//Similarly, \some\ armour values for a smidge more survivability compared to other catslugs.
-	mobcard_access = list(access_security, access_sec_doors, access_forensics_lockers, access_maint_tunnels)
+	myid_access = list(access_security, access_sec_doors, access_forensics_lockers, access_maint_tunnels)
 
 /datum/say_list/catslug/custom/gatslug
 	speak = list("Have any flashbangs?", "Valids!", "Heard spiders?", "What is that?", "Freeze!", "What are you doing?", "How did you get here?", "Red alert means big bangsticks.", "No being naughty now.", "WAOW!", "Who ate all the donuts?")
@@ -580,7 +580,7 @@
 	catalogue_data = list(/datum/category_item/catalogue/fauna/catslug/custom/medislug)
 	holder_type = /obj/item/weapon/holder/catslug/custom/medislug
 	say_list_type = /datum/say_list/catslug/custom/medislug
-	mobcard_access = list(access_medical, access_morgue, access_surgery, access_chemistry, access_virology, access_genetics)
+	myid_access = list(access_medical, access_morgue, access_surgery, access_chemistry, access_virology, access_genetics)
 
 /datum/say_list/catslug/custom/medislug
 	speak = list("Have any osteodaxon?", "What is that?", "Suit sensors!", "What are you doing?", "How did you get here?", "Put a mask on!", "No smoking!", "WAOW!", "Stop getting blood everywhere!", "WHERE IN MAINT?")
@@ -616,7 +616,7 @@
 	catalogue_data = list(/datum/category_item/catalogue/fauna/catslug/custom/scienceslug)
 	holder_type = /obj/item/weapon/holder/catslug/custom/scienceslug
 	say_list_type = /datum/say_list/catslug/custom/scienceslug
-	mobcard_access = list(access_robotics, access_tox, access_tox_storage, access_research, access_xenobiology, access_xenoarch)
+	myid_access = list(access_robotics, access_tox, access_tox_storage, access_research, access_xenobiology, access_xenoarch)
 
 
 /datum/say_list/catslug/custom/scienceslug
@@ -654,7 +654,7 @@
 	catalogue_data = list(/datum/category_item/catalogue/fauna/catslug/custom/cargoslug)
 	holder_type = /obj/item/weapon/holder/catslug/custom/cargoslug
 	say_list_type = /datum/say_list/catslug/custom/cargoslug
-	mobcard_access = list(access_maint_tunnels, access_mailsorting, access_cargo, access_cargo_bot, access_mining, access_mining_station)
+	myid_access = list(access_maint_tunnels, access_mailsorting, access_cargo, access_cargo_bot, access_mining, access_mining_station)
 
 /datum/say_list/catslug/custom/cargoslug
 	speak = list("Disposals is not for slip and slide.", "What is that?", "Stamp those manifests!", "What are you doing?", "How did you get here?", "Can order pizza crate?", "WAOW!", "Where are all of our materials?", "Got glubbs?")
@@ -693,7 +693,7 @@
 	catalogue_data = list(/datum/category_item/catalogue/fauna/catslug/custom/capslug)
 	holder_type = /obj/item/weapon/holder/catslug/custom/capslug
 	say_list_type = /datum/say_list/catslug/custom/capslug
-	mobcard_access = list(access_maint_tunnels)		//The all_station_access part below adds onto this.
+	myid_access = list(access_maint_tunnels)		//The all_station_access part below adds onto this.
 
 /datum/say_list/catslug/custom/capslug
 	speak = list("How open big glass box with shiny inside?.", "What is that?", "Respect my authority!", "What are you doing?", "How did you get here?", "Fax for yellow-shirts!", "WAOW!", "Why is that console blinking and clicking?", "Do we need to call for ERT?", "Have been called comdom before, not sure why they thought I was a balloon.")
@@ -708,7 +708,7 @@
 	mob_radio.ks2type = /obj/item/device/encryptionkey/heads/captain 		//Might not be able to speak, but the catslug can listen.
 	mob_radio.keyslot2 = new /obj/item/device/encryptionkey/heads/captain(mob_radio)
 	mob_radio.recalculateChannels(1)
-	mobcard.access |= get_all_station_access()
+	myid.access |= get_all_station_access()
 
 //=============================================================================
 //Admin-spawn only catslugs below - Expect overpowered things & silliness below
@@ -725,7 +725,7 @@
 	icon_dead = "deathslug_dead"
 	catalogue_data = list(/datum/category_item/catalogue/fauna/catslug) 			//So they don't get the spaceslug's cataloguer entry
 	say_list_type = /datum/say_list/catslug 			//Similarly, so they don't get the spaceslug's speech lines.
-	mobcard_access = list(access_cent_general, access_cent_specops, access_cent_living, access_cent_storage)
+	myid_access = list(access_cent_general, access_cent_specops, access_cent_living, access_cent_storage)
 	maxHealth = 100		//Tough noodles
 	health = 100
 	taser_kill = 0
@@ -750,7 +750,7 @@
 	. = ..()
 	mob_radio = new /obj/item/device/radio/headset/mob_headset(src)
 	mob_radio.frequency = DTH_FREQ 			//Can't tell if bugged, deathsquad freq in general seems broken
-	mobcard.access |= get_all_station_access()
+	myid.access |= get_all_station_access()
 
 //Syndicate catslug
 /mob/living/simple_mob/vore/alienanimals/catslug/custom/spaceslug/syndislug
@@ -763,7 +763,7 @@
 	icon_dead = "syndislug_dead"
 	catalogue_data = list(/datum/category_item/catalogue/fauna/catslug)
 	say_list_type = /datum/say_list/catslug
-	mobcard_access = list(access_maint_tunnels, access_syndicate, access_external_airlocks)
+	myid_access = list(access_maint_tunnels, access_syndicate, access_external_airlocks)
 	faction = "syndicate"
 	maxHealth = 100		//Tough noodles
 	health = 100
@@ -795,7 +795,7 @@
 	mob_radio.ks2type = /obj/item/device/encryptionkey/syndicate
 	mob_radio.keyslot2 = new /obj/item/device/encryptionkey/syndicate(mob_radio)
 	mob_radio.recalculateChannels(1)
-	mobcard.access |= get_all_station_access()
+	myid.access |= get_all_station_access()
 
 //ERT catslug
 /mob/living/simple_mob/vore/alienanimals/catslug/custom/spaceslug/responseslug
@@ -808,7 +808,7 @@
 	icon_dead = "responseslug_dead"
 	catalogue_data = list(/datum/category_item/catalogue/fauna/catslug)
 	say_list_type = /datum/say_list/catslug
-	mobcard_access = list(access_cent_general, access_cent_specops, access_cent_living, access_cent_storage)
+	myid_access = list(access_cent_general, access_cent_specops, access_cent_living, access_cent_storage)
 	maxHealth = 100		//Tough noodles
 	health = 100
 	taser_kill = 0
@@ -839,7 +839,7 @@
 	mob_radio.ks2type = /obj/item/device/encryptionkey/ert
 	mob_radio.keyslot2 = new /obj/item/device/encryptionkey/ert(mob_radio)
 	mob_radio.recalculateChannels(1)
-	mobcard.access |= get_all_station_access()
+	myid.access |= get_all_station_access()
 
 //Pilot Catslug
 

--- a/code/modules/mob/living/simple_mob/subtypes/animal/alien animals/catslug.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/alien animals/catslug.dm
@@ -44,7 +44,7 @@
 	friendly = list("hugs")
 	see_in_dark = 8
 
-	mobcard_provided = TRUE
+	ID_provided = TRUE
 
 	catalogue_data = list(/datum/category_item/catalogue/fauna/catslug)
 	ai_holder_type = /datum/ai_holder/simple_mob/melee/evasive/catslug

--- a/code/modules/ventcrawl/ventcrawl.dm
+++ b/code/modules/ventcrawl/ventcrawl.dm
@@ -69,7 +69,7 @@ var/list/ventcrawl_machinery = list(
 		return 1
 	if(isanimal(src))
 		var/mob/living/simple_mob/S = src
-		if(carried_item == S.mobcard)	//VOREStation Edit
+		if(carried_item == S.myid)	//VOREStation Edit
 			return 1	//VOREStation Edit
 	//Try to find it in our allowed list (istype includes subtypes)
 	var/listed = FALSE


### PR DESCRIPTION
So this is a weird one. At one point someone added custom code for giving ID's to simple mobs, but they gave it it's own custom slot. This causes **a lot** of weird issues with ID's when given to simple mobs, since a large amount of ID interactions are done on a slot called "myid".

This PR removes the custom "mobcard" slot and interaction, and switches it over to the already existing "myid" slot that is used everywhere. This fixes quite a many issues with simple mobs using their in-built ID's, especially cat slugs since they use the ID system the most. Some of these fixes include :

- Can now click open doors instead of being forced to bump into them
- Can use access restricted vending machines they have access to
- Can use access restricted consoles they have access to
- Can unlock lockers they have access to
- Can use access restricted buttons they have access to, airlock cyclers and blast door buttons being two examples
- Can change shortwave radios to department specific channels if they have the access

These are just some of the issues that were fixed by switching over to the already existing myid system.