### PR TITLE
tweak (fluff): Removes KHI from character set-up options

### DIFF
--- a/code/modules/client/preferences_factions.dm
+++ b/code/modules/client/preferences_factions.dm
@@ -25,7 +25,6 @@ var/global/list/citizenship_choices = list(
 	"Third Ares Confederation",
 	"Teshari Expeditionary Fleet",
 	"Altevian Hegemony",
-	"Kitsuhana Heavy Industries",
 	"Kosaky Fleets"
 	)
 
@@ -39,7 +38,6 @@ var/global/list/home_system_choices = list(
 	"Titan, Sol",
 	"Toledo, New Ohio",
 	"The Pact, Myria",
-	"Kitsuhana Prime",
 	"Kishar, Alpha Centauri",
 	"Anshar, Alpha Centauri",
 	"Heaven Complex, Alpha Centauri",
@@ -92,7 +90,6 @@ var/global/list/faction_choices = list(
 	"Gilthari Exports",
 	"Coyote Salvage Corp.",
 	"Chimera Genetics Corp.",
-	"Kitsuhana Heavy Industries",
 	"Independent Pilots Association",
 	"Local System Defense Force",
 	"United Solar Defense Force",


### PR DESCRIPTION
Loremaster discussion concluded that the KHI faction is out-of-scope of our current intended theme and setting. While we do not remove them outright, encouraging new players and characters to originate from KHI homeworld or be part of their faction makes things needlessly complicated and troublesome.

Therefore, KHI remains as something for the ATC system to be referenced and as part of technologies, but player characters ideally do not hold personal relation to them at this time.