### PR TITLE
Fixes and tweaks "Survivor Pods"

### DIFF
--- a/code/game/objects/structures/ghost_pods/survivor.dm
+++ b/code/game/objects/structures/ghost_pods/survivor.dm
@@ -41,6 +41,15 @@
 
 	handle_clothing_setup()
 
+/obj/structure/ghost_pod/manual/survivor/trigger()
+	. = ..()
+	desc += "\n The Pod's stasis is broken!"
+	visible_message(message = SPAN_WARNING("\The [src] hisses and blinks in a myriad of lights as its stasis ceases! \n \
+	What or whoever lays beneath may yet stir once more, but their wounds may be too grevious... "),
+	blind_message = SPAN_WARNING("You hear hissing from [src]!"),
+	runemessage = "HISS")
+
+
 /obj/structure/ghost_pod/manual/survivor/proc/handle_clothing_setup()
 	clothing_possibilities = list()
 

--- a/code/modules/client/preference_setup/antagonism/02_candidacy.dm
+++ b/code/modules/client/preference_setup/antagonism/02_candidacy.dm
@@ -23,6 +23,7 @@ var/global/list/special_roles = list( //keep synced with the defines BE_* in set
 	"morph" = 1,										// 18
 	"corgi" = 1,										// 19
 	"cursed sword" = 1,									// 20
+	"Ship Survivor" = 1,								// 21
 	//VOREStation Add End
 )
 


### PR DESCRIPTION
Fixes unreported bug where survivor pods would not send a query. This was caused due to imperfect fix to inability to opt out from it for the round.

Makes it clear when the pod was clicked on
Does this by making a visible_message when clicked and changing its description