### PR TITLE
Custom Link!

### DIFF
--- a/code/modules/client/preference_setup/general/06_flavor.dm
+++ b/code/modules/client/preference_setup/general/06_flavor.dm
@@ -12,7 +12,7 @@
 	S["flavor_texts_hands"]		>> pref.flavor_texts["hands"]
 	S["flavor_texts_legs"]		>> pref.flavor_texts["legs"]
 	S["flavor_texts_feet"]		>> pref.flavor_texts["feet"]
-
+	S["custom_link"]			>> pref.custom_link
 	//Flavour text for robots.
 	S["flavour_texts_robot_Default"] >> pref.flavour_texts_robot["Default"]
 	for(var/module in robot_module_types)
@@ -28,6 +28,7 @@
 	S["flavor_texts_hands"]		<< pref.flavor_texts["hands"]
 	S["flavor_texts_legs"]		<< pref.flavor_texts["legs"]
 	S["flavor_texts_feet"]		<< pref.flavor_texts["feet"]
+	S["custom_link"]			<< pref.custom_link
 
 	S["flavour_texts_robot_Default"] << pref.flavour_texts_robot["Default"]
 	for(var/module in robot_module_types)
@@ -50,11 +51,13 @@
 	character.ooc_notes 				= pref.metadata //VOREStation Add
 	character.ooc_notes_likes			= pref.metadata_likes
 	character.ooc_notes_dislikes		= pref.metadata_dislikes
+	character.custom_link				= pref.custom_link
 
 /datum/category_item/player_setup_item/general/flavor/content(var/mob/user)
 	. += "<b>Flavor:</b><br>"
 	. += "<a href='?src=\ref[src];flavor_text=open'>Set Flavor Text</a><br/>"
 	. += "<a href='?src=\ref[src];flavour_text_robot=open'>Set Robot Flavor Text</a><br/>"
+	. += "<a href='?src=\ref[src];custom_link=1'>Set Custom Link</a><br/>"
 
 /datum/category_item/player_setup_item/general/flavor/OnTopic(var/href,var/list/href_list, var/mob/user)
 	if(href_list["flavor_text"])
@@ -84,6 +87,14 @@
 					pref.flavour_texts_robot[href_list["flavour_text_robot"]] = msg
 		SetFlavourTextRobot(user)
 		return TOPIC_HANDLED
+	else if(href_list["custom_link"])
+		var/new_link = strip_html_simple(tgui_input_text(usr, "Enter a link to add on to your examine text! This should be a related image link/gallery, or things like your F-list. This is not the place for memes.", "Custom Link" , html_decode(pref.custom_link), max_length = 100, encode = TRUE,  prevent_enter = TRUE))
+		if(new_link && CanUseTopic(usr))
+			if(length(new_link) > 100)
+				to_chat(usr, "<span class = 'warning'>Your entry is too long, it must be 100 characters or less.</span>")
+				return
+			pref.custom_link = new_link
+			log_admin("[usr]/[usr.ckey] set their custom link to [pref.custom_link]")
 
 	return ..()
 

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -130,6 +130,7 @@ var/list/preferences_datums = list()
 
 	var/list/flavor_texts = list()
 	var/list/flavour_texts_robot = list()
+	var/custom_link = null
 
 	var/list/body_descriptors = list()
 

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -431,6 +431,9 @@
 		msg += "[flavor_text]"
 
 	// VOREStation Start
+	if(custom_link)
+		msg += "Custom link: [custom_link]"
+
 	if(ooc_notes)
 		msg += "<span class = 'deptradio'>OOC Notes:</span> <a href='?src=\ref[src];ooc_notes=1'>\[View\]</a>"
 	msg += "<span class='deptradio'><a href='?src=\ref[src];vore_prefs=1'>\[Mechanical Vore Preferences\]</a></span>"

--- a/code/modules/mob/living/living_defines_vr.dm
+++ b/code/modules/mob/living/living_defines_vr.dm
@@ -7,6 +7,7 @@
 	var/ooc_notes = null
 	var/ooc_notes_likes = null
 	var/ooc_notes_dislikes = null
+	var/custom_link = null
 	appearance_flags = TILE_BOUND|PIXEL_SCALE|KEEP_TOGETHER|LONG_GLIDE
 	var/hunger_rate = DEFAULT_HUNGER_FACTOR
 //custom say verbs

--- a/code/modules/mob/living/living_vr.dm
+++ b/code/modules/mob/living/living_vr.dm
@@ -58,6 +58,7 @@
 		to_chat(usr, "<span class='filter_notice'>OOC note dislikes have been updated. Don't forget to save!</span>")
 		log_admin("[key_name(usr)] updated their OOC note dislikes mid-round.")
 		ooc_notes_window(usr)
+
 /mob/living/proc/save_ooc_panel()
 	if(usr != src)
 		return
@@ -67,6 +68,22 @@
 	if(client.prefs.save_character())
 		to_chat(usr, "<span class='filter_notice'>Character preferences saved.</span>")
 
+/mob/living/verb/set_custom_link()
+	set name = "Set Custom Link"
+	set desc = "Set a custom link to show up with your examine text."
+	set category = "IC"
+
+	if(usr != src)
+		return
+	var/new_link = strip_html_simple(tgui_input_text(usr, "Enter a link to add on to your examine text! This should be a related image link/gallery, or things like your F-list. This is not the place for memes.", "Custom Link" , html_decode(custom_link), max_length = 100, encode = TRUE,  prevent_enter = TRUE))
+	if(new_link && CanUseTopic(usr))
+		if(length(new_link) > 100)
+			to_chat(usr, "<span class = 'warning'>Your entry is too long, it must be 100 characters or less.</span>")
+			return
+
+		custom_link = new_link
+		to_chat(usr, "<span class = 'notice'>Link set: [custom_link]</span>")
+		log_admin("[usr]/[usr.ckey] set their custom link to [custom_link]")
 
 /mob/living/verb/set_voice_freq()
 	set name = "Set Voice Frequency"

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -355,6 +355,7 @@
 			ooc_notes = meta_info
 			ooc_notes_likes = client.prefs.metadata_likes
 			ooc_notes_dislikes = client.prefs.metadata_dislikes
+		custom_link = client.prefs.custom_link
 
 /mob/living/silicon/robot/verb/namepick()
 	set name = "Pick Name"

--- a/code/modules/vore/eating/living_vr.dm
+++ b/code/modules/vore/eating/living_vr.dm
@@ -1057,9 +1057,12 @@
 
 /mob/living/examine(mob/user, infix, suffix)
 	. = ..()
+	if(custom_link)
+		. += "Custom link: [custom_link]"
 	if(ooc_notes)
 		. += "<span class = 'deptradio'>OOC Notes:</span> <a href='?src=\ref[src];ooc_notes=1'>\[View\]</a>"
 	. += "<span class='deptradio'><a href='?src=\ref[src];vore_prefs=1'>\[Mechanical Vore Preferences\]</a></span>"
+
 
 /mob/living/Topic(href, href_list)	//Can't find any instances of Topic() being overridden by /mob/living in polaris' base code, even though /mob/living/carbon/human's Topic() has a ..() call
 	if(href_list["vore_prefs"])


### PR DESCRIPTION
Allows one to set a custom link to show up in their examine text!

One thing people used the OOC notes for was to post image/flist links in the chat and get clickable links!

Since the OOC panel is a thing now, I thought it would be good to enshrine that function into something that's specifically for it.

This allows you to enter an extra 100 character string underneath your flavortext in your examine text, which can technically be anything, but it's intended to be space for links to show up and be clickable!

![image](https://github.com/VOREStation/VOREStation/assets/24854483/fa10b56e-a28c-4978-ac97-a279618b5ebe)