### PR TITLE
Friendlier Tesla Components

### DIFF
--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -272,6 +272,13 @@
 
 /obj/machinery/power/emitter/examine(mob/user)
 	. = ..()
+	switch(state)
+		if(0)
+			. += "<span class='warning'>It is not secured in place at all!</span>"
+		if(1)
+			. += "<span class='warning'>It has been bolted down securely, but not welded into place.</span>"
+		if(2)
+			. += "<span class='notice'>It has been bolted down securely and welded down into place.</span>"
 	var/integrity_percentage = round((integrity / initial(integrity)) * 100)
 	switch(integrity_percentage)
 		if(0 to 30)
@@ -279,7 +286,7 @@
 		if(31 to 70)
 			. += "<span class='danger'>It is damaged.</span>"
 		if(77 to 99)
-			. += "<span class='warning'It is slightly damaged.</span>"
+			. += "<span class='warning'>It is slightly damaged.</span>"
 
 //R-UST port
 /obj/machinery/power/emitter/proc/get_initial_fire_delay()

--- a/code/modules/power/singularity/field_generator.dm
+++ b/code/modules/power/singularity/field_generator.dm
@@ -40,6 +40,15 @@ field_generator power level display
 	var/light_power_on = 1
 	light_color = "#5BA8FF"
 
+/obj/machinery/field_generator/examine()
+	. = ..()
+	switch(state)
+		if(0)
+			. += "<span class='warning'>It is not secured in place at all!</span>"
+		if(1)
+			. += "<span class='warning'>It has been bolted down securely, but not welded into place.</span>"
+		if(2)
+			. += "<span class='notice'>It has been bolted down securely and welded down into place.</span>"
 
 /obj/machinery/field_generator/update_icon()
 	cut_overlays()

--- a/code/modules/power/singularity/generator.dm
+++ b/code/modules/power/singularity/generator.dm
@@ -10,6 +10,10 @@
 	var/energy = 0
 	var/creation_type = /obj/singularity
 
+/obj/machinery/the_singularitygen/examine()
+	. = ..()
+	. += "<span class='notice'>It is [anchored ? "secured" : "not secured"]!</span>"
+
 /obj/machinery/the_singularitygen/process()
 	var/turf/T = get_turf(src)
 	if(src.energy >= 200)

--- a/code/modules/power/tesla/coil.dm
+++ b/code/modules/power/tesla/coil.dm
@@ -21,6 +21,10 @@
 /obj/machinery/power/tesla_coil/pre_mapped
 	anchored = TRUE
 
+/obj/machinery/power/tesla_coil/examine()
+	. = ..()
+	. += "<span class='notice'>It is [anchored ? "secured" : "not secured"]!</span>"
+
 /obj/machinery/power/tesla_coil/New()
 	..()
 	wires = new(src)
@@ -106,6 +110,10 @@
 	can_buckle = TRUE
 	buckle_lying = FALSE
 	circuit = /obj/item/weapon/circuitboard/grounding_rod
+
+/obj/machinery/power/grounding_rod/examine()
+	. = ..()
+	. += "<span class='notice'>It is [anchored ? "secured" : "not secured"]!</span>"
 
 /obj/machinery/power/grounding_rod/pre_mapped
 	anchored = TRUE

--- a/code/modules/power/tesla/generator.dm
+++ b/code/modules/power/tesla/generator.dm
@@ -5,6 +5,10 @@
 	icon_state = "TheSingGen"
 	creation_type = /obj/singularity/energy_ball
 
+/obj/machinery/the_singularitygen/tesla/examine()
+	. = ..()
+	. += "<span class='notice'>It is [anchored ? "secured" : "not secured"]!</span>"
+
 /obj/machinery/the_singularitygen/tesla/tesla_act(power, explosive = FALSE)
 	if(explosive)
 		energy += power


### PR DESCRIPTION
Just a little QoL/usability tweak for engineers, especially new ones. Examining the various tesla components (EB generator, field generator, grounding rod, tesla coil, emitter) will now report their anchored/welded states (as applicable) in text so you don't have to figure it out by subtle changes to their sprites, by rubbing your face all over them, or by testing them with a wrench/welder.

Also applies the same logic to the singularity generator, and fixes a missing `>` in some of the emitter formatting that was slipping through CI somehow.