### PR TITLE
One-way conveyor switches

### DIFF
--- a/code/modules/recycling/conveyor2.dm
+++ b/code/modules/recycling/conveyor2.dm
@@ -332,7 +332,7 @@
 /obj/machinery/conveyor_switch/oneway
 	oneway = 1
 
-/obj/machinery/conveyor_switch/examine
+/obj/machinery/conveyor_switch/examine()
 	.=..()
-	if(oneway)
-	. += " It appears to only go in one direction."
+	if(oneway == 1)
+		. += " It appears to only go in one direction."

--- a/code/modules/recycling/conveyor2.dm
+++ b/code/modules/recycling/conveyor2.dm
@@ -207,6 +207,7 @@
 	var/position = 0			// 0 off, -1 reverse, 1 forward
 	var/last_pos = -1			// last direction setting
 	var/operated = 1			// true if just operated
+	var/oneway = 0				// Voreadd: One way levels mid-round!
 
 	var/id = "" 				// must match conveyor IDs to control them
 
@@ -265,7 +266,7 @@
 		return
 
 	if(position == 0)
-		if(last_pos < 0)
+		if(last_pos < 0 || oneway == 1)
 			position = 1
 			last_pos = 0
 		else
@@ -315,22 +316,23 @@
 					conveyors += C
 			return
 
+	if(istype(I, /obj/item/weapon/tool/wrench))
+		if(panel_open)
+			if(oneway == 1)
+				to_chat(user, "You set the switch to two way operation.")
+				oneway = 0
+				playsound(src, I.usesound, 50, 1)
+				return
+			else
+				to_chat(user, "You set the switch to one way operation.")
+				oneway = 1
+				playsound(src, I.usesound, 50, 1)
+				return
+
 /obj/machinery/conveyor_switch/oneway
-	var/convdir = 1 //Set to 1 or -1 depending on which way you want the convayor to go. (In other words keep at 1 and set the proper dir on the belts.)
-	desc = "A conveyor control switch. It appears to only go in one direction."
+	oneway = 1
 
-// attack with hand, switch position
-/obj/machinery/conveyor_switch/oneway/attack_hand(mob/user)
-	if(position == 0)
-		position = convdir
-	else
-		position = 0
-
-	operated = 1
-	update()
-
-	// find any switches with same id as this one, and set their positions to match us
-	for(var/obj/machinery/conveyor_switch/S in machines)
-		if(S.id == src.id)
-			S.position = position
-			S.update()
+/obj/machinery/conveyor_switch/examine
+	.=..()
+	if(oneway)
+	. += " It appears to only go in one direction."

--- a/maps/tether/tether-05-station1.dmm
+++ b/maps/tether/tether-05-station1.dmm
@@ -24233,7 +24233,7 @@
 /area/gateway/prep_room)
 "kHf" = (
 /obj/machinery/conveyor_switch/oneway{
-	convdir = -1;
+	//convdir = -1;		//Incompatable with new behavior -Reo
 	id = "QMLoad2"
 	},
 /obj/machinery/light{


### PR DESCRIPTION
Makes it possible to make one-way switches that are not limited to being mapper only, inspired by other codebases that do similar things (TG and Yogs I know do this.)

You can make a switch into a one-way (or make a one-way back into a two-way) by wrenching it with it's service panel open.

The original one-way lever is changed to use the new system as well, so maps dont need to remove the levers or anything. Aside one which for some reason was a var-edited one-way switch to be reverse only?? I commented out the var-edit so it wouldn't error.