### PR TITLE
TGUI input lock

### DIFF
--- a/code/modules/client/preference_setup/global/01_ui.dm
+++ b/code/modules/client/preference_setup/global/01_ui.dm
@@ -14,6 +14,7 @@
 	S["tgui_fancy"]				>> pref.tgui_fancy
 	S["tgui_lock"]				>> pref.tgui_lock
 	S["tgui_input_mode"]		>> pref.tgui_input_mode
+	S["tgui_input_lock"]		>> pref.tgui_input_lock
 	S["tgui_large_buttons"]		>> pref.tgui_large_buttons
 	S["tgui_swapped_buttons"]	>> pref.tgui_swapped_buttons
 
@@ -29,6 +30,7 @@
 	S["tgui_fancy"]				<< pref.tgui_fancy
 	S["tgui_lock"]				<< pref.tgui_lock
 	S["tgui_input_mode"]		<< pref.tgui_input_mode
+	S["tgui_input_lock"]		<< pref.tgui_input_lock
 	S["tgui_large_buttons"]		<< pref.tgui_large_buttons
 	S["tgui_swapped_buttons"]	<< pref.tgui_swapped_buttons
 
@@ -44,6 +46,7 @@
 	pref.tgui_fancy			= sanitize_integer(pref.tgui_fancy, 0, 1, initial(pref.tgui_fancy))
 	pref.tgui_lock			= sanitize_integer(pref.tgui_lock, 0, 1, initial(pref.tgui_lock))
 	pref.tgui_input_mode	= sanitize_integer(pref.tgui_input_mode, 0, 1, initial(pref.tgui_input_mode))
+	pref.tgui_input_lock	= sanitize_integer(pref.tgui_input_lock, 0, 1, initial(pref.tgui_input_lock))
 	pref.tgui_large_buttons	= sanitize_integer(pref.tgui_large_buttons, 0, 1, initial(pref.tgui_large_buttons))
 	pref.tgui_swapped_buttons	= sanitize_integer(pref.tgui_swapped_buttons, 0, 1, initial(pref.tgui_swapped_buttons))
 
@@ -56,9 +59,10 @@
 	. += "<b>Client FPS:</b> <a href='?src=\ref[src];select_client_fps=1'><b>[pref.client_fps]</b></a><br>"
 	. += "<b>Random Ambience Frequency:</b> <a href='?src=\ref[src];select_ambience_freq=1'><b>[pref.ambience_freq]</b></a><br>"
 	. += "<b>Ambience Chance:</b> <a href='?src=\ref[src];select_ambience_chance=1'><b>[pref.ambience_chance]</b></a><br>"
-	. += "<b>tgui Window Mode:</b> <a href='?src=\ref[src];tgui_fancy=1'><b>[(pref.tgui_fancy) ? "Fancy (default)" : "Compatible (slower)"]</b></a><br>"
-	. += "<b>tgui Window Placement:</b> <a href='?src=\ref[src];tgui_lock=1'><b>[(pref.tgui_lock) ? "Primary Monitor" : "Free (default)"]</b></a><br>"
+	. += "<b>TGUI Window Mode:</b> <a href='?src=\ref[src];tgui_fancy=1'><b>[(pref.tgui_fancy) ? "Fancy (default)" : "Compatible (slower)"]</b></a><br>"
+	. += "<b>TGUI Window Placement:</b> <a href='?src=\ref[src];tgui_lock=1'><b>[(pref.tgui_lock) ? "Primary Monitor" : "Free (default)"]</b></a><br>"
 	. += "<b>TGUI Input Framework:</b> <a href='?src=\ref[src];tgui_input_mode=1'><b>[(pref.tgui_input_mode) ? "Enabled" : "Disabled (default)"]</b></a><br>"
+	. += "<b>TGUI Input Lock:</b> <a href='?src=\ref[src];tgui_input_lock=1'><b>[(pref.tgui_input_lock) ? "Enabled" : "Disabled (default)"]</b></a><br>"
 	. += "<b>TGUI Large Buttons:</b> <a href='?src=\ref[src];tgui_large_buttons=1'><b>[(pref.tgui_large_buttons) ? "Enabled (default)" : "Disabled"]</b></a><br>"
 	. += "<b>TGUI Swapped Buttons:</b> <a href='?src=\ref[src];tgui_swapped_buttons=1'><b>[(pref.tgui_swapped_buttons) ? "Enabled" : "Disabled (default)"]</b></a><br>"
 	if(can_select_ooc_color(user))
@@ -107,14 +111,14 @@
 		if(pref.client)
 			pref.client.fps = fps_new
 		return TOPIC_REFRESH
-		
+
 	else if(href_list["select_ambience_freq"])
 		var/ambience_new = tgui_input_number(user, "Input how often you wish to hear ambience repeated! (1-60 MINUTES, 0 for disabled)", "Global Preference", pref.ambience_freq, 60, 0)
 		if(isnull(ambience_new) || !CanUseTopic(user)) return TOPIC_NOACTION
 		if(ambience_new < 0 || ambience_new > 60) return TOPIC_NOACTION
 		pref.ambience_freq = ambience_new
 		return TOPIC_REFRESH
-		
+
 	else if(href_list["select_ambience_chance"])
 		var/ambience_chance_new = tgui_input_number(user, "Input the chance you'd like to hear ambience played to you (On area change, or by random ambience). 35 means a 35% chance to play ambience. This is a range from 0-100. 0 disables ambience playing entirely. This is also affected by Ambience Frequency.", "Global Preference", pref.ambience_freq, 100, 0)
 		if(isnull(ambience_chance_new) || !CanUseTopic(user)) return TOPIC_NOACTION
@@ -125,13 +129,17 @@
 	else if(href_list["tgui_fancy"])
 		pref.tgui_fancy = !pref.tgui_fancy
 		return TOPIC_REFRESH
-		
+
 	else if(href_list["tgui_lock"])
 		pref.tgui_lock = !pref.tgui_lock
 		return TOPIC_REFRESH
 
 	else if(href_list["tgui_input_mode"])
 		pref.tgui_input_mode = !pref.tgui_input_mode
+		return TOPIC_REFRESH
+
+	else if(href_list["tgui_input_lock"])
+		pref.tgui_input_lock = !pref.tgui_input_lock
 		return TOPIC_REFRESH
 
 	else if(href_list["tgui_large_buttons"])

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -29,6 +29,7 @@ var/list/preferences_datums = list()
 	var/tgui_fancy = TRUE
 	var/tgui_lock = FALSE
 	var/tgui_input_mode = FALSE			// All the Input Boxes (Text,Number,List,Alert)
+	var/tgui_input_lock = FALSE
 	var/tgui_large_buttons = TRUE
 	var/tgui_swapped_buttons = FALSE
 

--- a/code/modules/tgui_input/text.dm
+++ b/code/modules/tgui_input/text.dm
@@ -39,6 +39,11 @@
 				return input(user, message, title, default) as message|null
 			else
 				return input(user, message, title, default) as text|null
+
+	//Client has TGUI input lock on; override whatever prevent_enter was specified beforehand
+	if(user.client.prefs.tgui_input_lock)
+		prevent_enter = TRUE
+
 	var/datum/tgui_input_text/text_input = new(user, message, title, default, max_length, multiline, encode, timeout, prevent_enter)
 	text_input.tgui_interact(user)
 	text_input.wait()


### PR DESCRIPTION
A slightly messy pref/DM-side override of how tgui text input boxes work. Adds a new global preference (defaults to disabled) that makes it so *any* TGUI text input *will not* auto-submit when you hit enter.

**PROS:** You can now use linebreaks in TGUI input boxes, and you can't send your message before it's finished if you accidentally hit the enter key.  
**CONS:** You have to manually click the SUBMIT button each time, for any say/whisper/emote/subtle.

Fortunately you can easily swap back and forth by just going into character setup, global prefs tab, hit the toggle, save, and it instantly applies!

Would rather have solved this TGUI-side and just enabled shift+enter, but that would be a way greater time investment.