### PR TITLE
mecha medigun required_type fix

### DIFF
--- a/code/game/mecha/equipment/tools/medigun_vr.dm
+++ b/code/game/mecha/equipment/tools/medigun_vr.dm
@@ -8,4 +8,5 @@
 	projectile = /obj/item/projectile/beam/medigun
 	fire_sound = 'sound/weapons/eluger.ogg'
 	equip_type = EQUIP_UTILITY
+	required_type = /obj/mecha/medical
 	origin_tech = list(TECH_MATERIAL = 5, TECH_COMBAT = 5, TECH_BIO = 6, TECH_POWER = 6)


### PR DESCRIPTION
Partially related to #14924 , general small fix for required_type for the medigun.