### PR TITLE
Removes Extra Exploration Seating Area

### DIFF
--- a/maps/stellar_delight/stellar_delight1.dmm
+++ b/maps/stellar_delight/stellar_delight1.dmm
@@ -296,10 +296,10 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/milspec,
@@ -2461,13 +2461,6 @@
 	},
 /turf/simulated/floor,
 /area/maintenance/stellardelight/substation/exploration)
-"ey" = (
-/obj/structure/cable/green{
-	color = "#42038a";
-	icon_state = "1-2"
-	},
-/turf/simulated/wall/bay/purple,
-/area/stellardelight/deck1/exploration)
 "ez" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/gloves/sterile/latex,
@@ -3526,30 +3519,6 @@
 "gQ" = (
 /turf/simulated/wall/bay/brown,
 /area/stellardelight/deck1/oreprocessing)
-"gS" = (
-/obj/structure/cable/green{
-	color = "#42038a";
-	icon_state = "1-8"
-	},
-/obj/structure/cable/green{
-	color = "#42038a";
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 6
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/milspec,
-/area/stellardelight/deck1/explobriefing)
 "gT" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -5139,19 +5108,21 @@
 "jZ" = (
 /obj/structure/cable/green{
 	color = "#42038a";
-	icon_state = "4-8"
+	icon_state = "2-4"
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 8
+	dir = 4;
+	icon_state = "pipe-c"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+	dir = 6
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals6,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
 	},
 /turf/simulated/floor/tiled/milspec,
-/area/stellardelight/deck1/exploration)
+/area/stellardelight/deck1/explobriefing)
 "ka" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /obj/effect/floor_decal/industrial/warning{
@@ -6080,15 +6051,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/janitor)
-"md" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/bed/chair/backed_red{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/milspec,
-/area/stellardelight/deck1/exploration)
 "me" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -6403,18 +6365,6 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/stellardelight/deck1/shuttlebay)
-"mH" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/structure/bed/chair/backed_red{
-	dir = 4
-	},
-/obj/machinery/firealarm/angled{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/milspec,
-/area/stellardelight/deck1/exploration)
 "mI" = (
 /obj/machinery/door/firedoor/glass/hidden/steel{
 	dir = 1
@@ -6468,12 +6418,11 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/stellardelight/deck1/fore)
 "mP" = (
-/obj/machinery/computer/ship/navigation/telescreen{
-	pixel_x = -32
+/obj/machinery/light/small{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/milspec,
-/area/stellardelight/deck1/explobriefing)
+/turf/simulated/floor,
+/area/maintenance/stellardelight/deck1/exploration)
 "mQ" = (
 /obj/machinery/door/firedoor/glass/hidden/steel{
 	dir = 8
@@ -7161,20 +7110,12 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
 "oq" = (
-/obj/structure/cable/green{
-	color = "#42038a";
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/computer/ship/navigation/telescreen{
+	pixel_x = -32
 	},
-/obj/structure/cable/green{
-	color = "#42038a";
-	icon_state = "1-8"
-	},
-/obj/structure/cable/green{
-	color = "#42038a";
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/airless,
-/area/stellardelight/deck1/exterior)
+/turf/simulated/floor/tiled/milspec,
+/area/stellardelight/deck1/explobriefing)
 "or" = (
 /obj/structure/window/reinforced/full,
 /obj/structure/window/reinforced{
@@ -7516,11 +7457,14 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/armoury)
 "pd" = (
-/obj/machinery/computer/ship/navigation/telescreen{
-	pixel_x = -64
-	},
-/turf/simulated/floor/tiled/milspec,
-/area/stellardelight/deck1/exploration)
+/obj/structure/closet,
+/obj/random/maintenance,
+/obj/random/maintenance,
+/obj/random/maintenance,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/clean,
+/turf/simulated/floor,
+/area/maintenance/stellardelight/deck1/exploration)
 "pe" = (
 /turf/simulated/floor/tiled/eris/steel/brown_platform,
 /area/stellardelight/deck1/miningshuttle)
@@ -8074,10 +8018,9 @@
 /area/stellardelight/deck1/explobriefing)
 "ql" = (
 /obj/structure/table/woodentable,
-/obj/machinery/light{
-	dir = 1
+/obj/machinery/microwave{
+	pixel_y = 7
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/milspec,
 /area/stellardelight/deck1/explobriefing)
 "qm" = (
@@ -8646,14 +8589,24 @@
 "rB" = (
 /obj/structure/cable/green{
 	color = "#42038a";
-	icon_state = "1-2"
+	icon_state = "4-8"
 	},
-/obj/machinery/light/small{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/door/airlock/angled_bay/hatch{
+	dir = 4;
+	door_color = "#ffffff";
+	name = "maintenance access";
+	req_one_access = null;
+	stripe_color = "#5a19a8"
+	},
 /turf/simulated/floor,
 /area/maintenance/stellardelight/deck1/exploration)
 "rC" = (
@@ -8745,12 +8698,20 @@
 /turf/simulated/floor/tiled/steel_ridged,
 /area/medical/morgue)
 "rM" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
+/obj/structure/cable/green{
+	color = "#42038a";
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/milspec,
-/area/stellardelight/deck1/exploration)
+/obj/structure/cable/green{
+	color = "#42038a";
+	icon_state = "1-4"
+	},
+/obj/structure/cable/green{
+	color = "#42038a";
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/airless,
+/area/stellardelight/deck1/exterior)
 "rN" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -9458,10 +9419,8 @@
 /turf/simulated/floor/airless,
 /area/stellardelight/deck1/exterior)
 "tm" = (
-/obj/structure/dogbed,
-/mob/living/simple_mob/animal/passive/tindalos/twigs,
-/turf/simulated/floor/tiled/milspec,
-/area/stellardelight/deck1/exploration)
+/turf/simulated/wall/bay/r_wall/purple,
+/area/maintenance/stellardelight/deck1/exploration)
 "tn" = (
 /obj/machinery/light{
 	dir = 4
@@ -9838,12 +9797,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/stellardelight/deck1/port)
-"uf" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/milspec,
-/area/stellardelight/deck1/exploration)
 "ug" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -9970,11 +9923,6 @@
 "uw" = (
 /turf/space/internal_edge/left,
 /area/stellardelight/deck1/starboard)
-"ux" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/milspec,
-/area/stellardelight/deck1/exploration)
 "uy" = (
 /obj/structure/table/rack/shelf/steel,
 /obj/item/weapon/gun/energy/ionrifle/pistol,
@@ -10289,11 +10237,9 @@
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/toilet)
 "ve" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/milspec,
-/area/stellardelight/deck1/exploration)
+/obj/structure/closet/emcloset,
+/turf/simulated/floor,
+/area/maintenance/stellardelight/deck1/exploration)
 "vf" = (
 /obj/machinery/door/firedoor/glass,
 /obj/structure/cable/yellow{
@@ -10777,9 +10723,12 @@
 "wk" = (
 /obj/structure/cable/green{
 	color = "#42038a";
-	icon_state = "1-2"
+	icon_state = "0-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/power/apc/angled{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/milspec,
 /area/stellardelight/deck1/explobriefing)
 "wm" = (
@@ -10813,12 +10762,13 @@
 /turf/simulated/floor/tiled/eris/steel/cargo,
 /area/stellardelight/deck1/mining)
 "wq" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/alarm/angled{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/milspec,
-/area/stellardelight/deck1/explobriefing)
+/obj/structure/table/rack,
+/obj/random/maintenance/cargo,
+/obj/random/maintenance/cargo,
+/obj/random/maintenance/cargo,
+/obj/random/maintenance/clean,
+/turf/simulated/floor,
+/area/maintenance/stellardelight/deck1/exploration)
 "ws" = (
 /obj/structure/cable/pink{
 	icon_state = "4-8"
@@ -13197,12 +13147,6 @@
 /obj/effect/landmark/start/visitor,
 /turf/simulated/floor/wood,
 /area/library)
-"By" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/milspec,
-/area/stellardelight/deck1/exploration)
 "Bz" = (
 /obj/structure/cable/green{
 	icon_state = "1-4"
@@ -13570,15 +13514,13 @@
 /turf/simulated/floor/wood,
 /area/library)
 "Cl" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/machinery/camera/network/command{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/milspec,
-/area/stellardelight/deck1/explobriefing)
+/obj/structure/table/rack/shelf,
+/obj/random/contraband,
+/obj/random/maintenance/research,
+/obj/random/maintenance,
+/obj/random/maintenance,
+/turf/simulated/floor,
+/area/maintenance/stellardelight/deck1/exploration)
 "Cm" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/disposalpipe/up{
@@ -13782,13 +13724,12 @@
 /turf/simulated/floor/tiled/eris/white/bluecorner,
 /area/medical/virology)
 "CK" = (
-/obj/machinery/button/remote/blast_door{
-	id = "explowindowlockdown";
-	name = "Window Lockdown";
-	pixel_y = 25
+/obj/item/device/radio/intercom{
+	dir = 1;
+	pixel_y = 24
 	},
 /turf/simulated/floor/tiled/milspec,
-/area/stellardelight/deck1/exploration)
+/area/stellardelight/deck1/explobriefing)
 "CL" = (
 /obj/structure/stairs/spawner/north,
 /obj/structure/window/reinforced{
@@ -13869,24 +13810,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/stellardelight/deck1/aft)
-"CW" = (
-/obj/structure/cable/green{
-	color = "#42038a";
-	icon_state = "2-4"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals6,
-/turf/simulated/floor/tiled/milspec,
-/area/stellardelight/deck1/explobriefing)
 "CX" = (
 /obj/effect/floor_decal/chapel{
 	dir = 1
@@ -14314,6 +14237,14 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/rnd/workshop)
+"DX" = (
+/obj/structure/closet/crate,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/cargo,
+/obj/random/maintenance/cargo,
+/obj/random/maintenance,
+/turf/simulated/floor,
+/area/maintenance/stellardelight/deck1/exploration)
 "DY" = (
 /obj/structure/railing/grey{
 	dir = 4
@@ -14974,11 +14905,11 @@
 "Fy" = (
 /obj/structure/flora/pottedplant/orientaltree,
 /obj/machinery/light,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
 /obj/machinery/camera/network/command{
 	dir = 9
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/milspec,
 /area/stellardelight/deck1/explobriefing)
@@ -15634,18 +15565,11 @@
 /turf/simulated/floor,
 /area/stellardelight/deck1/explobriefing)
 "Hf" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
-/obj/structure/bed/chair/backed_red{
-	dir = 4
-	},
-/obj/item/device/radio/intercom{
-	dir = 8;
-	pixel_x = -24
-	},
-/turf/simulated/floor/tiled/milspec,
-/area/stellardelight/deck1/exploration)
+/obj/structure/table/rack/shelf,
+/obj/random/maintenance/research,
+/obj/random/maintenance,
+/turf/simulated/floor,
+/area/maintenance/stellardelight/deck1/exploration)
 "Hg" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -15883,11 +15807,16 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/lobby)
 "HG" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+/obj/structure/table/woodentable,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/machinery/camera/network/command{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/milspec,
-/area/stellardelight/deck1/exploration)
+/area/stellardelight/deck1/explobriefing)
 "HH" = (
 /obj/machinery/door/firedoor/glass,
 /obj/structure/window/bay/reinforced,
@@ -15964,13 +15893,26 @@
 /turf/simulated/floor/tiled/eris/white/bluecorner,
 /area/medical/exam_room)
 "HS" = (
-/obj/structure/table/woodentable,
-/obj/machinery/microwave{
-	pixel_y = 7
+/obj/structure/cable/green{
+	color = "#42038a";
+	icon_state = "1-8"
 	},
-/obj/item/device/radio/intercom{
-	dir = 1;
-	pixel_y = 24
+/obj/structure/cable/green{
+	color = "#42038a";
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 6
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/milspec,
 /area/stellardelight/deck1/explobriefing)
@@ -16767,11 +16709,15 @@
 /turf/simulated/floor/tiled/eris/white/bluecorner,
 /area/stellardelight/deck1/lowermed)
 "Jz" = (
-/obj/machinery/newscaster{
-	pixel_y = 28
-	},
-/turf/simulated/floor/tiled/milspec,
-/area/stellardelight/deck1/exploration)
+/obj/structure/closet,
+/obj/random/contraband,
+/obj/random/maintenance,
+/obj/random/maintenance,
+/obj/random/maintenance,
+/obj/random/maintenance/cargo,
+/obj/random/maintenance/research,
+/turf/simulated/floor,
+/area/maintenance/stellardelight/deck1/exploration)
 "JA" = (
 /obj/structure/cable/white{
 	icon_state = "1-2"
@@ -17554,16 +17500,16 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/stellardelight/deck1/starboard)
 "Lp" = (
-/obj/machinery/power/apc/angled{
-	dir = 8
-	},
-/obj/structure/cable/green{
-	color = "#42038a";
-	icon_state = "0-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/milspec,
-/area/stellardelight/deck1/explobriefing)
+/obj/structure/closet,
+/obj/random/maintenance,
+/obj/random/maintenance,
+/obj/random/maintenance,
+/obj/random/maintenance,
+/obj/random/maintenance,
+/obj/random/maintenance/cargo,
+/obj/random/maintenance/research,
+/turf/simulated/floor,
+/area/maintenance/stellardelight/deck1/exploration)
 "Lq" = (
 /obj/structure/cable/green{
 	color = "#42038a";
@@ -17807,25 +17753,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/security_cell_hallway)
 "LO" = (
-/obj/structure/cable/green{
-	color = "#42038a";
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
+/obj/machinery/light/small{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	color = "#42038a";
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/tiled/milspec,
-/area/stellardelight/deck1/exploration)
+/turf/simulated/floor,
+/area/maintenance/stellardelight/deck1/exploration)
 "LP" = (
 /obj/structure/table/standard,
 /obj/machinery/cell_charger,
@@ -18832,12 +18764,15 @@
 /turf/simulated/floor/tiled/dark,
 /area/rnd/xenobiology)
 "NY" = (
-/obj/structure/cable/green{
-	color = "#42038a";
-	icon_state = "1-2"
+/obj/machinery/door/airlock/angled_bay/hatch{
+	dir = 4;
+	door_color = "#e6ab22";
+	name = "Exploration Substation";
+	req_one_access = list(10);
+	stripe_color = "#e6ab22"
 	},
-/turf/simulated/wall/bay/r_wall/steel,
-/area/stellardelight/deck1/exploration)
+/turf/simulated/floor,
+/area/maintenance/stellardelight/deck1/exploration)
 "NZ" = (
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 5
@@ -19499,9 +19434,14 @@
 /turf/simulated/floor/tiled/milspec,
 /area/stellardelight/deck1/exploration)
 "PE" = (
-/obj/machinery/alarm/angled,
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/milspec,
-/area/stellardelight/deck1/exploration)
+/area/stellardelight/deck1/explobriefing)
 "PF" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -20604,8 +20544,8 @@
 /turf/simulated/floor/tiled/eris,
 /area/rnd/xenobiology/xenoflora)
 "RS" = (
-/turf/simulated/wall/bay/purple,
-/area/stellardelight/deck1/explobriefing)
+/turf/simulated/wall/bay/steel,
+/area/maintenance/stellardelight/deck1/exploration)
 "RT" = (
 /obj/machinery/door/firedoor/glass,
 /obj/structure/cable/white{
@@ -20833,11 +20773,13 @@
 /turf/simulated/floor,
 /area/maintenance/stellardelight/substation/security)
 "Sn" = (
-/obj/structure/flora/pottedplant/orientaltree,
-/obj/machinery/light,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
+/obj/structure/dogbed,
+/mob/living/simple_mob/animal/passive/tindalos/twigs,
+/obj/structure/cable/green{
+	color = "#42038a";
+	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/milspec,
 /area/stellardelight/deck1/explobriefing)
 "Sq" = (
@@ -21422,27 +21364,10 @@
 /turf/simulated/floor/tiled/milspec,
 /area/stellardelight/deck1/explobriefing)
 "TD" = (
-/obj/structure/cable/green{
-	color = "#42038a";
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 8
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 5
-	},
+/obj/structure/flora/pottedplant/orientaltree,
+/obj/machinery/light,
 /turf/simulated/floor/tiled/milspec,
-/area/stellardelight/deck1/exploration)
+/area/stellardelight/deck1/explobriefing)
 "TE" = (
 /obj/effect/floor_decal/milspec/color/orange/half,
 /turf/simulated/floor/tiled/dark,
@@ -21545,13 +21470,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/stellardelight/deck1/aft)
-"TP" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/floor_decal/steeldecal/steel_decals6{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/milspec,
-/area/stellardelight/deck1/explobriefing)
 "TQ" = (
 /obj/structure/cable/green{
 	icon_state = "1-8"
@@ -21568,24 +21486,13 @@
 /turf/simulated/floor,
 /area/maintenance/stellardelight/deck1/starboardcent)
 "TR" = (
-/obj/structure/cable/green{
-	color = "#42038a";
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals6{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/milspec,
-/area/stellardelight/deck1/exploration)
+/obj/structure/table/rack,
+/obj/random/maintenance/cargo,
+/obj/random/maintenance/cargo,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/clean,
+/turf/simulated/floor,
+/area/maintenance/stellardelight/deck1/exploration)
 "TS" = (
 /obj/random/maintenance/security,
 /obj/random/maintenance/security,
@@ -21834,11 +21741,12 @@
 /turf/simulated/floor/tiled/milspec,
 /area/stellardelight/deck1/explobriefing)
 "Up" = (
-/obj/machinery/status_display{
-	pixel_y = 32
-	},
-/turf/simulated/floor/tiled/milspec,
-/area/stellardelight/deck1/explobriefing)
+/obj/structure/table/rack/shelf,
+/obj/random/medical,
+/obj/random/medical,
+/obj/random/maintenance,
+/turf/simulated/floor,
+/area/maintenance/stellardelight/deck1/exploration)
 "Uq" = (
 /obj/structure/cable/pink{
 	icon_state = "1-2"
@@ -23491,14 +23399,9 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/stellardelight/deck1/researchserver)
 "XH" = (
-/obj/machinery/status_display{
-	pixel_y = 32
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals6{
-	dir = 1
-	},
+/obj/machinery/alarm/angled,
 /turf/simulated/floor/tiled/milspec,
-/area/stellardelight/deck1/exploration)
+/area/stellardelight/deck1/explobriefing)
 "XJ" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/milspec/color/emerald/half{
@@ -30669,7 +30572,7 @@ iU
 iU
 iU
 KZ
-vT
+mP
 tE
 Jo
 BP
@@ -30677,7 +30580,7 @@ Cc
 gw
 xw
 vT
-Gy
+DX
 ra
 bD
 vF
@@ -30813,13 +30716,13 @@ um
 In
 wm
 Ag
+wm
 Ly
 wm
 wm
-rB
 wm
 Np
-Oz
+vT
 ra
 RF
 vF
@@ -30953,16 +30856,16 @@ KD
 KP
 um
 if
-WM
-WM
-WM
-WM
-WM
-WM
-WM
-XD
-WM
-nk
+RS
+RS
+NY
+RS
+RS
+RS
+RS
+rB
+RS
+ra
 RF
 vF
 bD
@@ -31095,16 +30998,16 @@ ng
 cC
 um
 if
-WM
+RS
 Cl
-wq
+vT
 mP
 Lp
-wk
-sT
-gS
-Sn
-nk
+RS
+wq
+if
+Gy
+ra
 bD
 hE
 JE
@@ -31237,18 +31140,18 @@ um
 Jp
 um
 if
-WM
-Rz
-Rz
-Uo
-kg
-kg
-kg
-ji
-kO
-He
-JE
-en
+RS
+Hf
+vT
+vT
+Jz
+RS
+TR
+if
+ve
+ra
+RF
+vF
 uq
 RF
 vF
@@ -31379,16 +31282,16 @@ Mn
 PL
 DQ
 XM
-WM
+RS
 Up
-Rz
-TC
-zZ
-yP
-zZ
-OB
-Rz
-ny
+vT
+vT
+pd
+RS
+LO
+if
+pd
+ra
 bD
 vF
 uq
@@ -31521,16 +31424,16 @@ Ua
 Ua
 Ua
 Ec
+RS
+tm
 WM
-HS
-Rz
-TC
-oZ
-Zh
-rt
-OB
-Rz
-ny
+WM
+WM
+WM
+WM
+XD
+WM
+nk
 uq
 vF
 uq
@@ -31663,16 +31566,16 @@ ex
 Pu
 Ua
 Ec
-WM
-Rz
-Rz
-NA
-An
-An
-An
-sN
-Rz
-ny
+Jz
+tm
+HG
+oq
+wk
+Sn
+sT
+HS
+TD
+nk
 bD
 vF
 uq
@@ -31805,16 +31708,16 @@ fQ
 nl
 MV
 gt
-WM
+Oz
+tm
 ql
-TP
-CW
-Fx
-fe
-qk
-aC
-Fy
-nk
+Rz
+Rz
+Rz
+Rz
+sN
+Rz
+ny
 bD
 vF
 uq
@@ -31949,16 +31852,16 @@ pC
 pC
 pC
 pC
-vy
-mW
-RS
-RS
-RS
-RS
-RS
-nk
-RF
-vF
+Rz
+Uo
+kg
+kg
+kg
+ji
+kO
+He
+JE
+rM
 uq
 RF
 vF
@@ -32092,13 +31995,13 @@ nd
 Nx
 pC
 XH
-TR
-WH
-mH
-WH
-WH
-Hf
-LZ
+TC
+zZ
+yP
+zZ
+OB
+Rz
+nk
 bD
 hE
 JE
@@ -32234,13 +32137,13 @@ ZQ
 sO
 pC
 CK
-jZ
-DO
-uf
-DO
-pd
-ve
-uB
+TC
+oZ
+Zh
+rt
+OB
+Rz
+ny
 uq
 vF
 bD
@@ -32375,14 +32278,14 @@ tY
 tY
 zK
 pC
-By
-TD
-ux
-rM
-Qt
-Qt
-HG
-uB
+Rz
+NA
+An
+An
+An
+sN
+Rz
+ny
 uq
 vF
 uq
@@ -32519,12 +32422,12 @@ eJ
 pC
 PE
 jZ
-PC
-PC
-PC
-md
-tm
-LZ
+Fx
+fe
+qk
+aC
+Fy
+nk
 bD
 vF
 uq
@@ -32659,16 +32562,16 @@ AD
 UR
 xk
 pC
-Jz
-LO
-ey
-ey
-ey
-ey
-ey
-NY
-JE
-oq
+vy
+mW
+WM
+WM
+WM
+WM
+WM
+nk
+RF
+vF
 uq
 uq
 uq
@@ -32803,8 +32706,8 @@ tu
 pC
 zL
 SE
+Dt
 vz
-WH
 WH
 WH
 gh
@@ -33087,7 +32990,7 @@ Pw
 DO
 iQ
 KU
-PC
+DO
 PC
 lw
 PC


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Removes the extra seating area that use to be the Pathfinder's office. Bug pet was moved into the briefing room and the briefing room was moved to cover the space. Maints had some additions to fill the gap.

## How This Contributes To The VOREStation Roleplay Experience

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

No more weird double seating area in that section.

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
 
Map changes in SDMM
![Screenshot 2023-06-04 191325](https://github.com/VOREStation/VOREStation/assets/609886/ea351b60-dbe7-4832-ade6-36545f966eb5)

Map changes in a Test Session 1
![Screenshot 2023-06-04 194028](https://github.com/VOREStation/VOREStation/assets/609886/2ec518d9-da12-4992-bef6-bad94ce54a57)

Map changes in a Test Session 2
![Screenshot 2023-06-04 194058](https://github.com/VOREStation/VOREStation/assets/609886/524f8fa5-9ad8-4088-91e3-fb4c32850143)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
del: Removes the extra seating area that use to be the Pathfinder's office. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
