### PR TITLE
Move animal nom verb to abilities tab

### DIFF
--- a/code/modules/vore/eating/simple_animal_vr.dm
+++ b/code/modules/vore/eating/simple_animal_vr.dm
@@ -8,7 +8,7 @@
 //
 /mob/living/simple_mob/proc/animal_nom(mob/living/T in living_mobs(1))
 	set name = "Animal Nom"
-	set category = "IC"
+	set category = "Abilities" // Moving this to abilities from IC as it's more fitting there
 	set desc = "Since you can't grab, you get a verb!"
 
 	if(stat != CONSCIOUS)


### PR DESCRIPTION
Simply moves the animal nom verb to the abilities tab, rather than the IC, as it's more fitting there for convienence and it's function. That's all!