### PR TITLE
Fix inability to "Never this round" survivor pod prompt

### DIFF
--- a/code/datums/ghost_query.dm
+++ b/code/datums/ghost_query.dm
@@ -214,4 +214,5 @@
 	and they are attempting to open the cryopod.\n \
 	Would you like to play as the occupant? \n \
 	You MUST NOT use your station character!!!"
+	be_special_flag = BE_SURVIVOR
 	cutoff_number = 1


### PR DESCRIPTION

Bug:
This type of ghost-joinable role doesn't have a role type flag associated with it, so I can't prevent future requests, sorry. Bug a dev! 

Fixed by adding the flag to the datum.