### PR TITLE
Tweak(mapping): Significantly reworks sci-aerostat solars airlocks

### DIFF
--- a/maps/expedition_vr/aerostat/aerostat_science_outpost.dmm
+++ b/maps/expedition_vr/aerostat/aerostat_science_outpost.dmm
@@ -11,12 +11,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/blue{
 	dir = 10
 	},
-/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	cycle_to_external_air = 1;
-	id_tag = "aerostat_northwest_airlock";
-	name = "Aerostat Airlock Controller";
-	pixel_y = 25
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 6
 	},
+/obj/machinery/airlock_sensor{
+	pixel_y = 27
+	},
+/obj/effect/map_helper/airlock/sensor/chamber_sensor,
 /turf/simulated/floor,
 /area/offmap/aerostat/inside/arm/nw)
 "ac" = (
@@ -392,6 +393,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 5
 	},
+/obj/machinery/airlock_sensor{
+	dir = 1;
+	pixel_y = -30
+	},
+/obj/effect/map_helper/airlock/sensor/chamber_sensor,
 /turf/simulated/floor,
 /area/offmap/aerostat/inside/arm/sw)
 "aX" = (
@@ -402,6 +408,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 9
 	},
+/obj/machinery/airlock_sensor{
+	dir = 1;
+	pixel_y = -30
+	},
+/obj/effect/map_helper/airlock/sensor/chamber_sensor,
 /turf/simulated/floor,
 /area/offmap/aerostat/inside/arm/se)
 "aY" = (
@@ -929,14 +940,10 @@
 /area/offmap/aerostat)
 "cw" = (
 /obj/effect/floor_decal/rust,
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/aux{
-	dir = 8
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
 	},
-/obj/effect/map_helper/airlock/atmos/chamber_pump,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor,
+/turf/simulated/shuttle/wall/voidcraft/green/virgo2,
 /area/offmap/aerostat/inside/arm/nw)
 "cx" = (
 /obj/effect/floor_decal/rust,
@@ -1033,21 +1040,12 @@
 /turf/simulated/floor/tiled/steel_ridged,
 /area/offmap/aerostat/inside/airlock/west)
 "cJ" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 8
-	},
-/obj/effect/map_helper/airlock/atmos/chamber_pump,
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
 /obj/effect/floor_decal/rust,
-/obj/machinery/power/apc{
-	dir = 4;
-	pixel_x = 28
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/aux{
+	dir = 8;
+	power_rating = 90000
 	},
+/obj/effect/map_helper/airlock/atmos/pump_out_internal,
 /turf/simulated/floor,
 /area/offmap/aerostat/inside/arm/sw)
 "cM" = (
@@ -1288,12 +1286,13 @@
 	icon_state = "2-4"
 	},
 /obj/effect/floor_decal/rust,
-/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	cycle_to_external_air = 1;
-	id_tag = "aerostat_northeast_airlock";
-	name = "Aerostat Airlock Controller";
-	pixel_y = 25
+/obj/machinery/atmospherics/pipe/simple/hidden/aux{
+	dir = 10
 	},
+/obj/machinery/airlock_sensor{
+	pixel_y = 27
+	},
+/obj/effect/map_helper/airlock/sensor/chamber_sensor,
 /turf/simulated/floor,
 /area/offmap/aerostat/inside/arm/ne)
 "ds" = (
@@ -1355,8 +1354,12 @@
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/rust,
-/obj/machinery/atmospherics/pipe/manifold/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/machinery/atmospherics/pipe/simple/hidden/aux,
+/obj/machinery/door/airlock/external,
+/obj/effect/map_helper/airlock/door/int_door,
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
 	},
 /turf/simulated/floor,
 /area/offmap/aerostat/inside/arm/ne)
@@ -1608,11 +1611,19 @@
 	},
 /obj/effect/floor_decal/rust,
 /obj/machinery/atmospherics/pipe/simple/hidden/blue,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/aux{
 	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
+	cycle_to_external_air = 1;
+	dir = 4;
+	id_tag = "aerostat_northwest_airlock";
+	name = "Aerostat Airlock Controller";
+	pixel_x = -22
 	},
 /turf/simulated/floor,
 /area/offmap/aerostat/inside/arm/nw)
@@ -1888,14 +1899,10 @@
 "fe" = (
 /obj/effect/decal/cleanable/cobweb2,
 /obj/effect/floor_decal/rust,
-/obj/machinery/power/solar_control,
-/obj/structure/cable/yellow{
-	icon_state = "0-2"
-	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 4;
+	dir = 8;
 	frequency = 1380;
-	id_tag = null
+	power_rating = 90000
 	},
 /obj/effect/map_helper/airlock/atmos/pump_out_internal,
 /turf/simulated/floor,
@@ -2097,11 +2104,16 @@
 /turf/simulated/floor/plating/virgo2,
 /area/offmap/aerostat/solars)
 "fM" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 8
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
 	},
-/obj/effect/map_helper/airlock/atmos/pump_out_external,
-/obj/effect/floor_decal/rust,
+/obj/structure/grille,
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
 /turf/simulated/floor/plating/virgo2,
 /area/offmap/aerostat/inside/arm/nw)
 "fP" = (
@@ -2563,12 +2575,10 @@
 	},
 /obj/effect/floor_decal/rust,
 /obj/machinery/atmospherics/pipe/simple/hidden/blue,
-/obj/machinery/airlock_sensor{
-	dir = 8;
-	pixel_x = 25
-	},
-/obj/effect/map_helper/airlock/sensor/int_sensor,
 /obj/machinery/atmospherics/pipe/simple/hidden/aux,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 5
+	},
 /turf/simulated/floor,
 /area/offmap/aerostat/inside/arm/nw)
 "hF" = (
@@ -2860,7 +2870,8 @@
 /area/offmap/aerostat/inside/genetics)
 "ja" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 4
+	dir = 4;
+	power_rating = 90000
 	},
 /obj/effect/map_helper/airlock/atmos/chamber_pump,
 /obj/effect/floor_decal/rust,
@@ -2939,6 +2950,15 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/westhall)
+"jr" = (
+/obj/effect/floor_decal/rust,
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/aux{
+	dir = 8;
+	power_rating = 90000
+	},
+/obj/effect/map_helper/airlock/atmos/pump_out_external,
+/turf/simulated/floor/plating/virgo2,
+/area/offmap/aerostat/inside/arm/sw)
 "ju" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/green{
 	dir = 4
@@ -3126,6 +3146,7 @@
 	},
 /obj/effect/floor_decal/rust,
 /obj/machinery/door/airlock/external,
+/obj/effect/map_helper/airlock/door/ext_door,
 /turf/simulated/floor/tiled/steel_ridged,
 /area/offmap/aerostat/inside/arm/se)
 "kc" = (
@@ -3211,15 +3232,11 @@
 /turf/simulated/floor/tiled,
 /area/offmap/aerostat/inside/xenobiolab)
 "ks" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 4
-	},
-/obj/effect/map_helper/airlock/atmos/chamber_pump,
-/obj/machinery/light/small{
-	dir = 8
-	},
 /obj/effect/floor_decal/rust,
-/turf/simulated/floor,
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/turf/simulated/shuttle/wall/voidcraft/green/virgo2,
 /area/offmap/aerostat/inside/arm/ne)
 "kt" = (
 /obj/machinery/atmospherics/portables_connector,
@@ -3307,16 +3324,16 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/airlock/south)
 "kJ" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/machinery/atmospherics/pipe/simple/hidden{
+/obj/machinery/atmospherics/pipe/simple/hidden/aux{
 	dir = 10
 	},
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/machinery/power/solar_control,
+/obj/effect/floor_decal/rust,
+/obj/effect/decal/cleanable/cobweb,
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
 	},
-/obj/machinery/door/firedoor/glass,
-/turf/simulated/floor/plating/virgo2,
+/turf/simulated/floor,
 /area/offmap/aerostat/inside/arm/se)
 "kN" = (
 /obj/machinery/door/firedoor/glass,
@@ -3458,10 +3475,16 @@
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/toxins)
 "ls" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 6
+/obj/machinery/power/apc{
+	dir = 4;
+	pixel_x = 28
 	},
-/turf/simulated/shuttle/wall/voidcraft/green/virgo2,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow,
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor,
 /area/offmap/aerostat/inside/arm/nw)
 "lt" = (
 /obj/structure/grille,
@@ -3893,11 +3916,15 @@
 /turf/unsimulated/floor/sky/virgo2_sky,
 /area/offmap/aerostat)
 "mT" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden{
-	dir = 8
+/obj/structure/cable/heavyduty{
+	icon_state = "1-2"
 	},
-/turf/simulated/shuttle/wall/voidcraft/green/virgo2,
-/area/offmap/aerostat/inside/arm/ne)
+/obj/effect/floor_decal/rust,
+/obj/machinery/atmospherics/pipe/simple/hidden/blue,
+/obj/machinery/atmospherics/pipe/simple/hidden/aux,
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/turf/simulated/floor,
+/area/offmap/aerostat/inside/arm/nw)
 "mU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -3986,17 +4013,31 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/atmos)
 "np" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 10
+/obj/structure/cable/heavyduty{
+	icon_state = "1-2"
 	},
-/turf/simulated/shuttle/wall/voidcraft/green/virgo2,
-/area/offmap/aerostat/inside/arm/nw)
+/obj/effect/floor_decal/rust,
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/machinery/atmospherics/pipe/simple/hidden/aux,
+/obj/machinery/airlock_sensor{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/effect/map_helper/airlock/sensor/int_sensor,
+/turf/simulated/floor,
+/area/offmap/aerostat/inside/arm/ne)
 "nr" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+/obj/effect/floor_decal/rust,
+/obj/machinery/atmospherics/pipe/simple/hidden/aux{
 	dir = 8
 	},
-/obj/effect/map_helper/airlock/atmos/pump_out_external,
-/obj/effect/floor_decal/rust,
+/obj/structure/grille,
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/plating/virgo2,
 /area/offmap/aerostat/inside/arm/sw)
 "ns" = (
@@ -4168,11 +4209,15 @@
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/toxins)
 "nW" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 6
+/obj/effect/map_helper/airlock/atmos/pump_out_external,
+/obj/effect/floor_decal/rust,
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 8;
+	frequency = 1380;
+	id_tag = null
 	},
-/turf/simulated/shuttle/wall/voidcraft/green/virgo2,
-/area/offmap/aerostat/inside/arm/ne)
+/turf/simulated/floor/plating/virgo2,
+/area/offmap/aerostat/inside/arm/nw)
 "nY" = (
 /obj/machinery/alarm{
 	dir = 4;
@@ -4212,13 +4257,21 @@
 /area/offmap/aerostat/inside/toxins)
 "oj" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 8
+	dir = 8;
+	power_rating = 90000
 	},
-/obj/effect/map_helper/airlock/atmos/chamber_pump,
 /obj/effect/floor_decal/rust,
 /obj/machinery/light/small{
 	dir = 4
 	},
+/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
+	cycle_to_external_air = 1;
+	dir = 1;
+	id_tag = "aerostat_southwest_airlock";
+	name = "Aerostat Airlock Controller";
+	pixel_y = -21
+	},
+/obj/effect/map_helper/airlock/atmos/chamber_pump,
 /turf/simulated/floor,
 /area/offmap/aerostat/inside/arm/sw)
 "ol" = (
@@ -4257,12 +4310,16 @@
 /area/offmap/aerostat/inside/xenoarch)
 "os" = (
 /obj/effect/floor_decal/rust,
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 4;
-	frequency = 1380;
-	id_tag = null
+/obj/machinery/airlock_sensor{
+	pixel_y = 26
 	},
-/obj/effect/map_helper/airlock/atmos/pump_out_internal,
+/obj/effect/map_helper/airlock/sensor/int_sensor,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor,
 /area/offmap/aerostat/inside/arm/nw)
 "ot" = (
@@ -4534,11 +4591,9 @@
 	},
 /obj/effect/floor_decal/rust,
 /obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/machinery/airlock_sensor{
-	dir = 4;
-	pixel_x = -25
+/obj/machinery/atmospherics/pipe/simple/hidden/aux{
+	dir = 10
 	},
-/obj/effect/map_helper/airlock/sensor/int_sensor,
 /turf/simulated/floor,
 /area/offmap/aerostat/inside/arm/se)
 "pA" = (
@@ -4612,15 +4667,11 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/westhall)
 "pT" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 8
-	},
-/obj/effect/map_helper/airlock/atmos/pump_out_internal,
 /obj/effect/floor_decal/rust,
-/turf/simulated/floor,
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/turf/simulated/shuttle/wall/voidcraft/green/virgo2,
 /area/offmap/aerostat/inside/arm/se)
 "pV" = (
 /obj/structure/cable/heavyduty{
@@ -4838,12 +4889,11 @@
 	},
 /obj/effect/floor_decal/rust,
 /obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	cycle_to_external_air = 1;
-	dir = 8;
-	id_tag = "aerostat_southeast_airlock";
-	name = "Aerostat Airlock Controller";
-	pixel_x = 25
+/obj/machinery/door/airlock/external,
+/obj/machinery/atmospherics/pipe/simple/hidden/aux,
+/obj/effect/map_helper/airlock/door/int_door,
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
 	},
 /turf/simulated/floor,
 /area/offmap/aerostat/inside/arm/se)
@@ -5179,8 +5229,10 @@
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/xenoarch)
 "sn" = (
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/turf/simulated/shuttle/wall/voidcraft/green/virgo2,
+/turf/simulated/shuttle/wall/voidcraft/hard_corner{
+	color = "#eacd7c";
+	stripe_color = "#00FF00"
+	},
 /area/offmap/aerostat/inside/arm/nw)
 "so" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/red,
@@ -5200,9 +5252,6 @@
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/rust,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 10
 	},
@@ -5210,7 +5259,17 @@
 	dir = 8;
 	pixel_x = 30
 	},
-/obj/effect/map_helper/airlock/sensor/chamber_sensor,
+/obj/machinery/atmospherics/pipe/simple/hidden/aux,
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
+	cycle_to_external_air = 1;
+	dir = 8;
+	id_tag = "aerostat_northeast_airlock";
+	name = "Aerostat Airlock Controller";
+	pixel_x = 29
+	},
 /turf/simulated/floor,
 /area/offmap/aerostat/inside/arm/ne)
 "sw" = (
@@ -5353,8 +5412,10 @@
 /turf/simulated/floor,
 /area/offmap/aerostat/inside/airlock/south)
 "sZ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/turf/simulated/shuttle/wall/voidcraft/green/virgo2,
+/turf/simulated/shuttle/wall/voidcraft/hard_corner{
+	color = "#eacd7c";
+	stripe_color = "#00FF00"
+	},
 /area/offmap/aerostat/inside/arm/ne)
 "tf" = (
 /obj/structure/closet/crate/bin{
@@ -5489,21 +5550,12 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/southchamb)
 "tF" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 4
-	},
-/obj/effect/map_helper/airlock/atmos/chamber_pump,
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
 /obj/effect/floor_decal/rust,
-/obj/machinery/power/apc{
-	dir = 8;
-	pixel_x = -22
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/aux{
+	dir = 4;
+	power_rating = 90000
 	},
+/obj/effect/map_helper/airlock/atmos/pump_out_internal,
 /turf/simulated/floor,
 /area/offmap/aerostat/inside/arm/se)
 "tH" = (
@@ -6099,9 +6151,10 @@
 /obj/structure/cable/heavyduty{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/external,
 /obj/machinery/atmospherics/pipe/simple/hidden,
-/turf/simulated/floor/tiled/steel_ridged,
+/obj/machinery/atmospherics/pipe/simple/hidden/aux,
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor,
 /area/offmap/aerostat/inside/arm/se)
 "wl" = (
 /obj/machinery/hologram/holopad,
@@ -6209,14 +6262,15 @@
 	},
 /obj/effect/floor_decal/rust,
 /obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	cycle_to_external_air = 1;
-	dir = 4;
-	id_tag = "aerostat_southwest_airlock";
-	name = "Aerostat Airlock Controller";
-	pixel_x = -25
+/obj/machinery/atmospherics/pipe/simple/hidden/aux{
+	dir = 6
 	},
-/turf/simulated/floor,
+/obj/machinery/door/airlock/external,
+/obj/effect/map_helper/airlock/door/int_door,
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled/steel_ridged,
 /area/offmap/aerostat/inside/arm/sw)
 "wJ" = (
 /obj/structure/reagent_dispensers/watertank,
@@ -6401,11 +6455,17 @@
 /turf/simulated/floor/plating/virgo2,
 /area/offmap/aerostat/inside/arm/sw)
 "xx" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/aux{
+	dir = 8
 	},
-/obj/effect/map_helper/airlock/atmos/pump_out_external,
-/obj/effect/floor_decal/rust,
+/obj/structure/grille,
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced{
+	dir = 8;
+	pixel_x = -4
+	},
+/obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/plating/virgo2,
 /area/offmap/aerostat/inside/arm/ne)
 "xy" = (
@@ -6499,10 +6559,12 @@
 /obj/structure/cable/heavyduty{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/external,
 /obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/effect/map_helper/airlock/door/int_door,
-/turf/simulated/floor/tiled/steel_ridged,
+/obj/effect/floor_decal/rust,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor,
 /area/offmap/aerostat/inside/arm/sw)
 "xO" = (
 /obj/structure/window/reinforced{
@@ -6534,19 +6596,6 @@
 "xV" = (
 /turf/simulated/wall,
 /area/offmap/aerostat/inside/virology)
-"xW" = (
-/obj/structure/cable/heavyduty{
-	icon_state = "1-2"
-	},
-/obj/effect/floor_decal/rust,
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/machinery/airlock_sensor{
-	dir = 8;
-	pixel_x = 25
-	},
-/obj/effect/map_helper/airlock/sensor/int_sensor,
-/turf/simulated/floor,
-/area/offmap/aerostat/inside/arm/sw)
 "yc" = (
 /obj/machinery/atmospherics/pipe/tank/air{
 	dir = 4
@@ -6838,14 +6887,11 @@
 "zq" = (
 /obj/effect/floor_decal/rust,
 /obj/effect/decal/cleanable/cobweb,
-/obj/machinery/power/solar_control,
-/obj/structure/cable/yellow{
-	icon_state = "0-2"
-	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 8
-	},
 /obj/effect/map_helper/airlock/atmos/pump_out_internal,
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/aux{
+	dir = 4;
+	power_rating = 90000
+	},
 /turf/simulated/floor,
 /area/offmap/aerostat/inside/arm/ne)
 "zr" = (
@@ -6906,11 +6952,12 @@
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/rust,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/machinery/atmospherics/pipe/simple/hidden/aux{
+	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden{
-	dir = 8
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
 	},
 /turf/simulated/floor,
 /area/offmap/aerostat/inside/arm/sw)
@@ -6981,16 +7028,12 @@
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/xenoarch)
 "zR" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/machinery/atmospherics/pipe/simple/hidden{
+/obj/machinery/power/solar_control,
+/obj/machinery/atmospherics/pipe/simple/hidden/aux{
 	dir = 9
 	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/glass,
-/turf/simulated/floor/plating/virgo2,
+/obj/structure/cable/yellow,
+/turf/simulated/floor,
 /area/offmap/aerostat/inside/arm/ne)
 "zV" = (
 /obj/machinery/door/airlock/glass_research{
@@ -7028,10 +7071,9 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/blue,
-/obj/machinery/door/airlock/external,
 /obj/machinery/atmospherics/pipe/simple/hidden/aux,
-/obj/effect/map_helper/airlock/door/int_door,
-/turf/simulated/floor/tiled/steel_ridged,
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/turf/simulated/floor,
 /area/offmap/aerostat/inside/arm/nw)
 "Ab" = (
 /obj/machinery/atmospherics/portables_connector{
@@ -7043,24 +7085,32 @@
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/xenoarch)
 "Ac" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 6
+/obj/effect/map_helper/airlock/atmos/pump_out_external,
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/aux{
+	dir = 4;
+	power_rating = 90000
 	},
-/turf/simulated/shuttle/wall/voidcraft/hard_corner{
-	color = "#eacd7c";
-	stripe_color = "#00FF00"
-	},
-/area/offmap/aerostat/inside/arm/se)
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor/plating/virgo2,
+/area/offmap/aerostat/inside/arm/ne)
 "Ad" = (
 /obj/structure/cable/heavyduty{
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/rust,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/machinery/atmospherics/pipe/simple/hidden/aux{
+	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden{
-	dir = 4
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
+	cycle_to_external_air = 1;
+	dir = 8;
+	id_tag = "aerostat_southeast_airlock";
+	name = "Aerostat Airlock Controller";
+	pixel_x = 28
 	},
 /turf/simulated/floor,
 /area/offmap/aerostat/inside/arm/se)
@@ -7277,6 +7327,19 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/atmos)
+"AM" = (
+/obj/structure/cable/heavyduty{
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/rust,
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/machinery/airlock_sensor{
+	dir = 8;
+	pixel_x = -24
+	},
+/obj/effect/map_helper/airlock/sensor/int_sensor,
+/turf/simulated/floor,
+/area/offmap/aerostat/inside/arm/sw)
 "AN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 1
@@ -7315,10 +7378,10 @@
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/firingrange)
 "AX" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 5
+/turf/simulated/shuttle/wall/voidcraft/hard_corner{
+	color = "#eacd7c";
+	stripe_color = "#00FF00"
 	},
-/turf/simulated/shuttle/wall/voidcraft/green/virgo2,
 /area/offmap/aerostat/inside/arm/se)
 "AY" = (
 /obj/machinery/portable_atmospherics/powered/scrubber/huge/stationary{
@@ -7503,12 +7566,13 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/aux{
 	dir = 8
 	},
-/obj/machinery/airlock_sensor{
-	dir = 4;
-	pixel_x = -32
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/machinery/door/airlock/external,
+/obj/effect/map_helper/airlock/door/int_door,
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
 	},
-/obj/effect/map_helper/airlock/sensor/chamber_sensor,
-/turf/simulated/floor,
+/turf/simulated/floor/tiled/steel_ridged,
 /area/offmap/aerostat/inside/arm/nw)
 "BS" = (
 /obj/structure/cable/heavyduty{
@@ -7758,6 +7822,15 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/miscstorage)
+"CX" = (
+/obj/effect/map_helper/airlock/atmos/pump_out_external,
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/aux{
+	dir = 4;
+	power_rating = 90000
+	},
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor/plating/virgo2,
+/area/offmap/aerostat/inside/arm/se)
 "Da" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/green{
 	dir = 1
@@ -8055,12 +8128,6 @@
 	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/offmap/aerostat/inside/airlock/north)
-"Er" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden{
-	dir = 4
-	},
-/turf/simulated/shuttle/wall/voidcraft/green/virgo2,
-/area/offmap/aerostat/inside/arm/sw)
 "Es" = (
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/tiled/techfloor,
@@ -8077,15 +8144,13 @@
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/toxins)
 "Ev" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/machinery/atmospherics/pipe/manifold/hidden{
+/obj/machinery/atmospherics/pipe/manifold/hidden/aux{
 	dir = 8
 	},
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/effect/floor_decal/rust,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/plating/virgo2,
 /area/offmap/aerostat/inside/arm/sw)
 "Ew" = (
@@ -8246,14 +8311,11 @@
 /area/offmap/aerostat/inside/toxins)
 "Fk" = (
 /obj/effect/floor_decal/rust,
-/obj/effect/decal/cleanable/cobweb,
-/obj/machinery/power/solar_control,
-/obj/structure/cable/yellow{
-	icon_state = "0-2"
-	},
-/obj/effect/map_helper/airlock/atmos/pump_out_internal,
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+/obj/machinery/light/small{
 	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/offmap/aerostat/inside/arm/se)
@@ -8265,20 +8327,14 @@
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/xenoarch)
 "Fo" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 4
-	},
-/obj/effect/map_helper/airlock/atmos/pump_out_internal,
 /obj/effect/floor_decal/rust,
-/obj/machinery/airlock_sensor{
-	dir = 8;
-	pixel_x = 30
+/obj/machinery/atmospherics/pipe/simple/hidden/aux{
+	dir = 9
 	},
-/obj/effect/map_helper/airlock/sensor/chamber_sensor,
-/turf/simulated/floor,
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/turf/simulated/shuttle/wall/voidcraft/green/virgo2,
 /area/offmap/aerostat/inside/arm/sw)
 "Fr" = (
 /obj/machinery/atmospherics/portables_connector{
@@ -8396,15 +8452,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/westhall)
-"FV" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 5
-	},
-/turf/simulated/shuttle/wall/voidcraft/hard_corner{
-	color = "#eacd7c";
-	stripe_color = "#00FF00"
-	},
-/area/offmap/aerostat/inside/arm/ne)
 "FW" = (
 /obj/effect/floor_decal/industrial/warning/dust{
 	dir = 8
@@ -9159,10 +9206,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/airlock_sensor/airlock_exterior{
-	dir = 4;
-	pixel_x = -32
-	},
 /obj/effect/map_helper/airlock/sensor/ext_sensor,
 /turf/simulated/floor/plating/virgo2,
 /area/offmap/aerostat/inside/arm/se)
@@ -9277,14 +9320,18 @@
 /turf/simulated/floor,
 /area/offmap/aerostat/inside/airlock/north)
 "IY" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 10
+/obj/structure/cable/heavyduty{
+	icon_state = "1-2"
 	},
-/turf/simulated/shuttle/wall/voidcraft/hard_corner{
-	color = "#eacd7c";
-	stripe_color = "#00FF00"
+/obj/effect/floor_decal/rust,
+/obj/machinery/atmospherics/pipe/simple/hidden/blue,
+/obj/machinery/atmospherics/pipe/simple/hidden/aux,
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/maintenance/rnd{
+	req_one_access = null
 	},
-/area/offmap/aerostat/inside/arm/sw)
+/turf/simulated/floor/tiled/steel_ridged,
+/area/offmap/aerostat/inside/arm/nw)
 "IZ" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
@@ -9674,21 +9721,15 @@
 /turf/simulated/floor/tiled/steel_ridged,
 /area/offmap/aerostat/inside/toxins)
 "KE" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/aux{
-	dir = 8
+	dir = 8;
+	power_rating = 90000
 	},
 /obj/effect/map_helper/airlock/atmos/chamber_pump,
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/obj/machinery/power/apc{
-	dir = 4;
-	pixel_x = 28
-	},
 /obj/effect/floor_decal/rust,
+/obj/machinery/light/small{
+	dir = 4
+	},
 /turf/simulated/floor,
 /area/offmap/aerostat/inside/arm/nw)
 "KH" = (
@@ -9898,6 +9939,16 @@
 "LK" = (
 /turf/simulated/shuttle/wall/voidcraft/green,
 /area/offmap/aerostat/inside/arm/ne)
+"LN" = (
+/obj/effect/floor_decal/rust,
+/obj/effect/floor_decal/rust,
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/aux{
+	dir = 8;
+	power_rating = 90000
+	},
+/obj/effect/map_helper/airlock/atmos/pump_out_external,
+/turf/simulated/floor/plating/virgo2,
+/area/offmap/aerostat/inside/arm/sw)
 "LR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/blue,
 /obj/structure/cable{
@@ -10112,11 +10163,17 @@
 /turf/simulated/floor,
 /area/offmap/aerostat/inside/arm/sw)
 "Mz" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden{
-	dir = 4
+/obj/structure/cable/heavyduty{
+	icon_state = "1-2"
 	},
-/turf/simulated/shuttle/wall/voidcraft/green/virgo2,
-/area/offmap/aerostat/inside/arm/nw)
+/obj/effect/floor_decal/rust,
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/maintenance/rnd{
+	req_one_access = null
+	},
+/turf/simulated/floor,
+/area/offmap/aerostat/inside/arm/ne)
 "MA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/white,
@@ -10769,10 +10826,10 @@
 /obj/structure/cable/heavyduty{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/external,
 /obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/effect/map_helper/airlock/door/int_door,
-/turf/simulated/floor/tiled/steel_ridged,
+/obj/machinery/atmospherics/pipe/simple/hidden/aux,
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor,
 /area/offmap/aerostat/inside/arm/ne)
 "Py" = (
 /obj/effect/floor_decal/rust,
@@ -11043,10 +11100,19 @@
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/toxins)
 "QI" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 5
+/obj/machinery/atmospherics/pipe/simple/hidden/aux,
+/obj/effect/floor_decal/rust,
+/obj/machinery/power/apc{
+	dir = 4;
+	pixel_x = 28
 	},
-/turf/simulated/shuttle/wall/voidcraft/green/virgo2,
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
 /area/offmap/aerostat/inside/arm/sw)
 "QK" = (
 /obj/structure/cable{
@@ -11141,16 +11207,12 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/southchamb)
 "QZ" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 5
 	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/glass,
-/turf/simulated/floor/plating/virgo2,
+/obj/machinery/power/solar_control,
+/obj/structure/cable/yellow,
+/turf/simulated/floor,
 /area/offmap/aerostat/inside/arm/nw)
 "Ra" = (
 /obj/machinery/airlock_sensor/airlock_exterior{
@@ -11281,10 +11343,10 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/airlock/south)
 "Rt" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 9
+/turf/simulated/shuttle/wall/voidcraft/hard_corner{
+	color = "#eacd7c";
+	stripe_color = "#00FF00"
 	},
-/turf/simulated/shuttle/wall/voidcraft/green/virgo2,
 /area/offmap/aerostat/inside/arm/sw)
 "Ru" = (
 /obj/machinery/light,
@@ -11385,11 +11447,17 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/easthall)
 "RN" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden{
-	dir = 8
+/obj/structure/cable/heavyduty{
+	icon_state = "1-2"
 	},
-/turf/simulated/shuttle/wall/voidcraft/green/virgo2,
-/area/offmap/aerostat/inside/arm/se)
+/obj/effect/floor_decal/rust,
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/machinery/door/airlock/maintenance/rnd{
+	req_one_access = null
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/tiled/steel_ridged,
+/area/offmap/aerostat/inside/arm/sw)
 "RO" = (
 /obj/structure/cable/heavyduty{
 	icon_state = "1-2"
@@ -11448,10 +11516,16 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/westhall)
 "Sd" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 10
+/obj/machinery/power/apc{
+	dir = 8;
+	pixel_x = -22
 	},
-/turf/simulated/shuttle/wall/voidcraft/green/virgo2,
+/obj/effect/floor_decal/rust,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow,
+/turf/simulated/floor,
 /area/offmap/aerostat/inside/arm/ne)
 "Si" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
@@ -11544,15 +11618,10 @@
 /area/offmap/aerostat/inside/toxins)
 "SG" = (
 /obj/effect/floor_decal/rust,
-/obj/effect/decal/cleanable/cobweb2,
-/obj/machinery/power/solar_control,
+/obj/machinery/atmospherics/pipe/simple/hidden/aux,
 /obj/structure/cable/yellow{
-	icon_state = "0-2"
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 4
-	},
-/obj/effect/map_helper/airlock/atmos/pump_out_internal,
 /turf/simulated/floor,
 /area/offmap/aerostat/inside/arm/sw)
 "SH" = (
@@ -11626,16 +11695,14 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/airlock/south)
 "SS" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
 /obj/machinery/atmospherics/pipe/manifold/hidden{
-	dir = 8
+	dir = 1
 	},
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor/glass,
-/turf/simulated/floor/plating/virgo2,
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor,
 /area/offmap/aerostat/inside/arm/nw)
 "ST" = (
 /obj/machinery/atmospherics/unary/heat_exchanger{
@@ -11974,7 +12041,9 @@
 	dir = 8;
 	pixel_x = 30
 	},
-/obj/effect/map_helper/airlock/sensor/chamber_sensor,
+/obj/machinery/atmospherics/pipe/simple/hidden/aux,
+/obj/effect/map_helper/airlock/sensor/int_sensor,
+/obj/effect/floor_decal/rust,
 /turf/simulated/floor,
 /area/offmap/aerostat/inside/arm/se)
 "Us" = (
@@ -11984,14 +12053,17 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/offmap/aerostat/inside/atmos)
 "Ut" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 9
+/obj/structure/cable/heavyduty{
+	icon_state = "1-2"
 	},
-/turf/simulated/shuttle/wall/voidcraft/hard_corner{
-	color = "#eacd7c";
-	stripe_color = "#00FF00"
+/obj/effect/floor_decal/rust,
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/machinery/door/airlock/maintenance/rnd{
+	req_one_access = null
 	},
-/area/offmap/aerostat/inside/arm/nw)
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/tiled/steel_ridged,
+/area/offmap/aerostat/inside/arm/se)
 "Uv" = (
 /obj/structure/bed/chair/office/light,
 /turf/simulated/floor/tiled/techfloor,
@@ -12034,16 +12106,18 @@
 /turf/simulated/wall,
 /area/offmap/aerostat/inside/telesci)
 "UD" = (
-/obj/structure/grille,
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/machinery/atmospherics/pipe/simple/hidden{
+/obj/machinery/atmospherics/pipe/simple/hidden/aux{
 	dir = 6
 	},
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/effect/floor_decal/rust,
+/obj/machinery/power/solar_control,
+/obj/effect/decal/cleanable/cobweb2,
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
 	},
-/obj/machinery/door/firedoor/glass,
+/obj/machinery/atmospherics/pipe/simple/hidden/aux{
+	dir = 6
+	},
 /turf/simulated/floor/plating/virgo2,
 /area/offmap/aerostat/inside/arm/sw)
 "UG" = (
@@ -12314,16 +12388,12 @@
 /turf/simulated/floor/plating/virgo2,
 /area/offmap/aerostat/solars)
 "VQ" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/machinery/atmospherics/pipe/manifold/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/hidden/aux,
+/obj/effect/floor_decal/rust,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/glass,
-/turf/simulated/floor/plating/virgo2,
+/turf/simulated/floor,
 /area/offmap/aerostat/inside/arm/se)
 "VR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
@@ -12386,11 +12456,9 @@
 	},
 /obj/effect/floor_decal/rust,
 /obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/machinery/airlock_sensor{
-	dir = 4;
-	pixel_x = -25
+/obj/machinery/atmospherics/pipe/simple/hidden/aux{
+	dir = 9
 	},
-/obj/effect/map_helper/airlock/sensor/int_sensor,
 /turf/simulated/floor,
 /area/offmap/aerostat/inside/arm/ne)
 "Wf" = (
@@ -12469,11 +12537,17 @@
 /turf/simulated/floor,
 /area/offmap/aerostat/inside/arm/se)
 "Ww" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 4
+/obj/structure/grille,
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced{
+	dir = 8;
+	pixel_x = -4
 	},
-/obj/effect/map_helper/airlock/atmos/pump_out_external,
-/obj/effect/floor_decal/rust,
+/obj/machinery/atmospherics/pipe/simple/hidden/aux{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/plating/virgo2,
 /area/offmap/aerostat/inside/arm/se)
 "Wx" = (
@@ -12799,16 +12873,14 @@
 /turf/simulated/wall,
 /area/offmap/aerostat/inside/genetics)
 "XK" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/machinery/atmospherics/pipe/manifold/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/hidden/aux{
+	dir = 1
 	},
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/effect/floor_decal/rust,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor/glass,
-/turf/simulated/floor/plating/virgo2,
+/turf/simulated/floor,
 /area/offmap/aerostat/inside/arm/ne)
 "XL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -12944,21 +13016,15 @@
 /turf/simulated/floor/tiled/steel_ridged,
 /area/offmap/aerostat/inside/westhall)
 "Yi" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 4
+	dir = 4;
+	power_rating = 90000
 	},
 /obj/effect/map_helper/airlock/atmos/chamber_pump,
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
-/obj/machinery/power/apc{
-	dir = 8;
-	pixel_x = -22
-	},
 /obj/effect/floor_decal/rust,
+/obj/machinery/light/small{
+	dir = 8
+	},
 /turf/simulated/floor,
 /area/offmap/aerostat/inside/arm/ne)
 "Yj" = (
@@ -13309,11 +13375,14 @@
 /turf/simulated/wall,
 /area/offmap/aerostat/inside/toxins)
 "ZG" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+/obj/effect/floor_decal/rust,
+/obj/effect/decal/cleanable/cobweb,
+/obj/machinery/light/small{
 	dir = 8
 	},
-/obj/effect/map_helper/airlock/atmos/pump_out_internal,
-/obj/effect/floor_decal/rust,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor,
 /area/offmap/aerostat/inside/arm/ne)
 "ZH" = (
@@ -13413,10 +13482,18 @@
 /turf/simulated/floor/tiled/white,
 /area/offmap/aerostat/inside/toxins)
 "ZU" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 9
+/obj/machinery/power/apc{
+	dir = 8;
+	pixel_x = -22
 	},
-/turf/simulated/shuttle/wall/voidcraft/green/virgo2,
+/obj/effect/floor_decal/rust,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor,
 /area/offmap/aerostat/inside/arm/se)
 "ZV" = (
 /obj/structure/cable/heavyduty{
@@ -20858,11 +20935,11 @@ ac
 ab
 dX
 BR
-Ou
+mT
 zX
 hC
 Ou
-Ou
+IY
 Ou
 Ou
 Ou
@@ -21004,7 +21081,7 @@ os
 ls
 SS
 QZ
-ac
+sn
 ac
 sQ
 sQ
@@ -21060,11 +21137,11 @@ Mw
 nN
 nN
 nN
+RN
 nN
 nN
-xW
 xN
-nN
+AM
 wI
 zB
 aW
@@ -21139,14 +21216,14 @@ aw
 aw
 aw
 ac
-np
+ac
+ac
 sn
-sn
-Mz
-Ut
+ac
+ac
 fM
 fM
-aw
+ac
 Qg
 aw
 aw
@@ -21202,7 +21279,7 @@ cU
 xw
 xw
 cU
-cU
+Rt
 UD
 Ev
 QI
@@ -21286,8 +21363,8 @@ aw
 aw
 aw
 aw
-aw
-aw
+nW
+nW
 aw
 Qg
 aw
@@ -21344,11 +21421,11 @@ aw
 aw
 aw
 Qg
-aw
+cU
 nr
 nr
-IY
-Er
+cU
+cU
 Rt
 cU
 cU
@@ -21487,8 +21564,8 @@ aw
 aw
 Qg
 aw
-aw
-aw
+LN
+jr
 aw
 aw
 aw
@@ -25321,8 +25398,8 @@ aw
 aw
 Qg
 aw
-aw
-aw
+CX
+CX
 aw
 aw
 aw
@@ -25404,8 +25481,8 @@ aw
 aw
 aw
 aw
-aw
-aw
+Ac
+Ac
 aw
 Qg
 aw
@@ -25462,11 +25539,11 @@ aw
 aw
 aw
 Qg
-aw
+aY
 Ww
 Ww
-Ac
-RN
+aY
+aY
 AX
 aY
 aY
@@ -25541,14 +25618,14 @@ aw
 aw
 aw
 fb
-nW
+fb
+fb
 sZ
-sZ
-mT
-FV
+fb
+fb
 xx
 xx
-aw
+fb
 Qg
 aw
 aw
@@ -25604,7 +25681,7 @@ aY
 jU
 jU
 aY
-aY
+AX
 kJ
 VQ
 ZU
@@ -25690,7 +25767,7 @@ ZG
 Sd
 XK
 zR
-fb
+sZ
 fb
 tM
 tM
@@ -25746,7 +25823,7 @@ Wu
 RO
 RO
 RO
-RO
+Ut
 RO
 pz
 wj
@@ -25828,11 +25905,11 @@ fb
 dr
 sr
 dy
-zp
+np
 Ps
 We
 zp
-zp
+Mz
 zp
 zp
 zp


### PR DESCRIPTION
-Fixes south-east sci-aerostat solar airlock starting Unbolted (https://github.com/VOREStation/VOREStation/issues/14970)

While fixing this bug, I remembered that the aerostat commonly suffers from the fact that late-join attempts to power it up fail from bolted airlocks. This was fine, due to there being an unbolted one in the south-east.

However, said unbolted south-east one didn't even work at all to cycle in/out, this was due to absence of airlock door labels' absence.

However, adding those labels made the solars tracking computer inaccessible in event of aerostat running out of power.

Therefore, alternate solution meant moving the tracking computers out of the airlock, which led to a significant rework of the 4 aerostat airlocks.

I've also went and used custom vents for the 4 airlocks due to cycling time taking forever. The custom vents have double power output (90KW over 45 KW normal.) I justified this by similar special vents existing elsewhere with similar atmospheric challenges.