### PR TITLE
Adds sanity check to spin()

### DIFF
--- a/code/modules/food/food/snacks.dm
+++ b/code/modules/food/food/snacks.dm
@@ -1153,7 +1153,7 @@
 	has_been_heated = 1
 	user.visible_message("<span class='notice'>[user] crushes \the [src] package.</span>", "You crush \the [src] package and feel a comfortable heat build up. Now just to wait for it to be ready.")
 	spawn(200)
-		if(src)
+		if(!QDELETED(src))
 			if(src.loc == user)
 				to_chat(user, "You think \the [src] is ready to eat about now.")
 			heat()

--- a/code/modules/mob/animations.dm
+++ b/code/modules/mob/animations.dm
@@ -296,6 +296,8 @@ note dizziness decrements automatically in the mob's Life() proc.
 	return TRUE //Found an item, doing item attack animation.
 
 /mob/proc/spin(spintime, speed)
+	if(!speed || speed < 1)		// Do NOT spin with infinite speed, it will break the reality
+		return
 	spawn()
 		var/D = dir
 		while(spintime >= speed)


### PR DESCRIPTION
WHy the HELL does it allow you to SPIN at INFINITE SPEED breaking the entire GAME and turning server into LAGFEST and does it with DEFAULT vars WHY

![3lb9iz](https://github.com/VOREStation/VOREStation/assets/31296024/c50acba0-d258-437c-be05-cd0a49813bd4)


Also unrelated donk pocket runtime i forgot to commit