### PR TITLE
Adds new Debris Field POI: Phoron Tanker!

### DIFF
--- a/code/game/objects/items/poi_items.dm
+++ b/code/game/objects/items/poi_items.dm
@@ -114,3 +114,130 @@
 	catalogue_data = list(/datum/category_item/catalogue/information/objects/growthcanister)
 	anchored = FALSE
 	density = TRUE
+
+
+/obj/item/poi/broken_drone_circuit
+	name = "Central Processing Strata"	//Ideally we spawn this as loot for robotic enemies
+	desc = "The pinnacle of artifical intelligence which can be achieved using classical computer science. \n \
+	This one seems somewhat damaged. Perhaps a trained roboticist could extract its memories?"
+	catalogue_data = list(/datum/category_item/catalogue/technology/drone/drones)
+	icon = 'icons/obj/module.dmi'
+	icon_state = "mainboard"
+	w_class = ITEMSIZE_NORMAL
+	origin_tech = list(TECH_ENGINEERING = 4, TECH_MATERIAL = 3, TECH_DATA = 4)
+	var/drone_name = ""	//Randomly picked unless pre-defined. Used by tool examines
+	var/examine_multitool = "TEST_multi - CONTACT DEV"	//Read by attacking with multitool
+	var/examine_canalyzer = "TEST_canalyzer spoken - CONTACT DEV"	//Read by attacking with cyborg analyzer. Define in New() if using vars
+	var/examine_canalyzer_printed = ""	//If we want different formatting or more detals for printed. By default unused
+	var/wirecutted = FALSE
+	var/unscrewed = FALSE
+	var/unlocked = FALSE
+	var/fried = FALSE
+	var/has_paper = FALSE
+
+
+/obj/item/poi/broken_drone_circuit/New()
+	drone_name = "[pick(list("ADA","DOS","GNU","MAC","WIN","NJS","SKS","DRD","IOS","CRM","IBM","TEX","LVM","BSD",))]-[rand(1000, 9999)]]"
+	var/new_canalyzer = "[drone_name] [examine_canalyzer]"	//Only way I could think to dynamically insert drone name here
+	examine_canalyzer = new_canalyzer
+
+/obj/item/poi/broken_drone_circuit/attackby(obj/item/I as obj, mob/living/user as mob)
+	if(!istype(user))
+		return FALSE
+	if(fried)
+		to_chat(user, span_warning("[src] is covered in black marks. You feel there's nothing more you can do..."))
+		return FALSE
+
+	var/turf/message_turf = get_turf(user)	//We use this to ensure everyone can see it!
+	if(istype(I, /obj/item/weapon/tool/screwdriver))
+		unscrewed = !unscrewed
+		to_chat(user, "You screw the blackbox panel [unscrewed ? "off" : "on"]")
+
+	if(istype(I, /obj/item/weapon/tool/wirecutters))
+		wirecutted = !wirecutted
+		to_chat(user, "You [wirecutted ? "cut" : "mend"] the power wire to the blackbox")
+
+	if(istype(I, /obj/item/weapon/paper) && unscrewed)
+		if(!has_paper)
+			to_chat(user, "You feed the debug printer some paper")
+			has_paper = TRUE
+			qdel(I)
+		else
+			to_chat(user, span_notice("[src] cannot hold more than 1 sheet of paper."))
+
+	if(istype(I, /obj/item/device/multitool))
+		if(!unscrewed && !wirecutted)
+			to_chat(user, span_notice("You cannot access the debug interface with the panel screwed on!"))
+		else if(unscrewed && !wirecutted)
+			message_turf.audible_message(message = examine_multitool,
+			deaf_message = "<b>[src]</b> flashes red repeatedly", runemessage= "Beep! Beep!")
+			to_chat(user, span_warning("The components spark from the multitool's unregulated pulse. \
+			Perhaps it'd been better to use more sophisticated tools..."))
+			fried = TRUE
+			message_turf.visible_message(message = "<b>[src]</b> FLASHES VIOLENTLY!",
+			blind_message = "ZAP!", runemessage = "CRACKLE!")
+			var/used_hand = user.get_organ(user.get_active_hand())
+			user.electrocute_act(10,def_zone = used_hand)
+		else if(wirecutted)	//The security circuit is accessible outside the special panel, so we don't care for screwdrivers
+			to_chat(user, span_notice("You modify the security settings."))
+			unlocked = TRUE
+
+	if(istype(I, /obj/item/device/robotanalyzer))
+		if(!unscrewed)
+			to_chat(user, span_notice("You cannot access the debug interface with the panel screwed on!"))
+		else if(wirecutted)
+			to_chat(user, span_notice("You only receive garbled data. Perhaps you should reconnect the wires?"))
+		else if(!unlocked)
+			to_chat(user, span_danger("Security protocols seemingly engage, purging and bricking the circuit!\n \
+			Perhaps, it would've been a good idea to disconnect some wires while pulsing the security circuit..."))
+		else
+			if(!has_paper)
+				message_turf.visible_message(message = "<b>[src]</b> displays, 'PAPER NOT BIN'",
+				blind_message = "you hear VERY ANGRY beeping.", runemessage = "BEEP BEEP!")
+				message_turf.audible_message(message = "<b>[src]</b> recites, \n '[examine_canalyzer]'",
+				deaf_message = "<b>[src]</b> flashes green!", runemessage= "Ping!")
+			else
+				message_turf.audible_message(message = "<b>[src]</b> rattles loudly as it prints",
+				deaf_message = "<b>[src]</b> flashes green!", runemessage= "RATTLE RATTLE")
+				var/obj/item/weapon/paper/P = new /obj/item/weapon/paper(get_turf(src))
+				P.name = "[drone_name] blackbox transcript"
+				P.info = "[examine_canalyzer_printed ? examine_canalyzer_printed : examine_canalyzer]"
+				has_paper = FALSE
+
+
+	return ..()
+
+/obj/item/poi/broken_drone_circuit/attack_self(mob/living/user as mob)
+
+
+	user.visible_message(message = "[user] is studiously examining [src]", self_message = "You take your time to analyze the circuit...")
+	var/message = ""
+	if(fried)
+		message += "Amidst the scorch mark, you barely make out [drone_name] stenciled on the board... \n"
+		to_chat(user, message)
+		return FALSE
+	else
+		message += "You see [drone_name] stenciled onto the board on close inspection! This looks like a secure drone intelligence strata. \n"
+
+
+	if(unlocked)
+		message += "The power logic to the blackbox is scorched. Whatever secrets lie in the blackbox are yours for taking! \n"
+	else if(wirecutted)
+		message += "The power wire to the blackbox has been cut. It's safe to pulse the circuit with power, the blackbox won't fry. \n"
+
+	else if(!unscrewed && !wirecutted)
+		message += "The blackbox is intact, it seems to have a direct wire into the PSU. Strange... \n"
+
+	else if(unscrewed && !wirecutted)
+		message += "Some manner of hardwired logic seems to connect the PSU into the databanks. There is no step-down circuit. \n \
+		It looks like a single pulse will fry this system for good\n"
+	if(unscrewed && !has_paper)
+		message += "Looks like there's a printer without any paper in it."
+
+
+	if(do_after(user, delay = 5 SECONDS))
+		to_chat(user, message)
+
+
+
+	..()

--- a/maps/expedition_vr/space/_debrisfield.dm
+++ b/maps/expedition_vr/space/_debrisfield.dm
@@ -96,6 +96,30 @@
 	name = "POI - Overrun Science Ship"
 	requires_power = 0
 
+/area/submap/debrisfield/phoron_tanker
+	name = "POI - Hijacked Phoron Tanker"
+	var/ic_name = ""
+	requires_power = 0
+	has_gravity = FALSE
+
+
+/area/submap/debrisfield/phoron_tanker/Initialize()
+	. = ..()
+	var/datum/lore/organization/O = loremaster.organizations[/datum/lore/organization/tsc/nanotrasen]
+	ic_name = pick(O.ship_names)
+	name = "NTV [ic_name]"
+	if(!tag)
+		tag = "POI_NT_TANKER_BOAT" //Can't define at compile time, this ensures the area has this if empty
+	if(apc)
+		apc.name = "[name] APC"
+		air_vent_names = list()
+		air_scrub_names = list()
+		air_vent_info = list()
+		air_scrub_info = list()
+		for(var/obj/machinery/alarm/AA in src)
+			AA.name = "[name] Air Alarm"
+
+
 /area/submap/debrisfield/luxury_boat
 	secret_name = 0
 

--- a/maps/submaps/pois_vr/debris_field/_templates.dm
+++ b/maps/submaps/pois_vr/debris_field/_templates.dm
@@ -211,6 +211,11 @@
 	mappath = 'ship_sci_overrun.dmm'
 	cost = 35
 	allow_duplicates = FALSE
+/datum/map_template/debrisfield/phoron_tanker
+	name = "Betrayed Phoron Tanker"
+	mappath = 'ship_tanker_betrayed.dmm'
+	cost = 35
+	allow_duplicates = FALSE
 
 /datum/map_template/debrisfield/ship_tourist_overrun
 	name = "Overrun private yacht"
@@ -289,6 +294,13 @@
 /datum/map_template/debrisfield/blasted_sdf
 	name = "Blasted SDF Corvette"
 	mappath = 'maps/offmap_vr/om_ships/sdf_corvette_wreck.dmm'
+	cost = 35
+	allow_duplicates = FALSE
+	discard_prob = 25
+
+/datum/map_template/debrisfield/phoron_tanker
+	name = "Betrayed Phoron Tanker"
+	mappath = 'ship_tanker_betrayed.dmm'
 	cost = 35
 	allow_duplicates = FALSE
 	discard_prob = 25

--- a/maps/submaps/pois_vr/debris_field/debrisfield_things.dm
+++ b/maps/submaps/pois_vr/debris_field/debrisfield_things.dm
@@ -206,3 +206,126 @@ hope nobody ever has to read this. has to find her.<br>\
 if you do, im sorry.<br>\
 i just hope whatever happens, she finds the mercy we werent equipped to give her.<br>\
 <i>The author's signature is smudged beyond recognition.</i>"}
+
+/mob/living/simple_mob/humanoid/merc/melee/drone/tanker_escort
+	name = "NED Sigma-Phi "
+	desc = "A rudimentary combat drone! You might recognize this as an automated gamma escort for semi-autonomous NanoTrasen vessels."
+	tt_desc = "Escort Gamma Drone"
+	tt_desc = null
+	health = 75
+	maxHealth = 75
+	ai_holder_type = /datum/ai_holder/simple_mob/merc/tanker_escort
+	say_list_type = /datum/say_list/merc/drone/tanker_escort
+	corpse = /obj/effect/landmark/mobcorpse/syndicatesoldier/drone/tanker
+	loot_list = list(/obj/item/poi/broken_drone_circuit/phoron_tanker = 100, /obj/item/weapon/material/knife/tacknife = 100)
+	min_oxy = 0
+	max_oxy = 0
+	min_tox = 0
+	max_tox = 0
+	min_co2 = 0
+	max_co2 = 0
+	min_n2 = 0
+	max_n2 = 0
+	minbodytemp = 0
+
+
+/mob/living/simple_mob/humanoid/merc/melee/sword/drone/tanker_escort
+	name = "NED Sigma-Delta "
+	desc = "A rudimentary combat drone! You might recognize this as an automated gamma escort for semi-autonomous NanoTrasen vessels."
+	tt_desc = "Escort Gamma Drone"
+	health = 35 // Glass cannon
+	maxHealth = 75
+	tt_desc = null
+	ai_holder_type = /datum/ai_holder/simple_mob/merc/tanker_escort
+	say_list_type = /datum/say_list/merc/drone/tanker_escort
+	corpse = /obj/effect/landmark/mobcorpse/syndicatesoldier/drone/tanker
+	loot_list = list(/obj/item/poi/broken_drone_circuit/phoron_tanker = 100,
+	/obj/item/weapon/shield/energy = 100, /obj/item/weapon/melee/energy/sword/color = 20)
+	min_oxy = 0
+	max_oxy = 0
+	min_tox = 0
+	max_tox = 0
+	min_co2 = 0
+	max_co2 = 0
+	min_n2 = 0
+	max_n2 = 0
+	minbodytemp = 0
+
+/mob/living/simple_mob/humanoid/merc/ranged/smg/drone/tanker_escort
+	name = "NED Rho-Phi"
+	desc = "A rudimentary combat drone! You might recognize this as an automated gamma escort for semi-autonomous NanoTrasen vessels."
+	tt_desc = "Escort Gamma Drone"
+	health = 100 //Max health stays same, but our guy got hit with a mateba a few times..
+	ai_holder_type = /datum/ai_holder/simple_mob/merc/ranged/tanker_escort
+	say_list_type = /datum/say_list/merc/drone/tanker_escort
+	corpse = /obj/effect/landmark/mobcorpse/syndicatesoldier/drone/tanker
+	loot_list = list(/obj/item/poi/broken_drone_circuit/phoron_tanker = 100, /obj/item/weapon/gun/projectile/automatic/c20r = 100)
+	min_oxy = 0
+	max_oxy = 0
+	min_tox = 0
+	max_tox = 0
+	min_co2 = 0
+	max_co2 = 0
+	min_n2 = 0
+	max_n2 = 0
+	minbodytemp = 0
+
+/obj/effect/landmark/mobcorpse/syndicatesoldier/drone/tanker
+	corpsesynthbrand = "NanoTrasen"
+	corpseidjob = "Tanker Security"
+
+/obj/effect/landmark/mobcorpse/syndicatesoldier/drone/tanker/generateCorpseName()
+	var/letter = "NED"
+	var/number = rand(0,999)
+	return "[letter]-[number] Guard Drone"
+
+/datum/ai_holder/simple_mob/merc/tanker_escort
+	threaten = FALSE //We're jumping from shadows!
+
+/datum/ai_holder/simple_mob/merc/ranged/tanker_escort
+	threaten_delay = 3 SECONDS //Bugged escort drones, we give a warning, take aim... FIRE!
+
+/datum/say_list/merc/drone/tanker_escort
+	speak = list( "Attempt Do-dock... Do-dock... Err-",
+	"Re-resc . . . Rescind. Rescind Tanker!",
+	"Evaluate Asteroid",
+	"Report Al-Al-Al-Al...",
+	"Find Fax!"
+	)
+	say_threaten = list("INTRU-INT-INT")
+	say_escalate = list("Janitorial Engaged!", "Shoot to-ta-te stun!")
+
+/obj/item/poi/broken_drone_circuit/phoron_tanker
+	origin_tech = list(TECH_ENGINEERING = 4, TECH_MATERIAL = 3, TECH_DATA = 4, TECH_COMBAT = 6)
+	var/static/area/submap/debrisfield/phoron_tanker/tanker	//Doing this to save some perf
+	examine_multitool = "ERR- ERR- KZZZHT \n \
+	designation: <b>kzth!</b> \n assignment: <b>CRACKLE</b> \n \
+	ZRRRRRRRRRRRRR  \n \
+	goal: RETURN HOME status: Successful \n \
+	goal: PRO-PRO"
+
+/obj/item/poi/broken_drone_circuit/phoron_tanker/New()
+	drone_name = "NED-[pick(list("ADA","DOS","GNU","MAC","WIN","NJS","SKS","DRD","IOS","CRM","IBM","TEX","LVM","BSD",))]-[rand(1000, 9999)]]"
+	tanker = locate("POI_NT_TANKER_BOAT")	//actual .dmm area has this
+	var/tankername = "Unknown Ship"
+	if(tanker)
+		tankername = tanker.ic_name
+
+	examine_canalyzer = "<b>UNIT DESIGNATION</b>: [drone_name] \n <b>UNIT ASSIGNMENT</b>: [tankername] \n \
+	<b>TASKING</b>: Accompany & Protect <b>STATUS</b>: INTERRUPTED \n \
+	<b>TASKING</b>: HIJACK DETECTED <b>STATUS</b>: RESOLVED \n \
+	<b>TASKING</b>: RETURN HOME <b>STATUS</b>: SUCCESSFULLY RETURNED TO NSB ADEGAPHIA \n \
+	<b>TASKING</b>: WAIT HANDOFF AUTHORITY <b>STATUS</b>: ACTIVE"
+	examine_canalyzer_printed =  "<b>UNIT DESIGNATION</b>: [drone_name] <br> <b>UNIT ASSIGNMENT</b>: [tankername] <br> \
+	<b>TASKING</b>: Accompany & Protect <b>STATUS</b>: INTERRUPTED <br> \
+	<b>EVENT</b>: POWER SURGE DETECTED   <br><b>STATUS</b>: 069 082 082 079 082 <br> \
+	<b>DIAG</b>: SENSORS  <br> <b>STATUS</b>: 070 065 073 076 <br>\
+	<b>EVENT</b>: POWER SURGE DETECTED  <br> <b>STATUS</b>: RESE7 COMPLEvE <br> \
+	<b>DIAG</b>: SENSORS  <br> <b>STATUS</b>: PPAAS <br> \
+	<b>TASKING</b>: HIJACK DETECTED  <br> <b>STATUS</b>: RESsOLV3D <br> \
+	<b>EVENT</b>: DISCHARGE <b>STATUS</b>: CONfIVED <br> \
+	<b>DIAG</b>: PLATING <b>STATUS</b>: DENtED <br> \
+	<b>TASKING</b>: RETURN HOME  <br> <b>STATUS</b>: S8CCeSSFULLY RETURnED tO NSB AD3GAPhIA <br> \
+	<b>EVENT</b> IMPACT  <br> <b>STATUS</b>: NOTE HArD DOCkING <br> \
+	<b>TASKING</b>: WAIT HANDOFF AUTHORITY <b>STATUS</b>: 4CTIVE <br> \
+	<b>EVENT</b>: TRESPAS <b>STATUS</b>: 3Limited"

--- a/maps/submaps/pois_vr/debris_field/ship_tanker_betrayed.dmm
+++ b/maps/submaps/pois_vr/debris_field/ship_tanker_betrayed.dmm
@@ -1,0 +1,1267 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"ah" = (
+/obj/item/stack/rods,
+/obj/item/weapon/reagent_containers/food/snacks/slice/vegetablepizza,
+/turf/space/cracked_asteroid{
+	temperature = 2.7
+	},
+/area/submap/debrisfield/phoron_tanker)
+"al" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 6
+	},
+/turf/simulated/floor/plating/external{
+	nitrogen = 0;
+	oxygen = 0;
+	temperature = 2.7
+	},
+/area/submap/debrisfield/phoron_tanker)
+"ar" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/tiled/techfloor,
+/area/submap/debrisfield/phoron_tanker)
+"aE" = (
+/obj/effect/map_effect/perma_light,
+/turf/space,
+/area/space)
+"aF" = (
+/mob/living/simple_mob/humanoid/merc/melee/sword/drone/tanker_escort,
+/turf/simulated/floor/plating/external{
+	nitrogen = 0;
+	oxygen = 0;
+	temperature = 2.7
+	},
+/area/submap/debrisfield/phoron_tanker)
+"ck" = (
+/obj/machinery/atmospherics/pipe/simple/visible,
+/turf/simulated/floor/tiled/techmaint/airless,
+/area/submap/debrisfield/phoron_tanker)
+"cM" = (
+/obj/item/stack/cable_coil,
+/turf/space,
+/area/space)
+"dD" = (
+/obj/machinery/door/airlock/external,
+/turf/simulated/floor/tiled/techfloor,
+/area/submap/debrisfield/phoron_tanker)
+"dU" = (
+/turf/simulated/wall/rplastitanium,
+/area/submap/debrisfield/phoron_tanker)
+"eo" = (
+/obj/structure/table/wooden_reinforced,
+/obj/machinery/microwave/advanced,
+/turf/simulated/floor/tiled/techfloor,
+/area/submap/debrisfield/phoron_tanker)
+"ey" = (
+/obj/item/ammo_casing/a95,
+/obj/effect/decal/cleanable/blood/gibs/robot/limb,
+/obj/effect/decal/cleanable/blood/oil,
+/turf/simulated/floor/tiled/techfloor,
+/area/submap/debrisfield/phoron_tanker)
+"eV" = (
+/obj/effect/decal/cleanable/blood/gibs/limb,
+/turf/simulated/floor/tiled/techfloor,
+/area/submap/debrisfield/phoron_tanker)
+"ff" = (
+/obj/structure/lattice,
+/obj/item/broken_device,
+/obj/machinery/embedded_controller/radio/simple_docking_controller{
+	pixel_x = 1;
+	pixel_y = 20
+	},
+/turf/space,
+/area/submap/debrisfield/phoron_tanker)
+"fU" = (
+/mob/living/simple_mob/humanoid/merc/ranged/smg/drone/tanker_escort,
+/turf/simulated/floor/tiled/techfloor,
+/area/submap/debrisfield/phoron_tanker)
+"gn" = (
+/obj/effect/map_effect/perma_light,
+/turf/space/cracked_asteroid{
+	temperature = 2.7
+	},
+/area/submap/debrisfield/phoron_tanker)
+"gz" = (
+/obj/machinery/light_switch{
+	pixel_y = -24
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/submap/debrisfield/phoron_tanker)
+"ht" = (
+/obj/item/stack/cable_coil,
+/mob/living/simple_mob/humanoid/merc/melee/drone/tanker_escort,
+/turf/simulated/mineral/floor/ignore_mapgen/cave{
+	name = "asteroid";
+	nitrogen = 0;
+	oxygen = 0;
+	temperature = 2.7
+	},
+/area/submap/debrisfield/phoron_tanker)
+"hx" = (
+/obj/effect/decal/cleanable/blood/oil,
+/turf/space/cracked_asteroid{
+	temperature = 2.7
+	},
+/area/submap/debrisfield/phoron_tanker)
+"ik" = (
+/obj/structure/meteorite,
+/turf/simulated/floor/plating/external{
+	nitrogen = 0;
+	oxygen = 0;
+	temperature = 2.7
+	},
+/area/submap/debrisfield/phoron_tanker)
+"iD" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 10
+	},
+/turf/simulated/floor/plating/external{
+	nitrogen = 0;
+	oxygen = 0;
+	temperature = 2.7
+	},
+/area/submap/debrisfield/phoron_tanker)
+"jx" = (
+/turf/simulated/floor/tiled/techfloor,
+/area/submap/debrisfield/phoron_tanker)
+"jT" = (
+/obj/structure/curtain/black,
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/tiled/techfloor,
+/area/submap/debrisfield/phoron_tanker)
+"ko" = (
+/obj/structure/lattice,
+/obj/item/pipe,
+/turf/space,
+/area/submap/debrisfield/phoron_tanker)
+"kq" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/item/robot_parts/head,
+/obj/effect/decal/cleanable/blood/gibs/robot,
+/obj/effect/decal/cleanable/blood/oil,
+/obj/item/weapon/broken_gun/laserrifle,
+/turf/simulated/floor/tiled/techfloor,
+/area/submap/debrisfield/phoron_tanker)
+"ky" = (
+/obj/item/stack/material/steel,
+/turf/space/cracked_asteroid{
+	temperature = 2.7
+	},
+/area/submap/debrisfield/phoron_tanker)
+"kI" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/submap/debrisfield/phoron_tanker)
+"li" = (
+/obj/item/weapon/reagent_containers/food/snacks/slice/vegetablepizza,
+/turf/space/cracked_asteroid{
+	temperature = 2.7
+	},
+/area/submap/debrisfield/phoron_tanker)
+"mm" = (
+/obj/item/stack/material/wood,
+/turf/space/cracked_asteroid{
+	temperature = 2.7
+	},
+/area/submap/debrisfield/phoron_tanker)
+"mG" = (
+/obj/machinery/atmospherics/pipe/tank/phoron/full{
+	dir = 4
+	},
+/turf/simulated/floor/plating/external{
+	nitrogen = 0;
+	oxygen = 0;
+	temperature = 2.7
+	},
+/area/submap/debrisfield/phoron_tanker)
+"mP" = (
+/obj/item/weapon/card/id/event/altcard/centcom,
+/obj/structure/closet/wardrobe/captain,
+/turf/simulated/floor/tiled/techfloor,
+/area/submap/debrisfield/phoron_tanker)
+"ng" = (
+/obj/structure/shuttle/engine/propulsion{
+	dir = 8
+	},
+/obj/item/pipe,
+/turf/space,
+/area/submap/debrisfield/phoron_tanker)
+"nn" = (
+/obj/item/ammo_casing/a95,
+/obj/machinery/light/floortube/flicker,
+/turf/simulated/floor/tiled/techfloor,
+/area/submap/debrisfield/phoron_tanker)
+"nJ" = (
+/obj/structure/lattice,
+/obj/item/stack/material/steel,
+/turf/space,
+/area/space)
+"ou" = (
+/turf/simulated/mineral/floor/ignore_mapgen/cave{
+	name = "asteroid";
+	nitrogen = 0;
+	oxygen = 0;
+	temperature = 2.7
+	},
+/area/submap/debrisfield/phoron_tanker)
+"ox" = (
+/obj/machinery/door/window{
+	dir = 8
+	},
+/obj/item/ammo_casing/a95,
+/turf/simulated/floor/tiled/techfloor,
+/area/submap/debrisfield/phoron_tanker)
+"pc" = (
+/mob/living/simple_mob/humanoid/merc/melee/drone/tanker_escort,
+/turf/simulated/floor/tiled/techmaint/airless,
+/area/submap/debrisfield/phoron_tanker)
+"pk" = (
+/obj/machinery/door/window,
+/obj/item/ammo_casing/a95,
+/turf/simulated/floor/tiled/techfloor,
+/area/submap/debrisfield/phoron_tanker)
+"po" = (
+/obj/machinery/shower{
+	dir = 4
+	},
+/obj/structure/curtain/open/shower,
+/turf/simulated/floor/tiled/techfloor,
+/area/submap/debrisfield/phoron_tanker)
+"py" = (
+/turf/simulated/wall/durasteel,
+/area/submap/debrisfield/phoron_tanker)
+"qv" = (
+/obj/structure/window/reinforced,
+/obj/structure/curtain/black,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/submap/debrisfield/phoron_tanker)
+"ro" = (
+/obj/machinery/light/small/emergency/flicker{
+	dir = 8
+	},
+/turf/simulated/floor/plating/external{
+	nitrogen = 0;
+	oxygen = 0;
+	temperature = 2.7
+	},
+/area/submap/debrisfield/phoron_tanker)
+"rt" = (
+/obj/structure/lattice,
+/obj/item/stack/cable_coil,
+/turf/space,
+/area/submap/debrisfield/phoron_tanker)
+"sU" = (
+/obj/item/broken_device,
+/turf/simulated/floor/plating/external{
+	nitrogen = 0;
+	oxygen = 0;
+	temperature = 2.7
+	},
+/area/submap/debrisfield/phoron_tanker)
+"sY" = (
+/obj/item/weapon/reagent_containers/food/snacks/meat,
+/turf/simulated/mineral/floor/ignore_mapgen/cave{
+	name = "asteroid";
+	nitrogen = 0;
+	oxygen = 0;
+	temperature = 2.7
+	},
+/area/submap/debrisfield/phoron_tanker)
+"ta" = (
+/obj/structure/meteorite,
+/turf/space/cracked_asteroid{
+	temperature = 2.7
+	},
+/area/submap/debrisfield/phoron_tanker)
+"tg" = (
+/obj/structure/window/reinforced,
+/obj/structure/curtain/black,
+/turf/simulated/floor/tiled/techfloor,
+/area/submap/debrisfield/phoron_tanker)
+"tw" = (
+/obj/machinery/atmospherics/pipe/simple/visible,
+/turf/simulated/floor/plating/external{
+	nitrogen = 0;
+	oxygen = 0;
+	temperature = 2.7
+	},
+/area/submap/debrisfield/phoron_tanker)
+"uo" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/portables_connector,
+/turf/space,
+/area/submap/debrisfield/phoron_tanker)
+"uF" = (
+/obj/effect/decal/cleanable/blood/oil,
+/turf/simulated/mineral/floor/ignore_mapgen/cave{
+	name = "asteroid";
+	nitrogen = 0;
+	oxygen = 0;
+	temperature = 2.7
+	},
+/area/submap/debrisfield/phoron_tanker)
+"uL" = (
+/obj/tether_away_spawner/debrisfield/carp,
+/turf/template_noop,
+/area/space)
+"uO" = (
+/obj/machinery/atmospherics/pipe/manifold/visible{
+	dir = 8
+	},
+/turf/simulated/floor/plating/external{
+	nitrogen = 0;
+	oxygen = 0;
+	temperature = 2.7
+	},
+/area/submap/debrisfield/phoron_tanker)
+"vs" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/techmaint/airless,
+/area/submap/debrisfield/phoron_tanker)
+"vL" = (
+/turf/simulated/floor/tiled/techmaint/airless,
+/area/submap/debrisfield/phoron_tanker)
+"xo" = (
+/obj/structure/lattice,
+/obj/item/stack/tile/floor/eris/steel,
+/turf/space,
+/area/submap/debrisfield/phoron_tanker)
+"xx" = (
+/obj/structure/lattice,
+/obj/item/pipe,
+/obj/machinery/atmospherics/portables_connector,
+/turf/space,
+/area/submap/debrisfield/phoron_tanker)
+"xF" = (
+/obj/machinery/door/airlock/external,
+/turf/space,
+/area/space)
+"xX" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/techmaint/airless,
+/area/submap/debrisfield/phoron_tanker)
+"yp" = (
+/obj/structure/bed,
+/obj/item/weapon/bedsheet/ian,
+/obj/structure/closet/walllocker_double/emergency_engi/south,
+/obj/machinery/light/flicker{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/submap/debrisfield/phoron_tanker)
+"yH" = (
+/obj/item/stack/rods,
+/turf/space,
+/area/space)
+"zf" = (
+/turf/space/cracked_asteroid{
+	temperature = 2.7
+	},
+/area/submap/debrisfield/phoron_tanker)
+"zi" = (
+/obj/machinery/atmospherics/pipe/manifold/visible{
+	dir = 4
+	},
+/turf/simulated/floor/plating/external{
+	nitrogen = 0;
+	oxygen = 0;
+	temperature = 2.7
+	},
+/area/submap/debrisfield/phoron_tanker)
+"zZ" = (
+/obj/structure/curtain/black,
+/turf/simulated/floor/tiled/techfloor,
+/area/submap/debrisfield/phoron_tanker)
+"Ad" = (
+/obj/item/ammo_casing/a95,
+/turf/simulated/floor/tiled/techfloor,
+/area/submap/debrisfield/phoron_tanker)
+"AV" = (
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/tiled/techfloor,
+/area/submap/debrisfield/phoron_tanker)
+"AY" = (
+/obj/machinery/embedded_controller/radio/simple_docking_controller,
+/turf/space,
+/area/space)
+"BU" = (
+/obj/structure/closet/secure_closet/freezer/fridge,
+/turf/simulated/floor/tiled/techfloor,
+/area/submap/debrisfield/phoron_tanker)
+"CI" = (
+/obj/structure/lattice,
+/obj/structure/meteorite,
+/turf/space,
+/area/submap/debrisfield/phoron_tanker)
+"CW" = (
+/turf/space,
+/area/space)
+"DI" = (
+/obj/structure/table/wooden_reinforced,
+/obj/machinery/light/flicker{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/submap/debrisfield/phoron_tanker)
+"Ea" = (
+/obj/structure/meteorite,
+/turf/space,
+/area/submap/debrisfield/phoron_tanker)
+"Ev" = (
+/obj/item/stack/tile/floor/eris/steel,
+/obj/machinery/atmospherics/pipe/manifold/visible{
+	dir = 8
+	},
+/turf/simulated/floor/plating/external{
+	nitrogen = 0;
+	oxygen = 0;
+	temperature = 2.7
+	},
+/area/submap/debrisfield/phoron_tanker)
+"Ex" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/techmaint/airless,
+/area/submap/debrisfield/phoron_tanker)
+"Fb" = (
+/obj/structure/lattice,
+/obj/structure/meteorite,
+/obj/effect/map_effect/perma_light,
+/turf/space,
+/area/submap/debrisfield/phoron_tanker)
+"Fi" = (
+/obj/machinery/power/apc/critical{
+	dir = 1;
+	pixel_y = 24
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/submap/debrisfield/phoron_tanker)
+"Fl" = (
+/turf/simulated/floor/plating/external{
+	nitrogen = 0;
+	oxygen = 0;
+	temperature = 2.7
+	},
+/area/submap/debrisfield/phoron_tanker)
+"Fv" = (
+/obj/structure/lattice,
+/obj/item/stack/material/steel,
+/turf/space,
+/area/submap/debrisfield/phoron_tanker)
+"Fz" = (
+/turf/simulated/mineral/ignore_mapgen{
+	name = "asteroid"
+	},
+/area/submap/debrisfield/phoron_tanker)
+"FD" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techmaint/airless,
+/area/submap/debrisfield/phoron_tanker)
+"FY" = (
+/obj/structure/shuttle/engine/propulsion,
+/obj/item/stack/cable_coil,
+/obj/item/pipe,
+/turf/space,
+/area/space)
+"Gq" = (
+/obj/machinery/light/small/emergency/flicker{
+	dir = 4
+	},
+/turf/simulated/floor/plating/external{
+	nitrogen = 0;
+	oxygen = 0;
+	temperature = 2.7
+	},
+/area/submap/debrisfield/phoron_tanker)
+"Hk" = (
+/obj/structure/toilet{
+	dir = 1
+	},
+/obj/machinery/light/small/emergency/flicker,
+/turf/simulated/floor/tiled/techfloor,
+/area/submap/debrisfield/phoron_tanker)
+"HV" = (
+/obj/structure/lattice,
+/turf/space,
+/area/space)
+"HY" = (
+/obj/item/stack/rods,
+/turf/space/cracked_asteroid{
+	temperature = 2.7
+	},
+/area/submap/debrisfield/phoron_tanker)
+"IF" = (
+/obj/item/stack/rods,
+/turf/simulated/mineral/ignore_mapgen{
+	name = "asteroid"
+	},
+/area/submap/debrisfield/phoron_tanker)
+"JD" = (
+/obj/effect/map_effect/perma_light,
+/turf/simulated/mineral/floor/ignore_mapgen/cave{
+	name = "asteroid";
+	nitrogen = 0;
+	oxygen = 0;
+	temperature = 2.7
+	},
+/area/submap/debrisfield/phoron_tanker)
+"JG" = (
+/obj/machinery/computer/shuttle,
+/turf/simulated/floor/tiled/techfloor,
+/area/submap/debrisfield/phoron_tanker)
+"JM" = (
+/obj/item/stack/material/steel,
+/turf/simulated/mineral/ignore_mapgen{
+	name = "asteroid"
+	},
+/area/submap/debrisfield/phoron_tanker)
+"KR" = (
+/obj/machinery/alarm{
+	pixel_x = 1;
+	pixel_y = 24
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/submap/debrisfield/phoron_tanker)
+"Lr" = (
+/obj/structure/bed/chair/bay/comfy/captain,
+/obj/effect/decal/cleanable/blood/gibs,
+/obj/item/weapon/gun/projectile/revolver/mateba,
+/turf/simulated/floor/tiled/techfloor,
+/area/submap/debrisfield/phoron_tanker)
+"LM" = (
+/obj/structure/table/wooden_reinforced,
+/obj/item/modular_computer/laptop/preset/custom_loadout/elite,
+/turf/simulated/floor/tiled/techfloor,
+/area/submap/debrisfield/phoron_tanker)
+"Oe" = (
+/obj/structure/lattice,
+/obj/item/broken_device,
+/turf/space,
+/area/submap/debrisfield/phoron_tanker)
+"Ok" = (
+/obj/structure/bed/chair/office/dark,
+/turf/simulated/floor/tiled/techfloor,
+/area/submap/debrisfield/phoron_tanker)
+"Pi" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/submap/debrisfield/phoron_tanker)
+"QA" = (
+/obj/item/clothing/head/beret/centcom/captain,
+/turf/simulated/floor/tiled/techfloor,
+/area/submap/debrisfield/phoron_tanker)
+"QC" = (
+/obj/item/stack/material/steel,
+/turf/space,
+/area/space)
+"RX" = (
+/turf/template_noop,
+/area/space)
+"Sb" = (
+/obj/structure/meteorite,
+/obj/machinery/light/small/emergency/flicker,
+/turf/simulated/floor/tiled/techmaint/airless,
+/area/submap/debrisfield/phoron_tanker)
+"SI" = (
+/obj/machinery/light/flicker{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/submap/debrisfield/phoron_tanker)
+"Tk" = (
+/obj/machinery/computer/ship/navigation,
+/turf/simulated/floor/tiled/techfloor,
+/area/submap/debrisfield/phoron_tanker)
+"Tm" = (
+/obj/item/stack/tile/floor/eris/steel,
+/turf/space,
+/area/submap/debrisfield/phoron_tanker)
+"TG" = (
+/obj/machinery/computer/ship/helm,
+/turf/simulated/floor/tiled/techfloor,
+/area/submap/debrisfield/phoron_tanker)
+"TJ" = (
+/obj/machinery/door/window,
+/turf/simulated/floor/tiled/techfloor,
+/area/submap/debrisfield/phoron_tanker)
+"TL" = (
+/obj/effect/decal/cleanable/blood/oil/streak,
+/turf/simulated/mineral/floor/ignore_mapgen/cave{
+	name = "asteroid";
+	nitrogen = 0;
+	oxygen = 0;
+	temperature = 2.7
+	},
+/area/submap/debrisfield/phoron_tanker)
+"Uh" = (
+/obj/machinery/atmospherics/pipe/tank/phoron/full{
+	dir = 8
+	},
+/turf/simulated/floor/plating/external{
+	nitrogen = 0;
+	oxygen = 0;
+	temperature = 2.7
+	},
+/area/submap/debrisfield/phoron_tanker)
+"Vl" = (
+/obj/effect/map_effect/perma_light,
+/turf/simulated/wall/rplastitanium,
+/area/submap/debrisfield/phoron_tanker)
+"Vr" = (
+/obj/item/broken_device,
+/turf/space/cracked_asteroid{
+	temperature = 2.7
+	},
+/area/submap/debrisfield/phoron_tanker)
+"VD" = (
+/obj/structure/lattice,
+/turf/space,
+/area/submap/debrisfield/phoron_tanker)
+"VW" = (
+/obj/structure/meteorite,
+/turf/space,
+/area/space)
+"VY" = (
+/obj/structure/window/reinforced,
+/turf/simulated/floor/tiled/techfloor,
+/area/submap/debrisfield/phoron_tanker)
+"XW" = (
+/obj/item/stack/material/steel,
+/turf/simulated/mineral/floor/ignore_mapgen/cave{
+	name = "asteroid";
+	nitrogen = 0;
+	oxygen = 0;
+	temperature = 2.7
+	},
+/area/submap/debrisfield/phoron_tanker)
+"Yp" = (
+/obj/effect/decal/cleanable/blood/oil/streak,
+/turf/space/cracked_asteroid{
+	temperature = 2.7
+	},
+/area/submap/debrisfield/phoron_tanker)
+"YI" = (
+/obj/structure/window/reinforced,
+/obj/machinery/light/floortube/flicker,
+/turf/simulated/floor/tiled/techfloor,
+/area/submap/debrisfield/phoron_tanker)
+"Zk" = (
+/obj/structure/curtain/black,
+/turf/simulated/wall,
+/area/submap/debrisfield/phoron_tanker)
+"Zv" = (
+/obj/item/stack/cable_coil,
+/turf/template_noop,
+/area/space)
+"ZQ" = (
+/turf/space,
+/area/submap/debrisfield/phoron_tanker)
+
+(1,1,1) = {"
+uL
+RX
+RX
+RX
+RX
+RX
+RX
+RX
+RX
+RX
+RX
+RX
+RX
+RX
+FY
+CW
+RX
+RX
+RX
+"}
+(2,1,1) = {"
+VD
+ng
+CW
+CW
+CW
+CW
+CW
+CW
+CW
+CW
+CW
+CW
+CW
+CW
+CW
+CW
+RX
+RX
+RX
+"}
+(3,1,1) = {"
+VD
+VD
+al
+uO
+uO
+uO
+uO
+uO
+uO
+uO
+uO
+uO
+uO
+VD
+aE
+CW
+RX
+RX
+RX
+"}
+(4,1,1) = {"
+QC
+cM
+Uh
+Uh
+Uh
+Uh
+Uh
+Uh
+Uh
+Uh
+Uh
+Uh
+Uh
+VD
+nJ
+yH
+RX
+RX
+RX
+"}
+(5,1,1) = {"
+CW
+VD
+dU
+dU
+dU
+dU
+dU
+dU
+dU
+dU
+dU
+dU
+dU
+ZQ
+CW
+CW
+CW
+yH
+CW
+"}
+(6,1,1) = {"
+Oe
+VD
+ro
+VD
+Fl
+Fl
+Fl
+ro
+Fl
+Fl
+ZQ
+Fl
+Fl
+VD
+VD
+VD
+CW
+CW
+AY
+"}
+(7,1,1) = {"
+VD
+Fb
+VD
+sU
+Fl
+Fl
+Fl
+Fl
+CI
+Fl
+Fl
+Fl
+VD
+VD
+rt
+VD
+gn
+Fz
+Fz
+"}
+(8,1,1) = {"
+VD
+VD
+Fl
+Fl
+Fl
+sU
+VD
+Fl
+ik
+Fl
+Fl
+Fl
+Gq
+VD
+VD
+VD
+Yp
+Yp
+Fz
+"}
+(9,1,1) = {"
+VD
+Oe
+dU
+dU
+dU
+dU
+dU
+dU
+dU
+dU
+dU
+CW
+dU
+ZQ
+Tm
+Fz
+TL
+ou
+Fz
+"}
+(10,1,1) = {"
+RX
+QC
+mG
+mG
+mG
+mG
+mG
+ik
+mG
+mG
+mG
+VW
+mG
+Fz
+Fz
+Fz
+ou
+Fz
+Fz
+"}
+(11,1,1) = {"
+Zv
+CW
+iD
+zi
+zi
+zi
+zi
+zi
+zi
+zi
+zi
+CW
+zi
+Fz
+ht
+ou
+ou
+Fz
+CW
+"}
+(12,1,1) = {"
+RX
+CW
+CW
+CW
+CW
+CW
+CW
+CW
+CW
+CW
+CW
+CW
+CW
+Fz
+Fz
+Fz
+zf
+Fz
+CW
+"}
+(13,1,1) = {"
+RX
+CW
+ta
+Fz
+Fz
+dU
+dU
+dU
+VD
+VD
+VD
+dU
+dU
+dU
+CW
+CW
+gn
+cM
+CW
+"}
+(14,1,1) = {"
+RX
+zf
+JD
+ah
+Fz
+ck
+ck
+ck
+ck
+VD
+ck
+ck
+Ex
+dU
+CW
+QC
+VW
+VW
+xF
+"}
+(15,1,1) = {"
+ZQ
+HY
+sY
+mm
+Fz
+py
+py
+py
+py
+py
+py
+py
+xX
+tw
+HV
+VW
+yH
+CW
+CW
+"}
+(16,1,1) = {"
+ZQ
+li
+mm
+Fz
+Fz
+DI
+eo
+tg
+zZ
+Pi
+po
+py
+vL
+dU
+Fz
+Fz
+gn
+Fz
+yH
+"}
+(17,1,1) = {"
+Ea
+Fz
+Fz
+Fz
+BU
+jx
+Ok
+tg
+zZ
+jx
+Hk
+py
+aF
+dU
+Fz
+Yp
+zf
+Fz
+CW
+"}
+(18,1,1) = {"
+Fz
+Fz
+FD
+py
+kI
+TJ
+kI
+qv
+zZ
+jT
+zZ
+py
+Sb
+dU
+Fz
+TL
+ou
+Fz
+CW
+"}
+(19,1,1) = {"
+VD
+VD
+CI
+py
+Tk
+QA
+eV
+jx
+ar
+ox
+kq
+py
+xo
+VD
+Vr
+TL
+ou
+Fz
+Fz
+"}
+(20,1,1) = {"
+VD
+VD
+Fv
+py
+TG
+Lr
+AV
+AV
+Ad
+ey
+nn
+dD
+Oe
+Vr
+hx
+uF
+XW
+ou
+Fz
+"}
+(21,1,1) = {"
+VD
+CI
+VD
+py
+JG
+AV
+jx
+eV
+kI
+kI
+pk
+py
+ff
+VD
+zf
+ou
+ou
+ou
+Fz
+"}
+(22,1,1) = {"
+RX
+dU
+FD
+py
+KR
+AV
+jx
+YI
+Zk
+zZ
+zZ
+py
+Fl
+dU
+Fz
+ou
+ou
+Fz
+Fz
+"}
+(23,1,1) = {"
+RX
+dU
+FD
+py
+Fi
+AV
+jx
+VY
+Zk
+LM
+gz
+py
+pc
+dU
+Fz
+Fz
+Fz
+Fz
+CW
+"}
+(24,1,1) = {"
+RX
+dU
+FD
+py
+fU
+SI
+jx
+VY
+Zk
+mP
+yp
+py
+vL
+dU
+zf
+RX
+RX
+RX
+RX
+"}
+(25,1,1) = {"
+RX
+dU
+FD
+py
+py
+py
+py
+py
+py
+py
+py
+py
+vs
+Fl
+zf
+RX
+RX
+RX
+RX
+"}
+(26,1,1) = {"
+RX
+dU
+xX
+ck
+ck
+ck
+tw
+Ev
+ck
+ck
+ck
+vL
+VD
+CI
+ky
+RX
+RX
+RX
+RX
+"}
+(27,1,1) = {"
+RX
+Vl
+dU
+dU
+dU
+dU
+dU
+VD
+dU
+dU
+dU
+dU
+VD
+HY
+ky
+RX
+RX
+RX
+RX
+"}
+(28,1,1) = {"
+uL
+RX
+RX
+RX
+VD
+ko
+xx
+VD
+VD
+VD
+ko
+uo
+IF
+JM
+dU
+RX
+RX
+RX
+RX
+"}


### PR DESCRIPTION
### What this does

1. Adds a new "puzzlebox" to be used by event-runners and mappers alike: broken_drone_circuit! Given some simple var-edits, you can hide lore inside a drone brain for players to solve (or shock themselves with failing!) 

Mappers have more leeway than event-runners, as going for defining things in initialize() rather than in the vars directly permits some dynamic text to be used!

2. Creates a new POI for the Debris Field - a phoron tanker whose drones mysteriously went rogue and murdered its singular crew! This is meant to be a more challenging POI for the Debris field, quite likely to lead to dying for solo players due to ambushes. However, there's ample fore-warning for the bossfight and the first ambush is not much worse than an elder carp (a drone waiting out of LoS to jump the player with a knife!)

Preceeding the boss is a tougher ambush of another knife-wielder AND an esword drone. Knifewielders have reduced health to make it less frustrating given they ambush you, and the esword drone has been reduced to die within 2-3 egun shots. 

The boss themselves likewise has somewhat less HP than other drone mobs partly due to story, partly due to mercy. The boss has a naive approach of taking the airlock, but they do give a warning before engaging allowing players to retreat and assess the situation: There's an SMG wielding dude watching a doorway. There has to be a better way - and there is! As the ship crashed into asteroids, part of its kitchen was destroyed... While durasteel hull may prevent sapping and flanking - a few loose rubble won't stop a well-coordinated team of 4-8 players! With flanking, the boss should go down without MUCH grief.

Plus, that esword dude had a shield. Hopefully this too encourages players to try and flank.

They can also try to facetank but - smg wielding and embedding bullets may not be best idea.

As an additional reward for clearing the bridge, players may find a mateba!

This ship cannot be repaired, I hope I'd managed to convey it was MUCH BIGGER before the impact, and that it was broken in two with a bunch more vaporized.

Gravity is disabled.

### How it looks:

![image](https://github.com/VOREStation/VOREStation/assets/20523270/fe50573e-8bf7-47de-9c23-d0d4bffd1094)


### Why we need this:

Debris field could do with variety to encourage players to take initiative to go there more frequently! 


### Commit details:

https://github.com/VOREStation/VOREStation/pull/15112/commits/6eac2449578bd79cf5b16adcdf6d33f275d4b374
This is implemented to act as drops by combat drone enemies in the "phoron tanker" POI. I am commiting separately as this is the generalized form to be re-used and distinct enough from mapping.

This variant should not be seen by players. Either view-variable edit examine_canalyzer/multitool/canalyzer_printed or edit in mapmaker or define it in code thru a subtype

If making it spawn from a mob, you'll need to make a subtype. When defining a subtype, New() can be used for dynamic naming like use of drone_name in examine stuff.

https://github.com/VOREStation/VOREStation/pull/15112/commits/a2c2a7db9d051b4586fd328606340d26c020d251
Adds a new POI to the Debris Field, the "Betrayed Phoron Tanker"
This betrayed Phoron tanker's submap area is uniquely defined for its initialization, changing its name and assignign that name dynamically to all its contents

It contains a boss mob of an SMG wielding drone mercenary, a miniboss (who has the shield you might want to wear for boss) with an esword, and 2 mooks with knives.

Rewards include a mateba, 20% chance of an esword and the SMG. Plus, lots of gaseous phoron and durasteel to salvage.

Each drone introduces a mini-puzzle: If players want to learn what happened, they must unlock the drone brain's blackbox and print out the events of the last doomed voyage. This uses the previously commited poi_items.dm broken_drone_circuit.

Story: Escort drones went rogue due to ion laws, fighting their sole pilot/captain and killing them. They proceeded to try and fly back to Tether, but since the Tether's dock is on an asteroid, these broken drones went and crashed their phoron tanker into the nearest asteroid. The Bridge survived due to being made of durasteel.