### PR TITLE
Altevian Packaged Meals are no longer made of Mylar

### DIFF
--- a/code/modules/food/food/snacks.dm
+++ b/code/modules/food/food/snacks.dm
@@ -37,6 +37,9 @@
 	/// Packaged meals that have opening animation
 	var/package_opening_state
 
+	/// Packaged Altevian Meal Check (for ones with fancy opening animations)
+	var/altevian = FALSE
+
 	/// If this is canned. If true, it will print a message and ask you to open it
 	var/canned = FALSE
 	/// Canned food switch to this state when opened, if set
@@ -289,8 +292,12 @@
 
 /obj/item/weapon/reagent_containers/food/snacks/proc/unpackage(mob/user)
 	package = FALSE
-	to_chat(user, "<span class='notice'>You unwrap [src].</span>")
-	playsound(user,'sound/effects/packagedfoodopen.ogg', 15, 1)
+	if(altevian)
+		to_chat(user, "<span class='notice'>You open [src].</span>")
+		playsound(user,'sound/machines/click.ogg', 15, 1)
+	else
+		to_chat(user, "<span class='notice'>You unwrap [src].</span>")
+		playsound(user,'sound/effects/packagedfoodopen.ogg', 15, 1)
 	if(package_trash)
 		var/obj/item/T = new package_trash
 		user.put_in_hands(T)

--- a/code/modules/food/food/snacks_vr.dm
+++ b/code/modules/food/food/snacks_vr.dm
@@ -846,6 +846,7 @@
 	package_open_state = "altevian_pack_burger-open"
 	package_opening_state = "altevian_pack_burger-opening"
 	package = TRUE
+	altevian = TRUE
 	trash = /obj/item/trash/ratpackburger
 	nutriment_amt = 2
 	nutriment_desc = list("fresh buns" = 2, "burger patty" = 4, "pickles" = 1)
@@ -858,6 +859,7 @@
 	package_open_state = "altevian_pack_cheese-open"
 	package_opening_state = "altevian_pack_cheese-opening"
 	package = TRUE
+	altevian = TRUE
 	trash = /obj/item/trash/ratpackcheese
 	nutriment_amt = 2
 	nutriment_desc = list("gourmand cheese" = 4)
@@ -870,6 +872,7 @@
 	package_open_state = "altevian_pack_turkey-open"
 	package_opening_state = "altevian_pack_turkey-opening"
 	package = TRUE
+	altevian = TRUE
 	trash = /obj/item/trash/ratpackturkey
 	nutriment_amt = 18
 	nutriment_desc = list("high-quality poultry" = 4)
@@ -882,6 +885,7 @@
 	package_open_state = "altevian_pack_ramen_standard-open"
 	package_opening_state = "altevian_pack_ramen_standard-opening"
 	package = TRUE
+	altevian = TRUE
 	trash = /obj/item/trash/ratpackramen/standard
 	nutriment_amt = 2
 	nutriment_desc = list("savory noodles" = 4)
@@ -910,6 +914,7 @@
 	package_open_state = "altevian_pack_taco-open"
 	package_opening_state = "altevian_pack_taco-opening"
 	package = TRUE
+	altevian = TRUE
 	trash = /obj/item/trash/ratpacktaco
 	nutriment_amt = 2
 	nutriment_desc = list("salsa sauce" = 2, "meat chunks" = 4, "cheese" = 3)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

The cool Altevian Packaged Meals use the Packaged code that already exists in the game. When opening it plays a custom soundbite of a chips bag opening (specifically a Lays bag if I remember correctly) but a Lays bag the Altevian Packaged Meals ain't. While I didn't create a custom soundbite for these, I did make it where the Bluespace Upgraded Box makes a 'click' sound as opposed to a plastic/mylar bag opening. Could be changed later down the line, either to encompassed more than the Altevian Packaged Meals simply by changing the name of the check or by adding a custom sfx for the Altevian Packaged Meals opening.

EDIT:
**_This check should only be applied to the MRE like Altevian meals, not every piece of Altevian food!_**

## How This Contributes To The VOREStation Roleplay Experience

No more mylar cases for the fancy Altevian Packaged Meals means players won't be confused by it. I guess. Honestly I think this just makes better sense than the sound effect currently being used by the Altevian Packaged Meals.

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
code: Added a check for Altevian Packaged Meals
sound: Changed sound effect played by opening Altevian Packaged Meals
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->