### PR TITLE
Reagent Cleanup

### DIFF
--- a/code/modules/reagents/reagents/food_drinks.dm
+++ b/code/modules/reagents/reagents/food_drinks.dm
@@ -4538,6 +4538,12 @@
 	nutriment_factor = 40 //very filling
 	color = "#d169b2"
 
+/datum/reagent/nutriment/magicdust/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed)
+	..()
+	playsound(M, 'sound/items/hooh.ogg', 50, 1, -1)
+	if(prob(5))
+		to_chat(M, "<span class='warning'>You feel like you've been gnomed...</span>")
+
 /datum/reagent/drink/soda/kompot
 	name = "Kompot"
 	id = "kompot"

--- a/code/modules/reagents/reagents/food_drinks_vr.dm
+++ b/code/modules/reagents/reagents/food_drinks_vr.dm
@@ -31,29 +31,6 @@
 /datum/reagent/lipozine/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	M.adjust_nutrition(-20 * removed)
 
-/datum/reagent/ethanol/deathbell
-	name = "Deathbell"
-	id = "deathbell"
-	description = "A successful experiment to make the most alcoholic thing possible."
-	taste_description = "your brains smashed out by a smooth brick of hard, ice cold alcohol"
-	color = "#9f6aff"
-	taste_mult = 5
-	strength = 10
-	adj_temp = 10
-	targ_temp = 330
-
-	glass_name = "Deathbell"
-	glass_desc = "The perfect blend of the most alcoholic things a bartender can get their hands on."
-
-/datum/reagent/ethanol/deathbell/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed)
-	..()
-
-	if(M.species.robo_ethanol_drunk || !(M.isSynthetic()))
-		if(dose * strength >= strength) // Early warning
-			M.make_dizzy(24) // Intentionally higher than normal to compensate for it's previous effects.
-		if(dose * strength >= strength * 2.5) // Slurring takes longer. Again, intentional.
-			M.slurring = max(M.slurring, 30)
-
 /datum/reagent/ethanol/burnout
 	name = "Burnout"
 	id = "burnout"
@@ -102,6 +79,40 @@
 
 	glass_name = "Monster Tamer"
 	glass_desc = "This looks like a vaguely-alcoholic slurry of meat. Gross."
+
+/datum/reagent/ethanol/monstertamer/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed)
+	..()
+
+	if(!(M.isSynthetic()))
+		if(M.species.organic_food_coeff) //it's still food!
+			switch(alien)
+				if(IS_DIONA) //Diona don't get any nutrition from nutriment or protein.
+				if(IS_SKRELL)
+					M.adjustToxLoss(0.25 * removed)  //Equivalent to half as much protein, since it's half protein.
+				if(IS_TESHARI)
+					M.adjust_nutrition(alt_nutriment_factor * 1.2 * removed) //Give them the same nutrition they would get from protein.
+				if(IS_UNATHI)
+					M.adjust_nutrition(alt_nutriment_factor * 1.125 * removed) //Give them the same nutrition they would get from protein.
+					//Takes into account the 0.5 factor for all nutriment which is applied on top of the 2.25 factor for protein.
+				//Chimera don't need their own case here since their factors for nutriment and protein cancel out.
+				else
+					M.adjust_nutrition(alt_nutriment_factor * removed)
+		if(ishuman(M))
+			var/mob/living/carbon/human/H = M
+			if(H.feral > 0 && H.nutrition > 150 && H.traumatic_shock < 20 && H.jitteriness < 100) //Same check as feral triggers to stop them immediately re-feralling
+				H.feral -= removed * 3 // should calm them down quick, provided they're actually in a state to STAY calm.
+				if (H.feral <=0) //check if they're unferalled
+					H.feral = 0
+					to_chat(H, "<span class='info'>Your mind starts to clear, soothed into a state of clarity as your senses return.</span>")
+					log_and_message_admins("is no longer feral.", H)
+
+/datum/reagent/ethanol/monstertamer/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
+	..()
+	if(alien == IS_SKRELL)
+		M.adjustToxLoss(removed)  //Equivalent to half as much protein, since it's half protein.
+	if(M.species.organic_food_coeff)
+		if(alien == IS_SLIME || alien == IS_CHIMERA) //slimes and chimera can get nutrition from injected nutriment and protein
+			M.adjust_nutrition(alt_nutriment_factor * removed)
 
 /datum/reagent/ethanol/pink_russian
 	name = "Pink Russian"
@@ -158,51 +169,11 @@
 	glass_name = "Mudslide"
 	glass_desc = "A richly coloured drink, comes with a chocolate garnish!"
 
-/datum/reagent/ethanol/monstertamer/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed)
-	..()
-
-	if(!(M.isSynthetic()))
-		if(M.species.organic_food_coeff) //it's still food!
-			switch(alien)
-				if(IS_DIONA) //Diona don't get any nutrition from nutriment or protein.
-				if(IS_SKRELL)
-					M.adjustToxLoss(0.25 * removed)  //Equivalent to half as much protein, since it's half protein.
-				if(IS_TESHARI)
-					M.adjust_nutrition(alt_nutriment_factor * 1.2 * removed) //Give them the same nutrition they would get from protein.
-				if(IS_UNATHI)
-					M.adjust_nutrition(alt_nutriment_factor * 1.125 * removed) //Give them the same nutrition they would get from protein.
-					//Takes into account the 0.5 factor for all nutriment which is applied on top of the 2.25 factor for protein.
-				//Chimera don't need their own case here since their factors for nutriment and protein cancel out.
-				else
-					M.adjust_nutrition(alt_nutriment_factor * removed)
-		if(ishuman(M))
-			var/mob/living/carbon/human/H = M
-			if(H.feral > 0 && H.nutrition > 150 && H.traumatic_shock < 20 && H.jitteriness < 100) //Same check as feral triggers to stop them immediately re-feralling
-				H.feral -= removed * 3 // should calm them down quick, provided they're actually in a state to STAY calm.
-				if (H.feral <=0) //check if they're unferalled
-					H.feral = 0
-					to_chat(H, "<span class='info'>Your mind starts to clear, soothed into a state of clarity as your senses return.</span>")
-					log_and_message_admins("is no longer feral.", H)
-
-/datum/reagent/ethanol/monstertamer/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
-	..()
-	if(alien == IS_SKRELL)
-		M.adjustToxLoss(removed)  //Equivalent to half as much protein, since it's half protein.
-	if(M.species.organic_food_coeff)
-		if(alien == IS_SLIME || alien == IS_CHIMERA) //slimes and chimera can get nutrition from injected nutriment and protein
-			M.adjust_nutrition(alt_nutriment_factor * removed)
-
-/datum/reagent/nutriment/magicdust/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed)
-	..()
-	playsound(M, 'sound/items/hooh.ogg', 50, 1, -1)
-	if(prob(5))
-		to_chat(M, "<span class='warning'>You feel like you've been gnomed...</span>")
-
 /datum/reagent/ethanol/galacticpanic
 	name = "Galactic Panic Attack"
 	id = "galacticpanic"
 	description = "The absolute worst thing you could ever put in your body."
-	taste_description = "an entire galaxy collasping in on itself."
+	taste_description = "an entire galaxy collasping in on itself"
 	strength = 10
 	druggy = 50
 	halluci = 30
@@ -229,31 +200,29 @@
 	name = "Space Bulldog"
 	id = "bulldog"
 	description = "An inventive kahlua recipe."
-	taste_description = "fizzy, creamy, soda and coffee hell."
+	taste_description = "fizzy, creamy, soda and coffee hell"
 	strength = 30
 	color = "#d3785d"
 
 	glass_name = "Space Bulldog"
 	glass_desc = "It looks like someone poured cola in a cup of coffee."
 
-
 /datum/reagent/ethanol/sbagliato
 	name = "Negroni Sbagliato"
 	id = "sbagliato"
 	description = "A drink invented because a bartender was too drunk."
-	taste_description = "sweet bubbly wine and vermouth."
+	taste_description = "sweet bubbly wine and vermouth"
 	strength = 30
 	color = "#d3785d"
 
 	glass_name = "Negroni Sbagliato"
 	glass_desc = "Bubbles constantly pop up to the surface with a quiet fizz."
 
-
 /datum/reagent/ethanol/italiancrisis
 	name = "Italian Crisis"
 	id = "italiancrisis"
 	description = "This drink was concocted by a madwoman, causing the Italian Crisis of 2123."
-	taste_description = "cola, fruit, fizz, coffee, and cream swirled together in an old boot."
+	taste_description = "cola, fruit, fizz, coffee, and cream swirled together in an old boot"
 	strength = 20
 	druggy = 0
 	halluci = 0
@@ -267,7 +236,7 @@
 	name = "Sweet Rush"
 	id = "sugarrush"
 	description = "A favorite drink amongst poor bartenders living in Neo Detroit."
-	taste_description = "sweet bubblegum vodka."
+	taste_description = "sweet bubblegum vodka"
 	strength = 30
 	color = "#d3785d"
 
@@ -278,7 +247,7 @@
 	name = "Lotus"
 	id = "lotus"
 	description = "The result of making one mistake after another and trying to cover it up with sugar."
-	taste_description = "rich, sweet fruit and even more sugar."
+	taste_description = "rich, sweet fruit and even more sugar"
 	strength = 25
 	color = "#d3785d"
 
@@ -289,7 +258,7 @@
 	name = "Dumb Shroom Juice"
 	id = "shroomjuice"
 	description = "The mushroom farmer didn't sort through their stock very well."
-	taste_description = "sweet and sour citrus with a savory kick."
+	taste_description = "sweet and sour citrus with a savory kick"
 	strength = 100
 	druggy = 30
 	halluci = 30
@@ -303,7 +272,7 @@
 	name = "Russian Roulette"
 	id = "russianroulette"
 	description = "The perfect drink for wagering your liver on a game of cards."
-	taste_description = "coffee, vodka, cream, and a hot metal slug."
+	taste_description = "coffee, vodka, cream, and a hot metal slug"
 	strength = 30
 	var/adj_dizzy = 30
 	color = "#d3785d"
@@ -321,7 +290,7 @@
 	name = "The Love Maker"
 	id = "lovemaker"
 	description = "A drink said to help one find true love."
-	taste_description = "sweet fruit and honey."
+	taste_description = "sweet fruit and honey"
 	strength = 30
 	druggy = 0
 	halluci = 0
@@ -337,7 +306,7 @@
 	name = "Honey Shot"
 	id = "honeyshot"
 	description = "The perfect drink for bees."
-	taste_description = "sweet tart grenadine flavored with honey."
+	taste_description = "sweet tart grenadine flavored with honey"
 	strength = 40
 	var/adj_dizzy = 10
 	color = "#d3785d"
@@ -349,7 +318,7 @@
 	name = "Appletini"
 	id = "appletini"
 	description = "A classic cocktail using every grandma's favorite fruit."
-	taste_description = "green sour apple with a hint of alcohol."
+	taste_description = "green sour apple with a hint of alcohol"
 	strength = 45
 	color = "#d3785d"
 
@@ -360,7 +329,7 @@
 	name = "Glowing Appletini"
 	id = "glowingappletini"
 	description = "A new nuclear take on a pre-modern classic!"
-	taste_description = "overwhelmingly sour apples powered by a nuclear fission reactor."
+	taste_description = "overwhelmingly sour apples powered by a nuclear fission reactor"
 	strength = 30
 	druggy = 20
 	var/adj_dizzy = 20
@@ -373,7 +342,7 @@
 	name = "Slow Comfortable Screw Against the Wall"
 	id = "scsatw"
 	description = "The screwdriver's bigger cousin."
-	taste_description = "smooth, savory booze and tangy orange juice."
+	taste_description = "smooth, savory booze and tangy orange juice"
 	strength = 30
 	druggy = 0
 	halluci = 0
@@ -387,7 +356,7 @@
 	name = "Choccy Milk"
 	id = "choccymilk"
 	description = "Coco and milk, a timeless classic."
-	taste_description = "sophisticated bittersweet chocolate mixed with silky, creamy, whole milk."
+	taste_description = "sophisticated bittersweet chocolate mixed with silky, creamy, whole milk"
 	color = "#d3785d"
 
 	glass_name = "Choccy Milk"
@@ -397,7 +366,7 @@
 	name = "Red Space Flush"
 	id = "redspaceflush"
 	description = "A drink made by imbueing the essence of redspace into the spirits."
-	taste_description = "whiskey and rum strung out through a hellish dimensional rift."
+	taste_description = "whiskey and rum strung out through a hellish dimensional rift"
 	strength = 30
 	druggy = 10
 	var/adj_dizzy = 10
@@ -410,7 +379,7 @@
 	name = "Graveyard"
 	id = "graveyard"
 	description = "The result of taking a cup and filling it with all the drinks at the fountain."
-	taste_description = "sugar and fizz."
+	taste_description = "sugar and fizz"
 	color = "#d3785d"
 
 	glass_name = "Graveyard"
@@ -420,7 +389,7 @@
 	name = "Giant Beer"
 	id = "bigbeer"
 	description = "Bars in Neo Detroit started to sell this drink when the city put mandatory drink limits in 2289."
-	taste_description = "beer, but bigger."
+	taste_description = "beer, but bigger"
 	strength = 40
 	color = "#d3785d"
 
@@ -431,7 +400,7 @@
 	name = "Sweet Tea"
 	id = "sweettea"
 	description = "Tea that is sweetened with some form of sweetener."
-	taste_description = "tea that is sweet."
+	taste_description = "tea that is sweet"
 	color = "#d3785d"
 
 	glass_name = "Sweet Tea"
@@ -441,7 +410,7 @@
 	name = "Unsweetened Tea"
 	id = "unsweettea"
 	description = "A sick experiment to take the sweetness out of tea after sugar has been added resulted in this."
-	taste_description = "bland, slightly bitter, discount black tea."
+	taste_description = "bland, slightly bitter, discount black tea"
 	strength = 80
 	druggy = 10
 	color = "#d3785d"
@@ -453,7 +422,7 @@
 	name = "Hair of the Rat"
 	id = "hairoftherat"
 	description = "A meatier version of the monster tamer, complete with extra meat."
-	taste_description = "meat, whiskey, ground meat, and more meat."
+	taste_description = "meat, whiskey, ground meat, and more meat"
 	strength = 45
 	color = "#d3785d"
 	metabolism = REM * 3.5 // about right for mixing nutriment and ethanol.
@@ -461,7 +430,7 @@
 	//using a new variable instead of nutriment_factor so we can call ..() without that adding nutrition for us without taking factors for protein into account
 
 	glass_name = "Hair of the Rat"
-	glass_desc = "The alcohol equivelant of saying your burger isn't cooked rare enough."
+	glass_desc = "The alcoholic equivalent of saying your burger isn't cooked rare enough."
 
 /datum/reagent/ethanol/hairoftherat/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed)
 	..()


### PR DESCRIPTION
As noted in #14796, I noticed there was some duplication of stuff. It wasn't as bad as I thought; pretty much only deathbell was duplicated (for some reason?). This amends that by removing the duplicated stuff that lead to the problem in the first place, and may also be causing people to get twice as dizzy and hit the inbuilt slurring cap twice as fast as intended.

Doesn't alter any of its other, normal alcohol behaviours though, so don't think it's gotten any weaker. The 'early warning' has just been toned down. Standard define is [here](https://github.com/VOREStation/VOREStation/blob/3b01381dc3f316d6a5d9d06534c0c20ed2887aa0/code/modules/reagents/reagents/food_drinks.dm#L4506).

Also cleaned up placement of a few bits of code to be with their reagent, and shaved superfluous full stops off some taste descs.