### PR TITLE
Misc fixes

### DIFF
--- a/code/_onclick/hud/human.dm
+++ b/code/_onclick/hud/human.dm
@@ -160,10 +160,8 @@
 		using.alpha = HUD.ui_alpha
 		adding += using
 
-		using = new /obj/screen()
+		using = new /obj/screen/useself()
 		using.icon = HUD.ui_style
-		using.icon_state = "use"
-		using.name = "use held item on self"
 		using.screen_loc = ui_swaphand2
 		using.color = HUD.ui_color
 		using.alpha = HUD.ui_alpha
@@ -424,3 +422,15 @@
 /obj/screen/wizard/energy
 	name = "energy"
 	icon_state = "wiz_energy"
+
+/obj/screen/useself
+	name = "use held item on self"
+	icon_state = "use"
+	var/next = 0
+
+/obj/screen/useself/proc/can_use(var/mob/living/carbon/human/h, var/obj/item/i)	//Basically trying to use the item this way skips the cooldown
+	if(world.time >= next)														//And trying to check the cooldown doesn't work because when you click the UI it sets a cooldown
+		next = h.get_attack_speed(i)											//So instead we'll just put a cooldown on the use button and apply the item's cooldown to the player
+		h.setClickCooldown(next)												//Otherwise you can click the button and yourself faster than the normal cooldown. SO WE SET BOTH!!!!
+		next += world.time
+		i.attack(h, h)

--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -477,13 +477,14 @@
 			usr.down()
 
 		if("use held item on self")
+			var/obj/screen/useself/s = src
 			if(ishuman(usr))
 				var/mob/living/carbon/human/u = usr
 				var/obj/item/i = u.get_active_hand()
 				if(i)
-					i.attack(usr, usr)
+					s.can_use(u,i)
 				else
-					to_chat(usr, "<span class='notice'>You're not holding anything to use.</span>")
+					to_chat(usr, "<span class='notice'>You're not holding anything to use. You need to have something in your active hand to use it.</span>")
 
 		if("module")
 			if(isrobot(usr))

--- a/code/game/objects/micro_structures.dm
+++ b/code/game/objects/micro_structures.dm
@@ -55,9 +55,56 @@
 		if(8)
 			pixel_x = -32
 
+/obj/structure/micro_tunnel/proc/find_destinations()
+	var/list/destinations = list()
+	var/turf/myturf = get_turf(src.loc)
+	var/datum/planet/planet
+	for(var/datum/planet/P in SSplanets.planets)
+		if(myturf.z in P.expected_z_levels)
+			planet = P
+		else
+	for(var/obj/structure/micro_tunnel/t in world)
+		if(t == src)
+			continue
+		if(magic || t.magic)
+			destinations |= t
+			continue
+		if(t.z == z)
+			destinations |= t
+			continue
+		var/turf/targetturf = get_turf(t.loc)
+		if(planet)
+			if(targetturf.z in planet.expected_z_levels)
+				destinations |= t
+				continue
+			else
+		var/above = GetAbove(myturf)
+		if(above && t.z == z + 1)
+			destinations |= t
+			continue
+		var/below = GetBelow(myturf)
+		if(below && t.z == z - 1)
+			destinations |= t
+	return destinations
+
 /obj/structure/micro_tunnel/attack_hand(mob/living/user)
-	if(!isliving(user))
+	tunnel_interact(user)
+	return ..()
+
+/obj/structure/micro_tunnel/attack_generic(mob/user, damage, attack_verb)
+	tunnel_interact(user)
+	return ..()
+
+/obj/structure/micro_tunnel/attack_robot(mob/living/user)
+	var/turf/hole = get_turf(src)	//Borgs can click stuff from far away, let's make sure they're next to the hole
+	var/turf/borg = get_turf(user)
+	if(hole.AdjacentQuick(borg))
+		tunnel_interact(user)
 		return ..()
+
+/obj/structure/micro_tunnel/proc/tunnel_interact(mob/living/user)
+	if(!isliving(user))
+		return
 	if(user.loc == src)
 		var/list/our_options = list("Exit", "Move")
 
@@ -83,35 +130,7 @@
 					to_chat(user, "<span class = 'warning'>You can't do that unless you're in \the [src].</span>")
 					return
 
-				var/list/destinations = list()
-				var/turf/myturf = get_turf(src.loc)
-				var/datum/planet/planet
-				for(var/datum/planet/P in SSplanets.planets)
-					if(myturf.z in P.expected_z_levels)
-						planet = P
-					else
-				for(var/obj/structure/micro_tunnel/t in world)
-					if(t == src)
-						continue
-					if(magic || t.magic)
-						destinations |= t
-						continue
-					if(t.z == z)
-						destinations |= t
-						continue
-					var/turf/targetturf = get_turf(t.loc)
-					if(planet)
-						if(targetturf.z in planet.expected_z_levels)
-							destinations |= t
-							continue
-						else
-					var/above = GetAbove(myturf)
-					if(above && t.z == z + 1)
-						destinations |= t
-						continue
-					var/below = GetBelow(myturf)
-					if(below && t.z == z - 1)
-						destinations |= t
+				var/list/destinations = find_destinations()
 
 				if(!destinations.len)
 					to_chat(user, "<span class = 'warning'>There are no other tunnels connected to this one!</span>")
@@ -212,10 +231,6 @@
 
 	return FALSE
 
-/obj/structure/micro_tunnel/attack_generic(mob/user, damage, attack_verb)
-	attack_hand(user)
-	return ..()
-
 /obj/structure/micro_tunnel/MouseDrop_T(mob/living/M, mob/living/user)
 	. = ..()
 	if(M != user)
@@ -301,6 +316,9 @@
 					to_chat(usr, "<span class = 'warning'>You can't do that unless you're in \the [src].</span>")
 					return
 				var/list/destinations = list()
+				if(istype(src,/obj/structure/micro_tunnel))	//If we're in a tunnel let's also get the tunnel's destinations
+					var/obj/structure/micro_tunnel/t = src
+					destinations = t.find_destinations()
 				var/turf/myturf = get_turf(src.loc)
 				for(var/obj/o in range(1,myturf))
 					if(!istype(o,/obj))

--- a/code/modules/mob/living/simple_mob/on_click.dm
+++ b/code/modules/mob/living/simple_mob/on_click.dm
@@ -13,9 +13,13 @@
 
 	switch(a_intent)
 		if(I_HELP)
-			var/mob/living/L = A
-			if(istype(L) && (!has_hands || !L.attempt_to_scoop(src)))
-				custom_emote(1,"[pick(friendly)] \the [A]!")
+			if(isliving(A))
+				var/mob/living/L = A
+				if(istype(L) && (!has_hands || !L.attempt_to_scoop(src)))
+					custom_emote(1,"[pick(friendly)] \the [A]!")
+			if(istype(A,/obj/structure/micro_tunnel))	//Allows simplemobs to click on mouse holes, mice should be allowed to go in mouse holes, and other mobs
+				var/obj/structure/micro_tunnel/t = A	//should be allowed to drag the mice out of the mouse holes!
+				t.tunnel_interact(src)
 
 		if(I_HURT)
 			if(can_special_attack(A) && special_attack_target(A))

--- a/code/modules/mob/say_vr.dm
+++ b/code/modules/mob/say_vr.dm
@@ -25,7 +25,7 @@
 		usr.emote_vr(message)
 
 /mob/verb/me_verb_subtle_custom(message as message) // Literally same as above but with mode_selection set to true
-	set name = "Custom Subtle"
+	set name = "Subtle (Custom)"
 	set category = "IC"
 	set desc = "Emote to nearby people, with ability to choose which specific portion of people you wish to target."
 


### PR DESCRIPTION
Applies cooldown to the 'use item on self' button, and makes the 'you don't have an item' text a little more informative.

Also re-renames 'Custom Subtle' back to 'Subtle (Custom)', I didn't test this originally because I thought my pants were really big, and turns out that doing this just makes it first in the list for subtles, which is WORSE! I'm not sure what to rename it so that it won't show up in the list when I type sub, so! Let's just put it back.

Also touches up simple mobs and mouse holes so that simple mobs (such as mice) can click on mouse holes to interact with them! Turns out mice couldn't properly use mouse holes, and that seems like a shame! This is fixed now. Incidentally, borgs can also use mouse holes now.