### PR TITLE
Modifies bloodsucker subtle bleedless mode to NOT leave bloodsplatter

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/station_special_abilities_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_special_abilities_vr.dm
@@ -492,12 +492,17 @@
 		else
 			B.apply_damage(5, BRUTE, BP_HEAD) //You're getting fangs pushed into your neck. What do you expect????
 
-		B.drip(80) //Remove enough blood to make them a bit woozy, but not take oxyloss.
-		adjust_nutrition(400)
-		sleep(50)
-		B.drip(1)
-		sleep(50)
-		B.drip(1)
+
+		if(!noise && !bleed) //If we're quiet and careful, there should be no blood to serve as evidence
+			B.remove_blood(82) //Removing in one go since we dont want splatter
+			adjust_nutrition(410) //We drink it all, not letting any go to waste!
+		else //Otherwise, we're letting blood drop to the floor
+			B.drip(80) //Remove enough blood to make them a bit woozy, but not take oxyloss.
+			adjust_nutrition(400)
+			sleep(50)
+			B.drip(1)
+			sleep(50)
+			B.drip(1)
 
 
 //Welcome to the adapted changeling absorb code.


### PR DESCRIPTION
### What this does:
Adds new logic where "Always Subtle" and "Subtle, Bleedless" options no longer place blood splatter on the ground

### Why we need this:
I realized today during talk in #Cadet-Academy about scene clean-up that this might be useful.
WHILE leaving a bunch of drops of blood shouldn't squick anyone given you can do that even if not scening...
If you're trying to do vampirism stuff publicly without being seen, having blood drip under your partner will end up drawing attention to you all the same.

You can now treat your loved ones as caprisun without anyone around you any wiser!

