### PR TITLE
fix(accessory): Fixes IAA badge permissions

### DIFF
--- a/code/modules/clothing/under/accessories/badges.dm
+++ b/code/modules/clothing/under/accessories/badges.dm
@@ -80,6 +80,7 @@
 	desc = "This glowing blue badge marks the holder as THE LAW."
 	icon_state = "holobadge"
 	var/emagged //Emagging removes Sec check.
+	var/valid_access = list(access_security) //Default access is security, to be overriden or expanded as desired
 
 /obj/item/clothing/accessory/badge/holo/cord
 	icon_state = "holobadge-cord"
@@ -111,10 +112,14 @@
 			var/obj/item/device/pda/pda = O
 			id_card = pda.id
 
-		if(access_security in id_card.access || emagged)
-			to_chat(user, "You imprint your ID details onto the badge.")
-			set_name(user.real_name)
-		else
+		var/found = FALSE
+		for(var/access in valid_access)
+			if(access in id_card.access || emagged)
+				to_chat(user, "You imprint your ID details onto the badge.")
+				set_name(user.real_name)
+				found = TRUE
+				break
+		if(!found)
 			to_chat(user, "[src] rejects your insufficient access rights.")
 		return
 	..()
@@ -157,6 +162,7 @@
 	desc = "This badge marks the holder as an investigative agent."
 	icon_state = "invbadge"
 	badge_string = "Corporate Investigator"
+	valid_access = list(access_security, access_lawyer)	//Permitting both sec and IAA!
 	slot_flags = SLOT_TIE | SLOT_BELT
 
 /obj/item/clothing/accessory/badge/holo/sheriff


### PR DESCRIPTION
- Tweaks holobadge definition to have per-badge defined access rather than have it hardcoded into attackby
- Tweaks holobadge attackby logic to use the newly introduced var for checking access *Using these, fixes IAA "Investigator" badge from not being usable by IAA 
- Kept security access for them for now, as that was the initial implementation and I don't want to change that in a bugfix. However, I believe it may be worth updating the detective/investigator badges to instead check for access_forensics_equipment instead (thus limiting them to detectives and IAA)

Fixes https://github.com/VOREStation/VOREStation/issues/15052