### PR TITLE
Chocolate Allergy

### DIFF
--- a/code/__defines/species_languages.dm
+++ b/code/__defines/species_languages.dm
@@ -38,6 +38,7 @@
 #define ALLERGEN_SUGARS		0x400	// For unathi-like reactions
 #define ALLERGEN_EGGS		0x800	// For Skrell eggs allergy
 #define ALLERGEN_STIMULANT	0x1000	// Stimulants are what makes the Tajaran heart go ruh roh - not just coffee!
+#define ALLERGEN_CHOCOLATE	0x2000	// Makes dogs die if they want to?
 
 // Allergen reactions
 #define AG_PHYS_DMG	0x1	// brute

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
@@ -306,6 +306,13 @@
 	custom_only = FALSE
 	allergen = ALLERGEN_COFFEE
 
+/datum/trait/neutral/allergy/chocolate
+	name = "Allergy: Chocolate"
+	desc = "You're highly allergic to coco and chocolate in specific. NB: By taking this trait, you acknowledge there is a significant risk your character may suffer a fatal reaction if exposed to this substance."
+	cost = 0
+	custom_only = FALSE
+	allergen = ALLERGEN_CHOCOLATE
+
 /datum/trait/neutral/allergy_reaction
 	name = "Allergy Reaction: Disable Toxicity"
 	desc = "Take this trait to disable the toxic damage effect of being exposed to one of your allergens. Combine with the Disable Suffocation trait to have purely nonlethal reactions."

--- a/code/modules/reagents/reagents/food_drinks.dm
+++ b/code/modules/reagents/reagents/food_drinks.dm
@@ -435,6 +435,7 @@
 	reagent_state = SOLID
 	nutriment_factor = 5
 	color = "#302000"
+	allergen_type = ALLERGEN_CHOCOLATE
 
 /datum/reagent/nutriment/chocolate
 	name = "Chocolate"
@@ -444,6 +445,7 @@
 	color = "#582815"
 	nutriment_factor = 5
 	taste_mult = 1.3
+	allergen_type = ALLERGEN_CHOCOLATE
 
 /datum/reagent/nutriment/instantjuice
 	name = "Juice Powder"
@@ -691,6 +693,7 @@
 	description = "A dry mix for making delicious brownies."
 	reagent_state = SOLID
 	color = "#441a03"
+	allergen_type = ALLERGEN_CHOCOLATE
 
 /datum/reagent/cakebatter
 	name = "Cake Batter"
@@ -1220,6 +1223,7 @@
 
 	glass_name = "chocolate milk"
 	glass_desc = "Deliciously fattening!"
+	allergen_type = ALLERGEN_CHOCOLATE
 
 /datum/reagent/drink/milk/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed)
 	..()
@@ -1660,6 +1664,7 @@
 	cup_icon_state = "cup_coco"
 	cup_name = "cup of hot chocolate"
 	cup_desc = "Made with love! And cocoa beans."
+	allergen_type = ALLERGEN_CHOCOLATE
 
 /datum/reagent/drink/soda/sodawater
 	name = "Soda Water"
@@ -1834,7 +1839,7 @@
 
 	glass_name = "Chocolate Milkshake"
 	glass_desc = "A refreshing chocolate milkshake, just like mom used to make."
-	allergen_type = ALLERGEN_DAIRY //Made with dairy products
+	allergen_type = ALLERGEN_DAIRY|ALLERGEN_CHOCOLATE //Made with dairy products
 
 /datum/reagent/drink/milkshake/berryshake
 	name = "Berry Milkshake"


### PR DESCRIPTION
Adds a neutral trait for an allergy to chocolate.
Adds ALLERGEN_CHOCOLATE tag to a number of food/drink reagents, such as coco, chocolate, chocolate milk.

Tested and it seems to work fine with the foods that I tested (chocolate bar, hot chocolate and a few others).