### PR TITLE
Health Analyzer post-guidance improvements

### DIFF
--- a/code/game/objects/items/devices/scanners/guide.dm
+++ b/code/game/objects/items/devices/scanners/guide.dm
@@ -1,8 +1,9 @@
 /obj/item/device/healthanalyzer/verb/toggle_guide()
-	name = "Toggle Guidance"
-	desc = "Toggles whether or not \the [src] will provide guidance and instruction in addition to scanning."
+	set name = "Toggle Guidance"
+	set desc = "Toggles whether or not \the [src] will provide guidance and instruction in addition to scanning."
+	set category = "Object"
 	guide = !guide
-	to_chat(usr, "<span class='notice'>You toggle \the [src]'s guidance system.</span>")
+	to_chat(usr, "<span class='notice'>You toggle \the [src]'s guidance system [guide ? "on" : "off"].</span>")
 
 
 /obj/item/device/healthanalyzer/guide
@@ -37,23 +38,34 @@
 	var/bloodloss = FALSE
 	var/robotparts = FALSE
 
-	for(var/obj/item/organ/org in M.organs)
+	for(var/obj/item/organ/external/org in M.organs)
+		if(!istype(org))		//how?
+			continue
 		if(org.robotic >= ORGAN_ROBOT)
 			robotparts = TRUE
 			continue
-		if(istype(org,/obj/item/organ/external))
-			var/obj/item/organ/external/e = org
-			if(e.status & ORGAN_BLEEDING)
-				bleeding_external = TRUE
-			if(e.status & ORGAN_BROKEN && (!e.splinted))
-				bone = TRUE
-		if(istype(org,/obj/item/organ/internal))
-			if(org.status & ORGAN_BLEEDING)
+		for(var/datum/wound/W in org.wounds)
+			if(W.internal)
 				bleeding_internal = TRUE
-			if(org.damage)
-				organ = TRUE
-		if(org.germ_level > INFECTION_LEVEL_ONE)
+				break
+		if(org.status & ORGAN_BLEEDING)
+			bleeding_external = TRUE
+		if(org.status & ORGAN_BROKEN && (!org.splinted))
+			bone = TRUE
+		if(org.has_infected_wound())
 			infection = TRUE
+
+
+	for(var/obj/item/organ/org in M.internal_organs)
+		if(!istype(org))		//how?
+			continue
+		if(org.robotic >= ORGAN_ROBOT)
+			robotparts = TRUE
+			continue
+		if(org.status & ORGAN_BLEEDING)
+			bleeding_internal = TRUE
+		if(org.damage >= 1 && !istype(org, /obj/item/organ/internal/brain))
+			organ = TRUE
 
 	var/blood_volume = M.vessel.get_reagent_amount("blood")
 	if(blood_volume <= M.species.blood_volume*M.species.blood_level_safe)
@@ -61,24 +73,24 @@
 
 	if(bleeding_external)
 		dat += "<b>Surface bleeding</b> - Bandage immediately or apply brute-damage fixing chemicals (i.e. Bicaridine) if no bandages available.<br>"
-	if(bleeding_internal && (advscan >= 1 && showadvscan == 1))
+	if(bleeding_internal)
 		dat += "<b>Internal bleeding</b> - Commence internal vein repair surgery or apply clotting chemicals (i.e. Myelamine).<br>"
 	if(M.getOxyLoss())
 		dat += "<b>Suffociation</b> - Give Dexalin or Dexaline Plus. Check for heart or lung damage.<br>"
 	if(infection)
 		dat += "<b>Infection</b> - Give Spaceacilin. If severe, overdose on Spaceacilin and monitor until well.<br>"
-	if((M.getBrainLoss() >= 1 && advscan >= 2 && showadvscan == 1) || M.getBrainLoss() >= 10)
-		dat += "<b>Brain damage</b> - Commence brain repair surgery, apply Alkysine, or universal organ-repair chemicals. (i.e. Peridaxon)<br>"
+	if(M.getBrainLoss() >= 1)
+		dat += "<b>Brain damage</b> - Commence brain repair surgery, apply Alkysine, or universal organ-repair chemicals. (i.e. Peridaxon).<br>"
 	if(M.radiation || M.accumulated_rads)
 		dat += "<b>Radiation</b> - Give Hyroanlin or Arithazine. Monitor for genetic damage.<br>"
-	if(organ && (advscan >= 1 && showadvscan == 1))
+	if(organ)
 		dat += "<b>Organ damage</b> - Give Peridaxon. Perform full body scan for targetted organ repair surgery.<br>"
 	if(bloodloss)
 		dat += "<b>Low blood volume</b> - Commence blood transfusion via IV drip or provide blood-restorative chemicals (i.e. Iron)."
 	if(M.getToxLoss())
 		dat += "<b>Toxins</b> - Give Dylovene or Cartholine. Vomitting is normal and helpful. Tends to be a symptom of larger issues, such as infection.<br>"
 	if(M.getBruteLoss())
-		dat += "<b>Brute Trauma</b> - Bandage wounded body part. Give Bicaridine or Vermicetol.<br>"
+		dat += "<b>Brute trauma</b> - Bandage wounded body part. Give Bicaridine or Vermicetol.<br>"
 	if(M.getFireLoss())
 		dat += "<b>Surface burn</b> - Salve wounded body part in ointment. Give Kelotane or Dermaline. Check for infections.<br>"
 	if(M.getCloneLoss())
@@ -86,7 +98,7 @@
 	if(bone)
 		dat += "<b>Bone fracture</b> - Splint damaged area. Treat with bone repair surgery or Osteodaxon after treating brute damage.<br>"
 	if(M.virus2.len)
-		dat += "<b>Viral infection</b> - Proceed with virology pathogen curing procedures or apply antiviral chemicals (i.e. Corophizine)<br>"
+		dat += "<b>Viral infection</b> - Proceed with virology pathogen curing procedures or apply antiviral chemicals (i.e. Corophizine).<br>"
 	if(robotparts)
 		dat += "<b>Robotic body parts</b> - Should not be repaired by medical personnel, refer to robotics if damaged."
 

--- a/code/game/objects/items/devices/scanners/health.dm
+++ b/code/game/objects/items/devices/scanners/health.dm
@@ -230,7 +230,7 @@
 		dat += "<span class='warning'>Severe brain damage detected. Subject likely to have a traumatic brain injury.</span><br>"
 	else if (M.getBrainLoss() >= 10)
 		dat += "<span class='warning'>Significant brain damage detected. Subject may have had a concussion.</span><br>"
-	else if (M.getBrainLoss() >= 1 && advscan >= 2 && showadvscan == 1)
+	else if (M.getBrainLoss() >= 1)
 		dat += "<span class='warning'>Minor brain damage detected.</span><br>"
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M

--- a/code/game/objects/items/devices/scanners/health.dm
+++ b/code/game/objects/items/devices/scanners/health.dm
@@ -250,6 +250,26 @@
 		var/fracture_dat = ""	// All the fractures
 		var/infection_dat = ""	// All the infections
 		var/ib_dat = ""			// All the IB
+		var/int_damage_acc = 0  // For internal organs
+		for(var/obj/item/organ/internal/i in H.internal_organs)
+			if(!i || i.robotic >= ORGAN_ROBOT || istype(i, /obj/item/organ/internal/brain))
+				continue 		// not there or robotic or brain which is handled separately
+			if(i.damage || i.status & ORGAN_DEAD)
+				int_damage_acc += (i.damage + ((i.status & ORGAN_DEAD) ? 30 : 0))
+				if(advscan >= 2 && showadvscan == 1)
+					if(advscan >= 3)
+						var/dam_adj
+						if(i.damage >= i.min_broken_damage || i.status & ORGAN_DEAD)
+							dam_adj = "Severe"
+						else if(i.damage >= i.min_bruised_damage)
+							dam_adj = "Moderate"
+						else
+							dam_adj = "Mild"
+						dat += "<span class='warning'>[dam_adj] damage detected to subject's [i.name].</span><br>"
+					else
+						dat += "<span class='warning'>Damage detected to subject's [i.name].</span><br>"
+		if(int_damage_acc >= 1 && (advscan < 2 || !showadvscan))
+			dat += "<span class='warning'>Damage detected to subject's internal organs.</span><br>"
 		for(var/obj/item/organ/external/e in H.organs)
 			if(!e)
 				continue

--- a/maps/submaps/pois_vr/aerostat/Boombase.dmm
+++ b/maps/submaps/pois_vr/aerostat/Boombase.dmm
@@ -57,7 +57,7 @@
 /turf/simulated/floor/tiled/techfloor/virgo2,
 /area/submap/virgo2/BoomBase)
 "ao" = (
-/mob/living/simple_mob/animal/space/jelly,
+/mob/living/simple_mob/vore/jelly,
 /turf/simulated/floor/tiled/techfloor/virgo2,
 /area/submap/virgo2/BoomBase)
 "ap" = (
@@ -96,7 +96,7 @@
 /area/submap/virgo2/BoomBase)
 "ax" = (
 /obj/effect/decal/cleanable/dirt,
-/mob/living/simple_mob/animal/space/jelly,
+/mob/living/simple_mob/vore/jelly,
 /turf/simulated/floor/tiled/techfloor/virgo2,
 /area/submap/virgo2/BoomBase)
 "ay" = (


### PR DESCRIPTION
Reduces thresholds for brain damage to be detectable at all.
Allows the analyzer to detect internal organ damage. Detects presence of damage at normal and improved level, detects which organs are damaged at advanced level, detects approximate damage severity at phasic level.
Fixes some bugs regarding the internal organ damage not being detectable by guide.
Fixes bug related to toggling guidance feature resetting name of the analyzer

Unrelatedly, fixes jelly paths on one of pois.