### PR TITLE
Fixes mapgen errors from POI corpses by re-ticking corpse.dm

### DIFF
--- a/vorestation.dme
+++ b/vorestation.dme
@@ -1828,6 +1828,7 @@
 #include "code\modules\asset_cache\asset_list.dm"
 #include "code\modules\asset_cache\asset_list_items.dm"
 #include "code\modules\awaymissions\bluespaceartillery.dm"
+#include "code\modules\awaymissions\corpse.dm"
 #include "code\modules\awaymissions\exile.dm"
 #include "code\modules\awaymissions\gateway.dm"
 #include "code\modules\awaymissions\gateway_vr.dm"


### PR DESCRIPTION
While fixing the jukebox empty field warnings, I noticed that...

`## ERROR: Maploader skipping undefined type: '/obj/effect/landmark/corpse/bridgeofficer' (key=pQ)`

happened for all the corpses in the luxury yacht POI. Upon investigating, I'd found that the corpses were no longer spawning at all and Heroman pointed out after I asked him what that error means that...

The file these objects were defined in was unticked. So! I went and investigate why that were the case - was there any issue that this file was causing?

No issues at all from what I can infer, just a misclick during an unrelated PR:
Here's the commit that unticked it as proof that it being re-ticked should not cause any issues - in addition to not seeing any errors during server init nor within the runtimes verb.

https://github.com/VOREStation/VOREStation/commit/0ff5390b531b39cef8495a735969cb68e53a0a51