### PR TITLE
Tweaks Long Predatorial Reach (Persistence, trait panel)

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
@@ -139,8 +139,19 @@
 
 /datum/trait/neutral/long_vore
 	name = "Long Predatorial Reach"
-	desc = "Makes you able to use your tongue to grab creatures."
+	desc = "Makes you able to use an unspecified appendage to grab creatures."
+	tutorial = "This trait allows you to change its colour and functionality in-game as well as on the trait panel. <br> \
+	The trait panel persists between rounds, whereas the in-game modifications are temporary.<br><br> \
+	Two functionalities exist: Reach out with the appendage towards prey (default, 'Disabled' option on character setup \
+	for the 'Throw Yourself' entry), or fling yourself at the prey and devour them with a pounce! <br> \
+	Maximum range: 5 tiles<br>\
+	Governed by: Throw Vore preferences (both prey and pred must enable it!) <br> \
+	Governed by: Drop Vore (both prey and pred must enable it!) <br> \
+	Governed by: Spontaneous Pred/Prey (Both sides must have appropriate one enabled.) <br> \
+	If both sides have both pred/prey enabled, favours the character being thrown as prey."
 	cost = 0
+	has_preferences = list("appendage_color" = list(TRAIT_PREF_TYPE_COLOR, "Appendage Colour", TRAIT_VAREDIT_TARGET_MOB, "#e03997"),
+	"appendage_alt_setting" = list(TRAIT_PREF_TYPE_BOOLEAN, "Throw yourself?", TRAIT_VAREDIT_TARGET_MOB, FALSE),)
 	custom_only = FALSE
 
 /datum/trait/neutral/long_vore/apply(var/datum/species/S,var/mob/living/carbon/human/H)

--- a/code/modules/mob/living/simple_mob/subtypes/vore/vore.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/vore.dm
@@ -26,8 +26,6 @@
 	permit_healbelly = client.prefs_vr.permit_healbelly
 	noisy = client.prefs_vr.noisy
 	selective_preference = client.prefs_vr.selective_preference
-	appendage_color = client.prefs_vr.appendage_color
-	appendage_alt_setting = client.prefs_vr.appendage_alt_setting
 	eating_privacy_global = client.prefs_vr.eating_privacy_global
 
 	drop_vore = client.prefs_vr.drop_vore

--- a/code/modules/vore/eating/living_vr.dm
+++ b/code/modules/vore/eating/living_vr.dm
@@ -279,8 +279,6 @@
 	P.can_be_drop_pred = src.can_be_drop_pred
 	P.allow_inbelly_spawning = src.allow_inbelly_spawning
 	P.allow_spontaneous_tf = src.allow_spontaneous_tf
-	P.appendage_color = src.appendage_color
-	P.appendage_alt_setting = src.appendage_alt_setting
 	P.step_mechanics_pref = src.step_mechanics_pref
 	P.pickup_pref = src.pickup_pref
 	P.drop_vore = src.drop_vore
@@ -329,8 +327,6 @@
 	can_be_drop_pred = P.can_be_drop_pred
 	allow_inbelly_spawning = P.allow_inbelly_spawning
 	allow_spontaneous_tf = P.allow_spontaneous_tf
-	appendage_color = P.appendage_color
-	appendage_alt_setting = P.appendage_alt_setting
 	step_mechanics_pref = P.step_mechanics_pref
 	pickup_pref = P.pickup_pref
 	drop_vore = P.drop_vore

--- a/code/modules/vore/eating/vore_vr.dm
+++ b/code/modules/vore/eating/vore_vr.dm
@@ -71,8 +71,6 @@ V::::::V           V::::::VO:::::::OOO:::::::ORR:::::R     R:::::REE::::::EEEEEE
 	var/list/belly_prefs = list()
 	var/vore_taste = "nothing in particular"
 	var/vore_smell = "nothing in particular"
-	var/appendage_color = "#e03997" //Default pink. Used for the 'long_vore' trait.
-	var/appendage_alt_setting = 0	//Decides if appendage user is thrown at target or not.
 
 	var/selective_preference = DM_DEFAULT
 
@@ -174,8 +172,6 @@ V::::::V           V::::::VO:::::::OOO:::::::ORR:::::R     R:::::REE::::::EEEEEE
 	vore_smell = json_from_file["vore_smell"]
 	permit_healbelly = json_from_file["permit_healbelly"]
 	noisy = json_from_file["noisy"]
-	appendage_color = json_from_file["appendage_color"]
-	appendage_alt_setting = json_from_file["appendage_alt_setting"]
 	selective_preference = json_from_file["selective_preference"]
 	show_vore_fx = json_from_file["show_vore_fx"]
 	can_be_drop_prey = json_from_file["can_be_drop_prey"]
@@ -216,10 +212,6 @@ V::::::V           V::::::VO:::::::OOO:::::::ORR:::::R     R:::::REE::::::EEEEEE
 		selective_preference = DM_DEFAULT
 	if (isnull(noisy))
 		noisy = FALSE
-	if (isnull(appendage_color))
-		appendage_color = "#e03997"
-	if (isnull(appendage_alt_setting))
-		appendage_alt_setting = 0
 	if(isnull(show_vore_fx))
 		show_vore_fx = TRUE
 	if(isnull(can_be_drop_prey))
@@ -301,8 +293,6 @@ V::::::V           V::::::VO:::::::OOO:::::::ORR:::::R     R:::::REE::::::EEEEEE
 			"vore_smell"			= vore_smell,
 			"permit_healbelly"		= permit_healbelly,
 			"noisy" 				= noisy,
-			"appendage_color"		= appendage_color,
-			"appendage_alt_setting" = appendage_alt_setting,
 			"selective_preference"	= selective_preference,
 			"show_vore_fx"			= show_vore_fx,
 			"can_be_drop_prey"		= can_be_drop_prey,

--- a/code/modules/vore/eating/vorepanel_vr.dm
+++ b/code/modules/vore/eating/vorepanel_vr.dm
@@ -273,8 +273,6 @@
 		"can_be_drop_pred" = host.can_be_drop_pred,
 		"allow_inbelly_spawning" = host.allow_inbelly_spawning,
 		"allow_spontaneous_tf" = host.allow_spontaneous_tf,
-		"appendage_color" = host.appendage_color,
-		"appendage_alt_setting" = host.appendage_alt_setting,
 		"step_mechanics_active" = host.step_mechanics_pref,
 		"pickup_mechanics_active" = host.pickup_pref,
 		"noisy" = host.noisy,


### PR DESCRIPTION
### What this does:
Modifies the trait panel entry for long predatorial reach during character set-up to change mode (drag/yeet) and colour persistently.

Also adds a tutorial for how this trait works because that is surprisingly complicated.

Deletes previous unsuccessful attempt at persistence from the code.

### Why we need this
Requested by a player

### Note for downstream
The \<br> may prolly break your tests, I tried to use \n instead, but that didnt work with TGUI.
Other, code also use \<br> so... it should be fine (for instance: build mode to_chat hints)

### Commit details
https://github.com/VOREStation/VOREStation/commit/b12595273eec85e3b6dbe63b79a283022f013908
* Rips out all previous attempts at persistence that did not work
* Adds two new buttons to trait panel when selecting "Long Predatorial Reach"
* These set colour and mode across rounds
* In game choices still don't persist, only character setup/trait panel
* Furthermore, extends trait with a tutorial that explains how it actually works.