### PR TITLE
Adds a verb to toggle whether enter sends or creates newline for TGUI input framework.

### DIFF
--- a/code/modules/client/preferences_toggle_procs.dm
+++ b/code/modules/client/preferences_toggle_procs.dm
@@ -379,6 +379,17 @@
 		You will have to reload VChat and/or reconnect to the server for these changes to take place. \
 		VChat message persistence is not guaranteed if you change this again before the start of the next round.")
 
+/client/verb/toggle_tgui_inputlock()
+	set name = "Toggle TGUI Input Lock"
+	set category = "Preferences"
+	set desc = "Toggles whether or not pressing the 'Enter' key in TGUI input sends the message or creates a new line."
+
+	prefs.tgui_input_lock = !prefs.tgui_input_lock	//There is no preference datum for tgui input lock, nor for any TGUI prefs.
+	SScharacter_setup.queue_preferences_save(prefs)
+
+	to_chat(src, span_notice("You have toggled TGUI input lock: [prefs.tgui_input_lock ? "ON" : "OFF"] \n \
+	This setting determines whether pressing enter on TGUI input sends the input, or creates a newline."))
+
 /client/verb/toggle_status_indicators()
 	set name = "Toggle Status Indicators"
 	set category = "Preferences"


### PR DESCRIPTION
Adds a new verb under the Preferences verb tab, "Togle-TGUI-Input-Lock" that when pressed/called from command line invert the present preference from TRUE to FALSE and vice versa, saves it to persist and notifies the user that they have enabled/disabled it and what this setting does.

This was done using a simple var = !var rather than the toggle_preference() proc as none of the TGUI preferences have a preference datum. I believe this is due to the way they're positioned in the character set-up window (they're on the top rather than the bottom). As such, I felt it best not to create a datum just for this.

The reason we need this is that although inserting newlines is great when RPing in a slower paced, heavier setting - fast-paced interactions become unnecessarily clunky with the input lock and opening character setup to toggle it back and forth is tiresome. This way, players can just press a button during gameplay or type "Toggle-TGU" and press space to autocomplete.