### PR TITLE
Simplified Coin Press

### DIFF
--- a/code/modules/economy/mint.dm
+++ b/code/modules/economy/mint.dm
@@ -1,210 +1,49 @@
 /**********************Mint**************************/
 /obj/machinery/mineral/mint
 	name = "Coin press"
+	desc = "A relatively crude hand-operated coin press that turns sheets (or ingots, as the case may be) of materials into fresh coins. They're <i>probably</i> not going to be considered legal tender in most polities, but you might fool a vending machine with one..?<br><br><i>It looks like it'll accept silver, gold, diamond, iron, solid phoron, and uranium.</i>"
 	icon = 'icons/obj/stationobjs.dmi'
 	icon_state = "coinpress0"
 	density = TRUE
 	anchored = TRUE
-	var/obj/machinery/mineral/input = null
-	var/obj/machinery/mineral/output = null
-	var/amt_silver = 0 //amount of silver
-	var/amt_gold = 0   //amount of gold
-	var/amt_diamond = 0
-	var/amt_iron = 0
-	var/amt_phoron = 0
-	var/amt_uranium = 0
-	var/newCoins = 0   //how many coins the machine made in it's last load
-	var/processing = 0
-	var/chosen = MAT_STEEL //which material will be used to make coins
-	var/coinsToProduce = 10
+	var/coinsToProduce = 6	//how many coins do we make per sheet? a sheet is 2000 units whilst a coin is 250, and some material should be lost in the process
+	var/list/validMats = list("silver", "gold", "diamond", "iron", "phoron", "uranium")	//what's valid stuff to make coins out of?
 
-
-/obj/machinery/mineral/mint/Initialize()
-	. = ..()
-	for (var/dir in cardinal)
-		input = locate(/obj/machinery/mineral/input, get_step(src, dir))
-		if(input)
-			break
-	for (var/dir in cardinal)
-		output = locate(/obj/machinery/mineral/output, get_step(src, dir))
-		if(output)
-			break
-
-/obj/machinery/mineral/mint/process()
-	if(!input)
-		return
-
-	var/obj/item/stack/O = locate(/obj/item/stack, input.loc)
-	if(!O)
-		return
-
-	var/processed = 1
-	switch(O.get_material_name())
-		if("gold")
-			amt_gold += 100 * O.get_amount()
-		if("silver")
-			amt_silver += 100 * O.get_amount()
-		if("diamond")
-			amt_diamond += 100 * O.get_amount()
-		if("phoron")
-			amt_phoron += 100 * O.get_amount()
-		if("uranium")
-			amt_uranium += 100 * O.get_amount()
-		if(MAT_STEEL)
-			amt_iron += 100 * O.get_amount()
-		else
-			processed = 0
-	if(processed)
-		qdel(O)
-
-/obj/machinery/mineral/mint/attack_hand(user as mob)
-
-	var/dat = "<b>Coin Press</b><br>"
-
-	if (!input)
-		dat += text("input connection status: ")
-		dat += text("<b><font color='red'>NOT CONNECTED</font></b><br>")
-	if (!output)
-		dat += text("<br>output connection status: ")
-		dat += text("<b><font color='red'>NOT CONNECTED</font></b><br>")
-
-	dat += text("<br><font color='#ffcc00'><b>Gold inserted: </b>[amt_gold]</font> ")
-	if (chosen == "gold")
-		dat += text("chosen")
-	else
-		dat += text("<A href='?src=\ref[src];choose=gold'>Choose</A>")
-	dat += text("<br><font color='#888888'><b>Silver inserted: </b>[amt_silver]</font> ")
-	if (chosen == "silver")
-		dat += text("chosen")
-	else
-		dat += text("<A href='?src=\ref[src];choose=silver'>Choose</A>")
-	dat += text("<br><font color='#555555'><b>Iron inserted: </b>[amt_iron]</font> ")
-	if (chosen == MAT_STEEL)
-		dat += text("chosen")
-	else
-		dat += text("<A href='?src=\ref[src];choose=metal'>Choose</A>")
-	dat += text("<br><font color='#8888FF'><b>Diamond inserted: </b>[amt_diamond]</font> ")
-	if (chosen == "diamond")
-		dat += text("chosen")
-	else
-		dat += text("<A href='?src=\ref[src];choose=diamond'>Choose</A>")
-	dat += text("<br><font color='#FF8800'><b>Phoron inserted: </b>[amt_phoron]</font> ")
-	if (chosen == "phoron")
-		dat += text("chosen")
-	else
-		dat += text("<A href='?src=\ref[src];choose=phoron'>Choose</A>")
-	dat += text("<br><font color='#008800'><b>Uranium inserted: </b>[amt_uranium]</font> ")
-	if (chosen == "uranium")
-		dat += text("chosen")
-	else
-		dat += text("<A href='?src=\ref[src];choose=uranium'>Choose</A>")
-
-	dat += text("<br><br>Will produce [coinsToProduce] [chosen] coins if enough materials are available.<br>")
-	//dat += text("The dial which controls the number of conins to produce seems to be stuck. A technician has already been dispatched to fix this.")
-	dat += text("<A href='?src=\ref[src];chooseAmt=-10'>-10</A> ")
-	dat += text("<A href='?src=\ref[src];chooseAmt=-5'>-5</A> ")
-	dat += text("<A href='?src=\ref[src];chooseAmt=-1'>-1</A> ")
-	dat += text("<A href='?src=\ref[src];chooseAmt=1'>+1</A> ")
-	dat += text("<A href='?src=\ref[src];chooseAmt=5'>+5</A> ")
-	dat += text("<A href='?src=\ref[src];chooseAmt=10'>+10</A> ")
-
-	dat += text("<br><br>In total this machine produced <font color='green'><b>[newCoins]</b></font> coins.")
-	dat += text("<br><A href='?src=\ref[src];makeCoins=[1]'>Make coins</A>")
-	user << browse("[dat]", "window=mint")
-
-/obj/machinery/mineral/mint/Topic(href, href_list)
-	if(..())
-		return 1
-	usr.set_machine(src)
-	src.add_fingerprint(usr)
-	if(processing==1)
-		to_chat(usr, "<font color='blue'>The machine is processing.</font>")
-		return
-	if(href_list["choose"])
-		chosen = href_list["choose"]
-	if(href_list["chooseAmt"])
-		coinsToProduce = between(0, coinsToProduce + text2num(href_list["chooseAmt"]), 1000)
-	if(href_list["makeCoins"])
-		var/temp_coins = coinsToProduce
-		if (src.output)
-			processing = 1;
+/obj/machinery/mineral/mint/attackby(obj/item/stack/material/M as obj, mob/user as mob)
+	if(M.default_type in validMats)
+		user.visible_message("[user] starts to feed a sheet of [M.default_type] into \the [src].")
+		while(M.amount > 0)
 			icon_state = "coinpress1"
-			var/obj/item/weapon/moneybag/M
-			switch(chosen)
-				if(MAT_STEEL)
-					while(amt_iron > 0 && coinsToProduce > 0)
-						if (locate(/obj/item/weapon/moneybag,output.loc))
-							M = locate(/obj/item/weapon/moneybag,output.loc)
-						else
-							M = new/obj/item/weapon/moneybag(output.loc)
-						new/obj/item/weapon/coin/iron(M)
-						amt_iron -= 20
-						coinsToProduce--
-						newCoins++
-						src.updateUsrDialog()
-						sleep(5);
-				if("gold")
-					while(amt_gold > 0 && coinsToProduce > 0)
-						if (locate(/obj/item/weapon/moneybag,output.loc))
-							M = locate(/obj/item/weapon/moneybag,output.loc)
-						else
-							M = new/obj/item/weapon/moneybag(output.loc)
-						new /obj/item/weapon/coin/gold(M)
-						amt_gold -= 20
-						coinsToProduce--
-						newCoins++
-						src.updateUsrDialog()
-						sleep(5);
-				if("silver")
-					while(amt_silver > 0 && coinsToProduce > 0)
-						if (locate(/obj/item/weapon/moneybag,output.loc))
-							M = locate(/obj/item/weapon/moneybag,output.loc)
-						else
-							M = new/obj/item/weapon/moneybag(output.loc)
-						new /obj/item/weapon/coin/silver(M)
-						amt_silver -= 20
-						coinsToProduce--
-						newCoins++
-						src.updateUsrDialog()
-						sleep(5);
-				if("diamond")
-					while(amt_diamond > 0 && coinsToProduce > 0)
-						if (locate(/obj/item/weapon/moneybag,output.loc))
-							M = locate(/obj/item/weapon/moneybag,output.loc)
-						else
-							M = new/obj/item/weapon/moneybag(output.loc)
-						new /obj/item/weapon/coin/diamond(M)
-						amt_diamond -= 20
-						coinsToProduce--
-						newCoins++
-						src.updateUsrDialog()
-						sleep(5);
-				if("phoron")
-					while(amt_phoron > 0 && coinsToProduce > 0)
-						if (locate(/obj/item/weapon/moneybag,output.loc))
-							M = locate(/obj/item/weapon/moneybag,output.loc)
-						else
-							M = new/obj/item/weapon/moneybag(output.loc)
-						new /obj/item/weapon/coin/phoron(M)
-						amt_phoron -= 20
-						coinsToProduce--
-						newCoins++
-						src.updateUsrDialog()
-						sleep(5);
-				if("uranium")
-					while(amt_uranium > 0 && coinsToProduce > 0)
-						if (locate(/obj/item/weapon/moneybag,output.loc))
-							M = locate(/obj/item/weapon/moneybag,output.loc)
-						else
-							M = new/obj/item/weapon/moneybag(output.loc)
-						new /obj/item/weapon/coin/uranium(M)
-						amt_uranium -= 20
-						coinsToProduce--
-						newCoins++
-						src.updateUsrDialog()
-						sleep(5)
-			icon_state = "coinpress0"
-			processing = 0;
-			coinsToProduce = temp_coins
-	src.updateUsrDialog()
-	return
+			if(do_after(user, 2 SECONDS, src))
+				M.amount--
+				if(M.default_type == "silver")
+					while(coinsToProduce-- > 0)
+						new /obj/item/weapon/coin/silver(user.loc)
+				else if(M.default_type == "gold")
+					while(coinsToProduce-- > 0)
+						new /obj/item/weapon/coin/gold(user.loc)
+				else if(M.default_type == "diamond")
+					while(coinsToProduce-- > 0)
+						new /obj/item/weapon/coin/diamond(user.loc)
+				else if(M.default_type == "iron")
+					while(coinsToProduce-- > 0)
+						new /obj/item/weapon/coin/iron(user.loc)
+				else if(M.default_type == "phoron")
+					while(coinsToProduce-- > 0)
+						new /obj/item/weapon/coin/phoron(user.loc)
+				else if(M.default_type == "uranium")
+					while(coinsToProduce-- > 0)
+						new /obj/item/weapon/coin/uranium(user.loc)
+				src.visible_message("<span class='notice'>\The [src] rattles and dispenses several [M.default_type] coins!</span>")
+				coinsToProduce = initial(coinsToProduce)
+				if(M.amount == 0)
+					icon_state = "coinpress0"
+					qdel(M)	//clean it up just to be sure
+					src.visible_message("<span class='notice'>\The [src] has run out of usable materials.</span>")
+					break
+			else
+				to_chat(usr,"<span class='warning'>\The [src] is hand-operated and requires your full attention!</span>")
+				icon_state = "coinpress0"
+				break
+	else
+		src.visible_message("<span class='notice'>\The [src] doesn't look like it'll accept that material.</span>")


### PR DESCRIPTION
Rewrites the coin press to a much simpler method of operation: it is now a basic hand-operated press that turns one ingot into six coins (loss of 500 material units in shavings/etc.) after two seconds, placing them at the user's feet. It will continue to process as long as your in-hand stack has sheets on it, and if you move away during the process it aborts.

Valid materials are silver, gold, diamond, phoron, uranium, and iron (previously steel). More could be added pretty easily too, if coin sprites and objects were made and coded.

Also adds a description to the coin press, since it hasn't had one this entire time.

Tested and works quite nicely. Now the Talon's coin press will actually be usable!

Previously the coin press required mapped input and output spots for some reason. Typical overcomplicated project that the original developer seems to have forgotten about, no surprises there.