### PR TITLE
Removes the visible emote from toggling AR hud to bring in-line with …

### DIFF
--- a/code/modules/clothing/glasses/hud_vr.dm
+++ b/code/modules/clothing/glasses/hud_vr.dm
@@ -132,7 +132,6 @@
 
 	//We do not check if user can move or not, since this system is inspired to help see chat bubbles during scenes primarily.
 	//Preventing turning off the HUD could get in the way of scene flow.
-	usr.visible_emote("toggles a button on their [src.name]!") //Since we're turning stuff like arrest/medical HUD on/off, we should inform those nearby.
 	if(ar_toggled)
 		away_planes = enables_planes
 		enables_planes = null


### PR DESCRIPTION
…other toggles

The advantage brought by informing people around the user is significantly diminished by it being potentially spammy and distracting. I'd initially added it as a "well, knowing if someone got sec/medhud on you is potentially important", but it's not really relevant for our own usecase. Plus, you still got the examine panel so it's not nearly enough of a big deal to justify the visible emote