### PR TITLE
Shotgun Tweak

### DIFF
--- a/code/modules/projectiles/ammunition/rounds.dm
+++ b/code/modules/projectiles/ammunition/rounds.dm
@@ -273,7 +273,7 @@
 
 /obj/item/ammo_casing/a12g
 	name = "shotgun slug"
-	desc = "A 12 gauge slug."
+	desc = "A 12 gauge slug shell."
 	icon_state = "slshell"
 	caliber = "12g"
 	projectile_type = /obj/item/projectile/bullet/shotgun
@@ -281,9 +281,9 @@
 
 /obj/item/ammo_casing/a12g/pellet
 	name = "shotgun shell"
-	desc = "A 12 gauge shell."
+	desc = "A 12 gauge buckshot shell."
 	icon_state = "gshell"
-	projectile_type = /obj/item/projectile/bullet/pellet/shotgun
+	projectile_type = /obj/item/projectile/scatter/shotgun //formerly /obj/item/projectile/bullet/pellet/shotgun
 
 /obj/item/ammo_casing/a12g/blank
 	name = "shotgun shell"
@@ -301,7 +301,7 @@
 
 /obj/item/ammo_casing/a12g/beanbag
 	name = "beanbag shell"
-	desc = "A beanbag shell."
+	desc = "A 12 gauge beanbag shell."
 	icon_state = "bshell"
 	projectile_type = /obj/item/projectile/bullet/shotgun/beanbag
 	matter = list(MAT_STEEL = 180)

--- a/code/modules/projectiles/projectile/scatter.dm
+++ b/code/modules/projectiles/projectile/scatter.dm
@@ -86,6 +86,21 @@
  * Ballistic
  */
 
+/obj/item/projectile/scatter/shotgun
+	name = "Shotgun scatter projectile"
+	hud_state = "shotgun_buckshot"
+	spread_submunition_damage = FALSE
+	submunition_spread_max = 60
+	submunition_spread_min = 50
+	submunitions = list(
+		/obj/item/projectile/bullet/shotgun/scatterprojectile = 6
+		)
+
+/obj/item/projectile/bullet/shotgun/scatterprojectile
+	name = "pellet"
+	fire_sound = 'sound/weapons/Gunshot_shotgun.ogg'
+	damage = 12
+	armor_penetration = 0
 
 /obj/item/projectile/scatter/flechette
 	damage = 60


### PR DESCRIPTION
Lifts some old tweaks from downstream to make [shotgun](https://www.youtube.com/watch?v=7JtH_0WcKyA) shotshells behave you'd expect: they release a cluster of pellets that individually do damage, not whatever the weird clustering system is.

Still pretty powerful up close (12x6=72 damage!) but spread and BayMiss™ will eat the damage alive at longer ranges, as will heavy armour.

Replaces shotgun pellet shell contents wholesale, though the original projectile is untouched.