### PR TITLE
Update Mining Drone IFF

### DIFF
--- a/code/modules/mob/living/simple_mob/subtypes/mechanical/drones/mining_drone.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/mechanical/drones/mining_drone.dm
@@ -67,7 +67,7 @@
 	var/last_search = 0
 	var/search_cooldown = 5 SECONDS
 	var/ignoreunarmed = TRUE
-	var/allowedtools = list(/obj/item/weapon/pickaxe, /obj/item/weapon/gun/energy/kinetic_accelerator, /obj/item/weapon/gun/magnetic/matfed/phoronbore, /obj/item/weapon/kinetic_crusher)
+	var/allowedtools = list(/obj/item/weapon/pickaxe, /obj/item/weapon/gun/energy/kinetic_accelerator, /obj/item/weapon/gun/magnetic/matfed/phoronbore, /obj/item/weapon/kinetic_crusher, /obj/item/weapon/melee/shock_maul)
 
 /mob/living/simple_mob/mechanical/mining_drone/Initialize()
 	ion_trail = new


### PR DESCRIPTION
The Concussion Maul is billed as "typically used for mining", so I've made a little tweak to add it to the list of ignored weapons accordingly.

Should've done this in the initial project but, well, here we are.