### PR TITLE
feature: Adds admin logging to disposals incidents

### DIFF
--- a/code/game/objects/stumble_into_vr.dm
+++ b/code/game/objects/stumble_into_vr.dm
@@ -23,6 +23,7 @@
 /obj/machinery/disposal/stumble_into(mob/living/M)
 	playsound(src, 'sound/effects/clang.ogg', 25, 1, -1)
 	visible_message("<span class='warning'>[M] [pick("tripped", "stumbled")] into \the [src]!</span>")
+	log_and_message_admins("stumbled into \the [src]", M)
 	if(M.client)
 		M.client.perspective = EYE_PERSPECTIVE
 		M.client.eye = src

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -142,6 +142,8 @@
 
 	user.drop_item()
 	if(I)
+		if(istype(I, /obj/item/weapon/holder/micro))
+			log_and_message_admins("placed [I.name]  inside \the [src]", user)
 		I.forceMove(src)
 
 	to_chat(user, "You place \the [I] into the [src].")
@@ -181,6 +183,7 @@
 											// must be awake, not stunned or whatever
 		msg = "[user.name] climbs into the [src]."
 		to_chat(user, "You climb into the [src].")
+		log_and_message_admins("climbed into disposals!", user)
 	else if(target != user && !user.restrained() && !user.stat && !user.weakened && !user.stunned && !user.paralysis)
 		msg = "[user.name] stuffs [target.name] into the [src]!"
 		to_chat(user, "You stuff [target.name] into the [src]!")
@@ -527,6 +530,8 @@
 	. = ..()
 	if(istype(AM, /obj/item) && !istype(AM, /obj/item/projectile))
 		if(prob(75))
+			if(istype(AM, /obj/item/weapon/holder/micro))
+				log_and_message_admins("[AM] was thrown into \the [src]")
 			AM.forceMove(src)
 			visible_message("\The [AM] lands in \the [src].")
 		else
@@ -541,6 +546,8 @@
 			return
 		if(prob(75))
 			I.forceMove(src)
+			if(istype(I, /obj/item/weapon/holder/micro))
+				log_and_message_admins("[I.name] was thrown into \the [src]")
 			for(var/mob/M in viewers(src))
 				M.show_message("\The [I] lands in \the [src].", 3)
 		else


### PR DESCRIPTION
### What this does
Adds admin logging for uncovered cases of disposals entry (micro thrown, placed; stumbling, clickdragging self) with unique messages for better incident investigation.

### Why we need this
Satin asked me to add this.

### Commit details
https://github.com/VOREStation/VOREStation/commit/b3341a7451fd9480633cc21dc2d3a6d14a81e308
* Adds logging for placing a micro holder in hand into disposals
* Adds logging for throwing a micro holder into disposals
* Adds logging for click dragging self into disposals
* Adds logging for stumbling into disposals while drunk or otherwise able to stumble
* Each logic has special terms when logged for clarity to clear up intent/innocence.