### PR TITLE
SQL Injection Fix

### DIFF
--- a/code/modules/admin/IsBanned.dm
+++ b/code/modules/admin/IsBanned.dm
@@ -46,11 +46,11 @@
 		var/cidquery = ""
 		if(address)
 			failedip = 0
-			ipquery = " OR ip = '[address]' "
+			ipquery = " OR ip = '[sanitizeSQL(address)]' "
 
 		if(computer_id)
 			failedcid = 0
-			cidquery = " OR computerid = '[computer_id]' "
+			cidquery = " OR computerid = '[sanitizeSQL(computer_id)]' "
 
 		var/DBQuery/query = dbcon.NewQuery("SELECT ckey, ip, computerid, a_ckey, reason, expiration_time, duration, bantime, bantype FROM erro_ban WHERE (ckey = '[ckeytext]' [ipquery] [cidquery]) AND (bantype = 'PERMABAN'  OR (bantype = 'TEMPBAN' AND expiration_time > Now())) AND isnull(unbanned)")
 
@@ -81,4 +81,3 @@
 			message_admins("[key] has logged in with a blank ip in the ban check.")
 		return ..()	//default pager ban stuff
 #endif
-

--- a/code/modules/vchat/vchat_client.dm
+++ b/code/modules/vchat/vchat_client.dm
@@ -263,6 +263,12 @@ GLOBAL_DATUM_INIT(iconCache, /savefile, new("data/iconCache.sav")) //Cache of ic
 	if(!cid && !ip && !ckey)
 		return
 
+	if(cid && !isnum(cid) && !(cid == ""))
+		log_and_message_admins("[key_name(owner)] - bancheck with invalid cid! ([cid])")
+
+	if(ip && !findtext(ip, new/regex("^((25[0-5]|(2[0-4]|1\\d|[1-9]|)\\d)\\.?\\b){4}$")) && !(ip == ""))
+		log_and_message_admins("[key_name(owner)] - bancheck with invalid ip! ([ip])")
+
 	var/list/ban = world.IsBanned(key = ckey, address = ip, computer_id = cid)
 	if(ban)
 		log_and_message_admins("[key_name(owner)] has a cookie from a banned account! (Cookie: [ckey], [ip], [cid])")


### PR DESCRIPTION
This PR mitigates an security issue with the bancheck that can be triggered via vchat.
It allows one to pass custom variables as the ckey, ip address or cid which can result in queries like these:
![image](https://github.com/VOREStation/VOREStation/assets/12716288/8931afbc-b71f-4d65-b9ac-da262c7e7fd0)

This PR basically sanitizes the variables before the query and gives the admins a warning if invalid data was passed.

Screenshot of test that it still works after the fix:
![image](https://github.com/VOREStation/VOREStation/assets/12716288/7b4039b9-946b-4739-912f-464336709a7e)
