### PR TITLE
Up-ports verkister's "Give Remote LOOC another colour" PR from Chomp

### DIFF
--- a/code/modules/client/verbs/ooc.dm
+++ b/code/modules/client/verbs/ooc.dm
@@ -182,7 +182,7 @@
 	for(var/client/target in r_receivers)
 		var/admin_stuff = "/([key])([admin_jump_link(mob, target.holder)])"
 
-		to_chat(target, "<span class='ooc looc'>" + create_text_tag("looc", "LOOC:", target) + " <span class='prefix'>(R)</span><EM>[display_name][admin_stuff]:</EM> <span class='message'>[msg]</span></span>")
+		to_chat(target, "<span class='ooc rlooc'>" + create_text_tag("looc", "LOOC:", target) + " <span class='prefix'>(R)</span><EM>[display_name][admin_stuff]:</EM> <span class='message'>[msg]</span></span>") //CHOMPEdit
 
 /mob/proc/get_looc_source()
 	return src

--- a/code/modules/vchat/css/ss13styles.css
+++ b/code/modules/vchat/css/ss13styles.css
@@ -76,6 +76,7 @@ body.inverted {
 .ooc .everyone			{color: #002eb8;}
 .inverted .ooc .everyone {color: #004ed8;} /* Dark mode */
 .looc				    {color: #3A9696;}
+.rlooc					{color: #3ABB96;} /* CHOMPEdit */
 .ooc .elevated			{color: #2e78d9;}
 .ooc .moderator			{color: #184880;}
 .ooc .developer			{color: #1b521f;}

--- a/code/stylesheet.dm
+++ b/code/stylesheet.dm
@@ -17,6 +17,7 @@ em						{font-style: normal;font-weight: bold;}
 /* OOC */
 .ooc					{font-weight: bold;}
 .looc					{color: #3A9696;}
+.rlooc					{color: #3ABB96;} //CHOMPEdit
 .ooc img.text_tag		{width: 32px; height: 10px;}
 
 .ooc .everyone			{color: #002eb8;}


### PR DESCRIPTION
### What this does:

Adds a new span class definition: ooc rlooc. This causes R-LOOC colour to change from the first colour (see image) to the second one. There is no Dark/light mode distinction.

~~Unfortunately, I could not get an in-game screenshot as guest accounts cannot use OOC. However, the code compiles, nothing broke and it's a welcome change.~~ I made it work

LOOC/old RLOOC

![image](https://github.com/VOREStation/VOREStation/assets/20523270/7bc8b617-59ed-45bf-8f7f-44096326c411)

New RLOOC

![image](https://github.com/VOREStation/VOREStation/assets/20523270/193ce59f-9be1-47b9-b559-7c77dcf44903)

EDIT: I made the guest be able to speak

![image](https://github.com/VOREStation/VOREStation/assets/20523270/229fe01f-8609-4773-984b-21cb27e0c24e)



### Why we need this:

As discussed downstream, differentiating local LOOCs that are personally relevant and irrelevant remote LOOCs that do not require intervention or assistance (people having chats, people arguing harmlessly) is difficult at glance. This should resolve that.

### Original PR:

https://github.com/CHOMPStation2/CHOMPStation2/commit/3152d84216fe42b52f38cec6995b16a97287fd25

### Commit Details:

https://github.com/VOREStation/VOREStation/commit/019037141873eab905ffb9b57d9cbad185fe22f8

