### PR TITLE
Implements Climbing

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -112,6 +112,9 @@
 
 	var/protean_drop_whitelist = FALSE
 
+	var/rock_climbing = FALSE //If true, allows climbing cliffs using click drag for single Z, walls if multiZ
+	var/climbing_delay = 1 //If rock_climbing, lower better.
+
 /obj/item/New()
 	..()
 	if(embed_chance < 0)

--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -17,6 +17,7 @@
 	var/dirty_prob = 2	// Chance of being dirty roundstart
 	var/dirt = 0
 	var/special_temperature //Used for turf HE-Pipe interaction
+	var/climbable = FALSE //Adds proc to wall if set to TRUE on its initialization, defined here since not all walls are subtypes of wall
 
 	var/icon_edge = 'icons/turf/outdoors_edge.dmi'	//VOREStation Addition - Allows for alternative edge icon files
 
@@ -63,6 +64,14 @@
 	if(istype(loc, /area/chapel))
 		holy = 1
 	levelupdate()
+	if(climbable)
+		verbs += /turf/simulated/proc/climb_wall
+
+/turf/simulated/examine(mob/user)
+	. = ..()
+	if(climbable)
+		. += "This [src] looks climbable."
+
 
 /turf/simulated/proc/AddTracks(var/typepath,var/bloodDNA,var/comingdir,var/goingdir,var/bloodcolor="#A10808")
 	var/obj/effect/decal/cleanable/blood/tracks/tracks = locate(typepath) in src

--- a/code/game/turfs/simulated/outdoors/atmoscaves_vr.dm
+++ b/code/game/turfs/simulated/outdoors/atmoscaves_vr.dm
@@ -2,11 +2,13 @@
 	oxygen = MOLES_O2STANDARD
 	nitrogen = MOLES_N2STANDARD
 	temperature	= T20C
+	climbable = TRUE
 
 /turf/simulated/mineral/ignore_mapgen/cave
 	oxygen = MOLES_O2STANDARD
 	nitrogen = MOLES_N2STANDARD
 	temperature	= T20C
+	climbable = TRUE
 
 /turf/simulated/mineral/floor/cave
 	oxygen = MOLES_O2STANDARD

--- a/code/game/turfs/simulated/wall_types_vr.dm
+++ b/code/game/turfs/simulated/wall_types_vr.dm
@@ -206,6 +206,7 @@ var/list/flesh_overlay_cache = list()
 /turf/simulated/wall/solidrock
 	icon_state = "solidrock"
 	icon = 'icons/turf/wall_masks_vr.dmi'
+	climbable = TRUE
 
 /turf/simulated/wall/titanium
 	icon_state = "titanium"

--- a/code/game/turfs/simulated_vr.dm
+++ b/code/game/turfs/simulated_vr.dm
@@ -1,5 +1,15 @@
 /turf/simulated
 	can_start_dirty = FALSE	// We have enough premapped dirt where needed
 
+
+
 /turf/simulated/floor/plating
 	can_start_dirty = TRUE	// But let maints and decrepit areas have some randomness
+
+
+/turf/simulated/proc/toggle_climbability() //Again, b
+	if(climbable)
+		verbs -= /turf/simulated/proc/climb_wall
+	else
+		verbs += /turf/simulated/proc/climb_wall
+	climbable = !climbable

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -604,7 +604,6 @@
 
 	var/water_speed = 0		//Speed boost/decrease in water, lower/negative values mean more speed
 	var/snow_speed = 0		//Speed boost/decrease on snow, lower/negative values mean more speed
-	var/rock_climbing = FALSE // If true, allows climbing cliffs with clickdrag.
 
 	var/step_volume_mod = 1	//How quiet or loud footsteps in this shoe are
 

--- a/code/modules/clothing/shoes/boots.dm
+++ b/code/modules/clothing/shoes/boots.dm
@@ -190,6 +190,7 @@
 	desc = "A pair of winter boots, with metal bracing attached to assist in climbing rocky terrain."
 	icon_state = "climbing_boots"
 	rock_climbing = TRUE
+	//Climbing delay with boots is 1
 
 /obj/item/clothing/shoes/boots/tactical
 	name = "tactical boots"

--- a/code/modules/mob/living/carbon/human/species/species_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/species_vr.dm
@@ -38,6 +38,8 @@
 	var/micro_size_mod = 0		// How different is our size for interactions that involve us being small?
 	var/macro_size_mod = 0		// How different is our size for interactions that involve us being big?
 	var/digestion_nutrition_modifier = 1
+	var/can_climb = FALSE
+	var/climbing_delay = 1.5	// We climb with a quarter delay
 
 
 /datum/species/proc/give_numbing_bite() //Holy SHIT this is hacky, but it works. Updating a mob's attacks mid game is insane.

--- a/code/modules/mob/living/carbon/human/species/station/station_special_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_special_vr.dm
@@ -423,6 +423,8 @@
 	primitive_form = "Wolpin"
 	color_mult = 1
 	icon_height = 64
+	can_climb = TRUE
+	climbing_delay = 1
 
 	min_age = 18
 	max_age = 200
@@ -460,4 +462,3 @@
 		BP_L_FOOT = list("path" = /obj/item/organ/external/foot),
 		BP_R_FOOT = list("path" = /obj/item/organ/external/foot/right)
 		)
-

--- a/code/modules/mob/living/carbon/human/species/station/station_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_vr.dm
@@ -319,6 +319,8 @@
 	genders = list(MALE, FEMALE, PLURAL, NEUTER)
 	wikilink="https://wiki.vore-station.net/Tajaran"
 	agility = 90
+	can_climb = TRUE
+	climbing_delay = 1.25 //No vassilian, but faster than a human who learned to climb!
 
 /datum/species/skrell
 	spawn_flags = SPECIES_CAN_JOIN
@@ -387,7 +389,7 @@
 	tail_animation = 'icons/mob/species/vox/tail.dmi'
 	deform = 'icons/mob/human_races/r_def_vox_old.dmi'
 	color_mult = 1
-	
+
 	descriptors = list(
 		/datum/mob_descriptor/vox_markings = 0
 		)

--- a/code/modules/mob/living/carbon/human/species/station/station_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_vr.dm
@@ -320,7 +320,7 @@
 	wikilink="https://wiki.vore-station.net/Tajaran"
 	agility = 90
 	can_climb = TRUE
-	climbing_delay = 1.25 //No vassilian, but faster than a human who learned to climb!
+	climbing_delay = 1.00 //Cats are good climbers.
 
 /datum/species/skrell
 	spawn_flags = SPECIES_CAN_JOIN

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/positive.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/positive.dm
@@ -218,3 +218,35 @@
 	cost = 1
 	var_changes = list("throwforce_absorb_threshold" = 10)
 
+
+
+
+/datum/trait/positive/wall_climber
+	name = "Climber"
+	desc = "You can climb certain walls without tools!"
+	tutorial = "You must approach a wall and right click it and select the \
+	'climb wall' verb to climb it. You suffer from a movement delay of 1.5 with this trait.\n \
+	Your total climb time is expected to be 17.5 seconds. Tools may reduce this."
+	cost = 0
+	custom_only = FALSE
+	var_changes = list("can_climb" = TRUE)
+
+/datum/trait/positive/wall_climber_pro
+	name = "Climber, Master"
+	desc = "You can climb certain walls without tools! You are a professional rock climber at this, letting you climb as fast as a tajara!"
+	tutorial = "You must approach a wall and right click it and select the \
+	'climb wall' verb to climb it. Your movement delay is just 1.25 with this trait.\n \
+	Your climb time is expected to be 9 seconds. Tools may reduce this. "
+	cost = 1
+	custom_only = FALSE
+	var_changes = list("can_climb" = TRUE, "climbing_delay" = 1.25)
+
+/datum/trait/positive/wall_climber_master
+	name = "Climber, Master"
+	desc = "You can climb certain walls without tools! You are a true master at this, letting you climb as a vassilian!"
+	tutorial = "You must approach a wall and right click it and select the \
+	'climb wall' verb to climb it. Your movement delay is just 1.0 with this trait. \n \
+	Your climb time is expected to be 5 seconds."
+	cost = 2
+	custom_only = FALSE
+	var_changes = list("can_climb" = TRUE, "climbing_delay" = 1.0)

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/positive.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/positive.dm
@@ -226,27 +226,36 @@
 	desc = "You can climb certain walls without tools!"
 	tutorial = "You must approach a wall and right click it and select the \
 	'climb wall' verb to climb it. You suffer from a movement delay of 1.5 with this trait.\n \
-	Your total climb time is expected to be 17.5 seconds. Tools may reduce this."
+	Your total climb time is expected to be 17.5 seconds. Tools may reduce this. \n\n \
+	This likewise allows descending walls, provided you're facing an empty space and standing on \
+	a climbable wall. To climbe like so, use the verb 'Climb Down Wall' in IC tab!"
 	cost = 0
 	custom_only = FALSE
 	var_changes = list("can_climb" = TRUE)
+	excludes = list(/datum/trait/positive/wall_climber_pro,/datum/trait/positive/wall_climber_master)
 
 /datum/trait/positive/wall_climber_pro
 	name = "Climber, Master"
 	desc = "You can climb certain walls without tools! You are a professional rock climber at this, letting you climb as fast as a tajara!"
 	tutorial = "You must approach a wall and right click it and select the \
 	'climb wall' verb to climb it. Your movement delay is just 1.25 with this trait.\n \
-	Your climb time is expected to be 9 seconds. Tools may reduce this. "
+	Your climb time is expected to be 9 seconds. Tools may reduce this. \n\n \
+	This likewise allows descending walls, provided you're facing an empty space and standing on \
+	a climbable wall. To climbe like so, use the verb 'Climb Down Wall' in IC tab!"
 	cost = 1
 	custom_only = FALSE
 	var_changes = list("can_climb" = TRUE, "climbing_delay" = 1.25)
+	excludes = list(/datum/trait/positive/wall_climber,/datum/trait/positive/wall_climber_master)
 
 /datum/trait/positive/wall_climber_master
 	name = "Climber, Master"
 	desc = "You can climb certain walls without tools! You are a true master at this, letting you climb as a vassilian!"
 	tutorial = "You must approach a wall and right click it and select the \
 	'climb wall' verb to climb it. Your movement delay is just 1.0 with this trait. \n \
-	Your climb time is expected to be 5 seconds."
+	Your climb time is expected to be 5 seconds. \n\n \
+	This likewise allows descending walls, provided you're facing an empty space and standing on \
+	a climbable wall. To climbe like so, use the verb 'Climb Down Wall' in IC tab!"
 	cost = 2
 	custom_only = FALSE
 	var_changes = list("can_climb" = TRUE, "climbing_delay" = 1.0)
+	excludes = list(/datum/trait/positive/wall_climber_pro,/datum/trait/positive/wall_climber)

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/positive.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/positive.dm
@@ -222,8 +222,22 @@
 
 
 /datum/trait/positive/wall_climber
-	name = "Climber"
-	desc = "You can climb certain walls without tools!"
+	name = "Climber, Amateur"
+	desc = "You can climb certain walls without tools! This is likely a personal skill you developed."
+	tutorial = "You must approach a wall and right click it and select the \
+	'climb wall' verb to climb it. You suffer from a movement delay of 1.5 with this trait.\n \
+	Your total climb time is expected to be 17.5 seconds. Tools may reduce this. \n\n \
+	This likewise allows descending walls, provided you're facing an empty space and standing on \
+	a climbable wall. To climbe like so, use the verb 'Climb Down Wall' in IC tab!"
+	cost = 1
+	custom_only = FALSE
+	banned_species = list(SPECIES_TAJ, SPECIES_VASILISSAN)	// They got unique climbing delay.
+	var_changes = list("can_climb" = TRUE)
+	excludes = list(/datum/trait/positive/wall_climber_pro, /datum/trait/positive/wall_climber_natural)
+
+/datum/trait/positive/wall_climber_natural
+	name = "Climber, Natural"
+	desc = "You can climb certain walls without tools! This is likely due to the unique anatomy of your species. CUSTOM AND XENOCHIM ONLY"
 	tutorial = "You must approach a wall and right click it and select the \
 	'climb wall' verb to climb it. You suffer from a movement delay of 1.5 with this trait.\n \
 	Your total climb time is expected to be 17.5 seconds. Tools may reduce this. \n\n \
@@ -231,31 +245,26 @@
 	a climbable wall. To climbe like so, use the verb 'Climb Down Wall' in IC tab!"
 	cost = 0
 	custom_only = FALSE
-	var_changes = list("can_climb" = TRUE)
-	excludes = list(/datum/trait/positive/wall_climber_pro,/datum/trait/positive/wall_climber_master)
+	allowed_species = list(SPECIES_XENOCHIMERA, SPECIES_CUSTOM)	//So that we avoid needless bloat for xenochim
+	excludes = list(/datum/trait/positive/wall_climber_pro, /datum/trait/positive/wall_climber)
 
 /datum/trait/positive/wall_climber_pro
-	name = "Climber, Master"
-	desc = "You can climb certain walls without tools! You are a professional rock climber at this, letting you climb as fast as a tajara!"
+	name = "Climber, Professional"
+	desc = "You can climb certain walls without tools! You are a professional rock climber at this, letting you climb almost twice as fast!"
 	tutorial = "You must approach a wall and right click it and select the \
 	'climb wall' verb to climb it. Your movement delay is just 1.25 with this trait.\n \
 	Your climb time is expected to be 9 seconds. Tools may reduce this. \n\n \
 	This likewise allows descending walls, provided you're facing an empty space and standing on \
 	a climbable wall. To climbe like so, use the verb 'Climb Down Wall' in IC tab!"
-	cost = 1
-	custom_only = FALSE
-	var_changes = list("can_climb" = TRUE, "climbing_delay" = 1.25)
-	excludes = list(/datum/trait/positive/wall_climber,/datum/trait/positive/wall_climber_master)
-
-/datum/trait/positive/wall_climber_master
-	name = "Climber, Master"
-	desc = "You can climb certain walls without tools! You are a true master at this, letting you climb as a vassilian!"
-	tutorial = "You must approach a wall and right click it and select the \
-	'climb wall' verb to climb it. Your movement delay is just 1.0 with this trait. \n \
-	Your climb time is expected to be 5 seconds. \n\n \
-	This likewise allows descending walls, provided you're facing an empty space and standing on \
-	a climbable wall. To climbe like so, use the verb 'Climb Down Wall' in IC tab!"
 	cost = 2
 	custom_only = FALSE
-	var_changes = list("can_climb" = TRUE, "climbing_delay" = 1.0)
-	excludes = list(/datum/trait/positive/wall_climber_pro,/datum/trait/positive/wall_climber)
+	var_changes = list("climbing_delay" = 1.25)
+	varchange_type = TRAIT_VARCHANGE_LESS_BETTER
+	excludes = list(/datum/trait/positive/wall_climber,/datum/trait/positive/wall_climber_natural)
+
+// This feels jank, but it's the cleanest way I could do TRAIT_VARCHANGE_LESS_BETTER while having a boolean var change
+// Alternate would've been banned_species = list(SPECIES_TAJ, SPECIES_VASSILISIAN)
+// Opted for this as it's "future proof"
+/datum/trait/positive/wall_climber_pro/apply(var/datum/species/S,var/mob/living/carbon/human/H)
+	..()
+	S.can_climb = TRUE

--- a/code/modules/mob/living/living_defines_vr.dm
+++ b/code/modules/mob/living/living_defines_vr.dm
@@ -14,3 +14,5 @@
 //custom temperature discomfort vars
 	var/list/custom_heat = list()
 	var/list/custom_cold = list()
+	var/can_climb = FALSE //Checked by turfs when using climb_wall(). Defined here for silicons and simple mobs
+	var/climbing_delay = 1.5 //By default, mobs climb at quarter speed. To be overriden by specific simple mobs or species speed

--- a/code/modules/mob/living/simple_mob/subtypes/animal/alien animals/catslug.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/alien animals/catslug.dm
@@ -43,6 +43,8 @@
 	mob_size = MOB_SMALL
 	friendly = list("hugs")
 	see_in_dark = 8
+	can_climb = TRUE
+	climbing_delay = 2.0
 
 	ID_provided = TRUE
 

--- a/code/modules/multiz/movement_vr.dm
+++ b/code/modules/multiz/movement_vr.dm
@@ -89,12 +89,34 @@
 	set category = "Object"
 	set src in oview(1)
 
-	if(!istype(usr, /mob/living)) return
+	if(!istype(usr, /mob/living)) return	//Why would ghosts want to climb?
 	var/mob/living/L = usr
 	var/climbing_delay_min = L.climbing_delay
 	var/fall_chance = 0
 	var/drop_our_held = FALSE
 
+	//Checking if there's any point trying to climb
+	var/turf/above_wall = GetAbove(src)
+	if(!above_wall) //No multiZ
+		to_chat(L, SPAN_NOTICE("There's nothing interesting over this cliff!"))
+		return
+	var/turf/above_mob = GetAbove(L)	//Making sure we got headroom
+	if(!above_mob.CanZPass(L, UP))
+		to_chat(L, SPAN_WARNING("\The [above_mob] blocks your way."))
+		return
+	if(above_wall.density) //We check density rather than type since some walls dont have a floor on top.
+		to_chat(L, SPAN_WARNING("\The [above_wall] blocks your way."))
+		return
+	if(LAZYLEN(above_wall.contents) > 30) //We avoid checking the contents if it's too cluttered to avoid issues
+		to_chat(L, SPAN_WARNING("\The [above_wall] is too cluttered to climb onto!"))
+		return
+	for(var/atom/A in above_wall.contents)
+		if(A.density)
+			to_chat(L, SPAN_WARNING("\The [A.name] blocks your way!"))
+			return
+
+	//human mobs got species and can wear special equipment
+	//We give them some snowflake treatment as a consequence
 	if(ishuman(L))
 		var/permit_human = FALSE
 		var/mob/living/carbon/human/H = L
@@ -114,6 +136,7 @@
 			you will fall and get hurt. More agile species might have better luck", "Second Thoughts", list("Bring it!", "Stay grounded"))
 			if(sure == "Stay grounded") return
 			fall_chance = clamp(100 - H.species.agility, 40, 90) //This should be 80 for most species. Traceur would reduce to 10%, so clamping higher
+	//If not a human mob, must be simple or silicon. They got a var stored on their mob we can check
 	else if(!L.can_climb)
 		var/sure = tgui_alert(L,"Are you sure you want to try without tools? It's VERY LIKELY \
 			you will fall and get hurt. More agile species might have better luck", "Second Thoughts", list("Bring it!", "Stay grounded"))
@@ -123,6 +146,7 @@
 		else
 			fall_chance = 55  //Simple mobs do.
 		climbing_delay_min = 2
+	//Catslugs are a snowflake case because of references.
 	if(istype(L, /mob/living/simple_mob/vore/alienanimals/catslug))
 		var/obj/O = L.get_active_hand()
 		if(istype(O, /obj/item/weapon/material/twohanded/spear))
@@ -131,28 +155,8 @@
 				drop_our_held = TRUE
 				climbing_delay_min = 0.75
 
-
-
-	var/turf/above_wall = GetAbove(src)
-	if(!above_wall) //Should we even bother?
-		to_chat(L, SPAN_NOTICE("There's nothing interesting over this cliff!"))
-		return
-	//Making sure we got headroom
-	var/turf/above_mob = GetAbove(L)
-	if(!above_mob.CanZPass(L, UP))
-		to_chat(L, SPAN_WARNING("\The [above_mob] blocks your way."))
-		return
-	if(above_wall.density) //We check density rather than type since some walls dont have a floor on top.
-		to_chat(L, SPAN_WARNING("\The [above_wall] blocks your way."))
-		return
-	if(LAZYLEN(above_wall.contents) > 30) //We avoid checking the contents if it's too cluttered to avoid issues
-		to_chat(L, SPAN_WARNING("\The [above_wall] is too cluttered to climb onto!"))
-		return
-	for(var/atom/A in above_wall.contents)
-		if(A.density)
-			to_chat(L, SPAN_WARNING("\The [A.name] blocks your way!"))
-			return
-
+	//We proceed with the actual climbing!
+	// ################### CLIMB TIME BELOW: #############################
 	// Climb time is 3.75 for scugs with spears (spear is dropped)
 	// Climb time is 5 for Master climbers, Vassilians, Well-geared humans
 	// Climb time is 9 for Tajara and Professional Climbers
@@ -171,14 +175,116 @@
 			climb_time += 2.5 SECONDS
 	L.custom_emote(VISIBLE_MESSAGE, "begins to climb up on \The [src]")
 	var/oops_time = world.time
-	to_chat(L, SPAN_WARNING("If you get interrupted after 4 seconds of climbing, you will fall and hurt yourself, beware!"))
+	var/grace_time = 4 SECONDS
+	to_chat(L, SPAN_WARNING("If you get interrupted after [grace_time] seconds of climbing, you will fall and hurt yourself, beware!"))
 	if(do_after(L,climb_time))
 		if(prob(fall_chance))
 			to_chat(L, SPAN_DANGER("You slipped and fell!"))
 			L.forceMove(above_mob)
-		if(drop_our_held)
-			L.drop_item(get_turf(L))
-		L.forceMove(above_wall)
+		else
+			if(drop_our_held)
+				L.drop_item(get_turf(L))
+			L.forceMove(above_wall)
+
 		to_chat(L, SPAN_NOTICE("You clambered up successfully!"))
-	else if(world.time > (oops_time + 4 SECONDS))
+	else if(world.time > (oops_time + grace_time))
 		L.forceMove(above_mob)
+
+/mob/living/verb/climb_down()
+	set name = "Climb down wall"
+	set desc = "attempt to climb down the wall you are standing on, in direction you're looking"
+	set category = "IC"
+
+	var/fall_chance = 0	//Increased if we can't actually climb
+	var/turf/our_turf = get_turf(src) //floor we're standing on
+	var/climbing_delay_min = src.climbing_delay //We take the lowest climbing delay between mob, species and gear.
+
+
+	//Check if we can even try to climb
+	var/turf/below_wall = GetBelow(our_turf)
+	if(!below_wall)	//No multiZ
+		to_chat(src, SPAN_NOTICE("There's nothing interesting below us!"))
+		return
+	if(!istype(below_wall,/turf/simulated)) //Our var is on simulated turfs, we must enforce this
+		to_chat(src, SPAN_NOTICE("There's nothing useful to grab onto!"))
+		return
+	var/turf/simulated/climbing_surface = below_wall
+	if(!climbing_surface.density) //passable turfs make no sense to climb
+		to_chat(src, SPAN_NOTICE("There's nothing climbable below us!"))
+		return
+	var/turf/front_of_us = get_step(src, dir) //We get the spot we are facing
+	if(!front_of_us.CanZPass(src, DOWN)) //Makes sure where we're climbing isnt blocked by a tile or there's a wall below it.
+		to_chat(src, SPAN_NOTICE("\The [front_of_us] blocks your way in this direction!"))
+		return
+	var/turf/destination = GetBelow(front_of_us)
+	if(isopenspace(destination)) //We don't allow descending more than 1 Z at a time
+		to_chat(src, SPAN_NOTICE("You're too high up to climb down from here! Find a more gentle descent!"))
+		return
+
+	//Determining whether we should be able to climb safely and how fast
+	if(ishuman(src))
+		var/permit_human = FALSE
+		var/mob/living/carbon/human/H = src
+		if(H.species.climbing_delay < H.climbing_delay)
+			climbing_delay_min = H.species.climbing_delay
+		var/list/gear = list(H.head, H.wear_mask, H.wear_suit, H.w_uniform,
+		H.gloves, H.shoes, H.belt, H.get_active_hand(), H.get_inactive_hand())
+		if(H.can_climb || H.species.can_climb)
+			permit_human = TRUE
+		for(var/obj/item/I in gear)
+			if(I.rock_climbing)
+				permit_human = TRUE
+				if(I.climbing_delay > climbing_delay_min)
+					climbing_delay_min = I.climbing_delay //We get the maximum possible speedup out of worn equipment
+		if(!permit_human)
+			var/sure = tgui_alert(H,"Are you sure you want to try without tools? It's VERY LIKELY \
+			you will fall and get hurt. More agile species might have better luck", "Second Thoughts", list("Bring it!", "Stay grounded"))
+			if(sure == "Stay grounded") return
+			fall_chance = clamp(100 - H.species.agility, 40, 90) //This should be 80 for most species. Traceur would reduce to 10%, so clamping higher
+	//If not a human mob, must be simple or silicon. They got a var stored on their mob we can check
+	else if(!src.can_climb)
+		var/sure = tgui_alert(src,"Are you sure you want to try without tools? It's VERY LIKELY \
+			you will fall and get hurt. More agile species might have better luck", "Second Thoughts", list("Bring it!", "Stay grounded"))
+		if(sure == "Stay grounded") return
+		if(isrobot(src))
+			fall_chance = 80 // Robots get no mercy
+		else
+			fall_chance = 55  //Simple mobs do.
+		climbing_delay_min = 2
+	//This time, scugs get no snowflake treatment. We're climbing DOWN, not up!
+
+	//We proceed with the actual climbing!
+	// ################### CLIMB TIME BELOW: #############################
+	// Climb time is 3.75 for scugs with spears (spear is dropped)
+	// Climb time is 5 for Master climbers, Vassilians, Well-geared humans
+	// Climb time is 9 for Tajara and Professional Climbers
+	// Climb time is 17.5 Seconds for amateur climbers
+	// Climb time is 20 seconds for scugs without a spear
+	// Climb time is 30 for gearless untrained people
+	var/climb_time = (5 * climbing_delay_min) SECONDS
+	if(fall_chance)
+		to_chat(src, SPAN_WARNING("You begin climbing down along \The [below_wall]. Getting a grip is exceedingly difficult..."))
+		climb_time += 20 SECONDS
+	else
+		to_chat(src, SPAN_NOTICE("You begin climbing down \The [below_wall]! "))
+		if(climbing_delay_min > 1.25)
+			climb_time += 10 SECONDS
+		if(climbing_delay_min > 1.0)
+			climb_time += 2.5 SECONDS
+	if(!climbing_surface.climbable)
+		to_chat(src, SPAN_DANGER("\The [climbing_surface] is not suitable for climbing! Even for a master climber, this is risky!"))
+		if(fall_chance < 75 )
+			fall_chance = 75
+	src.custom_emote(VISIBLE_MESSAGE, "begins to climb down along  \The [below_wall]")
+	var/oops_time = world.time
+	var/grace_time = 3 SECONDS
+	to_chat(src, SPAN_WARNING("If you get interrupted after [grace_time] seconds of climbing, you will fall and hurt yourself, beware!"))
+	if(do_after(src,climb_time))
+		if(prob(fall_chance))
+			to_chat(src, SPAN_DANGER("You slipped and fell!"))
+			src.forceMove(front_of_us)
+		else
+			src.forceMove(destination)
+		to_chat(src, SPAN_NOTICE("You descended successfully!"))
+	else if(world.time > (oops_time + grace_time))
+		src.forceMove(front_of_us)


### PR DESCRIPTION
### What this does
  Creates a brand new mechanic for traversal: Climbing!

  Climbing allows a mob/living to walk up to a special wall (marked by examine) and climb on top of it!
  However, not all can do so:
  Most will fail 80% of the time, unless they use specialized gear or are naturally inclined/trained for climbing.

  Agile people (traceur, tajara) have a lower chance to fall (altho tajara can climb by default and faster)

**As such, 3 new traits are added,**
  Climber, Amateur, costs 1 point for removing fall chance (all species can take)
  Climber, professional that climbs faster, costing 2 pts
  Climber, Natural for 0 points (xenochim and custom only)

  Simple mobs and silicons can try climbing as well. Silicons may later (another PR) receive a climbing module maybe to also let them climb.

  Simple mobs so far only extend to scugs who get a special mechanic! Scugs may reduce their slow climb to a lightning fast one if they drop the spear in their hand and leave it behind.

  Vassilians and Taj are master climbers

### You can climb down too now as of commit https://github.com/VOREStation/VOREStation/pull/14989/commits/11e325cd6f0143401125f0af3c8e9fae81500024

  Same logic as earlier, but we allow trying on unclimbable walls (since you could just walk off the edge anyway).
  In this case, if unclimbable we set a minimum 75% fall chance even if master climber
  You are also warned of trying to descend 2Z at once and prevented from doing so.

### Climbing accounts for nutrition as of https://github.com/VOREStation/VOREStation/pull/14989/commits/d1f8bdf8514d1db8e25ca2de80f73040dcf3fb94

        Climbing up costs 50, climbing down costs 25 nutrition
        You cannot climb if you got less than it'd cost
        Climbing with less than 100 nutrition introduces a minimum 30% fall chance
        Climbing with less than 200 nutrition introduces a 1 second delay.


### Climbing speeds
	 Climb time is 3.75 for scugs with spears (spear is dropped)
	 Climb time is 5 for Vassilians, Taj and best-gear
	 Climb time is 9 for Professional Climbers
	 Climb time is 17.5 Seconds for amateur climbers
	 Climb time is 20 seconds for scugs without a spear
	 Climb time is 30 for gearless untrained people
         Speed increased by 1 second if under 200 Nutrition for all

### Commit Details
https://github.com/VOREStation/VOREStation/pull/14989/commits/d1f8bdf8514d1db8e25ca2de80f73040dcf3fb94

- Traits reorganized
  - No more 0 pt trait for non-custom species, UNLESS: you are a xenochimera
  - Non-custom, non-xenochim must spend 1 point to be able to climb (climber, amateur) in vein of soft fall
  - Custom/Xenochim can take (climber, natural) for 0 pts in vein of winged flight
  - All species may take (climber, master) for 2 pts to halve their climbing speed
- Adjusted Tajara to be as fast as Vassilians to.
- Implemented Nutrition logic in inspiration of winged flight
  - Climbing up costs twice as much nutrition as climbing down (50 vs 25)
  - Climbing while hungry (less than 200 nutrition) introduces a delay of 1 second
  - Climbing while starving (less than 100 nutrition) introduces 30% fall chance (does not override if higher)
  - Cannot climb if nutrition is lower than 50 for up, 25 if down.

https://github.com/VOREStation/VOREStation/pull/14989/commits/11e325cd6f0143401125f0af3c8e9fae81500024
* Same logic as climbing up for fall chance
* Additional fall chance if trying to climb down a unclimbable wall: min 75%
* Works by checking the turf 1 step in front of the mob if empty,
and places them under that turf if it is possible
* Climbing times are same as climbing up
* Grace period somewhat shorter
* Also added tweaks to logic of climbing up to avoid pointless checks
* Also tweaked the traits (expanded tutorial for climbing down, proper trait exclusion)


https://github.com/VOREStation/VOREStation/pull/14989/commits/83f7e90b8e807c0e507a3b26b1c517afa67fa5a2
* Adds new turf/simulated proc: climb_wall
  * Anyone can attempt this by standing next to wall
  * Untrained have chance to fall
  * Trained dont fall unless interrupted
  * Speed varies wildly depending on gear & skills
    * Takes lowest climb_delay, multiplies 5 by it
    * Depending on tresholds, may add 10/5 seconds on top (>1.25, >1.0)
  * Gear can enable even rookies to climb. Simplemobs cant use gear
  * Except scugs. They can specifically use their spears to climb, leaving it behind
* Adds new turf/simulated var: climbable
  * solidrock, /mineral/cave have climbable set to true
* Adds new turf/simulated logic for init, examine() and a yet-unused proc
  * proc toggle_climbability allows turning walls climbable. Useful for GMs!
  * Could also later implement a tool to turn walls climbable when used using it.
* Adds new mob/living vars, can_climb and climbing_delay
  * These are for handling silicons and simple mobs
* Adds new species vars, can_climb and climbing_delay
  * These are for human mobs
* climbing_delay defaults to 1.5
  * Tajara have it at 1.25
  * Vassalian have it at 1
  * Scugs got it at 2.0, reduced to 0.75 when using spear
* New traits: climber; climber, professional; climber, master
  * Cost 0, 1, 2 pts as positive trait respectively
  * Enable safe climbing, reduce delay to 1.25, 1.0 respectively
* moves rock_climber from shoes to items define
* Adds new item var, climbing_delay set at 1