### PR TITLE
Fix(TGUI): fixes PDA atmos scanner from showing gibberish

### DIFF
--- a/code/modules/pda/core_apps.dm
+++ b/code/modules/pda/core_apps.dm
@@ -113,7 +113,7 @@
 			// Values were extracted from the template itself
 			results = list(
 						list("entry" = "Pressure", "units" = "kPa", "val" = "[round(pressure,0.1)]", "bad_high" = 120, "poor_high" = 110, "poor_low" = 95, "bad_low" = 80),
-						list("entry" = "Temperature", "units" = "&deg;C", "val" = "[round(environment.temperature-T0C,0.1)]", "bad_high" = 35, "poor_high" = 25, "poor_low" = 15, "bad_low" = 5),
+						list("entry" = "Temperature", "units" = "\u00B0C", "val" = "[round(environment.temperature-T0C,0.1)]", "bad_high" = 35, "poor_high" = 25, "poor_low" = 15, "bad_low" = 5),
 						list("entry" = "Oxygen", "units" = "kPa", "val" = "[round(o2_level*100,0.1)]", "bad_high" = 140, "poor_high" = 135, "poor_low" = 19, "bad_low" = 17),
 						list("entry" = "Nitrogen", "units" = "kPa", "val" = "[round(n2_level*100,0.1)]", "bad_high" = 105, "poor_high" = 85, "poor_low" = 50, "bad_low" = 40),
 						list("entry" = "Carbon Dioxide", "units" = "kPa", "val" = "[round(co2_level*100,0.1)]", "bad_high" = 10, "poor_high" = 5, "poor_low" = 0, "bad_low" = 0),


### PR DESCRIPTION
Makes it use unicode character call instead of whatever it was.
It seems the improved HTML encoding code hated that form of input and caused issues.

Bug was noticed while working on sth else so not reported.

### Bug:
![image](https://github.com/VOREStation/VOREStation/assets/20523270/17637352-5272-4f85-bbbc-8d5b1c696b20)
### Fix
![image](https://github.com/VOREStation/VOREStation/assets/20523270/847230cd-65ab-43cf-b310-3bef8e431178)
