### PR TITLE
Fixes oversight of picnic blankets NOT being anchored

### DIFF
--- a/code/game/objects/items/weapons/picnic_blankets.dm
+++ b/code/game/objects/items/weapons/picnic_blankets.dm
@@ -33,6 +33,7 @@
 	var/blanket_type = CENTER
 	layer = HIDING_LAYER - 0.01 //Stuff shouldn't be able to hide under the blanket on the ground
 	var/list/attached_blankets = list()
+	anchored = TRUE
 
 /obj/structure/picnic_blanket_deployed/verb/fold_up()
 	set name = "Fold up"


### PR DESCRIPTION
* I assumed all obj/structure start as anchored
* I assumed wrong.
* I need to stop assuming things
* Anyway, bugfix for informal bugreport "throwing items at blankets causes them to get dislodged weirdly."