### PR TITLE
fix(repath): Fixes ore satchels from picking up BS crystals

### DIFF
--- a/code/modules/research/teleport_vr.dm
+++ b/code/modules/research/teleport_vr.dm
@@ -19,5 +19,5 @@
 	id = "bluespace_crystal"
 	req_tech = list(TECH_BLUESPACE = 3, TECH_PHORON = 4)
 	materials = list(MAT_DIAMOND = 1500, MAT_PHORON = 1500)
-	build_path = /obj/item/weapon/ore/bluespace_crystal/artificial
+	build_path = /obj/item/weapon/bluespace_crystal/artificial
 	sort_string = "PAAAB"

--- a/code/modules/telesci/bscyrstal.dm
+++ b/code/modules/telesci/bscyrstal.dm
@@ -1,6 +1,6 @@
 // Bluespace crystals, used in telescience and when crushed it will blink you to a random turf.
 
-/obj/item/weapon/ore/bluespace_crystal
+/obj/item/weapon/bluespace_crystal
 	name = "bluespace crystal"
 	desc = "A glowing bluespace crystal, not much is known about how they work. It looks very delicate."
 	icon = 'icons/obj/telescience.dmi'
@@ -9,12 +9,12 @@
 	origin_tech = list(TECH_BLUESPACE = 6, TECH_MATERIAL = 3)
 	var/blink_range = 8 // The teleport range when crushed/thrown at someone.
 
-/obj/item/weapon/ore/bluespace_crystal/New()
+/obj/item/weapon/bluespace_crystal/New()
 	..()
 	pixel_x = rand(-5, 5)
 	pixel_y = rand(-5, 5)
 
-/obj/item/weapon/ore/bluespace_crystal/attack_self(mob/user)
+/obj/item/weapon/bluespace_crystal/attack_self(mob/user)
 	user.visible_message("<span class='warning'>[user] crushes [src]!</span>", "<span class='danger'>You crush [src]!</span>")
 	var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread()
 	s.set_up(5, 1, get_turf(src))
@@ -23,10 +23,10 @@
 	user.unEquip(src)
 	qdel(src)
 
-/obj/item/weapon/ore/bluespace_crystal/proc/blink_mob(mob/living/L)
+/obj/item/weapon/bluespace_crystal/proc/blink_mob(mob/living/L)
 	do_teleport(L, get_turf(L), blink_range, asoundin = 'sound/effects/phasein.ogg')
 
-/obj/item/weapon/ore/bluespace_crystal/throw_impact(atom/hit_atom)
+/obj/item/weapon/bluespace_crystal/throw_impact(atom/hit_atom)
 	if(!..()) // not caught in mid-air
 		visible_message("<span class='notice'>[src] fizzles and disappears upon impact!</span>")
 		var/turf/T = get_turf(hit_atom)
@@ -39,7 +39,7 @@
 
 // Artifical bluespace crystal, doesn't give you much research.
 
-/obj/item/weapon/ore/bluespace_crystal/artificial
+/obj/item/weapon/bluespace_crystal/artificial
 	name = "artificial bluespace crystal"
 	desc = "An artificially made bluespace crystal, it looks delicate."
 	origin_tech = list(TECH_BLUESPACE = 3, TECH_PHORON = 4)

--- a/code/modules/telesci/construction.dm
+++ b/code/modules/telesci/construction.dm
@@ -15,7 +15,7 @@
 	build_path = /obj/machinery/telepad
 	origin_tech = list(TECH_DATA = 4, TECH_ENGINEERING = 4, TECH_PHORON = 4, TECH_BLUESPACE = 5)
 	req_components = list(
-							/obj/item/weapon/ore/bluespace_crystal = 1,
+							/obj/item/weapon/bluespace_crystal = 1,
 							/obj/item/weapon/stock_parts/capacitor = 2,
 							/obj/item/stack/cable_coil = 5,
 							/obj/item/weapon/stock_parts/console_screen = 1)
@@ -27,7 +27,7 @@
 	build_path = /obj/machinery/power/quantumpad
 	origin_tech = list(TECH_ENGINEERING = 4, TECH_POWER = 4, TECH_BLUESPACE = 4)
 	req_components = list(
-		/obj/item/weapon/ore/bluespace_crystal = 1,
+		/obj/item/weapon/bluespace_crystal = 1,
 		/obj/item/weapon/stock_parts/capacitor = 1,
 		/obj/item/weapon/stock_parts/manipulator = 1,
 		/obj/item/stack/cable_coil = 5)

--- a/code/modules/telesci/telepad.dm
+++ b/code/modules/telesci/telepad.dm
@@ -14,7 +14,7 @@
 /obj/machinery/telepad/New()
 	..()
 	component_parts = list()
-	component_parts += new /obj/item/weapon/ore/bluespace_crystal(src)
+	component_parts += new /obj/item/weapon/bluespace_crystal(src)
 	component_parts += new /obj/item/weapon/stock_parts/capacitor(src)
 	component_parts += new /obj/item/weapon/stock_parts/capacitor(src)
 	component_parts += new /obj/item/weapon/stock_parts/console_screen(src)

--- a/code/modules/telesci/telesci_computer.dm
+++ b/code/modules/telesci/telesci_computer.dm
@@ -46,10 +46,10 @@
 	. = ..()
 	recalibrate()
 	for(var/i = 1; i <= starting_crystals; i++)
-		crystals += new /obj/item/weapon/ore/bluespace_crystal/artificial(src) // starting crystals
+		crystals += new /obj/item/weapon/bluespace_crystal/artificial(src) // starting crystals
 
 /obj/machinery/computer/telescience/attackby(obj/item/W, mob/user, params)
-	if(istype(W, /obj/item/weapon/ore/bluespace_crystal))
+	if(istype(W, /obj/item/weapon/bluespace_crystal))
 		if(crystals.len >= max_crystals)
 			to_chat(user, "<span class='warning'>There are not enough crystal slots.</span>")
 			return

--- a/maps/expedition_vr/aerostat/aerostat_science_outpost.dmm
+++ b/maps/expedition_vr/aerostat/aerostat_science_outpost.dmm
@@ -5308,7 +5308,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/table/standard,
-/obj/item/weapon/ore/bluespace_crystal,
+/obj/item/weapon/bluespace_crystal,
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/telesci)
 "sQ" = (

--- a/maps/offmap_vr/om_ships/aro3.dmm
+++ b/maps/offmap_vr/om_ships/aro3.dmm
@@ -1226,7 +1226,7 @@
 /obj/structure/closet/crate{
 	name = "qpad parts"
 	},
-/obj/item/weapon/ore/bluespace_crystal,
+/obj/item/weapon/bluespace_crystal,
 /obj/item/weapon/stock_parts/capacitor/hyper,
 /obj/item/weapon/stock_parts/manipulator/hyper,
 /obj/item/stack/cable_coil{

--- a/maps/submaps/surface_submaps/plains/leopardmanderden.dmm
+++ b/maps/submaps/surface_submaps/plains/leopardmanderden.dmm
@@ -20,7 +20,7 @@
 	},
 /area/submap/LeopardmanderDen)
 "bj" = (
-/obj/item/weapon/ore/bluespace_crystal,
+/obj/item/weapon/bluespace_crystal,
 /turf/simulated/floor/outdoors/grass/sif/virgo3b{
 	outdoors = 0
 	},

--- a/maps/submaps/surface_submaps/wilderness/leopardmanderden.dmm
+++ b/maps/submaps/surface_submaps/wilderness/leopardmanderden.dmm
@@ -20,7 +20,7 @@
 	},
 /area/submap/LeopardmanderDen)
 "bj" = (
-/obj/item/weapon/ore/bluespace_crystal,
+/obj/item/weapon/bluespace_crystal,
 /turf/simulated/floor/outdoors/grass/sif,
 /area/submap/LeopardmanderDen)
 "bO" = (

--- a/maps/tether/submaps/underdark_pois/goldhall.dmm
+++ b/maps/tether/submaps/underdark_pois/goldhall.dmm
@@ -23,7 +23,7 @@
 /area/mine/explored/underdark)
 "g" = (
 /obj/effect/decal/remains,
-/obj/item/weapon/ore/bluespace_crystal,
+/obj/item/weapon/bluespace_crystal,
 /turf/simulated/floor/tiled/kafel_full/yellow/virgo3b,
 /area/mine/explored/underdark)
 


### PR DESCRIPTION
- Repaths Bluespace crystals from obj/item/weapon/ore subtype to obj/item/weapon subtype.
- Adjusts all code references appropriately

I've looked as far as VScode can let me, and I could not find any actual implementation, reference of mechanic that looked like it was using the /ore/ subtype's special mechanics.

Furthermore, I looked in mine_turfs and mineral outcrops codes to see if bluespace crystals were ever treated as an ore/mineral. Once more, I found nothing there either.

Beyond this, I asked cody if they'd ever encountered BS crystals as part of the xenoarch procedure and they reported no

Therefore, I've come to the conclusion that there is absolutely no reason for bluespace crystals to be an ore subtype. Doing this does lose their ability to be sampled by a core sampler but... There was no turf that'd spawn BS crystals (and ore sampler requires it to have been made by a mineral turf).

As such! I repathed it and all references to it and its artificial subtype.



Testing shows that all techs involving BScrystals function as expected (telepad, telesci computer, quantum pad), with deconstruction and construction alike and their expected functionalities.


Fixes https://github.com/VOREStation/VOREStation/issues/15012