### PR TITLE
Robot species

### DIFF
--- a/code/modules/mob/living/silicon/robot/examine.dm
+++ b/code/modules/mob/living/silicon/robot/examine.dm
@@ -1,5 +1,5 @@
 /mob/living/silicon/robot/examine(mob/user)
-	var/custom_infix = custom_name ? ", [modtype][sprite_type] [braintype]" : ""
+	var/custom_infix = custom_name ? ", [modtype][sprite_type ? " [sprite_type]" : ""] [braintype]" : ""
 	. = ..(user, infix = custom_infix)
 
 	if (src.getBruteLoss())

--- a/code/modules/mob/living/silicon/robot/examine.dm
+++ b/code/modules/mob/living/silicon/robot/examine.dm
@@ -1,5 +1,5 @@
 /mob/living/silicon/robot/examine(mob/user)
-	var/custom_infix = custom_name ? ", [modtype] [braintype]" : ""
+	var/custom_infix = custom_name ? ", [modtype][sprite_type] [braintype]" : ""
 	. = ..(user, infix = custom_infix)
 
 	if (src.getBruteLoss())
@@ -29,7 +29,7 @@
 				. += "It appears to be in stand-by mode." //afk
 		if(UNCONSCIOUS)		. += "<span class='warning'>It doesn't seem to be responding.</span>"
 		if(DEAD)			. += "<span class='deadsay'>It looks completely unsalvageable.</span>"
-	
+
 	// VOREStation Edit: Start
 	. += attempt_vr(src,"examine_bellies_borg",args) //VOREStation Edit
 	// VOREStation Edit: End

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -1125,7 +1125,7 @@
 		var/selection = tgui_input_list(src, "Select an icon! [triesleft ? "You have [triesleft] more chance\s." : "This is your last try."]", "Robot Icon", module_sprites)
 		sprite_datum = selection
 		if(!istype(src,/mob/living/silicon/robot/drone))
-			robot_species = selection
+			robot_species = sprite_datum.name
 		if(notransform)
 			to_chat(src, "Your current transformation has not finished yet!")
 			choose_icon(icon_selection_tries)
@@ -1151,7 +1151,7 @@
 
 	icon_selected = 1
 	icon_selection_tries = 0
-	sprite_type = " [robot_species]"
+	sprite_type = robot_species
 	to_chat(src, "<span class='filter_notice'>Your icon has been set. You now require a module reset to change it.</span>")
 
 /mob/living/silicon/robot/proc/set_default_module_icon()

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -82,6 +82,7 @@
 	//var/list/laws = list()
 	var/viewalerts = 0
 	var/modtype = "Default"
+	var/sprite_type = null
 	var/lower_mod = 0
 	var/jetpack = 0
 	var/datum/effect/effect/system/ion_trail_follow/ion_trail = null
@@ -1105,6 +1106,7 @@
 	return
 
 /mob/living/silicon/robot/proc/choose_icon(var/triesleft)
+	var/robot_species = null
 	if(!SSrobot_sprites)
 		to_chat(src, "Robot Sprites have not been initialized yet. How are you choosing a sprite? Harass a coder.")
 		return
@@ -1122,6 +1124,8 @@
 	else
 		var/selection = tgui_input_list(src, "Select an icon! [triesleft ? "You have [triesleft] more chance\s." : "This is your last try."]", "Robot Icon", module_sprites)
 		sprite_datum = selection
+		if(!istype(src,/mob/living/silicon/robot/drone))
+			robot_species = selection
 		if(notransform)
 			to_chat(src, "Your current transformation has not finished yet!")
 			choose_icon(icon_selection_tries)
@@ -1147,6 +1151,7 @@
 
 	icon_selected = 1
 	icon_selection_tries = 0
+	sprite_type = " [robot_species]"
 	to_chat(src, "<span class='filter_notice'>Your icon has been set. You now require a module reset to change it.</span>")
 
 /mob/living/silicon/robot/proc/set_default_module_icon()


### PR DESCRIPTION
Robots don't have a species but now it will tell people what sprite you picked in your examine text, similar to how species is done for carbon mobs!

![image](https://github.com/VOREStation/VOREStation/assets/24854483/73f54ab0-7d78-4fcf-970d-1e339718857e)
![image](https://github.com/VOREStation/VOREStation/assets/24854483/426acbf3-99da-4f0f-8886-be60174973e4)

If you don't pick a sprite, or are a maint drone, it doesn't set a name like this and will look as it normally does!
