### PR TITLE
Randomness updates

### DIFF
--- a/code/game/area/Away Mission areas.dm
+++ b/code/game/area/Away Mission areas.dm
@@ -1,4 +1,4 @@
-/area/awaymission
+/area
 	name = "\improper Unknown Location"
 	icon_state = "away"
 	var/list/valid_spawn_turfs = list()
@@ -6,51 +6,86 @@
 	var/list/valid_flora = list()
 	var/mobcountmax = 0
 	var/floracountmax = 0
+	var/semirandom = FALSE
+	var/semirandom_groups = 0
+	var/semirandom_group_min = 0
+	var/semirandom_group_max = 10
+	var/mob_intent = "default"	//"default" uses default settings, use "hostile", "retaliate", or "passive" respectively
 
-/area/awaymission/proc/EvalValidSpawnTurfs()
+/area/proc/EvalValidSpawnTurfs()
 	//Adds turfs to the valid)turfs list, used for spawning.
-	if(mobcountmax || floracountmax)
+	if(mobcountmax || floracountmax || semirandom)
 		for(var/turf/simulated/floor/F in src)
 			valid_spawn_turfs += F
 		for(var/turf/unsimulated/floor/F in src)
 			valid_spawn_turfs += F
 
-/area/awaymission/LateInitialize()
+/area/LateInitialize()
 	..()
 	EvalValidSpawnTurfs()
-		
+
 	if(!valid_spawn_turfs.len && (mobcountmax || floracountmax))
-		to_world_log("Error! [src] does not have any turfs!")
+		log_and_message_admins("Error! [src] does not have any turfs!")
 		return TRUE
 
 	//Handles random mob placement for mobcountmax, as defined/randomized in initialize of each individual area.
-	if(mobcountmax)
+	if(mobcountmax || semirandom)
 		spawn_mob_on_turf()
 
 	//Handles random flora placement for floracountmax, as defined/randomized in initialize of each individual area.
 	if(floracountmax)
 		spawn_flora_on_turf()
-	
-	to_world("Away mission spawning done.")
 
-/area/awaymission/proc/spawn_mob_on_turf()
+	message_admins("Away mission spawning done.")
+
+/area/proc/spawn_mob_on_turf()
 	if(!valid_mobs.len)
 		to_world_log("[src] does not have a set valid mobs list!")
 		return TRUE
-		
+
 	var/mob/M
 	var/turf/Turf
-	for(var/mobscount = 0 to mobcountmax)
-		M = pick(valid_mobs)
-		Turf = pick(valid_spawn_turfs)
-		valid_spawn_turfs -= Turf
-		new M(Turf)
+	if(semirandom)
+		for(var/groupscount = 0 to (semirandom_groups - 1))
+			var/ourgroup = pickweight(valid_mobs)
+			var/goodnum = rand(semirandom_group_min, semirandom_group_max)
+			for(var/mobscount = 0 to (goodnum - 1))
+				M = pickweight(ourgroup)
+				Turf = pick(valid_spawn_turfs)
+				valid_spawn_turfs -= Turf
+				var/mob/ourmob = new M(Turf)
+				adjust_mob(ourmob)
+	else
+		for(var/mobscount = 0 to mobcountmax)
+			M = pickweight(valid_mobs)
+			Turf = pick(valid_spawn_turfs)
+			valid_spawn_turfs -= Turf
+			var/mob/ourmob = new M(Turf)
+			adjust_mob(ourmob)
 
-/area/awaymission/proc/spawn_flora_on_turf()
+/area/proc/adjust_mob(var/mob/living/M)
+	if(!isliving(M))
+		log_admin("[src] spawned [M.type], which is not mob/living, FIXIT")
+		return
+	var/datum/ai_holder/AI = M.ai_holder
+	switch(mob_intent)
+		if("default")
+			return
+		if("hostile")
+			AI.hostile = TRUE
+			AI.retaliate = TRUE
+		if("retaliate")
+			AI.hostile = FALSE
+			AI.retaliate = TRUE
+		if("passive")
+			AI.hostile = FALSE
+			AI.retaliate = FALSE
+
+/area/proc/spawn_flora_on_turf()
 	if(!valid_flora.len)
 		to_world_log("[src] does not have a set valid flora list!")
 		return TRUE
-		
+
 	var/obj/F
 	var/turf/Turf
 	for(var/floracount = 0 to floracountmax)

--- a/maps/offmap_vr/common_offmaps.dm
+++ b/maps/offmap_vr/common_offmaps.dm
@@ -254,7 +254,7 @@
 	name = "Redgate Submap"
 	desc = "Please do not use this."
 	mappath = null
-	associated_map_datum = null
+	associated_map_datum = /datum/map_z_level/common_lateload/redgate_destination
 
 /datum/map_z_level/common_lateload/redgate_destination
 	name = "Redgate Destination"
@@ -269,25 +269,21 @@
 	name = "Teppi Ranch"
 	desc = "An abandoned teppi ranch!"
 	mappath = 'maps/redgate/teppiranch.dmm'
-	associated_map_datum = /datum/map_z_level/common_lateload/redgate_destination
 
 /datum/map_template/common_lateload/redgate/innland
 	name = "Innland"
 	desc = "Caves and grass and a tavern, woah!"
 	mappath = 'maps/redgate/innland.dmm'
-	associated_map_datum = /datum/map_z_level/common_lateload/redgate_destination
 
 /datum/map_template/common_lateload/redgate/abandonedisland
 	name = "Abandoned Island"
 	desc = "It seems like it used to be people here!"
 	mappath = 'maps/redgate/abandonedisland.dmm'
-	associated_map_datum = /datum/map_z_level/common_lateload/redgate_destination
 
 /datum/map_template/common_lateload/redgate/darkadventure
 	name = "Dark Adventure"
 	desc = "This place seems broken!"
 	mappath = 'maps/redgate/darkadventure.dmm'
-	associated_map_datum = /datum/map_z_level/common_lateload/redgate_destination
 
 //////////////////////////////////////////////////////////////////////////////////////
 // Admin-use z-levels for loading whenever an admin feels like


### PR DESCRIPTION
Adds a 'family' var to fake_sun, allowing them to inherit the settings of other fake_suns with the same 'family'

Also adjusts the mob spawning mechanics for areas, moved those mechanics to area, rather than area/awaymission, that way it can be set for any area, should one desire. Additionally adds semirandom mob spawning functionality to the area spawning mechanics, allowing one to feed the system a list of lists of mob types, and having it only pick as many groups of those as is desired.