### PR TITLE
Altevian Clothing Fix

### DIFF
--- a/code/modules/clothing/under/altevian_vr.dm
+++ b/code/modules/clothing/under/altevian_vr.dm
@@ -19,24 +19,29 @@
 	name = "Altevian Hegemony Security Pants"
 	icon_state = "altevian-pants-sec"
 	worn_state = "altevian-pants-sec"
+	armor = list(melee = 10, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 0, rad = 0)
+	siemens_coefficient = 0.9
 	starting_accessories = list(/obj/item/clothing/accessory/jacket/altevian/security)
 
 /obj/item/clothing/under/pants/altevian/engineering
 	name = "Altevian Hegemony Engineering Pants"
 	icon_state = "altevian-pants-eng"
 	worn_state = "altevian-pants-eng"
+	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 0, rad = 10)
 	starting_accessories = list(/obj/item/clothing/accessory/jacket/altevian/engineering)
 
 /obj/item/clothing/under/pants/altevian/medical
 	name = "Altevian Hegemony Medical Pants"
 	icon_state = "altevian-pants-med"
 	worn_state = "altevian-pants-med"
+	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 10, rad = 0)
 	starting_accessories = list(/obj/item/clothing/accessory/jacket/altevian/medical)
 
 /obj/item/clothing/under/pants/altevian/science
 	name = "Altevian Hegemony Science Pants"
 	icon_state = "altevian-pants-sci"
 	worn_state = "altevian-pants-sci"
+	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 10, bio = 0, rad = 0)
 	starting_accessories = list(/obj/item/clothing/accessory/jacket/altevian/science)
 
 /obj/item/clothing/under/pants/altevian/cargo
@@ -56,20 +61,25 @@
 
 /obj/item/clothing/under/altevian/sci
 	name = "Altevian Science Duty Jumpsuit"
+	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 10, bio = 0, rad = 0)
 	icon_state = "altevian-specialist-sci"
 	worn_state = "altevian-specialist-sci"
 
 /obj/item/clothing/under/altevian/med
 	name = "Altevian Medical Duty Jumpsuit"
+	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 10, rad = 0)
 	icon_state = "altevian-specialist-med"
 	worn_state = "altevian-specialist-med"
 
 /obj/item/clothing/under/altevian/sec
 	name = "Altevian Security Duty Jumpsuit"
+	armor = list(melee = 10, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 0, rad = 0)
+	siemens_coefficient = 0.9
 	icon_state = "altevian-specialist-sec"
 	worn_state = "altevian-specialist-sec"
 
 /obj/item/clothing/under/altevian/eng
 	name = "Altevian Engineering Duty Jumpsuit"
+	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 0, rad = 10)
 	icon_state = "altevian-specialist-eng"
 	worn_state = "altevian-specialist-eng"


### PR DESCRIPTION
Fixes the job based clothing of Altevians not having the minor stat buffs of their humanoid counterparts clothing options.

Hydroponics and Janitorial are the only other job suits that offer any bonuses, but Altevians don't have any specific special suits for those jobs; I can't fix what does not exist!