### PR TITLE
Mech Nanopaste repairs fix

### DIFF
--- a/code/game/mecha/components/_component.dm
+++ b/code/game/mecha/components/_component.dm
@@ -138,11 +138,25 @@
 		var/obj/item/stack/nanopaste/NP = W
 
 		if(integrity < max_integrity)
+			to_chat(user, "<span class='notice'>You start to repair damage to \the [src].</span>")
 			while(integrity < max_integrity && NP)
-				if(do_after(user, 1 SECOND, src) && NP.use(1))
-					adjust_integrity(10)
+				if(do_after(user, 1 SECOND, src))
+					NP.use(1)
+					adjust_integrity(NP.mech_repair)
+
+					if(integrity >= max_integrity)
+						to_chat(user, "<span class='notice'>You finish repairing \the [src].</span>")
+						break
+
+					else if(NP.amount == 0)
+						to_chat(user, "<span class='warning'>Insufficient nanopaste to complete repairs!</span>")
+						break
+
 
 			return
+
+		else
+			to_chat(user, "<span class='notice'>\The [src] doesn't require repairs.</span>")
 
 	return ..()
 

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -1567,15 +1567,27 @@
 			for(var/slot in internal_components)
 				var/obj/item/mecha_parts/component/C = internal_components[slot]
 
-				if(C)
+				if(!C)
+					to_chat(user, "<span class='notice'>There are no components installed!</span>")
+					return
 
-					if(C.integrity < C.max_integrity)
-						while(C.integrity < C.max_integrity && NP && do_after(user, 1 SECOND, src))
-							if(NP.use(1))
-								C.adjust_integrity(10)
+				if(C.integrity >= C.max_integrity)
+					to_chat(user, "<span class='notice'>\The [C] does not require repairs.</span>")
 
-						to_chat(user, "<span class='notice'>You repair damage to \the [C].</span>")
+				else if(C.integrity < C.max_integrity)
+					to_chat(user, "<span class='notice'>You start to repair damage to \the [C].</span>")
+					while(C.integrity < C.max_integrity && NP)
+						if(do_after(user, 1 SECOND, src))
+							NP.use(1)
+							C.adjust_integrity(NP.mech_repair)
 
+							if(C.integrity >= C.max_integrity)
+								to_chat(user, "<span class='notice'>You finish repairing \the [C].</span>")
+								break
+
+							else if(NP.amount == 0)
+								to_chat(user, "<span class='warning'>Insufficient nanopaste to complete repairs!</span>")
+								break
 			return
 
 		else

--- a/code/game/objects/items/stacks/nanopaste_vr.dm
+++ b/code/game/objects/items/stacks/nanopaste_vr.dm
@@ -2,6 +2,7 @@
 	var/restoration_external = 5
 	var/restoration_internal = 20
 	var/repair_external = FALSE
+	var/mech_repair = 10
 
 /obj/item/stack/nanopaste/advanced
 	name = "advanced nanopaste"
@@ -11,3 +12,4 @@
 	icon_state = "adv_nanopaste"
 	restoration_external = 10
 	repair_external = TRUE
+	mech_repair = 20

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -17,7 +17,7 @@
 	center_of_mass = null
 	var/list/datum/stack_recipe/recipes
 	var/singular_name
-	VAR_PROTECTED/amount = 1
+	var/amount = 1
 	var/max_amount //also see stack recipes initialisation, param "max_res_amount" must be equal to this max_amount
 	var/stacktype //determines whether different stack types can merge
 	var/build_type = null //used when directly applied to a turf


### PR DESCRIPTION
This fixes the repair interact for nanopaste on damaged mechs by overhauling the relevant proc section(s). This isn't a *perfect* fix of the interact as the `do_after` for mechs won't cooperate no matter what, but I'm calling that an acceptable loss in the face of an otherwise server-killing issue.

It also adds additional feedback to the interacts for the repair process and makes advanced nanopaste more effective at repairing damaged mech components.

Tested fairly thoroughly, and fixes #14846