### PR TITLE
Adds a new button to vvar dropdown to cause IB for human mobs

### DIFF
--- a/code/modules/admin/view_variables/helpers.dm
+++ b/code/modules/admin/view_variables/helpers.dm
@@ -38,6 +38,7 @@
 		<option value='?_src_=vars;[HrefToken()];mob_player_panel=\ref[src]'>Show player panel</option>
 		<option>---</option>
 		<option value='?_src_=vars;[HrefToken()];give_modifier=\ref[src]'>Give Modifier</option>
+		<option value='?_src_=vars;[HrefToken()];give_wound_internal=\ref[src]'>Give Internal Bleeding</option>
 		<option value='?_src_=vars;[HrefToken()];give_spell=\ref[src]'>Give Spell</option>
 		<option value='?_src_=vars;[HrefToken()];give_disease2=\ref[src]'>Give Disease</option>
 		<option value='?_src_=vars;[HrefToken()];give_disease=\ref[src]'>Give TG-style Disease</option>


### PR DESCRIPTION
### What this does

Adds a new button for staff to inflict Internal Bleeding on ANY valid external organ (read: limbs) for human mob (basically, player mobs). It asks for severity, which determines how fast it will bleed and whether it can heal on its own. 

This button can be found in the vvar screen as depicted:

![image](https://github.com/VOREStation/VOREStation/assets/20523270/66a2af77-b281-4ba1-8add-698c1a9a6277)

### Why we need this

I need this for the event(s) I plan to run. This will permit fine-tuning medical content (TM) for the appropriate challenge level.

I specifically plan to make heavy use of this on tether.


### Commit details
https://github.com/VOREStation/VOREStation/commit/057077b443511c5a068bceaccd90784385c4d00f
Adds a new button to the dropdown menu in VV that brings up a dialogue requesting bleeding severity and location before inflicting the requested wound.

In case of targetting a player mob, we notify them with a custom pain message and log it to prevent potential abuse.