### PR TITLE
Uniform Selectors

### DIFF
--- a/code/modules/client/preference_setup/loadout/loadout_uni_selector.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_uni_selector.dm
@@ -326,7 +326,7 @@
 	display_name = "Medical - Basic Uniforms"
 	description = "Select from a range of outfits available to all Medical personnel."
 	allowed_roles = list("Chief Medical Officer","Medical Doctor","Chemist","Psychiatrist","Paramedic")
-	path =
+	path = /obj/item/clothing/under/rank/neo_med
 	slot = slot_w_uniform
 	sort_category = "Uniform Selectors"
 	cost = 2
@@ -400,7 +400,7 @@
 	display_name = "Medical - Chief Medical Officer's Uniforms"
 	description = "Select from a range of outfits available to all Chief Medical Officers."
 	allowed_roles = list("Chief Medical Officer")
-	path =
+	path = /obj/item/clothing/under/rank/neo_cmo
 	slot = slot_w_uniform
 	sort_category = "Uniform Selectors"
 	cost = 2

--- a/code/modules/client/preference_setup/loadout/loadout_uni_selector.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_uni_selector.dm
@@ -120,6 +120,7 @@
 /datum/gear/uniform/civvie_uniform_selector/New()
 	..()
 	var/list/selector_uniforms = list(
+		"KHI uniform"=/obj/item/clothing/under/rank/khi/civ,
 		"TG&C plain turtleneck"=/obj/item/clothing/under/rank/neo_suspect_turtleneck,
 		"TG&C plain turtleneck w/ skirt"=/obj/item/clothing/under/rank/neo_suspect_turtleskirt,
 		"TG&C blue turtleneck"=/obj/item/clothing/under/rank/neo_suspect_turtleneck_blue,
@@ -189,7 +190,11 @@
 		"ST: Next Generation Ops"=/obj/item/clothing/under/rank/trek/engsec/next,
 		"ST: Voyager Ops"=/obj/item/clothing/under/rank/trek/engsec/voy,
 		"ST: DS9 Ops"=/obj/item/clothing/under/rank/trek/engsec/ds9,
-		"ST: Enterprise Ops"=/obj/item/clothing/under/rank/trek/engsec/ent
+		"ST: Enterprise Ops"=/obj/item/clothing/under/rank/trek/engsec/ent,
+		"TG&C bodyguard's suit"=/obj/item/clothing/under/rank/bodyguard_suit,
+		"TG&C bodyguard's skirt"=/obj/item/clothing/under/rank/bodyguard_skirt,
+		"TG&C bodyguard's turtleneck"=/obj/item/clothing/under/rank/bodyguard_turtleneck,
+		"TG&C bodyguard's turtleneck w/ skirt"=/obj/item/clothing/under/rank/bodyguard_turtleskirt
 	)
 	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(selector_uniforms))
 

--- a/code/modules/client/preference_setup/loadout/loadout_uni_selector.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_uni_selector.dm
@@ -1,4 +1,6 @@
+//template for quickly making more, if it's ever needed
 /*
+
 /datum/gear/uniform/BLANK_selector
 	display_name = "DEPT - BLANK's Uniforms"
 	description = "Select from a range of outfits available to all BLANK personnel."
@@ -15,11 +17,13 @@
 	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(selector_uniforms))
 */
 
+//Command/Specific
+
 /datum/gear/uniform/site_manager_selector
 	display_name = "Command - Site Manager's Uniforms"
 	description = "Select from a range of outfits available to all Site Managers."
 	allowed_roles = list("Site Manager")
-	path = /obj/item/clothing/under/dress/dress_cap
+	path = /obj/item/clothing/under/rank/neo_captain
 	slot = slot_w_uniform
 	sort_category = "Uniform Selectors"
 	cost = 2
@@ -34,7 +38,13 @@
 		"ST: Voyager Command"=/obj/item/clothing/under/rank/trek/command/voy,
 		"ST: DS9 Command"=/obj/item/clothing/under/rank/trek/command/ds9,
 		"ST: Enterprise Command"=/obj/item/clothing/under/rank/trek/command/ent,
-		"voidsuit underlayer"=/obj/item/clothing/under/undersuit/command
+		"voidsuit underlayer"=/obj/item/clothing/under/undersuit/command,
+		"TG&C jumpsuit"=/obj/item/clothing/under/rank/neo_captain,
+		"TG&C jumpskirt"=/obj/item/clothing/under/rank/neo_captain_skirt,
+		"TG&C utility suit"=/obj/item/clothing/under/rank/neo_commandutil,
+		"TG&C black suit"=/obj/item/clothing/under/rank/neo_captain_blacksuit,
+		"TG&C parade uniform"=/obj/item/clothing/under/rank/neo_captain_parade,
+		"TG&C jumpkilt"=/obj/item/clothing/under/rank/neo_captain_kilt
 	)
 	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(selector_uniforms))
 
@@ -42,7 +52,7 @@
 	display_name = "Command - Head of Personnel's Uniforms"
 	description = "Select from a range of outfits available to all Heads of Personnel."
 	allowed_roles = list("Head of Personnel")
-	path = /obj/item/clothing/under/dress/dress_hop
+	path = /obj/item/clothing/under/rank/neo_hop
 	slot = slot_w_uniform
 	sort_category = "Uniform Selectors"
 	cost = 2
@@ -58,9 +68,18 @@
 		"ST: Voyager Command"=/obj/item/clothing/under/rank/trek/command/voy,
 		"ST: DS9 Command"=/obj/item/clothing/under/rank/trek/command/ds9,
 		"ST: Enterprise Command"=/obj/item/clothing/under/rank/trek/command/ent,
-		"voidsuit underlayer"=/obj/item/clothing/under/undersuit/command
+		"voidsuit underlayer"=/obj/item/clothing/under/undersuit/command,
+		"TG&C command utility"=/obj/item/clothing/under/rank/neo_commandutil,
+		"TG&C jumpsuit"=/obj/item/clothing/under/rank/neo_hop,
+		"TG&C jumpskirt"=/obj/item/clothing/under/rank/neo_hop_skirt,
+		"TG&C parade uniform"=/obj/item/clothing/under/rank/neo_hop_parade_masc,
+		"TG&C parade dress"=/obj/item/clothing/under/rank/neo_hop_parade_fem,
+		"TG&C turtleneck"=/obj/item/clothing/under/rank/neo_hop_turtle,
+		"TG&C turtleneck w/ skirt"=/obj/item/clothing/under/rank/neo_hop_turtle_skirt
 	)
 	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(selector_uniforms))
+
+//Security
 
 /datum/gear/uniform/security_selector
 	display_name = "Security - Basic Uniforms"
@@ -176,6 +195,8 @@
 	)
 	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(selector_uniforms))
 
+//Cargo
+
 /datum/gear/uniform/quartermaster_selector
 	display_name = "Cargo - Quartermaster's Uniforms"
 	description = "Select from a range of outfits available to all Quartermasters."
@@ -254,6 +275,8 @@
 	)
 	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(selector_uniforms))
 
+//Engineering
+
 /datum/gear/uniform/engineering_chief_selector
 	display_name = "Engineering - Chief Engineer's Uniforms"
 	description = "Select from a range of outfits available to all Chief Engineers."
@@ -321,6 +344,8 @@
 		"TG&C jumpskirt"=/obj/item/clothing/under/rank/neo_atmos_skirt
 	)
 	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(selector_uniforms))
+
+//Medical
 
 /datum/gear/uniform/medical_selector
 	display_name = "Medical - Basic Uniforms"
@@ -419,5 +444,74 @@
 		"TG&C jumpskirt"=/obj/item/clothing/under/rank/neo_cmo_skirt,
 		"TG&C turtleneck"=/obj/item/clothing/under/rank/neo_cmo_turtle,
 		"TG&C turtleneck w/ skirt"=/obj/item/clothing/under/rank/neo_cmo_turtle_skirt
+	)
+	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(selector_uniforms))
+
+//Science
+
+/datum/gear/uniform/research_director_selector
+	display_name = "Science - Research Director's Uniforms"
+	description = "Select from a range of outfits available to all Research Directors."
+	allowed_roles = list("Research Director")
+	path = /obj/item/clothing/under/rank/neo_rd_suit
+	slot = slot_w_uniform
+	sort_category = "Uniform Selectors"
+	cost = 2
+
+/datum/gear/uniform/research_director_selector/New()
+	..()
+	var/list/selector_uniforms = list(
+		"KHI uniform, command"=/obj/item/clothing/under/rank/khi/cmd,
+		"ST: Original Series Command"=/obj/item/clothing/under/rank/trek/command,
+		"ST: Next Generation Command"=/obj/item/clothing/under/rank/trek/command/next,
+		"ST: Voyager Command"=/obj/item/clothing/under/rank/trek/command/voy,
+		"ST: DS9 Command"=/obj/item/clothing/under/rank/trek/command/ds9,
+		"ST: Enterprise Command"=/obj/item/clothing/under/rank/trek/command/ent,
+		"TG&C jumpsuit"=/obj/item/clothing/under/rank/neo_rd_suit,
+		"TG&C jumpskirt"=/obj/item/clothing/under/rank/neo_rd_suit_skirt,
+		"TG&C turtleneck"=/obj/item/clothing/under/rank/neo_rd_turtle,
+		"TG&C turtleneck w/ skirt"=/obj/item/clothing/under/rank/neo_rd_turtle_skirt
+	)
+	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(selector_uniforms))
+
+/datum/gear/uniform/science_dept_selector
+	display_name = "Science - Basic Uniforms"
+	description = "Select from a range of outfits available to all Science personnel."
+	allowed_roles = list("Scientist","Research Director","Roboticist","Xenobiologist","Xenobotanist")
+	path = /obj/item/clothing/under/rank/neo_science
+	slot = slot_w_uniform
+	sort_category = "Uniform Selectors"
+	cost = 2
+
+/datum/gear/uniform/science_dept_selector/New()
+	..()
+	var/list/selector_uniforms = list(
+		"TG&C jumpsuit"=/obj/item/clothing/under/rank/neo_science,
+		"TG&C jumpskirt"=/obj/item/clothing/under/rank/neo_science_skirt,
+		"TG&C utility"=/obj/item/clothing/under/rank/neo_util_sci,
+		"KHI uniform"=/obj/item/clothing/under/rank/khi/sci,
+		"ST: Original Series Med-Sci"=/obj/item/clothing/under/rank/trek/medsci,
+		"ST: Next Generation Med-Sci"=/obj/item/clothing/under/rank/trek/medsci/next,
+		"ST: Voyager Med-Sci"=/obj/item/clothing/under/rank/trek/medsci/voy,
+		"ST: DS9 Med-Sci"=/obj/item/clothing/under/rank/trek/medsci/ds9,
+		"ST: Enterprise Med-Sci"=/obj/item/clothing/under/rank/trek/medsci/ent
+	)
+	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(selector_uniforms))
+
+/datum/gear/uniform/science_robotics_selector
+	display_name = "Science - Roboticist's Uniforms"
+	description = "Select from a range of outfits available to all Roboticists."
+	allowed_roles = list("Research Director","Roboticist")
+	path = /obj/item/clothing/under/rank/neo_robo
+	slot = slot_w_uniform
+	sort_category = "Uniform Selectors"
+	cost = 2
+
+/datum/gear/uniform/science_robotics_selector/New()
+	..()
+	var/list/selector_uniforms = list(
+		"skirt"=/obj/item/clothing/under/rank/roboticist/skirt,
+		"TG&C jumpsuit"=/obj/item/clothing/under/rank/neo_robo,
+		"TG&C jumpskirt"=/obj/item/clothing/under/rank/neo_robo_skirt
 	)
 	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(selector_uniforms))

--- a/code/modules/client/preference_setup/loadout/loadout_uni_selector.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_uni_selector.dm
@@ -1,5 +1,5 @@
 /*
-/datum/gear/uniform_selector/BLANK
+/datum/gear/uniform/BLANK_selector
 	display_name = "DEPT - BLANK's Uniforms"
 	description = "Select from a range of outfits available to all BLANK personnel."
 	allowed_roles = list("")
@@ -8,25 +8,23 @@
 	sort_category = "Uniform Selectors"
 	cost = 2
 
-/datum/gear/uniform_selector/BLANK/New()
+/datum/gear/uniform/BLANK_selector/New()
 	..()
 	var/list/selector_uniforms = list(
 	)
 	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(selector_uniforms))
 */
 
-/datum/gear/uniform_selector
-	slot = slot_w_uniform
-	sort_category = "Uniform Selectors"
-	cost = 2
-
-/datum/gear/uniform_selector/site_manager
+/datum/gear/uniform/site_manager_selector
 	display_name = "Command - Site Manager's Uniforms"
 	description = "Select from a range of outfits available to all Site Managers."
 	allowed_roles = list("Site Manager")
 	path = /obj/item/clothing/under/dress/dress_cap
+	slot = slot_w_uniform
+	sort_category = "Uniform Selectors"
+	cost = 2
 
-/datum/gear/uniform_selector/site_manager/New()
+/datum/gear/uniform/site_manager_selector/New()
 	..()
 	var/list/selector_uniforms = list(
 		"uniform w/ dress"=/obj/item/clothing/under/dress/dress_cap,
@@ -40,13 +38,16 @@
 	)
 	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(selector_uniforms))
 
-/datum/gear/uniform_selector/head_of_personnel
+/datum/gear/uniform/head_of_personnel_selector
 	display_name = "Command - Head of Personnel's Uniforms"
 	description = "Select from a range of outfits available to all Heads of Personnel."
 	allowed_roles = list("Head of Personnel")
 	path = /obj/item/clothing/under/dress/dress_hop
+	slot = slot_w_uniform
+	sort_category = "Uniform Selectors"
+	cost = 2
 
-/datum/gear/uniform_selector/head_of_personnel/New()
+/datum/gear/uniform/head_of_personnel_selector/New()
 	..()
 	var/list/selector_uniforms = list(
 		"uniform w/ dress"=/obj/item/clothing/under/dress/dress_hop,
@@ -61,13 +62,16 @@
 	)
 	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(selector_uniforms))
 
-/datum/gear/uniform_selector/security
+/datum/gear/uniform/security_selector
 	display_name = "Security - Basic Uniforms"
 	description = "Select from a range of outfits available to all Security personnel."
 	allowed_roles = list("Head of Security", "Warden", "Detective", "Security Officer")
 	path = /obj/item/clothing/under/rank/security/corp
+	slot = slot_w_uniform
+	sort_category = "Uniform Selectors"
+	cost = 2
 
-/datum/gear/uniform_selector/security/New()
+/datum/gear/uniform/security_selector/New()
 	..()
 	var/list/selector_uniforms = list(
 		"undersuit, modernized"=/obj/item/clothing/under/rank/security/modern,
@@ -98,13 +102,16 @@
 	)
 	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(selector_uniforms))
 
-/datum/gear/uniform_selector/security_warden
+/datum/gear/uniform/security_warden_selector
 	display_name = "Security - Warden's Uniforms"
 	description = "Select from a range of outfits available to Wardens."
 	allowed_roles = list("Head of Security","Warden")
 	path = /obj/item/clothing/under/rank/warden/corp
+	slot = slot_w_uniform
+	sort_category = "Uniform Selectors"
+	cost = 2
 
-/datum/gear/uniform_selector/security_warden/New()
+/datum/gear/uniform/security_warden_selector/New()
 	..()
 	var/list/selector_uniforms = list(
 		"skirt"=/obj/item/clothing/under/rank/warden/skirt,
@@ -116,13 +123,16 @@
 	)
 	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(selector_uniforms))
 
-/datum/gear/uniform_selector/security_detective
+/datum/gear/uniform/security_detective_selector
 	display_name = "Security - Detective's Uniforms"
 	description = "Select from a range of outfits available to all Detectives."
 	allowed_roles = list("Head of Security","Detective")
 	path = /obj/item/clothing/under/det/corporate
+	slot = slot_w_uniform
+	sort_category = "Uniform Selectors"
+	cost = 2
 
-/datum/gear/uniform_selector/security_detective/New()
+/datum/gear/uniform/security_detective_selector/New()
 	..()
 	var/list/selector_uniforms = list(
 		"skirt"=/obj/item/clothing/under/det/skirt,
@@ -130,13 +140,16 @@
 	)
 	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(selector_uniforms))
 
-/datum/gear/uniform_selector/security_head
+/datum/gear/uniform/security_head_selector
 	display_name = "Security - Head's Uniforms"
 	description = "Select from a range of outfits available to all Heads of Security."
 	allowed_roles = list("Head of Security")
 	path = /obj/item/clothing/under/rank/head_of_security/corp
+	slot = slot_w_uniform
+	sort_category = "Uniform Selectors"
+	cost = 2
 
-/datum/gear/uniform_selector/security_head/New()
+/datum/gear/uniform/security_head_selector/New()
 	..()
 	var/list/selector_uniforms = list(
 		"skirt"=/obj/item/clothing/under/rank/head_of_security/skirt,
@@ -163,13 +176,16 @@
 	)
 	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(selector_uniforms))
 
-/datum/gear/uniform_selector/quartermaster
+/datum/gear/uniform/quartermaster_selector
 	display_name = "Cargo - Quartermaster's Uniforms"
 	description = "Select from a range of outfits available to all Quartermasters."
 	allowed_roles = list("Quartermaster")
 	path = /obj/item/clothing/under/rank/cargo/jeans
+	slot = slot_w_uniform
+	sort_category = "Uniform Selectors"
+	cost = 2
 
-/datum/gear/uniform_selector/quartermaster/New()
+/datum/gear/uniform/quartermaster_selector/New()
 	..()
 	var/list/selector_uniforms = list(
 		"skirt"=/obj/item/clothing/under/rank/cargo/skirt,
@@ -192,13 +208,16 @@
 	)
 	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(selector_uniforms))
 
-/datum/gear/uniform_selector/cargo_general
+/datum/gear/uniform/cargo_general_selector
 	display_name = "Cargo - Basic Uniforms"
 	description = "Select from a range of outfits available to all Cargo personnel."
 	allowed_roles = list("Cargo Technician","Shaft Miner","Quartermaster")
 	path = /obj/item/clothing/under/rank/cargotech/jeans
+	slot = slot_w_uniform
+	sort_category = "Uniform Selectors"
+	cost = 2
 
-/datum/gear/uniform_selector/cargo_general/New()
+/datum/gear/uniform/cargo_general_selector/New()
 	..()
 	var/list/selector_uniforms = list(
 		"skirt"=/obj/item/clothing/under/rank/cargotech/skirt,
@@ -218,13 +237,16 @@
 	)
 	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(selector_uniforms))
 
-/datum/gear/uniform_selector/cargo_miner
+/datum/gear/uniform/cargo_miner_selector
 	display_name = "Cargo - Miner's Uniforms"
 	description = "Select from a range of outfits available to all Mining personnel."
 	allowed_roles = list("Shaft Miner","Quartermaster")
 	path = /obj/item/clothing/under/rank/neo_miner
+	slot = slot_w_uniform
+	sort_category = "Uniform Selectors"
+	cost = 2
 
-/datum/gear/uniform_selector/cargo_miner/New()
+/datum/gear/uniform/cargo_miner_selector/New()
 	..()
 	var/list/selector_uniforms = list(
 		"TG&C miner's uniform"=/obj/item/clothing/under/rank/neo_miner,
@@ -232,13 +254,16 @@
 	)
 	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(selector_uniforms))
 
-/datum/gear/uniform_selector/engineering_chief
+/datum/gear/uniform/engineering_chief_selector
 	display_name = "Engineering - Chief Engineer's Uniforms"
 	description = "Select from a range of outfits available to all Chief Engineers."
 	allowed_roles = list("Chief Engineer")
 	path = /obj/item/clothing/under/rank/neo_chiefengi
+	slot = slot_w_uniform
+	sort_category = "Uniform Selectors"
+	cost = 2
 
-/datum/gear/uniform_selector/engineering_chief/New()
+/datum/gear/uniform/engineering_chief_selector/New()
 	..()
 	var/list/selector_uniforms = list(
 		"skirt"=/obj/item/clothing/under/rank/chief_engineer/skirt,
@@ -253,13 +278,16 @@
 	)
 	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(selector_uniforms))
 
-/datum/gear/uniform_selector/engineer
+/datum/gear/uniform/engineer_selector
 	display_name = "Engineering - Basic Uniforms"
 	description = "Select from a range of outfits available to all Engineering personnel."
 	allowed_roles = list("Chief Engineer","Engineer","Atmospheric Technician")
 	path = /obj/item/clothing/under/rank/neo_engi
+	slot = slot_w_uniform
+	sort_category = "Uniform Selectors"
+	cost = 2
 
-/datum/gear/uniform_selector/engineer/New()
+/datum/gear/uniform/engineer_selector/New()
 	..()
 	var/list/selector_uniforms = list(
 		"skirt"=/obj/item/clothing/under/rank/engineer/skirt,
@@ -276,17 +304,120 @@
 	)
 	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(selector_uniforms))
 
-/datum/gear/uniform_selector/engi_atmos
+/datum/gear/uniform/engi_atmos_selector
 	display_name = "Engineering - Atmos Tech's Uniforms"
 	description = "Select from a range of outfits available to all Atmospherics Technicians."
 	allowed_roles = list("Chief Engineer","Atmospheric Technician")
 	path = /obj/item/clothing/under/rank/atmospheric_technician/skirt
+	slot = slot_w_uniform
+	sort_category = "Uniform Selectors"
+	cost = 2
 
-/datum/gear/uniform_selector/engi_atmos/New()
+/datum/gear/uniform/engi_atmos_selector/New()
 	..()
 	var/list/selector_uniforms = list(
 		"skirt"=/obj/item/clothing/under/rank/atmospheric_technician/skirt,
 		"TG&C jumpsuit"=/obj/item/clothing/under/rank/neo_atmos,
 		"TG&C jumpskirt"=/obj/item/clothing/under/rank/neo_atmos_skirt
+	)
+	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(selector_uniforms))
+
+/datum/gear/uniform/medical_selector
+	display_name = "Medical - Basic Uniforms"
+	description = "Select from a range of outfits available to all Medical personnel."
+	allowed_roles = list("Chief Medical Officer","Medical Doctor","Chemist","Psychiatrist","Paramedic")
+	path =
+	slot = slot_w_uniform
+	sort_category = "Uniform Selectors"
+	cost = 2
+
+/datum/gear/uniform/medical_selector/New()
+	..()
+	var/list/selector_uniforms = list(
+		"skirt"=/obj/item/clothing/under/rank/medical/skirt,
+		"virologist skirt"=/obj/item/clothing/under/rank/virologist/skirt,
+		"turtleneck"=/obj/item/clothing/under/rank/medical/turtleneck,
+		"vey-medical jumpsuit"=/obj/item/clothing/under/corp/veymed,
+		"KHI uniform"=/obj/item/clothing/under/rank/khi/med,
+		"ST: Original Series Med-Sci"=/obj/item/clothing/under/rank/trek/medsci,
+		"ST: Next Generation Med-Sci"=/obj/item/clothing/under/rank/trek/medsci/next,
+		"ST: Voyager Med-Sci"=/obj/item/clothing/under/rank/trek/medsci/voy,
+		"ST: DS9 Med-Sci"=/obj/item/clothing/under/rank/trek/medsci/ds9,
+		"ST: Enterprise Med-Sci"=/obj/item/clothing/under/rank/trek/medsci/ent,
+		"TG&C jumpsuit"=/obj/item/clothing/under/rank/neo_med,
+		"TG&C jumpskirt"=/obj/item/clothing/under/rank/neo_med_skirt,
+		"TG&C virology jumpsuit"=/obj/item/clothing/under/rank/neo_viro,
+		"TG&C virology jumpskirt"=/obj/item/clothing/under/rank/neo_viro_skirt,
+		"TG&C dark jumpsuit"=/obj/item/clothing/under/rank/neo_med_dark,
+		"TG&C dark jumpskirt"=/obj/item/clothing/under/rank/neo_med_dark_skirt
+	)
+	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(selector_uniforms))
+
+/datum/gear/uniform/chemist_selector
+	display_name = "Medical - Chemist's Uniforms"
+	description = "Select from a range of outfits available to all Chemists."
+	allowed_roles = list("Chief Medical Officer","Chemist")
+	path = /obj/item/clothing/under/rank/neo_chem
+	slot = slot_w_uniform
+	sort_category = "Uniform Selectors"
+	cost = 2
+
+/datum/gear/uniform/chemist_selector/New()
+	..()
+	var/list/selector_uniforms = list(
+		"skirt"=/obj/item/clothing/under/rank/chemist/skirt,
+		"TG&C chemist's jumpsuit"=/obj/item/clothing/under/rank/neo_chem,
+		"TG&C chemist's jumpskirt"=/obj/item/clothing/under/rank/neo_chem_skirt,
+		"TG&C pharmacy jumpsuit"=/obj/item/clothing/under/rank/neo_pharma,
+		"TG&C pharmacy jumpskirt"=/obj/item/clothing/under/rank/neo_pharma_skirt
+	)
+	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(selector_uniforms))
+
+/datum/gear/uniform/paramedic_selector
+	display_name = "Medical - Paramedic's Uniforms"
+	description = "Select from a range of outfits available to all Paramedics."
+	allowed_roles = list("Medical Doctor","Chief Medical Officer","Paramedic")
+	path = /obj/item/clothing/under/rank/paramedunidark
+	slot = slot_w_uniform
+	sort_category = "Uniform Selectors"
+	cost = 2
+
+/datum/gear/uniform/paramedic_selector/New()
+	..()
+	var/list/selector_uniforms = list(
+		"dark"=/obj/item/clothing/under/rank/paramedunidark,
+		"dark w/ skirt"=/obj/item/clothing/under/rank/parameduniskirtdark,
+		"light"=/obj/item/clothing/under/rank/paramedunilight,
+		"light w/ skirt"=/obj/item/clothing/under/rank/parameduniskirtlight,
+		"TG&C jumpsuit"=/obj/item/clothing/under/rank/neo_para,
+		"TG&C jumpskirt"=/obj/item/clothing/under/rank/neo_para_skirt,
+		"TG&C light jumpsuit"=/obj/item/clothing/under/rank/neo_para_light,
+		"TG&C light jumpskirt"=/obj/item/clothing/under/rank/neo_para_light_skirt
+	)
+	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(selector_uniforms))
+
+/datum/gear/uniform/chief_medical_selector
+	display_name = "Medical - Chief Medical Officer's Uniforms"
+	description = "Select from a range of outfits available to all Chief Medical Officers."
+	allowed_roles = list("Chief Medical Officer")
+	path =
+	slot = slot_w_uniform
+	sort_category = "Uniform Selectors"
+	cost = 2
+
+/datum/gear/uniform/chief_medical_selector/New()
+	..()
+	var/list/selector_uniforms = list(
+		"skirt"=/obj/item/clothing/under/rank/chief_medical_officer/skirt,
+		"KHI uniform, command"=/obj/item/clothing/under/rank/khi/cmd,
+		"ST: Original Series Command"=/obj/item/clothing/under/rank/trek/command,
+		"ST: Next Generation Command"=/obj/item/clothing/under/rank/trek/command/next,
+		"ST: Voyager Command"=/obj/item/clothing/under/rank/trek/command/voy,
+		"ST: DS9 Command"=/obj/item/clothing/under/rank/trek/command/ds9,
+		"ST: Enterprise Command"=/obj/item/clothing/under/rank/trek/command/ent,
+		"TG&C jumpsuit"=/obj/item/clothing/under/rank/neo_cmo,
+		"TG&C jumpskirt"=/obj/item/clothing/under/rank/neo_cmo_skirt,
+		"TG&C turtleneck"=/obj/item/clothing/under/rank/neo_cmo_turtle,
+		"TG&C turtleneck w/ skirt"=/obj/item/clothing/under/rank/neo_cmo_turtle_skirt
 	)
 	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(selector_uniforms))

--- a/code/modules/client/preference_setup/loadout/loadout_uni_selector.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_uni_selector.dm
@@ -1,0 +1,119 @@
+/*
+/datum/gear/uniform_selector/BLANK
+	display_name = "BLANK's Uniform Selector"
+	description = "Select from a range of outfits available to all BLANK personnel."
+	allowed_roles = list("")
+	path =
+	slot = slot_w_uniform
+	sort_category = "Uniform Selectors"
+	cost = 2
+
+/datum/gear/uniform_selector/BLANK/New()
+	..()
+	var/list/selector_uniforms = list(
+	)
+	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(selector_uniforms))
+*/
+
+/datum/gear/uniform_selector/security
+	display_name = "Security - Basic Uniforms"
+	description = "Select from a range of outfits available to all Security personnel."
+	allowed_roles = list("Head of Security", "Warden", "Detective", "Security Officer")
+	path = /obj/item/clothing/under/rank/security/corp
+	slot = slot_w_uniform
+	sort_category = "Uniform Selectors"
+	cost = 2
+
+/datum/gear/uniform_selector/security/New()
+	..()
+	var/list/selector_uniforms = list(
+	"undersuit, modernized"=/obj/item/clothing/under/rank/security/modern,
+	"KHI uniform"=/obj/item/clothing/under/rank/khi/sec,
+	"voidsuit underlayer"=/obj/item/clothing/under/undersuit/sec,
+	"skirt"=/obj/item/clothing/under/rank/security/skirt,
+	"turtleneck"=/obj/item/clothing/under/rank/security/turtleneck,
+	"corporate"=/obj/item/clothing/under/rank/security/corp,
+	"navy blue"=/obj/item/clothing/under/rank/security/navyblue,
+	"Proxima Centauri Risk Control"=/obj/item/clothing/under/corp/pcrc,
+	"TG&C jumpsuit"=/obj/item/clothing/under/rank/neo_sec_red,
+	"TG&C jumpskirt"=/obj/item/clothing/under/rank/neo_sec_red_skirt,
+	"TG&C blue jumpsuit"=/obj/item/clothing/under/rank/neo_sec_blue,
+	"TG&C white"=/obj/item/clothing/under/rank/neo_sec_suit,
+	"TG&C blue"=/obj/item/clothing/under/rank/neo_sec_suit_blue,
+	"TG&C turtleneck"=/obj/item/clothing/under/rank/neo_sec_turtle_red,
+	"TG&C turtleneck & skirt"=/obj/item/clothing/under/rank/neo_sec_turtle_red_skirt,
+	"TG&C blue turtleneck"=/obj/item/clothing/under/rank/neo_sec_turtle_blue,
+	"TG&C blue turtleneck & skirt"=/obj/item/clothing/under/rank/neo_sec_turtle_blue_skirt,
+	"corrections officer"=/obj/item/clothing/under/rank/neo_corrections,
+	"corrections officer w/ skirt"=/obj/item/clothing/under/rank/neo_corrections_skirt,
+	"runner's turtleneck"=/obj/item/clothing/under/rank/neo_runner
+	)
+	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(selector_uniforms))
+
+/datum/gear/uniform_selector/security_warden
+	display_name = "Security - Warden's Uniforms"
+	description = "Select from a range of outfits available to Wardens."
+	allowed_roles = list("Head of Security","Warden")
+	path = /obj/item/clothing/under/rank/warden/corp
+	slot = slot_w_uniform
+	sort_category = "Uniform Selectors"
+	cost = 2
+
+/datum/gear/uniform_selector/security_warden/New()
+	..()
+	var/list/selector_uniforms = list(
+	"skirt"=/obj/item/clothing/under/rank/warden/skirt,
+	"corporate"=/obj/item/clothing/under/rank/warden/corp,
+	"navy blue"=/obj/item/clothing/under/rank/warden/navyblue,
+	"TG&C jumpsuit"=/obj/item/clothing/under/rank/neo_warden_red,
+	"TG&C jumpskirt"=/obj/item/clothing/under/rank/neo_warden_red_skirt,
+	"TG&C blue jumpsuit"=/obj/item/clothing/under/rank/neo_warden_blue
+	)
+	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(selector_uniforms))
+
+/datum/gear/uniform_selector/security_detective
+	display_name = "Security - Detective's Uniforms"
+	description = "Select from a range of outfits available to all Detectives."
+	allowed_roles = list("Head of Security","Detective")
+	path = /obj/item/clothing/under/det/corporate
+	slot = slot_w_uniform
+	sort_category = "Uniform Selectors"
+	cost = 2
+
+/datum/gear/uniform_selector/security_detective/New()
+	..()
+	var/list/selector_uniforms = list(
+	"skirt"=/obj/item/clothing/under/det/skirt,
+	"corporate"=/obj/item/clothing/under/det/corporate
+	)
+	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(selector_uniforms))
+
+/datum/gear/uniform_selector/security_head
+	display_name = "Security - Head's Uniforms"
+	description = "Select from a range of outfits available to all Heads of Security."
+	allowed_roles = list("Head of Security")
+	path = /obj/item/clothing/under/rank/head_of_security/corp
+	slot = slot_w_uniform
+	sort_category = "Uniform Selectors"
+	cost = 2
+
+/datum/gear/uniform_selector/security_head/New()
+	..()
+	var/list/selector_uniforms = list(
+	"skirt"=/obj/item/clothing/under/rank/head_of_security/skirt,
+	"corporate"=/obj/item/clothing/under/rank/head_of_security/corp,
+	"navy blue"=/obj/item/clothing/under/rank/head_of_security/navyblue,
+	"voidsuit underlayer"=/obj/item/clothing/under/undersuit/sec/hos,
+	"TG&C jumpsuit"=/obj/item/clothing/under/rank/neo_hos_red,
+	"TG&C jumpskirt"=/obj/item/clothing/under/rank/neo_hos_red_skirt,
+	"TG&C turtleneck"=/obj/item/clothing/under/rank/neo_hos_blackred,
+	"TG&C turtleneck & skirt"=/obj/item/clothing/under/rank/neo_hos_blackred_skirt,
+	"TG&C parade uniform"=/obj/item/clothing/under/rank/neo_hos_parade,
+	"TG&C parade uniform, feminine"=/obj/item/clothing/under/rank/neo_hos_parade_fem,
+	"TG&C blue"=/obj/item/clothing/under/rank/neo_hos_blue,
+	"TG&C blue turtleneck"=/obj/item/clothing/under/rank/neo_hos_blackblue,
+	"TG&C blue turtleneck & skirt"=/obj/item/clothing/under/rank/neo_hos_blackblue_skirt,
+	"TG&C blue parade uniform"=/obj/item/clothing/under/rank/neo_hos_parade_blue,
+	"TG&C blue parade uniform, feminine"=/obj/item/clothing/under/rank/neo_hos_parade_blue_fem
+	)
+	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(selector_uniforms))

--- a/code/modules/client/preference_setup/loadout/loadout_uni_selector.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_uni_selector.dm
@@ -24,7 +24,6 @@
 	description = "Select from a range of outfits available to all Site Managers."
 	allowed_roles = list("Site Manager")
 	path = /obj/item/clothing/under/rank/neo_captain
-	slot = slot_w_uniform
 	sort_category = "Uniform Selectors"
 	cost = 2
 
@@ -53,7 +52,6 @@
 	description = "Select from a range of outfits available to all Heads of Personnel."
 	allowed_roles = list("Head of Personnel")
 	path = /obj/item/clothing/under/rank/neo_hop
-	slot = slot_w_uniform
 	sort_category = "Uniform Selectors"
 	cost = 2
 
@@ -79,6 +77,80 @@
 	)
 	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(selector_uniforms))
 
+/datum/gear/uniform/pilot_uniform_selector
+	display_name = "Civilian - Pilot's Uniforms"
+	description = "Select from a range of outfits available to all Pilots."
+	allowed_roles = list("Pilot")
+	path = /obj/item/clothing/under/rank/neo_pilot
+	sort_category = "Uniform Selectors"
+	cost = 1
+
+/datum/gear/uniform/pilot_uniform_selector/New()
+	..()
+	var/list/selector_uniforms = list(
+		"TG&C jumpsuit"=/obj/item/clothing/under/rank/neo_pilot,
+		"TG&C jumpskirt"=/obj/item/clothing/under/rank/neo_pilot_skirt,
+		"Major Bill's flightsuit"=/obj/item/clothing/under/mbill_flight
+	)
+	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(selector_uniforms))
+
+/datum/gear/uniform/janitor_uniform_selector
+	display_name = "Civilian - Janitor's Uniforms"
+	description = "Select from a range of outfits available to all Janitorial personnel."
+	allowed_roles = list("Janitor")
+	path = /obj/item/clothing/under/rank/neo_janitor
+	sort_category = "Uniform Selectors"
+	cost = 1
+
+/datum/gear/uniform/janitor_uniform_selector/New()
+	..()
+	var/list/selector_uniforms = list(
+		"TG&C janitor's uniform"=/obj/item/clothing/under/rank/neo_janitor,
+		"TG&C janitor's uniform w/ skirt"=/obj/item/clothing/under/rank/neo_janitor_skirt
+	)
+	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(selector_uniforms))
+
+/datum/gear/uniform/civvie_uniform_selector
+	display_name = "Civilian - Basic Uniforms"
+	description = "Select from a range of uniforms available to all personnel. Includes miscellaneous corporate contractor uniforms."
+	path = /obj/item/clothing/under/utility/grey
+	sort_category = "Uniform Selectors"
+	cost = 1
+
+/datum/gear/uniform/civvie_uniform_selector/New()
+	..()
+	var/list/selector_uniforms = list(
+		"TG&C plain turtleneck"=/obj/item/clothing/under/rank/neo_suspect_turtleneck,
+		"TG&C plain turtleneck w/ skirt"=/obj/item/clothing/under/rank/neo_suspect_turtleskirt,
+		"TG&C blue turtleneck"=/obj/item/clothing/under/rank/neo_suspect_turtleneck_blue,
+		"TG&C blue turtleneck w/ skirt"=/obj/item/clothing/under/rank/neo_suspect_turtleskirt_blue,
+		"TG&C red turtleneck"=/obj/item/clothing/under/rank/neo_suspicious_turtleneck,
+		"TG&C red turtleneck w/ skirt"=/obj/item/clothing/under/rank/neo_suspicious_turtleskirt,
+		"TG&C comfy overalls"=/obj/item/clothing/under/rank/neo_suspect_overalls,
+		"TG&C comfy overalls w/ skirt"=/obj/item/clothing/under/rank/neo_suspect_overalls_skirt,
+		"TG&C contractor's suit"=/obj/item/clothing/under/rank/neo_contract,
+		"Corporate, Major Bill's uniform"=/obj/item/clothing/under/mbill,
+		"Corporate, Aether Atmospherics uniform"=/obj/item/clothing/under/corp/aether,
+		"Corporate, Focal Point Energistics uniform"=/obj/item/clothing/under/corp/focal,
+		"Corporate, Grayson Manufactories uniform"=/obj/item/clothing/under/corp/grayson,
+		"Corporate, Grayson Manufactories jumpsuit"=/obj/item/clothing/under/corp/grayson_jump,
+		"Corporate, Ward-Takahashi uniform"=/obj/item/clothing/under/corp/wardt,
+		"Corporate, Hephaestus Arms uniform"=/obj/item/clothing/under/corp/hephaestus,
+		"Corporate, Centauri Provisions uniform"=/obj/item/clothing/under/corp/centauri,
+		"Corporate, Morpheus Cyberkinetics uniform"=/obj/item/clothing/under/corp/morpheus,
+		"Corporate, Wulf Aeronautics uniform"=/obj/item/clothing/under/corp/wulf,
+		"Corporate, Zeng-Hu uniform"=/obj/item/clothing/under/corp/zenghu,
+		"Corporate, Xion Manufacturing uniform"=/obj/item/clothing/under/corp/xion,
+		"Galactic Survey utility uniform"=/obj/item/clothing/under/gsa,
+		"Galactic Survey reinforced uniform"=/obj/item/clothing/under/gsa_work,
+		"Utility uniform, black"=/obj/item/clothing/under/utility,
+		"Utility uniform, navy"=/obj/item/clothing/under/utility/blue,
+		"Utility uniform, grey"=/obj/item/clothing/under/utility/grey,
+		"Utility uniform, tan"=/obj/item/clothing/under/utility/tan,
+		"Utility uniform, green"=/obj/item/clothing/under/utility/green
+	)
+	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(selector_uniforms))
+
 //Security
 
 /datum/gear/uniform/security_selector
@@ -86,7 +158,6 @@
 	description = "Select from a range of outfits available to all Security personnel."
 	allowed_roles = list("Head of Security", "Warden", "Detective", "Security Officer")
 	path = /obj/item/clothing/under/rank/security/corp
-	slot = slot_w_uniform
 	sort_category = "Uniform Selectors"
 	cost = 2
 
@@ -99,7 +170,8 @@
 		"skirt"=/obj/item/clothing/under/rank/security/skirt,
 		"turtleneck"=/obj/item/clothing/under/rank/security/turtleneck,
 		"corporate"=/obj/item/clothing/under/rank/security/corp,
-		"navy blue"=/obj/item/clothing/under/rank/security/navyblue,
+		"formal, navy"=/obj/item/clothing/under/rank/security/navyblue,
+		"formal, tan"=/obj/item/clothing/under/rank/security/tan,
 		"Proxima Centauri Risk Control"=/obj/item/clothing/under/corp/pcrc,
 		"TG&C jumpsuit"=/obj/item/clothing/under/rank/neo_sec_red,
 		"TG&C jumpskirt"=/obj/item/clothing/under/rank/neo_sec_red_skirt,
@@ -126,7 +198,6 @@
 	description = "Select from a range of outfits available to Wardens."
 	allowed_roles = list("Head of Security","Warden")
 	path = /obj/item/clothing/under/rank/warden/corp
-	slot = slot_w_uniform
 	sort_category = "Uniform Selectors"
 	cost = 2
 
@@ -135,7 +206,8 @@
 	var/list/selector_uniforms = list(
 		"skirt"=/obj/item/clothing/under/rank/warden/skirt,
 		"corporate"=/obj/item/clothing/under/rank/warden/corp,
-		"navy blue"=/obj/item/clothing/under/rank/warden/navyblue,
+		"formal, navy"=/obj/item/clothing/under/rank/warden/navyblue,
+		"formal, tan"=/obj/item/clothing/under/rank/warden/navyblue,
 		"TG&C jumpsuit"=/obj/item/clothing/under/rank/neo_warden_red,
 		"TG&C jumpskirt"=/obj/item/clothing/under/rank/neo_warden_red_skirt,
 		"TG&C blue jumpsuit"=/obj/item/clothing/under/rank/neo_warden_blue
@@ -147,7 +219,6 @@
 	description = "Select from a range of outfits available to all Detectives."
 	allowed_roles = list("Head of Security","Detective")
 	path = /obj/item/clothing/under/det/corporate
-	slot = slot_w_uniform
 	sort_category = "Uniform Selectors"
 	cost = 2
 
@@ -164,7 +235,6 @@
 	description = "Select from a range of outfits available to all Heads of Security."
 	allowed_roles = list("Head of Security")
 	path = /obj/item/clothing/under/rank/head_of_security/corp
-	slot = slot_w_uniform
 	sort_category = "Uniform Selectors"
 	cost = 2
 
@@ -173,7 +243,8 @@
 	var/list/selector_uniforms = list(
 		"skirt"=/obj/item/clothing/under/rank/head_of_security/skirt,
 		"corporate"=/obj/item/clothing/under/rank/head_of_security/corp,
-		"navy blue"=/obj/item/clothing/under/rank/head_of_security/navyblue,
+		"formal, navy"=/obj/item/clothing/under/rank/head_of_security/navyblue,
+		"formal, tan"=/obj/item/clothing/under/rank/head_of_security/tan,
 		"voidsuit underlayer"=/obj/item/clothing/under/undersuit/sec/hos,
 		"TG&C jumpsuit"=/obj/item/clothing/under/rank/neo_hos_red,
 		"TG&C jumpskirt"=/obj/item/clothing/under/rank/neo_hos_red_skirt,
@@ -202,7 +273,6 @@
 	description = "Select from a range of outfits available to all Quartermasters."
 	allowed_roles = list("Quartermaster")
 	path = /obj/item/clothing/under/rank/cargo/jeans
-	slot = slot_w_uniform
 	sort_category = "Uniform Selectors"
 	cost = 2
 
@@ -234,7 +304,6 @@
 	description = "Select from a range of outfits available to all Cargo personnel."
 	allowed_roles = list("Cargo Technician","Shaft Miner","Quartermaster")
 	path = /obj/item/clothing/under/rank/cargotech/jeans
-	slot = slot_w_uniform
 	sort_category = "Uniform Selectors"
 	cost = 2
 
@@ -263,7 +332,6 @@
 	description = "Select from a range of outfits available to all Mining personnel."
 	allowed_roles = list("Shaft Miner","Quartermaster")
 	path = /obj/item/clothing/under/rank/neo_miner
-	slot = slot_w_uniform
 	sort_category = "Uniform Selectors"
 	cost = 2
 
@@ -282,7 +350,6 @@
 	description = "Select from a range of outfits available to all Chief Engineers."
 	allowed_roles = list("Chief Engineer")
 	path = /obj/item/clothing/under/rank/neo_chiefengi
-	slot = slot_w_uniform
 	sort_category = "Uniform Selectors"
 	cost = 2
 
@@ -306,7 +373,6 @@
 	description = "Select from a range of outfits available to all Engineering personnel."
 	allowed_roles = list("Chief Engineer","Engineer","Atmospheric Technician")
 	path = /obj/item/clothing/under/rank/neo_engi
-	slot = slot_w_uniform
 	sort_category = "Uniform Selectors"
 	cost = 2
 
@@ -332,7 +398,6 @@
 	description = "Select from a range of outfits available to all Atmospherics Technicians."
 	allowed_roles = list("Chief Engineer","Atmospheric Technician")
 	path = /obj/item/clothing/under/rank/atmospheric_technician/skirt
-	slot = slot_w_uniform
 	sort_category = "Uniform Selectors"
 	cost = 2
 
@@ -352,7 +417,6 @@
 	description = "Select from a range of outfits available to all Medical personnel."
 	allowed_roles = list("Chief Medical Officer","Medical Doctor","Chemist","Psychiatrist","Paramedic")
 	path = /obj/item/clothing/under/rank/neo_med
-	slot = slot_w_uniform
 	sort_category = "Uniform Selectors"
 	cost = 2
 
@@ -383,7 +447,6 @@
 	description = "Select from a range of outfits available to all Chemists."
 	allowed_roles = list("Chief Medical Officer","Chemist")
 	path = /obj/item/clothing/under/rank/neo_chem
-	slot = slot_w_uniform
 	sort_category = "Uniform Selectors"
 	cost = 2
 
@@ -403,7 +466,6 @@
 	description = "Select from a range of outfits available to all Paramedics."
 	allowed_roles = list("Medical Doctor","Chief Medical Officer","Paramedic")
 	path = /obj/item/clothing/under/rank/paramedunidark
-	slot = slot_w_uniform
 	sort_category = "Uniform Selectors"
 	cost = 2
 
@@ -426,7 +488,6 @@
 	description = "Select from a range of outfits available to all Chief Medical Officers."
 	allowed_roles = list("Chief Medical Officer")
 	path = /obj/item/clothing/under/rank/neo_cmo
-	slot = slot_w_uniform
 	sort_category = "Uniform Selectors"
 	cost = 2
 
@@ -454,7 +515,6 @@
 	description = "Select from a range of outfits available to all Research Directors."
 	allowed_roles = list("Research Director")
 	path = /obj/item/clothing/under/rank/neo_rd_suit
-	slot = slot_w_uniform
 	sort_category = "Uniform Selectors"
 	cost = 2
 
@@ -479,7 +539,6 @@
 	description = "Select from a range of outfits available to all Science personnel."
 	allowed_roles = list("Scientist","Research Director","Roboticist","Xenobiologist","Xenobotanist")
 	path = /obj/item/clothing/under/rank/neo_science
-	slot = slot_w_uniform
 	sort_category = "Uniform Selectors"
 	cost = 2
 
@@ -503,7 +562,6 @@
 	description = "Select from a range of outfits available to all Roboticists."
 	allowed_roles = list("Research Director","Roboticist")
 	path = /obj/item/clothing/under/rank/neo_robo
-	slot = slot_w_uniform
 	sort_category = "Uniform Selectors"
 	cost = 2
 

--- a/code/modules/client/preference_setup/loadout/loadout_uni_selector.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_uni_selector.dm
@@ -15,26 +15,28 @@
 	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(selector_uniforms))
 */
 
+/datum/gear/uniform_selector
+	slot = slot_w_uniform
+	sort_category = "Uniform Selectors"
+	cost = 2
+
 /datum/gear/uniform_selector/site_manager
 	display_name = "Command - Site Manager's Uniforms"
 	description = "Select from a range of outfits available to all Site Managers."
 	allowed_roles = list("Site Manager")
 	path = /obj/item/clothing/under/dress/dress_cap
-	slot = slot_w_uniform
-	sort_category = "Uniform Selectors"
-	cost = 2
 
 /datum/gear/uniform_selector/site_manager/New()
 	..()
 	var/list/selector_uniforms = list(
-	"uniform w/ dress"=/obj/item/clothing/under/dress/dress_cap,
-	"KHI uniform"=/obj/item/clothing/under/rank/khi/cmd,
-	"ST: Original Series Command"=/obj/item/clothing/under/rank/trek/command,
-	"ST: Next Generation Command"=/obj/item/clothing/under/rank/trek/command/next,
-	"ST: Voyager Command"=/obj/item/clothing/under/rank/trek/command/voy,
-	"ST: DS9 Command"=/obj/item/clothing/under/rank/trek/command/ds9,
-	"ST: Enterprise Command"=/obj/item/clothing/under/rank/trek/command/ent,
-	"voidsuit underlayer"=/obj/item/clothing/under/undersuit/command
+		"uniform w/ dress"=/obj/item/clothing/under/dress/dress_cap,
+		"KHI uniform"=/obj/item/clothing/under/rank/khi/cmd,
+		"ST: Original Series Command"=/obj/item/clothing/under/rank/trek/command,
+		"ST: Next Generation Command"=/obj/item/clothing/under/rank/trek/command/next,
+		"ST: Voyager Command"=/obj/item/clothing/under/rank/trek/command/voy,
+		"ST: DS9 Command"=/obj/item/clothing/under/rank/trek/command/ds9,
+		"ST: Enterprise Command"=/obj/item/clothing/under/rank/trek/command/ent,
+		"voidsuit underlayer"=/obj/item/clothing/under/undersuit/command
 	)
 	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(selector_uniforms))
 
@@ -43,22 +45,19 @@
 	description = "Select from a range of outfits available to all Heads of Personnel."
 	allowed_roles = list("Head of Personnel")
 	path = /obj/item/clothing/under/dress/dress_hop
-	slot = slot_w_uniform
-	sort_category = "Uniform Selectors"
-	cost = 2
 
 /datum/gear/uniform_selector/head_of_personnel/New()
 	..()
 	var/list/selector_uniforms = list(
-	"uniform w/ dress"=/obj/item/clothing/under/dress/dress_hop,
-	"HR director"=/obj/item/clothing/under/dress/dress_hr,
-	"KHI uniform"=/obj/item/clothing/under/rank/khi/cmd,
-	"ST: Original Series Command"=/obj/item/clothing/under/rank/trek/command,
-	"ST: Next Generation Command"=/obj/item/clothing/under/rank/trek/command/next,
-	"ST: Voyager Command"=/obj/item/clothing/under/rank/trek/command/voy,
-	"ST: DS9 Command"=/obj/item/clothing/under/rank/trek/command/ds9,
-	"ST: Enterprise Command"=/obj/item/clothing/under/rank/trek/command/ent,
-	"voidsuit underlayer"=/obj/item/clothing/under/undersuit/command
+		"uniform w/ dress"=/obj/item/clothing/under/dress/dress_hop,
+		"HR director"=/obj/item/clothing/under/dress/dress_hr,
+		"KHI uniform"=/obj/item/clothing/under/rank/khi/cmd,
+		"ST: Original Series Command"=/obj/item/clothing/under/rank/trek/command,
+		"ST: Next Generation Command"=/obj/item/clothing/under/rank/trek/command/next,
+		"ST: Voyager Command"=/obj/item/clothing/under/rank/trek/command/voy,
+		"ST: DS9 Command"=/obj/item/clothing/under/rank/trek/command/ds9,
+		"ST: Enterprise Command"=/obj/item/clothing/under/rank/trek/command/ent,
+		"voidsuit underlayer"=/obj/item/clothing/under/undersuit/command
 	)
 	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(selector_uniforms))
 
@@ -67,38 +66,35 @@
 	description = "Select from a range of outfits available to all Security personnel."
 	allowed_roles = list("Head of Security", "Warden", "Detective", "Security Officer")
 	path = /obj/item/clothing/under/rank/security/corp
-	slot = slot_w_uniform
-	sort_category = "Uniform Selectors"
-	cost = 2
 
 /datum/gear/uniform_selector/security/New()
 	..()
 	var/list/selector_uniforms = list(
-	"undersuit, modernized"=/obj/item/clothing/under/rank/security/modern,
-	"KHI uniform"=/obj/item/clothing/under/rank/khi/sec,
-	"voidsuit underlayer"=/obj/item/clothing/under/undersuit/sec,
-	"skirt"=/obj/item/clothing/under/rank/security/skirt,
-	"turtleneck"=/obj/item/clothing/under/rank/security/turtleneck,
-	"corporate"=/obj/item/clothing/under/rank/security/corp,
-	"navy blue"=/obj/item/clothing/under/rank/security/navyblue,
-	"Proxima Centauri Risk Control"=/obj/item/clothing/under/corp/pcrc,
-	"TG&C jumpsuit"=/obj/item/clothing/under/rank/neo_sec_red,
-	"TG&C jumpskirt"=/obj/item/clothing/under/rank/neo_sec_red_skirt,
-	"TG&C blue jumpsuit"=/obj/item/clothing/under/rank/neo_sec_blue,
-	"TG&C white"=/obj/item/clothing/under/rank/neo_sec_suit,
-	"TG&C blue"=/obj/item/clothing/under/rank/neo_sec_suit_blue,
-	"TG&C turtleneck"=/obj/item/clothing/under/rank/neo_sec_turtle_red,
-	"TG&C turtleneck & skirt"=/obj/item/clothing/under/rank/neo_sec_turtle_red_skirt,
-	"TG&C blue turtleneck"=/obj/item/clothing/under/rank/neo_sec_turtle_blue,
-	"TG&C blue turtleneck & skirt"=/obj/item/clothing/under/rank/neo_sec_turtle_blue_skirt,
-	"corrections officer"=/obj/item/clothing/under/rank/neo_corrections,
-	"corrections officer w/ skirt"=/obj/item/clothing/under/rank/neo_corrections_skirt,
-	"runner's turtleneck"=/obj/item/clothing/under/rank/neo_runner,
-	"ST: Original Series Ops"=/obj/item/clothing/under/rank/trek/engsec,
-	"ST: Next Generation Ops"=/obj/item/clothing/under/rank/trek/engsec/next,
-	"ST: Voyager Ops"=/obj/item/clothing/under/rank/trek/engsec/voy,
-	"ST: DS9 Ops"=/obj/item/clothing/under/rank/trek/engsec/ds9,
-	"ST: Enterprise Ops"=/obj/item/clothing/under/rank/trek/engsec/ent
+		"undersuit, modernized"=/obj/item/clothing/under/rank/security/modern,
+		"KHI uniform"=/obj/item/clothing/under/rank/khi/sec,
+		"voidsuit underlayer"=/obj/item/clothing/under/undersuit/sec,
+		"skirt"=/obj/item/clothing/under/rank/security/skirt,
+		"turtleneck"=/obj/item/clothing/under/rank/security/turtleneck,
+		"corporate"=/obj/item/clothing/under/rank/security/corp,
+		"navy blue"=/obj/item/clothing/under/rank/security/navyblue,
+		"Proxima Centauri Risk Control"=/obj/item/clothing/under/corp/pcrc,
+		"TG&C jumpsuit"=/obj/item/clothing/under/rank/neo_sec_red,
+		"TG&C jumpskirt"=/obj/item/clothing/under/rank/neo_sec_red_skirt,
+		"TG&C blue jumpsuit"=/obj/item/clothing/under/rank/neo_sec_blue,
+		"TG&C white"=/obj/item/clothing/under/rank/neo_sec_suit,
+		"TG&C blue"=/obj/item/clothing/under/rank/neo_sec_suit_blue,
+		"TG&C turtleneck"=/obj/item/clothing/under/rank/neo_sec_turtle_red,
+		"TG&C turtleneck & skirt"=/obj/item/clothing/under/rank/neo_sec_turtle_red_skirt,
+		"TG&C blue turtleneck"=/obj/item/clothing/under/rank/neo_sec_turtle_blue,
+		"TG&C blue turtleneck & skirt"=/obj/item/clothing/under/rank/neo_sec_turtle_blue_skirt,
+		"corrections officer"=/obj/item/clothing/under/rank/neo_corrections,
+		"corrections officer w/ skirt"=/obj/item/clothing/under/rank/neo_corrections_skirt,
+		"runner's turtleneck"=/obj/item/clothing/under/rank/neo_runner,
+		"ST: Original Series Ops"=/obj/item/clothing/under/rank/trek/engsec,
+		"ST: Next Generation Ops"=/obj/item/clothing/under/rank/trek/engsec/next,
+		"ST: Voyager Ops"=/obj/item/clothing/under/rank/trek/engsec/voy,
+		"ST: DS9 Ops"=/obj/item/clothing/under/rank/trek/engsec/ds9,
+		"ST: Enterprise Ops"=/obj/item/clothing/under/rank/trek/engsec/ent
 	)
 	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(selector_uniforms))
 
@@ -107,19 +103,16 @@
 	description = "Select from a range of outfits available to Wardens."
 	allowed_roles = list("Head of Security","Warden")
 	path = /obj/item/clothing/under/rank/warden/corp
-	slot = slot_w_uniform
-	sort_category = "Uniform Selectors"
-	cost = 2
 
 /datum/gear/uniform_selector/security_warden/New()
 	..()
 	var/list/selector_uniforms = list(
-	"skirt"=/obj/item/clothing/under/rank/warden/skirt,
-	"corporate"=/obj/item/clothing/under/rank/warden/corp,
-	"navy blue"=/obj/item/clothing/under/rank/warden/navyblue,
-	"TG&C jumpsuit"=/obj/item/clothing/under/rank/neo_warden_red,
-	"TG&C jumpskirt"=/obj/item/clothing/under/rank/neo_warden_red_skirt,
-	"TG&C blue jumpsuit"=/obj/item/clothing/under/rank/neo_warden_blue
+		"skirt"=/obj/item/clothing/under/rank/warden/skirt,
+		"corporate"=/obj/item/clothing/under/rank/warden/corp,
+		"navy blue"=/obj/item/clothing/under/rank/warden/navyblue,
+		"TG&C jumpsuit"=/obj/item/clothing/under/rank/neo_warden_red,
+		"TG&C jumpskirt"=/obj/item/clothing/under/rank/neo_warden_red_skirt,
+		"TG&C blue jumpsuit"=/obj/item/clothing/under/rank/neo_warden_blue
 	)
 	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(selector_uniforms))
 
@@ -128,15 +121,12 @@
 	description = "Select from a range of outfits available to all Detectives."
 	allowed_roles = list("Head of Security","Detective")
 	path = /obj/item/clothing/under/det/corporate
-	slot = slot_w_uniform
-	sort_category = "Uniform Selectors"
-	cost = 2
 
 /datum/gear/uniform_selector/security_detective/New()
 	..()
 	var/list/selector_uniforms = list(
-	"skirt"=/obj/item/clothing/under/det/skirt,
-	"corporate"=/obj/item/clothing/under/det/corporate
+		"skirt"=/obj/item/clothing/under/det/skirt,
+		"corporate"=/obj/item/clothing/under/det/corporate
 	)
 	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(selector_uniforms))
 
@@ -145,28 +135,31 @@
 	description = "Select from a range of outfits available to all Heads of Security."
 	allowed_roles = list("Head of Security")
 	path = /obj/item/clothing/under/rank/head_of_security/corp
-	slot = slot_w_uniform
-	sort_category = "Uniform Selectors"
-	cost = 2
 
 /datum/gear/uniform_selector/security_head/New()
 	..()
 	var/list/selector_uniforms = list(
-	"skirt"=/obj/item/clothing/under/rank/head_of_security/skirt,
-	"corporate"=/obj/item/clothing/under/rank/head_of_security/corp,
-	"navy blue"=/obj/item/clothing/under/rank/head_of_security/navyblue,
-	"voidsuit underlayer"=/obj/item/clothing/under/undersuit/sec/hos,
-	"TG&C jumpsuit"=/obj/item/clothing/under/rank/neo_hos_red,
-	"TG&C jumpskirt"=/obj/item/clothing/under/rank/neo_hos_red_skirt,
-	"TG&C turtleneck"=/obj/item/clothing/under/rank/neo_hos_blackred,
-	"TG&C turtleneck & skirt"=/obj/item/clothing/under/rank/neo_hos_blackred_skirt,
-	"TG&C parade uniform"=/obj/item/clothing/under/rank/neo_hos_parade,
-	"TG&C parade uniform, feminine"=/obj/item/clothing/under/rank/neo_hos_parade_fem,
-	"TG&C blue"=/obj/item/clothing/under/rank/neo_hos_blue,
-	"TG&C blue turtleneck"=/obj/item/clothing/under/rank/neo_hos_blackblue,
-	"TG&C blue turtleneck & skirt"=/obj/item/clothing/under/rank/neo_hos_blackblue_skirt,
-	"TG&C blue parade uniform"=/obj/item/clothing/under/rank/neo_hos_parade_blue,
-	"TG&C blue parade uniform, feminine"=/obj/item/clothing/under/rank/neo_hos_parade_blue_fem
+		"skirt"=/obj/item/clothing/under/rank/head_of_security/skirt,
+		"corporate"=/obj/item/clothing/under/rank/head_of_security/corp,
+		"navy blue"=/obj/item/clothing/under/rank/head_of_security/navyblue,
+		"voidsuit underlayer"=/obj/item/clothing/under/undersuit/sec/hos,
+		"TG&C jumpsuit"=/obj/item/clothing/under/rank/neo_hos_red,
+		"TG&C jumpskirt"=/obj/item/clothing/under/rank/neo_hos_red_skirt,
+		"TG&C turtleneck"=/obj/item/clothing/under/rank/neo_hos_blackred,
+		"TG&C turtleneck & skirt"=/obj/item/clothing/under/rank/neo_hos_blackred_skirt,
+		"TG&C parade uniform"=/obj/item/clothing/under/rank/neo_hos_parade,
+		"TG&C parade uniform, feminine"=/obj/item/clothing/under/rank/neo_hos_parade_fem,
+		"TG&C blue"=/obj/item/clothing/under/rank/neo_hos_blue,
+		"TG&C blue turtleneck"=/obj/item/clothing/under/rank/neo_hos_blackblue,
+		"TG&C blue turtleneck & skirt"=/obj/item/clothing/under/rank/neo_hos_blackblue_skirt,
+		"TG&C blue parade uniform"=/obj/item/clothing/under/rank/neo_hos_parade_blue,
+		"TG&C blue parade uniform, feminine"=/obj/item/clothing/under/rank/neo_hos_parade_blue_fem,
+		"KHI uniform, command"=/obj/item/clothing/under/rank/khi/cmd,
+		"ST: Original Series Command"=/obj/item/clothing/under/rank/trek/command,
+		"ST: Next Generation Command"=/obj/item/clothing/under/rank/trek/command/next,
+		"ST: Voyager Command"=/obj/item/clothing/under/rank/trek/command/voy,
+		"ST: DS9 Command"=/obj/item/clothing/under/rank/trek/command/ds9,
+		"ST: Enterprise Command"=/obj/item/clothing/under/rank/trek/command/ent
 	)
 	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(selector_uniforms))
 
@@ -175,25 +168,27 @@
 	description = "Select from a range of outfits available to all Quartermasters."
 	allowed_roles = list("Quartermaster")
 	path = /obj/item/clothing/under/rank/cargo/jeans
-	slot = slot_w_uniform
-	sort_category = "Uniform Selectors"
-	cost = 2
 
 /datum/gear/uniform_selector/quartermaster/New()
 	..()
 	var/list/selector_uniforms = list(
-	"skirt"=/obj/item/clothing/under/rank/cargo/skirt,
-	"jeans"=/obj/item/clothing/under/rank/cargo/jeans,
-	"jeans, feminine cut"=/obj/item/clothing/under/rank/cargo/jeans/female,
-	"KHI uniform"=/obj/item/clothing/under/rank/khi/crg,
-	"TG&C jumpsuit"=/obj/item/clothing/under/rank/neo_qm,
-	"TG&C jumpskirt"=/obj/item/clothing/under/rank/neo_qm_skirt,
-	"TG&C casualwear"=/obj/item/clothing/under/rank/neo_qm_jacket,
-	"TG&C button-up"=/obj/item/clothing/under/rank/neo_qm_white,
-	"TG&C button-up w/ skirt"=/obj/item/clothing/under/rank/neo_qm_white_skirt,
-	"TG&C turtleneck"=/obj/item/clothing/under/rank/neo_qm_turtle,
-	"TG&C turtleneck w/ skirt"=/obj/item/clothing/under/rank/neo_qm_turtle_skirt,
-	"TG&C gorka suit"=/obj/item/clothing/under/rank/neo_qm_gorka
+		"skirt"=/obj/item/clothing/under/rank/cargo/skirt,
+		"jeans"=/obj/item/clothing/under/rank/cargo/jeans,
+		"jeans, feminine cut"=/obj/item/clothing/under/rank/cargo/jeans/female,
+		"KHI uniform, command"=/obj/item/clothing/under/rank/khi/cmd,
+		"TG&C jumpsuit"=/obj/item/clothing/under/rank/neo_qm,
+		"TG&C jumpskirt"=/obj/item/clothing/under/rank/neo_qm_skirt,
+		"TG&C casualwear"=/obj/item/clothing/under/rank/neo_qm_jacket,
+		"TG&C button-up"=/obj/item/clothing/under/rank/neo_qm_white,
+		"TG&C button-up w/ skirt"=/obj/item/clothing/under/rank/neo_qm_white_skirt,
+		"TG&C turtleneck"=/obj/item/clothing/under/rank/neo_qm_turtle,
+		"TG&C turtleneck w/ skirt"=/obj/item/clothing/under/rank/neo_qm_turtle_skirt,
+		"TG&C gorka suit"=/obj/item/clothing/under/rank/neo_qm_gorka,
+		"ST: Original Series Command"=/obj/item/clothing/under/rank/trek/command,
+		"ST: Next Generation Command"=/obj/item/clothing/under/rank/trek/command/next,
+		"ST: Voyager Command"=/obj/item/clothing/under/rank/trek/command/voy,
+		"ST: DS9 Command"=/obj/item/clothing/under/rank/trek/command/ds9,
+		"ST: Enterprise Command"=/obj/item/clothing/under/rank/trek/command/ent
 	)
 	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(selector_uniforms))
 
@@ -202,28 +197,96 @@
 	description = "Select from a range of outfits available to all Cargo personnel."
 	allowed_roles = list("Cargo Technician","Shaft Miner","Quartermaster")
 	path = /obj/item/clothing/under/rank/cargotech/jeans
-	slot = slot_w_uniform
-	sort_category = "Uniform Selectors"
-	cost = 2
 
 /datum/gear/uniform_selector/cargo_general/New()
 	..()
 	var/list/selector_uniforms = list(
-	"skirt"=/obj/item/clothing/under/rank/cargotech/skirt,
-	"jeans"=/obj/item/clothing/under/rank/cargotech/jeans,
-	"jeans, feminine cut"=/obj/item/clothing/under/rank/cargotech/jeans/female,
-	"KHI uniform"=/obj/item/clothing/under/rank/khi/crg,
-	"TG&C shorts"=/obj/item/clothing/under/rank/neo_cargo_shorts,
-	"TG&C skirt"=/obj/item/clothing/under/rank/neo_cargo_skirt,
-	"TG&C miner's uniform"=/obj/item/clothing/under/rank/neo_miner,
-	"TG&C hunter's uniform"=/obj/item/clothing/under/rank/neo_miner_fauna,
-	"TG&C jumpsuit"=/obj/item/clothing/under/rank/neo_cargo,
-	"TG&C utility uniform"=/obj/item/clothing/under/rank/neo_util_cargo,
-	"TG&C dark"=/obj/item/clothing/under/rank/neo_cargo_dark,
-	"TG&C casual"=/obj/item/clothing/under/rank/neo_cargo_casual,
-	"TG&C turtleneck"=/obj/item/clothing/under/rank/neo_cargo_turtle,
-	"TG&C turtleneck w/ skirt"=/obj/item/clothing/under/rank/neo_cargo_turtle_skirt,
-	"TG&C gorka suit"=/obj/item/clothing/under/rank/neo_cargo_gorka,
-	"customs officer"=/obj/item/clothing/under/rank/neo_cargo_customs
+		"skirt"=/obj/item/clothing/under/rank/cargotech/skirt,
+		"jeans"=/obj/item/clothing/under/rank/cargotech/jeans,
+		"jeans, feminine cut"=/obj/item/clothing/under/rank/cargotech/jeans/female,
+		"KHI uniform"=/obj/item/clothing/under/rank/khi/crg,
+		"TG&C shorts"=/obj/item/clothing/under/rank/neo_cargo_shorts,
+		"TG&C skirt"=/obj/item/clothing/under/rank/neo_cargo_skirt,
+		"TG&C jumpsuit"=/obj/item/clothing/under/rank/neo_cargo,
+		"TG&C utility uniform"=/obj/item/clothing/under/rank/neo_util_cargo,
+		"TG&C dark"=/obj/item/clothing/under/rank/neo_cargo_dark,
+		"TG&C casual"=/obj/item/clothing/under/rank/neo_cargo_casual,
+		"TG&C turtleneck"=/obj/item/clothing/under/rank/neo_cargo_turtle,
+		"TG&C turtleneck w/ skirt"=/obj/item/clothing/under/rank/neo_cargo_turtle_skirt,
+		"TG&C gorka suit"=/obj/item/clothing/under/rank/neo_cargo_gorka,
+		"customs officer"=/obj/item/clothing/under/rank/neo_cargo_customs
+	)
+	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(selector_uniforms))
+
+/datum/gear/uniform_selector/cargo_miner
+	display_name = "Cargo - Miner's Uniforms"
+	description = "Select from a range of outfits available to all Mining personnel."
+	allowed_roles = list("Shaft Miner","Quartermaster")
+	path = /obj/item/clothing/under/rank/neo_miner
+
+/datum/gear/uniform_selector/cargo_miner/New()
+	..()
+	var/list/selector_uniforms = list(
+		"TG&C miner's uniform"=/obj/item/clothing/under/rank/neo_miner,
+		"TG&C hunter's uniform"=/obj/item/clothing/under/rank/neo_miner_fauna
+	)
+	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(selector_uniforms))
+
+/datum/gear/uniform_selector/engineering_chief
+	display_name = "Engineering - Chief Engineer's Uniforms"
+	description = "Select from a range of outfits available to all Chief Engineers."
+	allowed_roles = list("Chief Engineer")
+	path = /obj/item/clothing/under/rank/neo_chiefengi
+
+/datum/gear/uniform_selector/engineering_chief/New()
+	..()
+	var/list/selector_uniforms = list(
+		"skirt"=/obj/item/clothing/under/rank/chief_engineer/skirt,
+		"KHI uniform, command"=/obj/item/clothing/under/rank/khi/cmd,
+		"ST: Original Series Command"=/obj/item/clothing/under/rank/trek/command,
+		"ST: Next Generation Command"=/obj/item/clothing/under/rank/trek/command/next,
+		"ST: Voyager Command"=/obj/item/clothing/under/rank/trek/command/voy,
+		"ST: DS9 Command"=/obj/item/clothing/under/rank/trek/command/ds9,
+		"ST: Enterprise Command"=/obj/item/clothing/under/rank/trek/command/ent,
+		"TG&C jumpsuit"=/obj/item/clothing/under/rank/neo_chiefengi,
+		"TG&C jumpskirt"=/obj/item/clothing/under/rank/neo_chiefengi_skirt
+	)
+	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(selector_uniforms))
+
+/datum/gear/uniform_selector/engineer
+	display_name = "Engineering - Basic Uniforms"
+	description = "Select from a range of outfits available to all Engineering personnel."
+	allowed_roles = list("Chief Engineer","Engineer","Atmospheric Technician")
+	path = /obj/item/clothing/under/rank/neo_engi
+
+/datum/gear/uniform_selector/engineer/New()
+	..()
+	var/list/selector_uniforms = list(
+		"skirt"=/obj/item/clothing/under/rank/engineer/skirt,
+		"turtleneck"=/obj/item/clothing/under/rank/engineer/turtleneck,
+		"KHI uniform"=/obj/item/clothing/under/rank/khi/eng,
+		"ST: Original Series Ops"=/obj/item/clothing/under/rank/trek/engsec,
+		"ST: Next Generation Ops"=/obj/item/clothing/under/rank/trek/engsec/next,
+		"ST: Voyager Ops"=/obj/item/clothing/under/rank/trek/engsec/voy,
+		"ST: DS9 Ops"=/obj/item/clothing/under/rank/trek/engsec/ds9,
+		"ST: Enterprise Ops"=/obj/item/clothing/under/rank/trek/engsec/ent,
+		"voidsuit underlayer"=/obj/item/clothing/under/undersuit/hazard,
+		"TG&C jumpsuit"=/obj/item/clothing/under/rank/neo_engi,
+		"TG&C jumpskirt"=/obj/item/clothing/under/rank/neo_engi_skirt
+	)
+	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(selector_uniforms))
+
+/datum/gear/uniform_selector/engi_atmos
+	display_name = "Engineering - Atmos Tech's Uniforms"
+	description = "Select from a range of outfits available to all Atmospherics Technicians."
+	allowed_roles = list("Chief Engineer","Atmospheric Technician")
+	path = /obj/item/clothing/under/rank/atmospheric_technician/skirt
+
+/datum/gear/uniform_selector/engi_atmos/New()
+	..()
+	var/list/selector_uniforms = list(
+		"skirt"=/obj/item/clothing/under/rank/atmospheric_technician/skirt,
+		"TG&C jumpsuit"=/obj/item/clothing/under/rank/neo_atmos,
+		"TG&C jumpskirt"=/obj/item/clothing/under/rank/neo_atmos_skirt
 	)
 	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(selector_uniforms))

--- a/code/modules/client/preference_setup/loadout/loadout_uni_selector.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_uni_selector.dm
@@ -1,6 +1,6 @@
 /*
 /datum/gear/uniform_selector/BLANK
-	display_name = "BLANK's Uniform Selector"
+	display_name = "DEPT - BLANK's Uniforms"
 	description = "Select from a range of outfits available to all BLANK personnel."
 	allowed_roles = list("")
 	path =
@@ -14,6 +14,53 @@
 	)
 	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(selector_uniforms))
 */
+
+/datum/gear/uniform_selector/site_manager
+	display_name = "Command - Site Manager's Uniforms"
+	description = "Select from a range of outfits available to all Site Managers."
+	allowed_roles = list("Site Manager")
+	path = /obj/item/clothing/under/dress/dress_cap
+	slot = slot_w_uniform
+	sort_category = "Uniform Selectors"
+	cost = 2
+
+/datum/gear/uniform_selector/site_manager/New()
+	..()
+	var/list/selector_uniforms = list(
+	"uniform w/ dress"=/obj/item/clothing/under/dress/dress_cap,
+	"KHI uniform"=/obj/item/clothing/under/rank/khi/cmd,
+	"ST: Original Series Command"=/obj/item/clothing/under/rank/trek/command,
+	"ST: Next Generation Command"=/obj/item/clothing/under/rank/trek/command/next,
+	"ST: Voyager Command"=/obj/item/clothing/under/rank/trek/command/voy,
+	"ST: DS9 Command"=/obj/item/clothing/under/rank/trek/command/ds9,
+	"ST: Enterprise Command"=/obj/item/clothing/under/rank/trek/command/ent,
+	"voidsuit underlayer"=/obj/item/clothing/under/undersuit/command
+	)
+	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(selector_uniforms))
+
+/datum/gear/uniform_selector/head_of_personnel
+	display_name = "Command - Head of Personnel's Uniforms"
+	description = "Select from a range of outfits available to all Heads of Personnel."
+	allowed_roles = list("Head of Personnel")
+	path = /obj/item/clothing/under/dress/dress_hop
+	slot = slot_w_uniform
+	sort_category = "Uniform Selectors"
+	cost = 2
+
+/datum/gear/uniform_selector/head_of_personnel/New()
+	..()
+	var/list/selector_uniforms = list(
+	"uniform w/ dress"=/obj/item/clothing/under/dress/dress_hop,
+	"HR director"=/obj/item/clothing/under/dress/dress_hr,
+	"KHI uniform"=/obj/item/clothing/under/rank/khi/cmd,
+	"ST: Original Series Command"=/obj/item/clothing/under/rank/trek/command,
+	"ST: Next Generation Command"=/obj/item/clothing/under/rank/trek/command/next,
+	"ST: Voyager Command"=/obj/item/clothing/under/rank/trek/command/voy,
+	"ST: DS9 Command"=/obj/item/clothing/under/rank/trek/command/ds9,
+	"ST: Enterprise Command"=/obj/item/clothing/under/rank/trek/command/ent,
+	"voidsuit underlayer"=/obj/item/clothing/under/undersuit/command
+	)
+	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(selector_uniforms))
 
 /datum/gear/uniform_selector/security
 	display_name = "Security - Basic Uniforms"
@@ -46,7 +93,12 @@
 	"TG&C blue turtleneck & skirt"=/obj/item/clothing/under/rank/neo_sec_turtle_blue_skirt,
 	"corrections officer"=/obj/item/clothing/under/rank/neo_corrections,
 	"corrections officer w/ skirt"=/obj/item/clothing/under/rank/neo_corrections_skirt,
-	"runner's turtleneck"=/obj/item/clothing/under/rank/neo_runner
+	"runner's turtleneck"=/obj/item/clothing/under/rank/neo_runner,
+	"ST: Original Series Ops"=/obj/item/clothing/under/rank/trek/engsec,
+	"ST: Next Generation Ops"=/obj/item/clothing/under/rank/trek/engsec/next,
+	"ST: Voyager Ops"=/obj/item/clothing/under/rank/trek/engsec/voy,
+	"ST: DS9 Ops"=/obj/item/clothing/under/rank/trek/engsec/ds9,
+	"ST: Enterprise Ops"=/obj/item/clothing/under/rank/trek/engsec/ent
 	)
 	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(selector_uniforms))
 
@@ -115,5 +167,63 @@
 	"TG&C blue turtleneck & skirt"=/obj/item/clothing/under/rank/neo_hos_blackblue_skirt,
 	"TG&C blue parade uniform"=/obj/item/clothing/under/rank/neo_hos_parade_blue,
 	"TG&C blue parade uniform, feminine"=/obj/item/clothing/under/rank/neo_hos_parade_blue_fem
+	)
+	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(selector_uniforms))
+
+/datum/gear/uniform_selector/quartermaster
+	display_name = "Cargo - Quartermaster's Uniforms"
+	description = "Select from a range of outfits available to all Quartermasters."
+	allowed_roles = list("Quartermaster")
+	path = /obj/item/clothing/under/rank/cargo/jeans
+	slot = slot_w_uniform
+	sort_category = "Uniform Selectors"
+	cost = 2
+
+/datum/gear/uniform_selector/quartermaster/New()
+	..()
+	var/list/selector_uniforms = list(
+	"skirt"=/obj/item/clothing/under/rank/cargo/skirt,
+	"jeans"=/obj/item/clothing/under/rank/cargo/jeans,
+	"jeans, feminine cut"=/obj/item/clothing/under/rank/cargo/jeans/female,
+	"KHI uniform"=/obj/item/clothing/under/rank/khi/crg,
+	"TG&C jumpsuit"=/obj/item/clothing/under/rank/neo_qm,
+	"TG&C jumpskirt"=/obj/item/clothing/under/rank/neo_qm_skirt,
+	"TG&C casualwear"=/obj/item/clothing/under/rank/neo_qm_jacket,
+	"TG&C button-up"=/obj/item/clothing/under/rank/neo_qm_white,
+	"TG&C button-up w/ skirt"=/obj/item/clothing/under/rank/neo_qm_white_skirt,
+	"TG&C turtleneck"=/obj/item/clothing/under/rank/neo_qm_turtle,
+	"TG&C turtleneck w/ skirt"=/obj/item/clothing/under/rank/neo_qm_turtle_skirt,
+	"TG&C gorka suit"=/obj/item/clothing/under/rank/neo_qm_gorka
+	)
+	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(selector_uniforms))
+
+/datum/gear/uniform_selector/cargo_general
+	display_name = "Cargo - Basic Uniforms"
+	description = "Select from a range of outfits available to all Cargo personnel."
+	allowed_roles = list("Cargo Technician","Shaft Miner","Quartermaster")
+	path = /obj/item/clothing/under/rank/cargotech/jeans
+	slot = slot_w_uniform
+	sort_category = "Uniform Selectors"
+	cost = 2
+
+/datum/gear/uniform_selector/cargo_general/New()
+	..()
+	var/list/selector_uniforms = list(
+	"skirt"=/obj/item/clothing/under/rank/cargotech/skirt,
+	"jeans"=/obj/item/clothing/under/rank/cargotech/jeans,
+	"jeans, feminine cut"=/obj/item/clothing/under/rank/cargotech/jeans/female,
+	"KHI uniform"=/obj/item/clothing/under/rank/khi/crg,
+	"TG&C shorts"=/obj/item/clothing/under/rank/neo_cargo_shorts,
+	"TG&C skirt"=/obj/item/clothing/under/rank/neo_cargo_skirt,
+	"TG&C miner's uniform"=/obj/item/clothing/under/rank/neo_miner,
+	"TG&C hunter's uniform"=/obj/item/clothing/under/rank/neo_miner_fauna,
+	"TG&C jumpsuit"=/obj/item/clothing/under/rank/neo_cargo,
+	"TG&C utility uniform"=/obj/item/clothing/under/rank/neo_util_cargo,
+	"TG&C dark"=/obj/item/clothing/under/rank/neo_cargo_dark,
+	"TG&C casual"=/obj/item/clothing/under/rank/neo_cargo_casual,
+	"TG&C turtleneck"=/obj/item/clothing/under/rank/neo_cargo_turtle,
+	"TG&C turtleneck w/ skirt"=/obj/item/clothing/under/rank/neo_cargo_turtle_skirt,
+	"TG&C gorka suit"=/obj/item/clothing/under/rank/neo_cargo_gorka,
+	"customs officer"=/obj/item/clothing/under/rank/neo_cargo_customs
 	)
 	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(selector_uniforms))

--- a/code/modules/clothing/under/jobs/security.dm
+++ b/code/modules/clothing/under/jobs/security.dm
@@ -190,3 +190,28 @@
 	icon_state = "wardenblueclothes"
 	item_state_slots = list(slot_r_hand_str = "ba_suit", slot_l_hand_str = "ba_suit")
 	rolled_sleeves = 0
+
+/*
+ * Tan uniforms
+ */
+/obj/item/clothing/under/rank/security/tan
+	name = "security officer's uniform"
+	desc = "The latest in fashionable security outfits."
+	icon_state = "officertanclothes"
+	item_state_slots = list(slot_r_hand_str = "ba_suit", slot_l_hand_str = "ba_suit")
+	rolled_sleeves = 0
+
+/obj/item/clothing/under/rank/head_of_security/tan
+	desc = "The insignia on this uniform tells you that this uniform belongs to the Head of Security."
+	name = "head of security's uniform"
+	icon_state = "hostanclothes"
+	item_state_slots = list(slot_r_hand_str = "ba_suit", slot_l_hand_str = "ba_suit")
+	rolled_sleeves = 0
+
+/obj/item/clothing/under/rank/warden/tan
+	desc = "The insignia on this uniform tells you that this uniform belongs to the Warden."
+	name = "warden's uniform"
+	icon_state = "wardentanclothes"
+	item_state_slots = list(slot_r_hand_str = "ba_suit", slot_l_hand_str = "ba_suit")
+	rolled_sleeves = 0
+

--- a/code/modules/clothing/under/miscellaneous.dm
+++ b/code/modules/clothing/under/miscellaneous.dm
@@ -239,6 +239,7 @@
 	name = "sleek overalls"
 	desc = "A set of modern pleather reinforced overalls."
 	icon_state = "overalls_sleek"
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS
 
 /obj/item/clothing/under/pirate
 	name = "pirate outfit"

--- a/code/modules/clothing/under/solgov.dm
+++ b/code/modules/clothing/under/solgov.dm
@@ -63,6 +63,18 @@
 	icon_state = "greyutility"
 	worn_state = "greyutility"
 
+/obj/item/clothing/under/utility/tan
+	name = "utility uniform"
+	desc = "A comfortable tan utility jumpsuit."
+	icon_state = "tanutility"
+	worn_state = "tanutility"
+
+/obj/item/clothing/under/utility/green
+	name = "utility uniform"
+	desc = "A comfortable green utility jumpsuit."
+	icon_state = "greenutility"
+	worn_state = "greenutility"
+
 //Here's the real ones
 /obj/item/clothing/under/solgov/utility/sifguard
 	name = "\improper SifGuard uniform"

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -1942,6 +1942,7 @@
 #include "code\modules\client\preference_setup\loadout\loadout_smoking.dm"
 #include "code\modules\client\preference_setup\loadout\loadout_suit.dm"
 #include "code\modules\client\preference_setup\loadout\loadout_suit_vr.dm"
+#include "code\modules\client\preference_setup\loadout\loadout_uni_selector.dm"
 #include "code\modules\client\preference_setup\loadout\loadout_uniform.dm"
 #include "code\modules\client\preference_setup\loadout\loadout_uniform_vr.dm"
 #include "code\modules\client\preference_setup\loadout\loadout_utility.dm"


### PR DESCRIPTION
Adds a new category of uniform selectors which include all the valid, role-restricted uniforms for a role under a single option. The intent of this is to provide easier selection of job uniforms in what is now an increasingly bloated loadout list.

This __**will not**__ replace or remove anything at the present time, to avoid disrupting loadouts.

![image](https://github.com/VOREStation/VOREStation/assets/49700375/153689a4-92b9-403e-bd65-7216eabe47e1)

- [x] Command
- [x] Security
- [x] Cargo
- [x] Engineering
- [x] Science
- [x] Medical

May eventually be expanded to cover suits and other slots as well, but probably in another PR.