### PR TITLE
Stopgap fix for cyborg surgegical saw missing icon

### DIFF
--- a/code/game/objects/items/weapons/surgery_tools.dm
+++ b/code/game/objects/items/weapons/surgery_tools.dm
@@ -244,7 +244,7 @@
 	toolspeed = 0.5
 
 /obj/item/weapon/surgical/circular_saw/cyborg
-	icon_state = "cyborg_saw"
+	//icon_state = "cyborg_saw"
 	toolspeed = 0.5
 
 /obj/item/weapon/surgical/bonegel/cyborg


### PR DESCRIPTION
Just a stopgap. Will keep it open until the next release, and close if proper icon is provided before then.