### PR TITLE
Renames some borg sprite appearances

### DIFF
--- a/code/modules/mob/living/silicon/robot/sprites/civilian.dm
+++ b/code/modules/mob/living/silicon/robot/sprites/civilian.dm
@@ -120,12 +120,12 @@
 	sprite_icon_state = "spider"
 
 /datum/robot_sprite/service/drone
-	name = "Drone - Service"
+	name = "AG Model-Serv"
 	sprite_icon_state = "drone-crisis"
 	has_custom_open_sprites = TRUE
 
 /datum/robot_sprite/service/drone_hydro
-	name = "Drone - Hydro"
+	name = "AG Model-Hydro"
 	sprite_icon_state = "drone-hydro"
 	sprite_hud_icon_state = "hydroponics"
 	has_custom_open_sprites = TRUE
@@ -151,11 +151,11 @@
 	has_custom_open_sprites = TRUE
 
 /datum/robot_sprite/service/handy
-	name = "Handy - Service"
+	name = "Handy-Serv"
 	sprite_icon_state = "handy"
 
 /datum/robot_sprite/service/handy_hydro
-	name = "Handy - Hydro"
+	name = "Handy-Hydro"
 	sprite_icon_state = "handy-hydro"
 	sprite_hud_icon_state = "hydroponics"
 
@@ -183,13 +183,13 @@
 	has_vore_belly_sprites = FALSE
 
 /datum/robot_sprite/dogborg/service/vale
-	name = "ServicehoundV2"
+	name = "Hound V2"
 	sprite_icon_state = "vale"
 	has_eye_light_sprites = TRUE
 	has_vore_belly_sprites = FALSE
 
 /datum/robot_sprite/dogborg/service/valedark
-	name = "ServicehoundV2 Darkmode"
+	name = "Hound V2 Darkmode"
 	sprite_icon_state = "valedark"
 	has_eye_light_sprites = TRUE
 	has_vore_belly_sprites = FALSE
@@ -304,7 +304,7 @@
 	rest_sprite_options = list("Default", "Bellyup")
 
 /datum/robot_sprite/dogborg/tall/service/k4t_alt1
-	name = "K4Talt"
+	name = "K4T Alt"
 	sprite_icon_state = "k4t_alt1"
 	has_eye_light_sprites = TRUE
 	has_custom_open_sprites = TRUE
@@ -334,7 +334,7 @@
 	sprite_icon_state = "spider"
 
 /datum/robot_sprite/clerical/drone
-	name = "Drone"
+	name = "AG Model"
 	sprite_icon_state = "drone"
 	has_custom_open_sprites = TRUE
 

--- a/code/modules/mob/living/silicon/robot/sprites/combat.dm
+++ b/code/modules/mob/living/silicon/robot/sprites/combat.dm
@@ -121,7 +121,7 @@
 	has_gun_sprite = TRUE
 
 /datum/robot_sprite/dogborg/tall/combat/hound
-	name = "Combat Hound"
+	name = "Hound"
 	sprite_icon_state = "hound"
 	sprite_hud_icon_state = "ert"
 	rest_sprite_options = list("Default")

--- a/code/modules/mob/living/silicon/robot/sprites/engineering.dm
+++ b/code/modules/mob/living/silicon/robot/sprites/engineering.dm
@@ -51,11 +51,11 @@
 	sprite_icon_state = "landmate"
 
 /datum/robot_sprite/engineering/landmatetread
-	name = "Landmate - Treaded"
+	name = "Landmate-Treaded"
 	sprite_icon_state = "landmatetread"
 
 /datum/robot_sprite/engineering/drone
-	name = "Drone"
+	name = "AG Model"
 	sprite_icon_state = "drone"
 	has_custom_open_sprites = TRUE
 
@@ -136,19 +136,19 @@
 	has_dead_sprite_overlay = FALSE
 
 /datum/robot_sprite/dogborg/engineering/vale
-	name = "V2 Engidog"
+	name = "Hound V2"
 	sprite_icon_state = "vale"
 	sprite_hud_icon_state = "pupdozer"
 	has_eye_light_sprites = TRUE
 
 /datum/robot_sprite/dogborg/engineering/hound
-	name = "EngiHound"
+	name = "Hound"
 	sprite_icon_state = "hound"
 	sprite_hud_icon_state = "pupdozer"
 	has_eye_light_sprites = TRUE
 
 /datum/robot_sprite/dogborg/engineering/hounddark
-	name = "EngiHoundDark"
+	name = "Hound Dark"
 	sprite_icon_state = "hounddark"
 	sprite_hud_icon_state = "pupdozer"
 	has_eye_light_sprites = TRUE
@@ -207,7 +207,7 @@
 	rest_sprite_options = list("Default", "Bellyup")
 
 /datum/robot_sprite/dogborg/tall/engineering/k4t_alt1
-	name = "K4Talt"
+	name = "K4T Alt"
 	sprite_icon_state = "k4t_alt1"
 	has_eye_light_sprites = TRUE
 	has_custom_open_sprites = TRUE

--- a/code/modules/mob/living/silicon/robot/sprites/event.dm
+++ b/code/modules/mob/living/silicon/robot/sprites/event.dm
@@ -18,7 +18,7 @@
 				ourborg.add_overlay("[sprite_icon_state]-shield")
 
 /datum/robot_sprite/lost/drone
-	name = "Drone"
+	name = "AG Model"
 	sprite_icon_state = "drone"
 	has_shield_sprite = TRUE
 
@@ -66,7 +66,7 @@
 				ourborg.add_overlay("[sprite_icon_state]-shield")
 
 /datum/robot_sprite/gravekeeper/drone
-	name = "Drone"
+	name = "AG Model"
 	sprite_icon_state = "drone"
 	has_shield_sprite = TRUE
 

--- a/code/modules/mob/living/silicon/robot/sprites/janitor.dm
+++ b/code/modules/mob/living/silicon/robot/sprites/janitor.dm
@@ -48,7 +48,7 @@
 	sprite_icon_state = "mopgearrex"
 
 /datum/robot_sprite/janitor/drone
-	name = "Drone"
+	name = "AG Model"
 	sprite_icon_state = "drone"
 	has_custom_open_sprites = TRUE
 
@@ -110,13 +110,13 @@
 	sprite_icon = 'icons/mob/robot/janitor_wide.dmi'
 
 /datum/robot_sprite/dogborg/janitor/scrubpup
-	name = "Custodial Hound"
+	name = "Scrubpup"
 	sprite_icon_state = "scrubpup"
 	sprite_hud_icon_state = "janihound"
 	has_eye_light_sprites = TRUE
 
 /datum/robot_sprite/dogborg/janitor/vale
-	name = "Janihound Model V-2"
+	name = "Hound V2"
 	sprite_icon_state = "vale"
 	sprite_hud_icon_state = "janihound"
 	has_eye_light_sprites = TRUE
@@ -192,7 +192,7 @@
 	rest_sprite_options = list("Default", "Bellyup")
 
 /datum/robot_sprite/dogborg/tall/mining/k4t_alt1
-	name = "K4Talt"
+	name = "K4T Alt"
 	sprite_icon_state = "k4t_alt1"
 	has_eye_light_sprites = TRUE
 	has_custom_open_sprites = TRUE

--- a/code/modules/mob/living/silicon/robot/sprites/medical.dm
+++ b/code/modules/mob/living/silicon/robot/sprites/medical.dm
@@ -130,7 +130,7 @@
 	rest_sprite_options = list("Default", "Bellyup")
 
 /datum/robot_sprite/dogborg/tall/medical/k4t_alt1
-	name = "K4Talt"
+	name = "K4T Alt"
 	sprite_icon_state = "k4t_alt1"
 	has_eye_light_sprites = TRUE
 	has_custom_open_sprites = TRUE
@@ -155,7 +155,7 @@
 	sprite_icon_state = "sleek"
 
 /datum/robot_sprite/surgical/drone
-	name = "Drone"
+	name = "AG Model"
 	sprite_icon_state = "drone"
 	has_custom_open_sprites = TRUE
 
@@ -275,12 +275,12 @@
 	sprite_icon_state = "sleek"
 
 /datum/robot_sprite/crisis/drone
-	name = "Drone - Medical"
+	name = "AG Model-Med"
 	sprite_icon_state = "drone-crisis"
 	has_custom_open_sprites = TRUE
 
 /datum/robot_sprite/crisis/drone_chem
-	name = "Drone - Chemistry"
+	name = "AG Model-Chem"
 	sprite_icon_state = "drone-chem"
 	has_custom_open_sprites = TRUE
 
@@ -338,21 +338,21 @@
 		SP.attack_verb = list("batted", "pawed", "bopped", "whapped")
 
 /datum/robot_sprite/dogborg/crisis/hound
-	name = "Medical Hound"
+	name = "Medihound"
 	sprite_icon_state = "hound"
 	sprite_hud_icon_state = "medihound"
 	has_eye_light_sprites = TRUE
 	has_sleeper_light_indicator = TRUE
 
 /datum/robot_sprite/dogborg/crisis/hounddark
-	name = "Dark Medical Hound"
+	name = "Medihound Dark"
 	sprite_icon_state = "hounddark"
 	sprite_hud_icon_state = "medihound"
 	has_eye_light_sprites = TRUE
 	has_sleeper_light_indicator = TRUE
 
 /datum/robot_sprite/dogborg/crisis/vale
-	name = "Mediborg Model V-2"
+	name = "Medihound V2"
 	sprite_icon_state = "vale"
 	sprite_hud_icon_state = "medihound"
 	has_eye_light_sprites = TRUE

--- a/code/modules/mob/living/silicon/robot/sprites/mining.dm
+++ b/code/modules/mob/living/silicon/robot/sprites/mining.dm
@@ -47,7 +47,7 @@
 	sprite_icon_state = "treadhead"
 
 /datum/robot_sprite/mining/drone
-	name = "Drone"
+	name = "AG Model"
 	sprite_icon_state = "drone"
 	has_custom_open_sprites = TRUE
 
@@ -114,12 +114,12 @@
 	has_eye_light_sprites = TRUE
 
 /datum/robot_sprite/dogborg/mining/hound
-	name = "CargoHound"
+	name = "Cargohound"
 	sprite_icon_state = "hound"
 	has_eye_light_sprites = TRUE
 
 /datum/robot_sprite/dogborg/mining/hounddark
-	name = "CargoHoundDark"
+	name = "Cargohound Dark"
 	sprite_icon_state = "hounddark"
 	has_eye_light_sprites = TRUE
 
@@ -177,7 +177,7 @@
 	rest_sprite_options = list("Default", "Bellyup")
 
 /datum/robot_sprite/dogborg/tall/mining/k4t_alt1
-	name = "K4Talt"
+	name = "K4T Alt"
 	sprite_icon_state = "k4t_alt1"
 	has_eye_light_sprites = TRUE
 	has_custom_open_sprites = TRUE

--- a/code/modules/mob/living/silicon/robot/sprites/science.dm
+++ b/code/modules/mob/living/silicon/robot/sprites/science.dm
@@ -34,7 +34,7 @@
 	sprite_icon_state = "droid"
 
 /datum/robot_sprite/science/drone
-	name = "Drone"
+	name = "AG Model"
 	sprite_icon_state = "drone"
 	has_custom_open_sprites = TRUE
 
@@ -113,7 +113,7 @@
 		J.attack_verb = list("batted", "pawed", "bopped", "whapped")
 
 /datum/robot_sprite/dogborg/science/vale
-	name = "Research Hound"
+	name = "Hound V2"
 	sprite_icon_state = "vale"
 	sprite_hud_icon_state = "sci-borg"
 	has_eye_light_sprites = TRUE
@@ -127,13 +127,13 @@
 	has_dead_sprite_overlay = FALSE
 
 /datum/robot_sprite/dogborg/science/hound
-	name = "SciHound"
+	name = "Hound"
 	sprite_icon_state = "hound"
 	sprite_hud_icon_state = "sci-borg"
 	has_eye_light_sprites = TRUE
 
 /datum/robot_sprite/dogborg/science/darkhound
-	name = "SciHoundDark"
+	name = "Hound Dark"
 	sprite_icon_state = "hounddark"
 	sprite_hud_icon_state = "sci-borg"
 	has_eye_light_sprites = TRUE

--- a/code/modules/mob/living/silicon/robot/sprites/security.dm
+++ b/code/modules/mob/living/silicon/robot/sprites/security.dm
@@ -18,7 +18,7 @@
 	sprite_icon_state = "bloodhound"
 
 /datum/robot_sprite/security/treadhound
-	name = "Cerberus - Treaded"
+	name = "Cerberus-Treaded"
 	sprite_icon_state = "treadhound"
 
 /datum/robot_sprite/security/marina
@@ -54,6 +54,11 @@
 	name = "Black Knight"
 	sprite_icon_state = "oldbot"
 	has_eye_sprites = FALSE
+
+/datum/robot_sprite/security/drone
+	name = "AG Model"
+	sprite_icon_state = "drone"
+	has_custom_open_sprites = TRUE
 
 /datum/robot_sprite/security/insekt
 	name = "Insekt"
@@ -142,7 +147,7 @@
 	has_taser_sprite = TRUE
 
 /datum/robot_sprite/dogborg/security/vale
-	name = "Secborg Model V-2"
+	name = "Hound V2"
 	sprite_icon_state = "vale"
 	sprite_hud_icon_state = "k9"
 	has_eye_light_sprites = TRUE

--- a/code/modules/mob/living/silicon/robot/sprites/standard.dm
+++ b/code/modules/mob/living/silicon/robot/sprites/standard.dm
@@ -48,7 +48,7 @@
 	sprite_icon_state = "droid"
 
 /datum/robot_sprite/standard/drone
-	name = "Drone"
+	name = "AG Model"
 	sprite_icon_state = "drone"
 	has_custom_open_sprites = TRUE
 

--- a/code/modules/mob/living/silicon/robot/sprites/syndicate.dm
+++ b/code/modules/mob/living/silicon/robot/sprites/syndicate.dm
@@ -14,7 +14,7 @@
 	sprite_icon_state = "bloodhound"
 
 /datum/robot_sprite/protector/treadhound
-	name = "Cerberus - Treaded"
+	name = "Cerberus-Treaded"
 	sprite_icon_state = "treadhound"
 
 /datum/robot_sprite/protector/squats


### PR DESCRIPTION
To account for new examine-naming system.

All Drone sprites renamed to AG Model
Most hound sprite names are unified as Hound, Hound V2, etc.
Just some smaller visual adjustments for these names to look better when seen in examine rather than only in selection window.


Also fixes security Drone/AG Model sprite not existing