### PR TITLE
Alternate to https://github.com/VOREStation/VOREStation/pull/14959 New Admin verb: Report Player Status

### DIFF
--- a/code/modules/admin/admin_verb_lists_vr.dm
+++ b/code/modules/admin/admin_verb_lists_vr.dm
@@ -170,7 +170,9 @@ var/list/admin_verbs_fun = list(
 	/client/proc/add_mob_for_narration,	//VOREStation Add
 	/client/proc/remove_mob_for_narration,	//VOREStation Add
 	/client/proc/narrate_mob,	//VOREStation Add
-	/client/proc/narrate_mob_args //VOREStation Add
+	/client/proc/narrate_mob_args, //VOREStation Add
+	/client/proc/getPlayerStatus //VORESTation Add
+
 	)
 
 var/list/admin_verbs_spawn = list(

--- a/code/modules/admin/verbs/get_player_status.dm
+++ b/code/modules/admin/verbs/get_player_status.dm
@@ -1,0 +1,44 @@
+#define INACTIVITY_CAP 15 MINUTES //Creating a define for this for more straight forward finagling.
+
+
+//TGUI functionality planned for easier readability, so creating a new file for this
+//TGUI functionality will call a datum to handle things separately
+/client/proc/getPlayerStatus()
+	set name = "Report Player Status"
+	set desc = "Get information on all active players in-game."
+	set category = "EventKit"
+
+	if(!check_rights(R_FUN)) return
+
+	var/player_list_local = player_list //Copying player list so we don't touch a global var all the time
+	var/list/area_list = list() //An associative list, where key is area name, value is a list of mob references
+	var/inactives = 0
+	var/players = 0
+
+	//Initializing our working list
+	for(var/player in player_list_local)
+
+		if(!istype(player, /mob/living)) continue //We only care for living players
+		var/mob/living/L = player
+		players += 1
+		if(L.client.inactivity > INACTIVITY_CAP)
+			inactives += 1
+			continue //Anyone who hasn't done anything in 15 minutes is likely too busy
+		var/area_name = get_area_name(L)
+		if(area_name in area_list)
+			area_list[area_name] += L // area_name:list(A,B,C); we add L to (A,B,C)
+		else
+			area_list[area_name] = list(L)
+
+	var/message = "#### The Following Players Are Likely Available #### \n"
+	for(var/cur_area in area_list)
+		var/area_players = area_list[cur_area]
+		message += "**** There are currently [LAZYLEN(area_players)] in [cur_area] **** \n"
+
+
+		for(var/mob/living/L in area_players)
+			message += "[L.name] ([L.key]) at ([L.x];[L.y]) has been inactive for [round(L.client.inactivity / (60 SECONDS))] minutes. \n"
+
+
+	message += "#### Over all, there are [players] eligible players, of which [inactives] were hidden due to inactivity.  ####"
+	to_chat(usr, SPAN_NOTICE(message))

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -1755,6 +1755,7 @@
 #include "code\modules\admin\verbs\dice.dm"
 #include "code\modules\admin\verbs\entity_narrate.dm"
 #include "code\modules\admin\verbs\fps.dm"
+#include "code\modules\admin\verbs\get_player_status.dm"
 #include "code\modules\admin\verbs\getlogs.dm"
 #include "code\modules\admin\verbs\grief_fixers.dm"
 #include "code\modules\admin\verbs\lightning_strike.dm"


### PR DESCRIPTION
### What this is:
Based on feedback on https://github.com/VOREStation/VOREStation/pull/14959, 
I asked Tank for what could be salvaged, what would still be useful.

This is what we arrived at:

![image](https://github.com/VOREStation/VOREStation/assets/20523270/03673f08-c329-4779-aa54-7eda9106da1a)

A to_chat() proc that takes which areas players are in, sorts them by said areas and returns their coordinates, activity and name.


### Commit Details
https://github.com/VOREStation/VOREStation/commit/a9cbd8fa4fea0876f6cf56662f97c70a5780c423
* Adds a new verb in the "EventKit" tab
* New verb copies player_list and sorts it into an assoc list of area:(players)
* It then prints out each area's list of players, giving their (x,y) coordinates
* It also notifies of how long since their last action, rounded to nearest minute
* Players who took ABSOLUTELY NO ACTION for 15 minutes are pruned to reduce clutter
* Tracks pruned players, players who are actually in-game as mob/living
* Reports this as well.