### PR TITLE
Replaces deprecated virology paths in map files with new one

### DIFF
--- a/maps/expedition_vr/aerostat/aerostat_science_outpost.dmm
+++ b/maps/expedition_vr/aerostat/aerostat_science_outpost.dmm
@@ -1105,7 +1105,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/offmap/aerostat/inside/lobby)
 "cT" = (
-/obj/machinery/smartfridge/chemistry/virology,
+/obj/machinery/smartfridge/virology,
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/virology)
 "cU" = (

--- a/maps/groundbase/gb-centcomm.dmm
+++ b/maps/groundbase/gb-centcomm.dmm
@@ -15121,7 +15121,7 @@
 /obj/effect/floor_decal/corner/green/border{
 	dir = 10
 	},
-/obj/machinery/smartfridge/chemistry/virology,
+/obj/machinery/smartfridge/virology,
 /turf/simulated/floor/tiled/white,
 /area/centcom/medical)
 "XE" = (

--- a/maps/stellar_delight/ship_centcom.dmm
+++ b/maps/stellar_delight/ship_centcom.dmm
@@ -9664,7 +9664,7 @@
 /obj/effect/floor_decal/corner/green/border{
 	dir = 10
 	},
-/obj/machinery/smartfridge/chemistry/virology,
+/obj/machinery/smartfridge/virology,
 /turf/simulated/floor/tiled/white,
 /area/centcom/medical)
 "KJ" = (

--- a/maps/submaps/admin_use_vr/dhael_centcom.dmm
+++ b/maps/submaps/admin_use_vr/dhael_centcom.dmm
@@ -5726,7 +5726,7 @@
 /obj/effect/floor_decal/corner/green/border{
 	dir = 10
 	},
-/obj/machinery/smartfridge/chemistry/virology,
+/obj/machinery/smartfridge/virology,
 /turf/unsimulated/floor/steel{
 	icon_state = "white"
 	},

--- a/maps/tether/submaps/tether_centcom.dmm
+++ b/maps/tether/submaps/tether_centcom.dmm
@@ -9700,7 +9700,7 @@
 /obj/effect/floor_decal/corner/green/border{
 	dir = 10
 	},
-/obj/machinery/smartfridge/chemistry/virology,
+/obj/machinery/smartfridge/virology,
 /turf/simulated/floor/tiled/white,
 /area/centcom/medical)
 "KJ" = (


### PR DESCRIPTION
* Fixes https://github.com/VOREStation/VOREStation/issues/14952

All virology replacements are NOT secure. This is because the original smartfridges weren't secure ones either. This mostly touches centcomm files, with one admin_use submap for a retired staff (Dhael) and most importantly: Stellar Delight's Aerostat.

I've only tested the aerostat fridge, but the rest should behave all the same.

There was one more deprecated path, but that's in polaris-2.dmm so idc about that
