### PR TITLE
Adds verb for players to show event interest, GMs to check this

### DIFF
--- a/code/_helpers/global_lists_vr.dm
+++ b/code/_helpers/global_lists_vr.dm
@@ -12,6 +12,7 @@ var/global/list/everyone_traits_negative = list()	// Neutral traits available to
 var/global/list/traits_costs = list()		// Just path = cost list, saves time in char setup
 var/global/list/all_traits = list()			// All of 'em at once (same instances)
 var/global/list/active_ghost_pods = list()
+var/global/list/event_consent_list = list() // Assoc list of player ckey as key time of entry as value. Used for giving GMs player enthusiasm info.
 
 //Global vars for making the overmap_renamer subsystem.
 //Collects all instances by reference of visitable overmap objects of /obj/effect/overmap/visitable like the debris field.

--- a/code/modules/admin/admin_verb_lists_vr.dm
+++ b/code/modules/admin/admin_verb_lists_vr.dm
@@ -170,7 +170,8 @@ var/list/admin_verbs_fun = list(
 	/client/proc/add_mob_for_narration,	//VOREStation Add
 	/client/proc/remove_mob_for_narration,	//VOREStation Add
 	/client/proc/narrate_mob,	//VOREStation Add
-	/client/proc/narrate_mob_args //VOREStation Add
+	/client/proc/narrate_mob_args, //VOREStation Add
+	/client/proc/assess_player_readiness  //VOREStation Add
 	)
 
 var/list/admin_verbs_spawn = list(

--- a/code/modules/admin/verbs/adminhelp_vr.dm
+++ b/code/modules/admin/verbs/adminhelp_vr.dm
@@ -37,3 +37,29 @@
 	spawn(10 MINUTES)
 		if(usr)		// In case we left in the 10 minute cooldown
 			usr.verbs += /client/verb/adminspice	// 10 minute cool-down for spice request
+
+//Works using the event_consent_list associative list. key is ckey, value is time they pressed the button.
+//Checked by /client/proc/assess_player_readiness()
+/client/verb/show_event_interest()
+	set category = "Admin"
+	set name = "Show Event Enthusiasm"
+	set desc = "Let staff wanting to run events know you're eager for disruptive events."
+
+	if(usr.key in event_consent_list)
+		var/choice = tgui_alert(usr, "Would you rather focus on scenes or chilling out?",
+		"Withdraw Enthusiasm", list("Choose to Relax", "Cancel"))
+		if(choice == "Choose to Relax")
+			event_consent_list -= usr.key
+			to_chat(usr, SPAN_NOTICE("You have been removed from the list of people enthusiastic for events."))
+	else if(istype(usr, /mob/living))
+		var/choice = tgui_alert(usr, "Would you like to let staff know that you are actively available to respond to and engage with impromptu events \
+		such as rescuing people, filling special orders and so forth? This will add you to a list that staff can request at any time \
+		telling them where you are and whether you are AFK. This does not compel staff to entertain you. \
+		Please note: Your OOC prefs WILL NOT be overriden by opting in.",
+		"Consent to Disruption", list("Show Enthusiasm", "Cancel"))
+		if(choice == "Show Enthusiasm")
+			event_consent_list[usr.key] = world.time
+			to_chat(usr, SPAN_NOTICE("You have been added to list of players who are eager to have the rounds shaken up. \
+			You will be automatically removed if afk for over 30 minutes or leave the round through the verb or cryo/tram/portal"))
+	else
+		to_chat(usr, SPAN_NOTICE("Only players actively in the round can show interest!"))

--- a/code/modules/admin/verbs/assess_player_readiness.dm
+++ b/code/modules/admin/verbs/assess_player_readiness.dm
@@ -1,0 +1,66 @@
+
+//Works using the event_consent_list associative list. key is ckey, value is time they pressed the button.
+//List expanded by /client/verb/show_event_interest()
+/client/proc/assess_player_readiness()
+	set name = "Assess player Interest"
+	set desc = "Obtain a list of players who are actively and eagerly OK with their rounds being disrupted by events."
+	set category = "Fun"
+
+	if(!check_rights(R_FUN)) return
+
+	log_and_message_admins("has checked the event consent list", usr)
+
+	var/message = "The following players have shown interest in their rounds being shaken up: \n"
+	var/alive = 0
+	var/counter = 0
+	var/consenters = LAZYLEN(event_consent_list) //Stopping iteration early if we found all our people
+
+	for(var/mob/player in player_list)
+
+		//We skip if the current player's ckey is not in the volunteer list
+		if(!event_consent_list[player.key])
+			continue
+
+		if(istype(player, /mob/living)) //If it is, and it's alive - we can check where they are.
+			var/mob/living/L = player
+			var/area = get_area(L)
+			var/elapsed_time = (world.time - event_consent_list[L.key]) / (60 SECONDS)
+			var/activity = L.client.inactivity / (60 SECONDS)
+			if(activity > 30)
+				to_chat(L, SPAN_NOTICE("As you are inactive, you were removed from list of players \
+				showing active interest in their rounds being shaken up."))
+				event_consent_list -= L.key
+				continue
+			message += "[player] ([L.key]) opted in [elapsed_time] minutes ago. They were last active [activity] minutes ago.\n \
+			Current location: [area] \n"
+			alive += 1
+		else  //Otherwise, they're likely dead.
+			var/elapsed_time = (world.time - event_consent_list[player.key]) / (60 SECONDS)
+			var/activity = player.client.inactivity / (60 SECONDS)
+			if(activity > 30)
+				to_chat(player, SPAN_NOTICE("As you are inactive, you were removed from list of players \
+				showing active interest in their rounds being shaken up."))
+				event_consent_list -= player.key
+				continue
+			message += "[player] ([player.key]) opted in [elapsed_time] minutes ago. They were last active [activity] minutes ago.\n \
+			They're likely dead, right now.\n"
+
+		counter += 1
+		if(counter > consenters) //We found all players who are open to spice!
+			break
+
+	message += "In total, there are [alive] currently-living players available for events!"
+	to_chat(usr, SPAN_NOTICE(message))
+
+
+
+
+
+
+
+
+/datum/event_readiness
+	var/list/names = list()
+	var/list/time_consented = list()
+	var/list/refs = list()
+	var/list/status = list()

--- a/code/modules/mob/dead/observer/free_vr.dm
+++ b/code/modules/mob/dead/observer/free_vr.dm
@@ -35,6 +35,10 @@ var/global/list/prevent_respawns = list()
 	if(mind)
 		SStranscore.leave_round(src)
 
+	//Removing player from list used by GMs to check player event interest.
+	if(key in event_consent_list)
+		event_consent_list -= key
+
 	//Job slot cleanup
 	var/job = src.mind.assigned_role
 	job_master.FreeRole(job)

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -1738,6 +1738,7 @@
 #include "code\modules\admin\verbs\adminpm.dm"
 #include "code\modules\admin\verbs\adminsay.dm"
 #include "code\modules\admin\verbs\antag-ooc.dm"
+#include "code\modules\admin\verbs\assess_player_readiness.dm"
 #include "code\modules\admin\verbs\atmosdebug.dm"
 #include "code\modules\admin\verbs\BrokenInhands.dm"
 #include "code\modules\admin\verbs\buildmode.dm"


### PR DESCRIPTION
### What this does:
 - Adds two new verbs, one for all clients: Show Event Enthusiasm
   - Adds user into a global list where the time they pressed the button is recorded. They can always remove themselves
 - The other verb: Assess Player Interest
   - Prints contents of the aforementioned global list in a new line for each user like in the attached image: 
![image](https://github.com/VOREStation/VOREStation/assets/20523270/851d1101-13f1-407a-8a27-f7fdae6fac6b)
 - Entries inactive for 30 minutes automatically removed, notifying the player that this happened
 - Players leaving the round thru the verb or tram/cryo/portal are likewise removed by cleanup() verb.
 - This list exists on a per-round basis, as this is an active, enthusiastic demonstration of interest.
 - This is also not request-spice. This merely shows enthusiasm, does not request events.
 
### Why we need this:

Months ago I recall some GMs had complained that they had had ideas for the Stellar Delight but were disheartened from pursuing them due to not knowing if people would even bite, show interest.

Hopefully, players who would like such things will press this button to remove anxieties over "Will people even care? Will I get flamed for wanting to make things interesting?"

### Caveats:

Wording may still need refinement Above screenshot is before some commitee work to improve wording. Present wording is in the files changed window.

### Testing:
- Confirmed player quitting the round by verb after dying removed them
- Confirmed player quitting the round by cryo removed them
- Confirmed player dying by digestion or violence did NOT remove them
- Confirmed list shape with 2 entries (1 guest acc, 1 host acc)
- Confirmed player choosing to stop showing enthusiasm is removed from the list
- Confirmed changing the area between calls changes the area var
- Confirmed inactivity check (setting the if comparison to 1 minute temporarily) works for auto removal
- Confirmed it does NOT show up for non-admin.


### Commit details:
https://github.com/VOREStation/VOREStation/pull/14959/commits/431dd7aaf67c46635991ae638576c70382103335
* New global associative list: key player ckey, value world.time
* New client verb under admin tab: "Show Event Enthusiasm"
* If usr.key in global associative list, let them remove themselves from it
* Else, let them add themselves, noting when they did so
* New admin verb under Fun tab:  "Assess player Interest"
* Iterates over player list, comparing ckeys against the new list
* Checks if mob/living or not, incrementing an alive counter
* Prints to chat each hit's name, ckey, time since opt in in minutes, inactivity in minutes and current area.
* If dead, skips area and denotes the possibility
* Removes entries who were inactive for 30 minutes
* Notifies entry player if they were removed
* Has a counter var to avoid iterating over all of player_list if we found our players faster than the whole list.
* cleanup() modified to also remove usrs leaving the round