### PR TITLE
Adds functionality to buildmode's AI mode to adjust a.i wander behavior

### DIFF
--- a/code/modules/admin/verbs/buildmode.dm
+++ b/code/modules/admin/verbs/buildmode.dm
@@ -158,7 +158,9 @@
 							Left Mouse Button on AI mob            = Select/Deselect mob<br>\
 							Left Mouse Button + alt on AI mob      = Toggle hostility on mob<br>\
 							Left Mouse Button + shift on AI mob    = Toggle AI (also resets)<br>\
-							Left Mouse Button + ctrl on AI mob 	  = Copy mob faction<br>\
+							Left Mouse Button + ctrl on AI mob 	   = Copy mob faction<br>\
+							Middle Mouse Button + shift on any     = Set selected mob(s) to wander<br>\
+							Middle Mouse Button + shift on any     = Set selected mob(s) to NOT wander<br>\
 							Right Mouse Button + ctrl on any mob   = Paste mob faction copied with Left Mouse Button + shift<br>\
 							Right Mouse Button on enemy mob        = Command selected mobs to attack mob<br>\
 							Right Mouse Button on allied mob       = Command selected mobs to follow mob<br>\
@@ -544,6 +546,18 @@
 				else //Not living
 					for(var/mob/living/unit in holder.selected_mobs)
 						holder.deselect_AI_mob(user.client, unit)
+
+			if(pa.Find("middle"))
+				if(pa.Find("shift"))
+					to_chat(user, SPAN_NOTICE("All selected mobs set to wander"))
+					for(var/mob/living/unit in holder.selected_mobs)
+						var/datum/ai_holder/AI = unit.ai_holder
+						AI.wander = TRUE
+				if(pa.Find("ctrl"))
+					to_chat(user, SPAN_NOTICE("Setting mobs set to NOT wander"))
+					for(var/mob/living/unit in holder.selected_mobs)
+						var/datum/ai_holder/AI = unit.ai_holder
+						AI.wander = FALSE
 
 
 			if(pa.Find("right"))


### PR DESCRIPTION
### What it does

- Adds new functionality to buildmode that, when in AI mode, pressing MMB + shift on anything in the game screen enables all selected mobs to wander freely around their home turf.
- Alternatively, pressing MMB + CTRL turns off their wandering, prompting them to sit still until someone disturbs them.

Mobs chill out if multiple are set to go to the same tile, lining up neatly.

### Why we need this
It has been a recurring complaint that puppeting mobs is a pain in the ass because they refuse to sit still and wander around randomly.

This should put an end to that.

Furthermore, Selis's PR about mob spawning inspired me.

Using the MMB as it was yet unused for AI mode; currently allowing clicking on anything since there's no other functionality tied to that button. If that changes, we can probably wrap this in a check for turfs or something.






### Commit log
https://github.com/VOREStation/VOREStation/commit/d71653c9b693aef4fdfdd22ffc3bbb2130486ef0
* Works by clicking on ANY object/turf/mob
* MMB + Shift = Wander
* MMB + CTRL = NOT wander
* Adds this info to help button