### PR TITLE
tweak: Adds ability to add atoms to entity narrate while in buildmode

### DIFF
--- a/code/modules/admin/verbs/buildmode.dm
+++ b/code/modules/admin/verbs/buildmode.dm
@@ -159,8 +159,9 @@
 							Left Mouse Button + alt on AI mob      = Toggle hostility on mob<br>\
 							Left Mouse Button + shift on AI mob    = Toggle AI (also resets)<br>\
 							Left Mouse Button + ctrl on AI mob 	   = Copy mob faction<br>\
+							Middle Mouse Button + alt on any atom  = Add atom to entity narrate menu <br>\
 							Middle Mouse Button + shift on any     = Set selected mob(s) to wander<br>\
-							Middle Mouse Button + shift on any     = Set selected mob(s) to NOT wander<br>\
+							Middle Mouse Button + ctrl on any      = Set selected mob(s) to NOT wander<br>\
 							Right Mouse Button + ctrl on any mob   = Paste mob faction copied with Left Mouse Button + shift<br>\
 							Right Mouse Button on enemy mob        = Command selected mobs to attack mob<br>\
 							Right Mouse Button on allied mob       = Command selected mobs to follow mob<br>\
@@ -558,6 +559,9 @@
 					for(var/mob/living/unit in holder.selected_mobs)
 						var/datum/ai_holder/AI = unit.ai_holder
 						AI.wander = FALSE
+				if(pa.Find("alt") && isatom(object))
+					to_chat(user, SPAN_NOTICE("Adding [object] to Entity Narrate List!"))
+					user.client.add_mob_for_narration(object)
 
 
 			if(pa.Find("right"))


### PR DESCRIPTION
### What this does

Buildmode under "AI MODE" now has MMB + ALT while clicking on an atom (mob, turf, obj) bring up the dialogue for adding a new entity for narration with the entity narrate interface. As normal, it asks for a special tag to differentiate similar atoms.

### Why we need this

I decided to muck around a little with build-mode on live and quickly realized "Buildmode is used to actively manage mob movement and stuff, but you cannot rightclick to add them for narration. This means you need to leave buildmode, rightclick, return to build mode and toggle AI mode back on."

I decided that's too clunky for my tastes.

### Testing

Spawned a scug with advanced buildmode, swapped to AI mode, turned off its wandering and then added it to entity narrate where I could talk through it.


### Commit Details: https://github.com/VOREStation/VOREStation/commit/6e087c13288fc1fe024f16901b25565dc5fa010e
- Adds "ALT MMB" under "AI MODE" in buildmode to bring up add_mob_for_narration verb
- Updates Hint with new information
- Fixes bad hint for wander toggle (Shift-> CTRL for NOT wander)