### PR TITLE
reworks handling of transparent limbs (manual mirror)

### DIFF
--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -278,7 +278,7 @@ var/global/list/damage_icon_parts = list() //see UpdateDamageIcon()
 			icon_key += "0"
 			continue
 		if(part)
-			wholeicontransparent &&= part.nonsolid
+			wholeicontransparent &&= part.transparent //VORESTATION EDIT: transparent instead of nonsolid
 			icon_key += "[part.species.get_race_key(part.owner)]"
 			icon_key += "[part.dna.GetUIState(DNA_UI_GENDER)]"
 			icon_key += "[part.s_tone]"
@@ -343,11 +343,7 @@ var/global/list/damage_icon_parts = list() //see UpdateDamageIcon()
 				Cutter.Blend("#000000", ICON_MULTIPLY)	// Black again.
 
 		for(var/obj/item/organ/external/part in organs)
-<<<<<<< HEAD
-			if(isnull(part) || part.is_stump() || part.is_hidden_by_sprite_accessory()) //VOREStation Edit allowing tails to prevent bodyparts rendering, granting more spriter freedom for taur/digitigrade stuff.
-=======
-			if(isnull(part) || part.is_stump() || part == chest)
->>>>>>> 5632af32c9a... reworks handling of transparent limbs (#8947)
+			if(isnull(part) || part.is_stump() || part == chest || part.is_hidden_by_sprite_accessory()) //VOREStation Edit allowing tails to prevent bodyparts rendering, granting more spriter freedom for taur/digitigrade stuff.
 				continue
 			var/icon/temp = part.get_icon(skeleton, !wholeicontransparent)
 
@@ -373,7 +369,7 @@ var/global/list/damage_icon_parts = list() //see UpdateDamageIcon()
 					temp2.Insert(new/icon(temp,dir=EAST),dir=EAST)
 				if(part.icon_position & RIGHT)
 					temp2.Insert(new/icon(temp,dir=WEST),dir=WEST)
-				if (part.nonsolid && !wholeicontransparent) //apply a little (a lot) extra transparency to make it look better
+				if (part.transparent && !wholeicontransparent) //apply a little (a lot) extra transparency to make it look better //VORESTATION EDIT: transparent instead of nonsolid
 					if ((istype(part, /obj/item/organ/external/leg) && apply_extra_transparency_leg) || (istype(part, /obj/item/organ/external/foot) && apply_extra_transparency_foot)) //maybe
 						temp2 += rgb(,,,30)
 				base_icon.Blend(temp2, ICON_UNDERLAY)
@@ -518,22 +514,14 @@ var/global/list/damage_icon_parts = list() //see UpdateDamageIcon()
 
 			face_standing.Blend(hair_s, ICON_OVERLAY)
 
-<<<<<<< HEAD
-	if(head_organ.transparent)		//VOREStation Edit: Prometheans are not ALWAYS transparent
-=======
 	var/icon/ears_s = get_ears_overlay()
 
-	if(head_organ.nonsolid || head_organ.transparent)
->>>>>>> 5632af32c9a... reworks handling of transparent limbs (#8947)
+	if(head_organ.transparent) //VORESTATION EDIT: transparent instead of nonsolid
 		face_standing += rgb(,,,120)
 		if (ears_s)
 			ears_s += rgb(,,,180)
 
-<<<<<<< HEAD
-	var/icon/ears_s = get_ears_overlay()
 	var/image/em_block_ears
-=======
->>>>>>> 5632af32c9a... reworks handling of transparent limbs (#8947)
 	if(ears_s)
 		if(ears_s.Height() > face_standing.Height()) // Tol ears
 			face_standing.Crop(1, 1, face_standing.Width(), ears_s.Height())
@@ -598,13 +586,10 @@ var/global/list/damage_icon_parts = list() //see UpdateDamageIcon()
 	else
 		eyes_icon.Blend(rgb(128,0,0), ICON_ADD)
 
-<<<<<<< HEAD
 	// Convert to emissive at some point
-=======
-	if (head_organ.nonsolid)
+	if (head_organ.transparent) //VOREStation Edit: transparent instead of nonsolid
 		eyes_icon += rgb(,,,180)
 
->>>>>>> 5632af32c9a... reworks handling of transparent limbs (#8947)
 	var/image/eyes_image = image(eyes_icon)
 	eyes_image.plane = PLANE_LIGHTING_ABOVE
 	eyes_image.appearance_flags = appearance_flags
@@ -1023,22 +1008,18 @@ var/global/list/damage_icon_parts = list() //see UpdateDamageIcon()
 	remove_layer(TAIL_UPPER_LAYER_ALT)
 	remove_layer(TAIL_LOWER_LAYER)
 
-<<<<<<< HEAD
 	var/tail_layer = get_tail_layer()
 	if(src.tail_style && src.tail_style.clip_mask_state)
 		tail_layer = TAIL_UPPER_LAYER		// Use default, let clip mask handle everything
 	if(tail_alt && tail_layer == TAIL_UPPER_LAYER)
 		tail_layer = TAIL_UPPER_LAYER_ALT
-=======
-	var/obj/item/organ/external/chest = organs_by_name[BP_TORSO]
 
-	var/tail_layer = GET_TAIL_LAYER
->>>>>>> 5632af32c9a... reworks handling of transparent limbs (#8947)
+	var/obj/item/organ/external/chest = organs_by_name[BP_TORSO]
 
 	var/image/tail_image = get_tail_image()
 	if(tail_image)
 		tail_image.layer = BODY_LAYER+tail_layer
-		tail_image.alpha = chest?.nonsolid ? 180 : 255
+		tail_image.alpha = chest?.transparent ? 180 : 255 //VORESTATION EDIT: transparent instead of nonsolid
 		overlays_standing[tail_layer] = tail_image
 		apply_layer(tail_layer)
 		return
@@ -1049,7 +1030,7 @@ var/global/list/damage_icon_parts = list() //see UpdateDamageIcon()
 	if(species_tail && !(wear_suit && wear_suit.flags_inv & HIDETAIL))
 		var/icon/tail_s = get_tail_icon()
 		tail_image = image(icon = tail_s, icon_state = "[species_tail]_s", layer = BODY_LAYER+tail_layer)
-		tail_image.alpha = chest?.nonsolid ? 180 : 255
+		tail_image.alpha = chest?.transparent ? 180 : 255 //VORESTATION EDIT: transparent instead of nonsolid
 		overlays_standing[tail_layer] = tail_image
 		animate_tail_reset()
 
@@ -1152,16 +1133,13 @@ var/global/list/damage_icon_parts = list() //see UpdateDamageIcon()
 	remove_layer(WING_LAYER)
 	remove_layer(WING_LOWER_LAYER)
 
-<<<<<<< HEAD
 	var/image/wing_image = get_wing_image(FALSE)
-=======
+
 	var/obj/item/organ/external/chest = organs_by_name[BP_TORSO]
 
-	var/image/wing_image = get_wing_image()
->>>>>>> 5632af32c9a... reworks handling of transparent limbs (#8947)
 	if(wing_image)
 		wing_image.layer = BODY_LAYER+WING_LAYER
-		wing_image.alpha = chest?.nonsolid ? 180 : 255
+		wing_image.alpha = chest?.transparent ? 180 : 255 //VORESTATION EDIT: transparent instead of nonsolid
 		overlays_standing[WING_LAYER] = wing_image
 	if(wing_style && wing_style.multi_dir)
 		wing_image = get_wing_image(TRUE)

--- a/code/modules/organs/organ_icon.dm
+++ b/code/modules/organs/organ_icon.dm
@@ -180,7 +180,6 @@ var/global/list/limb_icon_cache = list()
 				mob_icon.Blend(mark_s, ICON_OVERLAY) //So when it's on your body, it has icons
 				icon_cache_key += "[M][markings[M]["color"]]"
 
-<<<<<<< HEAD
 		if(body_hair && islist(h_col) && h_col.len >= 3)
 			var/cache_key = "[body_hair]-[icon_name]-[h_col[1]][h_col[2]][h_col[3]]"
 			if(!limb_icon_cache[cache_key])
@@ -189,10 +188,9 @@ var/global/list/limb_icon_cache = list()
 				limb_icon_cache[cache_key] = I
 			mob_icon.Blend(limb_icon_cache[cache_key], ICON_OVERLAY)
 		// VOREStation edit ends here
-=======
-	if (nonsolid && !istype(src,/obj/item/organ/external/head) && can_apply_transparency && should_apply_transparency)
+
+	if (transparent && !istype(src,/obj/item/organ/external/head) && can_apply_transparency && should_apply_transparency) //VORESTATION EDIT: transparent instead of nonsolid
 		mob_icon += rgb(,,,180) //do it here so any markings become transparent as well
->>>>>>> 5632af32c9a... reworks handling of transparent limbs (#8947)
 
 	dir = EAST
 	icon = mob_icon
@@ -228,12 +226,6 @@ var/global/list/limb_icon_cache = list()
 			icon_cache_key += "_color_[s_col[1]]_[s_col[2]]_[s_col[3]]_[ICON_ADD]"
 		//VOREStation Edit End
 
-<<<<<<< HEAD
-	// Translucency.
-	if(transparent) applying += rgb(,,,180) // SO INTUITIVE TY BYOND //VOREStation Edit
-
-=======
->>>>>>> 5632af32c9a... reworks handling of transparent limbs (#8947)
 	return applying
 
 /obj/item/organ/external/var/icon_cache_key

--- a/code/modules/organs/organ_icon.dm
+++ b/code/modules/organs/organ_icon.dm
@@ -79,7 +79,7 @@ var/global/list/limb_icon_cache = list()
 
 	return res
 
-/obj/item/organ/external/proc/get_icon(var/skeletal)
+/obj/item/organ/external/proc/get_icon(var/skeletal, var/can_apply_transparency = TRUE)
 
 	for(var/M in markings)
 		var/datum/sprite_accessory/marking/mark = markings[M]["datum"]
@@ -107,6 +107,8 @@ var/global/list/limb_icon_cache = list()
 	if(owner && owner.gender == FEMALE)
 		gender = "f"
 
+	var/should_apply_transparency = FALSE
+
 	if(!force_icon_key)
 		icon_cache_key = "[icon_name]_[species ? species.get_bodytype() : SPECIES_HUMAN]" //VOREStation Edit
 	else
@@ -131,9 +133,11 @@ var/global/list/limb_icon_cache = list()
 				mob_icon = new /icon('icons/mob/human_races/r_skeleton.dmi', "[icon_name][gender ? "_[gender]" : ""]")
 			else if (robotic >= ORGAN_ROBOT)
 				mob_icon = new /icon('icons/mob/human_races/robotic.dmi', "[icon_name][gender ? "_[gender]" : ""]")
+				should_apply_transparency = TRUE
 				apply_colouration(mob_icon)
 			else
 				mob_icon = new /icon(species.get_icobase(owner, (status & ORGAN_MUTATED)), "[icon_name][gender ? "_[gender]" : ""]")
+				should_apply_transparency = TRUE
 				apply_colouration(mob_icon)
 
 			//Body markings, actually does not include head this time. Done separately above.
@@ -165,6 +169,7 @@ var/global/list/limb_icon_cache = list()
 
 	if(model)
 		icon_cache_key += "_model_[model]"
+		should_apply_transparency = TRUE
 		apply_colouration(mob_icon)
 		if(owner && owner.synth_markings)
 			for(var/M in markings)
@@ -175,6 +180,7 @@ var/global/list/limb_icon_cache = list()
 				mob_icon.Blend(mark_s, ICON_OVERLAY) //So when it's on your body, it has icons
 				icon_cache_key += "[M][markings[M]["color"]]"
 
+<<<<<<< HEAD
 		if(body_hair && islist(h_col) && h_col.len >= 3)
 			var/cache_key = "[body_hair]-[icon_name]-[h_col[1]][h_col[2]][h_col[3]]"
 			if(!limb_icon_cache[cache_key])
@@ -183,6 +189,10 @@ var/global/list/limb_icon_cache = list()
 				limb_icon_cache[cache_key] = I
 			mob_icon.Blend(limb_icon_cache[cache_key], ICON_OVERLAY)
 		// VOREStation edit ends here
+=======
+	if (nonsolid && !istype(src,/obj/item/organ/external/head) && can_apply_transparency && should_apply_transparency)
+		mob_icon += rgb(,,,180) //do it here so any markings become transparent as well
+>>>>>>> 5632af32c9a... reworks handling of transparent limbs (#8947)
 
 	dir = EAST
 	icon = mob_icon
@@ -218,9 +228,12 @@ var/global/list/limb_icon_cache = list()
 			icon_cache_key += "_color_[s_col[1]]_[s_col[2]]_[s_col[3]]_[ICON_ADD]"
 		//VOREStation Edit End
 
+<<<<<<< HEAD
 	// Translucency.
 	if(transparent) applying += rgb(,,,180) // SO INTUITIVE TY BYOND //VOREStation Edit
 
+=======
+>>>>>>> 5632af32c9a... reworks handling of transparent limbs (#8947)
 	return applying
 
 /obj/item/organ/external/var/icon_cache_key

--- a/code/modules/organs/subtypes/standard.dm
+++ b/code/modules/organs/subtypes/standard.dm
@@ -400,7 +400,7 @@
 
 	add_overlay(get_hair_icon())
 
-	if (nonsolid && can_apply_transparency)
+	if (transparent && can_apply_transparency) //VOREStation Edit: transparent instead of nonsolid
 		mob_icon += rgb(,,,180) //do it here so any markings become transparent as well
 
 	return mob_icon

--- a/code/modules/organs/subtypes/standard.dm
+++ b/code/modules/organs/subtypes/standard.dm
@@ -339,7 +339,7 @@
 		"<span class='notice'>You make \the [I] kiss \the [src]!.</span>")
 	return ..()
 
-/obj/item/organ/external/head/get_icon()
+/obj/item/organ/external/head/get_icon(var/skeletal, var/can_apply_transparency = TRUE)
 	..()
 
 	//The overlays are not drawn on the mob, they are used for if the head is removed and becomes an item
@@ -399,6 +399,9 @@
 		icon_cache_key += "[eye_icon]"
 
 	add_overlay(get_hair_icon())
+
+	if (nonsolid && can_apply_transparency)
+		mob_icon += rgb(,,,180) //do it here so any markings become transparent as well
 
 	return mob_icon
 


### PR DESCRIPTION
## Original PR: https://github.com/PolarisSS13/Polaris/pull/8947
Old transparent limbs were handled fairly badly, with no code for tails, ears, markings, or wings being transparent as well. This fixes that.

Old transparency handling: https://www.youtube.com/watch?v=tTvf5CHl2r8

new transparency handling: https://www.youtube.com/watch?v=rb8An2eykYw

## manual mirror of https://github.com/VOREStation/VOREStation/pull/14653