### PR TITLE
A variety of miscellaneous bugfixes

### DIFF
--- a/code/game/machinery/doors/blast_door.dm
+++ b/code/game/machinery/doors/blast_door.dm
@@ -203,7 +203,7 @@
 	else if(src.density && (user.a_intent == I_HURT)) //If we can't pry it open and it's not a weapon.... Eh, let's attack it anyway.
 		var/obj/item/weapon/W = C
 		user.setClickCooldown(user.get_attack_speed(W))
-		if(W.damtype == BRUTE || W.damtype == BURN)
+		if(istype(W) && (W.damtype == BRUTE || W.damtype == BURN))
 			user.do_attack_animation(src)
 			if(W.force < min_force) //No actual non-weapon item shouls have a force greater than the min_force, but let's include this just in case.
 				user.visible_message("<span class='danger'>\The [user] hits \the [src] with \the [W] with no visible effect.</span>")

--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -84,11 +84,11 @@
 			R.adjustBruteLoss(-weld_rate)
 		if(wire_rate && R.getFireLoss() && cell.checked_use(wire_power_use * wire_rate * CELLRATE))
 			R.adjustFireLoss(-wire_rate)
-	
+
 	//VOREStation Add Start
 	else if(ispAI(occupant))
 		var/mob/living/silicon/pai/P = occupant
-			
+
 		if(P.nutrition < 400)
 			P.nutrition = min(P.nutrition+10, 400)
 			cell.use(7000/450*10)
@@ -110,7 +110,7 @@
 
 			// Also recharge their internal battery.
 			if(H.isSynthetic() && H.nutrition < 500) //VOREStation Edit
-				H.nutrition = min(H.nutrition+(10*(1-max(H.species.synthetic_food_coeff, 0.9))), 500) //VOREStation Edit
+				H.nutrition = min(H.nutrition+(10*(1-min(H.species.synthetic_food_coeff, 0.9))), 500) //VOREStation Edit
 				cell.use(7000/450*10)
 
 			// And clear up radiation
@@ -268,7 +268,7 @@
 		occupant = R
 		update_icon()
 		return 1
-		
+
 	//VOREStation Add Start
 	else if(istype(L, /mob/living/silicon/pai))
 		var/mob/living/silicon/pai/P = L

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -208,7 +208,7 @@
 
 					var/mattermult = istype(Ob, /obj/item) ? min(2000, 400 * Ob.w_class) : 2000
 
-					Ob.matter[recipe.use_material] = mattermult / produced * required
+					Ob.matter[recipe.matter_material] = mattermult / produced * required
 
 		O.set_dir(user.dir)
 		O.add_fingerprint(user)

--- a/code/modules/client/preference_setup/general/02_language.dm
+++ b/code/modules/client/preference_setup/general/02_language.dm
@@ -42,7 +42,7 @@
 			pref.alternate_languages.len = (S.num_alternate_languages + pref.extra_languages) // Truncate to allowed length
 
 		// VOREStation Edit Start
-		if(!(pref.preferred_language in pref.alternate_languages) || !pref.preferred_language) // Safety handling for if our preferred language is ever somehow removed from the character's list of langauges, or they don't have one set
+		if((!(pref.preferred_language in pref.alternate_languages) && !(pref.preferred_language == LANGUAGE_GALCOM) && !(pref.preferred_language == S.language)) || !pref.preferred_language) // Safety handling for if our preferred language is ever somehow removed from the character's list of langauges, or they don't have one set
 			pref.preferred_language = S.language // Reset to default, for safety
 		// VOREStation Edit end
 

--- a/code/modules/flufftext/look_up.dm
+++ b/code/modules/flufftext/look_up.dm
@@ -17,10 +17,10 @@
 		return
 
 	else // They're outside and hopefully on a planet.
-		var/datum/planet/P = SSplanets.z_to_planet[T.z]
-		if(!P)
+		if(!(T.z in SSplanets.z_to_planet) || !(SSplanets.z_to_planet[T.z]))
 			to_chat(usr, span("warning", "You appear to be outside, but not on a planet... Something is wrong."))
 			return
+		var/datum/planet/P = SSplanets.z_to_planet[T.z]
 
 		var/datum/weather_holder/WH = P.weather_holder
 

--- a/code/modules/mob/living/bot/medbot.dm
+++ b/code/modules/mob/living/bot/medbot.dm
@@ -196,7 +196,7 @@
 		icon_state = "medibot[on]"
 
 /mob/living/bot/medbot/attack_hand(mob/living/carbon/human/H)
-	if(H.a_intent == I_DISARM && !is_tipped)
+	if(istype(H) && H.a_intent == I_DISARM && !is_tipped)
 		H.visible_message("<span class='danger'>[H] begins tipping over [src].</span>", "<span class='warning'>You begin tipping over [src]...</span>")
 
 		if(world.time > last_tipping_action_voice + 15 SECONDS)
@@ -209,7 +209,7 @@
 		if(do_after(H, 3 SECONDS, target=src))
 			tip_over(H)
 
-	else if(H.a_intent == I_HELP && is_tipped)
+	else if(istype(H) && H.a_intent == I_HELP && is_tipped)
 		H.visible_message("<span class='notice'>[H] begins righting [src].</span>", "<span class='notice'>You begin righting [src]...</span>")
 		if(do_after(H, 3 SECONDS, target=src))
 			set_right(H)


### PR DESCRIPTION
Fixes species with nonstandard default language being unable to set Galcom as their default - Fixes #14815, Fixes #15042

Fixes wrong calculation of power gain for synths from the recharger - Fixes #15071 

Fixes AI/borgs being able to tip medbots - Fixes #15011 

Fixes some objects made from material crafting not being properly recyclable

Fixes runtime related to mobs being thrown at blast doors

Fixes runtime related to looking up on non-planetary outdoors