### PR TITLE
Adds means for staff to initialize new mob ai or modify existing ai type

### DIFF
--- a/code/modules/admin/view_variables/helpers.dm
+++ b/code/modules/admin/view_variables/helpers.dm
@@ -48,6 +48,7 @@
 		<option value='?_src_=vars;[HrefToken()];make_skeleton=\ref[src]'>Make 2spooky</option>
 
 		<option value='?_src_=vars;[HrefToken()];direct_control=\ref[src]'>Assume Direct Control</option>
+		<option value='?_src_=vars;[HrefToken()];give_ai=\ref[src]'>Enable/Modify A.I</option>
 		<option value='?_src_=vars;[HrefToken()];drop_everything=\ref[src]'>Drop Everything</option>
 
 		<option value='?_src_=vars;[HrefToken()];regenerateicons=\ref[src]'>Regenerate Icons</option>

--- a/code/modules/admin/view_variables/topic.dm
+++ b/code/modules/admin/view_variables/topic.dm
@@ -157,6 +157,29 @@
 		if(usr.client)
 			usr.client.cmd_assume_direct_control(M)
 
+	else if(href_list["give_ai"])
+		if(!check_rights(0))	return
+
+		var/mob/M = locate(href_list["give_ai"])
+		if(!istype(M, /mob/living))
+			to_chat(usr, span_notice("This can only be used on instances of type /mob/living"))
+			return
+		var/mob/living/L = M
+		if(L.client || L.teleop)
+			to_chat(usr, span_warning("This cannot be used on player mobs!"))
+			return
+
+		if(L.ai_holder)	//Cleaning up the original ai
+			var/ai_holder_old = L.ai_holder
+			L.ai_holder = null
+			qdel(ai_holder_old)	//Only way I could make #TESTING - Unable to be GC'd to stop. del() logs show it works.
+		L.ai_holder_type = tgui_input_list(usr, "Choose AI holder", "AI Type", typesof(/datum/ai_holder/))
+		L.initialize_ai_holder()
+		L.faction = sanitize(tgui_input_text(usr, "Please input AI faction", "AI faction", "neutral"))
+		L.a_intent = tgui_input_list(usr, "Please choose AI intent", "AI intent", list(I_HURT, I_HELP))
+		if(tgui_alert(usr, "Make mob wake up? This is needed for carbon mobs.", "Wake mob?", list("Yes", "No")) == "Yes")
+			L.AdjustSleeping(-100)
+
 	else if(href_list["make_skeleton"])
 		if(!check_rights(R_FUN))	return
 

--- a/code/modules/ai/ai_holder.dm
+++ b/code/modules/ai/ai_holder.dm
@@ -15,12 +15,7 @@
 	var/ai_holder_type = null // Which ai_holder datum to give to the mob when initialized. If null, nothing happens.
 
 /mob/living/Initialize()
-	if(ai_holder_type)
-		ai_holder = new ai_holder_type(src)
-		if(istype(src, /mob/living/carbon/human))
-			var/mob/living/carbon/human/H = src
-			H.hud_used = new /datum/hud(H)
-			H.create_mob_hud(H.hud_used)
+	initialize_ai_holder()
 	return ..()
 
 /mob/living/Destroy()
@@ -36,6 +31,15 @@
 	if(!stat && !key && ai_holder)
 		ai_holder.manage_processing(AI_PROCESSING)
 	return ..()
+
+//Extracted from mob/living/Initialize() so that we may call it at any time after a mob was created
+/mob/living/proc/initialize_ai_holder()
+	if(ai_holder_type)
+		ai_holder = new ai_holder_type(src)
+		if(istype(src, /mob/living/carbon/human))
+			var/mob/living/carbon/human/H = src
+			H.hud_used = new /datum/hud(H)
+			H.create_mob_hud(H.hud_used)
 
 /datum/ai_holder
 	var/mob/living/holder = null		// The mob this datum is going to control.

--- a/code/modules/ai/ai_holder.dm
+++ b/code/modules/ai/ai_holder.dm
@@ -15,7 +15,8 @@
 	var/ai_holder_type = null // Which ai_holder datum to give to the mob when initialized. If null, nothing happens.
 
 /mob/living/Initialize()
-	initialize_ai_holder()
+	if(!ai_holder)
+		initialize_ai_holder()
 	return ..()
 
 /mob/living/Destroy()
@@ -34,8 +35,15 @@
 
 //Extracted from mob/living/Initialize() so that we may call it at any time after a mob was created
 /mob/living/proc/initialize_ai_holder()
+	if(ai_holder)	//Making double sure we clean up and properly GC the original ai_holder
+		var/old_holder = ai_holder
+		ai_holder = null
+		qdel(old_holder)
 	if(ai_holder_type)
 		ai_holder = new ai_holder_type(src)
+		if(!ai_holder)
+			log_debug("[src] could not initialize ai_holder of type [ai_holder_type]")
+			return
 		if(istype(src, /mob/living/carbon/human))
 			var/mob/living/carbon/human/H = src
 			H.hud_used = new /datum/hud(H)


### PR DESCRIPTION
### What this does

First, it moves the ai initialization proc out from mob/living/Initialize() into its own proc. This change does not affect existing functionality.

Using the aforementioned change, a new dropdown button is added in the view variables screen, "Enable/Modify AI".

Pressing this button causes the following to happen:

1. A list input appears (searchable with TGUI input mode) listing all types of /datum/ai_holder. This list is not sanitized for the mob subtype you are calling, discretion is advised for which is used. However, simple_mob/melee/evasive works just fine on carbon mobs (only issue is they attack without the usual simple mob delays)
2. After a new ai type is chosen, the previously extracted logic is called thus initializing a new ai_holder instance.
3. The event-runner is then requested to input mob faction (free-form, sanitized text input)
4. The event-runner is then requested to choose between harm and help intent as the mob's chosen intent
5. The event-runner is finally asked if they'd like the mob to wake up. This question exists because carbon mobs, when spawned, fall asleep unless they got either a client or a ai_holder. They remain asleep until the login() proc calls AdjustSleep(), so we need to work around that.


### Why we need this:

Carbon mobs are the only form of mob that can be surgerized. Unfortunately, we do not have carbon mobs other than an aggressive /mob/living/carbon/human/ai_controlled type for GMs to puppet using buildmode.

By enabling spawning any form of carbon mob (say, generating them in character setup then spawn charactering them in) and then slapping an ai into it, build-mode puppeteering is enabled.

Furthermore, there may exist mobs with already estabilished ai types, but these ai types are not conductive to the current event. This enables changing that in a way that cleanly garbage collects.

Extracting the logic from the initialize() proc was neccessary as previously the only way to init a new ai was by creating a new mob, directly using new datum in vv for ai_holder failed as new datum cannot take new() arguments.

Finally, simply extracting the proc was not sufficient. A lot of variables need to be modified (type, faction, intent, then procCall the new proc, then procCall AdjustSleeping(-5)). This I felt to be awfully clunky during my initial tests, and would have driven me insane doing it in an actual event set-up.

Therefore: A new button that automates that entire process. This has the bonus of cleanly GCing the previous holder type AND giving you a neat and searchable list of all possible options!

### How it looks

![image](https://github.com/VOREStation/VOREStation/assets/20523270/2a518855-4523-46a9-af6d-b2655fddb812)

### Commit Details:

https://github.com/VOREStation/VOREStation/commit/5c02c5a60a8a3841217110430ad56598e543eb85
Adds a new button to the dropdown of "View Variables" for mobs that works for subtypes of mob/living.

This new button automates setting a new ai type for a mob, making sure it's properly garbage collected and then simplifies setting faction, intent and ensures carbon mobs wake up.

https://github.com/VOREStation/VOREStation/commit/39a06b30132bd519e8d0169c7b635036f6d8004d
Moves the logic for initializing an ai_holder from mob/living/Initialize() into its own proc, replacing the original code with a call of this proc.

Functionally, nothing has been changed. However, this enables ai reinitialization for gms