### PR TITLE
Rascal's Pass Z1 changes: Adds countertop sinks to bar & café

### DIFF
--- a/maps/groundbase/gb-z1.dmm
+++ b/maps/groundbase/gb-z1.dmm
@@ -5858,17 +5858,22 @@
 /area/groundbase/security/briefing)
 "mL" = (
 /obj/structure/table/hardwoodtable,
-/obj/item/weapon/reagent_containers/food/drinks/flask/vacuumflask,
 /obj/structure/sign/painting/library_secure{
 	pixel_y = -30
 	},
-/obj/item/weapon/reagent_containers/food/drinks/shaker,
-/obj/item/weapon/reagent_containers/glass/rag,
 /obj/machinery/light{
 	dir = 4
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
+	},
+/obj/random/mug,
+/obj/random/mug,
+/obj/random/mug,
+/obj/random/mug,
+/obj/item/weapon/reagent_containers/food/drinks/shaker{
+	pixel_x = 5;
+	pixel_y = 6
 	},
 /turf/simulated/floor/lino,
 /area/groundbase/civilian/cafe)
@@ -7636,6 +7641,10 @@
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
+	},
+/obj/item/weapon/reagent_containers/food/drinks/flask/vacuumflask{
+	pixel_x = -9;
+	pixel_y = 5
 	},
 /turf/simulated/floor/lino,
 /area/groundbase/civilian/cafe)
@@ -11873,10 +11882,15 @@
 /obj/machinery/camera/network/civilian{
 	dir = 8
 	},
-/obj/random/mug,
-/obj/random/mug,
-/obj/random/mug,
-/obj/random/mug,
+/obj/structure/sink/countertop{
+	dir = 8;
+	pixel_x = 7;
+	pixel_y = 5
+	},
+/obj/item/weapon/reagent_containers/glass/rag{
+	pixel_x = -5;
+	pixel_y = 17
+	},
 /turf/simulated/floor/lino,
 /area/groundbase/civilian/cafe)
 "Bb" = (

--- a/maps/groundbase/gb-z1.dmm
+++ b/maps/groundbase/gb-z1.dmm
@@ -16973,15 +16973,27 @@
 /area/security/range)
 "Ng" = (
 /obj/structure/table/marble,
-/obj/item/device/retail_scanner/civilian,
+/obj/item/device/retail_scanner/civilian{
+	pixel_x = -8
+	},
 /obj/machinery/button/remote/blast_door{
 	id = "Bar";
 	name = "Bar shutters";
 	pixel_x = -3;
 	pixel_y = 26
 	},
-/obj/item/weapon/reagent_containers/food/drinks/shaker,
-/obj/item/weapon/reagent_containers/glass/rag,
+/obj/item/weapon/reagent_containers/food/drinks/shaker{
+	pixel_x = -10;
+	pixel_y = 11
+	},
+/obj/item/weapon/reagent_containers/glass/rag{
+	pixel_x = -9
+	},
+/obj/structure/sink/countertop{
+	dir = 8;
+	pixel_x = 7;
+	pixel_y = 5
+	},
 /turf/simulated/floor/lino,
 /area/groundbase/civilian/bar)
 "Nh" = (


### PR DESCRIPTION
### Commit  https://github.com/VOREStation/VOREStation/pull/15100/commits/5d2ec7f7aadc580064c7e7a9de78a7ad1aab0eb8
Per player request. Also rearranges some of the countertop items to fit the new countertop

### Commit https://github.com/VOREStation/VOREStation/pull/15100/commits/9ba0e47694fb24aee8de706f5cf59383ca6cef64
Bartender having to run off to go and dump their drinks and wash glasses in the bathroom didn't feel particularly hygenic. While an awkward reach due to the limited space, this does the job just fine!