### PR TITLE
Agent ID Feedback

### DIFF
--- a/code/game/objects/items/weapons/id cards/syndicate_ids.dm
+++ b/code/game/objects/items/weapons/id cards/syndicate_ids.dm
@@ -30,7 +30,7 @@
 	if(istype(O, /obj/item/weapon/card/id))
 		var/obj/item/weapon/card/id/I = O
 		src.access |= I.access
-		if(player_is_antag(user.mind))
+		if(player_is_antag(user.mind) || registered_user == user)
 			to_chat(user, "<span class='notice'>The microscanner activates as you pass it over the ID, copying its access.</span>")
 
 /obj/item/weapon/card/id/syndicate/attack_self(mob/user as mob)


### PR DESCRIPTION
Agent IDs dont give feedback when scanning access, since antags are Not Real. This should fix that with an edgecase, checking if you're the owner of the card, while also not breaking the intention of having the card's covert functions shown to everyone.