### PR TITLE
Modifies scug picnic to use picnic blanket, makes it more aesthetically pleasing

### DIFF
--- a/maps/groundbase/pois/outdoors16.dmm
+++ b/maps/groundbase/pois/outdoors16.dmm
@@ -13,26 +13,17 @@
 /area/template_noop)
 "d" = (
 /obj/structure/table/wooden_reinforced,
+/obj/structure/picnic_blanket_deployed/for_mapping_use{
+	desc = "An old and worn picnic blanket. Its colours appear bleached from being outside too much.";
+	folded_desc = "A worn picnic blanket with a rough texture. One could swear it seems to be covered in strange, otter-like fur";
+	name = "weathered picnic blanket"
+	},
 /obj/item/weapon/storage/toolbox/lunchbox/cat/filled{
-	pixel_y = 8
+	pixel_x = 6;
+	pixel_y = 9
 	},
-/obj/item/weapon/storage/toolbox/lunchbox/nymph/filled,
-/obj/item/clothing/suit/leathercoat{
-	desc = "Who would use a leather coat as a tablecloth?!";
-	name = "Tablecloth?!";
-	pixel_x = 5
-	},
-/obj/item/clothing/suit/greatcoat{
-	desc = "This great coat appears covered in food! Did... it get stolen and reused as ... ?!";
-	name = "Tablecloth?";
-	pixel_x = -9
-	},
+/obj/item/weapon/reagent_containers/food/snacks/fruitsalad,
 /turf/simulated/floor/outdoors/grass/seasonal/notrees_nomobs_nosnow,
-/area/template_noop)
-"g" = (
-/obj/effect/decal/cleanable/fruit_smudge,
-/obj/item/weapon/storage/mre/random,
-/turf/simulated/floor/outdoors/grass/seasonal/notrees_nomobs_lowsnow,
 /area/template_noop)
 "h" = (
 /obj/structure/table/bench/wooden,
@@ -47,16 +38,13 @@
 /obj/structure/table/wooden_reinforced,
 /obj/random/pizzabox,
 /obj/item/weapon/storage/toolbox/lunchbox/mars/filled{
-	pixel_x = -10;
+	pixel_x = -7;
 	pixel_y = 11
 	},
-/obj/item/weapon/bedsheet/rd{
-	desc = "Is this Nubbins' doing?!";
-	name = "Strange tablecloth";
-	pixel_x = 11;
-	pixel_y = 12
+/obj/random/mug{
+	pixel_x = 10;
+	pixel_y = 9
 	},
-/obj/random/mug,
 /turf/simulated/floor/outdoors/grass/seasonal/notrees_nomobs_nosnow,
 /area/template_noop)
 "k" = (
@@ -70,10 +58,6 @@
 "n" = (
 /obj/effect/decal/cleanable/filth,
 /turf/simulated/floor/outdoors/grass/seasonal/notrees_nomobs_lowsnow,
-/area/template_noop)
-"p" = (
-/obj/random/junk,
-/turf/simulated/floor/outdoors/grass/seasonal/nomobs,
 /area/template_noop)
 "s" = (
 /obj/structure/table/bench/wooden,
@@ -127,16 +111,15 @@
 /area/template_noop)
 "N" = (
 /obj/structure/table/wooden_reinforced,
-/obj/item/weapon/bedsheet/hosdouble{
-	desc = "Odd, this tablecloth looks... suspiciously like the bedsheets NanoTrasen security staff use!";
-	name = "Picnic Blanket"
+/obj/item/weapon/storage/toolbox/lunchbox/heart/filled{
+	pixel_x = -4;
+	pixel_y = -6
 	},
-/obj/item/weapon/bedsheet/hosdouble{
-	desc = "Odd, this tablecloth looks... suspiciously like the bedsheets NanoTrasen security staff use!";
-	name = "Picnic Blanket";
-	pixel_x = 11
+/obj/random/mug{
+	pixel_x = 10;
+	pixel_y = 9
 	},
-/obj/item/weapon/storage/toolbox/lunchbox/heart/filled,
+/obj/effect/decal/cleanable/tomato_smudge,
 /turf/simulated/floor/outdoors/grass/seasonal/notrees_nomobs_nosnow,
 /area/template_noop)
 "O" = (
@@ -148,10 +131,6 @@
 /obj/random/mug,
 /turf/simulated/floor/outdoors/grass/seasonal/notrees_nomobs_nosnow,
 /area/template_noop)
-"Q" = (
-/obj/random/cigarettes,
-/turf/simulated/floor/outdoors/grass/seasonal/nomobs,
-/area/template_noop)
 "S" = (
 /obj/structure/table/bench/wooden,
 /obj/item/weapon/towel/random,
@@ -162,7 +141,6 @@
 /turf/simulated/floor/outdoors/grass/seasonal/notrees_nomobs_nosnow,
 /area/template_noop)
 "T" = (
-/obj/effect/decal/cleanable/tomato_smudge,
 /turf/simulated/floor/outdoors/grass/seasonal/notrees_nomobs_lowsnow,
 /area/template_noop)
 "Y" = (
@@ -181,18 +159,18 @@ A
 a
 T
 n
-n
+T
 Y
 "}
 (3,1,1) = {"
-Q
+A
 s
 h
 J
 w
 "}
 (4,1,1) = {"
-L
+A
 N
 d
 i
@@ -208,7 +186,7 @@ m
 (6,1,1) = {"
 L
 z
-g
+T
 k
 A
 "}
@@ -217,5 +195,5 @@ A
 A
 A
 A
-p
+A
 "}


### PR DESCRIPTION
The scugs finally found someone's lost picnic blanket. No longer will heads of staff find themselves without their bedsheets.

I'd attach a picture (will do later) but there's a storm and I want to PR this before shutting my PC down so I dont forget

The promised screenshot:

![image](https://github.com/VOREStation/VOREStation/assets/20523270/d03b98df-0c60-45ae-ba7e-aa9002f89a5a)


It is still messy on the ground with random trash, BUT! The table is finally neatly arranged. All thanks to proper visibility layers and not having to mess around with coats.