### PR TITLE
Removes eventkit from non-staff browser. fixing bug by doing so

### DIFF
--- a/code/modules/admin/admin_verb_lists_vr.dm
+++ b/code/modules/admin/admin_verb_lists_vr.dm
@@ -186,7 +186,8 @@ var/list/admin_verbs_spawn = list(
 	/client/proc/spawn_chemdisp_cartridge,
 	/client/proc/map_template_load,
 	/client/proc/map_template_upload,
-	/client/proc/map_template_load_on_new_z
+	/client/proc/map_template_load_on_new_z,
+	/client/proc/eventkit_open_mob_spawner //VOREStation Add
 	)
 
 var/list/admin_verbs_server = list(

--- a/code/modules/eventkit/gm_interfaces/mob_spawner.dm
+++ b/code/modules/eventkit/gm_interfaces/mob_spawner.dm
@@ -120,7 +120,7 @@
 	. = ..()
 	qdel(src)
 
-/client/verb/eventkit_open_mob_spawner()
+/client/proc/eventkit_open_mob_spawner()
 	set category = "EventKit"
 	set name = "Open Mob Spawner"
 	set desc = "Opens an advanced version of the mob spawner."


### PR DESCRIPTION
* Changes Open Mob Spawner to be a proc
* Adds Open Mob Spawner to admin_verbs_spawn


Fixes https://github.com/VOREStation/VOREStation/issues/14958