### PR TITLE
Lighting subsystem update

### DIFF
--- a/code/controllers/subsystems/lighting.dm
+++ b/code/controllers/subsystems/lighting.dm
@@ -30,60 +30,86 @@ SUBSYSTEM_DEF(lighting)
 	MC_SPLIT_TICK_INIT(3)
 	if(!init_tick_checks)
 		MC_SPLIT_TICK
+
 	var/list/queue = sources_queue
 	var/i = 0
-	for (i in 1 to length(queue))
-		var/datum/light_source/L = queue[i]
 
+	// UPDATE SOURCE QUEUE
+	queue = sources_queue
+	while(i < length(queue)) //we don't use for loop here because i cannot be changed during an iteration
+		i += 1
+
+		var/datum/light_source/L = queue[i]
 		L.update_corners()
 
-		L.needs_update = LIGHTING_NO_UPDATE
+		if(!QDELETED(L))
+			L.needs_update = LIGHTING_NO_UPDATE
+		else
+			i -= 1 // update_corners() has removed L from the list, move back so we don't overflow or skip the next element
 
+		// We unroll TICK_CHECK here so we can clear out the queue to ensure any removals/additions when sleeping don't fuck us
 		if(init_tick_checks)
-			CHECK_TICK
+			if(!TICK_CHECK)
+				continue
+			queue.Cut(1, i + 1)
+			i = 0
+			stoplag()
 		else if (MC_TICK_CHECK)
 			break
 	if (i)
-		queue.Cut(1, i+1)
+		queue.Cut(1, i + 1)
 		i = 0
 
 	if(!init_tick_checks)
 		MC_SPLIT_TICK
 
+	// UPDATE CORNERS QUEUE
 	queue = corners_queue
-	for (i in 1 to length(queue))
-		var/datum/lighting_corner/C = queue[i]
+	while(i < length(queue)) //we don't use for loop here because i cannot be changed during an iteration
+		i += 1
 
+		var/datum/lighting_corner/C = queue[i]
 		C.needs_update = FALSE //update_objects() can call qdel if the corner is storing no data
 		C.update_objects()
-		
+
+		// We unroll TICK_CHECK here so we can clear out the queue to ensure any removals/additions when sleeping don't fuck us
 		if(init_tick_checks)
-			CHECK_TICK
+			if(!TICK_CHECK)
+				continue
+			queue.Cut(1, i + 1)
+			i = 0
+			stoplag()
 		else if (MC_TICK_CHECK)
 			break
 	if (i)
-		queue.Cut(1, i+1)
+		queue.Cut(1, i + 1)
 		i = 0
-
 
 	if(!init_tick_checks)
 		MC_SPLIT_TICK
 
+	// UPDATE OBJECTS QUEUE
 	queue = objects_queue
-	for (i in 1 to length(queue))
-		var/datum/lighting_object/O = queue[i]
+	while(i < length(queue)) //we don't use for loop here because i cannot be changed during an iteration
+		i += 1
 
+		var/datum/lighting_object/O = queue[i]
 		if (QDELETED(O))
 			continue
-
 		O.update()
 		O.needs_update = FALSE
+
+		// We unroll TICK_CHECK here so we can clear out the queue to ensure any removals/additions when sleeping don't fuck us
 		if(init_tick_checks)
-			CHECK_TICK
+			if(!TICK_CHECK)
+				continue
+			queue.Cut(1, i + 1)
+			i = 0
+			stoplag()
 		else if (MC_TICK_CHECK)
 			break
 	if (i)
-		queue.Cut(1, i+1)
+		queue.Cut(1, i + 1)
 
 
 /datum/controller/subsystem/lighting/Recover()

--- a/code/modules/lighting/lighting_source.dm
+++ b/code/modules/lighting/lighting_source.dm
@@ -33,7 +33,6 @@
 
 	/// Whether we have applied our light yet or not.
 	var/applied = FALSE
-
 	/// whether we are to be added to SSlighting's sources_queue list for an update
 	var/needs_update = LIGHTING_NO_UPDATE
 


### PR DESCRIPTION
This just updates the ticking logic inside of the subsystem a little bit. It unfortunately (probably) does not solve turf lighting updating issues that sometimes happen.

I tested this and stuff was still nicely glowing fine. Turned lights on/off and used a fire alarm to see the changes.
No runtimes or errors either.

Hopefully this fixes a runtime that did occasionally appeared on downstream.