### PR TITLE
Removes roundstart firework launchers

### DIFF
--- a/maps/groundbase/gb-z2.dmm
+++ b/maps/groundbase/gb-z2.dmm
@@ -210,7 +210,6 @@
 /turf/simulated/floor/tiled,
 /area/groundbase/science/robotics)
 "aw" = (
-/obj/machinery/firework_launcher,
 /turf/simulated/floor/tiled,
 /area/groundbase/science/hall)
 "ax" = (

--- a/maps/tether/tether-01-surface1.dmm
+++ b/maps/tether/tether-01-surface1.dmm
@@ -8980,7 +8980,6 @@
 /area/tether/surfacebase/surface_one_hall)
 "aoR" = (
 /obj/machinery/light/small,
-/obj/machinery/firework_launcher,
 /turf/simulated/floor/tiled,
 /area/rnd/hardstorage)
 "aoS" = (


### PR DESCRIPTION
Something to add a BIT more effort as an extra step in the firework process, requiring science to actually build their own first.