### PR TITLE
Gun Reloading Microtweaks

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -79,6 +79,8 @@
 	var/sel_mode = 1 //index of the currently selected mode
 	var/list/firemodes = list()
 
+	var/reload_time = 1		//Base reload time in seconds
+
 	//aiming system stuff
 	var/keep_aim = 1 	//1 for keep shooting until aim is lowered
 						//0 for one bullet after tarrget moves and aim is lowered

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -14,6 +14,8 @@
 	var/modifystate
 	var/charge_meter = 1	//if set, the icon state will be chosen based on the current charge
 
+	reload_time = 5		//Energy weapons are slower to reload than ballistics by default, but this is no change from current values
+
 	//self-recharging
 	var/self_recharge = 0	//if set, the weapon will recharge itself
 	var/use_external_power = 0 //if set, the weapon will look for an external power source to draw from, otherwise it recharges magically
@@ -113,8 +115,8 @@
 	if(!power_supply) return null
 	if(!ispath(projectile_type)) return null
 	if(!power_supply.checked_use(charge_cost)) return null
-	var/mob/living/M = loc // TGMC Ammo HUD 
-	if(istype(M)) // TGMC Ammo HUD 
+	var/mob/living/M = loc // TGMC Ammo HUD
+	if(istype(M)) // TGMC Ammo HUD
 		M?.hud_used.update_ammo_hud(M, src)
 	return new projectile_type(src)
 
@@ -129,7 +131,7 @@
 				to_chat(user, "<span class='notice'>[src] already has a power cell.</span>")
 			else
 				user.visible_message("[user] is reloading [src].", "<span class='notice'>You start to insert [P] into [src].</span>")
-				if(do_after(user, 5 * P.w_class))
+				if(do_after(user, reload_time * P.w_class))
 					user.remove_from_mob(P)
 					power_supply = P
 					P.loc = src


### PR DESCRIPTION
Some teeny tiny tweaks to reloading standard energy and ballistic weapons by introducing a `reload_time` var which can be set per-gun, exposing a formerly fixed value.

This has the following immediate effects:
- Ballistics will take a tiny bit longer to reload and do require you to stand still, but are still almost instant.
- Energy weapons should have no change in reload time.
- Launchers and various special weapons are unaffected.

This (potentially) allows finer control and balance of certain weapons down the line if anyone's inclined to meddle with such things, such as making pistols much faster to reload than rifles and so forth. I was also considering adding a seperate `reload_mod` value to ammo, but it seems like it already uses the ammo's `w_class` as a multiplier.

Also cleans up some trailing spaces because textpad decided to do that automatically I guess!

Tested and works OK.