### PR TITLE
Fixes human mobs ending up with their blood datums deleted, creates fallback if that still happens

### DIFF
--- a/code/game/gamemodes/cult/construct_spells.dm
+++ b/code/game/gamemodes/cult/construct_spells.dm
@@ -472,7 +472,7 @@
 		var/mob/living/carbon/human/H = owner
 		if(!H.should_have_organ(O_HEART))
 			return 1
-		if(H.vessel.remove_reagent("blood", amount))
+		if(H.remove_blood(amount))
 			return 1
 	return 0
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1261,7 +1261,7 @@
 			vessel.maximum_volume = species.blood_volume
 			vessel.add_reagent("blood", species.blood_volume - vessel.total_volume)
 		else if(vessel.total_volume > species.blood_volume)
-			vessel.remove_reagent("blood", vessel.total_volume - species.blood_volume)
+			vessel.remove_reagent("blood",vessel.total_volume - species.blood_volume) //This one should stay remove_reagent to work even lack of a O_heart
 			vessel.maximum_volume = species.blood_volume
 		fixblood()
 		species.update_attack_types() //VOREStation Edit - Required for any trait that updates unarmed_types in setup.
@@ -1731,7 +1731,7 @@
 			if(blood_volume < species?.blood_volume*species?.blood_level_fatal)
 				bloodtrail = 0	//Most of it's gone already, just leave it be
 			else
-				vessel.remove_reagent("blood", 1)
+				remove_blood(1)
 		if(bloodtrail)
 			if(istype(loc, /turf/simulated))
 				var/turf/T = loc

--- a/code/modules/mob/living/simple_mob/subtypes/animal/sif/leech.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/sif/leech.dm
@@ -183,7 +183,7 @@
 
 		if(!docile && ishuman(host) && chemicals < max_chemicals)
 			var/mob/living/carbon/human/H = host
-			H.vessel.remove_reagent("blood", 1)
+			H.remove_blood(1)
 			if(!H.reagents.has_reagent("inaprovaline"))
 				H.reagents.add_reagent("inaprovaline", 1)
 			chemicals += 2

--- a/code/modules/organs/blood.dm
+++ b/code/modules/organs/blood.dm
@@ -219,8 +219,6 @@ var/const/CE_STABLE_THRESHOLD = 0.5
 	if(!amt)
 		return 0
 
-	amt = amt * (src.mob_size/MOB_MEDIUM)
-
 	var/current_blood = vessel.get_reagent_amount("blood")
 	if(current_blood < BLOOD_MINIMUM_STOP_PROCESS)
 		return 0 //We stop processing under 3 units of blood because apparently weird shit can make it overflowrandomly.
@@ -271,7 +269,7 @@ var/const/CE_STABLE_THRESHOLD = 0.5
 	if(!should_have_organ(O_HEART))
 		return null
 
-	if(vessel.get_reagent_amount("blood") < amount || vessel.get_reagent_amount("blood") < BLOOD_MINIMUM_STOP_PROCESS)
+	if(vessel.get_reagent_amount("blood") < max(amount, BLOOD_MINIMUM_STOP_PROCESS))
 		return null
 
 	. = ..()

--- a/code/modules/organs/blood.dm
+++ b/code/modules/organs/blood.dm
@@ -210,10 +210,12 @@ var/const/CE_STABLE_THRESHOLD = 0.5
 	if(!amt)
 		return 0
 
+	amt = amt * (src.mob_size/MOB_MEDIUM)
+
 	if(amt > vessel.get_reagent_amount("blood"))
 		amt = vessel.get_reagent_amount("blood") - 1	// Bit of a safety net; it's impossible to add blood if there's not blood already in the vessel.
 
-	return vessel.remove_reagent("blood",amt * (src.mob_size/MOB_MEDIUM))
+	return vessel.remove_reagent("blood",amt)
 
 /****************************************************
 				BLOOD TRANSFERS

--- a/code/modules/organs/blood.dm
+++ b/code/modules/organs/blood.dm
@@ -260,7 +260,7 @@ var/const/CE_STABLE_THRESHOLD = 0.5
 		return null
 
 	. = ..()
-	vessel.remove_reagent("blood",amount) // Removes blood if human
+	remove_blood(amount) // Removes blood if human
 
 //Transfers blood from container ot vessels
 /mob/living/carbon/proc/inject_blood(var/datum/reagent/blood/injected, var/amount)

--- a/code/modules/organs/blood.dm
+++ b/code/modules/organs/blood.dm
@@ -1,3 +1,4 @@
+#define BLOOD_MINIMUM_STOP_PROCESS 2.1 // Define to avoid hitting 0 blood.
 /****************************************************
 				BLOOD SYSTEM
 ****************************************************/
@@ -14,8 +15,12 @@ var/const/CE_STABLE_THRESHOLD = 0.5
 /mob/living/carbon/human/var/datum/reagents/vessel // Container for blood and BLOOD ONLY. Do not transfer other chems here.
 /mob/living/carbon/human/var/var/pale = 0          // Should affect how mob sprite is drawn, but currently doesn't.
 
-//Initializes blood vessels
-/mob/living/carbon/human/proc/make_blood()
+/***Initializes blood vessels
+ * Called code/modules/mob/living/carbon/human/human.dm#L1259 set_species procedure with 0 args
+ * Also called by inject_blood as fallback with amt = injected_amount
+ * MUST be followed by calling fixblood() allways.
+***/
+/mob/living/carbon/human/proc/make_blood(var/amt = 0)
 
 	if(vessel)
 		return
@@ -29,7 +34,11 @@ var/const/CE_STABLE_THRESHOLD = 0.5
 	if(!should_have_organ(O_HEART)) //We want the var for safety but we can do without the actual blood.
 		return
 
-	vessel.add_reagent("blood",species.blood_volume)
+	if(!amt)
+		vessel.add_reagent("blood",species.blood_volume)
+	else
+		vessel.add_reagent("blood", clamp(amt, 1, species.blood_volume))
+
 
 //Resets blood data
 /mob/living/carbon/human/proc/fixblood()
@@ -212,8 +221,12 @@ var/const/CE_STABLE_THRESHOLD = 0.5
 
 	amt = amt * (src.mob_size/MOB_MEDIUM)
 
-	if(amt > vessel.get_reagent_amount("blood"))
-		amt = vessel.get_reagent_amount("blood") - 1	// Bit of a safety net; it's impossible to add blood if there's not blood already in the vessel.
+	var/current_blood = vessel.get_reagent_amount("blood")
+	if(current_blood < BLOOD_MINIMUM_STOP_PROCESS)
+		return 0 //We stop processing under 3 units of blood because apparently weird shit can make it overflowrandomly.
+
+	if(amt > current_blood)
+		amt = current_blood - 2	// Bit of a safety net; it's impossible to add blood if there's not blood already in the vessel.
 
 	return vessel.remove_reagent("blood",amt)
 
@@ -258,7 +271,7 @@ var/const/CE_STABLE_THRESHOLD = 0.5
 	if(!should_have_organ(O_HEART))
 		return null
 
-	if(vessel.get_reagent_amount("blood") < amount)
+	if(vessel.get_reagent_amount("blood") < amount || vessel.get_reagent_amount("blood") < BLOOD_MINIMUM_STOP_PROCESS)
 		return null
 
 	. = ..()
@@ -290,8 +303,28 @@ var/const/CE_STABLE_THRESHOLD = 0.5
 
 	var/datum/reagent/blood/our = get_blood(vessel)
 
-	if (!injected || !our)
+	if (!injected)
 		return
+	if(!our)
+		log_debug("[src] has no blood reagent, proceeding with fallback reinitialization.")
+		var/vessel_old = vessel
+		vessel = null
+		qdel(vessel_old)
+		make_blood(amount)
+		if(!vessel)
+			log_debug("Failed to re-initialize blood datums on [src]!")
+			return
+		if(vessel.total_volume < species.blood_volume)
+			vessel.add_reagent("blood", species.blood_volume - vessel.total_volume)
+		else if(vessel.total_volume > species.blood_volume)
+			vessel.maximum_volume = species.blood_volume
+		fixblood()
+		our = get_blood(vessel)
+		if(!our)
+			log_debug("Failed to re-initialize blood datums on [src]!")
+			return
+
+
 	if(blood_incompatible(injected.data["blood_type"],our.data["blood_type"],injected.data["species"],our.data["species"]) )
 		reagents.add_reagent("toxin",amount * 0.5)
 		reagents.update_total()

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -750,7 +750,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 			if(!(W.can_autoheal() || (bicardose && inaprovaline) || myeldose))	//bicaridine and inaprovaline stop internal wounds from growing bigger with time, unless it is so small that it is already healing
 				W.open_wound(0.1 * wound_update_accuracy)
 
-			owner.vessel.remove_reagent("blood", wound_update_accuracy * W.damage/40) //line should possibly be moved to handle_blood, so all the bleeding stuff is in one place.
+			owner.remove_blood( wound_update_accuracy * W.damage/40) //line should possibly be moved to handle_blood, so all the bleeding stuff is in one place.
 			if(prob(1 * wound_update_accuracy))
 				owner.custom_pain("You feel a stabbing pain in your [name]!", 50)
 

--- a/code/modules/xenoarcheaology/effects/vampire.dm
+++ b/code/modules/xenoarcheaology/effects/vampire.dm
@@ -27,7 +27,7 @@
 		B.target_turf = pick(RANGE_TURFS(1, holder))
 		B.blood_DNA = list()
 		B.blood_DNA[M.dna.unique_enzymes] = M.dna.b_type
-		M.vessel.remove_reagent("blood",rand(10,30))
+		M.remove_blood(rand(10,30))
 
 /datum/artifact_effect/vampire/DoEffectTouch(var/mob/user)
 	bloodcall(user)

--- a/code/modules/xenoarcheaology/finds/special.dm
+++ b/code/modules/xenoarcheaology/finds/special.dm
@@ -134,7 +134,7 @@
 		B.target_turf = pick(range(1, src))
 		B.blood_DNA = list()
 		B.blood_DNA[M.dna.unique_enzymes] = M.dna.b_type
-		M.vessel.remove_reagent("blood",rand(25,50))
+		M.remove_blood(rand(25,50))
 
 //animated blood 2 SPOOKY
 /obj/effect/decal/cleanable/blood/splatter/animated


### PR DESCRIPTION
### What This does

In multiple commits, it tries to avert the blood datum getting deleted by hitting 0 blood.

1. Updates the code to use remove_blood() rather than remove_reagent() where sensible. Remove_reagent straight up deletes blood, whereas remove_blood() has checking to ensure at least 1 u blood remains
2. Updates remove_blood to scale its blood loss by creature size BEFORE it does sanity checks
3. Updates remove_blood and take_blood to use a preprocessor #define to outright stop processing/handling blood removal if we're below critical treshold (defined as 2.1, and we increased sanity check to be at 2u. 1u is too dangerous due to floating point weirdness (assuming)).
4. Implements a fall-back if the blood datum still gets deleted based on staff-side fix for such issues
### Why we need this

Fixes https://github.com/VOREStation/VOREStation/issues/14817

More generally, remove_reagent("blood", amt) is too dangerous to use, we should use the appropriate proc for handling blood which is remove_blood. In some cases direct touching is justified - such as during set_species as O_HEART might not apply to all species but we still want them to have blood and sometimes we're working with an organ outside a mob and other wackiness.

We also want a fallback because although I did my best to do testing - organ code is cursed and I rather want to make it a seamless experience even if stuff breaks. We make sure to create debug logs if it still happens so that we can track down such issues.

### Commit details

https://github.com/VOREStation/VOREStation/commit/09acdfd92225de78f764f99057ba01d2063f221e

Fixes https://github.com/VOREStation/VOREStation/issues/14817

remove_reagent has no sanitization for making sure the person has at least 1 u of blood remaining, and is therefore unsafe to use.

This commit changes all human remove_reagent("blood", amt) calls with remove_blood(amt).

This should prevent blood disappearing from internal bleeding or dragging someone while they're down or from drawing blood from them and so forth.

Not all cases of remove_reagent("blood", amt) were changed, as some act on organs or other reagent containers not part of a human mob or because it's set_species

https://github.com/VOREStation/VOREStation/commit/12bb4f00bf8f8fd557b9dbdb7854fd01fffa33c0

Mob size affects how much blood you should lose, by default 1 (20/20). However, in cases this is not true (non-medium mobs), this can lead to overflow of blood taken as this scaling happens AFTER we ensure amt is not greater than whatever it takes to get 1 blood.

This should safeguard against that.

https://github.com/VOREStation/VOREStation/commit/f1b5e812ce3ccc7d0285cf77dcbf6ce2286b00a8
Also stops processing blood loss at 2.1. This allows the mob to regenerate some blood without losing any more, but I doubt anyone would farm a human mob for blood at a rate of 0.1 per multiple ticks. 2.1 is defined as a preprocessor #define to make it easier to sync stuff and avoid magic numbers.

The fallback essentially follows the same procedures as a staff member would do to fix this issue: creates blood, sets their blood volume at species amount if wrong, fixes datums around blood. It logs failures and occurances.